### PR TITLE
fix proto import path

### DIFF
--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -1,5 +1,6 @@
 # gazelle:prefix github.com/michelangelo-ai/michelangelo/proto
 # gazelle:proto_strip_import_prefix /proto
+# gazelle:proto_import_prefix michelangelo
 # gazelle:proto default
 # gazelle:go_proto_compilers @io_bazel_rules_go//proto:gogoslick_proto
 # gazelle:go_grpc_compilers @io_bazel_rules_go//proto:gogoslick_grpc

--- a/proto/api/BUILD.bazel
+++ b/proto/api/BUILD.bazel
@@ -9,6 +9,7 @@ proto_library(
         "list.proto",
         "options.proto",
     ],
+    import_prefix = "michelangelo",
     strip_import_prefix = "/proto",
     visibility = ["//visibility:public"],
     deps = [


### PR DESCRIPTION
The proto file import path was wrongly set to "api" in the last pull request.
This pull request sets the proto file import path to "michelangel.api"