### PR TITLE
Add Spark and Ray job CRD protos from v2beta1

### DIFF
--- a/proto/api/v2/BUILD.bazel
+++ b/proto/api/v2/BUILD.bazel
@@ -6,7 +6,12 @@ proto_library(
     name = "v2_proto",
     srcs = [
         "git.proto",
+        "job.proto",
+        "pod.proto",
         "project.proto",
+        "ray_job.proto",
+        "spark_job.proto",
+        "user.proto",
     ],
     import_prefix = "michelangelo",
     strip_import_prefix = "/proto",

--- a/proto/api/v2/job.proto
+++ b/proto/api/v2/job.proto
@@ -1,0 +1,100 @@
+syntax = "proto3";
+
+package michelangelo.api.v2;
+
+option go_package = "api/v2";
+
+import "k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto";
+
+// @Deprecated - use ResourceAffinity instead
+// ClusterAffinity provides cluster affinity
+message ClusterAffinity {
+  // cluster selector
+  k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector cluster_selector = 1;
+}
+
+// ResourceAffinity provides affinity on how
+// resources should be selected. It can include
+// their type, the region they're, if they're
+// experimental resources etc.
+message ResourceAffinity {
+  // resource selector
+  k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 1;
+}
+
+// Affinity for job
+message Affinity {
+  // TODO Mark this as reserved after removing usage
+  // Cluster affinity
+  ClusterAffinity cluster_affinity = 1;
+
+  // Resource affinity
+  ResourceAffinity resource_affinity = 2;
+
+  // TODO: Add inter-job and anti-affinity
+}
+
+// AssignmentInfo provides assignment
+// related status
+message AssignmentInfo {
+  // Qualified name of the resource pool
+  string resource_pool = 1;
+
+  // Name of the assigned cluster. The cluster
+  // object is defined in cluster.proto
+  string cluster = 2;
+
+  // @Deprecated
+  // Job's url to view job specific details
+  string job_url = 3 [deprecated = true];
+}
+
+// @Deprecated - use AssignmentInfo instead
+// ClusterAssignment provides cluster assignment
+// related status
+message ClusterAssignment {
+  // cluster name of the assigned cluster
+  string cluster = 1;
+}
+
+// TerminationType of a job
+enum TerminationType {
+  // invalid
+  TERMINATION_TYPE_INVALID = 0;
+
+  // succeeded
+  TERMINATION_TYPE_SUCCEEDED = 1;
+
+  // failed
+  TERMINATION_TYPE_FAILED = 2;
+}
+
+// TerminationSpec provides job termination
+// related information
+message TerminationSpec {
+  // TerminationType i.e. succeeded vs failed
+  TerminationType type = 1;
+
+  // Reason for termination if not successful
+  string reason = 2;
+}
+
+// SchedulingSpec provides job scheduling
+// related information
+message SchedulingSpec {
+  // Set to true if a job is preemptible. Preemptible jobs
+  // may use the elastic resources from other resource
+  // pools. These are subject to preemption when the
+  // demand in the other pools rise.
+  bool preemptible = 1;
+
+  // TODO: Add priority related information
+}
+
+message SchedulingInfo {
+  // last scheduling attempt
+  k8s.io.apimachinery.pkg.apis.meta.v1.Time last_attempt_time = 1;
+
+  // number of attempts at scheduling
+  int32 num_attempts = 2;
+}

--- a/proto/api/v2/pod.proto
+++ b/proto/api/v2/pod.proto
@@ -1,0 +1,68 @@
+// This file defines the Pod related messages in Michelangelo API.
+
+syntax = "proto3";
+
+package michelangelo.api.v2;
+
+option go_package = "api/v2";
+
+import "michelangelo/api/options.proto";
+
+// Resource requirements of a Kubernetes Pod or Peloton task
+// This proto is shared among project, pipeline and job. Default value is legitimate for input validation.
+// TODO: Replace with K8s Quantity in ResourceRequirements
+message ResourceSpec {
+  // CPU limit in number of CPU cores
+  int32 cpu = 1 [(michelangelo.api.validation) = {min: "0"}];
+
+  // Memory limit such as 32G
+  string memory = 2;
+
+  // Disk size limit such as 100G
+  string disk_size = 3;
+
+  // GPU limit in number of GPUs
+  int32 gpu = 4 [(michelangelo.api.validation) = {min: "0"}];
+
+  // File descriptor limit in number of open file descriptors
+  int32 file_descriptors = 5 [(michelangelo.api.validation) = {min: "0"}];
+
+  // GPU sku identifier. Mandatory for
+  // cloud workloads
+  string gpu_sku = 6;
+}
+
+// Environment represents an environment variable present in a Pod.
+message Environment {
+  // Name of the environment variable.
+  string name = 1;
+
+  // Value of the environment variable.
+  string value = 2;
+}
+
+// Specification for the Pod in a Spark or Horovod job.
+message PodSpec {
+  // Optional name of the Pod
+  string name = 1;
+
+  // Resource requirement of the Pod
+  ResourceSpec resource = 2;
+
+  // Custom docker image name
+  string image = 3;
+
+  // Environment variables
+  repeated Environment env = 4;
+
+  // Security token used to read/write to secure HDFS.
+  // TODO: replace this with K8s or Peloton Secrets
+  string hdfs_delegation_token = 5;
+
+  // Custom module to run on Pod initialization
+  string on_init = 6;
+
+  // Optional command for the container.
+  // The container image's ENTRYPOINT is used if this is not provided.
+  repeated string command = 7;
+}

--- a/proto/api/v2/ray_job.proto
+++ b/proto/api/v2/ray_job.proto
@@ -1,0 +1,134 @@
+// This file defines the Ray Job in Michelangelo API
+
+syntax = "proto3";
+
+package michelangelo.api.v2;
+
+option go_package = "api/v2";
+
+import "k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto";
+import "michelangelo/api/options.proto";
+import "michelangelo/api/v2/job.proto";
+import "michelangelo/api/v2/pod.proto";
+import "michelangelo/api/v2/user.proto";
+
+// Specification for the head/driver in a Ray job
+message HeadSpec {
+  // Pod spec for the Ray head
+  PodSpec pod = 1;
+}
+
+// Specification for the workers in a Ray job
+message WorkerSpec {
+  // Pod spec for the Ray worker instances
+  PodSpec pod = 1;
+
+  // Minimum number of worker instances
+  int32 min_instances = 2;
+
+  // Maximum number of worker instances
+  int32 max_instances = 3;
+
+  // Node type for a worker in a heterogeneous cluster
+  string node_type = 4;
+
+  // Ray object store memory will be allocated based on this
+  // ratio of the overall worker memory
+  double object_store_memory_ratio = 5;
+}
+
+// Specification for a Ray job
+message RayJobSpec {
+
+  // User initiating the ray job workload
+  UserInfo user = 1;
+
+  // Affinity for the clusters and other jobs
+  Affinity affinity = 2;
+
+  // Ray head specification
+  HeadSpec head = 3;
+
+  // Ray worker specification
+  WorkerSpec worker = 4;
+
+  // User-specified Ray configurations
+  map<string, string> ray_conf = 5;
+
+  // Termination spec
+  TerminationSpec termination = 6;
+
+  // Scheduling spec
+  SchedulingSpec scheduling = 7;
+
+  // Ray worker specification. This field is introduced to
+  // support clusters that have a heterogeneous set of workers.
+  // Eventually we should deprecate the worker field above because
+  // it can be represent by this field.
+  repeated WorkerSpec workers = 8;
+}
+
+// Information on the head node
+message RayHeadNodeInfo  {
+  // Name of the pod
+  string name = 1;
+
+  // Namespace of the pod
+  string namespace = 2;
+
+  // Ip address of the pod
+  string ip = 3;
+
+  // Port for clients to connect
+  int32 client_port = 4;
+
+  // Dashboard port for the ray cluster
+  int32 dashboard_port = 5;
+}
+
+// Defines the status of a Ray job
+message RayJobStatus {
+  // Information on the head node
+  RayHeadNodeInfo head_node = 1;
+
+  // Conditions that describe states
+  repeated k8s.io.apimachinery.pkg.apis.meta.v1.Condition conditions = 2;
+
+  // TODO Mark this as reserved after removing the usage
+  // Cluster Assignment
+  ClusterAssignment cluster_assignment = 3;
+
+  // Assignment info
+  AssignmentInfo assignment = 4;
+
+  // Scheduling info
+  SchedulingInfo scheduling_info = 5;
+
+  // Ray Job's url to view ray job specific details
+  string job_url = 7;
+}
+
+// RayJob is refer to a Ray job.
+message RayJob {
+  option (michelangelo.api.resource) = {};
+
+  k8s.io.apimachinery.pkg.apis.meta.v1.TypeMeta type_meta = 1;
+  k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 2;
+
+  // Spec of the desired behavior of the Ray job.
+  RayJobSpec spec = 3;
+
+  // Most recently observed status of the Ray job.
+  RayJobStatus status = 4;
+}
+
+// A list of Ray job objects.
+message RayJobList {
+  option (michelangelo.api.resource_list) = {};
+
+  k8s.io.apimachinery.pkg.apis.meta.v1.TypeMeta type_meta = 1;
+  k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 2;
+
+  // A list of Ray jobs
+  repeated RayJob items = 3;
+}

--- a/proto/api/v2/spark_job.proto
+++ b/proto/api/v2/spark_job.proto
@@ -1,0 +1,133 @@
+syntax = "proto3";
+
+package michelangelo.api.v2;
+
+option go_package = "api/v2";
+
+import "k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto";
+import "michelangelo/api/options.proto";
+import "michelangelo/api/conditions.proto";
+import "michelangelo/api/v2/job.proto";
+import "michelangelo/api/v2/pod.proto";
+import "michelangelo/api/v2/user.proto";
+
+// Specification for the driver in a Spark job
+message DriverSpec {
+  // Pod spec for the Spark driver
+  PodSpec pod = 1;
+}
+
+// Specification for the executors in a Spark job
+message ExecutorSpec {
+  // Pod spec for the Spark executors
+  PodSpec pod = 1;
+
+  // Number of executor instances
+  int32 instances = 2;
+}
+
+// Specification for a Spark job (application)
+message SparkJobSpec {
+  // User initiating the spark job workload.
+  // Used to map to the command-line flag “–proxy-user” in spark-submit.
+  UserInfo user = 1;
+
+  // Affinity for the clusters and other jobs
+  Affinity affinity = 2;
+
+  // Spark driver specification
+  DriverSpec driver = 3;
+
+  // Spark executor specification
+  ExecutorSpec executor = 4;
+
+  // User-specified Spark configuration properties as they would use
+  // the "--conf" option in spark-submit.
+  map<string, string> spark_conf = 5;
+
+  // Fully qualified main class name for
+  // java or scala application
+  string main_class = 6;
+
+  // Main application file e.g. jar or
+  // python file
+  string main_application_file = 7;
+
+  // List of arguments to be passed to the application.
+  repeated string main_args = 9;
+
+  // Dependencies specifies all possible types of dependencies of a Spark application.
+  Dependencies deps = 10;
+
+  // Termination spec
+  TerminationSpec termination = 11;
+
+  // Scheduling spec
+  SchedulingSpec scheduling = 12;
+
+  // Spark version specify the version of spark to use
+  string spark_version = 13;
+}
+
+// Dependencies specifies all possible types of dependencies of a Spark application.
+message Dependencies {
+  // Jars is a list of JAR files the Spark application depends on.
+  repeated string jars = 1;
+
+  // Files is a list of files the Spark application depends on.
+  repeated string files = 2;
+
+  // PyFiles is a list of Python files the Spark application depends on.
+  repeated string py_files = 3;
+}
+
+// Defines the status of a Spark job
+message SparkJobStatus {
+  // Deprecated - use status_conditions instead
+  // Conditions that describe states
+  repeated k8s.io.apimachinery.pkg.apis.meta.v1.Condition conditions = 1;
+
+  // TODO Mark this as reserved after removing the usage
+  // Cluster Assignment
+  ClusterAssignment cluster_assignment = 2;
+
+  // Assignment info
+  AssignmentInfo assignment = 3;
+
+  // Scheduling info
+  SchedulingInfo scheduling_info = 4;
+
+  // Conditions that describe states
+  repeated Condition status_conditions = 6;
+
+  // Spark Job's url to view spark job specific details
+  string job_url = 7;
+
+  // Spark application id
+  string application_id = 8;
+}
+
+// SparkJob refers to a Spark job.
+message SparkJob {
+  option (michelangelo.api.resource) = {};
+
+  k8s.io.apimachinery.pkg.apis.meta.v1.TypeMeta type_meta = 1;
+  k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 2;
+
+  // Spec of the desired behavior of the Spark job.
+  SparkJobSpec spec = 3;
+
+  // Most recently observed status of the Spark job.
+  SparkJobStatus status = 4;
+}
+
+// A list of Spark job objects.
+message SparkJobList {
+  option (michelangelo.api.resource_list) = {};
+
+  k8s.io.apimachinery.pkg.apis.meta.v1.TypeMeta type_meta = 1;
+  k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 2;
+
+  // A list of Spark jobs
+  repeated SparkJob items = 3;
+}

--- a/proto/api/v2/user.proto
+++ b/proto/api/v2/user.proto
@@ -1,0 +1,16 @@
+// This file defines the User related messages in Michelangelo API.
+
+syntax = "proto3";
+
+package michelangelo.api.v2;
+
+option go_package = "api/v2";
+
+// Defines actor information.
+message UserInfo {
+
+  // LDAP of user.
+  string name = 1;
+
+  string proxy_user = 2;
+}


### PR DESCRIPTION
Add Spark and Ray job CRD protos from v2beta1 to v1 unchanged. 

A few TODO items:
- Replace PodSpec with k8s/api/corev1/ PodTemplate
- Split RayJob to RayJob and RayCluster
