### PR TITLE
Create ray cluster and make ray job kubeRay compatible

### DIFF
--- a/proto/api/v2/ray_cluster.proto
+++ b/proto/api/v2/ray_cluster.proto
@@ -9,6 +9,7 @@ option go_package = "api/v2";
 import "k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto";
 import "michelangelo/api/options.proto";
 import "michelangelo/api/v2/pod.proto";
+import "michelangelo/api/v2/job.proto";
 import "michelangelo/api/v2/user.proto";
 
 // Specification for Ray cluster head node
@@ -37,8 +38,8 @@ message RayWorkerSpec {
   // Node type for a worker in a heterogeneous cluster
   string node_type = 4;
 
-  // Ray object store memory will be allocated based on this
-  // ratio of the overall worker memory
+  // Ray object store memory will be allocated based on this ratio of the overall worker memory.
+  // This ratio is specified as an entrypoint parameter to configure the memory allocated for the object store during worker node startup.
   double object_store_memory_ratio = 5;
 
   // Ray start parameters for the worker nodes
@@ -63,11 +64,11 @@ message RayClusterSpec {
   // Additional Ray cluster-wide configurations
   map<string, string> ray_conf = 5;
 
-  // Enable or disable in-tree autoscaling
-  bool enable_in_tree_autoscaling = 6;
+  // Termination spec
+  TerminationSpec termination = 6;
 
-  // True if this is a kill request, used to terminate the cluster
-  bool kill = 7;
+  // Scheduling spec
+  SchedulingSpec scheduling = 7;
 }
 
 // Describes the state of a ray cluster.
@@ -115,45 +116,150 @@ message Endpoints {
   string serve = 5;
 }
 
-// Specification for the head/driver in a Ray cluster
-message Head {
-  // IP and port for accessing the Ray head node
-  string port_ip = 1;
+// Information on the head node
+message RayHeadNodeInfo  {
+  // Name of the pod.
+  // This is the unique identifier for the head node's pod within the Kubernetes cluster.
+  string name = 1;
 
-  // IP address of the head service
-  string service_ip = 2;
+  // Namespace of the pod.
+  // Specifies the Kubernetes namespace where the head node's pod is deployed.
+  // Namespaces allow logical separation of resources within a Kubernetes cluster.
+  string namespace = 2;
+
+  // IP address of the pod.
+  // This is the internal cluster IP assigned to the head node's pod, used for inter-node communication.
+  string ip = 3;
+
+  // Port for clients to connect.
+  // This port is used by external clients to connect to the Ray cluster's head node.
+  // It serves as the primary entry point for submitting jobs and managing cluster state.
+  int32 client_port = 4;
+
+  // Dashboard port for the Ray cluster.
+  // Provides a web-based interface to monitor and manage the Ray cluster.
+  // The dashboard displays metrics, logs, and node details for operational insights.
+  int32 dashboard_port = 5;
+
+  // Jupyter Notebook port for the Ray cluster.
+  // This port is used if a Jupyter Notebook server is running on the head node.
+  // While optional, it allows users to interactively develop and run Ray-based applications.
+  int32 jupyter_notebook_port = 6;
+}
+
+// Information on the pod errors
+message PodErrors {
+  // Name of the failed pod.
+  // Identifies the specific pod within the cluster that encountered an error.
+  string name = 1;
+
+  // Name of the failed container.
+  // Specifies the container within the pod that failed. Pods can have multiple containers, each serving different purposes.
+  string container_name = 2;
+
+  // Exit code of the failed container in the pod.
+  // Indicates the status code returned by the container's process upon failure.
+  // Non-zero exit codes usually signify an error or abnormal termination.
+  int32 exit_code = 3;
+
+  // Reason for the failure.
+  // Provides a brief description of why the container or pod failed.
+  // This is often derived from Kubernetes events and can include reasons like "OOMKilled" or "CrashLoopBackOff".
+  string reason = 4;
+
+  // Message describing the failure.
+  // Offers additional details about the error, including system-level messages or logs.
+  // This field is useful for debugging and determining the root cause of the failure.
+  string message = 5;
 }
 
 // Defines the status of a Ray cluster
-message RayClusterStatus {
+message RayJobStatus {
 
-  // Current state of the Ray cluster
+  // Current state of the Ray cluster.
+  // This field reflects the operational state of the cluster, such as "Running", "Pending", or "Failed".
+  // It is updated based on the observed state transitions in the Ray cluster managed by the Kubernetes operator.
   RayClusterState state = 1;
 
-  // Unique identifier for the generated Ray cluster in the Ray operator
+  // Unique identifier for the generated Ray cluster in the Ray operator.
+  // This ID is critical for associating jobs with specific Ray clusters in Kubernetes.
+  // It ensures the operator can track and manage individual clusters efficiently.
   string cluster_id = 2;
 
-  // Observed number of worker replicas available in the cluster
+  // Observed number of worker replicas available in the cluster.
+  // This value is dynamically updated based on the current state of the cluster.
+  // It reflects the actual number of active worker nodes currently running and available to handle tasks.
   int32 available_worker_replicas = 3;
 
-  // Desired number of worker replicas across all groups
+  // Desired number of worker replicas across all groups.
+  // This value is derived from the desired specifications set in WorkerGroupSpec in raycluster_types.go.
+  // It represents the target number of workers defined during cluster creation or scaling operations.
   int32 desired_worker_replicas = 4;
 
-  // Minimum number of worker replicas across all groups
+  // Minimum number of worker replicas across all groups.
+  // It aligns with the minimum configuration provided in the cluster spec.
+  // This value ensures the cluster maintains a baseline number of workers to meet operational requirements.
   int32 min_worker_replicas = 5;
 
-  // Maximum number of worker replicas across all groups
+  // Maximum number of worker replicas across all groups.
+  // It reflects the upper limit for scaling workers, often specified in autoscaling configurations.
+  // This value prevents over-provisioning and helps control resource costs.
   int32 max_worker_replicas = 6;
 
-  // Endpoints to access the cluster services
+  // Endpoints to access the cluster services.
+  // These endpoints include the head service and potentially other ingress points for the cluster.
+  // They are used for communication with the head node and accessing cluster-level APIs.
   Endpoints endpoints = 7;
 
-  // Details about the Ray head node
-  Head head = 8;
-
-  // Last update time for the cluster status
+  // Last update time for the cluster status.
+  // This timestamp is managed by Kubernetes and helps track the most recent changes to the cluster.
+  // It provides a snapshot of when the cluster's status was last refreshed.
   k8s.io.apimachinery.pkg.apis.meta.v1.Time last_update_time = 9;
+
+  // Information on the head node.
+  // The head node is critical for coordinating worker nodes and running the Ray scheduler.
+  // This field includes details about the pod running the head node, such as its IP address and health status.
+  RayHeadNodeInfo head_node = 10;
+
+  // Cluster assignment details.
+  // This field is marked for deprecation and should be removed in the future.
+  // It currently provides metadata about the logical grouping of clusters, but its usage is being phased out.
+  // TODO: Mark this as reserved after removing the usage.
+  ClusterAssignment cluster_assignment = 11;
+
+  // Assignment information.
+  // Provides additional metadata about how the cluster is allocated for specific workloads.
+  // This field helps map resources to their intended tasks or tenants within a shared environment.
+  // For example, it can include priority levels, tenant-specific resource limits, or job-specific constraints.
+  // These details ensure efficient resource utilization and prevent conflicts in multi-tenant environments.
+  AssignmentInfo assignment = 12;
+
+  // Scheduling information.
+  // Contains data on how resources are allocated and scheduled within the cluster.
+  // This includes policies for distributing tasks and managing resource contention.
+  // Scheduling policies can be defined to prioritize critical jobs, balance workloads, or meet SLAs (Service Level Agreements).
+  // It also includes the scheduling status of each worker group, indicating readiness or pending states.
+  SchedulingInfo scheduling_info = 13;
+
+  // Conditions that describe the states.
+  // These conditions detail specific events or issues affecting the cluster.
+  // Examples include "PodsPending" or "AutoScalingInProgress" to indicate operational status.
+  repeated Condition status_conditions = 14;
+
+  // URL to view job-specific details.
+  // This field is used for debugging and monitoring purposes, offering a direct link to job metadata.
+  // It provides an entry point to view logs, metrics, and other details for a given Ray job.
+  string job_url = 15;
+
+  // Information on pod errors in the Ray cluster.
+  // Collected from pod events, this information is essential for diagnosing issues, though the presence of errors
+  // does not necessarily mean the cluster is unhealthy.
+  // Examples include issues like "ContainerImagePullBackOff" or "CrashLoopBackOff" that may require intervention.
+  // Each error entry provides detailed context, such as error type, associated pod name, and timestamps of occurrences.
+  // This information aids in root cause analysis and accelerates resolution of cluster failures.
+  repeated PodErrors pod_errors = 16;
 }
+
 
 // RayCluster refers to a Ray cluster.
 message RayCluster {

--- a/proto/api/v2/ray_cluster.proto
+++ b/proto/api/v2/ray_cluster.proto
@@ -172,70 +172,65 @@ message RayJobStatus {
   // It is updated based on the observed state transitions in the Ray cluster managed by the Kubernetes operator.
   RayClusterState state = 1;
 
-  // Unique identifier for the generated Ray cluster in the Ray operator.
-  // This ID is critical for associating jobs with specific Ray clusters in Kubernetes.
-  // It ensures the operator can track and manage individual clusters efficiently.
-  string cluster_id = 2;
-
   // Observed number of worker replicas available in the cluster.
   // This value is dynamically updated based on the current state of the cluster.
   // It reflects the actual number of active worker nodes currently running and available to handle tasks.
-  int32 available_worker_replicas = 3;
+  int32 available_worker_replicas = 2;
 
   // Desired number of worker replicas across all groups.
   // This value is derived from the desired specifications set in WorkerGroupSpec in raycluster_types.go.
   // It represents the target number of workers defined during cluster creation or scaling operations.
-  int32 desired_worker_replicas = 4;
+  int32 desired_worker_replicas = 3;
 
   // Minimum number of worker replicas across all groups.
   // It aligns with the minimum configuration provided in the cluster spec.
   // This value ensures the cluster maintains a baseline number of workers to meet operational requirements.
-  int32 min_worker_replicas = 5;
+  int32 min_worker_replicas = 4;
 
   // Maximum number of worker replicas across all groups.
   // It reflects the upper limit for scaling workers, often specified in autoscaling configurations.
   // This value prevents over-provisioning and helps control resource costs.
-  int32 max_worker_replicas = 6;
+  int32 max_worker_replicas = 5;
 
   // Last update time for the cluster status.
   // This timestamp is managed by Kubernetes and helps track the most recent changes to the cluster.
   // It provides a snapshot of when the cluster's status was last refreshed.
-  k8s.io.apimachinery.pkg.apis.meta.v1.Time last_update_time = 8;
+  k8s.io.apimachinery.pkg.apis.meta.v1.Time last_update_time = 6;
 
   // Information on the head node.
   // The head node is critical for coordinating worker nodes and running the Ray scheduler.
   // This field includes details about the pod running the head node, such as its IP address and health status.
-  RayHeadNodeInfo head_node = 9;
+  RayHeadNodeInfo head_node = 7;
 
   // Cluster assignment details.
   // This field is marked for deprecation and should be removed in the future.
   // It currently provides metadata about the logical grouping of clusters, but its usage is being phased out.
   // TODO: Mark this as reserved after removing the usage.
-  ClusterAssignment cluster_assignment = 10;
+  ClusterAssignment cluster_assignment = 8;
 
   // Assignment information.
   // Provides additional metadata about how the cluster is allocated for specific workloads.
   // This field helps map resources to their intended tasks or tenants within a shared environment.
   // For example, it can include priority levels, tenant-specific resource limits, or job-specific constraints.
   // These details ensure efficient resource utilization and prevent conflicts in multi-tenant environments.
-  AssignmentInfo assignment = 11;
+  AssignmentInfo assignment = 9;
 
   // Scheduling information.
   // Contains data on how resources are allocated and scheduled within the cluster.
   // This includes policies for distributing tasks and managing resource contention.
   // Scheduling policies can be defined to prioritize critical jobs, balance workloads, or meet SLAs (Service Level Agreements).
   // It also includes the scheduling status of each worker group, indicating readiness or pending states.
-  SchedulingInfo scheduling_info = 12;
+  SchedulingInfo scheduling_info = 10;
 
   // Conditions that describe the states.
   // These conditions detail specific events or issues affecting the cluster.
   // Examples include "PodsPending" or "AutoScalingInProgress" to indicate operational status.
-  repeated Condition status_conditions = 13;
+  repeated Condition status_conditions = 11;
 
   // URL to view job-specific details.
   // This field is used for debugging and monitoring purposes, offering a direct link to job metadata.
   // It provides an entry point to view logs, metrics, and other details for a given Ray job.
-  string job_url = 14;
+  string job_url = 12;
 
   // Information on pod errors in the Ray cluster.
   // Collected from pod events, this information is essential for diagnosing issues, though the presence of errors
@@ -243,7 +238,7 @@ message RayJobStatus {
   // Examples include issues like "ContainerImagePullBackOff" or "CrashLoopBackOff" that may require intervention.
   // Each error entry provides detailed context, such as error type, associated pod name, and timestamps of occurrences.
   // This information aids in root cause analysis and accelerates resolution of cluster failures.
-  repeated PodErrors pod_errors = 15;
+  repeated PodErrors pod_errors = 13;
 }
 
 

--- a/proto/api/v2/ray_cluster.proto
+++ b/proto/api/v2/ray_cluster.proto
@@ -172,65 +172,45 @@ message RayJobStatus {
   // It is updated based on the observed state transitions in the Ray cluster managed by the Kubernetes operator.
   RayClusterState state = 1;
 
-  // Observed number of worker replicas available in the cluster.
-  // This value is dynamically updated based on the current state of the cluster.
-  // It reflects the actual number of active worker nodes currently running and available to handle tasks.
-  int32 available_worker_replicas = 2;
-
-  // Desired number of worker replicas across all groups.
-  // This value is derived from the desired specifications set in WorkerGroupSpec in raycluster_types.go.
-  // It represents the target number of workers defined during cluster creation or scaling operations.
-  int32 desired_worker_replicas = 3;
-
-  // Minimum number of worker replicas across all groups.
-  // It aligns with the minimum configuration provided in the cluster spec.
-  // This value ensures the cluster maintains a baseline number of workers to meet operational requirements.
-  int32 min_worker_replicas = 4;
-
-  // Maximum number of worker replicas across all groups.
-  // It reflects the upper limit for scaling workers, often specified in autoscaling configurations.
-  // This value prevents over-provisioning and helps control resource costs.
-  int32 max_worker_replicas = 5;
-
   // Last update time for the cluster status.
   // This timestamp is managed by Kubernetes and helps track the most recent changes to the cluster.
   // It provides a snapshot of when the cluster's status was last refreshed.
-  k8s.io.apimachinery.pkg.apis.meta.v1.Time last_update_time = 6;
+  k8s.io.apimachinery.pkg.apis.meta.v1.Time last_update_time = 2;
 
   // Information on the head node.
   // The head node is critical for coordinating worker nodes and running the Ray scheduler.
   // This field includes details about the pod running the head node, such as its IP address and health status.
-  RayHeadNodeInfo head_node = 7;
+  RayHeadNodeInfo head_node = 3;
 
   // Cluster assignment details.
   // This field is marked for deprecation and should be removed in the future.
   // It currently provides metadata about the logical grouping of clusters, but its usage is being phased out.
   // TODO: Mark this as reserved after removing the usage.
-  ClusterAssignment cluster_assignment = 8;
+  ClusterAssignment cluster_assignment = 4;
 
   // Assignment information.
   // Provides additional metadata about how the cluster is allocated for specific workloads.
   // This field helps map resources to their intended tasks or tenants within a shared environment.
   // For example, it can include priority levels, tenant-specific resource limits, or job-specific constraints.
   // These details ensure efficient resource utilization and prevent conflicts in multi-tenant environments.
-  AssignmentInfo assignment = 9;
+  AssignmentInfo assignment = 5;
 
   // Scheduling information.
   // Contains data on how resources are allocated and scheduled within the cluster.
   // This includes policies for distributing tasks and managing resource contention.
   // Scheduling policies can be defined to prioritize critical jobs, balance workloads, or meet SLAs (Service Level Agreements).
   // It also includes the scheduling status of each worker group, indicating readiness or pending states.
-  SchedulingInfo scheduling_info = 10;
+  SchedulingInfo scheduling_info = 6;
 
   // Conditions that describe the states.
   // These conditions detail specific events or issues affecting the cluster.
   // Examples include "PodsPending" or "AutoScalingInProgress" to indicate operational status.
-  repeated Condition status_conditions = 11;
+  repeated Condition status_conditions = 7;
 
   // URL to view job-specific details.
   // This field is used for debugging and monitoring purposes, offering a direct link to job metadata.
   // It provides an entry point to view logs, metrics, and other details for a given Ray job.
-  string job_url = 12;
+  string job_url = 8;
 
   // Information on pod errors in the Ray cluster.
   // Collected from pod events, this information is essential for diagnosing issues, though the presence of errors
@@ -238,7 +218,7 @@ message RayJobStatus {
   // Examples include issues like "ContainerImagePullBackOff" or "CrashLoopBackOff" that may require intervention.
   // Each error entry provides detailed context, such as error type, associated pod name, and timestamps of occurrences.
   // This information aids in root cause analysis and accelerates resolution of cluster failures.
-  repeated PodErrors pod_errors = 13;
+  repeated PodErrors pod_errors = 9;
 }
 
 

--- a/proto/api/v2/ray_cluster.proto
+++ b/proto/api/v2/ray_cluster.proto
@@ -40,7 +40,7 @@ message RayWorkerSpec {
   // ratio of the overall worker memory
   double object_store_memory_ratio = 5;
 
-  // Ray start parameters for the head node
+  // Ray start parameters for the worker nodes
   map<string, string> ray_start_params = 6;
 }
 
@@ -56,6 +56,7 @@ message RayClusterSpec {
   // Ray head specification
   RayHeadSpec head = 3;
 
+  // Specifications for the worker groups in the cluster
   repeated RayWorkerSpec workers = 4;
 
   // Additional Ray cluster-wide configurations
@@ -64,55 +65,69 @@ message RayClusterSpec {
   // Enable or disable in-tree autoscaling
   bool enable_in_tree_autoscaling = 6;
 
-  // True if this is a kill request.
+  // True if this is a kill request, used to terminate the cluster
   bool kill = 7;
 }
 
 // Describes the state of a dashboard.
 enum RayClusterState {
-  // The dashboard state is invalid.
+  // The cluster state is invalid.
   RAY_CLUSTER_STATE_INVALID = 0;
 
+  // The cluster is in the process of being created.
   RAY_CLUSTER_STATE_CREATING = 1;
 
+  // The cluster is being provisioned.
   RAY_CLUSTER_STATE_PROVISIONING = 2;
 
+  // The cluster is ready for use.
   RAY_CLUSTER_STATE_READY = 3;
 
+  // The cluster is being terminated.
   RAY_CLUSTER_STATE_TERMINATING = 4;
 
+  // The cluster has been terminated.
   RAY_CLUSTER_STATE_TERMINATED = 5;
 
+  // The cluster creation or operation failed.
   RAY_CLUSTER_STATE_FAILED = 6;
 
+  // The cluster state is unknown.
   RAY_CLUSTER_STATE_UNKNOWN = 7;
 }
 
 message Endpoints {
+  // Endpoint for client communication with the Ray cluster
   string client = 1;
 
+  // Endpoint for accessing the Ray dashboard
   string dashboard = 2;
 
+  // Endpoint for accessing metrics from the Ray cluster
   string metrics = 3;
 
+  // Endpoint for accessing the Redis server in the Ray cluster
   string redis = 4;
 
+  // Endpoint for Ray Serve (model serving functionality)
   string serve = 5;
 }
 
 message Head {
+  // IP and port for accessing the Ray head node
   string port_ip = 1;
 
+  // IP address of the head service
   string service_ip = 2;
 }
 
 // Defines the status of a Ray cluster
 message RayClusterStatus {
 
-  // state of the ray cluster
+  // Current state of the Ray cluster
   RayClusterState state = 1;
 
-  // generated ray cluster in ray operator
+  // Unique identifier for the generated Ray cluster in the Ray operator
   string cluster_id = 2;
 
   // Observed number of worker replicas available in the cluster
@@ -127,8 +142,10 @@ message RayClusterStatus {
   // Maximum number of worker replicas across all groups
   int32 max_worker_replicas = 6;
 
+  // Endpoints to access the cluster services
   Endpoints endpoints = 7;
 
+  // Details about the Ray head node
   Head head = 8;
 
   // Last update time for the cluster status
@@ -139,7 +156,10 @@ message RayClusterStatus {
 message RayCluster {
   option (github.com.uber.michelangelo.api.resource) = {};
 
+  // Type metadata for the Ray cluster
   k8s.io.apimachinery.pkg.apis.meta.v1.TypeMeta type_meta = 1;
+
+  // Metadata for the Ray cluster object
   k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 2;
 
   // Spec of the desired behavior of the Ray cluster.
@@ -153,7 +173,10 @@ message RayCluster {
 message RayClusterList {
   option (github.com.uber.michelangelo.api.resource_list) = {};
 
+  // Type metadata for the list of Ray clusters
   k8s.io.apimachinery.pkg.apis.meta.v1.TypeMeta type_meta = 1;
+
+  // Metadata for the list of Ray cluster objects
   k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 2;
 
   // A list of Ray clusters

--- a/proto/api/v2/ray_cluster.proto
+++ b/proto/api/v2/ray_cluster.proto
@@ -11,7 +11,7 @@ import "michelangelo/api/options.proto";
 import "michelangelo/api/v2/pod.proto";
 import "michelangelo/api/v2/user.proto";
 
-// Specification for Ray head node
+// Specification for Ray cluster head node
 message RayHeadSpec {
   // Kubernetes service type for the head service
   string service_type = 1;
@@ -70,7 +70,7 @@ message RayClusterSpec {
   bool kill = 7;
 }
 
-// Describes the state of a dashboard.
+// Describes the state of a ray cluster.
 enum RayClusterState {
   // The cluster state is invalid.
   RAY_CLUSTER_STATE_INVALID = 0;
@@ -97,6 +97,7 @@ enum RayClusterState {
   RAY_CLUSTER_STATE_UNKNOWN = 7;
 }
 
+// Specification for the endpoints
 message Endpoints {
   // Endpoint for client communication with the Ray cluster
   string client = 1;
@@ -114,6 +115,7 @@ message Endpoints {
   string serve = 5;
 }
 
+// Specification for the head/driver in a Ray cluster
 message Head {
   // IP and port for accessing the Ray head node
   string port_ip = 1;

--- a/proto/api/v2/ray_cluster.proto
+++ b/proto/api/v2/ray_cluster.proto
@@ -11,6 +11,7 @@ import "michelangelo/api/options.proto";
 import "michelangelo/api/v2/pod.proto";
 import "michelangelo/api/v2/user.proto";
 
+// Specification for Ray head node
 message RayHeadSpec {
   // Kubernetes service type for the head service
   string service_type = 1;
@@ -22,7 +23,7 @@ message RayHeadSpec {
   map<string, string> ray_start_params = 3;
 }
 
-// Specification for the workers in a Ray job
+// Specification for the workers in a Ray cluster
 message RayWorkerSpec {
   // Pod spec for the Ray worker instances
   PodSpec pod = 1;
@@ -47,7 +48,7 @@ message RayWorkerSpec {
 // Specification for a Ray cluster
 message RayClusterSpec {
 
-  // User initiating the ray job workload
+  // User initiating the ray cluster workload
   UserInfo user = 1;
 
   // Ray version for the cluster

--- a/proto/api/v2/ray_cluster.proto
+++ b/proto/api/v2/ray_cluster.proto
@@ -38,12 +38,8 @@ message RayWorkerSpec {
   // Node type for a worker in a heterogeneous cluster
   string node_type = 4;
 
-  // Ray object store memory will be allocated based on this ratio of the overall worker memory.
-  // This ratio is specified as an entrypoint parameter to configure the memory allocated for the object store during worker node startup.
-  double object_store_memory_ratio = 5;
-
   // Ray start parameters for the worker nodes
-  map<string, string> ray_start_params = 6;
+  map<string, string> ray_start_params = 5;
 }
 
 // Specification for a Ray cluster
@@ -76,8 +72,8 @@ enum RayClusterState {
   // The cluster state is invalid.
   RAY_CLUSTER_STATE_INVALID = 0;
 
-  // The cluster is in the process of being created.
-  RAY_CLUSTER_STATE_CREATING = 1;
+  // The cluster is in the process of being launched.
+  RAY_CLUSTER_STATE_LAUNCHED = 1;
 
   // The cluster is being provisioned.
   RAY_CLUSTER_STATE_PROVISIONING = 2;

--- a/proto/api/v2/ray_cluster.proto
+++ b/proto/api/v2/ray_cluster.proto
@@ -98,50 +98,6 @@ enum RayClusterState {
   RAY_CLUSTER_STATE_UNKNOWN = 7;
 }
 
-// Specification for the endpoints
-//
-// The `Endpoints` message defines a structured way to provide
-// access points to different services within a Ray cluster. These endpoints
-// are critical for cluster operations, enabling communication, monitoring, and
-// serving functionality. Each field corresponds to a specific service
-// and serves as an interface for external and internal tools to interact
-// with the cluster components.
-//
-// This specification is designed to be extensible and aligns with
-// the requirements of the Ray operator specification, ensuring that
-// all necessary endpoints for cluster management are included.
-message Endpoints {
-  // Endpoint for client communication with the Ray cluster.
-  // This endpoint allows clients to connect and interact with the Ray cluster.
-  // It is typically used for submitting tasks, retrieving results, and managing jobs.
-  // Example: "ray://<cluster-ip>:<client-port>" to facilitate task distribution.
-  string client = 1;
-
-  // Endpoint for accessing the Ray dashboard.
-  // The dashboard provides a web-based interface to monitor cluster state, visualize tasks, and access logs.
-  // It is commonly used by developers and operators for debugging and performance monitoring.
-  // Example: "http://<cluster-ip>:<dashboard-port>" to view cluster status.
-  string dashboard = 2;
-
-  // Endpoint for accessing metrics from the Ray cluster.
-  // Metrics include operational details such as resource utilization, task throughput, and system health.
-  // This endpoint integrates with monitoring tools for real-time analytics.
-  // Example: Prometheus or Grafana can scrape this endpoint for visualization and alerts.
-  string metrics = 3;
-
-  // Endpoint for accessing the Redis server in the Ray cluster.
-  // Redis is used internally by Ray for cluster metadata storage and task scheduling.
-  // This endpoint allows direct access for debugging or administrative purposes.
-  // Example: "redis://<cluster-ip>:<redis-port>" for metadata inspection.
-  string redis = 4;
-
-  // Endpoint for Ray Serve (model serving functionality).
-  // Ray Serve enables scalable model deployment and inference.
-  // This endpoint is used to expose APIs for serving machine learning models hosted on the cluster.
-  // Example: "http://<cluster-ip>:<serve-port>" for RESTful API access to deployed models.
-  string serve = 5;
-}
-
 // Specification for RayHeadNodeInfo
 //
 // The `RayHeadNodeInfo` message provides critical details about the head node
@@ -171,15 +127,10 @@ message RayHeadNodeInfo  {
   // It serves as the primary entry point for submitting jobs and managing cluster state.
   int32 client_port = 4;
 
-  // Dashboard port for the Ray cluster.
-  // Provides a web-based interface to monitor and manage the Ray cluster.
-  // The dashboard displays metrics, logs, and node details for operational insights.
-  int32 dashboard_port = 5;
-
   // Jupyter Notebook port for the Ray cluster.
   // This port is used if a Jupyter Notebook server is running on the head node.
   // While optional, it allows users to interactively develop and run Ray-based applications.
-  int32 jupyter_notebook_port = 6;
+  int32 jupyter_notebook_port = 5;
 }
 
 // Specification for PodErrors
@@ -250,50 +201,45 @@ message RayJobStatus {
   // This value prevents over-provisioning and helps control resource costs.
   int32 max_worker_replicas = 6;
 
-  // Endpoints to access the cluster services.
-  // These endpoints include the head service and potentially other ingress points for the cluster.
-  // They are used for communication with the head node and accessing cluster-level APIs.
-  Endpoints endpoints = 7;
-
   // Last update time for the cluster status.
   // This timestamp is managed by Kubernetes and helps track the most recent changes to the cluster.
   // It provides a snapshot of when the cluster's status was last refreshed.
-  k8s.io.apimachinery.pkg.apis.meta.v1.Time last_update_time = 9;
+  k8s.io.apimachinery.pkg.apis.meta.v1.Time last_update_time = 8;
 
   // Information on the head node.
   // The head node is critical for coordinating worker nodes and running the Ray scheduler.
   // This field includes details about the pod running the head node, such as its IP address and health status.
-  RayHeadNodeInfo head_node = 10;
+  RayHeadNodeInfo head_node = 9;
 
   // Cluster assignment details.
   // This field is marked for deprecation and should be removed in the future.
   // It currently provides metadata about the logical grouping of clusters, but its usage is being phased out.
   // TODO: Mark this as reserved after removing the usage.
-  ClusterAssignment cluster_assignment = 11;
+  ClusterAssignment cluster_assignment = 10;
 
   // Assignment information.
   // Provides additional metadata about how the cluster is allocated for specific workloads.
   // This field helps map resources to their intended tasks or tenants within a shared environment.
   // For example, it can include priority levels, tenant-specific resource limits, or job-specific constraints.
   // These details ensure efficient resource utilization and prevent conflicts in multi-tenant environments.
-  AssignmentInfo assignment = 12;
+  AssignmentInfo assignment = 11;
 
   // Scheduling information.
   // Contains data on how resources are allocated and scheduled within the cluster.
   // This includes policies for distributing tasks and managing resource contention.
   // Scheduling policies can be defined to prioritize critical jobs, balance workloads, or meet SLAs (Service Level Agreements).
   // It also includes the scheduling status of each worker group, indicating readiness or pending states.
-  SchedulingInfo scheduling_info = 13;
+  SchedulingInfo scheduling_info = 12;
 
   // Conditions that describe the states.
   // These conditions detail specific events or issues affecting the cluster.
   // Examples include "PodsPending" or "AutoScalingInProgress" to indicate operational status.
-  repeated Condition status_conditions = 14;
+  repeated Condition status_conditions = 13;
 
   // URL to view job-specific details.
   // This field is used for debugging and monitoring purposes, offering a direct link to job metadata.
   // It provides an entry point to view logs, metrics, and other details for a given Ray job.
-  string job_url = 15;
+  string job_url = 14;
 
   // Information on pod errors in the Ray cluster.
   // Collected from pod events, this information is essential for diagnosing issues, though the presence of errors
@@ -301,7 +247,7 @@ message RayJobStatus {
   // Examples include issues like "ContainerImagePullBackOff" or "CrashLoopBackOff" that may require intervention.
   // Each error entry provides detailed context, such as error type, associated pod name, and timestamps of occurrences.
   // This information aids in root cause analysis and accelerates resolution of cluster failures.
-  repeated PodErrors pod_errors = 16;
+  repeated PodErrors pod_errors = 15;
 }
 
 

--- a/proto/api/v2/ray_cluster.proto
+++ b/proto/api/v2/ray_cluster.proto
@@ -99,24 +99,59 @@ enum RayClusterState {
 }
 
 // Specification for the endpoints
+//
+// The `Endpoints` message defines a structured way to provide
+// access points to different services within a Ray cluster. These endpoints
+// are critical for cluster operations, enabling communication, monitoring, and
+// serving functionality. Each field corresponds to a specific service
+// and serves as an interface for external and internal tools to interact
+// with the cluster components.
+//
+// This specification is designed to be extensible and aligns with
+// the requirements of the Ray operator specification, ensuring that
+// all necessary endpoints for cluster management are included.
 message Endpoints {
-  // Endpoint for client communication with the Ray cluster
+  // Endpoint for client communication with the Ray cluster.
+  // This endpoint allows clients to connect and interact with the Ray cluster.
+  // It is typically used for submitting tasks, retrieving results, and managing jobs.
+  // Example: "ray://<cluster-ip>:<client-port>" to facilitate task distribution.
   string client = 1;
 
-  // Endpoint for accessing the Ray dashboard
+  // Endpoint for accessing the Ray dashboard.
+  // The dashboard provides a web-based interface to monitor cluster state, visualize tasks, and access logs.
+  // It is commonly used by developers and operators for debugging and performance monitoring.
+  // Example: "http://<cluster-ip>:<dashboard-port>" to view cluster status.
   string dashboard = 2;
 
-  // Endpoint for accessing metrics from the Ray cluster
+  // Endpoint for accessing metrics from the Ray cluster.
+  // Metrics include operational details such as resource utilization, task throughput, and system health.
+  // This endpoint integrates with monitoring tools for real-time analytics.
+  // Example: Prometheus or Grafana can scrape this endpoint for visualization and alerts.
   string metrics = 3;
 
-  // Endpoint for accessing the Redis server in the Ray cluster
+  // Endpoint for accessing the Redis server in the Ray cluster.
+  // Redis is used internally by Ray for cluster metadata storage and task scheduling.
+  // This endpoint allows direct access for debugging or administrative purposes.
+  // Example: "redis://<cluster-ip>:<redis-port>" for metadata inspection.
   string redis = 4;
 
-  // Endpoint for Ray Serve (model serving functionality)
+  // Endpoint for Ray Serve (model serving functionality).
+  // Ray Serve enables scalable model deployment and inference.
+  // This endpoint is used to expose APIs for serving machine learning models hosted on the cluster.
+  // Example: "http://<cluster-ip>:<serve-port>" for RESTful API access to deployed models.
   string serve = 5;
 }
 
-// Information on the head node
+// Specification for RayHeadNodeInfo
+//
+// The `RayHeadNodeInfo` message provides critical details about the head node
+// of a Ray cluster. The head node acts as the central coordinator for the
+// cluster, managing worker nodes and facilitating communication among them.
+//
+// This information is essential for understanding the cluster topology,
+// diagnosing connectivity issues, and interacting with the cluster's core
+// components. Each field encapsulates a specific aspect of the head node's
+// configuration and its operational parameters.
 message RayHeadNodeInfo  {
   // Name of the pod.
   // This is the unique identifier for the head node's pod within the Kubernetes cluster.
@@ -147,7 +182,16 @@ message RayHeadNodeInfo  {
   int32 jupyter_notebook_port = 6;
 }
 
-// Information on the pod errors
+// Specification for PodErrors
+//
+// The `PodErrors` message provides detailed information about errors encountered
+// by pods within a Kubernetes-managed Ray cluster. Errors in pods can significantly
+// impact the performance and availability of the cluster. Understanding and resolving
+// these errors is crucial for maintaining cluster stability and operational integrity.
+//
+// Each field in this message captures a specific aspect of the error, enabling detailed
+// diagnostics and facilitating faster resolution. These fields are derived from Kubernetes
+// events and system-level error messages.
 message PodErrors {
   // Name of the failed pod.
   // Identifies the specific pod within the cluster that encountered an error.

--- a/proto/api/v2/ray_cluster.proto
+++ b/proto/api/v2/ray_cluster.proto
@@ -1,0 +1,161 @@
+// This file defines the Ray Cluster in Michelangelo API
+
+syntax = "proto3";
+
+package michelangelo.api.v2;
+
+option go_package = "api/v2";
+
+import "k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto";
+import "michelangelo/api/options.proto";
+import "michelangelo/api/v2/pod.proto";
+import "michelangelo/api/v2/user.proto";
+
+message RayHeadSpec {
+  // Kubernetes service type for the head service
+  string service_type = 1;
+
+  // Pod spec for the Ray head
+  PodSpec pod = 2;
+
+  // Ray start parameters for the head node
+  map<string, string> ray_start_params = 3;
+}
+
+// Specification for the workers in a Ray job
+message RayWorkerSpec {
+  // Pod spec for the Ray worker instances
+  PodSpec pod = 1;
+
+  // Minimum number of worker instances
+  int32 min_instances = 2;
+
+  // Maximum number of worker instances
+  int32 max_instances = 3;
+
+  // Node type for a worker in a heterogeneous cluster
+  string node_type = 4;
+
+  // Ray object store memory will be allocated based on this
+  // ratio of the overall worker memory
+  double object_store_memory_ratio = 5;
+
+  // Ray start parameters for the head node
+  map<string, string> ray_start_params = 6;
+}
+
+// Specification for a Ray cluster
+message RayClusterSpec {
+
+  // User initiating the ray job workload
+  UserInfo user = 1;
+
+  // Ray version for the cluster
+  string ray_version = 2;
+
+  // Ray head specification
+  RayHeadSpec head = 3;
+
+  repeated RayWorkerSpec workers = 4;
+
+  // Additional Ray cluster-wide configurations
+  map<string, string> ray_conf = 5;
+
+  // Enable or disable in-tree autoscaling
+  bool enable_in_tree_autoscaling = 6;
+
+  // True if this is a kill request.
+  bool kill = 7;
+}
+
+// Describes the state of a dashboard.
+enum RayClusterState {
+  // The dashboard state is invalid.
+  RAY_CLUSTER_STATE_INVALID = 0;
+
+  RAY_CLUSTER_STATE_CREATING = 1;
+
+  RAY_CLUSTER_STATE_PROVISIONING = 2;
+
+  RAY_CLUSTER_STATE_READY = 3;
+
+  RAY_CLUSTER_STATE_TERMINATING = 4;
+
+  RAY_CLUSTER_STATE_TERMINATED = 5;
+
+  RAY_CLUSTER_STATE_FAILED = 6;
+
+  RAY_CLUSTER_STATE_UNKNOWN = 7;
+}
+
+message Endpoints {
+  string client = 1;
+
+  string dashboard = 2;
+
+  string metrics = 3;
+
+  string redis = 4;
+
+  string serve = 5;
+}
+
+message Head {
+  string port_ip = 1;
+
+  string service_ip = 2;
+}
+
+// Defines the status of a Ray cluster
+message RayClusterStatus {
+
+  // state of the ray cluster
+  RayClusterState state = 1;
+
+  // generated ray cluster in ray operator
+  string cluster_id = 2;
+
+  // Observed number of worker replicas available in the cluster
+  int32 available_worker_replicas = 3;
+
+  // Desired number of worker replicas across all groups
+  int32 desired_worker_replicas = 4;
+
+  // Minimum number of worker replicas across all groups
+  int32 min_worker_replicas = 5;
+
+  // Maximum number of worker replicas across all groups
+  int32 max_worker_replicas = 6;
+
+  Endpoints endpoints = 7;
+
+  Head head = 8;
+
+  // Last update time for the cluster status
+  k8s.io.apimachinery.pkg.apis.meta.v1.Time last_update_time = 9;
+}
+
+// RayCluster refers to a Ray cluster.
+message RayCluster {
+  option (github.com.uber.michelangelo.api.resource) = {};
+
+  k8s.io.apimachinery.pkg.apis.meta.v1.TypeMeta type_meta = 1;
+  k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 2;
+
+  // Spec of the desired behavior of the Ray cluster.
+  RayClusterSpec spec = 3;
+
+  // Most recently observed status of the Ray cluster.
+  RayClusterStatus status = 4;
+}
+
+// A list of Ray cluster objects.
+message RayClusterList {
+  option (github.com.uber.michelangelo.api.resource_list) = {};
+
+  k8s.io.apimachinery.pkg.apis.meta.v1.TypeMeta type_meta = 1;
+  k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 2;
+
+  // A list of Ray clusters
+  repeated RayCluster items = 3;
+}

--- a/proto/api/v2/ray_job.proto
+++ b/proto/api/v2/ray_job.proto
@@ -15,16 +15,19 @@ import "michelangelo/api/v2/user.proto";
 // Specification for a Ray job
 message RayJobSpec {
 
-  // User initiating the ray job workload
+  // Information about the user initiating the Ray job workload
   UserInfo user = 1;
 
-  // User-specified Ray configurations
+  // Key-value pairs specifying user-defined Ray configurations
   map<string, string> ray_conf = 2;
 
+  // Entrypoint script or command to start the Ray job
   string entrypoint = 3;
 
-  string jobId = 4;
+  // Unique identifier for the Ray job
+  string job_id = 4;
 
+  // Reference to the Ray cluster where the job will be executed
   michelangelo.api.ResourceIdentifier cluster = 5 [
     (michelangelo.api.resource_reference) = {
       type: "michelangelo.uber.com/RayCluster"
@@ -32,62 +35,79 @@ message RayJobSpec {
   ];
 }
 
-// Describes the state of a dashboard.
+// Enum representing the various states of a Ray job
 enum RayJobState {
-  // The dashboard state is invalid.
+  // The state is invalid (used as a default value)
   RAY_JOB_V2_STATE_INVALID = 0;
 
+  // The job is currently being initialized
   RAY_JOB_V2_STATE_INITIALIZING = 1;
 
+  // The job is actively running
   RAY_JOB_V2_STATE_RUNNING = 2;
 
+  // The job completed successfully
   RAY_JOB_V2_STATE_SUCCEEDED = 3;
 
+  // The job failed to complete
   RAY_JOB_V2_STATE_FAILED = 4;
 
+  // The job was terminated or killed
   RAY_JOB_V2_STATE_KILLED = 5;
 }
 
 // Defines the status of a Ray job
 message RayJobV2Status {
+  // Current state of the Ray job
   RayJobState state = 1;
 
+  // Unique identifier for the Ray job
   string job_id = 2;
 
-  string jobStatus = 3;
+  // Status message providing additional information about the job
+  string job_status = 3;
 
+  // Additional message describing the current state or issues
   string message = 4;
 
-  string rayClusterStatus = 5;
+  // Status of the associated Ray cluster
+  string ray_cluster_status = 5;
 
-  string dashboardURL = 6;
+  // URL to access the Ray job's dashboard
+  string dashboard_url = 6;
 
-  string jobDeploymentStatus = 7;
+  // Deployment status of the Ray job
+  string job_deployment_status = 7;
 
-  string rayClusterName = 8;
+  // Name of the Ray cluster running the job
+  string ray_cluster_name = 8;
 }
 
-// RayJob is refer to a Ray job.
+// Represents a Ray job and its specifications
 message RayJob {
+  // Annotation for Michelangelo resource identification
   option (michelangelo.api.resource) = {};
 
+  // Kubernetes metadata for the Ray job
   k8s.io.apimachinery.pkg.apis.meta.v1.TypeMeta type_meta = 1;
   k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 2;
 
-  // Spec of the desired behavior of the Ray job.
+  // Specification for the desired behavior of the Ray job
   RayJobSpec spec = 3;
 
-  // Most recently observed status of the Ray job.
+  // Most recently observed status of the Ray job
   RayJobStatus status = 4;
 }
 
-// A list of Ray job objects.
+// A collection of Ray job objects
 message RayJobList {
+  // Annotation for Michelangelo resource list identification
   option (michelangelo.api.resource_list) = {};
 
+  // Kubernetes metadata for the Ray job list
   k8s.io.apimachinery.pkg.apis.meta.v1.TypeMeta type_meta = 1;
   k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 2;
 
-  // A list of Ray jobs
+  // List of Ray job objects
   repeated RayJob items = 3;
 }

--- a/proto/api/v2/ray_job.proto
+++ b/proto/api/v2/ray_job.proto
@@ -18,9 +18,6 @@ message RayJobSpec {
   // Information about the user initiating the Ray job workload
   UserInfo user = 1;
 
-  // Key-value pairs specifying user-defined Ray configurations
-  map<string, string> ray_conf = 2;
-
   // Entrypoint script or command to start the Ray job
   // This field specifies the main executable or script that initiates the Ray job.
   // Examples can include the path to a Python script, a shell command, or any executable.
@@ -29,13 +26,13 @@ message RayJobSpec {
   // a script that initializes the Ray cluster and launches training tasks.
   // It should be ensured that the entrypoint script is compatible with the environment
   // and dependencies provided in the job configuration.
-  string entrypoint = 3;
+  string entrypoint = 2;
 
   // Unique identifier for the Ray job
-  string job_id = 4;
+  string job_id = 3;
 
   // Reference to the Ray cluster where the job will be executed
-  michelangelo.api.ResourceIdentifier cluster = 5 [
+  michelangelo.api.ResourceIdentifier cluster = 4 [
     (michelangelo.api.resource_reference) = {
       type: "michelangelo.uber.com/RayCluster"
     }

--- a/proto/api/v2/ray_job.proto
+++ b/proto/api/v2/ray_job.proto
@@ -22,6 +22,13 @@ message RayJobSpec {
   map<string, string> ray_conf = 2;
 
   // Entrypoint script or command to start the Ray job
+  // This field specifies the main executable or script that initiates the Ray job.
+  // Examples can include the path to a Python script, a shell command, or any executable.
+  // The entrypoint is critical for defining the task logic and orchestration.
+  // For instance, if running a distributed training job, the entrypoint might be
+  // a script that initializes the Ray cluster and launches training tasks.
+  // It should be ensured that the entrypoint script is compatible with the environment
+  // and dependencies provided in the job configuration.
   string entrypoint = 3;
 
   // Unique identifier for the Ray job
@@ -38,22 +45,22 @@ message RayJobSpec {
 // Enum representing the various states of a Ray job
 enum RayJobState {
   // The state is invalid (used as a default value)
-  RAY_JOB_V2_STATE_INVALID = 0;
+  RAY_JOB_STATE_INVALID = 0;
 
   // The job is currently being initialized
-  RAY_JOB_V2_STATE_INITIALIZING = 1;
+  RAY_JOB_STATE_INITIALIZING = 1;
 
   // The job is actively running
-  RAY_JOB_V2_STATE_RUNNING = 2;
+  RAY_JOB_STATE_RUNNING = 2;
 
   // The job completed successfully
-  RAY_JOB_V2_STATE_SUCCEEDED = 3;
+  RAY_JOB_STATE_SUCCEEDED = 3;
 
   // The job failed to complete
-  RAY_JOB_V2_STATE_FAILED = 4;
+  RAY_JOB_STATE_FAILED = 4;
 
   // The job was terminated or killed
-  RAY_JOB_V2_STATE_KILLED = 5;
+  RAY_JOB_STATE_KILLED = 5;
 }
 
 // Defines the status of a Ray job

--- a/proto/api/v2/ray_job.proto
+++ b/proto/api/v2/ray_job.proto
@@ -72,6 +72,13 @@ message RayJobStatus {
   string job_id = 2;
 
   // Status message providing additional information about the job
+  // Examples of job status:
+  // - SUCCEEDED: Indicates the job has successfully completed all tasks.
+  // - FAILED: Indicates the job encountered an error or issue and could not complete.
+  // - STOPPED: Indicates the job was intentionally halted by a user or system.
+  // - RUNNING: Indicates the job is currently in progress and tasks are being executed.
+  // This field provides a textual representation of the current job state for debugging
+  // and monitoring purposes.
   string job_status = 3;
 
   // Additional message describing the current state or issues
@@ -83,7 +90,18 @@ message RayJobStatus {
   // URL to access the Ray job's dashboard
   string dashboard_url = 6;
 
-  // Deployment status of the Ray job
+  // Deployment status of the Ray job.
+  // Examples of job_deployment_status values:
+  //   - "Pending": The job is created but not yet started, waiting for resources or prerequisites.
+  //   - "Running": The job is actively executing tasks.
+  //   - "Succeeded": The job has completed successfully without errors.
+  //   - "Failed": The job terminated prematurely due to an error.
+  //   - "Terminating": The job is in the process of being shut down.
+  //   - "Cancelled": The job was manually stopped before completion.
+  //   - "Scaling": Resources are being adjusted to meet the job's demands.
+  //   - "Initializing": The job is setting up dependencies or preparing resources.
+  //   - "ResourcePending": The job is waiting for sufficient resources to execute.
+  //   - "Error: <specific_error>": A custom error message, such as "Error: Insufficient Memory".
   string job_deployment_status = 7;
 
   // Name of the Ray cluster running the job

--- a/proto/api/v2/ray_job.proto
+++ b/proto/api/v2/ray_job.proto
@@ -12,100 +12,59 @@ import "michelangelo/api/v2/job.proto";
 import "michelangelo/api/v2/pod.proto";
 import "michelangelo/api/v2/user.proto";
 
-// Specification for the head/driver in a Ray job
-message HeadSpec {
-  // Pod spec for the Ray head
-  PodSpec pod = 1;
-}
-
-// Specification for the workers in a Ray job
-message WorkerSpec {
-  // Pod spec for the Ray worker instances
-  PodSpec pod = 1;
-
-  // Minimum number of worker instances
-  int32 min_instances = 2;
-
-  // Maximum number of worker instances
-  int32 max_instances = 3;
-
-  // Node type for a worker in a heterogeneous cluster
-  string node_type = 4;
-
-  // Ray object store memory will be allocated based on this
-  // ratio of the overall worker memory
-  double object_store_memory_ratio = 5;
-}
-
 // Specification for a Ray job
 message RayJobSpec {
 
   // User initiating the ray job workload
   UserInfo user = 1;
 
-  // Affinity for the clusters and other jobs
-  Affinity affinity = 2;
-
-  // Ray head specification
-  HeadSpec head = 3;
-
-  // Ray worker specification
-  WorkerSpec worker = 4;
-
   // User-specified Ray configurations
-  map<string, string> ray_conf = 5;
+  map<string, string> ray_conf = 2;
 
-  // Termination spec
-  TerminationSpec termination = 6;
+  string entrypoint = 3;
 
-  // Scheduling spec
-  SchedulingSpec scheduling = 7;
+  string jobId = 4;
 
-  // Ray worker specification. This field is introduced to
-  // support clusters that have a heterogeneous set of workers.
-  // Eventually we should deprecate the worker field above because
-  // it can be represent by this field.
-  repeated WorkerSpec workers = 8;
+  michelangelo.api.ResourceIdentifier cluster = 5 [
+    (michelangelo.api.resource_reference) = {
+      type: "michelangelo.uber.com/RayCluster"
+    }
+  ];
 }
 
-// Information on the head node
-message RayHeadNodeInfo  {
-  // Name of the pod
-  string name = 1;
+// Describes the state of a dashboard.
+enum RayJobState {
+  // The dashboard state is invalid.
+  RAY_JOB_V2_STATE_INVALID = 0;
 
-  // Namespace of the pod
-  string namespace = 2;
+  RAY_JOB_V2_STATE_INITIALIZING = 1;
 
-  // Ip address of the pod
-  string ip = 3;
+  RAY_JOB_V2_STATE_RUNNING = 2;
 
-  // Port for clients to connect
-  int32 client_port = 4;
+  RAY_JOB_V2_STATE_SUCCEEDED = 3;
 
-  // Dashboard port for the ray cluster
-  int32 dashboard_port = 5;
+  RAY_JOB_V2_STATE_FAILED = 4;
+
+  RAY_JOB_V2_STATE_KILLED = 5;
 }
 
 // Defines the status of a Ray job
-message RayJobStatus {
-  // Information on the head node
-  RayHeadNodeInfo head_node = 1;
+message RayJobV2Status {
+  RayJobState state = 1;
 
-  // Conditions that describe states
-  repeated k8s.io.apimachinery.pkg.apis.meta.v1.Condition conditions = 2;
+  string job_id = 2;
 
-  // TODO Mark this as reserved after removing the usage
-  // Cluster Assignment
-  ClusterAssignment cluster_assignment = 3;
+  string jobStatus = 3;
 
-  // Assignment info
-  AssignmentInfo assignment = 4;
+  string message = 4;
 
-  // Scheduling info
-  SchedulingInfo scheduling_info = 5;
+  string rayClusterStatus = 5;
 
-  // Ray Job's url to view ray job specific details
-  string job_url = 7;
+  string dashboardURL = 6;
+
+  string jobDeploymentStatus = 7;
+
+  string rayClusterName = 8;
 }
 
 // RayJob is refer to a Ray job.

--- a/proto/api/v2/ray_job.proto
+++ b/proto/api/v2/ray_job.proto
@@ -64,7 +64,7 @@ enum RayJobState {
 }
 
 // Defines the status of a Ray job
-message RayJobV2Status {
+message RayJobStatus {
   // Current state of the Ray job
   RayJobState state = 1;
 

--- a/proto/api/v2/ray_job.proto
+++ b/proto/api/v2/ray_job.proto
@@ -86,9 +86,6 @@ message RayJobStatus {
   // Additional message describing the current state or issues
   string message = 4;
 
-  // Status of the associated Ray cluster
-  string ray_cluster_status = 5;
-
   // URL to access the Ray job's dashboard
   string dashboard_url = 6;
 

--- a/proto/api/v2/ray_job.proto
+++ b/proto/api/v2/ray_job.proto
@@ -28,11 +28,16 @@ message RayJobSpec {
   // and dependencies provided in the job configuration.
   string entrypoint = 2;
 
+
+  // Ray object store memory will be allocated based on this ratio of the overall worker memory.
+  // This ratio is specified as an entrypoint parameter to configure the memory allocated for the object store during worker node startup.
+  double object_store_memory_ratio = 3;
+
   // Unique identifier for the Ray job
-  string job_id = 3;
+  string job_id = 4;
 
   // Reference to the Ray cluster where the job will be executed
-  michelangelo.api.ResourceIdentifier cluster = 4 [
+  michelangelo.api.ResourceIdentifier cluster = 5 [
     (michelangelo.api.resource_reference) = {
       type: "michelangelo.uber.com/RayCluster"
     }


### PR DESCRIPTION
1. Create new ray cluster, 
2. Modify existing ray job for job-only specs, 
3. Referring cluster in RayJob for association