### PR TITLE
make gazelle ingore python directory

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,6 @@
 # gazelle:exclude .git/
 # gazelle:exclude pkg/
+# gazelle:exclude python/
 # gazelle:exclude build/
 # gazelle:exclude tools/bazelisk.py
 # gazelle:proto default


### PR DESCRIPTION
Make gazelle ingore python directory as we use Poetry to manage python dependencies & build