### PR TITLE
Setup static analyzers for Go

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -31,3 +31,11 @@ gazelle(
     ],
     command = "update-repos",
 )
+
+load("@io_bazel_rules_go//go:def.bzl", "nogo", "TOOLS_NOGO")
+
+nogo(
+    name = "default_nogo",
+    deps = TOOLS_NOGO,
+    visibility = ["//visibility:public"],
+)

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -9,6 +9,7 @@
 # gazelle:prefix github.com/michelangelo-ai/michelangelo
 
 load("@bazel_gazelle//:def.bzl", "DEFAULT_LANGUAGES", "gazelle", "gazelle_binary")
+load("@io_bazel_rules_go//go:def.bzl", "TOOLS_NOGO", "nogo")
 load("@rules_python_gazelle_plugin//:def.bzl", "GAZELLE_PYTHON_RUNTIME_DEPS")
 
 gazelle_binary(
@@ -32,10 +33,8 @@ gazelle(
     command = "update-repos",
 )
 
-load("@io_bazel_rules_go//go:def.bzl", "nogo", "TOOLS_NOGO")
-
 nogo(
     name = "default_nogo",
-    deps = TOOLS_NOGO,
     visibility = ["//visibility:public"],
+    deps = TOOLS_NOGO,
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,6 +20,11 @@ go_sdk.download(
     version = "1.23.3",
 )
 
+go_sdk.nogo(
+    includes = ["@//:__subpackages__"],
+    nogo = "//:default_nogo",
+)
+
 ###########################################
 ############# Third-party DEPENDENCIES ####
 ###########################################


### PR DESCRIPTION
This PR sets up build-time static analyzers for Go. For more info: https://github.com/bazel-contrib/rules_go/blob/master/go/nogo.rst