### PR TITLE
Refactor and cleanup logging

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,1 +1,2 @@
 pkg
+go/vendor

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -32,6 +32,8 @@ go_deps.from_file(go_mod = "//go:go.mod")
 use_repo(
     go_deps,
     "com_github_dave_dst",
+    "com_github_go_logr_logr",
+    "com_github_go_logr_zapr",
     "com_github_gobuffalo_flect",
     "com_github_gogo_protobuf",
     "com_github_gogo_status",

--- a/go/BUILD.bazel
+++ b/go/BUILD.bazel
@@ -1,3 +1,4 @@
+# gazelle:exclude vendor
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(

--- a/go/go.mod
+++ b/go/go.mod
@@ -4,6 +4,7 @@ go 1.23.2
 
 require (
 	github.com/dave/dst v0.27.3
+	github.com/go-logr/zapr v1.3.0
 	github.com/gobuffalo/flect v1.0.3
 	github.com/gogo/status v1.1.0
 	github.com/google/uuid v1.6.0
@@ -34,7 +35,7 @@ require (
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
-	github.com/go-logr/logr v1.4.2 // indirect
+	github.com/go-logr/logr v1.4.2
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect

--- a/go/kubeproto/templates/crd_svc.tmpl
+++ b/go/kubeproto/templates/crd_svc.tmpl
@@ -3,10 +3,10 @@ func New{{.KindName}}ServiceHandler(client *K8sClient, handler api.Handler, metr
 }
 
 type {{.LowerKindName}}ServiceHandler struct {
-	client *K8sClient
-	apiHandler api.Handler
-	MetricsScope tally.Scope
-	auth authapi.Auth
+	client          *K8sClient
+	apiHandler      api.Handler
+	MetricsScope    tally.Scope
+	auth            authapi.Auth
 	auditLogEmitter logging.AuditLog
 }
 
@@ -91,9 +91,9 @@ func (c {{.LowerKindName}}ServiceHandler) Create{{.KindName}}(ctx context.Contex
 	logger.Info("Create{{.KindName}} Request Called")
 
 	metric := c.MetricsScope.Tagged(map[string]string{
-		logging.APIProcedureTag:      	"Create{{.KindName}}",
-		logging.NamespaceTag:     	   	request.{{.KindName}}.ObjectMeta.Namespace,
-		logging.EntityNameTag:   	   	request.{{.KindName}}.ObjectMeta.Name,
+		logging.APIProcedureTag: "Create{{.KindName}}",
+		logging.NamespaceTag:    request.{{.KindName}}.ObjectMeta.Namespace,
+		logging.EntityNameTag:   request.{{.KindName}}.ObjectMeta.Name,
 	})
 
 	if Emit{{.KindName}}WriteMetric != nil {
@@ -179,9 +179,9 @@ func (c {{.LowerKindName}}ServiceHandler) Get{{.KindName}}(ctx context.Context, 
 	logger.Info("Get{{.KindName}} Request Called")
 
 	metric := c.MetricsScope.Tagged(map[string]string{
-		logging.APIProcedureTag:      	"Get{{.KindName}}",
-		logging.NamespaceTag:     	   	request.Namespace,
-		logging.EntityNameTag:   	   	request.Name,
+		logging.APIProcedureTag: "Get{{.KindName}}",
+		logging.NamespaceTag:    request.Namespace,
+		logging.EntityNameTag:   request.Name,
 	})
 
 	getOptions := &metav1.GetOptions{}
@@ -238,9 +238,9 @@ func (c {{.LowerKindName}}ServiceHandler) Update{{.KindName}}(ctx context.Contex
 	logger.Info("Update{{.KindName}} Request Called")
 
 	metric := c.MetricsScope.Tagged(map[string]string{
-		logging.APIProcedureTag:      	"Update{{.KindName}}",
-		logging.NamespaceTag:     	   	request.{{.KindName}}.ObjectMeta.Namespace,
-		logging.EntityNameTag:   	   	request.{{.KindName}}.ObjectMeta.Name,
+		logging.APIProcedureTag: "Update{{.KindName}}",
+		logging.NamespaceTag:    request.{{.KindName}}.ObjectMeta.Namespace,
+		logging.EntityNameTag:   request.{{.KindName}}.ObjectMeta.Name,
 	})
 
 	if Emit{{.KindName}}WriteMetric != nil {
@@ -325,9 +325,9 @@ func (c {{.LowerKindName}}ServiceHandler) Delete{{.KindName}}(ctx context.Contex
 	logger.Info("Delete{{.KindName}} Request Called")
 
 	metric := c.MetricsScope.Tagged(map[string]string{
-		logging.APIProcedureTag:      	"Delete{{.KindName}}",
-		logging.NamespaceTag:     	   	request.Namespace,
-		logging.EntityNameTag:  	   	request.Name,
+		logging.APIProcedureTag: "Delete{{.KindName}}",
+		logging.NamespaceTag:    request.Namespace,
+		logging.EntityNameTag:   request.Name,
 	})
 
 	defer c.auditLogEmitter.Emit(ctx, c.build{{.KindName}}AuditLogEventForDelete(
@@ -403,8 +403,8 @@ func (c {{.LowerKindName}}ServiceHandler) Delete{{.KindName}}Collection(ctx cont
 	logger.Info("Delete{{.KindName}}Collection Request Called")
 
 	metric := c.MetricsScope.Tagged(map[string]string{
-		logging.APIProcedureTag:      	"Delete{{.KindName}}Collection",
-		logging.NamespaceTag:     	   	request.Namespace,
+		logging.APIProcedureTag: "Delete{{.KindName}}Collection",
+		logging.NamespaceTag:    request.Namespace,
 	})
 
 	defer c.auditLogEmitter.Emit(ctx, c.build{{.KindName}}AuditLogEventForDeleteCollection(
@@ -483,8 +483,8 @@ func (c {{.LowerKindName}}ServiceHandler) List{{.KindName}}(ctx context.Context,
 	logger.Info("List{{.KindName}} Request Called")
 
 	metric := c.MetricsScope.Tagged(map[string]string{
-		logging.APIProcedureTag:      	"List{{.KindName}}",
-		logging.NamespaceTag:      	   	request.Namespace,
+		logging.APIProcedureTag: "List{{.KindName}}",
+		logging.NamespaceTag:    request.Namespace,
 	})
 
 	result := &{{.KindName}}List{}

--- a/go/kubeproto/templates/crd_svc.tmpl
+++ b/go/kubeproto/templates/crd_svc.tmpl
@@ -1,5 +1,5 @@
 func New{{.KindName}}ServiceHandler(client *K8sClient, handler api.Handler, metricsScope tally.Scope, auth authapi.Auth, auditLog logging.AuditLog) {{.KindName}}ServiceYARPCServer {
-	return &{{.LowerKindName}}ServiceHandler{client: client, apiHandler: handler, MetricsScope: metricsScope.SubScope(logging.UAPIYARPCMetricScopeKey), auth: auth, auditLogEmitter: auditLog}
+	return &{{.LowerKindName}}ServiceHandler{client: client, apiHandler: handler, MetricsScope: metricsScope.SubScope(logging.MichelangeloAPIScopeName), auth: auth, auditLogEmitter: auditLog}
 }
 
 type {{.LowerKindName}}ServiceHandler struct {
@@ -83,31 +83,17 @@ var {{.KindName}}ApiHook interface {
 } = nil
 
 func (c {{.LowerKindName}}ServiceHandler) Create{{.KindName}}(ctx context.Context, request *Create{{.KindName}}Request) (resp *Create{{.KindName}}Response, err error) {
-
 	logger := logging.GetLogrLoggerOrPanic()
-	maUUID := logging.GetMaUUID(ctx)
 
-	// Add MA UUID to Annotation
-	annotation := request.{{.KindName}}.GetAnnotations()
-	if annotation == nil {
-		annotation = make(map[string]string)
-	}
-	annotation[logging.MaUUIDKey] = maUUID
-	request.{{.KindName}}.SetAnnotations(annotation)
+	requestJSON := logging.MarshalToString(request)
 
-	requestJSON := logging.MarshalAndTruncateRequest(request)
-
-	logger = logger.WithValues(logging.MaUUIDKey, maUUID, "request", requestJSON, "context", ctx, logging.UnifiedLogKey, true)
+	logger = logger.WithValues("request", requestJSON, "context", ctx)
 	logger.Info("Create{{.KindName}} Request Called")
 
-	actor := logging.GetActor(ctx)
-
 	metric := c.MetricsScope.Tagged(map[string]string{
-		logging.YAPRCTypeTag:      	"Create{{.KindName}}",
-		logging.ProjectTag: 	   	request.{{.KindName}}.ObjectMeta.Namespace,
-		logging.EntityTag: 	   		request.{{.KindName}}.ObjectMeta.Name,
-		logging.YARPCActorTag:		actor,
-		logging.YARPCSourceTag:     logging.GetSource(ctx),
+		logging.APIProcedureTag:      	"Create{{.KindName}}",
+		logging.NamespaceTag:     	   	request.{{.KindName}}.ObjectMeta.Namespace,
+		logging.EntityNameTag:   	   	request.{{.KindName}}.ObjectMeta.Name,
 	})
 
 	if Emit{{.KindName}}WriteMetric != nil {
@@ -119,7 +105,6 @@ func (c {{.LowerKindName}}ServiceHandler) Create{{.KindName}}(ctx context.Contex
 												request,
 												resp,
 												err,
-												maUUID,
 												),
 				)
 
@@ -187,22 +172,16 @@ func (c {{.LowerKindName}}ServiceHandler) Create{{.KindName}}(ctx context.Contex
 }
 
 func (c {{.LowerKindName}}ServiceHandler) Get{{.KindName}}(ctx context.Context, request *Get{{.KindName}}Request) (resp *Get{{.KindName}}Response, err error) {
-
 	logger := logging.GetLogrLoggerOrPanic()
-	maUUID := logging.GetMaUUID(ctx)
-	requestJSON := logging.MarshalAndTruncateRequest(request)
+	requestJSON := logging.MarshalToString(request)
 
-	logger = logger.WithValues(logging.MaUUIDKey, maUUID, "request", requestJSON, "context", ctx, logging.UnifiedLogKey, true)
+	logger = logger.WithValues("request", requestJSON, "context", ctx)
 	logger.Info("Get{{.KindName}} Request Called")
 
-	actor := logging.GetActor(ctx)
-
 	metric := c.MetricsScope.Tagged(map[string]string{
-		logging.YAPRCTypeTag:      	"Get{{.KindName}}",
-		logging.ProjectTag: 	   	request.Namespace,
-		logging.EntityTag: 	   		request.Name,
-		logging.YARPCActorTag:		actor,
-		logging.YARPCSourceTag:     logging.GetSource(ctx),
+		logging.APIProcedureTag:      	"Get{{.KindName}}",
+		logging.NamespaceTag:     	   	request.Namespace,
+		logging.EntityNameTag:   	   	request.Name,
 	})
 
 	getOptions := &metav1.GetOptions{}
@@ -218,7 +197,6 @@ func (c {{.LowerKindName}}ServiceHandler) Get{{.KindName}}(ctx context.Context, 
 												request,
 												resp,
 												err,
-												maUUID,
 												),
 				)
 
@@ -253,31 +231,16 @@ func (c {{.LowerKindName}}ServiceHandler) Get{{.KindName}}(ctx context.Context, 
 }
 
 func (c {{.LowerKindName}}ServiceHandler) Update{{.KindName}}(ctx context.Context, request *Update{{.KindName}}Request) (resp *Update{{.KindName}}Response, err error) {
-
 	logger := logging.GetLogrLoggerOrPanic()
-	maUUID := logging.GetMaUUID(ctx)
+	requestJSON := logging.MarshalToString(request)
 
-	// Add MA UUID to Annotation
-	annotation := request.{{.KindName}}.GetAnnotations()
-	if annotation == nil {
-		annotation = make(map[string]string)
-	}
-	annotation[logging.MaUUIDKey] = maUUID
-	request.{{.KindName}}.SetAnnotations(annotation)
-
-	requestJSON := logging.MarshalAndTruncateRequest(request)
-
-	logger = logger.WithValues(logging.MaUUIDKey, maUUID, "request", requestJSON, "context", ctx, logging.UnifiedLogKey, true)
+	logger = logger.WithValues("request", requestJSON, "context", ctx)
 	logger.Info("Update{{.KindName}} Request Called")
 
-	actor := logging.GetActor(ctx)
-
 	metric := c.MetricsScope.Tagged(map[string]string{
-		logging.YAPRCTypeTag:      	"Update{{.KindName}}",
-		logging.ProjectTag: 	   	request.{{.KindName}}.ObjectMeta.Namespace,
-		logging.EntityTag: 	   		request.{{.KindName}}.ObjectMeta.Name,
-		logging.YARPCActorTag:		actor,
-		logging.YARPCSourceTag:     logging.GetSource(ctx),
+		logging.APIProcedureTag:      	"Update{{.KindName}}",
+		logging.NamespaceTag:     	   	request.{{.KindName}}.ObjectMeta.Namespace,
+		logging.EntityNameTag:   	   	request.{{.KindName}}.ObjectMeta.Name,
 	})
 
 	if Emit{{.KindName}}WriteMetric != nil {
@@ -289,7 +252,6 @@ func (c {{.LowerKindName}}ServiceHandler) Update{{.KindName}}(ctx context.Contex
 												request,
 												resp,
 												err,
-												maUUID,
 												),
 				)
 
@@ -356,22 +318,16 @@ func (c {{.LowerKindName}}ServiceHandler) Update{{.KindName}}(ctx context.Contex
 }
 
 func (c {{.LowerKindName}}ServiceHandler) Delete{{.KindName}}(ctx context.Context, request *Delete{{.KindName}}Request) (resp *Delete{{.KindName}}Response, err error) {
-
 	logger := logging.GetLogrLoggerOrPanic()
-	maUUID := logging.GetMaUUID(ctx)
-	requestJSON := logging.MarshalAndTruncateRequest(request)
+	requestJSON := logging.MarshalToString(request)
 
-	logger = logger.WithValues(logging.MaUUIDKey, maUUID, "request", requestJSON, "context", ctx, logging.UnifiedLogKey, true)
+	logger = logger.WithValues("request", requestJSON, "context", ctx)
 	logger.Info("Delete{{.KindName}} Request Called")
 
-	actor := logging.GetActor(ctx)
-
 	metric := c.MetricsScope.Tagged(map[string]string{
-		logging.YAPRCTypeTag:      	"Delete{{.KindName}}",
-		logging.ProjectTag: 	   	request.Namespace,
-		logging.EntityTag: 	   		request.Name,
-		logging.YARPCActorTag:		actor,
-		logging.YARPCSourceTag:     logging.GetSource(ctx),
+		logging.APIProcedureTag:      	"Delete{{.KindName}}",
+		logging.NamespaceTag:     	   	request.Namespace,
+		logging.EntityNameTag:  	   	request.Name,
 	})
 
 	defer c.auditLogEmitter.Emit(ctx, c.build{{.KindName}}AuditLogEventForDelete(
@@ -379,7 +335,6 @@ func (c {{.LowerKindName}}ServiceHandler) Delete{{.KindName}}(ctx context.Contex
 												request,
 												resp,
 												err,
-												maUUID,
 												),
 				)
 
@@ -413,14 +368,6 @@ func (c {{.LowerKindName}}ServiceHandler) Delete{{.KindName}}(ctx context.Contex
 	deleteObj := &{{.KindName}}{
 		ObjectMeta: metav1.ObjectMeta{Namespace: request.Namespace, Name: request.Name}}
 
-	// Add MA UUID to Annotation
-	annotation := deleteObj.GetAnnotations()
-	if annotation == nil {
-		annotation = make(map[string]string)
-		deleteObj.SetAnnotations(annotation)
-	}
-	annotation[logging.MaUUIDKey] = maUUID
-
 	if {{.KindName}}ApiHook != nil {
 		if err = {{.KindName}}ApiHook.BeforeDelete(ctx, request); err != nil {
 			logger.Error(err, "Error in BeforeDelete Validation", "error", err, "api_msg_tag", "Delete{{.KindName}}")
@@ -449,21 +396,15 @@ func (c {{.LowerKindName}}ServiceHandler) Delete{{.KindName}}(ctx context.Contex
 }
 
 func (c {{.LowerKindName}}ServiceHandler) Delete{{.KindName}}Collection(ctx context.Context, request *Delete{{.KindName}}CollectionRequest) (resp *Delete{{.KindName}}CollectionResponse, err error) {
-
 	logger := logging.GetLogrLoggerOrPanic()
-	maUUID := logging.GetMaUUID(ctx)
-	requestJSON := logging.MarshalAndTruncateRequest(request)
+	requestJSON := logging.MarshalToString(request)
 
-	logger = logger.WithValues(logging.MaUUIDKey, maUUID, "request", requestJSON, "context", ctx, logging.UnifiedLogKey, true)
+	logger = logger.WithValues("request", requestJSON, "context", ctx)
 	logger.Info("Delete{{.KindName}}Collection Request Called")
 
-	actor := logging.GetActor(ctx)
-
 	metric := c.MetricsScope.Tagged(map[string]string{
-		logging.YAPRCTypeTag:      	"Delete{{.KindName}}Collection",
-		logging.ProjectTag: 	   	request.Namespace,
-		logging.YARPCActorTag:		actor,
-		logging.YARPCSourceTag:     logging.GetSource(ctx),
+		logging.APIProcedureTag:      	"Delete{{.KindName}}Collection",
+		logging.NamespaceTag:     	   	request.Namespace,
 	})
 
 	defer c.auditLogEmitter.Emit(ctx, c.build{{.KindName}}AuditLogEventForDeleteCollection(
@@ -471,7 +412,6 @@ func (c {{.LowerKindName}}ServiceHandler) Delete{{.KindName}}Collection(ctx cont
 												request,
 												resp,
 												err,
-												maUUID,
 												),
 				)
 
@@ -537,19 +477,14 @@ func (c {{.LowerKindName}}ServiceHandler) Delete{{.KindName}}Collection(ctx cont
 func (c {{.LowerKindName}}ServiceHandler) List{{.KindName}}(ctx context.Context, request *List{{.KindName}}Request) (resp *List{{.KindName}}Response, err error) {
 
 	logger := logging.GetLogrLoggerOrPanic()
-	maUUID := logging.GetMaUUID(ctx)
-	requestJSON := logging.MarshalAndTruncateRequest(request)
+	requestJSON := logging.MarshalToString(request)
 
-	logger = logger.WithValues(logging.MaUUIDKey, maUUID, "request", requestJSON, "context", ctx, logging.UnifiedLogKey, true)
+	logger = logger.WithValues("request", requestJSON, "context", ctx)
 	logger.Info("List{{.KindName}} Request Called")
 
-	actor := logging.GetActor(ctx)
-
 	metric := c.MetricsScope.Tagged(map[string]string{
-		logging.YAPRCTypeTag:      	"List{{.KindName}}",
-		logging.ProjectTag: 	   	request.Namespace,
-		logging.YARPCActorTag:		actor,
-		logging.YARPCSourceTag:     logging.GetSource(ctx),
+		logging.APIProcedureTag:      	"List{{.KindName}}",
+		logging.NamespaceTag:      	   	request.Namespace,
 	})
 
 	result := &{{.KindName}}List{}
@@ -568,7 +503,6 @@ func (c {{.LowerKindName}}ServiceHandler) List{{.KindName}}(ctx context.Context,
 												request,
 												resp,
 												err,
-												maUUID,
 												),
 				)
 
@@ -591,56 +525,51 @@ func (c {{.LowerKindName}}ServiceHandler) List{{.KindName}}(ctx context.Context,
 	return resp, err
 }
 
-func (c {{.LowerKindName}}ServiceHandler) buildAuditLogEvent(ctx context.Context, procedure string, entityType string, requestNamespace string, requestName string, request interface{}, response interface{}, grpcErr error, maUUID string) *logging.UAPIAuditLogEvent {
-	userEmail := logging.GetActor(ctx)
-	requestJSON := logging.MarshalAndTruncateRequest(request)
-	responseJSON := logging.MarshalAndTruncateRequest(response)
-	source := logging.GetSource(ctx)
+func (c {{.LowerKindName}}ServiceHandler) buildAuditLogEvent(ctx context.Context, procedure string, entityType string, requestNamespace string, requestName string, request interface{}, response interface{}, grpcErr error) *logging.AuditLogEvent {
+	requestJSON := logging.MarshalToString(request)
+	responseJSON := logging.MarshalToString(response)
 	errMsg := ""
 	if grpcErr != nil {
 		errMsg = grpcErr.Error()
 	}
 
-	event := &logging.UAPIAuditLogEvent{
-		Namespace:  &requestNamespace,
-		EntityType: &entityType,
-		EntityName: &requestName,
-		Procedure:  &procedure,
-		UserEmail:  &userEmail,
-		Source: 	&source,
-		Request:    &requestJSON,
-		Response:   &responseJSON,
-		Error:      &errMsg,
-		MAUUID:     &maUUID,
+	event := &logging.AuditLogEvent{
+		Namespace:  requestNamespace,
+		EntityType: entityType,
+		EntityName: requestName,
+		Procedure:  procedure,
+		Request:    requestJSON,
+		Response:   responseJSON,
+		Error:      errMsg,
 	}
 
 	return event
 }
 
-func (c {{.LowerKindName}}ServiceHandler) build{{.KindName}}AuditLogEventForCreate(ctx context.Context, request *Create{{.KindName}}Request, response *Create{{.KindName}}Response, grpcErr error, maUUID string) *logging.UAPIAuditLogEvent {
+func (c {{.LowerKindName}}ServiceHandler) build{{.KindName}}AuditLogEventForCreate(ctx context.Context, request *Create{{.KindName}}Request, response *Create{{.KindName}}Response, grpcErr error) *logging.AuditLogEvent {
 	requestNamespace := request.{{.KindName}}.ObjectMeta.Namespace
 	requestName := request.{{.KindName}}.ObjectMeta.Name
 	entityType := "{{.KindName}}"
 	procedure := "Create{{.KindName}}"
-	return c.buildAuditLogEvent(ctx, procedure, entityType, requestNamespace, requestName, request, response, grpcErr, maUUID)
+	return c.buildAuditLogEvent(ctx, procedure, entityType, requestNamespace, requestName, request, response, grpcErr)
 }
 
-func (c {{.LowerKindName}}ServiceHandler) build{{.KindName}}AuditLogEventForGet(ctx context.Context, request *Get{{.KindName}}Request, response *Get{{.KindName}}Response, grpcErr error, maUUID string) *logging.UAPIAuditLogEvent {
+func (c {{.LowerKindName}}ServiceHandler) build{{.KindName}}AuditLogEventForGet(ctx context.Context, request *Get{{.KindName}}Request, response *Get{{.KindName}}Response, grpcErr error) *logging.AuditLogEvent {
 	requestNamespace := request.Namespace
 	requestName := request.Name
 	entityType := "{{.KindName}}"
 	procedure := "Get{{.KindName}}"
-	return c.buildAuditLogEvent(ctx, procedure, entityType, requestNamespace, requestName, request, response, grpcErr, maUUID)
+	return c.buildAuditLogEvent(ctx, procedure, entityType, requestNamespace, requestName, request, response, grpcErr)
 
 }
 
-func (c {{.LowerKindName}}ServiceHandler) build{{.KindName}}AuditLogEventForUpdate(ctx context.Context, request *Update{{.KindName}}Request, response *Update{{.KindName}}Response, grpcErr error, maUUID string) *logging.UAPIAuditLogEvent {
+func (c {{.LowerKindName}}ServiceHandler) build{{.KindName}}AuditLogEventForUpdate(ctx context.Context, request *Update{{.KindName}}Request, response *Update{{.KindName}}Response, grpcErr error) *logging.AuditLogEvent {
 	requestNamespace := request.{{.KindName}}.ObjectMeta.Namespace
 	requestName := request.{{.KindName}}.ObjectMeta.Name
 	entityType := "{{.KindName}}"
 	procedure := "Update{{.KindName}}"
 
-	event := c.buildAuditLogEvent(ctx, procedure, entityType, requestNamespace, requestName, request, response, grpcErr, maUUID)
+	event := c.buildAuditLogEvent(ctx, procedure, entityType, requestNamespace, requestName, request, response, grpcErr)
 
 	preCRD := ""
 	getOptions := &metav1.GetOptions{
@@ -653,20 +582,20 @@ func (c {{.LowerKindName}}ServiceHandler) build{{.KindName}}AuditLogEventForUpda
 	err := c.apiHandler.Get(ctx, requestNamespace, requestName, getOptions, result)
 
 	if err == nil {
-		preCRD = logging.MarshalAndTruncateRequest(result)
+		preCRD = logging.MarshalToString(result)
 	}
 
-	event.PreCRD = &preCRD
+	event.PreCRD = preCRD
 
 	return event
 }
 
-func (c {{.LowerKindName}}ServiceHandler) build{{.KindName}}AuditLogEventForDelete(ctx context.Context, request *Delete{{.KindName}}Request, response *Delete{{.KindName}}Response, grpcErr error, maUUID string) *logging.UAPIAuditLogEvent {
+func (c {{.LowerKindName}}ServiceHandler) build{{.KindName}}AuditLogEventForDelete(ctx context.Context, request *Delete{{.KindName}}Request, response *Delete{{.KindName}}Response, grpcErr error) *logging.AuditLogEvent {
 	requestNamespace := request.Namespace
 	requestName := request.Name
 	entityType := "{{.KindName}}"
 	procedure := "Delete{{.KindName}}"
-	event := c.buildAuditLogEvent(ctx, procedure, entityType, requestNamespace, requestName, request, response, grpcErr, maUUID)
+	event := c.buildAuditLogEvent(ctx, procedure, entityType, requestNamespace, requestName, request, response, grpcErr)
 
 	preCRD := ""
 	getOptions := &metav1.GetOptions{
@@ -679,29 +608,29 @@ func (c {{.LowerKindName}}ServiceHandler) build{{.KindName}}AuditLogEventForDele
 	err := c.apiHandler.Get(ctx, requestNamespace, requestName, getOptions, result)
 
 	if err == nil {
-		preCRD = logging.MarshalAndTruncateRequest(result)
+		preCRD = logging.MarshalToString(result)
 	}
 
-	event.PreCRD = &preCRD
+	event.PreCRD = preCRD
 
 	return event
 
 }
 
-func (c {{.LowerKindName}}ServiceHandler) build{{.KindName}}AuditLogEventForDeleteCollection(ctx context.Context, request *Delete{{.KindName}}CollectionRequest, response *Delete{{.KindName}}CollectionResponse, grpcErr error, maUUID string) *logging.UAPIAuditLogEvent {
+func (c {{.LowerKindName}}ServiceHandler) build{{.KindName}}AuditLogEventForDeleteCollection(ctx context.Context, request *Delete{{.KindName}}CollectionRequest, response *Delete{{.KindName}}CollectionResponse, grpcErr error) *logging.AuditLogEvent {
 	requestNamespace := request.Namespace
 	requestName := ""
 	entityType := "{{.KindName}}"
 	procedure := "Delete{{.KindName}}Collection"
-	return c.buildAuditLogEvent(ctx, procedure, entityType, requestNamespace, requestName, request, response, grpcErr, maUUID)
+	return c.buildAuditLogEvent(ctx, procedure, entityType, requestNamespace, requestName, request, response, grpcErr)
 }
 
-func (c {{.LowerKindName}}ServiceHandler) build{{.KindName}}AuditLogEventForList(ctx context.Context, request *List{{.KindName}}Request, response *List{{.KindName}}Response, grpcErr error, maUUID string) *logging.UAPIAuditLogEvent {
+func (c {{.LowerKindName}}ServiceHandler) build{{.KindName}}AuditLogEventForList(ctx context.Context, request *List{{.KindName}}Request, response *List{{.KindName}}Response, grpcErr error) *logging.AuditLogEvent {
 	requestNamespace := request.Namespace
 	requestName := ""
 	entityType := "{{.KindName}}"
 	procedure := "List{{.KindName}}"
-	event := c.buildAuditLogEvent(ctx, procedure, entityType, requestNamespace, requestName, request, response, grpcErr, maUUID)
+	event := c.buildAuditLogEvent(ctx, procedure, entityType, requestNamespace, requestName, request, response, grpcErr)
 
 	responseList := ""
 	if grpcErr != nil {
@@ -710,7 +639,7 @@ func (c {{.LowerKindName}}ServiceHandler) build{{.KindName}}AuditLogEventForList
 		}
 	}
 
-	event.Response = &responseList
+	event.Response = responseList
 
 	return event
 }

--- a/go/logging/BUILD.bazel
+++ b/go/logging/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -15,4 +15,11 @@ go_library(
         "@com_github_go_logr_zapr//:go_default_library",
         "@org_uber_go_zap//:go_default_library",
     ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["utils_test.go"],
+    embed = [":go_default_library"],
+    deps = ["@com_github_stretchr_testify//assert:go_default_library"],
 )

--- a/go/logging/BUILD.bazel
+++ b/go/logging/BUILD.bazel
@@ -5,7 +5,14 @@ go_library(
     srcs = [
         "audit_log_struct.go",
         "audit_logger.go",
+        "constants.go",
+        "utils.go",
     ],
     importpath = "github.com/michelangelo-ai/michelangelo/go/logging",
     visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_go_logr_logr//:go_default_library",
+        "@com_github_go_logr_zapr//:go_default_library",
+        "@org_uber_go_zap//:go_default_library",
+    ],
 )

--- a/go/logging/audit_log_struct.go
+++ b/go/logging/audit_log_struct.go
@@ -5,16 +5,8 @@ type AuditLogEvent struct {
 	EntityType string
 	EntityName string
 	Procedure  string
-	UserEmail  string
-	Source     string
-	Headers    string
 	Request    string
 	Response   string
 	Error      string
-	MAUUID     string
-	RuntimeEnv string
-	CRDDiff    string
 	PreCRD     string
-	TimeStamp  int64
-	Dimension  string
 }

--- a/go/logging/constants.go
+++ b/go/logging/constants.go
@@ -1,0 +1,13 @@
+package logging
+
+// MichelangeloAPIScopeName is the metrics sub-scope name for all Michelangelo API calls
+const MichelangeloAPIScopeName = "ma_api"
+
+// APIProcedureTag is the metrics tag key for yarpc procedure name
+const APIProcedureTag = "api_procedure"
+
+// NamespaceTag is the metrics tag key for Michelangelo project name
+const NamespaceTag = "namespace"
+
+// EntityNameTag is the Tally metrics tag key for entity name
+const EntityNameTag = "name"

--- a/go/logging/constants.go
+++ b/go/logging/constants.go
@@ -1,7 +1,7 @@
 package logging
 
-// MichelangeloAPIScopeName is the metrics sub-scope name for all Michelangelo API calls
-const MichelangeloAPIScopeName = "ma_api"
+// MichelangeloAPIScopeName is the sub-scope name for Michelangelo API metrics
+const MichelangeloAPIScopeName = "api"
 
 // APIProcedureTag is the metrics tag key for yarpc procedure name
 const APIProcedureTag = "api_procedure"

--- a/go/logging/utils.go
+++ b/go/logging/utils.go
@@ -3,6 +3,7 @@ package logging
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
 	"go.uber.org/zap"

--- a/go/logging/utils.go
+++ b/go/logging/utils.go
@@ -1,0 +1,25 @@
+package logging
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
+	"go.uber.org/zap"
+)
+
+// MarshalToString marshals the input message into JSON form and convert into string.
+func MarshalToString(v interface{}) string {
+	b, _ := json.Marshal(v)
+	return string(b)
+}
+
+// GetLogrLoggerOrPanic returns a logr logger
+func GetLogrLoggerOrPanic() logr.Logger {
+	zc := zap.NewProductionConfig()
+	z, err := zc.Build()
+	if err != nil {
+		panic(fmt.Sprintf("Can't get logr logger, error %s", err.Error()))
+	}
+	return zapr.NewLogger(z)
+}

--- a/go/logging/utils_test.go
+++ b/go/logging/utils_test.go
@@ -1,8 +1,9 @@
 package logging
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMarshalToString(t *testing.T) {

--- a/go/logging/utils_test.go
+++ b/go/logging/utils_test.go
@@ -1,0 +1,57 @@
+package logging
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestMarshalToString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    interface{}
+		expected string
+	}{
+		{
+			name:     "Marshal map",
+			input:    map[string]interface{}{"key": "value", "num": 42},
+			expected: `{"key":"value","num":42}`,
+		},
+		{
+			name:     "Marshal string",
+			input:    "test",
+			expected: `"test"`,
+		},
+		{
+			name:     "Marshal int",
+			input:    123,
+			expected: `123`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := MarshalToString(tt.input)
+			if result != tt.expected {
+				t.Errorf("Expected: %s, got: %s", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestGetLogrLoggerOrPanic(t *testing.T) {
+	t.Run("successful logger creation", func(t *testing.T) {
+		// This should not panic
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("GetLogrLoggerOrPanic() should not panic but did: %v", r)
+			}
+		}()
+
+		logger := GetLogrLoggerOrPanic()
+		assert.NotNil(t, logger, "Logger should not be nil")
+
+		// Test that the logger can be used
+		// This shouldn't panic
+		logger.Info("test message", "key", "value")
+	})
+}


### PR DESCRIPTION
1. Remove MA UUID and UnifiedLog
MA UUID is a uuid used for tracing requests across multiple services and stages
UnifiedLog is a log tag to mark log messages that are useful for Michelangelo users and log messages that are only for Michelangelo developers.
Both were not fully implemented. Based on our experience in the last 2 years, these features are not very useful and hard to maintain.

2. Remove the tally and log tags for user email, caller, source
This information is added to yarpc context by Uber's internal libraries. We can't get this info in open source code. We will retrieve this information from context in Uber's internal implementation of audit logger and metrics emit functions

3. Rename tally sub scope name from 'uapi_yarpc' to 'ma_api'
In OSS Michelangelo we don't use the term "unified API", as there is only one Michelanelo API

4. Rename tally tag name from "project" to "namespace"
Although, in most cases, k8s namespaces corresponds to michelangelo projects. There are a few cases the namespaces are not projects. Calling this tag "namespace" is more accurate

5. Do not truncate JSON string in the generated yarpc service code
Different logging services have different maximum string length limits. We will do the truncation in the custom implementations of audit log and log sink, rater than setting a global limit.

6. Remove the fields of AuditLogEvent that are not set / used in OSS michelangelo

7. Remove "Unified Log"
We used to use 2 loggers: zap sugar logger and logr logger. "Unified Log" was added as an abstract layer on top of these 2 loggers.  Now, we should only use logr. "Unified Log" is no longer needed

7. added go/vendor in .bazelignore
This directory is generated by 'go mod vendor' command