### PR TITLE
Build python package for pypi.org (Exclude all source code in poetry package builder in temporary)

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -34,3 +34,15 @@ The last step will create a `.venv` directory if it doesn't already exist.
 This directory contains a Python virtual environment with all the dependencies installed.
 You can activate this virtual environment and use it like any other Python virtual environment, 
 or you can run commands via the Poetry CLI, e.g., `poetry run python`, `poetry run pytest`, etc.
+
+
+
+### Package Build
+
+- Assume all development environment config is ready. (Poetry is installed)
+
+```
+poetry build
+```
+
+It will leverage the `poetry` configuration in [pyproject.toml] file (`tool.poetry` section)

--- a/python/README.md
+++ b/python/README.md
@@ -34,15 +34,3 @@ The last step will create a `.venv` directory if it doesn't already exist.
 This directory contains a Python virtual environment with all the dependencies installed.
 You can activate this virtual environment and use it like any other Python virtual environment, 
 or you can run commands via the Poetry CLI, e.g., `poetry run python`, `poetry run pytest`, etc.
-
-
-
-### Package Build
-
-- Assume all development environment config is ready. (Poetry is installed)
-
-```
-poetry build
-```
-
-It will leverage the `poetry` configuration in [pyproject.toml] file (`tool.poetry` section)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "michelangelo"
 version = "0.1.0"
-description = "Python Michelangelo package"
+description = "Michelangelo is an end-to-end model lifecycle management system at large scale"
 authors = ["todo <todo@uber.com>"]
 readme = "README.md"
 exclude = ["michelangelo"]    # TODO: temporary exclude all codes in package building

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,10 +1,10 @@
 [tool.poetry]
-name = "pymichelangelo"
+name = "michelangelo"
 version = "0.1.0"
 description = "Python Michelangelo package"
 authors = ["todo <todo@uber.com>"]
 readme = "README.md"
-exclude = ["michelangelo/"]    # TODO: temporary exclude all codes in package building
+exclude = ["michelangelo"]    # TODO: temporary exclude all codes in package building
 
 
 [tool.poetry.dependencies]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,10 +1,13 @@
 [tool.poetry]
-name = "michelangelo"
+name = "pymichelangelo"
 version = "0.1.0"
 description = "Michelangelo is an end-to-end model lifecycle management system at large scale"
 authors = ["Michelangelo Team <michelangelo-oss-group@uber.com>"]
 readme = "README.md"
 exclude = ["michelangelo"]    # TODO: temporary exclude all codes in package building
+packages = [
+    { include = "michelangelo" },
+]
 
 
 [tool.poetry.dependencies]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -2,7 +2,7 @@
 name = "michelangelo"
 version = "0.1.0"
 description = "Michelangelo is an end-to-end model lifecycle management system at large scale"
-authors = ["todo <todo@uber.com>"]
+authors = ["Michelangelo Team <michelangelo-oss-group@uber.com>"]
 readme = "README.md"
 exclude = ["michelangelo"]    # TODO: temporary exclude all codes in package building
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,9 +1,10 @@
 [tool.poetry]
-name = "michelangelo"
+name = "pymichelangelo"
 version = "0.1.0"
-description = "todo"
+description = "Python Michelangelo package"
 authors = ["todo <todo@uber.com>"]
 readme = "README.md"
+exclude = ["michelangelo/"]    # TODO: temporary exclude all codes in package building
 
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
#61 

Exclude all source code in poetry package builder in temporary. Checked that the compiled wheel file only contains some metadata files only with current config.

```
['michelangelo-0.1.0.dist-info/METADATA',
 'michelangelo-0.1.0.dist-info/WHEEL',
 'michelangelo-0.1.0.dist-info/entry_points.txt',
 'michelangelo-0.1.0.dist-info/RECORD']
```