### PR TITLE
fix package name in v2/emtpy.go; run bazel mod tidy

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -33,11 +33,11 @@ oci.pull(
     digest = "sha256:ccaef5ee2f1850270d453fdf700a5392534f8d1a8ca2acda391fbb6a06b81c86",
     image = "gcr.io/distroless/base",
     platforms = [
-            "linux/amd64",
-            "linux/arm64",
-        ],
+        "linux/amd64",
+        "linux/arm64",
+    ],
 )
-use_repo(oci, "distroless_base")
+use_repo(oci, "distroless_base", "distroless_base_linux_amd64", "distroless_base_linux_arm64")
 
 go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//go:go.mod")

--- a/proto/api/v2/empty.go
+++ b/proto/api/v2/empty.go
@@ -1,1 +1,1 @@
-package kubeproto
+package v2


### PR DESCRIPTION
The package name of api/v2/empty.go should be v2
Update MODEULE.bazel with 'bazel mod tidy'