### PR TITLE
simplify and improve error handling in api handler

### DIFF
--- a/go/api/handler/handler.go
+++ b/go/api/handler/handler.go
@@ -191,7 +191,7 @@ func (handler *apiHandler) Get(
 		}
 	}
 	// if the k8s client error is not "not found", return the error
-	if statusErr, ok := err.(*apiErrors.StatusError); !ok || statusErr.Status().Reason != metav1.StatusReasonNotFound {
+	if !apiErrors.IsNotFound(err) {
 		return surfaceGrpcError(err, "get", namespace, name)
 	}
 
@@ -242,14 +242,10 @@ func (handler *apiHandler) Update(ctx context.Context, obj ctrlRTClient.Object, 
 	})
 
 	// If the object does not exist in K8s/ETCD, update it in MetadataStorage directly.
-	if statusErr, ok := err.(*apiErrors.StatusError); ok {
-		if statusErr.Status().Reason == metav1.StatusReasonNotFound {
-			if storage.EnableMetadataStorage(&handler.conf) {
-				err = handleUpdate(ctx, tmpObj, handler.metadataStorage, true, nil, handler.blobStorage)
-				if err != nil {
-					return surfaceGrpcError(err, "update", tmpObj.GetNamespace(), tmpObj.GetName())
-				}
-			}
+	if apiErrors.IsNotFound(err) && storage.EnableMetadataStorage(&handler.conf) {
+		err = handleUpdate(ctx, tmpObj, handler.metadataStorage, true, nil, handler.blobStorage)
+		if err != nil {
+			return surfaceGrpcError(err, "update", tmpObj.GetNamespace(), tmpObj.GetName())
 		}
 	}
 
@@ -357,11 +353,9 @@ func (handler *apiHandler) Delete(ctx context.Context, obj ctrlRTClient.Object,
 	}
 
 	// If the object does not exist in K8s/ETCD, delete it in metadata storage.
-	if statusErr, ok := err.(*apiErrors.StatusError); ok {
-		if statusErr.Status().Reason == metav1.StatusReasonNotFound && handler.metadataStorage != nil {
-			log.Info("Object does not exist in ETCD - deleting from metadata storage")
-			return deleteObjectFromMetadataStorage(ctx, log, obj, handler)
-		}
+	if apiErrors.IsNotFound(err) && storage.EnableMetadataStorage(&handler.conf) {
+		log.Info("Object does not exist in ETCD - deleting from metadata storage")
+		return deleteObjectFromMetadataStorage(ctx, log, obj, handler)
 	}
 	return err
 }
@@ -528,17 +522,21 @@ func getCRTListOptions(namespace string, opts *metav1.ListOptions) (*ctrlRTClien
 }
 
 func surfaceGrpcError(err error, apiAction string, namespace string, name string) error {
-	if statusErr, ok := err.(*apiErrors.StatusError); ok {
-		grpcErrCode, found := api.K8sStatusReasonToGrpcError[statusErr.Status().Reason]
-		if found == false {
-			grpcErrCode = codes.Unknown
-		}
+	if err == nil {
+		return nil
+	}
+	errMsg := fmt.Sprintf("failed to %v API object. namespace: %v, name: %v", apiAction, namespace, name)
 
-		return status.Errorf(grpcErrCode, "failed to %v API object. namespace: %v, name: %v. %v",
-			apiAction, namespace, name, statusErr.Error())
+	// k8s errors
+	if _, ok := err.(apiErrors.APIStatus); ok {
+		return api.K8sError2GrpcError(err, errMsg)
 	}
 
-	return err
+	// other errors
+	// if err is a grpc status error, status.Convert() keeps the original error code
+	// otherwise, the error code is set to Unknown
+	s := status.Convert(err)
+	return status.Errorf(s.Code(), "%v: %v", errMsg, err)
 }
 
 func initLogger(ctx context.Context, log logr.Logger, action string, namespace string, name string,

--- a/go/api/handler/handler_test.go
+++ b/go/api/handler/handler_test.go
@@ -357,13 +357,15 @@ func TestK8sAndMetadataStorage(t *testing.T) {
 
 	// Get a non-existing job
 	getModeltmp := &v2pb.RayJob{}
-	nonexistentErr := errors.New("failed to get object. Namespace: default, Name: nonexistent")
+	nonexistentErr := status.Errorf(codes.NotFound, "RayJob namespace=nonexistent AND name=nonexistent not found")
 	mockMetadataStorage.EXPECT().
 		GetByName(gomock.Any(), "default", "nonexistent", gomock.Any()).
 		Return(nonexistentErr).Times(1)
 
 	err = handler.Get(context.Background(), "default", "nonexistent", nil, getModeltmp)
-	assert.Equal(t, nonexistentErr, err)
+	grpcStatus := status.Convert(err)
+	assert.Equal(t, codes.NotFound, grpcStatus.Code())
+	assert.ErrorContains(t, err, nonexistentErr.Error())
 
 	// When metadata storage is enabled, List() only returns objects from metadata storage and blob fields are not set
 	jobList := &v2pb.RayJobList{}


### PR DESCRIPTION
1. use IsNotFound() function to check k8s not found error
2. use K8sError2GrpcError() function to convert k8s error code to grpc error code
3. improve error messages for non-k8s errors in surfaceGrpcError