### PR TITLE
Dev Release of Michelangelo services

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,2 +1,5 @@
-pkg
+docker
 go/vendor
+pkg
+python
+tools

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+bazel-*
+pkg
+MODULE.bazel.lock

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,0 @@
-bazel-*
-pkg
-MODULE.bazel.lock

--- a/.envrc
+++ b/.envrc
@@ -34,6 +34,4 @@ if ! ./tools/assert_python_version.py $python_version; then
     exit 1
 fi
 
-if [ -f .envrc.local ] ; then
-    source_env .envrc.local
-fi
+source_env_if_exists .envrc.local

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -49,7 +49,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: [ controllermgr ] Extract Metadata
+      - name: controllermgr / Extract Metadata
         id: meta-controllermgr
         uses: docker/metadata-action@v5  # https://github.com/docker/metadata-action
         with:
@@ -61,7 +61,7 @@ jobs:
             type=ref,event=tag
             type=ref,prefix=pr-,event=pr
 
-      - name: [ worker ] Extract Metadata
+      - name: worker / Extract Metadata
         id: meta-worker
         uses: docker/metadata-action@v5  # https://github.com/docker/metadata-action
         with:
@@ -73,7 +73,7 @@ jobs:
             type=ref,event=tag
             type=ref,prefix=pr-,event=pr
 
-      - name: [ controllermgr ] Push Image
+      - name: controllermgr / Push Image
         id: push
         uses: docker/build-push-action@v6  # https://github.com/docker/build-push-action
         with:
@@ -87,7 +87,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
 
-      - name: [ worker ] Push Image
+      - name: worker / Push Image
         id: push
         uses: docker/build-push-action@v6  # https://github.com/docker/build-push-action
         with:

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -2,8 +2,6 @@ name: Dev Release
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches: [ main ]
   push:
     branches: [ main ]
 

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -33,7 +33,6 @@ jobs:
         id: push
         uses: docker/build-push-action@v6
         with:
-          context: .
           build-args: |
             BAZEL_TARGET=//go/cmd/controllermgr
             BINARY_PATH=bazel-bin/go/cmd/controllermgr/controllermgr_/controllermgr

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -4,12 +4,14 @@ on:
   workflow_dispatch:
   pull_request:
     branches: [ main ]
+  push:
+    branches: [ main ]
 
 env:
   REGISTRY: ghcr.io
 
 jobs:
-  push-containers:
+  push-service-container-images:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -17,21 +19,28 @@ jobs:
       attestations: write
       id-token: write
     steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4  # https://github.com/actions/checkout
 
       - name: Cache Bazel Outputs
-        uses: actions/cache@v4
+        uses: actions/cache@v4  # https://github.com/actions/cache
         with:
           path: ~/.cache/bazel
           key: bazel_cache_root
           restore-keys: bazel_cache_root
 
-      - name: Build controllermgr
+      - name: Build Services
         run: |
           ./tools/bazel build //go/cmd/controllermgr
           cp bazel-bin/go/cmd/controllermgr/controllermgr_/controllermgr controllermgr
+          ./tools/bazel build //go/cmd/worker
+          cp bazel-bin/go/cmd/worker/worker_/worker worker
 
       - name: Login to Container Registry
         uses: docker/login-action@v3
@@ -40,8 +49,8 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract Metadata
-        id: meta
+      - name: [ controllermgr ] Extract Metadata
+        id: meta-controllermgr
         uses: docker/metadata-action@v5  # https://github.com/docker/metadata-action
         with:
           images: ${{ env.REGISTRY }}/michelangelo-ai/controllermgr
@@ -52,22 +61,42 @@ jobs:
             type=ref,event=tag
             type=ref,prefix=pr-,event=pr
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - name: [ worker ] Extract Metadata
+        id: meta-worker
+        uses: docker/metadata-action@v5  # https://github.com/docker/metadata-action
+        with:
+          images: ${{ env.REGISTRY }}/michelangelo-ai/worker
+          tags: |
+            type=schedule,pattern={{date 'YYYYMMDD-hhmmss' tz='UTC'}}
+            type=sha
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,prefix=pr-,event=pr
 
-      - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and Push
+      - name: [ controllermgr ] Push Image
         id: push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v6  # https://github.com/docker/build-push-action
         with:
           context: .
           file: docker/service.Dockerfile
           build-args: |
             BINARY_PATH=controllermgr
             CONFIG_PATH=go/cmd/controllermgr/config
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta-controllermgr.outputs.tags }}
+          labels: ${{ steps.meta-controllermgr.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+
+      - name: [ worker ] Push Image
+        id: push
+        uses: docker/build-push-action@v6  # https://github.com/docker/build-push-action
+        with:
+          context: .
+          file: docker/service.Dockerfile
+          build-args: |
+            BINARY_PATH=worker
+            CONFIG_PATH=go/cmd/worker/config
+          tags: ${{ steps.meta-worker.outputs.tags }}
+          labels: ${{ steps.meta-worker.outputs.labels }}
           platforms: linux/amd64,linux/arm64
           push: true

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
+#  pull_request:
+#    branches: [ main ]
 
 env:
   REGISTRY: ghcr.io
@@ -14,7 +14,7 @@ jobs:
   push-service-container-images:
     runs-on: ubuntu-24.04
     strategy:
-      max-parallel: 1
+      # max-parallel: 1
       matrix:
         service: [controllermgr, worker]
 

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -1,0 +1,43 @@
+name: Dev Release
+
+on:
+  workflow_dispatch: # Manually triggered with the new workflow_dispatch event
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  dev-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract Metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/michelangelo-ai/controllermgr
+          tags: |
+            type=schedule
+            type=sha
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and Push
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          build-args: |
+            BAZEL_TARGET=//go/cmd/controllermgr
+            BINARY_PATH=bazel-bin/go/cmd/controllermgr/controllermgr_/controllermgr
+            CONFIG_PATH=go/cmd/controllermgr/config
+          file: docker/service.Dockerfile
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -3,13 +3,18 @@ name: Dev Release
 on:
   workflow_dispatch: # Manually triggered with the new workflow_dispatch event
   pull_request:
-    branches: [main]
+    branches: [ main ]
 env:
   REGISTRY: ghcr.io
 
 jobs:
   dev-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
     steps:
       - name: Login to GHCR
         uses: docker/login-action@v3

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -38,6 +38,6 @@ jobs:
             BINARY_PATH=bazel-bin/go/cmd/controllermgr/controllermgr_/controllermgr
             CONFIG_PATH=go/cmd/controllermgr/config
           file: docker/service.Dockerfile
-          push: false
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 env:
   REGISTRY: ghcr.io
@@ -11,11 +13,17 @@ env:
 jobs:
   push-service-container-images:
     runs-on: ubuntu-24.04
+    strategy:
+      max-parallel: 1
+      matrix:
+        service: [controllermgr, worker]
+
     permissions:
       contents: read
       packages: write
       attestations: write
       id-token: write
+
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -33,12 +41,10 @@ jobs:
           key: bazel_cache_root
           restore-keys: bazel_cache_root
 
-      - name: Build Services
+      - name: ${{ matrix.service }} / Build  Binary
         run: |
-          ./tools/bazel build //go/cmd/controllermgr
-          cp bazel-bin/go/cmd/controllermgr/controllermgr_/controllermgr controllermgr
-          ./tools/bazel build //go/cmd/worker
-          cp bazel-bin/go/cmd/worker/worker_/worker worker
+          ./tools/bazel build //go/cmd/${{ matrix.service }}
+          cp bazel-bin/go/cmd/${{ matrix.service }}/${{ matrix.service }}_/${{ matrix.service }} ${{ matrix.service }}
 
       - name: Login to Container Registry
         uses: docker/login-action@v3
@@ -47,11 +53,11 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: controllermgr / Extract Metadata
-        id: meta-controllermgr
-        uses: docker/metadata-action@v5  # https://github.com/docker/metadata-action
+      - name: ${{ matrix.service }} / Extract Docker Metadata
+        id: meta
+        uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/michelangelo-ai/controllermgr
+          images: ${{ env.REGISTRY }}/michelangelo-ai/${{ matrix.service }}
           tags: |
             type=schedule,pattern={{date 'YYYYMMDD-hhmmss' tz='UTC'}}
             type=sha
@@ -59,42 +65,15 @@ jobs:
             type=ref,event=tag
             type=ref,prefix=pr-,event=pr
 
-      - name: worker / Extract Metadata
-        id: meta-worker
-        uses: docker/metadata-action@v5  # https://github.com/docker/metadata-action
-        with:
-          images: ${{ env.REGISTRY }}/michelangelo-ai/worker
-          tags: |
-            type=schedule,pattern={{date 'YYYYMMDD-hhmmss' tz='UTC'}}
-            type=sha
-            type=ref,event=branch
-            type=ref,event=tag
-            type=ref,prefix=pr-,event=pr
-
-      - name: controllermgr / Push Image
-        id: push-controllermgr
-        uses: docker/build-push-action@v6  # https://github.com/docker/build-push-action
+      - name: ${{ matrix.service }} / Build & Push Image
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/service.Dockerfile
           build-args: |
-            BINARY_PATH=controllermgr
-            CONFIG_PATH=go/cmd/controllermgr/config
-          tags: ${{ steps.meta-controllermgr.outputs.tags }}
-          labels: ${{ steps.meta-controllermgr.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-          push: true
-
-      - name: worker / Push Image
-        id: push-worker
-        uses: docker/build-push-action@v6  # https://github.com/docker/build-push-action
-        with:
-          context: .
-          file: docker/service.Dockerfile
-          build-args: |
-            BINARY_PATH=worker
-            CONFIG_PATH=go/cmd/worker/config
-          tags: ${{ steps.meta-worker.outputs.tags }}
-          labels: ${{ steps.meta-worker.outputs.labels }}
+            BINARY_PATH=${{ matrix.service }}
+            CONFIG_PATH=go/cmd/${{ matrix.service }}/config
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
           push: true

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -2,7 +2,8 @@ name: Dev Release
 
 on:
   workflow_dispatch: # Manually triggered with the new workflow_dispatch event
-
+  pull_request:
+    branches: [main]
 env:
   REGISTRY: ghcr.io
 

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -29,7 +29,9 @@ jobs:
           restore-keys: bazel_cache_root
 
       - name: Build controllermgr
-        run: ./tools/bazel build //go/cmd/controllermgr
+        run: |
+          ./tools/bazel build //go/cmd/controllermgr
+          cp bazel-bin/go/cmd/controllermgr/controllermgr_/controllermgr controllermgr
 
       - name: Login to Container Registry
         uses: docker/login-action@v3
@@ -56,19 +58,14 @@ jobs:
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Verify the binary exists
-        run: |
-          pwd
-          ls -la bazel-bin/go/cmd/controllermgr/controllermgr_/controllermgr
-
       - name: Build and Push
         id: push
         uses: docker/build-push-action@v6
         with:
-          context: /home/runner/work/michelangelo/michelangelo
+          context: .
           file: docker/service.Dockerfile
           build-args: |
-            BINARY_PATH=bazel-bin/go/cmd/controllermgr/controllermgr_/controllermgr
+            BINARY_PATH=controllermgr
             CONFIG_PATH=go/cmd/controllermgr/config
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -4,45 +4,69 @@ on:
   workflow_dispatch: # Manually triggered with the new workflow_dispatch event
   pull_request:
     branches: [ main ]
+
 env:
   REGISTRY: ghcr.io
 
 jobs:
-  dev-release:
-    runs-on: ubuntu-latest
+  push-containers:
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write
       attestations: write
       id-token: write
     steps:
-      - name: Login to GHCR
+
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Cache Bazel Outputs
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/bazel
+          key: bazel_cache_root
+          restore-keys: |
+            bazel_cache_root
+
+      - name: Build controllermgr
+        run: ./tools/bazel build //go/cmd/controllermgr
+
+      - name: Login to Container Registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Extract Metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/michelangelo-ai/controllermgr
           tags: |
-            type=schedule
+            type=schedule,pattern={{date 'YYYYMMDD-hhmmss' tz='UTC'}}
             type=sha
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,prefix=pr-,event=pr
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Build and Push
         id: push
         uses: docker/build-push-action@v6
         with:
+          context: .
+          file: docker/service.Dockerfile
           build-args: |
-            BAZEL_TARGET=//go/cmd/controllermgr
             BINARY_PATH=bazel-bin/go/cmd/controllermgr/controllermgr_/controllermgr
             CONFIG_PATH=go/cmd/controllermgr/config
-          file: docker/service.Dockerfile
-          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          push: true

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -3,7 +3,7 @@ name: Dev Release
 on:
   workflow_dispatch:
   pull_request:
-    branches: [main]
+    branches: [ main ]
 
 env:
   REGISTRY: ghcr.io
@@ -31,9 +31,6 @@ jobs:
       - name: Build controllermgr
         run: ./tools/bazel build //go/cmd/controllermgr
 
-      - name: Verify the binary exists
-        run: ls -la ./bazel-bin/go/cmd/controllermgr/controllermgr_/controllermgr
-
       - name: Login to Container Registry
         uses: docker/login-action@v3
         with:
@@ -43,7 +40,7 @@ jobs:
 
       - name: Extract Metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v5  # https://github.com/docker/metadata-action
         with:
           images: ${{ env.REGISTRY }}/michelangelo-ai/controllermgr
           tags: |
@@ -59,6 +56,11 @@ jobs:
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Verify the binary exists
+        run: |
+          pwd
+          ls -la bazel-bin/go/cmd/controllermgr/controllermgr_/controllermgr
+
       - name: Build and Push
         id: push
         uses: docker/build-push-action@v6
@@ -66,8 +68,8 @@ jobs:
           context: .
           file: docker/service.Dockerfile
           build-args: |
-            BINARY_PATH=./bazel-bin/go/cmd/controllermgr/controllermgr_/controllermgr
-            CONFIG_PATH=./go/cmd/controllermgr/config
+            BINARY_PATH=bazel-bin/go/cmd/controllermgr/controllermgr_/controllermgr
+            CONFIG_PATH=go/cmd/controllermgr/config
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -69,4 +69,5 @@ jobs:
             CONFIG_PATH=go/cmd/controllermgr/config
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
           push: true

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -74,7 +74,7 @@ jobs:
             type=ref,prefix=pr-,event=pr
 
       - name: controllermgr / Push Image
-        id: push
+        id: push-controllermgr
         uses: docker/build-push-action@v6  # https://github.com/docker/build-push-action
         with:
           context: .
@@ -88,7 +88,7 @@ jobs:
           push: true
 
       - name: worker / Push Image
-        id: push
+        id: push-worker
         uses: docker/build-push-action@v6  # https://github.com/docker/build-push-action
         with:
           context: .

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -1,9 +1,9 @@
 name: Dev Release
 
 on:
-  workflow_dispatch: # Manually triggered with the new workflow_dispatch event
+  workflow_dispatch:
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 env:
   REGISTRY: ghcr.io
@@ -24,14 +24,15 @@ jobs:
       - name: Cache Bazel Outputs
         uses: actions/cache@v4
         with:
-          path: |
-            ~/.cache/bazel
+          path: ~/.cache/bazel
           key: bazel_cache_root
-          restore-keys: |
-            bazel_cache_root
+          restore-keys: bazel_cache_root
 
       - name: Build controllermgr
         run: ./tools/bazel build //go/cmd/controllermgr
+
+      - name: Verify the binary exists
+        run: ls -la ./bazel-bin/go/cmd/controllermgr/controllermgr_/controllermgr
 
       - name: Login to Container Registry
         uses: docker/login-action@v3
@@ -65,8 +66,8 @@ jobs:
           context: .
           file: docker/service.Dockerfile
           build-args: |
-            BINARY_PATH=bazel-bin/go/cmd/controllermgr/controllermgr_/controllermgr
-            CONFIG_PATH=go/cmd/controllermgr/config
+            BINARY_PATH=./bazel-bin/go/cmd/controllermgr/controllermgr_/controllermgr
+            CONFIG_PATH=./go/cmd/controllermgr/config
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -65,7 +65,7 @@ jobs:
         id: push
         uses: docker/build-push-action@v6
         with:
-          context: .
+          context: "{{defaultContext}}"
           file: docker/service.Dockerfile
           build-args: |
             BINARY_PATH=bazel-bin/go/cmd/controllermgr/controllermgr_/controllermgr

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -65,7 +65,7 @@ jobs:
         id: push
         uses: docker/build-push-action@v6
         with:
-          context: "{{defaultContext}}"
+          context: /home/runner/work/michelangelo/michelangelo
           file: docker/service.Dockerfile
           build-args: |
             BINARY_PATH=bazel-bin/go/cmd/controllermgr/controllermgr_/controllermgr

--- a/.gitignore
+++ b/.gitignore
@@ -278,3 +278,5 @@ MODULE.bazel.lock
 .idea
 # ignore go vendor directory
 /go/vendor
+
+.envrc.local

--- a/docker/service.Dockerfile
+++ b/docker/service.Dockerfile
@@ -1,0 +1,46 @@
+# Dockerfile for Michelangelo services.
+#
+# Build Examples:
+#   Build an image for the controllermgr service:
+#   docker build -t michelangelo-controllermgr -f docker/service.Dockerfile --build-arg BAZEL_TARGET=//go/cmd/controllermgr --build-arg BINARY_PATH=bazel-bin/go/cmd/controllermgr/controllermgr_/controllermgr --build-arg CONFIG_PATH=go/cmd/controllermgr/config .
+#
+#   Build an image for the worker service:
+#   docker build -t michelangelo-worker -f docker/service.Dockerfile --build-arg BAZEL_TARGET=//go/cmd/worker --build-arg BINARY_PATH=bazel-bin/go/cmd/worker/worker_/worker --build-arg CONFIG_PATH=go/cmd/worker/config .
+FROM debian:12-slim AS build
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    direnv \
+    python3 \
+    ca-certificates \
+    build-essential \
+    curl \
+    unzip \
+    sudo \
+    && rm -rf /var/lib/apt/lists/*
+
+# Bazel target that builds a service into a binary executable.
+# Ex: //go/cmd/controllermgr:controllermgr
+ARG BAZEL_TARGET
+
+WORKDIR /repo
+COPY . .
+
+RUN ./tools/bazel build $BAZEL_TARGET
+
+# Distroless: https://github.com/GoogleContainerTools/distroless
+FROM gcr.io/distroless/static-debian12
+
+# Path to the service binary built by the BAZEL_TARGET.
+# The path must be relative to the repository root.
+# Ex: go/cmd/controllermgr/controllermgr_/controllermgr
+ARG BINARY_PATH
+
+# Path to the service config directory.
+# The path must be relative to the repository root.
+# Ex: bazel-bin/go/cmd/controllermgr/config
+ARG CONFIG_PATH
+
+COPY --from=build /repo/$BINARY_PATH /app
+COPY --from=build /repo/$CONFIG_PATH /config
+
+ENTRYPOINT ["/app"]

--- a/docker/service.Dockerfile
+++ b/docker/service.Dockerfile
@@ -1,31 +1,4 @@
 # Dockerfile for Michelangelo services.
-#
-# Build Examples:
-#   Build an image for the controllermgr service:
-#   docker build -t michelangelo-controllermgr -f docker/service.Dockerfile --build-arg BAZEL_TARGET=//go/cmd/controllermgr --build-arg BINARY_PATH=bazel-bin/go/cmd/controllermgr/controllermgr_/controllermgr --build-arg CONFIG_PATH=go/cmd/controllermgr/config .
-#
-#   Build an image for the worker service:
-#   docker build -t michelangelo-worker -f docker/service.Dockerfile --build-arg BAZEL_TARGET=//go/cmd/worker --build-arg BINARY_PATH=bazel-bin/go/cmd/worker/worker_/worker --build-arg CONFIG_PATH=go/cmd/worker/config .
-FROM debian:12-slim AS build
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    direnv \
-    python3 \
-    ca-certificates \
-    build-essential \
-    curl \
-    unzip \
-    sudo \
-    && rm -rf /var/lib/apt/lists/*
-
-# Bazel target that builds a service into a binary executable.
-# Ex: //go/cmd/controllermgr:controllermgr
-ARG BAZEL_TARGET
-
-WORKDIR /repo
-COPY . .
-
-RUN ./tools/bazel build $BAZEL_TARGET
 
 # Distroless: https://github.com/GoogleContainerTools/distroless
 FROM gcr.io/distroless/static-debian12
@@ -40,7 +13,7 @@ ARG BINARY_PATH
 # Ex: bazel-bin/go/cmd/controllermgr/config
 ARG CONFIG_PATH
 
-COPY --from=build /repo/$BINARY_PATH /app
-COPY --from=build /repo/$CONFIG_PATH /config
+COPY $BINARY_PATH /app
+COPY $CONFIG_PATH /config
 
 ENTRYPOINT ["/app"]

--- a/go/cmd/controllermgr/BUILD.bazel
+++ b/go/cmd/controllermgr/BUILD.bazel
@@ -31,6 +31,14 @@ go_binary(
     env = {
         "CONFIG_DIR": "$(location :config)",
     },
+    gc_linkopts = [
+        # The following GC options instruct Bazel to build a static binary for running the service in a static
+        # Distroless container. https://github.com/GoogleContainerTools/distroless
+        "-linkmode",
+        "external",
+        "-extldflags",
+        "-static",
+    ],
     visibility = ["//visibility:public"],
 )
 

--- a/go/cmd/worker/BUILD.bazel
+++ b/go/cmd/worker/BUILD.bazel
@@ -22,5 +22,13 @@ go_binary(
     env = {
         "CONFIG_DIR": "$(location :config)",
     },
+    gc_linkopts = [
+        # The following GC options instruct Bazel to build a static binary for running the service in a static
+        # Distroless container. https://github.com/GoogleContainerTools/distroless
+        "-linkmode",
+        "external",
+        "-extldflags",
+        "-static",
+    ],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
- Added reusable Dockerfile for all Michelangelo services, e.g., controllermgr, api, worker, etc.
- Added GitHub workflow responsible for building container images of Michelangelo services and pushing them to the [Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) in org's packages: https://github.com/orgs/michelangelo-ai/packages