### PR TITLE
only do static link on Linux

### DIFF
--- a/go/cmd/controllermgr/BUILD.bazel
+++ b/go/cmd/controllermgr/BUILD.bazel
@@ -31,14 +31,17 @@ go_binary(
     env = {
         "CONFIG_DIR": "$(location :config)",
     },
-    gc_linkopts = [
-        # The following GC options instruct Bazel to build a static binary for running the service in a static
-        # Distroless container. https://github.com/GoogleContainerTools/distroless
-        "-linkmode",
-        "external",
-        "-extldflags",
-        "-static",
-    ],
+    gc_linkopts = select({
+        "@io_bazel_rules_go//go/platform:linux": [
+            # The following GC options instruct Bazel to build a static binary for running the service in a static
+            # Distroless container. https://github.com/GoogleContainerTools/distroless
+            "-linkmode",
+            "external",
+            "-extldflags",
+            "-static",
+        ],
+        "//conditions:default": [],
+    }),
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
Mac doesn't support full static link. The "-static" flag causes build failures on Mac.

As the static link is only needed for the distroless docker images in Linux, we don't need these link options on other platforms