### PR TITLE
Add unmarshalJson method to all proto generated go code

### DIFF
--- a/go/cmd/kubeproto/protoc-gen-kubeproto/main.go
+++ b/go/cmd/kubeproto/protoc-gen-kubeproto/main.go
@@ -313,7 +313,7 @@ func updateGoFile(gofile *plugingo.CodeGeneratorResponse_File, protofile *protog
 							genImmutability(typeName, &crdFunctionsBuf, options)
 							genCRDObject(typeName, gInfo, &crdFunctionsBuf)
 							genCRDBlobFields(typeName, protoMsg, &crdFunctionsBuf, extTypes)
-							genCRDEnumFields(typeName, protoMsg, &crdFunctionsBuf, extTypes, processedGoPackageList)
+							genCRDEnumTypeFields(typeName, protoMsg, &crdFunctionsBuf, extTypes, processedGoPackageList)
 							crdFunctionsBuf.Write([]byte("func init() {\n\tYamlSchemas[\"" + typeName + "\"] = `"))
 							yamlStr := string(yaml.GenerateCRDYaml(protofile, extTypes, *gInfo))
 							crdFunctionsBuf.Write([]byte(strings.Replace(yamlStr, "`", "`+\"`\"+`", -1)))
@@ -489,11 +489,11 @@ func generate(reqData []byte) *plugingo.CodeGeneratorResponse {
 	return resp
 }
 
-// findEnumFields recursively finds all enum fields within a given protobuf message and its nested messages.
+// findEnumTypeFields recursively finds all enum fields within a given protobuf message and its nested messages.
 //
 // This function:
 // - Traverses through all fields of the given message (`curMsg`).
-// - Identifies enum fields and adds them to `enumFields`, ensuring they are not duplicated.
+// - Identifies enum fields and adds them to `enumTypeFields`, ensuring they are not duplicated.
 // - Recursively processes nested messages to extract enum fields from them as well.
 // - Maintains a record of processed message types and Go package imports to avoid redundant processing.
 //
@@ -501,11 +501,11 @@ func generate(reqData []byte) *plugingo.CodeGeneratorResponse {
 //
 //	curMsg                 *protogen.Message     - The current protobuf message being analyzed.
 //	pathPrefix             string               - The prefix representing the field hierarchy (used for recursion).
-//	enumFields             *[]string            - A list to store discovered enum field names.
+//	enumTypeFields             *[]string            - A list to store discovered enum type names.
 //	processedMessageTypes  *map[protogen.GoIdent]bool - Tracks already processed message types to prevent cycles.
 //	extTypes               *protoregistry.Types - A registry of external types (not used in this function but may be useful for extensions).
 //	processedGoPackageList *map[string]bool     - A map to track processed Go packages and prevent duplicate enum field entries.
-func findEnumFields(curMsg *protogen.Message, pathPrefix string, enumFields *[]string,
+func findEnumTypeFields(curMsg *protogen.Message, pathPrefix string, enumTypeFields *[]string,
 	processedMessageTypes *map[protogen.GoIdent]bool, extTypes *protoregistry.Types, processedGoPackageList *map[string]bool) {
 	for _, field := range curMsg.Fields {
 		// Check if this field is an enum
@@ -514,14 +514,14 @@ func findEnumFields(curMsg *protogen.Message, pathPrefix string, enumFields *[]s
 			if _, found := (*processedGoPackageList)[key]; !found {
 				(*processedGoPackageList)[key] = true
 				newPrefix := strings.Trim(field.Enum.GoIdent.GoName, ".")
-				*enumFields = append(*enumFields, newPrefix)
+				*enumTypeFields = append(*enumTypeFields, newPrefix)
 			}
 		}
 		// Continue processing nested messages
 		if field.Message != nil && field.Message.GoIdent.GoImportPath == curMsg.GoIdent.GoImportPath {
 			if _, found := (*processedMessageTypes)[field.Message.GoIdent]; !found {
 				(*processedMessageTypes)[field.Message.GoIdent] = true
-				findEnumFields(field.Message, pathPrefix+"."+field.GoName, enumFields, processedMessageTypes,
+				findEnumTypeFields(field.Message, pathPrefix+"."+field.GoName, enumTypeFields, processedMessageTypes,
 					extTypes, processedGoPackageList)
 				delete(*processedMessageTypes, field.Message.GoIdent)
 			}
@@ -529,11 +529,11 @@ func findEnumFields(curMsg *protogen.Message, pathPrefix string, enumFields *[]s
 	}
 }
 
-// genCRDEnumFields generates UnmarshalJSON methods for all enum fields in a given CRD (Custom Resource Definition) message.
+// genCRDEnumTypeFields generates UnmarshalJSON methods for all enum fields in a given CRD (Custom Resource Definition) message.
 //
 // This function:
 // - Identifies all enum fields within the provided CRD protobuf message (`crdMsg`).
-// - Uses `findEnumFields` to traverse nested messages and collect enum field names.
+// - Uses `findEnumTypeFields` to traverse nested messages and collect enum field names.
 // - Iterates through the discovered enum fields and generates UnmarshalJSON methods using a template.
 // - Writes the generated code to the provided buffer (`crdBuf`).
 //
@@ -544,16 +544,16 @@ func findEnumFields(curMsg *protogen.Message, pathPrefix string, enumFields *[]s
 //	crdBuf                 *bytes.Buffer            - The buffer to write the generated code to.
 //	extTypes               *protoregistry.Types     - A registry of external types (may be useful for future extensions).
 //	processedGoPackageList *map[string]bool         - A map to track processed Go packages to avoid redundant processing.
-func genCRDEnumFields(crdName string, crdMsg *protogen.Message, crdBuf *bytes.Buffer, extTypes *protoregistry.Types,
+func genCRDEnumTypeFields(crdName string, crdMsg *protogen.Message, crdBuf *bytes.Buffer, extTypes *protoregistry.Types,
 	processedGoPackageList *map[string]bool,
 ) {
 	processedMessageTypes := make(map[protogen.GoIdent]bool)
-	enumFields := make([]string, 0)
+	enumTypeFields := make([]string, 0)
 	// Find all enum fields in the CRD message
-	findEnumFields(crdMsg, "", &enumFields, &processedMessageTypes, extTypes, processedGoPackageList)
+	findEnumTypeFields(crdMsg, "", &enumTypeFields, &processedMessageTypes, extTypes, processedGoPackageList)
 
 	// Generate UnmarshalJSON methods for each enum field
-	for _, enumTypeName := range enumFields {
+	for _, enumTypeName := range enumTypeFields {
 		typeInfo := struct {
 			EnumTypeName string
 		}{

--- a/go/cmd/kubeproto/protoc-gen-kubeproto/main.go
+++ b/go/cmd/kubeproto/protoc-gen-kubeproto/main.go
@@ -314,12 +314,12 @@ func updateGoFile(gofile *plugingo.CodeGeneratorResponse_File, protofile *protog
 							genCRDObject(typeName, gInfo, &crdFunctionsBuf)
 							genCRDBlobFields(typeName, protoMsg, &crdFunctionsBuf, extTypes)
 							genCRDEnumFields(typeName, protoMsg, &crdFunctionsBuf, extTypes, processedGoPackageList)
+							crdFunctionsBuf.Write([]byte("func init() {\n\tYamlSchemas[\"" + typeName + "\"] = `"))
+							yamlStr := string(yaml.GenerateCRDYaml(protofile, extTypes, *gInfo))
+							crdFunctionsBuf.Write([]byte(strings.Replace(yamlStr, "`", "`+\"`\"+`", -1)))
+							crdFunctionsBuf.Write([]byte("`\n"))
+							crdFunctionsBuf.Write([]byte("}"))
 						}
-						crdFunctionsBuf.Write([]byte("func init() {\n\tYamlSchemas[\"" + typeName + "\"] = `"))
-						yamlStr := string(yaml.GenerateCRDYaml(protofile, extTypes, *gInfo))
-						crdFunctionsBuf.Write([]byte(strings.Replace(yamlStr, "`", "`+\"`\"+`", -1)))
-						crdFunctionsBuf.Write([]byte("`\n"))
-						crdFunctionsBuf.Write([]byte("}"))
 					}
 				}
 			}

--- a/go/cmd/kubeproto/protoc-gen-kubeproto/main.go
+++ b/go/cmd/kubeproto/protoc-gen-kubeproto/main.go
@@ -483,6 +483,21 @@ func generate(reqData []byte) *plugingo.CodeGeneratorResponse {
 	return resp
 }
 
+// findEnumFields recursively finds all enum fields within a given protobuf message and its nested messages.
+//
+// This function:
+// - Traverses through all fields of the given message (`curMsg`).
+// - Identifies enum fields and adds them to `enumFields`, ensuring they are not duplicated.
+// - Recursively processes nested messages to extract enum fields from them as well.
+// - Maintains a record of processed message types and Go package imports to avoid redundant processing.
+//
+// Args:
+//   curMsg                 *protogen.Message     - The current protobuf message being analyzed.
+//   pathPrefix             string               - The prefix representing the field hierarchy (used for recursion).
+//   enumFields             *[]string            - A list to store discovered enum field names.
+//   processedMessageTypes  *map[protogen.GoIdent]bool - Tracks already processed message types to prevent cycles.
+//   extTypes               *protoregistry.Types - A registry of external types (not used in this function but may be useful for extensions).
+//   processedGoPackageList *map[string]bool     - A map to track processed Go packages and prevent duplicate enum field entries.
 func findEnumFields(curMsg *protogen.Message, pathPrefix string, enumFields *[]string,
 	processedMessageTypes *map[protogen.GoIdent]bool, extTypes *protoregistry.Types, processedGoPackageList *map[string]bool) {
 	for _, field := range curMsg.Fields {

--- a/go/cmd/kubeproto/protoc-gen-kubeproto/main.go
+++ b/go/cmd/kubeproto/protoc-gen-kubeproto/main.go
@@ -11,6 +11,12 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/michelangelo-ai/michelangelo/go/kubeproto/pboptions"
+	"github.com/michelangelo-ai/michelangelo/go/kubeproto/tags"
+	"github.com/michelangelo-ai/michelangelo/go/kubeproto/templates"
+	"github.com/michelangelo-ai/michelangelo/go/kubeproto/util"
+	"github.com/michelangelo-ai/michelangelo/go/kubeproto/yaml"
+
 	"github.com/dave/dst"
 	"github.com/dave/dst/decorator"
 	"github.com/gogo/protobuf/proto"
@@ -18,11 +24,6 @@ import (
 	plugingo "github.com/gogo/protobuf/protoc-gen-gogo/plugin"
 	"github.com/gogo/protobuf/vanity"
 	"github.com/gogo/protobuf/vanity/command"
-	"github.com/michelangelo-ai/michelangelo/go/kubeproto/pboptions"
-	"github.com/michelangelo-ai/michelangelo/go/kubeproto/tags"
-	"github.com/michelangelo-ai/michelangelo/go/kubeproto/templates"
-	"github.com/michelangelo-ai/michelangelo/go/kubeproto/util"
-	"github.com/michelangelo-ai/michelangelo/go/kubeproto/yaml"
 	"google.golang.org/protobuf/compiler/protogen"
 	golangproto "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoregistry"
@@ -37,6 +38,11 @@ var snakeCaseSeparators = regexp.MustCompile("-\\.")
 var logger = log.New(os.Stderr, "", 0)
 
 const _testProtoImportPath = "michelangelo/tools/kubeproto/unittest/pb"
+
+type EnumValue struct {
+	Name        string // Enum value as a string (e.g., "Pending")
+	GoEnumValue string // Fully qualified Go enum value (e.g., "MyEnum_PENDING")
+}
 
 // Call gogo proto to generate go code from protobuf
 // The options are chosen to make the generated go code to be compatible
@@ -492,12 +498,13 @@ func generate(reqData []byte) *plugingo.CodeGeneratorResponse {
 // - Maintains a record of processed message types and Go package imports to avoid redundant processing.
 //
 // Args:
-//   curMsg                 *protogen.Message     - The current protobuf message being analyzed.
-//   pathPrefix             string               - The prefix representing the field hierarchy (used for recursion).
-//   enumFields             *[]string            - A list to store discovered enum field names.
-//   processedMessageTypes  *map[protogen.GoIdent]bool - Tracks already processed message types to prevent cycles.
-//   extTypes               *protoregistry.Types - A registry of external types (not used in this function but may be useful for extensions).
-//   processedGoPackageList *map[string]bool     - A map to track processed Go packages and prevent duplicate enum field entries.
+//
+//	curMsg                 *protogen.Message     - The current protobuf message being analyzed.
+//	pathPrefix             string               - The prefix representing the field hierarchy (used for recursion).
+//	enumFields             *[]string            - A list to store discovered enum field names.
+//	processedMessageTypes  *map[protogen.GoIdent]bool - Tracks already processed message types to prevent cycles.
+//	extTypes               *protoregistry.Types - A registry of external types (not used in this function but may be useful for extensions).
+//	processedGoPackageList *map[string]bool     - A map to track processed Go packages and prevent duplicate enum field entries.
 func findEnumFields(curMsg *protogen.Message, pathPrefix string, enumFields *[]string,
 	processedMessageTypes *map[protogen.GoIdent]bool, extTypes *protoregistry.Types, processedGoPackageList *map[string]bool) {
 	for _, field := range curMsg.Fields {
@@ -522,11 +529,6 @@ func findEnumFields(curMsg *protogen.Message, pathPrefix string, enumFields *[]s
 	}
 }
 
-type EnumValue struct {
-	Name        string // Enum value as a string (e.g., "Pending")
-	GoEnumValue string // Fully qualified Go enum value (e.g., "MyEnum_PENDING")
-}
-
 // genCRDEnumFields generates UnmarshalJSON methods for all enum fields in a given CRD (Custom Resource Definition) message.
 //
 // This function:
@@ -536,11 +538,12 @@ type EnumValue struct {
 // - Writes the generated code to the provided buffer (`crdBuf`).
 //
 // Args:
-//   crdName                string                    - The name of the CRD being processed.
-//   crdMsg                 *protogen.Message         - The protobuf message representing the CRD.
-//   crdBuf                 *bytes.Buffer            - The buffer to write the generated code to.
-//   extTypes               *protoregistry.Types     - A registry of external types (may be useful for future extensions).
-//   processedGoPackageList *map[string]bool         - A map to track processed Go packages to avoid redundant processing.
+//
+//	crdName                string                    - The name of the CRD being processed.
+//	crdMsg                 *protogen.Message         - The protobuf message representing the CRD.
+//	crdBuf                 *bytes.Buffer            - The buffer to write the generated code to.
+//	extTypes               *protoregistry.Types     - A registry of external types (may be useful for future extensions).
+//	processedGoPackageList *map[string]bool         - A map to track processed Go packages to avoid redundant processing.
 func genCRDEnumFields(crdName string, crdMsg *protogen.Message, crdBuf *bytes.Buffer, extTypes *protoregistry.Types,
 	processedGoPackageList *map[string]bool,
 ) {

--- a/go/cmd/kubeproto/protoc-gen-kubeproto/main.go
+++ b/go/cmd/kubeproto/protoc-gen-kubeproto/main.go
@@ -11,12 +11,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/michelangelo-ai/michelangelo/go/kubeproto/pboptions"
-	"github.com/michelangelo-ai/michelangelo/go/kubeproto/tags"
-	"github.com/michelangelo-ai/michelangelo/go/kubeproto/templates"
-	"github.com/michelangelo-ai/michelangelo/go/kubeproto/util"
-	"github.com/michelangelo-ai/michelangelo/go/kubeproto/yaml"
-
 	"github.com/dave/dst"
 	"github.com/dave/dst/decorator"
 	"github.com/gogo/protobuf/proto"
@@ -24,6 +18,11 @@ import (
 	plugingo "github.com/gogo/protobuf/protoc-gen-gogo/plugin"
 	"github.com/gogo/protobuf/vanity"
 	"github.com/gogo/protobuf/vanity/command"
+	"github.com/michelangelo-ai/michelangelo/go/kubeproto/pboptions"
+	"github.com/michelangelo-ai/michelangelo/go/kubeproto/tags"
+	"github.com/michelangelo-ai/michelangelo/go/kubeproto/templates"
+	"github.com/michelangelo-ai/michelangelo/go/kubeproto/util"
+	"github.com/michelangelo-ai/michelangelo/go/kubeproto/yaml"
 	"google.golang.org/protobuf/compiler/protogen"
 	golangproto "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoregistry"
@@ -203,7 +202,7 @@ func genCRD(crdBuf *bytes.Buffer, filename string, name string, protoComments *p
 //     generate deep copy functions, add controller-tools markers, and register the type to k8s runtime scheme
 //  5. If the input file contains michelangelo.api.k8s_api_group_name option, generate group-version info for k8s runtime
 func updateGoFile(gofile *plugingo.CodeGeneratorResponse_File, protofile *protogen.File,
-	extTypes *protoregistry.Types, gInfo *yaml.GroupInfo) {
+	extTypes *protoregistry.Types, gInfo *yaml.GroupInfo, processedGoPackageList *map[string]bool) {
 	dstFile, err := decorator.Parse(*gofile.Content)
 	if err != nil {
 		logger.Panicf("failed to parse gogoproto generated file %v: %v", gofile.GetName(), err)
@@ -308,12 +307,13 @@ func updateGoFile(gofile *plugingo.CodeGeneratorResponse_File, protofile *protog
 							genImmutability(typeName, &crdFunctionsBuf, options)
 							genCRDObject(typeName, gInfo, &crdFunctionsBuf)
 							genCRDBlobFields(typeName, protoMsg, &crdFunctionsBuf, extTypes)
-							crdFunctionsBuf.Write([]byte("func init() {\n\tYamlSchemas[\"" + typeName + "\"] = `"))
-							yamlStr := string(yaml.GenerateCRDYaml(protofile, extTypes, *gInfo))
-							crdFunctionsBuf.Write([]byte(strings.Replace(yamlStr, "`", "`+\"`\"+`", -1)))
-							crdFunctionsBuf.Write([]byte("`\n"))
-							crdFunctionsBuf.Write([]byte("}"))
+							genCRDEnumFields(typeName, protoMsg, &crdFunctionsBuf, extTypes, processedGoPackageList)
 						}
+						crdFunctionsBuf.Write([]byte("func init() {\n\tYamlSchemas[\"" + typeName + "\"] = `"))
+						yamlStr := string(yaml.GenerateCRDYaml(protofile, extTypes, *gInfo))
+						crdFunctionsBuf.Write([]byte(strings.Replace(yamlStr, "`", "`+\"`\"+`", -1)))
+						crdFunctionsBuf.Write([]byte("`\n"))
+						crdFunctionsBuf.Write([]byte("}"))
 					}
 				}
 			}
@@ -471,15 +471,66 @@ func generate(reqData []byte) *plugingo.CodeGeneratorResponse {
 	// Load group info
 	gInfo := yaml.LoadGroupInfo(gen, extTypes, false)
 
+	processedGoPackageList := make(map[string]bool)
 	for _, f := range gen.Files {
 		// skip the proto file that don't need to generate go code,
 		// such as imported proto files
 		if !f.Generate {
 			continue
 		}
-		updateGoFile(gofiles[f.Proto.GetName()], f, extTypes, gInfo)
+		updateGoFile(gofiles[f.Proto.GetName()], f, extTypes, gInfo, &processedGoPackageList)
 	}
 	return resp
+}
+
+func findEnumFields(curMsg *protogen.Message, pathPrefix string, enumFields *[]string,
+	processedMessageTypes *map[protogen.GoIdent]bool, extTypes *protoregistry.Types, processedGoPackageList *map[string]bool) {
+	for _, field := range curMsg.Fields {
+		// Check if this field is an enum
+		if field.Enum != nil {
+			key := fmt.Sprintf("%s.%s", field.Enum.GoIdent.GoImportPath, field.Enum.GoIdent.GoName)
+			if _, found := (*processedGoPackageList)[key]; !found {
+				(*processedGoPackageList)[key] = true
+				newPrefix := strings.Trim(field.Enum.GoIdent.GoName, ".")
+				*enumFields = append(*enumFields, newPrefix)
+			}
+		}
+		// Continue processing nested messages
+		if field.Message != nil && field.Message.GoIdent.GoImportPath == curMsg.GoIdent.GoImportPath {
+			if _, found := (*processedMessageTypes)[field.Message.GoIdent]; !found {
+				(*processedMessageTypes)[field.Message.GoIdent] = true
+				findEnumFields(field.Message, pathPrefix+"."+field.GoName, enumFields, processedMessageTypes,
+					extTypes, processedGoPackageList)
+				delete(*processedMessageTypes, field.Message.GoIdent)
+			}
+		}
+	}
+}
+
+type EnumValue struct {
+	Name        string // Enum value as a string (e.g., "Pending")
+	GoEnumValue string // Fully qualified Go enum value (e.g., "MyEnum_PENDING")
+}
+
+func genCRDEnumFields(crdName string, crdMsg *protogen.Message, crdBuf *bytes.Buffer, extTypes *protoregistry.Types,
+	processedGoPackageList *map[string]bool,
+) {
+	processedMessageTypes := make(map[protogen.GoIdent]bool)
+	enumFields := make([]string, 0)
+	// Find all enum fields in the CRD message
+	findEnumFields(crdMsg, "", &enumFields, &processedMessageTypes, extTypes, processedGoPackageList)
+
+	// Generate UnmarshalJSON methods for each enum field
+	for _, enumFieldName := range enumFields {
+		typeInfo := struct {
+			EnumFieldName string
+			EnumValues    []EnumValue
+		}{
+			EnumFieldName: enumFieldName,
+		}
+		templates.CRDUnmarshalEnum.Execute(crdBuf, typeInfo)
+		crdBuf.Write([]byte("\n"))
+	}
 }
 
 func main() {

--- a/go/cmd/kubeproto/protoc-gen-kubeproto/main.go
+++ b/go/cmd/kubeproto/protoc-gen-kubeproto/main.go
@@ -553,12 +553,11 @@ func genCRDEnumFields(crdName string, crdMsg *protogen.Message, crdBuf *bytes.Bu
 	findEnumFields(crdMsg, "", &enumFields, &processedMessageTypes, extTypes, processedGoPackageList)
 
 	// Generate UnmarshalJSON methods for each enum field
-	for _, enumFieldName := range enumFields {
+	for _, enumTypeName := range enumFields {
 		typeInfo := struct {
-			EnumFieldName string
-			EnumValues    []EnumValue
+			EnumTypeName string
 		}{
-			EnumFieldName: enumFieldName,
+			EnumTypeName: enumTypeName,
 		}
 		templates.CRDUnmarshalEnum.Execute(crdBuf, typeInfo)
 		crdBuf.Write([]byte("\n"))

--- a/go/cmd/kubeproto/protoc-gen-kubeproto/main.go
+++ b/go/cmd/kubeproto/protoc-gen-kubeproto/main.go
@@ -527,6 +527,20 @@ type EnumValue struct {
 	GoEnumValue string // Fully qualified Go enum value (e.g., "MyEnum_PENDING")
 }
 
+// genCRDEnumFields generates UnmarshalJSON methods for all enum fields in a given CRD (Custom Resource Definition) message.
+//
+// This function:
+// - Identifies all enum fields within the provided CRD protobuf message (`crdMsg`).
+// - Uses `findEnumFields` to traverse nested messages and collect enum field names.
+// - Iterates through the discovered enum fields and generates UnmarshalJSON methods using a template.
+// - Writes the generated code to the provided buffer (`crdBuf`).
+//
+// Args:
+//   crdName                string                    - The name of the CRD being processed.
+//   crdMsg                 *protogen.Message         - The protobuf message representing the CRD.
+//   crdBuf                 *bytes.Buffer            - The buffer to write the generated code to.
+//   extTypes               *protoregistry.Types     - A registry of external types (may be useful for future extensions).
+//   processedGoPackageList *map[string]bool         - A map to track processed Go packages to avoid redundant processing.
 func genCRDEnumFields(crdName string, crdMsg *protogen.Message, crdBuf *bytes.Buffer, extTypes *protoregistry.Types,
 	processedGoPackageList *map[string]bool,
 ) {

--- a/go/cmd/kubeproto/protoc-gen-kubeproto/main_test.go
+++ b/go/cmd/kubeproto/protoc-gen-kubeproto/main_test.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"encoding/json"
 	"go/token"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -158,8 +159,12 @@ func TestJSON(t *testing.T) {
 	testObject.Spec.Description = "test"
 
 	testObjectJSON, err := json.Marshal(testObject)
-	assert.True(t, err == nil)
+	assert.Nil(t, err)
 	assert.Equal(t, ObjectJSON, string(testObjectJSON))
+	testObjectUnmarshalled := &testpb.TestObject{}
+	err = json.Unmarshal(testObjectJSON, testObjectUnmarshalled)
+	assert.Nil(t, err)
+	assert.True(t, reflect.DeepEqual(testObject, testObjectUnmarshalled))
 
 	// Test enum type
 	testEnum := &testpb.TestObjectSpec{
@@ -181,6 +186,10 @@ func TestJSON(t *testing.T) {
 	testEnumJSON, err := json.Marshal(testEnum)
 	assert.True(t, err == nil)
 	assert.Equal(t, EnumJSON, string(testEnumJSON))
+	testEnumUnmarshalled := &testpb.TestObjectSpec{}
+	err = json.Unmarshal(testEnumJSON, testEnumUnmarshalled)
+	assert.Nil(t, err)
+	assert.True(t, reflect.DeepEqual(testEnum, testEnumUnmarshalled))
 
 	// Test Any type
 	testMsg := &testpb.TestMsg{
@@ -196,6 +205,10 @@ func TestJSON(t *testing.T) {
 	testAnyJSON, err := json.Marshal(testAny)
 	assert.True(t, err == nil)
 	assert.Equal(t, AnyJSON, string(testAnyJSON))
+	testAnyUnmarshalled := &testpb.TestObjectSpec{}
+	err = json.Unmarshal(testAnyJSON, testAnyUnmarshalled)
+	assert.Nil(t, err)
+	assert.True(t, reflect.DeepEqual(testAny, testAnyUnmarshalled))
 
 	// Test Timestamp type
 	timestamp, err := types.TimestampProto(
@@ -208,18 +221,30 @@ func TestJSON(t *testing.T) {
 	testTimeJSON, err := json.Marshal(testTimestamp)
 	assert.True(t, err == nil)
 	assert.Equal(t, TimeJSON, string(testTimeJSON))
+	testTimeUnmarshalled := &testpb.TestObjectSpec{}
+	err = json.Unmarshal(testTimeJSON, testTimeUnmarshalled)
+	assert.Nil(t, err)
+	assert.True(t, reflect.DeepEqual(testTimestamp, testTimeUnmarshalled))
 
 	// Test duration type
 	testDuration := types.DurationProto(1000 * time.Second)
 	testDurationJSON, err := json.Marshal(testDuration)
 	assert.True(t, err == nil)
 	assert.Equal(t, DurationJSON, string(testDurationJSON))
+	testDurationUnmarshalled := &types.Duration{}
+	err = json.Unmarshal(testDurationJSON, testDurationUnmarshalled)
+	assert.Nil(t, err)
+	assert.True(t, reflect.DeepEqual(testDuration, testDurationUnmarshalled))
 
 	// Test duration type
 	testDuration2 := types.DurationProto(1000 * time.Nanosecond)
 	testDurationJSON2, err := json.Marshal(testDuration2)
 	assert.True(t, err == nil)
 	assert.Equal(t, DurationJSON2, string(testDurationJSON2))
+	testDurationUnmarshalled2 := &types.Duration{}
+	err = json.Unmarshal(testDurationJSON2, testDurationUnmarshalled2)
+	assert.Nil(t, err)
+	assert.True(t, reflect.DeepEqual(testDuration2, testDurationUnmarshalled2))
 
 	tmp := &testpb.TestObjectSpec{}
 	err = json.Unmarshal(testTimeJSON, tmp)
@@ -262,6 +287,10 @@ func TestJSON(t *testing.T) {
 	testStructJSON, err := json.Marshal(testPbWithStruct)
 	assert.Nil(t, err)
 	assert.Equal(t, StructJSON, string(testStructJSON))
+	testStructUnmarshalled := &testpb.TestObjectSpec{}
+	err = json.Unmarshal(testStructJSON, testStructUnmarshalled)
+	assert.Nil(t, err)
+	assert.True(t, reflect.DeepEqual(testPbWithStruct, testStructUnmarshalled))
 
 	testPbWithStructDecode := &testpb.TestObjectSpec{}
 	err = json.Unmarshal(testStructJSON, testPbWithStructDecode)

--- a/go/cmd/kubeproto/protoc-gen-kubeproto/main_test.go
+++ b/go/cmd/kubeproto/protoc-gen-kubeproto/main_test.go
@@ -67,9 +67,13 @@ func TestGen(t *testing.T) {
 
 	var projectFile *plugin_go.CodeGeneratorResponse_File
 	var groupInfoFile *plugin_go.CodeGeneratorResponse_File
+	var testObjectFile *plugin_go.CodeGeneratorResponse_File
 	for _, f := range resp.GetFile() {
 		if strings.HasSuffix(*f.Name, "project_ut.pb.go") {
 			projectFile = f
+		}
+		if strings.HasSuffix(*f.Name, "testobject.pb.go") {
+			testObjectFile = f
 		}
 		if strings.HasSuffix(*f.Name, "groupversion_info_ut.pb.go") {
 			groupInfoFile = f
@@ -90,6 +94,11 @@ func TestGen(t *testing.T) {
 	assert.Contains(t, c, `func (in *ProjectList) DeepCopy() *ProjectList`)
 	assert.Contains(t, c, `YamlSchemas["Project"] =`)
 	assert.Contains(t, c, `name: projects-plural.michelangelo.api`)
+
+	c = testObjectFile.GetContent()
+	assert.Contains(t, c, `func (m *DataType) UnmarshalJSON(b []byte) error {`)
+	assert.Contains(t, c, `func (m *TestObjectSpec_ClusterType) UnmarshalJSON(b []byte) error {`)
+
 	//TODO(https://github.com/uber/michelangelo/issues/65): assert.Contains(t, c, expectedCRDDescription)
 
 	assert.True(t, groupInfoFile != nil)

--- a/go/kubeproto/templates/templates.go
+++ b/go/kubeproto/templates/templates.go
@@ -47,19 +47,19 @@ var CRDHasBlobFields = template.Must(template.New("crdHasBlobFields").Parse(`fun
 `))
 
 // CRDUnmarshalEnum is a template for the HasEnumFields() function.
-var CRDUnmarshalEnum = template.Must(template.New("unmarshalJSON").Parse(`func (m *{{.EnumFieldName}}) UnmarshalJSON(b []byte) error {
+var CRDUnmarshalEnum = template.Must(template.New("unmarshalJSON").Parse(`func (m *{{.EnumTypeName}}) UnmarshalJSON(b []byte) error {
 	var s string
     err := json.Unmarshal(b, &s)
 	if err != nil {
 		return err
 	}
 	// Check if the string exists in the map
-	val, exists := {{.EnumFieldName}}_value[s]
+	val, exists := {{.EnumTypeName}}_value[s]
 	if !exists {
 		return fmt.Errorf("invalid DataType: %s", s)
 	}
 	
-	*m = {{.EnumFieldName}}(val)
+	*m = {{.EnumTypeName}}(val)
 	return nil
 }
 `))

--- a/go/kubeproto/templates/templates.go
+++ b/go/kubeproto/templates/templates.go
@@ -46,6 +46,24 @@ var CRDHasBlobFields = template.Must(template.New("crdHasBlobFields").Parse(`fun
 }
 `))
 
+// CRDUnmarshalEnum is a template for the HasEnumFields() function.
+var CRDUnmarshalEnum = template.Must(template.New("unmarshalJSON").Parse(`func (m *{{.EnumFieldName}}) UnmarshalJSON(b []byte) error {
+	var s string
+    err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	// Check if the string exists in the map
+	val, exists := {{.EnumFieldName}}_value[s]
+	if !exists {
+		return fmt.Errorf("invalid DataType: %s", s)
+	}
+	
+	*m = {{.EnumFieldName}}(val)
+	return nil
+}
+`))
+
 // CRDClearBlobFieldsHeader is a template of the ClearBlobFields() function signature
 var CRDClearBlobFieldsHeader = template.Must(template.New("crdClearBlobFields").Parse(`func (m *{{.Name}}) ClearBlobFields() {
 `))

--- a/go/kubeproto/yaml/test/project.yaml
+++ b/go/kubeproto/yaml/test/project.yaml
@@ -20,6 +20,15 @@ spec:
         properties:
           spec:
             properties:
+              dataType:
+                enum:
+                  - DATA_TYPE_INVALID
+                  - DATA_TYPE_UNKNOWN
+                  - DATA_TYPE_NUMERIC
+                  - DATA_TYPE_ARRAY
+                  - DATA_TYPE_BOOLEAN
+                  - DATA_TYPE_DATE
+                type: string
               meta:
                 properties:
                   name:

--- a/go/kubeproto/yaml/test/project.yaml
+++ b/go/kubeproto/yaml/test/project.yaml
@@ -22,12 +22,12 @@ spec:
             properties:
               dataType:
                 enum:
-                  - DATA_TYPE_INVALID
-                  - DATA_TYPE_UNKNOWN
-                  - DATA_TYPE_NUMERIC
-                  - DATA_TYPE_ARRAY
-                  - DATA_TYPE_BOOLEAN
-                  - DATA_TYPE_DATE
+                - DATA_TYPE_INVALID
+                - DATA_TYPE_UNKNOWN
+                - DATA_TYPE_NUMERIC
+                - DATA_TYPE_ARRAY
+                - DATA_TYPE_BOOLEAN
+                - DATA_TYPE_DATE
                 type: string
               meta:
                 properties:

--- a/proto/test/kubeproto/project_ut.proto
+++ b/proto/test/kubeproto/project_ut.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package michelangelo.test.kubeproto;
 
 import "k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto";
+import "michelangelo/test/kubeproto/testobject.proto";
 import "michelangelo/api/options.proto";
 
 option go_package = "kubeproto";
@@ -23,6 +24,10 @@ message ProjectSpec {
   option (michelangelo.api.no_default) = true;
   // Metadata of the ML project
   Metadata meta = 1;
+
+  // Testing enum that appears in another proto under the same package.
+  // to make sure we don't generate two version of unmarshalJson method
+  DataType data_type = 7;
 }
 
 // Defines the status of a ML project

--- a/python/michelangelo/uniflow/core/build.py
+++ b/python/michelangelo/uniflow/core/build.py
@@ -279,102 +279,35 @@ def _fn_path(fn: Callable) -> Path:
 
 
 class FunctionTransformer(ast.NodeTransformer):
-    """
-    A custom AST transformer that modifies function syntax for a restricted execution environment.
-    
-    This transformer:
-    - Prohibits certain Python constructs (e.g., `import`, `try`, `is`, `is not`).
-    - Transforms annotated assignments into regular assignments.
-    - Validates and processes global variable references.
-    - Integrates with dependency tracking to manage external references.
-
-    The main use case is ensuring compatibility with a restricted subset of Python (e.g., 
-    Starlark-like environments) while handling dependencies for workflow execution.
-    """
     def __init__(self, fn):
         self._code = fn.__code__
         self._module = inspect.getmodule(fn)
         self.deps = Dependencies()
 
     def visit_AnnAssign(self, node):
-        """
-        Transforms annotated assignments (`a: type = value`) into standard assignments (`a = value`).
-        
-        Example:
-            Input: `a: dict = foo()`
-            Output: `a = foo()`
-        
-        This ensures compatibility with environments that do not support type annotations.
-        """
+        # Replace annotated assignment with just assignment. Ex:
+        # a: dict = foo()  ->  a = foo()
         return ast.Assign(
             value=node.value,
             targets=[node.target],
         )
 
     def visit_Is(self, _node):
-        """
-        Prohibits the use of the `is` operator, enforcing `==` instead.
-        
-        Raises:
-            NameError: If `is` is used in the function.
-        """
         raise NameError("[is] is not supported, use == instead")
 
     def visit_IsNot(self, _node):
-        """
-        Prohibits the use of the `is not` operator, enforcing `!=` instead.
-        
-        Raises:
-            NameError: If `is not` is used in the function.
-        """
         raise NameError("[is not] is not supported, use != instead")
 
     def visit_Import(self, _node):
-        """
-        Prohibits `import` statements to prevent arbitrary code execution.
-        
-        Raises:
-            NameError: Always.
-        """
         raise NameError("[import] is not supported")
 
     def visit_ImportFrom(self, _node):
-        """
-        Prohibits `from ... import ...` statements for the same reason as `import`.
-        
-        Raises:
-            NameError: Always.
-        """
         raise NameError("[import] is not supported")
 
     def visit_Try(self, _node):
-        """
-        Prohibits `try` statements to avoid exception handling mechanisms.
-        
-        Raises:
-            NameError: Always.
-        """
         raise NameError("[try] is not supported")
 
     def visit_Name(self, node: ast.Name):
-        """
-        Handles variable references by validating their usage and tracking dependencies.
-        
-        - If a variable is a local function variable, it is preserved.
-        - If a variable is a global reference, it is checked against allowed built-ins.
-        - If a variable is a workflow function, it is registered in dependencies.
-        - If a variable is a plugin function, it is transformed into an alias reference.
-
-        Args:
-            node (ast.Name): The AST node representing a variable name.
-
-        Returns:
-            ast.Name or transformed AST node.
-
-        Raises:
-            ValueError: If a referenced global is not found in the function's globals.
-            NameError: If an unsupported global variable is used.
-        """
         if not isinstance(node.ctx, ast.Load):
             # Skip non load var context. I.e. keep var assignment code as-is.
             return node

--- a/python/michelangelo/uniflow/core/build.py
+++ b/python/michelangelo/uniflow/core/build.py
@@ -279,35 +279,102 @@ def _fn_path(fn: Callable) -> Path:
 
 
 class FunctionTransformer(ast.NodeTransformer):
+    """
+    A custom AST transformer that modifies function syntax for a restricted execution environment.
+    
+    This transformer:
+    - Prohibits certain Python constructs (e.g., `import`, `try`, `is`, `is not`).
+    - Transforms annotated assignments into regular assignments.
+    - Validates and processes global variable references.
+    - Integrates with dependency tracking to manage external references.
+
+    The main use case is ensuring compatibility with a restricted subset of Python (e.g., 
+    Starlark-like environments) while handling dependencies for workflow execution.
+    """
     def __init__(self, fn):
         self._code = fn.__code__
         self._module = inspect.getmodule(fn)
         self.deps = Dependencies()
 
     def visit_AnnAssign(self, node):
-        # Replace annotated assignment with just assignment. Ex:
-        # a: dict = foo()  ->  a = foo()
+        """
+        Transforms annotated assignments (`a: type = value`) into standard assignments (`a = value`).
+        
+        Example:
+            Input: `a: dict = foo()`
+            Output: `a = foo()`
+        
+        This ensures compatibility with environments that do not support type annotations.
+        """
         return ast.Assign(
             value=node.value,
             targets=[node.target],
         )
 
     def visit_Is(self, _node):
+        """
+        Prohibits the use of the `is` operator, enforcing `==` instead.
+        
+        Raises:
+            NameError: If `is` is used in the function.
+        """
         raise NameError("[is] is not supported, use == instead")
 
     def visit_IsNot(self, _node):
+        """
+        Prohibits the use of the `is not` operator, enforcing `!=` instead.
+        
+        Raises:
+            NameError: If `is not` is used in the function.
+        """
         raise NameError("[is not] is not supported, use != instead")
 
     def visit_Import(self, _node):
+        """
+        Prohibits `import` statements to prevent arbitrary code execution.
+        
+        Raises:
+            NameError: Always.
+        """
         raise NameError("[import] is not supported")
 
     def visit_ImportFrom(self, _node):
+        """
+        Prohibits `from ... import ...` statements for the same reason as `import`.
+        
+        Raises:
+            NameError: Always.
+        """
         raise NameError("[import] is not supported")
 
     def visit_Try(self, _node):
+        """
+        Prohibits `try` statements to avoid exception handling mechanisms.
+        
+        Raises:
+            NameError: Always.
+        """
         raise NameError("[try] is not supported")
 
     def visit_Name(self, node: ast.Name):
+        """
+        Handles variable references by validating their usage and tracking dependencies.
+        
+        - If a variable is a local function variable, it is preserved.
+        - If a variable is a global reference, it is checked against allowed built-ins.
+        - If a variable is a workflow function, it is registered in dependencies.
+        - If a variable is a plugin function, it is transformed into an alias reference.
+
+        Args:
+            node (ast.Name): The AST node representing a variable name.
+
+        Returns:
+            ast.Name or transformed AST node.
+
+        Raises:
+            ValueError: If a referenced global is not found in the function's globals.
+            NameError: If an unsupported global variable is used.
+        """
         if not isinstance(node.ctx, ast.Load):
             # Skip non load var context. I.e. keep var assignment code as-is.
             return node


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
Add unmarshalJson method to all proto generated go code.

**Why?**
This is due to error in controller manager:
W0211 16:56:01.791761   37339 reflector.go:569] external/gazelle~~go_deps~io_k8s_client_go/tools/cache/reflector.go:251: failed to list *v2.RayCluster: json: cannot unmarshal string into Go struct field RayCluster.items.spec of type v2.TerminationType

**How did you test it?**
Unit test and local cluster mode test

**Potential risks**
When directly using v2pb ENUM fields in any go-code place potentially will cause unmarshal issue, for example, defining struct for uniflow code using v2pb ENUM field will have issue for cannot unmarshal string into Go struct field. So we need to avoid direct using those ENUM in non-proto place and try to use string instead

**Release notes**
N/A

**Documentation Changes**
N/A
