### PR TITLE
change api server port and print configuration

### DIFF
--- a/go/cmd/apiserver/config/base.yaml
+++ b/go/cmd/apiserver/config/base.yaml
@@ -1,7 +1,7 @@
 apiserver:
   yarpc:
     host: "localhost"
-    port: 8080
+    port: 14566
   k8s:
     qps: 300
     burst: 600

--- a/go/cmd/apiserver/main.go
+++ b/go/cmd/apiserver/main.go
@@ -10,7 +10,9 @@ import (
 	"github.com/michelangelo-ai/michelangelo/go/logging"
 	v2pb "github.com/michelangelo-ai/michelangelo/proto/api/v2"
 	"github.com/uber-go/tally"
+	uberconfig "go.uber.org/config"
 	"go.uber.org/fx"
+	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 )
@@ -28,6 +30,7 @@ func opts() fx.Option {
 		env.Module,
 		config.Module,
 		zapfx.Module,
+		fx.Invoke(printConfig),
 		apihandler.APIServerModule,
 		auth.DummyAuthModule,
 		logging.DummyAuditLogModule,
@@ -61,4 +64,8 @@ func getScheme() (*runtime.Scheme, error) {
 		return nil, err
 	}
 	return s, nil
+}
+
+func printConfig(logger *zap.Logger, provider uberconfig.Provider) {
+	logger.Info("Configuration", zap.Any("config", provider.Get(uberconfig.Root)))
 }

--- a/go/cmd/worker/config/base.yaml
+++ b/go/cmd/worker/config/base.yaml
@@ -1,5 +1,5 @@
 worker:
-  address: localhost:8080
+  address: localhost:14566
   maApiServiceName: ma-apiserver
 
 logging:


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [X] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
Change the default api server gRPC port to 14566 to avoid conflict
Print configuration when api server starts

<!-- Tell your future self why have you made these changes -->
**Why?**
8080 is the default port of many other services, it's more likely to have conflict
Print configuration to help debugging


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
tested locally

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
