### PR TITLE
allow multiple api hooks

### DIFF
--- a/go/cmd/apiserver/BUILD.bazel
+++ b/go/cmd/apiserver/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//go/base/env:go_default_library",
         "//go/base/zapfx:go_default_library",
         "//go/logging:go_default_library",
+        "//go/project/apihook:go_default_library",
         "//go/storage:go_default_library",
         "//proto/api/v2:go_default_library",
         "@com_github_uber_go_tally//:go_default_library",

--- a/go/cmd/apiserver/main.go
+++ b/go/cmd/apiserver/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/michelangelo-ai/michelangelo/go/base/env"
 	"github.com/michelangelo-ai/michelangelo/go/base/zapfx"
 	"github.com/michelangelo-ai/michelangelo/go/logging"
+	projectapihook "github.com/michelangelo-ai/michelangelo/go/project/apihook"
 	v2pb "github.com/michelangelo-ai/michelangelo/proto/api/v2"
 	"github.com/uber-go/tally"
 	uberconfig "go.uber.org/config"
@@ -40,6 +41,7 @@ func opts() fx.Option {
 		fx.Provide(getMetadataStorageConfig),
 		fx.Provide(provideDispatcher),
 		fx.Provide(getScheme),
+		fx.Provide(projectapihook.GetProjectAPIHook),
 		v2pb.ProjectSvcModule,
 		v2pb.RayClusterSvcModule,
 		v2pb.RayJobSvcModule,

--- a/go/cmd/kubeproto/protoc-gen-kubeyarpc/main_test.go
+++ b/go/cmd/kubeproto/protoc-gen-kubeyarpc/main_test.go
@@ -50,6 +50,7 @@ func TestGen(t *testing.T) {
 	assert.Contains(t, p.imports, `"go.uber.org/fx"`)
 	assert.Contains(t, p.imports, `"k8s.io/apimachinery/pkg/apis/meta/v1"`)
 
-	assert.Contains(t, c, `func NewProjectServiceHandler(handler api.Handler, metricsScope tally.Scope, auth authapi.Auth, auditLog logging.AuditLog) ProjectServiceYARPCServer`)
+	assert.Contains(t, c, `func NewProjectServiceHandler(params FxProjectServiceHandlerParams) ProjectServiceYARPCServer {`)
+	assert.Contains(t, c, `type ProjectAPIHook interface`)
 	assert.Contains(t, c, `var ProjectSvcModule =`)
 }

--- a/go/kubeproto/templates/crd_svc.tmpl
+++ b/go/kubeproto/templates/crd_svc.tmpl
@@ -1,5 +1,21 @@
-func New{{.KindName}}ServiceHandler(handler api.Handler, metricsScope tally.Scope, auth authapi.Auth, auditLog logging.AuditLog) {{.KindName}}ServiceYARPCServer {
-	return &{{.LowerKindName}}ServiceHandler{apiHandler: handler, MetricsScope: metricsScope.SubScope(logging.MichelangeloAPIScopeName), auth: auth, auditLogEmitter: auditLog}
+type Fx{{.KindName}}ServiceHandlerParams struct {
+	fx.In
+
+	Handler      api.Handler
+	MetricsScope tally.Scope
+	Auth         authapi.Auth
+	AuditLog     logging.AuditLog
+	ApiHooks     []{{.KindName}}APIHook `group:"apiHooks"`
+}
+
+func New{{.KindName}}ServiceHandler(params Fx{{.KindName}}ServiceHandlerParams) {{.KindName}}ServiceYARPCServer {
+	return &{{.LowerKindName}}ServiceHandler{
+	    apiHandler:      params.Handler,
+	    MetricsScope:    params.MetricsScope.SubScope(logging.MichelangeloAPIScopeName),
+	    auth:            params.Auth,
+	    auditLogEmitter: params.AuditLog,
+	    apiHooks:        params.ApiHooks,
+	}
 }
 
 type {{.LowerKindName}}ServiceHandler struct {
@@ -7,15 +23,12 @@ type {{.LowerKindName}}ServiceHandler struct {
 	MetricsScope    tally.Scope
 	auth            authapi.Auth
 	auditLogEmitter logging.AuditLog
+	apiHooks        []{{.KindName}}APIHook
 }
 
-// Emit{{.KindName}}WriteMetric allows developer to emit metrics when they Create and Update each CRD object
-// This metric emitter will emit metrics after the Create/Update API call completed.
-var Emit{{.KindName}}WriteMetric func(context.Context, tally.Scope, *{{.KindName}}, error, api.Handler) = nil
-
-// {{.KindName}}ApiHook allows API developers to hook the standard CRUD methods,
+// {{.KindName}}APIHook allows API developers to hook the standard CRUD methods,
 // before the request is sent to K8s API server, or before the response is returned to the client.
-var {{.KindName}}ApiHook interface {
+type {{.KindName}}APIHook interface {
 	// BeforeCreate is called before a Create{{.KindName}}Request is sent to the K8s API server.
 	//
 	// This method can be used to validate or modify the Create{{.KindName}}Request, before it's sent to the k8s API
@@ -77,11 +90,38 @@ var {{.KindName}}ApiHook interface {
 	// removed, the gRPC call Delete{{.KindName}} still returns success (error = nil). It's the API developer's
 	// responsibility to remove the orphan data (e.g. with a garbage collection job).
 	OnDeleteCollectionSuccess(context.Context, *Delete{{.KindName}}CollectionRequest)
+}
 
+// Noop{{.KindName}}APIHook is a no-op implementation of {{.KindName}}APIHook, which can be embedded in a
+// {{.KindName}}APIHook struct to implement only the methods that are needed.
+type Noop{{.KindName}}APIHook struct{}
 
-} = nil
+func (n Noop{{.KindName}}APIHook) BeforeCreate(context.Context, *Create{{.KindName}}Request) error {
+	return nil
+}
 
-func (c {{.LowerKindName}}ServiceHandler) Create{{.KindName}}(ctx context.Context, request *Create{{.KindName}}Request) (resp *Create{{.KindName}}Response, err error) {
+func (n Noop{{.KindName}}APIHook) BeforeUpdate(context.Context, *Update{{.KindName}}Request) error {
+	return nil
+}
+
+func (n Noop{{.KindName}}APIHook) OnGetSuccess(context.Context, *{{.KindName}}) error {
+	return nil
+}
+
+func (n Noop{{.KindName}}APIHook) BeforeDelete(context.Context, *Delete{{.KindName}}Request) error {
+	return nil
+}
+
+func (n Noop{{.KindName}}APIHook) OnDeleteSuccess(context.Context, *Delete{{.KindName}}Request) {}
+
+func (n Noop{{.KindName}}APIHook) BeforeDeleteCollection(context.Context, *Delete{{.KindName}}CollectionRequest) error {
+	return nil
+}
+
+func (n Noop{{.KindName}}APIHook) OnDeleteCollectionSuccess(context.Context, *Delete{{.KindName}}CollectionRequest) {}
+
+func (c {{.LowerKindName}}ServiceHandler) Create{{.KindName}}(
+	ctx context.Context, request *Create{{.KindName}}Request) (resp *Create{{.KindName}}Response, err error) {
 	logger := logging.GetLogrLoggerOrPanic()
 
 	requestJSON := logging.MarshalToString(request)
@@ -95,10 +135,6 @@ func (c {{.LowerKindName}}ServiceHandler) Create{{.KindName}}(ctx context.Contex
 		logging.EntityNameTag:   request.{{.KindName}}.ObjectMeta.Name,
 	})
 
-	if Emit{{.KindName}}WriteMetric != nil {
-		defer Emit{{.KindName}}WriteMetric(ctx, metric, request.{{.KindName}}, err, c.apiHandler)
-	}
-
 	defer c.auditLogEmitter.Emit(ctx, c.build{{.KindName}}AuditLogEventForCreate(
 												ctx,
 												request,
@@ -111,9 +147,7 @@ func (c {{.LowerKindName}}ServiceHandler) Create{{.KindName}}(ctx context.Contex
 	userAuthenticated, err := c.auth.UserAuthenticated(ctx)
 	if !userAuthenticated {
 		logger.Error(err, "User is not authenticated")
-		if Emit{{.KindName}}WriteMetric == nil {
-			metric.Counter("unauthenticated").Inc(1)
-		}
+		metric.Counter("unauthenticated").Inc(1)
 		return nil, err
 	}
 
@@ -123,9 +157,7 @@ func (c {{.LowerKindName}}ServiceHandler) Create{{.KindName}}(ctx context.Contex
 
 	if !userAuthorized {
 		logger.Error(err, "User is not authorized")
-		if Emit{{.KindName}}WriteMetric == nil {
-			metric.Counter("unauthorized").Inc(1)
-		}
+		metric.Counter("unauthorized").Inc(1)
 		return nil, err
 	}
 
@@ -134,43 +166,35 @@ func (c {{.LowerKindName}}ServiceHandler) Create{{.KindName}}(ctx context.Contex
 		createOptions = request.CreateOptions
 	}
 
-	if {{.KindName}}ApiHook != nil {
-		if err = api.Validate(request.{{.KindName}}); err != nil {
-			if Emit{{.KindName}}WriteMetric == nil {
-				metric.Counter("fail").Inc(1)
-			}
-			return nil, err
-		}
-		if err = {{.KindName}}ApiHook.BeforeCreate(ctx, request); err != nil {
-			logger.Error(err, "Error in BeforeCreate Validation", "error", err, "api_msg_tag", "Create{{.KindName}}")
-			if Emit{{.KindName}}WriteMetric == nil {
-				metric.Counter("fail").Inc(1)
-			}
-			return nil, err
-		}
-
+    if err = api.Validate(request.{{.KindName}}); err != nil {
+		metric.Counter("fail").Inc(1)
+		return nil, err
 	}
 
+    for _, hook := range c.apiHooks {
+        if err = hook.BeforeCreate(ctx, request); err != nil {
+            logger.Error(err, "Error in BeforeCreate API hook", "error", err, "api_msg_tag", "Create{{.KindName}}")
+            metric.Counter("fail").Inc(1)
+            return nil, err
+        }
+    }
 
 	err = c.apiHandler.Create(ctx, request.{{.KindName}}, createOptions)
 
 	if err != nil {
 		logger.Error(err, "API Handler failed to create {{.KindName}}", "error", err, "api_msg_tag", "Create{{.KindName}}")
-		if Emit{{.KindName}}WriteMetric == nil {
-				metric.Counter("fail").Inc(1)
-		}
+		metric.Counter("fail").Inc(1)
 		return nil, err
 	}
 
 	logger.Info("Create{{.KindName}} Request Successfully Completed.", "api_msg_tag", "Create{{.KindName}}")
 
-	if Emit{{.KindName}}WriteMetric == nil {
-		metric.Counter("success").Inc(1)
-	}
+	metric.Counter("success").Inc(1)
 	return &Create{{.KindName}}Response{ {{.KindName}}: request.{{.KindName}}}, err
 }
 
-func (c {{.LowerKindName}}ServiceHandler) Get{{.KindName}}(ctx context.Context, request *Get{{.KindName}}Request) (resp *Get{{.KindName}}Response, err error) {
+func (c {{.LowerKindName}}ServiceHandler) Get{{.KindName}}(
+	ctx context.Context, request *Get{{.KindName}}Request) (resp *Get{{.KindName}}Response, err error) {
 	logger := logging.GetLogrLoggerOrPanic()
 	requestJSON := logging.MarshalToString(request)
 
@@ -211,14 +235,13 @@ func (c {{.LowerKindName}}ServiceHandler) Get{{.KindName}}(ctx context.Context, 
 	result.APIVersion = "michelangelo.uber.com/v2beta1"
 	result.Kind = "{{.KindName}}"
 
-	if {{.KindName}}ApiHook != nil {
-		if err = {{.KindName}}ApiHook.OnGetSuccess(ctx, result); err != nil {
-			logger.Error(err, "Error in OnGetSuccess call after successful k8s Get", "error", err, "api_msg_tag", "Get{{.KindName}}")
-			metric.Counter("fail").Inc(1)
-			return nil, err
-		}
-
-	}
+    for _, hook := range c.apiHooks {
+        if err = hook.OnGetSuccess(ctx, result); err != nil {
+            logger.Error(err, "Error in OnGetSuccess API hook", "error", err, "api_msg_tag", "Get{{.KindName}}")
+            metric.Counter("fail").Inc(1)
+            return nil, err
+        }
+    }
 
 	logger.Info("Get{{.KindName}} Request Successfully Completed.", "api_msg_tag", "Get{{.KindName}}")
 
@@ -229,7 +252,8 @@ func (c {{.LowerKindName}}ServiceHandler) Get{{.KindName}}(ctx context.Context, 
 	return &Get{{.KindName}}Response{ {{.KindName}}: result}, nil
 }
 
-func (c {{.LowerKindName}}ServiceHandler) Update{{.KindName}}(ctx context.Context, request *Update{{.KindName}}Request) (resp *Update{{.KindName}}Response, err error) {
+func (c {{.LowerKindName}}ServiceHandler) Update{{.KindName}}(
+	ctx context.Context, request *Update{{.KindName}}Request) (resp *Update{{.KindName}}Response, err error) {
 	logger := logging.GetLogrLoggerOrPanic()
 	requestJSON := logging.MarshalToString(request)
 
@@ -241,10 +265,6 @@ func (c {{.LowerKindName}}ServiceHandler) Update{{.KindName}}(ctx context.Contex
 		logging.NamespaceTag:    request.{{.KindName}}.ObjectMeta.Namespace,
 		logging.EntityNameTag:   request.{{.KindName}}.ObjectMeta.Name,
 	})
-
-	if Emit{{.KindName}}WriteMetric != nil {
-		defer Emit{{.KindName}}WriteMetric(ctx, metric, request.{{.KindName}}, err, c.apiHandler)
-	}
 
 	defer c.auditLogEmitter.Emit(ctx, c.build{{.KindName}}AuditLogEventForUpdate(
 												ctx,
@@ -258,9 +278,7 @@ func (c {{.LowerKindName}}ServiceHandler) Update{{.KindName}}(ctx context.Contex
 	userAuthenticated, err := c.auth.UserAuthenticated(ctx)
 	if !userAuthenticated {
 		logger.Error(err, "User is not authenticated")
-		if Emit{{.KindName}}WriteMetric == nil {
-			metric.Counter("unauthenticated").Inc(1)
-		}
+		metric.Counter("unauthenticated").Inc(1)
 		return nil, err
 	}
 
@@ -270,9 +288,7 @@ func (c {{.LowerKindName}}ServiceHandler) Update{{.KindName}}(ctx context.Contex
 
 	if !userAuthorized {
 		logger.Error(err, "User is not authorized")
-		if Emit{{.KindName}}WriteMetric == nil {
-			metric.Counter("unauthorized").Inc(1)
-		}
+		metric.Counter("unauthorized").Inc(1)
 		return nil, err
 	}
 
@@ -281,42 +297,35 @@ func (c {{.LowerKindName}}ServiceHandler) Update{{.KindName}}(ctx context.Contex
 		updateOptions = request.UpdateOptions
 	}
 
-	if {{.KindName}}ApiHook != nil {
-		if err = api.Validate(request.{{.KindName}}); err != nil {
-			if Emit{{.KindName}}WriteMetric == nil {
-				metric.Counter("fail").Inc(1)
-			}
-			return nil, err
-		}
-		if err = {{.KindName}}ApiHook.BeforeUpdate(ctx, request); err != nil {
-			logger.Error(err, "Error in BeforeUpdate Validation", "error", err, "api_msg_tag", "Update{{.KindName}}")
-			if Emit{{.KindName}}WriteMetric == nil {
-				metric.Counter("fail").Inc(1)
-			}
-			return nil, err
-		}
+    if err = api.Validate(request.{{.KindName}}); err != nil {
+    	metric.Counter("fail").Inc(1)
+    	return nil, err
+    }
 
-	}
+    for _, hook := range c.apiHooks {
+        if err = hook.BeforeUpdate(ctx, request); err != nil {
+            logger.Error(err, "Error in BeforeUpdate API hook", "error", err, "api_msg_tag", "Update{{.KindName}}")
+            metric.Counter("fail").Inc(1)
+            return nil, err
+        }
+    }
 
 	err = c.apiHandler.Update(ctx, request.{{.KindName}}, updateOptions)
 
 	if err != nil {
 		logger.Error(err, "API Handler failed to update {{.KindName}}", "error", err, "api_msg_tag", "Update{{.KindName}}")
-		if Emit{{.KindName}}WriteMetric == nil {
-				metric.Counter("fail").Inc(1)
-		}
+		metric.Counter("fail").Inc(1)
 		return nil, err
 	}
 
 	logger.Info("Update{{.KindName}} Request Successfully Completed.", "api_msg_tag", "Update{{.KindName}}")
 
-	if Emit{{.KindName}}WriteMetric == nil {
-		metric.Counter("success").Inc(1)
-	}
+	metric.Counter("success").Inc(1)
 	return &Update{{.KindName}}Response{ {{.KindName}}: request.{{.KindName}}}, err
 }
 
-func (c {{.LowerKindName}}ServiceHandler) Delete{{.KindName}}(ctx context.Context, request *Delete{{.KindName}}Request) (resp *Delete{{.KindName}}Response, err error) {
+func (c {{.LowerKindName}}ServiceHandler) Delete{{.KindName}}(
+	ctx context.Context, request *Delete{{.KindName}}Request) (resp *Delete{{.KindName}}Response, err error) {
 	logger := logging.GetLogrLoggerOrPanic()
 	requestJSON := logging.MarshalToString(request)
 
@@ -341,9 +350,7 @@ func (c {{.LowerKindName}}ServiceHandler) Delete{{.KindName}}(ctx context.Contex
 	userAuthenticated, err := c.auth.UserAuthenticated(ctx)
 	if !userAuthenticated {
 		logger.Error(err, "User is not authenticated")
-		if Emit{{.KindName}}WriteMetric == nil {
-			metric.Counter("unauthenticated").Inc(1)
-		}
+		metric.Counter("unauthenticated").Inc(1)
 		return nil, err
 	}
 
@@ -353,9 +360,7 @@ func (c {{.LowerKindName}}ServiceHandler) Delete{{.KindName}}(ctx context.Contex
 
 	if !userAuthorized {
 		logger.Error(err, "User is not authorized")
-		if Emit{{.KindName}}WriteMetric == nil {
-			metric.Counter("unauthorized").Inc(1)
-		}
+		metric.Counter("unauthorized").Inc(1)
 		return nil, err
 	}
 
@@ -367,14 +372,13 @@ func (c {{.LowerKindName}}ServiceHandler) Delete{{.KindName}}(ctx context.Contex
 	deleteObj := &{{.KindName}}{
 		ObjectMeta: metav1.ObjectMeta{Namespace: request.Namespace, Name: request.Name}}
 
-	if {{.KindName}}ApiHook != nil {
-		if err = {{.KindName}}ApiHook.BeforeDelete(ctx, request); err != nil {
-			logger.Error(err, "Error in BeforeDelete Validation", "error", err, "api_msg_tag", "Delete{{.KindName}}")
-			metric.Counter("fail").Inc(1)
-			return nil, err
-		}
-
-	}
+    for _, hook := range c.apiHooks {
+        if err = hook.BeforeDelete(ctx, request); err != nil {
+            logger.Error(err, "Error in BeforeDelete API hook", "error", err, "api_msg_tag", "Delete{{.KindName}}")
+            metric.Counter("fail").Inc(1)
+            return nil, err
+        }
+    }
 
 	err = c.apiHandler.Delete(ctx, deleteObj, deleteOptions)
 
@@ -384,9 +388,9 @@ func (c {{.LowerKindName}}ServiceHandler) Delete{{.KindName}}(ctx context.Contex
 		return nil, err
 	}
 
-	if {{.KindName}}ApiHook != nil {
-		{{.KindName}}ApiHook.OnDeleteSuccess(ctx, request)
-	}
+    for _, hook := range c.apiHooks {
+        hook.OnDeleteSuccess(ctx, request)
+    }
 
 	logger.Info("Delete{{.KindName}} Request Successfully Completed.", "api_msg_tag", "Delete{{.KindName}}")
 
@@ -394,7 +398,8 @@ func (c {{.LowerKindName}}ServiceHandler) Delete{{.KindName}}(ctx context.Contex
 	return &Delete{{.KindName}}Response{}, nil
 }
 
-func (c {{.LowerKindName}}ServiceHandler) Delete{{.KindName}}Collection(ctx context.Context, request *Delete{{.KindName}}CollectionRequest) (resp *Delete{{.KindName}}CollectionResponse, err error) {
+func (c {{.LowerKindName}}ServiceHandler) Delete{{.KindName}}Collection(
+	ctx context.Context, request *Delete{{.KindName}}CollectionRequest) (resp *Delete{{.KindName}}CollectionResponse, err error) {
 	logger := logging.GetLogrLoggerOrPanic()
 	requestJSON := logging.MarshalToString(request)
 
@@ -418,9 +423,7 @@ func (c {{.LowerKindName}}ServiceHandler) Delete{{.KindName}}Collection(ctx cont
 	userAuthenticated, err := c.auth.UserAuthenticated(ctx)
 	if !userAuthenticated {
 		logger.Error(err, "User is not authenticated")
-		if Emit{{.KindName}}WriteMetric == nil {
-			metric.Counter("unauthenticated").Inc(1)
-		}
+		metric.Counter("unauthenticated").Inc(1)
 		return nil, err
 	}
 
@@ -430,9 +433,7 @@ func (c {{.LowerKindName}}ServiceHandler) Delete{{.KindName}}Collection(ctx cont
 
 	if !userAuthorized {
 		logger.Error(err, "User is not authorized")
-		if Emit{{.KindName}}WriteMetric == nil {
-			metric.Counter("unauthorized").Inc(1)
-		}
+		metric.Counter("unauthorized").Inc(1)
 		return nil, err
 	}
 
@@ -446,13 +447,12 @@ func (c {{.LowerKindName}}ServiceHandler) Delete{{.KindName}}Collection(ctx cont
 		listOptions = request.ListOptions
 	}
 
-	if {{.KindName}}ApiHook != nil {
-		if err = {{.KindName}}ApiHook.BeforeDeleteCollection(ctx, request); err != nil {
-			logger.Error(err, "Error in BeforeDeleteCollection Validation", "error", err, "api_msg_tag", "Delete{{.KindName}}Collection")
+	for _, hook := range c.apiHooks {
+		if err = hook.BeforeDeleteCollection(ctx, request); err != nil {
+		 	logger.Error(err, "Error in BeforeDeleteCollection", "error", err, "api_msg_tag", "Delete{{.KindName}}Collection")
 			metric.Counter("fail").Inc(1)
 			return nil, err
 		}
-
 	}
 
 	err = c.apiHandler.DeleteCollection(ctx, &{{.KindName}}{}, request.Namespace, deleteOptions, listOptions)
@@ -463,9 +463,9 @@ func (c {{.LowerKindName}}ServiceHandler) Delete{{.KindName}}Collection(ctx cont
 		return nil, err
 	}
 
-	if {{.KindName}}ApiHook != nil {
-		{{.KindName}}ApiHook.OnDeleteCollectionSuccess(ctx, request)
-	}
+    for _, hook := range c.apiHooks {
+        hook.OnDeleteCollectionSuccess(ctx, request)
+    }
 
 	logger.Info("Delete{{.KindName}}Collection Request Successfully Completed.", "api_msg_tag", "Delete{{.KindName}}Collection")
 
@@ -473,7 +473,8 @@ func (c {{.LowerKindName}}ServiceHandler) Delete{{.KindName}}Collection(ctx cont
 	return &Delete{{.KindName}}CollectionResponse{}, nil
 }
 
-func (c {{.LowerKindName}}ServiceHandler) List{{.KindName}}(ctx context.Context, request *List{{.KindName}}Request) (resp *List{{.KindName}}Response, err error) {
+func (c {{.LowerKindName}}ServiceHandler) List{{.KindName}}(
+	ctx context.Context, request *List{{.KindName}}Request) (resp *List{{.KindName}}Response, err error) {
 
 	logger := logging.GetLogrLoggerOrPanic()
 	requestJSON := logging.MarshalToString(request)
@@ -524,7 +525,8 @@ func (c {{.LowerKindName}}ServiceHandler) List{{.KindName}}(ctx context.Context,
 	return resp, err
 }
 
-func (c {{.LowerKindName}}ServiceHandler) buildAuditLogEvent(ctx context.Context, procedure string, entityType string, requestNamespace string, requestName string, request interface{}, response interface{}, grpcErr error) *logging.AuditLogEvent {
+func (c {{.LowerKindName}}ServiceHandler) buildAuditLogEvent(
+	ctx context.Context, procedure string, entityType string, requestNamespace string, requestName string, request interface{}, response interface{}, grpcErr error) *logging.AuditLogEvent {
 	requestJSON := logging.MarshalToString(request)
 	responseJSON := logging.MarshalToString(response)
 	errMsg := ""
@@ -545,7 +547,11 @@ func (c {{.LowerKindName}}ServiceHandler) buildAuditLogEvent(ctx context.Context
 	return event
 }
 
-func (c {{.LowerKindName}}ServiceHandler) build{{.KindName}}AuditLogEventForCreate(ctx context.Context, request *Create{{.KindName}}Request, response *Create{{.KindName}}Response, grpcErr error) *logging.AuditLogEvent {
+func (c {{.LowerKindName}}ServiceHandler) build{{.KindName}}AuditLogEventForCreate(
+	ctx context.Context,
+	request *Create{{.KindName}}Request,
+	response *Create{{.KindName}}Response,
+	grpcErr error) *logging.AuditLogEvent {
 	requestNamespace := request.{{.KindName}}.ObjectMeta.Namespace
 	requestName := request.{{.KindName}}.ObjectMeta.Name
 	entityType := "{{.KindName}}"
@@ -553,7 +559,9 @@ func (c {{.LowerKindName}}ServiceHandler) build{{.KindName}}AuditLogEventForCrea
 	return c.buildAuditLogEvent(ctx, procedure, entityType, requestNamespace, requestName, request, response, grpcErr)
 }
 
-func (c {{.LowerKindName}}ServiceHandler) build{{.KindName}}AuditLogEventForGet(ctx context.Context, request *Get{{.KindName}}Request, response *Get{{.KindName}}Response, grpcErr error) *logging.AuditLogEvent {
+func (c {{.LowerKindName}}ServiceHandler) build{{.KindName}}AuditLogEventForGet(
+	ctx context.Context, request *Get{{.KindName}}Request,
+	response *Get{{.KindName}}Response, grpcErr error) *logging.AuditLogEvent {
 	requestNamespace := request.Namespace
 	requestName := request.Name
 	entityType := "{{.KindName}}"
@@ -562,7 +570,9 @@ func (c {{.LowerKindName}}ServiceHandler) build{{.KindName}}AuditLogEventForGet(
 
 }
 
-func (c {{.LowerKindName}}ServiceHandler) build{{.KindName}}AuditLogEventForUpdate(ctx context.Context, request *Update{{.KindName}}Request, response *Update{{.KindName}}Response, grpcErr error) *logging.AuditLogEvent {
+func (c {{.LowerKindName}}ServiceHandler) build{{.KindName}}AuditLogEventForUpdate(
+	ctx context.Context, request *Update{{.KindName}}Request,
+	response *Update{{.KindName}}Response, grpcErr error) *logging.AuditLogEvent {
 	requestNamespace := request.{{.KindName}}.ObjectMeta.Namespace
 	requestName := request.{{.KindName}}.ObjectMeta.Name
 	entityType := "{{.KindName}}"
@@ -589,7 +599,9 @@ func (c {{.LowerKindName}}ServiceHandler) build{{.KindName}}AuditLogEventForUpda
 	return event
 }
 
-func (c {{.LowerKindName}}ServiceHandler) build{{.KindName}}AuditLogEventForDelete(ctx context.Context, request *Delete{{.KindName}}Request, response *Delete{{.KindName}}Response, grpcErr error) *logging.AuditLogEvent {
+func (c {{.LowerKindName}}ServiceHandler) build{{.KindName}}AuditLogEventForDelete(
+	ctx context.Context, request *Delete{{.KindName}}Request,
+	response *Delete{{.KindName}}Response, grpcErr error) *logging.AuditLogEvent {
 	requestNamespace := request.Namespace
 	requestName := request.Name
 	entityType := "{{.KindName}}"
@@ -616,7 +628,9 @@ func (c {{.LowerKindName}}ServiceHandler) build{{.KindName}}AuditLogEventForDele
 
 }
 
-func (c {{.LowerKindName}}ServiceHandler) build{{.KindName}}AuditLogEventForDeleteCollection(ctx context.Context, request *Delete{{.KindName}}CollectionRequest, response *Delete{{.KindName}}CollectionResponse, grpcErr error) *logging.AuditLogEvent {
+func (c {{.LowerKindName}}ServiceHandler) build{{.KindName}}AuditLogEventForDeleteCollection(
+	ctx context.Context, request *Delete{{.KindName}}CollectionRequest,
+	response *Delete{{.KindName}}CollectionResponse, grpcErr error) *logging.AuditLogEvent {
 	requestNamespace := request.Namespace
 	requestName := ""
 	entityType := "{{.KindName}}"
@@ -624,7 +638,9 @@ func (c {{.LowerKindName}}ServiceHandler) build{{.KindName}}AuditLogEventForDele
 	return c.buildAuditLogEvent(ctx, procedure, entityType, requestNamespace, requestName, request, response, grpcErr)
 }
 
-func (c {{.LowerKindName}}ServiceHandler) build{{.KindName}}AuditLogEventForList(ctx context.Context, request *List{{.KindName}}Request, response *List{{.KindName}}Response, grpcErr error) *logging.AuditLogEvent {
+func (c {{.LowerKindName}}ServiceHandler) build{{.KindName}}AuditLogEventForList(
+	ctx context.Context, request *List{{.KindName}}Request,
+	response *List{{.KindName}}Response, grpcErr error) *logging.AuditLogEvent {
 	requestNamespace := request.Namespace
 	requestName := ""
 	entityType := "{{.KindName}}"

--- a/go/project/apihook/BUILD.bazel
+++ b/go/project/apihook/BUILD.bazel
@@ -1,0 +1,39 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["apihook.go"],
+    importpath = "github.com/michelangelo-ai/michelangelo/go/project/apihook",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//go/api:go_default_library",
+        "//proto/api/v2:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_client_go//kubernetes/typed/core/v1:go_default_library",
+        "@io_k8s_client_go//rest:go_default_library",
+        "@org_golang_google_grpc//codes:go_default_library",
+        "@org_golang_google_grpc//status:go_default_library",
+        "@org_uber_go_fx//:go_default_library",
+        "@org_uber_go_zap//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["apihook_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//proto/api/v2:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime:go_default_library",
+        "@io_k8s_client_go//kubernetes/fake:go_default_library",
+        "@io_k8s_client_go//kubernetes/typed/core/v1:go_default_library",
+        "@io_k8s_client_go//rest:go_default_library",
+        "@io_k8s_client_go//testing:go_default_library",
+        "@org_uber_go_zap//:go_default_library",
+    ],
+)

--- a/go/project/apihook/apihook.go
+++ b/go/project/apihook/apihook.go
@@ -2,6 +2,8 @@ package apihook
 
 import (
 	"context"
+	"strings"
+
 	"github.com/michelangelo-ai/michelangelo/go/api"
 	v2 "github.com/michelangelo-ai/michelangelo/proto/api/v2"
 	"go.uber.org/fx"
@@ -13,7 +15,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sCoreClient "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
-	"strings"
 )
 
 const (

--- a/go/project/apihook/apihook.go
+++ b/go/project/apihook/apihook.go
@@ -54,11 +54,16 @@ type apiHook struct {
 func (a apiHook) BeforeCreate(ctx context.Context, request *v2.CreateProjectRequest) error {
 	// Validate the request
 	if request.Project.Namespace != _integrationTestNamespace && request.Project.Name != request.Project.Namespace {
-		return status.Errorf(codes.InvalidArgument, "project name and namespace cannot be different")
+		return status.Errorf(codes.InvalidArgument,
+			"project name <%s> is different from namespace name <%s>. Project name must be the same as namespace name.",
+			request.Project.Name,
+			request.Project.Namespace)
 	}
 
 	if request.Project.Namespace == _defaultNamespace || strings.HasPrefix(request.Project.Namespace, _systemNamespacePrefix) {
-		return status.Errorf(codes.PermissionDenied, "users are forbidden to create project in default or system namespace")
+		return status.Errorf(codes.PermissionDenied,
+			"namespace <%s> is invalid. Users are forbidden to create projects in default or system namespace",
+			request.Project.Namespace)
 	}
 
 	// Create namespace

--- a/go/project/apihook/apihook.go
+++ b/go/project/apihook/apihook.go
@@ -1,0 +1,88 @@
+package apihook
+
+import (
+	"context"
+	"github.com/michelangelo-ai/michelangelo/go/api"
+	v2 "github.com/michelangelo-ai/michelangelo/proto/api/v2"
+	"go.uber.org/fx"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	corev1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sCoreClient "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+	"strings"
+)
+
+const (
+	_defaultNamespace         = "default"
+	_integrationTestNamespace = "ma-integration-test"
+	_systemNamespacePrefix    = "kube-"
+)
+
+type FxProjectAPIHookResult struct {
+	fx.Out
+	APIHook v2.ProjectAPIHook `group:"apiHooks"`
+}
+
+// GetProjectAPIHook returns the API hook for Project
+func GetProjectAPIHook(logger *zap.Logger, apiHandler api.Handler, k8sRestConfig *rest.Config) (FxProjectAPIHookResult, error) {
+	k8sClient, err := k8sCoreClient.NewForConfig(k8sRestConfig)
+	if err != nil {
+		return FxProjectAPIHookResult{}, err
+	}
+	return FxProjectAPIHookResult{
+		APIHook: apiHook{
+			logger:     logger,
+			apiHandler: apiHandler,
+			k8sClient:  k8sClient,
+		},
+	}, nil
+}
+
+type apiHook struct {
+	v2.NoopProjectAPIHook
+	logger     *zap.Logger
+	apiHandler api.Handler
+	k8sClient  k8sCoreClient.CoreV1Interface
+}
+
+// BeforeCreate creates a new namespace of the same name before creating a project
+func (a apiHook) BeforeCreate(ctx context.Context, request *v2.CreateProjectRequest) error {
+	// Validate the request
+	if request.Project.Namespace != _integrationTestNamespace && request.Project.Name != request.Project.Namespace {
+		return status.Errorf(codes.InvalidArgument, "project name and namespace cannot be different")
+	}
+
+	if request.Project.Namespace == _defaultNamespace || strings.HasPrefix(request.Project.Namespace, _systemNamespacePrefix) {
+		return status.Errorf(codes.PermissionDenied, "users are forbidden to create project in default or system namespace")
+	}
+
+	// Create namespace
+	namespace := corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "namespace",
+			APIVersion: "core/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: request.Project.Namespace,
+		},
+		Spec: corev1.NamespaceSpec{},
+	}
+	resp, err := a.k8sClient.Namespaces().Create(ctx, &namespace, metav1.CreateOptions{})
+
+	// if namespace already exist, we continue with project creation
+	if k8sErrors.IsAlreadyExists(err) {
+		a.logger.Info("Namespace already exists.")
+		return nil
+	}
+	if err != nil {
+		a.logger.Error("Fail to create namespace", zap.Error(err))
+		return api.K8sError2GrpcError(err, "failed to create namespace")
+	}
+
+	a.logger.Info("Successfully create namespace", zap.String("namespace", request.Project.Namespace), zap.Any("response", resp))
+	return nil
+}

--- a/go/project/apihook/apihook_test.go
+++ b/go/project/apihook/apihook_test.go
@@ -112,7 +112,9 @@ func TestCreateProject(t *testing.T) {
 			},
 			setup: nil,
 			assert: func(t *testing.T, err error, client k8sCoreClient.CoreV1Interface) {
-				assert.Error(t, err, "project name and namespace cannot be different")
+				assert.Error(t, err)
+				assert.ErrorContains(t, err,
+					"project name <test_project> is different from namespace name <test>. Project name must be the same as namespace name.")
 			},
 		},
 		{
@@ -136,7 +138,9 @@ func TestCreateProject(t *testing.T) {
 			},
 			setup: nil,
 			assert: func(t *testing.T, err error, client k8sCoreClient.CoreV1Interface) {
-				assert.Error(t, err, "users are forbidden to create project in default or system namespace")
+				assert.Error(t, err)
+				assert.ErrorContains(t, err,
+					"namespace <default> is invalid. Users are forbidden to create projects in default or system namespace")
 			},
 		},
 	}

--- a/go/project/apihook/apihook_test.go
+++ b/go/project/apihook/apihook_test.go
@@ -1,0 +1,169 @@
+package apihook
+
+import (
+	"context"
+	v2 "github.com/michelangelo-ai/michelangelo/proto/api/v2"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakek8sclient "k8s.io/client-go/kubernetes/fake"
+	k8sCoreClient "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+	k8stesting "k8s.io/client-go/testing"
+	"testing"
+)
+
+func TestCreateProject(t *testing.T) {
+	request := &v2.CreateProjectRequest{
+		Project: &v2.Project{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "test",
+				Namespace: "test",
+			},
+			Spec: v2.ProjectSpec{
+				Tier:        2,
+				Description: "unit test project",
+				RootDir:     "/test-dir",
+				Owner: &v2.OwnerInfo{
+					OwningTeam: "1234",
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name          string
+		expectedError bool
+		req           *v2.CreateProjectRequest
+		setup         func(client k8sCoreClient.CoreV1Interface, clientset *fakek8sclient.Clientset)
+		assert        func(t *testing.T, err error, client k8sCoreClient.CoreV1Interface)
+	}{
+		{
+			name:  "create new namespace",
+			req:   request,
+			setup: nil,
+			assert: func(t *testing.T, err error, client k8sCoreClient.CoreV1Interface) {
+				assert.NoError(t, err)
+				list, err := client.Namespaces().List(context.Background(), v1.ListOptions{})
+				assert.NoError(t, err)
+				assert.Len(t, list.Items, 1)
+				assert.Equal(t, "test", list.Items[0].Name)
+			},
+		},
+		{
+			name: "create a project with existing namespace",
+			req:  request,
+			setup: func(client k8sCoreClient.CoreV1Interface, _ *fakek8sclient.Clientset) {
+				namespace := corev1.Namespace{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "namespace",
+						APIVersion: "core/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: request.Project.Namespace,
+					},
+					Spec: corev1.NamespaceSpec{},
+				}
+				_, err := client.Namespaces().Create(context.Background(), &namespace, v1.CreateOptions{})
+				assert.NoError(t, err)
+			},
+			assert: func(t *testing.T, err error, client k8sCoreClient.CoreV1Interface) {
+				assert.NoError(t, err)
+				list, err := client.Namespaces().List(context.Background(), v1.ListOptions{})
+				assert.NoError(t, err)
+				assert.Len(t, list.Items, 1)
+				assert.Equal(t, "test", list.Items[0].Name)
+			},
+		},
+		{
+			name: "failed to create namespace",
+			req:  request,
+			setup: func(_ k8sCoreClient.CoreV1Interface, clientset *fakek8sclient.Clientset) {
+				clientset.PrependReactor("create", "namespaces", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, nil, assert.AnError
+				})
+			},
+			assert: func(t *testing.T, err error, client k8sCoreClient.CoreV1Interface) {
+				assert.Error(t, err, "failed to create namespace: assert.AnError general error for testing")
+			},
+		},
+		{
+			name:          "create project with a name different from namespace throws error",
+			expectedError: true,
+			req: &v2.CreateProjectRequest{
+				Project: &v2.Project{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "test_project",
+						Namespace: "test",
+					},
+					Spec: v2.ProjectSpec{
+						Tier:        2,
+						Description: "unit test project",
+						RootDir:     "/test-dir",
+						Owner: &v2.OwnerInfo{
+							OwningTeam: "1234",
+						},
+					},
+				},
+			},
+			setup: nil,
+			assert: func(t *testing.T, err error, client k8sCoreClient.CoreV1Interface) {
+				assert.Error(t, err, "project name and namespace cannot be different")
+			},
+		},
+		{
+			name:          "create project with name = 'default' throws error",
+			expectedError: true,
+			req: &v2.CreateProjectRequest{
+				Project: &v2.Project{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "default",
+						Namespace: "default",
+					},
+					Spec: v2.ProjectSpec{
+						Tier:        2,
+						Description: "unit test project",
+						RootDir:     "/test-dir",
+						Owner: &v2.OwnerInfo{
+							OwningTeam: "1234",
+						},
+					},
+				},
+			},
+			setup: nil,
+			assert: func(t *testing.T, err error, client k8sCoreClient.CoreV1Interface) {
+				assert.Error(t, err, "users are forbidden to create project in default or system namespace")
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			clientSet := fakek8sclient.NewClientset()
+			client := clientSet.CoreV1()
+			fakeAPIHook := apiHook{
+				logger:     zap.NewNop(),
+				apiHandler: nil,
+				k8sClient:  client,
+			}
+
+			if tc.setup != nil {
+				tc.setup(client, clientSet)
+			}
+			err := fakeAPIHook.BeforeCreate(context.Background(), tc.req)
+			tc.assert(t, err, client)
+		})
+	}
+}
+
+func TestGetProjectAPIHook(t *testing.T) {
+	logger := zap.NewNop()
+	k8sRestConfig := &rest.Config{}
+	result, err := GetProjectAPIHook(logger, nil, k8sRestConfig)
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.NotNil(t, result.APIHook)
+}

--- a/go/project/apihook/apihook_test.go
+++ b/go/project/apihook/apihook_test.go
@@ -2,6 +2,8 @@ package apihook
 
 import (
 	"context"
+	"testing"
+
 	v2 "github.com/michelangelo-ai/michelangelo/proto/api/v2"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
@@ -13,7 +15,6 @@ import (
 	k8sCoreClient "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	k8stesting "k8s.io/client-go/testing"
-	"testing"
 )
 
 func TestCreateProject(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [X] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
1. Modify api hook interface, allowing multiple api hooks on each CRD type
2. Remove Emit{{.KindName}}WriteMetric
3. Add a project api hook to create the corresponding namespace

<!-- Tell your future self why have you made these changes -->
**Why?**
1. Each CRD type may need 3 or more api hooks: 1) api hook in oss repo that is needed by both Uber and OSS users, 2) api hook in uber internal repo that handles uber specific logic, 3) api hook added by open source users to custom michelangelo for their own use cases
2. Emit{{.KindName}}WriteMetric was added to emit some type specific metrics. The generated metrics are never used. Remove this logic to keep the code simple and clean
3. Each Michelangelo project corresponding to a namespace of the same name. All the objects of this project will be in this namespace.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested locally using python client

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
We will need a user doc for how to develop CRD types, api hooks, and controllers
