### PR TITLE
fix ray issue when downgraded to v1.0

### DIFF
--- a/go/controllers/rayjob/BUILD.bazel
+++ b/go/controllers/rayjob/BUILD.bazel
@@ -38,6 +38,7 @@ go_test(
         "@com_github_ray_project_kuberay_ray_operator//pkg/client/clientset/versioned/typed/ray/v1/fake:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_apimachinery//pkg/types:go_default_library",

--- a/go/controllers/rayjob/controller.go
+++ b/go/controllers/rayjob/controller.go
@@ -145,6 +145,10 @@ func (r *Reconciler) Register(mgr ctrl.Manager) error {
 }
 
 func (r *Reconciler) createJob(ctx context.Context, log logr.Logger, job *v2pb.RayJob, cluster *v2pb.RayCluster) error {
+	pod := cluster.Spec.Head.Pod
+	if len(cluster.Spec.Workers) > 0 {
+		pod = cluster.Spec.Workers[0].Pod
+	}
 	rayJob := &v1.RayJob{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "RayJob",
@@ -160,7 +164,10 @@ func (r *Reconciler) createJob(ctx context.Context, log logr.Logger, job *v2pb.R
 				"rayClusterNamespace": cluster.Namespace,
 			},
 			Entrypoint: job.Spec.Entrypoint,
-			// TODO: SubmissionMode
+			// kuberay 1.0 only support SubmitterPodTemplate for configuration submitter pod
+			// We need to allow user to configure the submitter pod template via ray task configuration
+			// TODO: add support for v1.2.2 kuberay once we upgrade to newer version
+			SubmitterPodTemplate: pod,
 		},
 	}
 

--- a/go/controllers/rayjob/controller_test.go
+++ b/go/controllers/rayjob/controller_test.go
@@ -13,6 +13,7 @@ import (
 	v1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	rayv1fake "github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned/typed/ray/v1/fake"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -167,6 +168,15 @@ func TestReconciler_Reconcile(t *testing.T) {
 					Status: v2pb.RayClusterStatus{
 						State: v2pb.RAY_CLUSTER_STATE_READY,
 					},
+					Spec: v2pb.RayClusterSpec{
+						Head: &v2pb.RayHeadSpec{
+							Pod: &corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{},
+								},
+							},
+						},
+					},
 				}
 				objects = append(objects, rayJob)
 				objects = append(objects, cluster)
@@ -203,6 +213,15 @@ func TestReconciler_Reconcile(t *testing.T) {
 					},
 					Status: v2pb.RayClusterStatus{
 						State: v2pb.RAY_CLUSTER_STATE_READY,
+					},
+					Spec: v2pb.RayClusterSpec{
+						Head: &v2pb.RayHeadSpec{
+							Pod: &corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{},
+								},
+							},
+						},
 					},
 				}
 				objects = append(objects, rayJob)

--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -126,7 +126,7 @@ Be aware that CR_PAT environment variable is required while Michelangelo is NOT 
     for r in resources:
         _kube_create(_dir / "resources" / r)
 
-    _exec("kubectl", "create", "-k", "github.com/ray-project/kuberay/ray-operator/config/default?ref=v1.2.2")
+    _exec("kubectl", "create", "-k", "github.com/ray-project/kuberay/ray-operator/config/default?ref=v1.0.0")
 
     _exec("kubectl", "wait", "--all", "pods", "--for=condition=ready", "--timeout=600s")
     _exec("kubectl", "-n", "ray-system", "wait", "--all", "deployments", "--for=condition=available", "--timeout=600s")

--- a/python/michelangelo/uniflow/plugins/ray/task.star
+++ b/python/michelangelo/uniflow/plugins/ray/task.star
@@ -366,8 +366,8 @@ def ray_cluster_spec(
             },
             "workers": [
                 {
-                    "minInstances": worker_instances,  # Keeping original variable
-                    "maxInstances": worker_instances,  # Keeping original variable
+                    "minInstances": worker_instances,
+                    "maxInstances": worker_instances,
                     "nodeType": "worker-group-1",
                     "objectStoreMemoryRatio": 0.0,
                     "rayStartParams": {
@@ -376,13 +376,14 @@ def ray_cluster_spec(
                     },
                     "pod": {
                         "spec": {
+                            "restartPolicy": "Never",
                             "containers": [
                                 {
                                     "name": "worker",
                                     "resources": {
                                         "requests": worker_resource,
                                     },
-                                    "image": image,  # Keeping original variable
+                                    "image": image,
                                     "imagePullPolicy": IMAGE_PULL_POLICY,
                                     "env": env,
                                     "envFrom": [


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
Configure Submitter pod for ray job

<!-- Tell your future self why have you made these changes -->
**Why?**
When submission mode is not supported when we downgraded to KubeRay v1.0, we can only set the SubmitterPodTemplate for configuring submitter pod.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local cluster mode

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
We need to allow user to configure this in plugin later on

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
