### PR TITLE
Fix inline issue in protobuf UnmarshalJson method for array type

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -53,6 +53,7 @@ use_repo(
     "com_github_gogo_status",
     "com_github_golang_mock",
     "com_github_golang_protobuf",
+    "com_github_google_go_cmp",
     "com_github_google_uuid",
     "com_github_json_iterator_go",
     "com_github_michelangelo_ai_michelangelo_proto",

--- a/go/cmd/kubeproto/protoc-gen-kubeproto/BUILD.bazel
+++ b/go/cmd/kubeproto/protoc-gen-kubeproto/BUILD.bazel
@@ -38,7 +38,6 @@ go_test(
     embed = [":go_default_library"],
     embedsrcs = ["test/expected_go_code.txt"],
     deps = [
-        "//proto/api/v2:go_default_library",
         "//proto/test/kubeproto:go_default_library",
         "@com_github_dave_dst//:go_default_library",
         "@com_github_dave_dst//decorator:go_default_library",

--- a/go/cmd/kubeproto/protoc-gen-kubeproto/BUILD.bazel
+++ b/go/cmd/kubeproto/protoc-gen-kubeproto/BUILD.bazel
@@ -38,11 +38,13 @@ go_test(
     embed = [":go_default_library"],
     embedsrcs = ["test/expected_go_code.txt"],
     deps = [
+        "//proto/api/v2:go_default_library",
         "//proto/test/kubeproto:go_default_library",
         "@com_github_dave_dst//:go_default_library",
         "@com_github_dave_dst//decorator:go_default_library",
         "@com_github_gogo_protobuf//protoc-gen-gogo/plugin:go_default_library",
         "@com_github_gogo_protobuf//types:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/api/resource:go_default_library",

--- a/go/cmd/kubeproto/protoc-gen-kubeproto/main_test.go
+++ b/go/cmd/kubeproto/protoc-gen-kubeproto/main_test.go
@@ -4,12 +4,13 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
 	"go/token"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 

--- a/go/cmd/kubeproto/protoc-gen-kubeproto/main_test.go
+++ b/go/cmd/kubeproto/protoc-gen-kubeproto/main_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	_ "embed"
 	"encoding/json"
+	"fmt"
+	"github.com/google/go-cmp/cmp"
 	"go/token"
 	"reflect"
 	"strings"
@@ -312,6 +314,36 @@ func TestJSONPod(t *testing.T) {
 		Spec: testpb.TestObjectSpec{
 			Pod: &corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Command: []string{"/bin/sh"},
+							Image:   "alpine",
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									MountPath: "/var/www/html",
+									Name:      "www",
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "logs",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+						{
+							Name: "config",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "fluent-bit-config",
+									},
+								},
+							},
+						},
+					},
 					Containers: []corev1.Container{
 						{
 							Name:       "test-container",
@@ -368,6 +400,13 @@ func TestJSONPod(t *testing.T) {
 	json.Unmarshal(testObjectJSON, &testObjectUnmarshalled)
 	assert.Equal(t, testObjectUnmarshalled.Spec.Pod.Spec.Containers[0].EnvFrom[0].ConfigMapRef.LocalObjectReference.Name, "test")
 	assert.Equal(t, testObjectUnmarshalled.Spec.Pod.Spec.Containers[1].EnvFrom[0].ConfigMapRef.LocalObjectReference.Name, "test2")
+	assert.Equal(t, testObjectUnmarshalled.Spec.Pod.Spec.Volumes[1].VolumeSource.ConfigMap.LocalObjectReference.Name, "fluent-bit-config")
+	if diff := cmp.Diff(testObject, testObjectUnmarshalled); diff != "" {
+		fmt.Println("Mismatch (-origin +unmarshalled):")
+		fmt.Println(diff)
+	} else {
+		fmt.Println("✅ testObjectUnmarshalled is equal to originCluster")
+	}
 }
 func TestImmutability(t *testing.T) {
 	obj2 := &testpb.TestObject{}

--- a/go/go.mod
+++ b/go/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/gogo/status v1.1.0
 	github.com/golang/mock v1.7.0-rc.1
 	github.com/golang/protobuf v1.5.4
+	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/json-iterator/go v1.1.12
 	github.com/michelangelo-ai/michelangelo/proto v0.0.0-00010101000000-000000000000
@@ -63,7 +64,6 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.2.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/go/kubeproto/util/util.go
+++ b/go/kubeproto/util/util.go
@@ -332,7 +332,7 @@ func ApplyInlineFields(jsonData []byte, fields []InlineFieldMapping) ([]byte, er
 			}
 		}
 	}
-
+	// Iterate over each field mapping to apply the inline transformations.
 	for _, field := range fields {
 		var matchedResults []MatchedResult
 		resolvePath(jsonStr, fmt.Sprintf("%s.%s", field.Path, field.FieldToBeTrimmed), "", &matchedResults)
@@ -340,6 +340,7 @@ func ApplyInlineFields(jsonData []byte, fields []InlineFieldMapping) ([]byte, er
 		for _, match := range matchedResults {
 			var err error
 			if strings.HasSuffix(field.Path, ".#") {
+				// Array update for handling inline fields in array
 				// Get the full object at the matched path
 				original := gjson.Get(jsonStr, match.Path)
 				var obj map[string]interface{}

--- a/go/kubeproto/util/util.go
+++ b/go/kubeproto/util/util.go
@@ -1,10 +1,11 @@
 package util
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"regexp"
-	"strconv"
+	"sort"
 	"strings"
 
 	"github.com/tidwall/gjson"
@@ -175,8 +176,8 @@ func SetPackageAlias(file *dst.File, pkgPath string, newAlias string) {
 
 // InlineFieldMapping holds old and new paths for inline fields.
 type InlineFieldMapping struct {
-	OldPath string
-	NewPath string
+	Path             string
+	FieldToBeTrimmed string
 }
 
 // RemoveInlineFields identifies old and new JSON paths for inline fields.
@@ -221,10 +222,9 @@ func RemoveInlineFields(typ reflect.Type, currentPath string, visited map[reflec
 
 		oldPath := strings.TrimPrefix(currentPath+"."+fieldName, ".")
 		if jsonTag == ",inline" {
-			newFlattenedPath := strings.TrimPrefix(currentPath, ".")
 			*paths = append(*paths, InlineFieldMapping{
-				OldPath: oldPath,
-				NewPath: newFlattenedPath,
+				Path:             currentPath,
+				FieldToBeTrimmed: fieldName,
 			})
 		}
 		// Recursively process the field type
@@ -282,55 +282,107 @@ type MatchedResult struct {
 // - A byte slice containing the modified JSON data.
 // - An error if any issues occur during the processing.
 func ApplyInlineFields(jsonData []byte, fields []InlineFieldMapping) ([]byte, error) {
-	// Convert the JSON byte slice to a string for easier manipulation.
+	sort.Slice(fields, func(i, j int) bool {
+		return len(fields[i].Path) > len(fields[j].Path) // longest first
+	})
+
 	jsonStr := string(jsonData)
-
-	// Helper function to find matched paths with resolved indices.
-	var findMatchedPaths func(jsonStr, currentPath, resolvedPath string, results *[]MatchedResult)
-	findMatchedPaths = func(jsonStr, currentPath, resolvedPath string, results *[]MatchedResult) {
-		value := gjson.Get(jsonStr, currentPath)
-
-		// Check if the value is an array.
-		if value.IsArray() {
-			value.ForEach(func(index, item gjson.Result) bool {
-				nextPath := strings.Replace(currentPath, "#", strconv.Itoa(int(index.Int())), 1)
-				nextResolvedPath := strings.Replace(resolvedPath, "#", strconv.Itoa(int(index.Int())), 1)
-				findMatchedPaths(jsonStr, nextPath, nextResolvedPath, results)
-				return true
-			})
-		} else if value.IsObject() {
-			value.ForEach(func(key, item gjson.Result) bool {
-				nextPath := fmt.Sprintf("%s.%s", currentPath, key.Str)
-				nextResolvedPath := fmt.Sprintf("%s.%s", resolvedPath, key.Str)
-				findMatchedPaths(jsonStr, nextPath, nextResolvedPath, results)
-				return true
-			})
-		} else if value.Exists() {
-			*results = append(*results, MatchedResult{
-				Path:  resolvedPath,
-				Value: value,
-			})
+	var resolvePath func(jsonStr, path, resolvedOld string, results *[]MatchedResult)
+	resolvePath = func(jsonStr, path, currentResolved string, results *[]MatchedResult) {
+		tokens := strings.SplitN(path, ".", 2)
+		current := tokens[0]
+		rest := ""
+		if len(tokens) > 1 {
+			rest = tokens[1]
 		}
-	}
 
-	// Iterate over each field mapping to apply the inline transformations.
-	for _, field := range fields {
-		var matchedResults []MatchedResult
-		findMatchedPaths(jsonStr, field.OldPath, field.NewPath, &matchedResults)
+		// If current is a wildcard
+		if current == "#" {
+			array := gjson.Get(jsonStr, currentResolved)
+			if !array.IsArray() {
+				return
+			}
+			array.ForEach(func(index, item gjson.Result) bool {
+				nextPath := currentResolved
+				if nextPath != "" {
+					nextPath += "."
+				}
+				nextPath += fmt.Sprintf("%d", index.Int())
+				resolvePath(jsonStr, rest, nextPath, results)
+				return true
+			})
+		} else {
+			nextPath := currentResolved
+			if nextPath != "" {
+				nextPath += "."
+			}
+			nextPath += current
 
-		for _, match := range matchedResults {
-			// Construct the new path dynamically.
-			newPath := strings.Replace(match.Path, field.OldPath, field.NewPath, 1)
-
-			// Set the new value using sjson.
-			var err error
-			jsonStr, err = sjson.Set(jsonStr, newPath, match.Value.Value())
-			if err != nil {
-				return nil, err
+			if rest != "" {
+				resolvePath(jsonStr, rest, nextPath, results)
+			} else {
+				val := gjson.Get(jsonStr, nextPath)
+				lastDot := strings.LastIndex(nextPath, ".")
+				if val.Exists() && lastDot > 0 {
+					*results = append(*results, MatchedResult{
+						Path:  nextPath[:lastDot],
+						Value: val,
+					})
+				}
 			}
 		}
 	}
 
-	// Return the modified JSON data as a byte slice.
+	for _, field := range fields {
+		var matchedResults []MatchedResult
+		resolvePath(jsonStr, fmt.Sprintf("%s.%s", field.Path, field.FieldToBeTrimmed), "", &matchedResults)
+
+		for _, match := range matchedResults {
+			var err error
+			if strings.HasSuffix(field.Path, ".#") {
+				// Get the full object at the matched path
+				original := gjson.Get(jsonStr, match.Path)
+				var obj map[string]interface{}
+				if err = json.Unmarshal([]byte(original.Raw), &obj); err != nil {
+					return nil, err
+				}
+
+				// Apply match.Value to the existing object
+				var patch map[string]interface{}
+				if err = json.Unmarshal([]byte(match.Value.Raw), &patch); err != nil {
+					return nil, err
+				}
+				for k, v := range patch {
+					obj[k] = v // overwrite or add
+				}
+
+				// Marshal the updated object
+				updatedBytes, jErr := json.Marshal(obj)
+				if jErr != nil {
+					return nil, jErr
+				}
+
+				// Replace the full element at match.Path
+				jsonStr, err = sjson.SetRaw(jsonStr, match.Path, string(updatedBytes))
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				// Normal non-array update
+				jsonStr, err = sjson.SetRaw(jsonStr, match.Path, match.Value.Raw)
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+
 	return []byte(jsonStr), nil
+}
+
+func joinPath(prefix, token string) string {
+	if prefix == "" {
+		return token
+	}
+	return prefix + "." + token
 }

--- a/go/kubeproto/util/util.go
+++ b/go/kubeproto/util/util.go
@@ -380,10 +380,3 @@ func ApplyInlineFields(jsonData []byte, fields []InlineFieldMapping) ([]byte, er
 
 	return []byte(jsonStr), nil
 }
-
-func joinPath(prefix, token string) string {
-	if prefix == "" {
-		return token
-	}
-	return prefix + "." + token
-}

--- a/go/kubeproto/util/util_test.go
+++ b/go/kubeproto/util/util_test.go
@@ -64,6 +64,97 @@ func unmarshalDefaultAny(msg proto.Message, b []byte) error {
 	}).Unmarshal(bytes.NewReader(b), msg)
 }
 
+func TestApplyInlineFields(t *testing.T) {
+	tests := []struct {
+		name     string
+		jsonData []byte
+		fields   []util.InlineFieldMapping
+		want     []byte
+		wantErr  bool
+	}{
+		{
+			name: "simple inline field",
+			jsonData: []byte(`{
+                "name": "test",
+                "details": {
+                    "info": "data"
+                }
+            }`),
+			fields: []util.InlineFieldMapping{
+				{Path: "details", FieldToBeTrimmed: "info"},
+			},
+			want: []byte(`{
+                "name": "test",
+                "details": "data"
+            }`),
+			wantErr: false,
+		},
+		{
+			name: "nested inline field",
+			jsonData: []byte(`{
+                "name": "test",
+                "details": {
+                    "info": {
+                        "data": "value"
+                    }
+                }
+            }`),
+			fields: []util.InlineFieldMapping{
+				{Path: "details.info", FieldToBeTrimmed: "data"},
+			},
+			want: []byte(`{
+                "name": "test",
+                "details": {
+                    "info": "value"
+                }
+            }`),
+			wantErr: false,
+		},
+		{
+			name: "array inline field",
+			jsonData: []byte(`{
+                "items": [
+					{
+						"name": "test",
+						"details": {
+							"data": "value"
+						}
+					},
+					{
+						"name": "test2",
+						"details": {
+							"data": "value2"
+						}
+					}
+                ]
+            }`),
+			fields: []util.InlineFieldMapping{
+				{Path: "items.#", FieldToBeTrimmed: "details"},
+			},
+			want: []byte(`{
+                "items": [
+					{"data":"value","details":{"data":"value"},"name":"test"},
+					{"data":"value2","details":{"data":"value2"},"name":"test2"}
+                ]
+            }`),
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := util.ApplyInlineFields(tt.jsonData, tt.fields)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ApplyInlineFields() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !bytes.Equal(got, tt.want) {
+				t.Errorf("ApplyInlineFields() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestAnyMarshal(t *testing.T) {
 	const randomTestString = "ma2022"
 	const randomTestString2 = "ma20api"


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
Add fix to UnmarshalJSON method for handling array type. The volumes in PodTemplateSpec has inline for its element.

<!-- Tell your future self why have you made these changes -->
**Why?**
The current unmarshalJSON doesn't work with array type inline.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test and local cluster run

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
