### PR TITLE
fix enum json unmarshal

### DIFF
--- a/go/kubeproto/templates/BUILD.bazel
+++ b/go/kubeproto/templates/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "mysql_label_annotation_tables.tmpl",
         "mysql_main_table_columns.tmpl",
         "mysql_main_table_indices.tmpl",
+        "unmarshal_enum.tmpl",
     ],
     importpath = "github.com/michelangelo-ai/michelangelo/go/kubeproto/templates",
     visibility = ["//visibility:public"],

--- a/go/kubeproto/templates/templates.go
+++ b/go/kubeproto/templates/templates.go
@@ -47,23 +47,11 @@ var CRDHasBlobFields = template.Must(template.New("crdHasBlobFields").Parse(`fun
 }
 `))
 
+//go:embed unmarshal_enum.tmpl
+var unmarshalEnum string
+
 // CRDUnmarshalEnum is a template for the HasEnumFields() function.
-var CRDUnmarshalEnum = template.Must(template.New("unmarshalJSON").Parse(`func (m *{{.EnumTypeName}}) UnmarshalJSON(b []byte) error {
-	var s string
-    err := json.Unmarshal(b, &s)
-	if err != nil {
-		return err
-	}
-	// Check if the string exists in the map
-	val, exists := {{.EnumTypeName}}_value[s]
-	if !exists {
-		return fmt.Errorf("invalid DataType: %s", s)
-	}
-	
-	*m = {{.EnumTypeName}}(val)
-	return nil
-}
-`))
+var CRDUnmarshalEnum = template.Must(template.New("unmarshalJSON").Parse(unmarshalEnum))
 
 // CRDClearBlobFieldsHeader is a template of the ClearBlobFields() function signature
 var CRDClearBlobFieldsHeader = template.Must(template.New("crdClearBlobFields").Parse(`func (m *{{.Name}}) ClearBlobFields() {

--- a/go/kubeproto/templates/unmarshal_enum.tmpl
+++ b/go/kubeproto/templates/unmarshal_enum.tmpl
@@ -10,7 +10,7 @@ func (m *{{.EnumTypeName}}) UnmarshalJSON(b []byte) error {
 		return nil
 	}
 	var s string
-    err = json.Unmarshal(b, &s)
+	err = json.Unmarshal(b, &s)
 	if err != nil {
 		return err
 	}

--- a/go/kubeproto/templates/unmarshal_enum.tmpl
+++ b/go/kubeproto/templates/unmarshal_enum.tmpl
@@ -1,0 +1,25 @@
+// UnmarshalJSON unmarshals a JSON value into a {{.EnumTypeName}}.
+// Since {{.EnumTypeName}} is an integer in go, the standard JSON encoder marshals it as a number.
+// But as a protobuf enum, it is marshaled as a string. In different situations, a {{.EnumTypeName}} value
+// may be marshaled as either a number or a string. This function allows unmarshalling from both formats.
+func (m *{{.EnumTypeName}}) UnmarshalJSON(b []byte) error {
+	var num int32
+	err := json.Unmarshal(b, &num)
+	if err == nil {
+		*m = {{.EnumTypeName}}(num)
+		return nil
+	}
+	var s string
+    err = json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	// Check if the string exists in the map
+	val, exists := {{.EnumTypeName}}_value[s]
+	if !exists {
+		return fmt.Errorf("invalid DataType: %s", s)
+	}
+
+	*m = {{.EnumTypeName}}(val)
+	return nil
+}


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
Allow UnmarshalJSON() method of protobuf enum types unmarshalling from both integer and string

<!-- Tell your future self why have you made these changes -->
**Why?**
Protobuf enum types are marshaled as JSON string
But when the type is marshaled directly with encoding/json, it's marshaled as an integer
This fix allows unmarshalling from either form

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
