### PR TITLE
Onboard Michelangelo Studio to react-router

### DIFF
--- a/javascript/packages/core/package.json
+++ b/javascript/packages/core/package.json
@@ -11,9 +11,13 @@
     "@bufbuild/protobuf": "^2.2.5",
     "@connectrpc/connect": "^2.0.2",
     "@connectrpc/connect-web": "^2.0.2",
+    "@types/pluralize": "^0.0.33",
     "baseui": "^0.0.0-next-2113e1821",
+    "pluralize": "^8.0.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
+    "react-router": "6.29.0",
+    "react-router-dom": "6.29.0",
     "styletron-engine-monolithic": "^1.0.0",
     "styletron-react": "^6.1.1"
   },

--- a/javascript/packages/core/src/components/views/project/project-detail.tsx
+++ b/javascript/packages/core/src/components/views/project/project-detail.tsx
@@ -1,0 +1,46 @@
+import { useEffect } from 'react';
+import { useState } from 'react';
+import { createClient, Interceptor } from '@connectrpc/connect';
+import { createGrpcWebTransport } from '@connectrpc/connect-web';
+
+import { Project } from '@ma/gen-api/v2/project_pb';
+import { ProjectService } from '@ma/gen-api/v2/project_svc_pb';
+import { useStudioParams } from '@/hooks/routing/use-studio-params/use-studio-params';
+
+export function ProjectDetail() {
+  const [project, setProject] = useState<Project>();
+  const { projectId } = useStudioParams('base');
+
+  useEffect(() => {
+    const getProject = async () => {
+      const callerInterceptor: Interceptor = (next) => async (req) => {
+        req.header.set('context-Ttl-Ms', '10000');
+        req.header.set('grpc-timeout', '1000000m');
+        req.header.set('Rpc-Caller', 'ma-studio');
+        req.header.set('Rpc-Encoding', 'proto');
+        req.header.set('Rpc-Service', 'ma-apiserver');
+
+        return await next(req);
+      };
+
+      const transport = createGrpcWebTransport({
+        baseUrl: 'http://localhost:8081',
+        interceptors: [callerInterceptor],
+        useBinaryFormat: true,
+      });
+
+      const client = createClient(ProjectService, transport);
+      const projectResponse = await client.getProject({
+        name: projectId,
+        namespace: projectId,
+      });
+      setProject(projectResponse.project);
+    };
+
+    getProject().catch((error) => {
+      console.error('Error getting project:', error);
+    });
+  }, [projectId]);
+
+  return <div>{project?.metadata?.name}</div>;
+}

--- a/javascript/packages/core/src/hooks/routing/use-studio-params/constants.ts
+++ b/javascript/packages/core/src/hooks/routing/use-studio-params/constants.ts
@@ -1,0 +1,83 @@
+import type { ParamsTransformer, StudioParamsView } from './types';
+
+/**
+ * A mapping of view types to their corresponding parameter transformers.
+ * Each transformer is responsible for converting base parameters into the
+ * specific parameter type required by that view.
+ *
+ * The transformers handle three types of parameters:
+ * 1. Base parameters (entity, phase, projectId)
+ * 2. Route parameters from the URL path
+ * 3. Query parameters from the URL search string
+ *
+ * @remarks
+ * While the underlying view type should assume existence of the parameters, the
+ * transformers provide fallback values to ensure that the parameters are correctly
+ * typed and normalized.
+ *
+ * For example, a Schema Driven UI detail view should _always_ have an entityId. But
+ * the URL parsing does not guarantee entityId's existence. Consequently, the
+ * detail view transformer provides a fallback entityId value of an empty string.
+ *
+ * @example
+ * ```typescript
+ * // Transform parameters for a form view
+ * const formParams = VIEW_TYPE_TO_PARAMS.form(
+ *   baseParams,
+ *   { entityId: 'model-123' },
+ *   { entitySubType: 'pipeline' }
+ * );
+ *
+ * // Transform parameters for a detail view
+ * const detailParams = VIEW_TYPE_TO_PARAMS.detail(
+ *   baseParams,
+ *   { entityId: 'model-123', entityTab: 'overview' },
+ *   { revisionId: 'rev-456' }
+ * );
+ * ```
+ *
+ * @see {@link ParamsTransformer} for the transformer function type
+ * @see {@link StudioParamsViewType} for all available view types
+ */
+export const VIEW_TYPE_TO_PARAMS: Record<StudioParamsView, ParamsTransformer<StudioParamsView>> = {
+  form: (routeParams, queryParams) => ({
+    phase: routeParams.phase!,
+    projectId: routeParams.projectId!,
+    entity: routeParams.entity!,
+    entityId: routeParams.entityId!,
+    entitySubType: queryParams.entitySubType,
+    revisionId: queryParams.revisionId,
+  }),
+  detail: (routeParams, queryParams) => ({
+    phase: routeParams.phase!,
+    projectId: routeParams.projectId!,
+    entity: routeParams.entity!,
+    entityId: routeParams.entityId!,
+    entityTab: routeParams.entityTab!,
+    revisionId: queryParams.revisionId,
+    pipelineName: queryParams.pipelineName,
+  }),
+  list: (routeParams) => ({
+    phase: routeParams.phase!,
+    entity: routeParams.entity!,
+    projectId: routeParams.projectId!,
+  }),
+  'form-detail': (routeParams, queryParams) => ({
+    phase: routeParams.phase!,
+    projectId: routeParams.projectId!,
+    entity: routeParams.entity!,
+    entityId: routeParams.entityId!,
+    entityTab: routeParams.entityTab,
+    entitySubType: queryParams.entitySubType,
+    revisionId: queryParams.revisionId,
+    pipelineName: queryParams.pipelineName,
+  }),
+  base: (routeParams, queryParams) => ({
+    ...routeParams,
+    ...queryParams,
+  }),
+  unregistered: (routeParams, queryParams) => ({
+    ...routeParams,
+    ...queryParams,
+  }),
+};

--- a/javascript/packages/core/src/hooks/routing/use-studio-params/normalize-entity-param.ts
+++ b/javascript/packages/core/src/hooks/routing/use-studio-params/normalize-entity-param.ts
@@ -1,0 +1,27 @@
+import pluralize from 'pluralize';
+
+import { StudioParamsBase } from '@/hooks/routing/use-studio-params/types';
+
+const ALWAYS_SINGULAR_ENTITIES = [
+  'model-performance',
+  'feature-consistency',
+  'model-excellence-score',
+  'offline-feature-quality',
+  'fairness-estimator',
+  'data-quality',
+  'chat',
+];
+
+export function normalizeEntityParam(params: Partial<StudioParamsBase>): Partial<StudioParamsBase> {
+  const entity = params.entity;
+
+  if (!entity || entity === '') {
+    return params;
+  }
+
+  if (ALWAYS_SINGULAR_ENTITIES.some((e) => entity === e)) {
+    return params;
+  }
+
+  return { ...params, entity: pluralize(entity) };
+}

--- a/javascript/packages/core/src/hooks/routing/use-studio-params/types.ts
+++ b/javascript/packages/core/src/hooks/routing/use-studio-params/types.ts
@@ -1,0 +1,155 @@
+import { Phase } from '@/types/common/studio-types';
+import { View } from '@/types/common/view-types';
+
+/**
+ * Parameters that can be extracted from the route path. These parameters
+ * should be available in the Routes registered to the application's router.
+ */
+export type RouteParams = {
+  /** The entity identifier (e.g., 'model', 'experiment') */
+  entity: string;
+  /** The specific ID of the entity being viewed */
+  entityId: string;
+  /** The current tab being viewed for the entity */
+  entityTab: string;
+  /** The current phase of the project (e.g., 'train', 'deploy') */
+  phase: Phase;
+  /** The ID of the project being viewed */
+  projectId: string;
+  /**
+   * The ID of the revision being viewed. revisionId is only available in RouteParams
+   * for project forms. For other forms, the revision ID is extracted from the query params.
+   */
+  revisionId: string;
+};
+
+/**
+ * Parameters that can be extracted from the URL query string.
+ */
+export type QueryParams = {
+  /** The subtype of the entity being viewed (e.g., specific pipeline type) */
+  entitySubType: string;
+  /** The ID of a specific revision being viewed */
+  revisionId: string;
+
+  /**
+   * Non-standardized query params. This allows for useStudioParams callers
+   * to access query params that are unique to their use case and should not
+   * be relied on globally.
+   */
+  [key: string]: string;
+};
+
+/**
+ * Base parameters required for all studio views. A base studio view
+ * is a view defined within the Schema Driven UI. These views are either
+ * a 'list' view, a 'detail' view, or a 'form' view.
+ */
+export type StudioParamsBase = Pick<RouteParams, 'entity' | 'phase' | 'projectId'>;
+
+/**
+ * Parameters specific to form views.
+ *
+ * entitySubType is only available for form views that are configured to support multiple
+ * entity subtypes. @see {@link FormViewT} for more information.
+ *
+ * revisionId is only available for form views that modify a revisioned entity. @see
+ * {@link REVISION_TYPE} for more information.
+ */
+export type StudioParamsForm = StudioParamsBase &
+  Partial<Pick<QueryParams, 'entitySubType' | 'revisionId'>> &
+  Pick<RouteParams, 'entityId'>;
+
+/**
+ * Parameters specific to detail views.
+ *
+ * revisionId is only available for detail views that modify a revisioned entity. @see
+ * {@link REVISION_TYPE} for more information.
+ *
+ * pipelineName is a special query param that is used to identify the pipeline in
+ * alert detail views. @see {@link PIPELINE_LEVEL_ALERT_FORM_SCHEMA} for more information.
+ */
+export type StudioParamsDetail = StudioParamsBase &
+  Partial<Pick<QueryParams, 'revisionId' | 'pipelineName'>> &
+  Pick<RouteParams, 'entityId' | 'entityTab'>;
+
+/**
+ * Parameters for combined form-detail views.
+ *
+ * There are lots of components that are used in form and detail views. This type
+ * ensures that common fields between form and detail views are handled consistently.
+ * For example, the form and detail views both use the entityId field.
+ */
+export type StudioParamsFormDetail = Pick<
+  StudioParamsForm,
+  Extract<keyof StudioParamsForm, keyof StudioParamsDetail>
+> &
+  Pick<StudioParamsDetail, Extract<keyof StudioParamsForm, keyof StudioParamsDetail>> &
+  Partial<Omit<StudioParamsForm, Extract<keyof StudioParamsForm, keyof StudioParamsDetail>>> &
+  Partial<Omit<StudioParamsDetail, Extract<keyof StudioParamsForm, keyof StudioParamsDetail>>>;
+
+/**
+ * Union type of all possible view types in the studio.
+ * Extends ViewTypeT with additional special view types.
+ * @see ViewTypeT for the base view types ('form' | 'detail' | 'list')
+ *
+ * 'base' is a special view type that is used to represent the base parameters
+ * for all views registered to the Schema Driven UI router.
+ *
+ * 'form-detail' is a special view type that is used to represent the parameters
+ * for combined form-detail views.
+ *
+ * 'unregistered' is a special view type that is used to represent views that are not registered
+ * to the Schema Driven UI router but are still part of the studio application.
+ */
+export type StudioParamsView = View | 'base' | 'form-detail' | 'unregistered';
+
+/**
+ * Maps a view type to its corresponding parameter type.
+ *
+ * @template T - The view type to get parameters for
+ * @example
+ * ```typescript
+ * // Gets form view parameters
+ * type FormParams = ViewTypeToParamType<'form'>;
+ * // Gets detail view parameters
+ * type DetailParams = ViewTypeToParamType<'detail'>;
+ * ```
+ */
+export type ViewTypeToParamType<T extends StudioParamsView> = T extends 'form'
+  ? StudioParamsForm
+  : T extends 'detail'
+    ? StudioParamsDetail
+    : T extends 'list'
+      ? StudioParamsBase
+      : T extends 'base'
+        ? StudioParamsBase & Partial<RouteParams> & Partial<QueryParams>
+        : T extends 'form-detail'
+          ? StudioParamsFormDetail
+          : T extends 'unregistered'
+            ? Record<string, string | undefined>
+            : never;
+
+/**
+ * A function type that transforms base parameters into view-specific parameters.
+ * Used to create consistent parameter transformations for different view types.
+ *
+ * @template V - The view type to transform parameters for
+ * @param baseParams - The base parameters to transform
+ * @param routeParams - The route parameters available
+ * @param queryParams - The query parameters available
+ * @returns Parameters specific to the view type
+ *
+ * @example
+ * ```typescript
+ * const formTransformer: ParamsTransformer<'form'> = (base, params, query) => ({
+ *   ...base,
+ *   entityId: params.entityId ?? '',
+ *   entitySubType: query.entitySubType
+ * });
+ * ```
+ */
+export type ParamsTransformer<V extends StudioParamsView> = (
+  routeParams: Partial<RouteParams>,
+  queryParams: Partial<QueryParams>
+) => ViewTypeToParamType<V>;

--- a/javascript/packages/core/src/hooks/routing/use-studio-params/use-studio-params.ts
+++ b/javascript/packages/core/src/hooks/routing/use-studio-params/use-studio-params.ts
@@ -1,0 +1,49 @@
+import React from 'react';
+import { useParams } from 'react-router';
+
+import useURLQueryString from '@/hooks/routing/use-url-query-string';
+import { Phase } from '@/types/common/studio-types';
+
+import type { QueryParams, RouteParams, StudioParamsView, ViewTypeToParamType } from './types';
+
+import { VIEW_TYPE_TO_PARAMS } from './constants';
+import { normalizeEntityParam } from './normalize-entity-param';
+
+/**
+ * Hook to get and transform studio parameters based on the view type.
+ *
+ * @template T - The view type to get parameters for. Defaults to 'unregistered'
+ * @param viewType - Must match the type parameter T
+ * @returns Parameters specific to the view type
+ *
+ * @example
+ * ```typescript
+ * // With explicit type
+ * const formParams = useStudioParams('form');
+ *
+ * // Using default type
+ * const unregisteredParams = useStudioParams('unregistered');
+ * ```
+ */
+export function useStudioParams<T extends StudioParamsView = 'unregistered'>(
+  viewType: T
+): ViewTypeToParamType<T> {
+  const params: Partial<RouteParams> = useParams();
+  const queryParams = useURLQueryString<QueryParams>();
+
+  return React.useMemo(() => {
+    if (!params.phase) {
+      return {
+        ...queryParams,
+        revisionId: params.revisionId,
+        projectId: params.projectId!,
+        phase: Phase.Project,
+        entity: 'projects',
+        entityId: params.projectId!,
+      } as ViewTypeToParamType<T>;
+    }
+
+    const transformer = VIEW_TYPE_TO_PARAMS[viewType];
+    return transformer(normalizeEntityParam(params), queryParams) as ViewTypeToParamType<T>;
+  }, [params, queryParams, viewType]);
+}

--- a/javascript/packages/core/src/hooks/routing/use-url-query-string.ts
+++ b/javascript/packages/core/src/hooks/routing/use-url-query-string.ts
@@ -1,0 +1,7 @@
+import { useLocation } from 'react-router';
+
+export default function useURLQueryString<T extends Record<string, string>>(): Partial<T> {
+  const location = useLocation();
+  const { search = '' } = location ?? {};
+  return Object.fromEntries(new URLSearchParams(search)) as Partial<T>;
+}

--- a/javascript/packages/core/src/index.tsx
+++ b/javascript/packages/core/src/index.tsx
@@ -1,51 +1,15 @@
-import { useEffect, useState } from 'react';
-import { createClient, type Interceptor } from '@connectrpc/connect';
-import { createGrpcWebTransport } from '@connectrpc/connect-web';
 import { AppNavBar } from 'baseui/app-nav-bar';
 
-import { ProjectService } from '@ma/gen-api/v2/project_svc_pb';
-import { MainViewContainer } from '@/components/views/main-view-container';
+import { Router } from '@/router/router';
 import { ThemeProvider } from '@/themes/provider';
-
-import type { Project } from '@ma/gen-api/v2/project_pb';
 
 import '@/styles/main.css';
 
 export function CoreApp() {
-  const [projects, setProjects] = useState<Project[]>([]);
-
-  useEffect(() => {
-    const listProjects = async () => {
-      const callerInterceptor: Interceptor = (next) => async (req) => {
-        req.header.set('context-Ttl-Ms', '10000');
-        req.header.set('grpc-timeout', '1000000m');
-        req.header.set('Rpc-Caller', 'ma-studio');
-        req.header.set('Rpc-Encoding', 'proto');
-        req.header.set('Rpc-Service', 'ma-apiserver');
-
-        return await next(req);
-      };
-
-      const transport = createGrpcWebTransport({
-        baseUrl: 'http://localhost:8081',
-        interceptors: [callerInterceptor],
-        useBinaryFormat: true,
-      });
-
-      const client = createClient(ProjectService, transport);
-      const projectResponse = await client.listProject({});
-      setProjects(projectResponse.projectList?.items ?? []);
-    };
-
-    listProjects().catch((error) => {
-      console.error('Error listing projects:', error);
-    });
-  }, []);
-
   return (
     <ThemeProvider>
       <AppNavBar title="Michelangelo Studio" />
-      <MainViewContainer>Hi! {projects[0]?.metadata?.name}</MainViewContainer>
+      <Router />
     </ThemeProvider>
   );
 }

--- a/javascript/packages/core/src/router/router.tsx
+++ b/javascript/packages/core/src/router/router.tsx
@@ -1,0 +1,22 @@
+import { Route, Routes } from 'react-router';
+import { BrowserRouter } from 'react-router-dom';
+
+import { MainViewContainer } from '@/components/views/main-view-container';
+import { ProjectDetail } from '@/components/views/project/project-detail';
+
+export function Router() {
+  return (
+    <BrowserRouter basename={'/'}>
+      <Routes>
+        <Route
+          path={':projectId'}
+          element={
+            <MainViewContainer hasBreadcrumb={false}>
+              <ProjectDetail />
+            </MainViewContainer>
+          }
+        />
+      </Routes>
+    </BrowserRouter>
+  );
+}

--- a/javascript/packages/core/src/types/common/studio-types.ts
+++ b/javascript/packages/core/src/types/common/studio-types.ts
@@ -1,0 +1,46 @@
+/**
+ * Represents the different phases in the Michelangelo Studio workflow.
+ * Each phase corresponds to a specific stage in the machine learning lifecycle.
+ *
+ * These phases serve two important purposes:
+ * 1. They are used in URLs to navigate between different sections of the application
+ * 2. They define the initial grouping of the application's schema and data structure
+ *
+ * The string values of these enums are used directly in URLs (e.g., /monitor, /train),
+ * so they should be kept URL-friendly and consistent.
+ *
+ * The phases are naturally grouped into three categories:
+ * - Phases that are distinct from any workflow, e.g., Project and Assistants
+ *
+ * - Traditional ML workflow: Data → Train → Retrain → Deploy → Monitor
+ *
+ * - Generative AI workflow: LLM → Data → Prompt → Finetune → Monitor
+ */
+export enum Phase {
+  /** Initial project setup and configuration phase */
+  Project = 'project',
+  /** Assistants builder phase*/
+  Assistants = 'assistants',
+
+  /** Data preparation and preprocessing phase */
+  Data = 'data',
+  /** Initial model training phase */
+  Train = 'train',
+  /** Model retraining and fine-tuning phase */
+  Retrain = 'retrain',
+  /** Model deployment and serving phase */
+  Deploy = 'deploy',
+  /** Model monitoring and performance tracking phase */
+  Monitor = 'monitor',
+
+  /** Large Language Model (LLM) configuration and management */
+  GenaiLLM = 'genai-llm',
+  /** Data preparation for generative AI models */
+  GenaiData = 'genai-data',
+  /** Prompt engineering and management */
+  GenaiPrompt = 'genai-prompt',
+  /** Fine-tuning of generative AI models */
+  GenaiFinetune = 'genai-finetune',
+  /** Monitoring of generative AI model performance */
+  GenaiMonitor = 'genai-monitor',
+}

--- a/javascript/packages/core/src/types/common/view-types.ts
+++ b/javascript/packages/core/src/types/common/view-types.ts
@@ -1,0 +1,4 @@
+/**
+ * Represents the type of Schema Driven view that is being rendered.
+ */
+export type View = 'form' | 'detail' | 'list';

--- a/javascript/tsconfig.base.json
+++ b/javascript/tsconfig.base.json
@@ -12,6 +12,7 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
+    "allowSyntheticDefaultImports": true,
     "baseUrl": ".",
     "paths": {
       "@ma/gen-api/*": ["gen/grpc/michelangelo/api/*"],

--- a/javascript/yarn.lock
+++ b/javascript/yarn.lock
@@ -481,6 +481,11 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.2.1.tgz#6d083acfddae21fb329c8df8c94bf895ce7d0c15"
   integrity sha512-VzgHzGblFmUeBmmrk55zPyrQIArQN4vujc9shWytaPdB3P7qhi0cpaiKIr7tlCmFv2lYUwnLospIqjL9ZSAhhg==
 
+"@remix-run/router@1.22.0":
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.22.0.tgz#dd8096cb055c475a4de6b35322b8d3b118c17b43"
+  integrity sha512-MBOl8MeOzpK0HQQQshKB7pABXbmyHizdTpqnrIseTbsv0nAepwC2ENZa1aaBExNQcpLoXmWthhak8SABLzvGPw==
+
 "@rollup/rollup-android-arm-eabi@4.39.0":
   version "4.39.0"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.39.0.tgz#1d8cc5dd3d8ffe569d8f7f67a45c7909828a0f66"
@@ -635,6 +640,11 @@
   integrity sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==
   dependencies:
     undici-types "~6.21.0"
+
+"@types/pluralize@^0.0.33":
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/@types/pluralize/-/pluralize-0.0.33.tgz#8ad9018368c584d268667dd9acd5b3b806e8c82a"
+  integrity sha512-JOqsl+ZoCpP4e8TDke9W79FDcSgPAR0l6pixx2JHkhnRjvShyYiAYw2LVsnA7K08Y6DeOnaU6ujmENO4os/cYg==
 
 "@types/react-dom@^19.0.4":
   version "19.1.1"
@@ -2432,6 +2442,11 @@ picomatch@^2.3.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
+pluralize@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
+  integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
+
 polished@^3.2.0:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/polished/-/polished-3.7.2.tgz#ec5ddc17a7d322a574d5e10ddd2a6f01d3e767d1"
@@ -2509,7 +2524,7 @@ react-clientside-effect@^1.2.7:
   dependencies:
     "@babel/runtime" "^7.12.13"
 
-react-dom@18.3.1, react-dom@^18.3.1:
+react-dom@18.3.1:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.3.1.tgz#c2265d79511b57d479b3dd3fdfa51536494c5cb4"
   integrity sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==
@@ -2579,6 +2594,21 @@ react-refresh@^0.14.2:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.2.tgz#3833da01ce32da470f1f936b9d477da5c7028bf9"
   integrity sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==
 
+react-router-dom@6.29.0:
+  version "6.29.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.29.0.tgz#2ffb56b03ef3d6d6daafcfad9f3922132d2ced94"
+  integrity sha512-pkEbJPATRJ2iotK+wUwHfy0xs2T59YPEN8BQxVCPeBZvK7kfPESRc/nyxzdcxR17hXgUPYx2whMwl+eo9cUdnQ==
+  dependencies:
+    "@remix-run/router" "1.22.0"
+    react-router "6.29.0"
+
+react-router@6.29.0:
+  version "6.29.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.29.0.tgz#14a329ca838b4de048fc5cca82874b727ee546b7"
+  integrity sha512-DXZJoE0q+KyeVw75Ck6GkPxFak63C4fGqZGNijnWgzB/HzSP1ZfTlBj5COaGWwhrMQ/R8bXiq5Ooy4KG+ReyjQ==
+  dependencies:
+    "@remix-run/router" "1.22.0"
+
 react-uid@^2.3.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/react-uid/-/react-uid-2.4.0.tgz#ce48a3e2a044964900f3ad5181a0d377702c56c5"
@@ -2611,7 +2641,7 @@ react-window@^1.8.5:
     "@babel/runtime" "^7.0.0"
     memoize-one ">=3.1.1 <6"
 
-react@18.3.1, react@^18.3.1:
+react@18.3.1:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react/-/react-18.3.1.tgz#49ab892009c53933625bd16b2533fc754cab2891"
   integrity sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==


### PR DESCRIPTION
Migrated core hooks for parsing URLs and added the ProjectDetail component.

Relocated data fetching logic from packages/core/index.tsx into new project-detail.tsx view because individual views/routes are responsible for data fetching, not the core/index.tsx exported component.

Added "allowSyntheticDefaultImports": true, such that import React from 'react' also provides React.useEffect. This matches our internal deployment.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**Project in URL that exists in API sandbox**
<img width="1840" alt="Screenshot 2025-04-18 at 11 51 13" src="https://github.com/user-attachments/assets/00cd89e3-aa69-40ce-a1b0-18a0d48d3aaf" />

**Project in URL that does not exist in API sandbox**
<img width="1840" alt="Screenshot 2025-04-18 at 11 55 28" src="https://github.com/user-attachments/assets/56106a97-a2b9-43a6-9933-055c6d6d586f" />