### PR TITLE
Add EnableCRDDeletion config and check not found error

### DIFF
--- a/go/api/crd/BUILD.bazel
+++ b/go/api/crd/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     importpath = "github.com/michelangelo-ai/michelangelo/go/api/crd",
     visibility = ["//visibility:public"],
     deps = [
+        "//go/api/utils:go_default_library",
         "@com_github_cenkalti_backoff//:go_default_library",
         "@io_k8s_apiextensions_apiserver//pkg/apis/apiextensions/v1:go_default_library",
         "@io_k8s_apiextensions_apiserver//pkg/client/clientset/clientset:go_default_library",

--- a/go/api/crd/gateway.go
+++ b/go/api/crd/gateway.go
@@ -4,6 +4,7 @@ package crd
 import (
 	"context"
 	"fmt"
+
 	"github.com/michelangelo-ai/michelangelo/go/api/utils"
 
 	"go.uber.org/fx"

--- a/go/api/crd/gateway.go
+++ b/go/api/crd/gateway.go
@@ -4,6 +4,7 @@ package crd
 import (
 	"context"
 	"fmt"
+	"github.com/michelangelo-ai/michelangelo/go/api/utils"
 
 	"go.uber.org/fx"
 	"go.uber.org/zap"
@@ -157,6 +158,9 @@ func (r *gateway) hasInstances(ctx context.Context, crd *apiextv1.CustomResource
 		}
 		result, err := r.dynamicClient.Resource(gvr).List(ctx, metav1.ListOptions{Limit: 1})
 		if err != nil {
+			if utils.IsNotFoundError(err) {
+				continue
+			}
 			return false, fmt.Errorf("failed to list existing instances of CRD %s: %w", crd.Name, err)
 		}
 		if len(result.Items) > 0 {

--- a/go/api/crd/sync.go
+++ b/go/api/crd/sync.go
@@ -3,6 +3,7 @@ package crd
 import (
 	"context"
 	"fmt"
+	"github.com/michelangelo-ai/michelangelo/go/api/utils"
 	"slices"
 	"strings"
 
@@ -147,7 +148,7 @@ func syncCRDs(ctx context.Context, logger *zap.Logger, groups []string, enableIn
 		if !found {
 			if enableCRDDeletion {
 				logger.Info("CRD deletion enabled. Delete CRD", zap.String("name", crd.Name))
-				if err = gateway.Delete(ctx, &crd); err != nil {
+				if err = gateway.Delete(ctx, &crd); err != nil && !utils.IsNotFoundError(err) {
 					logger.Error("Fail to delete CRD", zap.String("name", crd.Name), zap.Error(err))
 					return err
 				}

--- a/go/api/crd/sync.go
+++ b/go/api/crd/sync.go
@@ -24,6 +24,7 @@ const (
 type Configuration struct {
 	EnableCRDUpdate          bool `yaml:"enableCRDUpdate"`
 	EnableIncompatibleUpdate bool `yaml:"enableIncompatibleUpdate"`
+	EnableCRDDeletion        bool `yaml:"enableCRDDeletion"`
 }
 
 func ParseConfig(provider config.Provider) (*Configuration, error) {
@@ -88,12 +89,13 @@ type SyncCRDsParams struct {
 //	   - Otherwise, it will return an error
 func SyncCRDs(groups []string, yamlSchemas ...map[string]string) fx.Option {
 	return fx.Invoke(func(p SyncCRDsParams) error {
+		logger := p.Logger.With(zap.String("module", moduleName))
+		logger.Info("CRD sync config", zap.Any("config", p.Config))
 		if p.Config.EnableCRDUpdate {
-			logger := p.Logger.With(zap.String("module", moduleName))
-
 			p.Lifecycle.Append(fx.Hook{
 				OnStart: func(ctx context.Context) error {
-					return syncCRDs(ctx, logger, groups, p.Config.EnableIncompatibleUpdate, p.Gateway, yamlSchemas...)
+					return syncCRDs(ctx, logger, groups, p.Config.EnableIncompatibleUpdate, p.Config.EnableCRDDeletion,
+						p.Gateway, yamlSchemas...)
 				},
 				OnStop: nil,
 			})
@@ -103,8 +105,8 @@ func SyncCRDs(groups []string, yamlSchemas ...map[string]string) fx.Option {
 	})
 }
 
-func syncCRDs(ctx context.Context, logger *zap.Logger, groups []string, enableIncompatibleUpdate bool, gateway Gateway,
-	yamlSchemas ...map[string]string) error {
+func syncCRDs(ctx context.Context, logger *zap.Logger, groups []string, enableIncompatibleUpdate bool,
+	enableCRDDeletion bool, gateway Gateway, yamlSchemas ...map[string]string) error {
 
 	var crdList []*apiextv1.CustomResourceDefinition
 	for _, schemaMap := range yamlSchemas {
@@ -143,9 +145,14 @@ func syncCRDs(ctx context.Context, logger *zap.Logger, groups []string, enableIn
 			}
 		}
 		if !found {
-			if err = gateway.Delete(ctx, &crd); err != nil {
-				logger.Error("Fail to delete CRD", zap.String("name", crd.Name), zap.Error(err))
-				return err
+			if enableCRDDeletion {
+				logger.Info("CRD deletion enabled. Delete CRD", zap.String("name", crd.Name))
+				if err = gateway.Delete(ctx, &crd); err != nil {
+					logger.Error("Fail to delete CRD", zap.String("name", crd.Name), zap.Error(err))
+					return err
+				}
+			} else {
+				logger.Info("CRD deletion disabled. Skip deleting CRD", zap.String("name", crd.Name))
 			}
 		}
 	}

--- a/go/api/crd/sync.go
+++ b/go/api/crd/sync.go
@@ -3,9 +3,10 @@ package crd
 import (
 	"context"
 	"fmt"
-	"github.com/michelangelo-ai/michelangelo/go/api/utils"
 	"slices"
 	"strings"
+
+	"github.com/michelangelo-ai/michelangelo/go/api/utils"
 
 	"github.com/cenkalti/backoff"
 	"go.uber.org/config"

--- a/go/api/crd/sync_test.go
+++ b/go/api/crd/sync_test.go
@@ -127,7 +127,7 @@ func TestSyncCRDsFx(t *testing.T) {
 	assert.NoError(t, err)
 	crds, err := crdGateway.List(ctx)
 	assert.NoError(t, err)
-	assert.True(t, len(crds.Items) == 1)
+	assert.Len(t, crds.Items, 1)
 	assert.Equal(t, "test", crds.Items[0].Spec.Group)
 	assert.Equal(t, "v0", crds.Items[0].Spec.Versions[0].Name)
 	assert.Equal(t, "Project", crds.Items[0].Spec.Names.Kind)
@@ -144,6 +144,7 @@ func TestSyncCRDsFx(t *testing.T) {
 			return &Configuration{
 				EnableCRDUpdate:          true,
 				EnableIncompatibleUpdate: false,
+				EnableCRDDeletion:        true,
 			}
 		}),
 		SyncCRDs([]string{"test"}, map[string]string{
@@ -164,6 +165,7 @@ func TestSyncCRDsFx(t *testing.T) {
 	// delete a CRD while there are instances of the CRD in the cluster
 	crdGateway.dynamicClient = fakeClientWithResource
 
+	// CRD is not deleted when EnableCRDDeletion is set to false
 	app = fx.New(fx.Options(
 		fx.Provide(func() *zap.Logger {
 			return logger
@@ -175,6 +177,36 @@ func TestSyncCRDsFx(t *testing.T) {
 			return &Configuration{
 				EnableCRDUpdate:          true,
 				EnableIncompatibleUpdate: false,
+				EnableCRDDeletion:        false,
+			}
+		}),
+		fx.Invoke(func() error {
+			return nil
+		}),
+		SyncCRDs([]string{"test"}, map[string]string{}),
+	),
+	)
+	assert.NoError(t, app.Err())
+	err = app.Start(ctx)
+	assert.NoError(t, err)
+	crds, err = crdGateway.List(ctx)
+	assert.NoError(t, err)
+	assert.Len(t, crds.Items, 1)
+	assert.Equal(t, "Project", crds.Items[0].Spec.Names.Kind)
+
+	// expect error when deleting CRD with existing instances
+	app = fx.New(fx.Options(
+		fx.Provide(func() *zap.Logger {
+			return logger
+		}),
+		fx.Provide(func() Gateway {
+			return &crdGateway
+		}),
+		fx.Provide(func() *Configuration {
+			return &Configuration{
+				EnableCRDUpdate:          true,
+				EnableIncompatibleUpdate: false,
+				EnableCRDDeletion:        true,
 			}
 		}),
 		fx.Invoke(func() error {
@@ -201,6 +233,7 @@ func TestSyncCRDsFx(t *testing.T) {
 			return &Configuration{
 				EnableCRDUpdate:          true,
 				EnableIncompatibleUpdate: false,
+				EnableCRDDeletion:        true,
 			}
 		}),
 		fx.Invoke(func() error {
@@ -230,26 +263,26 @@ func TestSyncCRDs(t *testing.T) {
 	crdYaml, err := os.ReadFile(testCRDManifestDir + "/project.pb.yaml")
 	assert.NoError(t, err)
 	err = syncCRDs(context.Background(), logger, []string{"test"},
-		false, &crdGateway, map[string]string{"Project": string(crdYaml)})
+		false, true, &crdGateway, map[string]string{"Project": string(crdYaml)})
 	assert.NoError(t, err)
 
 	// incompatible change
 	crdYaml, err = os.ReadFile(testCRDManifestDir + "/project_delete_props.pb.yaml")
 	assert.NoError(t, err)
 	err = syncCRDs(context.Background(), logger, []string{"test"},
-		false, &crdGateway, map[string]string{"Project": string(crdYaml)})
+		false, true, &crdGateway, map[string]string{"Project": string(crdYaml)})
 	assert.Error(t, err, "failed to update CRD. Schema is incompatible, and there are existing instances. Abort updating CRD projects.test")
 
 	// fail to list existing CRDs
 	mockGateway := crdmocks.NewMockGateway(gomock.NewController(t))
 	mockGateway.EXPECT().List(gomock.Any()).Return(nil, fmt.Errorf("test error"))
 	err = syncCRDs(context.Background(), logger, []string{"test"},
-		false, mockGateway, map[string]string{"Project": string(crdYaml)})
+		false, true, mockGateway, map[string]string{"Project": string(crdYaml)})
 	assert.Error(t, err, "failed to list existing CRDs: test error")
 
 	// do not update CRDs that are not in the specified groups
 	err = syncCRDs(context.Background(), logger, []string{"test1", "test2"},
-		false, &crdGateway, map[string]string{"Project": string(crdYaml)})
+		false, true, &crdGateway, map[string]string{"Project": string(crdYaml)})
 	assert.Error(t, err, "CRD projects.test is not in the specified groups [test1, test2]")
 }
 


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [X] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
1. Add a new config option: EnableCRDDeletion
2. Check not found error in hasInstances() function

<!-- Tell your future self why have you made these changes -->
**Why?**
1. Deleting removed CRD types from k8s server can be a risky operation. This option alloww users choosing whether to delete CRD types automatically.
2. When rolling out multiple instances of api server at the same time, there can be a race condition that when an instance is checking or deleting a CRD it's already deleted by another instance. So, we have to ignore NotFound error when trying to delete a CRD type

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
