### PR TITLE
Implement apihandler.handleUpdate()

### DIFF
--- a/go/api/handler/handler.go
+++ b/go/api/handler/handler.go
@@ -136,8 +136,8 @@ func (handler *apiHandler) Create(ctx context.Context, obj ctrlRTClient.Object, 
 		return status.Errorf(codes.InvalidArgument, err.Error())
 	}
 
-	// Check if the object exists in MetadataStorage
 	if storage.EnableMetadataStorage(&handler.conf) {
+		// Check if the object exists in MetadataStorage
 		tmpObj := obj
 		err = handler.metadataStorage.GetByName(ctx, objMeta.GetNamespace(), objMeta.GetName(), tmpObj)
 		if err == nil {
@@ -612,7 +612,8 @@ func getSpec(object any) (any, error) {
 // handleUpdate updates the object in metadataStorage and blobStorage.
 func handleUpdate(ctx context.Context, obj ctrlRTClient.Object, metadataStorage storage.MetadataStorage, direct bool,
 	indexedFields []storage.IndexedField, handler storage.BlobStorage) error {
-	panic("not implemented")
+	// TODO: update the object in blob storage
+	return metadataStorage.Upsert(ctx, obj, direct, indexedFields)
 }
 
 // HandleDelete deletes the object in metadata storage and blob storage.

--- a/go/api/handler/handler.go
+++ b/go/api/handler/handler.go
@@ -367,8 +367,7 @@ func (handler *apiHandler) List(ctx context.Context, namespace string, opts *met
 	if storage.EnableMetadataStorage(&handler.conf) {
 		return handler.metadataStorageList(ctx, namespace, opts, listOptionsExt, list)
 	} else if listOptionsExt != nil && !listOptionsExt.Equal(&apipb.ListOptionsExt{}) {
-		return status.Errorf(codes.Unimplemented,
-			"ListOptionsExt is not supported, when Metadata Storage is not enabled.")
+		log.Info("ListOptionsExt is ignored when metadata storage is not enabled", "listOptionsExt", listOptionsExt)
 	}
 
 	parsedListOptions, err := getCRTListOptions(namespace, opts)

--- a/go/api/handler/handler_test.go
+++ b/go/api/handler/handler_test.go
@@ -227,17 +227,6 @@ func TestK8sOnly(t *testing.T) {
 		&metav1.ListOptions{LabelSelector: "bad label selector"}, nil, listJobs)
 	checkGrpcStatusCode(t, codes.InvalidArgument, err)
 
-	// ListOptionsExt is not supported
-	err = handler.List(context.Background(), "default", &metav1.ListOptions{}, &apipb.ListOptionsExt{
-		OrderBy: []*apipb.OrderBy{
-			{
-				Field: "test",
-			},
-		},
-	}, listJobs)
-	assert.Error(t, err)
-	checkGrpcStatusCode(t, codes.Unimplemented, err)
-
 	// Delete Collection
 	err = handler.DeleteCollection(context.Background(), &v2pb.RayJob{}, "project01", &metav1.DeleteOptions{}, &metav1.ListOptions{})
 	assert.NoError(t, err)

--- a/go/api/handler/handler_test.go
+++ b/go/api/handler/handler_test.go
@@ -227,6 +227,16 @@ func TestK8sOnly(t *testing.T) {
 		&metav1.ListOptions{LabelSelector: "bad label selector"}, nil, listJobs)
 	checkGrpcStatusCode(t, codes.InvalidArgument, err)
 
+	// ListOptionsExt is ignored
+	err = handler.List(context.Background(), "default", &metav1.ListOptions{}, &apipb.ListOptionsExt{
+		OrderBy: []*apipb.OrderBy{
+			{
+				Field: "test",
+			},
+		},
+	}, listJobs)
+	assert.NoError(t, err)
+
 	// Delete Collection
 	err = handler.DeleteCollection(context.Background(), &v2pb.RayJob{}, "project01", &metav1.DeleteOptions{}, &metav1.ListOptions{})
 	assert.NoError(t, err)


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [X] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
1. Implement apihandler.handleUpdate()
2. do not return error when ListOptionsExt is specified but metadata storage is not enabled

<!-- Tell your future self why have you made these changes -->
**Why?**
1. handleUpdate() was not implemented in the previous pr
2. some clients always submit request with ListOptionsExt without knowing if the server side has MetadataStorage. It's better to ignore the ListOptionsExt option instead of returning an error

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
