### PR TITLE
Fix Get-Started example accelerate version and MA service host

### DIFF
--- a/python/michelangelo/cli/sandbox/resources/michelangelo-config.yaml
+++ b/python/michelangelo/cli/sandbox/resources/michelangelo-config.yaml
@@ -8,4 +8,4 @@ data:
   MA_FILE_SYSTEM_S3_SCHEME: http
   AWS_ACCESS_KEY_ID: minioadmin
   AWS_SECRET_ACCESS_KEY: minioadmin
-  AWS_ENDPOINT_URL: http://host.docker.internal:9091
+  AWS_ENDPOINT_URL: http://minio:9091

--- a/python/michelangelo/cli/sandbox/resources/michelangelo-worker.yaml
+++ b/python/michelangelo/cli/sandbox/resources/michelangelo-worker.yaml
@@ -26,7 +26,7 @@ metadata:
 data:
   base.yaml: |
     worker:
-      address: host.docker.internal:14566
+      address: michelangelo-apiserver:14566
       maApiServiceName: ma-apiserver
 
     logging:
@@ -54,4 +54,4 @@ data:
       awsRegion: us-east-1
       awsAccessKeyId: minioadmin
       awsSecretAccessKey: minioadmin
-      awsEndpointUrl: host.docker.internal:9091
+      awsEndpointUrl: minio:9091

--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -2,36 +2,36 @@
 
 [[package]]
 name = "accelerate"
-version = "0.30.1"
+version = "0.34.2"
 description = "Accelerate"
 optional = true
 python-versions = ">=3.8.0"
 groups = ["main"]
 markers = "extra == \"example\" or extra == \"vllm\""
 files = [
-    {file = "accelerate-0.30.1-py3-none-any.whl", hash = "sha256:8dd4edd532a4dac72558c5fe6fe8cb70d0c8ec9e8733f48db97d51ee41cbe763"},
-    {file = "accelerate-0.30.1.tar.gz", hash = "sha256:96779c618889646b86dc928c9e55e86e50a7ccab59e1692e22096481977ae682"},
+    {file = "accelerate-0.34.2-py3-none-any.whl", hash = "sha256:d69159e2c4e4a473d14443b27d2d732929254e826b3ab4813b3785b5ac616c7c"},
+    {file = "accelerate-0.34.2.tar.gz", hash = "sha256:98c1ebe1f5a45c0a3af02dc60b5bb8b7d58d60c3326a326a06ce6d956b18ca5b"},
 ]
 
 [package.dependencies]
-huggingface-hub = "*"
-numpy = ">=1.17"
+huggingface-hub = ">=0.21.0"
+numpy = ">=1.17,<3.0.0"
 packaging = ">=20.0"
 psutil = "*"
 pyyaml = "*"
-safetensors = ">=0.3.1"
+safetensors = ">=0.4.3"
 torch = ">=1.10.0"
 
 [package.extras]
-deepspeed = ["deepspeed (<=0.14.0)"]
-dev = ["bitsandbytes", "black (>=23.1,<24.0)", "datasets", "diffusers", "evaluate", "hf-doc-builder (>=0.3.0)", "parameterized", "pytest (>=7.2.0,<=8.0.0)", "pytest-subtests", "pytest-xdist", "rich", "ruff (>=0.2.1,<0.3.0)", "scikit-learn", "scipy", "timm", "torchpippy (>=0.2.0)", "tqdm", "transformers"]
+deepspeed = ["deepspeed"]
+dev = ["bitsandbytes", "black (>=23.1,<24.0)", "datasets", "diffusers", "evaluate", "hf-doc-builder (>=0.3.0)", "parameterized", "pytest (>=7.2.0,<=8.0.0)", "pytest-subtests", "pytest-xdist", "rich", "ruff (>=0.2.1,<0.3.0)", "scikit-learn", "scipy", "timm", "torchdata (>=0.8.0)", "torchpippy (>=0.2.0)", "tqdm", "transformers"]
 quality = ["black (>=23.1,<24.0)", "hf-doc-builder (>=0.3.0)", "ruff (>=0.2.1,<0.3.0)"]
 rich = ["rich"]
 sagemaker = ["sagemaker"]
-test-dev = ["bitsandbytes", "datasets", "diffusers", "evaluate", "scikit-learn", "scipy", "timm", "torchpippy (>=0.2.0)", "tqdm", "transformers"]
+test-dev = ["bitsandbytes", "datasets", "diffusers", "evaluate", "scikit-learn", "scipy", "timm", "torchdata (>=0.8.0)", "torchpippy (>=0.2.0)", "tqdm", "transformers"]
 test-prod = ["parameterized", "pytest (>=7.2.0,<=8.0.0)", "pytest-subtests", "pytest-xdist"]
 test-trackers = ["comet-ml", "dvclive", "tensorboard", "wandb"]
-testing = ["bitsandbytes", "datasets", "diffusers", "evaluate", "parameterized", "pytest (>=7.2.0,<=8.0.0)", "pytest-subtests", "pytest-xdist", "scikit-learn", "scipy", "timm", "torchpippy (>=0.2.0)", "tqdm", "transformers"]
+testing = ["bitsandbytes", "datasets", "diffusers", "evaluate", "parameterized", "pytest (>=7.2.0,<=8.0.0)", "pytest-subtests", "pytest-xdist", "scikit-learn", "scipy", "timm", "torchdata (>=0.8.0)", "torchpippy (>=0.2.0)", "tqdm", "transformers"]
 
 [[package]]
 name = "aiobotocore"
@@ -5925,4 +5925,4 @@ vllm = ["accelerate", "datasets", "einops", "numpy", "pandas", "pyarrow", "pytor
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9.0"
-content-hash = "f8a5d8e28d5d3085109773c517daafa87cd5f4b6b740b102774c1ea34845b604"
+content-hash = "3d2a5c1e94ecca1e41a8ad7f3bd87f27f3f3e648d2fc4ebb0476b22f6d7594e6"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -29,7 +29,7 @@ jinja2 = { version = "^3.1.2", optional = true }
 pre-commit = {version = "^4.2.0", optional = true}
 
 # For example run
-accelerate = { version = "0.30.1", optional = true }
+accelerate = { version = "0.34.2", optional = true }
 datasets = { version = "3.2.0", optional = true }
 numpy = { version = "1.25", optional = true }
 pandas = { version = "1.5.1", optional = true }


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
1. Change Python example accelerate version from 0.30.1 to 0.34.2
2. Update service host name in Sandbox MA config and worker config


<!-- Tell your future self why have you made these changes -->
**Why?**
1. Resolve error `resolve 'AdamW' object has no attribute 'train'` when running example job in local execution
2. Resolve Cadence cannot schedule task issue with `lookup host.docker.internal on 10.43.0.10:53: no such host` error


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
