### PR TITLE
Onboard RPC handlers to MA Studio

### DIFF
--- a/javascript/app/App.tsx
+++ b/javascript/app/App.tsx
@@ -1,5 +1,12 @@
 import { CoreApp } from '@michelangelo/core';
+import { buildRPCQueryHooks, RpcProvider } from '@michelangelo/rpc';
 
 export function App() {
-  return <CoreApp />;
+  const { useQuery } = buildRPCQueryHooks();
+
+  return (
+    <RpcProvider>
+      <CoreApp useQuery={useQuery} />
+    </RpcProvider>
+  );
 }

--- a/javascript/app/package.json
+++ b/javascript/app/package.json
@@ -8,7 +8,8 @@
     "dev-production": "vite --config vite.config.production.ts"
   },
   "dependencies": {
-    "@michelangelo/core": "*"
+    "@michelangelo/core": "*",
+    "@michelangelo/rpc": "*"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.4.1",

--- a/javascript/app/tsconfig.app.json
+++ b/javascript/app/tsconfig.app.json
@@ -1,7 +1,7 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "noEmit": true,
     "tsBuildInfoFile": "../node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "jsx": "react-jsx"

--- a/javascript/eslint.config.js
+++ b/javascript/eslint.config.js
@@ -27,8 +27,8 @@ const sharedRules = {
     'error',
     {
       groups: [
-        // Group 1: React and third-party imports
-        ['^react', '^[^#./]'],
+        // Group 1: React and third-party imports (React first)
+        ['^react', '^@?\\w', '^[^#./]'],
 
         // Group 2: Internal imports (#) and relative imports
         ['^#\\w+', '^\\.'],
@@ -117,6 +117,23 @@ export default [
       parserOptions: {
         project: new URL('./packages/core/tsconfig.json', import.meta.url).pathname,
         tsconfigRootDir: new URL('./packages/core', import.meta.url).pathname,
+      },
+      globals: globals.browser,
+    },
+    plugins: sharedPlugins,
+    rules: sharedRules,
+  },
+
+  // RPC package
+  {
+    files: ['packages/rpc/**/*.{ts,tsx}'],
+    languageOptions: {
+      ecmaVersion: 2020,
+      sourceType: 'module',
+      parser: tseslint.parser,
+      parserOptions: {
+        project: new URL('./packages/rpc/tsconfig.json', import.meta.url).pathname,
+        tsconfigRootDir: new URL('./packages/rpc', import.meta.url).pathname,
       },
       globals: globals.browser,
     },

--- a/javascript/packages/core/components/views/project/project-detail.tsx
+++ b/javascript/packages/core/components/views/project/project-detail.tsx
@@ -1,46 +1,15 @@
-import { useEffect } from 'react';
-import { useState } from 'react';
-import { createClient, Interceptor } from '@connectrpc/connect';
-import { createGrpcWebTransport } from '@connectrpc/connect-web';
-
 import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
-import { Project } from '#gen-api/v2/project_pb';
-import { ProjectService } from '#gen-api/v2/project_svc_pb';
+import { useQueryProvider } from '#core/providers/query-provider/use-query-provider';
 
 export function ProjectDetail() {
-  const [project, setProject] = useState<Project>();
+  const { useQuery } = useQueryProvider();
   const { projectId } = useStudioParams('base');
+  const { data } = useQuery<{ project: Record<string, unknown> }>('GetProject', {
+    name: projectId,
+    namespace: projectId,
+  });
 
-  useEffect(() => {
-    const getProject = async () => {
-      const callerInterceptor: Interceptor = (next) => async (req) => {
-        req.header.set('context-Ttl-Ms', '10000');
-        req.header.set('grpc-timeout', '1000000m');
-        req.header.set('Rpc-Caller', 'ma-studio');
-        req.header.set('Rpc-Encoding', 'proto');
-        req.header.set('Rpc-Service', 'ma-apiserver');
-
-        return await next(req);
-      };
-
-      const transport = createGrpcWebTransport({
-        baseUrl: 'http://localhost:8081',
-        interceptors: [callerInterceptor],
-        useBinaryFormat: true,
-      });
-
-      const client = createClient(ProjectService, transport);
-      const projectResponse = await client.getProject({
-        name: projectId,
-        namespace: projectId,
-      });
-      setProject(projectResponse.project);
-    };
-
-    getProject().catch((error) => {
-      console.error('Error getting project:', error);
-    });
-  }, [projectId]);
-
-  return <div>{project?.metadata?.name}</div>;
+  // The project type will not be directly exposed to the @michelangelo/core package.
+  // eslint-disable-next-line @typescript-eslint/dot-notation
+  return <div>{data?.project?.metadata?.['name']}</div>;
 }

--- a/javascript/packages/core/index.tsx
+++ b/javascript/packages/core/index.tsx
@@ -1,15 +1,20 @@
 import { AppNavBar } from 'baseui/app-nav-bar';
 
+import { QueryProvider } from '#core/providers/query-provider/query-provider';
 import { Router } from '#core/router/router';
 import { ThemeProvider } from '#core/themes/provider';
 
+import type { QueryContextType } from '#core/providers/query-provider/types';
+
 import '#core/styles/main.css';
 
-export function CoreApp() {
+export function CoreApp(queryContext: QueryContextType) {
   return (
     <ThemeProvider>
-      <AppNavBar title="Michelangelo Studio" />
-      <Router />
+      <QueryProvider {...queryContext}>
+        <AppNavBar title="Michelangelo Studio" />
+        <Router />
+      </QueryProvider>
     </ThemeProvider>
   );
 }

--- a/javascript/packages/core/package.json
+++ b/javascript/packages/core/package.json
@@ -35,12 +35,11 @@
     ".": {
       "development": "./index.tsx",
       "production": "./dist/core.js",
-      "default": "./dist/core.js"
+      "default": "./dist/core.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "imports": {
-    "#gen-api/*": "../../gen/grpc/michelangelo/api/*",
-    "#gen-k8s/*": "../../gen/grpc/k8s.io/*",
     "#core/*": "./"
   }
 }

--- a/javascript/packages/core/package.json
+++ b/javascript/packages/core/package.json
@@ -4,7 +4,6 @@
   "version": "0.0.0",
   "type": "module",
   "main": "dist/core.js",
-  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc && vite build",
     "test": "vitest"
@@ -34,6 +33,7 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "development": "./index.tsx",
       "production": "./dist/core.js",
       "default": "./dist/core.js"

--- a/javascript/packages/core/package.json
+++ b/javascript/packages/core/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "main": "dist/core.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc && vite build",
     "test": "vitest"
@@ -35,8 +36,7 @@
     ".": {
       "development": "./index.tsx",
       "production": "./dist/core.js",
-      "default": "./dist/core.js",
-      "types": "./dist/index.d.ts"
+      "default": "./dist/core.js"
     }
   },
   "imports": {

--- a/javascript/packages/core/providers/query-provider/query-context.ts
+++ b/javascript/packages/core/providers/query-provider/query-context.ts
@@ -1,0 +1,9 @@
+import { createContext } from 'react';
+
+import type { QueryContextType } from './types';
+
+export const QueryContext = createContext<QueryContextType>({
+  useQuery: () => {
+    throw new Error('useQuery must be used within a QueryProvider');
+  },
+});

--- a/javascript/packages/core/providers/query-provider/query-provider.tsx
+++ b/javascript/packages/core/providers/query-provider/query-provider.tsx
@@ -1,0 +1,27 @@
+import { QueryContext } from './query-context';
+
+import type { QueryContextType } from './types';
+
+/**
+ * @description
+ * Provides the query context to the application. This configuration provided to the
+ * {@link QueryProvider} should be able to connect to the Michelangelo API yarpc server.
+ *
+ * @remarks
+ * Leverages {@link QueryContext} to provide the query context to the application.
+ *
+ * @example
+ * ```tsx
+ * <QueryProvider
+ *   useQuery={useQuery}
+ * >
+ *   <App />
+ * </QueryProvider>
+ * ```
+ */
+export const QueryProvider = ({
+  children,
+  ...queryContext
+}: { children: React.ReactNode } & QueryContextType) => {
+  return <QueryContext.Provider value={queryContext}>{children}</QueryContext.Provider>;
+};

--- a/javascript/packages/core/providers/query-provider/types.ts
+++ b/javascript/packages/core/providers/query-provider/types.ts
@@ -1,0 +1,16 @@
+/**
+ * @description
+ * The hooks provided to the application to connect to the services injected
+ * into the application.
+ *
+ * @remarks
+ * Since the available queryIds are injected into the application, the parameters and
+ * return types are unknown.
+ */
+export type QueryContextType = {
+  useQuery: <TData>(
+    queryId: string,
+    args: unknown,
+    options?: { enabled?: boolean }
+  ) => { data: TData | undefined };
+};

--- a/javascript/packages/core/providers/query-provider/use-query-provider.tsx
+++ b/javascript/packages/core/providers/query-provider/use-query-provider.tsx
@@ -1,0 +1,7 @@
+import { useContext } from 'react';
+
+import { QueryContext } from './query-context';
+
+export const useQueryProvider = () => {
+  return useContext(QueryContext);
+};

--- a/javascript/packages/rpc/build-rpc-query-hooks.ts
+++ b/javascript/packages/rpc/build-rpc-query-hooks.ts
@@ -1,0 +1,70 @@
+import { useMemo } from 'react';
+import {
+  useQuery as useTanstackQuery,
+  UseQueryOptions,
+  UseQueryResult,
+} from '@tanstack/react-query';
+
+import { useRpcProvider } from '#rpc/providers/rpc-provider/use-rpc-provider';
+import { RpcHandlers } from './handlers';
+
+import type { RpcRequest, RpcResponse } from './types';
+
+/**
+ * @description
+ * Builds a set of Tanstack Query-wrapped hooks for a given set of RPC handlers.
+ *
+ * @remarks
+ * Leverages {@link useRpcProvider} to access the available RPC handlers. If the RPC ID is not registered,
+ * an error will be thrown when the hook is called.
+ *
+ * @returns
+ * A set of query hooks for the given RPC handler.
+ */
+export function buildRPCQueryHooks<
+  TRpcHandlers extends Record<string, (args: unknown) => Promise<unknown>> = ReturnType<
+    typeof RpcHandlers
+  >,
+>(): {
+  // This explicit specification of the return type is necessary because the `useQuery` hook
+  // is generic and cannot be inferred.
+  useQuery: <
+    RpcId extends string,
+    TData = RpcId extends keyof TRpcHandlers ? RpcResponse<TRpcHandlers, RpcId> : unknown,
+  >(
+    rpcId: RpcId,
+    args: RpcId extends keyof TRpcHandlers ? RpcRequest<TRpcHandlers, RpcId> : unknown,
+    options?: Omit<UseQueryOptions<TData>, 'queryKey' | 'queryFn'>
+  ) => UseQueryResult<TData>;
+} {
+  const useRpcQueryKey = <RpcId extends string>(
+    rpcId: RpcId,
+    args: RpcId extends keyof TRpcHandlers ? RpcRequest<TRpcHandlers, RpcId> : unknown
+  ) => {
+    return useMemo(() => [rpcId, args] as const, [rpcId, args]);
+  };
+
+  const useQuery = <
+    RpcId extends string,
+    TData = RpcId extends keyof TRpcHandlers ? RpcResponse<TRpcHandlers, RpcId> : unknown,
+  >(
+    rpcId: RpcId,
+    args: RpcId extends keyof TRpcHandlers ? RpcRequest<TRpcHandlers, RpcId> : unknown,
+    options?: Omit<UseQueryOptions<TData>, 'queryKey' | 'queryFn'>
+  ): UseQueryResult<TData> => {
+    const rpcProvider = useRpcProvider();
+    const rpcHandler = rpcProvider[String(rpcId)];
+    if (!rpcHandler) {
+      throw new Error(`RPC ID "${String(rpcId)}" not registered in RpcProvider`);
+    }
+
+    const queryKey = useRpcQueryKey(rpcId, args);
+    return useTanstackQuery({
+      queryKey,
+      queryFn: () => rpcHandler(args) as Promise<TData>,
+      ...options,
+    });
+  };
+
+  return { useQuery };
+}

--- a/javascript/packages/rpc/handlers.ts
+++ b/javascript/packages/rpc/handlers.ts
@@ -1,0 +1,15 @@
+import { createClient, Transport } from '@connectrpc/connect';
+
+import { PipelineService } from './gen/michelangelo/api/v2/pipeline_svc_pb';
+import { ProjectService } from './gen/michelangelo/api/v2/project_svc_pb';
+
+export const RpcHandlers = (transport: Transport) => {
+  const ProjectServiceClient = createClient(ProjectService, transport);
+  const PipelineServiceClient = createClient(PipelineService, transport);
+
+  return {
+    ListProject: ProjectServiceClient.listProject,
+    GetProject: ProjectServiceClient.getProject,
+    ListPipeline: PipelineServiceClient.listPipeline,
+  };
+};

--- a/javascript/packages/rpc/index.ts
+++ b/javascript/packages/rpc/index.ts
@@ -1,0 +1,34 @@
+// Export all files from gen/michelangelo/api
+export * from './gen/michelangelo/api/conditions_pb';
+export * from './gen/michelangelo/api/list_pb';
+export * from './gen/michelangelo/api/options_pb';
+export * from './gen/michelangelo/api/typed_struct_pb';
+
+// Export all files from gen/michelangelo/api/v2
+export * from './gen/michelangelo/api/v2/git_pb';
+export * from './gen/michelangelo/api/v2/groupversion_info_pb';
+export * from './gen/michelangelo/api/v2/job_pb';
+export * from './gen/michelangelo/api/v2/model_pb';
+export * from './gen/michelangelo/api/v2/model_svc_pb';
+export * from './gen/michelangelo/api/v2/notification_pb';
+export * from './gen/michelangelo/api/v2/parameter_pb';
+export * from './gen/michelangelo/api/v2/pipeline_pb';
+export * from './gen/michelangelo/api/v2/pipeline_run_pb';
+export * from './gen/michelangelo/api/v2/pipeline_run_svc_pb';
+export * from './gen/michelangelo/api/v2/pipeline_svc_pb';
+export * from './gen/michelangelo/api/v2/pod_pb';
+export * from './gen/michelangelo/api/v2/project_pb';
+export * from './gen/michelangelo/api/v2/project_svc_pb';
+export * from './gen/michelangelo/api/v2/ray_cluster_pb';
+export * from './gen/michelangelo/api/v2/ray_cluster_svc_pb';
+export * from './gen/michelangelo/api/v2/ray_job_pb';
+export * from './gen/michelangelo/api/v2/ray_job_svc_pb';
+export * from './gen/michelangelo/api/v2/schema_pb';
+export * from './gen/michelangelo/api/v2/spark_job_pb';
+export * from './gen/michelangelo/api/v2/spark_job_svc_pb';
+export * from './gen/michelangelo/api/v2/trigger_run_pb';
+export * from './gen/michelangelo/api/v2/trigger_run_svc_pb';
+export * from './gen/michelangelo/api/v2/user_pb';
+
+export { buildRPCQueryHooks } from './build-rpc-query-hooks';
+export { RpcProvider } from './providers/rpc-provider/rpc-provider';

--- a/javascript/packages/rpc/package.json
+++ b/javascript/packages/rpc/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@michelangelo/rpc",
   "license": "UNLICENSED",
+  "type": "module",
   "version": "0.0.0",
   "scripts": {
     "build": "vite build"

--- a/javascript/packages/rpc/package.json
+++ b/javascript/packages/rpc/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@michelangelo/rpc",
+  "license": "UNLICENSED",
+  "version": "0.0.0",
+  "scripts": {
+    "build": "vite build"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.4.1",
+    "vite": "6.2.0"
+  },
+  "dependencies": {
+    "@connectrpc/connect": "^2.0.2",
+    "@connectrpc/connect-web": "^2.0.2",
+    "@tanstack/react-query": "^5.74.7"
+  },
+  "exports": {
+    ".": {
+      "default": "./index.ts"
+    }
+  },
+  "imports": {
+    "#rpc/*": "./"
+  }
+}

--- a/javascript/packages/rpc/providers/rpc-provider/rpc-context.ts
+++ b/javascript/packages/rpc/providers/rpc-provider/rpc-context.ts
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+import { RpcContextType } from './types';
+
+export const RpcContext = createContext<RpcContextType>({});

--- a/javascript/packages/rpc/providers/rpc-provider/rpc-provider.tsx
+++ b/javascript/packages/rpc/providers/rpc-provider/rpc-provider.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Interceptor } from '@connectrpc/connect';
+import { createGrpcWebTransport } from '@connectrpc/connect-web';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { RpcHandlers } from '#rpc/handlers';
+import { RpcContext } from './rpc-context';
+
+// This interceptor is used to set the headers for the RPC request to
+// be compatible with the Michelangelo API yarpc server.
+const callerInterceptor: Interceptor = (next) => async (req) => {
+  req.header.set('context-Ttl-Ms', '10000');
+  req.header.set('grpc-timeout', '1000000m');
+  req.header.set('Rpc-Caller', 'ma-studio');
+  req.header.set('Rpc-Encoding', 'proto');
+  req.header.set('Rpc-Service', 'ma-apiserver');
+
+  return await next(req);
+};
+
+// This transport is used to connect to the Envoy proxy that proxies gRPC web requests
+// to gRPC services.
+const transport = createGrpcWebTransport({
+  baseUrl: 'http://localhost:8081',
+  interceptors: [callerInterceptor],
+  useBinaryFormat: true,
+});
+
+const queryClient = new QueryClient();
+
+/**
+ * @description
+ * Provides the RPC handlers to the application.
+ *
+ * @remarks
+ * Leverages {@link RpcHandlers} to create the RPC handlers.
+ *
+ * @example
+ * ```tsx
+ * <RpcProvider>
+ *   <App />
+ * </RpcProvider>
+ * ```
+ */
+export const RpcProvider = ({ children }: { children: React.ReactNode }) => {
+  const handlers = RpcHandlers(transport);
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <RpcContext.Provider value={handlers}>{children}</RpcContext.Provider>
+    </QueryClientProvider>
+  );
+};

--- a/javascript/packages/rpc/providers/rpc-provider/types.ts
+++ b/javascript/packages/rpc/providers/rpc-provider/types.ts
@@ -1,0 +1,1 @@
+export type RpcContextType = Record<string, (args: unknown) => Promise<unknown>>;

--- a/javascript/packages/rpc/providers/rpc-provider/use-rpc-provider.ts
+++ b/javascript/packages/rpc/providers/rpc-provider/use-rpc-provider.ts
@@ -1,0 +1,7 @@
+import { useContext } from 'react';
+
+import { RpcContext } from './rpc-context';
+
+export function useRpcProvider() {
+  return useContext(RpcContext);
+}

--- a/javascript/packages/rpc/tsconfig.json
+++ b/javascript/packages/rpc/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["."],
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "moduleResolution": "node",
+    "noEmit": false,
+    "jsx": "react-jsx",
+    "outDir": "dist",
+    "rootDir": "."
+  }
+}

--- a/javascript/packages/rpc/types.ts
+++ b/javascript/packages/rpc/types.ts
@@ -1,0 +1,91 @@
+import { Message } from '@bufbuild/protobuf';
+import { UseQueryResult } from '@tanstack/react-query';
+
+/**
+ * @description
+ * Picks the request type from the RPC handler.
+ *
+ * @remarks
+ * Expects the request type to be the first parameter of the RPC handler.
+ *
+ * Leverages `OmitTypeName` to remove the `$typeName` and `$unknown` properties from the request type.
+ * This is necessary because the protobuf-es library adds these properties to the request type.
+ *
+ * @example
+ * ```ts
+ * type MyRequest = RpcRequest<{ myRpc: (args: { myField: string }) => Promise<void> }, 'myRpc'>;
+ * const myRequest: MyRequest = { myField: 'hello' };
+ * ```
+ */
+export type RpcRequest<
+  TRpcHandlers extends Record<string, (args: unknown) => Promise<unknown>>,
+  RpcId extends keyof TRpcHandlers,
+> = OmitTypeName<Parameters<TRpcHandlers[RpcId]>[0]>;
+
+/**
+ * @description
+ * Picks the response type from the RPC handler.
+ *
+ * @remarks
+ * Expects the response type to be wrapped in a `Promise`.
+ *
+ * Leverages `OmitTypeName` to remove the `$typeName` and `$unknown` properties from the response type.
+ * This is necessary because the protobuf-es library adds these properties to the response type.
+ *
+ * @example
+ * ```ts
+ * type MyResponse = RpcResponse<{ myRpc: (args: any) => Promise<{ myField: string }> }, 'myRpc'>;
+ * const myResponse: MyResponse = { myField: 'hello' };
+ * ```
+ */
+export type RpcResponse<
+  TRpcHandlers extends Record<string, (args: unknown) => Promise<unknown>>,
+  RpcId extends keyof TRpcHandlers,
+> = OmitTypeName<Awaited<ReturnType<TRpcHandlers[RpcId]>>>;
+
+export type BuildRPCQueryHooksReturn<
+  TRpcHandlers extends Record<string, (args: unknown) => Promise<unknown>>,
+> = {
+  useQuery: <
+    RpcId extends string,
+    TData = RpcId extends keyof TRpcHandlers ? RpcResponse<TRpcHandlers, RpcId> : unknown,
+  >(
+    rpcId: RpcId,
+    args: RpcId extends keyof TRpcHandlers ? RpcRequest<TRpcHandlers, RpcId> : unknown
+  ) => UseQueryResult<TData>;
+};
+
+/**
+ * @description
+ * Removes the `$typeName` and `$unknown` properties from a message. These are properties
+ * that are added by the protobuf-es library. We don't need them for our RPC calls.
+ *
+ * @example
+ * ```ts
+ * type MyMessage = {
+ *   $typeName: string;
+ *   $unknown: unknown;
+ *   myField: string;
+ * };
+ *
+ * type MyMessageWithoutTypeName = OmitTypeName<MyMessage>;
+ * const message: MyMessageWithoutTypeName = { myField: 'hello' };
+ * ```
+ *
+ * @see https://github.com/bufbuild/protobuf-es/issues/1016
+ */
+type OmitTypeName<T> = {
+  [P in keyof T as P extends '$typeName' | '$unknown' ? never : P]: Recurse<T[P]>;
+};
+
+type Recurse<F> = F extends (infer U)[]
+  ? Recurse<U>[]
+  : F extends Message
+    ? OmitTypeName<F>
+    : F extends { case: infer C extends string; value: infer V extends Message }
+      ? { case: C; value: OmitTypeName<V> }
+      : F extends Record<string, infer V extends Message>
+        ? Record<string, OmitTypeName<V>>
+        : F extends Record<number, infer V extends Message>
+          ? Record<number, OmitTypeName<V>>
+          : F;

--- a/javascript/packages/rpc/vite.config.ts
+++ b/javascript/packages/rpc/vite.config.ts
@@ -1,0 +1,25 @@
+import react from '@vitejs/plugin-react';
+import path from 'path';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: path.resolve(__dirname, 'index.ts'),
+      name: 'MichelangeloRpc',
+      formats: ['es'],
+    },
+    rollupOptions: {
+      external: [
+        'react',
+        '@bufbuild/protobuf',
+        '@connectrpc/connect',
+        '@connectrpc/connect-web',
+        '@tanstack/react-query',
+      ],
+    },
+    outDir: 'dist',
+    emptyOutDir: true,
+  },
+  plugins: [react()],
+});

--- a/javascript/tsconfig.base.json
+++ b/javascript/tsconfig.base.json
@@ -15,9 +15,8 @@
     "allowSyntheticDefaultImports": true,
     "baseUrl": ".",
     "paths": {
-      "#gen-api/*": ["gen/grpc/michelangelo/api/*"],
-      "#gen-k8s/*": ["gen/grpc/k8s.io/*"],
-      "#core/*": ["packages/core/*"]
+      "#core/*": ["packages/core/*"],
+      "#rpc/*": ["packages/rpc/*"]
     }
   }
 }

--- a/javascript/tsconfig.json
+++ b/javascript/tsconfig.json
@@ -3,6 +3,7 @@
   "references": [
     { "path": "./app/tsconfig.app.json" },
     { "path": "./app/tsconfig.node.json" },
-    { "path": "./packages/core" }
+    { "path": "./packages/core" },
+    { "path": "./packages/rpc" }
   ]
 }

--- a/javascript/yarn.lock
+++ b/javascript/yarn.lock
@@ -673,6 +673,18 @@
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
   integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
 
+"@tanstack/query-core@5.74.7":
+  version "5.74.7"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.74.7.tgz#beb565a5f3d95a1e3bd756e5eb1e41c3eb48ae7f"
+  integrity sha512-X3StkN/Y6KGHndTjJf8H8th7AX4bKfbRpiVhVqevf0QWlxl6DhyJ0TYG3R0LARa/+xqDwzU9mA4pbJxzPCI29A==
+
+"@tanstack/react-query@^5.74.7":
+  version "5.74.7"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.74.7.tgz#3507541b43de72399a19a71ff66828a12b859581"
+  integrity sha512-u4o/RIWnnrq26orGZu2NDPwmVof1vtAiiV6KYUXd49GuK+8HX+gyxoAYqIaZogvCE1cqOuZAhQKcrKGYGkrLxg==
+  dependencies:
+    "@tanstack/query-core" "5.74.7"
+
 "@testing-library/dom@^10.4.0":
   version "10.4.0"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-10.4.0.tgz#82a9d9462f11d240ecadbf406607c6ceeeff43a8"

--- a/tools/gen-grpc-client.sh
+++ b/tools/gen-grpc-client.sh
@@ -16,7 +16,7 @@ move_generated_files() {
     local src_k8s="${TMP_DIR}/gen/${client}/k8s"
     local src_api="${TMP_DIR}/gen/${client}/michelangelo/api"
   elif [ "$client" == "javascript" ]; then
-    client_dir="${WORKSPACE_ROOT}/${client}/gen/grpc"
+    client_dir="${WORKSPACE_ROOT}/${client}/packages/rpc/gen"
     local src_k8s="${TMP_DIR}/gen/${client}/k8s.io"
     local src_api="${TMP_DIR}/gen/${client}/michelangelo"
   else


### PR DESCRIPTION
One of the core components of MA Studio is its ability to connect to Unified API in a type-safe manner using react hooks. This diff implements this ability. Refactored @michelangelo/core and @michelangelo/app to use a new package, @michelangelo/rpc. This allows removal of all generated code references from @michelangelo/core, which is required to maintain a custom Michelangelo Studio RPC connection internally and externally.

Right now, the ProjectDetail component is explicitly accessing the query hooks. That said, I didn't want to temporarily register @michelangelo/rpc and a dependency of @michelangelo/core. For now, type oddities that come with direct access of useQuery results will be ignored.

When implementing buildRPCQueryHooks, TypeScript couldn't infer the complex types associated with RpcResponse/RpcRequest due to amount of Generics and wrapping (e.g., OmitTypeName). This is remedied by providing an explicit return type to buildRPCQueryHooks.

Leverage ConnectRPC example to remove "helper" fields from the generated type. Without removing $typeName, requests to Unified API endpoints would require #typeName throughout the request data.

Updated app/tsconfig.app.json to use "moduleResolution": "node" to remedy CICD failure running typecheck: @michelangelo/core types not found from app/App.tsx

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
**Direct access of hooks near createRPCQueryHooks** provides full type-safety. Only provided to packages dependent on @michelangelo/rpc
<img width="1840" alt="Screenshot 2025-04-29 at 23 14 16" src="https://github.com/user-attachments/assets/cb8e0e69-a638-41ac-8420-5d3ce0518951" />

**Direct access of nonexistent RPC Handler near createRPCQueryHooks** falls back I/O types to unknown
<img width="1840" alt="Screenshot 2025-04-29 at 23 14 41" src="https://github.com/user-attachments/assets/712f8cd9-de08-42f7-a48d-04c2afa6306a" />

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
