### PR TITLE
Add query transformation to hooks

### DIFF
--- a/javascript/packages/rpc/build-rpc-query-hooks.ts
+++ b/javascript/packages/rpc/build-rpc-query-hooks.ts
@@ -6,8 +6,11 @@ import {
 } from '@tanstack/react-query';
 
 import { useRpcProvider } from '#rpc/providers/rpc-provider/use-rpc-provider';
+import { extractEntityFromResponse } from '#rpc/transformations/common';
+import { isSingularResponse } from '#rpc/transformations/guards';
 import { RpcHandlers } from './handlers';
 
+import type { ExtractEntityFromResponse } from '#rpc/transformations/types';
 import type { RpcRequest, RpcResponse } from './types';
 
 /**
@@ -31,11 +34,14 @@ export function buildRPCQueryHooks<
   useQuery: <
     RpcId extends string,
     TData = RpcId extends keyof TRpcHandlers ? RpcResponse<TRpcHandlers, RpcId> : unknown,
+    TTransformedData = ExtractEntityFromResponse<TData>,
   >(
     rpcId: RpcId,
     args: RpcId extends keyof TRpcHandlers ? RpcRequest<TRpcHandlers, RpcId> : unknown,
-    options?: Omit<UseQueryOptions<TData>, 'queryKey' | 'queryFn'>
-  ) => UseQueryResult<TData>;
+    options?: Partial<
+      Omit<UseQueryOptions<TData, Error, TTransformedData>, 'queryKey' | 'queryFn' | 'select'>
+    >
+  ) => UseQueryResult<TTransformedData>;
 } {
   const useRpcQueryKey = <RpcId extends string>(
     rpcId: RpcId,
@@ -47,11 +53,14 @@ export function buildRPCQueryHooks<
   const useQuery = <
     RpcId extends string,
     TData = RpcId extends keyof TRpcHandlers ? RpcResponse<TRpcHandlers, RpcId> : unknown,
+    TTransformedData = ExtractEntityFromResponse<TData>,
   >(
     rpcId: RpcId,
     args: RpcId extends keyof TRpcHandlers ? RpcRequest<TRpcHandlers, RpcId> : unknown,
-    options?: Omit<UseQueryOptions<TData>, 'queryKey' | 'queryFn'>
-  ): UseQueryResult<TData> => {
+    options?: Partial<
+      Omit<UseQueryOptions<TData, Error, TTransformedData>, 'queryKey' | 'queryFn' | 'select'>
+    >
+  ): UseQueryResult<TTransformedData> => {
     const rpcProvider = useRpcProvider();
     const rpcHandler = rpcProvider[String(rpcId)];
     if (!rpcHandler) {
@@ -63,6 +72,12 @@ export function buildRPCQueryHooks<
       queryKey,
       queryFn: () => rpcHandler(args) as Promise<TData>,
       ...options,
+      select: (data: TData) => {
+        if (isSingularResponse(data)) {
+          return extractEntityFromResponse(data) as TTransformedData;
+        }
+        return data as unknown as TTransformedData;
+      },
     });
   };
 

--- a/javascript/packages/rpc/transformations/common.ts
+++ b/javascript/packages/rpc/transformations/common.ts
@@ -1,0 +1,40 @@
+import { ExtractEntityFromResponse, HasTypeName } from './types';
+
+/**
+ * Extracts the main entity from a response
+ *
+ * @example
+ * ```ts
+ * type MyResponse = {
+ *   $typeName: 'michelangelo.api.v2.GetProjectResponse';
+ *   project: Project;
+ * }
+ *
+ * expect(extractEntityFromResponse(myResponse)).toEqual(myResponse.project)    ;
+ *
+ * // If the response is not a valid response, it will throw an error
+ * type MyResponse = {
+ *   $typeName: 'some.other.api.v1.SomeOtherResponse';
+ *   someOtherEntity: SomeOtherEntity;
+ * }
+ *
+ * expect(extractEntityFromResponse(myResponse)).toThrowError(
+ *   'Entity name someOtherEntity not found in response'
+ * );
+ * ```
+ */
+export function extractEntityFromResponse<T extends HasTypeName>(
+  response: T
+): ExtractEntityFromResponse<T> {
+  const typeName = response.$typeName;
+  const entityName = typeName
+    .replace(/^michelangelo\.api\.v2\.(Get|Create|Update)/, '')
+    .replace(/Response$/, '')
+    .toLowerCase();
+
+  if (entityName in response) {
+    return response[entityName] as ExtractEntityFromResponse<T>;
+  }
+
+  throw new Error(`Entity name ${entityName} not found in response`);
+}

--- a/javascript/packages/rpc/transformations/guards.ts
+++ b/javascript/packages/rpc/transformations/guards.ts
@@ -1,0 +1,20 @@
+import { HasTypeName } from './types';
+
+/**
+ * Type predicate to check if an object has a $typeName property
+ */
+export function hasTypeName(value: unknown): value is HasTypeName {
+  return typeof value === 'object' && value !== null && '$typeName' in value;
+}
+
+/**
+ * Type guard to check if a response is an entity response (Get, Create, or Update)
+ */
+export function isSingularResponse<T>(value: T): value is T & HasTypeName {
+  return (
+    hasTypeName(value) &&
+    (value.$typeName.startsWith('michelangelo.api.v2.Get') ||
+      value.$typeName.startsWith('michelangelo.api.v2.Create') ||
+      value.$typeName.startsWith('michelangelo.api.v2.Update'))
+  );
+}

--- a/javascript/packages/rpc/transformations/types.ts
+++ b/javascript/packages/rpc/transformations/types.ts
@@ -1,0 +1,123 @@
+/**
+ * @description
+ * Type for objects that have a $typeName property. $typeName is added by the `@bufbuild/protobuf` library.
+ * This type is used to identify the associated protobuf message type.
+ *
+ * @example
+ * ```ts
+ * type GetProjectResponse = {
+ *   $typeName: 'michelangelo.api.v2.GetProjectResponse';
+ *   project: Project;
+ * };
+ * ```
+ */
+export type HasTypeName = {
+  $typeName: string;
+};
+
+/**
+ * @description
+ * Singular endpoints are endpoints that return a single entity.
+ *
+ * @example
+ * ```ts
+ * type GetProjectResponse = {
+ *   $typeName: 'michelangelo.api.v2.GetProjectResponse';
+ *   project: Project;
+ * };
+ */
+type SingularEndpoint = 'Get' | 'Create' | 'Update';
+
+/**
+ * @description
+ * Delete endpoint is the endpoint that deletes an entity.
+ */
+type DeleteEndpoint = 'Delete';
+
+/**
+ * @description
+ * List endpoint is the endpoint that returns a list of entities.
+ */
+type ListEndpoint = 'List';
+
+/**
+ * @description
+ * Type for the endpoint part of the $typeName property.
+ *
+ * @example
+ * ```ts
+ * // Endpoint can be used in a type guard to check if a response typeName
+ * // belongs to a known endpoint
+ * type IsProjectResponse<T extends string> =
+ *   T extends `michelangelo.api.v2.${Endpoint}ProjectResponse` ? true : false;
+ *
+ * type IsProjectResponseResult = IsProjectResponse<'michelangelo.api.v2.GetProjectResponse'>;
+ * // => true -- Get is not a known endpoint
+ *
+ * type IsProjectResponseResult = IsProjectResponse<'michelangelo.api.v2.RetryProjectResponse'>;
+ * // => false -- Retry is not a known endpoint
+ * ```
+ */
+type Endpoint = SingularEndpoint | ListEndpoint | DeleteEndpoint;
+
+/**
+ * @description
+ * Extracts the lowercased entity name from an absolute path to the response protobuf message.
+ * The resulting entity name should be used as the key to access the entity from the response object.
+ *
+ * @remarks
+ * This assumes that the response protobuf message is in the `michelangelo.api.v2` namespace.
+ *
+ * @example
+ * ```ts
+ * type GetProjectResponse = {
+ *   $typeName: 'michelangelo.api.v2.GetProjectResponse';
+ *   project: Project;
+ * };
+ *
+ * ExtractEntityName<'michelangelo.api.v2.GetProjectResponse'>;
+ * // => 'project'
+ *
+ * ExtractEntityName<'some.other.protobuf.GetProjectResponse'>;
+ * // => never
+ * ```
+ */
+type ExtractEntityName<T extends string> =
+  T extends `michelangelo.api.v2.${Endpoint}${infer Entity}Response` ? Lowercase<Entity> : never;
+
+/**
+ * @description
+ * Extracts the inner entity from a protobuf response message.
+ *
+ * @example
+ * ```ts
+ * type GetProjectResponse = {
+ *   $typeName: 'michelangelo.api.v2.GetProjectResponse';
+ *   project: Project;
+ * };
+ *
+ * ExtractEntityFromResponse<GetProjectResponse>;
+ * // => Project
+ *
+ * type ListProjectsResponse = {
+ *   $typeName: 'michelangelo.api.v2.ListProjectsResponse';
+ *   projects: Project[];
+ * };
+ *
+ * ExtractEntityFromResponse<ListProjectsResponse>;
+ * // => Project[]
+ *
+ * type SomeOtherResponse  = {
+ *   $typeName: 'some.other.protobuf.SomeOtherResponse';
+ *   someField: string;
+ * };
+ *
+ * ExtractEntityFromResponse<SomeOtherResponse>;
+ * // => SomeOtherResponse
+ * ```
+ */
+export type ExtractEntityFromResponse<T> = T extends HasTypeName
+  ? T extends Partial<Record<ExtractEntityName<T['$typeName']>, infer E>>
+    ? E
+    : T
+  : T;

--- a/javascript/packages/rpc/types.ts
+++ b/javascript/packages/rpc/types.ts
@@ -1,6 +1,8 @@
 import { Message } from '@bufbuild/protobuf';
 import { UseQueryResult } from '@tanstack/react-query';
 
+import { RpcHandlers } from './handlers';
+
 /**
  * @description
  * Picks the request type from the RPC handler.
@@ -29,9 +31,6 @@ export type RpcRequest<
  * @remarks
  * Expects the response type to be wrapped in a `Promise`.
  *
- * Leverages `OmitTypeName` to remove the `$typeName` and `$unknown` properties from the response type.
- * This is necessary because the protobuf-es library adds these properties to the response type.
- *
  * @example
  * ```ts
  * type MyResponse = RpcResponse<{ myRpc: (args: any) => Promise<{ myField: string }> }, 'myRpc'>;
@@ -41,7 +40,7 @@ export type RpcRequest<
 export type RpcResponse<
   TRpcHandlers extends Record<string, (args: unknown) => Promise<unknown>>,
   RpcId extends keyof TRpcHandlers,
-> = OmitTypeName<Awaited<ReturnType<TRpcHandlers[RpcId]>>>;
+> = Awaited<ReturnType<TRpcHandlers[RpcId]>>;
 
 export type BuildRPCQueryHooksReturn<
   TRpcHandlers extends Record<string, (args: unknown) => Promise<unknown>>,
@@ -54,6 +53,11 @@ export type BuildRPCQueryHooksReturn<
     args: RpcId extends keyof TRpcHandlers ? RpcRequest<TRpcHandlers, RpcId> : unknown
   ) => UseQueryResult<TData>;
 };
+
+/**
+ * @see {@link RpcHandlers}
+ */
+export type RpcHandlerType = ReturnType<typeof RpcHandlers>;
 
 /**
  * @description


### PR DESCRIPTION
Internally, MA Studio query hooks transform Response protobuf messages to provide direct access to the requested data. For example, instead of getting { project: Project } as a response, the hooks provide Project directly. Implemented this functionality for singular-entity endpoints like Get, Create, and Update. Implemented this using UseQueryOptions.select; removed select as an available input to useQuery.

This updated the return type of useQuery, which means that the QueryContextType can no longer support a generic that controls the data result. This is because the input

Leverage prototobuf-es $typeName property that is included with alongside the generated protobuf client code because it has all the information required for correctly extracting the entity: endpoint name, and entity name. In order to leverage the $typeName property, removed the OmitTypeName wrapper from RpcResponse. $typeName is still removed from RpcRequest. This works well because we don't require clients to provide $typeName but benefit from the server's insertion of the $typeName.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
**useQuery data provides direct access to CRD object**
<img width="1840" alt="Screenshot 2025-04-30 at 14 50 32" src="https://github.com/user-attachments/assets/0a14c750-edfa-4e5e-9ae2-b5c52fb19194" />

**Still renders project name when provided in URL**
<img width="1840" alt="Screenshot 2025-04-30 at 14 53 29" src="https://github.com/user-attachments/assets/a16e5312-bfc3-4ee6-8e43-4c5152ec1357" />


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
