### PR TITLE
Onboard project-aware querying to MA Studio

### DIFF
--- a/javascript/packages/core/components/views/project/project-detail.tsx
+++ b/javascript/packages/core/components/views/project/project-detail.tsx
@@ -1,12 +1,14 @@
 import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
-import { useQueryProvider } from '#core/providers/query-provider/use-query-provider';
+import { useStudioQuery } from '#core/hooks/use-studio-query';
 
 export function ProjectDetail() {
-  const { useQuery } = useQueryProvider();
   const { projectId } = useStudioParams('base');
-  const { data } = useQuery<{ project: Record<string, unknown> }>('GetProject', {
-    name: projectId,
-    namespace: projectId,
+  const { data } = useStudioQuery<{ project: Record<string, unknown> }>({
+    queryName: 'GetProject',
+    serviceOptions: {
+      name: projectId,
+      namespace: projectId,
+    },
   });
 
   // The project type will not be directly exposed to the @michelangelo/core package.

--- a/javascript/packages/core/hooks/__tests__/use-studio-query.test.ts
+++ b/javascript/packages/core/hooks/__tests__/use-studio-query.test.ts
@@ -1,0 +1,109 @@
+import { renderHook } from '@testing-library/react';
+import { vi } from 'vitest';
+
+import { useStudioQuery } from '#core/hooks/use-studio-query';
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getQueryProviderWrapper } from '#core/test/wrappers/get-query-provider-wrapper';
+import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
+
+describe('useStudioQuery', () => {
+  const mockUseQuery = vi.fn().mockReturnValue({ data: null, error: null, isLoading: false });
+
+  beforeEach(() => {
+    mockUseQuery.mockClear();
+  });
+
+  describe('when query returns no data', () => {
+    let result: ReturnType<typeof useStudioQuery>;
+
+    beforeAll(() => {
+      mockUseQuery.mockReturnValue({ data: null, error: null, isLoading: false });
+
+      const { result: _result } = renderHook(
+        () => useStudioQuery({ queryName: 'ListAnything', serviceOptions: {} }),
+        buildWrapper([getRouterWrapper(), getQueryProviderWrapper({ useQuery: mockUseQuery })])
+      );
+
+      result = _result.current;
+    });
+
+    test('returns data as is', () => {
+      expect(result.data).toBe(null);
+    });
+
+    test('returns other properties as-is', () => {
+      expect(result.error).toBe(null);
+      expect(result.isLoading).toBe(false);
+    });
+  });
+
+  describe('when clientOptions is not provided', () => {
+    let result: ReturnType<typeof useStudioQuery>;
+
+    beforeAll(() => {
+      mockUseQuery.mockReturnValue({ data: { test: 'data' }, error: null, isLoading: false });
+
+      const { result: _result } = renderHook(
+        () =>
+          useStudioQuery({
+            queryName: 'ListAnything',
+            serviceOptions: {},
+          }),
+        buildWrapper([getRouterWrapper(), getQueryProviderWrapper({ useQuery: mockUseQuery })])
+      );
+
+      result = _result.current;
+    });
+
+    test('returns data as is', () => {
+      expect(result.data).toEqual({ test: 'data' });
+    });
+
+    test('returns other properties as-is', () => {
+      expect(result.error).toBe(null);
+      expect(result.isLoading).toBe(false);
+    });
+  });
+
+  describe('query options passed to useRpcQuery', () => {
+    beforeEach(() => {
+      mockUseQuery.mockReturnValue({ data: {}, isLoading: false });
+    });
+
+    test('defaults namespace to projectId when omitted from serviceOptions args', () => {
+      renderHook(
+        () => useStudioQuery({ queryName: 'GetDataset', serviceOptions: {} }),
+        buildWrapper([
+          getRouterWrapper({ location: '/ma-dev-test' }),
+          getQueryProviderWrapper({ useQuery: mockUseQuery }),
+        ])
+      );
+
+      expect(mockUseQuery).toHaveBeenCalledWith(
+        'GetDataset',
+        expect.objectContaining({ namespace: 'ma-dev-test' }),
+        undefined
+      );
+    });
+
+    test('prefers provided namespace', () => {
+      renderHook(
+        () =>
+          useStudioQuery({
+            queryName: 'GetDataset',
+            serviceOptions: { namespace: 'provided-namespace' },
+          }),
+        buildWrapper([
+          getRouterWrapper({ location: '/ma-dev-test' }),
+          getQueryProviderWrapper({ useQuery: mockUseQuery }),
+        ])
+      );
+
+      expect(mockUseQuery).toHaveBeenCalledWith(
+        'GetDataset',
+        expect.objectContaining({ namespace: 'provided-namespace' }),
+        undefined
+      );
+    });
+  });
+});

--- a/javascript/packages/core/hooks/use-studio-query.ts
+++ b/javascript/packages/core/hooks/use-studio-query.ts
@@ -1,0 +1,20 @@
+import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
+import { useQueryProvider } from '#core/providers/query-provider/use-query-provider';
+
+import type { QueryOptions, QueryResult } from '#core/types/query-types';
+
+export const useStudioQuery = <TData>(args: {
+  queryName: string;
+  serviceOptions: Record<string, unknown>;
+  clientOptions?: QueryOptions;
+}): QueryResult<TData> => {
+  const { queryName, serviceOptions, clientOptions } = args;
+  const { projectId } = useStudioParams('base');
+  const { useQuery } = useQueryProvider();
+
+  return useQuery<TData>(
+    queryName,
+    { ...serviceOptions, namespace: serviceOptions?.namespace ?? projectId },
+    clientOptions
+  );
+};

--- a/javascript/packages/core/providers/query-provider/types.ts
+++ b/javascript/packages/core/providers/query-provider/types.ts
@@ -1,3 +1,5 @@
+import type { QueryOptions, QueryResult } from '#core/types/query-types';
+
 /**
  * @description
  * The hooks provided to the application to connect to the services injected
@@ -8,9 +10,5 @@
  * return types are unknown.
  */
 export type QueryContextType = {
-  useQuery: <TData>(
-    queryId: string,
-    args: unknown,
-    options?: { enabled?: boolean }
-  ) => { data: TData | undefined };
+  useQuery: <TData>(queryId: string, args: unknown, options?: QueryOptions) => QueryResult<TData>;
 };

--- a/javascript/packages/core/test/wrappers/get-query-provider-wrapper.tsx
+++ b/javascript/packages/core/test/wrappers/get-query-provider-wrapper.tsx
@@ -1,0 +1,39 @@
+import { vi } from 'vitest';
+
+import { QueryProvider } from '#core/providers/query-provider/query-provider';
+import { QueryContextType } from '#core/providers/query-provider/types';
+import { WrapperComponentProps } from './types';
+
+/**
+ * Creates a React wrapper for testing components that use query features.
+ * This wrapper is essential for testing components that use query hooks
+ * like useQuery, useMutation, etc.
+ *
+ * @param queryProvider - The hooks to use for the query provider
+ * @returns A wrapper component that provides query context to its children
+ *
+ * @example
+ * ```tsx
+ * // Simple usage with a specific route
+ * const mockUseQuery = jest.fn();
+ * const wrapper = getQueryProviderWrapper({ useQuery: mockUseQuery });
+ * render(<MyComponent />, { wrapper });
+ *
+ * expect(mockUseQuery).toHaveBeenCalledWith('queryId', { queryKey: ['queryId'] });
+ * ```
+ */
+export function getQueryProviderWrapper(queryProvider: QueryContextType) {
+  const mockUseQuery = vi.fn();
+
+  const base = {
+    useQuery: mockUseQuery,
+  };
+
+  return function QueryProviderWrapper({ children }: WrapperComponentProps) {
+    return (
+      <QueryProvider {...base} {...queryProvider}>
+        {children}
+      </QueryProvider>
+    );
+  };
+}

--- a/javascript/packages/core/test/wrappers/get-router-wrapper.tsx
+++ b/javascript/packages/core/test/wrappers/get-router-wrapper.tsx
@@ -40,6 +40,7 @@ export function getRouterWrapper(options?: { location?: string }) {
     return (
       <MemoryRouter initialEntries={[location]}>
         <Routes>
+          <Route path=":projectId" element={children} />
           <Route path="*" element={children} />
         </Routes>
       </MemoryRouter>

--- a/javascript/packages/core/types/query-types.ts
+++ b/javascript/packages/core/types/query-types.ts
@@ -1,0 +1,19 @@
+/**
+ * Options that can be passed to query hooks.
+ */
+export type QueryOptions = {
+  /** Whether the query should be enabled */
+  enabled?: boolean;
+};
+
+/**
+ * Standard result structure returned by query hooks.
+ */
+export type QueryResult<TData = unknown> = {
+  /** The data returned by the query */
+  data: TData | undefined;
+  /** Any error that occurred during the query */
+  error: Error | null;
+  /** Whether the query is currently loading */
+  isLoading: boolean;
+};


### PR DESCRIPTION
MA Studio exposes a schema-friendly hook, useStudioQuery, to query services. This hook injects project metadata into the query, if not provided, such that useQuery clients don't need to maintain the projectId ==> namespace relationship.

In order to test useStudioQuery effectively, updated router wrapper to support project-based routing. Otherwise the tests that verify serviceOptions.namespace falls back to projectId would not work.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
