### PR TITLE
Add support for external router provider

### DIFF
--- a/javascript/app/App.tsx
+++ b/javascript/app/App.tsx
@@ -1,4 +1,5 @@
-import { CoreApp } from '@michelangelo/core';
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import { CoreApp } from '@uber/michelangelo-core';
 import { request } from '@michelangelo/rpc';
 
 const dependencies = {
@@ -8,5 +9,11 @@ const dependencies = {
 };
 
 export function App() {
-  return <CoreApp dependencies={dependencies} />;
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/*" element={<CoreApp dependencies={dependencies} />} />
+      </Routes>
+    </BrowserRouter>
+  );
 }

--- a/javascript/app/App.tsx
+++ b/javascript/app/App.tsx
@@ -1,6 +1,6 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
-import { CoreApp } from '@uber/michelangelo-core';
 import { request } from '@michelangelo/rpc';
+import { CoreApp } from '@uber/michelangelo-core';
 
 const dependencies = {
   service: {

--- a/javascript/app/package.json
+++ b/javascript/app/package.json
@@ -8,8 +8,10 @@
     "dev-production": "vite --config vite.config.production.ts"
   },
   "dependencies": {
-    "@michelangelo/core": "*",
-    "@michelangelo/rpc": "*"
+    "@michelangelo/rpc": "*",
+    "@uber/michelangelo-core": "*",
+    "react-router": "6.29.0",
+    "react-router-dom": "6.29.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.4.1",

--- a/javascript/app/vite.config.ts
+++ b/javascript/app/vite.config.ts
@@ -8,6 +8,8 @@ export const baseConfig = defineConfig({
 
 export default defineConfig(() => {
   return mergeConfig(baseConfig, {
-    mode: 'development',
+    resolve: {
+      conditions: ['workspace'],
+    },
   });
 });

--- a/javascript/eslint.config.js
+++ b/javascript/eslint.config.js
@@ -107,9 +107,27 @@ export default [
     },
   },
 
+  // Core package tests
+  {
+    files: ['packages/core/**/__tests__/**/*.{ts,tsx}'],
+    languageOptions: {
+      ecmaVersion: 2020,
+      sourceType: 'module',
+      parser: tseslint.parser,
+      parserOptions: {
+        project: new URL('./packages/core/tsconfig.test.json', import.meta.url).pathname,
+        tsconfigRootDir: new URL('./packages/core', import.meta.url).pathname,
+      },
+      globals: globals.browser,
+    },
+    plugins: sharedPlugins,
+    rules: sharedRules,
+  },
+
   // Core package
   {
     files: ['packages/core/**/*.{ts,tsx}'],
+    ignores: ['packages/core/**/__tests__/**/*.{ts,tsx}'],
     languageOptions: {
       ecmaVersion: 2020,
       sourceType: 'module',

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -14,14 +14,14 @@
   "scripts": {
     "build": "yarn workspaces run build",
     "dev": "yarn workspace @michelangelo/app dev",
-    "dev-production": "yarn workspace @michelangelo/core build && yarn workspace @michelangelo/app dev-production",
+    "dev-production": "yarn workspace @uber/michelangelo-core build && yarn workspace @michelangelo/app dev-production",
     "format": "prettier --check .",
     "generate": "../tools/gen-grpc-client.sh --clients javascript",
     "lint": "eslint .",
     "prebuild": "yarn generate",
     "setup": "yarn install && yarn generate",
     "typecheck": "tsc -b",
-    "test": "yarn workspace @michelangelo/core test"
+    "test": "yarn workspace @uber/michelangelo-core test"
   },
   "dependencies": {},
   "devDependencies": {

--- a/javascript/packages/core/components/views/project/project-detail.tsx
+++ b/javascript/packages/core/components/views/project/project-detail.tsx
@@ -3,7 +3,7 @@ import { useStudioQuery } from '#core/hooks/use-studio-query';
 
 export function ProjectDetail() {
   const { projectId } = useStudioParams('base');
-  const { data } = useStudioQuery<{ metadata: Record<string, string> }>({
+  const { data } = useStudioQuery<{ project: Record<string, string> }>({
     queryName: 'GetProject',
     serviceOptions: {
       name: projectId,
@@ -13,5 +13,5 @@ export function ProjectDetail() {
 
   // The project type will not be directly exposed to the @michelangelo/core package.
   // eslint-disable-next-line @typescript-eslint/dot-notation
-  return <div>{data?.metadata?.['name']}</div>;
+  return <div>Project Name: {data?.project?.metadata?.['name']}</div>;
 }

--- a/javascript/packages/core/package.json
+++ b/javascript/packages/core/package.json
@@ -1,11 +1,10 @@
 {
-  "name": "@michelangelo/core",
+  "name": "@uber/michelangelo-core",
   "license": "UNLICENSED",
-  "version": "0.0.0",
+  "version": "0.0.17",
   "type": "module",
-  "main": "dist/core.js",
   "scripts": {
-    "build": "tsc && vite build",
+    "build": "vite build && tsc --emitDeclarationOnly",
     "test": "vitest"
   },
   "dependencies": {
@@ -18,8 +17,6 @@
     "pluralize": "^8.0.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-router": "6.29.0",
-    "react-router-dom": "6.29.0",
     "styletron-engine-monolithic": "^1.0.0",
     "styletron-react": "^6.1.1"
   },
@@ -28,16 +25,20 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@types/jest": "^29.5.14",
+    "@types/react-router": "^5.1.20",
     "@vitejs/plugin-react": "^4.4.1",
     "jsdom": "^26.1.0",
     "vitest": "^3.1.1"
   },
+  "peerDependencies": {
+    "react-router": "^6.29.0",
+    "react-router-dom": "^6.29.0"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "development": "./index.tsx",
-      "production": "./dist/core.js",
-      "default": "./dist/core.js"
+      "workspace": "./index.tsx",
+      "default": "./dist/michelangelo-core.js"
     }
   },
   "imports": {

--- a/javascript/packages/core/router/router.tsx
+++ b/javascript/packages/core/router/router.tsx
@@ -1,22 +1,19 @@
-import { Route, Routes } from 'react-router';
-import { BrowserRouter } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom';
 
 import { MainViewContainer } from '#core/components/views/main-view-container';
 import { ProjectDetail } from '#core/components/views/project/project-detail';
 
 export function Router() {
   return (
-    <BrowserRouter basename={'/'}>
-      <Routes>
-        <Route
-          path={':projectId'}
-          element={
-            <MainViewContainer hasBreadcrumb={false}>
-              <ProjectDetail />
-            </MainViewContainer>
-          }
-        />
-      </Routes>
-    </BrowserRouter>
+    <Routes>
+      <Route
+        path=":projectId"
+        element={
+          <MainViewContainer hasBreadcrumb={false}>
+            <ProjectDetail />
+          </MainViewContainer>
+        }
+      />
+    </Routes>
   );
 }

--- a/javascript/packages/core/tsconfig.json
+++ b/javascript/packages/core/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": ["."],
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["dist/**"],
   "compilerOptions": {
     "composite": true,
     "declaration": true,

--- a/javascript/packages/core/tsconfig.test.json
+++ b/javascript/packages/core/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["**/__tests__/**/*.ts", "**/__tests__/**/*.tsx"],
+  "compilerOptions": {
+    "noEmit": true
+  }
+}

--- a/javascript/yarn.lock
+++ b/javascript/yarn.lock
@@ -762,6 +762,11 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.7.tgz#4158d3105276773d5b7695cd4834b1722e4f37a8"
   integrity sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==
 
+"@types/history@^4.7.11":
+  version "4.7.11"
+  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.11.tgz#56588b17ae8f50c53983a524fc3cc47437969d64"
+  integrity sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz#7739c232a1fee9b4d3ce8985f314c0c6d33549d7"
@@ -817,6 +822,14 @@
   version "19.1.1"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-19.1.1.tgz#a8d097b28247d1129cf56e74d1622c98978c04ed"
   integrity sha512-jFf/woGTVTjUJsl2O7hcopJ1r0upqoq/vIOoCj0yLh3RIXxWcljlpuZ+vEBRXsymD1jhfeJrlyTy/S1UW+4y1w==
+
+"@types/react-router@^5.1.20":
+  version "5.1.20"
+  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-5.1.20.tgz#88eccaa122a82405ef3efbcaaa5dcdd9f021387c"
+  integrity sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==
+  dependencies:
+    "@types/history" "^4.7.11"
+    "@types/react" "*"
 
 "@types/react-virtualized-auto-sizer@^1.0.0":
   version "1.0.8"
@@ -3869,9 +3882,9 @@ vite-node@3.1.1:
     vite "^5.0.0 || ^6.0.0"
 
 vite@6.2.0, "vite@^5.0.0 || ^6.0.0", vite@^6.2.0:
-  version "6.3.4"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-6.3.4.tgz#d441a72c7cd9a93b719bb851250a4e6c119c9cff"
-  integrity sha512-BiReIiMS2fyFqbqNT/Qqt4CVITDU9M9vE+DKcVAsB+ZV0wvTKd+3hMbkpxz1b+NmEDMegpVbisKiAZOnvO92Sw==
+  version "6.3.5"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-6.3.5.tgz#fec73879013c9c0128c8d284504c6d19410d12a3"
+  integrity sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==
   dependencies:
     esbuild "^0.25.0"
     fdir "^6.4.4"


### PR DESCRIPTION
When integrating michelangelo-core into Uber's internal deployment, the internal deployment will wrap the michelangelo-core exports in its own router. This means that michelangelo-core must specify react-router as a peer dependency to avoid multiple router contexts.

Renamed the package from @michelangelo/core to @uber/michelangelo-core to allow for simple import back until our open source repository is public.

When testing import pack, the "development" conditional export did not work, since Uber's internal deployment leverages the "development" condition. All michelangelo-core dependents outside the workspace should access the dist/ copy of michelangelo-core.

**What type of PR is this? (check all applicable)**
- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
https://github.com/user-attachments/assets/e1dba7c2-e318-48dd-a157-607180d8e709



<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
