### PR TITLE
Add retry field to python decorator, and implement retry in starlark

### DIFF
--- a/python/michelangelo/uniflow/commons.star
+++ b/python/michelangelo/uniflow/commons.star
@@ -24,6 +24,8 @@ CACHE_OPERATION_GET = "GET"
 CACHE_ENABLED_TRUE = "true"
 CACHE_ENABLED_FALSE = "false"
 
+DEFAULT_RETRY_ATTEMPTS = 1
+
 def get_result_url():
     """
     Get the url for the result.json
@@ -73,7 +75,9 @@ def resource_dict(cpu, memory, disk = None, gpu = None, gpu_sku = ""):
         res["gpu_sku"] = gpu_sku
     return res
 
-def report_progress(task_path, task_name, task_log = "", task_message = "", task_state = "", start_time = "", end_time = "", output = ""):
+def report_progress(task_path, task_name, task_log = "", task_message = "", task_state = "", start_time = "", end_time = "", output = "", retry_attempt_id = ""):
+    if type(retry_attempt_id) != "str":
+        retry_attempt_id = str(retry_attempt_id)
     state_dict = {
         "task_path": task_path,
         "task_name": task_name,
@@ -83,6 +87,7 @@ def report_progress(task_path, task_name, task_log = "", task_message = "", task
         "start_time": start_time,
         "end_time": end_time,
         "output": output,
+        "retry_attempt_id": retry_attempt_id,
     }
     progress.report(str(state_dict))
 

--- a/python/michelangelo/uniflow/core/decorator.py
+++ b/python/michelangelo/uniflow/core/decorator.py
@@ -29,6 +29,8 @@ task_context = threading.local()
 task_context.config = None
 task_context.alias = None
 
+DEFAULT_RETRY_ATTEMPTS = 1
+
 
 class TaskFunction(Generic[P, R]):
     def __init__(
@@ -40,6 +42,7 @@ class TaskFunction(Generic[P, R]):
         io: IORegistry,
         cache_enabled: bool = False,
         cache_version: Optional[str] = None,
+        retry_attempts: int = DEFAULT_RETRY_ATTEMPTS,
     ):
         self._fn = fn
         self._config = config
@@ -47,6 +50,7 @@ class TaskFunction(Generic[P, R]):
         self._io = io
         self._cache_enabled = cache_enabled
         self._cache_version = cache_version
+        self._retry_attempts = retry_attempts
 
     def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R:
         fn_path = dot_path(self._fn)
@@ -104,6 +108,7 @@ class TaskFunction(Generic[P, R]):
         *,
         alias: Optional[str] = None,
         config: Optional[TaskConfig] = None,
+        retry_attempts: Optional[int] = None,
     ) -> "TaskFunction[P, R]":
         """
         Creates a new TaskFunction instance with overridden alias and/or config.
@@ -129,6 +134,7 @@ class TaskFunction(Generic[P, R]):
             io=self._io,
             cache_enabled=self._cache_enabled,
             cache_version=self._cache_version,
+            retry_attempts=retry_attempts or self._retry_attempts,
         )
 
     def _transpile(self, dependencies: Dependencies) -> ast.AST:
@@ -171,6 +177,7 @@ class TaskFunction(Generic[P, R]):
 
         keywords.append(ast.keyword("cache_enabled", ast.Constant(self._cache_enabled)))
         keywords.append(ast.keyword("cache_version", ast.Constant(self._cache_version)))
+        keywords.append(ast.keyword("retry_attempts", ast.Constant(self._retry_attempts)))
 
         # Construct and return AST Call node that calls the Task Factory Function with the keywords.
         origin_fn = inspect.unwrap(self._fn)
@@ -187,6 +194,7 @@ def task(
     io: IORegistry = default_io,
     cache_enabled: bool = False,
     cache_version: Optional[str] = None,
+    retry_attempts: int = DEFAULT_RETRY_ATTEMPTS,
 ):
     """
     Decorator for defining a task function. Usage example:
@@ -207,6 +215,7 @@ def task(
         cache_version: Optional[str]: Cache version for the task. Default is None.
             We can use this to save multiple versions of caches for the same task and specify the cache version used to
             skip the task. If it is None, the default cached version will be calculated by the docker image id of the task.
+        retry_attempts: int: Number of retry attempts for the task. Default is 1 (no retries).
     """
 
     def decorator(fn: Callable[P, R]) -> TaskFunction[P, R]:
@@ -217,6 +226,7 @@ def task(
             io=io,
             cache_enabled=cache_enabled,
             cache_version=cache_version,
+            retry_attempts=retry_attempts,
         )
         update_wrapper(task_fn, fn)
 

--- a/python/michelangelo/uniflow/plugins/ray/task.star
+++ b/python/michelangelo/uniflow/plugins/ray/task.star
@@ -1,5 +1,5 @@
 load("@plugin", "atexit", "json", "os", "ray", "time")
-load("../../commons.star", "CACHE_OPERATION_GET", "CACHE_OPERATION_PUT", "TASK_STATE_FAILED", "TASK_STATE_KILLED", "TASK_STATE_PENDING", "TASK_STATE_RUNNING", "TASK_STATE_SKIPPED", "TASK_STATE_SUCCEEDED", "TIME_FOMART", "create_cached_output", "get_cache_enabled", "get_cache_keys", "get_cached_output", "get_result_url", "get_task_image", "get_task_name", "io_read_json", "report_progress", "resource_dict", COMMONS_ENV = "ENV")
+load("../../commons.star", "DEFAULT_RETRY_ATTEMPTS", "CACHE_OPERATION_GET", "CACHE_OPERATION_PUT", "TASK_STATE_FAILED", "TASK_STATE_KILLED", "TASK_STATE_PENDING", "TASK_STATE_RUNNING", "TASK_STATE_SKIPPED", "TASK_STATE_SUCCEEDED", "TIME_FOMART", "create_cached_output", "get_cache_enabled", "get_cache_keys", "get_cached_output", "get_result_url", "get_task_image", "get_task_name", "io_read_json", "report_progress", "resource_dict", COMMONS_ENV = "ENV")
 
 CREATE_CLUSTER_TIMEOUT_SECONDS = 60 * 30  # Timeout duration for cluster creation in seconds.
 RAY_ENV = {
@@ -67,6 +67,7 @@ def task(
         alias = None,
         cache_version = None,
         cache_enabled = False,
+        retry_attempts = DEFAULT_RETRY_ATTEMPTS,
         head_cpu = RAY_DEFAULT_HEAD_CPU,
         head_memory = RAY_DEFAULT_HEAD_MEMORY,
         head_disk = RAY_DEFAULT_HEAD_DISK,
@@ -127,12 +128,16 @@ def task(
         _gpu_sku = os.environ.get("RAY_OVERRIDE_GPU_SKU." + task_path, gpu_sku)
         _zone = os.environ.get("RAY_OVERRIDE_ZONE." + task_path, zone)
 
+        _retry_attempts = retry_attempts
+
         # Apply resource types
         _head_cpu = int(_head_cpu)
         _head_gpu = int(_head_gpu)
         _worker_cpu = int(_worker_cpu)
         _worker_gpu = int(_worker_gpu)
         _worker_instances = int(_worker_instances)
+
+        result_url = get_result_url()
 
         # Create cluster
         cluster_namespace = namespace
@@ -154,96 +159,80 @@ def task(
             debug_enabled = breakpoint,
             runtime_env = runtime_env,
         )
-        cluster = ray.create_cluster(cluster)
-        cluster_name = cluster["metadata"]["name"]
-        cluster_namespace = cluster["metadata"]["namespace"]
 
-        print("ray | cluster created:", "ns=" + cluster_namespace, "n=" + cluster_name)
-        report_progress(
+        total_retry_attempt = retry_attempts
+        for retry_attempt_id in range(1, total_retry_attempt + 1):
+
+            job_state, job = execute_ray_task(
+                task_path=task_path,
+                task_name=task_name,
+                cluster=cluster,
+                cluster_namespace=cluster_namespace,
+                runtime_env=runtime_env,
+                start_time_formated_str=start_time_formated_str,
+                result_url=result_url,
+                args=args,
+                kwargs=kwargs,
+                retry_attempt_id=retry_attempt_id,
+                total_retry_attempt=total_retry_attempt,
+                breakpoint=breakpoint,
+            )
+
+            retryable = process_terminated_ray_job(
+                job_state,
+                job,
+                task_name,
+                task_path,
+                args,
+                kwargs,
+                cache_version,
+                namespace,
+                result_url,
+                start_time_formated_str,
+                retry_attempt_id,
+                total_retry_attempt,
+            )
+
+            if retryable == False:
+                break
+
+        result = io_read_json(result_url)
+        print("ray | caching", "result:", result)
+        return result
+
+    def with_overrides(alias = alias, config = ray_config(), retry_attempts = DEFAULT_RETRY_ATTEMPTS):
+        return task(
             task_path = task_path,
-            task_name = task_name,
-            task_message = "Ray Cluster Created Successfully",
-            task_state = TASK_STATE_RUNNING,
-            start_time = start_time_formated_str,
-            end_time = "",
+            alias = alias,
+            cache_version = cache_version,
+            cache_enabled = cache_enabled,
+            retry_attempts = retry_attempts,
+            head_cpu = head_cpu if "head_cpu" not in config else config["head_cpu"],
+            head_memory = head_memory if "head_memory" not in config else config["head_memory"],
+            head_disk = head_disk if "head_disk" not in config else config["head_disk"],
+            head_gpu = head_gpu if "head_gpu" not in config else config["head_gpu"],
+            head_object_store_memory = head_object_store_memory if "head_object_store_memory" not in config else config["head_object_store_memory"],
+            worker_cpu = worker_cpu if "worker_cpu" not in config else config["worker_cpu"],
+            worker_memory = worker_memory if "worker_memory" not in config else config["worker_memory"],
+            worker_disk = worker_disk if "worker_disk" not in config else config["worker_disk"],
+            worker_gpu = worker_gpu if "worker_gpu" not in config else config["worker_gpu"],
+            worker_object_store_memory = worker_object_store_memory if "worker_object_store_memory" not in config else config["worker_object_store_memory"],
+            worker_instances = worker_instances if "worker_instances" not in config else config["worker_instances"],
+            gpu_sku = gpu_sku if "gpu_sku" not in config else config["gpu_sku"],
+            zone = zone if "zone" not in config else config["zone"],
+            breakpoint = breakpoint if "breakpoint" not in config else config["breakpoint"],
+            runtime_env = runtime_env if "runtime_env" not in config else config["runtime_env"],
         )
 
-        def terminate_cluster():
-            ray.terminate_cluster(cluster_name, cluster_namespace, "job failed", "TERMINATION_TYPE_FAILED")
-            print("ray | cluster terminated:", "ns=" + cluster_namespace, "n=" + cluster_name)
+    callable = callable_object(callable)
+    callable.with_overrides = with_overrides
+    return callable
 
-        atexit.register(terminate_cluster)
+def process_terminated_ray_job(job_state, job, task_name, task_path, args, kwargs, cache_version, namespace, result_url, start_time_formated_str, retry_attempt_id, total_retry_attempt):
 
-        # Run job
-        result_url = get_result_url()
-        entrypoint = ray_job_entrypoint(task_path, result_url, args, kwargs)
-        print("ray | run job:", "task_path=" + task_path)
-        job = ray.create_job(
-            entrypoint,
-            ray_job_namespace = cluster_namespace,
-            ray_job_name = cluster_name,
-        )
-        print("ray | +run job: job=" + str(job))
+    retryable = False
 
-        def report_ray_task_result():
-            end_time_seconds = time.time()
-            end_time_formated_str = time.utc_format_seconds(TIME_FOMART, end_time_seconds)
-            if job["status"]["state"] == "RAY_JOB_STATE_SUCCEEDED":
-                report_progress(
-                    task_path = task_path,
-                    task_name = task_name,
-                    task_message = "Ray Job Succeeded",
-                    task_state = TASK_STATE_SUCCEEDED,
-                    start_time = start_time_formated_str,
-                    end_time = end_time_formated_str,
-                )
-            elif job["status"]["state"] == "RAY_JOB_STATE_KILLED":
-                message = job.get("message", "unknown reason")
-                task_message = "Ray Job killed with {}".format(message)
-                report_progress(
-                    task_path = task_path,
-                    task_name = task_name,
-                    task_message = task_message,
-                    task_state = TASK_STATE_KILLED,
-                    start_time = start_time_formated_str,
-                    end_time = end_time_formated_str,
-                )
-            else:
-                error_type = job.get("errorType", "internal")
-                message = job.get("message", "unknown error")
-                task_message = "Ray Job Failed with {} Error: {}".format(error_type, message)
-                report_progress(
-                    task_path = task_path,
-                    task_name = task_name,
-                    task_message = task_message,
-                    task_state = TASK_STATE_FAILED,
-                    start_time = start_time_formated_str,
-                    end_time = end_time_formated_str,
-                )
-
-        atexit.register(report_ray_task_result)
-
-        if breakpoint:
-            print("ray | breakpoint:", "ns=" + cluster_namespace, "n=" + cluster_name)
-
-            time.sleep(seconds = 60 * 60 * 24)
-            err_message = "internal: breakpoint timeout"
-            print("ray | error:", err_message)
-            fail(err_message)
-
-        # Terminate cluster
-        if job["status"]["state"] == "RAY_JOB_STATE_SUCCEEDED":
-            ray.terminate_cluster(cluster_name, cluster_namespace, "job succeeded", "TERMINATION_TYPE_SUCCEEDED")
-        else:
-            ray.terminate_cluster(cluster_name, cluster_namespace, "job failed", "TERMINATION_TYPE_FAILED")
-
-        report_ray_task_result()
-        atexit.unregister(terminate_cluster)
-        atexit.unregister(report_ray_task_result)
-
-        # Read result from the storage
-        if job["status"]["state"] != "RAY_JOB_STATE_SUCCEEDED":
-            fail("internal:", "message:bad job status:", job["status"]["state"], job)
+    if job_state == TASK_STATE_SUCCEEDED:
 
         cache_keys = get_cache_keys(task_path, task_name, args, kwargs, cache_version, CACHE_OPERATION_PUT)
         created_cached_output = create_cached_output(
@@ -265,36 +254,121 @@ def task(
             end_time = end_time_formated_str,
             task_message = "Ray Task Completed Successfully",
         )
-        result = io_read_json(result_url)
-        print("ray | caching", "result:", result)
-        return result
+        print("Ray job succeeded, attempt (" + str(retry_attempt_id) + " / " + str(total_retry_attempt) + ") succeeded")
 
-    def with_overrides(alias = alias, config=ray_config()):
-        return task(
+    elif job_state == TASK_STATE_KILLED:
+        print("Ray task killed, attempt (" + str(retry_attempt_id) + " / " + str(total_retry_attempt) + ").  no retry should be performed")
+        fail("Ray task killed, no retry should be performed")
+
+    elif job_state == TASK_STATE_FAILED:
+        print("Ray task failed, attempt (" + str(retry_attempt_id) + " / " + str(total_retry_attempt) + ") failed")
+        if retry_attempt_id < total_retry_attempt:
+            retryable = True
+        else:
+            print("Ray task failed after all (" + str(retry_attempt_id) + " / " + str(total_retry_attempt) + ") attempts were exhausted")
+            fail("Ray task failed after all retry attempts were exhausted ", "internal:", "message:bad job status:", job["status"]["state"], job)
+
+    return retryable
+
+
+def execute_ray_task(task_path, task_name, cluster, cluster_namespace, runtime_env, start_time_formated_str, result_url, args, kwargs, retry_attempt_id, total_retry_attempt, breakpoint=False):
+
+    print("Ray job running, attempt (" + str(retry_attempt_id) + " / " + str(total_retry_attempt) + ")")
+
+    cluster = ray.create_cluster(cluster)
+    cluster_name = cluster["metadata"]["name"]
+    cluster_namespace = cluster["metadata"]["namespace"]
+
+    print("ray | cluster created:", "ns=" + cluster_namespace, "n=" + cluster_name)
+    report_progress(
+        task_path = task_path,
+        task_name = task_name,
+        task_message = "Ray Cluster Created Successfully",
+        task_state = TASK_STATE_RUNNING,
+        start_time = start_time_formated_str,
+        end_time = "",
+    )
+
+    atexit.register(terminate_cluster, cluster_namespace, cluster_name)
+
+    # Run job
+    entrypoint = ray_job_entrypoint(task_path, result_url, args, kwargs)
+    print("ray | run job:", "task_path=" + task_path)
+    job = ray.create_job(
+        entrypoint,
+        ray_job_namespace = cluster_namespace,
+        ray_job_name = cluster_name,
+    )
+    print("ray | +run job: job=" + str(job))
+
+    atexit.register(report_ray_task_result, job, task_path, task_name, start_time_formated_str, retry_attempt_id)
+
+    if breakpoint:
+        print("ray | breakpoint:", "ns=" + cluster_namespace, "n=" + cluster_name)
+
+        time.sleep(seconds = 60 * 60 * 24)
+        err_message = "internal: breakpoint timeout"
+        print("ray | error:", err_message)
+        fail(err_message)
+
+    # Terminate cluster
+    job_state = report_ray_task_result(job, task_path, task_name, start_time_formated_str, retry_attempt_id)
+    if job_state == TASK_STATE_SUCCEEDED:
+        ray.terminate_cluster(cluster_name, cluster_namespace, "job succeeded", "TERMINATION_TYPE_SUCCEEDED")
+    else:
+        ray.terminate_cluster(cluster_name, cluster_namespace, "job failed", "TERMINATION_TYPE_FAILED")
+
+    atexit.unregister(terminate_cluster)
+    atexit.unregister(report_ray_task_result)
+
+    return(job_state, job)
+
+def terminate_cluster(cluster_namespace, cluster_name):
+    ray.terminate_cluster(cluster_name, cluster_namespace, "job failed", "TERMINATION_TYPE_FAILED")
+    print("ray | cluster terminated:", "ns=" + cluster_namespace, "n=" + cluster_name)
+
+def report_ray_task_result(job, task_path, task_name, start_time_formated_str, retry_attempt_id):
+
+    end_time_seconds = time.time()
+    end_time_formated_str = time.utc_format_seconds(TIME_FOMART, end_time_seconds)
+    if job["status"]["state"] == "RAY_JOB_STATE_SUCCEEDED":
+        report_progress(
             task_path = task_path,
-            alias = alias,
-            cache_version = cache_version,
-            cache_enabled = cache_enabled,
-            head_cpu = head_cpu if "head_cpu" not in config else config["head_cpu"],
-            head_memory = head_memory if "head_memory" not in config else config["head_memory"],
-            head_disk = head_disk if "head_disk" not in config else config["head_disk"],
-            head_gpu = head_gpu if "head_gpu" not in config else config["head_gpu"],
-            head_object_store_memory = head_object_store_memory if "head_object_store_memory" not in config else config["head_object_store_memory"],
-            worker_cpu = worker_cpu if "worker_cpu" not in config else config["worker_cpu"],
-            worker_memory = worker_memory if "worker_memory" not in config else config["worker_memory"],
-            worker_disk = worker_disk if "worker_disk" not in config else config["worker_disk"],
-            worker_gpu = worker_gpu if "worker_gpu" not in config else config["worker_gpu"],
-            worker_object_store_memory = worker_object_store_memory if "worker_object_store_memory" not in config else config["worker_object_store_memory"],
-            worker_instances = worker_instances if "worker_instances" not in config else config["worker_instances"],
-            gpu_sku = gpu_sku if "gpu_sku" not in config else config["gpu_sku"],
-            zone = zone if "zone" not in config else config["zone"],
-            breakpoint = breakpoint if "breakpoint" not in config else config["breakpoint"],
-            runtime_env = runtime_env if "runtime_env" not in config else config["runtime_env"],
+            task_name = task_name,
+            task_message = "Ray Job Succeeded",
+            task_state = TASK_STATE_SUCCEEDED,
+            start_time = start_time_formated_str,
+            end_time = end_time_formated_str,
+            retry_attempt_id = retry_attempt_id,
         )
-
-    callable = callable_object(callable)
-    callable.with_overrides = with_overrides
-    return callable
+        return TASK_STATE_SUCCEEDED
+    elif job["status"]["state"] == "RAY_JOB_STATE_KILLED":
+        message = job.get("message", "unknown reason")
+        task_message = "Ray Job killed with {}".format(message)
+        report_progress(
+            task_path = task_path,
+            task_name = task_name,
+            task_message = task_message,
+            task_state = TASK_STATE_KILLED,
+            start_time = start_time_formated_str,
+            end_time = end_time_formated_str,
+            retry_attempt_id = retry_attempt_id,
+        )
+        return TASK_STATE_KILLED
+    else:
+        error_type = job.get("errorType", "internal")
+        message = job.get("message", "unknown error")
+        task_message = "Ray Job Failed with {} Error: {}".format(error_type, message)
+        report_progress(
+            task_path = task_path,
+            task_name = task_name,
+            task_message = task_message,
+            task_state = TASK_STATE_FAILED,
+            start_time = start_time_formated_str,
+            end_time = end_time_formated_str,
+            retry_attempt_id = retry_attempt_id,
+        )
+        return TASK_STATE_FAILED
 
 def ray_job_entrypoint(task_path, result_url, args = None, kwargs = None):
     args = json.dumps(args) if args else "[]"

--- a/python/michelangelo/uniflow/plugins/spark/task.star
+++ b/python/michelangelo/uniflow/plugins/spark/task.star
@@ -1,5 +1,5 @@
 load("@plugin", "atexit", "json", "os", "spark", "time", "workflow")
-load("../../commons.star", "CACHE_OPERATION_GET", "CACHE_OPERATION_PUT", "TASK_STATE_FAILED", "TASK_STATE_KILLED", "TASK_STATE_PENDING", "TASK_STATE_RUNNING", "TASK_STATE_SKIPPED", "TASK_STATE_SUCCEEDED", "TIME_FOMART", "create_cached_output", "get_cache_enabled", "get_cache_keys", "get_cached_output", "get_result_url", "get_task_image", "get_task_name", "io_read_json", "report_progress", "resource_dict", COMMONS_ENV = "ENV")
+load("../../commons.star", "DEFAULT_RETRY_ATTEMPTS", "CACHE_OPERATION_GET", "CACHE_OPERATION_PUT", "TASK_STATE_FAILED", "TASK_STATE_KILLED", "TASK_STATE_PENDING", "TASK_STATE_RUNNING", "TASK_STATE_SKIPPED", "TASK_STATE_SUCCEEDED", "TIME_FOMART", "create_cached_output", "get_cache_enabled", "get_cache_keys", "get_cached_output", "get_result_url", "get_task_image", "get_task_name", "io_read_json", "report_progress", "resource_dict", COMMONS_ENV = "ENV")
 
 SPARK_ENV = {
 }
@@ -20,6 +20,7 @@ def spark_task(
         alias = None,
         cache_version = None,
         cache_enabled = False,
+        retry_attempts = DEFAULT_RETRY_ATTEMPTS,
         driver_cpu = SPARK_DEFAULT_DRIVER_CPU,
         driver_memory = SPARK_DEFAULT_DRIVER_MEMORY,
         driver_disk = SPARK_DEFAULT_DRIVER_DISK,
@@ -69,6 +70,8 @@ def spark_task(
         _executor_gpu = os.environ.get("SPARK_OVERRIDE_EXECUTOR_GPU." + task_path, executor_gpu)
         _executor_instances = os.environ.get("SPARK_OVERRIDE_EXECUTOR_INSTANCES." + task_path, executor_instances)
 
+        _retry_attempts = retry_attempts
+
         # Apply resource types
         _driver_cpu = int(_driver_cpu)
         _driver_gpu = int(_driver_gpu)
@@ -102,74 +105,48 @@ def spark_task(
             executor_instances = _executor_instances,
         )
 
-        # submit spark job
-        print("spark | submit job. ns:", namespace, "task_name:", task_name)
-        created_spark_job = spark.create_job(spark_job)
+        total_retry_attempt = retry_attempts
+        for retry_attempt_id in range(1, total_retry_attempt + 1):
 
-        # report task as pending
-        report_progress(
-            task_name = task_name,
-            task_path = task_path,
-            task_state = TASK_STATE_PENDING,
-            start_time = start_time_formated_str,
-            task_message = "Spark job has been submitted",
-            task_log = created_spark_job.get("status", {}).get("jobUrl", ""),
-            end_time = "",
-        )
+            job_state, terminated_job = execute_spark_task(
+                namespace=namespace,
+                task_name=task_name,
+                task_path=task_path,
+                spark_job=spark_job,
+                start_time_formated_str=start_time_formated_str,
+                retry_attempt_id=retry_attempt_id,
+                total_retry_attempt=total_retry_attempt,
+            )
 
-        def check_spark_job_final_state_at_workflow_exit():
-            """
-            Check the final state of the spark job
-            """
-            final_job = spark.sensor_job(job = created_spark_job)
-            report_spark_job_terminated(final_job, task_name, task_path, start_time_formated_str)
-            return
+            retryable = process_terminated_spark_job(
+                job_state,
+                terminated_job,
+                task_name,
+                task_path,
+                args,
+                kwargs,
+                cache_version,
+                namespace,
+                result_url,
+                start_time_formated_str,
+                retry_attempt_id,
+                total_retry_attempt,
+            )
 
-        # register the check_spark_job function to be called at the end of the workflow.
-        # this is to ensure that the task state is reported correctly even if the workflow is killed
-        atexit.register(check_spark_job_final_state_at_workflow_exit)
+            if retryable == False:
+                break
 
-        # senosr spark job until it is running and driver log url is available
-        terminated_job = spark.sensor_job(job = created_spark_job)
-
-        driver_log_url = ""
-
-        # senosr spark job until it is terminated
-        terminated_job = spark.sensor_job(job = created_spark_job)
-        if report_spark_job_terminated(terminated_job, task_name, task_path, start_time_formated_str) == True:
-            atexit.unregister(check_spark_job_final_state_at_workflow_exit)
-
-        cache_keys = get_cache_keys(task_path, task_name, args, kwargs, cache_version, CACHE_OPERATION_PUT)
-        print("spark | caching with key", "key:", cache_keys)
-        created_cached_output = create_cached_output(
-            namespace = namespace,
-            cache_keys = cache_keys,
-            zone = "",
-            ttl_in_days = 0,
-            task_name = task_name,
-            result_json_url = result_url,
-        )
-        end_time_seconds = time.time()
-        end_time_formated_str = time.utc_format_seconds(TIME_FOMART, end_time_seconds)
-        report_progress(
-            task_name = task_name,
-            task_path = task_path,
-            task_state = TASK_STATE_SUCCEEDED,
-            start_time = start_time_formated_str,
-            task_log = driver_log_url,
-            end_time = end_time_formated_str,
-            task_message = "Spark job succeeded",
-        )
         result = io_read_json(result_url)
         print("spark | caching", "result:", result)
         return result
 
-    def with_overrides(alias = alias, config = spark_config()):
+    def with_overrides(alias = alias, config = spark_config(), retry_attempts = DEFAULT_RETRY_ATTEMPTS):
         return spark_task(
             task_path = task_path,
             alias = alias,
             cache_version = cache_version,
             cache_enabled = cache_enabled,
+            retry_attempts = retry_attempts,
             driver_cpu = driver_cpu if "driver_cpu" not in config else config["driver_cpu"],
             driver_memory = driver_memory if "driver_memory" not in config else config["driver_memory"],
             driver_disk = driver_disk if "driver_disk" not in config else config["driver_disk"],
@@ -185,7 +162,106 @@ def spark_task(
     callable.with_overrides = with_overrides
     return callable
 
-def report_spark_job_terminated(job, task_name, task_path, start_time_formated_str):
+def process_terminated_spark_job(job_state, terminated_job, task_name, task_path, args, kwargs, cache_version, namespace, result_url, start_time_formated_str, retry_attempt_id, total_retry_attempt):
+
+    retryable = False
+
+    if job_state == TASK_STATE_SUCCEEDED:
+
+        cache_keys = get_cache_keys(task_path, task_name, args, kwargs, cache_version, CACHE_OPERATION_PUT)
+        print("spark | caching with key", "key:", cache_keys)
+        created_cached_output = create_cached_output(
+            namespace = namespace,
+            cache_keys = cache_keys,
+            zone = "",
+            ttl_in_days = 0,
+            task_name = task_name,
+            result_json_url = result_url,
+        )
+        end_time_seconds = time.time()
+        end_time_formated_str = time.utc_format_seconds(TIME_FOMART, end_time_seconds)
+
+        driver_log_url = ""
+        if type(terminated_job) == "dict":
+            driver_log_url = terminated_job.get("status", {}).get("jobUrl", "")
+
+        report_progress(
+            task_name = task_name,
+            task_path = task_path,
+            task_state = TASK_STATE_SUCCEEDED,
+            start_time = start_time_formated_str,
+            task_log = driver_log_url,
+            end_time = end_time_formated_str,
+            task_message = "Spark job succeeded",
+            output = created_cached_output.get("metadata", {}).get("name", ""),
+            retry_attempt_id = retry_attempt_id,
+        )
+        print("Spark job succeeded, attempt (" + str(retry_attempt_id) + " / " + str(total_retry_attempt) + ") succeeded")
+
+    elif job_state == TASK_STATE_KILLED:
+        print("Spark job killed, attempt (" + str(retry_attempt_id) + " / " + str(total_retry_attempt) + "). no retry should be performed")
+        fail("Spark job killed, no retry should be performed")
+
+    # If job failed or was killed, check if we have retries left
+    elif job_state == TASK_STATE_FAILED:
+        print("Spark job failed, attemp (" + str(retry_attempt_id) + " / " + str(total_retry_attempt) + ") failed")
+        if retry_attempt_id < total_retry_attempt:
+            retryable = True
+        else:
+            print("Spark job failed after all (" + str(retry_attempt_id) + " / " + str(total_retry_attempt) + ") attempts were exhausted")
+            fail("Spark job failed after all attempts were exhausted")
+
+    return retryable
+
+def execute_spark_task(namespace, task_name, task_path, spark_job, start_time_formated_str, retry_attempt_id, total_retry_attempt):
+
+    print("Spark job running, attempt (" + str(retry_attempt_id) + " / " + str(total_retry_attempt) + ")")
+    
+    driver_log_url = ""
+
+    # submit spark job
+    print("spark | submit job. ns:", namespace, "task_name:", task_name)
+    created_spark_job = spark.create_job(spark_job)
+
+    if type(created_spark_job) == "dict":
+        driver_log_url = created_spark_job.get("status", {}).get("jobUrl", "")
+
+    # report task as pending
+    report_progress(
+        task_name = task_name,
+        task_path = task_path,
+        task_state = TASK_STATE_PENDING,
+        start_time = start_time_formated_str,
+        task_message = "Spark job has been submitted",
+        task_log = driver_log_url,
+        retry_attempt_id = retry_attempt_id,
+    )
+
+    # register the check_spark_job function to be called at the end of the workflow.
+    # this is to ensure that the task state is reported correctly even if the workflow is killed
+    atexit.register(check_spark_job_final_state_at_workflow_exit, created_spark_job, task_name, task_path, start_time_formated_str, retry_attempt_id)
+
+    # senosr spark job until it is running and driver log url is available
+    running_job = spark.sensor_job(job = created_spark_job, assert_condition_type = spark.running_condition_type)
+
+    # senosr spark job until it is terminated
+    terminated_job = spark.sensor_job(job = created_spark_job)
+
+    job_state = report_spark_job_terminated(terminated_job, task_name, task_path, start_time_formated_str, retry_attempt_id)
+    if job_state == TASK_STATE_SUCCEEDED:
+        atexit.unregister(check_spark_job_final_state_at_workflow_exit)
+
+    return (job_state, terminated_job)
+
+def check_spark_job_final_state_at_workflow_exit(created_spark_job, task_name, task_path, start_time_formated_str, retry_attempt_id):
+    """
+    Check the final state of the spark job
+    """
+    final_job = spark.sensor_job(job = created_spark_job)
+    report_spark_job_terminated(final_job, task_name, task_path, start_time_formated_str, retry_attempt_id, unexpected_exit=True)
+    return
+
+def report_spark_job_terminated(job, task_name, task_path, start_time_formated_str, retry_attempt_id, unexpected_exit=False):
     """
     Report task progress based on the succeeded condition of the spark job
 
@@ -201,8 +277,8 @@ def report_spark_job_terminated(job, task_name, task_path, start_time_formated_s
     if type(job) != "dict":
         return False
 
-    conditions = job.get("status", {}).get("applicationId", "FAILED")
-    return conditions == "COMPLETED"
+    job_state = job.get("status", {}).get("applicationId", "FAILED")
+    return job_state
 
 # TODO add env label for spark job
 # Get the match labels for the spark job.

--- a/python/tests/uniflow/core/test_decorator.py
+++ b/python/tests/uniflow/core/test_decorator.py
@@ -168,7 +168,7 @@ class TaskTest(unittest.TestCase):
         exp = generate_random_text._transpile(deps)
 
         # Ensure that the @task "config" properties are included in the transpiled expression.
-        task_params = "cpu=2, memory='1g', spot_instance=False, cache_enabled=False, cache_version=None"
+        task_params = "cpu=2, memory='1g', spot_instance=False, cache_enabled=False, cache_version=None, retry_attempts=1"
         expected_str = f"__task_a('test_decorator.generate_random_text', {task_params})"
         self.assertEqual(
             expected_str,
@@ -189,7 +189,7 @@ class TaskTest(unittest.TestCase):
         exp = gzip_compress._transpile(deps)
 
         # Ensure that the "alias" property is included in the transpiled expression.
-        task_params = "alias='gzip', cpu=4, memory='1g', spot_instance=False, cache_enabled=False, cache_version=None"
+        task_params = "alias='gzip', cpu=4, memory='1g', spot_instance=False, cache_enabled=False, cache_version=None, retry_attempts=1"
         expected_str = f"__task_a('test_decorator.gzip_compress', {task_params})"
         self.assertEqual(
             expected_str,


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
Add 3 new fields (retry, retry_timeout, retry_interval) to Uniflow task python `decorator`

<!-- Tell your future self why have you made these changes -->
**Why?**
For the implementation of retry & timeout feature for Uniflow task
[Abstract ERD] https://docs.google.com/document/d/1ZoDKmWwYhsg5JsslPsb6b3kWNExmM90AvCmxmH79e6k/edit?usp=sharing 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

I test this by doing **remote-run on the boston housing example**

The boston housing example contains 3 uniflow tasks:
feature_prep(Ray) -> preprocess(Spark) -> train(Ray)

We specify retry = 1 for each of the task 
(notice that in the boston housing example, feature_prep and preprocess are later overrided in the main function, so need to modify in there)

We kick off the remote run running the following command 
`PYTHONPATH="." poetry run python ./examples/boston_housing_xgb/boston_housing_xgb.py remote-run --image docker.io/library/examples:latest --storage-url s3://default --yes`

After the remote-run, we use 

- check the log info on Cadence to check if the workflow run as expected
- `kubectl get pods` to check if the spark / ray pods are successfully terminated.
- can also use `kubectl logs <pod name>` to check if the log is failed with the correct reason

1. succeeded
**Run a remote run on boston hosuing as it is**
Log on Cadence:
```
[
  "ray | create cluster: ns: default image: docker.io/library/examples:latest task_name: feature_prep_overrides",
  "Ray job running, attempt (1 / 2)",
  "ray | cluster created: ns=default n=uf-ray-gztg8",
  "ray | run job: task_path=examples.boston_housing_xgb.boston_housing_xgb.feature_prep",
  "Ray job succeeded, attempt (1 / 2) succeeded",
  "Spark job running, attempt (1 / 2)",
  "spark | submit job. ns: default task_name: preprocess_overrides",
  "ray | create cluster: ns: default image: docker.io/library/examples:latest task_name: train",
  "Ray job running, attempt (1 / 2)",
  "ray | cluster created: ns=default n=uf-ray-hb4g6",
  "ray | run job: task_path=examples.boston_housing_xgb.boston_housing_xgb.train",
  "Ray job succeeded, attempt (1 / 2) succeeded",
  "train_result.path: /root/ray_results/XGBoostTrainer_2025-06-13_20-44-34/XGBoostTrainer_370de_00000_0_2025-06-13_20-44-34"
]
```

2. retryable failure

**Raise exception in feature_prep(Ray)** 
Log on Cadence:
```
[
  "ray | create cluster: ns: default image: docker.io/library/examples:rayerror task_name: feature_prep_overrides",
  "Ray job running, attempt (1 / 2)",
  "ray | cluster created: ns=default n=uf-ray-fm5qw",
  "ray | run job: task_path=examples.boston_housing_xgb.boston_housing_xgb.feature_prep",
  "Ray task failed, attempt (1 / 2) failed",
  "Ray job running, attempt (2 / 2)",
  "ray | cluster created: ns=default n=uf-ray-jmmxj",
  "ray | run job: task_path=examples.boston_housing_xgb.boston_housing_xgb.feature_prep",
  "Ray task failed, attempt (2 / 2) failed",
  "Ray task failed after all (2 / 2) attempts were exhausted"
]
```

**Raise exception in preprocess(Spark)** 
Log on Cadence:
```
[
  "ray | create cluster: ns: default image: docker.io/library/examples:new task_name: feature_prep_overrides",
  "Ray job running, attempt (1 / 2)",
  "ray | cluster created: ns=default n=uf-ray-jmmdn",
  "ray | run job: task_path=examples.boston_housing_xgb.boston_housing_xgb.feature_prep",
  "Ray job succeeded, attempt (1 / 2) succeeded",
  "Spark job running, attempt (1 / 2)",
  "spark | submit job. ns: default task_name: preprocess_overrides",
  "Spark job failed, attemp (1 / 2) failed",
  "Spark job running, attempt (2 / 2)",
  "spark | submit job. ns: default task_name: preprocess_overrides",
  "Spark job failed, attemp (2 / 2) failed",
  "Spark job failed after all (2 / 2) attempts were exhausted"
]
```

3. non-retryable failure (Not sure how to simulate a killed spark / ray job)



<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
