### PR TITLE
Migrate cell rendering system from internal repository

### DIFF
--- a/javascript/eslint.config.js
+++ b/javascript/eslint.config.js
@@ -44,7 +44,9 @@ const sharedRules = {
   'baseui/deprecated-theme-api': 'warn',
   'baseui/deprecated-component-api': 'warn',
   'baseui/no-deep-imports': 'warn',
-  '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
+  '@typescript-eslint/consistent-type-definitions': 'off',
+  '@typescript-eslint/no-explicit-any': 'off',
+  '@typescript-eslint/no-unsafe-call': 'off',
 };
 
 export default [

--- a/javascript/packages/core/components/cell/__tests__/hooks.tests.ts
+++ b/javascript/packages/core/components/cell/__tests__/hooks.tests.ts
@@ -1,0 +1,39 @@
+import { renderHook } from '@testing-library/react';
+import { Theme } from 'baseui';
+
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
+import { useCellStyles } from '../hooks';
+
+describe('useCellStyles', () => {
+  it('should return an empty object if style is undefined', () => {
+    const { result } = renderHook(
+      () => useCellStyles({ record: {}, style: undefined }),
+      buildWrapper([getBaseProviderWrapper()])
+    );
+    expect(result.current).toEqual({});
+  });
+
+  it('should return the style object if style is not a function', () => {
+    const style = { color: 'red' };
+    const { result } = renderHook(
+      () => useCellStyles({ record: {}, style }),
+      buildWrapper([getBaseProviderWrapper()])
+    );
+    expect(result.current).toEqual(style);
+  });
+
+  it('should call the style function with record and theme and return the result', () => {
+    const record = { id: 1 };
+    // Theme is defined in rtl-wrappers.tsx, so theme.colors.contentPositive can change
+    // during baseui updates.
+    const style = ({ theme }: { theme: Theme }) => {
+      return { backgroundColor: theme.colors.contentPositive };
+    };
+    const { result } = renderHook(
+      () => useCellStyles({ record, style }),
+      buildWrapper([getBaseProviderWrapper()])
+    );
+    expect(result.current).toEqual({ backgroundColor: '#048848' });
+  });
+});

--- a/javascript/packages/core/components/cell/constants.ts
+++ b/javascript/packages/core/components/cell/constants.ts
@@ -1,0 +1,76 @@
+import { BooleanCell } from './renderers/boolean/boolean-cell';
+
+import type { CellRenderer } from './types';
+
+export enum CellType {
+  /**
+   * @description Renders a gray **Tag** with formatted text
+   */
+  TAG = 'TAG',
+
+  /**
+   * @description Renders a **Checkmark** with formatted text
+   */
+  BOOLEAN = 'BOOLEAN',
+
+  /**
+   * @description Renders a formatted **Date**
+   * @example `2024/01/09 17:53:49`
+   */
+  DATE = 'DATE',
+
+  /**
+   * @description Renders a text slightly smaller and opaque than the standard text
+   */
+  DESCRIPTION = 'DESCRIPTION',
+
+  /**
+   * @description Renders a **Link** with formatted text \
+   * This type is implicitly used when a `url` is provided
+   */
+  LINK = 'LINK',
+
+  /**
+   * @description Renders a **Map** with formatted text lines
+   */
+  MAP = 'MAP',
+
+  /**
+   * @description Renders column items in a vertical list
+   */
+  REPEATED_ITEMS = 'REPEATED_ITEMS',
+
+  /**
+   * @description Renders a **Tag** with coloring and formatted text \
+   * Green for success cases, red for error cases and so on
+   *
+   * @see {@link src/components/cell/state/translation-maps/get-state-kind.ts}
+   */
+  STATE = 'STATE',
+
+  /**
+   * @description Renders different schemas based on typeMeta.kind \
+   * This is an implicit type when either `Revision` or `Draft` is provided
+   */
+  SWITCH_TYPE_META = 'SWITCH_TYPE_META',
+
+  /**
+   * @description Renders a standard non formatted/styled text
+   */
+  TEXT = 'TEXT',
+
+  /**
+   * @description Renders a **Badge** with formatted text `Tier {number}`
+   */
+  TIER = 'TIER',
+
+  /**
+   * @description Renders a **Badge** with formatted text \
+   * Sentence cased formatted with stripped type prefix or suffix
+   */
+  TYPE = 'TYPE',
+}
+
+export const CELL_RENDERERS: Record<string, CellRenderer<any>> = {
+  [CellType.BOOLEAN]: BooleanCell,
+};

--- a/javascript/packages/core/components/cell/get-cell-renderer.ts
+++ b/javascript/packages/core/components/cell/get-cell-renderer.ts
@@ -1,0 +1,6 @@
+import { CELL_RENDERERS } from './constants';
+import { CellRenderer } from './types';
+
+export function getCellRenderer(type: string): CellRenderer<unknown> | undefined {
+  return CELL_RENDERERS[type];
+}

--- a/javascript/packages/core/components/cell/hooks.ts
+++ b/javascript/packages/core/components/cell/hooks.ts
@@ -1,0 +1,22 @@
+import { useStyletron } from 'baseui';
+
+import type { StyleObject } from 'styletron-react';
+import type { SharedCell } from './types';
+
+export function useCellStyles({
+  record,
+  style,
+}: {
+  record: unknown;
+  style: SharedCell['style'] | undefined;
+}): StyleObject {
+  const [, theme] = useStyletron();
+
+  if (!style) return {};
+
+  if (typeof style !== 'function') {
+    return style;
+  }
+
+  return style({ record, theme });
+}

--- a/javascript/packages/core/components/cell/renderers/boolean/__tests__/boolean-cell.tests.tsx
+++ b/javascript/packages/core/components/cell/renderers/boolean/__tests__/boolean-cell.tests.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react';
+
+import { BooleanCell } from '../boolean-cell';
+
+describe('BooleanCell', () => {
+  test('Renders nothing for empty value', () => {
+    render(
+      <BooleanCell
+        column={{ id: 'spec.bool', label: 'ColumnLabel' }}
+        record={{ spec: { bool: false } }}
+        value={false}
+      />
+    );
+
+    expect(screen.queryByText('ColumnLabel')).toBeNull();
+  });
+
+  test('Renders nothing for falsy value', () => {
+    render(
+      <BooleanCell column={{ id: 'spec.bool' }} record={{ spec: { bool: false } }} value={false} />
+    );
+
+    expect(screen.queryByText('ColumnLabel')).toBeNull();
+  });
+
+  test('Renders column label for truthy value', () => {
+    render(
+      <BooleanCell
+        column={{ id: 'spec.bool', label: 'ColumnLabel' }}
+        record={{ spec: { bool: true } }}
+        value={true}
+      />
+    );
+
+    expect(screen.getByText('ColumnLabel')).toBeInTheDocument();
+  });
+});
+
+describe('BooleanTextRenderer', () => {
+  test('Renders nothing for empty value', () => {
+    // @ts-expect-error - intentionally testing with invalid props
+    expect(BooleanCell.toString({})).toBeFalsy();
+  });
+
+  test('Renders nothing for falsy value', () => {
+    expect(BooleanCell.toString({ value: false, column: { id: 'spec.bool' } })).toBeFalsy();
+  });
+
+  test('Renders True for truthy value without label', () => {
+    expect(BooleanCell.toString({ value: true, column: { id: 'spec.bool' } })).toBe('True');
+  });
+
+  test('Renders column label for truthy value', () => {
+    expect(
+      BooleanCell.toString({ value: true, column: { id: 'spec.bool', label: 'ColumnLabel' } })
+    ).toEqual('ColumnLabel');
+  });
+});

--- a/javascript/packages/core/components/cell/renderers/boolean/boolean-cell.tsx
+++ b/javascript/packages/core/components/cell/renderers/boolean/boolean-cell.tsx
@@ -18,7 +18,7 @@ export const BooleanCell = ({ value, column }: CellRendererProps<boolean>) => {
         ...theme.typography.ParagraphSmall,
       })}
     >
-      <Check size={14} />
+      <Check size={20} />
       {BooleanCell.toString({ column, value })}
     </div>
   );

--- a/javascript/packages/core/components/cell/renderers/boolean/boolean-cell.tsx
+++ b/javascript/packages/core/components/cell/renderers/boolean/boolean-cell.tsx
@@ -1,0 +1,31 @@
+import { useStyletron } from 'baseui';
+import { Check } from 'baseui/icon';
+
+import type { CellRendererProps } from '#core/components/cell/types';
+
+export const BooleanCell = ({ value, column }: CellRendererProps<boolean>) => {
+  const [css, theme] = useStyletron();
+
+  if (!value) return null;
+
+  return (
+    <div
+      className={css({
+        alignItems: 'center',
+        display: 'flex',
+        gap: '6px',
+        color: theme.colors.contentAccent,
+        ...theme.typography.ParagraphSmall,
+      })}
+    >
+      <Check size={14} />
+      {BooleanCell.toString({ column, value })}
+    </div>
+  );
+};
+
+BooleanCell.toString = (props: Pick<CellRendererProps<boolean>, 'column' | 'value'>) => {
+  if (!props.value) return '';
+
+  return props.column.label ?? 'True';
+};

--- a/javascript/packages/core/components/cell/types.ts
+++ b/javascript/packages/core/components/cell/types.ts
@@ -1,0 +1,147 @@
+import type { Theme } from 'baseui';
+import type { ReactNode } from 'react';
+import type { StyleObject } from 'styletron-react';
+import type { Accessor } from '#core/types/common/studio-types';
+
+export interface SharedCell<T = any> {
+  /**
+   * @description Unique identifier for the column
+   * If no accessor is provided, this id will be used to access the data
+   * @example 'metadata.name'
+   */
+  id: string;
+
+  /**
+   * @description Used to more flexibly control the cell value by providing a custom json-path or a function
+   * @example 'spec.content.metadata.name'
+   * @example (row) => `Revision ${row?.spec?.revisionId}`,
+   */
+  accessor?: Accessor;
+
+  /**
+   * @description Label to be displayed in the table header
+   */
+  label?: string;
+
+  /**
+   * @description Helper field that can control Filter type therefore the Filter UI (simple select/ date picker)
+   * @example ColumnType.DATE
+   */
+  type?: string;
+
+  /**
+   * @description Icon to be displayed in the data cell before the value
+   */
+  icon?: string;
+
+  /**
+   * @description When provided, the cell will display a tooltip on hover
+   */
+  tooltip?: CellTooltip;
+
+  /**
+   * @description Decorates every cell in the column row with content
+   *
+   * @example
+   * {
+   *  type: 'tooltip',
+   *  content: 'Show this tooltip next to the cell
+   * }
+   */
+  endEnhancer?: {
+    content: ReactNode;
+    type: 'tooltip';
+  };
+
+  /**
+   * @description Custom cell renderer
+   *
+   * @remarks Use caution when leveraging a custom `Cell` renderer, as the default
+   * renderer provides styling/hyperlinking/etc.
+   *
+   * Either ensure the cell you are configuring:
+   *  - Does not need this functionality
+   *  - Applies its own copy of this functionality
+   *
+   * @default
+   * @see src/components/cell/renderers/default/column-renderer.tsx
+   */
+  Cell?: CellRenderer<T>;
+
+  /**
+   * @description Style overrides to be applied to each cell
+   *
+   * @default {}
+   * @see src/components/pages/studio-evaluation-charts/report-charts/report-table/utils/columns-builder.ts
+   */
+  style?: StyleObject | CellStyleFunction;
+}
+
+export type CellTooltip = {
+  content: string | ((params: CellRendererProps) => React.ReactNode);
+  action: 'filter' | 'custom';
+};
+
+/**
+ * A function type that defines the style for a cell based on the provided arguments.
+ *
+ * @param args - An object containing the following properties:
+ *   @property record - The data record associated with the cell.
+ *   @property theme - The theme object used for styling.
+ *
+ * @returns A `StyleObject` that represents the computed style for the cell.
+ */
+export type CellStyleFunction = (args: { record: unknown; theme: Theme }) => StyleObject;
+
+export type CellRenderer<T, CellConfig = SharedCell> = {
+  (props: CellRendererProps<T, CellConfig>): ReactNode | null;
+
+  /**
+   * @description
+   * Primary consumer is table filtering smart search
+   */
+  toString?: (props: CellRendererProps<T, CellConfig>) => string;
+};
+
+export interface CellRendererProps<T = any, CellConfig = SharedCell<T>> {
+  column: CellConfig;
+
+  /**
+   * @description
+   * The record of data for the cell
+   *
+   * @remarks
+   * The value of the cell is the value of the record at the path specified by the
+   * accessor.
+   */
+  record: object;
+
+  /**
+   * @description
+   * This is the value that will be displayed in the cell.
+   *
+   * @remarks
+   * This is the value that will be displayed in the cell.
+   */
+  value: T;
+
+  /**
+   * @description
+   * The central Cell rendering component. This ensures that any cell renderers
+   * that require recursive rendering can access functionality provided by the
+   * central Cell renderer. For example, context, like table filtering, that is
+   * only available to a the Table instantiation of Cells
+   *
+   * @see
+   * src/components/cell/renderers/switch-type-meta
+   *
+   * @default
+   * src/components/cell/renderers/default/column-renderer.tsx
+   */
+  CellComponent?: CellRenderer<T>;
+}
+
+export type CellToStringParams<T = any, CellConfig = SharedCell> = Pick<
+  CellRendererProps<T, CellConfig>,
+  'column' | 'value'
+>;

--- a/javascript/packages/core/components/views/project/project-detail.tsx
+++ b/javascript/packages/core/components/views/project/project-detail.tsx
@@ -12,11 +12,11 @@ export function ProjectDetail() {
     },
   });
 
-  // The project type will not be directly exposed to the @michelangelo/core package.
-  // eslint-disable-next-line @typescript-eslint/dot-notation
   return (
     <div>
       <BooleanCell column={{ id: 'spec.bool' }} record={{ spec: { bool: true } }} value={true} />
+      {/* The project type will not be directly exposed to the @michelangelo/core package. */}
+      {/* eslint-disable-next-line @typescript-eslint/dot-notation */}
       Project Name: {data?.project?.metadata?.['name']}
     </div>
   );

--- a/javascript/packages/core/components/views/project/project-detail.tsx
+++ b/javascript/packages/core/components/views/project/project-detail.tsx
@@ -1,3 +1,4 @@
+import { BooleanCell } from '#core/components/cell/renderers/boolean/boolean-cell';
 import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
 import { useStudioQuery } from '#core/hooks/use-studio-query';
 
@@ -13,5 +14,10 @@ export function ProjectDetail() {
 
   // The project type will not be directly exposed to the @michelangelo/core package.
   // eslint-disable-next-line @typescript-eslint/dot-notation
-  return <div>Project Name: {data?.project?.metadata?.['name']}</div>;
+  return (
+    <div>
+      <BooleanCell column={{ id: 'spec.bool' }} record={{ spec: { bool: true } }} value={true} />
+      Project Name: {data?.project?.metadata?.['name']}
+    </div>
+  );
 }

--- a/javascript/packages/core/test-setup.ts
+++ b/javascript/packages/core/test-setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/javascript/packages/core/test/wrappers/get-base-provider-wrapper.tsx
+++ b/javascript/packages/core/test/wrappers/get-base-provider-wrapper.tsx
@@ -1,0 +1,12 @@
+// This is required for some BaseWeb components. If missing, BaseWeb will console.warn
+
+import { ThemeProvider } from '#core/themes/provider';
+import { WrapperComponentProps } from './types';
+
+// This is required for some BaseWeb components. If missing, BaseWeb will console.warn
+// something like "`LayersManager` was not found."
+export function getBaseProviderWrapper() {
+  return function BaseProviderWrapper({ children }: WrapperComponentProps) {
+    return <ThemeProvider>{children}</ThemeProvider>;
+  };
+}

--- a/javascript/packages/core/types/common/studio-types.ts
+++ b/javascript/packages/core/types/common/studio-types.ts
@@ -44,3 +44,30 @@ export enum Phase {
   /** Monitoring of generative AI model performance */
   GenaiMonitor = 'genai-monitor',
 }
+
+/**
+ * @description
+ * Defines a way to access a specific property or value from an object.
+ * This can be either a string representing a dot-notation path, or a function
+ * that directly extracts the value.
+ *
+ * @remarks
+ * When `Accessor` is a string, it represents a path using dot notation (e.g., `'name'`, `'address.street'`)
+ * and can include array indexing (e.g., `'users[0].name'`). A utility function is typically used to
+ * interpret this string path against an object.
+ *
+ * @example
+ * ```ts
+ * const accessor: Accessor = 'name';
+ * accessor({ name: 'John' }); // 'John'
+ *
+ * const accessor: Accessor = 'users[0].name';
+ * accessor({ users: [{ name: 'John' }] }); // 'John'
+ *
+ * const accessor: Accessor<string> = (object) => object.name;
+ * accessor({ name: 'John' }); // 'John'
+ * ```
+ */
+export type Accessor<K = unknown> = AccessorFn<K> | string;
+
+export type AccessorFn<T = unknown> = (object: unknown) => T;

--- a/javascript/packages/core/vitest.config.ts
+++ b/javascript/packages/core/vitest.config.ts
@@ -6,5 +6,6 @@ export default defineConfig({
     environment: 'jsdom', // Simulate a browser environment for React components
     globals: true, // Enable global Jest-like functions (describe, it, expect)
     include: ['**/__tests__/**/*.{ts,tsx}'],
+    setupFiles: ['./test-setup.ts'],
   },
 });

--- a/tools/gen-grpc-client.sh
+++ b/tools/gen-grpc-client.sh
@@ -97,7 +97,7 @@ plugins:
     out: gen/python
     include_imports: true
 
-  - remote: buf.build/bufbuild/es
+  - remote: buf.build/bufbuild/es:v2.2.5
     out: gen/javascript
     include_imports: true
 EOF


### PR DESCRIPTION
Migrate the cell rendering system from internal repository. The system includes
a type-safe infrastructure for defining cell renderers, with the BooleanCell
component as the first implementation. The project detail view has been updated
to demonstrate usage of the new BooleanCell component.

The implementation includes test coverage and TypeScript type definitions.
ESLint rules have been adjusted to match internal implementation patterns to
prevent migration blockers. Added test setup with jest-dom matchers to support
component testing.

Fixed development environment issues by pinning buf.build/es to version 2.2.5
to resolve version mismatch problems.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
