### PR TITLE
Prepare cell renderers for internal migration

### DIFF
--- a/javascript/app/package.json
+++ b/javascript/app/package.json
@@ -12,7 +12,9 @@
     "@tanstack/react-query": "5.39.0",
     "@uber/michelangelo-core": "*",
     "react-router-dom": "5.3.4",
-    "react-router-dom-v5-compat": "6.29.0"
+    "react-router-dom-v5-compat": "6.29.0",
+    "styletron-engine-atomic": "^1.6.2",
+    "styletron-react": "^6.1.1"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.4.1",

--- a/javascript/packages/core/index.tsx
+++ b/javascript/packages/core/index.tsx
@@ -29,3 +29,6 @@ export function CoreApp({ dependencies }: Props) {
 
 export { useStudioQuery } from '#core/hooks/use-studio-query';
 export { ServiceProvider } from '#core/providers/service-provider/service-provider';
+
+export { getCellRenderer } from '#core/components/cell/get-cell-renderer';
+export { BooleanCell } from '#core/components/cell/renderers/boolean/boolean-cell';

--- a/javascript/packages/core/package.json
+++ b/javascript/packages/core/package.json
@@ -21,9 +21,7 @@
     "baseui": "^13.0.0",
     "pluralize": "^8.0.0",
     "react": "18.3.1",
-    "react-dom": "18.3.1",
-    "styletron-engine-monolithic": "^1.0.0",
-    "styletron-react": "^6.1.1"
+    "react-dom": "18.3.1"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.0",
@@ -39,7 +37,9 @@
   "peerDependencies": {
     "react-router-dom": "^5.3.4",
     "react-router-dom-v5-compat": "^6.29.0",
-    "@tanstack/react-query": "^5.0.0"
+    "@tanstack/react-query": "^5.0.0",
+    "styletron-engine-atomic": "^1.0.0",
+    "styletron-react": "^6.1.1"
   },
   "exports": {
     ".": {

--- a/javascript/packages/core/themes/provider.tsx
+++ b/javascript/packages/core/themes/provider.tsx
@@ -1,5 +1,5 @@
 import { BaseProvider, createTheme } from 'baseui';
-import { Client as Styletron } from 'styletron-engine-monolithic';
+import { Client as Styletron } from 'styletron-engine-atomic';
 import { Provider as StyletronProvider } from 'styletron-react';
 
 import { GRID_OVERRIDES } from './shared';

--- a/javascript/yarn.lock
+++ b/javascript/yarn.lock
@@ -3825,10 +3825,10 @@ strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
-styletron-engine-monolithic@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/styletron-engine-monolithic/-/styletron-engine-monolithic-1.0.0.tgz#41e2bbf9dcbdddff2ff2165f38b563c60f6015e3"
-  integrity sha512-9x+RMLbjf6rzK7mLp5bWzh/wwLbgO0xrU07sW9p9SWu18d+lkfnE8SLDm+jf4NamehQv86etX0X+Zx4PvaeJyA==
+styletron-engine-atomic@^1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/styletron-engine-atomic/-/styletron-engine-atomic-1.6.2.tgz#9cfdaecb5ce27266c0d46436350df78178e6c6bb"
+  integrity sha512-vWSIxpCkYbVD3xhnxYwnJDJePD8p8pJCu7g1zFxdQIM4z34Eo1zj3LgXJI6yeNMrJ7PkE56SYK6ZOo3hpTOBzA==
   dependencies:
     inline-style-prefixer "^5.1.0"
     styletron-standard "^3.1.0"


### PR DESCRIPTION
Switch to styletron-engine-atomic to match internal implementation. Move
styletron dependencies to peerDependencies to ensure single instance is shared
across packages. Export cell renderer components from core package index for
internal consumption.

**What type of PR is this? (check all applicable)**
- [x] Refactor
- [] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
