### PR TITLE
Upgrade minio release to latest.

### DIFF
--- a/python/michelangelo/cli/sandbox/resources/minio.yaml
+++ b/python/michelangelo/cli/sandbox/resources/minio.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
     - name: minio
-      image: minio/minio:RELEASE.2023-04-20T17-56-55Z
+      image: minio/minio:RELEASE.2025-05-24T17-08-30Z
       command:
         - /bin/bash
         - -c


### PR DESCRIPTION
This pull request aims to enhance compatibility, configuration, and security aspects as highlighted in issue #202. It achieves this by upgrading the pinned release version from RELEASE.2023-04-20T17-56-55Z to a more recent release, RELEASE.2025-05-24T17-08-30Z.

The pull request has been validated by setting up a local sandbox environment to confirm that the Minio service remains accessible on both the console and API ports. To the best of my knowledge, there are no disruptive changes associated with the Minio release upgrade. In the event of any issues, reverting to the previous release is a straightforward process.