### PR TITLE
Add date cell renderer with timezone support

### DIFF
--- a/javascript/packages/core/components/cell/constants.ts
+++ b/javascript/packages/core/components/cell/constants.ts
@@ -1,4 +1,5 @@
 import { BooleanCell } from './renderers/boolean/boolean-cell';
+import { DateCell } from './renderers/date/date-cell';
 
 import type { CellRenderer } from './types';
 
@@ -73,4 +74,5 @@ export enum CellType {
 
 export const CELL_RENDERERS: Record<string, CellRenderer<any>> = {
   [CellType.BOOLEAN]: BooleanCell,
+  [CellType.DATE]: DateCell,
 };

--- a/javascript/packages/core/components/cell/renderers/date/__tests__/date-cell.tests.tsx
+++ b/javascript/packages/core/components/cell/renderers/date/__tests__/date-cell.tests.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react';
+
+import { UserTimeZone } from '#core/providers/user-provider/types';
+import { mockTimezone } from '#core/test/utils/mock-timezone';
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
+import { getUserProviderWrapper } from '#core/test/wrappers/get-user-provider-wrapper';
+import { DateCell } from '../date-cell';
+
+describe('DateCell', () => {
+  const restore = mockTimezone();
+
+  afterAll(() => {
+    restore();
+  });
+
+  test('Renders nothing for empty value', () => {
+    render(
+      <DateCell
+        column={{ id: 'spec.date' }}
+        record={{ spec: { date: undefined } }}
+        value={undefined}
+      />,
+      buildWrapper([getBaseProviderWrapper(), getUserProviderWrapper()])
+    );
+
+    expect(screen.queryByText(/2024/)).toBeNull();
+  });
+
+  test('Renders formatted date for valid timestamp in local timezone', () => {
+    render(
+      <DateCell
+        column={{ id: 'spec.date' }}
+        record={{ spec: { date: '1720656639' } }}
+        value="1720656639"
+      />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getUserProviderWrapper({ timeZone: UserTimeZone.Local }),
+      ])
+    );
+
+    expect(screen.getByText('2024/07/11 02:10:39 (GMT+2)')).toBeInTheDocument();
+  });
+
+  test('Renders UTC date when timezone is UTC', () => {
+    render(
+      <DateCell
+        column={{ id: 'spec.date' }}
+        record={{ spec: { date: '1720656639' } }}
+        value="1720656639"
+      />,
+      buildWrapper([getBaseProviderWrapper(), getUserProviderWrapper()])
+    );
+
+    expect(screen.getByText('2024/07/11 00:10:39 (UTC)')).toBeInTheDocument();
+  });
+
+  describe('toString', () => {
+    test('Returns empty string for empty value', () => {
+      expect(DateCell.toString({ value: undefined, column: { id: 'spec.date' } })).toBe('');
+    });
+
+    test('Returns formatted date string', () => {
+      expect(
+        DateCell.toString({
+          value: '1720656639',
+          column: { id: 'spec.date' },
+        })
+      ).toBe('2024/07/11 02:10:39 (GMT+2)');
+    });
+  });
+});

--- a/javascript/packages/core/components/cell/renderers/date/date-cell-to-string.ts
+++ b/javascript/packages/core/components/cell/renderers/date/date-cell-to-string.ts
@@ -1,0 +1,6 @@
+import { timestampToString } from '#core/utils/time-utils';
+
+import type { CellToStringParams } from '#core/components/cell/types';
+
+export const dateCellToString = ({ value }: CellToStringParams<string>) =>
+  timestampToString(value) ?? '';

--- a/javascript/packages/core/components/cell/renderers/date/date-cell.tsx
+++ b/javascript/packages/core/components/cell/renderers/date/date-cell.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import { DateTime } from '#core/components/date-time/date-time';
+import { dateCellToString } from './date-cell-to-string';
+
+import type { CellRendererProps } from '#core/components/cell/types';
+
+export const DateCell = (props: CellRendererProps<string>): React.ReactElement => {
+  return <DateTime timestamp={props.value} />;
+};
+
+DateCell.toString = dateCellToString;

--- a/javascript/packages/core/components/cell/types.ts
+++ b/javascript/packages/core/components/cell/types.ts
@@ -123,7 +123,7 @@ export interface CellRendererProps<T = any, CellConfig = SharedCell<T>> {
    * @remarks
    * This is the value that will be displayed in the cell.
    */
-  value: T;
+  value: T | undefined;
 
   /**
    * @description

--- a/javascript/packages/core/components/date-time/__tests__/date-time.tests.tsx
+++ b/javascript/packages/core/components/date-time/__tests__/date-time.tests.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react';
+
+import { UserTimeZone } from '#core/providers/user-provider/types';
+import { mockTimezone } from '#core/test/utils/mock-timezone';
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
+import { getUserProviderWrapper } from '#core/test/wrappers/get-user-provider-wrapper';
+import { DateTime } from '../date-time';
+
+describe('DateTime', () => {
+  const restore = mockTimezone();
+
+  afterAll(() => {
+    restore();
+  });
+
+  test('renders nothing when timestamp is undefined', () => {
+    render(
+      <DateTime timestamp={undefined} />,
+      buildWrapper([getBaseProviderWrapper(), getUserProviderWrapper()])
+    );
+
+    expect(screen.queryByText(/2024/)).toBeNull();
+  });
+
+  test('renders formatted date in local timezone', () => {
+    render(
+      <DateTime timestamp="1720656639" />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getUserProviderWrapper({ timeZone: UserTimeZone.Local }),
+      ])
+    );
+
+    expect(screen.getByText('2024/07/11 02:10:39 (GMT+2)')).toBeInTheDocument();
+  });
+
+  test('renders formatted date in UTC timezone', () => {
+    render(
+      <DateTime timestamp="1720656639" />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getUserProviderWrapper({ timeZone: UserTimeZone.UTC }),
+      ])
+    );
+
+    expect(screen.getByText('2024/07/11 00:10:39 (UTC)')).toBeInTheDocument();
+  });
+
+  test('renders formatted date for numeric timestamp', () => {
+    render(
+      <DateTime timestamp={1720656639} />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getUserProviderWrapper({ timeZone: UserTimeZone.Local }),
+      ])
+    );
+
+    expect(screen.getByText('2024/07/11 02:10:39 (GMT+2)')).toBeInTheDocument();
+  });
+});

--- a/javascript/packages/core/components/date-time/date-time.tsx
+++ b/javascript/packages/core/components/date-time/date-time.tsx
@@ -1,0 +1,14 @@
+import { useUserProvider } from '#core/providers/user-provider/use-user-provider';
+import { timestampToString } from '#core/utils/time-utils';
+
+import type { Props } from './types';
+
+export function DateTime(props: Props) {
+  const { timestamp } = props;
+
+  const { timeZone } = useUserProvider();
+
+  const dateString = timestamp ? timestampToString(timestamp, timeZone) : null;
+
+  return <>{dateString}</>;
+}

--- a/javascript/packages/core/components/date-time/types.ts
+++ b/javascript/packages/core/components/date-time/types.ts
@@ -1,0 +1,3 @@
+export type Props = {
+  timestamp?: string | number;
+};

--- a/javascript/packages/core/components/views/project/project-detail.tsx
+++ b/javascript/packages/core/components/views/project/project-detail.tsx
@@ -1,4 +1,5 @@
 import { BooleanCell } from '#core/components/cell/renderers/boolean/boolean-cell';
+import { DateCell } from '#core/components/cell/renderers/date/date-cell';
 import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
 import { useStudioQuery } from '#core/hooks/use-studio-query';
 
@@ -15,6 +16,12 @@ export function ProjectDetail() {
   return (
     <div>
       <BooleanCell column={{ id: 'spec.bool' }} record={{ spec: { bool: true } }} value={true} />
+      <DateCell
+        column={{ id: 'spec.date' }}
+        record={{ spec: { date: Date.now() / 1000 } }}
+        value={String(Date.now() / 1000)}
+      />
+      <br />
       {/* The project type will not be directly exposed to the @michelangelo/core package. */}
       {/* eslint-disable-next-line @typescript-eslint/dot-notation */}
       Project Name: {data?.project?.metadata?.['name']}

--- a/javascript/packages/core/index.tsx
+++ b/javascript/packages/core/index.tsx
@@ -32,3 +32,4 @@ export { ServiceProvider } from '#core/providers/service-provider/service-provid
 
 export { getCellRenderer } from '#core/components/cell/get-cell-renderer';
 export { BooleanCell } from '#core/components/cell/renderers/boolean/boolean-cell';
+export { DateCell } from '#core/components/cell/renderers/date/date-cell';

--- a/javascript/packages/core/package.json
+++ b/javascript/packages/core/package.json
@@ -20,7 +20,6 @@
     "@types/pluralize": "^0.0.33",
     "baseui": "^13.0.0",
     "lodash": "^4.17.21",
-    "moment": "^2.30.1",
     "pluralize": "^8.0.0",
     "react": "18.3.1",
     "react-dom": "18.3.1"

--- a/javascript/packages/core/package.json
+++ b/javascript/packages/core/package.json
@@ -19,6 +19,8 @@
     "@connectrpc/connect-web": "^2.0.2",
     "@types/pluralize": "^0.0.33",
     "baseui": "^13.0.0",
+    "lodash": "^4.17.21",
+    "moment": "^2.30.1",
     "pluralize": "^8.0.0",
     "react": "18.3.1",
     "react-dom": "18.3.1"
@@ -28,6 +30,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@types/jest": "^29.5.14",
+    "@types/lodash": "^4.17.17",
     "@types/react-router": "^5.1.20",
     "@vitejs/plugin-react": "^4.4.1",
     "jsdom": "^26.1.0",
@@ -35,9 +38,9 @@
     "vitest": "^3.1.1"
   },
   "peerDependencies": {
+    "@tanstack/react-query": "^5.0.0",
     "react-router-dom": "^5.3.4",
     "react-router-dom-v5-compat": "^6.29.0",
-    "@tanstack/react-query": "^5.0.0",
     "styletron-engine-atomic": "^1.0.0",
     "styletron-react": "^6.1.1"
   },

--- a/javascript/packages/core/providers/user-provider/types.ts
+++ b/javascript/packages/core/providers/user-provider/types.ts
@@ -1,0 +1,8 @@
+export enum UserTimeZone {
+  Local = 'local',
+  UTC = 'utc',
+}
+
+export type UserContextType = {
+  timeZone: UserTimeZone;
+};

--- a/javascript/packages/core/providers/user-provider/use-user-provider.tsx
+++ b/javascript/packages/core/providers/user-provider/use-user-provider.tsx
@@ -1,0 +1,7 @@
+import { useContext } from 'react';
+
+import { UserContext } from './user-context';
+
+export const useUserProvider = () => {
+  return useContext(UserContext);
+};

--- a/javascript/packages/core/providers/user-provider/user-context.ts
+++ b/javascript/packages/core/providers/user-provider/user-context.ts
@@ -1,0 +1,9 @@
+import { createContext } from 'react';
+
+import { UserTimeZone } from './types';
+
+import type { UserContextType } from './types';
+
+export const UserContext = createContext<UserContextType>({
+  timeZone: UserTimeZone.Local,
+});

--- a/javascript/packages/core/providers/user-provider/user-provider.tsx
+++ b/javascript/packages/core/providers/user-provider/user-provider.tsx
@@ -1,0 +1,10 @@
+import { UserContext } from './user-context';
+
+import type { UserContextType } from './types';
+
+export const UserProvider = ({
+  children,
+  ...userContext
+}: { children: React.ReactNode } & UserContextType) => {
+  return <UserContext.Provider value={userContext}>{children}</UserContext.Provider>;
+};

--- a/javascript/packages/core/test/utils/mock-timezone.ts
+++ b/javascript/packages/core/test/utils/mock-timezone.ts
@@ -1,0 +1,33 @@
+/**
+ * Mocks Intl.DateTimeFormat to control timezone output in tests.
+ * This ensures consistent timezone behavior across test files.
+ *
+ * @param defaultTimezone - The timezone to use when not explicitly set to UTC
+ * @returns A function to restore the original Intl.DateTimeFormat
+ *
+ * @example
+ * ```ts
+ * const restore = mockTimezone('Europe/Amsterdam');
+ *
+ * afterAll(() => {
+ *   restore();
+ * });
+ * ```
+ */
+export function mockTimezone(defaultTimezone = 'Europe/Amsterdam') {
+  const originalDateTimeFormat = Intl.DateTimeFormat;
+
+  global.Intl.DateTimeFormat = function (
+    locale?: string | string[],
+    options?: Intl.DateTimeFormatOptions
+  ): Intl.DateTimeFormat {
+    return new originalDateTimeFormat(locale, {
+      ...options,
+      timeZone: options?.timeZone === 'UTC' ? 'UTC' : defaultTimezone,
+    });
+  } as unknown as Intl.DateTimeFormatConstructor;
+
+  return () => {
+    global.Intl.DateTimeFormat = originalDateTimeFormat;
+  };
+}

--- a/javascript/packages/core/test/wrappers/get-user-provider-wrapper.tsx
+++ b/javascript/packages/core/test/wrappers/get-user-provider-wrapper.tsx
@@ -1,0 +1,35 @@
+import { type UserContextType, UserTimeZone } from '#core/providers/user-provider/types';
+import { UserProvider } from '#core/providers/user-provider/user-provider';
+import { WrapperComponentProps } from './types';
+
+/**
+ * Creates a React wrapper for testing components that use service features.
+ * This wrapper is essential for testing components that use service hooks
+ * like useStudioQuery, useStudioMutation, etc.
+ *
+ * @param serviceProvider - The service provider to use for the service context
+ * @returns A wrapper component that provides service context to its children
+ *
+ * @example
+ * ```tsx
+ * // Simple usage with a specific route
+ * const mockRequest = vi.fn();
+ * const wrapper = getServiceProviderWrapper({ request: mockRequest });
+ * render(<MyComponent />, { wrapper });
+ *
+ * expect(mockRequest).toHaveBeenCalledWith('requestId', { queryKey: ['requestId'] });
+ * ```
+ */
+export function getUserProviderWrapper(userProvider?: Partial<UserContextType>) {
+  const base = {
+    timeZone: UserTimeZone.UTC,
+  };
+
+  return function ServiceProviderWrapper({ children }: WrapperComponentProps) {
+    return (
+      <UserProvider {...base} {...userProvider}>
+        {children}
+      </UserProvider>
+    );
+  };
+}

--- a/javascript/packages/core/utils/__tests__/time-utils.tests.ts
+++ b/javascript/packages/core/utils/__tests__/time-utils.tests.ts
@@ -1,0 +1,56 @@
+import { UserTimeZone } from '#core/providers/user-provider/types';
+import { mockTimezone } from '#core/test/utils/mock-timezone';
+import { timestampToString } from '../time-utils';
+
+describe('time-utils', () => {
+  describe('timestampToString', () => {
+    const restore = mockTimezone();
+
+    afterAll(() => {
+      restore();
+    });
+
+    test('Handles falsy data', () => {
+      // @ts-expect-error todo(ts-migration) TS2345 Argument of type 'null' is not assignable to parameter of type 'string | number'.
+      expect(timestampToString(null)).toBeFalsy();
+    });
+
+    test('Handles non-epoch-second data', () => {
+      expect(timestampToString('something invalid')).toEqual('Invalid date');
+    });
+
+    test('Formats epoch seconds into date with time', () => {
+      expect(timestampToString(1671189655)).toMatch(
+        // This format is any two-digit day within December 2022. Any time during that day.
+        /2022\/12\/\d{2} \d{1,2}:\d{1,2}:\d{1,2}/
+      );
+    });
+
+    test('formats date correctly without the timezone', () => {
+      expect(timestampToString(1719907200)).toBe('2024/07/02 10:00:00 (GMT+2)');
+      expect(timestampToString(1720656639)).toBe('2024/07/11 02:10:39 (GMT+2)');
+      expect(timestampToString('1720656639')).toBe('2024/07/11 02:10:39 (GMT+2)');
+    });
+
+    test('formats date correctly in UTC timezone', () => {
+      expect(timestampToString(1719907200, UserTimeZone.UTC)).toBe('2024/07/02 08:00:00 (UTC)');
+      expect(timestampToString(1720656639, UserTimeZone.UTC)).toBe('2024/07/11 00:10:39 (UTC)');
+      expect(timestampToString('1720656639', UserTimeZone.UTC)).toBe('2024/07/11 00:10:39 (UTC)');
+    });
+
+    test('formats date correctly in local timezone', () => {
+      // GMT does not include summer time shift.
+      expect(timestampToString(1705063132, UserTimeZone.Local)).toBe('2024/01/12 13:38:52 (GMT+1)');
+      expect(timestampToString('1705063132', UserTimeZone.Local)).toBe(
+        '2024/01/12 13:38:52 (GMT+1)'
+      );
+
+      // GMT includes summer time shift.
+      expect(timestampToString(1719907200, UserTimeZone.Local)).toBe('2024/07/02 10:00:00 (GMT+2)');
+      expect(timestampToString(1720656639, UserTimeZone.Local)).toBe('2024/07/11 02:10:39 (GMT+2)');
+      expect(timestampToString('1720656639', UserTimeZone.Local)).toBe(
+        '2024/07/11 02:10:39 (GMT+2)'
+      );
+    });
+  });
+});

--- a/javascript/packages/core/utils/time-utils.ts
+++ b/javascript/packages/core/utils/time-utils.ts
@@ -1,0 +1,51 @@
+import { isNil } from 'lodash';
+
+import { UserTimeZone } from '#core/providers/user-provider/types';
+
+/**
+ * Converts a timestamp to a string.
+ * If timezone kind is specified, it adjust the time and also adds a timezone info.
+ *
+ * @example
+ * - timestampToString(1720656638) -> '2024/07/11 02:10:38'
+ * - timestampToString(1720656639, 'utc') -> '2024/07/11 00:10:39 (UTC)'
+ * - timestampToString(1720656639, 'local') -> '2024/07/11 02:10:39 (GMT+2)'
+ */
+export function timestampToString(
+  timestampRaw?: string | number,
+  timeZone?: UserTimeZone
+): string | null {
+  if (isNil(timestampRaw)) {
+    return null;
+  }
+
+  const date = new Date(Number(timestampRaw) * 1000);
+  if (isNaN(date.getTime())) {
+    return 'Invalid date';
+  }
+
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+    timeZone: timeZone === UserTimeZone.UTC ? 'UTC' : undefined,
+  });
+
+  const formattedDate = formatter
+    .format(date)
+    .replace(/(\d+)\/(\d+)\/(\d+)/, '$3/$1/$2') // Convert MM/DD/YYYY to YYYY/MM/DD
+    .replace(/,/g, ''); // Remove commas
+
+  const timeZoneFormatter = new Intl.DateTimeFormat('en-US', {
+    timeZoneName: 'short',
+    timeZone: timeZone === UserTimeZone.UTC ? 'UTC' : undefined,
+  });
+
+  const timeZoneString = timeZoneFormatter.format(date).split(' ').pop() ?? '';
+
+  return `${formattedDate} (${timeZoneString})`;
+}

--- a/javascript/yarn.lock
+++ b/javascript/yarn.lock
@@ -804,6 +804,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
+"@types/lodash@^4.17.17":
+  version "4.17.17"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.17.tgz#fb85a04f47e9e4da888384feead0de05f7070355"
+  integrity sha512-RRVJ+J3J+WmyOTqnz3PiBLA501eKwXl2noseKOrNo/6+XEHjTAxO4xHvxQB6QuNm+s4WRbn6rSiap8+EA+ykFQ==
+
 "@types/node@*":
   version "22.14.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-22.14.1.tgz#53b54585cec81c21eee3697521e31312d6ca1e6f"
@@ -3022,6 +3027,11 @@ mockdate@^3.0.5:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-3.0.5.tgz#789be686deb3149e7df2b663d2bc4392bc3284fb"
   integrity sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==
+
+moment@^2.30.1:
+  version "2.30.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
+  integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
 
 ms@^2.1.3:
   version "2.1.3"

--- a/javascript/yarn.lock
+++ b/javascript/yarn.lock
@@ -3028,11 +3028,6 @@ mockdate@^3.0.5:
   resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-3.0.5.tgz#789be686deb3149e7df2b663d2bc4392bc3284fb"
   integrity sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==
 
-moment@^2.30.1:
-  version "2.30.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
-  integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
-
 ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"


### PR DESCRIPTION
Add DateCell component with timezone-aware formatting. Include DateTime
component and time utilities for consistent date formatting across the
application. Add user provider for timezone preferences and test utilities
for timezone mocking. Update cell renderer types to handle undefined values
from accessor lookups.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
