### PR TITLE
Add log-viewer deployment job

### DIFF
--- a/python/michelangelo/cli/sandbox/resources/aws-credentials.yaml
+++ b/python/michelangelo/cli/sandbox/resources/aws-credentials.yaml
@@ -1,0 +1,8 @@
+apiVersion: "v1"
+kind: "Secret"
+metadata:
+  name: "aws-credentials"
+  namespace: "default"
+type: "Opaque"
+data:
+  credentials: "W2RlZmF1bHRdCmF3c19hY2Nlc3Nfa2V5X2lkID0gbWluaW9hZG1pbgphd3Nfc2VjcmV0X2FjY2Vzc19rZXkgPSBtaW5pb2FkbWluCg=="

--- a/python/michelangelo/cli/sandbox/resources/yscope-log-viewer-deployment.yaml
+++ b/python/michelangelo/cli/sandbox/resources/yscope-log-viewer-deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: "batch/v1"
+kind: "Job"
+metadata:
+  name: "yscope-log-viewer-deployment"
+spec:
+  template:
+    spec:
+      containers:
+        # Container to deploy the log viewer. To inspect logs, use the following command:
+        # `kubectl logs job.batch/yscope-log-viewer-deployment`
+        - name: "deploy-yscope-log-viewer"
+          image: "amazon/aws-cli:latest"
+          command:
+            - "/bin/bash"
+            - "-c"
+          args:
+            - "yum install -y gzip jq tar \
+            && curl -s \
+            https://raw.githubusercontent.com/y-scope/yscope-log-viewer/refs/heads/main/tools/\
+            deployment/s3/deploy.sh | bash"
+          env:
+            - name: "AWS_ENDPOINT_URL"
+              value: "http://minio:9091"
+            - name: "LOG_VIEWER_BUCKET"
+              value: "log-viewer"
+          volumeMounts:
+            - name: "aws-credentials-volume"
+              mountPath: "/root/.aws"
+          imagePullPolicy: "IfNotPresent"
+      restartPolicy: "Never"
+      volumes:
+        - name: aws-credentials-volume
+          secret:
+            secretName: aws-credentials

--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -147,6 +147,8 @@ Be aware that CR_PAT environment variable is required while Michelangelo is NOT 
         "mysql.yaml",
         "minio.yaml",
         "michelangelo-config.yaml",
+        "aws-credentials.yaml",
+        "yscope-log-viewer-deployment.yaml",
     ]
     if "apiserver" not in ns.exclude:
         resources.append("michelangelo-apiserver.yaml")
@@ -165,7 +167,8 @@ Be aware that CR_PAT environment variable is required while Michelangelo is NOT 
         "github.com/ray-project/kuberay/ray-operator/config/default?ref=v1.0.0",
     )
 
-    _exec("kubectl", "wait", "--all", "pods", "--for=condition=ready", "--timeout=600s")
+    _exec("kubectl", "wait", "--all", "pods", "--for=condition=ready", "--selector=!job-name", "--timeout=600s")
+    _exec("kubectl", "wait", "--all", "jobs", "--for=condition=complete", "--timeout=600s")
 
     links = []
     _assert_command(
@@ -253,6 +256,7 @@ def _setup_temporal(links, helm_existing_repos):
         "wait",
         "--for=condition=available",
         "deployment",
+        "--selector=!job-name",
         "--all",
         "--timeout=600s",
     )
@@ -288,7 +292,7 @@ def _setup_temporal(links, helm_existing_repos):
 
 def _setup_cadence(links):
     _kube_create(_dir / "resources" / "cadence.yaml")
-    _exec("kubectl", "wait", "--all", "pods", "--for=condition=ready", "--timeout=600s")
+    _exec("kubectl", "wait", "--all", "pods", "--for=condition=ready", "--selector=!job-name", "--timeout=600s")
     _kube_run(
         image="ubercadence/cli:v1.2.6",
         command=[

--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -167,8 +167,18 @@ Be aware that CR_PAT environment variable is required while Michelangelo is NOT 
         "github.com/ray-project/kuberay/ray-operator/config/default?ref=v1.0.0",
     )
 
-    _exec("kubectl", "wait", "--all", "pods", "--for=condition=ready", "--selector=!job-name", "--timeout=600s")
-    _exec("kubectl", "wait", "--all", "jobs", "--for=condition=complete", "--timeout=600s")
+    _exec(
+        "kubectl",
+        "wait",
+        "--all",
+        "pods",
+        "--for=condition=ready",
+        "--selector=!job-name",
+        "--timeout=600s",
+    )
+    _exec(
+        "kubectl", "wait", "--all", "jobs", "--for=condition=complete", "--timeout=600s"
+    )
 
     links = []
     _assert_command(
@@ -292,7 +302,15 @@ def _setup_temporal(links, helm_existing_repos):
 
 def _setup_cadence(links):
     _kube_create(_dir / "resources" / "cadence.yaml")
-    _exec("kubectl", "wait", "--all", "pods", "--for=condition=ready", "--selector=!job-name", "--timeout=600s")
+    _exec(
+        "kubectl",
+        "wait",
+        "--all",
+        "pods",
+        "--for=condition=ready",
+        "--selector=!job-name",
+        "--timeout=600s",
+    )
     _kube_run(
         image="ubercadence/cli:v1.2.6",
         command=[


### PR DESCRIPTION
# **What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

# Summary
This pull request introduces a simple Kubernetes batch job intended to deploy the log-viewer utilized at Uber to MinIO. The log-viewer, from the open-source project community accessible [here](https://github.com/y-scope/yscope-log-viewer), is deployed as a serverless application both within Uber and now within this repository. Essentially, the log-viewer comprises a collection of files stored in MinIO for direct user access in the form of a web-app, without the need for a dedicated container to host and serve the log-viewer. 

The log-viewer has been added to the repository with the purpose of:
* Begin to open-source some of the logging infra components within Uber relevant to the current project
* Offer a convenient and user-friendly method for users to directly view potentially large and compressed logs in the browser with a seamless user experience

# Deployment Validation
After creating a sandbox, we can use the command `kubectl get pods` to inspect the deployment status. Specifically `deploy-yscope-log-viewer-xxxxx` should be `Completed` status when the deployment is completed successfully. 

Upon creation a sandbox, we can utilize the command `kubectl get pods` to examine the deployment status. In particular, the status of `deploy-yscope-log-viewer-xxxxx` job should show as `Completed` once the deployment is successful.
```
$ kubectl get pods
NAME                             READY   STATUS      RESTARTS   AGE
cadence                          1/1     Running     0          25h
cadence-web                      1/1     Running     0          25h
yscope-log-viewer-deployment-zwmlh   0/1     Completed   0          25h
envoy                            1/1     Running     0          25h
michelangelo-apiserver           1/1     Running     0          25h
michelangelo-controllermgr       1/1     Running     0          25h
michelangelo-worker              1/1     Running     0          25h
minio                            1/1     Running     0          25h
mysql                            1/1     Running     0          25h
```
Alternatively, we can inspect the k8s job status as well:
```
$ kubectl get jobs
NAME                       STATUS     COMPLETIONS   DURATION   AGE
yscope-log-viewer-deployment   Complete   1/1           55s        25h
```
To access deployment logs, we can use the command `kubectl logs job.batch/yscope-log-viewer-deployment`
```
$ kubectl logs job.batch/yscope-log-viewer-deployment
Loaded plugins: ovl, priorities
Resolving Dependencies
--> Running transaction check
---> Package gzip.x86_64 0:1.5-10.amzn2.0.1 will be installed
---> Package jq.x86_64 0:1.5-1.amzn2.0.2 will be installed
--> Processing Dependency: libonig.so.2()(64bit) for package: jq-1.5-1.amzn2.0.2.x86_64
---> Package tar.x86_64 2:1.26-35.amzn2.0.4 will be installed
--> Running transaction check
---> Package oniguruma.x86_64 0:5.9.6-1.amzn2.0.7 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

================================================================================
 Package         Arch         Version                    Repository        Size
================================================================================
Installing:
 gzip            x86_64       1.5-10.amzn2.0.1           amzn2-core       129 k
 jq              x86_64       1.5-1.amzn2.0.2            amzn2-core       154 k
 tar             x86_64       2:1.26-35.amzn2.0.4        amzn2-core       846 k
Installing for dependencies:
 oniguruma       x86_64       5.9.6-1.amzn2.0.7          amzn2-core       127 k

Transaction Summary
================================================================================
Install  3 Packages (+1 Dependent package)

Total download size: 1.2 M
Installed size: 3.8 M
Downloading packages:
--------------------------------------------------------------------------------
Total                                              812 kB/s | 1.2 MB  00:01
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Installing : oniguruma-5.9.6-1.amzn2.0.7.x86_64                           1/4
  Installing : jq-1.5-1.amzn2.0.2.x86_64                                    2/4
  Installing : gzip-1.5-10.amzn2.0.1.x86_64                                 3/4
  Installing : 2:tar-1.26-35.amzn2.0.4.x86_64                               4/4
  Verifying  : 2:tar-1.26-35.amzn2.0.4.x86_64                               1/4
  Verifying  : jq-1.5-1.amzn2.0.2.x86_64                                    2/4
  Verifying  : gzip-1.5-10.amzn2.0.1.x86_64                                 3/4
  Verifying  : oniguruma-5.9.6-1.amzn2.0.7.x86_64                           4/4

Installed:
  gzip.x86_64 0:1.5-10.amzn2.0.1           jq.x86_64 0:1.5-1.amzn2.0.2
  tar.x86_64 2:1.26-35.amzn2.0.4

Dependency Installed:
  oniguruma.x86_64 0:5.9.6-1.amzn2.0.7

Complete!
2025-05-29T21:27:49Z [INFO] Waiting until http://minio:9091 endpoint becomes available.
2025-05-29T21:27:53Z [INFO] Creating s3://log-viewer bucket.
{
    "Location": "/log-viewer"
}
2025-05-29T21:28:00Z [INFO] Applying public read access policy to s3://log-viewer
2025-05-29T21:28:04Z [INFO] Downloading https://github.com/y-scope/yscope-log-viewer/releases/download/v0.1.0-main%2B20250529.e36606b/dist-0.1.0-main%2B20250529.e36606b.tar.gz
2025-05-29T21:28:05Z [INFO] Uploading yscope-log-viewer assets to s3://log-viewer
upload: ../tmp/tmp.8DcVUN5Qer/favicon.svg to s3://log-viewer/favicon.svg
upload: ../tmp/tmp.8DcVUN5Qer/index-wQ_eVaF3.css to s3://log-viewer/index-wQ_eVaF3.css
upload: ../tmp/tmp.8DcVUN5Qer/codicon-DCmgc-ay.ttf to s3://log-viewer/codicon-DCmgc-ay.ttf
upload: ../tmp/tmp.8DcVUN5Qer/MainWorker.worker-BILePOgk.js to s3://log-viewer/MainWorker.worker-BILePOgk.js
upload: ../tmp/tmp.8DcVUN5Qer/editor.worker-Z-F9bRfX.js to s3://log-viewer/editor.worker-Z-F9bRfX.js
upload: ../tmp/tmp.8DcVUN5Qer/index.html to s3://log-viewer/index.html
upload: ../tmp/tmp.8DcVUN5Qer/test/.gitignore to s3://log-viewer/test/.gitignore
upload: ../tmp/tmp.8DcVUN5Qer/monaco-editor-BMpKJKrA.css to s3://log-viewer/monaco-editor-BMpKJKrA.css
upload: ../tmp/tmp.8DcVUN5Qer/MainWorker.worker-BILePOgk.js.map to s3://log-viewer/MainWorker.worker-BILePOgk.js.map
upload: ../tmp/tmp.8DcVUN5Qer/index-BWrvKIAQ.js to s3://log-viewer/index-BWrvKIAQ.js
upload: ../tmp/tmp.8DcVUN5Qer/ClpFfiJs-worker-D0YNg94Y.wasm to s3://log-viewer/ClpFfiJs-worker-D0YNg94Y.wasm
upload: ../tmp/tmp.8DcVUN5Qer/editor.worker-Z-F9bRfX.js.map to s3://log-viewer/editor.worker-Z-F9bRfX.js.map
upload: ../tmp/tmp.8DcVUN5Qer/monaco-editor-BnIjO0C8.js to s3://log-viewer/monaco-editor-BnIjO0C8.js
upload: ../tmp/tmp.8DcVUN5Qer/index-BWrvKIAQ.js.map to s3://log-viewer/index-BWrvKIAQ.js.map
upload: ../tmp/tmp.8DcVUN5Qer/monaco-editor-BnIjO0C8.js.map to s3://log-viewer/monaco-editor-BnIjO0C8.js.map
2025-05-29T21:28:10Z [INFO] Deployment completed successfully!


+-----------------------------------------------------------------------------------+
|                                                                                   |
|   yscope-log-viewer is now available at http://minio:9091/log-viewer/index.html   |
|                                                                                   |
+-----------------------------------------------------------------------------------+
```

# Functionality Testing
Following the creation of a sandbox, the log-viewer deployment can be accessed at http://localhost:9091/log-viewer/index.html. Basic feature testing is carried out using this deployed log-viewer. It's important to note that only the basic functionalities have been deployed. Advanced features such as LLM integration with Uber's GenAI, which are exclusive to Uber's internal use, will not be set up nor available. Additionally, specific features like the default log formatter will be configured in a forthcoming pull request once other pull requests incorporating custom log handlers and fluent-bit integration are merged.

## 1. Raw JSON Log Viewing: 
![image](https://github.com/user-attachments/assets/b8eaaddb-2085-412d-a0be-a0f65a63a0c4)
## 2. Prettified JSON Log Viewing: 
![image](https://github.com/user-attachments/assets/098e5451-7228-41c1-841b-111cbd17e347)
## 3. Formatted + Prettified JSON Log Viewing
![image](https://github.com/user-attachments/assets/45bbc4f4-ac6b-4078-b65f-be3f0bf87976)
## 4. Search Functionality: 
![image](https://github.com/user-attachments/assets/b3c4f8cc-231f-4d2d-b8b6-a1aa209011d7)
## 5. Proper [perma-log-and-search-link](http://localhost:9091/log-viewer/index.html?filePath=http://localhost:9091/logs/example.jsonl#queryString=org.elasticsearch.xpack.ml.inference.assignment.TrainedModelAssignmentNodeService) Generation After Clicking the Share Button:  
![image](https://github.com/user-attachments/assets/934becc2-264a-4966-ad0f-8060c8a53914)
## 6. Secure Log File Access Through Pre-Signed [URL](http://localhost:9091/logs/example.jsonl?AWSAccessKeyId=minioadmin&Signature=YvPCTETusLK4FncFBGKEIHLtMZ4%3D&Expires=1749248897):
![image](https://github.com/user-attachments/assets/e5fe91bf-df8f-4ebd-b395-1bd7b9bed3f6)

# Potential risks
No risk at the moment since this component is quite independent.