### PR TITLE
Add description cell renderer with text truncation

### DIFF
--- a/javascript/packages/core/components/cell/renderers/description/__tests__/description-cell.tests.tsx
+++ b/javascript/packages/core/components/cell/renderers/description/__tests__/description-cell.tests.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+
+import { CellType } from '#core/components/cell/constants';
+import { DescriptionCell } from '../description-cell';
+
+describe('DescriptionColumn', () => {
+  test('Renders provided text', async () => {
+    render(
+      <DescriptionCell
+        column={{ id: 'spec.description', type: CellType.DESCRIPTION }}
+        record={{ spec: { description: 'Descriptive text in the column' } }}
+        value={'Descriptive text in the column'}
+      />
+    );
+
+    await screen.findByText('Descriptive text in the column');
+  });
+});

--- a/javascript/packages/core/components/cell/renderers/description/constants.ts
+++ b/javascript/packages/core/components/cell/renderers/description/constants.ts
@@ -1,0 +1,4 @@
+export enum DescriptionHierarchy {
+  PRIMARY,
+  SECONDARY,
+}

--- a/javascript/packages/core/components/cell/renderers/description/description-cell.tsx
+++ b/javascript/packages/core/components/cell/renderers/description/description-cell.tsx
@@ -1,0 +1,24 @@
+import { useStyletron } from 'baseui';
+
+import { DescriptionText } from '#core/components/description-text';
+import { TruncatedText } from '#core/components/truncated-text/truncated-text';
+import { DescriptionHierarchy } from './constants';
+
+import type { CellRendererProps } from '#core/components/cell/types';
+import type { DescriptionCellConfig } from './types';
+
+export const DescriptionCell = ({
+  column,
+  value,
+}: CellRendererProps<string, DescriptionCellConfig>) => {
+  const [, theme] = useStyletron();
+  return (
+    <DescriptionText
+      {...(column.hierarchy === DescriptionHierarchy.PRIMARY
+        ? { $styleOverrides: { color: theme.colors.contentPrimary } }
+        : {})}
+    >
+      <TruncatedText>{value}</TruncatedText>
+    </DescriptionText>
+  );
+};

--- a/javascript/packages/core/components/cell/renderers/description/types.ts
+++ b/javascript/packages/core/components/cell/renderers/description/types.ts
@@ -1,0 +1,9 @@
+import type { SharedCell } from '#core/components/cell/types';
+import type { DescriptionHierarchy } from './constants';
+
+export type DescriptionCellConfig = SharedCell & {
+  /**
+   * @description Used to control cell styling – e.g. color, font-size, etc.
+   */
+  hierarchy?: DescriptionHierarchy;
+};

--- a/javascript/packages/core/components/description-text.tsx
+++ b/javascript/packages/core/components/description-text.tsx
@@ -1,0 +1,14 @@
+import { styled } from 'baseui';
+
+import type { StyleObject } from 'styletron-react';
+
+export const DescriptionText = styled<'div', { $styleOverrides?: StyleObject }>(
+  'div',
+  ({ $theme, $styleOverrides }) => ({
+    ...$theme.typography.ParagraphSmall,
+    color: $theme.colors.contentSecondary,
+    display: 'flex',
+    alignItems: 'center',
+    ...$styleOverrides,
+  })
+);

--- a/javascript/packages/core/components/truncated-text/__tests__/truncated-text.tests.tsx
+++ b/javascript/packages/core/components/truncated-text/__tests__/truncated-text.tests.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+
+import { TruncatedText } from '../truncated-text';
+
+describe('TruncatedText', () => {
+  test('renders short text', () => {
+    render(<TruncatedText>test</TruncatedText>);
+
+    expect(screen.getByText('test')).toBeInTheDocument();
+  });
+});

--- a/javascript/packages/core/components/truncated-text/constants.ts
+++ b/javascript/packages/core/components/truncated-text/constants.ts
@@ -1,0 +1,5 @@
+export const ELLIPSIS_STYLES = {
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+} as const;

--- a/javascript/packages/core/components/truncated-text/truncated-text.tsx
+++ b/javascript/packages/core/components/truncated-text/truncated-text.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useRef, useState } from 'react';
+import { useStyletron } from 'baseui';
+import { ACCESSIBILITY_TYPE, PLACEMENT, StatefulTooltip } from 'baseui/tooltip';
+
+import { ELLIPSIS_STYLES } from './constants';
+
+import type { Props } from './types';
+
+export function TruncatedText({ children, overrides }: Props) {
+  const [css] = useStyletron();
+  const [isOverflowing, setIsOverflowing] = useState(false);
+  const anchorRef = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (anchorRef.current) {
+        setIsOverflowing(anchorRef.current.scrollWidth > anchorRef.current.clientWidth);
+      }
+    };
+
+    handleResize();
+    window.addEventListener('resize', handleResize);
+
+    return () => window.removeEventListener('resize', handleResize);
+  }, [anchorRef]);
+
+  const anchorContent = (
+    <div className={css({ display: 'flex', maxWidth: '100%' })}>
+      <span className={css(ELLIPSIS_STYLES)} ref={anchorRef}>
+        {children}
+      </span>
+    </div>
+  );
+
+  if (!isOverflowing) return anchorContent;
+
+  return (
+    <StatefulTooltip
+      overrides={overrides?.Tooltip}
+      accessibilityType={ACCESSIBILITY_TYPE.tooltip}
+      content={
+        <div className={css({ maxWidth: '400px', wordBreak: 'break-word' })}>{children}</div>
+      }
+      placement={PLACEMENT.top}
+      showArrow
+      returnFocus
+      autoFocus
+    >
+      {anchorContent}
+    </StatefulTooltip>
+  );
+}

--- a/javascript/packages/core/components/truncated-text/types.ts
+++ b/javascript/packages/core/components/truncated-text/types.ts
@@ -1,0 +1,9 @@
+import type { PopoverOverrides } from 'baseui/tooltip';
+import type { ReactNode } from 'react';
+
+export type Props = {
+  children: ReactNode | string;
+  overrides?: {
+    Tooltip: PopoverOverrides;
+  };
+};

--- a/javascript/packages/core/components/views/project/project-detail.tsx
+++ b/javascript/packages/core/components/views/project/project-detail.tsx
@@ -1,5 +1,7 @@
 import { BooleanCell } from '#core/components/cell/renderers/boolean/boolean-cell';
 import { DateCell } from '#core/components/cell/renderers/date/date-cell';
+import { DescriptionHierarchy } from '#core/components/cell/renderers/description/constants';
+import { DescriptionCell } from '#core/components/cell/renderers/description/description-cell';
 import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
 import { useStudioQuery } from '#core/hooks/use-studio-query';
 
@@ -20,6 +22,12 @@ export function ProjectDetail() {
         column={{ id: 'spec.date' }}
         record={{ spec: { date: Date.now() / 1000 } }}
         value={String(Date.now() / 1000)}
+      />
+      <br />
+      <DescriptionCell
+        column={{ id: 'spec.description', hierarchy: DescriptionHierarchy.SECONDARY }}
+        record={{ spec: { description: 'Descriptive text in the column' } }}
+        value={'Descriptive text in the column'}
       />
       <br />
       {/* The project type will not be directly exposed to the @michelangelo/core package. */}

--- a/javascript/packages/core/index.tsx
+++ b/javascript/packages/core/index.tsx
@@ -33,3 +33,8 @@ export { ServiceProvider } from '#core/providers/service-provider/service-provid
 export { getCellRenderer } from '#core/components/cell/get-cell-renderer';
 export { BooleanCell } from '#core/components/cell/renderers/boolean/boolean-cell';
 export { DateCell } from '#core/components/cell/renderers/date/date-cell';
+export { DescriptionCell } from '#core/components/cell/renderers/description/description-cell';
+export { DescriptionHierarchy } from '#core/components/cell/renderers/description/constants';
+
+export { DescriptionText } from '#core/components/description-text';
+export { TruncatedText } from '#core/components/truncated-text/truncated-text';


### PR DESCRIPTION
Add DescriptionCell component with hierarchy-based styling. Include TruncatedText component for handling long text with tooltips and DescriptionText for consistent styling. Export DescriptionHierarchy enum for configuring cell appearance.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
<img width="1840" alt="Screenshot 2025-06-02 at 10 56 26" src="https://github.com/user-attachments/assets/bdd18deb-39d1-4cd7-a399-dd099813d3f7" />



<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
