### PR TITLE
Add state cell renderer with configurable text and color maps

### DIFF
--- a/javascript/app/icons.ts
+++ b/javascript/app/icons.ts
@@ -1,5 +1,5 @@
 import CheckCircle from '@mui/icons-material/CheckCircle';
-import Launch from '@mui/icons-material/launch';
+import Launch from '@mui/icons-material/Launch';
 
 export const ICONS = {
   arrowLaunch: Launch,

--- a/javascript/app/icons.ts
+++ b/javascript/app/icons.ts
@@ -1,0 +1,7 @@
+import CheckCircle from '@mui/icons-material/CheckCircle';
+import Launch from '@mui/icons-material/launch';
+
+export const ICONS = {
+  arrowLaunch: Launch,
+  circleCheckFilled: CheckCircle,
+} as const;

--- a/javascript/packages/core/components/cell/constants.ts
+++ b/javascript/packages/core/components/cell/constants.ts
@@ -5,6 +5,7 @@ import { LinkCell } from './renderers/link/link-cell';
 import { MultiCell } from './renderers/multi/multi-cell';
 import { StateCell } from './renderers/state/state-cell';
 import { TagCell } from './renderers/tag/tag-cell';
+import { TypeCell } from './renderers/type/type-cell';
 
 import type { CellRenderer } from './types';
 
@@ -91,4 +92,5 @@ export const CELL_RENDERERS: Record<string, CellRenderer<unknown>> = {
   [CellType.REPEATED_ITEMS]: MultiCell,
   [CellType.STATE]: StateCell as CellRenderer<string>,
   [CellType.TAG]: TagCell,
+  [CellType.TYPE]: TypeCell,
 };

--- a/javascript/packages/core/components/cell/constants.ts
+++ b/javascript/packages/core/components/cell/constants.ts
@@ -3,6 +3,7 @@ import { DateCell } from './renderers/date/date-cell';
 import { DescriptionCell } from './renderers/description/description-cell';
 import { LinkCell } from './renderers/link/link-cell';
 import { MultiCell } from './renderers/multi/multi-cell';
+import { StateCell } from './renderers/state/state-cell';
 import { TagCell } from './renderers/tag/tag-cell';
 
 import type { CellRenderer } from './types';
@@ -88,5 +89,6 @@ export const CELL_RENDERERS: Record<string, CellRenderer<unknown>> = {
   [CellType.LINK]: LinkCell,
   [CellType.MULTI]: MultiCell,
   [CellType.REPEATED_ITEMS]: MultiCell,
+  [CellType.STATE]: StateCell as CellRenderer<string>,
   [CellType.TAG]: TagCell,
 };

--- a/javascript/packages/core/components/cell/renderers/state/__tests__/get-state-color.tests.ts
+++ b/javascript/packages/core/components/cell/renderers/state/__tests__/get-state-color.tests.ts
@@ -1,0 +1,33 @@
+import { COLOR } from '#core/components/tag/constants';
+import { getStateColor } from '../get-state-color';
+
+describe('getStateColor', () => {
+  it('should return gray for empty value', () => {
+    expect(getStateColor('')).toBe(COLOR.gray);
+  });
+
+  it('should return red for error states', () => {
+    expect(getStateColor('PIPELINE_STATE_ERROR')).toBe(COLOR.red);
+    expect(getStateColor('ANY_STATE_ERROR')).toBe(COLOR.red);
+  });
+
+  it('should return green for success states', () => {
+    expect(getStateColor('PIPELINE_STATE_SUCCESS')).toBe(COLOR.green);
+    expect(getStateColor('ANY_STATE_SUCCESS')).toBe(COLOR.green);
+  });
+
+  it('should return blue for running states', () => {
+    expect(getStateColor('PIPELINE_STATE_RUNNING')).toBe(COLOR.blue);
+    expect(getStateColor('ANY_STATE_RUNNING')).toBe(COLOR.blue);
+  });
+
+  it('should return gray for invalid states', () => {
+    expect(getStateColor('PIPELINE_STATE_INVALID')).toBe(COLOR.gray);
+    expect(getStateColor('ANY_STATE_INVALID')).toBe(COLOR.gray);
+  });
+
+  it('should return gray for unknown states', () => {
+    expect(getStateColor('PIPELINE_STATE_UNKNOWN')).toBe(COLOR.gray);
+    expect(getStateColor('ANY_STATE')).toBe(COLOR.gray);
+  });
+});

--- a/javascript/packages/core/components/cell/renderers/state/__tests__/state-cell.tests.tsx
+++ b/javascript/packages/core/components/cell/renderers/state/__tests__/state-cell.tests.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from '@testing-library/react';
+
+import { StateCell } from '../state-cell';
+import { stateToString } from '../state-cell-to-string';
+
+describe('StateCell', () => {
+  it('should render state text with default color when no custom maps are provided', () => {
+    render(<StateCell column={{ id: 'state' }} record={{}} value="PIPELINE_STATE_BUILDING" />);
+
+    expect(screen.getByText('Building')).toBeInTheDocument();
+  });
+
+  it('should render custom state text when provided in stateTextMap', () => {
+    render(
+      <StateCell
+        column={{
+          id: 'state',
+          stateTextMap: {
+            PIPELINE_STATE_BUILDING: 'Custom Building Text',
+          },
+        }}
+        record={{}}
+        value="PIPELINE_STATE_BUILDING"
+      />
+    );
+
+    expect(screen.getByText('Custom Building Text')).toBeInTheDocument();
+  });
+
+  it('should render empty value correctly', () => {
+    const { container } = render(<StateCell column={{ id: 'state' }} record={{}} value="" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('should render invalid state as Queued', () => {
+    render(<StateCell column={{ id: 'state' }} record={{}} value="PIPELINE_STATE_INVALID" />);
+
+    expect(screen.getByText('Queued')).toBeInTheDocument();
+  });
+
+  describe('toString', () => {
+    it('should return empty string for empty value', () => {
+      const result = stateToString({
+        column: { id: 'state' },
+        value: '',
+      });
+
+      expect(result).toBe('');
+    });
+
+    it('should return custom text from stateTextMap when available', () => {
+      const result = stateToString({
+        column: {
+          id: 'state',
+          stateTextMap: {
+            PIPELINE_STATE_BUILDING: 'Custom Building Text',
+          },
+        },
+        value: 'PIPELINE_STATE_BUILDING',
+      });
+
+      expect(result).toBe('Custom Building Text');
+    });
+
+    it('should return Queued for invalid states', () => {
+      const result = stateToString({
+        column: { id: 'state' },
+        value: 'PIPELINE_STATE_INVALID',
+      });
+
+      expect(result).toBe('Queued');
+    });
+
+    it('should return sentence case for unknown states', () => {
+      const result = stateToString({
+        column: { id: 'state' },
+        value: 'PIPELINE_STATE_UNKNOWN_STATE',
+      });
+
+      expect(result).toBe('Unknown state');
+    });
+  });
+});

--- a/javascript/packages/core/components/cell/renderers/state/get-state-color.ts
+++ b/javascript/packages/core/components/cell/renderers/state/get-state-color.ts
@@ -1,0 +1,30 @@
+import { COLOR } from '#core/components/tag/constants';
+
+import type { TagColor } from '#core/components/tag/types';
+
+/**
+ * @description
+ * Provides a default implementation for determining the color of a state tag
+ * based on the value. This is used when no `stateColorMap` is provided to the
+ * `StateCell` component.
+ *
+ * @param value - The value of the state
+ * @returns The color of the state tag
+ *
+ * @example
+ * ```ts
+ * getStateColor('PIPELINE_STATE_ERROR'); // 'red'
+ * getStateColor('PIPELINE_STATE_SUCCESS'); // 'green'
+ * getStateColor('PIPELINE_STATE_RUNNING'); // 'blue'
+ * getStateColor('PIPELINE_STATE_INVALID'); // 'gray'
+ * getStateColor(''); // 'gray'
+ * ```
+ */
+export const getStateColor = (value: string): TagColor => {
+  if (!value) return COLOR.gray;
+  if (value.endsWith('_ERROR')) return COLOR.red;
+  if (value.endsWith('_SUCCESS')) return COLOR.green;
+  if (value.endsWith('_RUNNING')) return COLOR.blue;
+  if (value.endsWith('_INVALID')) return COLOR.gray;
+  return COLOR.gray;
+};

--- a/javascript/packages/core/components/cell/renderers/state/state-cell-to-string.ts
+++ b/javascript/packages/core/components/cell/renderers/state/state-cell-to-string.ts
@@ -1,0 +1,14 @@
+import { sentenceCaseEnumValue } from '#core/utils/string-utils';
+
+import type { CellToStringParams } from '#core/components/cell/types';
+import type { StateCellConfig } from './types';
+
+export const stateToString = ({
+  column,
+  value,
+}: CellToStringParams<string, StateCellConfig>): string => {
+  if (!value) return '';
+  if (column.stateTextMap?.[value]) return column.stateTextMap[value];
+  if (value.endsWith('_INVALID')) return 'Queued';
+  return sentenceCaseEnumValue(value, /(\w+_)STATE_/);
+};

--- a/javascript/packages/core/components/cell/renderers/state/state-cell.tsx
+++ b/javascript/packages/core/components/cell/renderers/state/state-cell.tsx
@@ -1,0 +1,21 @@
+import { TagCell } from '#core/components/cell/renderers/tag/tag-cell';
+import { getStateColor } from './get-state-color';
+import { stateToString } from './state-cell-to-string';
+
+import type { CellRendererProps } from '#core/components/cell/types';
+import type { StateCellConfig } from './types';
+
+export const StateCell = (props: CellRendererProps<string, StateCellConfig>) => {
+  const { value = '', record, column } = props;
+  const color = column.stateColorMap?.[value] ?? getStateColor(value);
+
+  return (
+    <TagCell
+      column={{ id: 'state', color }}
+      value={stateToString({ value, column })}
+      record={record}
+    />
+  );
+};
+
+StateCell.toString = stateToString;

--- a/javascript/packages/core/components/cell/renderers/state/types.ts
+++ b/javascript/packages/core/components/cell/renderers/state/types.ts
@@ -1,0 +1,26 @@
+import type { SharedCell } from '#core/components/cell/types';
+import type { TagColor } from '#core/components/tag/types';
+
+export type StateCellConfig = SharedCell<string> & {
+  /**
+   * @description A map of state values to their display text
+   * @example
+   * {
+   *   'PIPELINE_STATE_BUILDING': 'Building',
+   *   'PIPELINE_STATE_ERROR': 'Error'
+   * }
+   */
+  stateTextMap?: Record<string, string>;
+
+  /**
+   * @description A map of state values to their tag colors
+   * If not provided, will use the default implementation that colors based on state suffix
+   * @example
+   * {
+   *   'PIPELINE_STATE_ERROR': 'red',
+   *   'PIPELINE_STATE_SUCCESS': 'green',
+   *   'PIPELINE_STATE_BUILDING': 'blue'
+   * }
+   */
+  stateColorMap?: Record<string, TagColor>;
+};

--- a/javascript/packages/core/components/cell/renderers/type/__tests__/type-cell.tests.tsx
+++ b/javascript/packages/core/components/cell/renderers/type/__tests__/type-cell.tests.tsx
@@ -1,0 +1,105 @@
+import { render, screen } from '@testing-library/react';
+
+import { TypeCell } from '../type-cell';
+import { typeCellToString } from '../type-cell-to-string';
+
+describe('TypeCell', () => {
+  it('should render type text with default styling when no custom maps are provided', () => {
+    render(<TypeCell column={{ id: 'type' }} record={{}} value="FEATURE_TYPE_CATEGORICAL" />);
+
+    expect(screen.getByText('Categorical')).toBeInTheDocument();
+  });
+
+  it('should render custom type text when provided in typeTextMap', () => {
+    render(
+      <TypeCell
+        column={{
+          id: 'type',
+          typeTextMap: {
+            FEATURE_TYPE_CATEGORICAL: 'Custom Categorical Text',
+          },
+        }}
+        record={{}}
+        value="FEATURE_TYPE_CATEGORICAL"
+      />
+    );
+
+    expect(screen.getByText('Custom Categorical Text')).toBeInTheDocument();
+  });
+
+  it('should render empty value correctly', () => {
+    const { container } = render(<TypeCell column={{ id: 'type' }} record={{}} value="" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  describe('toString', () => {
+    it('should return empty string for empty value', () => {
+      const result = typeCellToString({
+        column: { id: 'type' },
+        value: '',
+      });
+
+      expect(result).toBe('');
+    });
+
+    it('should return custom text from typeTextMap when available', () => {
+      const result = typeCellToString({
+        column: {
+          id: 'type',
+          typeTextMap: {
+            FEATURE_TYPE_CATEGORICAL: 'Custom Categorical Text',
+          },
+        },
+        value: 'FEATURE_TYPE_CATEGORICAL',
+      });
+
+      expect(result).toBe('Custom Categorical Text');
+    });
+
+    it('should handle FORMAT prefix correctly', () => {
+      const result = typeCellToString({
+        column: { id: 'type' },
+        value: 'DATA_FORMAT_CSV',
+      });
+
+      expect(result).toBe('Csv');
+    });
+
+    it('should handle KIND prefix correctly', () => {
+      const result = typeCellToString({
+        column: { id: 'type' },
+        value: 'MODEL_KIND_TENSORFLOW',
+      });
+
+      expect(result).toBe('Tensorflow');
+    });
+
+    it('should handle TYPE prefix correctly', () => {
+      const result = typeCellToString({
+        column: { id: 'type' },
+        value: 'FEATURE_TYPE_CATEGORICAL',
+      });
+
+      expect(result).toBe('Categorical');
+    });
+
+    it('should handle non-prefixed values correctly', () => {
+      const result = typeCellToString({
+        column: { id: 'type' },
+        value: 'SIMPLE_TYPE',
+      });
+
+      expect(result).toBe('Simple type');
+    });
+
+    it('should handle numeric values gracefully', () => {
+      const result = typeCellToString({
+        column: { id: 'type' },
+        // @ts-expect-error - we want to test the function with a non-string input
+        value: 123,
+      });
+
+      expect(result).toEqual(123);
+    });
+  });
+});

--- a/javascript/packages/core/components/cell/renderers/type/constants.ts
+++ b/javascript/packages/core/components/cell/renderers/type/constants.ts
@@ -1,0 +1,1 @@
+export const TYPE_LIKE_PREFIXES = ['FORMAT', 'KIND', 'TYPE'];

--- a/javascript/packages/core/components/cell/renderers/type/type-cell-to-string.ts
+++ b/javascript/packages/core/components/cell/renderers/type/type-cell-to-string.ts
@@ -1,0 +1,29 @@
+import { sentenceCaseEnumValue } from '#core/utils/string-utils';
+import { TYPE_LIKE_PREFIXES } from './constants';
+
+import type { CellToStringParams } from '#core/components/cell/types';
+import type { TypeCellConfig } from './types';
+
+export const typeCellToString = ({
+  value,
+  column,
+}: CellToStringParams<string, TypeCellConfig>): string => {
+  if (!value) return '';
+
+  const knownTranslation = column.typeTextMap?.[value];
+  if (knownTranslation) return knownTranslation;
+
+  for (const typeLikePrefix of TYPE_LIKE_PREFIXES) {
+    // We expect the `value` to be a string type here, possessing an `.includes()` method.
+    // However, it's possible for `value` to be a number, which occurs when the .proto
+    // definitions on the backend are updated (e.g., new pipeline types are introduced), but the
+    // frontend hasn't been updated yet. In such cases, calling `value.includes()` causes the
+    // web page to crash. To prevent this, we ensure `value` is a string and possesses the
+    // `.includes()` method.
+    if (typeof value === 'string' && value.includes(`_${typeLikePrefix}_`)) {
+      return sentenceCaseEnumValue(value, new RegExp(`(\\w+_)${typeLikePrefix}_`));
+    }
+  }
+
+  return sentenceCaseEnumValue(value);
+};

--- a/javascript/packages/core/components/cell/renderers/type/type-cell.tsx
+++ b/javascript/packages/core/components/cell/renderers/type/type-cell.tsx
@@ -1,0 +1,28 @@
+import { BEHAVIOR, COLOR, HIERARCHY, SIZE } from '#core/components/tag/constants';
+import { Tag } from '#core/components/tag/tag';
+import { typeCellToString } from './type-cell-to-string';
+
+import type { CellRenderer } from '#core/components/cell/types';
+import type { TypeCellConfig } from './types';
+
+export const TypeCell: CellRenderer<string, TypeCellConfig> = ({ value, column }) => {
+  const content = typeCellToString({ value, column });
+
+  if (!content) {
+    return null;
+  }
+
+  return (
+    <Tag
+      size={SIZE.xSmall}
+      behavior={BEHAVIOR.selection}
+      hierarchy={HIERARCHY.secondary}
+      color={COLOR.gray}
+      closeable={false}
+    >
+      {content}
+    </Tag>
+  );
+};
+
+TypeCell.toString = typeCellToString;

--- a/javascript/packages/core/components/cell/renderers/type/types.ts
+++ b/javascript/packages/core/components/cell/renderers/type/types.ts
@@ -1,0 +1,8 @@
+import type { SharedCell } from '#core/components/cell/types';
+
+export type TypeCellConfig = SharedCell<string> & {
+  /**
+   * @description A map of type values to their display text
+   */
+  typeTextMap?: Record<string, string>;
+};

--- a/javascript/packages/core/components/views/project/project-detail.tsx
+++ b/javascript/packages/core/components/views/project/project-detail.tsx
@@ -5,6 +5,7 @@ import { DescriptionHierarchy } from '#core/components/cell/renderers/descriptio
 import { DescriptionCell } from '#core/components/cell/renderers/description/description-cell';
 import { LinkCell } from '#core/components/cell/renderers/link/link-cell';
 import { MultiCell } from '#core/components/cell/renderers/multi/multi-cell';
+import { StateCell } from '#core/components/cell/renderers/state/state-cell';
 import { Icon } from '#core/components/icon/icon';
 import { IconKind } from '#core/components/icon/types';
 import { Link } from '#core/components/link/link';
@@ -82,6 +83,12 @@ export function ProjectDetail() {
       <Tag closeable={false} size={SIZE.xSmall} color={COLOR.gray} behavior={BEHAVIOR.display}>
         Tag
       </Tag>
+      <br />
+      <StateCell
+        column={{ id: 'spec.state', stateColorMap: { PIPELINE_STATE_BUILDING: 'blue' } }}
+        record={{ spec: { state: 'PIPELINE_STATE_BUILDING' } }}
+        value="PIPELINE_STATE_BUILDING"
+      />
       <br />
       {/* The project type will not be directly exposed to the @michelangelo/core package. */}
       {/* eslint-disable-next-line @typescript-eslint/dot-notation */}

--- a/javascript/packages/core/utils/__tests__/string-utils.tests.ts
+++ b/javascript/packages/core/utils/__tests__/string-utils.tests.ts
@@ -1,4 +1,4 @@
-import { capitalizeFirstLetter, isAbsoluteURL } from '../string-utils';
+import { capitalizeFirstLetter, isAbsoluteURL, sentenceCaseEnumValue } from '../string-utils';
 
 describe('capitalizeFirstLetter', () => {
   it('should capitalize the first letter of the string', () => {
@@ -29,5 +29,46 @@ describe('isAbsoluteURL', () => {
 
   it('should return false if the string is not a valid absolute URL', () => {
     expect(isAbsoluteURL('something')).toBe(false);
+  });
+});
+
+describe('sentenceCaseEnumValue', () => {
+  it('should convert enum values to sentence case', () => {
+    expect(sentenceCaseEnumValue('PIPELINE_STATE_BUILDING', 'PIPELINE_STATE_')).toBe('Building');
+    expect(sentenceCaseEnumValue('PIPELINE_STATE_MULTIPLE_ERRORS', 'PIPELINE_STATE_')).toBe(
+      'Multiple errors'
+    );
+    expect(sentenceCaseEnumValue('SOME_OTHER_ENUM_TYPE_VALUE', 'SOME_OTHER_ENUM_TYPE_')).toBe(
+      'Value'
+    );
+  });
+
+  it('should handle empty prefix', () => {
+    expect(sentenceCaseEnumValue('HELLO_WORLD')).toBe('Hello world');
+  });
+
+  it('should handle RegExp prefix', () => {
+    expect(sentenceCaseEnumValue('PIPELINE_STATE_BUILDING', /^PIPELINE_STATE_/)).toBe('Building');
+    expect(sentenceCaseEnumValue('PIPELINE_STATE_BUILDING', new RegExp('^PIPELINE_STATE_'))).toBe(
+      'Building'
+    );
+  });
+
+  it('should handle non-string input', () => {
+    // @ts-expect-error - we want to test the function with a non-string input
+    expect(sentenceCaseEnumValue(123)).toBe(123);
+  });
+
+  it('should handle invalid prefix type', () => {
+    // @ts-expect-error - we want to test the function with an invalid prefix type
+    expect(sentenceCaseEnumValue('HELLO_WORLD', 123)).toBe('HELLO_WORLD');
+  });
+
+  it('should handle empty string input', () => {
+    expect(sentenceCaseEnumValue('')).toBe('');
+  });
+
+  it('should handle string with no underscores', () => {
+    expect(sentenceCaseEnumValue('HELLO', '')).toBe('Hello');
   });
 });

--- a/javascript/packages/core/utils/string-utils.ts
+++ b/javascript/packages/core/utils/string-utils.ts
@@ -4,3 +4,53 @@ export const capitalizeFirstLetter = (str: string): string =>
   str.charAt(0).toUpperCase() + str.slice(1);
 
 export const isAbsoluteURL = (value: string) => isURL(encodeURI(value), { require_protocol: true });
+
+/**
+ * @description
+ * Transforms a string value into a sentence case format. Special handling for
+ * enum values is provided to strip enum value prefixes.
+ *
+ * @remarks
+ * Enum values are the string values associated with a particular enum fields.
+ * For instance, PipelineStateValues is a Unified API enum with values like
+ * PIPELINE_STATE_BUILDING, PIPELINE_STATE_ERROR, etc. This function can be used
+ * to translate these values to Building and Error respectively.
+ *
+ * @param enumValue - The value to translate
+ * @param enumValuePrefix - The prefix to remove from the value
+ * @returns The translated value
+ *
+ * @example
+ * ```ts
+ * sentenceCaseEnumValue('PIPELINE_STATE_BUILDING', 'PIPELINE_STATE_'); // 'Building'
+ * sentenceCaseEnumValue('PIPELINE_STATE_MULTIPLE_ERRORS', 'PIPELINE_STATE_'); // 'Multiple errors'
+ * sentenceCaseEnumValue('SOME_OTHER_ENUM_TYPE_VALUE', 'SOME_OTHER_ENUM_TYPE_'); // 'Value'
+ * ```
+ */
+export const sentenceCaseEnumValue = (
+  enumValue: string,
+  enumValuePrefix: string | RegExp = ''
+): string => {
+  if (!(typeof enumValue === 'string')) {
+    return enumValue;
+  }
+
+  if (!(typeof enumValuePrefix === 'string') && !(enumValuePrefix instanceof RegExp)) {
+    return enumValue;
+  }
+
+  let enumPrefixRegExp: RegExp;
+  if (typeof enumValuePrefix === 'string') {
+    enumPrefixRegExp = new RegExp(`^${enumValuePrefix}`);
+  } else {
+    // Support the caller explicitly providing match start character and caller
+    // omitting the match start character.
+    enumPrefixRegExp = enumValuePrefix.source.startsWith('^')
+      ? enumValuePrefix
+      : new RegExp(`^${enumValuePrefix.source}`);
+  }
+
+  return capitalizeFirstLetter(
+    enumValue.replace(enumPrefixRegExp, '').replace(/_/g, ' ').toLowerCase()
+  );
+};


### PR DESCRIPTION
Add StateCell component that renders state values as tags. The component accepts stateTextMap and stateColorMap properties to override default rendering behavior.

The implementation includes a fallback color mapping based on the state suffix. For example, we can be opinionated about mapping error-like states to red.

Onboarded the sentenceCaseEnumValue utility that helps pick specific values from formatted enum values.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
<img width="1840" alt="Screenshot 2025-06-04 at 15 02 03" src="https://github.com/user-attachments/assets/83d4a0e0-b7c2-4e83-bf4f-4e451aa466f2" />


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
