### PR TITLE
Implement unified cell rendering system

### DIFF
--- a/javascript/packages/core/components/cell/__tests__/get-cell-renderer.tests.tsx
+++ b/javascript/packages/core/components/cell/__tests__/get-cell-renderer.tests.tsx
@@ -1,0 +1,115 @@
+import { render, screen } from '@testing-library/react';
+
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
+import { getIconProviderWrapper } from '#core/test/wrappers/get-icon-provider-wrapper';
+import { CellType } from '../constants';
+import { getCellRenderer } from '../get-cell-renderer';
+
+import type { LinkCellConfig } from '../renderers/link/types';
+import type { CellRenderer, CellRendererProps } from '../types';
+
+describe('getCellRenderer', () => {
+  it('should return custom cell renderer when provided', () => {
+    const CustomCell: CellRenderer<string> = (props: CellRendererProps<string>) => (
+      <div>Custom: {props.value}</div>
+    );
+    const props: CellRendererProps<string> = {
+      column: { id: 'test', Cell: CustomCell },
+      record: {},
+      value: 'test value',
+    };
+
+    const CellComponent = getCellRenderer(props);
+    render(
+      <CellComponent {...props} />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+    );
+
+    expect(screen.getByText('Custom: test value')).toBeInTheDocument();
+  });
+
+  it('should return cell renderer for known type', () => {
+    const props: CellRendererProps<boolean> = {
+      column: { id: 'test', type: CellType.BOOLEAN, label: 'Is Active' },
+      record: {},
+      value: true,
+    };
+
+    const CellComponent = getCellRenderer(props);
+    render(
+      <CellComponent {...props} />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+    );
+
+    expect(screen.getByText('Is Active')).toBeInTheDocument();
+  });
+
+  it('should return link renderer for URL values', () => {
+    const props: CellRendererProps<string> = {
+      column: { id: 'test' },
+      record: {},
+      value: 'https://example.com',
+    };
+
+    const CellComponent = getCellRenderer(props);
+    render(
+      <CellComponent {...props} />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+    );
+
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', 'https://example.com');
+    expect(link).toHaveTextContent('Click here');
+  });
+
+  it('should return text cell renderer for unknown type', () => {
+    const props: CellRendererProps<string> = {
+      column: { id: 'test', type: 'unknown' },
+      record: {},
+      value: 'test value',
+    };
+
+    const CellComponent = getCellRenderer(props);
+    render(
+      <CellComponent {...props} />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+    );
+
+    expect(screen.getByText('test value')).toBeInTheDocument();
+  });
+
+  it('should return text cell renderer for no type', () => {
+    const props: CellRendererProps<string> = {
+      column: { id: 'test' },
+      record: {},
+      value: 'test value',
+    };
+
+    const CellComponent = getCellRenderer(props);
+    render(
+      <CellComponent {...props} />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+    );
+
+    expect(screen.getByText('test value')).toBeInTheDocument();
+  });
+
+  it('should return link renderer when url is provided in column', () => {
+    const props: CellRendererProps<string, LinkCellConfig> = {
+      column: { id: 'test', url: 'https://example.com' },
+      record: {},
+      value: 'Click me',
+    };
+
+    const CellComponent = getCellRenderer(props);
+    render(
+      <CellComponent {...props} />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+    );
+
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', 'https://example.com');
+    expect(link).toHaveTextContent('Click me');
+  });
+});

--- a/javascript/packages/core/components/cell/cell-to-string.ts
+++ b/javascript/packages/core/components/cell/cell-to-string.ts
@@ -3,7 +3,7 @@ import { getCellRenderer } from '#core/components/cell/get-cell-renderer';
 import type { CellRendererProps } from '#core/components/cell/types';
 
 export function cellToString(props: CellRendererProps<unknown>): string | undefined | null {
-  const renderer = getCellRenderer(props.column.type ?? '');
+  const renderer = getCellRenderer(props);
   if (renderer && Object.prototype.hasOwnProperty.call(renderer, 'toString') && renderer.toString)
     return renderer.toString(props);
 

--- a/javascript/packages/core/components/cell/constants.ts
+++ b/javascript/packages/core/components/cell/constants.ts
@@ -5,6 +5,7 @@ import { LinkCell } from './renderers/link/link-cell';
 import { MultiCell } from './renderers/multi/multi-cell';
 import { StateCell } from './renderers/state/state-cell';
 import { TagCell } from './renderers/tag/tag-cell';
+import { TextCell } from './renderers/text/text-cell';
 import { TypeCell } from './renderers/type/type-cell';
 
 import type { CellRenderer } from './types';
@@ -93,4 +94,5 @@ export const CELL_RENDERERS: Record<string, CellRenderer<unknown>> = {
   [CellType.STATE]: StateCell as CellRenderer<string>,
   [CellType.TAG]: TagCell,
   [CellType.TYPE]: TypeCell,
+  [CellType.TEXT]: TextCell,
 };

--- a/javascript/packages/core/components/cell/get-cell-renderer.ts
+++ b/javascript/packages/core/components/cell/get-cell-renderer.ts
@@ -1,6 +1,0 @@
-import { CELL_RENDERERS } from './constants';
-import { CellRenderer } from './types';
-
-export function getCellRenderer(type: string): CellRenderer<unknown> | undefined {
-  return CELL_RENDERERS[type];
-}

--- a/javascript/packages/core/components/cell/get-cell-renderer.tsx
+++ b/javascript/packages/core/components/cell/get-cell-renderer.tsx
@@ -1,0 +1,37 @@
+import isURL from 'validator/lib/isURL';
+
+import { CELL_RENDERERS } from '#core/components/cell/constants';
+import { TextCell } from '#core/components/cell/renderers/text/text-cell';
+import { CellRenderer, CellRendererProps } from '#core/components/cell/types';
+import { Link } from '#core/components/link/link';
+import { CellType } from './constants';
+
+export function getCellRenderer(args: CellRendererProps<unknown>): CellRenderer<unknown> {
+  const { column, value } = args;
+
+  const { Cell } = column;
+  if (Cell) {
+    return Cell;
+  }
+
+  const columnType = getType(args);
+  if (columnType && columnType in CELL_RENDERERS) {
+    return CELL_RENDERERS[columnType];
+  }
+
+  if (typeof value === 'string' && isURL(value)) {
+    const LinkRenderer = () => <Link href={value}>Click here</Link>;
+    LinkRenderer.displayName = 'LinkRenderer';
+    return LinkRenderer;
+  }
+
+  return TextCell;
+}
+
+function getType(args: CellRendererProps): string | undefined {
+  const { column } = args;
+
+  if ('url' in column) return CellType.LINK;
+
+  return column.type;
+}

--- a/javascript/packages/core/components/cell/renderers/__tests__/default-cell-renderer.tests.tsx
+++ b/javascript/packages/core/components/cell/renderers/__tests__/default-cell-renderer.tests.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from '@testing-library/react';
+
+import { CellType } from '#core/components/cell/constants';
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
+import { getIconProviderWrapper } from '#core/test/wrappers/get-icon-provider-wrapper';
+import { DefaultCellRenderer } from '../default-cell-renderer';
+
+describe('DefaultCellRenderer', () => {
+  it('should render with default styles when no style is provided', () => {
+    render(
+      <DefaultCellRenderer
+        column={{ id: 'test', type: CellType.TEXT }}
+        record={{}}
+        value="test value"
+      />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+    );
+
+    expect(screen.getByText('test value')).toBeInTheDocument();
+  });
+
+  it('should apply custom styles when provided', () => {
+    const customStyle = { color: 'red' };
+    render(
+      <DefaultCellRenderer
+        column={{ id: 'test', type: CellType.TEXT, style: customStyle }}
+        record={{}}
+        value="test value"
+      />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+    );
+
+    const cell = screen.getByText('test value');
+    expect(cell.parentElement).toHaveStyle({ color: 'rgb(255, 0, 0)' });
+  });
+
+  it('should render provided cell type', () => {
+    render(
+      <DefaultCellRenderer
+        column={{ id: 'test', type: CellType.BOOLEAN, label: 'Is Active' }}
+        record={{}}
+        value={true}
+      />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+    );
+
+    expect(screen.getByText('Is Active')).toBeInTheDocument();
+  });
+
+  it('should handle undefined values', () => {
+    const { container } = render(
+      <DefaultCellRenderer
+        column={{ id: 'test', type: CellType.TEXT }}
+        record={{}}
+        value={undefined}
+      />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+    );
+
+    expect(container).not.toBeEmptyDOMElement();
+  });
+
+  it('should handle null values', () => {
+    const { container } = render(
+      <DefaultCellRenderer column={{ id: 'test', type: CellType.TEXT }} record={{}} value={null} />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+    );
+
+    expect(container).not.toBeEmptyDOMElement();
+  });
+});

--- a/javascript/packages/core/components/cell/renderers/default-cell-renderer.tsx
+++ b/javascript/packages/core/components/cell/renderers/default-cell-renderer.tsx
@@ -1,0 +1,20 @@
+import { useStyletron } from 'baseui';
+
+import { getCellRenderer } from '#core/components/cell/get-cell-renderer';
+import { useCellStyles } from '#core/components/cell/hooks';
+
+import type { Cell, CellRendererProps } from '#core/components/cell/types';
+
+export function DefaultCellRenderer(props: CellRendererProps<unknown, Cell>) {
+  const [css] = useStyletron();
+  const { column, record } = props;
+  const style = useCellStyles({ record, style: column.style });
+
+  const Component = getCellRenderer(props);
+
+  return (
+    <div className={css(style)}>
+      <Component {...props} column={column} CellComponent={DefaultCellRenderer} />
+    </div>
+  );
+}

--- a/javascript/packages/core/components/cell/renderers/multi/multi-cell.tsx
+++ b/javascript/packages/core/components/cell/renderers/multi/multi-cell.tsx
@@ -1,15 +1,15 @@
 import { useStyletron } from 'baseui';
 
+import { DefaultCellRenderer } from '#core/components/cell/renderers/default-cell-renderer';
 import { Icon } from '#core/components/icon/icon';
 import { getObjectValue } from '#core/utils/object-utils';
-import { getCellRenderer } from '../../get-cell-renderer';
 
 import type { CellRenderer } from '#core/components/cell/types';
 import type { MultiCellConfig } from './types';
 
 export const MultiCell: CellRenderer<unknown, MultiCellConfig> = (props) => {
   const [css] = useStyletron();
-  const { column, record } = props;
+  const { column, record, CellComponent = DefaultCellRenderer } = props;
   const { items } = column;
 
   if (!columnHasData(column, record)) {
@@ -22,12 +22,6 @@ export const MultiCell: CellRenderer<unknown, MultiCellConfig> = (props) => {
       <div className={css(ITEMS_WRAPPER)}>
         {items.map((item, index) => {
           const value = getObjectValue<unknown>(record, item.accessor ?? item.id);
-
-          // TODO: Add default cell renderer
-          const CellComponent =
-            getCellRenderer(item.type ?? '') ??
-            (({ value }: { value: unknown }) => <div>{String(value)}</div>);
-
           return <CellComponent key={index} {...props} column={item} value={value ?? ''} />;
         })}
       </div>

--- a/javascript/packages/core/components/cell/renderers/text/text-cell.tsx
+++ b/javascript/packages/core/components/cell/renderers/text/text-cell.tsx
@@ -1,0 +1,7 @@
+import { TruncatedText } from '#core/components/truncated-text/truncated-text';
+
+import type { CellRenderer } from '#core/components/cell/types';
+
+export const TextCell: CellRenderer<string> = (props) => {
+  return <TruncatedText>{props.value}</TruncatedText>;
+};

--- a/javascript/packages/core/components/cell/types.ts
+++ b/javascript/packages/core/components/cell/types.ts
@@ -5,6 +5,8 @@ import type { DescriptionCellConfig } from '#core/components/cell/renderers/desc
 import type { LinkCellConfig } from '#core/components/cell/renderers/link/types';
 import type { MultiCellConfig } from '#core/components/cell/renderers/multi/types';
 import type { Accessor } from '#core/types/common/studio-types';
+import type { StateCellConfig } from './renderers/state/types';
+import type { TypeCellConfig } from './renderers/type/types';
 
 /**
  * @description
@@ -16,7 +18,8 @@ import type { Accessor } from '#core/types/common/studio-types';
  * @see {@link LinkCellConfig}
  * @see {@link MultiCellConfig}
  */
-export type Cell = SharedCell & (DescriptionCellConfig | LinkCellConfig | MultiCellConfig);
+export type Cell = SharedCell &
+  (DescriptionCellConfig | LinkCellConfig | MultiCellConfig | StateCellConfig | TypeCellConfig);
 
 export interface SharedCell<T = unknown> {
   /**

--- a/javascript/packages/core/components/views/project/project-detail.tsx
+++ b/javascript/packages/core/components/views/project/project-detail.tsx
@@ -1,11 +1,6 @@
 import { CellType } from '#core/components/cell/constants';
-import { BooleanCell } from '#core/components/cell/renderers/boolean/boolean-cell';
-import { DateCell } from '#core/components/cell/renderers/date/date-cell';
+import { DefaultCellRenderer } from '#core/components/cell/renderers/default-cell-renderer';
 import { DescriptionHierarchy } from '#core/components/cell/renderers/description/constants';
-import { DescriptionCell } from '#core/components/cell/renderers/description/description-cell';
-import { LinkCell } from '#core/components/cell/renderers/link/link-cell';
-import { MultiCell } from '#core/components/cell/renderers/multi/multi-cell';
-import { StateCell } from '#core/components/cell/renderers/state/state-cell';
 import { Icon } from '#core/components/icon/icon';
 import { IconKind } from '#core/components/icon/types';
 import { Link } from '#core/components/link/link';
@@ -26,23 +21,27 @@ export function ProjectDetail() {
 
   return (
     <div>
-      <BooleanCell column={{ id: 'spec.bool' }} record={{ spec: { bool: true } }} value={true} />
-      <DateCell
-        column={{ id: 'spec.date' }}
+      <DefaultCellRenderer
+        column={{ id: 'spec.bool', type: CellType.BOOLEAN }}
+        record={{ spec: { bool: true } }}
+        value={true}
+      />
+      <DefaultCellRenderer
+        column={{ id: 'spec.date', type: CellType.DATE }}
         record={{ spec: { date: Date.now() / 1000 } }}
         value={String(Date.now() / 1000)}
       />
       <br />
-      <DescriptionCell
-        column={{ id: 'spec.description', hierarchy: DescriptionHierarchy.SECONDARY }}
+      <DefaultCellRenderer
+        column={{ id: 'spec.description', type: CellType.DESCRIPTION }}
         record={{ spec: { description: 'Descriptive text in the column' } }}
         value={'Descriptive text in the column'}
       />
       <br />
       <Icon name="arrowLaunch" kind={IconKind.ACCENT} size={24} />
       <br />
-      <LinkCell
-        column={{ id: 'spec.link', url: 'https://www.google.com' }}
+      <DefaultCellRenderer
+        column={{ id: 'spec.link', type: CellType.LINK, url: 'https://www.google.com' }}
         record={{ spec: { link: 'https://www.google.com' } }}
         value={'https://www.google.com'}
       />
@@ -53,7 +52,7 @@ export function ProjectDetail() {
       <Link href="/">Home</Link>
       <br />
       Multi cell:
-      <MultiCell
+      <DefaultCellRenderer
         column={{
           id: 'spec.multi',
           type: CellType.MULTI,
@@ -84,8 +83,12 @@ export function ProjectDetail() {
         Tag
       </Tag>
       <br />
-      <StateCell
-        column={{ id: 'spec.state', stateColorMap: { PIPELINE_STATE_BUILDING: 'blue' } }}
+      <DefaultCellRenderer
+        column={{
+          id: 'spec.state',
+          type: CellType.STATE,
+          stateColorMap: { PIPELINE_STATE_BUILDING: 'blue' },
+        }}
         record={{ spec: { state: 'PIPELINE_STATE_BUILDING' } }}
         value="PIPELINE_STATE_BUILDING"
       />


### PR DESCRIPTION
The current cell rendering system requires direct usage of specific cell renderers, leading to inconsistent style application and complex cell type selection logic scattered across components. This change introduces a unified DefaultCellRenderer that centralizes these concerns.

The DefaultCellRenderer handles style application through useCellStyles hook and delegates to the appropriate cell renderer based on column configuration. The getCellRenderer function now accepts CellRendererProps to make cell selection decisions based on the full context of the cell being rendered.

Key changes:
- DefaultCellRenderer applies styles and delegates to specific renderers
- getCellRenderer handles cell selection based on column config and value
- TextCell serves as default renderer for unknown types
- MultiCell uses DefaultCellRenderer for nested cells
- Examples in ProjectDetail updated to use unified rendering approach

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
<img width="1840" alt="Screenshot 2025-06-04 at 16 02 51" src="https://github.com/user-attachments/assets/808ceae9-c171-4f24-8c1b-b05b4246cd65" />


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
