### PR TITLE
Refactor task imports in uniflow run_task.py

### DIFF
--- a/python/michelangelo/uniflow/core/run_task.py
+++ b/python/michelangelo/uniflow/core/run_task.py
@@ -13,16 +13,13 @@ def main():
         log.info("sys.argv: %s", a)
 
     p = argparse.ArgumentParser()
-    p.add_argument("--task", required=True, type=import_attribute)
+    p.add_argument("--task", required=True, type=str)
     p.add_argument("--args", required=True, type=decoder.decode)
     p.add_argument("--kwargs", required=True, type=decoder.decode)
     p.add_argument("--result-url", required=True, type=str)
     p.add_argument("--overrides", type=decoder.decode)
     ns = p.parse_args()
 
-    assert type(ns.task).__name__ == "TaskFunction", (
-        f"Expected task to be a TaskFunction instance, but got instance of {type(ns.task)}"
-    )
     assert isinstance(ns.args, list), (
         f"Expected args to be a list, but got {type(ns.args)}"
     )
@@ -36,7 +33,12 @@ def main():
         f"Expected result_url to end with .json, but got {ns.result_url}"
     )
 
-    task = ns.task
+    task = import_attribute(ns.task)
+
+    assert type(task).__name__ == "TaskFunction", (
+        f"Expected task to be a TaskFunction instance, but got instance of {type(task)}"
+    )
+
     if ns.overrides:
         assert isinstance(ns.overrides, dict)
         task = task.with_overrides(**ns.overrides)


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
Trigger the import function directly instead of through the arg parser


<!-- Tell your future self why have you made these changes -->
The arg parser nullify the stacktrace when there are error and making the errors very hard to debug


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Pipeline run with the new build

**Show error with stacktrace**
https://michelangelo-studio.uberinternal.com/ma/ma-dev-test-uber-one/train/runs/run-20250605-656116-089b021e

**Run without error**
https://michelangelo-studio.uberinternal.com/ma/ma-dev-test-uber-one/train/runs/run-20250605-656116-089b021e