### PR TITLE
Update michelangelo-core for merging cell renderers internally

### DIFF
--- a/javascript/packages/core/index.tsx
+++ b/javascript/packages/core/index.tsx
@@ -34,15 +34,37 @@ export function CoreApp({ dependencies }: Props) {
 export { useStudioQuery } from '#core/hooks/use-studio-query';
 export { ServiceProvider } from '#core/providers/service-provider/service-provider';
 
+export { cellToString } from '#core/components/cell/cell-to-string';
+export { DefaultCellRenderer } from '#core/components/cell/renderers/default-cell-renderer';
 export { getCellRenderer } from '#core/components/cell/get-cell-renderer';
+export * from '#core/components/cell/types';
+
 export { BooleanCell } from '#core/components/cell/renderers/boolean/boolean-cell';
 export { DateCell } from '#core/components/cell/renderers/date/date-cell';
 export { DescriptionCell } from '#core/components/cell/renderers/description/description-cell';
 export { DescriptionHierarchy } from '#core/components/cell/renderers/description/constants';
+export { LinkCell } from '#core/components/cell/renderers/link/link-cell';
+export { MultiCell } from '#core/components/cell/renderers/multi/multi-cell';
+export { StateCell } from '#core/components/cell/renderers/state/state-cell';
+export { TextCell } from '#core/components/cell/renderers/text/text-cell';
+export { TypeCell } from '#core/components/cell/renderers/type/type-cell';
 
+export { Box } from '#core/components/box/box';
+export { DateTime } from '#core/components/date-time/date-time';
 export { DescriptionText } from '#core/components/description-text';
+export { HelpTooltip } from '#core/components/help-tooltip';
+export { Link } from '#core/components/link/link';
+export { Markdown } from '#core/components/markdown/markdown';
+export { Row } from '#core/components/row/row';
+export { Tag } from '#core/components/tag/tag';
 export { TruncatedText } from '#core/components/truncated-text/truncated-text';
 
 export { Icon } from '#core/components/icon/icon';
 export { IconKind } from '#core/components/icon/types';
 export { IconProvider } from '#core/providers/icon-provider/icon-provider';
+
+export { UserProvider } from '#core/providers/user-provider/user-provider';
+
+export * from '#core/utils/object-utils';
+export * from '#core/utils/string-utils';
+export * from '#core/utils/time-utils';

--- a/javascript/packages/core/package.json
+++ b/javascript/packages/core/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@uber/michelangelo-core",
   "license": "UNLICENSED",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
-  "main": "./dist/michelangelo-core.cjs",
+  "main": "./dist/michelangelo-core.js",
   "module": "./dist/michelangelo-core.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/javascript/packages/core/vite.config.ts
+++ b/javascript/packages/core/vite.config.ts
@@ -20,13 +20,20 @@ export default defineConfig({
         '@connectrpc/connect',
         '@connectrpc/connect-web',
         'pluralize',
-        'styletron-engine-monolithic',
         'styletron-react',
+        'styletron-engine-atomic',
         '@tanstack/react-query',
       ],
     },
+    commonjsOptions: {
+      include: ['styletron-react', /node_modules/],
+      esmExternals: true,
+    },
     outDir: 'dist',
     emptyOutDir: true,
+  },
+  optimizeDeps: {
+    include: ['styletron-react'],
   },
   plugins: [react()],
 });


### PR DESCRIPTION
This commit includes the exporting of functionality migrated from internal repository to this open source repository.

When testing internally relying on the built output, experienced an issue where the build output included an attempt to import the default export from styletron-react. It appears to be related to rollup considering styletron-react a common JS library. Adding esmExternals: true for styletron-react removes the attempt to import the default export from styletron-react.

In order for the commonjsOptions to apply to styletron-react, registered styletron-react to optimizeDeps. This appears to be by-design for vite: https://github.com/vitejs/vite/issues/5668

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
