### PR TITLE
Implement lightweight pipeline and project list demo

### DIFF
--- a/javascript/packages/core/components/views/project/constants.ts
+++ b/javascript/packages/core/components/views/project/constants.ts
@@ -1,0 +1,69 @@
+import { CellType } from '#core/components/cell/constants';
+
+export const SHARED_PROJECT_CELL_CONFIG = [
+  {
+    id: 'metadata.creationTimestamp.seconds',
+    label: 'Created',
+    type: CellType.DATE,
+  },
+  {
+    id: 'spec.owner.owningTeam',
+    label: 'Owner',
+  },
+  {
+    id: 'spec.tier',
+    label: 'Tier',
+    type: CellType.TAG,
+  },
+];
+
+export const PIPELINE_CELL_CONFIG = [
+  { id: 'metadata.creationTimestamp.seconds', label: 'Created', type: CellType.DATE },
+  {
+    id: 'spec.type',
+    label: 'Type',
+    type: CellType.TYPE,
+    typeTextMap: {
+      0: 'Invalid',
+      1: 'Train',
+      2: 'Evaluation',
+      3: 'Performance Evaluation',
+      4: 'Experiment',
+      5: 'Retrain',
+      6: 'Prediction',
+      7: 'Performance Monitoring',
+      8: 'Basis Feature',
+      9: 'Data Prep',
+      10: 'Online Offline Feature Consistency',
+      11: 'Feature Group Compute',
+      12: 'Online Offline Feature Consistency Orchestration',
+      13: 'Post Processing',
+      14: 'Optimization',
+      15: 'Scorer',
+    },
+  },
+  {
+    id: 'spec.commit.branch',
+    label: 'Branch',
+    type: CellType.TEXT,
+  },
+  {
+    id: 'status.state',
+    label: 'State',
+    type: CellType.STATE,
+    stateTextMap: {
+      0: 'Invalid',
+      1: 'Created',
+      2: 'Building',
+      3: 'Ready',
+      4: 'Error',
+    },
+    stateColorMap: {
+      0: 'error',
+      1: 'positive',
+      2: 'warning',
+      3: 'positive',
+      4: 'error',
+    },
+  },
+];

--- a/javascript/packages/core/components/views/project/project-detail.tsx
+++ b/javascript/packages/core/components/views/project/project-detail.tsx
@@ -1,12 +1,15 @@
+import { useStyletron } from 'baseui';
+
 import { Box } from '#core/components/box/box';
-import { CellType } from '#core/components/cell/constants';
 import { Row } from '#core/components/row/row';
 import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
 import { useStudioQuery } from '#core/hooks/use-studio-query';
+import { PIPELINE_CELL_CONFIG, SHARED_PROJECT_CELL_CONFIG } from './constants';
 
 import type { Theme } from 'baseui';
 
 export function ProjectDetail() {
+  const [css, theme] = useStyletron();
   const { projectId } = useStudioParams('base');
   const { data } = useStudioQuery<{
     project: {
@@ -29,38 +32,65 @@ export function ProjectDetail() {
     },
   });
 
+  const pipelines = useStudioQuery<{
+    pipelineList: {
+      items: Array<{
+        metadata: {
+          name: string;
+        };
+        spec: {
+          type: string;
+        };
+        status: {
+          state: string;
+        };
+      }>;
+    };
+  }>({
+    queryName: 'ListPipeline',
+    serviceOptions: {
+      name: projectId,
+      namespace: projectId,
+    },
+  });
+
   return (
-    <Box
-      description={data?.project?.spec?.description}
-      title={data?.project?.metadata?.name}
-      overrides={{
-        BoxContainer: {
-          style: ({ $theme }: { $theme: Theme }) => ({
-            backgroundColor: $theme.colors.backgroundSecondary,
-            marginTop: $theme.sizing.scale400,
-          }),
-        },
-      }}
-    >
-      <Row
-        items={[
-          {
-            id: 'metadata.creationTimestamp.seconds',
-            label: 'Created',
-            type: CellType.DATE,
+    <div className={css({ gap: theme.sizing.scale400, display: 'flex', flexDirection: 'column' })}>
+      <Box
+        description={data?.project?.spec?.description}
+        title={data?.project?.metadata?.name}
+        overrides={{
+          BoxContainer: {
+            style: ({ $theme }: { $theme: Theme }) => ({
+              backgroundColor: $theme.colors.backgroundSecondary,
+              marginTop: $theme.sizing.scale400,
+            }),
           },
-          {
-            id: 'spec.owner.owningTeam',
-            label: 'Owner',
-          },
-          {
-            id: 'spec.tier',
-            label: 'Tier',
-            type: CellType.TAG,
-          },
-        ]}
-        record={data?.project}
-      />
-    </Box>
+        }}
+      >
+        <Row items={SHARED_PROJECT_CELL_CONFIG} record={data?.project} />
+      </Box>
+
+      {pipelines?.data?.pipelineList.items.map((item, index) => (
+        <Row
+          overrides={{
+            RowItemContainer: {
+              style: {
+                width: '200px',
+              },
+            },
+          }}
+          key={item.metadata.name}
+          record={item}
+          items={[
+            { id: 'metadata.name', label: 'Name', url: item.metadata.name },
+            ...PIPELINE_CELL_CONFIG,
+          ].map((cell) => ({
+            ...cell,
+            ...(index > 0 && { label: undefined }),
+          }))}
+        />
+      ))}
+    </div>
   );
 }

--- a/javascript/packages/core/components/views/project/project-list.tsx
+++ b/javascript/packages/core/components/views/project/project-list.tsx
@@ -1,0 +1,54 @@
+import { useStyletron } from 'baseui';
+
+import { Row } from '#core/components/row/row';
+import { useStudioQuery } from '#core/hooks/use-studio-query';
+import { SHARED_PROJECT_CELL_CONFIG } from './constants';
+
+export function ProjectList() {
+  const [css, theme] = useStyletron();
+
+  const { data } = useStudioQuery<{
+    projectList: {
+      items: Array<{
+        metadata: {
+          name: string;
+        };
+        spec: {
+          description: string;
+          owner: {
+            owningTeam: string;
+          };
+          tier: string;
+        };
+      }>;
+    };
+  }>({
+    queryName: 'ListProject',
+    serviceOptions: { namespace: '' },
+  });
+
+  return (
+    <div className={css({ marginTop: theme.sizing.scale400 })}>
+      {data?.projectList.items.map((item, index) => (
+        <Row
+          overrides={{
+            RowItemContainer: {
+              style: {
+                width: '120px',
+              },
+            },
+          }}
+          key={item.metadata.name}
+          record={item}
+          items={[
+            { id: 'metadata.name', label: 'Name', url: item.metadata.name },
+            ...SHARED_PROJECT_CELL_CONFIG,
+          ].map((cell) => ({
+            ...cell,
+            ...(index > 0 && { label: undefined }),
+          }))}
+        />
+      ))}
+    </div>
+  );
+}

--- a/javascript/packages/core/index.tsx
+++ b/javascript/packages/core/index.tsx
@@ -1,5 +1,6 @@
 import { AppNavBar } from 'baseui/app-nav-bar';
 
+import { Link } from '#core/components/link/link';
 import { IconProvider } from '#core/providers/icon-provider/icon-provider';
 import { ServiceProvider } from '#core/providers/service-provider/service-provider';
 import { Router } from '#core/router/router';
@@ -23,7 +24,16 @@ export function CoreApp({ dependencies }: Props) {
     <ThemeProvider>
       <ServiceProvider {...dependencies.service}>
         <IconProvider icons={dependencies.theme.icons}>
-          <AppNavBar title="Michelangelo Studio" />
+          <AppNavBar
+            title={
+              <Link
+                href="/"
+                overrides={{ Link: { style: { ':hover': { textDecoration: 'unset' } } } }}
+              >
+                Michelangelo Studio
+              </Link>
+            }
+          />
           <Router />
         </IconProvider>
       </ServiceProvider>

--- a/javascript/packages/core/router/router.tsx
+++ b/javascript/packages/core/router/router.tsx
@@ -2,10 +2,19 @@ import { Route, Routes } from 'react-router-dom-v5-compat';
 
 import { MainViewContainer } from '#core/components/views/main-view-container';
 import { ProjectDetail } from '#core/components/views/project/project-detail';
+import { ProjectList } from '#core/components/views/project/project-list';
 
 export function Router() {
   return (
     <Routes>
+      <Route
+        index
+        element={
+          <MainViewContainer hasBreadcrumb={false}>
+            <ProjectList />
+          </MainViewContainer>
+        }
+      />
       <Route
         path=":projectId"
         element={


### PR DESCRIPTION
Michelangelo Studio homepage now lists projects created in the ma sandbox. Users can click on a project to see project metadata and a list of pipelines in that project.

Discovered that the useBinaryFormat for connect's gRPC-web client returns enums as integers instead of strings. There is a lot of work required to get enums as values, so leveraging text mapping exposed by state/type cells.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

https://github.com/user-attachments/assets/7b41dba1-b063-4fb5-8e2e-ee249e3cf081




<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
