### PR TITLE
Export theme provider for theme injection

### DIFF
--- a/javascript/app/App.tsx
+++ b/javascript/app/App.tsx
@@ -1,6 +1,8 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom-v5-compat';
 import { request } from '@michelangelo/rpc';
 import { CoreApp } from '@uber/michelangelo-core';
+import { Client as Styletron } from 'styletron-engine-atomic';
+import { Provider as StyletronProvider } from 'styletron-react';
 
 import { ICONS } from './icons/icons';
 
@@ -13,12 +15,16 @@ const dependencies = {
   },
 };
 
+const engine = new Styletron();
+
 export function App() {
   return (
-    <BrowserRouter>
-      <Routes>
-        <Route path="/*" element={<CoreApp dependencies={dependencies} />} />
-      </Routes>
-    </BrowserRouter>
+    <StyletronProvider value={engine}>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/*" element={<CoreApp dependencies={dependencies} />} />
+        </Routes>
+      </BrowserRouter>
+    </StyletronProvider>
   );
 }

--- a/javascript/packages/core/index.tsx
+++ b/javascript/packages/core/index.tsx
@@ -76,6 +76,8 @@ export { Icon } from '#core/components/icon/icon';
 export { IconKind } from '#core/components/icon/types';
 export { IconProvider } from '#core/providers/icon-provider/icon-provider';
 
+export { ThemeProvider };
+
 export { UserProvider } from '#core/providers/user-provider/user-provider';
 
 export * from '#core/utils/object-utils';

--- a/javascript/packages/core/package.json
+++ b/javascript/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uber/michelangelo-core",
   "license": "UNLICENSED",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "main": "./dist/michelangelo-core.js",
   "module": "./dist/michelangelo-core.js",

--- a/javascript/packages/core/test/wrappers/get-base-provider-wrapper.tsx
+++ b/javascript/packages/core/test/wrappers/get-base-provider-wrapper.tsx
@@ -1,5 +1,8 @@
 // This is required for some BaseWeb components. If missing, BaseWeb will console.warn
 
+import { Client as Styletron } from 'styletron-engine-atomic';
+import { Provider as StyletronProvider } from 'styletron-react';
+
 import { ThemeProvider } from '#core/themes/provider';
 import { WrapperComponentProps } from './types';
 
@@ -7,6 +10,10 @@ import { WrapperComponentProps } from './types';
 // something like "`LayersManager` was not found."
 export function getBaseProviderWrapper() {
   return function BaseProviderWrapper({ children }: WrapperComponentProps) {
-    return <ThemeProvider>{children}</ThemeProvider>;
+    return (
+      <StyletronProvider value={new Styletron()}>
+        <ThemeProvider>{children}</ThemeProvider>
+      </StyletronProvider>
+    );
   };
 }

--- a/javascript/packages/core/themes/provider.tsx
+++ b/javascript/packages/core/themes/provider.tsx
@@ -1,14 +1,9 @@
 import { BaseProvider, createTheme } from 'baseui';
-import { Client as Styletron } from 'styletron-engine-atomic';
-import { Provider as StyletronProvider } from 'styletron-react';
 
 import { GRID_OVERRIDES } from './shared';
 
-export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const engine = new Styletron();
-  return (
-    <StyletronProvider value={engine}>
-      <BaseProvider theme={createTheme(GRID_OVERRIDES)}>{children}</BaseProvider>
-    </StyletronProvider>
-  );
+import type { Theme } from 'baseui';
+
+export function ThemeProvider({ children, theme }: { children: React.ReactNode; theme?: Theme }) {
+  return <BaseProvider theme={theme ?? createTheme(GRID_OVERRIDES)}>{children}</BaseProvider>;
 }


### PR DESCRIPTION
When exposing theme as a provider prop, styletron engine can get reinitialized when the theme prop changes. Relocated styletron provider to App.tsx, since the usecases for michelangelo-core already provider a styletron provider.

Michelangelo Studio internal deployment's theme does not get propagated to michelangelo-core components because baseui is packaged with michelangelo-core. Attempts to remove baseui from the michelangelo-core bundle did not interact well with the internal copy of baseui.

**What type of PR is this? (check all applicable)**
- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
