### PR TITLE
Add Canvas key schemas

### DIFF
--- a/python/michelangelo/canvas/schema/v2alpha1/config.py
+++ b/python/michelangelo/canvas/schema/v2alpha1/config.py
@@ -1,0 +1,60 @@
+from typing import Any, Optional
+
+from michelangelo.canvas.lib.shared.json_data.json_data import JSONData
+
+from .job_specs import JobSpecs
+
+
+class TaskConfig(JSONData):
+    """
+    Task config class.
+
+    Each task function is required to have a task config, and the task config will be the first argument
+    in the task function named as 'config' with type annotation.
+
+    The workflow framework will derive the task config type from task function and parse the task config from
+    the pipeline_conf.yaml.
+
+    Example task function signature:
+        @canvas_task(config=Ray(...)))
+        def example_task_func(config: ExampleTaskConfig, args...):
+
+    Attributes:
+        task_function (str): Fully qualified name of the task function.
+        config (Any): Task level config. The type is derived from the type annotation in the task function.
+    """
+
+    task_function: str
+    config: Any
+    job_specs: Optional[JobSpecs]
+
+
+class WorkflowConfig(JSONData):
+    """
+    Workflow config class.
+
+    This class defines the workflow config schema. It is used to load the configuration specified in
+    pipeline_conf.yaml.
+
+    Canvas supports two types of workflow functions: one with workflow level config and one without
+    workflow level config. The workflow function signatures are as follows:
+
+    1. Workflow function with workflow level config:
+        @workflow
+        def example_workflow_func(config: ExampleConfig, task_configs: dict[str, TaskConfig]):
+
+    2. Workflow function without workflow level config:
+        @workflow
+        def example_workflow_func2(task_configs: dict[str, TaskConfig]):
+
+    Attributes:
+        workflow_function (str): Fully qualified name of the workflow function.
+        workflow_config (Any): Optional workflow level config. The type is derived from the type annotation
+                               in the workflow function. Defaults to None if not provided.
+        task_configs (dict[str, TaskConfig]): Task level configs. Each task config is identified by the
+                                              task function name.
+    """
+
+    workflow_function: str
+    workflow_config: Any
+    task_configs: dict[str, TaskConfig]

--- a/python/michelangelo/canvas/schema/v2alpha1/job_specs.py
+++ b/python/michelangelo/canvas/schema/v2alpha1/job_specs.py
@@ -1,0 +1,90 @@
+from typing import Optional
+
+from michelangelo.canvas.lib.shared.json_data.field import field, _OneOf, one_of
+from michelangelo.canvas.lib.shared.json_data.json_data import JSONData
+
+
+class ResourceSpec(JSONData):
+    # CPU limit in number of CPU cores
+    cpu: int = field(ge=0)
+
+    # Memory limit such as 32G
+    memory: str
+
+    # Disk size limit such as 100G
+    disk_size: str
+
+    # GPU limit in number of GPUs
+    gpu: int = field(ge=0)
+
+    # GPU sku identifier. Mandatory for cloud workloads
+    gpu_sku: str
+
+
+class PodSpec(JSONData):
+    # Resource requirement of the Pod
+    resource: ResourceSpec
+
+
+class DriverSpec(JSONData):
+    # Pod spec for the Spark driver
+    pod: PodSpec
+
+
+class ExecutorSpec(JSONData):
+    # Pod spec for the Spark executors
+    pod: PodSpec
+
+    # Number of executor instances
+    instances: int = field(ge=0)
+
+
+class SparkJobSpec(JSONData):
+    # Spark driver specification
+    driver: DriverSpec
+
+    # Spark executor specification
+    executor: Optional[ExecutorSpec]
+
+    # Spark configuration
+    spark_conf: Optional[dict[str, str]]
+
+    # jar files
+    deps: Optional[dict[str, list[str]]]
+
+
+class HeadSpec(JSONData):
+    # Pod spec for the Ray head
+    pod: PodSpec
+
+
+# Specification for the workers in a Ray job
+class WorkerSpec(JSONData):
+    # Pod spec for the Ray worker instances
+    pod: PodSpec
+
+    # Minimum number of worker instances
+    min_instances: int = field(ge=0)
+
+    #  Maximum number of worker instances
+    max_instances: int = field(ge=0)
+
+
+class RayJobSpec(JSONData):
+    # Ray head specification
+    head: HeadSpec
+
+    # Ray worker specification
+    worker: WorkerSpec
+
+
+# Specification of a ML job.
+class JobSpecs(JSONData):
+    # TODO: support resource pool config
+    _one_of_job_specs = one_of(fields=["spark", "ray"], required=False)
+
+    # Spark job
+    spark: Optional[SparkJobSpec]
+
+    # Ray job
+    ray: Optional[RayJobSpec]

--- a/python/michelangelo/canvas/schema/v2alpha1/tests/job_specs_test.py
+++ b/python/michelangelo/canvas/schema/v2alpha1/tests/job_specs_test.py
@@ -1,0 +1,117 @@
+from google.protobuf import json_format
+from typing import Optional
+from unittest import TestCase
+
+from michelangelo.canvas.lib.shared.json_data.field import one_of
+from michelangelo.canvas.lib.shared.json_data.json_data import JSONData
+from michelangelo.canvas.schema.v2alpha1.job_specs import (
+    DriverSpec,
+    PodSpec,
+    JobSpecs,
+    RayJobSpec,
+    ResourceSpec,
+    SparkJobSpec,
+)
+from michelangelo.gen.api.v2.spark_job_pb2 import SparkJobSpec as UAPISparkJobSpec, DriverSpec as UAPIDriverSpec
+from michelangelo.gen.api.v2.pod_pb2 import PodSpec as UAPIPodSpec, ResourceSpec as UAPIResourceSpec
+
+
+class TestJobSpec(TestCase):
+
+    def test_canvas_job_spec_is_compatible_with_uapi_job_specs(self):
+        _cpu = 2
+        _memory = "100G"
+        _disk_size = "100G"
+
+        spark_job_spec = SparkJobSpec(
+            driver=DriverSpec(pod=PodSpec(resource=ResourceSpec(cpu=_cpu, memory=_memory, disk_size=_disk_size))),
+            executor=None,
+        )
+        job_spec = JobSpecs(spark=spark_job_spec)
+        json_str = job_spec.model_dump_json(exclude_defaults=False)
+        
+        # Test with available UAPI SparkJobSpec protobuf
+        import json
+        job_data = json.loads(json_str)
+        spark_json = json.dumps(job_data["spark"])
+        
+        uapi_spark_job_spec = UAPISparkJobSpec()
+        json_format.Parse(spark_json, uapi_spark_job_spec)
+        
+        self.assertEqual(uapi_spark_job_spec.driver.pod.resource.cpu, _cpu)
+        self.assertEqual(uapi_spark_job_spec.driver.pod.resource.memory, _memory)
+        self.assertEqual(uapi_spark_job_spec.driver.pod.resource.disk_size, _disk_size)
+
+    def test_canvas_job_spec_compatibility_with_spark_conf(self):
+        _cpu = 4
+        _memory = "32G"
+        _disk_size = "200G"
+        _spark_conf = {
+            "spark.executor.memory": "8G",
+            "spark.dynamicAllocation.enabled": "true",
+        }
+
+        spark_job_spec = SparkJobSpec(
+            driver=DriverSpec(
+                pod=PodSpec(resource=ResourceSpec(cpu=_cpu, memory=_memory, disk_size=_disk_size))
+            ),
+            executor=None,
+            spark_conf=_spark_conf,
+        )
+
+        job_spec = JobSpecs(spark=spark_job_spec)
+        json_str = job_spec.model_dump_json(exclude_defaults=False)
+        
+        # Test with available UAPI SparkJobSpec protobuf
+        import json
+        job_data = json.loads(json_str)
+        spark_json = json.dumps(job_data["spark"])
+        
+        uapi_spark_job_spec = UAPISparkJobSpec()
+        json_format.Parse(spark_json, uapi_spark_job_spec)
+        
+        spark_conf_map = dict(uapi_spark_job_spec.spark_conf)
+        self.assertEqual(spark_conf_map["spark.executor.memory"], "8G")
+        self.assertEqual(spark_conf_map["spark.dynamicAllocation.enabled"], "true")
+
+    def test_canvas_job_spec_compatibility_with_jars(self):
+        _cpu = 2
+        _memory = "16G"
+        _disk_size = "100G"
+        _jars = ["hdfs:///path/to/test1.jar", "hdfs:///path/to/test2.jar"]
+
+        spark_job_spec = SparkJobSpec(
+            driver=DriverSpec(
+                pod=PodSpec(resource=ResourceSpec(cpu=_cpu, memory=_memory, disk_size=_disk_size))
+            ),
+            executor=None,
+            deps={"jars": _jars},  # Match Python schema
+        )
+
+        job_spec = JobSpecs(spark=spark_job_spec)
+        json_str = job_spec.model_dump_json(exclude_defaults=False)
+        
+        # Test with available UAPI SparkJobSpec protobuf
+        import json
+        job_data = json.loads(json_str)
+        spark_json = json.dumps(job_data["spark"])
+        
+        uapi_spark_job_spec = UAPISparkJobSpec()
+        json_format.Parse(spark_json, uapi_spark_job_spec)
+        
+        jars_list = list(uapi_spark_job_spec.deps.jars)
+        self.assertEqual(jars_list, _jars)
+
+    def test_non_compatiable_job_spec(self):
+        class NonCompatibleJobSpec(JSONData):
+            _one_of_job_spec = one_of(fields=["spark", "ray"], required=False)
+            spark: Optional[SparkJobSpec]
+            ray: Optional[RayJobSpec]
+            # suppose someone add a non-compatible field on Canvas job spec and that field is not in UAPI
+            non_compatiable_field: str
+
+        invalid_job_spec = NonCompatibleJobSpec()
+        json_str = invalid_job_spec.model_dump_json(exclude_defaults=False)
+        
+        # Verify that the JSON contains the non-compatible field
+        self.assertIn("non_compatiable_field", json_str)


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
this introduces a new schema version (v2alpha1) for the Michelangelo Canvas job specifications system. Here are the key components and changes:
- TaskConfig, WorkflowConfig, JobSpecs

<!-- Tell your future self why have you made these changes -->
core configuration Schemas for canvas, will be used for later schema loading


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Unit tests


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->


<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->

