### PR TITLE
Upgrade michelangelo-core to 0.1.8

### DIFF
--- a/javascript/app/App.tsx
+++ b/javascript/app/App.tsx
@@ -5,6 +5,7 @@ import { Client as Styletron } from 'styletron-engine-atomic';
 import { Provider as StyletronProvider } from 'styletron-react';
 
 import { ICONS } from './icons/icons';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 const dependencies = {
   theme: {
@@ -16,15 +17,18 @@ const dependencies = {
 };
 
 const engine = new Styletron();
+const queryClient = new QueryClient();
 
 export function App() {
   return (
     <StyletronProvider value={engine}>
-      <BrowserRouter>
-        <Routes>
-          <Route path="/*" element={<CoreApp dependencies={dependencies} />} />
-        </Routes>
-      </BrowserRouter>
+      <QueryClientProvider client={queryClient}>
+        <BrowserRouter>
+          <Routes>
+            <Route path="/*" element={<CoreApp dependencies={dependencies} />} />
+          </Routes>
+        </BrowserRouter>
+      </QueryClientProvider>
     </StyletronProvider>
   );
 }

--- a/javascript/app/App.tsx
+++ b/javascript/app/App.tsx
@@ -1,11 +1,11 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom-v5-compat';
 import { request } from '@michelangelo/rpc';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { CoreApp } from '@uber/michelangelo-core';
 import { Client as Styletron } from 'styletron-engine-atomic';
 import { Provider as StyletronProvider } from 'styletron-react';
 
 import { ICONS } from './icons/icons';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 const dependencies = {
   theme: {

--- a/javascript/packages/core/components/cell/renderers/state/__tests__/get-state-color.tests.ts
+++ b/javascript/packages/core/components/cell/renderers/state/__tests__/get-state-color.tests.ts
@@ -1,33 +1,33 @@
-import { COLOR } from '#core/components/tag/constants';
+import { TAG_COLOR } from '#core/components/tag/constants';
 import { getStateColor } from '../get-state-color';
 
 describe('getStateColor', () => {
   it('should return gray for empty value', () => {
-    expect(getStateColor('')).toBe(COLOR.gray);
+    expect(getStateColor('')).toBe(TAG_COLOR.gray);
   });
 
   it('should return red for error states', () => {
-    expect(getStateColor('PIPELINE_STATE_ERROR')).toBe(COLOR.red);
-    expect(getStateColor('ANY_STATE_ERROR')).toBe(COLOR.red);
+    expect(getStateColor('PIPELINE_STATE_ERROR')).toBe(TAG_COLOR.red);
+    expect(getStateColor('ANY_STATE_ERROR')).toBe(TAG_COLOR.red);
   });
 
   it('should return green for success states', () => {
-    expect(getStateColor('PIPELINE_STATE_SUCCESS')).toBe(COLOR.green);
-    expect(getStateColor('ANY_STATE_SUCCESS')).toBe(COLOR.green);
+    expect(getStateColor('PIPELINE_STATE_SUCCESS')).toBe(TAG_COLOR.green);
+    expect(getStateColor('ANY_STATE_SUCCESS')).toBe(TAG_COLOR.green);
   });
 
   it('should return blue for running states', () => {
-    expect(getStateColor('PIPELINE_STATE_RUNNING')).toBe(COLOR.blue);
-    expect(getStateColor('ANY_STATE_RUNNING')).toBe(COLOR.blue);
+    expect(getStateColor('PIPELINE_STATE_RUNNING')).toBe(TAG_COLOR.blue);
+    expect(getStateColor('ANY_STATE_RUNNING')).toBe(TAG_COLOR.blue);
   });
 
   it('should return gray for invalid states', () => {
-    expect(getStateColor('PIPELINE_STATE_INVALID')).toBe(COLOR.gray);
-    expect(getStateColor('ANY_STATE_INVALID')).toBe(COLOR.gray);
+    expect(getStateColor('PIPELINE_STATE_INVALID')).toBe(TAG_COLOR.gray);
+    expect(getStateColor('ANY_STATE_INVALID')).toBe(TAG_COLOR.gray);
   });
 
   it('should return gray for unknown states', () => {
-    expect(getStateColor('PIPELINE_STATE_UNKNOWN')).toBe(COLOR.gray);
-    expect(getStateColor('ANY_STATE')).toBe(COLOR.gray);
+    expect(getStateColor('PIPELINE_STATE_UNKNOWN')).toBe(TAG_COLOR.gray);
+    expect(getStateColor('ANY_STATE')).toBe(TAG_COLOR.gray);
   });
 });

--- a/javascript/packages/core/components/cell/renderers/state/get-state-color.ts
+++ b/javascript/packages/core/components/cell/renderers/state/get-state-color.ts
@@ -1,4 +1,4 @@
-import { COLOR } from '#core/components/tag/constants';
+import { TAG_COLOR } from '#core/components/tag/constants';
 
 import type { TagColor } from '#core/components/tag/types';
 
@@ -21,10 +21,10 @@ import type { TagColor } from '#core/components/tag/types';
  * ```
  */
 export const getStateColor = (value: string): TagColor => {
-  if (!value) return COLOR.gray;
-  if (value.endsWith('_ERROR')) return COLOR.red;
-  if (value.endsWith('_SUCCESS')) return COLOR.green;
-  if (value.endsWith('_RUNNING')) return COLOR.blue;
-  if (value.endsWith('_INVALID')) return COLOR.gray;
-  return COLOR.gray;
+  if (!value) return TAG_COLOR.gray;
+  if (value.endsWith('_ERROR')) return TAG_COLOR.red;
+  if (value.endsWith('_SUCCESS')) return TAG_COLOR.green;
+  if (value.endsWith('_RUNNING')) return TAG_COLOR.blue;
+  if (value.endsWith('_INVALID')) return TAG_COLOR.gray;
+  return TAG_COLOR.gray;
 };

--- a/javascript/packages/core/components/cell/renderers/tag/tag-cell.tsx
+++ b/javascript/packages/core/components/cell/renderers/tag/tag-cell.tsx
@@ -1,4 +1,4 @@
-import { BEHAVIOR, COLOR, HIERARCHY, SIZE } from '#core/components/tag/constants';
+import { TAG_BEHAVIOR, TAG_COLOR, TAG_HIERARCHY, TAG_SIZE } from '#core/components/tag/constants';
 import { Tag } from '#core/components/tag/tag';
 
 import type { CellRenderer } from '#core/components/cell/types';
@@ -11,11 +11,11 @@ export const TagCell: CellRenderer<string, TagCellConfig> = ({ value, column }) 
 
   return (
     <Tag
-      size={SIZE.xSmall}
-      hierarchy={HIERARCHY.secondary}
-      behavior={BEHAVIOR.selection}
+      size={TAG_SIZE.xSmall}
+      hierarchy={TAG_HIERARCHY.secondary}
+      behavior={TAG_BEHAVIOR.selection}
       closeable={false}
-      color={column.color ?? COLOR.gray}
+      color={column.color ?? TAG_COLOR.gray}
       overrides={{
         Root: {
           style: {

--- a/javascript/packages/core/components/cell/renderers/type/type-cell.tsx
+++ b/javascript/packages/core/components/cell/renderers/type/type-cell.tsx
@@ -1,4 +1,4 @@
-import { BEHAVIOR, COLOR, HIERARCHY, SIZE } from '#core/components/tag/constants';
+import { TAG_BEHAVIOR, TAG_COLOR, TAG_HIERARCHY, TAG_SIZE } from '#core/components/tag/constants';
 import { Tag } from '#core/components/tag/tag';
 import { typeCellToString } from './type-cell-to-string';
 
@@ -14,10 +14,10 @@ export const TypeCell: CellRenderer<string, TypeCellConfig> = ({ value, column }
 
   return (
     <Tag
-      size={SIZE.xSmall}
-      behavior={BEHAVIOR.selection}
-      hierarchy={HIERARCHY.secondary}
-      color={COLOR.gray}
+      size={TAG_SIZE.xSmall}
+      behavior={TAG_BEHAVIOR.selection}
+      hierarchy={TAG_HIERARCHY.secondary}
+      color={TAG_COLOR.gray}
       closeable={false}
     >
       {content}

--- a/javascript/packages/core/components/row/components/__tests__/row-item.test.tsx
+++ b/javascript/packages/core/components/row/components/__tests__/row-item.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+
+import { RowItem } from '../row-item';
+
+import type { CellRenderer } from '#core/components/cell/types';
+
+describe('RowItem', () => {
+  const mockItem = {
+    id: 'name',
+    label: 'Name',
+    accessor: 'name',
+  };
+
+  const mockRecord = {
+    name: 'John Doe',
+    age: 30,
+  };
+
+  it('renders with DefaultCellRenderer when no CellComponent is provided', () => {
+    render(<RowItem item={mockItem} record={mockRecord} />);
+
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('John Doe')).toBeInTheDocument();
+  });
+
+  it('uses custom CellComponent when provided', () => {
+    const CustomCellRenderer: CellRenderer<string> = ({ value }) => (
+      <span data-testid="custom-cell">Custom: {value}</span>
+    );
+
+    render(<RowItem item={mockItem} record={mockRecord} CellComponent={CustomCellRenderer} />);
+
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Custom: John Doe')).toBeInTheDocument();
+  });
+
+  it('uses accessor when provided instead of id for value extraction', () => {
+    const itemWithAccessor = {
+      id: 'user',
+      label: 'User Name',
+      accessor: 'profile.name',
+    };
+
+    const recordWithNestedData = {
+      profile: {
+        name: 'Jane Smith',
+      },
+    };
+
+    render(<RowItem item={itemWithAccessor} record={recordWithNestedData} />);
+
+    expect(screen.getByText('Jane Smith')).toBeInTheDocument();
+  });
+});

--- a/javascript/packages/core/components/row/components/row-item.tsx
+++ b/javascript/packages/core/components/row/components/row-item.tsx
@@ -1,6 +1,7 @@
 import { useStyletron } from 'baseui';
 
 import { DefaultCellRenderer } from '#core/components/cell/renderers/default-cell-renderer';
+import { CellRenderer } from '#core/components/cell/types';
 import { getObjectValue } from '#core/utils/object-utils';
 import { RowLabel } from './row-label';
 
@@ -9,16 +10,17 @@ import type { RowProps } from '#core/components/row/types';
 export const RowItem = (props: {
   item: RowProps['items'][number];
   record: NonNullable<RowProps['record']>;
+  CellComponent?: CellRenderer<unknown>;
 }) => {
   const [css, theme] = useStyletron();
-  const { record, item } = props;
+  const { record, item, CellComponent = DefaultCellRenderer } = props;
 
   const value = getObjectValue(record, item.accessor ?? item.id);
   return (
     <div>
       <RowLabel label={item.label} />
       <div className={css(theme.typography.ParagraphSmall)}>
-        <DefaultCellRenderer value={value} column={item} record={record} />
+        <CellComponent value={value} column={item} record={record} />
       </div>
     </div>
   );

--- a/javascript/packages/core/components/row/row.tsx
+++ b/javascript/packages/core/components/row/row.tsx
@@ -3,7 +3,7 @@ import { getOverrides } from 'baseui';
 import { Skeleton } from 'baseui/skeleton';
 
 import { getObjectValue } from '#core/utils/object-utils';
-import { RowItem } from './components/row-item';
+import { RowItem as BaseRowItem } from './components/row-item';
 import { StyledRowContainer, StyledRowItemContainer } from './styled-components';
 
 import type { RowProps } from '#core/components/row/types';
@@ -20,6 +20,8 @@ export function Row(props: RowProps) {
     overrides.RowItemContainer,
     StyledRowItemContainer
   );
+
+  const [RowItem, rowItemProps] = getOverrides(overrides.RowItem, BaseRowItem);
 
   return (
     <RowContainer {...rowContainerProps}>
@@ -52,7 +54,7 @@ export function Row(props: RowProps) {
             )}
             {!loading && (
               <RowItemContainer $index={i} {...rowItemContainerProps}>
-                {<RowItem item={item} record={record} />}
+                {<RowItem item={item} record={record} {...rowItemProps} />}
               </RowItemContainer>
             )}
           </React.Fragment>

--- a/javascript/packages/core/components/row/types.ts
+++ b/javascript/packages/core/components/row/types.ts
@@ -27,4 +27,5 @@ export type RowCell = Cell & {
 type RowOverrides = {
   RowContainer?: Override;
   RowItemContainer?: Override;
+  RowItem?: Override;
 };

--- a/javascript/packages/core/components/tag/constants.ts
+++ b/javascript/packages/core/components/tag/constants.ts
@@ -1,16 +1,16 @@
 import { HIERARCHY, SIZE as BASE_SIZE } from 'baseui/tag';
 
-export const SIZE = {
+export const TAG_SIZE = {
   xSmall: 'xSmall',
   ...BASE_SIZE,
 } as const;
 
-export const BEHAVIOR = {
+export const TAG_BEHAVIOR = {
   display: 'display',
   selection: 'selection',
 } as const;
 
-export const COLOR = {
+export const TAG_COLOR = {
   gray: 'gray',
   red: 'red',
   orange: 'orange',
@@ -23,4 +23,4 @@ export const COLOR = {
   lime: 'lime',
 } as const;
 
-export { HIERARCHY };
+export { HIERARCHY as TAG_HIERARCHY };

--- a/javascript/packages/core/components/tag/styled-components.ts
+++ b/javascript/packages/core/components/tag/styled-components.ts
@@ -1,101 +1,101 @@
-import { BEHAVIOR, COLOR, HIERARCHY, SIZE } from './constants';
+import { TAG_BEHAVIOR, TAG_COLOR, TAG_HIERARCHY, TAG_SIZE } from './constants';
 
 import type { Theme } from 'baseui';
 import type { ColorOverrides, TagBehavior, TagColor, TagHierarchy, TagSize } from './types';
 
 const COLOR_OVERRIDES: ColorOverrides = {
-  [HIERARCHY.primary]: {
-    [BEHAVIOR.display]: {
-      [COLOR.purple]: (theme: Theme) => ({
+  [TAG_HIERARCHY.primary]: {
+    [TAG_BEHAVIOR.display]: {
+      [TAG_COLOR.purple]: (theme: Theme) => ({
         color: theme.colors.white,
         backgroundColor: theme.colors.purple600,
       }),
-      [COLOR.magenta]: (theme: Theme) => ({
+      [TAG_COLOR.magenta]: (theme: Theme) => ({
         color: theme.colors.white,
         backgroundColor: theme.colors.magenta600,
       }),
     },
-    [BEHAVIOR.selection]: {
-      [COLOR.gray]: (theme: Theme) => ({
+    [TAG_BEHAVIOR.selection]: {
+      [TAG_COLOR.gray]: (theme: Theme) => ({
         borderColor: theme.colors.gray700,
       }),
-      [COLOR.red]: (theme: Theme) => ({
+      [TAG_COLOR.red]: (theme: Theme) => ({
         borderColor: theme.colors.red700,
       }),
-      [COLOR.orange]: (theme: Theme) => ({
+      [TAG_COLOR.orange]: (theme: Theme) => ({
         borderColor: theme.colors.orange700,
       }),
-      [COLOR.yellow]: (theme: Theme) => ({
+      [TAG_COLOR.yellow]: (theme: Theme) => ({
         borderColor: theme.colors.yellow700,
       }),
-      [COLOR.green]: (theme: Theme) => ({
+      [TAG_COLOR.green]: (theme: Theme) => ({
         borderColor: theme.colors.green700,
       }),
-      [COLOR.blue]: (theme: Theme) => ({
+      [TAG_COLOR.blue]: (theme: Theme) => ({
         borderColor: theme.colors.blue700,
       }),
-      [COLOR.purple]: (theme: Theme) => ({
+      [TAG_COLOR.purple]: (theme: Theme) => ({
         color: theme.colors.white,
         backgroundColor: theme.colors.purple600,
         borderColor: theme.colors.purple700,
       }),
-      [COLOR.magenta]: (theme: Theme) => ({
+      [TAG_COLOR.magenta]: (theme: Theme) => ({
         color: theme.colors.white,
         backgroundColor: theme.colors.magenta600,
         borderColor: theme.colors.magenta700,
       }),
-      [COLOR.teal]: (theme: Theme) => ({
+      [TAG_COLOR.teal]: (theme: Theme) => ({
         borderColor: theme.colors.teal700,
       }),
-      [COLOR.lime]: (theme: Theme) => ({
+      [TAG_COLOR.lime]: (theme: Theme) => ({
         borderColor: theme.colors.lime700,
       }),
     },
   },
-  [HIERARCHY.secondary]: {
-    [BEHAVIOR.display]: {
-      [COLOR.magenta]: (theme: Theme) => ({
+  [TAG_HIERARCHY.secondary]: {
+    [TAG_BEHAVIOR.display]: {
+      [TAG_COLOR.magenta]: (theme: Theme) => ({
         color: theme.colors.magenta700,
         backgroundColor: theme.colors.magenta50,
       }),
-      [COLOR.purple]: (theme: Theme) => ({
+      [TAG_COLOR.purple]: (theme: Theme) => ({
         color: theme.colors.purple700,
         backgroundColor: theme.colors.purple50,
       }),
     },
-    [BEHAVIOR.selection]: {
-      [COLOR.gray]: (theme: Theme) => ({
+    [TAG_BEHAVIOR.selection]: {
+      [TAG_COLOR.gray]: (theme: Theme) => ({
         borderColor: theme.colors.gray100,
       }),
-      [COLOR.red]: (theme: Theme) => ({
+      [TAG_COLOR.red]: (theme: Theme) => ({
         borderColor: theme.colors.red100,
       }),
-      [COLOR.orange]: (theme: Theme) => ({
+      [TAG_COLOR.orange]: (theme: Theme) => ({
         borderColor: theme.colors.orange100,
       }),
-      [COLOR.yellow]: (theme: Theme) => ({
+      [TAG_COLOR.yellow]: (theme: Theme) => ({
         borderColor: theme.colors.yellow100,
       }),
-      [COLOR.green]: (theme: Theme) => ({
+      [TAG_COLOR.green]: (theme: Theme) => ({
         borderColor: theme.colors.green100,
       }),
-      [COLOR.blue]: (theme: Theme) => ({
+      [TAG_COLOR.blue]: (theme: Theme) => ({
         borderColor: theme.colors.blue100,
       }),
-      [COLOR.purple]: (theme: Theme) => ({
+      [TAG_COLOR.purple]: (theme: Theme) => ({
         color: theme.colors.purple700,
         backgroundColor: theme.colors.purple50,
         borderColor: theme.colors.purple100,
       }),
-      [COLOR.magenta]: (theme: Theme) => ({
+      [TAG_COLOR.magenta]: (theme: Theme) => ({
         color: theme.colors.magenta700,
         backgroundColor: theme.colors.magenta50,
         borderColor: theme.colors.magenta100,
       }),
-      [COLOR.teal]: (theme: Theme) => ({
+      [TAG_COLOR.teal]: (theme: Theme) => ({
         borderColor: theme.colors.teal100,
       }),
-      [COLOR.lime]: (theme: Theme) => ({
+      [TAG_COLOR.lime]: (theme: Theme) => ({
         borderColor: theme.colors.lime100,
       }),
     },
@@ -121,7 +121,7 @@ export const getTagOverrides = (
   return {
     Root: {
       style: {
-        ...(size === SIZE.xSmall
+        ...(size === TAG_SIZE.xSmall
           ? {
               ...theme.typography.LabelXSmall,
               height: '20px',
@@ -144,7 +144,7 @@ export const getTagOverrides = (
 
     StartEnhancerContainer: {
       style: {
-        ...(size === SIZE.xSmall
+        ...(size === TAG_SIZE.xSmall
           ? {
               paddingRight: theme.sizing.scale100,
             }

--- a/javascript/packages/core/components/tag/tag.tsx
+++ b/javascript/packages/core/components/tag/tag.tsx
@@ -2,7 +2,7 @@ import { forwardRef } from 'react';
 import { mergeOverrides, useStyletron } from 'baseui';
 import { KIND as BASE_KIND, Tag as BaseTag } from 'baseui/tag';
 
-import { BEHAVIOR, COLOR, HIERARCHY, SIZE } from './constants';
+import { TAG_BEHAVIOR, TAG_COLOR, TAG_HIERARCHY, TAG_SIZE } from './constants';
 import { getTagOverrides } from './styled-components';
 
 import type { TagKind as BaseTagKind, TagSize as BaseTagSize } from 'baseui/tag';
@@ -13,19 +13,19 @@ export const Tag = forwardRef<HTMLElement, Props>(
     {
       children,
       overrides,
-      size = SIZE.small,
-      color = COLOR.gray,
-      behavior = BEHAVIOR.display,
-      hierarchy = HIERARCHY.secondary,
+      size = TAG_SIZE.small,
+      color = TAG_COLOR.gray,
+      behavior = TAG_BEHAVIOR.display,
+      hierarchy = TAG_HIERARCHY.secondary,
       ...rest
     },
     ref
   ) => {
     const [_, theme] = useStyletron();
 
-    const baseSize: BaseTagSize | undefined = size === SIZE.xSmall ? SIZE.small : size;
+    const baseSize: BaseTagSize | undefined = size === TAG_SIZE.xSmall ? TAG_SIZE.small : size;
     const baseKind: BaseTagKind | undefined =
-      color === COLOR.gray || color === COLOR.purple || color === COLOR.magenta
+      color === TAG_COLOR.gray || color === TAG_COLOR.purple || color === TAG_COLOR.magenta
         ? BASE_KIND.black
         : color;
 

--- a/javascript/packages/core/components/tag/types.ts
+++ b/javascript/packages/core/components/tag/types.ts
@@ -1,11 +1,11 @@
 import type { TagProps as BaseTagProps } from 'baseui/tag';
 import type { StyleFunction } from '#core/types/style-types';
-import type { BEHAVIOR, COLOR, HIERARCHY, SIZE } from './constants';
+import type { TAG_BEHAVIOR, TAG_COLOR, TAG_HIERARCHY, TAG_SIZE } from './constants';
 
-export type TagSize = keyof typeof SIZE;
-export type TagBehavior = keyof typeof BEHAVIOR;
-export type TagColor = keyof typeof COLOR;
-export type TagHierarchy = keyof typeof HIERARCHY;
+export type TagSize = keyof typeof TAG_SIZE;
+export type TagBehavior = keyof typeof TAG_BEHAVIOR;
+export type TagColor = keyof typeof TAG_COLOR;
+export type TagHierarchy = keyof typeof TAG_HIERARCHY;
 
 export interface Props extends Omit<BaseTagProps, 'size' | 'kind'> {
   size?: TagSize;

--- a/javascript/packages/core/hooks/routing/__tests__/use-url-query-string.test.ts
+++ b/javascript/packages/core/hooks/routing/__tests__/use-url-query-string.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react';
 
-import useURLQueryString from '#core/hooks/routing/use-url-query-string';
+import { useURLQueryString } from '#core/hooks/routing/use-url-query-string';
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
 

--- a/javascript/packages/core/hooks/routing/use-studio-params/use-studio-params.ts
+++ b/javascript/packages/core/hooks/routing/use-studio-params/use-studio-params.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useParams } from 'react-router-dom-v5-compat';
 
-import useURLQueryString from '#core/hooks/routing/use-url-query-string';
+import { useURLQueryString } from '#core/hooks/routing/use-url-query-string';
 import { Phase } from '#core/types/common/studio-types';
 import { VIEW_TYPE_TO_PARAMS } from './constants';
 import { normalizeEntityParam } from './normalize-entity-param';

--- a/javascript/packages/core/hooks/routing/use-url-query-string.ts
+++ b/javascript/packages/core/hooks/routing/use-url-query-string.ts
@@ -1,6 +1,6 @@
 import { useLocation } from 'react-router-dom-v5-compat';
 
-export default function useURLQueryString<T extends Record<string, string>>(): Partial<T> {
+export function useURLQueryString<T extends Record<string, string>>(): Partial<T> {
   const location = useLocation();
   const { search = '' } = location ?? {};
   return Object.fromEntries(new URLSearchParams(search)) as Partial<T>;

--- a/javascript/packages/core/index.tsx
+++ b/javascript/packages/core/index.tsx
@@ -45,10 +45,12 @@ export { useStudioQuery } from '#core/hooks/use-studio-query';
 export { ServiceProvider } from '#core/providers/service-provider/service-provider';
 
 export { cellToString } from '#core/components/cell/cell-to-string';
+export { cellTooltipHOC } from '#core/components/cell/components/tooltip/cell-tooltip-hoc';
 export { DefaultCellRenderer } from '#core/components/cell/renderers/default-cell-renderer';
 export { getCellRenderer } from '#core/components/cell/get-cell-renderer';
 export * from '#core/components/cell/types';
 export { CellType } from '#core/components/cell/constants';
+export { useCellStyles } from '#core/components/cell/hooks';
 
 export { BooleanCell } from '#core/components/cell/renderers/boolean/boolean-cell';
 export { DateCell } from '#core/components/cell/renderers/date/date-cell';
@@ -70,17 +72,28 @@ export { Link } from '#core/components/link/link';
 export * from '#core/components/link/styled-components';
 export { Markdown } from '#core/components/markdown/markdown';
 export { Row } from '#core/components/row/row';
+export type { RowCell, RowProps } from '#core/components/row/types';
 export { Tag } from '#core/components/tag/tag';
+export * from '#core/components/tag/constants';
+export type { TagColor, TagHierarchy, TagBehavior, TagSize } from '#core/components/tag/types';
 export { TruncatedText } from '#core/components/truncated-text/truncated-text';
 
 export { Icon } from '#core/components/icon/icon';
 export { IconKind } from '#core/components/icon/types';
 export { IconProvider } from '#core/providers/icon-provider/icon-provider';
+export * from '#core/providers/icon-provider/types';
 
 export { ThemeProvider };
 
 export { UserProvider } from '#core/providers/user-provider/user-provider';
 
+export { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
+export * from '#core/hooks/routing/use-studio-params/types';
+export { useURLQueryString } from '#core/hooks/routing/use-url-query-string';
+
 export * from '#core/utils/object-utils';
 export * from '#core/utils/string-utils';
 export * from '#core/utils/time-utils';
+
+export * from '#core/types/common/studio-types';
+export * from '#core/types/common/view-types';

--- a/javascript/packages/core/providers/service-provider/service-provider.tsx
+++ b/javascript/packages/core/providers/service-provider/service-provider.tsx
@@ -1,10 +1,6 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-
 import { ServiceContext } from './service-context';
 
 import type { ServiceContextType } from './types';
-
-const queryClient = new QueryClient();
 
 /**
  * @description
@@ -25,9 +21,5 @@ export const ServiceProvider = ({
   children,
   ...serviceContext
 }: { children: React.ReactNode } & ServiceContextType) => {
-  return (
-    <QueryClientProvider client={queryClient}>
-      <ServiceContext.Provider value={serviceContext}>{children}</ServiceContext.Provider>
-    </QueryClientProvider>
-  );
+  return <ServiceContext.Provider value={serviceContext}>{children}</ServiceContext.Provider>;
 };

--- a/javascript/packages/core/types/common/studio-types.ts
+++ b/javascript/packages/core/types/common/studio-types.ts
@@ -15,12 +15,16 @@
  * - Traditional ML workflow: Data → Train → Retrain → Deploy → Monitor
  *
  * - Generative AI workflow: LLM → Data → Prompt → Finetune → Monitor
+ *
+ * - Agent workflow: Data → Develop → Deploy → Monitor
  */
 export enum Phase {
   /** Initial project setup and configuration phase */
   Project = 'project',
   /** Assistants builder phase*/
   Assistants = 'assistants',
+  /** Agents builder phase */
+  Agents = 'agents',
 
   /** Data preparation and preprocessing phase */
   Data = 'data',
@@ -43,6 +47,15 @@ export enum Phase {
   GenaiFinetune = 'genai-finetune',
   /** Monitoring of generative AI model performance */
   GenaiMonitor = 'genai-monitor',
+
+  /** Agent data preparation and preprocessing phase */
+  AgentData = 'agent-data',
+  /** Agent development and training phase */
+  AgentDevelop = 'agent-develop',
+  /** Agent deployment and serving phase */
+  AgentDeploy = 'agent-deploy',
+  /** Agent monitoring and performance tracking phase */
+  AgentMonitor = 'agent-monitor',
 }
 
 /**


### PR DESCRIPTION
This commit standardizes the naming convention for tag-related constants by prefixing them with TAG_ to avoid naming conflicts and improve code clarity.

The RowItem component has been enhanced to accept an optional CellComponent prop, allowing for customizable cell rendering with proper override support. This allows internal consumer of Row to provide the internal version of CellComponent, which has access to more types of cell renderers.

New Phase enum values for Agent workflows have been added to support AgentData, AgentDevelop, AgentDeploy, and AgentMonitor phases, extending the existing Phase structure to accommodate agent-based development patterns alongside traditional ML and generative AI workflows.

Added more exports from index.tsx for internal consumption.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
