### PR TITLE
Add CellProvider for extensible custom cell renderers

### DIFF
--- a/javascript/packages/core/components/cell/__tests__/use-get-cell-renderer.tests.tsx
+++ b/javascript/packages/core/components/cell/__tests__/use-get-cell-renderer.tests.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
+import { getCellProviderWrapper } from '#core/test/wrappers/get-cell-provider-wrapper';
 import { getIconProviderWrapper } from '#core/test/wrappers/get-icon-provider-wrapper';
 import { CellType } from '../constants';
 import { useGetCellRenderer } from '../use-get-cell-renderer';
@@ -127,5 +128,226 @@ describe('useGetCellRenderer', () => {
     const link = screen.getByRole('link');
     expect(link).toHaveAttribute('href', 'https://example.com');
     expect(link).toHaveTextContent('Click me');
+  });
+
+  describe('CellProvider functionality', () => {
+    const CustomBadgeRenderer: CellRenderer<string> = (props: CellRendererProps<string>) => (
+      <div data-testid="custom-badge">Badge: {props.value}</div>
+    );
+
+    const CustomSpecialRenderer: CellRenderer<string> = (props: CellRendererProps<string>) => (
+      <div data-testid="custom-special">Special: {props.value}</div>
+    );
+
+    it('should use custom renderer from provider when type matches', () => {
+      const renderers = {
+        CUSTOM_BADGE: CustomBadgeRenderer,
+      };
+
+      const props: CellRendererProps<string> = {
+        column: { id: 'test', type: 'CUSTOM_BADGE' },
+        record: {},
+        value: 'test value',
+      };
+
+      render(
+        <TestCellRenderer props={props} />,
+        buildWrapper([
+          getBaseProviderWrapper(),
+          getIconProviderWrapper(),
+          getCellProviderWrapper({ renderers }),
+        ])
+      );
+
+      expect(screen.getByTestId('custom-badge')).toBeInTheDocument();
+      expect(screen.getByText('Badge: test value')).toBeInTheDocument();
+    });
+
+    it('should support multiple custom renderers', () => {
+      const renderers = {
+        CUSTOM_BADGE: CustomBadgeRenderer,
+        CUSTOM_SPECIAL: CustomSpecialRenderer,
+      };
+
+      const badgeProps: CellRendererProps<string> = {
+        column: { id: 'test1', type: 'CUSTOM_BADGE' },
+        record: {},
+        value: 'badge value',
+      };
+
+      const specialProps: CellRendererProps<string> = {
+        column: { id: 'test2', type: 'CUSTOM_SPECIAL' },
+        record: {},
+        value: 'special value',
+      };
+
+      render(
+        <div>
+          <TestCellRenderer props={badgeProps} />
+          <TestCellRenderer props={specialProps} />
+        </div>,
+        buildWrapper([
+          getBaseProviderWrapper(),
+          getIconProviderWrapper(),
+          getCellProviderWrapper({ renderers }),
+        ])
+      );
+
+      expect(screen.getByText('Badge: badge value')).toBeInTheDocument();
+      expect(screen.getByText('Special: special value')).toBeInTheDocument();
+    });
+
+    it('should fall back to built-in renderers when custom renderer not found', () => {
+      const renderers = {
+        CUSTOM_BADGE: CustomBadgeRenderer,
+      };
+
+      const props: CellRendererProps<boolean> = {
+        column: { id: 'test', type: CellType.BOOLEAN, label: 'Is Active' },
+        record: {},
+        value: true,
+      };
+
+      render(
+        <TestCellRenderer props={props} />,
+        buildWrapper([
+          getBaseProviderWrapper(),
+          getIconProviderWrapper(),
+          getCellProviderWrapper({ renderers }),
+        ])
+      );
+
+      expect(screen.getByText('Is Active')).toBeInTheDocument();
+    });
+
+    it('should prioritize column Cell over provider custom renderers', () => {
+      const ColumnCustomCell: CellRenderer<string> = (props: CellRendererProps<string>) => (
+        <div>Column Custom: {props.value}</div>
+      );
+
+      const renderers = {
+        CUSTOM_BADGE: CustomBadgeRenderer,
+      };
+
+      const props: CellRendererProps<string> = {
+        column: { id: 'test', type: 'CUSTOM_BADGE', Cell: ColumnCustomCell },
+        record: {},
+        value: 'test value',
+      };
+
+      render(
+        <TestCellRenderer props={props} />,
+        buildWrapper([
+          getBaseProviderWrapper(),
+          getIconProviderWrapper(),
+          getCellProviderWrapper({ renderers }),
+        ])
+      );
+
+      expect(screen.getByText('Column Custom: test value')).toBeInTheDocument();
+      expect(screen.queryByTestId('custom-badge')).not.toBeInTheDocument();
+    });
+
+    it('should prioritize provider custom renderers over built-in renderers', () => {
+      const CustomTextRenderer: CellRenderer<string> = (props: CellRendererProps<string>) => (
+        <div data-testid="custom-text">Custom Text: {props.value}</div>
+      );
+
+      const renderers = {
+        [CellType.TEXT]: CustomTextRenderer,
+      };
+
+      const props: CellRendererProps<string> = {
+        column: { id: 'test', type: CellType.TEXT },
+        record: {},
+        value: 'test value',
+      };
+
+      render(
+        <TestCellRenderer props={props} />,
+        buildWrapper([
+          getBaseProviderWrapper(),
+          getIconProviderWrapper(),
+          getCellProviderWrapper({ renderers }),
+        ])
+      );
+
+      expect(screen.getByTestId('custom-text')).toBeInTheDocument();
+      expect(screen.getByText('Custom Text: test value')).toBeInTheDocument();
+    });
+
+    it('should work with empty renderers', () => {
+      const props: CellRendererProps<string> = {
+        column: { id: 'test', type: CellType.TEXT },
+        record: {},
+        value: 'test value',
+      };
+
+      render(
+        <TestCellRenderer props={props} />,
+        buildWrapper([
+          getBaseProviderWrapper(),
+          getIconProviderWrapper(),
+          getCellProviderWrapper({ renderers: {} }),
+        ])
+      );
+
+      expect(screen.getByText('test value')).toBeInTheDocument();
+    });
+
+    it('should work without CellProvider (backward compatibility)', () => {
+      const props: CellRendererProps<string> = {
+        column: { id: 'test', type: CellType.TEXT },
+        record: {},
+        value: 'test value',
+      };
+
+      render(
+        <TestCellRenderer props={props} />,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
+
+      expect(screen.getByText('test value')).toBeInTheDocument();
+    });
+
+    it('should maintain URL detection with custom renderers present', () => {
+      const renderers = {
+        CUSTOM_BADGE: CustomBadgeRenderer,
+      };
+
+      const props: CellRendererProps<string> = {
+        column: { id: 'test' },
+        record: {},
+        value: 'https://example.com',
+      };
+
+      render(
+        <TestCellRenderer props={props} />,
+        buildWrapper([
+          getBaseProviderWrapper(),
+          getIconProviderWrapper(),
+          getCellProviderWrapper({ renderers }),
+        ])
+      );
+
+      const link = screen.getByRole('link');
+      expect(link).toHaveAttribute('href', 'https://example.com');
+      expect(link).toHaveTextContent('Click here');
+    });
+
+    it('should handle undefined renderers gracefully', () => {
+      const props: CellRendererProps<string> = {
+        column: { id: 'test', type: CellType.TEXT },
+        record: {},
+        value: 'test value',
+      };
+
+      render(
+        <TestCellRenderer props={props} />,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getCellProviderWrapper()])
+      );
+
+      expect(screen.getByText('test value')).toBeInTheDocument();
+    });
   });
 });

--- a/javascript/packages/core/components/cell/use-get-cell-renderer.tsx
+++ b/javascript/packages/core/components/cell/use-get-cell-renderer.tsx
@@ -4,12 +4,15 @@ import { CELL_RENDERERS } from '#core/components/cell/constants';
 import { TextCell } from '#core/components/cell/renderers/text/text-cell';
 import { CellRenderer, CellRendererProps } from '#core/components/cell/types';
 import { Link } from '#core/components/link/link';
+import { useCellProvider } from '#core/providers/cell-provider/use-cell-provider';
 import { CellType } from './constants';
 
 /**
  * @returns A function that returns a cell renderer for a given column.
  */
 export function useGetCellRenderer(): (args: CellRendererProps<unknown>) => CellRenderer<unknown> {
+  const cellContext = useCellProvider();
+
   return (args: CellRendererProps<unknown>) => {
     const { column, value } = args;
 
@@ -19,6 +22,11 @@ export function useGetCellRenderer(): (args: CellRendererProps<unknown>) => Cell
     }
 
     const columnType = getType(args);
+
+    if (columnType && cellContext?.renderers[columnType]) {
+      return cellContext.renderers[columnType];
+    }
+
     if (columnType && columnType in CELL_RENDERERS) {
       return CELL_RENDERERS[columnType];
     }

--- a/javascript/packages/core/index.tsx
+++ b/javascript/packages/core/index.tsx
@@ -97,3 +97,8 @@ export * from '#core/utils/time-utils';
 
 export * from '#core/types/common/studio-types';
 export * from '#core/types/common/view-types';
+
+// Cell Provider
+export { CellProvider } from '#core/providers/cell-provider/cell-provider';
+export { useCellProvider } from '#core/providers/cell-provider/use-cell-provider';
+export type { CellContextType } from '#core/providers/cell-provider/types';

--- a/javascript/packages/core/package.json
+++ b/javascript/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uber/michelangelo-core",
   "license": "UNLICENSED",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "type": "module",
   "main": "./dist/michelangelo-core.js",
   "module": "./dist/michelangelo-core.js",

--- a/javascript/packages/core/providers/cell-provider/cell-context.ts
+++ b/javascript/packages/core/providers/cell-provider/cell-context.ts
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+import type { CellContextType } from './types';
+
+export const CellContext = createContext<CellContextType | null>(null);

--- a/javascript/packages/core/providers/cell-provider/cell-provider.tsx
+++ b/javascript/packages/core/providers/cell-provider/cell-provider.tsx
@@ -1,0 +1,31 @@
+import { CellContext } from './cell-context';
+
+import type { CellContextType } from './types';
+
+/**
+ * @description
+ * Provider component that allows consumers to register custom cell renderers.
+ * These custom renderers will be checked before falling back to built-in renderers.
+ *
+ * @example
+ * ```tsx
+ * const customRenderers = {
+ *   'CUSTOM_BADGE': MyBadgeRenderer,
+ *   'SPECIAL_TYPE': MySpecialRenderer
+ * };
+ *
+ * <CellProvider renderers={customRenderers}>
+ *   <MyTable />
+ * </CellProvider>
+ * ```
+ */
+export const CellProvider = ({
+  children,
+  renderers = {},
+}: { children: React.ReactNode } & Partial<CellContextType>) => {
+  const contextValue: CellContextType = {
+    renderers,
+  };
+
+  return <CellContext.Provider value={contextValue}>{children}</CellContext.Provider>;
+};

--- a/javascript/packages/core/providers/cell-provider/types.ts
+++ b/javascript/packages/core/providers/cell-provider/types.ts
@@ -1,0 +1,24 @@
+import type { CellRenderer } from '#core/components/cell/types';
+
+/**
+ * @description
+ * The cell context provided to the application to extend built-in cell renderers
+ * with custom ones. Custom renderers are checked first before falling back to
+ * built-in behavior.
+ */
+export type CellContextType = {
+  /**
+   * @description
+   * Custom cell renderers that extend the built-in CELL_RENDERERS.
+   * These will be checked first before falling back to default behavior.
+   *
+   * @example
+   * ```tsx
+   * const renderers = {
+   *   'CUSTOM_BADGE': MyBadgeRenderer,
+   *   'SPECIAL_TYPE': MySpecialRenderer
+   * };
+   * ```
+   */
+  renderers: Record<string, CellRenderer<unknown>>;
+};

--- a/javascript/packages/core/providers/cell-provider/use-cell-provider.tsx
+++ b/javascript/packages/core/providers/cell-provider/use-cell-provider.tsx
@@ -1,0 +1,7 @@
+import { useContext } from 'react';
+
+import { CellContext } from './cell-context';
+
+export const useCellProvider = () => {
+  return useContext(CellContext);
+};

--- a/javascript/packages/core/test/wrappers/get-cell-provider-wrapper.tsx
+++ b/javascript/packages/core/test/wrappers/get-cell-provider-wrapper.tsx
@@ -1,0 +1,11 @@
+import { CellRenderer } from '#core/components/cell/types';
+import { CellProvider } from '#core/providers/cell-provider/cell-provider';
+import { WrapperComponentProps } from './types';
+
+export function getCellProviderWrapper({
+  renderers = {},
+}: { renderers?: Record<string, CellRenderer<unknown>> } = {}) {
+  return function CellProviderWrapper({ children }: WrapperComponentProps) {
+    return <CellProvider renderers={renderers}>{children}</CellProvider>;
+  };
+}


### PR DESCRIPTION
Previous cell rendering system only supported built-in CELL_RENDERERS
mapping, which blocked consumers from extending the library with custom
cell types without forking the core constants. This created a limitation
for applications needing domain-specific cell renderers while still
leveraging the library's cell rendering infrastructure.

This change introduces CellProvider following the established provider
pattern in /providers, allowing consumers to register custom renderers
via a `renderers` prop that extends built-in functionality. The provider
integrates with the refactored useGetCellRenderer hook to check custom
renderers before falling back to built-in behavior, maintaining full
backward compatibility for existing consumers.

The solution enables extensible cell rendering architecture while
preserving the existing priority chain: column Cell config → provider
custom renderers → built-in CELL_RENDERERS → URL detection → TextCell.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
