### PR TITLE
set DEFAULT_RETRY_ATTEMPTS = 0

### DIFF
--- a/python/michelangelo/uniflow/core/decorator.py
+++ b/python/michelangelo/uniflow/core/decorator.py
@@ -29,7 +29,7 @@ task_context = threading.local()
 task_context.config = None
 task_context.alias = None
 
-DEFAULT_RETRY_ATTEMPTS = 1
+DEFAULT_RETRY_ATTEMPTS = 0
 
 
 class TaskFunction(Generic[P, R]):

--- a/python/tests/uniflow/core/test_decorator.py
+++ b/python/tests/uniflow/core/test_decorator.py
@@ -168,7 +168,7 @@ class TaskTest(unittest.TestCase):
         exp = generate_random_text._transpile(deps)
 
         # Ensure that the @task "config" properties are included in the transpiled expression.
-        task_params = "cpu=2, memory='1g', spot_instance=False, cache_enabled=False, cache_version=None, retry_attempts=1"
+        task_params = "cpu=2, memory='1g', spot_instance=False, cache_enabled=False, cache_version=None, retry_attempts=0"
         expected_str = f"__task_a('test_decorator.generate_random_text', {task_params})"
         self.assertEqual(
             expected_str,
@@ -189,7 +189,7 @@ class TaskTest(unittest.TestCase):
         exp = gzip_compress._transpile(deps)
 
         # Ensure that the "alias" property is included in the transpiled expression.
-        task_params = "alias='gzip', cpu=4, memory='1g', spot_instance=False, cache_enabled=False, cache_version=None, retry_attempts=1"
+        task_params = "alias='gzip', cpu=4, memory='1g', spot_instance=False, cache_enabled=False, cache_version=None, retry_attempts=0"
         expected_str = f"__task_a('test_decorator.gzip_compress', {task_params})"
         self.assertEqual(
             expected_str,


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

change the DEFAULT_RETRY_ATTEMPTS from 1 to 0 
After discussion with Sally and Andrii
the final decision is to make total_attempt = 1 + retry_attempt 
instead of total_attempt = retry_attempt 

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
