### PR TITLE
Add safeStringify to display meaningful object content

### DIFF
--- a/javascript/packages/core/utils/__tests__/string-utils.tests.ts
+++ b/javascript/packages/core/utils/__tests__/string-utils.tests.ts
@@ -1,4 +1,9 @@
-import { capitalizeFirstLetter, isAbsoluteURL, sentenceCaseEnumValue } from '../string-utils';
+import {
+  capitalizeFirstLetter,
+  isAbsoluteURL,
+  safeStringify,
+  sentenceCaseEnumValue,
+} from '../string-utils';
 
 describe('capitalizeFirstLetter', () => {
   it('should capitalize the first letter of the string', () => {
@@ -70,5 +75,144 @@ describe('sentenceCaseEnumValue', () => {
 
   it('should handle string with no underscores', () => {
     expect(sentenceCaseEnumValue('HELLO', '')).toBe('Hello');
+  });
+});
+
+describe('safeStringify', () => {
+  describe('strings', () => {
+    it('should return strings unchanged', () => {
+      expect(safeStringify('hello world')).toBe('hello world');
+      expect(safeStringify('')).toBe('');
+      expect(safeStringify('already a string')).toBe('already a string');
+    });
+  });
+
+  describe('objects', () => {
+    it('should JSON.stringify simple objects', () => {
+      expect(safeStringify({ code: 500, message: 'Error' })).toBe('{"code":500,"message":"Error"}');
+      expect(safeStringify({ name: 'John', age: 30 })).toBe('{"name":"John","age":30}');
+    });
+
+    it('should handle empty objects', () => {
+      expect(safeStringify({})).toBe('{}');
+    });
+
+    it('should handle nested objects', () => {
+      const nested = { user: { name: 'John', profile: { age: 30 } } };
+      expect(safeStringify(nested)).toBe('{"user":{"name":"John","profile":{"age":30}}}');
+    });
+
+    it('should handle circular references gracefully', () => {
+      const circular: Record<string, unknown> = { name: 'test' };
+      circular.self = circular;
+
+      // Should fall back to String() without throwing
+      expect(safeStringify(circular)).toBe('[object Object]');
+    });
+  });
+
+  describe('arrays', () => {
+    it('should JSON.stringify arrays', () => {
+      expect(safeStringify([1, 2, 3])).toBe('[1,2,3]');
+      expect(safeStringify(['a', 'b', 'c'])).toBe('["a","b","c"]');
+      expect(safeStringify([{ id: 1 }, { id: 2 }])).toBe('[{"id":1},{"id":2}]');
+    });
+
+    it('should handle empty arrays', () => {
+      expect(safeStringify([])).toBe('[]');
+    });
+
+    it('should handle mixed type arrays', () => {
+      expect(safeStringify([1, 'text', true, null])).toBe('[1,"text",true,null]');
+    });
+  });
+
+  describe('primitives', () => {
+    it('should handle numbers', () => {
+      expect(safeStringify(42)).toBe('42');
+      expect(safeStringify(0)).toBe('0');
+      expect(safeStringify(-123)).toBe('-123');
+      expect(safeStringify(3.14)).toBe('3.14');
+    });
+
+    it('should handle booleans', () => {
+      expect(safeStringify(true)).toBe('true');
+      expect(safeStringify(false)).toBe('false');
+    });
+
+    it('should handle null and undefined', () => {
+      expect(safeStringify(null)).toBe('null');
+      expect(safeStringify(undefined)).toBe('undefined');
+    });
+
+    it('should handle special numbers -- fallsback to JSON.stringify behavior', () => {
+      expect(safeStringify(Infinity)).toBe('null');
+      expect(safeStringify(-Infinity)).toBe('null');
+      expect(safeStringify(NaN)).toBe('null');
+    });
+  });
+
+  describe('edge cases that trigger fallback', () => {
+    it('should handle BigInt by falling back to String()', () => {
+      const result = safeStringify(BigInt(123));
+      expect(result).toBe('123');
+    });
+
+    it('should handle Symbols by falling back to String()', () => {
+      const sym = Symbol('test');
+      const result = safeStringify(sym);
+      expect(result).toBe('Symbol(test)');
+    });
+
+    it('should handle functions by falling back to String()', () => {
+      const fn = function testFunction() {
+        return 'test';
+      };
+      const result = safeStringify(fn);
+      expect(result).toContain('function testFunction');
+    });
+
+    it('should handle Date objects', () => {
+      const date = new Date('2023-01-01T00:00:00.000Z');
+      expect(safeStringify(date)).toBe('"2023-01-01T00:00:00.000Z"');
+    });
+
+    it('should handle RegExp objects', () => {
+      const regex = /test/gi;
+      expect(safeStringify(regex)).toBe('{}'); // RegExp JSON.stringify to {}
+    });
+
+    it('should handle Error objects', () => {
+      const error = new Error('Test error');
+      expect(safeStringify(error)).toBe('{}'); // Error objects JSON.stringify to {}
+    });
+  });
+
+  describe('complex scenarios', () => {
+    it('should handle objects with JSON.stringify edge cases', () => {
+      const complex = {
+        string: 'hello',
+        number: 42,
+        boolean: true,
+        nullValue: null,
+        undefinedValue: undefined, // This will be omitted in JSON.stringify
+        array: [1, 2, 3],
+        nested: { inner: 'value' },
+      };
+
+      // undefined properties are omitted in JSON.stringify
+      expect(safeStringify(complex)).toBe(
+        '{"string":"hello","number":42,"boolean":true,"nullValue":null,"array":[1,2,3],"nested":{"inner":"value"}}'
+      );
+    });
+
+    it('should handle arrays with undefined and null', () => {
+      expect(safeStringify([1, undefined, null, 3])).toBe('[1,null,null,3]');
+    });
+
+    it('should handle deeply nested structures', () => {
+      const deep = { level1: { level2: { level3: { value: 'deep' } } } };
+      expect(safeStringify(deep)).toBe('{"level1":{"level2":{"level3":{"value":"deep"}}}}');
+    });
   });
 });

--- a/javascript/packages/core/utils/string-utils.ts
+++ b/javascript/packages/core/utils/string-utils.ts
@@ -54,3 +54,32 @@ export const sentenceCaseEnumValue = (
     enumValue.replace(enumPrefixRegExp, '').replace(/_/g, ' ').toLowerCase()
   );
 };
+
+/**
+ * @description
+ * Safely convert any value to a string, with JSON.stringify for objects.
+ * Handles edge cases like circular references, BigInt, and undefined values.
+ *
+ * @param value - The value to convert to a string
+ * @returns A string representation of the value
+ *
+ * @example
+ * ```ts
+ * safeStringify('already a string'); // 'already a string'
+ * safeStringify({ code: 500, message: 'Error' }); // '{"code":500,"message":"Error"}'
+ * safeStringify([1, 2, 3]); // '[1,2,3]'
+ * safeStringify(undefined); // 'undefined'
+ * safeStringify(circularRef); // '[object Object]' (fallback)
+ * ```
+ */
+export function safeStringify(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}


### PR DESCRIPTION
This utility will be used to handle "unknown" object content when parsing messages from errors. In particular, we cannot just use String() conversion on unknown values, since objects will be displayed as [object Object]. Additionally, we need to defensively using JSON.stringify() to avoid circular references.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
