### PR TITLE
Enable RPC framework compatibility through error normalization

### DIFF
--- a/javascript/packages/core/constants/grpc-status-codes.ts
+++ b/javascript/packages/core/constants/grpc-status-codes.ts
@@ -1,0 +1,23 @@
+/**
+ * gRPC status codes used as universal error codes
+ * @see https://grpc.github.io/grpc/core/md_doc_statuscodes.html
+ */
+export enum GrpcStatusCode {
+  OK = 0,
+  CANCELLED = 1,
+  UNKNOWN = 2,
+  INVALID_ARGUMENT = 3,
+  DEADLINE_EXCEEDED = 4,
+  NOT_FOUND = 5,
+  ALREADY_EXISTS = 6,
+  PERMISSION_DENIED = 7,
+  RESOURCE_EXHAUSTED = 8,
+  FAILED_PRECONDITION = 9,
+  ABORTED = 10,
+  OUT_OF_RANGE = 11,
+  UNIMPLEMENTED = 12,
+  INTERNAL = 13,
+  UNAVAILABLE = 14,
+  DATA_LOSS = 15,
+  UNAUTHENTICATED = 16,
+}

--- a/javascript/packages/core/index.tsx
+++ b/javascript/packages/core/index.tsx
@@ -102,3 +102,8 @@ export * from '#core/types/common/view-types';
 export { CellProvider } from '#core/providers/cell-provider/cell-provider';
 export { useCellProvider } from '#core/providers/cell-provider/use-cell-provider';
 export type { CellContextType } from '#core/providers/cell-provider/types';
+
+// Error Provider
+export { ErrorProvider } from '#core/providers/error-provider/error-provider';
+export { useApplicationError } from '#core/providers/error-provider/use-application-error';
+export { GrpcStatusCode } from '#core/constants/grpc-status-codes';

--- a/javascript/packages/core/providers/error-provider/__tests__/error-provider.test.tsx
+++ b/javascript/packages/core/providers/error-provider/__tests__/error-provider.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+
+import { GrpcStatusCode } from '#core/constants/grpc-status-codes';
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getErrorProviderWrapper } from '#core/test/wrappers/get-error-provider-wrapper';
+import { useApplicationError } from '../use-application-error';
+
+import type { ErrorNormalizer } from '#core/types/error-types';
+
+// Test component that uses the error context
+function TestComponent({ error }: { error: unknown }) {
+  const normalizedError = useApplicationError(error);
+
+  if (!normalizedError) {
+    return <div>No error</div>;
+  }
+
+  return <div>{normalizedError.message}</div>;
+}
+
+describe('ErrorProvider', () => {
+  it('should return No error when no error is falsy', () => {
+    render(<TestComponent error={null} />, buildWrapper([getErrorProviderWrapper()]));
+
+    expect(screen.getByText('No error')).toBeInTheDocument();
+  });
+
+  it('should use custom normalizer for application-specific errors', () => {
+    const customNormalizer: ErrorNormalizer = (error: unknown) => {
+      if (typeof error === 'object' && error !== null && 'customType' in error) {
+        return {
+          message: 'Custom handled error',
+          code: GrpcStatusCode.PERMISSION_DENIED,
+          source: 'custom-api',
+        };
+      }
+
+      return null;
+    };
+
+    render(
+      <TestComponent error={{ customType: 'MY_CUSTOM_ERROR' }} />,
+      buildWrapper([getErrorProviderWrapper({ normalizeError: customNormalizer })])
+    );
+
+    expect(screen.getByText('Custom handled error')).toBeInTheDocument();
+  });
+
+  it('should fall back to default when custom normalizer returns null', () => {
+    const customNormalizer: ErrorNormalizer = (error: unknown) => {
+      if (typeof error === 'object' && error !== null && 'customType' in error) {
+        return {
+          message: 'Custom handled error',
+          code: GrpcStatusCode.INVALID_ARGUMENT,
+          source: 'custom-handler',
+        };
+      }
+
+      return null;
+    };
+
+    const regularError = new Error('Regular error');
+
+    render(
+      <TestComponent error={regularError} />,
+      buildWrapper([getErrorProviderWrapper({ normalizeError: customNormalizer })])
+    );
+
+    expect(screen.getByText('Regular error')).toBeInTheDocument();
+    expect(screen.queryByText('Custom handled error')).not.toBeInTheDocument();
+  });
+
+  it('should throw error when used outside provider', () => {
+    expect(() => {
+      render(<TestComponent error={new Error('test')} />);
+    }).toThrow('useErrorSystem must be used within an ErrorProvider');
+  });
+});

--- a/javascript/packages/core/providers/error-provider/__tests__/normalize-universal-error.test.ts
+++ b/javascript/packages/core/providers/error-provider/__tests__/normalize-universal-error.test.ts
@@ -1,0 +1,83 @@
+import { GrpcStatusCode } from '#core/constants/grpc-status-codes';
+import { normalizeUniversalError } from '../normalize-universal-error';
+
+describe('normalizeUniversalError', () => {
+  it('should handle null/undefined errors', () => {
+    expect(normalizeUniversalError(null)).toEqual({
+      message: 'Unknown error occurred',
+      code: GrpcStatusCode.UNKNOWN,
+      source: 'unknown',
+    });
+
+    expect(normalizeUniversalError(undefined)).toEqual({
+      message: 'Unknown error occurred',
+      code: GrpcStatusCode.UNKNOWN,
+      source: 'unknown',
+    });
+  });
+
+  it('should handle native JavaScript errors', () => {
+    const nativeError = new Error('Native error message');
+
+    expect(normalizeUniversalError(nativeError)).toEqual({
+      message: 'Native error message',
+      code: GrpcStatusCode.UNKNOWN,
+      cause: nativeError,
+      source: 'javascript',
+    });
+  });
+
+  it('should handle string errors', () => {
+    expect(normalizeUniversalError('Something went wrong')).toEqual({
+      message: 'Something went wrong',
+      code: GrpcStatusCode.UNKNOWN,
+      source: 'string',
+    });
+  });
+
+  it('should handle generic objects with message property', () => {
+    const errorObj = { message: 'Object error message', code: 500 };
+
+    expect(normalizeUniversalError(errorObj)).toEqual({
+      message: 'Object error message',
+      code: GrpcStatusCode.UNKNOWN,
+      cause: errorObj,
+      source: 'unknown',
+    });
+  });
+
+  it('should handle objects without message property', () => {
+    const errorObj = { code: 500, data: 'some data' };
+
+    expect(normalizeUniversalError(errorObj)).toEqual({
+      message: 'Unknown error occurred',
+      code: GrpcStatusCode.UNKNOWN,
+      meta: { originalError: errorObj },
+      source: 'unknown',
+    });
+  });
+
+  it('should handle primitive values', () => {
+    expect(normalizeUniversalError(42)).toEqual({
+      message: 'Unknown error occurred',
+      code: GrpcStatusCode.UNKNOWN,
+      meta: { originalError: 42 },
+      source: 'unknown',
+    });
+
+    expect(normalizeUniversalError(true)).toEqual({
+      message: 'Unknown error occurred',
+      code: GrpcStatusCode.UNKNOWN,
+      meta: { originalError: true },
+      source: 'unknown',
+    });
+  });
+
+  it('should handle empty string', () => {
+    expect(normalizeUniversalError('')).toEqual({
+      message: '',
+      code: GrpcStatusCode.UNKNOWN,
+      source: 'string',
+    });
+  });
+});

--- a/javascript/packages/core/providers/error-provider/error-context.ts
+++ b/javascript/packages/core/providers/error-provider/error-context.ts
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+import type { ErrorContextValue } from './types';
+
+export const ErrorContext = createContext<ErrorContextValue | null>(null);

--- a/javascript/packages/core/providers/error-provider/error-provider.tsx
+++ b/javascript/packages/core/providers/error-provider/error-provider.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+import { ErrorContext } from './error-context';
+
+import type { ErrorContextValue } from './types';
+
+/**
+ * @description
+ * Provider that provides the system for normalizing errors specific
+ * to the application.
+ *
+ * @remarks
+ * normalizeError is required, but {@link normalizeUniversalError} will be
+ * used as a fallback if normalizeError does not return an {@link ApplicationError}.
+ *
+ * @example
+ * ```tsx
+ * <ErrorProvider normalizeError={(error) => {
+ *   if (error instanceof MyError) {
+ *     return {
+ *       message: error.message,
+ *       code: error.statusCode,
+ *       source: 'MyError',
+ *     };
+ *   }
+ *
+ *   return null; // Fallback to normalizeUniversalError
+ * }}>
+ *   <MyComponent />
+ * </ErrorProvider>
+ *
+ * const applicationError = useApplicationError(myError);
+ * console.log(applicationError);
+ * // { message: myError.message, code: myError.statusCode, source: 'MyError' }
+ * ```
+ */
+export function ErrorProvider({
+  children,
+  ...errorContext
+}: {
+  children: React.ReactNode;
+} & ErrorContextValue) {
+  return <ErrorContext.Provider value={errorContext}>{children}</ErrorContext.Provider>;
+}

--- a/javascript/packages/core/providers/error-provider/normalize-universal-error.ts
+++ b/javascript/packages/core/providers/error-provider/normalize-universal-error.ts
@@ -1,0 +1,66 @@
+import { GrpcStatusCode } from '#core/constants/grpc-status-codes';
+import { safeStringify } from '#core/utils/string-utils';
+
+import type { ApplicationError } from '#core/types/error-types';
+
+/**
+ * Normalizes any error to an {@link ApplicationError}: Michelangelo's standard
+ * error format, modeled after gRPC status codes.
+ *
+ * @param error - The error to normalize
+ * @returns The normalized error or null if the error is null/undefined
+ *
+ * @example
+ * ```ts
+ * const error = new Error('Something went wrong');
+ * const normalizedError = normalizeUniversalError(error);
+ * console.log(normalizedError);
+ * // { message: 'Something went wrong', code: 2, source: 'javascript' }
+ * ```
+ */
+export function normalizeUniversalError(error: unknown): ApplicationError | null {
+  if (error === null || error === undefined) {
+    return {
+      message: 'Unknown error occurred',
+      code: GrpcStatusCode.UNKNOWN,
+      source: 'unknown',
+    };
+  }
+
+  if (error instanceof Error) {
+    return {
+      message: error.message,
+      code: GrpcStatusCode.UNKNOWN,
+      cause: error,
+      source: 'javascript',
+    };
+  }
+
+  if (typeof error === 'string') {
+    return {
+      message: error,
+      code: GrpcStatusCode.UNKNOWN,
+      source: 'string',
+    };
+  }
+
+  if (typeof error === 'object' && error !== null) {
+    const errorObj = error as Record<string, unknown>;
+
+    if (errorObj.message) {
+      return {
+        message: safeStringify(errorObj.message),
+        code: GrpcStatusCode.UNKNOWN,
+        cause: error,
+        source: 'unknown',
+      };
+    }
+  }
+
+  return {
+    message: 'Unknown error occurred',
+    code: GrpcStatusCode.UNKNOWN,
+    meta: { originalError: error },
+    source: 'unknown',
+  };
+}

--- a/javascript/packages/core/providers/error-provider/types.ts
+++ b/javascript/packages/core/providers/error-provider/types.ts
@@ -1,0 +1,5 @@
+import type { ErrorNormalizer } from '#core/types/error-types';
+
+export interface ErrorContextValue {
+  normalizeError: ErrorNormalizer;
+}

--- a/javascript/packages/core/providers/error-provider/use-application-error.ts
+++ b/javascript/packages/core/providers/error-provider/use-application-error.ts
@@ -1,0 +1,26 @@
+import { useContext } from 'react';
+
+import { ErrorContext } from './error-context';
+import { normalizeUniversalError } from './normalize-universal-error';
+
+import type { ApplicationError } from '#core/types/error-types';
+
+/**
+ * Hook to normalize any error to ApplicationError. Must be used within
+ * an {@link ErrorContext}.
+ *
+ * @param error - The error to normalize
+ * @returns The normalized error or null if the error is null/undefined
+ */
+export function useApplicationError(error: unknown): ApplicationError | null {
+  const context = useContext(ErrorContext);
+  if (!context) {
+    throw new Error('useErrorSystem must be used within an ErrorProvider');
+  }
+  const { normalizeError } = context;
+
+  if (!error) return null;
+
+  const normalizedError = normalizeError(error);
+  return normalizedError ?? normalizeUniversalError(error);
+}

--- a/javascript/packages/core/test/wrappers/get-error-provider-wrapper.tsx
+++ b/javascript/packages/core/test/wrappers/get-error-provider-wrapper.tsx
@@ -1,0 +1,47 @@
+import { ErrorProvider } from '#core/providers/error-provider/error-provider';
+import { ErrorContextValue } from '#core/providers/error-provider/types';
+import { WrapperComponentProps } from './types';
+
+/**
+ * Creates a React wrapper for testing components that use error handling features.
+ * This wrapper is essential for testing components that use error hooks
+ * like useErrorSystem, useApplicationError, etc.
+ *
+ * @param errorContext - The error context configuration to use for the error provider
+ * @returns A wrapper component that provides error context to its children
+ *
+ * @example
+ * ```tsx
+ * // Simple usage with a custom normalizer
+ * const customNormalizer = (error: unknown) => {
+ *   if (isMyCustomError(error)) {
+ *     return { message: 'Custom error', code: 7, source: 'custom' };
+ *   }
+ *   return null;
+ * };
+ * const wrapper = getErrorProviderWrapper({ normalizeError: customNormalizer });
+ * render(<MyComponent />, { wrapper });
+ * ```
+ */
+export function getErrorProviderWrapper(errorContext: Partial<ErrorContextValue> = {}) {
+  const defaultNormalizeError = (error: unknown) => {
+    return {
+      message: 'Test error',
+      code: 2,
+      source: 'test',
+      meta: { originalError: error },
+    };
+  };
+
+  const base: ErrorContextValue = {
+    normalizeError: defaultNormalizeError,
+  };
+
+  return function ErrorProviderWrapper({ children }: WrapperComponentProps) {
+    return (
+      <ErrorProvider {...base} {...errorContext}>
+        {children}
+      </ErrorProvider>
+    );
+  };
+}

--- a/javascript/packages/core/types/error-types.ts
+++ b/javascript/packages/core/types/error-types.ts
@@ -1,0 +1,22 @@
+/**
+ * Core error interface that all error types should conform to
+ * Uses gRPC status codes as the universal standard
+ */
+export interface ApplicationError {
+  /** Human-readable error message */
+  message: string;
+  /** Error code - using gRPC codes as the standard */
+  code: number;
+  /** Optional additional context/metadata */
+  meta?: Record<string, unknown>;
+  /** Original error that caused this error */
+  cause?: unknown;
+  /** Error source/framework identifier */
+  source?: string;
+}
+
+/**
+ * Custom error normalizer function type
+ * Applications provide this to handle their specific error types
+ */
+export type ErrorNormalizer = (error: unknown) => ApplicationError | null;

--- a/javascript/packages/core/vitest.config.ts
+++ b/javascript/packages/core/vitest.config.ts
@@ -7,5 +7,6 @@ export default defineConfig({
     globals: true, // Enable global Jest-like functions (describe, it, expect)
     include: ['**/__tests__/**/*.{ts,tsx}'],
     setupFiles: ['./test-setup.ts'],
+    silent: 'passed-only',
   },
 });


### PR DESCRIPTION
Michelangelo internally is tightly coupled to Fusion's RPC error
formats. Open source Michelangelo is not using the Fusion plugin, so we
need to support distinct error interfaces that core components can
handle uniformly.

This establishes universal error normalization that converts any RPC framework's
error format to a common ApplicationError interface. Decouples core library
from specific RPC implementations while allowing applications to inject
framework-specific normalizers for their backend error types.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
