### PR TITLE
[Multiversion] Support syncing multiple CRD versions

### DIFF
--- a/go/api/crd/BUILD.bazel
+++ b/go/api/crd/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
         "@io_k8s_apiextensions_apiserver//pkg/apis/apiextensions/v1:go_default_library",
         "@io_k8s_apiextensions_apiserver//pkg/client/clientset/clientset/fake:go_default_library",
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1/unstructured:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime/schema:go_default_library",

--- a/go/api/crd/gateway.go
+++ b/go/api/crd/gateway.go
@@ -62,8 +62,13 @@ func NewCRDGateway(p GatewayParams) Gateway {
 }
 
 // ConditionalUpsert create or update CRD, also check for CRD compatibility before update
-func (r *gateway) ConditionalUpsert(ctx context.Context, crd *apiextv1.CustomResourceDefinition, enableIncompatibleUpdate bool) error {
+func (r *gateway) ConditionalUpsert(
+	ctx context.Context,
+	crd *apiextv1.CustomResourceDefinition,
+	enableIncompatibleUpdate bool) error {
 	r.logger.Info("Get CRD schema from k8s server.", zap.String("name", crd.Name))
+
+	// get existing CRDs in the cluster
 	crdOnServer, err := r.apiExtClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, crd.Name, metav1.GetOptions{})
 	if err != nil {
 		// directly update if CRD not found
@@ -85,6 +90,23 @@ func (r *gateway) ConditionalUpsert(ctx context.Context, crd *apiextv1.CustomRes
 		e := fmt.Errorf("failed to get CRD %s: %w", crd.Name, err)
 		r.logger.Error(e.Error())
 		return e
+	}
+
+	// return error if there are CRD versions that are in the cluster but is not in the corresponding new CRDs,
+	// as we don't currently support removing versions of CRDs in the cluster
+	for _, v := range crdOnServer.Spec.Versions {
+		find := false
+		for _, newV := range crd.Spec.Versions {
+			if v.Name == newV.Name {
+				find = true
+				break
+			}
+		}
+		if !find {
+			e := fmt.Errorf("CRD %s has version %s that is not in the new CRD", crd.Name, v.Name)
+			r.logger.Error(e.Error())
+			return e
+		}
 	}
 
 	// Compare change, then apply update conditionally
@@ -109,9 +131,8 @@ func (r *gateway) ConditionalUpsert(ctx context.Context, crd *apiextv1.CustomRes
 		}
 	}
 
-	// k8s use ResourceVersion for concurrency control
 	r.logger.Info("Update CRD definition.", zap.String("name", crd.Name))
-	crd.ResourceVersion = crdOnServer.ResourceVersion
+	crd.ResourceVersion = crdOnServer.ResourceVersion // for k8s concurrency control
 	updatedCRD, err := r.apiExtClient.ApiextensionsV1().CustomResourceDefinitions().Update(
 		ctx,
 		crd,
@@ -120,7 +141,7 @@ func (r *gateway) ConditionalUpsert(ctx context.Context, crd *apiextv1.CustomRes
 	if err != nil {
 		return err
 	}
-	r.logger.Info("CRD updated successfully to version", zap.String("name", updatedCRD.Name), zap.String("version", updatedCRD.ResourceVersion))
+	r.logger.Info("CRD updated", zap.String("name", updatedCRD.Name))
 	return nil
 }
 

--- a/go/api/crd/gateway_test.go
+++ b/go/api/crd/gateway_test.go
@@ -244,6 +244,38 @@ func TestConditionalUpsert(t *testing.T) {
 		err = crdGateway.ConditionalUpsert(ctx, crd, false)
 		assert.Error(t, err, "failed to get CRD project.test: test error")
 	})
+
+	t.Run("test upsert CRD with missing version in new CRD", func(t *testing.T) {
+		// Prepare existing CRD with multiple versions
+		crd, err := readCRDFromFile(testCRDManifestDir + "/project.pb.yaml")
+		assert.NotNil(t, crd)
+		assert.NoError(t, err)
+
+		// Create existing CRD with two versions
+		existingCRD := crd.DeepCopy()
+		existingCRD.Spec.Versions = append(existingCRD.Spec.Versions, apiextv1.CustomResourceDefinitionVersion{
+			Name:    "v1",
+			Served:  true,
+			Storage: false,
+			Schema:  existingCRD.Spec.Versions[0].Schema,
+		})
+
+		apiExtClientStub := apiExtFake.NewSimpleClientset(existingCRD)
+		crdGateway := gateway{
+			logger:        zap.NewExample(),
+			apiExtClient:  apiExtClientStub,
+			dynamicClient: fakeClientNoResource,
+		}
+
+		// Action: Try to upsert with only one version (missing v1)
+		ctx := context.Background()
+		newCRD := crd.DeepCopy() // Only has v0, missing v1 that exists on server
+		err = crdGateway.ConditionalUpsert(ctx, newCRD, false)
+
+		// Assert: Should fail because v1 version exists on server but not in new CRD
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "has version v1 that is not in the new CRD")
+	})
 }
 
 func TestList(t *testing.T) {

--- a/go/api/crd/schema_diff.go
+++ b/go/api/crd/schema_diff.go
@@ -1,6 +1,7 @@
 package crd
 
 import (
+	"fmt"
 	"reflect"
 
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -45,7 +46,7 @@ type schemaDiff struct {
 }
 
 // newSchemaDiff compare two JSONSchemaProps and return the diff
-func newSchemaDiff(old *apiextv1.JSONSchemaProps, new *apiextv1.JSONSchemaProps) (*schemaDiff, error) {
+func newSchemaDiff(old *apiextv1.JSONSchemaProps, new *apiextv1.JSONSchemaProps) *schemaDiff {
 	diff := schemaDiff{}
 
 	if old == nil {
@@ -61,10 +62,7 @@ func newSchemaDiff(old *apiextv1.JSONSchemaProps, new *apiextv1.JSONSchemaProps)
 	}
 
 	if old.Properties != nil || new.Properties != nil {
-		propertiesDiff, err := newSchemaObjectDiff(old.Properties, new.Properties)
-		if err != nil {
-			return nil, err
-		}
+		propertiesDiff := newSchemaObjectDiff(old.Properties, new.Properties)
 		diff.propertiesDiff = propertiesDiff
 	}
 
@@ -77,44 +75,32 @@ func newSchemaDiff(old *apiextv1.JSONSchemaProps, new *apiextv1.JSONSchemaProps)
 		if new.Items != nil {
 			newItemSchema = new.Items.Schema
 		}
-		itemsDiff, err := newSchemaDiff(oldItemSchema, newItemSchema)
-		if err != nil {
-			return nil, err
-		}
+		itemsDiff := newSchemaDiff(oldItemSchema, newItemSchema)
 		diff.itemsDiff = itemsDiff
 	}
 
 	if old.OneOf != nil || new.OneOf != nil {
-		oneOfDiff, err := newSchemaArrayDiff(old.OneOf, new.OneOf)
-		if err != nil {
-			return nil, err
-		}
+		oneOfDiff := newSchemaArrayDiff(old.OneOf, new.OneOf)
 		diff.oneOfDiff = oneOfDiff
 	}
 
 	if old.AnyOf != nil || new.AnyOf != nil {
-		anyOfDiff, err := newSchemaArrayDiff(old.AnyOf, new.AnyOf)
-		if err != nil {
-			return nil, err
-		}
+		anyOfDiff := newSchemaArrayDiff(old.AnyOf, new.AnyOf)
 		diff.anyOfDiff = anyOfDiff
 	}
 
 	if old.AllOf != nil || new.AllOf != nil {
-		allOfDiff, err := newSchemaArrayDiff(old.AllOf, new.AllOf)
-		if err != nil {
-			return nil, err
-		}
+		allOfDiff := newSchemaArrayDiff(old.AllOf, new.AllOf)
 		diff.allOfDiff = allOfDiff
 	}
 
 	// return nil if no diff exists
 	emptyDiff := schemaDiff{}
 	if diff == emptyDiff {
-		return nil, nil
+		return nil
 	}
 
-	return &diff, nil
+	return &diff
 }
 
 // Following changes are not compatible for a schema
@@ -161,7 +147,7 @@ type schemaArrayDiff struct {
 }
 
 // newSchemaArrayDiff compares two arrays of JSON property schemas
-func newSchemaArrayDiff(old []apiextv1.JSONSchemaProps, new []apiextv1.JSONSchemaProps) (*schemaArrayDiff, error) {
+func newSchemaArrayDiff(old []apiextv1.JSONSchemaProps, new []apiextv1.JSONSchemaProps) *schemaArrayDiff {
 
 	var deletedProps []*apiextv1.JSONSchemaProps
 	var addedProps []*apiextv1.JSONSchemaProps
@@ -173,10 +159,7 @@ func newSchemaArrayDiff(old []apiextv1.JSONSchemaProps, new []apiextv1.JSONSchem
 			continue
 		}
 
-		diff, err := newSchemaDiff(&old[i], &new[i])
-		if err != nil {
-			return nil, err
-		}
+		diff := newSchemaDiff(&old[i], &new[i])
 		if diff != nil {
 			modifiedProps = append(modifiedProps, diff)
 		}
@@ -187,10 +170,10 @@ func newSchemaArrayDiff(old []apiextv1.JSONSchemaProps, new []apiextv1.JSONSchem
 	}
 
 	if len(deletedProps) > 0 || len(addedProps) > 0 || len(modifiedProps) > 0 {
-		return &schemaArrayDiff{deleted: deletedProps, added: addedProps, modified: modifiedProps}, nil
+		return &schemaArrayDiff{deleted: deletedProps, added: addedProps, modified: modifiedProps}
 	}
 
-	return nil, nil
+	return nil
 }
 
 func (d *schemaArrayDiff) compatible() bool {
@@ -220,7 +203,7 @@ type schemaObjectDiff struct {
 	modified map[string]*schemaDiff
 }
 
-func newSchemaObjectDiff(old map[string]apiextv1.JSONSchemaProps, new map[string]apiextv1.JSONSchemaProps) (*schemaObjectDiff, error) {
+func newSchemaObjectDiff(old map[string]apiextv1.JSONSchemaProps, new map[string]apiextv1.JSONSchemaProps) *schemaObjectDiff {
 
 	deletedProps := make(map[string]*apiextv1.JSONSchemaProps)
 	addedProps := make(map[string]*apiextv1.JSONSchemaProps)
@@ -232,10 +215,7 @@ func newSchemaObjectDiff(old map[string]apiextv1.JSONSchemaProps, new map[string
 			continue
 		}
 
-		diff, err := newSchemaDiff(&oldValue, &newValue)
-		if err != nil {
-			return nil, err
-		}
+		diff := newSchemaDiff(&oldValue, &newValue)
 
 		if diff != nil {
 			modifiedProps[key] = diff
@@ -255,10 +235,10 @@ func newSchemaObjectDiff(old map[string]apiextv1.JSONSchemaProps, new map[string
 			deleted:  deletedProps,
 			added:    addedProps,
 			modified: modifiedProps,
-		}, nil
+		}
 	}
 
-	return nil, nil
+	return nil
 }
 
 func (d *schemaObjectDiff) compatible() bool {
@@ -335,15 +315,11 @@ func isSpecChangeCompatible(oldCRD *apiextv1.CustomResourceDefinition, newCRD *a
 	for k, oldVersion := range oldVersions {
 		newVersion, present := newVersions[k]
 		if !present {
-			// Allow deleting old CRD version
-			continue
+			return false, fmt.Errorf("CRD %s has version %s that is not in the new CRD", oldCRD.Name, k)
 		}
 
 		// compare the two schemas with the same version name
-		diff, err := newSchemaDiff(oldVersion.Schema.OpenAPIV3Schema, newVersion.Schema.OpenAPIV3Schema)
-		if err != nil {
-			return false, err
-		}
+		diff := newSchemaDiff(oldVersion.Schema.OpenAPIV3Schema, newVersion.Schema.OpenAPIV3Schema)
 
 		if diff != nil && !diff.compatible() {
 			return false, nil

--- a/go/api/crd/schema_diff_test.go
+++ b/go/api/crd/schema_diff_test.go
@@ -7,6 +7,7 @@ import (
 
 	assertion "github.com/stretchr/testify/assert"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
@@ -43,6 +44,150 @@ func TestSchemaDiff(t *testing.T) {
 		assertion.Equal(t, test.HasChange, diff.hasChange, test.Name)
 		assertion.Equal(t, test.Compatible, diff.compatible, test.Name)
 	}
+}
+
+func TestIsSpecChangeCompatible(t *testing.T) {
+	// Helper function to create a basic CRD version
+	createVersion := func(name string, storage bool, propertyType string) apiextv1.CustomResourceDefinitionVersion {
+		return apiextv1.CustomResourceDefinitionVersion{
+			Name:    name,
+			Served:  true,
+			Storage: storage,
+			Schema: &apiextv1.CustomResourceValidation{
+				OpenAPIV3Schema: &apiextv1.JSONSchemaProps{
+					Type: "object",
+					Properties: map[string]apiextv1.JSONSchemaProps{
+						"spec": {
+							Type: "object",
+							Properties: map[string]apiextv1.JSONSchemaProps{
+								"testProperty": {
+									Type: propertyType,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	// Helper function to create a CRD with given versions
+	createCRD := func(name string, versions ...apiextv1.CustomResourceDefinitionVersion) *apiextv1.CustomResourceDefinition {
+		return &apiextv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+			Spec: apiextv1.CustomResourceDefinitionSpec{
+				Versions: versions,
+			},
+		}
+	}
+
+	t.Run("no changes - same versions", func(t *testing.T) {
+		oldCRD := createCRD("test.example.com", createVersion("v1", true, "string"))
+		newCRD := createCRD("test.example.com", createVersion("v1", true, "string"))
+
+		compatible, err := isSpecChangeCompatible(oldCRD, newCRD)
+		assertion.NoError(t, err)
+		assertion.True(t, compatible)
+	})
+
+	t.Run("compatible - adding new version", func(t *testing.T) {
+		oldCRD := createCRD("test.example.com", createVersion("v1", true, "string"))
+		newCRD := createCRD("test.example.com",
+			createVersion("v1", false, "string"),
+			createVersion("v2", true, "string"))
+
+		compatible, err := isSpecChangeCompatible(oldCRD, newCRD)
+		assertion.NoError(t, err)
+		assertion.True(t, compatible)
+	})
+
+	t.Run("compatible - adding property to existing version", func(t *testing.T) {
+		oldCRD := createCRD("test.example.com", createVersion("v1", true, "string"))
+
+		// Create new CRD with additional property
+		newVersion := createVersion("v1", true, "string")
+		newVersion.Schema.OpenAPIV3Schema.Properties["spec"].Properties["newProperty"] = apiextv1.JSONSchemaProps{
+			Type: "integer",
+		}
+		newCRD := createCRD("test.example.com", newVersion)
+
+		compatible, err := isSpecChangeCompatible(oldCRD, newCRD)
+		assertion.NoError(t, err)
+		assertion.True(t, compatible)
+	})
+
+	t.Run("incompatible - removing existing version", func(t *testing.T) {
+		oldCRD := createCRD("test.example.com",
+			createVersion("v1", false, "string"),
+			createVersion("v2", true, "string"))
+		newCRD := createCRD("test.example.com", createVersion("v2", true, "string"))
+
+		compatible, err := isSpecChangeCompatible(oldCRD, newCRD)
+		assertion.Error(t, err)
+		assertion.False(t, compatible)
+		assertion.Contains(t, err.Error(), "has version v1 that is not in the new CRD")
+	})
+
+	t.Run("incompatible - changing property type", func(t *testing.T) {
+		oldCRD := createCRD("test.example.com", createVersion("v1", true, "string"))
+		newCRD := createCRD("test.example.com", createVersion("v1", true, "integer"))
+
+		compatible, err := isSpecChangeCompatible(oldCRD, newCRD)
+		assertion.NoError(t, err)
+		assertion.False(t, compatible)
+	})
+
+	t.Run("incompatible - removing property from existing version", func(t *testing.T) {
+		oldCRD := createCRD("test.example.com", createVersion("v1", true, "string"))
+
+		// Create new CRD without testProperty
+		newVersion := createVersion("v1", true, "string")
+		delete(newVersion.Schema.OpenAPIV3Schema.Properties["spec"].Properties, "testProperty")
+		newCRD := createCRD("test.example.com", newVersion)
+
+		compatible, err := isSpecChangeCompatible(oldCRD, newCRD)
+		assertion.NoError(t, err)
+		assertion.False(t, compatible)
+	})
+
+	t.Run("incompatible - new CRD with no versions", func(t *testing.T) {
+		oldCRD := createCRD("test.example.com", createVersion("v1", true, "string"))
+		newCRD := createCRD("test.example.com") // No versions
+
+		compatible, err := isSpecChangeCompatible(oldCRD, newCRD)
+		assertion.NoError(t, err)
+		assertion.False(t, compatible)
+	})
+
+	t.Run("compatible - old CRD with no versions", func(t *testing.T) {
+		oldCRD := createCRD("test.example.com") // No versions
+		newCRD := createCRD("test.example.com", createVersion("v1", true, "string"))
+
+		compatible, err := isSpecChangeCompatible(oldCRD, newCRD)
+		assertion.NoError(t, err)
+		assertion.True(t, compatible)
+	})
+
+	t.Run("compatible - multiple versions with compatible changes", func(t *testing.T) {
+		oldCRD := createCRD("test.example.com",
+			createVersion("v1", false, "string"),
+			createVersion("v2", true, "string"))
+
+		// Add new property to both versions and add v3
+		newV1 := createVersion("v1", false, "string")
+		newV1.Schema.OpenAPIV3Schema.Properties["spec"].Properties["newProp"] = apiextv1.JSONSchemaProps{Type: "integer"}
+		newV2 := createVersion("v2", false, "string")
+		newV2.Schema.OpenAPIV3Schema.Properties["spec"].Properties["newProp"] = apiextv1.JSONSchemaProps{Type: "integer"}
+		newV3 := createVersion("v3", true, "string")
+
+		newCRD := createCRD("test.example.com", newV1, newV2, newV3)
+
+		compatible, err := isSpecChangeCompatible(oldCRD, newCRD)
+		assertion.NoError(t, err)
+		assertion.True(t, compatible)
+	})
 }
 
 func readCRDFromFile(path string) (*apiextv1.CustomResourceDefinition, error) {

--- a/go/api/crd/sync.go
+++ b/go/api/crd/sync.go
@@ -3,7 +3,6 @@ package crd
 import (
 	"context"
 	"fmt"
-	"slices"
 	"strings"
 
 	"github.com/michelangelo-ai/michelangelo/go/api/utils"
@@ -24,9 +23,18 @@ const (
 
 // Configuration crd register configuration
 type Configuration struct {
-	EnableCRDUpdate          bool `yaml:"enableCRDUpdate"`
-	EnableIncompatibleUpdate bool `yaml:"enableIncompatibleUpdate"`
-	EnableCRDDeletion        bool `yaml:"enableCRDDeletion"`
+	EnableCRDUpdate          bool                     `yaml:"enableCRDUpdate"`
+	EnableIncompatibleUpdate bool                     `yaml:"enableIncompatibleUpdate"`
+	EnableCRDDeletion        bool                     `yaml:"enableCRDDeletion"`
+	CRDVersions              map[string]VersionConfig `yaml:"crdVersions"`
+}
+
+// VersionConfig defines how the versions of a CRD will be handled.
+type VersionConfig struct {
+	// Versions is a list of versions of the CRD that will be synced to the cluster.
+	Versions []string `yaml:"versions"`
+	// StorageVersion is the version that will be used as the storage version for the CRD.
+	StorageVersion string `yaml:"storageVersion"`
 }
 
 func ParseConfig(provider config.Provider) (*Configuration, error) {
@@ -36,6 +44,129 @@ func ParseConfig(provider config.Provider) (*Configuration, error) {
 		return nil, err
 	}
 	return &conf, nil
+}
+
+type SyncCRDsParams struct {
+	fx.In
+
+	Lifecycle fx.Lifecycle
+	Config    *Configuration
+	Logger    *zap.Logger
+	Gateway   Gateway
+}
+
+// SyncCRDs syncs CRDs in the specified k8s API group
+//
+// This function is used to ensure that the CRDs in the cluster match the CRDs defined in the yamlSchemas.
+// yamlSchemas is a list of CRD kind (name) to CRD yaml schema map. Each map corresponds to a version of the CRDs.
+//
+// In the specified k8s API group:
+//  1. If Config.enableCRDDeletion is true, for each CRD that is in the k8s cluster but is not in yamlSchemas,
+//     if the CRD does not have any instances in the cluster, the CRD will be deleted, otherwise returns an error.
+//  2. For each CRD that is in yamlSchemas but is not in the cluster, it will be created in the cluster.
+//  3. If multiple versions of the same CRD are defined in yamlSchemas, they will be merged into a single CRD object,
+//     according to the rules defined in Config.CRDVersions.
+//  4. CRDs that do not have a corresponding entry in Config.CRDVersions will be allowed to have only one version.
+//  5. If a CRD has multiple versions in Config.CRDVersions, one of them must be specified as the storage version.
+//  6. For each CRD that is in both yamlSchemas and the cluster, the schema of each matching version will be compared:
+//     If the schema change is backward compatible, the CRD version will be updated
+//     If the schema change is not backward compatible
+//     If enableIncompatibleUpdate is true, the CRD version will be updated
+//     If there is no existing instance in the cluster, the CRD will be updated
+//     Otherwise, it will return an error
+//  7. If a CRD version in the cluster does not have a corresponding entry in yamlSchemas, an error will be returned,
+//     as we don't currently support removing versions of CRDs in the cluster.
+func SyncCRDs(group string, yamlSchemas ...map[string]string) fx.Option {
+	return fx.Invoke(func(p SyncCRDsParams) error {
+		logger := p.Logger.With(zap.String("module", moduleName))
+		logger.Info("CRD sync config", zap.Any("config", p.Config))
+		if p.Config.EnableCRDUpdate {
+			p.Lifecycle.Append(fx.Hook{
+				OnStart: func(ctx context.Context) error {
+					return syncCRDs(ctx, logger, group, p.Config.EnableIncompatibleUpdate, p.Config.EnableCRDDeletion,
+						p.Gateway, p.Config.CRDVersions, yamlSchemas...)
+				},
+				OnStop: nil,
+			})
+		}
+
+		return nil
+	})
+}
+
+func syncCRDs(ctx context.Context,
+	logger *zap.Logger,
+	group string,
+	enableIncompatibleUpdate bool,
+	enableCRDDeletion bool,
+	gateway Gateway,
+	crdVersions map[string]VersionConfig,
+	yamlSchemas ...map[string]string) error {
+
+	// decode CRD yaml schemas into CRD objects
+	var crdList []*apiextv1.CustomResourceDefinition
+	for _, schemaMap := range yamlSchemas {
+		for kind, yamlStr := range schemaMap {
+			crd := apiextv1.CustomResourceDefinition{}
+			err := yaml.NewYAMLToJSONDecoder(strings.NewReader(yamlStr)).Decode(&crd)
+			if err != nil {
+				logger.Error("Fail to deserialize CRD from yaml",
+					zap.String("kind", kind), zap.String("yaml", yamlStr), zap.Error(err))
+				return err
+			}
+			if group != crd.Spec.Group {
+				e := fmt.Errorf("CRD %s is not in the specified group [%v]", crd.Name, group)
+				logger.Error(e.Error())
+				return e
+			}
+			crdList = append(crdList, &crd)
+		}
+	}
+
+	// get existing CRDs in the cluster
+	existingCRDs, err := gateway.List(ctx)
+	if err != nil {
+		logger.Error("Failed to list existing CRDs", zap.Error(err))
+		return err
+	}
+
+	// delete CRDs that are in the cluster but not in crdList
+	for _, crd := range existingCRDs.Items {
+		if group != crd.Spec.Group {
+			continue
+		}
+		found := false
+		for _, newCRD := range crdList {
+			if crd.Name == newCRD.Name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			if enableCRDDeletion {
+				logger.Info("CRD deletion enabled. Delete CRD", zap.String("name", crd.Name))
+				if err = gateway.Delete(ctx, &crd); err != nil && !utils.IsNotFoundError(err) {
+					logger.Error("Fail to delete CRD", zap.String("name", crd.Name), zap.Error(err))
+					return err
+				}
+			} else {
+				logger.Info("CRD deletion disabled. Skip deleting CRD", zap.String("name", crd.Name))
+			}
+		}
+	}
+
+	mergedCRDList, err := mergeCRDVersions(crdList, crdVersions)
+	if err != nil {
+		logger.Error("Failed to merge CRD versions", zap.Error(err))
+		return err
+	}
+
+	// upsert CRDs
+	if err = upsertCRDs(ctx, logger, gateway, mergedCRDList, enableIncompatibleUpdate); err != nil {
+		logger.Error("Failed to upsert CRDs", zap.Error(err))
+		return err
+	}
+	return nil
 }
 
 // upsertCRDs upsert CRD onto k8s cluster, also handle OCC conflict with retry
@@ -66,102 +197,105 @@ func upsertCRDs(ctx context.Context, logger *zap.Logger, gateway Gateway,
 	return nil
 }
 
-type SyncCRDsParams struct {
-	fx.In
-
-	Lifecycle fx.Lifecycle
-	Config    *Configuration
-	Logger    *zap.Logger
-	Gateway   Gateway
-}
-
-// SyncCRDs sync CRDs to k8s cluster
-// yamlSchemas is a list of CRD yaml schemas
+// mergeCRDVersions merges the versions of CRDs in crdList according to the rules specified in crdVersions.
 //
-//	In the specified k8s API groups:
-//	1. For each CRD that is in the cluster but is not in yamlSchemas,
-//	   If the CRD does not have existing instances in the cluster, the CRD will be deleted,
-//	   otherwise returns an error
-//	2. For each CRD that is in yamlSchemas but is not in the cluster, it will be created in the cluster
-//	3. For each CRD that is in both yamlSchemas and the cluster, the schema will be compared
-//	   If the schema change is backward compatible, the CRD will be updated
-//	   If the schema change is not backward compatible
-//	   - If enableIncompatibleUpdate is true, the CRD will be updated
-//	   - If there is no existing instance in the cluster, the CRD will be updated
-//	   - Otherwise, it will return an error
-func SyncCRDs(groups []string, yamlSchemas ...map[string]string) fx.Option {
-	return fx.Invoke(func(p SyncCRDsParams) error {
-		logger := p.Logger.With(zap.String("module", moduleName))
-		logger.Info("CRD sync config", zap.Any("config", p.Config))
-		if p.Config.EnableCRDUpdate {
-			p.Lifecycle.Append(fx.Hook{
-				OnStart: func(ctx context.Context) error {
-					return syncCRDs(ctx, logger, groups, p.Config.EnableIncompatibleUpdate, p.Config.EnableCRDDeletion,
-						p.Gateway, yamlSchemas...)
-				},
-				OnStop: nil,
-			})
+// crdVersions is a map where the key is the CRD name and the value is a VersionConfig. If a CRD in crdList doesn't
+// have a corresponding entry in crdVersions, it will only be allowed to have a single version, and that version will
+// be set as the storage version. If a CRD in crdList has a corresponding entry in crdVersions, all the versions
+// specified in crdVersions[crd.Name].Versions must exist in crdList. If a CRD has multiple versions in
+// crdVersions[crd.Name].Versions, one of them must be specified as the storage version. If a CRD has only one version
+// in crdVersions[crd.Name], that version is automatically set as the storage version.
+//
+// The function returns a list of merged CRDs, where all the versions of each CRD are combined into a single
+// CustomResourceDefinition object. If any of the rules are violated, an error is returned.
+func mergeCRDVersions(
+	crdList []*apiextv1.CustomResourceDefinition,
+	crdVersions map[string]VersionConfig) ([]*apiextv1.CustomResourceDefinition, error) {
+	var result []*apiextv1.CustomResourceDefinition
+	// group CRDs by names and versions
+	crds := make(map[string]map[string]*apiextv1.CustomResourceDefinition)
+	for _, crd := range crdList {
+		if _, exists := crds[crd.Name]; !exists {
+			crds[crd.Name] = make(map[string]*apiextv1.CustomResourceDefinition)
 		}
-
-		return nil
-	})
-}
-
-func syncCRDs(ctx context.Context, logger *zap.Logger, groups []string, enableIncompatibleUpdate bool,
-	enableCRDDeletion bool, gateway Gateway, yamlSchemas ...map[string]string) error {
-
-	var crdList []*apiextv1.CustomResourceDefinition
-	for _, schemaMap := range yamlSchemas {
-		for kind, yamlStr := range schemaMap {
-			crd := apiextv1.CustomResourceDefinition{}
-			err := yaml.NewYAMLToJSONDecoder(strings.NewReader(yamlStr)).Decode(&crd)
-			if err != nil {
-				logger.Error("Fail to deserialize CRD from yaml",
-					zap.String("kind", kind), zap.String("yaml", yamlStr), zap.Error(err))
-				return err
-			}
-			if !slices.Contains(groups, crd.Spec.Group) {
-				e := fmt.Errorf("CRD %s is not in the specified groups [%v]", crd.Name, groups)
-				logger.Error(e.Error())
-				return e
-			}
-			crdList = append(crdList, &crd)
+		if len(crd.Spec.Versions) != 1 {
+			return nil, fmt.Errorf(
+				"each CRD item must only have one version. CRD %s has %d versions",
+				crd.Name, len(crd.Spec.Versions))
 		}
+		if _, exists := crds[crd.Name][crd.Spec.Versions[0].Name]; exists {
+			return nil, fmt.Errorf("CRD %s has duplicated definitions of version %s",
+				crd.Name, crd.Spec.Versions[0].Name)
+		}
+		crds[crd.Name][crd.Spec.Versions[0].Name] = crd
 	}
 
-	existingCRDs, err := gateway.List(ctx)
-	if err != nil {
-		logger.Error("Failed to list existing CRDs", zap.Error(err))
-		return err
-	}
+	// merge versions for each CRD
+	for name, versions := range crds {
+		var mergedCRD *apiextv1.CustomResourceDefinition
+		// check if the CRD has a corresponding entry in crdVersions
+		if versionConfig, exists := crdVersions[name]; exists {
+			// check if the versions in crdVersions match the versions in crds
+			for _, version := range versionConfig.Versions {
+				if _, verExists := versions[version]; !verExists {
+					return nil, fmt.Errorf(
+						"version %s of CRD %s is specified in crdVersions, but does not exist not in crdList",
+						version, name)
+				}
+			}
 
-	for _, crd := range existingCRDs.Items {
-		if !slices.Contains(groups, crd.Spec.Group) {
-			continue
-		}
-		found := false
-		for _, newCRD := range crdList {
-			if crd.Name == newCRD.Name {
-				found = true
+			mergedCRD = versions[versionConfig.Versions[0]].DeepCopy()
+			for _, version := range versionConfig.Versions[1:] {
+				mergedCRD.Spec.Versions = append(mergedCRD.Spec.Versions, versions[version].Spec.Versions[0])
+			}
+
+			storageVersion := versionConfig.StorageVersion
+			if storageVersion == "" {
+				if len(mergedCRD.Spec.Versions) == 1 {
+					mergedCRD.Spec.Versions[0].Storage = true // set storage version
+				} else {
+					return nil, fmt.Errorf(
+						"CRD %s has multiple versions, but no storageVersion specified in crdVersions",
+						name)
+				}
+			} else {
+				foundStorage := false
+				for i, v := range mergedCRD.Spec.Versions {
+					if v.Name == storageVersion {
+						mergedCRD.Spec.Versions[i].Storage = true
+						foundStorage = true
+						break
+					}
+				}
+				if !foundStorage {
+					return nil, fmt.Errorf("CRD %s does not have the specified storage version %s",
+						name, storageVersion)
+				}
+			}
+			// Only set conversion strategy when there are multiple versions
+			if len(mergedCRD.Spec.Versions) > 1 {
+				// TODO: conversion strategy is set to NoneConverter for now,
+				// we will support webhook conversion in the next iteration
+				mergedCRD.Spec.Conversion = &apiextv1.CustomResourceConversion{
+					Strategy: apiextv1.NoneConverter,
+				}
+			}
+		} else {
+			// if the CRD does not have a corresponding entry in crdVersions, it must have only one version
+			// and that version will be set as the storage version
+			if len(versions) > 1 {
+				return nil, fmt.Errorf(
+					"CRD %s has multiple versions but version config specified in crdVersions",
+					name)
+			}
+
+			for _, crd := range versions {
+				mergedCRD = crd.DeepCopy()
+				mergedCRD.Spec.Versions[0].Storage = true // set the only version to be the storage version
 				break
 			}
 		}
-		if !found {
-			if enableCRDDeletion {
-				logger.Info("CRD deletion enabled. Delete CRD", zap.String("name", crd.Name))
-				if err = gateway.Delete(ctx, &crd); err != nil && !utils.IsNotFoundError(err) {
-					logger.Error("Fail to delete CRD", zap.String("name", crd.Name), zap.Error(err))
-					return err
-				}
-			} else {
-				logger.Info("CRD deletion disabled. Skip deleting CRD", zap.String("name", crd.Name))
-			}
-		}
+		result = append(result, mergedCRD)
 	}
-
-	if err = upsertCRDs(ctx, logger, gateway, crdList, enableIncompatibleUpdate); err != nil {
-		logger.Error("Failed to upsert CRDs", zap.Error(err))
-		return err
-	}
-	return nil
+	return result, nil
 }

--- a/go/api/crd/sync_test.go
+++ b/go/api/crd/sync_test.go
@@ -16,6 +16,7 @@ import (
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiExtFake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -94,7 +95,7 @@ func TestSyncCRDsFx(t *testing.T) {
 				EnableIncompatibleUpdate: false,
 			}
 		}),
-		SyncCRDs([]string{"test"}, map[string]string{
+		SyncCRDs("test", map[string]string{
 			"Project": string(crdYaml),
 		}),
 	),
@@ -117,7 +118,7 @@ func TestSyncCRDsFx(t *testing.T) {
 				EnableIncompatibleUpdate: false,
 			}
 		}),
-		SyncCRDs([]string{"test"}, map[string]string{
+		SyncCRDs("test", map[string]string{
 			"Project": string(crdYaml),
 		}),
 	),
@@ -147,7 +148,7 @@ func TestSyncCRDsFx(t *testing.T) {
 				EnableCRDDeletion:        true,
 			}
 		}),
-		SyncCRDs([]string{"test"}, map[string]string{
+		SyncCRDs("test", map[string]string{
 			"Project": string(crdYaml),
 		}),
 	),
@@ -183,7 +184,7 @@ func TestSyncCRDsFx(t *testing.T) {
 		fx.Invoke(func() error {
 			return nil
 		}),
-		SyncCRDs([]string{"test"}, map[string]string{}),
+		SyncCRDs("test", map[string]string{}),
 	),
 	)
 	assert.NoError(t, app.Err())
@@ -212,7 +213,7 @@ func TestSyncCRDsFx(t *testing.T) {
 		fx.Invoke(func() error {
 			return nil
 		}),
-		SyncCRDs([]string{"test"}, map[string]string{}),
+		SyncCRDs("test", map[string]string{}),
 	),
 	)
 	assert.NoError(t, app.Err())
@@ -239,7 +240,7 @@ func TestSyncCRDsFx(t *testing.T) {
 		fx.Invoke(func() error {
 			return nil
 		}),
-		SyncCRDs([]string{"test"}, map[string]string{}),
+		SyncCRDs("test", map[string]string{}),
 	),
 	)
 	assert.NoError(t, app.Err())
@@ -262,28 +263,28 @@ func TestSyncCRDs(t *testing.T) {
 	// new CRD
 	crdYaml, err := os.ReadFile(testCRDManifestDir + "/project.pb.yaml")
 	assert.NoError(t, err)
-	err = syncCRDs(context.Background(), logger, []string{"test"},
-		false, true, &crdGateway, map[string]string{"Project": string(crdYaml)})
+	err = syncCRDs(context.Background(), logger, "test",
+		false, true, &crdGateway, nil, map[string]string{"Project": string(crdYaml)})
 	assert.NoError(t, err)
 
 	// incompatible change
 	crdYaml, err = os.ReadFile(testCRDManifestDir + "/project_delete_props.pb.yaml")
 	assert.NoError(t, err)
-	err = syncCRDs(context.Background(), logger, []string{"test"},
-		false, true, &crdGateway, map[string]string{"Project": string(crdYaml)})
+	err = syncCRDs(context.Background(), logger, "test",
+		false, true, &crdGateway, nil, map[string]string{"Project": string(crdYaml)})
 	assert.Error(t, err, "failed to update CRD. Schema is incompatible, and there are existing instances. Abort updating CRD projects.test")
 
 	// fail to list existing CRDs
 	mockGateway := crdmocks.NewMockGateway(gomock.NewController(t))
 	mockGateway.EXPECT().List(gomock.Any()).Return(nil, fmt.Errorf("test error"))
-	err = syncCRDs(context.Background(), logger, []string{"test"},
-		false, true, mockGateway, map[string]string{"Project": string(crdYaml)})
+	err = syncCRDs(context.Background(), logger, "test",
+		false, true, mockGateway, nil, map[string]string{"Project": string(crdYaml)})
 	assert.Error(t, err, "failed to list existing CRDs: test error")
 
 	// do not update CRDs that are not in the specified groups
-	err = syncCRDs(context.Background(), logger, []string{"test1", "test2"},
-		false, true, &crdGateway, map[string]string{"Project": string(crdYaml)})
-	assert.Error(t, err, "CRD projects.test is not in the specified groups [test1, test2]")
+	err = syncCRDs(context.Background(), logger, "test1",
+		false, true, &crdGateway, nil, map[string]string{"Project": string(crdYaml)})
+	assert.Error(t, err, "CRD projects.test is not in the specified group test1")
 }
 
 func TestParseConfig(t *testing.T) {
@@ -301,13 +302,320 @@ apiserver:
 	assert.True(t, conf.EnableCRDUpdate)
 	assert.False(t, conf.EnableIncompatibleUpdate)
 
+	// Parse configuration with CRD versions
+	yamlConfStr2 := `
+apiserver:
+  crdSync:
+    enableCRDUpdate: true
+    enableIncompatibleUpdate: true
+    crdVersions:
+      project:
+        versions: [v1, v2]
+        storageVersion: v2
+`
+	provider2, err := config.NewYAML(config.Source(strings.NewReader(yamlConfStr2)))
+	assert.NoError(t, err)
+
+	conf2, err := ParseConfig(provider2)
+	assert.NoError(t, err)
+	assert.True(t, conf2.EnableCRDUpdate)
+	assert.True(t, conf2.EnableIncompatibleUpdate)
+	assert.Equal(t, conf2.CRDVersions, map[string]VersionConfig{
+		"project": {
+			Versions:       []string{"v1", "v2"},
+			StorageVersion: "v2",
+		},
+	})
+
 	invalidConfStr := `
 apiserver:
   crdSync:
     enableCRDUpdat: true
 `
-	provider2, err := config.NewYAML(config.Source(strings.NewReader(invalidConfStr)))
+	provider3, err := config.NewYAML(config.Source(strings.NewReader(invalidConfStr)))
 	assert.NoError(t, err)
-	_, err2 := ParseConfig(provider2)
+	_, err2 := ParseConfig(provider3)
 	assert.Error(t, err2)
+}
+
+func TestMergeCRDVersions(t *testing.T) {
+	// Helper function to create a test CRD with a specific version
+	createCRD := func(name, version string, storage bool) *apiextv1.CustomResourceDefinition {
+		return &apiextv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+			Spec: apiextv1.CustomResourceDefinitionSpec{
+				Group: "test.example.com",
+				Names: apiextv1.CustomResourceDefinitionNames{
+					Kind: strings.Title(name),
+				},
+				Versions: []apiextv1.CustomResourceDefinitionVersion{
+					{
+						Name:    version,
+						Storage: storage,
+						Served:  true,
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("Single CRD with one version and no version config", func(t *testing.T) {
+		crd := createCRD("test-crd", "v1", false)
+		crdList := []*apiextv1.CustomResourceDefinition{crd}
+
+		result, err := mergeCRDVersions(crdList, nil)
+		assert.NoError(t, err)
+		assert.Len(t, result, 1)
+		assert.Equal(t, "test-crd", result[0].Name)
+		assert.Len(t, result[0].Spec.Versions, 1)
+		assert.Equal(t, "v1", result[0].Spec.Versions[0].Name)
+		assert.True(t, result[0].Spec.Versions[0].Storage)
+	})
+
+	t.Run("Single CRD with version config", func(t *testing.T) {
+		crd := createCRD("test-crd", "v1", false)
+		crdList := []*apiextv1.CustomResourceDefinition{crd}
+		crdVersions := map[string]VersionConfig{
+			"test-crd": {
+				Versions:       []string{"v1"},
+				StorageVersion: "v1",
+			},
+		}
+
+		result, err := mergeCRDVersions(crdList, crdVersions)
+		assert.NoError(t, err)
+		assert.Len(t, result, 1)
+		assert.Equal(t, "test-crd", result[0].Name)
+		assert.Len(t, result[0].Spec.Versions, 1)
+		assert.Equal(t, "v1", result[0].Spec.Versions[0].Name)
+		assert.True(t, result[0].Spec.Versions[0].Storage)
+		// Single version CRDs should not have conversion strategy set
+		assert.Nil(t, result[0].Spec.Conversion)
+	})
+
+	t.Run("Multiple CRDs with different versions merged", func(t *testing.T) {
+		crd1 := createCRD("test-crd", "v1", false)
+		crd2 := createCRD("test-crd", "v2", false)
+		crdList := []*apiextv1.CustomResourceDefinition{crd1, crd2}
+		crdVersions := map[string]VersionConfig{
+			"test-crd": {
+				Versions:       []string{"v1", "v2"},
+				StorageVersion: "v2",
+			},
+		}
+
+		result, err := mergeCRDVersions(crdList, crdVersions)
+		assert.NoError(t, err)
+		assert.Len(t, result, 1)
+		assert.Equal(t, "test-crd", result[0].Name)
+		assert.Len(t, result[0].Spec.Versions, 2)
+
+		// Check that v2 is the storage version
+		v1Found := false
+		v2Found := false
+		for _, v := range result[0].Spec.Versions {
+			if v.Name == "v1" {
+				v1Found = true
+				assert.False(t, v.Storage)
+			}
+			if v.Name == "v2" {
+				v2Found = true
+				assert.True(t, v.Storage)
+			}
+		}
+		assert.True(t, v1Found)
+		assert.True(t, v2Found)
+
+		// Multiple version CRDs should have conversion strategy set
+		assert.NotNil(t, result[0].Spec.Conversion)
+		assert.Equal(t, apiextv1.NoneConverter, result[0].Spec.Conversion.Strategy)
+	})
+
+	t.Run("Single version with no explicit storage version in config", func(t *testing.T) {
+		crd := createCRD("test-crd", "v1", false)
+		crdList := []*apiextv1.CustomResourceDefinition{crd}
+		crdVersions := map[string]VersionConfig{
+			"test-crd": {
+				Versions: []string{"v1"},
+				// StorageVersion is empty
+			},
+		}
+
+		result, err := mergeCRDVersions(crdList, crdVersions)
+		assert.NoError(t, err)
+		assert.Len(t, result, 1)
+		assert.True(t, result[0].Spec.Versions[0].Storage)
+	})
+
+	t.Run("Error: CRD has multiple versions but no version config", func(t *testing.T) {
+		crd1 := createCRD("test-crd", "v1", false)
+		crd2 := createCRD("test-crd", "v2", false)
+		crdList := []*apiextv1.CustomResourceDefinition{crd1, crd2}
+		crdVersions := map[string]VersionConfig{}
+
+		_, err := mergeCRDVersions(crdList, crdVersions)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "CRD test-crd has multiple versions but version config specified in crdVersions")
+	})
+
+	t.Run("Error: CRD has multiple versions but no storage version specified", func(t *testing.T) {
+		crd1 := createCRD("test-crd", "v1", false)
+		crd2 := createCRD("test-crd", "v2", false)
+		crdList := []*apiextv1.CustomResourceDefinition{crd1, crd2}
+		crdVersions := map[string]VersionConfig{
+			"test-crd": {
+				Versions: []string{"v1", "v2"},
+				// StorageVersion is empty
+			},
+		}
+
+		_, err := mergeCRDVersions(crdList, crdVersions)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "CRD test-crd has multiple versions, but no storageVersion specified in crdVersions")
+	})
+
+	t.Run("Error: CRD has more than one version in spec", func(t *testing.T) {
+		crd := &apiextv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-crd",
+			},
+			Spec: apiextv1.CustomResourceDefinitionSpec{
+				Group: "test.example.com",
+				Names: apiextv1.CustomResourceDefinitionNames{
+					Kind: "TestCrd",
+				},
+				Versions: []apiextv1.CustomResourceDefinitionVersion{
+					{Name: "v1", Storage: true, Served: true},
+					{Name: "v2", Storage: false, Served: true},
+				},
+			},
+		}
+		crdList := []*apiextv1.CustomResourceDefinition{crd}
+		crdVersions := map[string]VersionConfig{}
+
+		_, err := mergeCRDVersions(crdList, crdVersions)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "each CRD item must only have one version. CRD test-crd has 2 versions")
+	})
+
+	t.Run("Error: Duplicate version definitions", func(t *testing.T) {
+		crd1 := createCRD("test-crd", "v1", false)
+		crd2 := createCRD("test-crd", "v1", false) // Same version
+		crdList := []*apiextv1.CustomResourceDefinition{crd1, crd2}
+		crdVersions := map[string]VersionConfig{}
+
+		_, err := mergeCRDVersions(crdList, crdVersions)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "CRD test-crd has duplicated definitions of version v1")
+	})
+
+	t.Run("Error: Version specified in config but not in CRD list", func(t *testing.T) {
+		crd := createCRD("test-crd", "v1", false)
+		crdList := []*apiextv1.CustomResourceDefinition{crd}
+		crdVersions := map[string]VersionConfig{
+			"test-crd": {
+				Versions:       []string{"v1", "v2"}, // v2 doesn't exist
+				StorageVersion: "v1",
+			},
+		}
+
+		_, err := mergeCRDVersions(crdList, crdVersions)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "version v2 of CRD test-crd is specified in crdVersions, but does not exist not in crdList")
+	})
+
+	t.Run("Error: Storage version not found in CRD versions", func(t *testing.T) {
+		crd := createCRD("test-crd", "v1", false)
+		crdList := []*apiextv1.CustomResourceDefinition{crd}
+		crdVersions := map[string]VersionConfig{
+			"test-crd": {
+				Versions:       []string{"v1"},
+				StorageVersion: "v2", // v2 doesn't exist
+			},
+		}
+
+		_, err := mergeCRDVersions(crdList, crdVersions)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "CRD test-crd does not have the specified storage version v2")
+	})
+
+	t.Run("Multiple different CRDs", func(t *testing.T) {
+		crd1 := createCRD("first-crd", "v1", false)
+		crd2 := createCRD("second-crd", "v1", false)
+		crdList := []*apiextv1.CustomResourceDefinition{crd1, crd2}
+		crdVersions := map[string]VersionConfig{
+			"first-crd": {
+				Versions:       []string{"v1"},
+				StorageVersion: "v1",
+			},
+		}
+
+		result, err := mergeCRDVersions(crdList, crdVersions)
+		assert.NoError(t, err)
+		assert.Len(t, result, 2)
+
+		// Check both CRDs are present
+		foundFirst := false
+		foundSecond := false
+		for _, crd := range result {
+			if crd.Name == "first-crd" {
+				foundFirst = true
+				assert.True(t, crd.Spec.Versions[0].Storage)
+				// Single version CRDs should not have conversion strategy set
+				assert.Nil(t, crd.Spec.Conversion)
+			}
+			if crd.Name == "second-crd" {
+				foundSecond = true
+				assert.True(t, crd.Spec.Versions[0].Storage)
+				// Single version CRDs should not have conversion strategy set
+				assert.Nil(t, crd.Spec.Conversion)
+			}
+		}
+		assert.True(t, foundFirst)
+		assert.True(t, foundSecond)
+	})
+
+	t.Run("Empty CRD list", func(t *testing.T) {
+		crdList := []*apiextv1.CustomResourceDefinition{}
+		crdVersions := map[string]VersionConfig{}
+
+		result, err := mergeCRDVersions(crdList, crdVersions)
+		assert.NoError(t, err)
+		assert.Len(t, result, 0)
+	})
+
+	t.Run("Conversion strategy only set for multiple versions", func(t *testing.T) {
+		// Test that single version CRDs don't get conversion strategy
+		singleVersionCRD := createCRD("single-crd", "v1", false)
+
+		// Test that multi-version CRDs do get conversion strategy
+		multiV1CRD := createCRD("multi-crd", "v1", false)
+		multiV2CRD := createCRD("multi-crd", "v2", false)
+
+		crdList := []*apiextv1.CustomResourceDefinition{singleVersionCRD, multiV1CRD, multiV2CRD}
+		crdVersions := map[string]VersionConfig{
+			"multi-crd": {
+				Versions:       []string{"v1", "v2"},
+				StorageVersion: "v2",
+			},
+		}
+
+		result, err := mergeCRDVersions(crdList, crdVersions)
+		assert.NoError(t, err)
+		assert.Len(t, result, 2)
+
+		for _, crd := range result {
+			if crd.Name == "single-crd" {
+				assert.Len(t, crd.Spec.Versions, 1)
+				assert.Nil(t, crd.Spec.Conversion, "Single version CRD should not have conversion strategy")
+			}
+			if crd.Name == "multi-crd" {
+				assert.Len(t, crd.Spec.Versions, 2)
+				assert.NotNil(t, crd.Spec.Conversion, "Multi-version CRD should have conversion strategy")
+				assert.Equal(t, apiextv1.NoneConverter, crd.Spec.Conversion.Strategy)
+			}
+		}
+	})
 }

--- a/go/cmd/apiserver/config/base.yaml
+++ b/go/cmd/apiserver/config/base.yaml
@@ -5,6 +5,11 @@ apiserver:
   crdSync:
     enableCRDUpdate: true
     enableIncompatibleUpdate: false
+    enableCRDDeletion: true
+    crdVersions:
+      project:
+        versions: [v2]
+        storage_version: v2
 
 k8s:
   qps: 300

--- a/go/cmd/apiserver/main.go
+++ b/go/cmd/apiserver/main.go
@@ -53,7 +53,7 @@ func opts() fx.Option {
 		v2pb.ModelSvcModule,
 		v2pb.TriggerRunSvcModule,
 		crd.Module,
-		crd.SyncCRDs([]string{v2pb.GroupVersion.Group}, v2pb.YamlSchemas),
+		crd.SyncCRDs(v2pb.GroupVersion.Group, v2pb.YamlSchemas),
 		fx.Invoke(registerProcedures),
 		fx.Invoke(startYARPCServer),
 	)


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
extend SyncCRDs() function to support synchronizing multiple CRD versions
1. only sync one API group each time
2. add an API server configuration (VersionConfig) to allow users specify which versions of each CRD are synced and which version is the storage version
3. merge multiple CRD version schemas (auto generated from protobuf) into one k8s CRD object, according to the configuration
4. remove "error" in newSchemaDiff() function's return, as the function doesn't really return any error

<!-- Tell your future self why have you made these changes -->
**Why?**
The open source Michelangelo project introduced backward incompatible changes to Michelangelo CRD schemas. When importing back to Uber internal, we will have to treat the open source CRD schemas as a newer version. 

This is the 1st pull request of a series planed changes to support multiple Michelangelo API & schema versions

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
added unit test cases

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
