### PR TITLE
Modify sandbox cli to create jobs cluster

### DIFF
--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -9,6 +9,7 @@ import time
 import uuid
 import yaml
 from pathlib import Path
+import base64
 
 short_description = "Manage the sandbox cluster."
 
@@ -19,7 +20,7 @@ This tool helps you create and manage a sandbox cluster directly on your machine
 
 _dir = Path(__file__).parent
 
-_kube_name = "michelangelo-sandbox"
+_michelangelo_sandbox_kube_cluster_name = "michelangelo-sandbox"
 _kube_ports = [
     "3306:30001",  # MySQL
     "9091:30007",  # MinIO
@@ -34,7 +35,15 @@ _cadence_ports = [
     "7933:30003",  # Cadence TChannel
     "8088:30004",  # Cadence Web
 ]
+
+# Ray framework ports
+_ray_ports = [
+    "10001:10001",  # Ray client port
+    "8265:8265",  # Ray dashboard
+]
+
 _cadence_domain = "default"
+_default_job_hosting_kube_cluster_name = "michelangelo-jobs-0"
 
 
 def init_arguments(p: argparse.ArgumentParser):
@@ -53,11 +62,28 @@ def init_arguments(p: argparse.ArgumentParser):
         default="cadence",
         help="Choose workflow engine: cadence or temporal (default: cadence).",
     )
+    create_p.add_argument(
+        "--create-jobs-cluster",
+        action="store_true",
+        help="Create an additional cluster for Ray jobs.",
+    )
+    create_p.add_argument(
+        "--jobs-cluster-name",
+        default=_default_job_hosting_kube_cluster_name,
+        help="Name of the jobs cluster to create when --create-jobs-cluster is used (default: %s)."
+        % _default_job_hosting_kube_cluster_name,
+    )
 
     _ = sp.add_parser(
         "demo", help="Create demo project and pipelines in the sandbox cluster."
     )
-    _ = sp.add_parser("delete", help="Delete the cluster.")
+    delete_p = sp.add_parser("delete", help="Delete the cluster.")
+    delete_p.add_argument(
+        "--jobs-cluster-name",
+        default=_default_job_hosting_kube_cluster_name,
+        help="Name of the jobs cluster to delete when --create-jobs-cluster is used (default: %s)."
+        % _default_job_hosting_kube_cluster_name,
+    )
     _ = sp.add_parser("start", help="Start the cluster.")
     _ = sp.add_parser("stop", help="Stop the cluster.")
 
@@ -94,7 +120,7 @@ def run(ns: argparse.Namespace):
 def _create(ns: argparse.Namespace):
     assert ns
     ports = _kube_ports + ([] if ns.workflow == "temporal" else _cadence_ports)
-    args = ["k3d", "cluster", "create", _kube_name, "--servers", "1", "--agents", "1"]
+    args = ["k3d", "cluster", "create", _michelangelo_sandbox_kube_cluster_name, "--servers", "1", "--agents", "1"]
 
     for p in ports:
         args += ["-p", f"{p}@agent:0"]
@@ -215,6 +241,12 @@ Be aware that CR_PAT environment variable is required while Michelangelo is NOT 
     _create_spark_operator(helm_existing_repos)
 
     print("\nSandbox created successfully.")
+
+    # Create the jobs cluster if requested
+    if ns.create_jobs_cluster:
+        _create_jobs_cluster(ns.jobs_cluster_name)
+        _create_cluster_crd(ns.jobs_cluster_name)
+        _create_cluster_secrets(ns.jobs_cluster_name)
 
 
 def _create_spark_operator(helm_existing_repos):
@@ -351,10 +383,10 @@ def _create_demo_crs(_: argparse.Namespace):
     """Create demo Custom Resources (CRs) for the sandbox environment."""
     # Check if cluster exists
     try:
-        _exec("k3d", "cluster", "get", _kube_name, raise_error=True)
+        _exec("k3d", "cluster", "get", _michelangelo_sandbox_kube_cluster_name, raise_error=True)
     except subprocess.CalledProcessError:
         _err_exit(
-            f"Cluster {_kube_name} not found. Please run 'ma sandbox create' first."
+            f"Cluster {_michelangelo_sandbox_kube_cluster_name} not found. Please run 'ma sandbox create' first."
         )
 
     # Check if cluster is running
@@ -362,7 +394,7 @@ def _create_demo_crs(_: argparse.Namespace):
         _exec("kubectl", "cluster-info", raise_error=True)
     except subprocess.CalledProcessError:
         _err_exit(
-            f"Cluster {_kube_name} is not running. Please run 'ma sandbox start' first."
+            f"Cluster {_michelangelo_sandbox_kube_cluster_name} is not running. Please run 'ma sandbox start' first."
         )
 
     demo_dir = _dir / "demo"
@@ -389,17 +421,21 @@ def _create_demo_crs(_: argparse.Namespace):
 
 def _delete(ns: argparse.Namespace):
     assert ns
-    _exec("k3d", "cluster", "delete", _kube_name)
+    if ns.jobs_cluster_name:
+        _exec("k3d", "cluster", "delete", ns.jobs_cluster_name)
+    else:
+        _exec("k3d", "cluster", "delete", _default_job_hosting_kube_cluster_name)
+    _exec("k3d", "cluster", "delete", _michelangelo_sandbox_kube_cluster_name)
 
 
 def _start(ns: argparse.Namespace):
     assert ns
-    _exec("k3d", "cluster", "start", _kube_name)
+    _exec("k3d", "cluster", "start", _michelangelo_sandbox_kube_cluster_name)
 
 
 def _stop(ns: argparse.Namespace):
     assert ns
-    _exec("k3d", "cluster", "stop", _kube_name)
+    _exec("k3d", "cluster", "stop", _michelangelo_sandbox_kube_cluster_name)
 
 
 def _kube_create(path: Path):
@@ -495,6 +531,161 @@ def _err_exit(err_message: str, code: int = 1):
     # Print the error message in red and bold.
     print(f"\033[91m\033[1mERROR: {err_message}\nexit {code}\033[0m")
     sys.exit(code)
+
+
+def _create_jobs_cluster(cluster_name: str):
+    """Create a dedicated cluster for jobs."""
+
+    args = [
+        "k3d",
+        "cluster",
+        "create",
+        cluster_name,
+        "--servers",
+        "1",
+        "--agents",
+        "2",  # More worker nodes for Ray
+        "--kubeconfig-switch-context=false",  # Don't switch kubectl context to this cluster
+    ]
+
+    # Add port mappings for Ray
+    for p in _ray_ports:
+        args += ["-p", f"{p}@agent:0"]
+
+    _exec(*args)
+
+    print(f"\nJobs cluster '{cluster_name}' created successfully.")
+
+
+# Given a cluster name, create a Cluster CRD in the sandbox cluster
+def _create_cluster_crd(cluster_name: str):
+    """Create a Cluster CRD for the Ray jobs cluster in the sandbox cluster."""
+    # Get kubeconfig for the Ray jobs cluster
+    kubeconfig = subprocess.check_output(
+        ["k3d", "kubeconfig", "get", cluster_name]
+    ).decode()
+
+    # Parse the kubeconfig YAML
+    kubeconfig_data = yaml.safe_load(kubeconfig)
+
+    # Extract server URL from clusters[0].cluster.server
+    server_url = kubeconfig_data["clusters"][0]["cluster"]["server"]
+
+    # Extract host and port from server URL
+    # Example: "https://host.docker.internal:52910"
+    import re
+
+    match = re.search(r"(https://[^:]+):(\d+)", server_url)
+    if not match:
+        raise ValueError(
+            f"Could not extract cluster host and port from server URL: {server_url}"
+        )
+    host, port = match.groups()
+
+    # Create Cluster CRD manifest
+    cluster_crd = {
+        "apiVersion": "michelangelo.api/v2",
+        "kind": "Cluster",
+        "metadata": {"name": cluster_name, "namespace": "default"},
+        "spec": {
+            "kubernetes": {
+                "rest": {
+                    "host": host,
+                    "port": port,
+                    "tokenTag": f"cluster-{cluster_name}-client-token",
+                    "caDataTag": f"cluster-{cluster_name}-ca-data",
+                },
+                "skus": [],
+            }
+        },
+    }
+
+    # Create a temporary file for the Cluster CRD
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml") as crd_file:
+        yaml.dump(cluster_crd, crd_file)
+        crd_file.flush()
+
+        # Apply the Cluster CRD to the sandbox cluster (explicitly specify context)
+        _exec("kubectl", "--context", f"k3d-{_michelangelo_sandbox_kube_cluster_name}", "apply", "-f", crd_file.name)
+
+        print(f"\nCreated Cluster CRD '{cluster_name}' in the sandbox cluster")
+        print(f"Cluster host: {host}")
+        print(f"Cluster port: {port}")
+        print(f"Server URL: {server_url}")
+
+
+def _create_cluster_secrets(cluster_name: str):
+    """Create Kubernetes secrets for the kubeconfig of the given cluster name."""
+    # Get kubeconfig for the cluster
+    kubeconfig = subprocess.check_output(
+        ["k3d", "kubeconfig", "get", cluster_name]
+    ).decode()
+
+    # Parse the kubeconfig YAML
+    kubeconfig_data = yaml.safe_load(kubeconfig)
+
+    # Extract certificate-authority-data from clusters[0].cluster
+    ca_data = kubeconfig_data["clusters"][0]["cluster"].get(
+        "certificate-authority-data"
+    )
+    if not ca_data:
+        raise ValueError("certificate-authority-data not found in kubeconfig")
+
+    # Create a secret for the certificate-authority-data
+    ca_secret = {
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "metadata": {"name": f"cluster-{cluster_name}-ca-data", "namespace": "default"},
+        "data": {"cadata": ca_data},
+    }
+
+    # Create a temporary file for the CA secret
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml") as ca_file:
+        yaml.dump(ca_secret, ca_file)
+        ca_file.flush()
+
+        # Apply the CA secret to the sandbox cluster
+        _exec("kubectl", "apply", "-f", ca_file.name)
+
+    # Create a new token for the default service account
+    token_raw = (
+        subprocess.check_output(
+            [
+                "kubectl",
+                "--context",
+                f"k3d-{cluster_name}",
+                "-n",
+                "default",
+                "create",
+                "token",
+                "default",
+            ]
+        )
+        .decode()
+        .strip()
+    )
+    token = base64.b64encode(token_raw.encode()).decode()
+
+    # Create a secret for the user token
+    token_secret = {
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "metadata": {
+            "name": f"cluster-{cluster_name}-client-token",
+            "namespace": "default",
+        },
+        "data": {"token": token},
+    }
+
+    # Create a temporary file for the token secret
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml") as token_file:
+        yaml.dump(token_secret, token_file)
+        token_file.flush()
+
+        # Apply the token secret to the sandbox cluster
+        _exec("kubectl", "apply", "-f", token_file.name)
+
+    print(f"\nCreated secrets for cluster '{cluster_name}' in the sandbox cluster")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
Added an option - create-jobs-cluster to michelangelo sandbox CLI to create an additional k8s cluster for jobs.

<!-- Tell your future self why have you made these changes -->
**Why?**
This new jobs cluster will be used by jobs controllers to schedule jobs in a separate cluster instead of the same cluster as michelangelo.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
```poetry run ma sandbox create --create-jobs-cluster```
Successfully creates the additional cluster

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
NA
<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
NA
<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
Will update https://github.com/michelangelo-ai/michelangelo/wiki/Getting-Started#running-michelangelos-api-sandbox-environment
To create a separate jobs cluster along with michelangelo-sandbox  run ```poetry run ma sandbox create --create-jobs-cluster``` 