### PR TITLE
Update getObjectValue function definition

### DIFF
--- a/javascript/packages/core/types/common/studio-types.ts
+++ b/javascript/packages/core/types/common/studio-types.ts
@@ -83,4 +83,4 @@ export enum Phase {
  */
 export type Accessor<K = unknown> = AccessorFn<K> | string;
 
-export type AccessorFn<T = unknown> = (object: unknown) => T;
+export type AccessorFn<T = unknown> = (object: unknown) => T | undefined;

--- a/javascript/packages/core/utils/__tests__/object-utils.tests.ts
+++ b/javascript/packages/core/utils/__tests__/object-utils.tests.ts
@@ -58,6 +58,20 @@ describe('object-utils', () => {
         expect(getObjectValue(testObject, 123)).toBeUndefined();
       });
     });
+
+    describe('with invalid object', () => {
+      it('should return undefined when object is null', () => {
+        expect(getObjectValue(null, 'name')).toBeUndefined();
+      });
+
+      it('should return undefined when object is undefined', () => {
+        expect(getObjectValue(undefined, 'name')).toBeUndefined();
+      });
+
+      it('should return undefined when object is a primitive', () => {
+        expect(getObjectValue(123, 'name')).toBeUndefined();
+      });
+    });
   });
 
   describe('getObjectSymbols', () => {

--- a/javascript/packages/core/utils/object-utils.ts
+++ b/javascript/packages/core/utils/object-utils.ts
@@ -3,12 +3,12 @@ import { get } from 'lodash';
 import type { Accessor } from '#core/types/common/studio-types';
 
 export function getObjectValue<K>(
-  obj: object,
+  obj: unknown,
   accessor: Accessor<K>,
   defaultValue?: K
 ): K | undefined {
   if (typeof accessor === 'function') {
-    return accessor(obj) || defaultValue;
+    return accessor(obj) ?? defaultValue;
   }
 
   if (typeof accessor === 'string') {


### PR DESCRIPTION
getObjectValue now accepts unknown as the data type for the object to access value from.

This migration intends to reconcile a difference between AccessorFn and getObjectValue: AccessorFn input is unknown; getObjectValue input is object. I don't believe all instantiations of getObjectValue can safely provide object type.

Ideally, both these types accept generics that detail input and output types. Currently, only output type generic is supported.

**What type of PR is this? (check all applicable)**
- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
