### PR TITLE
Fix YAML config key format for storage version

### DIFF
--- a/go/cmd/apiserver/config/base.yaml
+++ b/go/cmd/apiserver/config/base.yaml
@@ -9,7 +9,7 @@ apiserver:
     crdVersions:
       project:
         versions: [v2]
-        storage_version: v2
+        storageVersion: v2
 
 k8s:
   qps: 300


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
Earlier, we couldn't run the api server due to this error - 
yaml: unmarshal errors: line 3: field storage_version not found in type crd.VersionConfig. 
So, changed code to use correct key.

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
