### PR TITLE
Implement subprocess-based pipeline registration for MaCTL

### DIFF
--- a/go/cmd/apiserver/config/base.yaml
+++ b/go/cmd/apiserver/config/base.yaml
@@ -9,7 +9,7 @@ apiserver:
     crdVersions:
       project:
         versions: [v2]
-        storage_version: v2
+        storageVersion: v2
 
 k8s:
   qps: 300

--- a/python/examples/bert_cola/pipeline.yaml
+++ b/python/examples/bert_cola/pipeline.yaml
@@ -1,0 +1,9 @@
+apiVersion: michelangelo.api/v2
+kind: Pipeline
+metadata:
+  namespace: "ma-dev-test"
+  name: "bert-cola-test"
+spec:
+  type: "PIPELINE_TYPE_TRAIN"
+  manifest:
+    filePath: examples.bert_cola.bert_cola

--- a/python/michelangelo/cli/mactl/plugins/pipeline/create.py
+++ b/python/michelangelo/cli/mactl/plugins/pipeline/create.py
@@ -1,3 +1,5 @@
+import json
+import tempfile
 from copy import deepcopy
 from logging import getLogger
 from os import getenv
@@ -6,12 +8,130 @@ from uuid import uuid4
 
 from git import Repo
 from google.protobuf.message import Message
+from google.protobuf.struct_pb2 import Struct
 from grpc import Channel
 
 from mactl import CRD, PWD
+from michelangelo.cli.mactl.utils import (
+    run_subprocess_registration,
+    read_subprocess_outputs
+)
 
 
 _LOG = getLogger(__name__)
+
+# Constants for registration output files
+_UNIFLOW_TAR_TB_PATH_FILENAME = "uniflow_tar_tb_path.txt"
+_UNIFLOW_INPUT_FILENAME = "uniflow_input.txt"
+
+
+def get_pipeline_config_and_tar(repo_root: Path, config_file_relative_path: str, 
+                               bazel_target: str, project: str, pipeline: str, 
+                               yaml_dict: dict = None) -> tuple[Struct, str]:
+    """
+    Run pipeline registration via subprocess to get uniflow artifacts.
+    
+    Executes registration in the user's Python environment to obtain:
+    1) uniflow tarball path in TerraBlob from "uniflow_tar_tb_path.txt" 
+    2) uniflow workflow input from "uniflow_input.txt" converted to Struct
+    
+    Uses subprocess isolation to maintain clean separation between
+    MaCTL's environment and the user's pipeline dependencies.
+    
+    Args:
+        repo_root: Root directory of the git repository
+        config_file_relative_path: Relative path to config file from repo root
+        bazel_target: Bazel target (unused)
+        project: Project name
+        pipeline: Pipeline name
+        
+    Returns:
+        tuple: (workflow_inputs as Struct, uniflow_tar_tb_path as string)
+        
+    Raises:
+        FileNotFoundError: If config file doesn't exist
+        RuntimeError: If subprocess registration fails
+    """
+    config_file_path = repo_root / config_file_relative_path
+    
+    # Validate config file exists
+    if not config_file_path.exists():
+        raise FileNotFoundError(f"Config file {config_file_path} does not exist")
+    
+    # Create temporary directory for registration outputs
+    with tempfile.TemporaryDirectory(prefix="mactl_") as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        
+        _LOG.info("Running subprocess registration for project=%s, pipeline=%s", project, pipeline)
+        
+        try:
+            # Execute registration in subprocess (user's Python environment)
+            # The subprocess will read the config file and discover the workflow function
+            result = run_subprocess_registration(
+                project=project,
+                pipeline=pipeline,
+                config_file_path=str(config_file_path),
+                output_dir=str(tmp_path),
+                storage_url=None,  # Use default S3 path
+                output_filename=None,  # Use default filename
+                environ=None,
+                args=None,
+                kwargs=None,
+            )
+            
+            # Check subprocess result
+            if result.returncode != 0:
+                _LOG.error("Subprocess registration failed with exit code %d", result.returncode)
+                _LOG.error("Subprocess stderr: %s", result.stderr)
+                raise RuntimeError(f"Registration subprocess failed: {result.stderr}")
+            
+            _LOG.info("Subprocess registration completed successfully")
+            
+        except Exception as e:
+            _LOG.error("Failed to execute registration subprocess: %s", e)
+            raise RuntimeError(f"Error running pipeline registration: {e}")
+        
+        # Read subprocess outputs using status files
+        success, message, remote_path = read_subprocess_outputs(str(tmp_path))
+        
+        if not success:
+            raise RuntimeError(f"Registration failed: {message}")
+        
+        _LOG.info("Registration successful: %s", message)
+        
+        # Read uniflow tar TerraBlob path
+        tb_path_file = tmp_path / _UNIFLOW_TAR_TB_PATH_FILENAME
+        if not tb_path_file.exists():
+            # Fall back to default uniflow tar path file if TB path doesn't exist
+            tb_path_file = tmp_path / "uniflow_tar_path.txt"
+            
+        try:
+            uniflow_tar_tb_path = tb_path_file.read_text().strip()
+            _LOG.info("Read uniflow tar path: %s", uniflow_tar_tb_path)
+        except FileNotFoundError:
+            # Use remote path from status file if direct file read fails
+            if remote_path:
+                uniflow_tar_tb_path = remote_path
+                _LOG.info("Using tar path from status file: %s", uniflow_tar_tb_path)
+            else:
+                raise RuntimeError(f"Could not read uniflow tar path from {tb_path_file}")
+        
+        # Read uniflow workflow input  
+        input_file_path = tmp_path / _UNIFLOW_INPUT_FILENAME
+        try:
+            content = input_file_path.read_text()
+            input_data = json.loads(content)
+            _LOG.info("Read uniflow input data")
+        except FileNotFoundError:
+            raise RuntimeError(f"Could not read uniflow input from {input_file_path}")
+        except json.JSONDecodeError as e:
+            raise RuntimeError(f"Error parsing uniflow input JSON: {e}")
+        
+        # Convert to protobuf Struct
+        workflow_inputs = Struct()
+        workflow_inputs.update(input_data)
+        
+        return workflow_inputs, uniflow_tar_tb_path
 
 
 def generate_create(crd: CRD, channel: Channel):
@@ -26,6 +146,7 @@ def convert_crd_metadata_pipeline_create(
 ) -> dict:
     """
     Convert CRD metadata for pipeline create crd.
+    Integrates pipeline registration to get uniflow artifacts.
     """
     _LOG.info("Convert CRD metadata for class %r", crd_class)
     if not isinstance(yaml_dict, dict):
@@ -36,13 +157,58 @@ def convert_crd_metadata_pipeline_create(
     repo_root = Path(repo.git.rev_parse("--show-toplevel")).resolve()
     _LOG.info("Current git repository info: %r", repo)
 
+    # Extract project and pipeline names from metadata
+    project = yaml_dict["metadata"]["namespace"]  # Assuming namespace maps to project
+    pipeline = yaml_dict["metadata"]["name"]
+    
+    # Get relative path of config file from repo root
+    config_file_relative_path = str(yaml_path.relative_to(repo_root))
+    
+    # Run pipeline registration to get uniflow artifacts
+    try:
+        workflow_inputs, uniflow_tar_tb_path = get_pipeline_config_and_tar(
+            repo_root=repo_root,
+            config_file_relative_path=config_file_relative_path,
+            bazel_target="",  # Not used
+            project=project,
+            pipeline=pipeline
+        )
+        _LOG.info("Successfully obtained pipeline config and tar")
+    except FileNotFoundError as e:
+        _LOG.error("Config file not found: %s", e)
+        raise ValueError(f"Pipeline configuration file is missing: {e}")
+    except RuntimeError as e:
+        _LOG.error("Registration subprocess failed: %s", e)
+        # Check if this is a critical failure or can be handled gracefully
+        if "Python interpreter" in str(e):
+            raise ValueError(
+                f"Could not detect suitable Python environment for registration: {e}. "
+                "Please ensure you're in a valid Python project environment."
+            )
+        elif "workflow function" in str(e).lower():
+            raise ValueError(
+                f"Workflow function not found: {e}. "
+                f"Please ensure {project}.{pipeline}_workflow exists and is importable."
+            )
+        else:
+            # For other registration failures, continue with graceful degradation
+            _LOG.warning("Registration failed, continuing without uniflow artifacts: %s", e)
+            workflow_inputs = None
+            uniflow_tar_tb_path = ""
+    except Exception as e:
+        _LOG.error("Unexpected error during registration: %s", e)
+        # For unexpected errors, also use graceful degradation
+        _LOG.warning("Unexpected registration failure, continuing without uniflow artifacts")
+        workflow_inputs = None
+        uniflow_tar_tb_path = ""
+
     res = {"spec": deepcopy(yaml_dict["spec"])}
     res["metadata"] = {
         "clusterName": "",
         "generateName": "",
         "generation": "0",
-        "name": yaml_dict["metadata"]["name"],
-        "namespace": yaml_dict["metadata"]["namespace"],
+        "name": pipeline,
+        "namespace": project,
         "resourceVersion": "0",
         "uid": str(uuid4()),
     }
@@ -53,13 +219,21 @@ def convert_crd_metadata_pipeline_create(
     assert yaml_path.resolve().is_relative_to(repo_root), (
         f"Expected {yaml_path.resolve()} to be relative to {repo_root}"
     )
-    # "path": str(yaml_path.relative_to(PWD)),
-    # TODO: retrieve path from Project.
+    
     res["spec"]["manifest"] = {
-        "path": "platforms/uberai/michelangelo/ma_integration_test/pipelines/boston_housing/keras_workflow/pipeline.yaml",
-        "revision_id": repo.head.commit.hexsha,
+        "filePath": config_file_relative_path,
         "type": "PIPELINE_MANIFEST_TYPE_YAML",
     }
     res["spec"]["owner"] = {"name": getenv("UBER_LDAP_UID")}
+    
+    # Add uniflow artifacts if registration succeeded
+    # Note: The current protobuf schema doesn't support workflow_inputs or uniflow_tar_path
+    # These would need to be added to the manifest or stored differently
+    if workflow_inputs is not None:
+        _LOG.info("Workflow inputs discovered but not added to spec (schema limitation)")
+        
+    if uniflow_tar_tb_path:
+        _LOG.info("Uniflow tar path: %s (not added to spec due to schema limitation)", uniflow_tar_tb_path)
+    
     _LOG.debug("Converted CRD metadata: %r", res)
     return res

--- a/python/michelangelo/cli/mactl/plugins/pipeline/create.py
+++ b/python/michelangelo/cli/mactl/plugins/pipeline/create.py
@@ -9,12 +9,14 @@ from uuid import uuid4
 from git import Repo
 from google.protobuf.message import Message
 from google.protobuf.struct_pb2 import Struct
+from google.protobuf.any_pb2 import Any
+from michelangelo.gen.api.typed_struct_pb2 import TypedStruct
 from grpc import Channel
 
 from mactl import CRD
 from michelangelo.cli.mactl.utils import (
     run_subprocess_registration,
-    read_subprocess_outputs
+    read_subprocess_outputs,
 )
 
 
@@ -25,45 +27,54 @@ _UNIFLOW_TAR_PATH_FILENAME = "uniflow_tar_path.txt"
 _UNIFLOW_INPUT_FILENAME = "uniflow_input.txt"
 
 
-def get_pipeline_config_and_tar(repo_root: Path, config_file_relative_path: str, 
-                               bazel_target: str, project: str, pipeline: str, 
-                               yaml_dict: dict = None) -> tuple[Struct, str]:
+def get_pipeline_config_and_tar(
+    repo_root: Path,
+    config_file_relative_path: str,
+    bazel_target: str,
+    project: str,
+    pipeline: str,
+    yaml_dict: dict = None,
+) -> tuple[Struct, str, str]:
     """
     Run pipeline registration via subprocess to get uniflow artifacts.
-    
+
     Executes registration in the user's Python environment to obtain:
-    1) uniflow tarball path from "uniflow_tar_path.txt" 
+    1) uniflow tarball path from "uniflow_tar_path.txt"
     2) uniflow workflow input from "uniflow_input.txt" converted to Struct
-    
+
     Uses subprocess isolation to maintain clean separation between
     MaCTL's environment and the user's pipeline dependencies.
-    
+
     Args:
         repo_root: Root directory of the git repository
         config_file_relative_path: Relative path to config file from repo root
         bazel_target: Bazel target (unused)
         project: Project name
         pipeline: Pipeline name
-        
+
     Returns:
-        tuple: (workflow_inputs as Struct, uniflow_tar_path as string)
-        
+        tuple: (workflow_inputs as Struct, uniflow_tar_path as string, workflow_function_name as string)
+
     Raises:
         FileNotFoundError: If config file doesn't exist
         RuntimeError: If subprocess registration fails
     """
     config_file_path = repo_root / config_file_relative_path
-    
+
     # Validate config file exists
     if not config_file_path.exists():
         raise FileNotFoundError(f"Config file {config_file_path} does not exist")
-    
+
     # Create temporary directory for registration outputs
     with tempfile.TemporaryDirectory(prefix="mactl_") as tmp_dir:
         tmp_path = Path(tmp_dir)
-        
-        _LOG.info("Running subprocess registration for project=%s, pipeline=%s", project, pipeline)
-        
+
+        _LOG.info(
+            "Running subprocess registration for project=%s, pipeline=%s",
+            project,
+            pipeline,
+        )
+
         try:
             # Execute registration in subprocess (user's Python environment)
             # The subprocess will read the config file and discover the workflow function
@@ -78,30 +89,33 @@ def get_pipeline_config_and_tar(repo_root: Path, config_file_relative_path: str,
                 args=None,
                 kwargs=None,
             )
-            
+
             # Check subprocess result
             if result.returncode != 0:
-                _LOG.error("Subprocess registration failed with exit code %d", result.returncode)
+                _LOG.error(
+                    "Subprocess registration failed with exit code %d",
+                    result.returncode,
+                )
                 _LOG.error("Subprocess stderr: %s", result.stderr)
                 raise RuntimeError(f"Registration subprocess failed: {result.stderr}")
-            
+
             _LOG.info("Subprocess registration completed successfully")
-            
+
         except Exception as e:
             _LOG.error("Failed to execute registration subprocess: %s", e)
             raise RuntimeError(f"Error running pipeline registration: {e}")
-        
+
         # Read subprocess outputs using status files
         success, message, remote_path = read_subprocess_outputs(str(tmp_path))
-        
+
         if not success:
             raise RuntimeError(f"Registration failed: {message}")
-        
+
         _LOG.info("Registration successful: %s", message)
-        
+
         # Read uniflow tar path
         tar_path_file = tmp_path / _UNIFLOW_TAR_PATH_FILENAME
-            
+
         try:
             uniflow_tar_path = tar_path_file.read_text().strip()
             _LOG.info("Read uniflow tar path: %s", uniflow_tar_path)
@@ -111,24 +125,41 @@ def get_pipeline_config_and_tar(repo_root: Path, config_file_relative_path: str,
                 uniflow_tar_path = remote_path
                 _LOG.info("Using tar path from status file: %s", uniflow_tar_path)
             else:
-                raise RuntimeError(f"Could not read uniflow tar path from {tar_path_file}")
-        
-        # Read uniflow workflow input  
+                raise RuntimeError(
+                    f"Could not read uniflow tar path from {tar_path_file}"
+                )
+
+        # Read uniflow workflow input
         input_file_path = tmp_path / _UNIFLOW_INPUT_FILENAME
         try:
             content = input_file_path.read_text()
+            # Write to a permanent location for inspection
+            debug_file = Path("/tmp/uniflow_input_debug.txt")
+            debug_file.write_text(content)
+            print(f"DEBUG: uniflow_input.txt content written to {debug_file}")
+            print(f"DEBUG: Raw content: {content}")
+
             input_data = json.loads(content)
-            _LOG.info("Read uniflow input data")
+            print(f"DEBUG: Parsed data: {input_data}")
         except FileNotFoundError:
             raise RuntimeError(f"Could not read uniflow input from {input_file_path}")
         except json.JSONDecodeError as e:
             raise RuntimeError(f"Error parsing uniflow input JSON: {e}")
-        
+
         # Convert to protobuf Struct
         workflow_inputs = Struct()
         workflow_inputs.update(input_data)
-        
-        return workflow_inputs, uniflow_tar_path
+
+        # Read workflow function name
+        function_name_file = tmp_path / "workflow_function_name.txt"
+        try:
+            workflow_function_name = function_name_file.read_text().strip()
+            _LOG.info("Read workflow function name: %s", workflow_function_name)
+        except FileNotFoundError:
+            workflow_function_name = ""
+            _LOG.warning("Could not read workflow function name file")
+
+        return workflow_inputs, uniflow_tar_path, workflow_function_name
 
 
 def generate_create(crd: CRD, channel: Channel):
@@ -157,18 +188,20 @@ def convert_crd_metadata_pipeline_create(
     # Extract project and pipeline names from metadata
     project = yaml_dict["metadata"]["namespace"]  # Assuming namespace maps to project
     pipeline = yaml_dict["metadata"]["name"]
-    
+
     # Get relative path of config file from repo root
     config_file_relative_path = str(yaml_path.relative_to(repo_root))
-    
+
     # Run pipeline registration to get uniflow artifacts
     try:
-        workflow_inputs, uniflow_tar_path = get_pipeline_config_and_tar(
-            repo_root=repo_root,
-            config_file_relative_path=config_file_relative_path,
-            bazel_target="",  # Not used
-            project=project,
-            pipeline=pipeline
+        workflow_inputs, uniflow_tar_path, workflow_function_name = (
+            get_pipeline_config_and_tar(
+                repo_root=repo_root,
+                config_file_relative_path=config_file_relative_path,
+                bazel_target="",  # Not used
+                project=project,
+                pipeline=pipeline,
+            )
         )
         _LOG.info("Successfully obtained pipeline config and tar")
     except FileNotFoundError as e:
@@ -189,13 +222,18 @@ def convert_crd_metadata_pipeline_create(
             )
         else:
             # For other registration failures, continue with graceful degradation
-            _LOG.warning("Registration failed, continuing without uniflow artifacts: %s", e)
+            _LOG.warning(
+                "Registration failed, continuing without uniflow artifacts: %s", e
+            )
             workflow_inputs = None
             uniflow_tar_path = ""
+            workflow_function_name = ""
     except Exception as e:
         _LOG.error("Unexpected error during registration: %s", e)
         # For unexpected errors, also use graceful degradation
-        _LOG.warning("Unexpected registration failure, continuing without uniflow artifacts")
+        _LOG.warning(
+            "Unexpected registration failure, continuing without uniflow artifacts"
+        )
         workflow_inputs = None
         uniflow_tar_path = ""
 
@@ -216,21 +254,55 @@ def convert_crd_metadata_pipeline_create(
     assert yaml_path.resolve().is_relative_to(repo_root), (
         f"Expected {yaml_path.resolve()} to be relative to {repo_root}"
     )
-    
+
     res["spec"]["manifest"] = {
         "filePath": config_file_relative_path,
         "type": "PIPELINE_MANIFEST_TYPE_UNIFLOW",
     }
     res["spec"]["owner"] = {"name": getenv("UBER_LDAP_UID")}
-    
+
     # Add uniflow artifacts if registration succeeded
-    # Note: The current protobuf schema doesn't support workflow_inputs or uniflow_tar_path
-    # These would need to be added to the manifest or stored differently
     if workflow_inputs is not None:
-        _LOG.info("Workflow inputs discovered but not added to spec (schema limitation)")
-        
+        # Create the content field as a protobuf Any message containing the TypedStruct
+        # This matches the internal Go implementation pattern
+        typed_struct = TypedStruct()
+        typed_struct.type_url = "type.googleapis.com/michelangelo.UniFlowConf"
+        typed_struct.value.CopyFrom(workflow_inputs)
+
+        # Pack the TypedStruct into an Any message
+        content_any = Any()
+        content_any.Pack(typed_struct)
+
+        # Convert Any to dict with proper @type field
+        from google.protobuf.json_format import MessageToDict
+
+        content_dict = MessageToDict(content_any)
+
+        res["spec"]["manifest"]["content"] = content_dict
+        _LOG.info(
+            "Added content to spec manifest with Any-wrapped TypedStruct: %s",
+            content_dict,
+        )
+
     if uniflow_tar_path:
-        _LOG.info("Uniflow tar path: %s (not added to spec due to schema limitation)", uniflow_tar_path)
-    
+        res["spec"]["manifest"]["uniflowTar"] = uniflow_tar_path
+        _LOG.info("Added uniflow tar path to spec: %s", uniflow_tar_path)
+
+        # Add workflow function name if available
+        if workflow_function_name:
+            res["spec"]["manifest"]["uniflowFunction"] = workflow_function_name
+            _LOG.info("Added uniflow function to spec: %s", workflow_function_name)
+        else:
+            # Fallback to module path if function name not available
+            manifest_data = yaml_dict.get("spec", {}).get("manifest", {})
+            uniflow_function = manifest_data.get(
+                "uniflowFunction"
+            ) or manifest_data.get("filePath")
+            if uniflow_function:
+                res["spec"]["manifest"]["uniflowFunction"] = uniflow_function
+                _LOG.info(
+                    "Added uniflow function (fallback) to spec: %s", uniflow_function
+                )
+
     _LOG.debug("Converted CRD metadata: %r", res)
     return res

--- a/python/michelangelo/cli/mactl/plugins/pipeline/create.py
+++ b/python/michelangelo/cli/mactl/plugins/pipeline/create.py
@@ -21,7 +21,7 @@ from michelangelo.cli.mactl.utils import (
 _LOG = getLogger(__name__)
 
 # Constants for registration output files
-_UNIFLOW_TAR_TB_PATH_FILENAME = "uniflow_tar_tb_path.txt"
+_UNIFLOW_TAR_PATH_FILENAME = "uniflow_tar_path.txt"
 _UNIFLOW_INPUT_FILENAME = "uniflow_input.txt"
 
 
@@ -32,7 +32,7 @@ def get_pipeline_config_and_tar(repo_root: Path, config_file_relative_path: str,
     Run pipeline registration via subprocess to get uniflow artifacts.
     
     Executes registration in the user's Python environment to obtain:
-    1) uniflow tarball path in TerraBlob from "uniflow_tar_tb_path.txt" 
+    1) uniflow tarball path from "uniflow_tar_path.txt" 
     2) uniflow workflow input from "uniflow_input.txt" converted to Struct
     
     Uses subprocess isolation to maintain clean separation between
@@ -46,7 +46,7 @@ def get_pipeline_config_and_tar(repo_root: Path, config_file_relative_path: str,
         pipeline: Pipeline name
         
     Returns:
-        tuple: (workflow_inputs as Struct, uniflow_tar_tb_path as string)
+        tuple: (workflow_inputs as Struct, uniflow_tar_path as string)
         
     Raises:
         FileNotFoundError: If config file doesn't exist
@@ -99,22 +99,19 @@ def get_pipeline_config_and_tar(repo_root: Path, config_file_relative_path: str,
         
         _LOG.info("Registration successful: %s", message)
         
-        # Read uniflow tar TerraBlob path
-        tb_path_file = tmp_path / _UNIFLOW_TAR_TB_PATH_FILENAME
-        if not tb_path_file.exists():
-            # Fall back to default uniflow tar path file if TB path doesn't exist
-            tb_path_file = tmp_path / "uniflow_tar_path.txt"
+        # Read uniflow tar path
+        tar_path_file = tmp_path / _UNIFLOW_TAR_PATH_FILENAME
             
         try:
-            uniflow_tar_tb_path = tb_path_file.read_text().strip()
-            _LOG.info("Read uniflow tar path: %s", uniflow_tar_tb_path)
+            uniflow_tar_path = tar_path_file.read_text().strip()
+            _LOG.info("Read uniflow tar path: %s", uniflow_tar_path)
         except FileNotFoundError:
             # Use remote path from status file if direct file read fails
             if remote_path:
-                uniflow_tar_tb_path = remote_path
-                _LOG.info("Using tar path from status file: %s", uniflow_tar_tb_path)
+                uniflow_tar_path = remote_path
+                _LOG.info("Using tar path from status file: %s", uniflow_tar_path)
             else:
-                raise RuntimeError(f"Could not read uniflow tar path from {tb_path_file}")
+                raise RuntimeError(f"Could not read uniflow tar path from {tar_path_file}")
         
         # Read uniflow workflow input  
         input_file_path = tmp_path / _UNIFLOW_INPUT_FILENAME
@@ -131,7 +128,7 @@ def get_pipeline_config_and_tar(repo_root: Path, config_file_relative_path: str,
         workflow_inputs = Struct()
         workflow_inputs.update(input_data)
         
-        return workflow_inputs, uniflow_tar_tb_path
+        return workflow_inputs, uniflow_tar_path
 
 
 def generate_create(crd: CRD, channel: Channel):
@@ -166,7 +163,7 @@ def convert_crd_metadata_pipeline_create(
     
     # Run pipeline registration to get uniflow artifacts
     try:
-        workflow_inputs, uniflow_tar_tb_path = get_pipeline_config_and_tar(
+        workflow_inputs, uniflow_tar_path = get_pipeline_config_and_tar(
             repo_root=repo_root,
             config_file_relative_path=config_file_relative_path,
             bazel_target="",  # Not used
@@ -194,7 +191,7 @@ def convert_crd_metadata_pipeline_create(
             # For other registration failures, continue with graceful degradation
             _LOG.warning("Registration failed, continuing without uniflow artifacts: %s", e)
             workflow_inputs = None
-            uniflow_tar_tb_path = ""
+            uniflow_tar_path = ""
     except Exception as e:
         _LOG.error("Unexpected error during registration: %s", e)
         # For unexpected errors, also use graceful degradation
@@ -232,8 +229,8 @@ def convert_crd_metadata_pipeline_create(
     if workflow_inputs is not None:
         _LOG.info("Workflow inputs discovered but not added to spec (schema limitation)")
         
-    if uniflow_tar_tb_path:
-        _LOG.info("Uniflow tar path: %s (not added to spec due to schema limitation)", uniflow_tar_tb_path)
+    if uniflow_tar_path:
+        _LOG.info("Uniflow tar path: %s (not added to spec due to schema limitation)", uniflow_tar_path)
     
     _LOG.debug("Converted CRD metadata: %r", res)
     return res

--- a/python/michelangelo/cli/mactl/plugins/pipeline/create.py
+++ b/python/michelangelo/cli/mactl/plugins/pipeline/create.py
@@ -219,7 +219,7 @@ def convert_crd_metadata_pipeline_create(
     
     res["spec"]["manifest"] = {
         "filePath": config_file_relative_path,
-        "type": "PIPELINE_MANIFEST_TYPE_YAML",
+        "type": "PIPELINE_MANIFEST_TYPE_UNIFLOW",
     }
     res["spec"]["owner"] = {"name": getenv("UBER_LDAP_UID")}
     

--- a/python/michelangelo/cli/mactl/plugins/pipeline/create.py
+++ b/python/michelangelo/cli/mactl/plugins/pipeline/create.py
@@ -11,7 +11,7 @@ from google.protobuf.message import Message
 from google.protobuf.struct_pb2 import Struct
 from grpc import Channel
 
-from mactl import CRD, PWD
+from mactl import CRD
 from michelangelo.cli.mactl.utils import (
     run_subprocess_registration,
     read_subprocess_outputs
@@ -197,7 +197,7 @@ def convert_crd_metadata_pipeline_create(
         # For unexpected errors, also use graceful degradation
         _LOG.warning("Unexpected registration failure, continuing without uniflow artifacts")
         workflow_inputs = None
-        uniflow_tar_tb_path = ""
+        uniflow_tar_path = ""
 
     res = {"spec": deepcopy(yaml_dict["spec"])}
     res["metadata"] = {

--- a/python/michelangelo/cli/mactl/utils.py
+++ b/python/michelangelo/cli/mactl/utils.py
@@ -16,34 +16,34 @@ _logger = getLogger(__name__)
 def detect_user_python_interpreter() -> str:
     """
     Detect the user's Python interpreter from environment metadata.
-    
+
     This function attempts to find the appropriate Python interpreter
     for the user's project environment, following common patterns:
-    
+
     1. Virtual environment (venv/virtualenv)
-    2. Conda environment  
+    2. Conda environment
     3. Poetry environment
     4. UV environment
     5. System Python (fallback)
-    
+
     Returns:
         str: Path to the user's Python interpreter
-        
+
     Raises:
         RuntimeError: If no suitable Python interpreter can be found
     """
     _logger.debug("Detecting user Python interpreter")
-    
+
     # 1. Check for virtual environment
     if "VIRTUAL_ENV" in os.environ:
         venv_path = Path(os.environ["VIRTUAL_ENV"])
         python_exe = "python.exe" if sys.platform == "win32" else "python"
         python_path = venv_path / "bin" / python_exe
-        
+
         if python_path.exists():
             _logger.info("Found virtual environment Python: %s", python_path)
             return str(python_path)
-    
+
     # 2. Check for Conda environment
     if "CONDA_DEFAULT_ENV" in os.environ or "CONDA_PREFIX" in os.environ:
         conda_prefix = os.environ.get("CONDA_PREFIX")
@@ -51,29 +51,29 @@ def detect_user_python_interpreter() -> str:
             conda_path = Path(conda_prefix)
             python_exe = "python.exe" if sys.platform == "win32" else "python"
             python_path = conda_path / "bin" / python_exe
-            
+
             if python_path.exists():
                 _logger.info("Found Conda environment Python: %s", python_path)
                 return str(python_path)
-    
+
     # 3. Check for Poetry environment
     poetry_python = detect_poetry_python()
     if poetry_python:
         _logger.info("Found Poetry environment Python: %s", poetry_python)
         return poetry_python
-    
+
     # 4. Check for UV environment
     uv_python = detect_uv_python()
     if uv_python:
         _logger.info("Found UV environment Python: %s", uv_python)
         return uv_python
-    
+
     # 5. Fall back to system Python
     system_python = shutil.which("python3") or shutil.which("python")
     if system_python:
         _logger.info("Using system Python: %s", system_python)
         return system_python
-    
+
     raise RuntimeError(
         "Could not detect a suitable Python interpreter. "
         "Please ensure Python is installed and available in PATH."
@@ -83,7 +83,7 @@ def detect_user_python_interpreter() -> str:
 def detect_poetry_python() -> Optional[str]:
     """
     Detect Python interpreter from Poetry environment.
-    
+
     Returns:
         Optional[str]: Path to Poetry's Python interpreter if found
     """
@@ -91,33 +91,33 @@ def detect_poetry_python() -> Optional[str]:
         # Check if poetry is available
         if not shutil.which("poetry"):
             return None
-        
+
         # Run poetry env info to get interpreter path
         result = subprocess.run(
             ["poetry", "env", "info", "--path"],
             capture_output=True,
             text=True,
-            timeout=10
+            timeout=10,
         )
-        
+
         if result.returncode == 0:
             venv_path = Path(result.stdout.strip())
             python_exe = "python.exe" if sys.platform == "win32" else "python"
             python_path = venv_path / "bin" / python_exe
-            
+
             if python_path.exists():
                 return str(python_path)
-    
+
     except (subprocess.TimeoutExpired, subprocess.SubprocessError, OSError):
         _logger.debug("Failed to detect Poetry environment")
-    
+
     return None
 
 
 def detect_uv_python() -> Optional[str]:
     """
     Detect Python interpreter from UV environment.
-    
+
     Returns:
         Optional[str]: Path to UV's Python interpreter if found
     """
@@ -125,27 +125,24 @@ def detect_uv_python() -> Optional[str]:
         # Check if uv is available
         if not shutil.which("uv"):
             return None
-        
+
         # Check for UV project
         if not Path("pyproject.toml").exists():
             return None
-        
+
         # Run uv python find to get interpreter path
         result = subprocess.run(
-            ["uv", "python", "find"],
-            capture_output=True,
-            text=True,
-            timeout=10
+            ["uv", "python", "find"], capture_output=True, text=True, timeout=10
         )
-        
+
         if result.returncode == 0:
             python_path = result.stdout.strip()
             if python_path and Path(python_path).exists():
                 return python_path
-    
+
     except (subprocess.TimeoutExpired, subprocess.SubprocessError, OSError):
         _logger.debug("Failed to detect UV environment")
-    
+
     return None
 
 
@@ -162,10 +159,10 @@ def run_subprocess_registration(
 ) -> subprocess.CompletedProcess:
     """
     Execute registration in a subprocess using the user's Python environment.
-    
+
     Args:
         project: Project name
-        pipeline: Pipeline name  
+        pipeline: Pipeline name
         config_file_path: Path to pipeline configuration file
         output_dir: Directory for output files
         storage_url: Optional storage URL
@@ -173,25 +170,31 @@ def run_subprocess_registration(
         environ: Optional environment variables
         args: Optional positional arguments
         kwargs: Optional keyword arguments
-        
+
     Returns:
         subprocess.CompletedProcess: Result of subprocess execution
-        
+
     Raises:
         RuntimeError: If subprocess execution fails
     """
     # Detect user's Python interpreter
     user_python = detect_user_python_interpreter()
-    
+
     # Build subprocess command
     cmd = [
-        user_python, "-m", "michelangelo.uniflow.registration.subprocess",
-        "--project", project,
-        "--pipeline", pipeline,
-        "--config-file", config_file_path,
-        "--output-dir", output_dir,
+        user_python,
+        "-m",
+        "michelangelo.uniflow.registration.subprocess",
+        "--project",
+        project,
+        "--pipeline",
+        pipeline,
+        "--config-file",
+        config_file_path,
+        "--output-dir",
+        output_dir,
     ]
-    
+
     # Add optional arguments
     if storage_url:
         cmd.extend(["--storage-url", storage_url])
@@ -199,16 +202,19 @@ def run_subprocess_registration(
         cmd.extend(["--output-filename", output_filename])
     if environ:
         import json
+
         cmd.extend(["--environ", json.dumps(environ)])
     if args:
         import json
+
         cmd.extend(["--args", json.dumps(args)])
     if kwargs:
         import json
+
         cmd.extend(["--kwargs", json.dumps(kwargs)])
-    
+
     _logger.info("Executing registration subprocess: %s", " ".join(cmd))
-    
+
     try:
         # Execute subprocess with timeout
         result = subprocess.run(
@@ -218,13 +224,13 @@ def run_subprocess_registration(
             timeout=300,  # 5 minute timeout
             cwd=os.getcwd(),
         )
-        
+
         _logger.debug("Subprocess stdout: %s", result.stdout)
         if result.stderr:
             _logger.debug("Subprocess stderr: %s", result.stderr)
-        
+
         return result
-        
+
     except subprocess.TimeoutExpired as e:
         raise RuntimeError(f"Registration subprocess timed out after 5 minutes: {e}")
     except subprocess.SubprocessError as e:
@@ -234,18 +240,18 @@ def run_subprocess_registration(
 def read_subprocess_outputs(output_dir: str) -> Tuple[bool, str, Optional[str]]:
     """
     Read outputs from subprocess registration.
-    
+
     Args:
         output_dir: Directory containing output files
-        
+
     Returns:
         Tuple of (success, message, remote_path)
         - success: Whether registration succeeded
-        - message: Success/error message  
+        - message: Success/error message
         - remote_path: Remote tarball path if successful
     """
     output_path = Path(output_dir)
-    
+
     # Check for success indicator
     success_file = output_path / "registration_success.txt"
     if success_file.exists():
@@ -253,7 +259,7 @@ def read_subprocess_outputs(output_dir: str) -> Tuple[bool, str, Optional[str]]:
         if content.startswith("SUCCESS: "):
             remote_path = content[9:]  # Remove "SUCCESS: " prefix
             return True, "Registration completed successfully", remote_path
-    
+
     # Check for error indicator
     error_file = output_path / "registration_error.txt"
     if error_file.exists():
@@ -261,6 +267,6 @@ def read_subprocess_outputs(output_dir: str) -> Tuple[bool, str, Optional[str]]:
         if content.startswith("ERROR: "):
             error_msg = content[7:]  # Remove "ERROR: " prefix
             return False, f"Registration failed: {error_msg}", None
-    
+
     # No clear indicator found
     return False, "Registration status unknown - no status files found", None

--- a/python/michelangelo/cli/mactl/utils.py
+++ b/python/michelangelo/cli/mactl/utils.py
@@ -1,0 +1,266 @@
+"""
+Utility functions for MaCTL subprocess management and environment detection.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional, Tuple
+from logging import getLogger
+
+_logger = getLogger(__name__)
+
+
+def detect_user_python_interpreter() -> str:
+    """
+    Detect the user's Python interpreter from environment metadata.
+    
+    This function attempts to find the appropriate Python interpreter
+    for the user's project environment, following common patterns:
+    
+    1. Virtual environment (venv/virtualenv)
+    2. Conda environment  
+    3. Poetry environment
+    4. UV environment
+    5. System Python (fallback)
+    
+    Returns:
+        str: Path to the user's Python interpreter
+        
+    Raises:
+        RuntimeError: If no suitable Python interpreter can be found
+    """
+    _logger.debug("Detecting user Python interpreter")
+    
+    # 1. Check for virtual environment
+    if "VIRTUAL_ENV" in os.environ:
+        venv_path = Path(os.environ["VIRTUAL_ENV"])
+        python_exe = "python.exe" if sys.platform == "win32" else "python"
+        python_path = venv_path / "bin" / python_exe
+        
+        if python_path.exists():
+            _logger.info("Found virtual environment Python: %s", python_path)
+            return str(python_path)
+    
+    # 2. Check for Conda environment
+    if "CONDA_DEFAULT_ENV" in os.environ or "CONDA_PREFIX" in os.environ:
+        conda_prefix = os.environ.get("CONDA_PREFIX")
+        if conda_prefix:
+            conda_path = Path(conda_prefix)
+            python_exe = "python.exe" if sys.platform == "win32" else "python"
+            python_path = conda_path / "bin" / python_exe
+            
+            if python_path.exists():
+                _logger.info("Found Conda environment Python: %s", python_path)
+                return str(python_path)
+    
+    # 3. Check for Poetry environment
+    poetry_python = detect_poetry_python()
+    if poetry_python:
+        _logger.info("Found Poetry environment Python: %s", poetry_python)
+        return poetry_python
+    
+    # 4. Check for UV environment
+    uv_python = detect_uv_python()
+    if uv_python:
+        _logger.info("Found UV environment Python: %s", uv_python)
+        return uv_python
+    
+    # 5. Fall back to system Python
+    system_python = shutil.which("python3") or shutil.which("python")
+    if system_python:
+        _logger.info("Using system Python: %s", system_python)
+        return system_python
+    
+    raise RuntimeError(
+        "Could not detect a suitable Python interpreter. "
+        "Please ensure Python is installed and available in PATH."
+    )
+
+
+def detect_poetry_python() -> Optional[str]:
+    """
+    Detect Python interpreter from Poetry environment.
+    
+    Returns:
+        Optional[str]: Path to Poetry's Python interpreter if found
+    """
+    try:
+        # Check if poetry is available
+        if not shutil.which("poetry"):
+            return None
+        
+        # Run poetry env info to get interpreter path
+        result = subprocess.run(
+            ["poetry", "env", "info", "--path"],
+            capture_output=True,
+            text=True,
+            timeout=10
+        )
+        
+        if result.returncode == 0:
+            venv_path = Path(result.stdout.strip())
+            python_exe = "python.exe" if sys.platform == "win32" else "python"
+            python_path = venv_path / "bin" / python_exe
+            
+            if python_path.exists():
+                return str(python_path)
+    
+    except (subprocess.TimeoutExpired, subprocess.SubprocessError, OSError):
+        _logger.debug("Failed to detect Poetry environment")
+    
+    return None
+
+
+def detect_uv_python() -> Optional[str]:
+    """
+    Detect Python interpreter from UV environment.
+    
+    Returns:
+        Optional[str]: Path to UV's Python interpreter if found
+    """
+    try:
+        # Check if uv is available
+        if not shutil.which("uv"):
+            return None
+        
+        # Check for UV project
+        if not Path("pyproject.toml").exists():
+            return None
+        
+        # Run uv python find to get interpreter path
+        result = subprocess.run(
+            ["uv", "python", "find"],
+            capture_output=True,
+            text=True,
+            timeout=10
+        )
+        
+        if result.returncode == 0:
+            python_path = result.stdout.strip()
+            if python_path and Path(python_path).exists():
+                return python_path
+    
+    except (subprocess.TimeoutExpired, subprocess.SubprocessError, OSError):
+        _logger.debug("Failed to detect UV environment")
+    
+    return None
+
+
+def run_subprocess_registration(
+    project: str,
+    pipeline: str,
+    config_file_path: str,
+    output_dir: str,
+    storage_url: Optional[str] = None,
+    output_filename: Optional[str] = None,
+    environ: Optional[dict] = None,
+    args: Optional[list] = None,
+    kwargs: Optional[dict] = None,
+) -> subprocess.CompletedProcess:
+    """
+    Execute registration in a subprocess using the user's Python environment.
+    
+    Args:
+        project: Project name
+        pipeline: Pipeline name  
+        config_file_path: Path to pipeline configuration file
+        output_dir: Directory for output files
+        storage_url: Optional storage URL
+        output_filename: Optional output filename
+        environ: Optional environment variables
+        args: Optional positional arguments
+        kwargs: Optional keyword arguments
+        
+    Returns:
+        subprocess.CompletedProcess: Result of subprocess execution
+        
+    Raises:
+        RuntimeError: If subprocess execution fails
+    """
+    # Detect user's Python interpreter
+    user_python = detect_user_python_interpreter()
+    
+    # Build subprocess command
+    cmd = [
+        user_python, "-m", "michelangelo.uniflow.registration.subprocess",
+        "--project", project,
+        "--pipeline", pipeline,
+        "--config-file", config_file_path,
+        "--output-dir", output_dir,
+    ]
+    
+    # Add optional arguments
+    if storage_url:
+        cmd.extend(["--storage-url", storage_url])
+    if output_filename:
+        cmd.extend(["--output-filename", output_filename])
+    if environ:
+        import json
+        cmd.extend(["--environ", json.dumps(environ)])
+    if args:
+        import json
+        cmd.extend(["--args", json.dumps(args)])
+    if kwargs:
+        import json
+        cmd.extend(["--kwargs", json.dumps(kwargs)])
+    
+    _logger.info("Executing registration subprocess: %s", " ".join(cmd))
+    
+    try:
+        # Execute subprocess with timeout
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=300,  # 5 minute timeout
+            cwd=os.getcwd(),
+        )
+        
+        _logger.debug("Subprocess stdout: %s", result.stdout)
+        if result.stderr:
+            _logger.debug("Subprocess stderr: %s", result.stderr)
+        
+        return result
+        
+    except subprocess.TimeoutExpired as e:
+        raise RuntimeError(f"Registration subprocess timed out after 5 minutes: {e}")
+    except subprocess.SubprocessError as e:
+        raise RuntimeError(f"Failed to execute registration subprocess: {e}")
+
+
+def read_subprocess_outputs(output_dir: str) -> Tuple[bool, str, Optional[str]]:
+    """
+    Read outputs from subprocess registration.
+    
+    Args:
+        output_dir: Directory containing output files
+        
+    Returns:
+        Tuple of (success, message, remote_path)
+        - success: Whether registration succeeded
+        - message: Success/error message  
+        - remote_path: Remote tarball path if successful
+    """
+    output_path = Path(output_dir)
+    
+    # Check for success indicator
+    success_file = output_path / "registration_success.txt"
+    if success_file.exists():
+        content = success_file.read_text().strip()
+        if content.startswith("SUCCESS: "):
+            remote_path = content[9:]  # Remove "SUCCESS: " prefix
+            return True, "Registration completed successfully", remote_path
+    
+    # Check for error indicator
+    error_file = output_path / "registration_error.txt"
+    if error_file.exists():
+        content = error_file.read_text().strip()
+        if content.startswith("ERROR: "):
+            error_msg = content[7:]  # Remove "ERROR: " prefix
+            return False, f"Registration failed: {error_msg}", None
+    
+    # No clear indicator found
+    return False, "Registration status unknown - no status files found", None

--- a/python/michelangelo/uniflow/registration/__init__.py
+++ b/python/michelangelo/uniflow/registration/__init__.py
@@ -1,0 +1,24 @@
+"""
+Michelangelo Uniflow Registration Module
+
+This module provides utilities for building, uploading, and registering
+Uniflow pipelines with Michelangelo pipeline services.
+
+The module supports both direct registration (for development/testing) and
+subprocess-based registration (for production MaCTL usage with environment isolation).
+"""
+
+from .register import register, main, prepare_uniflow_input
+from .uniflow_tar import UniflowTarBuilder, prepare_uniflow_tar
+
+# Subprocess module is available for import but not exposed in __all__
+# to maintain clean API surface while allowing MaCTL to access it
+from . import subprocess
+
+__all__ = [
+    "register",
+    "main", 
+    "prepare_uniflow_input",
+    "UniflowTarBuilder",
+    "prepare_uniflow_tar",
+]

--- a/python/michelangelo/uniflow/registration/__init__.py
+++ b/python/michelangelo/uniflow/registration/__init__.py
@@ -8,8 +8,15 @@ The module supports both direct registration (for development/testing) and
 subprocess-based registration (for production MaCTL usage with environment isolation).
 """
 
-from michelangelo.uniflow.registration.register import register, main, prepare_uniflow_input
-from michelangelo.uniflow.registration.uniflow_tar import UniflowTarBuilder, prepare_uniflow_tar
+from michelangelo.uniflow.registration.register import (
+    register,
+    main,
+    prepare_uniflow_input,
+)
+from michelangelo.uniflow.registration.uniflow_tar import (
+    UniflowTarBuilder,
+    prepare_uniflow_tar,
+)
 
 # Subprocess module is available for import but not exposed in __all__
 # to maintain clean API surface while allowing MaCTL to access it

--- a/python/michelangelo/uniflow/registration/__init__.py
+++ b/python/michelangelo/uniflow/registration/__init__.py
@@ -8,12 +8,12 @@ The module supports both direct registration (for development/testing) and
 subprocess-based registration (for production MaCTL usage with environment isolation).
 """
 
-from .register import register, main, prepare_uniflow_input
-from .uniflow_tar import UniflowTarBuilder, prepare_uniflow_tar
+from michelangelo.uniflow.registration.register import register, main, prepare_uniflow_input
+from michelangelo.uniflow.registration.uniflow_tar import UniflowTarBuilder, prepare_uniflow_tar
 
 # Subprocess module is available for import but not exposed in __all__
 # to maintain clean API surface while allowing MaCTL to access it
-from . import subprocess
+from michelangelo.uniflow.registration import subprocess
 
 __all__ = [
     "register",

--- a/python/michelangelo/uniflow/registration/__init__.py
+++ b/python/michelangelo/uniflow/registration/__init__.py
@@ -17,7 +17,7 @@ from . import subprocess
 
 __all__ = [
     "register",
-    "main", 
+    "main",
     "prepare_uniflow_input",
     "UniflowTarBuilder",
     "prepare_uniflow_tar",

--- a/python/michelangelo/uniflow/registration/__init__.py
+++ b/python/michelangelo/uniflow/registration/__init__.py
@@ -21,4 +21,5 @@ __all__ = [
     "prepare_uniflow_input",
     "UniflowTarBuilder",
     "prepare_uniflow_tar",
+    "subprocess",
 ]

--- a/python/michelangelo/uniflow/registration/register.py
+++ b/python/michelangelo/uniflow/registration/register.py
@@ -33,29 +33,29 @@ def main(args=None):
     """
     p = register_argument_parser()
     ns = p.parse_args(args=args).__dict__
-    
+
     # Extract and import the function
-    fn_path = ns.pop('fn')
+    fn_path = ns.pop("fn")
     fn = import_attribute(fn_path)
-    
+
     register(fn=fn, **ns)
 
 
 def prepare_uniflow_input(
-    args: Optional[tuple], 
-    kwargs: Optional[dict], 
-    environ: Optional[dict], 
-    output_dir: str
+    args: Optional[tuple],
+    kwargs: Optional[dict],
+    environ: Optional[dict],
+    output_dir: str,
 ):
     """
     Prepare uniflow input file for workflow registration and write it to the output directory.
-    
+
     This creates a JSON file containing the arguments, keyword arguments, and environment
     variables that will be passed to the workflow function during execution.
 
     Args:
         args: Positional arguments to pass to the function
-        kwargs: Keyword arguments to pass to the function  
+        kwargs: Keyword arguments to pass to the function
         environ: Environment variables to set during execution
         output_dir: Directory to write the input file
 
@@ -63,16 +63,12 @@ def prepare_uniflow_input(
         str: Path to the created input file
     """
     _kwargs = list(kwargs.items()) if kwargs else []
-    inputs = {
-        "args": args or (),
-        "kwargs": _kwargs,
-        "environ": environ or {}
-    }
+    inputs = {"args": args or (), "kwargs": _kwargs, "environ": environ or {}}
 
     inputs_path = os.path.join(output_dir, "uniflow_input.txt")
     with open(inputs_path, "w") as f:
         json.dump(inputs, f, default=encoder.default, indent=2)
-    
+
     _logger.info("Wrote uniflow input to: %s", inputs_path)
     return inputs_path
 
@@ -108,51 +104,33 @@ After registration, use mactl to create the pipeline:
   mactl pipeline create pipeline.yaml
         """,
     )
-    
+
     p.add_argument(
         "fn",
         type=str,
-        help="Fully qualified function name (e.g., 'my_module.my_function')"
+        help="Fully qualified function name (e.g., 'my_module.my_function')",
     )
-    p.add_argument(
-        "--project", 
-        required=True,
-        help="The project name"
-    )
-    p.add_argument(
-        "--pipeline", 
-        required=True,
-        help="The pipeline name"
-    )
+    p.add_argument("--project", required=True, help="The project name")
+    p.add_argument("--pipeline", required=True, help="The pipeline name")
     p.add_argument(
         "--output-dir",
         required=True,
-        help="Directory to write pipeline artifacts for mactl consumption"
+        help="Directory to write pipeline artifacts for mactl consumption",
     )
     p.add_argument(
         "--storage-url",
-        help="Storage URL for uploading tarballs (default: s3://default/uniflow)"
+        help="Storage URL for uploading tarballs (default: s3://default/uniflow)",
     )
     p.add_argument(
         "--output-filename",
-        help="Name of the tar path output file (default: uniflow_tar_path.txt)"
+        help="Name of the tar path output file (default: uniflow_tar_path.txt)",
     )
     p.add_argument(
-        "--environ",
-        type=json.loads,
-        help="Environment variables as JSON string"
+        "--environ", type=json.loads, help="Environment variables as JSON string"
     )
-    p.add_argument(
-        "--args", 
-        type=json.loads,
-        help="Positional arguments as JSON array"
-    )
-    p.add_argument(
-        "--kwargs",
-        type=json.loads, 
-        help="Keyword arguments as JSON object"
-    )
-    
+    p.add_argument("--args", type=json.loads, help="Positional arguments as JSON array")
+    p.add_argument("--kwargs", type=json.loads, help="Keyword arguments as JSON object")
+
     return p
 
 
@@ -195,7 +173,7 @@ def register(
     """
     if not fn:
         raise ValueError("Function (fn) is required")
-    
+
     # Set defaults
     environ = environ or {}
     args = args or ()

--- a/python/michelangelo/uniflow/registration/register.py
+++ b/python/michelangelo/uniflow/registration/register.py
@@ -15,7 +15,7 @@ from typing import Callable, Optional
 from michelangelo.uniflow.core.codec import encoder
 from michelangelo.uniflow.core.utils import LOGGING_FORMAT, import_attribute
 
-from .uniflow_tar import prepare_uniflow_tar
+from michelangelo.uniflow.registration.uniflow_tar import prepare_uniflow_tar
 
 _logger = logging.getLogger(__name__)
 

--- a/python/michelangelo/uniflow/registration/register.py
+++ b/python/michelangelo/uniflow/registration/register.py
@@ -1,0 +1,246 @@
+"""
+CLI program for registering Uniflow workflows with Michelangelo.
+
+This module provides the main registration interface that builds, uploads,
+and prepares Uniflow workflows for pipeline creation via mactl.
+"""
+
+import argparse
+import json
+import logging
+import os
+import sys
+from typing import Callable, Optional
+
+from michelangelo.uniflow.core.codec import encoder
+from michelangelo.uniflow.core.utils import LOGGING_FORMAT, import_attribute
+
+from .uniflow_tar import prepare_uniflow_tar
+
+_logger = logging.getLogger(__name__)
+
+
+def main(args=None):
+    """
+    CLI program to register the given workflow.
+    
+    Usage:
+        python -m michelangelo.uniflow.registration.register \
+            --project my-project \
+            --pipeline my-pipeline \
+            --output-dir /tmp/pipeline-artifacts \
+            my_module.my_workflow_function
+    """
+    p = register_argument_parser()
+    ns = p.parse_args(args=args).__dict__
+    
+    # Extract and import the function
+    fn_path = ns.pop('fn')
+    fn = import_attribute(fn_path)
+    
+    register(fn=fn, **ns)
+
+
+def prepare_uniflow_input(
+    args: Optional[tuple], 
+    kwargs: Optional[dict], 
+    environ: Optional[dict], 
+    output_dir: str
+):
+    """
+    Prepare uniflow input file for workflow registration and write it to the output directory.
+    
+    This creates a JSON file containing the arguments, keyword arguments, and environment
+    variables that will be passed to the workflow function during execution.
+
+    Args:
+        args: Positional arguments to pass to the function
+        kwargs: Keyword arguments to pass to the function  
+        environ: Environment variables to set during execution
+        output_dir: Directory to write the input file
+
+    Returns:
+        str: Path to the created input file
+    """
+    _kwargs = list(kwargs.items()) if kwargs else []
+    inputs = {
+        "args": args or (),
+        "kwargs": _kwargs,
+        "environ": environ or {}
+    }
+
+    inputs_path = os.path.join(output_dir, "uniflow_input.txt")
+    with open(inputs_path, "w") as f:
+        json.dump(inputs, f, default=encoder.default, indent=2)
+    
+    _logger.info("Wrote uniflow input to: %s", inputs_path)
+    return inputs_path
+
+
+def register_argument_parser():
+    """
+    Creates an argument parser for the Pipeline Registration CLI.
+
+    Returns:
+        argparse.ArgumentParser: Configured argument parser
+    """
+    p = argparse.ArgumentParser(
+        description="Register a Uniflow workflow with Michelangelo",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Register a workflow function
+  python -m michelangelo.uniflow.registration.register \\
+    --project my-project \\
+    --pipeline my-pipeline \\
+    --output-dir /tmp/artifacts \\
+    my_module.train_model
+
+  # Register with custom storage
+  python -m michelangelo.uniflow.registration.register \\
+    --project my-project \\
+    --pipeline my-pipeline \\
+    --output-dir /tmp/artifacts \\
+    --storage-url s3://my-bucket/uniflow \\
+    my_module.train_model
+
+After registration, use mactl to create the pipeline:
+  mactl pipeline create pipeline.yaml
+        """,
+    )
+    
+    p.add_argument(
+        "fn",
+        type=str,
+        help="Fully qualified function name (e.g., 'my_module.my_function')"
+    )
+    p.add_argument(
+        "--project", 
+        required=True,
+        help="The project name"
+    )
+    p.add_argument(
+        "--pipeline", 
+        required=True,
+        help="The pipeline name"
+    )
+    p.add_argument(
+        "--output-dir",
+        required=True,
+        help="Directory to write pipeline artifacts for mactl consumption"
+    )
+    p.add_argument(
+        "--storage-url",
+        help="Storage URL for uploading tarballs (default: s3://default/uniflow)"
+    )
+    p.add_argument(
+        "--output-filename",
+        help="Name of the tar path output file (default: uniflow_tar_path.txt)"
+    )
+    p.add_argument(
+        "--environ",
+        type=json.loads,
+        help="Environment variables as JSON string"
+    )
+    p.add_argument(
+        "--args", 
+        type=json.loads,
+        help="Positional arguments as JSON array"
+    )
+    p.add_argument(
+        "--kwargs",
+        type=json.loads, 
+        help="Keyword arguments as JSON object"
+    )
+    
+    return p
+
+
+def register(
+    *,
+    fn: Callable,
+    project: str,
+    pipeline: str,
+    output_dir: str,
+    storage_url: Optional[str] = None,
+    output_filename: Optional[str] = None,
+    environ: Optional[dict] = None,
+    args: Optional[tuple] = None,
+    kwargs: Optional[dict] = None,
+):
+    """
+    Register the workflow function in the specified context.
+
+    This function builds a Uniflow package from the workflow function,
+    uploads it to storage, and creates the necessary files for mactl
+    to create a pipeline.
+
+    Args:
+        fn: The workflow function to register
+        project: The project name
+        pipeline: The pipeline name
+        output_dir: The output directory for artifacts
+        storage_url: Optional storage URL (defaults to s3://default/uniflow)
+        output_filename: Optional output filename (defaults to uniflow_tar_path.txt)
+        environ: Environment variables to pass to the workflow
+        args: Positional arguments to pass to the workflow function
+        kwargs: Keyword arguments to pass to the workflow function
+
+    Returns:
+        str: The remote path where the tarball was uploaded
+
+    Raises:
+        ValueError: If required parameters are missing
+        Exception: If registration fails
+    """
+    if not fn:
+        raise ValueError("Function (fn) is required")
+    
+    # Set defaults
+    environ = environ or {}
+    args = args or ()
+    kwargs = kwargs or {}
+
+    _logger.info(
+        "Registering workflow: %s.%s for project=%s, pipeline=%s",
+        fn.__module__,
+        fn.__name__,
+        project,
+        pipeline,
+    )
+
+    # Build the workflow function identifier
+    workflow_function = f"{fn.__module__}.{fn.__name__}"
+
+    try:
+        # Prepare and upload the uniflow tarball
+        remote_path = prepare_uniflow_tar(
+            project_name=project,
+            pipeline_name=pipeline,
+            output_dir=output_dir,
+            workflow_function=workflow_function,
+            workflow_function_obj=fn,
+            storage_base_url=storage_url,
+            output_filename=output_filename,
+        )
+
+        # Prepare the input configuration
+        prepare_uniflow_input(args, kwargs, environ, output_dir)
+
+        _logger.info("Registration completed successfully")
+        _logger.info("Tarball uploaded to: %s", remote_path)
+        _logger.info("Artifacts written to: %s", output_dir)
+        _logger.info(
+            "Next step: Use mactl to create the pipeline with the generated artifacts"
+        )
+
+        return remote_path
+
+    except Exception as e:
+        _logger.error("Registration failed: %s", e)
+        raise
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format=LOGGING_FORMAT)
+    sys.exit(main())

--- a/python/michelangelo/uniflow/registration/subprocess.py
+++ b/python/michelangelo/uniflow/registration/subprocess.py
@@ -1,0 +1,238 @@
+"""
+Subprocess registration module for MaCTL isolation.
+
+This module runs in the user's Python environment as a subprocess,
+allowing MaCTL to remain isolated while accessing user dependencies.
+Communication occurs via command-line arguments and file I/O.
+"""
+
+import argparse
+import inspect
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+from michelangelo.uniflow.core.utils import LOGGING_FORMAT, import_attribute
+from michelangelo.uniflow.registration import register
+
+_logger = logging.getLogger(__name__)
+
+
+def discover_workflow_from_config(config_file_path: str):
+    """
+    Discover and import workflow function from pipeline configuration.
+    
+    This function reads the pipeline YAML configuration, extracts the manifest.path,
+    and discovers @workflow decorated functions in that module.
+    
+    Args:
+        config_file_path: Path to pipeline YAML configuration file
+        
+    Returns:
+        Callable: The discovered workflow function
+        
+    Raises:
+        ValueError: If no workflow function found or multiple found
+        ImportError: If module cannot be imported
+    """
+    _logger.info("Discovering workflow function from config: %s", config_file_path)
+    
+    # Read YAML configuration
+    with open(config_file_path, 'r') as f:
+        config = yaml.safe_load(f)
+    
+    # Extract manifest path
+    manifest_data = config.get('spec', {}).get('manifest', {})
+    manifest_path = manifest_data.get('filePath') or manifest_data.get('path')
+    
+    if not manifest_path:
+        raise ValueError("No manifest.filePath or manifest.path found in pipeline configuration")
+    _logger.info("Found manifest path: %s", manifest_path)
+    
+    # Import the module
+    try:
+        # Use importlib to import the module directly
+        import importlib
+        module = importlib.import_module(manifest_path)
+        _logger.info("Successfully imported module: %s", manifest_path)
+    except ImportError as e:
+        _logger.error("Failed to import module %s: %s", manifest_path, e)
+        raise
+    
+    # Find @workflow decorated functions
+    workflow_functions = []
+    
+    for name, obj in inspect.getmembers(module):
+        if inspect.isfunction(obj):
+            # Check if function has @workflow decorator
+            if hasattr(obj, '__wrapped__') or hasattr(obj, '_uniflow_workflow'):
+                workflow_functions.append((name, obj))
+                _logger.info("Found workflow function: %s", name)
+    
+    # Validate results
+    if not workflow_functions:
+        raise ValueError(f"No @workflow decorated functions found in module {manifest_path}")
+    
+    if len(workflow_functions) > 1:
+        func_names = [name for name, _ in workflow_functions]
+        _logger.warning("Multiple workflow functions found: %s. Using first one.", func_names)
+    
+    selected_name, selected_func = workflow_functions[0]
+    _logger.info("Selected workflow function: %s", selected_name)
+    
+    return selected_func
+
+
+def main():
+    """
+    Entry point for subprocess registration.
+    
+    This function runs in the user's Python environment and handles
+    workflow registration independently from the main MaCTL process.
+    """
+    parser = create_argument_parser()
+    args = parser.parse_args()
+    
+    # Set up logging
+    logging.basicConfig(level=logging.INFO, format=LOGGING_FORMAT)
+    
+    try:
+        # Read pipeline configuration to discover workflow function
+        _logger.info("Reading pipeline configuration: %s", args.config_file)
+        workflow_fn = discover_workflow_from_config(args.config_file)
+        
+        # Parse optional JSON arguments
+        environ = json.loads(args.environ) if args.environ else None
+        fn_args = json.loads(args.args) if args.args else None
+        kwargs = json.loads(args.kwargs) if args.kwargs else None
+        
+        _logger.info("Starting registration process")
+        
+        # Execute registration in user's environment
+        remote_path = register(
+            fn=workflow_fn,
+            project=args.project,
+            pipeline=args.pipeline,
+            output_dir=args.output_dir,
+            storage_url=args.storage_url,
+            output_filename=args.output_filename,
+            environ=environ,
+            args=fn_args,
+            kwargs=kwargs,
+        )
+        
+        _logger.info("Registration completed successfully")
+        _logger.info("Remote tarball path: %s", remote_path)
+        
+        # Write success indicator
+        success_file = Path(args.output_dir) / "registration_success.txt"
+        success_file.write_text(f"SUCCESS: {remote_path}")
+        
+    except ImportError as e:
+        error_msg = f"Could not import workflow function from config '{args.config_file}': {e}"
+        _logger.error(error_msg)
+        
+        # Write failure indicator with specific error type
+        error_file = Path(args.output_dir) / "registration_error.txt"
+        error_file.write_text(f"ERROR: ImportError - {error_msg}")
+        
+        # Exit with specific error code for import failures
+        sys.exit(2)
+    except ModuleNotFoundError as e:
+        error_msg = f"Module not found for workflow function from config '{args.config_file}': {e}"
+        _logger.error(error_msg)
+        
+        # Write failure indicator
+        error_file = Path(args.output_dir) / "registration_error.txt"
+        error_file.write_text(f"ERROR: ModuleNotFoundError - {error_msg}")
+        
+        # Exit with specific error code for module not found
+        sys.exit(3)
+    except Exception as e:
+        error_msg = f"Registration failed: {e}"
+        _logger.error(error_msg)
+        
+        # Write failure indicator
+        error_file = Path(args.output_dir) / "registration_error.txt"
+        error_file.write_text(f"ERROR: {error_msg}")
+        
+        # Exit with general error code
+        sys.exit(1)
+
+
+def create_argument_parser() -> argparse.ArgumentParser:
+    """
+    Create argument parser for subprocess registration.
+    
+    Returns:
+        Configured argument parser
+    """
+    parser = argparse.ArgumentParser(
+        description="Subprocess registration for MaCTL pipeline workflows",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+This module is designed to run in the user's Python environment
+as a subprocess spawned by MaCTL. It handles workflow registration
+while maintaining environment isolation.
+
+Communication Protocol:
+- Input: Command-line arguments
+- Output: Files in specified output directory
+- Success: registration_success.txt + standard output files
+- Failure: registration_error.txt + exit code 1
+        """,
+    )
+    
+    # Required arguments
+    parser.add_argument(
+        "--project",
+        required=True,
+        help="Project name for the pipeline"
+    )
+    parser.add_argument(
+        "--pipeline", 
+        required=True,
+        help="Pipeline name"
+    )
+    parser.add_argument(
+        "--config-file",
+        required=True,
+        help="Path to pipeline configuration YAML file"
+    )
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        help="Directory to write registration output files"
+    )
+    
+    # Optional arguments
+    parser.add_argument(
+        "--storage-url",
+        help="Storage URL for uploading tarballs (default: s3://default/uniflow)"
+    )
+    parser.add_argument(
+        "--output-filename", 
+        help="Name of the tar path output file (default: uniflow_tar_path.txt)"
+    )
+    parser.add_argument(
+        "--environ",
+        help="Environment variables as JSON string"
+    )
+    parser.add_argument(
+        "--args",
+        help="Positional arguments as JSON array"
+    )
+    parser.add_argument(
+        "--kwargs", 
+        help="Keyword arguments as JSON object"
+    )
+    
+    return parser
+
+
+if __name__ == "__main__":
+    main()

--- a/python/michelangelo/uniflow/registration/subprocess.py
+++ b/python/michelangelo/uniflow/registration/subprocess.py
@@ -12,11 +12,10 @@ import json
 import logging
 import sys
 from pathlib import Path
-from typing import Optional
 
 import yaml
 
-from michelangelo.uniflow.core.utils import LOGGING_FORMAT, import_attribute
+from michelangelo.uniflow.core.utils import LOGGING_FORMAT
 from michelangelo.uniflow.registration import register
 
 _logger = logging.getLogger(__name__)

--- a/python/michelangelo/uniflow/registration/subprocess.py
+++ b/python/michelangelo/uniflow/registration/subprocess.py
@@ -17,6 +17,7 @@ import yaml
 
 from michelangelo.uniflow.core.utils import LOGGING_FORMAT
 from michelangelo.uniflow.registration import register
+from michelangelo.uniflow.registration.config_builder import ConfigBuilder
 
 _logger = logging.getLogger(__name__)
 
@@ -24,93 +25,112 @@ _logger = logging.getLogger(__name__)
 def discover_workflow_from_config(config_file_path: str):
     """
     Discover and import workflow function from pipeline configuration.
-    
+
     This function reads the pipeline YAML configuration, extracts the manifest.path,
     and discovers @workflow decorated functions in that module.
-    
+
     Args:
         config_file_path: Path to pipeline YAML configuration file
-        
+
     Returns:
         Callable: The discovered workflow function
-        
+
     Raises:
         ValueError: If no workflow function found or multiple found
         ImportError: If module cannot be imported
     """
     _logger.info("Discovering workflow function from config: %s", config_file_path)
-    
+
     # Read YAML configuration
-    with open(config_file_path, 'r') as f:
+    with open(config_file_path, "r") as f:
         config = yaml.safe_load(f)
-    
+
     # Extract manifest path
-    manifest_data = config.get('spec', {}).get('manifest', {})
-    manifest_path = manifest_data.get('filePath') or manifest_data.get('path')
-    
+    manifest_data = config.get("spec", {}).get("manifest", {})
+    manifest_path = manifest_data.get("filePath") or manifest_data.get("path")
+
     if not manifest_path:
-        raise ValueError("No manifest.filePath or manifest.path found in pipeline configuration")
+        raise ValueError(
+            "No manifest.filePath or manifest.path found in pipeline configuration"
+        )
     _logger.info("Found manifest path: %s", manifest_path)
-    
+
     # Import the module
     try:
         # Use importlib to import the module directly
         import importlib
+
         module = importlib.import_module(manifest_path)
         _logger.info("Successfully imported module: %s", manifest_path)
     except ImportError as e:
         _logger.error("Failed to import module %s: %s", manifest_path, e)
         raise
-    
+
     # Find @workflow decorated functions
     workflow_functions = []
-    
+
     for name, obj in inspect.getmembers(module):
         if inspect.isfunction(obj):
             # Check if function has @workflow decorator
-            if hasattr(obj, '__wrapped__') or hasattr(obj, '_uniflow_workflow'):
+            if hasattr(obj, "__wrapped__") or hasattr(obj, "_uniflow_workflow"):
                 workflow_functions.append((name, obj))
                 _logger.info("Found workflow function: %s", name)
-    
+
     # Validate results
     if not workflow_functions:
-        raise ValueError(f"No @workflow decorated functions found in module {manifest_path}")
-    
+        raise ValueError(
+            f"No @workflow decorated functions found in module {manifest_path}"
+        )
+
     if len(workflow_functions) > 1:
         func_names = [name for name, _ in workflow_functions]
-        _logger.warning("Multiple workflow functions found: %s. Using first one.", func_names)
-    
+        _logger.warning(
+            "Multiple workflow functions found: %s. Using first one.", func_names
+        )
+
     selected_name, selected_func = workflow_functions[0]
     _logger.info("Selected workflow function: %s", selected_name)
-    
+
     return selected_func
 
 
 def main():
     """
     Entry point for subprocess registration.
-    
+
     This function runs in the user's Python environment and handles
     workflow registration independently from the main MaCTL process.
     """
     parser = create_argument_parser()
     args = parser.parse_args()
-    
+
     # Set up logging
     logging.basicConfig(level=logging.INFO, format=LOGGING_FORMAT)
-    
+
     try:
         # Read pipeline configuration to discover workflow function
         _logger.info("Reading pipeline configuration: %s", args.config_file)
         workflow_fn = discover_workflow_from_config(args.config_file)
-        
-        # Parse optional JSON arguments
-        environ = json.loads(args.environ) if args.environ else None
-        fn_args = json.loads(args.args) if args.args else None
-        kwargs = json.loads(args.kwargs) if args.kwargs else None
-        
-        _logger.info("Starting registration process")
-        
+
+        # Create ConfigBuilder to extract workflow arguments
+        _logger.info("Analyzing workflow function for argument extraction")
+        config_builder = ConfigBuilder(workflow_fn)
+
+        # Get workflow arguments from function analysis
+        workflow_args = config_builder.get_workflow_args()
+        workflow_kwargs = config_builder.get_workflow_kwargs()
+        workflow_environ = config_builder.get_workflow_environ()
+
+        # Override with any provided arguments (command line takes precedence)
+        final_environ = json.loads(args.environ) if args.environ else workflow_environ
+        final_args = json.loads(args.args) if args.args else workflow_args
+        final_kwargs = json.loads(args.kwargs) if args.kwargs else workflow_kwargs
+
+        _logger.info("Starting registration process with extracted arguments")
+        _logger.info("Final args: %s", final_args)
+        _logger.info("Final kwargs: %s", final_kwargs)
+        _logger.info("Final environ: %s", final_environ)
+
         # Execute registration in user's environment
         remote_path = register(
             fn=workflow_fn,
@@ -119,46 +139,53 @@ def main():
             output_dir=args.output_dir,
             storage_url=args.storage_url,
             output_filename=args.output_filename,
-            environ=environ,
-            args=fn_args,
-            kwargs=kwargs,
+            environ=final_environ,
+            args=final_args,
+            kwargs=final_kwargs,
         )
-        
+
         _logger.info("Registration completed successfully")
         _logger.info("Remote tarball path: %s", remote_path)
-        
+
         # Write success indicator
         success_file = Path(args.output_dir) / "registration_success.txt"
         success_file.write_text(f"SUCCESS: {remote_path}")
-        
+
+        # Write workflow function name for main process
+        function_name_file = Path(args.output_dir) / "workflow_function_name.txt"
+        function_name_file.write_text(workflow_fn.__name__)
+        _logger.info("Wrote workflow function name: %s", workflow_fn.__name__)
+
     except ImportError as e:
-        error_msg = f"Could not import workflow function from config '{args.config_file}': {e}"
+        error_msg = (
+            f"Could not import workflow function from config '{args.config_file}': {e}"
+        )
         _logger.error(error_msg)
-        
+
         # Write failure indicator with specific error type
         error_file = Path(args.output_dir) / "registration_error.txt"
         error_file.write_text(f"ERROR: ImportError - {error_msg}")
-        
+
         # Exit with specific error code for import failures
         sys.exit(2)
     except ModuleNotFoundError as e:
         error_msg = f"Module not found for workflow function from config '{args.config_file}': {e}"
         _logger.error(error_msg)
-        
+
         # Write failure indicator
         error_file = Path(args.output_dir) / "registration_error.txt"
         error_file.write_text(f"ERROR: ModuleNotFoundError - {error_msg}")
-        
+
         # Exit with specific error code for module not found
         sys.exit(3)
     except Exception as e:
         error_msg = f"Registration failed: {e}"
         _logger.error(error_msg)
-        
+
         # Write failure indicator
         error_file = Path(args.output_dir) / "registration_error.txt"
         error_file.write_text(f"ERROR: {error_msg}")
-        
+
         # Exit with general error code
         sys.exit(1)
 
@@ -166,7 +193,7 @@ def main():
 def create_argument_parser() -> argparse.ArgumentParser:
     """
     Create argument parser for subprocess registration.
-    
+
     Returns:
         Configured argument parser
     """
@@ -185,51 +212,34 @@ Communication Protocol:
 - Failure: registration_error.txt + exit code 1
         """,
     )
-    
+
     # Required arguments
     parser.add_argument(
-        "--project",
-        required=True,
-        help="Project name for the pipeline"
+        "--project", required=True, help="Project name for the pipeline"
     )
+    parser.add_argument("--pipeline", required=True, help="Pipeline name")
     parser.add_argument(
-        "--pipeline", 
-        required=True,
-        help="Pipeline name"
-    )
-    parser.add_argument(
-        "--config-file",
-        required=True,
-        help="Path to pipeline configuration YAML file"
+        "--config-file", required=True, help="Path to pipeline configuration YAML file"
     )
     parser.add_argument(
         "--output-dir",
         required=True,
-        help="Directory to write registration output files"
+        help="Directory to write registration output files",
     )
-    
+
     # Optional arguments
     parser.add_argument(
         "--storage-url",
-        help="Storage URL for uploading tarballs (default: s3://default/uniflow)"
+        help="Storage URL for uploading tarballs (default: s3://default/uniflow)",
     )
     parser.add_argument(
-        "--output-filename", 
-        help="Name of the tar path output file (default: uniflow_tar_path.txt)"
+        "--output-filename",
+        help="Name of the tar path output file (default: uniflow_tar_path.txt)",
     )
-    parser.add_argument(
-        "--environ",
-        help="Environment variables as JSON string"
-    )
-    parser.add_argument(
-        "--args",
-        help="Positional arguments as JSON array"
-    )
-    parser.add_argument(
-        "--kwargs", 
-        help="Keyword arguments as JSON object"
-    )
-    
+    parser.add_argument("--environ", help="Environment variables as JSON string")
+    parser.add_argument("--args", help="Positional arguments as JSON array")
+    parser.add_argument("--kwargs", help="Keyword arguments as JSON object")
+
     return parser
 
 

--- a/python/michelangelo/uniflow/registration/uniflow_tar.py
+++ b/python/michelangelo/uniflow/registration/uniflow_tar.py
@@ -10,7 +10,7 @@ import os
 from typing import Callable, Optional
 
 # Import the storage-agnostic implementation
-from .uniflow_tar_impl import UniflowTarBuilderImpl
+from michelangelo.uniflow.registration.uniflow_tar_impl import UniflowTarBuilderImpl
 
 # Check for s3fs availability
 try:

--- a/python/michelangelo/uniflow/registration/uniflow_tar.py
+++ b/python/michelangelo/uniflow/registration/uniflow_tar.py
@@ -46,7 +46,7 @@ class UniflowTarBuilder:
 
         Args:
             project_name: Name of the project
-            pipeline_name: Name of the pipeline  
+            pipeline_name: Name of the pipeline
             workflow_function: Fully qualified function name
             workflow_function_obj: Optional callable workflow function object
             storage_base_url: Optional storage URL. Defaults to s3://default/uniflow
@@ -149,7 +149,9 @@ def prepare_uniflow_tar(
     os.makedirs(output_dir, exist_ok=True)
 
     # Use the filename from the builder (either provided or default)
-    actual_filename = output_filename if output_filename is not None else _UNIFLOW_TAR_PATH_FILENAME
+    actual_filename = (
+        output_filename if output_filename is not None else _UNIFLOW_TAR_PATH_FILENAME
+    )
     output_path = os.path.join(output_dir, actual_filename)
 
     # Write the remote path to file for mactl consumption

--- a/python/michelangelo/uniflow/registration/uniflow_tar.py
+++ b/python/michelangelo/uniflow/registration/uniflow_tar.py
@@ -1,0 +1,162 @@
+"""
+Michelangelo-specific wrapper for uniflow tar building with S3 defaults.
+
+This module provides backward compatibility for Michelangelo internal usage
+while delegating to the storage-agnostic implementation in uniflow_tar_impl.py.
+"""
+
+import logging
+import os
+from typing import Callable, Optional
+
+# Import the storage-agnostic implementation
+from .uniflow_tar_impl import UniflowTarBuilderImpl
+
+# Check for s3fs availability
+try:
+    import s3fs
+except ImportError:
+    s3fs = None
+
+_logger = logging.getLogger(__name__)
+_UNIFLOW_TAR_PATH_FILENAME = "uniflow_tar_path.txt"
+_DEFAULT_S3_PATH = "s3://default/uniflow"
+
+
+class UniflowTarBuilder:
+    """
+    Michelangelo-specific UniflowTarBuilder with S3 defaults.
+
+    This class maintains compatibility with existing usage patterns
+    while delegating to the storage-agnostic UniflowTarBuilderImpl.
+    Uses S3 with MinIO defaults for Michelangelo environments.
+    """
+
+    def __init__(
+        self,
+        project_name: str,
+        pipeline_name: str,
+        workflow_function: str,
+        workflow_function_obj: Optional[Callable] = None,
+        storage_base_url: Optional[str] = None,
+        output_filename: Optional[str] = None,
+    ):
+        """
+        Initialize the Michelangelo Uniflow tar builder.
+
+        Args:
+            project_name: Name of the project
+            pipeline_name: Name of the pipeline  
+            workflow_function: Fully qualified function name
+            workflow_function_obj: Optional callable workflow function object
+            storage_base_url: Optional storage URL. Defaults to s3://default/uniflow
+            output_filename: Name of output file. Defaults to uniflow_tar_path.txt
+        """
+        # Use S3 with MinIO defaults for Michelangelo
+        if storage_base_url is None:
+            storage_base_url = _DEFAULT_S3_PATH
+            _logger.debug("Using default S3 storage: %s", storage_base_url)
+
+        # Use Michelangelo-specific filename by default
+        if output_filename is None:
+            output_filename = _UNIFLOW_TAR_PATH_FILENAME
+
+        # Check s3fs availability if using S3
+        if storage_base_url.startswith("s3://") and s3fs is None:
+            _logger.warning(
+                "s3fs not available. Install with: pip install s3fs"
+                " or add s3fs to your dependencies."
+            )
+
+        # Delegate to storage-agnostic implementation
+        self._impl = UniflowTarBuilderImpl(
+            project_name=project_name,
+            pipeline_name=pipeline_name,
+            workflow_function=workflow_function,
+            workflow_function_obj=workflow_function_obj,
+            storage_base_path=storage_base_url,
+            output_filename=output_filename,
+        )
+
+    def get_random_tar_name(self) -> str:
+        """Delegate to underlying implementation."""
+        return self._impl.get_random_tar_name()
+
+    def get_tar_name(self) -> str:
+        """Delegate to underlying implementation."""
+        return self._impl.get_tar_name()
+
+    def get_remote_tar_path(self) -> str:
+        """Delegate to underlying implementation."""
+        return self._impl.get_remote_tar_path()
+
+    def build_and_upload_tarball(self) -> str:
+        """Delegate to underlying implementation."""
+        return self._impl.build_and_upload_tarball()
+
+
+def prepare_uniflow_tar(
+    project_name: str,
+    pipeline_name: str,
+    output_dir: str,
+    workflow_function: str,
+    workflow_function_obj: Optional[Callable] = None,
+    storage_base_url: Optional[str] = None,
+    output_filename: Optional[str] = None,
+):
+    """
+    Prepare and upload a Uniflow tarball for Michelangelo pipeline registration.
+
+    This function builds a Uniflow package, uploads it to storage, and writes
+    the storage path to a file for mactl consumption.
+
+    Args:
+        project_name: Name of the project
+        pipeline_name: Name of the pipeline
+        output_dir: Directory to write the tar path file
+        workflow_function: Fully qualified function name (e.g., "module.function")
+        workflow_function_obj: Optional callable workflow function object
+        storage_base_url: Optional storage URL. Defaults to s3://default/uniflow
+        output_filename: Name of output file. Defaults to uniflow_tar_path.txt
+
+    Returns:
+        str: The remote path where the tarball was uploaded
+
+    Raises:
+        ValueError: If workflow_function_obj is not provided
+        Exception: If build, upload, or file write fails
+    """
+    _logger.info(
+        "Preparing uniflow tar for project=%s, pipeline=%s",
+        project_name,
+        pipeline_name,
+    )
+
+    # Create tar builder with Michelangelo-specific defaults
+    tar_builder = UniflowTarBuilder(
+        project_name=project_name,
+        pipeline_name=pipeline_name,
+        workflow_function=workflow_function,
+        workflow_function_obj=workflow_function_obj,
+        storage_base_url=storage_base_url,
+        output_filename=output_filename,
+    )
+
+    # Build and upload the tarball
+    remote_path = tar_builder.build_and_upload_tarball()
+
+    # Ensure output directory exists
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Use the filename from the builder (either provided or default)
+    actual_filename = output_filename if output_filename is not None else _UNIFLOW_TAR_PATH_FILENAME
+    output_path = os.path.join(output_dir, actual_filename)
+
+    # Write the remote path to file for mactl consumption
+    with open(output_path, "w") as f:
+        f.write(remote_path)
+
+    _logger.info("Wrote tar path to: %s", output_path)
+    _logger.info("Remote tarball location: %s", remote_path)
+
+    return remote_path

--- a/python/michelangelo/uniflow/registration/uniflow_tar_impl.py
+++ b/python/michelangelo/uniflow/registration/uniflow_tar_impl.py
@@ -1,0 +1,123 @@
+"""
+Storage-agnostic implementation for building and uploading Uniflow tarballs.
+
+This module provides the core functionality for packaging Uniflow workflows
+into tarballs and uploading them to various storage backends using fsspec.
+"""
+
+import logging
+import uuid
+from pathlib import Path
+from typing import Callable, Optional
+
+try:
+    import fsspec
+except ImportError:
+    raise ImportError(
+        "fsspec is required for uniflow registration. "
+        "Install with: pip install fsspec"
+    )
+
+from michelangelo.uniflow.core.build import build
+
+_logger = logging.getLogger(__name__)
+
+
+class UniflowTarBuilderImpl:
+    """
+    Storage-agnostic Uniflow tar builder implementation.
+    
+    This class handles the core functionality of building Uniflow packages
+    and uploading them to any fsspec-compatible storage backend.
+    """
+
+    def __init__(
+        self,
+        project_name: str,
+        pipeline_name: str,
+        workflow_function: str,
+        workflow_function_obj: Optional[Callable] = None,
+        storage_base_path: str = "s3://default/uniflow",
+        output_filename: str = "uniflow_tar_path.txt",
+    ):
+        """
+        Initialize the Uniflow tar builder.
+
+        Args:
+            project_name: Name of the project
+            pipeline_name: Name of the pipeline
+            workflow_function: Fully qualified function name (e.g., "module.function")
+            workflow_function_obj: Optional callable workflow function object
+            storage_base_path: Base path for storing tarballs
+            output_filename: Name of the output file containing the tar path
+        """
+        self.project_name = project_name
+        self.pipeline_name = pipeline_name
+        self.workflow_function = workflow_function
+        self.workflow_function_obj = workflow_function_obj
+        self.storage_base_path = storage_base_path.rstrip("/")
+        self.output_filename = output_filename
+        self._tar_name = None
+
+    def get_random_tar_name(self) -> str:
+        """Generate a unique tar filename for this pipeline."""
+        if self._tar_name is None:
+            random_id = str(uuid.uuid4())[:8]
+            self._tar_name = f"{self.project_name}_{self.pipeline_name}_{random_id}.tar.gz"
+        return self._tar_name
+
+    def get_tar_name(self) -> str:
+        """Get the tar filename (alias for get_random_tar_name for compatibility)."""
+        return self.get_random_tar_name()
+
+    def get_remote_tar_path(self) -> str:
+        """Get the full remote storage path for the tarball."""
+        return f"{self.storage_base_path}/{self.get_random_tar_name()}"
+
+    def build_and_upload_tarball(self) -> str:
+        """
+        Build the Uniflow package and upload it to storage.
+
+        Returns:
+            str: The remote path where the tarball was uploaded
+
+        Raises:
+            ValueError: If workflow_function_obj is not provided
+            Exception: If build or upload fails
+        """
+        if not self.workflow_function_obj:
+            raise ValueError(
+                "workflow_function_obj is required for building. "
+                "Please provide the actual function object."
+            )
+
+        _logger.info(
+            "Building uniflow package for %s.%s",
+            self.project_name,
+            self.pipeline_name,
+        )
+
+        try:
+            # Use existing build system from michelangelo.uniflow.core.build
+            package = build(self.workflow_function_obj)
+            tarball_bytes = package.to_tarball_bytes()
+
+            _logger.info(
+                "Built tarball with %d bytes, main function: %s",
+                len(tarball_bytes),
+                package.main_function,
+            )
+
+            # Upload to storage using fsspec
+            remote_path = self.get_remote_tar_path()
+            _logger.info("Uploading to: %s", remote_path)
+
+            with fsspec.open(remote_path, "wb") as f:
+                f.write(tarball_bytes)
+
+            _logger.info("Successfully uploaded tarball to: %s", remote_path)
+            return remote_path
+
+        except Exception as e:
+            _logger.error("Failed to build and upload tarball: %s", e)
+            raise

--- a/python/michelangelo/uniflow/registration/uniflow_tar_impl.py
+++ b/python/michelangelo/uniflow/registration/uniflow_tar_impl.py
@@ -9,12 +9,7 @@ import logging
 import uuid
 from typing import Callable, Optional
 
-try:
-    import fsspec
-except ImportError:
-    raise ImportError(
-        "fsspec is required for uniflow registration. Install with: pip install fsspec"
-    )
+import fsspec
 
 from michelangelo.uniflow.core.build import build
 

--- a/python/michelangelo/uniflow/registration/uniflow_tar_impl.py
+++ b/python/michelangelo/uniflow/registration/uniflow_tar_impl.py
@@ -13,8 +13,7 @@ try:
     import fsspec
 except ImportError:
     raise ImportError(
-        "fsspec is required for uniflow registration. "
-        "Install with: pip install fsspec"
+        "fsspec is required for uniflow registration. Install with: pip install fsspec"
     )
 
 from michelangelo.uniflow.core.build import build
@@ -25,7 +24,7 @@ _logger = logging.getLogger(__name__)
 class UniflowTarBuilderImpl:
     """
     Storage-agnostic Uniflow tar builder implementation.
-    
+
     This class handles the core functionality of building Uniflow packages
     and uploading them to any fsspec-compatible storage backend.
     """
@@ -62,7 +61,9 @@ class UniflowTarBuilderImpl:
         """Generate a unique tar filename for this pipeline."""
         if self._tar_name is None:
             random_id = str(uuid.uuid4())[:8]
-            self._tar_name = f"{self.project_name}_{self.pipeline_name}_{random_id}.tar.gz"
+            self._tar_name = (
+                f"{self.project_name}_{self.pipeline_name}_{random_id}.tar.gz"
+            )
         return self._tar_name
 
     def get_tar_name(self) -> str:

--- a/python/michelangelo/uniflow/registration/uniflow_tar_impl.py
+++ b/python/michelangelo/uniflow/registration/uniflow_tar_impl.py
@@ -7,7 +7,6 @@ into tarballs and uploading them to various storage backends using fsspec.
 
 import logging
 import uuid
-from pathlib import Path
 from typing import Callable, Optional
 
 try:


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
Implements subprocess-based pipeline registration for MaCTL with environment isolation. MaCTL detects user's Python environment (venv/conda/poetry) and
  spawns subprocess to handle workflow registration, preventing dependency conflicts while maintaining clean separation between CLI and user code.

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Test using - 
1) bazel run //go/cmd/apiserver:apiserver
2) cd python
3) poetry run python -m michelangelo.cli.mactl.mactl create --file="examples/bert_cola/pipeline.yaml"

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
