### PR TITLE
[WIP] [kubeproto] Add ext field to all messages

### DIFF
--- a/go/cmd/kubeproto/protoc-gen-kubeproto/main.go
+++ b/go/cmd/kubeproto/protoc-gen-kubeproto/main.go
@@ -283,6 +283,22 @@ func updateGoFile(gofile *plugingo.CodeGeneratorResponse_File, protofile *protog
 						}
 					}
 
+					// Add "ext" field of type *anypb.Any to all structs
+					extField := &dst.Field{
+						Names: []*dst.Ident{dst.NewIdent("Ext")},
+						Type: &dst.StarExpr{
+							X: &dst.SelectorExpr{
+								X:   dst.NewIdent("anypb"),
+								Sel: dst.NewIdent("Any"),
+							},
+						},
+						Tag: &dst.BasicLit{
+							Kind:  token.STRING,
+							Value: "`json:\"ext,omitempty\" protobuf:\"bytes,1000,opt,name=ext,proto3\"`",
+						},
+					}
+					structType.Fields.List = append(structType.Fields.List, extField)
+
 					pbOptions := protoMsg.Desc.Options().(*descriptorpb.MessageOptions)
 					options, err := pboptions.ReadOptions(extTypes, pbOptions)
 					if err != nil {
@@ -335,6 +351,17 @@ func updateGoFile(gofile *plugingo.CodeGeneratorResponse_File, protofile *protog
 
 	if hasCRD {
 		updatedContent = strings.Replace(updatedContent, `import (`, "import ("+templates.CRDImports, 1)
+	}
+
+	// Always add anypb import since we're adding Ext field to all structs
+	if !strings.Contains(updatedContent, `"google.golang.org/protobuf/types/known/anypb"`) {
+		if strings.Contains(updatedContent, `import (`) {
+			updatedContent = strings.Replace(updatedContent, `import (`, "import (\n\t\"google.golang.org/protobuf/types/known/anypb\"", 1)
+		} else {
+			// Add import block if it doesn't exist
+			packageLine := fmt.Sprintf("package %s\n", dstFile.Name.Name)
+			updatedContent = strings.Replace(updatedContent, packageLine, packageLine+"\nimport (\n\t\"google.golang.org/protobuf/types/known/anypb\"\n)\n", 1)
+		}
 	}
 
 	gofile.Content = &updatedContent

--- a/proto/api/v2/BUILD.bazel
+++ b/proto/api/v2/BUILD.bazel
@@ -69,6 +69,7 @@ go_proto_library(
         "//proto/api:go_default_library",
         "@io_k8s_api//core/v1:core",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@org_golang_google_protobuf//types/known/anypb:go_default_library",
     ],
 )
 

--- a/proto/test/kubeproto/BUILD.bazel
+++ b/proto/test/kubeproto/BUILD.bazel
@@ -45,6 +45,7 @@ go_proto_library(
         "//proto/api/v2:go_default_library",
         "@io_k8s_api//core/v1:core",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@org_golang_google_protobuf//types/known/anypb:go_default_library",
     ],
 )
 


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ Y ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
Add ext field to all protos when running protoc protoc-gen-kubeproto

<!-- Tell your future self why have you made these changes -->
**Why?**
This adds an ext feild of type to extend the proto with external protos. One major usecase is to extend OSS project to import back uber internal fields.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
bazel build //go/cmd/kubeproto/protoc-gen-kubeproto:...
bazel build //proto/api/v2:...

This will generate all the protos, additionally include "EXT" feild in the protos

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
