### PR TITLE
Add protobuf struct utilities

### DIFF
--- a/javascript/packages/core/utils/proto/constants.ts
+++ b/javascript/packages/core/utils/proto/constants.ts
@@ -1,0 +1,8 @@
+export const STRUCT_KINDS = {
+  boolValue: 'boolValue',
+  listValue: 'listValue',
+  nullValue: 'nullValue',
+  numberValue: 'numberValue',
+  stringValue: 'stringValue',
+  structValue: 'structValue',
+} as const;

--- a/javascript/packages/core/utils/proto/struct-utils.ts
+++ b/javascript/packages/core/utils/proto/struct-utils.ts
@@ -1,0 +1,92 @@
+import { toPairs } from 'lodash';
+
+import { STRUCT_KINDS } from './constants';
+
+import type { DecodedStruct, Fields, ProtobufValue, Struct } from './types';
+
+/**
+ * Type guard to check if a value is a protocol buffer struct
+ */
+export function isStruct(struct: unknown): struct is Struct {
+  return (
+    !!struct &&
+    typeof struct === 'object' &&
+    'fields' in struct &&
+    typeof struct.fields === 'object' &&
+    !Array.isArray(struct.fields)
+  );
+}
+
+/**
+ * Helper function to get the distinct kind value from a protobuf value
+ */
+function getDistinctKindValue(value: ProtobufValue): {
+  kind: keyof typeof STRUCT_KINDS;
+  kindValue: unknown;
+} {
+  const pairs = toPairs(value);
+  const [kind, kindValue] = pairs[0] || [];
+  return { kind: kind as keyof typeof STRUCT_KINDS, kindValue };
+}
+
+/**
+ * Decodes protocol buffer struct fields to JavaScript objects
+ */
+function decodeStructFields(fields: Fields): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  for (const [key, value] of toPairs(fields)) {
+    result[key] = decodeStruct(value);
+  }
+
+  return result;
+}
+
+/**
+ * Decodes protocol buffer structs to JavaScript objects
+ */
+export function decodeStruct(struct: unknown): DecodedStruct {
+  // Handle null/undefined
+  if (struct == null) {
+    return struct;
+  }
+
+  // Handle direct struct with fields
+  if (isStruct(struct)) {
+    return decodeStructFields(struct.fields);
+  }
+
+  // Handle value objects
+  if (typeof struct === 'object' && struct !== null) {
+    const value = struct as ProtobufValue;
+    const { kind, kindValue } = getDistinctKindValue(value);
+
+    switch (kind) {
+      case STRUCT_KINDS.listValue:
+        if (kindValue && typeof kindValue === 'object' && 'values' in kindValue) {
+          const listValue = kindValue as { values: ProtobufValue[] };
+          return listValue.values.map((item) => decodeStruct(item));
+        }
+        return [];
+
+      case STRUCT_KINDS.nullValue:
+        return null;
+
+      case STRUCT_KINDS.structValue:
+        if (kindValue) {
+          return decodeStruct(kindValue);
+        }
+        return {};
+
+      case STRUCT_KINDS.boolValue:
+      case STRUCT_KINDS.numberValue:
+      case STRUCT_KINDS.stringValue:
+        return kindValue;
+
+      default:
+        return struct;
+    }
+  }
+
+  return struct;
+}

--- a/javascript/packages/core/utils/proto/types.ts
+++ b/javascript/packages/core/utils/proto/types.ts
@@ -1,0 +1,17 @@
+// Core type definitions for protocol buffer structs
+export type Struct = {
+  fields: Fields;
+};
+
+export type Fields = Record<string, ProtobufValue>;
+
+export type ProtobufValue = {
+  boolValue?: boolean;
+  listValue?: { values: ProtobufValue[] };
+  nullValue?: null;
+  numberValue?: number;
+  stringValue?: string;
+  structValue?: Struct;
+};
+
+export type DecodedStruct = unknown;


### PR DESCRIPTION
This change provides struct decoding functionality that converts protocol buffer structs to JavaScript objects and validates data types, enabling components to safely handle protobuf Struct data.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
