### PR TITLE
go language server settings and vendor directory for vscode & cursor

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,16 @@
     },
     "eslint.workingDirectories": [
         "./javascript"
-    ]
+    ],
+    "go.toolsEnvVars": {
+        "GO111MODULE": "on",
+        "GOFLAGS": "-mod=vendor",
+    },
+    "gopls": {
+        "verboseOutput": true,
+        "build.directoryFilters": [
+            "-",
+            "+go",
+        ],
+    }
 }

--- a/proto/test/kubeproto/indexing_errors/indexing_errors.proto
+++ b/proto/test/kubeproto/indexing_errors/indexing_errors.proto
@@ -1,13 +1,13 @@
 syntax = "proto3";
 
-package michelangelo.test.kubeproto;
+package michelangelo.test.kubeproto.indexing_errors;
 
 import "k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto";
 import "michelangelo/api/options.proto";
 import "michelangelo/api/v2/user.proto";
 import "google/protobuf/timestamp.proto";
 
-option go_package = "kubeproto";
+option go_package = "indexing_errors";
 
 message TestIndexingInvalidPathSpec {
 }

--- a/tools/update_vendor.sh
+++ b/tools/update_vendor.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+# update_vendor.sh
+#
+# This script ensures vendored Go code is updated for IDEs and development tools to use:
+# 1. Deletes go/vendor directory, if it exists.
+# 2. Runs `go mod vendor` to create a new go/vendor directory.
+# 3. Generates go code for all protobuf files via `bazel build //proto/...`.
+# 4. Copies generated .go files from Bazel output into the correct paths under go/vendor.
+
+set -euo pipefail
+
+GO_DIR="${WORKSPACE_ROOT}/go"
+VENDOR_DIR="${GO_DIR}/vendor"
+
+IMPORT_BASE="github.com/michelangelo-ai/michelangelo"
+
+echo "==> Generating go/vendor directory..."
+(cd "${GO_DIR}" && go mod vendor)
+
+echo "==> Querying Bazel go_proto_library targets..."
+TARGETS=$(bazel query 'kind("go_proto_library", //proto/...)')
+
+if [ -z "$TARGETS" ]; then
+    echo "    No go_proto_library targets found under //proto/"
+    exit 1
+fi
+echo "$TARGETS" | sed 's/^/      - /'
+
+echo "==> Copying generated .go files to vendor/..."
+
+for target in $TARGETS; do
+    # Parse label: //proto/api:api_go_proto -> proto/api api_go_proto
+    label="${target#//}"                     # proto/api:api_go_proto
+    pkg="${label%%:*}"                      # proto/api
+    name="${label##*:}"                     # api_go_proto
+
+    # Derive output path based on Bazel's convention:
+    #   bazel-bin/proto/api/api_go_proto/<importpath>/
+    OUT_PATH="bazel-bin/${pkg}/${name}_/"
+
+    # Use bazel cquery to extract importpath (from rule attrs)
+    IMPORTPATH="${IMPORT_BASE}/${pkg}"
+
+    if [ -z "$IMPORTPATH" ]; then
+        echo "    ⚠️  Skipping $target — could not determine importpath"
+        continue
+    fi
+
+    SRC="${WORKSPACE_ROOT}/${OUT_PATH}/${IMPORTPATH}"
+    DEST="${VENDOR_DIR}/${IMPORTPATH}"
+
+    if [ ! -d "${SRC}" ]; then
+        echo "    ⚠️  Generated directory not found for $target: ${SRC}"
+        continue
+    fi
+
+    echo "    $target → vendor/${IMPORTPATH}"
+    mkdir -p "${DEST}"
+    cp "${SRC}"/*.go "${DEST}/"
+done
+
+echo "==> Copying protobuf mock .go files to vendor/..."
+
+SRC="${WORKSPACE_ROOT}/bazel-bin/proto/api/v2/michelangelo_v2mock.go"
+DEST="${VENDOR_DIR}/mock/github.com/michelangelo-ai/michelangelo/proto/api/v2/v2mock"
+echo "    ${SRC} → ${DEST}"
+mkdir -p "${DEST}"
+cp "${SRC}" "${DEST}/"
+
+echo "✅ vendor directory update complete."

--- a/tools/update_vendor.sh
+++ b/tools/update_vendor.sh
@@ -60,12 +60,4 @@ for target in $TARGETS; do
     cp "${SRC}"/*.go "${DEST}/"
 done
 
-echo "==> Copying protobuf mock .go files to vendor/..."
-
-SRC="${WORKSPACE_ROOT}/bazel-bin/proto/api/v2/michelangelo_v2mock.go"
-DEST="${VENDOR_DIR}/mock/github.com/michelangelo-ai/michelangelo/proto/api/v2/v2mock"
-echo "    ${SRC} → ${DEST}"
-mkdir -p "${DEST}"
-cp "${SRC}" "${DEST}/"
-
 echo "✅ vendor directory update complete."


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
Dev tools

<!-- Describe what has changed in this PR -->
**What changed?**
Add a script to prepare go vendor directory for IDE use
Add gopls settings for vscode and cursor
Fix incorrect package name in a unit test protobuf file

<!-- Tell your future self why have you made these changes -->
**Why?**
Cursor and other IDEs need go language server (gopls) to index and navigate to 3rd party libraries
As we use bazel build, gopls doesn't work out-of-box
In this PR, I added a bash script to generate go vendor directory and copy protobuf generated code into the vendor directory. gopls will be able to find 3rd party libraries and protobuf generated code from vendor directory
Added gopls settings for vscode / cursor:
    1. use vendor mode
    2. enable go module (as we don't have go.mod in root directory, we need this flag to tell gopls we use go modules)
    3. only index go directory
Fixed a mistake in a unit test protobuf file. The file is in indexing_errors directory, but the package name was wrongly set to kubeproto. This didn't cause bazel build errors, but does confuse gopls


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
Updated wikipage https://github.com/michelangelo-ai/michelangelo/wiki/Setup-IDE-and-bazel