### PR TITLE
Add state persistence to pipeline(run) lists

### DIFF
--- a/javascript/CLAUDE.md
+++ b/javascript/CLAUDE.md
@@ -75,6 +75,9 @@
 
 - **Real interactions over mocks**: Reduce dependency mocking to test closer to production
 - **Mock server dependencies**: Don't connect to real servers, use established RPC mocking
+- **Business logic over implementation**: Test your business decisions and logic, not the tools you're using to implement them
+- **Avoid test duplication**: Don't test the same behavior in both unit and integration tests - choose the most appropriate level
+- **Success path plus key edge cases**: Test core functionality and meaningful edge cases. Skip testing scenarios already covered by dependencies. Skip testing unrealistic scenarios
 
 ### Test Organization
 
@@ -82,13 +85,10 @@
 - **Place tests near code**: Use closest `__tests__/` directory
 - **Well-named mocks**: Use descriptive names that explain test intent
 - **Inline when appropriate**: For simple cases tied directly to test expectations
-
-### Fixtures and Mocks
-
-- Well-named mocks: Use descriptive names that explain test intent
-- Inline when appropriate: For simple cases tied directly to test expectations
+- **Inline expect calls**: Prefer `expect(functionCall(args)).toEqual(result)` over assigning to variables when possible
 
 When to mock vs not mock:
 
 - ✅ DO mock: External APIs, RPC calls, server dependencies
-- ✅ DO use real: Internal hooks, components, React context
+- ✅ DO use real: Internal hooks, components, React context, well-tested utilities with error handling
+- ✅ DO use real: Dependencies that are already comprehensively tested and handle edge cases gracefully

--- a/javascript/CLAUDE.md
+++ b/javascript/CLAUDE.md
@@ -92,3 +92,48 @@ When to mock vs not mock:
 - ✅ DO mock: External APIs, RPC calls, server dependencies
 - ✅ DO use real: Internal hooks, components, React context, well-tested utilities with error handling
 - ✅ DO use real: Dependencies that are already comprehensively tested and handle edge cases gracefully
+
+---
+
+## Documentation Guidelines
+
+### When to Add Documentation
+
+**Add JSDoc when functions have**:
+
+- **Non-obvious behaviors**: Error handling, side effects, or special logic
+- **Edge cases**: Null handling, validation, or fallback behavior
+- **Public APIs**: Utilities shared across multiple features
+
+**Skip documentation for**:
+
+- Simple getters/setters that match their TypeScript signature
+- Internal implementation details
+
+### JSDoc Style
+
+- **Focus on "why" over "what"**: Explain behavior, not syntax
+- **Include examples for complex functions**: Show real usage scenarios
+- **Document edge cases and error handling**: What happens when inputs are invalid?
+- **Be concise but complete**: Cover important behavior without redundancy
+
+### Inline Comments
+
+**Use inline comments for**:
+
+- **Non-obvious implementation decisions**: Why a specific approach was chosen
+- **Complex logic explanation**: Clarify intricate algorithms or transformations
+- **Important context**: Business rules or constraints that affect the code
+
+**Good examples**:
+
+```typescript
+// Ignore localStorage errors (quota exceeded, private browsing, etc.)
+// Convert MM/DD/YYYY to YYYY/MM/DD format for consistency
+```
+
+### Avoid
+
+- **Type duplication**: Don't restate what TypeScript already expresses
+- **Obvious comments**: `// gets the pipeline run based on name`
+- **AI/agent references**: Keep documentation focused on code purpose

--- a/javascript/packages/core/components/table/__tests__/table.test.tsx
+++ b/javascript/packages/core/components/table/__tests__/table.test.tsx
@@ -407,4 +407,87 @@ describe('Table', () => {
       });
     });
   });
+
+  describe('state management integration', () => {
+    const testData = [
+      { id: '1', name: 'Alice Johnson', department: 'Engineering', status: 'Active' },
+      { id: '2', name: 'Bob Smith', department: 'Marketing', status: 'Inactive' },
+      { id: '3', name: 'Carol Davis', department: 'Engineering', status: 'Active' },
+      { id: '4', name: 'David Wilson', department: 'Sales', status: 'Active' },
+    ];
+
+    const testColumns = [
+      { id: 'name', label: 'Name' },
+      { id: 'department', label: 'Department' },
+      { id: 'status', label: 'Status' },
+    ];
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    });
+
+    describe('controlled state with search', () => {
+      it('respects controlled globalFilter state and updates search UI', () => {
+        const controlledState = {
+          globalFilter: 'Engineering',
+          setGlobalFilter: vi.fn(),
+        };
+
+        render(
+          <Table
+            data={testData}
+            columns={testColumns}
+            state={controlledState}
+            actionBarConfig={{ enableSearch: true }}
+          />,
+          buildWrapper([getInterpolationProviderWrapper(), getRouterWrapper()])
+        );
+
+        expect(screen.getByRole('searchbox')).toHaveValue('Engineering');
+        expect(screen.getAllByRole('row')).toHaveLength(3); // 1 header + 2 Engineering rows
+      });
+
+      it('updates filtered results when controlled state changes', async () => {
+        let currentState = {
+          globalFilter: '',
+          setGlobalFilter: vi.fn(),
+        };
+        const TestWrapper = () => (
+          <Table
+            data={testData}
+            columns={testColumns}
+            state={currentState}
+            actionBarConfig={{ enableSearch: true }}
+          />
+        );
+
+        const { rerender } = render(
+          <TestWrapper />,
+          buildWrapper([getInterpolationProviderWrapper(), getRouterWrapper()])
+        );
+
+        expect(screen.getAllByRole('row')).toHaveLength(5); // 1 header + 4 data rows
+        expect(screen.getByRole('searchbox')).toHaveValue('');
+
+        currentState = {
+          globalFilter: 'Marketing',
+          setGlobalFilter: vi.fn(),
+        };
+        rerender(<TestWrapper />);
+
+        // Check that the search input updates
+        expect(screen.getByRole('searchbox')).toHaveValue('Marketing');
+
+        await waitFor(() => {
+          expect(screen.getAllByRole('row')).toHaveLength(2); // 1 header + 1 Marketing row
+        });
+      });
+    });
+  });
 });

--- a/javascript/packages/core/components/table/constants.ts
+++ b/javascript/packages/core/components/table/constants.ts
@@ -1,0 +1,7 @@
+import type { TableState } from './types/table-types';
+
+export const TABLE_STATE_DEFAULTS: TableState = {
+  globalFilter: '',
+} as const;
+
+export const TABLE_LOCAL_STORAGE_KEY = 'ma-studio-table-settings';

--- a/javascript/packages/core/components/table/plugins/state-persistence/__tests__/use-local-storage-table-state.test.tsx
+++ b/javascript/packages/core/components/table/plugins/state-persistence/__tests__/use-local-storage-table-state.test.tsx
@@ -1,0 +1,246 @@
+import { act, renderHook } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+
+import { TABLE_LOCAL_STORAGE_KEY } from '#core/components/table/constants';
+import { Table } from '#core/components/table/table';
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getInterpolationProviderWrapper } from '#core/test/wrappers/get-interpolation-provider-wrapper';
+import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
+import { useLocalStorageTableState } from '../use-local-storage-table-state';
+
+import type { TableState } from '#core/components/table/types/table-types';
+
+describe('useLocalStorageTableState', () => {
+  const testData = [
+    { id: '1', name: 'Alice Johnson', department: 'Engineering', status: 'Active' },
+    { id: '2', name: 'Bob Smith', department: 'Marketing', status: 'Inactive' },
+    { id: '3', name: 'Carol Davis', department: 'Engineering', status: 'Active' },
+    { id: '4', name: 'David Wilson', department: 'Sales', status: 'Active' },
+  ];
+
+  const testColumns = [
+    { id: 'name', label: 'Name' },
+    { id: 'department', label: 'Department' },
+    { id: 'status', label: 'Status' },
+  ];
+
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  describe('hook behavior', () => {
+    it('returns default state when no persisted data exists', () => {
+      const { result } = renderHook(() =>
+        useLocalStorageTableState({ tableSettingsId: 'test-table' })
+      );
+
+      expect(result.current.globalFilter).toBe('');
+      expect(typeof result.current.setGlobalFilter).toBe('function');
+    });
+
+    it('persists state changes to localStorage', () => {
+      const { result } = renderHook(() =>
+        useLocalStorageTableState({ tableSettingsId: 'test-table' })
+      );
+
+      act(() => {
+        result.current.setGlobalFilter('test-filter');
+      });
+
+      const storedData = localStorage.getItem(TABLE_LOCAL_STORAGE_KEY);
+      expect(storedData).toBeTruthy();
+
+      const parsedData = JSON.parse(storedData!) as Record<string, Partial<TableState>>;
+      expect(parsedData['test-table'].globalFilter).toBe('test-filter');
+    });
+
+    it('restores state from localStorage on initialization', () => {
+      const existingState = {
+        'test-table.globalFilter': 'restored-filter',
+      };
+      localStorage.setItem(TABLE_LOCAL_STORAGE_KEY, JSON.stringify(existingState));
+
+      const { result } = renderHook(() =>
+        useLocalStorageTableState({ tableSettingsId: 'test-table' })
+      );
+
+      expect(result.current.globalFilter).toBe('restored-filter');
+    });
+
+    it('handles localStorage errors gracefully', () => {
+      const originalGetItem = localStorage.getItem.bind(localStorage) as unknown as () => string;
+      localStorage.getItem = vi.fn(() => {
+        throw new Error('SecurityError');
+      });
+
+      expect(() => {
+        renderHook(() => useLocalStorageTableState({ tableSettingsId: 'test-table' }));
+      }).not.toThrow();
+
+      localStorage.getItem = originalGetItem;
+    });
+
+    it('maintains separate state for different table settings IDs', () => {
+      const { result: result1 } = renderHook(() =>
+        useLocalStorageTableState({ tableSettingsId: 'table-1' })
+      );
+
+      const { result: result2 } = renderHook(() =>
+        useLocalStorageTableState({ tableSettingsId: 'table-2' })
+      );
+
+      act(() => {
+        result1.current.setGlobalFilter('filter-1');
+        result2.current.setGlobalFilter('filter-2');
+      });
+
+      const storedData = JSON.parse(localStorage.getItem(TABLE_LOCAL_STORAGE_KEY)!) as Record<
+        string,
+        Partial<TableState>
+      >;
+      expect(storedData['table-1'].globalFilter).toBe('filter-1');
+      expect(storedData['table-2'].globalFilter).toBe('filter-2');
+    });
+  });
+
+  describe('integration with Table component', () => {
+    function TableWithPersistence({ tableSettingsId }: { tableSettingsId: string }) {
+      const tableState = useLocalStorageTableState({ tableSettingsId });
+
+      return (
+        <Table
+          data={testData}
+          columns={testColumns}
+          state={tableState}
+          actionBarConfig={{ enableSearch: true }}
+        />
+      );
+    }
+
+    it('persists search state through table interactions', async () => {
+      const tableSettingsId = 'integration-test';
+
+      render(
+        <TableWithPersistence tableSettingsId={tableSettingsId} />,
+        buildWrapper([getInterpolationProviderWrapper(), getRouterWrapper()])
+      );
+
+      const user = userEvent.setup({
+        advanceTimers: vi.advanceTimersByTime.bind(vi) as (ms: number) => void,
+      });
+
+      await user.type(screen.getByRole('searchbox'), 'Engineering');
+      vi.runAllTimers();
+
+      await waitFor(() => {
+        expect(screen.getAllByRole('row')).toHaveLength(3); // 1 header + 2 Engineering rows
+      });
+
+      await waitFor(() => {
+        const storedData = localStorage.getItem(TABLE_LOCAL_STORAGE_KEY);
+        expect(storedData).toBeTruthy();
+
+        const parsedData = JSON.parse(storedData!) as Record<string, TableState>;
+        expect(parsedData[tableSettingsId].globalFilter).toEqual('Engineering');
+      });
+    });
+
+    it('restores search state when component remounts', () => {
+      const tableSettingsId = 'remount-test';
+      const existingState = {
+        [`${tableSettingsId}.globalFilter`]: 'Marketing',
+      };
+      localStorage.setItem(TABLE_LOCAL_STORAGE_KEY, JSON.stringify(existingState));
+
+      render(
+        <TableWithPersistence tableSettingsId={tableSettingsId} />,
+        buildWrapper([getInterpolationProviderWrapper(), getRouterWrapper()])
+      );
+
+      expect(screen.getByRole('searchbox')).toHaveValue('Marketing');
+      expect(screen.getAllByRole('row')).toHaveLength(2); // 1 header + 1 Marketing row
+    });
+
+    it('allows clearing persisted search state', async () => {
+      const tableSettingsId = 'clear-test';
+      const existingState = {
+        [tableSettingsId]: {
+          globalFilter: 'Engineering',
+        },
+      };
+      localStorage.setItem(TABLE_LOCAL_STORAGE_KEY, JSON.stringify(existingState));
+
+      render(
+        <TableWithPersistence tableSettingsId={tableSettingsId} />,
+        buildWrapper([getInterpolationProviderWrapper(), getRouterWrapper()])
+      );
+
+      expect(screen.getByRole('searchbox')).toHaveValue('Engineering');
+      expect(screen.getAllByRole('row')).toHaveLength(3);
+
+      const user = userEvent.setup({
+        advanceTimers: vi.advanceTimersByTime.bind(vi) as (ms: number) => void,
+      });
+
+      await user.click(screen.getByLabelText('Clear value'));
+      vi.runAllTimers();
+
+      await waitFor(() => {
+        expect(screen.getAllByRole('row')).toHaveLength(5); // 1 header + 4 data rows
+      });
+
+      await waitFor(() => {
+        const storedData = localStorage.getItem(TABLE_LOCAL_STORAGE_KEY);
+        const parsedData = JSON.parse(storedData!) as Record<string, Partial<TableState>>;
+        expect(parsedData[tableSettingsId].globalFilter).toBe('');
+      });
+    });
+
+    it('handles multiple tables with different settings IDs', async () => {
+      const tableSettingsId1 = 'multi-table-1';
+      const tableSettingsId2 = 'multi-table-2';
+
+      const { unmount } = render(
+        <TableWithPersistence tableSettingsId={tableSettingsId1} />,
+        buildWrapper([getInterpolationProviderWrapper(), getRouterWrapper()])
+      );
+
+      const user = userEvent.setup({
+        advanceTimers: vi.advanceTimersByTime.bind(vi) as (ms: number) => void,
+      });
+
+      await user.type(screen.getByRole('searchbox'), 'Engineering');
+      vi.runAllTimers();
+
+      await waitFor(() => {
+        expect(screen.getAllByRole('row')).toHaveLength(3);
+      });
+
+      unmount();
+
+      render(
+        <TableWithPersistence tableSettingsId={tableSettingsId2} />,
+        buildWrapper([getInterpolationProviderWrapper(), getRouterWrapper()])
+      );
+
+      expect(screen.getByRole('searchbox')).toHaveValue('');
+      expect(screen.getAllByRole('row')).toHaveLength(5); // 1 header + 4 data rows
+
+      const storedData = JSON.parse(localStorage.getItem(TABLE_LOCAL_STORAGE_KEY)!) as Record<
+        string,
+        Partial<TableState>
+      >;
+      expect(storedData[tableSettingsId1].globalFilter).toBe('Engineering');
+      expect(storedData[tableSettingsId2]).toBeUndefined();
+    });
+  });
+});

--- a/javascript/packages/core/components/table/plugins/state-persistence/__tests__/utils.test.ts
+++ b/javascript/packages/core/components/table/plugins/state-persistence/__tests__/utils.test.ts
@@ -1,0 +1,95 @@
+import { getAllTableUserSettings, getTableUserSettings, updateUserTableSettings } from '../utils';
+
+import type { TableState } from '#core/components/table/types/table-types';
+
+describe('state-persistence utils', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('getAllTableUserSettings', () => {
+    it('returns localStorage data when available', () => {
+      const mockData = {
+        'table-1': { globalFilter: 'search-1' },
+        'table-2': { globalFilter: 'search-2' },
+      };
+      localStorage.setItem('ma-studio-table-settings', JSON.stringify(mockData));
+
+      const result = getAllTableUserSettings();
+
+      expect(result).toEqual(mockData);
+    });
+
+    it('returns empty object when localStorage is empty', () => {
+      const result = getAllTableUserSettings();
+
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('getTableUserSettings', () => {
+    it('returns settings for specific table ID', () => {
+      const mockData = {
+        'table-1': { globalFilter: 'search-1' },
+        'table-2': { globalFilter: 'search-2' },
+      };
+      localStorage.setItem('ma-studio-table-settings', JSON.stringify(mockData));
+
+      const result = getTableUserSettings('table-1');
+
+      expect(result).toEqual({ globalFilter: 'search-1' });
+    });
+
+    it('returns empty object when table ID not found', () => {
+      localStorage.setItem('ma-studio-table-settings', JSON.stringify({}));
+
+      const result = getTableUserSettings('non-existent-table');
+
+      expect(result).toEqual({});
+    });
+
+    it('returns empty object when no table ID provided', () => {
+      const result = getTableUserSettings();
+
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('updateUserTableSettings', () => {
+    it('saves new settings using dot notation and returns true', () => {
+      const result = updateUserTableSettings('table-1.globalFilter', 'new-search');
+
+      expect(result).toBe(true);
+
+      const stored = JSON.parse(localStorage.getItem('ma-studio-table-settings')!) as Record<
+        string,
+        Partial<TableState>
+      >;
+      expect(stored).toEqual({ 'table-1': { globalFilter: 'new-search' } });
+    });
+
+    it('returns false when new settings are identical to existing', () => {
+      updateUserTableSettings('table-1.globalFilter', 'existing-search');
+
+      const result = updateUserTableSettings('table-1.globalFilter', 'existing-search');
+
+      expect(result).toBe(false);
+    });
+
+    it('merges new settings with existing data', () => {
+      updateUserTableSettings('table-1.globalFilter', 'existing');
+      updateUserTableSettings('table-2.globalFilter', 'other-table');
+
+      updateUserTableSettings('table-1.globalFilter', 'updated');
+
+      const stored = JSON.parse(localStorage.getItem('ma-studio-table-settings')!) as Record<
+        string,
+        Partial<TableState>
+      >;
+      expect(stored).toEqual({
+        'table-1': { globalFilter: 'updated' },
+        'table-2': { globalFilter: 'other-table' },
+      });
+    });
+  });
+});

--- a/javascript/packages/core/components/table/plugins/state-persistence/use-local-storage-table-state.ts
+++ b/javascript/packages/core/components/table/plugins/state-persistence/use-local-storage-table-state.ts
@@ -1,0 +1,40 @@
+import { TABLE_STATE_DEFAULTS } from '#core/components/table/constants';
+import { usePersistedTableState } from './use-persisted-table-state';
+
+import type { ControlledTableState } from '#core/components/table/types/table-types';
+
+/**
+ * Primary entry point for adding localStorage persistence to Table components.
+ * This hook manages table state with automatic localStorage persistence, falling back to
+ * {@link TABLE_STATE_DEFAULTS} when values are not found in localStorage.
+ *
+ * Use this hook to provide a `state` prop to the Table component for persistent
+ * user preferences across browser sessions.
+ *
+ * @example
+ * ```tsx
+ * // In your table component
+ * const tableState = useLocalStorageTableState({
+ *   tableSettingsId: 'user-dashboard-table',
+ * });
+ *
+ * return <Table data={data} columns={columns} state={tableState} />;
+ *
+ * // State persisted as: 'ma-studio-table-settings.user-dashboard-table.globalFilter'
+ * ```
+ */
+export function useLocalStorageTableState({
+  tableSettingsId,
+}: {
+  tableSettingsId: string;
+}): ControlledTableState {
+  const [globalFilter, setGlobalFilter] = usePersistedTableState<string>(
+    `${tableSettingsId}.globalFilter`,
+    TABLE_STATE_DEFAULTS.globalFilter
+  );
+
+  return {
+    globalFilter,
+    setGlobalFilter,
+  };
+}

--- a/javascript/packages/core/components/table/plugins/state-persistence/use-persisted-table-state.ts
+++ b/javascript/packages/core/components/table/plugins/state-persistence/use-persisted-table-state.ts
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+import { get } from 'lodash';
+
+import { getAllTableUserSettings, updateUserTableSettings } from './utils';
+
+import type { Dispatch, SetStateAction } from 'react';
+import type { TableState } from '#core/components/table/types/table-types';
+
+/**
+ * Custom hook to manage and persist individual pieces of table state.
+ *
+ * Ensures that table state is persisted to localStorage and can be restored
+ * when the component remounts.
+ *
+ * @param id - A unique identifier for the state. This corresponds to the localStorage path
+ * @param defaultValue - The default value for the state
+ * @returns Tuple of [currentState, setStateFunction]
+ */
+export function usePersistedTableState<StateType extends TableState[keyof TableState]>(
+  id: string,
+  defaultValue: StateType
+): [StateType, Dispatch<SetStateAction<StateType>>] {
+  const settings = getAllTableUserSettings();
+  // lodash.get can return Partial<StateType> so we need to cast to StateType
+  const [state, setState] = useState<StateType>(get(settings, id, defaultValue) as StateType);
+
+  const updateAndPersistState = (updater: SetStateAction<StateType>) => {
+    const newStateValue = updater instanceof Function ? updater(state) : updater;
+    updateUserTableSettings(id, newStateValue);
+    setState(newStateValue);
+  };
+
+  return [state, updateAndPersistState];
+}

--- a/javascript/packages/core/components/table/plugins/state-persistence/utils.ts
+++ b/javascript/packages/core/components/table/plugins/state-persistence/utils.ts
@@ -1,0 +1,43 @@
+import { cloneDeep, get, isEqual, set } from 'lodash';
+
+import { TABLE_LOCAL_STORAGE_KEY } from '#core/components/table/constants';
+import { safeLocalStorageGetItem, safeLocalStorageSetItem } from '#core/utils/local-storage-utils';
+
+import type { TableState } from '#core/components/table/types/table-types';
+
+const INITIAL_STATE = {} as const;
+
+export function getAllTableUserSettings(): Record<string, Partial<TableState>> {
+  return safeLocalStorageGetItem(TABLE_LOCAL_STORAGE_KEY, INITIAL_STATE);
+}
+
+export function getTableUserSettings(tableId?: string): Partial<TableState> {
+  if (tableId) {
+    const allTableSettings = getAllTableUserSettings();
+    const settings = allTableSettings[tableId];
+    if (settings !== undefined) {
+      return settings;
+    }
+  }
+  return INITIAL_STATE;
+}
+
+/**
+ * Updates user table settings in localStorage
+ *
+ * @param settingsId - The unique identifier for the table settings
+ * @param newSettings - The new settings to be applied
+ * @returns true if the settings were updated, false otherwise
+ */
+export function updateUserTableSettings<T = unknown>(settingsId: string, newSettings: T): boolean {
+  const current = getAllTableUserSettings();
+  if (isEqual(get(current, settingsId), newSettings)) {
+    return false;
+  }
+
+  safeLocalStorageSetItem(
+    TABLE_LOCAL_STORAGE_KEY,
+    set(cloneDeep(current), settingsId, newSettings)
+  );
+  return true;
+}

--- a/javascript/packages/core/components/table/table.tsx
+++ b/javascript/packages/core/components/table/table.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { getCoreRowModel, getFilteredRowModel, useReactTable } from '@tanstack/react-table';
 import { StyledTable } from 'baseui/table-semantic';
 
@@ -13,6 +12,7 @@ import { TableNoResultsState } from './components/table-no-results-state/table-n
 import { useColumnTransformer } from './hooks/use-column-transformer';
 import { TableContainer } from './styled-components';
 import { applyDefaultProps } from './utils/apply-default-props';
+import { composeTableState } from './utils/compose-table-state';
 import { getTableViewState } from './utils/get-table-view-state';
 
 import type { TableData } from './types/data-types';
@@ -21,15 +21,15 @@ import type { TableProps } from './types/table-types';
 export function Table<T extends TableData = TableData>(inputProps: TableProps<T>) {
   const props = applyDefaultProps<T>(inputProps);
   const columns = useColumnTransformer<T>(props.columns);
-  const [globalFilter, setGlobalFilter] = React.useState('');
+
+  const { state, initialState } = composeTableState(props.state ?? {});
 
   const table = useReactTable<T>({
     data: props.data,
     columns,
-    state: {
-      globalFilter,
-    },
-    onGlobalFilterChange: setGlobalFilter,
+    initialState,
+    ...(Object.keys(state).length > 0 && { state }),
+    ...(state.setGlobalFilter ? { onGlobalFilterChange: state.setGlobalFilter } : {}),
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     globalFilterFn: 'includesString',
@@ -39,15 +39,15 @@ export function Table<T extends TableData = TableData>(inputProps: TableProps<T>
     dataLength: props.data.length,
     error: props.error,
     loading: props.loading,
-    hasFiltersApplied: globalFilter.length > 0,
+    hasFiltersApplied: (table.getState().globalFilter as string)?.length > 0,
     filteredLength: table.getFilteredRowModel().rows.length,
   });
 
   return (
     <TableContainer>
       <TableActionBar
-        globalFilter={globalFilter}
-        setGlobalFilter={setGlobalFilter}
+        globalFilter={table.getState().globalFilter as string}
+        setGlobalFilter={table.setGlobalFilter}
         configuration={props.actionBarConfig}
       />
 
@@ -59,7 +59,7 @@ export function Table<T extends TableData = TableData>(inputProps: TableProps<T>
         {viewState === 'empty' && <TableEmptyState emptyState={props.emptyState} />}
 
         {viewState === 'filtered-empty' && (
-          <TableNoResultsState clearFilters={() => setGlobalFilter('')} />
+          <TableNoResultsState clearFilters={() => table.setGlobalFilter('')} />
         )}
 
         {viewState !== 'error' && (

--- a/javascript/packages/core/components/table/types/table-types.ts
+++ b/javascript/packages/core/components/table/types/table-types.ts
@@ -79,6 +79,31 @@ export interface TableRequiredFunctionalityProps {
    * @default { enableSearch: true }
    */
   actionBarConfig: TableActionBarConfig;
+
+  /**
+   * @description
+   * Table state for managing filters and other table state.
+   * Can include both controlled state (with setters) and initial state (without setters).
+   *
+   * @example
+   * ```ts
+   * // Controlled state -- setGlobalFilter is responsible for updating globalFilter
+   * {
+   *   globalFilter: 'search-1',
+   *   setGlobalFilter: (newValue: string) => {
+   *     // handle the new value
+   *   },
+   * }
+   * // Uncontrolled state -- globalFilter is the initial global filter value for the table.
+   * // Updates to the state will be handled by the Table component.
+   * {
+   *   globalFilter: 'search-1',
+   * }
+   * ```
+   *
+   * @default undefined
+   */
+  state: Partial<ControlledTableState> | undefined;
 }
 
 /**
@@ -101,3 +126,22 @@ export interface TablePropsResolved<T extends TableData = TableData>
  * These states determine which UI components should be rendered.
  */
 export type TableViewState = 'loading' | 'empty' | 'ready' | 'error' | 'filtered-empty';
+
+/**
+ * Table state containing aspects of table behavior.
+ */
+export type TableState = {
+  /** Global search/filter value */
+  globalFilter: string;
+};
+
+/**
+ * Table state with update functions for controlled state management.
+ */
+export type ControlledTableState = TableState & {
+  setGlobalFilter: (
+    updater:
+      | TableState['globalFilter']
+      | ((old: TableState['globalFilter']) => TableState['globalFilter'])
+  ) => void;
+};

--- a/javascript/packages/core/components/table/utils/__tests__/compose-table-state.test.ts
+++ b/javascript/packages/core/components/table/utils/__tests__/compose-table-state.test.ts
@@ -1,0 +1,107 @@
+import { vi } from 'vitest';
+
+import { composeTableState } from '../compose-table-state';
+
+describe('composeTableState', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Suppress console.warn for tests that intentionally trigger warnings
+    vi.spyOn(console, 'warn').mockImplementation(() => null);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('controlled vs uncontrolled state detection', () => {
+    it('routes to controlled state when both value and setter are provided', () => {
+      const mockSetter = vi.fn();
+      const input = {
+        globalFilter: 'test-filter',
+        setGlobalFilter: mockSetter,
+      };
+
+      const result = composeTableState(input);
+
+      expect(result.state).toEqual({
+        globalFilter: 'test-filter',
+        setGlobalFilter: mockSetter,
+      });
+      expect(result.initialState).toEqual({});
+    });
+
+    it('routes to uncontrolled state when only value is provided', () => {
+      const input = {
+        globalFilter: 'initial-filter',
+      };
+
+      const result = composeTableState(input);
+
+      expect(result.state).toEqual({});
+      expect(result.initialState).toEqual({
+        globalFilter: 'initial-filter',
+      });
+    });
+
+    it('handles empty state object', () => {
+      const result = composeTableState({});
+
+      expect(result.state).toEqual({});
+      expect(result.initialState).toEqual({});
+    });
+  });
+
+  describe('validation and warnings', () => {
+    it('warns when setter exists without corresponding value', () => {
+      const mockSetter = vi.fn();
+      const input = {
+        setGlobalFilter: mockSetter,
+        // Missing globalFilter value
+      };
+
+      composeTableState(input);
+
+      expect(console.warn).toHaveBeenCalledWith(
+        'Controlled state setter setGlobalFilter must be accompanied by property globalFilter'
+      );
+    });
+
+    it('does not warn for valid controlled state', () => {
+      const input = {
+        globalFilter: 'test',
+        setGlobalFilter: vi.fn(),
+      };
+
+      composeTableState(input);
+
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+
+    it('does not warn for valid uncontrolled state', () => {
+      const input = {
+        globalFilter: 'test',
+      };
+
+      composeTableState(input);
+
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles setter without value by creating controlled state with undefined value', () => {
+      const mockSetter = vi.fn();
+      const input = {
+        setGlobalFilter: mockSetter,
+      };
+
+      const result = composeTableState(input);
+
+      expect(result.state).toEqual({
+        globalFilter: undefined,
+        setGlobalFilter: mockSetter,
+      });
+      expect(result.initialState).toEqual({});
+    });
+  });
+});

--- a/javascript/packages/core/components/table/utils/apply-default-props.tsx
+++ b/javascript/packages/core/components/table/utils/apply-default-props.tsx
@@ -33,5 +33,6 @@ export function applyDefaultProps<T extends TableData = TableData>(
     actionBarConfig: props.actionBarConfig ?? {
       enableSearch: true,
     },
+    state: props.state ?? undefined,
   };
 }

--- a/javascript/packages/core/components/table/utils/compose-table-state.ts
+++ b/javascript/packages/core/components/table/utils/compose-table-state.ts
@@ -1,0 +1,48 @@
+import type { ControlledTableState, TableState } from '../types/table-types';
+
+const STATE_NAME_TO_STATE_SETTER_NAME = {
+  globalFilter: 'setGlobalFilter',
+} as const;
+
+/**
+ * Uses a partial state object to construct appropriate state configuration for
+ * the Table component.
+ *
+ * @param combinedState The combined state object, with setters and values
+ *
+ * @returns An object containing:
+ * - `initialState`: {@link TableState} Values that will be initialized to the provided value and managed
+ *  by the table during runtime.
+ *
+ * - `state`: {@link ControlledTableState} Values that will not be managed by the table and have an
+ *  associated setter function.
+ *
+ * @remarks
+ * A property will be considered controlled if the input state object contains a setter.
+ */
+export function composeTableState(combinedState: Partial<ControlledTableState>): {
+  initialState: Partial<TableState>;
+  state: Partial<ControlledTableState>;
+} {
+  const state = {};
+  const initialState = {};
+
+  Object.entries(STATE_NAME_TO_STATE_SETTER_NAME).forEach(([propertyName, setterName]) => {
+    if (setterName in combinedState) {
+      if (!(propertyName in combinedState)) {
+        console.warn(
+          `Controlled state setter ${setterName} must be accompanied by property ${propertyName}`
+        );
+      }
+
+      state[propertyName] = combinedState[propertyName] as TableState[keyof TableState];
+      state[setterName] = combinedState[
+        setterName
+      ] as ControlledTableState[keyof ControlledTableState];
+    } else if (propertyName in combinedState) {
+      initialState[propertyName] = combinedState[propertyName] as TableState[keyof TableState];
+    }
+  });
+
+  return { initialState, state };
+}

--- a/javascript/packages/core/components/views/project/project-detail.tsx
+++ b/javascript/packages/core/components/views/project/project-detail.tsx
@@ -4,6 +4,7 @@ import { HeadingMedium } from 'baseui/typography';
 
 import { Box } from '#core/components/box/box';
 import { Row } from '#core/components/row/row';
+import { useLocalStorageTableState } from '#core/components/table/plugins/state-persistence/use-local-storage-table-state';
 import { Table } from '#core/components/table/table';
 import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
 import { useStudioQuery } from '#core/hooks/use-studio-query';
@@ -69,6 +70,14 @@ export function ProjectDetail() {
     },
   });
 
+  const pipelineTableState = useLocalStorageTableState({
+    tableSettingsId: 'pipelines',
+  });
+
+  const pipelineRunTableState = useLocalStorageTableState({
+    tableSettingsId: 'pipeline-runs',
+  });
+
   return (
     <div
       className={css({
@@ -112,6 +121,7 @@ export function ProjectDetail() {
           data={pipelines?.data?.pipelineList.items ?? []}
           columns={PIPELINE_CELL_CONFIG}
           loading={pipelines.isLoading}
+          state={pipelineTableState}
         />
       </Card>
 
@@ -134,6 +144,7 @@ export function ProjectDetail() {
           data={pipelineRuns?.data?.pipelineRunList.items ?? []}
           columns={PIPELINE_RUN_CELL_CONFIG}
           loading={pipelineRuns.isLoading}
+          state={pipelineRunTableState}
         />
       </Card>
     </div>

--- a/javascript/packages/core/utils/__tests__/local-storage-utils.test.ts
+++ b/javascript/packages/core/utils/__tests__/local-storage-utils.test.ts
@@ -1,0 +1,125 @@
+import { safeLocalStorageGetItem, safeLocalStorageSetItem } from '../local-storage-utils';
+
+describe('local-storage-utils', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('safeLocalStorageSetItem', () => {
+    it('should store an item in localStorage', () => {
+      const testValue = { foo: 'bar', count: 42 };
+
+      safeLocalStorageSetItem('test-key', testValue);
+
+      expect(localStorage.getItem('test-key')).toBe(JSON.stringify(testValue));
+    });
+
+    it('should handle localStorage errors gracefully', () => {
+      const originalSetItem = (...args: Parameters<typeof localStorage.setItem>) =>
+        localStorage.setItem(...args);
+      localStorage.setItem = vi.fn(() => {
+        throw new Error('QuotaExceededError');
+      });
+
+      expect(() => {
+        safeLocalStorageSetItem('test-key', { data: 'test' });
+      }).not.toThrow();
+
+      localStorage.setItem = originalSetItem;
+    });
+
+    it('should store different data types', () => {
+      const testCases = [
+        { key: 'string-key', value: 'simple string', expected: '"simple string"' },
+        { key: 'number-key', value: 123, expected: '123' },
+        { key: 'boolean-key', value: true, expected: 'true' },
+        { key: 'array-key', value: [1, 2, 3], expected: '[1,2,3]' },
+        { key: 'null-key', value: null, expected: 'null' },
+        { key: 'object-key', value: { foo: 'bar' }, expected: '{"foo":"bar"}' },
+      ];
+
+      testCases.forEach(({ key, value, expected }) => {
+        safeLocalStorageSetItem(key, value);
+        expect(localStorage.getItem(key)).toBe(expected);
+      });
+    });
+  });
+
+  describe('safeLocalStorageGetItem', () => {
+    it('should retrieve an item from localStorage', () => {
+      const testValue = { foo: 'bar', count: 42 };
+      localStorage.setItem('test-key', JSON.stringify(testValue));
+
+      const result = safeLocalStorageGetItem('test-key', {});
+
+      expect(result).toEqual(testValue);
+    });
+
+    it('should return default value when item does not exist', () => {
+      const defaultValue = { default: true };
+
+      const result = safeLocalStorageGetItem('non-existent-key', defaultValue);
+
+      expect(result).toBe(defaultValue);
+    });
+
+    it('should return default value when localStorage item is null', () => {
+      localStorage.setItem('null-key', 'null');
+      const defaultValue = { default: true };
+
+      const result = safeLocalStorageGetItem('null-key', defaultValue);
+
+      expect(result).toBe(defaultValue);
+    });
+
+    it('should handle JSON parsing errors gracefully', () => {
+      localStorage.setItem('invalid-json', 'invalid json string');
+      const defaultValue = { default: true };
+
+      const result = safeLocalStorageGetItem('invalid-json', defaultValue);
+
+      expect(result).toBe(defaultValue);
+    });
+
+    it('should handle localStorage errors gracefully', () => {
+      const originalGetItem = (...args: Parameters<typeof localStorage.getItem>) =>
+        localStorage.getItem(...args);
+      localStorage.getItem = vi.fn(() => {
+        throw new Error('SecurityError');
+      });
+
+      const defaultValue = { default: true };
+      const result = safeLocalStorageGetItem('test-key', defaultValue);
+
+      expect(result).toBe(defaultValue);
+
+      localStorage.getItem = originalGetItem;
+    });
+
+    it('should handle different data types correctly', () => {
+      const testCases = [
+        {
+          key: 'string-key',
+          storedValue: '"simple string"',
+          defaultValue: '',
+          expected: 'simple string',
+        },
+        { key: 'number-key', storedValue: '123', defaultValue: 0, expected: 123 },
+        { key: 'boolean-key', storedValue: 'true', defaultValue: false, expected: true },
+        { key: 'array-key', storedValue: '[1,2,3]', defaultValue: [], expected: [1, 2, 3] },
+        {
+          key: 'object-key',
+          storedValue: '{"foo":"bar"}',
+          defaultValue: {},
+          expected: { foo: 'bar' },
+        },
+      ];
+
+      testCases.forEach(({ key, storedValue, defaultValue, expected }) => {
+        localStorage.setItem(key, storedValue);
+        const result = safeLocalStorageGetItem(key, defaultValue);
+        expect(result).toEqual(expected);
+      });
+    });
+  });
+});

--- a/javascript/packages/core/utils/local-storage-utils.ts
+++ b/javascript/packages/core/utils/local-storage-utils.ts
@@ -1,0 +1,35 @@
+/**
+ * Safely sets an item in localStorage with automatic JSON serialization.
+ * Silently handles localStorage errors
+ *
+ * @param key - The localStorage key
+ * @param item - The value to store (will be JSON.stringify'd)
+ */
+export function safeLocalStorageSetItem<T>(key: string, item: T): void {
+  try {
+    localStorage.setItem(key, JSON.stringify(item));
+  } catch {
+    // Ignore localStorage errors (quota exceeded, private browsing, etc.)
+  }
+}
+
+/**
+ * Safely retrieves and deserializes an item from localStorage.
+ * Returns the defaultValue on any error
+ *
+ * @param key - The localStorage key to retrieve
+ * @param defaultValue - Value returned if retrieval/parsing fails
+ * @returns The parsed value or defaultValue
+ */
+export function safeLocalStorageGetItem<T>(key: string, defaultValue: T): T {
+  try {
+    const item = localStorage.getItem(key);
+    if (item === null) {
+      return defaultValue;
+    }
+    const result = JSON.parse(item) as T;
+    return result ?? defaultValue;
+  } catch {
+    return defaultValue;
+  }
+}


### PR DESCRIPTION
b9847fd643d40f74420c1baf00c6b47f6bc6bfe1 -- Add controlled table state management to tables. This allows Tables to be instantiated with their own state such that parents can control state.

3026c928882921da588c05433b205d4e2ca50fed -- Add localStorage utilities with error handling

107232d22e287de8e032b3b5bca093e2e0288ab1 -- Implement table state persistence across browser sessions. This implements the useLocalStorageTableState hook used to persist table state across browse sessions.

https://github.com/user-attachments/assets/63af196e-0f80-4ed6-b6a7-456bae4e88b9

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
