### PR TITLE
Add datetime filter support to table columns

### DIFF
--- a/javascript/packages/core/components/table/__tests__/table.test.tsx
+++ b/javascript/packages/core/components/table/__tests__/table.test.tsx
@@ -625,6 +625,45 @@ describe('Table', () => {
 
         expect(screen.getAllByRole('row')).toHaveLength(5); // 1 header + 4 rows
       });
+
+      it('should use datetime filter for DATE columns and categorical for others', () => {
+        const mixedColumns = [
+          { id: 'name', label: 'Name', accessor: 'name' },
+          { id: 'createdAt', label: 'Created At', accessor: 'createdAt', type: 'DATE' },
+          { id: 'department', label: 'Department', accessor: 'department' },
+        ];
+
+        const mixedTestData = [
+          { name: 'Alice', createdAt: 1672531200, department: 'Engineering' }, // 2023-01-01
+          { name: 'Bob', createdAt: 1680307200, department: 'Marketing' }, // 2023-04-01
+        ];
+        render(
+          <Table
+            data={mixedTestData}
+            columns={mixedColumns}
+            state={{
+              globalFilter: '',
+              columnFilters: [
+                {
+                  id: 'createdAt',
+                  value: {
+                    operation: 'RANGE_DATETIME',
+                    range: [new Date('2023-01-01'), new Date('2023-03-01')],
+                    selection: [],
+                    description: 'Q1 2023',
+                    exclude: false,
+                  },
+                },
+                { id: 'department', value: ['Engineering'] },
+              ],
+            }}
+          />,
+          buildWrapper([getInterpolationProviderWrapper(), getRouterWrapper()])
+        );
+
+        expect(screen.getByRole('row', { name: /Alice/ })).toBeInTheDocument();
+        expect(screen.queryByRole('row', { name: /Bob/ })).not.toBeInTheDocument();
+      });
     });
   });
 });

--- a/javascript/packages/core/components/table/components/filter/__fixtures__/mock-row.ts
+++ b/javascript/packages/core/components/table/components/filter/__fixtures__/mock-row.ts
@@ -1,0 +1,14 @@
+import type { Row } from '@tanstack/react-table';
+
+/**
+ * Creates a mock TanStack Table Row for testing filter functions.
+ *
+ * @param data - The row data object
+ * @returns A mock Row object with getValue method and original data
+ */
+export function createMockRow<T extends Record<string, unknown>>(data: T): Row<T> {
+  return {
+    getValue: (columnId: string) => data[columnId],
+    original: data,
+  } as unknown as Row<T>;
+}

--- a/javascript/packages/core/components/table/components/filter/__tests__/use-categorical-filter-factory.test.ts
+++ b/javascript/packages/core/components/table/components/filter/__tests__/use-categorical-filter-factory.test.ts
@@ -1,6 +1,6 @@
-import { Row } from '@tanstack/react-table';
 import { renderHook } from '@testing-library/react';
 
+import { createMockRow } from '../__fixtures__/mock-row';
 import { useCategoricalFilterFactory } from '../categorical/use-categorical-filter-factory';
 
 const MOCK_COLUMN = {
@@ -89,9 +89,7 @@ describe('Categorical Filter', () => {
       const filterHook = result.current(MOCK_COLUMN);
       const filterFn = filterHook.buildTableFilterFn();
 
-      const mockRow = {
-        getValue: () => 'Engineering',
-      } as unknown as Row<{ department: string }>;
+      const mockRow = createMockRow({ department: 'Engineering' });
 
       expect(filterFn(mockRow, 'department', [])).toBe(true);
     });
@@ -101,15 +99,8 @@ describe('Categorical Filter', () => {
       const filterHook = result.current(MOCK_COLUMN);
       const filterFn = filterHook.buildTableFilterFn();
 
-      const engineeringRow = {
-        getValue: () => 'Engineering',
-        original: { department: 'Engineering' },
-      } as unknown as Row<{ department: string }>;
-
-      const marketingRow = {
-        getValue: () => 'Marketing',
-        original: { department: 'Marketing' },
-      } as unknown as Row<{ department: string }>;
+      const engineeringRow = createMockRow({ department: 'Engineering' });
+      const marketingRow = createMockRow({ department: 'Marketing' });
 
       const filterValue = ['Engineering', 'Design'];
 

--- a/javascript/packages/core/components/table/components/filter/__tests__/use-datetime-filter-factory.test.ts
+++ b/javascript/packages/core/components/table/components/filter/__tests__/use-datetime-filter-factory.test.ts
@@ -1,0 +1,277 @@
+import { renderHook } from '@testing-library/react';
+
+import { createMockRow } from '../__fixtures__/mock-row';
+import { DatetimeFilterValue } from '../datetime/types';
+import { useDatetimeFilterFactory } from '../datetime/use-datetime-filter-factory';
+
+const MOCK_COLUMN = {
+  id: 'createdAt',
+  label: 'Created At',
+  accessor: 'createdAt',
+  type: 'DATE',
+};
+
+describe('Datetime Filter', () => {
+  describe('Empty filter behavior', () => {
+    it('shows all rows when no range or selection provided', () => {
+      const { result } = renderHook(() => useDatetimeFilterFactory());
+      const filterHook = result.current(MOCK_COLUMN);
+
+      const emptyFilter: DatetimeFilterValue = {
+        operation: 'RANGE_DATETIME',
+        range: [],
+        selection: [],
+        description: '',
+        exclude: false,
+      };
+
+      expect(filterHook.isFilterInactive(emptyFilter)).toBe(true);
+    });
+
+    it('considers filter active when range is provided', () => {
+      const { result } = renderHook(() => useDatetimeFilterFactory());
+      const filterHook = result.current(MOCK_COLUMN);
+
+      const rangeFilter: DatetimeFilterValue = {
+        operation: 'RANGE_DATETIME',
+        range: [new Date('2023-01-01'), new Date('2023-12-31')],
+        selection: [],
+        description: 'Year 2023',
+        exclude: false,
+      };
+
+      expect(filterHook.isFilterInactive(rangeFilter)).toBe(false);
+    });
+
+    it('considers filter active when selection is provided', () => {
+      const { result } = renderHook(() => useDatetimeFilterFactory());
+      const filterHook = result.current(MOCK_COLUMN);
+
+      const selectionFilter: DatetimeFilterValue = {
+        operation: 'RANGE_DATETIME',
+        range: [],
+        selection: [1672531200], // 2023-01-01 epoch seconds
+        description: 'Selected dates',
+        exclude: false,
+      };
+
+      expect(filterHook.isFilterInactive(selectionFilter)).toBe(false);
+    });
+  });
+
+  describe('Filter Display Functions', () => {
+    it('returns empty string for inactive filters', () => {
+      const { result } = renderHook(() => useDatetimeFilterFactory());
+      const filterHook = result.current(MOCK_COLUMN);
+
+      const inactiveFilter: DatetimeFilterValue = {
+        operation: 'RANGE_DATETIME',
+        range: [],
+        selection: [],
+        description: '',
+        exclude: false,
+      };
+
+      expect(filterHook.getActiveFilter(inactiveFilter)).toBe('');
+      expect(filterHook.getFilterSummary(inactiveFilter)).toBe('');
+    });
+
+    it('returns description for active filters', () => {
+      const { result } = renderHook(() => useDatetimeFilterFactory());
+      const filterHook = result.current(MOCK_COLUMN);
+
+      const activeFilter: DatetimeFilterValue = {
+        operation: 'RANGE_DATETIME',
+        range: [new Date('2023-01-01'), new Date('2023-12-31')],
+        selection: [],
+        description: 'Year 2023',
+        exclude: false,
+      };
+
+      expect(filterHook.getActiveFilter(activeFilter)).toBe('Year 2023');
+      expect(filterHook.getFilterSummary(activeFilter)).toBe('Created At: Year 2023');
+    });
+
+    it('handles column without label in filter summary', () => {
+      const columnWithoutLabel = { ...MOCK_COLUMN, label: undefined };
+      const { result } = renderHook(() => useDatetimeFilterFactory());
+      const filterHook = result.current(columnWithoutLabel);
+
+      const activeFilter: DatetimeFilterValue = {
+        operation: 'RANGE_DATETIME',
+        range: [new Date('2023-01-01'), new Date('2023-12-31')],
+        selection: [],
+        description: 'Year 2023',
+        exclude: false,
+      };
+
+      expect(filterHook.getFilterSummary(activeFilter)).toBe('Year 2023');
+    });
+  });
+
+  describe('Filter Function Behavior', () => {
+    it('returns true for inactive filters (show all rows)', () => {
+      const { result } = renderHook(() => useDatetimeFilterFactory<{ createdAt: number }>());
+      const filterHook = result.current(MOCK_COLUMN);
+      const filterFn = filterHook.buildTableFilterFn();
+
+      const mockRow = createMockRow({ createdAt: 1672531200 }); // 2023-01-01
+
+      const inactiveFilter: DatetimeFilterValue = {
+        operation: 'RANGE_DATETIME',
+        range: [],
+        selection: [],
+        description: '',
+        exclude: false,
+      };
+
+      expect(filterFn(mockRow, 'createdAt', inactiveFilter)).toBe(true);
+    });
+
+    it('filters rows based on date range (epoch seconds)', () => {
+      const { result } = renderHook(() => useDatetimeFilterFactory<{ createdAt: number }>());
+      const filterHook = result.current(MOCK_COLUMN);
+      const filterFn = filterHook.buildTableFilterFn();
+
+      const jan1Row = createMockRow({ createdAt: 1672531200 }); // 2023-01-01
+      const dec31Row = createMockRow({ createdAt: 1703980800 }); // 2023-12-31
+      const beforeRangeRow = createMockRow({ createdAt: 1640995200 }); // 2022-01-01
+
+      const filterValue: DatetimeFilterValue = {
+        operation: 'RANGE_DATETIME',
+        range: [new Date('2023-01-01'), new Date('2023-12-31')],
+        selection: [],
+        description: 'Year 2023',
+        exclude: false,
+      };
+
+      expect(filterFn(jan1Row, 'createdAt', filterValue)).toBe(true);
+      expect(filterFn(dec31Row, 'createdAt', filterValue)).toBe(true);
+      expect(filterFn(beforeRangeRow, 'createdAt', filterValue)).toBe(false);
+    });
+
+    it('filters rows based on date range (string epoch seconds)', () => {
+      const { result } = renderHook(() => useDatetimeFilterFactory<{ createdAt: string }>());
+      const filterHook = result.current(MOCK_COLUMN);
+      const filterFn = filterHook.buildTableFilterFn();
+
+      const validRow = createMockRow({ createdAt: '1672531200' }); // 2023-01-01
+      const invalidRow = createMockRow({ createdAt: '1640995200' }); // 2022-01-01
+
+      const filterValue: DatetimeFilterValue = {
+        operation: 'RANGE_DATETIME',
+        range: [new Date('2023-01-01'), new Date('2023-12-31')],
+        selection: [],
+        description: 'Year 2023',
+        exclude: false,
+      };
+
+      expect(filterFn(validRow, 'createdAt', filterValue)).toBe(true);
+      expect(filterFn(invalidRow, 'createdAt', filterValue)).toBe(false);
+    });
+
+    it('should not filter rows with null/undefined cell values', () => {
+      const { result } = renderHook(() => useDatetimeFilterFactory());
+      const filterHook = result.current(MOCK_COLUMN);
+      const filterFn = filterHook.buildTableFilterFn();
+
+      const nullRow = createMockRow({ createdAt: null });
+      const undefinedRow = createMockRow({ createdAt: undefined });
+
+      const filterValue: DatetimeFilterValue = {
+        operation: 'RANGE_DATETIME',
+        range: [new Date('2023-01-01'), new Date('2023-12-31')],
+        selection: [],
+        description: 'Year 2023',
+        exclude: false,
+      };
+
+      // @ts-expect-error testing null/undefined edge cases
+      expect(filterFn(nullRow, 'createdAt', filterValue)).toBe(false);
+      // @ts-expect-error testing null/undefined edge cases
+      expect(filterFn(undefinedRow, 'createdAt', filterValue)).toBe(false);
+    });
+
+    it('should not filter rows with invalid date values', () => {
+      const { result } = renderHook(() => useDatetimeFilterFactory<{ createdAt: string }>());
+      const filterHook = result.current(MOCK_COLUMN);
+      const filterFn = filterHook.buildTableFilterFn();
+
+      const invalidDateRow = createMockRow({ createdAt: 'invalid-number' });
+
+      const filterValue: DatetimeFilterValue = {
+        operation: 'RANGE_DATETIME',
+        range: [new Date('2023-01-01'), new Date('2023-12-31')],
+        selection: [],
+        description: 'Year 2023',
+        exclude: false,
+      };
+
+      expect(filterFn(invalidDateRow, 'createdAt', filterValue)).toBe(false);
+    });
+
+    it('handles string dates stored in localStorage', () => {
+      const { result } = renderHook(() => useDatetimeFilterFactory<{ createdAt: number }>());
+      const filterHook = result.current(MOCK_COLUMN);
+      const filterFn = filterHook.buildTableFilterFn();
+
+      const validRow = createMockRow({ createdAt: 1672531200 }); // 2023-01-01
+
+      const filterValue: DatetimeFilterValue = {
+        operation: 'RANGE_DATETIME',
+        // Simulate dates stored as strings in localStorage
+        range: ['2023-01-01T00:00:00.000Z', '2023-12-31T23:59:59.000Z'] as unknown as Date[],
+        selection: [],
+        description: 'Year 2023',
+        exclude: false,
+      };
+
+      expect(filterFn(validRow, 'createdAt', filterValue)).toBe(true);
+    });
+
+    it('shows all rows when date range is incomplete (defensive behavior)', () => {
+      // When start or end date is missing, the filter returns true for all rows
+      // This is defensive behavior to avoid hiding data due to malformed filters
+      const { result } = renderHook(() => useDatetimeFilterFactory<{ createdAt: number }>());
+      const filterHook = result.current(MOCK_COLUMN);
+      const filterFn = filterHook.buildTableFilterFn();
+
+      const mockRow = createMockRow({ createdAt: 1672531200 }); // 2023-01-01
+
+      const incompleteFilter: DatetimeFilterValue = {
+        operation: 'RANGE_DATETIME',
+        range: [new Date('2023-01-01')], // Missing end date
+        selection: [],
+        description: 'Incomplete range',
+        exclude: false,
+      };
+
+      expect(filterFn(mockRow, 'createdAt', incompleteFilter)).toBe(true);
+    });
+
+    it('has autoRemove property set to isFilterInactive function', () => {
+      const { result } = renderHook(() => useDatetimeFilterFactory());
+      const filterHook = result.current(MOCK_COLUMN);
+      const filterFn = filterHook.buildTableFilterFn();
+
+      const inactiveFilter: DatetimeFilterValue = {
+        operation: 'RANGE_DATETIME',
+        range: [],
+        selection: [],
+        description: '',
+        exclude: false,
+      };
+
+      const activeFilter: DatetimeFilterValue = {
+        operation: 'RANGE_DATETIME',
+        range: [new Date('2023-01-01'), new Date('2023-12-31')],
+        selection: [],
+        description: 'Year 2023',
+        exclude: false,
+      };
+
+      expect(filterFn.autoRemove!(inactiveFilter)).toBe(true);
+      expect(filterFn.autoRemove!(activeFilter)).toBe(false);
+    });
+  });
+});

--- a/javascript/packages/core/components/table/components/filter/datetime/types.ts
+++ b/javascript/packages/core/components/table/components/filter/datetime/types.ts
@@ -1,0 +1,10 @@
+/**
+ * Datetime filter value representing a date range with operation details
+ */
+export interface DatetimeFilterValue {
+  operation: string;
+  range: Date[];
+  selection: number[];
+  description: string;
+  exclude: boolean;
+}

--- a/javascript/packages/core/components/table/components/filter/datetime/use-datetime-filter-factory.ts
+++ b/javascript/packages/core/components/table/components/filter/datetime/use-datetime-filter-factory.ts
@@ -1,0 +1,78 @@
+import { DatetimeColumn } from 'baseui/data-table';
+
+import { ColumnConfig } from '#core/components/table/types/column-types';
+import { TableData } from '#core/components/table/types/data-types';
+import { getDateFromEpochSeconds } from '#core/utils/time-utils';
+import { getCellValueForColumn } from '../categorical/get-cell-value-for-column';
+
+import type { Row } from '@tanstack/react-table';
+import type { FilterHook } from '../types';
+import type { DatetimeFilterValue } from './types';
+
+/**
+ * Factory hook that returns a builder function for datetime filters.
+ *
+ * @returns A function that takes a column and returns a FilterHook for datetime filtering
+ */
+export function useDatetimeFilterFactory<T extends TableData = TableData>(): (
+  column: ColumnConfig<T>
+) => FilterHook<T, DatetimeFilterValue> {
+  return (column: ColumnConfig<T>): FilterHook<T, DatetimeFilterValue> => {
+    const convertStringParamsToDate = (filterValue: DatetimeFilterValue): DatetimeFilterValue => {
+      return {
+        ...filterValue,
+        range: filterValue?.range?.map((a) => new Date(a)) || [],
+      };
+    };
+
+    const isFilterInactive = (filterValue: DatetimeFilterValue): boolean => {
+      return !filterValue?.range?.length && !filterValue?.selection?.length;
+    };
+
+    const getActiveFilter = (filterValue: DatetimeFilterValue): string => {
+      if (isFilterInactive(filterValue)) return '';
+      return filterValue?.description ?? '';
+    };
+
+    const getFilterSummary = (filterValue: DatetimeFilterValue): string => {
+      if (isFilterInactive(filterValue)) return '';
+      return `${column.label ? `${column.label}: ` : ''}${getActiveFilter(filterValue)}`;
+    };
+
+    const buildTableFilterFn = () => {
+      const filterFn = (row: Row<T>, id: string, filterValue: DatetimeFilterValue) => {
+        // We don't support single date filters
+        if (isFilterInactive(filterValue) || filterValue.range.length === 1) {
+          return true;
+        }
+
+        // When column filters are persisted in local storage, they are transformed to strings
+        const convertedFilterValue = filterValue.range.some((value) => typeof value === 'string')
+          ? convertStringParamsToDate(filterValue)
+          : filterValue;
+
+        const cellValue = getCellValueForColumn(column, row, id);
+
+        const cellDate = getDateFromEpochSeconds(
+          typeof cellValue === 'number' ? cellValue : parseFloat(cellValue as string)
+        );
+
+        return DatetimeColumn({
+          title: '',
+          mapDataToValue: () => new Date(),
+          // @ts-expect-error Michelangelo DatetimeFilterValue does not match BaseUI's FilterParameters type
+        }).buildFilter(convertedFilterValue)(cellDate);
+      };
+
+      filterFn.autoRemove = isFilterInactive;
+      return filterFn;
+    };
+
+    return {
+      isFilterInactive,
+      getActiveFilter,
+      getFilterSummary,
+      buildTableFilterFn,
+    };
+  };
+}

--- a/javascript/packages/core/components/table/components/filter/use-filter-factory.ts
+++ b/javascript/packages/core/components/table/components/filter/use-filter-factory.ts
@@ -1,4 +1,6 @@
+import { CellType } from '#core/components/cell/constants';
 import { useCategoricalFilterFactory } from './categorical/use-categorical-filter-factory';
+import { useDatetimeFilterFactory } from './datetime/use-datetime-filter-factory';
 
 import type { ColumnConfig } from '../../types/column-types';
 import type { TableData } from '../../types/data-types';
@@ -11,11 +13,16 @@ import type { FilterHook } from './types';
  */
 export function useFilterFactory<T extends TableData = TableData>(): (
   column: ColumnConfig<T>
-) => FilterHook<T, unknown[]> {
+) => FilterHook<T, unknown> {
   const createCategoricalFilter = useCategoricalFilterFactory<T>();
+  const createDatetimeFilter = useDatetimeFilterFactory<T>();
 
   return (column: ColumnConfig<T>) => {
-    // For now, all filters are categorical. We'll add datetime filter support later.
+    // Route to appropriate filter based on column type
+    if (column.type === CellType.DATE) {
+      return createDatetimeFilter(column);
+    }
+
     return createCategoricalFilter(column);
   };
 }


### PR DESCRIPTION
Date-type columns now have first class support for filtering row-level data.

The core filtering logic leverages BaseUI DatetimeColumn, since the filter component will leverage this. Notably, the provided filtering functionality doesn't handle an edge case where a start is provided but not an end.

The filter factory testing repetitively created Tanstack-friendly rows, so I created a reusuable row creator function and updated categorical filter tests to use it as well

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
