### PR TITLE
Add basic filter menu to table action bar

### DIFF
--- a/javascript/app/icons/icons.tsx
+++ b/javascript/app/icons/icons.tsx
@@ -1,3 +1,4 @@
+import AddIcon from '@mui/icons-material/Add';
 import AutorenewIcon from '@mui/icons-material/Autorenew';
 import CancelIcon from '@mui/icons-material/Cancel';
 import CheckCircle from '@mui/icons-material/CheckCircle';
@@ -19,4 +20,5 @@ export const ICONS = {
   circleCheckFilled: createMuiIconAdapter(CheckCircle),
   diamondEmpty: createMuiIconAdapter(CropSquareIcon),
   playerNext: createMuiIconAdapter(SkipNextIcon),
+  plus: createMuiIconAdapter(AddIcon),
 } as const;

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-menu-content/table-filter-menu-content.tsx
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-menu-content/table-filter-menu-content.tsx
@@ -1,0 +1,23 @@
+import { TableFilterOptionList } from '../table-filter-option-list/table-filter-option-list';
+
+import type { TableData } from '#core/components/table/types/data-types';
+import type { TableFilterMenuContentProps } from './types';
+
+export function TableFilterMenuContent<T extends TableData = TableData>(
+  props: TableFilterMenuContentProps<T>
+) {
+  const { selectedColumn, filterableColumns, onColumnSelect } = props;
+
+  if (selectedColumn) {
+    // TODO: Integrate with our filter factory system using selectedColumn.columnType
+    return (
+      <div>
+        Filter component placeholder for {selectedColumn.id} (type: {selectedColumn.columnType})
+      </div>
+    );
+  }
+
+  return (
+    <TableFilterOptionList filterableColumns={filterableColumns} onColumnSelect={onColumnSelect} />
+  );
+}

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-menu-content/types.ts
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-menu-content/types.ts
@@ -1,0 +1,8 @@
+import type { FilterableColumn } from '#core/components/table/components/table-action-bar/types';
+import type { TableData } from '#core/components/table/types/data-types';
+
+export interface TableFilterMenuContentProps<T extends TableData = TableData> {
+  filterableColumns: FilterableColumn<T>[];
+  selectedColumn?: FilterableColumn<T>;
+  onColumnSelect: (column: FilterableColumn<T>) => void;
+}

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-option-list/styled-components.ts
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-option-list/styled-components.ts
@@ -1,0 +1,7 @@
+import { styled } from 'baseui';
+
+export const ListContainer = styled('ul', {
+  margin: 0,
+  padding: 0,
+  listStyle: 'none',
+});

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-option-list/table-filter-option-list.tsx
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-option-list/table-filter-option-list.tsx
@@ -1,0 +1,47 @@
+import { useStyletron } from 'baseui';
+
+import { TableFilterOption } from '../table-filter-option/table-filter-option';
+import { ListContainer } from './styled-components';
+
+import type { TableData } from '#core/components/table/types/data-types';
+import type { TableFilterOptionListProps } from './types';
+
+export function TableFilterOptionList<T extends TableData = TableData>({
+  filterableColumns,
+  onColumnSelect,
+}: TableFilterOptionListProps<T>) {
+  const [css, theme] = useStyletron();
+
+  return (
+    <div
+      className={css({
+        backgroundColor: theme.colors.backgroundPrimary,
+        borderRadius: theme.borders.radius300,
+        width: '214px',
+        display: 'flex',
+        flexDirection: 'column',
+      })}
+    >
+      <div
+        className={css({
+          ...theme.typography.LabelSmall,
+          paddingBottom: theme.sizing.scale300,
+          paddingTop: theme.sizing.scale500,
+          paddingLeft: theme.sizing.scale500,
+          paddingRight: theme.sizing.scale500,
+        })}
+      >
+        Select column to filter
+      </div>
+      <ListContainer>
+        {filterableColumns.map((column) => (
+          <TableFilterOption
+            key={column.id}
+            label={column.title}
+            onClick={() => onColumnSelect(column)}
+          />
+        ))}
+      </ListContainer>
+    </div>
+  );
+}

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-option-list/types.ts
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-option-list/types.ts
@@ -1,0 +1,7 @@
+import type { FilterableColumn } from '#core/components/table/components/table-action-bar/types';
+import type { TableData } from '#core/components/table/types/data-types';
+
+export interface TableFilterOptionListProps<T extends TableData = TableData> {
+  filterableColumns: FilterableColumn<T>[];
+  onColumnSelect: (column: FilterableColumn<T>) => void;
+}

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-option/styled-components.ts
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-option/styled-components.ts
@@ -1,0 +1,32 @@
+import { styled } from 'baseui';
+
+export const FilterOptionItem = styled('li', ({ $theme }) => ({
+  ...$theme.typography.ParagraphSmall,
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  paddingTop: $theme.sizing.scale500,
+  paddingBottom: $theme.sizing.scale500,
+  paddingLeft: $theme.sizing.scale600,
+  paddingRight: $theme.sizing.scale800,
+  cursor: 'pointer',
+  position: 'relative',
+
+  ':hover': {
+    backgroundColor: $theme.colors.menuFillHover,
+  },
+
+  ':before': getPseudoDividerLineStyles($theme.colors.borderOpaque),
+}));
+
+function getPseudoDividerLineStyles(color: string) {
+  return {
+    position: 'absolute',
+    width: '85%',
+    content: '""',
+    borderTop: '1px solid',
+    borderColor: color,
+    top: 0,
+    left: '7.5%',
+  };
+}

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-option/table-filter-option.tsx
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-option/table-filter-option.tsx
@@ -1,0 +1,13 @@
+import { Icon } from '#core/components/icon/icon';
+import { FilterOptionItem } from './styled-components';
+
+import type { TableFilterOptionProps } from './types';
+
+export function TableFilterOption({ label, onClick }: TableFilterOptionProps) {
+  return (
+    <FilterOptionItem onClick={onClick}>
+      {label}
+      <Icon name="chevronRight" size={20} />
+    </FilterOptionItem>
+  );
+}

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-option/types.ts
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-option/types.ts
@@ -1,0 +1,4 @@
+export interface TableFilterOptionProps {
+  label: string;
+  onClick: () => void;
+}

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/table-filter-menu.tsx
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/table-filter-menu.tsx
@@ -1,0 +1,62 @@
+import { useCallback, useState } from 'react';
+import { Button, KIND, SHAPE, SIZE } from 'baseui/button';
+import { PLACEMENT, StatefulPopover } from 'baseui/popover';
+
+import { Icon } from '#core/components/icon/icon';
+import { TableFilterMenuContent } from './components/table-filter-menu-content/table-filter-menu-content';
+
+import type { FilterableColumn } from '#core/components/table/components/table-action-bar/types';
+import type { TableData } from '#core/components/table/types/data-types';
+import type { TableFilterMenuProps } from './types';
+
+export function TableFilterMenu<T extends TableData = TableData>(props: TableFilterMenuProps<T>) {
+  const { filterableColumns } = props;
+
+  const [selectedColumn, setSelectedColumn] = useState<FilterableColumn<T> | undefined>();
+  const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false);
+
+  const handleMenuClose = useCallback(() => {
+    setSelectedColumn(undefined);
+    setIsMenuOpen(false);
+  }, []);
+
+  return (
+    <StatefulPopover
+      placement={PLACEMENT.bottomLeft}
+      onClose={handleMenuClose}
+      onOpen={() => setIsMenuOpen(true)}
+      overrides={{
+        Body: {
+          style: {
+            // For some reason, the popover is not being positioned correctly when using
+            // any combination of content prop that leverage filterableColumns.
+            top: '44px',
+          },
+        },
+      }}
+      content={
+        <TableFilterMenuContent
+          filterableColumns={filterableColumns}
+          selectedColumn={selectedColumn}
+          onColumnSelect={setSelectedColumn}
+        />
+      }
+    >
+      <Button
+        shape={SHAPE.pill}
+        size={SIZE.compact}
+        kind={isMenuOpen ? KIND.primary : KIND.secondary}
+        startEnhancer={<Icon name="plus" size={16} />}
+        overrides={{
+          BaseButton: {
+            style: {
+              textWrap: 'nowrap',
+            },
+          },
+        }}
+      >
+        Add filter
+      </Button>
+    </StatefulPopover>
+  );
+}

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/transform-filterable-columns.ts
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/transform-filterable-columns.ts
@@ -1,0 +1,26 @@
+import { CellType } from '#core/components/cell/constants';
+
+import type { Header } from '@tanstack/react-table';
+import type { FilterableColumn } from '#core/components/table/components/table-action-bar/types';
+import type { ColumnConfig } from '#core/components/table/types/column-types';
+import type { TableData } from '#core/components/table/types/data-types';
+
+/**
+ * Transforms TanStack headers into FilterableColumn format
+ */
+export function transformFilterableColumns<T extends TableData = TableData>(
+  tanstackHeaders: Header<T, unknown>[]
+): FilterableColumn<T>[] {
+  return tanstackHeaders
+    .filter((header) => header.column.getCanFilter())
+    .map((header) => {
+      const columnConfig = header.column.columnDef.meta as ColumnConfig<T>;
+      const title = columnConfig.label ?? header.id;
+
+      return {
+        id: header.id,
+        title,
+        columnType: columnConfig.type ?? CellType.TEXT,
+      };
+    });
+}

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/types.ts
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/types.ts
@@ -1,0 +1,6 @@
+import type { FilterableColumn } from '#core/components/table/components/table-action-bar/types';
+import type { TableData } from '#core/components/table/types/data-types';
+
+export interface TableFilterMenuProps<T extends TableData = TableData> {
+  filterableColumns: FilterableColumn<T>[];
+}

--- a/javascript/packages/core/components/table/components/table-action-bar/table-action-bar.tsx
+++ b/javascript/packages/core/components/table/components/table-action-bar/table-action-bar.tsx
@@ -1,18 +1,24 @@
+import { TableFilterMenu } from './components/table-filter-menu/table-filter-menu';
 import { TableSearchInput } from './components/table-search-input/table-search-input';
 import { ActionsContainer, Container, TrailingContentContainer } from './styled-components';
 
 import type { TableActionBarProps } from './types';
 
-export function TableActionBar({
+export function TableActionBar<T>({
   globalFilter,
   setGlobalFilter,
   configuration,
-}: TableActionBarProps) {
+  filterableColumns = [],
+}: TableActionBarProps<T>) {
   return (
     <Container>
       <ActionsContainer>
         {configuration.enableSearch && (
           <TableSearchInput value={globalFilter} onChange={setGlobalFilter} />
+        )}
+
+        {configuration.enableFilters && filterableColumns.length > 0 && (
+          <TableFilterMenu filterableColumns={filterableColumns} />
         )}
 
         {configuration.middle}

--- a/javascript/packages/core/components/table/components/table-action-bar/types.ts
+++ b/javascript/packages/core/components/table/components/table-action-bar/types.ts
@@ -1,9 +1,11 @@
 import type { ReactNode } from 'react';
+import type { TableData } from '#core/components/table/types/data-types';
 
-export interface TableActionBarProps {
+export interface TableActionBarProps<T extends TableData = TableData> {
   globalFilter: string;
   setGlobalFilter: (value: string) => void;
   configuration: TableActionBarConfig;
+  filterableColumns?: FilterableColumn<T>[];
 }
 
 /**
@@ -18,6 +20,13 @@ export interface TableActionBarConfig {
   enableSearch?: boolean;
 
   /**
+   * Indicates whether filter menu functionality is enabled.
+   *
+   * @default true
+   */
+  enableFilters?: boolean;
+
+  /**
    * ReactNode to be rendered in the middle section of the action bar.
    */
   middle?: ReactNode;
@@ -26,4 +35,10 @@ export interface TableActionBarConfig {
    * ReactNode to be rendered in the trailing section of the action bar.
    */
   trailing?: ReactNode;
+}
+
+export interface FilterableColumn<_T extends TableData = TableData> {
+  id: string;
+  title: string;
+  columnType: string;
 }

--- a/javascript/packages/core/components/table/components/table-header/styled-components.ts
+++ b/javascript/packages/core/components/table/components/table-header/styled-components.ts
@@ -1,0 +1,7 @@
+import { withStyle } from 'baseui';
+import { StyledTableHeadCell as BaseStyledTableHeadCell } from 'baseui/table-semantic';
+
+// Unset z-index to prevent interference with popovers and overlays
+export const StyledTableHeadCell = withStyle(BaseStyledTableHeadCell, {
+  zIndex: 'unset',
+});

--- a/javascript/packages/core/components/table/components/table-header/table-header.tsx
+++ b/javascript/packages/core/components/table/components/table-header/table-header.tsx
@@ -1,4 +1,6 @@
-import { StyledTableHead, StyledTableHeadCell, StyledTableHeadRow } from 'baseui/table-semantic';
+import { StyledTableHead, StyledTableHeadRow } from 'baseui/table-semantic';
+
+import { StyledTableHeadCell } from './styled-components';
 
 import type { TableData } from '#core/components/table/types/data-types';
 import type { TableHeaderProps } from './types';

--- a/javascript/packages/core/components/table/table.tsx
+++ b/javascript/packages/core/components/table/table.tsx
@@ -1,6 +1,7 @@
 import { getCoreRowModel, getFilteredRowModel, useReactTable } from '@tanstack/react-table';
 import { StyledTable } from 'baseui/table-semantic';
 
+import { transformFilterableColumns } from './components/table-action-bar/components/table-filter-menu/transform-filterable-columns';
 import { TableActionBar } from './components/table-action-bar/table-action-bar';
 import { transformRows } from './components/table-body/row-transformer';
 import { TableBody } from './components/table-body/table-body';
@@ -52,6 +53,9 @@ export function Table<T extends TableData = TableData>(inputProps: TableProps<T>
         globalFilter={table.getState().globalFilter as string}
         setGlobalFilter={table.setGlobalFilter}
         configuration={props.actionBarConfig}
+        filterableColumns={transformFilterableColumns(
+          table.getHeaderGroups().flatMap((group) => group.headers)
+        )}
       />
 
       <StyledTable>

--- a/javascript/packages/core/components/table/utils/apply-default-props.tsx
+++ b/javascript/packages/core/components/table/utils/apply-default-props.tsx
@@ -32,6 +32,7 @@ export function applyDefaultProps<T extends TableData = TableData>(
     error: props.error ?? undefined,
     actionBarConfig: props.actionBarConfig ?? {
       enableSearch: true,
+      enableFilters: true,
     },
     state: props.state ?? undefined,
   };


### PR DESCRIPTION
Create TableFilterMenu component with BaseUI popover and integrate into TableActionBar. Currently, the component doesn't apply filtering to table.

Encountered a couple of styling issues:

  1. Table header cell provided by baseui has zIndex. Removed this to not conflict with filter menu popover. Notably, baseui discourages the direct usage of zIndex

  2. Filter menu popover was not respecting the bottom placement and was instead displaying on top of the add filter button. I couldn't find a systematic fix, so currently applying a hardcoded top style.

Implement internal FilterableColumn type and map Tanstack Header type to internal FilterableColumn type for loose coupling to specific table libraries.

https://github.com/user-attachments/assets/21f7c586-97fa-4a93-a81a-b1acd418f5b1

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
