### PR TITLE
Implement categorical filter menu integrated into table

### DIFF
--- a/javascript/app/icons/icons.tsx
+++ b/javascript/app/icons/icons.tsx
@@ -5,6 +5,7 @@ import CheckCircle from '@mui/icons-material/CheckCircle';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import CropSquareIcon from '@mui/icons-material/CropSquare';
 import Info from '@mui/icons-material/Info';
+import KeyboardBackspaceIcon from '@mui/icons-material/KeyboardBackspace';
 import Launch from '@mui/icons-material/Launch';
 import SkipNextIcon from '@mui/icons-material/SkipNext';
 
@@ -13,6 +14,7 @@ import { createMuiIconAdapter } from './mui-icon-adapter';
 export const ICONS = {
   arrowCircular: createMuiIconAdapter(AutorenewIcon),
   arrowLaunch: createMuiIconAdapter(Launch),
+  arrowLeft: createMuiIconAdapter(KeyboardBackspaceIcon),
   chevronRight: createMuiIconAdapter(ChevronRightIcon),
   circleI: createMuiIconAdapter(Info),
   circleX: createMuiIconAdapter(CancelIcon),

--- a/javascript/packages/core/components/table/__tests__/table.test.tsx
+++ b/javascript/packages/core/components/table/__tests__/table.test.tsx
@@ -4,6 +4,7 @@ import { vi } from 'vitest';
 
 import { GrpcStatusCode } from '#core/constants/grpc-status-codes';
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
 import { getInterpolationProviderWrapper } from '#core/test/wrappers/get-interpolation-provider-wrapper';
 import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
 import { ApplicationError } from '#core/types/error-types';
@@ -408,6 +409,137 @@ describe('Table', () => {
     });
   });
 
+  describe('filter menu integration', () => {
+    const testData = [
+      { id: '1', name: 'Alice Johnson', department: 'Engineering', status: 'Active' },
+      { id: '2', name: 'Bob Smith', department: 'Marketing', status: 'Inactive' },
+      { id: '3', name: 'Carol Davis', department: 'Engineering', status: 'Active' },
+      { id: '4', name: 'David Wilson', department: 'Sales', status: 'Active' },
+    ];
+
+    const testColumns = [
+      { id: 'name', label: 'Name' },
+      { id: 'department', label: 'Department' },
+      { id: 'status', label: 'Status' },
+    ];
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    describe('end-to-end filter menu workflow', () => {
+      beforeEach(() => {
+        render(
+          <Table data={testData} columns={testColumns} actionBarConfig={{ enableFilters: true }} />,
+          buildWrapper([
+            getBaseProviderWrapper(),
+            getInterpolationProviderWrapper(),
+            getRouterWrapper(),
+          ])
+        );
+      });
+
+      it('should complete full filter workflow: open menu → select column → apply filter → verify results → close menu', async () => {
+        const user = userEvent.setup();
+
+        // Initially should show all 4 rows
+        expect(screen.getAllByRole('row')).toHaveLength(5); // 1 header + 4 data rows
+
+        // Step 1: Open filter menu
+        const addFilterButton = screen.getByRole('button', { name: 'Add filter' });
+        expect(addFilterButton).toBeInTheDocument();
+        await user.click(addFilterButton);
+
+        // Step 2: Select department column
+        const departmentOption = screen.getByTestId('filter-option-Department');
+        await user.click(departmentOption);
+
+        // Step 3: Select Engineering value in categorical filter
+        const engineeringCheckbox = screen.getByLabelText('Engineering');
+        await user.click(engineeringCheckbox);
+
+        // Step 4: Apply the filter
+        const applyButton = screen.getByRole('button', { name: 'Apply' });
+        await user.click(applyButton);
+
+        await waitFor(() => {
+          const rows = screen.getAllByRole('row');
+          expect(rows).toHaveLength(3); // 1 header + 2 Engineering rows
+        });
+
+        expect(
+          screen.getByRole('row', { name: 'Alice Johnson Engineering Active' })
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole('row', { name: 'Carol Davis Engineering Active' })
+        ).toBeInTheDocument();
+        expect(
+          screen.queryByRole('row', { name: 'Bob Smith Marketing Inactive' })
+        ).not.toBeInTheDocument();
+        expect(
+          screen.queryByRole('row', { name: 'David Wilson Sales Active' })
+        ).not.toBeInTheDocument();
+      });
+
+      it('should allow removing filters and show all data again', async () => {
+        const user = userEvent.setup();
+
+        // Apply a filter first
+        await user.click(screen.getByRole('button', { name: 'Add filter' }));
+        await user.click(screen.getByTestId('filter-option-Department'));
+        await user.click(screen.getByLabelText('Engineering'));
+        await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+        // Verify filter is applied
+        await waitFor(() => {
+          expect(screen.getAllByRole('row')).toHaveLength(3);
+        });
+
+        // Open filter menu again and remove filter
+        await user.click(screen.getByRole('button', { name: 'Add filter' }));
+        await user.click(screen.getByTestId('filter-option-Department'));
+        await user.click(screen.getByLabelText('Engineering')); // Uncheck
+        await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+        // Verify all data is shown again
+        await waitFor(() => {
+          expect(screen.getAllByRole('row')).toHaveLength(5);
+        });
+      });
+
+      it('should support exclude mode filtering', async () => {
+        const user = userEvent.setup();
+
+        // Open filter menu and select Department column
+        await user.click(screen.getByRole('button', { name: 'Add filter' }));
+        await user.click(screen.getByTestId('filter-option-Department'));
+
+        // Select Marketing (we want to exclude this)
+        await user.click(screen.getByLabelText('Marketing'));
+
+        // Enable exclude mode
+        await user.click(screen.getByLabelText('Exclude'));
+        await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+        // Should show all rows EXCEPT Marketing (Bob Smith)
+        await waitFor(() => {
+          expect(screen.getAllByRole('row')).toHaveLength(4); // 1 header + 3 non-Marketing rows
+        });
+
+        expect(
+          screen.getByRole('row', { name: 'Alice Johnson Engineering Active' })
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole('row', { name: 'Carol Davis Engineering Active' })
+        ).toBeInTheDocument();
+        expect(screen.getByRole('row', { name: 'David Wilson Sales Active' })).toBeInTheDocument();
+        expect(
+          screen.queryByRole('row', { name: 'Bob Smith Marketing Inactive' })
+        ).not.toBeInTheDocument();
+      });
+    });
+  });
+
   describe('state management integration', () => {
     const testData = [
       { id: '1', name: 'Alice Johnson', department: 'Engineering', status: 'Active' },
@@ -490,54 +622,8 @@ describe('Table', () => {
       });
     });
 
-    describe('column filters', () => {
-      it('should apply column filters to data', () => {
-        render(
-          <Table
-            data={testData}
-            columns={testColumns}
-            state={{
-              globalFilter: '',
-              columnFilters: [
-                { id: 'department', value: ['Engineering'] },
-                { id: 'status', value: ['Active'] },
-              ],
-            }}
-          />,
-          buildWrapper([getInterpolationProviderWrapper(), getRouterWrapper()])
-        );
-
-        expect(
-          screen.getByRole('row', { name: 'Alice Johnson Engineering Active' })
-        ).toBeInTheDocument();
-        expect(
-          screen.getByRole('row', { name: 'Carol Davis Engineering Active' })
-        ).toBeInTheDocument();
-        expect(
-          screen.queryByRole('row', { name: 'Bob Smith Marketing Inactive' })
-        ).not.toBeInTheDocument();
-        expect(
-          screen.queryByRole('row', { name: 'David Wilson Sales Active' })
-        ).not.toBeInTheDocument();
-      });
-
-      it('should handle empty column filters', () => {
-        render(
-          <Table
-            data={testData}
-            columns={testColumns}
-            state={{
-              globalFilter: '',
-              columnFilters: [],
-            }}
-          />,
-          buildWrapper([getInterpolationProviderWrapper(), getRouterWrapper()])
-        );
-
-        expect(screen.getAllByRole('row')).toHaveLength(5); // 1 header + 4 rows
-      });
-
-      it('should handle column filters with multiple values (OR logic within column)', () => {
+    describe('column filters edge cases', () => {
+      it('should handle multiple values with OR logic within column', () => {
         render(
           <Table
             data={testData}
@@ -550,16 +636,7 @@ describe('Table', () => {
           buildWrapper([getInterpolationProviderWrapper(), getRouterWrapper()])
         );
 
-        // Should show Engineering OR Sales
-        expect(
-          screen.getByRole('row', { name: 'Alice Johnson Engineering Active' })
-        ).toBeInTheDocument();
-        expect(
-          screen.getByRole('row', { name: 'Carol Davis Engineering Active' })
-        ).toBeInTheDocument();
-        expect(screen.getByRole('row', { name: 'David Wilson Sales Active' })).toBeInTheDocument();
-
-        // Not Engineering OR Sales
+        expect(screen.getAllByRole('row')).toHaveLength(4); // 1 header + 3 matching rows
         expect(
           screen.queryByRole('row', { name: 'Bob Smith Marketing Inactive' })
         ).not.toBeInTheDocument();
@@ -578,29 +655,9 @@ describe('Table', () => {
           buildWrapper([getInterpolationProviderWrapper(), getRouterWrapper()])
         );
 
+        expect(screen.getAllByRole('row')).toHaveLength(2); // 1 header + 1 matching row
         expect(
           screen.getByRole('row', { name: 'Alice Johnson Engineering Active' })
-        ).toBeInTheDocument();
-        expect(
-          screen.queryByRole('row', { name: 'Carol Davis Engineering Active' })
-        ).not.toBeInTheDocument(); // Engineering but doesn't match "Alice"
-      });
-
-      it('should show no results when filters conflict', () => {
-        render(
-          <Table
-            data={testData}
-            columns={testColumns}
-            state={{
-              globalFilter: 'Alice',
-              columnFilters: [{ id: 'department', value: ['Marketing'] }],
-            }}
-          />,
-          buildWrapper([getInterpolationProviderWrapper(), getRouterWrapper()])
-        );
-
-        expect(
-          screen.getByText('There is no information available for selected filters')
         ).toBeInTheDocument();
       });
 

--- a/javascript/packages/core/components/table/components/filter/__tests__/categorical-filter.test.tsx
+++ b/javascript/packages/core/components/table/components/filter/__tests__/categorical-filter.test.tsx
@@ -1,0 +1,229 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
+import { getInterpolationProviderWrapper } from '#core/test/wrappers/get-interpolation-provider-wrapper';
+import { CategoricalFilter } from '../categorical/categorical-filter';
+
+import type { ColumnFilterProps } from '../types';
+
+/**
+ * BaseUI CategoricalColumn.Filter has 3 checkboxes: **Select all**, **Clear**, **Exclude**
+ */
+const BASE_UI_CHECKBOX_COUNT = 3;
+
+describe('CategoricalFilter', () => {
+  const mockClose = vi.fn();
+  const mockSetFilterValue = vi.fn();
+  const mockGetFilterValue = vi.fn();
+
+  const defaultProps: ColumnFilterProps = {
+    columnId: 'department',
+    close: mockClose,
+    getFilterValue: mockGetFilterValue,
+    setFilterValue: mockSetFilterValue,
+    preFilteredRows: [
+      { getValue: () => 'Engineering' },
+      { getValue: () => 'Marketing' },
+      { getValue: () => 'Engineering' },
+      { getValue: () => 'Sales' },
+      { getValue: () => 'Design' },
+    ],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetFilterValue.mockReturnValue(undefined);
+  });
+
+  describe('sorting logic', () => {
+    it('should sort values alphabetically when no filters are selected', () => {
+      render(
+        <CategoricalFilter {...defaultProps} />,
+        buildWrapper([getBaseProviderWrapper(), getInterpolationProviderWrapper()])
+      );
+
+      // Check that all expected values are present
+      expect(screen.getByLabelText('Design')).toBeInTheDocument();
+      expect(screen.getByLabelText('Engineering')).toBeInTheDocument();
+      expect(screen.getByLabelText('Marketing')).toBeInTheDocument();
+      expect(screen.getByLabelText('Sales')).toBeInTheDocument();
+    });
+
+    it('should sort selected values first, then alphabetical', () => {
+      mockGetFilterValue.mockReturnValue(['Sales', 'Design']);
+
+      render(
+        <CategoricalFilter {...defaultProps} />,
+        buildWrapper([getBaseProviderWrapper(), getInterpolationProviderWrapper()])
+      );
+
+      expect(screen.getByLabelText('Design')).toBeChecked();
+      expect(screen.getByLabelText('Sales')).toBeChecked();
+      expect(screen.getByLabelText('Engineering')).not.toBeChecked();
+      expect(screen.getByLabelText('Marketing')).not.toBeChecked();
+    });
+  });
+
+  it('should show no checkboxes checked when no filter is applied', () => {
+    render(
+      <CategoricalFilter {...defaultProps} />,
+      buildWrapper([getBaseProviderWrapper(), getInterpolationProviderWrapper()])
+    );
+
+    expect(screen.getByLabelText('Design')).not.toBeChecked();
+    expect(screen.getByLabelText('Engineering')).not.toBeChecked();
+    expect(screen.getByLabelText('Marketing')).not.toBeChecked();
+    expect(screen.getByLabelText('Sales')).not.toBeChecked();
+  });
+
+  describe('user interactions', () => {
+    it('should call setFilterValue and close when applying selection', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <CategoricalFilter {...defaultProps} />,
+        buildWrapper([getBaseProviderWrapper(), getInterpolationProviderWrapper()])
+      );
+
+      await user.click(screen.getByLabelText('Engineering'));
+      await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+      expect(mockSetFilterValue).toHaveBeenCalledWith(['Engineering']);
+      expect(mockClose).toHaveBeenCalled();
+    });
+
+    it('should set undefined when no values are selected', async () => {
+      const user = userEvent.setup();
+      mockGetFilterValue.mockReturnValue(['Engineering']);
+
+      render(
+        <CategoricalFilter {...defaultProps} />,
+        buildWrapper([getBaseProviderWrapper(), getInterpolationProviderWrapper()])
+      );
+
+      // Uncheck the only selected item
+      await user.click(screen.getByLabelText('Engineering'));
+      await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+      expect(mockSetFilterValue).toHaveBeenCalledWith(undefined);
+      expect(mockClose).toHaveBeenCalled();
+    });
+
+    it('should handle multiple selections', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <CategoricalFilter {...defaultProps} />,
+        buildWrapper([getBaseProviderWrapper(), getInterpolationProviderWrapper()])
+      );
+
+      await user.click(screen.getByLabelText('Engineering'));
+      await user.click(screen.getByLabelText('Design'));
+      await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+      expect(mockSetFilterValue).toHaveBeenCalledWith(
+        expect.arrayContaining(['Design', 'Engineering'])
+      );
+      expect(mockClose).toHaveBeenCalled();
+    });
+
+    it('should handle exclude logic when exclude is checked', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <CategoricalFilter {...defaultProps} />,
+        buildWrapper([getBaseProviderWrapper(), getInterpolationProviderWrapper()])
+      );
+
+      // Select Engineering and Design
+      await user.click(screen.getByLabelText('Engineering'));
+      await user.click(screen.getByLabelText('Design'));
+
+      // Enable exclude mode
+      await user.click(screen.getByLabelText('Exclude'));
+      await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+      // Should filter to everything EXCEPT Engineering and Design (i.e., Marketing and Sales)
+      expect(mockSetFilterValue).toHaveBeenCalledWith(
+        expect.arrayContaining(['Marketing', 'Sales'])
+      );
+      expect(mockClose).toHaveBeenCalled();
+    });
+
+    it('should return undefined when exclude mode results in empty selection', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <CategoricalFilter {...defaultProps} />,
+        buildWrapper([getBaseProviderWrapper(), getInterpolationProviderWrapper()])
+      );
+
+      // Select all values
+      await user.click(screen.getByLabelText('Engineering'));
+      await user.click(screen.getByLabelText('Design'));
+      await user.click(screen.getByLabelText('Marketing'));
+      await user.click(screen.getByLabelText('Sales'));
+
+      // Enable exclude mode (should exclude everything)
+      await user.click(screen.getByLabelText('Exclude'));
+      await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+      // Should clear the filter since excluding all values leaves nothing
+      expect(mockSetFilterValue).toHaveBeenCalledWith(undefined);
+      expect(mockClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('data extraction', () => {
+    it('should extract unique values from preFilteredRows', () => {
+      const propsWithDuplicates: ColumnFilterProps = {
+        ...defaultProps,
+        preFilteredRows: [
+          { getValue: () => 'Engineering' },
+          { getValue: () => 'Engineering' },
+          { getValue: () => 'Marketing' },
+          { getValue: () => 'Engineering' },
+        ],
+      };
+
+      render(
+        <CategoricalFilter {...propsWithDuplicates} />,
+        buildWrapper([getBaseProviderWrapper(), getInterpolationProviderWrapper()])
+      );
+
+      // getByLabelText will fail if there are multiple matches
+      expect(screen.getByLabelText('Engineering')).toBeInTheDocument();
+      expect(screen.getByLabelText('Marketing')).toBeInTheDocument();
+
+      expect(screen.getAllByRole('checkbox')).toHaveLength(BASE_UI_CHECKBOX_COUNT + 2);
+    });
+
+    it('should handle null and undefined values gracefully', () => {
+      const propsWithNulls: ColumnFilterProps = {
+        ...defaultProps,
+        preFilteredRows: [
+          { getValue: () => 'Engineering' },
+          { getValue: () => null },
+          { getValue: () => undefined },
+          { getValue: () => 'Marketing' },
+          { getValue: () => '' },
+        ],
+      };
+
+      render(
+        <CategoricalFilter {...propsWithNulls} />,
+        buildWrapper([getBaseProviderWrapper(), getInterpolationProviderWrapper()])
+      );
+
+      // Should only show non-null values (empty string is still a valid value)
+      expect(screen.getByLabelText('Engineering')).toBeInTheDocument();
+      expect(screen.getByLabelText('Marketing')).toBeInTheDocument();
+      expect(screen.getByLabelText('')).toBeInTheDocument();
+
+      expect(screen.getAllByRole('checkbox')).toHaveLength(BASE_UI_CHECKBOX_COUNT + 3);
+    });
+  });
+});

--- a/javascript/packages/core/components/table/components/filter/categorical/categorical-filter.tsx
+++ b/javascript/packages/core/components/table/components/filter/categorical/categorical-filter.tsx
@@ -1,0 +1,70 @@
+import { CategoricalColumn } from 'baseui/data-table';
+
+import { safeStringify } from '#core/utils/string-utils';
+
+import type { ColumnFilterProps } from '../types';
+
+export function CategoricalFilter({
+  columnId,
+  close,
+  getFilterValue,
+  setFilterValue,
+  preFilteredRows,
+}: ColumnFilterProps) {
+  // BaseUI requires these props but we don't use them in filter context
+  const CategoricalFilterPanel = CategoricalColumn({
+    title: '',
+    mapDataToValue: () => '',
+  }).renderFilter;
+
+  const uniqueValues = new Set<string>();
+  preFilteredRows.forEach((row) => {
+    const value = row.getValue(columnId);
+    if (value != null) {
+      uniqueValues.add(safeStringify(value));
+    }
+  });
+  const availableValues = Array.from(uniqueValues);
+
+  const currentSelection = (getFilterValue() as string[]) ?? [];
+
+  // Sort values: selected items first, then alphabetical within each group
+  const sortedValues = availableValues.sort((a, b) => {
+    const isSelectedA = currentSelection.includes(a);
+    const isSelectedB = currentSelection.includes(b);
+
+    if (isSelectedA === isSelectedB) {
+      return a.localeCompare(b);
+    }
+    return isSelectedA ? -1 : 1;
+  });
+
+  const handleFilterChange = ({
+    selection,
+    exclude,
+  }: {
+    selection: Set<string>;
+    exclude: boolean;
+  }) => {
+    // Apply exclude logic: invert selection if exclude is true
+    const filteredSelection = exclude
+      ? availableValues.filter((value) => !selection.has(value))
+      : Array.from(selection);
+
+    setFilterValue(filteredSelection.length > 0 ? filteredSelection : undefined);
+    close();
+  };
+
+  return (
+    <CategoricalFilterPanel
+      data={sortedValues}
+      setFilter={handleFilterChange}
+      close={close}
+      filterParams={{
+        description: '',
+        selection: new Set(currentSelection),
+        exclude: false,
+      }}
+    />
+  );
+}

--- a/javascript/packages/core/components/table/components/filter/datetime/datetime-filter.tsx
+++ b/javascript/packages/core/components/table/components/filter/datetime/datetime-filter.tsx
@@ -1,0 +1,11 @@
+import type { ColumnFilterProps } from '../types';
+
+export function DatetimeFilter({ columnId, close }: ColumnFilterProps) {
+  // TODO: Implement datetime filter
+  return (
+    <div style={{ padding: '16px' }}>
+      <div>Datetime filter for column: {columnId}</div>
+      <button onClick={close}>Close</button>
+    </div>
+  );
+}

--- a/javascript/packages/core/components/table/components/filter/get-column-filter.ts
+++ b/javascript/packages/core/components/table/components/filter/get-column-filter.ts
@@ -1,0 +1,18 @@
+import { CellType } from '#core/components/cell/constants';
+import { CategoricalFilter } from './categorical/categorical-filter';
+import { DatetimeFilter } from './datetime/datetime-filter';
+
+import type { ComponentType } from 'react';
+import type { ColumnFilterProps } from './types';
+
+/**
+ * Returns the appropriate filter component for a given column type
+ */
+export function getColumnFilter(columnType: string): ComponentType<ColumnFilterProps> {
+  switch (columnType as CellType) {
+    case CellType.DATE:
+      return DatetimeFilter;
+    default:
+      return CategoricalFilter;
+  }
+}

--- a/javascript/packages/core/components/table/components/filter/types.ts
+++ b/javascript/packages/core/components/table/components/filter/types.ts
@@ -52,4 +52,7 @@ export enum FilterMode {
 export type ColumnFilterProps = {
   columnId: string;
   close: () => void;
+  getFilterValue: () => unknown;
+  setFilterValue: (value: unknown) => void;
+  preFilteredRows: Array<{ getValue: (columnId: string) => unknown }>;
 };

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-menu-content/table-filter-menu-content.tsx
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-menu-content/table-filter-menu-content.tsx
@@ -1,3 +1,8 @@
+import { useStyletron } from 'baseui';
+import { Button, KIND, SIZE } from 'baseui/button';
+
+import { Icon } from '#core/components/icon/icon';
+import { getColumnFilter } from '#core/components/table/components/filter/get-column-filter';
 import { TableFilterOptionList } from '../table-filter-option-list/table-filter-option-list';
 
 import type { TableData } from '#core/components/table/types/data-types';
@@ -6,18 +11,54 @@ import type { TableFilterMenuContentProps } from './types';
 export function TableFilterMenuContent<T extends TableData = TableData>(
   props: TableFilterMenuContentProps<T>
 ) {
-  const { selectedColumn, filterableColumns, onColumnSelect } = props;
+  const {
+    columnFilters,
+    filterableColumns,
+    onClose,
+    preFilteredRows,
+    selectedColumn,
+    setColumnFilters,
+    setSelectedColumn,
+  } = props;
+
+  const [css, theme] = useStyletron();
 
   if (selectedColumn) {
-    // TODO: Integrate with our filter factory system using selectedColumn.columnType
+    const FilterComponent = getColumnFilter(selectedColumn.columnType);
+
     return (
-      <div>
-        Filter component placeholder for {selectedColumn.id} (type: {selectedColumn.columnType})
+      <div className={css({ backgroundColor: theme.colors.backgroundPrimary })}>
+        <Button
+          onClick={() => setSelectedColumn(undefined)}
+          kind={KIND.tertiary}
+          size={SIZE.compact}
+        >
+          <Icon name="arrowLeft" size={18} />
+        </Button>
+        <FilterComponent
+          columnId={selectedColumn.id}
+          close={onClose}
+          getFilterValue={() => {
+            const filter = columnFilters.find((f) => f.id === selectedColumn.id);
+            return filter?.value;
+          }}
+          setFilterValue={(value) => {
+            const newFilters = columnFilters.filter((f) => f.id !== selectedColumn.id);
+            if (value !== undefined) {
+              newFilters.push({ id: selectedColumn.id, value });
+            }
+            setColumnFilters(newFilters);
+          }}
+          preFilteredRows={preFilteredRows}
+        />
       </div>
     );
   }
 
   return (
-    <TableFilterOptionList filterableColumns={filterableColumns} onColumnSelect={onColumnSelect} />
+    <TableFilterOptionList
+      filterableColumns={filterableColumns}
+      setSelectedColumn={setSelectedColumn}
+    />
   );
 }

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-menu-content/types.ts
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-menu-content/types.ts
@@ -1,8 +1,13 @@
 import type { FilterableColumn } from '#core/components/table/components/table-action-bar/types';
 import type { TableData } from '#core/components/table/types/data-types';
+import type { ColumnFilter } from '#core/components/table/types/table-types';
 
 export interface TableFilterMenuContentProps<T extends TableData = TableData> {
   filterableColumns: FilterableColumn<T>[];
   selectedColumn?: FilterableColumn<T>;
-  onColumnSelect: (column: FilterableColumn<T>) => void;
+  setSelectedColumn: (column: FilterableColumn<T> | undefined) => void;
+  columnFilters: ColumnFilter[];
+  setColumnFilters: (filters: ColumnFilter[]) => void;
+  preFilteredRows: Array<{ getValue: (columnId: string) => unknown }>;
+  onClose: () => void;
 }

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-option-list/table-filter-option-list.tsx
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-option-list/table-filter-option-list.tsx
@@ -8,7 +8,7 @@ import type { TableFilterOptionListProps } from './types';
 
 export function TableFilterOptionList<T extends TableData = TableData>({
   filterableColumns,
-  onColumnSelect,
+  setSelectedColumn,
 }: TableFilterOptionListProps<T>) {
   const [css, theme] = useStyletron();
 
@@ -38,7 +38,7 @@ export function TableFilterOptionList<T extends TableData = TableData>({
           <TableFilterOption
             key={column.id}
             label={column.title}
-            onClick={() => onColumnSelect(column)}
+            onClick={() => setSelectedColumn(column)}
           />
         ))}
       </ListContainer>

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-option-list/types.ts
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-option-list/types.ts
@@ -3,5 +3,5 @@ import type { TableData } from '#core/components/table/types/data-types';
 
 export interface TableFilterOptionListProps<T extends TableData = TableData> {
   filterableColumns: FilterableColumn<T>[];
-  onColumnSelect: (column: FilterableColumn<T>) => void;
+  setSelectedColumn: (column: FilterableColumn<T>) => void;
 }

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-option/table-filter-option.tsx
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-option/table-filter-option.tsx
@@ -5,7 +5,7 @@ import type { TableFilterOptionProps } from './types';
 
 export function TableFilterOption({ label, onClick }: TableFilterOptionProps) {
   return (
-    <FilterOptionItem onClick={onClick}>
+    <FilterOptionItem onClick={onClick} data-testid={`filter-option-${label}`}>
       {label}
       <Icon name="chevronRight" size={20} />
     </FilterOptionItem>

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/table-filter-menu.tsx
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/table-filter-menu.tsx
@@ -10,7 +10,7 @@ import type { TableData } from '#core/components/table/types/data-types';
 import type { TableFilterMenuProps } from './types';
 
 export function TableFilterMenu<T extends TableData = TableData>(props: TableFilterMenuProps<T>) {
-  const { filterableColumns } = props;
+  const { filterableColumns, columnFilters, setColumnFilters, preFilteredRows } = props;
 
   const [selectedColumn, setSelectedColumn] = useState<FilterableColumn<T> | undefined>();
   const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false);
@@ -34,18 +34,25 @@ export function TableFilterMenu<T extends TableData = TableData>(props: TableFil
           },
         },
       }}
-      content={
+      content={({ close }) => (
         <TableFilterMenuContent
+          columnFilters={columnFilters}
           filterableColumns={filterableColumns}
+          onClose={() => {
+            handleMenuClose();
+            close();
+          }}
+          preFilteredRows={preFilteredRows}
           selectedColumn={selectedColumn}
-          onColumnSelect={setSelectedColumn}
+          setColumnFilters={setColumnFilters}
+          setSelectedColumn={setSelectedColumn}
         />
-      }
+      )}
     >
       <Button
         shape={SHAPE.pill}
         size={SIZE.compact}
-        kind={isMenuOpen ? KIND.primary : KIND.secondary}
+        kind={isMenuOpen || columnFilters.length > 0 ? KIND.primary : KIND.secondary}
         startEnhancer={<Icon name="plus" size={16} />}
         overrides={{
           BaseButton: {

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/types.ts
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/types.ts
@@ -1,6 +1,10 @@
 import type { FilterableColumn } from '#core/components/table/components/table-action-bar/types';
 import type { TableData } from '#core/components/table/types/data-types';
+import type { ColumnFilter } from '#core/components/table/types/table-types';
 
 export interface TableFilterMenuProps<T extends TableData = TableData> {
   filterableColumns: FilterableColumn<T>[];
+  columnFilters: ColumnFilter[];
+  setColumnFilters: (filters: ColumnFilter[]) => void;
+  preFilteredRows: Array<{ getValue: (columnId: string) => unknown }>;
 }

--- a/javascript/packages/core/components/table/components/table-action-bar/table-action-bar.tsx
+++ b/javascript/packages/core/components/table/components/table-action-bar/table-action-bar.tsx
@@ -7,6 +7,9 @@ import type { TableActionBarProps } from './types';
 export function TableActionBar<T>({
   globalFilter,
   setGlobalFilter,
+  columnFilters,
+  setColumnFilters,
+  preFilteredRows,
   configuration,
   filterableColumns = [],
 }: TableActionBarProps<T>) {
@@ -18,7 +21,12 @@ export function TableActionBar<T>({
         )}
 
         {configuration.enableFilters && filterableColumns.length > 0 && (
-          <TableFilterMenu filterableColumns={filterableColumns} />
+          <TableFilterMenu
+            filterableColumns={filterableColumns}
+            columnFilters={columnFilters}
+            setColumnFilters={setColumnFilters}
+            preFilteredRows={preFilteredRows}
+          />
         )}
 
         {configuration.middle}

--- a/javascript/packages/core/components/table/components/table-action-bar/types.ts
+++ b/javascript/packages/core/components/table/components/table-action-bar/types.ts
@@ -1,9 +1,15 @@
 import type { ReactNode } from 'react';
+import type { ColumnConfig } from '#core/components/table/types/column-types';
 import type { TableData } from '#core/components/table/types/data-types';
+import type { ColumnFilter } from '#core/components/table/types/table-types';
 
 export interface TableActionBarProps<T extends TableData = TableData> {
   globalFilter: string;
   setGlobalFilter: (value: string) => void;
+  columnFilters: ColumnFilter[];
+  setColumnFilters: (filters: ColumnFilter[]) => void;
+  columns: ColumnConfig<T>[];
+  preFilteredRows: Array<{ getValue: (columnId: string) => unknown }>;
   configuration: TableActionBarConfig;
   filterableColumns?: FilterableColumn<T>[];
 }

--- a/javascript/packages/core/components/table/table.tsx
+++ b/javascript/packages/core/components/table/table.tsx
@@ -52,6 +52,10 @@ export function Table<T extends TableData = TableData>(inputProps: TableProps<T>
       <TableActionBar
         globalFilter={table.getState().globalFilter as string}
         setGlobalFilter={table.setGlobalFilter}
+        columnFilters={table.getState().columnFilters}
+        setColumnFilters={table.setColumnFilters}
+        columns={columns}
+        preFilteredRows={table.getPreFilteredRowModel().rows}
         configuration={props.actionBarConfig}
         filterableColumns={transformFilterableColumns(
           table.getHeaderGroups().flatMap((group) => group.headers)


### PR DESCRIPTION
Replace basic filter menu placeholder for categorical filters with complete filtering infrastructure.

As with other table integration work, the Tanstack prefilteredRow is adapted to the internal row type to maintain loose coupling with the tanstack table library.

Replaced some table columnFilters tests with the integrated filter menu categorical filter testing. This duplication wouldn't add useful coverage.

Renamed onColumnSelect to setSelectedColumn, since the former suggests the prop is a side effect after selecting a column. In reality, it is the function that must persist the selected column.

To facility improved testing, added test IDs to the filter option list items. Otherwise there is conflict between the row data and the filter option list data.

https://github.com/user-attachments/assets/9753e441-fd9c-4e93-a67e-d66e40fdaafc

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
