### PR TITLE
Register extension validation hook

### DIFF
--- a/go/cmd/kubeproto/protoc-gen-validation/BUILD.bazel
+++ b/go/cmd/kubeproto/protoc-gen-validation/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//go/kubeproto/pboptions:go_default_library",
+        "//go/kubeproto/templates:go_default_library",
         "//go/kubeproto/util:go_default_library",
         "@org_golang_google_protobuf//compiler/protogen:go_default_library",
         "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",

--- a/go/cmd/kubeproto/protoc-gen-validation/main.go
+++ b/go/cmd/kubeproto/protoc-gen-validation/main.go
@@ -7,9 +7,11 @@ import (
 	"os"
 	"regexp"
 	"strconv"
+	"strings"
 	"text/template"
 
 	"github.com/michelangelo-ai/michelangelo/go/kubeproto/pboptions"
+	"github.com/michelangelo-ai/michelangelo/go/kubeproto/templates"
 	"github.com/michelangelo-ai/michelangelo/go/kubeproto/util"
 
 	"google.golang.org/protobuf/compiler/protogen"
@@ -18,26 +20,6 @@ import (
 	"google.golang.org/protobuf/types/descriptorpb"
 	"google.golang.org/protobuf/types/pluginpb"
 )
-
-var validateFuncTmp = template.Must(template.New("validateFunc").Parse(`
-// {{.TypeName}}ValidateExt is an extension hook for additional validation logic
-var {{.TypeName}}ValidateExt func(*{{.TypeName}}) error
-
-func (this *{{.TypeName}}) Validate(prefix string) error {
-{{.ValidateLogic}}
-	// Call extension validation if registered
-	if {{.TypeName}}ValidateExt != nil {
-		if err := {{.TypeName}}ValidateExt(this); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// Register{{.TypeName}}ValidateExt registers an extension validation function
-func Register{{.TypeName}}ValidateExt(f func(*{{.TypeName}}) error) {
-	{{.TypeName}}ValidateExt = f
-}`))
 
 var validateFieldTmp = template.Must(template.New("validateField").Parse(`
 		if {{.Condition}} {
@@ -280,11 +262,20 @@ var _ = strconv.Itoa
 			g.P(sets[i])
 		}
 
+		// Use the template from the templates package
 		var buf bytes.Buffer
-		validateFuncTmp.Execute(&buf, struct {
+		typeName := msg.GoIdent.GoName
+		typeNameLower := strings.ToLower(typeName[:1]) + typeName[1:]
+		
+		templates.Validation.Execute(&buf, struct {
 			TypeName      string
+			TypeNameLower string
 			ValidateLogic string
-		}{msg.GoIdent.GoName, validateCode})
+		}{
+			TypeName:      typeName,
+			TypeNameLower: typeNameLower,
+			ValidateLogic: validateCode,
+		})
 		g.P(buf.String())
 	}
 

--- a/go/cmd/kubeproto/protoc-gen-validation/main.go
+++ b/go/cmd/kubeproto/protoc-gen-validation/main.go
@@ -20,9 +20,23 @@ import (
 )
 
 var validateFuncTmp = template.Must(template.New("validateFunc").Parse(`
+// {{.TypeName}}ValidateExt is an extension hook for additional validation logic
+var {{.TypeName}}ValidateExt func(*{{.TypeName}}) error
+
 func (this *{{.TypeName}}) Validate(prefix string) error {
 {{.ValidateLogic}}
+	// Call extension validation if registered
+	if {{.TypeName}}ValidateExt != nil {
+		if err := {{.TypeName}}ValidateExt(this); err != nil {
+			return err
+		}
+	}
 	return nil
+}
+
+// Register{{.TypeName}}ValidateExt registers an extension validation function
+func Register{{.TypeName}}ValidateExt(f func(*{{.TypeName}}) error) {
+	{{.TypeName}}ValidateExt = f
 }`))
 
 var validateFieldTmp = template.Must(template.New("validateField").Parse(`

--- a/go/cmd/kubeproto/protoc-gen-validation/main.go
+++ b/go/cmd/kubeproto/protoc-gen-validation/main.go
@@ -266,7 +266,7 @@ var _ = strconv.Itoa
 		var buf bytes.Buffer
 		typeName := msg.GoIdent.GoName
 		typeNameLower := strings.ToLower(typeName[:1]) + typeName[1:]
-		
+
 		templates.Validation.Execute(&buf, struct {
 			TypeName      string
 			TypeNameLower string

--- a/go/cmd/kubeproto/protoc-gen-validation/main_test.go
+++ b/go/cmd/kubeproto/protoc-gen-validation/main_test.go
@@ -37,22 +37,22 @@ func TestGen(t *testing.T) {
 	assert.True(t, strings.Contains(goFile, "func (this *ValidationMsg2) Validate(prefix string) error"))
 	assert.True(t, strings.Contains(goFile, "func (this *ValidationMsg3) Validate(prefix string) error"))
 
-	// Test that extension variables are generated
-	assert.True(t, strings.Contains(goFile, "var ValidationMsg1ValidateExt func(*ValidationMsg1) error"))
-	assert.True(t, strings.Contains(goFile, "var ValidationMsg2ValidateExt func(*ValidationMsg2) error"))
-	assert.True(t, strings.Contains(goFile, "var ValidationMsg3ValidateExt func(*ValidationMsg3) error"))
+	// Test that extension variables are generated with private names (lowercase first letter)
+	assert.True(t, strings.Contains(goFile, "var validationMsg1ValidateExt func(*ValidationMsg1, string) error"))
+	assert.True(t, strings.Contains(goFile, "var validationMsg2ValidateExt func(*ValidationMsg2, string) error"))
+	assert.True(t, strings.Contains(goFile, "var validationMsg3ValidateExt func(*ValidationMsg3, string) error"))
 
-	// Test that extension calls are generated in validation functions
-	assert.True(t, strings.Contains(goFile, "if ValidationMsg1ValidateExt != nil {"))
-	assert.True(t, strings.Contains(goFile, "if err := ValidationMsg1ValidateExt(this); err != nil {"))
-	assert.True(t, strings.Contains(goFile, "if ValidationMsg2ValidateExt != nil {"))
-	assert.True(t, strings.Contains(goFile, "if err := ValidationMsg2ValidateExt(this); err != nil {"))
+	// Test that extension calls are generated in validation functions with private variable names
+	assert.True(t, strings.Contains(goFile, "if validationMsg1ValidateExt != nil {"))
+	assert.True(t, strings.Contains(goFile, "if err := validationMsg1ValidateExt(this, prefix); err != nil {"))
+	assert.True(t, strings.Contains(goFile, "if validationMsg2ValidateExt != nil {"))
+	assert.True(t, strings.Contains(goFile, "if err := validationMsg2ValidateExt(this, prefix); err != nil {"))
 
-	// Test that registration functions are generated
-	assert.True(t, strings.Contains(goFile, "func RegisterValidationMsg1ValidateExt(f func(*ValidationMsg1) error) {"))
-	assert.True(t, strings.Contains(goFile, "ValidationMsg1ValidateExt = f"))
-	assert.True(t, strings.Contains(goFile, "func RegisterValidationMsg2ValidateExt(f func(*ValidationMsg2) error) {"))
-	assert.True(t, strings.Contains(goFile, "ValidationMsg2ValidateExt = f"))
+	// Test that registration functions are generated (these remain public)
+	assert.True(t, strings.Contains(goFile, "func RegisterValidationMsg1ValidateExt(f func(*ValidationMsg1, string) error) {"))
+	assert.True(t, strings.Contains(goFile, "validationMsg1ValidateExt = f"))
+	assert.True(t, strings.Contains(goFile, "func RegisterValidationMsg2ValidateExt(f func(*ValidationMsg2, string) error) {"))
+	assert.True(t, strings.Contains(goFile, "validationMsg2ValidateExt = f"))
 }
 
 func TestNoDefault(t *testing.T) {
@@ -493,7 +493,7 @@ func TestOneof(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// Test extension functionality
+// Test extension functionality with prefix parameter
 func TestValidationExtension(t *testing.T) {
 	// Test basic extension registration and execution
 	m1 := testpb.ValidationMsg1{
@@ -506,33 +506,33 @@ func TestValidationExtension(t *testing.T) {
 	err := m1.Validate("")
 	assert.NoError(t, err)
 
-	// Register extension that always fails
-	testpb.RegisterValidationMsg1ValidateExt(func(msg *testpb.ValidationMsg1) error {
-		return status.Error(codes.InvalidArgument, "extension validation failed")
+	// Register extension that always fails and uses prefix
+	testpb.RegisterValidationMsg1ValidateExt(func(msg *testpb.ValidationMsg1, prefix string) error {
+		return status.Error(codes.InvalidArgument, prefix + "extension validation failed")
 	})
 
 	// Should now fail due to extension
-	err = m1.Validate("")
+	err = m1.Validate("test.")
 	assert.Error(t, err)
-	assert.Equal(t, status.Error(codes.InvalidArgument, "extension validation failed"), err)
+	assert.Equal(t, status.Error(codes.InvalidArgument, "test.extension validation failed"), err)
 
-	// Register extension that checks custom business logic
-	testpb.RegisterValidationMsg1ValidateExt(func(msg *testpb.ValidationMsg1) error {
+	// Register extension that checks custom business logic with prefix
+	testpb.RegisterValidationMsg1ValidateExt(func(msg *testpb.ValidationMsg1, prefix string) error {
 		if msg.F1 > 75 {
-			return status.Error(codes.InvalidArgument, "f1 cannot exceed 75 in extension validation")
+			return status.Error(codes.InvalidArgument, prefix + "f1 cannot exceed 75 in extension validation")
 		}
 		return nil
 	})
 
 	// Should pass with F1 = 50
-	err = m1.Validate("")
+	err = m1.Validate("test.")
 	assert.NoError(t, err)
 
 	// Should fail with F1 = 80
 	m1.F1 = 80
-	err = m1.Validate("")
+	err = m1.Validate("test.")
 	assert.Error(t, err)
-	assert.Equal(t, status.Error(codes.InvalidArgument, "f1 cannot exceed 75 in extension validation"), err)
+	assert.Equal(t, status.Error(codes.InvalidArgument, "test.f1 cannot exceed 75 in extension validation"), err)
 
 	// Clear extension
 	testpb.RegisterValidationMsg1ValidateExt(nil)
@@ -559,23 +559,23 @@ func TestValidationExtensionWithComplexMessage(t *testing.T) {
 	err := m2.Validate("")
 	assert.NoError(t, err)
 
-	// Register extension that validates array contents
-	testpb.RegisterValidationMsg2ValidateExt(func(msg *testpb.ValidationMsg2) error {
+	// Register extension that validates array contents and uses prefix
+	testpb.RegisterValidationMsg2ValidateExt(func(msg *testpb.ValidationMsg2, prefix string) error {
 		if len(msg.F9) > 0 && msg.F9[0] < 50 {
-			return status.Error(codes.InvalidArgument, "first element of f9 must be >= 50")
+			return status.Error(codes.InvalidArgument, prefix + "first element of f9 must be >= 50")
 		}
 		return nil
 	})
 
 	// Should pass with current values
-	err = m2.Validate("")
+	err = m2.Validate("msg2.")
 	assert.NoError(t, err)
 
 	// Should fail with small first element
 	m2.F9[0] = 25
-	err = m2.Validate("")
+	err = m2.Validate("msg2.")
 	assert.Error(t, err)
-	assert.Equal(t, status.Error(codes.InvalidArgument, "first element of f9 must be >= 50"), err)
+	assert.Equal(t, status.Error(codes.InvalidArgument, "msg2.first element of f9 must be >= 50"), err)
 
 	// Clear extension
 	testpb.RegisterValidationMsg2ValidateExt(nil)
@@ -591,32 +591,32 @@ func TestMultipleValidationExtensions(t *testing.T) {
 
 	m3 := testpb.ValidationMsg3{}
 
-	// Register extensions for both types
-	testpb.RegisterValidationMsg1ValidateExt(func(msg *testpb.ValidationMsg1) error {
+	// Register extensions for both types with prefix usage
+	testpb.RegisterValidationMsg1ValidateExt(func(msg *testpb.ValidationMsg1, prefix string) error {
 		if msg.F3 == "forbidden" {
-			return status.Error(codes.InvalidArgument, "f3 cannot be 'forbidden'")
+			return status.Error(codes.InvalidArgument, prefix + "f3 cannot be 'forbidden'")
 		}
 		return nil
 	})
 
-	testpb.RegisterValidationMsg3ValidateExt(func(msg *testpb.ValidationMsg3) error {
-		return status.Error(codes.InvalidArgument, "ValidationMsg3 extension always fails")
+	testpb.RegisterValidationMsg3ValidateExt(func(msg *testpb.ValidationMsg3, prefix string) error {
+		return status.Error(codes.InvalidArgument, prefix + "ValidationMsg3 extension always fails")
 	})
 
 	// m1 should pass
-	err := m1.Validate("")
+	err := m1.Validate("m1.")
 	assert.NoError(t, err)
 
 	// m3 should fail due to its extension
-	err = m3.Validate("")
+	err = m3.Validate("m3.")
 	assert.Error(t, err)
-	assert.Equal(t, status.Error(codes.InvalidArgument, "ValidationMsg3 extension always fails"), err)
+	assert.Equal(t, status.Error(codes.InvalidArgument, "m3.ValidationMsg3 extension always fails"), err)
 
 	// m1 should fail when f3 is "forbidden"
 	m1.F3 = "forbidden"
-	err = m1.Validate("")
+	err = m1.Validate("m1.")
 	assert.Error(t, err)
-	assert.Equal(t, status.Error(codes.InvalidArgument, "f3 cannot be 'forbidden'"), err)
+	assert.Equal(t, status.Error(codes.InvalidArgument, "m1.f3 cannot be 'forbidden'"), err)
 
 	// Clear extensions
 	testpb.RegisterValidationMsg1ValidateExt(nil)
@@ -640,9 +640,9 @@ func TestValidationExtensionErrorPropagation(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, status.Error(codes.InvalidArgument, "f1 must be in the range [10,100]"), err)
 
-	// Register extension
-	testpb.RegisterValidationMsg1ValidateExt(func(msg *testpb.ValidationMsg1) error {
-		return status.Error(codes.InvalidArgument, "extension validation error")
+	// Register extension with prefix
+	testpb.RegisterValidationMsg1ValidateExt(func(msg *testpb.ValidationMsg1, prefix string) error {
+		return status.Error(codes.InvalidArgument, prefix + "extension validation error")
 	})
 
 	// Should still fail built-in validation first (extension not reached)
@@ -654,9 +654,9 @@ func TestValidationExtensionErrorPropagation(t *testing.T) {
 	m1.F1 = 50
 
 	// Now should fail extension validation
-	err = m1.Validate("")
+	err = m1.Validate("test.")
 	assert.Error(t, err)
-	assert.Equal(t, status.Error(codes.InvalidArgument, "extension validation error"), err)
+	assert.Equal(t, status.Error(codes.InvalidArgument, "test.extension validation error"), err)
 
 	// Clear extension
 	testpb.RegisterValidationMsg1ValidateExt(nil)
@@ -682,7 +682,7 @@ func TestValidationExtensionNilSafety(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Register and then clear extension
-	testpb.RegisterValidationMsg1ValidateExt(func(msg *testpb.ValidationMsg1) error {
+	testpb.RegisterValidationMsg1ValidateExt(func(msg *testpb.ValidationMsg1, prefix string) error {
 		return nil
 	})
 

--- a/go/cmd/kubeproto/protoc-gen-validation/main_test.go
+++ b/go/cmd/kubeproto/protoc-gen-validation/main_test.go
@@ -32,9 +32,27 @@ func TestGen(t *testing.T) {
 	_, err := decorator.Parse(goFile)
 	assert.NoError(t, err)
 
+	// Test that validation functions are generated
 	assert.True(t, strings.Contains(goFile, "func (this *ValidationMsg1) Validate(prefix string) error"))
 	assert.True(t, strings.Contains(goFile, "func (this *ValidationMsg2) Validate(prefix string) error"))
 	assert.True(t, strings.Contains(goFile, "func (this *ValidationMsg3) Validate(prefix string) error"))
+
+	// Test that extension variables are generated
+	assert.True(t, strings.Contains(goFile, "var ValidationMsg1ValidateExt func(*ValidationMsg1) error"))
+	assert.True(t, strings.Contains(goFile, "var ValidationMsg2ValidateExt func(*ValidationMsg2) error"))
+	assert.True(t, strings.Contains(goFile, "var ValidationMsg3ValidateExt func(*ValidationMsg3) error"))
+
+	// Test that extension calls are generated in validation functions
+	assert.True(t, strings.Contains(goFile, "if ValidationMsg1ValidateExt != nil {"))
+	assert.True(t, strings.Contains(goFile, "if err := ValidationMsg1ValidateExt(this); err != nil {"))
+	assert.True(t, strings.Contains(goFile, "if ValidationMsg2ValidateExt != nil {"))
+	assert.True(t, strings.Contains(goFile, "if err := ValidationMsg2ValidateExt(this); err != nil {"))
+
+	// Test that registration functions are generated
+	assert.True(t, strings.Contains(goFile, "func RegisterValidationMsg1ValidateExt(f func(*ValidationMsg1) error) {"))
+	assert.True(t, strings.Contains(goFile, "ValidationMsg1ValidateExt = f"))
+	assert.True(t, strings.Contains(goFile, "func RegisterValidationMsg2ValidateExt(f func(*ValidationMsg2) error) {"))
+	assert.True(t, strings.Contains(goFile, "ValidationMsg2ValidateExt = f"))
 }
 
 func TestNoDefault(t *testing.T) {
@@ -472,5 +490,208 @@ func TestOneof(t *testing.T) {
 		F4: 2,
 	}}
 	err = m.Validate("")
+	assert.NoError(t, err)
+}
+
+// Test extension functionality
+func TestValidationExtension(t *testing.T) {
+	// Test basic extension registration and execution
+	m1 := testpb.ValidationMsg1{
+		F1: 50,
+		F3: "test",
+		F4: testpb.E1_C,
+	}
+
+	// Should pass without extension
+	err := m1.Validate("")
+	assert.NoError(t, err)
+
+	// Register extension that always fails
+	testpb.RegisterValidationMsg1ValidateExt(func(msg *testpb.ValidationMsg1) error {
+		return status.Error(codes.InvalidArgument, "extension validation failed")
+	})
+
+	// Should now fail due to extension
+	err = m1.Validate("")
+	assert.Error(t, err)
+	assert.Equal(t, status.Error(codes.InvalidArgument, "extension validation failed"), err)
+
+	// Register extension that checks custom business logic
+	testpb.RegisterValidationMsg1ValidateExt(func(msg *testpb.ValidationMsg1) error {
+		if msg.F1 > 75 {
+			return status.Error(codes.InvalidArgument, "f1 cannot exceed 75 in extension validation")
+		}
+		return nil
+	})
+
+	// Should pass with F1 = 50
+	err = m1.Validate("")
+	assert.NoError(t, err)
+
+	// Should fail with F1 = 80
+	m1.F1 = 80
+	err = m1.Validate("")
+	assert.Error(t, err)
+	assert.Equal(t, status.Error(codes.InvalidArgument, "f1 cannot exceed 75 in extension validation"), err)
+
+	// Clear extension
+	testpb.RegisterValidationMsg1ValidateExt(nil)
+
+	// Should pass again without extension
+	err = m1.Validate("")
+	assert.NoError(t, err)
+}
+
+func TestValidationExtensionWithComplexMessage(t *testing.T) {
+	// Test extension with more complex message
+	m2 := testpb.ValidationMsg2{
+		F1:  3,
+		F3:  "test",
+		F4:  testpb.E1_B,
+		F5:  &testpb.ValidationMsg3{},
+		F6:  100,
+		F7:  0.5,
+		F9:  []int64{100, 200},
+		F10: []byte{'A'},
+	}
+
+	// Should pass built-in validation
+	err := m2.Validate("")
+	assert.NoError(t, err)
+
+	// Register extension that validates array contents
+	testpb.RegisterValidationMsg2ValidateExt(func(msg *testpb.ValidationMsg2) error {
+		if len(msg.F9) > 0 && msg.F9[0] < 50 {
+			return status.Error(codes.InvalidArgument, "first element of f9 must be >= 50")
+		}
+		return nil
+	})
+
+	// Should pass with current values
+	err = m2.Validate("")
+	assert.NoError(t, err)
+
+	// Should fail with small first element
+	m2.F9[0] = 25
+	err = m2.Validate("")
+	assert.Error(t, err)
+	assert.Equal(t, status.Error(codes.InvalidArgument, "first element of f9 must be >= 50"), err)
+
+	// Clear extension
+	testpb.RegisterValidationMsg2ValidateExt(nil)
+}
+
+func TestMultipleValidationExtensions(t *testing.T) {
+	// Test that extensions work independently for different message types
+	m1 := testpb.ValidationMsg1{
+		F1: 50,
+		F3: "test",
+		F4: testpb.E1_C,
+	}
+
+	m3 := testpb.ValidationMsg3{}
+
+	// Register extensions for both types
+	testpb.RegisterValidationMsg1ValidateExt(func(msg *testpb.ValidationMsg1) error {
+		if msg.F3 == "forbidden" {
+			return status.Error(codes.InvalidArgument, "f3 cannot be 'forbidden'")
+		}
+		return nil
+	})
+
+	testpb.RegisterValidationMsg3ValidateExt(func(msg *testpb.ValidationMsg3) error {
+		return status.Error(codes.InvalidArgument, "ValidationMsg3 extension always fails")
+	})
+
+	// m1 should pass
+	err := m1.Validate("")
+	assert.NoError(t, err)
+
+	// m3 should fail due to its extension
+	err = m3.Validate("")
+	assert.Error(t, err)
+	assert.Equal(t, status.Error(codes.InvalidArgument, "ValidationMsg3 extension always fails"), err)
+
+	// m1 should fail when f3 is "forbidden"
+	m1.F3 = "forbidden"
+	err = m1.Validate("")
+	assert.Error(t, err)
+	assert.Equal(t, status.Error(codes.InvalidArgument, "f3 cannot be 'forbidden'"), err)
+
+	// Clear extensions
+	testpb.RegisterValidationMsg1ValidateExt(nil)
+	testpb.RegisterValidationMsg3ValidateExt(nil)
+
+	// Both should pass now (m1 might still fail built-in validation, but not extension)
+	err = m3.Validate("")
+	assert.NoError(t, err)
+}
+
+func TestValidationExtensionErrorPropagation(t *testing.T) {
+	// Test that extension errors are properly propagated and don't interfere with built-in validation
+	m1 := testpb.ValidationMsg1{
+		F1: 5, // This will fail built-in validation (min is 10)
+		F3: "test",
+		F4: testpb.E1_C,
+	}
+
+	// Should fail built-in validation first
+	err := m1.Validate("")
+	assert.Error(t, err)
+	assert.Equal(t, status.Error(codes.InvalidArgument, "f1 must be in the range [10,100]"), err)
+
+	// Register extension
+	testpb.RegisterValidationMsg1ValidateExt(func(msg *testpb.ValidationMsg1) error {
+		return status.Error(codes.InvalidArgument, "extension validation error")
+	})
+
+	// Should still fail built-in validation first (extension not reached)
+	err = m1.Validate("")
+	assert.Error(t, err)
+	assert.Equal(t, status.Error(codes.InvalidArgument, "f1 must be in the range [10,100]"), err)
+
+	// Fix built-in validation issue
+	m1.F1 = 50
+
+	// Now should fail extension validation
+	err = m1.Validate("")
+	assert.Error(t, err)
+	assert.Equal(t, status.Error(codes.InvalidArgument, "extension validation error"), err)
+
+	// Clear extension
+	testpb.RegisterValidationMsg1ValidateExt(nil)
+
+	// Should pass now
+	err = m1.Validate("")
+	assert.NoError(t, err)
+}
+
+func TestValidationExtensionNilSafety(t *testing.T) {
+	// Test that nil extensions are handled safely
+	m1 := testpb.ValidationMsg1{
+		F1: 50,
+		F3: "test",
+		F4: testpb.E1_C,
+	}
+
+	// Explicitly set extension to nil
+	testpb.RegisterValidationMsg1ValidateExt(nil)
+
+	// Should pass without issues
+	err := m1.Validate("")
+	assert.NoError(t, err)
+
+	// Register and then clear extension
+	testpb.RegisterValidationMsg1ValidateExt(func(msg *testpb.ValidationMsg1) error {
+		return nil
+	})
+
+	err = m1.Validate("")
+	assert.NoError(t, err)
+
+	// Clear extension again
+	testpb.RegisterValidationMsg1ValidateExt(nil)
+
+	err = m1.Validate("")
 	assert.NoError(t, err)
 }

--- a/go/cmd/kubeproto/protoc-gen-validation/main_test.go
+++ b/go/cmd/kubeproto/protoc-gen-validation/main_test.go
@@ -508,7 +508,7 @@ func TestValidationExtension(t *testing.T) {
 
 	// Register extension that always fails and uses prefix
 	testpb.RegisterValidationMsg1ValidateExt(func(msg *testpb.ValidationMsg1, prefix string) error {
-		return status.Error(codes.InvalidArgument, prefix + "extension validation failed")
+		return status.Error(codes.InvalidArgument, prefix+"extension validation failed")
 	})
 
 	// Should now fail due to extension
@@ -519,7 +519,7 @@ func TestValidationExtension(t *testing.T) {
 	// Register extension that checks custom business logic with prefix
 	testpb.RegisterValidationMsg1ValidateExt(func(msg *testpb.ValidationMsg1, prefix string) error {
 		if msg.F1 > 75 {
-			return status.Error(codes.InvalidArgument, prefix + "f1 cannot exceed 75 in extension validation")
+			return status.Error(codes.InvalidArgument, prefix+"f1 cannot exceed 75 in extension validation")
 		}
 		return nil
 	})
@@ -562,7 +562,7 @@ func TestValidationExtensionWithComplexMessage(t *testing.T) {
 	// Register extension that validates array contents and uses prefix
 	testpb.RegisterValidationMsg2ValidateExt(func(msg *testpb.ValidationMsg2, prefix string) error {
 		if len(msg.F9) > 0 && msg.F9[0] < 50 {
-			return status.Error(codes.InvalidArgument, prefix + "first element of f9 must be >= 50")
+			return status.Error(codes.InvalidArgument, prefix+"first element of f9 must be >= 50")
 		}
 		return nil
 	})
@@ -594,13 +594,13 @@ func TestMultipleValidationExtensions(t *testing.T) {
 	// Register extensions for both types with prefix usage
 	testpb.RegisterValidationMsg1ValidateExt(func(msg *testpb.ValidationMsg1, prefix string) error {
 		if msg.F3 == "forbidden" {
-			return status.Error(codes.InvalidArgument, prefix + "f3 cannot be 'forbidden'")
+			return status.Error(codes.InvalidArgument, prefix+"f3 cannot be 'forbidden'")
 		}
 		return nil
 	})
 
 	testpb.RegisterValidationMsg3ValidateExt(func(msg *testpb.ValidationMsg3, prefix string) error {
-		return status.Error(codes.InvalidArgument, prefix + "ValidationMsg3 extension always fails")
+		return status.Error(codes.InvalidArgument, prefix+"ValidationMsg3 extension always fails")
 	})
 
 	// m1 should pass
@@ -642,7 +642,7 @@ func TestValidationExtensionErrorPropagation(t *testing.T) {
 
 	// Register extension with prefix
 	testpb.RegisterValidationMsg1ValidateExt(func(msg *testpb.ValidationMsg1, prefix string) error {
-		return status.Error(codes.InvalidArgument, prefix + "extension validation error")
+		return status.Error(codes.InvalidArgument, prefix+"extension validation error")
 	})
 
 	// Should still fail built-in validation first (extension not reached)

--- a/go/kubeproto/templates/BUILD.bazel
+++ b/go/kubeproto/templates/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "mysql_main_table_columns.tmpl",
         "mysql_main_table_indices.tmpl",
         "unmarshal_enum.tmpl",
+        "validation.tmpl",
     ],
     importpath = "github.com/michelangelo-ai/michelangelo/go/kubeproto/templates",
     visibility = ["//visibility:public"],

--- a/go/kubeproto/templates/templates.go
+++ b/go/kubeproto/templates/templates.go
@@ -18,6 +18,12 @@ var crdListTmpl string
 // CRDList template of CRD list type
 var CRDList = template.Must(template.New("crdList").Parse(crdListTmpl))
 
+//go:embed validation.tmpl
+var validationTmpl string
+
+// Validation template for validation functions with extension hooks
+var Validation = template.Must(template.New("validation").Parse(validationTmpl))
+
 // RegisterCRDObject is a template that registers CRD Object to CrdObjects map
 var RegisterCRDObject = template.Must(template.New("registerCrdObject").Parse(`func init() {
 	CrdObjects["{{.Kind}}"] = &{{.Kind}}{

--- a/go/kubeproto/templates/validation.tmpl
+++ b/go/kubeproto/templates/validation.tmpl
@@ -1,0 +1,18 @@
+ // {{.TypeNameLower}}ValidateExt is an extension hook for additional validation logic
+var {{.TypeNameLower}}ValidateExt func(*{{.TypeName}}, string) error
+
+func (this *{{.TypeName}}) Validate(prefix string) error {
+{{.ValidateLogic}}
+	// Call extension validation if registered
+	if {{.TypeNameLower}}ValidateExt != nil {
+		if err := {{.TypeNameLower}}ValidateExt(this, prefix); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Register{{.TypeName}}ValidateExt registers an extension validation function
+func Register{{.TypeName}}ValidateExt(f func(*{{.TypeName}}, string) error) {
+	{{.TypeNameLower}}ValidateExt = f
+}


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ Y ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
Added hook to extend validation rules for extension validations

<!-- Tell your future self why have you made these changes -->
**Why?**
Need a way to extend for the new validation rules

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Manual:

`bazel build //proto/api/v2:v2_go_proto
`

Unit tests:

`bazel run //go/cmd/kubeproto/protoc-gen-validation:go_default_test -- -test.list .
`
New generated Project Validation method
```

// projectStatusValidateExt is an extension hook for additional validation logic
var projectStatusValidateExt func(*ProjectStatus, string) error

func (this *ProjectStatus) Validate(prefix string) error {

	{
		v := this.GetLastUpdateTime()
		n := `last_update_time`
		var i interface{}
		if reflect.ValueOf(v).Kind() == reflect.Ptr {
			i = reflect.ValueOf(v).Interface()
			if reflect.ValueOf(v).IsNil() {
				i = nil
			}
		} else {
			i = reflect.ValueOf(&v).Interface()
		}
		validate, hasValidate := i.(interface{ Validate(string) error })
		if hasValidate {
			if err := validate.Validate(prefix + n + "."); err != nil {
				return err
			}
		}
	}
	// Call extension validation if registered
	if projectStatusValidateExt != nil {
		if err := projectStatusValidateExt(this, prefix); err != nil {
			return err
		}
	}
	return nil
}

// RegisterProjectStatusValidateExt registers an extension validation function
func RegisterProjectStatusValidateExt(f func(*ProjectStatus, string) error) {
	projectStatusValidateExt = f
}

```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
