### PR TITLE
Add PhaseCard component for project workflow navigation

### DIFF
--- a/javascript/app/icons/icons.tsx
+++ b/javascript/app/icons/icons.tsx
@@ -1,12 +1,15 @@
 import AddIcon from '@mui/icons-material/Add';
+import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
 import AutorenewIcon from '@mui/icons-material/Autorenew';
 import CancelIcon from '@mui/icons-material/Cancel';
 import CheckCircle from '@mui/icons-material/CheckCircle';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import CloseIcon from '@mui/icons-material/Close';
 import CropSquareIcon from '@mui/icons-material/CropSquare';
 import Info from '@mui/icons-material/Info';
 import KeyboardBackspaceIcon from '@mui/icons-material/KeyboardBackspace';
 import Launch from '@mui/icons-material/Launch';
+import ShowChartIcon from '@mui/icons-material/ShowChart';
 import SkipNextIcon from '@mui/icons-material/SkipNext';
 
 import { createMuiIconAdapter } from './mui-icon-adapter';
@@ -15,6 +18,7 @@ export const ICONS = {
   arrowCircular: createMuiIconAdapter(AutorenewIcon),
   arrowLaunch: createMuiIconAdapter(Launch),
   arrowLeft: createMuiIconAdapter(KeyboardBackspaceIcon),
+  chartLine: createMuiIconAdapter(ShowChartIcon),
   chevronRight: createMuiIconAdapter(ChevronRightIcon),
   circleI: createMuiIconAdapter(Info),
   circleX: createMuiIconAdapter(CancelIcon),
@@ -23,4 +27,6 @@ export const ICONS = {
   diamondEmpty: createMuiIconAdapter(CropSquareIcon),
   playerNext: createMuiIconAdapter(SkipNextIcon),
   plus: createMuiIconAdapter(AddIcon),
+  stars: createMuiIconAdapter(AutoAwesomeIcon),
+  x: createMuiIconAdapter(CloseIcon),
 } as const;

--- a/javascript/packages/core/components/views/project/components/phase-list/phase-card.tsx
+++ b/javascript/packages/core/components/views/project/components/phase-list/phase-card.tsx
@@ -1,0 +1,67 @@
+import { useStyletron } from 'baseui';
+import { Button, KIND, SHAPE, SIZE } from 'baseui/button';
+
+import { Box } from '#core/components/box/box';
+import { Icon } from '#core/components/icon/icon';
+import { Link } from '#core/components/link/link';
+import { capitalizeFirstLetter } from '#core/utils/string-utils';
+
+import type { PhaseConfig } from '#core/types/common/studio-types';
+
+export function PhaseCard({ icon, name, description, docUrl, entities }: PhaseConfig) {
+  const [css, theme] = useStyletron();
+
+  return (
+    <Box
+      title={
+        <div className={css({ display: 'flex', alignItems: 'center', gap: theme.sizing.scale400 })}>
+          <Icon name={icon} size={theme.sizing.scale500} />
+          {name}
+        </div>
+      }
+      description={
+        description && (
+          <div className={css({ display: 'flex', alignItems: 'center' })}>
+            {description}
+            {docUrl && (
+              <Button
+                kind={KIND.tertiary}
+                onClick={() => window.open(docUrl, '_blank')}
+                shape={SHAPE.circle}
+                size={SIZE.mini}
+              >
+                <Icon name="arrowLaunch" title="Learn more" size={theme.sizing.scale500} />
+              </Button>
+            )}
+          </div>
+        )
+      }
+    >
+      {entities && entities.length > 0 && (
+        <div className={css({ display: 'flex', flexDirection: 'column' })}>
+          {entities.map((entity) => {
+            return (
+              <Link
+                key={entity.id}
+                href={entity.id}
+                overrides={{ Link: { style: theme.typography.ParagraphSmall } }}
+              >
+                {capitalizeFirstLetter(entity.name)}
+              </Link>
+            );
+          })}
+        </div>
+      )}
+      <Button
+        kind={KIND.secondary}
+        onClick={() => {
+          console.log('Navigate to phase');
+        }}
+        shape={SHAPE.circle}
+        overrides={{ BaseButton: { style: { marginTop: 'auto' } } }}
+      >
+        <Icon name="chevronRight" size={theme.sizing.scale700} />
+      </Button>
+    </Box>
+  );
+}

--- a/javascript/packages/core/components/views/project/project-detail.tsx
+++ b/javascript/packages/core/components/views/project/project-detail.tsx
@@ -8,6 +8,7 @@ import { useLocalStorageTableState } from '#core/components/table/plugins/state-
 import { Table } from '#core/components/table/table';
 import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
 import { useStudioQuery } from '#core/hooks/use-studio-query';
+import { PhaseCard } from './components/phase-list/phase-card';
 import {
   PIPELINE_CELL_CONFIG,
   PIPELINE_RUN_CELL_CONFIG,
@@ -101,6 +102,41 @@ export function ProjectDetail() {
       >
         <Row items={SHARED_PROJECT_CELL_CONFIG} record={data?.project} />
       </Box>
+
+      {/* Phase Card Demo */}
+      <div
+        className={css({
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))',
+          gap: theme.sizing.scale600,
+        })}
+      >
+        <PhaseCard
+          icon="database"
+          name="Prepare & Analyze Data"
+          description="Create data pipelines and analyze your datasets"
+          docUrl="https://example.com/docs/data"
+          entities={[
+            { id: 'pipelines', name: 'pipelines' },
+            { id: 'datasources', name: 'data sources' },
+            { id: 'runs', name: 'runs' },
+          ]}
+        />
+
+        <PhaseCard
+          icon="chartLine"
+          name="Train & Evaluate"
+          description="Train machine learning models and evaluate their performance"
+          docUrl="https://example.com/docs/train"
+          entities={[
+            { id: 'pipelines', name: 'pipelines' },
+            { id: 'runs', name: 'runs' },
+            { id: 'models', name: 'trained models' },
+            { id: 'evaluations', name: 'evaluations' },
+            { id: 'notebooks', name: 'notebooks' },
+          ]}
+        />
+      </div>
 
       {/* Pipelines Section */}
       <Card

--- a/javascript/packages/core/types/common/studio-types.ts
+++ b/javascript/packages/core/types/common/studio-types.ts
@@ -58,6 +58,52 @@ export enum Phase {
   AgentMonitor = 'agent-monitor',
 }
 
+export interface PhaseEntityConfig {
+  /**
+   * Name of the entity as it appears within MA Studio. Should be plural, lower case
+   * version of the name.
+   *
+   * @example
+   * trained models
+   * pipelines
+   * feature consistency (intentionally not pluralized since this entity is never referred
+   *  to as "feature consistencies")
+   */
+  name: string;
+  /**
+   * Unique ID for entity within its phase, used in URL, should be plural form with
+   * no whitespace
+   *
+   * @example
+   * models
+   * pipelines
+   * feature-consistency
+   */
+  id: string;
+}
+
+/**
+ * Simplified phase configuration matching the original studio config structure
+ */
+export interface PhaseConfig {
+  /** Icon name from the application's icon provider system */
+  icon: string;
+  /**
+   * Display name for the phase
+   *
+   * @example
+   * "Prepare & Analyze Data"
+   * "Train & Evaluate"
+   */
+  name: string;
+  /** Optional descriptive text explaining what this phase does */
+  description?: string;
+  /** Optional URL to external documentation for this phase */
+  docUrl?: string;
+  /** List of entities (like pipelines, models) that belong to this phase */
+  entities: PhaseEntityConfig[];
+}
+
 /**
  * @description
  * Defines a way to access a specific property or value from an object.


### PR DESCRIPTION
Add PhaseCard component that displays workflow phases with visual icons, descriptions, and direct entity access. This solution provides immediate visibility into available phases. Navigation is currently not configured.

<img width="1840" height="1129" alt="Screenshot 2025-08-05 at 16 48 38" src="https://github.com/user-attachments/assets/e32a1416-8829-4df2-87c4-87cc6ff25f8b" />


**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
