### PR TITLE
Add state management system to PhaseCard component

### DIFF
--- a/javascript/packages/core/components/views/project/components/phase-list/phase-card.tsx
+++ b/javascript/packages/core/components/views/project/components/phase-list/phase-card.tsx
@@ -8,8 +8,12 @@ import { capitalizeFirstLetter } from '#core/utils/string-utils';
 
 import type { PhaseConfig } from '#core/types/common/studio-types';
 
-export function PhaseCard({ icon, name, description, docUrl, entities }: PhaseConfig) {
+export function PhaseCard(props: PhaseConfig) {
+  const { icon, name, description, docUrl, state, entities } = props;
   const [css, theme] = useStyletron();
+
+  const isPhaseDisabled = state === 'disabled' || state === 'comingSoon';
+  const isComingSoon = state === 'comingSoon';
 
   return (
     <Box
@@ -37,9 +41,38 @@ export function PhaseCard({ icon, name, description, docUrl, entities }: PhaseCo
         )
       }
     >
-      {entities && entities.length > 0 && (
+      {isComingSoon ? (
+        <div
+          className={css({
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            flex: '1',
+            color: theme.colors.contentTertiary,
+          })}
+        >
+          Coming soon
+        </div>
+      ) : (
         <div className={css({ display: 'flex', flexDirection: 'column' })}>
           {entities.map((entity) => {
+            const isEntityDisabled = isPhaseDisabled || entity.state === 'disabled';
+
+            if (isEntityDisabled) {
+              return (
+                <span
+                  key={entity.id}
+                  className={css({
+                    ...theme.typography.ParagraphSmall,
+                    cursor: 'default',
+                    color: theme.colors.contentTertiary,
+                  })}
+                >
+                  {capitalizeFirstLetter(entity.name)}
+                </span>
+              );
+            }
+
             return (
               <Link
                 key={entity.id}
@@ -52,16 +85,19 @@ export function PhaseCard({ icon, name, description, docUrl, entities }: PhaseCo
           })}
         </div>
       )}
-      <Button
-        kind={KIND.secondary}
-        onClick={() => {
-          console.log('Navigate to phase');
-        }}
-        shape={SHAPE.circle}
-        overrides={{ BaseButton: { style: { marginTop: 'auto' } } }}
-      >
-        <Icon name="chevronRight" size={theme.sizing.scale700} />
-      </Button>
+
+      {!isPhaseDisabled && (
+        <Button
+          kind={KIND.secondary}
+          onClick={() => {
+            console.log('Navigate to phase');
+          }}
+          shape={SHAPE.circle}
+          overrides={{ BaseButton: { style: { marginTop: 'auto' } } }}
+        >
+          <Icon name="chevronRight" size={theme.sizing.scale700} />
+        </Button>
+      )}
     </Box>
   );
 }

--- a/javascript/packages/core/components/views/project/project-detail.tsx
+++ b/javascript/packages/core/components/views/project/project-detail.tsx
@@ -116,10 +116,11 @@ export function ProjectDetail() {
           name="Prepare & Analyze Data"
           description="Create data pipelines and analyze your datasets"
           docUrl="https://example.com/docs/data"
+          state="disabled"
           entities={[
-            { id: 'pipelines', name: 'pipelines' },
-            { id: 'datasources', name: 'data sources' },
-            { id: 'runs', name: 'runs' },
+            { id: 'pipelines', name: 'pipelines', state: 'active' },
+            { id: 'datasources', name: 'data sources', state: 'active' },
+            { id: 'runs', name: 'runs', state: 'active' },
           ]}
         />
 
@@ -128,13 +129,23 @@ export function ProjectDetail() {
           name="Train & Evaluate"
           description="Train machine learning models and evaluate their performance"
           docUrl="https://example.com/docs/train"
+          state="active"
           entities={[
-            { id: 'pipelines', name: 'pipelines' },
-            { id: 'runs', name: 'runs' },
-            { id: 'models', name: 'trained models' },
-            { id: 'evaluations', name: 'evaluations' },
-            { id: 'notebooks', name: 'notebooks' },
+            { id: 'pipelines', name: 'pipelines', state: 'active' },
+            { id: 'runs', name: 'runs', state: 'active' },
+            { id: 'models', name: 'trained models', state: 'disabled' },
+            { id: 'evaluations', name: 'evaluations', state: 'disabled' },
+            { id: 'notebooks', name: 'notebooks', state: 'disabled' },
           ]}
+        />
+
+        <PhaseCard
+          icon="database"
+          name="Deploy & Predict"
+          description="Deploy your models and predict new data"
+          docUrl="https://example.com/docs/predict"
+          state="comingSoon"
+          entities={[]}
         />
       </div>
 

--- a/javascript/packages/core/types/common/studio-types.ts
+++ b/javascript/packages/core/types/common/studio-types.ts
@@ -80,6 +80,8 @@ export interface PhaseEntityConfig {
    * feature-consistency
    */
   id: string;
+  /** State controlling whether this entity is interactive */
+  state: PhaseEntityState;
 }
 
 /**
@@ -100,9 +102,30 @@ export interface PhaseConfig {
   description?: string;
   /** Optional URL to external documentation for this phase */
   docUrl?: string;
+  /** State controlling overall phase behavior and appearance */
+  state: PhaseState;
   /** List of entities (like pipelines, models) that belong to this phase */
   entities: PhaseEntityConfig[];
 }
+
+/**
+ * Phase state controlling overall phase behavior and appearance
+ *
+ * @example
+ * `active` - The phase is fully functional and can be interacted with
+ * `comingSoon` - The phase is not yet available but will be in the future
+ * `disabled` - The phase is not available and cannot be interacted with
+ */
+export type PhaseState = 'active' | 'comingSoon' | 'disabled';
+
+/**
+ * Entity state controlling individual entity behavior within a phase
+ *
+ * @example
+ * `active` - The entity is fully functional and can be interacted with
+ * `disabled` - The entity is not available and cannot be interacted with
+ */
+export type PhaseEntityState = 'active' | 'disabled';
 
 /**
  * @description


### PR DESCRIPTION
Phases and phase entities can now be configured with varying levels of availability: active, disabled, coming soon. This allows phases to be shared with users without requiring complete feature support.

Kept state --> rendering logic within PhaseCard instead of extracting to sub components to explicitly tie rendering and business logic together.

https://github.com/user-attachments/assets/5471bd6f-3666-45a2-977c-8d43b5d25250

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
