### PR TITLE
Add schema-based body renderer for execution task details

### DIFF
--- a/javascript/packages/core/components/views/execution/__tests__/execution.test.tsx
+++ b/javascript/packages/core/components/views/execution/__tests__/execution.test.tsx
@@ -135,4 +135,46 @@ describe('Execution view', () => {
     expect(screen.getByText('No execution data')).toBeInTheDocument();
     expect(screen.getByText('No tasks available')).toBeInTheDocument();
   });
+
+  it('should render body schema content for leaf tasks', async () => {
+    const user = userEvent.setup();
+    const schemaWithBody = buildSchema({
+      tasks: {
+        body: [
+          {
+            type: 'struct',
+            label: 'Input Parameters',
+            accessor: 'input',
+          },
+        ],
+      },
+    });
+
+    const executionData = {
+      status: {
+        steps: [
+          buildStep({
+            displayName: 'Data Processing Task',
+            state: 'PIPELINE_RUN_STEP_STATE_SUCCEEDED',
+            input: {
+              fields: {
+                dataset: { stringValue: 'training_data.csv', kind: 'stringValue' },
+              },
+            },
+          }),
+        ],
+      },
+    };
+
+    render(<Execution schema={schemaWithBody} data={executionData} />);
+
+    // No body content should be visible before accordion is expanded
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+
+    // Expand accordion to see body content
+    await user.click(screen.getByRole('button', { name: 'Data Processing Task Down Small' }));
+    await user.click(screen.getByRole('button', { name: /Input Parameters/ }));
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+    expect(screen.getByText('"training_data.csv"')).toBeInTheDocument();
+  });
 });

--- a/javascript/packages/core/components/views/execution/components/task-details/__tests__/task-body.test.tsx
+++ b/javascript/packages/core/components/views/execution/components/task-details/__tests__/task-body.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 
-import { TASK_STATE } from '../../../constants';
+import { TASK_STATE } from '#core/components/views/execution/constants';
 import { createTask } from '../__fixtures__/task-details-fixtures';
 import { TaskBody } from '../task-body';
 
@@ -48,5 +48,51 @@ describe('TaskBody', () => {
     expect(screen.getByText('Success Task')).toBeInTheDocument();
     expect(screen.getByText('Running Task')).toBeInTheDocument();
     expect(screen.getByText('Error Task')).toBeInTheDocument();
+  });
+
+  it('should render body schema when no subtasks exist', () => {
+    const leafTask = createTask({
+      name: 'Leaf Task',
+      record: {
+        displayName: 'Leaf Task',
+        output: { result: 'success' },
+      },
+    });
+
+    const bodySchema = [
+      {
+        type: 'struct',
+        label: 'Task Output',
+        accessor: 'output',
+      },
+    ];
+
+    render(<TaskBody task={leafTask} bodySchema={bodySchema} />);
+
+    expect(screen.getByText('Task Output')).toBeInTheDocument();
+  });
+
+  it('should prioritize subtasks over body schema', () => {
+    const taskWithBoth = createTask({
+      name: 'Parent Task',
+      subTasks: [createTask({ name: 'Child Task' })],
+      record: {
+        output: { result: 'success' },
+      },
+    });
+
+    const bodySchema = [
+      {
+        type: 'struct',
+        label: 'Should Not Render',
+        accessor: 'output',
+      },
+    ];
+
+    render(<TaskBody task={taskWithBoth} bodySchema={bodySchema} />);
+
+    // Should render subtask, not body schema
+    expect(screen.getByText('Child Task')).toBeInTheDocument();
+    expect(screen.queryByText('Should Not Render')).not.toBeInTheDocument();
   });
 });

--- a/javascript/packages/core/components/views/execution/components/task-details/__tests__/task-details.test.tsx
+++ b/javascript/packages/core/components/views/execution/components/task-details/__tests__/task-details.test.tsx
@@ -5,6 +5,16 @@ import { createTask } from '../__fixtures__/task-details-fixtures';
 import { TaskDetails } from '../task-details';
 
 describe('TaskDetails', () => {
+  it('should render simple header when task has no subtasks and no bodySchema', () => {
+    const leafTask = createTask({ name: 'Leaf Task' });
+
+    render(<TaskDetails task={leafTask} />);
+
+    expect(screen.getByText('Leaf Task')).toBeInTheDocument();
+
+    expect(screen.queryByRole('button', { expanded: false })).not.toBeInTheDocument();
+  });
+
   it('should render accordion when task has subtasks', () => {
     const taskWithSubtasks = createTask({
       name: 'Parent Task',
@@ -19,14 +29,22 @@ describe('TaskDetails', () => {
     expect(accordionPanel).toBeInTheDocument();
   });
 
-  it('should render simple header when task has no subtasks', () => {
-    const leafTask = createTask({ name: 'Leaf Task' });
+  it('should render accordion when task has bodySchema but no subtasks', () => {
+    const leafTaskWithBodySchema = createTask({ name: 'Data Processing Task' });
+    const bodySchema = [
+      {
+        type: 'struct',
+        label: 'Input Parameters',
+        accessor: 'input',
+      },
+    ];
 
-    render(<TaskDetails task={leafTask} />);
+    render(<TaskDetails task={leafTaskWithBodySchema} bodySchema={bodySchema} />);
 
-    expect(screen.getByText('Leaf Task')).toBeInTheDocument();
+    expect(screen.getByText('Data Processing Task')).toBeInTheDocument();
 
-    expect(screen.queryByRole('button', { expanded: false })).not.toBeInTheDocument();
+    const accordionPanel = screen.getByRole('button', { expanded: false });
+    expect(accordionPanel).toBeInTheDocument();
   });
 
   it('should start accordion collapsed by default', () => {

--- a/javascript/packages/core/components/views/execution/components/task-details/renderers/__tests__/task-body-struct.test.tsx
+++ b/javascript/packages/core/components/views/execution/components/task-details/renderers/__tests__/task-body-struct.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { TaskBodyStruct } from '../task-body-struct';
+
+describe('TaskBodyStruct', () => {
+  it('should render struct data as formatted JSON', async () => {
+    const user = userEvent.setup();
+    const structValue = {
+      fields: {
+        dataset: { stringValue: 'training_data.csv', kind: 'stringValue' },
+        batchSize: { numberValue: 32, kind: 'numberValue' },
+      },
+    };
+
+    render(<TaskBodyStruct label="Input Parameters" value={structValue} />);
+
+    const accordionButton = screen.getByRole('button', { name: /Input Parameters/ });
+    expect(accordionButton).toBeInTheDocument();
+
+    await user.click(accordionButton);
+
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+    expect(screen.getByText('"training_data.csv"')).toBeInTheDocument();
+    expect(screen.getByText('32')).toBeInTheDocument();
+  });
+
+  it('should handle non-struct objects', async () => {
+    const user = userEvent.setup();
+    const regularObject = {
+      name: 'test-pipeline',
+      version: '1.0.0',
+    };
+
+    render(<TaskBodyStruct label="Configuration" value={regularObject} />);
+
+    const accordionButton = screen.getByRole('button', { name: /Configuration/ });
+    await user.click(accordionButton);
+
+    expect(screen.getByText('"test-pipeline"')).toBeInTheDocument();
+    expect(screen.getByText('"1.0.0"')).toBeInTheDocument();
+  });
+
+  it('should handle null and undefined values', async () => {
+    const user = userEvent.setup();
+
+    const { rerender } = render(<TaskBodyStruct label="Empty Value" value={null} />);
+
+    const accordionButton = screen.getByRole('button', { name: /Empty Value/ });
+    await user.click(accordionButton);
+
+    expect(screen.getByText('null')).toBeInTheDocument();
+
+    rerender(<TaskBodyStruct label="Empty Value" value={undefined} />);
+    await user.click(accordionButton);
+
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('should not allow editing the JSON content', async () => {
+    const user = userEvent.setup();
+    const testValue = { test: 'data' };
+
+    render(<TaskBodyStruct label="Read Only Test" value={testValue} />);
+
+    const accordionButton = screen.getByRole('button', { name: /Read Only Test/ });
+    await user.click(accordionButton);
+
+    const textEditor = screen.getByRole('textbox');
+
+    // Try to type in the editor - should not change content
+    await user.click(textEditor);
+    await user.type(textEditor, 'should not appear');
+    expect(screen.getByText(/"test":/i)).toBeInTheDocument();
+    expect(screen.getByText(/"data"/i)).toBeInTheDocument();
+    expect(screen.queryByText('should not appear')).not.toBeInTheDocument();
+  });
+
+  it('should expand accordion to show content', async () => {
+    const user = userEvent.setup();
+    const testValue = { test: 'data' };
+
+    render(<TaskBodyStruct label="Toggle Test" value={testValue} />);
+
+    const accordionButton = screen.getByRole('button', { name: /Toggle Test/ });
+
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+
+    await user.click(accordionButton);
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+});

--- a/javascript/packages/core/components/views/execution/components/task-details/renderers/task-body-struct.tsx
+++ b/javascript/packages/core/components/views/execution/components/task-details/renderers/task-body-struct.tsx
@@ -1,0 +1,18 @@
+import { StatefulPanel } from 'baseui/accordion';
+import { LabelSmall } from 'baseui/typography';
+
+import { TextEditor } from '#core/components/text-editor/text-editor';
+import { decodeStruct, isStruct } from '#core/utils/proto/struct-utils';
+
+export function TaskBodyStruct(props: { label: string; value: object | undefined | null }) {
+  const { label, value } = props;
+
+  const decodedValue = isStruct(value) ? decodeStruct(value) : value;
+  const prettyJson = JSON.stringify(decodedValue, null, 2);
+
+  return (
+    <StatefulPanel title={<LabelSmall>{label}</LabelSmall>}>
+      <TextEditor readOnly language="json" value={prettyJson} onChange={() => null} />
+    </StatefulPanel>
+  );
+}

--- a/javascript/packages/core/components/views/execution/components/task-details/renderers/types.ts
+++ b/javascript/packages/core/components/views/execution/components/task-details/renderers/types.ts
@@ -1,0 +1,22 @@
+import type { Accessor } from '#core/types/common/studio-types';
+
+export type TaskBodySchema = SharedTaskBodySchema;
+
+export interface SharedTaskBodySchema {
+  /**
+   * Controls how the body content is rendered
+   *
+   * @example 'struct'
+   */
+  type: string;
+
+  label: string;
+
+  /**
+   * Used to access the value of the body content
+   *
+   * @example 'spec.content.metadata.name'
+   * @example (task) => task.input
+   */
+  accessor: Accessor<unknown>;
+}

--- a/javascript/packages/core/components/views/execution/components/task-details/task-body.tsx
+++ b/javascript/packages/core/components/views/execution/components/task-details/task-body.tsx
@@ -1,14 +1,27 @@
+import { getObjectValue } from '#core/utils/object-utils';
 import { TaskFlow } from '../task-flow';
+import { TaskBodyStruct } from './renderers/task-body-struct';
 
 import type { TaskBodyProps } from './types';
 
 export function TaskBody<TTaskRecord extends object>(props: TaskBodyProps<TTaskRecord>) {
-  const { task } = props;
+  const { task, bodySchema } = props;
   const { subTasks } = task;
 
-  if (!subTasks?.length) {
-    return null;
+  if (subTasks?.length) {
+    return <TaskFlow taskList={subTasks} />;
   }
 
-  return <TaskFlow taskList={subTasks} />;
+  if (bodySchema?.length) {
+    return bodySchema.map((schema, index) => {
+      const { label } = schema;
+      const value = getObjectValue<unknown>(task.record, schema.accessor);
+
+      if (schema.type === 'struct') {
+        return <TaskBodyStruct key={index} label={label} value={value as object} />;
+      }
+    });
+  }
+
+  return <div>No subtasks, no body schema for {task.name}</div>;
 }

--- a/javascript/packages/core/components/views/execution/components/task-details/task-details.tsx
+++ b/javascript/packages/core/components/views/execution/components/task-details/task-details.tsx
@@ -3,7 +3,6 @@ import { StatefulPanel } from 'baseui/accordion';
 import { TaskBody } from './task-body';
 import { TaskHeader } from './task-header';
 
-import type { Task } from '../../types';
 import type { TaskDetailsProps } from './types';
 
 /**
@@ -14,29 +13,23 @@ import type { TaskDetailsProps } from './types';
  * @param task - The task data to display
  * @param onClick - Optional click handler for task interaction
  * @param metadata - Optional metadata field configurations for rich display
+ * @param bodySchema - Optional body content schema for leaf tasks
  */
 export function TaskDetails<TTaskRecord extends object = object>(
   props: TaskDetailsProps<TTaskRecord>
 ) {
-  const { task, onClick, metadata } = props;
+  const { task, onClick, metadata, bodySchema } = props;
 
-  if (shouldRenderBody(task)) {
+  if (!!task.subTasks?.length || bodySchema?.length) {
     return (
       <StatefulPanel
         title={<TaskHeader task={task} onClick={onClick} metadata={metadata} />}
         initialState={{ expanded: false }}
       >
-        <TaskBody task={task} />
+        <TaskBody task={task} bodySchema={bodySchema} />
       </StatefulPanel>
     );
   }
 
   return <TaskHeader task={task} onClick={onClick} metadata={metadata} />;
-}
-
-/**
- * Determines if task should render accordion body (when it has subtasks).
- */
-function shouldRenderBody<TTaskRecord extends object>(task: Task<TTaskRecord>): boolean {
-  return !!task.subTasks?.length;
 }

--- a/javascript/packages/core/components/views/execution/components/task-details/types.ts
+++ b/javascript/packages/core/components/views/execution/components/task-details/types.ts
@@ -1,10 +1,12 @@
 import type { Cell } from '#core/components/cell/types';
-import type { Task } from '../../types';
+import type { Task } from '#core/components/views/execution/types';
+import type { TaskBodySchema } from './renderers/types';
 
 export type TaskDetailsProps<TTaskRecord extends object = object> = {
   task: Task<TTaskRecord>;
   onClick?: () => void;
   metadata?: Cell[];
+  bodySchema?: TaskBodySchema[];
 };
 
 export type TaskHeaderProps<TTaskRecord extends object = object> = {
@@ -15,4 +17,5 @@ export type TaskHeaderProps<TTaskRecord extends object = object> = {
 
 export type TaskBodyProps<TTaskRecord extends object = object> = {
   task: Task<TTaskRecord>;
+  bodySchema?: TaskBodySchema[];
 };

--- a/javascript/packages/core/components/views/execution/execution.tsx
+++ b/javascript/packages/core/components/views/execution/execution.tsx
@@ -58,7 +58,12 @@ export function Execution<
         className={css({ display: 'flex', flexDirection: 'column', gap: theme.sizing.scale600 })}
       >
         {taskList.map((task, index) => (
-          <TaskDetails key={index} task={task} metadata={schema.tasks.header.metadata} />
+          <TaskDetails
+            key={index}
+            task={task}
+            metadata={schema.tasks.header.metadata}
+            bodySchema={schema.tasks.body}
+          />
         ))}
       </div>
     </div>

--- a/javascript/packages/core/components/views/execution/types.ts
+++ b/javascript/packages/core/components/views/execution/types.ts
@@ -1,5 +1,6 @@
 import type { Cell } from '#core/components/cell/types';
 import type { Accessor } from '#core/types/common/studio-types';
+import type { TaskBodySchema } from './components/task-details/renderers/types';
 import type { TASK_STATE } from './constants';
 
 export type TaskState = (typeof TASK_STATE)[keyof typeof TASK_STATE];
@@ -121,6 +122,20 @@ export type ExecutionDetailViewSchema<
        */
       metadata?: Cell[];
     };
+
+    /**
+     * Optional array of body content configurations for rendering detailed task information.
+     * Each configuration specifies how to extract and display specific aspects of task data.
+     *
+     * @example
+     * ```typescript
+     * body: [
+     *   { type: 'struct', label: 'Input', accessor: 'input' },
+     *   { type: 'struct', label: 'Output', accessor: 'output' }
+     * ]
+     * ```
+     */
+    body?: TaskBodySchema[];
 
     /**
      * Transforms raw task records into standardized task states.

--- a/javascript/packages/core/components/views/sandbox/fixtures/execution-data.ts
+++ b/javascript/packages/core/components/views/sandbox/fixtures/execution-data.ts
@@ -3,6 +3,28 @@ export const successfulPipelineRun = {
   status: {
     steps: [
       {
+        subSteps: [],
+        displayName: 'Data Validation',
+        state: 'PIPELINE_RUN_STEP_STATE_SUCCEEDED',
+        startTime: { seconds: '1704067000', nanos: 0 },
+        endTime: { seconds: '1704067100', nanos: 0 },
+        input: {
+          fields: {
+            dataset_path: { stringValue: '/data/training.csv', kind: 'stringValue' },
+            validation_rules: { stringValue: 'schema_v1.json', kind: 'stringValue' },
+          },
+        },
+        output: {
+          fields: {
+            valid_rows: { numberValue: 1000, kind: 'numberValue' },
+            invalid_rows: { numberValue: 5, kind: 'numberValue' },
+          },
+        },
+        stepCachedOutputs: {
+          intermediateVars: [{ namespace: 'ml-workspace', name: 'validation-cache-123' }],
+        },
+      },
+      {
         subSteps: [
           {
             subSteps: [],

--- a/javascript/packages/core/components/views/sandbox/sandbox.tsx
+++ b/javascript/packages/core/components/views/sandbox/sandbox.tsx
@@ -84,6 +84,23 @@ const executionSchema: ExecutionDetailViewSchema = {
         },
       ],
     },
+    body: [
+      {
+        type: 'struct',
+        label: 'Input Parameters',
+        accessor: 'input',
+      },
+      {
+        type: 'struct',
+        label: 'Output Results',
+        accessor: 'output',
+      },
+      {
+        type: 'struct',
+        label: 'Cached Outputs',
+        accessor: 'stepCachedOutputs',
+      },
+    ],
     stateBuilder: (record: { state: string }) => {
       switch (record.state) {
         case 'PIPELINE_RUN_STEP_STATE_SUCCEEDED':


### PR DESCRIPTION
Replace hardcoded task display with configurable body rendering system that supports different content types through schema configuration.

Previous approach only showed task metadata and subtasks, limiting visibility into task execution details like input parameters and output results. This blocked users from understanding task behavior and debugging failed executions.

New system uses TaskBodySchema configuration to specify renderer types and data accessors, enabling flexible display of protobuf struct data as formatted JSON. Architecture follows established cell renderer patterns with dedicated renderers/ directory for extensibility to more display types.

https://github.com/user-attachments/assets/c94919ca-fb66-4219-af4f-cab2fbb49ce1

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
