### PR TITLE
Add active filter display

### DIFF
--- a/javascript/CLAUDE.md
+++ b/javascript/CLAUDE.md
@@ -32,6 +32,23 @@
   - **Simple "Props"**: When component file contains single component
   - **"ComponentNameProps"**: When multiple components exist or props are exported
 
+#### Event Handlers
+
+- **Use semantic function names**: Focus on intent rather than event type
+- **Avoid redundant prefixes**: Don't use `handleOn*` since "handle" already implies event handling
+
+**❌ Avoid:**
+```typescript
+const handleOnMouseEnter = () => { /* show tooltip */ };
+const handleOnClick = () => { /* toggle menu */ };
+```
+
+**✅ Prefer:**
+```typescript
+const showTooltipAfterDelay = () => { /* show tooltip */ };
+const toggleMenu = () => { /* toggle menu */ };
+```
+
 ### Type Safety
 
 - **Prefer `unknown` over `any`**: For better compile-time safety when creating new types

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-active-filter-tag-list/__tests__/table-active-filter-tag-list.test.tsx
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-active-filter-tag-list/__tests__/table-active-filter-tag-list.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+
+import { CellType } from '#core/components/cell/constants';
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
+import { ActiveFilterTagList } from '../table-active-filter-tag-list';
+
+import type { FilterableColumn } from '#core/components/table/components/table-action-bar/types';
+
+describe('ActiveFilterTagList', () => {
+  const mockFilterableColumns: FilterableColumn[] = [
+    {
+      id: 'testCol1',
+      label: 'Option 1',
+      type: CellType.TEXT,
+      getFilterValue: () => ['opt1', 'opt2', 'opt3'],
+      setFilterValue: vi.fn(),
+    },
+    {
+      id: 'testCol2',
+      label: 'Option 2',
+      type: CellType.DATE,
+      getFilterValue: () => ({
+        range: ['dummy'],
+        selection: ['dummy'],
+        description: 'dateOption',
+      }),
+      setFilterValue: vi.fn(),
+    },
+    {
+      id: 'testCol3',
+      label: 'Option 3',
+      type: CellType.TEXT,
+      getFilterValue: () => undefined,
+      setFilterValue: vi.fn(),
+    },
+  ];
+
+  test('renders nothing when no columns have active filters', () => {
+    const columnsWithoutFilters = mockFilterableColumns.map((col) => ({
+      ...col,
+      getFilterValue: () => undefined,
+    }));
+
+    render(
+      <ActiveFilterTagList filterableColumns={columnsWithoutFilters} preFilteredRows={[]} />,
+      buildWrapper([getBaseProviderWrapper()])
+    );
+
+    expect(screen.queryByText('Option 1')).not.toBeInTheDocument();
+    expect(screen.queryByText('Option 2')).not.toBeInTheDocument();
+    expect(screen.queryByText('Option 3')).not.toBeInTheDocument();
+  });
+
+  test('renders active filter tags for columns with filter values', () => {
+    render(
+      <ActiveFilterTagList filterableColumns={mockFilterableColumns} preFilteredRows={[]} />,
+      buildWrapper([getBaseProviderWrapper()])
+    );
+
+    expect(screen.getByText('(3) Option 1: opt1, opt2, opt3')).toBeInTheDocument();
+    expect(screen.getByText('Option 2: dateOption')).toBeInTheDocument();
+    expect(screen.queryByText('Option 3')).not.toBeInTheDocument();
+  });
+
+  test('clicking delete button calls setFilterValue with undefined', async () => {
+    const user = userEvent.setup();
+    const setFilterMock = vi.fn();
+    const columnsWithMock = [
+      {
+        ...mockFilterableColumns[0],
+        setFilterValue: setFilterMock,
+      },
+    ];
+
+    render(
+      <ActiveFilterTagList filterableColumns={columnsWithMock} preFilteredRows={[]} />,
+      buildWrapper([getBaseProviderWrapper()])
+    );
+
+    const deleteButton = screen.getAllByTitle('Delete')[0];
+    await user.click(deleteButton);
+
+    expect(setFilterMock).toHaveBeenCalledWith(undefined);
+  });
+
+  test('clicking on tag opens filter popover', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ActiveFilterTagList filterableColumns={mockFilterableColumns} preFilteredRows={[]} />,
+      buildWrapper([getBaseProviderWrapper()])
+    );
+
+    const tag = screen.getByText('(3) Option 1: opt1, opt2, opt3');
+    await user.click(tag);
+
+    // Should open the categorical filter (since it's TEXT type)
+    expect(screen.getByRole('checkbox', { name: 'Select All' })).toBeInTheDocument();
+  });
+});

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-active-filter-tag-list/table-active-filter-tag-list.tsx
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-active-filter-tag-list/table-active-filter-tag-list.tsx
@@ -1,0 +1,27 @@
+import { useStyletron } from 'baseui';
+
+import { ActiveFilterTag } from './table-active-filter-tag';
+
+import type { ActiveFilterTagListProps } from './types';
+
+export function ActiveFilterTagList<TData = unknown>(props: ActiveFilterTagListProps<TData>) {
+  const { filterableColumns, preFilteredRows } = props;
+  const [css, theme] = useStyletron();
+
+  const filteredColumns = filterableColumns.filter((column) => {
+    const filterValue = column.getFilterValue();
+    return filterValue !== undefined && filterValue !== null;
+  });
+
+  if (filteredColumns.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={css({ display: 'flex', flexWrap: 'wrap', gap: theme.sizing.scale300 })}>
+      {filteredColumns.map((column) => (
+        <ActiveFilterTag key={column.id} column={column} preFilteredRows={preFilteredRows} />
+      ))}
+    </div>
+  );
+}

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-active-filter-tag-list/table-active-filter-tag.tsx
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-active-filter-tag-list/table-active-filter-tag.tsx
@@ -1,0 +1,89 @@
+import { useState } from 'react';
+import { useStyletron } from 'baseui';
+import { PLACEMENT, StatefulPopover } from 'baseui/popover';
+import { KIND, Tag } from 'baseui/tag';
+import { Tooltip } from 'baseui/tooltip';
+
+import { getColumnFilter } from '#core/components/table/components/filter/get-column-filter';
+import { useFilterFactory } from '#core/components/table/components/filter/use-filter-factory';
+import { TruncatedText } from '#core/components/truncated-text/truncated-text';
+
+import type { Theme } from 'baseui';
+import type { ColumnConfig } from '#core/components/table/types/column-types';
+import type { ActiveFilterTagProps } from './types';
+
+export function ActiveFilterTag<TData = unknown>(props: ActiveFilterTagProps<TData>) {
+  const { column, preFilteredRows } = props;
+  const [css, theme] = useStyletron();
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [showTooltip, setShowTooltip] = useState(false);
+  const [delayHandler, setDelayHandler] = useState<NodeJS.Timeout | null>(null);
+  const createFilter = useFilterFactory();
+  const filter = createFilter({
+    id: column.id,
+    type: column.type,
+    label: column.label,
+  } satisfies ColumnConfig<TData>);
+
+  const showTooltipAfterDelay = () => {
+    setDelayHandler(setTimeout(() => setShowTooltip(true), 1000));
+  };
+
+  const hideTooltipImmediately = () => {
+    if (delayHandler) {
+      clearTimeout(delayHandler);
+    }
+    setShowTooltip(false);
+  };
+
+  const FilterComponent = getColumnFilter(column.type);
+
+  return (
+    <StatefulPopover
+      placement={PLACEMENT.bottomLeft}
+      content={({ close }) => (
+        <FilterComponent
+          columnId={column.id}
+          close={close}
+          getFilterValue={column.getFilterValue}
+          setFilterValue={column.setFilterValue}
+          preFilteredRows={preFilteredRows}
+        />
+      )}
+      onOpen={() => setIsMenuOpen(true)}
+      onClose={() => setIsMenuOpen(false)}
+    >
+      <Tag
+        kind={KIND.blue}
+        overrides={
+          isMenuOpen
+            ? {
+                Root: {
+                  style: ({ $theme }: { $theme: Theme }) => ({
+                    borderColor: $theme.colors.accent,
+                    borderWidth: '2px',
+                  }),
+                },
+              }
+            : {}
+        }
+        onActionClick={() => column.setFilterValue(undefined)}
+      >
+        <Tooltip
+          content={() => (
+            <div className={css({ maxWidth: theme.sizing.scale4800, overflowWrap: 'break-word' })}>
+              {filter.getActiveFilter(column.getFilterValue())}
+            </div>
+          )}
+          placement={PLACEMENT.top}
+          isOpen={showTooltip}
+          onMouseEnter={showTooltipAfterDelay}
+          onMouseLeave={hideTooltipImmediately}
+          showArrow={true}
+        >
+          <TruncatedText>{filter.getFilterSummary(column.getFilterValue())}</TruncatedText>
+        </Tooltip>
+      </Tag>
+    </StatefulPopover>
+  );
+}

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-active-filter-tag-list/types.ts
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-active-filter-tag-list/types.ts
@@ -1,0 +1,12 @@
+import type { FilterableColumn } from '#core/components/table/components/table-action-bar/types';
+import type { TableData } from '#core/components/table/types/data-types';
+
+export type ActiveFilterTagListProps<TData extends TableData = TableData> = {
+  filterableColumns: FilterableColumn<TData>[];
+  preFilteredRows: Array<{ getValue: (columnId: string) => unknown }>;
+};
+
+export type ActiveFilterTagProps<TData extends TableData = TableData> = {
+  column: FilterableColumn<TData>;
+  preFilteredRows: Array<{ getValue: (columnId: string) => unknown }>;
+};

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-menu-content/table-filter-menu-content.tsx
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-menu-content/table-filter-menu-content.tsx
@@ -24,7 +24,7 @@ export function TableFilterMenuContent<T extends TableData = TableData>(
   const [css, theme] = useStyletron();
 
   if (selectedColumn) {
-    const FilterComponent = getColumnFilter(selectedColumn.columnType);
+    const FilterComponent = getColumnFilter(selectedColumn.type);
 
     return (
       <div className={css({ backgroundColor: theme.colors.backgroundPrimary })}>

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-option-list/table-filter-option-list.tsx
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-option-list/table-filter-option-list.tsx
@@ -37,7 +37,7 @@ export function TableFilterOptionList<T extends TableData = TableData>({
         {filterableColumns.map((column) => (
           <TableFilterOption
             key={column.id}
-            label={column.title}
+            label={column.label}
             onClick={() => setSelectedColumn(column)}
           />
         ))}

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/transform-filterable-columns.ts
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/transform-filterable-columns.ts
@@ -15,12 +15,14 @@ export function transformFilterableColumns<T extends TableData = TableData>(
     .filter((header) => header.column.getCanFilter())
     .map((header) => {
       const columnConfig = header.column.columnDef.meta as ColumnConfig<T>;
-      const title = columnConfig.label ?? header.id;
+      const label = columnConfig.label ?? header.id;
 
       return {
         id: header.id,
-        title,
-        columnType: columnConfig.type ?? CellType.TEXT,
+        label,
+        type: columnConfig.type ?? CellType.TEXT,
+        getFilterValue: header.column.getFilterValue,
+        setFilterValue: header.column.setFilterValue,
       };
     });
 }

--- a/javascript/packages/core/components/table/components/table-action-bar/table-action-bar.tsx
+++ b/javascript/packages/core/components/table/components/table-action-bar/table-action-bar.tsx
@@ -1,3 +1,4 @@
+import { ActiveFilterTagList } from './components/table-active-filter-tag-list/table-active-filter-tag-list';
 import { TableFilterMenu } from './components/table-filter-menu/table-filter-menu';
 import { TableSearchInput } from './components/table-search-input/table-search-input';
 import { ActionsContainer, Container, TrailingContentContainer } from './styled-components';
@@ -35,6 +36,13 @@ export function TableActionBar<T>({
           <TrailingContentContainer>{configuration.trailing}</TrailingContentContainer>
         )}
       </ActionsContainer>
+
+      {configuration.enableFilters && filterableColumns.length > 0 && (
+        <ActiveFilterTagList
+          filterableColumns={filterableColumns}
+          preFilteredRows={preFilteredRows}
+        />
+      )}
     </Container>
   );
 }

--- a/javascript/packages/core/components/table/components/table-action-bar/types.ts
+++ b/javascript/packages/core/components/table/components/table-action-bar/types.ts
@@ -45,6 +45,8 @@ export interface TableActionBarConfig {
 
 export interface FilterableColumn<_T extends TableData = TableData> {
   id: string;
-  title: string;
-  columnType: string;
+  label: string;
+  type: string;
+  getFilterValue: () => unknown;
+  setFilterValue: (value: unknown) => void;
 }


### PR DESCRIPTION
Implement visual active filter tags in table action bar to indicate filters currently applied to table. Eliminate unnecessary data transformations in FilterableColumn interface by replacing title and columnType transformations with direct label/type usage.

The reuse of FilterableColumn interface revealed an anti-pattern when transforming between FilterableColumn and ColumnConfig. For example, the previous FilterableColumn resulted in transformations from "label" to "title", only to transform them back for filter factory usage.

https://github.com/user-attachments/assets/7a02c0bd-406b-4156-9c98-3d1f210261aa
<img width="1840" height="1129" alt="Screenshot 2025-08-06 at 17 09 12" src="https://github.com/user-attachments/assets/9fffcd49-7f12-4ae7-8023-eee4751757b4" />


**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
