### PR TITLE
Complete schema-based body renderer implementation

### DIFF
--- a/javascript/packages/core/components/views/execution/__tests__/execution.test.tsx
+++ b/javascript/packages/core/components/views/execution/__tests__/execution.test.tsx
@@ -146,6 +146,25 @@ describe('Execution view', () => {
             label: 'Input Parameters',
             accessor: 'input',
           },
+          {
+            type: 'textarea',
+            label: 'Logs',
+            accessor: 'logs',
+            markdown: false,
+          },
+          {
+            type: 'metadata',
+            label: 'Performance',
+            accessor: 'performance',
+            cells: [
+              {
+                id: 'duration',
+                label: 'Duration',
+                type: CellType.TEXT,
+                accessor: 'duration',
+              },
+            ],
+          },
         ],
       },
     });
@@ -161,6 +180,10 @@ describe('Execution view', () => {
                 dataset: { stringValue: 'training_data.csv', kind: 'stringValue' },
               },
             },
+            logs: 'Model training completed',
+            performance: {
+              duration: '2h 15m',
+            },
           }),
         ],
       },
@@ -169,12 +192,26 @@ describe('Execution view', () => {
     render(<Execution schema={schemaWithBody} data={executionData} />);
 
     // No body content should be visible before accordion is expanded
-    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    expect(screen.queryByText('Input Parameters')).not.toBeInTheDocument();
+    expect(screen.queryByText('Logs')).not.toBeInTheDocument();
+    expect(screen.queryByText('Performance')).not.toBeInTheDocument();
 
-    // Expand accordion to see body content
+    // All body schema labels should be present after accordion is expanded
     await user.click(screen.getByRole('button', { name: 'Data Processing Task Down Small' }));
+    expect(screen.getByText('Input Parameters')).toBeInTheDocument();
+    expect(screen.getByText('Logs')).toBeInTheDocument();
+    expect(screen.getByText('Performance')).toBeInTheDocument();
+
+    // Textarea content should be immediately visible
+    expect(screen.getByLabelText('Logs')).toHaveTextContent('Model training completed');
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    expect(screen.queryByText('2h 15m')).not.toBeInTheDocument();
+
     await user.click(screen.getByRole('button', { name: /Input Parameters/ }));
     expect(screen.getByRole('textbox')).toBeInTheDocument();
     expect(screen.getByText('"training_data.csv"')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /Performance/ }));
+    expect(screen.getByText('2h 15m')).toBeInTheDocument();
   });
 });

--- a/javascript/packages/core/components/views/execution/components/task-details/__tests__/task-body.test.tsx
+++ b/javascript/packages/core/components/views/execution/components/task-details/__tests__/task-body.test.tsx
@@ -1,8 +1,12 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
+import { CellType } from '#core/components/cell/constants';
 import { TASK_STATE } from '#core/components/views/execution/constants';
 import { createTask } from '../__fixtures__/task-details-fixtures';
 import { TaskBody } from '../task-body';
+
+import type { TaskBodySchema } from '../renderers/types';
 
 describe('TaskBody', () => {
   it('should render TaskNodeList when subtasks exist', () => {
@@ -94,5 +98,90 @@ describe('TaskBody', () => {
     // Should render subtask, not body schema
     expect(screen.getByText('Child Task')).toBeInTheDocument();
     expect(screen.queryByText('Should Not Render')).not.toBeInTheDocument();
+  });
+
+  it('should render textarea renderer for textarea type', () => {
+    const taskWithTextarea = createTask({
+      name: 'Log Task',
+      record: {
+        errorLog: 'Pipeline failed at step 3',
+      },
+    });
+
+    const bodySchema = [
+      {
+        type: 'textarea',
+        label: 'Error Log',
+        accessor: 'errorLog',
+        markdown: false,
+      },
+    ];
+
+    render(<TaskBody task={taskWithTextarea} bodySchema={bodySchema} />);
+
+    expect(screen.getByText('Error Log')).toBeInTheDocument();
+    expect(screen.getByText('Pipeline failed at step 3')).toBeInTheDocument();
+  });
+
+  it('should render metadata renderer for metadata type', async () => {
+    const user = userEvent.setup();
+    const taskWithMetadata = createTask({
+      name: 'Task with Metadata',
+      record: {
+        metadata: {
+          status: 'Success',
+          duration: '5m 30s',
+        },
+      },
+    });
+
+    const bodySchema = [
+      {
+        type: 'metadata',
+        label: 'Task Metadata',
+        accessor: 'metadata',
+        cells: [
+          {
+            id: 'status',
+            label: 'Status',
+            type: CellType.TEXT,
+            accessor: 'status',
+          },
+          {
+            id: 'duration',
+            label: 'Duration',
+            type: CellType.TEXT,
+            accessor: 'duration',
+          },
+        ],
+      },
+    ];
+
+    render(<TaskBody task={taskWithMetadata} bodySchema={bodySchema} />);
+
+    const accordionButton = screen.getByRole('button', { name: /Task Metadata/ });
+    await user.click(accordionButton);
+
+    expect(screen.getByText('Success')).toBeInTheDocument();
+    expect(screen.getByText('5m 30s')).toBeInTheDocument();
+  });
+
+  it('should handle unknown schema types gracefully', () => {
+    const taskWithUnknownSchema = createTask({
+      name: 'Task with Unknown Schema',
+      record: { data: 'some data' },
+    });
+
+    const bodySchema = [
+      {
+        type: 'unknown-type',
+        label: 'Unknown',
+        accessor: 'data',
+      } as unknown as TaskBodySchema,
+    ];
+
+    render(<TaskBody task={taskWithUnknownSchema} bodySchema={bodySchema} />);
+
+    expect(screen.queryByText('Unknown')).not.toBeInTheDocument();
   });
 });

--- a/javascript/packages/core/components/views/execution/components/task-details/renderers/__tests__/task-body-metadata.test.tsx
+++ b/javascript/packages/core/components/views/execution/components/task-details/renderers/__tests__/task-body-metadata.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { CellType } from '#core/components/cell/constants';
+import { TaskBodyMetadata } from '../task-body-metadata';
+
+describe('TaskBodyMetadata', () => {
+  const mockCells = [
+    {
+      id: 'status',
+      label: 'Status',
+      type: CellType.TEXT,
+      accessor: 'status',
+    },
+    {
+      id: 'duration',
+      label: 'Duration',
+      type: CellType.TEXT,
+      accessor: 'duration',
+    },
+    {
+      id: 'startTime',
+      label: 'Started',
+      type: CellType.DATE,
+      accessor: 'startTime',
+    },
+  ];
+
+  it('should render metadata in accordion with label', async () => {
+    const user = userEvent.setup();
+    const mockData = {
+      status: 'Success',
+      duration: '5m 30s',
+      startTime: '2025-01-01T08:00:00Z',
+    };
+
+    render(<TaskBodyMetadata label="Task Metadata" value={mockData} cells={mockCells} />);
+
+    const accordionButton = screen.getByRole('button', { name: /Task Metadata/ });
+    expect(accordionButton).toBeInTheDocument();
+
+    await user.click(accordionButton);
+
+    expect(screen.getByText('Success')).toBeInTheDocument();
+    expect(screen.getByText('5m 30s')).toBeInTheDocument();
+  });
+
+  it('should handle undefined value gracefully', async () => {
+    const user = userEvent.setup();
+
+    render(<TaskBodyMetadata label="Empty Metadata" value={undefined} cells={mockCells} />);
+
+    const accordionButton = screen.getByRole('button', { name: /Empty Metadata/ });
+    await user.click(accordionButton);
+
+    expect(screen.queryByText('Success')).not.toBeInTheDocument();
+  });
+
+  it('should handle empty cells array', async () => {
+    const user = userEvent.setup();
+    const mockData = { status: 'Success' };
+
+    render(<TaskBodyMetadata label="No Cells" value={mockData} cells={[]} />);
+
+    const accordionButton = screen.getByRole('button', { name: /No Cells/ });
+    expect(accordionButton).toBeInTheDocument();
+
+    await user.click(accordionButton);
+  });
+
+  it('should render with partial data', async () => {
+    const user = userEvent.setup();
+    const partialData = {
+      status: 'Running',
+    };
+
+    render(<TaskBodyMetadata label="Partial Metadata" value={partialData} cells={mockCells} />);
+
+    const accordionButton = screen.getByRole('button', { name: /Partial Metadata/ });
+    await user.click(accordionButton);
+
+    expect(screen.getByText('Running')).toBeInTheDocument();
+    expect(screen.queryByText('5m 30s')).not.toBeInTheDocument();
+  });
+
+  it('should render cells with different cell types', async () => {
+    const user = userEvent.setup();
+    const cellsWithStates = [
+      {
+        id: 'state',
+        label: 'State',
+        type: CellType.STATE,
+        accessor: 'state',
+        stateTextMap: {
+          SUCCESS: 'Completed',
+          FAILED: 'Failed',
+        },
+        stateColorMap: {
+          SUCCESS: 'green',
+          FAILED: 'red',
+        },
+      },
+    ];
+
+    const stateData = { state: 'SUCCESS' };
+
+    render(<TaskBodyMetadata label="State Metadata" value={stateData} cells={cellsWithStates} />);
+
+    const accordionButton = screen.getByRole('button', { name: /State Metadata/ });
+    await user.click(accordionButton);
+
+    expect(screen.getByText('Completed')).toBeInTheDocument();
+  });
+});

--- a/javascript/packages/core/components/views/execution/components/task-details/renderers/__tests__/task-body-textarea.test.tsx
+++ b/javascript/packages/core/components/views/execution/components/task-details/renderers/__tests__/task-body-textarea.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+
+import { TaskBodyTextarea } from '../task-body-textarea';
+
+describe('TaskBodyTextarea', () => {
+  it('should render text content without markdown', () => {
+    render(
+      <TaskBodyTextarea label="Error Log" value="Pipeline failed at step 3" markdown={false} />
+    );
+
+    expect(screen.getByText('Error Log')).toBeInTheDocument();
+    expect(screen.getByText('Pipeline failed at step 3')).toBeInTheDocument();
+  });
+
+  it('should render text content with markdown by default', () => {
+    const markdownText = '# Error\nPipeline **failed** at step 3';
+
+    render(<TaskBodyTextarea label="Error Log" value={markdownText} />);
+
+    expect(screen.getByText('Error Log')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1, name: 'Error' })).toBeInTheDocument();
+  });
+
+  it('should truncate text to 10000 characters', () => {
+    const longText = 'x'.repeat(20000);
+    const expectedText = 'x'.repeat(10000);
+
+    render(<TaskBodyTextarea label="Long Log" value={longText} markdown={false} />);
+
+    expect(screen.getByText(expectedText)).toBeInTheDocument();
+    expect(screen.queryByText(longText)).not.toBeInTheDocument();
+  });
+
+  it('should not render when value is undefined', () => {
+    render(<TaskBodyTextarea label="Empty Log" value={undefined} />);
+
+    expect(screen.queryByText('Empty Log')).not.toBeInTheDocument();
+  });
+
+  it('should not render when value is empty string', () => {
+    render(<TaskBodyTextarea label="Empty Log" value="" />);
+
+    expect(screen.queryByText('Empty Log')).not.toBeInTheDocument();
+  });
+});

--- a/javascript/packages/core/components/views/execution/components/task-details/renderers/task-body-metadata.tsx
+++ b/javascript/packages/core/components/views/execution/components/task-details/renderers/task-body-metadata.tsx
@@ -1,0 +1,16 @@
+import { StatefulPanel } from 'baseui/accordion';
+import { LabelSmall } from 'baseui/typography';
+
+import { Row } from '#core/components/row/row';
+
+import type { TaskBodyMetadataProps } from './types';
+
+export function TaskBodyMetadata(props: TaskBodyMetadataProps) {
+  const { label, cells, value } = props;
+
+  return (
+    <StatefulPanel title={<LabelSmall>{label}</LabelSmall>}>
+      <Row items={cells} record={value ?? undefined} />
+    </StatefulPanel>
+  );
+}

--- a/javascript/packages/core/components/views/execution/components/task-details/renderers/task-body-textarea.tsx
+++ b/javascript/packages/core/components/views/execution/components/task-details/renderers/task-body-textarea.tsx
@@ -1,0 +1,38 @@
+import { useStyletron } from 'baseui';
+import { LabelSmall, ParagraphSmall } from 'baseui/typography';
+
+import { Markdown } from '#core/components/markdown/markdown';
+
+import type { TaskBodyTextAreaProps } from './types';
+
+export function TaskBodyTextarea(props: TaskBodyTextAreaProps) {
+  const [css, theme] = useStyletron();
+  const { label, value, markdown = true, error = false } = props;
+
+  if (!value) return null;
+
+  const trimmedText = value.substring(0, 10000);
+
+  return (
+    <div
+      className={css({
+        backgroundColor: error
+          ? theme.colors.backgroundNegativeLight
+          : theme.colors.backgroundSecondary,
+        borderRadius: theme.borders.radius300,
+        minHeight: theme.sizing.scale1600,
+        overflow: 'auto',
+        padding: theme.sizing.scale600,
+        resize: 'vertical',
+      })}
+    >
+      <LabelSmall id="textarea-title">{label}</LabelSmall>
+      <ParagraphSmall
+        aria-labelledby="textarea-title"
+        className={css({ marginBottom: 0, marginTop: theme.sizing.scale100 })}
+      >
+        {markdown ? <Markdown>{trimmedText}</Markdown> : trimmedText}
+      </ParagraphSmall>
+    </div>
+  );
+}

--- a/javascript/packages/core/components/views/execution/components/task-details/renderers/types.ts
+++ b/javascript/packages/core/components/views/execution/components/task-details/renderers/types.ts
@@ -1,6 +1,7 @@
+import type { RowCell } from '#core/components/row/types';
 import type { Accessor } from '#core/types/common/studio-types';
 
-export type TaskBodySchema = SharedTaskBodySchema;
+export type TaskBodySchema = SharedTaskBodySchema | TaskBodyTextareaSchema | TaskBodyMetadataSchema;
 
 export interface SharedTaskBodySchema {
   /**
@@ -19,4 +20,21 @@ export interface SharedTaskBodySchema {
    * @example (task) => task.input
    */
   accessor: Accessor<unknown>;
+}
+
+export interface TaskBodyTextareaSchema extends SharedTaskBodySchema {
+  error?: boolean;
+  markdown?: boolean;
+}
+
+export interface TaskBodyMetadataSchema extends SharedTaskBodySchema {
+  cells: RowCell[];
+}
+
+export interface TaskBodyTextAreaProps extends Omit<TaskBodyTextareaSchema, 'type' | 'accessor'> {
+  value?: string;
+}
+
+export interface TaskBodyMetadataProps extends Omit<TaskBodyMetadataSchema, 'type' | 'accessor'> {
+  value?: Record<string, unknown>;
 }

--- a/javascript/packages/core/components/views/execution/components/task-details/task-body.tsx
+++ b/javascript/packages/core/components/views/execution/components/task-details/task-body.tsx
@@ -1,6 +1,9 @@
 import { getObjectValue } from '#core/utils/object-utils';
 import { TaskFlow } from '../task-flow';
+import { TaskBodyMetadata } from './renderers/task-body-metadata';
 import { TaskBodyStruct } from './renderers/task-body-struct';
+import { TaskBodyTextarea } from './renderers/task-body-textarea';
+import { TaskBodyMetadataSchema, TaskBodyTextareaSchema } from './renderers/types';
 
 import type { TaskBodyProps } from './types';
 
@@ -20,6 +23,33 @@ export function TaskBody<TTaskRecord extends object>(props: TaskBodyProps<TTaskR
       if (schema.type === 'struct') {
         return <TaskBodyStruct key={index} label={label} value={value as object} />;
       }
+
+      if (schema.type === 'textarea') {
+        const { error, markdown } = schema as TaskBodyTextareaSchema;
+        return (
+          <TaskBodyTextarea
+            key={index}
+            label={label}
+            value={value as string}
+            error={error}
+            markdown={markdown}
+          />
+        );
+      }
+
+      if (schema.type === 'metadata') {
+        const { cells } = schema as TaskBodyMetadataSchema;
+        return (
+          <TaskBodyMetadata
+            key={index}
+            label={label}
+            value={value as Record<string, unknown>}
+            cells={cells}
+          />
+        );
+      }
+
+      return null;
     });
   }
 

--- a/javascript/packages/core/components/views/sandbox/fixtures/execution-data.ts
+++ b/javascript/packages/core/components/views/sandbox/fixtures/execution-data.ts
@@ -8,6 +8,8 @@ export const successfulPipelineRun = {
         state: 'PIPELINE_RUN_STEP_STATE_SUCCEEDED',
         startTime: { seconds: '1704067000', nanos: 0 },
         endTime: { seconds: '1704067100', nanos: 0 },
+        message:
+          'Successfully validated dataset with 1000 valid rows and 5 invalid rows. Schema validation passed.',
         input: {
           fields: {
             dataset_path: { stringValue: '/data/training.csv', kind: 'stringValue' },
@@ -23,6 +25,7 @@ export const successfulPipelineRun = {
         stepCachedOutputs: {
           intermediateVars: [{ namespace: 'ml-workspace', name: 'validation-cache-123' }],
         },
+        logUrl: 'https://example.com/logs/data-validation',
       },
       {
         subSteps: [
@@ -123,7 +126,8 @@ export const successfulPipelineRun = {
           seconds: '1704067800',
           nanos: 424685937,
         },
-        logUrl: '',
+        logUrl: 'https://build.example.com/logs/image-build-20240101',
+        message: 'All container images built successfully. Ready for deployment phase.',
         output: {
           fields: {
             preprocess: {
@@ -140,7 +144,6 @@ export const successfulPipelineRun = {
             },
           },
         },
-        message: '',
         displayName: 'Image Build',
         input: null,
         stepCachedOutputs: null,
@@ -276,7 +279,7 @@ export const successfulPipelineRun = {
         },
         logUrl: 'https://workflow.example.com/executions/run-20240101-120000/summary',
         output: null,
-        message: '',
+        message: 'Workflow completed successfully. All tasks executed without errors.',
         displayName: 'Execute Workflow',
         input: null,
         stepCachedOutputs: null,

--- a/javascript/packages/core/components/views/sandbox/sandbox.tsx
+++ b/javascript/packages/core/components/views/sandbox/sandbox.tsx
@@ -96,9 +96,32 @@ const executionSchema: ExecutionDetailViewSchema = {
         accessor: 'output',
       },
       {
-        type: 'struct',
-        label: 'Cached Outputs',
-        accessor: 'stepCachedOutputs',
+        type: 'metadata',
+        label: 'Execution Info',
+        accessor: (record: { displayName?: string; logUrl?: string }) => {
+          return {
+            executionName: record.displayName ?? 'N/A',
+            logUrl: record.logUrl ?? '',
+          };
+        },
+        cells: [
+          {
+            id: 'executionName',
+            label: 'Execution Name',
+            type: CellType.TEXT,
+            accessor: 'executionName',
+          },
+          {
+            id: 'logUrl',
+            label: 'Log URL',
+          },
+        ],
+      },
+      {
+        type: 'textarea',
+        label: 'Task Message',
+        accessor: 'message',
+        markdown: false,
       },
     ],
     stateBuilder: (record: { state: string }) => {


### PR DESCRIPTION
This change completes the renderer system by adding TaskBodyTextarea for text/markdown content and TaskBodyMetadata for structured data display using Row components.

Enhanced sandbox demonstrates all three renderer types working together with realistic data scenarios.

<img width="1840" height="1129" alt="Screenshot 2025-08-07 at 15 07 09" src="https://github.com/user-attachments/assets/f0830aca-aacf-4d37-9f4b-91842caa2c3c" />

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
