### PR TITLE
Standardize execution view styling

### DIFF
--- a/javascript/packages/core/components/views/execution/components/task-details/renderers/task-body-metadata.tsx
+++ b/javascript/packages/core/components/views/execution/components/task-details/renderers/task-body-metadata.tsx
@@ -1,7 +1,7 @@
-import { StatefulPanel } from 'baseui/accordion';
 import { LabelSmall } from 'baseui/typography';
 
 import { Row } from '#core/components/row/row';
+import { TaskPanel } from '#core/components/views/execution/styled-components';
 
 import type { TaskBodyMetadataProps } from './types';
 
@@ -9,8 +9,8 @@ export function TaskBodyMetadata(props: TaskBodyMetadataProps) {
   const { label, cells, value } = props;
 
   return (
-    <StatefulPanel title={<LabelSmall>{label}</LabelSmall>}>
+    <TaskPanel title={<LabelSmall>{label}</LabelSmall>}>
       <Row items={cells} record={value ?? undefined} />
-    </StatefulPanel>
+    </TaskPanel>
   );
 }

--- a/javascript/packages/core/components/views/execution/components/task-details/renderers/task-body-struct.tsx
+++ b/javascript/packages/core/components/views/execution/components/task-details/renderers/task-body-struct.tsx
@@ -1,7 +1,7 @@
-import { StatefulPanel } from 'baseui/accordion';
 import { LabelSmall } from 'baseui/typography';
 
 import { TextEditor } from '#core/components/text-editor/text-editor';
+import { TaskPanel } from '#core/components/views/execution/styled-components';
 import { decodeStruct, isStruct } from '#core/utils/proto/struct-utils';
 
 export function TaskBodyStruct(props: { label: string; value: object | undefined | null }) {
@@ -11,8 +11,8 @@ export function TaskBodyStruct(props: { label: string; value: object | undefined
   const prettyJson = JSON.stringify(decodedValue, null, 2);
 
   return (
-    <StatefulPanel title={<LabelSmall>{label}</LabelSmall>}>
+    <TaskPanel title={<LabelSmall>{label}</LabelSmall>}>
       <TextEditor readOnly language="json" value={prettyJson} onChange={() => null} />
-    </StatefulPanel>
+    </TaskPanel>
   );
 }

--- a/javascript/packages/core/components/views/execution/components/task-details/task-body.tsx
+++ b/javascript/packages/core/components/views/execution/components/task-details/task-body.tsx
@@ -1,3 +1,6 @@
+import { useStyletron } from 'baseui';
+
+import { Box } from '#core/components/box/box';
 import { getObjectValue } from '#core/utils/object-utils';
 import { TaskFlow } from '../task-flow';
 import { TaskBodyMetadata } from './renderers/task-body-metadata';
@@ -8,49 +11,60 @@ import { TaskBodyMetadataSchema, TaskBodyTextareaSchema } from './renderers/type
 import type { TaskBodyProps } from './types';
 
 export function TaskBody<TTaskRecord extends object>(props: TaskBodyProps<TTaskRecord>) {
+  const [css, theme] = useStyletron();
   const { task, bodySchema } = props;
   const { subTasks } = task;
 
   if (subTasks?.length) {
-    return <TaskFlow taskList={subTasks} />;
+    return (
+      <Box>
+        <TaskFlow taskList={subTasks} />
+      </Box>
+    );
   }
 
   if (bodySchema?.length) {
-    return bodySchema.map((schema, index) => {
-      const { label } = schema;
-      const value = getObjectValue<unknown>(task.record, schema.accessor);
+    return (
+      <div
+        className={css({ display: 'flex', flexDirection: 'column', gap: theme.sizing.scale600 })}
+      >
+        {bodySchema.map((schema, index) => {
+          const { label } = schema;
+          const value = getObjectValue<unknown>(task.record, schema.accessor);
 
-      if (schema.type === 'struct') {
-        return <TaskBodyStruct key={index} label={label} value={value as object} />;
-      }
+          if (schema.type === 'struct') {
+            return <TaskBodyStruct key={index} label={label} value={value as object} />;
+          }
 
-      if (schema.type === 'textarea') {
-        const { error, markdown } = schema as TaskBodyTextareaSchema;
-        return (
-          <TaskBodyTextarea
-            key={index}
-            label={label}
-            value={value as string}
-            error={error}
-            markdown={markdown}
-          />
-        );
-      }
+          if (schema.type === 'textarea') {
+            const { error, markdown } = schema as TaskBodyTextareaSchema;
+            return (
+              <TaskBodyTextarea
+                key={index}
+                label={label}
+                value={value as string}
+                error={error}
+                markdown={markdown}
+              />
+            );
+          }
 
-      if (schema.type === 'metadata') {
-        const { cells } = schema as TaskBodyMetadataSchema;
-        return (
-          <TaskBodyMetadata
-            key={index}
-            label={label}
-            value={value as Record<string, unknown>}
-            cells={cells}
-          />
-        );
-      }
+          if (schema.type === 'metadata') {
+            const { cells } = schema as TaskBodyMetadataSchema;
+            return (
+              <TaskBodyMetadata
+                key={index}
+                label={label}
+                value={value as Record<string, unknown>}
+                cells={cells}
+              />
+            );
+          }
 
-      return null;
-    });
+          return null;
+        })}
+      </div>
+    );
   }
 
   return <div>No subtasks, no body schema for {task.name}</div>;

--- a/javascript/packages/core/components/views/execution/components/task-details/task-details.tsx
+++ b/javascript/packages/core/components/views/execution/components/task-details/task-details.tsx
@@ -1,5 +1,4 @@
-import { StatefulPanel } from 'baseui/accordion';
-
+import { TaskPanel } from '#core/components/views/execution/styled-components';
 import { TaskBody } from './task-body';
 import { TaskHeader } from './task-header';
 
@@ -22,12 +21,12 @@ export function TaskDetails<TTaskRecord extends object = object>(
 
   if (!!task.subTasks?.length || bodySchema?.length) {
     return (
-      <StatefulPanel
+      <TaskPanel
         title={<TaskHeader task={task} onClick={onClick} metadata={metadata} />}
         initialState={{ expanded: false }}
       >
         <TaskBody task={task} bodySchema={bodySchema} />
-      </StatefulPanel>
+      </TaskPanel>
     );
   }
 

--- a/javascript/packages/core/components/views/execution/components/task-details/task-header.tsx
+++ b/javascript/packages/core/components/views/execution/components/task-details/task-header.tsx
@@ -17,7 +17,7 @@ export function TaskHeader<TTaskRecord extends object>(props: TaskHeaderProps<TT
     <div className={css({ display: 'flex', flexDirection: 'column', gap: theme.sizing.scale800 })}>
       <div className={css({ display: 'flex', gap: theme.sizing.scale500 })}>
         <div className={css({ marginTop: '2px' })}>
-          <TaskStateIcon state={state} size={20} />
+          <TaskStateIcon state={state} />
         </div>
         <div
           className={css({

--- a/javascript/packages/core/components/views/execution/components/task-state-icon.tsx
+++ b/javascript/packages/core/components/views/execution/components/task-state-icon.tsx
@@ -5,10 +5,10 @@ import { STATE_TO_ICON_MAP } from '#core/components/views/execution/constants';
 
 import type { TaskState } from '#core/components/views/execution/types';
 
-export function TaskStateIcon(props: { state: TaskState; size?: number }) {
-  const { state, size = 16 } = props;
-  const [, { colors }] = useStyletron();
+export function TaskStateIcon(props: { state: TaskState }) {
+  const { state } = props;
+  const [, { colors, sizing }] = useStyletron();
   const iconProps = STATE_TO_ICON_MAP[state];
 
-  return <Icon name={iconProps.name} color={colors[iconProps.colorName]} size={size} />;
+  return <Icon name={iconProps.name} color={colors[iconProps.colorName]} size={sizing.scale750} />;
 }

--- a/javascript/packages/core/components/views/execution/components/task-step-card/task-step-card.tsx
+++ b/javascript/packages/core/components/views/execution/components/task-step-card/task-step-card.tsx
@@ -16,7 +16,7 @@ export function TaskStepCard<TTaskRecord extends object = object>(
 
   return (
     <TaskStepCardContainer $state={state} role="button" tabIndex={0} onClick={onClick}>
-      <TaskStateIcon state={state} size={20} />
+      <TaskStateIcon state={state} />
       <TaskStepName>{name}</TaskStepName>
       {hasSubTasks && focused ? (
         <div

--- a/javascript/packages/core/components/views/execution/execution.tsx
+++ b/javascript/packages/core/components/views/execution/execution.tsx
@@ -1,14 +1,17 @@
 import React from 'react';
 import { useStyletron } from 'baseui';
 
+import { Box } from '#core/components/box/box';
 import { ErrorView } from '#core/components/error-view/error-view';
 import { CircleExclamationMark } from '#core/components/illustrations/circle-exclamation-mark/circle-exclamation-mark';
 import { CircleExclamationMarkKind } from '#core/components/illustrations/circle-exclamation-mark/types';
 import { TaskDetails } from './components/task-details/task-details';
 import { TaskFlow } from './components/task-flow';
+import { TaskStateIcon } from './components/task-state-icon';
 import { TaskSeparator } from './styled-components';
 import { buildTaskList } from './utils/build-task-list';
 import { buildTaskMatrix } from './utils/build-task-matrix';
+import { determineExecutionState } from './utils/determine-execution-state';
 
 import type { ExecutionDetailViewSchema } from './types';
 
@@ -40,8 +43,16 @@ export function Execution<
 
   return (
     <div className={css({ display: 'flex', flexDirection: 'column', gap: theme.sizing.scale800 })}>
-      <div>
-        <h3>Overview</h3>
+      <Box
+        title={
+          <div
+            className={css({ display: 'flex', alignItems: 'center', gap: theme.sizing.scale500 })}
+          >
+            <TaskStateIcon state={determineExecutionState(taskList)} />
+            Overview
+          </div>
+        }
+      >
         <div
           className={css({ display: 'flex', flexDirection: 'column', gap: theme.sizing.scale600 })}
         >
@@ -52,7 +63,7 @@ export function Execution<
             </React.Fragment>
           ))}
         </div>
-      </div>
+      </Box>
 
       <div
         className={css({ display: 'flex', flexDirection: 'column', gap: theme.sizing.scale600 })}

--- a/javascript/packages/core/components/views/execution/styled-components.ts
+++ b/javascript/packages/core/components/views/execution/styled-components.ts
@@ -1,7 +1,0 @@
-import { styled } from 'baseui';
-
-export const TaskSeparator = styled('hr', ({ $theme }) => ({
-  border: 'none',
-  borderBottom: `2px dashed ${$theme.colors.contentInverseTertiary}`,
-  margin: `${$theme.sizing.scale200} 0`,
-}));

--- a/javascript/packages/core/components/views/execution/styled-components.tsx
+++ b/javascript/packages/core/components/views/execution/styled-components.tsx
@@ -1,0 +1,50 @@
+import { styled } from 'baseui';
+import { StatefulPanel } from 'baseui/accordion';
+
+import { StyledBoxContainer } from '#core/components/box/styled-components';
+
+import type { Theme } from 'baseui';
+import type { StatefulPanelProps } from 'baseui/accordion';
+
+export const TaskSeparator = styled('hr', ({ $theme }) => ({
+  border: 'none',
+  borderBottom: `2px dashed ${$theme.colors.contentInverseTertiary}`,
+  margin: `${$theme.sizing.scale200} 0`,
+}));
+
+export function TaskPanel(props: StatefulPanelProps) {
+  return (
+    <StatefulPanel
+      {...props}
+      overrides={{
+        PanelContainer: {
+          component: StyledBoxContainer,
+          props: { onClick: (e: MouseEvent) => e.stopPropagation() },
+          style: ({ $theme, $expanded }: { $expanded: boolean; $theme: Theme }) => ({
+            ...(!$expanded && { gap: 0 }),
+            transitionProperty: 'gap',
+            transitionDuration: $theme.animation.timing500,
+          }),
+        },
+        Content: {
+          style: {
+            padding: 0,
+            // paddingBottom appears provided by the StyledContent component controlled by
+            // baseui overrides padding: 0
+            paddingBottom: 0,
+          },
+        },
+        Header: {
+          style: {
+            padding: 0,
+          },
+        },
+        ToggleIcon: {
+          style: {
+            alignSelf: 'flex-start',
+          },
+        },
+      }}
+    />
+  );
+}

--- a/javascript/packages/core/components/views/execution/utils/__tests__/determine-execution-state.test.ts
+++ b/javascript/packages/core/components/views/execution/utils/__tests__/determine-execution-state.test.ts
@@ -1,0 +1,132 @@
+import { createTask } from '#core/components/views/execution/components/task-details/__fixtures__/task-details-fixtures';
+import { TASK_STATE } from '#core/components/views/execution/constants';
+import { Task } from '#core/components/views/execution/types';
+import { determineExecutionState } from '../determine-execution-state';
+
+describe('determineExecutionState', () => {
+  it('should return PENDING for empty task list', () => {
+    expect(determineExecutionState([])).toBe(TASK_STATE.PENDING);
+  });
+
+  it('should return RUNNING when any task is running', () => {
+    const tasks = [
+      createTask({ state: TASK_STATE.SUCCESS }),
+      createTask({ state: TASK_STATE.RUNNING }),
+      createTask({ state: TASK_STATE.PENDING }),
+    ];
+
+    expect(determineExecutionState(tasks)).toBe(TASK_STATE.RUNNING);
+  });
+
+  it('should return RUNNING when multiple tasks are running', () => {
+    const tasks = [
+      createTask({ state: TASK_STATE.RUNNING }),
+      createTask({ state: TASK_STATE.SUCCESS }),
+      createTask({ state: TASK_STATE.RUNNING }),
+    ];
+
+    expect(determineExecutionState(tasks)).toBe(TASK_STATE.RUNNING);
+  });
+
+  it('should return ERROR when any task failed and none are running', () => {
+    const tasks = [
+      createTask({ state: TASK_STATE.SUCCESS }),
+      createTask({ state: TASK_STATE.ERROR }),
+      createTask({ state: TASK_STATE.PENDING }),
+    ];
+
+    expect(determineExecutionState(tasks)).toBe(TASK_STATE.ERROR);
+  });
+
+  it('should return ERROR when multiple tasks failed and none are running', () => {
+    const tasks = [
+      createTask({ state: TASK_STATE.ERROR }),
+      createTask({ state: TASK_STATE.SUCCESS }),
+      createTask({ state: TASK_STATE.ERROR }),
+    ];
+
+    expect(determineExecutionState(tasks)).toBe(TASK_STATE.ERROR);
+  });
+
+  it('should prioritize RUNNING over ERROR', () => {
+    const tasks = [
+      createTask({ state: TASK_STATE.ERROR }),
+      createTask({ state: TASK_STATE.RUNNING }),
+      createTask({ state: TASK_STATE.ERROR }),
+    ];
+
+    expect(determineExecutionState(tasks)).toBe(TASK_STATE.RUNNING);
+  });
+
+  it('should return last task state when no running or error tasks', () => {
+    const tasks = [
+      createTask({ state: TASK_STATE.SUCCESS }),
+      createTask({ state: TASK_STATE.SKIPPED }),
+      createTask({ state: TASK_STATE.SUCCESS }),
+    ];
+
+    expect(determineExecutionState(tasks)).toBe(TASK_STATE.SUCCESS);
+  });
+
+  it('should return last task state for pending tasks', () => {
+    const tasks = [
+      createTask({ state: TASK_STATE.PENDING }),
+      createTask({ state: TASK_STATE.PENDING }),
+      createTask({ state: TASK_STATE.PENDING }),
+    ];
+
+    expect(determineExecutionState(tasks)).toBe(TASK_STATE.PENDING);
+  });
+
+  it('should handle single task correctly', () => {
+    expect(determineExecutionState([createTask({ state: TASK_STATE.SUCCESS })])).toBe(
+      TASK_STATE.SUCCESS
+    );
+    expect(determineExecutionState([createTask({ state: TASK_STATE.ERROR })])).toBe(
+      TASK_STATE.ERROR
+    );
+    expect(determineExecutionState([createTask({ state: TASK_STATE.RUNNING })])).toBe(
+      TASK_STATE.RUNNING
+    );
+    expect(determineExecutionState([createTask({ state: TASK_STATE.PENDING })])).toBe(
+      TASK_STATE.PENDING
+    );
+    expect(determineExecutionState([createTask({ state: TASK_STATE.SKIPPED })])).toBe(
+      TASK_STATE.SKIPPED
+    );
+  });
+
+  it('should handle mixed states with success at end', () => {
+    const tasks = [
+      createTask({ state: TASK_STATE.SUCCESS }),
+      createTask({ state: TASK_STATE.SKIPPED }),
+      createTask({ state: TASK_STATE.SUCCESS }),
+    ];
+
+    expect(determineExecutionState(tasks)).toBe(TASK_STATE.SUCCESS);
+  });
+
+  it('should handle mixed states with pending at end', () => {
+    const tasks = [
+      createTask({ state: TASK_STATE.SUCCESS }),
+      createTask({ state: TASK_STATE.SUCCESS }),
+      createTask({ state: TASK_STATE.PENDING }),
+    ];
+
+    expect(determineExecutionState(tasks)).toBe(TASK_STATE.PENDING);
+  });
+
+  it('should handle edge case where last task state is undefined', () => {
+    const tasks = [
+      {
+        name: 'Test Task',
+        state: undefined,
+        subTasks: [],
+        record: {},
+        focused: false,
+      } as unknown as Task,
+    ];
+
+    expect(determineExecutionState(tasks)).toBe(TASK_STATE.PENDING);
+  });
+});

--- a/javascript/packages/core/components/views/execution/utils/determine-execution-state.ts
+++ b/javascript/packages/core/components/views/execution/utils/determine-execution-state.ts
@@ -1,0 +1,17 @@
+import { TASK_STATE } from '../constants';
+
+import type { Task, TaskState } from '../types';
+
+export function determineExecutionState(taskList: Task[]): TaskState {
+  if (!taskList.length) {
+    return TASK_STATE.PENDING;
+  }
+  if (taskList.some(({ state }) => state === TASK_STATE.RUNNING)) {
+    return TASK_STATE.RUNNING;
+  }
+  if (taskList.some(({ state }) => state === TASK_STATE.ERROR)) {
+    return TASK_STATE.ERROR;
+  }
+
+  return taskList.at(-1)?.state ?? TASK_STATE.PENDING;
+}


### PR DESCRIPTION
**Duplicate of #303, accidentally merged 303 into feature branch instead of main 🙃 **

Migrate execution components to consistent styling patterns with custom TaskPanel.

Previous implementation relied on BaseUI's StatefulPanel directly, which does not include border required to match designs. This change creates TaskPanel wrapper with standardized overrides. This is reused across all panel-wrapped components for consistent behavior & styling.

Implement overall execution state determination in utility that allows execution overview to display icon. During this implementation, realized that TaskStateIcon always has the same size, so inlined that size.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
