### PR TITLE
Add column configuration system for table component

### DIFF
--- a/javascript/app/icons/icons.tsx
+++ b/javascript/app/icons/icons.tsx
@@ -11,6 +11,7 @@ import CropSquareIcon from '@mui/icons-material/CropSquare';
 import Info from '@mui/icons-material/Info';
 import KeyboardBackspaceIcon from '@mui/icons-material/KeyboardBackspace';
 import Launch from '@mui/icons-material/Launch';
+import SettingsIcon from '@mui/icons-material/Settings';
 import ShowChartIcon from '@mui/icons-material/ShowChart';
 import SkipNextIcon from '@mui/icons-material/SkipNext';
 
@@ -29,6 +30,7 @@ export const ICONS = {
   diamondEmpty: createMuiIconAdapter(CropSquareIcon),
   playerNext: createMuiIconAdapter(SkipNextIcon),
   plus: createMuiIconAdapter(AddIcon),
+  settings: createMuiIconAdapter(SettingsIcon),
   sortAscending: createMuiIconAdapter(ArrowUpwardIcon),
   sortDescending: createMuiIconAdapter(ArrowDownwardIcon),
   stars: createMuiIconAdapter(AutoAwesomeIcon),

--- a/javascript/packages/core/components/table/__fixtures__/table-test-helpers.ts
+++ b/javascript/packages/core/components/table/__fixtures__/table-test-helpers.ts
@@ -1,3 +1,4 @@
+import { screen } from '@testing-library/react';
 import { fromPairs } from 'lodash';
 
 import type { ColumnConfig } from '../types/column-types';
@@ -26,4 +27,15 @@ export function buildTableColumns(numberOfColumns: number): ColumnConfig[] {
 
 export function getArrayWithLength(length: number): number[] {
   return Array.from({ length }, (_, i) => i + 1);
+}
+
+/**
+ * Helper to assert expected column header count, accounting for table structure.
+ * By default includes the column configuration button.
+ */
+export function expectTableHeaders(options: { dataColumns: number; hasConfigButton?: boolean }) {
+  let expectedCount = options.dataColumns;
+  if (options.hasConfigButton !== false) expectedCount += 1; // defaults to true
+
+  expect(screen.getAllByRole('columnheader')).toHaveLength(expectedCount);
 }

--- a/javascript/packages/core/components/table/__tests__/table.test.tsx
+++ b/javascript/packages/core/components/table/__tests__/table.test.tsx
@@ -9,7 +9,11 @@ import { getIconProviderWrapper } from '#core/test/wrappers/get-icon-provider-wr
 import { getInterpolationProviderWrapper } from '#core/test/wrappers/get-interpolation-provider-wrapper';
 import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
 import { ApplicationError } from '#core/types/error-types';
-import { buildTableColumns, buildTableData } from '../__fixtures__/table-test-helpers';
+import {
+  buildTableColumns,
+  buildTableData,
+  expectTableHeaders,
+} from '../__fixtures__/table-test-helpers';
 import { Table } from '../table';
 
 import type { TablePaginationProps } from '../components/table-pagination/types';
@@ -34,7 +38,7 @@ describe('Table', () => {
     });
 
     it('renders column headers', () => {
-      expect(screen.getAllByRole('columnheader')).toHaveLength(numberOfColumns);
+      expectTableHeaders({ dataColumns: numberOfColumns });
       expect(
         screen.getByRole('row', { name: 'Column1 Column2 Column3 Column4' })
       ).toBeInTheDocument();
@@ -67,7 +71,7 @@ describe('Table', () => {
     });
 
     it('renders column headers', () => {
-      expect(screen.getAllByRole('columnheader')).toHaveLength(numberOfColumns);
+      expectTableHeaders({ dataColumns: numberOfColumns });
       expect(screen.getByRole('row', { name: 'Column1 Column2 Column3' })).toBeInTheDocument();
     });
   });
@@ -90,7 +94,7 @@ describe('Table', () => {
     });
 
     it('renders column headers', () => {
-      expect(screen.getAllByRole('columnheader')).toHaveLength(numberOfColumns);
+      expectTableHeaders({ dataColumns: numberOfColumns });
       expect(
         screen.getByRole('row', { name: 'Column1 Column2 Column3 Column4' })
       ).toBeInTheDocument();
@@ -120,7 +124,7 @@ describe('Table', () => {
     });
 
     it('renders column headers', () => {
-      expect(screen.getAllByRole('columnheader')).toHaveLength(1);
+      expectTableHeaders({ dataColumns: 1 });
       expect(screen.getByRole('row', { name: 'Column1' })).toBeInTheDocument();
     });
 
@@ -151,7 +155,7 @@ describe('Table', () => {
     });
 
     it('renders column headers when loading', () => {
-      expect(screen.getAllByRole('columnheader')).toHaveLength(4);
+      expectTableHeaders({ dataColumns: 4 });
     });
 
     it('does not render data rows when loading', () => {
@@ -183,7 +187,7 @@ describe('Table', () => {
     });
 
     it('renders column headers when loading', () => {
-      expect(screen.getAllByRole('columnheader')).toHaveLength(3);
+      expectTableHeaders({ dataColumns: 3 });
     });
 
     it('does not render data rows when loading', () => {
@@ -1155,6 +1159,126 @@ describe('Table', () => {
       expect(screen.getAllByRole('row')[1]).toHaveTextContent('Alice');
       expect(screen.getAllByRole('row')[2]).toHaveTextContent('Bob');
       expect(screen.getAllByRole('row')[3]).toHaveTextContent('Charlie');
+    });
+  });
+
+  describe('column configuration integration', () => {
+    const testData = buildTableData(3, 4);
+    const testColumns = buildTableColumns(4);
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      localStorage.clear();
+    });
+
+    it('renders column configuration button in table header', () => {
+      render(
+        <Table data={testData} columns={testColumns} />,
+        buildWrapper([
+          getBaseProviderWrapper(),
+          getInterpolationProviderWrapper(),
+          getRouterWrapper(),
+        ])
+      );
+
+      expect(screen.getByTitle('Configure columns')).toBeInTheDocument();
+    });
+
+    it('opens column configuration popover when button is clicked', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <Table data={testData} columns={testColumns} />,
+        buildWrapper([
+          getBaseProviderWrapper(),
+          getInterpolationProviderWrapper(),
+          getRouterWrapper(),
+        ])
+      );
+
+      // Column header text is rendered
+      expect(screen.getByText('Column1')).toBeInTheDocument();
+      expect(screen.getByText('Column2')).toBeInTheDocument();
+      expect(screen.getByText('Column3')).toBeInTheDocument();
+      expect(screen.getByText('Column4')).toBeInTheDocument();
+
+      await user.click(screen.getByTitle('Configure columns'));
+
+      // First column is the unique identifier column, so it is not rendered in the popover
+      expect(screen.getByText('Column1')).toBeInTheDocument();
+
+      // Column headers are rendered twice, once in the table header and once in the popover
+      expect(screen.getAllByText('Column2')).toHaveLength(2);
+      expect(screen.getAllByText('Column3')).toHaveLength(2);
+      expect(screen.getAllByText('Column4')).toHaveLength(2);
+    });
+
+    it('reorders columns and reflects changes in table headers', () => {
+      render(
+        <Table
+          data={testData}
+          columns={testColumns}
+          state={{ columnOrder: ['col2', 'col1', 'col3', 'col4'] }}
+        />,
+        buildWrapper([
+          getBaseProviderWrapper(),
+          getInterpolationProviderWrapper(),
+          getRouterWrapper(),
+        ])
+      );
+
+      const headers = screen.getAllByRole('columnheader');
+      expect(headers[0]).toHaveTextContent('Column2');
+      expect(headers[1]).toHaveTextContent('Column1');
+      expect(headers[2]).toHaveTextContent('Column3');
+      expect(headers[3]).toHaveTextContent('Column4');
+
+      const firstDataRow = screen.getByRole('row', {
+        name: 'row1-col2-data row1-col1-data row1-col3-data row1-col4-data',
+      });
+      expect(firstDataRow).toBeInTheDocument();
+    });
+
+    it('hides column and reflects changes in table structure', () => {
+      render(
+        <Table
+          data={testData}
+          columns={testColumns}
+          state={{ columnVisibility: { col2: false } }}
+        />,
+        buildWrapper([
+          getBaseProviderWrapper(),
+          getInterpolationProviderWrapper(),
+          getRouterWrapper(),
+        ])
+      );
+
+      // Should only show 3 data columns (Column2 is hidden)
+      expectTableHeaders({ dataColumns: 3 });
+      expect(screen.getByRole('columnheader', { name: 'Column1' })).toBeInTheDocument();
+      expect(screen.queryByRole('columnheader', { name: 'Column2' })).not.toBeInTheDocument();
+      expect(screen.getByRole('columnheader', { name: 'Column3' })).toBeInTheDocument();
+      expect(screen.getByRole('columnheader', { name: 'Column4' })).toBeInTheDocument();
+
+      // Data rows should exclude the hidden column
+      const firstDataRow = screen.getByRole('row', {
+        name: 'row1-col1-data row1-col3-data row1-col4-data',
+      });
+      expect(firstDataRow).toBeInTheDocument();
+    });
+
+    it('handles empty columns gracefully', () => {
+      render(
+        <Table data={[]} columns={[]} />,
+        buildWrapper([
+          getBaseProviderWrapper(),
+          getInterpolationProviderWrapper(),
+          getRouterWrapper(),
+        ])
+      );
+
+      const configButton = screen.getByTitle('Configure columns');
+      expect(configButton).toBeInTheDocument();
     });
   });
 });

--- a/javascript/packages/core/components/table/components/table-body/table-body.tsx
+++ b/javascript/packages/core/components/table/components/table-body/table-body.tsx
@@ -13,6 +13,8 @@ export const TableBody = <T extends TableData = TableData>({ rows }: TableBodyPr
           {row.cells.map((cell) => (
             <StyledTableBodyCell key={cell.id}>{cell.content}</StyledTableBodyCell>
           ))}
+          {/* Placeholder action cell to align with column configuration button */}
+          <StyledTableBodyCell />
         </StyledTableBodyRow>
       ))}
     </StyledTableBody>

--- a/javascript/packages/core/components/table/components/table-header/components/table-column-configuration-button/__tests__/utils.test.ts
+++ b/javascript/packages/core/components/table/components/table-header/components/table-column-configuration-button/__tests__/utils.test.ts
@@ -1,0 +1,75 @@
+import { vi } from 'vitest';
+
+import { CellType } from '#core/components/cell/constants';
+import { createColumnListChangeHandler } from '../utils';
+
+import type { TableData } from '#core/components/table/types/data-types';
+import type { ConfigurableColumn } from '../types';
+
+describe('createColumnListChangeHandler', () => {
+  const mockColumns: ConfigurableColumn<TableData>[] = [
+    { type: CellType.TEXT, id: 'col1', label: 'Column 1', isVisible: true, canHide: false },
+    { type: CellType.TEXT, id: 'col2', label: 'Column 2', isVisible: true, canHide: true },
+    { type: CellType.TEXT, id: 'col3', label: 'Column 3', isVisible: false, canHide: true },
+    { type: CellType.TEXT, id: 'col4', label: 'Column 4', isVisible: true, canHide: true },
+  ];
+
+  let mockSetColumnOrder: ReturnType<typeof vi.fn>;
+  let mockSetColumnVisibility: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockSetColumnOrder = vi.fn();
+    mockSetColumnVisibility = vi.fn();
+  });
+
+  it('reorders columns when given position indices', () => {
+    const handler = createColumnListChangeHandler(
+      mockColumns,
+      mockSetColumnOrder,
+      mockSetColumnVisibility
+    );
+
+    handler({ oldIndex: 0, newIndex: 2 });
+
+    expect(mockSetColumnOrder).toHaveBeenCalledWith(['col1', 'col3', 'col4', 'col2']);
+    expect(mockSetColumnVisibility).not.toHaveBeenCalled();
+  });
+
+  it('toggles column visibility when newIndex is -1', () => {
+    const handler = createColumnListChangeHandler(
+      mockColumns,
+      mockSetColumnOrder,
+      mockSetColumnVisibility
+    );
+
+    handler({ oldIndex: 0, newIndex: -1 });
+
+    expect(mockSetColumnOrder).not.toHaveBeenCalled();
+
+    // setColumnVisibility is called with a function, we need to call it to get the result
+    const updaterFunction = mockSetColumnVisibility.mock.calls[0][0] as (
+      columnVisibility: Record<string, boolean>
+    ) => Record<string, boolean>;
+
+    // col2 starts visible (true) and should be toggled to hidden (false)
+    const currentVisibility = { col1: true, col2: true, col3: false, col4: true };
+    const result = updaterFunction(currentVisibility);
+
+    expect(result).toEqual({
+      col1: true,
+      col2: false,
+      col3: false,
+      col4: true,
+    });
+  });
+
+  it('handles empty columns array', () => {
+    const handler = createColumnListChangeHandler([], mockSetColumnOrder, mockSetColumnVisibility);
+
+    handler({ oldIndex: 0, newIndex: 1 });
+
+    // Should call setColumnOrder (arrayMove behavior with empty array may vary)
+    expect(mockSetColumnOrder).toHaveBeenCalled();
+    expect(mockSetColumnVisibility).not.toHaveBeenCalled();
+  });
+});

--- a/javascript/packages/core/components/table/components/table-header/components/table-column-configuration-button/table-column-configuration-button.tsx
+++ b/javascript/packages/core/components/table/components/table-header/components/table-column-configuration-button/table-column-configuration-button.tsx
@@ -1,0 +1,70 @@
+import { useStyletron } from 'baseui';
+import { Button, KIND, SIZE } from 'baseui/button';
+import { Checkbox } from 'baseui/checkbox';
+import { List, SharedStylePropsArg, StyledCloseHandle, StyledLabel } from 'baseui/dnd-list';
+import { PLACEMENT, StatefulPopover } from 'baseui/popover';
+
+import { Icon } from '#core/components/icon/icon';
+import { TableData } from '#core/components/table/types/data-types';
+import { createColumnListChangeHandler } from './utils';
+
+import type { ConfigurableColumn, TableColumnConfigurationButtonProps } from './types';
+
+export function TableColumnConfigurationButton<T extends TableData = TableData>({
+  columns,
+  setColumnOrder,
+  setColumnVisibility,
+}: TableColumnConfigurationButtonProps<T>) {
+  const [css, theme] = useStyletron();
+
+  return (
+    <StatefulPopover
+      placement={PLACEMENT.bottomRight}
+      content={() => (
+        <div
+          className={css({
+            backgroundColor: theme.colors.backgroundPrimary,
+            borderRadius: theme.borders.radius300,
+            width: '214px',
+            display: 'flex',
+            flexDirection: 'column',
+          })}
+        >
+          <List
+            removable
+            overrides={{
+              Item: { style: { height: theme.sizing.scale800 } },
+              Label: {
+                component: (props: { $value: ConfigurableColumn<T> } & SharedStylePropsArg) => (
+                  <StyledLabel {...props}>{props.$value.label}</StyledLabel>
+                ),
+              },
+              CloseHandle: {
+                component: (props: { $value: ConfigurableColumn<T> } & SharedStylePropsArg) => (
+                  <StyledCloseHandle {...props}>
+                    <Checkbox
+                      checked={props.$value.isVisible}
+                      disabled={!props.$value.canHide}
+                      title={`Toggle ${props.$value.label}`}
+                    />
+                  </StyledCloseHandle>
+                ),
+              },
+            }}
+            onChange={createColumnListChangeHandler(columns, setColumnOrder, setColumnVisibility)}
+            // @ts-expect-error Items are expected to be React Nodes, but we set them as objects
+            // and with the help of overrides, we render them as React Nodes
+
+            // MA Studio does not support reordering or hiding the first column, since it is usually
+            // the unique identifier column.
+            items={columns.slice(1)}
+          />
+        </div>
+      )}
+    >
+      <Button title="Configure columns" size={SIZE.mini} kind={KIND.tertiary}>
+        <Icon name="settings" size={theme.sizing.scale700} />
+      </Button>
+    </StatefulPopover>
+  );
+}

--- a/javascript/packages/core/components/table/components/table-header/components/table-column-configuration-button/types.ts
+++ b/javascript/packages/core/components/table/components/table-header/components/table-column-configuration-button/types.ts
@@ -1,0 +1,13 @@
+import { ColumnRenderState, VisibilityCapability } from '#core/components/table/types/column-types';
+import { TableData } from '#core/components/table/types/data-types';
+
+import type { ControlledTableState } from '#core/components/table/types/table-types';
+
+export interface TableColumnConfigurationButtonProps<T extends TableData = TableData> {
+  columns: Array<ConfigurableColumn<T>>;
+  setColumnOrder: ControlledTableState['setColumnOrder'];
+  setColumnVisibility: ControlledTableState['setColumnVisibility'];
+}
+
+export type ConfigurableColumn<T extends TableData = TableData> = ColumnRenderState<T> &
+  VisibilityCapability;

--- a/javascript/packages/core/components/table/components/table-header/components/table-column-configuration-button/utils.ts
+++ b/javascript/packages/core/components/table/components/table-header/components/table-column-configuration-button/utils.ts
@@ -1,0 +1,45 @@
+import { arrayMove } from 'baseui/dnd-list';
+
+import { TableData } from '#core/components/table/types/data-types';
+
+import type {
+  ColumnOrderState,
+  ControlledTableState,
+} from '#core/components/table/types/table-types';
+import type { ConfigurableColumn } from './types';
+
+/**
+ * Handles BaseUI dnd-list changes for column reordering and visibility toggling.
+ *
+ * BaseUI uses -1 as a special identifier for toggle visibility operations,
+ * while positive indices represent reordering operations.
+ */
+export function createColumnListChangeHandler<T extends TableData = TableData>(
+  columns: ConfigurableColumn<T>[],
+  setColumnOrder: ControlledTableState['setColumnOrder'],
+  setColumnVisibility: ControlledTableState['setColumnVisibility']
+) {
+  return (state: { oldIndex: number; newIndex: number }) => {
+    const wasToggledHidden = state.newIndex === -1;
+
+    // +1 to account for sliced first column
+    const oldIndex = state.oldIndex + 1;
+    const newIndex = state.newIndex + 1;
+
+    if (wasToggledHidden) {
+      const column = columns[oldIndex];
+      setColumnVisibility((old) => ({
+        ...old,
+        [column.id]: !column.isVisible,
+      }));
+    } else {
+      setColumnOrder(
+        arrayMove(
+          columns.map((c) => c.id),
+          oldIndex,
+          newIndex
+        ) as ColumnOrderState
+      );
+    }
+  };
+}

--- a/javascript/packages/core/components/table/components/table-header/table-header.tsx
+++ b/javascript/packages/core/components/table/components/table-header/table-header.tsx
@@ -1,41 +1,60 @@
 import { useStyletron } from 'baseui';
 import { StyledTableHead, StyledTableHeadRow } from 'baseui/table-semantic';
 
+import { TableColumnConfigurationButton } from './components/table-column-configuration-button/table-column-configuration-button';
 import { TableSortIcon } from './components/table-sort-icon/table-sort-icon';
 import { StyledSortableTableHeadCell, StyledTableHeadCell } from './styled-components';
 
 import type { TableData } from '#core/components/table/types/data-types';
 import type { TableHeaderProps } from './types';
 
-export const TableHeader = <T extends TableData = TableData>({ columns }: TableHeaderProps<T>) => {
+export const TableHeader = <T extends TableData = TableData>({
+  columns,
+  setColumnOrder,
+  setColumnVisibility,
+}: TableHeaderProps<T>) => {
   const [css, theme] = useStyletron();
   return (
     <StyledTableHead>
       <StyledTableHeadRow>
-        {columns.map((column) =>
-          column.canSort ? (
-            <StyledSortableTableHeadCell
-              key={column.id}
-              $isFocusVisible={false}
-              onClick={column.onToggleSort}
-              role="columnheader"
-            >
-              <div
-                className={css({
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: theme.sizing.scale300,
-                })}
+        {columns
+          .filter((column) => column.isVisible)
+          .map((column) =>
+            column.canSort ? (
+              <StyledSortableTableHeadCell
+                key={column.id}
+                $isFocusVisible={false}
+                onClick={column.onToggleSort}
+                role="columnheader"
               >
-                <div>{column.label}</div>
-                <TableSortIcon column={{ getIsSorted: () => column.sortDirection ?? false }} />
-              </div>
-            </StyledSortableTableHeadCell>
-          ) : (
-            <StyledTableHeadCell key={column.id} role="columnheader">
-              {column.label}
-            </StyledTableHeadCell>
-          )
+                <div
+                  className={css({
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: theme.sizing.scale300,
+                  })}
+                >
+                  <div>{column.label}</div>
+                  <TableSortIcon column={{ getIsSorted: () => column.sortDirection ?? false }} />
+                </div>
+              </StyledSortableTableHeadCell>
+            ) : (
+              <StyledTableHeadCell key={column.id} role="columnheader">
+                {column.label}
+              </StyledTableHeadCell>
+            )
+          )}
+
+        {setColumnOrder && setColumnVisibility && (
+          <StyledTableHeadCell role="columnheader">
+            <div className={css({ display: 'flex', justifyContent: 'center' })}>
+              <TableColumnConfigurationButton
+                columns={columns}
+                setColumnOrder={setColumnOrder}
+                setColumnVisibility={setColumnVisibility}
+              />
+            </div>
+          </StyledTableHeadCell>
         )}
       </StyledTableHeadRow>
     </StyledTableHead>

--- a/javascript/packages/core/components/table/components/table-header/types.ts
+++ b/javascript/packages/core/components/table/components/table-header/types.ts
@@ -1,9 +1,13 @@
 import type {
   ColumnRenderState,
   SortingCapability,
+  VisibilityCapability,
 } from '#core/components/table/types/column-types';
 import type { TableData } from '#core/components/table/types/data-types';
+import type { ControlledTableState } from '#core/components/table/types/table-types';
 
 export type TableHeaderProps<T extends TableData = TableData> = {
-  columns: Array<ColumnRenderState<T> & SortingCapability>;
+  columns: Array<ColumnRenderState<T> & SortingCapability & VisibilityCapability>;
+  setColumnOrder: ControlledTableState['setColumnOrder'];
+  setColumnVisibility: ControlledTableState['setColumnVisibility'];
 };

--- a/javascript/packages/core/components/table/constants.ts
+++ b/javascript/packages/core/components/table/constants.ts
@@ -42,6 +42,8 @@ export const TABLE_STATE_DEFAULTS: TableState = {
     pageSize: DEFAULT_PAGE_SIZE,
   },
   sorting: [],
+  columnOrder: [],
+  columnVisibility: {},
 } as const;
 
 export const TABLE_LOCAL_STORAGE_KEY = 'ma-studio-table-settings';

--- a/javascript/packages/core/components/table/plugins/state-persistence/use-local-storage-table-state.ts
+++ b/javascript/packages/core/components/table/plugins/state-persistence/use-local-storage-table-state.ts
@@ -5,6 +5,8 @@ import { usePersistedTableState } from './use-persisted-table-state';
 
 import type {
   ColumnFilter,
+  ColumnOrderState,
+  ColumnVisibilityState,
   ControlledTableState,
   PaginationState,
   SortingState,
@@ -55,6 +57,16 @@ export function useLocalStorageTableState({
     TABLE_STATE_DEFAULTS.sorting
   );
 
+  const [columnOrder, setColumnOrder] = usePersistedTableState<ColumnOrderState>(
+    `${tableSettingsId}.columnOrder`,
+    TABLE_STATE_DEFAULTS.columnOrder
+  );
+
+  const [columnVisibility, setColumnVisibility] = usePersistedTableState<ColumnVisibilityState>(
+    `${tableSettingsId}.columnVisibility`,
+    TABLE_STATE_DEFAULTS.columnVisibility
+  );
+
   // pageIndex is not persisted (resets on reload)
   const [pageIndex, setPageIndex] = useState<number>(0);
 
@@ -75,5 +87,9 @@ export function useLocalStorageTableState({
     },
     sorting,
     setSorting,
+    columnOrder,
+    setColumnOrder,
+    columnVisibility,
+    setColumnVisibility,
   };
 }

--- a/javascript/packages/core/components/table/table.tsx
+++ b/javascript/packages/core/components/table/table.tsx
@@ -39,6 +39,8 @@ export function Table<T extends TableData = TableData>(inputProps: TableProps<T>
     ...(state.setColumnFilters ? { onColumnFiltersChange: state.setColumnFilters } : {}),
     ...(state.setPagination ? { onPaginationChange: state.setPagination } : {}),
     ...(state.setSorting ? { onSortingChange: state.setSorting } : {}),
+    ...(state.setColumnOrder ? { onColumnOrderChange: state.setColumnOrder } : {}),
+    ...(state.setColumnVisibility ? { onColumnVisibilityChange: state.setColumnVisibility } : {}),
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     ...(!props.disableSorting
@@ -58,7 +60,7 @@ export function Table<T extends TableData = TableData>(inputProps: TableProps<T>
     filteredLength: table.getFilteredRowModel().rows.length,
   });
 
-  const transformedColumns = transformColumns(table.getAllColumns());
+  const transformedColumns = transformColumns(table.getAllLeafColumns());
 
   return (
     <TableContainer>
@@ -89,7 +91,13 @@ export function Table<T extends TableData = TableData>(inputProps: TableProps<T>
           />
         )}
 
-        {viewState !== 'error' && <TableHeader<T> columns={transformedColumns} />}
+        {viewState !== 'error' && (
+          <TableHeader<T>
+            columns={transformedColumns}
+            setColumnOrder={table.setColumnOrder}
+            setColumnVisibility={table.setColumnVisibility}
+          />
+        )}
 
         {viewState === 'ready' && (
           <TableBody<T> rows={transformRows<T>(table.getRowModel().rows)} />

--- a/javascript/packages/core/components/table/types/column-types.ts
+++ b/javascript/packages/core/components/table/types/column-types.ts
@@ -65,3 +65,12 @@ export type SortingCapability = {
   onToggleSort: (e: React.MouseEvent<HTMLDivElement>) => void;
   sortDirection: false | 'asc' | 'desc';
 };
+
+/**
+ * Defines a column's visibility capabilities and current state.
+ * Used to hide columns from the table.
+ */
+export type VisibilityCapability = {
+  canHide: boolean;
+  isVisible: boolean;
+};

--- a/javascript/packages/core/components/table/types/table-types.ts
+++ b/javascript/packages/core/components/table/types/table-types.ts
@@ -193,6 +193,10 @@ export type SortingState = Array<{
   desc: boolean;
 }>;
 
+export type ColumnOrderState = string[];
+
+export type ColumnVisibilityState = Record<string, boolean>;
+
 /**
  * Table state containing aspects of table behavior.
  */
@@ -205,6 +209,10 @@ export type TableState = {
   pagination: PaginationState;
   /** Sorting state */
   sorting: SortingState;
+  /** Column order state */
+  columnOrder: ColumnOrderState;
+  /** Column visibility state */
+  columnVisibility: ColumnVisibilityState;
 };
 
 /**
@@ -219,4 +227,10 @@ export type ControlledTableState = TableState & {
   setColumnFilters: (updater: ColumnFilter[] | ((old: ColumnFilter[]) => ColumnFilter[])) => void;
   setPagination: (updater: PaginationState | ((old: PaginationState) => PaginationState)) => void;
   setSorting: (updater: SortingState | ((old: SortingState) => SortingState)) => void;
+  setColumnOrder: (
+    updater: ColumnOrderState | ((old: ColumnOrderState) => ColumnOrderState)
+  ) => void;
+  setColumnVisibility: (
+    updater: ColumnVisibilityState | ((old: ColumnVisibilityState) => ColumnVisibilityState)
+  ) => void;
 };

--- a/javascript/packages/core/components/table/utils/__fixtures__/tanstack-builders.ts
+++ b/javascript/packages/core/components/table/utils/__fixtures__/tanstack-builders.ts
@@ -11,6 +11,8 @@ export const getTanstackColumn = (overrides?: {
   sortDirection?: false | 'asc' | 'desc';
   canFilter?: boolean;
   filterValue?: string;
+  canHide?: boolean;
+  isVisible?: boolean;
   columnConfig?: Partial<ColumnConfig<TableData>>;
 }): Column<TableData, unknown> =>
   ({
@@ -28,5 +30,7 @@ export const getTanstackColumn = (overrides?: {
     getCanFilter: vi.fn(() => overrides?.canFilter ?? true),
     getFilterValue: vi.fn(() => overrides?.filterValue ?? ''),
     setFilterValue: vi.fn(),
+    getCanHide: vi.fn(() => overrides?.canHide ?? true),
+    getIsVisible: vi.fn(() => overrides?.isVisible ?? true),
     getContext: vi.fn(() => ({})),
   }) as unknown as Column<TableData, unknown>;

--- a/javascript/packages/core/components/table/utils/compose-table-state.ts
+++ b/javascript/packages/core/components/table/utils/compose-table-state.ts
@@ -5,6 +5,8 @@ const STATE_NAME_TO_STATE_SETTER_NAME = {
   columnFilters: 'setColumnFilters',
   pagination: 'setPagination',
   sorting: 'setSorting',
+  columnOrder: 'setColumnOrder',
+  columnVisibility: 'setColumnVisibility',
 } as const;
 
 /**

--- a/javascript/packages/core/components/table/utils/transform-columns.ts
+++ b/javascript/packages/core/components/table/utils/transform-columns.ts
@@ -6,6 +6,7 @@ import type {
   ColumnRenderState,
   FilteringCapability,
   SortingCapability,
+  VisibilityCapability,
 } from '#core/components/table/types/column-types';
 import type { TableData } from '#core/components/table/types/data-types';
 
@@ -14,7 +15,7 @@ import type { TableData } from '#core/components/table/types/data-types';
  */
 export function transformColumns<T extends TableData = TableData>(
   columns: Column<T, unknown>[]
-): Array<ColumnRenderState<T> & FilteringCapability & SortingCapability> {
+): Array<ColumnRenderState<T> & FilteringCapability & SortingCapability & VisibilityCapability> {
   return columns.map((column) => {
     const columnConfig = column.columnDef.meta as ColumnConfig<T>;
     const label = columnConfig.label ?? column.id;
@@ -31,6 +32,9 @@ export function transformColumns<T extends TableData = TableData>(
       canSort: column.getCanSort(),
       onToggleSort: column.getToggleSortingHandler() ?? (() => undefined),
       sortDirection: column.getIsSorted(),
+
+      canHide: column.getCanHide(),
+      isVisible: column.getIsVisible(),
     };
   });
 }

--- a/javascript/packages/core/vitest.config.ts
+++ b/javascript/packages/core/vitest.config.ts
@@ -11,5 +11,21 @@ export default defineConfig({
     env: {
       TZ: 'UTC', // Force UTC timezone for all tests
     },
+    deps: {
+      optimizer: {
+        web: {
+          enabled: true,
+          // BaseUI dnd-list appears to be bundled incorrectly according to vitest's
+          // expectations. This is a workaround recommended by vite maintainers.
+          //
+          // Why this is only needed in test environment—vitest and vite bundle dependencies differently
+          // https://github.com/vitest-dev/vitest/discussions/3221#discussioncomment-5675350
+
+          // Proposed, and working solution:
+          // https://github.com/vitest-dev/vitest/issues/4007#issuecomment-1691368010
+          include: ['baseui/dnd-list'],
+        },
+      },
+    },
   },
 });


### PR DESCRIPTION
Implement drag-and-drop column reordering and visibility controls for customizable table layouts. This replaces static column structure withconfigurable system that persists column order and visibility preferences in localStorage.

When integrating BaseUI dnd-list for reordering interactions, tests leveraging Table component began failing with require() of ES Module error message. This only occurs in vitest environment and not vite environment due to differences in module dependencies resolution. Vitest dependency optimization enables proper module resolution during testing without affecting browser functionality.

Integration with BaseUI dnd-list requires -1 as special identifier for visibility toggle operations.

MA Studio disallows users from relocating the first column, since it's reserved for unique identifying information (i.e., name). To manage this, the column configuration component & utility offset moved column indices by one, since the unmoveable first column still reserves the first index in the column order list.

https://github.com/user-attachments/assets/0341448e-17fc-49a8-b24b-1f2afaf4ae3b

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
