### PR TITLE
Implement cell tooltip filtering

### DIFF
--- a/javascript/packages/core/components/table/__fixtures__/column-factory.ts
+++ b/javascript/packages/core/components/table/__fixtures__/column-factory.ts
@@ -1,0 +1,38 @@
+import { merge } from 'lodash';
+
+import type { DeepPartial } from '#core/types/utility-types';
+import type { ColumnConfig } from '../types/column-types';
+
+/**
+ * Factory for creating ColumnConfig test fixtures.
+ * Provides minimal required properties for testing with sensible defaults.
+ *
+ * @param base - Partial object shared across all test fixtures for a test suite
+ * @returns Function that generates a complete column configuration using overrides.
+ *
+ * @example
+ * ```typescript
+ * // Basic usage
+ * const buildColumn = buildColumnFactory();
+ * const column = buildColumn({ id: 'name', label: 'Name' });
+ *
+ * // With base configuration for test suite
+ * const buildTooltipColumn = buildColumnFactory({
+ *   tooltip: { action: 'filter' }
+ * });
+ * const nameColumn = buildTooltipColumn({
+ *   id: 'metadata.name',
+ *   tooltip: { content: 'Click to filter by name' }
+ * });
+ * ```
+ */
+export const buildColumnFactory = (base: DeepPartial<ColumnConfig> = {}) => {
+  return (overrides: DeepPartial<ColumnConfig> = {}): ColumnConfig => {
+    const required: ColumnConfig = {
+      id: 'test-column',
+      label: 'Test Column',
+    };
+
+    return merge({}, required, base, overrides);
+  };
+};

--- a/javascript/packages/core/components/table/__fixtures__/table-test-helpers.ts
+++ b/javascript/packages/core/components/table/__fixtures__/table-test-helpers.ts
@@ -39,3 +39,12 @@ export function expectTableHeaders(options: { dataColumns: number; hasConfigButt
 
   expect(screen.getAllByRole('columnheader')).toHaveLength(expectedCount);
 }
+
+/**
+ * Helper to assert expected row count, accounting for table structure.
+ */
+export function expectTableRows(options: { dataRows: number }) {
+  const expectedCount = options.dataRows + 1; // Header row
+
+  expect(screen.getAllByRole('row')).toHaveLength(expectedCount);
+}

--- a/javascript/packages/core/components/table/__tests__/table.test.tsx
+++ b/javascript/packages/core/components/table/__tests__/table.test.tsx
@@ -13,6 +13,7 @@ import {
   buildTableColumns,
   buildTableData,
   expectTableHeaders,
+  expectTableRows,
 } from '../__fixtures__/table-test-helpers';
 import { Table } from '../table';
 
@@ -1372,6 +1373,53 @@ describe('Table', () => {
 
       const configButton = screen.getByTitle('Configure columns');
       expect(configButton).toBeInTheDocument();
+    });
+  });
+
+  describe('tooltip filter integration', () => {
+    it('changes displayed table data when tooltip filter is applied', async () => {
+      const user = userEvent.setup();
+      const testData = [
+        { id: '1', name: 'Alice Johnson', department: 'Engineering' },
+        { id: '2', name: 'Bob Smith', department: 'Marketing' },
+        { id: '3', name: 'Carol Davis', department: 'Engineering' },
+      ];
+
+      const columns = [
+        {
+          id: 'name',
+          label: 'Name',
+          tooltip: {
+            content: 'Click to filter by this name',
+            action: 'filter' as const,
+          },
+        },
+        { id: 'department', label: 'Department' },
+      ];
+
+      render(
+        <Table data={testData} columns={columns} />,
+        buildWrapper([
+          getBaseProviderWrapper(),
+          getInterpolationProviderWrapper(),
+          getRouterWrapper(),
+          getIconProviderWrapper({
+            icons: {
+              chevronRight: () => <div>Chevron Right</div>,
+            },
+          }),
+        ])
+      );
+
+      expectTableRows({ dataRows: 3 });
+      await user.hover(screen.getByText('Alice Johnson'));
+      const tooltip = await screen.findByText('Click to filter by this name');
+      await user.click(tooltip);
+
+      await waitFor(() => {
+        expectTableRows({ dataRows: 1 });
+        expect(screen.getByRole('row', { name: 'Alice Johnson Engineering' })).toBeInTheDocument();
+      });
     });
   });
 });

--- a/javascript/packages/core/components/table/components/table-cell/__tests__/table-cell.test.tsx
+++ b/javascript/packages/core/components/table/components/table-cell/__tests__/table-cell.test.tsx
@@ -1,6 +1,11 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
 
+import { buildColumnFactory } from '#core/components/table/__fixtures__/column-factory';
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
+import { getIconProviderWrapper } from '#core/test/wrappers/get-icon-provider-wrapper';
 import { getInterpolationProviderWrapper } from '#core/test/wrappers/get-interpolation-provider-wrapper';
 import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
 import { TableCell } from '../table-cell';
@@ -42,5 +47,136 @@ describe('TableCell', () => {
       'href',
       'https://Jane Smith.com'
     );
+  });
+
+  describe('tooltip functionality', () => {
+    const mockSetColumnFilterValue = vi.fn();
+    const buildColumn = buildColumnFactory();
+
+    const defaultProps = {
+      record: { id: 1, name: 'Test Record' },
+      value: 'test-value',
+      columnFilterValue: undefined,
+      setColumnFilterValue: mockSetColumnFilterValue,
+    };
+
+    beforeEach(() => {
+      mockSetColumnFilterValue.mockClear();
+    });
+
+    it('renders cell without tooltip when column has no tooltip config', () => {
+      const column = buildColumn({ id: 'basic-column', label: 'Basic Column' });
+
+      render(
+        <TableCell {...defaultProps} column={column} />,
+        buildWrapper([getInterpolationProviderWrapper(), getRouterWrapper()])
+      );
+
+      expect(screen.getByText('test-value')).toBeInTheDocument();
+      expect(screen.queryByTestId('tooltip-hover-container')).not.toBeInTheDocument();
+    });
+
+    it('renders cell with tooltip when column has tooltip config', () => {
+      const column = buildColumn({
+        id: 'tooltip-column',
+        label: 'Tooltip Column',
+        tooltip: {
+          content: 'Click to filter by this value',
+          action: 'filter',
+        },
+      });
+
+      render(
+        <TableCell {...defaultProps} column={column} />,
+        buildWrapper([
+          getBaseProviderWrapper(),
+          getInterpolationProviderWrapper(),
+          getRouterWrapper(),
+        ])
+      );
+
+      expect(screen.getByText('test-value')).toBeInTheDocument();
+      expect(screen.getByTestId('tooltip-hover-container')).toBeInTheDocument();
+    });
+
+    it('shows tooltip content on hover', async () => {
+      const user = userEvent.setup();
+      const column = buildColumn({
+        tooltip: {
+          content: 'Click to filter by this value',
+          action: 'filter',
+        },
+      });
+
+      render(
+        <TableCell {...defaultProps} column={column} />,
+        buildWrapper([
+          getBaseProviderWrapper(),
+          getInterpolationProviderWrapper(),
+          getRouterWrapper(),
+        ])
+      );
+
+      await user.hover(screen.getByText('test-value'));
+      await screen.findByText('Click to filter by this value');
+    });
+
+    it('applies filter when tooltip is clicked', async () => {
+      const user = userEvent.setup();
+      const column = buildColumn({
+        id: 'filter-column',
+        tooltip: {
+          content: 'Click to filter by this value',
+          action: 'filter',
+        },
+      });
+
+      render(
+        <TableCell {...defaultProps} column={column} />,
+        buildWrapper([
+          getBaseProviderWrapper(),
+          getInterpolationProviderWrapper(),
+          getIconProviderWrapper({
+            icons: {
+              chevronRight: () => <div>Chevron Right</div>,
+            },
+          }),
+          getRouterWrapper(),
+        ])
+      );
+
+      await user.hover(screen.getByText('test-value'));
+      const tooltipContent = await screen.findByText('Click to filter by this value');
+      await user.click(tooltipContent);
+
+      expect(mockSetColumnFilterValue).toHaveBeenCalledWith(['test-value']);
+    });
+
+    it('hides tooltip when same filter is already applied', () => {
+      const column = buildColumn({
+        id: 'existing-filter-column',
+        tooltip: {
+          content: 'Click to filter by this value',
+          action: 'filter',
+        },
+      });
+
+      const propsWithExistingFilter = {
+        ...defaultProps,
+        columnFilterValue: ['test-value'],
+      };
+
+      render(
+        <TableCell {...propsWithExistingFilter} column={column} />,
+        buildWrapper([
+          getBaseProviderWrapper(),
+          getInterpolationProviderWrapper(),
+          getRouterWrapper(),
+        ])
+      );
+
+      expect(screen.getByText('test-value')).toBeInTheDocument();
+      expect(screen.queryByTestId('tooltip-hover-container')).not.toBeInTheDocument();
+    });
   });
 });

--- a/javascript/packages/core/components/table/components/table-cell/table-cell.tsx
+++ b/javascript/packages/core/components/table/components/table-cell/table-cell.tsx
@@ -1,17 +1,50 @@
+import { CellTooltipContentRenderer } from '#core/components/cell/components/tooltip/cell-tooltip-content-renderer';
+import { CellTooltipWrapper } from '#core/components/cell/components/tooltip/cell-tooltip-wrapper';
+import { TooltipHOCProps } from '#core/components/cell/components/tooltip/types';
 import { useGetCellRenderer } from '#core/components/cell/use-get-cell-renderer';
 import { useInterpolationResolver } from '#core/interpolation/use-interpolation-resolver';
+import { isFilterAlreadyApplied } from './utils';
 
-import type { CellRendererProps } from '#core/components/cell/types';
-import type { ColumnConfig } from '#core/components/table/types/column-types';
-import type { TableData } from '#core/components/table/types/data-types';
+import type { TableCellProps } from './types';
 
-export const TableCell = (props: CellRendererProps<TableData, ColumnConfig>) => {
-  const { record, value } = props;
+export const TableCell = (props: TableCellProps) => {
+  const { record, value, columnFilterValue, setColumnFilterValue } = props;
   const resolver = useInterpolationResolver();
   const column = resolver(props.column, { row: record });
 
   const getCellRenderer = useGetCellRenderer();
   const ColumnRenderer = getCellRenderer({ column, record, value });
 
-  return <ColumnRenderer column={column} record={record} value={value} />;
+  const renderedCell = <ColumnRenderer column={column} record={record} value={value} />;
+
+  if (column.tooltip) {
+    const { action } = column.tooltip;
+
+    if (action === 'filter' && isFilterAlreadyApplied(columnFilterValue, value)) {
+      return renderedCell;
+    }
+
+    const actionHandler = () => {
+      if (action === 'filter' && setColumnFilterValue) {
+        setColumnFilterValue([value]);
+      }
+    };
+
+    return (
+      <CellTooltipWrapper
+        actionHandler={actionHandler}
+        content={
+          <CellTooltipContentRenderer
+            column={column as TooltipHOCProps<unknown>['column']}
+            record={record}
+            value={value}
+          />
+        }
+      >
+        {renderedCell}
+      </CellTooltipWrapper>
+    );
+  }
+
+  return renderedCell;
 };

--- a/javascript/packages/core/components/table/components/table-cell/types.ts
+++ b/javascript/packages/core/components/table/components/table-cell/types.ts
@@ -1,0 +1,8 @@
+import type { CellRendererProps } from '#core/components/cell/types';
+import type { ColumnConfig } from '#core/components/table/types/column-types';
+import type { TableData } from '#core/components/table/types/data-types';
+
+export interface TableCellProps extends CellRendererProps<TableData, ColumnConfig> {
+  columnFilterValue?: unknown;
+  setColumnFilterValue?: (value: unknown) => void;
+}

--- a/javascript/packages/core/components/table/components/table-cell/utils.ts
+++ b/javascript/packages/core/components/table/components/table-cell/utils.ts
@@ -1,0 +1,8 @@
+export function isFilterAlreadyApplied(currentColumnFilter: unknown, cellValue: unknown): boolean {
+  if (!currentColumnFilter) return false;
+
+  if (Array.isArray(currentColumnFilter)) {
+    return currentColumnFilter.length === 1 && currentColumnFilter[0] === cellValue;
+  }
+  return currentColumnFilter === cellValue;
+}

--- a/javascript/packages/core/components/table/hooks/__tests__/use-column-transformer.test.ts
+++ b/javascript/packages/core/components/table/hooks/__tests__/use-column-transformer.test.ts
@@ -150,6 +150,8 @@ describe('useColumnTransformer', () => {
         columnDef: {
           meta: { id: 'name', label: 'Name', accessor: 'name' },
         },
+        getFilterValue: () => 'John Doe',
+        setFilterValue: vi.fn(),
       },
       row: {
         original: { name: 'John Doe' },

--- a/javascript/packages/core/components/table/hooks/use-column-transformer.tsx
+++ b/javascript/packages/core/components/table/hooks/use-column-transformer.tsx
@@ -51,6 +51,8 @@ export function useColumnTransformer<T extends TableData = TableData>(
             column={props.column.columnDef.meta as ColumnConfig}
             record={props.row.original as object}
             value={props.getValue()}
+            columnFilterValue={props.column.getFilterValue()}
+            setColumnFilterValue={props.column.setFilterValue}
           />
         ),
         filterFn: filterHook.buildTableFilterFn(),

--- a/javascript/packages/core/config/entities/pipeline/list.ts
+++ b/javascript/packages/core/config/entities/pipeline/list.ts
@@ -8,6 +8,10 @@ export const PIPELINE_CELL_CONFIG: ColumnConfig[] = [
     id: 'metadata.name',
     label: 'Name',
     url: '/${studio.projectId}/pipelines/${data.metadata.name}',
+    tooltip: {
+      content: 'Click to filter by this pipeline name',
+      action: 'filter',
+    },
   },
   { id: 'metadata.creationTimestamp.seconds', label: 'Created', type: CellType.DATE },
   {


### PR DESCRIPTION
Enable users to filter table data by clicking on cell tooltips.
Tooltips appear on cells with column.tooltip configuration and
apply column-specific filters when clicked.

Smart tooltip behavior hides filter actions when the same filter
is already applied, preventing redundant user interactions.

When passing column to CellTooltipContentRenderer, I couldn't 
find a way to avoid casting column to expect column props type. 
To me, it seems that the column.tooltip conditional should be sufficient.

https://github.com/user-attachments/assets/a637cdf6-4d98-4be0-8253-b7f684381979

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
