### PR TITLE
Implement sticky table columns for horizontal scroll UX

### DIFF
--- a/javascript/packages/core/components/table/__tests__/table.test.tsx
+++ b/javascript/packages/core/components/table/__tests__/table.test.tsx
@@ -1422,4 +1422,31 @@ describe('Table', () => {
       });
     });
   });
+
+  describe('sticky sides integration', () => {
+    const testData = buildTableData(3, 4);
+    const testColumns = buildTableColumns(4);
+
+    it('applies sticky positioning to columns when enableStickySides is true', () => {
+      render(
+        <Table data={testData} columns={testColumns} enableStickySides={true} />,
+        buildWrapper([getInterpolationProviderWrapper(), getRouterWrapper()])
+      );
+
+      // Check for sticky column test IDs that the withStickySides HOC adds
+      // Should have sticky cells for both header and data rows in first column
+      const stickyCells = screen.getAllByTestId('sticky-cell-left-sticky');
+      expect(stickyCells.length).toBeGreaterThan(0);
+    });
+
+    it('does not apply sticky positioning when enableStickySides is false', () => {
+      render(
+        <Table data={testData} columns={testColumns} enableStickySides={false} />,
+        buildWrapper([getInterpolationProviderWrapper(), getRouterWrapper()])
+      );
+
+      // Should not have sticky cell test IDs
+      expect(screen.queryByTestId('sticky-cell-left-sticky')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/javascript/packages/core/components/table/components/table-body/table-body.tsx
+++ b/javascript/packages/core/components/table/components/table-body/table-body.tsx
@@ -4,20 +4,34 @@ import { StyledTableBodyCell, StyledTableBodyRow } from 'baseui/table-semantic';
 import { StyledTableBody } from '#core/components/table/styled-components';
 import { getSelectionColumnCellStyles } from '../table-selection-column/styled-components';
 import { TableSelectionColumn } from '../table-selection-column/table-selection-column';
+import { withStickySides } from '../with-sticky-sides/with-sticky-sides';
 
 import type { TableData } from '#core/components/table/types/data-types';
 import type { TableBodyProps } from './types';
 
+const StickySidesTableBodyRow = withStickySides(StyledTableBodyRow);
+
 export const TableBody = <T extends TableData = TableData>({
   rows,
   enableRowSelection,
+  enableStickySides,
+  scrollRatio,
 }: TableBodyProps<T>) => {
   const [css, theme] = useStyletron();
+
+  const lastColumnIndex = rows[0].cells.length + 1;
 
   return (
     <StyledTableBody>
       {rows.map((row) => (
-        <StyledTableBodyRow key={row.id}>
+        <StickySidesTableBodyRow
+          key={row.id}
+          enableStickySides={enableStickySides}
+          enableRowSelection={enableRowSelection}
+          lastColumnIndex={lastColumnIndex}
+          scrollRatio={scrollRatio}
+          role="row"
+        >
           {enableRowSelection && (
             <StyledTableBodyCell className={css(getSelectionColumnCellStyles(theme))}>
               <TableSelectionColumn
@@ -34,7 +48,7 @@ export const TableBody = <T extends TableData = TableData>({
 
           {/* Placeholder action cell to align with column configuration button */}
           <StyledTableBodyCell />
-        </StyledTableBodyRow>
+        </StickySidesTableBodyRow>
       ))}
     </StyledTableBody>
   );

--- a/javascript/packages/core/components/table/components/table-body/types.ts
+++ b/javascript/packages/core/components/table/components/table-body/types.ts
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import type { SelectableCapability } from '#core/components/table/types/column-types';
 import type { TableData } from '#core/components/table/types/data-types';
+import type { WithStickySidesProps } from '../with-sticky-sides/types';
 
 export type TableCell<_T extends TableData = TableData> = {
   id: string;
@@ -14,5 +15,5 @@ export type TableRow<T extends TableData = TableData> = {
 
 export type TableBodyProps<T extends TableData = TableData> = {
   rows: TableRow<T>[];
-  enableRowSelection?: boolean;
-};
+  enableRowSelection: boolean;
+} & Pick<WithStickySidesProps, 'enableStickySides' | 'scrollRatio'>;

--- a/javascript/packages/core/components/table/components/table-header/styled-components.ts
+++ b/javascript/packages/core/components/table/components/table-header/styled-components.ts
@@ -4,12 +4,12 @@ import {
   StyledTableHeadCellSortable as BaseStyledTableHeadCellSortable,
 } from 'baseui/table-semantic';
 
-// Unset z-index to prevent interference with popovers and overlays
-export const StyledTableHeadCell = withStyle(BaseStyledTableHeadCell, {
-  zIndex: 'unset',
-});
+export const StyledTableHeadCell = withStyle(BaseStyledTableHeadCell, () => ({
+  zIndex: 'unset', // Unset z-index to prevent interference with popovers and overlays
+  position: 'inherit', // Position inherit to allow for sticky columns
+}));
 
-// Unset z-index to prevent interference with popovers and overlays
-export const StyledSortableTableHeadCell = withStyle(BaseStyledTableHeadCellSortable, {
-  zIndex: 'unset',
-});
+export const StyledSortableTableHeadCell = withStyle(BaseStyledTableHeadCellSortable, () => ({
+  zIndex: 'unset', // Unset z-index to prevent interference with popovers and overlays
+  position: 'inherit', // Position inherit to allow for sticky columns
+}));

--- a/javascript/packages/core/components/table/components/table-header/table-header.tsx
+++ b/javascript/packages/core/components/table/components/table-header/table-header.tsx
@@ -3,12 +3,15 @@ import { StyledTableHead, StyledTableHeadRow } from 'baseui/table-semantic';
 
 import { getSelectionColumnCellStyles } from '../table-selection-column/styled-components';
 import { TableSelectionColumn } from '../table-selection-column/table-selection-column';
+import { withStickySides } from '../with-sticky-sides/with-sticky-sides';
 import { TableColumnConfigurationButton } from './components/table-column-configuration-button/table-column-configuration-button';
 import { TableSortIcon } from './components/table-sort-icon/table-sort-icon';
 import { StyledSortableTableHeadCell, StyledTableHeadCell } from './styled-components';
 
 import type { TableData } from '#core/components/table/types/data-types';
 import type { TableHeaderProps } from './types';
+
+const StickySidesTableHeadRow = withStickySides(StyledTableHeadRow);
 
 export const TableHeader = <T extends TableData = TableData>({
   columns,
@@ -17,11 +20,20 @@ export const TableHeader = <T extends TableData = TableData>({
   enableRowSelection,
   isSelected,
   onToggleSelection,
+  enableStickySides,
+  scrollRatio,
 }: TableHeaderProps<T>) => {
   const [css, theme] = useStyletron();
+
   return (
     <StyledTableHead>
-      <StyledTableHeadRow>
+      <StickySidesTableHeadRow
+        enableStickySides={enableStickySides}
+        enableRowSelection={enableRowSelection}
+        lastColumnIndex={columns.filter((column) => column.isVisible).length + 1}
+        scrollRatio={scrollRatio}
+        role="header"
+      >
         {enableRowSelection && (
           <StyledTableHeadCell
             role="columnheader"
@@ -74,7 +86,7 @@ export const TableHeader = <T extends TableData = TableData>({
             </div>
           </StyledTableHeadCell>
         )}
-      </StyledTableHeadRow>
+      </StickySidesTableHeadRow>
     </StyledTableHead>
   );
 };

--- a/javascript/packages/core/components/table/components/table-header/types.ts
+++ b/javascript/packages/core/components/table/components/table-header/types.ts
@@ -6,10 +6,12 @@ import type {
 } from '#core/components/table/types/column-types';
 import type { TableData } from '#core/components/table/types/data-types';
 import type { ControlledTableState } from '#core/components/table/types/table-types';
+import type { WithStickySidesProps } from '../with-sticky-sides/types';
 
 export type TableHeaderProps<T extends TableData = TableData> = {
   columns: Array<ColumnRenderState<T> & SortingCapability & VisibilityCapability>;
   setColumnOrder: ControlledTableState['setColumnOrder'];
   setColumnVisibility: ControlledTableState['setColumnVisibility'];
-  enableRowSelection?: boolean;
-} & Omit<SelectableCapability, 'canSelect'>;
+  enableRowSelection: boolean;
+} & Omit<SelectableCapability, 'canSelect'> &
+  Pick<WithStickySidesProps, 'enableStickySides' | 'scrollRatio'>;

--- a/javascript/packages/core/components/table/components/with-sticky-sides/__tests__/build-shadow-styles.test.ts
+++ b/javascript/packages/core/components/table/components/with-sticky-sides/__tests__/build-shadow-styles.test.ts
@@ -1,0 +1,34 @@
+import { buildShadowStyles } from '../build-shadow-styles';
+
+describe('buildShadowStyles', () => {
+  it('positions right shadow correctly', () => {
+    const result = buildShadowStyles('right', 0.5);
+
+    expect(result['::before']).toMatchObject({
+      right: '-7px',
+      left: 'auto',
+    });
+  });
+
+  it('positions left shadow correctly', () => {
+    const result = buildShadowStyles('left', 0.3);
+
+    expect(result['::before']).toMatchObject({
+      right: 'auto',
+      left: '-7px',
+    });
+  });
+
+  it('handles no scroll state (opacity 0)', () => {
+    const result = buildShadowStyles('right', -1);
+
+    expect(result['::before']?.opacity).toBe(0);
+  });
+
+  it('calculates opacity based on scroll ratio', () => {
+    expect(buildShadowStyles('right', 0)['::before']?.opacity).toBe(0);
+    expect(buildShadowStyles('right', 1)['::before']?.opacity).toBe(1);
+    expect(buildShadowStyles('left', 0)['::before']?.opacity).toBe(1);
+    expect(buildShadowStyles('left', 1)['::before']?.opacity).toBe(0);
+  });
+});

--- a/javascript/packages/core/components/table/components/with-sticky-sides/__tests__/get-table-sticky-configs.test.ts
+++ b/javascript/packages/core/components/table/components/with-sticky-sides/__tests__/get-table-sticky-configs.test.ts
@@ -1,0 +1,22 @@
+import { getTableStickyConfigs } from '../get-table-sticky-configs';
+
+describe('getTableStickyConfigs', () => {
+  it('generates config for selection + first data column', () => {
+    const result = getTableStickyConfigs(true, 5);
+
+    expect(result).toEqual({
+      0: { stickySide: 'left', position: 0, shadowSide: 'none' },
+      1: { stickySide: 'left', position: 56, shadowSide: 'right' },
+      5: { stickySide: 'right', position: 0, shadowSide: 'left' },
+    });
+  });
+
+  it('generates config for first data column only', () => {
+    const result = getTableStickyConfigs(false, 3);
+
+    expect(result).toEqual({
+      1: { stickySide: 'left', position: 0, shadowSide: 'right' },
+      3: { stickySide: 'right', position: 0, shadowSide: 'left' },
+    });
+  });
+});

--- a/javascript/packages/core/components/table/components/with-sticky-sides/__tests__/with-sticky-sides.test.tsx
+++ b/javascript/packages/core/components/table/components/with-sticky-sides/__tests__/with-sticky-sides.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { withStickySides } from '../with-sticky-sides';
+
+describe('withStickySides integration tests', () => {
+  const MockRow = ({
+    children,
+    ...props
+  }: { children: React.ReactNode } & Record<string, unknown>) => <tr {...props}>{children}</tr>;
+
+  const StickySidesRow = withStickySides(MockRow);
+
+  it('creates no sticky cells when enableStickySides is false', () => {
+    render(
+      <StickySidesRow
+        enableStickySides={false}
+        enableRowSelection={true}
+        lastColumnIndex={3}
+        scrollRatio={0}
+        role="row"
+      >
+        <td>Cell 1</td>
+        <td>Cell 2</td>
+        <td>Cell 3</td>
+        <td>Cell 4</td>
+      </StickySidesRow>
+    );
+
+    expect(screen.queryByTestId(/^sticky-cell-/)).not.toBeInTheDocument();
+  });
+
+  it('creates sticky columns for table with row selection', () => {
+    render(
+      <StickySidesRow
+        enableStickySides={true}
+        enableRowSelection={true}
+        lastColumnIndex={3}
+        scrollRatio={0}
+        role="row"
+      >
+        <td>Selection</td>
+        <td>First Data</td>
+        <td>Regular</td>
+        <td>Config</td>
+      </StickySidesRow>
+    );
+
+    // Should have sticky: selection (0) + first data (1) + config (3)
+    expect(screen.getAllByTestId('sticky-cell-left-sticky')).toHaveLength(2);
+    expect(screen.getAllByTestId('sticky-cell-right-sticky')).toHaveLength(1);
+  });
+
+  it('creates sticky columns for table without row selection', () => {
+    render(
+      <StickySidesRow
+        enableStickySides={true}
+        enableRowSelection={false}
+        lastColumnIndex={2}
+        scrollRatio={0}
+        role="row"
+      >
+        <td>First Data</td>
+        <td>Regular</td>
+        <td>Config</td>
+      </StickySidesRow>
+    );
+
+    // Should have sticky: first data (0) + config (2)
+    expect(screen.getAllByTestId('sticky-cell-left-sticky')).toHaveLength(1);
+    expect(screen.getAllByTestId('sticky-cell-right-sticky')).toHaveLength(1);
+  });
+
+  it('preserves original child content', () => {
+    render(
+      <StickySidesRow
+        enableStickySides={true}
+        enableRowSelection={true}
+        lastColumnIndex={3}
+        scrollRatio={0}
+        role="row"
+      >
+        <td>Checkbox Column</td>
+        <td>Name Column</td>
+        <td>Status Column</td>
+        <td>Config Button</td>
+      </StickySidesRow>
+    );
+
+    expect(screen.getByText('Checkbox Column')).toBeInTheDocument();
+    expect(screen.getByText('Name Column')).toBeInTheDocument();
+    expect(screen.getByText('Status Column')).toBeInTheDocument();
+    expect(screen.getByText('Config Button')).toBeInTheDocument();
+  });
+});

--- a/javascript/packages/core/components/table/components/with-sticky-sides/build-shadow-styles.ts
+++ b/javascript/packages/core/components/table/components/with-sticky-sides/build-shadow-styles.ts
@@ -1,0 +1,58 @@
+import type { StyleObject } from 'styletron-standard';
+import type { ShadowSide } from './types';
+
+const SHADOW_CONFIGS = {
+  left: {
+    right: 'auto',
+    left: '-7px',
+    getOpacity: (scrollRatio: number) => (scrollRatio === -1 ? 0 : 1 - scrollRatio),
+  },
+  right: {
+    right: '-7px',
+    left: 'auto',
+    getOpacity: (scrollRatio: number) => (scrollRatio === -1 ? 0 : scrollRatio),
+  },
+} as const;
+
+/**
+ * Builds CSS styles for shadow effects on sticky table columns.
+ *
+ * Creates a visual shadow indicator that appears when content is scrolled
+ * off-screen, helping users understand there's more content in that direction.
+ *
+ * Shadow behavior:
+ * - Left shadow: Appears when scrolled right, fades as scroll approaches left edge
+ * - Right shadow: Appears when scrolled left, fades as scroll approaches right edge
+ * - No shadow: Returns empty styles (used for selection column)
+ *
+ * The shadow is implemented as a CSS ::before pseudo-element with:
+ * - 7px width positioned outside the column
+ * - Linear gradient from shadow color to transparent
+ * - Opacity controlled by scroll position (-1 = no scroll, 0-1 = scroll ratio)
+ *
+ * @param shadowSide - Which side should show the shadow ('left', 'right', 'none')
+ * @param scrollRatio - Current scroll position (-1 = no scroll, 0 = start, 1 = end)
+ * @returns Style object with ::before pseudo-element for shadow effect
+ */
+export function buildShadowStyles(
+  shadowSide: ShadowSide,
+  scrollRatio: number
+): { '::before'?: StyleObject } {
+  if (shadowSide === 'none') return {};
+
+  const { getOpacity, ...rest } = SHADOW_CONFIGS[shadowSide];
+
+  return {
+    '::before': {
+      ...rest,
+      content: '" "',
+      position: 'absolute',
+      top: 0,
+      bottom: 0,
+      width: '7px',
+      opacity: Math.ceil(getOpacity(scrollRatio)),
+      transition: 'opacity 0.2s ease',
+      background: `linear-gradient(to ${shadowSide}, rgba(0,0,0, 0.15), rgba(0, 0, 0, 0) 4px)`,
+    },
+  };
+}

--- a/javascript/packages/core/components/table/components/with-sticky-sides/get-table-sticky-configs.ts
+++ b/javascript/packages/core/components/table/components/with-sticky-sides/get-table-sticky-configs.ts
@@ -1,0 +1,61 @@
+import type { StickyColumnConfigs } from './types';
+
+// Measured width of the table selection column (checkbox + padding)
+// This value was determined by measuring the actual rendered selection column
+// If the selection column styling changes, this may need to be updated
+const SELECTION_COLUMN_WIDTH = 56;
+
+/**
+ * Generates sticky column configurations for table rows.
+ *
+ * Determines which columns should be sticky and their positioning based on:
+ * - Whether row selection (checkbox column) is enabled
+ * - The index of the last column for right-side sticking
+ *
+ * When row selection is enabled:
+ * - Column 0 (checkbox) sticks to left at position 0 with no shadow
+ * - Column 1 (first data) sticks to left at position 56px with right shadow
+ * - Last column sticks to right with left shadow
+ *
+ * When row selection is disabled:
+ * - Column 1 (first data) sticks to left at position 0 with right shadow
+ * - Last column sticks to right with left shadow
+ *
+ * @param enableRowSelection - Whether the table has a selection checkbox column
+ * @param lastColumnIndex - Zero-based index of the rightmost column
+ * @returns Configuration object mapping column indices to sticky settings
+ */
+export function getTableStickyConfigs(
+  enableRowSelection: boolean,
+  lastColumnIndex: number
+): StickyColumnConfigs {
+  const configs: StickyColumnConfigs = {};
+
+  if (enableRowSelection) {
+    configs[0] = {
+      stickySide: 'left',
+      position: 0,
+      shadowSide: 'none',
+    };
+
+    configs[1] = {
+      stickySide: 'left',
+      position: SELECTION_COLUMN_WIDTH,
+      shadowSide: 'right',
+    };
+  } else {
+    configs[1] = {
+      stickySide: 'left',
+      position: 0,
+      shadowSide: 'right',
+    };
+  }
+
+  configs[lastColumnIndex] = {
+    stickySide: 'right',
+    position: 0,
+    shadowSide: 'left',
+  };
+
+  return configs;
+}

--- a/javascript/packages/core/components/table/components/with-sticky-sides/types.ts
+++ b/javascript/packages/core/components/table/components/with-sticky-sides/types.ts
@@ -1,0 +1,36 @@
+export interface WithStickySidesProps {
+  enableStickySides: boolean;
+  /** Whether the table has row selection checkboxes (affects column positioning) */
+  enableRowSelection: boolean;
+  /** Zero-based index of the rightmost column (used for right-side sticky positioning) */
+  lastColumnIndex: number;
+  /** Current horizontal scroll ratio (-1 = no scroll, 0 = left edge, 1 = right edge) */
+  scrollRatio: number;
+  /** ARIA role for the wrapped component */
+  role: string;
+  children: React.ReactNode;
+}
+
+/**
+ * Configuration for a single sticky column's positioning and shadow behavior.
+ */
+export interface StickyColumnConfig {
+  stickySide: 'left' | 'right';
+  /** Offset in pixels from the sticky side (accounts for other sticky columns) */
+  position: number;
+  shadowSide: ShadowSide;
+}
+
+/**
+ * Map of column indices to their sticky configurations.
+ */
+export type StickyColumnConfigs = Record<number, StickyColumnConfig>;
+
+/**
+ * Direction for shadow effects on sticky columns.
+ *
+ * - 'left': Shadow when content scrolled off to the left
+ * - 'right': Shadow when content scrolled off to the right
+ * - 'none': No shadow effects (selection column)
+ */
+export type ShadowSide = 'left' | 'right' | 'none';

--- a/javascript/packages/core/components/table/components/with-sticky-sides/with-sticky-sides.tsx
+++ b/javascript/packages/core/components/table/components/with-sticky-sides/with-sticky-sides.tsx
@@ -1,0 +1,78 @@
+import React, { useRef } from 'react';
+import { useStyletron } from 'baseui';
+
+import { useHover } from '#core/hooks/use-hover';
+import { buildShadowStyles } from './build-shadow-styles';
+import { getTableStickyConfigs } from './get-table-sticky-configs';
+
+import type { WithStickySidesProps } from './types';
+
+/**
+ * Higher-Order Component that adds sticky column functionality to table rows.
+ *
+ * Wraps table row components to make specified columns stick to the left/right edges
+ * during horizontal scrolling, with shadow effects to indicate hidden content.
+ *
+ * Automatically handles:
+ * - First column (+ selection column if enabled) sticking to left
+ * - Last column sticking to right
+ * - Shadow effects based on scroll position
+ * - Hover background colors for better UX
+ *
+ * @param Component - The table row component to wrap (typically StyledTableHeadRow or StyledTableBodyRow)
+ * @returns Enhanced component with sticky column behavior
+ */
+export function withStickySides<P extends object>(
+  Component: React.ComponentType<P>
+): React.ComponentType<P & WithStickySidesProps> {
+  return function StickySidesHOC(props: P & WithStickySidesProps) {
+    const {
+      enableStickySides,
+      enableRowSelection,
+      lastColumnIndex,
+      scrollRatio = -1,
+      role,
+      children,
+      ...componentProps
+    } = props;
+
+    const [css, theme] = useStyletron();
+    const hoverContainerRef = useRef<HTMLElement>(null);
+    const isContainerHovered = useHover(hoverContainerRef);
+
+    if (!enableStickySides) {
+      return <Component {...(componentProps as P)}>{children}</Component>;
+    }
+
+    const backgroundColor =
+      isContainerHovered && role === 'row'
+        ? theme.colors.tableStripedBackground
+        : theme.colors.tableHeadBackgroundColor;
+
+    const sharedStickyStyles = {
+      position: 'sticky !important' as 'sticky',
+      backgroundColor: `${backgroundColor} !important`,
+    };
+
+    const stickyConfigs = getTableStickyConfigs(enableRowSelection, lastColumnIndex);
+
+    return (
+      <Component {...(componentProps as P)} ref={hoverContainerRef}>
+        {React.Children.map(children, (child, index) => {
+          const config = stickyConfigs[index];
+          if (!config) return child;
+
+          const stickyStyles = {
+            ...sharedStickyStyles,
+            [config.stickySide]: `${config.position}px !important`,
+          };
+
+          return React.cloneElement(child as React.ReactElement<Record<string, unknown>>, {
+            className: `${css(stickyStyles)} ${css(buildShadowStyles(config.shadowSide, scrollRatio))}`,
+            'data-testid': `sticky-cell-${config.stickySide}-sticky`,
+          });
+        })}
+      </Component>
+    );
+  };
+}

--- a/javascript/packages/core/components/table/styled-components.ts
+++ b/javascript/packages/core/components/table/styled-components.ts
@@ -1,17 +1,9 @@
-import { styled, withStyle } from 'baseui';
+import { withStyle } from 'baseui';
 import {
   StyledTableBody as BaseStyledTableBody,
   StyledTableBodyCell as BaseStyledTableBodyCell,
   StyledTableBodyRow as BaseStyledTableBodyRow,
 } from 'baseui/table-semantic';
-
-export const TableContainer = styled('div', ({ $theme }) => ({
-  overflow: 'auto',
-  position: 'relative',
-  display: 'flex',
-  flexDirection: 'column',
-  gap: $theme.sizing.scale400,
-}));
 
 export const StyledTableBody = withStyle(BaseStyledTableBody, ({ $theme }) => ({
   backgroundColor: $theme.colors.tableHeadBackgroundColor,

--- a/javascript/packages/core/components/table/table.tsx
+++ b/javascript/packages/core/components/table/table.tsx
@@ -5,8 +5,10 @@ import {
   getSortedRowModel,
   useReactTable,
 } from '@tanstack/react-table';
+import { useStyletron } from 'baseui';
 import { StyledTable } from 'baseui/table-semantic';
 
+import { useScrollRatio } from '#core/hooks/use-scroll';
 import { TableActionBar } from './components/table-action-bar/table-action-bar';
 import { transformRows } from './components/table-body/row-transformer';
 import { TableBody } from './components/table-body/table-body';
@@ -16,7 +18,6 @@ import { TableHeader } from './components/table-header/table-header';
 import { TableNoResultsState } from './components/table-no-results-state/table-no-results-state';
 import { useColumnTransformer } from './hooks/use-column-transformer';
 import { TableSelectionProvider } from './plugins/selection/table-selection-provider';
-import { TableContainer } from './styled-components';
 import { applyDefaultProps } from './utils/apply-default-props';
 import { composeTableState } from './utils/compose-table-state';
 import { getTableViewState } from './utils/get-table-view-state';
@@ -28,8 +29,10 @@ import type { TableProps } from './types/table-types';
 export function Table<T extends TableData = TableData>(inputProps: TableProps<T>) {
   const props = applyDefaultProps<T>(inputProps);
   const columns = useColumnTransformer<T>(props.columns);
+  const [css, theme] = useStyletron();
 
   const { state, initialState } = composeTableState(props.state ?? {});
+  const { scrollRatio, tableRef, updateScrollRatio } = useScrollRatio(columns);
 
   const table = useReactTable<T>({
     data: props.data,
@@ -66,16 +69,16 @@ export function Table<T extends TableData = TableData>(inputProps: TableProps<T>
   const transformedColumns = transformColumns(table.getAllLeafColumns());
 
   return (
-    <TableSelectionProvider
-      value={{
-        selectedRows: table.getSelectedRowModel().flatRows.map((row) => row.original),
-        selectionEnabled: props.enableRowSelection,
-        toggleAllRowsSelected: (selected: boolean) => table.toggleAllRowsSelected(selected),
-        getIsAllRowsSelected: () => table.getIsAllRowsSelected(),
-        getIsSomeRowsSelected: () => table.getIsSomeRowsSelected(),
-      }}
-    >
-      <TableContainer>
+    <div className={css({ display: 'flex', flexDirection: 'column', gap: theme.sizing.scale400 })}>
+      <TableSelectionProvider
+        value={{
+          selectedRows: table.getSelectedRowModel().flatRows.map((row) => row.original),
+          selectionEnabled: props.enableRowSelection,
+          toggleAllRowsSelected: (selected: boolean) => table.toggleAllRowsSelected(selected),
+          getIsAllRowsSelected: () => table.getIsAllRowsSelected(),
+          getIsSomeRowsSelected: () => table.getIsSomeRowsSelected(),
+        }}
+      >
         <TableActionBar
           globalFilter={table.getState().globalFilter as string}
           setGlobalFilter={table.setGlobalFilter}
@@ -87,41 +90,50 @@ export function Table<T extends TableData = TableData>(inputProps: TableProps<T>
           filterableColumns={transformedColumns.filter((column) => column.canFilter)}
         />
 
-        <StyledTable>
-          {viewState === 'loading' && <props.loadingView />}
+        <div
+          className={css({ overflow: 'auto', position: 'relative' })}
+          ref={tableRef as React.RefObject<HTMLDivElement>}
+          onScroll={updateScrollRatio}
+        >
+          <StyledTable>
+            {viewState === 'loading' && <props.loadingView />}
 
-          {viewState === 'error' && <TableErrorState error={props.error!} />}
+            {viewState === 'error' && <TableErrorState error={props.error!} />}
 
-          {viewState === 'empty' && <TableEmptyState emptyState={props.emptyState} />}
+            {viewState === 'empty' && <TableEmptyState emptyState={props.emptyState} />}
 
-          {viewState === 'filtered-empty' && (
-            <TableNoResultsState
-              clearFilters={() => {
-                table.setGlobalFilter('');
-                table.setColumnFilters([]);
-              }}
-            />
-          )}
+            {viewState === 'filtered-empty' && (
+              <TableNoResultsState
+                clearFilters={() => {
+                  table.setGlobalFilter('');
+                  table.setColumnFilters([]);
+                }}
+              />
+            )}
 
-          {viewState !== 'error' && (
-            <TableHeader<T>
-              columns={transformedColumns}
-              setColumnOrder={table.setColumnOrder}
-              setColumnVisibility={table.setColumnVisibility}
-              enableRowSelection={props.enableRowSelection}
-              isSelected={table.getIsAllRowsSelected()}
-              onToggleSelection={(selected: boolean) => table.toggleAllRowsSelected(selected)}
-            />
-          )}
+            {viewState !== 'error' && (
+              <TableHeader<T>
+                columns={transformedColumns}
+                setColumnOrder={table.setColumnOrder}
+                setColumnVisibility={table.setColumnVisibility}
+                enableRowSelection={props.enableRowSelection}
+                isSelected={table.getIsAllRowsSelected()}
+                onToggleSelection={(selected: boolean) => table.toggleAllRowsSelected(selected)}
+                enableStickySides={props.enableStickySides}
+                scrollRatio={scrollRatio}
+              />
+            )}
 
-          {viewState === 'ready' && (
-            <TableBody<T>
-              rows={transformRows<T>(table.getRowModel().rows)}
-              enableRowSelection={props.enableRowSelection}
-            />
-          )}
-        </StyledTable>
-
+            {viewState === 'ready' && (
+              <TableBody<T>
+                rows={transformRows<T>(table.getRowModel().rows)}
+                enableRowSelection={props.enableRowSelection}
+                enableStickySides={props.enableStickySides}
+                scrollRatio={scrollRatio}
+              />
+            )}
+          </StyledTable>
+        </div>
         {!props.disablePagination && viewState === 'ready' && (
           <props.pagination
             gotoPage={table.setPageIndex}
@@ -132,7 +144,7 @@ export function Table<T extends TableData = TableData>(inputProps: TableProps<T>
             fetchPlugin={props.fetchPlugin}
           />
         )}
-      </TableContainer>
-    </TableSelectionProvider>
+      </TableSelectionProvider>
+    </div>
   );
 }

--- a/javascript/packages/core/components/table/types/table-types.ts
+++ b/javascript/packages/core/components/table/types/table-types.ts
@@ -159,6 +159,15 @@ export interface TableRequiredFunctionalityProps {
    * @default false
    */
   enableRowSelection: boolean;
+
+  /**
+   * @description
+   * If true, enables sticky column functionality for better horizontal scrolling experience.
+   * First and last columns will remain visible during horizontal scroll.
+   *
+   * @default false
+   */
+  enableStickySides: boolean;
 }
 
 /**

--- a/javascript/packages/core/components/table/utils/apply-default-props.tsx
+++ b/javascript/packages/core/components/table/utils/apply-default-props.tsx
@@ -49,6 +49,7 @@ export function applyDefaultProps<T extends TableData = TableData>(
     state: resolveTableState(props.state, disablePagination, pageSizes),
     pagination: props.pagination ?? TablePagination,
     enableRowSelection: props.enableRowSelection ?? false,
+    enableStickySides: props.enableStickySides ?? false,
   };
 }
 

--- a/javascript/packages/core/components/views/phase-entity-view/entity-table.tsx
+++ b/javascript/packages/core/components/views/phase-entity-view/entity-table.tsx
@@ -34,6 +34,7 @@ export function EntityTable({ service, listViewConfig, tableSettingsId }: Entity
   return (
     <Table
       data={data?.[`${service}List`]?.items ?? []}
+      enableStickySides={true}
       error={error ?? undefined}
       columns={listViewConfig.columns}
       loading={isLoading}

--- a/javascript/packages/core/hooks/__tests__/use-scroll.test.tsx
+++ b/javascript/packages/core/hooks/__tests__/use-scroll.test.tsx
@@ -2,13 +2,6 @@ import { act, renderHook } from '@testing-library/react';
 
 import { useScrollRatio } from '../use-scroll';
 
-// Mock ResizeObserver
-global.ResizeObserver = vi.fn().mockImplementation(() => ({
-  observe: vi.fn(),
-  unobserve: vi.fn(),
-  disconnect: vi.fn(),
-}));
-
 describe('useScrollRatio', () => {
   it('should return -1 initially', () => {
     const { result } = renderHook(() => useScrollRatio([]));

--- a/javascript/packages/core/test-setup.ts
+++ b/javascript/packages/core/test-setup.ts
@@ -23,3 +23,13 @@ const timezoneOffset = new Date().getTimezoneOffset();
 if (timezoneOffset !== 0) {
   console.warn(`⚠️  Expected UTC timezone but got offset: ${timezoneOffset} minutes`);
 }
+
+/**
+ * Mock ResizeObserver for components that use it (like sticky table columns)
+ * JSDOM doesn't provide ResizeObserver, so we need to mock it globally
+ */
+global.ResizeObserver = vi.fn().mockImplementation(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+}));


### PR DESCRIPTION
Add sticky column functionality to table component using Higher-Order Component pattern with scroll-aware shadow indicators and automatic selection column integration.

Users lose context during horizontal scrolling in wide tables, particularly in data-heavy views like entity tables where the leftmost identifying columns and rightmost action columns would disappear off-screen.

The solution takes into account row selection to support maintaining visibility of the checkbox when scrolling. Currently, the architecture is specific to our selectable column, since there is not another MA table use case for sticky sides.

Updated enableRowSelection type to be required for Header and Body -- it is guarnateed by the applyDefaultProps infrastructure.

https://github.com/user-attachments/assets/da4ec30d-173b-4155-b89e-ce166498c90e

https://github.com/user-attachments/assets/a6a5b5ae-888c-40e6-afde-6739d1bafefb

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
