### PR TITLE
Implement expandable table rows

### DIFF
--- a/javascript/app/icons/icons.tsx
+++ b/javascript/app/icons/icons.tsx
@@ -9,6 +9,7 @@ import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import CloseIcon from '@mui/icons-material/Close';
 import CropSquareIcon from '@mui/icons-material/CropSquare';
 import Info from '@mui/icons-material/Info';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardBackspaceIcon from '@mui/icons-material/KeyboardBackspace';
 import Launch from '@mui/icons-material/Launch';
 import SettingsIcon from '@mui/icons-material/Settings';
@@ -23,6 +24,7 @@ export const ICONS = {
   arrowLeft: createMuiIconAdapter(KeyboardBackspaceIcon),
   chartLine: createMuiIconAdapter(ShowChartIcon),
   chevronRight: createMuiIconAdapter(ChevronRightIcon),
+  chevronDown: createMuiIconAdapter(KeyboardArrowDownIcon),
   circleI: createMuiIconAdapter(Info),
   circleX: createMuiIconAdapter(CancelIcon),
   circleCheck: createMuiIconAdapter(CheckCircle),

--- a/javascript/packages/core/components/table/__tests__/table.test.tsx
+++ b/javascript/packages/core/components/table/__tests__/table.test.tsx
@@ -15,6 +15,7 @@ import {
   expectTableHeaders,
   expectTableRows,
 } from '../__fixtures__/table-test-helpers';
+import { TableRow } from '../components/table-body/types';
 import { Table } from '../table';
 
 import type { TablePaginationProps } from '../components/table-pagination/types';
@@ -1447,6 +1448,104 @@ describe('Table', () => {
 
       // Should not have sticky cell test IDs
       expect(screen.queryByTestId('sticky-cell-left-sticky')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('row expansion integration', () => {
+    const testData = [
+      { id: '1', name: 'Alice Johnson', department: 'Engineering' },
+      { id: '2', name: 'Bob Smith', department: 'Marketing' },
+      { id: '3', name: 'Carol Davis', department: 'Engineering' },
+    ];
+
+    const testColumns = [
+      { id: 'name', label: 'Name' },
+      { id: 'department', label: 'Department' },
+    ];
+
+    const TestSubRow = ({ row }: { row: TableRow }) => <span>Expanded details for {row.id}</span>;
+
+    const mockIcons = {
+      chevronRight: (props: { title: string }) => <div title={props.title}>Chevron Right</div>,
+      chevronDown: (props: { title: string }) => <div title={props.title}>Chevron Down</div>,
+    };
+
+    it('does not render expand controls when subRow prop is not provided', () => {
+      render(
+        <Table data={testData} columns={testColumns} />,
+        buildWrapper([getInterpolationProviderWrapper(), getRouterWrapper()])
+      );
+
+      expect(screen.queryByTitle('Expand')).not.toBeInTheDocument();
+    });
+
+    it('renders expand controls and handles expansion workflow', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <Table data={testData} columns={testColumns} subRow={TestSubRow} />,
+        buildWrapper([
+          getBaseProviderWrapper(),
+          getInterpolationProviderWrapper(),
+          getRouterWrapper(),
+          getIconProviderWrapper({ icons: mockIcons }),
+        ])
+      );
+
+      // All rows should have expand controls, no sub-rows initially
+      expect(screen.getAllByTitle('Expand')).toHaveLength(3);
+      expect(screen.queryByTitle('Collapse')).not.toBeInTheDocument();
+      expect(screen.queryByText('Expanded details for 1')).not.toBeInTheDocument();
+
+      // Expand first row
+      const firstExpandButton = screen.getAllByTitle('Expand')[0];
+      await user.click(firstExpandButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('Expanded details for 0')).toBeInTheDocument();
+        expect(screen.getByTitle('Collapse')).toBeInTheDocument();
+        expect(screen.getAllByTitle('Expand')).toHaveLength(2);
+      });
+
+      // Other rows should remain collapsed
+      expect(screen.queryByText('Expanded details for 1')).not.toBeInTheDocument();
+      expect(screen.queryByText('Expanded details for 2')).not.toBeInTheDocument();
+
+      const collapseButton = screen.getByTitle('Collapse');
+      await user.click(collapseButton);
+
+      await waitFor(() => {
+        expect(screen.queryByText('Expanded details for 0')).not.toBeInTheDocument();
+        expect(screen.getAllByTitle('Expand')).toHaveLength(3);
+        expect(screen.queryByTitle('Collapse')).not.toBeInTheDocument();
+      });
+    });
+
+    it('allows multiple rows to be expanded simultaneously', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <Table data={testData} columns={testColumns} subRow={TestSubRow} />,
+        buildWrapper([
+          getBaseProviderWrapper(),
+          getInterpolationProviderWrapper(),
+          getRouterWrapper(),
+          getIconProviderWrapper({ icons: mockIcons }),
+        ])
+      );
+
+      const expandButtons = screen.getAllByTitle('Expand');
+
+      await user.click(expandButtons[0]);
+      await user.click(expandButtons[2]);
+
+      await waitFor(() => {
+        expect(screen.getByText('Expanded details for 0')).toBeInTheDocument();
+        expect(screen.queryByText('Expanded details for 1')).not.toBeInTheDocument();
+        expect(screen.getByText('Expanded details for 2')).toBeInTheDocument();
+        expect(screen.getAllByTitle('Expand')).toHaveLength(1);
+        expect(screen.getAllByTitle('Collapse')).toHaveLength(2);
+      });
     });
   });
 });

--- a/javascript/packages/core/components/table/components/table-body/__fixtures__/mock-table-body.ts
+++ b/javascript/packages/core/components/table/components/table-body/__fixtures__/mock-table-body.ts
@@ -28,5 +28,8 @@ export const getTanstackRowFixture = (overrides?: {
     getCanSelect: vi.fn(() => true),
     getIsSelected: vi.fn(() => false),
     toggleSelected: vi.fn(),
+    getCanExpand: vi.fn(() => true),
+    getIsExpanded: vi.fn(() => false),
+    onToggleExpanded: vi.fn(),
   } as unknown as Row<TableData>;
 };

--- a/javascript/packages/core/components/table/components/table-body/__tests__/row-transformer.test.ts
+++ b/javascript/packages/core/components/table/components/table-body/__tests__/row-transformer.test.ts
@@ -20,6 +20,9 @@ describe('transformRows', () => {
         canSelect: true,
         isSelected: false,
         onToggleSelection: expect.any(Function) as (selected: boolean) => void,
+        canExpand: true,
+        isExpanded: false,
+        onToggleExpanded: expect.any(Function) as () => void,
       },
       {
         id: 'row-2',
@@ -30,6 +33,9 @@ describe('transformRows', () => {
         canSelect: true,
         isSelected: false,
         onToggleSelection: expect.any(Function) as (selected: boolean) => void,
+        canExpand: true,
+        isExpanded: false,
+        onToggleExpanded: expect.any(Function) as () => void,
       },
     ]);
   });

--- a/javascript/packages/core/components/table/components/table-body/row-transformer.ts
+++ b/javascript/packages/core/components/table/components/table-body/row-transformer.ts
@@ -16,5 +16,8 @@ export function transformRows<T extends TableData = TableData>(
     canSelect: row.getCanSelect(),
     isSelected: row.getIsSelected(),
     onToggleSelection: (selected: boolean) => row.toggleSelected(selected),
+    canExpand: row.getCanExpand(),
+    isExpanded: row.getIsExpanded(),
+    onToggleExpanded: () => row.toggleExpanded(),
   }));
 }

--- a/javascript/packages/core/components/table/components/table-body/table-body.tsx
+++ b/javascript/packages/core/components/table/components/table-body/table-body.tsx
@@ -1,7 +1,9 @@
+import React from 'react';
 import { useStyletron } from 'baseui';
-import { StyledTableBodyCell, StyledTableBodyRow } from 'baseui/table-semantic';
+import { StyledTableBodyRow } from 'baseui/table-semantic';
 
-import { StyledTableBody } from '#core/components/table/styled-components';
+import { StyledTableBody, StyledTableBodyCell } from '#core/components/table/styled-components';
+import { TableExpandIcon } from '../table-expand-icon/table-expand-icon';
 import { getSelectionColumnCellStyles } from '../table-selection-column/styled-components';
 import { TableSelectionColumn } from '../table-selection-column/table-selection-column';
 import { withStickySides } from '../with-sticky-sides/with-sticky-sides';
@@ -16,6 +18,7 @@ export const TableBody = <T extends TableData = TableData>({
   enableRowSelection,
   enableStickySides,
   scrollRatio,
+  subRow,
 }: TableBodyProps<T>) => {
   const [css, theme] = useStyletron();
 
@@ -24,31 +27,61 @@ export const TableBody = <T extends TableData = TableData>({
   return (
     <StyledTableBody>
       {rows.map((row) => (
-        <StickySidesTableBodyRow
-          key={row.id}
-          enableStickySides={enableStickySides}
-          enableRowSelection={enableRowSelection}
-          lastColumnIndex={lastColumnIndex}
-          scrollRatio={scrollRatio}
-          role="row"
-        >
-          {enableRowSelection && (
-            <StyledTableBodyCell className={css(getSelectionColumnCellStyles(theme))}>
-              <TableSelectionColumn
-                canSelect={row.canSelect ?? false}
-                isSelected={row.isSelected ?? false}
-                onToggleSelection={row.onToggleSelection ?? (() => undefined)}
-              />
-            </StyledTableBodyCell>
+        <React.Fragment key={row.id}>
+          <StickySidesTableBodyRow
+            enableStickySides={enableStickySides}
+            enableRowSelection={enableRowSelection}
+            lastColumnIndex={lastColumnIndex}
+            scrollRatio={scrollRatio}
+            role="row"
+          >
+            {enableRowSelection && (
+              <StyledTableBodyCell className={css(getSelectionColumnCellStyles(theme))}>
+                <TableSelectionColumn
+                  canSelect={row.canSelect ?? false}
+                  isSelected={row.isSelected ?? false}
+                  onToggleSelection={row.onToggleSelection ?? (() => undefined)}
+                />
+              </StyledTableBodyCell>
+            )}
+
+            {row.cells.map((cell, cellIndex) => (
+              <StyledTableBodyCell
+                key={cell.id}
+                $columnNumber={cellIndex}
+                $enableRowSelection={enableRowSelection}
+              >
+                {row.canExpand && cellIndex === 0 ? (
+                  <div
+                    className={css({
+                      display: 'flex',
+                      alignItems: 'center',
+                      cursor: 'pointer',
+                      gap: theme.sizing.scale100,
+                    })}
+                    onClick={row.onToggleExpanded}
+                  >
+                    <TableExpandIcon expanded={row.isExpanded} />
+                    {cell.content}
+                  </div>
+                ) : (
+                  cell.content
+                )}
+              </StyledTableBodyCell>
+            ))}
+
+            {/* Placeholder action cell to align with column configuration button */}
+            <StyledTableBodyCell />
+          </StickySidesTableBodyRow>
+
+          {subRow && row.isExpanded && (
+            <StyledTableBodyRow>
+              <StyledTableBodyCell colSpan={row.cells.length + (enableRowSelection ? 2 : 1)}>
+                {React.createElement(subRow, { row })}
+              </StyledTableBodyCell>
+            </StyledTableBodyRow>
           )}
-
-          {row.cells.map((cell) => (
-            <StyledTableBodyCell key={cell.id}>{cell.content}</StyledTableBodyCell>
-          ))}
-
-          {/* Placeholder action cell to align with column configuration button */}
-          <StyledTableBodyCell />
-        </StickySidesTableBodyRow>
+        </React.Fragment>
       ))}
     </StyledTableBody>
   );

--- a/javascript/packages/core/components/table/components/table-body/types.ts
+++ b/javascript/packages/core/components/table/components/table-body/types.ts
@@ -11,9 +11,28 @@ export type TableCell<_T extends TableData = TableData> = {
 export type TableRow<T extends TableData = TableData> = {
   id: string;
   cells: TableCell<T>[];
-} & SelectableCapability;
+} & SelectableCapability &
+  ExpandableCapability;
 
 export type TableBodyProps<T extends TableData = TableData> = {
   rows: TableRow<T>[];
   enableRowSelection: boolean;
+  subRow?: React.ComponentType<{ row: TableRow<T> }>;
 } & Pick<WithStickySidesProps, 'enableStickySides' | 'scrollRatio'>;
+
+/**
+ * Defines a row's expansion capabilities and current state.
+ * Used by expandable row components to enable sub-row expansion interactions.
+ *
+ * @example
+ * ```ts
+ * // isExpanded = false
+ * onToggleExpanded()
+ * expect(isExpanded).toBe(true)
+ * ```
+ */
+export type ExpandableCapability = {
+  canExpand: boolean;
+  isExpanded: boolean;
+  onToggleExpanded: () => void;
+};

--- a/javascript/packages/core/components/table/components/table-expand-icon/table-expand-icon.tsx
+++ b/javascript/packages/core/components/table/components/table-expand-icon/table-expand-icon.tsx
@@ -1,0 +1,8 @@
+import { Icon } from '#core/components/icon/icon';
+
+export function TableExpandIcon({ expanded }: { expanded: boolean }) {
+  const iconName = expanded ? 'chevronDown' : 'chevronRight';
+  const title = expanded ? 'Collapse' : 'Expand';
+
+  return <Icon name={iconName} title={title} size={16} />;
+}

--- a/javascript/packages/core/components/table/styled-components.ts
+++ b/javascript/packages/core/components/table/styled-components.ts
@@ -16,8 +16,12 @@ export const StyledTableBodyRow = BaseStyledTableBodyRow;
  */
 export const StyledTableBodyCell = withStyle<
   typeof BaseStyledTableBodyCell,
-  { $columnNumber?: number }
->(BaseStyledTableBodyCell, ({ $columnNumber }) => ({
-  fontWeight: $columnNumber === 0 ? 500 : 'normal',
-  verticalAlign: 'middle',
-}));
+  { $columnNumber?: number; $enableRowSelection?: boolean }
+>(BaseStyledTableBodyCell, ({ $columnNumber, $enableRowSelection }) => {
+  const firstDataColumnIndex = $enableRowSelection ? 1 : 0;
+
+  return {
+    fontWeight: $columnNumber === firstDataColumnIndex ? 500 : 'normal',
+    verticalAlign: 'middle',
+  };
+});

--- a/javascript/packages/core/components/table/table.tsx
+++ b/javascript/packages/core/components/table/table.tsx
@@ -1,5 +1,6 @@
 import {
   getCoreRowModel,
+  getExpandedRowModel,
   getFilteredRowModel,
   getPaginationRowModel,
   getSortedRowModel,
@@ -52,6 +53,12 @@ export function Table<T extends TableData = TableData>(inputProps: TableProps<T>
       ? { getSortedRowModel: getSortedRowModel() }
       : { enableSorting: false }),
     ...(!props.disablePagination ? { getPaginationRowModel: getPaginationRowModel() } : {}),
+    ...(props.subRow
+      ? {
+          getExpandedRowModel: getExpandedRowModel(),
+          getRowCanExpand: () => true,
+        }
+      : {}),
     enableRowSelection: props.enableRowSelection,
     globalFilterFn: 'includesString',
   });
@@ -130,6 +137,7 @@ export function Table<T extends TableData = TableData>(inputProps: TableProps<T>
                 enableRowSelection={props.enableRowSelection}
                 enableStickySides={props.enableStickySides}
                 scrollRatio={scrollRatio}
+                subRow={props.subRow}
               />
             )}
           </StyledTable>

--- a/javascript/packages/core/components/table/types/table-types.ts
+++ b/javascript/packages/core/components/table/types/table-types.ts
@@ -2,6 +2,7 @@ import { EmptyState } from '../components/table-empty-state/types';
 
 import type { ApplicationError } from '#core/types/error-types';
 import type { TableActionBarConfig } from '../components/table-action-bar/types';
+import type { TableRow } from '../components/table-body/types';
 import type { PageSizeOption, TablePaginationProps } from '../components/table-pagination/types';
 import type { ColumnConfig } from './column-types';
 import type { TableData } from './data-types';
@@ -170,20 +171,34 @@ export interface TableRequiredFunctionalityProps {
   enableStickySides: boolean;
 }
 
+interface TableOptionalProps {
+  /**
+   * @description
+   * Component to render sub-rows for expandable row functionality.
+   * When provided, rows will show expand/collapse controls in the first column.
+   * Sub-rows are rendered below the main row content spanning all columns.
+   *
+   * @default undefined
+   */
+  subRow?: React.ComponentType<{ row: TableRow<TableData> }>;
+}
+
 /**
  * Input props that users provide to the Table component.
  * Optional props will be filled with defaults via applyDefaultProps.
  */
 export interface TableProps<T extends TableData = TableData>
   extends TableRequiredUserProps<T>,
-    Partial<TableRequiredFunctionalityProps> {}
+    Partial<TableRequiredFunctionalityProps>,
+    TableOptionalProps {}
 /**
  * Resolved props with all defaults applied.
  * Child components can rely on these props being defined.
  */
 export interface TablePropsResolved<T extends TableData = TableData>
   extends TableRequiredUserProps<T>,
-    TableRequiredFunctionalityProps {}
+    TableRequiredFunctionalityProps,
+    TableOptionalProps {}
 
 /**
  * Represents the possible view states of a table component.


### PR DESCRIPTION
Add row expansion functionality enabling custom sub-row components that render below expanded table rows.

The implementation follows existing capability-based architecture pattern, adding ExpandableCapability alongside SelectableCapability to maintain type consistency.

During implementation, discovered that the left-most data column was not receiving bold font weight. Updated to ensure the instantiation of the cell component receives column index.


https://github.com/user-attachments/assets/eaeae6db-f1a1-478a-944e-41059c0c26d8

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
