### PR TITLE
Fix the wrong variable usage for sandbox cluster name in jobs cluster secret creation

### DIFF
--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -689,7 +689,7 @@ def _create_cluster_secrets(cluster_name: str):
         _exec(
             "kubectl",
             "--context",
-            f"k3d-{_kube_name}",
+            f"k3d-{_michelangelo_sandbox_kube_cluster_name}",
             "apply",
             "-f",
             ca_file.name,
@@ -729,7 +729,7 @@ def _create_cluster_secrets(cluster_name: str):
         _exec(
             "kubectl",
             "--context",
-            f"k3d-{_kube_name}",
+            f"k3d-{_michelangelo_sandbox_kube_cluster_name}",
             "apply",
             "-f",
             token_file.name,


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
- Corrected the `kubectl --context` value in `python/michelangelo/cli/sandbox/sandbox.py` to use `_michelangelo_sandbox_kube_cluster_name` instead of `_kube_name`.
- Updated both secret-apply calls (CA and token) within `_create_cluster_secrets(cluster_name: str)`.

**Why?**
- The wrong variable led to applying secrets against an incorrect or non-existent Kubernetes context, causing sandbox jobs cluster secrets to fail to create/update.

**How did you test it?**
- Tested locally by running the sandbox cluster secret creation - `poetry run ma sandbox create --create-jobs-cluster`

**Potential risks**
- Low risk; affects only the sandbox jobs cluster secret creation path.

**Release notes**
- Fix: Use correct sandbox cluster context when creating jobs cluster secrets.

**Documentation Changes**
- None.