### PR TITLE
Wait for jobs only if any exist in the sandbox cluster creation

### DIFF
--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -217,9 +217,25 @@ Be aware that CR_PAT environment variable is required while Michelangelo is NOT 
         "--selector=!job-name",
         "--timeout=600s",
     )
-    _exec(
-        "kubectl", "wait", "--all", "jobs", "--for=condition=complete", "--timeout=600s"
-    )
+
+    # Wait for Jobs only if any jobs exist
+    try:
+        job_names = (
+            subprocess.check_output(["kubectl", "get", "jobs", "-o", "name"]).decode().strip()
+        )
+    except subprocess.CalledProcessError:
+        job_names = ""
+    if job_names:
+        _exec(
+            "kubectl",
+            "wait",
+            "--all",
+            "jobs",
+            "--for=condition=complete",
+            "--timeout=600s",
+        )
+    else:
+        print("[*] No Kubernetes Jobs found; skipping wait for jobs.")
 
     links = []
     _assert_command(


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
- Updated `python/michelangelo/cli/sandbox/sandbox.py` to wait on Kubernetes Jobs only if any exist.
- Added a `kubectl get jobs -o name` pre-check with a try/except; skip `kubectl wait --all jobs ...` when no jobs are found and log a message instead.

**Why?**
- To prevent failures like "no matching resources found" when `kubectl wait --all jobs` is executed in clusters with zero Jobs during sandbox creation.
- Improves reliability and makes sandbox setup idempotent in empty or freshly created clusters.

**How did you test it?**
- Comment out all of the jobs in the resource creation [here](https://github.com/michelangelo-ai/michelangelo/blob/main/python/michelangelo/cli/sandbox/sandbox.py#L185-L186).  
- Run `poetry run ma sandbox create` :
  - Scenario with no Jobs: verified it skips waiting and proceeds without error.
  - Scenario with Jobs present: verified it waits for completion successfully.

**Potential risks**
- If `kubectl get jobs` transiently fails, the try/except will skip waiting, potentially not waiting for jobs that do exist.
- Behavior depends on the current kube context/namespace matching where jobs are created.

**Release notes**
- Sandbox: Only wait for Kubernetes Jobs when present, avoiding "no matching resources found" errors during setup.

**Documentation Changes**
- NA