### PR TITLE
Long TTL for ray-manager cluster auth token

### DIFF
--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -805,6 +805,8 @@ def _create_cluster_secrets(cluster_name: str):
                 "create",
                 "token",
                 "ray-manager",
+                # Required to override kubectl's 1h default token TTL; set ~10y to prevent frequent sandbox expirations
+                "--duration=87600h",
             ]
         )
         .decode()


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
- Extended the TTL for the `ray-manager` service account token created by the sandbox CLI by adding `--duration=87600h` to the token creation command in `python/michelangelo/cli/sandbox/sandbox.py`.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Prevent frequent token expirations that disrupt sandbox usage. Default TTL is 1 hour.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Ran the sandbox CLI to create sandbox - `poetry run ma sandbox create --create-jobs-cluster`
- Confirmed token issuance succeeds without errors.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- Longer-lived tokens increase impact if compromised; requires mindful handling and potential periodic rotation, but this is a local sandbox cluster so we can afford to be more lenient.

**Release notes**
- Sandbox `ray-manager` auth token now created with a long TTL (87600h ~ 10 years) to reduce token expiration interruptions.

**Documentation Changes**
- NA