### PR TITLE
Improve error logs reporting in Uniflow's remote run command

### DIFF
--- a/python/michelangelo/uniflow/core/remote_run.py
+++ b/python/michelangelo/uniflow/core/remote_run.py
@@ -1,4 +1,3 @@
-import argparse
 import base64
 import json
 import logging
@@ -140,11 +139,9 @@ class RemoteRun:
                 raise RuntimeError("User interrupted the Remote Run submission")
 
         try:
-            stdout = subprocess.check_output(cmd, text=True)
+            stdout = _subprocess_run(cmd)
         except KeyboardInterrupt:
             sys.exit(130)
-
-        print(stdout)
 
         dashboard_url = os.environ.get("UFC_CADENCE_DASHBOARD_URL", "")
 
@@ -282,11 +279,9 @@ class RemoteRunTemporal:
 
         # Run the Temporal workflow
         try:
-            stdout = subprocess.check_output(cmd, text=True)
+            stdout = _subprocess_run(cmd)
         except KeyboardInterrupt:
             sys.exit(130)
-
-        print(stdout)
 
         # Extract Run ID and print dashboard link if applicable
         dashboard_url = os.environ.get("UFC_TEMPORAL_DASHBOARD_URL", "")
@@ -304,3 +299,32 @@ class RemoteRunTemporal:
         print(
             "Dashboard:", f"{dashboard_url}/workflows/{workflow_id}/{run_id[0]}/summary"
         )
+
+
+def _subprocess_run(args: list[str]) -> str:
+    """
+    Executes a subprocess command, prints stdout and stderr, and returns the stdout as text string.
+
+    Args:
+        args: Command to execute.
+
+    Returns:
+        str: The stdout output from the subprocess, or empty string if none.
+
+    Raises:
+        subprocess.CalledProcessError: If the subprocess returns a non-zero exit code.
+    """
+    r = subprocess.run(
+        args,
+        text=True,
+        capture_output=True,
+    )
+    if r.stdout:
+        sys.stdout.write(r.stdout)
+        sys.stdout.flush()
+    if r.stderr:
+        sys.stderr.write(r.stderr)
+        sys.stderr.flush()
+
+    r.check_returncode()
+    return r.stdout or ""

--- a/python/tests/uniflow/core/test_remote_run.py
+++ b/python/tests/uniflow/core/test_remote_run.py
@@ -29,6 +29,8 @@ class Test(unittest.TestCase):
         """
         This test case verifies the remote run command with a minimal set of arguments.
         """
+        subprocess_run.return_value.stdout = ""
+        subprocess_run.return_value.stderr = ""
         # Provide a minimal set of the arguments required to run the workflow in the remote mode.
 
         rr = RemoteRun(
@@ -99,6 +101,8 @@ class Test(unittest.TestCase):
         This test case verifies that user-provided arguments and environment variables are properly encoded
         and passed to the Cadence workflow execution input.
         """
+        subprocess_run.return_value.stdout = ""
+        subprocess_run.return_value.stderr = ""
         # Run my_workflow with arguments and environment variables.
         # Users may provide multiple arguments encoded in JSON. Example:
         #


### PR DESCRIPTION
**TL;DR**

This PR improves error logs reporting in Uniflow's remote run command.

**Details**

Remote run logic relies on calling an external process, e.g., `cadence` or `temporal`, to submit a workflow for execution. In some cases, those external processes might fail and print valuable error logs in either stderr or stdout streams. This PR ensures that these error logs are captured and surfaced to the end user.
