### PR TITLE
Add initialState parameter to table state persistence

### DIFF
--- a/javascript/packages/core/components/table/components/table-cell/__tests__/get-responsive-column-width.test.ts
+++ b/javascript/packages/core/components/table/components/table-cell/__tests__/get-responsive-column-width.test.ts
@@ -1,0 +1,66 @@
+import { DeepPartial } from '#core/types/utility-types';
+import { getResponsiveColumnWidth } from '../get-responsive-column-width';
+
+import type { Theme } from 'baseui';
+
+describe('getResponsiveColumnWidth', () => {
+  it('creates responsive max width styles for multiple breakpoints', () => {
+    const mockTheme: Pick<Theme, 'breakpoints'> = {
+      breakpoints: {
+        small: 320,
+        medium: 600,
+        large: 1280,
+      },
+    };
+
+    const result = getResponsiveColumnWidth(mockTheme as Theme);
+
+    expect(result).toEqual({
+      '@media screen and (min-width: 320px)': { maxWidth: '150px' },
+      '@media screen and (min-width: 600px)': { maxWidth: '300px' },
+      '@media screen and (min-width: 1280px)': { maxWidth: '450px' },
+    });
+  });
+
+  it('returns empty object for theme with no breakpoints', () => {
+    const mockTheme: Pick<Theme, 'breakpoints'> = {
+      // @ts-expect-error intentional empty breakpoints object
+      breakpoints: {},
+    };
+
+    const result = getResponsiveColumnWidth(mockTheme as Theme);
+
+    expect(result).toEqual({});
+  });
+
+  it('handles single breakpoint correctly', () => {
+    const mockTheme: DeepPartial<Pick<Theme, 'breakpoints'>> = {
+      breakpoints: {
+        small: 480,
+      },
+    };
+
+    const result = getResponsiveColumnWidth(mockTheme as Theme);
+
+    expect(result).toEqual({
+      '@media screen and (min-width: 480px)': { maxWidth: '150px' },
+    });
+  });
+
+  it('preserves breakpoint order from theme object', () => {
+    const mockTheme: Pick<Theme, 'breakpoints'> = {
+      breakpoints: {
+        large: 1200,
+        small: 320,
+        medium: 768,
+      },
+    };
+
+    const result = getResponsiveColumnWidth(mockTheme as Theme);
+    const keys = Object.keys(result);
+
+    expect(keys[0]).toBe('@media screen and (min-width: 1200px)');
+    expect(keys[1]).toBe('@media screen and (min-width: 320px)');
+    expect(keys[2]).toBe('@media screen and (min-width: 768px)');
+  });
+});

--- a/javascript/packages/core/components/table/components/table-cell/get-responsive-column-width.ts
+++ b/javascript/packages/core/components/table/components/table-cell/get-responsive-column-width.ts
@@ -1,0 +1,30 @@
+import type { Theme } from 'baseui';
+
+const BASE_MAX_WIDTH = 150;
+
+/**
+ * Creates responsive max width constraints for table columns based on viewport breakpoints.
+ * Multiplies base width by breakpoint index to provide more space on larger screens.
+ *
+ * @param theme - BaseUI theme containing breakpoint configuration
+ * @returns Object with media query keys and corresponding maxWidth values
+ *
+ * @example
+ * // For breakpoints: { small: 320, medium: 600, large: 1280 }
+ * // Returns: {
+ * //   '@media screen and (min-width: 320px)': { maxWidth: '150px' },
+ * //   '@media screen and (min-width: 600px)': { maxWidth: '300px' },
+ * //   '@media screen and (min-width: 1280px)': { maxWidth: '450px' }
+ * // }
+ */
+export function getResponsiveColumnWidth(theme: Theme) {
+  const result = {};
+  const breakpoints = Object.entries(theme.breakpoints);
+
+  for (const [index, [, value]] of breakpoints.entries()) {
+    const query = `@media screen and (min-width: ${value}px)`;
+    result[query] = { maxWidth: `${BASE_MAX_WIDTH * (index + 1)}px` };
+  }
+
+  return result;
+}

--- a/javascript/packages/core/components/table/components/table-cell/table-cell.tsx
+++ b/javascript/packages/core/components/table/components/table-cell/table-cell.tsx
@@ -1,13 +1,17 @@
+import { useStyletron } from 'baseui';
+
 import { CellTooltipContentRenderer } from '#core/components/cell/components/tooltip/cell-tooltip-content-renderer';
 import { CellTooltipWrapper } from '#core/components/cell/components/tooltip/cell-tooltip-wrapper';
 import { TooltipHOCProps } from '#core/components/cell/components/tooltip/types';
 import { useGetCellRenderer } from '#core/components/cell/use-get-cell-renderer';
 import { useInterpolationResolver } from '#core/interpolation/use-interpolation-resolver';
+import { getResponsiveColumnWidth } from './get-responsive-column-width';
 import { isFilterAlreadyApplied } from './utils';
 
 import type { TableCellProps } from './types';
 
 export const TableCell = (props: TableCellProps) => {
+  const [css, theme] = useStyletron();
   const { record, value, columnFilterValue, setColumnFilterValue } = props;
   const resolver = useInterpolationResolver();
   const column = resolver(props.column, { row: record });
@@ -15,7 +19,11 @@ export const TableCell = (props: TableCellProps) => {
   const getCellRenderer = useGetCellRenderer();
   const ColumnRenderer = getCellRenderer({ column, record, value });
 
-  const renderedCell = <ColumnRenderer column={column} record={record} value={value} />;
+  const renderedCell = (
+    <div className={css({ ...getResponsiveColumnWidth(theme), overflow: 'hidden' })}>
+      <ColumnRenderer column={column} record={record} value={value} CellComponent={TableCell} />
+    </div>
+  );
 
   if (column.tooltip) {
     const { action } = column.tooltip;

--- a/javascript/packages/core/components/table/components/table-header/styled-components.ts
+++ b/javascript/packages/core/components/table/components/table-header/styled-components.ts
@@ -4,12 +4,17 @@ import {
   StyledTableHeadCellSortable as BaseStyledTableHeadCellSortable,
 } from 'baseui/table-semantic';
 
-export const StyledTableHeadCell = withStyle(BaseStyledTableHeadCell, () => ({
+export const StyledTableHeadCell = withStyle(BaseStyledTableHeadCell, ({ $theme }) => ({
   zIndex: 'unset', // Unset z-index to prevent interference with popovers and overlays
   position: 'inherit', // Position inherit to allow for sticky columns
+  ...$theme.typography.LabelSmall,
 }));
 
-export const StyledSortableTableHeadCell = withStyle(BaseStyledTableHeadCellSortable, () => ({
-  zIndex: 'unset', // Unset z-index to prevent interference with popovers and overlays
-  position: 'inherit', // Position inherit to allow for sticky columns
-}));
+export const StyledSortableTableHeadCell = withStyle(
+  BaseStyledTableHeadCellSortable,
+  ({ $theme }) => ({
+    zIndex: 'unset', // Unset z-index to prevent interference with popovers and overlays
+    position: 'inherit', // Position inherit to allow for sticky columns
+    ...$theme.typography.LabelSmall,
+  })
+);

--- a/javascript/packages/core/components/table/plugins/state-persistence/__tests__/use-local-storage-table-state.test.tsx
+++ b/javascript/packages/core/components/table/plugins/state-persistence/__tests__/use-local-storage-table-state.test.tsx
@@ -76,6 +76,21 @@ describe('useLocalStorageTableState', () => {
       expect(result.current.globalFilter).toBe('restored-filter');
     });
 
+    it('uses initial state when no persisted data exists', () => {
+      const { result } = renderHook(() =>
+        useLocalStorageTableState({
+          tableSettingsId: 'test-table',
+          initialState: {
+            globalFilter: 'initial-filter',
+            columnVisibility: { name: false },
+          },
+        })
+      );
+
+      expect(result.current.globalFilter).toBe('initial-filter');
+      expect(result.current.columnVisibility).toEqual({ name: false });
+    });
+
     it('handles localStorage errors gracefully', () => {
       const originalGetItem = localStorage.getItem.bind(localStorage) as unknown as () => string;
       localStorage.getItem = vi.fn(() => {

--- a/javascript/packages/core/components/table/plugins/state-persistence/use-local-storage-table-state.ts
+++ b/javascript/packages/core/components/table/plugins/state-persistence/use-local-storage-table-state.ts
@@ -15,17 +15,33 @@ import type {
 
 /**
  * Primary entry point for adding localStorage persistence to Table components.
- * This hook manages table state with automatic localStorage persistence, falling back to
- * {@link TABLE_STATE_DEFAULTS} when values are not found in localStorage.
+ * This hook manages table state with automatic localStorage persistence.
+ *
+ * **State Priority (highest to lowest):**
+ * 1. **Persisted state** from localStorage (user's saved preferences)
+ * 2. **Initial state** from props (schema defaults, initial configuration)
+ * 3. **Table defaults** from {@link TABLE_STATE_DEFAULTS}
  *
  * Use this hook to provide a `state` prop to the Table component for persistent
  * user preferences across browser sessions.
  *
+ * @param tableSettingsId - Unique identifier for this table's settings in localStorage
+ * @param initialState - Optional initial state to use when no persisted state exists
+ *
  * @example
  * ```tsx
- * // In your table component
+ * // Basic usage
  * const tableState = useLocalStorageTableState({
  *   tableSettingsId: 'user-dashboard-table',
+ * });
+ *
+ * // With initial state (e.g., hidden columns from schema)
+ * const tableState = useLocalStorageTableState({
+ *   tableSettingsId: 'user-dashboard-table',
+ *   initialState: {
+ *     columnVisibility: { hiddenColumnId: false },
+ *     sorting: [{ id: 'name', desc: false }],
+ *   },
  * });
  *
  * return <Table data={data} columns={columns} state={tableState} />;
@@ -35,37 +51,39 @@ import type {
  */
 export function useLocalStorageTableState({
   tableSettingsId,
+  initialState,
 }: {
   tableSettingsId: string;
+  initialState?: Partial<ControlledTableState>;
 }): ControlledTableState {
   const [globalFilter, setGlobalFilter] = usePersistedTableState<string>(
     `${tableSettingsId}.globalFilter`,
-    TABLE_STATE_DEFAULTS.globalFilter
+    initialState?.globalFilter ?? TABLE_STATE_DEFAULTS.globalFilter
   );
 
   const [columnFilters, setColumnFilters] = usePersistedTableState<ColumnFilter[]>(
     `${tableSettingsId}.columnFilters`,
-    TABLE_STATE_DEFAULTS.columnFilters
+    initialState?.columnFilters ?? TABLE_STATE_DEFAULTS.columnFilters
   );
 
   const [pageSize, setPageSize] = usePersistedTableState<number>(
     `${tableSettingsId}.pageSize`,
-    TABLE_STATE_DEFAULTS.pagination.pageSize
+    initialState?.pagination?.pageSize ?? TABLE_STATE_DEFAULTS.pagination.pageSize
   );
 
   const [sorting, setSorting] = usePersistedTableState<SortingState>(
     `${tableSettingsId}.sorting`,
-    TABLE_STATE_DEFAULTS.sorting
+    initialState?.sorting ?? TABLE_STATE_DEFAULTS.sorting
   );
 
   const [columnOrder, setColumnOrder] = usePersistedTableState<ColumnOrderState>(
     `${tableSettingsId}.columnOrder`,
-    TABLE_STATE_DEFAULTS.columnOrder
+    initialState?.columnOrder ?? TABLE_STATE_DEFAULTS.columnOrder
   );
 
   const [columnVisibility, setColumnVisibility] = usePersistedTableState<ColumnVisibilityState>(
     `${tableSettingsId}.columnVisibility`,
-    TABLE_STATE_DEFAULTS.columnVisibility
+    initialState?.columnVisibility ?? TABLE_STATE_DEFAULTS.columnVisibility
   );
 
   // pageIndex and rowSelection are not persisted (reset on reload)

--- a/javascript/packages/core/components/views/project/project-list.tsx
+++ b/javascript/packages/core/components/views/project/project-list.tsx
@@ -33,6 +33,7 @@ export function ProjectList() {
         data={data?.projectList.items ?? []}
         columns={SHARED_PROJECT_CELL_CONFIG}
         loading={isLoading}
+        enableStickySides
       />
     </div>
   );


### PR DESCRIPTION
Replace single-fallback persistence model with configurable initial state to bridge studio-table schema properties with new table state system.

Previous persistence always fell back to TABLE_STATE_DEFAULTS when no localStorage existed, preventing table users from providing their own set of initial configuration.

Maintains backward compatibility by making initialState optional with existing TABLE_STATE_DEFAULTS behavior when not provided.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
