### PR TITLE
Improve icon sizing compatability

### DIFF
--- a/javascript/app/icons/icons.tsx
+++ b/javascript/app/icons/icons.tsx
@@ -12,6 +12,7 @@ import Info from '@mui/icons-material/Info';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardBackspaceIcon from '@mui/icons-material/KeyboardBackspace';
 import Launch from '@mui/icons-material/Launch';
+import SearchIcon from '@mui/icons-material/Search';
 import SettingsIcon from '@mui/icons-material/Settings';
 import ShowChartIcon from '@mui/icons-material/ShowChart';
 import SkipNextIcon from '@mui/icons-material/SkipNext';
@@ -32,6 +33,7 @@ export const ICONS = {
   diamondEmpty: createMuiIconAdapter(CropSquareIcon),
   playerNext: createMuiIconAdapter(SkipNextIcon),
   plus: createMuiIconAdapter(AddIcon),
+  search: createMuiIconAdapter(SearchIcon),
   settings: createMuiIconAdapter(SettingsIcon),
   sortAscending: createMuiIconAdapter(ArrowUpwardIcon),
   sortDescending: createMuiIconAdapter(ArrowDownwardIcon),

--- a/javascript/app/icons/mui-icon-adapter.tsx
+++ b/javascript/app/icons/mui-icon-adapter.tsx
@@ -3,7 +3,9 @@ import type { IconProps } from 'baseui/icon';
 import type { ComponentType } from 'react';
 
 export const createMuiIconAdapter = (Icon: ComponentType<SvgIconProps>) => {
-  return (props: IconProps) => (
-    <Icon sx={{ ...props.style, color: props.color, fontSize: props.size }} />
-  );
+  return (props: IconProps) => {
+    // Scale Material UI icons to match internal icon sizing (14px internal ≈ 12px Material UI)
+    const scaledSize = props.size ? `calc(${props.size} * 1.125)` : props.size;
+    return <Icon sx={{ ...props.style, color: props.color, fontSize: scaledSize }} />;
+  };
 };

--- a/javascript/packages/core/components/cell/components/tooltip/cell-tooltip-wrapper.tsx
+++ b/javascript/packages/core/components/cell/components/tooltip/cell-tooltip-wrapper.tsx
@@ -1,3 +1,4 @@
+import { useStyletron } from 'baseui';
 import { ACCESSIBILITY_TYPE, PLACEMENT, StatefulTooltip } from 'baseui/tooltip';
 
 import { Icon } from '#core/components/icon/icon';
@@ -7,6 +8,7 @@ import type { TooltipWrapperProps } from './types';
 
 export function CellTooltipWrapper(props: TooltipWrapperProps) {
   const { actionHandler, children, content } = props;
+  const [, theme] = useStyletron();
 
   return (
     <StatefulTooltip
@@ -18,7 +20,7 @@ export function CellTooltipWrapper(props: TooltipWrapperProps) {
       content={
         <ClickableContainer onClick={actionHandler}>
           {content}
-          {!!actionHandler && <Icon name="chevronRight" size="18px" />}
+          {!!actionHandler && <Icon name="chevronRight" size={theme.sizing.scale650} />}
         </ClickableContainer>
       }
     >

--- a/javascript/packages/core/components/cell/renderers/boolean/boolean-cell.tsx
+++ b/javascript/packages/core/components/cell/renderers/boolean/boolean-cell.tsx
@@ -20,7 +20,7 @@ export const BooleanCell = ({ value, column }: CellRendererProps<boolean>) => {
         ...theme.typography.ParagraphSmall,
       })}
     >
-      <Icon name="circleCheckFilled" kind={IconKind.ACCENT} size={14} />
+      <Icon name="circleCheckFilled" kind={IconKind.ACCENT} size={theme.sizing.scale550} />
       {BooleanCell.toString({ column, value })}
     </div>
   );

--- a/javascript/packages/core/components/cell/renderers/multi/multi-cell.tsx
+++ b/javascript/packages/core/components/cell/renderers/multi/multi-cell.tsx
@@ -8,7 +8,7 @@ import type { CellRenderer } from '#core/components/cell/types';
 import type { MultiCellConfig } from './types';
 
 export const MultiCell: CellRenderer<unknown, MultiCellConfig> = (props) => {
-  const [css] = useStyletron();
+  const [css, theme] = useStyletron();
   const { column, record, CellComponent = DefaultCellRenderer } = props;
   const { items } = column;
 
@@ -18,7 +18,7 @@ export const MultiCell: CellRenderer<unknown, MultiCellConfig> = (props) => {
 
   return (
     <div className={css(COLUMN_WRAPPER)}>
-      {column.icon && <Icon name={column.icon} size={16} width="32px" />}
+      {column.icon && <Icon name={column.icon} size={theme.sizing.scale600} width="32px" />}
       <div className={css(ITEMS_WRAPPER)}>
         {items.map((item, index) => {
           const value = getObjectValue<unknown>(record, item.accessor ?? item.id);

--- a/javascript/packages/core/components/icon/icon.tsx
+++ b/javascript/packages/core/components/icon/icon.tsx
@@ -9,7 +9,7 @@ import type { Props } from './types';
 
 export const Icon = memo<Props>(function Icon(props: Props) {
   const [, theme] = useStyletron();
-  const { color, name, icon, kind = IconKind.PRIMARY } = props;
+  const { color, name, icon, kind = IconKind.PRIMARY, size = theme.sizing.scale550 } = props;
   const { icons } = useIconProvider();
 
   const IconComponent = icon ?? (name ? icons[name] : null);
@@ -19,6 +19,7 @@ export const Icon = memo<Props>(function Icon(props: Props) {
   return (
     <IconComponent
       {...props}
+      size={size}
       color={color ?? theme.colors[`content${capitalizeFirstLetter(kind)}`]}
       style={{ minWidth: 'fit-content' }}
     />

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-menu-content/table-filter-menu-content.tsx
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-menu-content/table-filter-menu-content.tsx
@@ -33,7 +33,7 @@ export function TableFilterMenuContent<T extends TableData = TableData>(
           kind={KIND.tertiary}
           size={SIZE.compact}
         >
-          <Icon name="arrowLeft" size={18} />
+          <Icon name="arrowLeft" size={theme.sizing.scale650} />
         </Button>
         <FilterComponent
           columnId={selectedColumn.id}

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-option/table-filter-option.tsx
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-option/table-filter-option.tsx
@@ -7,7 +7,7 @@ export function TableFilterOption({ label, onClick }: TableFilterOptionProps) {
   return (
     <FilterOptionItem onClick={onClick} data-testid={`filter-option-${label}`}>
       {label}
-      <Icon name="chevronRight" size={20} />
+      <Icon name="chevronRight" />
     </FilterOptionItem>
   );
 }

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/table-filter-menu.tsx
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/table-filter-menu.tsx
@@ -53,7 +53,7 @@ export function TableFilterMenu<T extends TableData = TableData>(props: TableFil
         shape={SHAPE.pill}
         size={SIZE.compact}
         kind={isMenuOpen || columnFilters.length > 0 ? KIND.primary : KIND.secondary}
-        startEnhancer={<Icon name="plus" size={16} />}
+        startEnhancer={<Icon name="plus" />}
         overrides={{
           BaseButton: {
             style: {

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-search-input/table-search-input.tsx
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-search-input/table-search-input.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Search } from 'baseui/icon';
 import { Input, SIZE } from 'baseui/input';
+
+import { Icon } from '#core/components/icon/icon';
 
 import type { TableSearchInputProps } from './types';
 
@@ -38,7 +39,7 @@ export function TableSearchInput({ value, onChange }: TableSearchInputProps) {
         ClearIcon: { props: { size: 20 } },
       }}
       placeholder="Search..."
-      startEnhancer={<Search size={20} />}
+      startEnhancer={<Icon name="search" />}
     />
   );
 }

--- a/javascript/packages/core/components/table/components/table-expand-icon/table-expand-icon.tsx
+++ b/javascript/packages/core/components/table/components/table-expand-icon/table-expand-icon.tsx
@@ -1,8 +1,11 @@
+import { useStyletron } from 'baseui';
+
 import { Icon } from '#core/components/icon/icon';
 
 export function TableExpandIcon({ expanded }: { expanded: boolean }) {
+  const [, theme] = useStyletron();
   const iconName = expanded ? 'chevronDown' : 'chevronRight';
   const title = expanded ? 'Collapse' : 'Expand';
 
-  return <Icon name={iconName} title={title} size={16} />;
+  return <Icon name={iconName} title={title} size={theme.sizing.scale600} />;
 }

--- a/javascript/packages/core/components/table/components/table-header/components/table-column-configuration-button/table-column-configuration-button.tsx
+++ b/javascript/packages/core/components/table/components/table-header/components/table-column-configuration-button/table-column-configuration-button.tsx
@@ -63,7 +63,7 @@ export function TableColumnConfigurationButton<T extends TableData = TableData>(
       )}
     >
       <Button title="Configure columns" size={SIZE.mini} kind={KIND.tertiary}>
-        <Icon name="settings" size={theme.sizing.scale700} />
+        <Icon name="settings" />
       </Button>
     </StatefulPopover>
   );

--- a/javascript/packages/core/components/table/components/table-header/components/table-sort-icon/table-sort-icon.tsx
+++ b/javascript/packages/core/components/table/components/table-header/components/table-sort-icon/table-sort-icon.tsx
@@ -10,5 +10,5 @@ export function TableSortIcon(props: TableSortIconProps) {
   const iconName = sortDirection === 'desc' ? 'sortDescending' : 'sortAscending';
   const iconKind = sortDirection ? IconKind.ACCENT : IconKind.TERTIARY;
 
-  return <Icon name={iconName} kind={iconKind} title="Toggle Sort" size={16} />;
+  return <Icon name={iconName} kind={iconKind} title="Toggle Sort" />;
 }

--- a/javascript/packages/core/components/views/execution/components/task-state-icon.tsx
+++ b/javascript/packages/core/components/views/execution/components/task-state-icon.tsx
@@ -10,5 +10,5 @@ export function TaskStateIcon(props: { state: TaskState }) {
   const [, { colors, sizing }] = useStyletron();
   const iconProps = STATE_TO_ICON_MAP[state];
 
-  return <Icon name={iconProps.name} color={colors[iconProps.colorName]} size={sizing.scale750} />;
+  return <Icon name={iconProps.name} color={colors[iconProps.colorName]} size={sizing.scale700} />;
 }


### PR DESCRIPTION
Icons provided by baseui are a factor larger than Material UI icons. This leads to inconsistent rendering for Uber's internal application.

Apply a scale to increase the size value applied to the Material UI icon and update instantiations of icons to user smaller sizes.

A default icon size of scale550 (default 14px) is now applied to the Icon component, as this appears to be the common fallback for icon sizing.

<img width="1840" height="1128" alt="Screenshot 2025-08-30 at 14 04 46" src="https://github.com/user-attachments/assets/c574a61e-7b08-43df-8733-7e964bd0d6fe" />
<img width="1840" height="1128" alt="Screenshot 2025-08-30 at 14 04 35" src="https://github.com/user-attachments/assets/cd37af56-fbb9-4799-bbc4-7bb5d6b8fb3a" />


**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
