### PR TITLE
Shrink table header spacing

### DIFF
--- a/javascript/packages/core/components/table/components/table-header/styled-components.ts
+++ b/javascript/packages/core/components/table/components/table-header/styled-components.ts
@@ -18,3 +18,9 @@ export const StyledSortableTableHeadCell = withStyle(
     ...$theme.typography.LabelSmall,
   })
 );
+
+// BaseWeb Button comes with its own padding to support good hoverable areas. When combined
+// with `StyledTableHeadCell`, this padding creates too tall of a header row.
+export const StyledTableConfigurationButtonHeadCell = withStyle(StyledTableHeadCell, {
+  padding: 0,
+});

--- a/javascript/packages/core/components/table/components/table-header/table-header.tsx
+++ b/javascript/packages/core/components/table/components/table-header/table-header.tsx
@@ -6,7 +6,11 @@ import { TableSelectionColumn } from '../table-selection-column/table-selection-
 import { withStickySides } from '../with-sticky-sides/with-sticky-sides';
 import { TableColumnConfigurationButton } from './components/table-column-configuration-button/table-column-configuration-button';
 import { TableSortIcon } from './components/table-sort-icon/table-sort-icon';
-import { StyledSortableTableHeadCell, StyledTableHeadCell } from './styled-components';
+import {
+  StyledSortableTableHeadCell,
+  StyledTableConfigurationButtonHeadCell,
+  StyledTableHeadCell,
+} from './styled-components';
 
 import type { TableData } from '#core/components/table/types/data-types';
 import type { TableHeaderProps } from './types';
@@ -76,7 +80,7 @@ export const TableHeader = <T extends TableData = TableData>({
           )}
 
         {setColumnOrder && setColumnVisibility && (
-          <StyledTableHeadCell role="columnheader">
+          <StyledTableConfigurationButtonHeadCell role="columnheader">
             <div className={css({ display: 'flex', justifyContent: 'center' })}>
               <TableColumnConfigurationButton
                 columns={columns}
@@ -84,7 +88,7 @@ export const TableHeader = <T extends TableData = TableData>({
                 setColumnVisibility={setColumnVisibility}
               />
             </div>
-          </StyledTableHeadCell>
+          </StyledTableConfigurationButtonHeadCell>
         )}
       </StickySidesTableHeadRow>
     </StyledTableHead>


### PR DESCRIPTION
Table header spacing was artificially bloated by padding applied to baseui's Button component.

We maintain the Button padding such that the hover effect remains visible.

**See difference between table header sizes**
| Before | After | 
| :------- | :------: |
| <img width="1840" height="1128" alt="Screenshot 2025-08-30 at 14 07 42" src="https://github.com/user-attachments/assets/15498d9f-6d92-4e93-86b9-386c7dd2032c" /> | <img width="1840" height="1128" alt="Screenshot 2025-08-30 at 14 06 18" src="https://github.com/user-attachments/assets/0fd93bc1-a89a-4208-8cf6-cc79ff3fbf52" />  |


**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
