### PR TITLE
Fix table filter option generation

### DIFF
--- a/javascript/packages/core/components/table/__tests__/table.test.tsx
+++ b/javascript/packages/core/components/table/__tests__/table.test.tsx
@@ -18,6 +18,7 @@ import {
 import { TableBodyProps, TableRow } from '../components/table-body/types';
 import { Table } from '../table';
 
+import type { Accessor } from '#core/types/common/studio-types';
 import type { TablePaginationProps } from '../components/table-pagination/types';
 
 describe('Table', () => {
@@ -589,6 +590,43 @@ describe('Table', () => {
         expect(screen.getByLabelText('Engineering')).toBeInTheDocument();
         expect(screen.getByLabelText('Marketing')).toBeInTheDocument();
         expect(screen.getByLabelText('Sales')).toBeInTheDocument();
+      });
+
+      it('should support building filter options for columns with accessor function', async () => {
+        const user = userEvent.setup();
+
+        const data = [
+          { id: '1', name: 'Alice Johnson', department: 'Engineering', status: 'Active' },
+          { id: '2', name: 'Bob Smith', department: 'Marketing', status: 'Inactive' },
+          { id: '3', name: 'Carol Davis', department: 'Sales', status: 'Active' },
+        ];
+
+        const columns = [
+          { id: 'name', label: 'Name' },
+          {
+            id: 'department-column-id',
+            label: 'Department',
+            accessor: ((row: { department: string }) =>
+              `Dept: ${row.department}`) as unknown as Accessor<{ department: string }>,
+          },
+          { id: 'status', label: 'Status' },
+        ];
+
+        render(
+          <Table data={data} columns={columns} actionBarConfig={{ enableFilters: true }} />,
+          buildWrapper([
+            getBaseProviderWrapper(),
+            getInterpolationProviderWrapper(),
+            getRouterWrapper(),
+          ])
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Add filter' }));
+        await user.click(screen.getByTestId('filter-option-Department'));
+
+        await waitFor(() => {
+          expect(screen.getAllByText('Dept: Engineering')).toHaveLength(2);
+        });
       });
     });
   });

--- a/javascript/packages/core/components/table/table.tsx
+++ b/javascript/packages/core/components/table/table.tsx
@@ -21,7 +21,6 @@ import { TableSelectionProvider } from './plugins/selection/table-selection-prov
 import { applyDefaultProps } from './utils/apply-default-props';
 import { composeTableState } from './utils/compose-table-state';
 import { getTableViewState } from './utils/get-table-view-state';
-import { normalizeColumnAccessor } from './utils/normalize-column-accessor';
 import { transformColumns } from './utils/transform-columns';
 
 import type { TableData } from './types/data-types';
@@ -80,7 +79,7 @@ export function Table<T extends TableData = TableData>(inputProps: TableProps<T>
     getValue: (columnId: string) => {
       const column = columns.find((col) => col.id === columnId);
       if (!column) return undefined;
-      return normalizeColumnAccessor(column)(rowData);
+      return column.accessorFn(rowData);
     },
   }));
 


### PR DESCRIPTION
The initial implementation of unfiltered data resulted in columns missing category filter options if the column used an accessor function for getting cell values.

This is because the columns references to build the unfiltered data list had been transformed to be Tanstack Table friendly, with accessorFn prop instead of accessor.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
