### PR TITLE
Disable page index reset

### DIFF
--- a/javascript/packages/core/components/table/table.tsx
+++ b/javascript/packages/core/components/table/table.tsx
@@ -61,6 +61,7 @@ export function Table<T extends TableData = TableData>(inputProps: TableProps<T>
       : {}),
     enableRowSelection: props.enableRowSelection,
     globalFilterFn: 'includesString',
+    autoResetPageIndex: false,
   });
 
   const viewState = getTableViewState({


### PR DESCRIPTION
Default behavior for Tanstack Table is to reset some table state on props change. MA Studio doesn't want this for page indices, as it has the potential to block changing table pages

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested by importing the Table component into Uber's internal codebase and verifying pagination operation is the same.


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
