### PR TITLE
Fix issues during Execution merge back

### DIFF
--- a/javascript/packages/core/components/views/execution/__tests__/execution.test.tsx
+++ b/javascript/packages/core/components/views/execution/__tests__/execution.test.tsx
@@ -3,6 +3,8 @@ import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 
 import { CellType } from '#core/components/cell/constants';
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
 import {
   buildExecutionSchemaFactory,
   buildTaskStepFactory,
@@ -29,7 +31,7 @@ describe('Execution view', () => {
       },
     };
 
-    render(<Execution schema={buildSchema()} data={executionData} />);
+    render(<Execution schema={buildSchema()} data={executionData} />, buildWrapper([getRouterWrapper()]));
 
     // Should render each parent task in both overview and details sections
     expect(screen.getAllByText('Build Pipeline')).toHaveLength(2);
@@ -73,7 +75,7 @@ describe('Execution view', () => {
       },
     };
 
-    render(<Execution schema={buildSchema()} data={executionData} />);
+    render(<Execution schema={buildSchema()} data={executionData} />, buildWrapper([getRouterWrapper()]));
 
     // Should render parent task in both sections
     expect(screen.getAllByText('Unfocused Step')).toHaveLength(2);
@@ -150,7 +152,7 @@ describe('Execution view', () => {
       },
     };
 
-    render(<Execution schema={schemaWithMetadata} data={executionData} />);
+    render(<Execution schema={schemaWithMetadata} data={executionData} />, buildWrapper([getRouterWrapper()]));
 
     // Should render task name in both sections (Overview + Details)
     expect(screen.getAllByText('Build Task')).toHaveLength(2);
@@ -163,7 +165,7 @@ describe('Execution view', () => {
   it('should handle empty execution data gracefully', () => {
     const emptyData = {};
 
-    render(<Execution schema={buildSchema()} data={emptyData} />);
+    render(<Execution schema={buildSchema()} data={emptyData} />, buildWrapper([getRouterWrapper()]));
 
     expect(screen.getByText('No execution data')).toBeInTheDocument();
     expect(screen.getByText('No tasks available')).toBeInTheDocument();
@@ -186,15 +188,14 @@ describe('Execution view', () => {
             markdown: false,
           },
           {
-            type: 'metadata',
+            type: 'metadata' as const,
             label: 'Performance',
-            accessor: 'performance',
             cells: [
               {
                 id: 'duration',
                 label: 'Duration',
                 type: CellType.TEXT,
-                accessor: 'duration',
+                accessor: 'performance.duration',
               },
             ],
           },
@@ -235,7 +236,7 @@ describe('Execution view', () => {
       },
     };
 
-    render(<Execution schema={schemaWithBody} data={executionData} />);
+    render(<Execution schema={schemaWithBody} data={executionData} />, buildWrapper([getRouterWrapper()]));
 
     // All body schema labels should be present for focused task
     expect(screen.getByText('Input Parameters')).toBeInTheDocument();
@@ -283,7 +284,7 @@ describe('Execution view', () => {
         },
       };
 
-      render(<Execution schema={buildSchema()} data={executionData} />);
+      render(<Execution schema={buildSchema()} data={executionData} />, buildWrapper([getRouterWrapper()]));
 
       // Click task name in overview
       await user.click(screen.getAllByText('Build Pipeline')[0]);
@@ -313,7 +314,7 @@ describe('Execution view', () => {
         },
       };
 
-      render(<Execution schema={buildSchema()} data={executionData} />);
+      render(<Execution schema={buildSchema()} data={executionData} />, buildWrapper([getRouterWrapper()]));
 
       // Click subtask name in overview
       await user.click(screen.getAllByText('feature_prep')[0]);

--- a/javascript/packages/core/components/views/execution/__tests__/execution.test.tsx
+++ b/javascript/packages/core/components/views/execution/__tests__/execution.test.tsx
@@ -31,7 +31,10 @@ describe('Execution view', () => {
       },
     };
 
-    render(<Execution schema={buildSchema()} data={executionData} />, buildWrapper([getRouterWrapper()]));
+    render(
+      <Execution schema={buildSchema()} data={executionData} />,
+      buildWrapper([getRouterWrapper()])
+    );
 
     // Should render each parent task in both overview and details sections
     expect(screen.getAllByText('Build Pipeline')).toHaveLength(2);
@@ -75,7 +78,10 @@ describe('Execution view', () => {
       },
     };
 
-    render(<Execution schema={buildSchema()} data={executionData} />, buildWrapper([getRouterWrapper()]));
+    render(
+      <Execution schema={buildSchema()} data={executionData} />,
+      buildWrapper([getRouterWrapper()])
+    );
 
     // Should render parent task in both sections
     expect(screen.getAllByText('Unfocused Step')).toHaveLength(2);
@@ -152,7 +158,10 @@ describe('Execution view', () => {
       },
     };
 
-    render(<Execution schema={schemaWithMetadata} data={executionData} />, buildWrapper([getRouterWrapper()]));
+    render(
+      <Execution schema={schemaWithMetadata} data={executionData} />,
+      buildWrapper([getRouterWrapper()])
+    );
 
     // Should render task name in both sections (Overview + Details)
     expect(screen.getAllByText('Build Task')).toHaveLength(2);
@@ -165,7 +174,10 @@ describe('Execution view', () => {
   it('should handle empty execution data gracefully', () => {
     const emptyData = {};
 
-    render(<Execution schema={buildSchema()} data={emptyData} />, buildWrapper([getRouterWrapper()]));
+    render(
+      <Execution schema={buildSchema()} data={emptyData} />,
+      buildWrapper([getRouterWrapper()])
+    );
 
     expect(screen.getByText('No execution data')).toBeInTheDocument();
     expect(screen.getByText('No tasks available')).toBeInTheDocument();
@@ -236,7 +248,10 @@ describe('Execution view', () => {
       },
     };
 
-    render(<Execution schema={schemaWithBody} data={executionData} />, buildWrapper([getRouterWrapper()]));
+    render(
+      <Execution schema={schemaWithBody} data={executionData} />,
+      buildWrapper([getRouterWrapper()])
+    );
 
     // All body schema labels should be present for focused task
     expect(screen.getByText('Input Parameters')).toBeInTheDocument();
@@ -284,7 +299,10 @@ describe('Execution view', () => {
         },
       };
 
-      render(<Execution schema={buildSchema()} data={executionData} />, buildWrapper([getRouterWrapper()]));
+      render(
+        <Execution schema={buildSchema()} data={executionData} />,
+        buildWrapper([getRouterWrapper()])
+      );
 
       // Click task name in overview
       await user.click(screen.getAllByText('Build Pipeline')[0]);
@@ -314,7 +332,10 @@ describe('Execution view', () => {
         },
       };
 
-      render(<Execution schema={buildSchema()} data={executionData} />, buildWrapper([getRouterWrapper()]));
+      render(
+        <Execution schema={buildSchema()} data={executionData} />,
+        buildWrapper([getRouterWrapper()])
+      );
 
       // Click subtask name in overview
       await user.click(screen.getAllByText('feature_prep')[0]);

--- a/javascript/packages/core/components/views/execution/components/task-details/__tests__/task-body.test.tsx
+++ b/javascript/packages/core/components/views/execution/components/task-details/__tests__/task-body.test.tsx
@@ -2,6 +2,8 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { CellType } from '#core/components/cell/constants';
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
 import { TASK_STATE } from '#core/components/views/execution/constants';
 import { createTask } from '../__fixtures__/task-details-fixtures';
 import { TaskBody } from '../task-body';
@@ -19,7 +21,7 @@ describe('TaskBody', () => {
       ],
     });
 
-    render(<TaskBody task={taskWithSubtasks} />);
+    render(<TaskBody task={taskWithSubtasks} />, buildWrapper([getRouterWrapper()]));
 
     expect(screen.getAllByText('Child Task 1')).toHaveLength(2);
     expect(screen.getAllByText('Child Task 2')).toHaveLength(2);
@@ -32,7 +34,7 @@ describe('TaskBody', () => {
       subTasks: [createTask({ name: 'Only Child' })],
     });
 
-    render(<TaskBody task={taskWithOneSubtask} />);
+    render(<TaskBody task={taskWithOneSubtask} />, buildWrapper([getRouterWrapper()]));
 
     expect(screen.getAllByText('Only Child')).toHaveLength(2);
   });
@@ -47,7 +49,7 @@ describe('TaskBody', () => {
       ],
     });
 
-    render(<TaskBody task={taskWithMixedSubtasks} />);
+    render(<TaskBody task={taskWithMixedSubtasks} />, buildWrapper([getRouterWrapper()]));
 
     expect(screen.getAllByText('Success Task')).toHaveLength(2);
     expect(screen.getAllByText('Running Task')).toHaveLength(2);
@@ -65,13 +67,13 @@ describe('TaskBody', () => {
 
     const bodySchema = [
       {
-        type: 'struct',
+        type: 'struct' as const,
         label: 'Task Output',
         accessor: 'output',
       },
     ];
 
-    render(<TaskBody task={leafTask} bodySchema={bodySchema} />);
+    render(<TaskBody task={leafTask} bodySchema={bodySchema} />, buildWrapper([getRouterWrapper()]));
 
     expect(screen.getByText('Task Output')).toBeInTheDocument();
   });
@@ -87,13 +89,13 @@ describe('TaskBody', () => {
 
     const bodySchema = [
       {
-        type: 'struct',
+        type: 'struct' as const,
         label: 'Should Not Render',
         accessor: 'output',
       },
     ];
 
-    render(<TaskBody task={taskWithBoth} bodySchema={bodySchema} />);
+    render(<TaskBody task={taskWithBoth} bodySchema={bodySchema} />, buildWrapper([getRouterWrapper()]));
 
     // Should render subtask, not body schema
     expect(screen.getAllByText('Child Task')).toHaveLength(2);
@@ -110,14 +112,14 @@ describe('TaskBody', () => {
 
     const bodySchema = [
       {
-        type: 'textarea',
+        type: 'textarea' as const,
         label: 'Error Log',
         accessor: 'errorLog',
         markdown: false,
       },
     ];
 
-    render(<TaskBody task={taskWithTextarea} bodySchema={bodySchema} />);
+    render(<TaskBody task={taskWithTextarea} bodySchema={bodySchema} />, buildWrapper([getRouterWrapper()]));
 
     expect(screen.getByText('Error Log')).toBeInTheDocument();
     expect(screen.getByText('Pipeline failed at step 3')).toBeInTheDocument();
@@ -137,27 +139,26 @@ describe('TaskBody', () => {
 
     const bodySchema = [
       {
-        type: 'metadata',
+        type: 'metadata' as const,
         label: 'Task Metadata',
-        accessor: 'metadata',
         cells: [
           {
             id: 'status',
             label: 'Status',
             type: CellType.TEXT,
-            accessor: 'status',
+            accessor: 'metadata.status',
           },
           {
             id: 'duration',
             label: 'Duration',
             type: CellType.TEXT,
-            accessor: 'duration',
+            accessor: 'metadata.duration',
           },
         ],
       },
     ];
 
-    render(<TaskBody task={taskWithMetadata} bodySchema={bodySchema} />);
+    render(<TaskBody task={taskWithMetadata} bodySchema={bodySchema} />, buildWrapper([getRouterWrapper()]));
 
     const accordionButton = screen.getByRole('button', { name: /Task Metadata/ });
     await user.click(accordionButton);
@@ -180,7 +181,7 @@ describe('TaskBody', () => {
       } as unknown as TaskBodySchema,
     ];
 
-    render(<TaskBody task={taskWithUnknownSchema} bodySchema={bodySchema} />);
+    render(<TaskBody task={taskWithUnknownSchema} bodySchema={bodySchema} />, buildWrapper([getRouterWrapper()]));
 
     expect(screen.queryByText('Unknown')).not.toBeInTheDocument();
   });

--- a/javascript/packages/core/components/views/execution/components/task-details/__tests__/task-body.test.tsx
+++ b/javascript/packages/core/components/views/execution/components/task-details/__tests__/task-body.test.tsx
@@ -2,9 +2,9 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { CellType } from '#core/components/cell/constants';
+import { TASK_STATE } from '#core/components/views/execution/constants';
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
-import { TASK_STATE } from '#core/components/views/execution/constants';
 import { createTask } from '../__fixtures__/task-details-fixtures';
 import { TaskBody } from '../task-body';
 
@@ -73,7 +73,10 @@ describe('TaskBody', () => {
       },
     ];
 
-    render(<TaskBody task={leafTask} bodySchema={bodySchema} />, buildWrapper([getRouterWrapper()]));
+    render(
+      <TaskBody task={leafTask} bodySchema={bodySchema} />,
+      buildWrapper([getRouterWrapper()])
+    );
 
     expect(screen.getByText('Task Output')).toBeInTheDocument();
   });
@@ -95,7 +98,10 @@ describe('TaskBody', () => {
       },
     ];
 
-    render(<TaskBody task={taskWithBoth} bodySchema={bodySchema} />, buildWrapper([getRouterWrapper()]));
+    render(
+      <TaskBody task={taskWithBoth} bodySchema={bodySchema} />,
+      buildWrapper([getRouterWrapper()])
+    );
 
     // Should render subtask, not body schema
     expect(screen.getAllByText('Child Task')).toHaveLength(2);
@@ -119,7 +125,10 @@ describe('TaskBody', () => {
       },
     ];
 
-    render(<TaskBody task={taskWithTextarea} bodySchema={bodySchema} />, buildWrapper([getRouterWrapper()]));
+    render(
+      <TaskBody task={taskWithTextarea} bodySchema={bodySchema} />,
+      buildWrapper([getRouterWrapper()])
+    );
 
     expect(screen.getByText('Error Log')).toBeInTheDocument();
     expect(screen.getByText('Pipeline failed at step 3')).toBeInTheDocument();
@@ -158,7 +167,10 @@ describe('TaskBody', () => {
       },
     ];
 
-    render(<TaskBody task={taskWithMetadata} bodySchema={bodySchema} />, buildWrapper([getRouterWrapper()]));
+    render(
+      <TaskBody task={taskWithMetadata} bodySchema={bodySchema} />,
+      buildWrapper([getRouterWrapper()])
+    );
 
     const accordionButton = screen.getByRole('button', { name: /Task Metadata/ });
     await user.click(accordionButton);
@@ -181,7 +193,10 @@ describe('TaskBody', () => {
       } as unknown as TaskBodySchema,
     ];
 
-    render(<TaskBody task={taskWithUnknownSchema} bodySchema={bodySchema} />, buildWrapper([getRouterWrapper()]));
+    render(
+      <TaskBody task={taskWithUnknownSchema} bodySchema={bodySchema} />,
+      buildWrapper([getRouterWrapper()])
+    );
 
     expect(screen.queryByText('Unknown')).not.toBeInTheDocument();
   });

--- a/javascript/packages/core/components/views/execution/components/task-details/__tests__/task-details.test.tsx
+++ b/javascript/packages/core/components/views/execution/components/task-details/__tests__/task-details.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
 import { createTask } from '../__fixtures__/task-details-fixtures';
 import { TaskDetails } from '../task-details';
 
@@ -8,7 +10,7 @@ describe('TaskDetails', () => {
   it('should render simple header when task has no subtasks and no bodySchema', () => {
     const leafTask = createTask({ name: 'Leaf Task' });
 
-    render(<TaskDetails task={leafTask} />);
+    render(<TaskDetails task={leafTask} />, buildWrapper([getRouterWrapper()]));
 
     expect(screen.getByText('Leaf Task')).toBeInTheDocument();
 
@@ -21,7 +23,7 @@ describe('TaskDetails', () => {
       subTasks: [createTask({ name: 'Child Task 1' }), createTask({ name: 'Child Task 2' })],
     });
 
-    render(<TaskDetails task={taskWithSubtasks} />);
+    render(<TaskDetails task={taskWithSubtasks} />, buildWrapper([getRouterWrapper()]));
 
     expect(screen.getByText('Parent Task')).toBeInTheDocument();
 
@@ -33,13 +35,13 @@ describe('TaskDetails', () => {
     const leafTaskWithBodySchema = createTask({ name: 'Data Processing Task' });
     const bodySchema = [
       {
-        type: 'struct',
+        type: 'struct' as const,
         label: 'Input Parameters',
         accessor: 'input',
       },
     ];
 
-    render(<TaskDetails task={leafTaskWithBodySchema} bodySchema={bodySchema} />);
+    render(<TaskDetails task={leafTaskWithBodySchema} bodySchema={bodySchema} />, buildWrapper([getRouterWrapper()]));
 
     expect(screen.getByText('Data Processing Task')).toBeInTheDocument();
 
@@ -53,7 +55,7 @@ describe('TaskDetails', () => {
       subTasks: [createTask({ name: 'Child Task' })],
     });
 
-    render(<TaskDetails task={taskWithSubtasks} />);
+    render(<TaskDetails task={taskWithSubtasks} />, buildWrapper([getRouterWrapper()]));
 
     const accordionPanel = screen.getByRole('button', { expanded: false });
     expect(accordionPanel).toBeInTheDocument();
@@ -68,7 +70,7 @@ describe('TaskDetails', () => {
       subTasks: [createTask({ name: 'Child Task 1' }), createTask({ name: 'Child Task 2' })],
     });
 
-    render(<TaskDetails task={taskWithSubtasks} />);
+    render(<TaskDetails task={taskWithSubtasks} />, buildWrapper([getRouterWrapper()]));
 
     const accordionPanel = screen.getByRole('button', { expanded: false });
     await user.click(accordionPanel);
@@ -80,7 +82,7 @@ describe('TaskDetails', () => {
   it('should handle tasks with empty subtasks array as leaf task', () => {
     const taskWithEmptySubtasks = createTask({ name: 'Task', subTasks: [] });
 
-    render(<TaskDetails task={taskWithEmptySubtasks} />);
+    render(<TaskDetails task={taskWithEmptySubtasks} />, buildWrapper([getRouterWrapper()]));
 
     expect(screen.getByText('Task')).toBeInTheDocument();
     expect(screen.queryByRole('button', { expanded: false })).not.toBeInTheDocument();

--- a/javascript/packages/core/components/views/execution/components/task-details/__tests__/task-details.test.tsx
+++ b/javascript/packages/core/components/views/execution/components/task-details/__tests__/task-details.test.tsx
@@ -41,7 +41,10 @@ describe('TaskDetails', () => {
       },
     ];
 
-    render(<TaskDetails task={leafTaskWithBodySchema} bodySchema={bodySchema} />, buildWrapper([getRouterWrapper()]));
+    render(
+      <TaskDetails task={leafTaskWithBodySchema} bodySchema={bodySchema} />,
+      buildWrapper([getRouterWrapper()])
+    );
 
     expect(screen.getByText('Data Processing Task')).toBeInTheDocument();
 

--- a/javascript/packages/core/components/views/execution/components/task-details/renderers/__tests__/task-body-struct.test.tsx
+++ b/javascript/packages/core/components/views/execution/components/task-details/renderers/__tests__/task-body-struct.test.tsx
@@ -41,20 +41,15 @@ describe('TaskBodyStruct', () => {
     expect(screen.getByText('"1.0.0"')).toBeInTheDocument();
   });
 
-  it('should handle null and undefined values', async () => {
+  it('should handle undefined values', async () => {
     const user = userEvent.setup();
 
-    const { rerender } = render(<TaskBodyStruct label="Empty Value" value={null} />);
+    render(<TaskBodyStruct label="Empty Value" value={undefined} />);
 
     const accordionButton = screen.getByRole('button', { name: /Empty Value/ });
     await user.click(accordionButton);
 
-    expect(screen.getByText('null')).toBeInTheDocument();
-
-    rerender(<TaskBodyStruct label="Empty Value" value={undefined} />);
-    await user.click(accordionButton);
-
-    expect(screen.getByRole('textbox')).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: '' })).toBeInTheDocument();
   });
 
   it('should not allow editing the JSON content', async () => {

--- a/javascript/packages/core/components/views/execution/components/task-details/renderers/task-body-struct.tsx
+++ b/javascript/packages/core/components/views/execution/components/task-details/renderers/task-body-struct.tsx
@@ -4,7 +4,9 @@ import { TextEditor } from '#core/components/text-editor/text-editor';
 import { TaskPanel } from '#core/components/views/execution/styled-components';
 import { decodeStruct, isStruct } from '#core/utils/proto/struct-utils';
 
-export function TaskBodyStruct(props: { label: string; value: object | undefined | null }) {
+import type { TaskBodyStructProps } from './types';
+
+export function TaskBodyStruct(props: TaskBodyStructProps) {
   const { label, value } = props;
 
   const decodedValue = isStruct(value) ? decodeStruct(value) : value;

--- a/javascript/packages/core/components/views/execution/components/task-details/renderers/types.ts
+++ b/javascript/packages/core/components/views/execution/components/task-details/renderers/types.ts
@@ -1,7 +1,7 @@
 import type { RowCell } from '#core/components/row/types';
 import type { Accessor } from '#core/types/common/studio-types';
 
-export type TaskBodySchema = SharedTaskBodySchema | TaskBodyTextareaSchema | TaskBodyMetadataSchema;
+export type TaskBodySchema = TaskBodyStructSchema | TaskBodyTextareaSchema | TaskBodyMetadataSchema;
 
 export interface SharedTaskBodySchema {
   /**
@@ -12,6 +12,10 @@ export interface SharedTaskBodySchema {
   type: string;
 
   label: string;
+}
+
+export interface TaskBodyStructSchema extends SharedTaskBodySchema {
+  type: 'struct';
 
   /**
    * Used to access the value of the body content
@@ -19,22 +23,38 @@ export interface SharedTaskBodySchema {
    * @example 'spec.content.metadata.name'
    * @example (task) => task.input
    */
-  accessor: Accessor<unknown>;
+  accessor: Accessor<object>;
 }
 
 export interface TaskBodyTextareaSchema extends SharedTaskBodySchema {
+  type: 'textarea';
+
   error?: boolean;
   markdown?: boolean;
+
+  /**
+   * Used to access the value of the body content
+   *
+   * @example 'spec.content.metadata.name'
+   * @example (task) => task.input
+   */
+  accessor: Accessor<string>;
 }
 
 export interface TaskBodyMetadataSchema extends SharedTaskBodySchema {
+  type: 'metadata';
+
   cells: RowCell[];
+}
+
+export interface TaskBodyStructProps extends Omit<TaskBodyStructSchema, 'type' | 'accessor'> {
+  value?: object;
 }
 
 export interface TaskBodyTextAreaProps extends Omit<TaskBodyTextareaSchema, 'type' | 'accessor'> {
   value?: string;
 }
 
-export interface TaskBodyMetadataProps extends Omit<TaskBodyMetadataSchema, 'type' | 'accessor'> {
+export interface TaskBodyMetadataProps extends Omit<TaskBodyMetadataSchema, 'type'> {
   value?: Record<string, unknown>;
 }

--- a/javascript/packages/core/components/views/execution/components/task-details/task-body.tsx
+++ b/javascript/packages/core/components/views/execution/components/task-details/task-body.tsx
@@ -2,12 +2,12 @@ import { useStyletron } from 'baseui';
 
 import { Box } from '#core/components/box/box';
 import { TaskContentStack } from '#core/components/views/execution/styled-components';
+import { useInterpolationResolver } from '#core/interpolation/use-interpolation-resolver';
 import { getObjectValue } from '#core/utils/object-utils';
 import { TaskFlow } from '../task-flow';
 import { TaskBodyMetadata } from './renderers/task-body-metadata';
 import { TaskBodyStruct } from './renderers/task-body-struct';
 import { TaskBodyTextarea } from './renderers/task-body-textarea';
-import { TaskBodyMetadataSchema, TaskBodyTextareaSchema } from './renderers/types';
 import { TaskDetails } from './task-details';
 
 import type { TaskBodyProps } from './types';
@@ -16,6 +16,7 @@ export function TaskBody<TTaskRecord extends object>(props: TaskBodyProps<TTaskR
   const [css, theme] = useStyletron();
   const { task, bodySchema } = props;
   const { subTasks } = task;
+  const resolver = useInterpolationResolver();
 
   if (subTasks?.length) {
     return (
@@ -31,25 +32,27 @@ export function TaskBody<TTaskRecord extends object>(props: TaskBodyProps<TTaskR
   }
 
   if (bodySchema?.length) {
+    const resolvedBodySchema = resolver(bodySchema, { row: task });
     return (
       <div
         className={css({ display: 'flex', flexDirection: 'column', gap: theme.sizing.scale600 })}
       >
-        {bodySchema.map((schema, index) => {
+        {resolvedBodySchema.map((schema, index) => {
           const { label } = schema;
-          const value = getObjectValue<unknown>(task.record, schema.accessor);
 
           if (schema.type === 'struct') {
-            return <TaskBodyStruct key={index} label={label} value={value as object} />;
+            const value = getObjectValue<object>(task.record, schema.accessor);
+            return <TaskBodyStruct key={index} label={label} value={value} />;
           }
 
           if (schema.type === 'textarea') {
-            const { error, markdown } = schema as TaskBodyTextareaSchema;
+            const value = getObjectValue<string>(task.record, schema.accessor);
+            const { error, markdown } = schema;
             return (
               <TaskBodyTextarea
                 key={index}
                 label={label}
-                value={value as string}
+                value={value}
                 error={error}
                 markdown={markdown}
               />
@@ -57,12 +60,12 @@ export function TaskBody<TTaskRecord extends object>(props: TaskBodyProps<TTaskR
           }
 
           if (schema.type === 'metadata') {
-            const { cells } = schema as TaskBodyMetadataSchema;
+            const { cells } = schema;
             return (
               <TaskBodyMetadata
                 key={index}
                 label={label}
-                value={value as Record<string, unknown>}
+                value={task.record as Record<string, unknown>}
                 cells={cells}
               />
             );

--- a/javascript/packages/core/components/views/execution/utils/build-task-list.ts
+++ b/javascript/packages/core/components/views/execution/utils/build-task-list.ts
@@ -39,8 +39,11 @@ export function buildTaskList<TData extends object, TTaskRecord extends object>(
       return state !== TASK_STATE.SUCCESS && state !== TASK_STATE.SKIPPED;
     });
 
+    const primaryHeading = getObjectValue(taskRecord, tasks.header.heading);
+    const fallbackName = get(taskRecord, 'name');
+
     return {
-      name: (getObjectValue(taskRecord, tasks.header.heading) ?? get(taskRecord, 'name'))!,
+      name: (primaryHeading?.trim() ? primaryHeading : fallbackName)!,
       state: schema.tasks.stateBuilder(taskRecord, taskIndex, siblingTasks, data),
       subTasks: subTasksAccessor
         ? getObjectValue(taskRecord, subTasksAccessor, [])!.map(buildTask)

--- a/javascript/packages/core/components/views/sandbox/sandbox.tsx
+++ b/javascript/packages/core/components/views/sandbox/sandbox.tsx
@@ -96,24 +96,19 @@ const executionSchema: ExecutionDetailViewSchema = {
         accessor: 'output',
       },
       {
-        type: 'metadata',
+        type: 'metadata' as const,
         label: 'Execution Info',
-        accessor: (record: { displayName?: string; logUrl?: string }) => {
-          return {
-            executionName: record.displayName ?? 'N/A',
-            logUrl: record.logUrl ?? '',
-          };
-        },
         cells: [
           {
-            id: 'executionName',
+            id: 'displayName',
             label: 'Execution Name',
             type: CellType.TEXT,
-            accessor: 'executionName',
+            accessor: 'displayName',
           },
           {
             id: 'logUrl',
             label: 'Log URL',
+            accessor: 'logUrl',
           },
         ],
       },


### PR DESCRIPTION
accessor is not a common task body schema property, as metadata renderer inlines accessor within cell. Explicitly added accessor (with expected output type) in each type and added explicit type for clarity and type safety.

Task body renderer accepts interpolations at the task-level, for example metadata cells is an interpolator in Uber's instantiation of the pipeline run execution view.

The fallback for task name was not engaging, since the getObjectValue was returning an empty string (non-falsy).

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local: <img width="1840" height="1128" alt="Screenshot 2025-08-31 at 14 05 12" src="https://github.com/user-attachments/assets/88a1ebb5-f9e3-47f0-8ac9-5825ed3c2878" />

Also tested by installing in Uber environment

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
