### PR TITLE
Implement configuration-driven entity detail view

### DIFF
--- a/javascript/packages/core/components/views/phase-entity-view/__tests__/utils.test.ts
+++ b/javascript/packages/core/components/views/phase-entity-view/__tests__/utils.test.ts
@@ -51,9 +51,9 @@ describe('isListableEntity', () => {
         state: 'active',
         views: [
           {
-            // @ts-expect-error - detail is not a valid view type
             type: 'detail',
-            columns: [],
+            metadata: [],
+            pages: [],
           },
         ],
       },
@@ -82,9 +82,9 @@ describe('isListableEntity', () => {
             columns: [{ id: 'name', label: 'Name', type: CellType.TEXT }],
           },
           {
-            // @ts-expect-error - detail is not a valid view type
             type: 'detail',
-            columns: [],
+            metadata: [],
+            pages: [],
           },
         ],
       },
@@ -96,9 +96,9 @@ describe('isListableEntity', () => {
         state: 'active',
         views: [
           {
-            // @ts-expect-error - detail is not a valid view type
             type: 'detail',
-            columns: [],
+            metadata: [],
+            pages: [],
           },
           {
             type: 'list',

--- a/javascript/packages/core/components/views/types.ts
+++ b/javascript/packages/core/components/views/types.ts
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import type { Cell } from '#core/components/cell/types';
 import type { ColumnConfig } from '#core/components/table/types/column-types';
 
 export type MainViewContainerProps = {
@@ -6,9 +7,28 @@ export type MainViewContainerProps = {
   hasBreadcrumb?: boolean;
 };
 
+export type ViewConfig = ListViewConfig | DetailViewConfig;
+
 export interface ListViewConfig {
   type: 'list';
   columns: ColumnConfig[];
 }
 
-export type ViewConfig = ListViewConfig;
+export interface DetailViewConfig {
+  type: 'detail';
+  /**
+   * Metadata items to display in the detail view header
+   */
+  metadata: Cell[];
+  /**
+   * Content sections to display in the detail view
+   */
+  pages: DetailPageConfig[];
+}
+
+export interface DetailPageConfig {
+  /**
+   * Type of page content to render
+   */
+  type: string;
+}

--- a/javascript/packages/core/config/entities/pipeline/list.ts
+++ b/javascript/packages/core/config/entities/pipeline/list.ts
@@ -7,7 +7,7 @@ export const PIPELINE_CELL_CONFIG: ColumnConfig[] = [
   {
     id: 'metadata.name',
     label: 'Name',
-    url: '/${studio.projectId}/pipelines/${data.metadata.name}',
+    // url: '/${studio.projectId}/${studio.phase}/pipelines/${data.metadata.name}',
     tooltip: {
       content: 'Click to filter by this pipeline name',
       action: 'filter',

--- a/javascript/packages/core/config/entities/run/detail.ts
+++ b/javascript/packages/core/config/entities/run/detail.ts
@@ -1,0 +1,13 @@
+import { SHARED_RUN_CELL_CONFIG } from './shared';
+
+import type { DetailViewConfig } from '#core/components/views/types';
+
+export const RUN_DETAIL_CONFIG: DetailViewConfig = {
+  type: 'detail',
+  metadata: SHARED_RUN_CELL_CONFIG,
+  pages: [
+    {
+      type: 'execution',
+    },
+  ],
+};

--- a/javascript/packages/core/config/entities/run/list.ts
+++ b/javascript/packages/core/config/entities/run/list.ts
@@ -1,4 +1,4 @@
-import { CellType } from '#core/components/cell/constants';
+import { SHARED_RUN_CELL_CONFIG } from './shared';
 
 import type { ColumnConfig } from '#core/components/table/types/column-types';
 import type { ListViewConfig } from '#core/components/views/types';
@@ -7,51 +7,9 @@ export const PIPELINE_RUN_CELL_CONFIG: ColumnConfig[] = [
   {
     id: 'metadata.name',
     label: 'Name',
-    url: '/${studio.projectId}/runs/${data.metadata.name}',
+    url: '/${studio.projectId}/${studio.phase}/runs/${data.metadata.name}',
   },
-  { id: 'metadata.creationTimestamp.seconds', label: 'Created', type: CellType.DATE },
-  {
-    id: 'spec.pipeline.name',
-    label: 'Pipeline',
-    items: [
-      {
-        id: 'spec.pipeline.name',
-        type: CellType.TEXT,
-      },
-      {
-        id: 'spec.revision.name',
-        type: CellType.DESCRIPTION,
-      },
-    ],
-  },
-  {
-    id: 'spec.actor.name',
-    label: 'Started by',
-    type: CellType.TEXT,
-  },
-  {
-    id: 'status.state',
-    label: 'State',
-    type: CellType.STATE,
-    stateTextMap: {
-      0: 'Queued',
-      1: 'Pending',
-      2: 'Running',
-      3: 'Succeeded',
-      4: 'Killed',
-      5: 'Failed',
-      6: 'Skipped',
-    },
-    stateColorMap: {
-      0: 'gray',
-      1: 'blue',
-      2: 'blue',
-      3: 'green',
-      4: 'red',
-      5: 'red',
-      6: 'gray',
-    },
-  },
+  ...SHARED_RUN_CELL_CONFIG,
 ];
 
 export const RUN_LIST_CONFIG: ListViewConfig = {

--- a/javascript/packages/core/config/entities/run/run.ts
+++ b/javascript/packages/core/config/entities/run/run.ts
@@ -1,3 +1,4 @@
+import { RUN_DETAIL_CONFIG } from './detail';
 import { RUN_LIST_CONFIG } from './list';
 
 import type { PhaseEntityConfig } from '#core/types/common/studio-types';
@@ -7,5 +8,5 @@ export const RUN_ENTITY_CONFIG: PhaseEntityConfig = {
   name: 'Pipeline Runs',
   service: 'pipelineRun',
   state: 'active',
-  views: [RUN_LIST_CONFIG],
+  views: [RUN_LIST_CONFIG, RUN_DETAIL_CONFIG],
 };

--- a/javascript/packages/core/config/entities/run/shared.ts
+++ b/javascript/packages/core/config/entities/run/shared.ts
@@ -1,0 +1,53 @@
+import { CellType } from '#core/components/cell/constants';
+import { Cell } from '#core/components/cell/types';
+
+/**
+ * Cell configurations rendered for Pipeline Runs:
+ *  - Columns for list view
+ *  - Header metadata for detail view
+ */
+export const SHARED_RUN_CELL_CONFIG: Cell[] = [
+  { id: 'metadata.creationTimestamp.seconds', label: 'Created', type: CellType.DATE },
+  {
+    id: 'spec.pipeline.name',
+    label: 'Pipeline',
+    items: [
+      {
+        id: 'spec.pipeline.name',
+        type: CellType.TEXT,
+      },
+      {
+        id: 'spec.revision.name',
+        type: CellType.DESCRIPTION,
+      },
+    ],
+  },
+  {
+    id: 'spec.actor.name',
+    label: 'Started by',
+    type: CellType.TEXT,
+  },
+  {
+    id: 'status.state',
+    label: 'State',
+    type: CellType.STATE,
+    stateTextMap: {
+      0: 'Queued',
+      1: 'Pending',
+      2: 'Running',
+      3: 'Succeeded',
+      4: 'Killed',
+      5: 'Failed',
+      6: 'Skipped',
+    },
+    stateColorMap: {
+      0: 'gray',
+      1: 'blue',
+      2: 'blue',
+      3: 'green',
+      4: 'red',
+      5: 'red',
+      6: 'gray',
+    },
+  },
+];

--- a/javascript/packages/core/router/__tests__/entity-detail-route.test.tsx
+++ b/javascript/packages/core/router/__tests__/entity-detail-route.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+
+import { CellType } from '#core/components/cell/constants';
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getErrorProviderWrapper } from '#core/test/wrappers/get-error-provider-wrapper';
+import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
+import { getServiceProviderWrapper } from '#core/test/wrappers/get-service-provider-wrapper';
+import {
+  buildEntityConfigFactory,
+  buildPhaseConfigFactory,
+} from '../__fixtures__/phase-config-factory';
+import { EntityDetailRoute } from '../entity-detail-route';
+
+import type { PhaseConfig } from '#core/types/common/studio-types';
+
+describe('EntityDetailRoute', () => {
+  const buildEntity = buildEntityConfigFactory();
+  const buildPhase = buildPhaseConfigFactory();
+
+  const testPhaseEntityConfig: Record<string, PhaseConfig> = {
+    train: buildPhase({
+      id: 'train',
+      entities: [
+        buildEntity({
+          id: 'runs',
+          name: 'Pipeline Runs',
+          service: 'pipelineRun',
+          views: [
+            {
+              type: 'detail',
+              metadata: [
+                { id: 'metadata.creationTimestamp.seconds', label: 'Created', type: CellType.DATE },
+                { id: 'status.state', label: 'State', type: CellType.STATE },
+              ],
+              pages: [{ type: 'execution' }],
+            },
+          ],
+        }),
+      ],
+    }),
+  };
+
+  test('renders complete detail view with header', async () => {
+    const mockEntityData = {
+      pipelineRun: {
+        metadata: {
+          creationTimestamp: {
+            seconds: 1640995200, // 2022-01-01
+          },
+        },
+        status: {
+          state: 'RUNNING',
+        },
+      },
+    };
+    const mockRequest = vi.fn().mockResolvedValue(mockEntityData);
+
+    render(
+      <EntityDetailRoute phases={testPhaseEntityConfig} />,
+      buildWrapper([
+        getErrorProviderWrapper(),
+        getRouterWrapper({
+          location: '/myproject/train/runs/run-123',
+        }),
+        getServiceProviderWrapper({ request: mockRequest }),
+      ])
+    );
+
+    expect(screen.getByRole('button', { name: /go back/i })).toBeInTheDocument();
+    expect(screen.getByText('Pipeline Runs')).toBeInTheDocument(); // subtitle from entity config
+    expect(screen.getByText('run-123')).toBeInTheDocument(); // title from URL entityId
+
+    // Wait for and verify metadata is rendered
+    expect(await screen.findByText('State')).toBeInTheDocument();
+    expect(await screen.findByText('Running')).toBeInTheDocument();
+
+    expect(screen.getByText('execution will go here...')).toBeInTheDocument();
+  });
+
+  test('handles error when entity not found', async () => {
+    const mockRequest = vi.fn().mockRejectedValue(new Error('Entity not found'));
+
+    render(
+      <EntityDetailRoute phases={testPhaseEntityConfig} />,
+      buildWrapper([
+        getErrorProviderWrapper(),
+        getRouterWrapper({
+          location: '/myproject/train/runs/run-123',
+        }),
+        getServiceProviderWrapper({ request: mockRequest }),
+      ])
+    );
+
+    await screen.findByText('Entity not found');
+    expect(screen.getByRole('button', { name: /Back to list/i })).toBeInTheDocument();
+  });
+});

--- a/javascript/packages/core/router/entity-detail-route.tsx
+++ b/javascript/packages/core/router/entity-detail-route.tsx
@@ -1,0 +1,87 @@
+import { useNavigate } from 'react-router-dom-v5-compat';
+import { useStyletron } from 'baseui';
+
+import { ErrorView } from '#core/components/error-view/error-view';
+import { CircleExclamationMark } from '#core/components/illustrations/circle-exclamation-mark/circle-exclamation-mark';
+import { CircleExclamationMarkKind } from '#core/components/illustrations/circle-exclamation-mark/types';
+import { Row } from '#core/components/row/row';
+import { DetailView } from '#core/components/views/detail-view/detail-view';
+import { PHASES } from '#core/config/phases/phases';
+import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
+import { useStudioQuery } from '#core/hooks/use-studio-query';
+import { capitalizeFirstLetter } from '#core/utils/string-utils';
+
+import type { PhaseConfig } from '#core/types/common/studio-types';
+
+/**
+ * Route component that handles entity detail views.
+ *
+ * Maps URL parameters to specific entity detail pages and handles:
+ * - Unknown phases/entities with appropriate error messages
+ * - Entity not found scenarios
+ * - Navigation back to entity list
+ *
+ * @param phases - Phase configuration override for testing
+ */
+export function EntityDetailRoute({ phases = PHASES }: { phases: Record<string, PhaseConfig> }) {
+  const [, theme] = useStyletron();
+  const { phase, entity, entityId, projectId } = useStudioParams('detail');
+  const navigate = useNavigate();
+  const entityConfig = phases[phase].entities.find((e) => e.id === entity);
+  const { data, isLoading, error } = useStudioQuery<Record<string, unknown>>({
+    queryName: `Get${capitalizeFirstLetter(entityConfig?.service ?? '')}`,
+    serviceOptions: {
+      namespace: projectId,
+      name: entityId,
+    },
+    clientOptions: {
+      enabled: !!entityConfig?.service && !!entityId,
+    },
+  });
+
+  // TODO: error handling for URLs that don't match any entity config
+  const detailViewConfig =
+    (entityConfig?.views ?? []).find((view) => view.type === 'detail') ?? undefined;
+
+  if (error) {
+    return (
+      <ErrorView
+        title="Entity not found"
+        description={`Could not load ${entity} "${entityId}". ${error.message}`}
+        illustration={
+          <CircleExclamationMark
+            kind={CircleExclamationMarkKind.ERROR}
+            width={theme.sizing.scale1600}
+          />
+        }
+        buttonConfig={{
+          onClick: () => navigate(`/${projectId}/${phase}/${entity}`),
+          content: 'Back to list',
+        }}
+      />
+    );
+  }
+
+  const handleGoBack = () => {
+    navigate(`/${projectId}/${phase}/${entity}`);
+  };
+
+  return (
+    <DetailView
+      subtitle={entityConfig!.name}
+      title={entityId}
+      onGoBack={handleGoBack}
+      headerContent={
+        <Row
+          items={detailViewConfig!.metadata}
+          record={data?.[entityConfig!.service] as Record<string, unknown>}
+          loading={isLoading}
+        />
+      }
+    >
+      {detailViewConfig!.pages.map((page, index) => (
+        <div key={index}>{page.type} will go here...</div>
+      ))}
+    </DetailView>
+  );
+}

--- a/javascript/packages/core/router/entity-detail-route.tsx
+++ b/javascript/packages/core/router/entity-detail-route.tsx
@@ -17,13 +17,12 @@ import type { PhaseConfig } from '#core/types/common/studio-types';
  * Route component that handles entity detail views.
  *
  * Maps URL parameters to specific entity detail pages and handles:
- * - Unknown phases/entities with appropriate error messages
  * - Entity not found scenarios
  * - Navigation back to entity list
  *
- * @param phases - Phase configuration override for testing
+ * @param phases - Phase configuration override for testing. Defaults to {@link PHASES}.
  */
-export function EntityDetailRoute({ phases = PHASES }: { phases: Record<string, PhaseConfig> }) {
+export function EntityDetailRoute({ phases = PHASES }: { phases?: Record<string, PhaseConfig> }) {
   const [, theme] = useStyletron();
   const { phase, entity, entityId, projectId } = useStudioParams('detail');
   const navigate = useNavigate();

--- a/javascript/packages/core/router/router.tsx
+++ b/javascript/packages/core/router/router.tsx
@@ -4,6 +4,7 @@ import { MainViewContainer } from '#core/components/views/main-view-container';
 import { ProjectDetail } from '#core/components/views/project/project-detail';
 import { ProjectList } from '#core/components/views/project/project-list';
 import { Sandbox } from '#core/components/views/sandbox/sandbox';
+import { EntityDetailRoute } from './entity-detail-route';
 import { PhaseListRoute } from './phase-list-route';
 
 export function Router() {
@@ -30,6 +31,14 @@ export function Router() {
         element={
           <MainViewContainer hasBreadcrumb={false}>
             <ProjectDetail />
+          </MainViewContainer>
+        }
+      />
+      <Route
+        path=":projectId/:phase/:entity/:entityId/:entityTab?"
+        element={
+          <MainViewContainer hasBreadcrumb={false}>
+            <EntityDetailRoute />
           </MainViewContainer>
         }
       />

--- a/javascript/packages/core/test/wrappers/get-router-wrapper.tsx
+++ b/javascript/packages/core/test/wrappers/get-router-wrapper.tsx
@@ -40,6 +40,7 @@ export function getRouterWrapper(options?: { location?: string }) {
     return (
       <MemoryRouter initialEntries={[location]}>
         <Routes>
+          <Route path=":projectId/:phase/:entity/:entityId/:entityTab?" element={children} />
           <Route path=":projectId/:phase/:entity?" element={children} />
           <Route path=":projectId" element={children} />
           <Route path="*" element={children} />

--- a/javascript/packages/rpc/handlers.ts
+++ b/javascript/packages/rpc/handlers.ts
@@ -14,4 +14,7 @@ export const RPC_HANDLERS = {
   ListPipelineRun: SERVICES.PipelineRunService.listPipelineRun as ExtractUnaryRpc<
     typeof SERVICES.PipelineRunService.listPipelineRun
   >,
+  GetPipelineRun: SERVICES.PipelineRunService.getPipelineRun as ExtractUnaryRpc<
+    typeof SERVICES.PipelineRunService.getPipelineRun
+  >,
 } as const;


### PR DESCRIPTION
Create EntityDetailRoute component & onboard pipeline runs to display
simple metadata about a pipeline run

Existing pipeline runs column configuration is extracted into a shared
constant that can be used by both the run list columns configuration and
the run detail view metadata configuration.

Error handling for out of sync URLs and phase configuration is omitted
in favor of an upcoming centralized solution that reduces duplication
between PhaseEntityView and EntityDetailView.

<img width="1392" height="1105" alt="Screenshot 2025-09-02 at 14 09 49" src="https://github.com/user-attachments/assets/68a53270-c26d-41a6-93cc-186792cc2828" />


**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
