### PR TITLE
Provide Row action access to row record

### DIFF
--- a/javascript/packages/core/components/table/__tests__/table.test.tsx
+++ b/javascript/packages/core/components/table/__tests__/table.test.tsx
@@ -1544,8 +1544,9 @@ describe('Table', () => {
       { id: 'department', label: 'Department' },
     ];
 
-    const TestActions = ({ row }: { row: TableRow }) => (
+    const TestActions = ({ row }: { row: TableRow<{ name: string }> }) => (
       <div>
+        <span>Actions for row {row.record.name}</span>
         <button>Edit row {row.id}</button>
         <button>Delete row {row.id}</button>
       </div>
@@ -1557,6 +1558,8 @@ describe('Table', () => {
         buildWrapper([getInterpolationProviderWrapper(), getRouterWrapper()])
       );
 
+      expect(screen.getByText('Actions for row Alice Johnson')).toBeInTheDocument();
+      expect(screen.getByText('Actions for row Bob Smith')).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Edit row 0' })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Delete row 0' })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Edit row 1' })).toBeInTheDocument();

--- a/javascript/packages/core/components/table/components/table-body/row-transformer.ts
+++ b/javascript/packages/core/components/table/components/table-body/row-transformer.ts
@@ -13,6 +13,7 @@ export function transformRows<T extends TableData = TableData>(
       id: cell.id,
       content: flexRender(cell.column.columnDef.cell, cell.getContext()),
     })),
+    record: row.original,
     canSelect: row.getCanSelect(),
     isSelected: row.getIsSelected(),
     onToggleSelection: (selected: boolean) => row.toggleSelected(selected),

--- a/javascript/packages/core/components/table/components/table-body/types.ts
+++ b/javascript/packages/core/components/table/components/table-body/types.ts
@@ -11,6 +11,7 @@ export type TableCell<_T extends TableData = TableData> = {
 export type TableRow<T extends TableData = TableData> = {
   id: string;
   cells: TableCell<T>[];
+  record: T;
 } & SelectableCapability &
   ExpandableCapability;
 


### PR DESCRIPTION
Uber's internal use of table row actions require access to data for each particular row. For example, enabling a particular action for a row based on the type of data being displayed.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Installed internally in Uber and verified row actions were behaving as expected
Added unit test to verify that row record is provided to actions component

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
