### PR TITLE
Extend detail view pages with execution support

### DIFF
--- a/javascript/packages/core/components/views/detail-view/components/detail-view-page-renderer/detail-view-page-renderer.tsx
+++ b/javascript/packages/core/components/views/detail-view/components/detail-view-page-renderer/detail-view-page-renderer.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import { Execution } from '#core/components/views/execution/execution';
+
+import type {
+  CustomDetailPageConfig,
+  ExecutionDetailPageConfig,
+} from '#core/components/views/detail-view/types/detail-view-schema-types';
+import type { PageRendererProps } from './types';
+
+export function DetailViewPageRenderer<T extends object = object>({
+  page,
+  data,
+  isLoading,
+}: PageRendererProps<T>) {
+  switch (page.type) {
+    case 'custom':
+      return React.createElement((page as CustomDetailPageConfig).component, { data, isLoading });
+
+    case 'execution':
+      return <Execution schema={page as ExecutionDetailPageConfig} data={data ?? {}} />;
+
+    default:
+      return <div>Page type '{page.type}' not yet supported</div>;
+  }
+}

--- a/javascript/packages/core/components/views/detail-view/components/detail-view-page-renderer/types.ts
+++ b/javascript/packages/core/components/views/detail-view/components/detail-view-page-renderer/types.ts
@@ -1,0 +1,7 @@
+import type { DetailPageConfig } from '#core/components/views/detail-view/types/detail-view-schema-types';
+
+export interface PageRendererProps<T extends object = object> {
+  page: DetailPageConfig<T>;
+  data: T | undefined;
+  isLoading: boolean;
+}

--- a/javascript/packages/core/config/entities/run/detail.ts
+++ b/javascript/packages/core/config/entities/run/detail.ts
@@ -1,3 +1,5 @@
+import { CellType } from '#core/components/cell/constants';
+import { TASK_STATE } from '#core/components/views/execution/constants';
 import { SHARED_RUN_CELL_CONFIG } from './shared';
 
 import type { DetailViewConfig } from '#core/components/views/types';
@@ -7,9 +9,113 @@ export const RUN_DETAIL_CONFIG: DetailViewConfig = {
   metadata: SHARED_RUN_CELL_CONFIG,
   pages: [
     {
-      id: 'execution',
-      label: 'Execution',
+      id: 'steps',
+      label: 'Steps',
       type: 'execution',
+      emptyState: {
+        title: 'No execution data',
+        description: 'No steps available for this pipeline run',
+      },
+      tasks: {
+        accessor: 'status.steps',
+        subTasksAccessor: 'subSteps',
+        header: {
+          heading: 'displayName',
+          metadata: [
+            {
+              id: 'startTime.seconds',
+              label: 'Start time',
+              type: CellType.DATE,
+            },
+            {
+              id: 'endTime.seconds',
+              label: 'End time',
+              type: CellType.DATE,
+            },
+            {
+              id: 'duration',
+              label: 'Duration',
+              type: CellType.TEXT,
+              accessor: (record: {
+                startTime: { seconds: string };
+                endTime: { seconds: string };
+              }) => {
+                if (record.startTime?.seconds && record.endTime?.seconds) {
+                  const start = parseInt(record.startTime.seconds) * 1000;
+                  const end = parseInt(record.endTime.seconds) * 1000;
+                  const durationMs = end - start;
+                  const durationSec = Math.round(durationMs / 1000);
+                  return `${durationSec}s`;
+                }
+                return null;
+              },
+            },
+            {
+              id: 'logUrl',
+              label: 'Logs',
+            },
+            {
+              id: 'state',
+              label: 'Status',
+              type: CellType.STATE,
+              stateTextMap: {
+                0: 'Pending',
+                1: 'Pending',
+                2: 'Running',
+                3: 'Success',
+                4: 'Killed',
+                5: 'Failed',
+                6: 'Skipped',
+              },
+              stateColorMap: {
+                0: 'gray',
+                1: 'blue',
+                2: 'blue',
+                3: 'green',
+                4: 'red',
+                5: 'red',
+                6: 'gray',
+              },
+            },
+          ],
+        },
+        body: [
+          {
+            type: 'struct',
+            label: 'Input Parameters',
+            accessor: 'input',
+          },
+          {
+            type: 'struct',
+            label: 'Output Results',
+            accessor: 'output',
+          },
+          {
+            type: 'textarea',
+            label: 'Task Message',
+            accessor: 'message',
+            markdown: false,
+          },
+        ],
+        stateBuilder: (record: { state: number }) => {
+          switch (record.state) {
+            case 1:
+              return TASK_STATE.PENDING;
+            case 2:
+              return TASK_STATE.RUNNING;
+            case 3:
+              return TASK_STATE.SUCCESS;
+            case 4:
+              return TASK_STATE.ERROR;
+            case 5:
+              return TASK_STATE.ERROR;
+            case 6:
+              return TASK_STATE.SKIPPED;
+            default:
+              return TASK_STATE.PENDING;
+          }
+        },
+      },
     },
   ],
 };

--- a/javascript/packages/core/router/__tests__/entity-detail-route.test.tsx
+++ b/javascript/packages/core/router/__tests__/entity-detail-route.test.tsx
@@ -4,6 +4,7 @@ import { vi } from 'vitest';
 
 import { CellType } from '#core/components/cell/constants';
 import { CustomDetailPageConfig } from '#core/components/views/detail-view/types/detail-view-schema-types';
+import { buildExecutionSchemaFactory } from '#core/components/views/execution/__fixtures__/execution-schema-factory';
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getErrorProviderWrapper } from '#core/test/wrappers/get-error-provider-wrapper';
 import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
@@ -20,6 +21,7 @@ describe('EntityDetailRoute', () => {
     name: 'Pipeline Runs',
     service: 'pipelineRun',
   });
+  const buildExecutionSchema = buildExecutionSchemaFactory();
   const buildPhase = buildPhaseConfigFactory();
 
   test('renders execution tab', async () => {
@@ -39,7 +41,13 @@ describe('EntityDetailRoute', () => {
                   },
                   { id: 'status.state', label: 'State', type: CellType.STATE },
                 ],
-                pages: [{ id: 'execution', label: 'Execution', type: 'execution' }],
+                pages: [
+                  {
+                    id: 'execution',
+                    label: 'Execution',
+                    ...buildExecutionSchema(),
+                  },
+                ],
               },
             ],
           }),
@@ -56,6 +64,18 @@ describe('EntityDetailRoute', () => {
         },
         status: {
           state: 'RUNNING',
+          steps: [
+            {
+              displayName: 'Data Preparation',
+              state: 'SUCCEEDED',
+              subSteps: [],
+            },
+            {
+              displayName: 'Model Training',
+              state: 'RUNNING',
+              subSteps: [],
+            },
+          ],
         },
       },
     };
@@ -80,9 +100,10 @@ describe('EntityDetailRoute', () => {
     expect(await screen.findByText('State')).toBeInTheDocument();
     expect(await screen.findByText('Running')).toBeInTheDocument();
 
-    // Verify tab functionality
+    // Verify minimal execution tab functionality
     expect(screen.getByText('Execution')).toBeInTheDocument();
-    expect(screen.getByText("Page type 'execution' not yet supported")).toBeInTheDocument();
+    await screen.findAllByText('Data Preparation');
+    await screen.findAllByText('Model Training');
   });
 
   test('renders custom detail pages and navigates between them', async () => {
@@ -160,7 +181,11 @@ describe('EntityDetailRoute', () => {
                 metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
                 pages: [
                   { id: 'unknown-type', label: 'Unknown Type', type: 'some-unknown-type' },
-                  { id: 'execution', label: 'Execution', type: 'execution' },
+                  {
+                    id: 'execution',
+                    label: 'Execution',
+                    ...buildExecutionSchema(),
+                  },
                 ],
               },
             ],
@@ -255,7 +280,13 @@ describe('EntityDetailRoute', () => {
               {
                 type: 'detail',
                 metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
-                pages: [{ id: 'execution', label: 'Execution', type: 'execution' }],
+                pages: [
+                  {
+                    id: 'execution',
+                    label: 'Execution',
+                    ...buildExecutionSchema(),
+                  },
+                ],
               },
             ],
           }),
@@ -299,7 +330,13 @@ describe('EntityDetailRoute', () => {
               {
                 type: 'detail',
                 metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
-                pages: [{ id: 'execution', label: 'Execution', type: 'execution' }],
+                pages: [
+                  {
+                    id: 'execution',
+                    label: 'Execution',
+                    ...buildExecutionSchema(),
+                  },
+                ],
               },
             ],
           }),

--- a/javascript/packages/core/router/entity-detail-route.tsx
+++ b/javascript/packages/core/router/entity-detail-route.tsx
@@ -6,6 +6,7 @@ import { ErrorView } from '#core/components/error-view/error-view';
 import { CircleExclamationMark } from '#core/components/illustrations/circle-exclamation-mark/circle-exclamation-mark';
 import { CircleExclamationMarkKind } from '#core/components/illustrations/circle-exclamation-mark/types';
 import { Row } from '#core/components/row/row';
+import { DetailViewPageRenderer } from '#core/components/views/detail-view/components/detail-view-page-renderer/detail-view-page-renderer';
 import { DetailViewPages } from '#core/components/views/detail-view/components/detail-view-pages/detail-view-pages';
 import { DetailView } from '#core/components/views/detail-view/detail-view';
 import { PHASES } from '#core/config/phases/phases';
@@ -13,7 +14,6 @@ import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studi
 import { useStudioQuery } from '#core/hooks/use-studio-query';
 import { capitalizeFirstLetter } from '#core/utils/string-utils';
 
-import type { CustomDetailPageConfig } from '#core/components/views/detail-view/types/detail-view-schema-types';
 import type { PhaseConfig } from '#core/types/common/studio-types';
 
 /**
@@ -110,15 +110,13 @@ export function EntityDetailRoute({ phases = PHASES }: { phases?: Record<string,
         tabs={detailViewConfig!.pages.map((page) => ({
           id: page.id,
           label: page.label,
-          content:
-            page.type === 'custom' ? (
-              React.createElement((page as CustomDetailPageConfig).component, {
-                data,
-                isLoading,
-              })
-            ) : (
-              <div>Page type '{page.type}' not yet supported</div>
-            ),
+          content: (
+            <DetailViewPageRenderer
+              page={page}
+              data={data?.[entityConfig!.service] as object | undefined}
+              isLoading={isLoading}
+            />
+          ),
         }))}
         activeTabId={entityTab}
         onTabSelect={navigateToTab}


### PR DESCRIPTION
Replace hardcoded detail page type handling with component-based renderer to enable extensible page type support.

Add complete execution page configuration to RUN_DETAIL_CONFIG. Update tab label from "Execution" to "Steps" to match pipeline run terminology.

https://github.com/user-attachments/assets/87b37480-5d3f-4db8-971f-458f83c970c9

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
