### PR TITLE
Add project-namespaced filter persistence to table state

### DIFF
--- a/javascript/packages/core/components/table/plugins/state-persistence/__tests__/use-local-storage-table-state.test.tsx
+++ b/javascript/packages/core/components/table/plugins/state-persistence/__tests__/use-local-storage-table-state.test.tsx
@@ -63,6 +63,39 @@ describe('useLocalStorageTableState', () => {
       expect(parsedData['test-table'].globalFilter).toBe('test-filter');
     });
 
+    it('persists filter settings under filterSettingsId when provided', () => {
+      const { result } = renderHook(() =>
+        useLocalStorageTableState({
+          tableSettingsId: 'test-table',
+          filterSettingsId: 'test-table.project-123',
+        })
+      );
+
+      act(() => {
+        result.current.setGlobalFilter('project-filter');
+        result.current.setColumnFilters([{ id: 'status', value: ['Active'] }]);
+        result.current.setPagination({ pageIndex: 0, pageSize: 25 });
+      });
+
+      const storedData = localStorage.getItem(TABLE_LOCAL_STORAGE_KEY);
+      expect(storedData).toBeTruthy();
+
+      const parsedData = JSON.parse(storedData!) as
+        | Record<string, Partial<TableState>>
+        | Record<string, Record<string, Partial<TableState>>>;
+
+      // Filters stored under filterSettingsId
+      expect((parsedData['test-table']['project-123'] as Partial<TableState>).globalFilter).toBe(
+        'project-filter'
+      );
+      expect(
+        (parsedData['test-table']['project-123'] as Partial<TableState>).columnFilters
+      ).toEqual([{ id: 'status', value: ['Active'] }]);
+
+      // Global settings stored under tableSettingsId
+      expect((parsedData['test-table'] as TableState['pagination']).pageSize).toEqual(25);
+    });
+
     it('restores state from localStorage on initialization', () => {
       const existingState = {
         'test-table.globalFilter': 'restored-filter',
@@ -74,6 +107,28 @@ describe('useLocalStorageTableState', () => {
       );
 
       expect(result.current.globalFilter).toBe('restored-filter');
+    });
+
+    it('restores project-specific filter state when filterSettingsId is provided', () => {
+      const existingState = {
+        'test-table.project-123.globalFilter': 'project-restored-filter',
+        'test-table.project-123.columnFilters': [{ id: 'department', value: ['Sales'] }],
+        'test-table.columnVisibility': { status: false },
+        'test-table.pageSize': 15,
+      };
+      localStorage.setItem(TABLE_LOCAL_STORAGE_KEY, JSON.stringify(existingState));
+
+      const { result } = renderHook(() =>
+        useLocalStorageTableState({
+          tableSettingsId: 'test-table',
+          filterSettingsId: 'test-table.project-123',
+        })
+      );
+
+      expect(result.current.globalFilter).toBe('project-restored-filter');
+      expect(result.current.columnFilters).toEqual([{ id: 'department', value: ['Sales'] }]);
+      expect(result.current.columnVisibility).toEqual({ status: false });
+      expect(result.current.pagination.pageSize).toBe(15);
     });
 
     it('uses initial state when no persisted data exists', () => {
@@ -125,11 +180,81 @@ describe('useLocalStorageTableState', () => {
       expect(storedData['table-1'].globalFilter).toBe('filter-1');
       expect(storedData['table-2'].globalFilter).toBe('filter-2');
     });
+
+    it('allows different projects to have separate filter state for same table', () => {
+      const { result: project1 } = renderHook(() =>
+        useLocalStorageTableState({
+          tableSettingsId: 'user-table',
+          filterSettingsId: 'user-table.project-123',
+        })
+      );
+
+      const { result: project2 } = renderHook(() =>
+        useLocalStorageTableState({
+          tableSettingsId: 'user-table',
+          filterSettingsId: 'user-table.project-456',
+        })
+      );
+
+      act(() => {
+        project1.current.setGlobalFilter('project-123-filter');
+        project1.current.setColumnFilters([{ id: 'status', value: ['Active'] }]);
+        project1.current.setColumnVisibility({ name: false });
+
+        project2.current.setGlobalFilter('project-456-filter');
+        project2.current.setColumnFilters([{ id: 'status', value: ['Inactive'] }]);
+        project2.current.setColumnVisibility({ department: false });
+      });
+
+      const storedData = JSON.parse(localStorage.getItem(TABLE_LOCAL_STORAGE_KEY)!) as
+        | Record<string, Partial<TableState>>
+        | Record<string, Record<string, Partial<TableState>>>;
+
+      // Project 1 filters stored separately
+      expect((storedData['user-table']['project-123'] as Partial<TableState>).globalFilter).toBe(
+        'project-123-filter'
+      );
+      expect(
+        (storedData['user-table']['project-123'] as Partial<TableState>).columnFilters
+      ).toEqual([{ id: 'status', value: ['Active'] }]);
+
+      // Project 2 filters stored separately
+      expect((storedData['user-table']['project-456'] as Partial<TableState>).globalFilter).toBe(
+        'project-456-filter'
+      );
+      expect(
+        (storedData['user-table']['project-456'] as Partial<TableState>).columnFilters
+      ).toEqual([{ id: 'status', value: ['Inactive'] }]);
+
+      // Global settings should be shared (last write wins)
+      expect((storedData['user-table'] as Partial<TableState>).columnVisibility).toEqual({
+        department: false,
+      });
+    });
   });
 
   describe('integration with Table component', () => {
     function TableWithPersistence({ tableSettingsId }: { tableSettingsId: string }) {
       const tableState = useLocalStorageTableState({ tableSettingsId });
+
+      return (
+        <Table
+          data={testData}
+          columns={testColumns}
+          state={tableState}
+          actionBarConfig={{ enableSearch: true }}
+        />
+      );
+    }
+
+    function TableWithProjectFilters({
+      tableSettingsId,
+      filterSettingsId,
+    }: {
+      tableSettingsId: string;
+      filterSettingsId?: string;
+    }) {
+      const tableState = useLocalStorageTableState({ tableSettingsId, filterSettingsId });
 
       return (
         <Table
@@ -256,6 +381,50 @@ describe('useLocalStorageTableState', () => {
       >;
       expect(storedData[tableSettingsId1].globalFilter).toBe('Engineering');
       expect(storedData[tableSettingsId2]).toBeUndefined();
+    });
+
+    it('isolates filter state between projects while sharing global settings', async () => {
+      const user = userEvent.setup({
+        advanceTimers: vi.advanceTimersByTime.bind(vi) as (ms: number) => void,
+      });
+
+      const { unmount: unmountProject1 } = render(
+        <TableWithProjectFilters
+          tableSettingsId="shared-table"
+          filterSettingsId="shared-table.project-1"
+        />,
+        buildWrapper([getInterpolationProviderWrapper(), getRouterWrapper()])
+      );
+
+      await user.type(screen.getByRole('searchbox'), 'Engineering');
+      vi.runAllTimers();
+
+      await waitFor(() => {
+        expect(screen.getAllByRole('row')).toHaveLength(3); // 1 header + 2 Engineering rows
+      });
+
+      unmountProject1();
+
+      render(
+        <TableWithProjectFilters
+          tableSettingsId="shared-table"
+          filterSettingsId="shared-table.project-2"
+        />,
+        buildWrapper([getInterpolationProviderWrapper(), getRouterWrapper()])
+      );
+
+      expect(screen.getByRole('searchbox')).toHaveValue('');
+      expect(screen.getAllByRole('row')).toHaveLength(5);
+
+      const storedData = JSON.parse(localStorage.getItem(TABLE_LOCAL_STORAGE_KEY)!) as Record<
+        string,
+        Partial<TableState> | Record<string, Partial<TableState>>
+      >;
+
+      expect((storedData['shared-table']['project-1'] as Partial<TableState>).globalFilter).toBe(
+        'Engineering'
+      );
+      expect(storedData['shared-table']['project-2']).toBeUndefined();
     });
   });
 });

--- a/javascript/packages/core/components/table/plugins/state-persistence/use-local-storage-table-state.ts
+++ b/javascript/packages/core/components/table/plugins/state-persistence/use-local-storage-table-state.ts
@@ -22,22 +22,35 @@ import type {
  * 2. **Initial state** from props (schema defaults, initial configuration)
  * 3. **Table defaults** from {@link TABLE_STATE_DEFAULTS}
  *
+ * **Persistence Strategy:**
+ * - **Global settings** (columnVisibility, columnOrder, sorting, pageSize): Persist across all projects using tableSettingsId
+ * - **Filter settings** (globalFilter, columnFilters): Persist using filterSettingsId if provided, otherwise tableSettingsId
+ *
  * Use this hook to provide a `state` prop to the Table component for persistent
  * user preferences across browser sessions.
  *
- * @param tableSettingsId - Unique identifier for this table's settings in localStorage
+ * @param tableSettingsId - Unique identifier for global table settings (cross-project)
+ * @param filterSettingsId - Optional unique identifier for filter settings (project-specific).
+ *   When omitted, filters persist globally (useful for app-wide tables like project lists).
  * @param initialState - Optional initial state to use when no persisted state exists
  *
  * @example
  * ```tsx
- * // Basic usage
+ * // App-wide table (filters and settings both global)
+ * const tableState = useLocalStorageTableState({
+ *   tableSettingsId: 'projects-table',
+ * });
+ *
+ * // Project-specific filters (recommended for project-scoped data)
  * const tableState = useLocalStorageTableState({
  *   tableSettingsId: 'user-dashboard-table',
+ *   filterSettingsId: `user-dashboard-table.project-${projectId}`,
  * });
  *
  * // With initial state (e.g., hidden columns from schema)
  * const tableState = useLocalStorageTableState({
  *   tableSettingsId: 'user-dashboard-table',
+ *   filterSettingsId: `user-dashboard-table.project-${projectId}`,
  *   initialState: {
  *     columnVisibility: { hiddenColumnId: false },
  *     sorting: [{ id: 'name', desc: false }],
@@ -46,23 +59,28 @@ import type {
  *
  * return <Table data={data} columns={columns} state={tableState} />;
  *
- * // State persisted as: 'ma-studio-table-settings.user-dashboard-table.globalFilter'
+ * // State persisted as: 'ma-studio-table-settings.user-dashboard-table.project-${projectId}.globalFilter'
  * ```
  */
 export function useLocalStorageTableState({
   tableSettingsId,
+  filterSettingsId,
   initialState,
 }: {
   tableSettingsId: string;
+  filterSettingsId?: string;
   initialState?: Partial<ControlledTableState>;
 }): ControlledTableState {
+  // Use filterSettingsId for filters when provided, otherwise fall back to tableSettingsId
+  const filterNamespace = filterSettingsId ?? tableSettingsId;
+
   const [globalFilter, setGlobalFilter] = usePersistedTableState<string>(
-    `${tableSettingsId}.globalFilter`,
+    `${filterNamespace}.globalFilter`,
     initialState?.globalFilter ?? TABLE_STATE_DEFAULTS.globalFilter
   );
 
   const [columnFilters, setColumnFilters] = usePersistedTableState<ColumnFilter[]>(
-    `${tableSettingsId}.columnFilters`,
+    `${filterNamespace}.columnFilters`,
     initialState?.columnFilters ?? TABLE_STATE_DEFAULTS.columnFilters
   );
 

--- a/javascript/packages/core/components/views/phase-entity-view/entity-table.tsx
+++ b/javascript/packages/core/components/views/phase-entity-view/entity-table.tsx
@@ -29,7 +29,10 @@ export function EntityTable({ service, listViewConfig, tableSettingsId }: Entity
     },
   });
 
-  const entityTableState = useLocalStorageTableState({ tableSettingsId });
+  const entityTableState = useLocalStorageTableState({
+    filterSettingsId: `${projectId}/${tableSettingsId}`,
+    tableSettingsId,
+  });
 
   return (
     <Table

--- a/javascript/packages/core/components/views/phase-entity-view/phase-entity-view.tsx
+++ b/javascript/packages/core/components/views/phase-entity-view/phase-entity-view.tsx
@@ -66,7 +66,7 @@ export function PhaseEntityView({ phaseId, entities }: PhaseEntityViewProps) {
             <EntityTable
               service={entity.service}
               listViewConfig={currentEntityConfig.views[0]}
-              tableSettingsId={`${phaseId}-${entity.id}`}
+              tableSettingsId={`${phaseId}/${entity.id}`}
             />
           )}
         </Tab>


### PR DESCRIPTION
Separate filter state from global table settings to solve UX problem where users working across multiple projects encountered inappropriate filter values when switching contexts.

Previous approach stored all table state under a single namespace, causing filter spillover between unrelated datasets. This change introduces optional filterSettingsId parameter that allows filters to persist separately from global table preferences. When filterSettingsId is omitted, behavior remains unchanged for app-wide tables like project lists where global filtering makes sense.


https://github.com/user-attachments/assets/58af48af-0d40-4730-b5ff-6dedda16cbc2

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
