### PR TITLE
Prevent users from being stuck on invalid pages after filtering

### DIFF
--- a/javascript/packages/core/components/table/__tests__/table.test.tsx
+++ b/javascript/packages/core/components/table/__tests__/table.test.tsx
@@ -1104,6 +1104,87 @@ describe('Table', () => {
       expect(screen.queryByRole('button', { name: /next/i })).not.toBeInTheDocument();
       expect(screen.getByText('No data')).toBeInTheDocument();
     });
+
+    it('resets to first page when current page becomes invalid due to filtering', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <Table
+          data={buildLargeDataset(50)}
+          columns={testColumns}
+          pageSizes={[{ id: 10, label: '10' }]}
+          actionBarConfig={{ enableFilters: true }}
+        />,
+        buildWrapper([
+          getBaseProviderWrapper(),
+          getInterpolationProviderWrapper(),
+          getRouterWrapper(),
+        ])
+      );
+
+      // Verify we start on page 1 of 5
+      expect(
+        screen.getByRole('button', { name: 'next page. current page 1 of 5' })
+      ).toBeInTheDocument();
+
+      // Navigate to page 5 using the next button
+      const nextButton = screen.getByRole('button', { name: /next page/i });
+      await user.click(nextButton);
+      await user.click(nextButton);
+      await user.click(nextButton);
+      await user.click(nextButton);
+
+      await screen.findByRole('button', { name: 'next page. current page 5 of 5' });
+
+      // Apply column filter that drastically reduces results
+      await user.click(screen.getByRole('button', { name: 'Add filter' }));
+      await user.click(screen.getByTestId('filter-option-Column1'));
+      await user.click(screen.getByLabelText('row1-col1-data'));
+      await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+      // Verify table page index is reset to 1 and data is displayed correctly
+      await screen.findByRole('button', { name: 'next page. current page 1 of 1' });
+      expect(screen.getByText('row1-col1-data')).toBeInTheDocument();
+      expect(screen.queryByText('row2-col1-data')).not.toBeInTheDocument();
+    });
+
+    it('does not reset page when current page remains valid after filtering', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <Table
+          data={buildLargeDataset(50)}
+          columns={testColumns}
+          pageSizes={[{ id: 5, label: '5' }]}
+          actionBarConfig={{ enableFilters: true }}
+        />,
+        buildWrapper([
+          getBaseProviderWrapper(),
+          getInterpolationProviderWrapper(),
+          getRouterWrapper(),
+        ])
+      );
+
+      // Navigate to page 2
+      const nextButton = screen.getByRole('button', { name: /next page/i });
+      await user.click(nextButton);
+      await screen.findByRole('button', { name: 'next page. current page 2 of 10' });
+
+      // Apply filter that still leaves 2 pages
+      await user.click(screen.getByRole('button', { name: 'Add filter' }));
+      await user.click(screen.getByTestId('filter-option-Column1'));
+      await user.click(screen.getByLabelText('row5-col1-data'));
+      await user.click(screen.getByLabelText('row10-col1-data'));
+      await user.click(screen.getByLabelText('row15-col1-data'));
+      await user.click(screen.getByLabelText('row20-col1-data'));
+      await user.click(screen.getByLabelText('row25-col1-data'));
+      await user.click(screen.getByLabelText('row30-col1-data'));
+      await user.click(screen.getByLabelText('row35-col1-data'));
+      await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+      // Should stay on page 2 since it's still valid (filtered results create 2 pages)
+      await screen.findByRole('button', { name: 'next page. current page 2 of 2' });
+    });
   });
 
   describe('sorting functionality', () => {

--- a/javascript/packages/core/components/table/hooks/__tests__/use-page-reset-handler.test.ts
+++ b/javascript/packages/core/components/table/hooks/__tests__/use-page-reset-handler.test.ts
@@ -1,0 +1,84 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { usePageResetHandler } from '../use-page-reset-handler';
+
+describe('usePageResetHandler', () => {
+  it('does not reset when page is valid', () => {
+    const mockGotoPage = vi.fn();
+
+    const { result } = renderHook(() =>
+      usePageResetHandler({
+        gotoPage: mockGotoPage,
+        pageCount: 5,
+        paginationState: { pageIndex: 2, pageSize: 10 }, // Page 3 of 5 = valid
+      })
+    );
+
+    expect(result.current.isResetting).toBe(false);
+    expect(mockGotoPage).not.toHaveBeenCalled();
+  });
+
+  it('does not reset when already on page 1', () => {
+    const mockGotoPage = vi.fn();
+
+    const { result } = renderHook(() =>
+      usePageResetHandler({
+        gotoPage: mockGotoPage,
+        pageCount: 1,
+        paginationState: { pageIndex: 0, pageSize: 10 }, // Page 1 of 1 = valid
+      })
+    );
+
+    expect(result.current.isResetting).toBe(false);
+    expect(mockGotoPage).not.toHaveBeenCalled();
+  });
+
+  it('resets page when current page becomes invalid', () => {
+    const mockGotoPage = vi.fn();
+
+    const { result, rerender } = renderHook(
+      ({ pageCount }) =>
+        usePageResetHandler({
+          gotoPage: mockGotoPage,
+          pageCount,
+          paginationState: { pageIndex: 4, pageSize: 10 }, // Page 5
+        }),
+      {
+        initialProps: { pageCount: 5 }, // Page 5 of 5 = valid
+      }
+    );
+
+    expect(result.current.isResetting).toBe(false);
+    expect(mockGotoPage).not.toHaveBeenCalled();
+
+    // Change to invalid page scenario (filtering reduced pages)
+    rerender({ pageCount: 2 }); // Page 5 of 2 pages = invalid
+    expect(mockGotoPage).toHaveBeenCalledWith(0);
+    expect(result.current.isResetting).toBe(true);
+  });
+
+  it('clears resetting flag when page reset completes', () => {
+    const mockGotoPage = vi.fn();
+
+    const { result, rerender } = renderHook(
+      ({ pageIndex, pageCount }) =>
+        usePageResetHandler({
+          gotoPage: mockGotoPage,
+          pageCount,
+          paginationState: { pageIndex, pageSize: 10 },
+        }),
+      {
+        initialProps: { pageIndex: 4, pageCount: 2 }, // Page 5 of 2 = invalid
+      }
+    );
+
+    // Simulate successful page reset (pageIndex becomes 0)
+    expect(result.current.isResetting).toBe(true);
+    expect(mockGotoPage).toHaveBeenCalledWith(0);
+
+    // Page index becomes 0, so should clear resetting flag
+    rerender({ pageIndex: 0, pageCount: 2 });
+    expect(result.current.isResetting).toBe(false);
+  });
+});

--- a/javascript/packages/core/components/table/hooks/use-page-reset-handler.ts
+++ b/javascript/packages/core/components/table/hooks/use-page-reset-handler.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+
+import type { PaginationState } from '../types/table-types';
+
+/**
+ * Resets pagination to first page when current page becomes invalid due to filtering.
+ */
+export function usePageResetHandler(args: {
+  gotoPage: (page: number) => void;
+  pageCount: number;
+  paginationState: PaginationState;
+}) {
+  const { paginationState, pageCount, gotoPage } = args;
+  const { pageIndex } = paginationState;
+  const [isActiveResetting, setIsActiveResetting] = useState(false);
+
+  useEffect(() => {
+    const outOfBounds = pageIndex + 1 > pageCount;
+    if (pageIndex !== 0 && outOfBounds) {
+      setIsActiveResetting(true);
+      gotoPage(0);
+    }
+  }, [pageIndex, pageCount, gotoPage]);
+
+  useEffect(() => {
+    if (isActiveResetting && pageIndex === 0) {
+      setIsActiveResetting(false);
+    }
+  }, [isActiveResetting, pageIndex]);
+
+  // Consider both "actively resetting" and "needs reset" as resetting state
+  // to avoid empty state flash before useEffect triggers
+  const needsReset = pageIndex + 1 > pageCount && pageIndex !== 0;
+  return { isResetting: isActiveResetting || needsReset };
+}

--- a/javascript/packages/core/components/table/table.tsx
+++ b/javascript/packages/core/components/table/table.tsx
@@ -17,6 +17,7 @@ import { TableErrorState } from './components/table-error-state/table-error-stat
 import { TableHeader } from './components/table-header/table-header';
 import { TableNoResultsState } from './components/table-no-results-state/table-no-results-state';
 import { useColumnTransformer } from './hooks/use-column-transformer';
+import { usePageResetHandler } from './hooks/use-page-reset-handler';
 import { TableSelectionProvider } from './plugins/selection/table-selection-provider';
 import { applyDefaultProps } from './utils/apply-default-props';
 import { composeTableState } from './utils/compose-table-state';
@@ -63,17 +64,23 @@ export function Table<T extends TableData = TableData>(inputProps: TableProps<T>
     autoResetPageIndex: false,
   });
 
+  const transformedColumns = transformColumns(table.getAllLeafColumns());
+
+  const { isResetting } = usePageResetHandler({
+    gotoPage: table.setPageIndex,
+    pageCount: table.getPageCount(),
+    paginationState: table.getState().pagination,
+  });
+
   const viewState = getTableViewState({
     dataLength: props.data.length,
     error: props.error,
-    loading: props.loading,
+    loading: props.loading || isResetting,
     hasFiltersApplied:
       (table.getState().globalFilter as string)?.length > 0 ||
       (table.getState().columnFilters?.length ?? 0) > 0,
-    filteredLength: table.getFilteredRowModel().rows.length,
+    filteredLength: table.getRowModel().rows.length,
   });
-
-  const transformedColumns = transformColumns(table.getAllLeafColumns());
 
   // Create lightweight row objects for filter components that only need getValue()
   const preFilteredRows = props.unFilteredData.map((rowData) => ({


### PR DESCRIPTION
Fix UX issue where users applying filters while on non-first pages
would remain on empty page results instead of seeing filtered data.

Previous table behavior left users stranded on pages that no longer
existed after filtering reduced the dataset. This created confusion
since users would see empty tables despite having matching data on
earlier pages.

The page reset prevents empty state flashing by monitoring the active
resetting (updating page index state) and detecting when a page reset
is needed. This completely eliminates any "No data" messages briefly
appearing during page reset operations.

This required fixing a race condition in viewState logic that used
filtered row counts instead of Tanstack-table recommended combined
getRowModel row counts.

https://github.com/user-attachments/assets/e5425137-ec48-41a9-a878-8e0fee77ebd5

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
