### PR TITLE
Fix table search icon size inconsistencies

### DIFF
--- a/javascript/app/icons/icons.tsx
+++ b/javascript/app/icons/icons.tsx
@@ -30,6 +30,7 @@ export const ICONS = {
   circleX: createMuiIconAdapter(CancelIcon),
   circleCheck: createMuiIconAdapter(CheckCircle),
   circleCheckFilled: createMuiIconAdapter(CheckCircle),
+  deleteAlt: createMuiIconAdapter(CancelIcon),
   diamondEmpty: createMuiIconAdapter(CropSquareIcon),
   playerNext: createMuiIconAdapter(SkipNextIcon),
   plus: createMuiIconAdapter(AddIcon),

--- a/javascript/app/icons/mui-icon-adapter.tsx
+++ b/javascript/app/icons/mui-icon-adapter.tsx
@@ -4,8 +4,22 @@ import type { ComponentType } from 'react';
 
 export const createMuiIconAdapter = (Icon: ComponentType<SvgIconProps>) => {
   return (props: IconProps) => {
+    const { size, style, color, shapeRendering, title, ...baseUIProps } = props;
+
     // Scale Material UI icons to match internal icon sizing (14px internal ≈ 12px Material UI)
-    const scaledSize = props.size ? `calc(${props.size} * 1.125)` : props.size;
-    return <Icon sx={{ ...props.style, color: props.color, fontSize: scaledSize }} />;
+    const scaledSize = size ? `calc(${size} * 1.125)` : size;
+
+    // Remove BaseUI-specific props that would cause type errors
+    const { overrides: _overrides, fontSize: _fontSize, ...compatibleProps } = baseUIProps;
+
+    return (
+      <Icon
+        {...compatibleProps}
+        htmlColor={color}
+        shapeRendering={String(shapeRendering)}
+        titleAccess={String(title)}
+        sx={{ ...style, fontSize: scaledSize }}
+      />
+    );
   };
 };

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-search-input/table-search-input.tsx
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-search-input/table-search-input.tsx
@@ -36,7 +36,6 @@ export function TableSearchInput({ value, onChange }: TableSearchInputProps) {
       size={SIZE.compact}
       overrides={{
         Root: { style: { width: '250px' } },
-        ClearIcon: { props: { size: 20 } },
       }}
       placeholder="Search..."
       startEnhancer={<Icon name="search" />}

--- a/javascript/packages/core/index.tsx
+++ b/javascript/packages/core/index.tsx
@@ -24,7 +24,7 @@ type Props = {
 
 export function CoreApp({ dependencies }: Props) {
   return (
-    <ThemeProvider>
+    <ThemeProvider icons={dependencies.theme.icons}>
       <ServiceProvider {...dependencies.service}>
         <ErrorProvider {...dependencies.error}>
           <IconProvider icons={dependencies.theme.icons}>

--- a/javascript/packages/core/themes/provider.tsx
+++ b/javascript/packages/core/themes/provider.tsx
@@ -1,9 +1,30 @@
 import { BaseProvider, createTheme } from 'baseui';
 
+import { capitalizeFirstLetter } from '#core/utils/string-utils';
 import { GRID_OVERRIDES } from './shared';
 
 import type { Theme } from 'baseui';
+import type { IconMap } from '#core/providers/icon-provider/types';
 
-export function ThemeProvider({ children, theme }: { children: React.ReactNode; theme?: Theme }) {
-  return <BaseProvider theme={theme ?? createTheme(GRID_OVERRIDES)}>{children}</BaseProvider>;
+export function ThemeProvider({
+  children,
+  icons,
+  theme,
+}: {
+  children: React.ReactNode;
+  icons?: IconMap;
+  theme?: Theme;
+}) {
+  // TODO: rename Icons to be PascalCase #364
+  const iconEntries = icons
+    ? Object.fromEntries(
+        Object.entries(icons).map(([key, value]) => [capitalizeFirstLetter(key), value])
+      )
+    : {};
+
+  return (
+    <BaseProvider theme={theme ?? createTheme({ ...GRID_OVERRIDES, icons: iconEntries })}>
+      {children}
+    </BaseProvider>
+  );
 }


### PR DESCRIPTION
Integrate Material UI icons into BaseUI theme system to resolve rendering differences between internal and external repositories.

The previous approach resulted in TableSearchInput's clear icon size being oversized in Uber's internal codebase while rightsized for this open source repository.

When forwarding CoreApp's icon dependency to BaseWeb's theme, discovered that we were not properly forwarding all icon props (e.g., onClick was not working with the forwarded Material UI deleteAlt icon). There are a handful of type conflicts between MaterialUI and BaseWeb icon props, which are managed by normalizing select props to strings.

Created #364 to track the full onboarding of icon provider forwarding to BaseWeb theme.

https://github.com/user-attachments/assets/4bb9ae40-8f01-4c17-8d19-ace77f27dfee

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
