### PR TITLE
Add dynamic row selection state management

### DIFF
--- a/javascript/packages/core/components/table/__tests__/table.test.tsx
+++ b/javascript/packages/core/components/table/__tests__/table.test.tsx
@@ -16,6 +16,7 @@ import {
   expectTableRows,
 } from '../__fixtures__/table-test-helpers';
 import { TableBodyProps, TableRow } from '../components/table-body/types';
+import { useTableSelectionContext } from '../plugins/selection/table-selection-context';
 import { Table } from '../table';
 
 import type { Accessor } from '#core/types/common/studio-types';
@@ -1341,82 +1342,140 @@ describe('Table', () => {
 
     it('does not render selection checkboxes when selection is disabled', () => {
       render(
-        <Table data={testData} columns={testColumns} enableRowSelection={false} />,
+        <Table data={testData} columns={testColumns} state={{ rowSelectionEnabled: false }} />,
         buildWrapper([getInterpolationProviderWrapper(), getRouterWrapper()])
       );
 
       expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
     });
 
-    it('renders selection checkboxes when selection is enabled', () => {
-      render(
-        <Table data={testData} columns={testColumns} enableRowSelection={true} />,
-        buildWrapper([getInterpolationProviderWrapper(), getRouterWrapper()])
-      );
-
-      // Should have header checkbox + 3 row checkboxes
-      expect(screen.getAllByRole('checkbox')).toHaveLength(4);
-    });
-
-    it('selects individual rows when row checkbox is clicked', async () => {
+    it('selects individual rows when row checkbox is clicked after enabling selection', async () => {
       const user = userEvent.setup();
 
       render(
-        <Table data={testData} columns={testColumns} enableRowSelection={true} />,
+        <Table data={testData} columns={testColumns} state={{ rowSelectionEnabled: true }} />,
         buildWrapper([getInterpolationProviderWrapper(), getRouterWrapper()])
       );
 
-      const checkboxes = screen.getAllByRole('checkbox');
-      const firstRowCheckbox = checkboxes[1]; // Skip header checkbox
+      const checkboxes = await screen.findAllByRole('checkbox');
+      const firstRowCheckbox = checkboxes[1];
 
       expect(firstRowCheckbox).not.toBeChecked();
-
       await user.click(firstRowCheckbox);
-
       expect(firstRowCheckbox).toBeChecked();
     });
 
-    it('selects all rows when header checkbox is clicked', async () => {
+    it('selects all rows when header checkbox is clicked after enabling selection', async () => {
       const user = userEvent.setup();
 
       render(
-        <Table data={testData} columns={testColumns} enableRowSelection={true} />,
+        <Table data={testData} columns={testColumns} state={{ rowSelectionEnabled: true }} />,
         buildWrapper([getInterpolationProviderWrapper(), getRouterWrapper()])
       );
 
-      const checkboxes = screen.getAllByRole('checkbox');
+      const checkboxes = await screen.findAllByRole('checkbox');
       const headerCheckbox = checkboxes[0];
 
       expect(headerCheckbox).not.toBeChecked();
-
       await user.click(headerCheckbox);
 
-      // All checkboxes should be checked
       checkboxes.forEach((checkbox) => {
         expect(checkbox).toBeChecked();
       });
     });
 
-    it('provides selection context for external components', () => {
-      const TestComponent = () => {
-        // This would be imported from the plugin
-        // const { selectedRows, selectionEnabled } = useTableSelectionContext();
-        return <div data-testid="selection-context">Selection context available</div>;
+    it('provides selection context for external components', async () => {
+      const user = userEvent.setup();
+
+      const SelectionToggle = () => {
+        const { selectionEnabled, setSelectionEnabled } = useTableSelectionContext();
+        return (
+          <div>
+            <span>Selection status: {selectionEnabled ? 'enabled' : 'disabled'}</span>
+            <button onClick={() => setSelectionEnabled(!selectionEnabled)}>Toggle Selection</button>
+          </div>
+        );
       };
 
       render(
         <Table
           data={testData}
           columns={testColumns}
-          enableRowSelection={true}
           actionBarConfig={{
-            trailing: <TestComponent />,
+            trailing: <SelectionToggle />,
           }}
         />,
         buildWrapper([getInterpolationProviderWrapper(), getRouterWrapper()])
       );
 
-      expect(screen.getByTestId('selection-context')).toBeInTheDocument();
+      expect(screen.getByText('Selection status: disabled')).toBeInTheDocument();
+      await user.click(screen.getByRole('button', { name: 'Toggle Selection' }));
+      await screen.findByText('Selection status: enabled');
+    });
+
+    it('supports enabling selection when starting disabled', async () => {
+      const user = userEvent.setup();
+
+      const SelectionToggle = () => {
+        const { selectionEnabled, setSelectionEnabled } = useTableSelectionContext();
+        return (
+          <div>
+            <span>Selection status: {selectionEnabled ? 'enabled' : 'disabled'}</span>
+            <button onClick={() => setSelectionEnabled(true)}>Enable Selection</button>
+          </div>
+        );
+      };
+
+      render(
+        <Table
+          data={testData}
+          columns={testColumns}
+          state={{ rowSelectionEnabled: false }}
+          actionBarConfig={{
+            trailing: <SelectionToggle />,
+          }}
+        />,
+        buildWrapper([getInterpolationProviderWrapper(), getRouterWrapper()])
+      );
+
+      expect(screen.getByText('Selection status: disabled')).toBeInTheDocument();
+      await user.click(screen.getByRole('button', { name: 'Enable Selection' }));
+
+      // Selection should now be enabled since setSelectionEnabled(true) was called
+      expect(screen.getByText('Selection status: enabled')).toBeInTheDocument();
+    });
+
+    it('supports controlled row selection state', async () => {
+      const user = userEvent.setup();
+      const controlledState = false;
+      const mockSetter = vi.fn();
+
+      const SelectionToggle = () => {
+        const { selectionEnabled, setSelectionEnabled } = useTableSelectionContext();
+        return (
+          <div>
+            <span>Selection status: {selectionEnabled ? 'enabled' : 'disabled'}</span>
+            <button onClick={() => setSelectionEnabled(true)}>Enable Selection</button>
+          </div>
+        );
+      };
+
+      render(
+        <Table
+          data={testData}
+          columns={testColumns}
+          state={{
+            rowSelectionEnabled: controlledState,
+            setRowSelectionEnabled: mockSetter,
+          }}
+          actionBarConfig={{ trailing: <SelectionToggle /> }}
+        />,
+        buildWrapper([getInterpolationProviderWrapper(), getRouterWrapper()])
+      );
+
+      expect(screen.getByText('Selection status: disabled')).toBeInTheDocument();
+      await user.click(screen.getByRole('button', { name: 'Enable Selection' }));
+      expect(mockSetter).toHaveBeenCalledWith(true);
     });
   });
 

--- a/javascript/packages/core/components/table/constants.ts
+++ b/javascript/packages/core/components/table/constants.ts
@@ -45,6 +45,7 @@ export const TABLE_STATE_DEFAULTS: TableState = {
   columnOrder: [],
   columnVisibility: {},
   rowSelection: {},
+  rowSelectionEnabled: false,
 } as const;
 
 export const TABLE_LOCAL_STORAGE_KEY = 'ma-studio-table-settings';

--- a/javascript/packages/core/components/table/plugins/selection/table-selection-context.tsx
+++ b/javascript/packages/core/components/table/plugins/selection/table-selection-context.tsx
@@ -5,6 +5,7 @@ import type { TableSelectionContext as TableSelectionContextType } from './types
 export const TableSelectionContext = React.createContext<TableSelectionContextType>({
   selectedRows: [],
   selectionEnabled: false,
+  setSelectionEnabled: () => null,
   toggleAllRowsSelected: () => null,
   getIsAllRowsSelected: () => false,
   getIsSomeRowsSelected: () => false,

--- a/javascript/packages/core/components/table/plugins/selection/types.ts
+++ b/javascript/packages/core/components/table/plugins/selection/types.ts
@@ -3,6 +3,7 @@ import type { TableData } from '#core/components/table/types/data-types';
 export type TableSelectionContext<T extends TableData = TableData> = {
   selectedRows: T[];
   selectionEnabled: boolean;
+  setSelectionEnabled: (enabled: boolean) => void;
   toggleAllRowsSelected: (selected: boolean) => void;
   getIsAllRowsSelected: () => boolean;
   getIsSomeRowsSelected: () => boolean;

--- a/javascript/packages/core/components/table/plugins/selection/use-row-selection-state.ts
+++ b/javascript/packages/core/components/table/plugins/selection/use-row-selection-state.ts
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import { ControlledTableState, TableState } from '../../types/table-types';
+
+/**
+ * Provides controlled/uncontrolled state management for row selection enabling/disabling
+ *
+ * @remarks
+ * This hook handles both controlled and uncontrolled row selection state:
+ *
+ * **Controlled mode**: When `state.setRowSelectionEnabled` is provided,
+ * uses the provided state and setter directly.
+ *
+ * **Uncontrolled mode**: When only `initialState.rowSelectionEnabled` is provided,
+ * manages internal state that can be updated via the returned setter.
+ *
+ * This is necessary because TanStack Table doesn't provide built-in state management
+ * for dynamically enabling/disabling row selection.
+ */
+export function useRowSelectionState({
+  state,
+  initialState,
+}: {
+  state: Partial<ControlledTableState>;
+  initialState: Partial<TableState>;
+}): { enableRowSelection: boolean; setRowSelectionEnabled: (enabled: boolean) => void } {
+  const [internalRowSelectionEnabled, setInternalRowSelectionEnabled] = React.useState(
+    initialState.rowSelectionEnabled
+  );
+
+  const enableRowSelection = state.setRowSelectionEnabled
+    ? state.rowSelectionEnabled
+    : internalRowSelectionEnabled;
+
+  return {
+    enableRowSelection: enableRowSelection ?? false,
+    setRowSelectionEnabled: state.setRowSelectionEnabled ?? setInternalRowSelectionEnabled,
+  };
+}

--- a/javascript/packages/core/components/table/plugins/state-persistence/use-local-storage-table-state.ts
+++ b/javascript/packages/core/components/table/plugins/state-persistence/use-local-storage-table-state.ts
@@ -107,6 +107,9 @@ export function useLocalStorageTableState({
   // pageIndex and rowSelection are not persisted (reset on reload)
   const [pageIndex, setPageIndex] = useState<number>(0);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const [rowSelectionEnabled, setRowSelectionEnabled] = useState<boolean>(
+    initialState?.rowSelectionEnabled ?? TABLE_STATE_DEFAULTS.rowSelectionEnabled
+  );
 
   return {
     globalFilter,
@@ -131,5 +134,7 @@ export function useLocalStorageTableState({
     setColumnVisibility,
     rowSelection,
     setRowSelection,
+    rowSelectionEnabled,
+    setRowSelectionEnabled,
   };
 }

--- a/javascript/packages/core/components/table/table.tsx
+++ b/javascript/packages/core/components/table/table.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import {
   getCoreRowModel,
   getExpandedRowModel,
@@ -19,6 +20,7 @@ import { TableNoResultsState } from './components/table-no-results-state/table-n
 import { useColumnTransformer } from './hooks/use-column-transformer';
 import { usePageResetHandler } from './hooks/use-page-reset-handler';
 import { TableSelectionProvider } from './plugins/selection/table-selection-provider';
+import { useRowSelectionState } from './plugins/selection/use-row-selection-state';
 import { applyDefaultProps } from './utils/apply-default-props';
 import { composeTableState } from './utils/compose-table-state';
 import { getTableViewState } from './utils/get-table-view-state';
@@ -33,6 +35,11 @@ export function Table<T extends TableData = TableData>(inputProps: TableProps<T>
   const [css, theme] = useStyletron();
 
   const { state, initialState } = composeTableState(props.state ?? {});
+  const { enableRowSelection, setRowSelectionEnabled } = useRowSelectionState({
+    state,
+    initialState,
+  });
+
   const { scrollRatio, tableRef, updateScrollRatio } = useScrollRatio(columns);
 
   const table = useReactTable<T>({
@@ -59,7 +66,7 @@ export function Table<T extends TableData = TableData>(inputProps: TableProps<T>
           getRowCanExpand: () => true,
         }
       : {}),
-    enableRowSelection: props.enableRowSelection,
+    enableRowSelection,
     globalFilterFn: 'includesString',
     autoResetPageIndex: false,
   });
@@ -96,7 +103,8 @@ export function Table<T extends TableData = TableData>(inputProps: TableProps<T>
       <TableSelectionProvider
         value={{
           selectedRows: table.getSelectedRowModel().flatRows.map((row) => row.original),
-          selectionEnabled: props.enableRowSelection,
+          selectionEnabled: enableRowSelection,
+          setSelectionEnabled: setRowSelectionEnabled,
           toggleAllRowsSelected: (selected: boolean) => table.toggleAllRowsSelected(selected),
           getIsAllRowsSelected: () => table.getIsAllRowsSelected(),
           getIsSomeRowsSelected: () => table.getIsSomeRowsSelected(),
@@ -139,7 +147,7 @@ export function Table<T extends TableData = TableData>(inputProps: TableProps<T>
                 columns={transformedColumns}
                 setColumnOrder={table.setColumnOrder}
                 setColumnVisibility={table.setColumnVisibility}
-                enableRowSelection={props.enableRowSelection}
+                enableRowSelection={enableRowSelection}
                 isSelected={table.getIsAllRowsSelected()}
                 onToggleSelection={(selected: boolean) => table.toggleAllRowsSelected(selected)}
                 enableStickySides={props.enableStickySides}
@@ -150,7 +158,7 @@ export function Table<T extends TableData = TableData>(inputProps: TableProps<T>
             {viewState === 'ready' && (
               <props.body
                 rows={transformRows<T>(table.getRowModel().rows)}
-                enableRowSelection={props.enableRowSelection}
+                enableRowSelection={enableRowSelection}
                 enableStickySides={props.enableStickySides}
                 scrollRatio={scrollRatio}
                 subRow={props.subRow}

--- a/javascript/packages/core/components/table/types/table-types.ts
+++ b/javascript/packages/core/components/table/types/table-types.ts
@@ -154,15 +154,6 @@ export interface TableRequiredFunctionalityProps {
 
   /**
    * @description
-   * If true, enables row selection functionality with checkboxes in the first column.
-   * Selection state is ephemeral and resets on component unmount.
-   *
-   * @default false
-   */
-  enableRowSelection: boolean;
-
-  /**
-   * @description
    * If true, enables sticky column functionality for better horizontal scrolling experience.
    * First and last columns will remain visible during horizontal scroll.
    *
@@ -278,6 +269,8 @@ export type TableState = {
   columnVisibility: ColumnVisibilityState;
   /** Row selection state */
   rowSelection: RowSelectionState;
+  /** Row selection mode enabled state */
+  rowSelectionEnabled: boolean;
 };
 
 /**
@@ -301,4 +294,5 @@ export type ControlledTableState = TableState & {
   setRowSelection: (
     updater: RowSelectionState | ((old: RowSelectionState) => RowSelectionState)
   ) => void;
+  setRowSelectionEnabled: (enabled: boolean) => void;
 };

--- a/javascript/packages/core/components/table/utils/apply-default-props.tsx
+++ b/javascript/packages/core/components/table/utils/apply-default-props.tsx
@@ -49,7 +49,6 @@ export function applyDefaultProps<T extends TableData = TableData>(
     pageSizes,
     state: resolveTableState(props.state, disablePagination, pageSizes),
     pagination: props.pagination ?? TablePagination,
-    enableRowSelection: props.enableRowSelection ?? false,
     enableStickySides: props.enableStickySides ?? false,
     body: props.body ?? TableBody,
     unFilteredData: props.unFilteredData ?? props.data,
@@ -61,18 +60,23 @@ function resolveTableState(
   disablePagination: boolean,
   pageSizes: PageSizeOption[]
 ): Partial<ControlledTableState> | undefined {
-  if (disablePagination || userState?.setPagination) {
-    return userState;
+  const baseState = {
+    ...userState,
+    rowSelectionEnabled: userState?.rowSelectionEnabled ?? false,
+  };
+
+  if (disablePagination || baseState?.setPagination) {
+    return baseState;
   }
 
-  const requestedPageSize = userState?.pagination?.pageSize;
+  const requestedPageSize = baseState?.pagination?.pageSize;
   const normalizedPageSize = normalizePageSize(requestedPageSize, pageSizes);
 
   return {
-    ...userState,
+    ...baseState,
     pagination: {
       pageIndex: 0,
-      ...userState?.pagination,
+      ...baseState?.pagination,
       pageSize: normalizedPageSize,
     },
   };

--- a/javascript/packages/core/components/table/utils/compose-table-state.ts
+++ b/javascript/packages/core/components/table/utils/compose-table-state.ts
@@ -8,6 +8,7 @@ const STATE_NAME_TO_STATE_SETTER_NAME = {
   columnOrder: 'setColumnOrder',
   columnVisibility: 'setColumnVisibility',
   rowSelection: 'setRowSelection',
+  rowSelectionEnabled: 'setRowSelectionEnabled',
 } as const;
 
 /**


### PR DESCRIPTION
Replace static enableRowSelection prop with state-managed rowSelectionEnabled to support dynamic toggling of selection mode. This enables use cases like batch actions where selection UI should only appear when actively needed.

New implementation integrates rowSelectionEnabled into the standard table state API, supporting both controlled and uncontrolled patterns. The approach maintains consistency with other table state while adding custom controlled/uncontrolled logic since TanStack Table lacks built-in support for dynamic selection toggling.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Installed locally in Uber environment to verify existing batch delete flow worked correctly

https://github.com/user-attachments/assets/fa7ef401-28cb-41cd-9ffc-e272a04fd37a


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
