### PR TITLE
Introduce InputTableState to eliminate pageIndex requirement

### DIFF
--- a/javascript/packages/core/components/table/plugins/state-persistence/use-local-storage-table-state.ts
+++ b/javascript/packages/core/components/table/plugins/state-persistence/use-local-storage-table-state.ts
@@ -8,6 +8,7 @@ import type {
   ColumnOrderState,
   ColumnVisibilityState,
   ControlledTableState,
+  InputTableState,
   PaginationState,
   RowSelectionState,
   SortingState,
@@ -69,7 +70,7 @@ export function useLocalStorageTableState({
 }: {
   tableSettingsId: string;
   filterSettingsId?: string;
-  initialState?: Partial<ControlledTableState>;
+  initialState?: InputTableState;
 }): ControlledTableState {
   // Use filterSettingsId for filters when provided, otherwise fall back to tableSettingsId
   const filterNamespace = filterSettingsId ?? tableSettingsId;

--- a/javascript/packages/core/components/table/types/table-types.ts
+++ b/javascript/packages/core/components/table/types/table-types.ts
@@ -130,7 +130,7 @@ export interface TableRequiredFunctionalityProps {
    *
    * @default undefined
    */
-  state: Partial<ControlledTableState> | undefined;
+  state: InputTableState | undefined;
 
   /**
    * @description
@@ -296,3 +296,26 @@ export type ControlledTableState = TableState & {
   ) => void;
   setRowSelectionEnabled: (enabled: boolean) => void;
 };
+
+/**
+ * Table state that users can provide as input to control table behavior.
+ *
+ * Excludes `pageIndex` from pagination state to prevent users from being
+ * forced to manage navigation state when they only want to configure
+ * table behavior.
+ *
+ * @example
+ * ```tsx
+ * const tableState: InputTableState = {
+ *   pagination: { pageSize: 25 },
+ *   globalFilter: 'search term'
+ * };
+ *
+ * <Table data={data} columns={columns} state={tableState} />
+ * ```
+ */
+export type InputTableState = Partial<
+  Omit<ControlledTableState, 'pagination'> & {
+    pagination?: Partial<Omit<PaginationState, 'pageIndex'>>;
+  }
+>;

--- a/javascript/packages/core/components/table/utils/apply-default-props.tsx
+++ b/javascript/packages/core/components/table/utils/apply-default-props.tsx
@@ -8,7 +8,12 @@ import { normalizePageSize } from '../components/table-pagination/utils';
 
 import type { PageSizeOption } from '../components/table-pagination/types';
 import type { TableData } from '../types/data-types';
-import type { ControlledTableState, TableProps, TablePropsResolved } from '../types/table-types';
+import type {
+  ControlledTableState,
+  InputTableState,
+  TableProps,
+  TablePropsResolved,
+} from '../types/table-types';
 
 /**
  * Applies default properties to the given table properties.
@@ -56,7 +61,7 @@ export function applyDefaultProps<T extends TableData = TableData>(
 }
 
 function resolveTableState(
-  userState: Partial<ControlledTableState> | undefined,
+  userState: InputTableState | undefined,
   disablePagination: boolean,
   pageSizes: PageSizeOption[]
 ): Partial<ControlledTableState> | undefined {
@@ -65,8 +70,8 @@ function resolveTableState(
     rowSelectionEnabled: userState?.rowSelectionEnabled ?? false,
   };
 
-  if (disablePagination || baseState?.setPagination) {
-    return baseState;
+  if (disablePagination) {
+    return baseState as Partial<ControlledTableState>;
   }
 
   const requestedPageSize = baseState?.pagination?.pageSize;

--- a/javascript/packages/core/components/table/utils/compose-table-state.ts
+++ b/javascript/packages/core/components/table/utils/compose-table-state.ts
@@ -1,4 +1,4 @@
-import type { ControlledTableState, TableState } from '../types/table-types';
+import type { ControlledTableState, InputTableState, TableState } from '../types/table-types';
 
 const STATE_NAME_TO_STATE_SETTER_NAME = {
   globalFilter: 'setGlobalFilter',
@@ -27,7 +27,7 @@ const STATE_NAME_TO_STATE_SETTER_NAME = {
  * @remarks
  * A property will be considered controlled if the input state object contains a setter.
  */
-export function composeTableState(combinedState: Partial<ControlledTableState>): {
+export function composeTableState(combinedState: InputTableState): {
   initialState: Partial<TableState>;
   state: Partial<ControlledTableState>;
 } {


### PR DESCRIPTION
Replace Partial<ControlledTableState> with InputTableState type that excludes pageIndex from user-controllable table state properties.

Previous approach forced users to provide pageIndex when controlling pagination state, creating unnecessary coupling between configuration preferences (pageSize) and navigation state (current page). This made the API harder to use since users who only wanted to set page size had to also manage page navigation state they shouldn't care about.

**What type of PR is this? (check all applicable)**
- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
