### PR TITLE
feat(MaCTL): Pipeline Dev Run Cli+Plugin Implementation

### DIFF
--- a/proto/api/v2/pipeline_run.proto
+++ b/proto/api/v2/pipeline_run.proto
@@ -120,6 +120,10 @@ message PipelineRunSpec {
   // recipients, and conditions for when to send notifications.
   repeated Notification notifications = 11;
 
+  // Pipeline spec for pipeline dev run.
+  // When specified, the pipeline run controller will use the following pipeline spec to run the pipeline.
+  PipelineSpec pipeline_spec = 12;
+
   // Extension field for additional custom data
   google.protobuf.Any ext = 999;
 }

--- a/python/michelangelo/cli/mactl/mactl.py
+++ b/python/michelangelo/cli/mactl/mactl.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from types import MethodType
 from typing import Any, Callable, Union
 from uuid import uuid4
+from collections import defaultdict
 import logging
 import re
 import sys
@@ -72,6 +73,13 @@ def snake_to_camel(name: str) -> str:
     ex) "my_function_name" → "MyFunctionName"
     """
     return "".join(word.capitalize() for word in name.split("_"))
+
+
+def kebab_to_snake(name: str) -> str:
+    """
+    Converts kebab-case to snake_case (e.g., 'dev-run' -> 'dev_run').
+    """
+    return name.replace("-", "_")
 
 
 def bind_signature(signature):
@@ -155,9 +163,14 @@ class CRD:
             _LOG.info("Bound arguments: %r", bound_args.arguments)
             _self: CRD = bound_args.arguments["self"]
 
+            if len(bound_args.arguments["namespace"]) != 1:
+                raise ValueError('exactly one "namespace" argument is required')
+            if len(bound_args.arguments["name"]) != 1:
+                raise ValueError('exactly one "name" argument is required')
+
             request_input = input_class(
-                namespace=bound_args.arguments["namespace"],
-                name=bound_args.arguments["name"],
+                namespace=bound_args.arguments["namespace"][0],
+                name=bound_args.arguments["name"][0],
             )
             _LOG.info(
                 "DELETE Request input (%r) ready: %r",
@@ -205,9 +218,14 @@ class CRD:
             _LOG.info("Bound arguments: %r", bound_args.arguments)
             _self: CRD = bound_args.arguments["self"]
 
+            if len(bound_args.arguments["name"]) != 1:
+                raise ValueError('exactly one "name" argument is required')
+            if len(bound_args.arguments["namespace"]) != 1:
+                raise ValueError('exactly one "namespace" argument is required')
+
             request_input = input_class(
-                namespace=bound_args.arguments["namespace"],
-                name=bound_args.arguments["name"],
+                namespace=bound_args.arguments["namespace"][0],
+                name=bound_args.arguments["name"][0],
             )
             _LOG.info(
                 "GET Request input (%r) ready: %r",
@@ -254,8 +272,11 @@ class CRD:
             _LOG.info("Bound arguments: %r", bound_args.arguments)
             _self: CRD = bound_args.arguments["self"]
 
+            if len(bound_args.arguments["file"]) != 1:
+                raise ValueError('exactly one "file" argument is required')
+
             _namespace, _name = get_crd_namespace_and_name_from_yaml(
-                bound_args.arguments["file"]
+                bound_args.arguments["file"][0]
             )
             message_instance = _self.get(_namespace, _name)
             _LOG.info("Retrieved message instance: %r", message_instance)
@@ -300,10 +321,13 @@ class CRD:
             _LOG.info("Bound arguments: %r", bound_args.arguments)
             _self: CRD = bound_args.arguments["self"]
 
+            if len(bound_args.arguments["file"]) > 1:
+                raise ValueError('exactly one "file" argument is required')
+
             request_input = read_yaml_to_crd_request(
                 input_class,
                 _self.name,
-                bound_args.arguments["file"],
+                bound_args.arguments["file"][0],
                 _self.func_crd_metadata_converter,
             )
 
@@ -331,6 +355,14 @@ class CRD:
         This is a placeholder that plugins will override.
         """
         _LOG.info("Generate RUN method for %r / %r", self.name, self.full_name)
+        pass
+
+    def generate_dev_run(self, channel: Channel):
+        """
+        Generate dev run function - delegated to plugins.
+        This is a placeholder that plugins will override.
+        """
+        _LOG.info("Generate DEV RUN method for %r / %r", self.name, self.full_name)
         pass
 
     def generate_list(self, channel: Channel):
@@ -378,8 +410,11 @@ class CRD:
             bound_args.apply_defaults()
             _LOG.info("Bound arguments: %r", bound_args.arguments)
 
+            if len(bound_args.arguments["namespace"]) > 1:
+                raise ValueError('exactly one "namespace" argument is required')
+
             request_input = input_class(
-                namespace=bound_args.arguments["namespace"],
+                namespace=bound_args.arguments["namespace"][0],
             )
             _LOG.info(
                 "LIST Request input (%r) ready: %r",
@@ -731,37 +766,46 @@ def get_service_descriptors(channel, service_name) -> list[FileDescriptorProto]:
             yield fd
 
 
-def parse_args() -> tuple[list[str], dict[str, str]]:
+def parse_args() -> tuple[list[str], dict[str, list[str]]]:
     """
     Parse command line arguments.
     Returns a tuple of (args, kwargs).
     """
     args = []
-    kwargs = {}
+    kwargs = defaultdict(list)
     for arg in sys.argv[1:]:
         if "=" in arg:
             key, value = arg.split("=", 1)
             key = key.lstrip("-")
-            kwargs[key] = value
+            kwargs[key].append(value)
         else:
             args.append(arg)
     _LOG.info("Parsed arguments: %r  /  %r", args, kwargs)
     return args, kwargs
 
 
-def handle_args() -> tuple[str, str, dict[str, str]]:
+def handle_args() -> tuple[str, str, dict[str, list[str]]]:
     args, kwargs = parse_args()
 
     user_command_action = args[0]
-    assert user_command_action in ["get", "create", "apply", "delete", "list", "run"]
+    assert user_command_action in [
+        "get",
+        "create",
+        "apply",
+        "delete",
+        "list",
+        "run",
+        "dev-run",
+    ]
 
-    if user_command_action not in ["apply", "create", "run"]:
+    if user_command_action not in ["apply", "create", "dev-run"]:
         user_command_crd = args[1]
-    elif user_command_action == "run":
-        user_command_crd = args[1]  # e.g., "pipeline" from "run pipeline"
     else:
-        _LOG.info("Action is 'apply', read user_command_crd from yaml")
-        user_command_crd = camel_to_snake(get_crd_name_from_yaml(kwargs["file"]))
+        _LOG.info("read user_command_crd from yaml")
+        assert len(kwargs["file"]) == 1, "exactly one yaml file is required"
+        user_command_crd = camel_to_snake(get_crd_name_from_yaml(kwargs["file"][0]))
+
+    user_command_action = kebab_to_snake(user_command_action)
 
     _LOG.info(
         "User command CRD: %r / User command action: %r",

--- a/python/michelangelo/cli/mactl/mactl.py
+++ b/python/michelangelo/cli/mactl/mactl.py
@@ -95,6 +95,36 @@ def bind_signature(signature):
     return decorator
 
 
+def get_single_arg(arguments: dict, key: str) -> str:
+    """
+    Get a single argument from the arguments dictionary.
+
+    Args:
+        arguments: The arguments dictionary.
+        key: The key of the argument to get.
+
+    Returns:
+        The value of the single argument.
+
+    Raises:
+        ValueError: If the argument is not in the dictionary or is not a string or a list with one element.
+    """
+    if key not in arguments:
+        raise ValueError(f'argument "{key}" is required')
+    value = arguments[key]
+    if isinstance(value, str):
+        return value
+    elif isinstance(value, list):
+        if len(value) == 1:
+            return value[0]
+        else:
+            raise ValueError(f'exactly one "{key}" argument is required')
+    else:
+        raise ValueError(
+            f'Argument "{key}" must be a string or a list with one element'
+        )
+
+
 class CRD:
     """
     Representation of each CRD with its service methods
@@ -163,14 +193,12 @@ class CRD:
             _LOG.info("Bound arguments: %r", bound_args.arguments)
             _self: CRD = bound_args.arguments["self"]
 
-            if len(bound_args.arguments["namespace"]) != 1:
-                raise ValueError('exactly one "namespace" argument is required')
-            if len(bound_args.arguments["name"]) != 1:
-                raise ValueError('exactly one "name" argument is required')
+            _namespace = get_single_arg(bound_args.arguments, "namespace")
+            _name = get_single_arg(bound_args.arguments, "name")
 
             request_input = input_class(
-                namespace=bound_args.arguments["namespace"][0],
-                name=bound_args.arguments["name"][0],
+                namespace=_namespace,
+                name=_name,
             )
             _LOG.info(
                 "DELETE Request input (%r) ready: %r",
@@ -218,14 +246,12 @@ class CRD:
             _LOG.info("Bound arguments: %r", bound_args.arguments)
             _self: CRD = bound_args.arguments["self"]
 
-            if len(bound_args.arguments["name"]) != 1:
-                raise ValueError('exactly one "name" argument is required')
-            if len(bound_args.arguments["namespace"]) != 1:
-                raise ValueError('exactly one "namespace" argument is required')
+            _name = get_single_arg(bound_args.arguments, "name")
+            _namespace = get_single_arg(bound_args.arguments, "namespace")
 
             request_input = input_class(
-                namespace=bound_args.arguments["namespace"][0],
-                name=bound_args.arguments["name"][0],
+                namespace=_namespace,
+                name=_name,
             )
             _LOG.info(
                 "GET Request input (%r) ready: %r",
@@ -271,17 +297,13 @@ class CRD:
             _LOG.info("Start apply_func for %r", self.full_name)
             _LOG.info("Bound arguments: %r", bound_args.arguments)
             _self: CRD = bound_args.arguments["self"]
+            _file = get_single_arg(bound_args.arguments, "file")
 
-            if len(bound_args.arguments["file"]) != 1:
-                raise ValueError('exactly one "file" argument is required')
-
-            _namespace, _name = get_crd_namespace_and_name_from_yaml(
-                bound_args.arguments["file"][0]
-            )
+            _namespace, _name = get_crd_namespace_and_name_from_yaml(_file)
             message_instance = _self.get(_namespace, _name)
             _LOG.info("Retrieved message instance: %r", message_instance)
             request_input = self.read_yaml_and_update_crd_request(
-                input_class, bound_args.arguments["file"], message_instance
+                input_class, _file, message_instance
             )
 
             method_fullname = f"/{_self.full_name}/{method_name}"
@@ -321,13 +343,12 @@ class CRD:
             _LOG.info("Bound arguments: %r", bound_args.arguments)
             _self: CRD = bound_args.arguments["self"]
 
-            if len(bound_args.arguments["file"]) > 1:
-                raise ValueError('exactly one "file" argument is required')
+            _file = get_single_arg(bound_args.arguments, "file")
 
             request_input = read_yaml_to_crd_request(
                 input_class,
                 _self.name,
-                bound_args.arguments["file"][0],
+                _file,
                 _self.func_crd_metadata_converter,
             )
 
@@ -410,11 +431,10 @@ class CRD:
             bound_args.apply_defaults()
             _LOG.info("Bound arguments: %r", bound_args.arguments)
 
-            if len(bound_args.arguments["namespace"]) > 1:
-                raise ValueError('exactly one "namespace" argument is required')
+            _namespace = get_single_arg(bound_args.arguments, "namespace")
 
             request_input = input_class(
-                namespace=bound_args.arguments["namespace"][0],
+                namespace=_namespace,
             )
             _LOG.info(
                 "LIST Request input (%r) ready: %r",

--- a/python/michelangelo/cli/mactl/plugins/pipeline/create.py
+++ b/python/michelangelo/cli/mactl/plugins/pipeline/create.py
@@ -185,6 +185,49 @@ def convert_crd_metadata_pipeline_create(
     # Get relative path of config file from repo root
     config_file_relative_path = str(yaml_path.relative_to(repo_root))
 
+    workflow_inputs, uniflow_tar_path, workflow_function_name = (
+        handle_workflow_inputs_retrieval(
+            repo_root, config_file_relative_path, project, pipeline
+        )
+    )
+
+    res = {}
+
+    res["metadata"] = {
+        "annotations": yaml_dict["metadata"].get("annotations", {}),
+        "clusterName": "",
+        "generateName": "",
+        "generation": "0",
+        "name": pipeline,
+        "namespace": project,
+        "resourceVersion": "0",
+        "uid": str(uuid4()),
+    }
+
+    return populate_pipeline_spec_with_workflow_inputs(
+        res,
+        yaml_dict,
+        workflow_inputs,
+        repo,
+        yaml_path,
+        repo_root,
+        config_file_relative_path,
+        uniflow_tar_path,
+        workflow_function_name,
+    )
+
+
+def handle_workflow_inputs_retrieval(
+    repo_root: Path, config_file_relative_path: str, project: str, pipeline: str
+) -> tuple[dict, str, str]:
+    """
+    Handle workflow inputs retrieval from subprocess registration.
+    """
+
+    workflow_inputs = None
+    uniflow_tar_path = ""
+    workflow_function_name = ""
+
     # Run pipeline registration to get uniflow artifacts
     try:
         workflow_inputs, uniflow_tar_path, workflow_function_name = (
@@ -218,29 +261,30 @@ def convert_crd_metadata_pipeline_create(
             _LOG.warning(
                 "Registration failed, continuing without uniflow artifacts: %s", e
             )
-            workflow_inputs = None
-            uniflow_tar_path = ""
-            workflow_function_name = ""
     except Exception as e:
         _LOG.error("Unexpected error during registration: %s", e)
         # For unexpected errors, also use graceful degradation
         _LOG.warning(
             "Unexpected registration failure, continuing without uniflow artifacts"
         )
-        workflow_inputs = None
-        uniflow_tar_path = ""
+    return workflow_inputs, uniflow_tar_path, workflow_function_name
 
-    res = {"spec": deepcopy(yaml_dict["spec"])}
-    res["metadata"] = {
-        "annotations": yaml_dict["metadata"].get("annotations", {}),
-        "clusterName": "",
-        "generateName": "",
-        "generation": "0",
-        "name": pipeline,
-        "namespace": project,
-        "resourceVersion": "0",
-        "uid": str(uuid4()),
-    }
+
+def populate_pipeline_spec_with_workflow_inputs(
+    res: dict,
+    yaml_dict: dict,
+    workflow_inputs: dict,
+    repo: Repo,
+    yaml_path: Path,
+    repo_root: Path,
+    config_file_relative_path: str,
+    uniflow_tar_path: str,
+    workflow_function_name: str,
+) -> dict:
+    """
+    Populate pipeline spec with workflow inputs.
+    """
+    res["spec"] = deepcopy(yaml_dict["spec"])
     res["spec"]["commit"] = {
         "branch": repo.active_branch.name,
         "git_ref": repo.head.commit.hexsha,

--- a/python/michelangelo/cli/mactl/plugins/pipeline/dev_run.py
+++ b/python/michelangelo/cli/mactl/plugins/pipeline/dev_run.py
@@ -17,6 +17,7 @@ from mactl import (
     get_message_class_by_name,
     get_methods_from_service,
     yaml_to_dict,
+    get_single_arg,
 )
 
 from plugins.pipeline.create import (
@@ -59,8 +60,11 @@ def generate_dev_run(crd: CRD, channel: Channel):
     output_class = get_message_class_by_name(method_pool, method_run.output_type[1:])
 
     dev_run_func_signature = Signature(
-        [Parameter("self", Parameter.POSITIONAL_OR_KEYWORD)]
-        + [Parameter(name, Parameter.POSITIONAL_OR_KEYWORD) for name in ["file", "env"]]
+        [
+            Parameter("self", Parameter.POSITIONAL_OR_KEYWORD),
+            Parameter("file", Parameter.POSITIONAL_OR_KEYWORD),
+            Parameter("env", Parameter.POSITIONAL_OR_KEYWORD, default={}),
+        ]
     )
 
     @bind_signature(dev_run_func_signature)
@@ -69,13 +73,14 @@ def generate_dev_run(crd: CRD, channel: Channel):
         _LOG.info("Bound arguments: %r", bound_args.arguments)
         _self: CRD = bound_args.arguments["self"]
 
-        if len(bound_args.arguments["file"]) != 1:
-            raise ValueError('exactly one "file" argument is required')
+        _file = get_single_arg(bound_args.arguments, "file")
 
-        environment_variables = _process_env_variables(bound_args.arguments["env"])
+        environment_variables = _process_env_variables(
+            bound_args.arguments.get("env", [])
+        )
 
         # parse pipeline yaml file
-        yaml_path_string = bound_args.arguments["file"][0]
+        yaml_path_string = _file
         yaml_path = Path(yaml_path_string).resolve()
         yaml_dict = yaml_to_dict(yaml_path_string)
         yaml_dict[_ENV_VARIABLE_KEY] = environment_variables

--- a/python/michelangelo/cli/mactl/plugins/pipeline/dev_run.py
+++ b/python/michelangelo/cli/mactl/plugins/pipeline/dev_run.py
@@ -174,7 +174,10 @@ def generate_pipeline_dev_run_object(yaml_dict: dict, pipeline_spec: dict) -> di
 
     pipeline_run_spec = pipeline_run_obj.setdefault("spec", {})
     # embed environment variables into pipeline_run.spec.inputs
-    pipeline_run_spec["input"] = yaml_dict.get(_ENV_VARIABLE_KEY, {})
+    if yaml_dict.get(_ENV_VARIABLE_KEY):
+        pipeline_run_spec["input"] = {
+            _ENV_VARIABLE_KEY: yaml_dict.get(_ENV_VARIABLE_KEY, {})
+        }
     # embed pipeline_spec into pipeline_run.pipeline_run_spec
     pipeline_run_spec["pipeline_spec"] = pipeline_spec.get("spec", {})
 

--- a/python/michelangelo/cli/mactl/plugins/pipeline/dev_run.py
+++ b/python/michelangelo/cli/mactl/plugins/pipeline/dev_run.py
@@ -31,6 +31,7 @@ from plugins.pipeline.run import (
 )
 
 _ENV_VARIABLE_KEY = "env"
+_UNIFLOW_IMAGE_ANNOTATION_KEY = "michelangelo/uniflow-image"
 
 _LOG = getLogger(__name__)
 
@@ -174,10 +175,24 @@ def generate_pipeline_dev_run_object(yaml_dict: dict, pipeline_spec: dict) -> di
 
     pipeline_run_spec = pipeline_run_obj.setdefault("spec", {})
     # embed environment variables into pipeline_run.spec.inputs
-    if yaml_dict.get(_ENV_VARIABLE_KEY):
+    environment_variables = yaml_dict.get(_ENV_VARIABLE_KEY, {})
+    if environment_variables:
         pipeline_run_spec["input"] = {
-            _ENV_VARIABLE_KEY: yaml_dict.get(_ENV_VARIABLE_KEY, {})
+            "environ": environment_variables,
         }
+
+    # embed uniflow image annotations into pipeline_run.metadata.annotations
+    uniflow_image_annotation_value = (
+        yaml_dict.get("metadata", {})
+        .get("annotations", {})
+        .get(_UNIFLOW_IMAGE_ANNOTATION_KEY, "")
+    )
+    if uniflow_image_annotation_value:
+        pipeline_run_metadata = pipeline_run_obj.setdefault("metadata", {})
+        pipeline_run_metadata["annotations"] = {
+            _UNIFLOW_IMAGE_ANNOTATION_KEY: uniflow_image_annotation_value,
+        }
+
     # embed pipeline_spec into pipeline_run.pipeline_run_spec
     pipeline_run_spec["pipeline_spec"] = pipeline_spec.get("spec", {})
 

--- a/python/michelangelo/cli/mactl/plugins/pipeline/dev_run.py
+++ b/python/michelangelo/cli/mactl/plugins/pipeline/dev_run.py
@@ -1,0 +1,192 @@
+from types import MethodType
+from logging import getLogger
+from inspect import Signature, Parameter
+from pathlib import Path
+
+
+from git import Repo
+from google.protobuf.json_format import ParseDict
+from google.protobuf.message import Message
+from grpc import Channel
+
+
+from mactl import (
+    CRD,
+    METADATA_STUB,
+    bind_signature,
+    get_message_class_by_name,
+    get_methods_from_service,
+    yaml_to_dict,
+)
+
+from plugins.pipeline.create import (
+    handle_workflow_inputs_retrieval,
+    populate_pipeline_spec_with_workflow_inputs,
+)
+
+from plugins.pipeline.run import (
+    generate_pipeline_run_object,
+    generate_pipeline_run_name,
+)
+
+_ENV_VARIABLE_KEY = "env"
+
+_LOG = getLogger(__name__)
+
+
+def generate_dev_run(crd: CRD, channel: Channel):
+    """
+    Generate dev run function for pipeline CRD.
+    """
+    _LOG.info("Generating `pipeline run` cr for dev-run: %s", crd)
+
+    pipeline_run_service = "michelangelo.api.v2.PipelineRunService"
+    methods, method_pool = get_methods_from_service(channel, pipeline_run_service)
+    method_name = "CreatePipelineRun"
+
+    _LOG.info("Run input/output of method %r", method_name)
+    try:
+        method_run = methods[method_name]
+    except KeyError:
+        _LOG.warning(
+            "Method %r not found in service %r", method_name, pipeline_run_service
+        )
+        return
+
+    _LOG.info("Run method input type: %r", method_run.input_type)
+    _LOG.info("Run method output type: %r", method_run.output_type)
+    input_class = get_message_class_by_name(method_pool, method_run.input_type[1:])
+    output_class = get_message_class_by_name(method_pool, method_run.output_type[1:])
+
+    dev_run_func_signature = Signature(
+        [Parameter("self", Parameter.POSITIONAL_OR_KEYWORD)]
+        + [Parameter(name, Parameter.POSITIONAL_OR_KEYWORD) for name in ["file", "env"]]
+    )
+
+    @bind_signature(dev_run_func_signature)
+    def dev_run_func(bound_args: Signature) -> Message:
+        _LOG.info("Start dev_run_func for pipeline")
+        _LOG.info("Bound arguments: %r", bound_args.arguments)
+        _self: CRD = bound_args.arguments["self"]
+
+        if len(bound_args.arguments["file"]) != 1:
+            raise ValueError('exactly one "file" argument is required')
+
+        environment_variables = _process_env_variables(bound_args.arguments["env"])
+
+        # parse pipeline yaml file
+        yaml_path_string = bound_args.arguments["file"][0]
+        yaml_path = Path(yaml_path_string).resolve()
+        yaml_dict = yaml_to_dict(yaml_path_string)
+        yaml_dict[_ENV_VARIABLE_KEY] = environment_variables
+
+        pipeline_dev_run_dict = _self.func_crd_metadata_converter(
+            yaml_dict, input_class, yaml_path
+        )
+
+        _LOG.debug("CR content: %r", pipeline_dev_run_dict)
+
+        request_input = input_class()
+        ParseDict(pipeline_dev_run_dict, request_input)
+
+        method_fullname = f"/{pipeline_run_service}/{method_name}"
+        _LOG.info("Method fullname for gRPC call: %s", method_fullname)
+        stub_method = channel.unary_unary(
+            method_fullname,
+            request_serializer=input_class.SerializeToString,
+            response_deserializer=output_class.FromString,
+        )
+        response = stub_method(
+            request_input,
+            metadata=METADATA_STUB,
+            timeout=30,
+        )
+        _LOG.info("Stub method completed (%r): %r", type(response), response)
+        return response
+
+    dev_run_func.__signature__ = dev_run_func_signature
+    crd.dev_run = MethodType(dev_run_func, crd)
+
+
+def convert_crd_metadata_pipeline_dev_run(
+    yaml_dict: dict, crd_class: type[Message], yaml_path: Path
+) -> dict:
+    """
+    Convert CRD metadata for pipeline dev-run command.
+    This function generates a PipelineRunRequest object from command line arguments.
+    """
+    _LOG.info("Converting metadata for pipeline run command")
+
+    if not isinstance(yaml_dict, dict):
+        _LOG.error("Expected a dictionary, got: %r", type(yaml_dict))
+        raise ValueError("Expected a dictionary for pipeline run metadata")
+
+    repo = Repo(".", search_parent_directories=True)
+    repo_root = Path(repo.git.rev_parse("--show-toplevel")).resolve()
+    _LOG.info("Current git repository info: %r", repo)
+
+    # Extract project and pipeline names from metadata
+    project = yaml_dict["metadata"]["namespace"]  # Assuming namespace maps to project
+    pipeline = yaml_dict["metadata"]["name"]
+
+    # Get relative path of config file from repo root
+    config_file_relative_path = str(yaml_path.relative_to(repo_root))
+
+    workflow_inputs, uniflow_tar_path, workflow_function_name = (
+        handle_workflow_inputs_retrieval(
+            repo_root, config_file_relative_path, project, pipeline
+        )
+    )
+
+    pipeline_spec = populate_pipeline_spec_with_workflow_inputs(
+        {},
+        yaml_dict,
+        workflow_inputs,
+        repo,
+        yaml_path,
+        repo_root,
+        config_file_relative_path,
+        uniflow_tar_path,
+        workflow_function_name,
+    )
+
+    pipeline_dev_run_cr = generate_pipeline_dev_run_object(yaml_dict, pipeline_spec)
+    return {"pipeline_run": pipeline_dev_run_cr}
+
+
+def generate_pipeline_dev_run_object(yaml_dict: dict, pipeline_spec: dict) -> dict:
+    """
+    Generate Pipeline Dev Run CR as dictionary.
+    """
+
+    namespace = yaml_dict.get("metadata", {}).get("namespace", "")
+    pipeline_name = yaml_dict.get("metadata", {}).get("name", "")
+    pipeline_run_name = generate_pipeline_run_name()
+
+    pipeline_run_obj = generate_pipeline_run_object(
+        run_name=pipeline_run_name, pipeline_name=pipeline_name, namespace=namespace
+    )
+
+    pipeline_run_spec = pipeline_run_obj.setdefault("spec", {})
+    # embed environment variables into pipeline_run.spec.inputs
+    pipeline_run_spec["input"] = yaml_dict.get(_ENV_VARIABLE_KEY, {})
+    # embed pipeline_spec into pipeline_run.pipeline_run_spec
+    pipeline_run_spec["pipeline_spec"] = pipeline_spec.get("spec", {})
+
+    return pipeline_run_obj
+
+
+def _process_env_variables(env_variables: list[str]) -> dict:
+    """
+    Process environment variables which are passed as a list of strings.
+    Format of the environment variables is "<ENV_VAR>=<VALUE>".
+    """
+    env_dict = {}
+    for env_variable in env_variables:
+        key_value_pair = env_variable.split("=", 1)
+        if len(key_value_pair) != 2:
+            raise TypeError(
+                f"Invalid environment variable format: {env_variable}, expected format is <ENV_VAR>=<VALUE>"
+            )
+        env_dict[key_value_pair[0]] = key_value_pair[1]
+    return env_dict

--- a/python/michelangelo/cli/mactl/plugins/pipeline/main.py
+++ b/python/michelangelo/cli/mactl/plugins/pipeline/main.py
@@ -6,6 +6,10 @@ from mactl import CRD
 from plugins.pipeline.apply import generate_apply
 from plugins.pipeline.create import generate_create
 from plugins.pipeline.run import generate_run, convert_crd_metadata_pipeline_run
+from plugins.pipeline.dev_run import (
+    generate_dev_run,
+    convert_crd_metadata_pipeline_dev_run,
+)
 
 
 _LOG = getLogger(__name__)
@@ -25,6 +29,7 @@ def apply_plugins(
     if target_command == "run":
         crd.func_crd_metadata_converter = convert_crd_metadata_pipeline_run
         generate_run(crd, channel)
+    if target_command == "dev_run":
+        crd.func_crd_metadata_converter = convert_crd_metadata_pipeline_dev_run
+        generate_dev_run(crd, channel)
     _LOG.info("Plugins applied successfully to crd: %s", crd)
-
-

--- a/python/michelangelo/cli/mactl/plugins/pipeline/run.py
+++ b/python/michelangelo/cli/mactl/plugins/pipeline/run.py
@@ -15,6 +15,7 @@ from mactl import (
     get_message_class_by_name,
     bind_signature,
     METADATA_STUB,
+    get_single_arg,
 )
 
 
@@ -59,14 +60,12 @@ def generate_run(crd: CRD, channel: Channel):
         _LOG.info("Bound arguments: %r", bound_args.arguments)
         _self: CRD = bound_args.arguments["self"]
 
-        if len(bound_args.arguments["namespace"]) != 1:
-            raise ValueError('exactly one "namespace" argument is required')
-        if len(bound_args.arguments["name"]) != 1:
-            raise ValueError('exactly one "name" argument is required')
+        _namespace = get_single_arg(bound_args.arguments, "namespace")
+        _name = get_single_arg(bound_args.arguments, "name")
 
         run_kwargs = {
-            "namespace": bound_args.arguments["namespace"][0],
-            "name": bound_args.arguments["name"][0],
+            "namespace": _namespace,
+            "name": _name,
         }
 
         pipeline_run_dict = _self.func_crd_metadata_converter(

--- a/python/michelangelo/cli/mactl/plugins/pipeline/run.py
+++ b/python/michelangelo/cli/mactl/plugins/pipeline/run.py
@@ -10,7 +10,12 @@ from inspect import Signature, Parameter
 from types import MethodType
 from google.protobuf.message import Message
 from google.protobuf.json_format import ParseDict
-from mactl import get_methods_from_service, get_message_class_by_name, bind_signature, METADATA_STUB
+from mactl import (
+    get_methods_from_service,
+    get_message_class_by_name,
+    bind_signature,
+    METADATA_STUB,
+)
 
 
 _LOG = getLogger(__name__)
@@ -21,50 +26,60 @@ def generate_run(crd: CRD, channel: Channel):
     Generate run function for pipeline CRD.
     """
     _LOG.info("Generating `pipeline run` crd for: %s", crd)
-    
+
     pipeline_run_service = "michelangelo.api.v2.PipelineRunService"
     methods, method_pool = get_methods_from_service(channel, pipeline_run_service)
     method_name = "CreatePipelineRun"
-    
+
     _LOG.info("Run input/output of method %r", method_name)
     try:
         method_create = methods[method_name]
     except KeyError:
-        _LOG.warning("Method %r not found in service %r", method_name, pipeline_run_service)
+        _LOG.warning(
+            "Method %r not found in service %r", method_name, pipeline_run_service
+        )
         return
-    
+
     _LOG.info("Run method input type: %r", method_create.input_type)
     _LOG.info("Run method output type: %r", method_create.output_type)
     input_class = get_message_class_by_name(method_pool, method_create.input_type[1:])
     output_class = get_message_class_by_name(method_pool, method_create.output_type[1:])
-    
+
     run_func_signature = Signature(
         [Parameter("self", Parameter.POSITIONAL_OR_KEYWORD)]
-        + [Parameter(name, Parameter.POSITIONAL_OR_KEYWORD) for name in ["namespace", "name"]]
+        + [
+            Parameter(name, Parameter.POSITIONAL_OR_KEYWORD)
+            for name in ["namespace", "name"]
+        ]
     )
-    
+
     @bind_signature(run_func_signature)
     def run_func(bound_args: Signature) -> Message:
         _LOG.info("Start run_func for pipeline")
         _LOG.info("Bound arguments: %r", bound_args.arguments)
         _self: CRD = bound_args.arguments["self"]
-        
+
+        if len(bound_args.arguments["namespace"]) != 1:
+            raise ValueError('exactly one "namespace" argument is required')
+        if len(bound_args.arguments["name"]) != 1:
+            raise ValueError('exactly one "name" argument is required')
+
         run_kwargs = {
-            "namespace": bound_args.arguments["namespace"],
-            "name": bound_args.arguments["name"]
+            "namespace": bound_args.arguments["namespace"][0],
+            "name": bound_args.arguments["name"][0],
         }
-        
+
         pipeline_run_dict = _self.func_crd_metadata_converter(
             run_kwargs, input_class, None
         )
-        
+
         request_input = input_class()
         ParseDict(pipeline_run_dict, request_input)
-        
+
         service_name = "michelangelo.api.v2.PipelineRunService"
         method_fullname = f"/{service_name}/{method_name}"
         _LOG.info("Method fullname for gRPC call: %s", method_fullname)
-        
+
         stub_method = channel.unary_unary(
             method_fullname,
             request_serializer=input_class.SerializeToString,
@@ -77,7 +92,7 @@ def generate_run(crd: CRD, channel: Channel):
         )
         _LOG.info("Stub method completed (%r): %r", type(response), response)
         return response
-    
+
     run_func.__signature__ = run_func_signature  # type: ignore[attr-defined]
     crd.run = MethodType(run_func, crd)
 
@@ -90,68 +105,78 @@ def convert_crd_metadata_pipeline_run(
     This function generates a CreatePipelineRunRequest object from command line arguments.
     """
     _LOG.info("Converting metadata for pipeline run command")
-    
+
     if not isinstance(yaml_dict, dict):
         _LOG.error("Expected a dictionary, got: %r", type(yaml_dict))
         raise ValueError("Expected a dictionary for pipeline run metadata")
-    
+
     # Validate required arguments
     if "namespace" not in yaml_dict:
         raise ValueError("--namespace is required for pipeline run")
     if "name" not in yaml_dict:
         raise ValueError("--name is required for pipeline run")
-    
+
     namespace = yaml_dict["namespace"]
     pipeline_name = yaml_dict["name"]
-    
-    timestamp = int(time.time())
-    uuid8 = str(uuid.uuid4())[:8]
-    run_name = f"run-{timestamp}-{uuid8}"
-    
-    _LOG.info("Generating pipeline run: %s for pipeline: %s in namespace: %s", 
-              run_name, pipeline_name, namespace)
-    
-    pipeline_run = generate_pipeline_run_object(
-        run_name=run_name,
-        pipeline_name=pipeline_name,
-        namespace=namespace
+    run_name = generate_pipeline_run_name()
+
+    _LOG.info(
+        "Generating pipeline run: %s for pipeline: %s in namespace: %s",
+        run_name,
+        pipeline_name,
+        namespace,
     )
-    
+
+    pipeline_run = generate_pipeline_run_object(
+        run_name=run_name, pipeline_name=pipeline_name, namespace=namespace
+    )
+
     return {"pipeline_run": pipeline_run}
 
 
-def generate_pipeline_run_object(run_name: str, pipeline_name: str, namespace: str) -> dict:
+def generate_pipeline_run_object(
+    run_name: str, pipeline_name: str, namespace: str
+) -> dict:
     """
     Generate PipelineRun object as dictionary.
-    
+
     Args:
         run_name: Generated unique name for the pipeline run
         pipeline_name: Name of the target pipeline to run
         namespace: Kubernetes namespace
-        
+
     Returns:
         dict: Configured pipeline run object as dictionary
     """
-    
+
     pipeline_run_dict = {
         "typeMeta": {
             "kind": "PipelineRun",
-            "apiVersion": "michelangelo.api/v2"
+            "apiVersion": "michelangelo.api/v2",
         },
         "metadata": {
             "name": run_name,
-            "namespace": namespace
+            "namespace": namespace,
         },
         "spec": {
             "pipeline": {
                 "name": pipeline_name,
-                "namespace": namespace
+                "namespace": namespace,
             },
             "actor": {
-                "name": "mactl-user" 
-            }
-        }
+                "name": "mactl-user",
+            },
+        },
     }
-    
+
     _LOG.info("Generated pipeline run object: %s", run_name)
     return pipeline_run_dict
+
+
+def generate_pipeline_run_name() -> str:
+    """
+    Generates a pipeline-run name.
+    """
+    timestamp = int(time.time())
+    uuid8 = str(uuid.uuid4())[:8]
+    return f"run-{timestamp}-{uuid8}"


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
This PR implements the pipeline dev-run function. This includes a new plugin implementation for pipeline dev-run and a small refactor on the cli side to accept multi-value flags and on the plugin side to re-use functions. Left comments in the PR to aid review.

<!-- Tell your future self why have you made these changes -->
**Why?**
Users want to be able to quickly iterate on their pipeline changes. They also want to be able to inject environment variables to run their pipelines. The dev-run feature allows users to run pipelines without registering them. Additional details can be found in [this ERD](https://docs.google.com/document/d/1Jjip6T1yaFCqIOGWZfSqn5nhubUo-16wQia32V8IZyE/edit?tab=t.0).


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Used sandbox to verify changes locally. Verified the request json contains all expected fields:
- `pipeline_spec` containing pipeline spec
- `input` containing env variables

Confirmed that tar ball gets uploaded to minio object store (identical to `mactl create`).


<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
I will update [MaCTL wiki](https://github.com/michelangelo-ai/michelangelo/wiki/MaCTL-(Michelangelo-CLI-interface)) once the changes get merged.
