### PR TITLE
Enable dynamic column resolution and full column rendering in filters

### DIFF
--- a/javascript/packages/core/components/table/components/filter/__tests__/categorical-filter.test.tsx
+++ b/javascript/packages/core/components/table/components/filter/__tests__/categorical-filter.test.tsx
@@ -19,17 +19,23 @@ describe('CategoricalFilter', () => {
   const mockSetFilterValue = vi.fn();
   const mockGetFilterValue = vi.fn();
 
+  const mockColumn = {
+    id: 'department',
+    label: 'Department',
+    type: 'text',
+  };
+
   const defaultProps: ColumnFilterProps = {
-    columnId: 'department',
+    column: mockColumn,
     close: mockClose,
     getFilterValue: mockGetFilterValue,
     setFilterValue: mockSetFilterValue,
     preFilteredRows: [
-      { getValue: () => 'Engineering' },
-      { getValue: () => 'Marketing' },
-      { getValue: () => 'Engineering' },
-      { getValue: () => 'Sales' },
-      { getValue: () => 'Design' },
+      { getValue: () => 'Engineering', record: { department: 'Engineering' } },
+      { getValue: () => 'Marketing', record: { department: 'Marketing' } },
+      { getValue: () => 'Engineering', record: { department: 'Engineering' } },
+      { getValue: () => 'Sales', record: { department: 'Sales' } },
+      { getValue: () => 'Design', record: { department: 'Design' } },
     ],
   };
 
@@ -182,10 +188,10 @@ describe('CategoricalFilter', () => {
       const propsWithDuplicates: ColumnFilterProps = {
         ...defaultProps,
         preFilteredRows: [
-          { getValue: () => 'Engineering' },
-          { getValue: () => 'Engineering' },
-          { getValue: () => 'Marketing' },
-          { getValue: () => 'Engineering' },
+          { getValue: () => 'Engineering', record: { department: 'Engineering' } },
+          { getValue: () => 'Engineering', record: { department: 'Engineering' } },
+          { getValue: () => 'Marketing', record: { department: 'Marketing' } },
+          { getValue: () => 'Engineering', record: { department: 'Engineering' } },
         ],
       };
 
@@ -205,11 +211,11 @@ describe('CategoricalFilter', () => {
       const propsWithNulls: ColumnFilterProps = {
         ...defaultProps,
         preFilteredRows: [
-          { getValue: () => 'Engineering' },
-          { getValue: () => null },
-          { getValue: () => undefined },
-          { getValue: () => 'Marketing' },
-          { getValue: () => '' },
+          { getValue: () => 'Engineering', record: { department: 'Engineering' } },
+          { getValue: () => null, record: { department: null } },
+          { getValue: () => undefined, record: { department: undefined } },
+          { getValue: () => 'Marketing', record: { department: 'Marketing' } },
+          { getValue: () => '', record: { department: '' } },
         ],
       };
 
@@ -225,5 +231,53 @@ describe('CategoricalFilter', () => {
 
       expect(screen.getAllByRole('checkbox')).toHaveLength(BASE_UI_CHECKBOX_COUNT + 3);
     });
+  });
+
+  it('should show display text but filter with raw values when cellToString differs from raw data', async () => {
+    const user = userEvent.setup();
+
+    const stateColumn = {
+      id: 'status',
+      label: 'Status',
+      type: 'STATE',
+      stateTextMap: {
+        PIPELINE_STATE_BUILDING: 'Building',
+        PIPELINE_STATE_ERROR: 'Failed',
+        PIPELINE_STATE_SUCCESS: 'Complete',
+      },
+    };
+
+    const stateProps: ColumnFilterProps = {
+      column: stateColumn,
+      close: mockClose,
+      getFilterValue: mockGetFilterValue,
+      setFilterValue: mockSetFilterValue,
+      preFilteredRows: [
+        {
+          getValue: () => 'PIPELINE_STATE_BUILDING',
+          record: { status: 'PIPELINE_STATE_BUILDING' },
+        },
+        { getValue: () => 'PIPELINE_STATE_ERROR', record: { status: 'PIPELINE_STATE_ERROR' } },
+        { getValue: () => 'PIPELINE_STATE_SUCCESS', record: { status: 'PIPELINE_STATE_SUCCESS' } },
+      ],
+    };
+
+    render(
+      <CategoricalFilter {...stateProps} />,
+      buildWrapper([getBaseProviderWrapper(), getInterpolationProviderWrapper()])
+    );
+
+    // Should show display text in filter options
+    expect(screen.getByLabelText('Building')).toBeInTheDocument();
+    expect(screen.getByLabelText('Failed')).toBeInTheDocument();
+    expect(screen.getByLabelText('Complete')).toBeInTheDocument();
+
+    // Select display value and apply filter
+    await user.click(screen.getByLabelText('Building'));
+    await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+    // Should filter with raw value, not display text
+    expect(mockSetFilterValue).toHaveBeenCalledWith(['PIPELINE_STATE_BUILDING']);
+    expect(mockClose).toHaveBeenCalled();
   });
 });

--- a/javascript/packages/core/components/table/components/filter/__tests__/datetime-filter.test.tsx
+++ b/javascript/packages/core/components/table/components/filter/__tests__/datetime-filter.test.tsx
@@ -16,15 +16,21 @@ describe('DatetimeFilter', () => {
   const mockSetFilterValue = vi.fn();
   const mockGetFilterValue = vi.fn();
 
+  const mockColumn = {
+    id: 'createdAt',
+    label: 'Created At',
+    type: 'date',
+  };
+
   const defaultProps: ColumnFilterProps = {
-    columnId: 'createdAt',
+    column: mockColumn,
     close: mockClose,
     getFilterValue: mockGetFilterValue,
     setFilterValue: mockSetFilterValue,
     preFilteredRows: [
-      { getValue: () => 1672531200 }, // 2023-01-01 epoch seconds
-      { getValue: () => 1680307200 }, // 2023-04-01 epoch seconds
-      { getValue: () => 1687824000 }, // 2023-06-27 epoch seconds
+      { getValue: () => 1672531200, record: { createdAt: 1672531200 } }, // 2023-01-01 epoch seconds
+      { getValue: () => 1680307200, record: { createdAt: 1680307200 } }, // 2023-04-01 epoch seconds
+      { getValue: () => 1687824000, record: { createdAt: 1687824000 } }, // 2023-06-27 epoch seconds
     ],
   };
 

--- a/javascript/packages/core/components/table/components/filter/categorical/categorical-filter.tsx
+++ b/javascript/packages/core/components/table/components/filter/categorical/categorical-filter.tsx
@@ -1,37 +1,37 @@
 import { CategoricalColumn } from 'baseui/data-table';
 
 import { safeStringify } from '#core/utils/string-utils';
+import { useFilterDisplayMapping } from './use-filter-display-mapping';
 
 import type { ColumnFilterProps } from '../types';
 
-export function CategoricalFilter({
-  columnId,
+export function CategoricalFilter<TData = unknown>({
+  column,
   close,
   getFilterValue,
   setFilterValue,
   preFilteredRows,
-}: ColumnFilterProps) {
+}: ColumnFilterProps<TData>) {
   // BaseUI requires these props but we don't use them in filter context
   const CategoricalFilterPanel = CategoricalColumn({
     title: '',
     mapDataToValue: () => '',
   }).renderFilter;
 
-  const uniqueValues = new Set<string>();
-  preFilteredRows.forEach((row) => {
-    const value = row.getValue(columnId);
-    if (value != null) {
-      uniqueValues.add(safeStringify(value));
-    }
+  const [filterValueToDisplayValue, displayValueToFilterValue] = useFilterDisplayMapping({
+    preFilteredRows,
+    column,
   });
-  const availableValues = Array.from(uniqueValues);
 
-  const currentSelection = (getFilterValue() as string[]) ?? [];
+  const availableDisplayValues = Object.keys(displayValueToFilterValue);
+  const currentDisplaySelection = ((getFilterValue() as unknown[]) ?? [])
+    .map((value) => filterValueToDisplayValue[safeStringify(value)])
+    .filter(Boolean);
 
-  // Sort values: selected items first, then alphabetical within each group
-  const sortedValues = availableValues.sort((a, b) => {
-    const isSelectedA = currentSelection.includes(a);
-    const isSelectedB = currentSelection.includes(b);
+  // Sort display values: selected items first, then alphabetical within each group
+  const sortedDisplayValues = availableDisplayValues.sort((a, b) => {
+    const isSelectedA = currentDisplaySelection.includes(a);
+    const isSelectedB = currentDisplaySelection.includes(b);
 
     if (isSelectedA === isSelectedB) {
       return a.localeCompare(b);
@@ -47,22 +47,26 @@ export function CategoricalFilter({
     exclude: boolean;
   }) => {
     // Apply exclude logic: invert selection if exclude is true
-    const filteredSelection = exclude
-      ? availableValues.filter((value) => !selection.has(value))
+    const selectedDisplayValues = exclude
+      ? availableDisplayValues.filter((displayValue) => !selection.has(displayValue))
       : Array.from(selection);
 
-    setFilterValue(filteredSelection.length > 0 ? filteredSelection : undefined);
+    const filterValues = selectedDisplayValues.map(
+      (displayValue) => displayValueToFilterValue[displayValue]
+    );
+
+    setFilterValue(filterValues.length > 0 ? filterValues : undefined);
     close();
   };
 
   return (
     <CategoricalFilterPanel
-      data={sortedValues}
+      data={sortedDisplayValues}
       setFilter={handleFilterChange}
       close={close}
       filterParams={{
         description: '',
-        selection: new Set(currentSelection),
+        selection: new Set(currentDisplaySelection),
         exclude: false,
       }}
     />

--- a/javascript/packages/core/components/table/components/filter/categorical/use-filter-display-mapping.ts
+++ b/javascript/packages/core/components/table/components/filter/categorical/use-filter-display-mapping.ts
@@ -1,0 +1,40 @@
+import { useMemo } from 'react';
+
+import { useCellToString } from '#core/components/cell/use-cell-to-string';
+import { safeStringify } from '#core/utils/string-utils';
+
+import type { FilterableRow } from '#core/components/table/components/filter/types';
+import type { ColumnConfig } from '#core/components/table/types/column-types';
+
+export function useFilterDisplayMapping<TData>({
+  preFilteredRows,
+  column,
+}: {
+  preFilteredRows: FilterableRow<TData>[];
+  column: ColumnConfig<TData>;
+}) {
+  const cellToString = useCellToString();
+
+  return useMemo(() => {
+    const displayToFilter: Record<string, unknown> = {};
+    const filterToDisplay: Record<string, string> = {};
+
+    preFilteredRows.forEach((row) => {
+      const rawValue = row.getValue(column.id);
+      if (rawValue == null) return;
+
+      const displayValue = cellToString({ value: rawValue, record: row.record as object, column });
+
+      // Preserve empty strings as valid filter options when cellToString returns null/undefined
+      const finalDisplayValue = displayValue == null && rawValue === '' ? '' : displayValue;
+
+      if (finalDisplayValue == null || finalDisplayValue in displayToFilter) return;
+
+      const filterKey = safeStringify(rawValue);
+      displayToFilter[finalDisplayValue] = rawValue;
+      filterToDisplay[filterKey] = finalDisplayValue;
+    });
+
+    return [filterToDisplay, displayToFilter] as const;
+  }, [preFilteredRows, cellToString, column]);
+}

--- a/javascript/packages/core/components/table/components/filter/datetime/datetime-filter.tsx
+++ b/javascript/packages/core/components/table/components/filter/datetime/datetime-filter.tsx
@@ -6,7 +6,11 @@ import { convertStringParamsToDate } from './utils';
 
 import type { ColumnFilterProps } from '../types';
 
-export function DatetimeFilter({ close, getFilterValue, setFilterValue }: ColumnFilterProps) {
+export function DatetimeFilter<TData = unknown>({
+  close,
+  getFilterValue,
+  setFilterValue,
+}: ColumnFilterProps<TData>) {
   // BaseUI requires these props but we don't use them in filter context
   const DatetimeFilterPanel = DatetimeColumn({
     title: '',

--- a/javascript/packages/core/components/table/components/filter/types.ts
+++ b/javascript/packages/core/components/table/components/filter/types.ts
@@ -1,6 +1,15 @@
 import type { Row } from '@tanstack/react-table';
-import type { FilteringCapability } from '#core/components/table/types/column-types';
+import type { ColumnConfig, FilteringCapability } from '#core/components/table/types/column-types';
 import type { TableData } from '../../types/data-types';
+
+/**
+ * Represents a table row that can be filtered, providing both column value access
+ * and the original record data for display formatting.
+ */
+export type FilterableRow<TData = TableData> = {
+  getValue: (columnId: string) => unknown;
+  record: TData;
+};
 
 /**
  * Filter function type that matches TanStack Table's filterfn interface.
@@ -50,8 +59,8 @@ export enum FilterMode {
 /**
  * Column filter props for filter components.
  */
-export type ColumnFilterProps = {
-  columnId: string;
+export type ColumnFilterProps<TData = TableData> = {
+  column: ColumnConfig<TData>;
   close: () => void;
-  preFilteredRows: Array<{ getValue: (columnId: string) => unknown }>;
+  preFilteredRows: FilterableRow<TData>[];
 } & Omit<FilteringCapability, 'canFilter'>;

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-active-filter-tag-list/table-active-filter-tag.tsx
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-active-filter-tag-list/table-active-filter-tag.tsx
@@ -43,7 +43,7 @@ export function ActiveFilterTag<TData = unknown>(props: ActiveFilterTagProps<TDa
       placement={PLACEMENT.bottomLeft}
       content={({ close }) => (
         <FilterComponent
-          columnId={column.id}
+          column={column}
           close={close}
           getFilterValue={column.getFilterValue}
           setFilterValue={column.setFilterValue}

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-active-filter-tag-list/types.ts
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-active-filter-tag-list/types.ts
@@ -1,12 +1,13 @@
+import type { FilterableRow } from '#core/components/table/components/filter/types';
 import type { FilterableColumn } from '#core/components/table/components/table-action-bar/types';
 import type { TableData } from '#core/components/table/types/data-types';
 
 export type ActiveFilterTagListProps<TData extends TableData = TableData> = {
   filterableColumns: FilterableColumn<TData>[];
-  preFilteredRows: Array<{ getValue: (columnId: string) => unknown }>;
+  preFilteredRows: FilterableRow<TData>[];
 };
 
 export type ActiveFilterTagProps<TData extends TableData = TableData> = {
   column: FilterableColumn<TData>;
-  preFilteredRows: Array<{ getValue: (columnId: string) => unknown }>;
+  preFilteredRows: FilterableRow<TData>[];
 };

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-menu-content/table-filter-menu-content.tsx
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-menu-content/table-filter-menu-content.tsx
@@ -36,7 +36,7 @@ export function TableFilterMenuContent<T extends TableData = TableData>(
           <Icon name="arrowLeft" size={theme.sizing.scale650} />
         </Button>
         <FilterComponent
-          columnId={selectedColumn.id}
+          column={selectedColumn}
           close={onClose}
           getFilterValue={() => {
             const filter = columnFilters.find((f) => f.id === selectedColumn.id);
@@ -56,7 +56,7 @@ export function TableFilterMenuContent<T extends TableData = TableData>(
   }
 
   return (
-    <TableFilterOptionList
+    <TableFilterOptionList<T>
       filterableColumns={filterableColumns}
       setSelectedColumn={setSelectedColumn}
     />

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-menu-content/types.ts
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-menu-content/types.ts
@@ -1,3 +1,4 @@
+import type { FilterableRow } from '#core/components/table/components/filter/types';
 import type { FilterableColumn } from '#core/components/table/components/table-action-bar/types';
 import type { TableData } from '#core/components/table/types/data-types';
 import type { ColumnFilter } from '#core/components/table/types/table-types';
@@ -8,6 +9,6 @@ export interface TableFilterMenuContentProps<T extends TableData = TableData> {
   setSelectedColumn: (column: FilterableColumn<T> | undefined) => void;
   columnFilters: ColumnFilter[];
   setColumnFilters: (filters: ColumnFilter[]) => void;
-  preFilteredRows: Array<{ getValue: (columnId: string) => unknown }>;
+  preFilteredRows: FilterableRow<T>[];
   onClose: () => void;
 }

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/types.ts
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/types.ts
@@ -1,3 +1,4 @@
+import type { FilterableRow } from '#core/components/table/components/filter/types';
 import type { FilterableColumn } from '#core/components/table/components/table-action-bar/types';
 import type { TableData } from '#core/components/table/types/data-types';
 import type { ColumnFilter } from '#core/components/table/types/table-types';
@@ -6,5 +7,5 @@ export interface TableFilterMenuProps<T extends TableData = TableData> {
   filterableColumns: FilterableColumn<T>[];
   columnFilters: ColumnFilter[];
   setColumnFilters: (filters: ColumnFilter[]) => void;
-  preFilteredRows: Array<{ getValue: (columnId: string) => unknown }>;
+  preFilteredRows: FilterableRow<T>[];
 }

--- a/javascript/packages/core/components/table/components/table-action-bar/types.ts
+++ b/javascript/packages/core/components/table/components/table-action-bar/types.ts
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import type { FilterableRow } from '#core/components/table/components/filter/types';
 import type {
   ColumnConfig,
   ColumnRenderState,
@@ -13,7 +14,7 @@ export interface TableActionBarProps<T extends TableData = TableData> {
   columnFilters: ColumnFilter[];
   setColumnFilters: (filters: ColumnFilter[]) => void;
   columns: ColumnConfig<T>[];
-  preFilteredRows: Array<{ getValue: (columnId: string) => unknown }>;
+  preFilteredRows: FilterableRow<T>[];
   configuration: TableActionBarConfig;
   filterableColumns?: FilterableColumn<T>[];
 }
@@ -47,5 +48,9 @@ export interface TableActionBarConfig {
   trailing?: ReactNode;
 }
 
-export type FilterableColumn<TData extends TableData = TableData> = ColumnRenderState<TData> &
+export type FilterableColumn<TData extends TableData = TableData> = Omit<
+  ColumnConfig<TData>,
+  keyof ColumnRenderState<TData>
+> &
+  ColumnRenderState<TData> &
   Omit<FilteringCapability, 'canFilter'>;

--- a/javascript/packages/core/components/table/components/table-cell/table-cell.tsx
+++ b/javascript/packages/core/components/table/components/table-cell/table-cell.tsx
@@ -5,6 +5,7 @@ import { CellTooltipWrapper } from '#core/components/cell/components/tooltip/cel
 import { TooltipHOCProps } from '#core/components/cell/components/tooltip/types';
 import { useGetCellRenderer } from '#core/components/cell/use-get-cell-renderer';
 import { useInterpolationResolver } from '#core/interpolation/use-interpolation-resolver';
+import { resolveColumnForRow } from '../../utils/column-resolution-utils';
 import { getResponsiveColumnWidth } from './get-responsive-column-width';
 import { isFilterAlreadyApplied } from './utils';
 
@@ -14,7 +15,7 @@ export const TableCell = (props: TableCellProps) => {
   const [css, theme] = useStyletron();
   const { record, value, columnFilterValue, setColumnFilterValue } = props;
   const resolver = useInterpolationResolver();
-  const column = resolver(props.column, { row: record });
+  const column = resolver(resolveColumnForRow(props.column, record), { row: record });
 
   const getCellRenderer = useGetCellRenderer();
   const ColumnRenderer = getCellRenderer({ column, record, value });

--- a/javascript/packages/core/components/table/table.tsx
+++ b/javascript/packages/core/components/table/table.tsx
@@ -89,6 +89,7 @@ export function Table<T extends TableData = TableData>(inputProps: TableProps<T>
       if (!column) return undefined;
       return column.accessorFn(rowData);
     },
+    record: rowData as T,
   }));
 
   return (
@@ -102,7 +103,7 @@ export function Table<T extends TableData = TableData>(inputProps: TableProps<T>
           getIsSomeRowsSelected: () => table.getIsSomeRowsSelected(),
         }}
       >
-        <TableActionBar
+        <TableActionBar<T>
           globalFilter={table.getState().globalFilter as string}
           setGlobalFilter={table.setGlobalFilter}
           columnFilters={table.getState().columnFilters}

--- a/javascript/packages/core/components/table/types/column-types.ts
+++ b/javascript/packages/core/components/table/types/column-types.ts
@@ -9,7 +9,7 @@ declare module '@tanstack/react-table' {
   interface ColumnMeta<TData extends TableData, TValue> extends ColumnConfig<TData> {}
 }
 
-export type ColumnConfig<TData extends TableData = TableData> = Cell<TData> & {
+export type ColumnConfig<TData = TableData> = Cell<TData> & {
   /**
    * @description
    * Configures the filtering mode for the column. If using `FilterMode.SERVER`, ensure

--- a/javascript/packages/core/components/table/utils/transform-columns.ts
+++ b/javascript/packages/core/components/table/utils/transform-columns.ts
@@ -1,9 +1,8 @@
 import { CellType } from '#core/components/cell/constants';
 
 import type { Column } from '@tanstack/react-table';
-import type { ColumnConfig } from '#core/components/table/types/column-types';
+import type { ColumnConfig, ColumnRenderState } from '#core/components/table/types/column-types';
 import type {
-  ColumnRenderState,
   FilteringCapability,
   SortingCapability,
   VisibilityCapability,
@@ -12,16 +11,23 @@ import type { TableData } from '#core/components/table/types/data-types';
 
 /**
  * Create a list of columns that can be used when rendering #core/components/table/*
+ * Returns full ColumnConfig with centralized defaults applied
  */
 export function transformColumns<T extends TableData = TableData>(
   columns: Column<T, unknown>[]
-): Array<ColumnRenderState<T> & FilteringCapability & SortingCapability & VisibilityCapability> {
+): Array<
+  Omit<ColumnConfig<T>, keyof ColumnRenderState<T>> &
+    ColumnRenderState<T> &
+    FilteringCapability &
+    SortingCapability &
+    VisibilityCapability
+> {
   return columns.map((column) => {
     const columnConfig = column.columnDef.meta as ColumnConfig<T>;
     const label = columnConfig.label ?? column.id;
 
     return {
-      id: column.id,
+      ...columnConfig,
       label,
       type: columnConfig.type ?? CellType.TEXT,
 


### PR DESCRIPTION
Introduce row-aware column resolution in table cells, enabling column configuration to adapt based on individual row data. This unlocks support for typeMeta-based columns.

Integrate full column rendering support into table filter system by replacing raw value display with cellToString functionality. Previously, filters showed raw data values while cells showed formatted display text, creating inconsistent UX where users saw "PIPELINE_STATE_BUILDING" in filters but "Building" in cells.

Upgrade filter system architecture to use complete ColumnConfig instead of limited column metadata. This enables cellToString to properly render complex column types like state cells that require stateTextMap configuration.

Added record to prefilteredRows for usage in cellToString and consolidated FilterableRow type instead of hardcoded Array<{ getValue, record}>

| Before | After | 
|---|---|
|  <img width="1392" height="1104" alt="Screenshot 2025-09-08 at 15 39 17" src="https://github.com/user-attachments/assets/15e0d91b-a725-46e6-9b05-5d5bf5a0a370" /> | <img width="1392" height="1104" alt="Screenshot 2025-09-08 at 15 20 55" src="https://github.com/user-attachments/assets/cead3b75-ab95-4bd7-b560-a3f7c31f64c9" /> |

I also installed internally to verify the typeMeta.kind-based implementation.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
