### PR TITLE
Add table grouping support

### DIFF
--- a/javascript/packages/core/components/table/__tests__/table.test.tsx
+++ b/javascript/packages/core/components/table/__tests__/table.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 
@@ -1684,7 +1684,11 @@ describe('Table', () => {
       { id: 'department', label: 'Department' },
     ];
 
-    const TestActions = ({ row }: { row: TableRow<{ name: string }> }) => (
+    const TestActions = ({
+      row,
+    }: {
+      row: TableRow<{ id: string; name: string; department: string }>;
+    }) => (
       <div>
         <span>Actions for row {row.record.name}</span>
         <button>Edit row {row.id}</button>
@@ -1749,6 +1753,183 @@ describe('Table', () => {
           return element?.textContent === 'Custom: Bob Smith';
         })
       ).toBeInTheDocument();
+    });
+  });
+
+  describe('grouping integration', () => {
+    const groupedTestData = [
+      { id: '1', name: 'Alice Johnson', department: 'Engineering', count: 5 },
+      { id: '2', name: 'Bob Smith', department: 'Engineering', count: 3 },
+      { id: '3', name: 'Carol Davis', department: 'Marketing', count: 8 },
+      { id: '4', name: 'David Wilson', department: 'Marketing', count: 2 },
+    ];
+
+    const groupedTestColumns = [
+      {
+        id: 'department',
+        label: 'Department',
+        enableGrouping: true,
+      },
+      { id: 'name', label: 'Name' },
+      {
+        id: 'count',
+        label: 'Count',
+        aggregationFn: 'sum' as const,
+        aggregatedCell: ({ value }: { value: unknown }) => <span>Total: {String(value)}</span>,
+      },
+    ];
+
+    const mockIcons = {
+      chevronRight: (props: { title: string }) => <div title={props.title}>Chevron Right</div>,
+      chevronDown: (props: { title: string }) => <div title={props.title}>Chevron Down</div>,
+    };
+
+    it('renders grouped rows with expand controls and aggregated cells when grouping is enabled', () => {
+      render(
+        <Table
+          data={groupedTestData}
+          columns={groupedTestColumns}
+          state={{ grouping: ['department'] }}
+          disablePagination={true}
+        />,
+        buildWrapper([
+          getBaseProviderWrapper(),
+          getInterpolationProviderWrapper(),
+          getRouterWrapper(),
+          getIconProviderWrapper({ icons: mockIcons }),
+        ])
+      );
+
+      expectTableRows({ dataRows: 2 });
+
+      // Should render department group headers with aggregated values
+      const engineeringRow = screen.getByRole('row', { name: /Engineering.*Total: 8/ });
+      const marketingRow = screen.getByRole('row', { name: /Marketing.*Total: 10/ });
+      expect(engineeringRow).toBeInTheDocument();
+      expect(marketingRow).toBeInTheDocument();
+
+      // Should have expand controls for each grouped row
+      expect(within(engineeringRow).getByTitle('Expand')).toBeInTheDocument();
+      expect(within(marketingRow).getByTitle('Expand')).toBeInTheDocument();
+    });
+
+    it('expands grouped rows to show individual records', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <Table
+          data={groupedTestData}
+          columns={groupedTestColumns}
+          state={{ grouping: ['department'] }}
+          disablePagination={true}
+        />,
+        buildWrapper([
+          getBaseProviderWrapper(),
+          getInterpolationProviderWrapper(),
+          getRouterWrapper(),
+          getIconProviderWrapper({ icons: mockIcons }),
+        ])
+      );
+
+      expectTableRows({ dataRows: 2 });
+      expect(screen.queryByRole('row', { name: /Alice Johnson/ })).not.toBeInTheDocument();
+
+      // Expand Engineering group
+      const engineeringRow = screen.getByRole('row', { name: /Engineering/ });
+      const engineeringExpandButton = within(engineeringRow).getByTitle('Expand');
+      await user.click(engineeringExpandButton);
+
+      await waitFor(() => {
+        expectTableRows({ dataRows: 4 });
+      });
+
+      expect(screen.getByRole('row', { name: /Alice Johnson/ })).toBeInTheDocument();
+      expect(screen.getByRole('row', { name: /Bob Smith/ })).toBeInTheDocument();
+
+      // Engineering row should now have collapse button
+      const updatedEngineeringRow = screen.getByRole('row', { name: /Engineering/ });
+      expect(within(updatedEngineeringRow).getByTitle('Collapse')).toBeInTheDocument();
+
+      // Marketing row should still have expand button
+      const marketingRow = screen.getByRole('row', { name: /Marketing/ });
+      expect(within(marketingRow).getByTitle('Expand')).toBeInTheDocument();
+    });
+
+    it('handles custom aggregation functions', () => {
+      const customColumns = [
+        {
+          id: 'department',
+          label: 'Department',
+          enableGrouping: true,
+        },
+        { id: 'name', label: 'Name' },
+        {
+          id: 'count',
+          label: 'Average Count',
+          aggregationFn: (columnId: string, leafRows: unknown[]) => {
+            const sum = leafRows.reduce<number>(
+              (acc: number, row: { getValue: (columnId: string) => number }) =>
+                acc + row.getValue(columnId),
+              0
+            );
+            const avg = sum / leafRows.length;
+            return Math.round(avg * 100) / 100; // Round to 2 decimal places
+          },
+          aggregatedCell: ({ value }: { value: unknown }) => <span>Avg: {String(value)}</span>,
+        },
+      ];
+
+      render(
+        <Table
+          data={groupedTestData}
+          columns={customColumns}
+          state={{ grouping: ['department'] }}
+          disablePagination={true}
+        />,
+        buildWrapper([
+          getBaseProviderWrapper(),
+          getInterpolationProviderWrapper(),
+          getRouterWrapper(),
+        ])
+      );
+
+      // Should render averaged values in grouped rows
+      expect(screen.getByRole('row', { name: /Engineering — Avg: 4/ })).toBeInTheDocument(); // Engineering: (5 + 3) / 2 = 4
+      expect(screen.getByRole('row', { name: /Marketing — Avg: 5/ })).toBeInTheDocument(); // Marketing: (8 + 2) / 2 = 5
+    });
+
+    it('falls back to regular cell when no aggregatedCell is provided', () => {
+      const fallbackColumns = [
+        {
+          id: 'department',
+          label: 'Department',
+          enableGrouping: true,
+        },
+        {
+          id: 'count',
+          label: 'Count',
+          aggregationFn: 'sum' as const,
+          // No aggregatedCell provided - should fallback to regular TableCell
+        },
+      ];
+
+      render(
+        <Table
+          data={groupedTestData}
+          columns={fallbackColumns}
+          state={{ grouping: ['department'] }}
+          disablePagination={true}
+        />,
+        buildWrapper([
+          getBaseProviderWrapper(),
+          getInterpolationProviderWrapper(),
+          getRouterWrapper(),
+        ])
+      );
+
+      // Should render aggregated values using fallback TableCell in grouped rows
+      expect(screen.getByRole('row', { name: /Engineering 8/ })).toBeInTheDocument(); // Engineering: 5 + 3
+      expect(screen.getByRole('row', { name: /Marketing 10/ })).toBeInTheDocument(); // Marketing: 8 + 2
     });
   });
 

--- a/javascript/packages/core/components/table/components/filter/get-column-filter.ts
+++ b/javascript/packages/core/components/table/components/filter/get-column-filter.ts
@@ -3,12 +3,15 @@ import { CategoricalFilter } from './categorical/categorical-filter';
 import { DatetimeFilter } from './datetime/datetime-filter';
 
 import type { ComponentType } from 'react';
+import type { TableData } from '#core/components/table/types/data-types';
 import type { ColumnFilterProps } from './types';
 
 /**
  * Returns the appropriate filter component for a given column type
  */
-export function getColumnFilter(columnType: string): ComponentType<ColumnFilterProps> {
+export function getColumnFilter<T extends TableData = TableData>(
+  columnType: string
+): ComponentType<ColumnFilterProps<T>> {
   switch (columnType as CellType) {
     case CellType.DATE:
       return DatetimeFilter;

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-active-filter-tag-list/table-active-filter-tag.tsx
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-active-filter-tag-list/table-active-filter-tag.tsx
@@ -36,7 +36,7 @@ export function ActiveFilterTag<TData = unknown>(props: ActiveFilterTagProps<TDa
     setShowTooltip(false);
   };
 
-  const FilterComponent = getColumnFilter(column.type);
+  const FilterComponent = getColumnFilter<TData>(column.type);
 
   return (
     <StatefulPopover

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-menu-content/table-filter-menu-content.tsx
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-menu-content/table-filter-menu-content.tsx
@@ -24,7 +24,7 @@ export function TableFilterMenuContent<T extends TableData = TableData>(
   const [css, theme] = useStyletron();
 
   if (selectedColumn) {
-    const FilterComponent = getColumnFilter(selectedColumn.type);
+    const FilterComponent = getColumnFilter<T>(selectedColumn.type);
 
     return (
       <div className={css({ backgroundColor: theme.colors.backgroundPrimary })}>

--- a/javascript/packages/core/components/table/components/table-body/__fixtures__/mock-table-body.ts
+++ b/javascript/packages/core/components/table/components/table-body/__fixtures__/mock-table-body.ts
@@ -23,6 +23,9 @@ export const getTanstackRowFixture = (overrides?: {
             },
           },
           getContext: vi.fn(() => ({})),
+          getIsGrouped: vi.fn(() => false),
+          getIsAggregated: vi.fn(() => false),
+          getIsPlaceholder: vi.fn(() => false),
         })) as unknown as Cell<TableData, unknown>[]
     ),
     getCanSelect: vi.fn(() => true),
@@ -30,6 +33,7 @@ export const getTanstackRowFixture = (overrides?: {
     toggleSelected: vi.fn(),
     getCanExpand: vi.fn(() => true),
     getIsExpanded: vi.fn(() => false),
+    getToggleExpandedHandler: vi.fn(() => vi.fn()),
     onToggleExpanded: vi.fn(),
   } as unknown as Row<TableData>;
 };

--- a/javascript/packages/core/components/table/components/table-body/__tests__/row-transformer.test.tsx
+++ b/javascript/packages/core/components/table/components/table-body/__tests__/row-transformer.test.tsx
@@ -1,3 +1,5 @@
+import { render, screen } from '@testing-library/react';
+
 import { getTanstackRowFixture } from '../__fixtures__/mock-table-body';
 import { transformRows } from '../row-transformer';
 
@@ -14,8 +16,8 @@ describe('transformRows', () => {
       {
         id: 'row-1',
         cells: [
-          { id: 'row-1-cell-0', content: 'John' },
-          { id: 'row-1-cell-1', content: '30' },
+          { id: 'row-1-cell-0', content: expect.any(Object) as React.ReactElement },
+          { id: 'row-1-cell-1', content: expect.any(Object) as React.ReactElement },
         ],
         canSelect: true,
         isSelected: false,
@@ -27,8 +29,8 @@ describe('transformRows', () => {
       {
         id: 'row-2',
         cells: [
-          { id: 'row-2-cell-0', content: 'Jane' },
-          { id: 'row-2-cell-1', content: '25' },
+          { id: 'row-2-cell-0', content: expect.any(Object) as React.ReactElement },
+          { id: 'row-2-cell-1', content: expect.any(Object) as React.ReactElement },
         ],
         canSelect: true,
         isSelected: false,
@@ -38,6 +40,19 @@ describe('transformRows', () => {
         onToggleExpanded: expect.any(Function) as () => void,
       },
     ]);
+
+    // Test that cell content renders the expected values
+    render(<div>{result[0].cells[0].content}</div>);
+    expect(screen.getByText('John')).toBeInTheDocument();
+
+    render(<div>{result[0].cells[1].content}</div>);
+    expect(screen.getByText('30')).toBeInTheDocument();
+
+    render(<div>{result[1].cells[0].content}</div>);
+    expect(screen.getByText('Jane')).toBeInTheDocument();
+
+    render(<div>{result[1].cells[1].content}</div>);
+    expect(screen.getByText('25')).toBeInTheDocument();
   });
 
   it('handles empty rows array', () => {

--- a/javascript/packages/core/components/table/components/table-body/row-transformer.ts
+++ b/javascript/packages/core/components/table/components/table-body/row-transformer.ts
@@ -1,4 +1,6 @@
-import { flexRender } from '@tanstack/react-table';
+import React from 'react';
+
+import { TableCellContent } from './table-cell-content';
 
 import type { Row } from '@tanstack/react-table';
 import type { TableData } from '#core/components/table/types/data-types';
@@ -9,9 +11,13 @@ export function transformRows<T extends TableData = TableData>(
 ): TableRow<T>[] {
   return tanstackRows.map((row) => ({
     id: row.id,
-    cells: row.getVisibleCells().map((cell) => ({
+    cells: row.getVisibleCells().map((cell, columnIndex) => ({
       id: cell.id,
-      content: flexRender(cell.column.columnDef.cell, cell.getContext()),
+      content: React.createElement(TableCellContent<T>, {
+        cell,
+        row,
+        columnIndex,
+      }),
     })),
     record: row.original,
     canSelect: row.getCanSelect(),

--- a/javascript/packages/core/components/table/components/table-body/table-body.tsx
+++ b/javascript/packages/core/components/table/components/table-body/table-body.tsx
@@ -7,7 +7,6 @@ import {
   StyledTableBody,
   StyledTableBodyCell,
 } from '#core/components/table/styled-components';
-import { TableExpandIcon } from '../table-expand-icon/table-expand-icon';
 import { getSelectionColumnCellStyles } from '../table-selection-column/styled-components';
 import { TableSelectionColumn } from '../table-selection-column/table-selection-column';
 import { withStickySides } from '../with-sticky-sides/with-sticky-sides';
@@ -56,22 +55,7 @@ export const TableBody = <T extends TableData = TableData>({
                 $columnNumber={cellIndex}
                 $enableRowSelection={enableRowSelection}
               >
-                {row.canExpand && cellIndex === 0 ? (
-                  <div
-                    className={css({
-                      display: 'flex',
-                      alignItems: 'center',
-                      cursor: 'pointer',
-                      gap: theme.sizing.scale100,
-                    })}
-                    onClick={row.onToggleExpanded}
-                  >
-                    <TableExpandIcon expanded={row.isExpanded} />
-                    {cell.content}
-                  </div>
-                ) : (
-                  cell.content
-                )}
+                {cell.content}
               </StyledTableBodyCell>
             ))}
 

--- a/javascript/packages/core/components/table/components/table-body/table-cell-content.tsx
+++ b/javascript/packages/core/components/table/components/table-body/table-cell-content.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { flexRender } from '@tanstack/react-table';
+import { useStyletron } from 'baseui';
+
+import { TableExpandIcon } from '../table-expand-icon/table-expand-icon';
+
+import type { Cell, Row } from '@tanstack/react-table';
+import type { TableData } from '../../types/data-types';
+
+export function TableCellContent<T extends TableData = TableData>({
+  cell,
+  row,
+  columnIndex,
+}: {
+  cell: Cell<T, unknown>;
+  row: Row<T>;
+  columnIndex: number;
+}): React.ReactNode {
+  const [css, theme] = useStyletron();
+
+  // Handle grouped cells or expandable rows - show expand/collapse controls with cell content
+  if (cell.getIsGrouped() || (row.getCanExpand() && columnIndex === 0)) {
+    return (
+      <div
+        className={css({
+          display: 'flex',
+          alignItems: 'center',
+          cursor: 'pointer',
+          gap: theme.sizing.scale600,
+        })}
+        onClick={row.getToggleExpandedHandler()}
+      >
+        <TableExpandIcon expanded={row.getIsExpanded()} />
+        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+      </div>
+    );
+  }
+
+  if (cell.getIsAggregated()) {
+    return flexRender(
+      cell.column.columnDef.aggregatedCell ?? cell.column.columnDef.cell,
+      cell.getContext()
+    );
+  }
+
+  if (cell.getIsPlaceholder()) {
+    return null;
+  }
+
+  return flexRender(cell.column.columnDef.cell, cell.getContext());
+}

--- a/javascript/packages/core/components/table/constants.ts
+++ b/javascript/packages/core/components/table/constants.ts
@@ -42,6 +42,7 @@ export const TABLE_STATE_DEFAULTS: TableState = {
     pageSize: DEFAULT_PAGE_SIZE,
   },
   sorting: [],
+  grouping: [],
   columnOrder: [],
   columnVisibility: {},
   rowSelection: {},

--- a/javascript/packages/core/components/table/hooks/use-column-transformer.tsx
+++ b/javascript/packages/core/components/table/hooks/use-column-transformer.tsx
@@ -26,7 +26,7 @@ import type { TableData } from '../types/data-types';
  * ```
  */
 export function useColumnTransformer<T extends TableData = TableData>(
-  columns: ColumnConfig[]
+  columns: ColumnConfig<T>[]
 ): {
   id: string;
   header?: string;
@@ -55,8 +55,26 @@ export function useColumnTransformer<T extends TableData = TableData>(
             setColumnFilterValue={props.column.setFilterValue}
           />
         ),
+        aggregatedCell: (props: CellContext<T, unknown>) =>
+          column.aggregatedCell ? (
+            <column.aggregatedCell
+              column={props.column.columnDef.meta as ColumnConfig<T>}
+              record={props.row.original as object}
+              value={props.getValue() as T}
+            />
+          ) : (
+            <TableCell
+              column={props.column.columnDef.meta as ColumnConfig}
+              record={props.row.original as object}
+              value={props.getValue()}
+              columnFilterValue={props.column.getFilterValue()}
+              setColumnFilterValue={props.column.setFilterValue}
+            />
+          ),
         filterFn: filterHook.buildTableFilterFn(),
         enableSorting: column.enableSorting ?? true,
+        enableGrouping: column.enableGrouping ?? false,
+        aggregationFn: column.aggregationFn,
         sortUndefined: 'last',
       };
     });

--- a/javascript/packages/core/components/table/plugins/state-persistence/use-local-storage-table-state.ts
+++ b/javascript/packages/core/components/table/plugins/state-persistence/use-local-storage-table-state.ts
@@ -8,6 +8,7 @@ import type {
   ColumnOrderState,
   ColumnVisibilityState,
   ControlledTableState,
+  GroupingState,
   InputTableState,
   PaginationState,
   RowSelectionState,
@@ -105,11 +106,14 @@ export function useLocalStorageTableState({
     initialState?.columnVisibility ?? TABLE_STATE_DEFAULTS.columnVisibility
   );
 
-  // pageIndex and rowSelection are not persisted (reset on reload)
+  // Not persisted on reload
   const [pageIndex, setPageIndex] = useState<number>(0);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [rowSelectionEnabled, setRowSelectionEnabled] = useState<boolean>(
     initialState?.rowSelectionEnabled ?? TABLE_STATE_DEFAULTS.rowSelectionEnabled
+  );
+  const [grouping, setGrouping] = useState<GroupingState>(
+    initialState?.grouping ?? TABLE_STATE_DEFAULTS.grouping
   );
 
   return {
@@ -137,5 +141,7 @@ export function useLocalStorageTableState({
     setRowSelection,
     rowSelectionEnabled,
     setRowSelectionEnabled,
+    grouping,
+    setGrouping,
   };
 }

--- a/javascript/packages/core/components/table/table.tsx
+++ b/javascript/packages/core/components/table/table.tsx
@@ -3,6 +3,7 @@ import {
   getCoreRowModel,
   getExpandedRowModel,
   getFilteredRowModel,
+  getGroupedRowModel,
   getPaginationRowModel,
   getSortedRowModel,
   useReactTable,
@@ -60,6 +61,12 @@ export function Table<T extends TableData = TableData>(inputProps: TableProps<T>
       ? { getSortedRowModel: getSortedRowModel() }
       : { enableSorting: false }),
     ...(!props.disablePagination ? { getPaginationRowModel: getPaginationRowModel() } : {}),
+    ...(initialState.grouping?.length || state.grouping?.length
+      ? {
+          getGroupedRowModel: getGroupedRowModel(),
+          getExpandedRowModel: getExpandedRowModel(),
+        }
+      : {}),
     ...(props.subRow
       ? {
           getExpandedRowModel: getExpandedRowModel(),
@@ -96,7 +103,7 @@ export function Table<T extends TableData = TableData>(inputProps: TableProps<T>
       if (!column) return undefined;
       return column.accessorFn(rowData);
     },
-    record: rowData as T,
+    record: rowData,
   }));
 
   return (

--- a/javascript/packages/core/components/table/types/column-types.ts
+++ b/javascript/packages/core/components/table/types/column-types.ts
@@ -1,6 +1,8 @@
 import '@tanstack/react-table'; //or vue, svelte, solid, qwik, etc.
 
-import type { Cell } from '#core/components/cell/types';
+import type { AggregationFnOption } from '@tanstack/react-table';
+import type { ComponentType } from 'react';
+import type { Cell, CellRendererProps } from '#core/components/cell/types';
 import type { FilterMode } from '../components/filter/types';
 import type { TableData } from './data-types';
 
@@ -23,6 +25,49 @@ export type ColumnConfig<TData = TableData> = Cell<TData> & {
    * @default true
    */
   enableSorting?: boolean;
+
+  /**
+   * @description
+   * Enables grouping functionality for this column. When true, this column can be used
+   * as a grouping column and will show expand/collapse controls when grouped.
+   *
+   * @default false
+   */
+  enableGrouping?: boolean;
+
+  /**
+   * @description
+   * Defines how values should be aggregated when this column is grouped.
+   * Can be a string identifier for built-in aggregation functions or a custom function.
+   *
+   * Built-in aggregation functions include: 'count', 'sum', 'min', 'max', 'extent', 'mean', 'median', 'unique', 'uniqueCount'
+   *
+   * @example
+   * ```tsx
+   * // Built-in aggregation
+   * { aggregationFn: 'count' }
+   *
+   * // Custom aggregation
+   * {
+   *   aggregationFn: (columnId, leafRows) => {
+   *     return leafRows.reduce((sum, row) => sum + row.getValue(columnId), 0);
+   *   }
+   * }
+   * ```
+   *
+   * @see https://tanstack.com/table/latest/docs/api/features/grouping#aggregation-functions
+   * @default undefined
+   */
+  aggregationFn?: AggregationFnOption<TData>;
+
+  /**
+   * @description
+   * Custom cell renderer to use when this column's cells are aggregated in a grouped row.
+   * If not provided, the regular Cell renderer will be used.
+   *
+   * @default undefined
+   */
+  aggregatedCell?: ComponentType<CellRendererProps<TData, ColumnConfig<TData>>>;
 };
 
 /**

--- a/javascript/packages/core/components/table/types/table-types.ts
+++ b/javascript/packages/core/components/table/types/table-types.ts
@@ -36,7 +36,7 @@ export interface TableRequiredUserProps<T extends TableData = TableData> {
  * Required props for `Table` and its sub-components to render. Users
  * may omit these props, in which case a default value will be provided.
  */
-export interface TableRequiredFunctionalityProps {
+export interface TableRequiredFunctionalityProps<T extends TableData = TableData> {
   /**
    * @description Configure landing card when the table has no data
    *
@@ -167,7 +167,7 @@ export interface TableRequiredFunctionalityProps {
    *
    * @default TableBody
    */
-  body: React.ComponentType<TableBodyProps<TableData>>;
+  body: React.ComponentType<TableBodyProps<T>>;
 
   /**
    * @description
@@ -177,10 +177,10 @@ export interface TableRequiredFunctionalityProps {
    *
    * @default props.data
    */
-  unFilteredData: Array<TableData>;
+  unFilteredData: Array<T>;
 }
 
-interface TableOptionalProps {
+interface TableOptionalProps<T extends TableData = TableData> {
   /**
    * @description
    * Component to render sub-rows for expandable row functionality.
@@ -189,7 +189,7 @@ interface TableOptionalProps {
    *
    * @default undefined
    */
-  subRow?: React.ComponentType<{ row: TableRow<TableData> }>;
+  subRow?: React.ComponentType<{ row: TableRow<T> }>;
 
   /**
    * @description
@@ -199,7 +199,7 @@ interface TableOptionalProps {
    *
    * @default undefined
    */
-  actions?: React.ComponentType<{ row: TableRow<TableData> }>;
+  actions?: React.ComponentType<{ row: TableRow<T> }>;
 }
 
 /**
@@ -208,16 +208,16 @@ interface TableOptionalProps {
  */
 export interface TableProps<T extends TableData = TableData>
   extends TableRequiredUserProps<T>,
-    Partial<TableRequiredFunctionalityProps>,
-    TableOptionalProps {}
+    Partial<TableRequiredFunctionalityProps<T>>,
+    TableOptionalProps<T> {}
 /**
  * Resolved props with all defaults applied.
  * Child components can rely on these props being defined.
  */
 export interface TablePropsResolved<T extends TableData = TableData>
   extends TableRequiredUserProps<T>,
-    TableRequiredFunctionalityProps,
-    TableOptionalProps {}
+    TableRequiredFunctionalityProps<T>,
+    TableOptionalProps<T> {}
 
 /**
  * Represents the possible view states of a table component.
@@ -251,6 +251,8 @@ export type ColumnVisibilityState = Record<string, boolean>;
 
 export type RowSelectionState = Record<string, boolean>;
 
+export type GroupingState = string[];
+
 /**
  * Table state containing aspects of table behavior.
  */
@@ -271,6 +273,8 @@ export type TableState = {
   rowSelection: RowSelectionState;
   /** Row selection mode enabled state */
   rowSelectionEnabled: boolean;
+  /** Grouping state - array of column IDs to group by */
+  grouping: GroupingState;
 };
 
 /**
@@ -295,6 +299,7 @@ export type ControlledTableState = TableState & {
     updater: RowSelectionState | ((old: RowSelectionState) => RowSelectionState)
   ) => void;
   setRowSelectionEnabled: (enabled: boolean) => void;
+  setGrouping: (updater: GroupingState | ((old: GroupingState) => GroupingState)) => void;
 };
 
 /**

--- a/javascript/packages/core/components/table/utils/compose-table-state.ts
+++ b/javascript/packages/core/components/table/utils/compose-table-state.ts
@@ -9,6 +9,7 @@ const STATE_NAME_TO_STATE_SETTER_NAME = {
   columnVisibility: 'setColumnVisibility',
   rowSelection: 'setRowSelection',
   rowSelectionEnabled: 'setRowSelectionEnabled',
+  grouping: 'setGrouping',
 } as const;
 
 /**


### PR DESCRIPTION
Replace individual cell rendering with component-based architecture to enable TanStack table grouping functionality.

Grouping is not persisted on reload, since there is not currently a use case for completely caller-controlled grouping state. The use cases within Michelangelo currently are for tables that are always grouped the same way.

Create TableCellContent component to centralize cell rendering logic that was previously scattered across different render paths. This architectural change enables proper handling of TanStack's grouped, aggregated, and placeholder cell states while maintaining the existing Cell component API for backward compatibility.

This centralization revealed a few locations within the Table component tree that were not being provided the TableData generic.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Installed into Uber environment and verified grouping worked for existing use cases

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
