### PR TITLE
Export more properties to TableRow API

### DIFF
--- a/javascript/packages/core/components/table/__tests__/table.test.tsx
+++ b/javascript/packages/core/components/table/__tests__/table.test.tsx
@@ -1691,6 +1691,8 @@ describe('Table', () => {
     }) => (
       <div>
         <span>Actions for row {row.record.name}</span>
+        <span>Cell count: {row.cells.length}</span>
+        <span>First column: {row.cells[0]?.column.label}</span>
         <button>Edit row {row.id}</button>
         <button>Delete row {row.id}</button>
       </div>
@@ -1704,6 +1706,8 @@ describe('Table', () => {
 
       expect(screen.getByText('Actions for row Alice Johnson')).toBeInTheDocument();
       expect(screen.getByText('Actions for row Bob Smith')).toBeInTheDocument();
+      expect(screen.getAllByText('Cell count: 2')).toHaveLength(2);
+      expect(screen.getAllByText('First column: Name')).toHaveLength(2);
       expect(screen.getByRole('button', { name: 'Edit row 0' })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Delete row 0' })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Edit row 1' })).toBeInTheDocument();

--- a/javascript/packages/core/components/table/components/table-body/__fixtures__/mock-table-body.ts
+++ b/javascript/packages/core/components/table/components/table-body/__fixtures__/mock-table-body.ts
@@ -13,6 +13,7 @@ export const getTanstackRowFixture = (overrides?: {
 
   return {
     id,
+    original: { id },
     getVisibleCells: vi.fn(
       () =>
         cellContents.map((content, index) => ({
@@ -20,12 +21,18 @@ export const getTanstackRowFixture = (overrides?: {
           column: {
             columnDef: {
               cell: content,
+              meta: {
+                id: `column-${index}`,
+                label: `Column ${index + 1}`,
+                type: 'string',
+              },
             },
           },
           getContext: vi.fn(() => ({})),
           getIsGrouped: vi.fn(() => false),
           getIsAggregated: vi.fn(() => false),
           getIsPlaceholder: vi.fn(() => false),
+          getValue: vi.fn(() => content),
         })) as unknown as Cell<TableData, unknown>[]
     ),
     getCanSelect: vi.fn(() => true),
@@ -34,6 +41,6 @@ export const getTanstackRowFixture = (overrides?: {
     getCanExpand: vi.fn(() => true),
     getIsExpanded: vi.fn(() => false),
     getToggleExpandedHandler: vi.fn(() => vi.fn()),
-    onToggleExpanded: vi.fn(),
+    toggleExpanded: vi.fn(),
   } as unknown as Row<TableData>;
 };

--- a/javascript/packages/core/components/table/components/table-body/__tests__/row-transformer.test.tsx
+++ b/javascript/packages/core/components/table/components/table-body/__tests__/row-transformer.test.tsx
@@ -16,9 +16,20 @@ describe('transformRows', () => {
       {
         id: 'row-1',
         cells: [
-          { id: 'row-1-cell-0', content: expect.any(Object) as React.ReactElement },
-          { id: 'row-1-cell-1', content: expect.any(Object) as React.ReactElement },
+          {
+            id: 'row-1-cell-0',
+            content: expect.any(Object) as React.ReactElement,
+            column: { id: 'column-0', label: 'Column 1', type: 'string' },
+            value: 'John',
+          },
+          {
+            id: 'row-1-cell-1',
+            content: expect.any(Object) as React.ReactElement,
+            column: { id: 'column-1', label: 'Column 2', type: 'string' },
+            value: '30',
+          },
         ],
+        record: { id: 'row-1' },
         canSelect: true,
         isSelected: false,
         onToggleSelection: expect.any(Function) as (selected: boolean) => void,
@@ -29,9 +40,20 @@ describe('transformRows', () => {
       {
         id: 'row-2',
         cells: [
-          { id: 'row-2-cell-0', content: expect.any(Object) as React.ReactElement },
-          { id: 'row-2-cell-1', content: expect.any(Object) as React.ReactElement },
+          {
+            id: 'row-2-cell-0',
+            content: expect.any(Object) as React.ReactElement,
+            column: { id: 'column-0', label: 'Column 1', type: 'string' },
+            value: 'Jane',
+          },
+          {
+            id: 'row-2-cell-1',
+            content: expect.any(Object) as React.ReactElement,
+            column: { id: 'column-1', label: 'Column 2', type: 'string' },
+            value: '25',
+          },
         ],
+        record: { id: 'row-2' },
         canSelect: true,
         isSelected: false,
         onToggleSelection: expect.any(Function) as (selected: boolean) => void,

--- a/javascript/packages/core/components/table/components/table-body/row-transformer.ts
+++ b/javascript/packages/core/components/table/components/table-body/row-transformer.ts
@@ -3,6 +3,7 @@ import React from 'react';
 import { TableCellContent } from './table-cell-content';
 
 import type { Row } from '@tanstack/react-table';
+import type { ColumnConfig } from '#core/components/table/types/column-types';
 import type { TableData } from '#core/components/table/types/data-types';
 import type { TableRow } from './types';
 
@@ -18,6 +19,8 @@ export function transformRows<T extends TableData = TableData>(
         row,
         columnIndex,
       }),
+      column: cell.column.columnDef.meta! as ColumnConfig<T>,
+      value: cell.getValue(),
     })),
     record: row.original,
     canSelect: row.getCanSelect(),

--- a/javascript/packages/core/components/table/components/table-body/types.ts
+++ b/javascript/packages/core/components/table/components/table-body/types.ts
@@ -1,11 +1,14 @@
 import type { ReactNode } from 'react';
 import type { SelectableCapability } from '#core/components/table/types/column-types';
+import type { ColumnConfig } from '#core/components/table/types/column-types';
 import type { TableData } from '#core/components/table/types/data-types';
 import type { WithStickySidesProps } from '../with-sticky-sides/types';
 
-export type TableCell<_T extends TableData = TableData> = {
+export type TableCell<T extends TableData = TableData> = {
   id: string;
   content: ReactNode;
+  column: ColumnConfig<T>;
+  value: unknown;
 };
 
 export type TableRow<T extends TableData = TableData> = {


### PR DESCRIPTION
TableRow API now includes raw cell value and column configuration. This specifically enables more sophisticated row actions, like showing a popup including the column name and unformatted data.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
