### PR TITLE
Fix table column width collapsing

### DIFF
--- a/javascript/packages/core/components/table/styled-components.ts
+++ b/javascript/packages/core/components/table/styled-components.ts
@@ -1,9 +1,14 @@
 import { styled, withStyle } from 'baseui';
 import {
+  StyledTable as BaseStyledTable,
   StyledTableBody as BaseStyledTableBody,
   StyledTableBodyCell as BaseStyledTableBodyCell,
   StyledTableBodyRow as BaseStyledTableBodyRow,
 } from 'baseui/table-semantic';
+
+export const StyledTable = withStyle(BaseStyledTable, {
+  width: 'max-content',
+});
 
 export const StyledTableBody = withStyle(BaseStyledTableBody, ({ $theme }) => ({
   backgroundColor: $theme.colors.tableHeadBackgroundColor,

--- a/javascript/packages/core/components/table/table.tsx
+++ b/javascript/packages/core/components/table/table.tsx
@@ -9,7 +9,6 @@ import {
   useReactTable,
 } from '@tanstack/react-table';
 import { useStyletron } from 'baseui';
-import { StyledTable } from 'baseui/table-semantic';
 
 import { useScrollRatio } from '#core/hooks/use-scroll';
 import { TableActionBar } from './components/table-action-bar/table-action-bar';
@@ -22,6 +21,7 @@ import { useColumnTransformer } from './hooks/use-column-transformer';
 import { usePageResetHandler } from './hooks/use-page-reset-handler';
 import { TableSelectionProvider } from './plugins/selection/table-selection-provider';
 import { useRowSelectionState } from './plugins/selection/use-row-selection-state';
+import { StyledTable } from './styled-components';
 import { applyDefaultProps } from './utils/apply-default-props';
 import { composeTableState } from './utils/compose-table-state';
 import { getTableViewState } from './utils/get-table-view-state';


### PR DESCRIPTION
Add max-content width to table to prevent columns with long/significant data from ellipsing when other narrow columns use white space.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Overloaded pipeline run table to force overflow
<img width="1840" height="1129" alt="Screenshot 2025-09-09 at 21 29 50" src="https://github.com/user-attachments/assets/e706fced-0e53-4d97-8a38-6604b7fedc53" />

Installed in Uber environment and verified

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
