### PR TITLE
Fix multi-cell column filter display

### DIFF
--- a/javascript/packages/core/components/table/__tests__/table.test.tsx
+++ b/javascript/packages/core/components/table/__tests__/table.test.tsx
@@ -629,6 +629,64 @@ describe('Table', () => {
           expect(screen.getAllByText('Dept: Engineering')).toHaveLength(2);
         });
       });
+
+      it('should use first item from multi-cell column for filter options', async () => {
+        const user = userEvent.setup();
+
+        const data = [
+          {
+            id: '1',
+            pipelineName: 'my-ml-pipeline',
+            revisionId: 'draft-12345',
+            description: 'ML training pipeline',
+          },
+          {
+            id: '2',
+            pipelineName: 'data-processing',
+            revisionId: 'rev-67890',
+            description: 'Data preprocessing pipeline',
+          },
+        ];
+
+        const multiCellColumn = {
+          id: 'pipeline-info',
+          label: 'Pipeline',
+          items: [
+            { id: 'pipelineName', accessor: 'pipelineName' },
+            { id: 'revisionId', accessor: 'revisionId' },
+            { id: 'description', accessor: 'description' },
+          ],
+        };
+
+        const columns = [multiCellColumn];
+
+        render(
+          <Table data={data} columns={columns} actionBarConfig={{ enableFilters: true }} />,
+          buildWrapper([
+            getBaseProviderWrapper(),
+            getInterpolationProviderWrapper(),
+            getRouterWrapper(),
+          ])
+        );
+
+        // Checking table content as baseline for filter options
+        expect(screen.getByText('my-ml-pipeline')).toBeInTheDocument();
+        expect(screen.getByText('data-processing')).toBeInTheDocument();
+        expect(screen.getByText('draft-12345')).toBeInTheDocument();
+        expect(screen.getByText('rev-67890')).toBeInTheDocument();
+        expect(screen.getByText('ML training pipeline')).toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: 'Add filter' }));
+        await user.click(screen.getByTestId('filter-option-Pipeline'));
+        await waitFor(() => {
+          expect(screen.getAllByText('my-ml-pipeline')).toHaveLength(2);
+          expect(screen.getAllByText('data-processing')).toHaveLength(2);
+        });
+
+        expect(screen.getAllByText('draft-12345')).toHaveLength(1);
+        expect(screen.getAllByText('rev-67890')).toHaveLength(1);
+        expect(screen.getAllByText('ML training pipeline')).toHaveLength(1);
+      });
     });
   });
 

--- a/javascript/packages/core/components/table/components/filter/categorical/__tests__/get-cell-value-for-column.test.ts
+++ b/javascript/packages/core/components/table/components/filter/categorical/__tests__/get-cell-value-for-column.test.ts
@@ -1,0 +1,219 @@
+import { getCellValueForColumn } from '#core/components/table/components/filter/categorical/get-cell-value-for-column';
+
+import type { Row } from '@tanstack/react-table';
+import type { FilterableRow } from '#core/components/table/components/filter/types';
+import type { ColumnConfig } from '#core/components/table/types/column-types';
+
+describe('getCellValueForColumn', () => {
+  const mockRecord = {
+    name: 'my-pipeline',
+    version: 'v1.0',
+    status: 'running',
+  };
+
+  const createMockRow = (getValue: (id: string) => unknown): Row<unknown> =>
+    ({
+      getValue,
+      original: mockRecord,
+    }) as Row<unknown>;
+
+  const createMockFilterableRow = (getValue: (id: string) => unknown): FilterableRow<unknown> => ({
+    getValue,
+    record: mockRecord,
+  });
+
+  describe('regular columns (no items)', () => {
+    it('should return raw value for regular column with TanStack Row', () => {
+      const column: ColumnConfig = {
+        id: 'name',
+        label: 'Name',
+      };
+
+      const row = createMockRow(() => 'test-value');
+      const result = getCellValueForColumn(column, row, 'name');
+
+      expect(result).toBe('test-value');
+    });
+
+    it('should return raw value for regular column with FilterableRow', () => {
+      const column: ColumnConfig = {
+        id: 'name',
+        label: 'Name',
+      };
+
+      const row = createMockFilterableRow(() => 'test-value');
+      const result = getCellValueForColumn(column, row, 'name');
+
+      expect(result).toBe('test-value');
+    });
+
+    it('should handle null/undefined values for regular columns', () => {
+      const column: ColumnConfig = {
+        id: 'name',
+        label: 'Name',
+      };
+
+      const row = createMockRow(() => null);
+      const result = getCellValueForColumn(column, row, 'name');
+
+      expect(result).toBe('');
+    });
+
+    it('should return objects unchanged for regular columns', () => {
+      const column: ColumnConfig = {
+        id: 'metadata',
+        label: 'Metadata',
+      };
+
+      const complexObject = { nested: { value: 'test' } };
+      const row = createMockRow(() => complexObject);
+      const result = getCellValueForColumn(column, row, 'metadata');
+
+      expect(result).toBe(complexObject);
+    });
+  });
+
+  describe('multi-cell columns (with items)', () => {
+    const multiCellColumn: ColumnConfig = {
+      id: 'pipeline-info',
+      label: 'Pipeline Info',
+      items: [
+        { id: 'name', accessor: 'name' },
+        { id: 'version', accessor: 'version' },
+        { id: 'status', accessor: 'status' },
+      ],
+    };
+
+    it('should extract first item from joined string with TanStack Row', () => {
+      const joinedValue = 'my-pipeline__JOIN__v1.0__JOIN__running';
+      const row = createMockRow(() => joinedValue);
+
+      const result = getCellValueForColumn(multiCellColumn, row, 'pipeline-info');
+
+      expect(result).toBe('my-pipeline');
+    });
+
+    it('should extract first item from joined string with FilterableRow', () => {
+      const joinedValue = 'data-processor__JOIN__v2.1__JOIN__stopped';
+      const row = createMockFilterableRow(() => joinedValue);
+
+      const result = getCellValueForColumn(multiCellColumn, row, 'pipeline-info');
+
+      expect(result).toBe('data-processor');
+    });
+
+    it('should handle empty first item in joined string', () => {
+      const joinedValue = '__JOIN__v1.0__JOIN__running';
+      const row = createMockRow(() => joinedValue);
+
+      const result = getCellValueForColumn(multiCellColumn, row, 'pipeline-info');
+
+      expect(result).toBe('');
+    });
+
+    it('should handle single item without join string', () => {
+      const row = createMockRow(() => 'single-value');
+
+      const result = getCellValueForColumn(multiCellColumn, row, 'pipeline-info');
+
+      expect(result).toBe('single-value');
+    });
+
+    it('should warn and fallback when multi-cell column returns non-string', () => {
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => null);
+      const objectValue = { name: 'my-pipeline', version: 'v1.0' };
+      const row = createMockRow(() => objectValue);
+
+      const result = getCellValueForColumn(multiCellColumn, row, 'pipeline-info');
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Expected string from normalizeColumnAccessor for multi-cell column pipeline-info, got:',
+        'object',
+        objectValue
+      );
+      expect(result).toBe('{"name":"my-pipeline","version":"v1.0"}'); // safeStringify converts object to JSON, no __JOIN__ to split
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should warn and fallback when multi-cell column returns number', () => {
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => null);
+      const row = createMockRow(() => 42);
+
+      const result = getCellValueForColumn(multiCellColumn, row, 'pipeline-info');
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Expected string from normalizeColumnAccessor for multi-cell column pipeline-info, got:',
+        'number',
+        42
+      );
+      expect(result).toBe('42'); // safeStringify converts to string, no __JOIN__ to split
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should handle null/undefined for multi-cell columns', () => {
+      const row = createMockRow(() => null);
+
+      const result = getCellValueForColumn(multiCellColumn, row, 'pipeline-info');
+
+      expect(result).toBe('');
+    });
+
+    it('should use effective column id when resolveColumnForRow returns different id', () => {
+      // This tests the resolveColumnForRow integration
+      const joinedValue = 'resolved-pipeline__JOIN__v3.0__JOIN__active';
+      const row = createMockRow((id) => {
+        if (id === 'pipeline-info') return joinedValue;
+        return undefined;
+      });
+
+      const result = getCellValueForColumn(multiCellColumn, row, 'pipeline-info');
+
+      expect(result).toBe('resolved-pipeline');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle empty string from getValue', () => {
+      const column: ColumnConfig = {
+        id: 'empty',
+        label: 'Empty',
+        items: [{ id: 'name' }],
+      };
+
+      const row = createMockRow(() => '');
+      const result = getCellValueForColumn(column, row, 'empty');
+
+      expect(result).toBe('');
+    });
+
+    it('should handle whitespace-only string for multi-cell', () => {
+      const column: ColumnConfig = {
+        id: 'whitespace',
+        label: 'Whitespace',
+        items: [{ id: 'name' }],
+      };
+
+      const row = createMockRow(() => '   ');
+      const result = getCellValueForColumn(column, row, 'whitespace');
+
+      expect(result).toBe('   '); // Should preserve whitespace
+    });
+
+    it('should handle complex joined values with special characters', () => {
+      const column: ColumnConfig = {
+        id: 'complex',
+        label: 'Complex',
+        items: [{ id: 'name' }, { id: 'description' }],
+      };
+
+      const joinedValue = 'pipeline-with-dashes__JOIN__Description with spaces and symbols!@#';
+      const row = createMockRow(() => joinedValue);
+
+      const result = getCellValueForColumn(column, row, 'complex');
+
+      expect(result).toBe('pipeline-with-dashes');
+    });
+  });
+});

--- a/javascript/packages/core/components/table/components/filter/categorical/get-cell-value-for-column.ts
+++ b/javascript/packages/core/components/table/components/filter/categorical/get-cell-value-for-column.ts
@@ -1,24 +1,40 @@
 import { MULTI_COLUMN_DATA_JOIN_STRING } from '#core/components/table/constants';
 import { ColumnConfig } from '#core/components/table/types/column-types';
 import { resolveColumnForRow } from '#core/components/table/utils/column-resolution-utils';
+import { safeStringify } from '#core/utils/string-utils';
 
 import type { Row } from '@tanstack/react-table';
 import type { TableData } from '#core/components/table/types/data-types';
+import type { FilterableRow } from '../types';
 
 /**
- * Extracts cell values for filtering from TanStack table rows.
+ * Extracts cell values for filtering from table rows (TanStack Row or FilterableRow).
+ * For multi-cell columns (columns with 'items'), returns only the first item's value.
  */
 export function getCellValueForColumn<T extends TableData = TableData>(
   column: ColumnConfig<T>,
-  row: Row<T>,
+  row: Row<T> | FilterableRow<T>,
   columnId: string
 ): unknown {
-  const effectiveColumn = resolveColumnForRow(column, row.original);
+  const record = 'original' in row ? row.original : row.record;
+  const effectiveColumn = resolveColumnForRow<T>(column, record);
   const effectiveId = effectiveColumn.id || columnId;
 
-  const rawValue = row.getValue<string | undefined>(effectiveId) ?? '';
+  const rawValue = row.getValue(effectiveId) ?? '';
 
-  return 'items' in effectiveColumn
-    ? (rawValue.split(MULTI_COLUMN_DATA_JOIN_STRING).at(0) ?? '')
-    : rawValue;
+  if ('items' in effectiveColumn) {
+    // For multi-cell columns, normalizeColumnAccessor should have created a joined string
+    if (typeof rawValue !== 'string') {
+      console.warn(
+        `Expected string from normalizeColumnAccessor for multi-cell column ${effectiveId}, got:`,
+        typeof rawValue,
+        rawValue
+      );
+      return safeStringify(rawValue).split(MULTI_COLUMN_DATA_JOIN_STRING).at(0) ?? '';
+    }
+
+    return rawValue.split(MULTI_COLUMN_DATA_JOIN_STRING).at(0) ?? '';
+  }
+
+  return rawValue;
 }

--- a/javascript/packages/core/components/table/components/filter/categorical/use-filter-display-mapping.ts
+++ b/javascript/packages/core/components/table/components/filter/categorical/use-filter-display-mapping.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 
 import { useCellToString } from '#core/components/cell/use-cell-to-string';
 import { safeStringify } from '#core/utils/string-utils';
+import { getCellValueForColumn } from './get-cell-value-for-column';
 
 import type { FilterableRow } from '#core/components/table/components/filter/types';
 import type { ColumnConfig } from '#core/components/table/types/column-types';
@@ -20,7 +21,7 @@ export function useFilterDisplayMapping<TData>({
     const filterToDisplay: Record<string, string> = {};
 
     preFilteredRows.forEach((row) => {
-      const rawValue = row.getValue(column.id);
+      const rawValue = getCellValueForColumn(column, row, column.id);
       if (rawValue == null) return;
 
       const displayValue = cellToString({ value: rawValue, record: row.record as object, column });

--- a/javascript/packages/core/components/table/hooks/use-column-transformer.tsx
+++ b/javascript/packages/core/components/table/hooks/use-column-transformer.tsx
@@ -30,7 +30,7 @@ export function useColumnTransformer<T extends TableData = TableData>(
 ): {
   id: string;
   header?: string;
-  accessorFn: AccessorFn<T>;
+  accessorFn: AccessorFn;
   meta: ColumnConfig<T>;
   cell: (props: CellContext<T, unknown>) => ReactNode;
   filterFn?: TableFilterFn<T, unknown[]>;
@@ -44,7 +44,7 @@ export function useColumnTransformer<T extends TableData = TableData>(
       return {
         id: column.id,
         meta: column,
-        accessorFn: normalizeColumnAccessor(column),
+        accessorFn: normalizeColumnAccessor<T>(column),
         header: column.label,
         cell: (props: CellContext<T, unknown>) => (
           <TableCell

--- a/javascript/packages/core/components/table/utils/__tests__/normalize-column-accessor.test.ts
+++ b/javascript/packages/core/components/table/utils/__tests__/normalize-column-accessor.test.ts
@@ -74,4 +74,152 @@ describe('normalizeColumnAccessor', () => {
 
     expect(result).toBeUndefined();
   });
+
+  it('should join values from multiple items with MULTI_COLUMN_DATA_JOIN_STRING', () => {
+    const column: ColumnConfig = {
+      id: 'pipeline-info',
+      label: 'Pipeline Info',
+      items: [
+        { id: 'name', accessor: 'name' },
+        { id: 'version', accessor: 'version' },
+        { id: 'status', accessor: 'status' },
+      ],
+    };
+
+    const accessorFn = normalizeColumnAccessor(column);
+    const result = accessorFn({
+      name: 'my-pipeline',
+      version: 'v1.0',
+      status: 'running',
+    });
+
+    expect(result).toBe('my-pipeline__JOIN__v1.0__JOIN__running');
+  });
+
+  it('should handle missing values in multi-cell items', () => {
+    const column: ColumnConfig = {
+      id: 'info',
+      label: 'Info',
+      items: [
+        { id: 'name', accessor: 'name' },
+        { id: 'missing', accessor: 'missing' },
+        { id: 'status', accessor: 'status' },
+      ],
+    };
+
+    const accessorFn = normalizeColumnAccessor(column);
+    const result = accessorFn({
+      name: 'test',
+      status: 'active',
+    });
+
+    expect(result).toBe('test__JOIN____JOIN__active');
+  });
+
+  it('should handle empty multi-cell items array', () => {
+    const column: ColumnConfig = {
+      id: 'empty',
+      label: 'Empty',
+      items: [],
+    };
+
+    const accessorFn = normalizeColumnAccessor(column);
+    const result = accessorFn({ name: 'test' });
+
+    expect(result).toBe('');
+  });
+
+  it('should use item accessor over item id when both are provided', () => {
+    const column: ColumnConfig = {
+      id: 'mixed',
+      label: 'Mixed',
+      items: [{ id: 'wrongPath', accessor: 'correctPath' }],
+    };
+
+    const accessorFn = normalizeColumnAccessor(column);
+    const result = accessorFn({
+      wrongPath: 'wrong',
+      correctPath: 'correct',
+    });
+
+    expect(result).toBe('correct');
+  });
+
+  it('should fall back to item id when accessor is not provided', () => {
+    const column: ColumnConfig = {
+      id: 'fallback',
+      label: 'Fallback',
+      items: [
+        { id: 'name' }, // no accessor
+      ],
+    };
+
+    const accessorFn = normalizeColumnAccessor(column);
+    const result = accessorFn({ name: 'test-value' });
+
+    expect(result).toBe('test-value');
+  });
+
+  it('should handle nested paths in multi-cell items', () => {
+    const column: ColumnConfig = {
+      id: 'nested',
+      label: 'Nested',
+      items: [
+        { id: 'userProfile', accessor: 'user.profile.name' },
+        { id: 'userEmail', accessor: 'user.email' },
+      ],
+    };
+
+    const accessorFn = normalizeColumnAccessor(column);
+    const result = accessorFn({
+      user: {
+        profile: { name: 'John Doe' },
+        email: 'john@example.com',
+      },
+    });
+
+    expect(result).toBe('John Doe__JOIN__john@example.com');
+  });
+
+  it('should handle mixed primitive and complex values in multi-cell items', () => {
+    const column: ColumnConfig = {
+      id: 'mixed-types',
+      label: 'Mixed Types',
+      items: [
+        { id: 'name', accessor: 'name' },
+        { id: 'count', accessor: 'count' },
+        { id: 'active', accessor: 'active' },
+      ],
+    };
+
+    const accessorFn = normalizeColumnAccessor(column);
+    const result = accessorFn({
+      name: 'test',
+      count: 42,
+      active: true,
+    });
+
+    expect(result).toBe('test__JOIN__42__JOIN__true');
+  });
+
+  it('should handle null and undefined values in multi-cell items', () => {
+    const column: ColumnConfig = {
+      id: 'nullish',
+      label: 'Nullish',
+      items: [
+        { id: 'name', accessor: 'name' },
+        { id: 'nullValue', accessor: 'nullValue' },
+        { id: 'undefinedValue', accessor: 'undefinedValue' },
+      ],
+    };
+
+    const accessorFn = normalizeColumnAccessor(column);
+    const result = accessorFn({
+      name: 'test',
+      nullValue: null,
+      undefinedValue: undefined,
+    });
+
+    expect(result).toBe('test__JOIN____JOIN__');
+  });
 });

--- a/javascript/packages/core/components/table/utils/normalize-column-accessor.ts
+++ b/javascript/packages/core/components/table/utils/normalize-column-accessor.ts
@@ -1,4 +1,6 @@
 import { getObjectValue } from '#core/utils/object-utils';
+import { MULTI_COLUMN_DATA_JOIN_STRING } from '../constants';
+import { resolveColumnForRow } from './column-resolution-utils';
 
 import type { AccessorFn } from '#core/types/common/studio-types';
 import type { ColumnConfig } from '../types/column-types';
@@ -7,17 +9,39 @@ import type { TableData } from '../types/data-types';
 /**
  * Creates a standardized accessor function for extracting data from table rows.
  *
+ * For multi-cell columns (columns with 'items'), the data required for each item
+ * is concatenated with MULTI_COLUMN_DATA_JOIN_STRING for searchability.
+ *
  * @example
  * ```tsx
  * const column = { id: 'name', accessor: 'user.profile.name' };
  * const accessorFn = normalizeColumnAccessor(column);
  * const value = accessorFn({ user: { profile: { name: 'John' } } }); // 'John'
+ *
+ * // For multi-cell columns:
+ * const multiColumn = {
+ *   id: 'info',
+ *   items: [
+ *     { id: 'name', accessor: 'name' },
+ *     { id: 'age', accessor: 'age' }
+ *   ]
+ * };
+ * const multiAccessor = normalizeColumnAccessor(multiColumn);
+ * const value = multiAccessor({ name: 'John', age: 30 }); // 'John__JOIN__30'
  * ```
  */
 export function normalizeColumnAccessor<T extends TableData = TableData>(
   column: ColumnConfig<T>
-): AccessorFn<T> {
-  return (row) => {
-    return getObjectValue<T>(row, column.accessor ?? column.id);
+): AccessorFn {
+  return (row: T) => {
+    const resolvedColumn = resolveColumnForRow<T>(column, row);
+
+    if ('items' in resolvedColumn) {
+      return resolvedColumn.items
+        .map((item) => getObjectValue(row, item.accessor ?? item.id))
+        .join(MULTI_COLUMN_DATA_JOIN_STRING);
+    }
+
+    return getObjectValue<T>(row, resolvedColumn.accessor ?? resolvedColumn.id);
   };
 }


### PR DESCRIPTION
Update filter value extraction to show first item values instead of raw cell data, no data, or joined internal data.

The table was missing multi-cell support in the column accessor logic that creates searchable joined values for filtering. This caused getCellValueForColumn to receive empty values instead of the expected joined strings, breaking the filter extraction logic.

Add multi-cell value joining to normalizeColumnAccessor and update getCellValueForColumn to handle both TanStack Row and FilterableRow types with runtime validation that warns when the accessor contract is violated.

Fix AccessorFn type signature that incorrectly suggested the accessor returns the row type instead of extracted values.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Installed into Uber environment and verified multi-cell columns

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
