### PR TITLE
Hide pagination for small tables

### DIFF
--- a/javascript/packages/core/components/table/__tests__/table.test.tsx
+++ b/javascript/packages/core/components/table/__tests__/table.test.tsx
@@ -1114,7 +1114,7 @@ describe('Table', () => {
       });
     });
 
-    it('shows pagination state for single page with custom pagination', () => {
+    it('hides pagination state for single page with custom pagination', () => {
       const singlePageData = buildLargeDataset(15);
 
       const CustomPagination = (props: TablePaginationProps) => (
@@ -1145,8 +1145,9 @@ describe('Table', () => {
         ])
       );
 
-      expect(screen.getByText('Page 1 of 1')).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled();
+      expect(screen.queryByText('Page 1 of 1')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Next' })).not.toBeInTheDocument();
+      expectTableRows({ dataRows: 15 });
     });
 
     it('hides pagination for empty data', () => {
@@ -1162,6 +1163,47 @@ describe('Table', () => {
       expect(screen.queryByText('Page 1 of')).not.toBeInTheDocument();
       expect(screen.queryByRole('button', { name: /next/i })).not.toBeInTheDocument();
       expect(screen.getByText('No data')).toBeInTheDocument();
+    });
+
+    it('hides pagination for less data than minimum page size', () => {
+      render(
+        <Table
+          data={buildTableData(5, 3)}
+          columns={testColumns}
+          pageSizes={[{ id: 10, label: '10' }]}
+        />,
+        buildWrapper([
+          getBaseProviderWrapper(),
+          getInterpolationProviderWrapper(),
+          getRouterWrapper(),
+        ])
+      );
+
+      expect(screen.queryByText('Page 1 of')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /next/i })).not.toBeInTheDocument();
+      expectTableRows({ dataRows: 5 });
+    });
+
+    it('hides pagination for equal data to minimum page size', () => {
+      render(
+        <Table
+          data={buildTableData(5, 3)}
+          columns={testColumns}
+          pageSizes={[
+            { id: 10, label: '10' },
+            { id: 5, label: '5' },
+          ]}
+        />,
+        buildWrapper([
+          getBaseProviderWrapper(),
+          getInterpolationProviderWrapper(),
+          getRouterWrapper(),
+        ])
+      );
+
+      expect(screen.queryByText('Page 1 of')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /next/i })).not.toBeInTheDocument();
+      expectTableRows({ dataRows: 5 });
     });
 
     it('resets to first page when current page becomes invalid due to filtering', async () => {

--- a/javascript/packages/core/components/table/table.tsx
+++ b/javascript/packages/core/components/table/table.tsx
@@ -178,16 +178,19 @@ export function Table<T extends TableData = TableData>(inputProps: TableProps<T>
             )}
           </StyledTable>
         </div>
-        {!props.disablePagination && viewState === 'ready' && (
-          <props.pagination
-            gotoPage={table.setPageIndex}
-            pageCount={table.getPageCount()}
-            setPageSize={table.setPageSize}
-            state={table.getState().pagination}
-            pageSizes={props.pageSizes}
-            fetchPlugin={props.fetchPlugin}
-          />
-        )}
+        {!props.disablePagination &&
+          viewState === 'ready' &&
+          table.getPreFilteredRowModel().rows.length >
+            Math.min(...props.pageSizes.map((size) => size.id)) && (
+            <props.pagination
+              gotoPage={table.setPageIndex}
+              pageCount={table.getPageCount()}
+              setPageSize={table.setPageSize}
+              state={table.getState().pagination}
+              pageSizes={props.pageSizes}
+              fetchPlugin={props.fetchPlugin}
+            />
+          )}
       </TableSelectionProvider>
     </div>
   );


### PR DESCRIPTION
Tables with fewer prefiltered rows than minimum configured page size will no longer display the pagination component.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Modified page sizes for pipeline/runs tables
**Min page size 10**
<img width="920" height="565" alt="Screenshot 2025-09-11 at 09 07 20" src="https://github.com/user-attachments/assets/661e60f0-fa3e-487d-abcd-741ac034a5bb" />

**Min page size 1**
<img width="920" height="565" alt="Screenshot 2025-09-11 at 09 07 20" src="https://github.com/user-attachments/assets/661e60f0-fa3e-487d-abcd-741ac034a5bb" />

<img width="920" height="565" alt="Screenshot 2025-09-11 at 09 25 04" src="https://github.com/user-attachments/assets/0f2288c6-501c-4ccb-82f0-801009c60f68" />



<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
