### PR TITLE
Fix global filtering for complex data types in table

### DIFF
--- a/javascript/packages/core/components/table/__tests__/table.test.tsx
+++ b/javascript/packages/core/components/table/__tests__/table.test.tsx
@@ -232,15 +232,41 @@ describe('Table', () => {
 
   describe('search functionality integration', () => {
     const testData = [
-      { id: '1', name: 'Apple Product', category: 'Electronics' },
-      { id: '2', name: 'Banana Split', category: 'Food' },
-      { id: '3', name: 'Orange Juice', category: 'Beverage' },
-      { id: '4', name: 'Apple Pie', category: 'Food' },
+      {
+        id: '1',
+        name: 'Apple Product',
+        category: 'Electronics',
+        metadata: { brand: 'Apple', warranty: '2-years' },
+        tags: ['smartphone', 'tech'],
+      },
+      {
+        id: '2',
+        name: 'Banana Split',
+        category: 'Food',
+        metadata: { calories: '300', allergens: 'dairy' },
+        tags: ['dessert', 'ice-cream'],
+      },
+      {
+        id: '3',
+        name: 'Orange Juice',
+        category: 'Beverage',
+        metadata: { vitamin: 'C', organic: 'true' },
+        tags: ['fresh', 'citrus'],
+      },
+      {
+        id: '4',
+        name: 'Apple Pie',
+        category: 'Food',
+        metadata: { calories: '450', allergens: 'gluten' },
+        tags: ['dessert', 'baked'],
+      },
     ];
 
     const testColumns = [
       { id: 'name', label: 'Name' },
       { id: 'category', label: 'Category' },
+      { id: 'metadata', label: 'Metadata' },
+      { id: 'tags', label: 'Tags' },
     ];
 
     beforeEach(() => {
@@ -276,7 +302,7 @@ describe('Table', () => {
         await user.type(screen.getByRole('searchbox'), 'Apple');
         vi.runAllTimers();
         await waitFor(() => {
-          expect(screen.getAllByRole('row')).toHaveLength(3); // 1 header + 2 rows
+          expectTableRows({ dataRows: 2 });
         });
 
         expect(screen.queryByRole('cell', { name: 'Banana Split' })).not.toBeInTheDocument();
@@ -362,6 +388,40 @@ describe('Table', () => {
         await waitFor(() => {
           expect(screen.getAllByRole('row')).toHaveLength(5); // 1 header + 4 rows
         });
+      });
+
+      it('searches within map values in complex data', async () => {
+        const user = userEvent.setup({
+          advanceTimers: vi.advanceTimersByTime.bind(vi) as (ms: number) => void,
+        });
+
+        await user.type(screen.getByRole('searchbox'), 'calories');
+        vi.runAllTimers();
+        await waitFor(() => {
+          expectTableRows({ dataRows: 2 });
+        });
+
+        expect(screen.getByRole('cell', { name: 'Banana Split' })).toBeInTheDocument();
+        expect(screen.getByRole('cell', { name: 'Apple Pie' })).toBeInTheDocument();
+        expect(screen.queryByRole('cell', { name: 'Apple Product' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('cell', { name: 'Orange Juice' })).not.toBeInTheDocument();
+      });
+
+      it('searches within array values in complex data', async () => {
+        const user = userEvent.setup({
+          advanceTimers: vi.advanceTimersByTime.bind(vi) as (ms: number) => void,
+        });
+
+        await user.type(screen.getByRole('searchbox'), 'dessert');
+        vi.runAllTimers();
+        await waitFor(() => {
+          expectTableRows({ dataRows: 2 });
+        });
+
+        expect(screen.getByRole('cell', { name: 'Banana Split' })).toBeInTheDocument();
+        expect(screen.getByRole('cell', { name: 'Apple Pie' })).toBeInTheDocument();
+        expect(screen.queryByRole('cell', { name: 'Apple Product' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('cell', { name: 'Orange Juice' })).not.toBeInTheDocument();
       });
     });
 

--- a/javascript/packages/core/components/table/table.tsx
+++ b/javascript/packages/core/components/table/table.tsx
@@ -25,6 +25,7 @@ import { StyledTable } from './styled-components';
 import { applyDefaultProps } from './utils/apply-default-props';
 import { composeTableState } from './utils/compose-table-state';
 import { getTableViewState } from './utils/get-table-view-state';
+import { globalFilterFn } from './utils/global-filter-fn';
 import { transformColumns } from './utils/transform-columns';
 
 import type { TableData } from './types/data-types';
@@ -74,7 +75,11 @@ export function Table<T extends TableData = TableData>(inputProps: TableProps<T>
         }
       : {}),
     enableRowSelection,
-    globalFilterFn: 'includesString',
+    // Tanstack/table filters searchable columns for global filter based on the
+    // typeof accessed data. In combination with our custom globalFilterFn, we
+    // can safely assume all columns are searchable.
+    getColumnCanGlobalFilter: () => true,
+    globalFilterFn: globalFilterFn<T>,
     autoResetPageIndex: false,
   });
 

--- a/javascript/packages/core/components/table/utils/global-filter-fn.ts
+++ b/javascript/packages/core/components/table/utils/global-filter-fn.ts
@@ -1,0 +1,29 @@
+import { safeStringify } from '#core/utils/string-utils';
+
+import type { Row } from '@tanstack/react-table';
+import type { TableData } from '../types/data-types';
+
+/**
+ * Global filter that performs "includes string" matching on any data type by converting
+ * complex structures (objects, arrays) to JSON strings. This enables searching within
+ * nested object properties and array elements that would otherwise be unsearchable.
+ *
+ * @example
+ * // Searches within: { metadata: { type: 'urgent' } } or ['frontend', 'react']
+ * globalFilterFn(row, 'metadata', 'urgent') // finds 'urgent' in JSON string
+ */
+export function globalFilterFn<T extends TableData = TableData>(
+  row: Row<T>,
+  columnId: string,
+  filterValue: string
+): boolean {
+  if (!row.getValue(columnId)) return false;
+
+  const result = safeStringify(row.getValue(columnId))
+    .toLowerCase()
+    .includes(filterValue.toLowerCase());
+
+  return result;
+}
+
+globalFilterFn.autoRemove = (val: unknown) => val === undefined || val === null;


### PR DESCRIPTION
Replace TanStack's 'includesString' with custom globalFilterFn that handles objects and arrays. Force all columns to be globally filterable to override TanStack's automatic column filtering disablement.

TanStack Table automatically disables global filtering for columns that return non-primitive values (objects, arrays), even when the data can be meaningfully searched. This blocked users from searching within metadata objects and tag arrays that contain searchable content.

The new approach uses safeStringify to convert any data type to JSON strings, enabling "includes string" matching within nested object properties and array elements. Combined with getColumnCanGlobalFilter override, this ensures all columns remain searchable regardless of their data complexity.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests
Integrated into Uber environment and verified with complex table data


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
