### PR TITLE
Separate column tooltip from core table cell

### DIFF
--- a/javascript/packages/core/components/table/components/table-cell/column-tooltip-hoc.tsx
+++ b/javascript/packages/core/components/table/components/table-cell/column-tooltip-hoc.tsx
@@ -1,0 +1,60 @@
+import { CellTooltipContentRenderer } from '#core/components/cell/components/tooltip/cell-tooltip-content-renderer';
+import { CellTooltipWrapper } from '#core/components/cell/components/tooltip/cell-tooltip-wrapper';
+import { isFilterAlreadyApplied } from './utils';
+
+import type { TooltipHOCProps } from '#core/components/cell/components/tooltip/types';
+import type { CellRenderer } from '#core/components/cell/types';
+import type { TableCellProps } from './types';
+
+/**
+ * Creates a tooltip HOC that provides filter actions to custom tooltip content
+ *
+ * @remarks
+ * **Filter behavior:**
+ * - If `action="filter"` and the current value already matches `columnFilterValue`, tooltip is hidden
+ * - Filter action handler is automatically wired when `action="filter"` and
+ *  `setColumnFilterValue` is provided
+ *
+ * @example
+ * ```typescript
+ * // Simple filter tooltip
+ * const column = {
+ *   id: 'status',
+ *   label: 'Status',
+ *   tooltip: {
+ *     content: 'Click to filter by this status',
+ *     action: 'filter'
+ *   }
+ * };
+ * ```
+ */
+export function columnTooltipHOC<T = unknown>(
+  Component: CellRenderer<T>,
+  columnFilterValue?: TableCellProps['columnFilterValue'],
+  setColumnFilterValue?: TableCellProps['setColumnFilterValue']
+): CellRenderer<T> {
+  return function ColumnTooltipHOC(props: TooltipHOCProps<T>) {
+    const { column, value } = props;
+    const { action } = column.tooltip;
+
+    // If filter is already applied, render without tooltip
+    if (action === 'filter' && isFilterAlreadyApplied(columnFilterValue, value)) {
+      return <Component {...props} />;
+    }
+
+    const actionHandler = () => {
+      if (action === 'filter' && setColumnFilterValue) {
+        setColumnFilterValue([value]);
+      }
+    };
+
+    return (
+      <CellTooltipWrapper
+        actionHandler={actionHandler}
+        content={<CellTooltipContentRenderer {...props} />}
+      >
+        <Component {...props} />
+      </CellTooltipWrapper>
+    );
+  };
+}

--- a/javascript/packages/core/components/table/components/table-cell/table-cell.tsx
+++ b/javascript/packages/core/components/table/components/table-cell/table-cell.tsx
@@ -1,13 +1,10 @@
 import { useStyletron } from 'baseui';
 
-import { CellTooltipContentRenderer } from '#core/components/cell/components/tooltip/cell-tooltip-content-renderer';
-import { CellTooltipWrapper } from '#core/components/cell/components/tooltip/cell-tooltip-wrapper';
-import { TooltipHOCProps } from '#core/components/cell/components/tooltip/types';
 import { useGetCellRenderer } from '#core/components/cell/use-get-cell-renderer';
 import { useInterpolationResolver } from '#core/interpolation/use-interpolation-resolver';
 import { resolveColumnForRow } from '../../utils/column-resolution-utils';
+import { columnTooltipHOC } from './column-tooltip-hoc';
 import { getResponsiveColumnWidth } from './get-responsive-column-width';
-import { isFilterAlreadyApplied } from './utils';
 
 import type { TableCellProps } from './types';
 
@@ -19,41 +16,13 @@ export const TableCell = (props: TableCellProps) => {
 
   const getCellRenderer = useGetCellRenderer();
   const ColumnRenderer = getCellRenderer({ column, record, value });
+  const Component = column.tooltip
+    ? columnTooltipHOC(ColumnRenderer, columnFilterValue, setColumnFilterValue)
+    : ColumnRenderer;
 
-  const renderedCell = (
+  return (
     <div className={css({ ...getResponsiveColumnWidth(theme), overflow: 'hidden' })}>
-      <ColumnRenderer column={column} record={record} value={value} CellComponent={TableCell} />
+      <Component column={column} record={record} value={value} CellComponent={TableCell} />
     </div>
   );
-
-  if (column.tooltip) {
-    const { action } = column.tooltip;
-
-    if (action === 'filter' && isFilterAlreadyApplied(columnFilterValue, value)) {
-      return renderedCell;
-    }
-
-    const actionHandler = () => {
-      if (action === 'filter' && setColumnFilterValue) {
-        setColumnFilterValue([value]);
-      }
-    };
-
-    return (
-      <CellTooltipWrapper
-        actionHandler={actionHandler}
-        content={
-          <CellTooltipContentRenderer
-            column={column as TooltipHOCProps<unknown>['column']}
-            record={record}
-            value={value}
-          />
-        }
-      >
-        {renderedCell}
-      </CellTooltipWrapper>
-    );
-  }
-
-  return renderedCell;
 };


### PR DESCRIPTION
In preparation for adding more functionality to the column tooltip HOC, separate it from TableCell. No changed functionality.

**What type of PR is this? (check all applicable)**
- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
https://github.com/user-attachments/assets/97403fba-69ed-42b9-9978-51328b476878


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
