### PR TITLE
Fix aggressive table cell truncation

### DIFF
--- a/javascript/packages/core/components/table/components/table-cell/table-cell.tsx
+++ b/javascript/packages/core/components/table/components/table-cell/table-cell.tsx
@@ -23,7 +23,7 @@ export const TableCell = <T = unknown,>(props: TableCellProps<T>) => {
     : ColumnRenderer;
 
   return (
-    <div className={css({ ...getResponsiveColumnWidth(theme), overflow: 'hidden', ...style })}>
+    <div className={css({ ...getResponsiveColumnWidth(theme), ...style })}>
       <Component column={column} record={record} value={value} CellComponent={TableCell} />
     </div>
   );

--- a/javascript/packages/core/components/table/styled-components.ts
+++ b/javascript/packages/core/components/table/styled-components.ts
@@ -6,9 +6,7 @@ import {
   StyledTableBodyRow as BaseStyledTableBodyRow,
 } from 'baseui/table-semantic';
 
-export const StyledTable = withStyle(BaseStyledTable, {
-  width: 'max-content',
-});
+export const StyledTable = BaseStyledTable;
 
 export const StyledTableBody = withStyle(BaseStyledTableBody, ({ $theme }) => ({
   backgroundColor: $theme.colors.tableHeadBackgroundColor,


### PR DESCRIPTION
Tables now more opportunistically utilize cell max-width as opposed to truncating content.

Removed the width: 'max-content' and overflow: 'hidden', which prevents dense, standard tables from collapsing important context (like name). While also being less opinionated for tables with custom bodies. The max-content was causing custom bodies to overly utilize horizontal scrolling when collapsing would have been better.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Installed internally and tested on Uber tables

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
