### PR TITLE
Fix ColumnConfig tooltip type

### DIFF
--- a/javascript/packages/core/components/table/types/column-types.ts
+++ b/javascript/packages/core/components/table/types/column-types.ts
@@ -1,8 +1,11 @@
 import '@tanstack/react-table'; //or vue, svelte, solid, qwik, etc.
 
+import { TableRow } from '../components/table-body/types';
+
 import type { AggregationFnOption, SortingFnOption } from '@tanstack/react-table';
-import type { ComponentType } from 'react';
-import type { Cell, CellRendererProps } from '#core/components/cell/types';
+import type { ComponentType, ReactNode } from 'react';
+import type { Cell, CellRendererProps, CellTooltip } from '#core/components/cell/types';
+import type { DistributiveOmit } from '#core/types/utility-types';
 import type { FilterMode } from '../components/filter/types';
 import type { TableData } from './data-types';
 
@@ -11,7 +14,7 @@ declare module '@tanstack/react-table' {
   interface ColumnMeta<TData extends TableData, TValue> extends ColumnConfig<TData> {}
 }
 
-export type ColumnConfig<TData = TableData> = Cell<TData> & {
+export type ColumnConfig<TData = TableData> = DistributiveOmit<Cell<TData>, 'tooltip'> & {
   /**
    * @description
    * Configures the filtering mode for the column. If using `FilterMode.SERVER`, ensure
@@ -76,6 +79,14 @@ export type ColumnConfig<TData = TableData> = Cell<TData> & {
    * @see https://tanstack.com/table/latest/docs/api/features/sorting#sorting-functions
    */
   sortingFn?: SortingFnOption<TData>;
+
+  /**
+   * @description
+   * Custom tooltip to be displayed when this column's cells are hovered.
+   *
+   * @default undefined
+   */
+  tooltip?: ColumnTooltip<TData>;
 };
 
 /**
@@ -143,4 +154,19 @@ export type SelectableCapability = {
   canSelect: boolean;
   isSelected: boolean;
   onToggleSelection: (selected: boolean) => void;
+};
+
+export type ColumnTooltip<TData extends TableData = TableData> = Omit<CellTooltip, 'content'> & {
+  /**
+   * @description
+   * The content to be displayed in the tooltip.
+   *
+   * @remarks
+   * If a function is provided, it will be called with the cell renderer props and the row data.
+   */
+  content:
+    | string
+    | ((
+        params: CellRendererProps<TData, ColumnConfig<TData>> & { row: TableRow<TData> }
+      ) => ReactNode);
 };

--- a/javascript/packages/core/types/utility-types.ts
+++ b/javascript/packages/core/types/utility-types.ts
@@ -8,3 +8,30 @@
 export type DeepPartial<T> = {
   [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
 };
+
+/**
+ * Distributive version of TypeScript's built-in `Omit` utility type.
+ *
+ * @description
+ * Unlike the standard `Omit<T, K>`, this type properly handles union types by
+ * distributing the omit operation across each member of the union. This is
+ * essential when working with discriminated unions where you need to remove
+ * a property from all variants.
+ *
+ * @example
+ * ```typescript
+ * // Standard Omit fails with unions:
+ * type BadExample = Omit<{ a: string; b: number } | { a: string; c: boolean }, 'a'>;
+ * // Result: {} (loses all other properties)
+ *
+ * // DistributiveOmit works correctly:
+ * type GoodExample = DistributiveOmit<{ a: string; b: number } | { a: string; c: boolean }, 'a'>;
+ * // Result: { b: number } | { c: boolean } (preserves other properties)
+ * ```
+ *
+ * @template T - The union type to omit properties from
+ * @template K - The keys to omit from each member of the union
+ *
+ * @see https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types
+ */
+export type DistributiveOmit<T, K extends PropertyKey> = T extends unknown ? Omit<T, K> : never;


### PR DESCRIPTION
Tooltips defined within table context now are typed correctly to accept row context.

In order to continue the pattern of ColumnConfig extending Cell, leveraged distributed omit pattern provided by TypeScript. This ensures that ColumnConfig still has access to Cell types like MultiCellConfig, while also overwriting tooltip in all Cell types.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Installed internally and passed typescript checking

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
