### PR TITLE
Remove TableData from accessor generic

### DIFF
--- a/javascript/packages/core/components/cell/types.ts
+++ b/javascript/packages/core/components/cell/types.ts
@@ -34,7 +34,7 @@ export interface SharedCell<T = unknown> {
    * @example 'spec.content.metadata.name'
    * @example (row) => `Revision ${row?.spec?.revisionId}`,
    */
-  accessor?: Accessor<T>;
+  accessor?: Accessor<unknown>;
 
   /**
    * @description Label to be displayed in the table header

--- a/javascript/packages/core/components/table/utils/normalize-column-accessor.ts
+++ b/javascript/packages/core/components/table/utils/normalize-column-accessor.ts
@@ -42,6 +42,6 @@ export function normalizeColumnAccessor<T extends TableData = TableData>(
         .join(MULTI_COLUMN_DATA_JOIN_STRING);
     }
 
-    return getObjectValue<T>(row, resolvedColumn.accessor ?? resolvedColumn.id);
+    return getObjectValue<unknown>(row, resolvedColumn.accessor ?? resolvedColumn.id);
   };
 }


### PR DESCRIPTION
The accessor type generic is typed for the accessor's return value. When provided the TableData generic, it is like saying the accessor returns the unaccessed data.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Installed into Uber environment and passed typechecking

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
