### PR TITLE
Make sticky sides the table default

### DIFF
--- a/javascript/packages/core/components/table/components/table-body/table-body.tsx
+++ b/javascript/packages/core/components/table/components/table-body/table-body.tsx
@@ -26,7 +26,7 @@ export const TableBody = <T extends TableData = TableData>({
 }: TableBodyProps<T>) => {
   const [css, theme] = useStyletron();
 
-  const lastColumnIndex = rows[0].cells.length + 1;
+  const lastVisibleColumnIndex = rows[0].cells.filter((cell) => cell.isVisible).length + 1;
 
   return (
     <StyledTableBody>
@@ -35,7 +35,7 @@ export const TableBody = <T extends TableData = TableData>({
           <StickySidesTableBodyRow
             enableStickySides={enableStickySides}
             enableRowSelection={enableRowSelection}
-            lastColumnIndex={lastColumnIndex}
+            lastColumnIndex={lastVisibleColumnIndex}
             scrollRatio={scrollRatio}
             role="row"
           >

--- a/javascript/packages/core/components/table/types/table-types.ts
+++ b/javascript/packages/core/components/table/types/table-types.ts
@@ -158,7 +158,7 @@ export interface TableRequiredFunctionalityProps<T extends TableData = TableData
    * If true, enables sticky column functionality for better horizontal scrolling experience.
    * First and last columns will remain visible during horizontal scroll.
    *
-   * @default false
+   * @default true
    */
   enableStickySides: boolean;
 

--- a/javascript/packages/core/components/table/utils/apply-default-props.tsx
+++ b/javascript/packages/core/components/table/utils/apply-default-props.tsx
@@ -55,7 +55,7 @@ export function applyDefaultProps<T extends TableData = TableData>(
     pageSizes,
     state: resolveTableState(props.state, disablePagination, pageSizes),
     pagination: props.pagination ?? TablePagination,
-    enableStickySides: props.enableStickySides ?? false,
+    enableStickySides: props.enableStickySides ?? true,
     body: props.body ?? TableBody,
     header: props.header ?? TableHeader,
     unFilteredData: props.unFilteredData ?? props.data,

--- a/javascript/packages/core/components/views/phase-entity-view/entity-table.tsx
+++ b/javascript/packages/core/components/views/phase-entity-view/entity-table.tsx
@@ -37,7 +37,6 @@ export function EntityTable({ service, listViewConfig, tableSettingsId }: Entity
   return (
     <Table
       data={data?.[`${service}List`]?.items ?? []}
-      enableStickySides={true}
       error={error ?? undefined}
       columns={listViewConfig.columns}
       loading={isLoading}

--- a/javascript/packages/core/components/views/project/project-list.tsx
+++ b/javascript/packages/core/components/views/project/project-list.tsx
@@ -33,7 +33,6 @@ export function ProjectList() {
         data={data?.projectList.items ?? []}
         columns={SHARED_PROJECT_CELL_CONFIG}
         loading={isLoading}
-        enableStickySides
       />
     </div>
   );


### PR DESCRIPTION
The majority of Uber use cases assume tables have sticky sides enabled.

Fixed bug in sticky column calculation that considered hidden columns.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Installed internally & verified on data dense tables

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
