### PR TITLE
Add generics to view configurations

### DIFF
--- a/javascript/packages/core/components/views/phase-entity-view/entity-table.tsx
+++ b/javascript/packages/core/components/views/phase-entity-view/entity-table.tsx
@@ -19,10 +19,14 @@ import type { EntityTableProps } from './types';
  * />
  * ```
  */
-export function EntityTable({ service, listViewConfig, tableSettingsId }: EntityTableProps) {
+export function EntityTable<T extends object = object>({
+  service,
+  listViewConfig,
+  tableSettingsId,
+}: EntityTableProps<T>) {
   const { projectId } = useStudioParams('base');
 
-  const { data, isLoading, error } = useStudioQuery<Record<`${string}List`, { items: unknown[] }>>({
+  const { data, isLoading, error } = useStudioQuery<Record<`${string}List`, { items: T[] }>>({
     queryName: `List${capitalizeFirstLetter(service)}`,
     serviceOptions: {
       namespace: projectId,

--- a/javascript/packages/core/components/views/phase-entity-view/phase-entity-view.tsx
+++ b/javascript/packages/core/components/views/phase-entity-view/phase-entity-view.tsx
@@ -17,7 +17,10 @@ import type { PhaseEntityViewProps } from './types';
  * Expects to receive only active entities with list views. Auto-redirects to first
  * entity if no entity in URL to prevent empty states.
  */
-export function PhaseEntityView({ phaseId, entities }: PhaseEntityViewProps) {
+export function PhaseEntityView<T extends object = object>({
+  phaseId,
+  entities,
+}: PhaseEntityViewProps<T>) {
   const [, theme] = useStyletron();
   const navigate = useNavigate();
   const { projectId, entity: currentEntity } = useStudioParams('list');
@@ -63,7 +66,7 @@ export function PhaseEntityView({ phaseId, entities }: PhaseEntityViewProps) {
       {entities.map((entity, index) => (
         <Tab key={String(index)} title={entity.name}>
           {String(index) === activeKey && (
-            <EntityTable
+            <EntityTable<T>
               service={entity.service}
               listViewConfig={currentEntityConfig.views[0]}
               tableSettingsId={`${phaseId}/${entity.id}`}

--- a/javascript/packages/core/components/views/phase-entity-view/types.ts
+++ b/javascript/packages/core/components/views/phase-entity-view/types.ts
@@ -1,20 +1,20 @@
 import type { ListViewConfig, ViewConfig } from '#core/components/views/types';
 import type { PhaseEntityConfig } from '#core/types/common/studio-types';
 
-export type ListableEntity = PhaseEntityConfig & {
+export type ListableEntity<T extends object = object> = PhaseEntityConfig<T> & {
   state: 'active';
-  views: ViewConfig[] & { 0: ListViewConfig };
+  views: ViewConfig<T>[] & { 0: ListViewConfig<T> };
 };
 
-export interface PhaseEntityViewProps {
+export interface PhaseEntityViewProps<T extends object = object> {
   phaseId: string;
-  entities: ListableEntity[];
+  entities: ListableEntity<T>[];
 }
 
-export interface EntityTableProps {
+export interface EntityTableProps<T extends object = object> {
   /** Service name used to construct RPC query (e.g., 'pipeline' → 'ListPipeline') */
   service: string;
-  listViewConfig: ListViewConfig;
+  listViewConfig: ListViewConfig<T>;
   /** Unique ID for table state persistence */
   tableSettingsId: string;
 }

--- a/javascript/packages/core/components/views/types.ts
+++ b/javascript/packages/core/components/views/types.ts
@@ -8,11 +8,11 @@ export type MainViewContainerProps = {
   hasBreadcrumb?: boolean;
 };
 
-export type ViewConfig = ListViewConfig | DetailViewConfig;
+export type ViewConfig<T extends object = object> = ListViewConfig<T> | DetailViewConfig<T>;
 
-export interface ListViewConfig {
+export interface ListViewConfig<T extends object = object> {
   type: 'list';
-  columns: ColumnConfig[];
+  columns: ColumnConfig<T>[];
 }
 
 export interface DetailViewConfig<T extends object = object> {

--- a/javascript/packages/core/config/entities/pipeline/list.ts
+++ b/javascript/packages/core/config/entities/pipeline/list.ts
@@ -3,7 +3,7 @@ import { CellType } from '#core/components/cell/constants';
 import type { ColumnConfig } from '#core/components/table/types/column-types';
 import type { ListViewConfig } from '#core/components/views/types';
 
-export const PIPELINE_CELL_CONFIG: ColumnConfig[] = [
+export const PIPELINE_CELL_CONFIG: ColumnConfig<object>[] = [
   {
     id: 'metadata.name',
     label: 'Name',
@@ -63,7 +63,7 @@ export const PIPELINE_CELL_CONFIG: ColumnConfig[] = [
   },
 ];
 
-export const PIPELINE_LIST_CONFIG: ListViewConfig = {
+export const PIPELINE_LIST_CONFIG: ListViewConfig<object> = {
   type: 'list',
   columns: PIPELINE_CELL_CONFIG,
 };

--- a/javascript/packages/core/config/entities/run/list.ts
+++ b/javascript/packages/core/config/entities/run/list.ts
@@ -3,7 +3,7 @@ import { SHARED_RUN_CELL_CONFIG } from './shared';
 import type { ColumnConfig } from '#core/components/table/types/column-types';
 import type { ListViewConfig } from '#core/components/views/types';
 
-export const PIPELINE_RUN_CELL_CONFIG: ColumnConfig[] = [
+export const PIPELINE_RUN_CELL_CONFIG: ColumnConfig<object>[] = [
   {
     id: 'metadata.name',
     label: 'Name',
@@ -12,7 +12,7 @@ export const PIPELINE_RUN_CELL_CONFIG: ColumnConfig[] = [
   ...SHARED_RUN_CELL_CONFIG,
 ];
 
-export const RUN_LIST_CONFIG: ListViewConfig = {
+export const RUN_LIST_CONFIG: ListViewConfig<object> = {
   type: 'list',
   columns: PIPELINE_RUN_CELL_CONFIG,
 };

--- a/javascript/packages/core/config/entities/trigger/list.ts
+++ b/javascript/packages/core/config/entities/trigger/list.ts
@@ -4,7 +4,7 @@ import { TRIGGER_PIPELINE_CELL_CONFIG, TRIGGER_STATE_CELL_CONFIG } from './share
 import type { ColumnConfig } from '#core/components/table/types/column-types';
 import type { ListViewConfig } from '#core/components/views/types';
 
-export const TRIGGER_LIST_CONFIG: ListViewConfig = {
+export const TRIGGER_LIST_CONFIG: ListViewConfig<object> = {
   type: 'list',
   columns: [
     {
@@ -16,5 +16,5 @@ export const TRIGGER_LIST_CONFIG: ListViewConfig = {
     { id: 'spec.actor.name', label: 'Started by', type: CellType.TEXT },
     TRIGGER_PIPELINE_CELL_CONFIG,
     TRIGGER_STATE_CELL_CONFIG,
-  ] as ColumnConfig[],
+  ] as ColumnConfig<object>[],
 };

--- a/javascript/packages/core/types/common/studio-types.ts
+++ b/javascript/packages/core/types/common/studio-types.ts
@@ -60,7 +60,7 @@ export enum Phase {
   AgentMonitor = 'agent-monitor',
 }
 
-export interface PhaseEntityConfig {
+export interface PhaseEntityConfig<T extends object = object> {
   /**
    * Name of the entity as it appears within MA Studio. Should be plural, lower case
    * version of the name.
@@ -100,7 +100,7 @@ export interface PhaseEntityConfig {
   /** State controlling whether this entity is interactive */
   state: PhaseEntityState;
   /** List of view configurations for this entity */
-  views: ViewConfig[];
+  views: ViewConfig<T>[];
 }
 
 /**


### PR DESCRIPTION
The generics for view configurations correspond to the data displayed in those views. For the primary use case, this is a particular CRD like Pipeline or PipelineRun.

For now, the configurations are explicitly providing object generic to unify the column configuration and the view configuration.

**What type of PR is this? (check all applicable)**
- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
