### PR TITLE
Introduce reusable TableConfig pattern

### DIFF
--- a/javascript/packages/core/components/views/__fixtures__/table-config-factory.ts
+++ b/javascript/packages/core/components/views/__fixtures__/table-config-factory.ts
@@ -7,7 +7,6 @@ import type { TableConfig } from '../types';
 
 /**
  * Factory for creating TableConfig test fixtures.
- * Provides comprehensive configuration for testing with sensible defaults.
  *
  * @param base - Partial object shared across all test fixtures for a test suite
  * @returns Function that generates a complete table config using overrides.
@@ -22,11 +21,6 @@ import type { TableConfig } from '../types';
  * const searchDisabledConfig = buildConfig({
  *   disableSearch: true,
  *   emptyState: { title: 'Custom Empty State' }
- * });
- *
- * // Minimal config
- * const minimalConfig = buildConfig({
- *   columns: [{ id: 'name', label: 'Name' }]
  * });
  * ```
  */

--- a/javascript/packages/core/components/views/__fixtures__/table-config-factory.ts
+++ b/javascript/packages/core/components/views/__fixtures__/table-config-factory.ts
@@ -1,0 +1,61 @@
+import { merge } from 'lodash';
+
+import { CellType } from '#core/components/cell/constants';
+
+import type { DeepPartial } from '#core/types/utility-types';
+import type { TableConfig } from '../types';
+
+/**
+ * Factory for creating TableConfig test fixtures.
+ * Provides comprehensive configuration for testing with sensible defaults.
+ *
+ * @param base - Partial object shared across all test fixtures for a test suite
+ * @returns Function that generates a complete table config using overrides.
+ *
+ * @example
+ * ```typescript
+ * // Setup base configuration for test suite
+ * const buildConfig = buildTableConfigFactory();
+ * const basicConfig = buildConfig();
+ *
+ * // Custom variations
+ * const searchDisabledConfig = buildConfig({
+ *   disableSearch: true,
+ *   emptyState: { title: 'Custom Empty State' }
+ * });
+ *
+ * // Minimal config
+ * const minimalConfig = buildConfig({
+ *   columns: [{ id: 'name', label: 'Name' }]
+ * });
+ * ```
+ */
+export const buildTableConfigFactory = <T extends object = object>(
+  base: DeepPartial<TableConfig<T>> = {}
+) => {
+  return (overrides: DeepPartial<TableConfig<T>> = {}): TableConfig<T> => {
+    const required: TableConfig<T> = {
+      columns: [
+        { id: 'name', label: 'Name', type: CellType.TEXT },
+        { id: 'status', label: 'Status', type: CellType.TEXT },
+        { id: 'createdAt', label: 'Created', type: CellType.DATE },
+      ],
+      emptyState: {
+        title: 'No items',
+        content: 'No items found.',
+      },
+      disablePagination: false,
+      disableSorting: false,
+      disableSearch: false,
+      disableFilters: false,
+      pageSizes: [
+        { id: 10, label: '10' },
+        { id: 25, label: '25' },
+        { id: 50, label: '50' },
+      ],
+      enableStickySides: true,
+    };
+
+    return merge({}, required, base, overrides);
+  };
+};

--- a/javascript/packages/core/components/views/phase-entity-view/__tests__/utils.test.ts
+++ b/javascript/packages/core/components/views/phase-entity-view/__tests__/utils.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, test } from 'vitest';
 
 import { CellType } from '#core/components/cell/constants';
+import { buildTableConfigFactory } from '#core/components/views/__fixtures__/table-config-factory';
 import { isListableEntity } from '../utils';
 
 import type { PhaseEntityConfig } from '#core/types/common/studio-types';
 
 describe('isListableEntity', () => {
+  const buildTableConfig = buildTableConfigFactory({
+    columns: [{ id: 'name', label: 'Name', type: CellType.TEXT }],
+  });
+
   const testCases: Array<{
     name: string;
     entity: Pick<PhaseEntityConfig, 'state' | 'views'>;
@@ -18,7 +23,7 @@ describe('isListableEntity', () => {
         views: [
           {
             type: 'list',
-            columns: [{ id: 'name', label: 'Name', type: CellType.TEXT }],
+            tableConfig: buildTableConfig(),
           },
         ],
       },
@@ -31,7 +36,7 @@ describe('isListableEntity', () => {
         views: [
           {
             type: 'list',
-            columns: [{ id: 'name', label: 'Name', type: CellType.TEXT }],
+            tableConfig: buildTableConfig(),
           },
         ],
       },
@@ -66,7 +71,7 @@ describe('isListableEntity', () => {
         views: [
           {
             type: 'list',
-            columns: [],
+            tableConfig: buildTableConfig({ columns: [] }),
           },
         ],
       },
@@ -79,7 +84,7 @@ describe('isListableEntity', () => {
         views: [
           {
             type: 'list',
-            columns: [{ id: 'name', label: 'Name', type: CellType.TEXT }],
+            tableConfig: buildTableConfig(),
           },
           {
             type: 'detail',
@@ -102,7 +107,7 @@ describe('isListableEntity', () => {
           },
           {
             type: 'list',
-            columns: [{ id: 'name', label: 'Name', type: CellType.TEXT }],
+            tableConfig: buildTableConfig(),
           },
         ],
       },

--- a/javascript/packages/core/components/views/phase-entity-view/entity-table.tsx
+++ b/javascript/packages/core/components/views/phase-entity-view/entity-table.tsx
@@ -1,5 +1,6 @@
 import { useLocalStorageTableState } from '#core/components/table/plugins/state-persistence/use-local-storage-table-state';
 import { Table } from '#core/components/table/table';
+import { adaptTableConfigToTableProps } from '#core/components/views/utils/table-view-adapter';
 import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
 import { useStudioQuery } from '#core/hooks/use-studio-query';
 import { capitalizeFirstLetter } from '#core/utils/string-utils';
@@ -14,14 +15,14 @@ import type { EntityTableProps } from './types';
  * // Renders pipelines table with query 'ListPipeline' and data from 'pipelineList.items'
  * <EntityTable
  *   service="pipeline"
- *   listViewConfig={{ type: 'list', columns: PIPELINE_COLUMNS }}
+ *   tableConfig={{ columns: PIPELINE_COLUMNS, disableSearch: true }}
  *   tableSettingsId="train-pipelines"
  * />
  * ```
  */
 export function EntityTable<T extends object = object>({
   service,
-  listViewConfig,
+  tableConfig,
   tableSettingsId,
 }: EntityTableProps<T>) {
   const { projectId } = useStudioParams('base');
@@ -38,17 +39,11 @@ export function EntityTable<T extends object = object>({
     tableSettingsId,
   });
 
-  return (
-    <Table
-      data={data?.[`${service}List`]?.items ?? []}
-      error={error ?? undefined}
-      columns={listViewConfig.columns}
-      loading={isLoading}
-      pageSizes={[
-        { id: 1, label: '1' },
-        { id: 2, label: '2' },
-      ]}
-      state={entityTableState}
-    />
-  );
+  const tableProps = adaptTableConfigToTableProps<T>(tableConfig, {
+    data: data?.[`${service}List`]?.items ?? [],
+    loading: isLoading,
+    error: error ?? undefined,
+  });
+
+  return <Table {...tableProps} state={entityTableState} />;
 }

--- a/javascript/packages/core/components/views/phase-entity-view/phase-entity-view.tsx
+++ b/javascript/packages/core/components/views/phase-entity-view/phase-entity-view.tsx
@@ -68,7 +68,7 @@ export function PhaseEntityView<T extends object = object>({
           {String(index) === activeKey && (
             <EntityTable<T>
               service={entity.service}
-              listViewConfig={currentEntityConfig.views[0]}
+              tableConfig={currentEntityConfig.views[0].tableConfig}
               tableSettingsId={`${phaseId}/${entity.id}`}
             />
           )}

--- a/javascript/packages/core/components/views/phase-entity-view/types.ts
+++ b/javascript/packages/core/components/views/phase-entity-view/types.ts
@@ -1,4 +1,4 @@
-import type { ListViewConfig, ViewConfig } from '#core/components/views/types';
+import type { ListViewConfig, TableConfig, ViewConfig } from '#core/components/views/types';
 import type { PhaseEntityConfig } from '#core/types/common/studio-types';
 
 export type ListableEntity<T extends object = object> = PhaseEntityConfig<T> & {
@@ -12,9 +12,9 @@ export interface PhaseEntityViewProps<T extends object = object> {
 }
 
 export interface EntityTableProps<T extends object = object> {
-  /** Service name used to construct RPC query (e.g., 'pipeline' → 'ListPipeline') */
+  /** Service name for data fetching (e.g., 'pipeline' → 'ListPipeline') */
   service: string;
-  listViewConfig: ListViewConfig<T>;
+  tableConfig: TableConfig<T>;
   /** Unique ID for table state persistence */
   tableSettingsId: string;
 }

--- a/javascript/packages/core/components/views/types.ts
+++ b/javascript/packages/core/components/views/types.ts
@@ -1,6 +1,10 @@
 import type { ReactNode } from 'react';
 import type { Cell } from '#core/components/cell/types';
+import type { EmptyState } from '#core/components/table/components/table-empty-state/types';
+import type { PageSizeOption } from '#core/components/table/components/table-pagination/types';
 import type { ColumnConfig } from '#core/components/table/types/column-types';
+import type { TableData } from '#core/components/table/types/data-types';
+import type { TableProps as _TableProps } from '#core/components/table/types/table-types';
 import type { DetailPageConfig } from '#core/components/views/detail-view/types/detail-view-schema-types';
 
 export type MainViewContainerProps = {
@@ -12,7 +16,7 @@ export type ViewConfig<T extends object = object> = ListViewConfig<T> | DetailVi
 
 export interface ListViewConfig<T extends object = object> {
   type: 'list';
-  columns: ColumnConfig<T>[];
+  tableConfig: TableConfig<T>;
 }
 
 export interface DetailViewConfig<T extends object = object> {
@@ -23,4 +27,28 @@ export interface DetailViewConfig<T extends object = object> {
 
   /** Content sections to display in the detail view */
   pages: DetailPageConfig<T>[];
+}
+
+/**
+ * Table configuration exposed to views. Can be used by detail view tables,
+ * list views, form tables, etc.
+ *
+ * Defaults are inherited from {@link _TableProps}
+ */
+export interface TableConfig<T extends TableData = TableData> {
+  columns: ColumnConfig<T>[];
+
+  /** Content to display when the table has no data */
+  emptyState?: EmptyState;
+
+  disablePagination?: boolean;
+  disableSorting?: boolean;
+  disableSearch?: boolean;
+  disableFilters?: boolean;
+
+  /** Available page sizes for the table */
+  pageSizes?: PageSizeOption[];
+
+  /** Whether to enable sticky sides in the table */
+  enableStickySides?: boolean;
 }

--- a/javascript/packages/core/components/views/utils/__tests__/table-view-adapter.test.ts
+++ b/javascript/packages/core/components/views/utils/__tests__/table-view-adapter.test.ts
@@ -9,8 +9,6 @@ describe('adaptTableConfigToTableProps', () => {
       { id: 'name', label: 'Name' },
       { id: 'status', label: 'Status' },
     ],
-    emptyState: undefined,
-    pageSizes: undefined,
   });
 
   const mockRuntimeProps = {
@@ -20,7 +18,12 @@ describe('adaptTableConfigToTableProps', () => {
   };
 
   it('should handle minimal TableConfig with only columns', () => {
-    const minimalConfig = buildTableConfig();
+    const minimalConfig = {
+      columns: [
+        { id: 'name', label: 'Name' },
+        { id: 'status', label: 'Status' },
+      ],
+    };
     const result = adaptTableConfigToTableProps(minimalConfig, mockRuntimeProps);
 
     expect(result).toEqual({
@@ -74,7 +77,7 @@ describe('adaptTableConfigToTableProps', () => {
     expect(result.loading).toBe(false);
   });
 
-  it('should correctly map disable flags to actionBar enables', () => {
+  describe('should correctly map disable flags to actionBar enables', () => {
     const testCases = [
       {
         description: 'both disabled',
@@ -132,7 +135,7 @@ describe('adaptTableConfigToTableProps', () => {
       disableSearch: _disableSearch,
       disableFilters: _disableFilters,
       ...expectedProps
-    } = config;
+    } = { ...config, ...mockRuntimeProps };
 
     expect(passedThroughProps).toEqual(expectedProps);
   });

--- a/javascript/packages/core/components/views/utils/__tests__/table-view-adapter.test.ts
+++ b/javascript/packages/core/components/views/utils/__tests__/table-view-adapter.test.ts
@@ -1,0 +1,139 @@
+import { buildTableConfigFactory } from '#core/components/views/__fixtures__/table-config-factory';
+import { adaptTableConfigToTableProps } from '../table-view-adapter';
+
+import type { ApplicationError } from '#core/types/error-types';
+
+describe('adaptTableConfigToTableProps', () => {
+  const buildTableConfig = buildTableConfigFactory({
+    columns: [
+      { id: 'name', label: 'Name' },
+      { id: 'status', label: 'Status' },
+    ],
+    emptyState: undefined,
+    pageSizes: undefined,
+  });
+
+  const mockRuntimeProps = {
+    data: [{ name: 'Item 1', status: 'Active' }],
+    loading: false,
+    error: undefined,
+  };
+
+  it('should handle minimal TableConfig with only columns', () => {
+    const minimalConfig = buildTableConfig();
+    const result = adaptTableConfigToTableProps(minimalConfig, mockRuntimeProps);
+
+    expect(result).toEqual({
+      data: mockRuntimeProps.data,
+      loading: false,
+      error: undefined,
+      columns: minimalConfig.columns,
+      emptyState: undefined,
+      actionBarConfig: {
+        enableSearch: true,
+        enableFilters: true,
+      },
+      disablePagination: undefined,
+      disableSorting: undefined,
+      pageSizes: undefined,
+      enableStickySides: undefined,
+    });
+  });
+
+  it('should handle loading state', () => {
+    const tableConfig = buildTableConfig();
+    const loadingRuntimeProps = {
+      data: [],
+      loading: true,
+      error: undefined,
+    };
+
+    const result = adaptTableConfigToTableProps(tableConfig, loadingRuntimeProps);
+
+    expect(result.loading).toBe(true);
+    expect(result.data).toEqual([]);
+  });
+
+  it('should handle error state', () => {
+    const tableConfig = buildTableConfig();
+    const mockError: ApplicationError = {
+      name: 'ApplicationError',
+      message: 'Failed to load data',
+      code: 500,
+    };
+
+    const errorRuntimeProps = {
+      data: [],
+      loading: false,
+      error: mockError,
+    };
+
+    const result = adaptTableConfigToTableProps(tableConfig, errorRuntimeProps);
+
+    expect(result.error).toBe(mockError);
+    expect(result.loading).toBe(false);
+  });
+
+  it('should correctly map disable flags to actionBar enables', () => {
+    const testCases = [
+      {
+        description: 'both disabled',
+        input: { disableSearch: true, disableFilters: true },
+        expected: { enableSearch: false, enableFilters: false },
+      },
+      {
+        description: 'both enabled',
+        input: { disableSearch: false, disableFilters: false },
+        expected: { enableSearch: true, enableFilters: true },
+      },
+      {
+        description: 'mixed states',
+        input: { disableSearch: true, disableFilters: false },
+        expected: { enableSearch: false, enableFilters: true },
+      },
+      {
+        description: 'undefined (defaults to enabled)',
+        input: {},
+        expected: { enableSearch: true, enableFilters: true },
+      },
+    ];
+
+    test.each(testCases)('$description', ({ input, expected }) => {
+      const tableConfig = buildTableConfig(input);
+
+      expect(adaptTableConfigToTableProps(tableConfig, mockRuntimeProps).actionBarConfig).toEqual(
+        expected
+      );
+    });
+  });
+
+  it('should pass through all TableConfig properties unchanged except actionBar transformation', () => {
+    const config = buildTableConfig({
+      columns: [{ id: 'test', label: 'Test' }],
+      emptyState: { title: 'Empty', content: 'No data' },
+      disablePagination: false,
+      disableSorting: true,
+      disableSearch: false,
+      disableFilters: true,
+      pageSizes: [{ id: 5, label: '5' }],
+      enableStickySides: false,
+    });
+
+    const result = adaptTableConfigToTableProps(config, mockRuntimeProps);
+
+    expect(result.actionBarConfig).toEqual({
+      enableSearch: !config.disableSearch,
+      enableFilters: !config.disableFilters,
+    });
+
+    const { actionBarConfig: _actionBarConfig, ...passedThroughProps } = result;
+
+    const {
+      disableSearch: _disableSearch,
+      disableFilters: _disableFilters,
+      ...expectedProps
+    } = config;
+
+    expect(passedThroughProps).toEqual(expectedProps);
+  });
+});

--- a/javascript/packages/core/components/views/utils/table-view-adapter.ts
+++ b/javascript/packages/core/components/views/utils/table-view-adapter.ts
@@ -1,0 +1,38 @@
+import type { TableActionBarConfig } from '#core/components/table/components/table-action-bar/types';
+import type { TableData } from '#core/components/table/types/data-types';
+import type { TableProps } from '#core/components/table/types/table-types';
+import type { ApplicationError } from '#core/types/error-types';
+import type { TableConfig } from '../types';
+
+/**
+ * Converts TableConfig configuration to TableProps for the core Table component.
+ *
+ * This adapter bridges the gap between table configuration leveraged by configuration
+ * driven views and the specific props required by the Table component.
+ */
+export function adaptTableConfigToTableProps<T extends TableData = TableData>(
+  config: TableConfig<T>,
+  runtimeProps: {
+    data: Array<T>;
+    loading: boolean;
+    error?: ApplicationError;
+  }
+): TableProps<T> {
+  const actionBarConfig: TableActionBarConfig = {
+    enableSearch: !config.disableSearch,
+    enableFilters: !config.disableFilters,
+  };
+
+  return {
+    data: runtimeProps.data,
+    loading: runtimeProps.loading,
+    error: runtimeProps.error,
+    columns: config.columns,
+    emptyState: config.emptyState,
+    actionBarConfig,
+    disablePagination: config.disablePagination,
+    disableSorting: config.disableSorting,
+    pageSizes: config.pageSizes,
+    enableStickySides: config.enableStickySides,
+  };
+}

--- a/javascript/packages/core/config/entities/pipeline/list.ts
+++ b/javascript/packages/core/config/entities/pipeline/list.ts
@@ -65,5 +65,7 @@ export const PIPELINE_CELL_CONFIG: ColumnConfig<object>[] = [
 
 export const PIPELINE_LIST_CONFIG: ListViewConfig<object> = {
   type: 'list',
-  columns: PIPELINE_CELL_CONFIG,
+  tableConfig: {
+    columns: PIPELINE_CELL_CONFIG,
+  },
 };

--- a/javascript/packages/core/config/entities/run/list.ts
+++ b/javascript/packages/core/config/entities/run/list.ts
@@ -14,5 +14,7 @@ export const PIPELINE_RUN_CELL_CONFIG: ColumnConfig<object>[] = [
 
 export const RUN_LIST_CONFIG: ListViewConfig<object> = {
   type: 'list',
-  columns: PIPELINE_RUN_CELL_CONFIG,
+  tableConfig: {
+    columns: PIPELINE_RUN_CELL_CONFIG,
+  },
 };

--- a/javascript/packages/core/config/entities/trigger/list.ts
+++ b/javascript/packages/core/config/entities/trigger/list.ts
@@ -6,15 +6,17 @@ import type { ListViewConfig } from '#core/components/views/types';
 
 export const TRIGGER_LIST_CONFIG: ListViewConfig<object> = {
   type: 'list',
-  columns: [
-    {
-      id: 'metadata.name',
-      label: 'Name',
-      url: '/${studio.projectId}/${studio.phase}/triggers/${data.metadata.name}',
-    },
-    { id: 'metadata.creationTimestamp.seconds', label: 'Created', type: CellType.DATE },
-    { id: 'spec.actor.name', label: 'Started by', type: CellType.TEXT },
-    TRIGGER_PIPELINE_CELL_CONFIG,
-    TRIGGER_STATE_CELL_CONFIG,
-  ] as ColumnConfig<object>[],
+  tableConfig: {
+    columns: [
+      {
+        id: 'metadata.name',
+        label: 'Name',
+        url: '/${studio.projectId}/${studio.phase}/triggers/${data.metadata.name}',
+      },
+      { id: 'metadata.creationTimestamp.seconds', label: 'Created', type: CellType.DATE },
+      { id: 'spec.actor.name', label: 'Started by', type: CellType.TEXT },
+      TRIGGER_PIPELINE_CELL_CONFIG,
+      TRIGGER_STATE_CELL_CONFIG,
+    ],
+  },
 };

--- a/javascript/packages/core/config/entities/trigger/list.ts
+++ b/javascript/packages/core/config/entities/trigger/list.ts
@@ -1,7 +1,6 @@
 import { CellType } from '#core/components/cell/constants';
 import { TRIGGER_PIPELINE_CELL_CONFIG, TRIGGER_STATE_CELL_CONFIG } from './shared';
 
-import type { ColumnConfig } from '#core/components/table/types/column-types';
 import type { ListViewConfig } from '#core/components/views/types';
 
 export const TRIGGER_LIST_CONFIG: ListViewConfig<object> = {

--- a/javascript/packages/core/router/__fixtures__/phase-config-factory.ts
+++ b/javascript/packages/core/router/__fixtures__/phase-config-factory.ts
@@ -32,10 +32,12 @@ export const buildEntityConfigFactory = (base: DeepPartial<PhaseEntityConfig> = 
       views: [
         {
           type: 'list',
-          columns: [
-            { id: 'metadata.name', label: 'Name', type: CellType.TEXT },
-            { id: 'status', label: 'Status', type: CellType.TEXT },
-          ],
+          tableConfig: {
+            columns: [
+              { id: 'metadata.name', label: 'Name', type: CellType.TEXT },
+              { id: 'status', label: 'Status', type: CellType.TEXT },
+            ],
+          },
         },
       ],
     };

--- a/javascript/packages/core/router/__tests__/phase-list-route.test.tsx
+++ b/javascript/packages/core/router/__tests__/phase-list-route.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 
 import { CellType } from '#core/components/cell/constants';
+import { buildTableConfigFactory } from '#core/components/views/__fixtures__/table-config-factory';
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getErrorProviderWrapper } from '#core/test/wrappers/get-error-provider-wrapper';
 import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
@@ -18,6 +19,9 @@ import type { PhaseConfig } from '#core/types/common/studio-types';
 describe('PhaseListRoute', () => {
   const buildEntity = buildEntityConfigFactory();
   const buildPhase = buildPhaseConfigFactory();
+  const buildTableConfig = buildTableConfigFactory({
+    columns: [{ id: 'name', label: 'Name', type: CellType.TEXT }],
+  });
 
   const testPhaseEntityConfig: Record<string, PhaseConfig> = {
     train: buildPhase({
@@ -43,7 +47,7 @@ describe('PhaseListRoute', () => {
           views: [
             {
               type: 'list',
-              columns: [{ id: 'name', label: 'Name', type: CellType.TEXT }],
+              tableConfig: buildTableConfig(),
             },
           ],
         }),
@@ -61,7 +65,7 @@ describe('PhaseListRoute', () => {
           views: [
             {
               type: 'list',
-              columns: [{ id: 'name', label: 'Name', type: CellType.TEXT }],
+              tableConfig: buildTableConfig(),
             },
           ],
         }),
@@ -117,7 +121,7 @@ describe('PhaseListRoute', () => {
             views: [
               {
                 type: 'list',
-                columns: [{ id: 'name', label: 'Name', type: CellType.TEXT }],
+                tableConfig: buildTableConfig(),
               },
             ],
           }),
@@ -304,7 +308,7 @@ describe('PhaseListRoute', () => {
             views: [
               {
                 type: 'list',
-                columns: [{ id: 'metadata.name', label: 'Name', type: CellType.TEXT }],
+                tableConfig: buildTableConfig(),
               },
             ],
           }),


### PR DESCRIPTION
Replace direct Table prop passing with configuration-driven approach. Migrate ListViewConfig composition to separate presentation concerns from data fetching logic.

Current approach tightly coupled table configuration to the list view configuration, which preventing reuse in new context like detail view table pages.

This change introduces TableConfig as a reusable interface that encapsulates all table behavior configuration, with an adapter pattern (adaptTableConfigToTableProps) that handles the conversion from static configuration + runtime data to Table component props.

**What type of PR is this? (check all applicable)**
- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Ran development environment locally and verified pipeline/runs/triggers rendered correctly

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
