### PR TITLE
Implement test utility for mocking queries

### DIFF
--- a/javascript/packages/core/test/wrappers/__tests__/get-service-provider-wrapper.tests.ts
+++ b/javascript/packages/core/test/wrappers/__tests__/get-service-provider-wrapper.tests.ts
@@ -1,0 +1,142 @@
+import { createQueryMockRouter } from '#core/test/wrappers/get-service-provider-wrapper';
+
+describe('createQueryMockRouter', () => {
+  test('routes different query names to correct responses', async () => {
+    const mockRequest = createQueryMockRouter({
+      GetPipelineRun: { pipelineRun: { name: 'specific-run' } },
+      ListPipelineRun: { pipelineRunList: { items: [{ name: 'list-item' }] } },
+      GetDataset: { dataset: { name: 'dataset-name' } },
+    });
+
+    const runResponse = await mockRequest('GetPipelineRun', { name: 'run-123' });
+    const listResponse = await mockRequest('ListPipelineRun', {});
+    const datasetResponse = await mockRequest('GetDataset', { namespace: 'test' });
+
+    expect(runResponse).toEqual({ pipelineRun: { name: 'specific-run' } });
+    expect(listResponse).toEqual({ pipelineRunList: { items: [{ name: 'list-item' }] } });
+    expect(datasetResponse).toEqual({ dataset: { name: 'dataset-name' } });
+  });
+
+  test('rejects unmocked queries with helpful error messages', async () => {
+    const mockRequest = createQueryMockRouter({
+      GetPipelineRun: { pipelineRun: { name: 'test' } },
+    });
+
+    await expect(mockRequest('UnmockedQuery', { filter: 'active' })).rejects.toThrow(
+      'Unexpected query: UnmockedQuery with args: {"filter":"active"}'
+    );
+  });
+
+  test('matches queries with specific service options', async () => {
+    const mockRequest = createQueryMockRouter({
+      'ListPipelineRun:{"filter":"status=SUCCESS","limit":10,"namespace":"project"}': {
+        pipelineRunList: { items: [{ name: 'filtered-run' }] },
+      },
+      ListPipelineRun: {
+        pipelineRunList: { items: [{ name: 'default-run' }] },
+      },
+    });
+
+    const filteredResponse = await mockRequest('ListPipelineRun', {
+      filter: 'status=SUCCESS',
+      limit: 10,
+      namespace: 'project',
+    });
+    const defaultResponse = await mockRequest('ListPipelineRun', {});
+
+    expect(filteredResponse).toEqual({
+      pipelineRunList: { items: [{ name: 'filtered-run' }] },
+    });
+    expect(defaultResponse).toEqual({
+      pipelineRunList: { items: [{ name: 'default-run' }] },
+    });
+  });
+
+  test('matches service options regardless of property order', async () => {
+    const mockRequest = createQueryMockRouter({
+      'ListPipelineRun:{"filter":"active","limit":20,"namespace":"test-project"}': {
+        pipelineRunList: { items: [{ name: 'order-agnostic-match' }] },
+      },
+    });
+
+    const response = await mockRequest('ListPipelineRun', {
+      limit: 20,
+      namespace: 'test-project',
+      filter: 'active',
+    });
+
+    expect(response).toEqual({
+      pipelineRunList: { items: [{ name: 'order-agnostic-match' }] },
+    });
+  });
+
+  test('handles complex nested service options', async () => {
+    const mockRequest = createQueryMockRouter({
+      'GetPipelineRun:{"metadata":{"labels":{"env":"prod"}},"namespace":"production"}': {
+        pipelineRun: { name: 'production-run' },
+      },
+    });
+
+    const response = await mockRequest('GetPipelineRun', {
+      metadata: { labels: { env: 'prod' } },
+      namespace: 'production',
+    });
+
+    expect(response).toEqual({ pipelineRun: { name: 'production-run' } });
+  });
+
+  test('falls back to basic query name when specific args do not match', async () => {
+    const mockRequest = createQueryMockRouter({
+      'ListPipelineRun:{"filter":"status=SUCCESS"}': {
+        pipelineRunList: { items: [{ name: 'success-only' }] },
+      },
+      ListPipelineRun: {
+        pipelineRunList: { items: [{ name: 'fallback-response' }] },
+      },
+    });
+
+    const response = await mockRequest('ListPipelineRun', { filter: 'status=FAILED' });
+
+    expect(response).toEqual({
+      pipelineRunList: { items: [{ name: 'fallback-response' }] },
+    });
+  });
+
+  test('properly rejects with Error objects', async () => {
+    const mockRequest = createQueryMockRouter({
+      GetPipelineRun: new Error('Pipeline not found'),
+      ListPipelineRun: { pipelineRunList: { items: [] } },
+    });
+
+    await expect(mockRequest('GetPipelineRun', { name: 'missing-run' })).rejects.toThrow(
+      'Pipeline not found'
+    );
+
+    const successResponse = await mockRequest('ListPipelineRun', {});
+    expect(successResponse).toEqual({ pipelineRunList: { items: [] } });
+  });
+
+  test('handles error responses with specific service options', async () => {
+    const mockRequest = createQueryMockRouter({
+      'GetPipelineRun:{"name":"restricted"}': new Error('Access denied'),
+      GetPipelineRun: { pipelineRun: { name: 'default-access' } },
+    });
+
+    await expect(mockRequest('GetPipelineRun', { name: 'restricted' })).rejects.toThrow(
+      'Access denied'
+    );
+
+    const successResponse = await mockRequest('GetPipelineRun', { name: 'public' });
+    expect(successResponse).toEqual({ pipelineRun: { name: 'default-access' } });
+  });
+
+  test('handles empty args object', async () => {
+    const mockRequest = createQueryMockRouter({
+      'ListPipelineRun:{}': { pipelineRunList: { items: [{ name: 'empty-args' }] } },
+      ListPipelineRun: { pipelineRunList: { items: [{ name: 'no-args' }] } },
+    });
+
+    const emptyArgsResponse = await mockRequest('ListPipelineRun', {});
+    expect(emptyArgsResponse).toEqual({ pipelineRunList: { items: [{ name: 'empty-args' }] } });
+  });
+});

--- a/javascript/packages/core/test/wrappers/get-service-provider-wrapper.tsx
+++ b/javascript/packages/core/test/wrappers/get-service-provider-wrapper.tsx
@@ -1,4 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { isEqual } from 'lodash';
 import { vi } from 'vitest';
 
 import { ServiceProvider } from '#core/providers/service-provider/service-provider';
@@ -12,6 +13,9 @@ import { WrapperComponentProps } from './types';
  *
  * Each wrapper gets a fresh QueryClient instance to ensure test isolation.
  *
+ * @remarks
+ * Use {@link createQueryMockRouter} for complex mocking scenarios.
+ *
  * @param serviceProvider - The service provider to use for the service context
  * @returns A wrapper component that provides service context to its children
  *
@@ -23,6 +27,17 @@ import { WrapperComponentProps } from './types';
  * render(<MyComponent />, { wrapper });
  *
  * expect(mockRequest).toHaveBeenCalledWith('requestId', { queryKey: ['requestId'] });
+ *
+ * // Usage with multiple requests
+ * const mockRequest = createQueryMockRouter({
+ *   'GetPipelineRun:{"namespace":"project-name","name":"pipeline-name"}': { pipelineRun: { name: 'test' } },
+ *   'ListPipelineRun': { pipelineRunList: { items: [] } },
+ * });
+ * const wrapper = getServiceProviderWrapper({ request: mockRequest });
+ * render(<MyComponent />, { wrapper });
+ *
+ * expect(mockRequest).toHaveBeenCalledWith('GetPipelineRun', { queryKey: ['GetPipelineRun'] });
+ * expect(mockRequest).toHaveBeenCalledWith('ListPipelineRun', { queryKey: ['ListPipelineRun'] });
  * ```
  */
 export function getServiceProviderWrapper(serviceProvider: Partial<ServiceContextType>) {
@@ -49,4 +64,61 @@ export function getServiceProviderWrapper(serviceProvider: Partial<ServiceContex
       </QueryClientProvider>
     );
   };
+}
+
+/**
+ * Creates a query-aware mock request function that responds based on queryName and serviceOptions.
+ *
+ * @param responses - Map of queryName or "queryName:serviceOptions" to response data or Error
+ * @returns Mock function that routes requests based on queryName and optionally serviceOptions
+ *
+ * @example
+ * ```tsx
+ * const mockRequest = createQueryMockRouter({
+ *   'GetPipelineRun': { pipelineRun: { name: 'test' } },
+ *   'ListPipelineRun': { pipelineRunList: { items: [] } },
+ *   'ListPipeline:{"namespace":"project","filter":"status=SUCCESS"}': { // Exact serviceOptions match
+ *     pipelineList: { items: [{ name: 'filtered' }] }
+ *   },
+ * });
+ *
+ * const wrapper = getServiceProviderWrapper({ request: mockRequest });
+ * ```
+ */
+export function createQueryMockRouter(
+  responses: Record<string, object | Error>
+): ServiceContextType['request'] {
+  return vi.fn((queryName: string, args: object) => {
+    if (args) {
+      for (const [responseKey, response] of Object.entries(responses)) {
+        if (isEqual(parseArgsFromKey(responseKey), { queryName, args })) {
+          return response instanceof Error ? Promise.reject(response) : Promise.resolve(response);
+        }
+      }
+    }
+
+    const response = responses[queryName];
+    if (response === undefined) {
+      const argsStr = args ? JSON.stringify(args) : 'undefined';
+      return Promise.reject(new Error(`Unexpected query: ${queryName} with args: ${argsStr}`));
+    }
+
+    return response instanceof Error ? Promise.reject(response) : Promise.resolve(response);
+  });
+}
+
+/** Parse query args from a response key like "QueryName:{"key":"value"}" */
+function parseArgsFromKey(key: string): { queryName: string; args: object } | null {
+  const colonIndex = key.indexOf(':');
+  if (colonIndex === -1) return null;
+
+  const queryName = key.slice(0, colonIndex);
+  const argsStr = key.slice(colonIndex + 1);
+
+  try {
+    const args = JSON.parse(argsStr) as object;
+    return { queryName, args };
+  } catch {
+    return null;
+  }
 }


### PR DESCRIPTION
Introduce createQueryMockRouter function to enable testing components that make multiple queries with different service options. Supports both simple query routing and complex parameter-specific responses.

Previous testing approach required manually setting up vi.fn() mocks for each query scenario, making it difficult to test components that conditionally query different endpoints based on service options. This became particularly challenging when starting testing for detail pages with tables (page has primary query, table has secondary query)

The utility uses deep object comparison such that developers don't need to worry about argument property ordering (which should not impact query output in normal operation).

**What type of PR is this? (check all applicable)**
- [] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
