### PR TITLE
Add table page support to detail view components

### DIFF
--- a/javascript/packages/core/components/views/detail-view/components/detail-view-page-renderer/detail-view-page-renderer.tsx
+++ b/javascript/packages/core/components/views/detail-view/components/detail-view-page-renderer/detail-view-page-renderer.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 
 import { Execution } from '#core/components/views/execution/execution';
+import { DetailViewTablePage } from './pages/detail-view-table-page/detail-view-table-page';
 
 import type {
   CustomDetailPageConfig,
   ExecutionDetailPageConfig,
+  TableDetailPageConfig,
 } from '#core/components/views/detail-view/types/detail-view-schema-types';
 import type { PageRendererProps } from './types';
 
@@ -19,6 +21,18 @@ export function DetailViewPageRenderer<T extends object = object>({
 
     case 'execution':
       return <Execution schema={page as ExecutionDetailPageConfig} data={data ?? {}} />;
+
+    case 'table': {
+      const tablePage = page as TableDetailPageConfig<T>;
+      return (
+        <DetailViewTablePage<T>
+          isDetailViewLoading={isLoading}
+          queryConfig={tablePage.queryConfig}
+          tableConfig={tablePage.tableConfig}
+          pageId={tablePage.id}
+        />
+      );
+    }
 
     default:
       return <div>Page type '{page.type}' not yet supported</div>;

--- a/javascript/packages/core/components/views/detail-view/components/detail-view-page-renderer/pages/detail-view-table-page/__tests__/detail-view-table-page.test.tsx
+++ b/javascript/packages/core/components/views/detail-view/components/detail-view-page-renderer/pages/detail-view-table-page/__tests__/detail-view-table-page.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from '@testing-library/react';
+
+import { CellType } from '#core/components/cell/constants';
+import { buildTableConfigFactory } from '#core/components/views/__fixtures__/table-config-factory';
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getErrorProviderWrapper } from '#core/test/wrappers/get-error-provider-wrapper';
+import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
+import {
+  createQueryMockRouter,
+  getServiceProviderWrapper,
+} from '#core/test/wrappers/get-service-provider-wrapper';
+import { DetailViewTablePage } from '../detail-view-table-page';
+
+describe('DetailViewTablePage', () => {
+  const buildTableConfig = buildTableConfigFactory();
+
+  const defaultProps = {
+    queryConfig: {
+      endpoint: 'list',
+      service: 'pipelineRun',
+      serviceOptions: {},
+    },
+    tableConfig: buildTableConfig({
+      columns: [{ id: 'name', label: 'Run Name', type: CellType.TEXT }],
+    }),
+    pageId: 'test-table',
+  };
+
+  test('fetches and displays table data when not loading', async () => {
+    const mockRequest = createQueryMockRouter({
+      ListPipelineRun: {
+        pipelineRunList: { items: [{ name: 'Test Run 1' }, { name: 'Test Run 2' }] },
+      },
+    });
+
+    render(
+      <DetailViewTablePage {...defaultProps} isDetailViewLoading={false} />,
+      buildWrapper([
+        getErrorProviderWrapper(),
+        getRouterWrapper({ location: '/project/train/runs' }),
+        getServiceProviderWrapper({ request: mockRequest }),
+      ])
+    );
+
+    await screen.findByRole('row', { name: /Test Run 1/ });
+    expect(screen.getByRole('row', { name: /Test Run 2/ })).toBeInTheDocument();
+  });
+
+  test('does not fetch table data and shows loading when detail view is loading', () => {
+    const mockRequest = createQueryMockRouter({
+      ListPipelineRun: {
+        pipelineRunList: { items: [{ name: 'Should Not Appear' }] },
+      },
+    });
+
+    render(
+      <DetailViewTablePage {...defaultProps} isDetailViewLoading={true} />,
+      buildWrapper([
+        getErrorProviderWrapper(),
+        getRouterWrapper({ location: '/project/train/runs' }),
+        getServiceProviderWrapper({ request: mockRequest }),
+      ])
+    );
+
+    // Verify table query was never called due to detail view loading
+    expect(mockRequest).not.toHaveBeenCalledWith('ListPipelineRun', expect.anything());
+
+    expect(screen.queryByText('Should Not Appear')).not.toBeInTheDocument();
+    expect(screen.getByTestId('table-loading-state')).toBeInTheDocument();
+  });
+
+  test('respects query clientOptions.enabled when detail view is not loading', () => {
+    const mockRequest = createQueryMockRouter({
+      ListPipelineRun: {
+        pipelineRunList: { items: [{ name: 'Should Not Appear' }] },
+      },
+    });
+
+    render(
+      <DetailViewTablePage
+        {...defaultProps}
+        isDetailViewLoading={false}
+        queryConfig={{
+          endpoint: 'list',
+          service: 'pipelineRun',
+          serviceOptions: {},
+          clientOptions: { enabled: false },
+        }}
+      />,
+      buildWrapper([
+        getErrorProviderWrapper(),
+        getRouterWrapper({ location: '/project/train/runs' }),
+        getServiceProviderWrapper({ request: mockRequest }),
+      ])
+    );
+
+    expect(mockRequest).not.toHaveBeenCalledWith('ListPipelineRun', expect.anything());
+    expect(screen.queryByText('Should Not Appear')).not.toBeInTheDocument();
+  });
+});

--- a/javascript/packages/core/components/views/detail-view/components/detail-view-page-renderer/pages/detail-view-table-page/detail-view-table-page.tsx
+++ b/javascript/packages/core/components/views/detail-view/components/detail-view-page-renderer/pages/detail-view-table-page/detail-view-table-page.tsx
@@ -1,0 +1,62 @@
+import { useLocalStorageTableState } from '#core/components/table/plugins/state-persistence/use-local-storage-table-state';
+import { Table } from '#core/components/table/table';
+import { adaptTableConfigToTableProps } from '#core/components/views/utils/table-view-adapter';
+import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
+import { useStudioQuery } from '#core/hooks/use-studio-query';
+import { capitalizeFirstLetter } from '#core/utils/string-utils';
+
+import type { DetailViewTablePageProps } from './types';
+
+/**
+ * Configuration-driven table page component for detail views
+ *
+ * Automatically handles data fetching via useStudioQuery and table state persistence.
+ *
+ * @example
+ * ```tsx
+ * <TablePage
+ *   queryConfig={{
+ *     service: 'pipelineRun',
+ *     endpoint: 'list',
+ *     serviceOptions: {
+ *       namespace: projectId,
+ *     },
+ *   }}
+ *   tableConfig={{ columns: PIPELINE_RUN_COLUMNS, disableSearch: true }}
+ *   pageId="runs"
+ * />
+ * ```
+ */
+export function DetailViewTablePage<T extends object = object>({
+  isDetailViewLoading = false,
+  queryConfig,
+  tableConfig,
+  pageId,
+}: DetailViewTablePageProps<T>) {
+  const { projectId, phase, entity } = useStudioParams('detail');
+
+  const { data, isLoading, error } = useStudioQuery<Record<`${string}List`, { items: T[] }>>({
+    queryName: `List${capitalizeFirstLetter(queryConfig.service)}`,
+    serviceOptions: {
+      namespace: projectId,
+      ...queryConfig.serviceOptions,
+    },
+    clientOptions: {
+      ...queryConfig.clientOptions,
+      enabled: !isDetailViewLoading && queryConfig.clientOptions?.enabled,
+    },
+  });
+
+  const tableState = useLocalStorageTableState({
+    tableSettingsId: `${phase}/${entity}/${pageId}`,
+    filterSettingsId: `${projectId}/${phase}/${entity}/${pageId}`,
+  });
+
+  const tableProps = adaptTableConfigToTableProps<T>(tableConfig, {
+    data: data?.[`${queryConfig.service}List`]?.items ?? [],
+    loading: isLoading || isDetailViewLoading,
+    error: error ?? undefined,
+  });
+
+  return <Table {...tableProps} state={tableState} />;
+}

--- a/javascript/packages/core/components/views/detail-view/components/detail-view-page-renderer/pages/detail-view-table-page/types.ts
+++ b/javascript/packages/core/components/views/detail-view/components/detail-view-page-renderer/pages/detail-view-table-page/types.ts
@@ -1,0 +1,15 @@
+import type { TableConfig } from '#core/components/views/types';
+import type { QueryConfig } from '#core/types/query-types';
+
+export interface DetailViewTablePageProps<T extends object = object> {
+  /** Query configuration for fetching data to display in the table */
+  queryConfig: QueryConfig;
+
+  tableConfig: TableConfig<T>;
+
+  /** Unique page identifier for table state persistence */
+  pageId: string;
+
+  /** Whether the parent detail view is loading, preventing table queries */
+  isDetailViewLoading?: boolean;
+}

--- a/javascript/packages/core/components/views/detail-view/types/detail-view-schema-types.ts
+++ b/javascript/packages/core/components/views/detail-view/types/detail-view-schema-types.ts
@@ -1,8 +1,11 @@
 import type { ExecutionDetailViewSchema } from '#core/components/views/execution/types';
+import type { TableConfig } from '#core/components/views/types';
+import type { QueryConfig } from '#core/types/query-types';
 
 export type DetailPageConfig<T extends object = object> =
   | BaseDetailPageConfig
   | ExecutionDetailPageConfig<T>
+  | TableDetailPageConfig<T>
   | CustomDetailPageConfig<T>;
 
 interface BaseDetailPageConfig {
@@ -20,6 +23,15 @@ export interface ExecutionDetailPageConfig<T extends object = object>
   extends BaseDetailPageConfig,
     ExecutionDetailViewSchema<T> {
   type: 'execution';
+}
+
+export interface TableDetailPageConfig<T extends object = object> extends BaseDetailPageConfig {
+  type: 'table';
+
+  /** Query configuration for fetching data to display in the table */
+  queryConfig: QueryConfig;
+
+  tableConfig: TableConfig<T>;
 }
 
 export interface CustomDetailPageConfig<T extends object = object> extends BaseDetailPageConfig {

--- a/javascript/packages/core/components/views/phase-entity-view/types.ts
+++ b/javascript/packages/core/components/views/phase-entity-view/types.ts
@@ -1,5 +1,6 @@
 import type { ListViewConfig, TableConfig, ViewConfig } from '#core/components/views/types';
 import type { PhaseEntityConfig } from '#core/types/common/studio-types';
+import type { QueryConfig } from '#core/types/query-types';
 
 export type ListableEntity<T extends object = object> = PhaseEntityConfig<T> & {
   state: 'active';
@@ -13,7 +14,7 @@ export interface PhaseEntityViewProps<T extends object = object> {
 
 export interface EntityTableProps<T extends object = object> {
   /** Service name for data fetching (e.g., 'pipeline' → 'ListPipeline') */
-  service: string;
+  service: QueryConfig['service'];
   tableConfig: TableConfig<T>;
   /** Unique ID for table state persistence */
   tableSettingsId: string;

--- a/javascript/packages/core/router/__tests__/entity-detail-route.test.tsx
+++ b/javascript/packages/core/router/__tests__/entity-detail-route.test.tsx
@@ -3,12 +3,19 @@ import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 
 import { CellType } from '#core/components/cell/constants';
-import { CustomDetailPageConfig } from '#core/components/views/detail-view/types/detail-view-schema-types';
+import { buildTableConfigFactory } from '#core/components/views/__fixtures__/table-config-factory';
+import {
+  CustomDetailPageConfig,
+  TableDetailPageConfig,
+} from '#core/components/views/detail-view/types/detail-view-schema-types';
 import { buildExecutionSchemaFactory } from '#core/components/views/execution/__fixtures__/execution-schema-factory';
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getErrorProviderWrapper } from '#core/test/wrappers/get-error-provider-wrapper';
 import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
-import { getServiceProviderWrapper } from '#core/test/wrappers/get-service-provider-wrapper';
+import {
+  createQueryMockRouter,
+  getServiceProviderWrapper,
+} from '#core/test/wrappers/get-service-provider-wrapper';
 import {
   buildEntityConfigFactory,
   buildPhaseConfigFactory,
@@ -22,6 +29,7 @@ describe('EntityDetailRoute', () => {
     service: 'pipelineRun',
   });
   const buildExecutionSchema = buildExecutionSchemaFactory();
+  const buildTableConfig = buildTableConfigFactory();
   const buildPhase = buildPhaseConfigFactory();
 
   test('renders execution tab', async () => {
@@ -359,5 +367,242 @@ describe('EntityDetailRoute', () => {
 
     await screen.findByText('Entity not found');
     expect(screen.getByRole('button', { name: /Back to list/i })).toBeInTheDocument();
+  });
+
+  test('handles error when entity not found', async () => {
+    const testPhases = {
+      train: buildPhase({
+        id: 'train',
+        entities: [
+          buildEntity({
+            views: [
+              {
+                type: 'detail',
+                metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
+                pages: [
+                  {
+                    id: 'execution',
+                    label: 'Execution',
+                    ...buildExecutionSchema(),
+                  },
+                ],
+              },
+            ],
+          }),
+        ],
+      }),
+    };
+
+    const mockRequest = vi.fn().mockRejectedValue(new Error('Entity not found'));
+
+    render(
+      <EntityDetailRoute phases={testPhases} />,
+      buildWrapper([
+        getErrorProviderWrapper(),
+        getRouterWrapper({
+          location: '/myproject/train/runs/run-123',
+        }),
+        getServiceProviderWrapper({ request: mockRequest }),
+      ])
+    );
+
+    await screen.findByText('Entity not found');
+    expect(screen.getByRole('button', { name: /Back to list/i })).toBeInTheDocument();
+  });
+
+  test('table does not fetch data when query is disabled', async () => {
+    const testPhases = {
+      train: buildPhase({
+        id: 'train',
+        entities: [
+          buildEntity({
+            views: [
+              {
+                type: 'detail',
+                metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
+                pages: [
+                  {
+                    id: 'runs-table',
+                    label: 'Related Runs',
+                    type: 'table',
+                    queryConfig: {
+                      service: 'pipelineRun',
+                      serviceOptions: {},
+                      clientOptions: { enabled: false },
+                    },
+                    tableConfig: buildTableConfig({
+                      columns: [{ id: 'name', label: 'Run Name', type: CellType.TEXT }],
+                    }),
+                  },
+                ],
+              },
+            ],
+          }),
+        ],
+      }),
+    };
+
+    const mockEntityData = {
+      pipelineRun: {
+        metadata: {
+          creationTimestamp: {
+            seconds: 1640995200,
+          },
+        },
+        status: {
+          state: 'SUCCESS',
+        },
+      },
+    };
+
+    const mockRequest = createQueryMockRouter({
+      GetPipelineRun: mockEntityData,
+      ListPipelineRun: { pipelineRunList: { items: [{ name: 'Should Not Appear' }] } },
+    });
+
+    render(
+      <EntityDetailRoute phases={testPhases} />,
+      buildWrapper([
+        getErrorProviderWrapper(),
+        getRouterWrapper({
+          location: '/myproject/train/runs/run-123',
+        }),
+        getServiceProviderWrapper({ request: mockRequest }),
+      ])
+    );
+
+    // Verify detail view loads
+    await screen.findByText('Success');
+    expect(screen.getByText('Related Runs')).toBeInTheDocument();
+
+    // Verify table query was never called due to enabled: false
+    expect(mockRequest).not.toHaveBeenCalledWith('ListPipelineRun', expect.anything());
+    expect(screen.queryByText('Should Not Appear')).not.toBeInTheDocument();
+  });
+
+  test('table respects custom service options from config', async () => {
+    const testPhases = {
+      train: buildPhase({
+        id: 'train',
+        entities: [
+          buildEntity({
+            views: [
+              {
+                type: 'detail',
+                metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
+                pages: [
+                  {
+                    id: 'filtered-runs',
+                    label: 'Filtered Runs',
+                    type: 'table',
+                    queryConfig: {
+                      service: 'pipelineRun',
+                      serviceOptions: {
+                        filter: 'status=SUCCESS',
+                        limit: 10,
+                      },
+                    },
+                    tableConfig: buildTableConfig({
+                      columns: [{ id: 'name', label: 'Run Name', type: CellType.TEXT }],
+                    }),
+                  },
+                ],
+              },
+            ],
+          }),
+        ],
+      }),
+    };
+
+    const mockEntityData = {
+      pipelineRun: {
+        metadata: { creationTimestamp: { seconds: 1640995200 } },
+        status: { state: 'SUCCESS' },
+      },
+    };
+
+    const mockRequest = createQueryMockRouter({
+      GetPipelineRun: mockEntityData,
+      'ListPipelineRun:{"filter":"status=SUCCESS","limit":10,"namespace":"myproject"}': {
+        pipelineRunList: { items: [{ name: 'Filtered Success Run' }] },
+      },
+    });
+
+    render(
+      <EntityDetailRoute phases={testPhases} />,
+      buildWrapper([
+        getErrorProviderWrapper(),
+        getRouterWrapper({
+          location: '/myproject/train/runs/run-123',
+        }),
+        getServiceProviderWrapper({ request: mockRequest }),
+      ])
+    );
+
+    await screen.findByRole('row', { name: /Filtered Success Run/ });
+  });
+
+  test('handles table tab request failure gracefully', async () => {
+    const testPhases = {
+      train: buildPhase({
+        id: 'train',
+        entities: [
+          buildEntity({
+            views: [
+              {
+                type: 'detail',
+                metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
+                pages: [
+                  {
+                    id: 'runs-table',
+                    label: 'Related Runs',
+                    type: 'table',
+                    queryConfig: {
+                      service: 'pipelineRun',
+                      endpoint: 'list',
+                      serviceOptions: {},
+                    },
+                    tableConfig: buildTableConfig({
+                      columns: [{ id: 'name', label: 'Run Name', type: CellType.TEXT }],
+                    }),
+                  } as TableDetailPageConfig,
+                ],
+              },
+            ],
+          }),
+        ],
+      }),
+    };
+
+    const mockEntityData = {
+      pipelineRun: {
+        metadata: {
+          creationTimestamp: {
+            seconds: 1640995200,
+          },
+        },
+        status: {
+          state: 'SUCCESS',
+        },
+      },
+    };
+
+    const mockRequest = createQueryMockRouter({
+      GetPipelineRun: mockEntityData,
+      ListPipelineRun: new Error('Table API Error'),
+    });
+
+    render(
+      <EntityDetailRoute phases={testPhases} />,
+      buildWrapper([
+        getErrorProviderWrapper(),
+        getRouterWrapper({
+          location: '/myproject/train/runs/run-123',
+        }),
+        getServiceProviderWrapper({ request: mockRequest }),
+      ])
+    );
+
+    await screen.findByText('Unable to fetch data for the table');
   });
 });

--- a/javascript/packages/core/test/wrappers/__tests__/get-service-provider-wrapper.tests.ts
+++ b/javascript/packages/core/test/wrappers/__tests__/get-service-provider-wrapper.tests.ts
@@ -1,0 +1,142 @@
+import { createQueryMockRouter } from '#core/test/wrappers/get-service-provider-wrapper';
+
+describe('createQueryMockRouter', () => {
+  test('routes different query names to correct responses', async () => {
+    const mockRequest = createQueryMockRouter({
+      GetPipelineRun: { pipelineRun: { name: 'specific-run' } },
+      ListPipelineRun: { pipelineRunList: { items: [{ name: 'list-item' }] } },
+      GetDataset: { dataset: { name: 'dataset-name' } },
+    });
+
+    const runResponse = await mockRequest('GetPipelineRun', { name: 'run-123' });
+    const listResponse = await mockRequest('ListPipelineRun', {});
+    const datasetResponse = await mockRequest('GetDataset', { namespace: 'test' });
+
+    expect(runResponse).toEqual({ pipelineRun: { name: 'specific-run' } });
+    expect(listResponse).toEqual({ pipelineRunList: { items: [{ name: 'list-item' }] } });
+    expect(datasetResponse).toEqual({ dataset: { name: 'dataset-name' } });
+  });
+
+  test('rejects unmocked queries with helpful error messages', async () => {
+    const mockRequest = createQueryMockRouter({
+      GetPipelineRun: { pipelineRun: { name: 'test' } },
+    });
+
+    await expect(mockRequest('UnmockedQuery', { filter: 'active' })).rejects.toThrow(
+      'Unexpected query: UnmockedQuery with args: {"filter":"active"}'
+    );
+  });
+
+  test('matches queries with specific service options', async () => {
+    const mockRequest = createQueryMockRouter({
+      'ListPipelineRun:{"filter":"status=SUCCESS","limit":10,"namespace":"project"}': {
+        pipelineRunList: { items: [{ name: 'filtered-run' }] },
+      },
+      ListPipelineRun: {
+        pipelineRunList: { items: [{ name: 'default-run' }] },
+      },
+    });
+
+    const filteredResponse = await mockRequest('ListPipelineRun', {
+      filter: 'status=SUCCESS',
+      limit: 10,
+      namespace: 'project',
+    });
+    const defaultResponse = await mockRequest('ListPipelineRun', {});
+
+    expect(filteredResponse).toEqual({
+      pipelineRunList: { items: [{ name: 'filtered-run' }] },
+    });
+    expect(defaultResponse).toEqual({
+      pipelineRunList: { items: [{ name: 'default-run' }] },
+    });
+  });
+
+  test('matches service options regardless of property order', async () => {
+    const mockRequest = createQueryMockRouter({
+      'ListPipelineRun:{"filter":"active","limit":20,"namespace":"test-project"}': {
+        pipelineRunList: { items: [{ name: 'order-agnostic-match' }] },
+      },
+    });
+
+    const response = await mockRequest('ListPipelineRun', {
+      limit: 20,
+      namespace: 'test-project',
+      filter: 'active',
+    });
+
+    expect(response).toEqual({
+      pipelineRunList: { items: [{ name: 'order-agnostic-match' }] },
+    });
+  });
+
+  test('handles complex nested service options', async () => {
+    const mockRequest = createQueryMockRouter({
+      'GetPipelineRun:{"metadata":{"labels":{"env":"prod"}},"namespace":"production"}': {
+        pipelineRun: { name: 'production-run' },
+      },
+    });
+
+    const response = await mockRequest('GetPipelineRun', {
+      metadata: { labels: { env: 'prod' } },
+      namespace: 'production',
+    });
+
+    expect(response).toEqual({ pipelineRun: { name: 'production-run' } });
+  });
+
+  test('falls back to basic query name when specific args do not match', async () => {
+    const mockRequest = createQueryMockRouter({
+      'ListPipelineRun:{"filter":"status=SUCCESS"}': {
+        pipelineRunList: { items: [{ name: 'success-only' }] },
+      },
+      ListPipelineRun: {
+        pipelineRunList: { items: [{ name: 'fallback-response' }] },
+      },
+    });
+
+    const response = await mockRequest('ListPipelineRun', { filter: 'status=FAILED' });
+
+    expect(response).toEqual({
+      pipelineRunList: { items: [{ name: 'fallback-response' }] },
+    });
+  });
+
+  test('properly rejects with Error objects', async () => {
+    const mockRequest = createQueryMockRouter({
+      GetPipelineRun: new Error('Pipeline not found'),
+      ListPipelineRun: { pipelineRunList: { items: [] } },
+    });
+
+    await expect(mockRequest('GetPipelineRun', { name: 'missing-run' })).rejects.toThrow(
+      'Pipeline not found'
+    );
+
+    const successResponse = await mockRequest('ListPipelineRun', {});
+    expect(successResponse).toEqual({ pipelineRunList: { items: [] } });
+  });
+
+  test('handles error responses with specific service options', async () => {
+    const mockRequest = createQueryMockRouter({
+      'GetPipelineRun:{"name":"restricted"}': new Error('Access denied'),
+      GetPipelineRun: { pipelineRun: { name: 'default-access' } },
+    });
+
+    await expect(mockRequest('GetPipelineRun', { name: 'restricted' })).rejects.toThrow(
+      'Access denied'
+    );
+
+    const successResponse = await mockRequest('GetPipelineRun', { name: 'public' });
+    expect(successResponse).toEqual({ pipelineRun: { name: 'default-access' } });
+  });
+
+  test('handles empty args object', async () => {
+    const mockRequest = createQueryMockRouter({
+      'ListPipelineRun:{}': { pipelineRunList: { items: [{ name: 'empty-args' }] } },
+      ListPipelineRun: { pipelineRunList: { items: [{ name: 'no-args' }] } },
+    });
+
+    const emptyArgsResponse = await mockRequest('ListPipelineRun', {});
+    expect(emptyArgsResponse).toEqual({ pipelineRunList: { items: [{ name: 'empty-args' }] } });
+  });
+});

--- a/javascript/packages/core/test/wrappers/get-service-provider-wrapper.tsx
+++ b/javascript/packages/core/test/wrappers/get-service-provider-wrapper.tsx
@@ -1,4 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { isEqual } from 'lodash';
 import { vi } from 'vitest';
 
 import { ServiceProvider } from '#core/providers/service-provider/service-provider';
@@ -12,6 +13,9 @@ import { WrapperComponentProps } from './types';
  *
  * Each wrapper gets a fresh QueryClient instance to ensure test isolation.
  *
+ * @remarks
+ * Use {@link createQueryMockRouter} for complex mocking scenarios.
+ *
  * @param serviceProvider - The service provider to use for the service context
  * @returns A wrapper component that provides service context to its children
  *
@@ -23,6 +27,17 @@ import { WrapperComponentProps } from './types';
  * render(<MyComponent />, { wrapper });
  *
  * expect(mockRequest).toHaveBeenCalledWith('requestId', { queryKey: ['requestId'] });
+ *
+ * // Usage with multiple requests
+ * const mockRequest = createQueryMockRouter({
+ *   'GetPipelineRun:{"namespace":"project-name","name":"pipeline-name"}': { pipelineRun: { name: 'test' } },
+ *   'ListPipelineRun': { pipelineRunList: { items: [] } },
+ * });
+ * const wrapper = getServiceProviderWrapper({ request: mockRequest });
+ * render(<MyComponent />, { wrapper });
+ *
+ * expect(mockRequest).toHaveBeenCalledWith('GetPipelineRun', { queryKey: ['GetPipelineRun'] });
+ * expect(mockRequest).toHaveBeenCalledWith('ListPipelineRun', { queryKey: ['ListPipelineRun'] });
  * ```
  */
 export function getServiceProviderWrapper(serviceProvider: Partial<ServiceContextType>) {
@@ -49,4 +64,61 @@ export function getServiceProviderWrapper(serviceProvider: Partial<ServiceContex
       </QueryClientProvider>
     );
   };
+}
+
+/**
+ * Creates a query-aware mock request function that responds based on queryName and serviceOptions.
+ *
+ * @param responses - Map of queryName or "queryName:serviceOptions" to response data or Error
+ * @returns Mock function that routes requests based on queryName and optionally serviceOptions
+ *
+ * @example
+ * ```tsx
+ * const mockRequest = createQueryMockRouter({
+ *   'GetPipelineRun': { pipelineRun: { name: 'test' } },
+ *   'ListPipelineRun': { pipelineRunList: { items: [] } },
+ *   'ListPipeline:{"namespace":"project","filter":"status=SUCCESS"}': { // Exact serviceOptions match
+ *     pipelineList: { items: [{ name: 'filtered' }] }
+ *   },
+ * });
+ *
+ * const wrapper = getServiceProviderWrapper({ request: mockRequest });
+ * ```
+ */
+export function createQueryMockRouter(
+  responses: Record<string, object | Error>
+): ServiceContextType['request'] {
+  return vi.fn((queryName: string, args: object) => {
+    if (args) {
+      for (const [responseKey, response] of Object.entries(responses)) {
+        if (isEqual(parseArgsFromKey(responseKey), { queryName, args })) {
+          return response instanceof Error ? Promise.reject(response) : Promise.resolve(response);
+        }
+      }
+    }
+
+    const response = responses[queryName];
+    if (response === undefined) {
+      const argsStr = args ? JSON.stringify(args) : 'undefined';
+      return Promise.reject(new Error(`Unexpected query: ${queryName} with args: ${argsStr}`));
+    }
+
+    return response instanceof Error ? Promise.reject(response) : Promise.resolve(response);
+  });
+}
+
+/** Parse query args from a response key like "QueryName:{"key":"value"}" */
+function parseArgsFromKey(key: string): { queryName: string; args: object } | null {
+  const colonIndex = key.indexOf(':');
+  if (colonIndex === -1) return null;
+
+  const queryName = key.slice(0, colonIndex);
+  const argsStr = key.slice(colonIndex + 1);
+
+  try {
+    const args = JSON.parse(argsStr) as object;
+    return { queryName, args };
+  } catch {
+    return null;
+  }
 }

--- a/javascript/packages/core/types/common/studio-types.ts
+++ b/javascript/packages/core/types/common/studio-types.ts
@@ -1,4 +1,5 @@
 import type { ViewConfig } from '#core/components/views/types';
+import type { QueryConfig } from '#core/types/query-types';
 
 /**
  * Represents the different phases in the Michelangelo Studio workflow.
@@ -96,7 +97,7 @@ export interface PhaseEntityConfig<T extends object = object> {
    * For PipelineRunService, root protobuf field name is pipelineRun. This field
    * should be pipelineRun. Query will be ListPipelineRun.
    */
-  service: string;
+  service: QueryConfig['service'];
   /** State controlling whether this entity is interactive */
   state: PhaseEntityState;
   /** List of view configurations for this entity */

--- a/javascript/packages/core/types/query-types.ts
+++ b/javascript/packages/core/types/query-types.ts
@@ -1,3 +1,22 @@
+import { useStudioQuery as _useStudioQuery } from '#core/hooks/use-studio-query';
+
+/**
+ * Configuration for a query that can be used by {@link _useStudioQuery}
+ */
+export interface QueryConfig {
+  /** Lowercase endpoint of the service to query, e.g. 'get', 'list' */
+  endpoint: string;
+
+  /** camelCase name of the service to query, e.g. 'pipelineRun' */
+  service: string;
+
+  /** Options to pass to the service, e.g. 'namespace', 'name' */
+  serviceOptions: Record<string, unknown>;
+
+  /** Options to pass to the query, e.g. 'enabled' */
+  clientOptions?: QueryOptions;
+}
+
 /**
  * Options that can be passed to query hooks.
  */


### PR DESCRIPTION
Introduce DetailViewTablePage component to enable data tables as tabs within entity detail views.

Previous detail view system only supported execution and custom pages, limiting the ability to show related data like filtered pipeline runs or associated resources within entity details.

Onboarded reusable QueryConfig type that contains configuration for queries that can be used by the core useStudioQuery hook.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
