### PR TITLE
Interpolate cell configuration in renderer

### DIFF
--- a/javascript/packages/core/components/cell/renderers/__tests__/default-cell-renderer.tests.tsx
+++ b/javascript/packages/core/components/cell/renderers/__tests__/default-cell-renderer.tests.tsx
@@ -5,6 +5,7 @@ import { CellType } from '#core/components/cell/constants';
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
 import { getIconProviderWrapper } from '#core/test/wrappers/get-icon-provider-wrapper';
+import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
 import { DefaultCellRenderer } from '../default-cell-renderer';
 
 describe('DefaultCellRenderer', () => {
@@ -15,7 +16,7 @@ describe('DefaultCellRenderer', () => {
         record={{}}
         value="test value"
       />,
-      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getRouterWrapper()])
     );
 
     expect(screen.getByText('test value')).toBeInTheDocument();
@@ -29,7 +30,7 @@ describe('DefaultCellRenderer', () => {
         record={{}}
         value="test value"
       />,
-      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getRouterWrapper()])
     );
 
     const cell = screen.getByText('test value');
@@ -43,7 +44,7 @@ describe('DefaultCellRenderer', () => {
         record={{}}
         value={true}
       />,
-      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getRouterWrapper()])
     );
 
     expect(screen.getByText('Is Active')).toBeInTheDocument();
@@ -56,7 +57,7 @@ describe('DefaultCellRenderer', () => {
         record={{}}
         value={undefined}
       />,
-      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getRouterWrapper()])
     );
 
     expect(container).not.toBeEmptyDOMElement();
@@ -65,7 +66,7 @@ describe('DefaultCellRenderer', () => {
   it('should handle null values', () => {
     const { container } = render(
       <DefaultCellRenderer column={{ id: 'test', type: CellType.TEXT }} record={{}} value={null} />,
-      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getRouterWrapper()])
     );
 
     expect(container).not.toBeEmptyDOMElement();
@@ -90,11 +91,41 @@ describe('DefaultCellRenderer', () => {
       buildWrapper([
         getBaseProviderWrapper(),
         getIconProviderWrapper({ icons: { circleI: () => <div>circleI</div> } }),
+        getRouterWrapper(),
       ])
     );
 
     expect(screen.getByText('test value')).toBeInTheDocument();
     await user.hover(screen.getByText('circleI'));
     await screen.findByText('Enhancement tooltip content');
+  });
+
+  it('should resolve interpolations in column config', () => {
+    render(
+      <DefaultCellRenderer
+        column={{
+          id: 'test',
+          type: CellType.TEXT,
+          url: 'https://${row.name}.com',
+          endEnhancer: {
+            content: 'Enhancement tooltip content',
+            type: 'tooltip',
+          },
+        }}
+        record={{ name: 'John Doe' }}
+        value="test value"
+      />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper({ icons: { circleI: () => <div>circleI</div> } }),
+        getRouterWrapper(),
+      ])
+    );
+
+    expect(screen.getByText('test value')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'test value' })).toHaveAttribute(
+      'href',
+      'https://John Doe.com'
+    );
   });
 });

--- a/javascript/packages/core/components/cell/renderers/default-cell-renderer.tsx
+++ b/javascript/packages/core/components/cell/renderers/default-cell-renderer.tsx
@@ -5,26 +5,29 @@ import { cellTooltipHOC } from '#core/components/cell/components/tooltip/cell-to
 import { useCellStyles } from '#core/components/cell/hooks';
 import { CellContainer } from '#core/components/cell/styled-components';
 import { useGetCellRenderer } from '#core/components/cell/use-get-cell-renderer';
+import { useInterpolationResolver } from '#core/interpolation/use-interpolation-resolver';
 
 import type { Cell, CellRendererProps } from '#core/components/cell/types';
 
 export function DefaultCellRenderer(props: CellRendererProps<unknown, Cell>) {
   const [css] = useStyletron();
   const { column, record } = props;
-  const style = useCellStyles({ record, style: column.style });
+  const resolver = useInterpolationResolver();
+  const resolvedColumn = resolver(column, { row: record });
+  const style = useCellStyles({ record, style: resolvedColumn.style });
 
   const getCellRenderer = useGetCellRenderer();
   const ColumnRendererComponent = getCellRenderer(props);
-  const Component = column.tooltip
+  const Component = resolvedColumn.tooltip
     ? cellTooltipHOC(ColumnRendererComponent)
     : ColumnRendererComponent;
 
   return (
     <CellContainer>
       <div className={css(style)}>
-        <Component {...props} CellComponent={DefaultCellRenderer} />
+        <Component {...props} column={resolvedColumn} CellComponent={DefaultCellRenderer} />
       </div>
-      <CellEnhancer endEnhancer={column.endEnhancer} />
+      <CellEnhancer endEnhancer={resolvedColumn.endEnhancer} />
     </CellContainer>
   );
 }

--- a/javascript/packages/core/components/cell/renderers/multi/__tests__/multi-cell.tests.tsx
+++ b/javascript/packages/core/components/cell/renderers/multi/__tests__/multi-cell.tests.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from '@testing-library/react';
 
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getIconProviderWrapper } from '#core/test/wrappers/get-icon-provider-wrapper';
+import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
 import { MultiCell } from '../multi-cell';
 
 describe('MultiCell', () => {
@@ -24,7 +26,7 @@ describe('MultiCell', () => {
         record={mockRecord}
         value={undefined}
       />,
-      { wrapper: getIconProviderWrapper() }
+      buildWrapper([getIconProviderWrapper(), getRouterWrapper()])
     );
 
     expect(screen.getByText('—')).toBeInTheDocument();
@@ -40,7 +42,7 @@ describe('MultiCell', () => {
         record={mockRecord}
         value={undefined}
       />,
-      { wrapper: getIconProviderWrapper() }
+      buildWrapper([getIconProviderWrapper(), getRouterWrapper()])
     );
 
     expect(screen.getByText('Test Pipeline')).toBeInTheDocument();
@@ -58,7 +60,7 @@ describe('MultiCell', () => {
         record={mockRecord}
         value={undefined}
       />,
-      { wrapper: getIconProviderWrapper() }
+      buildWrapper([getIconProviderWrapper(), getRouterWrapper()])
     );
 
     expect(screen.getAllByTitle('Check').length).toBeGreaterThan(0);
@@ -74,7 +76,7 @@ describe('MultiCell', () => {
         record={mockRecord}
         value={undefined}
       />,
-      { wrapper: getIconProviderWrapper() }
+      buildWrapper([getIconProviderWrapper(), getRouterWrapper()])
     );
 
     expect(screen.getByText('Test Description')).toBeInTheDocument();
@@ -91,7 +93,7 @@ describe('MultiCell', () => {
         record={mockRecord}
         value={undefined}
       />,
-      { wrapper: getIconProviderWrapper() }
+      buildWrapper([getIconProviderWrapper(), getRouterWrapper()])
     );
 
     expect(screen.getByText('—')).toBeInTheDocument();

--- a/javascript/packages/core/components/row/__tests__/row.test.tsx
+++ b/javascript/packages/core/components/row/__tests__/row.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen } from '@testing-library/react';
 
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
 import { Row } from '../row';
 
 describe('Row', () => {
@@ -16,13 +18,13 @@ describe('Row', () => {
   };
 
   it('renders skeleton loaders when loading is true', () => {
-    render(<Row items={mockItems} loading={true} />);
+    render(<Row items={mockItems} loading={true} />, buildWrapper([getRouterWrapper()]));
     const skeletons = screen.getAllByTestId('loading');
     expect(skeletons).toHaveLength(mockItems.length);
   });
 
   it('filters out empty items when hideEmpty is true', () => {
-    render(<Row items={mockItems} record={mockRecord} />);
+    render(<Row items={mockItems} record={mockRecord} />, buildWrapper([getRouterWrapper()]));
     expect(screen.getByText('John Doe')).toBeInTheDocument();
     expect(screen.getByText('30')).toBeInTheDocument();
     expect(screen.queryByText('Email')).not.toBeInTheDocument();
@@ -30,7 +32,10 @@ describe('Row', () => {
 
   it('renders all items when hideEmpty is false', () => {
     const itemsWithoutHideEmpty = mockItems.map((item) => ({ ...item, hideEmpty: false }));
-    render(<Row items={itemsWithoutHideEmpty} record={mockRecord} />);
+    render(
+      <Row items={itemsWithoutHideEmpty} record={mockRecord} />,
+      buildWrapper([getRouterWrapper()])
+    );
     expect(screen.getByText('John Doe')).toBeInTheDocument();
     expect(screen.getByText('30')).toBeInTheDocument();
     expect(screen.getByText('Email')).toBeInTheDocument();
@@ -49,7 +54,7 @@ describe('Row', () => {
       },
     };
 
-    render(<Row items={mockItems} overrides={overrides} />);
+    render(<Row items={mockItems} overrides={overrides} />, buildWrapper([getRouterWrapper()]));
     expect(screen.getByTestId('custom-container')).toBeInTheDocument();
   });
 
@@ -61,7 +66,10 @@ describe('Row', () => {
       },
     };
 
-    render(<Row items={itemsWithAccessor} record={nestedRecord} />);
+    render(
+      <Row items={itemsWithAccessor} record={nestedRecord} />,
+      buildWrapper([getRouterWrapper()])
+    );
     expect(screen.getByText('John Doe')).toBeInTheDocument();
   });
 });

--- a/javascript/packages/core/components/row/components/__tests__/row-item.test.tsx
+++ b/javascript/packages/core/components/row/components/__tests__/row-item.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen } from '@testing-library/react';
 
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
 import { RowItem } from '../row-item';
 
 import type { CellRenderer } from '#core/components/cell/types';
@@ -17,7 +19,7 @@ describe('RowItem', () => {
   };
 
   it('renders with DefaultCellRenderer when no CellComponent is provided', () => {
-    render(<RowItem item={mockItem} record={mockRecord} />);
+    render(<RowItem item={mockItem} record={mockRecord} />, buildWrapper([getRouterWrapper()]));
 
     expect(screen.getByText('Name')).toBeInTheDocument();
     expect(screen.getByText('John Doe')).toBeInTheDocument();
@@ -28,7 +30,10 @@ describe('RowItem', () => {
       <span data-testid="custom-cell">Custom: {value}</span>
     );
 
-    render(<RowItem item={mockItem} record={mockRecord} CellComponent={CustomCellRenderer} />);
+    render(
+      <RowItem item={mockItem} record={mockRecord} CellComponent={CustomCellRenderer} />,
+      buildWrapper([getRouterWrapper()])
+    );
 
     expect(screen.getByText('Name')).toBeInTheDocument();
     expect(screen.getByText('Custom: John Doe')).toBeInTheDocument();
@@ -47,7 +52,10 @@ describe('RowItem', () => {
       },
     };
 
-    render(<RowItem item={itemWithAccessor} record={recordWithNestedData} />);
+    render(
+      <RowItem item={itemWithAccessor} record={recordWithNestedData} />,
+      buildWrapper([getRouterWrapper()])
+    );
 
     expect(screen.getByText('Jane Smith')).toBeInTheDocument();
   });

--- a/javascript/packages/core/components/views/execution/components/task-details/__tests__/task-header.test.tsx
+++ b/javascript/packages/core/components/views/execution/components/task-details/__tests__/task-header.test.tsx
@@ -3,6 +3,7 @@ import { ArrowUp, Check, Delete } from 'baseui/icon';
 
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getIconProviderWrapper } from '#core/test/wrappers/get-icon-provider-wrapper';
+import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
 import { TASK_STATE } from '../../../constants';
 import { createTask } from '../__fixtures__/task-details-fixtures';
 import { TaskHeader } from '../task-header';
@@ -25,6 +26,7 @@ describe('TaskHeader', () => {
             arrowCircular: ArrowUp,
           },
         }),
+        getRouterWrapper(),
       ])
     );
 
@@ -43,7 +45,7 @@ describe('TaskHeader', () => {
       },
     });
 
-    render(<TaskHeader task={task} metadata={mockMetadata} />);
+    render(<TaskHeader task={task} metadata={mockMetadata} />, buildWrapper([getRouterWrapper()]));
 
     expect(screen.getByText('Task with Metadata')).toBeInTheDocument();
     expect(screen.getByText('Status')).toBeInTheDocument();
@@ -102,7 +104,7 @@ describe('TaskHeader', () => {
       record: { displayName: 'Incomplete Task' }, // Missing status, duration, startTime
     });
 
-    render(<TaskHeader task={task} metadata={mockMetadata} />);
+    render(<TaskHeader task={task} metadata={mockMetadata} />, buildWrapper([getRouterWrapper()]));
 
     expect(screen.getByText('Incomplete Task')).toBeInTheDocument();
 

--- a/javascript/packages/core/components/views/execution/components/task-details/renderers/__tests__/task-body-metadata.test.tsx
+++ b/javascript/packages/core/components/views/execution/components/task-details/renderers/__tests__/task-body-metadata.test.tsx
@@ -2,6 +2,8 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { CellType } from '#core/components/cell/constants';
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
 import { TaskBodyMetadata } from '../task-body-metadata';
 
 describe('TaskBodyMetadata', () => {
@@ -34,7 +36,10 @@ describe('TaskBodyMetadata', () => {
       startTime: '2025-01-01T08:00:00Z',
     };
 
-    render(<TaskBodyMetadata label="Task Metadata" value={mockData} cells={mockCells} />);
+    render(
+      <TaskBodyMetadata label="Task Metadata" value={mockData} cells={mockCells} />,
+      buildWrapper([getRouterWrapper()])
+    );
 
     const accordionButton = screen.getByRole('button', { name: /Task Metadata/ });
     expect(accordionButton).toBeInTheDocument();
@@ -48,7 +53,10 @@ describe('TaskBodyMetadata', () => {
   it('should handle undefined value gracefully', async () => {
     const user = userEvent.setup();
 
-    render(<TaskBodyMetadata label="Empty Metadata" value={undefined} cells={mockCells} />);
+    render(
+      <TaskBodyMetadata label="Empty Metadata" value={undefined} cells={mockCells} />,
+      buildWrapper([getRouterWrapper()])
+    );
 
     const accordionButton = screen.getByRole('button', { name: /Empty Metadata/ });
     await user.click(accordionButton);
@@ -60,7 +68,10 @@ describe('TaskBodyMetadata', () => {
     const user = userEvent.setup();
     const mockData = { status: 'Success' };
 
-    render(<TaskBodyMetadata label="No Cells" value={mockData} cells={[]} />);
+    render(
+      <TaskBodyMetadata label="No Cells" value={mockData} cells={[]} />,
+      buildWrapper([getRouterWrapper()])
+    );
 
     const accordionButton = screen.getByRole('button', { name: /No Cells/ });
     expect(accordionButton).toBeInTheDocument();
@@ -74,7 +85,10 @@ describe('TaskBodyMetadata', () => {
       status: 'Running',
     };
 
-    render(<TaskBodyMetadata label="Partial Metadata" value={partialData} cells={mockCells} />);
+    render(
+      <TaskBodyMetadata label="Partial Metadata" value={partialData} cells={mockCells} />,
+      buildWrapper([getRouterWrapper()])
+    );
 
     const accordionButton = screen.getByRole('button', { name: /Partial Metadata/ });
     await user.click(accordionButton);
@@ -104,7 +118,10 @@ describe('TaskBodyMetadata', () => {
 
     const stateData = { state: 'SUCCESS' };
 
-    render(<TaskBodyMetadata label="State Metadata" value={stateData} cells={cellsWithStates} />);
+    render(
+      <TaskBodyMetadata label="State Metadata" value={stateData} cells={cellsWithStates} />,
+      buildWrapper([getRouterWrapper()])
+    );
 
     const accordionButton = screen.getByRole('button', { name: /State Metadata/ });
     await user.click(accordionButton);


### PR DESCRIPTION
Cell configurations (i.e., detail view metadata) now support resolving interpolations. This unblocks some removal of internal Uber code where a cell renderer component is maintained for interpolation purposes.

**What type of PR is this? (check all applicable)**
- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
