### PR TITLE
Replace build-time environment config with runtime injection

### DIFF
--- a/javascript/app/package.json
+++ b/javascript/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@michelangelo/app",
   "license": "UNLICENSED",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "scripts": {
     "build": "vite build --config vite.config.ts",

--- a/javascript/app/public/config.json
+++ b/javascript/app/public/config.json
@@ -1,0 +1,3 @@
+{
+  "apiBaseUrl": "http://localhost:8081"
+}

--- a/javascript/packages/rpc/__tests__/runtime-config.test.ts
+++ b/javascript/packages/rpc/__tests__/runtime-config.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { getApiConfig } from '../runtime-config';
+import { getRuntimeConfig } from '../runtime-config';
 
 // Mock fetch globally
 global.fetch = vi.fn();
@@ -27,16 +27,16 @@ describe('getApiConfig', () => {
       json: () => Promise.resolve({ apiBaseUrl: 'http://production-envoy:8081' }),
     } as Response);
 
-    const result = await getApiConfig();
+    const result = await getRuntimeConfig();
 
-    expect(result).toBe('http://production-envoy:8081');
+    expect(result.apiBaseUrl).toBe('http://production-envoy:8081');
     expect(mockFetch).toHaveBeenCalledWith('/config.json');
   });
 
   it('should throw error when fetch fails with network error', async () => {
     mockFetch.mockRejectedValueOnce(new Error('Network error'));
 
-    await expect(getApiConfig()).rejects.toThrow(
+    await expect(getRuntimeConfig()).rejects.toThrow(
       'Failed to load runtime configuration. Check that config.json is properly mounted.'
     );
   });
@@ -47,7 +47,7 @@ describe('getApiConfig', () => {
       status: 404,
     } as Response);
 
-    await expect(getApiConfig()).rejects.toThrow(
+    await expect(getRuntimeConfig()).rejects.toThrow(
       'Failed to load runtime configuration. Check that config.json is properly mounted.'
     );
   });
@@ -58,7 +58,7 @@ describe('getApiConfig', () => {
       status: 500,
     } as Response);
 
-    await expect(getApiConfig()).rejects.toThrow(
+    await expect(getRuntimeConfig()).rejects.toThrow(
       'Failed to load runtime configuration. Check that config.json is properly mounted.'
     );
   });
@@ -69,7 +69,7 @@ describe('getApiConfig', () => {
       json: () => Promise.reject(new SyntaxError('Unexpected token')),
     } as Response);
 
-    await expect(getApiConfig()).rejects.toThrow(
+    await expect(getRuntimeConfig()).rejects.toThrow(
       'Failed to load runtime configuration. Check that config.json contains valid JSON.'
     );
   });
@@ -80,7 +80,7 @@ describe('getApiConfig', () => {
       json: () => Promise.resolve({ someOtherField: 'value' }),
     } as Response);
 
-    await expect(getApiConfig()).rejects.toThrow(
+    await expect(getRuntimeConfig()).rejects.toThrow(
       'Failed to load runtime configuration. Check that config.json contains apiBaseUrl field.'
     );
   });
@@ -88,7 +88,7 @@ describe('getApiConfig', () => {
   it('should throw specific error for network connectivity issues', async () => {
     mockFetch.mockRejectedValueOnce(new TypeError('Failed to fetch'));
 
-    await expect(getApiConfig()).rejects.toThrow(
+    await expect(getRuntimeConfig()).rejects.toThrow(
       'Failed to load runtime configuration. Check network connectivity.'
     );
   });

--- a/javascript/packages/rpc/__tests__/runtime-config.test.ts
+++ b/javascript/packages/rpc/__tests__/runtime-config.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getApiConfig } from '../runtime-config';
+
+// Mock fetch globally
+global.fetch = vi.fn();
+const mockFetch = fetch as ReturnType<typeof vi.fn>;
+
+// Mock window.location
+const mockLocation = {
+  hostname: 'localhost',
+};
+
+Object.defineProperty(global, 'window', {
+  value: { location: mockLocation },
+  writable: true,
+});
+
+describe('getApiConfig', () => {
+  beforeEach(() => {
+    mockFetch.mockClear();
+  });
+
+  it('should return apiBaseUrl from config.json when fetch succeeds', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ apiBaseUrl: 'http://production-envoy:8081' }),
+    } as Response);
+
+    const result = await getApiConfig();
+
+    expect(result).toBe('http://production-envoy:8081');
+    expect(mockFetch).toHaveBeenCalledWith('/config.json');
+  });
+
+  it('should throw error when fetch fails with network error', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+    await expect(getApiConfig()).rejects.toThrow(
+      'Failed to load runtime configuration. Check that config.json is properly mounted.'
+    );
+  });
+
+  it('should throw error when config.json returns 404', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+    } as Response);
+
+    await expect(getApiConfig()).rejects.toThrow(
+      'Failed to load runtime configuration. Check that config.json is properly mounted.'
+    );
+  });
+
+  it('should throw error when config.json returns 500', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    } as Response);
+
+    await expect(getApiConfig()).rejects.toThrow(
+      'Failed to load runtime configuration. Check that config.json is properly mounted.'
+    );
+  });
+
+  it('should throw specific error when JSON parsing fails', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.reject(new SyntaxError('Unexpected token')),
+    } as Response);
+
+    await expect(getApiConfig()).rejects.toThrow(
+      'Failed to load runtime configuration. Check that config.json contains valid JSON.'
+    );
+  });
+
+  it('should throw specific error when apiBaseUrl field is missing', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ someOtherField: 'value' }),
+    } as Response);
+
+    await expect(getApiConfig()).rejects.toThrow(
+      'Failed to load runtime configuration. Check that config.json contains apiBaseUrl field.'
+    );
+  });
+
+  it('should throw specific error for network connectivity issues', async () => {
+    mockFetch.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+
+    await expect(getApiConfig()).rejects.toThrow(
+      'Failed to load runtime configuration. Check network connectivity.'
+    );
+  });
+});

--- a/javascript/packages/rpc/handlers.ts
+++ b/javascript/packages/rpc/handlers.ts
@@ -1,26 +1,41 @@
-import { SERVICES } from './services';
+import { getServices } from './services';
 import { ExtractUnaryRpc } from './types';
 
-export const RPC_HANDLERS = {
-  ListProject: SERVICES.ProjectService.listProject as ExtractUnaryRpc<
-    typeof SERVICES.ProjectService.listProject
-  >,
-  GetProject: SERVICES.ProjectService.getProject as ExtractUnaryRpc<
-    typeof SERVICES.ProjectService.getProject
-  >,
-  ListPipeline: SERVICES.PipelineService.listPipeline as ExtractUnaryRpc<
-    typeof SERVICES.PipelineService.listPipeline
-  >,
-  ListPipelineRun: SERVICES.PipelineRunService.listPipelineRun as ExtractUnaryRpc<
-    typeof SERVICES.PipelineRunService.listPipelineRun
-  >,
-  GetPipelineRun: SERVICES.PipelineRunService.getPipelineRun as ExtractUnaryRpc<
-    typeof SERVICES.PipelineRunService.getPipelineRun
-  >,
-  ListTriggerRun: SERVICES.TriggerRunService.listTriggerRun as ExtractUnaryRpc<
-    typeof SERVICES.TriggerRunService.listTriggerRun
-  >,
-  GetTriggerRun: SERVICES.TriggerRunService.getTriggerRun as ExtractUnaryRpc<
-    typeof SERVICES.TriggerRunService.getTriggerRun
-  >,
-} as const;
+let handlersPromise: Promise<Awaited<ReturnType<typeof createHandlers>>> | null = null;
+
+async function createHandlers() {
+  const services = await getServices();
+
+  return {
+    ListProject: services.ProjectService.listProject as ExtractUnaryRpc<
+      typeof services.ProjectService.listProject
+    >,
+    GetProject: services.ProjectService.getProject as ExtractUnaryRpc<
+      typeof services.ProjectService.getProject
+    >,
+    ListPipeline: services.PipelineService.listPipeline as ExtractUnaryRpc<
+      typeof services.PipelineService.listPipeline
+    >,
+    ListPipelineRun: services.PipelineRunService.listPipelineRun as ExtractUnaryRpc<
+      typeof services.PipelineRunService.listPipelineRun
+    >,
+    GetPipelineRun: services.PipelineRunService.getPipelineRun as ExtractUnaryRpc<
+      typeof services.PipelineRunService.getPipelineRun
+    >,
+    ListTriggerRun: services.TriggerRunService.listTriggerRun as ExtractUnaryRpc<
+      typeof services.TriggerRunService.listTriggerRun
+    >,
+    GetTriggerRun: services.TriggerRunService.getTriggerRun as ExtractUnaryRpc<
+      typeof services.TriggerRunService.getTriggerRun
+    >,
+  } as const;
+}
+
+/** Gets the RPC handlers, initializing them with runtime configuration on first call. */
+export async function getRpcHandlers() {
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+  if (!handlersPromise) {
+    handlersPromise = createHandlers();
+  }
+  return handlersPromise;
+}

--- a/javascript/packages/rpc/request.ts
+++ b/javascript/packages/rpc/request.ts
@@ -1,4 +1,4 @@
-import { RPC_HANDLERS } from './handlers';
+import { getRpcHandlers } from './handlers';
 import { OmitTypeName, RpcHandlerType } from './types';
 
 /**
@@ -15,9 +15,10 @@ import { OmitTypeName, RpcHandlerType } from './types';
  * // response is of type ListProjectResponse
  * ```
  */
-export function request<RpcId extends keyof RpcHandlerType>(
+export async function request<RpcId extends keyof RpcHandlerType>(
   rpcId: RpcId,
   args: OmitTypeName<Parameters<RpcHandlerType[RpcId]>[0]>
-): ReturnType<RpcHandlerType[RpcId]> {
-  return RPC_HANDLERS[rpcId](args) as ReturnType<RpcHandlerType[RpcId]>;
+): Promise<Awaited<ReturnType<RpcHandlerType[RpcId]>>> {
+  const handlers = await getRpcHandlers();
+  return (await handlers[rpcId](args)) as Awaited<ReturnType<RpcHandlerType[RpcId]>>;
 }

--- a/javascript/packages/rpc/runtime-config.ts
+++ b/javascript/packages/rpc/runtime-config.ts
@@ -1,0 +1,46 @@
+interface RuntimeConfig {
+  apiBaseUrl: string;
+}
+
+// Fetches runtime configuration from /config.json.
+export async function getApiConfig(): Promise<string> {
+  let response: Response;
+  try {
+    response = await fetch('/config.json');
+  } catch (error) {
+    if (error instanceof TypeError && error.message.includes('fetch')) {
+      console.error(`Config network error: ${error.message}`);
+      throw createConfigError('Check network connectivity.', { cause: error });
+    }
+    console.error(
+      `Config fetch error: ${error instanceof Error ? error.message : 'Unknown error'}`
+    );
+    throw createConfigError('Check that config.json is properly mounted.', { cause: error });
+  }
+
+  if (!response.ok) {
+    console.error(`Config fetch failed: ${response.status} ${response.statusText}`);
+    throw createConfigError('Check that config.json is properly mounted.', { cause: response });
+  }
+
+  let config: RuntimeConfig;
+  try {
+    config = (await response.json()) as RuntimeConfig;
+  } catch (error) {
+    console.error(
+      `Config JSON parsing failed: ${error instanceof Error ? error.message : 'Invalid JSON'}`
+    );
+    throw createConfigError('Check that config.json contains valid JSON.', { cause: error });
+  }
+
+  if (!config.apiBaseUrl) {
+    console.error('Config missing apiBaseUrl field', JSON.stringify(config));
+    throw createConfigError('Check that config.json contains apiBaseUrl field.');
+  }
+
+  return config.apiBaseUrl;
+}
+
+function createConfigError(reason: string, options?: ErrorOptions): Error {
+  return new Error(`Failed to load runtime configuration. ${reason}`, options);
+}

--- a/javascript/packages/rpc/runtime-config.ts
+++ b/javascript/packages/rpc/runtime-config.ts
@@ -3,7 +3,7 @@ interface RuntimeConfig {
 }
 
 // Fetches runtime configuration from /config.json.
-export async function getApiConfig(): Promise<string> {
+export async function getRuntimeConfig(): Promise<RuntimeConfig> {
   let response: Response;
   try {
     response = await fetch('/config.json');
@@ -38,7 +38,7 @@ export async function getApiConfig(): Promise<string> {
     throw createConfigError('Check that config.json contains apiBaseUrl field.');
   }
 
-  return config.apiBaseUrl;
+  return config;
 }
 
 function createConfigError(reason: string, options?: ErrorOptions): Error {

--- a/javascript/packages/rpc/services.ts
+++ b/javascript/packages/rpc/services.ts
@@ -5,6 +5,7 @@ import { PipelineRunService } from './gen/michelangelo/api/v2/pipeline_run_svc_p
 import { PipelineService } from './gen/michelangelo/api/v2/pipeline_svc_pb';
 import { ProjectService } from './gen/michelangelo/api/v2/project_svc_pb';
 import { TriggerRunService } from './gen/michelangelo/api/v2/trigger_run_svc_pb';
+import { getApiConfig } from './runtime-config';
 
 // This interceptor is used to set the headers for the RPC request to
 // be compatible with the Michelangelo API yarpc server.
@@ -18,17 +19,41 @@ const callerInterceptor: Interceptor = (next) => async (req) => {
   return await next(req);
 };
 
-// This transport is used to connect to the Envoy proxy that proxies gRPC web requests
-// to gRPC services.
-const transport = createGrpcWebTransport({
-  baseUrl: 'http://localhost:8081',
-  interceptors: [callerInterceptor],
-  useBinaryFormat: true,
-});
+type Services = {
+  ProjectService: ReturnType<typeof createClient<typeof ProjectService>>;
+  PipelineService: ReturnType<typeof createClient<typeof PipelineService>>;
+  PipelineRunService: ReturnType<typeof createClient<typeof PipelineRunService>>;
+  TriggerRunService: ReturnType<typeof createClient<typeof TriggerRunService>>;
+};
 
-export const SERVICES = {
-  ProjectService: createClient(ProjectService, transport),
-  PipelineService: createClient(PipelineService, transport),
-  PipelineRunService: createClient(PipelineRunService, transport),
-  TriggerRunService: createClient(TriggerRunService, transport),
-} as const;
+let servicesPromise: Promise<Services> | null = null;
+
+async function createServices(): Promise<Services> {
+  const baseUrl = await getApiConfig();
+
+  // This transport is used to connect to the Envoy proxy that proxies gRPC web requests
+  // to gRPC services.
+  const transport = createGrpcWebTransport({
+    baseUrl,
+    interceptors: [callerInterceptor],
+    useBinaryFormat: true,
+  });
+
+  return {
+    ProjectService: createClient(ProjectService, transport),
+    PipelineService: createClient(PipelineService, transport),
+    PipelineRunService: createClient(PipelineRunService, transport),
+    TriggerRunService: createClient(TriggerRunService, transport),
+  } as const;
+}
+
+/**
+ * Gets the RPC services, initializing them with runtime configuration on first call.
+ */
+export async function getServices(): Promise<Services> {
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+  if (!servicesPromise) {
+    servicesPromise = createServices();
+  }
+  return servicesPromise;
+}

--- a/javascript/packages/rpc/services.ts
+++ b/javascript/packages/rpc/services.ts
@@ -5,7 +5,7 @@ import { PipelineRunService } from './gen/michelangelo/api/v2/pipeline_run_svc_p
 import { PipelineService } from './gen/michelangelo/api/v2/pipeline_svc_pb';
 import { ProjectService } from './gen/michelangelo/api/v2/project_svc_pb';
 import { TriggerRunService } from './gen/michelangelo/api/v2/trigger_run_svc_pb';
-import { getApiConfig } from './runtime-config';
+import { getRuntimeConfig } from './runtime-config';
 
 // This interceptor is used to set the headers for the RPC request to
 // be compatible with the Michelangelo API yarpc server.
@@ -29,12 +29,12 @@ type Services = {
 let servicesPromise: Promise<Services> | null = null;
 
 async function createServices(): Promise<Services> {
-  const baseUrl = await getApiConfig();
+  const { apiBaseUrl } = await getRuntimeConfig();
 
   // This transport is used to connect to the Envoy proxy that proxies gRPC web requests
   // to gRPC services.
   const transport = createGrpcWebTransport({
-    baseUrl,
+    baseUrl: apiBaseUrl,
     interceptors: [callerInterceptor],
     useBinaryFormat: true,
   });

--- a/javascript/packages/rpc/types.ts
+++ b/javascript/packages/rpc/types.ts
@@ -1,11 +1,11 @@
 import { Message } from '@bufbuild/protobuf';
 
-import { RPC_HANDLERS } from './handlers';
+import { getRpcHandlers } from './handlers';
 
 /**
- * @see {@link RPC_HANDLERS}
+ * @see {@link getRpcHandlers}
  */
-export type RpcHandlerType = typeof RPC_HANDLERS;
+export type RpcHandlerType = Awaited<ReturnType<typeof getRpcHandlers>>;
 
 /**
  * @description

--- a/javascript/tsconfig.base.json
+++ b/javascript/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "target": "ES2022",
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "module": "ESNext",
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/javascript/tsconfig.json
+++ b/javascript/tsconfig.json
@@ -1,9 +1,9 @@
 {
-  "files": [],
-  "references": [
-    { "path": "./app/tsconfig.app.json" },
-    { "path": "./app/tsconfig.node.json" },
-    { "path": "./packages/core" },
-    { "path": "./packages/rpc" }
-  ]
+  "extends": "./tsconfig.base.json",
+  "include": ["vitest.config.ts"],
+  "compilerOptions": {
+    "types": ["vitest/globals"],
+    "noEmit": true,
+    "moduleResolution": "bundler"
+  }
 }

--- a/python/michelangelo/cli/sandbox/resources/michelangelo-ui.yaml
+++ b/python/michelangelo/cli/sandbox/resources/michelangelo-ui.yaml
@@ -1,3 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ui-config
+data:
+  config.json: |
+    {
+      "apiBaseUrl": "http://localhost:8081"
+    }
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -20,6 +30,10 @@ spec:
         imagePullPolicy: Always
         ports:
         - containerPort: 80
+        volumeMounts:
+        - name: ui-config
+          mountPath: /usr/share/nginx/html/config.json
+          subPath: config.json
         resources:
           requests:
             memory: "128Mi"
@@ -27,6 +41,10 @@ spec:
           limits:
             memory: "256Mi"
             cpu: "200m"
+      volumes:
+      - name: ui-config
+        configMap:
+          name: ui-config
 ---
 apiVersion: v1
 kind: Service

--- a/python/michelangelo/cli/sandbox/resources/michelangelo-ui.yaml
+++ b/python/michelangelo/cli/sandbox/resources/michelangelo-ui.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: ui-config
+  name: public-config
 data:
   config.json: |
     {
@@ -31,7 +31,7 @@ spec:
         ports:
         - containerPort: 80
         volumeMounts:
-        - name: ui-config
+        - name: public-config
           mountPath: /usr/share/nginx/html/config.json
           subPath: config.json
         resources:
@@ -42,9 +42,9 @@ spec:
             memory: "256Mi"
             cpu: "200m"
       volumes:
-      - name: ui-config
+      - name: public-config
         configMap:
-          name: ui-config
+          name: public-config
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Migrate RPC service initialization from build-time localhost:8081 hardcoding to runtime config.json fetching. Convert synchronous service creation to async initialization with singleton pattern.

Previous approach hardcoded API endpoints at build time, preventing operators from configuring different envoy proxy endpoints without rebuilding Docker images. This blocked flexible Kubernetes deployments where the same image needs to route to different backend services.

New runtime configuration fetches /config.json on first RPC call, enabling ConfigMap-based endpoint configuration while preserving localhost:8081 behavior for local development. Async refactoring aligns request() function implementation with existing usage patterns in use-studio-query hook, which was already calling request with await.

Singleton caching ensures configuration is fetched once per session with comprehensive error handling providing diagnostic messages for deployment troubleshooting.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Docker UI configured with localhost:8081 API URL
<img width="920" height="565" alt="docker-local-fetch" src="https://github.com/user-attachments/assets/3e2a8aa1-0bef-4814-84e9-1576f89cfdd6" />

<img width="920" height="565" alt="docker-local-8081" src="https://github.com/user-attachments/assets/ec0f2eb3-5c3a-469b-99e7-80b020aa1c09" />

Docker UI configured with envoy:8081 API URL (fails to query, since envoy is listening on localhost:8081)
<img width="920" height="565" alt="envoy-8081-fetch" src="https://github.com/user-attachments/assets/fe43f18a-b1e8-474d-a55f-dcc44ee38f2c" />

<img width="920" height="565" alt="envoy-8081" src="https://github.com/user-attachments/assets/8ac917c4-b058-4d42-a654-66482150067c" />

Local dev (yarn dev) finds localhost:8081 in app/public/config.json. Maintains existing behavior
<img width="920" height="565" alt="local-8081" src="https://github.com/user-attachments/assets/c0e2bf76-4a8f-4416-a32d-99812235c9b6" />

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
For local development, developers leveraging michelangelo-ui docker could observe empty data due to inability for michelangelo-ui to access michelangelo-apiserver

For local development, developers leveraging vite dev mode could observer empty data due to inability for vite application to access michelangelo-apiserver

For production deployments, e.g. Grab, users could observe empty data due to inability for michelangelo-ui to access michelangelo-apiserver

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
