### PR TITLE
Display task metadata in for subtasks

### DIFF
--- a/javascript/packages/core/components/views/execution/__tests__/execution.test.tsx
+++ b/javascript/packages/core/components/views/execution/__tests__/execution.test.tsx
@@ -155,6 +155,14 @@ describe('Execution view', () => {
             state: 'PIPELINE_RUN_STEP_STATE_FAILED',
             duration: '5m 30s',
             startTime: '2025-01-01T08:00:00Z',
+            subSteps: [
+              buildStep({
+                displayName: 'Subtask 1',
+                state: 'PIPELINE_RUN_STEP_STATE_SUCCEEDED',
+                duration: '1m 30s',
+                startTime: '2025-01-01T08:00:00Z',
+              }),
+            ],
           }),
         ],
       },
@@ -168,9 +176,16 @@ describe('Execution view', () => {
     // Should render task name in both sections (Overview + Details)
     expect(screen.getAllByText('Build Task')).toHaveLength(2);
 
+    // Should render parent task metadata
     expect(screen.getByText('Failed')).toBeInTheDocument();
     expect(screen.getByText('5m 30s')).toBeInTheDocument();
-    expect(screen.getByText('Started')).toBeInTheDocument();
+
+    // Should render subtask metadata
+    expect(screen.getByText('Success')).toBeInTheDocument();
+    expect(screen.getByText('1m 30s')).toBeInTheDocument();
+
+    // Shown for both parent and subtask
+    expect(screen.getAllByText('Started')).toHaveLength(2);
   });
 
   it('should handle empty execution data gracefully', () => {

--- a/javascript/packages/core/components/views/execution/components/task-details/task-body.tsx
+++ b/javascript/packages/core/components/views/execution/components/task-details/task-body.tsx
@@ -16,7 +16,7 @@ import type { TaskBodyProps } from './types';
 
 export function TaskBody<TTaskRecord extends object>(props: TaskBodyProps<TTaskRecord>) {
   const [css, theme] = useStyletron();
-  const { task, bodySchema, overrides } = props;
+  const { task, bodySchema, overrides, metadata } = props;
   const { subTasks } = task;
   const resolver = useInterpolationResolver();
 
@@ -32,7 +32,13 @@ export function TaskBody<TTaskRecord extends object>(props: TaskBodyProps<TTaskR
           />
         </Box>
         {subTasks.map((task, index) => (
-          <TaskDetails key={index} task={task} bodySchema={bodySchema} overrides={overrides} />
+          <TaskDetails
+            key={index}
+            task={task}
+            bodySchema={bodySchema}
+            overrides={overrides}
+            metadata={metadata}
+          />
         ))}
       </TaskContentStack>
     );

--- a/javascript/packages/core/components/views/execution/components/task-details/task-details.tsx
+++ b/javascript/packages/core/components/views/execution/components/task-details/task-details.tsx
@@ -28,7 +28,7 @@ export function TaskDetails<TTaskRecord extends object = object>(
         title={<TaskHeader task={task} metadata={metadata} />}
         initialState={{ expanded: task.focused }}
       >
-        <TaskBody task={task} bodySchema={bodySchema} overrides={overrides} />
+        <TaskBody task={task} bodySchema={bodySchema} metadata={metadata} overrides={overrides} />
       </TaskPanel>
     );
   }

--- a/javascript/packages/core/components/views/execution/components/task-details/types.ts
+++ b/javascript/packages/core/components/views/execution/components/task-details/types.ts
@@ -17,6 +17,7 @@ export type TaskHeaderProps<TTaskRecord extends object = object> = {
 
 export type TaskBodyProps<TTaskRecord extends object = object> = {
   task: Task<TTaskRecord>;
+  metadata?: Cell[];
   bodySchema?: TaskBodySchema[];
   overrides?: ExecutionOverrides<TTaskRecord>;
 };


### PR DESCRIPTION
The metadata configuration is now fully propagated throughout the Execution
components, which ensures that information like logs appears for sub tasks
in addition to parent tasks.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
<img width="1392" height="1105" alt="Screenshot 2025-09-22 at 15 20 49" src="https://github.com/user-attachments/assets/9424974b-4674-4e7d-b3ba-77efcbd6443d" />

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
