### PR TITLE
Change mactl syntax to resource-action order

### DIFF
--- a/python/michelangelo/cli/mactl/mactl.py
+++ b/python/michelangelo/cli/mactl/mactl.py
@@ -807,7 +807,10 @@ def parse_args() -> tuple[list[str], dict[str, list[str]]]:
 def handle_args() -> tuple[str, str, dict[str, list[str]]]:
     args, kwargs = parse_args()
 
-    user_command_action = args[0]
+    # New syntax: mactl <resource> <action> [options]
+    user_command_crd = args[0]
+    user_command_action = args[1]
+
     assert user_command_action in [
         "get",
         "create",
@@ -818,12 +821,9 @@ def handle_args() -> tuple[str, str, dict[str, list[str]]]:
         "dev-run",
     ]
 
-    if user_command_action not in ["apply", "create", "dev-run"]:
-        user_command_crd = args[1]
-    else:
-        _LOG.info("read user_command_crd from yaml")
+    # For file-based actions, validate file parameter exists (preserving original validation)
+    if user_command_action in ["apply", "create", "dev-run"]:
         assert len(kwargs["file"]) == 1, "exactly one yaml file is required"
-        user_command_crd = camel_to_snake(get_crd_name_from_yaml(kwargs["file"][0]))
 
     user_command_action = kebab_to_snake(user_command_action)
 


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [-] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
Changed mactl command syntax from mactl <action> <resource> to mactl <resource> <action> for consistency. Resource is now always specified on command line instead of being inferred from YAML files for create/apply/dev-run operations.

<!-- Tell your future self why have you made these changes -->
**Why?**
  - More intuitive syntax consistent with kubectl and other CLI tools
  - Eliminates inconsistency where some commands required explicit resource specification while others inferred it from YAML

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
 Tested locally with various command combinations:
  - Regular commands: mactl pipeline get, mactl model list
  - File operations: mactl pipeline create file=x.yaml, mactl model apply file=y.yaml
  - Error cases: missing arguments, invalid actions
  - All parsing and validation works correctly

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
 Breaking change for existing users. Commands like mactl create file=pipeline.yaml must become mactl pipeline create 
  file=pipeline.yaml.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
CHANGE: mactl syntax changed from mactl <action> <resource> to mactl <resource> <action>. Update scripts accordingly.

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
