### PR TITLE
Add trigger detail view with dynamic pipeline run filtering

### DIFF
--- a/javascript/packages/core/config/entities/trigger/detail.ts
+++ b/javascript/packages/core/config/entities/trigger/detail.ts
@@ -1,7 +1,10 @@
 import { CellType } from '#core/components/cell/constants';
+import { SHARED_RUN_CELL_CONFIG } from '#core/config/entities/run/shared';
+import { interpolate } from '#core/interpolation/interpolate';
 import { TRIGGER_PIPELINE_CELL_CONFIG, TRIGGER_STATE_CELL_CONFIG } from './shared';
 
 import type { DetailViewConfig } from '#core/components/views/types';
+import type { Trigger } from './types';
 
 export const TRIGGER_DETAIL_CONFIG: DetailViewConfig = {
   type: 'detail',
@@ -11,5 +14,34 @@ export const TRIGGER_DETAIL_CONFIG: DetailViewConfig = {
     TRIGGER_PIPELINE_CELL_CONFIG,
     TRIGGER_STATE_CELL_CONFIG,
   ],
-  pages: [],
+  pages: [
+    {
+      id: 'runs',
+      label: 'Recent Runs',
+      type: 'table',
+      queryConfig: {
+        endpoint: 'list',
+        service: 'pipelineRun',
+        serviceOptions: {
+          listOptions: {
+            labelSelector: interpolate(({ page }: { page: Trigger }) =>
+              page.spec.trigger.triggerType.case === 'batchRerun'
+                ? 'pipelinerun.michelangelo/triggered-by=${page.metadata.name}'
+                : 'pipelinerun.michelangelo/source-trigger=${page.metadata.name}'
+            ),
+          },
+        },
+      },
+      tableConfig: {
+        columns: [
+          {
+            id: 'metadata.name',
+            label: 'Name',
+            url: '/${studio.projectId}/${studio.phase}/runs/${row.metadata.name}',
+          },
+          ...SHARED_RUN_CELL_CONFIG,
+        ],
+      },
+    },
+  ],
 };

--- a/javascript/packages/core/config/entities/trigger/detail.ts
+++ b/javascript/packages/core/config/entities/trigger/detail.ts
@@ -1,10 +1,8 @@
 import { CellType } from '#core/components/cell/constants';
 import { SHARED_RUN_CELL_CONFIG } from '#core/config/entities/run/shared';
-import { interpolate } from '#core/interpolation/interpolate';
 import { TRIGGER_PIPELINE_CELL_CONFIG, TRIGGER_STATE_CELL_CONFIG } from './shared';
 
 import type { DetailViewConfig } from '#core/components/views/types';
-import type { Trigger } from './types';
 
 export const TRIGGER_DETAIL_CONFIG: DetailViewConfig = {
   type: 'detail',
@@ -24,11 +22,7 @@ export const TRIGGER_DETAIL_CONFIG: DetailViewConfig = {
         service: 'pipelineRun',
         serviceOptions: {
           listOptions: {
-            labelSelector: interpolate(({ page }: { page: Trigger }) =>
-              page.spec.trigger.triggerType.case === 'batchRerun'
-                ? 'pipelinerun.michelangelo/triggered-by=${page.metadata.name}'
-                : 'pipelinerun.michelangelo/source-trigger=${page.metadata.name}'
-            ),
+            labelSelector: 'pipelinerun.michelangelo/triggered-by=${page.metadata.name}',
           },
         },
       },

--- a/javascript/packages/core/config/entities/trigger/types.ts
+++ b/javascript/packages/core/config/entities/trigger/types.ts
@@ -1,0 +1,12 @@
+export type Trigger = {
+  metadata: {
+    name: string;
+  };
+  spec: {
+    trigger: {
+      triggerType: {
+        case: 'cronSchedule' | 'batchRerun' | 'intervalSchedule';
+      };
+    };
+  };
+};

--- a/javascript/packages/core/router/__tests__/entity-detail-route.test.tsx
+++ b/javascript/packages/core/router/__tests__/entity-detail-route.test.tsx
@@ -605,4 +605,112 @@ describe('EntityDetailRoute', () => {
 
     await screen.findByText('Unable to fetch data for the table');
   });
+
+  test('resolves interpolation at various configuration levels', async () => {
+    const testPhases = {
+      train: buildPhase({
+        id: 'train',
+        entities: [
+          buildEntity({
+            views: [
+              {
+                type: 'detail',
+                metadata: [
+                  { id: 'status.state', label: 'State', type: CellType.STATE },
+                  {
+                    id: 'metadata.name',
+                    label: 'Name: ${page.metadata.name}',
+                    type: CellType.TEXT,
+                  },
+                ],
+                pages: [
+                  {
+                    id: 'interpolated-table',
+                    label: 'Related Runs',
+                    type: 'table',
+                    queryConfig: {
+                      endpoint: 'list',
+                      service: 'pipelineRun',
+                      serviceOptions: {
+                        listOptions: {
+                          labelSelector:
+                            'pipelinerun.michelangelo/source-trigger=${page.metadata.name}',
+                        },
+                      },
+                    },
+                    tableConfig: buildTableConfig({
+                      columns: [
+                        {
+                          id: 'metadata.name',
+                          label: 'Run Name',
+                          type: CellType.TEXT,
+                          url: '/${studio.projectId}/${studio.phase}/runs/${row.metadata.name}?page=${page.metadata.name}',
+                        },
+                      ],
+                    }),
+                  },
+                ],
+              },
+            ],
+          }),
+        ],
+      }),
+    };
+
+    const mockRequest = createQueryMockRouter({
+      GetPipelineRun: {
+        pipelineRun: {
+          metadata: {
+            name: 'test-trigger-123',
+            namespace: 'myproject',
+            creationTimestamp: { seconds: 1640995200 },
+          },
+          status: { state: 'SUCCESS' },
+        },
+      },
+      'ListPipelineRun:{"listOptions":{"labelSelector":"pipelinerun.michelangelo/source-trigger=test-trigger-123"},"namespace":"myproject"}':
+        {
+          pipelineRunList: {
+            items: [
+              {
+                metadata: { name: 'run-1' },
+                status: { state: 'SUCCESS' },
+              },
+              {
+                metadata: { name: 'run-2' },
+                status: { state: 'FAILED' },
+              },
+            ],
+          },
+        },
+    });
+
+    render(
+      <EntityDetailRoute phases={testPhases} />,
+      buildWrapper([
+        getErrorProviderWrapper(),
+        getRouterWrapper({
+          location: '/myproject/train/runs/test-trigger-123',
+        }),
+        getServiceProviderWrapper({ request: mockRequest }),
+      ])
+    );
+
+    // Resolve interpolation in metadata label
+    await screen.findByText('Name: test-trigger-123');
+
+    // Verify interpolation in serviceOptions worked by checking the table data loads
+    await screen.findByRole('row', { name: /run-1/ });
+    await screen.findByRole('row', { name: /run-2/ });
+
+    // Verify interpolation of shared page/row data
+    expect(screen.getByRole('link', { name: /run-1/ })).toHaveAttribute(
+      'href',
+      '/myproject/train/runs/run-1?page=test-trigger-123'
+    );
+    expect(screen.getByRole('link', { name: /run-2/ })).toHaveAttribute(
+      'href',
+      '/myproject/train/runs/run-2?page=test-trigger-123'
+    );
+  });
 });

--- a/javascript/packages/core/router/entity-detail-route.tsx
+++ b/javascript/packages/core/router/entity-detail-route.tsx
@@ -12,6 +12,7 @@ import { DetailView } from '#core/components/views/detail-view/detail-view';
 import { PHASES } from '#core/config/phases/phases';
 import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
 import { useStudioQuery } from '#core/hooks/use-studio-query';
+import { useInterpolationResolver } from '#core/interpolation/use-interpolation-resolver';
 import { capitalizeFirstLetter } from '#core/utils/string-utils';
 
 import type { PhaseConfig } from '#core/types/common/studio-types';
@@ -30,6 +31,7 @@ export function EntityDetailRoute({ phases = PHASES }: { phases?: Record<string,
   const { phase, entity, entityId, projectId, entityTab } = useStudioParams('detail');
   const navigate = useNavigate();
   const entityConfig = phases[phase].entities.find((e) => e.id === entity);
+  const resolver = useInterpolationResolver();
 
   const { data, isLoading, error } = useStudioQuery<Record<string, unknown>>({
     queryName: `Get${capitalizeFirstLetter(entityConfig?.service ?? '')}`,
@@ -93,30 +95,22 @@ export function EntityDetailRoute({ phases = PHASES }: { phases?: Record<string,
     );
   }
 
+  const entityData = data?.[entityConfig!.service] as Record<string, unknown> | undefined;
+  const resolvedDetailViewConfig = resolver(detailViewConfig, { page: entityData });
   return (
     <DetailView
       subtitle={entityConfig!.name}
       title={entityId}
       onGoBack={returnToEntityList}
       headerContent={
-        <Row
-          items={detailViewConfig!.metadata}
-          record={data?.[entityConfig!.service] as Record<string, unknown>}
-          loading={isLoading}
-        />
+        <Row items={resolvedDetailViewConfig!.metadata} record={entityData} loading={isLoading} />
       }
     >
       <DetailViewPages
-        tabs={detailViewConfig!.pages.map((page) => ({
+        tabs={resolvedDetailViewConfig!.pages.map((page) => ({
           id: page.id,
           label: page.label,
-          content: (
-            <DetailViewPageRenderer
-              page={page}
-              data={data?.[entityConfig!.service] as object | undefined}
-              isLoading={isLoading}
-            />
-          ),
+          content: <DetailViewPageRenderer page={page} data={entityData} isLoading={isLoading} />,
         }))}
         activeTabId={entityTab}
         onTabSelect={navigateToTab}


### PR DESCRIPTION
Implement table view that displays pipeline runs related to specific triggers.

Triggers use different labeling patterns for pipeline runs depending on their type: batch rerun triggers label runs with "triggered-by" while other trigger types use "source-trigger". Our gRPC client transforms protobuf oneofs to objects with "case" key that corresponds to the name of the oneof key.

Add interpolation support to entity detail route to resolve template strings in service options at runtime, enabling trigger-specific filtering that wasn't possible with static configuration.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
```
# Trigger without pipeline label
apiVersion: michelangelo.api/v2
kind: TriggerRun
metadata:
  name: no-label-trigger
  namespace: ma-dev-test
spec:
  pipeline:
    name: backup-pipeline
    namespace: ma-dev-test
  actor:
    name: system-user
  trigger:
    cronSchedule:
      cron: "0 2 * * *"%           

# Pipeline run for no-label-trigger (uses source-trigger label)
apiVersion: michelangelo.api/v2
kind: PipelineRun
metadata:
  name: no-label-run-1
  namespace: ma-dev-test
  labels:
    pipelinerun.michelangelo/source-trigger: no-label-trigger
spec:
  pipeline:
    name: backup-pipeline
    namespace: ma-dev-test
  actor:
    name: system-user
```

<img width="920" height="565" alt="Screenshot 2025-09-24 at 18 17 44" src="https://github.com/user-attachments/assets/01d17f89-6c04-481e-98a3-9baf77391fc6" />

```
# Regular cron trigger - uses source-trigger label
apiVersion: michelangelo.api/v2
kind: TriggerRun
metadata:
  name: cron-trigger
  namespace: ma-dev-test
  labels:
    pipeline: data-pipeline
spec:
  pipeline:
    name: data-pipeline
    namespace: ma-dev-test
  actor:
    name: craig.marker
  trigger:
    cronSchedule:
      cron: "0 9 * * *"

# Pipeline runs for cron-trigger (uses source-trigger label)
apiVersion: michelangelo.api/v2
kind: PipelineRun
metadata:
  name: cron-run-1
  namespace: ma-dev-test
  labels:
    pipelinerun.michelangelo/source-trigger: cron-trigger
spec:
  pipeline:
    name: data-pipeline
    namespace: ma-dev-test
  actor:
    name: craig.marker

---
apiVersion: michelangelo.api/v2
kind: PipelineRun
metadata:
  name: cron-run-2
  namespace: ma-dev-test
  labels:
    pipelinerun.michelangelo/source-trigger: cron-trigger
spec:
  pipeline:
    name: data-pipeline
    namespace: ma-dev-test
  actor:
    name: craig.marker
```

<img width="920" height="565" alt="Screenshot 2025-09-24 at 18 17 42" src="https://github.com/user-attachments/assets/8f0e9887-85c0-4841-b6dc-ea8d52993635" />

```
# Batch rerun trigger - uses triggered-by label
apiVersion: michelangelo.api/v2
kind: TriggerRun
metadata:
  name: batch-rerun-trigger
  namespace: ma-dev-test
  labels:
    pipeline: data-pipeline
spec:
  pipeline:
    name: data-pipeline
    namespace: ma-dev-test
  actor:
    name: craig.marker
  trigger:
    batchRerun:
      pipelineRuns:
        - name: failed-run-1
          namespace: ma-dev-test

# Pipeline runs for batch-rerun-trigger (uses triggered-by label)
apiVersion: michelangelo.api/v2
kind: PipelineRun
metadata:
  name: batch-run-1
  namespace: ma-dev-test
  labels:
    pipelinerun.michelangelo/triggered-by: batch-rerun-trigger
spec:
  pipeline:
    name: data-pipeline
    namespace: ma-dev-test
  actor:
    name: craig.marker

---
apiVersion: michelangelo.api/v2
kind: PipelineRun
metadata:
  name: batch-run-2
  namespace: ma-dev-test
  labels:
    pipelinerun.michelangelo/triggered-by: batch-rerun-trigger
spec:
  pipeline:
    name: data-pipeline
    namespace: ma-dev-test
  actor:
    name: craig.marker

```
<img width="920" height="565" alt="Screenshot 2025-09-24 at 18 17 39" src="https://github.com/user-attachments/assets/6e73145c-6f7d-4c3e-82eb-6642eacbcd0f" />



<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
