### PR TITLE
Add Imagespec to uniflow task decorator

### DIFF
--- a/python/michelangelo/uniflow/core/__init__.py
+++ b/python/michelangelo/uniflow/core/__init__.py
@@ -6,9 +6,11 @@ from michelangelo.uniflow.core.decorator import (
 )
 from michelangelo.uniflow.core.io_registry import IO
 from michelangelo.uniflow.core.context import create_context
+from michelangelo.uniflow.core.image_spec import ImageSpec
 
 __all__ = [
     "IO",
+    "ImageSpec",
     "create_context",
     "star_plugin",
     "task_context",

--- a/python/michelangelo/uniflow/core/decorator.py
+++ b/python/michelangelo/uniflow/core/decorator.py
@@ -14,6 +14,7 @@ from michelangelo.uniflow.core.codec import encoder
 from michelangelo.uniflow.core.ref import ref, unref, Ref
 from michelangelo.uniflow.core.task_config import TaskConfig, Dependencies
 from michelangelo.uniflow.core.utils import dot_path
+from michelangelo.uniflow.core.image_spec import ImageSpec
 
 if sys.version_info < (3, 10):
     from typing_extensions import ParamSpec
@@ -43,6 +44,7 @@ class TaskFunction(Generic[P, R]):
         cache_enabled: bool = False,
         cache_version: Optional[str] = None,
         retry_attempts: int = DEFAULT_RETRY_ATTEMPTS,
+        image_spec: Optional[ImageSpec] = None,
     ):
         self._fn = fn
         self._config = config
@@ -51,6 +53,7 @@ class TaskFunction(Generic[P, R]):
         self._cache_enabled = cache_enabled
         self._cache_version = cache_version
         self._retry_attempts = retry_attempts
+        self._image_spec = image_spec
 
     def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R:
         fn_path = dot_path(self._fn)
@@ -109,6 +112,7 @@ class TaskFunction(Generic[P, R]):
         alias: Optional[str] = None,
         config: Optional[TaskConfig] = None,
         retry_attempts: Optional[int] = None,
+        image_spec: Optional[ImageSpec] = None,
     ) -> "TaskFunction[P, R]":
         """
         Creates a new TaskFunction instance with overridden alias and/or config.
@@ -124,6 +128,11 @@ class TaskFunction(Generic[P, R]):
                                            For example, if the original configuration specifies a head_cpu = 4, head_memory = 16GB,
                                            and the new configuration specifies a CPU count of 8,
                                            the resulting configuration will have a head_cpu = 8 and a head_memory = 16GB.
+            retry_attempts (Optional[int]): An optional retry attempts for the task. Default is 1 (no retries).
+            image_spec (Optional[ImageSpec]): An optional ImageSpec object. This object will be merged the original image spec in the decorator.
+                                             For example, if the original image spec specifies a container image = "docker.io/library/examples:latest",
+                                             and the new image spec specifies a container image = "docker.io/library/examples:latest",
+                                             the resulting image spec will have a container image = "docker.io/library/examples:latest".
         Returns:
             TaskFunction[P, R]: A new TaskFunction instance with the specified overrides.
         """
@@ -135,6 +144,7 @@ class TaskFunction(Generic[P, R]):
             cache_enabled=self._cache_enabled,
             cache_version=self._cache_version,
             retry_attempts=retry_attempts or self._retry_attempts,
+            image_spec=image_spec or self._image_spec,
         )
 
     def _transpile(self, dependencies: Dependencies) -> ast.AST:
@@ -181,6 +191,12 @@ class TaskFunction(Generic[P, R]):
             ast.keyword("retry_attempts", ast.Constant(self._retry_attempts))
         )
 
+        if self._image_spec:
+            if self._image_spec.container_image:
+                keywords.append(ast.keyword("container_image", ast.Constant(self._image_spec.container_image)))
+            if self._image_spec.receipt:
+                keywords.append(ast.keyword("receipt", ast.Constant(self._image_spec.receipt)))
+
         # Construct and return AST Call node that calls the Task Factory Function with the keywords.
         origin_fn = inspect.unwrap(self._fn)
         return ast.Call(
@@ -197,6 +213,7 @@ def task(
     cache_enabled: bool = False,
     cache_version: Optional[str] = None,
     retry_attempts: int = DEFAULT_RETRY_ATTEMPTS,
+    image_spec: Optional[ImageSpec] = None,
 ):
     """
     Decorator for defining a task function. Usage example:
@@ -204,6 +221,16 @@ def task(
         @task(config=Python(cpu=1), cache_enabled=True, cache_version="v0")
         def task_1(a, b):
             return a + b
+
+        @task(
+            config=RayTask(cpu=1),
+            image_spec=ImageSpec(
+                container_image="my-image:latest",
+                receipt="bazel://path/to:target"
+            )
+        )
+        def task_with_custom_image():
+            pass
 
     Parameters:
         config: Task configuration object. It defines task type, such as Python, Spark, etc, as well as type-specific parameters.
@@ -218,6 +245,7 @@ def task(
             We can use this to save multiple versions of caches for the same task and specify the cache version used to
             skip the task. If it is None, the default cached version will be calculated by the docker image id of the task.
         retry_attempts: int: Number of retry attempts for the task. Default is 1 (no retries).
+        image_spec: Optional[ImageSpec]: Container image specification for the task. Allows specifying custom container images and build targets.
     """
 
     def decorator(fn: Callable[P, R]) -> TaskFunction[P, R]:
@@ -229,6 +257,7 @@ def task(
             cache_enabled=cache_enabled,
             cache_version=cache_version,
             retry_attempts=retry_attempts,
+            image_spec=image_spec,
         )
         update_wrapper(task_fn, fn)
 

--- a/python/michelangelo/uniflow/core/image_spec.py
+++ b/python/michelangelo/uniflow/core/image_spec.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class ImageSpec:
+    """
+    ImageSpec defines container image specifications for uniflow tasks.
+
+    Example usage:
+        @uniflow.task(
+            config=RayTask(cpu=1),
+            image_spec=ImageSpec(
+                container_image="docker.io/library/examples:latest",
+                receipt="bazel://uber/ai/michelangelo/sdk/workflow/tasks/llm_feature_prep:uniflow_default_task_image"
+            )
+        )
+        def my_task():
+            pass
+    """
+
+    container_image: Optional[str] = None
+    """The container image name/tag to use for task execution"""
+
+    receipt: Optional[str] = None
+    """Build receipt/target for reproducible image builds"""

--- a/python/tests/uniflow/core/test_decorator.py
+++ b/python/tests/uniflow/core/test_decorator.py
@@ -10,6 +10,7 @@ from unittest import mock
 from michelangelo.uniflow.core.decorator import task, TaskFunction, workflow
 from michelangelo.uniflow.core.task_config import Dependencies
 from michelangelo.uniflow.core.ref import Ref
+from michelangelo.uniflow.core.image_spec import ImageSpec
 from tests.uniflow.core.test_task_config import TaskA, TaskB, a_environ, b_environ
 
 
@@ -99,6 +100,33 @@ def _echo_task(x):
     return x
 
 
+@task(
+    config=TaskA(cpu=1),
+    image_spec=ImageSpec(
+        container_image="test-image:latest",
+        receipt="bazel://test/path:target"
+    )
+)
+def task_with_image_spec():
+    """Task that uses ImageSpec with both container_image and receipt."""
+    return "task_with_image_spec_result"
+
+
+@task(
+    config=TaskA(cpu=2),
+    image_spec=ImageSpec(container_image="registry-image:v1.0")
+)
+def task_with_registry_image():
+    """Task that uses ImageSpec with only container_image (no receipt)."""
+    return "task_with_registry_image_result"
+
+
+@task(config=TaskA(cpu=1))
+def task_without_image_spec():
+    """Task without ImageSpec (baseline for comparison)."""
+    return "task_without_image_spec_result"
+
+
 @workflow()
 def generate_random_text_workflow(
     spec: RandomTextSpec,
@@ -120,6 +148,20 @@ def with_overrides_workflow(a, b) -> tuple:
     b = echo_task.with_overrides(alias="echo_b")(b)
 
     return a, b
+
+
+@workflow()
+def image_spec_workflow() -> dict:
+    """Workflow that tests ImageSpec functionality."""
+    result1 = task_with_image_spec()
+    result2 = task_with_registry_image()
+    result3 = task_without_image_spec()
+
+    return {
+        "with_image_spec": result1,
+        "with_registry_image": result2,
+        "without_image_spec": result3
+    }
 
 
 class TaskTest(unittest.TestCase):
@@ -233,3 +275,95 @@ class TestWorkflow(unittest.TestCase):
         a, b = with_overrides_workflow("foo", "bar")
         self.assertEqual(a, "foo")
         self.assertEqual(b, "bar")
+
+
+class ImageSpecTest(unittest.TestCase):
+    """Test cases for ImageSpec functionality in uniflow tasks."""
+
+    def test_task_with_image_spec(self):
+        """Test that tasks with ImageSpec can be created and have the correct attributes."""
+        self.assertIsInstance(task_with_image_spec, TaskFunction)
+        self.assertIsNotNone(task_with_image_spec._image_spec)
+        self.assertEqual(task_with_image_spec._image_spec.container_image, "test-image:latest")
+        self.assertEqual(task_with_image_spec._image_spec.receipt, "bazel://test/path:target")
+
+    def test_task_without_image_spec(self):
+        """Test that tasks without ImageSpec have None for image_spec."""
+        self.assertIsInstance(task_without_image_spec, TaskFunction)
+        self.assertIsNone(task_without_image_spec._image_spec)
+
+    @mock.patch.dict(
+        "os.environ",
+        {
+            "UF_STORAGE_URL": "memory://test",
+        },
+    )
+    def test_task_execution_with_image_spec(self):
+        """Test that tasks with ImageSpec execute correctly."""
+        result = task_with_image_spec()
+        self.assertEqual(result, "task_with_image_spec_result")
+
+        result2 = task_with_registry_image()
+        self.assertEqual(result2, "task_with_registry_image_result")
+
+    def test_task_transpile_with_image_spec(self):
+        """Test AST transpilation includes ImageSpec container_image and receipt."""
+        self.assertIsInstance(task_with_image_spec, TaskFunction)
+
+        deps = Dependencies()
+        exp = task_with_image_spec._transpile(deps)
+
+        # Check that container_image and receipt are included in transpiled AST
+        transpiled_code = ast.unparse(exp)
+        self.assertIn("container_image='test-image:latest'", transpiled_code)
+        self.assertIn("receipt='bazel://test/path:target'", transpiled_code)
+
+        # Verify basic task parameters are still present
+        self.assertIn("cpu=1", transpiled_code)
+        self.assertIn("cache_enabled=False", transpiled_code)
+
+    def test_task_transpile_with_registry_image_only(self):
+        """Test AST transpilation with only container_image (no receipt)."""
+        self.assertIsInstance(task_with_registry_image, TaskFunction)
+
+        deps = Dependencies()
+        exp = task_with_registry_image._transpile(deps)
+
+        transpiled_code = ast.unparse(exp)
+        self.assertIn("container_image='registry-image:v1.0'", transpiled_code)
+        # Receipt should not be present since it's None
+        self.assertNotIn("receipt=", transpiled_code)
+
+    def test_task_transpile_without_image_spec(self):
+        """Test AST transpilation without ImageSpec doesn't include image parameters."""
+        self.assertIsInstance(task_without_image_spec, TaskFunction)
+
+        deps = Dependencies()
+        exp = task_without_image_spec._transpile(deps)
+
+        transpiled_code = ast.unparse(exp)
+        # Neither container_image nor receipt should be present
+        self.assertNotIn("container_image=", transpiled_code)
+        self.assertNotIn("receipt=", transpiled_code)
+
+    def test_with_overrides_image_spec(self):
+        """Test task overrides with ImageSpec."""
+        # Create override with new ImageSpec
+        new_image_spec = ImageSpec(
+            container_image="override-image:v2.0",
+            receipt="bazel://override/path:target"
+        )
+
+        overridden_task = task_with_image_spec.with_overrides(
+            alias="overridden_task",
+            image_spec=new_image_spec
+        )
+
+        # Verify the override worked
+        self.assertEqual(overridden_task._alias, "overridden_task")
+        self.assertIsNotNone(overridden_task._image_spec)
+        self.assertEqual(overridden_task._image_spec.container_image, "override-image:v2.0")
+        self.assertEqual(overridden_task._image_spec.receipt, "bazel://override/path:target")
+
+        # Original task should be unchanged
+        self.assertEqual(task_with_image_spec._image_spec.container_image, "test-image:latest")


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
  Added `ImageSpec` support to uniflow task decorator, allowing tasks to specify
  custom container images and bazel build targets:

  - Created new `ImageSpec` dataclass with `container_image` and `receipt` fields
  - Enhanced `TaskFunction` class to accept and store `image_spec` parameter
  - Updated `task` decorator to support `image_spec` parameter
  - Modified AST transpilation to include container image metadata in generated
  Starlark code
  - Added `with_overrides()` support for `image_spec`
  - Exported `ImageSpec` in core package `__init__.py`


<!-- Tell your future self why have you made these changes -->
 This feature enables users to specify custom container images for specific tasks,
  supporting both:
  1. Pre-built images from container registries
  2. Images built from bazel targets with reproducible build receipts


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
unit test added tests/uniflow/core/test_decorator.py


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->


<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
  Users can now specify custom container images for uniflow tasks:

  ```python
  @uniflow.task(
      config=RayTask(cpu=1),
      image_spec=ImageSpec(
          container_image="my-custom-image:latest",
          receipt="bazel://path/to:build_target"
      )
  )
  def my_task():
      pass

  This enables:
  - Custom ML environments per task
  - Reproducible builds via bazel receipts
  - Mixed container environments within single workflows

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
Not ready to use yet, still need more implementation work.
