### PR TITLE
Add RadioField with dual string/boolean value support

### DIFF
--- a/javascript/packages/core/components/form/fields/radio/__tests__/radio-field.test.tsx
+++ b/javascript/packages/core/components/form/fields/radio/__tests__/radio-field.test.tsx
@@ -1,0 +1,178 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { RadioField } from '#core/components/form/fields/radio/radio-field';
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
+import { getFormProviderWrapper } from '#core/test/wrappers/get-form-provider-wrapper';
+import { getIconProviderWrapper } from '#core/test/wrappers/get-icon-provider-wrapper';
+
+describe('RadioField', () => {
+  const options = [
+    { value: 'dev', label: 'Development' },
+    { value: 'staging', label: 'Staging' },
+    { value: 'prod', label: 'Production' },
+  ];
+
+  it('renders with label and options', () => {
+    render(
+      <RadioField name="environment" label="Environment" options={options} />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getFormProviderWrapper({})])
+    );
+
+    expect(screen.getByText('Environment')).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Development' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Staging' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Production' })).toBeInTheDocument();
+  });
+
+  it('shows required indicator when required', () => {
+    render(
+      <RadioField name="environment" label="Environment" required options={options} />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getFormProviderWrapper({})])
+    );
+
+    expect(
+      screen.getAllByText((_content, node) => node?.textContent === 'Environment*').length
+    ).toBeGreaterThan(0);
+  });
+
+  it('handles user selection', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(
+      <>
+        <RadioField name="environment" label="Environment" options={options} />
+        <button type="submit">Submit</button>
+      </>,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getFormProviderWrapper({ onSubmit }),
+      ])
+    );
+
+    const stagingRadio = screen.getByRole('radio', { name: 'Staging' });
+    await user.click(stagingRadio);
+
+    expect(stagingRadio).toBeChecked();
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        { environment: 'staging' },
+        expect.anything(),
+        expect.anything()
+      )
+    );
+  });
+
+  it('displays help tooltip when description is provided', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <RadioField
+        name="environment"
+        label="Environment"
+        description="Select the target environment"
+        options={options}
+      />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getFormProviderWrapper({})])
+    );
+
+    await user.hover(screen.getByRole('img', { name: 'help' }));
+    await screen.findByText('Select the target environment');
+  });
+
+  it('handles boolean options correctly', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(
+      <>
+        <RadioField
+          name="autoFlip"
+          label="Auto Flip"
+          options={[
+            { value: true, label: 'Enabled' },
+            { value: false, label: 'Disabled' },
+          ]}
+        />
+        <button type="submit">Submit</button>
+      </>,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getFormProviderWrapper({ onSubmit }),
+      ])
+    );
+
+    const enabledRadio = screen.getByRole('radio', { name: 'Enabled' });
+    await user.click(enabledRadio);
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        { autoFlip: true },
+        expect.anything(),
+        expect.anything()
+      )
+    );
+  });
+
+  it('displays as read-only input when readOnly is true', () => {
+    render(
+      <RadioField name="environment" label="Environment" options={options} readOnly />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getFormProviderWrapper({ initialValues: { environment: 'staging' } }),
+      ])
+    );
+
+    const textbox = screen.getByRole('textbox', { name: 'Environment' });
+    expect(textbox).toHaveValue('Staging');
+    expect(textbox).toHaveAttribute('readOnly');
+  });
+
+  it('disables all options when disabled prop is set', () => {
+    render(
+      <RadioField name="environment" label="Environment" options={options} disabled />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getFormProviderWrapper({})])
+    );
+
+    options.forEach((option) => {
+      expect(screen.getByRole('radio', { name: option.label })).toBeDisabled();
+    });
+  });
+
+  it('disables individual options when option.disabled is true', () => {
+    const optionsWithDisabled = [
+      { value: 'dev', label: 'Development' },
+      { value: 'staging', label: 'Staging', disabled: true },
+      { value: 'prod', label: 'Production' },
+    ];
+
+    render(
+      <RadioField name="environment" label="Environment" options={optionsWithDisabled} />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getFormProviderWrapper({})])
+    );
+
+    expect(screen.getByRole('radio', { name: 'Development' })).not.toBeDisabled();
+    expect(screen.getByRole('radio', { name: 'Staging' })).toBeDisabled();
+    expect(screen.getByRole('radio', { name: 'Production' })).not.toBeDisabled();
+  });
+
+  it('displays caption text', () => {
+    render(
+      <RadioField
+        name="environment"
+        label="Environment"
+        options={options}
+        caption="Choose your deployment target"
+      />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getFormProviderWrapper({})])
+    );
+
+    expect(screen.getByText('Choose your deployment target')).toBeInTheDocument();
+  });
+});

--- a/javascript/packages/core/components/form/fields/radio/radio-field.tsx
+++ b/javascript/packages/core/components/form/fields/radio/radio-field.tsx
@@ -1,0 +1,107 @@
+import React, { useCallback } from 'react';
+import { Input } from 'baseui/input';
+import { ALIGN, Radio as RadioItem, RadioGroup } from 'baseui/radio';
+
+import { FormControl } from '#core/components/form/components/form-control';
+import { useField } from '#core/components/form/hooks/use-field';
+
+import type { Theme } from 'baseui';
+import type { RadioFieldProps } from './types';
+
+export const RadioField: React.FC<RadioFieldProps> = ({
+  name,
+  label,
+  required,
+  readOnly,
+  disabled,
+  description,
+  caption,
+  options,
+  align = ALIGN.horizontal,
+}) => {
+  const { input, meta } = useField<string | boolean>(name);
+
+  const isBoolean = options.every(({ value }) => typeof value === 'boolean');
+
+  const handleChange = useCallback(
+    (event: React.FormEvent<HTMLInputElement>) => {
+      const strVal = event.currentTarget.value;
+      input.onChange(isBoolean ? strVal === 'true' : strVal);
+    },
+    [input, isBoolean]
+  );
+
+  if (readOnly) {
+    return (
+      <FormControl
+        label={label}
+        required={required}
+        description={description}
+        caption={caption}
+        error={meta.touched && meta.error ? meta.error : undefined}
+      >
+        <Input
+          id={input.name}
+          readOnly
+          value={options.find((option) => option.value === input.value)?.label ?? ''}
+          overrides={{
+            InputContainer: {
+              style: ({ $theme }: { $theme: Theme }) => ({
+                backgroundColor: $theme.colors.backgroundPrimary,
+              }),
+            },
+          }}
+        />
+      </FormControl>
+    );
+  }
+
+  return (
+    <FormControl
+      label={label}
+      required={required}
+      description={description}
+      caption={caption}
+      error={meta.touched && meta.error ? meta.error : undefined}
+    >
+      <RadioGroup
+        name={input.name}
+        value={typeof input.value === 'boolean' ? String(input.value) : input.value}
+        align={align}
+        disabled={disabled}
+        onChange={handleChange}
+        onBlur={input.onBlur}
+        overrides={{
+          RadioGroupRoot: {
+            style: ({ $theme }: { $theme: Theme }) => ({ gap: $theme.sizing.scale600 }),
+          },
+        }}
+      >
+        {options.map((option) => (
+          <RadioItem
+            key={String(option.value)}
+            value={typeof option.value === 'boolean' ? String(option.value) : option.value}
+            disabled={option.disabled}
+            overrides={{
+              RadioMarkOuter: {
+                style: ({ $theme }: { $theme: Theme }) => ({
+                  height: $theme.sizing.scale600,
+                  width: $theme.sizing.scale600,
+                }),
+              },
+              RadioMarkInner: {
+                style: ({ $checked, $theme }: { $checked: boolean; $theme: Theme }) => ({
+                  height: $checked ? $theme.sizing.scale100 : $theme.sizing.scale400,
+                  width: $checked ? $theme.sizing.scale100 : $theme.sizing.scale400,
+                  transform: 'none',
+                }),
+              },
+            }}
+          >
+            {option.label}
+          </RadioItem>
+        ))}
+      </RadioGroup>
+    </FormControl>
+  );
+};

--- a/javascript/packages/core/components/form/fields/radio/types.ts
+++ b/javascript/packages/core/components/form/fields/radio/types.ts
@@ -1,0 +1,13 @@
+import type { Align } from 'baseui/radio';
+import type { BaseFieldProps } from '../types';
+
+export interface RadioOption {
+  value: string | boolean;
+  label: string;
+  disabled?: boolean;
+}
+
+export interface RadioFieldProps extends BaseFieldProps {
+  options: RadioOption[];
+  align?: Align;
+}

--- a/javascript/packages/core/test/wrappers/get-form-provider-wrapper.tsx
+++ b/javascript/packages/core/test/wrappers/get-form-provider-wrapper.tsx
@@ -1,4 +1,4 @@
-import { Form } from 'react-final-form';
+import { Form } from '#core/components/form/form';
 
 import type { FormProps } from '#core/components/form/types';
 import type { WrapperComponentProps } from './types';
@@ -10,7 +10,7 @@ export function getFormProviderWrapper(
   return function FormProviderWrapper({ children }: WrapperComponentProps) {
     return (
       <Form onSubmit={onSubmit} initialValues={initialValues}>
-        {() => <>{children}</>}
+        {children}
       </Form>
     );
   };


### PR DESCRIPTION
Implement RadioField component that handles both string options (environment selection) and boolean options (feature toggles).

BaseUI RadioGroup only accepts string values, but forms require both string environment names and boolean flags (for trigger auto flip to latest master).

Fix test wrapper to use actual Form component instead of raw React Final Form, enabling proper form submission testing.

readOnly radio fields are displayed as input with associated value to improve experience in detail views.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

https://github.com/user-attachments/assets/0bf5fbe5-06ad-4cdd-a826-dcdcd2711fc2



<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
