### PR TITLE
Add SelectField component

### DIFF
--- a/javascript/packages/core/components/form/fields/select/__tests__/select-field.test.tsx
+++ b/javascript/packages/core/components/form/fields/select/__tests__/select-field.test.tsx
@@ -1,0 +1,294 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { SelectField } from '#core/components/form/fields/select/select-field';
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
+import { getFormProviderWrapper } from '#core/test/wrappers/get-form-provider-wrapper';
+import { getIconProviderWrapper } from '#core/test/wrappers/get-icon-provider-wrapper';
+
+describe('SelectField', () => {
+  const options = [
+    { id: 'low', label: 'Low Priority' },
+    { id: 'medium', label: 'Medium Priority' },
+    { id: 'high', label: 'High Priority' },
+  ];
+
+  it('renders with label and placeholder', () => {
+    render(
+      <SelectField
+        name="priority"
+        label="Priority"
+        options={options}
+        placeholder="Select priority level"
+      />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getFormProviderWrapper({})])
+    );
+
+    expect(screen.getByRole('combobox', { name: 'Priority' })).toBeInTheDocument();
+    expect(screen.getByText('Select priority level')).toBeInTheDocument();
+  });
+
+  it('shows required indicator when required', () => {
+    render(
+      <SelectField name="priority" label="Priority" required options={options} />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getFormProviderWrapper({})])
+    );
+
+    expect(
+      screen.getAllByText((_, element) => element?.textContent === 'Priority*').length
+    ).toBeGreaterThan(0);
+  });
+
+  it('displays help tooltip when description is provided', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <SelectField
+        name="priority"
+        label="Priority"
+        description="Select the priority level for this task"
+        options={options}
+      />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getFormProviderWrapper({})])
+    );
+
+    await user.hover(screen.getByRole('img', { name: 'help' }));
+    await screen.findByText('Select the priority level for this task');
+  });
+
+  it('submits the selected value', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(
+      <>
+        <SelectField name="priority" label="Priority" options={options} />
+        <button type="submit">Submit</button>
+      </>,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getFormProviderWrapper({ onSubmit }),
+      ])
+    );
+
+    const select = screen.getByRole('combobox', { name: 'Priority' });
+    await user.click(select);
+
+    expect(screen.getByRole('option', { name: 'Low Priority' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Medium Priority' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'High Priority' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('option', { name: 'Low Priority' }));
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        { priority: 'low' },
+        expect.anything(),
+        expect.anything()
+      )
+    );
+  });
+
+  it('filters options by search input', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <SelectField name="priority" label="Priority" options={options} searchable />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getFormProviderWrapper()])
+    );
+
+    const select = screen.getByRole('combobox', { name: 'Priority' });
+    await user.type(select, 'Low');
+
+    expect(screen.getAllByRole('option')).toHaveLength(1);
+    expect(screen.getByRole('option', { name: 'Low Priority' })).toBeInTheDocument();
+  });
+
+  it('supports numeric ids', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(
+      <>
+        <SelectField
+          name="priority"
+          label="Priority"
+          options={[
+            { id: 0, label: 'Low Priority' },
+            { id: 1, label: 'Medium Priority' },
+            { id: 2, label: 'High Priority' },
+          ]}
+        />
+        <button type="submit">Submit</button>
+      </>,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getFormProviderWrapper({ onSubmit }),
+      ])
+    );
+
+    const select = screen.getByRole('combobox', { name: 'Priority' });
+    await user.click(select);
+
+    await user.click(screen.getByRole('option', { name: 'Low Priority' }));
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith({ priority: 0 }, expect.anything(), expect.anything())
+    );
+  });
+
+  it('supports multi-select mode', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(
+      <>
+        <SelectField name="priority" label="Priority" options={options} multi />
+        <button type="submit">Submit</button>
+      </>,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getFormProviderWrapper({ onSubmit }),
+      ])
+    );
+
+    // Select Low Priority
+    let select = screen.getByRole('combobox');
+    await user.click(select);
+    await user.click(await screen.findByRole('option', { name: 'Low Priority' }));
+
+    // Select Medium Priority
+    select = await screen.findByRole('combobox', { name: /Selected Low Priority/ });
+    await user.click(select);
+    await user.click(await screen.findByRole('option', { name: 'Medium Priority' }));
+
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        { priority: ['low', 'medium'] },
+        expect.anything(),
+        expect.anything()
+      )
+    );
+  });
+
+  it('supports creatable mode', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(
+      <>
+        <SelectField name="priority" label="Priority" options={options} creatable />
+        <button type="submit">Submit</button>
+      </>,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getFormProviderWrapper({ onSubmit }),
+      ])
+    );
+
+    const select = screen.getByRole('combobox', { name: 'Priority' });
+    await user.type(select, 'new');
+    await user.click(await screen.findByRole('option', { name: 'new' }));
+
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        { priority: 'new' },
+        expect.anything(),
+        expect.anything()
+      )
+    );
+  });
+
+  it('supports nonexisting options in creatable mode', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(
+      <>
+        <SelectField name="priority" label="Priority" options={options} creatable />
+        <button type="submit">Submit</button>
+      </>,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getFormProviderWrapper({ initialValues: { priority: 'new' }, onSubmit }),
+      ])
+    );
+
+    expect(screen.getByText('new')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        { priority: 'new' },
+        expect.anything(),
+        expect.anything()
+      )
+    );
+  });
+
+  it('omits clear button when readOnly or disabled', () => {
+    render(
+      <>
+        <SelectField name="disabled" label="Disabled" options={options} disabled />
+        <SelectField name="readonly" label="Read only" options={options} readOnly />
+      </>,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getFormProviderWrapper({ initialValues: { disabled: 'low', readonly: 'low' } }),
+      ])
+    );
+
+    expect(screen.getAllByRole('combobox', { hidden: true })).toHaveLength(2);
+    expect(screen.queryByRole('button', { name: 'Clear' })).not.toBeInTheDocument();
+  });
+
+  it('omits placeholder when readOnly or disabled', () => {
+    render(
+      <>
+        <SelectField
+          name="disabled"
+          label="Disabled"
+          options={options}
+          disabled
+          placeholder="Disabled placeholder"
+        />
+        <SelectField
+          name="readonly"
+          label="Read only"
+          options={options}
+          readOnly
+          placeholder="Read only placeholder"
+        />
+      </>,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getFormProviderWrapper()])
+    );
+
+    expect(screen.getByRole('combobox', { name: 'Disabled' })).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: 'Read only' })).toBeInTheDocument();
+    expect(screen.queryByText('Disabled placeholder')).not.toBeInTheDocument();
+    expect(screen.queryByText('Read only placeholder')).not.toBeInTheDocument();
+  });
+
+  it('displays caption text', () => {
+    render(
+      <SelectField
+        name="priority"
+        label="Priority"
+        options={options}
+        caption="Choose the appropriate priority level"
+      />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getFormProviderWrapper({})])
+    );
+
+    expect(screen.getByText('Choose the appropriate priority level')).toBeInTheDocument();
+  });
+});

--- a/javascript/packages/core/components/form/fields/select/build-select-overrides.ts
+++ b/javascript/packages/core/components/form/fields/select/build-select-overrides.ts
@@ -1,0 +1,29 @@
+import { mergeOverrides } from 'baseui';
+
+import type { Theme } from 'baseui';
+import type { SelectOverrides } from 'baseui/select';
+
+export function buildSelectOverrides(disabled?: boolean, readOnly?: boolean): SelectOverrides {
+  // When rendered inside modals, dropdown options can overflow past the modal body into its backdrop.
+  const base = { Popover: { props: { ignoreBoundary: true } } };
+
+  if (disabled) {
+    return mergeOverrides(base, { Tag: { props: { closeable: false, disabled: false } } });
+  }
+
+  if (readOnly) {
+    return mergeOverrides(base, {
+      Input: { props: { readOnly: true } },
+      ControlContainer: {
+        props: { onClick: () => null },
+        style: ({ $theme }: { $theme: Theme }) => ({
+          backgroundColor: $theme.colors.backgroundPrimary,
+        }),
+      },
+      SelectArrow: { props: { size: 0 } },
+      Tag: { props: { closeable: false } },
+    });
+  }
+
+  return base;
+}

--- a/javascript/packages/core/components/form/fields/select/format-selected-value.ts
+++ b/javascript/packages/core/components/form/fields/select/format-selected-value.ts
@@ -1,0 +1,13 @@
+/**
+ * Parse {value} from {T | T[]} into an array of {T}
+ *
+ * @remarks
+ * Baseui expects the `value` to be an array, but select fields can persist single values.
+ */
+export function formatSelectedValue<T>(value: Array<T> | T): Array<T> {
+  if (value) {
+    return Array.isArray(value) ? value : [value];
+  }
+
+  return [];
+}

--- a/javascript/packages/core/components/form/fields/select/select-field.tsx
+++ b/javascript/packages/core/components/form/fields/select/select-field.tsx
@@ -1,0 +1,77 @@
+import React, { useCallback, useMemo } from 'react';
+import { OnChangeParams, Select } from 'baseui/select';
+
+import { FormControl } from '#core/components/form/components/form-control';
+import { useField } from '#core/components/form/hooks/use-field';
+import { buildSelectOverrides } from './build-select-overrides';
+import { formatSelectedValue } from './format-selected-value';
+
+import type { SelectFieldProps, SelectOption } from './types';
+
+export const SelectField: React.FC<SelectFieldProps> = ({
+  name,
+  label,
+  required,
+  readOnly,
+  disabled,
+  description,
+  caption,
+  placeholder,
+  options,
+  clearable = true,
+  searchable = true,
+  multi = false,
+  creatable = false,
+}) => {
+  const { input, meta } = useField<string | string[] | number[] | number>(name);
+
+  const handleChange = useCallback(
+    (params: { value: ReadonlyArray<SelectOption> }) => {
+      if (multi) {
+        const values = params.value.map((item) => item.id);
+        input.onChange(values as string[] | number[]);
+      } else {
+        const value = params.value.length > 0 ? params.value[0].id : '';
+        input.onChange(value);
+      }
+    },
+    [input, multi]
+  );
+
+  const value = useMemo<SelectOption[]>(() => {
+    return formatSelectedValue(input.value).map<SelectOption>((item) => {
+      const selectedFromOption = options?.find((option) => option.id === item);
+      if (selectedFromOption) return selectedFromOption;
+
+      return { id: item, label: String(item) }; // Creatable options will fall into this case
+    });
+  }, [input.value, options]);
+
+  return (
+    <FormControl
+      label={label}
+      required={required}
+      description={description}
+      caption={caption}
+      error={meta.touched && meta.error ? meta.error : undefined}
+    >
+      <Select
+        id={name}
+        value={value}
+        options={options}
+        onChange={handleChange as (params: OnChangeParams) => unknown}
+        onBlur={input.onBlur}
+        placeholder={!disabled && !readOnly ? placeholder : ''}
+        disabled={disabled}
+        clearable={!disabled && !readOnly && clearable}
+        searchable={searchable}
+        multi={multi}
+        overrides={buildSelectOverrides(disabled, readOnly)}
+        creatable={creatable}
+        // Modified getOptionLabel in BaseWeb Select to avoid adding "Create" prefix on user input for
+        // creatable dropdowns, as creation typically occurs during form submission. The prefix is misleading.
+        getOptionLabel={({ option }) => option.label}
+      />
+    </FormControl>
+  );
+};

--- a/javascript/packages/core/components/form/fields/select/types.ts
+++ b/javascript/packages/core/components/form/fields/select/types.ts
@@ -1,0 +1,15 @@
+import type { BaseFieldProps } from '../types';
+
+export interface SelectOption {
+  id: string | number;
+  label: string;
+  disabled?: boolean;
+}
+
+export interface SelectFieldProps extends BaseFieldProps {
+  options: SelectOption[];
+  clearable?: boolean;
+  searchable?: boolean;
+  multi?: boolean;
+  creatable?: boolean;
+}

--- a/javascript/packages/core/test/wrappers/get-form-provider-wrapper.tsx
+++ b/javascript/packages/core/test/wrappers/get-form-provider-wrapper.tsx
@@ -1,4 +1,4 @@
-import { Form } from 'react-final-form';
+import { Form } from '#core/components/form/form';
 
 import type { FormProps } from '#core/components/form/types';
 import type { WrapperComponentProps } from './types';
@@ -10,7 +10,7 @@ export function getFormProviderWrapper(
   return function FormProviderWrapper({ children }: WrapperComponentProps) {
     return (
       <Form onSubmit={onSubmit} initialValues={initialValues}>
-        {() => <>{children}</>}
+        {children}
       </Form>
     );
   };


### PR DESCRIPTION
Implement complete dropdown selection component with multi-select, creatable options, and form integration capabilities.

Creatable mode addresses the challenge of form state pre-populated with user-generated values that don't exist in predefined options. If the associated form initial value is non-null/undefined, it will be displayed as the selected option in creatable select.

Implement utility, formatSelectedValue, to normalize form state between BaseUI expected (array) and form-supported (array of values or single value).

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

https://github.com/user-attachments/assets/6816271d-60a5-496d-ac27-032c3f2f501d




<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
