### PR TITLE
Add BooleanField for checkboxes and toggle switches

### DIFF
--- a/javascript/packages/core/components/form/fields/boolean/__tests__/boolean-field.test.tsx
+++ b/javascript/packages/core/components/form/fields/boolean/__tests__/boolean-field.test.tsx
@@ -1,0 +1,153 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { BooleanField } from '#core/components/form/fields/boolean/boolean-field';
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
+import { getFormProviderWrapper } from '#core/test/wrappers/get-form-provider-wrapper';
+import { getIconProviderWrapper } from '#core/test/wrappers/get-icon-provider-wrapper';
+
+describe('BooleanField', () => {
+  it('renders with label and checkbox', () => {
+    render(
+      <BooleanField name="enabled" label="Enable Feature" />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getFormProviderWrapper({})])
+    );
+
+    expect(screen.getByText('Enable Feature')).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: 'Disabled' })).not.toBeChecked();
+  });
+
+  it('shows required indicator when required', () => {
+    render(
+      <BooleanField name="enabled" label="Enable Feature" required />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getFormProviderWrapper({})])
+    );
+
+    expect(
+      screen.getAllByText((_, element) => element?.textContent === 'Enable Feature*').length
+    ).toBeGreaterThan(0);
+  });
+
+  it('handles user interaction', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(
+      <>
+        <BooleanField name="enabled" label="Enable Feature" />
+        <button type="submit">Submit</button>
+      </>,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getFormProviderWrapper({ onSubmit }),
+      ])
+    );
+
+    const checkbox = screen.getByRole('checkbox', { name: 'Disabled' });
+    expect(checkbox).not.toBeChecked();
+
+    await user.click(checkbox);
+    expect(checkbox).toBeChecked();
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith({ enabled: true }, expect.anything(), expect.anything())
+    );
+  });
+
+  it('displays help tooltip when description is provided', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <BooleanField
+        name="enabled"
+        label="Enable Feature"
+        description="Toggle this feature on or off"
+      />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getFormProviderWrapper({})])
+    );
+
+    await user.hover(screen.getByRole('img', { name: 'help' }));
+    await screen.findByText('Toggle this feature on or off');
+  });
+
+  it('uses custom checkbox label when provided', () => {
+    render(
+      <BooleanField
+        name="notifications"
+        label="Notifications"
+        checkboxLabel="Send email notifications"
+      />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getFormProviderWrapper({})])
+    );
+
+    expect(screen.getByRole('checkbox', { name: 'Send email notifications' })).toBeInTheDocument();
+  });
+
+  it('shows initial value when provided', async () => {
+    render(
+      <BooleanField name="enabled" label="Enable Feature" toggle />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getFormProviderWrapper({ initialValues: { enabled: true } }),
+      ])
+    );
+
+    const checkbox = await screen.findByRole('checkbox', { name: 'Enabled' });
+    expect(checkbox).toBeChecked();
+  });
+
+  it('is disabled when disabled prop is true', async () => {
+    render(
+      <BooleanField name="enabled" label="Enable Feature" disabled />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getFormProviderWrapper({})])
+    );
+
+    const checkbox = await screen.findByRole('checkbox', { name: 'Disabled' });
+    expect(checkbox).toBeDisabled();
+  });
+
+  it('is read-only when readOnly prop is true', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(
+      <>
+        <BooleanField name="enabled" label="Enable Feature" readOnly />
+        <button type="submit">Submit</button>
+      </>,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getFormProviderWrapper({ initialValues: { enabled: false }, onSubmit }),
+      ])
+    );
+
+    const checkbox = await screen.findByRole('checkbox', { name: 'Disabled' });
+    await user.click(checkbox);
+    expect(checkbox).not.toBeChecked();
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        { enabled: false },
+        expect.anything(),
+        expect.anything()
+      )
+    );
+  });
+
+  it('displays caption text', () => {
+    render(
+      <BooleanField
+        name="enabled"
+        label="Enable Feature"
+        caption="This will enable advanced features"
+      />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getFormProviderWrapper({})])
+    );
+
+    expect(screen.getByText('This will enable advanced features')).toBeInTheDocument();
+  });
+});

--- a/javascript/packages/core/components/form/fields/boolean/boolean-field.tsx
+++ b/javascript/packages/core/components/form/fields/boolean/boolean-field.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { Checkbox, LABEL_PLACEMENT, STYLE_TYPE } from 'baseui/checkbox';
+
+import { FormControl } from '#core/components/form/components/form-control';
+import { useField } from '#core/components/form/hooks/use-field';
+
+import type { Theme } from 'baseui';
+import type { BooleanFieldProps } from './types';
+
+export const BooleanField: React.FC<BooleanFieldProps> = ({
+  name,
+  label,
+  required,
+  readOnly,
+  disabled,
+  description,
+  caption,
+  checkboxLabel,
+  toggle = false,
+}) => {
+  const { input, meta } = useField<boolean>(name);
+
+  const handleChange = (event: React.FormEvent<HTMLInputElement>) => {
+    input.onChange(event.currentTarget.checked);
+  };
+
+  const displayLabel = checkboxLabel ?? (input.value ? 'Enabled' : 'Disabled');
+
+  return (
+    <FormControl
+      label={label}
+      required={required}
+      description={description}
+      caption={caption}
+      error={meta.touched && meta.error ? meta.error : undefined}
+    >
+      <Checkbox
+        checked={input.value ?? false}
+        onChange={readOnly ? undefined : handleChange}
+        onBlur={input.onBlur}
+        disabled={disabled}
+        checkmarkType={toggle ? STYLE_TYPE.toggle_round : STYLE_TYPE.default}
+        labelPlacement={LABEL_PLACEMENT.right}
+        overrides={{
+          Label: {
+            style: ({ $theme }: { $theme: Theme }) => ({
+              fontSize: $theme.sizing.scale550,
+            }),
+          },
+          Root: {
+            style: readOnly ? { cursor: 'default' } : {},
+          },
+        }}
+      >
+        {displayLabel}
+      </Checkbox>
+    </FormControl>
+  );
+};

--- a/javascript/packages/core/components/form/fields/boolean/types.ts
+++ b/javascript/packages/core/components/form/fields/boolean/types.ts
@@ -1,0 +1,17 @@
+import type { BaseFieldProps } from '../types';
+
+export interface BooleanFieldProps extends BaseFieldProps {
+  /**
+   * Custom label for the checkbox itself.
+   *
+   * @default "Enabled" when checked or "Disabled" when unchecked.
+   */
+  checkboxLabel?: string;
+
+  /**
+   * Renders as a toggle switch instead of a standard checkbox.
+   *
+   * @default false
+   */
+  toggle?: boolean;
+}

--- a/javascript/packages/core/test/wrappers/get-form-provider-wrapper.tsx
+++ b/javascript/packages/core/test/wrappers/get-form-provider-wrapper.tsx
@@ -1,4 +1,4 @@
-import { Form } from 'react-final-form';
+import { Form } from '#core/components/form/form';
 
 import type { FormProps } from '#core/components/form/types';
 import type { WrapperComponentProps } from './types';
@@ -10,7 +10,7 @@ export function getFormProviderWrapper(
   return function FormProviderWrapper({ children }: WrapperComponentProps) {
     return (
       <Form onSubmit={onSubmit} initialValues={initialValues}>
-        {() => <>{children}</>}
+        {children}
       </Form>
     );
   };


### PR DESCRIPTION
Introduce BooleanField supporting both checkbox and toggle switch display modes.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
<img width="920" height="565" alt="Screenshot 2025-09-30 at 11 12 55" src="https://github.com/user-attachments/assets/e5438dde-3912-407d-857b-d29da312d098" />

https://github.com/user-attachments/assets/f0788719-e29c-4485-ab5c-65cb72df4794

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
