### PR TITLE
Add CollapsibleBox component

### DIFF
--- a/javascript/packages/core/components/box/__tests__/collapsible-box.test.tsx
+++ b/javascript/packages/core/components/box/__tests__/collapsible-box.test.tsx
@@ -1,0 +1,217 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
+import { CollapsibleBox } from '../collapsible-box';
+
+describe('CollapsibleBox', () => {
+  describe('Controlled mode warnings', () => {
+    const expectedWarning =
+      'CollapsibleBox: `expanded` prop provided without `onToggle`. ' +
+      'This will make the component unresponsive to user interaction. ' +
+      'Either provide `onToggle` or use `defaultExpanded` instead.';
+
+    let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => null);
+    });
+
+    afterEach(() => {
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('warns when expanded is provided without onToggle', () => {
+      render(
+        <CollapsibleBox expanded={false} title="Test">
+          Content
+        </CollapsibleBox>,
+        buildWrapper([getBaseProviderWrapper()])
+      );
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(expectedWarning);
+    });
+
+    it('does not warn when expanded is provided with onToggle', () => {
+      render(
+        <CollapsibleBox expanded={false} onToggle={() => null} title="Test">
+          Content
+        </CollapsibleBox>,
+        buildWrapper([getBaseProviderWrapper()])
+      );
+
+      const calls = consoleWarnSpy.mock.calls.filter((call) => call[0] === expectedWarning);
+      expect(calls).toHaveLength(0);
+    });
+
+    it('does not warn when using defaultExpanded (uncontrolled)', () => {
+      render(
+        <CollapsibleBox defaultExpanded={true} title="Test">
+          Content
+        </CollapsibleBox>,
+        buildWrapper([getBaseProviderWrapper()])
+      );
+
+      const calls = consoleWarnSpy.mock.calls.filter((call) => call[0] === expectedWarning);
+      expect(calls).toHaveLength(0);
+    });
+  });
+
+  it('renders collapsed by default', () => {
+    render(
+      <CollapsibleBox title="Collapsible Section">
+        <div>Hidden Content</div>
+      </CollapsibleBox>,
+      buildWrapper([getBaseProviderWrapper()])
+    );
+
+    expect(screen.getByRole('button', { expanded: false })).toBeInTheDocument();
+    expect(screen.queryByText('Hidden Content')).not.toBeInTheDocument();
+  });
+
+  it('renders expanded when defaultExpanded is true', () => {
+    render(
+      <CollapsibleBox title="Collapsible Section" defaultExpanded={true}>
+        <div>Content</div>
+      </CollapsibleBox>,
+      buildWrapper([getBaseProviderWrapper()])
+    );
+
+    expect(screen.getByRole('button', { expanded: true })).toBeInTheDocument();
+    expect(screen.getByText('Content')).toBeInTheDocument();
+  });
+
+  it('toggles expansion when clicked in uncontrolled mode', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <CollapsibleBox title="Toggle Test">
+        <div>Collapsible Content</div>
+      </CollapsibleBox>,
+      buildWrapper([getBaseProviderWrapper()])
+    );
+
+    await user.click(screen.getByRole('button', { expanded: false }));
+    expect(screen.getByRole('button', { expanded: true })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { expanded: true }));
+    expect(screen.getByRole('button', { expanded: false })).toBeInTheDocument();
+  });
+
+  it('calls onToggle when provided in uncontrolled mode', async () => {
+    const user = userEvent.setup();
+    const onToggle = vi.fn();
+
+    render(
+      <CollapsibleBox title="Toggle Test" onToggle={onToggle}>
+        Content
+      </CollapsibleBox>,
+      buildWrapper([getBaseProviderWrapper()])
+    );
+
+    await user.click(screen.getByRole('button'));
+    expect(onToggle).toHaveBeenCalledWith(true);
+
+    await user.click(screen.getByRole('button'));
+    expect(onToggle).toHaveBeenCalledWith(false);
+  });
+
+  it('starts with defaultExpanded state in uncontrolled mode', async () => {
+    const user = userEvent.setup();
+    const onToggle = vi.fn();
+
+    render(
+      <CollapsibleBox title="Test" defaultExpanded={true} onToggle={onToggle}>
+        Content
+      </CollapsibleBox>,
+      buildWrapper([getBaseProviderWrapper()])
+    );
+
+    expect(screen.getByRole('button', { expanded: true })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button'));
+    expect(onToggle).toHaveBeenCalledWith(false);
+  });
+
+  it('uses expanded prop to control state in controlled mode', async () => {
+    const user = userEvent.setup();
+    const onToggle = vi.fn();
+
+    const { rerender } = render(
+      <CollapsibleBox title="Controlled Test" expanded={false} onToggle={onToggle}>
+        Content
+      </CollapsibleBox>,
+      buildWrapper([getBaseProviderWrapper()])
+    );
+
+    expect(screen.getByRole('button', { expanded: false })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button'));
+    expect(onToggle).toHaveBeenCalledWith(true);
+    expect(screen.getByRole('button', { expanded: false })).toBeInTheDocument();
+
+    rerender(
+      <CollapsibleBox title="Controlled Test" expanded={true} onToggle={onToggle}>
+        Content
+      </CollapsibleBox>
+    );
+
+    expect(screen.getByRole('button', { expanded: true })).toBeInTheDocument();
+  });
+
+  it('remains in controlled state when toggled without onToggle', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <CollapsibleBox title="Stuck Test" expanded={false}>
+        Content
+      </CollapsibleBox>,
+      buildWrapper([getBaseProviderWrapper()])
+    );
+
+    await user.click(screen.getByRole('button', { expanded: false }));
+    expect(screen.getByRole('button', { expanded: false })).toBeInTheDocument();
+  });
+
+  it('does not toggle when disabled', async () => {
+    const user = userEvent.setup();
+    const onToggle = vi.fn();
+
+    render(
+      <CollapsibleBox title="Disabled Test" disabled={true} onToggle={onToggle}>
+        Content
+      </CollapsibleBox>,
+      buildWrapper([getBaseProviderWrapper()])
+    );
+
+    await user.click(screen.getByRole('button', { expanded: false }));
+
+    expect(onToggle).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { expanded: false })).toBeInTheDocument();
+  });
+
+  it('applies overrides to elements', () => {
+    const testId = 'test-container';
+
+    render(
+      <CollapsibleBox
+        title="Override Test"
+        overrides={{
+          Container: {
+            props: { 'data-testid': testId },
+          },
+          HeaderTitle: {
+            props: { 'data-testid': 'test-title' },
+          },
+        }}
+      >
+        Content
+      </CollapsibleBox>,
+      buildWrapper([getBaseProviderWrapper()])
+    );
+
+    expect(screen.getByTestId(testId)).toBeInTheDocument();
+    expect(screen.getByTestId('test-title')).toHaveTextContent('Override Test');
+  });
+});

--- a/javascript/packages/core/components/box/box.tsx
+++ b/javascript/packages/core/components/box/box.tsx
@@ -3,9 +3,9 @@ import { getOverrides } from 'baseui';
 import { DescriptionText } from '#core/components/description-text';
 import { StyledBoxContainer, StyledBoxHeader, StyledBoxTitle } from './styled-components';
 
-import type { Props } from './types';
+import type { BoxProps } from './types';
 
-export function Box(props: Props) {
+export function Box(props: BoxProps) {
   const { children, description, overrides = {}, title } = props;
 
   const [BoxContainer, boxContainerProps] = getOverrides(

--- a/javascript/packages/core/components/box/collapsible-box.tsx
+++ b/javascript/packages/core/components/box/collapsible-box.tsx
@@ -1,0 +1,99 @@
+import React, { useEffect, useState } from 'react';
+import { getOverrides, mergeOverrides, Theme } from 'baseui';
+import { Panel } from 'baseui/accordion';
+
+import { DescriptionText } from '#core/components/description-text';
+import { StyledBoxContainer, StyledBoxTitle } from './styled-components';
+
+import type { CollapsibleBoxProps } from './types';
+
+export const CollapsibleBox: React.FC<CollapsibleBoxProps> = ({
+  children,
+  title,
+  description,
+  expanded: controlledExpanded,
+  defaultExpanded = false,
+  onToggle,
+  disabled = false,
+  overrides = {},
+}) => {
+  const [internalExpanded, setInternalExpanded] = useState(defaultExpanded);
+
+  const isControlled = controlledExpanded !== undefined;
+  const expanded = isControlled ? controlledExpanded : internalExpanded;
+
+  useEffect(() => {
+    if (isControlled && !onToggle) {
+      console.warn(
+        'CollapsibleBox: `expanded` prop provided without `onToggle`. ' +
+          'This will make the component unresponsive to user interaction. ' +
+          'Either provide `onToggle` or use `defaultExpanded` instead.'
+      );
+    }
+  }, [isControlled, onToggle]);
+
+  const handleToggle = () => {
+    if (disabled) return;
+
+    const newExpanded = !expanded;
+
+    if (!isControlled) {
+      setInternalExpanded(newExpanded);
+    }
+
+    onToggle?.(newExpanded);
+  };
+
+  const [HeaderTitle, headerTitleProps] = getOverrides(overrides.HeaderTitle, StyledBoxTitle);
+
+  const header = title ? (
+    <div>
+      <HeaderTitle {...headerTitleProps}>{title}</HeaderTitle>
+      {description && <DescriptionText>{description}</DescriptionText>}
+    </div>
+  ) : undefined;
+
+  return (
+    <Panel
+      expanded={expanded}
+      onChange={handleToggle}
+      title={header}
+      overrides={mergeOverrides(
+        {
+          PanelContainer: {
+            component: StyledBoxContainer,
+            style: ({ $expanded, $theme }: { $expanded: boolean; $theme: Theme }) => ({
+              ...(!$expanded && { gap: 0 }),
+              transitionProperty: 'gap',
+              transitionDuration: $theme.animation.timing500,
+            }),
+          },
+          Header: {
+            style: {
+              padding: 0,
+            },
+          },
+          Content: {
+            style: {
+              padding: 0,
+              paddingBottom: 0,
+            },
+          },
+          ToggleIcon: {
+            style: {
+              alignSelf: 'flex-start',
+            },
+          },
+        },
+        {
+          ...(overrides.Container && { PanelContainer: overrides.Container }),
+          ...(overrides.Header && { Header: overrides.Header }),
+          ...(overrides.Content && { Content: overrides.Content }),
+          ...(overrides.ToggleIcon && { ToggleIcon: overrides.ToggleIcon }),
+        }
+      )}
+    >
+      {children}
+    </Panel>
+  );
+};

--- a/javascript/packages/core/components/box/types.ts
+++ b/javascript/packages/core/components/box/types.ts
@@ -1,16 +1,57 @@
 import type { Override } from 'baseui/overrides';
 import type { ReactNode } from 'react';
 
-export type Props = {
+export type BoxContentProps = {
   children: ReactNode;
-  description?: ReactNode | string;
-  overrides?: BoxOverrides;
   title?: ReactNode | string;
+  description?: ReactNode | string;
 };
 
-type BoxOverrides = {
+export type BoxOverrides = {
   BoxContainer?: Override;
   BoxDescription?: Override;
   BoxHeader?: Override;
   BoxTitle?: Override;
 };
+
+export type BoxProps = BoxContentProps & {
+  overrides?: BoxOverrides;
+};
+
+type CollapsibleBoxOverrides = {
+  Container?: Override;
+  Header?: Override;
+  HeaderTitle?: Override;
+  Content?: Override;
+  ToggleIcon?: Override;
+};
+
+export interface CollapsibleBoxProps extends BoxContentProps {
+  expanded?: boolean;
+
+  /**
+   * Whether the box begins in an expanded state
+   *
+   * @default false
+   */
+  defaultExpanded?: boolean;
+  onToggle?: (expanded: boolean) => void;
+
+  /**
+   * Controls whether the box's expansion state can be toggled
+   *
+   * @default false
+   */
+  disabled?: boolean;
+
+  /**
+   * Overrides for styling the collapsible box elements.
+   *
+   * @example
+   * <CollapsibleBox overrides={{
+   *   Container: { style: { backgroundColor: 'gray' } },
+   *   HeaderTitle: { style: { fontWeight: 'bold' } }
+   * }} />
+   */
+  overrides?: CollapsibleBoxOverrides;
+}

--- a/javascript/packages/core/components/views/execution/components/task-details/renderers/task-body-struct.tsx
+++ b/javascript/packages/core/components/views/execution/components/task-details/renderers/task-body-struct.tsx
@@ -1,7 +1,7 @@
 import { LabelSmall } from 'baseui/typography';
 
+import { CollapsibleBox } from '#core/components/box/collapsible-box';
 import { TextEditor } from '#core/components/text-editor/text-editor';
-import { TaskPanel } from '#core/components/views/execution/styled-components';
 import { decodeStruct, isStruct } from '#core/utils/proto/struct-utils';
 
 import type { TaskBodyStructProps } from './types';
@@ -13,8 +13,8 @@ export function TaskBodyStruct(props: TaskBodyStructProps) {
   const prettyJson = JSON.stringify(decodedValue, null, 2);
 
   return (
-    <TaskPanel title={<LabelSmall>{label}</LabelSmall>}>
+    <CollapsibleBox title={<LabelSmall>{label}</LabelSmall>}>
       <TextEditor readOnly language="json" value={prettyJson} onChange={() => null} />
-    </TaskPanel>
+    </CollapsibleBox>
   );
 }

--- a/javascript/packages/core/components/views/execution/components/task-details/task-details.tsx
+++ b/javascript/packages/core/components/views/execution/components/task-details/task-details.tsx
@@ -26,7 +26,7 @@ export function TaskDetails<TTaskRecord extends object = object>(
       <TaskPanel
         id={scrollId}
         title={<TaskHeader task={task} metadata={metadata} />}
-        initialState={{ expanded: task.focused }}
+        defaultExpanded={task.focused}
       >
         <TaskBody task={task} bodySchema={bodySchema} metadata={metadata} overrides={overrides} />
       </TaskPanel>

--- a/javascript/packages/core/components/views/execution/styled-components.tsx
+++ b/javascript/packages/core/components/views/execution/styled-components.tsx
@@ -1,10 +1,8 @@
 import { styled } from 'baseui';
-import { StatefulPanel } from 'baseui/accordion';
 
-import { StyledBoxContainer } from '#core/components/box/styled-components';
+import { CollapsibleBox } from '#core/components/box/collapsible-box';
 
-import type { Theme } from 'baseui';
-import type { StatefulPanelProps } from 'baseui/accordion';
+import type { CollapsibleBoxProps } from '#core/components/box/types';
 
 export const TaskSeparator = styled('hr', ({ $theme }) => ({
   border: 'none',
@@ -22,43 +20,24 @@ export const TaskContentStack = styled('div', ({ $theme }) => ({
   gap: $theme.sizing.scale800,
 }));
 
-export function TaskPanel(props: StatefulPanelProps & { id?: string }) {
-  const { id, ...restProps } = props;
+export function TaskPanel(props: CollapsibleBoxProps & { id?: string }) {
+  const { id, defaultExpanded, overrides: userOverrides, ...collapsibleBoxProps } = props;
+
+  const taskPanelOverrides = {
+    Container: {
+      props: {
+        id,
+        onClick: (e: MouseEvent) => e.stopPropagation(),
+      },
+    },
+    ...userOverrides,
+  };
+
   return (
-    <StatefulPanel
-      {...restProps}
-      overrides={{
-        PanelContainer: {
-          component: StyledBoxContainer,
-          props: {
-            id,
-            onClick: (e: MouseEvent) => e.stopPropagation(),
-          },
-          style: ({ $theme, $expanded }: { $expanded: boolean; $theme: Theme }) => ({
-            ...(!$expanded && { gap: 0 }),
-            transitionProperty: 'gap',
-            transitionDuration: $theme.animation.timing500,
-          }),
-        },
-        Content: {
-          style: {
-            padding: 0,
-            // paddingBottom appears provided by the StyledContent component controlled by
-            // baseui overrides padding: 0
-            paddingBottom: 0,
-          },
-        },
-        Header: {
-          style: {
-            padding: 0,
-          },
-        },
-        ToggleIcon: {
-          style: {
-            alignSelf: 'flex-start',
-          },
-        },
-      }}
+    <CollapsibleBox
+      {...collapsibleBoxProps}
+      defaultExpanded={defaultExpanded ?? false}
+      overrides={taskPanelOverrides}
     />
   );
 }


### PR DESCRIPTION
Create new CollapsibleBox component for task panels and upcoming collapsible form groups. Refactor TaskPanel to use CollapsibleBox internally, eliminating duplicate Panel configuration code.

CollapsibleBox reuses Box's styled components but exposes single-level stemantic overrides instead of merged BoxOverrides & PanelOverrides. This both clarifies the override merging behavior and improves the connection between CollapsibleBox & Panel.

CollapsibleBox supports both controlled and uncontrolled expansion modes. Controlled mode requires expanded and expansion click handler and will warn if the former exists but the latter is omitted for dev exp.

**What type of PR is this? (check all applicable)**
- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
**Production**
<img width="920" height="565" alt="Screenshot 2025-09-30 at 13 34 11" src="https://github.com/user-attachments/assets/4f3ce5dd-0912-49dd-9a6c-99c0c0118f95" />

**Local**
<img width="920" height="565" alt="Screenshot 2025-09-30 at 13 34 05" src="https://github.com/user-attachments/assets/1367a8dc-e890-4803-af3e-6396aa154893" />


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
