### PR TITLE
Add render prop pattern to Form for wrapper composition

### DIFF
--- a/javascript/packages/core/components/form/__tests__/form.test.tsx
+++ b/javascript/packages/core/components/form/__tests__/form.test.tsx
@@ -90,4 +90,79 @@ describe('Form integration', () => {
       )
     );
   });
+
+  it('supports render prop for wrapping form element', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(
+      <Form
+        id="wrapped-form"
+        onSubmit={onSubmit}
+        render={(formElement) => (
+          <div data-testid="wrapper">
+            <div data-testid="header">Header Content</div>
+            {formElement}
+            <div data-testid="footer">Footer Content</div>
+          </div>
+        )}
+      >
+        <StringField name="email" label="Email" />
+        <button type="submit">Submit</button>
+      </Form>,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+    );
+
+    expect(screen.getByTestId('wrapper')).toBeInTheDocument();
+    expect(screen.getByTestId('header')).toHaveTextContent('Header Content');
+    expect(screen.getByTestId('footer')).toHaveTextContent('Footer Content');
+    expect(screen.getByLabelText('Email')).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText('Email'), 'test@example.com');
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        { email: 'test@example.com' },
+        expect.anything(),
+        expect.anything()
+      )
+    );
+  });
+
+  it('allows external submit button in render prop wrapper via form id', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(
+      <Form
+        id="wrapped-form"
+        onSubmit={onSubmit}
+        render={(formElement) => (
+          <div data-testid="wrapper">
+            {formElement}
+            <div data-testid="footer">
+              <button type="submit" form="wrapped-form">
+                External Submit
+              </button>
+            </div>
+          </div>
+        )}
+      >
+        <StringField name="email" label="Email" />
+      </Form>,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+    );
+
+    await user.type(screen.getByLabelText('Email'), 'test@example.com');
+    await user.click(screen.getByRole('button', { name: 'External Submit' }));
+
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        { email: 'test@example.com' },
+        expect.anything(),
+        expect.anything()
+      )
+    );
+  });
 });

--- a/javascript/packages/core/components/form/form.tsx
+++ b/javascript/packages/core/components/form/form.tsx
@@ -4,27 +4,34 @@ import { useStyletron } from 'baseui';
 
 import type { FormProps } from './types';
 
-export const Form: React.FC<FormProps> = ({ onSubmit, initialValues, id, children }) => {
+export const Form: React.FC<FormProps> = ({ onSubmit, initialValues, id, children, render }) => {
   const [css, theme] = useStyletron();
 
   return (
     <FinalForm
       onSubmit={onSubmit}
       initialValues={initialValues}
-      render={({ handleSubmit }) => (
-        // react-final-form internally uses a promise to handle the form submission
-        // so we need to disable the eslint rule. I tested the execution of handleSubmit
-        // and it is synchronous.
+      render={({ handleSubmit }) => {
+        const formElement = (
+          <form
+            className={css({
+              display: 'flex',
+              flexDirection: 'column',
+              gap: theme.sizing.scale600,
+            })}
+            id={id}
+            // react-final-form internally uses a promise to handle the form submission
+            // so we need to disable the eslint rule. I tested the execution of handleSubmit
+            // and it is synchronous.
+            // eslint-disable-next-line @typescript-eslint/no-misused-promises
+            onSubmit={handleSubmit}
+          >
+            {children}
+          </form>
+        );
 
-        <form
-          className={css({ display: 'flex', flexDirection: 'column', gap: theme.sizing.scale600 })}
-          id={id}
-          // eslint-disable-next-line @typescript-eslint/no-misused-promises
-          onSubmit={handleSubmit}
-        >
-          {children}
-        </form>
-      )}
+        return render ? render(formElement) : formElement;
+      }}
     />
   );
 };

--- a/javascript/packages/core/components/form/types.ts
+++ b/javascript/packages/core/components/form/types.ts
@@ -1,9 +1,42 @@
 export interface FormProps {
   onSubmit: (values: Record<string, unknown>) => void | object | Promise<object>;
   initialValues?: Record<string, unknown>;
-  /** Form ID for external submit button integration in modals */
+
+  /** Form ID for external submit button integration */
   id?: string;
   children: React.ReactNode;
+
+  /**
+   * Optional render prop for wrapping the form element.
+   * When provided, the form element is passed to this function, allowing
+   * components outside the form element to access form state via useFormState.
+   *
+   * @example
+   * ```tsx
+   * // Form with external submit button in wrapper
+   * <Form
+   *   id="my-form"
+   *   onSubmit={handleSubmit}
+   *   render={(formElement) => (
+   *     <div>
+   *       {formElement}
+   *       <footer>
+   *         <button type="submit" form="my-form">Submit</button>
+   *       </footer>
+   *     </div>
+   *   )}
+   * >
+   *   <StringField name="email" label="Email" />
+   * </Form>
+   *
+   * // Standalone form (no render prop needed)
+   * <Form onSubmit={handleSubmit}>
+   *   <StringField name="email" label="Email" />
+   *   <button type="submit">Submit</button>
+   * </Form>
+   * ```
+   */
+  render?: (formElement: React.ReactNode) => React.ReactNode;
 }
 
 export interface FormState {


### PR DESCRIPTION
Add optional render prop to Form component that enables wrapping the form element while maintaining React Final Form context access.

Previous approach required submit buttons to be inside the form element, which prevented common UI patterns like dialog footers with action buttons. External buttons could use the form id attribute, but couldn't access form state (like submitting status) because they were outside React Final Form's context boundary.

This render prop pattern follows React conventions (similar to React Router element) where React Final Form's context wraps both the form element and its wrapper, allowing external components to use useFormState hook. This enables dialog/modal forms with footer buttons that can access submitting state.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
