### PR TITLE
[Trigger controller] fix flaky tests

### DIFF
--- a/go/components/triggerrun/controller_test.go
+++ b/go/components/triggerrun/controller_test.go
@@ -409,7 +409,11 @@ func setUpReconciler(t *testing.T, initialObjects []runtime.Object, params Param
 	scheme := runtime.NewScheme()
 	err := v2pb.AddToScheme(scheme)
 	assert.NoError(t, err)
-	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initialObjects...).Build()
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(initialObjects...).
+		WithStatusSubresource(&v2pb.TriggerRun{}).
+		Build()
 	reconciler := NewReconciler(params)
 	reconciler.Handler = apiHandler.NewFakeAPIHandler(k8sClient)
 	return *reconciler


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
Fix unit tests error on K8s version issue
The tests broke after the Kubernetes client library upgrade to v0.28.15 (PR #433). After this upgrade, the fake client's behavior changed:
Before: Status subresource updates worked automatically on fake objects
After: The fake client requires explicit configuration via .WithStatusSubresource() to enable status updates

Without this configuration, when tests called UpdateStatus() on TriggerRun objects, the fake client couldn't find the resources because the status subresource wasn't properly registered.

<!-- Tell your future self why have you made these changes -->
**Why?**
Added .WithStatusSubresource(&v2pb.TriggerRun{}) to the fake client builder in the setUpReconciler() function to consolidate to K8s library upgrade.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested locally

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
N/A
<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
N/A