### PR TITLE
Add CRD naming utilities for resource generation

### DIFF
--- a/javascript/packages/core/utils/__tests__/name-utils.tests.ts
+++ b/javascript/packages/core/utils/__tests__/name-utils.tests.ts
@@ -1,0 +1,42 @@
+import { vi } from 'vitest';
+
+import { generateSuffix } from '../name-utils';
+
+const mockCrypto = {
+  randomUUID: vi.fn(() => 'abcd1234-5678-90ef-ghij-klmnopqrstuv'),
+};
+Object.defineProperty(global, 'crypto', {
+  value: mockCrypto,
+  writable: true,
+});
+
+// Mock Date constructor for predictable timestamps
+const originalDate = Date;
+const mockDate = new Date('2024-01-01T12:00:00.000Z');
+
+beforeEach(() => {
+  // @ts-expect-error only mocking Date methods required for testing
+  global.Date = vi.fn(() => mockDate);
+  global.Date.parse = originalDate.parse;
+});
+
+afterEach(() => {
+  global.Date = originalDate;
+});
+
+describe('generateSuffix', () => {
+  it('should generate suffix without date by default', () => {
+    const result = generateSuffix();
+    expect(result).toBe('-abcd1234');
+  });
+
+  it('should generate suffix without date when withDate is false', () => {
+    const result = generateSuffix({ withDate: false });
+    expect(result).toBe('-abcd1234');
+  });
+
+  it('should generate suffix with date when withDate is true', () => {
+    const result = generateSuffix({ withDate: true });
+    expect(result).toBe('-20240101-120000-abcd1234');
+  });
+});

--- a/javascript/packages/core/utils/__tests__/time-utils.test.ts
+++ b/javascript/packages/core/utils/__tests__/time-utils.test.ts
@@ -1,4 +1,4 @@
-import { getDateFromEpochSeconds, getEpochSecondsFromDate } from '../time-utils';
+import { getDateFromEpochSeconds, getEpochSecondsFromDate, parseISOString } from '../time-utils';
 
 describe('time-utils', () => {
   describe('getDateFromEpochSeconds', () => {
@@ -54,6 +54,52 @@ describe('time-utils', () => {
       const backToEpochSeconds = getEpochSecondsFromDate(date);
 
       expect(backToEpochSeconds).toBe(originalEpochSeconds);
+    });
+  });
+
+  describe('parseISOString', () => {
+    const validCases = [
+      {
+        input: '2024-01-01T12:00:00.000Z',
+        expected: { date: '2024-01-01', time: '12:00:00.000Z' },
+        description: 'standard ISO string with milliseconds',
+      },
+      {
+        input: '2024-12-25T23:59:59Z',
+        expected: { date: '2024-12-25', time: '23:59:59Z' },
+        description: 'ISO string without milliseconds',
+      },
+      {
+        input: '2024-02-29T00:00:00.000Z',
+        expected: { date: '2024-02-29', time: '00:00:00.000Z' },
+        description: 'leap year date',
+      },
+      {
+        input: '1970-01-01T00:00:00.000Z',
+        expected: { date: '1970-01-01', time: '00:00:00.000Z' },
+        description: 'Unix epoch start',
+      },
+    ];
+
+    const invalidCases = [
+      { input: 'invalid-date', description: 'completely invalid string' },
+      { input: '2024-13-01T12:00:00.000Z', description: 'invalid month' },
+      { input: 'not-a-date', description: 'non-date string' },
+      { input: '', description: 'empty string' },
+      { input: '2024-01-01 12:00:00', description: 'space instead of T separator' },
+      { input: '2024-01-01', description: 'date only, no time' },
+      { input: '12:00:00', description: 'time only, no date' },
+      { input: '2024-01-01T12:00:00T.000Z', description: 'multiple T separators' },
+    ];
+
+    test.each(validCases)('should parse $description', ({ input, expected }) => {
+      const result = parseISOString(input);
+      expect(result).toEqual(expected);
+    });
+
+    test.each(invalidCases)('should return null for $description', ({ input }) => {
+      const result = parseISOString(input);
+      expect(result).toBe(null);
     });
   });
 });

--- a/javascript/packages/core/utils/name-utils.ts
+++ b/javascript/packages/core/utils/name-utils.ts
@@ -1,0 +1,43 @@
+import { parseISOString } from './time-utils';
+
+const SUFFIX_DELIMITER = '-';
+const UUID_SUFFIX_LENGTH = 8;
+
+/**
+ * Generates a suffix to use when generating CRD names. Optionally includes a date suffix
+ * before the UUID suffix. The UUID suffix is eight characters long.
+ *
+ * @example
+ * ```ts
+ * // Assuming the current date is 2024-01-01 12:00:00 UTC
+ * generateSuffix() // returns '-abcd1234'
+ * generateSuffix({ withDate: true }) // returns '-20240101-120000-abcd1234'
+ *
+ * // Usage when creating a pipeline run
+ * const pipelineRunName = `run-${generateSuffix({ withDate: true })}`;
+ * expect(pipelineRunName).toBe('run-20240101-120000-abcd1234');
+ * ```
+ */
+export const generateSuffix = (config: { withDate: boolean } = { withDate: false }): string => {
+  const uuidSuffix = `${SUFFIX_DELIMITER}${crypto.randomUUID().substring(0, UUID_SUFFIX_LENGTH)}`;
+
+  if (config.withDate) {
+    const isoString = new Date().toISOString();
+    const parsed = parseISOString(isoString);
+
+    if (!parsed) {
+      console.warn('Date.toISOString() returned an invalid ISO string', isoString);
+      return uuidSuffix;
+    }
+
+    const { date, time } = parsed;
+    const compactDate = date.replace(/-/g, ''); // "2024-01-01" -> "20240101"
+
+    // Remove milliseconds/timezone: "12:00:00.000Z" -> "12:00:00" -> "120000"
+    const compactTime = time.replace(/\..*$/, '').replace(/:/g, '');
+
+    return `${SUFFIX_DELIMITER}${compactDate}-${compactTime}${uuidSuffix}`;
+  }
+
+  return uuidSuffix;
+};

--- a/javascript/packages/core/utils/time-utils.ts
+++ b/javascript/packages/core/utils/time-utils.ts
@@ -67,3 +67,29 @@ export function getDateFromEpochSeconds(epochSeconds: number): Date {
 export function getEpochSecondsFromDate(date: Date): number {
   return Math.floor(date.getTime() / 1000);
 }
+
+/**
+ * Parses an ISO string into date and time components.
+ *
+ * @param isoString - ISO date string like "2024-01-01T12:00:00.000Z"
+ * @returns Object with compact date and time strings, or null if invalid
+ *
+ * @example
+ * parseISOString("2024-01-01T12:00:00.000Z")
+ * // { date: "2024-01-01", time: "12:00:00" }
+ *
+ * parseISOString("invalid") // null
+ */
+export function parseISOString(isoString: string): { date: string; time: string } | null {
+  if (isNaN(Date.parse(isoString))) {
+    return null;
+  }
+
+  // "2024-01-01T12:00:00.000Z" -> ["2024-01-01", "12:00:00.000Z"]
+  const parts = isoString.split('T');
+  if (parts.length !== 2) {
+    return null;
+  }
+
+  return { date: parts[0], time: parts[1] };
+}


### PR DESCRIPTION
Create standardized naming utilities to support consistent resource naming across pipeline runs, triggers, and drafts following CRD naming conventions.

Pipeline runs require human-readable timestamps for operator identification and debugging, while other resources need simple UUID suffixes for uniqueness. This dual approach addresses the different operational needs: operators distinguishing between pipeline executions versus system-generated resource identification.

The implementation uses native browser APIs and avoids external dependencies like moment. I did not find a native mechanism for getting concatenated date/time strings, (gets 20251006 for YYYYMMDD date and 100820 for HHMMSS time). The implementation depends on the standardization of ISO strings (T after time completes) instead of hardcoded number indices or constants.

Date-based naming format (YYYYMMDD-HHMMSS-uuid8) provides sortable, human-readable identifiers that help operators correlate pipeline runs with logs and monitoring data.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
