### PR TITLE
Add Observed generation to conditions

### DIFF
--- a/proto/api/conditions.proto
+++ b/proto/api/conditions.proto
@@ -33,6 +33,9 @@ message Condition {
 
   // Condition and plugin specific information that can be stored in between condition evluations.
   google.protobuf.Any metadata = 6;
+
+  // ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+  int64 observed_generation = 7;
 }
 
 // Defines the status of a condition.


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**
- Added `int64 observed_generation = 7;` to `Condition` in `proto/api/conditions.proto`.
- Documented it as the `.metadata.generation` the condition was set based upon.

**Why?**
- To record the resource generation a condition corresponds to, enabling consumers to detect stale conditions and align with Kubernetes’ ObservedGeneration semantics.

**How did you test it?**
- Schema-only change; verified the diff and that the `.proto` compiles locally.
- No runtime behavior in this PR; consequent job controllers use this field. 

**Potential risks**
- NA

**Release notes**
- API: Added `Condition.observed_generation` (int64, field 7). Backward-compatible for Protobuf; regenerate client/server stubs to access the new field.

**Documentation Changes**
- NA