### PR TITLE
Add PageHeader component

### DIFF
--- a/javascript/packages/core/components/page-header/__tests__/page-header.test.tsx
+++ b/javascript/packages/core/components/page-header/__tests__/page-header.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Alert } from 'baseui/icon';
+import { vi } from 'vitest';
+
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
+import { getIconProviderWrapper } from '#core/test/wrappers/get-icon-provider-wrapper';
+import { PageHeader } from '../page-header';
+
+describe('PageHeader', () => {
+  const originalWindowOpen = window.open;
+
+  beforeEach(() => {
+    window.open = vi.fn();
+  });
+
+  afterEach(() => {
+    window.open = originalWindowOpen;
+  });
+
+  test('renders label text', () => {
+    render(<PageHeader label="My Page Title" />, buildWrapper([getBaseProviderWrapper()]));
+
+    expect(screen.getByRole('heading', { name: 'My Page Title' })).toBeInTheDocument();
+  });
+
+  test('renders icon when provided', () => {
+    render(
+      <PageHeader label="Train & Evaluate" icon="chartLine" />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper({ icons: { chartLine: Alert } }),
+      ])
+    );
+
+    expect(screen.getByRole('img', { name: 'Alert' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Train & Evaluate' })).toBeInTheDocument();
+  });
+
+  test('renders description when provided', () => {
+    render(
+      <PageHeader label="Title" description="This is a description" />,
+      buildWrapper([getBaseProviderWrapper()])
+    );
+
+    expect(screen.getByText('This is a description')).toBeInTheDocument();
+  });
+
+  test('renders documentation button when docUrl is provided with description', () => {
+    render(
+      <PageHeader label="Title" description="Description text" docUrl="https://docs.example.com" />,
+      buildWrapper([getBaseProviderWrapper()])
+    );
+
+    expect(screen.getByRole('button', { name: /learn more/i })).toBeInTheDocument();
+  });
+
+  test('does not render documentation button when docUrl provided without description', () => {
+    render(
+      <PageHeader label="Title" docUrl="https://docs.example.com" />,
+      buildWrapper([getBaseProviderWrapper()])
+    );
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  test('opens documentation URL in new window when button clicked', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <PageHeader
+        label="Title"
+        description="Description"
+        docUrl="https://docs.example.com/guide"
+      />,
+      buildWrapper([getBaseProviderWrapper()])
+    );
+
+    await user.click(screen.getByRole('button', { name: /learn more/i }));
+
+    expect(window.open).toHaveBeenCalledWith('https://docs.example.com/guide', '_blank');
+  });
+});

--- a/javascript/packages/core/components/page-header/page-header.tsx
+++ b/javascript/packages/core/components/page-header/page-header.tsx
@@ -1,0 +1,78 @@
+import { useStyletron } from 'baseui';
+import { Button, KIND, SHAPE, SIZE } from 'baseui/button';
+import { HeadingSmall } from 'baseui/typography';
+
+import { DescriptionText } from '#core/components/description-text';
+import { Icon } from '#core/components/icon/icon';
+
+import type { PageHeaderProps } from './types';
+
+/**
+ * Page header component for displaying page titles, icons, descriptions, and documentation links.
+ *
+ * @example
+ * ```tsx
+ * // Phase header with all features
+ * <PageHeader
+ *   icon="chartLine"
+ *   label="Train & Evaluate"
+ *   description="Train machine learning models and evaluate their performance"
+ *   docUrl="https://docs.example.com/train"
+ * />
+ *
+ * // Simple header without icon
+ * <PageHeader label="My Page Title" />
+ * ```
+ */
+export function PageHeader({ icon, docUrl, label, description }: PageHeaderProps) {
+  const [css, theme] = useStyletron();
+
+  return (
+    <div
+      className={css({ display: 'flex', justifyContent: 'space-between', alignItems: 'center' })}
+    >
+      <div
+        className={css({
+          display: 'grid',
+          gridTemplateColumns: icon ? 'auto 1fr' : '1fr',
+          gridTemplateRows: 'auto auto',
+          columnGap: theme.sizing.scale500,
+          rowGap: theme.sizing.scale100,
+          alignItems: 'center',
+        })}
+      >
+        {icon && <Icon name={icon} size={theme.sizing.scale600} />}
+        <HeadingSmall as="h2" className={css({ margin: 0 })}>
+          {label}
+        </HeadingSmall>
+        {description && icon && <div />}
+        {description && (
+          <DescriptionText>
+            {description}
+            {docUrl && (
+              <Button
+                aria-label="Learn more"
+                kind={KIND.tertiary}
+                onClick={() => window.open(docUrl, '_blank')}
+                shape={SHAPE.circle}
+                size={SIZE.mini}
+                overrides={{
+                  BaseButton: {
+                    style: {
+                      // Default Button height includes container for hover effect, which results in
+                      // unwanted vertical space between the description text and the label
+                      height: theme.typography.ParagraphSmall.lineHeight,
+                      width: theme.typography.ParagraphSmall.lineHeight,
+                    },
+                  },
+                }}
+              >
+                <Icon name="arrowLaunch" size={theme.sizing.scale500} />
+              </Button>
+            )}
+          </DescriptionText>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/javascript/packages/core/components/page-header/types.ts
+++ b/javascript/packages/core/components/page-header/types.ts
@@ -1,0 +1,22 @@
+export interface PageHeaderProps {
+  /**
+   * Icon name from the icon provider system.
+   * When provided, creates a 2-column grid layout with icon in the left column.
+   */
+  icon?: string;
+
+  /** Main heading text displayed in the header */
+  label: string;
+
+  /**
+   * Optional description text displayed below the label.
+   * Supports inline documentation link when combined with docUrl.
+   */
+  description?: string;
+
+  /**
+   * Optional URL to external documentation.
+   * When provided with description, renders a "Learn more" button with arrow icon.
+   */
+  docUrl?: string;
+}

--- a/javascript/packages/core/components/views/phase-entity-view/phase-entity-view.tsx
+++ b/javascript/packages/core/components/views/phase-entity-view/phase-entity-view.tsx
@@ -6,9 +6,11 @@ import { Tab, Tabs } from 'baseui/tabs-motion';
 import { ErrorView } from '#core/components/error-view/error-view';
 import { CircleExclamationMark } from '#core/components/illustrations/circle-exclamation-mark/circle-exclamation-mark';
 import { CircleExclamationMarkKind } from '#core/components/illustrations/circle-exclamation-mark/types';
+import { PageHeader } from '#core/components/page-header/page-header';
 import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
 import { EntityTable } from './entity-table';
 
+import type { Theme } from 'baseui/theme';
 import type { PhaseEntityViewProps } from './types';
 
 /**
@@ -18,18 +20,18 @@ import type { PhaseEntityViewProps } from './types';
  * entity if no entity in URL to prevent empty states.
  */
 export function PhaseEntityView<T extends object = object>({
-  phaseId,
+  phaseConfig,
   entities,
 }: PhaseEntityViewProps<T>) {
-  const [, theme] = useStyletron();
+  const [css, theme] = useStyletron();
   const navigate = useNavigate();
   const { projectId, entity: currentEntity } = useStudioParams('list');
 
   useEffect(() => {
     if (!currentEntity) {
-      navigate(`/${projectId}/${phaseId}/${entities[0].id}`);
+      navigate(`/${projectId}/${phaseConfig.id}/${entities[0].id}`);
     }
-  }, [currentEntity, navigate, projectId, phaseId, entities]);
+  }, [currentEntity, navigate, projectId, phaseConfig.id, entities]);
 
   const currentEntityIndex = entities.findIndex((entity) => entity.id === currentEntity);
   const activeKey = currentEntityIndex >= 0 ? currentEntityIndex.toString() : '0';
@@ -37,7 +39,7 @@ export function PhaseEntityView<T extends object = object>({
   const routeToEntity = ({ activeKey }: { activeKey: React.Key }) => {
     const selectedEntity = entities[Number(activeKey)];
     if (selectedEntity) {
-      navigate(`/${projectId}/${phaseId}/${selectedEntity.id}`);
+      navigate(`/${projectId}/${phaseConfig.id}/${selectedEntity.id}`);
     }
   };
 
@@ -62,21 +64,39 @@ export function PhaseEntityView<T extends object = object>({
   }
 
   return (
-    <Tabs activeKey={activeKey} onChange={routeToEntity}>
-      {entities.map((entity, index) => (
-        <Tab key={String(index)} title={entity.name}>
-          {String(index) === activeKey && (
-            <EntityTable<T>
-              service={entity.service}
-              tableConfig={{
-                ...currentEntityConfig.views[0].tableConfig,
-                actions: entity.actions,
-              }}
-              tableSettingsId={`${phaseId}/${entity.id}`}
-            />
-          )}
-        </Tab>
-      ))}
-    </Tabs>
+    <div className={css({ marginTop: theme.sizing.scale800 })}>
+      <PageHeader
+        icon={phaseConfig.icon}
+        label={phaseConfig.name}
+        description={phaseConfig.description}
+        docUrl={phaseConfig.docUrl}
+      />
+      <Tabs
+        activeKey={activeKey}
+        onChange={routeToEntity}
+        overrides={{
+          Root: {
+            style: ({ $theme }: { $theme: Theme }) => ({
+              marginTop: $theme.sizing.scale600,
+            }),
+          },
+        }}
+      >
+        {entities.map((entity, index) => (
+          <Tab key={String(index)} title={entity.name}>
+            {String(index) === activeKey && (
+              <EntityTable<T>
+                service={entity.service}
+                tableConfig={{
+                  ...currentEntityConfig.views[0].tableConfig,
+                  actions: entity.actions,
+                }}
+                tableSettingsId={`${phaseConfig.id}/${entity.id}`}
+              />
+            )}
+          </Tab>
+        ))}
+      </Tabs>
+    </div>
   );
 }

--- a/javascript/packages/core/components/views/phase-entity-view/types.ts
+++ b/javascript/packages/core/components/views/phase-entity-view/types.ts
@@ -1,5 +1,5 @@
 import type { ListViewConfig, TableConfig, ViewConfig } from '#core/components/views/types';
-import type { PhaseEntityConfig } from '#core/types/common/studio-types';
+import type { PhaseConfig, PhaseEntityConfig } from '#core/types/common/studio-types';
 import type { QueryConfig } from '#core/types/query-types';
 
 export type ListableEntity<T extends object = object> = PhaseEntityConfig<T> & {
@@ -8,7 +8,12 @@ export type ListableEntity<T extends object = object> = PhaseEntityConfig<T> & {
 };
 
 export interface PhaseEntityViewProps<T extends object = object> {
-  phaseId: string;
+  /**
+   * Listable entities passed separately via entities prop; phaseConfig is used for
+   * other metadata
+   */
+  phaseConfig: Omit<PhaseConfig, 'entities'>;
+
   entities: ListableEntity<T>[];
 }
 

--- a/javascript/packages/core/router/__tests__/phase-list-route.test.tsx
+++ b/javascript/packages/core/router/__tests__/phase-list-route.test.tsx
@@ -1,11 +1,13 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { Alert } from 'baseui/icon';
 import { vi } from 'vitest';
 
 import { CellType } from '#core/components/cell/constants';
 import { buildTableConfigFactory } from '#core/components/views/__fixtures__/table-config-factory';
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getErrorProviderWrapper } from '#core/test/wrappers/get-error-provider-wrapper';
+import { getIconProviderWrapper } from '#core/test/wrappers/get-icon-provider-wrapper';
 import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
 import { getServiceProviderWrapper } from '#core/test/wrappers/get-service-provider-wrapper';
 import {
@@ -375,5 +377,45 @@ describe('PhaseListRoute', () => {
 
     expect(screen.getByRole('tab', { name: 'Pipelines' })).toBeInTheDocument();
     expect(screen.queryByRole('tab', { name: 'Pipeline Runs' })).not.toBeInTheDocument();
+  });
+
+  test('renders phase header with config metadata', () => {
+    const configWithDescription = {
+      train: buildPhase({
+        id: 'train',
+        icon: 'train',
+        name: 'Train & Evaluate',
+        description: 'Train machine learning models and evaluate their performance',
+        docUrl: 'https://docs.example.com',
+        entities: [
+          buildEntity({
+            id: 'pipelines',
+            name: 'Pipelines',
+            service: 'pipeline',
+          }),
+        ],
+      }),
+    };
+
+    const mockRequest = vi.fn().mockResolvedValue({
+      pipelineList: { items: [] },
+    });
+
+    render(
+      <PhaseListRoute phases={configWithDescription} />,
+      buildWrapper([
+        getErrorProviderWrapper(),
+        getRouterWrapper({ location: '/myproject/train/pipelines' }),
+        getServiceProviderWrapper({ request: mockRequest }),
+        getIconProviderWrapper({ icons: { train: Alert } }),
+      ])
+    );
+
+    expect(screen.getByRole('img', { name: 'Alert' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Train & Evaluate' })).toBeInTheDocument();
+    expect(
+      screen.getByText('Train machine learning models and evaluate their performance')
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Learn more' })).toBeInTheDocument();
   });
 });

--- a/javascript/packages/core/router/phase-list-route.tsx
+++ b/javascript/packages/core/router/phase-list-route.tsx
@@ -65,5 +65,5 @@ export function PhaseListRoute({ phases = PHASES }: { phases?: Record<string, Ph
     );
   }
 
-  return <PhaseEntityView phaseId={phase} entities={listableEntities} />;
+  return <PhaseEntityView phaseConfig={phases[phase]} entities={listableEntities} />;
 }


### PR DESCRIPTION
Create PageHeader component to display page titles with optional icons, descriptions, and documentation links. Uses CSS Grid to ensure title and description text align vertically regardless of whether an icon is present.

Eliminate data duplication in PhaseEntityView by deriving phase ID from phaseConfig.id instead of passing it separately, and omit entities from phaseConfig type since they're passed as a separate prop. This prevents potential bugs from passing conflicting data through multiple props.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
With all props
<img width="1840" height="1128" alt="Screenshot 2025-10-09 at 07 45 27" src="https://github.com/user-attachments/assets/4d374965-0be8-41ab-bedd-fc307fcd2512" />

No Icon
<img width="1840" height="1128" alt="Screenshot 2025-10-09 at 07 45 43" src="https://github.com/user-attachments/assets/5cc52db0-728b-45b2-916c-d11d60ba69f1" />

No description
<img width="1840" height="1128" alt="Screenshot 2025-10-09 at 07 45 48" src="https://github.com/user-attachments/assets/80d4b350-ff68-46e6-801d-041dae438063" />

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
