### PR TITLE
refactor(Worker): Rename UAPI Plugin to Model

### DIFF
--- a/go/worker/plugins/model/BUILD.bazel
+++ b/go/worker/plugins/model/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
         "plugin.go",
         "starlark_module.go",
     ],
-    importpath = "github.com/michelangelo-ai/michelangelo/go/worker/plugins/uapi",
+    importpath = "github.com/michelangelo-ai/michelangelo/go/worker/plugins/model",
     visibility = ["//visibility:public"],
     deps = [
         "//go/worker/activities/model:go_default_library",

--- a/go/worker/plugins/model/model.star
+++ b/go/worker/plugins/model/model.star
@@ -1,5 +1,5 @@
 """
-uapi_plugins.star allows you to implement uapi plugins in starlark code.
+model.star allows you to implement plugins related to managing models in starlark code.
 
 Functions:
     model_search: searches for a model based on the specified criteria.
@@ -15,7 +15,7 @@ Functions:
                 model_revision_id: int: RevisionID of the model
 """
 
-load("@plugin", "uapi")
+load("@plugin", "model")
 
 def main():
     return test_model_search()
@@ -28,5 +28,5 @@ def test_model_search():
     namespace = "default"
     deployment_name = "test-model"
 
-    data = uapi.model_search(namespace, deployment_name)
+    data = model.model_search(namespace, deployment_name)
     return data

--- a/go/worker/plugins/model/plugin.go
+++ b/go/worker/plugins/model/plugin.go
@@ -1,4 +1,4 @@
-package uapi
+package model
 
 import (
 	"github.com/cadence-workflow/starlark-worker/service"
@@ -6,7 +6,7 @@ import (
 	"go.starlark.net/starlark"
 )
 
-const pluginID = "uapi"
+const pluginID = "model"
 
 var Plugin = &plugin{}
 

--- a/go/worker/plugins/model/starlark_module.go
+++ b/go/worker/plugins/model/starlark_module.go
@@ -1,4 +1,4 @@
-package uapi
+package model
 
 import (
 	"fmt"

--- a/go/worker/plugins/model/starlark_module_test.go
+++ b/go/worker/plugins/model/starlark_module_test.go
@@ -1,4 +1,4 @@
-package uapi
+package model
 
 import (
 	"testing"
@@ -11,7 +11,7 @@ import (
 
 	"github.com/michelangelo-ai/michelangelo/go/worker/plugins/utils"
 
-	uapi "github.com/michelangelo-ai/michelangelo/go/worker/activities/model"
+	modelactivities "github.com/michelangelo-ai/michelangelo/go/worker/activities/model"
 )
 
 type Test struct {
@@ -40,14 +40,14 @@ func (r *Test) TearDownTest() {
 // In particular, we ensure that the plugin returns a starlark.Dict with the correct fields and excludes deprecated fields.
 func (r *Test) TestModelSearch() {
 	env := r.env.Cadence.GetTestWorkflowEnvironment()
-	env.RegisterActivity(uapi.Activities.ModelSearch)
-	modelSearchActivityResponse := &uapi.ModelSearchResponse{
+	env.RegisterActivity(modelactivities.Activities.ModelSearch)
+	modelSearchActivityResponse := &modelactivities.ModelSearchResponse{
 		ModelName:       "test-model",
 		ModelRevisionID: 0,
 		Namespace:       "test-namespace",
 	}
 
-	env.OnActivity(uapi.Activities.ModelSearch, mock.Anything, mock.Anything).Once().Return(modelSearchActivityResponse, nil)
+	env.OnActivity(modelactivities.Activities.ModelSearch, mock.Anything, mock.Anything).Once().Return(modelSearchActivityResponse, nil)
 	r.env.Cadence.ExecuteFunction("/test.star", "test_model_search", nil, nil, nil)
 	require := r.Require()
 	var gotResponse *starlark.Dict
@@ -85,8 +85,8 @@ func (r *Test) TestModelSearch() {
 // TestModelSearchWithActivityError checks if the modelsearch plugin returns an error when the activity fails.
 func (r *Test) TestModelSearchWithActivityError() {
 	env := r.env.Cadence.GetTestWorkflowEnvironment()
-	env.RegisterActivity(uapi.Activities.ModelSearch)
-	env.OnActivity(uapi.Activities.ModelSearch, mock.Anything, mock.Anything).Once().Return(nil, cadence.NewCustomError("activity error"))
+	env.RegisterActivity(modelactivities.Activities.ModelSearch)
+	env.OnActivity(modelactivities.Activities.ModelSearch, mock.Anything, mock.Anything).Once().Return(nil, cadence.NewCustomError("activity error"))
 	r.env.Cadence.ExecuteFunction("/test.star", "test_model_search", nil, nil, nil)
 	require := r.Require()
 	var res any

--- a/go/worker/plugins/model/testdata/test.star
+++ b/go/worker/plugins/model/testdata/test.star
@@ -1,7 +1,7 @@
-load("@plugin", "uapi")
+load("@plugin", "model")
 
 def test_model_search():
-    return uapi.model_search(
+    return model.model_search(
         namespace = "default",
         deployment_name = "test-model-deployment",
     )

--- a/go/worker/starlark/BUILD.bazel
+++ b/go/worker/starlark/BUILD.bazel
@@ -7,10 +7,10 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//go/worker/plugins/cachedoutput:go_default_library",
+        "//go/worker/plugins/model:go_default_library",
         "//go/worker/plugins/ray:go_default_library",
         "//go/worker/plugins/spark:go_default_library",
         "//go/worker/plugins/storage:go_default_library",
-        "//go/worker/plugins/uapi:go_default_library",
         "@com_github_cadence_workflow_starlark_worker//service:go_default_library",
         "@com_github_cadence_workflow_starlark_worker//worker:go_default_library",
         "@org_uber_go_fx//:go_default_library",

--- a/go/worker/starlark/module.go
+++ b/go/worker/starlark/module.go
@@ -8,10 +8,10 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/michelangelo-ai/michelangelo/go/worker/plugins/cachedoutput"
+	"github.com/michelangelo-ai/michelangelo/go/worker/plugins/model"
 	"github.com/michelangelo-ai/michelangelo/go/worker/plugins/ray"
 	"github.com/michelangelo-ai/michelangelo/go/worker/plugins/spark"
 	"github.com/michelangelo-ai/michelangelo/go/worker/plugins/storage"
-	"github.com/michelangelo-ai/michelangelo/go/worker/plugins/uapi"
 )
 
 // RegisterStoragePlugin adds the storage plugin to the plugin registry.
@@ -34,9 +34,9 @@ func RegisterSparkPlugin(registry map[string]service.IPlugin) {
 	registry[spark.Plugin.ID()] = spark.Plugin
 }
 
-// RegisterUAPIPlugin adds the uapi plugin to the plugin registry.
-func RegisterUAPIPlugin(registry map[string]service.IPlugin) {
-	registry[uapi.Plugin.ID()] = uapi.Plugin
+// RegisterModelPlugin adds the model plugin to the plugin registry.
+func RegisterModelPlugin(registry map[string]service.IPlugin) {
+	registry[model.Plugin.ID()] = model.Plugin
 }
 
 // CreateStarlarkService creates the starlark service with all registered plugins.
@@ -61,6 +61,6 @@ var Module = fx.Options(
 	fx.Invoke(RegisterCachedOutputPlugin),
 	fx.Invoke(RegisterRayPlugin),
 	fx.Invoke(RegisterSparkPlugin),
-	fx.Invoke(RegisterUAPIPlugin),
+	fx.Invoke(RegisterModelPlugin),
 	fx.Invoke(CreateStarlarkService),
 )


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
The current pattern for Starlark plugin enforces that each entity remains its own plugin. Renaming `UAPI` plugin to `Model` to stay consistent with the pattern.