### PR TITLE
Add generic type support to form system

### DIFF
--- a/javascript/packages/core/components/form/components/form-dialog/form-dialog.tsx
+++ b/javascript/packages/core/components/form/components/form-dialog/form-dialog.tsx
@@ -1,4 +1,4 @@
-import React, { useId } from 'react';
+import { useId } from 'react';
 import { Button, KIND } from 'baseui/button';
 import { PLACEMENT, SIZE } from 'baseui/dialog';
 import { FORM_ERROR } from 'final-form';
@@ -8,6 +8,7 @@ import { FormErrorBanner } from '#core/components/form/components/form-error-ban
 import { SubmitButton } from '#core/components/form/components/submit-button/submit-button';
 import { Form } from '#core/components/form/form';
 
+import type { FormData } from '#core/components/form/types';
 import type { FormDialogProps } from './types';
 
 /**
@@ -34,7 +35,7 @@ import type { FormDialogProps } from './types';
  * </FormDialog>
  * ```
  */
-export const FormDialog: React.FC<FormDialogProps> = ({
+export const FormDialog = <FieldValues extends FormData = FormData>({
   isOpen,
   onDismiss,
   heading,
@@ -43,10 +44,10 @@ export const FormDialog: React.FC<FormDialogProps> = ({
   initialValues,
   submitLabel = 'Submit',
   children,
-}) => {
+}: FormDialogProps<FieldValues>) => {
   const formId = useId();
 
-  const handleSubmit = async (values: Record<string, unknown>) => {
+  const handleSubmit = async (values: FieldValues) => {
     try {
       await onSubmit(values);
       onDismiss(); // Auto-close on successful submit
@@ -56,7 +57,7 @@ export const FormDialog: React.FC<FormDialogProps> = ({
   };
 
   return (
-    <Form
+    <Form<FieldValues>
       id={formId}
       initialValues={initialValues}
       onSubmit={handleSubmit}

--- a/javascript/packages/core/components/form/components/form-dialog/types.ts
+++ b/javascript/packages/core/components/form/components/form-dialog/types.ts
@@ -1,8 +1,8 @@
 import type { Size as DialogSize } from 'baseui/dialog';
-import type { FormProps } from '#core/components/form/types';
+import type { FormData, FormProps } from '#core/components/form/types';
 
-export interface FormDialogProps
-  extends Pick<FormProps, 'onSubmit' | 'initialValues' | 'children'> {
+export interface FormDialogProps<FieldValues extends FormData = FormData>
+  extends Pick<FormProps<FieldValues>, 'onSubmit' | 'initialValues' | 'children'> {
   isOpen: boolean;
   onDismiss: () => void;
   heading: string;

--- a/javascript/packages/core/components/form/fields/string/string-field.tsx
+++ b/javascript/packages/core/components/form/fields/string/string-field.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Input } from 'baseui/input';
 
 import { FormControl } from '#core/components/form/components/form-control';

--- a/javascript/packages/core/components/form/fields/types.ts
+++ b/javascript/packages/core/components/form/fields/types.ts
@@ -3,6 +3,7 @@ export interface BaseFieldProps {
    *
    *  - Identifies the field input in the form
    *  - Corresponds to the data key in the form object
+   *  - Supports dot notation for nested fields (e.g., "user.name", "spec.pipeline.name")
    *
    * Learn more:{@link https://final-form.org/docs/final-form/field-names}
    */

--- a/javascript/packages/core/components/form/form.tsx
+++ b/javascript/packages/core/components/form/form.tsx
@@ -1,10 +1,15 @@
-import React from 'react';
 import { Form as FinalForm } from 'react-final-form';
 import { useStyletron } from 'baseui';
 
-import type { FormProps } from './types';
+import type { FormData, FormProps } from './types';
 
-export const Form: React.FC<FormProps> = ({ onSubmit, initialValues, id, children, render }) => {
+export const Form = <FieldValues extends FormData = FormData>({
+  onSubmit,
+  initialValues,
+  id,
+  children,
+  render,
+}: FormProps<FieldValues>) => {
   const [css, theme] = useStyletron();
 
   return (

--- a/javascript/packages/core/components/form/hooks/use-form-state.ts
+++ b/javascript/packages/core/components/form/hooks/use-form-state.ts
@@ -1,12 +1,14 @@
 import { useFormState as useReactFinalFormState } from 'react-final-form';
 
-import type { FormState } from '../types';
+import type { FormData, FormState } from '../types';
 
 /**
  * Hook for accessing form state with customizable subscriptions.
  *
  * @param subscription - Object specifying which state properties to subscribe to.
  *                      If not provided, subscribes to all available properties.
+ *
+ * @generic FieldValues - The shape of the form data. Defaults to {@link FormData}
  *
  * @example
  * ```tsx
@@ -20,17 +22,18 @@ import type { FormState } from '../types';
  * const formState = useFormState();
  * ```
  */
-export function useFormState(): FormState;
-export function useFormState(
-  subscription: Partial<Record<keyof FormState, boolean>>
-): Partial<FormState>;
-export function useFormState(
-  subscription?: Partial<Record<keyof FormState, boolean>>
-): FormState | Partial<FormState> {
+export function useFormState<FieldValues extends FormData = FormData>(): FormState<FieldValues>;
+export function useFormState<FieldValues extends FormData = FormData>(
+  subscription: Partial<Record<keyof FormState<FieldValues>, boolean>>
+): Partial<FormState<FieldValues>>;
+export function useFormState<FieldValues extends FormData = FormData>(
+  subscription?: Partial<Record<keyof FormState<FieldValues>, boolean>>
+): FormState<FieldValues> | Partial<FormState<FieldValues>> {
   const reactFinalFormSubscription = subscription
     ? {
         submitting: subscription.submitting,
         submitError: subscription.submitError,
+        values: subscription.values,
       }
     : undefined;
 
@@ -41,5 +44,6 @@ export function useFormState(
   return {
     submitting: formState.submitting,
     submitError: formState.submitError as unknown,
-  } as FormState | Partial<FormState>;
+    values: formState.values as FieldValues | undefined,
+  } as FormState<FieldValues> | Partial<FormState<FieldValues>>;
 }

--- a/javascript/packages/core/components/form/types.ts
+++ b/javascript/packages/core/components/form/types.ts
@@ -1,6 +1,10 @@
-export interface FormProps {
-  onSubmit: (values: Record<string, unknown>) => void | object | Promise<object>;
-  initialValues?: Record<string, unknown>;
+import type { DeepPartial } from '#core/types/utility-types';
+
+export type FormData = Record<string, unknown>;
+
+export interface FormProps<FieldValues extends FormData = FormData> {
+  onSubmit: (values: FieldValues) => void | object | Promise<object>;
+  initialValues?: DeepPartial<FieldValues>;
 
   /** Form ID for external submit button integration */
   id?: string;
@@ -39,9 +43,10 @@ export interface FormProps {
   render?: (formElement: React.ReactNode) => React.ReactNode;
 }
 
-export interface FormState {
+export interface FormState<FieldValues extends FormData = FormData> {
   submitting: boolean;
   submitError?: string;
+  values?: FieldValues;
 }
 
 export interface FieldState {

--- a/javascript/packages/core/config/entities/pipeline/create-pipeline-run-dialog.tsx
+++ b/javascript/packages/core/config/entities/pipeline/create-pipeline-run-dialog.tsx
@@ -8,14 +8,18 @@ import { useStudioMutation } from '#core/hooks/use-studio-mutation';
 import { generateSuffix } from '#core/utils/name-utils';
 
 import type { Pipeline } from '#core/config/entities/pipeline/types';
+import type { PipelineRun } from '#core/config/entities/run/types';
 
 export const CreatePipelineRunDialog: React.FC<{ record: Pipeline }> = ({ record }) => {
   const [showRunModal, setShowRunModal] = useState(false);
   const { projectId } = useStudioParams('base');
 
-  const createPipelineRunMutation = useStudioMutation({ mutationName: 'CreatePipelineRun' });
+  const createPipelineRunMutation = useStudioMutation<
+    { pipelineRun: PipelineRun },
+    { pipelineRun: PipelineRun }
+  >({ mutationName: 'CreatePipelineRun' });
 
-  const handleRunSubmit = async (values: Record<string, unknown>) => {
+  const handleRunSubmit = async (values: PipelineRun) => {
     if (createPipelineRunMutation.isPending) {
       return;
     }
@@ -45,7 +49,7 @@ export const CreatePipelineRunDialog: React.FC<{ record: Pipeline }> = ({ record
         Run
       </Button>
 
-      <FormDialog
+      <FormDialog<PipelineRun>
         isOpen={showRunModal}
         onDismiss={() => setShowRunModal(false)}
         heading="Start new pipeline run"


### PR DESCRIPTION
Replace untyped form data handling with TypeScript generics for type safety at form boundaries. Use FieldValues generic parameter on Form, FormDialog, and useFormState components.

Previous approach treated all form data as Record<string, unknown>, preventing compile-time validation of onSubmit handlers and form state access.

Tried to onboard generic parameter to field level, such that the field name was type checked from the form data type. The dot notation paths made this pretty challenging, so I omitted. There is also no good way to have children inherit parent generic context.

Changed initialValues to DeepPartial<FieldValues> to support partial nested object initialization, allowing forms to start with incomplete data that gets filled in during user interaction.

**What type of PR is this? (check all applicable)**
- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
