### PR TITLE
feat(uniflow): add transpiler callback

### DIFF
--- a/python/michelangelo/uniflow/core/build.py
+++ b/python/michelangelo/uniflow/core/build.py
@@ -7,8 +7,9 @@ import tarfile
 from dataclasses import dataclass
 from io import BytesIO
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 from collections.abc import Iterator
+from abc import ABC
 
 import fsspec
 
@@ -44,10 +45,8 @@ def main(args=None):
         return
 
     with (
-        sys.stdout.buffer
-        if a.output == "-"
-        else fsspec.open(a.output, mode="wb") as out
-    ):
+        sys.stdout.buffer if a.output == "-" else fsspec.open(a.output, mode="wb")
+    ) as out:
         out.write(tarball)
 
 
@@ -144,10 +143,26 @@ class Package:
         return bb.getvalue()
 
 
-def build(fn: Callable) -> Package:
-    # TODO: andrii: strip_path_prefix
+class TranspilerCallback(ABC):
+    """
+    Callback interface for the transpiler to make the transpilation process observable.
+    Users can extend this class and override its methods to act on transpilation events,
+    e.g., to collect additional metadata about the transpiled code.
+    """
+
+    def on_task_function(self, task_fn: TaskFunction):
+        """
+        Called when a reference to the @task function is encountered during transpilation.
+        """
+        pass
+
+
+def build(
+    fn: Callable,
+    transpiler_callback: Optional[TranspilerCallback] = None,
+) -> Package:
     files = {}
-    fn_path = _transpile_function(fn, files)
+    fn_path = _transpile_function(fn, files, transpiler_callback)
 
     package_files: dict[str, bytes] = {}
 
@@ -182,7 +197,11 @@ def build(fn: Callable) -> Package:
     )
 
 
-def _transpile_function(fn: Callable, files: dict[Path, Any]) -> Path:
+def _transpile_function(
+    fn: Callable,
+    files: dict[Path, Any],
+    transpiler_callback: Optional[TranspilerCallback],
+) -> Path:
     fn = inspect.unwrap(
         fn
     )  # Get the user function by unwrapping decorators such as @workflow.
@@ -212,7 +231,7 @@ def _transpile_function(fn: Callable, files: dict[Path, Any]) -> Path:
         arg.annotation = None
 
     # Transform function's code using FunctionTransformer
-    transformer = FunctionTransformer(fn)
+    transformer = FunctionTransformer(fn, transpiler_callback)
     transformer.visit(tree)
     # Add transformed function to the file
     file.add_function(tree)
@@ -233,7 +252,7 @@ def _transpile_function(fn: Callable, files: dict[Path, Any]) -> Path:
             # External dependency - add it to the `load` statements
             file.add_load(dep_path.as_posix(), alias, dep.__name__)
 
-        _transpile_function(dep, files)
+        _transpile_function(dep, files, transpiler_callback)
 
     return fn_path
 
@@ -296,18 +315,20 @@ def _fn_path(fn: Callable) -> Path:
 
 
 class FunctionTransformer(ast.NodeTransformer):
-    def __init__(self, fn):
+    def __init__(
+        self,
+        fn,
+        transpiler_callback: Optional[TranspilerCallback],
+    ):
         self._code = fn.__code__
         self._module = inspect.getmodule(fn)
+        self._transpiler_callback = transpiler_callback
         self.deps = Dependencies()
 
     def visit_AnnAssign(self, node):
         # Replace annotated assignment with just assignment. Ex:
         # a: dict = foo()  ->  a = foo()
-        return ast.Assign(
-            value=node.value,
-            targets=[node.target],
-        )
+        return ast.Assign(value=node.value, targets=[node.target])
 
     def visit_Is(self, _node):
         raise NameError("[is] is not supported, use == instead")
@@ -380,6 +401,8 @@ class FunctionTransformer(ast.NodeTransformer):
 
         if task := getattr(v, "_uf_task", None):
             assert isinstance(task, TaskFunction)
+            if self._transpiler_callback:
+                self._transpiler_callback.on_task_function(task)
             return task._transpile(self.deps)
 
         if is_star_plugin(v):

--- a/python/michelangelo/uniflow/core/decorator.py
+++ b/python/michelangelo/uniflow/core/decorator.py
@@ -201,9 +201,16 @@ class TaskFunction(Generic[P, R]):
 
         if self._image_spec:
             if self._image_spec.container_image:
-                keywords.append(ast.keyword("container_image", ast.Constant(self._image_spec.container_image)))
+                keywords.append(
+                    ast.keyword(
+                        "container_image",
+                        ast.Constant(self._image_spec.container_image),
+                    )
+                )
             if self._image_spec.receipt:
-                keywords.append(ast.keyword("receipt", ast.Constant(self._image_spec.receipt)))
+                keywords.append(
+                    ast.keyword("receipt", ast.Constant(self._image_spec.receipt))
+                )
 
         # Construct and return AST Call node that calls the Task Factory Function with the keywords.
         origin_fn = inspect.unwrap(self._fn)

--- a/python/michelangelo/uniflow/core/decorator.py
+++ b/python/michelangelo/uniflow/core/decorator.py
@@ -55,6 +55,14 @@ class TaskFunction(Generic[P, R]):
         self._retry_attempts = retry_attempts
         self._image_spec = image_spec
 
+    @property
+    def image_spec(self) -> Optional[ImageSpec]:
+        return self._image_spec
+
+    @property
+    def fn(self) -> Callable[P, R]:
+        return self._fn
+
     def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R:
         fn_path = dot_path(self._fn)
         if task_context.config is not None:

--- a/python/tests/uniflow/core/demo_app/demo_app.py
+++ b/python/tests/uniflow/core/demo_app/demo_app.py
@@ -2,7 +2,7 @@ from functools import wraps
 import logging
 from typing import Callable
 
-from michelangelo.uniflow.core import workflow, task
+from michelangelo.uniflow.core import workflow, task, image_spec
 from michelangelo.uniflow.core.lib.time import sleep
 from michelangelo.uniflow.core.utils import LOGGING_FORMAT
 from tests.uniflow.core.demo_platform.test_conf.task_b import TaskB
@@ -22,7 +22,7 @@ def test_wrapper(fn: Callable):
     return wrapper
 
 
-@task(config=TaskB())
+@task(config=TaskB(), image_spec=image_spec.ImageSpec(container_image="test_image:test"))
 def task_1(msg):
     log.info("task_1: msg: %r", msg)
     return {"status": "ok"}

--- a/python/tests/uniflow/core/demo_app/demo_app.py
+++ b/python/tests/uniflow/core/demo_app/demo_app.py
@@ -22,7 +22,9 @@ def test_wrapper(fn: Callable):
     return wrapper
 
 
-@task(config=TaskB(), image_spec=image_spec.ImageSpec(container_image="test_image:test"))
+@task(
+    config=TaskB(), image_spec=image_spec.ImageSpec(container_image="test_image:test")
+)
 def task_1(msg):
     log.info("task_1: msg: %r", msg)
     return {"status": "ok"}

--- a/python/tests/uniflow/core/test_build.py
+++ b/python/tests/uniflow/core/test_build.py
@@ -1,14 +1,15 @@
 import json
 import unittest
 
-from michelangelo.uniflow.core.build import build
+from michelangelo.uniflow.core.build import build, TranspilerCallback
+import tests.uniflow.core.demo_app.demo_app as demo_app
+import tests.uniflow.core.demo_platform.workflows as demo_platform_workflows
 
 
 class Test(unittest.TestCase):
     def test_demo_app(self):
-        from tests.uniflow.core.demo_app.demo_app import main
 
-        package = build(main)
+        package = build(demo_app.main)
 
         # Find and assert the main file
         main_file = [
@@ -44,3 +45,35 @@ class Test(unittest.TestCase):
             "main_function": package.main_function,
         }
         self.assertEqual(expected_meta, meta)
+
+    def test_build_with_transpiler_callback(self):
+
+        class MyTranspilerCallback(TranspilerCallback):
+
+            def __init__(self):
+                self.task_functions = []
+
+            def on_task_function(self, task_fn):
+                self.task_functions.append(task_fn)
+
+        transpiler_callback = MyTranspilerCallback()
+        package0 = build(demo_app.main, transpiler_callback=transpiler_callback)
+        self.assertIsNotNone(package0)
+
+        task_functions = transpiler_callback.task_functions
+
+        self.assertEqual(len(task_functions), 3)
+
+        t = task_functions[0]
+        self.assertEqual(t, demo_app.task_1)
+        self.assertEqual(t.image_spec.container_image, "test_image:test")
+
+        t = task_functions[1]
+        self.assertEqual(t, demo_app.task_wrapped)
+        self.assertIsNone(t.image_spec)
+
+        t = task_functions[2]
+        self.assertEqual(t, demo_platform_workflows._greetings_task)
+
+        package1 = build(demo_app.main)
+        self.assertEqual(package0, package1)

--- a/python/tests/uniflow/core/test_build.py
+++ b/python/tests/uniflow/core/test_build.py
@@ -8,7 +8,6 @@ import tests.uniflow.core.demo_platform.workflows as demo_platform_workflows
 
 class Test(unittest.TestCase):
     def test_demo_app(self):
-
         package = build(demo_app.main)
 
         # Find and assert the main file
@@ -47,9 +46,7 @@ class Test(unittest.TestCase):
         self.assertEqual(expected_meta, meta)
 
     def test_build_with_transpiler_callback(self):
-
         class MyTranspilerCallback(TranspilerCallback):
-
             def __init__(self):
                 self.task_functions = []
 


### PR DESCRIPTION
**What type of PR is this?**

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Added a new optional `transpiler_callback` argument to Uniflow's `build` function.

**Why?**

Callback interface for the transpiler to make the transpilation process observable. Users can provide their own callbacks to act on transpilation events.

**How did you test it?**

Unit test