### PR TITLE
Added Ray Cluster Creation Timeout

### DIFF
--- a/python/michelangelo/uniflow/plugins/ray/task.star
+++ b/python/michelangelo/uniflow/plugins/ray/task.star
@@ -1,7 +1,7 @@
 load("@plugin", "atexit", "json", "os", "ray", "time")
 load("../../commons.star", "DEFAULT_RETRY_ATTEMPTS", "CACHE_OPERATION_GET", "CACHE_OPERATION_PUT", "TASK_STATE_FAILED", "TASK_STATE_KILLED", "TASK_STATE_PENDING", "TASK_STATE_RUNNING", "TASK_STATE_SKIPPED", "TASK_STATE_SUCCEEDED", "TIME_FOMART", "create_cached_output", "get_cache_enabled", "get_cache_keys", "get_cached_output", "get_result_url", "get_task_image", "get_task_name", "io_read_json", "report_progress", "resource_dict", COMMONS_ENV = "ENV")
 
-CREATE_CLUSTER_TIMEOUT_SECONDS = 60 * 30  # Timeout duration for cluster creation in seconds.
+DEFAULT_CREATE_CLUSTER_TIMEOUT_SECONDS = 60 * 30  # Timeout duration for cluster creation in seconds.
 RAY_ENV = {
     "RAY_DEDUP_LOGS": "0",
     # RAY_NUM_REDIS_GET_RETRIES controls the number of retries for a worker node to connect to the GCS (Global Control Service) at startup.
@@ -9,8 +9,8 @@ RAY_ENV = {
     # The default value is 20, giving a worker about 140 seconds to connect to the GCS (7 seconds per retry).
     # We need to provide workers more time to connect because the Job Controller doesn't support gang scheduling of nodes.
     # As a result, a worker node might start significantly earlier than the head node.
-    # Calculate RAY_NUM_REDIS_GET_RETRIES to allow workers approximately CREATE_CLUSTER_TIMEOUT_SECONDS to connect to the GCS, assuming 7 seconds per retry.
-    "RAY_NUM_REDIS_GET_RETRIES": str((CREATE_CLUSTER_TIMEOUT_SECONDS // 7) + 1),
+    # Calculate RAY_NUM_REDIS_GET_RETRIES to allow workers approximately DEFAULT_CREATE_CLUSTER_TIMEOUT_SECONDS to connect to the GCS, assuming 7 seconds per retry.
+    "RAY_NUM_REDIS_GET_RETRIES": str((DEFAULT_CREATE_CLUSTER_TIMEOUT_SECONDS // 7) + 1),
 }
 RAY_DEFAULT_HEAD_CPU = os.environ.get("RAY_DEFAULT_HEAD_CPU", "8")
 RAY_DEFAULT_HEAD_MEMORY = os.environ.get("RAY_DEFAULT_HEAD_MEMORY", "32Gi")
@@ -292,7 +292,7 @@ def execute_ray_task(task_path, task_name, cluster, cluster_namespace, runtime_e
         retry_attempt_id = retry_attempt_id,
     )
 
-    cluster = ray.create_cluster(cluster, timeout_seconds = CREATE_CLUSTER_TIMEOUT_SECONDS)
+    cluster = ray.create_cluster(cluster, timeout_seconds = DEFAULT_CREATE_CLUSTER_TIMEOUT_SECONDS)
     cluster_url = cluster["status"].get("jobUrl", "UAPI did not report RayJob URL")
     cluster_name = cluster["metadata"]["name"]
     cluster_namespace = cluster["metadata"]["namespace"]

--- a/python/michelangelo/uniflow/plugins/ray/task.star
+++ b/python/michelangelo/uniflow/plugins/ray/task.star
@@ -292,7 +292,7 @@ def execute_ray_task(task_path, task_name, cluster, cluster_namespace, runtime_e
         retry_attempt_id = retry_attempt_id,
     )
 
-    cluster = ray.create_cluster(cluster)
+    cluster = ray.create_cluster(cluster, timeout_seconds = CREATE_CLUSTER_TIMEOUT_SECONDS)
     cluster_url = cluster["status"].get("jobUrl", "UAPI did not report RayJob URL")
     cluster_name = cluster["metadata"]["name"]
     cluster_namespace = cluster["metadata"]["namespace"]


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
Added Ray cluster creation timeout to ensure that pipeline run does not get stuck if cluster creation has failed.

<!-- Tell your future self why have you made these changes -->
**Why?**
This bug fix is important for avoiding the pipeline run controller to be stuck when ray cluster creation is not successful and keeps retrying.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I have tested this with end-to-end pipeline runs. Previously, when the incorrect image has been passed in, the execute workflow appears to be stuck. However, after adding the timeout, the execute workflow step now correctly fails after the timeout duration.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
If these changes are incorrect, future pipeline runs can be affected.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
