### PR TITLE
fix(controllermgr): Remove invalid port field from config

### DIFF
--- a/python/michelangelo/cli/sandbox/resources/michelangelo-controllermgr.yaml
+++ b/python/michelangelo/cli/sandbox/resources/michelangelo-controllermgr.yaml
@@ -47,7 +47,6 @@ data:
       healthProbeBindAddress: ${HEALTH_ADDRESS::8081}
       leaderElection: false
       leaderElectionID: decaf1259.michelangelo.uber.com
-      port: 9443
 
     controllers:
       rayCluster:


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
Removes the port field on the `michelangelo-controllermgr.yaml`.

<!-- Tell your future self why have you made these changes -->
**Why?**
The port field was removed in [this commit](https://github.com/michelangelo-ai/michelangelo/commit/f3807c20675ad7e767f299d7a063090e655f8c9e#diff-5da4693d918b22ac9da31f08f75f48f4459e497d84d1fa413bd8a40d472a0644L18). The existence of the port field in the `michelangelo-controllermgr.yaml` produces an error during sandbox creation:
```
failed to build controllermgr.Config:
received non-nil error from function "github.com/michelangelo-ai/michelangelo/go/controllermgr".newConfig                                                       
        go/controllermgr/config.go:21:
yaml: unmarshal errors:
  line 5: field port not found in type controllermgr.Config
```