### PR TITLE
NEW FEATURE: Added `mactl triger_run kill` command

### DIFF
--- a/python/michelangelo/cli/mactl/mactl.py
+++ b/python/michelangelo/cli/mactl/mactl.py
@@ -419,7 +419,9 @@ class CRD:
             _LOG.info("Retrieved resource for kill: %r", current_resource)
 
             # Create update request with kill flag set
-            current_dict = MessageToDict(current_resource, preserving_proto_field_name=True)
+            current_dict = MessageToDict(
+                current_resource, preserving_proto_field_name=True
+            )
 
             # Set kill flag in spec
             resource_name = _self.name

--- a/python/michelangelo/cli/mactl/mactl.py
+++ b/python/michelangelo/cli/mactl/mactl.py
@@ -386,6 +386,80 @@ class CRD:
         _LOG.info("Generate DEV RUN method for %r / %r", self.name, self.full_name)
         pass
 
+    def generate_kill(self, channel: Channel):
+        """
+        Generate kill function of this class.
+        """
+        # Ensure get method is available for retrieving current resource
+        self.generate_get(channel)
+
+        _LOG.info("Generate KILL method for %r / %r", self.name, self.full_name)
+        method_name, input_class, output_class = self._extract_method_info(
+            channel, self.full_name, "Update"
+        )
+
+        kill_func_signature = Signature(
+            [Parameter("self", Parameter.POSITIONAL_OR_KEYWORD)]
+            + [
+                Parameter(name, Parameter.POSITIONAL_OR_KEYWORD)
+                for name in ["namespace", "name"]
+            ]
+        )
+
+        @bind_signature(kill_func_signature)
+        def kill_func(bound_args: Signature) -> Message:
+            _LOG.info("Start kill_func for %r", self.full_name)
+            _LOG.info("Bound arguments: %r", bound_args.arguments)
+            _self: CRD = bound_args.arguments["self"]
+            _name = get_single_arg(bound_args.arguments, "name")
+            _namespace = get_single_arg(bound_args.arguments, "namespace")
+
+            # Get current resource
+            current_resource = _self.get(_namespace, _name)
+            _LOG.info("Retrieved resource for kill: %r", current_resource)
+
+            # Create update request with kill flag set
+            current_dict = MessageToDict(current_resource, preserving_proto_field_name=True)
+
+            # Set kill flag in spec
+            resource_name = _self.name
+            if resource_name in current_dict and "spec" in current_dict[resource_name]:
+                current_dict[resource_name]["spec"]["kill"] = True
+            else:
+                _LOG.error("Invalid resource structure for kill operation")
+                raise ValueError(f"Cannot set kill flag on {resource_name}")
+
+            # Convert back to protobuf message for update
+            request_input = input_class()
+            ParseDict(current_dict, request_input, ignore_unknown_fields=True)
+
+            _LOG.info(
+                "KILL Request input (%r) ready: %r",
+                type(request_input),
+                request_input,
+            )
+
+            method_fullname = f"/{_self.full_name}/{method_name}"
+            _LOG.info("Method fullname for gRPC call: %s", method_fullname)
+
+            stub_method = channel.unary_unary(
+                method_fullname,
+                request_serializer=input_class.SerializeToString,
+                response_deserializer=output_class.FromString,
+            )
+
+            response = stub_method(
+                request_input,
+                metadata=METADATA_STUB,
+                timeout=30,
+            )
+
+            _LOG.info("Kill operation completed (%r): %r", type(response), response)
+            return response
+
+        kill_func.__signature__ = kill_func_signature  # type: ignore[attr-defined]
+        self.kill = MethodType(kill_func, self)
+
     def generate_list(self, channel: Channel):
         """
         Generate list function of this class.
@@ -819,6 +893,7 @@ def handle_args() -> tuple[str, str, dict[str, list[str]]]:
         "list",
         "run",
         "dev-run",
+        "kill",
     ]
 
     # For file-based actions, validate file parameter exists (preserving original validation)

--- a/python/michelangelo/cli/mactl/mactl.py
+++ b/python/michelangelo/cli/mactl/mactl.py
@@ -519,7 +519,9 @@ def get_message_class_by_name(pool: DescriptorPool, message_name: str) -> type[M
     return MessageClass
 
 
-def read_plugins(crd: CRD, user_command_action: str, crds: dict[str, CRD], channel: Channel) -> None:
+def read_plugins(
+    crd: CRD, user_command_action: str, crds: dict[str, CRD], channel: Channel
+) -> None:
     """
     Read and apply plugins for a given crd.
     """

--- a/python/michelangelo/cli/mactl/mactl.py
+++ b/python/michelangelo/cli/mactl/mactl.py
@@ -388,104 +388,11 @@ class CRD:
 
     def generate_kill(self, channel: Channel):
         """
-        Generate kill function that terminates resources by setting spec.kill=true.
-        Prompts for confirmation unless --yes flag is provided.
-
-        Examples: mactl trigger_run kill --namespace=ma-dev-test --name=training-pipeline-cron-trigger
-                 mactl pipeline_run kill --namespace=ma-dev-test --name=pipeline-run-20251016-210000-0523962d --yes
+        Generate kill function - delegated to plugins.
+        This is a placeholder that plugins will override.
         """
-        # Ensure get method is available for retrieving current resource
-        self.generate_get(channel)
-
         _LOG.info("Generate KILL method for %r / %r", self.name, self.full_name)
-        method_name, input_class, output_class = self._extract_method_info(
-            channel, self.full_name, "Update"
-        )
-
-        kill_func_signature = Signature(
-            [Parameter("self", Parameter.POSITIONAL_OR_KEYWORD)]
-            + [
-                Parameter(name, Parameter.POSITIONAL_OR_KEYWORD)
-                for name in ["namespace", "name"]
-            ]
-            + [Parameter("yes", Parameter.POSITIONAL_OR_KEYWORD, default=[])]
-        )
-
-        @bind_signature(kill_func_signature)
-        def kill_func(bound_args: Signature) -> Message:
-            _LOG.info("Start kill_func for %r", self.full_name)
-            _LOG.info("Bound arguments: %r", bound_args.arguments)
-            _self: CRD = bound_args.arguments["self"]
-            _name = get_single_arg(bound_args.arguments, "name")
-            _namespace = get_single_arg(bound_args.arguments, "namespace")
-            _yes = bound_args.arguments.get("yes", [])
-
-            # Confirmation logic
-            if not _yes:
-                resource_type = _self.name.replace("_", " ")
-                confirmation = input(f" > kill '{_name}' {resource_type}? [y/N] ")
-                if confirmation.lower() not in ['y', 'yes']:
-                    print("Kill operation cancelled.")
-                    return None
-
-            # Get current resource
-            current_resource = _self.get(_namespace, _name)
-            _LOG.info("Retrieved resource for kill: %r", current_resource)
-
-            # Create update request with kill flag set
-            current_dict = MessageToDict(
-                current_resource, preserving_proto_field_name=True
-            )
-
-            # Set kill flag in spec
-            resource_name = _self.name
-            if resource_name in current_dict and "spec" in current_dict[resource_name]:
-                current_dict[resource_name]["spec"]["kill"] = True
-            else:
-                _LOG.error("Missing required spec field in the resource structure")
-                raise ValueError(f"Cannot set kill flag on {resource_name}")
-
-            # Convert back to protobuf message for update
-            request_input = input_class()
-            ParseDict(current_dict, request_input, ignore_unknown_fields=True)
-
-            _LOG.info(
-                "KILL Request input (%r) ready: %r",
-                type(request_input),
-                request_input,
-            )
-
-            method_fullname = f"/{_self.full_name}/{method_name}"
-            _LOG.info("Method fullname for gRPC call: %s", method_fullname)
-
-            stub_method = channel.unary_unary(
-                method_fullname,
-                request_serializer=input_class.SerializeToString,
-                response_deserializer=output_class.FromString,
-            )
-
-            response = stub_method(
-                request_input,
-                metadata=METADATA_STUB,
-                timeout=30,
-            )
-
-            # Assert kill operation is successful by checking response spec
-            response_dict = MessageToDict(response, preserving_proto_field_name=True)
-            resource_name = _self.name
-            if (resource_name in response_dict and
-                "spec" in response_dict[resource_name] and
-                response_dict[resource_name]["spec"].get("kill") is True):
-                _LOG.info("Kill operation successfully set spec.kill=true")
-            else:
-                _LOG.error("Kill operation failed: spec.kill not set to true in response")
-                raise RuntimeError(f"Kill operation failed for {resource_name}: spec.kill not properly set")
-
-            _LOG.info("Kill operation completed (%r): %r", type(response), response)
-            return response
-
-        kill_func.__signature__ = kill_func_signature  # type: ignore[attr-defined]
-        self.kill = MethodType(kill_func, self)
+        pass
 
     def generate_list(self, channel: Channel):
         """
@@ -612,7 +519,7 @@ def get_message_class_by_name(pool: DescriptorPool, message_name: str) -> type[M
     return MessageClass
 
 
-def read_plugins(crd: CRD, user_command_action: str, crds: dict[str, CRD]) -> None:
+def read_plugins(crd: CRD, user_command_action: str, crds: dict[str, CRD], channel: Channel) -> None:
     """
     Read and apply plugins for a given crd.
     """
@@ -976,7 +883,7 @@ def main(channel: Channel):
         crds[user_command_crd], f"generate_{user_command_action}"
     )
     func_action_generator(channel)
-    read_plugins(crds[user_command_crd], user_command_action, crds)
+    read_plugins(crds[user_command_crd], user_command_action, crds, channel)
 
     assert hasattr(crds[user_command_crd], user_command_action)
     func_action = getattr(crds[user_command_crd], user_command_action)

--- a/python/michelangelo/cli/mactl/mactl.py
+++ b/python/michelangelo/cli/mactl/mactl.py
@@ -388,7 +388,11 @@ class CRD:
 
     def generate_kill(self, channel: Channel):
         """
-        Generate kill function of this class.
+        Generate kill function that terminates resources by setting spec.kill=true.
+        Prompts for confirmation unless --yes flag is provided.
+
+        Examples: mactl trigger_run kill --namespace=ma-dev-test --name=training-pipeline-cron-trigger
+                 mactl pipeline_run kill --namespace=ma-dev-test --name=pipeline-run-20251016-210000-0523962d --yes
         """
         # Ensure get method is available for retrieving current resource
         self.generate_get(channel)
@@ -404,6 +408,7 @@ class CRD:
                 Parameter(name, Parameter.POSITIONAL_OR_KEYWORD)
                 for name in ["namespace", "name"]
             ]
+            + [Parameter("yes", Parameter.POSITIONAL_OR_KEYWORD, default=[])]
         )
 
         @bind_signature(kill_func_signature)
@@ -413,6 +418,15 @@ class CRD:
             _self: CRD = bound_args.arguments["self"]
             _name = get_single_arg(bound_args.arguments, "name")
             _namespace = get_single_arg(bound_args.arguments, "namespace")
+            _yes = bound_args.arguments.get("yes", [])
+
+            # Confirmation logic
+            if not _yes:
+                resource_type = _self.name.replace("_", " ")
+                confirmation = input(f" > kill '{_name}' {resource_type}? [y/N] ")
+                if confirmation.lower() not in ['y', 'yes']:
+                    print("Kill operation cancelled.")
+                    return None
 
             # Get current resource
             current_resource = _self.get(_namespace, _name)
@@ -428,7 +442,7 @@ class CRD:
             if resource_name in current_dict and "spec" in current_dict[resource_name]:
                 current_dict[resource_name]["spec"]["kill"] = True
             else:
-                _LOG.error("Invalid resource structure for kill operation")
+                _LOG.error("Missing required spec field in the resource structure")
                 raise ValueError(f"Cannot set kill flag on {resource_name}")
 
             # Convert back to protobuf message for update
@@ -455,6 +469,17 @@ class CRD:
                 metadata=METADATA_STUB,
                 timeout=30,
             )
+
+            # Assert kill operation is successful by checking response spec
+            response_dict = MessageToDict(response, preserving_proto_field_name=True)
+            resource_name = _self.name
+            if (resource_name in response_dict and
+                "spec" in response_dict[resource_name] and
+                response_dict[resource_name]["spec"].get("kill") is True):
+                _LOG.info("Kill operation successfully set spec.kill=true")
+            else:
+                _LOG.error("Kill operation failed: spec.kill not set to true in response")
+                raise RuntimeError(f"Kill operation failed for {resource_name}: spec.kill not properly set")
 
             _LOG.info("Kill operation completed (%r): %r", type(response), response)
             return response
@@ -874,6 +899,10 @@ def parse_args() -> tuple[list[str], dict[str, list[str]]]:
             key, value = arg.split("=", 1)
             key = key.lstrip("-")
             kwargs[key].append(value)
+        elif arg.startswith("--"):
+            # Handle boolean flags like --yes
+            key = arg.lstrip("-")
+            kwargs[key].append(True)
         else:
             args.append(arg)
     _LOG.info("Parsed arguments: %r  /  %r", args, kwargs)

--- a/python/michelangelo/cli/mactl/plugins/pipeline/dev_run.py
+++ b/python/michelangelo/cli/mactl/plugins/pipeline/dev_run.py
@@ -171,11 +171,15 @@ def convert_crd_metadata_pipeline_dev_run(
     # Extract resume_from parameter if present
     resume_from = yaml_dict.get("resume_from")
 
-    pipeline_dev_run_cr = generate_pipeline_dev_run_object(yaml_dict, pipeline_spec, resume_from)
+    pipeline_dev_run_cr = generate_pipeline_dev_run_object(
+        yaml_dict, pipeline_spec, resume_from
+    )
     return {"pipeline_run": pipeline_dev_run_cr}
 
 
-def generate_pipeline_dev_run_object(yaml_dict: dict, pipeline_spec: dict, resume_from: str = None) -> dict:
+def generate_pipeline_dev_run_object(
+    yaml_dict: dict, pipeline_spec: dict, resume_from: str = None
+) -> dict:
     """
     Generate Pipeline Dev Run CR as dictionary.
 
@@ -190,7 +194,10 @@ def generate_pipeline_dev_run_object(yaml_dict: dict, pipeline_spec: dict, resum
     pipeline_run_name = generate_pipeline_run_name()
 
     pipeline_run_obj = generate_pipeline_run_object(
-        run_name=pipeline_run_name, pipeline_name=pipeline_name, namespace=namespace, resume_from=resume_from
+        run_name=pipeline_run_name,
+        pipeline_name=pipeline_name,
+        namespace=namespace,
+        resume_from=resume_from,
     )
 
     pipeline_run_spec = pipeline_run_obj.setdefault("spec", {})

--- a/python/michelangelo/cli/mactl/plugins/pipeline/run.py
+++ b/python/michelangelo/cli/mactl/plugins/pipeline/run.py
@@ -133,7 +133,10 @@ def convert_crd_metadata_pipeline_run(
     )
 
     pipeline_run = generate_pipeline_run_object(
-        run_name=run_name, pipeline_name=pipeline_name, namespace=namespace, resume_from=resume_from
+        run_name=run_name,
+        pipeline_name=pipeline_name,
+        namespace=namespace,
+        resume_from=resume_from,
     )
 
     return {"pipeline_run": pipeline_run}
@@ -200,7 +203,10 @@ def parse_resume_from(resume_from: str, namespace: str) -> dict:
         dict: Resume spec dictionary matching the Resume proto message
     """
     if not resume_from:
-        _LOG.error("Invalid resume_from format. Expected 'pipeline_run_name' or 'pipeline_run_name:step_name', got: %r", resume_from)
+        _LOG.error(
+            "Invalid resume_from format. Expected 'pipeline_run_name' or 'pipeline_run_name:step_name', got: %r",
+            resume_from,
+        )
         return None
 
     # Check if step name is provided
@@ -216,7 +222,7 @@ def parse_resume_from(resume_from: str, namespace: str) -> dict:
             "name": pipeline_run_name,
             "namespace": namespace,
         },
-        "resumeFrom": resume_from_list
+        "resumeFrom": resume_from_list,
     }
 
     _LOG.info("Parsed resume_from '%s' to resume spec: %r", resume_from, resume_spec)

--- a/python/michelangelo/cli/mactl/plugins/trigger_run/kill.py
+++ b/python/michelangelo/cli/mactl/plugins/trigger_run/kill.py
@@ -1,0 +1,104 @@
+from logging import getLogger
+from inspect import Signature, Parameter
+from types import MethodType
+
+from grpc import Channel
+from google.protobuf.message import Message
+from google.protobuf.json_format import MessageToDict, ParseDict
+
+from mactl import CRD, bind_signature, METADATA_STUB, get_single_arg
+
+
+_LOG = getLogger(__name__)
+
+
+def generate_kill(crd: CRD, channel: Channel):
+    """
+    Generate kill function for pipeline_run CRD.
+    """
+    _LOG.info("Generating `pipeline_run kill` for: %s", crd)
+
+    crd.generate_get(channel)
+
+    method_name, input_class, output_class = crd._extract_method_info(
+        channel, crd.full_name, "Update"
+    )
+
+    kill_func_signature = Signature(
+        [Parameter("self", Parameter.POSITIONAL_OR_KEYWORD)]
+        + [
+            Parameter(name, Parameter.POSITIONAL_OR_KEYWORD)
+            for name in ["namespace", "name"]
+        ]
+        + [Parameter("yes", Parameter.POSITIONAL_OR_KEYWORD, default=[])]
+    )
+
+    @bind_signature(kill_func_signature)
+    def kill_func(bound_args: Signature) -> Message:
+        _LOG.info("Start kill_func for pipeline_run")
+        _LOG.info("Bound arguments: %r", bound_args.arguments)
+        _self: CRD = bound_args.arguments["self"]
+        _name = get_single_arg(bound_args.arguments, "name")
+        _namespace = get_single_arg(bound_args.arguments, "namespace")
+        _yes = bound_args.arguments.get("yes", [])
+
+        if not _yes:
+            resource_type = _self.name.replace("_", " ")
+            confirmation = input(f" > kill '{_name}' {resource_type}? [y/N] ")
+            if confirmation.lower() not in ['y', 'yes']:
+                print("Kill operation cancelled.")
+                return None
+
+        current_resource = _self.get(_namespace, _name)
+        _LOG.info("Retrieved resource for kill: %r", current_resource)
+
+        current_dict = MessageToDict(
+            current_resource, preserving_proto_field_name=True
+        )
+
+        resource_name = _self.name
+        if resource_name in current_dict and "spec" in current_dict[resource_name]:
+            current_dict[resource_name]["spec"]["kill"] = True
+        else:
+            _LOG.error("Missing required spec field in the resource structure")
+            raise ValueError(f"Cannot set kill flag on {resource_name}")
+
+        request_input = input_class()
+        ParseDict(current_dict, request_input, ignore_unknown_fields=True)
+
+        _LOG.info(
+            "KILL Request input (%r) ready: %r",
+            type(request_input),
+            request_input,
+        )
+
+        method_fullname = f"/{_self.full_name}/{method_name}"
+        _LOG.info("Method fullname for gRPC call: %s", method_fullname)
+
+        stub_method = channel.unary_unary(
+            method_fullname,
+            request_serializer=input_class.SerializeToString,
+            response_deserializer=output_class.FromString,
+        )
+
+        response = stub_method(
+            request_input,
+            metadata=METADATA_STUB,
+            timeout=30,
+        )
+
+        response_dict = MessageToDict(response, preserving_proto_field_name=True)
+        resource_name = _self.name
+        if (resource_name in response_dict and
+            "spec" in response_dict[resource_name] and
+            response_dict[resource_name]["spec"].get("kill") is True):
+            _LOG.info("Kill operation successfully set spec.kill=true")
+        else:
+            _LOG.error("Kill operation failed: spec.kill not set to true in response")
+            raise RuntimeError(f"Kill operation failed for {resource_name}: spec.kill not properly set")
+
+        _LOG.info("Kill operation completed (%r): %r", type(response), response)
+        return response
+
+    kill_func.__signature__ = kill_func_signature
+    crd.kill = MethodType(kill_func, crd)

--- a/python/michelangelo/cli/mactl/plugins/trigger_run/kill.py
+++ b/python/michelangelo/cli/mactl/plugins/trigger_run/kill.py
@@ -45,16 +45,14 @@ def generate_kill(crd: CRD, channel: Channel):
         if not _yes:
             resource_type = _self.name.replace("_", " ")
             confirmation = input(f" > kill '{_name}' {resource_type}? [y/N] ")
-            if confirmation.lower() not in ['y', 'yes']:
+            if confirmation.lower() not in ["y", "yes"]:
                 print("Kill operation cancelled.")
                 return None
 
         current_resource = _self.get(_namespace, _name)
         _LOG.info("Retrieved resource for kill: %r", current_resource)
 
-        current_dict = MessageToDict(
-            current_resource, preserving_proto_field_name=True
-        )
+        current_dict = MessageToDict(current_resource, preserving_proto_field_name=True)
 
         resource_name = _self.name
         if resource_name in current_dict and "spec" in current_dict[resource_name]:
@@ -89,13 +87,17 @@ def generate_kill(crd: CRD, channel: Channel):
 
         response_dict = MessageToDict(response, preserving_proto_field_name=True)
         resource_name = _self.name
-        if (resource_name in response_dict and
-            "spec" in response_dict[resource_name] and
-            response_dict[resource_name]["spec"].get("kill") is True):
+        if (
+            resource_name in response_dict
+            and "spec" in response_dict[resource_name]
+            and response_dict[resource_name]["spec"].get("kill") is True
+        ):
             _LOG.info("Kill operation successfully set spec.kill=true")
         else:
             _LOG.error("Kill operation failed: spec.kill not set to true in response")
-            raise RuntimeError(f"Kill operation failed for {resource_name}: spec.kill not properly set")
+            raise RuntimeError(
+                f"Kill operation failed for {resource_name}: spec.kill not properly set"
+            )
 
         _LOG.info("Kill operation completed (%r): %r", type(response), response)
         return response

--- a/python/michelangelo/cli/mactl/plugins/trigger_run/main.py
+++ b/python/michelangelo/cli/mactl/plugins/trigger_run/main.py
@@ -1,0 +1,21 @@
+from logging import getLogger
+
+from grpc import Channel
+
+from mactl import CRD
+from plugins.trigger_run.kill import generate_kill
+
+
+_LOG = getLogger(__name__)
+
+
+def apply_plugins(
+    crd: CRD, target_command: str, crds: dict[str, CRD], channel: Channel
+):
+    """
+    Apply plugins to the crd.
+    """
+    _LOG.info("Applying plugins to crd: %r / %r", crd, target_command)
+    if target_command == "kill":
+        generate_kill(crd, channel)
+    _LOG.info("Plugins applied successfully to crd: %s", crd)


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [*] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

  **What changed?**
  Added `mactl triger_run kill` command. Implemented generic kill functionality that sets `spec.kill=true` via gRPC Update
  method, enabling clean Cadence workflow termination.

  <!-- Tell your future self why have you made these changes -->
  **Why?**
Users need a clean way to  terminate triggers without leaving orphaned processes. This provides the missing lifecycle management piece.

  <!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
  **How did you test it?**
<img width="1490" height="397" alt="Screenshot 2025-10-16 at 2 04 28 PM" src="https://github.com/user-attachments/assets/2e96c7ab-d8e7-4768-844d-15bf41fae1ee" />

  - Created trigger → killed with mactl → verified state change to killed
  - Tested edge cases: killing non-existent resources, already killed resources

  <!-- Assuming the worst case, what can be broken when deploying this change to production? -->
  **Potential risks**
  Low risk - purely additive feature. Only adds new "kill" action to existing mactl commands. Uses existing gRPC Update infrastructure. 

  <!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
  **Release notes**
  **NEW FEATURE**: Added `mactl triger_run kill` command
  - `mactl trigger_run kill --namespace=<ns> --name=<name>`
  - Clean Cadence workflow termination without orphaned processes