### PR TITLE
Fix tls issue for apiserver

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,3 @@
-load("@rules_python//python:defs.bzl", "py_library")
-
 # gazelle:exclude .git/
 # gazelle:exclude pkg/
 # gazelle:exclude python/
@@ -39,10 +37,4 @@ nogo(
     name = "default_nogo",
     visibility = ["//visibility:public"],
     deps = TOOLS_NOGO,
-)
-
-py_library(
-    name = "michelangelo",
-    srcs = ["javascript/node_modules/flatted/python/flatted.py"],
-    visibility = ["//:__subpackages__"],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_python//python:defs.bzl", "py_library")
+
 # gazelle:exclude .git/
 # gazelle:exclude pkg/
 # gazelle:exclude python/
@@ -37,4 +39,10 @@ nogo(
     name = "default_nogo",
     visibility = ["//visibility:public"],
     deps = TOOLS_NOGO,
+)
+
+py_library(
+    name = "michelangelo",
+    srcs = ["javascript/node_modules/flatted/python/flatted.py"],
+    visibility = ["//:__subpackages__"],
 )

--- a/go/worker/BUILD.bazel
+++ b/go/worker/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//proto/api/v2:go_default_library",
         "@com_github_cadence_workflow_starlark_worker//plugin:go_default_library",
         "@com_github_cadence_workflow_starlark_worker//service:go_default_library",
+        "@org_golang_google_grpc//credentials:go_default_library",
         "@org_uber_go_config//:go_default_library",
         "@org_uber_go_fx//:go_default_library",
         "@org_uber_go_yarpc//:go_default_library",
@@ -25,6 +26,5 @@ go_library(
         "@org_uber_go_yarpc//peer:go_default_library",
         "@org_uber_go_yarpc//peer/hostport:go_default_library",
         "@org_uber_go_yarpc//transport/grpc:go_default_library",
-        "@org_golang_google_grpc//credentials:go_default_library",
     ],
 )

--- a/go/worker/BUILD.bazel
+++ b/go/worker/BUILD.bazel
@@ -21,6 +21,10 @@ go_library(
         "@org_uber_go_config//:go_default_library",
         "@org_uber_go_fx//:go_default_library",
         "@org_uber_go_yarpc//:go_default_library",
+        "@org_uber_go_yarpc//api/transport:go_default_library",
+        "@org_uber_go_yarpc//peer:go_default_library",
+        "@org_uber_go_yarpc//peer/hostport:go_default_library",
         "@org_uber_go_yarpc//transport/grpc:go_default_library",
+        "@org_golang_google_grpc//credentials:go_default_library",
     ],
 )

--- a/go/worker/config.go
+++ b/go/worker/config.go
@@ -1,10 +1,17 @@
 package worker
 
 import (
+	"crypto/tls"
+	"strings"
+
 	"go.uber.org/config"
 	"go.uber.org/fx"
 	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/peer"
+	"go.uber.org/yarpc/peer/hostport"
 	"go.uber.org/yarpc/transport/grpc"
+	"google.golang.org/grpc/credentials"
 
 	v2pb "github.com/michelangelo-ai/michelangelo/proto/api/v2"
 )
@@ -15,6 +22,7 @@ const configKey = "worker"
 type Config struct {
 	MaAPIServiceName string `yaml:"maApiServiceName"`
 	Address          string `yaml:"address"`
+	UseTLS           bool   `yaml:"useTLS"`
 }
 
 // Params provides dependencies for YARPC dispatcher.
@@ -41,7 +49,32 @@ func NewConfig(provider config.Provider) (Config, error) {
 
 // NewYARPCDispatcher creates and starts a new YARPC dispatcher.
 func NewYARPCDispatcher(p Params) (*yarpc.Dispatcher, error) {
-	tran := grpc.NewTransport().NewSingleOutbound(p.Config.Address)
+	var tran transport.UnaryOutbound
+
+	// Check config to determine if we should use TLS
+	if p.Config.UseTLS {
+		// Configure TLS for secure connections (e.g., ingress endpoints)
+		tlsConfig := &tls.Config{
+			ServerName: extractServerName(p.Config.Address),
+		}
+		creds := credentials.NewTLS(tlsConfig)
+
+		// Create a dialer with TLS credentials
+		dialer := grpc.NewTransport().NewDialer(grpc.DialerCredentials(creds))
+
+		// Create a peer chooser with the TLS-enabled dialer
+		chooser := peer.NewSingle(
+			hostport.Identify(p.Config.Address),
+			dialer,
+		)
+
+		// Create outbound with the chooser
+		tran = grpc.NewTransport().NewOutbound(chooser)
+	} else {
+		// Use insecure connection for local development
+		tran = grpc.NewTransport().NewSingleOutbound(p.Config.Address)
+	}
+
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name:      p.Config.MaAPIServiceName,
 		Outbounds: yarpc.Outbounds{p.Config.MaAPIServiceName: {Unary: tran}},
@@ -87,4 +120,13 @@ func NewModelServiceClient(p ClientParams) v2pb.ModelServiceYARPCClient {
 // NewDeploymentServiceClient creates a DeploymentService YARPC client.
 func NewDeploymentServiceClient(p ClientParams) v2pb.DeploymentServiceYARPCClient {
 	return v2pb.NewDeploymentServiceYARPCClient(p.Dispatcher.ClientConfig(p.Config.MaAPIServiceName))
+}
+
+// extractServerName extracts the server name from an address for TLS SNI
+func extractServerName(address string) string {
+	// Extract hostname from "hostname:port" format
+	if idx := strings.LastIndex(address, ":"); idx >= 0 {
+		return address[:idx]
+	}
+	return address
 }

--- a/python/michelangelo/cli/mactl/mactl.py
+++ b/python/michelangelo/cli/mactl/mactl.py
@@ -20,7 +20,7 @@ from google.protobuf.descriptor_pb2 import (
 from google.protobuf.descriptor_pool import DescriptorPool
 from google.protobuf.json_format import MessageToDict, ParseDict
 from google.protobuf.message import Message
-from grpc import Channel, insecure_channel
+from grpc import Channel, insecure_channel, secure_channel, ssl_channel_credentials
 from grpc_reflection.v1alpha import reflection_pb2, reflection_pb2_grpc
 from yaml import YAMLError, safe_load as yaml_safe_load
 
@@ -47,7 +47,9 @@ METADATA = [
 # Allow overriding the API server address via environment variable
 # This enables pointing the CLI to a k8s NodePort (e.g., 127.0.0.1:30009)
 ADDRESS = getenv("MACTL_ADDRESS", ADDRESS)
-
+# Allow overriding TLS usage via environment variable
+# Set to "true" to force TLS, "false" to force insecure, or leave unset for auto-detection
+USE_TLS = getenv("MACTL_USE_TLS", "true").lower()
 
 METADATA_STUB = METADATA + [("ttl", "600")]
 
@@ -891,5 +893,20 @@ def main(channel: Channel):
 
 
 if __name__ == "__main__":
-    with insecure_channel(ADDRESS) as channel:
-        main(channel)
+    if USE_TLS == "true":
+        # Force TLS
+        should_use_tls = True
+        print(f"Using TLS (forced via MACTL_USE_TLS=true) to connect to {ADDRESS}")
+    else:
+        should_use_tls = False
+        print(f"Using insecure connection (forced via MACTL_USE_TLS=false) to connect to {ADDRESS}")
+
+    if should_use_tls:
+        # Use secure TLS connection
+        credentials = ssl_channel_credentials()
+        with secure_channel(ADDRESS, credentials) as channel:
+            main(channel)
+    else:
+        # Use insecure connection for local development
+        with insecure_channel(ADDRESS) as channel:
+            main(channel)

--- a/python/michelangelo/cli/mactl/mactl_test.py
+++ b/python/michelangelo/cli/mactl/mactl_test.py
@@ -4,8 +4,9 @@ Unit tests for mactl CLI functions.
 Tests gRPC reflection services and service class creation logic.
 """
 
+import os
 from unittest import TestCase
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, MagicMock
 
 from grpc_reflection.v1alpha.reflection_pb2 import ServerReflectionRequest
 
@@ -488,3 +489,303 @@ class GetServiceDescriptorsTest(TestCase):
 
         # Verify the result is empty
         self.assertEqual(len(result), 0)
+
+
+class TLSConfigurationTest(TestCase):
+    """
+    Tests for TLS configuration functionality added to mactl
+    """
+
+    def setUp(self):
+        """Set up test environment variables"""
+        # Store original environment variables
+        self.original_env = {}
+        for key in ["MACTL_USE_TLS", "MACTL_ADDRESS"]:
+            self.original_env[key] = os.environ.get(key)
+
+    def tearDown(self):
+        """Restore original environment variables"""
+        for key, value in self.original_env.items():
+            if value is not None:
+                os.environ[key] = value
+            elif key in os.environ:
+                del os.environ[key]
+
+    @patch.dict(os.environ, {"MACTL_USE_TLS": "true"}, clear=False)
+    def test_use_tls_environment_variable_true(self):
+        """Test that MACTL_USE_TLS=true is properly parsed"""
+        # Need to reload the module to pick up new environment variable
+        import importlib
+        import michelangelo.cli.mactl.mactl
+        importlib.reload(michelangelo.cli.mactl.mactl)
+
+        from michelangelo.cli.mactl.mactl import USE_TLS
+        self.assertEqual(USE_TLS, "true")
+
+    @patch.dict(os.environ, {"MACTL_USE_TLS": "TRUE"}, clear=False)
+    def test_use_tls_environment_variable_case_insensitive(self):
+        """Test that MACTL_USE_TLS is case insensitive and converts to lowercase"""
+        import importlib
+        import michelangelo.cli.mactl.mactl
+        importlib.reload(michelangelo.cli.mactl.mactl)
+
+        from michelangelo.cli.mactl.mactl import USE_TLS
+        self.assertEqual(USE_TLS, "true")
+
+    @patch.dict(os.environ, {"MACTL_USE_TLS": "false"}, clear=False)
+    def test_use_tls_environment_variable_false(self):
+        """Test that MACTL_USE_TLS=false is properly parsed"""
+        import importlib
+        import michelangelo.cli.mactl.mactl
+        importlib.reload(michelangelo.cli.mactl.mactl)
+
+        from michelangelo.cli.mactl.mactl import USE_TLS
+        self.assertEqual(USE_TLS, "false")
+
+    @patch.dict(os.environ, {}, clear=False)
+    def test_use_tls_default_value(self):
+        """Test that USE_TLS defaults to 'true' when not set"""
+        # Remove MACTL_USE_TLS if it exists
+        if "MACTL_USE_TLS" in os.environ:
+            del os.environ["MACTL_USE_TLS"]
+
+        import importlib
+        import michelangelo.cli.mactl.mactl
+        importlib.reload(michelangelo.cli.mactl.mactl)
+
+        from michelangelo.cli.mactl.mactl import USE_TLS
+        self.assertEqual(USE_TLS, "true")
+
+    @patch.dict(os.environ, {"MACTL_USE_TLS": "invalid"}, clear=False)
+    def test_use_tls_invalid_value(self):
+        """Test that invalid values for MACTL_USE_TLS are handled"""
+        import importlib
+        import michelangelo.cli.mactl.mactl
+        importlib.reload(michelangelo.cli.mactl.mactl)
+
+        from michelangelo.cli.mactl.mactl import USE_TLS
+        self.assertEqual(USE_TLS, "invalid")  # Invalid values are preserved as-is
+
+
+class TLSConnectionTest(TestCase):
+    """
+    Tests for TLS connection functionality in main execution
+    """
+
+    @patch("michelangelo.cli.mactl.mactl.main")
+    @patch("michelangelo.cli.mactl.mactl.secure_channel")
+    @patch("michelangelo.cli.mactl.mactl.ssl_channel_credentials")
+    @patch("builtins.print")
+    def test_main_execution_with_tls_enabled(self, mock_print, mock_ssl_creds, mock_secure_channel, mock_main):
+        """Test main execution path when TLS is enabled"""
+        # Setup mocks
+        mock_channel = MagicMock()
+        mock_secure_channel.return_value.__enter__ = Mock(return_value=mock_channel)
+        mock_secure_channel.return_value.__exit__ = Mock(return_value=None)
+        mock_credentials = MagicMock()
+        mock_ssl_creds.return_value = mock_credentials
+
+        # Mock the module-level constants
+        with patch("michelangelo.cli.mactl.mactl.USE_TLS", "true"), \
+             patch("michelangelo.cli.mactl.mactl.ADDRESS", "test-server:443"):
+
+            # Import and run the main block
+            from michelangelo.cli.mactl import mactl
+
+            # Execute the main block logic directly
+            if mactl.USE_TLS == "true":
+                should_use_tls = True
+                print(f"Using TLS (forced via MACTL_USE_TLS=true) to connect to {mactl.ADDRESS}")
+            else:
+                should_use_tls = False
+                print(f"Using insecure connection (forced via MACTL_USE_TLS=false) to connect to {mactl.ADDRESS}")
+
+            if should_use_tls:
+                credentials = mactl.ssl_channel_credentials()
+                with mactl.secure_channel(mactl.ADDRESS, credentials) as channel:
+                    mactl.main(channel)
+            else:
+                with mactl.insecure_channel(mactl.ADDRESS) as channel:
+                    mactl.main(channel)
+
+        # Verify TLS connection setup
+        mock_ssl_creds.assert_called_once()
+        mock_secure_channel.assert_called_once_with("test-server:443", mock_credentials)
+        mock_main.assert_called_once_with(mock_channel)
+        mock_print.assert_called_once_with("Using TLS (forced via MACTL_USE_TLS=true) to connect to test-server:443")
+
+    @patch("michelangelo.cli.mactl.mactl.main")
+    @patch("michelangelo.cli.mactl.mactl.insecure_channel")
+    @patch("builtins.print")
+    def test_main_execution_with_tls_disabled(self, mock_print, mock_insecure_channel, mock_main):
+        """Test main execution path when TLS is disabled"""
+        # Setup mocks
+        mock_channel = MagicMock()
+        mock_insecure_channel.return_value.__enter__ = Mock(return_value=mock_channel)
+        mock_insecure_channel.return_value.__exit__ = Mock(return_value=None)
+
+        # Mock the module-level constants
+        with patch("michelangelo.cli.mactl.mactl.USE_TLS", "false"), \
+             patch("michelangelo.cli.mactl.mactl.ADDRESS", "localhost:5435"):
+
+            # Import and run the main block
+            from michelangelo.cli.mactl import mactl
+
+            # Execute the main block logic directly
+            if mactl.USE_TLS == "true":
+                should_use_tls = True
+                print(f"Using TLS (forced via MACTL_USE_TLS=true) to connect to {mactl.ADDRESS}")
+            else:
+                should_use_tls = False
+                print(f"Using insecure connection (forced via MACTL_USE_TLS=false) to connect to {mactl.ADDRESS}")
+
+            if should_use_tls:
+                credentials = mactl.ssl_channel_credentials()
+                with mactl.secure_channel(mactl.ADDRESS, credentials) as channel:
+                    mactl.main(channel)
+            else:
+                with mactl.insecure_channel(mactl.ADDRESS) as channel:
+                    mactl.main(channel)
+
+        # Verify insecure connection setup
+        mock_insecure_channel.assert_called_once_with("localhost:5435")
+        mock_main.assert_called_once_with(mock_channel)
+        mock_print.assert_called_once_with("Using insecure connection (forced via MACTL_USE_TLS=false) to connect to localhost:5435")
+
+    @patch("michelangelo.cli.mactl.mactl.main")
+    @patch("michelangelo.cli.mactl.mactl.secure_channel")
+    @patch("michelangelo.cli.mactl.mactl.ssl_channel_credentials")
+    @patch("michelangelo.cli.mactl.mactl.insecure_channel")
+    def test_channel_context_manager_usage(self, mock_insecure_channel, mock_ssl_creds, mock_secure_channel, mock_main):
+        """Test that channels are properly used as context managers"""
+        mock_channel = MagicMock()
+
+        # Test TLS channel context manager
+        mock_secure_channel.return_value = MagicMock()
+        mock_secure_channel.return_value.__enter__ = Mock(return_value=mock_channel)
+        mock_secure_channel.return_value.__exit__ = Mock(return_value=None)
+        mock_credentials = MagicMock()
+        mock_ssl_creds.return_value = mock_credentials
+
+        with patch("michelangelo.cli.mactl.mactl.USE_TLS", "true"), \
+             patch("michelangelo.cli.mactl.mactl.ADDRESS", "test-server:443"):
+
+            from michelangelo.cli.mactl import mactl
+
+            # Test secure channel usage
+            if mactl.USE_TLS == "true":
+                credentials = mactl.ssl_channel_credentials()
+                with mactl.secure_channel(mactl.ADDRESS, credentials) as channel:
+                    mactl.main(channel)
+
+        # Verify context manager methods were called
+        mock_secure_channel.return_value.__enter__.assert_called_once()
+        mock_secure_channel.return_value.__exit__.assert_called_once()
+        mock_main.assert_called_once_with(mock_channel)
+
+        # Reset mocks
+        mock_main.reset_mock()
+        mock_insecure_channel.reset_mock()
+
+        # Test insecure channel context manager
+        mock_insecure_channel.return_value = MagicMock()
+        mock_insecure_channel.return_value.__enter__ = Mock(return_value=mock_channel)
+        mock_insecure_channel.return_value.__exit__ = Mock(return_value=None)
+
+        with patch("michelangelo.cli.mactl.mactl.USE_TLS", "false"), \
+             patch("michelangelo.cli.mactl.mactl.ADDRESS", "localhost:5435"):
+
+            from michelangelo.cli.mactl import mactl
+
+            # Test insecure channel usage
+            if mactl.USE_TLS != "true":
+                with mactl.insecure_channel(mactl.ADDRESS) as channel:
+                    mactl.main(channel)
+
+        # Verify context manager methods were called
+        mock_insecure_channel.return_value.__enter__.assert_called_once()
+        mock_insecure_channel.return_value.__exit__.assert_called_once()
+        mock_main.assert_called_once_with(mock_channel)
+
+    def test_address_environment_variable_integration(self):
+        """Test that MACTL_ADDRESS works with TLS configuration"""
+        test_address = "custom-server:9999"
+
+        with patch.dict(os.environ, {"MACTL_ADDRESS": test_address, "MACTL_USE_TLS": "true"}, clear=False):
+            import importlib
+            import michelangelo.cli.mactl.mactl
+            importlib.reload(michelangelo.cli.mactl.mactl)
+
+            from michelangelo.cli.mactl.mactl import ADDRESS, USE_TLS
+            self.assertEqual(ADDRESS, test_address)
+            self.assertEqual(USE_TLS, "true")
+
+
+class TLSImportsTest(TestCase):
+    """
+    Tests to verify that TLS-related imports are correctly added
+    """
+
+    def test_tls_imports_available(self):
+        """Test that TLS-related functions are imported and available"""
+        from michelangelo.cli.mactl.mactl import (
+            secure_channel,
+            ssl_channel_credentials,
+            insecure_channel
+        )
+
+        # Verify imports are callable
+        self.assertTrue(callable(secure_channel))
+        self.assertTrue(callable(ssl_channel_credentials))
+        self.assertTrue(callable(insecure_channel))
+
+    def test_module_imports_grpc_tls_functions(self):
+        """Test that the module successfully imports gRPC TLS functions"""
+        import michelangelo.cli.mactl.mactl as mactl_module
+
+        # Check that the functions exist as attributes of the module
+        self.assertTrue(hasattr(mactl_module, "secure_channel"))
+        self.assertTrue(hasattr(mactl_module, "ssl_channel_credentials"))
+        self.assertTrue(hasattr(mactl_module, "insecure_channel"))
+
+
+class TLSErrorHandlingTest(TestCase):
+    """
+    Tests for TLS error handling scenarios
+    """
+
+    @patch("michelangelo.cli.mactl.mactl.ssl_channel_credentials")
+    @patch("michelangelo.cli.mactl.mactl.secure_channel")
+    def test_tls_connection_failure_handling(self, mock_secure_channel, mock_ssl_creds):
+        """Test handling of TLS connection failures"""
+        # Mock TLS connection failure
+        mock_ssl_creds.return_value = MagicMock()
+        mock_secure_channel.side_effect = Exception("TLS connection failed")
+
+        with patch("michelangelo.cli.mactl.mactl.USE_TLS", "true"), \
+             patch("michelangelo.cli.mactl.mactl.ADDRESS", "bad-server:443"):
+
+            from michelangelo.cli.mactl import mactl
+
+            # This should raise the TLS connection exception
+            with self.assertRaises(Exception) as context:
+                credentials = mactl.ssl_channel_credentials()
+                with mactl.secure_channel(mactl.ADDRESS, credentials) as channel:
+                    pass  # Connection should fail before reaching main()
+
+            self.assertEqual(str(context.exception), "TLS connection failed")
+
+    @patch("michelangelo.cli.mactl.mactl.ssl_channel_credentials")
+    def test_ssl_credentials_creation_failure(self, mock_ssl_creds):
+        """Test handling of SSL credentials creation failure"""
+        # Mock SSL credentials creation failure
+        mock_ssl_creds.side_effect = Exception("Failed to create SSL credentials")
+
+        with patch("michelangelo.cli.mactl.mactl.USE_TLS", "true"):
+            from michelangelo.cli.mactl import mactl
+
+            # This should raise the SSL credentials exception
+            with self.assertRaises(Exception) as context:
+                mactl.ssl_channel_credentials()
+
+            self.assertEqual(str(context.exception), "Failed to create SSL credentials")


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
To add TLS credential for go client ma-apiserver and python client ma-apiserver

<!-- Tell your future self why have you made these changes -->
**Why?**
Add TLS for connectivity from worker to apiserver. Due to we've using localhost for grpc connection before, we never used TLS for this. However, when partner using external GRPC connection, they experienced 404 issue due to no TLS credential. This PR is to fix this issue.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Remote run

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
