### PR TITLE
Remove `clusterName` field in pipeline apply/create for OSS api server

### DIFF
--- a/python/michelangelo/cli/mactl/mactl.py
+++ b/python/michelangelo/cli/mactl/mactl.py
@@ -585,7 +585,6 @@ def convert_crd_metadata(
 
     res = {"spec": deepcopy(yaml_dict["spec"])}
     res["metadata"] = {
-        "clusterName": "",
         "generateName": "",
         "generation": "0",
         "name": yaml_dict["metadata"]["name"],

--- a/python/michelangelo/cli/mactl/plugins/pipeline/apply.py
+++ b/python/michelangelo/cli/mactl/plugins/pipeline/apply.py
@@ -37,7 +37,6 @@ def convert_crd_metadata_pipeline_apply(
 
     res = {"spec": deepcopy(yaml_dict["spec"])}
     res["metadata"] = {
-        "clusterName": "",
         "generateName": "",
         "generation": "0",
         "name": yaml_dict["metadata"]["name"],

--- a/python/michelangelo/cli/mactl/plugins/pipeline/create.py
+++ b/python/michelangelo/cli/mactl/plugins/pipeline/create.py
@@ -195,7 +195,6 @@ def convert_crd_metadata_pipeline_create(
 
     res["metadata"] = {
         "annotations": yaml_dict["metadata"].get("annotations", {}),
-        "clusterName": "",
         "generateName": "",
         "generation": "0",
         "name": pipeline,


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

Remove the hardcoded `clusterName` field in pipeline apply/create for OSS api server.

<!-- Tell your future self why have you made these changes -->
**Why?**

This field was auto generated by the mactl plugin, since the uber-internal server does not allow to create the pipeline CRD without this field. However, we've decided to focus on the OSS part first, so this PR removes this field.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
