### PR TITLE
Implement Granular control for Incompatible schema with per-CRD allowlist

### DIFF
--- a/go/api/crd/sync.go
+++ b/go/api/crd/sync.go
@@ -76,15 +76,15 @@ type SyncCRDsParams struct {
 //     Otherwise, it will return an error
 //  7. If a CRD version in the cluster does not have a corresponding entry in yamlSchemas, an error will be returned,
 //     as we don't currently support removing versions of CRDs in the cluster.
-func SyncCRDs(group string, yamlSchemas ...map[string]string) fx.Option {
+func SyncCRDs(group string, incompatibleUpdateAllowList []string, yamlSchemas ...map[string]string) fx.Option {
 	return fx.Invoke(func(p SyncCRDsParams) error {
 		logger := p.Logger.With(zap.String("module", moduleName))
 		logger.Info("CRD sync config", zap.Any("config", p.Config))
 		if p.Config.EnableCRDUpdate {
 			p.Lifecycle.Append(fx.Hook{
 				OnStart: func(ctx context.Context) error {
-					return syncCRDs(ctx, logger, group, p.Config.EnableIncompatibleUpdate, p.Config.EnableCRDDeletion,
-						p.Gateway, p.Config.CRDVersions, yamlSchemas...)
+					return syncCRDs(ctx, logger, group, p.Config.EnableCRDDeletion,
+						p.Gateway, p.Config.CRDVersions, incompatibleUpdateAllowList, yamlSchemas...)
 				},
 				OnStop: nil,
 			})
@@ -97,10 +97,10 @@ func SyncCRDs(group string, yamlSchemas ...map[string]string) fx.Option {
 func syncCRDs(ctx context.Context,
 	logger *zap.Logger,
 	group string,
-	enableIncompatibleUpdate bool,
 	enableCRDDeletion bool,
 	gateway Gateway,
 	crdVersions map[string]VersionConfig,
+	incompatibleUpdateAllowList []string,
 	yamlSchemas ...map[string]string) error {
 
 	// decode CRD yaml schemas into CRD objects
@@ -162,7 +162,7 @@ func syncCRDs(ctx context.Context,
 	}
 
 	// upsert CRDs
-	if err = upsertCRDs(ctx, logger, gateway, mergedCRDList, enableIncompatibleUpdate); err != nil {
+	if err = upsertCRDs(ctx, logger, gateway, mergedCRDList, incompatibleUpdateAllowList); err != nil {
 		logger.Error("Failed to upsert CRDs", zap.Error(err))
 		return err
 	}
@@ -171,9 +171,12 @@ func syncCRDs(ctx context.Context,
 
 // upsertCRDs upsert CRD onto k8s cluster, also handle OCC conflict with retry
 func upsertCRDs(ctx context.Context, logger *zap.Logger, gateway Gateway,
-	crds []*apiextv1.CustomResourceDefinition, enableIncompatibleUpdate bool) error {
+	crds []*apiextv1.CustomResourceDefinition, allowList []string) error {
 	logger.Info("Compare CRD in cluster with new CRD definition, and conditionally update CRDs")
 	for _, crd := range crds {
+		// Per-CRD decision: only allowlist matters
+		enableIncompatibleUpdate := isInAllowList(crd.Name, allowList)
+
 		err := backoff.Retry(func() error {
 			err := gateway.ConditionalUpsert(ctx, crd, enableIncompatibleUpdate)
 			if err != nil {
@@ -298,4 +301,14 @@ func mergeCRDVersions(
 		result = append(result, mergedCRD)
 	}
 	return result, nil
+}
+
+// isInAllowList checks if the given CRD name is in the incompatible update allowlist
+func isInAllowList(crdName string, allowList []string) bool {
+	for _, allowed := range allowList {
+		if crdName == allowed {
+			return true
+		}
+	}
+	return false
 }

--- a/go/api/crd/sync.go
+++ b/go/api/crd/sync.go
@@ -23,10 +23,9 @@ const (
 
 // Configuration crd register configuration
 type Configuration struct {
-	EnableCRDUpdate          bool                     `yaml:"enableCRDUpdate"`
-	EnableIncompatibleUpdate bool                     `yaml:"enableIncompatibleUpdate"`
-	EnableCRDDeletion        bool                     `yaml:"enableCRDDeletion"`
-	CRDVersions              map[string]VersionConfig `yaml:"crdVersions"`
+	EnableCRDUpdate   bool                     `yaml:"enableCRDUpdate"`
+	EnableCRDDeletion bool                     `yaml:"enableCRDDeletion"`
+	CRDVersions       map[string]VersionConfig `yaml:"crdVersions"`
 }
 
 // VersionConfig defines how the versions of a CRD will be handled.

--- a/go/api/crd/sync_test.go
+++ b/go/api/crd/sync_test.go
@@ -33,7 +33,7 @@ func TestUpsertCRDs(t *testing.T) {
 		crd, err := readCRDFromFile(testCRDManifestDir + "/project.pb.yaml")
 		assert.NotNil(t, crd)
 		assert.NoError(t, err)
-		err = upsertCRDs(ctx, logger, crdGatewayMock, []*apiextv1.CustomResourceDefinition{crd}, false)
+		err = upsertCRDs(ctx, logger, crdGatewayMock, []*apiextv1.CustomResourceDefinition{crd}, []string{})
 		assert.NoError(t, err)
 	})
 
@@ -48,7 +48,7 @@ func TestUpsertCRDs(t *testing.T) {
 		crd, err := readCRDFromFile(testCRDManifestDir + "/project.pb.yaml")
 		assert.NotNil(t, crd)
 		assert.NoError(t, err)
-		err = upsertCRDs(ctx, logger, crdGatewayMock, []*apiextv1.CustomResourceDefinition{crd}, false)
+		err = upsertCRDs(ctx, logger, crdGatewayMock, []*apiextv1.CustomResourceDefinition{crd}, []string{})
 		assert.NoError(t, err)
 	})
 
@@ -61,7 +61,7 @@ func TestUpsertCRDs(t *testing.T) {
 		crd, err := readCRDFromFile(testCRDManifestDir + "/project.pb.yaml")
 		assert.NotNil(t, crd)
 		assert.NoError(t, err)
-		err = upsertCRDs(ctx, logger, crdGatewayMock, []*apiextv1.CustomResourceDefinition{crd}, false)
+		err = upsertCRDs(ctx, logger, crdGatewayMock, []*apiextv1.CustomResourceDefinition{crd}, []string{})
 		assert.Error(t, err)
 	})
 }
@@ -95,7 +95,7 @@ func TestSyncCRDsFx(t *testing.T) {
 				EnableIncompatibleUpdate: false,
 			}
 		}),
-		SyncCRDs("test", map[string]string{
+		SyncCRDs("test", []string{}, map[string]string{
 			"Project": string(crdYaml),
 		}),
 	),
@@ -118,7 +118,7 @@ func TestSyncCRDsFx(t *testing.T) {
 				EnableIncompatibleUpdate: false,
 			}
 		}),
-		SyncCRDs("test", map[string]string{
+		SyncCRDs("test", []string{}, map[string]string{
 			"Project": string(crdYaml),
 		}),
 	),
@@ -148,7 +148,7 @@ func TestSyncCRDsFx(t *testing.T) {
 				EnableCRDDeletion:        true,
 			}
 		}),
-		SyncCRDs("test", map[string]string{
+		SyncCRDs("test", []string{}, map[string]string{
 			"Project": string(crdYaml),
 		}),
 	),
@@ -184,7 +184,7 @@ func TestSyncCRDsFx(t *testing.T) {
 		fx.Invoke(func() error {
 			return nil
 		}),
-		SyncCRDs("test", map[string]string{}),
+		SyncCRDs("test", []string{}, map[string]string{}),
 	),
 	)
 	assert.NoError(t, app.Err())
@@ -213,7 +213,7 @@ func TestSyncCRDsFx(t *testing.T) {
 		fx.Invoke(func() error {
 			return nil
 		}),
-		SyncCRDs("test", map[string]string{}),
+		SyncCRDs("test", []string{}, map[string]string{}),
 	),
 	)
 	assert.NoError(t, app.Err())
@@ -240,7 +240,7 @@ func TestSyncCRDsFx(t *testing.T) {
 		fx.Invoke(func() error {
 			return nil
 		}),
-		SyncCRDs("test", map[string]string{}),
+		SyncCRDs("test", []string{}, map[string]string{}),
 	),
 	)
 	assert.NoError(t, app.Err())
@@ -264,26 +264,26 @@ func TestSyncCRDs(t *testing.T) {
 	crdYaml, err := os.ReadFile(testCRDManifestDir + "/project.pb.yaml")
 	assert.NoError(t, err)
 	err = syncCRDs(context.Background(), logger, "test",
-		false, true, &crdGateway, nil, map[string]string{"Project": string(crdYaml)})
+		true, &crdGateway, nil, []string{}, map[string]string{"Project": string(crdYaml)})
 	assert.NoError(t, err)
 
 	// incompatible change
 	crdYaml, err = os.ReadFile(testCRDManifestDir + "/project_delete_props.pb.yaml")
 	assert.NoError(t, err)
 	err = syncCRDs(context.Background(), logger, "test",
-		false, true, &crdGateway, nil, map[string]string{"Project": string(crdYaml)})
+		true, &crdGateway, nil, []string{}, map[string]string{"Project": string(crdYaml)})
 	assert.Error(t, err, "failed to update CRD. Schema is incompatible, and there are existing instances. Abort updating CRD projects.test")
 
 	// fail to list existing CRDs
 	mockGateway := crdmocks.NewMockGateway(gomock.NewController(t))
 	mockGateway.EXPECT().List(gomock.Any()).Return(nil, fmt.Errorf("test error"))
 	err = syncCRDs(context.Background(), logger, "test",
-		false, true, mockGateway, nil, map[string]string{"Project": string(crdYaml)})
+		true, mockGateway, nil, []string{}, map[string]string{"Project": string(crdYaml)})
 	assert.Error(t, err, "failed to list existing CRDs: test error")
 
 	// do not update CRDs that are not in the specified groups
 	err = syncCRDs(context.Background(), logger, "test1",
-		false, true, &crdGateway, nil, map[string]string{"Project": string(crdYaml)})
+		true, &crdGateway, nil, []string{}, map[string]string{"Project": string(crdYaml)})
 	assert.Error(t, err, "CRD projects.test is not in the specified group test1")
 }
 
@@ -617,5 +617,93 @@ func TestMergeCRDVersions(t *testing.T) {
 				assert.Equal(t, apiextv1.NoneConverter, crd.Spec.Conversion.Strategy)
 			}
 		}
+	})
+}
+
+func TestIsInAllowList(t *testing.T) {
+	t.Run("CRD in allowlist", func(t *testing.T) {
+		allowList := []string{"deployments.michelangelo.api", "agents.michelangelo.api"}
+		result := isInAllowList("deployments.michelangelo.api", allowList)
+		assert.True(t, result)
+	})
+
+	t.Run("CRD not in allowlist", func(t *testing.T) {
+		allowList := []string{"deployments.michelangelo.api", "agents.michelangelo.api"}
+		result := isInAllowList("projects.michelangelo.api", allowList)
+		assert.False(t, result)
+	})
+
+	t.Run("Empty allowlist", func(t *testing.T) {
+		allowList := []string{}
+		result := isInAllowList("deployments.michelangelo.api", allowList)
+		assert.False(t, result)
+	})
+
+	t.Run("Nil allowlist", func(t *testing.T) {
+		var allowList []string
+		result := isInAllowList("deployments.michelangelo.api", allowList)
+		assert.False(t, result)
+	})
+}
+
+func TestUpsertCRDsWithAllowList(t *testing.T) {
+	logger, err := zap.NewDevelopment()
+	assert.NoError(t, err)
+
+	t.Run("CRD in allowlist enables incompatible updates", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		crdGatewayMock := crdmocks.NewMockGateway(ctrl)
+
+		// Expect ConditionalUpsert to be called with enableIncompatibleUpdate=true
+		crdGatewayMock.EXPECT().ConditionalUpsert(gomock.Any(), gomock.Any(), true).Return(nil).Times(1)
+
+		ctx := context.Background()
+		crd, err := readCRDFromFile(testCRDManifestDir + "/project.pb.yaml")
+		assert.NotNil(t, crd)
+		assert.NoError(t, err)
+
+		// Set the CRD name to match our allowlist
+		crd.Name = "deployments.michelangelo.api"
+
+		allowList := []string{"deployments.michelangelo.api"}
+		err = upsertCRDs(ctx, logger, crdGatewayMock, []*apiextv1.CustomResourceDefinition{crd}, allowList)
+		assert.NoError(t, err)
+	})
+
+	t.Run("CRD not in allowlist disables incompatible updates", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		crdGatewayMock := crdmocks.NewMockGateway(ctrl)
+
+		// Expect ConditionalUpsert to be called with enableIncompatibleUpdate=false
+		crdGatewayMock.EXPECT().ConditionalUpsert(gomock.Any(), gomock.Any(), false).Return(nil).Times(1)
+
+		ctx := context.Background()
+		crd, err := readCRDFromFile(testCRDManifestDir + "/project.pb.yaml")
+		assert.NotNil(t, crd)
+		assert.NoError(t, err)
+
+		// Set the CRD name to NOT match our allowlist
+		crd.Name = "projects.michelangelo.api"
+
+		allowList := []string{"deployments.michelangelo.api"}
+		err = upsertCRDs(ctx, logger, crdGatewayMock, []*apiextv1.CustomResourceDefinition{crd}, allowList)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Empty allowlist disables incompatible updates for all CRDs", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		crdGatewayMock := crdmocks.NewMockGateway(ctrl)
+
+		// Expect ConditionalUpsert to be called with enableIncompatibleUpdate=false
+		crdGatewayMock.EXPECT().ConditionalUpsert(gomock.Any(), gomock.Any(), false).Return(nil).Times(1)
+
+		ctx := context.Background()
+		crd, err := readCRDFromFile(testCRDManifestDir + "/project.pb.yaml")
+		assert.NotNil(t, crd)
+		assert.NoError(t, err)
+
+		allowList := []string{}
+		err = upsertCRDs(ctx, logger, crdGatewayMock, []*apiextv1.CustomResourceDefinition{crd}, allowList)
+		assert.NoError(t, err)
 	})
 }

--- a/go/api/crd/sync_test.go
+++ b/go/api/crd/sync_test.go
@@ -91,7 +91,7 @@ func TestSyncCRDsFx(t *testing.T) {
 		}),
 		fx.Provide(func() *Configuration {
 			return &Configuration{
-				EnableCRDUpdate:          false,
+				EnableCRDUpdate: false,
 			}
 		}),
 		SyncCRDs("test", []string{}, map[string]string{
@@ -113,7 +113,7 @@ func TestSyncCRDsFx(t *testing.T) {
 		}),
 		fx.Provide(func() *Configuration {
 			return &Configuration{
-				EnableCRDUpdate:          true,
+				EnableCRDUpdate: true,
 			}
 		}),
 		SyncCRDs("test", []string{}, map[string]string{
@@ -141,8 +141,8 @@ func TestSyncCRDsFx(t *testing.T) {
 		}),
 		fx.Provide(func() *Configuration {
 			return &Configuration{
-				EnableCRDUpdate:          true,
-				EnableCRDDeletion:        true,
+				EnableCRDUpdate:   true,
+				EnableCRDDeletion: true,
 			}
 		}),
 		SyncCRDs("test", []string{}, map[string]string{
@@ -173,8 +173,8 @@ func TestSyncCRDsFx(t *testing.T) {
 		}),
 		fx.Provide(func() *Configuration {
 			return &Configuration{
-				EnableCRDUpdate:          true,
-				EnableCRDDeletion:        false,
+				EnableCRDUpdate:   true,
+				EnableCRDDeletion: false,
 			}
 		}),
 		fx.Invoke(func() error {
@@ -201,8 +201,8 @@ func TestSyncCRDsFx(t *testing.T) {
 		}),
 		fx.Provide(func() *Configuration {
 			return &Configuration{
-				EnableCRDUpdate:          true,
-				EnableCRDDeletion:        true,
+				EnableCRDUpdate:   true,
+				EnableCRDDeletion: true,
 			}
 		}),
 		fx.Invoke(func() error {
@@ -227,8 +227,8 @@ func TestSyncCRDsFx(t *testing.T) {
 		}),
 		fx.Provide(func() *Configuration {
 			return &Configuration{
-				EnableCRDUpdate:          true,
-				EnableCRDDeletion:        true,
+				EnableCRDUpdate:   true,
+				EnableCRDDeletion: true,
 			}
 		}),
 		fx.Invoke(func() error {

--- a/go/api/crd/sync_test.go
+++ b/go/api/crd/sync_test.go
@@ -92,7 +92,6 @@ func TestSyncCRDsFx(t *testing.T) {
 		fx.Provide(func() *Configuration {
 			return &Configuration{
 				EnableCRDUpdate:          false,
-				EnableIncompatibleUpdate: false,
 			}
 		}),
 		SyncCRDs("test", []string{}, map[string]string{
@@ -115,7 +114,6 @@ func TestSyncCRDsFx(t *testing.T) {
 		fx.Provide(func() *Configuration {
 			return &Configuration{
 				EnableCRDUpdate:          true,
-				EnableIncompatibleUpdate: false,
 			}
 		}),
 		SyncCRDs("test", []string{}, map[string]string{
@@ -144,7 +142,6 @@ func TestSyncCRDsFx(t *testing.T) {
 		fx.Provide(func() *Configuration {
 			return &Configuration{
 				EnableCRDUpdate:          true,
-				EnableIncompatibleUpdate: false,
 				EnableCRDDeletion:        true,
 			}
 		}),
@@ -177,7 +174,6 @@ func TestSyncCRDsFx(t *testing.T) {
 		fx.Provide(func() *Configuration {
 			return &Configuration{
 				EnableCRDUpdate:          true,
-				EnableIncompatibleUpdate: false,
 				EnableCRDDeletion:        false,
 			}
 		}),
@@ -206,7 +202,6 @@ func TestSyncCRDsFx(t *testing.T) {
 		fx.Provide(func() *Configuration {
 			return &Configuration{
 				EnableCRDUpdate:          true,
-				EnableIncompatibleUpdate: false,
 				EnableCRDDeletion:        true,
 			}
 		}),
@@ -233,7 +228,6 @@ func TestSyncCRDsFx(t *testing.T) {
 		fx.Provide(func() *Configuration {
 			return &Configuration{
 				EnableCRDUpdate:          true,
-				EnableIncompatibleUpdate: false,
 				EnableCRDDeletion:        true,
 			}
 		}),
@@ -267,12 +261,17 @@ func TestSyncCRDs(t *testing.T) {
 		true, &crdGateway, nil, []string{}, map[string]string{"Project": string(crdYaml)})
 	assert.NoError(t, err)
 
-	// incompatible change
+	// incompatible change - should be blocked with empty allowlist
 	crdYaml, err = os.ReadFile(testCRDManifestDir + "/project_delete_props.pb.yaml")
 	assert.NoError(t, err)
 	err = syncCRDs(context.Background(), logger, "test",
 		true, &crdGateway, nil, []string{}, map[string]string{"Project": string(crdYaml)})
 	assert.Error(t, err, "failed to update CRD. Schema is incompatible, and there are existing instances. Abort updating CRD projects.test")
+
+	// same incompatible change - should be allowed when CRD is in allowlist
+	err = syncCRDs(context.Background(), logger, "test",
+		true, &crdGateway, nil, []string{"projects.test"}, map[string]string{"Project": string(crdYaml)})
+	assert.NoError(t, err, "incompatible update should be allowed when CRD is in allowlist")
 
 	// fail to list existing CRDs
 	mockGateway := crdmocks.NewMockGateway(gomock.NewController(t))
@@ -292,7 +291,6 @@ func TestParseConfig(t *testing.T) {
 apiserver:
   crdSync:
     enableCRDUpdate: true
-    enableIncompatibleUpdate: false
 `
 	provider, err := config.NewYAML(config.Source(strings.NewReader(yamlConfStr)))
 	assert.NoError(t, err)
@@ -300,14 +298,12 @@ apiserver:
 	conf, err := ParseConfig(provider)
 	assert.NoError(t, err)
 	assert.True(t, conf.EnableCRDUpdate)
-	assert.False(t, conf.EnableIncompatibleUpdate)
 
 	// Parse configuration with CRD versions
 	yamlConfStr2 := `
 apiserver:
   crdSync:
     enableCRDUpdate: true
-    enableIncompatibleUpdate: true
     crdVersions:
       project:
         versions: [v1, v2]
@@ -319,7 +315,6 @@ apiserver:
 	conf2, err := ParseConfig(provider2)
 	assert.NoError(t, err)
 	assert.True(t, conf2.EnableCRDUpdate)
-	assert.True(t, conf2.EnableIncompatibleUpdate)
 	assert.Equal(t, conf2.CRDVersions, map[string]VersionConfig{
 		"project": {
 			Versions:       []string{"v1", "v2"},

--- a/go/cmd/apiserver/config/base.yaml
+++ b/go/cmd/apiserver/config/base.yaml
@@ -4,7 +4,6 @@ apiserver:
     port: 14566
   crdSync:
     enableCRDUpdate: true
-    enableIncompatibleUpdate: false
     enableCRDDeletion: true
     crdVersions:
       project:

--- a/go/cmd/apiserver/main.go
+++ b/go/cmd/apiserver/main.go
@@ -54,7 +54,9 @@ func opts() fx.Option {
 		v2pb.TriggerRunSvcModule,
 		v2pb.DeploymentSvcModule,
 		crd.Module,
-		crd.SyncCRDs(v2pb.GroupVersion.Group, v2pb.YamlSchemas),
+		crd.SyncCRDs(v2pb.GroupVersion.Group,
+			[]string{},
+			v2pb.YamlSchemas),
 		fx.Invoke(registerProcedures),
 		fx.Invoke(startYARPCServer),
 	)

--- a/python/michelangelo/cli/sandbox/resources/michelangelo-apiserver.yaml
+++ b/python/michelangelo/cli/sandbox/resources/michelangelo-apiserver.yaml
@@ -53,4 +53,3 @@ data:
         enableMetadataStorage: false
       crdSync:
         enableCRDUpdate: true
-        enableIncompatibleUpdate: false


### PR DESCRIPTION
- Add incompatibleUpdateAllowList parameter to SyncCRDs function
- Remove global enableIncompatibleUpdate flag dependency from CRD sync flow
- Implement per-CRD logic: only CRDs in allowlist can have incompatible updates
- Add isInAllowList helper function for CRD name matching
- Update all function signatures and call sites
- Add comprehensive test coverage for allowlist functionality
- Default to empty allowlist for safe behavior

This provides granular per-CRD control over incompatible schema updates without configuration complexity.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
