### PR TITLE
[Proto] Change ProjectSpec.ext CRD schema as optional (from required)

### DIFF
--- a/proto/api/v2/project.proto
+++ b/proto/api/v2/project.proto
@@ -118,7 +118,7 @@ message ProjectSpec {
   ProjectTypeInfo type_info = 10 [(michelangelo.api.validation) = {optional: true}];
 
   // Extension field for additional custom data
-  google.protobuf.Any ext = 999;
+  google.protobuf.Any ext = 999 [(michelangelo.api.validation) = {optional: true}];
 }
 
 // Describes the state of a project resource.


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

Change ProjectSpec.ext CRD schema as optional (from required)

<!-- Tell your future self why have you made these changes -->
**Why?**

Since all member fields of ProjectSpec is set as required field, we'd like to change this field as optional.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
