### PR TITLE
MA Sandbox changes for running ray jobs in compute cluster

### DIFF
--- a/.github/workflows/python-coverage.yml
+++ b/.github/workflows/python-coverage.yml
@@ -86,6 +86,7 @@ jobs:
           ANNOTATION_TYPE: warning
           VERBOSE: true
           COVERAGE_PATH: python
+          COVERAGE_DATA_BRANCH: main
         continue-on-error: true
 
       # Upload coverage to Codecov for tracking over time

--- a/.github/workflows/python-coverage.yml
+++ b/.github/workflows/python-coverage.yml
@@ -86,6 +86,7 @@ jobs:
           ANNOTATION_TYPE: warning
           VERBOSE: true
           COVERAGE_PATH: python
+        continue-on-error: true
 
       # Upload coverage to Codecov for tracking over time
       - name: Upload coverage to Codecov

--- a/.github/workflows/python-coverage.yml
+++ b/.github/workflows/python-coverage.yml
@@ -86,7 +86,6 @@ jobs:
           ANNOTATION_TYPE: warning
           VERBOSE: true
           COVERAGE_PATH: python
-          COVERAGE_DATA_BRANCH: main
 
       # Upload coverage to Codecov for tracking over time
       - name: Upload coverage to Codecov

--- a/python/michelangelo/cli/sandbox/resources/rbac-ray.yaml
+++ b/python/michelangelo/cli/sandbox/resources/rbac-ray.yaml
@@ -5,25 +5,24 @@ metadata:
   namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+# ClusterRole for Spark/Ray jobs across namespaces; one federated client uses a single ServiceAccount secret to create jobs in multiple namespaces.
+kind: ClusterRole
 metadata:
   name: ray-manager
-  namespace: default
 rules:
 - apiGroups: ["ray.io"]
   resources: ["rayclusters", "rayjobs"]
   verbs: ["create","get","list","watch","update","patch","delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: ray-manager-binding
-  namespace: default
 subjects:
 - kind: ServiceAccount
   name: ray-manager
   namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: ray-manager

--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -48,7 +48,7 @@ _ray_ports = [
 ]
 
 _cadence_domain = "default"
-_default_job_hosting_kube_cluster_name = "michelangelo-jobs-0"
+_default_compute_kube_cluster_name = "michelangelo-compute-0"
 
 
 def init_arguments(p: argparse.ArgumentParser):
@@ -68,7 +68,7 @@ def init_arguments(p: argparse.ArgumentParser):
         help="Choose workflow engine: cadence or temporal (default: cadence).",
     )
     create_p.add_argument(
-        "--create-jobs-cluster",
+        "--create-compute-cluster",
         action="store_true",
         help="Create an additional cluster for Ray jobs.",
     )
@@ -79,10 +79,10 @@ def init_arguments(p: argparse.ArgumentParser):
         default=[],
     )
     create_p.add_argument(
-        "--jobs-cluster-name",
-        default=_default_job_hosting_kube_cluster_name,
-        help="Name of the jobs cluster to create when --create-jobs-cluster is used (default: %s)."
-        % _default_job_hosting_kube_cluster_name,
+        "--compute-cluster-name",
+        default=_default_compute_kube_cluster_name,
+        help="Name of the compute cluster to create when --create-compute-cluster is used (default: %s)."
+        % _default_compute_kube_cluster_name,
     )
 
     _ = sp.add_parser(
@@ -90,10 +90,10 @@ def init_arguments(p: argparse.ArgumentParser):
     )
     delete_p = sp.add_parser("delete", help="Delete the cluster.")
     delete_p.add_argument(
-        "--jobs-cluster-name",
-        default=_default_job_hosting_kube_cluster_name,
-        help="Name of the jobs cluster to delete when --create-jobs-cluster is used (default: %s)."
-        % _default_job_hosting_kube_cluster_name,
+        "--compute-cluster-name",
+        default=_default_compute_kube_cluster_name,
+        help="Name of the compute cluster to delete when --create-compute-cluster is used (default: %s)."
+        % _default_compute_kube_cluster_name,
     )
     _ = sp.add_parser("start", help="Start the cluster.")
     _ = sp.add_parser("stop", help="Stop the cluster.")
@@ -321,11 +321,16 @@ Be aware that CR_PAT environment variable is required while Michelangelo is NOT 
     else:
         raise ValueError(f"Unsupported workflow engine: {ns.workflow}")
 
-    # Create the jobs cluster if requested
-    if ns.create_jobs_cluster:
-        _create_jobs_cluster(ns.jobs_cluster_name)
-        _create_cluster_crd(ns.jobs_cluster_name)
-        _create_cluster_secrets(ns.jobs_cluster_name)
+    # Create separate compute cluster if requested
+    if ns.create_compute_cluster:
+        _create_compute_cluster(ns.compute_cluster_name)
+        _create_compute_cluster_crd(ns.compute_cluster_name)
+        _apply_compute_cluster_rbac(ns.compute_cluster_name)
+        _create_compute_cluster_secrets(ns.compute_cluster_name)
+    else:  # Use the control plane cluster as the default compute cluster if a dedicated compute cluster is not requested
+        _create_compute_cluster_crd(_michelangelo_sandbox_kube_cluster_name)
+        _apply_compute_cluster_rbac(_michelangelo_sandbox_kube_cluster_name)
+        _create_compute_cluster_secrets(_michelangelo_sandbox_kube_cluster_name)
 
     _kube_wait()
 
@@ -388,6 +393,8 @@ def _create_spark_operator(helm_existing_repos):
         "spark-operator",
         "--create-namespace",
         "--wait",
+        "--timeout",
+        "20m",
     )
 
 
@@ -416,6 +423,8 @@ def _create_kuberay_operator(helm_existing_repos):
         "ray-system",
         "--create-namespace",
         "--wait",
+        "--timeout",
+        "20m",
     )
 
 
@@ -557,10 +566,25 @@ def _create_demo_crs(_: argparse.Namespace):
 
 def _delete(ns: argparse.Namespace):
     assert ns
-    if ns.jobs_cluster_name:
-        _exec("k3d", "cluster", "delete", ns.jobs_cluster_name)
-    else:
-        _exec("k3d", "cluster", "delete", _default_job_hosting_kube_cluster_name)
+    # Determine which compute cluster to check for
+    compute_cluster = (
+        ns.compute_cluster_name
+        if ns.compute_cluster_name
+        else _default_compute_kube_cluster_name
+    )
+
+    # Check if compute cluster exists before attempting to delete
+    try:
+        subprocess.check_output(
+            ["k3d", "cluster", "get", compute_cluster], stderr=subprocess.DEVNULL
+        )
+        # Cluster exists, delete it
+        _exec("k3d", "cluster", "delete", compute_cluster)
+    except subprocess.CalledProcessError:
+        # Cluster doesn't exist, skip deletion
+        print(f"Compute cluster '{compute_cluster}' not found, skipping deletion.")
+
+    # Always try to delete the main sandbox cluster
     _exec("k3d", "cluster", "delete", _michelangelo_sandbox_kube_cluster_name)
 
 
@@ -600,8 +624,8 @@ def _kube_wait(pods: bool = True, jobs: bool = True):
         )
 
 
-def _apply_jobs_rbac(cluster_name: str):
-    """Apply RBAC for Ray management in the jobs cluster.
+def _apply_compute_cluster_rbac(cluster_name: str):
+    """Apply RBAC for Ray management in the compute cluster.
 
     This creates the ServiceAccount `ray-manager`, a namespaced Role with permissions on
     Ray resources, and a RoleBinding to bind them, in the `default` namespace of the
@@ -708,8 +732,37 @@ def _err_exit(err_message: str, code: int = 1):
     sys.exit(code)
 
 
-def _create_jobs_cluster(cluster_name: str):
-    """Create a dedicated cluster for jobs."""
+def _create_compute_cluster(cluster_name: str):
+    """Create a dedicated compute cluster for running Ray jobs.
+
+    This function sets up a separate Kubernetes cluster specifically for executing
+    Ray workloads. The compute cluster includes:
+
+    Infrastructure Components:
+    - k3d cluster with 1 server and 2 agent nodes
+    - KubeRay operator for managing Ray clusters
+    - RBAC permissions for ray-manager service account
+
+    Storage Components (required for Ray jobs):
+    TODO: remove this once we have a proper way to handle multicluster Object store access. Multi Cluster Logging & Monitoring.
+    - MinIO object storage (accessible on ports 9190-9191)
+    - michelangelo-config ConfigMap (S3 endpoint and credentials)
+    - aws-credentials Secret (for AWS CLI access)
+    - S3 buckets: 'default' and 'logs'
+
+    Network Configuration:
+    - Ray client port: 10001
+    - Ray dashboard: 8265
+    - MinIO API: 9191 (mapped from 30007 in cluster)
+    - MinIO Console: 9190 (mapped from 30008 in cluster)
+
+    Note: Ray pods reference the michelangelo-config ConfigMap via envFrom,
+    which is why storage must be set up in the compute cluster.
+
+    Args:
+        cluster_name: Name of the k3d cluster to create
+    """
+
     args = [
         "k3d",
         "cluster",
@@ -726,27 +779,164 @@ def _create_jobs_cluster(cluster_name: str):
     for p in _ray_ports:
         args += ["-p", f"{p}@agent:0"]
 
+    # Add MinIO ports for the compute cluster
+    args += [
+        "-p",
+        "9191:30007@agent:0",
+    ]  # MinIO API (using different host port to avoid conflict)
+    args += [
+        "-p",
+        "9190:30008@agent:0",
+    ]  # MinIO Console (using different host port to avoid conflict)
+
     _exec(*args)
 
     # Add kuberay operator to the jobs cluster
     _exec(
+        "helm",
+        "install",
+        "--kube-context",
+        f"k3d-{cluster_name}",
+        "kuberay-operator",
+        "kuberay/kuberay-operator",
+        "--version",
+        "1.4.2",
+        "--namespace",
+        "ray-system",
+        "--create-namespace",
+        "--wait",
+        "--timeout",
+        "20m",
+    )
+
+    # Deploy MinIO in compute cluster
+    _deploy_minio_to_cluster(cluster_name)
+
+    # Create michelangelo-config ConfigMap
+    _create_config_in_cluster(cluster_name)
+
+    # Create aws-credentials Secret
+    _create_aws_credentials_in_cluster(cluster_name)
+
+    # Setup S3 buckets
+    _setup_buckets_in_cluster(cluster_name)
+
+    # Wait for all resources to be ready
+    _exec(
         "kubectl",
         "--context",
         f"k3d-{cluster_name}",
-        "create",
-        "-k",
-        "github.com/ray-project/kuberay/ray-operator/config/default?ref=v1.0.0",
+        "wait",
+        "--all",
+        "pods",
+        "--for=condition=ready",
+        "--selector=!job-name",
+        "--timeout=600s",
+    )
+    # Wait for bucket setup job to complete
+    _exec(
+        "kubectl",
+        "--context",
+        f"k3d-{cluster_name}",
+        "wait",
+        "--all",
+        "jobs",
+        "--for=condition=complete",
+        "--timeout=600s",
     )
 
-    # Apply RBAC for ray-manager in the jobs cluster
-    _apply_jobs_rbac(cluster_name)
+    print(
+        f"\nJobs cluster '{cluster_name}' created successfully with MinIO and configurations."
+    )
 
-    print(f"\nJobs cluster '{cluster_name}' created successfully.")
+
+def _deploy_minio_to_cluster(cluster_name: str):
+    """Deploy MinIO to the compute cluster."""
+    _exec(
+        "kubectl",
+        "--context",
+        f"k3d-{cluster_name}",
+        "apply",
+        "-f",
+        str(_dir / "resources" / "minio.yaml"),
+    )
+    print(f"Deployed MinIO to cluster '{cluster_name}'")
+
+
+def _create_config_in_cluster(cluster_name: str):
+    """Create michelangelo-config ConfigMap in compute cluster."""
+    _exec(
+        "kubectl",
+        "--context",
+        f"k3d-{cluster_name}",
+        "apply",
+        "-f",
+        str(_dir / "resources" / "michelangelo-config.yaml"),
+    )
+    print(f"Created michelangelo-config ConfigMap in cluster '{cluster_name}'")
+
+
+def _create_aws_credentials_in_cluster(cluster_name: str):
+    """Create aws-credentials Secret in compute cluster."""
+    _exec(
+        "kubectl",
+        "--context",
+        f"k3d-{cluster_name}",
+        "apply",
+        "-f",
+        str(_dir / "resources" / "aws-credentials.yaml"),
+    )
+    print(f"Created aws-credentials Secret in cluster '{cluster_name}'")
+
+
+def _setup_buckets_in_cluster(cluster_name: str):
+    """Setup S3 buckets in the compute cluster's MinIO."""
+    _exec(
+        "kubectl",
+        "--context",
+        f"k3d-{cluster_name}",
+        "apply",
+        "-f",
+        str(_dir / "resources" / "sandbox-bucket-setup.yaml"),
+    )
+    print(f"Started bucket setup job in cluster '{cluster_name}'")
+
+
+def _create_ma_system_namespace():
+    """Create the ma-system namespace in the sandbox cluster if it doesn't exist."""
+    try:
+        # Check if namespace already exists
+        subprocess.check_output(
+            [
+                "kubectl",
+                "--context",
+                f"k3d-{_michelangelo_sandbox_kube_cluster_name}",
+                "get",
+                "namespace",
+                "ma-system",
+            ],
+            stderr=subprocess.DEVNULL,
+        )
+        print("Namespace 'ma-system' already exists.")
+    except subprocess.CalledProcessError:
+        # Namespace doesn't exist, create it
+        _exec(
+            "kubectl",
+            "--context",
+            f"k3d-{_michelangelo_sandbox_kube_cluster_name}",
+            "create",
+            "namespace",
+            "ma-system",
+        )
+        print("Created namespace 'ma-system' in the sandbox cluster.")
 
 
 # Given a cluster name, create a Cluster CRD in the sandbox cluster
-def _create_cluster_crd(cluster_name: str):
+def _create_compute_cluster_crd(cluster_name: str):
     """Create a Cluster CRD for the Ray jobs cluster in the sandbox cluster."""
+    # Ensure ma-system namespace exists
+    _create_ma_system_namespace()
+
     # Get kubeconfig for the Ray jobs cluster
     kubeconfig = subprocess.check_output(
         ["k3d", "kubeconfig", "get", cluster_name]
@@ -773,7 +963,7 @@ def _create_cluster_crd(cluster_name: str):
     cluster_crd = {
         "apiVersion": "michelangelo.api/v2",
         "kind": "Cluster",
-        "metadata": {"name": cluster_name, "namespace": "default"},
+        "metadata": {"name": cluster_name, "namespace": "ma-system"},
         "spec": {
             "kubernetes": {
                 "rest": {
@@ -808,7 +998,7 @@ def _create_cluster_crd(cluster_name: str):
         print(f"Server URL: {server_url}")
 
 
-def _create_cluster_secrets(cluster_name: str):
+def _create_compute_cluster_secrets(cluster_name: str):
     """Create Kubernetes secrets for the kubeconfig of the given cluster name."""
     # Get kubeconfig for the cluster
     kubeconfig = subprocess.check_output(

--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -9,13 +9,15 @@ import tempfile
 import time
 import uuid
 from pathlib import Path
+from typing import Optional
 
 import yaml
 
 short_description = "Manage the sandbox cluster."
 
 description = """
-Michelangelo Sandbox is a lightweight version of the Michelangelo platform, tailored for local development and testing.
+Michelangelo Sandbox is a lightweight version of the Michelangelo platform,
+tailored for local development and testing.
 This tool helps you create and manage a sandbox cluster directly on your machine.
 """
 
@@ -52,12 +54,16 @@ _default_compute_kube_cluster_name = "michelangelo-compute-0"
 
 
 def init_arguments(p: argparse.ArgumentParser):
+    """Initialize command-line arguments for the sandbox CLI."""
     sp = p.add_subparsers(dest="action", required=True)
 
     create_p = sp.add_parser("create", help="Create and start the cluster.")
     create_p.add_argument(
         "--exclude",
-        help="Excludes specified services. Available options: apiserver, controllermgr, ui, worker",
+        help=(
+            "Excludes specified services. "
+            "Available options: apiserver, controllermgr, ui, worker"
+        ),
         nargs="+",
         default=[],
     )
@@ -81,8 +87,11 @@ def init_arguments(p: argparse.ArgumentParser):
     create_p.add_argument(
         "--compute-cluster-name",
         default=_default_compute_kube_cluster_name,
-        help="Name of the compute cluster to create when --create-compute-cluster is used (default: %s)."
-        % _default_compute_kube_cluster_name,
+        help=(
+            f"Name of the compute cluster to create when "
+            f"--create-compute-cluster is used "
+            f"(default: {_default_compute_kube_cluster_name})."
+        ),
     )
 
     _ = sp.add_parser(
@@ -92,14 +101,18 @@ def init_arguments(p: argparse.ArgumentParser):
     delete_p.add_argument(
         "--compute-cluster-name",
         default=_default_compute_kube_cluster_name,
-        help="Name of the compute cluster to delete when --create-compute-cluster is used (default: %s)."
-        % _default_compute_kube_cluster_name,
+        help=(
+            f"Name of the compute cluster to delete when "
+            f"--create-compute-cluster is used "
+            f"(default: {_default_compute_kube_cluster_name})."
+        ),
     )
     _ = sp.add_parser("start", help="Start the cluster.")
     _ = sp.add_parser("stop", help="Stop the cluster.")
 
 
 def main(args=None):
+    """Main entry point for the sandbox CLI."""
     p = argparse.ArgumentParser(description=description)
     init_arguments(p)
     ns = p.parse_args(args=args)
@@ -107,6 +120,7 @@ def main(args=None):
 
 
 def run(ns: argparse.Namespace):
+    """Run the sandbox command based on the parsed namespace."""
     # Assert prerequisites. Sandbox depends on the following tools:
     _assert_command("k3d", "k3d not found, please install it: https://k3d.io")
     _assert_command(
@@ -153,15 +167,23 @@ def _create(ns: argparse.Namespace):
     if not cr_pat:
         _err_exit(
             """
-CR_PAT environment variable is not set. To pull Michelangelo's containers from the GitHub Container Registry, please create a GitHub personal access token (classic) with the "read:packages" scope. Then, save this token to the CR_PAT environment variable, e.g.: `export CR_PAT=ghp_...`.
+CR_PAT environment variable is not set. To pull Michelangelo's containers
+from the GitHub Container Registry, please create a GitHub personal access
+token (classic) with the "read:packages" scope. Then, save this token to the
+CR_PAT environment variable, e.g.: `export CR_PAT=ghp_...`.
 
-For a detailed guide, check https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic.
+For a detailed guide, check:
+https://docs.github.com/en/packages/working-with-a-github-packages-registry/
+working-with-the-container-registry#authenticating-with-a-personal-access-token-classic.
 
-Be aware that CR_PAT environment variable is required while Michelangelo is NOT publicly accessible. Once we become public, the token will no longer be necessary, and this assertion will be removed.
+Be aware that CR_PAT environment variable is required while Michelangelo is NOT
+publicly accessible. Once we become public, the token will no longer be
+necessary, and this assertion will be removed.
 """
         )
 
-    # Create a temporary registry file with the GitHub Container Registry authentication.
+    # Create a temporary registry file with the GitHub Container Registry
+    # authentication.
     registry = {
         "mirrors": {
             "ghcr.io": {
@@ -178,11 +200,10 @@ Be aware that CR_PAT environment variable is required while Michelangelo is NOT 
         },
     }
 
-    registry_file = tempfile.NamedTemporaryFile(mode="wt")
-    json.dump(registry, registry_file)
-    registry_file.flush()
-
-    args += ["--registry-config", registry_file.name]
+    with tempfile.NamedTemporaryFile(mode="wt", delete=False) as registry_file:
+        json.dump(registry, registry_file)
+        registry_file.flush()
+        args += ["--registry-config", registry_file.name]
 
     # BLOCK END ----------------------------------------------------------------------
 
@@ -299,7 +320,8 @@ Be aware that CR_PAT environment variable is required while Michelangelo is NOT 
     try:
         helm_existing_repos = subprocess.check_output(["helm", "repo", "list"]).decode()
     except subprocess.CalledProcessError:
-        # helm repo list returns non-zero exit status when no repositories are configured
+        # helm repo list returns non-zero exit status when no repositories
+        # are configured
         helm_existing_repos = ""
 
     if "ray" not in ns.exclude:
@@ -327,7 +349,9 @@ Be aware that CR_PAT environment variable is required while Michelangelo is NOT 
         _create_compute_cluster_crd(ns.compute_cluster_name)
         _apply_compute_cluster_rbac(ns.compute_cluster_name)
         _create_compute_cluster_secrets(ns.compute_cluster_name)
-    else:  # Use the control plane cluster as the default compute cluster if a dedicated compute cluster is not requested
+    else:
+        # Use the control plane cluster as the default compute cluster if a
+        # dedicated compute cluster is not requested
         _create_compute_cluster_crd(_michelangelo_sandbox_kube_cluster_name)
         _apply_compute_cluster_rbac(_michelangelo_sandbox_kube_cluster_name)
         _create_compute_cluster_secrets(_michelangelo_sandbox_kube_cluster_name)
@@ -335,7 +359,8 @@ Be aware that CR_PAT environment variable is required while Michelangelo is NOT 
     _kube_wait()
 
     print(
-        "\n🚀 Sandbox created successfully. To access the services, please use the following links:\n"
+        "\n🚀 Sandbox created successfully. "
+        "To access the services, please use the following links:\n"
     )
     for title, url, comment in links:
         print(f"  - {title}: {url} {comment}")
@@ -344,9 +369,7 @@ Be aware that CR_PAT environment variable is required while Michelangelo is NOT 
 
 
 def _create_bucket_setup(bucket_names):
-    """
-    Create S3 bucket setup job with the provided bucket list.
-    """
+    """Create S3 bucket setup job with the provided bucket list."""
     bucket_names_str = ",".join(bucket_names)
 
     # Read the original bucket setup YAML
@@ -400,7 +423,10 @@ def _create_spark_operator(helm_existing_repos):
 
 def _create_kuberay_operator(helm_existing_repos):
     """Create the KubeRay operator using Helm.
-    Reference: https://docs.ray.io/en/releases-2.49.1/cluster/kubernetes/getting-started/kuberay-operator-installation.html#method-1-helm-recommended
+
+    Reference:
+    https://docs.ray.io/en/releases-2.49.1/cluster/kubernetes/getting-started/
+    kuberay-operator-installation.html#method-1-helm-recommended.
     """
     if "kuberay" not in helm_existing_repos:
         _exec(
@@ -531,7 +557,8 @@ def _create_demo_crs(_: argparse.Namespace):
         )
     except subprocess.CalledProcessError:
         _err_exit(
-            f"Cluster {_michelangelo_sandbox_kube_cluster_name} not found. Please run 'ma sandbox create' first."
+            f"Cluster {_michelangelo_sandbox_kube_cluster_name} not found. "
+            "Please run 'ma sandbox create' first."
         )
 
     # Check if cluster is running
@@ -539,7 +566,8 @@ def _create_demo_crs(_: argparse.Namespace):
         _exec("kubectl", "cluster-info", raise_error=True)
     except subprocess.CalledProcessError:
         _err_exit(
-            f"Cluster {_michelangelo_sandbox_kube_cluster_name} is not running. Please run 'ma sandbox start' first."
+            f"Cluster {_michelangelo_sandbox_kube_cluster_name} is not running. "
+            "Please run 'ma sandbox start' first."
         )
 
     demo_dir = _dir / "demo"
@@ -645,7 +673,7 @@ def _apply_compute_cluster_rbac(cluster_name: str):
 def _kube_run(
     image: str,
     command: list[str],
-    env: dict[str, str] = None,
+    env: Optional[dict[str, str]] = None,
     retry_attempts: int = 0,
 ):
     assert image
@@ -657,7 +685,8 @@ def _kube_run(
         uuid.uuid4().hex,  # Pod's name.
         "--restart=Never",  # The restart policy for the Pod.
         "--rm",  # Delete the pod after it exits.
-        "--stdin",  # Keep stdin open on the container in the pod, allowing the command to block until completion.
+        "--stdin",  # Keep stdin open on the container in the pod,
+        # allowing the command to block until completion.
         "--image",
         image,
     ]
@@ -678,30 +707,39 @@ def _exec(
     retry_delay_seconds: int = 5,
     raise_error: bool = False,
 ):
-    """Execute a shell command with optional retries. If the command exits with a non-zero code, it will be retried up to
+    """Execute a shell command with optional retries.
+
+    If the command exits with a non-zero code, it will be retried up to
     retry_attempts times, waiting retry_delay_seconds between attempts.
 
     Parameters:
-        *args: Variable-length argument list representing the command to run and its arguments.
-        retry_attempts: Number of times to retry the command on failure. Defaults to 0 (no retry).
-        retry_delay_seconds: Number of seconds to wait between retries. Defaults to 5.
-        raise_error: Determines how to handle errors after the final retry. If True, the function will raise a
-            subprocess.CalledProcessError. If False, the function will terminate the program with the exit code of the
-            failed command. Defaults to False.
+        *args: Variable-length argument list representing the command to run
+            and its arguments.
+        retry_attempts: Number of times to retry the command on failure.
+            Defaults to 0 (no retry).
+        retry_delay_seconds: Number of seconds to wait between retries.
+            Defaults to 5.
+        raise_error: Determines how to handle errors after the final retry.
+            If True, the function will raise a subprocess.CalledProcessError.
+            If False, the function will terminate the program with the exit
+            code of the failed command. Defaults to False.
 
     Returns:
         None.
 
     Raises:
-        subprocess.CalledProcessError: If the command fails after all retries and raise_error is True.
+        subprocess.CalledProcessError: If the command fails after all retries
+            and raise_error is True.
 
     Examples:
         - Basic usage with a single command: _exec("ls", "-l", "~/bin")
-        - Run a script with retries: _exec("bash", "my_script.sh", retry_attempts=3, retry_delay_seconds=2)
+        - Run a script with retries: _exec("bash", "my_script.sh",
+          retry_attempts=3, retry_delay_seconds=2)
 
     Side Effects:
         - Prints the command being executed and retry messages if any.
-        - Terminates the program if raise_error is False and retries are exhausted.
+        - Terminates the program if raise_error is False and retries are
+          exhausted.
     """
     for i in range(retry_attempts + 1):
         try:
@@ -744,7 +782,8 @@ def _create_compute_cluster(cluster_name: str):
     - RBAC permissions for ray-manager service account
 
     Storage Components (required for Ray jobs):
-    TODO: remove this once we have a proper way to handle multicluster Object store access. Multi Cluster Logging & Monitoring.
+    TODO: remove this once we have a proper way to handle multicluster Object
+    store access. Multi Cluster Logging & Monitoring.
     - MinIO object storage (accessible on ports 9190-9191)
     - michelangelo-config ConfigMap (S3 endpoint and credentials)
     - aws-credentials Secret (for AWS CLI access)
@@ -762,7 +801,6 @@ def _create_compute_cluster(cluster_name: str):
     Args:
         cluster_name: Name of the k3d cluster to create
     """
-
     args = [
         "k3d",
         "cluster",
@@ -772,7 +810,8 @@ def _create_compute_cluster(cluster_name: str):
         "1",
         "--agents",
         "2",  # More worker nodes for Ray
-        "--kubeconfig-switch-context=false",  # Don't switch kubectl context to this cluster
+        # Don't switch kubectl context to this cluster
+        "--kubeconfig-switch-context=false",
     ]
 
     # Add port mappings for Ray
@@ -846,7 +885,8 @@ def _create_compute_cluster(cluster_name: str):
     )
 
     print(
-        f"\nJobs cluster '{cluster_name}' created successfully with MinIO and configurations."
+        f"\nJobs cluster '{cluster_name}' created successfully with MinIO "
+        "and configurations."
     )
 
 
@@ -1051,7 +1091,8 @@ def _create_compute_cluster_secrets(cluster_name: str):
                 "create",
                 "token",
                 "ray-manager",
-                # Required to override kubectl's 1h default token TTL; set ~10y to prevent frequent sandbox expirations
+                # Required to override kubectl's 1h default token TTL;
+                # set ~10y to prevent frequent sandbox expirations
                 "--duration=87600h",
             ]
         )

--- a/python/tests/cli/sandbox/test_sandbox.py
+++ b/python/tests/cli/sandbox/test_sandbox.py
@@ -1,5 +1,6 @@
 """Unit tests for sandbox module."""
 
+import argparse
 import subprocess
 from unittest import TestCase
 from unittest.mock import Mock, patch
@@ -391,9 +392,7 @@ class DeleteTest(TestCase):
     @patch("michelangelo.cli.sandbox.sandbox._exec")
     @patch("michelangelo.cli.sandbox.sandbox.subprocess.check_output")
     @patch("builtins.print")
-    def test_delete_prints_skip_message(
-        self, mock_print, mock_check_output, mock_exec
-    ):
+    def test_delete_prints_skip_message(self, mock_print, mock_check_output, mock_exec):
         """Test that skip message is printed when cluster doesn't exist."""
         ns = Mock()
         ns.compute_cluster_name = "test-compute"
@@ -406,7 +405,114 @@ class DeleteTest(TestCase):
         # Verify skip message was printed
         print_calls = [str(c) for c in mock_print.call_args_list]
         skip_message_found = any(
-            "not found" in str(c) and "skipping deletion" in str(c)
-            for c in print_calls
+            "not found" in str(c) and "skipping deletion" in str(c) for c in print_calls
         )
         self.assertTrue(skip_message_found, "Skip message should be printed")
+
+
+class CreateFunctionComputeClusterTest(TestCase):
+    """Tests for _create function compute cluster logic."""
+
+    @patch("michelangelo.cli.sandbox.sandbox._kube_wait")
+    @patch("michelangelo.cli.sandbox.sandbox._create_cadence_domain")
+    @patch("michelangelo.cli.sandbox.sandbox._create_spark_operator")
+    @patch("michelangelo.cli.sandbox.sandbox._create_kuberay_operator")
+    @patch("michelangelo.cli.sandbox.sandbox.subprocess.check_output")
+    @patch("michelangelo.cli.sandbox.sandbox._assert_command")
+    @patch("michelangelo.cli.sandbox.sandbox._kube_create")
+    @patch("michelangelo.cli.sandbox.sandbox._exec")
+    @patch("michelangelo.cli.sandbox.sandbox.os.environ.get")
+    @patch("michelangelo.cli.sandbox.sandbox._create_compute_cluster_secrets")
+    @patch("michelangelo.cli.sandbox.sandbox._apply_compute_cluster_rbac")
+    @patch("michelangelo.cli.sandbox.sandbox._create_compute_cluster_crd")
+    @patch("michelangelo.cli.sandbox.sandbox._create_compute_cluster")
+    def test_create_with_dedicated_compute_cluster(
+        self,
+        mock_create_compute_cluster,
+        mock_create_crd,
+        mock_apply_rbac,
+        mock_create_secrets,
+        mock_env_get,
+        mock_exec,
+        mock_kube_create,
+        mock_assert_command,
+        mock_check_output,
+        mock_create_kuberay,
+        mock_create_spark,
+        mock_create_cadence_domain,
+        mock_kube_wait,
+    ):
+        """Test _create function with dedicated compute cluster."""
+        # Setup namespace with create_compute_cluster=True
+        ns = argparse.Namespace(
+            workflow="cadence",
+            exclude=[],
+            include_experimental=[],
+            create_compute_cluster=True,
+            compute_cluster_name="test-compute-cluster",
+        )
+
+        # Mock environment variable
+        mock_env_get.return_value = "test-token"
+        mock_check_output.return_value = b""
+
+        sandbox._create(ns)
+
+        # Verify dedicated compute cluster functions were called
+        mock_create_compute_cluster.assert_called_once_with("test-compute-cluster")
+        mock_create_crd.assert_called_once_with("test-compute-cluster")
+        mock_apply_rbac.assert_called_once_with("test-compute-cluster")
+        mock_create_secrets.assert_called_once_with("test-compute-cluster")
+
+    @patch("michelangelo.cli.sandbox.sandbox._kube_wait")
+    @patch("michelangelo.cli.sandbox.sandbox._create_cadence_domain")
+    @patch("michelangelo.cli.sandbox.sandbox._create_spark_operator")
+    @patch("michelangelo.cli.sandbox.sandbox._create_kuberay_operator")
+    @patch("michelangelo.cli.sandbox.sandbox.subprocess.check_output")
+    @patch("michelangelo.cli.sandbox.sandbox._assert_command")
+    @patch("michelangelo.cli.sandbox.sandbox._kube_create")
+    @patch("michelangelo.cli.sandbox.sandbox._exec")
+    @patch("michelangelo.cli.sandbox.sandbox.os.environ.get")
+    @patch("michelangelo.cli.sandbox.sandbox._create_compute_cluster_secrets")
+    @patch("michelangelo.cli.sandbox.sandbox._apply_compute_cluster_rbac")
+    @patch("michelangelo.cli.sandbox.sandbox._create_compute_cluster_crd")
+    @patch("michelangelo.cli.sandbox.sandbox._create_compute_cluster")
+    def test_create_without_dedicated_compute_cluster(
+        self,
+        mock_create_compute_cluster,
+        mock_create_crd,
+        mock_apply_rbac,
+        mock_create_secrets,
+        mock_env_get,
+        mock_exec,
+        mock_kube_create,
+        mock_assert_command,
+        mock_check_output,
+        mock_create_kuberay,
+        mock_create_spark,
+        mock_create_cadence_domain,
+        mock_kube_wait,
+    ):
+        """Test _create function without dedicated compute cluster (uses control plane)."""
+        # Setup namespace with create_compute_cluster=False
+        ns = argparse.Namespace(
+            workflow="cadence",
+            exclude=[],
+            include_experimental=[],
+            create_compute_cluster=False,
+            compute_cluster_name="test-compute-cluster",
+        )
+
+        # Mock environment variable
+        mock_env_get.return_value = "test-token"
+        mock_check_output.return_value = b""
+
+        sandbox._create(ns)
+
+        # Verify dedicated compute cluster was NOT created
+        mock_create_compute_cluster.assert_not_called()
+
+        # Verify control plane cluster CRD/RBAC/secrets were created with sandbox cluster name
+        mock_create_crd.assert_called_once_with("michelangelo-sandbox")
+        mock_apply_rbac.assert_called_once_with("michelangelo-sandbox")
+        mock_create_secrets.assert_called_once_with("michelangelo-sandbox")

--- a/python/tests/cli/sandbox/test_sandbox.py
+++ b/python/tests/cli/sandbox/test_sandbox.py
@@ -1,0 +1,412 @@
+"""Unit tests for sandbox module."""
+
+import subprocess
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from michelangelo.cli.sandbox import sandbox
+
+
+class CreateComputeClusterTest(TestCase):
+    """Tests for _create_compute_cluster function."""
+
+    @patch("michelangelo.cli.sandbox.sandbox._setup_buckets_in_cluster")
+    @patch("michelangelo.cli.sandbox.sandbox._create_aws_credentials_in_cluster")
+    @patch("michelangelo.cli.sandbox.sandbox._create_config_in_cluster")
+    @patch("michelangelo.cli.sandbox.sandbox._deploy_minio_to_cluster")
+    @patch("michelangelo.cli.sandbox.sandbox._exec")
+    def test_create_compute_cluster_success(
+        self,
+        mock_exec,
+        mock_deploy_minio,
+        mock_create_config,
+        mock_create_aws_creds,
+        mock_setup_buckets,
+    ):
+        """Test successful creation of compute cluster."""
+        cluster_name = "test-compute-cluster"
+
+        sandbox._create_compute_cluster(cluster_name)
+
+        # Verify k3d cluster creation was called
+        k3d_calls = [c for c in mock_exec.call_args_list if c[0][0] == "k3d"]
+        self.assertEqual(len(k3d_calls), 1)
+
+        # Verify cluster creation arguments
+        k3d_call_args = k3d_calls[0][0]
+        self.assertIn("cluster", k3d_call_args)
+        self.assertIn("create", k3d_call_args)
+        self.assertIn(cluster_name, k3d_call_args)
+
+        # Verify helm install for kuberay was called
+        helm_calls = [c for c in mock_exec.call_args_list if c[0][0] == "helm"]
+        self.assertEqual(len(helm_calls), 1)
+
+        # Verify all setup functions were called
+        mock_deploy_minio.assert_called_once_with(cluster_name)
+        mock_create_config.assert_called_once_with(cluster_name)
+        mock_create_aws_creds.assert_called_once_with(cluster_name)
+        mock_setup_buckets.assert_called_once_with(cluster_name)
+
+    @patch("michelangelo.cli.sandbox.sandbox._setup_buckets_in_cluster")
+    @patch("michelangelo.cli.sandbox.sandbox._create_aws_credentials_in_cluster")
+    @patch("michelangelo.cli.sandbox.sandbox._create_config_in_cluster")
+    @patch("michelangelo.cli.sandbox.sandbox._deploy_minio_to_cluster")
+    @patch("michelangelo.cli.sandbox.sandbox._exec")
+    def test_create_compute_cluster_with_ray_ports(
+        self,
+        mock_exec,
+        mock_deploy_minio,
+        mock_create_config,
+        mock_create_aws_creds,
+        mock_setup_buckets,
+    ):
+        """Test that Ray ports are properly configured."""
+        cluster_name = "test-cluster"
+
+        sandbox._create_compute_cluster(cluster_name)
+
+        # Get the k3d cluster create call
+        k3d_call = [c for c in mock_exec.call_args_list if c[0][0] == "k3d"][0]
+        k3d_args = k3d_call[0]
+
+        # Verify Ray ports are included
+        port_args = [
+            arg for arg in k3d_args if "10001" in str(arg) or "8265" in str(arg)
+        ]
+        self.assertGreater(len(port_args), 0, "Ray ports should be configured")
+
+    @patch("michelangelo.cli.sandbox.sandbox._setup_buckets_in_cluster")
+    @patch("michelangelo.cli.sandbox.sandbox._create_aws_credentials_in_cluster")
+    @patch("michelangelo.cli.sandbox.sandbox._create_config_in_cluster")
+    @patch("michelangelo.cli.sandbox.sandbox._deploy_minio_to_cluster")
+    @patch("michelangelo.cli.sandbox.sandbox._exec")
+    def test_create_compute_cluster_with_minio_ports(
+        self,
+        mock_exec,
+        mock_deploy_minio,
+        mock_create_config,
+        mock_create_aws_creds,
+        mock_setup_buckets,
+    ):
+        """Test that MinIO ports are properly configured."""
+        cluster_name = "test-cluster"
+
+        sandbox._create_compute_cluster(cluster_name)
+
+        # Get the k3d cluster create call
+        k3d_call = [c for c in mock_exec.call_args_list if c[0][0] == "k3d"][0]
+        k3d_args = k3d_call[0]
+
+        # Verify MinIO ports are included
+        port_args = [
+            arg for arg in k3d_args if "9190" in str(arg) or "9191" in str(arg)
+        ]
+        self.assertGreater(len(port_args), 0, "MinIO ports should be configured")
+
+
+class DeployMinioToClusterTest(TestCase):
+    """Tests for _deploy_minio_to_cluster function."""
+
+    @patch("michelangelo.cli.sandbox.sandbox._exec")
+    def test_deploy_minio_success(self, mock_exec):
+        """Test successful MinIO deployment."""
+        cluster_name = "test-cluster"
+
+        sandbox._deploy_minio_to_cluster(cluster_name)
+
+        # Verify kubectl apply was called with correct context
+        mock_exec.assert_called_once()
+        call_args = mock_exec.call_args[0]
+
+        self.assertEqual(call_args[0], "kubectl")
+        self.assertIn("--context", call_args)
+        self.assertIn(f"k3d-{cluster_name}", call_args)
+        self.assertIn("apply", call_args)
+        self.assertIn("-f", call_args)
+
+
+class CreateConfigInClusterTest(TestCase):
+    """Tests for _create_config_in_cluster function."""
+
+    @patch("michelangelo.cli.sandbox.sandbox._exec")
+    def test_create_config_success(self, mock_exec):
+        """Test successful config creation."""
+        cluster_name = "test-cluster"
+
+        sandbox._create_config_in_cluster(cluster_name)
+
+        # Verify kubectl apply was called
+        mock_exec.assert_called_once()
+        call_args = mock_exec.call_args[0]
+
+        self.assertEqual(call_args[0], "kubectl")
+        self.assertIn("--context", call_args)
+        self.assertIn(f"k3d-{cluster_name}", call_args)
+        self.assertIn("apply", call_args)
+
+
+class CreateAwsCredentialsInClusterTest(TestCase):
+    """Tests for _create_aws_credentials_in_cluster function."""
+
+    @patch("michelangelo.cli.sandbox.sandbox._exec")
+    def test_create_aws_credentials_success(self, mock_exec):
+        """Test successful AWS credentials creation."""
+        cluster_name = "test-cluster"
+
+        sandbox._create_aws_credentials_in_cluster(cluster_name)
+
+        # Verify kubectl apply was called
+        mock_exec.assert_called_once()
+        call_args = mock_exec.call_args[0]
+
+        self.assertEqual(call_args[0], "kubectl")
+        self.assertIn("--context", call_args)
+        self.assertIn(f"k3d-{cluster_name}", call_args)
+        self.assertIn("apply", call_args)
+
+
+class SetupBucketsInClusterTest(TestCase):
+    """Tests for _setup_buckets_in_cluster function."""
+
+    @patch("michelangelo.cli.sandbox.sandbox._exec")
+    def test_setup_buckets_success(self, mock_exec):
+        """Test successful bucket setup."""
+        cluster_name = "test-cluster"
+
+        sandbox._setup_buckets_in_cluster(cluster_name)
+
+        # Verify kubectl apply was called
+        mock_exec.assert_called_once()
+        call_args = mock_exec.call_args[0]
+
+        self.assertEqual(call_args[0], "kubectl")
+        self.assertIn("--context", call_args)
+        self.assertIn(f"k3d-{cluster_name}", call_args)
+        self.assertIn("apply", call_args)
+
+
+class CreateMaSystemNamespaceTest(TestCase):
+    """Tests for _create_ma_system_namespace function."""
+
+    @patch("michelangelo.cli.sandbox.sandbox._exec")
+    @patch("michelangelo.cli.sandbox.sandbox.subprocess.check_output")
+    def test_namespace_already_exists(self, mock_check_output, mock_exec):
+        """Test when namespace already exists."""
+        # Simulate namespace exists
+        mock_check_output.return_value = b"ma-system"
+
+        sandbox._create_ma_system_namespace()
+
+        # Verify check was called but create was not
+        mock_check_output.assert_called_once()
+        mock_exec.assert_not_called()
+
+    @patch("michelangelo.cli.sandbox.sandbox._exec")
+    @patch("michelangelo.cli.sandbox.sandbox.subprocess.check_output")
+    def test_namespace_does_not_exist(self, mock_check_output, mock_exec):
+        """Test when namespace doesn't exist."""
+        # Simulate namespace doesn't exist
+        mock_check_output.side_effect = subprocess.CalledProcessError(1, "kubectl")
+
+        sandbox._create_ma_system_namespace()
+
+        # Verify create was called
+        mock_exec.assert_called_once()
+        call_args = mock_exec.call_args[0]
+
+        self.assertEqual(call_args[0], "kubectl")
+        self.assertIn("create", call_args)
+        self.assertIn("namespace", call_args)
+        self.assertIn("ma-system", call_args)
+
+
+class CreateComputeClusterCrdTest(TestCase):
+    """Tests for _create_compute_cluster_crd function."""
+
+    @patch("michelangelo.cli.sandbox.sandbox._exec")
+    @patch("michelangelo.cli.sandbox.sandbox._create_ma_system_namespace")
+    @patch("michelangelo.cli.sandbox.sandbox.subprocess.check_output")
+    def test_create_cluster_crd_success(
+        self, mock_check_output, mock_create_ns, mock_exec
+    ):
+        """Test successful CRD creation."""
+        cluster_name = "test-cluster"
+
+        # Mock kubeconfig output
+        mock_check_output.return_value = b"apiVersion: v1\nclusters:\n- cluster:\n    certificate-authority-data: dGVzdA==\n    server: https://127.0.0.1:12345\n  name: test"
+
+        sandbox._create_compute_cluster_crd(cluster_name)
+
+        # Verify namespace creation was called
+        mock_create_ns.assert_called_once()
+
+        # Verify kubeconfig was retrieved
+        mock_check_output.assert_called_once()
+        call_args = mock_check_output.call_args[0][0]
+        self.assertIn("k3d", call_args)
+        self.assertIn("kubeconfig", call_args)
+        self.assertIn(cluster_name, call_args)
+
+        # Verify kubectl apply was called via _exec
+        mock_exec.assert_called_once()
+        exec_call_args = mock_exec.call_args[0]
+        self.assertEqual(exec_call_args[0], "kubectl")
+        self.assertIn("apply", exec_call_args)
+
+
+class CreateComputeClusterSecretsTest(TestCase):
+    """Tests for _create_compute_cluster_secrets function."""
+
+    @patch("michelangelo.cli.sandbox.sandbox._exec")
+    @patch("michelangelo.cli.sandbox.sandbox.subprocess.check_output")
+    def test_create_secrets_success(self, mock_check_output, mock_exec):
+        """Test successful secrets creation."""
+        cluster_name = "test-cluster"
+
+        # Mock kubeconfig output with proper structure
+        kubeconfig_yaml = """apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    certificate-authority-data: dGVzdENBZGF0YQ==
+    server: https://127.0.0.1:12345
+  name: test-cluster
+users:
+- name: test-user
+  user:
+    client-certificate-data: dGVzdENlcnREYXRh
+    client-key-data: dGVzdEtleURhdGE=
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test-context
+current-context: test-context
+"""
+        # Mock both check_output calls (kubeconfig and kubectl create token)
+        mock_check_output.side_effect = [
+            kubeconfig_yaml.encode(),
+            b"test-token-value",
+        ]
+
+        sandbox._create_compute_cluster_secrets(cluster_name)
+
+        # Verify check_output was called twice (kubeconfig and token)
+        self.assertEqual(mock_check_output.call_count, 2)
+
+        # Verify kubectl apply was called multiple times (CA secret and token secret)
+        self.assertGreaterEqual(mock_exec.call_count, 2)
+
+
+class ApplyComputeClusterRbacTest(TestCase):
+    """Tests for _apply_compute_cluster_rbac function."""
+
+    @patch("michelangelo.cli.sandbox.sandbox._exec")
+    def test_apply_rbac_success(self, mock_exec):
+        """Test successful RBAC application."""
+        cluster_name = "test-cluster"
+
+        sandbox._apply_compute_cluster_rbac(cluster_name)
+
+        # Verify kubectl apply was called
+        mock_exec.assert_called_once()
+        call_args = mock_exec.call_args[0]
+
+        self.assertEqual(call_args[0], "kubectl")
+        self.assertIn("--context", call_args)
+        self.assertIn(f"k3d-{cluster_name}", call_args)
+        self.assertIn("apply", call_args)
+        self.assertIn("-f", call_args)
+
+
+class DeleteTest(TestCase):
+    """Tests for _delete function."""
+
+    @patch("michelangelo.cli.sandbox.sandbox._exec")
+    @patch("michelangelo.cli.sandbox.sandbox.subprocess.check_output")
+    def test_delete_with_existing_compute_cluster(self, mock_check_output, mock_exec):
+        """Test deletion when compute cluster exists."""
+        ns = Mock()
+        ns.compute_cluster_name = "test-compute"
+
+        # Simulate cluster exists
+        mock_check_output.return_value = b"test-compute"
+
+        sandbox._delete(ns)
+
+        # Verify check was called
+        mock_check_output.assert_called_once()
+        call_args = mock_check_output.call_args[0][0]
+        self.assertIn("k3d", call_args)
+        self.assertIn("cluster", call_args)
+        self.assertIn("get", call_args)
+        self.assertIn("test-compute", call_args)
+
+        # Verify both clusters were deleted
+        delete_calls = [c for c in mock_exec.call_args_list if "delete" in c[0]]
+        self.assertEqual(len(delete_calls), 2)
+
+    @patch("michelangelo.cli.sandbox.sandbox._exec")
+    @patch("michelangelo.cli.sandbox.sandbox.subprocess.check_output")
+    def test_delete_with_nonexistent_compute_cluster(
+        self, mock_check_output, mock_exec
+    ):
+        """Test deletion when compute cluster doesn't exist."""
+        ns = Mock()
+        ns.compute_cluster_name = "test-compute"
+
+        # Simulate cluster doesn't exist
+        mock_check_output.side_effect = subprocess.CalledProcessError(1, "k3d")
+
+        sandbox._delete(ns)
+
+        # Verify check was called
+        mock_check_output.assert_called_once()
+
+        # Verify only main cluster was deleted (not the compute cluster)
+        delete_calls = [c for c in mock_exec.call_args_list if "delete" in c[0]]
+        self.assertEqual(len(delete_calls), 1)
+
+        # Verify it was the main sandbox cluster
+        main_delete_call = delete_calls[0][0]
+        self.assertIn("michelangelo-sandbox", main_delete_call)
+
+    @patch("michelangelo.cli.sandbox.sandbox._exec")
+    @patch("michelangelo.cli.sandbox.sandbox.subprocess.check_output")
+    def test_delete_without_compute_cluster_name(self, mock_check_output, mock_exec):
+        """Test deletion when no compute cluster name is specified."""
+        ns = Mock()
+        ns.compute_cluster_name = None
+
+        # Simulate default cluster doesn't exist
+        mock_check_output.side_effect = subprocess.CalledProcessError(1, "k3d")
+
+        sandbox._delete(ns)
+
+        # Verify check was called with default name
+        call_args = mock_check_output.call_args[0][0]
+        self.assertIn("michelangelo-compute-0", call_args)
+
+    @patch("michelangelo.cli.sandbox.sandbox._exec")
+    @patch("michelangelo.cli.sandbox.sandbox.subprocess.check_output")
+    @patch("builtins.print")
+    def test_delete_prints_skip_message(
+        self, mock_print, mock_check_output, mock_exec
+    ):
+        """Test that skip message is printed when cluster doesn't exist."""
+        ns = Mock()
+        ns.compute_cluster_name = "test-compute"
+
+        # Simulate cluster doesn't exist
+        mock_check_output.side_effect = subprocess.CalledProcessError(1, "k3d")
+
+        sandbox._delete(ns)
+
+        # Verify skip message was printed
+        print_calls = [str(c) for c in mock_print.call_args_list]
+        skip_message_found = any(
+            "not found" in str(c) and "skipping deletion" in str(c)
+            for c in print_calls
+        )
+        self.assertTrue(skip_message_found, "Skip message should be printed")

--- a/python/tests/cli/sandbox/test_sandbox.py
+++ b/python/tests/cli/sandbox/test_sandbox.py
@@ -8,8 +8,136 @@ from unittest.mock import Mock, patch
 from michelangelo.cli.sandbox import sandbox
 
 
-class CreateComputeClusterTest(TestCase):
-    """Tests for _create_compute_cluster function."""
+class CreateFunctionTest(TestCase):
+    """Tests for _create function logic."""
+
+    @patch("michelangelo.cli.sandbox.sandbox._kube_wait")
+    @patch("michelangelo.cli.sandbox.sandbox._create_cadence_domain")
+    @patch("michelangelo.cli.sandbox.sandbox._create_spark_operator")
+    @patch("michelangelo.cli.sandbox.sandbox._create_kuberay_operator")
+    @patch("michelangelo.cli.sandbox.sandbox.subprocess.check_output")
+    @patch("michelangelo.cli.sandbox.sandbox._assert_command")
+    @patch("michelangelo.cli.sandbox.sandbox._kube_create")
+    @patch("michelangelo.cli.sandbox.sandbox._exec")
+    @patch("michelangelo.cli.sandbox.sandbox.os.environ.get")
+    @patch("michelangelo.cli.sandbox.sandbox.tempfile.NamedTemporaryFile")
+    @patch("michelangelo.cli.sandbox.sandbox._create_compute_cluster_secrets")
+    @patch("michelangelo.cli.sandbox.sandbox._apply_compute_cluster_rbac")
+    @patch("michelangelo.cli.sandbox.sandbox._create_compute_cluster_crd")
+    @patch("michelangelo.cli.sandbox.sandbox._create_compute_cluster")
+    def test_create_with_dedicated_compute_cluster(
+        self,
+        mock_create_compute_cluster,
+        mock_create_crd,
+        mock_apply_rbac,
+        mock_create_secrets,
+        mock_tempfile,
+        mock_env_get,
+        mock_exec,
+        mock_kube_create,
+        mock_assert_command,
+        mock_check_output,
+        mock_create_kuberay,
+        mock_create_spark,
+        mock_create_cadence_domain,
+        mock_kube_wait,
+    ):
+        """Test dedicated cluster functions called with compute cluster name."""
+        # Setup namespace with create_compute_cluster=True
+        ns = argparse.Namespace(
+            workflow="cadence",
+            exclude=[],
+            include_experimental=[],
+            create_compute_cluster=True,
+            compute_cluster_name="test-compute-cluster",
+        )
+
+        # Mock environment variable and dependencies
+        mock_env_get.return_value = "test-token"
+        mock_check_output.return_value = (
+            b"kuberay\thttps://ray-project.github.io/kuberay-helm\n"
+        )
+        mock_registry_file = Mock()
+        mock_registry_file.name = "/tmp/test-registry.json"
+        mock_registry_file.__enter__ = Mock(return_value=mock_registry_file)
+        mock_registry_file.__exit__ = Mock(return_value=False)
+        mock_tempfile.return_value = mock_registry_file
+
+        sandbox._create(ns)
+
+        # Verify dedicated compute cluster functions were called with the
+        # compute cluster name
+        mock_create_compute_cluster.assert_called_once_with("test-compute-cluster")
+        mock_create_crd.assert_called_once_with("test-compute-cluster")
+        mock_apply_rbac.assert_called_once_with("test-compute-cluster")
+        mock_create_secrets.assert_called_once_with("test-compute-cluster")
+
+    @patch("michelangelo.cli.sandbox.sandbox._kube_wait")
+    @patch("michelangelo.cli.sandbox.sandbox._create_cadence_domain")
+    @patch("michelangelo.cli.sandbox.sandbox._create_spark_operator")
+    @patch("michelangelo.cli.sandbox.sandbox._create_kuberay_operator")
+    @patch("michelangelo.cli.sandbox.sandbox.subprocess.check_output")
+    @patch("michelangelo.cli.sandbox.sandbox._assert_command")
+    @patch("michelangelo.cli.sandbox.sandbox._kube_create")
+    @patch("michelangelo.cli.sandbox.sandbox._exec")
+    @patch("michelangelo.cli.sandbox.sandbox.os.environ.get")
+    @patch("michelangelo.cli.sandbox.sandbox.tempfile.NamedTemporaryFile")
+    @patch("michelangelo.cli.sandbox.sandbox._create_compute_cluster_secrets")
+    @patch("michelangelo.cli.sandbox.sandbox._apply_compute_cluster_rbac")
+    @patch("michelangelo.cli.sandbox.sandbox._create_compute_cluster_crd")
+    @patch("michelangelo.cli.sandbox.sandbox._create_compute_cluster")
+    def test_create_without_dedicated_compute_cluster(
+        self,
+        mock_create_compute_cluster,
+        mock_create_crd,
+        mock_apply_rbac,
+        mock_create_secrets,
+        mock_tempfile,
+        mock_env_get,
+        mock_exec,
+        mock_kube_create,
+        mock_assert_command,
+        mock_check_output,
+        mock_create_kuberay,
+        mock_create_spark,
+        mock_create_cadence_domain,
+        mock_kube_wait,
+    ):
+        """Test control plane cluster functions called with sandbox cluster name."""
+        # Setup namespace with create_compute_cluster=False
+        ns = argparse.Namespace(
+            workflow="cadence",
+            exclude=[],
+            include_experimental=[],
+            create_compute_cluster=False,
+            compute_cluster_name="test-compute-cluster",
+        )
+
+        # Mock environment variable and dependencies
+        mock_env_get.return_value = "test-token"
+        mock_check_output.return_value = (
+            b"kuberay\thttps://ray-project.github.io/kuberay-helm\n"
+        )
+        mock_registry_file = Mock()
+        mock_registry_file.name = "/tmp/test-registry.json"
+        mock_registry_file.__enter__ = Mock(return_value=mock_registry_file)
+        mock_registry_file.__exit__ = Mock(return_value=False)
+        mock_tempfile.return_value = mock_registry_file
+
+        sandbox._create(ns)
+
+        # Verify dedicated compute cluster was NOT created
+        mock_create_compute_cluster.assert_not_called()
+
+        # Verify control plane cluster CRD/RBAC/secrets were created with
+        # sandbox cluster name
+        mock_create_crd.assert_called_once_with("michelangelo-sandbox")
+        mock_apply_rbac.assert_called_once_with("michelangelo-sandbox")
+        mock_create_secrets.assert_called_once_with("michelangelo-sandbox")
+
+
+class ComputeClusterSetupTest(TestCase):
+    """Tests for compute cluster setup functions."""
 
     @patch("michelangelo.cli.sandbox.sandbox._setup_buckets_in_cluster")
     @patch("michelangelo.cli.sandbox.sandbox._create_aws_credentials_in_cluster")
@@ -44,70 +172,8 @@ class CreateComputeClusterTest(TestCase):
         self.assertEqual(len(helm_calls), 1)
 
         # Verify all setup functions were called
-        mock_deploy_minio.assert_called_once_with(cluster_name)
         mock_create_config.assert_called_once_with(cluster_name)
         mock_create_aws_creds.assert_called_once_with(cluster_name)
-        mock_setup_buckets.assert_called_once_with(cluster_name)
-
-    @patch("michelangelo.cli.sandbox.sandbox._setup_buckets_in_cluster")
-    @patch("michelangelo.cli.sandbox.sandbox._create_aws_credentials_in_cluster")
-    @patch("michelangelo.cli.sandbox.sandbox._create_config_in_cluster")
-    @patch("michelangelo.cli.sandbox.sandbox._deploy_minio_to_cluster")
-    @patch("michelangelo.cli.sandbox.sandbox._exec")
-    def test_create_compute_cluster_with_ray_ports(
-        self,
-        mock_exec,
-        mock_deploy_minio,
-        mock_create_config,
-        mock_create_aws_creds,
-        mock_setup_buckets,
-    ):
-        """Test that Ray ports are properly configured."""
-        cluster_name = "test-cluster"
-
-        sandbox._create_compute_cluster(cluster_name)
-
-        # Get the k3d cluster create call
-        k3d_call = [c for c in mock_exec.call_args_list if c[0][0] == "k3d"][0]
-        k3d_args = k3d_call[0]
-
-        # Verify Ray ports are included
-        port_args = [
-            arg for arg in k3d_args if "10001" in str(arg) or "8265" in str(arg)
-        ]
-        self.assertGreater(len(port_args), 0, "Ray ports should be configured")
-
-    @patch("michelangelo.cli.sandbox.sandbox._setup_buckets_in_cluster")
-    @patch("michelangelo.cli.sandbox.sandbox._create_aws_credentials_in_cluster")
-    @patch("michelangelo.cli.sandbox.sandbox._create_config_in_cluster")
-    @patch("michelangelo.cli.sandbox.sandbox._deploy_minio_to_cluster")
-    @patch("michelangelo.cli.sandbox.sandbox._exec")
-    def test_create_compute_cluster_with_minio_ports(
-        self,
-        mock_exec,
-        mock_deploy_minio,
-        mock_create_config,
-        mock_create_aws_creds,
-        mock_setup_buckets,
-    ):
-        """Test that MinIO ports are properly configured."""
-        cluster_name = "test-cluster"
-
-        sandbox._create_compute_cluster(cluster_name)
-
-        # Get the k3d cluster create call
-        k3d_call = [c for c in mock_exec.call_args_list if c[0][0] == "k3d"][0]
-        k3d_args = k3d_call[0]
-
-        # Verify MinIO ports are included
-        port_args = [
-            arg for arg in k3d_args if "9190" in str(arg) or "9191" in str(arg)
-        ]
-        self.assertGreater(len(port_args), 0, "MinIO ports should be configured")
-
-
-class DeployMinioToClusterTest(TestCase):
-    """Tests for _deploy_minio_to_cluster function."""
 
     @patch("michelangelo.cli.sandbox.sandbox._exec")
     def test_deploy_minio_success(self, mock_exec):
@@ -126,10 +192,6 @@ class DeployMinioToClusterTest(TestCase):
         self.assertIn("apply", call_args)
         self.assertIn("-f", call_args)
 
-
-class CreateConfigInClusterTest(TestCase):
-    """Tests for _create_config_in_cluster function."""
-
     @patch("michelangelo.cli.sandbox.sandbox._exec")
     def test_create_config_success(self, mock_exec):
         """Test successful config creation."""
@@ -145,10 +207,6 @@ class CreateConfigInClusterTest(TestCase):
         self.assertIn("--context", call_args)
         self.assertIn(f"k3d-{cluster_name}", call_args)
         self.assertIn("apply", call_args)
-
-
-class CreateAwsCredentialsInClusterTest(TestCase):
-    """Tests for _create_aws_credentials_in_cluster function."""
 
     @patch("michelangelo.cli.sandbox.sandbox._exec")
     def test_create_aws_credentials_success(self, mock_exec):
@@ -166,10 +224,6 @@ class CreateAwsCredentialsInClusterTest(TestCase):
         self.assertIn(f"k3d-{cluster_name}", call_args)
         self.assertIn("apply", call_args)
 
-
-class SetupBucketsInClusterTest(TestCase):
-    """Tests for _setup_buckets_in_cluster function."""
-
     @patch("michelangelo.cli.sandbox.sandbox._exec")
     def test_setup_buckets_success(self, mock_exec):
         """Test successful bucket setup."""
@@ -185,10 +239,6 @@ class SetupBucketsInClusterTest(TestCase):
         self.assertIn("--context", call_args)
         self.assertIn(f"k3d-{cluster_name}", call_args)
         self.assertIn("apply", call_args)
-
-
-class CreateMaSystemNamespaceTest(TestCase):
-    """Tests for _create_ma_system_namespace function."""
 
     @patch("michelangelo.cli.sandbox.sandbox._exec")
     @patch("michelangelo.cli.sandbox.sandbox.subprocess.check_output")
@@ -221,10 +271,6 @@ class CreateMaSystemNamespaceTest(TestCase):
         self.assertIn("namespace", call_args)
         self.assertIn("ma-system", call_args)
 
-
-class CreateComputeClusterCrdTest(TestCase):
-    """Tests for _create_compute_cluster_crd function."""
-
     @patch("michelangelo.cli.sandbox.sandbox._exec")
     @patch("michelangelo.cli.sandbox.sandbox._create_ma_system_namespace")
     @patch("michelangelo.cli.sandbox.sandbox.subprocess.check_output")
@@ -235,7 +281,11 @@ class CreateComputeClusterCrdTest(TestCase):
         cluster_name = "test-cluster"
 
         # Mock kubeconfig output
-        mock_check_output.return_value = b"apiVersion: v1\nclusters:\n- cluster:\n    certificate-authority-data: dGVzdA==\n    server: https://127.0.0.1:12345\n  name: test"
+        mock_check_output.return_value = (
+            b"apiVersion: v1\nclusters:\n- cluster:\n    "
+            b"certificate-authority-data: dGVzdA==\n    "
+            b"server: https://127.0.0.1:12345\n  name: test"
+        )
 
         sandbox._create_compute_cluster_crd(cluster_name)
 
@@ -254,10 +304,6 @@ class CreateComputeClusterCrdTest(TestCase):
         exec_call_args = mock_exec.call_args[0]
         self.assertEqual(exec_call_args[0], "kubectl")
         self.assertIn("apply", exec_call_args)
-
-
-class CreateComputeClusterSecretsTest(TestCase):
-    """Tests for _create_compute_cluster_secrets function."""
 
     @patch("michelangelo.cli.sandbox.sandbox._exec")
     @patch("michelangelo.cli.sandbox.sandbox.subprocess.check_output")
@@ -299,10 +345,6 @@ current-context: test-context
         # Verify kubectl apply was called multiple times (CA secret and token secret)
         self.assertGreaterEqual(mock_exec.call_count, 2)
 
-
-class ApplyComputeClusterRbacTest(TestCase):
-    """Tests for _apply_compute_cluster_rbac function."""
-
     @patch("michelangelo.cli.sandbox.sandbox._exec")
     def test_apply_rbac_success(self, mock_exec):
         """Test successful RBAC application."""
@@ -319,10 +361,6 @@ class ApplyComputeClusterRbacTest(TestCase):
         self.assertIn(f"k3d-{cluster_name}", call_args)
         self.assertIn("apply", call_args)
         self.assertIn("-f", call_args)
-
-
-class DeleteTest(TestCase):
-    """Tests for _delete function."""
 
     @patch("michelangelo.cli.sandbox.sandbox._exec")
     @patch("michelangelo.cli.sandbox.sandbox.subprocess.check_output")
@@ -408,111 +446,3 @@ class DeleteTest(TestCase):
             "not found" in str(c) and "skipping deletion" in str(c) for c in print_calls
         )
         self.assertTrue(skip_message_found, "Skip message should be printed")
-
-
-class CreateFunctionComputeClusterTest(TestCase):
-    """Tests for _create function compute cluster logic."""
-
-    @patch("michelangelo.cli.sandbox.sandbox._kube_wait")
-    @patch("michelangelo.cli.sandbox.sandbox._create_cadence_domain")
-    @patch("michelangelo.cli.sandbox.sandbox._create_spark_operator")
-    @patch("michelangelo.cli.sandbox.sandbox._create_kuberay_operator")
-    @patch("michelangelo.cli.sandbox.sandbox.subprocess.check_output")
-    @patch("michelangelo.cli.sandbox.sandbox._assert_command")
-    @patch("michelangelo.cli.sandbox.sandbox._kube_create")
-    @patch("michelangelo.cli.sandbox.sandbox._exec")
-    @patch("michelangelo.cli.sandbox.sandbox.os.environ.get")
-    @patch("michelangelo.cli.sandbox.sandbox._create_compute_cluster_secrets")
-    @patch("michelangelo.cli.sandbox.sandbox._apply_compute_cluster_rbac")
-    @patch("michelangelo.cli.sandbox.sandbox._create_compute_cluster_crd")
-    @patch("michelangelo.cli.sandbox.sandbox._create_compute_cluster")
-    def test_create_with_dedicated_compute_cluster(
-        self,
-        mock_create_compute_cluster,
-        mock_create_crd,
-        mock_apply_rbac,
-        mock_create_secrets,
-        mock_env_get,
-        mock_exec,
-        mock_kube_create,
-        mock_assert_command,
-        mock_check_output,
-        mock_create_kuberay,
-        mock_create_spark,
-        mock_create_cadence_domain,
-        mock_kube_wait,
-    ):
-        """Test _create function with dedicated compute cluster."""
-        # Setup namespace with create_compute_cluster=True
-        ns = argparse.Namespace(
-            workflow="cadence",
-            exclude=[],
-            include_experimental=[],
-            create_compute_cluster=True,
-            compute_cluster_name="test-compute-cluster",
-        )
-
-        # Mock environment variable
-        mock_env_get.return_value = "test-token"
-        mock_check_output.return_value = b""
-
-        sandbox._create(ns)
-
-        # Verify dedicated compute cluster functions were called
-        mock_create_compute_cluster.assert_called_once_with("test-compute-cluster")
-        mock_create_crd.assert_called_once_with("test-compute-cluster")
-        mock_apply_rbac.assert_called_once_with("test-compute-cluster")
-        mock_create_secrets.assert_called_once_with("test-compute-cluster")
-
-    @patch("michelangelo.cli.sandbox.sandbox._kube_wait")
-    @patch("michelangelo.cli.sandbox.sandbox._create_cadence_domain")
-    @patch("michelangelo.cli.sandbox.sandbox._create_spark_operator")
-    @patch("michelangelo.cli.sandbox.sandbox._create_kuberay_operator")
-    @patch("michelangelo.cli.sandbox.sandbox.subprocess.check_output")
-    @patch("michelangelo.cli.sandbox.sandbox._assert_command")
-    @patch("michelangelo.cli.sandbox.sandbox._kube_create")
-    @patch("michelangelo.cli.sandbox.sandbox._exec")
-    @patch("michelangelo.cli.sandbox.sandbox.os.environ.get")
-    @patch("michelangelo.cli.sandbox.sandbox._create_compute_cluster_secrets")
-    @patch("michelangelo.cli.sandbox.sandbox._apply_compute_cluster_rbac")
-    @patch("michelangelo.cli.sandbox.sandbox._create_compute_cluster_crd")
-    @patch("michelangelo.cli.sandbox.sandbox._create_compute_cluster")
-    def test_create_without_dedicated_compute_cluster(
-        self,
-        mock_create_compute_cluster,
-        mock_create_crd,
-        mock_apply_rbac,
-        mock_create_secrets,
-        mock_env_get,
-        mock_exec,
-        mock_kube_create,
-        mock_assert_command,
-        mock_check_output,
-        mock_create_kuberay,
-        mock_create_spark,
-        mock_create_cadence_domain,
-        mock_kube_wait,
-    ):
-        """Test _create function without dedicated compute cluster (uses control plane)."""
-        # Setup namespace with create_compute_cluster=False
-        ns = argparse.Namespace(
-            workflow="cadence",
-            exclude=[],
-            include_experimental=[],
-            create_compute_cluster=False,
-            compute_cluster_name="test-compute-cluster",
-        )
-
-        # Mock environment variable
-        mock_env_get.return_value = "test-token"
-        mock_check_output.return_value = b""
-
-        sandbox._create(ns)
-
-        # Verify dedicated compute cluster was NOT created
-        mock_create_compute_cluster.assert_not_called()
-
-        # Verify control plane cluster CRD/RBAC/secrets were created with sandbox cluster name
-        mock_create_crd.assert_called_once_with("michelangelo-sandbox")
-        mock_apply_rbac.assert_called_once_with("michelangelo-sandbox")
-        mock_create_secrets.assert_called_once_with("michelangelo-sandbox")


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

This PR introduces support for running Ray jobs in a dedicated compute cluster separate from the Michelangelo control plane. Key changes include:

1. **Dual cluster mode support**: Added logic to use the control plane cluster as the default compute cluster when `--create-jobs-cluster` flag is not set
2. **Enhanced compute cluster setup**: Expanded `_create_jobs_cluster()` to provision a fully functional Ray execution environment including:
   - KubeRay operator installation
   - MinIO object storage deployment (ports 9190-9191)
   - Required ConfigMaps (`michelangelo-config`) and Secrets (`aws-credentials`)
   - Automatic S3 bucket creation (`default` and `logs`)
   - RBAC configuration for ray-manager service account
3. **Improved operator stability**: Added 20-minute timeouts to Spark and KubeRay operator Helm installations
4. **Safer cluster deletion**: Added existence check before attempting to delete jobs cluster
5. **Namespace organization**: Cluster CRDs now created in `ma-system` namespace instead of `default`

<!-- Tell your future self why have you made these changes -->
**Why?**

Ray jobs require object storage and specific configuration to function properly. Previously, the jobs cluster was a minimal Kubernetes cluster without the necessary infrastructure. This PR ensures that:

- Ray pods can access S3-compatible storage (MinIO) for artifacts and logs
- Environment variables and credentials are properly configured via ConfigMaps/Secrets
- The compute cluster is self-contained and can operate independently
- Users have flexibility to either use a dedicated compute cluster or reuse the control plane cluster for simpler setups

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

- Tested sandbox creation with `--create-jobs-cluster` flag to verify dedicated compute cluster setup
- Tested sandbox creation without the flag to verify control plane cluster is used as compute cluster
- Verified MinIO deployment and bucket creation in compute cluster
- Tested sandbox deletion with and without jobs cluster to ensure proper cleanup
- Confirmed Ray jobs can successfully run in the compute cluster with access to storage

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

- **Port conflicts**: New MinIO ports (9190-9191) could conflict with existing services if users are already using these ports
- **Resource consumption**: Dedicated compute cluster with MinIO increases local resource requirements (CPU, memory, disk)
- **Namespace migration**: Moving Cluster CRDs from `default` to `ma-system` namespace could affect existing deployments if not properly migrated
- **Timeout duration**: 20-minute operator installation timeouts might still be insufficient in resource-constrained environments

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

- ✨ **New**: Support for running Ray jobs in dedicated compute clusters with full infrastructure (MinIO, ConfigMaps, Secrets)
- ✨ **New**: Automatic compute cluster setup when `--create-jobs-cluster` flag is used
- ✨ **New**: Control plane cluster can now serve as default compute cluster when dedicated cluster is not requested
- 🔧 **Improved**: Operator installation stability with 20-minute timeouts
- 🔧 **Improved**: Safer sandbox deletion with cluster existence checks
- 📝 **Changed**: Cluster CRDs now created in `ma-system` namespace (migration required for existing deployments)

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**

- [ ] Update sandbox CLI documentation to explain `--create-jobs-cluster` behavior and compute cluster concepts
- [ ] Document MinIO port mappings (9190-9191) and potential port conflicts
- [ ] Add migration guide for moving existing Cluster CRDs from `default` to `ma-system` namespace
- [ ] Document resource requirements for dedicated compute cluster mode
- [ ] Update Ray job execution documentation with storage configuration details
