### PR TITLE
[MACTL] Separate the implementation of apply/create from CRD class

### DIFF
--- a/python/michelangelo/cli/mactl/mactl.py
+++ b/python/michelangelo/cli/mactl/mactl.py
@@ -175,7 +175,7 @@ def get_crd(crd_method_info, full_name: str, namespace: str, name: str) -> Messa
 
 def get_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Message:
     """
-    Common CRD member method implementation for GET method.
+    Default common CRD member method implementation for GET method.
     """
     _LOG.info("Bound arguments: %r", bound_args.arguments)
     _self: CRD = bound_args.arguments["self"]
@@ -189,7 +189,7 @@ def get_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Mess
 
 def delete_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Message:
     """
-    Common CRD member method implementation for DELETE method.
+    Default common CRD member method implementation for DELETE method.
     """
     _LOG.info("Bound arguments: %r", bound_args.arguments)
     _self: CRD = bound_args.arguments["self"]
@@ -206,6 +206,72 @@ def delete_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> M
         "DELETE Request input (%r) ready: %r",
         type(request_input),
         request_input,
+    )
+
+    method_fullname = f"/{_self.full_name}/{crd_method_info.method_name}"
+    _LOG.info("Method fullname for gRPC call: %s", method_fullname)
+    stub_method = channel.unary_unary(
+        method_fullname,
+        request_serializer=crd_method_info.input_class.SerializeToString,
+        response_deserializer=crd_method_info.output_class.FromString,
+    )
+    response = stub_method(
+        request_input,
+        metadata=METADATA_STUB,
+        timeout=30,
+    )
+    _LOG.info("Stub method completed (%r): %r", type(response), response)
+    return response
+
+
+def apply_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Message:
+    """
+    Default common CRD member method implementation for APPLY method.
+    """
+    _LOG.info("Bound arguments: %r", bound_args.arguments)
+    _self: CRD = bound_args.arguments["self"]
+    _LOG.info("Start apply_func for %r", _self.full_name)
+
+    _file = get_single_arg(bound_args.arguments, "file")
+
+    _namespace, _name = get_crd_namespace_and_name_from_yaml(_file)
+    message_instance = _self.get(_namespace, _name)
+    _LOG.info("Retrieved message instance: %r", message_instance)
+    request_input = _self.read_yaml_and_update_crd_request(
+        crd_method_info.input_class, _file, message_instance
+    )
+
+    method_fullname = f"/{_self.full_name}/{crd_method_info.method_name}"
+    _LOG.info("Method fullname for gRPC call: %s", method_fullname)
+    stub_method = channel.unary_unary(
+        method_fullname,
+        request_serializer=crd_method_info.input_class.SerializeToString,
+        response_deserializer=crd_method_info.output_class.FromString,
+    )
+    response = stub_method(
+        request_input,
+        metadata=METADATA_STUB,
+        timeout=30,
+    )
+    _LOG.info("Stub method completed (%r): %r", type(response), response)
+    return response
+
+
+def create_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Message:
+    """
+    Default common CRD member method implementation for CREATE method.
+    """
+    _LOG.info("Bound arguments: %r", bound_args.arguments)
+    _self: CRD = bound_args.arguments["self"]
+    _LOG.info("Start create_func for %r", _self.full_name)
+
+    _file = get_single_arg(bound_args.arguments, "file")
+
+    request_input = read_yaml_to_crd_request(
+        crd_method_info.input_class,
+        _self.name,
+        _file,
+        _self.func_crd_metadata_converter,
     )
 
     method_fullname = f"/{_self.full_name}/{crd_method_info.method_name}"
@@ -323,91 +389,37 @@ class CRD:
         self.generate_get(channel)
 
         _LOG.info("Generate APPLY method for %r / %r", self.name, self.full_name)
-        method_name, input_class, output_class = self._extract_method_info(
-            channel, self.full_name, "Update"
+        method_info = CrdMethodInfo(
+            channel, *self._extract_method_info(channel, self.full_name, "Update")
         )
         apply_func_signature = Signature(
             [Parameter("self", Parameter.POSITIONAL_OR_KEYWORD)]
             + [Parameter(name, Parameter.POSITIONAL_OR_KEYWORD) for name in ["file"]]
         )
 
-        @bind_signature(apply_func_signature)
-        def apply_func(bound_args: Signature) -> Message:
-            _LOG.info("Start apply_func for %r", self.full_name)
-            _LOG.info("Bound arguments: %r", bound_args.arguments)
-            _self: CRD = bound_args.arguments["self"]
-            _file = get_single_arg(bound_args.arguments, "file")
-
-            _namespace, _name = get_crd_namespace_and_name_from_yaml(_file)
-            message_instance = _self.get(_namespace, _name)
-            _LOG.info("Retrieved message instance: %r", message_instance)
-            request_input = self.read_yaml_and_update_crd_request(
-                input_class, _file, message_instance
-            )
-
-            method_fullname = f"/{_self.full_name}/{method_name}"
-            _LOG.info("Method fullname for gRPC call: %s", method_fullname)
-            stub_method = channel.unary_unary(
-                method_fullname,
-                request_serializer=input_class.SerializeToString,
-                response_deserializer=output_class.FromString,
-            )
-            response = stub_method(
-                request_input,
-                metadata=METADATA_STUB,
-                timeout=30,
-            )
-            _LOG.info("Stub method completed (%r): %r", type(response), response)
-            return response
-
-        apply_func.__signature__ = apply_func_signature  # type: ignore[attr-defined]
-        self.apply = MethodType(apply_func, self)
+        bound_func = partial(apply_func_impl, method_info)
+        bound_func = bind_signature(apply_func_signature)(bound_func)
+        self.apply = MethodType(bound_func, self)
+        _LOG.debug("Generated APPLY injected well: %r", self.apply)
 
     def generate_create(self, channel: Channel):
         """
         Generate create function of this class.
         """
         _LOG.info("Generate CREATE method for %r / %r", self.name, self.full_name)
-        method_name, input_class, output_class = self._extract_method_info(
-            channel, self.full_name, "Create"
+
+        method_info = CrdMethodInfo(
+            channel, *self._extract_method_info(channel, self.full_name, "Create")
         )
         create_func_signature = Signature(
             [Parameter("self", Parameter.POSITIONAL_OR_KEYWORD)]
             + [Parameter(name, Parameter.POSITIONAL_OR_KEYWORD) for name in ["file"]]
         )
 
-        @bind_signature(create_func_signature)
-        def create_func(bound_args: Signature) -> Message:
-            _LOG.info("Start create_func for %r", self.full_name)
-            _LOG.info("Bound arguments: %r", bound_args.arguments)
-            _self: CRD = bound_args.arguments["self"]
-
-            _file = get_single_arg(bound_args.arguments, "file")
-
-            request_input = read_yaml_to_crd_request(
-                input_class,
-                _self.name,
-                _file,
-                _self.func_crd_metadata_converter,
-            )
-
-            method_fullname = f"/{_self.full_name}/{method_name}"
-            _LOG.info("Method fullname for gRPC call: %s", method_fullname)
-            stub_method = channel.unary_unary(
-                method_fullname,
-                request_serializer=input_class.SerializeToString,
-                response_deserializer=output_class.FromString,
-            )
-            response = stub_method(
-                request_input,
-                metadata=METADATA_STUB,
-                timeout=30,
-            )
-            _LOG.info("Stub method completed (%r): %r", type(response), response)
-            return response
-
-        create_func.__signature__ = create_func_signature  # type: ignore[attr-defined]
-        self.create = MethodType(create_func, self)
+        bound_func = partial(create_func_impl, method_info)
+        bound_func = bind_signature(create_func_signature)(bound_func)
+        self.create = MethodType(bound_func, self)
+        _LOG.debug("Generated CREATE injected well: %r", self.create)
 
     def generate_run(self, channel: Channel):
         """

--- a/python/michelangelo/cli/mactl/mactl.py
+++ b/python/michelangelo/cli/mactl/mactl.py
@@ -136,28 +136,31 @@ class CrdMethodInfo:
     """
 
     channel: Channel
+    crd_full_name: str
     method_name: str
     input_class: type[Message]
     output_class: type[Message]
 
 
-def get_crd(crd_method_info, full_name: str, namespace: str, name: str) -> Message:
+def get_crd(crd_method_info, namespace: str, name: str) -> Message:
     """
     Run CRD.GET method with grpc reflection
     """
-    _LOG.debug("CRD method info: %r", crd_method_info)
-
     request_input = crd_method_info.input_class(
         namespace=namespace,
         name=name,
     )
-    _LOG.info(
-        "GET Request input (%r) ready: %r",
-        type(request_input),
-        request_input,
-    )
+    return crd_method_call(crd_method_info, request_input)
 
-    method_fullname = f"/{full_name}/{crd_method_info.method_name}"
+
+def crd_method_call(crd_method_info, request_input: Message) -> Message:
+    """
+    Call member method call of a CRD with grpc reflection
+    """
+    _LOG.debug("CRD method info: %r", crd_method_info)
+    _LOG.debug("Request input (%r): %r", type(request_input), request_input)
+
+    method_fullname = f"/{crd_method_info.crd_full_name}/{crd_method_info.method_name}"
     _LOG.info("Method fullname for gRPC call: %s", method_fullname)
     stub_method = crd_method_info.channel.unary_unary(
         method_fullname,
@@ -178,13 +181,11 @@ def get_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Mess
     Default common CRD member method implementation for GET method.
     """
     _LOG.info("Bound arguments: %r", bound_args.arguments)
-    _self: CRD = bound_args.arguments["self"]
-    _LOG.info("Start get_func for %r", _self.full_name)
 
     _name = get_single_arg(bound_args.arguments, "name")
     _namespace = get_single_arg(bound_args.arguments, "namespace")
 
-    return get_crd(crd_method_info, _self.full_name, _namespace, _name)
+    return get_crd(crd_method_info, _namespace, _name)
 
 
 def delete_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Message:
@@ -192,8 +193,6 @@ def delete_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> M
     Default common CRD member method implementation for DELETE method.
     """
     _LOG.info("Bound arguments: %r", bound_args.arguments)
-    _self: CRD = bound_args.arguments["self"]
-    _LOG.info("Start delete_func for %r", _self.full_name)
 
     _namespace = get_single_arg(bound_args.arguments, "namespace")
     _name = get_single_arg(bound_args.arguments, "name")
@@ -202,26 +201,7 @@ def delete_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> M
         namespace=_namespace,
         name=_name,
     )
-    _LOG.info(
-        "DELETE Request input (%r) ready: %r",
-        type(request_input),
-        request_input,
-    )
-
-    method_fullname = f"/{_self.full_name}/{crd_method_info.method_name}"
-    _LOG.info("Method fullname for gRPC call: %s", method_fullname)
-    stub_method = channel.unary_unary(
-        method_fullname,
-        request_serializer=crd_method_info.input_class.SerializeToString,
-        response_deserializer=crd_method_info.output_class.FromString,
-    )
-    response = stub_method(
-        request_input,
-        metadata=METADATA_STUB,
-        timeout=30,
-    )
-    _LOG.info("Stub method completed (%r): %r", type(response), response)
-    return response
+    return crd_method_call(crd_method_info, request_input)
 
 
 def apply_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Message:
@@ -241,20 +221,7 @@ def apply_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Me
         crd_method_info.input_class, _file, message_instance
     )
 
-    method_fullname = f"/{_self.full_name}/{crd_method_info.method_name}"
-    _LOG.info("Method fullname for gRPC call: %s", method_fullname)
-    stub_method = channel.unary_unary(
-        method_fullname,
-        request_serializer=crd_method_info.input_class.SerializeToString,
-        response_deserializer=crd_method_info.output_class.FromString,
-    )
-    response = stub_method(
-        request_input,
-        metadata=METADATA_STUB,
-        timeout=30,
-    )
-    _LOG.info("Stub method completed (%r): %r", type(response), response)
-    return response
+    return crd_method_call(crd_method_info, request_input)
 
 
 def create_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Message:
@@ -274,20 +241,7 @@ def create_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> M
         _self.func_crd_metadata_converter,
     )
 
-    method_fullname = f"/{_self.full_name}/{crd_method_info.method_name}"
-    _LOG.info("Method fullname for gRPC call: %s", method_fullname)
-    stub_method = channel.unary_unary(
-        method_fullname,
-        request_serializer=crd_method_info.input_class.SerializeToString,
-        response_deserializer=crd_method_info.output_class.FromString,
-    )
-    response = stub_method(
-        request_input,
-        metadata=METADATA_STUB,
-        timeout=30,
-    )
-    _LOG.info("Stub method completed (%r): %r", type(response), response)
-    return response
+    return crd_method_call(crd_method_info, request_input)
 
 
 class CRD:
@@ -346,7 +300,9 @@ class CRD:
         """
         _LOG.info("Generate DELETE method for %r / %r", self.name, self.full_name)
         method_info = CrdMethodInfo(
-            channel, *self._extract_method_info(channel, self.full_name, "Delete")
+            channel,
+            self.full_name,
+            *self._extract_method_info(channel, self.full_name, "Delete"),
         )
         delete_func_signature = Signature(
             [Parameter("self", Parameter.POSITIONAL_OR_KEYWORD)]
@@ -367,7 +323,9 @@ class CRD:
         """
         _LOG.info("Generate GET method for %r / %r", self.name, self.full_name)
         method_info = CrdMethodInfo(
-            channel, *self._extract_method_info(channel, self.full_name, "Get")
+            channel,
+            self.full_name,
+            *self._extract_method_info(channel, self.full_name, "Get"),
         )
         get_func_signature = Signature(
             [Parameter("self", Parameter.POSITIONAL_OR_KEYWORD)]
@@ -390,7 +348,9 @@ class CRD:
 
         _LOG.info("Generate APPLY method for %r / %r", self.name, self.full_name)
         method_info = CrdMethodInfo(
-            channel, *self._extract_method_info(channel, self.full_name, "Update")
+            channel,
+            self.full_name,
+            *self._extract_method_info(channel, self.full_name, "Update"),
         )
         apply_func_signature = Signature(
             [Parameter("self", Parameter.POSITIONAL_OR_KEYWORD)]
@@ -409,7 +369,9 @@ class CRD:
         _LOG.info("Generate CREATE method for %r / %r", self.name, self.full_name)
 
         method_info = CrdMethodInfo(
-            channel, *self._extract_method_info(channel, self.full_name, "Create")
+            channel,
+            self.full_name,
+            *self._extract_method_info(channel, self.full_name, "Create"),
         )
         create_func_signature = Signature(
             [Parameter("self", Parameter.POSITIONAL_OR_KEYWORD)]

--- a/python/michelangelo/cli/mactl/mactl.py
+++ b/python/michelangelo/cli/mactl/mactl.py
@@ -141,20 +141,15 @@ class CrdMethodInfo:
     output_class: type[Message]
 
 
-def get_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Message:
+def get_crd(crd_method_info, full_name: str, namespace: str, name: str) -> Message:
     """
-    Common CRD member method implementation for GET method.
+    Run CRD.GET method with grpc reflection
     """
-    _LOG.info("Bound arguments: %r", bound_args.arguments)
-    _self: CRD = bound_args.arguments["self"]
-    _LOG.info("Start get_func for %r", _self.full_name)
-
-    _name = get_single_arg(bound_args.arguments, "name")
-    _namespace = get_single_arg(bound_args.arguments, "namespace")
+    _LOG.debug("CRD method info: %r", crd_method_info)
 
     request_input = crd_method_info.input_class(
-        namespace=_namespace,
-        name=_name,
+        namespace=namespace,
+        name=name,
     )
     _LOG.info(
         "GET Request input (%r) ready: %r",
@@ -162,7 +157,7 @@ def get_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Mess
         request_input,
     )
 
-    method_fullname = f"/{_self.full_name}/{crd_method_info.method_name}"
+    method_fullname = f"/{full_name}/{crd_method_info.method_name}"
     _LOG.info("Method fullname for gRPC call: %s", method_fullname)
     stub_method = crd_method_info.channel.unary_unary(
         method_fullname,
@@ -176,6 +171,20 @@ def get_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Mess
     )
     _LOG.info("Stub method completed (%r): %r", type(response), response)
     return response
+
+
+def get_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Message:
+    """
+    Common CRD member method implementation for GET method.
+    """
+    _LOG.info("Bound arguments: %r", bound_args.arguments)
+    _self: CRD = bound_args.arguments["self"]
+    _LOG.info("Start get_func for %r", _self.full_name)
+
+    _name = get_single_arg(bound_args.arguments, "name")
+    _namespace = get_single_arg(bound_args.arguments, "namespace")
+
+    return get_crd(crd_method_info, _self.full_name, _namespace, _name)
 
 
 def delete_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Message:


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

Separate the implementation of apply/create from CRD class for reusability and better unit test in the future.


<!-- Tell your future self why have you made these changes -->
**Why?**

It was difficult to share the common functions and create a unit test out of the grpc reflection feature itself, so core implementation is separated out.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
