### PR TITLE
Revert UnmarshalJSON from main CRD type

### DIFF
--- a/go/cmd/kubeproto/protoc-gen-kubeproto/main_test.go
+++ b/go/cmd/kubeproto/protoc-gen-kubeproto/main_test.go
@@ -560,3 +560,71 @@ func TestUnmarshalJSON_DisallowUnknownFields(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown field")
 }
+
+// TestInlineEmbedding tests that CRD types can be embedded inline with additional fields.
+// This is a regression test for the UnmarshalJSON issue where the type alias pattern
+// would cause additional fields to be lost during unmarshaling.
+func TestInlineEmbedding(t *testing.T) {
+	// Define a struct that embeds TestObject inline with additional fields
+	// This simulates how consuming repositories use inline embedding
+	type TestObjectResponse struct {
+		testpb.TestObject `json:",inline"`
+		AdditionalField   string            `json:"additional_field,omitempty"`
+		DebuggingInfo     map[string]string `json:"debugging_info,omitempty"`
+	}
+
+	// Create a complete JSON string with both TestObject and additional fields
+	// We use raw JSON to avoid marshaling issues with oneof fields
+	jsonStr := `{
+		"apiVersion": "test/v1",
+		"kind": "TestObject",
+		"metadata": {
+			"name": "test-object",
+			"namespace": "default"
+		},
+		"spec": {
+			"description": "test description"
+		},
+		"status": {},
+		"additional_field": "extra-value",
+		"debugging_info": {
+			"log_level": "debug",
+			"trace_id": "12345"
+		}
+	}`
+
+	// Unmarshal the JSON
+	var unmarshaled TestObjectResponse
+	err := json.Unmarshal([]byte(jsonStr), &unmarshaled)
+	assert.Nil(t, err, "Failed to unmarshal JSON with inline embedding")
+
+	// Verify embedded TestObject fields are preserved
+	assert.Equal(t, "test/v1", unmarshaled.TypeMeta.APIVersion)
+	assert.Equal(t, "TestObject", unmarshaled.TypeMeta.Kind)
+	assert.Equal(t, "test-object", unmarshaled.ObjectMeta.Name)
+	assert.Equal(t, "default", unmarshaled.ObjectMeta.Namespace)
+	assert.Equal(t, "test description", unmarshaled.Spec.Description)
+
+	// CRITICAL: Verify additional fields are NOT lost
+	// If UnmarshalJSON with type alias pattern is added back to the main CRD type,
+	// these assertions will fail because the type alias consumes the entire JSON
+	// and ignores fields that aren't part of the CRD type itself.
+	assert.Equal(t, "extra-value", unmarshaled.AdditionalField,
+		"Additional fields lost! This indicates UnmarshalJSON on main CRD type breaks inline embedding")
+	assert.NotNil(t, unmarshaled.DebuggingInfo,
+		"DebuggingInfo map lost! This indicates UnmarshalJSON on main CRD type breaks inline embedding")
+	assert.Equal(t, "debug", unmarshaled.DebuggingInfo["log_level"])
+	assert.Equal(t, "12345", unmarshaled.DebuggingInfo["trace_id"])
+
+	// Now test the reverse: Marshal and verify both parts are included
+	remarshaled, err := json.Marshal(unmarshaled)
+	assert.Nil(t, err)
+
+	// Unmarshal into a generic map to verify all fields are present
+	var jsonMap map[string]interface{}
+	err = json.Unmarshal(remarshaled, &jsonMap)
+	assert.Nil(t, err)
+
+	assert.Equal(t, "extra-value", jsonMap["additional_field"])
+	assert.NotNil(t, jsonMap["debugging_info"])
+}

--- a/go/kubeproto/templates/crd.tmpl
+++ b/go/kubeproto/templates/crd.tmpl
@@ -395,46 +395,6 @@ func (in *{{.Name}}) DeepCopyInto(out *{{.Name}}) {
 	out.Status = *proto.Clone(&in.Status).(*{{.Name}}Status)
 }
 
-// UnmarshalJSON unmarshals the full CR and provides detailed logging with resource context
-func (m *{{.Name}}) UnmarshalJSON(b []byte) error {
-    // Use standard JSON unmarshalling first
-    type Alias {{.Name}}
-    aux := (*Alias)(m)
-    if err := json.Unmarshal(b, aux); err != nil {
-        // Log with full resource context when available
-        logger := log.Log.WithName("cr-unmarshal")
-        logFields := []interface{}{
-            "resourceType", "{{.Name}}",
-            "fieldType", "full_object",
-            "rawDataLength", len(b),
-            "rawDataPreview", string(b[:min(len(b), 200)]),
-        }
-        
-        // Extract resource identification from ObjectMeta if available
-        if m.ObjectMeta.Name != "" {
-            logFields = append(logFields, "resourceName", m.ObjectMeta.Name)
-        }
-        if m.ObjectMeta.Namespace != "" {
-            logFields = append(logFields, "resourceNamespace", m.ObjectMeta.Namespace)
-        }
-        
-        logger.Error(err, "Failed to unmarshal full CR object", logFields...)
-        
-        // Emit metrics for unmarshal errors
-        metricLabels := map[string]string{
-            "resource_type": "{{.Name}}",
-            "field_type": "full_object",
-            "error_type": "unmarshal_error",
-        }
-        if m.ObjectMeta.Namespace != "" {
-            metricLabels["namespace"] = m.ObjectMeta.Namespace
-        }
-        metrics.GetGlobalRegistry().IncrementCounter("cr_unmarshal_errors", metricLabels)
-        return err
-    }
-    return nil
-}
-
 func init() {
 	SchemeBuilder.Register(&{{.Name}}{})
 }

--- a/go/kubeproto/templates/templates.go
+++ b/go/kubeproto/templates/templates.go
@@ -105,11 +105,9 @@ var CRDImports = `
 	"encoding/json"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/michelangelo-ai/michelangelo/go/kubeproto/util"
-	"github.com/michelangelo-ai/michelangelo/go/kubeproto/metrics"
 	"github.com/michelangelo-ai/michelangelo/go/storage"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 `
 
 // CrdSvcHandlerImports imports of CRD YARPC handlers

--- a/go/kubeproto/templates/templates_test.go
+++ b/go/kubeproto/templates/templates_test.go
@@ -58,11 +58,9 @@ func TestTemplates(t *testing.T) {
 	"encoding/json"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/michelangelo-ai/michelangelo/go/kubeproto/util"
-	"github.com/michelangelo-ai/michelangelo/go/kubeproto/metrics"
 	"github.com/michelangelo-ai/michelangelo/go/storage"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 `, CRDImports)
 
 	buf.Reset()


### PR DESCRIPTION
Remove the UnmarshalJSON method from the main CRD type that was added in commit c36a54c6. This method breaks inline embedding in consuming repositories.

Problem:
When a CRD type (e.g., PipelineRun) is embedded inline with additional fields, the type alias pattern in UnmarshalJSON causes those additional fields to be lost during unmarshaling.

Example of broken usage:
  type PipelineRunResponse struct {
      v2beta1.PipelineRun `json:",inline"`
      DebuggingResources  commons.DebuggingResources `json:"debugging_resources"`
  }

Why this is safe:
- The UnmarshalJSON method is not used anywhere in this OSS repository
- CRDs are handled via controller-runtime which doesn't call UnmarshalJSON
- The logging it provided is redundant (Spec/Status already handle errors)
- It only breaks functionality without providing value

Changes:
- go/kubeproto/templates/crd.tmpl: Removed UnmarshalJSON from main CRD type
- go/kubeproto/templates/templates.go: Removed unused imports (metrics, log)
- go/kubeproto/templates/templates_test.go: Updated test expectations

The Spec and Status UnmarshalJSON methods remain unchanged and continue to provide necessary protobuf-to-JSON conversion.

Tested:
- All kubeproto tests passing
- Generated CRD code builds successfully
- Inline embedding now works correctly in consuming repos

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
