### PR TITLE
Fix ignored error returns in logging and pipeline processing

### DIFF
--- a/go/components/pipelinerun/actors/executeworkflow.go
+++ b/go/components/pipelinerun/actors/executeworkflow.go
@@ -331,7 +331,10 @@ func decodePipelineManifestContent(pipelineSpec v2.PipelineSpec) (map[string]int
 		return nil, fmt.Errorf("unmarshal pipeline manifest content to typed struct: %w", err)
 	}
 	marshaler := &jsonpb.Marshaler{}
-	pipelineConfigStr, _ := marshaler.MarshalToString(pbStruct.Value)
+	pipelineConfigStr, err := marshaler.MarshalToString(pbStruct.Value)
+	if err != nil {
+		return nil, fmt.Errorf("marshal pipeline manifest to JSON string: %w", err)
+	}
 	pipelineConfig := make(map[string]interface{})
 	err = json.Unmarshal([]byte(pipelineConfigStr), &pipelineConfig)
 	if err != nil {

--- a/go/logging/utils.go
+++ b/go/logging/utils.go
@@ -10,8 +10,12 @@ import (
 )
 
 // MarshalToString marshals the input message into JSON form and convert into string.
+// If marshaling fails, returns an error message string instead of silently ignoring the error.
 func MarshalToString(v interface{}) string {
-	b, _ := json.Marshal(v)
+	b, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprintf("<error marshaling to JSON: %v>", err)
+	}
 	return string(b)
 }
 

--- a/go/logging/utils_test.go
+++ b/go/logging/utils_test.go
@@ -39,6 +39,13 @@ func TestMarshalToString(t *testing.T) {
 	}
 }
 
+func TestMarshalToStringError(t *testing.T) {
+	// Test with unmarshalable type (channels cannot be marshaled to JSON)
+	ch := make(chan int)
+	result := MarshalToString(ch)
+	assert.Contains(t, result, "<error marshaling to JSON:", "Should return error message for unmarshalable type")
+}
+
 func TestGetLogrLoggerOrPanic(t *testing.T) {
 	t.Run("successful logger creation", func(t *testing.T) {
 		// This should not panic


### PR DESCRIPTION
## Summary
This PR addresses **Issue #497** from the Go code quality analysis - critical error handling issues where errors were being silently ignored with blank identifiers (`_`), which could lead to unexpected behavior or silent failures.

### Changes Made
1. **go/logging/utils.go** 
   - Fixed `MarshalToString()` to handle JSON marshaling errors explicitly
   - Now returns a descriptive error message string instead of silently ignoring failures
   - Updated documentation to clarify error handling behavior

2. **go/components/pipelinerun/actors/executeworkflow.go**
   - Fixed ignored error from `marshaler.MarshalToString()` in `decodePipelineManifestContent()`
   - Added proper error checking and propagation with `%w` wrapping
   - Prevents potential silent failures in pipeline manifest processing

3. **go/logging/utils_test.go**
   - Added `TestMarshalToStringError()` to verify error handling behavior
   - Tests unmarshalable types (channels) to ensure error messages are returned

### Impact
- **Before:** Errors were silently discarded, potentially leading to incorrect behavior or data corruption
- **After:** All errors are explicitly handled with proper error messages and propagation

### Testing
- All existing tests pass 
- New test case added for error handling 
- Follows Effective Go principles for error handling 
