### PR TITLE
[MaCTL] Apply dynamic argparser by CRD and action functions

### DIFF
--- a/python/michelangelo/cli/mactl/mactl.py
+++ b/python/michelangelo/cli/mactl/mactl.py
@@ -1013,6 +1013,8 @@ def main(channel: Channel):
     """
     Main function for mactl
     """
+    _LOG.debug("Starting mactl...")
+
     # Load config and set environment variables
     if CONFIG_FILE.exists():
         with open(CONFIG_FILE, "r") as f:
@@ -1025,7 +1027,6 @@ def main(channel: Channel):
         if not getenv("AWS_ENDPOINT_URL"):
             environ["AWS_ENDPOINT_URL"] = minio_config.get("endpoint_url", "")
 
-    print("Starting mactl...")
     # Phase 1: Discover CRDs and create resource subcommands
     services = list_services(channel)
     _LOG.info("Got %d services: %r", len(services), services)
@@ -1074,9 +1075,6 @@ def main(channel: Channel):
         prog=f"mactl {user_command_crd} {user_command_action}"
     )
 
-    func_generator = getattr(crds[user_command_crd], f"generate_{user_command_action}")
-    func_generator(channel, action_parser)  # Now accepts parser!
-
     # Load plugins (may also configure action_parser)
     read_plugins(
         crds[user_command_crd],
@@ -1085,11 +1083,15 @@ def main(channel: Channel):
         channel,
     )
 
+    func_generator = getattr(crds[user_command_crd], f"generate_{user_command_action}")
+    func_generator(channel, action_parser)
+
     # Phase 4: Parse remaining arguments
     args = action_parser.parse_args(remaining[1:])
 
     # Phase 5: Execute
     func_action = getattr(crds[user_command_crd], user_command_action)
+    _LOG.debug("target action function is ready: %r", func_action)
     result = func_action(**vars(args))
 
     # Convert to JSON and pretty print

--- a/python/michelangelo/cli/mactl/mactl.py
+++ b/python/michelangelo/cli/mactl/mactl.py
@@ -3,6 +3,7 @@ MaCTL - Michelangelo Command Line Tool
 A command line interface to interact with the Michelangelo API server via gRPC.
 """
 
+from argparse import ArgumentParser
 from collections import defaultdict
 from collections.abc import MutableMapping
 from copy import deepcopy
@@ -14,7 +15,7 @@ from logging import basicConfig, getLogger, WARNING
 from os import getenv, environ
 from pathlib import Path
 from types import MethodType
-from typing import Any, Callable, Union
+from typing import Any, Callable, Optional, Union
 import logging
 import re
 import sys
@@ -354,6 +355,36 @@ def create_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> M
     return crd_method_call(crd_method_info, request_input)
 
 
+def configure_get_parser(parser: ArgumentParser) -> None:
+    """
+    Configure argparse parser for GET action.
+    Adds --namespace and --name arguments.
+
+    Args:
+        parser: ArgumentParser to configure
+    """
+    parser.add_argument(
+        "name",
+        nargs="?",
+        type=str,
+        help="Name of the resource (can be configured with --name)",
+    )
+    parser.add_argument(
+        "-n",
+        "--namespace",
+        type=str,
+        required=True,
+        help="Namespace of the resource",
+    )
+    parser.add_argument(
+        "--name",
+        dest="name",
+        type=str,
+        required=False,
+        help="Name of the resource",
+    )
+
+
 class CRD:
     """
     Representation of each CRD with its service methods
@@ -427,9 +458,14 @@ class CRD:
         self.delete = MethodType(bound_func, self)
         _LOG.debug("Generated DELETE injected well: %r", self.delete)
 
-    def generate_get(self, channel: Channel):
+    def generate_get(self, channel: Channel, parser: Optional[ArgumentParser] = None):
         """
         Generate get function of this class.
+        Optionally configure argparse parser with arguments.
+
+        Args:
+            channel: gRPC channel
+            parser: Optional ArgumentParser to configure with --namespace and --name
         """
         _LOG.info("Generate GET method for %r / %r", self.name, self.full_name)
         method_info = CrdMethodInfo(
@@ -437,6 +473,12 @@ class CRD:
             self.full_name,
             *self._extract_method_info(channel, self.full_name, "Get"),
         )
+
+        # Configure argparse if parser provided
+        if parser is not None:
+            _LOG.info("Configuring argparse for GET action")
+            configure_get_parser(parser)
+
         get_func_signature = Signature(
             [Parameter("self", Parameter.POSITIONAL_OR_KEYWORD)]
             + [Parameter("namespace", Parameter.POSITIONAL_OR_KEYWORD)]
@@ -929,15 +971,29 @@ def main(channel: Channel):
             f" '{user_command_action}' action."
         )
 
-    # Generate and run
-    func_action_generator = getattr(
-        crds[user_command_crd], f"generate_{user_command_action}"
-    )
-    func_action_generator(channel)
+    # For 'get' action, use dynamic argparse
+    if user_command_action == "get":
+        action_parser = ArgumentParser(
+            prog=f"mactl {user_command_crd} get",
+            description=f"Get {user_command_crd} resource",
+        )
+        func_action_generator = getattr(
+            crds[user_command_crd], f"generate_{user_command_action}"
+        )
+        func_action_generator(channel, action_parser)
 
-    assert hasattr(crds[user_command_crd], user_command_action)
-    func_action = getattr(crds[user_command_crd], user_command_action)
-    result = func_action(**kwargs)
+        # Parse args from sys.argv[3:] and execute
+        args = action_parser.parse_args(sys.argv[3:])
+        func_action = getattr(crds[user_command_crd], user_command_action)
+        result = func_action(**vars(args))
+    else:
+        func_action_generator = getattr(
+            crds[user_command_crd], f"generate_{user_command_action}"
+        )
+        func_action_generator(channel)
+
+        func_action = getattr(crds[user_command_crd], user_command_action)
+        result = func_action(**kwargs)
 
     # Convert to JSON and pretty print
     # temporary disable json converting due to issue:

--- a/python/michelangelo/cli/mactl/mactl.py
+++ b/python/michelangelo/cli/mactl/mactl.py
@@ -355,22 +355,6 @@ def create_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> M
     return crd_method_call(crd_method_info, request_input)
 
 
-def configure_parser(parser: ArgumentParser, arguments: list[dict]) -> None:
-    """
-    Configure argparse parser for action.
-    Detailed arguments would be defined by `arguments`.
-
-    Args:
-        parser: ArgumentParser to configure
-        arguments: list of args and kwargs to add to the parser
-    """
-    _LOG.debug("Start to configure parser with args: %r", arguments)
-    for arg_def in arguments:
-        args = arg_def.get("args", [])
-        kwargs = arg_def.get("kwargs", {})
-        parser.add_argument(*args, **kwargs)
-
-
 class CRD:
     """
     Representation of each CRD with its service methods
@@ -382,6 +366,48 @@ class CRD:
         self.func_crd_metadata_converter = convert_crd_metadata
         self.method_info: dict = {}
         self.func_signature: dict = {
+            "apply": [
+                {
+                    "func_signature": Parameter(
+                        "file",
+                        Parameter.POSITIONAL_OR_KEYWORD,
+                    ),
+                    "args": ["-f", "--file"],
+                    "kwargs": {
+                        "dest": "file",
+                        "type": str,
+                        "required": True,
+                        "help": "Custom Resource YAML file (can be configured with --file)",
+                    },
+                },
+            ],
+            "delete": [
+                {
+                    "func_signature": Parameter(
+                        "namespace", Parameter.POSITIONAL_OR_KEYWORD
+                    ),
+                    "args": ["-n", "--namespace"],
+                    "kwargs": {
+                        "type": str,
+                        "required": True,
+                        "help": "Namespace of the resource",
+                    },
+                },
+                {
+                    "func_signature": Parameter(
+                        "name",
+                        Parameter.POSITIONAL_OR_KEYWORD,
+                        default="",
+                    ),
+                    "args": ["--name"],
+                    "kwargs": {
+                        "dest": "name",
+                        "type": str,
+                        "required": True,
+                        "help": "Name of the resource",
+                    },
+                },
+            ],
             "get": [
                 {
                     "args": ["name"],
@@ -422,6 +448,42 @@ class CRD:
     def __repr__(self):
         return f"CRD(name={self.name}, full_name={self.full_name})"
 
+    def configure_parser(self, action: str, parser: Optional[ArgumentParser]) -> None:
+        """
+        Configure argparse parser for action, if parse is set.
+        Detailed arguments would be defined by `arguments`.
+
+        Args:
+            parser: ArgumentParser to configure
+            arguments: list of args and kwargs to add to the parser
+        """
+        _LOG.info("Configuring argparse (%r) for CRD `%r` action", parser, action)
+        if parser is None:
+            return
+        _LOG.debug(
+            "Start to configure parser with args: %r", self.func_signature[action]
+        )
+        for arg_def in self.func_signature[action]:
+            args = arg_def.get("args", [])
+            kwargs = arg_def.get("kwargs", {})
+            parser.add_argument(*args, **kwargs)
+
+    def _read_signatures(self, method_name: str) -> Signature:
+        """
+        Read function signatures for method name.
+        """
+        _LOG.debug("Prepare func signature for `%r` function", method_name)
+        res = Signature(
+            [Parameter("self", Parameter.POSITIONAL_OR_KEYWORD)]
+            + [
+                arg["func_signature"]
+                for arg in self.func_signature[method_name]
+                if "func_signature" in arg
+            ]
+        )
+        _LOG.debug("Read func signature: %r", res)
+        return res
+
     def _extract_method_info(
         self, channel: Channel, full_name: str, function_name: str
     ) -> tuple[str, type[Message], type[Message]]:
@@ -458,7 +520,7 @@ class CRD:
         )
         return method_name, input_class, output_class
 
-    def generate_delete(self, channel: Channel):
+    def generate_delete(self, channel: Channel, parser: Optional[ArgumentParser] = None):
         """
         Generate delete function of this class.
         """
@@ -468,16 +530,12 @@ class CRD:
             self.full_name,
             *self._extract_method_info(channel, self.full_name, "Delete"),
         )
-        delete_func_signature = Signature(
-            [Parameter("self", Parameter.POSITIONAL_OR_KEYWORD)]
-            + [
-                Parameter(name, Parameter.POSITIONAL_OR_KEYWORD)
-                for name in ["namespace", "name"]
-            ]
-        )
+
+        self.configure_parser("delete", parser)
+        func_signature = self._read_signatures("delete")
 
         bound_func = partial(delete_func_impl, method_info)
-        bound_func = bind_signature(delete_func_signature)(bound_func)
+        bound_func = bind_signature(func_signature)(bound_func)
         self.delete = MethodType(bound_func, self)
         _LOG.debug("Generated DELETE injected well: %r", self.delete)
 
@@ -497,27 +555,15 @@ class CRD:
             *self._extract_method_info(channel, self.full_name, "Get"),
         )
 
-        # Configure argparse if parser provided
-        if parser is not None:
-            _LOG.info("Configuring argparse for GET action")
-            configure_parser(parser, self.func_signature["get"])
-
-        get_func_signature = Signature(
-            [Parameter("self", Parameter.POSITIONAL_OR_KEYWORD)]
-            + [
-                arg["func_signature"]
-                for arg in self.func_signature["get"]
-                if "func_signature" in arg
-            ]
-        )
-        _LOG.debug("GET func signature: %r", get_func_signature)
+        self.configure_parser("get", parser)
+        func_signature = self._read_signatures("get")
 
         bound_func = partial(get_func_impl, method_info)
-        bound_func = bind_signature(get_func_signature)(bound_func)
+        bound_func = bind_signature(func_signature)(bound_func)
         self.get = MethodType(bound_func, self)
         _LOG.debug("Generated GET injected well: %r", self.get)
 
-    def generate_apply(self, channel: Channel):
+    def generate_apply(self, channel: Channel, parser: Optional[ArgumentParser] = None):
         """
         Generate apply function of this class.
         """
@@ -529,13 +575,12 @@ class CRD:
             self.full_name,
             *self._extract_method_info(channel, self.full_name, "Update"),
         )
-        apply_func_signature = Signature(
-            [Parameter("self", Parameter.POSITIONAL_OR_KEYWORD)]
-            + [Parameter(name, Parameter.POSITIONAL_OR_KEYWORD) for name in ["file"]]
-        )
+
+        self.configure_parser("apply", parser)
+        func_signature = self._read_signatures("apply")
 
         bound_func = partial(apply_func_impl, method_info)
-        bound_func = bind_signature(apply_func_signature)(bound_func)
+        bound_func = bind_signature(func_signature)(bound_func)
         self.apply = MethodType(bound_func, self)
         _LOG.debug("Generated APPLY injected well: %r", self.apply)
 
@@ -980,47 +1025,72 @@ def main(channel: Channel):
         if not getenv("AWS_ENDPOINT_URL"):
             environ["AWS_ENDPOINT_URL"] = minio_config.get("endpoint_url", "")
 
-    user_command_crd, user_command_action, kwargs = handle_args()
-
     print("Starting mactl...")
+    # Phase 1: Discover CRDs and create resource subcommands
     services = list_services(channel)
     _LOG.info("Got %d services: %r", len(services), services)
-
     crds = create_serivce_classes(services)
-    read_plugins(crds[user_command_crd], user_command_action, crds, channel)
 
-    assert user_command_crd in crds, (
-        f"Command {user_command_crd} not found in services: {list(crds)}"
+    # Phase 2: Pre-parse to get selected resource
+    base_parser = ArgumentParser(description="MaCTL - Michelangelo CLI", add_help=False)
+    base_parser.add_argument(
+        "-vv",
+        "--verbose",
+        action="store_true",
+        help="Increase verbosity level",
     )
-    if not hasattr(crds[user_command_crd], f"generate_{user_command_action}"):
-        raise ValueError(
-            f"Command '{user_command_crd}' does not support"
-            f" '{user_command_action}' action."
-        )
+    resource_subparsers = base_parser.add_subparsers(dest="resource", required=True)
 
-    # For 'get' action, use dynamic argparse
-    if user_command_action == "get":
-        action_parser = ArgumentParser(
-            prog=f"mactl {user_command_crd} get",
-            description=f"Get {user_command_crd} resource",
-        )
-        func_action_generator = getattr(
-            crds[user_command_crd], f"generate_{user_command_action}"
-        )
-        func_action_generator(channel, action_parser)
+    for crd_name in crds.keys():
+        resource_subparsers.add_parser(crd_name, add_help=False)
 
-        # Parse args from sys.argv[3:] and execute
-        args = action_parser.parse_args(sys.argv[3:])
-        func_action = getattr(crds[user_command_crd], user_command_action)
-        result = func_action(**vars(args))
-    else:
-        func_action_generator = getattr(
-            crds[user_command_crd], f"generate_{user_command_action}"
-        )
-        func_action_generator(channel)
+    # Parse only resource name, leave rest for later
+    namespace, remaining = base_parser.parse_known_args()
+    user_command_crd = namespace.resource
 
-        func_action = getattr(crds[user_command_crd], user_command_action)
-        result = func_action(**kwargs)
+    # Handle CRD-level help (e.g., "ma project --help" or "ma project -h")
+    # TODO: this will be generated by CRD automatically later
+    if len(remaining) >= 1 and remaining[0] in ["--help", "-h"]:
+        print(f"Usage: mactl {user_command_crd} <action> [options]")
+        print("\nAvailable actions:")
+        print("  get       Get or List specific resource(s)")
+        print("  apply     Create or update a resource from YAML file")
+        print("  delete    Delete a resource")
+        print(
+            f"\nFor action-specific help, use: mactl {user_command_crd} <action> --help"
+        )
+        sys.exit(0)
+
+    if len(remaining) < 1:
+        print(f"Usage: mactl {user_command_crd} <action>")
+        print("Available actions: get, create, apply, delete, list")
+        print(f"Run 'mactl {user_command_crd} --help' for more information")
+        sys.exit(1)
+
+    user_command_action = kebab_to_snake(remaining[0])
+
+    # Phase 3: Generate method + configure argparse
+    action_parser = ArgumentParser(
+        prog=f"mactl {user_command_crd} {user_command_action}"
+    )
+
+    func_generator = getattr(crds[user_command_crd], f"generate_{user_command_action}")
+    func_generator(channel, action_parser)  # Now accepts parser!
+
+    # Load plugins (may also configure action_parser)
+    read_plugins(
+        crds[user_command_crd],
+        user_command_action,
+        crds,
+        channel,
+    )
+
+    # Phase 4: Parse remaining arguments
+    args = action_parser.parse_args(remaining[1:])
+
+    # Phase 5: Execute
+    func_action = getattr(crds[user_command_crd], user_command_action)
+    result = func_action(**vars(args))
 
     # Convert to JSON and pretty print
     # temporary disable json converting due to issue:

--- a/python/michelangelo/cli/mactl/mactl.py
+++ b/python/michelangelo/cli/mactl/mactl.py
@@ -1085,6 +1085,13 @@ def main(channel: Channel):
         channel,
     )
 
+    # TODO: this will be handled by CRD automatically later with argparse
+    if user_command_action not in crds[user_command_crd].func_signature:
+        print(f"Unknown action: {user_command_action}")
+        print(f"Available actions: {', '.join(crds[user_command_crd].func_signature)}")
+        print(f"Run 'mactl {user_command_crd} --help' for more information")
+        sys.exit(1)
+
     func_generator = getattr(crds[user_command_crd], f"generate_{user_command_action}")
     func_generator(channel, action_parser)
 

--- a/python/michelangelo/cli/mactl/mactl.py
+++ b/python/michelangelo/cli/mactl/mactl.py
@@ -355,34 +355,20 @@ def create_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> M
     return crd_method_call(crd_method_info, request_input)
 
 
-def configure_get_parser(parser: ArgumentParser) -> None:
+def configure_parser(parser: ArgumentParser, arguments: list[dict]) -> None:
     """
-    Configure argparse parser for GET action.
-    Adds --namespace and --name arguments.
+    Configure argparse parser for action.
+    Detailed arguments would be defined by `arguments`.
 
     Args:
         parser: ArgumentParser to configure
+        arguments: list of args and kwargs to add to the parser
     """
-    parser.add_argument(
-        "name",
-        nargs="?",
-        type=str,
-        help="Name of the resource (can be configured with --name)",
-    )
-    parser.add_argument(
-        "-n",
-        "--namespace",
-        type=str,
-        required=True,
-        help="Namespace of the resource",
-    )
-    parser.add_argument(
-        "--name",
-        dest="name",
-        type=str,
-        required=False,
-        help="Name of the resource",
-    )
+    _LOG.debug("Start to configure parser with args: %r", arguments)
+    for arg_def in arguments:
+        args = arg_def.get("args", [])
+        kwargs = arg_def.get("kwargs", {})
+        parser.add_argument(*args, **kwargs)
 
 
 class CRD:
@@ -395,6 +381,43 @@ class CRD:
         self.full_name = full_name
         self.func_crd_metadata_converter = convert_crd_metadata
         self.method_info: dict = {}
+        self.func_signature: dict = {
+            "get": [
+                {
+                    "args": ["name"],
+                    "kwargs": {
+                        "nargs": "?",
+                        "type": str,
+                        "help": "Name of the resource (can be configured with --name)",
+                    },
+                },
+                {
+                    "func_signature": Parameter(
+                        "namespace", Parameter.POSITIONAL_OR_KEYWORD
+                    ),
+                    "args": ["-n", "--namespace"],
+                    "kwargs": {
+                        "type": str,
+                        "required": True,
+                        "help": "Namespace of the resource",
+                    },
+                },
+                {
+                    "func_signature": Parameter(
+                        "name",
+                        Parameter.POSITIONAL_OR_KEYWORD,
+                        default="",
+                    ),
+                    "args": ["--name"],
+                    "kwargs": {
+                        "dest": "name",
+                        "type": str,
+                        "required": False,
+                        "help": "Name of the resource",
+                    },
+                },
+            ],
+        }
 
     def __repr__(self):
         return f"CRD(name={self.name}, full_name={self.full_name})"
@@ -477,13 +500,17 @@ class CRD:
         # Configure argparse if parser provided
         if parser is not None:
             _LOG.info("Configuring argparse for GET action")
-            configure_get_parser(parser)
+            configure_parser(parser, self.func_signature["get"])
 
         get_func_signature = Signature(
             [Parameter("self", Parameter.POSITIONAL_OR_KEYWORD)]
-            + [Parameter("namespace", Parameter.POSITIONAL_OR_KEYWORD)]
-            + [Parameter("name", Parameter.POSITIONAL_OR_KEYWORD, default="")]
+            + [
+                arg["func_signature"]
+                for arg in self.func_signature["get"]
+                if "func_signature" in arg
+            ]
         )
+        _LOG.debug("GET func signature: %r", get_func_signature)
 
         bound_func = partial(get_func_impl, method_info)
         bound_func = bind_signature(get_func_signature)(bound_func)

--- a/python/michelangelo/cli/mactl/mactl.py
+++ b/python/michelangelo/cli/mactl/mactl.py
@@ -520,7 +520,9 @@ class CRD:
         )
         return method_name, input_class, output_class
 
-    def generate_delete(self, channel: Channel, parser: Optional[ArgumentParser] = None):
+    def generate_delete(
+        self, channel: Channel, parser: Optional[ArgumentParser] = None
+    ):
         """
         Generate delete function of this class.
         """

--- a/python/michelangelo/cli/mactl/mactl.py
+++ b/python/michelangelo/cli/mactl/mactl.py
@@ -1049,6 +1049,9 @@ def main(channel: Channel):
 
     # Parse only resource name, leave rest for later
     namespace, remaining = base_parser.parse_known_args()
+    _LOG.debug(
+        "Parsed arguments -- namespace: %r / remaining: %r", namespace, remaining
+    )
     user_command_crd = namespace.resource
 
     # Handle CRD-level help (e.g., "ma project --help" or "ma project -h")

--- a/python/michelangelo/cli/mactl/mactl.py
+++ b/python/michelangelo/cli/mactl/mactl.py
@@ -1064,7 +1064,7 @@ def main(channel: Channel):
 
     if len(remaining) < 1:
         print(f"Usage: mactl {user_command_crd} <action>")
-        print("Available actions: get, create, apply, delete, list")
+        print("Available actions: get, apply, delete")
         print(f"Run 'mactl {user_command_crd} --help' for more information")
         sys.exit(1)
 

--- a/python/michelangelo/cli/mactl/plugins/pipeline/dev_run.py
+++ b/python/michelangelo/cli/mactl/plugins/pipeline/dev_run.py
@@ -1,8 +1,9 @@
-from types import MethodType
-from logging import getLogger
+from argparse import ArgumentParser
 from inspect import Signature, Parameter
+from logging import getLogger
 from pathlib import Path
-
+from types import MethodType
+from typing import Optional
 
 from git import Repo
 from google.protobuf.json_format import ParseDict
@@ -36,11 +37,59 @@ _UNIFLOW_IMAGE_ANNOTATION_KEY = "michelangelo/uniflow-image"
 _LOG = getLogger(__name__)
 
 
-def generate_dev_run(crd: CRD, channel: Channel):
+def generate_dev_run(
+    crd: CRD, channel: Channel, parser: Optional[ArgumentParser] = None
+):
     """
     Generate dev run function for pipeline CRD.
     """
     _LOG.info("Generating `pipeline run` cr for dev-run: %s", crd)
+    crd.func_signature["dev_run"] = [
+        {
+            "func_signature": Parameter(
+                "file",
+                Parameter.POSITIONAL_OR_KEYWORD,
+            ),
+            "args": ["-f", "--file"],
+            "kwargs": {
+                "type": str,
+                "required": True,
+                "help": "Path to the pipeline YAML configuration file",
+            },
+        },
+        {
+            "func_signature": Parameter(
+                "env",
+                Parameter.POSITIONAL_OR_KEYWORD,
+                default={},
+            ),
+            "args": ["--env"],
+            "kwargs": {
+                "type": str,
+                "required": False,
+                "default": {},
+                "help": "Name of the resource",
+            },
+        },
+        {
+            "func_signature": Parameter(
+                "resume_from",
+                Parameter.POSITIONAL_OR_KEYWORD,
+                default=None,
+            ),
+            "args": ["--resume_from"],
+            "kwargs": {
+                "type": str,
+                "required": False,
+                "default": None,
+                "help": "Resume from a previous pipeline run. Format: 'pipeline_run_name[:step_name]'",
+            },
+        },
+    ]
+    _LOG.debug(
+        "Added function signature for action and argparser: %r",
+        crd.func_signature,
+    )
 
     pipeline_run_service = "michelangelo.api.v2.PipelineRunService"
     methods, method_pool = get_methods_from_service(channel, pipeline_run_service)
@@ -60,16 +109,10 @@ def generate_dev_run(crd: CRD, channel: Channel):
     input_class = get_message_class_by_name(method_pool, method_run.input_type[1:])
     output_class = get_message_class_by_name(method_pool, method_run.output_type[1:])
 
-    dev_run_func_signature = Signature(
-        [
-            Parameter("self", Parameter.POSITIONAL_OR_KEYWORD),
-            Parameter("file", Parameter.POSITIONAL_OR_KEYWORD),
-            Parameter("env", Parameter.POSITIONAL_OR_KEYWORD, default={}),
-            Parameter("resume_from", Parameter.POSITIONAL_OR_KEYWORD, default=None),
-        ]
-    )
+    crd.configure_parser("dev_run", parser)
+    func_signature = crd._read_signatures("dev_run")
 
-    @bind_signature(dev_run_func_signature)
+    @bind_signature(func_signature)
     def dev_run_func(bound_args: Signature) -> Message:
         _LOG.info("Start dev_run_func for pipeline")
         _LOG.info("Bound arguments: %r", bound_args.arguments)
@@ -122,7 +165,7 @@ def generate_dev_run(crd: CRD, channel: Channel):
         _LOG.info("Stub method completed (%r): %r", type(response), response)
         return response
 
-    dev_run_func.__signature__ = dev_run_func_signature
+    dev_run_func.__signature__ = func_signature  # type: ignore[attr-defined]
     crd.dev_run = MethodType(dev_run_func, crd)
 
 

--- a/python/michelangelo/cli/mactl/plugins/pipeline/main.py
+++ b/python/michelangelo/cli/mactl/plugins/pipeline/main.py
@@ -28,10 +28,12 @@ def apply_plugins(
         crd.func_crd_metadata_converter = convert_crd_metadata_pipeline_create
     if target_command == "run":
         crd.func_crd_metadata_converter = convert_crd_metadata_pipeline_run
-        crd.generate_run = MethodType(lambda self, ch: generate_run(self, ch), crd)
+        crd.generate_run = MethodType(
+            lambda self, ch, parser: generate_run(self, ch, parser), crd
+        )
     if target_command == "dev_run":
         crd.func_crd_metadata_converter = convert_crd_metadata_pipeline_dev_run
         crd.generate_dev_run = MethodType(
-            lambda self, ch: generate_dev_run(self, ch), crd
+            lambda self, ch, parser: generate_dev_run(self, ch, parser), crd
         )
     _LOG.info("Plugins applied successfully to crd: %s", crd)

--- a/python/michelangelo/cli/mactl/plugins/pipeline/run.py
+++ b/python/michelangelo/cli/mactl/plugins/pipeline/run.py
@@ -1,6 +1,8 @@
 import time
 import uuid
+from argparse import ArgumentParser
 from logging import getLogger
+from typing import Optional
 
 from grpc import Channel
 
@@ -22,11 +24,55 @@ from mactl import (
 _LOG = getLogger(__name__)
 
 
-def generate_run(crd: CRD, channel: Channel):
+def generate_run(crd: CRD, channel: Channel, parser: Optional[ArgumentParser] = None):
     """
     Generate run function for pipeline CRD.
     """
     _LOG.info("Generating `pipeline run` crd for: %s", crd)
+    crd.func_signature["run"] = [
+        {
+            "func_signature": Parameter(
+                "namespace",
+                Parameter.POSITIONAL_OR_KEYWORD,
+            ),
+            "args": ["-n", "--namespace"],
+            "kwargs": {
+                "type": str,
+                "required": True,
+                "help": "Namespace of the resource",
+            },
+        },
+        {
+            "func_signature": Parameter(
+                "name",
+                Parameter.POSITIONAL_OR_KEYWORD,
+            ),
+            "args": ["--name"],
+            "kwargs": {
+                "type": str,
+                "required": True,
+                "help": "Name of the resource",
+            },
+        },
+        {
+            "func_signature": Parameter(
+                "resume_from",
+                Parameter.POSITIONAL_OR_KEYWORD,
+                default=None,
+            ),
+            "args": ["--resume_from"],
+            "kwargs": {
+                "type": str,
+                "required": False,
+                "default": None,
+                "help": "Resume from a previous pipeline run. Format: 'pipeline_run_name[:step_name]'",
+            },
+        },
+    ]
+    _LOG.debug(
+        "Added function signature for action and argparser: %r",
+        crd.func_signature,
+    )
 
     pipeline_run_service = "michelangelo.api.v2.PipelineRunService"
     methods, method_pool = get_methods_from_service(channel, pipeline_run_service)
@@ -46,16 +92,10 @@ def generate_run(crd: CRD, channel: Channel):
     input_class = get_message_class_by_name(method_pool, method_create.input_type[1:])
     output_class = get_message_class_by_name(method_pool, method_create.output_type[1:])
 
-    run_func_signature = Signature(
-        [Parameter("self", Parameter.POSITIONAL_OR_KEYWORD)]
-        + [
-            Parameter(name, Parameter.POSITIONAL_OR_KEYWORD)
-            for name in ["namespace", "name"]
-        ]
-        + [Parameter("resume_from", Parameter.POSITIONAL_OR_KEYWORD, default=None)]
-    )
+    crd.configure_parser("run", parser)
+    func_signature = crd._read_signatures("run")
 
-    @bind_signature(run_func_signature)
+    @bind_signature(func_signature)
     def run_func(bound_args: Signature) -> Message:
         _LOG.info("Start run_func for pipeline")
         _LOG.info("Bound arguments: %r", bound_args.arguments)
@@ -97,7 +137,7 @@ def generate_run(crd: CRD, channel: Channel):
         _LOG.info("Stub method completed (%r): %r", type(response), response)
         return response
 
-    run_func.__signature__ = run_func_signature  # type: ignore[attr-defined]
+    run_func.__signature__ = func_signature  # type: ignore[attr-defined]
     crd.run = MethodType(run_func, crd)
 
 

--- a/python/michelangelo/cli/mactl/plugins/trigger_run/kill.py
+++ b/python/michelangelo/cli/mactl/plugins/trigger_run/kill.py
@@ -1,6 +1,8 @@
+from argparse import ArgumentParser
 from logging import getLogger
 from inspect import Signature, Parameter
 from types import MethodType
+from typing import Optional
 
 from grpc import Channel
 from google.protobuf.message import Message
@@ -12,11 +14,56 @@ from mactl import CRD, bind_signature, METADATA_STUB, get_single_arg
 _LOG = getLogger(__name__)
 
 
-def generate_kill(crd: CRD, channel: Channel):
+def generate_kill(crd: CRD, channel: Channel, parser: Optional[ArgumentParser] = None):
     """
     Generate kill function for pipeline_run CRD.
     """
     _LOG.info("Generating `pipeline_run kill` for: %s", crd)
+    crd.func_signature["kill"] = [
+        {
+            "func_signature": Parameter(
+                "namespace",
+                Parameter.POSITIONAL_OR_KEYWORD,
+            ),
+            "args": ["-n", "--namespace"],
+            "kwargs": {
+                "type": str,
+                "required": True,
+                "help": "Namespace of the resource",
+            },
+        },
+        {
+            "func_signature": Parameter(
+                "name",
+                Parameter.POSITIONAL_OR_KEYWORD,
+            ),
+            "args": ["--name"],
+            "kwargs": {
+                "type": str,
+                "required": True,
+                "help": "Name of the resource",
+            },
+        },
+        {
+            "func_signature": Parameter(
+                "yes",
+                Parameter.POSITIONAL_OR_KEYWORD,
+                default=False,
+            ),
+            "args": ["--yes"],
+            "kwargs": {
+                "action": "store_true",
+                "help": (
+                    "Automatic yes to prompts; assume 'yes' as answer to "
+                    "all prompts and run non-interactively."
+                ),
+            },
+        },
+    ]
+    _LOG.debug(
+        "Added function signature for action and argparser: %r",
+        crd.func_signature,
+    )
 
     crd.generate_get(channel)
 
@@ -24,23 +71,17 @@ def generate_kill(crd: CRD, channel: Channel):
         channel, crd.full_name, "Update"
     )
 
-    kill_func_signature = Signature(
-        [Parameter("self", Parameter.POSITIONAL_OR_KEYWORD)]
-        + [
-            Parameter(name, Parameter.POSITIONAL_OR_KEYWORD)
-            for name in ["namespace", "name"]
-        ]
-        + [Parameter("yes", Parameter.POSITIONAL_OR_KEYWORD, default=[])]
-    )
+    crd.configure_parser("kill", parser)
+    func_signature = crd._read_signatures("kill")
 
-    @bind_signature(kill_func_signature)
+    @bind_signature(func_signature)
     def kill_func(bound_args: Signature) -> Message:
         _LOG.info("Start kill_func for pipeline_run")
         _LOG.info("Bound arguments: %r", bound_args.arguments)
         _self: CRD = bound_args.arguments["self"]
         _name = get_single_arg(bound_args.arguments, "name")
         _namespace = get_single_arg(bound_args.arguments, "namespace")
-        _yes = bound_args.arguments.get("yes", [])
+        _yes = bound_args.arguments.get("yes", False)
 
         if not _yes:
             resource_type = _self.name.replace("_", " ")
@@ -102,5 +143,5 @@ def generate_kill(crd: CRD, channel: Channel):
         _LOG.info("Kill operation completed (%r): %r", type(response), response)
         return response
 
-    kill_func.__signature__ = kill_func_signature
+    kill_func.__signature__ = func_signature
     crd.kill = MethodType(kill_func, crd)

--- a/python/michelangelo/cli/mactl/plugins/trigger_run/main.py
+++ b/python/michelangelo/cli/mactl/plugins/trigger_run/main.py
@@ -18,5 +18,7 @@ def apply_plugins(
     """
     _LOG.info("Applying plugins to crd: %r / %r", crd, target_command)
     if target_command == "kill":
-        crd.generate_kill = MethodType(lambda self, ch: generate_kill(self, ch), crd)
+        crd.generate_kill = MethodType(
+            lambda self, ch, parser: generate_kill(self, ch, parser), crd
+        )
     _LOG.info("Plugins applied successfully to crd: %s", crd)


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

[MaCTL] Apply dynamic argparser by CRD and action functions


With using the `argparse` library, most of type checking and help commands would be covered by argparse

Example command with wrong argument 1 (shows available arguments)

```bash
$ ma asdfasdfadsf
usage: ma [-vv] {cached_output,deployment,model_family,model,pipeline_run,pipeline,project,ray_cluster,ray_job,spark_job,trigger_run} ...
ma: error: argument resource: invalid choice: 'asdfasdfadsf' (choose from 'cached_output', 'deployment', 'model_family', 'model', 'pipeline_run', 'pipeline', 'project', 'ray_cluster', 'ray_job', 'spark_job', 'trigger_run')
```


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**




<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
