### PR TITLE
Fix error wrapping in kubeproto code generation

### DIFF
--- a/go/kubeproto/util/util.go
+++ b/go/kubeproto/util/util.go
@@ -60,7 +60,7 @@ func GetPluginAndExtensions(data []byte, overrideGoPackageOpt bool) (*protogen.P
 	req := &pluginpb.CodeGeneratorRequest{}
 	err := proto.Unmarshal(data, req)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to unmarshal input from protoc %v", err)
+		return nil, nil, fmt.Errorf("failed to unmarshal input from protoc %w", err)
 	}
 	ReplaceImportPath(req)
 
@@ -75,7 +75,7 @@ func GetPluginAndExtensions(data []byte, overrideGoPackageOpt bool) (*protogen.P
 	// initialize protobuf generator
 	gen, err := protogen.Options{}.New(req)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to initialize golang proto generator %v", err)
+		return nil, nil, fmt.Errorf("failed to initialize golang proto generator %w", err)
 	}
 
 	// Load protobuf extensions from all the imported protobuf files


### PR DESCRIPTION
## Summary
- Replace `%v` with `%w` in `fmt.Errorf` calls to preserve error chains in protobuf code generation
- Fixes 2 instances in `go/kubeproto/util/util.go`

## Changes
- Line 63: Failed to unmarshal input from protoc error
- Line 78: Failed to initialize golang proto generator error

## Impact
Enables proper error unwrapping and improves debugging capabilities by preserving the full error context chain during protobuf generation.

## Test plan
- [ ] Verify existing tests pass
- [ ] Confirm error chains are properly preserved during protobuf generation failures

Fixes #498

🤖 Generated with [Claude Code](https://claude.com/claude-code)