### PR TITLE
Fix error wrapping in trigger parameter parsing

### DIFF
--- a/go/worker/activities/trigger/parameter/backfill_trigger.go
+++ b/go/worker/activities/trigger/parameter/backfill_trigger.go
@@ -164,7 +164,7 @@ func calculateBackfillRunTimestamps(triggerRun *v2pb.TriggerRun) ([]time.Time, e
 	}
 	cronSchedule, err := cron.ParseStandard(cronExp)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse cron schedule in original trigger run: %v", err)
+		return nil, fmt.Errorf("failed to parse cron schedule in original trigger run: %w", err)
 	}
 	nextRunTimestamp := cronSchedule.Next(startTimestamp)
 	previousOneRunTimestamp := nextRunTimestamp.Add(-cronSchedule.Next(nextRunTimestamp).Sub(nextRunTimestamp))


### PR DESCRIPTION
## Summary
- Replace `%v` with `%w` in `fmt.Errorf` call to preserve error chain in cron schedule parsing
- Fixes 1 instance in `go/worker/activities/trigger/parameter/backfill_trigger.go`

## Changes
- Line 167: Failed to parse cron schedule in original trigger run error

## Impact
Enables proper error unwrapping and improves debugging capabilities by preserving the full error context chain during cron schedule parsing.

## Test plan
- [ ] Verify existing tests pass
- [ ] Confirm error chains are properly preserved during cron parsing failures

Fixes #498

🤖 Generated with [Claude Code](https://claude.com/claude-code)