### PR TITLE
Fix error wrapping in pipeline controller status update

### DIFF
--- a/go/components/pipelinerun/controller.go
+++ b/go/components/pipelinerun/controller.go
@@ -65,7 +65,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if err = r.updatePipelineRunStatus(ctx, pipelineRun, originalPipelineRun); err != nil {
 		if returnErr != nil {
 			logger.Error("Failed to update pipeline run status", zap.Error(err))
-			return result, fmt.Errorf("update pipeline run status for %q: %w (previous error: %v)", req.NamespacedName, err, returnErr)
+			return result, fmt.Errorf("update pipeline run status for %q: %w (previous error: %w)", req.NamespacedName, err, returnErr)
 		}
 		logger.Error("Failed to update pipeline run status",
 			zap.Error(err),


### PR DESCRIPTION
## Summary
- Replace `%v` with `%w` in `fmt.Errorf` call to preserve both error chains
- Fixes 1 instance in `go/components/pipelinerun/controller.go`
- Uses Go 1.20+ multiple error wrapping feature

## Changes
- Line 68: Wrap both `err` and `returnErr` with `%w` for complete error chain preservation

## Impact
Enables proper unwrapping of both the status update error and the previous error, improving debugging capabilities when multiple errors occur during pipeline run status updates.

## Test plan
- [ ] Verify existing tests pass
- [ ] Confirm both error chains are properly preserved and can be unwrapped with errors.Is/errors.As

Fixes #498
