### PR TITLE
Fix underscore prefix naming in worker plugins

### DIFF
--- a/go/worker/plugins/cachedoutput/starlark_module.go
+++ b/go/worker/plugins/cachedoutput/starlark_module.go
@@ -46,8 +46,8 @@ var properties = map[string]star.PropertyFactory{}
 
 // These are some error reasons
 const (
-	_errorReasonUnpackArgs           = "UnpackArgsError"
-	_errorReasonConvertStarlarkValue = "ConvertStarlarkValueError"
+	errorReasonUnpackArgs           = "UnpackArgsError"
+	errorReasonConvertStarlarkValue = "ConvertStarlarkValueError"
 )
 
 // get returns a cachedoutput obj by namespace and name
@@ -68,7 +68,7 @@ func (r *module) get(t *starlark.Thread, _ *starlark.Builtin, args starlark.Tupl
 		"namespace", &namespace,
 		"name", &name,
 	); err != nil {
-		logger.Error(_errorReasonUnpackArgs, ext.ZapError(err)...)
+		logger.Error(errorReasonUnpackArgs, ext.ZapError(err)...)
 		return nil, err
 	}
 
@@ -86,7 +86,7 @@ func (r *module) get(t *starlark.Thread, _ *starlark.Builtin, args starlark.Tupl
 
 	var cachedOutputValue starlark.Value
 	if err := utils.AsStar(response.CachedOutput, &cachedOutputValue); err != nil {
-		logger.Error(_errorReasonConvertStarlarkValue, ext.ZapError(err)...)
+		logger.Error(errorReasonConvertStarlarkValue, ext.ZapError(err)...)
 		return nil, err
 	}
 	return cachedOutputValue, nil
@@ -105,13 +105,13 @@ func (r *module) put(t *starlark.Thread, _ *starlark.Builtin, args starlark.Tupl
 	if err := starlark.UnpackArgs("put", args, kwargs,
 		"cachedoutput", &cachedOutputDict,
 	); err != nil {
-		logger.Error(_errorReasonUnpackArgs, ext.ZapError(err)...)
+		logger.Error(errorReasonUnpackArgs, ext.ZapError(err)...)
 		return nil, err
 	}
 
 	co := v2pb.CachedOutput{}
 	if err := utils.AsGo(cachedOutputDict, &co); err != nil {
-		logger.Error(_errorReasonConvertStarlarkValue, ext.ZapError(err)...)
+		logger.Error(errorReasonConvertStarlarkValue, ext.ZapError(err)...)
 		return nil, err
 	}
 
@@ -128,7 +128,7 @@ func (r *module) put(t *starlark.Thread, _ *starlark.Builtin, args starlark.Tupl
 
 	var cachedOutputValue starlark.Value
 	if err := utils.AsStar(response.CachedOutput, &cachedOutputValue); err != nil {
-		logger.Error(_errorReasonConvertStarlarkValue, ext.ZapError(err)...)
+		logger.Error(errorReasonConvertStarlarkValue, ext.ZapError(err)...)
 		return nil, err
 	}
 
@@ -158,26 +158,26 @@ func (r *module) query(t *starlark.Thread, _ *starlark.Builtin, args starlark.Tu
 		"lookback_days", &lookbackDaysValue,
 		"limit", &limitValue,
 	); err != nil {
-		logger.Error(_errorReasonUnpackArgs, ext.ZapError(err)...)
+		logger.Error(errorReasonUnpackArgs, ext.ZapError(err)...)
 		return nil, err
 	}
 
 	var namespace string
 	if err := utils.AsGo(namespaceValue, &namespace); err != nil {
-		logger.Error(_errorReasonConvertStarlarkValue, ext.ZapError(err)...)
+		logger.Error(errorReasonConvertStarlarkValue, ext.ZapError(err)...)
 		return nil, err
 	}
 
 	matchCriterion := map[string]interface{}{}
 	if err := utils.AsGo(matchCritrionDict, &matchCriterion); err != nil {
-		logger.Error(_errorReasonConvertStarlarkValue, ext.ZapError(err)...)
+		logger.Error(errorReasonConvertStarlarkValue, ext.ZapError(err)...)
 		return nil, err
 	}
 
 	orderBy := []*apipb.OrderBy{}
 
 	if err := utils.AsGo(orderByValue, &orderBy); err != nil {
-		logger.Error(_errorReasonConvertStarlarkValue, ext.ZapError(err)...)
+		logger.Error(errorReasonConvertStarlarkValue, ext.ZapError(err)...)
 		return nil, err
 	}
 
@@ -185,12 +185,12 @@ func (r *module) query(t *starlark.Thread, _ *starlark.Builtin, args starlark.Tu
 	var limit int
 
 	if err := utils.AsGo(lookbackDaysValue, &lookbackDays); err != nil {
-		logger.Error(_errorReasonConvertStarlarkValue, ext.ZapError(err)...)
+		logger.Error(errorReasonConvertStarlarkValue, ext.ZapError(err)...)
 		return nil, err
 	}
 
 	if err := utils.AsGo(limitValue, &limit); err != nil {
-		logger.Error(_errorReasonConvertStarlarkValue, ext.ZapError(err)...)
+		logger.Error(errorReasonConvertStarlarkValue, ext.ZapError(err)...)
 		return nil, err
 	}
 	labelSelectors := []string{}
@@ -225,7 +225,7 @@ func (r *module) query(t *starlark.Thread, _ *starlark.Builtin, args starlark.Tu
 
 	var responseValue starlark.Value
 	if err := utils.AsStar(response, &responseValue); err != nil {
-		logger.Error(_errorReasonConvertStarlarkValue, ext.ZapError(err)...)
+		logger.Error(errorReasonConvertStarlarkValue, ext.ZapError(err)...)
 		return nil, err
 	}
 	return responseValue, nil

--- a/go/worker/plugins/spark/starlark_module.go
+++ b/go/worker/plugins/spark/starlark_module.go
@@ -16,20 +16,20 @@ import (
 
 // These are some error reasons
 const (
-	_errorReasonUnpackArgs           = "UnpackArgsError"
-	_errorReasonConvertJob           = "ConvertSparkJobError"
-	_errorReasonConvertStarlarkValue = "ConvertStarlarkValueError"
-	_errorReasonSubmitJob            = "SubmitJobError"
-	_errorReasonSensorJob            = "SensorJobError"
-	_errorReasonTermninateJob        = "TerminateJobError"
+	errorReasonUnpackArgs           = "UnpackArgsError"
+	errorReasonConvertJob           = "ConvertSparkJobError"
+	errorReasonConvertStarlarkValue = "ConvertStarlarkValueError"
+	errorReasonSubmitJob            = "SubmitJobError"
+	errorReasonSensorJob            = "SensorJobError"
+	errorReasonTermninateJob        = "TerminateJobError"
 )
 
-const _reasonForCancel = "Canceled by request"
+const reasonForCancel = "Canceled by request"
 
 // These are general const
 const (
-	_defaultPollSeconds  = 10
-	_maxJobSensorRetries = 100
+	defaultPollSeconds  = 10
+	maxJobSensorRetries = 100
 )
 
 // TODO: andrii: implement Spark starlark plugin here
@@ -78,7 +78,7 @@ func (r *module) createJob(t *starlark.Thread, _ *starlark.Builtin, args starlar
 		"job", &_job,
 		"timeout_seconds?", &timeout,
 	); err != nil {
-		logger.Error(_errorReasonUnpackArgs, ext.ZapError(err)...)
+		logger.Error(errorReasonUnpackArgs, ext.ZapError(err)...)
 		return nil, err
 	}
 	if timeout == 0 {
@@ -129,19 +129,19 @@ func (r *module) sensorJob(t *starlark.Thread, _ *starlark.Builtin, args starlar
 
 	var _job *starlark.Dict
 	timeout := int64(utils.CadenceLongTimeout.Seconds())
-	poll := _defaultPollSeconds
+	poll := defaultPollSeconds
 	var assertConditionType string = utils.SucceededCondition
 
 	if err := starlark.UnpackArgs("sensor_job", args, kwargs,
 		"job", &_job,
 		"assert_condition_type?", &assertConditionType,
 	); err != nil {
-		logger.Error(_errorReasonUnpackArgs, ext.ZapError(err)...)
+		logger.Error(errorReasonUnpackArgs, ext.ZapError(err)...)
 		return nil, err
 	}
 	var sparkJob v2pb.SparkJob
 	if err := utils.AsGo(_job, &sparkJob); err != nil {
-		logger.Error(_errorReasonConvertJob, ext.ZapError(err)...)
+		logger.Error(errorReasonConvertJob, ext.ZapError(err)...)
 		return nil, err
 	}
 
@@ -155,7 +155,7 @@ func (r *module) sensorJob(t *starlark.Thread, _ *starlark.Builtin, args starlar
 		Namespace: sparkJob.Namespace,
 	}
 	var getSparkJobResponse spark.SensorSparkJobResponse
-	maxSensorTries := _maxJobSensorRetries
+	maxSensorTries := maxJobSensorRetries
 	for i := 0; i < maxSensorTries; i++ {
 		if err := workflow.ExecuteActivity(sensorCtx, spark.Activities.SensorSparkJob, getSparkJobRequest).Get(ctx, &getSparkJobResponse); err != nil {
 			if workflow.IsCanceledError(ctx, err) {
@@ -165,21 +165,21 @@ func (r *module) sensorJob(t *starlark.Thread, _ *starlark.Builtin, args starlar
 					Name:      sparkJob.Name,
 					Namespace: sparkJob.Namespace,
 					Type:      v2pb.TERMINATION_TYPE_FAILED,
-					Reason:    _reasonForCancel,
+					Reason:    reasonForCancel,
 				}
 				var terminateResponse v2pb.UpdateSparkJobResponse
 				if terminateErr := workflow.ExecuteActivity(ctx, spark.Activities.TerminateSparkJob, terminateRequest).Get(ctx, &terminateResponse); terminateErr != nil {
-					logger.Error(_errorReasonTermninateJob, ext.ZapError(terminateErr)...)
+					logger.Error(errorReasonTermninateJob, ext.ZapError(terminateErr)...)
 					return nil, terminateErr
 				}
 				var res starlark.Value
 				if convertErr := utils.AsStar(terminateResponse.SparkJob, &res); convertErr != nil {
-					logger.Error(_errorReasonConvertJob, ext.ZapError(err)...)
+					logger.Error(errorReasonConvertJob, ext.ZapError(err)...)
 					return nil, convertErr
 				}
 				return res, nil
 			}
-			logger.Error(_errorReasonSensorJob, ext.ZapError(err)...)
+			logger.Error(errorReasonSensorJob, ext.ZapError(err)...)
 			continue
 		}
 		// we will break as long as succeeded condition has been set
@@ -190,7 +190,7 @@ func (r *module) sensorJob(t *starlark.Thread, _ *starlark.Builtin, args starlar
 
 	var sparkJobValue starlark.Value
 	if err := utils.AsStar(getSparkJobResponse.SparkJob, &sparkJobValue); err != nil {
-		logger.Error(_errorReasonConvertStarlarkValue, ext.ZapError(err)...)
+		logger.Error(errorReasonConvertStarlarkValue, ext.ZapError(err)...)
 		return nil, err
 	}
 	return sparkJobValue, nil

--- a/go/worker/workflows/trigger/backfill_trigger_workflows.go
+++ b/go/worker/workflows/trigger/backfill_trigger_workflows.go
@@ -10,7 +10,7 @@ import (
 // BackfillTrigger workflow with provided trigger run spec
 func (r *workflows) BackfillTrigger(ctx workflow.Context, req triggerrun.CreateTriggerRequest) (map[string]any, error) {
 	ctx = workflow.WithBackend(ctx, r.workflow)
-	ctx = workflow.WithActivityOptions(ctx, _activityOptionsDefault)
+	ctx = workflow.WithActivityOptions(ctx, activityOptionsDefault)
 	tr := req.TriggerRun
 	log := workflow.GetLogger(ctx).With(
 		zap.String("trigger_run", tr.Name),

--- a/go/worker/workflows/trigger/cron_trigger_workflows.go
+++ b/go/worker/workflows/trigger/cron_trigger_workflows.go
@@ -35,11 +35,11 @@ const (
 )
 
 var (
-	// _defaultWaitSeconds is the default wait seconds for the trigger workflow
-	_defaultWaitSeconds = 600
+	// defaultWaitSeconds is the default wait seconds for the trigger workflow
+	defaultWaitSeconds = 600
 
-	// _defaultParameterID is the default parameter id for the trigger workflow
-	_defaultParameterID = "default"
+	// defaultParameterID is the default parameter id for the trigger workflow
+	defaultParameterID = "default"
 
 	// TriggerredByLabel stores the name of the TriggerRun which triggered the pipeline_run
 	TriggerredByLabel = "pipelinerun.michelangelo/triggered-by"
@@ -60,8 +60,8 @@ var (
 	// PipelineManifestTypeLabel is to indicate the manifest type of this pipeline
 	PipelineManifestTypeLabel = "pipeline.michelangelo/PipelineManifestType"
 
-	// _activityOptionsDefault is the default activity options for the trigger workflow
-	_activityOptionsDefault = workflow.ActivityOptions{
+	// activityOptionsDefault is the default activity options for the trigger workflow
+	activityOptionsDefault = workflow.ActivityOptions{
 		ScheduleToStartTimeout: time.Second * 30,
 		StartToCloseTimeout:    time.Second * 30,
 		RetryPolicy: &workflow.RetryPolicy{
@@ -94,7 +94,7 @@ var (
 // CronTrigger workflow with provided trigger run spec
 func (r *workflows) CronTrigger(ctx workflow.Context, req triggerrun.CreateTriggerRequest) (map[string]any, error) {
 	ctx = workflow.WithBackend(ctx, r.workflow)
-	ctx = workflow.WithActivityOptions(ctx, _activityOptionsDefault)
+	ctx = workflow.WithActivityOptions(ctx, activityOptionsDefault)
 	tr := req.TriggerRun
 	log := workflow.GetLogger(ctx).With(
 		zap.String("trigger_run", tr.Name),
@@ -135,13 +135,13 @@ func batchRun(ctx workflow.Context, tr *v2pb.TriggerRun) error {
 		zap.String("namespace", tr.Namespace),
 		zap.String("trigger_name", tr.Name),
 	)
-	waitSeconds := _defaultWaitSeconds
+	waitSeconds := defaultWaitSeconds
 	if tr.Spec.Trigger.BatchPolicy != nil && tr.Spec.Trigger.BatchPolicy.Wait != nil {
 		waitSeconds = int(tr.Spec.Trigger.BatchPolicy.Wait.Seconds)
 	}
 	if len(tr.Spec.Trigger.ParametersMap) == 0 {
 		tr.Spec.Trigger.ParametersMap = map[string]*v2pb.PipelineExecutionParameters{
-			_defaultParameterID: {},
+			defaultParameterID: {},
 		}
 	}
 	var (
@@ -172,7 +172,7 @@ func concurrentRun(ctx workflow.Context, tr *v2pb.TriggerRun) error {
 	log := workflow.GetLogger(ctx)
 	if len(tr.Spec.Trigger.ParametersMap) == 0 {
 		tr.Spec.Trigger.ParametersMap = map[string]*v2pb.PipelineExecutionParameters{
-			_defaultParameterID: {},
+			defaultParameterID: {},
 		}
 	}
 	var (


### PR DESCRIPTION
## Summary
Remove underscore prefixes from constants to comply with Go naming conventions. In Go, visibility is controlled by case (uppercase = exported, lowercase = unexported), not underscores.

## Changes
**worker/plugins/spark/starlark_module.go** (9 constants):
- `_errorReasonUnpackArgs` → `errorReasonUnpackArgs`
- `_errorReasonConvertJob` → `errorReasonConvertJob`
- `_errorReasonConvertStarlarkValue` → `errorReasonConvertStarlarkValue`
- `_errorReasonSubmitJob` → `errorReasonSubmitJob`
- `_errorReasonSensorJob` → `errorReasonSensorJob`
- `_errorReasonTermninateJob` → `errorReasonTermninateJob`
- `_reasonForCancel` → `reasonForCancel`
- `_defaultPollSeconds` → `defaultPollSeconds`
- `_maxJobSensorRetries` → `maxJobSensorRetries`

**worker/plugins/cachedoutput/starlark_module.go** (2 constants):
- `_errorReasonUnpackArgs` → `errorReasonUnpackArgs`
- `_errorReasonConvertStarlarkValue` → `errorReasonConvertStarlarkValue`

**worker/workflows/trigger/cron_trigger_workflows.go** (3 constants):
- `_defaultWaitSeconds` → `defaultWaitSeconds`
- `_defaultParameterID` → `defaultParameterID`
- `_activityOptionsDefault` → `activityOptionsDefault`

## Impact
- Improves code readability
- Complies with Go naming conventions and Effective Go guidelines
- No functional changes

## Test plan
- [ ] Verify existing tests pass
- [ ] Confirm no behavioral changes

Fixes #499

🤖 Generated with [Claude Code](https://claude.com/claude-code)