### PR TITLE
Fix underscore prefix naming in base config

### DIFF
--- a/go/base/config/config.go
+++ b/go/base/config/config.go
@@ -16,11 +16,11 @@ import (
 )
 
 const (
-	_configKeySeparator       = ":"
-	_defaultConfigDir         = "config"
-	_k8sConfigKey             = "k8s"
-	_metadataStorageConfigKey = "metadataStorage"
-	_workflowClientConfigKey  = "workflowClient"
+	configKeySeparator       = ":"
+	defaultConfigDir         = "config"
+	k8sConfigKey             = "k8s"
+	metadataStorageConfigKey = "metadataStorage"
+	workflowClientConfigKey  = "workflowClient"
 )
 
 // K8sConfig is the configuration for k8s REST client.
@@ -76,9 +76,9 @@ func New(p Params) (Result, error) {
 func getConfigDirs(env env.Context) []string {
 	// Allow overriding the directory where config is loaded from
 	if env.ConfigPath != "" {
-		return strings.Split(env.ConfigPath, _configKeySeparator)
+		return strings.Split(env.ConfigPath, configKeySeparator)
 	}
-	return []string{_defaultConfigDir}
+	return []string{defaultConfigDir}
 }
 
 // GetK8sConfig parses the configuration file and returns the k8s REST client configuration
@@ -89,7 +89,7 @@ func GetK8sConfig(provider config.Provider) (*rest.Config, error) {
 		return nil, err
 	}
 	k8sConfig := K8sConfig{}
-	err = provider.Get(_k8sConfigKey).Populate(&k8sConfig)
+	err = provider.Get(k8sConfigKey).Populate(&k8sConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -101,13 +101,13 @@ func GetK8sConfig(provider config.Provider) (*rest.Config, error) {
 // GetMetadataStorageConfig parses the configuration file and returns the metadata storage configuration
 func GetMetadataStorageConfig(provider config.Provider) (storage.MetadataStorageConfig, error) {
 	storageConfig := storage.MetadataStorageConfig{}
-	err := provider.Get(_metadataStorageConfigKey).Populate(&storageConfig)
+	err := provider.Get(metadataStorageConfigKey).Populate(&storageConfig)
 	return storageConfig, err
 }
 
 // GetWorkflowClientConfig parses the configuration file and returns the workflow client configuration
 func GetWorkflowClientConfig(provider config.Provider) (WorkflowClientConfig, error) {
 	workflowClientConfig := WorkflowClientConfig{}
-	err := provider.Get(_workflowClientConfigKey).Populate(&workflowClientConfig)
+	err := provider.Get(workflowClientConfigKey).Populate(&workflowClientConfig)
 	return workflowClientConfig, err
 }

--- a/go/base/config/yaml.go
+++ b/go/base/config/yaml.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	_baseFile = "base"
+	baseFile = "base"
 )
 
 func newYAML(env env.Context, lookupFun config.LookupFunc) (config.Provider, error) {
@@ -49,7 +49,7 @@ func defaultExpandedFiles(env env.Context) []FileInfo {
 
 	// Always load base configuration and environment-specific configuration.
 	names := []string{
-		_baseFile,   // base
+		baseFile,   // base
 		environment, // production
 	}
 

--- a/go/base/config/yaml.go
+++ b/go/base/config/yaml.go
@@ -49,7 +49,7 @@ func defaultExpandedFiles(env env.Context) []FileInfo {
 
 	// Always load base configuration and environment-specific configuration.
 	names := []string{
-		baseFile,   // base
+		baseFile,    // base
 		environment, // production
 	}
 

--- a/go/base/env/env.go
+++ b/go/base/env/env.go
@@ -10,10 +10,10 @@ import (
 const (
 	configPathKey         = "CONFIG_DIR"
 	runtimeEnvironmentKey = "RUNTIME_ENVIRONMENT"
-	EnvProduction          = "production"
-	EnvStaging             = "staging"
-	EnvTest                = "test"
-	EnvDevelopment         = "development"
+	EnvProduction         = "production"
+	EnvStaging            = "staging"
+	EnvTest               = "test"
+	EnvDevelopment        = "development"
 )
 
 // Module provides a Context, which describes the runtime context of the

--- a/go/base/env/env.go
+++ b/go/base/env/env.go
@@ -8,8 +8,8 @@ import (
 )
 
 const (
-	_configPathKey         = "CONFIG_DIR"
-	_runtimeEnvironmentKey = "RUNTIME_ENVIRONMENT"
+	configPathKey         = "CONFIG_DIR"
+	runtimeEnvironmentKey = "RUNTIME_ENVIRONMENT"
 	EnvProduction          = "production"
 	EnvStaging             = "staging"
 	EnvTest                = "test"
@@ -35,9 +35,9 @@ type Result struct {
 func New() Result {
 	return Result{
 		Environment: Context{
-			ConfigPath:         os.Getenv(_configPathKey),
+			ConfigPath:         os.Getenv(configPathKey),
 			Hostname:           getHostname(),
-			RuntimeEnvironment: os.Getenv(_runtimeEnvironmentKey),
+			RuntimeEnvironment: os.Getenv(runtimeEnvironmentKey),
 		},
 	}
 }


### PR DESCRIPTION
## Summary
Remove underscore prefixes from constants to comply with Go naming conventions. In Go, visibility is controlled by case (uppercase = exported, lowercase = unexported), not underscores.

## Changes
**base/config/config.go** (5 constants):
- `_configKeySeparator` → `configKeySeparator`
- `_defaultConfigDir` → `defaultConfigDir`
- `_k8sConfigKey` → `k8sConfigKey`
- `_metadataStorageConfigKey` → `metadataStorageConfigKey`
- `_workflowClientConfigKey` → `workflowClientConfigKey`

**base/config/yaml.go** (1 constant):
- `_baseFile` → `baseFile`

**base/env/env.go** (2 constants):
- `_configPathKey` → `configPathKey`
- `_runtimeEnvironmentKey` → `runtimeEnvironmentKey`

## Impact
- Improves code readability
- Complies with Go naming conventions and Effective Go guidelines
- No functional changes

## Test plan
- [ ] Verify existing tests pass
- [ ] Confirm no behavioral changes

Fixes #499
