### PR TITLE
Fix underscore prefix naming in components

### DIFF
--- a/go/api/handler/handler.go
+++ b/go/api/handler/handler.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	_apiActionLatencyMetric = "apiActionLatency"
+	apiActionLatencyMetric = "apiActionLatency"
 )
 
 // NewFakeAPIHandler creates an API handler with the provided k8s client.  This is used for unit test only.
@@ -461,7 +461,7 @@ func emitAPIMetrics(action string, scope tally.Scope, logger logr.Logger, t time
 	tag := map[string]string{"action": action, "kind": kind}
 	// 10 bucket ~= 1 sec
 	// 16 bucket ~= 1 min
-	scope.Tagged(tag).Histogram(_apiActionLatencyMetric, tally.MustMakeExponentialDurationBuckets(time.Millisecond, 2.0,
+	scope.Tagged(tag).Histogram(apiActionLatencyMetric, tally.MustMakeExponentialDurationBuckets(time.Millisecond, 2.0,
 		16)).RecordDuration(took)
 	scope.Tagged(tag).Counter("calls")
 	logger.Info(fmt.Sprintf("API %s took %d milli seconds", action, took.Milliseconds()), "headers", headers)

--- a/go/components/pipelinerun/actors/executeworkflow.go
+++ b/go/components/pipelinerun/actors/executeworkflow.go
@@ -31,9 +31,9 @@ const (
 	WorkflowEnvironKey         = "environ"
 	WorkflowKWArgsKey          = "kwargs"
 	WorkflowArgsKey            = "args"
-	_cacheEnabledVarName       = "CACHE_ENABLED"
-	_cacheVersionVarName       = "CACHE_VERSION"
-	_CacheOperationGet         = "GET"
+	cacheEnabledVarName       = "CACHE_ENABLED"
+	cacheVersionVarName       = "CACHE_VERSION"
+	cacheOperationGet         = "GET"
 )
 
 // TaskProgress is the struct for the task progress queried from Cadence Workflow
@@ -345,14 +345,14 @@ func decodePipelineManifestContent(pipelineSpec v2.PipelineSpec) (map[string]int
 
 func (a *ExecuteWorkflowActor) addTaskCacheEnv(ctx context.Context, pipelineRun *v2.PipelineRun, envs map[string]interface{}) error {
 	logger := a.logger.With(zap.String("pipelineRun", fmt.Sprintf("%s/%s", pipelineRun.Namespace, pipelineRun.Name)))
-	envs[_cacheEnabledVarName] = "false"
-	envs[_cacheVersionVarName] = pipelineRun.Name
+	envs[cacheEnabledVarName] = "false"
+	envs[cacheVersionVarName] = pipelineRun.Name
 	if pipelineRun.Spec.Resume == nil || pipelineRun.Spec.Resume.PipelineRun == nil {
 		return nil
 	}
 
 	// if resume from a previous run, enable cache
-	envs[_cacheEnabledVarName] = "true"
+	envs[cacheEnabledVarName] = "true"
 	resumePipelineRunID := pipelineRun.Spec.Resume.PipelineRun
 	taskCacheVersion := map[string]string{}
 
@@ -373,13 +373,13 @@ func (a *ExecuteWorkflowActor) addTaskCacheEnv(ctx context.Context, pipelineRun 
 	}
 	logger.Info("Final Task Cache Version", zap.Any("taskCacheVersion", taskCacheVersion))
 	for taskName, cacheVersion := range taskCacheVersion {
-		envs[fmt.Sprintf("%s_%s_%s", _cacheVersionVarName, _CacheOperationGet, taskName)] = cacheVersion
+		envs[fmt.Sprintf("%s_%s_%s", cacheVersionVarName, cacheOperationGet, taskName)] = cacheVersion
 	}
 	// Finally, we disable cache for the specified task
 	resumeFromTasks := pipelineRun.Spec.Resume.ResumeFrom
 	if resumeFromTasks != nil && len(resumeFromTasks) > 0 {
 		for _, resumeFromTask := range resumeFromTasks {
-			envs[fmt.Sprintf("%s_%s", _cacheEnabledVarName, resumeFromTask)] = "false"
+			envs[fmt.Sprintf("%s_%s", cacheEnabledVarName, resumeFromTask)] = "false"
 		}
 	}
 	return nil

--- a/go/components/pipelinerun/actors/executeworkflow.go
+++ b/go/components/pipelinerun/actors/executeworkflow.go
@@ -31,9 +31,9 @@ const (
 	WorkflowEnvironKey         = "environ"
 	WorkflowKWArgsKey          = "kwargs"
 	WorkflowArgsKey            = "args"
-	cacheEnabledVarName       = "CACHE_ENABLED"
-	cacheVersionVarName       = "CACHE_VERSION"
-	cacheOperationGet         = "GET"
+	cacheEnabledVarName        = "CACHE_ENABLED"
+	cacheVersionVarName        = "CACHE_VERSION"
+	cacheOperationGet          = "GET"
 )
 
 // TaskProgress is the struct for the task progress queried from Cadence Workflow

--- a/go/components/project/apihook/apihook.go
+++ b/go/components/project/apihook/apihook.go
@@ -17,9 +17,9 @@ import (
 )
 
 const (
-	_defaultNamespace         = "default"
-	_integrationTestNamespace = "ma-integration-test"
-	_systemNamespacePrefix    = "kube-"
+	defaultNamespace         = "default"
+	integrationTestNamespace = "ma-integration-test"
+	systemNamespacePrefix    = "kube-"
 )
 
 // RegisterProjectAPIHook returns the API hook for Project
@@ -46,14 +46,14 @@ type apiHook struct {
 // BeforeCreate creates a new namespace of the same name before creating a project
 func (a apiHook) BeforeCreate(ctx context.Context, request *v2.CreateProjectRequest) error {
 	// Validate the request
-	if request.Project.Namespace != _integrationTestNamespace && request.Project.Name != request.Project.Namespace {
+	if request.Project.Namespace != integrationTestNamespace && request.Project.Name != request.Project.Namespace {
 		return status.Errorf(codes.InvalidArgument,
 			"project name <%s> is different from namespace name <%s>. Project name must be the same as namespace name.",
 			request.Project.Name,
 			request.Project.Namespace)
 	}
 
-	if request.Project.Namespace == _defaultNamespace || strings.HasPrefix(request.Project.Namespace, _systemNamespacePrefix) {
+	if request.Project.Namespace == defaultNamespace || strings.HasPrefix(request.Project.Namespace, systemNamespacePrefix) {
 		return status.Errorf(codes.PermissionDenied,
 			"namespace <%s> is invalid. Users are forbidden to create projects in default or system namespace",
 			request.Project.Namespace)

--- a/go/components/triggerrun/controller.go
+++ b/go/components/triggerrun/controller.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	// this is the concurrency reconcile loops for trigger run, it can be tuned if needed.
-	_maximumConcurrentReconciles = 10
+	maximumConcurrentReconciles = 10
 )
 
 // Params are the params for instantiating the reconciler.
@@ -173,7 +173,7 @@ func (r *Reconciler) Register(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v2pb.TriggerRun{}).
-		WithOptions(controller.Options{MaxConcurrentReconciles: _maximumConcurrentReconciles}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: maximumConcurrentReconciles}).
 		Complete(r)
 }
 


### PR DESCRIPTION
## Summary
Remove underscore prefixes from constants to comply with Go naming conventions. In Go, visibility is controlled by case (uppercase = exported, lowercase = unexported), not underscores.

## Changes
**components/pipelinerun/actors/executeworkflow.go** (3 constants):
- `_cacheEnabledVarName` → `cacheEnabledVarName`
- `_cacheVersionVarName` → `cacheVersionVarName`
- `_CacheOperationGet` → `cacheOperationGet`

**components/triggerrun/controller.go** (1 constant):
- `_maximumConcurrentReconciles` → `maximumConcurrentReconciles`

**components/project/apihook/apihook.go** (3 constants):
- `_defaultNamespace` → `defaultNamespace`
- `_integrationTestNamespace` → `integrationTestNamespace`
- `_systemNamespacePrefix` → `systemNamespacePrefix`

**api/handler/handler.go** (1 constant):
- `_apiActionLatencyMetric` → `apiActionLatencyMetric`

## Impact
- Improves code readability
- Complies with Go naming conventions and Effective Go guidelines
- No functional changes

## Test plan
- [ ] Verify existing tests pass
- [ ] Confirm no behavioral changes

Fixes #499
