### PR TITLE
Fix boolean comparison anti-patterns in API

### DIFF
--- a/go/api/api.go
+++ b/go/api/api.go
@@ -81,7 +81,7 @@ func GetGrpcStatusCode(err error) codes.Code {
 		}
 
 		grpcErrCode, found := K8sStatusReasonToGrpcError[statusErr.Status().Reason]
-		if found == false {
+		if !found {
 			grpcErrCode = codes.Unknown
 		}
 		return grpcErrCode

--- a/go/api/handler/handler.go
+++ b/go/api/handler/handler.go
@@ -223,7 +223,7 @@ func (handler *apiHandler) Delete(ctx context.Context, obj ctrlRTClient.Object,
 	}
 
 	// Delete the object in K8s/ETCD
-	if storage.EnableMetadataStorage(&handler.conf) == false {
+	if !storage.EnableMetadataStorage(&handler.conf) {
 		err = handler.k8sHandler.Delete(ctx, obj, opts)
 		return surfaceGrpcError(err, "delete", objMeta.GetNamespace(), objMeta.GetName())
 	}
@@ -315,7 +315,7 @@ func (handler *apiHandler) DeleteCollection(
 	log, headers := initLogger(ctx, handler.logger, "DeleteCollection", namespace, "", kind)
 	defer emitAPIMetrics("DeleteCollection", handler.metrics, log, start, kind, headers)
 
-	if storage.EnableMetadataStorage(&handler.conf) == false {
+	if !storage.EnableMetadataStorage(&handler.conf) {
 		err := handler.k8sHandler.DeleteCollection(ctx, objType, namespace, deleteOpts, listOpts)
 		return surfaceGrpcError(err, "delete collection", namespace, "")
 	}


### PR DESCRIPTION
## Summary
Replace explicit boolean comparisons with idiomatic Go style to improve code readability and follow Go conventions.

## Changes
**api/api.go** (1 instance):
- Line 84: `if !found` instead of `if found == false`

**api/handler/handler.go** (2 instances):
- Line 226: `if !storage.EnableMetadataStorage(&handler.conf)` instead of `== false`
- Line 318: `if !storage.EnableMetadataStorage(&handler.conf)` instead of `== false`

## Impact
- Improves code readability
- Follows Go idiomatic conventions
- No functional changes

## Test plan
- [ ] Verify existing tests pass
- [ ] Confirm no behavioral changes

Fixes #500

🤖 Generated with [Claude Code](https://claude.com/claude-code)