### PR TITLE
Fix boolean comparison anti-patterns in kubeproto generators

### DIFF
--- a/go/cmd/kubeproto/protoc-gen-kubeproto/main.go
+++ b/go/cmd/kubeproto/protoc-gen-kubeproto/main.go
@@ -353,7 +353,7 @@ func genCRDObject(crdName string, gInfo *groupinfo.GroupInfo, crdBuf *bytes.Buff
 
 func genImmutability(crdName string, crdBuf *bytes.Buffer, crdOptions *pboptions.Options) {
 	crdIsImmutable := false
-	if crdOptions.Bool("resource.immutable") == true {
+	if crdOptions.Bool("resource.immutable") {
 		crdIsImmutable = true
 	}
 	typeInfo := struct {

--- a/go/cmd/kubeproto/protoc-gen-sql/main.go
+++ b/go/cmd/kubeproto/protoc-gen-sql/main.go
@@ -58,7 +58,7 @@ func generateSQLSchema(crdRootMsg *protogen.Message, crdOptions *pboptions.Optio
 				buf.Write([]byte("    KEY    `" + getIndexName(crdTableName, field.Key) + "` ("))
 				firstSubfield := true
 				for _, subField := range field.SubFields {
-					if firstSubfield == true {
+					if firstSubfield {
 						firstSubfield = false
 					} else {
 						buf.Write([]byte(", "))


### PR DESCRIPTION
## Summary
Replace explicit boolean comparisons with idiomatic Go style to improve code readability and follow Go conventions.

## Changes
**cmd/kubeproto/protoc-gen-sql/main.go** (1 instance):
- Line 61: `if firstSubfield` instead of `if firstSubfield == true`

**cmd/kubeproto/protoc-gen-kubeproto/main.go** (1 instance):
- Line 356: `if crdOptions.Bool("resource.immutable")` instead of `== true`

## Impact
- Improves code readability
- Follows Go idiomatic conventions
- No functional changes

## Test plan
- [ ] Verify existing tests pass
- [ ] Confirm no behavioral changes in code generation

Fixes #500

🤖 Generated with [Claude Code](https://claude.com/claude-code)