### PR TITLE
Fix boolean comparison anti-patterns in kubeproto YAML and worker plugin

### DIFF
--- a/go/kubeproto/yaml/kubeyaml.go
+++ b/go/kubeproto/yaml/kubeyaml.go
@@ -343,7 +343,7 @@ func parseRootSchema(msg *protogen.Message) *apiext.JSONSchemaProps {
 	_, foundSpec := schema.Properties["spec"]
 	_, foundStatus := schema.Properties["status"]
 
-	if foundSpec == false || foundStatus == false {
+	if !foundSpec || !foundStatus {
 		logger.Panicf("Failed to parse %v.proto. Make sure both %vSpec and %vStatus are defined.",
 			msg.GoIdent.GoName, msg.GoIdent.GoName, msg.GoIdent.GoName)
 	}

--- a/go/worker/plugins/ray/starlark_module.go
+++ b/go/worker/plugins/ray/starlark_module.go
@@ -89,7 +89,7 @@ func (r *module) createCluster(t *starlark.Thread, _ *starlark.Builtin, args sta
 	}
 	var sensorResponse ray.SensorRayClusterReadinessResponse
 	var printJobURL = true
-	for sensorResponse.Ready == false {
+	for !sensorResponse.Ready {
 		if err := workflow.ExecuteActivity(sensorCtx, ray.Activities.SensorRayClusterReadiness, sensorRequest).Get(sensorCtx, &sensorResponse); err != nil {
 			logger.Error("builtin-error", ext.ZapError(err)...)
 			reason := err.Error()


### PR DESCRIPTION
## Summary
Fixes boolean comparison anti-patterns in kubeproto YAML generation and Ray worker plugin by replacing `== false` comparisons with idiomatic `!` operator.

**Group 3 of 3** - Kubeproto YAML & Worker (2 instances)

## Changes
- `go/kubeproto/yaml/kubeyaml.go:346`: Changed `if foundSpec == false || foundStatus == false` to `if !foundSpec || !foundStatus`
- `go/worker/plugins/ray/starlark_module.go:92`: Changed `for sensorResponse.Ready == false` to `for !sensorResponse.Ready`

## Impact
- No functional changes
- Follows Effective Go conventions
- Improves code readability

Fixes #500

🤖 Generated with [Claude Code](https://claude.com/claude-code)