### PR TITLE
Fix processJobTermination return signature to (bool, error)

### DIFF
--- a/go/components/pipelinerun/actors/executeworkflow.go
+++ b/go/components/pipelinerun/actors/executeworkflow.go
@@ -97,7 +97,7 @@ func (a *ExecuteWorkflowActor) Run(ctx context.Context, pipelineRun *v2.Pipeline
 	}
 
 	if pipelineRun.Spec.Kill {
-		err, workflowTerminated := a.processJobTermination(ctx, pipelineRun)
+		workflowTerminated, err := a.processJobTermination(ctx, pipelineRun)
 		if err != nil {
 			logger.Error("failed to terminate workflow", zap.Error(err))
 			return &apipb.Condition{
@@ -212,7 +212,7 @@ func (a *ExecuteWorkflowActor) Run(ctx context.Context, pipelineRun *v2.Pipeline
 	return newCondition, nil
 }
 
-func (a *ExecuteWorkflowActor) processJobTermination(ctx context.Context, pipelineRun *v2.PipelineRun) (error, bool) {
+func (a *ExecuteWorkflowActor) processJobTermination(ctx context.Context, pipelineRun *v2.PipelineRun) (bool, error) {
 	workflowID := pipelineRun.Status.WorkflowId
 	runID := pipelineRun.Status.WorkflowRunId
 
@@ -223,15 +223,15 @@ func (a *ExecuteWorkflowActor) processJobTermination(ctx context.Context, pipeli
 				err := a.workflowClient.CancelWorkflow(ctx, workflowID, runID, defaultengine.KillReason)
 				// if CancelWorkflow return a non-nil error, the workflow has not been successfully terminated
 				if err != nil {
-					return err, false
+					return false, err
 				} else {
-					return err, true
+					return true, err
 				}
 			}
 		}
 	}
 	// in this case, the workflow is unable to be terminated because it has not yet been started
-	return nil, false
+	return false, nil
 }
 
 func (a *ExecuteWorkflowActor) StartWorkflow(ctx context.Context, pipelineRun *v2.PipelineRun, taskList string) (*clientInterfaces.WorkflowExecution, error) {

--- a/go/components/pipelinerun/actors/executeworkflow_test.go
+++ b/go/components/pipelinerun/actors/executeworkflow_test.go
@@ -979,7 +979,7 @@ func TestProcessJobTermination(t *testing.T) {
 			apiHandler := apiHandler.NewFakeAPIHandler(k8sClient)
 
 			actor := setUpExecuteWorkflowActor(t, workflowClient, blobStoreClient, apiHandler)
-			err, _ = actor.processJobTermination(context.Background(), testCase.pipelineRun)
+			_, err = actor.processJobTermination(context.Background(), testCase.pipelineRun)
 
 			if testCase.expectError {
 				require.Error(t, err)


### PR DESCRIPTION
## Summary
- Fixed the `processJobTermination` method signature to follow Go conventions by returning `(bool, error)` instead of `(error, bool)`
- Updated all return statements within the function to match the new signature
- Updated the caller in the `Run` method to use the correct variable order
- Updated test code to match the new signature

## Changes Made
- **executeworkflow.go:215**: Changed function signature from `(error, bool)` to `(bool, error)`
- **executeworkflow.go:100**: Updated caller to use `workflowTerminated, err := a.processJobTermination(ctx, pipelineRun)`
- **executeworkflow.go:226,228,234**: Updated all return statements to return `(bool, error)` instead of `(error, bool)`
- **executeworkflow_test.go:982**: Updated test to match new signature

## Test Plan
- [x] Ran existing unit tests with `bazel test //go/components/pipelinerun/actors:go_default_test --test_filter=TestProcessJobTermination`
- [x] All tests passed successfully

## References
Fixes #498
