### PR TITLE
Add documentation to PipelineRun and Spark controllers (Group 1/3)

### DIFF
--- a/go/components/pipelinerun/actors/executeworkflow.go
+++ b/go/components/pipelinerun/actors/executeworkflow.go
@@ -48,6 +48,8 @@ type TaskProgress struct {
 	RetryAttemptID string `json:"retry_attempt_id"` // identifies the specific retry attempt for this task execution
 }
 
+// ExecuteWorkflowActor handles the execution of workflows for pipeline runs by starting
+// and monitoring workflow executions in Cadence/Temporal.
 type ExecuteWorkflowActor struct {
 	conditionInterfaces.ConditionActor[*v2.PipelineRun]
 	logger         *zap.Logger
@@ -57,6 +59,8 @@ type ExecuteWorkflowActor struct {
 	configProvider uberconfig.Provider
 }
 
+// NewExecuteWorkflowActor creates a new ExecuteWorkflowActor with the specified dependencies
+// for managing workflow execution.
 func NewExecuteWorkflowActor(logger *zap.Logger, workflowClient clientInterfaces.WorkflowClient, blobStore *blobstore.BlobStore, apiHandler api.Handler, configProvider uberconfig.Provider) *ExecuteWorkflowActor {
 	return &ExecuteWorkflowActor{
 		logger:         logger.With(zap.String("actor", "execute-workflow")),

--- a/go/components/pipelinerun/actors/imagebuild.go
+++ b/go/components/pipelinerun/actors/imagebuild.go
@@ -16,11 +16,13 @@ const (
 	ImageBuildType = "Image Build"
 )
 
+// ImageBuildActor handles the image building stage of pipeline execution.
 type ImageBuildActor struct {
 	conditionInterfaces.ConditionActor[*v2.PipelineRun]
 	logger *zap.Logger
 }
 
+// NewImageBuildActor creates a new ImageBuildActor with the specified logger.
 func NewImageBuildActor(logger *zap.Logger) *ImageBuildActor {
 	return &ImageBuildActor{
 		logger: logger.With(zap.String("actor", "imagebuild")),

--- a/go/components/pipelinerun/actors/sourcepipeline.go
+++ b/go/components/pipelinerun/actors/sourcepipeline.go
@@ -16,12 +16,15 @@ const (
 	SourcePipelineType = "SourcePipeline"
 )
 
+// SourcePipelineActor handles retrieving and attaching the source pipeline definition
+// to a pipeline run.
 type SourcePipelineActor struct {
 	conditionInterfaces.ConditionActor[*v2.PipelineRun]
 	apiHandler api.Handler
 	logger     *zap.Logger
 }
 
+// NewSourcePipelineActor creates a new SourcePipelineActor with the specified API handler and logger.
 func NewSourcePipelineActor(apiHandler api.Handler, logger *zap.Logger) *SourcePipelineActor {
 	return &SourcePipelineActor{
 		apiHandler: apiHandler,

--- a/go/components/pipelinerun/actors/utils/utils.go
+++ b/go/components/pipelinerun/actors/utils/utils.go
@@ -28,6 +28,7 @@ const (
 	UniflowTaskStateSkipped   = "SKIPPED"
 )
 
+// GetStep retrieves a specific step from a pipeline run by name.
 func GetStep(pipelineRun *v2.PipelineRun, name string) *v2.PipelineRunStepInfo {
 	for _, step := range pipelineRun.Status.Steps {
 		if step.Name == name {

--- a/go/components/pipelinerun/controller.go
+++ b/go/components/pipelinerun/controller.go
@@ -15,6 +15,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
+// Reconciler reconciles PipelineRun objects by executing pipeline workflows
+// through the condition engine and managing their lifecycle states.
 type Reconciler struct {
 	api.Handler
 	logger            *zap.Logger
@@ -23,6 +25,8 @@ type Reconciler struct {
 	apiHandlerFactory apiHandler.Factory
 }
 
+// NewReconciler creates a new PipelineRun reconciler with the specified plugin,
+// logger, and API handler factory.
 func NewReconciler(plugin *plugin.Plugin, logger *zap.Logger, apiHandlerFactory apiHandler.Factory) *Reconciler {
 	logger = logger.With(zap.String("component", "pipelinerun"))
 	return &Reconciler{

--- a/go/components/pipelinerun/plugin/plugin.go
+++ b/go/components/pipelinerun/plugin/plugin.go
@@ -21,12 +21,15 @@ var (
 	)
 )
 
+// Plugin implements the PipelineRun plugin with a collection of condition actors
+// that execute different stages of the pipeline lifecycle.
 type Plugin struct {
 	conditionsInterfaces.Plugin[*v2.PipelineRun]
 	Actors []conditionsInterfaces.ConditionActor[*v2.PipelineRun]
 	Logger *zap.Logger
 }
 
+// PluginParams contains the dependencies required to create a PipelineRun plugin.
 type PluginParams struct {
 	fx.In
 	ApiHandler     api.Handler
@@ -36,6 +39,8 @@ type PluginParams struct {
 	Logger         *zap.Logger
 }
 
+// NewPlugin creates a new PipelineRun plugin with all required actors for managing
+// pipeline execution stages.
 func NewPlugin(params PluginParams) *Plugin {
 	logger := params.Logger.With(zap.String("plugin", "pipelinerun"))
 	return &Plugin{

--- a/go/components/spark/job/client/client.go
+++ b/go/components/spark/job/client/client.go
@@ -13,6 +13,8 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+// SparkClient implements the Spark job client interface for creating and managing
+// Spark applications in Kubernetes.
 type SparkClient struct {
 	K8sClient      rest.Interface
 	ParameterCodec runtime.ParameterCodec

--- a/go/components/spark/job/controller.go
+++ b/go/components/spark/job/controller.go
@@ -18,6 +18,8 @@ import (
 
 const requeueAfter = 10 * time.Second
 
+// Reconciler reconciles SparkJob objects by creating and monitoring Spark applications
+// in the cluster and updating their status accordingly.
 type Reconciler struct {
 	client.Client
 	SparkClient Client


### PR DESCRIPTION
## Summary

**Part 1 of 3** - This PR adds godoc documentation to exported types and functions in the **PipelineRun and Spark job controllers** to improve code maintainability and reduce documentation gaps.

This is the first of three PRs addressing documentation gaps identified in issue #501. Each PR focuses on a different component area for easier, focused review.

---

## Changes Made

### PipelineRun Controller Components
**Files:** `go/components/pipelinerun/controller.go`, `go/components/pipelinerun/plugin/plugin.go`

#### Reconciler (2 symbols)
- ✅ **`Reconciler`** - Type that reconciles PipelineRun objects by executing pipeline workflows through the condition engine and managing their lifecycle states
- ✅ **`NewReconciler`** - Constructor that creates a new PipelineRun reconciler with the specified plugin, logger, and API handler factory

**Code Example:**
```go
// Reconciler reconciles PipelineRun objects by executing pipeline workflows
// through the condition engine and managing their lifecycle states.
type Reconciler struct {
    api.Handler
    logger            *zap.Logger
    plugin            *plugin.Plugin
    engine            *defaultEngine.DefaultEngine[*v2pb.PipelineRun]
    apiHandlerFactory apiHandler.Factory
}

// NewReconciler creates a new PipelineRun reconciler with the specified plugin,
// logger, and API handler factory.
func NewReconciler(plugin *plugin.Plugin, logger *zap.Logger, apiHandlerFactory apiHandler.Factory) *Reconciler
```

#### Plugin System (3 symbols)
- ✅ **`Plugin`** - Implements the PipelineRun plugin with a collection of condition actors that execute different stages of the pipeline lifecycle
- ✅ **`PluginParams`** - Contains the dependencies required to create a PipelineRun plugin (fx.In struct)
- ✅ **`NewPlugin`** - Creates a new PipelineRun plugin with all required actors for managing pipeline execution stages

**Code Example:**
```go
// Plugin implements the PipelineRun plugin with a collection of condition actors
// that execute different stages of the pipeline lifecycle.
type Plugin struct {
    conditionsInterfaces.Plugin[*v2.PipelineRun]
    Actors []conditionsInterfaces.ConditionActor[*v2.PipelineRun]
    Logger *zap.Logger
}

// PluginParams contains the dependencies required to create a PipelineRun plugin.
type PluginParams struct {
    fx.In
    ApiHandler     api.Handler
    WorkflowClient clientInterfaces.WorkflowClient
    BlobStore      *blobstore.BlobStore
    ConfigProvider uberconfig.Provider
    Logger         *zap.Logger
}

// NewPlugin creates a new PipelineRun plugin with all required actors for managing
// pipeline execution stages.
func NewPlugin(params PluginParams) *Plugin
```

---

### PipelineRun Actors
**Files:** `go/components/pipelinerun/actors/*.go`

#### ImageBuildActor (2 symbols)
- ✅ **`ImageBuildActor`** - Handles the image building stage of pipeline execution
- ✅ **`NewImageBuildActor`** - Creates a new ImageBuildActor with the specified logger

**Location:** `go/components/pipelinerun/actors/imagebuild.go:19-26`

#### SourcePipelineActor (2 symbols)
- ✅ **`SourcePipelineActor`** - Handles retrieving and attaching the source pipeline definition to a pipeline run
- ✅ **`NewSourcePipelineActor`** - Creates a new SourcePipelineActor with the specified API handler and logger

**Location:** `go/components/pipelinerun/actors/sourcepipeline.go:19-28`

#### ExecuteWorkflowActor (2 symbols)
- ✅ **`ExecuteWorkflowActor`** - Handles the execution of workflows for pipeline runs by starting and monitoring workflow executions in Cadence/Temporal
- ✅ **`NewExecuteWorkflowActor`** - Creates a new ExecuteWorkflowActor with the specified dependencies for managing workflow execution

**Location:** `go/components/pipelinerun/actors/executeworkflow.go:51-67`

**Code Example:**
```go
// ExecuteWorkflowActor handles the execution of workflows for pipeline runs by starting
// and monitoring workflow executions in Cadence/Temporal.
type ExecuteWorkflowActor struct {
    conditionInterfaces.ConditionActor[*v2.PipelineRun]
    logger         *zap.Logger
    workflowClient clientInterfaces.WorkflowClient
    blobStore      *blobstore.BlobStore
    apiHandler     api.Handler
    configProvider uberconfig.Provider
}

// NewExecuteWorkflowActor creates a new ExecuteWorkflowActor with the specified dependencies
// for managing workflow execution.
func NewExecuteWorkflowActor(...) *ExecuteWorkflowActor
```

---

### Utility Functions
**File:** `go/components/pipelinerun/actors/utils/utils.go`

#### GetStep (1 symbol)
- ✅ **`GetStep`** - Retrieves a specific step from a pipeline run by name

**Location:** `go/components/pipelinerun/actors/utils/utils.go:31`

**Code Example:**
```go
// GetStep retrieves a specific step from a pipeline run by name.
func GetStep(pipelineRun *v2.PipelineRun, name string) *v2.PipelineRunStepInfo
```

---

### Spark Job Controller
**Files:** `go/components/spark/job/controller.go`, `go/components/spark/job/client/client.go`

#### Reconciler (1 symbol)
- ✅ **`Reconciler`** - Reconciles SparkJob objects by creating and monitoring Spark applications in the cluster and updating their status accordingly

**Location:** `go/components/spark/job/controller.go:21`

#### SparkClient (1 symbol)
- ✅ **`SparkClient`** - Implements the Spark job client interface for creating and managing Spark applications in Kubernetes

**Location:** `go/components/spark/job/client/client.go:16`

**Code Example:**
```go
// Reconciler reconciles SparkJob objects by creating and monitoring Spark applications
// in the cluster and updating their status accordingly.
type Reconciler struct {
    client.Client
    SparkClient Client
    env         env.Context
}

// SparkClient implements the Spark job client interface for creating and managing
// Spark applications in Kubernetes.
type SparkClient struct {
    K8sClient      rest.Interface
    ParameterCodec runtime.ParameterCodec
}
```

---

## Documentation Standards

All documentation follows **Go conventions** and **godoc best practices**:

✅ **Starts with symbol name** - Each comment begins with the name being documented  
✅ **Complete sentences** - Uses proper grammar and punctuation  
✅ **Clear and concise** - Explains purpose without unnecessary verbosity  
✅ **Context provided** - Describes what the type/function does and why it exists  
✅ **godoc compatible** - Will appear correctly in generated documentation

---

## Impact

### Maintainability
- **Before:** 14 exported symbols lacked documentation
- **After:** All symbols have clear, comprehensive godoc comments
- **Benefit:** Easier onboarding for new developers, better IDE tooltips, clearer API surface

### Coverage
- **Files Modified:** 8
- **Lines Added:** 23 (documentation only)
- **Symbols Documented:** 14
- **Component Coverage:** PipelineRun controller, actors, and Spark job infrastructure

---

## Testing

✅ **No functional changes** - This PR only adds documentation comments  
✅ **Code compiles successfully** - All Go files parse correctly  
✅ **Existing tests pass** - No behavioral changes to test  
✅ **godoc validation** - Documentation follows proper godoc format

**Verification:**
```bash
# Verify compilation
go build ./go/components/pipelinerun/...
go build ./go/components/spark/job/...

# Generate documentation
go doc github.com/michelangelo-ai/michelangelo/go/components/pipelinerun.Reconciler
go doc github.com/michelangelo-ai/michelangelo/go/components/spark/job.Reconciler
```

---

## Related Pull Requests

This is **Part 1 of 3** in the documentation improvement series:

- ✅ **PR #528 (this PR)** - Controllers and Actors (14 symbols)
- 🔜 **PR #529** - Worker plugins and utilities (12 symbols)
- 🔜 **PR #530** - Base infrastructure types (4 symbols)

**Total Impact:** 30+ symbols across all three PRs

---

## Checklist

- [x] Documentation follows Go conventions
- [x] All comments start with symbol name
- [x] Comments use complete sentences
- [x] Code compiles successfully
- [x] No functional changes
- [x] Commit message is descriptive
- [x] References issue #501

---

## Related Issues

Part of #501 - Documentation Gaps

**Severity:** Medium  
**Impact:** Reduces maintainability, affects developer experience  
**Fix:** Add doc comments to all exported symbols starting with the symbol name

---
