### PR TITLE
Fix spelling and grammar errors in Go code

### DIFF
--- a/go/api/api.go
+++ b/go/api/api.go
@@ -25,7 +25,7 @@ const (
 
 	// ImmutableAnnotation is used to mark a CRD object if the spec and status of the object
 	// will no longer be updated .  If this annotation is set to "true", ingester will remove
-	// this CRD ojbect from k8s/ETCD and only the annotation and label of the immutable CRD
+	// this CRD object from k8s/ETCD and only the annotation and label of the immutable CRD
 	// object can be changed in MySQL later on.
 	ImmutableAnnotation = "michelangelo/Immutable"
 

--- a/go/base/config/yaml.go
+++ b/go/base/config/yaml.go
@@ -26,7 +26,7 @@ func newYAML(env env.Context, lookupFun config.LookupFunc) (config.Provider, err
 
 // getYAMLFiles returns all config yaml files, includes
 // expanded files: base.yaml and {environment}.yaml, raw files: secretes.yaml
-// variable is defined like ${ENV_VAR_NAME:default} and expended by looking up os envs
+// variable is defined like ${ENV_VAR_NAME:default} and expanded by looking up os envs
 func getYAMLFiles(env env.Context) []FileInfo {
 	files := defaultExpandedFiles(env)
 	files = append(files, defaultRawFiles(env)...)
@@ -56,8 +56,8 @@ func defaultExpandedFiles(env env.Context) []FileInfo {
 	return namesToInfo(names, true)
 }
 
-// defaultRawFiles returns yaml files shouldn't be expanded,
-// e.g. secrets files which often unescaped contain special characters, like "S"
+// defaultRawFiles returns yaml files that shouldn't be expanded,
+// e.g. secrets files which often contain unescaped special characters, like "$"
 func defaultRawFiles(env env.Context) []FileInfo {
 	names := []string{SecretsFile}
 	return namesToInfo(names, false)

--- a/go/worker/plugins/spark/starlark_module.go
+++ b/go/worker/plugins/spark/starlark_module.go
@@ -196,14 +196,14 @@ func (r *module) sensorJob(t *starlark.Thread, _ *starlark.Builtin, args starlar
 	return sparkJobValue, nil
 }
 
-func getRunningConditionType(reciever starlark.Value) (starlark.Value, error) {
+func getRunningConditionType(receiver starlark.Value) (starlark.Value, error) {
 	return starlark.String(utils.SparkAppRunningCondition), nil
 }
 
-func getSucceededConditionType(reciever starlark.Value) (starlark.Value, error) {
+func getSucceededConditionType(receiver starlark.Value) (starlark.Value, error) {
 	return starlark.String(utils.SucceededCondition), nil
 }
 
-func getKilledConditionType(reciever starlark.Value) (starlark.Value, error) {
+func getKilledConditionType(receiver starlark.Value) (starlark.Value, error) {
 	return starlark.String(utils.KilledCondition), nil
 }


### PR DESCRIPTION
## Summary

This PR fixes multiple spelling and grammar errors in Go code to improve code professionalism and readability.

All changes are in comments and parameter names with **no functional impact** on the code behavior.

---

## Changes Made

### 1. API Constants (api/api.go)

**Location:** `go/api/api.go:28`

**Before:**
```go
// this CRD ojbect from k8s/ETCD
```

**After:**
```go
// this CRD object from k8s/ETCD
```

**Fix:** Corrected spelling of "ojbect" → "object"

---

### 2. Configuration Comments (base/config/yaml.go)

#### Fix 1: "expended" → "expanded"
**Location:** `go/base/config/yaml.go:29`

**Before:**
```go
// variable is defined like ${ENV_VAR_NAME:default} and expended by looking up os envs
```

**After:**
```go
// variable is defined like ${ENV_VAR_NAME:default} and expanded by looking up os envs
```

**Fix:** Corrected spelling of "expended" → "expanded"

#### Fix 2: Grammar improvement and example correction
**Location:** `go/base/config/yaml.go:60`

**Before:**
```go
// defaultRawFiles returns yaml files shouldn't be expanded,
// e.g. secrets files which often unescaped contain special characters, like "S"
```

**After:**
```go
// defaultRawFiles returns yaml files that shouldn't be expanded,
// e.g. secrets files which often contain unescaped special characters, like "$"
```

**Fixes:**
- Added "that" for proper grammar
- Fixed word order: "unescaped contain" → "contain unescaped"
- Corrected example character from "S" to "$" (the actual special character that causes issues in environment variable expansion)

---

### 3. Function Parameter Names (worker/plugins/spark/starlark_module.go)

**Locations:** Lines 199, 203, 207

**Before:**
```go
func getRunningConditionType(reciever starlark.Value) (starlark.Value, error) {
func getSucceededConditionType(reciever starlark.Value) (starlark.Value, error) {
func getKilledConditionType(reciever starlark.Value) (starlark.Value, error) {
```

**After:**
```go
func getRunningConditionType(receiver starlark.Value) (starlark.Value, error) {
func getSucceededConditionType(receiver starlark.Value) (starlark.Value, error) {
func getKilledConditionType(receiver starlark.Value) (starlark.Value, error) {
```

**Fix:** Corrected spelling of "reciever" → "receiver" in all 3 function signatures

---

## Summary of Fixes

| File | Line(s) | Error | Correction | Type |
|------|---------|-------|------------|------|
| `api/api.go` | 28 | ojbect | object | Spelling |
| `base/config/yaml.go` | 29 | expended | expanded | Spelling |
| `base/config/yaml.go` | 60 | unescaped contain | contain unescaped | Grammar |
| `base/config/yaml.go` | 60 | "S" | "$" | Example correction |
| `worker/plugins/spark/starlark_module.go` | 199, 203, 207 | reciever | receiver | Spelling (3×) |

**Total:** 6 typos/errors fixed across 3 files

---

## Impact

### Severity
**Low-Medium** - Affects code professionalism and readability

### Benefits
✅ **Improved professionalism** - Code appears more polished and well-maintained  
✅ **Better readability** - Correct spelling makes comments easier to understand  
✅ **Clearer intent** - Corrected example character "$" accurately shows what the code handles  
✅ **No functional changes** - All fixes are in comments and parameter names

### Testing
✅ **Code compiles successfully** - No syntax changes  
✅ **No behavioral changes** - Only comments and parameter names affected  
✅ **Existing tests pass** - No test updates needed

---

## Verification

```bash
# Verify spelling fixes
git diff HEAD~1 go/api/api.go
git diff HEAD~1 go/base/config/yaml.go
git diff HEAD~1 go/worker/plugins/spark/starlark_module.go

# Compile to ensure no syntax errors
go build ./go/api/...
go build ./go/base/config/...
go build ./go/worker/plugins/spark/...
```

---

## Related Issues

Fixes #502 - Spelling and Grammar Errors

**Original issue details:**
- Severity: Low-Medium - Affects professionalism
- Instances: Multiple occurrences
- Examples provided:
  - ✅ api/api.go:27 - "ojbect" → "object" (fixed)
  - ✅ base/config/yaml.go:28 - "expended" → "expanded" (fixed)
  - ✅ base/config/yaml.go:60 - "unescaped contain" grammar issue (fixed)

**Additional fixes found:**
- worker/plugins/spark/starlark_module.go - "reciever" → "receiver" (3 instances)

---

## Checklist

- [x] All reported typos fixed
- [x] Additional typos discovered and fixed
- [x] Code compiles successfully
- [x] No functional changes
- [x] Commit message is descriptive
- [x] References issue #502

---
