### PR TITLE
Remove commented-out code in component controllers

### DIFF
--- a/go/components/deployment/controller.go
+++ b/go/components/deployment/controller.go
@@ -269,6 +269,14 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, metrics *Co
 		deployment.Status.Stage = stage
 		terminal := r.handleStageTransition(ctx, metrics, deployment, err)
 		// Simplified: Skip revision management for now
+		// TODO: Decision needed on deployment revision management:
+		// - Either implement UpsertDeploymentRevision properly with full error handling
+		// - Or permanently remove revision management infrastructure if not needed
+		// - See discussion in issue tracking this technical debt
+		// upsertErr := UpsertDeploymentRevision(ctx, deployment, r.RevisionManager)
+		// if upsertErr != nil {
+		//	log.Info(fmt.Sprintf("fail to upsert deployment revision. Proceeding with deployment. Error: %+v", upsertErr))
+		// }
 		// Make sure that we only set the conditions to nil after the upserting the revision, so we keep track of the
 		// latest set of conditions to render.
 		if terminal {

--- a/go/components/deployment/controller.go
+++ b/go/components/deployment/controller.go
@@ -269,10 +269,6 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, metrics *Co
 		deployment.Status.Stage = stage
 		terminal := r.handleStageTransition(ctx, metrics, deployment, err)
 		// Simplified: Skip revision management for now
-		// upsertErr := UpsertDeploymentRevision(ctx, deployment, r.RevisionManager)
-		// if upsertErr != nil {
-		//	log.Info(fmt.Sprintf("fail to upsert deployment revision. Proceeding with deployment. Error: %+v", upsertErr))
-		// }
 		// Make sure that we only set the conditions to nil after the upserting the revision, so we keep track of the
 		// latest set of conditions to render.
 		if terminal {

--- a/go/components/deployment/controller.go
+++ b/go/components/deployment/controller.go
@@ -269,10 +269,10 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, metrics *Co
 		deployment.Status.Stage = stage
 		terminal := r.handleStageTransition(ctx, metrics, deployment, err)
 		// Simplified: Skip revision management for now
-		// TODO: Decision needed on deployment revision management:
+		// TODO(#534): Decision needed on deployment revision management:
 		// - Either implement UpsertDeploymentRevision properly with full error handling
 		// - Or permanently remove revision management infrastructure if not needed
-		// - See discussion in issue tracking this technical debt
+		// - See issue #534 for discussion
 		// upsertErr := UpsertDeploymentRevision(ctx, deployment, r.RevisionManager)
 		// if upsertErr != nil {
 		//	log.Info(fmt.Sprintf("fail to upsert deployment revision. Proceeding with deployment. Error: %+v", upsertErr))

--- a/go/components/deployment/controller.go
+++ b/go/components/deployment/controller.go
@@ -268,8 +268,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, metrics *Co
 		log.Info(message)
 		deployment.Status.Stage = stage
 		terminal := r.handleStageTransition(ctx, metrics, deployment, err)
-		// Simplified: Skip revision management for now
-		// TODO(#534): Decision needed on deployment revision management:
+		// TODO(#534): Enable these once revision codes are migrated:
 		// - Either implement UpsertDeploymentRevision properly with full error handling
 		// - Or permanently remove revision management infrastructure if not needed
 		// - See issue #534 for discussion

--- a/go/components/spark/job/module.go
+++ b/go/components/spark/job/module.go
@@ -19,7 +19,6 @@ func register(
 	mgr manager.Manager,
 	sparkClient Client,
 ) error {
-	//restConfig := mgr.GetConfig()
 	// Create SparkApplication client
 	return (&Reconciler{
 		Client:      mgr.GetClient(),


### PR DESCRIPTION
## Summary

This PR addresses commented-out dead code in component controllers as part of fixing issue #503 (Go code quality - Commented-Out Code). This is **Group 1 of 2** PRs that address commented code instances across the codebase.

**Scope**: Component controllers (Spark and Deployment)

## Changes Made

### 1. `components/spark/job/module.go` (Line 22)

**Removed**:
```go
//restConfig := mgr.GetConfig()
```

**Reason**: This variable assignment was commented out and never used. The `restConfig` variable is not referenced anywhere in the `register()` function. The descriptive comment "Create SparkApplication client" has been preserved to maintain code documentation.

**Context**: The `register()` function creates and registers a Spark job reconciler. The restConfig was likely from an earlier implementation but is no longer needed since the reconciler only requires the client, spark client, and environment.

### 2. `components/deployment/controller.go` (Lines 272-279)

**Added TODO comment** with issue tracking:
```go
// Simplified: Skip revision management for now
// TODO(#534): Decision needed on deployment revision management:
// - Either implement UpsertDeploymentRevision properly with full error handling
// - Or permanently remove revision management infrastructure if not needed
// - See issue #534 for discussion
// upsertErr := UpsertDeploymentRevision(ctx, deployment, r.RevisionManager)
// if upsertErr != nil {
//	log.Info(fmt.Sprintf("fail to upsert deployment revision. Proceeding with deployment. Error: %+v", upsertErr))
// }
```

**Reason**: This commented code represents intentionally disabled functionality ("Simplified: Skip revision management for now"). Rather than removing it, a TODO comment has been added referencing issue #534 to track this as technical debt requiring a decision.

**Context**: The `Reconcile()` method handles deployment stage transitions. The revision management was intentionally simplified, but it's unclear whether this is temporary or permanent. Issue #534 tracks the decision on whether to implement this feature properly or remove it permanently.

## Impact

- **Code cleanliness**: Removes 1 line of dead code (spark module)
- **Technical debt tracking**: Adds TODO(#534) to track revision management decision
- **Maintainability**: Clear tracking of intentionally disabled code vs. dead code
- **No functional changes**: Only removes dead code and adds tracking comments

## Related Issues

- #534 - Decision needed: Deployment revision management (created by this PR)
- #503 - Go code quality: Commented-Out Code (parent issue)

## Related PRs

- #533 (Group 2): Addresses commented code in worker activities and test files

## Testing

```bash
# Verify no compilation errors
go build ./components/spark/job/...
go build ./components/deployment/...

# Run existing tests
go test ./components/spark/job/...
go test ./components/deployment/...
```

## Files Changed

- `components/spark/job/module.go` - 1 line removed (dead code)
- `components/deployment/controller.go` - TODO(#534) added for technical debt tracking

---

Fixes #503 (partial - Group 1 of 2)