### PR TITLE
Remove commented-out code in worker activities and tests

### DIFF
--- a/go/worker/activities/model/model_activities.go
+++ b/go/worker/activities/model/model_activities.go
@@ -49,7 +49,6 @@ func (r *activities) GetModel(ctx context.Context, namespace string, modelName s
 
 // ModelSearch searches model by deployment name or v1 deployment tag
 func (r *activities) ModelSearch(ctx context.Context, request *ModelSearchRequest) (*ModelSearchResponse, error) {
-	// logger := activity.GetLogger(ctx)
 	logger := zap.NewNop()
 	if request.Namespace == "" || request.DeploymentName == "" {
 		return nil, fmt.Errorf("\"namespace\" and \"deployment name\" are required to perform model search")

--- a/go/worker/activities/model/model_activities_test.go
+++ b/go/worker/activities/model/model_activities_test.go
@@ -133,7 +133,6 @@ func (r *Suite) Test_ModelSearch_Failed() {
 		Namespace:      "ma-test-sandbox",
 		DeploymentName: "shadow-test",
 	})
-	// assert.NoError(r.T(), err)
 	var res *ModelSearchResponse
 	err = val.Get(&res)
 	assert.NoError(r.t, err)

--- a/go/worker/plugins/spark/starlark_module_test.go
+++ b/go/worker/plugins/spark/starlark_module_test.go
@@ -81,7 +81,6 @@ func (s *SparkModuleTestSuite) TestSensorJobSuccessfully() {
 	env := s.env.Cadence.GetTestWorkflowEnvironment()
 	env.RegisterActivity(spark.Activities.SensorSparkJob)
 
-	//var sensorJobReq v2pb.GetSparkJobRequest
 	env.OnActivity(spark.Activities.SensorSparkJob, mock.Anything, mock.Anything).
 		Return(func(ctx context.Context, req v2pb.GetSparkJobRequest) (*spark.SensorSparkJobResponse, error) {
 			// Simulate a Spark job's status condition


### PR DESCRIPTION
## Summary

This PR removes commented-out dead code from worker activities and test files as part of fixing issue #503 (Go code quality - Commented-Out Code). This is **Group 2 of 2** PRs that address all commented code instances across the codebase.

**Scope**: Worker activities and test files

## Changes Made

### 1. `worker/activities/model/model_activities.go` (Line 52)

**Removed**:
```go
// logger := activity.GetLogger(ctx)
```

**Reason**: This commented logger assignment is dead code. The function immediately assigns a no-op logger (`logger := zap.NewNop()`) on the next line, which is the active implementation. The commented line suggests there was an intention to use the activity logger from the context, but the implementation uses a no-op logger instead.

**Context**: The `ModelSearch()` activity searches for models by deployment name. The function uses `zap.NewNop()` for logging, which creates a no-operation logger that discards all logs. This is intentional behavior for this activity.

### 2. `worker/plugins/spark/starlark_module_test.go` (Line 84)

**Removed**:
```go
//var sensorJobReq v2pb.GetSparkJobRequest
```

**Reason**: This commented variable declaration is unused dead code. The test uses `mock.Anything` for the activity mock matcher instead of capturing the actual request in a typed variable. The variable was likely from an earlier test implementation but is no longer needed.

**Context**: The `TestSensorJobSuccessfully()` test verifies the Spark job sensor functionality. The test mocks the `SensorSparkJob` activity using a return function that receives the request as a parameter, making the commented variable declaration unnecessary.

### 3. `worker/activities/model/model_activities_test.go` (Line 136)

**Removed**:
```go
// assert.NoError(r.T(), err)
```

**Reason**: This commented assertion is redundant dead code. The test already has an active assertion `assert.NoError(r.t, err)` two lines below that performs the same check. The commented line uses `r.T()` (uppercase) while the active line uses `r.t` (lowercase), suggesting the comment was left during a refactoring.

**Context**: The test validates model search functionality. After executing the activity, the test checks for errors using `val.Get(&res)`, which returns an error that's properly asserted on line 138. The earlier commented assertion would have checked the error from `ExecuteActivity`, but this is not the actual error pattern being tested.

## Impact

- **Code cleanliness**: Removes 3 lines of dead code across 3 files
- **Maintainability**: Eliminates confusion about why code is commented vs. active
- **Test clarity**: Removes duplicate assertion that could confuse test intentions
- **No functional changes**: Only removes commented code; all active code remains unchanged

## Related Changes

- **Group 1 PR** (#532): Already addresses commented code in component controllers

## Testing

```bash
# Verify no compilation errors
go build ./worker/activities/model/...
go build ./worker/plugins/spark/...

# Run tests to ensure they still pass
go test ./worker/activities/model/...
go test ./worker/plugins/spark/...
```

## Files Changed

- `worker/activities/model/model_activities.go` - 1 line removed
- `worker/plugins/spark/starlark_module_test.go` - 1 line removed
- `worker/activities/model/model_activities_test.go` - 1 line removed

---

Fixes #503 (partial - Group 2 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)