### PR TITLE
Add Google Python Style Guide Claude skill

### DIFF
--- a/.claude/skills/python/google-style-guide/SKILL.md
+++ b/.claude/skills/python/google-style-guide/SKILL.md
@@ -19,9 +19,7 @@ Use this skill automatically when:
 **When Google's style guide conflicts with PEP 8, always follow PEP 8.** PEP 8 is the official Python style guide and is the canonical source for Python coding conventions. Google's guide extends and clarifies PEP 8 but should not override it.
 
 Common areas where conflicts may occur:
-- Line length (PEP 8: 79 chars, Google: 80-100 chars) → **Use 100 chars** (project standard)
-- Import formatting and ordering → Follow PEP 8 conventions
-- Whitespace and indentation rules → Follow PEP 8 strictly
+- Line length (PEP 8: 79 chars, Google: 80-100 chars) → **Use 99 chars** (project standard)
 
 ## Key Reminders
 

--- a/.claude/skills/python/google-style-guide/SKILL.md
+++ b/.claude/skills/python/google-style-guide/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Google Python Style Guide
+name: Google Python Style Guide (PEP 8 + Google Extensions)
 description: "Apply Python best practices, conventions, and style rules from Google's Python Style Guide. Use when writing, reviewing, or refactoring Python code to ensure clean, maintainable, and Pythonic implementations."
 ---
 
@@ -19,7 +19,7 @@ Use this skill automatically when:
 **When Google's style guide conflicts with PEP 8, always follow PEP 8.** PEP 8 is the official Python style guide and is the canonical source for Python coding conventions. Google's guide extends and clarifies PEP 8 but should not override it.
 
 Common areas where conflicts may occur:
-- Line length (PEP 8: 79 chars, Google: 80-100 chars) → **Use 99 chars** (project standard)
+- Line length (PEP 8: 79 chars, Google: 80-100 chars) → **Use Google style** (project standard)
 
 ## Key Reminders
 
@@ -30,7 +30,6 @@ Follow the conventions and patterns documented at https://google.github.io/style
 - Use `from x import y` where `x` is the package prefix and `y` is the module name with no prefix.
 - Import each module using the full pathname location
 - Avoid `from module import *`
-- Would we add this too?
 - Order: standard library, third-party, local application imports
 
 ### Naming Conventions
@@ -62,7 +61,7 @@ Follow the conventions and patterns documented at https://google.github.io/style
   ```
 
 ### Type Annotations
-- Use type hints for function signatures (Python 3.5+)
+- Use type hints for function signatures (Python 3.9+)
 - Annotate public APIs
 - Use `typing` module for complex types
 - Prefer specific types over `Any`

--- a/.claude/skills/python/google-style-guide/SKILL.md
+++ b/.claude/skills/python/google-style-guide/SKILL.md
@@ -27,8 +27,10 @@ Follow the conventions and patterns documented at https://google.github.io/style
 
 ### Imports
 - Use `import` statements for packages and modules only
+- Use `from x import y` where `x` is the package prefix and `y` is the module name with no prefix.
 - Import each module using the full pathname location
 - Avoid `from module import *`
+- Would we add this too?
 - Order: standard library, third-party, local application imports
 
 ### Naming Conventions

--- a/.claude/skills/python/google-style-guide/SKILL.md
+++ b/.claude/skills/python/google-style-guide/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: Google Python Style Guide
+description: "Apply Python best practices, conventions, and style rules from Google's Python Style Guide. Use when writing, reviewing, or refactoring Python code to ensure clean, maintainable, and Pythonic implementations."
+---
+
+# Google Python Style Guide
+
+Apply best practices and conventions from the official [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html) to write clean, idiomatic Python code.
+
+## When to Apply
+
+Use this skill automatically when:
+- Writing new Python code
+- Reviewing Python code
+- Refactoring existing Python implementations
+
+## Important: PEP 8 Takes Precedence
+
+**When Google's style guide conflicts with PEP 8, always follow PEP 8.** PEP 8 is the official Python style guide and is the canonical source for Python coding conventions. Google's guide extends and clarifies PEP 8 but should not override it.
+
+Common areas where conflicts may occur:
+- Line length (PEP 8: 79 chars, Google: 80-100 chars) → **Use 100 chars** (project standard)
+- Import formatting and ordering → Follow PEP 8 conventions
+- Whitespace and indentation rules → Follow PEP 8 strictly
+
+## Key Reminders
+
+Follow the conventions and patterns documented at https://google.github.io/styleguide/pyguide.html, with particular attention to:
+
+### Imports
+- Use `import` statements for packages and modules only
+- Import each module using the full pathname location
+- Avoid `from module import *`
+- Order: standard library, third-party, local application imports
+
+### Naming Conventions
+- `module_name`, `package_name`, `ClassName`, `method_name`, `ExceptionName`
+- `function_name`, `GLOBAL_CONSTANT_NAME`, `global_var_name`, `instance_var_name`
+- `function_parameter_name`, `local_var_name`
+- Single leading underscore `_` for internal use
+- Avoid single letter names except for counters/iterators
+
+### Documentation
+- Use docstrings for all public modules, functions, classes, and methods
+- Follow Google docstring format with Args, Returns, Raises sections
+- First line should be a one-line summary
+- Example:
+  ```python
+  def fetch_data(source: str, limit: int = 100) -> list[dict]:
+      """Fetches data from the specified source.
+
+      Args:
+          source: The data source URL or path.
+          limit: Maximum number of records to fetch.
+
+      Returns:
+          A list of dictionaries containing the fetched data.
+
+      Raises:
+          ValueError: If source is empty or invalid.
+      """
+  ```
+
+### Type Annotations
+- Use type hints for function signatures (Python 3.5+)
+- Annotate public APIs
+- Use `typing` module for complex types
+- Prefer specific types over `Any`
+
+### Error Handling
+- Use specific exceptions, not bare `except:`
+- Minimize code in `try/except` blocks
+- Use `finally` for cleanup actions
+- Prefer standard exceptions over custom ones
+
+### Code Organization
+- Maximum line length: 100 characters (Google standard, per project configuration)
+- Use 4 spaces for indentation (never tabs)
+- Two blank lines between top-level definitions
+- One blank line between method definitions
+
+### Best Practices
+- **Comprehensions**: Use for simple cases; avoid complex nested comprehensions
+- **Generators**: Prefer generators over lists for large datasets
+- **Lambda**: Use only for one-liners; use `def` for anything more complex
+- **Default Arguments**: Never use mutable objects as default values
+- **Properties**: Use `@property` for accessing/setting attributes with logic
+- **Context Managers**: Use `with` statements for resource management
+- **String Formatting**: Prefer f-strings (Python 3.6+) or `str.format()`
+
+### Anti-Patterns to Avoid
+- Global variables (except constants)
+- Mutable default arguments: `def foo(x=[]):` ❌
+- Wildcard imports: `from module import *` ❌
+- Bare except clauses: `except:` ❌
+- Using deprecated features (e.g., `%` string formatting)
+
+## References
+
+- Official Guide: https://google.github.io/styleguide/pyguide.html
+- PEP 8: https://peps.python.org/pep-0008/
+- Python Documentation: https://docs.python.org/3/


### PR DESCRIPTION
## Summary

Adds a comprehensive Claude skill for Python development following Google Python Style Guide with PEP 8 compliance.

**What's included:**
- Claude skill configuration (`.claude/skills/python/google-style-guide/SKILL.md`)
- Auto-activation when writing, reviewing, or refactoring Python code
- Google Python Style Guide conventions with clear PEP 8 precedence rules
- Project-specific configuration: 100-character line length

## Key Features

### Style Guide Enforcement
- **Imports**: Organization and ordering best practices
- **Naming**: Standard Python naming conventions (`module_name`, `ClassName`, etc.)
- **Documentation**: Google-style docstrings with Args/Returns/Raises sections
- **Type Annotations**: Modern type hinting guidelines
- **Error Handling**: Specific exceptions and proper try/except usage
- **Code Organization**: 100-char line length, 4-space indentation

### PEP 8 Precedence
When Google's guide conflicts with PEP 8, the skill enforces PEP 8 conventions, with the exception of:
- Line length: Uses 100 characters (project standard vs PEP 8's 79)

### Best Practices Covered
- List/dict comprehensions (simple cases only)
- Generators for large datasets
- Lambda functions (one-liners only)
- Context managers with `with` statements
- f-strings for formatting
- Anti-patterns to avoid (mutable defaults, wildcard imports, etc.)

## Integration with Code Quality Initiative

This skill supports the Python Code Quality Improvement Proposal documented in `tmp/michelangelo-docs/python/PYTHON_CODE_QUALITY_PROPOSAL.md` by:

1. Providing AI-assisted guidance during development
2. Enforcing consistent style across the codebase
3. Educating developers on Python best practices
4. Complementing automated tools (Ruff, mypy, pre-commit hooks)

## Usage

The skill automatically applies when:
- Writing new Python code
- Reviewing Python code in PRs
- Refactoring existing Python implementations

Developers can reference it at: `.claude/skills/python/google-style-guide/SKILL.md`

## Test Plan

- [x] Skill file properly formatted and placed in `.claude/skills/python/`
- [x] References Google Python Style Guide
- [x] Includes PEP 8 reference and precedence rules
- [x] 100-character line length configuration documented
- [x] Commit message references issue #525

## Benefits

- Consistency: Standardized Python code style across team
- Quality: Early detection of anti-patterns and style issues
- Efficiency: Reduced time in code reviews discussing style
- Onboarding: Clear, accessible style guide for new developers

Closes #525