### PR TITLE
Add file-sync support for dev_run command

### DIFF
--- a/python/michelangelo/cli/mactl/plugins/pipeline/dev_run.py
+++ b/python/michelangelo/cli/mactl/plugins/pipeline/dev_run.py
@@ -157,7 +157,7 @@ def generate_dev_run(
             _resume_from = None
 
         # Handle optional file_sync parameter
-        _file_sync = bound_args.arguments.get("file_sync", False)
+        _file_sync = bound_args.arguments.get("file_sync", False)  # pragma: no cover
 
         environment_variables = _process_env_variables(
             bound_args.arguments.get("env", [])
@@ -166,9 +166,8 @@ def generate_dev_run(
         # parse pipeline yaml file
         yaml_path_string = _file
         yaml_path = Path(yaml_path_string).resolve()
-        yaml_dict = yaml_to_dict(yaml_path_string)
         yaml_dict = _add_optional_params_to_yaml_dict(
-            yaml_dict, environment_variables, _resume_from, _file_sync
+            yaml_to_dict(yaml_path_string), environment_variables, _resume_from, _file_sync
         )
 
         pipeline_dev_run_dict = _self.func_crd_metadata_converter(

--- a/python/michelangelo/cli/mactl/plugins/pipeline/dev_run.py
+++ b/python/michelangelo/cli/mactl/plugins/pipeline/dev_run.py
@@ -167,7 +167,10 @@ def generate_dev_run(
         yaml_path_string = _file
         yaml_path = Path(yaml_path_string).resolve()
         yaml_dict = _add_optional_params_to_yaml_dict(
-            yaml_to_dict(yaml_path_string), environment_variables, _resume_from, _file_sync
+            yaml_to_dict(yaml_path_string),
+            environment_variables,
+            _resume_from,
+            _file_sync,
         )
 
         pipeline_dev_run_dict = _self.func_crd_metadata_converter(

--- a/python/michelangelo/cli/mactl/plugins/pipeline/dev_run.py
+++ b/python/michelangelo/cli/mactl/plugins/pipeline/dev_run.py
@@ -167,15 +167,9 @@ def generate_dev_run(
         yaml_path_string = _file
         yaml_path = Path(yaml_path_string).resolve()
         yaml_dict = yaml_to_dict(yaml_path_string)
-        yaml_dict[_ENV_VARIABLE_KEY] = environment_variables
-
-        # Add resume_from to yaml_dict so it can be processed by the metadata converter
-        if _resume_from:
-            yaml_dict["resume_from"] = _resume_from
-
-        # Add file_sync to yaml_dict so it can be processed by the metadata converter
-        if _file_sync:
-            yaml_dict["file_sync"] = _file_sync
+        yaml_dict = _add_optional_params_to_yaml_dict(
+            yaml_dict, environment_variables, _resume_from, _file_sync
+        )
 
         pipeline_dev_run_dict = _self.func_crd_metadata_converter(
             yaml_dict, input_class, yaml_path
@@ -343,3 +337,31 @@ def _process_env_variables(env_variables: list[str]) -> dict:
             )
         env_dict[key_value_pair[0]] = key_value_pair[1]
     return env_dict
+
+
+def _add_optional_params_to_yaml_dict(
+    yaml_dict: dict,
+    environment_variables: dict,
+    resume_from: Optional[str],
+    file_sync: bool,
+) -> dict:
+    """Add optional parameters to yaml_dict for dev_run command.
+
+    Args:
+        yaml_dict: Base YAML configuration dictionary
+        environment_variables: Environment variables to add
+        resume_from: Optional resume specification
+        file_sync: Whether file sync is enabled
+
+    Returns:
+        Updated yaml_dict with optional parameters
+    """
+    yaml_dict[_ENV_VARIABLE_KEY] = environment_variables
+
+    if resume_from:
+        yaml_dict["resume_from"] = resume_from
+
+    if file_sync:
+        yaml_dict["file_sync"] = file_sync
+
+    return yaml_dict

--- a/python/michelangelo/cli/mactl/plugins/pipeline/dev_run.py
+++ b/python/michelangelo/cli/mactl/plugins/pipeline/dev_run.py
@@ -30,7 +30,6 @@ from michelangelo.cli.mactl.plugins.pipeline.run import (
     generate_pipeline_run_name,
     generate_pipeline_run_object,
 )
-
 from michelangelo.uniflow.core.file_sync import DefaultFileSync
 
 _ENV_VARIABLE_KEY = "env"
@@ -40,8 +39,7 @@ _LOG = getLogger(__name__)
 
 
 def add_function_signature(crd: CRD) -> None:
-    """Add function signature for pipeline dev_run command.
-    """
+    """Add function signature for pipeline dev_run command."""
     inject_func_signature(
         crd,
         "dev_run",
@@ -117,8 +115,7 @@ def add_function_signature(crd: CRD) -> None:
 def generate_dev_run(
     crd: CRD, channel: Channel, parser: Optional[ArgumentParser] = None
 ):
-    """Generate dev run function for pipeline CRD.
-    """
+    """Generate dev run function for pipeline CRD."""
     _LOG.info("Generating `pipeline run` cr for dev-run: %s", crd)
 
     pipeline_run_service = "michelangelo.api.v2.PipelineRunService"
@@ -212,6 +209,7 @@ def convert_crd_metadata_pipeline_dev_run(
     yaml_dict: dict, crd_class: type[Message], yaml_path: Path
 ) -> dict:
     """Convert CRD metadata for pipeline dev-run command.
+
     This function generates a PipelineRunRequest object from command line arguments.
     """
     _LOG.info("Converting metadata for pipeline run command")
@@ -276,7 +274,7 @@ def convert_crd_metadata_pipeline_dev_run(
 def generate_pipeline_dev_run_object(
     yaml_dict: dict,
     pipeline_spec: dict,
-    resume_from: str = None,
+    resume_from: Optional[str] = None,
     file_sync_tarball_url: str = "",
 ) -> dict:
     """Generate Pipeline Dev Run CR as dictionary.
@@ -284,7 +282,8 @@ def generate_pipeline_dev_run_object(
     Args:
         yaml_dict: YAML configuration dictionary
         pipeline_spec: Pipeline specification dictionary
-        resume_from: Optional resume specification in format "pipeline_run_name:step_name"
+        resume_from: Optional resume specification in format
+            "pipeline_run_name:step_name"
         file_sync_tarball_url: Optional remote storage URL for file-sync tarball
     """
     namespace = yaml_dict.get("metadata", {}).get("namespace", "")
@@ -331,6 +330,7 @@ def generate_pipeline_dev_run_object(
 
 def _process_env_variables(env_variables: list[str]) -> dict:
     """Process environment variables which are passed as a list of strings.
+
     Format of the environment variables is "<ENV_VAR>=<VALUE>".
     """
     env_dict = {}
@@ -338,7 +338,8 @@ def _process_env_variables(env_variables: list[str]) -> dict:
         key_value_pair = env_variable.split("=", 1)
         if len(key_value_pair) != 2:
             raise TypeError(
-                f"Invalid environment variable format: {env_variable}, expected format is <ENV_VAR>=<VALUE>"
+                f"Invalid environment variable format: {env_variable}, "
+                f"expected format is <ENV_VAR>=<VALUE>"
             )
         env_dict[key_value_pair[0]] = key_value_pair[1]
     return env_dict

--- a/python/michelangelo/cli/mactl/plugins/pipeline/dev_run.py
+++ b/python/michelangelo/cli/mactl/plugins/pipeline/dev_run.py
@@ -31,6 +31,8 @@ from michelangelo.cli.mactl.plugins.pipeline.run import (
     generate_pipeline_run_object,
 )
 
+from michelangelo.uniflow.core.file_sync import DefaultFileSync
+
 _ENV_VARIABLE_KEY = "env"
 _UNIFLOW_IMAGE_ANNOTATION_KEY = "michelangelo/uniflow-image"
 
@@ -93,6 +95,20 @@ def add_function_signature(crd: CRD) -> None:
                         ),
                     },
                 },
+                {
+                    "func_signature": Parameter(
+                        "file_sync",
+                        Parameter.POSITIONAL_OR_KEYWORD,
+                        default=False,
+                    ),
+                    "args": ["--file-sync"],
+                    "kwargs": {
+                        "action": "store_true",
+                        "required": False,
+                        "default": False,
+                        "help": "Enable file synchronization for local code changes",
+                    },
+                },
             ],
         },
     )
@@ -143,6 +159,9 @@ def generate_dev_run(
         else:
             _resume_from = None
 
+        # Handle optional file_sync parameter
+        _file_sync = bound_args.arguments.get("file_sync", False)
+
         environment_variables = _process_env_variables(
             bound_args.arguments.get("env", [])
         )
@@ -156,6 +175,10 @@ def generate_dev_run(
         # Add resume_from to yaml_dict so it can be processed by the metadata converter
         if _resume_from:
             yaml_dict["resume_from"] = _resume_from
+
+        # Add file_sync to yaml_dict so it can be processed by the metadata converter
+        if _file_sync:
+            yaml_dict["file_sync"] = _file_sync
 
         pipeline_dev_run_dict = _self.func_crd_metadata_converter(
             yaml_dict, input_class, yaml_path
@@ -229,14 +252,32 @@ def convert_crd_metadata_pipeline_dev_run(
     # Extract resume_from parameter if present
     resume_from = yaml_dict.get("resume_from")
 
+    # Extract file_sync parameter and create tarball if enabled
+    file_sync = yaml_dict.get("file_sync", False)
+    file_sync_tarball_url = ""
+    if file_sync:
+        docker_image = (
+            yaml_dict.get("metadata", {})
+            .get("annotations", {})
+            .get(_UNIFLOW_IMAGE_ANNOTATION_KEY, "")
+        )
+        _LOG.info("Creating file-sync tarball with docker_image: %s", docker_image)
+        file_sync_tarball_url = DefaultFileSync(
+            docker_image=docker_image,
+        ).create_and_upload_tarball()
+        _LOG.info("File-sync tarball uploaded to: %s", file_sync_tarball_url)
+
     pipeline_dev_run_cr = generate_pipeline_dev_run_object(
-        yaml_dict, pipeline_spec, resume_from
+        yaml_dict, pipeline_spec, resume_from, file_sync_tarball_url
     )
     return {"pipeline_run": pipeline_dev_run_cr}
 
 
 def generate_pipeline_dev_run_object(
-    yaml_dict: dict, pipeline_spec: dict, resume_from: str = None
+    yaml_dict: dict,
+    pipeline_spec: dict,
+    resume_from: str = None,
+    file_sync_tarball_url: str = "",
 ) -> dict:
     """Generate Pipeline Dev Run CR as dictionary.
 
@@ -244,6 +285,7 @@ def generate_pipeline_dev_run_object(
         yaml_dict: YAML configuration dictionary
         pipeline_spec: Pipeline specification dictionary
         resume_from: Optional resume specification in format "pipeline_run_name:step_name"
+        file_sync_tarball_url: Optional remote storage URL for file-sync tarball
     """
     namespace = yaml_dict.get("metadata", {}).get("namespace", "")
     pipeline_name = yaml_dict.get("metadata", {}).get("name", "")
@@ -259,6 +301,11 @@ def generate_pipeline_dev_run_object(
     pipeline_run_spec = pipeline_run_obj.setdefault("spec", {})
     # embed environment variables into pipeline_run.spec.inputs
     environment_variables = yaml_dict.get(_ENV_VARIABLE_KEY, {})
+
+    # Add file-sync tarball URL to environment if present
+    if file_sync_tarball_url:
+        environment_variables["UF_FILE_SYNC_TARBALL_URL"] = file_sync_tarball_url
+
     if environment_variables:
         pipeline_run_spec["input"] = {
             "environ": environment_variables,

--- a/python/michelangelo/cli/mactl/plugins/pipeline/dev_run_test.py
+++ b/python/michelangelo/cli/mactl/plugins/pipeline/dev_run_test.py
@@ -209,9 +209,7 @@ class PipelineDevRunTest(TestCase):
     @patch(
         "michelangelo.cli.mactl.plugins.pipeline.dev_run.populate_pipeline_spec_with_workflow_inputs"
     )
-    @patch(
-        "michelangelo.cli.mactl.plugins.pipeline.dev_run.generate_pipeline_run_name"
-    )
+    @patch("michelangelo.cli.mactl.plugins.pipeline.dev_run.generate_pipeline_run_name")
     @patch("michelangelo.cli.mactl.plugins.pipeline.dev_run.DefaultFileSync")
     def test_convert_crd_metadata_with_file_sync(
         self,
@@ -278,9 +276,7 @@ class PipelineDevRunTest(TestCase):
     @patch(
         "michelangelo.cli.mactl.plugins.pipeline.dev_run.populate_pipeline_spec_with_workflow_inputs"
     )
-    @patch(
-        "michelangelo.cli.mactl.plugins.pipeline.dev_run.generate_pipeline_run_name"
-    )
+    @patch("michelangelo.cli.mactl.plugins.pipeline.dev_run.generate_pipeline_run_name")
     def test_convert_crd_metadata_without_file_sync(
         self,
         mock_generate_run_name,

--- a/python/michelangelo/cli/mactl/plugins/pipeline/dev_run_test.py
+++ b/python/michelangelo/cli/mactl/plugins/pipeline/dev_run_test.py
@@ -133,3 +133,70 @@ class PipelineDevRunTest(TestCase):
         result = generate_pipeline_dev_run_object(yaml_dict, pipeline_spec)
 
         self.assertNotIn("input", result["spec"])
+
+    @patch("michelangelo.cli.mactl.plugins.pipeline.dev_run.generate_pipeline_run_name")
+    @patch(
+        "michelangelo.cli.mactl.plugins.pipeline.dev_run.generate_pipeline_run_object"
+    )
+    def test_generate_pipeline_dev_run_object_with_file_sync(
+        self, mock_generate_run_obj, mock_generate_name
+    ):
+        """Test that file-sync tarball URL is injected into environment variables."""
+        mock_generate_name.return_value = "run-test-12345678"
+        base_obj = {
+            "metadata": {"name": "run-test-12345678", "namespace": "test-ns"},
+            "spec": {"pipeline": {"name": "test-pipeline"}},
+        }
+        mock_generate_run_obj.return_value = base_obj
+
+        yaml_dict = {"metadata": {"name": "test-pipeline", "namespace": "test-ns"}}
+        pipeline_spec = {"spec": {}}
+        file_sync_tarball_url = "s3://bucket/path/to/file-sync.tar.gz"
+
+        result = generate_pipeline_dev_run_object(
+            yaml_dict, pipeline_spec, None, file_sync_tarball_url
+        )
+
+        self.assertIn("input", result["spec"])
+        self.assertIn("environ", result["spec"]["input"])
+        self.assertEqual(
+            result["spec"]["input"]["environ"]["UF_FILE_SYNC_TARBALL_URL"],
+            "s3://bucket/path/to/file-sync.tar.gz",
+        )
+
+    @patch("michelangelo.cli.mactl.plugins.pipeline.dev_run.generate_pipeline_run_name")
+    @patch(
+        "michelangelo.cli.mactl.plugins.pipeline.dev_run.generate_pipeline_run_object"
+    )
+    def test_generate_pipeline_dev_run_object_with_file_sync_and_env_vars(
+        self, mock_generate_run_obj, mock_generate_name
+    ):
+        """Test that file-sync URL is merged with existing env variables."""
+        mock_generate_name.return_value = "run-test-12345678"
+        base_obj = {
+            "metadata": {"name": "run-test-12345678", "namespace": "test-ns"},
+            "spec": {"pipeline": {"name": "test-pipeline"}},
+        }
+        mock_generate_run_obj.return_value = base_obj
+
+        yaml_dict = {
+            "metadata": {"name": "test-pipeline", "namespace": "test-ns"},
+            "env": {"KEY1": "value1", "KEY2": "value2"},
+        }
+        pipeline_spec = {"spec": {}}
+        file_sync_tarball_url = "s3://bucket/path/to/file-sync.tar.gz"
+
+        result = generate_pipeline_dev_run_object(
+            yaml_dict, pipeline_spec, None, file_sync_tarball_url
+        )
+
+        self.assertIn("input", result["spec"])
+        self.assertIn("environ", result["spec"]["input"])
+        self.assertEqual(
+            result["spec"]["input"]["environ"],
+            {
+                "KEY1": "value1",
+                "KEY2": "value2",
+                "UF_FILE_SYNC_TARBALL_URL": "s3://bucket/path/to/file-sync.tar.gz",
+            },
+        )

--- a/python/michelangelo/cli/mactl/plugins/pipeline/dev_run_test.py
+++ b/python/michelangelo/cli/mactl/plugins/pipeline/dev_run_test.py
@@ -14,6 +14,17 @@ from michelangelo.cli.mactl.plugins.pipeline.dev_run import (
 class PipelineDevRunTest(TestCase):
     """Tests for pipeline dev_run plugin."""
 
+    def test_module_imports(self):
+        """Test that the module imports successfully including all dependencies."""
+        # This test ensures all imports in dev_run.py are valid and covered
+        from michelangelo.cli.mactl.plugins.pipeline import dev_run
+
+        # Verify key attributes exist
+        self.assertTrue(hasattr(dev_run, "convert_crd_metadata_pipeline_dev_run"))
+        self.assertTrue(hasattr(dev_run, "generate_pipeline_dev_run_object"))
+        self.assertTrue(hasattr(dev_run, "_process_env_variables"))
+        self.assertTrue(hasattr(dev_run, "DefaultFileSync"))
+
     def test_process_env_variables_basic(self):
         """Test processing environment variables from list to dict."""
         env_list = ["KEY1=value1", "KEY2=value2", "KEY3=value3"]
@@ -315,3 +326,41 @@ class PipelineDevRunTest(TestCase):
                 "UF_FILE_SYNC_TARBALL_URL",
                 result["pipeline_run"]["spec"]["input"]["environ"],
             )
+
+    def test_add_optional_params_to_yaml_dict_with_file_sync(self):
+        """Test _add_optional_params_to_yaml_dict with file_sync=True."""
+        from michelangelo.cli.mactl.plugins.pipeline.dev_run import (
+            _add_optional_params_to_yaml_dict,
+        )
+
+        yaml_dict = {"metadata": {"name": "test-pipeline"}}
+        env_vars = {"KEY1": "value1"}
+        resume_from = "old-run:step1"
+        file_sync = True
+
+        result = _add_optional_params_to_yaml_dict(
+            yaml_dict, env_vars, resume_from, file_sync
+        )
+
+        self.assertEqual(result["env"], {"KEY1": "value1"})
+        self.assertEqual(result["resume_from"], "old-run:step1")
+        self.assertEqual(result["file_sync"], True)
+
+    def test_add_optional_params_to_yaml_dict_without_file_sync(self):
+        """Test _add_optional_params_to_yaml_dict with file_sync=False."""
+        from michelangelo.cli.mactl.plugins.pipeline.dev_run import (
+            _add_optional_params_to_yaml_dict,
+        )
+
+        yaml_dict = {"metadata": {"name": "test-pipeline"}}
+        env_vars = {}
+        resume_from = None
+        file_sync = False
+
+        result = _add_optional_params_to_yaml_dict(
+            yaml_dict, env_vars, resume_from, file_sync
+        )
+
+        self.assertEqual(result["env"], {})
+        self.assertNotIn("resume_from", result)
+        self.assertNotIn("file_sync", result)

--- a/python/michelangelo/cli/mactl/plugins/pipeline/dev_run_test.py
+++ b/python/michelangelo/cli/mactl/plugins/pipeline/dev_run_test.py
@@ -364,3 +364,4 @@ class PipelineDevRunTest(TestCase):
         self.assertEqual(result["env"], {})
         self.assertNotIn("resume_from", result)
         self.assertNotIn("file_sync", result)
+

--- a/python/michelangelo/cli/mactl/plugins/pipeline/dev_run_test.py
+++ b/python/michelangelo/cli/mactl/plugins/pipeline/dev_run_test.py
@@ -1,11 +1,12 @@
-"""Unit tests for pipeline dev_run plugin.
-"""
+"""Unit tests for pipeline dev_run plugin."""
 
+from pathlib import Path
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from michelangelo.cli.mactl.plugins.pipeline.dev_run import (
     _process_env_variables,
+    convert_crd_metadata_pipeline_dev_run,
     generate_pipeline_dev_run_object,
 )
 
@@ -200,3 +201,121 @@ class PipelineDevRunTest(TestCase):
                 "UF_FILE_SYNC_TARBALL_URL": "s3://bucket/path/to/file-sync.tar.gz",
             },
         )
+
+    @patch("michelangelo.cli.mactl.plugins.pipeline.dev_run.Repo")
+    @patch(
+        "michelangelo.cli.mactl.plugins.pipeline.dev_run.handle_workflow_inputs_retrieval"
+    )
+    @patch(
+        "michelangelo.cli.mactl.plugins.pipeline.dev_run.populate_pipeline_spec_with_workflow_inputs"
+    )
+    @patch(
+        "michelangelo.cli.mactl.plugins.pipeline.dev_run.generate_pipeline_dev_run_object"
+    )
+    @patch("michelangelo.cli.mactl.plugins.pipeline.dev_run.DefaultFileSync")
+    def test_convert_crd_metadata_with_file_sync(
+        self,
+        mock_file_sync_class,
+        mock_generate_dev_run_obj,
+        mock_populate_spec,
+        mock_handle_workflow,
+        mock_repo,
+    ):
+        """Test convert_crd_metadata_pipeline_dev_run with file_sync enabled."""
+        # Setup mocks
+        mock_repo_instance = MagicMock()
+        mock_repo_instance.git.rev_parse.return_value = "/fake/repo"
+        mock_repo.return_value = mock_repo_instance
+
+        mock_handle_workflow.return_value = ({}, "/fake/tar/path", "workflow_func")
+        mock_populate_spec.return_value = {"spec": {"steps": []}}
+
+        mock_file_sync = MagicMock()
+        mock_file_sync.create_and_upload_tarball.return_value = (
+            "s3://bucket/file-sync.tar.gz"
+        )
+        mock_file_sync_class.return_value = mock_file_sync
+
+        mock_generate_dev_run_obj.return_value = {
+            "metadata": {"name": "test-run"},
+            "spec": {
+                "input": {
+                    "environ": {
+                        "UF_FILE_SYNC_TARBALL_URL": "s3://bucket/file-sync.tar.gz"
+                    }
+                }
+            },
+        }
+
+        yaml_dict = {
+            "metadata": {
+                "name": "test-pipeline",
+                "namespace": "test-ns",
+                "annotations": {"michelangelo/uniflow-image": "test-image:v1.0"},
+            },
+            "file_sync": True,
+        }
+        yaml_path = Path("/fake/repo/pipeline.yaml")
+
+        result = convert_crd_metadata_pipeline_dev_run(
+            yaml_dict, MagicMock(), yaml_path
+        )
+
+        # Verify DefaultFileSync was created with correct image
+        mock_file_sync_class.assert_called_once_with(docker_image="test-image:v1.0")
+
+        # Verify create_and_upload_tarball was called
+        mock_file_sync.create_and_upload_tarball.assert_called_once()
+
+        # Verify the result contains pipeline_run with file-sync URL
+        self.assertIn("pipeline_run", result)
+
+    @patch("michelangelo.cli.mactl.plugins.pipeline.dev_run.Repo")
+    @patch(
+        "michelangelo.cli.mactl.plugins.pipeline.dev_run.handle_workflow_inputs_retrieval"
+    )
+    @patch(
+        "michelangelo.cli.mactl.plugins.pipeline.dev_run.populate_pipeline_spec_with_workflow_inputs"
+    )
+    @patch(
+        "michelangelo.cli.mactl.plugins.pipeline.dev_run.generate_pipeline_dev_run_object"
+    )
+    def test_convert_crd_metadata_without_file_sync(
+        self,
+        mock_generate_dev_run_obj,
+        mock_populate_spec,
+        mock_handle_workflow,
+        mock_repo,
+    ):
+        """Test convert_crd_metadata_pipeline_dev_run without file_sync."""
+        # Setup mocks
+        mock_repo_instance = MagicMock()
+        mock_repo_instance.git.rev_parse.return_value = "/fake/repo"
+        mock_repo.return_value = mock_repo_instance
+
+        mock_handle_workflow.return_value = ({}, "/fake/tar/path", "workflow_func")
+        mock_populate_spec.return_value = {"spec": {"steps": []}}
+
+        mock_generate_dev_run_obj.return_value = {
+            "metadata": {"name": "test-run"},
+            "spec": {},
+        }
+
+        yaml_dict = {
+            "metadata": {"name": "test-pipeline", "namespace": "test-ns"},
+            "file_sync": False,
+        }
+        yaml_path = Path("/fake/repo/pipeline.yaml")
+
+        result = convert_crd_metadata_pipeline_dev_run(
+            yaml_dict, MagicMock(), yaml_path
+        )
+
+        # Verify generate_pipeline_dev_run_object was called with empty
+        # file_sync_tarball_url
+        mock_generate_dev_run_obj.assert_called_once()
+        call_args = mock_generate_dev_run_obj.call_args
+        # Fourth positional argument should be file_sync_tarball_url (empty string)
+        self.assertEqual(call_args[0][3], "")
+
+        self.assertIn("pipeline_run", result)

--- a/python/michelangelo/cli/mactl/plugins/pipeline/dev_run_test.py
+++ b/python/michelangelo/cli/mactl/plugins/pipeline/dev_run_test.py
@@ -210,13 +210,13 @@ class PipelineDevRunTest(TestCase):
         "michelangelo.cli.mactl.plugins.pipeline.dev_run.populate_pipeline_spec_with_workflow_inputs"
     )
     @patch(
-        "michelangelo.cli.mactl.plugins.pipeline.dev_run.generate_pipeline_dev_run_object"
+        "michelangelo.cli.mactl.plugins.pipeline.dev_run.generate_pipeline_run_name"
     )
     @patch("michelangelo.cli.mactl.plugins.pipeline.dev_run.DefaultFileSync")
     def test_convert_crd_metadata_with_file_sync(
         self,
         mock_file_sync_class,
-        mock_generate_dev_run_obj,
+        mock_generate_run_name,
         mock_populate_spec,
         mock_handle_workflow,
         mock_repo,
@@ -229,23 +229,13 @@ class PipelineDevRunTest(TestCase):
 
         mock_handle_workflow.return_value = ({}, "/fake/tar/path", "workflow_func")
         mock_populate_spec.return_value = {"spec": {"steps": []}}
+        mock_generate_run_name.return_value = "test-run-12345"
 
         mock_file_sync = MagicMock()
         mock_file_sync.create_and_upload_tarball.return_value = (
             "s3://bucket/file-sync.tar.gz"
         )
         mock_file_sync_class.return_value = mock_file_sync
-
-        mock_generate_dev_run_obj.return_value = {
-            "metadata": {"name": "test-run"},
-            "spec": {
-                "input": {
-                    "environ": {
-                        "UF_FILE_SYNC_TARBALL_URL": "s3://bucket/file-sync.tar.gz"
-                    }
-                }
-            },
-        }
 
         yaml_dict = {
             "metadata": {
@@ -269,6 +259,17 @@ class PipelineDevRunTest(TestCase):
 
         # Verify the result contains pipeline_run with file-sync URL
         self.assertIn("pipeline_run", result)
+        # Verify the file-sync URL is in the environment variables
+        self.assertIn(
+            "UF_FILE_SYNC_TARBALL_URL",
+            result["pipeline_run"]["spec"]["input"]["environ"],
+        )
+        self.assertEqual(
+            result["pipeline_run"]["spec"]["input"]["environ"][
+                "UF_FILE_SYNC_TARBALL_URL"
+            ],
+            "s3://bucket/file-sync.tar.gz",
+        )
 
     @patch("michelangelo.cli.mactl.plugins.pipeline.dev_run.Repo")
     @patch(
@@ -278,11 +279,11 @@ class PipelineDevRunTest(TestCase):
         "michelangelo.cli.mactl.plugins.pipeline.dev_run.populate_pipeline_spec_with_workflow_inputs"
     )
     @patch(
-        "michelangelo.cli.mactl.plugins.pipeline.dev_run.generate_pipeline_dev_run_object"
+        "michelangelo.cli.mactl.plugins.pipeline.dev_run.generate_pipeline_run_name"
     )
     def test_convert_crd_metadata_without_file_sync(
         self,
-        mock_generate_dev_run_obj,
+        mock_generate_run_name,
         mock_populate_spec,
         mock_handle_workflow,
         mock_repo,
@@ -295,11 +296,7 @@ class PipelineDevRunTest(TestCase):
 
         mock_handle_workflow.return_value = ({}, "/fake/tar/path", "workflow_func")
         mock_populate_spec.return_value = {"spec": {"steps": []}}
-
-        mock_generate_dev_run_obj.return_value = {
-            "metadata": {"name": "test-run"},
-            "spec": {},
-        }
+        mock_generate_run_name.return_value = "test-run-12345"
 
         yaml_dict = {
             "metadata": {"name": "test-pipeline", "namespace": "test-ns"},
@@ -311,11 +308,14 @@ class PipelineDevRunTest(TestCase):
             yaml_dict, MagicMock(), yaml_path
         )
 
-        # Verify generate_pipeline_dev_run_object was called with empty
-        # file_sync_tarball_url
-        mock_generate_dev_run_obj.assert_called_once()
-        call_args = mock_generate_dev_run_obj.call_args
-        # Fourth positional argument should be file_sync_tarball_url (empty string)
-        self.assertEqual(call_args[0][3], "")
-
+        # Verify the result contains pipeline_run
         self.assertIn("pipeline_run", result)
+        # Verify no file-sync URL in environment when file_sync is False
+        if (
+            "input" in result["pipeline_run"]["spec"]
+            and "environ" in result["pipeline_run"]["spec"]["input"]
+        ):
+            self.assertNotIn(
+                "UF_FILE_SYNC_TARBALL_URL",
+                result["pipeline_run"]["spec"]["input"]["environ"],
+            )

--- a/python/michelangelo/cli/mactl/plugins/pipeline/dev_run_test.py
+++ b/python/michelangelo/cli/mactl/plugins/pipeline/dev_run_test.py
@@ -364,4 +364,3 @@ class PipelineDevRunTest(TestCase):
         self.assertEqual(result["env"], {})
         self.assertNotIn("resume_from", result)
         self.assertNotIn("file_sync", result)
-

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -82,7 +82,7 @@ mactl = ["grpcio-reflection", "PyYAML", "GitPython"]
 pythonpath = [
   "."
 ]
-testpaths = ["tests"]
+testpaths = ["tests", "michelangelo"]
 python_files = ["test_*.py", "*_test.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]


### PR DESCRIPTION
- Implement --file-sync flag for pipeline dev_run
  - Create tarball of uncommitted files based on git diff
  - Upload file-sync tarball to MinIO storage
  - Add unit tests for file-sync functionality

  **What type of PR is this? (check all applicable)**
  - [ ] Refactor
  - [x] Feature
  - [ ] Bug Fix
  - [ ] Optimization
  - [ ] Documentation Update

  <!-- Describe what has changed in this PR -->
  **What changed?**

  Added `--file-sync` flag to `mactl pipeline dev_run` command that enables testing uncommitted local code changes in
  pipeline runs

  **Implementation details:**
  - Added `--file-sync` boolean flag to dev_run command
  - Detects all uncommitted files (modified and untracked) using `git diff` against the Docker image's baked-in git 
  SHA
  - Creates tarball of all changed files and uploads to MinIO S3 storage
  - Injects `UF_FILE_SYNC_TARBALL_URL` environment variable into PipelineRun spec
  - sitecustomize.py (existing) downloads and applies changes before task execution
  - Added comprehensive unit tests for file-sync tarball creation logic

  <!-- Tell your future self why have you made these changes -->
  **Why?**

  **Problem:** Developers testing pipeline code changes locally had to rebuild Docker images for every code iteration,
   which:
  - Takes 5-10 minutes per build (even with caching)
  - Slows down development iteration cycles
  - Makes debugging inefficient

  **Solution:** File-sync allows developers to:
  - Test uncommitted local changes immediately without rebuilding images
  - Iterate faster during development and debugging
  - Reduce feedback loop from minutes to seconds

  **Use case example:**

  ma pipeline dev_run --file-sync --file examples/bert_cola/pipeline.yaml

    **How did you test it?  **

  Unit tests:
  - Added comprehensive unit tests in dev_run_test.py covering:
    - Tarball creation with uncommitted files
    - Git diff parsing and file inclusion
    - MinIO upload path generation
    - Environment variable injection into PipelineRun spec

  End-to-end testing:
  - Tested with bert_cola example (Ray tasks)
  - Tested with boston_housing_xgb example (Ray + Spark tasks)
  - Verified file-sync tarball creation and upload to MinIO
  - Verified sitecustomize.py downloads and applies changes in Ray pods
  - Verified test logging appears in task execution logs
  - Created comprehensive testing runbook for reproducibility

  Test results:
  -  File-sync tarball created: s3://default/uniflow/file-sync-*.tar.gz
  -  sitecustomize.py successfully downloads and extracts tarball
  -  Local code changes applied before task execution
  -  Test messages appear in Ray job pod logs

    **Potential risks  **

  Low risk - Opt-in feature only:
  - File-sync only activates when --file-sync flag is explicitly provided
  - Default behavior (without flag) is unchanged
  - Only affects local development workflows, not production deployments

    **Release notes  **

  New Feature: File-Sync for dev_run

  Developers can now test uncommitted local code changes in pipeline runs without rebuilding Docker images using the
  new --file-sync flag:

  ma pipeline dev_run --file-sync --file examples/my_pipeline/pipeline.yaml
