### PR TITLE
Connect to control plane minio storage in compute cluster instead of creating a separate storage in compute cluster

### DIFF
--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -781,19 +781,13 @@ def _create_compute_cluster(cluster_name: str):
     - KubeRay operator for managing Ray clusters
     - RBAC permissions for ray-manager service account
 
-    Storage Components (required for Ray jobs):
-    TODO: remove this once we have a proper way to handle multicluster Object
-    store access. Multi Cluster Logging & Monitoring.
-    - MinIO object storage (accessible on ports 9190-9191)
+    Storage Configuration (required for Ray jobs):
     - michelangelo-config ConfigMap (S3 endpoint and credentials)
     - aws-credentials Secret (for AWS CLI access)
-    - S3 buckets: 'default' and 'logs'
 
     Network Configuration:
     - Ray client port: 10001
     - Ray dashboard: 8265
-    - MinIO API: 9191 (mapped from 30007 in cluster)
-    - MinIO Console: 9190 (mapped from 30008 in cluster)
 
     Note: Ray pods reference the michelangelo-config ConfigMap via envFrom,
     which is why storage must be set up in the compute cluster.
@@ -810,23 +804,15 @@ def _create_compute_cluster(cluster_name: str):
         "1",
         "--agents",
         "2",  # More worker nodes for Ray
-        # Don't switch kubectl context to this cluster
-        "--kubeconfig-switch-context=false",
+        "--kubeconfig-switch-context=false",  # Don't switch kubectl context
+        "--network",
+        f"k3d-{_michelangelo_sandbox_kube_cluster_name}",
+        # Use the same network as the control plane
     ]
 
     # Add port mappings for Ray
     for p in _ray_ports:
         args += ["-p", f"{p}@agent:0"]
-
-    # Add MinIO ports for the compute cluster
-    args += [
-        "-p",
-        "9191:30007@agent:0",
-    ]  # MinIO API (using different host port to avoid conflict)
-    args += [
-        "-p",
-        "9190:30008@agent:0",
-    ]  # MinIO Console (using different host port to avoid conflict)
 
     _exec(*args)
 
@@ -848,71 +834,46 @@ def _create_compute_cluster(cluster_name: str):
         "20m",
     )
 
-    # Deploy MinIO in compute cluster
-    _deploy_minio_to_cluster(cluster_name)
-
-    # Create michelangelo-config ConfigMap
-    _create_config_in_cluster(cluster_name)
+    # Create michelangelo-config ConfigMap pointing to control plane's MinIO
+    _create_config_in_compute_cluster(cluster_name)
 
     # Create aws-credentials Secret
     _create_aws_credentials_in_cluster(cluster_name)
 
-    # Setup S3 buckets
-    _setup_buckets_in_cluster(cluster_name)
-
-    # Wait for all resources to be ready
-    _exec(
-        "kubectl",
-        "--context",
-        f"k3d-{cluster_name}",
-        "wait",
-        "--all",
-        "pods",
-        "--for=condition=ready",
-        "--selector=!job-name",
-        "--timeout=600s",
-    )
-    # Wait for bucket setup job to complete
-    _exec(
-        "kubectl",
-        "--context",
-        f"k3d-{cluster_name}",
-        "wait",
-        "--all",
-        "jobs",
-        "--for=condition=complete",
-        "--timeout=600s",
-    )
-
     print(
-        f"\nJobs cluster '{cluster_name}' created successfully with MinIO "
-        "and configurations."
+        f"\nJobs cluster '{cluster_name}' created successfully "
+        "configured to use control plane storage."
     )
 
 
-def _deploy_minio_to_cluster(cluster_name: str):
-    """Deploy MinIO to the compute cluster."""
-    _exec(
-        "kubectl",
-        "--context",
-        f"k3d-{cluster_name}",
-        "apply",
-        "-f",
-        str(_dir / "resources" / "minio.yaml"),
-    )
-    print(f"Deployed MinIO to cluster '{cluster_name}'")
-
-
-def _create_config_in_cluster(cluster_name: str):
+def _create_config_in_compute_cluster(cluster_name: str):
     """Create michelangelo-config ConfigMap in compute cluster."""
-    _exec(
-        "kubectl",
-        "--context",
-        f"k3d-{cluster_name}",
-        "apply",
-        "-f",
-        str(_dir / "resources" / "michelangelo-config.yaml"),
-    )
+    config_path = _dir / "resources" / "michelangelo-config.yaml"
+
+    with open(config_path) as f:
+        config_data = yaml.safe_load(f)
+
+    # Update MinIO endpoint to point to the control plane's MinIO within the shared
+    # network k3d-michelangelo-sandbox-agent-0 is the hostname of the control plane's
+    # agent node. 30007 is the NodePort for MinIO API service.
+    if "data" in config_data:
+        config_data["data"]["AWS_ENDPOINT_URL"] = (
+            f"http://k3d-{_michelangelo_sandbox_kube_cluster_name}-agent-0:30007"
+        )
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml") as temp_config:
+        yaml.dump(config_data, temp_config)
+        temp_config.flush()
+
+        _exec(
+            "kubectl",
+            "--context",
+            f"k3d-{cluster_name}",
+            "apply",
+            "-f",
+            temp_config.name,
+        )
+
     print(f"Created michelangelo-config ConfigMap in cluster '{cluster_name}'")
 
 
@@ -927,19 +888,6 @@ def _create_aws_credentials_in_cluster(cluster_name: str):
         str(_dir / "resources" / "aws-credentials.yaml"),
     )
     print(f"Created aws-credentials Secret in cluster '{cluster_name}'")
-
-
-def _setup_buckets_in_cluster(cluster_name: str):
-    """Setup S3 buckets in the compute cluster's MinIO."""
-    _exec(
-        "kubectl",
-        "--context",
-        f"k3d-{cluster_name}",
-        "apply",
-        "-f",
-        str(_dir / "resources" / "sandbox-bucket-setup.yaml"),
-    )
-    print(f"Started bucket setup job in cluster '{cluster_name}'")
 
 
 def _create_ma_system_namespace():

--- a/python/tests/cli/sandbox/test_sandbox.py
+++ b/python/tests/cli/sandbox/test_sandbox.py
@@ -139,18 +139,14 @@ class CreateFunctionTest(TestCase):
 class ComputeClusterSetupTest(TestCase):
     """Tests for compute cluster setup functions."""
 
-    @patch("michelangelo.cli.sandbox.sandbox._setup_buckets_in_cluster")
     @patch("michelangelo.cli.sandbox.sandbox._create_aws_credentials_in_cluster")
-    @patch("michelangelo.cli.sandbox.sandbox._create_config_in_cluster")
-    @patch("michelangelo.cli.sandbox.sandbox._deploy_minio_to_cluster")
+    @patch("michelangelo.cli.sandbox.sandbox._create_config_in_compute_cluster")
     @patch("michelangelo.cli.sandbox.sandbox._exec")
     def test_create_compute_cluster_success(
         self,
         mock_exec,
-        mock_deploy_minio,
         mock_create_config,
         mock_create_aws_creds,
-        mock_setup_buckets,
     ):
         """Test successful creation of compute cluster."""
         cluster_name = "test-compute-cluster"
@@ -176,28 +172,11 @@ class ComputeClusterSetupTest(TestCase):
         mock_create_aws_creds.assert_called_once_with(cluster_name)
 
     @patch("michelangelo.cli.sandbox.sandbox._exec")
-    def test_deploy_minio_success(self, mock_exec):
-        """Test successful MinIO deployment."""
-        cluster_name = "test-cluster"
-
-        sandbox._deploy_minio_to_cluster(cluster_name)
-
-        # Verify kubectl apply was called with correct context
-        mock_exec.assert_called_once()
-        call_args = mock_exec.call_args[0]
-
-        self.assertEqual(call_args[0], "kubectl")
-        self.assertIn("--context", call_args)
-        self.assertIn(f"k3d-{cluster_name}", call_args)
-        self.assertIn("apply", call_args)
-        self.assertIn("-f", call_args)
-
-    @patch("michelangelo.cli.sandbox.sandbox._exec")
     def test_create_config_success(self, mock_exec):
-        """Test successful config creation."""
+        """Test successful config creation in compute cluster."""
         cluster_name = "test-cluster"
 
-        sandbox._create_config_in_cluster(cluster_name)
+        sandbox._create_config_in_compute_cluster(cluster_name)
 
         # Verify kubectl apply was called
         mock_exec.assert_called_once()
@@ -214,22 +193,6 @@ class ComputeClusterSetupTest(TestCase):
         cluster_name = "test-cluster"
 
         sandbox._create_aws_credentials_in_cluster(cluster_name)
-
-        # Verify kubectl apply was called
-        mock_exec.assert_called_once()
-        call_args = mock_exec.call_args[0]
-
-        self.assertEqual(call_args[0], "kubectl")
-        self.assertIn("--context", call_args)
-        self.assertIn(f"k3d-{cluster_name}", call_args)
-        self.assertIn("apply", call_args)
-
-    @patch("michelangelo.cli.sandbox.sandbox._exec")
-    def test_setup_buckets_success(self, mock_exec):
-        """Test successful bucket setup."""
-        cluster_name = "test-cluster"
-
-        sandbox._setup_buckets_in_cluster(cluster_name)
 
         # Verify kubectl apply was called
         mock_exec.assert_called_once()


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

**What changed?**

- Removed separate MinIO deployment from compute cluster creation
- Removed MinIO port mappings (9190-9191) from compute cluster
- Removed bucket setup job (`_setup_buckets_in_cluster`) and MinIO deployment function (`_deploy_minio_to_cluster`)
- Added network configuration to connect compute cluster to control plane's k3d network
- Modified `_create_config_in_compute_cluster` to point `AWS_ENDPOINT_URL` to control plane's MinIO service (via NodePort 30007)
- Removed waiting logic for MinIO pods and bucket setup jobs

**Why?**

- Eliminates duplicate object storage in compute clusters
- Simplifies architecture by using a single shared storage instance
- Reduces resource overhead and maintenance complexity
- Enables compute clusters to access the same storage as the control plane

**How did you test it?**

- poetry run ma sandbox create --create-compute-cluster --exclude ray spark ui                                                       
- docker build -t examples:latest -f ./examples/Dockerfile .                                                                                             
- k3d image import examples:latest -c michelangelo-compute-0                                                                                             
- PYTHONPATH=. poetry run python ./examples/bert_cola/bert_cola.py  remote-run --image docker.io/library/examples:latest --storage-url s3://default --yes

**Potential risks**
- NA


**Release notes**
- NA

**Breaking change**: 
- Compute clusters now connect to control plane's MinIO storage instead of creating their own. Ensure compute clusters are created on the same k3d network as the control plane.

**Documentation Changes**
- NA