### PR TITLE
docs(examples): Add comprehensive docstrings to llm_prediction example

### DIFF
--- a/python/examples/llm_prediction/data.py
+++ b/python/examples/llm_prediction/data.py
@@ -1,3 +1,9 @@
+"""Data loading utilities for LLM prediction workflows.
+
+This module provides functions to load datasets from HuggingFace and convert them
+to Ray Datasets for distributed processing.
+"""
+
 import logging
 from typing import Optional
 
@@ -28,6 +34,18 @@ def load_data(
     predict_column: str,
     limit: Optional[int] = None,
 ) -> tuple[Dataset, Dataset, Dataset]:
+    """Load dataset from HuggingFace and convert to Ray Dataset.
+
+    Args:
+        path: HuggingFace dataset path.
+        name: Dataset configuration name.
+        data_slice: Dataset split to load (e.g., 'train', 'test').
+        predict_column: Column name to rename to 'text' for prediction.
+        limit: Optional row limit for testing. Defaults to None.
+
+    Returns:
+        Ray Dataset with renamed prediction column.
+    """
     hf_dataset = datasets.load_dataset(path=path, name=name)
     hf_dataset = hf_dataset.rename_column(predict_column, "text")
     if limit:
@@ -50,6 +68,13 @@ def write_data(
     out_path: str,
     partitions: Optional[int] = None,
 ):
+    """Write Ray Dataset to CSV files.
+
+    Args:
+        dataset: Ray Dataset to write.
+        out_path: Output directory path for CSV files.
+        partitions: Optional number of partitions to repartition before writing. Defaults to None.
+    """
     if partitions:
         dataset = dataset.repartition(partitions)
     dataset.write_csv(out_path)

--- a/python/examples/llm_prediction/data.py
+++ b/python/examples/llm_prediction/data.py
@@ -73,7 +73,8 @@ def write_data(
     Args:
         dataset: Ray Dataset to write.
         out_path: Output directory path for CSV files.
-        partitions: Optional number of partitions to repartition before writing. Defaults to None.
+        partitions: Optional number of partitions to repartition before writing.
+            Defaults to None.
     """
     if partitions:
         dataset = dataset.repartition(partitions)

--- a/python/examples/llm_prediction/hf_predict.py
+++ b/python/examples/llm_prediction/hf_predict.py
@@ -1,3 +1,9 @@
+"""HuggingFace-based prediction module for LLM inference.
+
+This module implements distributed batch inference using HuggingFace transformers
+with Ray for parallel processing. Supports both CPU and GPU inference.
+"""
+
 import logging
 
 import numpy as np
@@ -11,6 +17,18 @@ log = logging.getLogger(__name__)
 
 
 class HFPredictor:
+    """HuggingFace text generation predictor for batch inference.
+
+    Uses HuggingFace transformers pipeline for distributed text generation with Ray.
+    Automatically handles device placement and supports both CPU and GPU inference.
+
+    Attributes:
+        generator: HuggingFace text-generation pipeline.
+        temperature: Sampling temperature for generation diversity.
+        top_p: Nucleus sampling threshold.
+        max_tokens: Maximum length for generated sequences.
+    """
+
     def __init__(
         self,
         model_name: str,
@@ -18,6 +36,14 @@ class HFPredictor:
         top_p: float,
         max_tokens: int,
     ):
+        """Initialize HuggingFace predictor.
+
+        Args:
+            model_name: HuggingFace model identifier.
+            temperature: Sampling temperature for generation.
+            top_p: Nucleus sampling parameter.
+            max_tokens: Maximum tokens to generate.
+        """
         self.generator = pipeline(
             "text-generation", model=model_name, device_map="auto"
         )
@@ -26,6 +52,14 @@ class HFPredictor:
         self.max_tokens = max_tokens
 
     def __call__(self, batch: dict[str, np.ndarray]) -> dict[str, list]:
+        """Generate text for a batch of prompts.
+
+        Args:
+            batch: Batch dictionary with 'text' key containing prompts.
+
+        Returns:
+            Dictionary with 'prompt' and 'generated_text' lists.
+        """
         prompt: list[str] = batch["text"].tolist()
         generated_text: list[str] = [
             self.generator(
@@ -68,6 +102,21 @@ def predict(
     top_p: float,
     max_tokens: int,
 ) -> Dataset:
+    """Run distributed batch prediction using HuggingFace models.
+
+    Args:
+        predict_data: Ray Dataset containing input prompts.
+        worker_instances: Number of concurrent Ray workers.
+        worker_gpu: Number of GPUs per worker.
+        batch_size: Batch size for prediction.
+        model_name: HuggingFace model identifier.
+        temperature: Sampling temperature.
+        top_p: Nucleus sampling parameter.
+        max_tokens: Maximum tokens to generate.
+
+    Returns:
+        Ray Dataset with generated text results.
+    """
     log.info("Starting offline prediction with HFPredictor...")
     log.info(
         f"Starting prediction with batch_size {batch_size} concurrency {worker_instances}"

--- a/python/examples/llm_prediction/hf_predict.py
+++ b/python/examples/llm_prediction/hf_predict.py
@@ -85,8 +85,10 @@ class HFPredictor:
         head_memory="4Gi",
         worker_cpu=1,
         worker_memory="4Gi",
-        worker_instances=1,  # TODO: make this configurable from workflow after supported is added
-        worker_gpu=0,  # TODO: make this configurable from workflow after supported is added
+        # TODO: make this configurable from workflow after supported is added
+        worker_instances=1,
+        # TODO: make this configurable from workflow after supported is added
+        worker_gpu=0,
         # breakpoint=True,
     ),
 )
@@ -119,7 +121,8 @@ def predict(
     """
     log.info("Starting offline prediction with HFPredictor...")
     log.info(
-        f"Starting prediction with batch_size {batch_size} concurrency {worker_instances}"
+        f"Starting prediction with batch_size {batch_size} and "
+        f"concurrency {worker_instances}"
     )
     predict_data = predict_data.map_batches(
         HFPredictor,

--- a/python/examples/llm_prediction/hf_prediction.py
+++ b/python/examples/llm_prediction/hf_prediction.py
@@ -1,3 +1,9 @@
+"""LLM prediction workflow using HuggingFace transformers.
+
+Example workflow demonstrating how to load data from HuggingFace datasets,
+run distributed batch inference with HF transformers, and save results.
+"""
+
 import michelangelo.uniflow.core as uniflow
 from examples.llm_prediction.data import load_data, write_data
 from examples.llm_prediction.hf_predict import predict
@@ -19,6 +25,25 @@ def llm_prediction_workflow(
     worker_instances: int = 1,
     worker_gpu: int = 0,
 ):
+    """LLM prediction workflow using HuggingFace models.
+
+    Loads data from HuggingFace datasets, runs batch prediction with HF transformers,
+    and writes results to storage.
+
+    Args:
+        data_path: HuggingFace dataset path.
+        data_name: Dataset configuration name.
+        data_slice: Dataset split to use.
+        data_predict_column: Column containing text to predict on.
+        data_limit: Maximum number of samples to process.
+        batch_size: Batch size for prediction.
+        model_name: HuggingFace model identifier.
+        temperature: Sampling temperature. Defaults to 1.0.
+        top_p: Nucleus sampling parameter. Defaults to 1.0.
+        max_tokens: Maximum tokens to generate.
+        worker_instances: Number of Ray workers. Defaults to 1.
+        worker_gpu: GPUs per worker. Defaults to 0.
+    """
     predict_data = load_data(
         path=data_path,
         name=data_name,

--- a/python/examples/llm_prediction/hf_prediction.py
+++ b/python/examples/llm_prediction/hf_prediction.py
@@ -73,11 +73,13 @@ def llm_prediction_workflow(
 
 
 # For Local Run: poetry run python examples/llm_prediction/hf_prediction.py
-# For Remote Run: poetry run python examples/llm_prediction/hf_prediction.py remote-run --storage-url <STORAGE_URL> --image <IMAGE>
+# For Remote Run: poetry run python examples/llm_prediction/hf_prediction.py
+# remote-run --storage-url <STORAGE_URL> --image <IMAGE>
 if __name__ == "__main__":
     ctx = uniflow.create_context()
 
-    # Disable use of fsspec in Ray Plugin. See UF_PLUGIN_RAY_USE_FSSPEC docstring for more information.
+    # Disable use of fsspec in Ray Plugin. See UF_PLUGIN_RAY_USE_FSSPEC
+    # docstring for more information.
     ctx.environ[UF_PLUGIN_RAY_USE_FSSPEC] = "0"
     ctx.environ["PYTORCH_MPS_HIGH_WATERMARK_RATIO"] = "0"
     ctx.environ["MA_NAMESPACE"] = "default"

--- a/python/examples/llm_prediction/vllm_predict.py
+++ b/python/examples/llm_prediction/vllm_predict.py
@@ -88,8 +88,10 @@ class VLLMPredictor:
         head_memory="4Gi",
         worker_cpu=1,
         worker_memory="16Gi",
-        worker_instances=1,  # TODO: make this configurable from workflow after supported is added
-        worker_gpu=1,  # TODO: make this configurable from workflow after supported is added
+        # TODO: make this configurable from workflow after supported is added
+        worker_instances=1,
+        # TODO: make this configurable from workflow after supported is added
+        worker_gpu=1,
         # breakpoint=True,
     ),
 )
@@ -138,11 +140,11 @@ def predict(
             [{"GPU": 1, "CPU": 1}] * tensor_parallel_size,
             strategy="STRICT_PACK",
         )
-        return dict(
-            scheduling_strategy=PlacementGroupSchedulingStrategy(
+        return {
+            "scheduling_strategy": PlacementGroupSchedulingStrategy(
                 pg, placement_group_capture_child_tasks=True
             )
-        )
+        }
 
     resources_kwarg: dict[str, Any] = {}
     if tensor_parallel_size == 1:
@@ -156,7 +158,9 @@ def predict(
         resources_kwarg["ray_remote_args_fn"] = scheduling_strategy_fn
 
     log.info(
-        f"Starting prediction with batch_size {batch_size} concurrency {concurrency} tensor_parallel_size {tensor_parallel_size}"
+        f"Starting prediction with batch_size {batch_size} "
+        f"concurrency {concurrency} "
+        f"tensor_parallel_size {tensor_parallel_size}"
     )
     predict_data = predict_data.map_batches(
         VLLMPredictor,

--- a/python/examples/llm_prediction/vllm_predict.py
+++ b/python/examples/llm_prediction/vllm_predict.py
@@ -1,3 +1,10 @@
+"""vLLM-based prediction module for high-performance LLM inference.
+
+This module implements distributed batch inference using vLLM for optimized
+throughput with tensor parallelism support. Significantly faster than standard
+HuggingFace transformers for production workloads.
+"""
+
 import logging
 from typing import Any
 
@@ -14,6 +21,18 @@ log = logging.getLogger(__name__)
 
 
 class VLLMPredictor:
+    """VLLM text generation predictor for high-performance batch inference.
+
+    Uses vLLM for optimized distributed text generation with tensor parallelism support.
+    Provides significantly faster inference than standard HuggingFace transformers
+    through PagedAttention and continuous batching optimizations.
+
+    Attributes:
+        tensor_parallel_size: Number of GPUs used for tensor parallelism.
+        llm: vLLM LLM instance with loaded model.
+        sampling_params: Sampling parameters for text generation.
+    """
+
     def __init__(
         self,
         model_name: str,
@@ -22,6 +41,15 @@ class VLLMPredictor:
         top_p: float,
         max_tokens: int,
     ):
+        """Initialize VLLM predictor.
+
+        Args:
+            model_name: HuggingFace model identifier.
+            tensor_parallel_size: Number of GPUs for tensor parallelism.
+            temperature: Sampling temperature for generation.
+            top_p: Nucleus sampling parameter.
+            max_tokens: Maximum tokens to generate.
+        """
         self.tensor_parallel_size = tensor_parallel_size
         self.llm = LLM(
             model=model_name,
@@ -34,6 +62,14 @@ class VLLMPredictor:
         )
 
     def __call__(self, batch: dict[str, np.ndarray]) -> dict[str, list]:
+        """Generate text for a batch of prompts using vLLM.
+
+        Args:
+            batch: Batch dictionary with 'text' key containing prompts.
+
+        Returns:
+            Dictionary with 'prompt' and 'generated_text' lists.
+        """
         outputs = self.llm.generate(batch["text"], self.sampling_params)
         prompt: list[str] = []
         generated_text: list[str] = []
@@ -70,6 +106,22 @@ def predict(
     top_p: float,
     max_tokens: int,
 ) -> Dataset:
+    """Run distributed batch prediction using vLLM with tensor parallelism.
+
+    Args:
+        predict_data: Ray Dataset containing input prompts.
+        tensor_parallel_size: Number of GPUs for tensor parallelism per model instance.
+        worker_instances: Number of Ray workers.
+        worker_gpu: Number of GPUs per worker.
+        batch_size: Batch size for prediction.
+        model_name: HuggingFace model identifier.
+        temperature: Sampling temperature.
+        top_p: Nucleus sampling parameter.
+        max_tokens: Maximum tokens to generate.
+
+    Returns:
+        Ray Dataset with generated text results.
+    """
     log.info("Starting offline prediction...")
 
     if worker_gpu % tensor_parallel_size != 0:

--- a/python/examples/llm_prediction/vllm_prediction.py
+++ b/python/examples/llm_prediction/vllm_prediction.py
@@ -75,11 +75,13 @@ def llm_prediction_workflow(
 
 
 # For Local Run: poetry run python examples/llm_prediction/vllm_prediction.py
-# For Remote Run: poetry run python examples/llm_prediction/vllm_prediction.py remote-run --storage-url <STORAGE_URL> --image <IMAGE>
+# For Remote Run: poetry run python examples/llm_prediction/vllm_prediction.py
+# remote-run --storage-url <STORAGE_URL> --image <IMAGE>
 if __name__ == "__main__":
     ctx = uniflow.create_context()
 
-    # Disable use of fsspec in Ray Plugin. See UF_PLUGIN_RAY_USE_FSSPEC docstring for more information.
+    # Disable use of fsspec in Ray Plugin. See UF_PLUGIN_RAY_USE_FSSPEC
+    # docstring for more information.
     ctx.environ[UF_PLUGIN_RAY_USE_FSSPEC] = "0"
     ctx.environ["PYTORCH_MPS_HIGH_WATERMARK_RATIO"] = "0"
     ctx.environ["MA_NAMESPACE"] = "default"

--- a/python/examples/llm_prediction/vllm_prediction.py
+++ b/python/examples/llm_prediction/vllm_prediction.py
@@ -1,3 +1,9 @@
+"""LLM prediction workflow using vLLM for high-performance inference.
+
+Example workflow demonstrating how to use vLLM for efficient batch inference
+with tensor parallelism. Ideal for production deployments requiring high throughput.
+"""
+
 import michelangelo.uniflow.core as uniflow
 from examples.llm_prediction.data import load_data, write_data
 from examples.llm_prediction.vllm_predict import predict
@@ -20,6 +26,26 @@ def llm_prediction_workflow(
     worker_gpu: int = 0,
     tensor_parallel_size: int = 1,
 ):
+    """LLM prediction workflow using vLLM for high-performance inference.
+
+    Loads data from HuggingFace datasets, runs batch prediction with vLLM,
+    and writes results to storage. Supports tensor parallelism for large models.
+
+    Args:
+        data_path: HuggingFace dataset path.
+        data_name: Dataset configuration name.
+        data_slice: Dataset split to use.
+        data_predict_column: Column containing text to predict on.
+        data_limit: Maximum number of samples to process.
+        batch_size: Batch size for prediction.
+        model_name: HuggingFace model identifier.
+        temperature: Sampling temperature.
+        top_p: Nucleus sampling parameter.
+        max_tokens: Maximum tokens to generate.
+        worker_instances: Number of Ray workers. Defaults to 1.
+        worker_gpu: GPUs per worker. Defaults to 0.
+        tensor_parallel_size: Number of GPUs for tensor parallelism. Defaults to 1.
+    """
     predict_data = load_data(
         path=data_path,
         name=data_name,


### PR DESCRIPTION
## Summary
Add comprehensive Google-style docstrings to the `llm_prediction` example, improving documentation quality with detailed Args, Returns, and Attributes sections for both HuggingFace and vLLM inference implementations.

## Changes
- ✅ Add module docstrings explaining HuggingFace vs vLLM approaches
- ✅ Enhance `HFPredictor` class with Attributes section
- ✅ Enhance `VLLMPredictor` class with PagedAttention optimization details
- ✅ Improve all function docstrings with complete Args/Returns
- ✅ Add context about tensor parallelism and distributed inference
- ✅ Document data loading utilities with HuggingFace dataset integration

## Statistics
- **Files modified**: 5
- **Lines added**: +177
- **Violations fixed**: D100, D101, D102, D103, D107

## Implementation Details
- Documented vLLM optimizations: PagedAttention, continuous batching
- Explained HuggingFace pipeline integration with Ray
- Added tensor parallelism configuration details

## Related Issue
Related to #571
Fixes #573

🤖 Generated with [Claude Code](https://claude.com/claude-code)