### PR TITLE
docs(uniflow): Add comprehensive docstrings to plugins module

### DIFF
--- a/python/michelangelo/uniflow/plugins/ray/__init__.py
+++ b/python/michelangelo/uniflow/plugins/ray/__init__.py
@@ -1,3 +1,13 @@
+"""Ray plugin for Michelangelo Uniflow.
+
+This package provides Ray-based execution support for Uniflow workflows. It includes
+task configuration for Ray clusters and I/O handlers for Ray datasets.
+
+Ray enables distributed Python execution with flexible resource management and
+automatic scaling. This plugin allows Uniflow workflows to leverage Ray's capabilities
+for parallel data processing and distributed task execution.
+"""
+
 from michelangelo.uniflow.plugins.ray.io import UF_PLUGIN_RAY_USE_FSSPEC, RayDatasetIO
 from michelangelo.uniflow.plugins.ray.task import RayTask
 

--- a/python/michelangelo/uniflow/plugins/ray/__init__.py
+++ b/python/michelangelo/uniflow/plugins/ray/__init__.py
@@ -13,6 +13,6 @@ from michelangelo.uniflow.plugins.ray.task import RayTask
 
 __all__ = [
     "UF_PLUGIN_RAY_USE_FSSPEC",
-    "RayTask",
     "RayDatasetIO",
+    "RayTask",
 ]

--- a/python/michelangelo/uniflow/plugins/ray/io.py
+++ b/python/michelangelo/uniflow/plugins/ray/io.py
@@ -1,3 +1,10 @@
+"""I/O handlers for Ray datasets in Uniflow workflows.
+
+This module provides I/O functionality for reading and writing Ray datasets in Uniflow
+workflows. It supports both fsspec and PyArrow filesystem backends for flexible
+storage access across different environments (local, S3, etc.).
+"""
+
 import os
 from typing import Any, Optional
 
@@ -19,13 +26,44 @@ _DEFAULT_UF_PLUGIN_RAY_USE_FSSPEC = "0"
 
 
 class RayDatasetIO(IO[Dataset]):
+    """I/O handler for Ray Dataset objects.
+
+    This class provides read and write operations for Ray datasets, storing them
+    in Parquet format. It supports multiple filesystem backends including local,
+    S3, and other storage systems via fsspec or PyArrow.
+
+    The filesystem backend is selected based on the UF_PLUGIN_RAY_USE_FSSPEC
+    environment variable.
+    """
+
     def write(self, url: str, ds: Dataset) -> Optional[Any]:
+        """Write a Ray dataset to the specified URL in Parquet format.
+
+        Args:
+            url: Target URL where the dataset should be written. Supports local paths
+                and remote URLs (e.g., s3://bucket/path).
+            ds: The Ray dataset to write.
+
+        Returns:
+            None. This implementation does not return metadata.
+        """
         fs, path = _fs_path(url)
         ds.write_parquet(path, filesystem=fs)
         metadata = None
         return metadata
 
     def read(self, url: str, metadata: Optional[Any]) -> Dataset:
+        """Read a Ray dataset from the specified URL.
+
+        Args:
+            url: Source URL from which to read the dataset. Supports local paths
+                and remote URLs (e.g., s3://bucket/path).
+            metadata: Optional metadata from write operation. Currently unused
+                and expected to be None.
+
+        Returns:
+            The loaded Ray dataset.
+        """
         assert metadata is None
         fs, path = _fs_path(url)
         return ray.data.read_parquet(path, filesystem=fs)
@@ -41,6 +79,15 @@ def _fs_path(url: str) -> tuple[Any, str]:
 
 
 def resolve_fs(protocol):
+    """Resolve filesystem handler for a given protocol.
+
+    Args:
+        protocol: The URL protocol (e.g., "s3", "file").
+
+    Returns:
+        A filesystem object for the specified protocol, or None if the protocol
+        doesn't require special handling.
+    """
     if protocol == "s3":
         import pyarrow.fs
 

--- a/python/michelangelo/uniflow/plugins/ray/io.py
+++ b/python/michelangelo/uniflow/plugins/ray/io.py
@@ -14,8 +14,9 @@ from ray.data import Dataset
 
 UF_PLUGIN_RAY_USE_FSSPEC = "UF_PLUGIN_RAY_USE_FSSPEC"
 """
-UF_PLUGIN_RAY_USE_FSSPEC is an environment variable that controls whether the Ray Plugin uses fsspec instead of Ray's
-default filesystem - pyarrow. Possible values:
+UF_PLUGIN_RAY_USE_FSSPEC is an environment variable that controls whether the
+Ray Plugin uses fsspec instead of Ray's default filesystem - pyarrow.
+Possible values:
   - 1 to use fsspec
   - 0 to use Ray's default filesystem.
 

--- a/python/michelangelo/uniflow/plugins/ray/task.py
+++ b/python/michelangelo/uniflow/plugins/ray/task.py
@@ -63,7 +63,8 @@ class RayTask(TaskConfig):
         worker_object_store_memory: Object store memory per worker node in bytes.
         worker_instances: Number of worker instances to launch.
         breakpoint: If True, enables breakpoint debugging for the task.
-        runtime_env: Runtime environment configuration dict for Ray (packages, env vars, etc.).
+        runtime_env: Runtime environment configuration dict for Ray
+            (packages, env vars, etc.).
     """
 
     head_cpu: Optional[int] = None
@@ -81,10 +82,11 @@ class RayTask(TaskConfig):
     runtime_env: Optional[dict] = None
 
     def get_binding(self) -> TaskBinding:
-        """Return the TaskBinding linking this config to its Starlark execution function.
+        """Return the TaskBinding linking this config to its Starlark function.
 
         Returns:
-            TaskBinding that specifies the Starlark file and function for Ray task execution.
+            TaskBinding that specifies the Starlark file and function for
+            Ray task execution.
         """
         return _binding
 
@@ -93,15 +95,17 @@ class RayTask(TaskConfig):
         """Return the TaskBinding for Ray configuration.
 
         Returns:
-            TaskBinding that specifies the Starlark file and function for Ray configuration.
+            TaskBinding that specifies the Starlark file and function for
+            Ray configuration.
         """
         return _config_binding
 
     def pre_run(self):
         """Initialize the Ray cluster before task execution.
 
-        Reads Ray initialization parameters from the _RAY_INIT_KWARGS environment
-        variable and initializes the Ray runtime with those parameters.
+        Reads Ray initialization parameters from the _RAY_INIT_KWARGS
+        environment variable and initializes the Ray runtime with those
+        parameters.
         """
         ray_init_kwargs = eval(os.environ.get("_RAY_INIT_KWARGS", "{}"))
         log.info(f"_RAY_INIT_KWARGS: {ray_init_kwargs}")

--- a/python/michelangelo/uniflow/plugins/ray/task.py
+++ b/python/michelangelo/uniflow/plugins/ray/task.py
@@ -1,3 +1,14 @@
+"""Ray task configuration and execution for Uniflow workflows.
+
+This module provides task configuration for executing Uniflow workflows on Ray clusters.
+It handles Ray cluster initialization, resource allocation, and lifecycle management
+for distributed task execution.
+
+Ray tasks support configurable resources for both head and worker nodes, including
+CPU, memory, disk, and GPU allocations. The execution model initializes a Ray cluster
+before running the task and properly shuts it down afterward.
+"""
+
 import logging
 import os
 from dataclasses import dataclass
@@ -29,6 +40,32 @@ _config_binding = TaskBinding(
 
 @dataclass
 class RayTask(TaskConfig):
+    """Configuration for Ray-based task execution in Uniflow workflows.
+
+    This class defines resource specifications and runtime configuration for executing
+    tasks on Ray clusters. It manages the lifecycle of Ray cluster initialization and
+    shutdown through pre_run and post_run hooks.
+
+    Unlike SparkTask which uses driver/executor terminology, RayTask uses head/worker
+    terminology to describe the cluster nodes. The head node coordinates execution
+    while worker nodes perform distributed computation.
+
+    Attributes:
+        head_cpu: Number of CPUs allocated to the head node.
+        head_memory: Memory allocation for the head node (e.g., "4G", "512M").
+        head_disk: Disk space allocation for the head node (e.g., "10G").
+        head_gpu: Number of GPUs allocated to the head node.
+        head_object_store_memory: Object store memory for the head node in bytes.
+        worker_cpu: Number of CPUs allocated per worker node.
+        worker_memory: Memory allocation per worker node (e.g., "4G", "512M").
+        worker_disk: Disk space allocation per worker node (e.g., "10G").
+        worker_gpu: Number of GPUs allocated per worker node.
+        worker_object_store_memory: Object store memory per worker node in bytes.
+        worker_instances: Number of worker instances to launch.
+        breakpoint: If True, enables breakpoint debugging for the task.
+        runtime_env: Runtime environment configuration dict for Ray (packages, env vars, etc.).
+    """
+
     head_cpu: Optional[int] = None
     head_memory: Optional[str] = None
     head_disk: Optional[str] = None
@@ -44,16 +81,35 @@ class RayTask(TaskConfig):
     runtime_env: Optional[dict] = None
 
     def get_binding(self) -> TaskBinding:
+        """Return the TaskBinding linking this config to its Starlark execution function.
+
+        Returns:
+            TaskBinding that specifies the Starlark file and function for Ray task execution.
+        """
         return _binding
 
     @classmethod
     def get_config_binding(cls) -> TaskBinding:
+        """Return the TaskBinding for Ray configuration.
+
+        Returns:
+            TaskBinding that specifies the Starlark file and function for Ray configuration.
+        """
         return _config_binding
 
     def pre_run(self):
+        """Initialize the Ray cluster before task execution.
+
+        Reads Ray initialization parameters from the _RAY_INIT_KWARGS environment
+        variable and initializes the Ray runtime with those parameters.
+        """
         ray_init_kwargs = eval(os.environ.get("_RAY_INIT_KWARGS", "{}"))
         log.info(f"_RAY_INIT_KWARGS: {ray_init_kwargs}")
         ray.init(**ray_init_kwargs)
 
     def post_run(self):
+        """Shut down the Ray cluster after task execution.
+
+        Ensures proper cleanup of Ray resources by shutting down the Ray runtime.
+        """
         ray.shutdown()

--- a/python/michelangelo/uniflow/plugins/spark/__init__.py
+++ b/python/michelangelo/uniflow/plugins/spark/__init__.py
@@ -1,3 +1,13 @@
+"""Spark plugin for Michelangelo Uniflow.
+
+This package provides Apache Spark-based execution support for Uniflow workflows.
+It includes task configuration for Spark clusters and I/O handlers for Spark DataFrames.
+
+Spark enables distributed data processing with SQL and DataFrame APIs. This plugin
+allows Uniflow workflows to leverage Spark's capabilities for large-scale batch
+processing and data transformations.
+"""
+
 from michelangelo.uniflow.plugins.spark.task import SparkTask
 
 __all__ = [

--- a/python/michelangelo/uniflow/plugins/spark/io.py
+++ b/python/michelangelo/uniflow/plugins/spark/io.py
@@ -1,3 +1,10 @@
+"""I/O handlers for Spark DataFrames in Uniflow workflows.
+
+This module provides I/O functionality for reading and writing Spark DataFrames in
+Uniflow workflows. It handles S3A filesystem configuration for MinIO compatibility
+and supports Parquet format for data persistence.
+"""
+
 import os
 from typing import Any, Optional
 
@@ -7,6 +14,14 @@ from michelangelo.uniflow.core.io_registry import IO
 
 
 def _ensure_s3a_config():
+    """Configure Spark session with S3A filesystem settings.
+
+    Initializes or retrieves a Spark session configured for S3A access, including
+    MinIO compatibility. Reads AWS credentials and endpoint from environment variables.
+
+    This function is called at module import time to ensure S3A configuration is
+    available before any I/O operations.
+    """
     SparkSession.builder.appName("SparkIO-S3A-Inject").config(
         "spark.hadoop.fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem"
     ).config(
@@ -27,25 +42,76 @@ _ensure_s3a_config()
 
 
 def read_data(url: str) -> DataFrame:
+    """Read a Spark DataFrame from a Parquet file.
+
+    Args:
+        url: The URL or path to read from. Supports local paths and S3 URLs.
+
+    Returns:
+        The loaded Spark DataFrame.
+    """
     spark = SparkSession.getActiveSession() or SparkSession.builder.getOrCreate()
     return spark.read.parquet(url)
 
 
 class SparkIO(IO[DataFrame]):
+    """I/O handler for Spark DataFrame objects.
+
+    This class provides read and write operations for Spark DataFrames, storing them
+    in Parquet format. It supports local filesystem paths and S3 URLs via S3A protocol.
+
+    The implementation expands tilde (~) paths and uses the active Spark session for
+    all I/O operations.
+    """
+
     def write(self, url: str, value: DataFrame) -> Optional[Any]:
+        """Write a Spark DataFrame to the specified URL in Parquet format.
+
+        Args:
+            url: Target URL where the DataFrame should be written. Supports local paths
+                (including ~-prefixed paths) and S3 URLs.
+            value: The Spark DataFrame to write.
+
+        Returns:
+            None. This implementation does not return metadata.
+        """
         self.write_data(url, value)
         return None
 
     def read(self, url: str, _metadata) -> DataFrame:
+        """Read a Spark DataFrame from the specified URL.
+
+        Args:
+            url: Source URL from which to read the DataFrame. Supports local paths
+                (including ~-prefixed paths) and S3 URLs.
+            _metadata: Optional metadata from write operation. Currently unused.
+
+        Returns:
+            The loaded Spark DataFrame.
+        """
         return self.read_data(url)
 
     @staticmethod
     def write_data(url: str, data: DataFrame):
+        """Write DataFrame to Parquet format at the given URL.
+
+        Args:
+            url: Target URL for writing. Tilde paths are expanded.
+            data: The Spark DataFrame to write.
+        """
         url = os.path.expanduser(url)
         data.write.parquet(url)
 
     @staticmethod
     def read_data(url: str) -> DataFrame:
+        """Read DataFrame from Parquet format at the given URL.
+
+        Args:
+            url: Source URL for reading. Tilde paths are expanded.
+
+        Returns:
+            The loaded Spark DataFrame.
+        """
         url = os.path.expanduser(url)
         spark = SparkSession.getActiveSession()
         return spark.read.parquet(url)

--- a/python/michelangelo/uniflow/plugins/spark/task.py
+++ b/python/michelangelo/uniflow/plugins/spark/task.py
@@ -1,12 +1,13 @@
 """Spark task configuration and execution for Uniflow workflows.
 
-This module provides task configuration for executing Uniflow workflows on Spark clusters.
-It handles Spark session initialization, resource allocation, and lifecycle management
-for distributed task execution.
+This module provides task configuration for executing Uniflow workflows on
+Spark clusters. It handles Spark session initialization, resource allocation,
+and lifecycle management for distributed task execution.
 
-Spark tasks support configurable resources for both driver and executor nodes, including
-CPU, memory, disk, and GPU allocations. The execution model initializes a Spark session
-with Hive support before running the task and properly stops it afterward.
+Spark tasks support configurable resources for both driver and executor nodes,
+including CPU, memory, disk, and GPU allocations. The execution model
+initializes a Spark session with Hive support before running the task and
+properly stops it afterward.
 """
 
 import logging
@@ -78,28 +79,30 @@ class SparkTask(TaskConfig):
     executor_instances: Optional[int] = None
 
     def get_binding(self) -> TaskBinding:
-        """Return the TaskBinding linking this config to its Starlark execution function.
+        """Return the TaskBinding linking this config to its Starlark function.
 
         Returns:
-            TaskBinding that specifies the Starlark file and function for Spark task execution.
+            TaskBinding that specifies the Starlark file and function for
+            Spark task execution.
         """
         return _binding
 
     @classmethod
-    def get_config_binding(self) -> TaskBinding:
+    def get_config_binding(cls) -> TaskBinding:
         """Return the TaskBinding for Spark configuration.
 
         Returns:
-            TaskBinding that specifies the Starlark file and function for Spark configuration.
+            TaskBinding that specifies the Starlark file and function for
+            Spark configuration.
         """
         return _config_binding
 
     def pre_run(self):
         """Initialize the Spark session before task execution.
 
-        Creates a Spark session with Hive support enabled. Additional Spark properties
-        can be specified via the _SPARK_PROPERTIES environment variable as comma-separated
-        key=value pairs.
+        Creates a Spark session with Hive support enabled. Additional Spark
+        properties can be specified via the _SPARK_PROPERTIES environment
+        variable as comma-separated key=value pairs.
         """
         sb = SparkSession.builder.enableHiveSupport()
 
@@ -114,7 +117,8 @@ class SparkTask(TaskConfig):
     def post_run(self):
         """Stop the Spark session after task execution.
 
-        Ensures proper cleanup of Spark resources by stopping the active session if one exists.
+        Ensures proper cleanup of Spark resources by stopping the active
+        session if one exists.
         """
         spark = SparkSession.getActiveSession()
         if spark:

--- a/python/michelangelo/uniflow/plugins/spark/task.py
+++ b/python/michelangelo/uniflow/plugins/spark/task.py
@@ -1,3 +1,14 @@
+"""Spark task configuration and execution for Uniflow workflows.
+
+This module provides task configuration for executing Uniflow workflows on Spark clusters.
+It handles Spark session initialization, resource allocation, and lifecycle management
+for distributed task execution.
+
+Spark tasks support configurable resources for both driver and executor nodes, including
+CPU, memory, disk, and GPU allocations. The execution model initializes a Spark session
+with Hive support before running the task and properly stops it afterward.
+"""
+
 import logging
 import os
 from dataclasses import dataclass
@@ -29,13 +40,31 @@ _config_binding = TaskBinding(
 
 @dataclass
 class SparkTask(TaskConfig):
-    """This class encapsulates the configuration properties required to orchestrate a Spark task, including resource
-    specifications. It is designed to interface with a Starlark function that executes a Spark job according to these
-    configurations.
+    """Configuration for Spark-based task execution in Uniflow workflows.
 
-    The class intentionally avoids defining default values for its properties. Instead, defaults should be provided
-    through the keyword arguments of the associated Starlark function. This approach facilitates more flexible
-    configuration management, allowing runtime overrides of the default settings.
+    This class defines resource specifications and runtime configuration for executing
+    tasks on Spark clusters. It manages the lifecycle of Spark session initialization
+    and shutdown through pre_run and post_run hooks.
+
+    Unlike RayTask which uses head/worker terminology, SparkTask uses driver/executor
+    terminology to describe the cluster nodes. The driver coordinates execution while
+    executors perform distributed computation.
+
+    The class intentionally avoids defining default values for its properties. Instead,
+    defaults should be provided through the keyword arguments of the associated Starlark
+    function. This approach facilitates more flexible configuration management, allowing
+    runtime overrides of the default settings.
+
+    Attributes:
+        driver_cpu: Number of CPUs allocated to the driver node.
+        driver_memory: Memory allocation for the driver node (e.g., "4G", "512M").
+        driver_disk: Disk space allocation for the driver node (e.g., "10G").
+        driver_gpu: Number of GPUs allocated to the driver node.
+        executor_cpu: Number of CPUs allocated per executor.
+        executor_memory: Memory allocation per executor (e.g., "4G", "512M").
+        executor_disk: Disk space allocation per executor (e.g., "10G").
+        executor_gpu: Number of GPUs allocated per executor.
+        executor_instances: Number of executor instances to launch.
     """
 
     driver_cpu: Optional[int] = None
@@ -49,13 +78,29 @@ class SparkTask(TaskConfig):
     executor_instances: Optional[int] = None
 
     def get_binding(self) -> TaskBinding:
+        """Return the TaskBinding linking this config to its Starlark execution function.
+
+        Returns:
+            TaskBinding that specifies the Starlark file and function for Spark task execution.
+        """
         return _binding
 
     @classmethod
     def get_config_binding(self) -> TaskBinding:
+        """Return the TaskBinding for Spark configuration.
+
+        Returns:
+            TaskBinding that specifies the Starlark file and function for Spark configuration.
+        """
         return _config_binding
 
     def pre_run(self):
+        """Initialize the Spark session before task execution.
+
+        Creates a Spark session with Hive support enabled. Additional Spark properties
+        can be specified via the _SPARK_PROPERTIES environment variable as comma-separated
+        key=value pairs.
+        """
         sb = SparkSession.builder.enableHiveSupport()
 
         if props := os.environ.get("_SPARK_PROPERTIES"):
@@ -67,6 +112,10 @@ class SparkTask(TaskConfig):
         assert spark
 
     def post_run(self):
+        """Stop the Spark session after task execution.
+
+        Ensures proper cleanup of Spark resources by stopping the active session if one exists.
+        """
         spark = SparkSession.getActiveSession()
         if spark:
             spark.stop()


### PR DESCRIPTION
## Summary
Add comprehensive Google-style docstrings to the `michelangelo/uniflow/plugins` module (both Ray and Spark plugins), improving documentation quality with detailed Args, Returns, and Attributes sections.

## Changes

### Ray Plugin (`michelangelo/uniflow/plugins/ray/`)
- ✅ Add module docstrings explaining Ray plugin purpose and distributed execution
- ✅ Enhance `RayTask` class with detailed Attributes section (13 attributes)
- ✅ Add class docstring for `RayDatasetIO` with implementation details
- ✅ Add method docstrings for `write()`, `read()`, `resolve_fs()`, lifecycle hooks
- ✅ Document fsspec and PyArrow filesystem backends

### Spark Plugin (`michelangelo/uniflow/plugins/spark/`)
- ✅ Add module docstrings explaining Spark plugin purpose and batch processing
- ✅ Enhance `SparkTask` class with detailed Attributes section (9 attributes)
- ✅ Add class docstring for `SparkIO` with implementation details  
- ✅ Add method docstrings for `write()`, `read()`, `write_data()`, `read_data()`
- ✅ Document S3A configuration for MinIO compatibility
- ✅ Fix D205 formatting violation

## Statistics
- **Files modified**: 6 (3 Ray + 3 Spark)
- **Lines added**: ~245
- **Violations fixed**: 24
  - D100: 4 (module docstrings)
  - D101: 3 (class docstrings)
  - D102: 14 (method docstrings)
  - D103: 2 (function docstrings)
  - D104: 1 (package docstring)
  - D205: 1 (formatting)

## Key Improvements
- Documented Ray vs Spark terminology differences (head/worker vs driver/executor)
- Explained lifecycle hooks (`pre_run`, `post_run`) and configuration binding
- Added implementation details for I/O backends and resource allocation

## Related Issue
Related to #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)