### PR TITLE
Update Python code coverage baseline to 66%

### DIFF
--- a/.github/workflows/python-coverage.yml
+++ b/.github/workflows/python-coverage.yml
@@ -99,13 +99,13 @@ jobs:
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
-      # Check overall coverage threshold (baseline: 34.94%)
-      - name: "Check overall coverage threshold (baseline: 34.94%)"
+      # Check overall coverage threshold (baseline: 66%)
+      - name: "Check overall coverage threshold (baseline: 66%)"
         run: |
-          # Baseline coverage is 34.94% - we don't fail on this
+          # Baseline coverage is 66% - we don't fail on this
           # The goal is to maintain or improve from baseline
-          poetry run coverage report --fail-under=34
-          echo "✅ Coverage meets baseline threshold (34.94%)"
+          poetry run coverage report --fail-under=66
+          echo "✅ Coverage meets baseline threshold (66%)"
           echo "📈 Goal: Maintain baseline and enforce 90% on new code"
         continue-on-error: true
 
@@ -156,7 +156,7 @@ jobs:
           echo "Overall coverage: **${{ env.COVERAGE }}%**" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Coverage Policy" >> $GITHUB_STEP_SUMMARY
-          echo "- **Baseline (existing code):** ≥34.94% (current coverage)" >> $GITHUB_STEP_SUMMARY
+          echo "- **Baseline (existing code):** ≥66% (current coverage)" >> $GITHUB_STEP_SUMMARY
           echo "- **New/changed code:** ≥90% ✅ **STRICTLY ENFORCED**" >> $GITHUB_STEP_SUMMARY
           echo "- **Long-term goal:** Improve baseline to 70%" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -258,10 +258,10 @@ exclude_lines = [
 ]
 
 # Overall coverage threshold (baseline for existing code)
-# Baseline: 34.94% (current coverage as of 2025-11-15)
+# Baseline: 66% (updated coverage as of 2025-12-02)
 # New code must meet 85% coverage (enforced in CI via diff-cover)
 # Long-term goal: Improve baseline to 70%
-fail_under = 34
+fail_under = 66
 
 [tool.coverage.html]
 directory = "htmlcov"


### PR DESCRIPTION
## Summary

Increase the Python code coverage baseline from 34% to 66% to reflect the significant improvement in test coverage achieved through recent documentation and testing efforts.

## Changes

- **pyproject.toml**: Update `fail_under` from 34 to 66 and update baseline comment to reflect new coverage level
- **.github/workflows/python-coverage.yml**: Update all baseline references from 34.94% to 66%:
  - Step name and comments
  - Coverage check command (`--fail-under=66`)
  - Coverage policy in GitHub summary output

## Impact

This change:
- Raises the minimum acceptable overall coverage from 34% to 66%
- Maintains the strict 90% coverage requirement for new/changed code
- Reflects the improved state of the codebase
- Continues progress toward the long-term goal of 70% coverage

## Test Plan

- [x] Updated baseline threshold in pyproject.toml
- [x] Updated all references in CI workflow
- [x] Verified no other references to old baseline remain
- [ ] CI will validate that current coverage meets 66% threshold