### PR TITLE
Ignore test fixtures in linter

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -176,6 +176,7 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 [tool.ruff.lint.per-file-ignores]
 "**/gen/**/*.py" = ["ALL"]
 "**/api/v2/services/gen/**/*.py" = ["ALL"]
+"**/tests/fixtures/**/*.py" = ["ALL"]
 
 # Google-style docstrings
 [tool.ruff.lint.pydocstyle]


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
Ignore test fixtures in linter. The fixtures are usually created to mock input/output of tests, they don't have to follow linter rules.

