### PR TITLE
Enforce all docstring rules (D100-D104) for new code

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -161,8 +161,12 @@ select = [
 ]
 
 ignore = [
-    "D104",   # Missing docstring in public package
-    # D100 (Missing docstring in public module) is now enforced for all new code
+    # All docstring rules are now enforced for new code:
+    # D100 - Missing docstring in public module
+    # D101 - Missing docstring in public class
+    # D102 - Missing docstring in public method
+    # D103 - Missing docstring in public function
+    # D104 - Missing docstring in public package
 ]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -161,8 +161,8 @@ select = [
 ]
 
 ignore = [
-    "D100",   # Missing docstring in public module (gradually enable)
     "D104",   # Missing docstring in public package
+    # D100 (Missing docstring in public module) is now enforced for all new code
 ]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.


### PR DESCRIPTION
## Summary

This PR enforces **all** pydocstyle docstring rules (D100-D104) for new code changes in the Python codebase by removing them from the ruff ignore list.

## Changes

- **pyproject.toml**: Removed D100 and D104 from the `ignore` list in the ruff configuration
- Updated comments to document that all docstring rules are now enforced
- Empty ignore list means comprehensive docstring enforcement

### Before:
```toml
ignore = [
    "D100",   # Missing docstring in public module (gradually enable)
    "D104",   # Missing docstring in public package
]
```

### After:
```toml
ignore = [
    # All docstring rules are now enforced for new code:
    # D100 - Missing docstring in public module
    # D101 - Missing docstring in public class
    # D102 - Missing docstring in public method
    # D103 - Missing docstring in public function
    # D104 - Missing docstring in public package
]
```

## Impact

**For New Code:**
- All new Python modules, packages, classes, methods, and functions must include docstrings
- Modified existing files will require docstrings to be added if they don't already have them
- Ruff will flag D100-D104 violations in CI for new/modified code

**For Existing Code:**
- No immediate impact on existing files that haven't been modified
- Existing code without docstrings will not trigger violations until those files are modified
- This allows for gradual improvement of documentation quality

## Docstring Rules Now Fully Enforced

All core docstring rules are now enforced for new code:

- ✅ **D100**: Missing docstring in public module
- ✅ **D101**: Missing docstring in public class
- ✅ **D102**: Missing docstring in public method
- ✅ **D103**: Missing docstring in public function
- ✅ **D104**: Missing docstring in public package

## Rationale

This change is part of the ongoing effort to improve documentation quality across the Michelangelo Python codebase. By enforcing comprehensive docstring rules for new code, we ensure that:

1. All new public APIs are properly documented from the start
2. The codebase documentation quality improves incrementally
3. Developers are prompted to add proper docstrings when modifying existing files
4. Documentation follows Google Python Style Guide conventions

## Testing

- Configuration change only, no code modifications
- CI will validate the ruff configuration
- Future PRs will be checked against these rules

## Integration with Previous Work

This PR complements the docstring improvement work done in previous PRs:
- **PR #653** (Phase 2): Added comprehensive docstrings to core library files
- **PR #654** (Phase 3): Added comprehensive docstrings to I/O utilities

With this enforcement in place, all future code changes will maintain the same high documentation standards established in those PRs.

## Related Issues

Closes #650