### PR TITLE
Add comprehensive docstrings to triggerrun and utils (Go)

### DIFF
--- a/go/components/triggerrun/backfill_trigger.go
+++ b/go/components/triggerrun/backfill_trigger.go
@@ -11,12 +11,24 @@ import (
 	k8stypes "k8s.io/apimachinery/pkg/types"
 )
 
+// backfillTrigger implements the Runner interface for one-time backfill workflows.
+//
+// This implementation manages workflows that execute once to process historical data
+// within a specified time range. Unlike cron triggers, backfill workflows complete
+// after successful execution rather than running continuously.
+//
+// The time range for backfill is specified in TriggerRun.Spec.StartTimestamp and
+// TriggerRun.Spec.EndTimestamp, which are passed to the workflow for processing.
 type backfillTrigger struct {
-	Log            logr.Logger
-	WorkflowClient clientInterface.WorkflowClient
+	Log            logr.Logger                    // Structured logger for trigger operations
+	WorkflowClient clientInterface.WorkflowClient // Workflow engine client (Cadence/Temporal)
 }
 
-// NewBackfillTrigger returns a new backfillTrigger
+// NewBackfillTrigger creates a new backfill trigger Runner.
+//
+// The returned Runner manages one-time workflows for historical data processing.
+// It requires a logger for structured logging and a workflow client for interacting
+// with the workflow engine.
 func NewBackfillTrigger(log logr.Logger, workflowClient clientInterface.WorkflowClient) Runner {
 	return &backfillTrigger{
 		Log:            log,
@@ -24,7 +36,25 @@ func NewBackfillTrigger(log logr.Logger, workflowClient clientInterface.Workflow
 	}
 }
 
-// Run starts the backfill trigger
+// Run starts a one-time backfill workflow.
+//
+// This method performs the following operations:
+//  1. Generate deterministic workflow ID from namespace and name
+//  2. Check if workflow is already running (idempotent start)
+//  3. Configure workflow options without cron schedule
+//  4. Start workflow execution with "trigger.BackfillTrigger" workflow type
+//  5. Return status with workflow ID and URL for monitoring
+//
+// The workflow uses:
+//   - ID: <namespace>.<name> (deterministic for idempotency)
+//   - TaskList: "trigger_run"
+//   - ExecutionStartToCloseTimeout: 1 year (practically no timeout)
+//   - DecisionTaskStartToCloseTimeout: 30 seconds
+//   - No CronSchedule (one-time execution)
+//
+// Returns State=RUNNING if workflow starts successfully or is already running,
+// State=FAILED if workflow start fails. The ExecutionWorkflowId field is populated
+// with the workflow execution ID for status tracking.
 func (r *backfillTrigger) Run(ctx context.Context, triggerRun *v2pb.TriggerRun) (v2pb.TriggerRunStatus, error) {
 	log := r.Log.WithValues("triggerRun", k8stypes.NamespacedName{
 		Namespace: triggerRun.Namespace,
@@ -96,7 +126,17 @@ func (r *backfillTrigger) Run(ctx context.Context, triggerRun *v2pb.TriggerRun) 
 	}, nil
 }
 
-// Kill stops the backfill trigger
+// Kill terminates a running backfill workflow.
+//
+// This method stops the one-time workflow execution. It first validates that the
+// workflow is in RUNNING state before attempting termination, returning an error
+// if the workflow is not running.
+//
+// The workflow termination is handled by the shared killWorkflow utility function.
+//
+// Returns State=KILLED on success. Returns an error if the workflow is not in
+// RUNNING state. If no workflow is running, returns KILLED without error
+// (idempotent termination).
 func (r *backfillTrigger) Kill(ctx context.Context, triggerRun *v2pb.TriggerRun) (v2pb.TriggerRunStatus, error) {
 	log := r.Log.WithValues("triggerRun", k8stypes.NamespacedName{
 		Namespace: triggerRun.Namespace,
@@ -114,7 +154,20 @@ func (r *backfillTrigger) Kill(ctx context.Context, triggerRun *v2pb.TriggerRun)
 	return killWorkflow(ctx, triggerRun, log, r.WorkflowClient, domain)
 }
 
-// GetStatus gets the status of a running backfill trigger
+// GetStatus retrieves the execution status of a backfill workflow.
+//
+// This method queries the workflow engine for the specific workflow execution
+// identified by ExecutionWorkflowId in the TriggerRun status. It maps workflow
+// execution states to TriggerRun states.
+//
+// The status check is delegated to getAdhocRunWorkflowStatus which handles
+// state mapping for one-time workflows:
+//   - Running → RUNNING
+//   - Completed → SUCCEEDED
+//   - Failed/TimedOut/Canceled/Terminated → FAILED
+//
+// Returns an error if ExecutionWorkflowId is empty (workflow was never started)
+// or if the workflow execution cannot be described.
 func (r *backfillTrigger) GetStatus(
 	ctx context.Context, triggerRun *v2pb.TriggerRun,
 ) (v2pb.TriggerRunStatus, error) {

--- a/go/components/triggerrun/controller.go
+++ b/go/components/triggerrun/controller.go
@@ -1,3 +1,31 @@
+// Package triggerrun implements a Kubernetes controller for managing TriggerRun resources.
+//
+// This package provides scheduled and event-driven workflow execution through a state machine
+// that manages the lifecycle of trigger runs. It supports multiple trigger types including
+// cron schedules, backfill operations, interval-based triggers, and batch reruns.
+//
+// Architecture:
+//
+// The controller uses a Runner interface abstraction to support different trigger types:
+//   - CronTrigger: Recurring scheduled workflows using cron expressions
+//   - BackfillTrigger: One-time workflows for historical data backfilling
+//   - IntervalTrigger: Workflows triggered at fixed intervals
+//   - BatchRerunTrigger: Bulk reprocessing of previously executed workflows
+//
+// State Machine:
+//
+// TriggerRun resources transition through the following states:
+//   - INVALID → RUNNING: Initial workflow start
+//   - RUNNING → SUCCEEDED/FAILED/KILLED: Terminal states based on execution outcome
+//
+// The controller reconciles resources every 60 seconds to check workflow status and handle
+// kill requests. Terminal states are marked immutable to prevent further modifications.
+//
+// Workflow Integration:
+//
+// The controller integrates with Cadence or Temporal workflow engines to execute
+// scheduled workflows. Each Runner implementation manages workflow lifecycle operations
+// including starting, monitoring, and terminating workflow executions.
 package triggerrun
 
 import (
@@ -20,11 +48,15 @@ import (
 )
 
 const (
-	// this is the concurrency reconcile loops for trigger run, it can be tuned if needed.
+	// maximumConcurrentReconciles defines the maximum number of concurrent reconcile loops
+	// for the TriggerRun controller. This value can be tuned based on cluster capacity.
 	maximumConcurrentReconciles = 10
 )
 
-// Params are the params for instantiating the reconciler.
+// Params contains the dependencies required to instantiate the TriggerRun Reconciler.
+//
+// This struct uses Uber FX dependency injection to wire controller dependencies.
+// The Runner implementations are tagged by name to inject the correct trigger type.
 type Params struct {
 	fx.In
 
@@ -32,13 +64,25 @@ type Params struct {
 	WorkflowClient    clientInterface.WorkflowClient
 	APIHandlerFactory apiHandler.Factory
 
-	CronTrigger       Runner `name:"cron-trigger"`
-	IntervalTrigger   Runner `name:"interval-trigger"`
-	BackfillTrigger   Runner `name:"backfill-trigger"`
-	BatchRerunTrigger Runner `name:"batch-rerun-trigger"`
+	CronTrigger       Runner `name:"cron-trigger"`        // Handles cron-based recurring workflows
+	IntervalTrigger   Runner `name:"interval-trigger"`    // Handles interval-based workflows
+	BackfillTrigger   Runner `name:"backfill-trigger"`    // Handles backfill workflows
+	BatchRerunTrigger Runner `name:"batch-rerun-trigger"` // Handles batch rerun workflows
 }
 
-// Reconciler reconciles a TriggerRun object
+// Reconciler reconciles TriggerRun resources through a state machine.
+//
+// The reconciler manages the complete lifecycle of trigger runs, from initial workflow
+// start through terminal states (SUCCEEDED, FAILED, or KILLED). It delegates execution
+// to the appropriate Runner based on the trigger type.
+//
+// State transitions are handled through a labeled switch statement that allows
+// breaking out of the state machine once a terminal state is reached. The reconciler
+// persists status updates to Kubernetes and requeues resources every 60 seconds for
+// ongoing status checks.
+//
+// The reconciler supports concurrent processing of multiple TriggerRun resources
+// based on the maximumConcurrentReconciles setting.
 type Reconciler struct {
 	api.Handler
 	Log    logr.Logger
@@ -46,13 +90,16 @@ type Reconciler struct {
 
 	apiHandlerFactory apiHandler.Factory
 
-	CronTrigger       Runner
-	IntervalTrigger   Runner
-	BackfillTrigger   Runner
-	BatchRerunTrigger Runner
+	CronTrigger       Runner // Executes cron-scheduled workflows
+	IntervalTrigger   Runner // Executes interval-based workflows
+	BackfillTrigger   Runner // Executes backfill workflows
+	BatchRerunTrigger Runner // Executes batch rerun workflows
 }
 
-// NewReconciler returns a new TriggerRun Reconciler.
+// NewReconciler creates a new TriggerRun Reconciler with the provided dependencies.
+//
+// The reconciler is initialized with Runner implementations for each supported trigger type.
+// The API handler is configured during registration through the Register method.
 func NewReconciler(p Params) *Reconciler {
 	return &Reconciler{
 		apiHandlerFactory: p.APIHandlerFactory,
@@ -63,7 +110,14 @@ func NewReconciler(p Params) *Reconciler {
 	}
 }
 
-// Reconcile reconciles the TriggerRun object
+// Reconcile implements the controller-runtime Reconciler interface for TriggerRun resources.
+//
+// This method is invoked by the controller framework whenever a TriggerRun resource is
+// created, updated, or periodically requeued. It fetches the resource from Kubernetes
+// and delegates to the reconcile helper method for state machine processing.
+//
+// If the resource has been deleted, reconciliation completes without error. Other fetch
+// errors are returned to be retried by the controller framework.
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("triggerRun", req.NamespacedName)
 	triggerRun := &v2pb.TriggerRun{}
@@ -78,6 +132,23 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	return r.reconcile(ctx, log, triggerRun)
 }
 
+// reconcile processes a TriggerRun through its state machine.
+//
+// State Machine Logic:
+//
+//   - Terminal states (SUCCEEDED/FAILED/KILLED): Mark resource immutable and stop reconciliation
+//   - INVALID: Start workflow execution using appropriate Runner, transition to RUNNING or FAILED
+//   - RUNNING: Check workflow status, handle kill requests if Spec.Kill is true
+//
+// The method performs the following operations:
+//  1. Check if resource is in terminal state and mark immutable if needed
+//  2. Create deep copy of resource to detect changes
+//  3. Execute state transitions through labeled StateMachine switch
+//  4. Persist status updates if resource changed
+//  5. Requeue after 60 seconds for continued monitoring
+//
+// Kill requests are processed by setting Spec.Kill=true, which causes the reconciler
+// to invoke the Runner's Kill method during the next reconciliation.
 func (r *Reconciler) reconcile(
 	ctx context.Context, log logr.Logger, triggerRun *v2pb.TriggerRun,
 ) (ctrl.Result, error) {
@@ -160,7 +231,15 @@ StateMachine:
 	return ctrl.Result{RequeueAfter: 60 * time.Second}, nil
 }
 
-// Register is used to register the controller with the manager.
+// Register registers the TriggerRun controller with the controller manager.
+//
+// This method configures the controller with:
+//   - API handler for Kubernetes operations
+//   - Structured logger with "triggerRun" prefix
+//   - TriggerRun resource watch
+//   - Maximum concurrent reconciles setting
+//
+// Returns an error if API handler creation or controller registration fails.
 func (r *Reconciler) Register(mgr ctrl.Manager) error {
 	r.Scheme = mgr.GetScheme()
 	handler, err := r.apiHandlerFactory.GetAPIHandler(mgr.GetClient())
@@ -177,6 +256,11 @@ func (r *Reconciler) Register(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
+// getRunner selects the appropriate Runner implementation based on the TriggerRun's trigger type.
+//
+// The selection is made using GetTriggerType which examines the TriggerRun spec to determine
+// whether it's a batch rerun, backfill, interval, or cron trigger. The default is CronTrigger
+// if the type cannot be determined.
 func (r *Reconciler) getRunner(tr *v2pb.TriggerRun) Runner {
 	triggerType := GetTriggerType(tr)
 	switch triggerType {

--- a/go/components/triggerrun/cron_trigger.go
+++ b/go/components/triggerrun/cron_trigger.go
@@ -11,12 +11,24 @@ import (
 	k8stypes "k8s.io/apimachinery/pkg/types"
 )
 
+// cronTrigger implements the Runner interface for cron-scheduled recurring workflows.
+//
+// This implementation manages workflows that execute on a recurring schedule defined by
+// cron expressions. The workflow continues running until explicitly killed, spawning
+// child workflow executions at each scheduled interval.
+//
+// The cron schedule is read from TriggerRun.Spec.Trigger.CronSchedule.Cron and passed
+// to the workflow engine's CronSchedule option.
 type cronTrigger struct {
-	Log            logr.Logger
-	WorkflowClient clientInterface.WorkflowClient
+	Log            logr.Logger                    // Structured logger for trigger operations
+	WorkflowClient clientInterface.WorkflowClient // Workflow engine client (Cadence/Temporal)
 }
 
-// NewCronTrigger returns a new cronTrigger
+// NewCronTrigger creates a new cron trigger Runner.
+//
+// The returned Runner manages recurring scheduled workflows using cron expressions.
+// It requires a logger for structured logging and a workflow client for interacting
+// with the workflow engine.
 func NewCronTrigger(log logr.Logger, workflowClient clientInterface.WorkflowClient) Runner {
 	return &cronTrigger{
 		Log:            log,
@@ -24,7 +36,24 @@ func NewCronTrigger(log logr.Logger, workflowClient clientInterface.WorkflowClie
 	}
 }
 
-// Run starts the cron trigger
+// Run starts a recurring cron-scheduled workflow.
+//
+// This method performs the following operations:
+//  1. Generate deterministic workflow ID from namespace and name
+//  2. Check if workflow is already running (idempotent start)
+//  3. Configure workflow options with cron schedule
+//  4. Start workflow execution with "trigger.CronTrigger" workflow type
+//  5. Return status with workflow URL for monitoring
+//
+// The workflow uses:
+//   - ID: <namespace>.<name> (deterministic for idempotency)
+//   - TaskList: "trigger_run"
+//   - ExecutionStartToCloseTimeout: 1 year (effectively no timeout)
+//   - DecisionTaskStartToCloseTimeout: 30 seconds
+//   - CronSchedule: From TriggerRun spec
+//
+// Returns State=RUNNING if workflow starts successfully or is already running,
+// State=FAILED if workflow start fails.
 func (r *cronTrigger) Run(ctx context.Context, triggerRun *v2pb.TriggerRun) (v2pb.TriggerRunStatus, error) {
 	log := r.Log.WithValues("triggerRun", k8stypes.NamespacedName{
 		Namespace: triggerRun.Namespace,
@@ -89,7 +118,14 @@ func (r *cronTrigger) Run(ctx context.Context, triggerRun *v2pb.TriggerRun) (v2p
 	}, nil
 }
 
-// Kill kills (terminates) the cron trigger
+// Kill terminates a running cron-scheduled workflow.
+//
+// This method stops the recurring workflow execution, preventing future scheduled
+// runs from being spawned. The workflow termination is handled by the shared
+// killWorkflow utility function.
+//
+// Returns State=KILLED on success. If no workflow is running, returns KILLED
+// without error (idempotent termination).
 func (r *cronTrigger) Kill(ctx context.Context, triggerRun *v2pb.TriggerRun) (v2pb.TriggerRunStatus, error) {
 	log := r.Log.WithValues("triggerRun", k8stypes.NamespacedName{
 		Namespace: triggerRun.Namespace,
@@ -99,7 +135,19 @@ func (r *cronTrigger) Kill(ctx context.Context, triggerRun *v2pb.TriggerRun) (v2
 	return killWorkflow(ctx, triggerRun, log, r.WorkflowClient, domain)
 }
 
-// GetStatus gets the status of a running cron trigger
+// GetStatus retrieves the execution status of a cron-scheduled workflow.
+//
+// This method checks for open workflow executions and maps workflow states to
+// TriggerRun states. For cron triggers, the workflow should remain running until
+// explicitly killed, so an active execution indicates RUNNING state.
+//
+// The status check is delegated to getRecurringRunWorkflowStatus which handles
+// state mapping for recurring workflows:
+//   - Open execution exists → RUNNING
+//   - Terminated/Canceled → KILLED
+//   - Failed/TimedOut → FAILED
+//
+// Returns the current TriggerRunStatus with state and error information if applicable.
 func (r *cronTrigger) GetStatus(
 	ctx context.Context, triggerRun *v2pb.TriggerRun,
 ) (v2pb.TriggerRunStatus, error) {

--- a/go/components/triggerrun/module.go
+++ b/go/components/triggerrun/module.go
@@ -8,11 +8,33 @@ import (
 	clientInterface "github.com/michelangelo-ai/michelangelo/go/base/workflowclient/interface"
 )
 
-// Module provides fx Options for triggerrun controller.
+// Module provides Uber FX dependency injection options for the TriggerRun controller.
+//
+// This module registers the controller with the Kubernetes controller manager and
+// initializes Runner implementations for supported trigger types (cron and backfill).
+//
+// Usage:
+//
+//	fx.New(
+//	    triggerrun.Module,
+//	    // other modules...
+//	)
 var Module = fx.Options(
 	fx.Invoke(register),
 )
 
+// register initializes and registers the TriggerRun controller with the manager.
+//
+// This function is invoked by Uber FX during application startup. It creates Runner
+// implementations for cron and backfill triggers, constructs the reconciler with these
+// runners, and registers the controller with the Kubernetes controller manager.
+//
+// Currently supports:
+//   - CronTrigger: Recurring workflows based on cron expressions
+//   - BackfillTrigger: One-time workflows for historical data processing
+//
+// Additional trigger types (interval and batch rerun) are planned but not yet implemented.
+// See TODO(#548) for tracking remaining trigger type implementations.
 func register(
 	mgr manager.Manager,
 	apiHandlerFactory apiHandler.Factory,

--- a/go/components/triggerrun/runner.go
+++ b/go/components/triggerrun/runner.go
@@ -6,15 +6,52 @@ import (
 	v2pb "github.com/michelangelo-ai/michelangelo/proto/api/v2"
 )
 
-// Runner interface to be implemented for different triggering engines
-// Each method return a PipelineRunStatus, which contains execution state and metadata, e.g. workflow id, url, etc.
+// Runner defines the interface for trigger execution engines.
+//
+// This interface abstracts workflow lifecycle operations for different trigger types
+// (cron, backfill, interval, batch rerun). Each Runner implementation manages workflow
+// execution through Cadence or Temporal, providing status tracking and termination support.
+//
+// All methods return a TriggerRunStatus containing the execution state and metadata
+// including workflow ID, run ID, and workflow UI URL.
+//
+// Implementations:
+//   - cronTrigger: Manages recurring workflows with cron schedules
+//   - backfillTrigger: Manages one-time backfill workflows
+//   - intervalTrigger: Manages interval-based workflows (planned)
+//   - batchRerunTrigger: Manages batch rerun workflows (planned)
 type Runner interface {
-	// Run start a trigger run
+	// Run starts workflow execution for a trigger run.
+	//
+	// This method initiates a workflow using the workflow client, configures execution
+	// parameters (task list, timeouts, schedules), and returns the initial status.
+	//
+	// For recurring triggers (cron/interval), this starts a long-running workflow that
+	// spawns child workflows on schedule. For one-time triggers (backfill), this starts
+	// a single workflow execution.
+	//
+	// Returns TriggerRunStatus with State=RUNNING on success or State=FAILED on error.
 	Run(ctx context.Context, triggerRun *v2pb.TriggerRun) (v2pb.TriggerRunStatus, error)
 
-	// Kill terminate a trigger run
+	// Kill terminates an active trigger run workflow.
+	//
+	// This method stops workflow execution by calling TerminateWorkflow on the workflow
+	// client. For recurring triggers, this stops future scheduled executions.
+	//
+	// Returns TriggerRunStatus with State=KILLED on success. If the workflow is already
+	// terminated or not running, returns KILLED without error.
 	Kill(ctx context.Context, triggerRun *v2pb.TriggerRun) (v2pb.TriggerRunStatus, error)
 
-	// GetStatus get status of a trigger run
+	// GetStatus retrieves the current execution status of a trigger run.
+	//
+	// This method queries the workflow engine for execution status and maps workflow
+	// states to TriggerRunStatus states:
+	//  - Running → RUNNING
+	//  - Completed → SUCCEEDED
+	//  - Failed/TimedOut → FAILED
+	//  - Terminated/Canceled → KILLED
+	//
+	// For recurring triggers, this checks if an open workflow execution exists.
+	// For one-time triggers, this describes the specific workflow execution.
 	GetStatus(ctx context.Context, triggerRun *v2pb.TriggerRun) (v2pb.TriggerRunStatus, error)
 }

--- a/go/components/triggerrun/util.go
+++ b/go/components/triggerrun/util.go
@@ -13,21 +13,38 @@ import (
 	v2pb "github.com/michelangelo-ai/michelangelo/proto/api/v2"
 )
 
-// TriggerType constants for different trigger types
+// TriggerType constants define the supported trigger types.
+//
+// These constants are used by GetTriggerType to determine which Runner implementation
+// should handle a specific TriggerRun resource.
 const (
-	TriggerTypeCron       = "cron"
-	TriggerTypeBackfill   = "backfill"
-	TriggerTypeBatchRerun = "batch_rerun"
-	TriggerTypeInterval   = "interval"
-	TriggerTypeUnknown    = "unknown"
+	TriggerTypeCron       = "cron"        // Recurring workflows based on cron expressions
+	TriggerTypeBackfill   = "backfill"    // One-time workflows for historical data processing
+	TriggerTypeBatchRerun = "batch_rerun" // Bulk reprocessing of previously executed workflows
+	TriggerTypeInterval   = "interval"    // Workflows triggered at fixed intervals
+	TriggerTypeUnknown    = "unknown"     // Unknown or unsupported trigger type
 )
 
-// CreateTriggerRequest DTO for the CreateTrigger workflow
+// CreateTriggerRequest is a data transfer object for trigger workflow execution.
+//
+// This struct is passed as the workflow input when starting trigger workflows
+// (both cron and backfill). It contains the complete TriggerRun specification
+// needed for workflow execution.
 type CreateTriggerRequest struct {
-	TriggerRun *v2pb.TriggerRun
+	TriggerRun *v2pb.TriggerRun // The TriggerRun resource containing execution parameters
 }
 
-// util function to kill workflow execution for cron trigger
+// killWorkflow terminates a running workflow execution.
+//
+// This shared utility function is used by all Runner implementations to stop
+// workflow execution. It performs the following operations:
+//  1. Generate workflow ID from TriggerRun namespace and name
+//  2. Query for open workflow execution using workflow client
+//  3. Call TerminateWorkflow if execution is running
+//  4. Return KILLED status regardless of whether workflow was running (idempotent)
+//
+// Returns State=KILLED on success. If no workflow is running, returns KILLED
+// without error (idempotent behavior).
 func killWorkflow(ctx context.Context, triggerRun *v2pb.TriggerRun, log logr.Logger, workflowClient clientInterface.WorkflowClient, domain string) (v2pb.TriggerRunStatus, error) {
 	wid := generateWorkflowID(triggerRun)
 	rid, err := getWorkflowOpenRunID(ctx, wid, workflowClient, domain)
@@ -61,7 +78,21 @@ func killWorkflow(ctx context.Context, triggerRun *v2pb.TriggerRun, log logr.Log
 	return triggerRun.Status, nil
 }
 
-// util function to get workflow execution status for recurring run trigger
+// getRecurringRunWorkflowStatus retrieves workflow status for recurring triggers (cron/interval).
+//
+// This function checks for open workflow executions and maps workflow states to
+// TriggerRun states. For recurring triggers, workflows should remain running until
+// explicitly terminated.
+//
+// State mapping:
+//   - Open execution with valid timestamp → RUNNING
+//   - Terminated/Canceled → KILLED (user-initiated termination)
+//   - Failed/TimedOut → FAILED (execution failure)
+//
+// The function uses ListOpenWorkflow to find active executions, examining the
+// execution time and status to determine the current state.
+//
+// Returns TriggerRunStatus with the current state and error message if applicable.
 func getRecurringRunWorkflowStatus(ctx context.Context, triggerRun *v2pb.TriggerRun, log logr.Logger, workflowClient clientInterface.WorkflowClient, domain string) (v2pb.TriggerRunStatus, error) {
 	wid := generateWorkflowID(triggerRun)
 	execInfo, err := getWorkflowOpenExecution(ctx, wid, workflowClient, domain)
@@ -114,7 +145,22 @@ func getRecurringRunWorkflowStatus(ctx context.Context, triggerRun *v2pb.Trigger
 	return v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING}, nil
 }
 
-// util function to get workflow execution status for adhoc run trigger
+// getAdhocRunWorkflowStatus retrieves workflow status for one-time triggers (backfill/batch rerun).
+//
+// This function queries the workflow engine for a specific workflow execution identified
+// by ExecutionWorkflowId in the TriggerRun status. It maps workflow execution states to
+// TriggerRun states.
+//
+// State mapping:
+//   - Running → RUNNING
+//   - Completed → SUCCEEDED
+//   - Failed/TimedOut/Canceled/Terminated → FAILED
+//
+// The function uses GetWorkflowExecutionInfo to describe the workflow execution and
+// determine its current state. Unlike recurring workflows, one-time workflows are
+// expected to complete or fail rather than run indefinitely.
+//
+// Returns an error if ExecutionWorkflowId is empty or if the workflow cannot be described.
 func getAdhocRunWorkflowStatus(ctx context.Context, triggerRun *v2pb.TriggerRun, log logr.Logger, workflowClient clientInterface.WorkflowClient, domain string) (v2pb.TriggerRunStatus, error) {
 	var (
 		execResponse *clientInterface.WorkflowExecutionInfo
@@ -166,7 +212,16 @@ func getAdhocRunWorkflowStatus(ctx context.Context, triggerRun *v2pb.TriggerRun,
 	}
 }
 
-// util function to get workflow open execution runID
+// getWorkflowOpenRunID retrieves the run ID of an open workflow execution.
+//
+// This function queries for open workflow executions matching the provided workflow ID
+// and extracts the run ID if an execution is found. The run ID uniquely identifies a
+// specific execution instance of a workflow.
+//
+// Returns:
+//   - Non-nil string pointer: Run ID of the open execution
+//   - nil: No open execution found (workflow not running or completed)
+//   - error: Failed to query workflow engine
 func getWorkflowOpenRunID(ctx context.Context, wid string, workflowClient clientInterface.WorkflowClient, domain string) (*string, error) {
 	execution, err := getWorkflowOpenExecution(ctx, wid, workflowClient, domain)
 	if err != nil {
@@ -178,7 +233,19 @@ func getWorkflowOpenRunID(ctx context.Context, wid string, workflowClient client
 	return &execution.Execution.RunID, nil
 }
 
-// util function to get workflow open execution
+// getWorkflowOpenExecution retrieves open workflow execution information.
+//
+// This function queries the workflow engine for open (currently running) workflow
+// executions matching the provided workflow ID. It uses ListOpenWorkflow with a time
+// filter from epoch start to present to find matching executions.
+//
+// The function uses exponential backoff retry (max 3 attempts) to handle transient
+// workflow engine errors.
+//
+// Returns:
+//   - Non-nil WorkflowExecutionInfo: Information about the open execution
+//   - nil: No open execution found (workflow not running or completed)
+//   - error: Failed to query workflow engine after retries
 func getWorkflowOpenExecution(ctx context.Context, wid string, workflowClient clientInterface.WorkflowClient, domain string) (*clientInterface.WorkflowExecutionInfo, error) {
 	var (
 		err      error
@@ -210,12 +277,34 @@ func getWorkflowOpenExecution(ctx context.Context, wid string, workflowClient cl
 	return &response.Executions[0], nil
 }
 
-// util function to generate workflow ID
+// generateWorkflowID creates a deterministic workflow ID from a TriggerRun resource.
+//
+// The workflow ID is constructed as "<namespace>.<name>" which ensures uniqueness
+// within the workflow engine domain and allows idempotent workflow starts. Using
+// the same workflow ID for repeated starts prevents duplicate workflow executions.
+//
+// Returns a string in the format "namespace.name".
 func generateWorkflowID(tr *v2pb.TriggerRun) string {
 	return tr.Namespace + "." + tr.Name
 }
 
-// util function to get workflow URL based on provider
+// getWorkflowURL constructs a web UI URL for workflow monitoring.
+//
+// This function generates URLs to access workflow execution details in either
+// Cadence Web or Temporal Web UI. The URL format differs between providers:
+//
+// Temporal:
+//   - Base URL: http://localhost:8080
+//   - Path: /namespaces/{domain}/workflows/{workflowId}
+//
+// Cadence (default):
+//   - Base URL: http://localhost:8088
+//   - Path: /domains/{domain}/workflows/{workflowId}
+//
+// Note: These URLs are configured for local development. In production environments,
+// the base URLs should be configured based on the actual Cadence/Temporal deployment.
+//
+// Returns a complete URL string for workflow monitoring.
 func getWorkflowURL(wid string, provider string) string {
 	domain := "default" // Default domain for both Cadence and Temporal
 	var (
@@ -237,12 +326,34 @@ func getWorkflowURL(wid string, provider string) string {
 	return logURL + path
 }
 
-// util function to check if the trigger run is in a terminate state
+// isTerminateState checks if a TriggerRun is in a terminal state.
+//
+// Terminal states are SUCCEEDED, FAILED, or KILLED. Once a TriggerRun reaches
+// a terminal state, it should be marked immutable and no further reconciliation
+// is required.
+//
+// Returns true if the TriggerRun is in a terminal state, false otherwise.
 func isTerminateState(tr *v2pb.TriggerRun) bool {
 	return tr.Status.State == v2pb.TRIGGER_RUN_STATE_FAILED || tr.Status.State == v2pb.TRIGGER_RUN_STATE_KILLED || tr.Status.State == v2pb.TRIGGER_RUN_STATE_SUCCEEDED
 }
 
-// GetTriggerType returns the trigger type for a given triggerRun
+// GetTriggerType determines the trigger type from a TriggerRun specification.
+//
+// This function examines the TriggerRun spec to identify which trigger type should
+// handle the resource. The determination is made by checking for specific fields
+// in priority order:
+//
+//  1. BatchRerun: Spec.Trigger.BatchRerun is set
+//  2. Backfill: Both Spec.StartTimestamp and Spec.EndTimestamp are set
+//  3. Interval: Spec.Trigger.IntervalSchedule is set
+//  4. Cron: Spec.Trigger.CronSchedule is set
+//  5. Unknown: None of the above conditions match
+//
+// The returned type string is used by the Reconciler to select the appropriate
+// Runner implementation.
+//
+// Returns one of the TriggerType constants (TriggerTypeCron, TriggerTypeBackfill,
+// TriggerTypeInterval, TriggerTypeBatchRerun, or TriggerTypeUnknown).
 func GetTriggerType(tr *v2pb.TriggerRun) string {
 	if tr.Spec.Trigger.GetBatchRerun() != nil {
 		return TriggerTypeBatchRerun

--- a/go/components/utils/proto.go
+++ b/go/components/utils/proto.go
@@ -1,3 +1,26 @@
+// Package utils provides utility functions for protobuf type conversions.
+//
+// This package offers bidirectional conversion between Protocol Buffer types
+// (proto.Value, proto.Struct, proto.ListValue) and Go's native interface{},
+// map[string]interface{}, and []interface{} types.
+//
+// The conversions support the full range of JSON-compatible types including:
+//   - Primitive types (string, bool, numbers)
+//   - Null values
+//   - Nested structures (maps and lists)
+//   - Binary data (encoded as base64 strings)
+//
+// These utilities are particularly useful when working with dynamic data that
+// needs to be passed between Go code and workflow engines (Cadence/Temporal) or
+// other systems that use Protocol Buffers for serialization.
+//
+// Usage:
+//
+//	// Convert proto.Value to Go interface{}
+//	goValue, err := MapProtoValueToInterface(protoValue)
+//
+//	// Convert Go interface{} to proto.Value
+//	protoValue, err := NewValue(goValue)
 package utils
 
 import (
@@ -8,7 +31,18 @@ import (
 	"github.com/gogo/protobuf/types"
 )
 
-// MapProtoValueToInterface transforms given proto Value to interface{} generic object representation
+// MapProtoValueToInterface converts a proto.Value to a Go interface{}.
+//
+// This function recursively converts Protocol Buffer Value types to their
+// corresponding Go representations:
+//   - StringValue → string
+//   - BoolValue → bool
+//   - NumberValue → float64
+//   - NullValue → nil
+//   - StructValue → map[string]interface{} (recursive)
+//   - ListValue → []interface{} (recursive)
+//
+// Returns an error if the proto.Value contains an unexpected or unsupported kind.
 func MapProtoValueToInterface(v *types.Value) (interface{}, error) {
 	if v == nil {
 		return nil, nil
@@ -35,7 +69,12 @@ func MapProtoValueToInterface(v *types.Value) (interface{}, error) {
 	return nil, fmt.Errorf("failed to map proto Value; unexpected kind: %#v", kind)
 }
 
-// MapProtoStructToInterface transforms given proto Struct to map[string]interface{} generic object representation
+// MapProtoStructToInterface converts a proto.Struct to a Go map[string]interface{}.
+//
+// This function recursively converts a Protocol Buffer Struct (similar to a JSON object)
+// to a Go map. Each field value is converted using MapProtoValueToInterface.
+//
+// Returns an error if any field value conversion fails.
 func MapProtoStructToInterface(v *types.Struct) (map[string]interface{}, error) {
 	if v == nil {
 		return nil, nil
@@ -51,7 +90,12 @@ func MapProtoStructToInterface(v *types.Struct) (map[string]interface{}, error) 
 	return r, nil
 }
 
-// MapProtoListValueToInterface transforms given proto ListValue to []interface{} generic object representation
+// MapProtoListValueToInterface converts a proto.ListValue to a Go []interface{}.
+//
+// This function recursively converts a Protocol Buffer ListValue (similar to a JSON array)
+// to a Go slice. Each element is converted using MapProtoValueToInterface.
+//
+// Returns an error if any element conversion fails.
 func MapProtoListValueToInterface(x *types.ListValue) ([]interface{}, error) {
 	if x == nil {
 		return nil, nil
@@ -73,25 +117,36 @@ func MapProtoListValueToInterface(x *types.ListValue) ([]interface{}, error) {
 
 // NewValue constructs a Value from a general-purpose Go interface.
 //
-//	╔════════════════════════╤════════════════════════════════════════════╗
-//	║ Go type                │ Conversion                                 ║
-//	╠════════════════════════╪════════════════════════════════════════════╣
-//	║ nil                    │ stored as NullValue                        ║
-//	║ bool                   │ stored as BoolValue                        ║
-//	║ int, int32, int64      │ stored as NumberValue                      ║
-//	║ uint, uint32, uint64   │ stored as NumberValue                      ║
-//	║ float32, float64       │ stored as NumberValue                      ║
-//	║ string                 │ stored as StringValue; must be valid UTF-8 ║
-//	║ []byte                 │ stored as StringValue; base64-encoded      ║
-//	║ map[string]interface{} │ stored as StructValue                      ║
-//	║ []interface{}          │ stored as ListValue                        ║
-//  ║ []map[string]interface{} | stored as ListValue					  ║
-//	╚════════════════════════╧════════════════════════════════════════════╝
+//		╔════════════════════════╤════════════════════════════════════════════╗
+//		║ Go type                │ Conversion                                 ║
+//		╠════════════════════════╪════════════════════════════════════════════╣
+//		║ nil                    │ stored as NullValue                        ║
+//		║ bool                   │ stored as BoolValue                        ║
+//		║ int, int32, int64      │ stored as NumberValue                      ║
+//		║ uint, uint32, uint64   │ stored as NumberValue                      ║
+//		║ float32, float64       │ stored as NumberValue                      ║
+//		║ string                 │ stored as StringValue; must be valid UTF-8 ║
+//		║ []byte                 │ stored as StringValue; base64-encoded      ║
+//		║ map[string]interface{} │ stored as StructValue                      ║
+//		║ []interface{}          │ stored as ListValue                        ║
+//	 ║ []map[string]interface{} | stored as ListValue					  ║
+//		╚════════════════════════╧════════════════════════════════════════════╝
 //
 // When converting an int64 or uint64 to a NumberValue, numeric precision loss
 // is possible since they are stored as a float64.
-
-// NewValue given interface{} type, produce *types.Value
+//
+// NewValue converts a Go interface{} to a proto.Value.
+//
+// This function performs type-based conversion from Go types to Protocol Buffer
+// Value types. It supports all primitive types, maps, slices, and byte arrays.
+//
+// Supported conversions are documented in the type table above. The function
+// recursively converts nested structures and validates UTF-8 encoding for strings.
+//
+// Returns an error if:
+//   - The input type is not supported
+//   - String values contain invalid UTF-8
+//   - Nested structure conversion fails
 func NewValue(v interface{}) (*types.Value, error) {
 	switch v := v.(type) {
 	case nil:
@@ -151,39 +206,46 @@ func NewValue(v interface{}) (*types.Value, error) {
 	}
 }
 
-// NewNullValue constructs a new null Value.
+// NewNullValue constructs a proto.Value representing a null value.
+//
+// This is equivalent to JSON's null value.
 func NewNullValue() *types.Value {
 	return &types.Value{Kind: &types.Value_NullValue{NullValue: types.NullValue_NULL_VALUE}}
 }
 
-// NewBoolValue constructs a new boolean Value.
+// NewBoolValue constructs a proto.Value representing a boolean.
 func NewBoolValue(v bool) *types.Value {
 	return &types.Value{Kind: &types.Value_BoolValue{BoolValue: v}}
 }
 
-// NewNumberValue constructs a new number Value.
+// NewNumberValue constructs a proto.Value representing a number.
+//
+// All numeric types are stored as float64 in Protocol Buffers.
 func NewNumberValue(v float64) *types.Value {
 	return &types.Value{Kind: &types.Value_NumberValue{NumberValue: v}}
 }
 
-// NewStringValue constructs a new string Value.
+// NewStringValue constructs a proto.Value representing a string.
 func NewStringValue(v string) *types.Value {
 	return &types.Value{Kind: &types.Value_StringValue{StringValue: v}}
 }
 
-// NewStructValue constructs a new struct Value.
+// NewStructValue constructs a proto.Value wrapping a proto.Struct.
 func NewStructValue(v *types.Struct) *types.Value {
 	return &types.Value{Kind: &types.Value_StructValue{StructValue: v}}
 }
 
-// NewListValue creates a new protobuf list value.
+// NewListValue constructs a proto.Value wrapping a proto.ListValue.
 func NewListValue(v *types.ListValue) *types.Value {
 	return &types.Value{Kind: &types.Value_ListValue{ListValue: v}}
 }
 
-// NewStruct constructs a Struct from a general-purpose Go map.
-// The map keys must be valid UTF-8.
-// The map values are converted using NewValue.
+// NewStruct constructs a proto.Struct from a Go map[string]interface{}.
+//
+// The map keys must be valid UTF-8 strings. The map values are recursively
+// converted using NewValue.
+//
+// Returns an error if any key is invalid UTF-8 or any value conversion fails.
 func NewStruct(v map[string]interface{}) (*types.Struct, error) {
 	x := &types.Struct{Fields: make(map[string]*types.Value, len(v))}
 	for k, v := range v {
@@ -199,8 +261,11 @@ func NewStruct(v map[string]interface{}) (*types.Struct, error) {
 	return x, nil
 }
 
-// NewList constructs a ListValue from a general-purpose Go slice.
-// The slice elements are converted using NewValue.
+// NewList constructs a proto.ListValue from a Go []interface{}.
+//
+// The slice elements are recursively converted using NewValue.
+//
+// Returns an error if any element conversion fails.
 func NewList(v []interface{}) (*types.ListValue, error) {
 	x := &types.ListValue{Values: make([]*types.Value, len(v))}
 	for i, v := range v {
@@ -213,7 +278,10 @@ func NewList(v []interface{}) (*types.ListValue, error) {
 	return x, nil
 }
 
-// NewStringList constructs a ListValue from a []string
+// NewStringList constructs a proto.ListValue from a Go []string.
+//
+// This is a specialized version of NewList optimized for string slices.
+// Each string is converted to a proto.Value using NewStringValue.
 func NewStringList(v []string) (*types.ListValue, error) {
 	x := &types.ListValue{Values: make([]*types.Value, len(v))}
 	for i, v := range v {
@@ -222,8 +290,12 @@ func NewStringList(v []string) (*types.ListValue, error) {
 	return x, nil
 }
 
-// NewListMap constructs a ListValue from a map[string]interface.
-// The slice elements are converted using NewStruct.
+// NewListMap constructs a proto.ListValue from a Go []map[string]interface{}.
+//
+// This is a specialized version of NewList for slices of maps. Each map is
+// converted to a proto.Struct using NewStruct.
+//
+// Returns an error if any map conversion fails.
 func NewListMap(v []map[string]interface{}) (*types.ListValue, error) {
 	x := &types.ListValue{Values: make([]*types.Value, len(v))}
 	for i, v := range v {


### PR DESCRIPTION
## Summary

Added comprehensive Go documentation to `go/components/triggerrun` and `go/components/utils` following Effective Go guidelines.

Closes #651

### TriggerRun Package (`go/components/triggerrun/`)
- **Package-level documentation**: Explains trigger-based workflow orchestration architecture
- **controller.go**: State machine reconciler managing TriggerRun lifecycle (INVALID → RUNNING → terminal states)
- **module.go**: Uber FX module with dependency injection for trigger types
- **runner.go**: Interface defining workflow lifecycle operations (Run/Kill/GetStatus)
- **cron_trigger.go**: Runner implementation for recurring workflows using cron expressions
- **backfill_trigger.go**: Runner implementation for one-time historical data processing
- **util.go**: Utility functions for workflow management, status checking, and URL generation

### Utils Package (`go/components/utils/`)
- **proto.go**: Bidirectional protobuf type conversions between proto.Value and Go types
- Complete documentation for all conversion functions (Map*/New*)
- Type conversion table documenting all supported Go → Protocol Buffer mappings

## Documentation Coverage

All files include:
- Package-level documentation explaining purpose and architecture
- Struct documentation with field descriptions
- Function/method documentation with:
  - Operation descriptions
  - Parameter documentation
  - Return value descriptions
  - State transition diagrams (where applicable)
  - Integration details with Cadence/Temporal workflow engines

## Test Plan
- [x] Verify documentation builds without errors
- [x] Review documentation for clarity and completeness
- [x] Ensure all exported symbols are documented
- [x] Confirm compliance with Effective Go guidelines