### PR TITLE
Model Manager: Add module level docstrings for every module

### DIFF
--- a/python/michelangelo/lib/model_manager/_private/constants/__init__.py
+++ b/python/michelangelo/lib/model_manager/_private/constants/__init__.py
@@ -1,2 +1,4 @@
+"""Private constants for the model manager."""
+
 # flake8: noqa:F401
 from .triton_backend_type import TritonBackendType

--- a/python/michelangelo/lib/model_manager/_private/constants/tests/triton_backend_type_test.py
+++ b/python/michelangelo/lib/model_manager/_private/constants/tests/triton_backend_type_test.py
@@ -1,3 +1,5 @@
+"""Tests for TritonBackendType constants."""
+
 from unittest import TestCase
 
 from michelangelo.lib.model_manager._private.constants import TritonBackendType

--- a/python/michelangelo/lib/model_manager/_private/constants/triton_backend_type.py
+++ b/python/michelangelo/lib/model_manager/_private/constants/triton_backend_type.py
@@ -1,3 +1,6 @@
+"""Triton backend type constants."""
+
+
 class TritonBackendType:
     """Triton Inference Server backend types for deployable model packages.
 

--- a/python/michelangelo/lib/model_manager/_private/packager/custom_triton/config_pbtxt.py
+++ b/python/michelangelo/lib/model_manager/_private/packager/custom_triton/config_pbtxt.py
@@ -1,3 +1,5 @@
+"""Config pbtxt generation module."""
+
 from michelangelo.lib.model_manager._private.constants.triton_backend_type import (
     TritonBackendType,
 )

--- a/python/michelangelo/lib/model_manager/_private/packager/custom_triton/constants.py
+++ b/python/michelangelo/lib/model_manager/_private/packager/custom_triton/constants.py
@@ -1,1 +1,3 @@
+"""Constants for custom triton packager."""
+
 MODEL_CLASS_FILE_NAME = "model_class.txt"

--- a/python/michelangelo/lib/model_manager/_private/packager/custom_triton/tests/config_pbtxt_test.py
+++ b/python/michelangelo/lib/model_manager/_private/packager/custom_triton/tests/config_pbtxt_test.py
@@ -1,3 +1,5 @@
+"""Tests for config.pbtxt template rendering."""
+
 from textwrap import dedent
 from unittest import TestCase
 

--- a/python/michelangelo/lib/model_manager/_private/packager/template_renderer/__init__.py
+++ b/python/michelangelo/lib/model_manager/_private/packager/template_renderer/__init__.py
@@ -1,3 +1,5 @@
+"""Template renderers for model packaging."""
+
 # flake8: noqa:F401
 from .template_renderer import TemplateRenderer
 from .triton_template_renderer import TritonTemplateRenderer

--- a/python/michelangelo/lib/model_manager/_private/packager/template_renderer/template_renderer.py
+++ b/python/michelangelo/lib/model_manager/_private/packager/template_renderer/template_renderer.py
@@ -1,3 +1,5 @@
+"""Template renderer module."""
+
 from typing import Optional
 
 from jinja2 import (

--- a/python/michelangelo/lib/model_manager/_private/packager/template_renderer/tests/template_renderer_test.py
+++ b/python/michelangelo/lib/model_manager/_private/packager/template_renderer/tests/template_renderer_test.py
@@ -1,3 +1,5 @@
+"""Tests for template renderer."""
+
 from unittest import TestCase
 
 from michelangelo.lib.model_manager._private.packager.template_renderer import (

--- a/python/michelangelo/lib/model_manager/_private/packager/template_renderer/triton_template_renderer.py
+++ b/python/michelangelo/lib/model_manager/_private/packager/template_renderer/triton_template_renderer.py
@@ -1,3 +1,5 @@
+"""Triton template renderer module."""
+
 from michelangelo.lib.model_manager._private.packager.template_renderer import (
     TemplateRenderer,
 )

--- a/python/michelangelo/lib/model_manager/_private/packager/templates/__init__.py
+++ b/python/michelangelo/lib/model_manager/_private/packager/templates/__init__.py
@@ -1,2 +1,1 @@
 """Templates for model packaging."""
-

--- a/python/michelangelo/lib/model_manager/_private/packager/templates/__init__.py
+++ b/python/michelangelo/lib/model_manager/_private/packager/templates/__init__.py
@@ -1,0 +1,2 @@
+"""Templates for model packaging."""
+

--- a/python/michelangelo/lib/model_manager/_private/schema/common/__init__.py
+++ b/python/michelangelo/lib/model_manager/_private/schema/common/__init__.py
@@ -1,2 +1,4 @@
+"""Common schema utilities."""
+
 # flake8: noqa:F401
 from .serde import dict_to_schema, dict_to_schema_item, schema_to_dict, schema_to_yaml

--- a/python/michelangelo/lib/model_manager/_private/schema/common/serde.py
+++ b/python/michelangelo/lib/model_manager/_private/schema/common/serde.py
@@ -1,3 +1,5 @@
+"""Schema serialization and deserialization."""
+
 from dataclasses import asdict, fields
 
 import yaml

--- a/python/michelangelo/lib/model_manager/_private/schema/common/tests/serde_test.py
+++ b/python/michelangelo/lib/model_manager/_private/schema/common/tests/serde_test.py
@@ -1,3 +1,5 @@
+"""Tests for schema serialization."""
+
 from unittest import TestCase
 
 import yaml

--- a/python/michelangelo/lib/model_manager/_private/schema/triton/__init__.py
+++ b/python/michelangelo/lib/model_manager/_private/schema/triton/__init__.py
@@ -1,3 +1,5 @@
+"""Triton schema utilities."""
+
 # flake8: noqa:F401
 from .config_schema import convert_model_schema, convert_schema_to_dict, convert_shape
 from .data_type import DATA_TYPE_MAPPING, convert_data_type

--- a/python/michelangelo/lib/model_manager/_private/schema/triton/config_schema.py
+++ b/python/michelangelo/lib/model_manager/_private/schema/triton/config_schema.py
@@ -1,3 +1,5 @@
+"""Config schema conversion module."""
+
 from michelangelo.lib.model_manager._private.schema.triton.data_type import (
     convert_data_type,
 )

--- a/python/michelangelo/lib/model_manager/_private/schema/triton/data_type.py
+++ b/python/michelangelo/lib/model_manager/_private/schema/triton/data_type.py
@@ -1,3 +1,5 @@
+"""Triton data type conversion module."""
+
 from michelangelo.lib.model_manager.schema import DataType
 
 # Mapping from ModelSchema data types to Triton data types.

--- a/python/michelangelo/lib/model_manager/_private/schema/triton/tests/config_schema_test.py
+++ b/python/michelangelo/lib/model_manager/_private/schema/triton/tests/config_schema_test.py
@@ -1,3 +1,5 @@
+"""Tests for config schema conversion."""
+
 from unittest import TestCase
 
 from michelangelo.lib.model_manager._private.schema.triton import (

--- a/python/michelangelo/lib/model_manager/_private/schema/triton/tests/triton_data_type_test.py
+++ b/python/michelangelo/lib/model_manager/_private/schema/triton/tests/triton_data_type_test.py
@@ -1,3 +1,5 @@
+"""Tests for triton data type conversion."""
+
 from unittest import TestCase
 
 from michelangelo.lib.model_manager._private.schema.triton.data_type import (

--- a/python/michelangelo/lib/model_manager/_private/schema/triton/tests/validate_schema_test.py
+++ b/python/michelangelo/lib/model_manager/_private/schema/triton/tests/validate_schema_test.py
@@ -1,3 +1,5 @@
+"""Tests for schema validation."""
+
 from unittest import TestCase
 
 from michelangelo.lib.model_manager._private.schema.triton import (

--- a/python/michelangelo/lib/model_manager/_private/schema/triton/validate_schema.py
+++ b/python/michelangelo/lib/model_manager/_private/schema/triton/validate_schema.py
@@ -1,3 +1,5 @@
+"""Schema validation module."""
+
 from michelangelo.lib.model_manager._private.schema.triton.data_type import (
     DATA_TYPE_MAPPING,
 )

--- a/python/michelangelo/lib/model_manager/_private/utils/asset_utils/__init__.py
+++ b/python/michelangelo/lib/model_manager/_private/utils/asset_utils/__init__.py
@@ -1,2 +1,4 @@
+"""Asset utilities for model manager."""
+
 # flake8: noqa:F401
 from .download import download_assets

--- a/python/michelangelo/lib/model_manager/_private/utils/asset_utils/download.py
+++ b/python/michelangelo/lib/model_manager/_private/utils/asset_utils/download.py
@@ -1,3 +1,5 @@
+"""Asset download module."""
+
 import os
 import shutil
 

--- a/python/michelangelo/lib/model_manager/_private/utils/asset_utils/tests/download_test.py
+++ b/python/michelangelo/lib/model_manager/_private/utils/asset_utils/tests/download_test.py
@@ -1,3 +1,5 @@
+"""Tests for asset download utilities."""
+
 import os
 import tempfile
 from unittest import TestCase

--- a/python/michelangelo/lib/model_manager/_private/utils/data_utils/__init__.py
+++ b/python/michelangelo/lib/model_manager/_private/utils/data_utils/__init__.py
@@ -1,3 +1,5 @@
+"""Data utilities for model manager."""
+
 # flake8: noqa:F401
 from .output_data import validate_output_data, validate_output_data_with_model_schema
 from .sample_data import validate_sample_data, validate_sample_data_with_model_schema

--- a/python/michelangelo/lib/model_manager/_private/utils/data_utils/numpy_data.py
+++ b/python/michelangelo/lib/model_manager/_private/utils/data_utils/numpy_data.py
@@ -1,3 +1,5 @@
+"""Numpy data validation utilities."""
+
 from typing import Optional
 
 from numpy import ndarray

--- a/python/michelangelo/lib/model_manager/_private/utils/data_utils/output_data.py
+++ b/python/michelangelo/lib/model_manager/_private/utils/data_utils/output_data.py
@@ -1,3 +1,5 @@
+"""Output data validation utilities."""
+
 from typing import Optional
 
 from numpy import ndarray

--- a/python/michelangelo/lib/model_manager/_private/utils/data_utils/sample_data.py
+++ b/python/michelangelo/lib/model_manager/_private/utils/data_utils/sample_data.py
@@ -1,3 +1,5 @@
+"""Sample data validation utilities."""
+
 from typing import Optional
 
 from numpy import ndarray

--- a/python/michelangelo/lib/model_manager/_private/utils/data_utils/tests/numpy_data_test.py
+++ b/python/michelangelo/lib/model_manager/_private/utils/data_utils/tests/numpy_data_test.py
@@ -1,3 +1,5 @@
+"""Tests for numpy data validation."""
+
 from typing import Optional
 from unittest import TestCase
 

--- a/python/michelangelo/lib/model_manager/_private/utils/data_utils/tests/output_data_test.py
+++ b/python/michelangelo/lib/model_manager/_private/utils/data_utils/tests/output_data_test.py
@@ -1,3 +1,5 @@
+"""Tests for output data validation."""
+
 from typing import Optional
 from unittest import TestCase
 

--- a/python/michelangelo/lib/model_manager/_private/utils/data_utils/tests/sample_data_test.py
+++ b/python/michelangelo/lib/model_manager/_private/utils/data_utils/tests/sample_data_test.py
@@ -1,3 +1,5 @@
+"""Tests for sample data validation."""
+
 from typing import Optional
 from unittest import TestCase
 

--- a/python/michelangelo/lib/model_manager/_private/utils/module_finder/__init__.py
+++ b/python/michelangelo/lib/model_manager/_private/utils/module_finder/__init__.py
@@ -1,3 +1,5 @@
+"""Module finder utilities."""
+
 # flake8: noqa:F401
 from .dependency_files import find_dependency_files
 from .import_parser import get_imports

--- a/python/michelangelo/lib/model_manager/_private/utils/module_finder/import_parser.py
+++ b/python/michelangelo/lib/model_manager/_private/utils/module_finder/import_parser.py
@@ -1,3 +1,5 @@
+"""Import parsing utilities."""
+
 import ast
 import inspect
 from types import ModuleType

--- a/python/michelangelo/lib/model_manager/_private/utils/module_finder/tests/import_parser_test.py
+++ b/python/michelangelo/lib/model_manager/_private/utils/module_finder/tests/import_parser_test.py
@@ -1,3 +1,5 @@
+"""Tests for import parsing."""
+
 import ast
 import importlib
 from unittest import TestCase

--- a/python/michelangelo/lib/model_manager/_private/utils/module_utils/__init__.py
+++ b/python/michelangelo/lib/model_manager/_private/utils/module_utils/__init__.py
@@ -1,2 +1,4 @@
+"""Module manipulation utilities."""
+
 # flake8: noqa:F401
 from .module_files import save_module_files

--- a/python/michelangelo/lib/model_manager/_private/utils/pickle_utils/__init__.py
+++ b/python/michelangelo/lib/model_manager/_private/utils/pickle_utils/__init__.py
@@ -1,3 +1,5 @@
+"""Pickle processing utilities."""
+
 # flake8: noqa:F401
 from .pickle_definition import find_pickle_definitions
 from .pickle_definition_walker import walk_pickle_definitions_in_dir

--- a/python/michelangelo/lib/model_manager/_private/utils/pickle_utils/pickle_definition.py
+++ b/python/michelangelo/lib/model_manager/_private/utils/pickle_utils/pickle_definition.py
@@ -1,3 +1,5 @@
+"""Pickle definition discovery utilities."""
+
 from __future__ import annotations
 
 import pickletools

--- a/python/michelangelo/lib/model_manager/_private/utils/pickle_utils/pickle_definition_walker.py
+++ b/python/michelangelo/lib/model_manager/_private/utils/pickle_utils/pickle_definition_walker.py
@@ -1,3 +1,5 @@
+"""Utilities for walking pickle definitions in directories."""
+
 from __future__ import annotations
 
 from collections.abc import Iterator  # noqa: TC003

--- a/python/michelangelo/lib/model_manager/_private/utils/pickle_utils/pickled_file.py
+++ b/python/michelangelo/lib/model_manager/_private/utils/pickle_utils/pickled_file.py
@@ -1,3 +1,5 @@
+"""Utilities for identifying and finding pickled files."""
+
 from __future__ import annotations
 
 import io

--- a/python/michelangelo/lib/model_manager/_private/utils/pickle_utils/tests/pickle_definition_test.py
+++ b/python/michelangelo/lib/model_manager/_private/utils/pickle_utils/tests/pickle_definition_test.py
@@ -1,3 +1,5 @@
+"""Tests for pickle definition discovery."""
+
 import os
 import pickle
 import pickletools

--- a/python/michelangelo/lib/model_manager/_private/utils/pickle_utils/tests/pickle_definition_walker_test.py
+++ b/python/michelangelo/lib/model_manager/_private/utils/pickle_utils/tests/pickle_definition_walker_test.py
@@ -1,3 +1,5 @@
+"""Tests for pickle definition walking."""
+
 import os
 import pickle
 import tempfile

--- a/python/michelangelo/lib/model_manager/_private/utils/pickle_utils/tests/pickled_file_test.py
+++ b/python/michelangelo/lib/model_manager/_private/utils/pickle_utils/tests/pickled_file_test.py
@@ -1,3 +1,5 @@
+"""Tests for pickled file identification."""
+
 import os
 import pickle
 import tempfile

--- a/python/michelangelo/lib/model_manager/_private/utils/reflection_utils/__init__.py
+++ b/python/michelangelo/lib/model_manager/_private/utils/reflection_utils/__init__.py
@@ -1,3 +1,5 @@
+"""Reflection utilities."""
+
 # flake8: noqa:F401
 from .module import find_attr_from_dir, find_attr_from_sys_modules, get_module
 from .root_import_path import get_root_import_path

--- a/python/michelangelo/lib/model_manager/_private/utils/reflection_utils/module.py
+++ b/python/michelangelo/lib/model_manager/_private/utils/reflection_utils/module.py
@@ -1,3 +1,5 @@
+"""Utilities for module reflection and attribute discovery."""
+
 from __future__ import annotations
 
 import importlib

--- a/python/michelangelo/lib/model_manager/_private/utils/reflection_utils/root_import_path.py
+++ b/python/michelangelo/lib/model_manager/_private/utils/reflection_utils/root_import_path.py
@@ -1,3 +1,5 @@
+"""Utilities for finding the root import path of a package."""
+
 import functools
 import os
 import sys

--- a/python/michelangelo/lib/model_manager/_private/utils/reflection_utils/tests/module_test.py
+++ b/python/michelangelo/lib/model_manager/_private/utils/reflection_utils/tests/module_test.py
@@ -1,3 +1,5 @@
+"""Tests for module reflection utilities."""
+
 import os
 import shutil
 import sys

--- a/python/michelangelo/lib/model_manager/_private/utils/reflection_utils/tests/root_import_path_test.py
+++ b/python/michelangelo/lib/model_manager/_private/utils/reflection_utils/tests/root_import_path_test.py
@@ -1,3 +1,5 @@
+"""Tests for root import path utilities."""
+
 from unittest import TestCase
 
 from michelangelo.lib.model_manager._private.utils.reflection_utils import (

--- a/python/michelangelo/lib/model_manager/constants/__init__.py
+++ b/python/michelangelo/lib/model_manager/constants/__init__.py
@@ -1,3 +1,5 @@
+"""Constants for the model manager."""
+
 # flake8: noqa:F401
 from .raw_model_type import RawModelType
 from .storage_type import StorageType

--- a/python/michelangelo/lib/model_manager/constants/raw_model_type.py
+++ b/python/michelangelo/lib/model_manager/constants/raw_model_type.py
@@ -1,3 +1,5 @@
+"""Raw model type constants."""
+
 class RawModelType:
     """Raw model types for the raw model package.
 

--- a/python/michelangelo/lib/model_manager/constants/raw_model_type.py
+++ b/python/michelangelo/lib/model_manager/constants/raw_model_type.py
@@ -1,5 +1,6 @@
 """Raw model type constants."""
 
+
 class RawModelType:
     """Raw model types for the raw model package.
 

--- a/python/michelangelo/lib/model_manager/constants/storage_type.py
+++ b/python/michelangelo/lib/model_manager/constants/storage_type.py
@@ -1,5 +1,6 @@
 """Storage type constants."""
 
+
 class StorageType:
     """Storage type constants."""
 

--- a/python/michelangelo/lib/model_manager/constants/storage_type.py
+++ b/python/michelangelo/lib/model_manager/constants/storage_type.py
@@ -1,3 +1,5 @@
+"""Storage type constants."""
+
 class StorageType:
     """Storage type constants."""
 

--- a/python/michelangelo/lib/model_manager/constants/tests/raw_model_type_test.py
+++ b/python/michelangelo/lib/model_manager/constants/tests/raw_model_type_test.py
@@ -1,3 +1,5 @@
+"""Tests for RawModelType constants."""
+
 from unittest import TestCase
 
 from michelangelo.lib.model_manager.constants import RawModelType

--- a/python/michelangelo/lib/model_manager/constants/tests/storage_type_test.py
+++ b/python/michelangelo/lib/model_manager/constants/tests/storage_type_test.py
@@ -1,3 +1,5 @@
+"""Tests for StorageType constants."""
+
 from unittest import TestCase
 
 from michelangelo.lib.model_manager.constants import StorageType

--- a/python/michelangelo/lib/model_manager/interface/custom_model.py
+++ b/python/michelangelo/lib/model_manager/interface/custom_model.py
@@ -1,3 +1,5 @@
+"""Interface for custom models."""
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod

--- a/python/michelangelo/lib/model_manager/interface/tests/custom_model_test.py
+++ b/python/michelangelo/lib/model_manager/interface/tests/custom_model_test.py
@@ -1,3 +1,5 @@
+"""Tests for CustomModel interface."""
+
 import tempfile
 from unittest import TestCase
 

--- a/python/michelangelo/lib/model_manager/packager/custom_triton/__init__.py
+++ b/python/michelangelo/lib/model_manager/packager/custom_triton/__init__.py
@@ -1,2 +1,4 @@
+"""Custom Triton model packager."""
+
 # flake8: noqa:F401
 from .custom_triton_packager import CustomTritonPackager

--- a/python/michelangelo/lib/model_manager/packager/custom_triton/custom_triton_packager.py
+++ b/python/michelangelo/lib/model_manager/packager/custom_triton/custom_triton_packager.py
@@ -1,3 +1,5 @@
+"""Packager for custom Triton models."""
+
 from typing import Optional, Union
 
 from numpy import ndarray

--- a/python/michelangelo/lib/model_manager/packager/custom_triton/tests/custom_triton_packager_test.py
+++ b/python/michelangelo/lib/model_manager/packager/custom_triton/tests/custom_triton_packager_test.py
@@ -1,3 +1,5 @@
+"""Tests for CustomTritonPackager."""
+
 from unittest import TestCase
 
 from michelangelo.lib.model_manager.packager.custom_triton import CustomTritonPackager

--- a/python/michelangelo/lib/model_manager/schema/__init__.py
+++ b/python/michelangelo/lib/model_manager/schema/__init__.py
@@ -1,3 +1,5 @@
+"""Schema definitions for the model manager."""
+
 # flake8: noqa:F401
 from michelangelo.lib.model_manager.schema.data_type import DataType
 from michelangelo.lib.model_manager.schema.model_schema import ModelSchema

--- a/python/michelangelo/lib/model_manager/schema/data_type.py
+++ b/python/michelangelo/lib/model_manager/schema/data_type.py
@@ -1,3 +1,5 @@
+"""Data types for model schema features."""
+
 from enum import Enum
 
 

--- a/python/michelangelo/lib/model_manager/schema/model_schema.py
+++ b/python/michelangelo/lib/model_manager/schema/model_schema.py
@@ -1,3 +1,5 @@
+"""Model schema definition."""
+
 from dataclasses import dataclass, field
 
 from michelangelo.lib.model_manager.schema.model_schema_item import ModelSchemaItem

--- a/python/michelangelo/lib/model_manager/schema/model_schema_item.py
+++ b/python/michelangelo/lib/model_manager/schema/model_schema_item.py
@@ -1,3 +1,5 @@
+"""Model schema item definition."""
+
 from dataclasses import dataclass
 
 from michelangelo.lib.model_manager.schema.data_type import DataType

--- a/python/michelangelo/lib/model_manager/schema/tests/data_type_test.py
+++ b/python/michelangelo/lib/model_manager/schema/tests/data_type_test.py
@@ -1,3 +1,5 @@
+"""Tests for DataType enum."""
+
 from unittest import TestCase
 
 from michelangelo.lib.model_manager.schema.data_type import DataType

--- a/python/michelangelo/lib/model_manager/schema/tests/model_schema_test.py
+++ b/python/michelangelo/lib/model_manager/schema/tests/model_schema_test.py
@@ -1,3 +1,5 @@
+"""Tests for ModelSchema."""
+
 from unittest import TestCase
 
 from michelangelo.lib.model_manager.schema import (


### PR DESCRIPTION
## Summary

This PR adds module-level docstrings to 63 files across the `model_manager` package to improve code documentation and IDE support.

## Changes

- Added concise module docstrings to all Python modules in:
  - `model_manager/_private/packager/custom_triton/` - Custom Triton packager modules
  - `model_manager/_private/packager/template_renderer/` - Template rendering utilities
  - `model_manager/_private/schema/` - Schema definitions and validation
  - `model_manager/_private/utils/` - Utility modules (asset_utils, data_utils, module_finder, pickle_utils, reflection_utils)
  - `model_manager/interface/` - Model interface definitions
  - `model_manager/packager/` - Packager implementations
  - `model_manager/schema/` - Public schema definitions
  - `model_manager/constants/` - Constants definitions

## Impact

- Improves code readability and maintainability
- Enhances IDE tooltips and documentation generation
- Provides better context for developers working with the model_manager package

## Testing

No functional changes - documentation only.