### PR TITLE
Model Manager: Update documentation and comments

### DIFF
--- a/python/michelangelo/lib/model_manager/constants/raw_model_type.py
+++ b/python/michelangelo/lib/model_manager/constants/raw_model_type.py
@@ -4,8 +4,6 @@
 class RawModelType:
     """Raw model types for the raw model package.
 
-    We may move this class to public API in the future.
-
     Attributes:
         CUSTOM_PYTHON: Custom Python model
         HUGGINGFACE: Huggingface Pipeline

--- a/python/michelangelo/lib/model_manager/constants/storage_type.py
+++ b/python/michelangelo/lib/model_manager/constants/storage_type.py
@@ -2,6 +2,14 @@
 
 
 class StorageType:
-    """Storage type constants."""
+    """Storage type constants for model storage locations.
+
+    This class defines constants for different storage backends that can be
+    used to store and retrieve model files.
+
+    Attributes:
+        LOCAL: Local filesystem storage. Model files are stored on the local
+            disk accessible to the current process.
+    """
 
     LOCAL = "local"

--- a/python/michelangelo/lib/model_manager/interface/custom_model.py
+++ b/python/michelangelo/lib/model_manager/interface/custom_model.py
@@ -8,19 +8,30 @@ from numpy import ndarray  # noqa: TC002
 
 
 class Model(ABC):
-    """The base class for custom models."""
+    """The base class for custom models.
+
+    This abstract base class defines the interface that all custom models must
+    implement. Custom models are used with the Model Manager to create Triton
+    model packages for serving.
+
+    Subclasses must implement the save, load, and predict methods to handle
+    model persistence and inference.
+    """
 
     @abstractmethod
     def save(self, path: str):
         """Save the model to the given path.
 
-        Strongly recommend to not use pickle or torch.save directly.
+        This method should serialize the model to disk. It is strongly
+        recommended to avoid using pickle or torch.save directly, as they can
+        have compatibility and security issues. Instead, prefer using format-
+        specific serialization methods (e.g., SavedModel for TensorFlow,
+        state_dict for PyTorch).
 
         Args:
-            path: The local path to save the model.
-
-        Returns:
-            None
+            path: The local filesystem path where the model should be saved.
+                This path should be a directory that will contain all model
+                artifacts.
         """
 
     @classmethod
@@ -28,11 +39,19 @@ class Model(ABC):
     def load(cls, path: str) -> Model:
         """Load the model from the given path.
 
+        This method should deserialize the model from disk and return a fully
+        initialized Model instance ready for inference.
+
         Args:
-            path: The local path to load the model from.
+            path: The local filesystem path containing the saved model
+                artifacts. This should be the same directory path that was
+                used in the save() method.
 
         Returns:
-            The model instance.
+            A fully initialized Model instance loaded from the specified path.
+
+        Raises:
+            NotImplementedError: If the subclass does not implement this method.
         """
         raise NotImplementedError("load method is not implemented")
 
@@ -43,9 +62,19 @@ class Model(ABC):
     ) -> dict[str, ndarray]:
         """Predict on the given data.
 
+        This method performs inference on the provided input data and returns
+        predictions. The input and output dictionaries must match the model
+        schema defined when creating the model package.
+
         Args:
-            inputs: The input data for prediction.
+            inputs: A dictionary mapping feature names to numpy arrays. Each
+                key should correspond to an input feature name defined in the
+                model schema, and each value should be a numpy array with shape
+                matching the schema specification.
 
         Returns:
-            The prediction result.
+            A dictionary mapping output feature names to numpy arrays. Each key
+            should correspond to an output feature name defined in the model
+            schema, and each value should be a numpy array containing the
+            predictions.
         """

--- a/python/michelangelo/lib/model_manager/packager/custom_triton/custom_triton_packager.py
+++ b/python/michelangelo/lib/model_manager/packager/custom_triton/custom_triton_packager.py
@@ -12,19 +12,39 @@ from michelangelo.lib.model_manager.schema import ModelSchema
 
 
 class CustomTritonPackager:
-    """Packager for custom Triton Python models."""
+    """Packager for custom Triton Python models.
+
+    This class provides utilities to package custom Python models that implement
+    the Model interface into formats suitable for deployment with NVIDIA Triton
+    Inference Server. It handles the generation of required configuration files,
+    dependency management, and model artifact organization.
+
+    The packager supports two main workflows:
+    1. Creating Triton model packages for Michelangelo Studio deployment
+    2. Creating raw model packages with sample data for testing and validation
+
+    Attributes:
+        gen: The template renderer used to generate Triton configuration files.
+        custom_batch_processing: Whether batch processing is handled manually by
+            the model implementation.
+    """
 
     def __init__(self, custom_batch_processing: Optional[bool] = False):
         """Create a CustomTritonPackager instance.
 
         Args:
-            custom_batch_processing (Optional):
-                If to handle batch manually in the Triton model package.
-                Default is False. If set to True, the user is responsible for handling
-                batch in the model class, and the model input/output will have an
-                additional batch dimension on top of the existing model schema.
-                For example, the schema shape [n, ..., m], the input dimension will
-                be [batch_size, n, ..., m].
+            custom_batch_processing: Whether to handle batching manually in the
+                model implementation. Defaults to False.
+
+                If False (default), Triton automatically handles batching and
+                the model's predict method receives individual samples with
+                shapes matching the model schema exactly.
+
+                If True, the model implementation is responsible for handling
+                batches, and the predict method will receive inputs with an
+                additional leading batch dimension. For example, if the schema
+                specifies shape [n, ..., m], the actual input shape will be
+                [batch_size, n, ..., m].
         """
         self.gen = TritonTemplateRenderer()
         self.custom_batch_processing = custom_batch_processing
@@ -40,28 +60,42 @@ class CustomTritonPackager:
         model_path_source_type: Optional[str] = StorageType.LOCAL,
         include_import_prefixes: Optional[list[str]] = None,
     ) -> str:
-        """Create a Triton model package for custom Python model.
+        """Create a Triton model package for deployment to Michelangelo Studio.
+
+        This method packages a custom Python model into a format suitable for
+        deployment on Triton Inference Server through Michelangelo Studio. It
+        generates the necessary configuration files, bundles dependencies, and
+        organizes model artifacts according to Triton's directory structure.
 
         Args:
-            model_path: the path of the raw model
-            model_class: the model class of the model
-                that contains the custom predict function
-            model_schema: the schema of the model
-            model_name: the name of model in MA Studio
-            dest_model_path: the path to save the model package
-                If not specified, a temporary directory will be created
-            model_revision: the revision of model in MA Studio
-            model_path_source_type: the source type of the model path,
-                e.g. 'hdfs', 'terrablob', default is 'hdfs'
-            include_import_prefixes (Optional): only save the imported
-                modules with the given prefixes in the model package,
-                e.g. ['uber', 'data.michelangelo'] only imports starting
-                with 'uber' or 'data.michelangelo' will be saved in the
-                model package.
-                and if the list is empty, save all imports
+            model_path: The path to the saved model artifacts. This should be
+                the directory containing the model files created by the Model's
+                save() method.
+            model_class: The fully qualified class name of the model
+                implementation (e.g., 'mypackage.models.MyModel'). This class
+                must implement the Model interface with save, load, and predict
+                methods.
+            model_schema: The schema defining the model's input and output
+                features, including their names, data types, and shapes.
+            model_name: The name to use for the model in Michelangelo Studio.
+                If not specified, a name will be derived from the model class.
+            dest_model_path: The directory path where the model package should
+                be saved. If not specified, a temporary directory will be
+                created and its path returned.
+            model_revision: The revision number for the model in Michelangelo
+                Studio. Defaults to "0".
+            model_path_source_type: The storage backend type where the model
+                artifacts are located. Should be a value from StorageType (e.g.,
+                StorageType.LOCAL). Defaults to StorageType.LOCAL.
+            include_import_prefixes: A list of module prefixes to include when
+                bundling dependencies. Only imported modules whose names start
+                with one of these prefixes will be included in the package. For
+                example, ['uber', 'data.michelangelo'] will only include modules
+                starting with 'uber' or 'data.michelangelo'. If None or empty,
+                all imported modules will be included.
 
         Returns:
-            The path of the model package
+            The absolute path to the generated model package directory.
         """
 
     def create_raw_model_package(
@@ -75,33 +109,55 @@ class CustomTritonPackager:
         requirements: Optional[Union[list[str], str]] = None,
         include_import_prefixes: Optional[list[str]] = None,
     ) -> str:
-        """Create a raw model package for custom Python model.
+        """Create a raw model package with sample data for testing.
+
+        This method creates a self-contained model package that includes sample
+        data for validation and testing. This is useful for verifying that the
+        model package works correctly before deployment, or for creating
+        shareable model artifacts for development and testing purposes.
+
+        The raw model package includes:
+        - Model artifacts and implementation code
+        - Sample input data for testing predictions
+        - Dependency specifications
+        - Triton configuration files
 
         Args:
-            model_path: the path of the raw model
-            model_class: the model class of the model
-                that contains the custom predict function
-            model_schema: the schema of the model, which specifies the
-                input/palette/output features
-            sample_data: the sample data of the model. A list of input data
-                for the predict function.
-            dest_model_path: the path to save the model package
-                If not specified, a temporary directory will be created
-            model_path_source_type: the source type of the model path,
-                e.g. 'hdfs', 'terrablob', default is 'hdfs'
-            requirements: the requirements of the model, which can be one
-                of the following:
-                - a list of requirements
-                - a path to the requirements.txt file
-                If not specified, the requirements will not be included in
-                the model package
-            include_import_prefixes (Optional): only save the imported
-                modules with the given prefixes in the model package,
-                e.g. ['uber', 'data.michelangelo'] only imports starting
-                with 'uber' or 'data.michelangelo' will be saved in the
-                model package.
-                and if the list is empty, save all imports
+            model_path: The path to the saved model artifacts. This should be
+                the directory containing the model files created by the Model's
+                save() method.
+            model_class: The fully qualified class name of the model
+                implementation (e.g., 'mypackage.models.MyModel'). This class
+                must implement the Model interface with save, load, and predict
+                methods.
+            model_schema: The schema defining the model's input, palette
+                (feature store), and output features, including their names,
+                data types, and shapes.
+            sample_data: A list of sample inputs for testing the model's
+                predict method. Each item should be a dictionary mapping input
+                feature names to numpy arrays, matching the format expected by
+                the model's predict method.
+            dest_model_path: The directory path where the model package should
+                be saved. If not specified, a temporary directory will be
+                created and its path returned.
+            model_path_source_type: The storage backend type where the model
+                artifacts are located. Should be a value from StorageType (e.g.,
+                StorageType.LOCAL). Defaults to StorageType.LOCAL.
+            requirements: The Python package dependencies required by the model.
+                This can be either:
+                - A list of requirement strings (e.g., ['numpy>=1.20.0',
+                  'scikit-learn==1.0.2'])
+                - A path to a requirements.txt file
+                If not specified, no additional requirements will be included in
+                the package (only the model code and its imports will be
+                bundled).
+            include_import_prefixes: A list of module prefixes to include when
+                bundling dependencies. Only imported modules whose names start
+                with one of these prefixes will be included in the package. For
+                example, ['uber', 'data.michelangelo'] will only include modules
+                starting with 'uber' or 'data.michelangelo'. If None or empty,
+                all imported modules will be included.
 
         Returns:
-            The path of the raw model package
+            The absolute path to the generated raw model package directory.
         """

--- a/python/michelangelo/lib/model_manager/schema/data_type.py
+++ b/python/michelangelo/lib/model_manager/schema/data_type.py
@@ -4,11 +4,35 @@ from enum import Enum
 
 
 class DataType(Enum):
-    """Enum for data types.
+    """Enum for data types used in model schemas.
 
-    The enum values are used to represent the data types of each feature in the
-    model schema. The enum values matches the ones in
-    https://github.com/michelangelo-ai/michelangelo/blob/main/proto/api/v2/schema.proto.
+    This enum defines the supported data types for model features (inputs,
+    outputs, and palette features). The values are used to specify the data
+    type of each feature in a ModelSchemaItem and correspond to the data types
+    defined in the Michelangelo schema protobuf specification.
+
+    The enum values match those in the protobuf definition at:
+    https://github.com/michelangelo-ai/michelangelo/blob/main/proto/api/v2/schema.proto
+
+    Attributes:
+        INVALID: Invalid or unset data type. Should not be used in valid
+            schemas.
+        UNKNOWN: Unknown data type. May be used as a placeholder during schema
+            inference.
+        BOOLEAN: Boolean values (True/False). Maps to bool in Python and
+            BOOL in Triton.
+        STRING: String/text data. Maps to str in Python and BYTES in Triton.
+        BYTE: 8-bit signed integer. Maps to int8 in NumPy and INT8 in Triton.
+        CHAR: Character data (8-bit unsigned integer). Maps to uint8 in NumPy.
+        SHORT: 16-bit signed integer. Maps to int16 in NumPy and INT16 in
+            Triton.
+        INT: 32-bit signed integer. Maps to int32 in NumPy and INT32 in Triton.
+        LONG: 64-bit signed integer. Maps to int64 in NumPy and INT64 in
+            Triton.
+        FLOAT: 32-bit floating point. Maps to float32 in NumPy and FP32 in
+            Triton.
+        DOUBLE: 64-bit floating point. Maps to float64 in NumPy and FP64 in
+            Triton.
     """
 
     INVALID = 0

--- a/python/michelangelo/lib/model_manager/schema/model_schema.py
+++ b/python/michelangelo/lib/model_manager/schema/model_schema.py
@@ -7,17 +7,37 @@ from michelangelo.lib.model_manager.schema.model_schema_item import ModelSchemaI
 
 @dataclass
 class ModelSchema:
-    """The model schema specifies the input/palette features a model requires.
+    """Schema definition for model inputs, outputs, and feature store features.
 
-    It makes predictions along with the data types of these features.
+    The model schema specifies the structure and data types of all features that
+    a model consumes and produces. This includes:
+    - Input features: Data provided directly in prediction requests
+    - Palette (feature store) features: Additional features retrieved from a
+      feature store based on input keys
+    - Output features: Predictions or results produced by the model
+
+    The schema is used for:
+    - Generating Triton configuration files
+    - Validating input/output data
+    - Type conversion and serialization
+    - Documentation and API contracts
+
+    Each schema component is a list of ModelSchemaItem objects that define the
+    name, data type, shape, and optionality of individual features.
 
     Attributes:
-        input_schema: A list of ModelSchemaItem representing the input
-            features of the model.
-        feature_store_features_schema: A list of ModelSchemaItem representing
-            the palette features of the model.
-        output_schema: A list of ModelSchemaItem representing the output
-            features of the model.
+        input_schema: A list of ModelSchemaItem objects representing the input
+            features that must be provided in prediction requests. These are
+            typically the raw features or keys used to look up additional
+            features from the feature store.
+        feature_store_features_schema: A list of ModelSchemaItem objects
+            representing palette features that are retrieved from a feature
+            store. These features are looked up based on keys in the input
+            schema and joined with the input features before being passed to
+            the model.
+        output_schema: A list of ModelSchemaItem objects representing the
+            output features produced by the model's predictions. These define
+            the structure and types of the prediction results.
     """
 
     input_schema: list[ModelSchemaItem] = field(default_factory=list)

--- a/python/michelangelo/lib/model_manager/schema/model_schema_item.py
+++ b/python/michelangelo/lib/model_manager/schema/model_schema_item.py
@@ -7,14 +7,50 @@ from michelangelo.lib.model_manager.schema.data_type import DataType
 
 @dataclass
 class ModelSchemaItem:
-    """ModelSchemaItem represents a single feature in a model schema.
+    """Represents a single feature in a model schema.
+
+    A ModelSchemaItem defines the metadata for one feature (input, output, or
+    palette feature) in a model schema. It specifies the feature's name, data
+    type, shape, and whether it's required or optional.
+
+    The shape follows NumPy array conventions, where each dimension is specified
+    as an integer. Variable-length dimensions can be indicated using -1.
+
+    Examples:
+        Scalar integer feature:
+            ModelSchemaItem(name="user_id", data_type=DataType.LONG, shape=[1])
+
+        Fixed-size vector of 10 floats:
+            ModelSchemaItem(name="embeddings", data_type=DataType.FLOAT,
+                          shape=[10])
+
+        2D array (10 rows, 5 columns):
+            ModelSchemaItem(name="features", data_type=DataType.DOUBLE,
+                          shape=[10, 5])
+
+        Variable-length sequence of integers:
+            ModelSchemaItem(name="sequence", data_type=DataType.INT,
+                          shape=[-1])
+
+        Optional string feature:
+            ModelSchemaItem(name="description", data_type=DataType.STRING,
+                          shape=[1], optional=True)
 
     Attributes:
-        name: The name of the feature.
-        data_type: The data type of the feature.
-        shape: The shape of the feature. For example, [10, 5] for a 2D array
-            with 10 rows and 5 columns.
-        optional: Indicate whether the feature is optional.
+        name: The name of the feature. This should be a valid Python identifier
+            and will be used as the key in input/output dictionaries.
+        data_type: The data type of the feature, specified as a DataType enum
+            value. Defaults to DataType.UNKNOWN if not specified.
+        shape: The shape of the feature as a list of integers following NumPy
+            conventions. For example:
+            - [1] for a scalar value
+            - [n] for a 1D array of length n
+            - [n, m] for a 2D array with n rows and m columns
+            - [-1] for a variable-length dimension
+            If None, the shape is unspecified.
+        optional: Whether this feature is optional. If True, the feature may be
+            omitted from input data. If False or None, the feature is required.
+            Defaults to None (treated as required).
     """
 
     name: str


### PR DESCRIPTION
This PR updates the docstrings and comments for the public interfaces of the Model Manager library to improve clarity.

**Updated files:**
- `python/michelangelo/lib/model_manager/constants/raw_model_type.py`
- `python/michelangelo/lib/model_manager/constants/storage_type.py`
- `python/michelangelo/lib/model_manager/interface/custom_model.py`
- `python/michelangelo/lib/model_manager/packager/custom_triton/custom_triton_packager.py`
- `python/michelangelo/lib/model_manager/schema/data_type.py`
- `python/michelangelo/lib/model_manager/schema/model_schema.py`
- `python/michelangelo/lib/model_manager/schema/model_schema_item.py`