### PR TITLE
fix(inference): update httproute path matching

### DIFF
--- a/go/components/inferenceserver/gateways/backends/triton.go
+++ b/go/components/inferenceserver/gateways/backends/triton.go
@@ -25,6 +25,8 @@ import (
 	v2pb "github.com/michelangelo-ai/michelangelo/proto/api/v2"
 )
 
+// TODO(#689): ghosharitra: refactor this package to use httproute.go instead
+
 // Triton Infrastructure Management
 type tritonBackend struct {
 	kubeClient             client.Client
@@ -305,7 +307,7 @@ func (b *tritonBackend) LoadModel(ctx context.Context, logger *zap.Logger, reque
 	logger.Info("Loading Triton model explicitly", zap.String("model", request.ModelName), zap.String("server", request.InferenceServer))
 
 	// Use the service endpoint configured in the backend
-	loadURL := fmt.Sprintf("%s/%s/v2/repository/models/%s/load", b.serviceEndpoint, request.InferenceServer, request.ModelName)
+	loadURL := fmt.Sprintf("%s/%s/repository/models/%s/load", b.serviceEndpoint, request.InferenceServer, request.ModelName)
 
 	// Create HTTP client with timeout
 	client := &http.Client{
@@ -372,7 +374,7 @@ func (b *tritonBackend) LoadModel(ctx context.Context, logger *zap.Logger, reque
 
 func (b *tritonBackend) UnloadModel(ctx context.Context, logger *zap.Logger, request gateways.UnloadModelRequest) error {
 	// Use the service endpoint configured in the backend
-	unloadURL := fmt.Sprintf("%s/%s/v2/repository/models/%s/unload", b.serviceEndpoint, request.InferenceServer, request.ModelName)
+	unloadURL := fmt.Sprintf("%s/%s/repository/models/%s/unload", b.serviceEndpoint, request.InferenceServer, request.ModelName)
 
 	logger.Info("Calling Triton unload API", zap.String("url", unloadURL), zap.String("model", request.ModelName))
 
@@ -425,7 +427,7 @@ func (b *tritonBackend) CheckModelStatus(ctx context.Context, logger *zap.Logger
 	logger.Info("Checking Triton model status", zap.String("model", request.ModelName), zap.String("server", request.InferenceServer))
 
 	// Use the service endpoint configured in the backend
-	readyURL := fmt.Sprintf("%s/%s/v2/models/%s/ready", b.serviceEndpoint, request.InferenceServer, request.ModelName)
+	readyURL := fmt.Sprintf("%s/%s/models/%s/ready", b.serviceEndpoint, request.InferenceServer, request.ModelName)
 
 	// Create HTTP client with timeout
 	client := &http.Client{
@@ -763,7 +765,7 @@ func (b *tritonBackend) createInferenceServerHTTPRoute(ctx context.Context, logg
 								"urlRewrite": map[string]interface{}{
 									"path": map[string]interface{}{
 										"type":               "ReplacePrefixMatch",
-										"replacePrefixMatch": "/",
+										"replacePrefixMatch": "/v2",
 									},
 								},
 							},
@@ -854,7 +856,7 @@ func (b *tritonBackend) updateHTTPRoute(ctx context.Context, logger *zap.Logger,
 								"urlRewrite": map[string]interface{}{
 									"path": map[string]interface{}{
 										"type":               "ReplacePrefixMatch",
-										"replacePrefixMatch": "/",
+										"replacePrefixMatch": "/v2",
 									},
 								},
 							},

--- a/go/components/inferenceserver/proxy/httproute.go
+++ b/go/components/inferenceserver/proxy/httproute.go
@@ -95,7 +95,7 @@ func (h *httpRouteManager) getOrCreateHTTPRoute(ctx context.Context, logger *zap
 		fmt.Sprintf("/%s", request.InferenceServer),
 		addSuffixToString(request.InferenceServer, inferenceServiceSuffix),
 		&baselineWeight,
-		"/",
+		"/v2",
 	)
 
 	createdRoute, err := h.dynamicClient.Resource(httpRouteGVR).Namespace(request.Namespace).Create(ctx, httpRoute, metav1.CreateOptions{})

--- a/go/components/inferenceserver/proxy/httproute.go
+++ b/go/components/inferenceserver/proxy/httproute.go
@@ -131,7 +131,7 @@ func (h *httpRouteManager) CheckDeploymentRouteStatus(ctx context.Context, logge
 	}
 
 	// Verify the route matches the expected model and inference server configuration
-	expectedMatchPath := fmt.Sprintf("/%s/%s/models/%s", request.InferenceServer, request.DeploymentName, request.ModelName)
+	expectedMatchPath := fmt.Sprintf("/%s/%s", request.InferenceServer, request.DeploymentName)
 	expectedRewritePath := fmt.Sprintf("/v2/models/%s", request.ModelName)
 	expectedBackendService := addSuffixToString(request.InferenceServer, inferenceServiceSuffix)
 
@@ -259,7 +259,7 @@ func (h *httpRouteManager) EnsureDeploymentRoute(ctx context.Context, logger *za
 		"michelangelo.ai/inference-server": inferenceServerName,
 	}
 
-	matchPath := fmt.Sprintf("/%s/%s/models/%s", inferenceServerName, request.DeploymentName, request.ModelName)
+	matchPath := fmt.Sprintf("/%s/%s", inferenceServerName, request.DeploymentName)
 	rewritePath := fmt.Sprintf("/v2/models/%s", request.ModelName)
 
 	httpRoute := buildHTTPRoute(

--- a/go/components/inferenceserver/proxy/httproute_test.go
+++ b/go/components/inferenceserver/proxy/httproute_test.go
@@ -59,6 +59,13 @@ func TestEnsureInferenceServerRoute(t *testing.T) {
 				backendMap := backendRefs[0].(map[string]interface{})
 				assert.Equal(t, "new-server-inference-service", backendMap["name"])
 				assert.Equal(t, int64(100), backendMap["weight"])
+
+				// Check URL rewrite filter
+				filters, _, _ := unstructured.NestedSlice(ruleMap, "filters")
+				require.Len(t, filters, 1)
+				filterMap := filters[0].(map[string]interface{})
+				replacePrefixMatch, _, _ := unstructured.NestedString(filterMap, "urlRewrite", "path", "replacePrefixMatch")
+				assert.Equal(t, "/v2", replacePrefixMatch)
 			},
 		},
 		{
@@ -68,7 +75,7 @@ func TestEnsureInferenceServerRoute(t *testing.T) {
 				Namespace:       "default",
 				ModelName:       "test-model",
 			},
-			existingHTTPRoute: createHTTPRouteWithProductionRoute("test-server-httproute", "default", "/test-server", "/"),
+			existingHTTPRoute: createHTTPRouteWithProductionRoute("test-server-httproute", "default", "/test-server", "/v2"),
 			expectError:       false,
 			validateFunc: func(t *testing.T, fakeClient *fake.FakeDynamicClient, err error) {
 				require.NoError(t, err)

--- a/go/components/inferenceserver/proxy/httproute_test.go
+++ b/go/components/inferenceserver/proxy/httproute_test.go
@@ -231,7 +231,7 @@ func TestEnsureDeploymentRoute(t *testing.T) {
 				matches, _, _ := unstructured.NestedSlice(firstRule, "matches")
 				firstMatch := matches[0].(map[string]interface{})
 				pathValue, _, _ := unstructured.NestedString(firstMatch, "path", "value")
-				assert.Equal(t, "/test-server/test-deployment/models/new-model", pathValue)
+				assert.Equal(t, "/test-server/test-deployment", pathValue)
 
 				// Verify the filter
 				filters, _, _ := unstructured.NestedSlice(firstRule, "filters")
@@ -254,7 +254,7 @@ func TestEnsureDeploymentRoute(t *testing.T) {
 				DeploymentName:  "existing-deployment",
 				ModelName:       "updated-model",
 			},
-			httpRoute:   createHTTPRouteWithProductionRoute("existing-deployment-httproute", "default", "/test-server/existing-deployment/models/old-model", "/v2/models/old-model"),
+			httpRoute:   createHTTPRouteWithProductionRoute("existing-deployment-httproute", "default", "/test-server/existing-deployment", "/v2/models/old-model"),
 			expectError: false,
 			validateFunc: func(t *testing.T, fakeClient *fake.FakeDynamicClient, err error) {
 				require.NoError(t, err)
@@ -274,7 +274,7 @@ func TestEnsureDeploymentRoute(t *testing.T) {
 				matches, _, _ := unstructured.NestedSlice(ruleMap, "matches")
 				matchMap := matches[0].(map[string]interface{})
 				pathValue, _, _ := unstructured.NestedString(matchMap, "path", "value")
-				assert.Equal(t, "/test-server/existing-deployment/models/updated-model", pathValue)
+				assert.Equal(t, "/test-server/existing-deployment", pathValue)
 
 				// Check filter was updated
 				filters, _, _ := unstructured.NestedSlice(ruleMap, "filters")
@@ -328,7 +328,7 @@ func TestCheckDeploymentRouteStatus(t *testing.T) {
 				InferenceServer: "test-server",
 				ModelName:       "test-model",
 			},
-			httpRoute:    createHTTPRouteWithProductionRoute("test-deployment-httproute", "default", "/test-server/test-deployment/models/test-model", "/v2/models/test-model"),
+			httpRoute:    createHTTPRouteWithProductionRoute("test-deployment-httproute", "default", "/test-server/test-deployment", "/v2/models/test-model"),
 			expectResult: true,
 			expectError:  false,
 		},

--- a/python/michelangelo/cli/sandbox/demo/inference/inferenceserver.yaml
+++ b/python/michelangelo/cli/sandbox/demo/inference/inferenceserver.yaml
@@ -1,7 +1,7 @@
 apiVersion: michelangelo.api/v2
 kind: InferenceServer
 metadata:
-  name: inference-server-bert-cola
+  name: inference-server-demo
   namespace: default
   labels:
     app: inference-server

--- a/python/michelangelo/cli/sandbox/demo/inference/inferenceserver.yaml
+++ b/python/michelangelo/cli/sandbox/demo/inference/inferenceserver.yaml
@@ -1,7 +1,7 @@
 apiVersion: michelangelo.api/v2
 kind: InferenceServer
 metadata:
-  name: inference-server-demo
+  name: inference-server-example
   namespace: default
   labels:
     app: inference-server

--- a/python/michelangelo/cli/sandbox/resources/model-sync.yaml
+++ b/python/michelangelo/cli/sandbox/resources/model-sync.yaml
@@ -257,7 +257,7 @@ spec:
               - key: app
                 operator: In
                 values:
-                - triton-inference-server-demo
+                - triton-inference-server-example
             topologyKey: kubernetes.io/hostname
             namespaces:
             - default
@@ -282,8 +282,8 @@ spec:
         - name: inference-servers-config
           mountPath: /config/inference-servers
           readOnly: true
-        - name: inference-server-demo-config
-          mountPath: /config/inference-server-demo
+        - name: inference-server-example-config
+          mountPath: /config/inference-server-example
           readOnly: true
         - name: sync-script
           mountPath: /scripts
@@ -303,9 +303,9 @@ spec:
       - name: inference-servers-config
         configMap:
           name: inference-servers-list
-      - name: inference-server-demo-config
+      - name: inference-server-example-config
         configMap:
-          name: inference-server-demo-model-config
+          name: inference-server-example-model-config
           optional: true
       - name: sync-script
         configMap:
@@ -325,4 +325,4 @@ metadata:
   namespace: default
 data:
   servers.txt: |
-    inference-server-demo
+    inference-server-example

--- a/python/michelangelo/cli/sandbox/resources/model-sync.yaml
+++ b/python/michelangelo/cli/sandbox/resources/model-sync.yaml
@@ -257,7 +257,7 @@ spec:
               - key: app
                 operator: In
                 values:
-                - triton-inference-server-bert-cola
+                - triton-inference-server-demo
             topologyKey: kubernetes.io/hostname
             namespaces:
             - default
@@ -282,8 +282,8 @@ spec:
         - name: inference-servers-config
           mountPath: /config/inference-servers
           readOnly: true
-        - name: inference-server-bert-cola-config
-          mountPath: /config/inference-server-bert-cola
+        - name: inference-server-demo-config
+          mountPath: /config/inference-server-demo
           readOnly: true
         - name: sync-script
           mountPath: /scripts
@@ -303,9 +303,9 @@ spec:
       - name: inference-servers-config
         configMap:
           name: inference-servers-list
-      - name: inference-server-bert-cola-config
+      - name: inference-server-demo-config
         configMap:
-          name: inference-server-bert-cola-model-config
+          name: inference-server-demo-model-config
           optional: true
       - name: sync-script
         configMap:
@@ -325,4 +325,4 @@ metadata:
   namespace: default
 data:
   servers.txt: |
-    inference-server-bert-cola
+    inference-server-demo

--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -1196,13 +1196,13 @@ def _create_inference_demo_crs():
         "🌐 Deployment-agnostic endpoint:\
             Use the following URL to test the inference server"
     )
-    print("  http://localhost:8080/inference-server-bert-cola/v2")
+    print("  http://localhost:8080/inference-server-demo/v2")
     print(
         "  For example,\
             to test inference of a model deployed to the above inference server:\n"
     )
     print(
-        "  curl -X POST http://localhost:8080/inference-server-bert-cola/v2/models/<model-name>/infer \\"  # noqa: E501
+        "  curl -X POST http://localhost:8080/inference-server-demo/v2/models/<model-name>/infer \\"  # noqa: E501
     )
     print('  -H "Content-Type: application/json" \\')
     print("  -d '{")

--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -1196,13 +1196,13 @@ def _create_inference_demo_crs():
         "🌐 Deployment-agnostic endpoint:\
             Use the following URL to test the inference server"
     )
-    print("  http://localhost:8080/inference-server-demo/v2")
+    print("  http://localhost:8080/inference-server-example")
     print(
         "  For example,\
             to test inference of a model deployed to the above inference server:\n"
     )
     print(
-        "  curl -X POST http://localhost:8080/inference-server-demo/v2/models/<model-name>/infer \\"  # noqa: E501
+        "  curl -X POST http://localhost:8080/inference-server-example/models/<model-name>/infer \\"  # noqa: E501
     )
     print('  -H "Content-Type: application/json" \\')
     print("  -d '{")


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
This PR makes the following changes:
1. Updates path matching for deployment httproutes to route `http://localhost:8080/<inference-server-name>/<deployment-name>/*` to `http://localhost:8080/v2/models/<model-name>/*`. This allows the deployment httproute to be agnostic of the model-name and the inference-server name.
2. Updates path matching for inferenceserver httproutes to route `http://localhost:8080/<inference-server-name>/models/<model-name>*` to `http://localhost:8080/v2/models/<model-name>/*`. 
3. Updates inference-server CR name from `inference-server-bert-cola` to `inference-server-example`. As part of this, we also update the model-sync script to target the appropriate inference-server.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
1. Tested changes in sandbox
2. Unit tests