### PR TITLE
fix(inference): rename configmap model storage path field to be protocol agnostic

### DIFF
--- a/go/components/deployment/plugins/oss/cleanup/cleanup_test.go
+++ b/go/components/deployment/plugins/oss/cleanup/cleanup_test.go
@@ -43,7 +43,7 @@ func TestRetrieve(t *testing.T) {
 			setupMocks: func(mcp *configmapmocks.MockModelConfigMapProvider, pp *proxymocks.MockProxyProvider) {
 				mcp.EXPECT().GetModelsFromConfigMap(gomock.Any(), gomock.Any()).Return(
 					[]configmap.ModelConfigEntry{
-						{Name: "old-model", S3Path: "s3://bucket/old-model"},
+						{Name: "old-model", StoragePath: "s3://bucket/old-model"},
 					}, nil)
 			},
 			expectedConditionStatus:  api.CONDITION_STATUS_FALSE,

--- a/go/components/deployment/plugins/oss/rollout/strategies/model_sync_actor.go
+++ b/go/components/deployment/plugins/oss/rollout/strategies/model_sync_actor.go
@@ -117,8 +117,9 @@ func (a *ModelSyncActor) Run(ctx context.Context, deployment *v2pb.Deployment, c
 			InferenceServer: inferenceServerName,
 			Namespace:       deployment.Namespace,
 			ModelConfig: configmap.ModelConfigEntry{
-				Name:   modelName,
-				S3Path: fmt.Sprintf("s3://deploy-models/%s/", modelName),
+				Name: modelName,
+				// TODO(#696): ghosharitra: make the storage path configurable w.r.t storage client and storage location
+				StoragePath: fmt.Sprintf("s3://deploy-models/%s/", modelName),
 			},
 		}); err != nil {
 			a.logger.Error("Failed to update deployment via ConfigMapProvider", zap.Error(err))

--- a/go/components/inferenceserver/configmap/interface.go
+++ b/go/components/inferenceserver/configmap/interface.go
@@ -8,8 +8,8 @@ import (
 
 // ModelConfigEntry represents a model configuration with name and storage location.
 type ModelConfigEntry struct {
-	Name   string `json:"name"`
-	S3Path string `json:"s3_path"`
+	Name        string `json:"name"`
+	StoragePath string `json:"storage_path"`
 }
 
 // CreateModelConfigMapRequest specifies parameters for creating a model configuration ConfigMap.

--- a/go/components/inferenceserver/configmap/provider.go
+++ b/go/components/inferenceserver/configmap/provider.go
@@ -156,7 +156,7 @@ func (p *defaultModelConfigMapProvider) AddModelToConfigMap(ctx context.Context,
 	found := false
 	for i, config := range currentConfigs {
 		if config.Name == request.ModelConfig.Name {
-			currentConfigs[i].S3Path = request.ModelConfig.S3Path
+			currentConfigs[i].StoragePath = request.ModelConfig.StoragePath
 			found = true
 			break
 		}
@@ -164,8 +164,8 @@ func (p *defaultModelConfigMapProvider) AddModelToConfigMap(ctx context.Context,
 
 	if !found {
 		currentConfigs = append(currentConfigs, ModelConfigEntry{
-			Name:   request.ModelConfig.Name,
-			S3Path: request.ModelConfig.S3Path,
+			Name:        request.ModelConfig.Name,
+			StoragePath: request.ModelConfig.StoragePath,
 		})
 	}
 

--- a/go/components/inferenceserver/configmap/provider_test.go
+++ b/go/components/inferenceserver/configmap/provider_test.go
@@ -29,8 +29,8 @@ func TestCreateModelConfigMap(t *testing.T) {
 				InferenceServer: "test-server",
 				Namespace:       "default",
 				ModelConfigs: []ModelConfigEntry{
-					{Name: "model1", S3Path: "s3://bucket/model1"},
-					{Name: "model2", S3Path: "s3://bucket/model2"},
+					{Name: "model1", StoragePath: "s3://bucket/model1"},
+					{Name: "model2", StoragePath: "s3://bucket/model2"},
 				},
 				Labels: map[string]string{
 					"custom-label": "custom-value",
@@ -78,7 +78,7 @@ func TestCreateModelConfigMap(t *testing.T) {
 				InferenceServer: "existing-server",
 				Namespace:       "default",
 				ModelConfigs: []ModelConfigEntry{
-					{Name: "new-model", S3Path: "s3://bucket/new-model"},
+					{Name: "new-model", StoragePath: "s3://bucket/new-model"},
 				},
 				Labels:      nil,
 				Annotations: nil,
@@ -94,7 +94,7 @@ func TestCreateModelConfigMap(t *testing.T) {
 						},
 					},
 					Data: map[string]string{
-						modelListKey: `[{"name":"old-model","s3_path":"s3://bucket/old-model"}]`,
+						modelListKey: `[{"name":"old-model","storage_path":"s3://bucket/old-model"}]`,
 					},
 				},
 			},
@@ -114,7 +114,7 @@ func TestCreateModelConfigMap(t *testing.T) {
 
 				// Should still have the old model, not the new one
 				expectedOldModels := []ModelConfigEntry{
-					{Name: "old-model", S3Path: "s3://bucket/old-model"},
+					{Name: "old-model", StoragePath: "s3://bucket/old-model"},
 				}
 				assert.Equal(t, expectedOldModels, actualModels)
 
@@ -169,19 +169,19 @@ func TestGetModelConfigMap(t *testing.T) {
 						modelListKey: `[
   {
     "name": "model1",
-    "s3_path": "s3://bucket/model1"
+    "storage_path": "s3://bucket/model1"
   },
   {
     "name": "model2",
-    "s3_path": "s3://bucket/model2"
+    "storage_path": "s3://bucket/model2"
   }
 ]`,
 					},
 				},
 			},
 			expectedResponse: []ModelConfigEntry{
-				{Name: "model1", S3Path: "s3://bucket/model1"},
-				{Name: "model2", S3Path: "s3://bucket/model2"},
+				{Name: "model1", StoragePath: "s3://bucket/model1"},
+				{Name: "model2", StoragePath: "s3://bucket/model2"},
 			},
 			expectError: false,
 		},
@@ -299,8 +299,8 @@ func TestAddModelToConfigMap(t *testing.T) {
 				InferenceServer: "test-server",
 				Namespace:       "default",
 				ModelConfig: ModelConfigEntry{
-					Name:   "new-model",
-					S3Path: "s3://bucket/new-model",
+					Name:        "new-model",
+					StoragePath: "s3://bucket/new-model",
 				},
 			},
 			existingConfigMaps: []runtime.Object{
@@ -310,7 +310,7 @@ func TestAddModelToConfigMap(t *testing.T) {
 						Namespace: "default",
 					},
 					Data: map[string]string{
-						modelListKey: `[{"name":"existing-model","s3_path":"s3://bucket/existing-model"}]`,
+						modelListKey: `[{"name":"existing-model","storage_path":"s3://bucket/existing-model"}]`,
 					},
 				},
 			},
@@ -330,8 +330,8 @@ func TestAddModelToConfigMap(t *testing.T) {
 				require.NoError(t, err)
 
 				expectedModels := []ModelConfigEntry{
-					{Name: "existing-model", S3Path: "s3://bucket/existing-model"},
-					{Name: "new-model", S3Path: "s3://bucket/new-model"},
+					{Name: "existing-model", StoragePath: "s3://bucket/existing-model"},
+					{Name: "new-model", StoragePath: "s3://bucket/new-model"},
 				}
 				assert.Equal(t, expectedModels, actualModels)
 			},
@@ -342,8 +342,8 @@ func TestAddModelToConfigMap(t *testing.T) {
 				InferenceServer: "test-server",
 				Namespace:       "default",
 				ModelConfig: ModelConfigEntry{
-					Name:   "existing-model",
-					S3Path: "s3://bucket/updated-path",
+					Name:        "existing-model",
+					StoragePath: "s3://bucket/updated-path",
 				},
 			},
 			existingConfigMaps: []runtime.Object{
@@ -353,7 +353,7 @@ func TestAddModelToConfigMap(t *testing.T) {
 						Namespace: "default",
 					},
 					Data: map[string]string{
-						modelListKey: `[{"name":"existing-model","s3_path":"s3://bucket/old-path"}]`,
+						modelListKey: `[{"name":"existing-model","storage_path":"s3://bucket/old-path"}]`,
 					},
 				},
 			},
@@ -373,7 +373,7 @@ func TestAddModelToConfigMap(t *testing.T) {
 				require.NoError(t, err)
 
 				expectedModels := []ModelConfigEntry{
-					{Name: "existing-model", S3Path: "s3://bucket/updated-path"},
+					{Name: "existing-model", StoragePath: "s3://bucket/updated-path"},
 				}
 				assert.Equal(t, expectedModels, actualModels)
 			},
@@ -384,8 +384,8 @@ func TestAddModelToConfigMap(t *testing.T) {
 				InferenceServer: "test-server",
 				Namespace:       "default",
 				ModelConfig: ModelConfigEntry{
-					Name:   "first-model",
-					S3Path: "s3://bucket/first-model",
+					Name:        "first-model",
+					StoragePath: "s3://bucket/first-model",
 				},
 			},
 			existingConfigMaps: []runtime.Object{
@@ -415,7 +415,7 @@ func TestAddModelToConfigMap(t *testing.T) {
 				require.NoError(t, err)
 
 				expectedModels := []ModelConfigEntry{
-					{Name: "first-model", S3Path: "s3://bucket/first-model"},
+					{Name: "first-model", StoragePath: "s3://bucket/first-model"},
 				}
 				assert.Equal(t, expectedModels, actualModels)
 			},
@@ -426,8 +426,8 @@ func TestAddModelToConfigMap(t *testing.T) {
 				InferenceServer: "non-existent-server",
 				Namespace:       "default",
 				ModelConfig: ModelConfigEntry{
-					Name:   "model",
-					S3Path: "s3://bucket/model",
+					Name:        "model",
+					StoragePath: "s3://bucket/model",
 				},
 			},
 			existingConfigMaps: []runtime.Object{},
@@ -489,11 +489,11 @@ func TestRemoveModelFromConfigMap(t *testing.T) {
 						modelListKey: `[
   {
     "name": "model-to-keep",
-    "s3_path": "s3://bucket/model-to-keep"
+    "storage_path": "s3://bucket/model-to-keep"
   },
   {
     "name": "model-to-remove",
-    "s3_path": "s3://bucket/model-to-remove"
+    "storage_path": "s3://bucket/model-to-remove"
   }
 ]`,
 					},
@@ -515,7 +515,7 @@ func TestRemoveModelFromConfigMap(t *testing.T) {
 				require.NoError(t, err)
 
 				expectedModels := []ModelConfigEntry{
-					{Name: "model-to-keep", S3Path: "s3://bucket/model-to-keep"},
+					{Name: "model-to-keep", StoragePath: "s3://bucket/model-to-keep"},
 				}
 				assert.Equal(t, expectedModels, actualModels)
 			},
@@ -534,7 +534,7 @@ func TestRemoveModelFromConfigMap(t *testing.T) {
 						Namespace: "default",
 					},
 					Data: map[string]string{
-						modelListKey: `[{"name":"existing-model","s3_path":"s3://bucket/existing-model"}]`,
+						modelListKey: `[{"name":"existing-model","storage_path":"s3://bucket/existing-model"}]`,
 					},
 				},
 			},
@@ -554,7 +554,7 @@ func TestRemoveModelFromConfigMap(t *testing.T) {
 				require.NoError(t, err)
 
 				expectedModels := []ModelConfigEntry{
-					{Name: "existing-model", S3Path: "s3://bucket/existing-model"},
+					{Name: "existing-model", StoragePath: "s3://bucket/existing-model"},
 				}
 				assert.Equal(t, expectedModels, actualModels)
 			},
@@ -573,7 +573,7 @@ func TestRemoveModelFromConfigMap(t *testing.T) {
 						Namespace: "default",
 					},
 					Data: map[string]string{
-						modelListKey: `[{"name":"only-model","s3_path":"s3://bucket/only-model"}]`,
+						modelListKey: `[{"name":"only-model","storage_path":"s3://bucket/only-model"}]`,
 					},
 				},
 			},
@@ -657,7 +657,7 @@ func TestDeleteModelConfigMap(t *testing.T) {
 						Namespace: "default",
 					},
 					Data: map[string]string{
-						modelListKey: `[{"name":"model","s3_path":"s3://bucket/model"}]`,
+						modelListKey: `[{"name":"model","storage_path":"s3://bucket/model"}]`,
 					},
 				},
 			},

--- a/python/michelangelo/cli/sandbox/resources/model-sync.yaml
+++ b/python/michelangelo/cli/sandbox/resources/model-sync.yaml
@@ -128,9 +128,9 @@ data:
         for desired_model in $DESIRED_MODELS; do
           if [ ! -z "$desired_model" ]; then
             # Look up S3 path from inference server config for this model
-            s3_path=$(jq -r --arg model "$desired_model" '.[] | select(.name == $model) | .s3_path' /tmp/model-list.json 2>/dev/null)
-            if [ "$s3_path" = "null" ] || [ -z "$s3_path" ]; then
-              s3_path="s3://deploy-models/$desired_model/"  # Default S3 path pattern
+            storage_path=$(jq -r --arg model "$desired_model" '.[] | select(.name == $model) | .storage_path' /tmp/model-list.json 2>/dev/null)
+            if [ "$storage_path" = "null" ] || [ -z "$storage_path" ]; then
+              storage_path="s3://deploy-models/$desired_model/"  # Default S3 path pattern
             fi
             
             model_dir="$SERVER_MODEL_DIR/$desired_model"
@@ -178,9 +178,9 @@ data:
             fi
             
             if [ "$needs_sync" = true ]; then
-              echo "SYNC: Syncing model $desired_model from $s3_path to $model_dir/"
+              echo "SYNC: Syncing model $desired_model from $storage_path to $model_dir/"
               mkdir -p "$model_dir"
-              aws s3 sync "$s3_path" "$model_dir/" --exact-timestamps --endpoint-url "$AWS_ENDPOINT_URL"
+              aws s3 sync "$storage_path" "$model_dir/" --exact-timestamps --endpoint-url "$AWS_ENDPOINT_URL"
               
               # Verify sync completed with valid structure
               if validate_model_structure "$model_dir"; then


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
1. Updating field name from `s3_path` to `storage_path` for model configmap entries.
2. Created new issue and added a todo to make model storage path configurable.


<!-- Tell your future self why have you made these changes -->
**Why?**
In production scenarios, the model may be stored in other storages (e.g. gcs, azure blob storage, terrablob, etc.). `storage_path` accommodates for all these scenarios.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
1. Ran changes in sandbox with updated image.