### PR TITLE
[Uniflow] Enable stack trace logging for argparse type validation errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ __pycache__/
 /python/develop-eggs/
 /python/dist/
 /python/downloads/
+/python/lightning_logs/
 eggs/
 .eggs/
 /python/lib/

--- a/python/michelangelo/uniflow/core/run_task.py
+++ b/python/michelangelo/uniflow/core/run_task.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Entrypoint for running a Uniflow task."""
+
 import argparse
 import logging
 import sys

--- a/python/michelangelo/uniflow/core/run_task.py
+++ b/python/michelangelo/uniflow/core/run_task.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+"""Entrypoint for running a Uniflow task."""
 import argparse
 import logging
 import sys

--- a/python/michelangelo/uniflow/core/run_task.py
+++ b/python/michelangelo/uniflow/core/run_task.py
@@ -15,10 +15,10 @@ def main():
 
     p = argparse.ArgumentParser()
     p.add_argument("--task", required=True, type=str)
-    p.add_argument("--args", required=True, type=decoder.decode)
-    p.add_argument("--kwargs", required=True, type=decoder.decode)
+    p.add_argument("--args", required=True, type=_decode_arg)
+    p.add_argument("--kwargs", required=True, type=_decode_arg)
     p.add_argument("--result-url", required=True, type=str)
-    p.add_argument("--overrides", type=decoder.decode)
+    p.add_argument("--overrides", type=_decode_arg)
     ns = p.parse_args()
 
     assert isinstance(ns.args, list), (
@@ -50,6 +50,23 @@ def main():
         _uf_result_url=ns.result_url,
     )
     log.info("[ ok ]")
+
+
+def _decode_arg(value: str):
+    """A type conversion function for argparse arguments that use Uniflow decoder.
+
+    Wraps `decoder.decode` to ensure stack trace logging on failure.
+    This avoids argparse's default behavior of suppressing traceback printing in type
+    conversion functions, making decoding errors easier to debug.
+
+    See: https://github.com/michelangelo-ai/michelangelo/issues/699
+    """
+    try:
+        return decoder.decode(value)
+    except Exception as e:
+        error_message = f"Failed to decode argument: {value}"
+        log.error(error_message, exc_info=True)
+        raise argparse.ArgumentTypeError(error_message) from e
 
 
 if __name__ == "__main__":

--- a/python/michelangelo/uniflow/core/run_task.py
+++ b/python/michelangelo/uniflow/core/run_task.py
@@ -10,6 +10,7 @@ log = logging.getLogger(__name__)
 
 
 def main():
+    """Entrypoint for running a Uniflow task."""
     for a in sys.argv:
         log.info("sys.argv: %s", a)
 

--- a/python/tests/uniflow/core/test_run_task_decode_arg.py
+++ b/python/tests/uniflow/core/test_run_task_decode_arg.py
@@ -1,0 +1,52 @@
+"""Tests for the _decode_arg function in run_task module."""
+
+import argparse
+import logging
+
+import pytest
+
+from michelangelo.uniflow.core.run_task import _decode_arg
+
+
+def test_decode_arg_success():
+    """Test successful decoding of valid JSON strings."""
+    # Test dict
+    value = '{"key": "value"}'
+    result = _decode_arg(value)
+    assert result == {"key": "value"}
+
+    # Test list
+    value = "[1, 2, 3]"
+    result = _decode_arg(value)
+    assert result == [1, 2, 3]
+
+    # Test primitive
+    value = "123"
+    result = _decode_arg(value)
+    assert result == 123
+
+
+def test_decode_arg_failure():
+    """Test that invalid JSON raises ArgumentTypeError."""
+    value = "invalid json"
+
+    with pytest.raises(argparse.ArgumentTypeError) as excinfo:
+        _decode_arg(value)
+
+    assert f"Failed to decode argument: {value}" in str(excinfo.value)
+
+
+def test_decode_arg_logging(caplog):
+    """Test that decoding errors are logged with stack trace."""
+    value = "invalid json"
+
+    with pytest.raises(argparse.ArgumentTypeError), caplog.at_level(logging.ERROR):
+        _decode_arg(value)
+
+    # Verify log record
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert record.levelname == "ERROR"
+    assert f"Failed to decode argument: {value}" in record.message
+    # Verify exc_info is present (stack trace)
+    assert record.exc_info is not None

--- a/python/tests/uniflow/core/test_run_task_decode_arg.py
+++ b/python/tests/uniflow/core/test_run_task_decode_arg.py
@@ -40,8 +40,10 @@ class TestDecodeArg(unittest.TestCase):
         """Test that decoding errors are logged with stack trace."""
         value = "invalid json"
 
-        with self.assertRaises(argparse.ArgumentTypeError), \
-             self.assertLogs(level=logging.ERROR) as cm:
+        with (
+            self.assertRaises(argparse.ArgumentTypeError),
+            self.assertLogs(level=logging.ERROR) as cm,
+        ):
             _decode_arg(value)
 
         # Verify log record

--- a/python/tests/uniflow/core/test_run_task_decode_arg.py
+++ b/python/tests/uniflow/core/test_run_task_decode_arg.py
@@ -2,51 +2,52 @@
 
 import argparse
 import logging
-
-import pytest
+import unittest
 
 from michelangelo.uniflow.core.run_task import _decode_arg
 
 
-def test_decode_arg_success():
-    """Test successful decoding of valid JSON strings."""
-    # Test dict
-    value = '{"key": "value"}'
-    result = _decode_arg(value)
-    assert result == {"key": "value"}
+class TestDecodeArg(unittest.TestCase):
+    """Tests for _decode_arg."""
 
-    # Test list
-    value = "[1, 2, 3]"
-    result = _decode_arg(value)
-    assert result == [1, 2, 3]
+    def test_decode_arg_success(self):
+        """Test successful decoding of valid JSON strings."""
+        # Test dict
+        value = '{"key": "value"}'
+        result = _decode_arg(value)
+        self.assertEqual(result, {"key": "value"})
 
-    # Test primitive
-    value = "123"
-    result = _decode_arg(value)
-    assert result == 123
+        # Test list
+        value = "[1, 2, 3]"
+        result = _decode_arg(value)
+        self.assertEqual(result, [1, 2, 3])
 
+        # Test primitive
+        value = "123"
+        result = _decode_arg(value)
+        self.assertEqual(result, 123)
 
-def test_decode_arg_failure():
-    """Test that invalid JSON raises ArgumentTypeError."""
-    value = "invalid json"
+    def test_decode_arg_failure(self):
+        """Test that invalid JSON raises ArgumentTypeError."""
+        value = "invalid json"
 
-    with pytest.raises(argparse.ArgumentTypeError) as excinfo:
-        _decode_arg(value)
+        with self.assertRaises(argparse.ArgumentTypeError) as cm:
+            _decode_arg(value)
 
-    assert f"Failed to decode argument: {value}" in str(excinfo.value)
+        self.assertIn(f"Failed to decode argument: {value}", str(cm.exception))
 
+    def test_decode_arg_logging(self):
+        """Test that decoding errors are logged with stack trace."""
+        value = "invalid json"
 
-def test_decode_arg_logging(caplog):
-    """Test that decoding errors are logged with stack trace."""
-    value = "invalid json"
+        with self.assertRaises(argparse.ArgumentTypeError), \
+             self.assertLogs(level=logging.ERROR) as cm:
+            _decode_arg(value)
 
-    with pytest.raises(argparse.ArgumentTypeError), caplog.at_level(logging.ERROR):
-        _decode_arg(value)
-
-    # Verify log record
-    assert len(caplog.records) == 1
-    record = caplog.records[0]
-    assert record.levelname == "ERROR"
-    assert f"Failed to decode argument: {value}" in record.message
-    # Verify exc_info is present (stack trace)
-    assert record.exc_info is not None
+        # Verify log record
+        self.assertEqual(len(cm.records), 1)
+        record = cm.records[0]
+        self.assertEqual(record.levelname, "ERROR")
+        self.assertIn(f"Failed to decode argument: {value}", record.message)
+        # Verify exc_info is present (stack trace)
+        self.assertIsNotNone(record.exc_info)


### PR DESCRIPTION
This PR addresses the issue https://github.com/michelangelo-ai/michelangelo/issues/699.

**Summary**

Improved Uniflow's task runner script (`run_task.py`) so that when an exception occurs during argument parsing —specifically within type conversion — Uniflow prints the full stack trace to aid debugging.

**Details**

Created a wrapping custom type function used in argparse definitions. The wrapper has the following logic:

- Call the Uniflow decoder.
- Catch Exception.
- Print error message with a traceback
- Re-raise the exception (as ArgumentTypeError) so argparse can still handle the exit flow correctly.

**Testing**

I ran the following script that provides a malformed JSON in `--args`:
```
python -m michelangelo.uniflow.core.run_task --task a.b.c --args '[1,2,invalid]' --kwargs '{}' --result-url foo.json
```
The output cleanly indicates the JSON decoder error, making it easy to debug:
```
2025-12-11 13:05:35,819 |     INFO | __main__                                 | sys.argv: --task
2025-12-11 13:05:35,819 |     INFO | __main__                                 | sys.argv: a.b.c
2025-12-11 13:05:35,819 |     INFO | __main__                                 | sys.argv: --args
2025-12-11 13:05:35,819 |     INFO | __main__                                 | sys.argv: [1,2,invalid]
2025-12-11 13:05:35,819 |     INFO | __main__                                 | sys.argv: --kwargs
2025-12-11 13:05:35,819 |     INFO | __main__                                 | sys.argv: {}
2025-12-11 13:05:35,819 |     INFO | __main__                                 | sys.argv: --result-url
2025-12-11 13:05:35,819 |     INFO | __main__                                 | sys.argv: foo.json
2025-12-11 13:05:35,820 |    ERROR | __main__                                 | Failed to decode argument: [1,2,invalid]
Traceback (most recent call last):
  File "/Users/andrii/github/michelangelo/python/michelangelo/uniflow/core/run_task.py", line 65, in _decode_arg
    return decoder.decode(value)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 6 (char 5)
usage: run_task.py [-h] --task TASK --args ARGS --kwargs KWARGS --result-url RESULT_URL [--overrides OVERRIDES]
run_task.py: error: argument --args: Failed to decode argument: [1,2,invalid]
```