### PR TITLE
Ignore .tmpl files in coverage report

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -237,6 +237,7 @@ omit = [
     "*/__pycache__/*",
     "*/site-packages/*",
     "*/sandbox.py",
+    "*/*.tmpl",    
 ]
 
 [tool.coverage.report]


### PR DESCRIPTION
## Summary

This PR updates the coverage configuration to exclude template files (`.tmpl`) from test coverage reports.

## Rationale

Template files (e.g., `.tmpl` files) are not executable Python code and should not be included in test coverage metrics. These files are typically used for code generation or configuration templating and are not directly testable as Python modules. Including them in coverage reports can artificially lower coverage percentages and create noise in the coverage metrics.

By adding `"*/*.tmpl"` to the `omit` list in `pyproject.toml`, we ensure that template files are excluded from coverage calculations, providing more accurate and meaningful coverage statistics for actual Python code.

## Changes

- Added `"*/*.tmpl"` to the `omit` list in `python/pyproject.toml`