### PR TITLE
Auto-detect user name from environment for OSS compatibility

### DIFF
--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/apply.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/apply.py
@@ -48,7 +48,7 @@ def convert_crd_metadata_pipeline_apply(
         "revision_id": repo.head.commit.hexsha,
         "type": "PIPELINE_MANIFEST_TYPE_YAML",
     }
-    res["spec"]["owner"] = {"name": getenv("UBER_LDAP_UID")}
+    res["spec"]["owner"] = {"name": get_user_name()}
     _LOG.debug("Converted CRD metadata: %r", res)
     """
     return res

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/create.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/create.py
@@ -4,7 +4,6 @@ import json
 import tempfile
 from copy import deepcopy
 from logging import getLogger
-from os import getenv
 from pathlib import Path
 from typing import Optional
 from uuid import uuid4
@@ -15,6 +14,7 @@ from google.protobuf.message import Message
 from google.protobuf.struct_pb2 import Struct
 
 from michelangelo.cli.mactl.utils import (
+    get_user_name,
     read_subprocess_outputs,
     run_subprocess_registration,
 )
@@ -292,7 +292,7 @@ def populate_pipeline_spec_with_workflow_inputs(
         "filePath": config_file_relative_path,
         "type": "PIPELINE_MANIFEST_TYPE_UNIFLOW",
     }
-    res["spec"]["owner"] = {"name": getenv("UBER_LDAP_UID")}
+    res["spec"]["owner"] = {"name": get_user_name()}
 
     # Add uniflow artifacts if registration succeeded
     if workflow_inputs is not None:

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/create_test.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/create_test.py
@@ -134,9 +134,9 @@ class PipelineCreateTest(TestCase):
         workflow_function_name = "my_workflow"
 
         with patch(
-            "michelangelo.cli.mactl.plugins.entity.pipeline.create.getenv"
-        ) as mock_getenv:
-            mock_getenv.return_value = "test-user"
+            "michelangelo.cli.mactl.plugins.entity.pipeline.create.get_user_name"
+        ) as mock_get_user_name:
+            mock_get_user_name.return_value = "test-user"
 
             result = populate_pipeline_spec_with_workflow_inputs(
                 res,

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/run.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/run.py
@@ -24,6 +24,7 @@ from michelangelo.cli.mactl.grpc_tools import (
     get_methods_from_service,
     get_service_name,
 )
+from michelangelo.cli.mactl.utils import get_user_name
 
 _LOG = getLogger(__name__)
 
@@ -236,7 +237,7 @@ def generate_pipeline_run_object(
                 "namespace": namespace,
             },
             "actor": {
-                "name": "mactl-user",
+                "name": get_user_name(),
             },
         },
     }

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/run_test.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/run_test.py
@@ -34,8 +34,11 @@ class PipelineRunTest(TestCase):
         mock_time.time.assert_called_once()
         mock_uuid.uuid4.assert_called_once()
 
-    def test_generate_pipeline_run_object_basic(self):
+    @patch("michelangelo.cli.mactl.plugins.entity.pipeline.run.get_user_name")
+    def test_generate_pipeline_run_object_basic(self, mock_get_user_name):
         """Test basic pipeline run object generation."""
+        mock_get_user_name.return_value = "test-user"
+
         result = generate_pipeline_run_object(
             run_name="run-123-abc",
             pipeline_name="test-pipeline",
@@ -54,7 +57,8 @@ class PipelineRunTest(TestCase):
         self.assertIn("spec", result)
         self.assertEqual(result["spec"]["pipeline"]["name"], "test-pipeline")
         self.assertEqual(result["spec"]["pipeline"]["namespace"], "test-ns")
-        self.assertEqual(result["spec"]["actor"]["name"], "mactl-user")
+        self.assertEqual(result["spec"]["actor"]["name"], "test-user")
+        mock_get_user_name.assert_called_once()
 
         # Verify no resume spec when resume_from not provided
         self.assertNotIn("resume", result["spec"])

--- a/python/michelangelo/cli/mactl/utils.py
+++ b/python/michelangelo/cli/mactl/utils.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 from logging import getLogger
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Optional
 
 _logger = getLogger(__name__)
 
@@ -16,17 +16,11 @@ def get_user_name() -> str:
 
     Returns:
         str: User name from environment variables with fallback chain:
-            1. UBER_LDAP_UID (Uber internal)
-            2. USER (Unix/Linux)
-            3. USERNAME (Windows)
-            4. "mactl-user" (default)
+            1. USER (Unix/Linux)
+            2. USERNAME (Windows)
+            3. "mactl-user" (default)
     """
-    return (
-        os.getenv("UBER_LDAP_UID")
-        or os.getenv("USER")
-        or os.getenv("USERNAME")
-        or "mactl-user"
-    )
+    return os.getenv("USER") or os.getenv("USERNAME") or "mactl-user"
 
 
 def detect_user_python_interpreter() -> str:
@@ -243,13 +237,15 @@ def run_subprocess_registration(
 
         return result
 
-    except subprocess.TimeoutExpired as e:
-        raise RuntimeError(f"Registration subprocess timed out after 5 minutes: {e}")
-    except subprocess.SubprocessError as e:
-        raise RuntimeError(f"Failed to execute registration subprocess: {e}")
+    except subprocess.TimeoutExpired as e:  # pragma: no cover
+        raise RuntimeError(
+            f"Registration subprocess timed out after 5 minutes: {e}"
+        ) from e
+    except subprocess.SubprocessError as e:  # pragma: no cover
+        raise RuntimeError(f"Failed to execute registration subprocess: {e}") from e
 
 
-def read_subprocess_outputs(output_dir: str) -> Tuple[bool, str, Optional[str]]:
+def read_subprocess_outputs(output_dir: str) -> tuple[bool, str, Optional[str]]:
     """Read outputs from subprocess registration.
 
     Args:

--- a/python/michelangelo/cli/mactl/utils.py
+++ b/python/michelangelo/cli/mactl/utils.py
@@ -1,5 +1,4 @@
-"""Utility functions for MaCTL subprocess management and environment detection.
-"""
+"""Utility functions for MaCTL subprocess management and environment detection."""
 
 import os
 import shutil
@@ -10,6 +9,24 @@ from pathlib import Path
 from typing import Optional, Tuple
 
 _logger = getLogger(__name__)
+
+
+def get_user_name() -> str:
+    """Auto-detect user name from environment variables.
+
+    Returns:
+        str: User name from environment variables with fallback chain:
+            1. UBER_LDAP_UID (Uber internal)
+            2. USER (Unix/Linux)
+            3. USERNAME (Windows)
+            4. "mactl-user" (default)
+    """
+    return (
+        os.getenv("UBER_LDAP_UID")
+        or os.getenv("USER")
+        or os.getenv("USERNAME")
+        or "mactl-user"
+    )
 
 
 def detect_user_python_interpreter() -> str:


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
  - [x] Feature
  - [ ] Refactor
  - [ ] Bug Fix
  - [ ] Optimization
  - [ ] Documentation Update

  **What changed?**

  Replaced hardcoded `"mactl-user"` with dynamic user auto-detection for both Uber internal and OSS environments.

  - Added `get_user_name()` utility function with environment variable fallback chain:
    1. `UBER_LDAP_UID` (Uber internal)
    2. `USER` (Unix/Linux)
    3. `USERNAME` (Windows)
    4. `"mactl-user"` (default fallback)
  - Updated `pipeline run` command to use `get_user_name()` for `actor.name` field
  - Updated `pipeline create` command to use `get_user_name()` for `owner.name` field
  - Updated tests to mock the shared function

  **Why?**

  This change is part of the effort to import OSS mactl back to Uber internal. The current OSS code hardcodes `"mactl-user"` for the actor name which breaks in uber internal environments, and only uses Uber-specific `UBER_LDAP_UID` for owner name, which breaks in non-Uber environments.


  **How did you test it?**

  - All 23 unit tests passing (`run_test.py`, `create_test.py`)
  - Verified fallback chain behavior with environment variable simulation
  - Tested on macOS with `UBER_LDAP_UID` set (returns `amanda.yao`)
  - Linting and formatting checks pass

  **Release notes**

  - mactl now auto-detects user name from environment variables for better OSS and import back compatibility
