### PR TITLE
merge process_terminated_job function in starlark

### DIFF
--- a/python/michelangelo/uniflow/commons.star
+++ b/python/michelangelo/uniflow/commons.star
@@ -1,4 +1,4 @@
-load("@plugin", "cachedoutput", "hashlib", "json", "os", "progress", "storage", "uuid", "workflow")
+load("@plugin", "cachedoutput", "hashlib", "json", "os", "progress", "storage", "time", "uuid", "workflow")
 
 ENV = {
     "UF_REMOTE_RUN": "1",
@@ -274,11 +274,11 @@ def get_storage_type(result_json_url):
 def get_pythonpath():
     """
     Get PYTHONPATH environment variable with file sync support.
-    
-    When file sync is enabled (UF_FILE_SYNC_TARBALL_URL is set), appends the 
-    sitecustomize.py directory to PYTHONPATH. This ensures sitecustomize.py runs 
+
+    When file sync is enabled (UF_FILE_SYNC_TARBALL_URL is set), appends the
+    sitecustomize.py directory to PYTHONPATH. This ensures sitecustomize.py runs
     automatically on container startup to apply local code changes before task execution.
-    
+
     Returns:
         PYTHONPATH value, defaulting to "/app" if not set by user.
         If file sync is enabled, appends ":/app/michelangelo/uniflow/core" to the path.
@@ -289,3 +289,84 @@ def get_pythonpath():
         # Append sitecustomize.py location to enable automatic file sync on container startup
         pythonpath = pythonpath + ":/app/michelangelo/uniflow/core"
     return pythonpath
+
+def process_terminated_job(
+        job_state,
+        task_name,
+        task_path,
+        args,
+        kwargs,
+        cache_version,
+        namespace,
+        result_url,
+        start_time_formatted_str,
+        retry_attempt_id,
+        total_retry_attempt,
+        job_type,
+        log_url):
+    """
+    Process the result of a terminated job (Spark or Ray).
+
+    This function handles the common logic for processing job termination states
+    across different job execution engines (Spark, Ray, etc.).
+
+    Args:
+        job_state: The final state of the job (SUCCEEDED, FAILED, or KILLED)
+        task_name: The name of the task
+        task_path: The path of the task
+        args: Input arguments to the task
+        kwargs: Input keyword arguments to the task
+        cache_version: The version of the cache
+        namespace: The namespace of the task
+        result_url: The URL where the result is stored
+        start_time_formatted_str: The formatted start time string
+        retry_attempt_id: The current retry attempt number
+        total_retry_attempt: The total number of retry attempts
+        job_type: The type of job ("Spark" or "Ray") for message customization
+        log_url: The URL to the job logs
+
+    Returns:
+        retryable: Boolean indicating whether the job should be retried
+    """
+    retryable = False
+
+    if job_state == TASK_STATE_SUCCEEDED:
+        cache_keys = get_cache_keys(task_path, task_name, args, kwargs, cache_version, CACHE_OPERATION_PUT)
+        print("{} | caching with key".format(job_type.lower()), "key:", cache_keys)
+        created_cached_output = create_cached_output(
+            namespace = namespace,
+            cache_keys = cache_keys,
+            zone = "",
+            ttl_in_days = 0,
+            task_name = task_name,
+            result_json_url = result_url,
+        )
+        end_time_seconds = time.time()
+        end_time_formatted_str = time.utc_format_seconds(TIME_FOMART, end_time_seconds)
+
+        report_progress(
+            task_path = task_path,
+            task_name = task_name,
+            task_log = log_url,
+            task_message = "{} job succeeded".format(job_type) if job_type == "Spark" else "{} Task Completed Successfully".format(job_type),
+            task_state = TASK_STATE_SUCCEEDED,
+            start_time = start_time_formatted_str,
+            end_time = end_time_formatted_str,
+            output = created_cached_output.get("metadata", {}).get("name", ""),
+            retry_attempt_id = retry_attempt_id,
+        )
+        print("{} job succeeded, attempt ({} / {}) succeeded".format(job_type, str(retry_attempt_id), str(total_retry_attempt)))
+
+    elif job_state == TASK_STATE_KILLED:
+        print("{} job killed, attempt ({} / {}). no retry should be performed".format(job_type, str(retry_attempt_id), str(total_retry_attempt)))
+        fail("{} job killed, no retry should be performed".format(job_type))
+
+    elif job_state == TASK_STATE_FAILED:
+        print("{} job failed, attempt ({} / {}) failed".format(job_type, str(retry_attempt_id), str(total_retry_attempt)))
+        if retry_attempt_id < total_retry_attempt:
+            retryable = True
+        else:
+            print("{} job failed after all ({} / {}) attempts were exhausted".format(job_type, str(retry_attempt_id), str(total_retry_attempt)))
+            fail("{} job failed after all attempts were exhausted".format(job_type))
+
+    return retryable

--- a/python/michelangelo/uniflow/plugins/ray/task.star
+++ b/python/michelangelo/uniflow/plugins/ray/task.star
@@ -1,5 +1,5 @@
 load("@plugin", "atexit", "json", "os", "ray", "time")
-load("../../commons.star", "DEFAULT_RETRY_ATTEMPTS", "CACHE_OPERATION_GET", "CACHE_OPERATION_PUT", "TASK_STATE_FAILED", "TASK_STATE_KILLED", "TASK_STATE_PENDING", "TASK_STATE_RUNNING", "TASK_STATE_SKIPPED", "TASK_STATE_SUCCEEDED", "TIME_FOMART", "create_cached_output", "get_cache_enabled", "get_cache_keys", "get_cached_output", "get_pythonpath", "get_result_url", "get_task_image", "get_task_name", "io_read_json", "report_progress", "resource_dict", COMMONS_ENV = "ENV")
+load("../../commons.star", "DEFAULT_RETRY_ATTEMPTS", "CACHE_OPERATION_GET", "CACHE_OPERATION_PUT", "TASK_STATE_FAILED", "TASK_STATE_KILLED", "TASK_STATE_PENDING", "TASK_STATE_RUNNING", "TASK_STATE_SKIPPED", "TASK_STATE_SUCCEEDED", "TIME_FOMART", "create_cached_output", "get_cache_enabled", "get_cache_keys", "get_cached_output", "get_pythonpath", "get_result_url", "get_task_image", "get_task_name", "io_read_json", "process_terminated_job", "report_progress", "resource_dict", COMMONS_ENV = "ENV")
 
 DEFAULT_CREATE_CLUSTER_TIMEOUT_SECONDS = 60 * 30  # Timeout duration for cluster creation in seconds.
 RAY_ENV = {
@@ -200,21 +200,24 @@ def task(
                 breakpoint=breakpoint,
             )
 
-            retryable = process_terminated_ray_job(
-                job_state,
-                job,
-                task_name,
-                task_path,
-                args,
-                kwargs,
-                cache_version,
-                namespace,
-                result_url,
-                start_time_formated_str,
-                retry_attempt_id,
-                total_retry_attempt,
-                cluster_url,
-                ray_job_name,
+            # Generate log URL from Ray job name
+            generated_log_url = get_ray_log_url(ray_job_name)
+            log_url = generated_log_url if generated_log_url else cluster_url
+
+            retryable = process_terminated_job(
+                job_state = job_state,
+                task_name = task_name,
+                task_path = task_path,
+                args = args,
+                kwargs = kwargs,
+                cache_version = cache_version,
+                namespace = namespace,
+                result_url = result_url,
+                start_time_formatted_str = start_time_formated_str,
+                retry_attempt_id = retry_attempt_id,
+                total_retry_attempt = total_retry_attempt,
+                job_type = "Ray",
+                log_url = log_url,
             )
 
             if retryable == False:
@@ -251,57 +254,6 @@ def task(
     callable = callable_object(callable)
     callable.with_overrides = with_overrides
     return callable
-
-def process_terminated_ray_job(job_state, job, task_name, task_path, args, kwargs, cache_version, namespace, result_url, start_time_formated_str, retry_attempt_id, total_retry_attempt, cluster_url, ray_job_name):
-
-    retryable = False
-
-    if job_state == TASK_STATE_SUCCEEDED:
-
-        cache_keys = get_cache_keys(task_path, task_name, args, kwargs, cache_version, CACHE_OPERATION_PUT)
-        created_cached_output = create_cached_output(
-            namespace = namespace,
-            cache_keys = cache_keys,
-            zone = "",
-            ttl_in_days = 0,
-            task_name = task_name,
-            result_json_url = result_url,
-        )
-        cached_output_name = created_cached_output.get("metadata", {}).get("name", "")
-        end_time_seconds = time.time()
-        end_time_formated_str = time.utc_format_seconds(TIME_FOMART, end_time_seconds)
-
-        # Generate log URL from Ray job name
-        generated_log_url = get_ray_log_url(ray_job_name)
-        log_url = generated_log_url if generated_log_url else cluster_url
-
-        report_progress(
-            task_name = task_name,
-            task_path = task_path,
-            task_state = TASK_STATE_SUCCEEDED,
-            task_log = log_url,
-            start_time = start_time_formated_str,
-            end_time = end_time_formated_str,
-            task_message = "Ray Task Completed Successfully",
-            output = cached_output_name,
-            retry_attempt_id = retry_attempt_id,
-        )
-        print("Ray job succeeded, attempt (" + str(retry_attempt_id) + " / " + str(total_retry_attempt) + ") succeeded")
-
-    elif job_state == TASK_STATE_KILLED:
-        print("Ray task killed, attempt (" + str(retry_attempt_id) + " / " + str(total_retry_attempt) + ").  no retry should be performed")
-        fail("Ray task killed, no retry should be performed")
-
-    elif job_state == TASK_STATE_FAILED:
-        print("Ray task failed, attempt (" + str(retry_attempt_id) + " / " + str(total_retry_attempt) + ") failed")
-        if retry_attempt_id < total_retry_attempt:
-            retryable = True
-        else:
-            print("Ray task failed after all (" + str(retry_attempt_id) + " / " + str(total_retry_attempt) + ") attempts were exhausted")
-            fail("Ray task failed after all retry attempts were exhausted ", "internal:", "message:bad job status:", job["status"]["state"], job)
-
-    return retryable
-
 
 def execute_ray_task(task_path, task_name, cluster, cluster_namespace, runtime_env, start_time_formated_str, result_url, args, kwargs, retry_attempt_id, total_retry_attempt, cache_version, namespace, breakpoint=False):
 

--- a/python/michelangelo/uniflow/plugins/spark/task.star
+++ b/python/michelangelo/uniflow/plugins/spark/task.star
@@ -1,5 +1,5 @@
 load("@plugin", "atexit", "json", "os", "spark", "time", "workflow")
-load("../../commons.star", "CACHE_OPERATION_GET", "CACHE_OPERATION_PUT", "DEFAULT_RETRY_ATTEMPTS", "TASK_STATE_FAILED", "TASK_STATE_KILLED", "TASK_STATE_PENDING", "TASK_STATE_RUNNING", "TASK_STATE_SKIPPED", "TASK_STATE_SUCCEEDED", "TIME_FOMART", "create_cached_output", "get_cache_enabled", "get_cache_keys", "get_cached_output", "get_pythonpath", "get_result_url", "get_task_image", "get_task_name", "io_read_json", "report_progress", "resource_dict", COMMONS_ENV = "ENV")
+load("../../commons.star", "CACHE_OPERATION_GET", "CACHE_OPERATION_PUT", "DEFAULT_RETRY_ATTEMPTS", "TASK_STATE_FAILED", "TASK_STATE_KILLED", "TASK_STATE_PENDING", "TASK_STATE_RUNNING", "TASK_STATE_SKIPPED", "TASK_STATE_SUCCEEDED", "TIME_FOMART", "create_cached_output", "get_cache_enabled", "get_cache_keys", "get_cached_output", "get_pythonpath", "get_result_url", "get_task_image", "get_task_name", "io_read_json", "process_terminated_job", "report_progress", "resource_dict", COMMONS_ENV = "ENV")
 
 SPARK_ENV = {
     "PYTHONPATH": get_pythonpath(),
@@ -137,19 +137,30 @@ def spark_task(
                 total_retry_attempt = total_retry_attempt,
             )
 
-            retryable = process_terminated_spark_job(
-                job_state,
-                terminated_job,
-                task_name,
-                task_path,
-                args,
-                kwargs,
-                cache_version,
-                namespace,
-                result_url,
-                start_time_formatted_str,
-                retry_attempt_id,
-                total_retry_attempt,
+            # Extract log URL from terminated job
+            driver_log_url = ""
+            spark_job_name = ""
+            if type(terminated_job) == "dict":
+                driver_log_url = terminated_job.get("status", {}).get("jobUrl", "")
+                spark_job_name = terminated_job.get("metadata", {}).get("name", "")
+
+            generated_log_url = get_spark_log_url(spark_job_name)
+            log_url = generated_log_url if generated_log_url else driver_log_url
+
+            retryable = process_terminated_job(
+                job_state = job_state,
+                task_name = task_name,
+                task_path = task_path,
+                args = args,
+                kwargs = kwargs,
+                cache_version = cache_version,
+                namespace = namespace,
+                result_url = result_url,
+                start_time_formatted_str = start_time_formatted_str,
+                retry_attempt_id = retry_attempt_id,
+                total_retry_attempt = total_retry_attempt,
+                job_type = "Spark",
+                log_url = log_url,
             )
 
             if retryable == False:
@@ -180,55 +191,6 @@ def spark_task(
     callable = callable_object(callable)
     callable.with_overrides = with_overrides
     return callable
-
-def process_terminated_spark_job(job_state, terminated_job, task_name, task_path, args, kwargs, cache_version, namespace, result_url, start_time_formatted_str, retry_attempt_id, total_retry_attempt):
-    retryable = False
-
-    if job_state == TASK_STATE_SUCCEEDED:
-        cache_keys = get_cache_keys(task_path, task_name, args, kwargs, cache_version, CACHE_OPERATION_PUT)
-        print("spark | caching with key", "key:", cache_keys)
-        created_cached_output = create_cached_output(
-            namespace = namespace,
-            cache_keys = cache_keys,
-            zone = "",
-            ttl_in_days = 0,
-            task_name = task_name,
-            result_json_url = result_url,
-        )
-        end_time_seconds = time.time()
-        end_time_formated_str = time.utc_format_seconds(TIME_FOMART, end_time_seconds)
-
-        driver_log_url = ""
-        if type(terminated_job) == "dict":
-            driver_log_url = terminated_job.get("status", {}).get("jobUrl", "")
-
-        report_progress(
-            task_path = task_path,
-            task_name = task_name,
-            task_log = driver_log_url,
-            task_message = "Spark job succeeded",
-            task_state = TASK_STATE_SUCCEEDED,
-            start_time = start_time_formatted_str,
-            end_time = end_time_formated_str,
-            output = created_cached_output.get("metadata", {}).get("name", ""),
-            retry_attempt_id = retry_attempt_id,
-        )
-        print("Spark job succeeded, attempt (" + str(retry_attempt_id) + " / " + str(total_retry_attempt) + ") succeeded")
-
-    elif job_state == TASK_STATE_KILLED:
-        print("Spark job killed, attempt (" + str(retry_attempt_id) + " / " + str(total_retry_attempt) + "). no retry should be performed")
-        fail("Spark job killed, no retry should be performed")
-
-        # If job failed or was killed, check if we have retries left
-    elif job_state == TASK_STATE_FAILED:
-        print("Spark job failed, attempt (" + str(retry_attempt_id) + " / " + str(total_retry_attempt) + ") failed")
-        if retry_attempt_id < total_retry_attempt:
-            retryable = True
-        else:
-            print("Spark job failed after all (" + str(retry_attempt_id) + " / " + str(total_retry_attempt) + ") attempts were exhausted")
-            fail("Spark job failed after all attempts were exhausted")
-
-    return retryable
 
 def execute_spark_task(namespace, task_name, task_path, spark_job, start_time_formatted_str, retry_attempt_id, total_retry_attempt):
     print("Spark job running, attempt (" + str(retry_attempt_id) + " / " + str(total_retry_attempt) + ")")


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
Merged `process_terminated_spark_job` and `process_terminated_ray_job` into a single generic `process_terminated_job` function in `commons.star`. Both Spark and Ray task executors now use this shared implementation.

- Created `process_terminated_job()` in `commons.star` with `job_type` parameter for engine-specific messaging
- Updated `spark/task.star` to extract log URLs and call the generic function
- Updated `ray/task.star` to extract log URLs and call the generic function
- Removed ~50 lines of duplicated code

<!-- Tell your future self why have you made these changes -->
**Why?**
The two functions were ~95% identical, differing only in:
- Log URL extraction logic (engine-specific)
- Success/failure message formatting
- Parameter names

This duplication made maintenance error-prone - any logic changes needed to be applied twice. A senior engineer suggested consolidating them to ensure consistent retry behavior across both execution engines.

**Test**
run e2e test
`PYTHONPATH=. poetry run python ./examples/bert_cola/bert_cola.py  remote-run --image docker.io/library/examples:latest --storage-url s3://default --yes`

Run successfully went through
