### PR TITLE
Fix JavaScript coverage N/A issue in combined coverage report

### DIFF
--- a/.github/workflows/combined-coverage.yml
+++ b/.github/workflows/combined-coverage.yml
@@ -56,11 +56,24 @@ jobs:
           if_no_artifact_found: warn
 
       - name: Download JavaScript coverage
+        id: download-js
         uses: dawidd6/action-download-artifact@v6
+        continue-on-error: true
         with:
           workflow: javascript-coverage.yml
           name: javascript-coverage-reports
           path: ./coverage-reports/javascript
+          if_no_artifact_found: warn
+
+      - name: Fallback to main branch JavaScript coverage
+        if: steps.download-js.outcome == 'failure'
+        uses: dawidd6/action-download-artifact@v6
+        continue-on-error: true
+        with:
+          workflow: javascript-coverage.yml
+          name: javascript-coverage-reports
+          path: ./coverage-reports/javascript
+          branch: main
           if_no_artifact_found: warn
 
       - name: Extract coverage metrics
@@ -69,27 +82,41 @@ jobs:
           # Python coverage
           if [ -f "coverage-reports/python/coverage.json" ]; then
             PYTHON_COV=$(python3 -c "import json; print(json.load(open('coverage-reports/python/coverage.json'))['totals']['percent_covered_display'])" 2>/dev/null || echo "N/A")
+            PYTHON_NOTE=""
           else
             PYTHON_COV="N/A"
+            PYTHON_NOTE=" (no coverage data)"
           fi
 
           # Go coverage
           if [ -f "coverage-reports/go/coverage.txt" ]; then
             GO_COV=$(grep "total:" coverage-reports/go/coverage.txt | awk '{print $3}' | sed 's/%//' || echo "N/A")
+            GO_NOTE=""
           else
             GO_COV="N/A"
+            GO_NOTE=" (no coverage data)"
           fi
 
           # JavaScript coverage
           if [ -f "coverage-reports/javascript/coverage-summary.json" ]; then
             JS_COV=$(node -p "require('./coverage-reports/javascript/coverage-summary.json').total.lines.pct" 2>/dev/null || echo "N/A")
+            # Check if we're using fallback coverage from main
+            if [ "${{ steps.download-js.outcome }}" == "failure" ]; then
+              JS_NOTE=" (from main branch)"
+            else
+              JS_NOTE=""
+            fi
           else
             JS_COV="N/A"
+            JS_NOTE=" (no coverage data)"
           fi
 
           echo "PYTHON_COVERAGE=$PYTHON_COV" >> $GITHUB_ENV
+          echo "PYTHON_NOTE=$PYTHON_NOTE" >> $GITHUB_ENV
           echo "GO_COVERAGE=$GO_COV" >> $GITHUB_ENV
+          echo "GO_NOTE=$GO_NOTE" >> $GITHUB_ENV
           echo "JS_COVERAGE=$JS_COV" >> $GITHUB_ENV
+          echo "JS_NOTE=$JS_NOTE" >> $GITHUB_ENV
 
       # Codecov upload disabled - coverage is reported via PR comments and artifacts
       # - name: Upload combined coverage to Codecov
@@ -110,9 +137,9 @@ jobs:
 
             | Component | Coverage | Baseline | New Code | Status |
             |-----------|----------|----------|----------|--------|
-            | 🐍 Python | ${{ env.PYTHON_COVERAGE }}% | ≥70% | ≥90% ✅ | ${{ env.PYTHON_COVERAGE != 'N/A' && '✅' || '⏭️' }} |
-            | 🐹 Go | ${{ env.GO_COVERAGE }}% | ≥60% | ≥90% ✅ | ${{ env.GO_COVERAGE != 'N/A' && '✅' || '⏭️' }} |
-            | 📜 JavaScript | ${{ env.JS_COVERAGE }}% | ≥78.74% | ≥90% ✅ | ${{ env.JS_COVERAGE != 'N/A' && '✅' || '⏭️' }} |
+            | 🐍 Python | ${{ env.PYTHON_COVERAGE }}%${{ env.PYTHON_NOTE }} | ≥70% | ≥90% ✅ | ${{ env.PYTHON_COVERAGE != 'N/A' && '✅' || '⏭️' }} |
+            | 🐹 Go | ${{ env.GO_COVERAGE }}%${{ env.GO_NOTE }} | ≥60% | ≥90% ✅ | ${{ env.GO_COVERAGE != 'N/A' && '✅' || '⏭️' }} |
+            | 📜 JavaScript | ${{ env.JS_COVERAGE }}%${{ env.JS_NOTE }} | ≥78.74% | ≥90% ✅ | ${{ env.JS_COVERAGE != 'N/A' && '✅' || '⏭️' }} |
 
             ---
 


### PR DESCRIPTION
## Problem

JavaScript coverage was showing as "N/A" in PRs that don't modify JavaScript files (like #714). This happens because:

1. The JavaScript coverage workflow only runs when JS files are changed
2. When no artifact exists for the current PR, the download fails
3. The coverage displays as confusing "N/A" instead of showing baseline coverage

## Root Cause

From the logs of PR #714:
```
Download JavaScript coverage	2025-12-18T03:33:21.6736334Z ==> (found) Run ID: 19917618804
Download JavaScript coverage	2025-12-18T03:33:21.6737183Z ==> (found) Run date: 2025-12-04T04:24:05Z
Download JavaScript coverage	2025-12-18T03:33:21.9213070Z ==> (not found) Artifact: javascript-coverage-reports
```

The workflow tried to find a JavaScript coverage artifact but only found one from Dec 4 (2 weeks old), which has expired.

## Solution

This PR implements a fallback mechanism:

1. **Try current PR first**: Attempt to download JS coverage from the current PR's workflow run
2. **Fallback to main branch**: If not found, download coverage from the main branch
3. **Add clear notes**: Show which source the coverage came from:
   - `(from main branch)` - when using fallback coverage
   - `(no coverage data)` - when no coverage available at all
4. **Graceful error handling**: Use `continue-on-error` to prevent failures

## Changes Made

- Added fallback step to download coverage from main branch when PR artifact not found
- Added notes to coverage report table to indicate data source
- Used `continue-on-error` for graceful handling of missing artifacts

## Benefits

- ✅ PRs will show actual JS coverage from main instead of "N/A"
- ✅ Clear indication when coverage is from base branch vs current PR
- ✅ Better user experience in PR reviews
- ✅ Less confusion about what "N/A" means

## Example Output

Before:
```
| 📜 JavaScript | N/A | ≥78.74% | ≥90% ✅ | ⏭️ |
```

After (for PRs without JS changes):
```
| 📜 JavaScript | 78.74% (from main branch) | ≥78.74% | ≥90% ✅ | ✅ |
```