### PR TITLE
Update python-build and python-coverage check: Free disk space before installing dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,22 @@ jobs:
           fetch-depth: 0  # Fetch full history for git operations
 
       #----------------------------------------------
+      #  Free disk space to prevent "No space left on device" errors
+      #----------------------------------------------
+      - name: Free disk space
+        run: |
+          echo "Disk space before cleanup:"
+          df -h
+          # Remove large packages not needed for Python builds
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/share/powershell
+          sudo rm -rf /usr/share/swift
+          echo "Disk space after cleanup:"
+          df -h
+
+      #----------------------------------------------
       #  Setup Python and Poetry using composite action
       #----------------------------------------------
       - name: Setup Python and Poetry

--- a/.github/workflows/python-coverage.yml
+++ b/.github/workflows/python-coverage.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           fetch-depth: 0  # Need full history for coverage comparison
 
-      - name: Free disk space for Bazel
+      - name: Free disk space
         run: |
           echo "Disk space before cleanup:"
           df -h

--- a/.github/workflows/python-coverage.yml
+++ b/.github/workflows/python-coverage.yml
@@ -27,6 +27,19 @@ jobs:
         with:
           fetch-depth: 0  # Need full history for coverage comparison
 
+      - name: Free disk space for Bazel
+        run: |
+          echo "Disk space before cleanup:"
+          df -h
+          # Remove large packages not needed for Go/Bazel builds
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/share/powershell
+          sudo rm -rf /usr/share/swift
+          echo "Disk space after cleanup:"
+          df -h
+
       - name: Set up Python 3.9
         uses: actions/setup-python@v5
         with:

--- a/python/michelangelo/lib/model_manager/packager/custom_triton/custom_triton_packager.py
+++ b/python/michelangelo/lib/model_manager/packager/custom_triton/custom_triton_packager.py
@@ -1,4 +1,4 @@
-"""Packager for custom Triton models."""
+"""Packager for custom Triton models. testing github actions."""
 
 import tempfile
 from typing import Optional, Union

--- a/python/michelangelo/lib/model_manager/packager/custom_triton/custom_triton_packager.py
+++ b/python/michelangelo/lib/model_manager/packager/custom_triton/custom_triton_packager.py
@@ -1,4 +1,4 @@
-"""Packager for custom Triton models. testing github actions."""
+"""Packager for custom Triton models."""
 
 import tempfile
 from typing import Optional, Union


### PR DESCRIPTION
Frees up ~20GB of runner disk storage: 
```shell
52s
Run echo "Disk space before cleanup:"
Disk space before cleanup:
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   57G   16G  79% /
tmpfs           3.9G   84K  3.9G   1% /dev/shm
tmpfs           1.6G  1.1M  1.6G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sda16      881M   62M  758M   8% /boot
/dev/sda15      105M  6.2M   99M   6% /boot/efi
tmpfs           795M   12K  795M   1% /run/user/1001
Disk space after cleanup:
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   37G   36G  51% /
tmpfs           3.9G   84K  3.9G   1% /dev/shm
tmpfs           1.6G  1.1M  1.6G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sda16      881M   62M  758M   8% /boot
/dev/sda15      105M  6.2M   99M   6% /boot/efi
tmpfs           795M   12K  795M   1% /run/user/1001
```