### PR TITLE
Fix controllermgr to support local development with external Kubernet…

### DIFF
--- a/go/components/jobs/common/secrets/secrets.go
+++ b/go/components/jobs/common/secrets/secrets.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/michelangelo-ai/michelangelo/go/components/jobs/common/constants"
 	v2pb "github.com/michelangelo-ai/michelangelo/proto/api/v2"
@@ -60,23 +59,23 @@ type InClusterClientSet struct {
 	ClientSet kubernetes.Interface `name:"inClusterClientSet"`
 }
 
-func NewInClusterClientSet() InClusterClientSet {
-	// Try in-cluster config first, then fall back to kubeconfig for local development
-	cfg, err := rest.InClusterConfig()
+// InClusterClientSetParams has params for the InClusterClientSet constructor
+type InClusterClientSetParams struct {
+	fx.In
+
+	Config *rest.Config
+}
+
+// NewInClusterClientSet creates a Kubernetes clientset using the injected rest.Config.
+// This allows the client to work both in-cluster and locally (via kubeconfig).
+func NewInClusterClientSet(p InClusterClientSetParams) (InClusterClientSet, error) {
+	k8sClusterClient, err := kubernetes.NewForConfig(p.Config)
 	if err != nil {
-		// Fall back to kubeconfig (controller-runtime's GetConfig handles this)
-		cfg, err = ctrl.GetConfig()
-		if err != nil {
-			panic(err)
-		}
-	}
-	k8sClusterClient, err := kubernetes.NewForConfig(cfg)
-	if err != nil {
-		panic(err)
+		return InClusterClientSet{}, err
 	}
 	return InClusterClientSet{
 		ClientSet: k8sClusterClient,
-	}
+	}, nil
 }
 
 // Result has the result of the constructor


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

Modified `NewInClusterClientSet` in `go/components/jobs/common/secrets/secrets.go` to accept an injected `*rest.Config` via FX dependency injection instead of hardcoding `rest.InClusterConfig()`.

- Added `InClusterClientSetParams` struct with `*rest.Config` field
- Changed function signature to `NewInClusterClientSet(p InClusterClientSetParams) (InClusterClientSet, error)`
- Replaced panic-on-error with proper error return

<!-- Tell your future self why have you made these changes -->
**Why?**

`rest.InClusterConfig()` only works when running inside a Kubernetes pod. When running the controllermgr locally (via `bazel run`) against a remote cluster (e.g., k3d sandbox), it would panic with `unable to load in-cluster configuration`.

This fix enables local development by using the existing `*rest.Config` already provided via FX ( [from `baseconfig.GetK8sConfig`](https://github.com/michelangelo-ai/michelangelo/blob/main/go/cmd/controllermgr/main.go#L83) ), which automatically handles both in-cluster and kubeconfig-based configurations.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

1. Started sandbox cluster: `poetry run ma sandbox create`
2. Verified all pods running: `kubectl get pods -n default`
3. Deleted in-cluster controllermgr: `kubectl delete pod michelangelo-controllermgr -n default`
4. Ran controllermgr locally: `HEALTH_ADDRESS=:8082 bazel run //go/cmd/controllermgr:controllermgr`
5. Verified service starts without panic and connects to cluster successfully

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

Low risk. The injected `*rest.Config` is the same config used by other components (e.g., controller manager, API handler). In production (in-cluster), `ctrl.GetConfig()` behaves identically to `rest.InClusterConfig()`.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

N/A - Internal fix for local development workflow. No schema or configuration changes.

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**

N/A - No user-facing or API changes. Backward compatible.