### PR TITLE
Add github workflow to deploy docs site

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,53 @@
+name: Deploy Docs (Bun)
+
+on:
+  push:
+    branches: [main]
+    paths: ['docs/**', 'website/**']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: website
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        run: bun run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: website/build
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**                                                    
- [ ] Refactor                                                                                         
- [x] Feature                                                                                          
- [ ] Bug Fix                                                                                          
- [ ] Optimization                                                                                     
- [ ] Documentation Update                                                                             
                                                                                                      
<!-- Describe what has changed in this PR -->                                                          
**What changed?**                                                                                      
Adds a GitHub Actions workflow (`deploy-docs.yml`) to automatically build and deploy the documentation 
site to GitHub Pages using Bun.                                                                        
                                                                                                      
The workflow:                                                                                          
- Triggers on pushes to `main` when `docs/**` or `website/**` paths change                             
- Supports manual triggering via `workflow_dispatch`                                                   
- Builds the site using Bun from the `website/` directory                                              
- Deploys to GitHub Pages using the official `deploy-pages` action                                     
                                                                                                      
<!-- Tell your future self why have you made these changes -->                                         
**Why?**                                                                                               
This is PR 3 of 3 for the docs site setup. Automates deployment so documentation updates are published 
automatically when merged to main.                                                                     
                                                                                                      
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? --> 
**How did you test it?**                                                                               
Workflow syntax validated. Will verify end-to-end after enabling GitHub Pages in repository settings.  
                                                                                                      
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->         
**Potential risks**                                                                                    
Low risk. This workflow only affects docs deployment and does not impact the core application. Requires
GitHub Pages to be enabled in repository settings with source set to "GitHub Actions".                
                                                                                                      
<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so,  
please mention it, and also update CHANGELOG.md -->                                                    
**Release notes**                                                                                      
Documentation site now automatically deploys to GitHub Pages on changes to `docs/` or `website/`.      
                                                                                                      
<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change       
backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? 
-->                                                                                                    
**Documentation Changes**                                                                              
N/A - This PR enables the documentation infrastructure itself.      