### PR TITLE
Add trigger run detail page enhancements

### DIFF
--- a/javascript/packages/core/config/entities/trigger/components/__tests__/trigger-information-tab.test.tsx
+++ b/javascript/packages/core/config/entities/trigger/components/__tests__/trigger-information-tab.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen } from '@testing-library/react';
+
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
+import { TriggerInformationTab } from '../trigger-information-tab';
+
+import type { TriggerRun } from '../../types';
+
+const mockTriggerRun: TriggerRun = {
+  metadata: {
+    name: 'test-trigger',
+    creationTimestamp: { seconds: 1704067200 },
+  },
+  spec: {
+    actor: { name: 'test-user' },
+    pipeline: { name: 'test-pipeline' },
+    revision: { name: 'test-revision' },
+    trigger: {
+      triggerType: { case: 'cronSchedule', value: { cron: '0 0 * * *' } },
+      parametersMap: {
+        param1: { value: 'value1' },
+        param2: { value: 'value2' },
+      },
+    },
+  },
+  status: {
+    state: 4,
+    logUrl: 'https://logs.example.com/trigger/123',
+    errorMessage: 'Test error message',
+  },
+};
+
+describe('TriggerInformationTab', () => {
+  it('renders loading state', () => {
+    render(
+      <TriggerInformationTab data={undefined} isLoading={true} />,
+      buildWrapper([getBaseProviderWrapper()])
+    );
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('renders no data state when data is undefined', () => {
+    render(
+      <TriggerInformationTab data={undefined} isLoading={false} />,
+      buildWrapper([getBaseProviderWrapper()])
+    );
+
+    expect(screen.getByText('No data available')).toBeInTheDocument();
+  });
+
+  it('renders log URL as clickable link', () => {
+    render(
+      <TriggerInformationTab data={mockTriggerRun} isLoading={false} />,
+      buildWrapper([getBaseProviderWrapper()])
+    );
+
+    const logLink = screen.getByRole('link', { name: mockTriggerRun.status!.logUrl });
+    expect(logLink).toHaveAttribute('href', mockTriggerRun.status!.logUrl);
+    expect(logLink).toHaveAttribute('target', '_blank');
+  });
+
+  it('renders fallback message when log URL is empty', () => {
+    const triggerRunWithoutLogUrl: TriggerRun = {
+      ...mockTriggerRun,
+      status: { state: 4 },
+    };
+
+    render(
+      <TriggerInformationTab data={triggerRunWithoutLogUrl} isLoading={false} />,
+      buildWrapper([getBaseProviderWrapper()])
+    );
+
+    expect(screen.getByText('No log URL available')).toBeInTheDocument();
+  });
+
+  it('renders error message when present', () => {
+    render(
+      <TriggerInformationTab data={mockTriggerRun} isLoading={false} />,
+      buildWrapper([getBaseProviderWrapper()])
+    );
+
+    expect(screen.getByText('Error Message')).toBeInTheDocument();
+    expect(screen.getByText('Test error message')).toBeInTheDocument();
+  });
+
+  it('does not render error section when error message is absent', () => {
+    const triggerRunWithoutError: TriggerRun = {
+      ...mockTriggerRun,
+      status: { state: 4, logUrl: 'https://logs.example.com/trigger/123' },
+    };
+
+    render(
+      <TriggerInformationTab data={triggerRunWithoutError} isLoading={false} />,
+      buildWrapper([getBaseProviderWrapper()])
+    );
+
+    expect(screen.queryByText('Error Message')).not.toBeInTheDocument();
+  });
+
+  it('renders parameters as JSON when present', () => {
+    render(
+      <TriggerInformationTab data={mockTriggerRun} isLoading={false} />,
+      buildWrapper([getBaseProviderWrapper()])
+    );
+
+    expect(screen.getByText('Parameters')).toBeInTheDocument();
+    expect(screen.getByText(/"param1"/)).toBeInTheDocument();
+  });
+
+  it('does not render parameters section when params are empty', () => {
+    const triggerRunWithoutParams: TriggerRun = {
+      ...mockTriggerRun,
+      spec: {
+        ...mockTriggerRun.spec,
+        trigger: {
+          triggerType: { case: 'cronSchedule', value: { cron: '0 0 * * *' } },
+        },
+      },
+    };
+
+    render(
+      <TriggerInformationTab data={triggerRunWithoutParams} isLoading={false} />,
+      buildWrapper([getBaseProviderWrapper()])
+    );
+
+    expect(screen.queryByText('Parameters')).not.toBeInTheDocument();
+  });
+});

--- a/javascript/packages/core/config/entities/trigger/components/trigger-information-tab.tsx
+++ b/javascript/packages/core/config/entities/trigger/components/trigger-information-tab.tsx
@@ -1,0 +1,101 @@
+import { useStyletron } from 'baseui';
+import { StyledLink } from 'baseui/link';
+
+import { Box } from '#core/components/box/box';
+
+import type { TriggerRun } from '../types';
+
+type TriggerInformationTabProps = {
+  data: TriggerRun | undefined;
+  isLoading: boolean;
+};
+
+export function TriggerInformationTab({ data, isLoading }: TriggerInformationTabProps) {
+  const [css, theme] = useStyletron();
+
+  if (isLoading) {
+    return (
+      <div className={css({ padding: theme.sizing.scale600 })}>
+        <Box title="Information">Loading...</Box>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className={css({ padding: theme.sizing.scale600 })}>
+        <Box title="Information">No data available</Box>
+      </div>
+    );
+  }
+
+  const logUrl = data.status?.logUrl;
+  const errorMessage = data.status?.errorMessage;
+  const parametersMap = data.spec?.trigger?.parametersMap;
+
+  const labelStyle = css({
+    ...theme.typography.LabelSmall,
+    color: theme.colors.contentSecondary,
+    marginBottom: theme.sizing.scale200,
+  });
+
+  const valueStyle = css({
+    ...theme.typography.ParagraphSmall,
+    color: theme.colors.contentPrimary,
+    marginBottom: theme.sizing.scale600,
+  });
+
+  const errorStyle = css({
+    ...theme.typography.ParagraphSmall,
+    color: theme.colors.negative,
+    backgroundColor: theme.colors.backgroundNegativeLight,
+    padding: theme.sizing.scale400,
+    borderRadius: theme.borders.radius200,
+    marginBottom: theme.sizing.scale600,
+  });
+
+  const jsonStyle = css({
+    ...theme.typography.MonoParagraphSmall,
+    backgroundColor: theme.colors.backgroundSecondary,
+    padding: theme.sizing.scale400,
+    borderRadius: theme.borders.radius200,
+    whiteSpace: 'pre-wrap',
+    overflow: 'auto',
+    maxHeight: '300px',
+  });
+
+  return (
+    <div className={css({ padding: theme.sizing.scale600 })}>
+      <Box title="Information">
+        <div className={css({ display: 'flex', flexDirection: 'column' })}>
+          <div className={labelStyle}>Log URL</div>
+          <div className={valueStyle}>
+            {logUrl ? (
+              <StyledLink href={logUrl} target="_blank" rel="noopener noreferrer">
+                {logUrl}
+              </StyledLink>
+            ) : (
+              <span className={css({ color: theme.colors.contentTertiary })}>
+                No log URL available
+              </span>
+            )}
+          </div>
+
+          {errorMessage && (
+            <>
+              <div className={labelStyle}>Error Message</div>
+              <div className={errorStyle}>{errorMessage}</div>
+            </>
+          )}
+
+          {parametersMap && Object.keys(parametersMap).length > 0 && (
+            <>
+              <div className={labelStyle}>Parameters</div>
+              <div className={jsonStyle}>{JSON.stringify(parametersMap, null, 2)}</div>
+            </>
+          )}
+        </div>
+      </Box>
+    </div>
+  );
+}

--- a/javascript/packages/core/config/entities/trigger/detail.ts
+++ b/javascript/packages/core/config/entities/trigger/detail.ts
@@ -1,18 +1,43 @@
 import { CellType } from '#core/components/cell/constants';
 import { SHARED_RUN_CELL_CONFIG } from '#core/config/entities/run/shared';
-import { TRIGGER_PIPELINE_CELL_CONFIG, TRIGGER_STATE_CELL_CONFIG } from './shared';
+import { TriggerInformationTab } from './components/trigger-information-tab';
+import {
+  TRIGGER_BATCH_SIZE_CELL_CONFIG,
+  TRIGGER_CRON_CELL_CONFIG,
+  TRIGGER_END_TIME_CELL_CONFIG,
+  TRIGGER_INTERVAL_CELL_CONFIG,
+  TRIGGER_MAX_CONCURRENCY_CELL_CONFIG,
+  TRIGGER_PIPELINE_CELL_CONFIG,
+  TRIGGER_START_TIME_CELL_CONFIG,
+  TRIGGER_STATE_CELL_CONFIG,
+  TRIGGER_WAIT_CELL_CONFIG,
+} from './shared';
 
+import type { TriggerRun } from './types';
 import type { DetailViewConfig } from '#core/components/views/types';
 
-export const TRIGGER_DETAIL_CONFIG: DetailViewConfig = {
+export const TRIGGER_DETAIL_CONFIG: DetailViewConfig<TriggerRun> = {
   type: 'detail',
   metadata: [
     { id: 'metadata.creationTimestamp.seconds', label: 'Created', type: CellType.DATE },
     { id: 'spec.actor.name', label: 'Started by', type: CellType.TEXT },
     TRIGGER_PIPELINE_CELL_CONFIG,
     TRIGGER_STATE_CELL_CONFIG,
+    TRIGGER_CRON_CELL_CONFIG,
+    TRIGGER_INTERVAL_CELL_CONFIG,
+    TRIGGER_BATCH_SIZE_CELL_CONFIG,
+    TRIGGER_WAIT_CELL_CONFIG,
+    TRIGGER_MAX_CONCURRENCY_CELL_CONFIG,
+    TRIGGER_START_TIME_CELL_CONFIG,
+    TRIGGER_END_TIME_CELL_CONFIG,
   ],
   pages: [
+    {
+      id: 'information',
+      label: 'Information',
+      type: 'custom',
+      component: TriggerInformationTab,
+    },
     {
       id: 'runs',
       label: 'Recent Runs',

--- a/javascript/packages/core/config/entities/trigger/shared.ts
+++ b/javascript/packages/core/config/entities/trigger/shared.ts
@@ -1,7 +1,9 @@
 import { CellType } from '#core/components/cell/constants';
-import { Cell } from '#core/components/cell/types';
 
-export const TRIGGER_STATE_CELL_CONFIG: Cell = {
+import type { RowCell } from '#core/components/row/types';
+import type { TriggerRun } from './types';
+
+export const TRIGGER_STATE_CELL_CONFIG: RowCell = {
   id: 'status.state',
   label: 'State',
   type: CellType.STATE,
@@ -23,7 +25,7 @@ export const TRIGGER_STATE_CELL_CONFIG: Cell = {
   },
 };
 
-export const TRIGGER_PIPELINE_CELL_CONFIG: Cell = {
+export const TRIGGER_PIPELINE_CELL_CONFIG: RowCell = {
   id: 'spec.pipeline.name',
   label: 'Pipeline',
   items: [
@@ -36,4 +38,76 @@ export const TRIGGER_PIPELINE_CELL_CONFIG: Cell = {
       type: CellType.DESCRIPTION,
     },
   ],
+};
+
+export const TRIGGER_CRON_CELL_CONFIG: RowCell = {
+  id: 'spec.trigger.triggerType.value.cron',
+  label: 'Cron Schedule',
+  type: CellType.TEXT,
+  accessor: (row: TriggerRun) => {
+    const triggerType = row.spec?.trigger?.triggerType;
+    if (triggerType?.case === 'cronSchedule') {
+      return triggerType.value.cron;
+    }
+    return undefined;
+  },
+  hideEmpty: true,
+};
+
+export const TRIGGER_INTERVAL_CELL_CONFIG: RowCell = {
+  id: 'spec.trigger.triggerType.value.interval.seconds',
+  label: 'Interval (seconds)',
+  type: CellType.TEXT,
+  accessor: (row: TriggerRun) => {
+    const triggerType = row.spec?.trigger?.triggerType;
+    if (triggerType?.case === 'intervalSchedule') {
+      return triggerType.value.interval?.seconds;
+    }
+    return undefined;
+  },
+  hideEmpty: true,
+};
+
+export const TRIGGER_BATCH_SIZE_CELL_CONFIG: RowCell = {
+  id: 'spec.trigger.batchPolicy.batchSize',
+  label: 'Batch Size',
+  type: CellType.TEXT,
+  accessor: (row: TriggerRun) => {
+    if (row.spec?.trigger?.maxConcurrency) return undefined;
+    return row.spec?.trigger?.batchPolicy?.batchSize;
+  },
+  hideEmpty: true,
+};
+
+export const TRIGGER_WAIT_CELL_CONFIG: RowCell = {
+  id: 'spec.trigger.batchPolicy.wait.seconds',
+  label: 'Wait (seconds)',
+  type: CellType.TEXT,
+  accessor: (row: TriggerRun) => {
+    if (row.spec?.trigger?.maxConcurrency) return undefined;
+    return row.spec?.trigger?.batchPolicy?.wait?.seconds;
+  },
+  hideEmpty: true,
+};
+
+export const TRIGGER_MAX_CONCURRENCY_CELL_CONFIG: RowCell = {
+  id: 'spec.trigger.maxConcurrency',
+  label: 'Max Concurrency',
+  type: CellType.TEXT,
+  accessor: (row: TriggerRun) => row.spec?.trigger?.maxConcurrency,
+  hideEmpty: true,
+};
+
+export const TRIGGER_START_TIME_CELL_CONFIG: RowCell = {
+  id: 'spec.startTimestamp.seconds',
+  label: 'Start Time',
+  type: CellType.DATE,
+  hideEmpty: true,
+};
+
+export const TRIGGER_END_TIME_CELL_CONFIG: RowCell = {
+  id: 'spec.endTimestamp.seconds',
+  label: 'End Time',
+  type: CellType.DATE,
+  hideEmpty: true,
 };

--- a/javascript/packages/core/config/entities/trigger/types.ts
+++ b/javascript/packages/core/config/entities/trigger/types.ts
@@ -1,12 +1,66 @@
-export type Trigger = {
+type CronSchedule = {
+  cron: string;
+};
+
+type IntervalSchedule = {
+  interval?: {
+    seconds: number;
+  };
+};
+
+type BatchPolicy = {
+  batchSize: number;
+  wait?: {
+    seconds: number;
+  };
+};
+
+type TriggerType =
+  | { case: 'cronSchedule'; value: CronSchedule }
+  | { case: 'intervalSchedule'; value: IntervalSchedule }
+  | { case: 'batchRerun'; value: unknown }
+  | { case: undefined; value?: undefined };
+
+/**
+ * TriggerRun represents a single execution of a pipeline trigger.
+ * Based on proto/api/v2/trigger_run.proto
+ *
+ * Note: This is a simplified UI type. The trigger.triggerType uses protobuf-es
+ * discriminated union format: { case: 'cronSchedule', value: CronSchedule }
+ */
+export type TriggerRun = {
   metadata: {
     name: string;
+    creationTimestamp?: {
+      seconds: number;
+    };
   };
   spec: {
-    trigger: {
-      triggerType: {
-        case: 'cronSchedule' | 'batchRerun' | 'intervalSchedule';
-      };
+    actor?: {
+      name: string;
     };
+    pipeline?: {
+      name: string;
+    };
+    revision?: {
+      name: string;
+    };
+    trigger: {
+      triggerType: TriggerType;
+      batchPolicy?: BatchPolicy;
+      maxConcurrency?: number;
+      parametersMap?: Record<string, unknown>;
+    };
+    startTimestamp?: {
+      seconds: number;
+    };
+    endTimestamp?: {
+      seconds: number;
+    };
+  };
+  status?: {
+    state: number;
+    logUrl?: string;
+    errorMessage?: string;
   };
 };


### PR DESCRIPTION
Expand TriggerRun type to match proto/api/v2/trigger_run.proto with proper protobuf-es discriminated union format for triggerType oneof. Add metadata cells for cron schedule, interval, batch size wait time, max concurrency, and start/end timestamps with conditional visibility.

Create TriggerInformationTab component displaying log URL, error message, and parameters JSON. Add as first tab in detail view with existing Recent Runs table as second tab.

Use function accessors for oneof fields since protobuf-es represents oneofs as { case, value } discriminated unions rather than sibling properties. Simple fields like batchPolicy and maxConcurrency use standard property paths.

**What type of PR is this? (check all applicable)**

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update  


**What changed?**

- Added `TriggerRun` type with proper protobuf-es discriminated union format for `triggerType` oneof
- Added 7 new metadata cell configs: cron schedule, interval, batch size, wait time, max concurrency, start/end timestamps
- Created `TriggerInformationTab` component showing log URL, error message, and parameters JSON
- Added Information tab as first tab in trigger detail view  


**Why?**  
To display additional trigger run metadata and provide an Information tab with log URL, error details, and execution parameters on the trigger detail page.

**How did you test it?**

- TypeScript type checking passes
- Added 8 unit tests for TriggerInformationTab component covering loading, error, and data states
- All 858 existing tests pass  

**Potential risks**  
Low risk. Adds new UI components and metadata fields. Does not modify existing functionality.  
Conditional visibility (`hideEmpty: true`) ensures fields only display when data is present.

**Release notes**  
Enhanced trigger detail page with additional metadata fields and new Information tab.

**Documentation Changes**  
None required. UI-only change with no API or configuration changes.
