### PR TITLE
Fix JSDoc accuracy issues in hook and component documentation

### DIFF
--- a/javascript/packages/core/components/icon/icon.tsx
+++ b/javascript/packages/core/components/icon/icon.tsx
@@ -28,6 +28,7 @@ import type { Props } from './types';
  *   - PRIMARY: contentPrimary color
  *   - SECONDARY: contentSecondary color
  *   - TERTIARY: contentTertiary color
+ *   - ACCENT: contentAccent color
  * @param props.size - Icon size. Defaults to theme.sizing.scale550
  * @param props.color - Custom color override. When provided, overrides kind-based coloring
  * @param props.title - Accessible title for the icon

--- a/javascript/packages/core/providers/icon-provider/use-icon-provider.ts
+++ b/javascript/packages/core/providers/icon-provider/use-icon-provider.ts
@@ -8,9 +8,8 @@ import { IconContext } from './icon-context';
  * This hook must be used within an IconProvider component. It provides access
  * to the icon registry which maps icon names to React components.
  *
- * @returns Icon context containing the icon registry mapping
- *
- * @throws Will throw if used outside of an IconProvider
+ * @returns Icon context containing the icon registry mapping. Returns default empty
+ *   registry if used outside of an IconProvider.
  *
  * @example
  * ```typescript

--- a/javascript/packages/core/providers/service-provider/use-service-provider.tsx
+++ b/javascript/packages/core/providers/service-provider/use-service-provider.tsx
@@ -8,9 +8,8 @@ import { ServiceContext } from './service-context';
  * This hook must be used within a ServiceProvider component. It provides access
  * to the request function for making API calls.
  *
- * @returns Service context containing the request function
- *
- * @throws Will throw if used outside of a ServiceProvider
+ * @returns Service context containing the request function. Note: The returned
+ *   `request` function will throw if called outside of a ServiceProvider.
  *
  * @example
  * ```typescript

--- a/javascript/packages/core/providers/user-provider/use-user-provider.tsx
+++ b/javascript/packages/core/providers/user-provider/use-user-provider.tsx
@@ -8,9 +8,8 @@ import { UserContext } from './user-context';
  * This hook must be used within a UserProvider component. It provides access
  * to the authenticated user's data.
  *
- * @returns User context containing the current user information
- *
- * @throws Will throw if used outside of a UserProvider
+ * @returns User context containing the current user information. Returns default
+ *   context values if used outside of a UserProvider.
  *
  * @example
  * ```typescript


### PR DESCRIPTION
Corrects documentation inaccuracies from Phase 1 and Phase 2 JSDoc additions:

- useIconProvider: Remove incorrect @throws claim (has default empty registry)
- useUserProvider: Remove incorrect @throws claim (has default context values)
- useServiceProvider: Clarify that request() throws, not the hook itself
- Icon: Add missing ACCENT kind to @param documentation  


Related to #652

**What type of PR is this? (check all applicable)**

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update  


**What changed?**  
 Fixed inaccurate JSDoc comments in 4 files:

- Removed `@throws` claims from `useIconProvider` and `useUserProvider` since these hooks return default context values rather than throwing when used outside their providers
- Updated `useServiceProvider` to clarify that the returned `request` function throws, not the hook itself
- Added missing `ACCENT` kind to Icon component's `@param props.kind` documentation  


**Why?**  
 The Phase 1 and Phase 2 JSDoc additions included some inaccuracies that could mislead developers. The `@throws` claims were inconsistent with the actual implementations (which use default context values), and the Icon documentation was incomplete.

**How did you test it?**  
 Verified against source implementations:

- Confirmed `IconContext` has default `{ icons: {} }`
- Confirmed `UserContext` has default `{ timeZone: UserTimeZone.Local }`
- Confirmed `ServiceContext.request` throws, not `useServiceProvider`
- Confirmed `IconKind` enum includes `ACCENT`  


**Potential risks**  
 None. Documentation-only changes with no runtime impact.

**Release notes**  
 N/A - Internal documentation fix

**Documentation Changes**  
 JSDoc comments only. No user-facing or API documentation changes required.  

