### PR TITLE
Add .npmrc to website to use public npm registry

### DIFF
--- a/website/.npmrc
+++ b/website/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/


### PR DESCRIPTION
Fixes 401 errors when developers have global npm config pointing to internal registry (unpm.uberinternal.com). Matches existing pattern in javascript/.npmrc.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

Added `.npmrc` to the `website/` directory to explicitly use the public npm registry (`registry.npmjs.org`).

<!-- Tell your future self why have you made these changes -->
**Why?**

Some developers have their global npm/bun config pointing to `unpm.uberinternal.com`. When running `bun install` in `website/`, they get 401 errors because public packages like `depd` aren't accessible through the internal registry without auth. The `javascript/` directory already has this fix.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Verified the pattern matches `javascript/.npmrc`. The affected developer can confirm the fix resolves their 401 error.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

None. This only affects local development `npm/bun install` behavior.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

N/A - local dev tooling only.

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**

None required.
