### PR TITLE
in hasInstances only list storage version

### DIFF
--- a/go/api/crd/gateway.go
+++ b/go/api/crd/gateway.go
@@ -173,6 +173,9 @@ func (r *gateway) List(ctx context.Context) (*apiextv1.CustomResourceDefinitionL
 
 func (r *gateway) hasInstances(ctx context.Context, crd *apiextv1.CustomResourceDefinition) (bool, error) {
 	for _, v := range crd.Spec.Versions {
+		if !v.Storage {
+			continue
+		}
 		gvr := schema.GroupVersionResource{
 			Group:    crd.Spec.Group,
 			Version:  v.Name,


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->

Instead of listing all CRD versions, only list storage version. This will skip all to conversion webhook. Because when doing syncCRD, the conversion webhook has not been setup.


<!-- Tell your future self why have you made these changes -->

To mitigate issue 
`failed to list existing instances of CRD projects.michelangelo.uber.com: conversion webhook for michelangelo.uber.com/v2beta1, Kind=Project failed: Post "
https://127.0.0.1:7155/convert?timeout=30s":
 read tcp 127.0.0.1:42798->127.0.0.1:7155: read: connection reset by peer`
 
 slack conversation: https://uber.slack.com/archives/CU0414YQ7/p1770226747940909?thread_ts=1770224963.825129&cid=CU0414YQ7 


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
