### PR TITLE
Add landing page with animated hero, features, and code examples

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -35,7 +35,7 @@ const config: Config = {
       {
         docs: {
           path: '../docs',
-          routeBasePath: '/',
+          routeBasePath: '/docs',
           sidebarPath: './sidebars.ts',
           editUrl: 'https://github.com/michelangelo-ai/michelangelo/tree/main/website/',
         },
@@ -82,7 +82,7 @@ const config: Config = {
           items: [
             {
               label: 'Getting Started',
-              to: '/',
+              to: '/docs',
             },
           ],
         },

--- a/website/src/components/Landing/AnimatedText.tsx
+++ b/website/src/components/Landing/AnimatedText.tsx
@@ -1,0 +1,57 @@
+import React, {useState, useEffect} from 'react';
+import styles from '../../css/landing.module.css';
+
+const phrases = [
+  'Feature Management',
+  'Model Training',
+  'Model Deployment',
+  'Production Monitoring',
+];
+
+export default function AnimatedText(): React.ReactElement {
+  const [currentPhraseIndex, setCurrentPhraseIndex] = useState(0);
+  const [displayedText, setDisplayedText] = useState('');
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  useEffect(() => {
+    // Check for reduced motion preference
+    const prefersReducedMotion = window.matchMedia(
+      '(prefers-reduced-motion: reduce)',
+    ).matches;
+
+    if (prefersReducedMotion) {
+      setDisplayedText(phrases[0]);
+      return;
+    }
+
+    const currentPhrase = phrases[currentPhraseIndex];
+    const typeSpeed = isDeleting ? 30 : 80;
+
+    const timer = setTimeout(() => {
+      if (!isDeleting) {
+        if (displayedText.length < currentPhrase.length) {
+          setDisplayedText(currentPhrase.slice(0, displayedText.length + 1));
+        } else {
+          // Pause before deleting
+          setTimeout(() => setIsDeleting(true), 2000);
+        }
+      } else {
+        if (displayedText.length > 0) {
+          setDisplayedText(displayedText.slice(0, -1));
+        } else {
+          setIsDeleting(false);
+          setCurrentPhraseIndex((prev) => (prev + 1) % phrases.length);
+        }
+      }
+    }, typeSpeed);
+
+    return () => clearTimeout(timer);
+  }, [displayedText, isDeleting, currentPhraseIndex]);
+
+  return (
+    <span className={styles.animatedText}>
+      {displayedText}
+      <span className={styles.cursor}>|</span>
+    </span>
+  );
+}

--- a/website/src/components/Landing/CodeExample.tsx
+++ b/website/src/components/Landing/CodeExample.tsx
@@ -1,0 +1,137 @@
+import React, {useState} from 'react';
+import {Highlight, themes} from 'prism-react-renderer';
+import styles from '../../css/landing.module.css';
+
+type TabKey = 'python' | 'cli' | 'yaml';
+
+interface Tab {
+  key: TabKey;
+  label: string;
+  language: string;
+  code: string;
+}
+
+const tabs: Tab[] = [
+  {
+    key: 'python',
+    label: 'Python',
+    language: 'python',
+    code: `from michelangelo import Model, FeatureStore
+
+# Connect to the feature store
+fs = FeatureStore("production")
+
+# Define and train a model
+model = Model(
+    name="fraud-detection",
+    features=fs.get_features(["user_history", "transaction"]),
+)
+model.train(data=training_data, epochs=100)
+
+# Deploy to production with one line
+model.deploy(environment="production", canary_percent=10)
+
+# Monitor in real-time
+model.monitor(alert_on_drift=True)`,
+  },
+  {
+    key: 'cli',
+    label: 'CLI',
+    language: 'bash',
+    code: `# Initialize a new ML project
+$ michelangelo init my-fraud-model
+
+# Train with distributed computing
+$ michelangelo train --config train.yaml --distributed
+
+# Evaluate model performance
+$ michelangelo evaluate --model fraud-detection --dataset test
+
+# Deploy with canary release
+$ michelangelo deploy fraud-detection:v2 \\
+    --environment production \\
+    --canary 10%
+
+# Monitor model health
+$ michelangelo monitor fraud-detection --watch`,
+  },
+  {
+    key: 'yaml',
+    label: 'YAML',
+    language: 'yaml',
+    code: `# michelangelo.yaml
+name: fraud-detection
+version: 2.0.0
+
+features:
+  source: feature-store/production
+  entities:
+    - user_history
+    - transaction_patterns
+    - device_fingerprint
+
+training:
+  framework: pytorch
+  distributed: true
+  resources:
+    gpu: 4
+    memory: 32Gi
+
+deployment:
+  environment: production
+  strategy: canary
+  canary_percent: 10
+  auto_rollback: true`,
+  },
+];
+
+export default function CodeExample(): React.ReactElement {
+  const [activeTab, setActiveTab] = useState<TabKey>('python');
+  const currentTab = tabs.find((t) => t.key === activeTab) ?? tabs[0];
+
+  return (
+    <section className={styles.codeExample}>
+      <div className={styles.codeExampleContainer}>
+        <h2 className={styles.codeExampleTitle}>Simple, powerful API</h2>
+        <p className={styles.codeExampleSubtitle}>
+          From training to production in minutes, not months
+        </p>
+
+        <div className={styles.codeBlock}>
+          <div className={styles.codeTabs}>
+            {tabs.map((tab) => (
+              <button
+                key={tab.key}
+                className={`${styles.codeTab} ${activeTab === tab.key ? styles.codeTabActive : ''}`}
+                onClick={() => setActiveTab(tab.key)}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+
+          <div className={styles.codeContent}>
+            <Highlight
+              theme={themes.dracula}
+              code={currentTab.code}
+              language={currentTab.language}
+            >
+              {({className, style, tokens, getLineProps, getTokenProps}) => (
+                <pre className={className} style={{...style, margin: 0}}>
+                  {tokens.map((line, i) => (
+                    <div key={i} {...getLineProps({line})}>
+                      <span className={styles.lineNumber}>{i + 1}</span>
+                      {line.map((token, key) => (
+                        <span key={key} {...getTokenProps({token})} />
+                      ))}
+                    </div>
+                  ))}
+                </pre>
+              )}
+            </Highlight>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/website/src/components/Landing/Features.tsx
+++ b/website/src/components/Landing/Features.tsx
@@ -1,0 +1,202 @@
+import React, {useEffect, useRef, useState} from 'react';
+import styles from '../../css/landing.module.css';
+
+interface Feature {
+  title: string;
+  description: string;
+  icon: React.ReactNode;
+}
+
+const features: Feature[] = [
+  {
+    title: 'Feature Management',
+    description:
+      'Centralized feature store with versioning, lineage tracking, and real-time serving for consistent ML features across training and inference.',
+    icon: <DatabaseIcon />,
+  },
+  {
+    title: 'Model Training',
+    description:
+      'Scalable distributed training with experiment tracking, hyperparameter tuning, and automatic resource management.',
+    icon: <BrainIcon />,
+  },
+  {
+    title: 'Evaluation',
+    description:
+      'Comprehensive model evaluation with automated metrics, A/B testing, and performance benchmarking across datasets.',
+    icon: <ChartIcon />,
+  },
+  {
+    title: 'Deployment',
+    description:
+      'One-click deployment to production with canary releases, traffic splitting, and automatic rollback capabilities.',
+    icon: <RocketIcon />,
+  },
+  {
+    title: 'Monitoring',
+    description:
+      'Real-time model monitoring with drift detection, alerting, and observability for production ML systems.',
+    icon: <EyeIcon />,
+  },
+];
+
+export default function Features(): React.ReactElement {
+  return (
+    <section className={styles.features}>
+      <div className={styles.featuresContainer}>
+        <h2 className={styles.featuresTitle}>
+          Everything you need for ML in production
+        </h2>
+        <div className={styles.featuresGrid}>
+          {features.map((feature, index) => (
+            <FeatureCard key={feature.title} feature={feature} index={index} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function FeatureCard({
+  feature,
+  index,
+}: {
+  feature: Feature;
+  index: number;
+}): React.ReactElement {
+  const ref = useRef<HTMLDivElement>(null);
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const prefersReducedMotion = window.matchMedia(
+      '(prefers-reduced-motion: reduce)',
+    ).matches;
+
+    if (prefersReducedMotion) {
+      setIsVisible(true);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+          observer.disconnect();
+        }
+      },
+      {threshold: 0.1},
+    );
+
+    if (ref.current) {
+      observer.observe(ref.current);
+    }
+
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div
+      ref={ref}
+      className={`${styles.featureCard} ${isVisible ? styles.featureCardVisible : ''}`}
+      style={{transitionDelay: `${index * 100}ms`}}
+    >
+      <div className={styles.featureIcon}>{feature.icon}</div>
+      <h3 className={styles.featureTitle}>{feature.title}</h3>
+      <p className={styles.featureDescription}>{feature.description}</p>
+    </div>
+  );
+}
+
+function DatabaseIcon(): React.ReactElement {
+  return (
+    <svg
+      width="32"
+      height="32"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <ellipse cx="12" cy="5" rx="9" ry="3" />
+      <path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3" />
+      <path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5" />
+    </svg>
+  );
+}
+
+function BrainIcon(): React.ReactElement {
+  return (
+    <svg
+      width="32"
+      height="32"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M9.5 2A2.5 2.5 0 0 1 12 4.5v15a2.5 2.5 0 0 1-4.96.44 2.5 2.5 0 0 1-2.96-3.08 3 3 0 0 1-.34-5.58 2.5 2.5 0 0 1 1.32-4.24 2.5 2.5 0 0 1 1.98-3A2.5 2.5 0 0 1 9.5 2Z" />
+      <path d="M14.5 2A2.5 2.5 0 0 0 12 4.5v15a2.5 2.5 0 0 0 4.96.44 2.5 2.5 0 0 0 2.96-3.08 3 3 0 0 0 .34-5.58 2.5 2.5 0 0 0-1.32-4.24 2.5 2.5 0 0 0-1.98-3A2.5 2.5 0 0 0 14.5 2Z" />
+    </svg>
+  );
+}
+
+function ChartIcon(): React.ReactElement {
+  return (
+    <svg
+      width="32"
+      height="32"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <line x1="18" y1="20" x2="18" y2="10" />
+      <line x1="12" y1="20" x2="12" y2="4" />
+      <line x1="6" y1="20" x2="6" y2="14" />
+    </svg>
+  );
+}
+
+function RocketIcon(): React.ReactElement {
+  return (
+    <svg
+      width="32"
+      height="32"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z" />
+      <path d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z" />
+      <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0" />
+      <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5" />
+    </svg>
+  );
+}
+
+function EyeIcon(): React.ReactElement {
+  return (
+    <svg
+      width="32"
+      height="32"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z" />
+      <circle cx="12" cy="12" r="3" />
+    </svg>
+  );
+}

--- a/website/src/components/Landing/GradientBackground.tsx
+++ b/website/src/components/Landing/GradientBackground.tsx
@@ -1,0 +1,45 @@
+import React, {useEffect, useState} from 'react';
+import styles from '../../css/landing.module.css';
+
+export default function GradientBackground(): React.ReactElement {
+  const [mousePosition, setMousePosition] = useState({x: 0, y: 0});
+
+  useEffect(() => {
+    const prefersReducedMotion = window.matchMedia(
+      '(prefers-reduced-motion: reduce)',
+    ).matches;
+
+    if (prefersReducedMotion) {
+      return;
+    }
+
+    const handleMouseMove = (e: MouseEvent) => {
+      // Normalize to -1 to 1 range centered on viewport
+      const x = (e.clientX / window.innerWidth - 0.5) * 2;
+      const y = (e.clientY / window.innerHeight - 0.5) * 2;
+      setMousePosition({x, y});
+    };
+
+    window.addEventListener('mousemove', handleMouseMove);
+    return () => window.removeEventListener('mousemove', handleMouseMove);
+  }, []);
+
+  // Each blob moves at different speeds for parallax effect
+  const blob1Style = {
+    transform: `translate(${mousePosition.x * 100}px, ${mousePosition.y * 80}px)`,
+  };
+  const blob2Style = {
+    transform: `translate(${mousePosition.x * -80}px, ${mousePosition.y * 100}px)`,
+  };
+  const blob3Style = {
+    transform: `translate(${mousePosition.x * 60}px, ${mousePosition.y * -70}px)`,
+  };
+
+  return (
+    <div className={styles.gradientBackground} aria-hidden="true">
+      <div className={styles.gradientBlob1} style={blob1Style} />
+      <div className={styles.gradientBlob2} style={blob2Style} />
+      <div className={styles.gradientBlob3} style={blob3Style} />
+    </div>
+  );
+}

--- a/website/src/components/Landing/Hero.tsx
+++ b/website/src/components/Landing/Hero.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import Link from '@docusaurus/Link';
+import AnimatedText from './AnimatedText';
+import styles from '../../css/landing.module.css';
+
+export default function Hero(): React.ReactElement {
+  return (
+    <section className={styles.hero}>
+      <div className={styles.heroContent}>
+        <h1 className={styles.heroTitle}>
+          ML at Scale.
+          <br />
+          <span className={styles.heroTitleAccent}>Open Source.</span>
+        </h1>
+        <p className={styles.heroSubtitle}>
+          The end-to-end platform for building, deploying, and monitoring ML
+          models
+        </p>
+        <div className={styles.heroTagline}>
+          <span className={styles.heroTaglinePrefix}>Built for</span>{' '}
+          <AnimatedText />
+        </div>
+        <div className={styles.heroCtas}>
+          <Link className={styles.ctaPrimary} to="/docs">
+            Get Started
+          </Link>
+          <Link
+            className={styles.ctaSecondary}
+            href="https://github.com/michelangelo-ai/michelangelo"
+          >
+            <GitHubIcon />
+            View on GitHub
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function GitHubIcon(): React.ReactElement {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+    </svg>
+  );
+}

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -48,6 +48,15 @@
   --custom-content-background: #ffffff;
   --custom-border-color: #e8e8e8;
   --uber-light-gray: #f3f3f3;
+
+  /* Landing page variables - Light mode */
+  --landing-bg: #fafafa;
+  --landing-gradient-1: rgba(37, 99, 235, 0.5);
+  --landing-gradient-2: rgba(124, 58, 237, 0.5);
+  --landing-gradient-3: rgba(219, 39, 119, 0.4);
+  --landing-accent: #276ef1;
+  --landing-gradient-text-1: #276ef1;
+  --landing-gradient-text-2: #7c3aed;
 }
 
 [data-theme='dark'] {
@@ -71,6 +80,15 @@
   /* Custom colors */
   --custom-content-background: #000000;
   --custom-border-color: #333333;
+
+  /* Landing page variables - Dark mode */
+  --landing-bg: #000000;
+  --landing-gradient-1: rgba(74, 135, 243, 0.4);
+  --landing-gradient-2: rgba(124, 58, 237, 0.4);
+  --landing-gradient-3: rgba(236, 72, 153, 0.3);
+  --landing-accent: #4a87f3;
+  --landing-gradient-text-1: #4a87f3;
+  --landing-gradient-text-2: #a78bfa;
 }
 
 /* ============================================
@@ -78,13 +96,12 @@
    ============================================ */
 
 .navbar {
-  backdrop-filter: saturate(180%) blur(10px);
-  background: rgba(255, 255, 255, 0.8);
+  background: rgba(255, 255, 255, 0.95);
   box-shadow: var(--custom-shadow-sm);
 }
 
 [data-theme='dark'] .navbar {
-  background: rgba(0, 0, 0, 0.85);
+  background: rgba(0, 0, 0, 0.95);
 }
 
 .navbar__title {

--- a/website/src/css/landing.module.css
+++ b/website/src/css/landing.module.css
@@ -1,0 +1,401 @@
+/* Landing Page Styles */
+
+.landing {
+  position: relative;
+  overflow-x: hidden;
+}
+
+/* Gradient Background */
+.gradientBackground {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: -1;
+  overflow: hidden;
+  background: var(--landing-bg);
+}
+
+.gradientBlob1,
+.gradientBlob2,
+.gradientBlob3 {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(80px);
+  opacity: 0.5;
+  transition: transform 0.3s ease-out;
+}
+
+.gradientBlob1 {
+  width: 600px;
+  height: 600px;
+  background: var(--landing-gradient-1);
+  top: -200px;
+  left: -100px;
+}
+
+.gradientBlob2 {
+  width: 500px;
+  height: 500px;
+  background: var(--landing-gradient-2);
+  top: 200px;
+  right: -150px;
+}
+
+.gradientBlob3 {
+  width: 400px;
+  height: 400px;
+  background: var(--landing-gradient-3);
+  bottom: -100px;
+  left: 30%;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .gradientBlob1,
+  .gradientBlob2,
+  .gradientBlob3 {
+    transition: none;
+  }
+}
+
+/* Hero Section */
+.hero {
+  min-height: calc(100vh - 60px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4rem 2rem;
+}
+
+.heroContent {
+  max-width: 900px;
+  text-align: center;
+}
+
+.heroTitle {
+  font-size: clamp(2.5rem, 8vw, 5rem);
+  font-weight: 800;
+  line-height: 1.1;
+  margin-bottom: 1.5rem;
+  color: var(--ifm-font-color-base);
+}
+
+.heroTitleAccent {
+  background: linear-gradient(
+    135deg,
+    var(--landing-gradient-text-1),
+    var(--landing-gradient-text-2)
+  );
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.heroSubtitle {
+  font-size: clamp(1.1rem, 3vw, 1.5rem);
+  color: var(--ifm-font-color-secondary);
+  margin-bottom: 2rem;
+  line-height: 1.5;
+}
+
+.heroTagline {
+  font-size: clamp(1rem, 2.5vw, 1.25rem);
+  color: var(--ifm-font-color-secondary);
+  margin-bottom: 3rem;
+  min-height: 2em;
+}
+
+.heroTaglinePrefix {
+  opacity: 0.7;
+}
+
+.animatedText {
+  color: var(--landing-accent);
+  font-weight: 600;
+}
+
+.cursor {
+  color: var(--landing-accent);
+  animation: blink 1s step-end infinite;
+}
+
+@keyframes blink {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cursor {
+    animation: none;
+  }
+}
+
+.heroCtas {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.ctaPrimary {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.875rem 2rem;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #ffffff;
+  background: linear-gradient(
+    135deg,
+    var(--landing-gradient-text-1),
+    var(--landing-gradient-text-2)
+  );
+  border-radius: 8px;
+  text-decoration: none;
+  transition:
+    transform 0.2s,
+    box-shadow 0.2s;
+}
+
+.ctaPrimary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 25px rgba(39, 110, 241, 0.3);
+  color: #ffffff;
+  text-decoration: none;
+}
+
+.ctaSecondary {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.875rem 2rem;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--ifm-font-color-base);
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 8px;
+  text-decoration: none;
+  transition:
+    transform 0.2s,
+    background 0.2s;
+}
+
+.ctaSecondary:hover {
+  transform: translateY(-2px);
+  background: rgba(255, 255, 255, 0.15);
+  color: var(--ifm-font-color-base);
+  text-decoration: none;
+}
+
+/* Features Section */
+.features {
+  padding: 6rem 2rem;
+  background: var(--ifm-background-surface-color);
+}
+
+.featuresContainer {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.featuresTitle {
+  font-size: clamp(1.75rem, 5vw, 2.5rem);
+  font-weight: 700;
+  text-align: center;
+  margin-bottom: 4rem;
+  color: var(--ifm-font-color-base);
+}
+
+.featuresGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+}
+
+.featureCard {
+  padding: 2rem;
+  background: var(--ifm-background-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 12px;
+  opacity: 0;
+  transform: translateY(30px);
+  transition:
+    opacity 0.6s ease-out,
+    transform 0.6s ease-out,
+    box-shadow 0.3s ease;
+}
+
+.featureCardVisible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.featureCard:hover {
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.15);
+  border-color: var(--landing-accent);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .featureCard {
+    opacity: 1;
+    transform: none;
+    transition: box-shadow 0.3s ease;
+  }
+}
+
+.featureIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  margin-bottom: 1.25rem;
+  background: linear-gradient(
+    135deg,
+    var(--landing-gradient-text-1),
+    var(--landing-gradient-text-2)
+  );
+  border-radius: 12px;
+  color: #ffffff;
+}
+
+.featureTitle {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+  color: var(--ifm-font-color-base);
+}
+
+.featureDescription {
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: var(--ifm-font-color-secondary);
+  margin: 0;
+}
+
+/* Code Example Section */
+.codeExample {
+  padding: 6rem 2rem;
+}
+
+.codeExampleContainer {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.codeExampleTitle {
+  font-size: clamp(1.75rem, 5vw, 2.5rem);
+  font-weight: 700;
+  text-align: center;
+  margin-bottom: 0.75rem;
+  color: var(--ifm-font-color-base);
+}
+
+.codeExampleSubtitle {
+  font-size: 1.1rem;
+  text-align: center;
+  color: var(--ifm-font-color-secondary);
+  margin-bottom: 3rem;
+}
+
+.codeBlock {
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+}
+
+.codeTabs {
+  display: flex;
+  background: #1e1e2e;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.codeTab {
+  padding: 0.75rem 1.5rem;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.6);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  transition:
+    color 0.2s,
+    background 0.2s;
+}
+
+.codeTab:hover {
+  color: rgba(255, 255, 255, 0.9);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.codeTabActive {
+  color: var(--landing-accent);
+  background: rgba(39, 110, 241, 0.1);
+  border-bottom: 2px solid var(--landing-accent);
+}
+
+.codeContent {
+  background: #282a36;
+  padding: 1.5rem;
+  overflow-x: auto;
+}
+
+.codeContent pre {
+  font-family: 'JetBrains Mono', 'Fira Code', 'Consolas', monospace;
+  font-size: 0.9rem;
+  line-height: 1.7;
+  background: transparent !important;
+}
+
+.lineNumber {
+  display: inline-block;
+  width: 2.5em;
+  margin-right: 1em;
+  color: rgba(255, 255, 255, 0.3);
+  text-align: right;
+  user-select: none;
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .hero {
+    padding: 3rem 1.5rem;
+    min-height: auto;
+  }
+
+  .heroCtas {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .ctaPrimary,
+  .ctaSecondary {
+    width: 100%;
+    max-width: 280px;
+    justify-content: center;
+  }
+
+  .features,
+  .codeExample {
+    padding: 4rem 1.5rem;
+  }
+
+  .featuresGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .codeContent pre {
+    font-size: 0.8rem;
+  }
+
+  .lineNumber {
+    width: 2em;
+  }
+}

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import Layout from '@theme/Layout';
+import GradientBackground from '../components/Landing/GradientBackground';
+import Hero from '../components/Landing/Hero';
+import Features from '../components/Landing/Features';
+import CodeExample from '../components/Landing/CodeExample';
+import styles from '../css/landing.module.css';
+
+export default function Home(): React.ReactElement {
+  return (
+    <Layout
+      title="ML at Scale. Open Source."
+      description="The end-to-end platform for building, deploying, and monitoring ML models"
+    >
+      <main className={styles.landing}>
+        <GradientBackground />
+        <Hero />
+        <Features />
+        <CodeExample />
+      </main>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary

Create a visually stunning landing page for Michelangelo at the root URL:

- **Animated gradient background** with floating blobs that follow cursor movement (parallax effect)
- **Hero section** with typewriter effect cycling through ML capabilities (Feature Management, Model Training, Model Deployment, Production Monitoring)
- **Feature cards** (5) with scroll-triggered fade-in animations using Intersection Observer
- **Tabbed code examples** (Python/CLI/YAML) with syntax highlighting via prism-react-renderer
- Dark/light mode support with Uber blue color scheme
- Move documentation route from `/` to `/docs`
- Respects `prefers-reduced-motion` for accessibility

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

- Added `website/src/pages/index.tsx` - Landing page route
- Added `website/src/components/Landing/` - Hero, Features, CodeExample, GradientBackground, AnimatedText components
- Added `website/src/css/landing.module.css` - Landing page styles with animations
- Updated `website/src/css/custom.css` - Added landing page CSS variables for theming
- Updated `website/docusaurus.config.ts` - Changed docs `routeBasePath` from `/` to `/docs`

**Why?**

The documentation site needed a proper landing page to introduce Michelangelo to new users. A landing page with clear value proposition, feature highlights, and code examples helps users understand what the platform offers before diving into documentation.

**How did you test it?**

- Tested locally with `bun run start`
- Verified landing page renders at `http://localhost:3003`
- Verified docs still accessible at `http://localhost:3003/docs`
- Tested dark/light mode toggle
- Tested scroll animations and cursor-following gradient
- Tested responsive layout on mobile viewport

**Potential risks**

- Low risk: This is additive - only adds new landing page components
- Documentation URLs change from `/` to `/docs` (existing links to `/` will now show landing page instead of docs index)

**Release notes**

New landing page added to documentation site. Documentation now accessible at `/docs` instead of `/`.

**Documentation Changes**

- Documentation route changed from `/` to `/docs`
- No API changes
- Wiki update not required (this is the docs site itself)
