### PR TITLE
Fix duplicate BaseProvider causing z-index issues with Layers

### DIFF
--- a/javascript/packages/core/themes/provider.tsx
+++ b/javascript/packages/core/themes/provider.tsx
@@ -1,4 +1,7 @@
+import { useContext } from 'react';
 import { BaseProvider, createTheme } from 'baseui';
+import { LayersContext } from 'baseui/layer';
+import { ThemeProvider as BaseUIThemeProvider } from 'baseui/styles';
 
 import { capitalizeFirstLetter } from '#core/utils/string-utils';
 import { GRID_OVERRIDES } from './shared';
@@ -15,6 +18,9 @@ export function ThemeProvider({
   icons?: IconMap;
   theme?: Theme;
 }) {
+  const { host } = useContext(LayersContext);
+  const hasParentProvider = host !== undefined;
+
   // TODO: rename Icons to be PascalCase #364
   const iconEntries = icons
     ? Object.fromEntries(
@@ -22,9 +28,11 @@ export function ThemeProvider({
       )
     : {};
 
-  return (
-    <BaseProvider theme={theme ?? createTheme({ ...GRID_OVERRIDES, icons: iconEntries })}>
-      {children}
-    </BaseProvider>
-  );
+  const resolvedTheme = theme ?? createTheme({ ...GRID_OVERRIDES, icons: iconEntries });
+
+  if (hasParentProvider) {
+    return <BaseUIThemeProvider theme={resolvedTheme}>{children}</BaseUIThemeProvider>;
+  }
+
+  return <BaseProvider theme={resolvedTheme}>{children}</BaseProvider>;
 }


### PR DESCRIPTION
When ThemeProvider is nested inside an existing BaseProvider, avoid rendering a second BaseProvider which resets the Layers stacking context. Detect the parent provider via LayersContext and fall back to BaseUIThemeProvider for theme-only propagation.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Bug Fix

<!-- Describe what has changed in this PR -->
**What changed?**

`ThemeProvider` now checks for an existing `BaseProvider` ancestor by reading `LayersContext`. When a parent provider is detected, it renders `BaseUIThemeProvider` (theme-only) instead of a second `BaseProvider`.

<!-- Tell your future self why have you made these changes -->
**Why?**

Nesting multiple `BaseProvider` instances resets the BaseUI `Layers` stacking context, which causes z-index issues for components that rely on Layers (e.g. modals, popovers, tooltips). The inner provider creates a new layer host, breaking the z-index ordering established by the outer provider.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

- Verified locally that nested `ThemeProvider` no longer creates a duplicate `BaseProvider`
- Confirmed Layers-dependent components (modals, popovers) render with correct z-index stacking

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

- Components relying on a fresh `BaseProvider` context from a nested `ThemeProvider` would now inherit the parent's layer host instead. This is the intended behavior but could surface if any code was depending on the reset.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

N/A

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**

N/A
