### PR TITLE
Retry functionality now works correctly without serialization errors

### DIFF
--- a/javascript/packages/core/components/cell/renderers/retry/retry-cell.tsx
+++ b/javascript/packages/core/components/cell/renderers/retry/retry-cell.tsx
@@ -3,6 +3,8 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useStyletron } from 'baseui';
 import { Button, KIND, SIZE } from 'baseui/button';
 import { Textarea } from 'baseui/textarea';
+import { create } from '@bufbuild/protobuf';
+import { RetryInfoSchema } from '@michelangelo/rpc';
 
 import { Dialog } from '#core/components/dialog/dialog';
 import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
@@ -64,13 +66,13 @@ export const RetryCell = (props: CellRendererProps<string>) => {
       ...pipelineRun,
       spec: {
         ...pipelineRun.spec,
-        retryInfo: {
+        retryInfo: create(RetryInfoSchema, {
           activityId: value,
           workflowId,
           // Must match status.workflowRunId to trigger backend retry processing
           workflowRunId,
           reason: retryReason,
-        },
+        }),
       },
     };
 


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
Replace plain object creation with proper protobuf message instantiation
  in retry cell component to fix binary serialization errors.

  The retry functionality was failing because retryInfo was being created
  as a plain JavaScript object, but the ConnectRPC service with binary
  format requires actual protobuf message instances.

<!-- Tell your future self why have you made these changes -->
**Why?**
  - Add imports for create() and RetryInfoSchema
  - Replace object literal with create(RetryInfoSchema, {...})
  - Maintain existing camelCase field names (activityId, workflowId, etc.)


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local UI yarn dev

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
