### PR TITLE
Fix retry mutation binary serialization failure

### DIFF
--- a/javascript/packages/core/components/cell/renderers/retry/retry-cell.tsx
+++ b/javascript/packages/core/components/cell/renderers/retry/retry-cell.tsx
@@ -60,10 +60,13 @@ export const RetryCell = (props: CellRendererProps<string>) => {
       return;
     }
 
+    // Strip protobuf internals so toBinary() re-normalizes nested messages
+    const { $typeName: _, $unknown: __, ...specFields } = pipelineRun.spec;
+
     const updatedPipelineRun = {
-      ...pipelineRun,
+      metadata: pipelineRun.metadata,
       spec: {
-        ...pipelineRun.spec,
+        ...specFields,
         retryInfo: {
           activityId: value,
           workflowId,


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Strip protobuf internal properties (`$typeName`, `$unknown`) from `pipelineRun.spec` before spreading, and pass `metadata` directly instead of spreading the entire `pipelineRun`.

**Why?**

Spreading a protobuf Message leaks `$typeName` into the plain object, causing `create()` to skip recursive normalization of nested messages via the `isMessage()` short-circuit. `retryInfo` then lacks `$typeName` and `toBinary()` throws in `assertOwn()`.

Without `$typeName` on the spec object, `create()` recursively normalizes all nested messages including `retryInfo`, and serialization succeeds. This avoids the circular dependency (`core` → `rpc` → `core`) that PR #808 introduced by importing `RetryInfoSchema` directly.

**How did you test it?**

- All 8 existing retry-cell tests pass
- TypeScript type-check passes (`tsc --noEmit`)

**Potential risks**

None. The mutation payload is functionally equivalent — only protobuf internals and the read-only `status` field are removed.

**Release notes**

N/A

**Documentation Changes**

None required.

Supersedes #808