### PR TITLE
Add robots.txt for docs site SEO

### DIFF
--- a/website/static/robots.txt
+++ b/website/static/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://michelangelo-ai.github.io/sitemap.xml


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**

Added `website/static/robots.txt` that allows all crawlers and points them to the sitemap generated by Docusaurus's `@docusaurus/plugin-sitemap` (included via `preset-classic`).

**Why?**

Without a `robots.txt`, search engines have no explicit crawling guidance and no reference to the sitemap URL. This is a basic SEO requirement for any public-facing site.

**How did you test it?**

- Verified `@docusaurus/plugin-sitemap` is included via `preset-classic` and not disabled in config
- Confirmed the sitemap URL matches the configured `url` in `docusaurus.config.ts`

**Potential risks**

None. Additive static file only.

**Release notes**

N/A

**Documentation Changes**

None required.