### PR TITLE
Add conversion option to RayCluster and RayJob

### DIFF
--- a/proto/api/v2/ray_cluster.proto
+++ b/proto/api/v2/ray_cluster.proto
@@ -232,7 +232,10 @@ message RayClusterStatus {
 
 // RayCluster refers to a Ray cluster.
 message RayCluster {
-  option (michelangelo.api.resource) = {};
+  // Annotation for Michelangelo resource identification
+  option (michelangelo.api.resource) = {
+    conversion: true  // Enable conversion for multi-version support
+  };
 
   // Type metadata for the Ray cluster
   k8s.io.apimachinery.pkg.apis.meta.v1.TypeMeta type_meta = 1;

--- a/proto/api/v2/ray_job.proto
+++ b/proto/api/v2/ray_job.proto
@@ -126,7 +126,9 @@ message RayJobStatus {
 // Represents a Ray job and its specifications
 message RayJob {
   // Annotation for Michelangelo resource identification
-  option (michelangelo.api.resource) = {};
+  option (michelangelo.api.resource) = {
+    conversion: true  // Enable conversion for multi-version support
+  };
 
   // Kubernetes metadata for the Ray job
   k8s.io.apimachinery.pkg.apis.meta.v1.TypeMeta type_meta = 1;


### PR DESCRIPTION
  **What type of PR is this? (check all applicable)**                                   
  - [ ] Refactor                                                                        
  - [x] Feature                                                                         
  - [ ] Bug Fix                                                                         
  - [ ] Optimization                                                                    
  - [ ] Documentation Update                                                            
                                                                                        
  **What changed?**                                                                     
  Added `conversion: true` option to RayCluster and RayJob resource definitions in their
   protobuf files. This enables conversion webhook support for multi-version CRD        
  compatibility.                                                                        
                                                                                        
  **Why?**                                                                              
  To enable Kubernetes conversion webhooks for RayCluster and RayJob CRDs, allowing     
  automatic conversion between different API versions. This is essential for supporting 
  multiple API versions of these resources in the cluster.                              
                                                                                        
  **How did you test it?**                                                              
NA - just added an new conversion option
CI/CD testing is enough
                                                                                        
  **Potential risks**                                                                   
 NA
                        
                                                                                        
  **Release notes**                                                                     
  Schema update: Enabled conversion support for RayCluster and RayJob CRDs to support   
  multi-version API compatibility.                                                      
                                                                                        
  **Documentation Changes**                                                             
None                    