### PR TITLE
feat: Add optional TLS support for Temporal workflow client

### DIFF
--- a/go/base/config/config.go
+++ b/go/base/config/config.go
@@ -36,6 +36,7 @@ type WorkflowClientConfig struct {
 	Domain    string `yaml:"domain"`
 	TaskList  string `yaml:"taskList"`
 	Provider  string `yaml:"provider"`
+	UseTLS    bool   `yaml:"useTLS"`
 }
 
 // Params defines the dependencies of the config fx module.

--- a/go/base/workflowclient/temporalclient/module.go
+++ b/go/base/workflowclient/temporalclient/module.go
@@ -1,6 +1,8 @@
 package temporalclient
 
 import (
+	"crypto/tls"
+
 	"github.com/cadence-workflow/starlark-worker/temporal"
 	baseconfig "github.com/michelangelo-ai/michelangelo/go/base/config"
 	clientInterface "github.com/michelangelo-ai/michelangelo/go/base/workflowclient/interface"
@@ -21,11 +23,20 @@ var Module = fx.Options(
 // NewTemporalClient creates a new TemporalClient
 func NewTemporalClient(config baseconfig.WorkflowClientConfig) (TemporalClientOut, error) {
 	defaultTemporalClientFactory := workflowfx.DefaultTemporalClientFactory{}
-	client, err := defaultTemporalClientFactory.NewTemporalClient(temporalClient.Options{
+	opts := temporalClient.Options{
 		HostPort:      config.Host,
 		Namespace:     config.Domain,
 		DataConverter: temporal.DataConverter{}, // using temporal.DataConverter{} from the starlark-worker package since it supports starlark types
-	})
+	}
+
+	// Add TLS connection options if UseTLS is enabled
+	if config.UseTLS {
+		opts.ConnectionOptions = temporalClient.ConnectionOptions{
+			TLS: &tls.Config{},
+		}
+	}
+
+	client, err := defaultTemporalClientFactory.NewTemporalClient(opts)
 	if err != nil {
 		return TemporalClientOut{}, err
 	}

--- a/go/cmd/controllermgr/config/base.yaml
+++ b/go/cmd/controllermgr/config/base.yaml
@@ -11,6 +11,7 @@ workflowClient:
   domain: default
   # taskList is a used as a fallback if project.Metatdata.Annotations["michelangelo/worker_queue"] is empty
   taskList: default # TODO: MaCTL support for adding project.Metatdata.Annotations["michelangelo/worker_queue"] to project CRD
+  # useTLS: false  # Optional: Enable TLS for Temporal/Cadence connections (default: false)
     
 k8s:
   qps: 300


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

Add `UseTLS` configuration option to WorkflowClientConfig to enable TLS connections for Temporal workflow clients.
Changes:
- Add UseTLS field to WorkflowClientConfig struct
- Configure TLS in NewTemporalClient when useTLS is enabled
- Add configuration example in controllermgr base config

<!-- Tell your future self why have you made these changes -->
**Why?**

This change allows users to enable TLS when connecting to Temporal
servers that require secure connections, while maintaining backward
compatibility by defaulting to non-TLS connections.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Run the worker and controllermgr in local to validate the connection to temporal server.


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
