### PR TITLE
Add landing page navbar styling and theme toggle animation

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -334,3 +334,47 @@ tr:hover td {
 [data-theme='dark'] ::-webkit-scrollbar-thumb:hover {
   background-color: rgba(255, 255, 255, 0.3);
 }
+
+/* ============================================
+   Landing Page Navbar - Always Black
+   ============================================ */
+
+html[data-landing-page] .navbar {
+  background: rgba(0, 0, 0, 0.95) !important;
+}
+
+html[data-landing-page] .navbar__title,
+html[data-landing-page] .navbar__link {
+  color: #ffffff !important;
+}
+
+html[data-landing-page] .navbar__link:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+/* Theme toggle icon - white on landing page */
+html[data-landing-page] .navbar [class*='colorModeToggle'] button {
+  color: #ffffff !important;
+}
+
+html[data-landing-page] .navbar [class*='colorModeToggle'] svg {
+  color: #ffffff !important;
+}
+
+/* ============================================
+   View Transitions for Theme Toggle
+   ============================================ */
+
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation: none;
+  mix-blend-mode: normal;
+}
+
+::view-transition-old(root) {
+  z-index: 1;
+}
+
+::view-transition-new(root) {
+  z-index: 9999;
+}

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import Layout from '@theme/Layout';
 import GradientBackground from '../components/Landing/GradientBackground';
 import Hero from '../components/Landing/Hero';
@@ -7,6 +7,13 @@ import CodeExample from '../components/Landing/CodeExample';
 import styles from '../css/landing.module.css';
 
 export default function Home(): React.ReactElement {
+  useEffect(() => {
+    document.documentElement.setAttribute('data-landing-page', 'true');
+    return () => {
+      document.documentElement.removeAttribute('data-landing-page');
+    };
+  }, []);
+
   return (
     <Layout
       title="ML at Scale. Open Source."

--- a/website/src/theme/ColorModeToggle/index.tsx
+++ b/website/src/theme/ColorModeToggle/index.tsx
@@ -1,0 +1,76 @@
+import React, { type ReactNode } from 'react';
+import ColorModeToggle from '@theme-original/ColorModeToggle';
+import type ColorModeToggleType from '@theme/ColorModeToggle';
+import type { WrapperProps } from '@docusaurus/types';
+import type { ColorMode } from '@docusaurus/theme-common';
+import { flushSync } from 'react-dom';
+
+type Props = WrapperProps<typeof ColorModeToggleType>;
+
+// Mirror Docusaurus logic for 3-value cycle
+function getNextColorMode(
+  colorMode: ColorMode | null,
+  respectPrefersColorScheme: boolean
+): ColorMode | null {
+  if (!respectPrefersColorScheme) {
+    return colorMode === 'dark' ? 'light' : 'dark';
+  }
+  switch (colorMode) {
+    case null:
+      return 'light';
+    case 'light':
+      return 'dark';
+    case 'dark':
+      return null;
+    default:
+      return 'light';
+  }
+}
+
+export default function ColorModeToggleWrapper(props: Props): ReactNode {
+  const handleClick = async (e: React.MouseEvent) => {
+    const nextMode = getNextColorMode(props.value, props.respectPrefersColorScheme ?? false);
+
+    // Fallback for unsupported browsers or reduced motion
+    if (
+      !document.startViewTransition ||
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    ) {
+      props.onChange(nextMode);
+      return;
+    }
+
+    const x = e.clientX;
+    const y = e.clientY;
+    const maxRadius = Math.hypot(
+      Math.max(x, window.innerWidth - x),
+      Math.max(y, window.innerHeight - y)
+    );
+
+    const transition = document.startViewTransition(() => {
+      flushSync(() => props.onChange(nextMode));
+    });
+
+    await transition.ready;
+
+    document.documentElement.animate(
+      {
+        clipPath: [
+          `circle(0px at ${x}px ${y}px)`,
+          `circle(${maxRadius}px at ${x}px ${y}px)`,
+        ],
+      },
+      {
+        duration: 500,
+        easing: 'ease-out',
+        pseudoElement: '::view-transition-new(root)',
+      }
+    );
+  };
+
+  return (
+    <div onClick={handleClick}>
+      <ColorModeToggle {...props} onChange={() => {}} />
+    </div>
+  );
+}


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

- Keep landing page navbar always black regardless of theme mode
- Add circular view transition animation for theme toggle button
- Handle 3-value theme cycle (light → dark → system → light)

**Why?**

Improves visual polish of the documentation site with a smooth theme transition animation and consistent landing page styling.

**How did you test it?**

- [x] `cd website && bun start`
- [x] Click theme toggle - cycles: light → dark → system → light
- [x] Circular animation expands from click position
- [x] Landing page navbar stays black in all theme modes
- [x] Safari/Firefox graceful fallback (no animation, theme still changes)
- [x] Reduced-motion preference skips animation

https://github.com/user-attachments/assets/dfcbec24-af56-4377-81fe-a80fb275569d

**Potential risks**

Minimal - CSS-only changes with graceful fallback for browsers that don't support View Transitions API.

**Release notes**

N/A

**Documentation Changes**

None