### PR TITLE
Add CLAUDE.md to website directory

### DIFF
--- a/website/CLAUDE.md
+++ b/website/CLAUDE.md
@@ -1,0 +1,19 @@
+# CLAUDE.md - Website Guidelines
+
+## Package Manager
+
+**Use `bun`, not npm or yarn.**
+
+| Task | Command |
+|------|---------|
+| Install | `bun install` |
+| Dev server | `bun run start` |
+| Build | `bun run build` |
+| Type check | `bun run typecheck` |
+| Clear cache | `bun run clear` |
+
+## Docusaurus Structure
+
+- Documentation source: `docs/` at repo root (not inside `website/`)
+- Theme customizations: `src/theme/` (swizzled components)
+- Static assets: `static/img/`


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**

Added `website/CLAUDE.md` to provide Claude Code with website-specific guidelines:
- Enforce `bun` as the package manager (not npm/yarn)
- Document common commands (install, dev, build, typecheck, clear)
- Document Docusaurus project structure

**Why?**

Claude Code was suggesting `npm` commands instead of `bun` for the website. This file ensures consistent tooling recommendations.

**How did you test it?**

Verified the file is correctly formatted and commands match existing `package.json` scripts.

**Potential risks**

None - this is a documentation-only change with no runtime impact.

**Release notes**

N/A

**Documentation Changes**

Adds internal Claude Code guidelines only; no user-facing documentation changes.