### PR TITLE
Remove decorative emojis from documentation

### DIFF
--- a/docs/about/core-concepts-and-key-terms.md
+++ b/docs/about/core-concepts-and-key-terms.md
@@ -125,9 +125,10 @@ A Model Family is a group of related ML models within a project that address dif
 
 **Familiar Equivalent**: Similar to organizing multiple models within one Kubeflow or SageMaker pipeline, where each model has a specific role in solving the overall problem.
 
-⚠️ **Common Confusion**:
+:::warning[Common Confusion]
 - A **Model** is a single trained artifact (e.g., one XGBoost classifier)
 - A **Model Family** is a group of models solving related sub-problems (e.g., three models for conversion, quality, and fairness in ranking)
+:::
 
 **Examples**:
 -   Model excellence scores track the quality of each model family

--- a/docs/about/overview.md
+++ b/docs/about/overview.md
@@ -60,7 +60,7 @@ _* Can be replaced by the plugin system for custom integrations_
 
 Pick the approach that matches your workflow and expertise:
 
-#### 🎨 UI Path - Start Here If You:
+#### UI Path - Start Here If You:
 - Want to **quickly experiment** with standard ML models (XGBoost, Classic ML, Deep Learning)
 - Prefer **visual workflows** over writing code
 - Are a **business analyst or product manager** building predictive models
@@ -75,7 +75,7 @@ Pick the approach that matches your workflow and expertise:
 
 **Best for**: Classification, regression, time series forecasting with standard features
 
-#### 💻 Code Path - Choose This If You:
+#### Code Path - Choose This If You:
 - Need **custom ML pipelines** with specialized preprocessing
 - Want **full control** over training loops, model architectures, or data transformations
 - Are building **production-grade workflows** that need to run on schedules
@@ -90,7 +90,7 @@ Pick the approach that matches your workflow and expertise:
 
 **Best for**: Custom architectures, multi-stage pipelines, A/B testing frameworks, feature engineering at scale
 
-#### 🔄 Hybrid Approach
+#### Hybrid Approach
 Many teams start with the **UI for initial experiments**, then transition to **code for production workflows**. You can:
 - Train initial models in the UI to validate feasibility
 - Committed YAML configurations by UI and extend in Canvas/rebuild in Uniflow

--- a/docs/dev/ui/configuration/configuration-api.md
+++ b/docs/dev/ui/configuration/configuration-api.md
@@ -109,7 +109,7 @@ See `javascript/packages/core/config/entities/*/list.ts` and `*/detail.ts` for c
 
 ## When to Use Configuration vs Custom Components
 
-**✅ Use configuration when the standard patterns fit:**
+**Use configuration when the standard patterns fit:**
 
 - Entity list views (tables with columns, sorting, filtering)
 - Entity detail views (metadata headers, content sections)
@@ -117,14 +117,14 @@ See `javascript/packages/core/config/entities/*/list.ts` and `*/detail.ts` for c
 - Workflow phases grouping related entities
 - Standard display types (dates, states, text, links)
 
-**🔧 Write custom components when you need:**
+**Write custom components when you need:**
 
 - UI patterns not covered by existing configurations
 - Complex interactive visualizations or custom interactions
 - Business logic beyond what accessor functions can handle
 - Integration with external systems requiring custom logic
 
-**💡 Engineering best practice: Dual interfaces**
+**Engineering best practice: Dual interfaces**
 
 When building new UI components for Michelangelo, provide both interfaces:
 


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**

Removed decorative emojis from documentation headings and inline text:

- `docs/about/overview.md`: Removed 🎨, 💻, 🔄 emojis from "UI Path", "Code Path", and "Hybrid Approach" headings
- `docs/about/core-concepts-and-key-terms.md`: Converted ⚠️ emoji callout to proper Docusaurus `:::warning` admonition
- `docs/dev/ui/configuration/configuration-api.md`: Removed ✅, 🔧, 💡 emojis from section headings

Functional emojis (✅/❌ in feature comparison tables) were intentionally kept as they serve as yes/no indicators.

**Why?**

Fixes #823

- Emojis render inconsistently across platforms and browsers
- May not be screen-reader friendly
- Professional documentation typically avoids emoji usage

**How did you test it?**

- Ran `bun run build` in the website directory - build succeeded
- Verified changes render correctly (warning admonition displays properly)

<img width="807" height="355" alt="image" src="https://github.com/user-attachments/assets/223fb989-23b5-4a30-8a91-4a01f9a93ef5" />


**Potential risks**

None - documentation-only changes with no functional impact.

**Release notes**

N/A - documentation cleanup

**Documentation Changes**

This PR updates the documentation itself to improve accessibility and consistency.