### PR TITLE
docs: improve page titles for clarity and consistency

### DIFF
--- a/docs/contributing/how-to-write-apis.md
+++ b/docs/contributing/how-to-write-apis.md
@@ -1,4 +1,4 @@
-# Writing APIs
+# How to Write APIs
 This guide walks through the steps for building and compiling Protocol Buffers (Protos) of ML entities in the Michelangelo using Bazel and Gazelle.
 
 ## 1. ML Entities in Proto Files

--- a/docs/contributing/use-go-mocks-in-unit-test.md
+++ b/docs/contributing/use-go-mocks-in-unit-test.md
@@ -1,4 +1,4 @@
-# Mock interfaces
+# Using Go Mocks in Unit Tests
 
 1. Add following line into the .go file that the interface(s) are defined:
 

--- a/docs/setup-guide/setup-ide-and-bazel.md
+++ b/docs/setup-guide/setup-ide-and-bazel.md
@@ -1,4 +1,4 @@
-# Set up golang server for VS Code / Cursor
+# Set Up Go Server for VS Code / Cursor
 
 1. Make sure [golang](https://go.dev/doc/install) is installed and setup correctly. 
 2. Install [gopls](https://github.com/golang/tools/blob/master/gopls/doc/index.md).

--- a/docs/user-guides/ml-pipelines/cache-and-pipelinerun-resume-form.md
+++ b/docs/user-guides/ml-pipelines/cache-and-pipelinerun-resume-form.md
@@ -1,4 +1,4 @@
-# Uniflow Caching: Applied to both Remote Run and MA studio PipelineRun
+# Uniflow Caching and PipelineRun Resume
 
 For each task in a Uniflow Remote Run,  we have cached and indexed the task results after the task execution. Next time when you execute the task, you have the option to skip the task execution by reusing the cached results. 
 

--- a/docs/user-guides/project-management-for-ml-pipelines.md
+++ b/docs/user-guides/project-management-for-ml-pipelines.md
@@ -1,4 +1,4 @@
-# What’s a project?
+# What's a Project?
 
 In Michelangelo, a project represents a **business use case** that is continuously measured through a defined set of performance metrics. Examples include **dish recommendations in Uber Eats** or **restaurant ranking on the home feed.** This structure—framing each project as a business use case—has enabled Uber to **drive sustained model evolution within a specific domain over time,** ensuring that improvements are directly tied to measurable business outcomes.
 


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**
Improved 5 documentation page titles for clarity and consistent Title Case:

| File | Before | After |
|------|--------|-------|
| `setup-ide-and-bazel.md` | Set up golang server for VS Code / Cursor | Set Up Go Server for VS Code / Cursor |
| `project-management-for-ml-pipelines.md` | What's a project? | What's a Project? |
| `use-go-mocks-in-unit-test.md` | Mock interfaces | Using Go Mocks in Unit Tests |
| `how-to-write-apis.md` | Writing APIs | How to Write APIs |
| `cache-and-pipelinerun-resume-form.md` | Uniflow Caching: Applied to both Remote Run and MA studio PipelineRun | Uniflow Caching and PipelineRun Resume |

**Why?**
Part of the public-readiness documentation audit (#822). These titles were either:
- Using sentence case instead of Title Case
- Vague or not matching their content (e.g., "Mock interfaces" for a guide about Go mocks)
- Overly long and unwieldy

Fixes #827

**How did you test it?**
- Ran `bun run build` in website/ - build passes successfully
- Verified no new broken links introduced

**Potential risks**
None - text-only changes to page titles. No functional impact.

**Release notes**
N/A - documentation only

**Documentation Changes**
This PR is itself the documentation change - improving page titles for clarity.