### PR TITLE
docs(website): unify navbar styling and add GitHub icon

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -71,6 +71,8 @@ const config: Config = {
           href: 'https://github.com/michelangelo-ai/michelangelo',
           label: 'GitHub',
           position: 'right',
+          className: 'header-github-link',
+          'aria-label': 'GitHub repository',
         },
       ],
     },

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -97,16 +97,13 @@
    ============================================ */
 
 .navbar {
-  background: rgba(255, 255, 255, 0.95);
-  box-shadow: var(--custom-shadow-sm);
-}
-
-[data-theme='dark'] .navbar {
   background: rgba(0, 0, 0, 0.95);
+  box-shadow: var(--custom-shadow-sm);
 }
 
 .navbar__title {
   font-weight: 600;
+  color: #ffffff;
 }
 
 .navbar__link {
@@ -114,21 +111,15 @@
   border-radius: 9999px;
   padding: 0.5rem 1rem;
   transition: background-color 0.15s ease, color 0.15s ease;
+  color: #ffffff;
 }
 
 .navbar__link:hover {
-  background-color: rgba(0, 0, 0, 0.05);
+  background-color: rgba(255, 255, 255, 0.1);
+  color: #ffffff;
 }
 
 .navbar__link--active {
-  background-color: rgba(39, 110, 241, 0.1);
-}
-
-[data-theme='dark'] .navbar__link:hover {
-  background-color: rgba(255, 255, 255, 0.1);
-}
-
-[data-theme='dark'] .navbar__link--active {
   background-color: rgba(74, 135, 243, 0.2);
 }
 
@@ -336,29 +327,15 @@ tr:hover td {
 }
 
 /* ============================================
-   Landing Page Navbar - Always Black
+   Theme Toggle - Always White
    ============================================ */
 
-html[data-landing-page] .navbar {
-  background: rgba(0, 0, 0, 0.95) !important;
+.navbar [class*='colorModeToggle'] button {
+  color: #ffffff;
 }
 
-html[data-landing-page] .navbar__title,
-html[data-landing-page] .navbar__link {
-  color: #ffffff !important;
-}
-
-html[data-landing-page] .navbar__link:hover {
-  background-color: rgba(255, 255, 255, 0.1);
-}
-
-/* Theme toggle icon - white on landing page */
-html[data-landing-page] .navbar [class*='colorModeToggle'] button {
-  color: #ffffff !important;
-}
-
-html[data-landing-page] .navbar [class*='colorModeToggle'] svg {
-  color: #ffffff !important;
+.navbar [class*='colorModeToggle'] svg {
+  color: #ffffff;
 }
 
 /* ============================================
@@ -377,4 +354,26 @@ html[data-landing-page] .navbar [class*='colorModeToggle'] svg {
 
 ::view-transition-new(root) {
   z-index: 9999;
+}
+
+/* ============================================
+   GitHub Icon in Navbar
+   ============================================ */
+
+.header-github-link {
+  display: flex;
+  align-items: center;
+}
+
+.header-github-link::before {
+  content: '';
+  width: 24px;
+  height: 24px;
+  display: flex;
+  margin-right: 0.5rem;
+  background: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='%23fff' d='M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12'/%3E%3C/svg%3E") no-repeat;
+}
+
+.header-github-link:hover {
+  opacity: 0.6;
 }


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

- Navbar is now always black with white text (consistent branding across light/dark modes)
- Added GitHub icon (white) next to the "GitHub" link in navbar
- Theme toggle icon is now always white
- Removed redundant light/dark mode navbar conditionals

**Why?**

Part of public-readiness audit (#822). Aligns navbar styling with Michelangelo branding and adds the GitHub icon for better discoverability.

**How did you test it?**

- `bun run build` passes
- Visual verification in dev server

**Potential risks**

Low - CSS-only changes to navbar styling.

**Release notes**

N/A

**Documentation Changes**

N/A

Fixes #825
Fixes #828