### PR TITLE
ci: skip unrelated workflows for docs-only changes

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,6 +3,9 @@ name: Python Ruff Lint & Format
 on:
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - 'website/**'
 
 jobs:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,8 +4,14 @@ name: Bazel Test
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - 'website/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - 'website/**'
 
 jobs:
   bazel-build:


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

**What changed?**
- Added `paths-ignore` for `docs/**` and `website/**` to `main.yml` (Bazel Test) and `lint.yaml` (Python Ruff Lint & Format)

**Why?**
- Documentation-only PRs were triggering all CI workflows (Bazel tests, Python tests, dirty checks, Ruff lint) unnecessarily, wasting CI resources and time. Most other workflows already had proper path filters.

**How did you test it?**
- Verified the YAML syntax is correct
- Confirmed that other workflows (go-coverage, python-coverage, js-coverage, etc.) already use similar path filtering patterns

**Potential risks**
- Minimal. `paths-ignore` is the safer approach — any new code directories will still trigger these workflows by default. Only `docs/` and `website/` changes are excluded.

**Release notes**
- N/A (CI-only change, no user-facing impact)

**Documentation Changes**
- N/A