### PR TITLE
ci: add dependency caching and bump setup-bun to v2

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -26,9 +26,17 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+
+      - name: Cache bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('website/bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
 
       - name: Install dependencies
         run: bun install --frozen-lockfile


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

**What changed?**
- Bumped `oven-sh/setup-bun` from v1 to v2
- Added `actions/cache@v4` step to cache bun's global install cache, keyed on `website/bun.lock`

**Why?**
Keep CI dependencies on their current major versions and avoid redundant package downloads on cache hits.

**How did you test it?**
Reviewed recent workflow run timing — install step is ~2s today, caching ensures it stays fast as dependencies grow.

**Potential risks**
None. Cache misses fall back to a clean install, which is the current behavior.

**Release notes**
N/A

**Documentation Changes**
N/A