### PR TITLE
Add skipIncompatibleCheck config flag for dev environments

### DIFF
--- a/go/api/crd/sync.go
+++ b/go/api/crd/sync.go
@@ -23,9 +23,10 @@ const (
 
 // Configuration crd register configuration
 type Configuration struct {
-	EnableCRDUpdate   bool                     `yaml:"enableCRDUpdate"`
-	EnableCRDDeletion bool                     `yaml:"enableCRDDeletion"`
-	CRDVersions       map[string]VersionConfig `yaml:"crdVersions"`
+	EnableCRDUpdate       bool                     `yaml:"enableCRDUpdate"`
+	EnableCRDDeletion     bool                     `yaml:"enableCRDDeletion"`
+	SkipIncompatibleCheck bool                     `yaml:"skipIncompatibleCheck"`
+	CRDVersions           map[string]VersionConfig `yaml:"crdVersions"`
 }
 
 // VersionConfig defines how the versions of a CRD will be handled.
@@ -84,7 +85,8 @@ func SyncCRDs(group string, incompatibleUpdateAllowList []string, yamlSchemas ..
 			p.Lifecycle.Append(fx.Hook{
 				OnStart: func(ctx context.Context) error {
 					return syncCRDs(ctx, logger, group, p.Config.EnableCRDDeletion,
-						p.Gateway, p.Config.CRDVersions, p.WebhookConversion, incompatibleUpdateAllowList, yamlSchemas...)
+						p.Gateway, p.Config.CRDVersions, p.WebhookConversion,
+						p.Config.SkipIncompatibleCheck, incompatibleUpdateAllowList, yamlSchemas...)
 				},
 				OnStop: nil,
 			})
@@ -101,6 +103,7 @@ func syncCRDs(ctx context.Context,
 	gateway Gateway,
 	crdVersions map[string]VersionConfig,
 	webhookConversion *apiextv1.WebhookConversion,
+	skipIncompatibleCheck bool,
 	incompatibleUpdateAllowList []string,
 	yamlSchemas ...map[string]string) error {
 
@@ -163,7 +166,7 @@ func syncCRDs(ctx context.Context,
 	}
 
 	// upsert CRDs
-	if err = upsertCRDs(ctx, logger, gateway, mergedCRDList, incompatibleUpdateAllowList); err != nil {
+	if err = upsertCRDs(ctx, logger, gateway, mergedCRDList, skipIncompatibleCheck, incompatibleUpdateAllowList); err != nil {
 		logger.Error("Failed to upsert CRDs", zap.Error(err))
 		return err
 	}
@@ -172,11 +175,11 @@ func syncCRDs(ctx context.Context,
 
 // upsertCRDs upsert CRD onto k8s cluster, also handle OCC conflict with retry
 func upsertCRDs(ctx context.Context, logger *zap.Logger, gateway Gateway,
-	crds []*apiextv1.CustomResourceDefinition, allowList []string) error {
+	crds []*apiextv1.CustomResourceDefinition, skipIncompatibleCheck bool, allowList []string) error {
 	logger.Info("Compare CRD in cluster with new CRD definition, and conditionally update CRDs")
 	for _, crd := range crds {
-		// Per-CRD decision: only allowlist matters
-		enableIncompatibleUpdate := isInAllowList(crd.Name, allowList)
+		// Per-CRD decision: skip check entirely (e.g. dev env) or consult allowlist
+		enableIncompatibleUpdate := skipIncompatibleCheck || isInAllowList(crd.Name, allowList)
 
 		err := backoff.Retry(func() error {
 			err := gateway.ConditionalUpsert(ctx, crd, enableIncompatibleUpdate)

--- a/go/api/crd/sync_test.go
+++ b/go/api/crd/sync_test.go
@@ -33,7 +33,7 @@ func TestUpsertCRDs(t *testing.T) {
 		crd, err := readCRDFromFile(testCRDManifestDir + "/project.pb.yaml")
 		assert.NotNil(t, crd)
 		assert.NoError(t, err)
-		err = upsertCRDs(ctx, logger, crdGatewayMock, []*apiextv1.CustomResourceDefinition{crd}, []string{})
+		err = upsertCRDs(ctx, logger, crdGatewayMock, []*apiextv1.CustomResourceDefinition{crd}, false, []string{})
 		assert.NoError(t, err)
 	})
 
@@ -48,7 +48,7 @@ func TestUpsertCRDs(t *testing.T) {
 		crd, err := readCRDFromFile(testCRDManifestDir + "/project.pb.yaml")
 		assert.NotNil(t, crd)
 		assert.NoError(t, err)
-		err = upsertCRDs(ctx, logger, crdGatewayMock, []*apiextv1.CustomResourceDefinition{crd}, []string{})
+		err = upsertCRDs(ctx, logger, crdGatewayMock, []*apiextv1.CustomResourceDefinition{crd}, false, []string{})
 		assert.NoError(t, err)
 	})
 
@@ -61,7 +61,7 @@ func TestUpsertCRDs(t *testing.T) {
 		crd, err := readCRDFromFile(testCRDManifestDir + "/project.pb.yaml")
 		assert.NotNil(t, crd)
 		assert.NoError(t, err)
-		err = upsertCRDs(ctx, logger, crdGatewayMock, []*apiextv1.CustomResourceDefinition{crd}, []string{})
+		err = upsertCRDs(ctx, logger, crdGatewayMock, []*apiextv1.CustomResourceDefinition{crd}, false, []string{})
 		assert.Error(t, err)
 	})
 }
@@ -258,32 +258,37 @@ func TestSyncCRDs(t *testing.T) {
 	crdYaml, err := os.ReadFile(testCRDManifestDir + "/project.pb.yaml")
 	assert.NoError(t, err)
 	err = syncCRDs(context.Background(), logger, "test",
-		true, &crdGateway, nil, nil, []string{}, map[string]string{"Project": string(crdYaml)})
+		true, &crdGateway, nil, nil, false, []string{}, map[string]string{"Project": string(crdYaml)})
 	assert.NoError(t, err)
 
 	// incompatible change - should be blocked with empty allowlist
 	crdYaml, err = os.ReadFile(testCRDManifestDir + "/project_delete_props.pb.yaml")
 	assert.NoError(t, err)
 	err = syncCRDs(context.Background(), logger, "test",
-		true, &crdGateway, nil, nil, []string{}, map[string]string{"Project": string(crdYaml)})
+		true, &crdGateway, nil, nil, false, []string{}, map[string]string{"Project": string(crdYaml)})
 	assert.Error(t, err, "failed to update CRD. Schema is incompatible, and there are existing instances. Abort updating CRD projects.test")
 
 	// same incompatible change - should be allowed when CRD is in allowlist
 	err = syncCRDs(context.Background(), logger, "test",
-		true, &crdGateway, nil, nil, []string{"projects.test"}, map[string]string{"Project": string(crdYaml)})
+		true, &crdGateway, nil, nil, false, []string{"projects.test"}, map[string]string{"Project": string(crdYaml)})
 	assert.NoError(t, err, "incompatible update should be allowed when CRD is in allowlist")
 
 	// fail to list existing CRDs
 	mockGateway := crdmocks.NewMockGateway(gomock.NewController(t))
 	mockGateway.EXPECT().List(gomock.Any()).Return(nil, fmt.Errorf("test error"))
 	err = syncCRDs(context.Background(), logger, "test",
-		true, mockGateway, nil, nil, []string{}, map[string]string{"Project": string(crdYaml)})
+		true, mockGateway, nil, nil, false, []string{}, map[string]string{"Project": string(crdYaml)})
 	assert.Error(t, err, "failed to list existing CRDs: test error")
 
 	// do not update CRDs that are not in the specified groups
 	err = syncCRDs(context.Background(), logger, "test1",
-		true, &crdGateway, nil, nil, []string{}, map[string]string{"Project": string(crdYaml)})
+		true, &crdGateway, nil, nil, false, []string{}, map[string]string{"Project": string(crdYaml)})
 	assert.Error(t, err, "CRD projects.test is not in the specified group test1")
+
+	// incompatible change - should be allowed when skipIncompatibleCheck is true (dev env)
+	err = syncCRDs(context.Background(), logger, "test",
+		true, &crdGateway, nil, nil, true, []string{}, map[string]string{"Project": string(crdYaml)})
+	assert.NoError(t, err, "incompatible update should be allowed when skipIncompatibleCheck is true")
 }
 
 func TestParseConfig(t *testing.T) {
@@ -298,6 +303,7 @@ apiserver:
 	conf, err := ParseConfig(provider)
 	assert.NoError(t, err)
 	assert.True(t, conf.EnableCRDUpdate)
+	assert.False(t, conf.SkipIncompatibleCheck, "skipIncompatibleCheck should default to false when not specified")
 
 	// Parse configuration with CRD versions
 	yamlConfStr2 := `
@@ -322,14 +328,29 @@ apiserver:
 		},
 	})
 
+	// Parse configuration with skipIncompatibleCheck
+	yamlConfStr3 := `
+apiserver:
+  crdSync:
+    enableCRDUpdate: true
+    skipIncompatibleCheck: true
+`
+	provider3, err := config.NewYAML(config.Source(strings.NewReader(yamlConfStr3)))
+	assert.NoError(t, err)
+
+	conf3, err := ParseConfig(provider3)
+	assert.NoError(t, err)
+	assert.True(t, conf3.EnableCRDUpdate)
+	assert.True(t, conf3.SkipIncompatibleCheck)
+
 	invalidConfStr := `
 apiserver:
   crdSync:
     enableCRDUpdat: true
 `
-	provider3, err := config.NewYAML(config.Source(strings.NewReader(invalidConfStr)))
+	provider4, err := config.NewYAML(config.Source(strings.NewReader(invalidConfStr)))
 	assert.NoError(t, err)
-	_, err2 := ParseConfig(provider3)
+	_, err2 := ParseConfig(provider4)
 	assert.Error(t, err2)
 }
 
@@ -661,7 +682,7 @@ func TestUpsertCRDsWithAllowList(t *testing.T) {
 		crd.Name = "deployments.michelangelo.api"
 
 		allowList := []string{"deployments.michelangelo.api"}
-		err = upsertCRDs(ctx, logger, crdGatewayMock, []*apiextv1.CustomResourceDefinition{crd}, allowList)
+		err = upsertCRDs(ctx, logger, crdGatewayMock, []*apiextv1.CustomResourceDefinition{crd}, false, allowList)
 		assert.NoError(t, err)
 	})
 
@@ -681,7 +702,7 @@ func TestUpsertCRDsWithAllowList(t *testing.T) {
 		crd.Name = "projects.michelangelo.api"
 
 		allowList := []string{"deployments.michelangelo.api"}
-		err = upsertCRDs(ctx, logger, crdGatewayMock, []*apiextv1.CustomResourceDefinition{crd}, allowList)
+		err = upsertCRDs(ctx, logger, crdGatewayMock, []*apiextv1.CustomResourceDefinition{crd}, false, allowList)
 		assert.NoError(t, err)
 	})
 
@@ -698,7 +719,26 @@ func TestUpsertCRDsWithAllowList(t *testing.T) {
 		assert.NoError(t, err)
 
 		allowList := []string{}
-		err = upsertCRDs(ctx, logger, crdGatewayMock, []*apiextv1.CustomResourceDefinition{crd}, allowList)
+		err = upsertCRDs(ctx, logger, crdGatewayMock, []*apiextv1.CustomResourceDefinition{crd}, false, allowList)
+		assert.NoError(t, err)
+	})
+
+	t.Run("skipIncompatibleCheck enables incompatible updates for all CRDs regardless of allowlist", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		crdGatewayMock := crdmocks.NewMockGateway(ctrl)
+
+		// Expect ConditionalUpsert to be called with enableIncompatibleUpdate=true even with empty allowlist
+		crdGatewayMock.EXPECT().ConditionalUpsert(gomock.Any(), gomock.Any(), true).Return(nil).Times(1)
+
+		ctx := context.Background()
+		crd, err := readCRDFromFile(testCRDManifestDir + "/project.pb.yaml")
+		assert.NotNil(t, crd)
+		assert.NoError(t, err)
+
+		// CRD is NOT in the allowlist, but skipIncompatibleCheck overrides
+		crd.Name = "projects.michelangelo.api"
+		allowList := []string{}
+		err = upsertCRDs(ctx, logger, crdGatewayMock, []*apiextv1.CustomResourceDefinition{crd}, true, allowList)
 		assert.NoError(t, err)
 	})
 }

--- a/go/cmd/apiserver/config/base.yaml
+++ b/go/cmd/apiserver/config/base.yaml
@@ -5,6 +5,7 @@ apiserver:
   crdSync:
     enableCRDUpdate: true
     enableCRDDeletion: true
+    skipIncompatibleCheck: false
     crdVersions:
       project:
         versions: [v2]


### PR DESCRIPTION
Add a new SkipIncompatibleCheck boolean to the CRD sync Configuration struct. When set to true (e.g. in dev environment configs), all CRDs are allowed to perform incompatible schema updates regardless of the allowlist, bypassing the compatibility guard entirely.

Changes:
- Add SkipIncompatibleCheck field to Configuration struct
- Thread the flag through SyncCRDs -> syncCRDs -> upsertCRDs
- Update upsertCRDs logic: enableIncompatibleUpdate = skipIncompatibleCheck || isInAllowList(...)
- Set skipIncompatibleCheck: false in base.yaml (production default)
- Add unit tests for the new flag

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
