### PR TITLE
Add missing table test coverage

### DIFF
--- a/javascript/packages/core/components/table/__tests__/table.test.tsx
+++ b/javascript/packages/core/components/table/__tests__/table.test.tsx
@@ -1640,6 +1640,137 @@ describe('Table', () => {
         expect(screen.getAllByRole('row')[3]).toHaveTextContent('Charlie');
       });
     });
+
+    describe('with undefined values', () => {
+      const undefinedSortData = [
+        { id: '1', name: 'Alice', age: 30 },
+        { id: '2', name: 'Charlie', age: 25 },
+        { id: '3', name: 'David', age: 35 },
+        { id: '4', name: 'Eve', age: undefined },
+        { id: '5', name: 'Bob', age: undefined },
+        { id: '6', name: undefined, age: 35 },
+      ];
+
+      const undefinedSortColumns = [
+        { id: 'name', label: 'Name', accessor: 'name', enableSorting: true },
+        { id: 'age', label: 'Age', accessor: 'age', enableSorting: true },
+      ];
+
+      it('should sort undefined values to the end when sorting ascending', async () => {
+        const user = userEvent.setup();
+
+        render(
+          <Table
+            data={undefinedSortData}
+            columns={undefinedSortColumns}
+            disablePagination={true}
+          />,
+          buildWrapper([
+            getBaseProviderWrapper(),
+            getIconProviderWrapper({ icons: mockIcons }),
+            getInterpolationProviderWrapper(),
+            getRouterWrapper(),
+          ])
+        );
+
+        await user.click(screen.getByRole('columnheader', { name: /age/i }));
+
+        await waitFor(() => {
+          expect(screen.getAllByRole('row')[5]).toHaveTextContent('Eve');
+          expect(screen.getAllByRole('row')[6]).toHaveTextContent('Bob');
+        });
+      });
+
+      it('should sort undefined values to the end when sorting descending', async () => {
+        const user = userEvent.setup();
+
+        render(
+          <Table
+            data={undefinedSortData}
+            columns={undefinedSortColumns}
+            disablePagination={true}
+          />,
+          buildWrapper([
+            getBaseProviderWrapper(),
+            getIconProviderWrapper({ icons: mockIcons }),
+            getInterpolationProviderWrapper(),
+            getRouterWrapper(),
+          ])
+        );
+
+        const ageHeader = screen.getByRole('columnheader', { name: /age/i });
+        await user.click(ageHeader);
+        await user.click(ageHeader);
+
+        await waitFor(() => {
+          expect(screen.getAllByRole('row')[5]).toHaveTextContent('Eve');
+          expect(screen.getAllByRole('row')[6]).toHaveTextContent('Bob');
+        });
+      });
+
+      it('should sort undefined values to the end for string columns', async () => {
+        const user = userEvent.setup();
+
+        render(
+          <Table
+            data={undefinedSortData}
+            columns={undefinedSortColumns}
+            disablePagination={true}
+          />,
+          buildWrapper([
+            getBaseProviderWrapper(),
+            getIconProviderWrapper({ icons: mockIcons }),
+            getInterpolationProviderWrapper(),
+            getRouterWrapper(),
+          ])
+        );
+
+        await user.click(screen.getByRole('columnheader', { name: /name/i }));
+
+        await waitFor(() => {
+          expect(screen.getAllByRole('row')[1]).toHaveTextContent('Alice');
+          expect(screen.getAllByRole('row')[2]).toHaveTextContent('Bob');
+          expect(screen.getAllByRole('row')[3]).toHaveTextContent('Charlie');
+          expect(screen.getAllByRole('row')[4]).toHaveTextContent('David');
+          expect(screen.getAllByRole('row')[5]).toHaveTextContent('Eve');
+        });
+      });
+
+      it('should maintain undefined-last behavior when switching between columns', async () => {
+        const user = userEvent.setup();
+
+        render(
+          <Table
+            data={undefinedSortData}
+            columns={undefinedSortColumns}
+            disablePagination={true}
+          />,
+          buildWrapper([
+            getBaseProviderWrapper(),
+            getIconProviderWrapper({ icons: mockIcons }),
+            getInterpolationProviderWrapper(),
+            getRouterWrapper(),
+          ])
+        );
+
+        // Sort by age
+        await user.click(screen.getByRole('columnheader', { name: /age/i }));
+        await waitFor(() => {
+          expect(screen.getAllByRole('row')[5]).toHaveTextContent('Eve');
+          expect(screen.getAllByRole('row')[6]).toHaveTextContent('Bob');
+        });
+
+        // Switch to sort by name
+        await user.click(screen.getByRole('columnheader', { name: /name/i }));
+        await waitFor(() => {
+          expect(screen.getAllByRole('row')[1]).toHaveTextContent('Alice');
+          expect(screen.getAllByRole('row')[2]).toHaveTextContent('Bob');
+          expect(screen.getAllByRole('row')[3]).toHaveTextContent('Charlie');
+          expect(screen.getAllByRole('row')[4]).toHaveTextContent('David');
+          expect(screen.getAllByRole('row')[5]).toHaveTextContent('Eve');
+        });
+      });
+    });
   });
 
   describe('row selection integration', () => {

--- a/javascript/packages/core/components/table/components/filter/__tests__/categorical-filter.test.tsx
+++ b/javascript/packages/core/components/table/components/filter/__tests__/categorical-filter.test.tsx
@@ -181,6 +181,40 @@ describe('CategoricalFilter', () => {
       expect(mockSetFilterValue).toHaveBeenCalledWith(undefined);
       expect(mockClose).toHaveBeenCalled();
     });
+
+    it('should select all values when "Select all" is clicked', async () => {
+      const user = userEvent.setup();
+      mockGetFilterValue.mockReturnValue(['Engineering']);
+
+      render(
+        <CategoricalFilter {...defaultProps} />,
+        buildWrapper([getBaseProviderWrapper(), getInterpolationProviderWrapper()])
+      );
+
+      await user.click(screen.getByRole('checkbox', { name: 'Select All' }));
+      await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+      expect(mockSetFilterValue).toHaveBeenCalledWith(
+        expect.arrayContaining(['Design', 'Engineering', 'Marketing', 'Sales'])
+      );
+      expect(mockClose).toHaveBeenCalled();
+    });
+
+    it('should clear all values when "Clear" is clicked', async () => {
+      const user = userEvent.setup();
+      mockGetFilterValue.mockReturnValue(['Engineering', 'Sales']);
+
+      render(
+        <CategoricalFilter {...defaultProps} />,
+        buildWrapper([getBaseProviderWrapper(), getInterpolationProviderWrapper()])
+      );
+
+      await user.click(screen.getByRole('checkbox', { name: 'Clear' }));
+      await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+      expect(mockSetFilterValue).toHaveBeenCalledWith(undefined);
+      expect(mockClose).toHaveBeenCalled();
+    });
   });
 
   describe('data extraction', () => {

--- a/javascript/packages/core/components/table/components/table-pagination/__tests__/table-pagination.test.tsx
+++ b/javascript/packages/core/components/table/components/table-pagination/__tests__/table-pagination.test.tsx
@@ -87,6 +87,15 @@ describe('TablePagination', () => {
     ).toBeInTheDocument();
   });
 
+  test('disables previous page button when on first page', () => {
+    render(
+      <TablePagination {...buildPaginationProps({ state: { pageIndex: 0, pageSize: 10 } })} />,
+      buildWrapper([getBaseProviderWrapper()])
+    );
+
+    expect(screen.getByRole('button', { name: /previous/ })).toBeDisabled();
+  });
+
   test('renders page size selector with correct options', async () => {
     const user = userEvent.setup();
     render(


### PR DESCRIPTION
Three behaviors were untested at any level of the test pyramid:

    # Tables are configured by default to sort undefined values last
    # Categorical filter includes Select All and Clear controls that add
    functionality above and beyond single value filtering
    # Previous page pagination buttons are disabled when there is no
    previous page to go to (e.g., already on the first page)

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
