### PR TITLE
fix(ci): resolve race condition in combined coverage report

### DIFF
--- a/.github/workflows/combined-coverage.yml
+++ b/.github/workflows/combined-coverage.yml
@@ -1,27 +1,9 @@
 name: Combined Coverage Report
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-    paths:
-      - 'python/**'
-      - 'go/**/*.go'
-      - 'go/**/BUILD.bazel'
-      - 'proto/**/*.proto'
-      - '**/*.js'
-      - '**/*.mjs'
-      - '**/*.cjs'
-      - '**/package.json'
-      - '**/package-lock.json'
-  push:
-    branches:
-      - main
-    paths:
-      - 'python/**'
-      - 'go/**/*.go'
-      - '**/*.js'
-      - '**/*.mjs'
-      - '**/*.cjs'
+  workflow_run:
+    workflows: ["JavaScript Coverage", "Python Coverage Check", "Go Coverage"]
+    types: [completed]
 
 permissions:
   contents: read
@@ -33,11 +15,28 @@ jobs:
   aggregate-coverage:
     name: Aggregate All Coverage
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event.workflow_run.event == 'pull_request'
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Get PR number
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          PULL_REQUESTS_JSON: ${{ toJSON(github.event.workflow_run.pull_requests) }}
+        run: |
+          PR_NUMBER=$(echo "$PULL_REQUESTS_JSON" | jq -r '.[0].number // empty')
+          if [ -z "$PR_NUMBER" ]; then
+            PR_NUMBER=$(gh pr list --head "$HEAD_BRANCH" --json number --jq '.[0].number' 2>/dev/null || echo "")
+          fi
+          if [ -z "$PR_NUMBER" ]; then
+            echo "Could not determine PR number, skipping"
+            exit 1
+          fi
+          echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
 
       - name: Download Python coverage
         uses: dawidd6/action-download-artifact@v6
@@ -132,6 +131,7 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: combined-coverage
+          number: ${{ steps.pr.outputs.number }}
           message: |
             ## 📊 Combined Coverage Report
 


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Switched the combined coverage workflow trigger from `pull_request` to `workflow_run` so it runs *after* individual coverage workflows (JavaScript, Python, Go) complete, instead of concurrently.

Three changes:
1. Trigger: `pull_request`/`push` → `workflow_run` on completion of individual coverage workflows
2. New step to extract PR number (since `workflow_run` doesn't have it automatically)
3. Pass PR number to the sticky comment action

Also fixed the Python workflow name reference from "Python Coverage" to "Python Coverage Check" to match the actual workflow name.

**Why?**

The combined coverage report was showing JavaScript coverage as "N/A" because it ran in parallel with the JS coverage workflow. The combined workflow finished in ~19 seconds while JS coverage took ~4 minutes, so the artifacts weren't uploaded yet when the combined workflow tried to download them.

Visible on PR #847: the combined report showed `📜 JavaScript | N/A% (no coverage data)` while the dedicated JS coverage comment correctly showed 79.18%.

<img width="665" height="269" alt="image" src="https://github.com/user-attachments/assets/894362f2-87e0-4943-b067-a7da1aa36ff1" />

**How did you test it?**

- Verified workflow names match exactly (`JavaScript Coverage`, `Python Coverage Check`, `Go Coverage`)
- Confirmed the `marocchino/sticky-pull-request-comment` action supports the `number` input for `workflow_run` contexts

**Potential risks**

- The combined report will now fire once per individual coverage workflow completion (up to 3 times per PR push). Each run updates the same sticky comment, so the final state will be correct. The intermediate updates may show partial data.
- The `workflow_run` event's `pull_requests` field may be empty for cross-fork PRs, but the `gh pr list` fallback handles this.

**Release notes**

N/A - CI-only change

**Documentation Changes**

None