### PR TITLE
fix(docs): use absolute paths for Welcome page links

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -10,15 +10,15 @@ Michelangelo is an ML platform for building, deploying, and managing machine lea
 
 ## Getting Started
 
-- **[Overview](./about/overview)** - Learn about the platform
-- **[Core Concepts](./about/core-concepts-and-key-terms)** - Key terms and concepts
-- **[Setup Guide](./setup-guide/sandbox-setup)** - Get started with your sandbox
+- **[Overview](/docs/about/overview)** - Learn about the platform
+- **[Core Concepts](/docs/about/core-concepts-and-key-terms)** - Key terms and concepts
+- **[Setup Guide](/docs/setup-guide/sandbox-setup)** - Get started with your sandbox
 
 ## Documentation
 
-- **[User Guides](./user-guides/project-management-for-ml-pipelines)** - End-to-end workflows
-- **[Operator Guides](./operator-guides/api-framework)** - Infrastructure and deployment
-- **[Contributing](./contributing/developer-guide)** - Development guides
+- **[User Guides](/docs/user-guides/project-management-for-ml-pipelines)** - End-to-end workflows
+- **[Operator Guides](/docs/operator-guides/api-framework)** - Infrastructure and deployment
+- **[Contributing](/docs/contributing/developer-guide)** - Development guides
 
 ## Quick Links
 


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**

Changed 6 relative markdown links in `docs/intro.md` (the Welcome page) from relative paths (`./about/overview`) to absolute paths (`/docs/about/overview`).

**Why?**

When navigating client-side from the landing page to `/docs`, the URL lacks a trailing slash. The browser resolves relative links like `./about/overview` against `/` (the parent of `docs`), producing `/about/overview` instead of `/docs/about/overview`. All Welcome page links were broken on initial navigation — refreshing the page fixed it because the server serves `/docs/` with a trailing slash, making relative resolution work correctly.

**How did you test it?**

- Verified links resolve to correct `/docs/...` paths regardless of trailing slash
- Confirmed other docs using relative links (sibling references, images) are unaffected since their parent path doesn't change

**Potential risks**

None. Only changes link targets in a single markdown file.

**Release notes**

Fix broken navigation links on the docs Welcome page when arriving from the main site.

**Documentation Changes**

This PR itself is the documentation fix.