### PR TITLE
ci: add docs build check for PRs and fail on broken links

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,0 +1,29 @@
+name: Docs Check
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'website/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: website
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        run: bun run build

--- a/docs/about/overview.md
+++ b/docs/about/overview.md
@@ -167,7 +167,7 @@ Michelangelo supports a wide range of ML use cases. Here are some common example
   - _Features_: Raw images + metadata
   - _Deployment_: Batch processing for catalog updates
 
-**Not sure where to start?** Check out our [tutorials](../tutorials) with end-to-end examples, or explore the [Model Registry](../model-registry) to see what others have built.
+**Not sure where to start?** Check out our [user guides](../user-guides) for end-to-end examples.
 
 ## Architecture
 
@@ -302,4 +302,4 @@ A: Yes, with proper configuration. Michelangelo supports:
 
 ---
 
-**Still have questions?** Check out our [documentation](../), join the [community forum](https://github.com/michelangelo-ai/michelangelo/discussions), or explore [example projects](../tutorials).
+**Still have questions?** Check out our [documentation](../), join the [community forum](https://github.com/michelangelo-ai/michelangelo/discussions), or explore the [user guides](../user-guides).

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -17,8 +17,8 @@ const config: Config = {
   organizationName: 'michelangelo-ai',
   projectName: 'michelangelo',
 
-  onBrokenLinks: 'warn',
-  onBrokenMarkdownLinks: 'warn',
+  onBrokenLinks: 'throw',
+  onBrokenMarkdownLinks: 'throw',
 
   markdown: {
     format: 'md',


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [x] Documentation Update

**What changed?**

- Added `.github/workflows/docs-check.yml` — runs `bun run build` on PRs that touch `docs/**` or `website/**`
- Changed `onBrokenLinks` and `onBrokenMarkdownLinks` from `'warn'` to `'throw'` in `docusaurus.config.ts` so the build fails on broken links
- Fixed 2 pre-existing broken links in `docs/about/overview.md` that referenced non-existent `../tutorials` and `../model-registry` pages

**Why?**

Docs-only PRs had zero CI validation. Broken links (like the ones that caused #854) could be merged without any check. The deploy workflow only runs after merge to main, so broken links were only caught in production.

**How did you test it?**

- Ran `bun run build` locally — build passes clean with the stricter setting after fixing the 2 broken links (~10s build time for 47 docs)
- Verified the build fails when broken links are present (before fixing overview.md)

**Potential risks**

Existing PRs touching docs will now need to pass the build check. Any previously-unnoticed broken links in future doc changes will block the PR (which is the intended behavior).

**Release notes**

Docs PRs now run a build check in CI that catches broken links before merge.

**Documentation Changes**

N/A — this PR adds CI infrastructure for docs validation.