### PR TITLE
ci: add docs build check and fix deprecation warnings

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,0 +1,29 @@
+name: Docs Check
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'website/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: website
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        run: bun run build

--- a/docs/about/overview.md
+++ b/docs/about/overview.md
@@ -167,7 +167,7 @@ Michelangelo supports a wide range of ML use cases. Here are some common example
   - _Features_: Raw images + metadata
   - _Deployment_: Batch processing for catalog updates
 
-**Not sure where to start?** Check out our [tutorials](../tutorials) with end-to-end examples, or explore the [Model Registry](../model-registry) to see what others have built.
+**Not sure where to start?** Check out our [user guides](../user-guides) for end-to-end examples.
 
 ## Architecture
 
@@ -302,4 +302,4 @@ A: Yes, with proper configuration. Michelangelo supports:
 
 ---
 
-**Still have questions?** Check out our [documentation](../), join the [community forum](https://github.com/michelangelo-ai/michelangelo/discussions), or explore [example projects](../tutorials).
+**Still have questions?** Check out our [documentation](../), join the [community forum](https://github.com/michelangelo-ai/michelangelo/discussions), or explore the [user guides](../user-guides).

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -18,10 +18,12 @@ const config: Config = {
   projectName: 'michelangelo',
 
   onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'throw',
 
   markdown: {
     format: 'md',
+    hooks: {
+      onBrokenMarkdownLinks: 'throw',
+    },
   },
 
   i18n: {

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -17,8 +17,8 @@ const config: Config = {
   organizationName: 'michelangelo-ai',
   projectName: 'michelangelo',
 
-  onBrokenLinks: 'warn',
-  onBrokenMarkdownLinks: 'warn',
+  onBrokenLinks: 'throw',
+  onBrokenMarkdownLinks: 'throw',
 
   markdown: {
     format: 'md',


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [x] Documentation Update

**What changed?**
- Added a CI workflow (`docs-check.yml`) that builds the docs site on PRs touching `docs/` or `website/`
- Changed `onBrokenLinks` and `onBrokenMarkdownLinks` from `warn` to `throw` so broken links fail the build
- Fixed broken markdown links in `docs/about/overview.md` (references to non-existent `tutorials` path)
- Migrated deprecated top-level `onBrokenMarkdownLinks` to `markdown.hooks.onBrokenMarkdownLinks` per Docusaurus deprecation notice

**Why?**
Broken links in docs were going unnoticed since there was no CI check and the config only warned. This ensures broken links are caught before merge and eliminates Docusaurus deprecation warnings.

**How did you test it?**
- `bun run build` in `website/` passes cleanly with no warnings

**Potential risks**
PRs with broken doc links will now fail CI — this is intentional.

**Release notes**
N/A — CI and docs config only.

**Documentation Changes**
Fixed broken links in overview page. No user-facing doc changes.