### PR TITLE
fix(website): migrate onBrokenMarkdownLinks to markdown.hooks

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -19,10 +19,12 @@ const config: Config = {
   projectName: 'michelangelo',
 
   onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'throw',
 
   markdown: {
     format: 'md',
+    hooks: {
+      onBrokenMarkdownLinks: 'throw',
+    },
   },
 
   i18n: {


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
- Moved `onBrokenMarkdownLinks` from the deprecated top-level config to `markdown.hooks.onBrokenMarkdownLinks`

**Why?**
Docusaurus deprecated the top-level `onBrokenMarkdownLinks` option and now requires it under `siteConfig.markdown.hooks`. This eliminates the deprecation warning during builds.

**How did you test it?**
- `bun run build` passes with no deprecation warning for `onBrokenMarkdownLinks`

**Potential risks**
None — same behavior, just moved to the non-deprecated config location.

**Release notes**
N/A

**Documentation Changes**
N/A