### PR TITLE
ci: speed up Bazel test workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,9 +28,9 @@ jobs:
         with:
           path: |
             ~/.cache/bazel
-          key: bazel-${{ runner.os }}-${{ hashFiles('.bazelversion', 'MODULE.bazel', 'MODULE.bazel.lock') }}
+          key: bazel-test-${{ runner.os }}-${{ hashFiles('.bazelversion', 'MODULE.bazel', 'MODULE.bazel.lock') }}
           restore-keys: |
-            bazel-${{ runner.os }}-
+            bazel-test-${{ runner.os }}-
 
       # Run Bazel tests
       - name: Run Bazel Test
@@ -95,9 +95,9 @@ jobs:
         with:
           path: |
             ~/.cache/bazel
-          key: bazel-${{ runner.os }}-${{ hashFiles('.bazelversion', 'MODULE.bazel', 'MODULE.bazel.lock') }}
+          key: bazel-dirty-${{ runner.os }}-${{ hashFiles('.bazelversion', 'MODULE.bazel', 'MODULE.bazel.lock') }}
           restore-keys: |
-            bazel-${{ runner.os }}-
+            bazel-dirty-${{ runner.os }}-
 
       - name: Run Gazelle
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,13 +28,13 @@ jobs:
         with:
           path: |
             ~/.cache/bazel
-          key: bazel_cache_root
+          key: bazel-${{ runner.os }}-${{ hashFiles('.bazelversion', 'MODULE.bazel', 'MODULE.bazel.lock') }}
           restore-keys: |
-            bazel_cache_root
+            bazel-${{ runner.os }}-
 
       # Run Bazel tests
       - name: Run Bazel Test
-        run: ./tools/bazel test ...
+        run: ./tools/bazel test //go/... //proto/... --build_tests_only
 
   python-build:
     runs-on: ubuntu-latest
@@ -95,9 +95,9 @@ jobs:
         with:
           path: |
             ~/.cache/bazel
-          key: bazel_cache_root
+          key: bazel-${{ runner.os }}-${{ hashFiles('.bazelversion', 'MODULE.bazel', 'MODULE.bazel.lock') }}
           restore-keys: |
-            bazel_cache_root
+            bazel-${{ runner.os }}-
 
       - name: Run Gazelle
         run: |


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

**What changed?**

- Replaced static `bazel_cache_root` cache key with content-based, workflow-specific keys (`bazel-test-`/`bazel-dirty-` prefixes with `hashFiles` for `.bazelversion`, `MODULE.bazel`, `MODULE.bazel.lock`)
- Narrowed test targets from `test ...` (all targets) to `test //go/... //proto/... --build_tests_only`
- Deleted the stale `bazel_cache_root` cache entry

**Why?**

The `bazel-build` job consistently took ~6.5 minutes. Three root causes:

1. **Stale cache**: The static `bazel_cache_root` key is immutable once saved, so the cache never updates. All 2903 build actions execute every run instead of being cache hits.
2. **Overly broad test scope**: `test ...` builds all targets (binaries, OCI images, tooling) when only tests are needed.
3. **Cache cross-contamination**: A generic `bazel-${{ runner.os }}-` restore key prefix matched a 4.9GB cache from `go-coverage.yml`, causing "No space left on device" failures. Fixed by using workflow-specific prefixes.

**How did you test it?**

Verified on this PR across multiple runs:

| Job | Before (baseline) | After (warm cache) | Improvement |
|-----|--------------------|--------------------|-------------|
| **bazel-build** | ~6.5 min | **~2.75 min** | **58% faster** |
| **dirty-check** | ~7+ min | **~2 min** | **71% faster** |
| **Total workflow** | ~7 min | **~3.2 min** | **54% faster** |

- Cold cache run (first run after cache reset): ~18.5 min — expected one-time cost
- Warm cache run: **~3.2 min** — cache hits working correctly
- All tests pass
- Cache step correctly saves new cache on miss and skips save on hit

**Potential risks**

- If tests exist outside `//go/...` and `//proto/...` they would no longer run in this workflow. Analysis of recent runs shows all 84 tests are within these targets.

**Release notes**

N/A — CI-only change, no user-facing impact.

**Documentation Changes**

None required.