### PR TITLE
ci: consolidate Bazel caches and speed up coverage workflow

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -38,8 +38,8 @@ jobs:
         uses: actions/cache@v4  # https://github.com/actions/cache
         with:
           path: ~/.cache/bazel
-          key: bazel_cache_root
-          restore-keys: bazel_cache_root
+          key: bazel-release-${{ runner.os }}-${{ hashFiles('.bazelversion', 'MODULE.bazel', 'MODULE.bazel.lock') }}
+          restore-keys: bazel-release-${{ runner.os }}-
 
       - name: ${{ matrix.service }} / Build  Binary
         run: |

--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -47,22 +47,17 @@ jobs:
         with:
           path: |
             ~/.cache/bazel
-          key: bazel-${{ runner.os }}-${{ hashFiles('.bazelversion', 'MODULE.bazel', 'MODULE.bazel.lock') }}
+          key: bazel-coverage-${{ runner.os }}-${{ hashFiles('.bazelversion', 'MODULE.bazel', 'MODULE.bazel.lock') }}
           restore-keys: |
-            bazel-${{ runner.os }}-
+            bazel-coverage-${{ runner.os }}-
 
-      - name: Run tests with Bazel
-        run: |
-          ./tools/bazel test //go/... \
-            --test_output=errors \
-            --test_summary=detailed
-
-      - name: Generate coverage with Bazel
+      - name: Run tests and generate coverage with Bazel
         run: |
           ./tools/bazel coverage //go/... \
             --combined_report=lcov \
             --instrumentation_filter="//go/[^/]*" \
-            --test_output=errors
+            --test_output=errors \
+            --test_summary=detailed
 
       - name: Process coverage data
         run: |
@@ -107,25 +102,6 @@ jobs:
             echo "total: (statements) 0%" > coverage.txt
           fi
 
-      - name: Generate alternative coverage report
-        if: env.COVERAGE == '0' || env.COVERAGE == ''
-        run: |
-          # Alternative: use bazel coverage with go tool format
-          echo "Attempting alternative coverage method..."
-
-          # Run coverage and capture output
-          ./tools/bazel coverage //go/... --combined_report=lcov || true
-
-          # Try to find any coverage data
-          find bazel-out -name "*.dat" -o -name "*.lcov" | head -10
-
-          # Set a placeholder
-          echo "COVERAGE=18.2" >> $GITHUB_ENV
-          echo "⚠️  Using cached coverage estimate"
-
-          # Create coverage.txt for combined workflow
-          echo "total: (statements) 18.2%" > coverage.txt
-
       - name: "Check coverage threshold (baseline: 60%)"
         run: |
           BASELINE=60
@@ -143,28 +119,6 @@ jobs:
             echo "📈 Goal: Maintain baseline and enforce 90% on new code"
           fi
 
-      # Codecov upload disabled - coverage is reported via PR comments and artifacts
-      # - name: Upload coverage to Codecov
-      #   uses: codecov/codecov-action@v4
-      #   with:
-      #     files: ./coverage.dat
-      #     flags: go
-      #     name: go-coverage
-      #     fail_ci_if_error: false
-      #     token: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Get test results summary
-        id: test_summary
-        run: |
-          # Count test results from Bazel
-          echo "Extracting test summary..."
-
-          # Get number of passing tests
-          PASSED=$(./tools/bazel test //go/... --test_summary=short 2>&1 | \
-            grep "tests pass" | awk '{print $1}' || echo "unknown")
-
-          echo "TESTS_PASSED=$PASSED" >> $GITHUB_ENV
-
       - name: Coverage report PR comment
         uses: marocchino/sticky-pull-request-comment@v2
         if: github.event_name == 'pull_request'
@@ -174,39 +128,11 @@ jobs:
             ## Go Coverage Report (Bazel)
 
             **Total Coverage:** ${{ env.COVERAGE }}%
-            **Tests Passed:** ${{ env.TESTS_PASSED }}
 
             **Coverage Policy:**
             - **Baseline (existing code):** ≥60% (current coverage)
             - **New/changed code:** ≥90% ✅ **STRICTLY ENFORCED**
             - **Long-term goal:** Improve baseline to 90%
-
-            <details>
-            <summary>Coverage Summary</summary>
-
-            ```
-            ${{ steps.test_summary.outputs.summary || 'See artifacts for details' }}
-            ```
-
-            </details>
-
-            <details>
-            <summary>📊 How to view detailed coverage</summary>
-
-            Download the coverage artifacts from this run and open `coverage-html/index.html`
-
-            Or run locally:
-            ```bash
-            bazel coverage //go/...
-            genhtml bazel-out/_coverage/_coverage_report.dat -o coverage-html
-            open coverage-html/index.html
-            ```
-
-            </details>
-
-            ---
-
-            **Note:** This project uses Bazel. Run `bazel test //go/...` locally to test.
 
             [View detailed HTML report in artifacts](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
@@ -226,7 +152,6 @@ jobs:
           echo "## Go Coverage Report (Bazel)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Total Coverage:** ${{ env.COVERAGE }}%" >> $GITHUB_STEP_SUMMARY
-          echo "**Tests Passed:** ${{ env.TESTS_PASSED }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Coverage Policy" >> $GITHUB_STEP_SUMMARY
           echo "- **Baseline (existing code):** ≥60% (current coverage)" >> $GITHUB_STEP_SUMMARY
@@ -249,21 +174,3 @@ jobs:
             cat coverage-summary.txt >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
           fi
-
-  coverage-quality-gate:
-    name: Coverage Quality Gate
-    runs-on: ubuntu-latest
-    needs: test-and-coverage
-    if: github.event_name == 'pull_request'
-
-    steps:
-      - name: Check coverage meets requirements
-        run: |
-          echo "✅ Go coverage checks completed"
-          echo "- Baseline coverage: ≥60% (current coverage)"
-          echo "- New code coverage: ≥90% ✅ STRICTLY ENFORCED"
-          echo ""
-          echo "📝 Coverage Policy:"
-          echo "- Existing code must maintain baseline (60%)"
-          echo "- New/changed code must meet 90% coverage"
-          echo "- Long-term goal: Improve baseline to 90%"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,9 +28,9 @@ jobs:
         with:
           path: |
             ~/.cache/bazel
-          key: bazel-test-${{ runner.os }}-${{ hashFiles('.bazelversion', 'MODULE.bazel', 'MODULE.bazel.lock') }}
+          key: bazel-main-${{ runner.os }}-${{ hashFiles('.bazelversion', 'MODULE.bazel', 'MODULE.bazel.lock') }}
           restore-keys: |
-            bazel-test-${{ runner.os }}-
+            bazel-main-${{ runner.os }}-
 
       # Run Bazel tests
       - name: Run Bazel Test
@@ -89,15 +89,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      # Cache Bazel outputs to speed up Bazel commands
-      - name: Cache Bazel Outputs
-        uses: actions/cache@v4
+      # Restore-only: reuse the cache saved by bazel-build (no redundant save)
+      - name: Restore Bazel Cache
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/.cache/bazel
-          key: bazel-dirty-${{ runner.os }}-${{ hashFiles('.bazelversion', 'MODULE.bazel', 'MODULE.bazel.lock') }}
+          key: bazel-main-${{ runner.os }}-${{ hashFiles('.bazelversion', 'MODULE.bazel', 'MODULE.bazel.lock') }}
           restore-keys: |
-            bazel-dirty-${{ runner.os }}-
+            bazel-main-${{ runner.os }}-
 
       - name: Run Gazelle
         run: |


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

**What changed?**

- **main.yml**: Unified `bazel-build` and `dirty-check` under a shared `bazel-main-` cache key. `dirty-check` switches from `actions/cache@v4` to `actions/cache/restore@v4` (restore-only) so it never saves a redundant smaller cache.
- **dev-release.yml**: Replaced stale static `bazel_cache_root` key with a proper content-hashed `bazel-release-` key (same bug fixed in #858 for main.yml).
- **go-coverage.yml**:
  - Renamed ambiguous `bazel-` cache prefix to `bazel-coverage-` for explicit isolation
  - Merged redundant `bazel test` + `bazel coverage` into a single step
  - Removed broken "Get test results summary" step (ran a full `bazel test` to produce "Executed" instead of a count)
  - Removed no-op `coverage-quality-gate` job (spun up a runner to echo static text; actual gating already in `test-and-coverage`)
  - Removed "Generate alternative coverage report" fallback (hardcoded `COVERAGE=18.2` and swallowed errors with `|| true`)
  - Removed commented-out Codecov integration
  - Cleaned up PR comment to show only working fields

**Why?**

After #858, the repo had 4 separate Bazel caches totaling ~9.1GB out of a 10GB repo limit. Combined with non-Bazel caches (venv ~3GB, bun ~100MB), total exceeded 10GB, triggering LRU eviction and unpredictable cold-cache runs.

| Cache key prefix | Size | Status |
|---|---|---|
| `bazel-test-Linux-` | 3,272 MB | renamed to `bazel-main-` |
| `bazel-dirty-Linux-` | 1,106 MB | eliminated (restore-only from `bazel-main-`) |
| `bazel-Linux-` | 4,710 MB | renamed to `bazel-coverage-` |
| `bazel_cache_root` | unknown | fixed to `bazel-release-` with content hash |

The go-coverage workflow had several issues beyond caching:
- Ran `bazel test` then `bazel coverage` (redundant), then `bazel test` again to extract a broken test count that displayed "Executed"
- A "Coverage Summary" section always showed "See artifacts for details" (referenced a step output that was never set)
- A fallback step hardcoded `COVERAGE=18.2` when real coverage data was not found, masking failures
- A `coverage-quality-gate` job spun up a whole runner just to echo static policy text (the real threshold check already runs in `test-and-coverage`)

**How did you test it?**

- Verified YAML syntax and logical correctness of cache key prefixes
- Confirmed `actions/cache/restore@v4` is the correct action for restore-only behavior
- Confirmed `bazel coverage` exits non-zero on test failures and supports `--test_output=errors` and `--test_summary=detailed`
- CI run on this PR validates all jobs pass
- Warm-cache re-run confirmed: `dirty-check` restores but does not save, `bazel-build` saves, coverage runs single Bazel invocation

**Potential risks**

- One-time cold cache on first run after merge for `dirty-check` and `go-coverage` (old key prefixes will not match new ones). Subsequent runs will be warm.
- Stale `bazel-test-Linux-*` cache entry should be cleaned up via GitHub API after merge.
- If `bazel coverage` truly fails to produce coverage data, the workflow will now fail at the threshold check instead of silently proceeding with a fake 18.2% value. This is the correct behavior.

**Release notes**

N/A - CI-only changes, no user-facing impact.

**Documentation Changes**

N/A