### PR TITLE
ci: remove dead code and fix silent failures in CI workflows

### DIFF
--- a/.github/workflows/combined-coverage.yml
+++ b/.github/workflows/combined-coverage.yml
@@ -117,16 +117,6 @@ jobs:
           echo "JS_COVERAGE=$JS_COV" >> $GITHUB_ENV
           echo "JS_NOTE=$JS_NOTE" >> $GITHUB_ENV
 
-      # Codecov upload disabled - coverage is reported via PR comments and artifacts
-      # - name: Upload combined coverage to Codecov
-      #   uses: codecov/codecov-action@v4
-      #   with:
-      #     files: ./coverage-reports/python/coverage.xml,./coverage-reports/go/coverage.out,./coverage-reports/javascript/lcov.info
-      #     flags: combined
-      #     name: combined-coverage
-      #     fail_ci_if_error: false
-      #     token: ${{ secrets.CODECOV_TOKEN }}
-
       - name: Create combined coverage report
         uses: marocchino/sticky-pull-request-comment@v2
         with:

--- a/.github/workflows/javascript-coverage.yml
+++ b/.github/workflows/javascript-coverage.yml
@@ -96,16 +96,6 @@ jobs:
             echo "📈 Goal: Maintain baseline and enforce 90% on new code"
           fi
 
-      # Codecov upload disabled - coverage is reported via PR comments and artifacts
-      # - name: Upload coverage to Codecov
-      #   uses: codecov/codecov-action@v4
-      #   with:
-      #     files: ./coverage/lcov.info,./coverage/coverage-final.json
-      #     flags: javascript
-      #     name: javascript-coverage
-      #     fail_ci_if_error: false
-      #     token: ${{ secrets.CODECOV_TOKEN }}
-
       - name: Coverage report PR comment
         uses: marocchino/sticky-pull-request-comment@v2
         if: github.event_name == 'pull_request'
@@ -192,20 +182,3 @@ jobs:
           echo "- **Baseline (existing code):** ≥78.74% (current coverage)" >> $GITHUB_STEP_SUMMARY
           echo "- **New/changed code:** ≥90% ✅ **STRICTLY ENFORCED**" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-
-  coverage-quality-gate:
-    name: Coverage Quality Gate
-    runs-on: ubuntu-latest
-    needs: test-coverage
-    if: github.event_name == 'pull_request'
-
-    steps:
-      - name: Check coverage meets requirements
-        run: |
-          echo "✅ JavaScript coverage checks completed"
-          echo "- Baseline coverage: ≥78.74% (current coverage)"
-          echo "- New code coverage: ≥90% ✅ STRICTLY ENFORCED"
-          echo ""
-          echo "📝 Coverage Policy:"
-          echo "- Existing code must maintain baseline (78.74%)"
-          echo "- New/changed code must meet 90% coverage"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,7 +13,6 @@ jobs:
   ruff:
     name: Python Run Ruff on Changed Files
     runs-on: ubuntu-latest
-    continue-on-error: true
     permissions:
       pull-requests: write   # For commenting on PRs
       contents: read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       # Checkout the repository
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Cache Bazel outputs
       - name: Cache Bazel Outputs
@@ -87,7 +87,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Restore-only: reuse the cache saved by bazel-build (no redundant save)
       - name: Restore Bazel Cache

--- a/.github/workflows/python-coverage.yml
+++ b/.github/workflows/python-coverage.yml
@@ -78,7 +78,6 @@ jobs:
             --cov-branch \
             --junitxml=junit.xml \
             -v
-        continue-on-error: true
 
       # Generate coverage badge
       - name: Generate coverage badge
@@ -102,25 +101,13 @@ jobs:
           COVERAGE_DATA_BRANCH: main
         continue-on-error: true
 
-      # Codecov upload disabled - coverage is reported via PR comments and artifacts
-      # - name: Upload coverage to Codecov
-      #   uses: codecov/codecov-action@v4
-      #   with:
-      #     file: ./python/coverage.xml
-      #     flags: python
-      #     name: python-coverage
-      #     fail_ci_if_error: false
-      #     token: ${{ secrets.CODECOV_TOKEN }}
-
       # Check overall coverage threshold (baseline: 70%)
       - name: "Check overall coverage threshold (baseline: 70%)"
         run: |
-          # Baseline coverage is 70% - we don't fail on this
-          # The goal is to maintain or improve from baseline
+          # Fail if coverage drops below baseline
           poetry run coverage report --fail-under=70
           echo "✅ Coverage meets baseline threshold (70%)"
           echo "📈 Goal: Maintain baseline and enforce 90% on new code"
-        continue-on-error: true
 
       # Check coverage for new/changed code (90% threshold)
       - name: Check diff coverage (90% for new code)


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Follow-up to #859. Cleans up remaining dead code from PR #543 (baseline coverage) across multiple workflows:

- **`javascript-coverage.yml`**: Removed no-op `coverage-quality-gate` job (spun up a runner just to echo static text) and commented-out Codecov block
- **`python-coverage.yml`**: Removed commented-out Codecov block. Removed `continue-on-error: true` from the pytest step (line 81) and baseline threshold check (line 123) — test failures and coverage drops were being silently swallowed
- **`combined-coverage.yml`**: Removed commented-out Codecov block
- **`main.yml`**: Upgraded `actions/checkout@v3` → `@v4` in `bazel-build` and `dirty-check` jobs (all other workflows already use v4)
- **`lint.yaml`**: Removed job-level `continue-on-error: true` from the `ruff` job — lint/format failures were silently suppressed despite explicit `exit 1` failure steps

**Why?**

- The Codecov blocks were commented out from day one (PR #543) and never wired up. Coverage is already reported via PR comments and artifacts in each workflow.
- The `coverage-quality-gate` job was a no-op — actual threshold checks already happen in the `test-coverage` job.
- `continue-on-error: true` on pytest meant test failures were silently ignored and coverage ran on potentially incomplete data. The baseline threshold check also had `continue-on-error: true`, making it a no-op. Net effect: the Python coverage workflow could never fail except on the diff-cover step.
- The lint job's `continue-on-error: true` at job level suppressed the explicit `exit 1` failure steps, so lint failures never blocked PRs.

**How did you test it?**

- Verified all workflow YAML is syntactically valid
- Confirmed coverage reporting paths (PR comments, artifacts, job summaries) are unaffected
- CI will validate on push

**Potential risks**

- `python-coverage.yml`: PRs with test failures or coverage below 70% baseline will now correctly fail (previously silently passed)
- `lint.yaml`: PRs with ruff lint/format issues will now correctly fail (previously silently passed)
- These are intentional — the workflows were broken, not informational

**Release notes**

N/A — CI-only changes, no user-facing impact.

**Documentation Changes**

None.