### PR TITLE
[mactl] Fix ValueError when UpdateTimestamp label is empty

### DIFF
--- a/python/michelangelo/cli/mactl/crd.py
+++ b/python/michelangelo/cli/mactl/crd.py
@@ -269,9 +269,14 @@ def prepare_column_info() -> list[dict]:
         },
         {
             "column_name": "LAST_UPDATED_SPEC",
-            "retrieve_func": lambda item: datetime.fromtimestamp(
-                int(item.metadata.labels["michelangelo/UpdateTimestamp"]) / 1_000_000
-            ).strftime("%Y-%m-%d_%H:%M:%S"),
+            "retrieve_func": lambda item: (
+                datetime.fromtimestamp(
+                    int(item.metadata.labels["michelangelo/UpdateTimestamp"])
+                    / 1_000_000
+                ).strftime("%Y-%m-%d_%H:%M:%S")
+                if item.metadata.labels.get("michelangelo/UpdateTimestamp", "")
+                else "N/A"
+            ),
             "max_length": len("LAST_UPDATED_SPEC") + 1,
         },
     ]

--- a/python/michelangelo/cli/mactl/crd_test.py
+++ b/python/michelangelo/cli/mactl/crd_test.py
@@ -79,6 +79,54 @@ class PrepareColumnInfoTest(TestCase):
             ],
         )
 
+    def test_prepare_column_info_empty_timestamp(self):
+        """Test prepare_column_info handles empty timestamp gracefully."""
+        # Mock Entity with empty timestamp
+        mock_item = Mock()
+        mock_item.metadata.namespace = "test-ns"
+        mock_item.metadata.name = "test-name"
+        mock_item.metadata.labels = {"michelangelo/UpdateTimestamp": ""}
+
+        # run func
+        result = prepare_column_info()
+
+        # Check results
+        retrieval_funcs = [col.pop("retrieve_func") for col in result]
+
+        # Should return "N/A" for empty timestamp instead of crashing
+        self.assertEqual(
+            [func(mock_item) for func in retrieval_funcs],
+            [
+                "test-ns",
+                "test-name",
+                "N/A",
+            ],
+        )
+
+    def test_prepare_column_info_missing_timestamp(self):
+        """Test prepare_column_info handles missing timestamp label."""
+        # Mock Entity without timestamp label
+        mock_item = Mock()
+        mock_item.metadata.namespace = "test-ns"
+        mock_item.metadata.name = "test-name"
+        mock_item.metadata.labels = {}
+
+        # run func
+        result = prepare_column_info()
+
+        # Check results
+        retrieval_funcs = [col.pop("retrieve_func") for col in result]
+
+        # Should return "N/A" for missing timestamp
+        self.assertEqual(
+            [func(mock_item) for func in retrieval_funcs],
+            [
+                "test-ns",
+                "test-name",
+                "N/A",
+            ],
+        )
+
 
 class ListFuncImplTest(TestCase):
     """Test cases for list_func_impl function."""


### PR DESCRIPTION
  **What type of PR is this? (check all applicable)**
  - [ ] Refactor
  - [ ] Feature
  - [x] Bug Fix
  - [ ] Optimization
  - [ ] Documentation Update

  **What changed?**

Fixed `ValueError` when listing resources (e.g., `ma project get`) that have an empty `UpdateTimestamp` label. The code now checks if the timestamp exists and is non-empty before attempting to convert it to an integer. When the timestamp is empty or missing, it displays "N/A" instead of crashing.

  **Why?**

Some resources  have empty `UpdateTimestamp` labels, causing `int('')` to raise a `ValueError` and crash the CLI when running get/list command, . 

  **How did you test it?**

  - Added 2 unit tests covering empty and missing timestamp scenarios
  - All tests pass: `pytest michelangelo/cli/mactl/crd_test.py::PrepareColumnInfoTest -v`
  - command 'ma project get -n ma-integration-test' doesn't crash after this fix
  - Lint checks pass: `ruff check`

  **Potential risks**

  Low risk - only affects display formatting. Resources with empty timestamps will now show "N/A" in the LAST_UPDATED_SPEC  column instead of crashing.

  **Release notes**

  None required - bug fix only.

  **Documentation Changes**

  None required.
