### PR TITLE
ci: add proper path filters to avoid unnecessary workflow runs

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -4,6 +4,11 @@ on:
   workflow_dispatch:
   push:
     branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - 'website/**'
+      - 'javascript/**'
+      - 'python/**'
 #  pull_request:
 #    branches: [ main ]
 

--- a/.github/workflows/javascript-coverage.yml
+++ b/.github/workflows/javascript-coverage.yml
@@ -3,19 +3,13 @@ name: JavaScript Coverage
 on:
   pull_request:
     paths:
-      - '**/*.js'
-      - '**/*.mjs'
-      - '**/*.cjs'
-      - '**/package.json'
-      - '**/package-lock.json'
+      - 'javascript/**'
       - '.github/workflows/javascript-coverage.yml'
   push:
     branches:
       - main
     paths:
-      - '**/*.js'
-      - '**/*.mjs'
-      - '**/*.cjs'
+      - 'javascript/**'
 
 permissions:
   contents: read

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,9 +3,9 @@ name: Python Ruff Lint & Format
 on:
   pull_request:
     branches: [main]
-    paths-ignore:
-      - 'docs/**'
-      - 'website/**'
+    paths:
+      - 'python/**'
+      - '.github/workflows/lint.yaml'
 
 jobs:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,11 +7,13 @@ on:
     paths-ignore:
       - 'docs/**'
       - 'website/**'
+      - 'javascript/**'
   pull_request:
     branches: [main]
     paths-ignore:
       - 'docs/**'
       - 'website/**'
+      - 'javascript/**'
 
 jobs:
   bazel-build:


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update

**What changed?**

Added/tightened path filters on 4 CI workflows so they only run when relevant files change:

| Workflow | Before | After | Strategy |
|---|---|---|---|
| `lint.yaml` (Python ruff) | `paths-ignore: [docs, website]` — ran for Go, JS, proto, .github changes | `paths: [python/**]` | Allowlist |
| `javascript-coverage.yml` | `**/*.js` — matched JS files anywhere in repo | `javascript/**` — matches `ui-pre-land.yaml` | Allowlist (tightened) |
| `main.yml` (Bazel Test) | `paths-ignore: [docs, website]` — ran for JS changes | Added `javascript/**` to ignore list | Blocklist (extended) |
| `dev-release.yml` (Docker images) | No filter — ran on every merge to main | `paths-ignore: [docs, website, javascript, python]` | Blocklist |

**Why?**

Workflows were running unnecessarily — e.g., Python ruff on a JS-only PR, Docker image builds on a docs-only merge. This wastes CI minutes and adds noise to PRs.

Strategy choice:
- **Allowlist (`paths`)** for language-specific tools (linters, coverage) — low-stakes if a run is missed
- **Blocklist (`paths-ignore`)** for build/release pipelines — stale artifacts are worse than an extra build, so new dependencies should trigger by default

**How did you test it?**

- Audited all 14 workflow files to understand triggers and dependencies
- Verified all Python files live under `python/` (no `.py` files elsewhere in repo)
- Verified `javascript/**` matches existing `ui-pre-land.yaml` convention
- Confirmed `main.yml`'s 3 jobs (Bazel Go/proto, pytest, dirty-check) have no JavaScript dependencies
- Confirmed `dev-release.yml` only builds Go service images via Bazel

**Potential risks**

- If Python files are added outside `python/`, `lint.yaml` won't trigger for them (unlikely — all Python lives in `python/`)
- `dev-release.yml` uses blocklist so new top-level directories will trigger builds by default (intentional — safer for a release pipeline)

**Release notes**

N/A — CI workflow optimization only

**Documentation Changes**

N/A