### PR TITLE
[mactl] add pagination limit support 

### DIFF
--- a/python/michelangelo/cli/mactl/crd.py
+++ b/python/michelangelo/cli/mactl/crd.py
@@ -26,7 +26,6 @@ from michelangelo.cli.mactl.grpc_tools import (
     get_message_class_by_name,
     get_methods_from_service,
 )
-from michelangelo.gen.api.list_pb2 import ListOptionsExt, PaginationSpec
 
 _LOG = getLogger(__name__)
 METADATA_STUB = []
@@ -220,6 +219,10 @@ def crd_method_call(crd_method_info, request_input: Message) -> Message:
 
     method_fullname = f"/{crd_method_info.crd_full_name}/{crd_method_info.method_name}"
     _LOG.info("Method fullname for gRPC call: %s", method_fullname)
+
+    request_size = len(request_input.SerializeToString())
+    _LOG.info("gRPC request size: %d bytes", request_size)
+
     stub_method = crd_method_info.channel.unary_unary(
         method_fullname,
         request_serializer=crd_method_info.input_class.SerializeToString,
@@ -230,6 +233,9 @@ def crd_method_call(crd_method_info, request_input: Message) -> Message:
         metadata=METADATA_STUB,
         timeout=30,
     )
+
+    response_size = len(response.SerializeToString())
+    _LOG.info("gRPC response size: %d bytes (%d KB)", response_size, response_size // 1024)
     _LOG.info("Stub method completed (%r): %r", type(response), response)
     return response
 
@@ -273,9 +279,14 @@ def prepare_column_info() -> list[dict]:
         },
         {
             "column_name": "LAST_UPDATED_SPEC",
-            "retrieve_func": lambda item: datetime.fromtimestamp(
-                int(item.metadata.labels["michelangelo/UpdateTimestamp"]) / 1_000_000
-            ).strftime("%Y-%m-%d_%H:%M:%S"),
+            "retrieve_func": lambda item: (
+                datetime.fromtimestamp(
+                    int(item.metadata.labels["michelangelo/UpdateTimestamp"])
+                    / 1_000_000
+                ).strftime("%Y-%m-%d_%H:%M:%S")
+                if item.metadata.labels.get("michelangelo/UpdateTimestamp", "")
+                else "N/A"
+            ),
             "max_length": len("LAST_UPDATED_SPEC") + 1,
         },
     ]
@@ -319,16 +330,22 @@ def list_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Mes
     _LOG.info("Bound arguments: %r", bound_args.arguments)
 
     limit = bound_args.arguments.get("limit", 100)
-    pagination_spec = PaginationSpec(offset=0, limit=limit)
-    list_options_ext = ListOptionsExt(pagination=pagination_spec)
 
-    call_res = crd_method_call_kwargs(
-        crd_method_info,
-        **{
-            "namespace": get_single_arg(bound_args.arguments, "namespace"),
-            "list_options_ext": list_options_ext,
+    request_dict = {
+        "namespace": get_single_arg(bound_args.arguments, "namespace"),
+        "list_options": {"limit": limit},
+        "list_options_ext": {
+            "pagination": {
+                "offset": 0,
+                "limit": limit,
+            }
         },
-    )
+    }
+
+    request_input = crd_method_info.input_class()
+    ParseDict(request_dict, request_input)
+    _LOG.info("ListRequest built: %r", request_input)
+    call_res = crd_method_call(crd_method_info, request_input)
     _LOG.debug("Succeed to list CRDs: %r", type(call_res))
     results = {k.name: v for k, v in call_res.ListFields() if k.name.endswith("_list")}
     _LOG.debug(
@@ -342,10 +359,13 @@ def list_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Mes
 
     print_list_formatted(raw_elems.items)
 
+    # Show warning if we got exactly the limit (there might be more)
     if len(raw_elems.items) == limit:
         print(
-            f"\n⚠️  Warning: Result count ({len(raw_elems.items)}) equals limit "
-            f"({limit}). There may be more items. Use --limit to increase."
+            f"\n⚠️  The response is limited to {limit} pipelines. "
+            f"There may be more than {limit} results. "
+            f"Consider a larger limit with --limit argument or using filter to narrow down the result. "
+            f"(default: 100)"
         )
 
     return call_res
@@ -726,7 +746,7 @@ class CRD:
         self.create = MethodType(bound_func, self)
         _LOG.debug("Generated CREATE injected well: %r", self.create)
 
-    def generate_list(self, channel: Channel):
+    def generate_list(self, channel: Channel, parser: Optional[ArgumentParser] = None):
         """Generate list function of this class."""
         _LOG.info("Generate LIST method for %r / %r", self.name, self.full_name)
 
@@ -735,6 +755,8 @@ class CRD:
             self.full_name,
             *self._extract_method_info(channel, self.full_name, "List"),
         )
+
+        self.configure_parser("list", parser)
         list_func_signature = Signature(
             [
                 Parameter("self", Parameter.POSITIONAL_OR_KEYWORD),

--- a/python/michelangelo/cli/mactl/crd.py
+++ b/python/michelangelo/cli/mactl/crd.py
@@ -543,34 +543,6 @@ class CRD:
                     },
                 ],
             },
-            "list": {
-                "help": "List entities in a namespace",
-                "args": [
-                    {
-                        "func_signature": Parameter(
-                            "namespace", Parameter.POSITIONAL_OR_KEYWORD
-                        ),
-                        "args": ["-n", "--namespace"],
-                        "kwargs": {
-                            "type": str,
-                            "required": True,
-                            "help": "Namespace of the resource",
-                        },
-                    },
-                    {
-                        "func_signature": Parameter(
-                            "limit", Parameter.POSITIONAL_OR_KEYWORD, default=100
-                        ),
-                        "args": ["--limit"],
-                        "kwargs": {
-                            "dest": "limit",
-                            "type": int,
-                            "default": 100,
-                            "help": "Maximum number of items to return (default: 100)",
-                        },
-                    },
-                ],
-            },
         }
 
         # TODO: This would be changed to use centralized config metadata stub

--- a/python/michelangelo/cli/mactl/crd.py
+++ b/python/michelangelo/cli/mactl/crd.py
@@ -26,6 +26,7 @@ from michelangelo.cli.mactl.grpc_tools import (
     get_message_class_by_name,
     get_methods_from_service,
 )
+from michelangelo.gen.api.list_pb2 import ListOptionsExt, PaginationSpec
 
 _LOG = getLogger(__name__)
 METADATA_STUB = []
@@ -241,7 +242,10 @@ def get_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Mess
         _LOG.debug("No name argument passed. List CRD in the namespace.")
         _self: CRD = bound_args.arguments["self"]
         _self.generate_list(crd_method_info.channel)
-        return _self.list(namespace=get_single_arg(bound_args.arguments, "namespace"))
+        return _self.list(
+            namespace=get_single_arg(bound_args.arguments, "namespace"),
+            limit=bound_args.arguments.get("limit", 100),
+        )
 
     call_res = crd_method_call_kwargs(
         crd_method_info,
@@ -314,9 +318,16 @@ def list_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Mes
     """Default common CRD member method implementation for LIST method."""
     _LOG.info("Bound arguments: %r", bound_args.arguments)
 
+    limit = bound_args.arguments.get("limit", 100)
+    pagination_spec = PaginationSpec(offset=0, limit=limit)
+    list_options_ext = ListOptionsExt(pagination=pagination_spec)
+
     call_res = crd_method_call_kwargs(
         crd_method_info,
-        **{"namespace": get_single_arg(bound_args.arguments, "namespace")},
+        **{
+            "namespace": get_single_arg(bound_args.arguments, "namespace"),
+            "list_options_ext": list_options_ext,
+        },
     )
     _LOG.debug("Succeed to list CRDs: %r", type(call_res))
     results = {k.name: v for k, v in call_res.ListFields() if k.name.endswith("_list")}
@@ -330,6 +341,13 @@ def list_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Mes
     raw_elems = results[next(iter(results))]
 
     print_list_formatted(raw_elems.items)
+
+    if len(raw_elems.items) == limit:
+        print(
+            f"\n⚠️  Warning: Result count ({len(raw_elems.items)}) equals limit "
+            f"({limit}). There may be more items. Use --limit to increase."
+        )
+
     return call_res
 
 
@@ -498,6 +516,49 @@ class CRD:
                             "type": str,
                             "required": False,
                             "help": "Name of the resource",
+                        },
+                    },
+                    {
+                        "func_signature": Parameter(
+                            "limit", Parameter.POSITIONAL_OR_KEYWORD, default=100
+                        ),
+                        "args": ["--limit"],
+                        "kwargs": {
+                            "dest": "limit",
+                            "type": int,
+                            "default": 100,
+                            "help": (
+                                "Maximum number of items to return when listing "
+                                "(default: 100)"
+                            ),
+                        },
+                    },
+                ],
+            },
+            "list": {
+                "help": "List entities in a namespace",
+                "args": [
+                    {
+                        "func_signature": Parameter(
+                            "namespace", Parameter.POSITIONAL_OR_KEYWORD
+                        ),
+                        "args": ["-n", "--namespace"],
+                        "kwargs": {
+                            "type": str,
+                            "required": True,
+                            "help": "Namespace of the resource",
+                        },
+                    },
+                    {
+                        "func_signature": Parameter(
+                            "limit", Parameter.POSITIONAL_OR_KEYWORD, default=100
+                        ),
+                        "args": ["--limit"],
+                        "kwargs": {
+                            "dest": "limit",
+                            "type": int,
+                            "default": 100,
+                            "help": "Maximum number of items to return (default: 100)",
                         },
                     },
                 ],
@@ -675,10 +736,10 @@ class CRD:
             *self._extract_method_info(channel, self.full_name, "List"),
         )
         list_func_signature = Signature(
-            [Parameter("self", Parameter.POSITIONAL_OR_KEYWORD)]
-            + [
-                Parameter(name, Parameter.POSITIONAL_OR_KEYWORD)
-                for name in ["namespace"]
+            [
+                Parameter("self", Parameter.POSITIONAL_OR_KEYWORD),
+                Parameter("namespace", Parameter.POSITIONAL_OR_KEYWORD),
+                Parameter("limit", Parameter.POSITIONAL_OR_KEYWORD, default=100),
             ]
         )
 

--- a/python/michelangelo/cli/mactl/crd.py
+++ b/python/michelangelo/cli/mactl/crd.py
@@ -352,8 +352,8 @@ def list_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Mes
         print(
             f"\n⚠️  The response is limited to {limit} pipelines. "
             f"There may be more than {limit} results. "
-            f"Consider a larger limit with --limit argument or using filter to narrow down the result. "
-            f"(default: 100)"
+            f"Consider a larger limit with --limit argument or using filter "
+            f"to narrow down the result. (default: 100)"
         )
 
     return call_res

--- a/python/michelangelo/cli/mactl/crd.py
+++ b/python/michelangelo/cli/mactl/crd.py
@@ -219,10 +219,6 @@ def crd_method_call(crd_method_info, request_input: Message) -> Message:
 
     method_fullname = f"/{crd_method_info.crd_full_name}/{crd_method_info.method_name}"
     _LOG.info("Method fullname for gRPC call: %s", method_fullname)
-
-    request_size = len(request_input.SerializeToString())
-    _LOG.info("gRPC request size: %d bytes", request_size)
-
     stub_method = crd_method_info.channel.unary_unary(
         method_fullname,
         request_serializer=crd_method_info.input_class.SerializeToString,
@@ -233,9 +229,6 @@ def crd_method_call(crd_method_info, request_input: Message) -> Message:
         metadata=METADATA_STUB,
         timeout=30,
     )
-
-    response_size = len(response.SerializeToString())
-    _LOG.info("gRPC response size: %d bytes (%d KB)", response_size, response_size // 1024)
     _LOG.info("Stub method completed (%r): %r", type(response), response)
     return response
 
@@ -279,14 +272,9 @@ def prepare_column_info() -> list[dict]:
         },
         {
             "column_name": "LAST_UPDATED_SPEC",
-            "retrieve_func": lambda item: (
-                datetime.fromtimestamp(
-                    int(item.metadata.labels["michelangelo/UpdateTimestamp"])
-                    / 1_000_000
-                ).strftime("%Y-%m-%d_%H:%M:%S")
-                if item.metadata.labels.get("michelangelo/UpdateTimestamp", "")
-                else "N/A"
-            ),
+            "retrieve_func": lambda item: datetime.fromtimestamp(
+                int(item.metadata.labels["michelangelo/UpdateTimestamp"]) / 1_000_000
+            ).strftime("%Y-%m-%d_%H:%M:%S"),
             "max_length": len("LAST_UPDATED_SPEC") + 1,
         },
     ]

--- a/python/michelangelo/cli/mactl/crd_test.py
+++ b/python/michelangelo/cli/mactl/crd_test.py
@@ -83,8 +83,9 @@ class PrepareColumnInfoTest(TestCase):
 class ListFuncImplTest(TestCase):
     """Test cases for list_func_impl function."""
 
-    @patch("michelangelo.cli.mactl.crd.crd_method_call_kwargs")
-    def test_list_func_impl(self, mock_call_kwargs):
+    @patch("michelangelo.cli.mactl.crd.crd_method_call")
+    @patch("michelangelo.cli.mactl.crd.ParseDict")
+    def test_list_func_impl(self, mock_parse_dict, mock_call):
         """Test list_func_impl extracts list fields and formats output."""
         # Create CrdMethodInfo instance
         crd_method_info = CrdMethodInfo(
@@ -108,7 +109,7 @@ class ListFuncImplTest(TestCase):
                 Mock(items=[mock_item]),
             )
         ]
-        mock_call_kwargs.return_value = mock_response
+        mock_call.return_value = mock_response
 
         # Execute - should not raise any exceptions
         list_func_impl(
@@ -116,13 +117,15 @@ class ListFuncImplTest(TestCase):
             Mock(arguments={"namespace": "test-namespace", "limit": 100}),
         )
 
-        # Verify crd_method_call_kwargs was called with correct arguments
-        call_args = mock_call_kwargs.call_args
-        self.assertEqual(call_args.kwargs["namespace"], "test-namespace")
-        self.assertTrue("list_options_ext" in call_args.kwargs)
+        # Verify ParseDict was called with correct request dict
+        call_args = mock_parse_dict.call_args
+        request_dict = call_args[0][0]
+        self.assertEqual(request_dict["namespace"], "test-namespace")
+        self.assertEqual(request_dict["list_options_ext"]["pagination"]["limit"], 100)
 
-    @patch("michelangelo.cli.mactl.crd.crd_method_call_kwargs")
-    def test_list_func_impl_with_limit_warning(self, mock_call_kwargs):
+    @patch("michelangelo.cli.mactl.crd.crd_method_call")
+    @patch("michelangelo.cli.mactl.crd.ParseDict")
+    def test_list_func_impl_with_limit_warning(self, mock_parse_dict, mock_call):
         """Test list_func_impl shows warning when result count equals limit."""
         crd_method_info = CrdMethodInfo(
             channel=Mock(),
@@ -145,15 +148,16 @@ class ListFuncImplTest(TestCase):
                 Mock(items=mock_items),
             )
         ]
-        mock_call_kwargs.return_value = mock_response
+        mock_call.return_value = mock_response
 
         list_func_impl(
             crd_method_info,
             Mock(arguments={"namespace": "test-namespace", "limit": 10}),
         )
 
-        call_args = mock_call_kwargs.call_args
-        self.assertEqual(call_args.kwargs["list_options_ext"].pagination.limit, 10)
+        call_args = mock_parse_dict.call_args
+        request_dict = call_args[0][0]
+        self.assertEqual(request_dict["list_options_ext"]["pagination"]["limit"], 10)
 
 
 class DeleteFuncImplTest(TestCase):

--- a/python/michelangelo/cli/mactl/crd_test.py
+++ b/python/michelangelo/cli/mactl/crd_test.py
@@ -208,6 +208,36 @@ class GetFuncImplTest(TestCase):
             crd_method_info, namespace="ns", name="proj"
         )
 
+    def test_get_func_impl_without_name_calls_list(self):
+        """Test get_func_impl without name calls list with limit."""
+        mock_crd = Mock()
+        mock_crd.list = Mock(return_value="list_result")
+        mock_crd.generate_list = Mock()
+
+        crd_method_info = CrdMethodInfo(
+            channel=Mock(),
+            crd_full_name="test.Service",
+            method_name="Get",
+            input_class=Mock,
+            output_class=Mock,
+        )
+
+        result = get_func_impl(
+            crd_method_info,
+            Mock(
+                arguments={
+                    "self": mock_crd,
+                    "namespace": "ns",
+                    "name": None,
+                    "limit": 50,
+                }
+            ),
+        )
+
+        mock_crd.generate_list.assert_called_once_with(crd_method_info.channel)
+        mock_crd.list.assert_called_once_with(namespace="ns", limit=50)
+        self.assertEqual(result, "list_result")
+
 
 class ApplyFuncImplTest(TestCase):
     """Test cases for apply_func_impl function."""

--- a/python/michelangelo/cli/mactl/crd_test.py
+++ b/python/michelangelo/cli/mactl/crd_test.py
@@ -111,12 +111,49 @@ class ListFuncImplTest(TestCase):
         mock_call_kwargs.return_value = mock_response
 
         # Execute - should not raise any exceptions
-        list_func_impl(crd_method_info, Mock(arguments={"namespace": "test-namespace"}))
+        list_func_impl(
+            crd_method_info,
+            Mock(arguments={"namespace": "test-namespace", "limit": 100}),
+        )
 
         # Verify crd_method_call_kwargs was called with correct arguments
-        mock_call_kwargs.assert_called_once_with(
-            crd_method_info, namespace="test-namespace"
+        call_args = mock_call_kwargs.call_args
+        self.assertEqual(call_args.kwargs["namespace"], "test-namespace")
+        self.assertTrue("list_options_ext" in call_args.kwargs)
+
+    @patch("michelangelo.cli.mactl.crd.crd_method_call_kwargs")
+    def test_list_func_impl_with_limit_warning(self, mock_call_kwargs):
+        """Test list_func_impl shows warning when result count equals limit."""
+        crd_method_info = CrdMethodInfo(
+            channel=Mock(),
+            crd_full_name="michelangelo.api.v2.ProjectService",
+            method_name="List",
+            input_class=Mock,
+            output_class=Mock,
         )
+
+        mock_items = [MagicMock() for _ in range(10)]
+        for item in mock_items:
+            item.metadata.namespace = "test-ns"
+            item.metadata.name = "test-project"
+            item.metadata.labels = {"michelangelo/UpdateTimestamp": "1640000000000000"}
+
+        mock_response = Mock()
+        mock_response.ListFields.return_value = [
+            (
+                Mock(name="project_list"),
+                Mock(items=mock_items),
+            )
+        ]
+        mock_call_kwargs.return_value = mock_response
+
+        list_func_impl(
+            crd_method_info,
+            Mock(arguments={"namespace": "test-namespace", "limit": 10}),
+        )
+
+        call_args = mock_call_kwargs.call_args
+        self.assertEqual(call_args.kwargs["list_options_ext"].pagination.limit, 10)
 
 
 class DeleteFuncImplTest(TestCase):


### PR DESCRIPTION
## **What type of PR is this? (check all applicable)**
  - [x] Feature
  - [ ] Refactor
  - [ ] Bug Fix
  - [x] Optimization
  - [ ] Documentation Update

  ## **What changed?**

  Added pagination support and `--limit` flag to get and list commands with a default limit of 100 items to prevent gRPC RESOURCE_EXHAUSTED errors.

  **Examples:**
  ```bash
  # List pipelines (defaults to 100 items)
  ma pipeline list -n my-namespace

  # List pipelines with custom limit
  ma pipeline list -n my-namespace --limit 10

  # Get pipelines without name (defaults to 100 items)
  ma pipeline get -n my-namespace

  # Get pipelines with custom limit
  ma pipeline get -n my-namespace --limit 10
  ```

  ## **Why?**

  Prevents `grpc.RpcError: RESOURCE_EXHAUSTED` errors when running commands like `ma pipeline get -n ma-integration-test` and `ma project get -n ma-integration-test`. The error occurs when response messages exceed the max size limit (e.g., "Received message larger thanmax (XXXXX vs. 104857600)"). By implementing pagination with a default 100-item limit, we keep message sizes within acceptable bounds.

  ## **How did you test it?**

  Tested on both staging and OSS servers:
  - **Staging** (`ma-integration-test`): Verified limits of 3, 10, 100 work correctly
  - **OSS** (`ma-dev-test`): Verified limits of 1, 2, 10 work correctly
  - **Message size reduction**: Confirmed ~1KB per pipeline (3KB for 3 items vs 102KB for 100 items)
  - **Warning behavior**: Verified warning appears when `result_count == limit`, not when `result_count < limit`

  ## **Potential risks**

  None 

  ## **Release notes**

ma get/list commands now default to 100 items per request to prevent RESOURCE_EXHAUSTED errors. Use pagination options to retrieve  additional results.

  ## **Documentation Changes**

  None required - CLI help text already includes `--limit` flag documentation.