### PR TITLE
Add field-level validation to form system

### DIFF
--- a/javascript/eslint.config.js
+++ b/javascript/eslint.config.js
@@ -60,6 +60,7 @@ export default [
       '**/node_modules/**',
       '**/dist/**',
       '**/gen/**',
+      '**/coverage/**',
       'eslint.config.js',
       '**/vite-env.d.ts',
     ],

--- a/javascript/packages/core/components/form/__tests__/form.test.tsx
+++ b/javascript/packages/core/components/form/__tests__/form.test.tsx
@@ -5,6 +5,8 @@ import { vi } from 'vitest';
 import { FormDialog } from '#core/components/form/components/form-dialog/form-dialog';
 import { StringField } from '#core/components/form/fields/string/string-field';
 import { Form } from '#core/components/form/form';
+import { combineValidators } from '#core/components/form/validation/combine-validators';
+import { minLength, required } from '#core/components/form/validation/validators';
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
 import { getIconProviderWrapper } from '#core/test/wrappers/get-icon-provider-wrapper';
@@ -165,6 +167,63 @@ describe('Form integration', () => {
         expect.anything()
       )
     );
+  });
+});
+
+describe('Form validation', () => {
+  it('allows submission after required field is filled', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(
+      <Form onSubmit={onSubmit}>
+        <StringField name="username" label="Username" required />
+        <button type="submit">Submit</button>
+      </Form>,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+    expect(await screen.findByText('This field is required.')).toBeInTheDocument();
+
+    await user.type(screen.getByRole('textbox', { name: 'Username *' }), 'johndoe');
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        { username: 'johndoe' },
+        expect.anything(),
+        expect.anything()
+      )
+    );
+  });
+
+  it('shows first error when composed validators fail sequentially', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(
+      <Form onSubmit={onSubmit}>
+        <StringField
+          name="username"
+          label="Username"
+          required
+          validate={combineValidators(required(), minLength(6))}
+        />
+        <button type="submit">Submit</button>
+      </Form>,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+    expect(await screen.findByText('This field is required.')).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    await user.type(screen.getByRole('textbox', { name: 'Username *' }), 'abc');
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+    expect(await screen.findByText('Must be at least 6 characters.')).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 });
 

--- a/javascript/packages/core/components/form/fields/boolean/boolean-field.tsx
+++ b/javascript/packages/core/components/form/fields/boolean/boolean-field.tsx
@@ -11,6 +11,7 @@ export const BooleanField: React.FC<BooleanFieldProps> = ({
   name,
   label,
   required,
+  validate,
   readOnly,
   disabled,
   description,
@@ -18,7 +19,7 @@ export const BooleanField: React.FC<BooleanFieldProps> = ({
   checkboxLabel,
   toggle = false,
 }) => {
-  const { input, meta } = useField<boolean>(name);
+  const { input, meta } = useField<boolean>(name, { required, validate });
 
   const handleChange = (event: React.FormEvent<HTMLInputElement>) => {
     input.onChange(event.currentTarget.checked);

--- a/javascript/packages/core/components/form/fields/radio/radio-field.tsx
+++ b/javascript/packages/core/components/form/fields/radio/radio-field.tsx
@@ -12,6 +12,7 @@ export const RadioField: React.FC<RadioFieldProps> = ({
   name,
   label,
   required,
+  validate,
   readOnly,
   disabled,
   description,
@@ -19,7 +20,7 @@ export const RadioField: React.FC<RadioFieldProps> = ({
   options,
   align = ALIGN.horizontal,
 }) => {
-  const { input, meta } = useField<string | boolean>(name);
+  const { input, meta } = useField<string | boolean>(name, { required, validate });
 
   const isBoolean = options.every(({ value }) => typeof value === 'boolean');
 

--- a/javascript/packages/core/components/form/fields/select/select-field.tsx
+++ b/javascript/packages/core/components/form/fields/select/select-field.tsx
@@ -12,6 +12,7 @@ export const SelectField: React.FC<SelectFieldProps> = ({
   name,
   label,
   required,
+  validate,
   readOnly,
   disabled,
   description,
@@ -23,7 +24,10 @@ export const SelectField: React.FC<SelectFieldProps> = ({
   multi = false,
   creatable = false,
 }) => {
-  const { input, meta } = useField<string | string[] | number[] | number>(name);
+  const { input, meta } = useField<string | string[] | number[] | number>(name, {
+    required,
+    validate,
+  });
 
   const handleChange = useCallback(
     (params: { value: ReadonlyArray<SelectOption> }) => {

--- a/javascript/packages/core/components/form/fields/string/string-field.tsx
+++ b/javascript/packages/core/components/form/fields/string/string-field.tsx
@@ -9,13 +9,14 @@ export const StringField: React.FC<BaseFieldProps> = ({
   name,
   label,
   required,
+  validate,
   readOnly,
   disabled,
   placeholder,
   description,
   caption,
 }) => {
-  const { input, meta } = useField<string>(name);
+  const { input, meta } = useField<string>(name, { required, validate });
 
   return (
     <FormControl

--- a/javascript/packages/core/components/form/fields/textarea/textarea-field.tsx
+++ b/javascript/packages/core/components/form/fields/textarea/textarea-field.tsx
@@ -9,6 +9,7 @@ export const TextareaField: React.FC<TextareaFieldProps> = ({
   name,
   label,
   required,
+  validate,
   readOnly,
   disabled,
   placeholder,
@@ -17,7 +18,7 @@ export const TextareaField: React.FC<TextareaFieldProps> = ({
   rows,
   maxLength,
 }) => {
-  const { input, meta } = useField<string>(name);
+  const { input, meta } = useField<string>(name, { required, validate });
   const currentLength = input.value?.length ?? 0;
 
   return (

--- a/javascript/packages/core/components/form/fields/types.ts
+++ b/javascript/packages/core/components/form/fields/types.ts
@@ -1,3 +1,5 @@
+import type { FieldValidator } from '#core/components/form/validation/types';
+
 export interface BaseFieldProps {
   /** Unique ID of the field,
    *
@@ -48,4 +50,11 @@ export interface BaseFieldProps {
    * **Markdown supported.**
    */
   caption?: string;
+
+  /**
+   * Validation function called on each value change after the field is touched.
+   * Returns an error message string when invalid, or `undefined` when valid.
+   * Use `combineValidators` to compose multiple validators.
+   */
+  validate?: FieldValidator;
 }

--- a/javascript/packages/core/components/form/hooks/use-field.ts
+++ b/javascript/packages/core/components/form/hooks/use-field.ts
@@ -1,9 +1,22 @@
 import { useField as useReactFinalFormField } from 'react-final-form';
 
+import { combineValidators } from '#core/components/form/validation/combine-validators';
+import { required as requiredValidator } from '#core/components/form/validation/validators';
+
+import type { FieldValidator } from '#core/components/form/validation/types';
 import type { FieldInput, FieldState } from '../types';
 
-export function useField<T = unknown>(name: string): { input: FieldInput<T>; meta: FieldState } {
-  const field = useReactFinalFormField<T>(name);
+export function useField<T = unknown>(
+  name: string,
+  options?: { validate?: FieldValidator; required?: boolean }
+): { input: FieldInput<T>; meta: FieldState } {
+  const composedValidate = options?.required
+    ? combineValidators(requiredValidator(), ...(options.validate ? [options.validate] : []))
+    : options?.validate;
+
+  const validate = composedValidate ? (value: T) => composedValidate(value as unknown) : undefined;
+
+  const field = useReactFinalFormField<T>(name, { validate });
 
   const input: FieldInput<T> = {
     value: field.input.value,
@@ -13,8 +26,7 @@ export function useField<T = unknown>(name: string): { input: FieldInput<T>; met
   };
 
   const meta: FieldState = {
-    // TODO: field.meta.error is typed as any, do we need better refinement?
-    error: field.meta.error as string,
+    error: typeof field.meta.error === 'string' ? field.meta.error : undefined,
     touched: !!field.meta.touched,
   };
 

--- a/javascript/packages/core/components/form/validation/__tests__/validators.test.ts
+++ b/javascript/packages/core/components/form/validation/__tests__/validators.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from 'vitest';
+
+import { combineValidators } from '#core/components/form/validation/combine-validators';
+import {
+  max,
+  maxLength,
+  min,
+  minLength,
+  regex,
+  required,
+  url,
+} from '#core/components/form/validation/validators';
+
+describe('required', () => {
+  it('returns undefined for non-empty string', () => {
+    expect(required()('hello')).toBeUndefined();
+  });
+
+  it('returns error for empty string', () => {
+    expect(required()('')).toBe('This field is required.');
+  });
+
+  it('returns error for whitespace-only string', () => {
+    expect(required()('   ')).toBe('This field is required.');
+  });
+
+  it('returns error for null', () => {
+    expect(required()(null)).toBe('This field is required.');
+  });
+
+  it('returns error for undefined', () => {
+    expect(required()(undefined)).toBe('This field is required.');
+  });
+
+  it('returns error for empty array', () => {
+    expect(required()([])).toBe('This field is required.');
+  });
+
+  it('returns error for empty object', () => {
+    expect(required()({})).toBe('This field is required.');
+  });
+
+  it('returns undefined for non-empty array', () => {
+    expect(required()(['a'])).toBeUndefined();
+  });
+
+  it('returns undefined for boolean false', () => {
+    expect(required()(false)).toBeUndefined();
+  });
+
+  it('returns undefined for number 0', () => {
+    expect(required()(0)).toBeUndefined();
+  });
+
+  it('uses custom error message', () => {
+    expect(required('Required!')('')).toBe('Required!');
+  });
+});
+
+describe('min', () => {
+  it('returns undefined for value above minimum', () => {
+    expect(min(5)(10)).toBeUndefined();
+  });
+
+  it('returns undefined for value equal to minimum', () => {
+    expect(min(5)(5)).toBeUndefined();
+  });
+
+  it('returns error for value below minimum', () => {
+    expect(min(5)(3)).toBe('Must be at least 5.');
+  });
+
+  it('returns undefined for empty value', () => {
+    expect(min(5)('')).toBeUndefined();
+    expect(min(5)(undefined)).toBeUndefined();
+  });
+
+  it('uses custom error message', () => {
+    expect(min(5, 'Too small')(3)).toBe('Too small');
+  });
+});
+
+describe('max', () => {
+  it('returns undefined for value below maximum', () => {
+    expect(max(10)(5)).toBeUndefined();
+  });
+
+  it('returns undefined for value equal to maximum', () => {
+    expect(max(10)(10)).toBeUndefined();
+  });
+
+  it('returns error for value above maximum', () => {
+    expect(max(10)(15)).toBe('Must be at most 10.');
+  });
+
+  it('returns undefined for empty value', () => {
+    expect(max(10)('')).toBeUndefined();
+    expect(max(10)(undefined)).toBeUndefined();
+  });
+
+  it('uses custom error message', () => {
+    expect(max(10, 'Too large')(15)).toBe('Too large');
+  });
+});
+
+describe('minLength', () => {
+  it('returns undefined for string meeting minimum length', () => {
+    expect(minLength(3)('abc')).toBeUndefined();
+  });
+
+  it('returns undefined for string longer than minimum', () => {
+    expect(minLength(3)('abcd')).toBeUndefined();
+  });
+
+  it('returns error for string shorter than minimum', () => {
+    expect(minLength(3)('ab')).toBe('Must be at least 3 characters.');
+  });
+
+  it('returns undefined for empty value', () => {
+    expect(minLength(3)('')).toBeUndefined();
+    expect(minLength(3)(undefined)).toBeUndefined();
+  });
+
+  it('uses custom error message', () => {
+    expect(minLength(3, 'Too short')('ab')).toBe('Too short');
+  });
+});
+
+describe('maxLength', () => {
+  it('returns undefined for string within maximum length', () => {
+    expect(maxLength(5)('abc')).toBeUndefined();
+  });
+
+  it('returns undefined for string equal to maximum length', () => {
+    expect(maxLength(5)('abcde')).toBeUndefined();
+  });
+
+  it('returns error for string exceeding maximum length', () => {
+    expect(maxLength(5)('abcdef')).toBe('Must be at most 5 characters.');
+  });
+
+  it('returns undefined for empty value', () => {
+    expect(maxLength(5)('')).toBeUndefined();
+    expect(maxLength(5)(undefined)).toBeUndefined();
+  });
+
+  it('uses custom error message', () => {
+    expect(maxLength(5, 'Too long')('abcdef')).toBe('Too long');
+  });
+});
+
+describe('regex', () => {
+  it('returns undefined for string matching pattern', () => {
+    expect(regex(/^[a-z]+$/)('hello')).toBeUndefined();
+  });
+
+  it('returns error for string not matching pattern', () => {
+    expect(regex(/^[a-z]+$/)('Hello123')).toBe('Invalid format.');
+  });
+
+  it('accepts string pattern', () => {
+    expect(regex('^[0-9]+$')('123')).toBeUndefined();
+    expect(regex('^[0-9]+$')('abc')).toBe('Invalid format.');
+  });
+
+  it('returns undefined for empty value', () => {
+    expect(regex(/^[a-z]+$/)('')).toBeUndefined();
+    expect(regex(/^[a-z]+$/)(undefined)).toBeUndefined();
+  });
+
+  it('uses custom error message', () => {
+    expect(regex(/^[a-z]+$/, 'Letters only')('123')).toBe('Letters only');
+  });
+});
+
+describe('url', () => {
+  it('returns undefined for valid absolute URL', () => {
+    expect(url()('https://example.com')).toBeUndefined();
+  });
+
+  it('returns error for relative URL', () => {
+    expect(url()('/relative/path')).toBe('Must be a valid URL.');
+  });
+
+  it('returns error for invalid URL', () => {
+    expect(url()('not a url')).toBe('Must be a valid URL.');
+  });
+
+  it('returns undefined for empty value', () => {
+    expect(url()('')).toBeUndefined();
+    expect(url()(undefined)).toBeUndefined();
+  });
+
+  it('uses custom error message', () => {
+    expect(url('Enter a valid URL')('bad')).toBe('Enter a valid URL');
+  });
+});
+
+describe('combineValidators', () => {
+  it('returns undefined when all validators pass', () => {
+    expect(combineValidators(required(), minLength(2))('hello')).toBeUndefined();
+  });
+
+  it('returns first error when first validator fails', () => {
+    expect(combineValidators(required(), minLength(2))('')).toBe('This field is required.');
+  });
+
+  it('returns second error when only second validator fails', () => {
+    expect(combineValidators(required(), minLength(10))('hi')).toBe(
+      'Must be at least 10 characters.'
+    );
+  });
+
+  it('stops at first error and does not run subsequent validators', () => {
+    const neverCalled = (value: unknown) => {
+      throw new Error(`Should not be called with: ${String(value)}`);
+    };
+    expect(combineValidators(required(), neverCalled)('')).toBe('This field is required.');
+  });
+
+  it('returns undefined when no validators are provided', () => {
+    expect(combineValidators()('anything')).toBeUndefined();
+  });
+});

--- a/javascript/packages/core/components/form/validation/combine-validators.ts
+++ b/javascript/packages/core/components/form/validation/combine-validators.ts
@@ -1,0 +1,11 @@
+import type { FieldValidator } from './types';
+
+export const combineValidators =
+  (...validators: FieldValidator[]): FieldValidator =>
+  (value) => {
+    for (const validator of validators) {
+      const error = validator(value);
+      if (error !== undefined) return error;
+    }
+    return undefined;
+  };

--- a/javascript/packages/core/components/form/validation/types.ts
+++ b/javascript/packages/core/components/form/validation/types.ts
@@ -1,0 +1,15 @@
+/**
+ * A function that validates a value and returns an error message if the value is invalid.
+ *
+ * @param value - The value to validate.
+ * @returns An error message if the value is invalid, or `undefined` if the value is valid.
+ *
+ * @example
+ * ```ts
+ * const validate = (value: unknown) => {
+ *   if (value === undefined) return 'Value is required';
+ *   return undefined;
+ * };
+ * ```
+ */
+export type FieldValidator = (value: unknown) => string | undefined;

--- a/javascript/packages/core/components/form/validation/validators.ts
+++ b/javascript/packages/core/components/form/validation/validators.ts
@@ -1,0 +1,79 @@
+import { isAbsoluteURL } from '#core/utils/string-utils';
+
+import type { FieldValidator } from './types';
+
+/**
+ * Checks whether a field value is empty (absent, blank, or structurally empty).
+ *
+ * Used by all format/range validators to skip validation on empty values.
+ * This separates *presence* from *format/range* concerns: an empty value is not
+ * a format error — it is a presence error, which belongs to `required()`.
+ *
+ * This means validators like `minLength` and `min` only apply when a value exists.
+ * To enforce both presence and a constraint, compose them:
+ *   `combineValidators(required(), minLength(8))`
+ *
+ * New validators should follow this convention: call `if (isEmpty(value)) return undefined`
+ * before applying any format or range check.
+ */
+const isEmpty = (value: unknown): boolean => {
+  if (value === undefined || value === null) return true;
+  if (typeof value === 'string') return value.trim() === '';
+  if (Array.isArray(value)) return value.length === 0;
+  if (typeof value === 'object') return Object.keys(value).length === 0;
+  return false;
+};
+
+export const required =
+  (errorMessage = 'This field is required.'): FieldValidator =>
+  (value) => {
+    if (typeof value === 'boolean' || typeof value === 'number') return undefined;
+    return isEmpty(value) ? errorMessage : undefined;
+  };
+
+export const min =
+  (minimum: number, errorMessage = `Must be at least ${minimum}.`): FieldValidator =>
+  (value) => {
+    if (isEmpty(value)) return undefined;
+    const num = Number(value);
+    return isNaN(num) || num < minimum ? errorMessage : undefined;
+  };
+
+export const max =
+  (maximum: number, errorMessage = `Must be at most ${maximum}.`): FieldValidator =>
+  (value) => {
+    if (isEmpty(value)) return undefined;
+    const num = Number(value);
+    return isNaN(num) || num > maximum ? errorMessage : undefined;
+  };
+
+export const minLength =
+  (length: number, errorMessage = `Must be at least ${length} characters.`): FieldValidator =>
+  (value) => {
+    if (isEmpty(value)) return undefined;
+    const str = String(value);
+    return str.length < length ? errorMessage : undefined;
+  };
+
+export const maxLength =
+  (length: number, errorMessage = `Must be at most ${length} characters.`): FieldValidator =>
+  (value) => {
+    if (isEmpty(value)) return undefined;
+    const str = String(value);
+    return str.length > length ? errorMessage : undefined;
+  };
+
+export const regex =
+  (pattern: string | RegExp, errorMessage = 'Invalid format.'): FieldValidator =>
+  (value) => {
+    if (isEmpty(value)) return undefined;
+    const re = typeof pattern === 'string' ? new RegExp(pattern) : pattern;
+    return re.test(String(value)) ? undefined : errorMessage;
+  };
+
+export const url =
+  (errorMessage = 'Must be a valid URL.'): FieldValidator =>
+  (value) => {
+    if (isEmpty(value)) return undefined;
+    return isAbsoluteURL(String(value)) ? undefined : errorMessage;
+  };


### PR DESCRIPTION
Introduce composable validators and wire them into fields so that validation errors can be associated with individual fields and block form submission.

Validators separate presence from format/range concerns — format validators like minLength skip empty values, deferring to required() for presence. This allows optional fields to carry constraints without needing a dedicated optional() wrapper.

The meta.error type assertion in useField was replaced with a runtime typeof guard. final-form types meta.error as any, and the previous as string cast silently allowed undefined through at runtime without TypeScript catching it. The onboarding of field-level validation ensures that meta.error will only be the return type provided by FieldValidator

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
