### PR TITLE
Add ability to initialize form field's through defaultValue and initialValue

### DIFF
--- a/javascript/packages/core/components/form/__tests__/form.test.tsx
+++ b/javascript/packages/core/components/form/__tests__/form.test.tsx
@@ -91,7 +91,12 @@ describe('Form integration', () => {
   it('uses field-level initialValue over defaultValue when both are provided', () => {
     render(
       <Form onSubmit={vi.fn()}>
-        <StringField name="email" label="Email" defaultValue="from-default" initialValue="from-field-initial" />
+        <StringField
+          name="email"
+          label="Email"
+          defaultValue="from-default"
+          initialValue="from-field-initial"
+        />
       </Form>,
       buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
     );

--- a/javascript/packages/core/components/form/__tests__/form.test.tsx
+++ b/javascript/packages/core/components/form/__tests__/form.test.tsx
@@ -66,6 +66,55 @@ describe('Form integration', () => {
     );
   });
 
+  it('populates the field with defaultValue', () => {
+    render(
+      <Form onSubmit={vi.fn()}>
+        <StringField name="email" label="Email" defaultValue="from-default" />
+      </Form>,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+    );
+
+    expect(screen.getByRole('textbox', { name: 'Email' })).toHaveValue('from-default');
+  });
+
+  it('uses initialValues over defaultValue when both are provided', () => {
+    render(
+      <Form onSubmit={vi.fn()} initialValues={{ email: 'from-form' }}>
+        <StringField name="email" label="Email" defaultValue="from-default" />
+      </Form>,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+    );
+
+    expect(screen.getByRole('textbox', { name: 'Email' })).toHaveValue('from-form');
+  });
+
+  it('uses field-level initialValue over defaultValue when both are provided', () => {
+    render(
+      <Form onSubmit={vi.fn()}>
+        <StringField name="email" label="Email" defaultValue="from-default" initialValue="from-field-initial" />
+      </Form>,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+    );
+
+    expect(screen.getByRole('textbox', { name: 'Email' })).toHaveValue('from-field-initial');
+  });
+
+  it('uses field-level initialValue when all three value sources are provided', () => {
+    render(
+      <Form onSubmit={vi.fn()} initialValues={{ email: 'from-form' }}>
+        <StringField
+          name="email"
+          label="Email"
+          defaultValue="from-default"
+          initialValue="from-field-initial"
+        />
+      </Form>,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+    );
+
+    expect(screen.getByRole('textbox', { name: 'Email' })).toHaveValue('from-field-initial');
+  });
+
   it('supports external submit button via form id', async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn();

--- a/javascript/packages/core/components/form/fields/boolean/boolean-field.tsx
+++ b/javascript/packages/core/components/form/fields/boolean/boolean-field.tsx
@@ -10,6 +10,8 @@ import type { BooleanFieldProps } from './types';
 export const BooleanField: React.FC<BooleanFieldProps> = ({
   name,
   label,
+  defaultValue,
+  initialValue,
   required,
   validate,
   readOnly,
@@ -19,7 +21,12 @@ export const BooleanField: React.FC<BooleanFieldProps> = ({
   checkboxLabel,
   toggle = false,
 }) => {
-  const { input, meta } = useField<boolean>(name, { required, validate });
+  const { input, meta } = useField<boolean>(name, {
+    required,
+    validate,
+    defaultValue,
+    initialValue,
+  });
 
   const handleChange = (event: React.FormEvent<HTMLInputElement>) => {
     input.onChange(event.currentTarget.checked);

--- a/javascript/packages/core/components/form/fields/boolean/types.ts
+++ b/javascript/packages/core/components/form/fields/boolean/types.ts
@@ -1,6 +1,6 @@
 import type { BaseFieldProps } from '../types';
 
-export interface BooleanFieldProps extends BaseFieldProps {
+export interface BooleanFieldProps extends BaseFieldProps<boolean> {
   /**
    * Custom label for the checkbox itself.
    *

--- a/javascript/packages/core/components/form/fields/radio/radio-field.tsx
+++ b/javascript/packages/core/components/form/fields/radio/radio-field.tsx
@@ -11,6 +11,8 @@ import type { RadioFieldProps } from './types';
 export const RadioField: React.FC<RadioFieldProps> = ({
   name,
   label,
+  defaultValue,
+  initialValue,
   required,
   validate,
   readOnly,
@@ -20,7 +22,12 @@ export const RadioField: React.FC<RadioFieldProps> = ({
   options,
   align = ALIGN.horizontal,
 }) => {
-  const { input, meta } = useField<string | boolean>(name, { required, validate });
+  const { input, meta } = useField<string | boolean>(name, {
+    required,
+    validate,
+    defaultValue,
+    initialValue,
+  });
 
   const isBoolean = options.every(({ value }) => typeof value === 'boolean');
 

--- a/javascript/packages/core/components/form/fields/radio/types.ts
+++ b/javascript/packages/core/components/form/fields/radio/types.ts
@@ -7,7 +7,7 @@ export interface RadioOption {
   disabled?: boolean;
 }
 
-export interface RadioFieldProps extends BaseFieldProps {
+export interface RadioFieldProps extends BaseFieldProps<string | boolean> {
   options: RadioOption[];
   align?: Align;
 }

--- a/javascript/packages/core/components/form/fields/select/select-field.tsx
+++ b/javascript/packages/core/components/form/fields/select/select-field.tsx
@@ -11,6 +11,8 @@ import type { SelectFieldProps, SelectOption } from './types';
 export const SelectField: React.FC<SelectFieldProps> = ({
   name,
   label,
+  defaultValue,
+  initialValue,
   required,
   validate,
   readOnly,
@@ -27,6 +29,8 @@ export const SelectField: React.FC<SelectFieldProps> = ({
   const { input, meta } = useField<string | string[] | number[] | number>(name, {
     required,
     validate,
+    defaultValue,
+    initialValue,
   });
 
   const handleChange = useCallback(

--- a/javascript/packages/core/components/form/fields/select/types.ts
+++ b/javascript/packages/core/components/form/fields/select/types.ts
@@ -6,7 +6,7 @@ export interface SelectOption {
   disabled?: boolean;
 }
 
-export interface SelectFieldProps extends BaseFieldProps {
+export interface SelectFieldProps extends BaseFieldProps<string | string[] | number | number[]> {
   options: SelectOption[];
   clearable?: boolean;
   searchable?: boolean;

--- a/javascript/packages/core/components/form/fields/string/string-field.tsx
+++ b/javascript/packages/core/components/form/fields/string/string-field.tsx
@@ -5,9 +5,11 @@ import { useField } from '#core/components/form/hooks/use-field';
 
 import type { BaseFieldProps } from '#core/components/form/fields/types';
 
-export const StringField: React.FC<BaseFieldProps> = ({
+export const StringField: React.FC<BaseFieldProps<string>> = ({
   name,
   label,
+  defaultValue,
+  initialValue,
   required,
   validate,
   readOnly,
@@ -16,7 +18,12 @@ export const StringField: React.FC<BaseFieldProps> = ({
   description,
   caption,
 }) => {
-  const { input, meta } = useField<string>(name, { required, validate });
+  const { input, meta } = useField<string>(name, {
+    required,
+    validate,
+    defaultValue,
+    initialValue,
+  });
 
   return (
     <FormControl

--- a/javascript/packages/core/components/form/fields/textarea/textarea-field.tsx
+++ b/javascript/packages/core/components/form/fields/textarea/textarea-field.tsx
@@ -8,6 +8,8 @@ import type { TextareaFieldProps } from './types';
 export const TextareaField: React.FC<TextareaFieldProps> = ({
   name,
   label,
+  defaultValue,
+  initialValue,
   required,
   validate,
   readOnly,
@@ -18,7 +20,12 @@ export const TextareaField: React.FC<TextareaFieldProps> = ({
   rows,
   maxLength,
 }) => {
-  const { input, meta } = useField<string>(name, { required, validate });
+  const { input, meta } = useField<string>(name, {
+    required,
+    validate,
+    defaultValue,
+    initialValue,
+  });
   const currentLength = input.value?.length ?? 0;
 
   return (

--- a/javascript/packages/core/components/form/fields/textarea/types.ts
+++ b/javascript/packages/core/components/form/fields/textarea/types.ts
@@ -1,6 +1,6 @@
 import type { BaseFieldProps } from '../types';
 
-export interface TextareaFieldProps extends BaseFieldProps {
+export interface TextareaFieldProps extends BaseFieldProps<string> {
   rows?: number;
   maxLength?: number;
 }

--- a/javascript/packages/core/components/form/fields/types.ts
+++ b/javascript/packages/core/components/form/fields/types.ts
@@ -1,6 +1,6 @@
 import type { FieldValidator } from '#core/components/form/validation/types';
 
-export interface BaseFieldProps {
+export interface BaseFieldProps<T = unknown> {
   /** Unique ID of the field,
    *
    *  - Identifies the field input in the form
@@ -15,6 +15,18 @@ export interface BaseFieldProps {
    * Label displayed above the field
    */
   label?: string;
+
+  /**
+   * The value of the field upon creation. Previously configured values take
+   * precedence over default value.
+   */
+  defaultValue?: T;
+
+  /**
+   * The value of the field upon page load. Takes precedence over default and
+   * configured values. Can be overwritten by user modification.
+   */
+  initialValue?: T;
 
   required?: boolean;
 

--- a/javascript/packages/core/components/form/hooks/use-field.ts
+++ b/javascript/packages/core/components/form/hooks/use-field.ts
@@ -8,7 +8,7 @@ import type { FieldInput, FieldState } from '../types';
 
 export function useField<T = unknown>(
   name: string,
-  options?: { validate?: FieldValidator; required?: boolean }
+  options?: { validate?: FieldValidator; required?: boolean; defaultValue?: T; initialValue?: T }
 ): { input: FieldInput<T>; meta: FieldState } {
   const composedValidate = options?.required
     ? combineValidators(requiredValidator(), ...(options.validate ? [options.validate] : []))
@@ -16,7 +16,11 @@ export function useField<T = unknown>(
 
   const validate = composedValidate ? (value: T) => composedValidate(value as unknown) : undefined;
 
-  const field = useReactFinalFormField<T>(name, { validate });
+  const field = useReactFinalFormField<T>(name, {
+    validate,
+    defaultValue: options?.defaultValue,
+    initialValue: options?.initialValue,
+  });
 
   const input: FieldInput<T> = {
     value: field.input.value,


### PR DESCRIPTION
Currently, form fields can only be initialized via the initialValues prop provided at the Form level. This PR enables fields to manage their own initialization independently.

This PR introduces support for defaultValue and initialValue at the field level. These work alongside the existing initialValues according to a defined priority hierarchy: if multiple values are provided for the same field, the highest-priority property determines the final value. These changes and the priority logic are covered by new test cases in form.test.tsx.

The hierarchy of the properties:
`initialValue` > `initialValues` at the form level > `defaultValue`

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
- Field signatures! They now accept optional `defaultValue` and `initialValue`
- `useField` hook now passes these two properties to react-final-form's `useField` hook

<!-- Tell your future self why have you made these changes -->
**Why?**
Easy form field initialization is essential for any kind of form and we need to provide a way for our library consumer's to do this.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested in the unit test. 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
There is a possibility for an initialValue or defaultValue to not properly set in a select field but since all the options were also controlled by the user, we can leave the responsibility to the user. But this is a good point to consider when we introduce an async select field component.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
N/A

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
N/A