### PR TITLE
Fix retry error by stripping protobuf internals at request layer

### DIFF
--- a/javascript/packages/core/components/cell/renderers/retry/retry-cell.tsx
+++ b/javascript/packages/core/components/cell/renderers/retry/retry-cell.tsx
@@ -60,13 +60,10 @@ export const RetryCell = (props: CellRendererProps<string>) => {
       return;
     }
 
-    // Strip protobuf internals so toBinary() re-normalizes nested messages
-    const { $typeName: _, $unknown: __, ...specFields } = pipelineRun.spec;
-
     const updatedPipelineRun = {
       metadata: pipelineRun.metadata,
       spec: {
-        ...specFields,
+        ...pipelineRun.spec,
         retryInfo: {
           activityId: value,
           workflowId,

--- a/javascript/packages/rpc/__tests__/request.test.ts
+++ b/javascript/packages/rpc/__tests__/request.test.ts
@@ -1,0 +1,52 @@
+import { expect, it, vi } from 'vitest';
+
+import { request } from '../request';
+
+vi.mock('../handlers', () => ({
+  getRpcHandlers: vi.fn(),
+}));
+
+const { getRpcHandlers } = await import('../handlers');
+const mockGetRpcHandlers = getRpcHandlers as ReturnType<typeof vi.fn>;
+
+function mockHandler(response: unknown) {
+  mockGetRpcHandlers.mockResolvedValue({
+    GetPipelineRun: vi.fn().mockResolvedValue(response),
+  });
+}
+
+it('strips $typeName and $unknown from response', async () => {
+  mockHandler({ $typeName: 'foo.Bar', $unknown: [], name: 'test' });
+
+  expect(await request('GetPipelineRun', {} as never)).toEqual({ name: 'test' });
+});
+
+it('recursively strips protobuf internals from nested objects', async () => {
+  mockHandler({
+    $typeName: 'outer',
+    nested: { $typeName: 'inner', value: 1 },
+  });
+
+  expect(await request('GetPipelineRun', {} as never)).toEqual({ nested: { value: 1 } });
+});
+
+it('preserves Uint8Array fields without corrupting them into plain objects', async () => {
+  const bytes = new Uint8Array([1, 2, 3]);
+  mockHandler({ $typeName: 'foo.Any', typeUrl: 'type.googleapis.com/foo', value: bytes });
+
+  const result = await request('GetPipelineRun', {} as never);
+
+  expect((result as { value: Uint8Array }).value).toBeInstanceOf(Uint8Array);
+  expect((result as { value: Uint8Array }).value).toEqual(bytes);
+});
+
+it('handles arrays containing objects with protobuf internals', async () => {
+  mockHandler({
+    items: [
+      { $typeName: 'foo', x: 1 },
+      { $typeName: 'bar', x: 2 },
+    ],
+  });
+
+  expect(await request('GetPipelineRun', {} as never)).toEqual({ items: [{ x: 1 }, { x: 2 }] });
+});

--- a/javascript/packages/rpc/request.ts
+++ b/javascript/packages/rpc/request.ts
@@ -4,9 +4,12 @@ import { OmitTypeName, RpcHandlerType } from './types';
 /**
  * Makes a gRPC-web request to the Michelangelo API.
  *
+ * Responses are decoded into plain objects — protobuf internals ($typeName, $unknown)
+ * are stripped recursively.
+ *
  * @param rpcId - The ID of the RPC handler to call.
  * @param args - The arguments to pass to the RPC handler.
- * @returns A promise that resolves to the RPC response.
+ * @returns A promise that resolves to the RPC response as a plain object.
  *
  * @example
  * ```ts
@@ -18,7 +21,23 @@ import { OmitTypeName, RpcHandlerType } from './types';
 export async function request<RpcId extends keyof RpcHandlerType>(
   rpcId: RpcId,
   args: OmitTypeName<Parameters<RpcHandlerType[RpcId]>[0]>
-): Promise<Awaited<ReturnType<RpcHandlerType[RpcId]>>> {
+): Promise<OmitTypeName<Awaited<ReturnType<RpcHandlerType[RpcId]>>>> {
   const handlers = await getRpcHandlers();
-  return (await handlers[rpcId](args)) as Awaited<ReturnType<RpcHandlerType[RpcId]>>;
+  const response = (await handlers[rpcId](args)) as Awaited<ReturnType<RpcHandlerType[RpcId]>>;
+  return toPlainObject(response) as OmitTypeName<Awaited<ReturnType<RpcHandlerType[RpcId]>>>;
+}
+
+// Recursively strips protobuf internals ($typeName, $unknown) from a response,
+// returning a plain object tree that is safe to spread and reconstruct into new requests.
+function toPlainObject(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') return value;
+  if (value instanceof Uint8Array) return value; // preserve bytes fields (e.g. google.protobuf.Any.value)
+  if (Array.isArray(value)) return value.map(toPlainObject);
+
+  const result: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+    if (key === '$typeName' || key === '$unknown') continue;
+    result[key] = toPlainObject(val);
+  }
+  return result;
 }


### PR DESCRIPTION
Move protobuf stripping from call sites into the shared request layer and ensure protobuf stripping is exhaustive.

The retry flow was constructing an UpdatePipelineRun request by spreading a partially cleaned pipelineRun.spec.PipelineSpec returned by GetPipelineRun. This didn't consider nested fields that also needed cleaning.

Rather than requiring each call site to manually strip these fields, a new utility, toPlainObject() now runs centrally on every response from request(). This lets call sites spread response data directly without knowing about protobuf internals.

While implementing this, Uint8Array fields (such as google.protobuf.Any.value) were found to be vulnerable to the same object traversal — Object.entries() would corrupt them into numeric-keyed plain objects. These are now explicitly preserved.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


https://github.com/user-attachments/assets/ec10bf1b-dffd-4aa1-b62b-f10cb84d4b47




<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
