### PR TITLE
Add FormErrorBanner with field registry

### DIFF
--- a/javascript/packages/core/components/form/__tests__/form.test.tsx
+++ b/javascript/packages/core/components/form/__tests__/form.test.tsx
@@ -1,8 +1,10 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { FORM_ERROR } from 'final-form';
 import { vi } from 'vitest';
 
 import { FormDialog } from '#core/components/form/components/form-dialog/form-dialog';
+import { FormErrorBanner } from '#core/components/form/components/form-error-banner/form-error-banner';
 import { StringField } from '#core/components/form/fields/string/string-field';
 import { Form } from '#core/components/form/form';
 import { combineValidators } from '#core/components/form/validation/combine-validators';
@@ -11,418 +13,610 @@ import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
 import { getIconProviderWrapper } from '#core/test/wrappers/get-icon-provider-wrapper';
 
-describe('Form integration', () => {
-  it('submits form with multiple field values', async () => {
-    const user = userEvent.setup();
-    const onSubmit = vi.fn();
+describe('Form', () => {
+  describe('integration', () => {
+    it('submits form with multiple field values', async () => {
+      const user = userEvent.setup();
+      const onSubmit = vi.fn();
 
-    render(
-      <Form onSubmit={onSubmit}>
-        <StringField name="email" label="Email" />
-        <StringField name="name" label="Name" />
-        <button type="submit">Submit</button>
-      </Form>,
-      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
-    );
-
-    await user.type(screen.getByLabelText('Email'), 'test@example.com');
-    await user.type(screen.getByLabelText('Name'), 'John Doe');
-    await user.click(screen.getByRole('button', { name: 'Submit' }));
-
-    await waitFor(() =>
-      expect(onSubmit).toHaveBeenCalledWith(
-        {
-          email: 'test@example.com',
-          name: 'John Doe',
-        },
-        expect.anything(),
-        expect.anything()
-      )
-    );
-  });
-
-  it('provides initial values to fields', async () => {
-    const user = userEvent.setup();
-    const onSubmit = vi.fn();
-    const initialValues = { email: 'initial@example.com', name: 'Initial User' };
-
-    render(
-      <div>
-        <Form onSubmit={onSubmit} initialValues={initialValues}>
+      render(
+        <Form onSubmit={onSubmit}>
           <StringField name="email" label="Email" />
           <StringField name="name" label="Name" />
           <button type="submit">Submit</button>
-        </Form>
-      </div>,
+        </Form>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
 
-      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
-    );
+      await user.type(screen.getByLabelText('Email'), 'test@example.com');
+      await user.type(screen.getByLabelText('Name'), 'John Doe');
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
 
-    expect(screen.getByRole('textbox', { name: 'Email' })).toHaveValue('initial@example.com');
-    expect(screen.getByRole('textbox', { name: 'Name' })).toHaveValue('Initial User');
-    await user.click(screen.getByRole('button', { name: 'Submit' }));
-    await waitFor(() =>
-      expect(onSubmit).toHaveBeenCalledWith(initialValues, expect.anything(), expect.anything())
-    );
-  });
+      await waitFor(() =>
+        expect(onSubmit).toHaveBeenCalledWith(
+          {
+            email: 'test@example.com',
+            name: 'John Doe',
+          },
+          expect.anything(),
+          expect.anything()
+        )
+      );
+    });
 
-  it('populates the field with defaultValue', () => {
-    render(
-      <Form onSubmit={vi.fn()}>
-        <StringField name="email" label="Email" defaultValue="from-default" />
-      </Form>,
-      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
-    );
+    it('provides initial values to fields', async () => {
+      const user = userEvent.setup();
+      const onSubmit = vi.fn();
+      const initialValues = { email: 'initial@example.com', name: 'Initial User' };
 
-    expect(screen.getByRole('textbox', { name: 'Email' })).toHaveValue('from-default');
-  });
+      render(
+        <div>
+          <Form onSubmit={onSubmit} initialValues={initialValues}>
+            <StringField name="email" label="Email" />
+            <StringField name="name" label="Name" />
+            <button type="submit">Submit</button>
+          </Form>
+        </div>,
 
-  it('uses initialValues over defaultValue when both are provided', () => {
-    render(
-      <Form onSubmit={vi.fn()} initialValues={{ email: 'from-form' }}>
-        <StringField name="email" label="Email" defaultValue="from-default" />
-      </Form>,
-      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
-    );
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
 
-    expect(screen.getByRole('textbox', { name: 'Email' })).toHaveValue('from-form');
-  });
+      expect(screen.getByRole('textbox', { name: 'Email' })).toHaveValue('initial@example.com');
+      expect(screen.getByRole('textbox', { name: 'Name' })).toHaveValue('Initial User');
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+      await waitFor(() =>
+        expect(onSubmit).toHaveBeenCalledWith(initialValues, expect.anything(), expect.anything())
+      );
+    });
 
-  it('uses field-level initialValue over defaultValue when both are provided', () => {
-    render(
-      <Form onSubmit={vi.fn()}>
-        <StringField
-          name="email"
-          label="Email"
-          defaultValue="from-default"
-          initialValue="from-field-initial"
-        />
-      </Form>,
-      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
-    );
+    it('populates the field with defaultValue', () => {
+      render(
+        <Form onSubmit={vi.fn()}>
+          <StringField name="email" label="Email" defaultValue="from-default" />
+        </Form>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
 
-    expect(screen.getByRole('textbox', { name: 'Email' })).toHaveValue('from-field-initial');
-  });
+      expect(screen.getByRole('textbox', { name: 'Email' })).toHaveValue('from-default');
+    });
 
-  it('uses field-level initialValue when all three value sources are provided', () => {
-    render(
-      <Form onSubmit={vi.fn()} initialValues={{ email: 'from-form' }}>
-        <StringField
-          name="email"
-          label="Email"
-          defaultValue="from-default"
-          initialValue="from-field-initial"
-        />
-      </Form>,
-      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
-    );
+    it('uses initialValues over defaultValue when both are provided', () => {
+      render(
+        <Form onSubmit={vi.fn()} initialValues={{ email: 'from-form' }}>
+          <StringField name="email" label="Email" defaultValue="from-default" />
+        </Form>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
 
-    expect(screen.getByRole('textbox', { name: 'Email' })).toHaveValue('from-field-initial');
-  });
+      expect(screen.getByRole('textbox', { name: 'Email' })).toHaveValue('from-form');
+    });
 
-  it('supports external submit button via form id', async () => {
-    const user = userEvent.setup();
-    const onSubmit = vi.fn();
+    it('uses field-level initialValue over defaultValue when both are provided', () => {
+      render(
+        <Form onSubmit={vi.fn()}>
+          <StringField
+            name="email"
+            label="Email"
+            defaultValue="from-default"
+            initialValue="from-field-initial"
+          />
+        </Form>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
 
-    render(
-      <div>
-        <Form id="test-form" onSubmit={onSubmit}>
-          <StringField name="email" label="Email" />
-        </Form>
-        <button type="submit" form="test-form">
-          External Submit
-        </button>
-      </div>,
-      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
-    );
+      expect(screen.getByRole('textbox', { name: 'Email' })).toHaveValue('from-field-initial');
+    });
 
-    await user.type(screen.getByLabelText('Email'), 'test@example.com');
-    await user.click(screen.getByRole('button', { name: 'External Submit' }));
+    it('uses field-level initialValue when all three value sources are provided', () => {
+      render(
+        <Form onSubmit={vi.fn()} initialValues={{ email: 'from-form' }}>
+          <StringField
+            name="email"
+            label="Email"
+            defaultValue="from-default"
+            initialValue="from-field-initial"
+          />
+        </Form>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
 
-    await waitFor(() =>
-      expect(onSubmit).toHaveBeenCalledWith(
-        { email: 'test@example.com' },
-        expect.anything(),
-        expect.anything()
-      )
-    );
-  });
+      expect(screen.getByRole('textbox', { name: 'Email' })).toHaveValue('from-field-initial');
+    });
 
-  it('supports render prop for wrapping form element', async () => {
-    const user = userEvent.setup();
-    const onSubmit = vi.fn();
+    it('supports external submit button via form id', async () => {
+      const user = userEvent.setup();
+      const onSubmit = vi.fn();
 
-    render(
-      <Form
-        id="wrapped-form"
-        onSubmit={onSubmit}
-        render={(formElement) => (
-          <div data-testid="wrapper">
-            <div data-testid="header">Header Content</div>
-            {formElement}
-            <div data-testid="footer">Footer Content</div>
-          </div>
-        )}
-      >
-        <StringField name="email" label="Email" />
-        <button type="submit">Submit</button>
-      </Form>,
-      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
-    );
+      render(
+        <div>
+          <Form id="test-form" onSubmit={onSubmit}>
+            <StringField name="email" label="Email" />
+          </Form>
+          <button type="submit" form="test-form">
+            External Submit
+          </button>
+        </div>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
 
-    expect(screen.getByTestId('wrapper')).toBeInTheDocument();
-    expect(screen.getByTestId('header')).toHaveTextContent('Header Content');
-    expect(screen.getByTestId('footer')).toHaveTextContent('Footer Content');
-    expect(screen.getByLabelText('Email')).toBeInTheDocument();
+      await user.type(screen.getByLabelText('Email'), 'test@example.com');
+      await user.click(screen.getByRole('button', { name: 'External Submit' }));
 
-    await user.type(screen.getByLabelText('Email'), 'test@example.com');
-    await user.click(screen.getByRole('button', { name: 'Submit' }));
+      await waitFor(() =>
+        expect(onSubmit).toHaveBeenCalledWith(
+          { email: 'test@example.com' },
+          expect.anything(),
+          expect.anything()
+        )
+      );
+    });
 
-    await waitFor(() =>
-      expect(onSubmit).toHaveBeenCalledWith(
-        { email: 'test@example.com' },
-        expect.anything(),
-        expect.anything()
-      )
-    );
-  });
+    it('supports render prop for wrapping form element', async () => {
+      const user = userEvent.setup();
+      const onSubmit = vi.fn();
 
-  it('allows external submit button in render prop wrapper via form id', async () => {
-    const user = userEvent.setup();
-    const onSubmit = vi.fn();
-
-    render(
-      <Form
-        id="wrapped-form"
-        onSubmit={onSubmit}
-        render={(formElement) => (
-          <div data-testid="wrapper">
-            {formElement}
-            <div data-testid="footer">
-              <button type="submit" form="wrapped-form">
-                External Submit
-              </button>
+      render(
+        <Form
+          id="wrapped-form"
+          onSubmit={onSubmit}
+          render={(formElement) => (
+            <div data-testid="wrapper">
+              <div data-testid="header">Header Content</div>
+              {formElement}
+              <div data-testid="footer">Footer Content</div>
             </div>
-          </div>
-        )}
-      >
-        <StringField name="email" label="Email" />
-      </Form>,
-      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
-    );
+          )}
+        >
+          <StringField name="email" label="Email" />
+          <button type="submit">Submit</button>
+        </Form>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
 
-    await user.type(screen.getByLabelText('Email'), 'test@example.com');
-    await user.click(screen.getByRole('button', { name: 'External Submit' }));
+      expect(screen.getByTestId('wrapper')).toBeInTheDocument();
+      expect(screen.getByTestId('header')).toHaveTextContent('Header Content');
+      expect(screen.getByTestId('footer')).toHaveTextContent('Footer Content');
+      expect(screen.getByLabelText('Email')).toBeInTheDocument();
 
-    await waitFor(() =>
-      expect(onSubmit).toHaveBeenCalledWith(
-        { email: 'test@example.com' },
-        expect.anything(),
-        expect.anything()
-      )
-    );
-  });
-});
+      await user.type(screen.getByLabelText('Email'), 'test@example.com');
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
 
-describe('Form validation', () => {
-  it('allows submission after required field is filled', async () => {
-    const user = userEvent.setup();
-    const onSubmit = vi.fn();
+      await waitFor(() =>
+        expect(onSubmit).toHaveBeenCalledWith(
+          { email: 'test@example.com' },
+          expect.anything(),
+          expect.anything()
+        )
+      );
+    });
 
-    render(
-      <Form onSubmit={onSubmit}>
-        <StringField name="username" label="Username" required />
-        <button type="submit">Submit</button>
-      </Form>,
-      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
-    );
+    it('allows external submit button in render prop wrapper via form id', async () => {
+      const user = userEvent.setup();
+      const onSubmit = vi.fn();
 
-    await user.click(screen.getByRole('button', { name: 'Submit' }));
-    expect(await screen.findByText('This field is required.')).toBeInTheDocument();
+      render(
+        <Form
+          id="wrapped-form"
+          onSubmit={onSubmit}
+          render={(formElement) => (
+            <div data-testid="wrapper">
+              {formElement}
+              <div data-testid="footer">
+                <button type="submit" form="wrapped-form">
+                  External Submit
+                </button>
+              </div>
+            </div>
+          )}
+        >
+          <StringField name="email" label="Email" />
+        </Form>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
 
-    await user.type(screen.getByRole('textbox', { name: 'Username *' }), 'johndoe');
-    await user.click(screen.getByRole('button', { name: 'Submit' }));
+      await user.type(screen.getByLabelText('Email'), 'test@example.com');
+      await user.click(screen.getByRole('button', { name: 'External Submit' }));
 
-    await waitFor(() =>
-      expect(onSubmit).toHaveBeenCalledWith(
-        { username: 'johndoe' },
-        expect.anything(),
-        expect.anything()
-      )
-    );
-  });
-
-  it('shows first error when composed validators fail sequentially', async () => {
-    const user = userEvent.setup();
-    const onSubmit = vi.fn();
-
-    render(
-      <Form onSubmit={onSubmit}>
-        <StringField
-          name="username"
-          label="Username"
-          required
-          validate={combineValidators(required(), minLength(6))}
-        />
-        <button type="submit">Submit</button>
-      </Form>,
-      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
-    );
-
-    await user.click(screen.getByRole('button', { name: 'Submit' }));
-    expect(await screen.findByText('This field is required.')).toBeInTheDocument();
-    expect(onSubmit).not.toHaveBeenCalled();
-
-    await user.type(screen.getByRole('textbox', { name: 'Username *' }), 'abc');
-    await user.click(screen.getByRole('button', { name: 'Submit' }));
-
-    expect(await screen.findByText('Must be at least 6 characters.')).toBeInTheDocument();
-    expect(onSubmit).not.toHaveBeenCalled();
-  });
-
-  it('focuses first field with error on failed submit', async () => {
-    const user = userEvent.setup();
-
-    render(
-      <Form onSubmit={vi.fn()}>
-        <StringField name="email" label="Email" required />
-        <StringField name="name" label="Name" required />
-        <button type="submit">Submit</button>
-      </Form>,
-      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
-    );
-
-    await user.click(screen.getByRole('button', { name: 'Submit' }));
-
-    await waitFor(() => {
-      expect(document.activeElement).toBe(screen.getByRole('textbox', { name: 'Email *' }));
+      await waitFor(() =>
+        expect(onSubmit).toHaveBeenCalledWith(
+          { email: 'test@example.com' },
+          expect.anything(),
+          expect.anything()
+        )
+      );
     });
   });
-});
 
-describe('FormDialog', () => {
-  const defaultProps = {
-    isOpen: true,
-    onDismiss: vi.fn(),
-    heading: 'Test Dialog',
-    onSubmit: vi.fn(),
-  };
+  describe('validation', () => {
+    it('allows submission after required field is filled', async () => {
+      const user = userEvent.setup();
+      const onSubmit = vi.fn();
 
-  beforeEach(() => {
-    vi.clearAllMocks();
+      render(
+        <Form onSubmit={onSubmit}>
+          <StringField name="username" label="Username" required />
+          <button type="submit">Submit</button>
+        </Form>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+      expect(await screen.findByText('This field is required.')).toBeInTheDocument();
+
+      await user.type(screen.getByRole('textbox', { name: 'Username *' }), 'johndoe');
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await waitFor(() =>
+        expect(onSubmit).toHaveBeenCalledWith(
+          { username: 'johndoe' },
+          expect.anything(),
+          expect.anything()
+        )
+      );
+    });
+
+    it('shows first error when composed validators fail sequentially', async () => {
+      const user = userEvent.setup();
+      const onSubmit = vi.fn();
+
+      render(
+        <Form onSubmit={onSubmit}>
+          <StringField
+            name="username"
+            label="Username"
+            required
+            validate={combineValidators(required(), minLength(6))}
+          />
+          <button type="submit">Submit</button>
+        </Form>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+      expect(await screen.findByText('This field is required.')).toBeInTheDocument();
+      expect(onSubmit).not.toHaveBeenCalled();
+
+      await user.type(screen.getByRole('textbox', { name: 'Username *' }), 'abc');
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      expect(await screen.findByText('Must be at least 6 characters.')).toBeInTheDocument();
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('focuses first field with error on failed submit', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <Form onSubmit={vi.fn()}>
+          <StringField name="email" label="Email" required />
+          <StringField name="name" label="Name" required />
+          <button type="submit">Submit</button>
+        </Form>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await waitFor(() => {
+        expect(document.activeElement).toBe(screen.getByRole('textbox', { name: 'Email *' }));
+      });
+    });
   });
 
-  it('renders dialog with form when open', async () => {
-    render(
-      <FormDialog {...defaultProps}>
-        <StringField name="email" label="Email" />
-      </FormDialog>,
-      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
-    );
+  describe('error display', () => {
+    const wrapper = buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()]);
 
-    await screen.findByRole('dialog', { name: 'Test Dialog' });
-    expect(screen.getByLabelText('Email')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Submit' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
-  });
-
-  it('does not render when closed', async () => {
-    render(
-      <FormDialog {...defaultProps} isOpen={false}>
-        <StringField name="email" label="Email" />
-      </FormDialog>,
-      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
-    );
-
-    try {
-      await screen.findByRole('dialog', {}, { timeout: 100 });
-      throw new Error('Dialog should not be in the document');
-    } catch (e: unknown) {
-      if (e instanceof Error) {
-        if (e.name !== 'TestingLibraryElementError') throw e;
-      } else {
-        throw e;
-      }
-
-      // Success!
+    function getErrorEntry(banner: HTMLElement, label: string, errorMessage: string) {
+      const labelButton = within(banner).getByRole('button', { name: label });
+      const entry = labelButton.closest('div')!;
+      expect(entry).toHaveTextContent(errorMessage);
+      return entry;
     }
-  });
 
-  it('submits form data and auto-closes on success', async () => {
-    const user = userEvent.setup();
-    const onSubmit = vi.fn().mockResolvedValue(undefined);
-    const onDismiss = vi.fn();
+    it('shows errors after failed submit', async () => {
+      const user = userEvent.setup();
 
-    render(
-      <FormDialog {...defaultProps} onSubmit={onSubmit} onDismiss={onDismiss}>
-        <StringField name="email" label="Email" />
-      </FormDialog>,
-      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
-    );
+      render(
+        <Form onSubmit={vi.fn()}>
+          <StringField name="email" label="Email Address" required />
+          <FormErrorBanner />
+          <button type="submit">Submit</button>
+        </Form>,
+        wrapper
+      );
 
-    await user.type(screen.getByLabelText('Email'), 'test@example.com');
-    await user.click(screen.getByRole('button', { name: 'Submit' }));
+      expect(screen.queryByRole('complementary')).not.toBeInTheDocument();
 
-    await waitFor(() => {
-      expect(onSubmit).toHaveBeenCalledWith({ email: 'test@example.com' });
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+      const banner = await screen.findByRole('complementary');
+      expect(banner).toHaveTextContent('This field is required.');
     });
 
-    await waitFor(() => {
+    it('clears errors when field is corrected', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <Form onSubmit={vi.fn()}>
+          <StringField name="email" label="Email Address" required />
+          <FormErrorBanner />
+          <button type="submit">Submit</button>
+        </Form>,
+        wrapper
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+      expect(await screen.findByRole('complementary')).toBeInTheDocument();
+
+      await user.type(screen.getByRole('textbox', { name: 'Email Address *' }), 'test@example.com');
+
+      await waitFor(() => {
+        expect(screen.queryByRole('complementary')).not.toBeInTheDocument();
+      });
+    });
+
+    it('focuses the correct field when clicking a label among multiple errors', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <Form onSubmit={vi.fn()}>
+          <StringField name="email" label="Email" required />
+          <StringField name="name" label="Name" required />
+          <FormErrorBanner />
+          <button type="submit">Submit</button>
+        </Form>,
+        wrapper
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      const banner = await screen.findByRole('complementary');
+      await user.click(within(banner).getByText('Name'));
+
+      expect(document.activeElement).toBe(screen.getByRole('textbox', { name: 'Name *' }));
+      expect(document.activeElement).not.toBe(screen.getByRole('textbox', { name: 'Email *' }));
+    });
+
+    it('does not show a clickable button for form-level errors', async () => {
+      const user = userEvent.setup();
+      const onSubmit = vi.fn().mockResolvedValue({ [FORM_ERROR]: 'Something went wrong' });
+
+      render(
+        <Form onSubmit={onSubmit}>
+          <StringField name="email" label="Email" />
+          <FormErrorBanner />
+          <button type="submit">Submit</button>
+        </Form>,
+        wrapper
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      const banner = await screen.findByRole('complementary');
+      expect(banner).toHaveTextContent('Something went wrong');
+      expect(within(banner).queryByRole('button')).not.toBeInTheDocument();
+    });
+
+    it('shows separate errors for sibling fields in the same nested object', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <Form onSubmit={vi.fn()}>
+          <StringField name="address.street" label="Street" required />
+          <StringField name="address.city" label="City" required />
+          <FormErrorBanner />
+          <button type="submit">Submit</button>
+        </Form>,
+        wrapper
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      const banner = await screen.findByRole('complementary');
+      getErrorEntry(banner, 'Street', 'This field is required.');
+      getErrorEntry(banner, 'City', 'This field is required.');
+    });
+
+    it('shows form-level error alongside field validation errors', async () => {
+      const user = userEvent.setup();
+      const onSubmit = vi.fn().mockResolvedValue({ [FORM_ERROR]: 'Server unavailable' });
+
+      render(
+        <Form onSubmit={onSubmit}>
+          <StringField name="email" label="Email" required />
+          <FormErrorBanner />
+          <button type="submit">Submit</button>
+        </Form>,
+        wrapper
+      );
+
+      // First submit — field error fires, onSubmit is never called because validation blocks it
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+      const banner = await screen.findByRole('complementary');
+      getErrorEntry(banner, 'Email', 'This field is required.');
+
+      // Fill the field and resubmit — now onSubmit is called and returns server error
+      await user.type(screen.getByRole('textbox', { name: 'Email *' }), 'test@example.com');
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      expect(await screen.findByText(/Server unavailable/)).toBeInTheDocument();
+    });
+
+    it('removes only the corrected field error when one of multiple errors is fixed', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <Form onSubmit={vi.fn()}>
+          <StringField name="email" label="Email" required />
+          <StringField name="name" label="Name" required />
+          <FormErrorBanner />
+          <button type="submit">Submit</button>
+        </Form>,
+        wrapper
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+      const banner = await screen.findByRole('complementary');
+
+      getErrorEntry(banner, 'Email', 'This field is required.');
+      getErrorEntry(banner, 'Name', 'This field is required.');
+
+      // Fix only the email field
+      await user.type(screen.getByRole('textbox', { name: 'Email *' }), 'test@example.com');
+
+      await waitFor(() => {
+        expect(
+          within(screen.getByRole('complementary')).queryByText('Email')
+        ).not.toBeInTheDocument();
+      });
+
+      // Name entry still present with label and error together
+      getErrorEntry(screen.getByRole('complementary'), 'Name', 'This field is required.');
+    });
+
+    it('shows error without label when field has no label', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <Form onSubmit={vi.fn()}>
+          <StringField name="username" required />
+          <FormErrorBanner />
+          <button type="submit">Submit</button>
+        </Form>,
+        wrapper
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      const errorDisplay = await screen.findByRole('complementary');
+      expect(within(errorDisplay).getByText('This field is required.')).toBeInTheDocument();
+      expect(within(errorDisplay).queryByRole('button')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('FormDialog', () => {
+    const defaultProps = {
+      isOpen: true,
+      onDismiss: vi.fn(),
+      heading: 'Test Dialog',
+      onSubmit: vi.fn(),
+    };
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('renders dialog with form when open', async () => {
+      render(
+        <FormDialog {...defaultProps}>
+          <StringField name="email" label="Email" />
+        </FormDialog>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
+
+      await screen.findByRole('dialog', { name: 'Test Dialog' });
+      expect(screen.getByLabelText('Email')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Submit' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    });
+
+    it('does not render when closed', async () => {
+      render(
+        <FormDialog {...defaultProps} isOpen={false}>
+          <StringField name="email" label="Email" />
+        </FormDialog>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
+
+      try {
+        await screen.findByRole('dialog', {}, { timeout: 100 });
+        throw new Error('Dialog should not be in the document');
+      } catch (e: unknown) {
+        if (e instanceof Error) {
+          if (e.name !== 'TestingLibraryElementError') throw e;
+        } else {
+          throw e;
+        }
+
+        // Success!
+      }
+    });
+
+    it('submits form data and auto-closes on success', async () => {
+      const user = userEvent.setup();
+      const onSubmit = vi.fn().mockResolvedValue(undefined);
+      const onDismiss = vi.fn();
+
+      render(
+        <FormDialog {...defaultProps} onSubmit={onSubmit} onDismiss={onDismiss}>
+          <StringField name="email" label="Email" />
+        </FormDialog>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
+
+      await user.type(screen.getByLabelText('Email'), 'test@example.com');
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledWith({ email: 'test@example.com' });
+      });
+
+      await waitFor(() => {
+        expect(onDismiss).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('calls onDismiss when cancel is clicked', async () => {
+      const user = userEvent.setup();
+      const onDismiss = vi.fn();
+
+      render(
+        <FormDialog {...defaultProps} onDismiss={onDismiss}>
+          <StringField name="email" label="Email" />
+        </FormDialog>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Cancel' }));
       expect(onDismiss).toHaveBeenCalledTimes(1);
     });
-  });
 
-  it('calls onDismiss when cancel is clicked', async () => {
-    const user = userEvent.setup();
-    const onDismiss = vi.fn();
+    it('handles submit errors without auto-closing', async () => {
+      const user = userEvent.setup();
+      const onSubmit = vi.fn().mockRejectedValue(new Error('Submit failed'));
+      const onDismiss = vi.fn();
 
-    render(
-      <FormDialog {...defaultProps} onDismiss={onDismiss}>
-        <StringField name="email" label="Email" />
-      </FormDialog>,
-      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
-    );
+      render(
+        <FormDialog {...defaultProps} onSubmit={onSubmit} onDismiss={onDismiss}>
+          <StringField name="email" label="Email" />
+        </FormDialog>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
 
-    await user.click(screen.getByRole('button', { name: 'Cancel' }));
-    expect(onDismiss).toHaveBeenCalledTimes(1);
-  });
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
 
-  it('handles submit errors without auto-closing', async () => {
-    const user = userEvent.setup();
-    const onSubmit = vi.fn().mockRejectedValue(new Error('Submit failed'));
-    const onDismiss = vi.fn();
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalled();
+      });
 
-    render(
-      <FormDialog {...defaultProps} onSubmit={onSubmit} onDismiss={onDismiss}>
-        <StringField name="email" label="Email" />
-      </FormDialog>,
-      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
-    );
-
-    await user.click(screen.getByRole('button', { name: 'Submit' }));
-
-    await waitFor(() => {
-      expect(onSubmit).toHaveBeenCalled();
+      expect(onDismiss).not.toHaveBeenCalled();
+      expect(screen.getByRole('dialog', { name: 'Test Dialog' })).toBeInTheDocument();
+      await screen.findByText(/Submit failed/);
     });
 
-    expect(onDismiss).not.toHaveBeenCalled();
-    expect(screen.getByRole('dialog', { name: 'Test Dialog' })).toBeInTheDocument();
-    await screen.findByText(/Submit failed/);
-  });
+    it('supports custom submit label and initial values', () => {
+      render(
+        <FormDialog
+          {...defaultProps}
+          submitLabel="Create Item"
+          initialValues={{ email: 'preset@example.com' }}
+        >
+          <StringField name="email" label="Email" />
+        </FormDialog>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
 
-  it('supports custom submit label and initial values', () => {
-    render(
-      <FormDialog
-        {...defaultProps}
-        submitLabel="Create Item"
-        initialValues={{ email: 'preset@example.com' }}
-      >
-        <StringField name="email" label="Email" />
-      </FormDialog>,
-      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
-    );
-
-    expect(screen.getByRole('button', { name: 'Create Item' })).toBeInTheDocument();
-    expect(screen.getByRole('textbox', { name: 'Email' })).toHaveValue('preset@example.com');
+      expect(screen.getByRole('button', { name: 'Create Item' })).toBeInTheDocument();
+      expect(screen.getByRole('textbox', { name: 'Email' })).toHaveValue('preset@example.com');
+    });
   });
 });

--- a/javascript/packages/core/components/form/components/form-dialog/form-dialog.tsx
+++ b/javascript/packages/core/components/form/components/form-dialog/form-dialog.tsx
@@ -4,7 +4,7 @@ import { PLACEMENT, SIZE } from 'baseui/dialog';
 import { FORM_ERROR } from 'final-form';
 
 import { Dialog } from '#core/components/dialog/dialog';
-import { FormErrorBanner } from '#core/components/form/components/form-error-banner';
+import { FormErrorBanner } from '#core/components/form/components/form-error-banner/form-error-banner';
 import { SubmitButton } from '#core/components/form/components/submit-button/submit-button';
 import { Form } from '#core/components/form/form';
 

--- a/javascript/packages/core/components/form/components/form-error-banner.tsx
+++ b/javascript/packages/core/components/form/components/form-error-banner.tsx
@@ -1,8 +1,0 @@
-import { useFormState } from '#core/components/form/hooks/use-form-state';
-
-// TODO: add error banner display styling
-export function FormErrorBanner() {
-  const { submitError } = useFormState({ submitError: true });
-
-  return submitError ? <span>{String(submitError)}</span> : null;
-}

--- a/javascript/packages/core/components/form/components/form-error-banner/form-error-banner.tsx
+++ b/javascript/packages/core/components/form/components/form-error-banner/form-error-banner.tsx
@@ -1,0 +1,51 @@
+import { useStyletron } from 'baseui';
+import { StyledLink } from 'baseui/link';
+
+import { Banner } from '#core/components/banner/banner';
+import { Markdown } from '#core/components/markdown/markdown';
+import { useFormErrorList } from './use-form-error-list';
+
+import type { ErrorEntry } from './types';
+
+/** Renders a banner containing form submission errors and validation errors
+ * with clickable links to the fields that have errors.
+ *
+ * Supports Markdown for the error message.
+ *
+ * @requires Must be rendered within a `<Form>` component
+ */
+export function FormErrorBanner() {
+  const [css, theme] = useStyletron();
+  const errors = useFormErrorList();
+
+  if (errors.length === 0) return null;
+
+  return (
+    <Banner kind="negative">
+      {errors.map((entry: ErrorEntry) => (
+        <div
+          key={entry.fieldPath}
+          className={css({ ...theme.typography.ParagraphSmall, textAlign: 'left' })}
+        >
+          {entry.fieldLabel && (
+            <StyledLink
+              $as="button"
+              type="button"
+              onClick={entry.focus}
+              className={css({
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+                padding: '0',
+              })}
+            >
+              {entry.fieldLabel}
+            </StyledLink>
+          )}
+          {entry.fieldLabel && entry.errorMessage && <>&nbsp;</>}
+          <Markdown>{entry.errorMessage}</Markdown>
+        </div>
+      ))}
+    </Banner>
+  );
+}

--- a/javascript/packages/core/components/form/components/form-error-banner/types.ts
+++ b/javascript/packages/core/components/form/components/form-error-banner/types.ts
@@ -1,0 +1,8 @@
+export type ErrorEntry = {
+  fieldPath: string;
+  fieldLabel?: string;
+
+  // Supports Markdown
+  errorMessage: string;
+  focus?: () => void;
+};

--- a/javascript/packages/core/components/form/components/form-error-banner/use-form-error-list.ts
+++ b/javascript/packages/core/components/form/components/form-error-banner/use-form-error-list.ts
@@ -1,0 +1,45 @@
+import { FORM_ERROR } from 'final-form';
+
+import { useFormContext } from '#core/components/form/form-context';
+import { useFormState } from '#core/components/form/hooks/use-form-state';
+import { toFlatDotPathMap } from '#core/utils/object-utils';
+
+import type { ErrorEntry } from './types';
+
+/**
+ * @returns A list of error entries for the form, including form-level
+ * submission errors and field-level validation errors.
+ */
+export function useFormErrorList(): ErrorEntry[] {
+  const { fieldRegistry } = useFormContext();
+  const { submitErrors, errors, touched } = useFormState({
+    submitErrors: true,
+    errors: true,
+    touched: true,
+  });
+
+  const formLevelError = submitErrors?.[FORM_ERROR] as Error | undefined;
+  const formLevelEntry: ErrorEntry[] = formLevelError
+    ? [{ fieldPath: FORM_ERROR, errorMessage: String(formLevelError) }]
+    : [];
+
+  if (!errors) return formLevelEntry;
+
+  const fieldEntries: ErrorEntry[] = [];
+
+  for (const [fieldPath, errorMessage] of Object.entries(toFlatDotPathMap(errors))) {
+    if (typeof errorMessage !== 'string') continue;
+    if (!touched?.[fieldPath]) continue;
+
+    fieldEntries.push({
+      fieldPath,
+      fieldLabel: fieldRegistry.get(fieldPath)?.label,
+      errorMessage,
+      focus: () => {
+        document.querySelector<HTMLElement>(`[name="${fieldPath}"]`)?.focus();
+      },
+    });
+  }
+
+  return [...formLevelEntry, ...fieldEntries];
+}

--- a/javascript/packages/core/components/form/fields/boolean/boolean-field.tsx
+++ b/javascript/packages/core/components/form/fields/boolean/boolean-field.tsx
@@ -26,6 +26,7 @@ export const BooleanField: React.FC<BooleanFieldProps> = ({
     validate,
     defaultValue,
     initialValue,
+    label,
   });
 
   const handleChange = (event: React.FormEvent<HTMLInputElement>) => {

--- a/javascript/packages/core/components/form/fields/radio/card-radio-field.tsx
+++ b/javascript/packages/core/components/form/fields/radio/card-radio-field.tsx
@@ -35,6 +35,7 @@ export const CardRadioField: React.FC<RadioFieldProps> = ({
     validate,
     defaultValue,
     initialValue,
+    label,
   });
 
   const selectedIndex = useMemo(

--- a/javascript/packages/core/components/form/fields/radio/inline-radio-field.tsx
+++ b/javascript/packages/core/components/form/fields/radio/inline-radio-field.tsx
@@ -27,6 +27,7 @@ export const InlineRadioField: React.FC<RadioFieldProps> = ({
     validate,
     defaultValue,
     initialValue,
+    label,
   });
 
   const isBoolean = options.every(({ value }) => typeof value === 'boolean');

--- a/javascript/packages/core/components/form/fields/select/select-field.tsx
+++ b/javascript/packages/core/components/form/fields/select/select-field.tsx
@@ -31,6 +31,7 @@ export const SelectField: React.FC<SelectFieldProps> = ({
     validate,
     defaultValue,
     initialValue,
+    label,
   });
 
   const handleChange = useCallback(

--- a/javascript/packages/core/components/form/fields/string/string-field.tsx
+++ b/javascript/packages/core/components/form/fields/string/string-field.tsx
@@ -23,6 +23,7 @@ export const StringField: React.FC<BaseFieldProps<string>> = ({
     validate,
     defaultValue,
     initialValue,
+    label,
   });
 
   return (

--- a/javascript/packages/core/components/form/fields/textarea/textarea-field.tsx
+++ b/javascript/packages/core/components/form/fields/textarea/textarea-field.tsx
@@ -25,6 +25,7 @@ export const TextareaField: React.FC<TextareaFieldProps> = ({
     validate,
     defaultValue,
     initialValue,
+    label,
   });
   const currentLength = input.value?.length ?? 0;
 

--- a/javascript/packages/core/components/form/form-context.ts
+++ b/javascript/packages/core/components/form/form-context.ts
@@ -1,0 +1,11 @@
+import { createContext, useContext } from 'react';
+
+import type { FormInstance } from './types';
+
+export const FormContext = createContext<FormInstance | null>(null);
+
+export function useFormContext(): FormInstance {
+  const formContext = useContext(FormContext);
+  if (!formContext) throw new Error('useFormContext must be used within a <Form>');
+  return formContext;
+}

--- a/javascript/packages/core/components/form/form.tsx
+++ b/javascript/packages/core/components/form/form.tsx
@@ -1,8 +1,11 @@
+import { useRef } from 'react';
 import { Form as FinalForm } from 'react-final-form';
 import { useStyletron } from 'baseui';
 import createFocusOnErrorDecorator from 'final-form-focus';
 
-import type { FormData, FormProps } from './types';
+import { FormContext } from './form-context';
+
+import type { FieldRegistry, FormData, FormProps } from './types';
 
 const focusOnErrorDecorator = createFocusOnErrorDecorator();
 
@@ -15,33 +18,36 @@ export const Form = <FieldValues extends FormData = FormData>({
   focusOnError = true,
 }: FormProps<FieldValues>) => {
   const [css, theme] = useStyletron();
+  const registryRef = useRef<FieldRegistry>(new Map());
 
   return (
-    <FinalForm
-      onSubmit={onSubmit}
-      initialValues={initialValues}
-      decorators={focusOnError ? [focusOnErrorDecorator] : undefined}
-      render={({ handleSubmit }) => {
-        const formElement = (
-          <form
-            className={css({
-              display: 'flex',
-              flexDirection: 'column',
-              gap: theme.sizing.scale600,
-            })}
-            id={id}
-            // react-final-form internally uses a promise to handle the form submission
-            // so we need to disable the eslint rule. I tested the execution of handleSubmit
-            // and it is synchronous.
-            // eslint-disable-next-line @typescript-eslint/no-misused-promises
-            onSubmit={handleSubmit}
-          >
-            {children}
-          </form>
-        );
+    <FormContext.Provider value={{ fieldRegistry: registryRef.current }}>
+      <FinalForm
+        onSubmit={onSubmit}
+        initialValues={initialValues}
+        decorators={focusOnError ? [focusOnErrorDecorator] : undefined}
+        render={({ handleSubmit }) => {
+          const formElement = (
+            <form
+              className={css({
+                display: 'flex',
+                flexDirection: 'column',
+                gap: theme.sizing.scale600,
+              })}
+              id={id}
+              // react-final-form internally uses a promise to handle the form submission
+              // so we need to disable the eslint rule. I tested the execution of handleSubmit
+              // and it is synchronous.
+              // eslint-disable-next-line @typescript-eslint/no-misused-promises
+              onSubmit={handleSubmit}
+            >
+              {children}
+            </form>
+          );
 
-        return render ? render(formElement) : formElement;
-      }}
-    />
+          return render ? render(formElement) : formElement;
+        }}
+      />
+    </FormContext.Provider>
   );
 };

--- a/javascript/packages/core/components/form/hooks/use-field-registration.ts
+++ b/javascript/packages/core/components/form/hooks/use-field-registration.ts
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+
+import { useFormContext } from '#core/components/form/form-context';
+
+export function useFieldRegistration(name: string, label: string | undefined): void {
+  const { fieldRegistry } = useFormContext();
+
+  useEffect(() => {
+    if (label) fieldRegistry.set(name, { label });
+    return () => {
+      fieldRegistry.delete(name);
+    };
+  }, [name, label, fieldRegistry]);
+}

--- a/javascript/packages/core/components/form/hooks/use-field.ts
+++ b/javascript/packages/core/components/form/hooks/use-field.ts
@@ -1,5 +1,6 @@
 import { useField as useReactFinalFormField } from 'react-final-form';
 
+import { useFieldRegistration } from '#core/components/form/hooks/use-field-registration';
 import { combineValidators } from '#core/components/form/validation/combine-validators';
 import { required as requiredValidator } from '#core/components/form/validation/validators';
 
@@ -8,8 +9,16 @@ import type { FieldInput, FieldState } from '../types';
 
 export function useField<T = unknown>(
   name: string,
-  options?: { validate?: FieldValidator; required?: boolean; defaultValue?: T; initialValue?: T }
+  options?: {
+    validate?: FieldValidator;
+    required?: boolean;
+    defaultValue?: T;
+    initialValue?: T;
+    label?: string;
+  }
 ): { input: FieldInput<T>; meta: FieldState } {
+  useFieldRegistration(name, options?.label);
+
   const composedValidate = options?.required
     ? combineValidators(requiredValidator(), ...(options.validate ? [options.validate] : []))
     : options?.validate;

--- a/javascript/packages/core/components/form/hooks/use-form-state.ts
+++ b/javascript/packages/core/components/form/hooks/use-form-state.ts
@@ -34,6 +34,12 @@ export function useFormState<FieldValues extends FormData = FormData>(
         submitting: subscription.submitting,
         submitError: subscription.submitError,
         values: subscription.values,
+        submitFailed: subscription.submitFailed,
+        hasValidationErrors: subscription.hasValidationErrors,
+        errors: subscription.errors,
+        submitErrors: subscription.submitErrors,
+        touched: subscription.touched,
+        modifiedSinceLastSubmit: subscription.modifiedSinceLastSubmit,
       }
     : undefined;
 
@@ -45,5 +51,11 @@ export function useFormState<FieldValues extends FormData = FormData>(
     submitting: formState.submitting,
     submitError: formState.submitError as unknown,
     values: formState.values as FieldValues | undefined,
+    submitFailed: formState.submitFailed,
+    hasValidationErrors: formState.hasValidationErrors,
+    errors: formState.errors as Record<string, unknown> | undefined,
+    submitErrors: formState.submitErrors as Record<string, unknown> | undefined,
+    touched: formState.touched as Record<string, boolean> | undefined,
+    modifiedSinceLastSubmit: formState.modifiedSinceLastSubmit,
   } as FormState<FieldValues> | Partial<FormState<FieldValues>>;
 }

--- a/javascript/packages/core/components/form/types.ts
+++ b/javascript/packages/core/components/form/types.ts
@@ -50,10 +50,20 @@ export interface FormProps<FieldValues extends FormData = FormData> {
   render?: (formElement: React.ReactNode) => React.ReactNode;
 }
 
+export interface FormInstance {
+  fieldRegistry: FieldRegistry;
+}
+
 export interface FormState<FieldValues extends FormData = FormData> {
   submitting: boolean;
   submitError?: string;
   values?: FieldValues;
+  submitFailed?: boolean;
+  hasValidationErrors?: boolean;
+  errors?: Record<string, unknown>;
+  submitErrors?: Record<string, unknown>;
+  touched?: Record<string, boolean>;
+  modifiedSinceLastSubmit?: boolean;
 }
 
 export interface FieldState {
@@ -67,3 +77,7 @@ export interface FieldInput<T = unknown> {
   onChange: (value: T) => void;
   onBlur: () => void;
 }
+
+export type FieldRegistry = Map<string, FieldRegistryEntry>;
+
+export type FieldRegistryEntry = { label: string };

--- a/javascript/packages/core/components/views/sandbox/sandbox.tsx
+++ b/javascript/packages/core/components/views/sandbox/sandbox.tsx
@@ -6,6 +6,7 @@ import { Tab, Tabs } from 'baseui/tabs';
 import { HeadingXXLarge, LabelLarge, ParagraphSmall } from 'baseui/typography';
 
 import { CellType } from '#core/components/cell/constants';
+import { FormErrorBanner } from '#core/components/form/components/form-error-banner/form-error-banner';
 import { SelectField } from '#core/components/form/fields/select/select-field';
 import { StringField } from '#core/components/form/fields/string/string-field';
 import { Form } from '#core/components/form/form';
@@ -321,6 +322,7 @@ export function Sandbox() {
                 <StringField name="slackHandle" label="Slack Handle" validate={required()} />
               </FormGroup>
 
+              <FormErrorBanner />
               <Block display="flex" justifyContent="flex-end" marginTop="scale600">
                 <Button type="submit">Submit — watch it scroll on error</Button>
               </Block>

--- a/javascript/packages/core/utils/__tests__/object-utils.tests.ts
+++ b/javascript/packages/core/utils/__tests__/object-utils.tests.ts
@@ -1,6 +1,38 @@
-import { getObjectSymbols, getObjectValue } from '../object-utils';
+import { getObjectSymbols, getObjectValue, toFlatDotPathMap } from '../object-utils';
 
 describe('object-utils', () => {
+  describe('toFlatDotPathMap', () => {
+    it('flattens a nested object into dot-notation keys', () => {
+      expect(toFlatDotPathMap({ address: { street: 'Main St', city: 'Boston' } })).toEqual({
+        'address.street': 'Main St',
+        'address.city': 'Boston',
+      });
+    });
+
+    it('handles deeply nested objects', () => {
+      expect(toFlatDotPathMap({ a: { b: { c: 'value' } } })).toEqual({ 'a.b.c': 'value' });
+    });
+
+    it('uses bracket notation for array indices', () => {
+      expect(toFlatDotPathMap({ items: [{ name: 'item1' }, { name: 'item2' }] })).toEqual({
+        'items[0].name': 'item1',
+        'items[1].name': 'item2',
+      });
+    });
+
+    it('handles mixed nesting of objects and arrays', () => {
+      expect(toFlatDotPathMap({ a: { b: [{ c: 'value' }] } })).toEqual({ 'a.b[0].c': 'value' });
+    });
+
+    it('returns leaf values of any type', () => {
+      expect(toFlatDotPathMap({ a: 1, b: true, c: null })).toEqual({ a: 1, b: true, c: null });
+    });
+
+    it('returns an empty object for an empty input', () => {
+      expect(toFlatDotPathMap({})).toEqual({});
+    });
+  });
+
   describe('getObjectValue', () => {
     const testObject = {
       name: 'John',

--- a/javascript/packages/core/utils/object-utils.ts
+++ b/javascript/packages/core/utils/object-utils.ts
@@ -2,6 +2,36 @@ import { get } from 'lodash';
 
 import type { Accessor } from '#core/types/common/studio-types';
 
+/**
+ * Recursively flattens a nested object into a flat map with dot-notation keys.
+ * Numeric keys (array indices) are formatted with bracket notation.
+ *
+ * @example toFlatDotPathMap({ address: { street: 'Main St' } })
+ * @returns { 'address.street': 'Main St' }
+ *
+ * @example toFlatDotPathMap({ items: [{ name: 'item1' }, { name: 'item2' }] })
+ * @returns { 'items[0].name': 'item1', 'items[1].name': 'item2' }
+ */
+export function toFlatDotPathMap(
+  obj: Record<string, unknown>,
+  prefix = ''
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(obj)) {
+    const isIndex = /^\d+$/.test(key);
+    const path = prefix ? (isIndex ? `${prefix}[${key}]` : `${prefix}.${key}`) : key;
+
+    if (value !== null && typeof value === 'object') {
+      Object.assign(result, toFlatDotPathMap(value as Record<string, unknown>, path));
+    } else {
+      result[path] = value;
+    }
+  }
+
+  return result;
+}
+
 export function getObjectValue<K>(
   obj: unknown,
   accessor: Accessor<K>,


### PR DESCRIPTION
Introduce a component that surfaces all validation errors on submit in a single banner, with clickable field labels that focus the relevant input.

Forms with many fields, particularly long scrollable ones, have no way to surface all validation errors at once — users must hunt for red inline errors. The banner solves this by collecting all touched field errors into one place after submit.

To show human-readable labels in the banner, fields needed a way to register themselves with their label. Added a FormContext that contains a field registry that lets each field self-register on mount and unregister on unmount, without coupling fields to the banner.

FormState was also missing several final-form subscriptions needed to drive the banner. These are now exposed through useFormState.

A shared toFlatDotPathMap utility handles flattening the nested final-form errors object into dot/bracket-notation path keys, supporting both plain objects and arrays.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
https://github.com/user-attachments/assets/dfc903a7-e011-4e91-9e4f-177b21a56894



<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
