### PR TITLE
Extend select field component

### DIFF
--- a/javascript/packages/core/components/form/fields/select/__tests__/select-field.test.tsx
+++ b/javascript/packages/core/components/form/fields/select/__tests__/select-field.test.tsx
@@ -311,4 +311,142 @@ describe('SelectField', () => {
 
     expect(screen.getByText('Choose the appropriate priority level')).toBeInTheDocument();
   });
+
+  it('submits object id as the field value', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    const objectOptions = [
+      { id: { tier: 'free', limit: 100 }, label: 'Free Tier' },
+      { id: { tier: 'pro', limit: 10000 }, label: 'Pro Tier' },
+    ];
+
+    render(
+      <>
+        <SelectField name="plan" label="Plan" options={objectOptions} />
+        <button type="submit">Submit</button>
+      </>,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getFormProviderWrapper({ onSubmit }),
+      ])
+    );
+
+    const select = screen.getByRole('combobox', { name: 'Plan' });
+    await user.click(select);
+    await user.click(screen.getByRole('option', { name: 'Pro Tier' }));
+
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        { plan: { tier: 'pro', limit: 10000 } },
+        expect.anything(),
+        expect.anything()
+      )
+    );
+  });
+
+  it('clears initial value that does not match any option', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(
+      <>
+        <SelectField name="priority" label="Priority" options={options} />
+        <button type="submit">Submit</button>
+      </>,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getFormProviderWrapper({ initialValues: { priority: 'nonexistent' }, onSubmit }),
+      ])
+    );
+
+    expect(screen.queryByText('nonexistent')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith({}, expect.anything(), expect.anything())
+    );
+  });
+
+  it('keeps only valid values in multi-select when some are invalid', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(
+      <>
+        <SelectField name="priority" label="Priority" options={options} multi />
+        <button type="submit">Submit</button>
+      </>,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getFormProviderWrapper({
+          initialValues: { priority: ['low', 'nonexistent', 'high'] },
+          onSubmit,
+        }),
+      ])
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Low Priority')).toBeInTheDocument();
+      expect(screen.getByText('High Priority')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('nonexistent')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        { priority: ['low', 'high'] },
+        expect.anything(),
+        expect.anything()
+      )
+    );
+  });
+
+  it('limits the number of visible options with maxOptions', async () => {
+    const user = userEvent.setup();
+    const manyOptions = Array.from({ length: 10 }, (_, i) => ({
+      id: `opt-${i}`,
+      label: `Option ${i}`,
+    }));
+
+    render(
+      <SelectField name="choice" label="Choice" options={manyOptions} maxOptions={3} />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getFormProviderWrapper()])
+    );
+
+    const select = screen.getByRole('combobox', { name: 'Choice' });
+    await user.click(select);
+
+    expect(screen.getAllByRole('option')).toHaveLength(3);
+  });
+
+  it('does not clear value while options are loading', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(
+      <>
+        <SelectField name="priority" label="Priority" options={[]} isLoading />
+        <button type="submit">Submit</button>
+      </>,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getFormProviderWrapper({ initialValues: { priority: 'low' }, onSubmit }),
+      ])
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        { priority: 'low' },
+        expect.anything(),
+        expect.anything()
+      )
+    );
+  });
 });

--- a/javascript/packages/core/components/form/fields/select/__tests__/select-field.test.tsx
+++ b/javascript/packages/core/components/form/fields/select/__tests__/select-field.test.tsx
@@ -450,6 +450,82 @@ describe('SelectField', () => {
     );
   });
 
+  it('matches object id regardless of key order', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    const objectOptions = [
+      { id: { tier: 'free', limit: 100 }, label: 'Free Tier' },
+      { id: { tier: 'pro', limit: 10000 }, label: 'Pro Tier' },
+    ];
+
+    render(
+      <>
+        <SelectField
+          name="plan"
+          label="Plan"
+          options={objectOptions}
+          initialValue={{ limit: 10000, tier: 'pro' }}
+        />
+        <button type="submit">Submit</button>
+      </>,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getFormProviderWrapper({ onSubmit }),
+      ])
+    );
+
+    expect(screen.getByText('Pro Tier')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        { plan: { tier: 'pro', limit: 10000 } },
+        expect.anything(),
+        expect.anything()
+      )
+    );
+  });
+
+  it('matches nested object id regardless of key order', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    const objectOptions = [
+      { id: { config: { region: 'us', zone: 'east' }, name: 'prod' }, label: 'Production' },
+      { id: { config: { region: 'eu', zone: 'west' }, name: 'staging' }, label: 'Staging' },
+    ];
+
+    render(
+      <>
+        <SelectField
+          name="env"
+          label="Environment"
+          options={objectOptions}
+          initialValue={{ name: 'staging', config: { zone: 'west', region: 'eu' } }}
+        />
+        <button type="submit">Submit</button>
+      </>,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getFormProviderWrapper({ onSubmit }),
+      ])
+    );
+
+    expect(screen.getByText('Staging')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        { env: { config: { region: 'eu', zone: 'west' }, name: 'staging' } },
+        expect.anything(),
+        expect.anything()
+      )
+    );
+  });
+
   it('does not clear value when creatable even if it has no matching option', async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn();

--- a/javascript/packages/core/components/form/fields/select/__tests__/select-field.test.tsx
+++ b/javascript/packages/core/components/form/fields/select/__tests__/select-field.test.tsx
@@ -406,7 +406,7 @@ describe('SelectField', () => {
     );
   });
 
-  it('limits the number of visible options with maxOptions', async () => {
+  it('limits the number of visible options with visibleOptionLimit', async () => {
     const user = userEvent.setup();
     const manyOptions = Array.from({ length: 10 }, (_, i) => ({
       id: `opt-${i}`,
@@ -414,7 +414,7 @@ describe('SelectField', () => {
     }));
 
     render(
-      <SelectField name="choice" label="Choice" options={manyOptions} maxOptions={3} />,
+      <SelectField name="choice" label="Choice" options={manyOptions} visibleOptionLimit={3} />,
       buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getFormProviderWrapper()])
     );
 
@@ -444,6 +444,34 @@ describe('SelectField', () => {
     await waitFor(() =>
       expect(onSubmit).toHaveBeenCalledWith(
         { priority: 'low' },
+        expect.anything(),
+        expect.anything()
+      )
+    );
+  });
+
+  it('does not clear value when creatable even if it has no matching option', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(
+      <>
+        <SelectField name="priority" label="Priority" options={options} creatable />
+        <button type="submit">Submit</button>
+      </>,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getFormProviderWrapper({ initialValues: { priority: 'custom' }, onSubmit }),
+      ])
+    );
+
+    expect(screen.getByText('custom')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        { priority: 'custom' },
         expect.anything(),
         expect.anything()
       )

--- a/javascript/packages/core/components/form/fields/select/__tests__/serialize-key.test.ts
+++ b/javascript/packages/core/components/form/fields/select/__tests__/serialize-key.test.ts
@@ -1,0 +1,37 @@
+import { serializeKey } from '../serialize-key';
+
+describe('serializeKey', () => {
+  it('produces identical output regardless of key order', () => {
+    expect(serializeKey({ a: 1, b: 2 })).toBe(serializeKey({ b: 2, a: 1 }));
+  });
+
+  it('handles nested objects with different key order', () => {
+    const a = { outer: { z: 1, a: 2 }, name: 'test' };
+    const b = { name: 'test', outer: { a: 2, z: 1 } };
+    expect(serializeKey(a)).toBe(serializeKey(b));
+  });
+
+  it('handles deeply nested objects', () => {
+    const a = { l1: { l2: { l3: { z: 'last', a: 'first' } } } };
+    const b = { l1: { l2: { l3: { a: 'first', z: 'last' } } } };
+    expect(serializeKey(a)).toBe(serializeKey(b));
+  });
+
+  it('preserves array order', () => {
+    expect(serializeKey([3, 1, 2])).toBe('[3,1,2]');
+    expect(serializeKey([3, 1, 2])).not.toBe(serializeKey([1, 2, 3]));
+  });
+
+  it('handles primitives', () => {
+    expect(serializeKey('hello')).toBe('"hello"');
+    expect(serializeKey(42)).toBe('42');
+    expect(serializeKey(null)).toBe('null');
+    expect(serializeKey(true)).toBe('true');
+  });
+
+  it('handles objects inside arrays', () => {
+    const a = [{ b: 2, a: 1 }];
+    const b = [{ a: 1, b: 2 }];
+    expect(serializeKey(a)).toBe(serializeKey(b));
+  });
+});

--- a/javascript/packages/core/components/form/fields/select/select-field.tsx
+++ b/javascript/packages/core/components/form/fields/select/select-field.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useMemo } from 'react';
-import { OnChangeParams, Select } from 'baseui/select';
+import { useEffect, useMemo } from 'react';
+import { filterOptions as defaultFilterOptions, OnChangeParams, Select } from 'baseui/select';
 
 import { FormControl } from '#core/components/form/components/form-control';
 import { useField } from '#core/components/form/hooks/use-field';
@@ -8,7 +8,24 @@ import { formatSelectedValue } from './format-selected-value';
 
 import type { SelectFieldProps, SelectOption } from './types';
 
-export const SelectField: React.FC<SelectFieldProps> = ({
+/**
+ * BaseUI requires option IDs to be string | number. To support arbitrary ID types
+ * (including objects), we serialize IDs to strings for BaseUI and resolve them back
+ * to their originals for form state via a lookup map.
+ */
+const serialize = JSON.stringify;
+
+function buildOptionLookup<V>(options: SelectOption<V>[]) {
+  const lookup = new Map<string, SelectOption<V>>();
+  const normalizedOptions = options.map((opt) => {
+    const key = serialize(opt.id);
+    lookup.set(key, opt);
+    return { id: key, label: opt.label, disabled: opt.disabled };
+  });
+  return { normalizedOptions, lookup };
+}
+
+export function SelectField<V = string | number>({
   name,
   label,
   defaultValue,
@@ -21,12 +38,14 @@ export const SelectField: React.FC<SelectFieldProps> = ({
   caption,
   placeholder,
   options,
+  maxOptions,
+  isLoading = false,
   clearable = true,
   searchable = true,
   multi = false,
   creatable = false,
-}) => {
-  const { input, meta } = useField<string | string[] | number[] | number>(name, {
+}: SelectFieldProps<V>) {
+  const { input, meta } = useField<V | V[]>(name, {
     required,
     validate,
     defaultValue,
@@ -34,27 +53,58 @@ export const SelectField: React.FC<SelectFieldProps> = ({
     label,
   });
 
-  const handleChange = useCallback(
-    (params: { value: ReadonlyArray<SelectOption> }) => {
-      if (multi) {
-        const values = params.value.map((item) => item.id);
-        input.onChange(values as string[] | number[]);
-      } else {
-        const value = params.value.length > 0 ? params.value[0].id : '';
-        input.onChange(value);
+  const { normalizedOptions, lookup } = useMemo(() => buildOptionLookup(options), [options]);
+
+  const resolveOriginalId = (serializedKey: string): V => {
+    const original = lookup.get(serializedKey);
+    return (original ? original.id : serializedKey) as V;
+  };
+
+  // Clear field value when it doesn't match any available option.
+  // Deps intentionally exclude input/multi to avoid re-running on every value change,
+  // which would loop since we call onChange inside.
+  useEffect(() => {
+    if (isLoading || creatable) return;
+
+    const currentValue = input.value;
+    if (!currentValue || (Array.isArray(currentValue) && currentValue.length === 0)) return;
+
+    if (multi) {
+      const values = currentValue as V[];
+      const validValues = values.filter((v) => lookup.has(serialize(v)));
+      if (validValues.length !== values.length) {
+        input.onChange(validValues as V | V[]);
       }
-    },
-    [input, multi]
-  );
+    } else if (!lookup.has(serialize(currentValue))) {
+      input.onChange('' as V | V[]);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lookup, isLoading]);
 
-  const value = useMemo<SelectOption[]>(() => {
-    return formatSelectedValue(input.value).map<SelectOption>((item) => {
-      const selectedFromOption = options?.find((option) => option.id === item);
-      if (selectedFromOption) return selectedFromOption;
+  const handleChange = (params: OnChangeParams) => {
+    if (multi) {
+      const values = params.value.map((item) => resolveOriginalId(String(item.id)));
+      input.onChange(values as V | V[]);
+    } else if (params.value.length > 0) {
+      input.onChange(resolveOriginalId(String(params.value[0].id)) as V | V[]);
+    } else {
+      input.onChange('' as V | V[]);
+    }
+  };
 
-      return { id: item, label: String(item) }; // Creatable options will fall into this case
-    });
-  }, [input.value, options]);
+  const selectedValue = useMemo(() => {
+    const items: Array<{ id: string; label: string; disabled?: boolean }> = [];
+    for (const item of formatSelectedValue(input.value)) {
+      const key = serialize(item);
+      const matched = lookup.get(key);
+      if (matched) {
+        items.push({ id: key, label: matched.label, disabled: matched.disabled });
+      } else if (creatable) {
+        items.push({ id: key, label: String(item) });
+      }
+    }
+    return items;
+  }, [input.value, lookup, creatable]);
 
   return (
     <FormControl
@@ -66,9 +116,9 @@ export const SelectField: React.FC<SelectFieldProps> = ({
     >
       <Select
         id={name}
-        value={value}
-        options={options}
-        onChange={handleChange as (params: OnChangeParams) => unknown}
+        value={selectedValue}
+        options={normalizedOptions}
+        onChange={handleChange}
         onBlur={input.onBlur}
         placeholder={!disabled && !readOnly ? placeholder : ''}
         disabled={disabled}
@@ -77,10 +127,14 @@ export const SelectField: React.FC<SelectFieldProps> = ({
         multi={multi}
         overrides={buildSelectOverrides(name, disabled, readOnly)}
         creatable={creatable}
+        filterOptions={(options, filterValue, excludeOptions, newProps) =>
+          defaultFilterOptions(options, filterValue, excludeOptions, newProps).slice(0, maxOptions)
+        }
+        isLoading={isLoading}
         // Modified getOptionLabel in BaseWeb Select to avoid adding "Create" prefix on user input for
         // creatable dropdowns, as creation typically occurs during form submission. The prefix is misleading.
         getOptionLabel={({ option }) => option.label}
       />
     </FormControl>
   );
-};
+}

--- a/javascript/packages/core/components/form/fields/select/select-field.tsx
+++ b/javascript/packages/core/components/form/fields/select/select-field.tsx
@@ -5,6 +5,7 @@ import { FormControl } from '#core/components/form/components/form-control';
 import { useField } from '#core/components/form/hooks/use-field';
 import { buildSelectOverrides } from './build-select-overrides';
 import { formatSelectedValue } from './format-selected-value';
+import { serializeKey } from './serialize-key';
 
 import type { SelectFieldProps, SelectOption } from './types';
 
@@ -39,13 +40,13 @@ export function SelectField<V = string | number>({
   const { baseUIOptions, findByValue, findByKey } = useMemo(() => {
     const map = new Map<string, SelectOption<V>>();
     const adapted = options.map((opt) => {
-      const key = JSON.stringify(opt.id);
+      const key = serializeKey(opt.id);
       map.set(key, opt);
       return { id: key, label: opt.label, disabled: opt.disabled };
     });
     return {
       baseUIOptions: adapted,
-      findByValue: (v: V) => map.get(JSON.stringify(v)),
+      findByValue: (v: V) => map.get(serializeKey(v)),
       findByKey: (key: string) => map.get(key),
     };
   }, [options]);
@@ -86,7 +87,7 @@ export function SelectField<V = string | number>({
   const baseUIValue = useMemo(() => {
     const items: Array<{ id: string; label: string; disabled?: boolean }> = [];
     for (const item of formatSelectedValue(input.value)) {
-      const key = JSON.stringify(item);
+      const key = serializeKey(item);
       const matched = findByKey(key);
       if (matched) {
         items.push({ id: key, label: matched.label, disabled: matched.disabled });

--- a/javascript/packages/core/components/form/fields/select/select-field.tsx
+++ b/javascript/packages/core/components/form/fields/select/select-field.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo } from 'react';
-import { filterOptions as defaultFilterOptions, OnChangeParams, Select } from 'baseui/select';
+import { filterOptions, OnChangeParams, Select } from 'baseui/select';
 
 import { FormControl } from '#core/components/form/components/form-control';
 import { useField } from '#core/components/form/hooks/use-field';
@@ -7,23 +7,6 @@ import { buildSelectOverrides } from './build-select-overrides';
 import { formatSelectedValue } from './format-selected-value';
 
 import type { SelectFieldProps, SelectOption } from './types';
-
-/**
- * BaseUI requires option IDs to be string | number. To support arbitrary ID types
- * (including objects), we serialize IDs to strings for BaseUI and resolve them back
- * to their originals for form state via a lookup map.
- */
-const serialize = JSON.stringify;
-
-function buildOptionLookup<V>(options: SelectOption<V>[]) {
-  const lookup = new Map<string, SelectOption<V>>();
-  const normalizedOptions = options.map((opt) => {
-    const key = serialize(opt.id);
-    lookup.set(key, opt);
-    return { id: key, label: opt.label, disabled: opt.disabled };
-  });
-  return { normalizedOptions, lookup };
-}
 
 export function SelectField<V = string | number>({
   name,
@@ -38,7 +21,7 @@ export function SelectField<V = string | number>({
   caption,
   placeholder,
   options,
-  maxOptions,
+  visibleOptionLimit,
   isLoading = false,
   clearable = true,
   searchable = true,
@@ -53,10 +36,22 @@ export function SelectField<V = string | number>({
     label,
   });
 
-  const { normalizedOptions, lookup } = useMemo(() => buildOptionLookup(options), [options]);
+  const { baseUIOptions, findByValue, findByKey } = useMemo(() => {
+    const map = new Map<string, SelectOption<V>>();
+    const adapted = options.map((opt) => {
+      const key = JSON.stringify(opt.id);
+      map.set(key, opt);
+      return { id: key, label: opt.label, disabled: opt.disabled };
+    });
+    return {
+      baseUIOptions: adapted,
+      findByValue: (v: V) => map.get(JSON.stringify(v)),
+      findByKey: (key: string) => map.get(key),
+    };
+  }, [options]);
 
   const resolveOriginalId = (serializedKey: string): V => {
-    const original = lookup.get(serializedKey);
+    const original = findByKey(serializedKey);
     return (original ? original.id : serializedKey) as V;
   };
 
@@ -71,32 +66,32 @@ export function SelectField<V = string | number>({
 
     if (multi) {
       const values = currentValue as V[];
-      const validValues = values.filter((v) => lookup.has(serialize(v)));
+      const validValues = values.filter((v) => findByValue(v));
       if (validValues.length !== values.length) {
-        input.onChange(validValues as V | V[]);
+        input.onChange(validValues);
       }
-    } else if (!lookup.has(serialize(currentValue))) {
+    } else if (!findByValue(currentValue as V)) {
       input.onChange('' as V | V[]);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [lookup, isLoading]);
+  }, [findByValue, isLoading]);
 
   const handleChange = (params: OnChangeParams) => {
     if (multi) {
       const values = params.value.map((item) => resolveOriginalId(String(item.id)));
-      input.onChange(values as V | V[]);
+      input.onChange(values);
     } else if (params.value.length > 0) {
-      input.onChange(resolveOriginalId(String(params.value[0].id)) as V | V[]);
+      input.onChange(resolveOriginalId(String(params.value[0].id)));
     } else {
       input.onChange('' as V | V[]);
     }
   };
 
-  const selectedValue = useMemo(() => {
+  const baseUIValue = useMemo(() => {
     const items: Array<{ id: string; label: string; disabled?: boolean }> = [];
     for (const item of formatSelectedValue(input.value)) {
-      const key = serialize(item);
-      const matched = lookup.get(key);
+      const key = JSON.stringify(item);
+      const matched = findByKey(key);
       if (matched) {
         items.push({ id: key, label: matched.label, disabled: matched.disabled });
       } else if (creatable) {
@@ -104,7 +99,7 @@ export function SelectField<V = string | number>({
       }
     }
     return items;
-  }, [input.value, lookup, creatable]);
+  }, [input.value, findByKey, creatable]);
 
   return (
     <FormControl
@@ -116,8 +111,8 @@ export function SelectField<V = string | number>({
     >
       <Select
         id={name}
-        value={selectedValue}
-        options={normalizedOptions}
+        value={baseUIValue}
+        options={baseUIOptions}
         onChange={handleChange}
         onBlur={input.onBlur}
         placeholder={!disabled && !readOnly ? placeholder : ''}
@@ -128,7 +123,7 @@ export function SelectField<V = string | number>({
         overrides={buildSelectOverrides(name, disabled, readOnly)}
         creatable={creatable}
         filterOptions={(options, filterValue, excludeOptions, newProps) =>
-          defaultFilterOptions(options, filterValue, excludeOptions, newProps).slice(0, maxOptions)
+          filterOptions(options, filterValue, excludeOptions, newProps).slice(0, visibleOptionLimit)
         }
         isLoading={isLoading}
         // Modified getOptionLabel in BaseWeb Select to avoid adding "Create" prefix on user input for

--- a/javascript/packages/core/components/form/fields/select/select-field.tsx
+++ b/javascript/packages/core/components/form/fields/select/select-field.tsx
@@ -50,11 +50,6 @@ export function SelectField<V = string | number>({
     };
   }, [options]);
 
-  const resolveOriginalId = (serializedKey: string): V => {
-    const original = findByKey(serializedKey);
-    return (original ? original.id : serializedKey) as V;
-  };
-
   // Clear field value when it doesn't match any available option.
   // Deps intentionally exclude input/multi to avoid re-running on every value change,
   // which would loop since we call onChange inside.
@@ -77,11 +72,12 @@ export function SelectField<V = string | number>({
   }, [findByValue, isLoading]);
 
   const handleChange = (params: OnChangeParams) => {
+    const selected = params.value as Array<{ id: string }>;
+
     if (multi) {
-      const values = params.value.map((item) => resolveOriginalId(String(item.id)));
-      input.onChange(values);
-    } else if (params.value.length > 0) {
-      input.onChange(resolveOriginalId(String(params.value[0].id)));
+      input.onChange(selected.map((item) => findByKey(item.id)?.id ?? (item.id as V)));
+    } else if (selected.length > 0) {
+      input.onChange(findByKey(selected[0].id)?.id ?? (selected[0].id as V));
     } else {
       input.onChange('' as V | V[]);
     }

--- a/javascript/packages/core/components/form/fields/select/serialize-key.ts
+++ b/javascript/packages/core/components/form/fields/select/serialize-key.ts
@@ -4,9 +4,11 @@
  * `{ b: 2, a: 1 }` both yield `'{"a":1,"b":2}'`. Handles nested objects.
  */
 export function serializeKey(value: unknown): string {
-  return JSON.stringify(value, (_, val) => {
+  return JSON.stringify(value, (_, val: unknown) => {
     if (val !== null && typeof val === 'object' && !Array.isArray(val)) {
-      return Object.fromEntries(Object.entries(val).sort(([a], [b]) => a.localeCompare(b)));
+      return Object.fromEntries(
+        Object.entries(val as Record<string, unknown>).sort(([a], [b]) => a.localeCompare(b))
+      );
     }
     return val;
   });

--- a/javascript/packages/core/components/form/fields/select/serialize-key.ts
+++ b/javascript/packages/core/components/form/fields/select/serialize-key.ts
@@ -1,0 +1,13 @@
+/**
+ * JSON.stringify with deterministic key ordering. Produces identical output
+ * regardless of property insertion order, so `{ a: 1, b: 2 }` and
+ * `{ b: 2, a: 1 }` both yield `'{"a":1,"b":2}'`. Handles nested objects.
+ */
+export function serializeKey(value: unknown): string {
+  return JSON.stringify(value, (_, val) => {
+    if (val !== null && typeof val === 'object' && !Array.isArray(val)) {
+      return Object.fromEntries(Object.entries(val).sort(([a], [b]) => a.localeCompare(b)));
+    }
+    return val;
+  });
+}

--- a/javascript/packages/core/components/form/fields/select/types.ts
+++ b/javascript/packages/core/components/form/fields/select/types.ts
@@ -1,15 +1,17 @@
 import type { BaseFieldProps } from '../types';
 
-export interface SelectOption {
-  id: string | number;
+export interface SelectOption<V = string | number> {
+  id: V;
   label: string;
   disabled?: boolean;
 }
 
-export interface SelectFieldProps extends BaseFieldProps<string | string[] | number | number[]> {
-  options: SelectOption[];
+export interface SelectFieldProps<V = string | number> extends BaseFieldProps<V | V[]> {
+  options: SelectOption<V>[];
   clearable?: boolean;
   searchable?: boolean;
   multi?: boolean;
   creatable?: boolean;
+  isLoading?: boolean;
+  maxOptions?: number;
 }

--- a/javascript/packages/core/components/form/fields/select/types.ts
+++ b/javascript/packages/core/components/form/fields/select/types.ts
@@ -6,12 +6,19 @@ export interface SelectOption<V = string | number> {
   disabled?: boolean;
 }
 
-export interface SelectFieldProps<V = string | number> extends BaseFieldProps<V | V[]> {
+interface SelectFieldOwnProps<V> {
   options: SelectOption<V>[];
   clearable?: boolean;
   searchable?: boolean;
-  multi?: boolean;
   creatable?: boolean;
   isLoading?: boolean;
-  maxOptions?: number;
+  /**
+   * Limit the number of visible options in the dropdown.
+   * By default there is no limit.
+   */
+  visibleOptionLimit?: number;
 }
+
+export type SelectFieldProps<V = string | number> =
+  | (SelectFieldOwnProps<V> & BaseFieldProps<V> & { multi?: false })
+  | (SelectFieldOwnProps<V> & BaseFieldProps<V[]> & { multi: true });


### PR DESCRIPTION
Extended select-field component to support:

- Getting options asynchronously
- Arbitrary option id types(including objects) 
  -  Internally, IDs are serialized to strings for BaseUI compatibility and resolved back to their originals for form state via a lookup map.
- Auto-clear invalid field values
  - When the current form value (from defaultValue, initialValue, or initialValues) doesn't match any available option, it's automatically cleared. In multi-select mode, only the invalid entries are removed. Skipped when isLoading is true (to avoid clearing before async options arrive) or when creatable is true (where unmatched values are intentional). 
- Add maxOptions prop to limit the number of visible dropdown options

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
