### PR TITLE
Add StickyFooter component with Form footer prop

### DIFF
--- a/javascript/packages/core/components/form/__tests__/form.test.tsx
+++ b/javascript/packages/core/components/form/__tests__/form.test.tsx
@@ -225,6 +225,53 @@ describe('Form', () => {
         )
       );
     });
+
+    it('submits form via sticky footer shorthand right content', async () => {
+      const user = userEvent.setup();
+      const onSubmit = vi.fn();
+
+      render(
+        <Form onSubmit={onSubmit} footer={{ right: <button type="submit">Save</button> }}>
+          <StringField name="email" label="Email" />
+        </Form>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
+
+      await user.type(screen.getByLabelText('Email'), 'test@example.com');
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      await waitFor(() =>
+        expect(onSubmit).toHaveBeenCalledWith(
+          { email: 'test@example.com' },
+          expect.anything(),
+          expect.anything()
+        )
+      );
+    });
+
+    it('renders sticky footer with shorthand left and right content', () => {
+      render(
+        <Form
+          onSubmit={vi.fn()}
+          footer={{ left: <span>Last saved 2m ago</span>, right: <button>Save</button> }}
+        >
+          <StringField name="email" label="Email" />
+        </Form>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
+      expect(screen.getByText('Last saved 2m ago')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+    });
+
+    it('renders custom footer ReactNode directly', () => {
+      render(
+        <Form onSubmit={vi.fn()} footer={<div data-testid="custom-footer">Custom</div>}>
+          <StringField name="email" label="Email" />
+        </Form>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
+      expect(screen.getByTestId('custom-footer')).toBeInTheDocument();
+    });
   });
 
   describe('validation', () => {

--- a/javascript/packages/core/components/form/components/sticky-footer/sticky-footer.tsx
+++ b/javascript/packages/core/components/form/components/sticky-footer/sticky-footer.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useRef, useState } from 'react';
+
+import { StickyFooterContainer, StickyFooterSlot, StickyFooterSpacer } from './styled-components';
+
+import type { StickyFooterProps } from './types';
+
+export function StickyFooter({ leftContent, rightContent }: StickyFooterProps) {
+  const footerRef = useRef<HTMLElement>(null);
+  const [footerHeight, setFooterHeight] = useState(0);
+
+  // Dynamically track footer height so the spacer always matches, preventing
+  // content from being hidden behind the fixed footer when scrolled to bottom.
+  useEffect(() => {
+    const footer = footerRef.current;
+    if (!footer) return;
+
+    const observer = new ResizeObserver(() => {
+      setFooterHeight(footer.offsetHeight);
+    });
+
+    observer.observe(footer);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <>
+      <StickyFooterSpacer $height={footerHeight} />
+      <StickyFooterContainer ref={footerRef}>
+        <StickyFooterSlot>{leftContent}</StickyFooterSlot>
+        <StickyFooterSlot>{rightContent}</StickyFooterSlot>
+      </StickyFooterContainer>
+    </>
+  );
+}

--- a/javascript/packages/core/components/form/components/sticky-footer/styled-components.ts
+++ b/javascript/packages/core/components/form/components/sticky-footer/styled-components.ts
@@ -1,0 +1,32 @@
+import { styled } from 'baseui';
+
+// Spacer that occupies the same height as the fixed footer, preventing page
+// content from being hidden behind it when scrolled to the bottom.
+export const StickyFooterSpacer = styled<'div', { $height: number }>('div', ({ $height }) => ({
+  height: `${$height}px`,
+  flexShrink: 0,
+}));
+
+export const StickyFooterContainer = styled('footer', ({ $theme }) => ({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  width: '100%',
+  position: 'fixed',
+  boxSizing: 'border-box',
+  left: 0,
+  bottom: 0,
+  boxShadow: $theme.lighting.shallowAbove,
+  backgroundColor: $theme.colors.backgroundPrimary,
+  paddingTop: $theme.sizing.scale600,
+  paddingBottom: $theme.sizing.scale600,
+  paddingLeft: $theme.sizing.scale900,
+  paddingRight: $theme.sizing.scale900,
+  gap: $theme.sizing.scale400,
+}));
+
+export const StickyFooterSlot = styled('div', ({ $theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: $theme.sizing.scale200,
+}));

--- a/javascript/packages/core/components/form/components/sticky-footer/types.ts
+++ b/javascript/packages/core/components/form/components/sticky-footer/types.ts
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react';
+
+export interface StickyFooterProps {
+  /** Usually form actions (e.g., submit button). */
+  rightContent?: ReactNode;
+
+  /** Usually secondary info, status text. */
+  leftContent?: ReactNode;
+}

--- a/javascript/packages/core/components/form/form.tsx
+++ b/javascript/packages/core/components/form/form.tsx
@@ -3,8 +3,10 @@ import { Form as FinalForm } from 'react-final-form';
 import { useStyletron } from 'baseui';
 import createFocusOnErrorDecorator from 'final-form-focus';
 
+import { StickyFooter } from '#core/components/form/components/sticky-footer/sticky-footer';
 import { FormContext } from './form-context';
 
+import type { ReactNode } from 'react';
 import type { FieldRegistry, FormData, FormProps } from './types';
 
 const focusOnErrorDecorator = createFocusOnErrorDecorator();
@@ -15,6 +17,7 @@ export const Form = <FieldValues extends FormData = FormData>({
   id,
   children,
   render,
+  footer,
   focusOnError = true,
 }: FormProps<FieldValues>) => {
   const [css, theme] = useStyletron();
@@ -42,6 +45,7 @@ export const Form = <FieldValues extends FormData = FormData>({
               onSubmit={handleSubmit}
             >
               {children}
+              {resolveFooter(footer)}
             </form>
           );
 
@@ -51,3 +55,14 @@ export const Form = <FieldValues extends FormData = FormData>({
     </FormContext.Provider>
   );
 };
+
+function resolveFooter(footer: FormProps['footer']): ReactNode {
+  if (!footer) return null;
+
+  if (typeof footer === 'object' && ('left' in footer || 'right' in footer)) {
+    const { left, right } = footer;
+    return <StickyFooter leftContent={left} rightContent={right} />;
+  }
+
+  return footer as ReactNode;
+}

--- a/javascript/packages/core/components/form/types.ts
+++ b/javascript/packages/core/components/form/types.ts
@@ -48,6 +48,23 @@ export interface FormProps<FieldValues extends FormData = FormData> {
    * ```
    */
   render?: (formElement: React.ReactNode) => React.ReactNode;
+
+  /**
+   * Renders a sticky footer fixed to the bottom of the viewport.
+   *
+   * @note `right` is usually reserved for form actions (e.g., submit button).
+   * @note `left` is usually reserved for secondary info, status text.
+   *
+   * @example
+   * ```tsx
+   * // Object with left and right content
+   * <Form footer={{ right: <SubmitButton>Save</SubmitButton>, left: <span>Last saved 2m ago</span> }}>
+   *
+   * // ReactNode for full control
+   * <Form footer={<MyCustomFooter />}>
+   * ```
+   */
+  footer?: { left?: React.ReactNode; right?: React.ReactNode } | React.ReactNode;
 }
 
 export interface FormInstance {

--- a/javascript/packages/core/components/views/sandbox/sandbox.tsx
+++ b/javascript/packages/core/components/views/sandbox/sandbox.tsx
@@ -247,6 +247,57 @@ export function Sandbox() {
           </Block>
         </Tab>
 
+        <Tab title="Form - Sticky Footer">
+          <Block marginTop="24px" maxWidth="600px">
+            <Form
+              onSubmit={(values) => console.log('Submitted:', values)}
+              footer={{
+                left: <span>Last saved 2m ago</span>,
+                right: <Button type="submit">Save changes</Button>,
+              }}
+            >
+              <FormGroup title="Personal Information" description="Your name and contact details.">
+                <StringField name="firstName" label="First Name" />
+                <StringField name="lastName" label="Last Name" />
+                <StringField name="email" label="Email Address" />
+                <StringField name="phone" label="Phone Number" />
+              </FormGroup>
+
+              <FormGroup title="Professional Details" description="Your role and team affiliation.">
+                <SelectField
+                  name="department"
+                  label="Department"
+                  options={[
+                    { id: 'engineering', label: 'Engineering' },
+                    { id: 'product', label: 'Product' },
+                    { id: 'design', label: 'Design' },
+                    { id: 'data', label: 'Data Science' },
+                  ]}
+                />
+                <StringField name="jobTitle" label="Job Title" />
+                <StringField name="manager" label="Manager Name" />
+              </FormGroup>
+
+              <FormGroup
+                title="Account Configuration"
+                description="Settings applied to your account on creation."
+              >
+                <SelectField
+                  name="region"
+                  label="Region"
+                  options={[
+                    { id: 'us-east', label: 'US East' },
+                    { id: 'us-west', label: 'US West' },
+                    { id: 'eu-west', label: 'EU West' },
+                    { id: 'ap-south', label: 'AP South' },
+                  ]}
+                />
+                <StringField name="slackHandle" label="Slack Handle" />
+              </FormGroup>
+            </Form>
+          </Block>
+        </Tab>
+
         <Tab title="Form - Focus on Error">
           <Block marginTop="24px" maxWidth="600px">
             <Notification


### PR DESCRIPTION
Add StickyFooter, a fixed viewport-bottom bar with left and right content slots, sized dynamically to prevent page content from being obscured when scrolled to the bottom.

Expose this through a new `footer` prop on Form. The shorthand { left, right } object automatically wraps content in StickyFooter, covering the common case of a submit button pinned to the viewport. A raw ReactNode is also accepted as an escape hatch for full control over the footer element.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

https://github.com/user-attachments/assets/172b4564-9673-4180-8762-1b4f7e1a9730



<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
