### PR TITLE
Add hook for programmatic form mutations

### DIFF
--- a/javascript/packages/core/components/form/__tests__/form.test.tsx
+++ b/javascript/packages/core/components/form/__tests__/form.test.tsx
@@ -7,6 +7,7 @@ import { FormDialog } from '#core/components/form/components/form-dialog/form-di
 import { FormErrorBanner } from '#core/components/form/components/form-error-banner/form-error-banner';
 import { StringField } from '#core/components/form/fields/string/string-field';
 import { Form } from '#core/components/form/form';
+import { useForm } from '#core/components/form/hooks/use-form';
 import { combineValidators } from '#core/components/form/validation/combine-validators';
 import { minLength, required } from '#core/components/form/validation/validators';
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
@@ -216,6 +217,104 @@ describe('Form', () => {
 
       await user.type(screen.getByLabelText('Email'), 'test@example.com');
       await user.click(screen.getByRole('button', { name: 'External Submit' }));
+
+      await waitFor(() =>
+        expect(onSubmit).toHaveBeenCalledWith(
+          { email: 'test@example.com' },
+          expect.anything(),
+          expect.anything()
+        )
+      );
+    });
+
+    it('useForm change() updates field value before submit', async () => {
+      const user = userEvent.setup();
+      const onSubmit = vi.fn();
+
+      function SetStatusButton() {
+        const { change } = useForm();
+        return <button onClick={() => change('status', 'in-progress')}>Set Status</button>;
+      }
+
+      render(
+        <Form onSubmit={onSubmit}>
+          <StringField name="status" label="Status" />
+          <SetStatusButton />
+          <button type="submit">Submit</button>
+        </Form>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Set Status' }));
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await waitFor(() =>
+        expect(onSubmit).toHaveBeenCalledWith(
+          { status: 'in-progress' },
+          expect.anything(),
+          expect.anything()
+        )
+      );
+    });
+
+    it('useForm multiple change() calls accumulate', async () => {
+      const user = userEvent.setup();
+      const onSubmit = vi.fn();
+
+      function SetFieldsButton() {
+        const { change } = useForm();
+        return (
+          <button
+            onClick={() => {
+              change('first', 'alpha');
+              change('second', 'beta');
+            }}
+          >
+            Set Fields
+          </button>
+        );
+      }
+
+      render(
+        <Form onSubmit={onSubmit}>
+          <StringField name="first" label="First" />
+          <StringField name="second" label="Second" />
+          <SetFieldsButton />
+          <button type="submit">Submit</button>
+        </Form>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Set Fields' }));
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await waitFor(() =>
+        expect(onSubmit).toHaveBeenCalledWith(
+          { first: 'alpha', second: 'beta' },
+          expect.anything(),
+          expect.anything()
+        )
+      );
+    });
+
+    it('useForm submit() triggers onSubmit programmatically', async () => {
+      const user = userEvent.setup();
+      const onSubmit = vi.fn();
+
+      function ProgrammaticSubmitButton() {
+        const { submit } = useForm();
+        return <button onClick={() => void submit()}>Programmatic Submit</button>;
+      }
+
+      render(
+        <Form onSubmit={onSubmit} initialValues={{ email: 'test@example.com' }}>
+          <StringField name="email" label="Email" />
+          <ProgrammaticSubmitButton />
+        </Form>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Programmatic Submit' }));
 
       await waitFor(() =>
         expect(onSubmit).toHaveBeenCalledWith(

--- a/javascript/packages/core/components/form/hooks/use-form.ts
+++ b/javascript/packages/core/components/form/hooks/use-form.ts
@@ -1,0 +1,15 @@
+import { useForm as useReactFinalForm } from 'react-final-form';
+
+import { useFormContext } from '#core/components/form/form-context';
+
+import type { FormApi } from '../types';
+
+export function useForm(): FormApi {
+  const { fieldRegistry } = useFormContext();
+  const form = useReactFinalForm();
+  return {
+    fieldRegistry,
+    change: form.change,
+    submit: form.submit,
+  };
+}

--- a/javascript/packages/core/components/form/types.ts
+++ b/javascript/packages/core/components/form/types.ts
@@ -98,3 +98,9 @@ export interface FieldInput<T = unknown> {
 export type FieldRegistry = Map<string, FieldRegistryEntry>;
 
 export type FieldRegistryEntry = { label: string };
+
+export interface FormApi {
+  fieldRegistry: FieldRegistry;
+  change: (name: string, value: unknown) => void;
+  submit: () => Promise<object | undefined> | undefined;
+}


### PR DESCRIPTION
Form consumers need a way to imperatively set field values and trigger submission from outside standard form controls, For example, when actions like state transitions mutate multiple fields before submitting.

The new useForm() hook exposes change() and submit() from the underlying form library, alongside the existing fieldRegistry, through a single unified hook. The abstraction is kept at the hook boundary so the underlying final-form library remains an implementation detail.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
