### PR TITLE
Add support for repeatable form fields

### DIFF
--- a/javascript/app/icons/icons.tsx
+++ b/javascript/app/icons/icons.tsx
@@ -8,6 +8,7 @@ import CheckCircle from '@mui/icons-material/CheckCircle';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import CloseIcon from '@mui/icons-material/Close';
 import CropSquareIcon from '@mui/icons-material/CropSquare';
+import Delete from '@mui/icons-material/Delete';
 import Info from '@mui/icons-material/Info';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardBackspaceIcon from '@mui/icons-material/KeyboardBackspace';
@@ -39,5 +40,6 @@ export const ICONS = {
   sortAscending: createMuiIconAdapter(ArrowUpwardIcon),
   sortDescending: createMuiIconAdapter(ArrowDownwardIcon),
   stars: createMuiIconAdapter(AutoAwesomeIcon),
+  trashCan: createMuiIconAdapter(Delete),
   x: createMuiIconAdapter(CloseIcon),
 } as const;

--- a/javascript/packages/core/components/form/__tests__/form.test.tsx
+++ b/javascript/packages/core/components/form/__tests__/form.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { DeleteAlt, Plus } from 'baseui/icon';
 import { FORM_ERROR } from 'final-form';
 import { vi } from 'vitest';
 
@@ -8,6 +9,8 @@ import { FormErrorBanner } from '#core/components/form/components/form-error-ban
 import { StringField } from '#core/components/form/fields/string/string-field';
 import { Form } from '#core/components/form/form';
 import { useForm } from '#core/components/form/hooks/use-form';
+import { ArrayFormGroup } from '#core/components/form/layout/array-form-group/array-form-group';
+import { ArrayFormRow } from '#core/components/form/layout/array-form-row/array-form-row';
 import { combineValidators } from '#core/components/form/validation/combine-validators';
 import { minLength, required } from '#core/components/form/validation/validators';
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
@@ -370,6 +373,117 @@ describe('Form', () => {
         buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
       );
       expect(screen.getByTestId('custom-footer')).toBeInTheDocument();
+    });
+
+    describe('Repeated layouts', () => {
+      const icons = { plus: Plus, deleteAlt: DeleteAlt };
+
+      it('submits ArrayFormGroup data as a nested array', async () => {
+        const user = userEvent.setup();
+        const onSubmit = vi.fn();
+
+        render(
+          <Form onSubmit={onSubmit}>
+            <ArrayFormGroup rootFieldPath="addresses" groupLabel="Address" minItems={1}>
+              {(name) => <StringField name={`${name}.street`} label="Street" />}
+            </ArrayFormGroup>
+            <button type="submit">Submit</button>
+          </Form>,
+          buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper({ icons })])
+        );
+
+        await waitFor(() => screen.getByRole('textbox', { name: 'Street' }));
+        await user.type(screen.getByRole('textbox', { name: 'Street' }), '123 Main St');
+        await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+        await waitFor(() =>
+          expect(onSubmit).toHaveBeenCalledWith(
+            { addresses: [{ street: '123 Main St' }] },
+            expect.anything(),
+            expect.anything()
+          )
+        );
+      });
+
+      it('submits ArrayFormRow data as a nested array', async () => {
+        const user = userEvent.setup();
+        const onSubmit = vi.fn();
+
+        render(
+          <Form onSubmit={onSubmit}>
+            <ArrayFormRow rootFieldPath="tags" minItems={1}>
+              {(name) => <StringField name={`${name}.value`} label="Tag" />}
+            </ArrayFormRow>
+            <button type="submit">Submit</button>
+          </Form>,
+          buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper({ icons })])
+        );
+
+        await waitFor(() => screen.getByRole('textbox', { name: 'Tag' }));
+        await user.type(screen.getByRole('textbox', { name: 'Tag' }), 'ml');
+        await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+        await waitFor(() =>
+          expect(onSubmit).toHaveBeenCalledWith(
+            { tags: [{ value: 'ml' }] },
+            expect.anything(),
+            expect.anything()
+          )
+        );
+      });
+
+      it('populates ArrayFormGroup fields from initialValues', async () => {
+        render(
+          <Form
+            onSubmit={vi.fn()}
+            initialValues={{
+              addresses: [{ street: '1 Infinite Loop' }, { street: '1600 Amphitheatre' }],
+            }}
+          >
+            <ArrayFormGroup rootFieldPath="addresses" groupLabel="Address">
+              {(name) => <StringField name={`${name}.street`} label="Street" />}
+            </ArrayFormGroup>
+            <button type="submit">Submit</button>
+          </Form>,
+          buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper({ icons })])
+        );
+
+        const fields = await screen.findAllByRole('textbox', { name: 'Street' });
+        expect(fields).toHaveLength(2);
+        expect(fields[0]).toHaveValue('1 Infinite Loop');
+        expect(fields[1]).toHaveValue('1600 Amphitheatre');
+      });
+
+      it('submits multiple added items', async () => {
+        const user = userEvent.setup();
+        const onSubmit = vi.fn();
+
+        render(
+          <Form onSubmit={onSubmit}>
+            <ArrayFormGroup rootFieldPath="contacts" groupLabel="Contact" minItems={1}>
+              {(name) => <StringField name={`${name}.email`} label="Email" />}
+            </ArrayFormGroup>
+            <button type="submit">Submit</button>
+          </Form>,
+          buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper({ icons })])
+        );
+
+        await waitFor(() => screen.getByRole('textbox', { name: 'Email' }));
+        await user.type(screen.getByRole('textbox', { name: 'Email' }), 'a@example.com');
+        await user.click(screen.getByRole('button', { name: /add contact/i }));
+
+        const fields = await screen.findAllByRole('textbox', { name: 'Email' });
+        await user.type(fields[1], 'b@example.com');
+        await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+        await waitFor(() =>
+          expect(onSubmit).toHaveBeenCalledWith(
+            { contacts: [{ email: 'a@example.com' }, { email: 'b@example.com' }] },
+            expect.anything(),
+            expect.anything()
+          )
+        );
+      });
     });
   });
 

--- a/javascript/packages/core/components/form/form.tsx
+++ b/javascript/packages/core/components/form/form.tsx
@@ -1,6 +1,7 @@
 import { useRef } from 'react';
 import { Form as FinalForm } from 'react-final-form';
 import { useStyletron } from 'baseui';
+import arrayMutators from 'final-form-arrays';
 import createFocusOnErrorDecorator from 'final-form-focus';
 
 import { StickyFooter } from '#core/components/form/components/sticky-footer/sticky-footer';
@@ -28,6 +29,7 @@ export const Form = <FieldValues extends FormData = FormData>({
       <FinalForm
         onSubmit={onSubmit}
         initialValues={initialValues}
+        mutators={{ ...arrayMutators }}
         decorators={focusOnError ? [focusOnErrorDecorator] : undefined}
         render={({ handleSubmit }) => {
           const formElement = (

--- a/javascript/packages/core/components/form/hooks/__tests__/use-array-field.test.tsx
+++ b/javascript/packages/core/components/form/hooks/__tests__/use-array-field.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { useArrayField } from '#core/components/form/hooks/use-array-field';
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
+import { getFormProviderWrapper } from '#core/test/wrappers/get-form-provider-wrapper';
+
+it('remove does not drop below minItems even when called directly without an isRemovable check', async () => {
+  function CustomArrayField() {
+    const { entries, add, remove } = useArrayField('items', { minItems: 2 });
+    return (
+      <div>
+        {entries.map(({ id }, index) => (
+          <div key={id}>
+            <span>Item {index + 1}</span>
+            <button type="button" aria-label={`Remove item ${index + 1}`} onClick={() => remove(index)}>
+              Remove
+            </button>
+          </div>
+        ))}
+        <button type="button" onClick={add}>Add</button>
+      </div>
+    );
+  }
+
+  const user = userEvent.setup();
+  render(<CustomArrayField />, buildWrapper([getBaseProviderWrapper(), getFormProviderWrapper()]));
+
+  await waitFor(() => expect(screen.getAllByText(/Item \d+/)).toHaveLength(2));
+
+  await user.click(screen.getByRole('button', { name: 'Add' }));
+  expect(screen.getAllByText(/Item \d+/)).toHaveLength(3);
+
+  await user.click(screen.getByRole('button', { name: 'Remove item 3' }));
+  await waitFor(() => expect(screen.getAllByText(/Item \d+/)).toHaveLength(2));
+
+  // Hook guard should block this — count stays at 2
+  await user.click(screen.getByRole('button', { name: 'Remove item 2' }));
+  expect(screen.getAllByText(/Item \d+/)).toHaveLength(2);
+});

--- a/javascript/packages/core/components/form/hooks/__tests__/use-array-field.test.tsx
+++ b/javascript/packages/core/components/form/hooks/__tests__/use-array-field.test.tsx
@@ -14,12 +14,18 @@ it('remove does not drop below minItems even when called directly without an isR
         {entries.map(({ id }, index) => (
           <div key={id}>
             <span>Item {index + 1}</span>
-            <button type="button" aria-label={`Remove item ${index + 1}`} onClick={() => remove(index)}>
+            <button
+              type="button"
+              aria-label={`Remove item ${index + 1}`}
+              onClick={() => remove(index)}
+            >
               Remove
             </button>
           </div>
         ))}
-        <button type="button" onClick={add}>Add</button>
+        <button type="button" onClick={add}>
+          Add
+        </button>
       </div>
     );
   }

--- a/javascript/packages/core/components/form/hooks/use-array-field.ts
+++ b/javascript/packages/core/components/form/hooks/use-array-field.ts
@@ -1,0 +1,76 @@
+import { useEffect, useRef } from 'react';
+import { useFieldArray } from 'react-final-form-arrays';
+
+import type { ArrayFieldOptions } from '#core/components/form/types';
+
+/**
+ * @param rootFieldPath - Dot-notation path to the root field of the array.
+ *
+ * @returns An object containing the following properties:
+ * - `entries`: one entry per array item, each with a stable `id` (UUID) for use as a React
+ * `key` prop and an `indexedFieldPath` for constructing nested field names. Guaranteed to have at
+ * least `minItems` entries after the initial effect runs.
+ *
+ * - `add`: Pushes one new empty item to the array.
+ *
+ * - `remove`: Removes an item from the array.
+ *
+ * - `isRemovable`: Indicates if an array item can be removed.
+ *
+ * @example
+ * ```tsx
+ * const { entries, add, remove, isRemovable } = useArrayField('contacts', { minItems: 1 });
+ *
+ * return (
+ *   <>
+ *     {entries.map(({ id, indexedFieldPath }, index) => (
+ *       <div key={id}>
+ *         <StringField name={`${indexedFieldPath}.email`} label="Email" />
+ *         {isRemovable && <button onClick={() => remove(index)}>Remove</button>}
+ *       </div>
+ *     ))}
+ *     <button onClick={add}>Add more</button>
+ *   </>
+ * );
+ * ```
+ */
+export function useArrayField(
+  rootFieldPath: string,
+  { minItems = 0, readOnly = false }: ArrayFieldOptions = {}
+) {
+  const { fields } = useFieldArray(rootFieldPath);
+
+  const entryIds = useRef<string[]>(
+    Array.from({ length: fields.length ?? 0 }, () => crypto.randomUUID())
+  );
+
+  useEffect(() => {
+    const currentLength = fields.length ?? 0;
+    if (currentLength < minItems) {
+      for (let i = currentLength; i < minItems; i++) {
+        entryIds.current.push(crypto.randomUUID());
+        fields.push({});
+      }
+    }
+  }, [fields, minItems]);
+
+  const add = () => {
+    entryIds.current.push(crypto.randomUUID());
+    fields.push({});
+  };
+
+  const remove = (index: number) => {
+    entryIds.current.splice(index, 1);
+    fields.remove(index);
+  };
+
+  return {
+    entries: fields.map((indexedFieldPath, index) => ({
+      id: entryIds.current[index],
+      indexedFieldPath,
+    })),
+    add,
+    remove,
+    isRemovable: (fields.length ?? 0) > minItems && !readOnly,
+  };
+}

--- a/javascript/packages/core/components/form/hooks/use-array-field.ts
+++ b/javascript/packages/core/components/form/hooks/use-array-field.ts
@@ -54,12 +54,15 @@ export function useArrayField(
     }
   }, [fields, minItems]);
 
+  const isRemovable = (fields.length ?? 0) > minItems && !readOnly;
+
   const add = () => {
     entryIds.current.push(crypto.randomUUID());
     fields.push({});
   };
 
   const remove = (index: number) => {
+    if (!isRemovable) return;
     entryIds.current.splice(index, 1);
     fields.remove(index);
   };
@@ -71,6 +74,6 @@ export function useArrayField(
     })),
     add,
     remove,
-    isRemovable: (fields.length ?? 0) > minItems && !readOnly,
+    isRemovable,
   };
 }

--- a/javascript/packages/core/components/form/layout/array-form-group/__tests__/array-form-group.test.tsx
+++ b/javascript/packages/core/components/form/layout/array-form-group/__tests__/array-form-group.test.tsx
@@ -59,6 +59,36 @@ it('uses groupLabel in add button label', () => {
   expect(screen.getByRole('button', { name: /add address/i })).toBeInTheDocument();
 });
 
+it('falls back to "Add more" when no groupLabel or addLabel is provided', () => {
+  render(
+    <ArrayFormGroup rootFieldPath="addresses">
+      {(name) => <StringField name={`${name}.street`} label="Street" />}
+    </ArrayFormGroup>,
+    buildWrapper([
+      getBaseProviderWrapper(),
+      getIconProviderWrapper({ icons }),
+      getFormProviderWrapper({}),
+    ])
+  );
+
+  expect(screen.getByRole('button', { name: 'Add more' })).toBeInTheDocument();
+});
+
+it('uses addLabel over the derived groupLabel label', () => {
+  render(
+    <ArrayFormGroup rootFieldPath="models" groupLabel="ML Model" addLabel="Add ML model">
+      {(name) => <StringField name={`${name}.name`} label="Name" />}
+    </ArrayFormGroup>,
+    buildWrapper([
+      getBaseProviderWrapper(),
+      getIconProviderWrapper({ icons }),
+      getFormProviderWrapper({}),
+    ])
+  );
+
+  expect(screen.getByRole('button', { name: 'Add ML model' })).toBeInTheDocument();
+});
+
 it('prepopulates groups to meet minItems on mount', async () => {
   render(
     <ArrayFormGroup rootFieldPath="addresses" groupLabel="Address" minItems={3}>

--- a/javascript/packages/core/components/form/layout/array-form-group/__tests__/array-form-group.test.tsx
+++ b/javascript/packages/core/components/form/layout/array-form-group/__tests__/array-form-group.test.tsx
@@ -1,0 +1,159 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DeleteAlt, Plus } from 'baseui/icon';
+
+import { StringField } from '#core/components/form/fields/string/string-field';
+import { ArrayFormGroup } from '#core/components/form/layout/array-form-group/array-form-group';
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
+import { getFormProviderWrapper } from '#core/test/wrappers/get-form-provider-wrapper';
+import { getIconProviderWrapper } from '#core/test/wrappers/get-icon-provider-wrapper';
+
+const icons = { plus: Plus, deleteAlt: DeleteAlt };
+
+it('renders numbered group titles when groupLabel is provided', async () => {
+  render(
+    <ArrayFormGroup rootFieldPath="addresses" groupLabel="Address" minItems={2}>
+      {(name) => <StringField name={`${name}.street`} label="Street" />}
+    </ArrayFormGroup>,
+    buildWrapper([
+      getBaseProviderWrapper(),
+      getIconProviderWrapper({ icons }),
+      getFormProviderWrapper({}),
+    ])
+  );
+
+  await waitFor(() => expect(screen.getAllByRole('textbox', { name: 'Street' })).toHaveLength(2));
+  expect(screen.getByText('Address 1')).toBeInTheDocument();
+  expect(screen.getByText('Address 2')).toBeInTheDocument();
+});
+
+it('renders no title when groupLabel is omitted', async () => {
+  render(
+    <ArrayFormGroup rootFieldPath="addresses" minItems={1}>
+      {(name) => <StringField name={`${name}.street`} label="Street" />}
+    </ArrayFormGroup>,
+    buildWrapper([
+      getBaseProviderWrapper(),
+      getIconProviderWrapper({ icons }),
+      getFormProviderWrapper({}),
+    ])
+  );
+
+  await waitFor(() => screen.getByRole('textbox', { name: 'Street' }));
+  expect(screen.queryByText(/\d+/)).not.toBeInTheDocument();
+});
+
+it('uses groupLabel in add button label', () => {
+  render(
+    <ArrayFormGroup rootFieldPath="addresses" groupLabel="Address">
+      {(name) => <StringField name={`${name}.street`} label="Street" />}
+    </ArrayFormGroup>,
+    buildWrapper([
+      getBaseProviderWrapper(),
+      getIconProviderWrapper({ icons }),
+      getFormProviderWrapper({}),
+    ])
+  );
+
+  expect(screen.getByRole('button', { name: /add address/i })).toBeInTheDocument();
+});
+
+it('prepopulates groups to meet minItems on mount', async () => {
+  render(
+    <ArrayFormGroup rootFieldPath="addresses" groupLabel="Address" minItems={3}>
+      {(name) => <StringField name={`${name}.street`} label="Street" />}
+    </ArrayFormGroup>,
+    buildWrapper([
+      getBaseProviderWrapper(),
+      getIconProviderWrapper({ icons }),
+      getFormProviderWrapper({}),
+    ])
+  );
+
+  await waitFor(() => expect(screen.getAllByRole('textbox', { name: 'Street' })).toHaveLength(3));
+});
+
+it('adds a group when the add button is clicked', async () => {
+  const user = userEvent.setup();
+
+  render(
+    <ArrayFormGroup rootFieldPath="addresses" groupLabel="Address" minItems={1}>
+      {(name) => <StringField name={`${name}.street`} label="Street" />}
+    </ArrayFormGroup>,
+    buildWrapper([
+      getBaseProviderWrapper(),
+      getIconProviderWrapper({ icons }),
+      getFormProviderWrapper({}),
+    ])
+  );
+
+  await waitFor(() => screen.getByRole('textbox', { name: 'Street' }));
+  await user.click(screen.getByRole('button', { name: /add address/i }));
+
+  expect(screen.getAllByRole('textbox', { name: 'Street' })).toHaveLength(2);
+  expect(screen.getByText('Address 2')).toBeInTheDocument();
+});
+
+it('hides remove when at minItems', async () => {
+  render(
+    <ArrayFormGroup rootFieldPath="addresses" groupLabel="Address" minItems={2}>
+      {(name) => <StringField name={`${name}.street`} label="Street" />}
+    </ArrayFormGroup>,
+    buildWrapper([
+      getBaseProviderWrapper(),
+      getIconProviderWrapper({ icons }),
+      getFormProviderWrapper({}),
+    ])
+  );
+
+  await waitFor(() => expect(screen.getAllByRole('textbox', { name: 'Street' })).toHaveLength(2));
+  expect(screen.queryByRole('button', { name: /remove/i })).not.toBeInTheDocument();
+});
+
+it('hides add and remove buttons when readOnly', async () => {
+  render(
+    <ArrayFormGroup rootFieldPath="addresses" groupLabel="Address" minItems={2} readOnly>
+      {(name) => <StringField name={`${name}.street`} label="Street" />}
+    </ArrayFormGroup>,
+    buildWrapper([
+      getBaseProviderWrapper(),
+      getIconProviderWrapper({ icons }),
+      getFormProviderWrapper({}),
+    ])
+  );
+
+  await waitFor(() => expect(screen.getAllByRole('textbox', { name: 'Street' })).toHaveLength(2));
+  expect(screen.queryByRole('button', { name: /add address/i })).not.toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: /remove/i })).not.toBeInTheDocument();
+});
+
+it('typing in the remaining group after removing the first does not corrupt values', async () => {
+  const user = userEvent.setup();
+
+  render(
+    <ArrayFormGroup rootFieldPath="contacts" groupLabel="Contact" minItems={1}>
+      {(name) => <StringField name={`${name}.name`} label="Name" />}
+    </ArrayFormGroup>,
+    buildWrapper([
+      getBaseProviderWrapper(),
+      getIconProviderWrapper({ icons }),
+      getFormProviderWrapper({}),
+    ])
+  );
+
+  await waitFor(() => screen.getByRole('textbox', { name: 'Name' }));
+
+  // Type in group 1, add group 2, type in group 2
+  await user.type(screen.getAllByRole('textbox', { name: 'Name' })[0], 'Alice');
+  await user.click(screen.getByRole('button', { name: /add contact/i }));
+  await user.type(screen.getAllByRole('textbox', { name: 'Name' })[1], 'Bob');
+
+  // Remove group 1
+  const removeButtons = screen.getAllByRole('button', { name: /remove/i });
+  await user.click(removeButtons[0]);
+
+  // Only 1 group remains, showing Bob's value (which shifted to index 0)
+  await waitFor(() => expect(screen.getAllByRole('textbox', { name: 'Name' })).toHaveLength(1));
+  expect(screen.getByRole('textbox', { name: 'Name' })).toHaveValue('Bob');
+});

--- a/javascript/packages/core/components/form/layout/array-form-group/__tests__/array-form-group.test.tsx
+++ b/javascript/packages/core/components/form/layout/array-form-group/__tests__/array-form-group.test.tsx
@@ -71,7 +71,7 @@ it('falls back to "Add more" when no groupLabel or addLabel is provided', () => 
     ])
   );
 
-  expect(screen.getByRole('button', { name: 'Add more' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /add more/i })).toBeInTheDocument();
 });
 
 it('uses addLabel over the derived groupLabel label', () => {
@@ -86,7 +86,7 @@ it('uses addLabel over the derived groupLabel label', () => {
     ])
   );
 
-  expect(screen.getByRole('button', { name: 'Add ML model' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /Add ML model/ })).toBeInTheDocument();
 });
 
 it('prepopulates groups to meet minItems on mount', async () => {

--- a/javascript/packages/core/components/form/layout/array-form-group/array-form-group.tsx
+++ b/javascript/packages/core/components/form/layout/array-form-group/array-form-group.tsx
@@ -12,6 +12,7 @@ import type { ArrayFormGroupProps } from './types';
 export function ArrayFormGroup({
   rootFieldPath,
   groupLabel,
+  addLabel: addLabelProp,
   minItems = 0,
   readOnly = false,
   children,
@@ -24,7 +25,7 @@ export function ArrayFormGroup({
     minItems,
     readOnly,
   });
-  const addLabel = groupLabel ? `Add ${groupLabel.toLowerCase()}` : 'Add more';
+  const addLabel = addLabelProp ?? (groupLabel ? `Add ${groupLabel.toLowerCase()}` : 'Add more');
 
   return (
     <>
@@ -36,7 +37,7 @@ export function ArrayFormGroup({
             tooltip={tooltip}
             collapsible={collapsible}
             endEnhancer={
-              isRemovable ? (
+              isRemovable && (
                 <Button
                   type="button"
                   kind={KIND.secondary}
@@ -48,7 +49,7 @@ export function ArrayFormGroup({
                 >
                   Remove
                 </Button>
-              ) : undefined
+              )
             }
             overrides={{
               // FormGroup comes with marginBottom that intends to be applied to separate groups in the

--- a/javascript/packages/core/components/form/layout/array-form-group/array-form-group.tsx
+++ b/javascript/packages/core/components/form/layout/array-form-group/array-form-group.tsx
@@ -1,0 +1,83 @@
+import { useStyletron } from 'baseui';
+import { Button, KIND, SHAPE, SIZE } from 'baseui/button';
+
+import { useArrayField } from '#core/components/form/hooks/use-array-field';
+import { FormGroup } from '#core/components/form/layout/form-group/form-group';
+import { Icon } from '#core/components/icon/icon';
+import { IconKind } from '#core/components/icon/types';
+import { RepeatedLayoutProvider } from '#core/providers/repeated-layout-provider/repeated-layout-provider';
+
+import type { ArrayFormGroupProps } from './types';
+
+export function ArrayFormGroup({
+  rootFieldPath,
+  groupLabel,
+  minItems = 0,
+  readOnly = false,
+  children,
+  description,
+  tooltip,
+  collapsible,
+}: ArrayFormGroupProps) {
+  const [, theme] = useStyletron();
+  const { entries, add, remove, isRemovable } = useArrayField(rootFieldPath, {
+    minItems,
+    readOnly,
+  });
+  const addLabel = groupLabel ? `Add ${groupLabel.toLowerCase()}` : 'Add more';
+
+  return (
+    <>
+      {entries.map(({ id, indexedFieldPath }, index) => (
+        <RepeatedLayoutProvider key={id} index={index} rootFieldPath={rootFieldPath}>
+          <FormGroup
+            title={groupLabel ? `${groupLabel} ${index + 1}` : undefined}
+            description={description}
+            tooltip={tooltip}
+            collapsible={collapsible}
+            endEnhancer={
+              isRemovable ? (
+                <Button
+                  type="button"
+                  kind={KIND.secondary}
+                  shape={SHAPE.pill}
+                  size={SIZE.compact}
+                  startEnhancer={<Icon name="trashCan" kind={IconKind.PRIMARY} />}
+                  aria-label="Remove"
+                  onClick={() => remove(index)}
+                >
+                  Remove
+                </Button>
+              ) : undefined
+            }
+            overrides={{
+              // FormGroup comes with marginBottom that intends to be applied to separate groups in the
+              // context of an entire form. Since the ArrayFormGroup has a button at the end, we need to
+              // remove the margin bottom to avoid disconnect between the form group and the button.
+              BoxContainer: { style: { marginBottom: 0 } },
+            }}
+          >
+            {children(indexedFieldPath, index)}
+          </FormGroup>
+        </RepeatedLayoutProvider>
+      ))}
+      {!readOnly && (
+        <Button
+          type="button"
+          kind={KIND.secondary}
+          shape={SHAPE.pill}
+          size={SIZE.compact}
+          startEnhancer={
+            <Icon name="plus" color={theme.colors.contentPrimary} size={theme.sizing.scale600} />
+          }
+          overrides={{
+            BaseButton: { style: { marginBottom: theme.sizing.scale600, width: '260px' } },
+          }}
+          onClick={add}
+        >
+          {addLabel}
+        </Button>
+      )}
+    </>
+  );
+}

--- a/javascript/packages/core/components/form/layout/array-form-group/types.ts
+++ b/javascript/packages/core/components/form/layout/array-form-group/types.ts
@@ -10,4 +10,13 @@ export interface ArrayFormGroupProps
    * Omit to render groups without a title.
    */
   groupLabel?: string;
+
+  /**
+   * Label for the add button. Overrides the default derived from `groupLabel`.
+   * Use when the default lowercased label is inappropriate, e.g. for acronyms:
+   * `addLabel="Add ML model"` instead of `"Add ml model"`.
+   *
+   * @default `"Add ${groupLabel.toLowerCase()}"` or `"Add more"` if no groupLabel
+   */
+  addLabel?: string;
 }

--- a/javascript/packages/core/components/form/layout/array-form-group/types.ts
+++ b/javascript/packages/core/components/form/layout/array-form-group/types.ts
@@ -1,0 +1,13 @@
+import type { FormGroupProps } from '#core/components/form/layout/form-group/types';
+import type { ArrayLayoutProps } from '#core/components/form/layout/types';
+
+export interface ArrayFormGroupProps
+  extends Omit<FormGroupProps, 'children' | 'title' | 'endEnhancer'>,
+    ArrayLayoutProps {
+  /**
+   * Prefix for auto-numbered group titles.
+   * e.g. `groupLabel="Address"` → "Address 1", "Address 2", ...
+   * Omit to render groups without a title.
+   */
+  groupLabel?: string;
+}

--- a/javascript/packages/core/components/form/layout/array-form-row/__tests__/array-form-row.test.tsx
+++ b/javascript/packages/core/components/form/layout/array-form-row/__tests__/array-form-row.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DeleteAlt, Plus } from 'baseui/icon';
+
+import { StringField } from '#core/components/form/fields/string/string-field';
+import { ArrayFormRow } from '#core/components/form/layout/array-form-row/array-form-row';
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
+import { getFormProviderWrapper } from '#core/test/wrappers/get-form-provider-wrapper';
+import { getIconProviderWrapper } from '#core/test/wrappers/get-icon-provider-wrapper';
+
+const icons = { plus: Plus, deleteAlt: DeleteAlt };
+
+it('renders children for each initial item', () => {
+  render(
+    <ArrayFormRow rootFieldPath="tags" minItems={2}>
+      {(name) => <StringField name={`${name}.value`} label="Tag" />}
+    </ArrayFormRow>,
+    buildWrapper([
+      getBaseProviderWrapper(),
+      getIconProviderWrapper({ icons }),
+      getFormProviderWrapper({}),
+    ])
+  );
+
+  expect(screen.getAllByRole('textbox', { name: 'Tag' })).toHaveLength(2);
+});
+
+it('prepopulates rows to meet minItems on mount', async () => {
+  render(
+    <ArrayFormRow rootFieldPath="tags" minItems={3}>
+      {(name) => <StringField name={`${name}.value`} label="Tag" />}
+    </ArrayFormRow>,
+    buildWrapper([
+      getBaseProviderWrapper(),
+      getIconProviderWrapper({ icons }),
+      getFormProviderWrapper({}),
+    ])
+  );
+
+  await waitFor(() => expect(screen.getAllByRole('textbox', { name: 'Tag' })).toHaveLength(3));
+});
+
+it('adds a row when "Add more" is clicked', async () => {
+  const user = userEvent.setup();
+
+  render(
+    <ArrayFormRow rootFieldPath="tags" minItems={1}>
+      {(name) => <StringField name={`${name}.value`} label="Tag" />}
+    </ArrayFormRow>,
+    buildWrapper([
+      getBaseProviderWrapper(),
+      getIconProviderWrapper({ icons }),
+      getFormProviderWrapper({}),
+    ])
+  );
+
+  await waitFor(() => screen.getByRole('textbox', { name: 'Tag' }));
+  await user.click(screen.getByRole('button', { name: /add more/i }));
+
+  expect(screen.getAllByRole('textbox', { name: 'Tag' })).toHaveLength(2);
+});
+
+it('hides remove button when at minItems', async () => {
+  render(
+    <ArrayFormRow rootFieldPath="tags" minItems={2}>
+      {(name) => <StringField name={`${name}.value`} label="Tag" />}
+    </ArrayFormRow>,
+    buildWrapper([
+      getBaseProviderWrapper(),
+      getIconProviderWrapper({ icons }),
+      getFormProviderWrapper({}),
+    ])
+  );
+
+  await waitFor(() => expect(screen.getAllByRole('textbox', { name: 'Tag' })).toHaveLength(2));
+  expect(screen.queryByRole('button', { name: /remove/i })).not.toBeInTheDocument();
+});
+
+it('removes a row when remove is clicked', async () => {
+  const user = userEvent.setup();
+
+  render(
+    <ArrayFormRow rootFieldPath="tags" minItems={1}>
+      {(name) => <StringField name={`${name}.value`} label="Tag" />}
+    </ArrayFormRow>,
+    buildWrapper([
+      getBaseProviderWrapper(),
+      getIconProviderWrapper({ icons }),
+      getFormProviderWrapper({}),
+    ])
+  );
+
+  await waitFor(() => screen.getByRole('textbox', { name: 'Tag' }));
+
+  // Add a second row so the remove button appears
+  await user.click(screen.getByRole('button', { name: /add more/i }));
+  expect(screen.getAllByRole('textbox', { name: 'Tag' })).toHaveLength(2);
+
+  // Remove one row
+  await user.click(screen.getAllByRole('button', { name: /remove/i })[0]);
+
+  await waitFor(() => expect(screen.getAllByRole('textbox', { name: 'Tag' })).toHaveLength(1));
+});
+
+it('hides add and remove buttons when readOnly', async () => {
+  render(
+    <ArrayFormRow rootFieldPath="tags" minItems={2} readOnly>
+      {(name) => <StringField name={`${name}.value`} label="Tag" />}
+    </ArrayFormRow>,
+    buildWrapper([
+      getBaseProviderWrapper(),
+      getIconProviderWrapper({ icons }),
+      getFormProviderWrapper({}),
+    ])
+  );
+
+  await waitFor(() => expect(screen.getAllByRole('textbox', { name: 'Tag' })).toHaveLength(2));
+  expect(screen.queryByRole('button', { name: /add more/i })).not.toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: /remove/i })).not.toBeInTheDocument();
+});

--- a/javascript/packages/core/components/form/layout/array-form-row/__tests__/array-form-row.test.tsx
+++ b/javascript/packages/core/components/form/layout/array-form-row/__tests__/array-form-row.test.tsx
@@ -56,7 +56,7 @@ it('adds a row when "Add more" is clicked', async () => {
   );
 
   await waitFor(() => screen.getByRole('textbox', { name: 'Tag' }));
-  await user.click(screen.getByRole('button', { name: /add more/i }));
+  await user.click(screen.getByRole('button', { name: /Add more/ }));
 
   expect(screen.getAllByRole('textbox', { name: 'Tag' })).toHaveLength(2);
 });
@@ -94,7 +94,7 @@ it('removes a row when remove is clicked', async () => {
   await waitFor(() => screen.getByRole('textbox', { name: 'Tag' }));
 
   // Add a second row so the remove button appears
-  await user.click(screen.getByRole('button', { name: /add more/i }));
+  await user.click(screen.getByRole('button', { name: /Add more/ }));
   expect(screen.getAllByRole('textbox', { name: 'Tag' })).toHaveLength(2);
 
   // Remove one row
@@ -115,10 +115,10 @@ it('uses addLabel for the add button', () => {
     ])
   );
 
-  expect(screen.getByRole('button', { name: 'Add tag' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /Add tag/ })).toBeInTheDocument();
 });
 
-it('Hides add and remove buttons when readOnly is true', async () => {
+it('hides add and remove buttons when readOnly', async () => {
   render(
     <ArrayFormRow rootFieldPath="tags" minItems={2} readOnly>
       {(name) => <StringField name={`${name}.value`} label="Tag" />}

--- a/javascript/packages/core/components/form/layout/array-form-row/__tests__/array-form-row.test.tsx
+++ b/javascript/packages/core/components/form/layout/array-form-row/__tests__/array-form-row.test.tsx
@@ -117,6 +117,8 @@ it('uses addLabel for the add button', () => {
 
   expect(screen.getByRole('button', { name: 'Add tag' })).toBeInTheDocument();
 });
+
+it('Hides add and remove buttons when readOnly is true', async () => {
   render(
     <ArrayFormRow rootFieldPath="tags" minItems={2} readOnly>
       {(name) => <StringField name={`${name}.value`} label="Tag" />}

--- a/javascript/packages/core/components/form/layout/array-form-row/__tests__/array-form-row.test.tsx
+++ b/javascript/packages/core/components/form/layout/array-form-row/__tests__/array-form-row.test.tsx
@@ -103,7 +103,20 @@ it('removes a row when remove is clicked', async () => {
   await waitFor(() => expect(screen.getAllByRole('textbox', { name: 'Tag' })).toHaveLength(1));
 });
 
-it('hides add and remove buttons when readOnly', async () => {
+it('uses addLabel for the add button', () => {
+  render(
+    <ArrayFormRow rootFieldPath="tags" addLabel="Add tag">
+      {(name) => <StringField name={`${name}.value`} label="Tag" />}
+    </ArrayFormRow>,
+    buildWrapper([
+      getBaseProviderWrapper(),
+      getIconProviderWrapper({ icons }),
+      getFormProviderWrapper({}),
+    ])
+  );
+
+  expect(screen.getByRole('button', { name: 'Add tag' })).toBeInTheDocument();
+});
   render(
     <ArrayFormRow rootFieldPath="tags" minItems={2} readOnly>
       {(name) => <StringField name={`${name}.value`} label="Tag" />}

--- a/javascript/packages/core/components/form/layout/array-form-row/array-form-row.tsx
+++ b/javascript/packages/core/components/form/layout/array-form-row/array-form-row.tsx
@@ -17,6 +17,7 @@ export function ArrayFormRow({
   children,
   name,
   span,
+  addLabel = 'Add more',
 }: ArrayFormRowProps) {
   const [css, theme] = useStyletron();
   const { entries, add, remove, isRemovable } = useArrayField(rootFieldPath, {
@@ -73,7 +74,7 @@ export function ArrayFormRow({
           }}
           onClick={add}
         >
-          Add more
+          {addLabel}
         </Button>
       )}
     </>

--- a/javascript/packages/core/components/form/layout/array-form-row/array-form-row.tsx
+++ b/javascript/packages/core/components/form/layout/array-form-row/array-form-row.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { useStyletron } from 'baseui';
+import { Button, KIND, SHAPE, SIZE } from 'baseui/button';
+
+import { useArrayField } from '#core/components/form/hooks/use-array-field';
+import { FormRow } from '#core/components/form/layout/form-row/form-row';
+import { Icon } from '#core/components/icon/icon';
+import { IconKind } from '#core/components/icon/types';
+import { RepeatedLayoutProvider } from '#core/providers/repeated-layout-provider/repeated-layout-provider';
+
+import type { ArrayFormRowProps } from './types';
+
+export function ArrayFormRow({
+  rootFieldPath,
+  minItems = 0,
+  readOnly = false,
+  children,
+  name,
+  span,
+}: ArrayFormRowProps) {
+  const [css, theme] = useStyletron();
+  const { entries, add, remove, isRemovable } = useArrayField(rootFieldPath, {
+    minItems,
+    readOnly,
+  });
+
+  return (
+    <>
+      {entries.map(({ id, indexedFieldPath }, index) => {
+        const rowContent = children(indexedFieldPath, index);
+        // Unwrap a top-level Fragment so callers can return multiple fields
+        // from the render prop and have each placed in its own grid column.
+        const rowChildren =
+          React.isValidElement<React.PropsWithChildren>(rowContent) &&
+          rowContent.type === React.Fragment
+            ? rowContent.props.children
+            : rowContent;
+
+        return (
+          <RepeatedLayoutProvider key={id} index={index} rootFieldPath={rootFieldPath}>
+            <div
+              className={css({ display: 'flex', alignItems: 'end', gap: theme.sizing.scale300 })}
+            >
+              <FormRow name={name} span={span}>
+                {rowChildren}
+              </FormRow>
+              {isRemovable && (
+                <Button
+                  type="button"
+                  kind={KIND.tertiary}
+                  shape={SHAPE.circle}
+                  size={SIZE.default}
+                  aria-label="Remove"
+                  onClick={() => remove(index)}
+                >
+                  <Icon name="deleteAlt" kind={IconKind.SECONDARY} />
+                </Button>
+              )}
+            </div>
+          </RepeatedLayoutProvider>
+        );
+      })}
+      {!readOnly && (
+        <Button
+          type="button"
+          kind={KIND.secondary}
+          size={SIZE.compact}
+          startEnhancer={
+            <Icon name="plus" color={theme.colors.contentPrimary} size={theme.sizing.scale600} />
+          }
+          overrides={{
+            BaseButton: { style: { marginBottom: theme.sizing.scale600, width: '260px' } },
+          }}
+          onClick={add}
+        >
+          Add more
+        </Button>
+      )}
+    </>
+  );
+}

--- a/javascript/packages/core/components/form/layout/array-form-row/types.ts
+++ b/javascript/packages/core/components/form/layout/array-form-row/types.ts
@@ -1,4 +1,12 @@
 import type { FormRowProps } from '#core/components/form/layout/form-row/types';
 import type { ArrayLayoutProps } from '#core/components/form/layout/types';
 
-export interface ArrayFormRowProps extends Omit<FormRowProps, 'children'>, ArrayLayoutProps {}
+export interface ArrayFormRowProps extends Omit<FormRowProps, 'children'>, ArrayLayoutProps {
+  /**
+   * Label for the add button.
+   * Use when "Add more" is insufficient, e.g. for acronyms: `addLabel="Add ML model"`.
+   *
+   * @default "Add more"
+   */
+  addLabel?: string;
+}

--- a/javascript/packages/core/components/form/layout/array-form-row/types.ts
+++ b/javascript/packages/core/components/form/layout/array-form-row/types.ts
@@ -1,0 +1,4 @@
+import type { FormRowProps } from '#core/components/form/layout/form-row/types';
+import type { ArrayLayoutProps } from '#core/components/form/layout/types';
+
+export interface ArrayFormRowProps extends Omit<FormRowProps, 'children'>, ArrayLayoutProps {}

--- a/javascript/packages/core/components/form/layout/form-group/form-group.tsx
+++ b/javascript/packages/core/components/form/layout/form-group/form-group.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useStyletron } from 'baseui';
+import { mergeOverrides, useStyletron } from 'baseui';
 
 import { Box } from '#core/components/box/box';
 import { CollapsibleBox } from '#core/components/box/collapsible-box';
@@ -14,19 +14,36 @@ export const FormGroup: React.FC<FormGroupProps> = ({
   tooltip,
   collapsible = false,
   endEnhancer,
+  overrides = {},
   children,
 }) => {
   const [css, theme] = useStyletron();
 
-  const enhancedTitle =
-    title && (tooltip ?? endEnhancer) ? (
+  const titleWithTooltip =
+    title && tooltip ? (
       <div className={css({ display: 'flex', alignItems: 'center', gap: theme.sizing.scale100 })}>
         {title}
-        {tooltip ? <HelpTooltip text={tooltip} /> : null}
-        {endEnhancer}
+        <HelpTooltip text={tooltip} />
       </div>
     ) : (
       title
+    );
+
+  const enhancedTitle =
+    titleWithTooltip && endEnhancer ? (
+      <div
+        className={css({
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          width: '100%',
+        })}
+      >
+        {titleWithTooltip}
+        {endEnhancer}
+      </div>
+    ) : (
+      titleWithTooltip
     );
 
   const enhancedDescription = description ? <Markdown>{description}</Markdown> : undefined;
@@ -54,13 +71,16 @@ export const FormGroup: React.FC<FormGroupProps> = ({
     <Box
       title={enhancedTitle}
       description={enhancedDescription}
-      overrides={{
-        BoxContainer: {
-          style: {
-            marginBottom: theme.sizing.scale600,
+      overrides={mergeOverrides(
+        {
+          BoxContainer: {
+            style: {
+              marginBottom: theme.sizing.scale600,
+            },
           },
         },
-      }}
+        overrides
+      )}
     >
       {children}
     </Box>

--- a/javascript/packages/core/components/form/layout/form-group/types.ts
+++ b/javascript/packages/core/components/form/layout/form-group/types.ts
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import type { BoxOverrides } from '#core/components/box/types';
 
 export interface FormGroupProps {
   title?: string;
@@ -18,6 +19,9 @@ export interface FormGroupProps {
 
   /** Additional content for the header (e.g., action buttons) */
   endEnhancer?: ReactNode;
+
+  /** BaseUI overrides for the underlying Box container */
+  overrides?: BoxOverrides;
 
   children: ReactNode;
 }

--- a/javascript/packages/core/components/form/layout/types.ts
+++ b/javascript/packages/core/components/form/layout/types.ts
@@ -1,0 +1,25 @@
+import type { ReactNode } from 'react';
+import type { ArrayFieldOptions } from '#core/components/form/types';
+
+export interface ArrayLayoutProps extends ArrayFieldOptions {
+  /**
+   * Dot-notation path to the root field of the array layout.
+   * @note The field value must be an array.
+   *
+   * @example 'addresses'
+   * @example 'contacts[0].emails'
+   */
+  rootFieldPath: string;
+
+  /**
+   * Render function called once per array item.
+   *
+   * @param indexedFieldPath - The indexed, dot-notation path for this item,
+   *   e.g. `"addresses[0]"`, `"contacts.emails[1]"`.
+   *   Prefix nested field names with this value:
+   *   `<StringField name={`${indexedFieldPath}.street`} />`
+   * @param index - Zero-based position of this item in the array. Use for display labels,
+   *   e.g. `Address ${index + 1}`.
+   */
+  children: (indexedFieldPath: string, index: number) => ReactNode;
+}

--- a/javascript/packages/core/components/form/types.ts
+++ b/javascript/packages/core/components/form/types.ts
@@ -105,3 +105,11 @@ export interface FormApi {
   change: (name: string, value: unknown) => void;
   submit: () => Promise<object | undefined> | undefined;
 }
+export interface ArrayFieldOptions {
+  /**
+   * Pre-populates with empty entries _on mount_ when the array has fewer items than this value,
+   * and prevents removal when the array has fewer items than this value.
+   */
+  minItems?: number;
+  readOnly?: boolean;
+}

--- a/javascript/packages/core/components/views/sandbox/sandbox.tsx
+++ b/javascript/packages/core/components/views/sandbox/sandbox.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { FormSpy } from 'react-final-form';
 import { Block } from 'baseui/block';
 import { Button } from 'baseui/button';
 import { Notification } from 'baseui/notification';
@@ -13,6 +14,8 @@ import { SelectField } from '#core/components/form/fields/select/select-field';
 import { StringField } from '#core/components/form/fields/string/string-field';
 import { UrlField } from '#core/components/form/fields/url/url-field';
 import { Form } from '#core/components/form/form';
+import { ArrayFormGroup } from '#core/components/form/layout/array-form-group/array-form-group';
+import { ArrayFormRow } from '#core/components/form/layout/array-form-row/array-form-row';
 import { FormColumn } from '#core/components/form/layout/form-column/form-column';
 import { FormGrid } from '#core/components/form/layout/form-grid/form-grid';
 import { FormGroup } from '#core/components/form/layout/form-group/form-group';
@@ -378,6 +381,61 @@ export function Sandbox() {
                 />
                 <StringField name="slackHandle" label="Slack Handle" />
               </FormGroup>
+            </Form>
+          </Block>
+        </Tab>
+
+        <Tab title="Repeated Fields">
+          <Block marginTop="24px" maxWidth="600px">
+            <Form onSubmit={(values) => console.log('Submitted:', values)}>
+              <ArrayFormGroup
+                rootFieldPath="addresses"
+                groupLabel="Address"
+                minItems={1}
+                description="Addresses are required."
+                tooltip="Addresses are required."
+              >
+                {(name) => (
+                  <>
+                    <StringField name={`${name}.street`} label="Street" validate={required()} />
+                    <StringField name={`${name}.city`} label="City" validate={required()} />
+                    <StringField name={`${name}.postcode`} label="Postcode" />
+                  </>
+                )}
+              </ArrayFormGroup>
+
+              <FormGroup
+                title="Supporting links"
+                description="Inline repeated fields using ArrayFormRow."
+              >
+                <ArrayFormRow rootFieldPath="links" span={[1, 2]} minItems={1}>
+                  {(name) => (
+                    <>
+                      <StringField name={`${name}.name`} label="Name" />
+                      <StringField name={`${name}.url`} label="URL" />
+                    </>
+                  )}
+                </ArrayFormRow>
+              </FormGroup>
+
+              <Block display="flex" justifyContent="flex-end" marginTop="scale600">
+                <Button type="submit">Submit</Button>
+              </Block>
+
+              <FormSpy subscription={{ values: true }}>
+                {({ values }) => (
+                  <Block
+                    as="pre"
+                    marginTop="scale600"
+                    padding="scale600"
+                    backgroundColor="backgroundSecondary"
+                    font="font300"
+                    overrides={{ Block: { style: { borderRadius: '8px', overflow: 'auto' } } }}
+                  >
+                    {JSON.stringify(values, null, 2)}
+                  </Block>
+                )}
+              </FormSpy>
             </Form>
           </Block>
         </Tab>

--- a/javascript/packages/core/package.json
+++ b/javascript/packages/core/package.json
@@ -24,6 +24,7 @@
     "@uiw/react-codemirror": "^4.21.23",
     "baseui": "15.0.0",
     "final-form": "4.20.10",
+    "final-form-arrays": "^1.1.2",
     "final-form-focus": "^1.1.2",
     "lodash": "^4.17.21",
     "markdown-to-jsx": "7.4.7",
@@ -31,6 +32,7 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-final-form": "6.5.9",
+    "react-final-form-arrays": "^3.1.4",
     "validator": "^13.15.15"
   },
   "devDependencies": {

--- a/javascript/yarn.lock
+++ b/javascript/yarn.lock
@@ -159,6 +159,11 @@
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.28.4.tgz#a70226016fabe25c5783b2f22d3e1c9bc5ca3326"
   integrity sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==
 
+"@babel/runtime@^7.19.4":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.28.6.tgz#d267a43cb1836dc4d182cce93ae75ba954ef6d2b"
+  integrity sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==
+
 "@babel/template@^7.27.2":
   version "7.27.2"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.27.2.tgz#fa78ceed3c4e7b63ebf6cb39e5852fca45f6809d"
@@ -2845,6 +2850,11 @@ fill-range@^7.1.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+final-form-arrays@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/final-form-arrays/-/final-form-arrays-1.2.0.tgz#8b7ff78a5bb917d1b3bd40ba02e67710b0a23d08"
+  integrity sha512-7wC38TOHO4LBcKW5Cp14CXefT985nOsuLt+cibiYVTRWiiYmxytxkJpu43wy8gMpDrJPinw3LXRW2AJdJx3eyw==
+
 final-form-focus@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/final-form-focus/-/final-form-focus-1.1.2.tgz#8ea5c4bd802e220cebaa47a587bb0be164eb6806"
@@ -4220,6 +4230,13 @@ react-dropzone@9.0.0:
     file-selector "^0.1.8"
     prop-types "^15.6.2"
     prop-types-extra "^1.1.0"
+
+react-final-form-arrays@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-final-form-arrays/-/react-final-form-arrays-3.1.4.tgz#2744941d8fd200fc648481022e515588f60bbac3"
+  integrity sha512-siVFAolUAe29rMR6u8VwepoysUcUdh6MLV2OWnCtKpsPRUdT9VUgECjAPaVMAH2GROZNiVB9On1H9MMrm9gdpg==
+  dependencies:
+    "@babel/runtime" "^7.19.4"
 
 react-final-form@6.5.9:
   version "6.5.9"


### PR DESCRIPTION
Introduce components and a hook for managing variable-length arrays of structured form fields.

useArrayField centralizes minItems enforcement and exposes an `entries` array — each entry pairs a stable UUID `id` with an `indexedFieldPath`. UUIDs are used as React key props so that removing an item causes React to destroy and recreate the shifted components rather than reuse DOM nodes that carry stale input state from their previous position.

ArrayFormGroup renders repeated card-style sections with numbered titles and a trash button. ArrayFormRow renders inline field rows with a compact remove button. Both use a render-prop children API so consumers control field content, and each implements its own add/remove buttons since the differences between them don't justify a shared abstraction.

FormGroup previously rendered endEnhancer inline next to the title with a small gap. It now uses space-between to push action buttons like the remove button to the far right of the card header regardless of title length. FormGroup also gains an overrides prop (BoxOverrides) so ArrayFormGroup can suppress the default bottom margin, which is instead provided by the add button below.

FormRow now provides support for unwrapping fragments. This allows ArrayFromRow to reuse FormRow component. This ensures ArrayFormRow renders fields in a row instead of a stack.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update


https://github.com/user-attachments/assets/2264f0d3-d417-40d3-a86e-4e9e350cfef8



