### PR TITLE
Fix flaky select-field test

### DIFF
--- a/javascript/packages/core/components/form/fields/select/__tests__/select-field.test.tsx
+++ b/javascript/packages/core/components/form/fields/select/__tests__/select-field.test.tsx
@@ -421,7 +421,9 @@ describe('SelectField', () => {
     const select = screen.getByRole('combobox', { name: 'Choice' });
     await user.click(select);
 
-    expect(screen.getAllByRole('option')).toHaveLength(3);
+    await waitFor(() => {
+      expect(screen.getAllByRole('option')).toHaveLength(3);
+    });
   });
 
   it('does not clear value while options are loading', async () => {


### PR DESCRIPTION
The select-field test was intermittently failing during local runs. The select dropdown opening is an asynchronous action, so there is a race condition that should be wrapped in a waitFor.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
