### PR TITLE
Support markdown in form-control captions

### DIFF
--- a/javascript/packages/core/components/form/components/form-control.tsx
+++ b/javascript/packages/core/components/form/components/form-control.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { useStyletron } from 'baseui';
 import { FormControl as BaseFormControl } from 'baseui/form-control';
 
+import { Markdown } from '#core/components/markdown/markdown';
+import { TruncatedText } from '#core/components/truncated-text/truncated-text';
 import { Label } from './label/label';
 
 import type { FormControlProps } from './types';
@@ -21,7 +23,13 @@ export const FormControl: React.FC<FormControlProps> = ({
     <div className={css({ width: '100%' })}>
       <BaseFormControl
         label={label && <Label label={label} required={required} description={description} />}
-        caption={caption}
+        caption={
+          caption && (
+            <TruncatedText>
+              <Markdown>{caption}</Markdown>
+            </TruncatedText>
+          )
+        }
         counter={counter}
         error={error}
         overrides={{
@@ -31,6 +39,11 @@ export const FormControl: React.FC<FormControlProps> = ({
               // provided by FormControl default interferes with form layout spacing.
               marginBottom: 0,
             },
+          },
+          Caption: {
+            style: ({ $error, $positive }) => ({
+              display: $error || $positive ? 'flex' : 'block',
+            }),
           },
         }}
       >

--- a/javascript/packages/core/components/form/components/types.ts
+++ b/javascript/packages/core/components/form/components/types.ts
@@ -2,6 +2,7 @@ export interface FormControlProps {
   label?: string;
   required?: boolean;
   description?: string;
+  /** Rendered as Markdown. */
   caption?: string;
   error?: string;
   counter?: {

--- a/javascript/packages/core/components/views/sandbox/sandbox.tsx
+++ b/javascript/packages/core/components/views/sandbox/sandbox.tsx
@@ -397,8 +397,18 @@ export function Sandbox() {
               >
                 {(name) => (
                   <>
-                    <StringField name={`${name}.street`} label="Street" validate={required()} />
-                    <StringField name={`${name}.city`} label="City" validate={required()} />
+                    <StringField
+                      name={`${name}.street`}
+                      label="Street"
+                      validate={required()}
+                      caption="This is a **formatted** caption with [a link](https://example.com) and `inline code`."
+                    />
+                    <StringField
+                      name={`${name}.city`}
+                      label="City"
+                      validate={required()}
+                      caption="This is a very long caption for the City field that demonstrates truncated text and tooltip behavior. The content intentionally exceeds the typical visible width of a form field caption, so when the field is constrained in a narrow container, the caption text will be truncated with an ellipsis. Hovering over the caption will show the full text in a tooltip, making it accessible and user-friendly while ensuring layout consistency. You can include additional helpful details here, such as formatting guidance, requirements, or other user instructions that might not fit easily in a single visible line."
+                    />
                     <StringField name={`${name}.postcode`} label="Postcode" />
                   </>
                 )}


### PR DESCRIPTION
- Introduces support for Markdown content in form captions.
- Handle caption content overflow.

In order to truncate Markdown content in form-field captions, `Caption` container needs to render it's content as block(by default its a flex container). That's why `Caption` styles are overridden for this case. 

https://github.com/user-attachments/assets/ea917a7c-9608-4e14-9a9e-a53efac71d88


**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
N/A

<!-- Tell your future self why have you made these changes -->
**Why?**
N/A

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Manually tested by adding a caption in one of the sandbox example form fields.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
N/A

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
N/A