### PR TITLE
Export AddButton component

### DIFF
--- a/javascript/packages/core/components/form/components/add-button/add-button.tsx
+++ b/javascript/packages/core/components/form/components/add-button/add-button.tsx
@@ -1,0 +1,45 @@
+import { useStyletron } from 'baseui';
+import { Button, KIND, SIZE } from 'baseui/button';
+
+import { Icon } from '#core/components/icon/icon';
+
+import type { AddButtonProps } from './types';
+
+/**
+ * Styled add button for form array layouts.
+ *
+ * Provides a consistent "add item" action across array-based form components.
+ * Renders a secondary compact button with a plus icon.
+ *
+ * @param props.label - Button label. Defaults to "Add more".
+ * @param props.shape - BaseUI button shape variant.
+ * @param props.onClick - Callback fired when the button is clicked.
+ *
+ * @example
+ * ```tsx
+ * const { add } = useArrayField('items');
+ *
+ * <AddButton onClick={add} label="Add item" />
+ * ```
+ */
+export function AddButton({ label = 'Add more', shape, onClick }: AddButtonProps) {
+  const [, theme] = useStyletron();
+
+  return (
+    <Button
+      type="button"
+      kind={KIND.secondary}
+      size={SIZE.compact}
+      shape={shape}
+      startEnhancer={
+        <Icon name="plus" color={theme.colors.contentPrimary} size={theme.sizing.scale600} />
+      }
+      overrides={{
+        BaseButton: { style: { marginBottom: theme.sizing.scale600, width: '260px' } },
+      }}
+      onClick={onClick}
+    >
+      {label}
+    </Button>
+  );
+}

--- a/javascript/packages/core/components/form/components/add-button/types.ts
+++ b/javascript/packages/core/components/form/components/add-button/types.ts
@@ -1,0 +1,7 @@
+import type { SHAPE } from 'baseui/button';
+
+export type AddButtonProps = {
+  label?: string;
+  shape?: keyof typeof SHAPE;
+  onClick: () => void;
+};

--- a/javascript/packages/core/components/form/layout/array-form-group/array-form-group.tsx
+++ b/javascript/packages/core/components/form/layout/array-form-group/array-form-group.tsx
@@ -1,6 +1,6 @@
-import { useStyletron } from 'baseui';
 import { Button, KIND, SHAPE, SIZE } from 'baseui/button';
 
+import { AddButton } from '#core/components/form/components/add-button/add-button';
 import { useArrayField } from '#core/components/form/hooks/use-array-field';
 import { FormGroup } from '#core/components/form/layout/form-group/form-group';
 import { Icon } from '#core/components/icon/icon';
@@ -20,7 +20,6 @@ export function ArrayFormGroup({
   tooltip,
   collapsible,
 }: ArrayFormGroupProps) {
-  const [, theme] = useStyletron();
   const { entries, add, remove, isRemovable } = useArrayField(rootFieldPath, {
     minItems,
     readOnly,
@@ -62,23 +61,7 @@ export function ArrayFormGroup({
           </FormGroup>
         </RepeatedLayoutProvider>
       ))}
-      {!readOnly && (
-        <Button
-          type="button"
-          kind={KIND.secondary}
-          shape={SHAPE.pill}
-          size={SIZE.compact}
-          startEnhancer={
-            <Icon name="plus" color={theme.colors.contentPrimary} size={theme.sizing.scale600} />
-          }
-          overrides={{
-            BaseButton: { style: { marginBottom: theme.sizing.scale600, width: '260px' } },
-          }}
-          onClick={add}
-        >
-          {addLabel}
-        </Button>
-      )}
+      {!readOnly && <AddButton label={addLabel} shape="pill" onClick={add} />}
     </>
   );
 }

--- a/javascript/packages/core/components/form/layout/array-form-group/array-form-group.tsx
+++ b/javascript/packages/core/components/form/layout/array-form-group/array-form-group.tsx
@@ -61,7 +61,7 @@ export function ArrayFormGroup({
           </FormGroup>
         </RepeatedLayoutProvider>
       ))}
-      {!readOnly && <AddButton label={addLabel} shape="pill" onClick={add} />}
+      {!readOnly && <AddButton label={addLabel} shape={SHAPE.pill} onClick={add} />}
     </>
   );
 }

--- a/javascript/packages/core/components/form/layout/array-form-row/array-form-row.tsx
+++ b/javascript/packages/core/components/form/layout/array-form-row/array-form-row.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useStyletron } from 'baseui';
 import { Button, KIND, SHAPE, SIZE } from 'baseui/button';
 
+import { AddButton } from '#core/components/form/components/add-button/add-button';
 import { useArrayField } from '#core/components/form/hooks/use-array-field';
 import { FormRow } from '#core/components/form/layout/form-row/form-row';
 import { Icon } from '#core/components/icon/icon';
@@ -61,22 +62,7 @@ export function ArrayFormRow({
           </RepeatedLayoutProvider>
         );
       })}
-      {!readOnly && (
-        <Button
-          type="button"
-          kind={KIND.secondary}
-          size={SIZE.compact}
-          startEnhancer={
-            <Icon name="plus" color={theme.colors.contentPrimary} size={theme.sizing.scale600} />
-          }
-          overrides={{
-            BaseButton: { style: { marginBottom: theme.sizing.scale600, width: '260px' } },
-          }}
-          onClick={add}
-        >
-          {addLabel}
-        </Button>
-      )}
+      {!readOnly && <AddButton label={addLabel} onClick={add} />}
     </>
   );
 }


### PR DESCRIPTION
Extract the duplicated add item button from `ArrayFormRow` and `ArrayFormGroup` into a standalone AddButton component.

**What type of PR is this? (check all applicable)**
- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
