### PR TITLE
Support parse and format in all form fields

### DIFF
--- a/javascript/packages/core/components/form/__tests__/form.test.tsx
+++ b/javascript/packages/core/components/form/__tests__/form.test.tsx
@@ -147,15 +147,11 @@ describe('Form', () => {
       await user.click(screen.getByRole('button', { name: 'Submit' }));
 
       await waitFor(() =>
-        expect(onSubmit).toHaveBeenCalledWith(
-          { code: 'ABC' },
-          expect.anything(),
-          expect.anything()
-        )
+        expect(onSubmit).toHaveBeenCalledWith({ code: 'ABC' }, expect.anything(), expect.anything())
       );
     });
 
-    it('applies format to transform stored value for display', async () => {
+    it('applies format to transform stored value for display', () => {
       render(
         <Form onSubmit={vi.fn()} initialValues={{ price: '1000' }}>
           <StringField

--- a/javascript/packages/core/components/form/__tests__/form.test.tsx
+++ b/javascript/packages/core/components/form/__tests__/form.test.tsx
@@ -127,6 +127,81 @@ describe('Form', () => {
       expect(screen.getByRole('textbox', { name: 'Email' })).toHaveValue('from-field-initial');
     });
 
+    it('applies parse to transform input before storing in form state', async () => {
+      const user = userEvent.setup();
+      const onSubmit = vi.fn();
+
+      render(
+        <Form onSubmit={onSubmit}>
+          <StringField
+            name="code"
+            label="Code"
+            parse={(value: unknown) => String(value).toUpperCase()}
+          />
+          <button type="submit">Submit</button>
+        </Form>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
+
+      await user.type(screen.getByLabelText('Code'), 'abc');
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await waitFor(() =>
+        expect(onSubmit).toHaveBeenCalledWith(
+          { code: 'ABC' },
+          expect.anything(),
+          expect.anything()
+        )
+      );
+    });
+
+    it('applies format to transform stored value for display', async () => {
+      render(
+        <Form onSubmit={vi.fn()} initialValues={{ price: '1000' }}>
+          <StringField
+            name="price"
+            label="Price"
+            format={(value: string) => (value ? `$${value}` : '')}
+          />
+        </Form>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
+
+      expect(screen.getByRole('textbox', { name: 'Price' })).toHaveValue('$1000');
+    });
+
+    it('applies format and parse together as inverse transforms', async () => {
+      const user = userEvent.setup();
+      const onSubmit = vi.fn();
+
+      render(
+        <Form onSubmit={onSubmit} initialValues={{ tag: 'initial' }}>
+          <StringField
+            name="tag"
+            label="Tag"
+            format={(value: string) => (value ? `#${value}` : '')}
+            parse={(value: unknown) => String(value).replace(/^#/, '')}
+          />
+          <button type="submit">Submit</button>
+        </Form>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
+
+      expect(screen.getByRole('textbox', { name: 'Tag' })).toHaveValue('#initial');
+
+      await user.clear(screen.getByRole('textbox', { name: 'Tag' }));
+      await user.type(screen.getByRole('textbox', { name: 'Tag' }), '#updated');
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await waitFor(() =>
+        expect(onSubmit).toHaveBeenCalledWith(
+          { tag: 'updated' },
+          expect.anything(),
+          expect.anything()
+        )
+      );
+    });
+
     it('supports external submit button via form id', async () => {
       const user = userEvent.setup();
       const onSubmit = vi.fn();

--- a/javascript/packages/core/components/form/fields/boolean/boolean-field.tsx
+++ b/javascript/packages/core/components/form/fields/boolean/boolean-field.tsx
@@ -18,6 +18,8 @@ export const BooleanField: React.FC<BooleanFieldProps> = ({
   disabled,
   description,
   caption,
+  format,
+  parse,
   checkboxLabel,
   toggle = false,
 }) => {
@@ -27,6 +29,8 @@ export const BooleanField: React.FC<BooleanFieldProps> = ({
     defaultValue,
     initialValue,
     label,
+    format,
+    parse,
   });
 
   const handleChange = (event: React.FormEvent<HTMLInputElement>) => {

--- a/javascript/packages/core/components/form/fields/checkbox/checkbox-field.tsx
+++ b/javascript/packages/core/components/form/fields/checkbox/checkbox-field.tsx
@@ -19,6 +19,8 @@ export const CheckboxField: React.FC<CheckboxFieldProps> = ({
   disabled,
   description,
   caption,
+  format,
+  parse,
   options,
 }) => {
   const [css, theme] = useStyletron();
@@ -29,6 +31,8 @@ export const CheckboxField: React.FC<CheckboxFieldProps> = ({
     defaultValue,
     initialValue,
     label,
+    format,
+    parse,
   });
 
   const { value = [], onChange } = input;

--- a/javascript/packages/core/components/form/fields/number/number-field.tsx
+++ b/javascript/packages/core/components/form/fields/number/number-field.tsx
@@ -18,6 +18,8 @@ export const NumberField: React.FC<BaseFieldProps<number | undefined>> = ({
   placeholder,
   description,
   caption,
+  format,
+  parse,
 }) => {
   const { input, meta } = useField<number | undefined>(name, {
     required,
@@ -25,6 +27,8 @@ export const NumberField: React.FC<BaseFieldProps<number | undefined>> = ({
     defaultValue,
     initialValue,
     label,
+    format,
+    parse,
   });
 
   return (

--- a/javascript/packages/core/components/form/fields/radio/card-radio-field.tsx
+++ b/javascript/packages/core/components/form/fields/radio/card-radio-field.tsx
@@ -27,6 +27,8 @@ export const CardRadioField: React.FC<RadioFieldProps> = ({
   disabled,
   description,
   caption,
+  format,
+  parse,
   options,
 }) => {
   const [, theme] = useStyletron();
@@ -36,6 +38,8 @@ export const CardRadioField: React.FC<RadioFieldProps> = ({
     defaultValue,
     initialValue,
     label,
+    format,
+    parse,
   });
 
   const selectedIndex = useMemo(

--- a/javascript/packages/core/components/form/fields/radio/inline-radio-field.tsx
+++ b/javascript/packages/core/components/form/fields/radio/inline-radio-field.tsx
@@ -19,6 +19,8 @@ export const InlineRadioField: React.FC<RadioFieldProps> = ({
   disabled,
   description,
   caption,
+  format,
+  parse,
   options,
   align = ALIGN.horizontal,
 }) => {
@@ -28,6 +30,8 @@ export const InlineRadioField: React.FC<RadioFieldProps> = ({
     defaultValue,
     initialValue,
     label,
+    format,
+    parse,
   });
 
   const isBoolean = options.every(({ value }) => typeof value === 'boolean');

--- a/javascript/packages/core/components/form/fields/select/select-field.tsx
+++ b/javascript/packages/core/components/form/fields/select/select-field.tsx
@@ -21,6 +21,8 @@ export function SelectField<V = string | number>({
   description,
   caption,
   placeholder,
+  format,
+  parse,
   options,
   visibleOptionLimit,
   isLoading = false,
@@ -35,6 +37,8 @@ export function SelectField<V = string | number>({
     defaultValue,
     initialValue,
     label,
+    format,
+    parse,
   });
 
   const { baseUIOptions, findByValue, findByKey } = useMemo(() => {

--- a/javascript/packages/core/components/form/fields/string/string-field.tsx
+++ b/javascript/packages/core/components/form/fields/string/string-field.tsx
@@ -17,6 +17,8 @@ export const StringField: React.FC<BaseFieldProps<string>> = ({
   placeholder,
   description,
   caption,
+  format,
+  parse,
 }) => {
   const { input, meta } = useField<string>(name, {
     required,
@@ -24,6 +26,8 @@ export const StringField: React.FC<BaseFieldProps<string>> = ({
     defaultValue,
     initialValue,
     label,
+    format,
+    parse,
   });
 
   return (

--- a/javascript/packages/core/components/form/fields/textarea/textarea-field.tsx
+++ b/javascript/packages/core/components/form/fields/textarea/textarea-field.tsx
@@ -17,6 +17,8 @@ export const TextareaField: React.FC<TextareaFieldProps> = ({
   placeholder,
   description,
   caption,
+  format,
+  parse,
   rows,
   maxLength,
 }) => {
@@ -26,6 +28,8 @@ export const TextareaField: React.FC<TextareaFieldProps> = ({
     defaultValue,
     initialValue,
     label,
+    format,
+    parse,
   });
   const currentLength = input.value?.length ?? 0;
 

--- a/javascript/packages/core/components/form/fields/types.ts
+++ b/javascript/packages/core/components/form/fields/types.ts
@@ -1,6 +1,6 @@
 import type { FieldValidator } from '#core/components/form/validation/types';
 
-export interface BaseFieldProps<T = unknown> {
+export interface BaseFieldProps<T = unknown, InputValue = T> {
   /** Unique ID of the field,
    *
    *  - Identifies the field input in the form
@@ -67,15 +67,13 @@ export interface BaseFieldProps<T = unknown> {
    * Transforms the input value before storing it in form state.
    * Called with the input value.
    */
-  /* eslint-disable @typescript-eslint/no-explicit-any */
-  parse?: (value: any) => T;
+  parse?: (value: InputValue) => T;
 
   /**
    * Transforms the field value for display in the input.
    * Called with the field value from form state.
    */
-  /* eslint-disable @typescript-eslint/no-explicit-any */
-  format?: (value: T) => any;
+  format?: (value: T) => InputValue;
 
   /**
    * Validation function called on each value change after the field is touched.

--- a/javascript/packages/core/components/form/fields/types.ts
+++ b/javascript/packages/core/components/form/fields/types.ts
@@ -64,6 +64,20 @@ export interface BaseFieldProps<T = unknown> {
   caption?: string;
 
   /**
+   * Transforms the input value before storing it in form state.
+   * Called with the input value.
+   */
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  parse?: (value: any) => T;
+
+  /**
+   * Transforms the field value for display in the input.
+   * Called with the field value from form state.
+   */
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  format?: (value: T) => any;
+
+  /**
    * Validation function called on each value change after the field is touched.
    * Returns an error message string when invalid, or `undefined` when valid.
    * Use `combineValidators` to compose multiple validators.

--- a/javascript/packages/core/components/form/fields/url/url-field.tsx
+++ b/javascript/packages/core/components/form/fields/url/url-field.tsx
@@ -17,6 +17,8 @@ export const UrlField: React.FC<UrlFieldProps> = ({
   validate,
   description,
   caption,
+  format,
+  parse,
   placeholder,
   urlName,
 }) => {
@@ -26,6 +28,8 @@ export const UrlField: React.FC<UrlFieldProps> = ({
     defaultValue,
     initialValue,
     label,
+    format,
+    parse,
   });
 
   const value = input.value;

--- a/javascript/packages/core/components/form/hooks/use-field.ts
+++ b/javascript/packages/core/components/form/hooks/use-field.ts
@@ -15,6 +15,10 @@ export function useField<T = unknown>(
     defaultValue?: T;
     initialValue?: T;
     label?: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    parse?: (value: any) => T;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    format?: (value: T) => any;
   }
 ): { input: FieldInput<T>; meta: FieldState } {
   useFieldRegistration(name, options?.label);
@@ -29,6 +33,8 @@ export function useField<T = unknown>(
     validate,
     defaultValue: options?.defaultValue,
     initialValue: options?.initialValue,
+    parse: options?.parse,
+    format: options?.format,
   });
 
   const input: FieldInput<T> = {

--- a/javascript/packages/core/components/form/hooks/use-field.ts
+++ b/javascript/packages/core/components/form/hooks/use-field.ts
@@ -7,7 +7,7 @@ import { required as requiredValidator } from '#core/components/form/validation/
 import type { FieldValidator } from '#core/components/form/validation/types';
 import type { FieldInput, FieldState } from '../types';
 
-export function useField<T = unknown>(
+export function useField<T = unknown, InputValue = T>(
   name: string,
   options?: {
     validate?: FieldValidator;
@@ -15,12 +15,10 @@ export function useField<T = unknown>(
     defaultValue?: T;
     initialValue?: T;
     label?: string;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    parse?: (value: any) => T;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    format?: (value: T) => any;
+    parse?: (value: InputValue) => T;
+    format?: (value: T) => InputValue;
   }
-): { input: FieldInput<T>; meta: FieldState } {
+): { input: FieldInput<T, InputValue>; meta: FieldState } {
   useFieldRegistration(name, options?.label);
 
   const composedValidate = options?.required
@@ -29,7 +27,7 @@ export function useField<T = unknown>(
 
   const validate = composedValidate ? (value: T) => composedValidate(value as unknown) : undefined;
 
-  const field = useReactFinalFormField<T>(name, {
+  const field = useReactFinalFormField<T, HTMLInputElement, InputValue>(name, {
     validate,
     defaultValue: options?.defaultValue,
     initialValue: options?.initialValue,
@@ -37,7 +35,7 @@ export function useField<T = unknown>(
     format: options?.format,
   });
 
-  const input: FieldInput<T> = {
+  const input: FieldInput<T, InputValue> = {
     value: field.input.value,
     name: field.input.name,
     onChange: field.input.onChange,

--- a/javascript/packages/core/components/form/types.ts
+++ b/javascript/packages/core/components/form/types.ts
@@ -88,10 +88,10 @@ export interface FieldState {
   touched: boolean;
 }
 
-export interface FieldInput<T = unknown> {
-  value: T;
+export interface FieldInput<T = unknown, InputValue = T> {
+  value: InputValue;
   name: string;
-  onChange: (value: unknown) => void;
+  onChange: (value: InputValue) => void;
   onBlur: () => void;
   onFocus: () => void;
 }

--- a/javascript/packages/core/components/form/types.ts
+++ b/javascript/packages/core/components/form/types.ts
@@ -91,7 +91,7 @@ export interface FieldState {
 export interface FieldInput<T = unknown> {
   value: T;
   name: string;
-  onChange: (value: T) => void;
+  onChange: (value: unknown) => void;
   onBlur: () => void;
   onFocus: () => void;
 }


### PR DESCRIPTION
- Add format and parse props to BaseFieldProps and forward them through useField to React Final Form in all field components.
- Widen input.onChange to accept unknown values so fields using parse can receive raw input values of a different type than the stored form state.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
