### PR TITLE
Add DateField component

### DIFF
--- a/javascript/packages/core/components/form/fields/date/__tests__/date-field.test.tsx
+++ b/javascript/packages/core/components/form/fields/date/__tests__/date-field.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from '@testing-library/react';
+
+import { DateField } from '#core/components/form/fields/date/date-field';
+import { DATE_FORMAT } from '#core/components/form/fields/date/types';
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
+import { getFormProviderWrapper } from '#core/test/wrappers/get-form-provider-wrapper';
+import { getIconProviderWrapper } from '#core/test/wrappers/get-icon-provider-wrapper';
+
+const wrapper = buildWrapper([
+  getBaseProviderWrapper(),
+  getIconProviderWrapper(),
+  getFormProviderWrapper({}),
+]);
+
+describe('DateField', () => {
+  it('renders with label', () => {
+    render(<DateField name="date" label="Start Date" />, wrapper);
+
+    expect(screen.getByText('Start Date')).toBeInTheDocument();
+  });
+
+  it('shows required indicator when required', () => {
+    render(<DateField name="date" label="Start Date" required />, wrapper);
+
+    expect(
+      screen.getAllByText((_, element) => element?.textContent === 'Start Date*').length
+    ).toBeGreaterThan(0);
+  });
+
+  it('displays caption text', () => {
+    render(<DateField name="date" label="Start Date" caption="Select a start date" />, wrapper);
+
+    expect(screen.getByText('Select a start date')).toBeInTheDocument();
+  });
+
+  it('displays help tooltip when description is provided', () => {
+    render(
+      <DateField name="date" label="Start Date" description="When the pipeline should start" />,
+      wrapper
+    );
+
+    expect(screen.getByRole('img', { name: 'help' })).toBeInTheDocument();
+  });
+
+  it('renders with placeholder', () => {
+    render(<DateField name="date" label="Start Date" />, wrapper);
+
+    expect(screen.getByPlaceholderText('MM/dd/yyyy')).toBeInTheDocument();
+  });
+
+  it('hides placeholder when disabled', () => {
+    render(<DateField name="date" label="Start Date" disabled />, wrapper);
+
+    expect(screen.queryByPlaceholderText('MM/dd/yyyy')).not.toBeInTheDocument();
+  });
+
+  it('hides placeholder when readOnly', () => {
+    render(<DateField name="date" label="Start Date" readOnly />, wrapper);
+
+    expect(screen.queryByPlaceholderText('MM/dd/yyyy')).not.toBeInTheDocument();
+  });
+
+  it('displays initial value with ISO format', () => {
+    render(
+      <DateField name="date" label="Start Date" dateFormat={DATE_FORMAT.ISO_DATE_STRING} />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getFormProviderWrapper({ initialValues: { date: '2024-01-15T00:00:00.000Z' } }),
+      ])
+    );
+
+    expect(screen.getByDisplayValue('01/15/2024')).toBeInTheDocument();
+  });
+
+  it('displays initial value with epoch format', () => {
+    // 1705276800 = 2024-01-15T00:00:00.000Z
+    render(
+      <DateField name="date" label="Start Date" dateFormat={DATE_FORMAT.EPOCH_SECONDS} />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getFormProviderWrapper({ initialValues: { date: '1705276800' } }),
+      ])
+    );
+
+    expect(screen.getByDisplayValue('01/15/2024')).toBeInTheDocument();
+  });
+
+  it('applies readOnly overrides when readOnly is true', () => {
+    render(<DateField name="date" label="Start Date" readOnly />, wrapper);
+
+    expect(screen.getByRole('textbox')).toHaveAttribute('readonly');
+  });
+});

--- a/javascript/packages/core/components/form/fields/date/date-field.tsx
+++ b/javascript/packages/core/components/form/fields/date/date-field.tsx
@@ -48,8 +48,7 @@ export const DateField: React.FC<DateFieldProps> = ({
 }) => {
   const { format, parse } = useDateFormatters(dateFormat);
 
-  // Date format can be epoch seconds string or ISO string
-  const { input, meta } = useField<string>(name, {
+  const { input, meta } = useField<string, Date | null>(name, {
     required,
     validate,
     defaultValue,
@@ -73,9 +72,8 @@ export const DateField: React.FC<DateFieldProps> = ({
         >
           <DatePicker
             id={input.name}
-            // Form state is string (epoch/ISO), but format() converts it to Date for the picker
-            value={input.value as unknown as Date | null}
-            onChange={({ date }) => {
+            value={input.value}
+            onChange={({ date }: { date: Date | null }) => {
               // For single date pickers, DatePicker onChange can be invoked with null date.
               // This is particularly problematic when user simply opens and closes date selection
               // without selecting a date. In this case, don't propagate the null value to the form.

--- a/javascript/packages/core/components/form/fields/date/date-field.tsx
+++ b/javascript/packages/core/components/form/fields/date/date-field.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { DatePicker } from 'baseui/datepicker';
+import { Cell, Grid } from 'baseui/layout-grid';
+import { isArray, isNil } from 'lodash';
+
+import { FormControl } from '#core/components/form/components/form-control';
+import { useField } from '#core/components/form/hooks/use-field';
+import { DATE_FORMAT, type DateFieldProps } from './types';
+import { useDateFormatters } from './use-date-formatters';
+
+import type { Theme } from 'baseui';
+import type { DatepickerOverrides } from 'baseui/datepicker';
+
+const READ_ONLY_OVERRIDES: DatepickerOverrides = {
+  Input: {
+    props: {
+      readOnly: true,
+      onFocus: () => undefined,
+      overrides: {
+        InputContainer: {
+          style: ({ $theme }: { $theme: Theme }) => ({
+            backgroundColor: $theme.colors.backgroundPrimary,
+          }),
+        },
+      },
+    },
+  },
+};
+
+const isEmptyInputValue = (value: unknown): boolean => {
+  return isNil(value) || value === '' || (isArray(value) && !value.length);
+};
+
+export const DateField: React.FC<DateFieldProps> = ({
+  name,
+  label,
+  defaultValue,
+  initialValue,
+  required,
+  validate,
+  readOnly,
+  placeholder,
+  disabled,
+  description,
+  caption,
+  noFutureDate,
+  dateFormat = DATE_FORMAT.ISO_DATE_STRING,
+}) => {
+  const { format, parse } = useDateFormatters(dateFormat);
+
+  // Date format can be epoch seconds string or ISO string
+  const { input, meta } = useField<string>(name, {
+    required,
+    validate,
+    defaultValue,
+    initialValue,
+    label,
+    // Overrides user-supplied format/parse — DateField requires its own
+    // formatters to bridge between date format strings and DatePicker Date objects.
+    format,
+    parse,
+  });
+
+  return (
+    <Grid gridColumns={1} gridMargins={[0]} gridMaxWidth={0}>
+      <Cell>
+        <FormControl
+          label={label}
+          required={required}
+          description={description}
+          caption={caption}
+          error={meta.touched && meta.error ? meta.error : undefined}
+        >
+          <DatePicker
+            id={input.name}
+            // Form state is string (epoch/ISO), but format() converts it to Date for the picker
+            value={input.value as unknown as Date | null}
+            onChange={({ date }) => {
+              // For single date pickers, DatePicker onChange can be invoked with null date.
+              // This is particularly problematic when user simply opens and closes date selection
+              // without selecting a date. In this case, don't propagate the null value to the form.
+              if (isNil(date) && isEmptyInputValue(input.value)) return;
+              input.onChange(date);
+            }}
+            placeholder={!disabled && !readOnly ? (placeholder ?? 'MM/dd/yyyy') : ''}
+            formatString="MM/dd/yyyy"
+            mask="99/99/9999"
+            onOpen={input.onFocus}
+            onRangeChange={input.onBlur}
+            onClose={input.onBlur}
+            maxDate={noFutureDate ? new Date() : undefined}
+            disabled={disabled}
+            overrides={readOnly ? READ_ONLY_OVERRIDES : undefined}
+          />
+        </FormControl>
+      </Cell>
+    </Grid>
+  );
+};

--- a/javascript/packages/core/components/form/fields/date/date-field.tsx
+++ b/javascript/packages/core/components/form/fields/date/date-field.tsx
@@ -9,27 +9,6 @@ import { DATE_FORMAT, type DateFieldProps } from './types';
 import { useDateFormatters } from './use-date-formatters';
 
 import type { Theme } from 'baseui';
-import type { DatepickerOverrides } from 'baseui/datepicker';
-
-const READ_ONLY_OVERRIDES: DatepickerOverrides = {
-  Input: {
-    props: {
-      readOnly: true,
-      onFocus: () => undefined,
-      overrides: {
-        InputContainer: {
-          style: ({ $theme }: { $theme: Theme }) => ({
-            backgroundColor: $theme.colors.backgroundPrimary,
-          }),
-        },
-      },
-    },
-  },
-};
-
-const isEmptyInputValue = (value: unknown): boolean => {
-  return isNil(value) || value === '' || (isArray(value) && !value.length);
-};
 
 export const DateField: React.FC<DateFieldProps> = ({
   name,
@@ -88,10 +67,32 @@ export const DateField: React.FC<DateFieldProps> = ({
             onClose={input.onBlur}
             maxDate={noFutureDate ? new Date() : undefined}
             disabled={disabled}
-            overrides={readOnly ? READ_ONLY_OVERRIDES : undefined}
+            overrides={
+              readOnly
+                ? {
+                    Input: {
+                      props: {
+                        readOnly: true,
+                        onFocus: () => undefined,
+                        overrides: {
+                          InputContainer: {
+                            style: ({ $theme }: { $theme: Theme }) => ({
+                              backgroundColor: $theme.colors.backgroundPrimary,
+                            }),
+                          },
+                        },
+                      },
+                    },
+                  }
+                : undefined
+            }
           />
         </FormControl>
       </Cell>
     </Grid>
   );
 };
+
+function isEmptyInputValue(value: unknown): boolean {
+  return isNil(value) || value === '' || (isArray(value) && !value.length);
+}

--- a/javascript/packages/core/components/form/fields/date/types.ts
+++ b/javascript/packages/core/components/form/fields/date/types.ts
@@ -1,0 +1,20 @@
+import type { BaseFieldProps } from '../types';
+
+export interface DateFieldProps extends BaseFieldProps<string> {
+  /** @default DATE_FORMAT.ISO_DATE_STRING */
+  dateFormat?: DATE_FORMAT;
+  /** Restricts selectable dates to today or earlier */
+  noFutureDate?: boolean;
+}
+
+export enum DATE_FORMAT {
+  /**
+   * Anticipates date as epoch seconds string. String is artifact of int64 protobuf fields
+   * being typed as Strings in TypeScript
+   */
+  EPOCH_SECONDS = 'epoch',
+  /**
+   * Anticipates date as ISO string.
+   */
+  ISO_DATE_STRING = 'iso',
+}

--- a/javascript/packages/core/components/form/fields/date/types.ts
+++ b/javascript/packages/core/components/form/fields/date/types.ts
@@ -1,9 +1,12 @@
 import type { BaseFieldProps } from '../types';
 
-export interface DateFieldProps extends BaseFieldProps<string> {
+export interface DateFieldProps extends BaseFieldProps<string, Date | null> {
   /** @default DATE_FORMAT.ISO_DATE_STRING */
   dateFormat?: DATE_FORMAT;
-  /** Restricts selectable dates to today or earlier */
+  /**
+   * Restricts selectable dates to today or earlier
+   * @default false
+   */
   noFutureDate?: boolean;
 }
 

--- a/javascript/packages/core/components/form/fields/date/use-date-formatters.ts
+++ b/javascript/packages/core/components/form/fields/date/use-date-formatters.ts
@@ -1,12 +1,41 @@
 import { getDateFromEpochSeconds, getEpochSecondsFromDate } from '#core/utils/time-utils';
 import { DATE_FORMAT } from './types';
 
-import type { BaseFieldProps } from '#core/components/form/fields/types';
-
 type UseDateFormattersReturn = {
-  format: NonNullable<BaseFieldProps<string>['format']>;
-  parse: NonNullable<BaseFieldProps<string>['parse']>;
+  format: (value: string) => Date | null;
+  parse: (value: Date | null) => string;
 };
+
+/**
+ * Returns `format` and `parse` functions that translate between date formats
+ * (epoch seconds string or ISO string) and the Date objects expected by BaseUI's DatePicker.
+ *
+ * The format pipeline converts stored values to display values:
+ *   Date format string → Date → timezone-adjusted Date
+ *
+ * The parse pipeline converts display values back to stored values:
+ *   timezone-adjusted Date → UTC Date → Date format string
+ *
+ * @param dateFormat - Controls the persisted date format (epoch or ISO).
+ */
+export function useDateFormatters(
+  dateFormat: DATE_FORMAT = DATE_FORMAT.ISO_DATE_STRING
+): UseDateFormattersReturn {
+  const toDate =
+    dateFormat === DATE_FORMAT.EPOCH_SECONDS
+      ? (value: string) => (value ? getDateFromEpochSeconds(parseInt(value)) : null)
+      : (value: string) => (value ? new Date(value) : null);
+
+  const fromDate =
+    dateFormat === DATE_FORMAT.EPOCH_SECONDS
+      ? (date: Date | null) => (date ? String(getEpochSecondsFromDate(date)) : '')
+      : (date: Date | null) => (date ? date.toISOString() : '');
+
+  return {
+    format: (value: string) => translateUTCDateToUserTimezone(toDate(value)),
+    parse: (value: Date | null) => fromDate(translateUserDateToUTC(value)),
+  };
+}
 
 /**
  * Adjusts a UTC Date so its local representation matches the original UTC components
@@ -26,35 +55,4 @@ function translateUserDateToUTC(date: Date | null): Date | null {
 
   const offsetMinutes = date.getTimezoneOffset();
   return new Date(date.getTime() - offsetMinutes * 60 * 1000);
-}
-
-/**
- * Returns `format` and `parse` functions that translate between date formats
- * (epoch seconds string or ISO string) and the Date objects expected by BaseUI's DatePicker.
- *
- * The format pipeline converts stored values to display values:
- *   Date format string → Date → timezone-adjusted Date
- *
- * The parse pipeline converts display values back to stored values:
- *   timezone-adjusted Date → UTC Date → Date format string
- *
- * @param dateFormat - Controls the persisted date format (epoch or ISO).
- */
-export function useDateFormatters(
-  dateFormat: DATE_FORMAT = DATE_FORMAT.ISO_DATE_STRING
-): UseDateFormattersReturn {
-  const toDate =
-    dateFormat === DATE_FORMAT.EPOCH_SECONDS
-      ? (value: string | null) => (value ? getDateFromEpochSeconds(parseInt(value)) : null)
-      : (value: string | null) => (value ? new Date(value) : null);
-
-  const fromDate =
-    dateFormat === DATE_FORMAT.EPOCH_SECONDS
-      ? (date: Date | null) => (date ? String(getEpochSecondsFromDate(date)) : null)
-      : (date: Date | null) => (date ? date.toISOString() : null);
-
-  return {
-    format: (value: string | null) => translateUTCDateToUserTimezone(toDate(value)),
-    parse: (value: Date | null) => fromDate(translateUserDateToUTC(value))!,
-  };
 }

--- a/javascript/packages/core/components/form/fields/date/use-date-formatters.ts
+++ b/javascript/packages/core/components/form/fields/date/use-date-formatters.ts
@@ -1,0 +1,60 @@
+import { getDateFromEpochSeconds, getEpochSecondsFromDate } from '#core/utils/time-utils';
+import { DATE_FORMAT } from './types';
+
+import type { BaseFieldProps } from '#core/components/form/fields/types';
+
+type UseDateFormattersReturn = {
+  format: NonNullable<BaseFieldProps<string>['format']>;
+  parse: NonNullable<BaseFieldProps<string>['parse']>;
+};
+
+/**
+ * Adjusts a UTC Date so its local representation matches the original UTC components
+ */
+function translateUTCDateToUserTimezone(date: Date | null): Date | null {
+  if (!date) return null;
+
+  const offsetMinutes = date.getTimezoneOffset();
+  return new Date(date.getTime() + offsetMinutes * 60 * 1000);
+}
+
+/**
+ * Adjusts a local-timezone Date so its UTC components match the original local display
+ */
+function translateUserDateToUTC(date: Date | null): Date | null {
+  if (!date) return date;
+
+  const offsetMinutes = date.getTimezoneOffset();
+  return new Date(date.getTime() - offsetMinutes * 60 * 1000);
+}
+
+/**
+ * Returns `format` and `parse` functions that translate between date formats
+ * (epoch seconds string or ISO string) and the Date objects expected by BaseUI's DatePicker.
+ *
+ * The format pipeline converts stored values to display values:
+ *   Date format string → Date → timezone-adjusted Date
+ *
+ * The parse pipeline converts display values back to stored values:
+ *   timezone-adjusted Date → UTC Date → Date format string
+ *
+ * @param dateFormat - Controls the persisted date format (epoch or ISO).
+ */
+export function useDateFormatters(
+  dateFormat: DATE_FORMAT = DATE_FORMAT.ISO_DATE_STRING
+): UseDateFormattersReturn {
+  const toDate =
+    dateFormat === DATE_FORMAT.EPOCH_SECONDS
+      ? (value: string | null) => (value ? getDateFromEpochSeconds(parseInt(value)) : null)
+      : (value: string | null) => (value ? new Date(value) : null);
+
+  const fromDate =
+    dateFormat === DATE_FORMAT.EPOCH_SECONDS
+      ? (date: Date | null) => (date ? String(getEpochSecondsFromDate(date)) : null)
+      : (date: Date | null) => (date ? date.toISOString() : null);
+
+  return {
+    format: (value: string | null) => translateUTCDateToUserTimezone(toDate(value)),
+    parse: (value: Date | null) => fromDate(translateUserDateToUTC(value))!,
+  };
+}


### PR DESCRIPTION
Implement DateField which supports taking dates either in ISO 8601 or epoch seconds. Overrode the parse and format of `useField` hook to be able to convert provided string dates into BaseUI DatePicker's expected Date.

For now this override will block users to provide their own parse or format methods. Later the logic can be changed to allow users provide their own parse & format methods.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
