### PR TITLE
fix(ingester): infer gvk from crd

### DIFF
--- a/go/components/ingester/module.go
+++ b/go/components/ingester/module.go
@@ -40,7 +40,12 @@ func register(p registerParams) error {
 	crdObjects := v2.AllCRDObjects
 
 	for _, obj := range crdObjects {
-		gvk := obj.GetObjectKind().GroupVersionKind()
+		gvks, _, err := p.Scheme.ObjectKinds(obj)
+		if err != nil || len(gvks) == 0 {
+			return fmt.Errorf("unable to determine GVK for object %T: %w", obj, err)
+		}
+		gvk := gvks[0]
+		obj.GetObjectKind().SetGroupVersionKind(gvk)
 		log := p.Logger.With(zap.String("kind", gvk.Kind))
 
 		// Cast runtime.Object to client.Object


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
The registration for each ingester controller requires the GVK from each CRD and then a controller named `ingester_<GVK>` is registered. However, the GVK is not set by default and hence `obj.GetObjectKind().GroupVersionKind()` returns empty hence an ingester-controller with the name `ingester_` is attempted to be registered. Therefore we encounter the following error in the second ingester-controller registration:
```
controller with name ingester_ already exists. Controller names must be unique to avoid multiple controllers reporting to the same metric
```

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Ran sandbox against changes. All ingester controllers were registered:
<img width="2027" height="365" alt="Screenshot 2026-03-18 at 5 32 58 PM" src="https://github.com/user-attachments/assets/04add1ef-862b-479a-a251-938c41129d54" />
