### PR TITLE
Add BreadcrumbBar with URL-driven breadcrumb trail

### DIFF
--- a/javascript/packages/core/components/breadcrumb-bar/__tests__/breadcrumb-bar.test.tsx
+++ b/javascript/packages/core/components/breadcrumb-bar/__tests__/breadcrumb-bar.test.tsx
@@ -1,0 +1,214 @@
+import { render, screen } from '@testing-library/react';
+
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
+import { getIconProviderWrapper } from '#core/test/wrappers/get-icon-provider-wrapper';
+import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
+import { BreadcrumbBar } from '../breadcrumb-bar';
+
+describe('BreadcrumbBar — project page', () => {
+  beforeEach(() => {
+    render(
+      <BreadcrumbBar
+        categories={[
+          {
+            id: 'core-ml',
+            name: 'Core ML',
+            phases: [
+              {
+                id: 'train',
+                name: 'Train & Evaluate',
+                icon: '',
+                state: 'active',
+                entities: [
+                  {
+                    id: 'models',
+                    name: 'trained models',
+                    state: 'active',
+                    service: 'model',
+                    views: [],
+                  },
+                ],
+              },
+            ],
+          },
+        ]}
+      />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getRouterWrapper({ location: '/my-project' }),
+      ])
+    );
+  });
+
+  it('renders a Home link to the root', () => {
+    expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute('href', '/');
+  });
+
+  it('renders the project ID as plain text (not a link)', () => {
+    expect(screen.getByText('my-project')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'my-project' })).not.toBeInTheDocument();
+  });
+
+  it('does not render category, phase, or entity breadcrumbs', () => {
+    expect(screen.queryByText('Core ML')).not.toBeInTheDocument();
+    expect(screen.queryByText('Train & Evaluate')).not.toBeInTheDocument();
+    expect(screen.queryByText('trained models')).not.toBeInTheDocument();
+  });
+});
+
+describe('BreadcrumbBar — phase entity page', () => {
+  beforeEach(() => {
+    render(
+      <BreadcrumbBar
+        categories={[
+          {
+            id: 'core-ml',
+            name: 'Core ML',
+            phases: [
+              {
+                id: 'train',
+                name: 'Train & Evaluate',
+                icon: '',
+                state: 'active',
+                entities: [
+                  {
+                    id: 'models',
+                    name: 'trained models',
+                    state: 'active',
+                    service: 'model',
+                    views: [],
+                  },
+                ],
+              },
+            ],
+          },
+        ]}
+      />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getRouterWrapper({ location: '/my-project/train/models' }),
+      ])
+    );
+  });
+
+  it('renders the project ID as a link', () => {
+    expect(screen.getByRole('link', { name: 'my-project' })).toHaveAttribute('href', '/my-project');
+  });
+
+  it('renders the category name as a link to the project', () => {
+    expect(screen.getByRole('link', { name: 'Core ML' })).toHaveAttribute('href', '/my-project');
+  });
+
+  it('renders the phase display name as a link, not the phase ID', () => {
+    expect(screen.getByRole('link', { name: 'Train & Evaluate' })).toHaveAttribute(
+      'href',
+      '/my-project/train'
+    );
+    expect(screen.queryByText('train')).not.toBeInTheDocument();
+  });
+
+  it('renders the entity name as plain text when there is no entity ID', () => {
+    expect(screen.getByText('trained models')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'trained models' })).not.toBeInTheDocument();
+  });
+});
+
+describe('BreadcrumbBar — entity detail page', () => {
+  beforeEach(() => {
+    render(
+      <BreadcrumbBar
+        categories={[
+          {
+            id: 'core-ml',
+            name: 'Core ML',
+            phases: [
+              {
+                id: 'train',
+                name: 'Train & Evaluate',
+                icon: '',
+                state: 'active',
+                entities: [
+                  {
+                    id: 'models',
+                    name: 'trained models',
+                    state: 'active',
+                    service: 'model',
+                    views: [],
+                  },
+                ],
+              },
+            ],
+          },
+        ]}
+      />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getRouterWrapper({ location: '/my-project/train/models/model-123' }),
+      ])
+    );
+  });
+
+  it('renders the entity name as a link', () => {
+    expect(screen.getByRole('link', { name: 'trained models' })).toHaveAttribute(
+      'href',
+      '/my-project/train/models'
+    );
+  });
+
+  it('renders the entity ID as plain text (not a link)', () => {
+    expect(screen.getByText('model-123')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'model-123' })).not.toBeInTheDocument();
+  });
+});
+
+describe('BreadcrumbBar — unknown phase/entity fallback', () => {
+  it('renders the raw phase ID when the phase is not found in config', () => {
+    render(
+      <BreadcrumbBar
+        categories={[
+          {
+            id: 'core-ml',
+            name: 'Core ML',
+            phases: [
+              { id: 'train', name: 'Train & Evaluate', icon: '', state: 'active', entities: [] },
+            ],
+          },
+        ]}
+      />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getRouterWrapper({ location: '/my-project/unknown-phase/some-entity' }),
+      ])
+    );
+    expect(screen.getByText('unknown-phase')).toBeInTheDocument();
+  });
+
+  it('renders the entity URL segment when the entity is not found in config', () => {
+    // normalizeEntityParam calls pluralize() on the entity param; use a segment
+    // that is already plural so it passes through unchanged.
+    render(
+      <BreadcrumbBar
+        categories={[
+          {
+            id: 'core-ml',
+            name: 'Core ML',
+            phases: [
+              { id: 'train', name: 'Train & Evaluate', icon: '', state: 'active', entities: [] },
+            ],
+          },
+        ]}
+      />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getRouterWrapper({ location: '/my-project/train/unknown-models' }),
+      ])
+    );
+    expect(screen.getByText('unknown-models')).toBeInTheDocument();
+  });
+});

--- a/javascript/packages/core/components/breadcrumb-bar/breadcrumb-bar.tsx
+++ b/javascript/packages/core/components/breadcrumb-bar/breadcrumb-bar.tsx
@@ -1,0 +1,119 @@
+import { useStyletron } from 'baseui';
+import { Breadcrumbs } from 'baseui/breadcrumbs';
+import { Cell, Grid } from 'baseui/layout-grid';
+
+import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
+import { Phase } from '#core/types/common/studio-types';
+import { BreadcrumbContainer, PlainLink } from './styled-components';
+
+import type { CategoryConfig } from '#core/types/common/studio-types';
+
+/**
+ * Reads the current URL to build the breadcrumb trail:
+ * Home > Project > Category > Phase > Entity > EntityId
+ *
+ * Category and Phase segments are derived from the supplied categories config.
+ *
+ * @example
+ * ```tsx
+ * const CATEGORIES: CategoryConfig[] = [
+ *   { id: 'core-ml', name: 'Core ML', phases: Object.values(PHASES) },
+ * ];
+ * <BreadcrumbBar categories={CATEGORIES} />
+ * ```
+ */
+export function BreadcrumbBar({ categories }: { categories: CategoryConfig[] }) {
+  const [css, theme] = useStyletron();
+  const { phase, entityId } = useStudioParams('base');
+  const isProjectPage = phase === Phase.Project;
+
+  return (
+    <BreadcrumbContainer>
+      <Grid gridColumns={1} gridGutters={0} gridGaps={0}>
+        <Cell>
+          <div
+            className={css({ display: 'flex', alignItems: 'center', gap: theme.sizing.scale600 })}
+          >
+            <Breadcrumbs
+              overrides={{
+                Root: {
+                  style: { color: theme.colors.contentPrimary },
+                  props: { 'data-tracking-name': 'breadcrumb-bar' },
+                },
+              }}
+            >
+              <PlainLink to="/" data-tracking-name="home">
+                Home
+              </PlainLink>
+              <ProjectBreadcrumb />
+              {!isProjectPage && <CategoryBreadcrumb categories={categories} />}
+              {!isProjectPage && <PhaseBreadcrumb categories={categories} />}
+              {!isProjectPage && <EntityBreadcrumb categories={categories} />}
+              {!isProjectPage && entityId && <EntityIdBreadcrumb />}
+            </Breadcrumbs>
+          </div>
+        </Cell>
+      </Grid>
+    </BreadcrumbContainer>
+  );
+}
+
+function ProjectBreadcrumb() {
+  const { projectId, phase } = useStudioParams('base');
+  const isProjectPage = phase === Phase.Project;
+  return isProjectPage ? (
+    <span>{projectId}</span>
+  ) : (
+    <PlainLink to={`/${projectId}`} data-tracking-name="project">
+      {projectId}
+    </PlainLink>
+  );
+}
+
+function CategoryBreadcrumb({ categories }: { categories: CategoryConfig[] }) {
+  const { projectId, phase } = useStudioParams('base');
+  // TODO #909: Deprecate Phase enum in favor of string, since Phase is configurable at
+  // the app configuration level
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
+  const category = categories.find((c) => c.phases.some((p) => p.id === phase));
+  if (!category) return null;
+  return (
+    <PlainLink to={`/${projectId}`} data-tracking-name="category">
+      {category.name}
+    </PlainLink>
+  );
+}
+
+function PhaseBreadcrumb({ categories }: { categories: CategoryConfig[] }) {
+  const { projectId, phase } = useStudioParams('base');
+  // TODO #909
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
+  const currentPhase = categories.flatMap((c) => c.phases).find((p) => p.id === phase);
+  const phaseName = currentPhase?.name ?? phase;
+  return (
+    <PlainLink to={`/${projectId}/${phase}`} data-tracking-name="phase">
+      {phaseName}
+    </PlainLink>
+  );
+}
+
+function EntityBreadcrumb({ categories }: { categories: CategoryConfig[] }) {
+  const { projectId, phase, entity, entityId } = useStudioParams('base');
+  // TODO #909
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
+  const currentPhase = categories.flatMap((c) => c.phases).find((p) => p.id === phase);
+  const entityName = currentPhase?.entities.find((e) => e.id === entity)?.name ?? entity;
+
+  return entityId ? (
+    <PlainLink to={`/${projectId}/${phase}/${entity}`} data-tracking-name="entity">
+      {entityName}
+    </PlainLink>
+  ) : (
+    <span>{entityName}</span>
+  );
+}
+
+function EntityIdBreadcrumb() {
+  const { entityId } = useStudioParams('form-detail');
+  return <span>{entityId}</span>;
+}

--- a/javascript/packages/core/components/breadcrumb-bar/styled-components.ts
+++ b/javascript/packages/core/components/breadcrumb-bar/styled-components.ts
@@ -1,0 +1,15 @@
+import { Link } from 'react-router-dom-v5-compat';
+import { styled } from 'baseui';
+
+export const PlainLink = styled(Link, ({ $theme }) => ({
+  textDecoration: 'none',
+  color: $theme.colors.contentTertiary,
+  ':visited': { color: $theme.colors.contentTertiary },
+  ':hover': { textDecoration: 'underline' },
+}));
+
+export const BreadcrumbContainer = styled('div', ({ $theme }) => ({
+  boxShadow: `inset 0px -1px 0px ${$theme.colors.borderOpaque}`,
+  paddingTop: $theme.sizing.scale650,
+  paddingBottom: $theme.sizing.scale650,
+}));

--- a/javascript/packages/core/components/views/main-view-container.tsx
+++ b/javascript/packages/core/components/views/main-view-container.tsx
@@ -1,13 +1,10 @@
 import { Cell, Grid } from 'baseui/layout-grid';
 
-import { BREADCRUMB_BAR_HEIGHT } from './constants';
-
 import type { MainViewContainerProps } from './types';
 
 /**
  * MainViewContainer is a layout wrapper component that provides consistent padding and spacing
- * for full-page layouts and components. It automatically handles top margin spacing based on
- * breadcrumb visibility.
+ * for full-page layouts and components.
  *
  * This component should be used to wrap any full-page content to ensure consistent layout
  * alignment and spacing across the application.
@@ -25,23 +22,10 @@ import type { MainViewContainerProps } from './types';
  * </MainViewContainer>
  * ```
  *
- * @property {boolean} [hasBreadcrumb=true] - Whether the page has a breadcrumb navigation. Controls top margin spacing.
- * @property {React.ReactNode} children - The content to be rendered within the container.
  */
-export const MainViewContainer = ({ hasBreadcrumb = true, children }: MainViewContainerProps) => {
+export const MainViewContainer = ({ children }: MainViewContainerProps) => {
   return (
-    <Grid
-      gridColumns={1}
-      gridGutters={0}
-      gridGaps={0}
-      overrides={{
-        Grid: {
-          style: {
-            marginTop: hasBreadcrumb ? BREADCRUMB_BAR_HEIGHT : 0,
-          },
-        },
-      }}
-    >
+    <Grid gridColumns={1} gridGutters={0} gridGaps={0}>
       <Cell>{children}</Cell>
     </Grid>
   );

--- a/javascript/packages/core/components/views/phase-entity-view/phase-entity-view.tsx
+++ b/javascript/packages/core/components/views/phase-entity-view/phase-entity-view.tsx
@@ -45,6 +45,9 @@ export function PhaseEntityView<T extends object = object>({
 
   const currentEntityConfig = entities.find((entity) => entity.id === currentEntity);
   if (!currentEntityConfig) {
+    // No entity in URL — useEffect above is about to redirect to the first entity.
+    // Return null to avoid flashing the error view during that redirect.
+    if (!currentEntity) return null;
     return (
       <ErrorView
         buttonConfig={{

--- a/javascript/packages/core/components/views/sandbox/sandbox.tsx
+++ b/javascript/packages/core/components/views/sandbox/sandbox.tsx
@@ -164,7 +164,7 @@ export function Sandbox() {
   );
 
   return (
-    <MainViewContainer hasBreadcrumb={false}>
+    <MainViewContainer>
       <HeadingXXLarge>Component Sandbox</HeadingXXLarge>
       <Block marginBottom="24px">This is a sandbox for testing WIP components and features.</Block>
 

--- a/javascript/packages/core/components/views/types.ts
+++ b/javascript/packages/core/components/views/types.ts
@@ -9,7 +9,6 @@ import type { DetailPageConfig } from '#core/components/views/detail-view/types/
 
 export type MainViewContainerProps = {
   children: ReactNode;
-  hasBreadcrumb?: boolean;
 };
 
 export type ViewConfig<T extends object = object> = ListViewConfig<T> | DetailViewConfig<T>;

--- a/javascript/packages/core/config/categories.ts
+++ b/javascript/packages/core/config/categories.ts
@@ -1,0 +1,7 @@
+import { PHASES } from '#core/config/phases/phases';
+
+import type { CategoryConfig } from '#core/types/common/studio-types';
+
+export const CATEGORIES: CategoryConfig[] = [
+  { id: 'core-ml', name: 'Core ML', phases: Object.values(PHASES) },
+];

--- a/javascript/packages/core/router/router.tsx
+++ b/javascript/packages/core/router/router.tsx
@@ -4,8 +4,10 @@ import { MainViewContainer } from '#core/components/views/main-view-container';
 import { ProjectDetail } from '#core/components/views/project/project-detail';
 import { ProjectList } from '#core/components/views/project/project-list';
 import { Sandbox } from '#core/components/views/sandbox/sandbox';
+import { CATEGORIES } from '#core/config/categories';
 import { EntityDetailRoute } from './entity-detail-route';
 import { PhaseListRoute } from './phase-list-route';
+import { StudioBar } from './studio-bar';
 
 export function Router() {
   return (
@@ -13,7 +15,7 @@ export function Router() {
       <Route
         index
         element={
-          <MainViewContainer hasBreadcrumb={false}>
+          <MainViewContainer>
             <ProjectList />
           </MainViewContainer>
         }
@@ -21,35 +23,37 @@ export function Router() {
       <Route
         path="sandbox"
         element={
-          <MainViewContainer hasBreadcrumb={false}>
+          <MainViewContainer>
             <Sandbox />
           </MainViewContainer>
         }
       />
-      <Route
-        path=":projectId"
-        element={
-          <MainViewContainer hasBreadcrumb={false}>
-            <ProjectDetail />
-          </MainViewContainer>
-        }
-      />
-      <Route
-        path=":projectId/:phase/:entity/:entityId/:entityTab?"
-        element={
-          <MainViewContainer hasBreadcrumb={false}>
-            <EntityDetailRoute />
-          </MainViewContainer>
-        }
-      />
-      <Route
-        path=":projectId/:phase/:entity?"
-        element={
-          <MainViewContainer hasBreadcrumb={false}>
-            <PhaseListRoute />
-          </MainViewContainer>
-        }
-      />
+      <Route element={<StudioBar categories={CATEGORIES} />}>
+        <Route
+          path=":projectId"
+          element={
+            <MainViewContainer>
+              <ProjectDetail />
+            </MainViewContainer>
+          }
+        />
+        <Route
+          path=":projectId/:phase/:entity/:entityId/:entityTab?"
+          element={
+            <MainViewContainer>
+              <EntityDetailRoute />
+            </MainViewContainer>
+          }
+        />
+        <Route
+          path=":projectId/:phase/:entity?"
+          element={
+            <MainViewContainer>
+              <PhaseListRoute />
+            </MainViewContainer>
+          }
+        />
+      </Route>
     </Routes>
   );
 }

--- a/javascript/packages/core/router/studio-bar.tsx
+++ b/javascript/packages/core/router/studio-bar.tsx
@@ -1,0 +1,33 @@
+import { Outlet } from 'react-router-dom-v5-compat';
+
+import { BreadcrumbBar } from '#core/components/breadcrumb-bar/breadcrumb-bar';
+
+import type { CategoryConfig } from '#core/types/common/studio-types';
+
+interface Props {
+  categories: CategoryConfig[];
+}
+
+/**
+ * Layout route component that renders Studio navigation bar above all project-level pages.
+ *
+ * Renders as a pathless Route element so child routes inherit its matched params,
+ * allowing useStudioParams (and useParams) to resolve correctly inside BreadcrumbBar.
+ *
+ * @example
+ * ```tsx
+ * <Routes>
+ *   <Route element={<StudioBar categories={CATEGORIES} />}>
+ *     <Route path=":projectId" element={<ProjectDetail />} />
+ *   </Route>
+ * </Routes>
+ * ```
+ */
+export function StudioBar({ categories }: Props) {
+  return (
+    <>
+      <BreadcrumbBar categories={categories} />
+      <Outlet />
+    </>
+  );
+}

--- a/javascript/packages/core/types/common/studio-types.ts
+++ b/javascript/packages/core/types/common/studio-types.ts
@@ -136,6 +136,23 @@ export interface PhaseConfig {
 }
 
 /**
+ * Groups phases into a logical category for display and filtering purposes.
+ *
+ * @example
+ * ```ts
+ * const CATEGORIES: CategoryConfig[] = [
+ *   { id: 'core-ml', name: 'Core ML', phases: [DATA_PHASE, TRAIN_PHASE] },
+ *   { id: 'gen-ai', name: 'Gen AI', phases: [GENAI_LLM_PHASE, GENAI_DATA_PHASE] },
+ * ];
+ * ```
+ */
+export interface CategoryConfig {
+  id: string;
+  name: string;
+  phases: PhaseConfig[];
+}
+
+/**
  * Phase state controlling overall phase behavior and appearance
  *
  * @example


### PR DESCRIPTION
Introduce BreadcrumbBar, StudioBar layout route, and CategoryConfig to give project-level pages a navigation context derived from the current URL.

Previously, project routes had no shared navigation ability — each page rendered in isolation with no way for users to orient themselves or move between levels of the hierarchy.

BreadcrumbBar reads the URL via useStudioParams and resolves human- readable names (phase display name, entity name) from the categories config. StudioBar wraps it as a pathless layout route so child routes inherit matched params without re-declaring them. CategoryConfig groups phases into named sections (e.g. "Core ML") for display and support for unique ML workflows.

hasBreadcrumb is removed from MainViewContainer — navigation layout is now the router's responsibility, not the container's.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
**Note**: MenuDrawer comes in stacked PR

https://github.com/user-attachments/assets/58280b8e-75bc-402f-9308-c933499ae0ff



<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
