### PR TITLE
Add slide-out menu drawer to BreadcrumbBar

### DIFF
--- a/javascript/app/icons/icons.tsx
+++ b/javascript/app/icons/icons.tsx
@@ -13,6 +13,7 @@ import Info from '@mui/icons-material/Info';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardBackspaceIcon from '@mui/icons-material/KeyboardBackspace';
 import Launch from '@mui/icons-material/Launch';
+import MenuIcon from '@mui/icons-material/Menu';
 import SearchIcon from '@mui/icons-material/Search';
 import SettingsIcon from '@mui/icons-material/Settings';
 import ShowChartIcon from '@mui/icons-material/ShowChart';
@@ -31,8 +32,10 @@ export const ICONS = {
   circleX: createMuiIconAdapter(CancelIcon),
   circleCheck: createMuiIconAdapter(CheckCircle),
   circleCheckFilled: createMuiIconAdapter(CheckCircle),
+  close: createMuiIconAdapter(CloseIcon),
   deleteAlt: createMuiIconAdapter(CancelIcon),
   diamondEmpty: createMuiIconAdapter(CropSquareIcon),
+  menu: createMuiIconAdapter(MenuIcon),
   playerNext: createMuiIconAdapter(SkipNextIcon),
   plus: createMuiIconAdapter(AddIcon),
   search: createMuiIconAdapter(SearchIcon),

--- a/javascript/packages/core/components/breadcrumb-bar/__tests__/breadcrumb-bar.test.tsx
+++ b/javascript/packages/core/components/breadcrumb-bar/__tests__/breadcrumb-bar.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
@@ -210,5 +211,174 @@ describe('BreadcrumbBar — unknown phase/entity fallback', () => {
       ])
     );
     expect(screen.getByText('unknown-models')).toBeInTheDocument();
+  });
+});
+
+describe('BreadcrumbBar — menu drawer', () => {
+  it('renders the Menu button', () => {
+    render(
+      <BreadcrumbBar
+        categories={[
+          {
+            id: 'core-ml',
+            name: 'Core ML',
+            phases: [
+              { id: 'train', name: 'Train & Evaluate', icon: '', state: 'active', entities: [] },
+            ],
+          },
+        ]}
+      />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getRouterWrapper({ location: '/my-project' }),
+      ])
+    );
+    expect(screen.getByRole('button', { name: /menu/i })).toBeInTheDocument();
+  });
+
+  it('opens the drawer and shows the phase and entities', async () => {
+    render(
+      <BreadcrumbBar
+        categories={[
+          {
+            id: 'core-ml',
+            name: 'Core ML',
+            phases: [
+              {
+                id: 'train',
+                name: 'Train & Evaluate',
+                icon: '',
+                state: 'active',
+                entities: [
+                  {
+                    id: 'models',
+                    name: 'trained models',
+                    state: 'active',
+                    service: 'model',
+                    views: [],
+                  },
+                ],
+              },
+            ],
+          },
+        ]}
+      />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getRouterWrapper({ location: '/my-project' }),
+      ])
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /menu/i }));
+
+    expect(screen.getByText('Train & Evaluate')).toBeInTheDocument();
+    expect(screen.getByText('Trained models')).toBeInTheDocument();
+  });
+
+  it('navigates to the entity route when an active entity is clicked', async () => {
+    render(
+      <BreadcrumbBar
+        categories={[
+          {
+            id: 'core-ml',
+            name: 'Core ML',
+            phases: [
+              {
+                id: 'train',
+                name: 'Train & Evaluate',
+                icon: '',
+                state: 'active',
+                entities: [
+                  {
+                    id: 'models',
+                    name: 'trained models',
+                    state: 'active',
+                    service: 'model',
+                    views: [],
+                  },
+                ],
+              },
+            ],
+          },
+        ]}
+      />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getRouterWrapper({ location: '/my-project' }),
+      ])
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /menu/i }));
+    await userEvent.click(screen.getByText('Trained models'));
+
+    expect(screen.getByText(/\/my-project\/train\/models/)).toBeInTheDocument();
+  });
+
+  it('does not navigate when a disabled entity is clicked', async () => {
+    render(
+      <BreadcrumbBar
+        categories={[
+          {
+            id: 'core-ml',
+            name: 'Core ML',
+            phases: [
+              {
+                id: 'train',
+                name: 'Train & Evaluate',
+                icon: '',
+                state: 'active',
+                entities: [
+                  {
+                    id: 'pipelines',
+                    name: 'pipelines',
+                    state: 'disabled',
+                    service: 'pipeline',
+                    views: [],
+                  },
+                ],
+              },
+            ],
+          },
+        ]}
+      />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getRouterWrapper({ location: '/my-project' }),
+      ])
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /menu/i }));
+    await userEvent.click(screen.getByText('Pipelines'));
+
+    expect(screen.queryByText(/\/my-project\/train/)).not.toBeInTheDocument();
+  });
+
+  it('shows "Coming soon" tag for coming-soon phases', async () => {
+    render(
+      <BreadcrumbBar
+        categories={[
+          {
+            id: 'core-ml',
+            name: 'Core ML',
+            phases: [
+              { id: 'retrain', name: 'Retrain', icon: '', state: 'comingSoon', entities: [] },
+            ],
+          },
+        ]}
+      />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getRouterWrapper({ location: '/my-project' }),
+      ])
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /menu/i }));
+
+    expect(screen.getByText('Coming soon')).toBeInTheDocument();
   });
 });

--- a/javascript/packages/core/components/breadcrumb-bar/breadcrumb-bar.tsx
+++ b/javascript/packages/core/components/breadcrumb-bar/breadcrumb-bar.tsx
@@ -4,15 +4,19 @@ import { Cell, Grid } from 'baseui/layout-grid';
 
 import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
 import { Phase } from '#core/types/common/studio-types';
+import { MenuDrawer } from './menu-drawer';
 import { BreadcrumbContainer, PlainLink } from './styled-components';
 
 import type { CategoryConfig } from '#core/types/common/studio-types';
 
 /**
+ * A breadcrumb navigation with an integrated hamburger menu drawer.
+ *
  * Reads the current URL to build the breadcrumb trail:
  * Home > Project > Category > Phase > Entity > EntityId
  *
  * Category and Phase segments are derived from the supplied categories config.
+ * The menu drawer shows all phases from all supplied categories.
  *
  * @example
  * ```tsx
@@ -24,8 +28,9 @@ import type { CategoryConfig } from '#core/types/common/studio-types';
  */
 export function BreadcrumbBar({ categories }: { categories: CategoryConfig[] }) {
   const [css, theme] = useStyletron();
-  const { phase, entityId } = useStudioParams('base');
+  const { projectId, phase, entityId } = useStudioParams('base');
   const isProjectPage = phase === Phase.Project;
+  const allPhases = categories.flatMap((c) => c.phases);
 
   return (
     <BreadcrumbContainer>
@@ -34,6 +39,7 @@ export function BreadcrumbBar({ categories }: { categories: CategoryConfig[] }) 
           <div
             className={css({ display: 'flex', alignItems: 'center', gap: theme.sizing.scale600 })}
           >
+            <MenuDrawer phases={allPhases} projectId={projectId} />
             <Breadcrumbs
               overrides={{
                 Root: {

--- a/javascript/packages/core/components/breadcrumb-bar/menu-drawer.tsx
+++ b/javascript/packages/core/components/breadcrumb-bar/menu-drawer.tsx
@@ -1,0 +1,92 @@
+import { useState } from 'react';
+import { useStyletron } from 'baseui';
+import { Button, KIND, SHAPE, SIZE } from 'baseui/button';
+import { ANCHOR, Drawer } from 'baseui/drawer';
+
+import { Icon } from '#core/components/icon/icon';
+import { Tag } from '#core/components/tag/tag';
+import { PhaseEntityList } from './phase-entity-list';
+import { PhaseHeader } from './styled-components';
+
+import type { PhaseConfig } from '#core/types/common/studio-types';
+
+export function MenuDrawer({ phases, projectId }: { phases: PhaseConfig[]; projectId: string }) {
+  const [css, theme] = useStyletron();
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  return (
+    <>
+      <Button
+        onClick={() => setIsMenuOpen(true)}
+        kind={KIND.secondary}
+        size={SIZE.mini}
+        shape={SHAPE.pill}
+        startEnhancer={() => <Icon name="menu" title="" />}
+        overrides={{
+          BaseButton: {
+            style: {
+              paddingLeft: theme.sizing.scale500,
+              paddingRight: theme.sizing.scale500,
+            },
+          },
+        }}
+      >
+        Menu
+      </Button>
+      <Drawer
+        isOpen={isMenuOpen}
+        autoFocus
+        onClose={() => setIsMenuOpen(false)}
+        anchor={ANCHOR.left}
+        overrides={{
+          DrawerContainer: {
+            style: { width: '375px' },
+          },
+          DrawerBody: {
+            style: {
+              display: 'flex',
+              flexDirection: 'column',
+              justifyContent: 'flex-start',
+              marginLeft: 0,
+              marginRight: 0,
+              marginBottom: 0,
+              marginTop: '44px',
+            },
+          },
+        }}
+      >
+        <div
+          className={css({ display: 'flex', flexDirection: 'column', gap: theme.sizing.scale400 })}
+        >
+          <span
+            className={css({
+              ...theme.typography.HeadingXSmall,
+              paddingLeft: theme.sizing.scale800,
+              paddingRight: theme.sizing.scale800,
+            })}
+          >
+            {projectId}
+          </span>
+          {phases.map((phase) => (
+            <div key={phase.id}>
+              <PhaseHeader $disabled={phase.state === 'disabled'}>
+                {phase.icon && <Icon name={phase.icon} size="16px" title="" />}
+                {phase.name}
+                {phase.state === 'comingSoon' && (
+                  <Tag size="xSmall" closeable={false}>
+                    Coming soon
+                  </Tag>
+                )}
+              </PhaseHeader>
+              <PhaseEntityList
+                phase={phase}
+                projectId={projectId}
+                onSelect={() => setIsMenuOpen(false)}
+              />
+            </div>
+          ))}
+        </div>
+      </Drawer>
+    </>
+  );
+}

--- a/javascript/packages/core/components/breadcrumb-bar/phase-entity-list.tsx
+++ b/javascript/packages/core/components/breadcrumb-bar/phase-entity-list.tsx
@@ -1,0 +1,56 @@
+import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
+import { useStyletron } from 'baseui';
+
+import { capitalizeFirstLetter } from '#core/utils/string-utils';
+import { EntityItem } from './styled-components';
+
+import type { PhaseConfig } from '#core/types/common/studio-types';
+
+export function PhaseEntityList({
+  phase,
+  projectId,
+  onSelect,
+}: {
+  phase: PhaseConfig;
+  projectId: string;
+  onSelect: () => void;
+}) {
+  const [css, theme] = useStyletron();
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+
+  const pathParts = pathname.split('/').filter(Boolean);
+  const currentPhase = pathParts[1];
+  const currentEntity = pathParts[2];
+
+  return (
+    <ul className={css({ listStyleType: 'none', padding: 0, margin: 0 })}>
+      {phase.entities.map((entity) => {
+        const isDisabled = entity.state !== 'active';
+        const isSelected = !isDisabled && currentPhase === phase.id && currentEntity === entity.id;
+
+        return (
+          <EntityItem
+            key={entity.id}
+            $disabled={isDisabled}
+            onClick={() => {
+              if (isDisabled) return;
+              onSelect();
+              navigate(`/${projectId}/${phase.id}/${entity.id}`);
+            }}
+          >
+            <span
+              className={css({
+                ...theme.typography.ParagraphSmall,
+                fontWeight: isSelected ? 'bold' : undefined,
+                color: isDisabled ? theme.colors.contentTertiary : undefined,
+              })}
+            >
+              {capitalizeFirstLetter(entity.name)}
+            </span>
+          </EntityItem>
+        );
+      })}
+    </ul>
+  );
+}

--- a/javascript/packages/core/components/breadcrumb-bar/styled-components.ts
+++ b/javascript/packages/core/components/breadcrumb-bar/styled-components.ts
@@ -13,3 +13,34 @@ export const BreadcrumbContainer = styled('div', ({ $theme }) => ({
   paddingTop: $theme.sizing.scale650,
   paddingBottom: $theme.sizing.scale650,
 }));
+
+export const PhaseHeader = styled<'li', { $disabled?: boolean }>('li', (props) => {
+  return {
+    ...props.$theme.typography.LabelMedium,
+    color: props.$disabled
+      ? props.$theme.colors.contentTertiary
+      : props.$theme.colors.contentPrimary,
+    paddingTop: props.$theme.sizing.scale500,
+    paddingBottom: props.$theme.sizing.scale300,
+    paddingLeft: props.$theme.sizing.scale800,
+    paddingRight: props.$theme.sizing.scale800,
+    display: 'flex',
+    alignItems: 'center',
+    whiteSpace: 'nowrap',
+    gap: props.$theme.sizing.scale600,
+  };
+});
+
+export const EntityItem = styled<'li', { $disabled?: boolean }>('li', ({ $theme, $disabled }) => ({
+  cursor: $disabled ? 'not-allowed' : 'pointer',
+  paddingTop: $theme.sizing.scale200,
+  paddingBottom: $theme.sizing.scale200,
+  paddingLeft: $theme.sizing.scale1600,
+  paddingRight: $theme.sizing.scale800,
+  ':hover': {
+    backgroundColor: $disabled ? undefined : $theme.colors.menuFillHover,
+  },
+  transitionProperty: 'background-color',
+  transitionDuration: $theme.animation.timing200,
+  transitionTimingFunction: $theme.animation.easeOutCurve,
+}));

--- a/javascript/packages/core/config/phases/phases.ts
+++ b/javascript/packages/core/config/phases/phases.ts
@@ -3,7 +3,7 @@ import { DEPLOY_PHASE } from './deploy';
 import { TRAIN_PHASE } from './train';
 
 export const PHASES = {
-  train: TRAIN_PHASE,
   data: DATA_PHASE,
+  train: TRAIN_PHASE,
   deploy: DEPLOY_PHASE,
 };


### PR DESCRIPTION
Add MenuDrawer to give users a way to navigate between entities without going back through the breadcrumb trail.

The breadcrumb bar alone only shows where you are — it doesn't let you move laterally to another entity in the same phase. The drawer surfaces all phases and their entities in a left-anchored panel, highlighting the current selection and disabling entities that are not yet active.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

https://github.com/user-attachments/assets/3bc9669b-b53f-4b34-a909-5a04a6bd1f6b



<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
