### PR TITLE
Add SubTaskListRenderer override to ExecutionOverrides

### DIFF
--- a/javascript/CLAUDE-COMMITS.md
+++ b/javascript/CLAUDE-COMMITS.md
@@ -1,0 +1,106 @@
+# CLAUDE-COMMITS.md - Commit Message Guidelines
+
+USE PROACTIVELY to write commit messages that explain WHY changes were made,
+not HOW they work. Code is generally self-explanatory for implementation details.
+
+## Commit Writing Flow
+
+1. Begin by aligning with the developer on particular changes to consider when
+   writing the commit. Encourage the developer to stage changes ready to commit
+   or provide git SHA(s) that include changes
+
+2. Read each file that was changed and summarize the changes.
+
+3. Write a commit message following the guidance outlined within this file,
+   CLAUDE-COMMITS.md
+
+## Core Principles
+
+- Focus on the reasons why the change was made
+- Explain what was wrong before, how it works now, and why this solution was chosen
+- Group related code changes and add line breaks between distinct changes
+- Be concise and not persuasive
+- Leave out implementation details - code explains the "how"
+- Be quick to ask clarifying questions of the developer
+
+## Structure Template
+
+```
+Summarize the change in around 50 characters
+
+Action-oriented phrase that describes what was done at a high level.
+Use phrases like "Replace X with Y" or "Migrate from X to Y". Wrap
+commit body lines at around 72 characters.
+
+Explain the reasoning behind why the code was changed in the ways
+it was changed. For example, explain what was wrong with the previous
+approach and why it needed to change. Describe any architectural
+constraints or limitations that drove this decision.
+
+Explain how the new approach solves the problem and why this specific
+solution was chosen over alternatives. Include any side effects or
+consequences that aren't immediately obvious.
+```
+
+## Situational Guidelines
+
+**Variable/Function Changes:**
+
+- Don't detail variable name changes or new function exports
+- Focus on why the function was needed and how it solves the problem
+- For new functions, explain the problem they solve, not where they're used
+
+**Configuration/Build Changes:**
+
+- Don't detail exact config changes
+- Explain why the change was needed and how it helps solve the broader problem
+
+**Bug Fixes:**
+
+- Explain the bug's root cause
+- Describe how this change fixes the underlying issue
+- Don't just describe symptoms
+
+**Refactoring:**
+
+- Explain why refactoring was necessary
+- Describe what architectural problem it solves
+- Connect it to enabling future capabilities (e.g., "blocks React hooks integration")
+
+**Constant/Value Changes:**
+
+- Don't detail the exact value change
+- Focus on why the change to the constant was needed
+
+## What NOT to Include
+
+- Details about how code works (code is self-explanatory)
+- Variable name changes as standalone items
+- Exact configuration file modifications
+- Changes related to testing or building
+- Step-by-step implementation details
+- Where functions are imported/exported
+- Persuasive language about code quality
+
+## Example Problem-Solution Pattern
+
+"Previous approach used inheritance pattern with filterFactory, which blocked
+React hooks architecture since hooks cannot use class inheritance. This
+change consolidates filtering into a single hook that automatically detects
+column configuration, eliminating the factory dependency and enabling future
+integration with React context for cellToString functionality."
+
+## Chat History Context
+
+Since Claude has access to chat history, reference previous conversations
+that explain the architectural motivations and constraints that led to
+the change.
+
+### Determining changes to consider
+
+During the course of a Claude Code Chat, many code changes may be discussed. You
+should always verify what the final changes were accepted by the developer.
+
+There also may be changes that were not discussed in any Claude Chat. For these
+changes, assess the changes in the context of the Claude Chat but do not assume
+that a clear connection will exist.

--- a/javascript/packages/core/components/views/execution/__tests__/execution.test.tsx
+++ b/javascript/packages/core/components/views/execution/__tests__/execution.test.tsx
@@ -426,8 +426,16 @@ describe('Execution view', () => {
     const CustomTaskListRenderer = ({ taskList }: { taskList: unknown[] }) => (
       <div>top-level: {taskList.length} tasks</div>
     );
-    const CustomSubTaskListRenderer = ({ taskList, parent }: { taskList: unknown[]; parent?: Task }) => (
-      <div>subtasks of {parent!.name}: {taskList.length} tasks</div>
+    const CustomSubTaskListRenderer = ({
+      taskList,
+      parent,
+    }: {
+      taskList: unknown[];
+      parent?: Task;
+    }) => (
+      <div>
+        subtasks of {parent!.name}: {taskList.length} tasks
+      </div>
     );
 
     const executionData = {
@@ -465,8 +473,16 @@ describe('Execution view', () => {
   });
 
   it('should fall back to TaskListRenderer for subtask rows when SubTaskListRenderer is not provided', () => {
-    const CustomTaskListRenderer = ({ taskList, parent }: { taskList: unknown[]; parent?: Task }) => (
-      <div>{parent ? `subtasks of ${parent.name}` : 'top-level'}: {taskList.length} tasks</div>
+    const CustomTaskListRenderer = ({
+      taskList,
+      parent,
+    }: {
+      taskList: unknown[];
+      parent?: Task;
+    }) => (
+      <div>
+        {parent ? `subtasks of ${parent.name}` : 'top-level'}: {taskList.length} tasks
+      </div>
     );
 
     const executionData = {

--- a/javascript/packages/core/components/views/execution/__tests__/execution.test.tsx
+++ b/javascript/packages/core/components/views/execution/__tests__/execution.test.tsx
@@ -422,6 +422,81 @@ describe('Execution view', () => {
     ).toHaveLength(2);
   });
 
+  it('should use SubTaskListRenderer for subtask rows and TaskListRenderer for the top-level row', () => {
+    const CustomTaskListRenderer = ({ taskList }: { taskList: unknown[] }) => (
+      <div>top-level: {taskList.length} tasks</div>
+    );
+    const CustomSubTaskListRenderer = ({ taskList, parent }: { taskList: unknown[]; parent?: Task }) => (
+      <div>subtasks of {parent!.name}: {taskList.length} tasks</div>
+    );
+
+    const executionData = {
+      status: {
+        steps: [
+          buildStep({
+            displayName: 'Parent Task',
+            state: 'PIPELINE_RUN_STEP_STATE_SUCCEEDED',
+            subSteps: [
+              buildStep({ displayName: 'Child 1', state: 'PIPELINE_RUN_STEP_STATE_SUCCEEDED' }),
+              buildStep({ displayName: 'Child 2', state: 'PIPELINE_RUN_STEP_STATE_SUCCEEDED' }),
+            ],
+          }),
+        ],
+      },
+    };
+
+    render(
+      <Execution
+        schema={buildSchema()}
+        data={executionData}
+        overrides={{
+          TaskListRenderer: { component: CustomTaskListRenderer },
+          SubTaskListRenderer: { component: CustomSubTaskListRenderer },
+        }}
+      />,
+      buildWrapper([getRouterWrapper()])
+    );
+
+    // Top-level row (no parent) uses TaskListRenderer
+    expect(screen.getByText('top-level: 1 tasks')).toBeInTheDocument();
+
+    // Subtask rows (parent defined) use SubTaskListRenderer — once in overview, once in TaskBody
+    expect(screen.getAllByText('subtasks of Parent Task: 2 tasks')).toHaveLength(2);
+  });
+
+  it('should fall back to TaskListRenderer for subtask rows when SubTaskListRenderer is not provided', () => {
+    const CustomTaskListRenderer = ({ taskList, parent }: { taskList: unknown[]; parent?: Task }) => (
+      <div>{parent ? `subtasks of ${parent.name}` : 'top-level'}: {taskList.length} tasks</div>
+    );
+
+    const executionData = {
+      status: {
+        steps: [
+          buildStep({
+            displayName: 'Parent Task',
+            state: 'PIPELINE_RUN_STEP_STATE_SUCCEEDED',
+            subSteps: [
+              buildStep({ displayName: 'Child 1', state: 'PIPELINE_RUN_STEP_STATE_SUCCEEDED' }),
+            ],
+          }),
+        ],
+      },
+    };
+
+    render(
+      <Execution
+        schema={buildSchema()}
+        data={executionData}
+        overrides={{ TaskListRenderer: { component: CustomTaskListRenderer } }}
+      />,
+      buildWrapper([getRouterWrapper()])
+    );
+
+    // TaskListRenderer is used for both top-level and subtask rows
+    expect(screen.getByText('top-level: 1 tasks')).toBeInTheDocument();
+    expect(screen.getAllByText('subtasks of Parent Task: 1 tasks')).toHaveLength(2);
+  });
+
   it('should use custom taskList when provided', () => {
     const customTaskList = [
       {

--- a/javascript/packages/core/components/views/execution/components/task-details/task-body.tsx
+++ b/javascript/packages/core/components/views/execution/components/task-details/task-body.tsx
@@ -28,7 +28,10 @@ export function TaskBody<TTaskRecord extends object>(props: TaskBodyProps<TTaskR
           <TaskFlow
             matrix={matrix}
             onTaskClick={scrollToTask}
-            overrides={{ TaskListRenderer: overrides?.TaskListRenderer }}
+            overrides={{
+              TaskListRenderer: overrides?.TaskListRenderer,
+              SubTaskListRenderer: overrides?.SubTaskListRenderer,
+            }}
           />
         </Box>
         {subTasks.map((task, index) => (

--- a/javascript/packages/core/components/views/execution/components/task-flow.tsx
+++ b/javascript/packages/core/components/views/execution/components/task-flow.tsx
@@ -16,22 +16,30 @@ export function TaskFlow<TTaskRecord extends object = object>({
     overrides?.TaskListRenderer,
     TaskListRenderer
   );
+  const [SubTaskListRendererComponent, subTaskListRendererProps] = getOverrides(
+    overrides?.SubTaskListRenderer ?? overrides?.TaskListRenderer,
+    TaskListRenderer
+  );
 
   return (
     <>
-      {matrix.map((item, index) => (
-        <React.Fragment key={index}>
-          {index > 0 && <TaskSeparator />}
-          <TaskFlowContainer>
-            <TaskListRendererComponent
-              taskList={item.taskList}
-              onTaskClick={onTaskClick}
-              parent={item.parent}
-              {...taskListRendererProps}
-            />
-          </TaskFlowContainer>
-        </React.Fragment>
-      ))}
+      {matrix.map((item, index) => {
+        const Renderer = item.parent ? SubTaskListRendererComponent : TaskListRendererComponent;
+        const rendererProps = item.parent ? subTaskListRendererProps : taskListRendererProps;
+        return (
+          <React.Fragment key={index}>
+            {index > 0 && <TaskSeparator />}
+            <TaskFlowContainer>
+              <Renderer
+                taskList={item.taskList}
+                onTaskClick={onTaskClick}
+                parent={item.parent}
+                {...rendererProps}
+              />
+            </TaskFlowContainer>
+          </React.Fragment>
+        );
+      })}
     </>
   );
 }

--- a/javascript/packages/core/components/views/execution/components/types.ts
+++ b/javascript/packages/core/components/views/execution/components/types.ts
@@ -3,7 +3,7 @@ import type { ExecutionOverrides, Task } from '#core/components/views/execution/
 export type TaskFlowProps<TTaskRecord extends object = object> = {
   matrix: TaskMatrixItem<TTaskRecord>[];
   onTaskClick: (task: Task<TTaskRecord>) => void;
-  overrides?: Pick<ExecutionOverrides<TTaskRecord>, 'TaskListRenderer'>;
+  overrides?: Pick<ExecutionOverrides<TTaskRecord>, 'TaskListRenderer' | 'SubTaskListRenderer'>;
 };
 
 export type TaskListRendererProps<TTaskRecord extends object = object> = {

--- a/javascript/packages/core/components/views/execution/execution.tsx
+++ b/javascript/packages/core/components/views/execution/execution.tsx
@@ -63,7 +63,10 @@ export function Execution<
             onTaskClick={(clickedTask) => {
               scrollToTask(clickedTask);
             }}
-            overrides={{ TaskListRenderer: overrides?.TaskListRenderer }}
+            overrides={{
+              TaskListRenderer: overrides?.TaskListRenderer,
+              SubTaskListRenderer: overrides?.SubTaskListRenderer,
+            }}
           />
         </TaskContentStack>
       </Box>

--- a/javascript/packages/core/components/views/execution/types.ts
+++ b/javascript/packages/core/components/views/execution/types.ts
@@ -192,18 +192,25 @@ export type Task<TTaskRecord extends object = object> = {
  *
  * Enables customization of execution rendering for different pipeline types:
  * - taskList: Override task data (bypasses buildTaskList)
- * - TaskListRenderer: Override how each taskList within matrix items is rendered
+ * - TaskListRenderer: Override how the top-level row is rendered
+ * - SubTaskListRenderer: Override how subtask rows are rendered (parent is always defined);
+ *   falls back to TaskListRenderer if not provided
  *
  * Example usage for ASL pipeline types:
  * ```
  * const overrides = {
  *   taskList: enhancedTasksWithASL,
- *   TaskListRenderer: { component: ASLTaskListRenderer }
+ *   SubTaskListRenderer: { component: ASLTaskListRenderer }
  * };
  * ```
  */
 export type ExecutionOverrides<TTaskRecord extends object = object> = {
   TaskListRenderer?: {
+    component?: ComponentType<TaskListRendererProps<TTaskRecord>>;
+    props?: Partial<TaskListRendererProps<TTaskRecord>>;
+  };
+  /** Override for subtask rows only — parent is always defined when this fires */
+  SubTaskListRenderer?: {
     component?: ComponentType<TaskListRendererProps<TTaskRecord>>;
     props?: Partial<TaskListRendererProps<TTaskRecord>>;
   };


### PR DESCRIPTION
Previously, TaskListRenderer applied to all rows in the task matrix — both the top-level row (no parent) and subtask rows (parent defined). This made it impossible to customize subtask rendering independently without also overriding the top-level row.

Add SubTaskListRenderer as a targeted override that fires only when a matrix row has a parent task. TaskFlow selects the renderer based on item.parent rather than row index, since TaskBody's inner TaskFlow always passes a parent even for its first row. SubTaskListRenderer falls back to TaskListRenderer when not provided, preserving existing behavior.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
