### PR TITLE
Change default API server port from 14566 to 15566 to avoid IDE exten…

### DIFF
--- a/.ma/config.toml.example
+++ b/.ma/config.toml.example
@@ -6,7 +6,7 @@
 #   cp .ma/config.toml.example ~/.ma/config.toml
 #   vim ~/.ma/config.toml  # Edit with your settings
 
-address = "127.0.0.1:14566"
+address = "127.0.0.1:15566"
 use_tls = false
 
 # Advanced: Custom gRPC metadata

--- a/docs/operator-guides/index.md
+++ b/docs/operator-guides/index.md
@@ -36,7 +36,7 @@ The following diagram shows the relationship between each of the services in Mic
 apiserver:
   yarpc:
     host: 0.0.0.0
-    port: 14566
+    port: 15566
   k8s:
     qps: 300
     burst: 600
@@ -153,7 +153,7 @@ static_resources:
                   address:
                     socket_address:
                       address: michelangelo-apiserver
-                      port_value: 14566
+                      port_value: 15566
 ```
 
 ### **Public UI Config**

--- a/docs/setup-guide/ma-sandbox-ports-and-endpoints.md
+++ b/docs/setup-guide/ma-sandbox-ports-and-endpoints.md
@@ -9,7 +9,7 @@ The sandbox maps NodePorts from the k3d cluster to localhost for easy access.
 | MySQL | 3306 | 30001 | `mysql` | 3306 | Storage for Cadence/Temporal |
 | MinIO (Console) | 9090 | 30008 | `minio` | 9090 | Web UI for MinIO |
 | MinIO (S3 API) | 9091 | 30007 | `minio` | 9091 | S3-compatible API endpoint |
-| Michelangelo API Server | 14566 | 30009 | `ma-apiserver` | 14566 | gRPC API (YARPC) |
+| Michelangelo API Server | 15566 | 30009 | `ma-apiserver` | 15566 | gRPC API (YARPC) |
 | Envoy (gRPC-web proxy) | 8081 | 30010 | `envoy` | 8081 | gRPC-web → gRPC proxy for UI/clients |
 | Cadence Frontend (gRPC) | 7833 | 30002 | `cadence` | 7833 | Cadence SDK/clients |
 | Cadence Frontend (TChannel) | 7933 | 30003 | `cadence` | 7933 | Cadence internal comms |
@@ -24,7 +24,7 @@ Quick links:
 Notes:
 
 - Envoy is applied unless `--exclude ui` is used. If excluded, the 8081 mapping may be unused.
-- The API server is reachable inside the cluster at `michelangelo-apiserver:14566` and externally via `localhost:14566`.
+- The API server is reachable inside the cluster at `michelangelo-apiserver:15566` and externally via `localhost:15566`.
 
 ### Temporal mode
 
@@ -62,7 +62,7 @@ These ports are primarily for intra-cluster communication but are listed for ref
   - Controller Manager webhook/manager: 9443
   - Metrics: 8080
   - Health probe: 8081
-- `michelangelo-apiserver` (service `ma-apiserver`): 14566
+- `michelangelo-apiserver` (service `ma-apiserver`): 15566
 - `minio`: 9090 (console), 9091 (S3 API)
 - `mysql`: 3306
 - `cadence`: 7833 (gRPC), 7933 (TChannel)

--- a/docs/user-guides/cli.md
+++ b/docs/user-guides/cli.md
@@ -51,15 +51,15 @@ All resource types support `get`, `apply`, and `delete` (see [supported resource
    ma sandbox create
    ```
 
-   This starts all required services, including the API server (`localhost:14566`), database, workflow engine, and object storage. See [Sandbox commands](#sandbox-commands) for the full command reference.
+   This starts all required services, including the API server (`localhost:15566`), database, workflow engine, and object storage. See [Sandbox commands](#sandbox-commands) for the full command reference.
 
 4. **(Optional) Configure a custom API server address:**
 
    ```bash
-   export MACTL_ADDRESS="127.0.0.1:14566"
+   export MACTL_ADDRESS="127.0.0.1:15566"
    ```
 
-   The default address (`127.0.0.1:14566`) works automatically with the sandbox. Only set this if you are connecting to a different API server instance.
+   The default address (`127.0.0.1:15566`) works automatically with the sandbox. Only set this if you are connecting to a different API server instance.
 
 ## Usage
 
@@ -394,7 +394,7 @@ The configuration file is located at `~/.ma/config.toml` and uses TOML format.
 
 ```toml
 [ma]
-address = "127.0.0.1:14566"
+address = "127.0.0.1:15566"
 use_tls = false
 
 [minio]
@@ -414,7 +414,7 @@ rpc-encoding = "proto"
 
 API server configuration is placed under the `[ma]` section.
 
-- `address` - Address of the API server (default: `127.0.0.1:14566`)
+- `address` - Address of the API server (default: `127.0.0.1:15566`)
 - `use_tls` - Whether the client uses TLS credentials (default: `false`)
 
 #### MinIO credentials

--- a/go/cmd/apiserver/config/base.yaml
+++ b/go/cmd/apiserver/config/base.yaml
@@ -1,7 +1,7 @@
 apiserver:
   yarpc:
     host: "localhost"
-    port: 14566
+    port: 15566
   crdSync:
     enableCRDUpdate: true
     enableCRDDeletion: true

--- a/go/cmd/worker/config/base.yaml
+++ b/go/cmd/worker/config/base.yaml
@@ -1,5 +1,5 @@
 worker:
-  address: localhost:14566
+  address: localhost:15566
   maApiServiceName: ma-apiserver
 
 logging:

--- a/python/examples/gpt_oss_20b_finetune/simple_workflow.py
+++ b/python/examples/gpt_oss_20b_finetune/simple_workflow.py
@@ -76,7 +76,7 @@ if __name__ == "__main__":
             "mysql+pymysql://root:root@localhost:3306/mlflow"
         )
         ctx.environ["MLFLOW_S3_ENDPOINT_URL"] = "http://localhost:9091"
-        ctx.environ["MA_API_SERVER"] = "localhost:14566"
+        ctx.environ["MA_API_SERVER"] = "localhost:15566"
 
     else:
         # Cluster deployment - use MLflow proxy to bypass security middleware
@@ -85,7 +85,7 @@ if __name__ == "__main__":
             "mysql+pymysql://root:root@mysql:3306/mlflow"
         )
         ctx.environ["MLFLOW_S3_ENDPOINT_URL"] = "http://minio:9091"
-        ctx.environ["MA_API_SERVER"] = "michelangelo-apiserver:14566"
+        ctx.environ["MA_API_SERVER"] = "michelangelo-apiserver:15566"
 
     # These remain the same for both local and cluster
     ctx.environ["MLFLOW_DEFAULT_ARTIFACT_ROOT"] = "s3://mlflow"

--- a/python/michelangelo/cli/mactl/config.py
+++ b/python/michelangelo/cli/mactl/config.py
@@ -14,7 +14,7 @@ else:
 _LOG = getLogger(__name__)
 
 DEFAULT_CONFIG = {
-    "address": "127.0.0.1:14566",
+    "address": "127.0.0.1:15566",
     "use_tls": False,
     "metadata": {
         "rpc-caller": "grpcurl",

--- a/python/michelangelo/cli/mactl/config_test.py
+++ b/python/michelangelo/cli/mactl/config_test.py
@@ -186,7 +186,7 @@ class LoadConfigTest(TestCase):
 
         result = load_config()
 
-        self.assertEqual(result["address"], "127.0.0.1:14566")
+        self.assertEqual(result["address"], "127.0.0.1:15566")
         self.assertFalse(result["use_tls"])
 
     @patch("michelangelo.cli.mactl.config._apply_env_overrides")
@@ -301,7 +301,7 @@ class DefaultConstantsTest(TestCase):
 
     def test_default_config_values(self):
         """Test DEFAULT_CONFIG default values."""
-        self.assertEqual(DEFAULT_CONFIG["address"], "127.0.0.1:14566")
+        self.assertEqual(DEFAULT_CONFIG["address"], "127.0.0.1:15566")
         self.assertFalse(DEFAULT_CONFIG["use_tls"])
         self.assertIn("metadata", DEFAULT_CONFIG)
         self.assertEqual(DEFAULT_CONFIG["metadata"]["rpc-caller"], "grpcurl")

--- a/python/michelangelo/cli/sandbox/resources/envoy.yaml
+++ b/python/michelangelo/cli/sandbox/resources/envoy.yaml
@@ -1,7 +1,7 @@
 # envoy.yaml (mounted via ConfigMap)
 # - Listens on port 8081
 # - Accepts gRPC-Web requests from localhost (UI)
-# - Forwards to michelangelo-apiserver (gRPC backend) on port 14566
+# - Forwards to michelangelo-apiserver (gRPC backend) on port 15566
 
 apiVersion: v1
 kind: Pod
@@ -103,4 +103,4 @@ data:
                       address:
                         socket_address:
                           address: michelangelo-apiserver
-                          port_value: 14566
+                          port_value: 15566

--- a/python/michelangelo/cli/sandbox/resources/michelangelo-apiserver.yaml
+++ b/python/michelangelo/cli/sandbox/resources/michelangelo-apiserver.yaml
@@ -10,7 +10,7 @@ spec:
       image: ghcr.io/michelangelo-ai/apiserver:main
       imagePullPolicy: IfNotPresent
       ports:
-        - containerPort: 14566
+        - containerPort: 15566
       volumeMounts:
         - name: config-volume
           mountPath: /config
@@ -30,10 +30,10 @@ spec:
   selector:
     app: michelangelo-apiserver
   ports:
-    - name: "14566"
-      port: 14566 # port export to the k8s cluster
+    - name: "15566"
+      port: 15566 # port export to the k8s cluster
       nodePort: 30009 # port export to the external world
-      targetPort: 14566 # port inside the container
+      targetPort: 15566 # port inside the container
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -46,7 +46,7 @@ data:
     apiserver:
       yarpc:
         host: 0.0.0.0
-        port: 14566
+        port: 15566
       k8s:
         qps: 300
         burst: 600

--- a/python/michelangelo/cli/sandbox/resources/michelangelo-temporal-worker.yaml
+++ b/python/michelangelo/cli/sandbox/resources/michelangelo-temporal-worker.yaml
@@ -26,7 +26,7 @@ metadata:
 data:
   base.yaml: |
     worker:
-      address: michelangelo-apiserver:14566
+      address: michelangelo-apiserver:15566
       maApiServiceName: ma-apiserver
 
     logging:

--- a/python/michelangelo/cli/sandbox/resources/michelangelo-worker.yaml
+++ b/python/michelangelo/cli/sandbox/resources/michelangelo-worker.yaml
@@ -26,7 +26,7 @@ metadata:
 data:
   base.yaml: |
     worker:
-      address: michelangelo-apiserver:14566
+      address: michelangelo-apiserver:15566
       maApiServiceName: ma-apiserver
 
     logging:

--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -30,7 +30,7 @@ _kube_ports = [
     "3306:30001",  # MySQL
     "9091:30007",  # MinIO
     "9090:30008",  # MinIO Console
-    "14566:30009",  # Michelangelo API Server
+    "15566:30009",  # Michelangelo API Server
     "8081:30010",  # Envoy gRPC --> gRPC-web proxy
     "8090:30011",  # Michelangelo UI
     "3000:30012",  # Grafana

--- a/start_services.sh
+++ b/start_services.sh
@@ -63,7 +63,7 @@ echo "- Controllermgr: 'Starting CRD schema comparison service' with 'interval:3
 echo "- CRD Check will run every 5 minutes and report schema differences"
 echo ""
 echo "📊 Service Endpoints:"
-echo "- API Server YARPC: localhost:14566"
+echo "- API Server YARPC: localhost:15566"
 echo "- Controllermgr Metrics: localhost:8082"
 echo "- Controllermgr Health: localhost:8083"
 echo "- MinIO Console: localhost:9090"


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
  - [ ] Refactor
  - [x] Feature
  - [ ] Bug Fix
  - [ ] Optimization
  - [ ] Documentation Update

  **What changed?**
  Changed the default API server port from 14566 to 15566 across all configuration files, documentation, and examples.

  **Why?**
  Port 14566 was conflicting with IDE extensions (particularly VS Code/Cursor extensions), causing connection reset errors when users tried to run `ma`commands. Port 15566 has no known conflicts and provides a better user experience by avoiding these port collision issues.

  **How did you test it?**
  - Created a fresh sandbox with the new port configuration
  - Verified the API server is accessible at localhost:15566
  - Ran `ma project get` command successfully
  - Confirmed port 14566 is no longer in use
  - Ran unit tests for config module - all passing

  **Release notes**
  - **Breaking change**: Default API server port changed from 14566 to 15566
  - Users should recreate their local sandbox with `ma sandbox delete && ma sandbox create`
  - Custom configurations should be updated to use the new port

  **Documentation Changes**
  - Updated all references to port 14566 in user guides, operator guides, and setup documentation
  - Updated example configurations and code samples