### PR TITLE
Fix pipeline create tar upload failure

### DIFF
--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/main.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/main.py
@@ -52,7 +52,7 @@ def apply_plugin_command(
     _LOG.info("Applying plugins to crd: %r / %r", crd, target_command)
     _LOG.debug("Available CRDs: %r", crds)
     _LOG.debug("gRPC Channel: %r", channel)
-    if target_command == "create":
+    if target_command in ("apply", "create"):
         crd.func_crd_metadata_converter = convert_crd_metadata_pipeline_create
     if target_command == "run":
         crd.func_crd_metadata_converter = convert_crd_metadata_pipeline_run

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/main_test.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/main_test.py
@@ -61,3 +61,58 @@ class PipelineMainTest(TestCase):
         # Verify that generate_kill was set
         self.assertTrue(hasattr(self.mock_crd, "generate_kill"))
         self.assertIsNotNone(self.mock_crd.generate_kill)
+
+    def test_apply_command_sets_metadata_converter(self):
+        """Test that apply command sets func_crd_metadata_converter.
+
+        CRITICAL BUG FIX TEST: This test ensures that the 'apply' command
+        properly configures the metadata converter, which is essential for
+        pipeline registration.
+
+        Background:
+        - The CRD.apply() function auto-creates an instance if it doesn't exist
+          by calling CRD.create() internally (see crd.py:400-404)
+        - CRD.create() relies on func_crd_metadata_converter to process the YAML
+          (see crd.py:424-428)
+        - For pipelines, convert_crd_metadata_pipeline_create() performs critical
+          registration steps including:
+          1. Running subprocess registration to build the uniflow tar
+          2. Extracting the tar path and workflow inputs
+          3. Adding uniflow tar path to spec.manifest.uniflowTar
+          4. Adding workflow inputs to spec.manifest.content
+
+        Impact of bug:
+        - Without this converter, 'mactl apply -f pipeline.yaml' would create a
+          pipeline WITHOUT the uniflow tar path in the spec
+        - The pipeline would be registered in the metadata store, but would have
+          no executable code
+        - When triggered, the pipeline would fail because the uniflow tar is
+          missing
+        - This is a silent failure - the apply command succeeds, but the pipeline
+          is broken
+
+        Why this test matters:
+        - Ensures 'apply' and 'create' commands have identical behavior for new
+          pipelines
+        - Prevents regression where apply command bypasses critical registration
+          steps
+        - Documents the dependency between apply → create → metadata converter
+          → tar upload
+        """
+        # Test that apply command sets the metadata converter
+        apply_plugin_command(self.mock_crd, "apply", self.mock_crds, self.mock_channel)
+
+        # Verify that the metadata converter was set
+        self.assertTrue(hasattr(self.mock_crd, "func_crd_metadata_converter"))
+        self.assertIsNotNone(self.mock_crd.func_crd_metadata_converter)
+
+        # Verify it's the same converter as create command uses
+        create_crd = Mock()
+        create_crd.func_signature = {}
+        apply_plugin_command(create_crd, "create", self.mock_crds, self.mock_channel)
+
+        self.assertEqual(
+            self.mock_crd.func_crd_metadata_converter,
+            create_crd.func_crd_metadata_converter,
+            "apply and create commands must use the same metadata converter",
+        )


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

Fix critical bug where `mactl apply` command failed to upload uniflow tar for new pipeline instances, causing registered pipelines to be non-executable.

<!-- Tell your future self why have you made these changes -->
**Why?**


The pipeline plugin's `apply_plugin_command()` only set the metadata converter for `create` command, but not for `apply` command:

  ```python
  # Before (buggy code)
  if target_command == "create":
      crd.func_crd_metadata_converter = convert_crd_metadata_pipeline_create
```

  Impact:
  - When mactl apply -f pipeline.yaml is used on a non-existent pipeline, the CRD framework automatically calls create() internally (crd.py:400-404)
  - However, without func_crd_metadata_converter set, the create operation skips critical registration steps:
    a. Running subprocess registration to build the uniflow tar
    b. Extracting tar path and workflow inputs
    c. Adding uniflow tar path to spec.manifest.uniflowTar
  - Result: Pipeline is registered in metadata store without executable code
  - When triggered, pipeline fails because uniflow tar is missing
  - This is a silent failure - the apply command succeeds, but creates a broken pipeline

  Solution

  Include apply command in the condition to ensure identical behavior:

  # After (fixed code)
  if target_command in ("apply", "create"):
      crd.func_crd_metadata_converter = convert_crd_metadata_pipeline_create

  Test Plan

  Added test_apply_command_sets_metadata_converter() which:
  - Verifies apply command sets the metadata converter
  - Confirms apply and create use the same converter function
  - Includes detailed docstring documenting the bug impact and why this test is critical
  - ✅ Test passes with fix
  - ❌ Test fails without fix (converter is Mock instead of actual function)

  Additional Context

  The apply command is designed to be idempotent - it auto-creates if the instance doesn't exist, or updates if it does. This fix ensures the auto-create path for pipelines properly executes the
  registration workflow, making apply and create functionally equivalent for new pipelines.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
