### PR TITLE
Upgrade packages/core to 0.1.15

### DIFF
--- a/javascript/packages/core/components/views/execution/components/task-details/task-details.tsx
+++ b/javascript/packages/core/components/views/execution/components/task-details/task-details.tsx
@@ -27,6 +27,7 @@ export function TaskDetails<TTaskRecord extends object = object>(
         id={scrollId}
         title={<TaskHeader task={task} metadata={metadata} />}
         defaultExpanded={task.focused}
+        state={task.state}
       >
         <TaskBody task={task} bodySchema={bodySchema} metadata={metadata} overrides={overrides} />
       </TaskPanel>

--- a/javascript/packages/core/components/views/execution/styled-components.tsx
+++ b/javascript/packages/core/components/views/execution/styled-components.tsx
@@ -1,8 +1,10 @@
 import { styled, Theme } from 'baseui';
 
 import { CollapsibleBox } from '#core/components/box/collapsible-box';
+import { STATE_TO_STYLE_MAP } from '#core/components/views/execution/constants';
 
 import type { CollapsibleBoxProps } from '#core/components/box/types';
+import type { TaskState } from '#core/components/views/execution/types';
 
 export const TaskSeparator = styled('hr', ({ $theme }) => ({
   border: 'none',
@@ -20,8 +22,8 @@ export const TaskContentStack = styled('div', ({ $theme }) => ({
   gap: $theme.sizing.scale800,
 }));
 
-export function TaskPanel(props: CollapsibleBoxProps & { id?: string }) {
-  const { id, defaultExpanded, overrides: userOverrides, ...collapsibleBoxProps } = props;
+export function TaskPanel(props: CollapsibleBoxProps & { id?: string; state?: TaskState }) {
+  const { id, defaultExpanded, state, overrides: userOverrides, ...collapsibleBoxProps } = props;
 
   const taskPanelOverrides = {
     Container: {
@@ -29,6 +31,14 @@ export function TaskPanel(props: CollapsibleBoxProps & { id?: string }) {
         id,
         onClick: (e: MouseEvent) => e.stopPropagation(),
       },
+      ...(state && {
+        style: ({ $theme }: { $theme: Theme }) => ({
+          borderColor:
+            $theme.colors[
+              STATE_TO_STYLE_MAP[state].borderColorName as keyof typeof $theme.colors
+            ],
+        }),
+      }),
     },
     Content: {
       style: ({ $theme }: { $theme: Theme }) => ({

--- a/javascript/packages/core/components/views/execution/styled-components.tsx
+++ b/javascript/packages/core/components/views/execution/styled-components.tsx
@@ -33,10 +33,7 @@ export function TaskPanel(props: CollapsibleBoxProps & { id?: string; state?: Ta
       },
       ...(state && {
         style: ({ $theme }: { $theme: Theme }) => ({
-          borderColor:
-            $theme.colors[
-              STATE_TO_STYLE_MAP[state].borderColorName as keyof typeof $theme.colors
-            ],
+          borderColor: $theme.colors[STATE_TO_STYLE_MAP[state].borderColorName],
         }),
       }),
     },

--- a/javascript/packages/core/index.tsx
+++ b/javascript/packages/core/index.tsx
@@ -144,3 +144,16 @@ export { useTableSelectionContext } from '#core/components/table/plugins/selecti
 export { FilterMode } from '#core/components/table/components/filter/types';
 export type { ColumnConfig } from '#core/components/table/types/column-types';
 export type { TableProps } from '#core/components/table/types/table-types';
+
+// Execution View
+export { Execution } from '#core/components/views/execution/execution';
+export type {
+  ExecutionDetailViewSchema,
+  ExecutionOverrides,
+  Task,
+  TaskState,
+} from '#core/components/views/execution/types';
+export type { TaskListRendererProps } from '#core/components/views/execution/components/types';
+export { TASK_STATE } from '#core/components/views/execution/constants';
+export { TaskListRenderer } from '#core/components/views/execution/components/task-list-renderer';
+export { TaskStepCard } from '#core/components/views/execution/components/task-step-card/task-step-card';

--- a/javascript/packages/core/package.json
+++ b/javascript/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uber/michelangelo-core",
   "license": "UNLICENSED",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "type": "module",
   "main": "./dist/michelangelo-core.js",
   "module": "./dist/michelangelo-core.js",


### PR DESCRIPTION
Export execution components for library users to compose their own execution style views.

Apply state-based border color to task detail panels

Task panels in the execution view were missing state-based border
styling — failed tasks appeared visually identical to successful
ones.

TaskPanel now accepts a state prop and applies the border color from
STATE_TO_STYLE_MAP, the same source used by flow diagram nodes.
Background color is intentionally excluded from panels (unlike flow
nodes) per design.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

**With change**
<img width="1840" height="1097" alt="Screenshot 2026-03-23 at 10 14 28" src="https://github.com/user-attachments/assets/e124f53d-2235-4f33-9dd9-c63a6a3b1861" />

**Without change**
<img width="1840" height="1097" alt="Screenshot 2026-03-23 at 10 18 32" src="https://github.com/user-attachments/assets/cfc3578a-a821-4803-b54c-aac8f12b38da" />

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
