### PR TITLE
bug(mlflow): get mlflow working on sandbox

### DIFF
--- a/python/michelangelo/cli/sandbox/resources/mlflow.yaml
+++ b/python/michelangelo/cli/sandbox/resources/mlflow.yaml
@@ -70,7 +70,7 @@ spec:
                       sys.exit(1)
           "
           # Start MLflow tracking server
-          mlflow server --backend-store-uri mysql+pymysql://root:root@mysql:3306/mlflow --default-artifact-root s3://mlflow --host 0.0.0.0 --port 5000 --serve-artifacts --no-host-validation
+          mlflow server --backend-store-uri mysql+pymysql://root:root@mysql:3306/mlflow --default-artifact-root s3://mlflow --host 0.0.0.0 --port 5000 --serve-artifacts
         readinessProbe:
           httpGet:
             path: /health

--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -311,7 +311,7 @@ necessary, and this assertion will be removed.
         )
 
     # Determine buckets to create based on enabled services
-    bucket_names = ["logs", "default"]
+    bucket_names = ["logs", "default", "deploy-models"]
     if "mlflow" in ns.include_experimental:
         bucket_names.append("mlflow")
         print("🪣 Adding MLflow bucket to S3 setup")
@@ -393,7 +393,7 @@ def _create_bucket_setup(bucket_names):
 
     # Replace the hardcoded bucket names with our dynamic list
     modified_content = content.replace(
-        'value: "logs,default"', f'value: "{bucket_names_str}"'
+        'value: "logs,default,deploy-models"', f'value: "{bucket_names_str}"'
     )
 
     # Create temporary file with modified content


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
1. `--no-host-validation` does not work with current mlflow version (3.6.0). Removed flag to enable mlflow server creation.
2. Fix bug regarding `mlflow` bucket creation in minio storage.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
1. Ran `ma sandbox create --include-experimental mlflow`
2. Verified and tested changes on sandbox through running `python/examples/gpt_oss_20b_finetune` workflow. 
3. Verified experiment shows up in mlflow site (http://localhost:5001/#/experiments). See screenshot:

<img width="2550" height="1121" alt="Screenshot 2026-03-20 at 6 42 22 PM" src="https://github.com/user-attachments/assets/ecd8ea93-9b99-4376-85f6-75399dc884a2" />


