### PR TITLE
Add CNAME for custom domain (michelangelo-ai.org)

### DIFF
--- a/website/static/CNAME
+++ b/website/static/CNAME
@@ -1,0 +1,1 @@
+michelangelo-ai.org


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
Added `static/CNAME` file with `michelangelo-ai.org` so GitHub Pages serves the site from the custom domain instead of `michelangelo-ai.github.io/michelangelo/`.

**Why?**
The site is currently broken at `michelangelo-ai.github.io/michelangelo/` because `baseUrl` is set to `/` (correct for custom domains). Rather than changing `baseUrl` to `/michelangelo/`, configuring the custom domain lets us keep `baseUrl: '/'` and serve from a clean URL.

**How did you test it?**
Verified the CNAME file is placed in `static/` so Docusaurus copies it to the build output root.

**Potential risks**
Site won't work until DNS is configured:
- `michelangelo-ai.org` A records → GitHub Pages IPs
- `www.michelangelo-ai.org` CNAME → `michelangelo-ai.github.io`
- GitHub repo Settings → Pages → Custom domain set to `michelangelo-ai.org`

**Release notes**
Site will be accessible at `https://michelangelo-ai.org`

**Documentation Changes**
None