### PR TITLE
Fix baseUrl for GitHub Pages project site

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -14,7 +14,7 @@ const config: Config = {
 
   // GitHub Pages deployment config
   url: 'https://michelangelo-ai.github.io',
-  baseUrl: '/',
+  baseUrl: '/michelangelo/',
   organizationName: 'michelangelo-ai',
   projectName: 'michelangelo',
 


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
Set `baseUrl` from `/` to `/michelangelo/` in `docusaurus.config.ts`.

**Why?**
GitHub Pages serves project repos (not named `<org>.github.io`) under `/<repo-name>/`. The site at `michelangelo-ai.github.io/michelangelo/` fails to load because `baseUrl` is set to `/`.

This is a **temporary fix** — revert once the custom domain (`michelangelo-ai.org`) DNS is configured and #971 (CNAME file) is merged.

**How did you test it?**
Verified Docusaurus docs confirm `baseUrl` must match the deployment path for GitHub Pages project sites.

**Potential risks**
- All site-internal links will be prefixed with `/michelangelo/`
- Must be reverted when switching to the custom domain

**Release notes**
Fixes the site not loading at `michelangelo-ai.github.io/michelangelo/`

**Documentation Changes**
None