### PR TITLE
Introduce label addon

### DIFF
--- a/javascript/packages/core/components/form/components/form-control.tsx
+++ b/javascript/packages/core/components/form/components/form-control.tsx
@@ -12,7 +12,7 @@ export const FormControl: React.FC<FormControlProps> = ({
   label,
   required,
   description,
-  labelAddon,
+  labelEndEnhancer,
   caption,
   error,
   counter,
@@ -20,16 +20,16 @@ export const FormControl: React.FC<FormControlProps> = ({
 }) => {
   const [css, theme] = useStyletron();
 
-  const labelEndEnhancer =
-    counter || labelAddon ? (
-      <LabelEndEnhancerContent counter={counter} labelAddon={labelAddon} />
+  const composedLabelEndEnhancer =
+    counter || labelEndEnhancer ? (
+      <LabelEndEnhancerContent counter={counter} labelEndEnhancer={labelEndEnhancer} />
     ) : undefined;
 
   return (
     <div className={css({ width: '100%' })}>
       <BaseFormControl
         label={label && <Label label={label} required={required} description={description} />}
-        labelEndEnhancer={labelEndEnhancer}
+        labelEndEnhancer={composedLabelEndEnhancer}
         caption={
           caption && (
             <TruncatedText>
@@ -66,9 +66,9 @@ export const FormControl: React.FC<FormControlProps> = ({
   );
 };
 
-const LabelEndEnhancerContent: React.FC<Pick<FormControlProps, 'counter' | 'labelAddon'>> = ({
+const LabelEndEnhancerContent: React.FC<Pick<FormControlProps, 'counter' | 'labelEndEnhancer'>> = ({
   counter,
-  labelAddon,
+  labelEndEnhancer,
 }) => {
   const [css, theme] = useStyletron();
 
@@ -84,7 +84,7 @@ const LabelEndEnhancerContent: React.FC<Pick<FormControlProps, 'counter' | 'labe
           {counter.length}/{counter.maxLength}
         </span>
       )}
-      {labelAddon}
+      {labelEndEnhancer}
     </>
   );
 };

--- a/javascript/packages/core/components/form/components/form-control.tsx
+++ b/javascript/packages/core/components/form/components/form-control.tsx
@@ -12,17 +12,24 @@ export const FormControl: React.FC<FormControlProps> = ({
   label,
   required,
   description,
+  labelAddon,
   caption,
   error,
   counter,
   children,
 }) => {
-  const [css] = useStyletron();
+  const [css, theme] = useStyletron();
+
+  const labelEndEnhancer =
+    counter || labelAddon ? (
+      <LabelEndEnhancerContent counter={counter} labelAddon={labelAddon} />
+    ) : undefined;
 
   return (
     <div className={css({ width: '100%' })}>
       <BaseFormControl
         label={label && <Label label={label} required={required} description={description} />}
+        labelEndEnhancer={labelEndEnhancer}
         caption={
           caption && (
             <TruncatedText>
@@ -30,7 +37,6 @@ export const FormControl: React.FC<FormControlProps> = ({
             </TruncatedText>
           )
         }
-        counter={counter}
         error={error}
         overrides={{
           ControlContainer: {
@@ -38,6 +44,13 @@ export const FormControl: React.FC<FormControlProps> = ({
               // For form fields, spacing is handled by form layout components. The marginBottom
               // provided by FormControl default interferes with form layout spacing.
               marginBottom: 0,
+            },
+          },
+          LabelEndEnhancer: {
+            style: {
+              display: 'flex',
+              alignItems: 'center',
+              gap: theme.sizing.scale300,
             },
           },
           Caption: {
@@ -50,5 +63,28 @@ export const FormControl: React.FC<FormControlProps> = ({
         {children}
       </BaseFormControl>
     </div>
+  );
+};
+
+const LabelEndEnhancerContent: React.FC<Pick<FormControlProps, 'counter' | 'labelAddon'>> = ({
+  counter,
+  labelAddon,
+}) => {
+  const [css, theme] = useStyletron();
+
+  return (
+    <>
+      {counter && (
+        <span
+          className={css({
+            ...theme.typography.font100,
+            color: theme.colors.contentPrimary,
+          })}
+        >
+          {counter.length}/{counter.maxLength}
+        </span>
+      )}
+      {labelAddon}
+    </>
   );
 };

--- a/javascript/packages/core/components/form/components/types.ts
+++ b/javascript/packages/core/components/form/components/types.ts
@@ -2,7 +2,7 @@ export interface FormControlProps {
   label?: string;
   required?: boolean;
   description?: string;
-  labelAddon?: React.ReactNode;
+  labelEndEnhancer?: React.ReactNode;
   /** Rendered as Markdown. */
   caption?: string;
   error?: string;

--- a/javascript/packages/core/components/form/components/types.ts
+++ b/javascript/packages/core/components/form/components/types.ts
@@ -2,6 +2,7 @@ export interface FormControlProps {
   label?: string;
   required?: boolean;
   description?: string;
+  labelAddon?: React.ReactNode;
   /** Rendered as Markdown. */
   caption?: string;
   error?: string;

--- a/javascript/packages/core/components/form/fields/boolean/boolean-field.tsx
+++ b/javascript/packages/core/components/form/fields/boolean/boolean-field.tsx
@@ -18,6 +18,7 @@ export const BooleanField: React.FC<BooleanFieldProps> = ({
   disabled,
   description,
   caption,
+  labelAddon,
   format,
   parse,
   checkboxLabel,
@@ -44,6 +45,7 @@ export const BooleanField: React.FC<BooleanFieldProps> = ({
       label={label}
       required={required}
       description={description}
+      labelAddon={labelAddon}
       caption={caption}
       error={meta.touched && meta.error ? meta.error : undefined}
     >

--- a/javascript/packages/core/components/form/fields/boolean/boolean-field.tsx
+++ b/javascript/packages/core/components/form/fields/boolean/boolean-field.tsx
@@ -18,7 +18,7 @@ export const BooleanField: React.FC<BooleanFieldProps> = ({
   disabled,
   description,
   caption,
-  labelAddon,
+  labelEndEnhancer,
   format,
   parse,
   checkboxLabel,
@@ -45,7 +45,7 @@ export const BooleanField: React.FC<BooleanFieldProps> = ({
       label={label}
       required={required}
       description={description}
-      labelAddon={labelAddon}
+      labelEndEnhancer={labelEndEnhancer}
       caption={caption}
       error={meta.touched && meta.error ? meta.error : undefined}
     >

--- a/javascript/packages/core/components/form/fields/checkbox/checkbox-field.tsx
+++ b/javascript/packages/core/components/form/fields/checkbox/checkbox-field.tsx
@@ -19,7 +19,7 @@ export const CheckboxField: React.FC<CheckboxFieldProps> = ({
   disabled,
   description,
   caption,
-  labelAddon,
+  labelEndEnhancer,
   format,
   parse,
   options,
@@ -53,7 +53,7 @@ export const CheckboxField: React.FC<CheckboxFieldProps> = ({
       label={label}
       required={required}
       description={description}
-      labelAddon={labelAddon}
+      labelEndEnhancer={labelEndEnhancer}
       caption={caption}
       error={meta.touched && meta.error ? meta.error : undefined}
     >

--- a/javascript/packages/core/components/form/fields/checkbox/checkbox-field.tsx
+++ b/javascript/packages/core/components/form/fields/checkbox/checkbox-field.tsx
@@ -19,6 +19,7 @@ export const CheckboxField: React.FC<CheckboxFieldProps> = ({
   disabled,
   description,
   caption,
+  labelAddon,
   format,
   parse,
   options,
@@ -52,6 +53,7 @@ export const CheckboxField: React.FC<CheckboxFieldProps> = ({
       label={label}
       required={required}
       description={description}
+      labelAddon={labelAddon}
       caption={caption}
       error={meta.touched && meta.error ? meta.error : undefined}
     >

--- a/javascript/packages/core/components/form/fields/date/date-field.tsx
+++ b/javascript/packages/core/components/form/fields/date/date-field.tsx
@@ -21,7 +21,7 @@ export const DateField: React.FC<DateFieldProps> = ({
   disabled,
   description,
   caption,
-  labelAddon,
+  labelEndEnhancer,
   noFutureDate,
   dateFormat = DateFormat.ISO_DATE_STRING,
 }) => {
@@ -44,7 +44,7 @@ export const DateField: React.FC<DateFieldProps> = ({
       label={label}
       required={required}
       description={description}
-      labelAddon={labelAddon}
+      labelEndEnhancer={labelEndEnhancer}
       caption={caption}
       error={meta.touched && meta.error ? meta.error : undefined}
     >

--- a/javascript/packages/core/components/form/fields/date/date-field.tsx
+++ b/javascript/packages/core/components/form/fields/date/date-field.tsx
@@ -21,6 +21,7 @@ export const DateField: React.FC<DateFieldProps> = ({
   disabled,
   description,
   caption,
+  labelAddon,
   noFutureDate,
   dateFormat = DateFormat.ISO_DATE_STRING,
 }) => {
@@ -43,6 +44,7 @@ export const DateField: React.FC<DateFieldProps> = ({
       label={label}
       required={required}
       description={description}
+      labelAddon={labelAddon}
       caption={caption}
       error={meta.touched && meta.error ? meta.error : undefined}
     >

--- a/javascript/packages/core/components/form/fields/markdown/markdown-field.tsx
+++ b/javascript/packages/core/components/form/fields/markdown/markdown-field.tsx
@@ -1,0 +1,95 @@
+import { useStyletron } from 'baseui';
+import { Textarea } from 'baseui/textarea';
+
+import { FormControl } from '#core/components/form/components/form-control';
+import { useField } from '#core/components/form/hooks/use-field';
+import { Markdown } from '#core/components/markdown/markdown';
+
+import type { MarkdownFieldProps } from './types';
+
+/**
+ * Markdown-aware text field with dual rendering modes.
+ *
+ * In edit mode, displays a plain textarea for raw markdown input.
+ * In read-only mode, renders the stored value as formatted markdown.
+ */
+export const MarkdownField: React.FC<MarkdownFieldProps> = ({
+  name,
+  label,
+  defaultValue,
+  initialValue,
+  required,
+  validate,
+  readOnly,
+  disabled,
+  placeholder,
+  description,
+  caption,
+  labelEndEnhancer,
+  format,
+  parse,
+  rows,
+  maxLength,
+}) => {
+  const { input, meta } = useField<string>(name, {
+    required,
+    validate,
+    defaultValue,
+    initialValue,
+    label,
+    format,
+    parse,
+  });
+  const [css, theme] = useStyletron();
+  const currentLength = input.value?.length ?? 0;
+
+  return (
+    <FormControl
+      label={label}
+      required={required}
+      description={description}
+      labelEndEnhancer={labelEndEnhancer}
+      caption={caption}
+      error={meta.touched && meta.error ? meta.error : undefined}
+      counter={maxLength ? { length: currentLength, maxLength } : undefined}
+    >
+      {readOnly ? (
+        <div
+          className={css({
+            ...theme.typography.font300,
+            // To prevent the div from collapsing when the content is empty
+            minHeight: String(theme.typography.font300.lineHeight),
+            border: `${theme.sizing.scale0} solid ${theme.colors.borderOpaque}`,
+            borderRadius: theme.borders.radius300,
+            paddingTop: theme.sizing.scale400,
+            paddingBottom: theme.sizing.scale400,
+            paddingLeft: theme.sizing.scale550,
+            paddingRight: theme.sizing.scale550,
+          })}
+        >
+          <Markdown>{input.value}</Markdown>
+        </div>
+      ) : (
+        <Textarea
+          id={input.name}
+          name={input.name}
+          value={input.value}
+          onChange={(e) => input.onChange(e.currentTarget.value)}
+          onBlur={input.onBlur}
+          onFocus={input.onFocus}
+          placeholder={placeholder}
+          disabled={disabled}
+          rows={rows}
+          maxLength={maxLength}
+          overrides={{
+            Input: {
+              style: {
+                resize: 'vertical',
+              },
+            },
+          }}
+        />
+      )}
+    </FormControl>
+  );
+};

--- a/javascript/packages/core/components/form/fields/markdown/types.ts
+++ b/javascript/packages/core/components/form/fields/markdown/types.ts
@@ -1,0 +1,11 @@
+import type { BaseFieldProps } from '../types';
+
+export interface MarkdownFieldProps extends BaseFieldProps<string> {
+  rows?: number;
+  /**
+   * Limits input length and displays a character counter in the label row.
+   * When `labelEndEnhancer` is also provided, the counter appears first
+   * followed by the enhancer content.
+   */
+  maxLength?: number;
+}

--- a/javascript/packages/core/components/form/fields/number/number-field.tsx
+++ b/javascript/packages/core/components/form/fields/number/number-field.tsx
@@ -18,7 +18,7 @@ export const NumberField: React.FC<BaseFieldProps<number | undefined>> = ({
   placeholder,
   description,
   caption,
-  labelAddon,
+  labelEndEnhancer,
   format,
   parse,
 }) => {
@@ -37,7 +37,7 @@ export const NumberField: React.FC<BaseFieldProps<number | undefined>> = ({
       label={label}
       required={required}
       description={description}
-      labelAddon={labelAddon}
+      labelEndEnhancer={labelEndEnhancer}
       caption={caption}
       error={meta.touched && meta.error ? meta.error : undefined}
     >

--- a/javascript/packages/core/components/form/fields/number/number-field.tsx
+++ b/javascript/packages/core/components/form/fields/number/number-field.tsx
@@ -18,6 +18,7 @@ export const NumberField: React.FC<BaseFieldProps<number | undefined>> = ({
   placeholder,
   description,
   caption,
+  labelAddon,
   format,
   parse,
 }) => {
@@ -36,6 +37,7 @@ export const NumberField: React.FC<BaseFieldProps<number | undefined>> = ({
       label={label}
       required={required}
       description={description}
+      labelAddon={labelAddon}
       caption={caption}
       error={meta.touched && meta.error ? meta.error : undefined}
     >

--- a/javascript/packages/core/components/form/fields/radio/card-radio-field.tsx
+++ b/javascript/packages/core/components/form/fields/radio/card-radio-field.tsx
@@ -27,6 +27,7 @@ export const CardRadioField: React.FC<RadioFieldProps> = ({
   disabled,
   description,
   caption,
+  labelAddon,
   format,
   parse,
   options,
@@ -62,6 +63,7 @@ export const CardRadioField: React.FC<RadioFieldProps> = ({
       label={label}
       required={required}
       description={description}
+      labelAddon={labelAddon}
       caption={caption}
       error={meta.touched && meta.error ? meta.error : undefined}
     >

--- a/javascript/packages/core/components/form/fields/radio/card-radio-field.tsx
+++ b/javascript/packages/core/components/form/fields/radio/card-radio-field.tsx
@@ -27,7 +27,7 @@ export const CardRadioField: React.FC<RadioFieldProps> = ({
   disabled,
   description,
   caption,
-  labelAddon,
+  labelEndEnhancer,
   format,
   parse,
   options,
@@ -63,7 +63,7 @@ export const CardRadioField: React.FC<RadioFieldProps> = ({
       label={label}
       required={required}
       description={description}
-      labelAddon={labelAddon}
+      labelEndEnhancer={labelEndEnhancer}
       caption={caption}
       error={meta.touched && meta.error ? meta.error : undefined}
     >

--- a/javascript/packages/core/components/form/fields/radio/inline-radio-field.tsx
+++ b/javascript/packages/core/components/form/fields/radio/inline-radio-field.tsx
@@ -19,6 +19,7 @@ export const InlineRadioField: React.FC<RadioFieldProps> = ({
   disabled,
   description,
   caption,
+  labelAddon,
   format,
   parse,
   options,
@@ -50,6 +51,7 @@ export const InlineRadioField: React.FC<RadioFieldProps> = ({
         label={label}
         required={required}
         description={description}
+        labelAddon={labelAddon}
         caption={caption}
         error={meta.touched && meta.error ? meta.error : undefined}
       >
@@ -74,6 +76,7 @@ export const InlineRadioField: React.FC<RadioFieldProps> = ({
       label={label}
       required={required}
       description={description}
+      labelAddon={labelAddon}
       caption={caption}
       error={meta.touched && meta.error ? meta.error : undefined}
     >

--- a/javascript/packages/core/components/form/fields/radio/inline-radio-field.tsx
+++ b/javascript/packages/core/components/form/fields/radio/inline-radio-field.tsx
@@ -19,7 +19,7 @@ export const InlineRadioField: React.FC<RadioFieldProps> = ({
   disabled,
   description,
   caption,
-  labelAddon,
+  labelEndEnhancer,
   format,
   parse,
   options,
@@ -51,7 +51,7 @@ export const InlineRadioField: React.FC<RadioFieldProps> = ({
         label={label}
         required={required}
         description={description}
-        labelAddon={labelAddon}
+        labelEndEnhancer={labelEndEnhancer}
         caption={caption}
         error={meta.touched && meta.error ? meta.error : undefined}
       >
@@ -76,7 +76,7 @@ export const InlineRadioField: React.FC<RadioFieldProps> = ({
       label={label}
       required={required}
       description={description}
-      labelAddon={labelAddon}
+      labelEndEnhancer={labelEndEnhancer}
       caption={caption}
       error={meta.touched && meta.error ? meta.error : undefined}
     >

--- a/javascript/packages/core/components/form/fields/select/select-field.tsx
+++ b/javascript/packages/core/components/form/fields/select/select-field.tsx
@@ -21,6 +21,7 @@ export function SelectField<V = string | number>({
   disabled,
   description,
   caption,
+  labelAddon,
   placeholder,
   format,
   parse,
@@ -108,6 +109,7 @@ export function SelectField<V = string | number>({
       label={label}
       required={required}
       description={description}
+      labelAddon={labelAddon}
       caption={caption}
       error={meta.touched && meta.error ? meta.error : undefined}
     >

--- a/javascript/packages/core/components/form/fields/select/select-field.tsx
+++ b/javascript/packages/core/components/form/fields/select/select-field.tsx
@@ -21,7 +21,7 @@ export function SelectField<V = string | number>({
   disabled,
   description,
   caption,
-  labelAddon,
+  labelEndEnhancer,
   placeholder,
   format,
   parse,
@@ -109,7 +109,7 @@ export function SelectField<V = string | number>({
       label={label}
       required={required}
       description={description}
-      labelAddon={labelAddon}
+      labelEndEnhancer={labelEndEnhancer}
       caption={caption}
       error={meta.touched && meta.error ? meta.error : undefined}
     >

--- a/javascript/packages/core/components/form/fields/string/string-field.tsx
+++ b/javascript/packages/core/components/form/fields/string/string-field.tsx
@@ -17,7 +17,7 @@ export const StringField: React.FC<BaseFieldProps<string>> = ({
   placeholder,
   description,
   caption,
-  labelAddon,
+  labelEndEnhancer,
   format,
   parse,
 }) => {
@@ -36,7 +36,7 @@ export const StringField: React.FC<BaseFieldProps<string>> = ({
       label={label}
       required={required}
       description={description}
-      labelAddon={labelAddon}
+      labelEndEnhancer={labelEndEnhancer}
       caption={caption}
       error={meta.touched && meta.error ? meta.error : undefined}
     >

--- a/javascript/packages/core/components/form/fields/string/string-field.tsx
+++ b/javascript/packages/core/components/form/fields/string/string-field.tsx
@@ -17,6 +17,7 @@ export const StringField: React.FC<BaseFieldProps<string>> = ({
   placeholder,
   description,
   caption,
+  labelAddon,
   format,
   parse,
 }) => {
@@ -35,6 +36,7 @@ export const StringField: React.FC<BaseFieldProps<string>> = ({
       label={label}
       required={required}
       description={description}
+      labelAddon={labelAddon}
       caption={caption}
       error={meta.touched && meta.error ? meta.error : undefined}
     >

--- a/javascript/packages/core/components/form/fields/textarea/__tests__/textarea-field.test.tsx
+++ b/javascript/packages/core/components/form/fields/textarea/__tests__/textarea-field.test.tsx
@@ -70,4 +70,47 @@ describe('TextareaField', () => {
 
     expect(screen.queryByText(/\d+ \/ \d+/)).not.toBeInTheDocument();
   });
+
+  it('renders labelAddon', () => {
+    render(
+      <TextareaField name="notes" label="Notes" labelAddon={<button>Generate</button>} />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getFormProviderWrapper({})])
+    );
+
+    expect(screen.getByRole('button', { name: 'Generate' })).toBeInTheDocument();
+  });
+
+  it('renders labelAddon alongside character count', () => {
+    render(
+      <TextareaField
+        name="notes"
+        label="Notes"
+        maxLength={100}
+        labelAddon={<button>Generate</button>}
+      />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getFormProviderWrapper({})])
+    );
+
+    expect(screen.getByText('0/100')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Generate' })).toBeInTheDocument();
+  });
+
+  it('updates character count alongside labelAddon as user types', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TextareaField
+        name="notes"
+        label="Notes"
+        maxLength={50}
+        labelAddon={<button>Generate</button>}
+      />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getFormProviderWrapper({})])
+    );
+
+    await user.type(screen.getByRole('textbox', { name: 'Notes' }), 'Hello');
+
+    expect(screen.getByText('5/50')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Generate' })).toBeInTheDocument();
+  });
 });

--- a/javascript/packages/core/components/form/fields/textarea/__tests__/textarea-field.test.tsx
+++ b/javascript/packages/core/components/form/fields/textarea/__tests__/textarea-field.test.tsx
@@ -71,22 +71,22 @@ describe('TextareaField', () => {
     expect(screen.queryByText(/\d+ \/ \d+/)).not.toBeInTheDocument();
   });
 
-  it('renders labelAddon', () => {
+  it('renders labelEndEnhancer', () => {
     render(
-      <TextareaField name="notes" label="Notes" labelAddon={<button>Generate</button>} />,
+      <TextareaField name="notes" label="Notes" labelEndEnhancer={<button>Generate</button>} />,
       buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getFormProviderWrapper({})])
     );
 
     expect(screen.getByRole('button', { name: 'Generate' })).toBeInTheDocument();
   });
 
-  it('renders labelAddon alongside character count', () => {
+  it('renders labelEndEnhancer alongside character count', () => {
     render(
       <TextareaField
         name="notes"
         label="Notes"
         maxLength={100}
-        labelAddon={<button>Generate</button>}
+        labelEndEnhancer={<button>Generate</button>}
       />,
       buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getFormProviderWrapper({})])
     );
@@ -95,7 +95,7 @@ describe('TextareaField', () => {
     expect(screen.getByRole('button', { name: 'Generate' })).toBeInTheDocument();
   });
 
-  it('updates character count alongside labelAddon as user types', async () => {
+  it('updates character count alongside labelEndEnhancer as user types', async () => {
     const user = userEvent.setup();
 
     render(
@@ -103,7 +103,7 @@ describe('TextareaField', () => {
         name="notes"
         label="Notes"
         maxLength={50}
-        labelAddon={<button>Generate</button>}
+        labelEndEnhancer={<button>Generate</button>}
       />,
       buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getFormProviderWrapper({})])
     );

--- a/javascript/packages/core/components/form/fields/textarea/textarea-field.tsx
+++ b/javascript/packages/core/components/form/fields/textarea/textarea-field.tsx
@@ -17,7 +17,7 @@ export const TextareaField: React.FC<TextareaFieldProps> = ({
   placeholder,
   description,
   caption,
-  labelAddon,
+  labelEndEnhancer,
   format,
   parse,
   rows,
@@ -39,7 +39,7 @@ export const TextareaField: React.FC<TextareaFieldProps> = ({
       label={label}
       required={required}
       description={description}
-      labelAddon={labelAddon}
+      labelEndEnhancer={labelEndEnhancer}
       caption={caption}
       error={meta.touched && meta.error ? meta.error : undefined}
       counter={maxLength ? { length: currentLength, maxLength } : undefined}

--- a/javascript/packages/core/components/form/fields/textarea/textarea-field.tsx
+++ b/javascript/packages/core/components/form/fields/textarea/textarea-field.tsx
@@ -17,6 +17,7 @@ export const TextareaField: React.FC<TextareaFieldProps> = ({
   placeholder,
   description,
   caption,
+  labelAddon,
   format,
   parse,
   rows,
@@ -38,6 +39,7 @@ export const TextareaField: React.FC<TextareaFieldProps> = ({
       label={label}
       required={required}
       description={description}
+      labelAddon={labelAddon}
       caption={caption}
       error={meta.touched && meta.error ? meta.error : undefined}
       counter={maxLength ? { length: currentLength, maxLength } : undefined}
@@ -54,6 +56,13 @@ export const TextareaField: React.FC<TextareaFieldProps> = ({
         disabled={disabled}
         rows={rows}
         maxLength={maxLength}
+        overrides={{
+          Input: {
+            style: {
+              resize: 'vertical',
+            },
+          },
+        }}
       />
     </FormControl>
   );

--- a/javascript/packages/core/components/form/fields/textarea/types.ts
+++ b/javascript/packages/core/components/form/fields/textarea/types.ts
@@ -2,6 +2,11 @@ import type { BaseFieldProps } from '../types';
 
 export interface TextareaFieldProps extends BaseFieldProps<string> {
   rows?: number;
+  /**
+   * Limits input length and displays a character counter in the label row.
+   * When `labelEndEnhancer` is also provided, the counter appears first
+   * followed by the enhancer content.
+   */
   maxLength?: number;
 }
 

--- a/javascript/packages/core/components/form/fields/types.ts
+++ b/javascript/packages/core/components/form/fields/types.ts
@@ -64,6 +64,12 @@ export interface BaseFieldProps<T = unknown, InputValue = T> {
   caption?: string;
 
   /**
+   * Arbitrary content rendered at the far right of the label row.
+   * Can be a React component, text, or an action button.
+   */
+  labelAddon?: React.ReactNode;
+
+  /**
    * Transforms the input value before storing it in form state.
    * Called with the input value.
    */

--- a/javascript/packages/core/components/form/fields/types.ts
+++ b/javascript/packages/core/components/form/fields/types.ts
@@ -67,7 +67,7 @@ export interface BaseFieldProps<T = unknown, InputValue = T> {
    * Arbitrary content rendered at the far right of the label row.
    * Can be a React component, text, or an action button.
    */
-  labelAddon?: React.ReactNode;
+  labelEndEnhancer?: React.ReactNode;
 
   /**
    * Transforms the input value before storing it in form state.

--- a/javascript/packages/core/components/form/fields/url/url-field.tsx
+++ b/javascript/packages/core/components/form/fields/url/url-field.tsx
@@ -17,6 +17,7 @@ export const UrlField: React.FC<UrlFieldProps> = ({
   validate,
   description,
   caption,
+  labelAddon,
   format,
   parse,
   placeholder,
@@ -39,6 +40,7 @@ export const UrlField: React.FC<UrlFieldProps> = ({
       label={label}
       required={required}
       description={description}
+      labelAddon={labelAddon}
       caption={caption}
       error={meta.touched && meta.error ? meta.error : undefined}
     >

--- a/javascript/packages/core/components/form/fields/url/url-field.tsx
+++ b/javascript/packages/core/components/form/fields/url/url-field.tsx
@@ -17,7 +17,7 @@ export const UrlField: React.FC<UrlFieldProps> = ({
   validate,
   description,
   caption,
-  labelAddon,
+  labelEndEnhancer,
   format,
   parse,
   placeholder,
@@ -40,7 +40,7 @@ export const UrlField: React.FC<UrlFieldProps> = ({
       label={label}
       required={required}
       description={description}
-      labelAddon={labelAddon}
+      labelEndEnhancer={labelEndEnhancer}
       caption={caption}
       error={meta.touched && meta.error ? meta.error : undefined}
     >

--- a/javascript/packages/core/components/views/sandbox/sandbox.tsx
+++ b/javascript/packages/core/components/views/sandbox/sandbox.tsx
@@ -12,8 +12,10 @@ import { CheckboxField } from '#core/components/form/fields/checkbox/checkbox-fi
 import { NumberField } from '#core/components/form/fields/number/number-field';
 import { SelectField } from '#core/components/form/fields/select/select-field';
 import { StringField } from '#core/components/form/fields/string/string-field';
+import { TextareaField } from '#core/components/form/fields/textarea/textarea-field';
 import { UrlField } from '#core/components/form/fields/url/url-field';
 import { Form } from '#core/components/form/form';
+import { useForm } from '#core/components/form/hooks/use-form';
 import { ArrayFormGroup } from '#core/components/form/layout/array-form-group/array-form-group';
 import { ArrayFormRow } from '#core/components/form/layout/array-form-row/array-form-row';
 import { FormColumn } from '#core/components/form/layout/form-column/form-column';
@@ -199,6 +201,75 @@ function ParentDebugRenderer({ taskList, parent, onTaskClick }: TaskListRenderer
   );
 }
 
+function LabelAddonExamples() {
+  const { change } = useForm();
+
+  return (
+    <>
+      <FormGroup title="Select with clear addon">
+        <SelectField
+          name="region"
+          label="Region"
+          labelAddon={
+            <Button size="mini" kind="tertiary" onClick={() => change('region', '')} type="button">
+              Clear
+            </Button>
+          }
+          options={[
+            { id: 'us-east', label: 'US East' },
+            { id: 'us-west', label: 'US West' },
+            { id: 'eu-west', label: 'EU West' },
+            { id: 'ap-south', label: 'AP South' },
+          ]}
+        />
+      </FormGroup>
+
+      <FormGroup title="Textarea with max length limit and addon">
+        <TextareaField
+          name="description"
+          label="Description"
+          maxLength={200}
+          rows={3}
+          labelAddon={
+            <Button
+              size="mini"
+              kind="tertiary"
+              onClick={() =>
+                change('description', 'Auto-generated description for the selected region.')
+              }
+              type="button"
+            >
+              Generate
+            </Button>
+          }
+        />
+      </FormGroup>
+
+      <FormGroup title="Textarea with only addon">
+        <TextareaField
+          name="addressLine1"
+          label="Address Line 1"
+          rows={3}
+          labelAddon={
+            <Button
+              size="mini"
+              kind="tertiary"
+              onClick={() => change('addressLine1', '')}
+              type="button"
+            >
+              Clear
+            </Button>
+          }
+        />
+      </FormGroup>
+
+      <FormGroup title="Textarea with only max length limit">
+        <TextareaField name="addressLine2" label="Address Line 2" rows={3} maxLength={100} />
+      </FormGroup>
+    </>
+  );
+}
+
 export function Sandbox() {
   const [activeKey, setActiveKey] = useState('0');
   const [jsonValue, setJsonValue] = useState(JSON.stringify(sampleJson, null, 2));
@@ -322,6 +393,17 @@ export function Sandbox() {
                 }}
               />
             </DetailView>
+          </Block>
+        </Tab>
+
+        <Tab title="Fields - Label addon">
+          <Block marginTop="24px" maxWidth="600px">
+            <Form onSubmit={(values) => console.log('Submitted:', values)}>
+              <LabelAddonExamples />
+              <Block display="flex" justifyContent="flex-end" marginTop="scale600">
+                <Button type="submit">Submit</Button>
+              </Block>
+            </Form>
           </Block>
         </Tab>
 

--- a/javascript/packages/core/components/views/sandbox/sandbox.tsx
+++ b/javascript/packages/core/components/views/sandbox/sandbox.tsx
@@ -210,7 +210,7 @@ function LabelAddonExamples() {
         <SelectField
           name="region"
           label="Region"
-          labelAddon={
+          labelEndEnhancer={
             <Button size="mini" kind="tertiary" onClick={() => change('region', '')} type="button">
               Clear
             </Button>
@@ -230,7 +230,7 @@ function LabelAddonExamples() {
           label="Description"
           maxLength={200}
           rows={3}
-          labelAddon={
+          labelEndEnhancer={
             <Button
               size="mini"
               kind="tertiary"
@@ -250,7 +250,7 @@ function LabelAddonExamples() {
           name="addressLine1"
           label="Address Line 1"
           rows={3}
-          labelAddon={
+          labelEndEnhancer={
             <Button
               size="mini"
               kind="tertiary"

--- a/javascript/packages/core/components/views/sandbox/sandbox.tsx
+++ b/javascript/packages/core/components/views/sandbox/sandbox.tsx
@@ -9,6 +9,7 @@ import { HeadingXXLarge, LabelLarge, ParagraphSmall } from 'baseui/typography';
 import { CellType } from '#core/components/cell/constants';
 import { FormErrorBanner } from '#core/components/form/components/form-error-banner/form-error-banner';
 import { CheckboxField } from '#core/components/form/fields/checkbox/checkbox-field';
+import { MarkdownField } from '#core/components/form/fields/markdown/markdown-field';
 import { NumberField } from '#core/components/form/fields/number/number-field';
 import { SelectField } from '#core/components/form/fields/select/select-field';
 import { StringField } from '#core/components/form/fields/string/string-field';
@@ -454,6 +455,23 @@ export function Sandbox() {
                   initialValue="https://example.com/docs"
                 />
                 <UrlField name="emptyUrl" label="Empty URL (no value)" />
+              </FormGroup>
+
+              <FormGroup title="Markdown Field">
+                <MarkdownField
+                  name="markdownEditable"
+                  label="Editable Markdown"
+                  placeholder="Enter **markdown** content here..."
+                  rows={4}
+                />
+                <MarkdownField
+                  name="markdownReadOnly"
+                  label="Read-Only Markdown"
+                  initialValue={
+                    '# Hello\nThis is **bold** and *italic* text.\n\n- Item 1\n- Item 2\n\n[Link](https://example.com)'
+                  }
+                  readOnly
+                />
               </FormGroup>
 
               <FormGroup title="FormNote">

--- a/javascript/packages/core/index.tsx
+++ b/javascript/packages/core/index.tsx
@@ -182,10 +182,12 @@ export { NumberField } from '#core/components/form/fields/number/number-field';
 export { CheckboxField } from '#core/components/form/fields/checkbox/checkbox-field';
 export { DateField } from '#core/components/form/fields/date/date-field';
 export { DateFormat } from '#core/components/form/fields/date/types';
+export { MarkdownField } from '#core/components/form/fields/markdown/markdown-field';
 
 // Form Layout
 export { FormGroup } from '#core/components/form/layout/form-group/form-group';
 export { FormRow } from '#core/components/form/layout/form-row/form-row';
+export { FormColumn } from '#core/components/form/layout/form-column/form-column';
 export { FormBanner } from '#core/components/form/layout/form-banner/form-banner';
 export { FormStep } from '#core/components/form/layout/form-step/form-step';
 export { ArrayFormRow } from '#core/components/form/layout/array-form-row/array-form-row';


### PR DESCRIPTION
Adds labelAddon prop on all form fields that renders arbitrary content(text, buttons, components) at the far right of the label row, alongside the existing counter when present.

**What changed**

- BaseFieldProps gains a `labelAddon?: ReactNode` prop, making it available to every field component.
- FormControl no longer delegates counter rendering to baseui's native counter prop. Instead, it builds a custom labelEndEnhancer via a LabelEndEnhancerContent component that renders the counter text and labelAddon side by side in a flex row. Tried to keep both counter and labelAddon, however the only way to keep them was to turn labelEndEnhancer into a function which returns ReactNode. With this change, [sharedProps are passed to the function](https://github.com/uber/baseweb/blob/main/src/form-control/form-control.tsx#L188) for it to retrieve `$length` and `$maxLength` of the counter. However, there was a bug(or feature) in form-control implementation where [maxLength is incorrectly set to length instead of maxLength](https://github.com/uber/baseweb/blob/main/src/form-control/form-control.tsx#L162) that breaks the behavior we want to have.
 - All field components destructure and forward labelAddon to FormControl.
- Also changed TextareaField component to render a resizer which could only resize the input vertically within the changes in this PR.

https://github.com/user-attachments/assets/6a8e8f84-1fea-4f07-82c9-78175fa2a1e8

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
