### PR TITLE
Add MarkdownField

### DIFF
--- a/javascript/packages/core/components/form/fields/markdown/markdown-field.tsx
+++ b/javascript/packages/core/components/form/fields/markdown/markdown-field.tsx
@@ -25,7 +25,7 @@ export const MarkdownField: React.FC<MarkdownFieldProps> = ({
   placeholder,
   description,
   caption,
-  labelAddon,
+  labelEndEnhancer,
   format,
   parse,
   rows,
@@ -48,7 +48,7 @@ export const MarkdownField: React.FC<MarkdownFieldProps> = ({
       label={label}
       required={required}
       description={description}
-      labelAddon={labelAddon}
+      labelEndEnhancer={labelEndEnhancer}
       caption={caption}
       error={meta.touched && meta.error ? meta.error : undefined}
       counter={maxLength ? { length: currentLength, maxLength } : undefined}

--- a/javascript/packages/core/components/form/fields/markdown/markdown-field.tsx
+++ b/javascript/packages/core/components/form/fields/markdown/markdown-field.tsx
@@ -1,0 +1,89 @@
+import { useStyletron } from 'baseui';
+import { Textarea } from 'baseui/textarea';
+
+import { FormControl } from '#core/components/form/components/form-control';
+import { useField } from '#core/components/form/hooks/use-field';
+import { Markdown } from '#core/components/markdown/markdown';
+
+import type { MarkdownFieldProps } from './types';
+
+export const MarkdownField: React.FC<MarkdownFieldProps> = ({
+  name,
+  label,
+  defaultValue,
+  initialValue,
+  required,
+  validate,
+  readOnly,
+  disabled,
+  placeholder,
+  description,
+  caption,
+  labelAddon,
+  format,
+  parse,
+  rows,
+  maxLength,
+}) => {
+  const { input, meta } = useField<string>(name, {
+    required,
+    validate,
+    defaultValue,
+    initialValue,
+    label,
+    format,
+    parse,
+  });
+  const [css, theme] = useStyletron();
+  const currentLength = input.value?.length ?? 0;
+
+  return (
+    <FormControl
+      label={label}
+      required={required}
+      description={description}
+      labelAddon={labelAddon}
+      caption={caption}
+      error={meta.touched && meta.error ? meta.error : undefined}
+      counter={maxLength ? { length: currentLength, maxLength } : undefined}
+    >
+      {readOnly ? (
+        <div
+          className={css({
+            ...theme.typography.font300,
+            // To prevent the div from collapsing when the content is empty
+            minHeight: String(theme.typography.font300.lineHeight),
+            border: `${theme.sizing.scale0} solid ${theme.colors.borderOpaque}`,
+            borderRadius: theme.borders.radius300,
+            paddingTop: theme.sizing.scale400,
+            paddingBottom: theme.sizing.scale400,
+            paddingLeft: theme.sizing.scale550,
+            paddingRight: theme.sizing.scale550,
+          })}
+        >
+          <Markdown>{input.value ?? ''}</Markdown>
+        </div>
+      ) : (
+        <Textarea
+          id={input.name}
+          name={input.name}
+          value={input.value ?? ''}
+          onChange={(e) => input.onChange(e.currentTarget.value)}
+          onBlur={input.onBlur}
+          onFocus={input.onFocus}
+          placeholder={placeholder}
+          disabled={disabled}
+          rows={rows}
+          maxLength={maxLength}
+          overrides={{
+            Input: {
+              style: {
+                resize: 'vertical',
+              },
+            },
+          }}
+        />
+      )}
+    </FormControl>
+  );
+};

--- a/javascript/packages/core/components/form/fields/markdown/markdown-field.tsx
+++ b/javascript/packages/core/components/form/fields/markdown/markdown-field.tsx
@@ -7,6 +7,12 @@ import { Markdown } from '#core/components/markdown/markdown';
 
 import type { MarkdownFieldProps } from './types';
 
+/**
+ * Markdown-aware text field with dual rendering modes.
+ *
+ * In edit mode, displays a plain textarea for raw markdown input.
+ * In read-only mode, renders the stored value as formatted markdown.
+ */
 export const MarkdownField: React.FC<MarkdownFieldProps> = ({
   name,
   label,
@@ -61,13 +67,13 @@ export const MarkdownField: React.FC<MarkdownFieldProps> = ({
             paddingRight: theme.sizing.scale550,
           })}
         >
-          <Markdown>{input.value ?? ''}</Markdown>
+          <Markdown>{input.value}</Markdown>
         </div>
       ) : (
         <Textarea
           id={input.name}
           name={input.name}
-          value={input.value ?? ''}
+          value={input.value}
           onChange={(e) => input.onChange(e.currentTarget.value)}
           onBlur={input.onBlur}
           onFocus={input.onFocus}

--- a/javascript/packages/core/components/form/fields/markdown/types.ts
+++ b/javascript/packages/core/components/form/fields/markdown/types.ts
@@ -1,0 +1,6 @@
+import type { BaseFieldProps } from '../types';
+
+export interface MarkdownFieldProps extends BaseFieldProps<string> {
+  rows?: number;
+  maxLength?: number;
+}

--- a/javascript/packages/core/components/form/fields/markdown/types.ts
+++ b/javascript/packages/core/components/form/fields/markdown/types.ts
@@ -2,5 +2,10 @@ import type { BaseFieldProps } from '../types';
 
 export interface MarkdownFieldProps extends BaseFieldProps<string> {
   rows?: number;
+  /**
+   * Limits input length and displays a character counter in the label row.
+   * When `labelEndEnhancer` is also provided, the counter appears first
+   * followed by the enhancer content.
+   */
   maxLength?: number;
 }

--- a/javascript/packages/core/components/views/sandbox/sandbox.tsx
+++ b/javascript/packages/core/components/views/sandbox/sandbox.tsx
@@ -9,6 +9,7 @@ import { HeadingXXLarge, LabelLarge, ParagraphSmall } from 'baseui/typography';
 import { CellType } from '#core/components/cell/constants';
 import { FormErrorBanner } from '#core/components/form/components/form-error-banner/form-error-banner';
 import { CheckboxField } from '#core/components/form/fields/checkbox/checkbox-field';
+import { MarkdownField } from '#core/components/form/fields/markdown/markdown-field';
 import { NumberField } from '#core/components/form/fields/number/number-field';
 import { SelectField } from '#core/components/form/fields/select/select-field';
 import { StringField } from '#core/components/form/fields/string/string-field';
@@ -454,6 +455,23 @@ export function Sandbox() {
                   initialValue="https://example.com/docs"
                 />
                 <UrlField name="emptyUrl" label="Empty URL (no value)" />
+              </FormGroup>
+
+              <FormGroup title="Markdown Field">
+                <MarkdownField
+                  name="markdownEditable"
+                  label="Editable Markdown"
+                  placeholder="Enter **markdown** content here..."
+                  rows={4}
+                />
+                <MarkdownField
+                  name="markdownReadOnly"
+                  label="Read-Only Markdown"
+                  initialValue={
+                    '# Hello\nThis is **bold** and *italic* text.\n\n- Item 1\n- Item 2\n\n[Link](https://example.com)'
+                  }
+                  readOnly
+                />
               </FormGroup>
 
               <FormGroup title="FormNote">

--- a/javascript/packages/core/index.tsx
+++ b/javascript/packages/core/index.tsx
@@ -182,10 +182,12 @@ export { NumberField } from '#core/components/form/fields/number/number-field';
 export { CheckboxField } from '#core/components/form/fields/checkbox/checkbox-field';
 export { DateField } from '#core/components/form/fields/date/date-field';
 export { DATE_FORMAT } from '#core/components/form/fields/date/types';
+export { MarkdownField } from '#core/components/form/fields/markdown/markdown-field';
 
 // Form Layout
 export { FormGroup } from '#core/components/form/layout/form-group/form-group';
 export { FormRow } from '#core/components/form/layout/form-row/form-row';
+export { FormColumn } from '#core/components/form/layout/form-column/form-column';
 export { FormBanner } from '#core/components/form/layout/form-banner/form-banner';
 export { FormStep } from '#core/components/form/layout/form-step/form-step';
 export { ArrayFormRow } from '#core/components/form/layout/array-form-row/array-form-row';


### PR DESCRIPTION
Add MarkdownField that renders a Textarea for editing and rendered markdown for read-only mode.

<img width="932" height="542" alt="Screenshot 2026-03-24 at 17 25 33" src="https://github.com/user-attachments/assets/1f9a55aa-dff0-496e-9785-c1f8b3834d1f" />

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
