### PR TITLE
Fixing wrong link for sandbox setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ We are **incrementally open-sourcing Michelangelo’s core capabilities**, ensur
 
 ## Installation
 
-To install Michelangelo-AI, follow [Sandbox Setup](https://github.com/michelangelo-ai/michelangelo/wiki/Sandbox-Setup) guide until GitHub respository is public.
+To install Michelangelo-AI, follow [Sandbox Setup](https://michelangelo-ai.github.io/michelangelo/docs/getting-started/sandbox-setup) guide until GitHub respository is public.
 
 ## Usage
 


### PR DESCRIPTION
old link was pointing to wiki instructions that have now been moved to the docs.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
