### PR TITLE
Rename package to @michelangelo-ai/core and add npm publish CI

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,75 @@
+name: Publish @michelangelo-ai/core to npm
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'javascript/packages/core/**'
+
+jobs:
+  check-version-change:
+    runs-on: ubuntu-latest
+    outputs:
+      version-changed: ${{ steps.check.outputs.changed }}
+      new-version: ${{ steps.check.outputs.version }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check if core package.json version changed
+        id: check
+        run: |
+          if git diff HEAD~1 HEAD --name-only | grep -q "javascript/packages/core/package.json"; then
+            VERSION=$(jq -r '.version' javascript/packages/core/package.json)
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "📦 core version changed to: $VERSION"
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "📦 core version unchanged, skipping publish"
+          fi
+
+  publish:
+    needs: check-version-change
+    if: needs.check-version-change.outputs.version-changed == 'true'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.11.0
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'yarn'
+          cache-dependency-path: javascript/yarn.lock
+
+      - name: Set up buf CLI
+        uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install dependencies
+        run: |
+          cd javascript
+          yarn setup
+
+      - name: Build @michelangelo-ai/core
+        run: |
+          cd javascript
+          yarn workspace @michelangelo-ai/core build
+
+      - name: Publish to npm
+        run: |
+          cd javascript/packages/core
+          npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -70,6 +70,4 @@ jobs:
       - name: Publish to npm
         run: |
           cd javascript/packages/core
-          npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          npm publish --provenance --access public

--- a/.github/workflows/ui-pre-land.yaml
+++ b/.github/workflows/ui-pre-land.yaml
@@ -41,7 +41,7 @@ jobs:
           WORKSPACE_ROOT: ${{ github.workspace }}
 
       - name: Build Core package for type resolution
-        run: yarn workspace @uber/michelangelo-core build
+        run: yarn workspace @michelangelo-ai/core build
 
       - name: Run ESLint
         run: yarn lint

--- a/javascript/app/App.tsx
+++ b/javascript/app/App.tsx
@@ -1,7 +1,7 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom-v5-compat';
 import { normalizeConnectError, request } from '@michelangelo/rpc';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { CoreApp } from '@michelangelo-ai/core';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Client as Styletron } from 'styletron-engine-atomic';
 import { Provider as StyletronProvider } from 'styletron-react';
 

--- a/javascript/app/App.tsx
+++ b/javascript/app/App.tsx
@@ -1,7 +1,7 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom-v5-compat';
 import { normalizeConnectError, request } from '@michelangelo/rpc';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { CoreApp } from '@uber/michelangelo-core';
+import { CoreApp } from '@michelangelo-ai/core';
 import { Client as Styletron } from 'styletron-engine-atomic';
 import { Provider as StyletronProvider } from 'styletron-react';
 

--- a/javascript/app/package.json
+++ b/javascript/app/package.json
@@ -15,7 +15,7 @@
     "@mui/icons-material": "^7.1.0",
     "@mui/material": "^7.1.0",
     "@tanstack/react-query": "5.39.0",
-    "@uber/michelangelo-core": "*",
+    "@michelangelo-ai/core": "*",
     "baseui": "15.0.0",
     "react-router-dom": "5.3.4",
     "react-router-dom-v5-compat": "6.29.0",

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "yarn workspaces run build",
     "dev": "yarn workspace @michelangelo/app dev",
-    "dev-production": "yarn workspace @uber/michelangelo-core build && yarn workspace @michelangelo/app dev-production",
+    "dev-production": "yarn workspace @michelangelo-ai/core build && yarn workspace @michelangelo/app dev-production",
     "format": "prettier --check .",
     "generate": "../tools/gen-grpc-client.sh --clients javascript",
     "lint": "eslint .",

--- a/javascript/packages/core/CLAUDE.md
+++ b/javascript/packages/core/CLAUDE.md
@@ -1,31 +1,5 @@
 # CLAUDE.md - Core Package Guidelines
 
-## Publishing to npm
-
-### How publishing is triggered
-
-Publishing is handled by `.github/workflows/npm-publish.yml`. It runs on every push to `main` that touches `javascript/packages/core/**`. The workflow checks whether the `version` field in `javascript/packages/core/package.json` changed in that commit. If it did, the package is built and published to npmjs.com under `@michelangelo-ai/core`. If the version is unchanged, the publish step is skipped.
-
-To release a new version: bump the version in `javascript/packages/core/package.json`, commit, and push (or merge) to `main`.
-
-### The `NPM_TOKEN` secret
-
-The workflow authenticates to npm using a repository secret named `NPM_TOKEN`. This must be a **granular access token from the personal npm account of the `@michelangelo-ai` org owner** (craig.marker). A team token will not work — only the org owner's personal token carries publish rights to the org's packages.
-
-**Creating the token:**
-
-1. Log in to npmjs.com as craig.marker.
-2. Go to Account → Access Tokens → Generate New Token → Granular Access Token.
-3. Grant **read and write** publish access, scoped to the `@michelangelo-ai` organization.
-4. Copy the token value.
-
-**Adding the secret to the repository:**
-
-1. In the GitHub repository, go to Settings → Secrets and variables → Actions.
-2. Click "New repository secret".
-3. Name: `NPM_TOKEN`, Value: the token copied above.
-4. Save.
-
 ## Testing Guidelines
 
 ### Using Established Test Wrappers

--- a/javascript/packages/core/CLAUDE.md
+++ b/javascript/packages/core/CLAUDE.md
@@ -1,5 +1,31 @@
 # CLAUDE.md - Core Package Guidelines
 
+## Publishing to npm
+
+### How publishing is triggered
+
+Publishing is handled by `.github/workflows/npm-publish.yml`. It runs on every push to `main` that touches `javascript/packages/core/**`. The workflow checks whether the `version` field in `javascript/packages/core/package.json` changed in that commit. If it did, the package is built and published to npmjs.com under `@michelangelo-ai/core`. If the version is unchanged, the publish step is skipped.
+
+To release a new version: bump the version in `javascript/packages/core/package.json`, commit, and push (or merge) to `main`.
+
+### The `NPM_TOKEN` secret
+
+The workflow authenticates to npm using a repository secret named `NPM_TOKEN`. This must be a **granular access token from the personal npm account of the `@michelangelo-ai` org owner** (craig.marker). A team token will not work — only the org owner's personal token carries publish rights to the org's packages.
+
+**Creating the token:**
+
+1. Log in to npmjs.com as craig.marker.
+2. Go to Account → Access Tokens → Generate New Token → Granular Access Token.
+3. Grant **read and write** publish access, scoped to the `@michelangelo-ai` organization.
+4. Copy the token value.
+
+**Adding the secret to the repository:**
+
+1. In the GitHub repository, go to Settings → Secrets and variables → Actions.
+2. Click "New repository secret".
+3. Name: `NPM_TOKEN`, Value: the token copied above.
+4. Save.
+
 ## Testing Guidelines
 
 ### Using Established Test Wrappers

--- a/javascript/packages/core/interpolation/types.ts
+++ b/javascript/packages/core/interpolation/types.ts
@@ -102,7 +102,7 @@ export interface InterpolationContext<U extends StudioParamsView = 'base'>
  * @example
  * ```typescript
  * // In your application code:
- * declare module '@uber/michelangelo-core' {
+ * declare module '@michelangelo-ai/core' {
  *   interface InterpolationContextExtensions {
  *     user: { uuid: string; email: string; username: string };
  *     project: { id: string; name: string };

--- a/javascript/packages/core/package.json
+++ b/javascript/packages/core/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@uber/michelangelo-core",
-  "license": "UNLICENSED",
+  "name": "@michelangelo-ai/core",
+  "license": "Apache-2.0",
   "version": "0.1.15",
   "type": "module",
   "main": "./dist/michelangelo-core.js",
@@ -56,6 +56,9 @@
     "react-router-dom-v5-compat": "^6.29.0",
     "styletron-engine-atomic": "^1.0.0",
     "styletron-react": "^6.1.1"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "exports": {
     ".": {

--- a/javascript/packages/rpc/normalize-connect-error.ts
+++ b/javascript/packages/rpc/normalize-connect-error.ts
@@ -1,7 +1,7 @@
 import { ConnectError } from '@connectrpc/connect';
-import { ApplicationError, GrpcStatusCode } from '@uber/michelangelo-core';
+import { ApplicationError, GrpcStatusCode } from '@michelangelo-ai/core';
 
-import type { ErrorNormalizer } from '@uber/michelangelo-core';
+import type { ErrorNormalizer } from '@michelangelo-ai/core';
 
 /**
  * Normalizes Connect RPC errors to ApplicationError format

--- a/javascript/packages/rpc/package.json
+++ b/javascript/packages/rpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@michelangelo/rpc",
-  "license": "UNLICENSED",
+  "license": "Apache-2.0",
   "type": "module",
   "version": "0.0.0",
   "scripts": {
@@ -14,7 +14,7 @@
   "dependencies": {
     "@connectrpc/connect": "^2.0.2",
     "@connectrpc/connect-web": "^2.0.2",
-    "@uber/michelangelo-core": "*"
+    "@michelangelo-ai/core": "*"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
The package was previously named @uber/michelangelo-core, which doesn't reflect the project's open-source identity or the @michelangelo-ai org that exists on npmjs.com.

Rename @uber/michelangelo-core to @michelangelo-ai/core across all workspace packages and update all import references. Update the license field from UNLICENSED to Apache-2.0 to match the repo's existing LICENSE file — a public npm package cannot carry UNLICENSED. Add publishConfig with access: public so scoped package publishes don't require an explicit --access flag.

Add a GitHub Actions workflow that publishes to npm automatically when the version in packages/core/package.json changes on a push to main.

**What type of PR is this? (check all applicable)**
- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
