### PR TITLE
Add inline broken link annotations to Docs Check

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -26,4 +26,40 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Build
-        run: bun run build
+        id: build
+        continue-on-error: true
+        run: bun run build 2>&1 | tee /tmp/build-output.txt
+
+      - name: Annotate broken links
+        if: steps.build.outcome == 'failure'
+        working-directory: .
+        run: |
+          current_file=""
+          while IFS= read -r line; do
+            if [[ "$line" =~ "Broken link on source page path = /michelangelo/"(.*): ]]; then
+              page_path="${BASH_REMATCH[1]}"
+              page_path="${page_path%/}"
+              if [[ -f "${page_path}/index.md" ]]; then
+                current_file="${page_path}/index.md"
+              elif [[ -f "${page_path}.md" ]]; then
+                current_file="${page_path}.md"
+              else
+                current_file=""
+              fi
+            fi
+            if [[ "$line" =~ "-> linking to "([^[:space:]]+) ]] && [[ -n "$current_file" ]]; then
+              broken_link="${BASH_REMATCH[1]}"
+              line_nums=$(grep -n "$broken_link" "$current_file" 2>/dev/null | cut -d: -f1)
+              if [[ -n "$line_nums" ]]; then
+                while IFS= read -r line_num; do
+                  echo "::error file=${current_file},line=${line_num}::Broken link: '${broken_link}' could not be resolved"
+                done <<< "$line_nums"
+              else
+                echo "::error file=${current_file}::Broken link: '${broken_link}' could not be resolved"
+              fi
+            fi
+          done < /tmp/build-output.txt
+
+      - name: Fail if build failed
+        if: steps.build.outcome == 'failure'
+        run: exit 1


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
Enhanced the Docs Check workflow to surface broken link errors as inline annotations on the PR diff. When `bun run build` detects broken links (via Docusaurus's `onBrokenLinks: 'throw'`), the workflow now:
1. Captures the build output
2. Parses Docusaurus's broken link error messages
3. Maps page paths back to source `.md` files and finds line numbers
4. Emits `::error file=path,line=N::` annotations that GitHub renders inline on "Files changed"

**Why?**
Non-technical doc contributors don't dig through CI logs. Broken link errors were invisible — the check would fail but the contributor wouldn't know which line or link was the problem. Inline annotations make this immediately obvious.

**How did you test it?**
- Tested the parsing script locally against the actual error output from a failed CI run (PR #988)
- Verified correct file path mapping (`/michelangelo/docs/user-guides/` → `docs/user-guides/index.md`)
- Verified line number detection for multiple occurrences of the same broken link

**Potential risks**
- The `baseUrl` (`/michelangelo/`) is hardcoded in the regex. If it changes in `docusaurus.config.ts`, the annotation step would need updating.
- GitHub limits annotations to 10 per step / 50 per job. Sufficient for typical doc PRs.

**Release notes**
N/A — CI workflow change only.

**Documentation Changes**
N/A