### PR TITLE
Fix relative link resolution on GitHub Pages

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -31,10 +31,18 @@ jobs:
           # Relative doc links without .md are passed through as raw href values.
           # GitHub Pages adds trailing slashes, which breaks browser resolution of
           # relative paths. Links with .md are resolved by Docusaurus at build time.
-          matches=$(grep -rEn '\]\(\.\./|\]\(\./' docs/ --include='*.md' \
-            | grep -v '\.md[)#]' | grep -v '\.png)' | grep -v '\.jpg)' \
-            | grep -v '\.svg)' | grep -v '\.gif)' | grep -v '\.go)' \
-            | grep -v 'http' || true)
+  SKIP_MD_EXTENSIONS='\.md[)#]'
+  SKIP_IMAGE_EXTENSIONS='\.(png|jpg|svg|gif)\)'
+  SKIP_CODE_EXTENSIONS='\.go\)'
+  SKIP_REMOTE_LINKS='http'
+
+  # Search for relative links, then drop (grep -v) the ones that match our skip patterns
+  matches=$(grep -rEn '\]\(\.\.?/' docs/ --include='*.md' | \
+    grep -vE "$SKIP_MD_EXTENSIONS"    | \
+    grep -vE "$SKIP_IMAGE_EXTENSIONS" | \
+    grep -vE "$SKIP_CODE_EXTENSIONS"  | \
+    grep -vE "$SKIP_REMOTE_LINKS"     | \
+    || true)
           if [ -n "$matches" ]; then
             while IFS=: read -r file line content; do
               echo "::error file=${file},line=${line}::Relative link without .md extension will break on GitHub Pages. Use ./foo.md instead of ./foo"

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -8,7 +8,7 @@ on:
       - 'website/**'
 
 jobs:
-  build:
+  validate-docs:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -24,6 +24,23 @@ jobs:
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
+
+      - name: Check for relative links without .md extension
+        working-directory: .
+        run: |
+          # Relative doc links without .md are passed through as raw href values.
+          # GitHub Pages adds trailing slashes, which breaks browser resolution of
+          # relative paths. Links with .md are resolved by Docusaurus at build time.
+          matches=$(grep -rEn '\]\(\.\./|\]\(\./' docs/ --include='*.md' \
+            | grep -v '\.md[)#]' | grep -v '\.png)' | grep -v '\.jpg)' \
+            | grep -v '\.svg)' | grep -v '\.gif)' | grep -v '\.go)' \
+            | grep -v 'http' || true)
+          if [ -n "$matches" ]; then
+            while IFS=: read -r file line content; do
+              echo "::error file=${file},line=${line}::Relative link without .md extension will break on GitHub Pages. Use ./foo.md instead of ./foo"
+            done <<< "$matches"
+            exit 1
+          fi
 
       - name: Build
         id: build

--- a/docs/contributing/dev/ui/configuration/configuration-api.md
+++ b/docs/contributing/dev/ui/configuration/configuration-api.md
@@ -218,10 +218,10 @@ The best way to learn is to explore working examples:
 
 Detailed API references for each configuration type:
 
-- [Cell Types Reference](cell-type-reference)
-- [Table Configuration Reference](table-configuration-reference)
-- [Phase Configuration Reference](phase-configuration-reference)
-- [Entity Configuration Reference](entity-configuration-reference)
+- [Cell Types Reference](./cell-type-reference.md)
+- [Table Configuration Reference](./table-configuration-reference.md)
+- [Phase Configuration Reference](./phase-configuration-reference.md)
+- [Entity Configuration Reference](./entity-configuration-reference.md)
 
 ### FAQ
 

--- a/docs/contributing/dev/ui/configuration/entity-configuration-reference.md
+++ b/docs/contributing/dev/ui/configuration/entity-configuration-reference.md
@@ -68,7 +68,7 @@ export const RUN_ENTITY_CONFIG: PhaseEntityConfig = {
 
 ## View Configuration
 
-Views define how entities are presented. See [Cell Types Reference](./cell-type-reference) for column/field configuration.
+Views define how entities are presented. See [Cell Types Reference](./cell-type-reference.md) for column/field configuration.
 
 - **List views**: `config/entities/*/list.ts` - Table columns with cells
 - **Detail views**: `config/entities/*/detail.ts` - Metadata header + content pages
@@ -128,6 +128,6 @@ The configuration system uses this mapping to:
 
 ## Related Documentation
 
-- [Phase Configuration Reference](phase-configuration-reference) - Configure phases that contain entities
-- [Cell Types Reference](./cell-type-reference) - Configure columns and fields in views
-- [Configuration API](./configuration-api) - overview of configuration system
+- [Phase Configuration Reference](./phase-configuration-reference.md) - Configure phases that contain entities
+- [Cell Types Reference](./cell-type-reference.md) - Configure columns and fields in views
+- [Configuration API](./configuration-api.md) - overview of configuration system

--- a/docs/contributing/dev/ui/configuration/phase-configuration-reference.md
+++ b/docs/contributing/dev/ui/configuration/phase-configuration-reference.md
@@ -55,7 +55,7 @@ The `state` property controls overall phase behavior and appearance:
 - Optional link to external documentation
 
 ### `entities`
-- Array of entity configurations (see [Entity Configuration Reference](./entity-configuration-reference))
+- Array of entity configurations (see [Entity Configuration Reference](./entity-configuration-reference.md))
 - Order in array affects display order in navigation
 
 ## Source Files
@@ -66,5 +66,5 @@ The `state` property controls overall phase behavior and appearance:
 
 ## Related Documentation
 
-- [Entity Configuration Reference](./entity-configuration-reference) - Configure entities within phases
-- [Configuration API](./configuration-api) - overview of configuration system
+- [Entity Configuration Reference](./entity-configuration-reference.md) - Configure entities within phases
+- [Configuration API](./configuration-api.md) - overview of configuration system

--- a/docs/contributing/dev/ui/configuration/table-configuration-reference.md
+++ b/docs/contributing/dev/ui/configuration/table-configuration-reference.md
@@ -9,7 +9,7 @@ Table configuration controls table-level behavior (pagination, sorting, search, 
 
 | Property            | Type               | Description                                                                    | Default                                                |
 | ------------------- | ------------------ | ------------------------------------------------------------------------------ | ------------------------------------------------------ |
-| `columns`           | `ColumnConfig[]`   | Array of column definitions (see [Cell Types Reference](./cell-type-reference)) | ✅ Required                                            |
+| `columns`           | `ColumnConfig[]`   | Array of column definitions (see [Cell Types Reference](./cell-type-reference.md)) | ✅ Required                                            |
 | `emptyState`        | `EmptyState`       | Content to display when table has no data                                      | `{ title: 'No data', content: 'No data is present.' }` |
 | `disablePagination` | `boolean`          | Show all data in single page without pagination controls                       | `false`                                                |
 | `disableSorting`    | `boolean`          | Disable sorting functionality for all columns                                  | `false`                                                |
@@ -23,7 +23,7 @@ Table configuration controls table-level behavior (pagination, sorting, search, 
 ### `columns`
 
 - Array of column configurations using cell types
-- See [Cell Types Reference](./cell-type-reference) for complete column/cell configuration
+- See [Cell Types Reference](./cell-type-reference.md) for complete column/cell configuration
 - Order in array determines initial display order
 
 ### `emptyState`
@@ -94,6 +94,6 @@ Controls what displays when the table has no data.
 
 ## Related Documentation
 
-- [Cell Types Reference](./cell-type-reference) - Column configuration (the `columns` property)
-- [Entity Configuration Reference](entity-configuration-reference) - How entities use list and detail views
-- [Configuration API](./configuration-api) - overview of configuration system
+- [Cell Types Reference](./cell-type-reference.md) - Column configuration (the `columns` property)
+- [Entity Configuration Reference](./entity-configuration-reference.md) - How entities use list and detail views
+- [Configuration API](./configuration-api.md) - overview of configuration system

--- a/docs/contributing/dev/ui/core-systems.md
+++ b/docs/contributing/dev/ui/core-systems.md
@@ -242,6 +242,6 @@ Available providers:
 
 ## Related Documentation
 
-- [Architecture Overview](./) - Technology stack and build process
-- [Types and Patterns](types-and-patterns) - TypeScript types and conventions
-- [UI Components](ui-components) - Table, cell, and form systems
+- [Architecture Overview](./index.md) - Technology stack and build process
+- [Types and Patterns](./types-and-patterns.md) - TypeScript types and conventions
+- [UI Components](./ui-components.md) - Table, cell, and form systems

--- a/docs/contributing/dev/ui/index.md
+++ b/docs/contributing/dev/ui/index.md
@@ -111,7 +111,7 @@ import { normalizeConnectError } from '#rpc/normalize-connect-error';
 
 ## Related Documentation
 
-- [Core Systems](core-systems) - Providers, hooks, and error handling
-- [Types and Patterns](types-and-patterns) - TypeScript types and React component patterns
-- [UI Components](ui-components) - Table, cell, form, and styling systems
-- [Configuration API](configuration/configuration-api) - Defining phases, entities, and views
+- [Core Systems](./core-systems.md) - Providers, hooks, and error handling
+- [Types and Patterns](./types-and-patterns.md) - TypeScript types and React component patterns
+- [UI Components](./ui-components.md) - Table, cell, form, and styling systems
+- [Configuration API](./configuration/configuration-api.md) - Defining phases, entities, and views

--- a/docs/contributing/dev/ui/types-and-patterns.md
+++ b/docs/contributing/dev/ui/types-and-patterns.md
@@ -217,6 +217,6 @@ import { useStudioQuery } from '#core/hooks';
 
 ## Related Documentation
 
-- [Architecture Overview](./) - Technology stack and build process
-- [Core Systems](core-systems) - Providers, hooks, and error handling
-- [UI Components](ui-components) - Table, cell, and form systems
+- [Architecture Overview](./index.md) - Technology stack and build process
+- [Core Systems](./core-systems.md) - Providers, hooks, and error handling
+- [UI Components](./ui-components.md) - Table, cell, and form systems

--- a/docs/contributing/dev/ui/ui-components.md
+++ b/docs/contributing/dev/ui/ui-components.md
@@ -330,6 +330,6 @@ Available wrapper functions:
 
 ## Related Documentation
 
-- [Architecture Overview](./) - Technology stack and build process
-- [Types and Patterns](types-and-patterns) - TypeScript types and conventions
-- [Core Systems](core-systems) - Providers, hooks, and error handling
+- [Architecture Overview](./index.md) - Technology stack and build process
+- [Types and Patterns](./types-and-patterns.md) - TypeScript types and conventions
+- [Core Systems](./core-systems.md) - Providers, hooks, and error handling

--- a/docs/getting-started/core-concepts-and-key-terms.md
+++ b/docs/getting-started/core-concepts-and-key-terms.md
@@ -558,6 +558,6 @@ def process_dataset(dataset: ray.data.Dataset) -> ray.data.Dataset:
 
 ## What's next?
 
-- **Ready to start building?** [Set up your local sandbox](./sandbox-setup) and then follow [Getting Started with Pipelines](../user-guides/ml-pipelines/getting-started)
-- **Want to see complete examples?** Browse [end-to-end tutorials](../user-guides#learning-by-examples) for XGBoost, BERT, GPT fine-tuning, and recommendation systems
-- **Interested in the CLI?** See the [CLI Reference](../user-guides/cli) for pipeline and project management commands
+- **Ready to start building?** [Set up your local sandbox](./sandbox-setup.md) and then follow [Getting Started with Pipelines](../user-guides/ml-pipelines/getting-started.md)
+- **Want to see complete examples?** Browse [end-to-end tutorials](../user-guides/index.md#learning-by-examples) for XGBoost, BERT, GPT fine-tuning, and recommendation systems
+- **Interested in the CLI?** See the [CLI Reference](../user-guides/cli.md) for pipeline and project management commands

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -4,12 +4,12 @@ Everything you need to understand Michelangelo and set up your environment.
 
 ## Start here
 
-- **[Overview](./overview)** — What Michelangelo is, how it works, and how familiar tools map to it
-- **[Core Concepts and Key Terms](./core-concepts-and-key-terms)** — Projects, workflows, tasks, and the key terms you'll encounter
+- **[Overview](./overview.md)** — What Michelangelo is, how it works, and how familiar tools map to it
+- **[Core Concepts and Key Terms](./core-concepts-and-key-terms.md)** — Projects, workflows, tasks, and the key terms you'll encounter
 
 ## Set up your environment
 
-- **[Sandbox Setup](./sandbox-setup)** — Set up a local Michelangelo cluster (~20 min)
-- **[IDE and Bazel Setup](./setup-ide-and-bazel)** — Configure your editor and build system
-- **[Custom Docker Images](./custom-docker-images-for-feature-branches-and-sandbox-testing)** — Build images for feature branches and sandbox testing
-- **[Sandbox Ports and Endpoints](./ma-sandbox-ports-and-endpoints)** — Reference for sandbox service ports
+- **[Sandbox Setup](./sandbox-setup.md)** — Set up a local Michelangelo cluster (~20 min)
+- **[IDE and Bazel Setup](./setup-ide-and-bazel.md)** — Configure your editor and build system
+- **[Custom Docker Images](./custom-docker-images-for-feature-branches-and-sandbox-testing.md)** — Build images for feature branches and sandbox testing
+- **[Sandbox Ports and Endpoints](./ma-sandbox-ports-and-endpoints.md)** — Reference for sandbox service ports

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -115,7 +115,7 @@ For more advanced tasks, such as training DL models, setting up customized retra
 
 CanvasFlex provides a highly customized, code driven ML development experience by applying software development principles to ML development. Users can create their own dependencies that can be managed in the UI environment.
 
-**Not sure where to start?** Check out our [user guides](../user-guides) for end-to-end examples.
+**Not sure where to start?** Check out our [user guides](../user-guides/index.md) for end-to-end examples.
 
 ## Architecture
 
@@ -250,12 +250,12 @@ A: Yes, with proper configuration. Michelangelo supports:
 
 ---
 
-**Still have questions?** Check out our [documentation](../), join the [community forum](https://github.com/michelangelo-ai/michelangelo/discussions), or explore the [user guides](../user-guides).
+**Still have questions?** Check out our [documentation](../intro.md), join the [community forum](https://github.com/michelangelo-ai/michelangelo/discussions), or explore the [user guides](../user-guides/index.md).
 
 ---
 
 ## What's next?
 
-- **Ready to build?** [Set up your local sandbox](./sandbox-setup) and follow the [Getting Started with Pipelines](../user-guides/ml-pipelines/getting-started) guide (~30 min)
-- **Want to understand the concepts first?** Read [Core Concepts and Key Terms](./core-concepts-and-key-terms)
-- **Looking for examples?** Browse [end-to-end tutorials](../user-guides#learning-by-examples) covering XGBoost, BERT, GPT fine-tuning, and recommendation systems
+- **Ready to build?** [Set up your local sandbox](./sandbox-setup.md) and follow the [Getting Started with Pipelines](../user-guides/ml-pipelines/getting-started.md) guide (~30 min)
+- **Want to understand the concepts first?** Read [Core Concepts and Key Terms](./core-concepts-and-key-terms.md)
+- **Looking for examples?** Browse [end-to-end tutorials](../user-guides/index.md#learning-by-examples) covering XGBoost, BERT, GPT fine-tuning, and recommendation systems

--- a/docs/getting-started/sandbox-setup.md
+++ b/docs/getting-started/sandbox-setup.md
@@ -415,6 +415,6 @@ Debugging workflow running in the cluster
 
 ## What's next?
 
-- **Build your first pipeline** — Follow [Getting Started with ML Pipelines](../user-guides/ml-pipelines/getting-started) to create a training workflow (~30 min)
+- **Build your first pipeline** — Follow [Getting Started with ML Pipelines](../user-guides/ml-pipelines/getting-started.md) to create a training workflow (~30 min)
 - **Explore example projects** — Try [Boston Housing XGBoost](https://github.com/michelangelo-ai/michelangelo/tree/main/python/examples/boston_housing_xgb), [BERT Text Classification](https://github.com/michelangelo-ai/michelangelo/tree/main/python/examples/bert_cola), or [GPT Fine-tuning](https://github.com/michelangelo-ai/michelangelo/tree/main/python/examples/gpt_oss_20b_finetune)
-- **Learn the CLI** — See the [CLI Reference](../user-guides/cli) for managing pipelines and projects
+- **Learn the CLI** — See the [CLI Reference](../user-guides/cli.md) for managing pipelines and projects

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -14,28 +14,27 @@ Michelangelo is an end-to-end ML platform for building, deploying, and managing 
 
 Understand what the platform does, how it compares to your current stack, and whether it fits your use case.
 
-- **[Overview](/docs/getting-started/overview)** — What Michelangelo is, how it works, and how familiar tools map to it
-- **[Core Concepts](/docs/getting-started/core-concepts-and-key-terms)** — Projects, workflows, tasks, and the key terms you'll encounter
+- **[Overview](./getting-started/overview.md)** — What Michelangelo is, how it works, and how familiar tools map to it
+- **[Core Concepts](./getting-started/core-concepts-and-key-terms.md)** — Projects, workflows, tasks, and the key terms you'll encounter
 
 ### I want to build my first pipeline
 
 Get a local environment running and build an end-to-end ML pipeline.
 
-- **[Sandbox Setup](/docs/getting-started/sandbox-setup)** — Set up a local Michelangelo cluster (~20 min)
-- **[Getting Started with Pipelines](/docs/user-guides/ml-pipelines/getting-started)** — Build your first pipeline from scratch (~30 min)
+- **[Sandbox Setup](./getting-started/sandbox-setup.md)** — Set up a local Michelangelo cluster (~20 min)
+- **[Getting Started with Pipelines](./user-guides/ml-pipelines/getting-started.md)** — Build your first pipeline from scratch (~30 min)
 - **[Example Projects](https://github.com/michelangelo-ai/michelangelo/tree/main/python/examples)** — Boston Housing, BERT text classification, GPT fine-tuning, and more
 
 ### I'm deploying or operating the platform
 
 Set up infrastructure, configure compute clusters, and deploy the UI.
 
-- **[Operator Guides](/docs/operator-guides)** — API framework, compute clusters, and serving infrastructure
-- **[Building from Source](/docs/contributing/building-michelangelo-ai-from-source)** — Compile and run the platform locally
+- **[Operator Guides](./operator-guides/index.md)** — API framework, compute clusters, and serving infrastructure
+- **[Building from Source](./contributing/building-michelangelo-ai-from-source.md)** — Compile and run the platform locally
 
 ### I want to contribute
 
-- **[Developer Guide](/docs/contributing/developer-guide)** — Contribution workflow and development practices
-- **[Documentation Guide](/docs/contributing/documentation-guide)** — How to write and structure docs
+- **[Documentation Guide](./contributing/documentation-guide.md)** — How to write and structure docs
 
 ## What Michelangelo is — and isn't
 
@@ -58,5 +57,5 @@ Understanding scope helps you decide if Michelangelo is the right tool.
 ## Quick links
 
 - [GitHub Repository](https://github.com/michelangelo-ai/michelangelo)
-- [CLI Reference](/docs/user-guides/cli)
-- [ML Pipelines Overview](/docs/user-guides/ml-pipelines)
+- [CLI Reference](./user-guides/cli.md)
+- [ML Pipelines Overview](./user-guides/ml-pipelines/index.md)

--- a/docs/operator-guides/ui/deploying-michelangelo-ui.md
+++ b/docs/operator-guides/ui/deploying-michelangelo-ui.md
@@ -101,7 +101,7 @@ The UI container serves the React application on port 80 (standard HTTP). Users 
 The UI serves static files (HTML, JS, CSS) from nginx, so it's a standard web server that needs HTTP access from users' browsers.
 
 ### Reference Implementation
-For a complete working example, see the [Sandbox Guide](../../getting-started/sandbox-setup) which includes all components configured and connected.
+For a complete working example, see the [Sandbox Guide](../../getting-started/sandbox-setup.md) which includes all components configured and connected.
 
 ### Verification
 Once deployed, verify the connection chain:

--- a/docs/operator-guides/ui/index.md
+++ b/docs/operator-guides/ui/index.md
@@ -10,7 +10,7 @@ Production deployment using sandbox manifests as templates for your infrastructu
 - **For: Platform operators**
 - **Use case: Full ML platform deployment with UI**
 
-→ **[Deploying Michelangelo UI](./deploying-michelangelo-ui)**
+→ **[Deploying Michelangelo UI](./deploying-michelangelo-ui.md)**
 
 ### Integrate with Existing React App
 Add Michelangelo components to your existing React application as npm dependencies that connect to your infrastructure.
@@ -18,7 +18,7 @@ Add Michelangelo components to your existing React application as npm dependenci
 - **For: Frontend developers, application teams**
 - **Use case: Separate frontend/backend infrastructure, or embedding ML capabilities in existing developer tools**
 
-→ **[React Library Integration](./michelangelo-react-library)**
+→ **[React Library Integration](./michelangelo-react-library.md)**
 
 ### Local Development
 Set up a development environment for contributing to the UI codebase.
@@ -26,7 +26,7 @@ Set up a development environment for contributing to the UI codebase.
 - **For: Contributors, UI developers**
 - **Use case: UI development and contributions**
 
-→ **[Local Development Setup](./local-development-setup)**
+→ **[Local Development Setup](./local-development-setup.md)**
 
 ## Architecture
 

--- a/docs/operator-guides/ui/local-development-setup.md
+++ b/docs/operator-guides/ui/local-development-setup.md
@@ -46,7 +46,7 @@ npm install --global yarn
 yarn --version  # Verify installation
 ```
 
-**For full-stack development (optional):** following [Michelangelo Sandbox Getting Started](../../getting-started/sandbox-setup).
+**For full-stack development (optional):** following [Michelangelo Sandbox Getting Started](../../getting-started/sandbox-setup.md).
 
 **Note:** The sandbox is optional for UI development. You can develop UI components and pages without a running API server by mocking responses or working with static data.
 
@@ -111,4 +111,4 @@ A: Yes, you can work with mock data or specifically on data-independent function
 - [Vite Documentation](https://vitejs.dev/)
 - [Yarn Workspaces Guide](https://classic.yarnpkg.com/en/docs/workspaces/)
 - [Node Version Manager (nvm)](https://github.com/nvm-sh/nvm)
-- [Michelangelo Sandbox Documentation](../../getting-started/sandbox-setup)
+- [Michelangelo Sandbox Documentation](../../getting-started/sandbox-setup.md)

--- a/docs/operator-guides/ui/michelangelo-react-library.md
+++ b/docs/operator-guides/ui/michelangelo-react-library.md
@@ -206,7 +206,7 @@ clusters:
               port_value: 8081                # Your API server port
 ```
 
-**Reference Configuration:** See complete Envoy setup in the [Deploying Michelangelo UI](./deploying-michelangelo-ui) guide.
+**Reference Configuration:** See complete Envoy setup in the [Deploying Michelangelo UI](./deploying-michelangelo-ui.md) guide.
 
 ### Icon Configuration
 

--- a/docs/user-guides/index.md
+++ b/docs/user-guides/index.md
@@ -25,7 +25,7 @@ Version and organize trained models:
 
 ### **5. Deploy Your Model**
 Serve predictions in production:
-* [**Deploy Models**](../operator-guides/serving) - Deploy models for real-time inference and batch scoring
+* [**Deploy Models**](../operator-guides/serving/index.md) - Deploy models for real-time inference and batch scoring
 
 ---
 
@@ -45,7 +45,7 @@ Serve predictions in production:
 * [Prepare your data](./prepare-your-data.md)
 * [Train a model](./train-and-register-a-model.md)
 * [Manage your models](./model-registry-guide.md)
-* [Deploy models](../operator-guides/serving)
+* [Deploy models](../operator-guides/serving/index.md)
 
 ### **Advanced Topics**
 

--- a/docs/user-guides/ml-pipelines/getting-started.md
+++ b/docs/user-guides/ml-pipelines/getting-started.md
@@ -13,8 +13,8 @@ Build and run your first ML pipeline on Michelangelo in minutes. This guide walk
 
 * Python 3.9+
 * [Poetry](https://python-poetry.org/) installed
-* For remote runs: Docker and access to a Kubernetes cluster (or use the [local sandbox](/getting-started/sandbox-setup.md))
-* [Create a project](/docs/user-guides/project-management-for-ml-pipelines/)
+* For remote runs: Docker and access to a Kubernetes cluster (or use the [local sandbox](../../getting-started/sandbox-setup.md))
+* [Create a project](../project-management-for-ml-pipelines.md)
 
 ## Environment setup
 


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**

- Added `.md` extensions to all relative doc links (19 doc files)
- Converted absolute `/docs/` links to relative `.md` links for consistency
- Added a CI check to `docs-check.yml` that flags relative links without `.md`
- Removed broken link to deleted `developer-guide.md` in `intro.md`

**Why?**

Relative links like `[user guides](../user-guides)` resolve incorrectly on GitHub Pages. When navigating to `/docs/getting-started/overview/` (trailing slash added by GitHub Pages), the browser treats `overview/` as a directory, so `../user-guides` resolves to `/docs/getting-started/user-guides` (404) instead of `/docs/user-guides`.

Docusaurus treats links with and without `.md` completely differently:

| Link style | Behavior |
|---|---|
| `[link](./overview)` | Passed through as raw `<a href>` — browser resolves relative to current URL. Breaks with trailing slashes. |
| `[link](./overview.md)` | Resolved by Docusaurus at build time to the correct absolute URL. `.md` stripped from output. Immune to trailing slashes. |

Using `.md` extensions is the [officially recommended approach](https://docusaurus.io/docs/markdown-features/links). Docusaurus's own site, React Native docs, and Tauri docs all use this pattern.

**How did you test it?**

- `bun run build` passes with no broken link errors
- CI link check passes (no relative links without `.md` found)

**Potential risks**

None — Docusaurus strips `.md` from output, so rendered URLs are unchanged.

**Release notes**

N/A — documentation infrastructure fix only.

**Documentation Changes**

Link formatting updated in 19 doc files. No content changes. CI check added to prevent regressions.

Closes #998