### PR TITLE
Revert baseUrl to / for custom domain

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -12,9 +12,9 @@ const config: Config = {
     experimental_faster: true,
   },
 
-  // GitHub Pages deployment config
-  url: 'https://michelangelo-ai.github.io',
-  baseUrl: '/michelangelo/',
+  // Custom domain deployment config
+  url: 'https://michelangelo-ai.org',
+  baseUrl: '/',
   organizationName: 'michelangelo-ai',
   projectName: 'michelangelo',
 


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
Reverts `baseUrl` from `/michelangelo/` back to `/` and updates the site `url` to `https://michelangelo-ai.org` (the custom domain).

This is the counterpart to PR #972, which set `baseUrl` to `/michelangelo/` as a temporary workaround for GitHub Pages project site serving.

**Why?**
Once DNS for `michelangelo-ai.org` is configured and propagated, the site will be served at the root path under the custom domain. The `/michelangelo/` prefix will no longer be needed and will break all site links.

The CNAME file (`michelangelo-ai.org`) was already added in PR #971.

**How did you test it?**
Verified the Docusaurus config matches the expected setup for custom domain deployments per the [Docusaurus docs](https://docusaurus.io/docs/deployment#deploying-to-github-pages).

**Potential risks**
- **Do NOT merge until DNS is fully configured and propagated** — merging early will break the site at `michelangelo-ai.github.io/michelangelo/`
- All internal links will lose the `/michelangelo/` prefix

**Release notes**
Switches site deployment from GitHub Pages project path to custom domain (`michelangelo-ai.org`).

**Documentation Changes**
None