### PR TITLE
Add top-level nav links to StudioBar menu drawer

### DIFF
--- a/javascript/packages/core/components/breadcrumb-bar/__tests__/breadcrumb-bar.test.tsx
+++ b/javascript/packages/core/components/breadcrumb-bar/__tests__/breadcrumb-bar.test.tsx
@@ -381,4 +381,61 @@ describe('BreadcrumbBar — menu drawer', () => {
 
     expect(screen.getByText('Coming soon')).toBeInTheDocument();
   });
+
+  it('renders top-level links with correct hrefs in the drawer', async () => {
+    render(
+      <BreadcrumbBar
+        categories={[
+          {
+            id: 'core-ml',
+            name: 'Core ML',
+            phases: [
+              { id: 'train', name: 'Train & Evaluate', icon: '', state: 'active', entities: [] },
+            ],
+          },
+        ]}
+        topLevelLinks={[
+          { label: 'Settings', path: '/settings' },
+          { label: 'Dashboard', path: '/dashboard' },
+        ]}
+      />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getRouterWrapper({ location: '/my-project' }),
+      ])
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /menu/i }));
+
+    expect(screen.getByRole('link', { name: /settings/i })).toHaveAttribute('href', '/settings');
+    expect(screen.getByRole('link', { name: /dashboard/i })).toHaveAttribute('href', '/dashboard');
+  });
+
+  it('navigates when a top-level link is clicked', async () => {
+    render(
+      <BreadcrumbBar
+        categories={[
+          {
+            id: 'core-ml',
+            name: 'Core ML',
+            phases: [
+              { id: 'train', name: 'Train & Evaluate', icon: '', state: 'active', entities: [] },
+            ],
+          },
+        ]}
+        topLevelLinks={[{ label: 'Settings', path: '/settings' }]}
+      />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getRouterWrapper({ location: '/my-project' }),
+      ])
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /menu/i }));
+    await userEvent.click(screen.getByRole('link', { name: /settings/i }));
+
+    expect(screen.getByText(/Current pathname: \/settings/)).toBeInTheDocument();
+  });
 });

--- a/javascript/packages/core/components/breadcrumb-bar/breadcrumb-bar.tsx
+++ b/javascript/packages/core/components/breadcrumb-bar/breadcrumb-bar.tsx
@@ -8,6 +8,7 @@ import { MenuDrawer } from './menu-drawer';
 import { BreadcrumbContainer, PlainLink } from './styled-components';
 
 import type { CategoryConfig } from '#core/types/common/studio-types';
+import type { NavLink } from './types';
 
 /**
  * A breadcrumb navigation with an integrated hamburger menu drawer.
@@ -18,6 +19,10 @@ import type { CategoryConfig } from '#core/types/common/studio-types';
  * Category and Phase segments are derived from the supplied categories config.
  * The menu drawer shows all phases from all supplied categories.
  *
+ * Top-level links (e.g. to pages outside the project context) can be provided via
+ * `topLevelLinks` and are rendered at the top of the menu drawer, above the
+ * project/phase hierarchy.
+ *
  * @example
  * ```tsx
  * const CATEGORIES: CategoryConfig[] = [
@@ -26,7 +31,13 @@ import type { CategoryConfig } from '#core/types/common/studio-types';
  * <BreadcrumbBar categories={CATEGORIES} />
  * ```
  */
-export function BreadcrumbBar({ categories }: { categories: CategoryConfig[] }) {
+export function BreadcrumbBar({
+  categories,
+  topLevelLinks,
+}: {
+  categories: CategoryConfig[];
+  topLevelLinks?: NavLink[];
+}) {
   const [css, theme] = useStyletron();
   const { projectId, phase, entityId } = useStudioParams('base');
   const isProjectPage = phase === Phase.Project;
@@ -39,7 +50,7 @@ export function BreadcrumbBar({ categories }: { categories: CategoryConfig[] }) 
           <div
             className={css({ display: 'flex', alignItems: 'center', gap: theme.sizing.scale600 })}
           >
-            <MenuDrawer phases={allPhases} projectId={projectId} />
+            <MenuDrawer phases={allPhases} projectId={projectId} topLevelLinks={topLevelLinks} />
             <Breadcrumbs
               overrides={{
                 Root: {

--- a/javascript/packages/core/components/breadcrumb-bar/menu-drawer.tsx
+++ b/javascript/packages/core/components/breadcrumb-bar/menu-drawer.tsx
@@ -6,11 +6,18 @@ import { ANCHOR, Drawer } from 'baseui/drawer';
 import { Icon } from '#core/components/icon/icon';
 import { Tag } from '#core/components/tag/tag';
 import { PhaseEntityList } from './phase-entity-list';
-import { PhaseHeader } from './styled-components';
+import { PhaseHeader, TopLevelNavLink } from './styled-components';
 
 import type { PhaseConfig } from '#core/types/common/studio-types';
+import type { NavLink } from './types';
 
-export function MenuDrawer({ phases, projectId }: { phases: PhaseConfig[]; projectId: string }) {
+interface Props {
+  phases: PhaseConfig[];
+  projectId: string;
+  topLevelLinks?: NavLink[];
+}
+
+export function MenuDrawer({ phases, projectId, topLevelLinks }: Props) {
   const [css, theme] = useStyletron();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
@@ -55,9 +62,30 @@ export function MenuDrawer({ phases, projectId }: { phases: PhaseConfig[]; proje
           },
         }}
       >
-        <div
+        <nav
           className={css({ display: 'flex', flexDirection: 'column', gap: theme.sizing.scale400 })}
         >
+          {topLevelLinks && topLevelLinks.length > 0 && (
+            <div>
+              <ul className={css({ listStyle: 'none', margin: 0, padding: 0 })}>
+                {topLevelLinks.map((link) => (
+                  <li key={link.path}>
+                    <TopLevelNavLink to={link.path} onClick={() => setIsMenuOpen(false)}>
+                      {link.label}
+                      <Icon name="chevronRight" title="" />
+                    </TopLevelNavLink>
+                  </li>
+                ))}
+              </ul>
+              <hr
+                className={css({
+                  borderTop: `1px solid ${theme.colors.borderOpaque}`,
+                  borderBottom: 0,
+                  margin: 0,
+                })}
+              />
+            </div>
+          )}
           <span
             className={css({
               ...theme.typography.HeadingXSmall,
@@ -85,7 +113,7 @@ export function MenuDrawer({ phases, projectId }: { phases: PhaseConfig[]; proje
               />
             </div>
           ))}
-        </div>
+        </nav>
       </Drawer>
     </>
   );

--- a/javascript/packages/core/components/breadcrumb-bar/styled-components.ts
+++ b/javascript/packages/core/components/breadcrumb-bar/styled-components.ts
@@ -8,6 +8,20 @@ export const PlainLink = styled(Link, ({ $theme }) => ({
   ':hover': { textDecoration: 'underline' },
 }));
 
+export const TopLevelNavLink = styled(Link, ({ $theme }) => ({
+  ...$theme.typography.LabelMedium,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  height: $theme.sizing.scale1200,
+  paddingLeft: $theme.sizing.scale600,
+  paddingRight: $theme.sizing.scale700,
+  textDecoration: 'none',
+  // Override the default visited link color
+  ':visited': { color: $theme.colors.contentPrimary },
+  ':hover': { backgroundColor: $theme.colors.menuFillHover },
+}));
+
 export const BreadcrumbContainer = styled('div', ({ $theme }) => ({
   boxShadow: `inset 0px -1px 0px ${$theme.colors.borderOpaque}`,
   paddingTop: $theme.sizing.scale650,

--- a/javascript/packages/core/components/breadcrumb-bar/types.ts
+++ b/javascript/packages/core/components/breadcrumb-bar/types.ts
@@ -1,0 +1,13 @@
+/**
+ * A top-level navigation link rendered in the menu drawer above the project/phase
+ * hierarchy. Intended for destinations that live outside the project context.
+ *
+ * `path` is resolved relative to the root router — the same base path that `"/"` in
+ * `BreadcrumbBar` resolves to.
+ */
+export interface NavLink {
+  /** Display label shown in the drawer */
+  label: string;
+  /** Route path relative to the root router (e.g. "/settings") */
+  path: string;
+}

--- a/javascript/packages/core/router/studio-bar.tsx
+++ b/javascript/packages/core/router/studio-bar.tsx
@@ -2,10 +2,12 @@ import { Outlet } from 'react-router-dom-v5-compat';
 
 import { BreadcrumbBar } from '#core/components/breadcrumb-bar/breadcrumb-bar';
 
+import type { NavLink } from '#core/components/breadcrumb-bar/types';
 import type { CategoryConfig } from '#core/types/common/studio-types';
 
 interface Props {
   categories: CategoryConfig[];
+  topLevelLinks?: NavLink[];
 }
 
 /**
@@ -13,6 +15,9 @@ interface Props {
  *
  * Renders as a pathless Route element so child routes inherit its matched params,
  * allowing useStudioParams (and useParams) to resolve correctly inside BreadcrumbBar.
+ *
+ * Top-level links (e.g. to pages outside the project context) can be provided via
+ * `topLevelLinks` and appear at the top of the menu drawer.
  *
  * @example
  * ```tsx
@@ -23,10 +28,10 @@ interface Props {
  * </Routes>
  * ```
  */
-export function StudioBar({ categories }: Props) {
+export function StudioBar({ categories, topLevelLinks }: Props) {
   return (
     <>
-      <BreadcrumbBar categories={categories} />
+      <BreadcrumbBar categories={categories} topLevelLinks={topLevelLinks} />
       <Outlet />
     </>
   );


### PR DESCRIPTION
Extend StudioBar, BreadcrumbBar, and MenuDrawer to accept an optional topLevelLinks prop — a list of { label, path } pairs rendered at the top of the menu drawer above the project/phase hierarchy.

This makes the drawer configurable for destinations that live outside the project context, which previously had no place in the navigation structure.

The links render as a semantic nav > ul > li structure, separated from the project section by an hr. The drawer wrapper is updated from div to nav to reflect that all drawer content is navigation.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
***Demo only*** -- removed from codebase before committing
<img width="1840" height="1131" alt="Screenshot 2026-03-25 at 13 26 50" src="https://github.com/user-attachments/assets/d6621e61-6884-40a9-b486-5eb54effe240" />


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
