### PR TITLE
Add local ESLint rule to ban barrel exports

### DIFF
--- a/javascript/.claude/skills/file-directory-structure/SKILL.md
+++ b/javascript/.claude/skills/file-directory-structure/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: File and Directory structuring
-description: "Trigger when implementing any new feature, hook, or component — decisions about where to put new files and how to import them must follow these rules. Also trigger when adding imports or spotting barrel exports (index.ts), which are banned in this codebase."
+description: 'Trigger when implementing any new feature, hook, or component — decisions about where to put new files and how to import them must follow these rules. Also trigger when adding imports.'
 user-invocable: false
 ---
 
@@ -8,7 +8,6 @@ user-invocable: false
 
 ## Import Strategy
 
-- **Direct imports only** — no `index.ts` barrel exports; import directly from source files
 - **Co-locate related code** — types, context, hooks, tests, and utils live alongside the component they belong to
 - **Flat over nested** — start flat; introduce a subdirectory only when you have multiple files of the same type (e.g., several hooks → `hooks/`, several utils → `utils/`)
 
@@ -39,6 +38,5 @@ user-invocable: false
 
 ## Anti-Patterns
 
-- ❌ `index.ts` barrel exports — import directly from source
 - ❌ Default exports — use named exports for all modules
 - ❌ Generic filenames without namespace (`action-button.tsx` vs `table-action-button.tsx`)

--- a/javascript/eslint-local-rules/__tests__/no-barrel-exports.test.js
+++ b/javascript/eslint-local-rules/__tests__/no-barrel-exports.test.js
@@ -1,0 +1,70 @@
+import { RuleTester } from 'eslint';
+
+import rule from '../no-barrel-exports.js';
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const tester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+  },
+});
+
+tester.run('no-barrel-exports', rule, {
+  valid: [
+    {
+      name: 'index.ts with no exports',
+      filename: 'index.ts',
+      code: `const x = 1;`,
+    },
+    {
+      name: 'index.ts with local declaration export',
+      filename: 'index.ts',
+      code: `export const Foo = 'bar';`,
+    },
+    {
+      name: 'index.ts with local function export',
+      filename: 'index.ts',
+      code: `export function hello() { return 'world'; }`,
+    },
+    {
+      name: 'non-index file with export-all re-export',
+      filename: 'utils.ts',
+      code: `export * from './foo';`,
+    },
+    {
+      name: 'non-index file with named re-export',
+      filename: 'utils.ts',
+      code: `export { Foo } from './foo';`,
+    },
+  ],
+
+  invalid: [
+    {
+      name: 'index.ts with export-all re-export',
+      filename: 'index.ts',
+      code: `export * from './foo';`,
+      errors: [{ messageId: 'noBarrelExport' }],
+    },
+    {
+      name: 'index.ts with named re-export',
+      filename: 'index.ts',
+      code: `export { Foo } from './foo';`,
+      errors: [{ messageId: 'noBarrelExport' }],
+    },
+    {
+      name: 'index.tsx with export-all re-export',
+      filename: 'index.tsx',
+      code: `export * from './components';`,
+      errors: [{ messageId: 'noBarrelExport' }],
+    },
+    {
+      name: 'index.ts with multiple re-exports',
+      filename: 'index.ts',
+      code: `export * from './foo';\nexport { Bar } from './bar';`,
+      errors: [{ messageId: 'noBarrelExport' }, { messageId: 'noBarrelExport' }],
+    },
+  ],
+});

--- a/javascript/eslint-local-rules/no-barrel-exports.js
+++ b/javascript/eslint-local-rules/no-barrel-exports.js
@@ -1,0 +1,53 @@
+/**
+ * @fileoverview Disallows barrel exports in index files.
+ *
+ * Barrel files (index.ts that re-export from other modules) obscure where code
+ * actually lives, make tree-shaking harder, and create circular-dependency
+ * risks. Import directly from the source file instead.
+ */
+
+/** @type {import('eslint').Rule.RuleModule} */
+const rule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Disallow barrel exports (re-exports) in index files',
+      recommended: true,
+    },
+    messages: {
+      noBarrelExport: [
+        'Barrel exports are not allowed in index files.',
+        'Import directly from the source file instead of re-exporting through an index.',
+        '',
+        '  // Instead of: export { Foo } from "./foo";',
+        '  // Import directly: import { Foo } from "./components/foo";',
+        '',
+      ].join('\n'),
+    },
+    schema: [],
+  },
+
+  create(context) {
+    const filename = context.getPhysicalFilename?.() ?? context.filename;
+    const basename = filename.split('/').pop() ?? '';
+
+    // Only apply to index files
+    if (!/^index\.[tj]sx?$/.test(basename)) {
+      return {};
+    }
+
+    return {
+      ExportAllDeclaration(node) {
+        context.report({ node, messageId: 'noBarrelExport' });
+      },
+
+      ExportNamedDeclaration(node) {
+        if (node.source !== null) {
+          context.report({ node, messageId: 'noBarrelExport' });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/javascript/eslint.config.js
+++ b/javascript/eslint.config.js
@@ -13,15 +13,6 @@ import reactRefresh from 'eslint-plugin-react-refresh';
 import simpleImportSort from 'eslint-plugin-simple-import-sort';
 import globals from 'globals';
 
-// Local rules plugin (single shared reference required by ESLint flat config)
-const localPlugin = {
-  rules: {
-    'no-module-scope-test-setup': noModuleScopeTestSetup,
-    'no-fixture-constants': noFixtureConstants,
-    'no-barrel-exports': noBarrelExports,
-  },
-};
-
 // Shared plugins (used in app and packages/*)
 const sharedPlugins = {
   prettier: prettierPlugin,
@@ -166,7 +157,9 @@ export default [
   // All package tests — enforce test setup conventions
   {
     files: ['packages/**/__tests__/**/*.{ts,tsx}'],
-    plugins: { local: localPlugin },
+    plugins: {
+      local: { rules: { 'no-module-scope-test-setup': noModuleScopeTestSetup } },
+    },
     rules: {
       'local/no-module-scope-test-setup': 'error',
     },
@@ -175,21 +168,26 @@ export default [
   // All package fixtures — enforce factory function exports only
   {
     files: ['packages/**/__fixtures__/**/*.{ts,tsx}'],
-    plugins: { local: localPlugin },
+    plugins: {
+      local: { rules: { 'no-fixture-constants': noFixtureConstants } },
+    },
     rules: {
       'local/no-fixture-constants': 'error',
     },
   },
 
-  // App and core — no barrel exports in index files
+  // App and packages — no barrel exports in index files
   {
-    files: ['packages/core/**/*.{ts,tsx}', 'app/**/*.{ts,tsx}'],
+    files: ['packages/core/**/*.{ts,tsx}', 'packages/rpc/**/*.{ts,tsx}', 'app/**/*.{ts,tsx}'],
     ignores: [
       'packages/core/index.tsx',
-      'packages/core/**/__tests__/**/*.{ts,tsx}',
-      'packages/core/**/__fixtures__/**/*.{ts,tsx}',
+      'packages/rpc/index.ts',
+      'packages/**/__tests__/**/*.{ts,tsx}',
+      'packages/**/__fixtures__/**/*.{ts,tsx}',
     ],
-    plugins: { local: localPlugin },
+    plugins: {
+      local: { rules: { 'no-barrel-exports': noBarrelExports } },
+    },
     rules: {
       'local/no-barrel-exports': 'error',
     },

--- a/javascript/eslint.config.js
+++ b/javascript/eslint.config.js
@@ -1,6 +1,7 @@
 // javascript/eslint.config.js
 import js from '@eslint/js';
 
+import noBarrelExports from './eslint-local-rules/no-barrel-exports.js';
 import noFixtureConstants from './eslint-local-rules/no-fixture-constants.js';
 import noModuleScopeTestSetup from './eslint-local-rules/no-module-scope-test-setup.js';
 import tseslint from 'typescript-eslint';
@@ -11,6 +12,15 @@ import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
 import simpleImportSort from 'eslint-plugin-simple-import-sort';
 import globals from 'globals';
+
+// Local rules plugin (single shared reference required by ESLint flat config)
+const localPlugin = {
+  rules: {
+    'no-module-scope-test-setup': noModuleScopeTestSetup,
+    'no-fixture-constants': noFixtureConstants,
+    'no-barrel-exports': noBarrelExports,
+  },
+};
 
 // Shared plugins (used in app and packages/*)
 const sharedPlugins = {
@@ -156,9 +166,7 @@ export default [
   // All package tests — enforce test setup conventions
   {
     files: ['packages/**/__tests__/**/*.{ts,tsx}'],
-    plugins: {
-      local: { rules: { 'no-module-scope-test-setup': noModuleScopeTestSetup } },
-    },
+    plugins: { local: localPlugin },
     rules: {
       'local/no-module-scope-test-setup': 'error',
     },
@@ -167,11 +175,23 @@ export default [
   // All package fixtures — enforce factory function exports only
   {
     files: ['packages/**/__fixtures__/**/*.{ts,tsx}'],
-    plugins: {
-      local: { rules: { 'no-fixture-constants': noFixtureConstants } },
-    },
+    plugins: { local: localPlugin },
     rules: {
       'local/no-fixture-constants': 'error',
+    },
+  },
+
+  // App and core — no barrel exports in index files
+  {
+    files: ['packages/core/**/*.{ts,tsx}', 'app/**/*.{ts,tsx}'],
+    ignores: [
+      'packages/core/index.tsx',
+      'packages/core/**/__tests__/**/*.{ts,tsx}',
+      'packages/core/**/__fixtures__/**/*.{ts,tsx}',
+    ],
+    plugins: { local: localPlugin },
+    rules: {
+      'local/no-barrel-exports': 'error',
     },
   },
 


### PR DESCRIPTION
Barrel files (index files that re-export from other modules) obscure where code actually lives, hurt tree-shaking, and create circular-dependency risks. The codebase already avoids them by convention — this enforces it automatically for packages/core and app.

The rule flags ExportAllDeclaration and ExportNamedDeclaration with a source in any index.[tj]sx? file. packages/core/index.tsx is excluded since it is the package's public entry point, not an internal barrel.

ESLint flat config requires all config blocks sharing a plugin name to reference the same object — defining the plugin inline per-block causes a "Cannot redefine plugin" error when file patterns overlap. Local rules are consolidated into a single localPlugin object to satisfy this constraint.

**What type of PR is this? (check all applicable)**
- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
