### PR TITLE
Enforce TypeScript import and naming conventions via ESLint

### DIFF
--- a/javascript/.claude/skills/typescript-cookbook/SKILL.md
+++ b/javascript/.claude/skills/typescript-cookbook/SKILL.md
@@ -8,11 +8,4 @@ user-invocable: false
 
 ## Type Design
 
-- **`unknown` over `any`** — better compile-time safety for new types
 - **Create focused types** — map from generated types, include only the properties you need
-- **No type suppression** — unless stress-testing with invalid input
-
-## Naming
-
-- **No T suffix** — use `Props`, `User`, not `PropsT`, `UserT`
-- **PascalCase** for all types and interfaces

--- a/javascript/eslint.config.js
+++ b/javascript/eslint.config.js
@@ -56,9 +56,44 @@ const sharedRules = {
     'error',
     { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
   ],
+  '@typescript-eslint/ban-ts-comment': [
+    'error',
+    {
+      'ts-ignore': true,
+      'ts-expect-error': 'allow-with-description',
+      'ts-nocheck': true,
+      'ts-check': false,
+    },
+  ],
+  '@typescript-eslint/naming-convention': [
+    'error',
+    {
+      selector: 'typeLike',
+      format: ['PascalCase'],
+      custom: { regex: 'T$', match: false },
+    },
+    {
+      selector: 'typeParameter',
+      format: ['PascalCase'],
+    },
+  ],
+  '@typescript-eslint/consistent-type-imports': [
+    'error',
+    {
+      prefer: 'type-imports',
+      fixStyle: 'separate-type-imports',
+      disallowTypeAnnotations: false,
+    },
+  ],
 };
 
 export default [
+  {
+    linterOptions: {
+      reportUnusedDisableDirectives: 'error',
+    },
+  },
+
   {
     ignores: [
       '**/node_modules/**',

--- a/javascript/packages/core/components/box/collapsible-box.tsx
+++ b/javascript/packages/core/components/box/collapsible-box.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from 'react';
-import { getOverrides, mergeOverrides, Theme } from 'baseui';
+import { getOverrides, mergeOverrides } from 'baseui';
 import { Panel } from 'baseui/accordion';
 
 import { DescriptionText } from '#core/components/description-text';
 import { StyledBoxContainer, StyledBoxTitle } from './styled-components';
 
+import type { Theme } from 'baseui';
 import type { CollapsibleBoxProps } from './types';
 
 export const CollapsibleBox: React.FC<CollapsibleBoxProps> = ({

--- a/javascript/packages/core/components/cell/__tests__/hooks.tests.ts
+++ b/javascript/packages/core/components/cell/__tests__/hooks.tests.ts
@@ -1,9 +1,10 @@
 import { renderHook } from '@testing-library/react';
-import { Theme } from 'baseui';
 
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
 import { useCellStyles } from '../hooks';
+
+import type { Theme } from 'baseui';
 
 describe('useCellStyles', () => {
   it('should return an empty object if style is undefined', () => {

--- a/javascript/packages/core/components/cell/components/tooltip/__tests__/tooltip.test.tsx
+++ b/javascript/packages/core/components/cell/components/tooltip/__tests__/tooltip.test.tsx
@@ -1,13 +1,14 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { CellRendererProps } from '#core/components/cell/types';
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
 import { getIconProviderWrapper } from '#core/test/wrappers/get-icon-provider-wrapper';
 import { CellTooltipContentRenderer } from '../cell-tooltip-content-renderer';
 import { cellTooltipHOC } from '../cell-tooltip-hoc';
 import { CellTooltipWrapper } from '../cell-tooltip-wrapper';
+
+import type { CellRendererProps } from '#core/components/cell/types';
 
 describe('Cell Tooltip Components', () => {
   describe('CellTooltipWrapper', () => {

--- a/javascript/packages/core/components/cell/use-get-cell-renderer.tsx
+++ b/javascript/packages/core/components/cell/use-get-cell-renderer.tsx
@@ -2,10 +2,11 @@ import isURL from 'validator/lib/isURL';
 
 import { CELL_RENDERERS } from '#core/components/cell/constants';
 import { TextCell } from '#core/components/cell/renderers/text/text-cell';
-import { CellRenderer, CellRendererProps } from '#core/components/cell/types';
 import { Link } from '#core/components/link/link';
 import { useCellProvider } from '#core/providers/cell-provider/use-cell-provider';
 import { CellType } from './constants';
+
+import type { CellRenderer, CellRendererProps } from '#core/components/cell/types';
 
 /**
  * Returns a function that resolves the appropriate cell renderer based on column

--- a/javascript/packages/core/components/form/fields/date/__tests__/date-field.test.tsx
+++ b/javascript/packages/core/components/form/fields/date/__tests__/date-field.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 
 import { DateField } from '#core/components/form/fields/date/date-field';
-import { DATE_FORMAT } from '#core/components/form/fields/date/types';
+import { DateFormat } from '#core/components/form/fields/date/types';
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
 import { getFormProviderWrapper } from '#core/test/wrappers/get-form-provider-wrapper';
@@ -75,7 +75,7 @@ describe('DateField', () => {
 
   it('displays initial value with ISO format', () => {
     render(
-      <DateField name="date" label="Start Date" dateFormat={DATE_FORMAT.ISO_DATE_STRING} />,
+      <DateField name="date" label="Start Date" dateFormat={DateFormat.ISO_DATE_STRING} />,
       buildWrapper([
         getBaseProviderWrapper(),
         getIconProviderWrapper(),
@@ -89,7 +89,7 @@ describe('DateField', () => {
   it('displays initial value with epoch format', () => {
     // 1705276800 = 2024-01-15T00:00:00.000Z
     render(
-      <DateField name="date" label="Start Date" dateFormat={DATE_FORMAT.EPOCH_SECONDS} />,
+      <DateField name="date" label="Start Date" dateFormat={DateFormat.EPOCH_SECONDS} />,
       buildWrapper([
         getBaseProviderWrapper(),
         getIconProviderWrapper(),

--- a/javascript/packages/core/components/form/fields/date/date-field.tsx
+++ b/javascript/packages/core/components/form/fields/date/date-field.tsx
@@ -4,7 +4,7 @@ import { isArray, isNil } from 'lodash';
 
 import { FormControl } from '#core/components/form/components/form-control';
 import { useField } from '#core/components/form/hooks/use-field';
-import { DATE_FORMAT, type DateFieldProps } from './types';
+import { type DateFieldProps, DateFormat } from './types';
 import { useDateFormatters } from './use-date-formatters';
 
 import type { Theme } from 'baseui';
@@ -22,7 +22,7 @@ export const DateField: React.FC<DateFieldProps> = ({
   description,
   caption,
   noFutureDate,
-  dateFormat = DATE_FORMAT.ISO_DATE_STRING,
+  dateFormat = DateFormat.ISO_DATE_STRING,
 }) => {
   const { format, parse } = useDateFormatters(dateFormat);
 

--- a/javascript/packages/core/components/form/fields/date/types.ts
+++ b/javascript/packages/core/components/form/fields/date/types.ts
@@ -1,8 +1,8 @@
 import type { BaseFieldProps } from '../types';
 
 export interface DateFieldProps extends BaseFieldProps<string, Date | null> {
-  /** @default DATE_FORMAT.ISO_DATE_STRING */
-  dateFormat?: DATE_FORMAT;
+  /** @default DateFormat.ISO_DATE_STRING */
+  dateFormat?: DateFormat;
   /**
    * Restricts selectable dates to today or earlier
    * @default false
@@ -10,7 +10,7 @@ export interface DateFieldProps extends BaseFieldProps<string, Date | null> {
   noFutureDate?: boolean;
 }
 
-export enum DATE_FORMAT {
+export enum DateFormat {
   /**
    * Anticipates date as epoch seconds string. String is artifact of int64 protobuf fields
    * being typed as Strings in TypeScript

--- a/javascript/packages/core/components/form/fields/date/use-date-formatters.ts
+++ b/javascript/packages/core/components/form/fields/date/use-date-formatters.ts
@@ -1,5 +1,5 @@
 import { getDateFromEpochSeconds, getEpochSecondsFromDate } from '#core/utils/time-utils';
-import { DATE_FORMAT } from './types';
+import { DateFormat } from './types';
 
 type UseDateFormattersReturn = {
   format: (value: string) => Date | null;
@@ -19,15 +19,15 @@ type UseDateFormattersReturn = {
  * @param dateFormat - Controls the persisted date format (epoch or ISO).
  */
 export function useDateFormatters(
-  dateFormat: DATE_FORMAT = DATE_FORMAT.ISO_DATE_STRING
+  dateFormat: DateFormat = DateFormat.ISO_DATE_STRING
 ): UseDateFormattersReturn {
   const toDate =
-    dateFormat === DATE_FORMAT.EPOCH_SECONDS
+    dateFormat === DateFormat.EPOCH_SECONDS
       ? (value: string) => (value ? getDateFromEpochSeconds(parseInt(value)) : null)
       : (value: string) => (value ? new Date(value) : null);
 
   const fromDate =
-    dateFormat === DATE_FORMAT.EPOCH_SECONDS
+    dateFormat === DateFormat.EPOCH_SECONDS
       ? (date: Date | null) => (date ? String(getEpochSecondsFromDate(date)) : '')
       : (date: Date | null) => (date ? date.toISOString() : '');
 

--- a/javascript/packages/core/components/form/fields/select/select-field.tsx
+++ b/javascript/packages/core/components/form/fields/select/select-field.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo } from 'react';
-import { filterOptions, OnChangeParams, Select } from 'baseui/select';
+import { filterOptions, Select } from 'baseui/select';
 
 import { FormControl } from '#core/components/form/components/form-control';
 import { useField } from '#core/components/form/hooks/use-field';
@@ -7,6 +7,7 @@ import { buildSelectOverrides } from './build-select-overrides';
 import { formatSelectedValue } from './format-selected-value';
 import { serializeKey } from './serialize-key';
 
+import type { OnChangeParams } from 'baseui/select';
 import type { SelectFieldProps, SelectOption } from './types';
 
 export function SelectField<V = string | number>({

--- a/javascript/packages/core/components/help-tooltip.tsx
+++ b/javascript/packages/core/components/help-tooltip.tsx
@@ -1,10 +1,11 @@
-import { ReactNode } from 'react';
 import { useStyletron } from 'baseui';
 import { ACCESSIBILITY_TYPE, PLACEMENT, StatefulTooltip } from 'baseui/tooltip';
 
 import { Icon } from '#core/components/icon/icon';
 import { IconKind } from '#core/components/icon/types';
 import { Markdown } from '#core/components/markdown/markdown';
+
+import type { ReactNode } from 'react';
 
 /**
  * Displays a help icon with a tooltip containing markdown-formatted help text.

--- a/javascript/packages/core/components/link/__tests__/link.test.tsx
+++ b/javascript/packages/core/components/link/__tests__/link.test.tsx
@@ -1,4 +1,3 @@
-import { ReactNode } from 'react';
 import { render, screen } from '@testing-library/react';
 import { Alert } from 'baseui/icon';
 
@@ -6,6 +5,8 @@ import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getIconProviderWrapper } from '#core/test/wrappers/get-icon-provider-wrapper';
 import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
 import { Link } from '../link';
+
+import type { ReactNode } from 'react';
 
 describe('Link', () => {
   describe('internal link', () => {

--- a/javascript/packages/core/components/row/components/row-item.tsx
+++ b/javascript/packages/core/components/row/components/row-item.tsx
@@ -1,10 +1,10 @@
 import { useStyletron } from 'baseui';
 
 import { DefaultCellRenderer } from '#core/components/cell/renderers/default-cell-renderer';
-import { CellRenderer } from '#core/components/cell/types';
 import { getObjectValue } from '#core/utils/object-utils';
 import { RowLabel } from './row-label';
 
+import type { CellRenderer } from '#core/components/cell/types';
 import type { RowProps } from '#core/components/row/types';
 
 export const RowItem = (props: {

--- a/javascript/packages/core/components/table/__tests__/table.test.tsx
+++ b/javascript/packages/core/components/table/__tests__/table.test.tsx
@@ -16,12 +16,12 @@ import {
   expectTableRows,
 } from '../__fixtures__/table-test-helpers';
 import { FilterMode } from '../components/filter/types';
-import { TableBodyProps } from '../components/table-body/types';
 import { useTableSelectionContext } from '../plugins/selection/table-selection-context';
 import { Table } from '../table';
 
 import type { TableRow } from '#core/components/table/types/row-types';
 import type { Accessor } from '#core/types/common/studio-types';
+import type { TableBodyProps } from '../components/table-body/types';
 import type { TablePaginationProps } from '../components/table-pagination/types';
 
 describe('Table', () => {

--- a/javascript/packages/core/components/table/components/filter/__tests__/use-datetime-filter-factory.test.ts
+++ b/javascript/packages/core/components/table/components/filter/__tests__/use-datetime-filter-factory.test.ts
@@ -1,8 +1,9 @@
 import { renderHook } from '@testing-library/react';
 
 import { createMockRow } from '../__fixtures__/mock-row';
-import { DatetimeFilterValue } from '../datetime/types';
 import { useDatetimeFilterFactory } from '../datetime/use-datetime-filter-factory';
+
+import type { DatetimeFilterValue } from '../datetime/types';
 
 // TODO(#977): — column param is partially unused in filter factories.
 // isFilterInactive, getActiveFilter, and buildTableFilterFn do not depend on

--- a/javascript/packages/core/components/table/components/filter/categorical/get-cell-value-for-column.ts
+++ b/javascript/packages/core/components/table/components/filter/categorical/get-cell-value-for-column.ts
@@ -1,9 +1,9 @@
 import { MULTI_COLUMN_DATA_JOIN_STRING } from '#core/components/table/constants';
-import { ColumnConfig } from '#core/components/table/types/column-types';
 import { resolveColumnForRow } from '#core/components/table/utils/column-resolution-utils';
 import { safeStringify } from '#core/utils/string-utils';
 
 import type { Row } from '@tanstack/react-table';
+import type { ColumnConfig } from '#core/components/table/types/column-types';
 import type { TableData } from '#core/components/table/types/data-types';
 import type { FilterableRow } from '../types';
 

--- a/javascript/packages/core/components/table/components/filter/categorical/use-categorical-filter-factory.ts
+++ b/javascript/packages/core/components/table/components/filter/categorical/use-categorical-filter-factory.ts
@@ -1,9 +1,9 @@
 import { useCellToString } from '#core/components/cell/use-cell-to-string';
-import { ColumnConfig } from '#core/components/table/types/column-types';
-import { TableData } from '#core/components/table/types/data-types';
 import { getCellValueForColumn } from './get-cell-value-for-column';
 
 import type { Row } from '@tanstack/react-table';
+import type { ColumnConfig } from '#core/components/table/types/column-types';
+import type { TableData } from '#core/components/table/types/data-types';
 import type { FilterHook } from '../types';
 
 /**

--- a/javascript/packages/core/components/table/components/filter/datetime/datetime-filter.tsx
+++ b/javascript/packages/core/components/table/components/filter/datetime/datetime-filter.tsx
@@ -1,10 +1,10 @@
 import { DatetimeColumn } from 'baseui/data-table';
 
 import { UNIFIED_API_ORIGIN_DATE } from './constants';
-import { DatetimeFilterValue } from './types';
 import { convertStringParamsToDate } from './utils';
 
 import type { ColumnFilterProps } from '../types';
+import type { DatetimeFilterValue } from './types';
 
 export function DatetimeFilter<TData = unknown>({
   close,

--- a/javascript/packages/core/components/table/components/filter/datetime/use-datetime-filter-factory.ts
+++ b/javascript/packages/core/components/table/components/filter/datetime/use-datetime-filter-factory.ts
@@ -1,11 +1,11 @@
 import { DatetimeColumn } from 'baseui/data-table';
 
-import { ColumnConfig } from '#core/components/table/types/column-types';
-import { TableData } from '#core/components/table/types/data-types';
 import { getDateFromEpochSeconds } from '#core/utils/time-utils';
 import { getCellValueForColumn } from '../categorical/get-cell-value-for-column';
 
 import type { Row } from '@tanstack/react-table';
+import type { ColumnConfig } from '#core/components/table/types/column-types';
+import type { TableData } from '#core/components/table/types/data-types';
 import type { FilterHook } from '../types';
 import type { DatetimeFilterValue } from './types';
 

--- a/javascript/packages/core/components/table/components/table-cell/__tests__/get-responsive-column-width.test.ts
+++ b/javascript/packages/core/components/table/components/table-cell/__tests__/get-responsive-column-width.test.ts
@@ -1,7 +1,7 @@
-import { DeepPartial } from '#core/types/utility-types';
 import { getResponsiveColumnWidth } from '../get-responsive-column-width';
 
 import type { Theme } from 'baseui';
+import type { DeepPartial } from '#core/types/utility-types';
 
 describe('getResponsiveColumnWidth', () => {
   it('creates responsive max width styles for multiple breakpoints', () => {

--- a/javascript/packages/core/components/table/components/table-header/components/table-column-configuration-button/table-column-configuration-button.tsx
+++ b/javascript/packages/core/components/table/components/table-header/components/table-column-configuration-button/table-column-configuration-button.tsx
@@ -1,13 +1,14 @@
 import { useStyletron } from 'baseui';
 import { Button, KIND, SIZE } from 'baseui/button';
 import { Checkbox } from 'baseui/checkbox';
-import { List, SharedStylePropsArg, StyledCloseHandle, StyledLabel } from 'baseui/dnd-list';
+import { List, StyledCloseHandle, StyledLabel } from 'baseui/dnd-list';
 import { PLACEMENT, StatefulPopover } from 'baseui/popover';
 
 import { Icon } from '#core/components/icon/icon';
-import { TableData } from '#core/components/table/types/data-types';
 import { createColumnListChangeHandler } from './utils';
 
+import type { SharedStylePropsArg } from 'baseui/dnd-list';
+import type { TableData } from '#core/components/table/types/data-types';
 import type { ConfigurableColumn, TableColumnConfigurationButtonProps } from './types';
 
 export function TableColumnConfigurationButton<T extends TableData = TableData>({

--- a/javascript/packages/core/components/table/components/table-header/components/table-column-configuration-button/types.ts
+++ b/javascript/packages/core/components/table/components/table-header/components/table-column-configuration-button/types.ts
@@ -1,6 +1,8 @@
-import { ColumnRenderState, VisibilityCapability } from '#core/components/table/types/column-types';
-import { TableData } from '#core/components/table/types/data-types';
-
+import type {
+  ColumnRenderState,
+  VisibilityCapability,
+} from '#core/components/table/types/column-types';
+import type { TableData } from '#core/components/table/types/data-types';
 import type { ControlledTableState } from '#core/components/table/types/table-types';
 
 export interface TableColumnConfigurationButtonProps<T extends TableData = TableData> {

--- a/javascript/packages/core/components/table/components/table-header/components/table-column-configuration-button/utils.ts
+++ b/javascript/packages/core/components/table/components/table-header/components/table-column-configuration-button/utils.ts
@@ -1,7 +1,6 @@
 import { arrayMove } from 'baseui/dnd-list';
 
-import { TableData } from '#core/components/table/types/data-types';
-
+import type { TableData } from '#core/components/table/types/data-types';
 import type {
   ColumnOrderState,
   ControlledTableState,

--- a/javascript/packages/core/components/table/hooks/__tests__/use-column-transformer.test.ts
+++ b/javascript/packages/core/components/table/hooks/__tests__/use-column-transformer.test.ts
@@ -1,4 +1,3 @@
-import { CellContext } from '@tanstack/react-table';
 import { renderHook, screen } from '@testing-library/react';
 import { render } from '@testing-library/react';
 
@@ -7,6 +6,7 @@ import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
 import { useColumnTransformer } from '../use-column-transformer';
 
+import type { CellContext } from '@tanstack/react-table';
 import type { ColumnConfig } from '../../types/column-types';
 
 describe('useColumnTransformer', () => {

--- a/javascript/packages/core/components/table/hooks/use-column-transformer.tsx
+++ b/javascript/packages/core/components/table/hooks/use-column-transformer.tsx
@@ -1,5 +1,4 @@
-import { ReactNode, useMemo } from 'react';
-import { CellContext, SortingFnOption } from '@tanstack/react-table';
+import { useMemo } from 'react';
 
 import { FilterMode } from '../components/filter/types';
 import { useFilterFactory } from '../components/filter/use-filter-factory';
@@ -7,6 +6,8 @@ import { transformRows } from '../components/table-body/row-transformer';
 import { TableCell } from '../components/table-cell/table-cell';
 import { normalizeColumnAccessor } from '../utils/normalize-column-accessor';
 
+import type { CellContext, SortingFnOption } from '@tanstack/react-table';
+import type { ReactNode } from 'react';
 import type { AccessorFn } from '#core/types/common/studio-types';
 import type { TableFilterFn } from '../components/filter/types';
 import type { ColumnConfig } from '../types/column-types';

--- a/javascript/packages/core/components/table/plugins/selection/use-row-selection-state.ts
+++ b/javascript/packages/core/components/table/plugins/selection/use-row-selection-state.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { ControlledTableState, TableState } from '../../types/table-types';
+import type { ControlledTableState, TableState } from '../../types/table-types';
 
 /**
  * Provides controlled/uncontrolled state management for row selection enabling/disabling

--- a/javascript/packages/core/components/table/types/table-types.ts
+++ b/javascript/packages/core/components/table/types/table-types.ts
@@ -1,8 +1,7 @@
-import { EmptyState } from '../components/table-empty-state/types';
-
 import type { ApplicationError } from '#core/types/error-types';
 import type { TableActionBarConfig } from '../components/table-action-bar/types';
 import type { TableBodyProps } from '../components/table-body/types';
+import type { EmptyState } from '../components/table-empty-state/types';
 import type { TableHeaderProps } from '../components/table-header/types';
 import type { PageSizeOption, TablePaginationProps } from '../components/table-pagination/types';
 import type { ColumnConfig } from './column-types';

--- a/javascript/packages/core/components/views/execution/styled-components.tsx
+++ b/javascript/packages/core/components/views/execution/styled-components.tsx
@@ -1,8 +1,9 @@
-import { styled, Theme } from 'baseui';
+import { styled } from 'baseui';
 
 import { CollapsibleBox } from '#core/components/box/collapsible-box';
 import { STATE_TO_STYLE_MAP } from '#core/components/views/execution/constants';
 
+import type { Theme } from 'baseui';
 import type { CollapsibleBoxProps } from '#core/components/box/types';
 import type { TaskState } from '#core/components/views/execution/types';
 

--- a/javascript/packages/core/components/views/execution/utils/__tests__/determine-execution-state.test.ts
+++ b/javascript/packages/core/components/views/execution/utils/__tests__/determine-execution-state.test.ts
@@ -1,7 +1,8 @@
 import { createTask } from '#core/components/views/execution/components/task-details/__fixtures__/task-details-fixtures';
 import { TASK_STATE } from '#core/components/views/execution/constants';
-import { Task } from '#core/components/views/execution/types';
 import { determineExecutionState } from '../determine-execution-state';
+
+import type { Task } from '#core/components/views/execution/types';
 
 describe('determineExecutionState', () => {
   it('should return PENDING for empty task list', () => {

--- a/javascript/packages/core/config/entities/run/shared.ts
+++ b/javascript/packages/core/config/entities/run/shared.ts
@@ -1,5 +1,6 @@
 import { CellType } from '#core/components/cell/constants';
-import { Cell } from '#core/components/cell/types';
+
+import type { Cell } from '#core/components/cell/types';
 
 /**
  * Cell configurations rendered for Pipeline Runs:

--- a/javascript/packages/core/config/entities/trigger/shared.ts
+++ b/javascript/packages/core/config/entities/trigger/shared.ts
@@ -1,5 +1,6 @@
 import { CellType } from '#core/components/cell/constants';
-import { Cell } from '#core/components/cell/types';
+
+import type { Cell } from '#core/components/cell/types';
 
 export const TRIGGER_STATE_CELL_CONFIG: Cell = {
   id: 'status.state',

--- a/javascript/packages/core/config/phases/data.ts
+++ b/javascript/packages/core/config/phases/data.ts
@@ -1,6 +1,7 @@
-import { PhaseConfig } from '#core/types/common/studio-types';
 import { PIPELINE_ENTITY_CONFIG } from '../entities/pipeline/pipeline';
 import { RUN_ENTITY_CONFIG } from '../entities/run/run';
+
+import type { PhaseConfig } from '#core/types/common/studio-types';
 
 export const DATA_PHASE: PhaseConfig = {
   id: 'data',

--- a/javascript/packages/core/config/phases/deploy.ts
+++ b/javascript/packages/core/config/phases/deploy.ts
@@ -1,4 +1,4 @@
-import { PhaseConfig } from '#core/types/common/studio-types';
+import type { PhaseConfig } from '#core/types/common/studio-types';
 
 export const DEPLOY_PHASE: PhaseConfig = {
   id: 'deploy',

--- a/javascript/packages/core/config/phases/train.ts
+++ b/javascript/packages/core/config/phases/train.ts
@@ -2,7 +2,8 @@ import { MODEL_ENTITY_CONFIG } from '#core/config/entities/model/model';
 import { PIPELINE_ENTITY_CONFIG } from '#core/config/entities/pipeline/pipeline';
 import { RUN_ENTITY_CONFIG } from '#core/config/entities/run/run';
 import { TRIGGER_ENTITY_CONFIG } from '#core/config/entities/trigger/trigger';
-import { PhaseConfig } from '#core/types/common/studio-types';
+
+import type { PhaseConfig } from '#core/types/common/studio-types';
 
 export const TRAIN_PHASE: PhaseConfig = {
   id: 'train',

--- a/javascript/packages/core/hooks/routing/use-studio-params/normalize-entity-param.ts
+++ b/javascript/packages/core/hooks/routing/use-studio-params/normalize-entity-param.ts
@@ -1,6 +1,6 @@
 import pluralize from 'pluralize';
 
-import { StudioParamsBase } from '#core/hooks/routing/use-studio-params/types';
+import type { StudioParamsBase } from '#core/hooks/routing/use-studio-params/types';
 
 const ALWAYS_SINGULAR_ENTITIES = [
   'model-performance',

--- a/javascript/packages/core/hooks/routing/use-studio-params/types.ts
+++ b/javascript/packages/core/hooks/routing/use-studio-params/types.ts
@@ -1,5 +1,5 @@
-import { Phase } from '#core/types/common/studio-types';
-import { StudioParamsView } from '#core/types/common/view-types';
+import type { Phase } from '#core/types/common/studio-types';
+import type { StudioParamsView } from '#core/types/common/view-types';
 
 /**
  * Parameters that can be extracted from the route path. These parameters

--- a/javascript/packages/core/index.tsx
+++ b/javascript/packages/core/index.tsx
@@ -181,7 +181,7 @@ export { UrlField } from '#core/components/form/fields/url/url-field';
 export { NumberField } from '#core/components/form/fields/number/number-field';
 export { CheckboxField } from '#core/components/form/fields/checkbox/checkbox-field';
 export { DateField } from '#core/components/form/fields/date/date-field';
-export { DATE_FORMAT } from '#core/components/form/fields/date/types';
+export { DateFormat } from '#core/components/form/fields/date/types';
 
 // Form Layout
 export { FormGroup } from '#core/components/form/layout/form-group/form-group';

--- a/javascript/packages/core/providers/error-provider/use-error-normalizer.ts
+++ b/javascript/packages/core/providers/error-provider/use-error-normalizer.ts
@@ -1,8 +1,9 @@
 import { useContext } from 'react';
 
-import { ErrorNormalizer } from '#core/types/error-types';
 import { ErrorContext } from './error-context';
 import { normalizeUniversalError } from './normalize-universal-error';
+
+import type { ErrorNormalizer } from '#core/types/error-types';
 
 /**
  * Returns a function that normalizes any error to ApplicationError format for

--- a/javascript/packages/core/providers/interpolation-provider/interpolation-provider.tsx
+++ b/javascript/packages/core/providers/interpolation-provider/interpolation-provider.tsx
@@ -1,7 +1,7 @@
-import { InterpolationContextExtensions } from '#core/interpolation/types';
 import { InterpolationContext } from './interpolation-context';
 
 import type { ReactNode } from 'react';
+import type { InterpolationContextExtensions } from '#core/interpolation/types';
 
 /**
  * Provides shared data context for interpolations throughout the component tree.

--- a/javascript/packages/core/providers/user-provider/types.ts
+++ b/javascript/packages/core/providers/user-provider/types.ts
@@ -1,4 +1,4 @@
-import { TimeZone } from '#core/types/time-types';
+import type { TimeZone } from '#core/types/time-types';
 
 export type UserContextType = {
   timeZone: TimeZone;

--- a/javascript/packages/core/router/__tests__/entity-detail-route.test.tsx
+++ b/javascript/packages/core/router/__tests__/entity-detail-route.test.tsx
@@ -4,10 +4,6 @@ import { vi } from 'vitest';
 
 import { CellType } from '#core/components/cell/constants';
 import { buildTableConfigFactory } from '#core/components/views/__fixtures__/table-config-factory';
-import {
-  CustomDetailPageConfig,
-  TableDetailPageConfig,
-} from '#core/components/views/detail-view/types/detail-view-schema-types';
 import { buildExecutionSchemaFactory } from '#core/components/views/execution/__fixtures__/execution-schema-factory';
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getErrorProviderWrapper } from '#core/test/wrappers/get-error-provider-wrapper';
@@ -21,6 +17,11 @@ import {
   buildPhaseConfigFactory,
 } from '../__fixtures__/phase-config-factory';
 import { EntityDetailRoute } from '../entity-detail-route';
+
+import type {
+  CustomDetailPageConfig,
+  TableDetailPageConfig,
+} from '#core/components/views/detail-view/types/detail-view-schema-types';
 
 describe('EntityDetailRoute', () => {
   const buildEntity = buildEntityConfigFactory({

--- a/javascript/packages/core/test/wrappers/build-wrapper.tsx
+++ b/javascript/packages/core/test/wrappers/build-wrapper.tsx
@@ -1,7 +1,6 @@
-import { Wrappers } from './types';
-
 import type { RenderOptions } from '@testing-library/react';
 import type { ReactNode } from 'react';
+import type { Wrappers } from './types';
 
 /**
  * Creates a testing wrapper that composes multiple React Testing Library wrappers.

--- a/javascript/packages/core/test/wrappers/get-base-provider-wrapper.tsx
+++ b/javascript/packages/core/test/wrappers/get-base-provider-wrapper.tsx
@@ -4,7 +4,8 @@ import { Client as Styletron } from 'styletron-engine-atomic';
 import { Provider as StyletronProvider } from 'styletron-react';
 
 import { ThemeProvider } from '#core/themes/provider';
-import { WrapperComponentProps } from './types';
+
+import type { WrapperComponentProps } from './types';
 
 // This is required for some BaseWeb components. If missing, BaseWeb will console.warn
 // something like "`LayersManager` was not found."

--- a/javascript/packages/core/test/wrappers/get-cell-provider-wrapper.tsx
+++ b/javascript/packages/core/test/wrappers/get-cell-provider-wrapper.tsx
@@ -1,6 +1,7 @@
-import { CellRenderer } from '#core/components/cell/types';
 import { CellProvider } from '#core/providers/cell-provider/cell-provider';
-import { WrapperComponentProps } from './types';
+
+import type { CellRenderer } from '#core/components/cell/types';
+import type { WrapperComponentProps } from './types';
 
 export function getCellProviderWrapper({
   renderers = {},

--- a/javascript/packages/core/test/wrappers/get-error-provider-wrapper.tsx
+++ b/javascript/packages/core/test/wrappers/get-error-provider-wrapper.tsx
@@ -1,7 +1,8 @@
 import { ErrorProvider } from '#core/providers/error-provider/error-provider';
-import { ErrorContextValue } from '#core/providers/error-provider/types';
 import { ApplicationError } from '#core/types/error-types';
-import { WrapperComponentProps } from './types';
+
+import type { ErrorContextValue } from '#core/providers/error-provider/types';
+import type { WrapperComponentProps } from './types';
 
 /**
  * Creates a React wrapper for testing components that use error handling features.

--- a/javascript/packages/core/test/wrappers/get-icon-provider-wrapper.tsx
+++ b/javascript/packages/core/test/wrappers/get-icon-provider-wrapper.tsx
@@ -2,7 +2,8 @@ import { Check } from 'baseui/icon';
 import { CircleExclamationPointFilled } from 'baseui/icon';
 
 import { IconProvider } from '#core/providers/icon-provider/icon-provider';
-import { WrapperComponentProps } from './types';
+
+import type { WrapperComponentProps } from './types';
 
 export function getIconProviderWrapper({
   icons = {

--- a/javascript/packages/core/test/wrappers/get-router-wrapper.tsx
+++ b/javascript/packages/core/test/wrappers/get-router-wrapper.tsx
@@ -1,6 +1,6 @@
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom-v5-compat';
 
-import { WrapperComponentProps } from './types';
+import type { WrapperComponentProps } from './types';
 
 /**
  * Creates a React Router wrapper for testing components that use routing features.

--- a/javascript/packages/core/test/wrappers/get-service-provider-wrapper.tsx
+++ b/javascript/packages/core/test/wrappers/get-service-provider-wrapper.tsx
@@ -3,8 +3,9 @@ import { isEqual } from 'lodash';
 import { vi } from 'vitest';
 
 import { ServiceProvider } from '#core/providers/service-provider/service-provider';
-import { ServiceContextType } from '#core/providers/service-provider/types';
-import { WrapperComponentProps } from './types';
+
+import type { ServiceContextType } from '#core/providers/service-provider/types';
+import type { WrapperComponentProps } from './types';
 
 /**
  * Creates a React wrapper for testing components that use service features.

--- a/javascript/packages/core/test/wrappers/get-user-provider-wrapper.tsx
+++ b/javascript/packages/core/test/wrappers/get-user-provider-wrapper.tsx
@@ -1,7 +1,8 @@
 import { type UserContextType } from '#core/providers/user-provider/types';
 import { UserProvider } from '#core/providers/user-provider/user-provider';
 import { TimeZone } from '#core/types/time-types';
-import { WrapperComponentProps } from './types';
+
+import type { WrapperComponentProps } from './types';
 
 /**
  * Creates a React wrapper for testing components that use service features.

--- a/javascript/packages/rpc/handlers.ts
+++ b/javascript/packages/rpc/handlers.ts
@@ -1,5 +1,6 @@
 import { getServices } from './services';
-import { ExtractUnaryRpc } from './types';
+
+import type { ExtractUnaryRpc } from './types';
 
 let handlersPromise: Promise<Awaited<ReturnType<typeof createHandlers>>> | null = null;
 

--- a/javascript/packages/rpc/request.ts
+++ b/javascript/packages/rpc/request.ts
@@ -1,5 +1,6 @@
 import { getRpcHandlers } from './handlers';
-import { OmitTypeName, RpcHandlerType } from './types';
+
+import type { OmitTypeName, RpcHandlerType } from './types';
 
 /**
  * Makes a gRPC-web request to the Michelangelo API.

--- a/javascript/packages/rpc/services.ts
+++ b/javascript/packages/rpc/services.ts
@@ -1,4 +1,4 @@
-import { createClient, Interceptor } from '@connectrpc/connect';
+import { createClient } from '@connectrpc/connect';
 import { createGrpcWebTransport } from '@connectrpc/connect-web';
 
 import { ModelService } from './gen/michelangelo/api/v2/model_svc_pb';
@@ -7,6 +7,8 @@ import { PipelineService } from './gen/michelangelo/api/v2/pipeline_svc_pb';
 import { ProjectService } from './gen/michelangelo/api/v2/project_svc_pb';
 import { TriggerRunService } from './gen/michelangelo/api/v2/trigger_run_svc_pb';
 import { getRuntimeConfig } from './runtime-config';
+
+import type { Interceptor } from '@connectrpc/connect';
 
 // This interceptor is used to set the headers for the RPC request to
 // be compatible with the Michelangelo API yarpc server.

--- a/javascript/packages/rpc/transformations/common.ts
+++ b/javascript/packages/rpc/transformations/common.ts
@@ -1,4 +1,4 @@
-import { ExtractEntityFromResponse, HasTypeName } from './types';
+import type { ExtractEntityFromResponse, HasTypeName } from './types';
 
 /**
  * Extracts the main entity from a response

--- a/javascript/packages/rpc/transformations/guards.ts
+++ b/javascript/packages/rpc/transformations/guards.ts
@@ -1,4 +1,4 @@
-import { HasTypeName } from './types';
+import type { HasTypeName } from './types';
 
 /**
  * Type predicate to check if an object has a $typeName property

--- a/javascript/packages/rpc/types.ts
+++ b/javascript/packages/rpc/types.ts
@@ -1,6 +1,5 @@
-import { Message } from '@bufbuild/protobuf';
-
-import { getRpcHandlers } from './handlers';
+import type { Message } from '@bufbuild/protobuf';
+import type { getRpcHandlers } from './handlers';
 
 /**
  * @see {@link getRpcHandlers}


### PR DESCRIPTION
The codebase already followed these patterns informally but had no lint enforcement, allowing drift. Type-only imports were written inconsistently as value imports, @ts-ignore was used without requiring justification, and type naming had no automated PascalCase check.

Add four rules to codify existing conventions:
- consistent-type-imports: separate `import type` statements
- ban-ts-comment: disallow @ts-ignore, require description on @ts-expect-error
- naming-convention: PascalCase for types/interfaces, no T-suffix on type names (with separate typeParameter selector to allow single-letter generics like <T>)
- reportUnusedDisableDirectives: flag stale eslint-disable comments

Rename DATE_FORMAT enum to DateFormat — the only naming-convention violation. Autofix ~50 files for consistent-type-imports.

**What type of PR is this? (check all applicable)**
- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
Consumers of the library leveraging DATE_FORMAT will need to update to use DateFormat instead.

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
