### PR TITLE
Mactl add proxy support

### DIFF
--- a/python/michelangelo/cli/mactl/mactl.py
+++ b/python/michelangelo/cli/mactl/mactl.py
@@ -387,8 +387,24 @@ def main(channel: Channel):
     """
 
 
+def _is_service_name(address: str) -> bool:
+    """Check if address is a service name (not host:port)."""
+    return ":" not in address and "." not in address
+
+
 def run():
     """Entry point for mactl."""
+    proxy_module_path = _CONFIG["plugin"].get("proxy", "")
+
+    if _is_service_name(ADDRESS) and proxy_module_path:
+        import importlib
+        proxy_mod = importlib.import_module(proxy_module_path)
+        CLIProxy = getattr(proxy_mod, "CLIProxy")
+        with CLIProxy() as proxy:
+            local_address = proxy.create_tunnel(ADDRESS)
+            with insecure_channel(local_address) as channel:
+                return main(channel)
+
     if USE_TLS:
         _LOG.info(
             "Using TLS (forced via MACTL_USE_TLS=%r) to connect to %r",
@@ -400,11 +416,10 @@ def run():
             return main(channel)
 
     _LOG.info(
-        "Using TLS (forced via MACTL_USE_TLS=%r) to connect to %r",
+        "Using insecure connection (MACTL_USE_TLS=%r) to connect to %r",
         USE_TLS,
         ADDRESS,
     )
-    # Use secure TLS connection
     # Use insecure connection for local development
     with insecure_channel(ADDRESS) as channel:
         return main(channel)

--- a/python/michelangelo/cli/mactl/mactl.py
+++ b/python/michelangelo/cli/mactl/mactl.py
@@ -399,8 +399,8 @@ def run():
     if _is_service_name(ADDRESS) and proxy_module_path:
         import importlib
         proxy_mod = importlib.import_module(proxy_module_path)
-        CLIProxy = proxy_mod.CLIProxy
-        with CLIProxy() as proxy:
+        cli_proxy_class = proxy_mod.CLIProxy
+        with cli_proxy_class() as proxy:
             local_address = proxy.create_tunnel(ADDRESS)
             with insecure_channel(local_address) as channel:
                 return main(channel)

--- a/python/michelangelo/cli/mactl/mactl.py
+++ b/python/michelangelo/cli/mactl/mactl.py
@@ -398,6 +398,7 @@ def run():
 
     if _is_service_name(ADDRESS) and proxy_module_path:
         import importlib
+
         proxy_mod = importlib.import_module(proxy_module_path)
         cli_proxy_class = proxy_mod.CLIProxy
         with cli_proxy_class() as proxy:

--- a/python/michelangelo/cli/mactl/mactl.py
+++ b/python/michelangelo/cli/mactl/mactl.py
@@ -399,7 +399,7 @@ def run():
     if _is_service_name(ADDRESS) and proxy_module_path:
         import importlib
         proxy_mod = importlib.import_module(proxy_module_path)
-        CLIProxy = getattr(proxy_mod, "CLIProxy")
+        CLIProxy = proxy_mod.CLIProxy
         with CLIProxy() as proxy:
             local_address = proxy.create_tunnel(ADDRESS)
             with insecure_channel(local_address) as channel:

--- a/python/michelangelo/cli/mactl/mactl.py
+++ b/python/michelangelo/cli/mactl/mactl.py
@@ -3,6 +3,7 @@
 A command line interface to interact with the Michelangelo API server via gRPC.
 """
 
+import importlib
 import logging
 import re
 import sys
@@ -397,8 +398,6 @@ def run():
     proxy_module_path = _CONFIG["plugin"].get("proxy", "")
 
     if _is_service_name(ADDRESS) and proxy_module_path:
-        import importlib
-
         proxy_mod = importlib.import_module(proxy_module_path)
         cli_proxy_class = proxy_mod.CLIProxy
         with cli_proxy_class() as proxy:

--- a/python/michelangelo/cli/mactl/mactl_test.py
+++ b/python/michelangelo/cli/mactl/mactl_test.py
@@ -14,6 +14,7 @@ from michelangelo.cli.mactl.crd import CRD
 from michelangelo.cli.mactl.mactl import (
     ADDRESS,
     DEFAULT_DIR_PLUGINS,
+    _is_service_name,
     check_crd,
     create_serivce_classes,
     discover_crds,
@@ -787,3 +788,115 @@ class MainFunctionTest(TestCase):
 
         # Verify Phase 5: Execute action
         mock_crd.create.assert_called_once_with(name="test")
+
+
+class ProxySupportTest(TestCase):
+    """Tests for proxy support functionality."""
+
+    def test_is_service_name_with_service_name(self):
+        """Test _is_service_name returns True for service names."""
+        self.assertTrue(_is_service_name("my-service"))
+        self.assertTrue(_is_service_name("apiserver"))
+        self.assertTrue(_is_service_name("backend-api"))
+
+    def test_is_service_name_with_host_port(self):
+        """Test _is_service_name returns False for host:port addresses."""
+        self.assertFalse(_is_service_name("localhost:8080"))
+        self.assertFalse(_is_service_name("api.example.com:443"))
+        self.assertFalse(_is_service_name("127.0.0.1:5000"))
+
+    def test_is_service_name_with_domain(self):
+        """Test _is_service_name returns False for domain names."""
+        self.assertFalse(_is_service_name("api.example.com"))
+        self.assertFalse(_is_service_name("sub.domain.example.org"))
+
+    @patch("michelangelo.cli.mactl.mactl.main")
+    @patch("michelangelo.cli.mactl.mactl.insecure_channel")
+    @patch("michelangelo.cli.mactl.mactl._CONFIG")
+    def test_run_with_proxy_for_service_name(
+        self, mock_config, mock_insecure_channel, mock_main
+    ):
+        """Test run() uses proxy when address is service name and proxy is configured."""
+        mock_proxy_instance = MagicMock()
+        mock_proxy_instance.create_tunnel.return_value = "localhost:12345"
+        mock_proxy_instance.__enter__ = Mock(return_value=mock_proxy_instance)
+        mock_proxy_instance.__exit__ = Mock(return_value=None)
+
+        mock_proxy_class = MagicMock(return_value=mock_proxy_instance)
+
+        mock_proxy_module = MagicMock()
+        mock_proxy_module.CLIProxy = mock_proxy_class
+
+        mock_channel = MagicMock()
+        mock_insecure_channel.return_value.__enter__ = Mock(return_value=mock_channel)
+        mock_insecure_channel.return_value.__exit__ = Mock(return_value=None)
+
+        mock_config.__getitem__.return_value = {
+            "proxy": "my.proxy.module",
+        }
+
+        with (
+            patch("michelangelo.cli.mactl.mactl.ADDRESS", "my-service"),
+            patch("michelangelo.cli.mactl.mactl.USE_TLS", False),
+            patch("importlib.import_module", return_value=mock_proxy_module),
+        ):
+            from michelangelo.cli.mactl.mactl import run
+
+            run()
+
+        mock_proxy_instance.create_tunnel.assert_called_once_with("my-service")
+        mock_insecure_channel.assert_called_once_with("localhost:12345")
+        mock_main.assert_called_once_with(mock_channel)
+
+    @patch("michelangelo.cli.mactl.mactl.main")
+    @patch("michelangelo.cli.mactl.mactl.insecure_channel")
+    @patch("michelangelo.cli.mactl.mactl._CONFIG")
+    def test_run_without_proxy_for_host_port(
+        self, mock_config, mock_insecure_channel, mock_main
+    ):
+        """Test run() skips proxy when address is host:port."""
+        mock_channel = MagicMock()
+        mock_insecure_channel.return_value.__enter__ = Mock(return_value=mock_channel)
+        mock_insecure_channel.return_value.__exit__ = Mock(return_value=None)
+
+        mock_config.__getitem__.return_value = {
+            "proxy": "my.proxy.module",
+        }
+
+        with (
+            patch("michelangelo.cli.mactl.mactl.ADDRESS", "localhost:8080"),
+            patch("michelangelo.cli.mactl.mactl.USE_TLS", False),
+        ):
+            from michelangelo.cli.mactl.mactl import run
+
+            run()
+
+        mock_insecure_channel.assert_called_once_with("localhost:8080")
+        mock_main.assert_called_once_with(mock_channel)
+
+    @patch("michelangelo.cli.mactl.mactl.main")
+    @patch("michelangelo.cli.mactl.mactl.insecure_channel")
+    @patch("michelangelo.cli.mactl.mactl._CONFIG")
+    def test_run_without_proxy_when_not_configured(
+        self, mock_config, mock_insecure_channel, mock_main
+    ):
+        """Test run() skips proxy when proxy module is not configured."""
+        mock_channel = MagicMock()
+        mock_insecure_channel.return_value.__enter__ = Mock(return_value=mock_channel)
+        mock_insecure_channel.return_value.__exit__ = Mock(return_value=None)
+
+        mock_config.__getitem__.return_value = {
+            "proxy": "",
+        }
+
+        with (
+            patch("michelangelo.cli.mactl.mactl.ADDRESS", "my-service"),
+            patch("michelangelo.cli.mactl.mactl.USE_TLS", False),
+        ):
+            from michelangelo.cli.mactl.mactl import run
+
+            run()
+
+        mock_insecure_channel.assert_called_once_with("my-service")
+        mock_main.assert_called_once_with(mock_channel)
+

--- a/python/michelangelo/cli/mactl/mactl_test.py
+++ b/python/michelangelo/cli/mactl/mactl_test.py
@@ -816,9 +816,7 @@ class ProxySupportTest(TestCase):
     def test_run_with_proxy_for_service_name(
         self, mock_config, mock_insecure_channel, mock_main
     ):
-        """Test run() uses proxy when address is service name and proxy is configured.
-
-        """
+        """Test proxy usage when address is service name and proxy configured."""
         mock_proxy_instance = MagicMock()
         mock_proxy_instance.create_tunnel.return_value = "localhost:12345"
         mock_proxy_instance.__enter__ = Mock(return_value=mock_proxy_instance)

--- a/python/michelangelo/cli/mactl/mactl_test.py
+++ b/python/michelangelo/cli/mactl/mactl_test.py
@@ -816,8 +816,8 @@ class ProxySupportTest(TestCase):
     def test_run_with_proxy_for_service_name(
         self, mock_config, mock_insecure_channel, mock_main
     ):
-        """Test run() uses proxy when address is service name and proxy is
-        configured.
+        """Test run() uses proxy when address is service name and proxy is configured.
+
         """
         mock_proxy_instance = MagicMock()
         mock_proxy_instance.create_tunnel.return_value = "localhost:12345"
@@ -901,4 +901,3 @@ class ProxySupportTest(TestCase):
 
         mock_insecure_channel.assert_called_once_with("my-service")
         mock_main.assert_called_once_with(mock_channel)
-

--- a/python/michelangelo/cli/mactl/mactl_test.py
+++ b/python/michelangelo/cli/mactl/mactl_test.py
@@ -816,7 +816,9 @@ class ProxySupportTest(TestCase):
     def test_run_with_proxy_for_service_name(
         self, mock_config, mock_insecure_channel, mock_main
     ):
-        """Test run() uses proxy when address is service name and proxy is configured."""
+        """Test run() uses proxy when address is service name and proxy is
+        configured.
+        """
         mock_proxy_instance = MagicMock()
         mock_proxy_instance.create_tunnel.return_value = "localhost:12345"
         mock_proxy_instance.__enter__ = Mock(return_value=mock_proxy_instance)


### PR DESCRIPTION
  **What type of PR is this? (check all applicable)**
  - [ ] Refactor
  - [x] Feature
  - [ ] Bug Fix
  - [ ] Optimization
  - [ ] Documentation Update

  **What changed?**
  Added proxy support to mactl CLI tool through a pluggable proxy module system
  configured via `plugin.proxy` in the config file.

  **Why?**
  Enable mactl to work in corporate/restricted network environments where traffic must go
   through a proxy server. This is essential for users who cannot directly connect to
  Michelangelo services.

  **How did you test it?**
  - Added unit tests for service name detection (`_is_service_name`)
  - Added integration tests for proxy module loading and tunnel creation
  - Tested proxy behavior with service names vs host:port addresses
  - Verified backward compatibility when proxy is not configured

  **Potential risks**
  - Requires users to implement a compatible CLIProxy class

  **Release notes**
  Added proxy support via pluggable proxy modules. Configure `plugin.proxy` in config
  file to specify a module path that implements a `CLIProxy` class with `create_tunnel()`
   method.

  **Documentation Changes**
  None - internal feature for advanced users who need proxy support