### PR TITLE
Fix import layering violations in packages/core

### DIFF
--- a/javascript/packages/core/components/cell/renderers/date/__tests__/date-cell.tests.tsx
+++ b/javascript/packages/core/components/cell/renderers/date/__tests__/date-cell.tests.tsx
@@ -1,10 +1,10 @@
 import { render, screen } from '@testing-library/react';
 
-import { TimeZone } from '#core/types/time-types';
 import { mockTimezone } from '#core/test/utils/mock-timezone';
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
 import { getUserProviderWrapper } from '#core/test/wrappers/get-user-provider-wrapper';
+import { TimeZone } from '#core/types/time-types';
 import { DateCell } from '../date-cell';
 
 describe('DateCell', () => {
@@ -34,10 +34,7 @@ describe('DateCell', () => {
         record={{ spec: { date: '1720656639' } }}
         value="1720656639"
       />,
-      buildWrapper([
-        getBaseProviderWrapper(),
-        getUserProviderWrapper({ timeZone: TimeZone.Local }),
-      ])
+      buildWrapper([getBaseProviderWrapper(), getUserProviderWrapper({ timeZone: TimeZone.Local })])
     );
 
     expect(screen.getByText('2024/07/11 02:10:39 (GMT+2)')).toBeInTheDocument();

--- a/javascript/packages/core/components/cell/renderers/date/__tests__/date-cell.tests.tsx
+++ b/javascript/packages/core/components/cell/renderers/date/__tests__/date-cell.tests.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 
-import { UserTimeZone } from '#core/providers/user-provider/types';
+import { TimeZone } from '#core/types/time-types';
 import { mockTimezone } from '#core/test/utils/mock-timezone';
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
@@ -36,7 +36,7 @@ describe('DateCell', () => {
       />,
       buildWrapper([
         getBaseProviderWrapper(),
-        getUserProviderWrapper({ timeZone: UserTimeZone.Local }),
+        getUserProviderWrapper({ timeZone: TimeZone.Local }),
       ])
     );
 

--- a/javascript/packages/core/components/date-time/__tests__/date-time.tests.tsx
+++ b/javascript/packages/core/components/date-time/__tests__/date-time.tests.tsx
@@ -1,10 +1,10 @@
 import { render, screen } from '@testing-library/react';
 
-import { TimeZone } from '#core/types/time-types';
 import { mockTimezone } from '#core/test/utils/mock-timezone';
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
 import { getUserProviderWrapper } from '#core/test/wrappers/get-user-provider-wrapper';
+import { TimeZone } from '#core/types/time-types';
 import { DateTime } from '../date-time';
 
 describe('DateTime', () => {
@@ -26,10 +26,7 @@ describe('DateTime', () => {
   test('renders formatted date in local timezone', () => {
     render(
       <DateTime timestamp="1720656639" />,
-      buildWrapper([
-        getBaseProviderWrapper(),
-        getUserProviderWrapper({ timeZone: TimeZone.Local }),
-      ])
+      buildWrapper([getBaseProviderWrapper(), getUserProviderWrapper({ timeZone: TimeZone.Local })])
     );
 
     expect(screen.getByText('2024/07/11 02:10:39 (GMT+2)')).toBeInTheDocument();
@@ -38,10 +35,7 @@ describe('DateTime', () => {
   test('renders formatted date in UTC timezone', () => {
     render(
       <DateTime timestamp="1720656639" />,
-      buildWrapper([
-        getBaseProviderWrapper(),
-        getUserProviderWrapper({ timeZone: TimeZone.UTC }),
-      ])
+      buildWrapper([getBaseProviderWrapper(), getUserProviderWrapper({ timeZone: TimeZone.UTC })])
     );
 
     expect(screen.getByText('2024/07/11 00:10:39 (UTC)')).toBeInTheDocument();
@@ -50,10 +44,7 @@ describe('DateTime', () => {
   test('renders formatted date for numeric timestamp', () => {
     render(
       <DateTime timestamp={1720656639} />,
-      buildWrapper([
-        getBaseProviderWrapper(),
-        getUserProviderWrapper({ timeZone: TimeZone.Local }),
-      ])
+      buildWrapper([getBaseProviderWrapper(), getUserProviderWrapper({ timeZone: TimeZone.Local })])
     );
 
     expect(screen.getByText('2024/07/11 02:10:39 (GMT+2)')).toBeInTheDocument();

--- a/javascript/packages/core/components/date-time/__tests__/date-time.tests.tsx
+++ b/javascript/packages/core/components/date-time/__tests__/date-time.tests.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 
-import { UserTimeZone } from '#core/providers/user-provider/types';
+import { TimeZone } from '#core/types/time-types';
 import { mockTimezone } from '#core/test/utils/mock-timezone';
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
@@ -28,7 +28,7 @@ describe('DateTime', () => {
       <DateTime timestamp="1720656639" />,
       buildWrapper([
         getBaseProviderWrapper(),
-        getUserProviderWrapper({ timeZone: UserTimeZone.Local }),
+        getUserProviderWrapper({ timeZone: TimeZone.Local }),
       ])
     );
 
@@ -40,7 +40,7 @@ describe('DateTime', () => {
       <DateTime timestamp="1720656639" />,
       buildWrapper([
         getBaseProviderWrapper(),
-        getUserProviderWrapper({ timeZone: UserTimeZone.UTC }),
+        getUserProviderWrapper({ timeZone: TimeZone.UTC }),
       ])
     );
 
@@ -52,7 +52,7 @@ describe('DateTime', () => {
       <DateTime timestamp={1720656639} />,
       buildWrapper([
         getBaseProviderWrapper(),
-        getUserProviderWrapper({ timeZone: UserTimeZone.Local }),
+        getUserProviderWrapper({ timeZone: TimeZone.Local }),
       ])
     );
 

--- a/javascript/packages/core/hooks/routing/use-studio-params/constants.ts
+++ b/javascript/packages/core/hooks/routing/use-studio-params/constants.ts
@@ -1,4 +1,5 @@
-import type { ParamsTransformer, StudioParamsView } from './types';
+import type { StudioParamsView } from '#core/types/common/view-types';
+import type { ParamsTransformer } from './types';
 
 /**
  * A mapping of view types to their corresponding parameter transformers.

--- a/javascript/packages/core/hooks/routing/use-studio-params/types.ts
+++ b/javascript/packages/core/hooks/routing/use-studio-params/types.ts
@@ -1,5 +1,5 @@
 import { Phase } from '#core/types/common/studio-types';
-import { View } from '#core/types/common/view-types';
+import { StudioParamsView } from '#core/types/common/view-types';
 
 /**
  * Parameters that can be extracted from the route path. These parameters
@@ -87,22 +87,6 @@ export type StudioParamsFormDetail = Pick<
   Pick<StudioParamsDetail, Extract<keyof StudioParamsForm, keyof StudioParamsDetail>> &
   Partial<Omit<StudioParamsForm, Extract<keyof StudioParamsForm, keyof StudioParamsDetail>>> &
   Partial<Omit<StudioParamsDetail, Extract<keyof StudioParamsForm, keyof StudioParamsDetail>>>;
-
-/**
- * Union type of all possible view types in the studio.
- * Extends ViewTypeT with additional special view types.
- * @see ViewTypeT for the base view types ('form' | 'detail' | 'list')
- *
- * 'base' is a special view type that is used to represent the base parameters
- * for all views registered to the Schema Driven UI router.
- *
- * 'form-detail' is a special view type that is used to represent the parameters
- * for combined form-detail views.
- *
- * 'unregistered' is a special view type that is used to represent views that are not registered
- * to the Schema Driven UI router but are still part of the studio application.
- */
-export type StudioParamsView = View | 'base' | 'form-detail' | 'unregistered';
 
 /**
  * Maps a view type to its corresponding parameter type.

--- a/javascript/packages/core/hooks/routing/use-studio-params/use-studio-params.ts
+++ b/javascript/packages/core/hooks/routing/use-studio-params/use-studio-params.ts
@@ -6,7 +6,8 @@ import { Phase } from '#core/types/common/studio-types';
 import { VIEW_TYPE_TO_PARAMS } from './constants';
 import { normalizeEntityParam } from './normalize-entity-param';
 
-import type { QueryParams, RouteParams, StudioParamsView, ViewTypeToParamType } from './types';
+import type { StudioParamsView } from '#core/types/common/view-types';
+import type { QueryParams, RouteParams, ViewTypeToParamType } from './types';
 
 /**
  * Hook to get and transform studio parameters based on the view type.

--- a/javascript/packages/core/interpolation/base.ts
+++ b/javascript/packages/core/interpolation/base.ts
@@ -1,4 +1,4 @@
-import type { StudioParamsView } from '#core/hooks/routing/use-studio-params/types';
+import type { StudioParamsView } from '#core/types/common/view-types';
 import type { InterpolationContext } from './types';
 
 /**

--- a/javascript/packages/core/interpolation/function-interpolation.ts
+++ b/javascript/packages/core/interpolation/function-interpolation.ts
@@ -1,6 +1,6 @@
 import { Interpolation } from './base';
 
-import type { StudioParamsView } from '#core/hooks/routing/use-studio-params/types';
+import type { StudioParamsView } from '#core/types/common/view-types';
 import type { InterpolationContext } from './types';
 
 /**

--- a/javascript/packages/core/interpolation/interpolate.ts
+++ b/javascript/packages/core/interpolation/interpolate.ts
@@ -1,7 +1,7 @@
 import { FunctionInterpolation } from './function-interpolation';
 import { StringInterpolation } from './string-interpolation';
 
-import type { StudioParamsView } from '#core/hooks/routing/use-studio-params/types';
+import type { StudioParamsView } from '#core/types/common/view-types';
 import type { InterpolationContext } from './types';
 
 /**

--- a/javascript/packages/core/interpolation/string-interpolation.ts
+++ b/javascript/packages/core/interpolation/string-interpolation.ts
@@ -3,7 +3,7 @@ import { get, has } from 'lodash';
 import { Interpolation } from './base';
 import { INTERPOLATION_PATTERN, SYNTAX_CHARS } from './constants';
 
-import type { StudioParamsView } from '#core/hooks/routing/use-studio-params/types';
+import type { StudioParamsView } from '#core/types/common/view-types';
 import type { InterpolationContext } from './types';
 
 /**

--- a/javascript/packages/core/interpolation/types.ts
+++ b/javascript/packages/core/interpolation/types.ts
@@ -1,6 +1,6 @@
 import type { ViewTypeToParamType } from '#core/hooks/routing/use-studio-params/types';
-import type { StudioParamsView } from '#core/types/common/view-types';
 import type { RepeatedLayoutState } from '#core/providers/repeated-layout-provider/types';
+import type { StudioParamsView } from '#core/types/common/view-types';
 import type { FunctionInterpolation } from './function-interpolation';
 import type { StringInterpolation } from './string-interpolation';
 

--- a/javascript/packages/core/interpolation/types.ts
+++ b/javascript/packages/core/interpolation/types.ts
@@ -1,7 +1,5 @@
-import type {
-  StudioParamsView,
-  ViewTypeToParamType,
-} from '#core/hooks/routing/use-studio-params/types';
+import type { ViewTypeToParamType } from '#core/hooks/routing/use-studio-params/types';
+import type { StudioParamsView } from '#core/types/common/view-types';
 import type { RepeatedLayoutState } from '#core/providers/repeated-layout-provider/types';
 import type { FunctionInterpolation } from './function-interpolation';
 import type { StringInterpolation } from './string-interpolation';

--- a/javascript/packages/core/providers/user-provider/types.ts
+++ b/javascript/packages/core/providers/user-provider/types.ts
@@ -1,8 +1,5 @@
-export enum UserTimeZone {
-  Local = 'local',
-  UTC = 'utc',
-}
+import { TimeZone } from '#core/types/time-types';
 
 export type UserContextType = {
-  timeZone: UserTimeZone;
+  timeZone: TimeZone;
 };

--- a/javascript/packages/core/providers/user-provider/user-context.ts
+++ b/javascript/packages/core/providers/user-provider/user-context.ts
@@ -1,9 +1,9 @@
 import { createContext } from 'react';
 
-import { UserTimeZone } from './types';
+import { TimeZone } from '#core/types/time-types';
 
 import type { UserContextType } from './types';
 
 export const UserContext = createContext<UserContextType>({
-  timeZone: UserTimeZone.Local,
+  timeZone: TimeZone.Local,
 });

--- a/javascript/packages/core/test/wrappers/get-user-provider-wrapper.tsx
+++ b/javascript/packages/core/test/wrappers/get-user-provider-wrapper.tsx
@@ -1,6 +1,6 @@
 import { type UserContextType } from '#core/providers/user-provider/types';
-import { TimeZone } from '#core/types/time-types';
 import { UserProvider } from '#core/providers/user-provider/user-provider';
+import { TimeZone } from '#core/types/time-types';
 import { WrapperComponentProps } from './types';
 
 /**

--- a/javascript/packages/core/test/wrappers/get-user-provider-wrapper.tsx
+++ b/javascript/packages/core/test/wrappers/get-user-provider-wrapper.tsx
@@ -1,4 +1,5 @@
-import { type UserContextType, UserTimeZone } from '#core/providers/user-provider/types';
+import { type UserContextType } from '#core/providers/user-provider/types';
+import { TimeZone } from '#core/types/time-types';
 import { UserProvider } from '#core/providers/user-provider/user-provider';
 import { WrapperComponentProps } from './types';
 
@@ -22,7 +23,7 @@ import { WrapperComponentProps } from './types';
  */
 export function getUserProviderWrapper(userProvider?: Partial<UserContextType>) {
   const base = {
-    timeZone: UserTimeZone.UTC,
+    timeZone: TimeZone.UTC,
   };
 
   return function ServiceProviderWrapper({ children }: WrapperComponentProps) {

--- a/javascript/packages/core/types/common/view-types.ts
+++ b/javascript/packages/core/types/common/view-types.ts
@@ -2,3 +2,19 @@
  * Represents the type of Schema Driven view that is being rendered.
  */
 export type View = 'form' | 'detail' | 'list';
+
+/**
+ * Union type of all possible view types in the studio.
+ * Extends View with additional special view types.
+ * @see View for the base view types ('form' | 'detail' | 'list')
+ *
+ * 'base' is a special view type that is used to represent the base parameters
+ * for all views registered to the Schema Driven UI router.
+ *
+ * 'form-detail' is a special view type that is used to represent the parameters
+ * for combined form-detail views.
+ *
+ * 'unregistered' is a special view type that is used to represent views that are not registered
+ * to the Schema Driven UI router but are still part of the studio application.
+ */
+export type StudioParamsView = View | 'base' | 'form-detail' | 'unregistered';

--- a/javascript/packages/core/types/time-types.ts
+++ b/javascript/packages/core/types/time-types.ts
@@ -1,0 +1,10 @@
+/**
+ * The user's preferred timezone context for displaying time-based data.
+ *
+ * - `Local` — times are shown in the user's browser/system timezone
+ * - `UTC` — times are shown in Coordinated Universal Time, independent of location
+ */
+export enum TimeZone {
+  Local = 'local',
+  UTC = 'utc',
+}

--- a/javascript/packages/core/utils/__tests__/time-utils.tests.ts
+++ b/javascript/packages/core/utils/__tests__/time-utils.tests.ts
@@ -1,5 +1,5 @@
-import { TimeZone } from '#core/types/time-types';
 import { mockTimezone } from '#core/test/utils/mock-timezone';
+import { TimeZone } from '#core/types/time-types';
 import { timestampToString } from '../time-utils';
 
 describe('time-utils', () => {
@@ -41,16 +41,12 @@ describe('time-utils', () => {
     test('formats date correctly in local timezone', () => {
       // GMT does not include summer time shift.
       expect(timestampToString(1705063132, TimeZone.Local)).toBe('2024/01/12 13:38:52 (GMT+1)');
-      expect(timestampToString('1705063132', TimeZone.Local)).toBe(
-        '2024/01/12 13:38:52 (GMT+1)'
-      );
+      expect(timestampToString('1705063132', TimeZone.Local)).toBe('2024/01/12 13:38:52 (GMT+1)');
 
       // GMT includes summer time shift.
       expect(timestampToString(1719907200, TimeZone.Local)).toBe('2024/07/02 10:00:00 (GMT+2)');
       expect(timestampToString(1720656639, TimeZone.Local)).toBe('2024/07/11 02:10:39 (GMT+2)');
-      expect(timestampToString('1720656639', TimeZone.Local)).toBe(
-        '2024/07/11 02:10:39 (GMT+2)'
-      );
+      expect(timestampToString('1720656639', TimeZone.Local)).toBe('2024/07/11 02:10:39 (GMT+2)');
     });
   });
 });

--- a/javascript/packages/core/utils/__tests__/time-utils.tests.ts
+++ b/javascript/packages/core/utils/__tests__/time-utils.tests.ts
@@ -1,4 +1,4 @@
-import { UserTimeZone } from '#core/providers/user-provider/types';
+import { TimeZone } from '#core/types/time-types';
 import { mockTimezone } from '#core/test/utils/mock-timezone';
 import { timestampToString } from '../time-utils';
 
@@ -33,22 +33,22 @@ describe('time-utils', () => {
     });
 
     test('formats date correctly in UTC timezone', () => {
-      expect(timestampToString(1719907200, UserTimeZone.UTC)).toBe('2024/07/02 08:00:00 (UTC)');
-      expect(timestampToString(1720656639, UserTimeZone.UTC)).toBe('2024/07/11 00:10:39 (UTC)');
-      expect(timestampToString('1720656639', UserTimeZone.UTC)).toBe('2024/07/11 00:10:39 (UTC)');
+      expect(timestampToString(1719907200, TimeZone.UTC)).toBe('2024/07/02 08:00:00 (UTC)');
+      expect(timestampToString(1720656639, TimeZone.UTC)).toBe('2024/07/11 00:10:39 (UTC)');
+      expect(timestampToString('1720656639', TimeZone.UTC)).toBe('2024/07/11 00:10:39 (UTC)');
     });
 
     test('formats date correctly in local timezone', () => {
       // GMT does not include summer time shift.
-      expect(timestampToString(1705063132, UserTimeZone.Local)).toBe('2024/01/12 13:38:52 (GMT+1)');
-      expect(timestampToString('1705063132', UserTimeZone.Local)).toBe(
+      expect(timestampToString(1705063132, TimeZone.Local)).toBe('2024/01/12 13:38:52 (GMT+1)');
+      expect(timestampToString('1705063132', TimeZone.Local)).toBe(
         '2024/01/12 13:38:52 (GMT+1)'
       );
 
       // GMT includes summer time shift.
-      expect(timestampToString(1719907200, UserTimeZone.Local)).toBe('2024/07/02 10:00:00 (GMT+2)');
-      expect(timestampToString(1720656639, UserTimeZone.Local)).toBe('2024/07/11 02:10:39 (GMT+2)');
-      expect(timestampToString('1720656639', UserTimeZone.Local)).toBe(
+      expect(timestampToString(1719907200, TimeZone.Local)).toBe('2024/07/02 10:00:00 (GMT+2)');
+      expect(timestampToString(1720656639, TimeZone.Local)).toBe('2024/07/11 02:10:39 (GMT+2)');
+      expect(timestampToString('1720656639', TimeZone.Local)).toBe(
         '2024/07/11 02:10:39 (GMT+2)'
       );
     });

--- a/javascript/packages/core/utils/time-utils.ts
+++ b/javascript/packages/core/utils/time-utils.ts
@@ -1,6 +1,6 @@
 import { isNil } from 'lodash';
 
-import { UserTimeZone } from '#core/providers/user-provider/types';
+import { TimeZone } from '#core/types/time-types';
 
 /**
  * Converts a timestamp to a string.
@@ -13,7 +13,7 @@ import { UserTimeZone } from '#core/providers/user-provider/types';
  */
 export function timestampToString(
   timestampRaw?: string | number,
-  timeZone?: UserTimeZone
+  timeZone?: TimeZone
 ): string | null {
   if (isNil(timestampRaw)) {
     return null;
@@ -32,7 +32,7 @@ export function timestampToString(
     minute: '2-digit',
     second: '2-digit',
     hour12: false,
-    timeZone: timeZone === UserTimeZone.UTC ? 'UTC' : undefined,
+    timeZone: timeZone === TimeZone.UTC ? 'UTC' : undefined,
   });
 
   const formattedDate = formatter
@@ -42,7 +42,7 @@ export function timestampToString(
 
   const timeZoneFormatter = new Intl.DateTimeFormat('en-US', {
     timeZoneName: 'short',
-    timeZone: timeZone === UserTimeZone.UTC ? 'UTC' : undefined,
+    timeZone: timeZone === TimeZone.UTC ? 'UTC' : undefined,
   });
 
   const timeZoneString = timeZoneFormatter.format(date).split(' ').pop() ?? '';


### PR DESCRIPTION
Prepare packages/core for import-zone enforcement by resolving two directional dependency violations that would otherwise block adding no-restricted-paths rules.

UserTimeZone was defined in providers/ but imported by utils/, which inverts the expected dependency direction — utilities should not depend on provider implementations. Moved the type to types/ so the dependency flows correctly: providers/ → types/, utils/ → types/.

With the type no longer tied to the user provider, the User prefix became misleading. Renamed to TimeZone and relocated to time-types.ts to reflect what it actually represents: a user preference for displaying time-based data, not a user-data concept.

StudioParamsView was defined inside hooks/routing/use-studio-params/ but referenced throughout interpolation/. This created a cycle because hooks/ also depends on interpolation/ (via use-studio-query). Moved StudioParamsView to types/common/view-types so both layers can import it without either depending on the other.

**What type of PR is this? (check all applicable)**
- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
