### PR TITLE
Fix docs-check workflow YAML syntax

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -31,18 +31,18 @@ jobs:
           # Relative doc links without .md are passed through as raw href values.
           # GitHub Pages adds trailing slashes, which breaks browser resolution of
           # relative paths. Links with .md are resolved by Docusaurus at build time.
-  SKIP_MD_EXTENSIONS='\.md[)#]'
-  SKIP_IMAGE_EXTENSIONS='\.(png|jpg|svg|gif)\)'
-  SKIP_CODE_EXTENSIONS='\.go\)'
-  SKIP_REMOTE_LINKS='http'
+          SKIP_MD_EXTENSIONS='\.md[)#]'
+          SKIP_IMAGE_EXTENSIONS='\.(png|jpg|svg|gif)\)'
+          SKIP_CODE_EXTENSIONS='\.go\)'
+          SKIP_REMOTE_LINKS='http'
 
-  # Search for relative links, then drop (grep -v) the ones that match our skip patterns
-  matches=$(grep -rEn '\]\(\.\.?/' docs/ --include='*.md' | \
-    grep -vE "$SKIP_MD_EXTENSIONS"    | \
-    grep -vE "$SKIP_IMAGE_EXTENSIONS" | \
-    grep -vE "$SKIP_CODE_EXTENSIONS"  | \
-    grep -vE "$SKIP_REMOTE_LINKS"     | \
-    || true)
+          # Search for relative links, then drop (grep -v) the ones that match our skip patterns
+          matches=$(grep -rEn '\]\(\.\.?/' docs/ --include='*.md' | \
+            grep -vE "$SKIP_MD_EXTENSIONS"    | \
+            grep -vE "$SKIP_IMAGE_EXTENSIONS" | \
+            grep -vE "$SKIP_CODE_EXTENSIONS"  | \
+            grep -vE "$SKIP_REMOTE_LINKS"     \
+            || true)
           if [ -n "$matches" ]; then
             while IFS=: read -r file line content; do
               echo "::error file=${file},line=${line}::Relative link without .md extension will break on GitHub Pages. Use ./foo.md instead of ./foo"


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

- Fixed indentation of the relative link check step in `docs-check.yml` (2 spaces → 10 spaces to match the YAML `run: |` block)
- Removed trailing `| \` before `|| true)` which created an invalid `| ||` pipe

**Why?**

An accepted GitHub suggestion in #999 introduced broken indentation and a shell syntax error, causing the workflow to fail on every run.

**How did you test it?**

Verified YAML syntax is valid and shell script parses correctly.

**Potential risks**

None — this restores the workflow to a working state.

**Release notes**

N/A

**Documentation Changes**

N/A