### PR TITLE
Add no-nested-ternary, eqeqeq, and no-default-export ESLint rules

### DIFF
--- a/javascript/eslint.config.js
+++ b/javascript/eslint.config.js
@@ -47,6 +47,16 @@ const sharedRules = {
   // Disabled due to BaseUI 15 compatibility issues
   // 'baseui/deprecated-theme-api': 'warn',
   // 'baseui/deprecated-component-api': 'warn',
+  'no-nested-ternary': 'error',
+  eqeqeq: ['error', 'always', { null: 'ignore' }],
+  'no-restricted-syntax': [
+    'error',
+    {
+      selector: 'ExportDefaultDeclaration',
+      message:
+        'Use named exports. Default exports make imports harder to refactor and autocomplete.',
+    },
+  ],
   'baseui/no-deep-imports': 'warn',
   '@typescript-eslint/array-type': 'off',
   '@typescript-eslint/consistent-type-definitions': 'off',
@@ -222,6 +232,19 @@ export default [
     },
     plugins: sharedPlugins,
     rules: sharedRules,
+  },
+
+  // Allow default exports in config files and type declarations (required by their frameworks)
+  {
+    files: [
+      'vitest.config.ts',
+      '**/vite.config.ts',
+      '**/vite.config.production.ts',
+      '**/*.d.ts',
+    ],
+    rules: {
+      'no-restricted-syntax': 'off',
+    },
   },
 
   // Disable conflicting style rules (Prettier)

--- a/javascript/packages/core/hooks/use-hover.ts
+++ b/javascript/packages/core/hooks/use-hover.ts
@@ -21,5 +21,3 @@ export function useHover(ref: React.RefObject<HTMLElement | null>): boolean {
 
   return isHovered;
 }
-
-export default useHover;

--- a/javascript/packages/core/utils/object-utils.ts
+++ b/javascript/packages/core/utils/object-utils.ts
@@ -20,7 +20,14 @@ export function toFlatDotPathMap(
 
   for (const [key, value] of Object.entries(obj)) {
     const isIndex = /^\d+$/.test(key);
-    const path = prefix ? (isIndex ? `${prefix}[${key}]` : `${prefix}.${key}`) : key;
+    let path: string;
+    if (!prefix) {
+      path = key;
+    } else if (isIndex) {
+      path = `${prefix}[${key}]`;
+    } else {
+      path = `${prefix}.${key}`;
+    }
 
     if (value !== null && typeof value === 'object') {
       Object.assign(result, toFlatDotPathMap(value as Record<string, unknown>, path));


### PR DESCRIPTION
Enforce three code style rules across all packages:

- no-nested-ternary: flat conditional expressions are easier to read and less prone to precedence mistakes.
- eqeqeq: strict equality everywhere, with a null exception since == null is used idiomatically for null/undefined checks.
- no-restricted-syntax (ExportDefaultDeclaration): named exports make imports easier to refactor and autocomplete. Config files and type declarations are exempted since their frameworks require default exports.

Refactor the single nested ternary in toFlatDotPathMap to an if/else chain to satisfy the new rule.

**What type of PR is this? (check all applicable)**
- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
