### PR TITLE
Add per-row actions system to table views

### DIFF
--- a/javascript/app/icons/icons.tsx
+++ b/javascript/app/icons/icons.tsx
@@ -15,6 +15,8 @@ import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardBackspaceIcon from '@mui/icons-material/KeyboardBackspace';
 import Launch from '@mui/icons-material/Launch';
 import MenuIcon from '@mui/icons-material/Menu';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import SearchIcon from '@mui/icons-material/Search';
 import SettingsIcon from '@mui/icons-material/Settings';
 import ShowChartIcon from '@mui/icons-material/ShowChart';
@@ -38,7 +40,9 @@ export const ICONS = {
   deleteAlt: createMuiIconAdapter(CancelIcon),
   diamondEmpty: createMuiIconAdapter(CropSquareIcon),
   menu: createMuiIconAdapter(MenuIcon),
+  overflowMenu: createMuiIconAdapter(MoreVertIcon),
   playerNext: createMuiIconAdapter(SkipNextIcon),
+  playerPlay: createMuiIconAdapter(PlayArrowIcon),
   plus: createMuiIconAdapter(AddIcon),
   search: createMuiIconAdapter(SearchIcon),
   settings: createMuiIconAdapter(SettingsIcon),

--- a/javascript/app/icons/mui-icon-adapter.tsx
+++ b/javascript/app/icons/mui-icon-adapter.tsx
@@ -17,7 +17,9 @@ export const createMuiIconAdapter = (Icon: ComponentType<SvgIconProps>) => {
         {...compatibleProps}
         htmlColor={color}
         shapeRendering={String(shapeRendering)}
-        titleAccess={String(title)}
+        // title is an optional Icon property; without checking for existence, the icon
+        // will include literal string "undefined" or "null" in the title attribute.
+        titleAccess={title ? String(title) : undefined}
         sx={{ ...style, fontSize: scaledSize }}
       />
     );

--- a/javascript/packages/core/components/actions/__tests__/actions-popover.test.tsx
+++ b/javascript/packages/core/components/actions/__tests__/actions-popover.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ActionsPopover } from '#core/components/actions/actions-popover';
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
+import { getIconProviderWrapper } from '#core/test/wrappers/get-icon-provider-wrapper';
+
+import type { ActionComponentProps } from '#core/components/actions/types';
+
+describe('ActionsPopover', () => {
+  function DeleteDialog({ isOpen }: ActionComponentProps) {
+    return isOpen ? <div role="dialog">Delete dialog</div> : null;
+  }
+
+  it('renders an "Actions" trigger button', () => {
+    render(
+      <ActionsPopover
+        actions={[{ display: { label: 'Delete' }, component: DeleteDialog }]}
+        record={{}}
+      />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+    );
+    expect(screen.getByRole('button', { name: 'Actions' })).toBeInTheDocument();
+  });
+
+  it('does not show menu items before the trigger is clicked', () => {
+    render(
+      <ActionsPopover
+        actions={[{ display: { label: 'Delete' }, component: DeleteDialog }]}
+        record={{}}
+      />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+    );
+    expect(screen.queryByRole('option', { name: 'Delete' })).not.toBeInTheDocument();
+  });
+
+  it('shows menu items when the trigger is clicked', async () => {
+    const user = userEvent.setup();
+    render(
+      <ActionsPopover
+        actions={[{ display: { label: 'Delete' }, component: DeleteDialog }]}
+        record={{}}
+      />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+    );
+    await user.click(screen.getByRole('button', { name: 'Actions' }));
+    expect(await screen.findByRole('option', { name: 'Delete' })).toBeInTheDocument();
+  });
+
+  it('renders an action menu item with an icon', async () => {
+    const user = userEvent.setup();
+    render(
+      <ActionsPopover
+        actions={[{ display: { label: 'Delete', icon: 'trash' }, component: DeleteDialog }]}
+        record={{}}
+      />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper({ icons: { trash: () => <div>Trash</div> } }),
+      ])
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Actions' }));
+    expect(await screen.findByRole('option', { name: /Trash Delete/ })).toBeInTheDocument();
+  });
+
+  it('opens the action component and closes the menu when a menu item is clicked', async () => {
+    const user = userEvent.setup();
+    render(
+      <ActionsPopover
+        actions={[{ display: { label: 'Delete' }, component: DeleteDialog }]}
+        record={{}}
+      />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+    );
+    await user.click(screen.getByRole('button', { name: 'Actions' }));
+    await user.click(await screen.findByRole('option', { name: 'Delete' }));
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByRole('option', { name: 'Delete' })).not.toBeInTheDocument();
+    });
+  });
+
+  it('passes data to the action component', async () => {
+    const user = userEvent.setup();
+    const Component = ({ record, isOpen }: ActionComponentProps) =>
+      isOpen ? <div role="dialog">{String(record.id)}</div> : null;
+    const data = { id: '42', type: 'pipeline' };
+    render(
+      <ActionsPopover
+        actions={[{ display: { label: 'Run' }, component: Component }]}
+        record={data}
+      />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+    );
+    await user.click(screen.getByRole('button', { name: 'Actions' }));
+    await user.click(await screen.findByRole('option', { name: 'Run' }));
+    expect(await screen.findByRole('dialog')).toHaveTextContent('42');
+  });
+
+  it('disables body scroll when opened and restores it on unmount', async () => {
+    const user = userEvent.setup();
+    const { unmount } = render(
+      <ActionsPopover
+        actions={[{ display: { label: 'Delete' }, component: DeleteDialog }]}
+        record={{}}
+      />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+    );
+    await user.click(screen.getByRole('button', { name: 'Actions' }));
+    expect(document.body.style.overflow).toBe('hidden');
+    unmount();
+    expect(document.body.style.overflow).toBe('');
+  });
+});

--- a/javascript/packages/core/components/actions/action-menu/action-menu-item.tsx
+++ b/javascript/packages/core/components/actions/action-menu/action-menu-item.tsx
@@ -1,0 +1,44 @@
+import { forwardRef } from 'react';
+import { ARTWORK_SIZES, ListItemLabel, MenuAdapter } from 'baseui/list';
+
+import { Icon } from '#core/components/icon/icon';
+
+import type { MenuAdapterProps } from 'baseui/list';
+import type { ComponentActionConfig, Data, SelectedAction } from '#core/components/actions/types';
+
+type ActionMenuItemProps = {
+  /**
+   * Item is the action configuration defined for a specific action in
+   * the ActionMenu list, passed as `item` per baseui MenuAdapter props.
+   */
+  item: ComponentActionConfig;
+  record: Data;
+  onSelectAction: (action: SelectedAction) => void;
+} & Omit<MenuAdapterProps, 'children' | 'item'>;
+
+export const ActionMenuItem = forwardRef<HTMLLIElement, ActionMenuItemProps>((props, ref) => {
+  const { item: action, record, onSelectAction, ...baseMenuProps } = props;
+
+  return (
+    <MenuAdapter
+      // MenuAdapter is a thin wrapper around BaseWeb's list components that adds
+      // support for artwork & handles interaction states & accessibility. The props
+      // forwarding is required boilerplate to get the aforementioned benefits.
+      {...baseMenuProps}
+      ref={ref}
+      role="option"
+      artwork={
+        action.display.icon
+          ? ({ size }: { size: number }) => <Icon name={action.display.icon} size={`${size}px`} />
+          : undefined
+      }
+      artworkSize={ARTWORK_SIZES.MEDIUM}
+      overrides={{ Root: { style: { height: '44px' } } }}
+      onClick={() => onSelectAction({ component: action.component, record })}
+    >
+      <ListItemLabel>{action.display.label}</ListItemLabel>
+    </MenuAdapter>
+  );
+});
+
+ActionMenuItem.displayName = 'ActionMenuItem';

--- a/javascript/packages/core/components/actions/action-menu/action-menu.tsx
+++ b/javascript/packages/core/components/actions/action-menu/action-menu.tsx
@@ -1,0 +1,27 @@
+import { StatefulMenu } from 'baseui/menu';
+
+import { ActionMenuItem } from './action-menu-item';
+
+import type { Theme } from 'baseui';
+import type { ActionConfig, Data, SelectedAction } from '#core/components/actions/types';
+
+type ActionMenuProps = {
+  actions: ActionConfig[];
+  record: Data;
+  onSelectAction: (action: SelectedAction) => void;
+};
+
+export function ActionMenu(props: ActionMenuProps) {
+  return (
+    <StatefulMenu
+      items={props.actions}
+      overrides={{
+        Option: {
+          component: ActionMenuItem,
+          props: { record: props.record, onSelectAction: props.onSelectAction },
+        },
+        List: { style: ({ $theme }: { $theme: Theme }) => ({ padding: $theme.sizing.scale600 }) },
+      }}
+    />
+  );
+}

--- a/javascript/packages/core/components/actions/actions-popover.tsx
+++ b/javascript/packages/core/components/actions/actions-popover.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useRef, useState } from 'react';
+import { useStyletron } from 'baseui';
+import { Button, KIND, SHAPE, SIZE } from 'baseui/button';
+import { PLACEMENT, StatefulPopover } from 'baseui/popover';
+
+import { Icon } from '#core/components/icon/icon';
+import { ActionMenu } from './action-menu/action-menu';
+
+import type { ButtonProps } from 'baseui/button';
+import type { BasePopoverProps } from 'baseui/popover';
+import type { ComponentType } from 'react';
+import type { ActionComponentProps, ActionConfig, Data } from './types';
+
+type ActionsPopoverProps<T extends Data> = {
+  actions: ActionConfig<T>[];
+  buttonProps?: ButtonProps;
+  record: T;
+  popoverProps?: BasePopoverProps;
+};
+
+export function ActionsPopover<T extends Data>({
+  actions,
+  buttonProps,
+  record,
+  popoverProps,
+}: ActionsPopoverProps<T>) {
+  const scrollDisabledRef = useRef(false);
+  const [activeAction, setActiveAction] = useState<{
+    component: ComponentType<ActionComponentProps>;
+    record: Data;
+  } | null>(null);
+  const [, theme] = useStyletron();
+
+  const disableScroll = () => {
+    document.body.style.overflow = 'hidden';
+    scrollDisabledRef.current = true;
+  };
+
+  const enableScroll = () => {
+    document.body.style.overflow = '';
+    scrollDisabledRef.current = false;
+  };
+
+  useEffect(() => {
+    return () => {
+      if (scrollDisabledRef.current) {
+        document.body.style.overflow = '';
+      }
+    };
+  }, []);
+
+  const ActiveComponent = activeAction?.component;
+
+  return (
+    <>
+      <StatefulPopover
+        focusLock
+        placement={PLACEMENT.bottomLeft}
+        {...popoverProps}
+        content={({ close }) => (
+          <ActionMenu
+            actions={actions as ActionConfig[]}
+            record={record}
+            onSelectAction={(action) => {
+              setActiveAction(action);
+              close();
+            }}
+          />
+        )}
+        onClose={enableScroll}
+        onOpen={disableScroll}
+      >
+        <Button
+          kind={KIND.tertiary}
+          shape={SHAPE.pill}
+          overrides={{
+            BaseButton: {
+              style: { paddingLeft: theme.sizing.scale100, paddingRight: theme.sizing.scale100 },
+            },
+          }}
+          {...buttonProps}
+          size={SIZE.compact}
+          title="Actions"
+          data-tracking-name="actions-popover-button"
+        >
+          <Icon name="overflowMenu" />
+        </Button>
+      </StatefulPopover>
+      {ActiveComponent && (
+        <ActiveComponent
+          record={activeAction.record}
+          isOpen
+          onClose={() => setActiveAction(null)}
+        />
+      )}
+    </>
+  );
+}

--- a/javascript/packages/core/components/actions/types.ts
+++ b/javascript/packages/core/components/actions/types.ts
@@ -1,0 +1,50 @@
+import type { ComponentType } from 'react';
+
+export type ActionConfig<T = Data> = ComponentActionConfig<T>;
+
+/**
+ * Base fields shared by all action configurations.
+ *
+ * @example
+ * ```ts
+ * const deleteAction: ComponentActionConfig<Pipeline> = {
+ *   display: { label: 'Delete', icon: 'trash' },
+ *   component: DeleteDialog,
+ * };
+ * ```
+ */
+export type ActionConfigBase = {
+  /**
+   * Controls how the action's trigger button is displayed to the user.
+   *
+   * @see {@link ActionTriggerDisplay}
+   */
+  display: ActionTriggerDisplay;
+};
+
+/**
+ * How the action's trigger button is displayed to the user
+ *
+ * @note icon is a string reference to an icon in the icon provider
+ */
+type ActionTriggerDisplay = {
+  label: string;
+  icon?: string;
+};
+
+export type Data = Record<string, unknown>;
+
+export type ComponentActionConfig<T = Data> = ActionConfigBase & {
+  component: ComponentType<ActionComponentProps<T>>;
+};
+
+export type ActionComponentProps<T = Data> = {
+  record: T;
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+export type SelectedAction = {
+  component: ComponentType<ActionComponentProps>;
+  record: Data;
+};

--- a/javascript/packages/core/components/views/phase-entity-view/__tests__/phase-entity-view.test.tsx
+++ b/javascript/packages/core/components/views/phase-entity-view/__tests__/phase-entity-view.test.tsx
@@ -50,8 +50,8 @@ describe('PhaseEntityView', () => {
       ])
     );
 
-    expect(screen.getByRole('tab', { name: 'pipelines' })).toBeInTheDocument();
-    expect(screen.getByRole('tab', { name: 'models' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Pipelines' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Models' })).toBeInTheDocument();
   });
 
   it('renders data fetched from the API in the table', async () => {

--- a/javascript/packages/core/components/views/phase-entity-view/__tests__/phase-entity-view.test.tsx
+++ b/javascript/packages/core/components/views/phase-entity-view/__tests__/phase-entity-view.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { CellType } from '#core/components/cell/constants';
+import {
+  buildEntityConfigFactory,
+  buildPhaseConfigFactory,
+} from '#core/router/__fixtures__/phase-config-factory';
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
+import { getErrorProviderWrapper } from '#core/test/wrappers/get-error-provider-wrapper';
+import { getIconProviderWrapper } from '#core/test/wrappers/get-icon-provider-wrapper';
+import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
+import {
+  createQueryMockRouter,
+  getServiceProviderWrapper,
+} from '#core/test/wrappers/get-service-provider-wrapper';
+import { PhaseEntityView } from '../phase-entity-view';
+
+import type { ActionComponentProps } from '#core/components/actions/types';
+import type { ListableEntity } from '../types';
+
+describe('PhaseEntityView', () => {
+  const buildPhaseConfig = buildPhaseConfigFactory({ id: 'training', name: 'Train & Evaluate' });
+  const buildPipelineEntityConfig = buildEntityConfigFactory({
+    id: 'pipelines',
+    name: 'Pipelines',
+    service: 'pipeline',
+  });
+  const buildModelEntityConfig = buildEntityConfigFactory({
+    id: 'models',
+    name: 'Models',
+    service: 'model',
+  });
+
+  it('renders a tab for each entity', () => {
+    render(
+      <PhaseEntityView
+        phaseConfig={buildPhaseConfig()}
+        entities={[buildPipelineEntityConfig(), buildModelEntityConfig()] as ListableEntity[]}
+      />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getErrorProviderWrapper(),
+        getServiceProviderWrapper({
+          request: createQueryMockRouter({ ListPipeline: { pipelineList: { items: [] } } }),
+        }),
+        getRouterWrapper({ location: '/project-1/training/pipeline' }),
+        getIconProviderWrapper(),
+      ])
+    );
+
+    expect(screen.getByRole('tab', { name: 'pipelines' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'models' })).toBeInTheDocument();
+  });
+
+  it('renders data fetched from the API in the table', async () => {
+    render(
+      <PhaseEntityView
+        phaseConfig={buildPhaseConfig()}
+        entities={[
+          buildPipelineEntityConfig({
+            views: [
+              {
+                type: 'list',
+                tableConfig: { columns: [{ id: 'name', label: 'Name', type: CellType.TEXT }] },
+              },
+            ],
+          }) as ListableEntity,
+        ]}
+      />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getErrorProviderWrapper(),
+        getServiceProviderWrapper({
+          request: createQueryMockRouter({
+            ListPipeline: { pipelineList: { items: [{ name: 'my-pipeline' }] } },
+          }),
+        }),
+        getRouterWrapper({ location: '/project-1/training/pipeline' }),
+        getIconProviderWrapper(),
+      ])
+    );
+
+    expect(await screen.findByRole('cell', { name: 'my-pipeline' })).toBeInTheDocument();
+  });
+
+  it('opens the action component when an action menu item is clicked', async () => {
+    const user = userEvent.setup();
+    const RunDialog = ({ isOpen }: ActionComponentProps) =>
+      isOpen ? <div role="dialog">Run dialog</div> : null;
+
+    render(
+      <PhaseEntityView
+        phaseConfig={buildPhaseConfig()}
+        entities={[
+          buildPipelineEntityConfig({
+            actions: [{ display: { label: 'Run' }, component: RunDialog }],
+          }) as ListableEntity,
+        ]}
+      />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getErrorProviderWrapper(),
+        getServiceProviderWrapper({
+          request: createQueryMockRouter({
+            ListPipeline: { pipelineList: { items: [{}] } },
+          }),
+        }),
+        getRouterWrapper({ location: '/project-1/training/pipeline' }),
+        getIconProviderWrapper(),
+      ])
+    );
+
+    await user.click(await screen.findByRole('button', { name: 'Actions' }));
+    await user.click(await screen.findByRole('option', { name: 'Run' }));
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+  });
+});

--- a/javascript/packages/core/components/views/types.ts
+++ b/javascript/packages/core/components/views/types.ts
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import type { ActionConfig } from '#core/components/actions/types';
 import type { Cell } from '#core/components/cell/types';
 import type { EmptyState } from '#core/components/table/components/table-empty-state/types';
 import type { PageSizeOption } from '#core/components/table/components/table-pagination/types';
@@ -51,6 +52,6 @@ export interface TableConfig<T extends TableData = TableData> {
   /** Whether to enable sticky sides in the table */
   enableStickySides?: boolean;
 
-  /** Optional actions component for the table */
-  actions?: React.ComponentType<{ record: T }>;
+  /** Optional actions to render in each table row */
+  actions?: ActionConfig<T>[];
 }

--- a/javascript/packages/core/components/views/utils/__tests__/table-view-adapter.test.ts
+++ b/javascript/packages/core/components/views/utils/__tests__/table-view-adapter.test.ts
@@ -77,6 +77,20 @@ describe('adaptTableConfigToTableProps', () => {
     expect(result.loading).toBe(false);
   });
 
+  it('returns undefined actions when config has no actions', () => {
+    const result = adaptTableConfigToTableProps(buildTableConfig(), mockRuntimeProps);
+    expect(result.actions).toBeUndefined();
+  });
+
+  it('returns a render function when actions are configured', () => {
+    // Full actions interaction is tested at the PhaseEntityView level.
+    const tableConfig = buildTableConfig({
+      actions: [{ display: { label: 'Delete' }, component: () => null }],
+    });
+    const result = adaptTableConfigToTableProps(tableConfig, mockRuntimeProps);
+    expect(typeof result.actions).toBe('function');
+  });
+
   describe('should correctly map disable flags to actionBar enables', () => {
     const testCases = [
       {

--- a/javascript/packages/core/components/views/utils/table-view-adapter.tsx
+++ b/javascript/packages/core/components/views/utils/table-view-adapter.tsx
@@ -1,6 +1,8 @@
+import { ActionsPopover } from '#core/components/actions/actions-popover';
+
+import type { ActionConfig, Data } from '#core/components/actions/types';
 import type { TableActionBarConfig } from '#core/components/table/components/table-action-bar/types';
 import type { TableData } from '#core/components/table/types/data-types';
-import type { TableRow } from '#core/components/table/types/row-types';
 import type { TableProps } from '#core/components/table/types/table-types';
 import type { ApplicationError } from '#core/types/error-types';
 import type { TableConfig } from '../types';
@@ -32,10 +34,14 @@ export function adaptTableConfigToTableProps<T extends TableData = TableData>(
     emptyState: config.emptyState,
     actions:
       'actions' in config && config.actions
-        ? ({ row }: { row: TableRow<T> }) => {
-            const ActionsComponent = config.actions!;
-            return <ActionsComponent record={row.record} />;
-          }
+        ? ({ row }: { row: { record: T } }) => (
+            // Actions require Record<string, unknown> but TableData is `unknown` — cast at the
+            // table/actions boundary since entity records are always objects in practice.
+            <ActionsPopover
+              actions={config.actions as ActionConfig<Data>[]}
+              record={row.record as Data}
+            />
+          )
         : undefined,
     actionBarConfig,
     disablePagination: config.disablePagination,

--- a/javascript/packages/core/config/entities/pipeline/__tests__/create-pipeline-run-form.test.tsx
+++ b/javascript/packages/core/config/entities/pipeline/__tests__/create-pipeline-run-form.test.tsx
@@ -1,7 +1,8 @@
+import { useState } from 'react';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { CreatePipelineRunDialog } from '#core/config/entities/pipeline/create-pipeline-run-dialog';
+import { CreatePipelineRunForm } from '#core/config/entities/pipeline/create-pipeline-run-form';
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
 import { getErrorProviderWrapper } from '#core/test/wrappers/get-error-provider-wrapper';
@@ -13,20 +14,17 @@ import {
   getServiceProviderWrapper,
 } from '#core/test/wrappers/get-service-provider-wrapper';
 
-import type { Pipeline } from '#core/config/entities/pipeline/types';
-
-describe('CreatePipelineRunDialog', () => {
-  const mockPipeline: Pipeline = {
-    metadata: {
-      name: 'test-pipeline',
-      namespace: 'test-namespace',
-    },
-    spec: {
-      owner: {
-        name: 'test-owner',
-      },
-    },
-  };
+describe('CreatePipelineRunForm', () => {
+  // Stateful wrapper providing real isOpen state so FormDialog can close on success.
+  // Defined inside describe (not module level) and data is co-located.
+  function FormWrapper() {
+    const [isOpen, setIsOpen] = useState(true);
+    const data = {
+      metadata: { name: 'test-pipeline', namespace: 'test-namespace' },
+      spec: { owner: { name: 'test-owner' } },
+    };
+    return <CreatePipelineRunForm record={data} isOpen={isOpen} onClose={() => setIsOpen(false)} />;
+  }
 
   it('submits pipeline run with correct data structure and closes dialog', async () => {
     const user = userEvent.setup();
@@ -36,7 +34,7 @@ describe('CreatePipelineRunDialog', () => {
     });
 
     render(
-      <CreatePipelineRunDialog record={mockPipeline} />,
+      <FormWrapper />,
       buildWrapper([
         getBaseProviderWrapper(),
         getIconProviderWrapper(),
@@ -47,7 +45,6 @@ describe('CreatePipelineRunDialog', () => {
       ])
     );
 
-    await user.click(screen.getByRole('button', { name: 'Run' }));
     const dialog = await screen.findByRole('dialog', { name: 'Start new pipeline run' });
     const submitButton = within(dialog).getByRole('button', { name: 'Run' });
     await user.click(submitButton);
@@ -85,7 +82,7 @@ describe('CreatePipelineRunDialog', () => {
     });
 
     render(
-      <CreatePipelineRunDialog record={mockPipeline} />,
+      <FormWrapper />,
       buildWrapper([
         getBaseProviderWrapper(),
         getIconProviderWrapper(),
@@ -96,7 +93,6 @@ describe('CreatePipelineRunDialog', () => {
       ])
     );
 
-    await user.click(screen.getByRole('button', { name: 'Run' }));
     const dialog = await screen.findByRole('dialog');
     const submitButton = within(dialog).getByRole('button', { name: 'Run' });
     await user.click(submitButton);

--- a/javascript/packages/core/config/entities/pipeline/create-pipeline-run-form.tsx
+++ b/javascript/packages/core/config/entities/pipeline/create-pipeline-run-form.tsx
@@ -1,17 +1,18 @@
-import React, { useState } from 'react';
-import { Button, KIND, SIZE } from 'baseui/button';
-
 import { FormDialog } from '#core/components/form/components/form-dialog/form-dialog';
 import { StringField } from '#core/components/form/fields/string/string-field';
 import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
 import { useStudioMutation } from '#core/hooks/use-studio-mutation';
 import { generateSuffix } from '#core/utils/name-utils';
 
+import type { ActionComponentProps } from '#core/components/actions/types';
 import type { Pipeline } from '#core/config/entities/pipeline/types';
 import type { PipelineRun } from '#core/config/entities/run/types';
 
-export const CreatePipelineRunDialog: React.FC<{ record: Pipeline }> = ({ record }) => {
-  const [showRunModal, setShowRunModal] = useState(false);
+export const CreatePipelineRunForm = ({
+  record,
+  isOpen,
+  onClose,
+}: ActionComponentProps<Pipeline>) => {
   const { projectId } = useStudioParams('base');
 
   const createPipelineRunMutation = useStudioMutation<
@@ -37,28 +38,22 @@ export const CreatePipelineRunDialog: React.FC<{ record: Pipeline }> = ({ record
         name: 'mastudio-user',
       },
       pipeline: {
-        name: record?.metadata?.name || '',
+        name: record?.metadata?.name ?? '',
         namespace: projectId,
       },
     },
   };
 
   return (
-    <>
-      <Button size={SIZE.compact} kind={KIND.secondary} onClick={() => setShowRunModal(true)}>
-        Run
-      </Button>
-
-      <FormDialog<PipelineRun>
-        isOpen={showRunModal}
-        onDismiss={() => setShowRunModal(false)}
-        heading="Start new pipeline run"
-        onSubmit={handleRunSubmit}
-        submitLabel={'Run'}
-        initialValues={initialValues}
-      >
-        <StringField name="spec.pipeline.name" label="Pipeline to run" readOnly />
-      </FormDialog>
-    </>
+    <FormDialog<PipelineRun>
+      isOpen={isOpen}
+      onDismiss={onClose}
+      heading="Start new pipeline run"
+      onSubmit={handleRunSubmit}
+      submitLabel={'Run'}
+      initialValues={initialValues}
+    >
+      <StringField name="spec.pipeline.name" label="Pipeline to run" readOnly />
+    </FormDialog>
   );
 };

--- a/javascript/packages/core/config/entities/pipeline/pipeline.ts
+++ b/javascript/packages/core/config/entities/pipeline/pipeline.ts
@@ -1,4 +1,4 @@
-import { CreatePipelineRunDialog } from './create-pipeline-run-dialog';
+import { CreatePipelineRunForm } from './create-pipeline-run-form';
 import { PIPELINE_LIST_CONFIG } from './list';
 
 import type { PhaseEntityConfig } from '#core/types/common/studio-types';
@@ -9,5 +9,10 @@ export const PIPELINE_ENTITY_CONFIG: PhaseEntityConfig = {
   service: 'pipeline',
   state: 'active',
   views: [PIPELINE_LIST_CONFIG],
-  actions: CreatePipelineRunDialog,
+  actions: [
+    {
+      display: { label: 'Run', icon: 'playerPlay' },
+      component: CreatePipelineRunForm,
+    },
+  ],
 };

--- a/javascript/packages/core/types/common/studio-types.ts
+++ b/javascript/packages/core/types/common/studio-types.ts
@@ -1,3 +1,4 @@
+import type { ActionConfig } from '#core/components/actions/types';
 import type { ViewConfig } from '#core/components/views/types';
 import type { QueryConfig } from '#core/types/query-types';
 
@@ -103,10 +104,10 @@ export interface PhaseEntityConfig<T extends object = object> {
   /** List of view configurations for this entity */
   views: ViewConfig<T>[];
   /**
-   * Optional actions component for this entity
-   * Rendered in table rows for list views and in detail view headers
+   * Optional actions to render for this entity.
+   * Rendered in table rows for list views.
    */
-  actions?: React.ComponentType<{ record: T }>;
+  actions?: ActionConfig<T>[];
 }
 
 /**


### PR DESCRIPTION
Table views previously supported one action per row via a single render-prop component that owned its own trigger button and open/close state. This replaces that with an array of action descriptors. The trigger button, overflow menu, and active-action lifecycle are shared infrastructure; each action declares a label, optional icon, and the component to open.

`CreatePipelineRunDialog` is renamed to `CreatePipelineRunForm` and updated to the new `ActionComponentProps` interface, removing its internal open/close state. It is registered as the first action on the pipelines entity.

Fix bug in MUI icon adapter that passed undefined icon title as string literal to title attribute.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
<img width="1840" height="1196" alt="Screenshot 2026-03-27 at 14 18 43" src="https://github.com/user-attachments/assets/0fd357cd-c19b-49de-b62f-88615273c262" />


https://github.com/user-attachments/assets/3a6483e7-4b6a-42c3-94d3-077fb1e24eef




<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
