### PR TITLE
Remove CR_PAT authentication requirement

### DIFF
--- a/docs/getting-started/sandbox-setup.md
+++ b/docs/getting-started/sandbox-setup.md
@@ -58,30 +58,6 @@ brew install kubectl
 brew install k3d
 ```
 
-### GitHub Personal Access Token
-
-Michelangelo is not publicly available yet, so we keep Michelangelo's Docker containers in the private GitHub Container
-Registry, which requires a [GitHub personal access token (classic)](https://github.com/settings/tokens) for authentication.
-
-To enable authentication for the sandbox, please create a GitHub personal access token (classic) with the
-"read:packages" scope and save it to the `CR_PAT` environment variable. For example, you can add the following line to
-your shell configuration file (such as `.bashrc` or `.zshrc`, depending on the shell you use):
-
-```bash
-$ export CR_PAT=your_token_...
-$ echo 'export CR_PAT=your_token_...' >> ~/.zshrc
-$ source ~/.zshrc
-
-# login before running ma sandbox so that MA docker image can be pulled
-$ docker login ghcr.io -u [your github id] -p [CR_PAT]
-```
-
-For a more detailed guide, please refer
-to https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic.
-
-> Be aware that `CR_PAT` environment variable is required while Michelangelo is NOT publicly accessible. Once we become
-> public, the token will no longer be necessary, and this section will be removed.
-
 ### Python Environment
 
 This project requires Python version 3.9 or higher to run certain scripts and tools.
@@ -279,7 +255,6 @@ kubectl delete pod minio
 kubectl apply -f michelangelo/cli/sandbox/resources/minio.yaml
 
 # Test docker pull
-docker login ghcr.io -u [your id] -p [CR_PAT]
 docker pull ghcr.io/michelangelo-ai/worker:sha-6161efe@sha256:aae98f00b82d744e453432a9008027fc74d44b78cc1731cb995c7ee654a8225d
 
 # Debugging container starting issue

--- a/docs/operator-guides/ingester-sandbox-validation.md
+++ b/docs/operator-guides/ingester-sandbox-validation.md
@@ -33,8 +33,6 @@ It covers sandbox creation, MySQL schema verification, CR creation, MySQL sync v
 
 #### Delete Existing Sandbox
 ```bash
-export CR_PAT="placeholder"
-export GITHUB_USERNAME="hkriplani"
 python3 python/michelangelo/cli/sandbox/sandbox.py delete
 ```
 **Output**:
@@ -57,11 +55,6 @@ pod/michelangelo-apiserver created
 pod/michelangelo-controllermgr created
 NAME: kuberay-operator ... STATUS: deployed
 ```
-
-> **Note**: `CR_PAT` is required for pulling from ghcr.io. Since images were cached locally, they were imported into the k3d cluster manually via:
-> ```bash
-> docker save <image> | ctr -n k8s.io images import -
-> ```
 
 #### Verify All Pods Running
 ```bash

--- a/docs/user-guides/ml-pipelines/running-uniflow.md
+++ b/docs/user-guides/ml-pipelines/running-uniflow.md
@@ -155,7 +155,6 @@ kubectl delete pod minio
 kubectl apply -f michelangelo/cli/sandbox/resources/minio.yaml
 
 # Test docker pull
-docker login ghcr.io -u [your-id] -p [CR_PAT]
 docker pull ghcr.io/michelangelo-ai/worker:latest
 
 # Debug container starting issues

--- a/python/michelangelo/cli/sandbox/README.md
+++ b/python/michelangelo/cli/sandbox/README.md
@@ -15,22 +15,6 @@ Please install the following software before proceeding:
 - [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
 - [k3d](https://k3d.io)
 
-**GitHub Personal Access Token**
-
-Michelangelo is not publicly available yet, so we keep Michelangelo's Docker containers in the private GitHub Container Registry, which requires a GitHub personal access token (classic) for authentication.
-
-To enable authentication for the sandbox, please create a GitHub personal access token (classic) with the "read:packages" scope and save it to the `CR_PAT` environment variable. For example, you can add the following line to your shell configuration file (such as `.bashrc` or `.zshrc`, depending on the shell you use):
-
-```bash
-export CR_PAT=your_token_...
-```
-
-For a more detailed guide, please refer to [Authenticating with a Personal Access Token (classic)](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic).
-
-> **Be aware:** The `CR_PAT` environment variable is required while Michelangelo is NOT publicly accessible. Once Michelangelo becomes public, this token will no longer be necessary, and this section will be removed.
-
-TODO: andrii: remove this section after the public release of Michelangelo
-
 ### Install Michelangelo CLI
 
 ```bash

--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -2,7 +2,6 @@
 
 import argparse
 import base64
-import os
 import shutil
 import subprocess
 import sys

--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -2,7 +2,6 @@
 
 import argparse
 import base64
-import json
 import os
 import shutil
 import subprocess
@@ -166,58 +165,6 @@ def _create(ns: argparse.Namespace):
 
     for p in ports:
         args += ["-p", f"{p}@agent:0"]
-
-    # TODO: andrii: Remove the following block once Michelangelo is publicly accessible.
-    # BLOCK START ----------------------------------------------------------------------
-    # Handle the GitHub Container Registry authentication.
-    env_cr_pat = "CR_PAT"
-    cr_pat = os.environ.get(env_cr_pat)
-    if not cr_pat:
-        _err_exit(
-            """
-CR_PAT environment variable is not set. To pull Michelangelo's containers
-from the GitHub Container Registry, please create a GitHub personal access
-token (classic) with the "read:packages" scope. Then, save this token to the
-CR_PAT environment variable, e.g.: `export CR_PAT=ghp_...`.
-
-For a detailed guide, check:
-https://docs.github.com/en/packages/working-with-a-github-packages-registry/
-working-with-the-container-registry#authenticating-with-a-personal-access-token-classic.
-
-Be aware that CR_PAT environment variable is required while Michelangelo is NOT
-publicly accessible. Once we become public, the token will no longer be
-necessary, and this assertion will be removed.
-"""
-        )
-
-    # Get GitHub username from environment variable
-    env_github_username = "GITHUB_USERNAME"
-    github_username = os.environ.get(env_github_username, "USERNAME")
-
-    # Create a temporary registry file with the GitHub Container Registry
-    # authentication.
-    registry = {
-        "mirrors": {
-            "ghcr.io": {
-                "endpoint": ["https://ghcr.io"],
-            },
-        },
-        "configs": {
-            "ghcr.io": {
-                "auth": {
-                    "username": github_username,
-                    "password": cr_pat,
-                },
-            },
-        },
-    }
-
-    with tempfile.NamedTemporaryFile(mode="wt", delete=False) as registry_file:
-        json.dump(registry, registry_file)
-        registry_file.flush()
-        args += ["--registry-config", registry_file.name]
-
-    # BLOCK END ----------------------------------------------------------------------
 
     _exec(*args)
 

--- a/python/tests/cli/sandbox/test_sandbox.py
+++ b/python/tests/cli/sandbox/test_sandbox.py
@@ -19,7 +19,6 @@ class CreateFunctionTest(TestCase):
     @patch("michelangelo.cli.sandbox.sandbox._assert_command")
     @patch("michelangelo.cli.sandbox.sandbox._kube_create")
     @patch("michelangelo.cli.sandbox.sandbox._exec")
-    @patch("michelangelo.cli.sandbox.sandbox.os.environ.get")
     @patch("michelangelo.cli.sandbox.sandbox.tempfile.NamedTemporaryFile")
     @patch("michelangelo.cli.sandbox.sandbox._create_compute_cluster_secrets")
     @patch("michelangelo.cli.sandbox.sandbox._apply_compute_cluster_rbac")
@@ -32,7 +31,6 @@ class CreateFunctionTest(TestCase):
         mock_apply_rbac,
         mock_create_secrets,
         mock_tempfile,
-        mock_env_get,
         mock_exec,
         mock_kube_create,
         mock_assert_command,
@@ -52,8 +50,7 @@ class CreateFunctionTest(TestCase):
             compute_cluster_name="test-compute-cluster",
         )
 
-        # Mock environment variable and dependencies
-        mock_env_get.return_value = "test-token"
+        # Mock dependencies
         mock_check_output.return_value = (
             b"kuberay\thttps://ray-project.github.io/kuberay-helm\n"
         )
@@ -80,7 +77,6 @@ class CreateFunctionTest(TestCase):
     @patch("michelangelo.cli.sandbox.sandbox._assert_command")
     @patch("michelangelo.cli.sandbox.sandbox._kube_create")
     @patch("michelangelo.cli.sandbox.sandbox._exec")
-    @patch("michelangelo.cli.sandbox.sandbox.os.environ.get")
     @patch("michelangelo.cli.sandbox.sandbox.tempfile.NamedTemporaryFile")
     @patch("michelangelo.cli.sandbox.sandbox._create_compute_cluster_secrets")
     @patch("michelangelo.cli.sandbox.sandbox._apply_compute_cluster_rbac")
@@ -93,7 +89,6 @@ class CreateFunctionTest(TestCase):
         mock_apply_rbac,
         mock_create_secrets,
         mock_tempfile,
-        mock_env_get,
         mock_exec,
         mock_kube_create,
         mock_assert_command,
@@ -113,8 +108,7 @@ class CreateFunctionTest(TestCase):
             compute_cluster_name="test-compute-cluster",
         )
 
-        # Mock environment variable and dependencies
-        mock_env_get.return_value = "test-token"
+        # Mock dependencies
         mock_check_output.return_value = (
             b"kuberay\thttps://ray-project.github.io/kuberay-helm\n"
         )


### PR DESCRIPTION
## Summary

- Removes `CR_PAT` env var check and auth block from `sandbox.py` (images are now publicly accessible on ghcr.io)
- Drops `import json` which was only used by the removed block
- Removes "GitHub Personal Access Token" prerequisite sections from `README.md` and `sandbox-setup.md`
- Cleans up `docker login` lines from debug snippets in `running-uniflow.md` and `sandbox-setup.md`
- Removes `export CR_PAT/GITHUB_USERNAME` commands and the CR_PAT note from `ingester-sandbox-validation.md`

## Test plan

- [x] Run `ma sandbox` without `CR_PAT` set and confirm it creates the sandbox successfully
- [x] Verify `docker pull ghcr.io/michelangelo-ai/worker:latest` works without login

Tested with remote run 
<img width="1439" height="349" alt="Screenshot 2026-03-30 at 2 55 30 PM" src="https://github.com/user-attachments/assets/37822493-d0db-4605-8959-505032a86201" />
