### PR TITLE
Extend no-module-scope-test-setup to catch wrapper helper functions

### DIFF
--- a/javascript/eslint-local-rules/__tests__/no-module-scope-test-setup.test.js
+++ b/javascript/eslint-local-rules/__tests__/no-module-scope-test-setup.test.js
@@ -54,6 +54,14 @@ tester.run('no-module-scope-test-setup', rule, {
       name: 'import statement at module scope',
       code: `import { render } from '@testing-library/react';`,
     },
+    {
+      name: 'module-scope function unrelated to buildWrapper',
+      code: `function formatLabel(name) { return name.toUpperCase(); }`,
+    },
+    {
+      name: 'buildWrapper inside a function called inside a test',
+      code: `it('renders', () => { const w = buildWrapper([getBaseProviderWrapper()]); render(el, w); });`,
+    },
   ],
 
   invalid: [
@@ -89,6 +97,21 @@ tester.run('no-module-scope-test-setup', rule, {
         { messageId: 'noModuleScopeWrapper' },
         { messageId: 'noModuleScopeSetupConst', data: { name: 'options' } },
       ],
+    },
+    {
+      name: 'function declaration wrapping buildWrapper at module scope',
+      code: `function buildTestWrapper(req) { return buildWrapper([getBaseProviderWrapper(), getServiceProviderWrapper({ request: req })]); }`,
+      errors: [{ messageId: 'noModuleScopeWrapperHelper', data: { name: 'buildTestWrapper' } }],
+    },
+    {
+      name: 'arrow function variable wrapping buildWrapper at module scope',
+      code: `const buildTestWrapper = (req) => buildWrapper([getBaseProviderWrapper(), getServiceProviderWrapper({ request: req })]);`,
+      errors: [{ messageId: 'noModuleScopeWrapperHelper', data: { name: 'buildTestWrapper' } }],
+    },
+    {
+      name: 'block-body arrow function variable wrapping buildWrapper at module scope',
+      code: `const buildTestWrapper = (req) => { return buildWrapper([getBaseProviderWrapper()]); };`,
+      errors: [{ messageId: 'noModuleScopeWrapperHelper', data: { name: 'buildTestWrapper' } }],
     },
   ],
 });

--- a/javascript/eslint-local-rules/no-module-scope-test-setup.js
+++ b/javascript/eslint-local-rules/no-module-scope-test-setup.js
@@ -26,6 +26,16 @@ const rule = {
         '',
       ].join('\n'),
 
+      noModuleScopeWrapperHelper: [
+        "'{{ name }}' wraps buildWrapper() at module scope.",
+        'Move the buildWrapper() call inline into each test so every test is self-contained:',
+        '',
+        '  it("renders", () => {',
+        '    render(<Foo />, buildWrapper([getBaseProviderWrapper()]));',
+        '  });',
+        '',
+      ].join('\n'),
+
       noModuleScopeSetupConst: [
         "'{{ name }}' is declared at module scope but looks like test setup (props, options, config).",
         'Inline it inside each test so every test is self-contained:',
@@ -66,6 +76,21 @@ const rule = {
       return false;
     }
 
+    function bodyCallsBuildWrapper(node) {
+      if (!node) return false;
+      if (callsBuildWrapper(node)) return true;
+      if (node.type === 'BlockStatement') {
+        return node.body.some(bodyCallsBuildWrapper);
+      }
+      if (node.type === 'ReturnStatement') {
+        return bodyCallsBuildWrapper(node.argument);
+      }
+      if (node.type === 'ExpressionStatement') {
+        return bodyCallsBuildWrapper(node.expression);
+      }
+      return false;
+    }
+
     /**
      * Heuristic: does this initializer look like test setup data?
      * Matches object literals, array literals, and JSX — the common shapes
@@ -82,6 +107,18 @@ const rule = {
     }
 
     return {
+      FunctionDeclaration(node) {
+        if (!isModuleScope(node)) return;
+        const name = node.id?.name ?? '<anonymous>';
+        if (bodyCallsBuildWrapper(node.body)) {
+          context.report({
+            node,
+            messageId: 'noModuleScopeWrapperHelper',
+            data: { name },
+          });
+        }
+      },
+
       VariableDeclaration(node) {
         if (!isModuleScope(node)) return;
 
@@ -93,6 +130,19 @@ const rule = {
             context.report({
               node: declarator,
               messageId: 'noModuleScopeWrapper',
+            });
+            continue;
+          }
+
+          if (
+            init &&
+            (init.type === 'ArrowFunctionExpression' || init.type === 'FunctionExpression') &&
+            bodyCallsBuildWrapper(init.body)
+          ) {
+            context.report({
+              node: declarator,
+              messageId: 'noModuleScopeWrapperHelper',
+              data: { name },
             });
             continue;
           }


### PR DESCRIPTION
Flags module-scope function declarations and arrow function variables whose bodies call buildWrapper(). Previously the rule only caught direct assignments (const wrapper = buildWrapper([...])); a named helper like function buildTestWrapper(req) { return buildWrapper([...]); } bypassed it while creating the same "hidden setup" problem.

Adds bodyCallsBuildWrapper() to walk BlockStatement/ReturnStatement/ ExpressionStatement nodes, a FunctionDeclaration handler, and a new noModuleScopeWrapperHelper message that points to either inline usage or packages/core/test/wrappers/ as the right abstraction level.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
