### PR TITLE
Extend action buttons to entity detail page headers

### DIFF
--- a/javascript/packages/core/components/actions/actions-buttons/actions-buttons.tsx
+++ b/javascript/packages/core/components/actions/actions-buttons/actions-buttons.tsx
@@ -16,7 +16,7 @@ type ActionsButtonsProps<T extends Data = Data> = {
 };
 
 /**
- * Renders action buttons in the detail page header, partitioned by hierarchy.
+ * Renders action buttons partitioned by hierarchy level and manages the selected action.
  *
  * Primary actions render as a fixed-width filled button, secondary as pill-shaped
  * buttons, and tertiary actions collapse into an overflow popover.

--- a/javascript/packages/core/components/actions/actions-buttons/actions-buttons.tsx
+++ b/javascript/packages/core/components/actions/actions-buttons/actions-buttons.tsx
@@ -29,7 +29,7 @@ export function ActionsButtons<T extends Data>({
   const [css, theme] = useStyletron();
   const [selectedAction, setSelectedAction] = useState<SelectedAction | null>(null);
 
-  if (!actions || actions.length === 0) return null;
+  if (actions.length === 0) return null;
 
   const { primary, secondary, tertiary } = partitionActions(actions);
   const ActiveComponent = selectedAction?.component;

--- a/javascript/packages/core/components/actions/actions-buttons/actions-buttons.tsx
+++ b/javascript/packages/core/components/actions/actions-buttons/actions-buttons.tsx
@@ -1,0 +1,98 @@
+import { useState } from 'react';
+import { useStyletron } from 'baseui';
+import { Button, KIND, SHAPE, SIZE } from 'baseui/button';
+import { PLACEMENT } from 'baseui/popover';
+
+import { ActionsPopover } from '#core/components/actions/actions-popover';
+import { Icon } from '#core/components/icon/icon';
+import { partitionActions } from './utils';
+
+import type { ActionConfig, Data, SelectedAction } from '#core/components/actions/types';
+
+type ActionsButtonsProps<T extends Data = Data> = {
+  actions: ActionConfig<T>[];
+  record: T;
+  loading?: boolean;
+};
+
+/**
+ * Renders action buttons in the detail page header, partitioned by hierarchy.
+ *
+ * Primary actions render as a fixed-width filled button, secondary as pill-shaped
+ * buttons, and tertiary actions collapse into an overflow popover.
+ */
+export function ActionsButtons<T extends Data>({
+  actions,
+  record,
+  loading,
+}: ActionsButtonsProps<T>) {
+  const [css, theme] = useStyletron();
+  const [selectedAction, setSelectedAction] = useState<SelectedAction | null>(null);
+
+  if (!actions || actions.length === 0) return null;
+
+  const { primary, secondary, tertiary } = partitionActions(actions);
+  const ActiveComponent = selectedAction?.component;
+
+  return (
+    <>
+      <div className={css({ display: 'flex', gap: theme.sizing.scale300 })}>
+        {primary && (
+          <Button
+            kind={KIND.primary}
+            size={SIZE.compact}
+            isLoading={loading}
+            overrides={{ Root: { style: { width: '200px' } } }}
+            startEnhancer={
+              primary.display.icon
+                ? () => (
+                    <Icon
+                      name={primary.display.icon}
+                      size={theme.sizing.scale550}
+                      color="inherit"
+                    />
+                  )
+                : undefined
+            }
+            onClick={() => setSelectedAction({ component: primary.component, record })}
+          >
+            {primary.display.label}
+          </Button>
+        )}
+        {secondary.map((action) => (
+          <Button
+            key={action.display.label}
+            kind={KIND.secondary}
+            shape={SHAPE.pill}
+            size={SIZE.compact}
+            isLoading={loading}
+            startEnhancer={
+              action.display.icon
+                ? () => (
+                    <Icon name={action.display.icon} size={theme.sizing.scale550} color="inherit" />
+                  )
+                : undefined
+            }
+            onClick={() => setSelectedAction({ component: action.component, record })}
+          >
+            {action.display.label}
+          </Button>
+        ))}
+        {tertiary.length > 0 && (
+          <ActionsPopover
+            actions={tertiary}
+            record={record}
+            popoverProps={{ placement: PLACEMENT.bottomRight }}
+          />
+        )}
+      </div>
+      {selectedAction && ActiveComponent && (
+        <ActiveComponent
+          record={selectedAction.record}
+          isOpen
+          onClose={() => setSelectedAction(null)}
+        />
+      )}
+    </>
+  );
+}

--- a/javascript/packages/core/components/actions/actions-buttons/types.ts
+++ b/javascript/packages/core/components/actions/actions-buttons/types.ts
@@ -1,0 +1,7 @@
+import type { ActionConfig, Data } from '#core/components/actions/types';
+
+export type PartitionedActions<T extends Data> = {
+  primary: ActionConfig<T> | undefined;
+  secondary: ActionConfig<T>[];
+  tertiary: ActionConfig<T>[];
+};

--- a/javascript/packages/core/components/actions/actions-buttons/utils.ts
+++ b/javascript/packages/core/components/actions/actions-buttons/utils.ts
@@ -1,0 +1,16 @@
+import type { ActionConfig, Data } from '#core/components/actions/types';
+import type { PartitionedActions } from './types';
+
+/**
+ * Splits an actions array by hierarchy level. Actions without an explicit
+ * hierarchy default to tertiary (overflow menu).
+ */
+export function partitionActions<T extends Data>(
+  actions: ActionConfig<T>[]
+): PartitionedActions<T> {
+  return {
+    primary: actions.find((a) => a.hierarchy === 'primary'),
+    secondary: actions.filter((a) => a.hierarchy === 'secondary'),
+    tertiary: actions.filter((a) => !a.hierarchy || a.hierarchy === 'tertiary'),
+  };
+}

--- a/javascript/packages/core/components/actions/actions-buttons/utils.ts
+++ b/javascript/packages/core/components/actions/actions-buttons/utils.ts
@@ -1,3 +1,5 @@
+import { ActionHierarchy } from '#core/components/actions/types';
+
 import type { ActionConfig, Data } from '#core/components/actions/types';
 import type { PartitionedActions } from './types';
 
@@ -9,8 +11,8 @@ export function partitionActions<T extends Data>(
   actions: ActionConfig<T>[]
 ): PartitionedActions<T> {
   return {
-    primary: actions.find((a) => a.hierarchy === 'primary'),
-    secondary: actions.filter((a) => a.hierarchy === 'secondary'),
-    tertiary: actions.filter((a) => !a.hierarchy || a.hierarchy === 'tertiary'),
+    primary: actions.find((a) => a.hierarchy === ActionHierarchy.PRIMARY),
+    secondary: actions.filter((a) => a.hierarchy === ActionHierarchy.SECONDARY),
+    tertiary: actions.filter((a) => !a.hierarchy || a.hierarchy === ActionHierarchy.TERTIARY),
   };
 }

--- a/javascript/packages/core/components/actions/types.ts
+++ b/javascript/packages/core/components/actions/types.ts
@@ -42,9 +42,9 @@ type ActionTriggerDisplay = {
 };
 
 export enum ActionHierarchy {
-  primary = 'primary',
-  secondary = 'secondary',
-  tertiary = 'tertiary',
+  PRIMARY = 'primary',
+  SECONDARY = 'secondary',
+  TERTIARY = 'tertiary',
 }
 
 export type Data = Record<string, unknown>;

--- a/javascript/packages/core/components/actions/types.ts
+++ b/javascript/packages/core/components/actions/types.ts
@@ -20,6 +20,15 @@ export type ActionConfigBase = {
    * @see {@link ActionTriggerDisplay}
    */
   display: ActionTriggerDisplay;
+
+  /**
+   * Visual hierarchy of the action's trigger button
+   *
+   * @note Actions without an explicit hierarchy default to tertiary (overflow menu).
+   *
+   * @see {@link ActionHierarchy}
+   */
+  hierarchy?: ActionHierarchy;
 };
 
 /**
@@ -31,6 +40,12 @@ type ActionTriggerDisplay = {
   label: string;
   icon?: string;
 };
+
+export enum ActionHierarchy {
+  primary = 'primary',
+  secondary = 'secondary',
+  tertiary = 'tertiary',
+}
 
 export type Data = Record<string, unknown>;
 

--- a/javascript/packages/core/components/views/detail-view/components/detail-view-header/detail-view-header.tsx
+++ b/javascript/packages/core/components/views/detail-view/components/detail-view-header/detail-view-header.tsx
@@ -1,6 +1,7 @@
 import { useStyletron } from 'baseui';
 import { Button, KIND, SHAPE, SIZE } from 'baseui/button';
 
+import { ActionsButtons } from '#core/components/actions/actions-buttons/actions-buttons';
 import { Icon } from '#core/components/icon/icon';
 import { ELLIPSIS_STYLES } from '#core/styles/constants';
 import { DetailHeaderContainer } from './styled-components';
@@ -8,7 +9,15 @@ import { DetailHeaderContainer } from './styled-components';
 import type { Theme } from 'baseui/theme';
 import type { DetailViewHeaderProps } from './types';
 
-export function DetailViewHeader({ subtitle, title, onGoBack, children }: DetailViewHeaderProps) {
+export function DetailViewHeader({
+  subtitle,
+  title,
+  onGoBack,
+  children,
+  actions,
+  record,
+  loading,
+}: DetailViewHeaderProps) {
   const [css, theme] = useStyletron();
 
   return (
@@ -18,6 +27,7 @@ export function DetailViewHeader({ subtitle, title, onGoBack, children }: Detail
           display: 'flex',
           gap: theme.sizing.scale800,
           justifyContent: 'flex-start',
+          alignItems: 'center',
         })}
       >
         <h5 className={css({ margin: 0, maxWidth: '50%' })}>
@@ -62,6 +72,11 @@ export function DetailViewHeader({ subtitle, title, onGoBack, children }: Detail
             </div>
           </div>
         </h5>
+        {actions && (
+          <div className={css({ marginLeft: 'auto', flexShrink: 0 })}>
+            <ActionsButtons actions={actions} record={record ?? {}} loading={loading} />
+          </div>
+        )}
       </div>
 
       {children}

--- a/javascript/packages/core/components/views/detail-view/detail-view.tsx
+++ b/javascript/packages/core/components/views/detail-view/detail-view.tsx
@@ -10,12 +10,22 @@ export function DetailView({
   onGoBack,
   headerContent,
   children,
+  actions,
+  record,
+  loading,
 }: DetailViewProps) {
   const [css, theme] = useStyletron();
 
   return (
     <div className={css({ display: 'flex', flexDirection: 'column', gap: theme.sizing.scale800 })}>
-      <DetailViewHeader title={title} subtitle={subtitle} onGoBack={onGoBack}>
+      <DetailViewHeader
+        title={title}
+        subtitle={subtitle}
+        onGoBack={onGoBack}
+        actions={actions}
+        record={record}
+        loading={loading}
+      >
         {headerContent}
       </DetailViewHeader>
 

--- a/javascript/packages/core/components/views/detail-view/types/detail-view-component-types.ts
+++ b/javascript/packages/core/components/views/detail-view/types/detail-view-component-types.ts
@@ -1,3 +1,5 @@
+import type { ActionConfig, Data } from '#core/components/actions/types';
+
 export interface DetailViewProps extends DetailHeaderBaseProps {
   /**
    * Content displayed at the bottom of the header container
@@ -18,6 +20,10 @@ export interface DetailHeaderBaseProps {
    */
   title?: string;
   onGoBack?: () => void;
+
+  actions?: ActionConfig[];
+  record?: Data;
+  loading?: boolean;
 }
 
 export interface DetailViewTab {

--- a/javascript/packages/core/components/views/detail-view/types/detail-view-component-types.ts
+++ b/javascript/packages/core/components/views/detail-view/types/detail-view-component-types.ts
@@ -1,4 +1,4 @@
-import type { ActionConfig, Data } from '#core/components/actions/types';
+import type { ActionConfig } from '#core/components/actions/types';
 
 export interface DetailViewProps extends DetailHeaderBaseProps {
   /**
@@ -21,8 +21,17 @@ export interface DetailHeaderBaseProps {
   title?: string;
   onGoBack?: () => void;
 
+  /**
+   * Configuration for set of action buttons that render within the header. These actions
+   * operate on the currently viewed entity record. For example, a "Delete" action would delete
+   * the currently viewed entity.
+   */
   actions?: ActionConfig[];
-  record?: Data;
+
+  /** The data for the currently viewed entity. */
+  record?: Record<string, unknown>;
+
+  /** Loading state for the currently viewed entity. Indicates that record data may be incomplete. */
   loading?: boolean;
 }
 

--- a/javascript/packages/core/config/entities/pipeline/detail.ts
+++ b/javascript/packages/core/config/entities/pipeline/detail.ts
@@ -1,0 +1,43 @@
+import { CellType } from '#core/components/cell/constants';
+import { SHARED_RUN_CELL_CONFIG } from '#core/config/entities/run/shared';
+import { PIPELINE_STATE_CELL, PIPELINE_TYPE_CELL } from './shared';
+
+import type { DetailViewConfig } from '#core/components/views/types';
+
+export const PIPELINE_DETAIL_CONFIG: DetailViewConfig = {
+  type: 'detail',
+  metadata: [
+    { id: 'metadata.creationTimestamp.seconds', label: 'Created', type: CellType.DATE },
+    { id: 'spec.owner.name', label: 'Owner', type: CellType.TEXT },
+    PIPELINE_TYPE_CELL,
+    { id: 'spec.commit.branch', label: 'Branch', type: CellType.TEXT },
+    PIPELINE_STATE_CELL,
+  ],
+  pages: [
+    {
+      id: 'runs',
+      label: 'Pipeline Runs',
+      type: 'table',
+      queryConfig: {
+        endpoint: 'list',
+        service: 'pipelineRun',
+        serviceOptions: {
+          listOptions: {
+            // Filter runs to only those belonging to the current pipeline
+            labelSelector: 'pipeline.michelangelo/name=${page.metadata.name}',
+          },
+        },
+      },
+      tableConfig: {
+        columns: [
+          {
+            id: 'metadata.name',
+            label: 'Name',
+            url: '/${studio.projectId}/${studio.phase}/runs/${row.metadata.name}',
+          },
+          ...SHARED_RUN_CELL_CONFIG,
+        ],
+      },
+    },
+  ],
+};

--- a/javascript/packages/core/config/entities/pipeline/list.ts
+++ b/javascript/packages/core/config/entities/pipeline/list.ts
@@ -9,6 +9,10 @@ export const PIPELINE_CELL_CONFIG: ColumnConfig<object>[] = [
     id: 'metadata.name',
     label: 'Name',
     url: '/${studio.projectId}/${studio.phase}/pipelines/${data.metadata.name}',
+    tooltip: {
+      content: 'Click to filter by this pipeline name',
+      action: 'filter',
+    },
   },
   { id: 'metadata.creationTimestamp.seconds', label: 'Created', type: CellType.DATE },
   PIPELINE_TYPE_CELL,

--- a/javascript/packages/core/config/entities/pipeline/list.ts
+++ b/javascript/packages/core/config/entities/pipeline/list.ts
@@ -1,4 +1,5 @@
 import { CellType } from '#core/components/cell/constants';
+import { PIPELINE_STATE_CELL, PIPELINE_TYPE_CELL } from './shared';
 
 import type { ColumnConfig } from '#core/components/table/types/column-types';
 import type { ListViewConfig } from '#core/components/views/types';
@@ -7,60 +8,16 @@ export const PIPELINE_CELL_CONFIG: ColumnConfig<object>[] = [
   {
     id: 'metadata.name',
     label: 'Name',
-    // url: '/${studio.projectId}/${studio.phase}/pipelines/${data.metadata.name}',
-    tooltip: {
-      content: 'Click to filter by this pipeline name',
-      action: 'filter',
-    },
+    url: '/${studio.projectId}/${studio.phase}/pipelines/${data.metadata.name}',
   },
   { id: 'metadata.creationTimestamp.seconds', label: 'Created', type: CellType.DATE },
-  {
-    id: 'spec.type',
-    label: 'Type',
-    type: CellType.TYPE,
-    typeTextMap: {
-      0: 'Invalid',
-      1: 'Train',
-      2: 'Evaluation',
-      3: 'Performance Evaluation',
-      4: 'Experiment',
-      5: 'Retrain',
-      6: 'Prediction',
-      7: 'Performance Monitoring',
-      8: 'Basis Feature',
-      9: 'Data Prep',
-      10: 'Online Offline Feature Consistency',
-      11: 'Feature Group Compute',
-      12: 'Online Offline Feature Consistency Orchestration',
-      13: 'Post Processing',
-      14: 'Optimization',
-      15: 'Scorer',
-    },
-  },
+  PIPELINE_TYPE_CELL,
   {
     id: 'spec.commit.branch',
     label: 'Branch',
     type: CellType.TEXT,
   },
-  {
-    id: 'status.state',
-    label: 'State',
-    type: CellType.STATE,
-    stateTextMap: {
-      0: 'Invalid',
-      1: 'Created',
-      2: 'Building',
-      3: 'Ready',
-      4: 'Error',
-    },
-    stateColorMap: {
-      0: 'red',
-      1: 'green',
-      2: 'yellow',
-      3: 'green',
-      4: 'red',
-    },
-  },
+  PIPELINE_STATE_CELL,
 ];
 
 export const PIPELINE_LIST_CONFIG: ListViewConfig<object> = {

--- a/javascript/packages/core/config/entities/pipeline/pipeline.ts
+++ b/javascript/packages/core/config/entities/pipeline/pipeline.ts
@@ -1,3 +1,4 @@
+import { ActionHierarchy } from '#core/components/actions/types';
 import { CreatePipelineRunForm } from './create-pipeline-run-form';
 import { PIPELINE_DETAIL_CONFIG } from './detail';
 import { PIPELINE_LIST_CONFIG } from './list';
@@ -14,7 +15,7 @@ export const PIPELINE_ENTITY_CONFIG: PhaseEntityConfig = {
     {
       display: { label: 'Run', icon: 'playerPlay' },
       component: CreatePipelineRunForm,
-      hierarchy: 'primary',
+      hierarchy: ActionHierarchy.PRIMARY,
     },
   ],
 };

--- a/javascript/packages/core/config/entities/pipeline/pipeline.ts
+++ b/javascript/packages/core/config/entities/pipeline/pipeline.ts
@@ -1,4 +1,5 @@
 import { CreatePipelineRunForm } from './create-pipeline-run-form';
+import { PIPELINE_DETAIL_CONFIG } from './detail';
 import { PIPELINE_LIST_CONFIG } from './list';
 
 import type { PhaseEntityConfig } from '#core/types/common/studio-types';
@@ -8,11 +9,12 @@ export const PIPELINE_ENTITY_CONFIG: PhaseEntityConfig = {
   name: 'Pipelines',
   service: 'pipeline',
   state: 'active',
-  views: [PIPELINE_LIST_CONFIG],
+  views: [PIPELINE_LIST_CONFIG, PIPELINE_DETAIL_CONFIG],
   actions: [
     {
       display: { label: 'Run', icon: 'playerPlay' },
       component: CreatePipelineRunForm,
+      hierarchy: 'primary',
     },
   ],
 };

--- a/javascript/packages/core/config/entities/pipeline/shared.ts
+++ b/javascript/packages/core/config/entities/pipeline/shared.ts
@@ -2,38 +2,17 @@ import { CellType } from '#core/components/cell/constants';
 
 import type { Cell } from '#core/components/cell/types';
 
-export const PIPELINE_TYPE_TEXT_MAP: Record<number, string> = {
-  0: 'Invalid',
-  1: 'Train',
-  2: 'Evaluation',
-  3: 'Performance Evaluation',
-  4: 'Experiment',
-  5: 'Retrain',
-  6: 'Prediction',
-  7: 'Performance Monitoring',
-  8: 'Basis Feature',
-  9: 'Data Prep',
-  10: 'Online Offline Feature Consistency',
-  11: 'Feature Group Compute',
-  12: 'Online Offline Feature Consistency Orchestration',
-  13: 'Post Processing',
-  14: 'Optimization',
-  15: 'Scorer',
-};
-
-export const PIPELINE_STATE_TEXT_MAP: Record<number, string> = {
-  0: 'Invalid',
-  1: 'Created',
-  2: 'Building',
-  3: 'Ready',
-  4: 'Error',
-};
-
 export const PIPELINE_STATE_CELL: Cell = {
   id: 'status.state',
   label: 'State',
   type: CellType.STATE,
-  stateTextMap: PIPELINE_STATE_TEXT_MAP,
+  stateTextMap: {
+    0: 'Invalid',
+    1: 'Created',
+    2: 'Building',
+    3: 'Ready',
+    4: 'Error',
+  },
   stateColorMap: {
     0: 'red',
     1: 'green',
@@ -47,5 +26,22 @@ export const PIPELINE_TYPE_CELL: Cell = {
   id: 'spec.type',
   label: 'Type',
   type: CellType.TYPE,
-  typeTextMap: PIPELINE_TYPE_TEXT_MAP,
+  typeTextMap: {
+    0: 'Invalid',
+    1: 'Train',
+    2: 'Evaluation',
+    3: 'Performance Evaluation',
+    4: 'Experiment',
+    5: 'Retrain',
+    6: 'Prediction',
+    7: 'Performance Monitoring',
+    8: 'Basis Feature',
+    9: 'Data Prep',
+    10: 'Online Offline Feature Consistency',
+    11: 'Feature Group Compute',
+    12: 'Online Offline Feature Consistency Orchestration',
+    13: 'Post Processing',
+    14: 'Optimization',
+    15: 'Scorer',
+  },
 };

--- a/javascript/packages/core/config/entities/pipeline/shared.ts
+++ b/javascript/packages/core/config/entities/pipeline/shared.ts
@@ -1,0 +1,51 @@
+import { CellType } from '#core/components/cell/constants';
+
+import type { Cell } from '#core/components/cell/types';
+
+export const PIPELINE_TYPE_TEXT_MAP: Record<number, string> = {
+  0: 'Invalid',
+  1: 'Train',
+  2: 'Evaluation',
+  3: 'Performance Evaluation',
+  4: 'Experiment',
+  5: 'Retrain',
+  6: 'Prediction',
+  7: 'Performance Monitoring',
+  8: 'Basis Feature',
+  9: 'Data Prep',
+  10: 'Online Offline Feature Consistency',
+  11: 'Feature Group Compute',
+  12: 'Online Offline Feature Consistency Orchestration',
+  13: 'Post Processing',
+  14: 'Optimization',
+  15: 'Scorer',
+};
+
+export const PIPELINE_STATE_TEXT_MAP: Record<number, string> = {
+  0: 'Invalid',
+  1: 'Created',
+  2: 'Building',
+  3: 'Ready',
+  4: 'Error',
+};
+
+export const PIPELINE_STATE_CELL: Cell = {
+  id: 'status.state',
+  label: 'State',
+  type: CellType.STATE,
+  stateTextMap: PIPELINE_STATE_TEXT_MAP,
+  stateColorMap: {
+    0: 'red',
+    1: 'green',
+    2: 'yellow',
+    3: 'green',
+    4: 'red',
+  },
+};
+
+export const PIPELINE_TYPE_CELL: Cell = {
+  id: 'spec.type',
+  label: 'Type',
+  type: CellType.TYPE,
+  typeTextMap: PIPELINE_TYPE_TEXT_MAP,
+};

--- a/javascript/packages/core/router/__tests__/entity-detail-route.test.tsx
+++ b/javascript/packages/core/router/__tests__/entity-detail-route.test.tsx
@@ -18,6 +18,7 @@ import {
 } from '../__fixtures__/phase-config-factory';
 import { EntityDetailRoute } from '../entity-detail-route';
 
+import type { ActionComponentProps } from '#core/components/actions/types';
 import type {
   CustomDetailPageConfig,
   TableDetailPageConfig,
@@ -713,5 +714,70 @@ describe('EntityDetailRoute', () => {
       'href',
       '/myproject/train/runs/run-2?page=test-trigger-123'
     );
+  });
+
+  test('renders entity-level actions in the detail page header', async () => {
+    const user = userEvent.setup();
+    const RunDialog = ({ isOpen, onClose }: ActionComponentProps) =>
+      isOpen ? (
+        <div role="dialog">
+          Run form <button onClick={onClose}>Close</button>
+        </div>
+      ) : null;
+
+    const testPhases = {
+      train: buildPhase({
+        id: 'train',
+        entities: [
+          buildEntity({
+            actions: [
+              {
+                display: { label: 'Run', icon: 'playerPlay' },
+                component: RunDialog,
+                hierarchy: 'primary',
+              },
+            ],
+            views: [
+              {
+                type: 'detail',
+                metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
+                pages: [
+                  {
+                    id: 'execution',
+                    label: 'Execution',
+                    ...buildExecutionSchema(),
+                  },
+                ],
+              },
+            ],
+          }),
+        ],
+      }),
+    };
+
+    const mockRequest = vi.fn().mockResolvedValue({
+      pipelineRun: {
+        metadata: { creationTimestamp: { seconds: 1640995200 } },
+        status: { state: 'SUCCESS', steps: [] },
+      },
+    });
+
+    render(
+      <EntityDetailRoute phases={testPhases} />,
+      buildWrapper([
+        getErrorProviderWrapper(),
+        getRouterWrapper({ location: '/myproject/train/runs/run-123' }),
+        getServiceProviderWrapper({ request: mockRequest }),
+      ])
+    );
+
+    const runButton = await screen.findByRole('button', { name: 'Run' });
+    expect(runButton).toBeInTheDocument();
+
+    await user.click(runButton);
+    expect(await screen.findByRole('dialog')).toHaveTextContent('Run form');
+
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 });

--- a/javascript/packages/core/router/__tests__/entity-detail-route.test.tsx
+++ b/javascript/packages/core/router/__tests__/entity-detail-route.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 
+import { ActionHierarchy } from '#core/components/actions/types';
 import { CellType } from '#core/components/cell/constants';
 import { buildTableConfigFactory } from '#core/components/views/__fixtures__/table-config-factory';
 import { buildExecutionSchemaFactory } from '#core/components/views/execution/__fixtures__/execution-schema-factory';
@@ -734,7 +735,7 @@ describe('EntityDetailRoute', () => {
               {
                 display: { label: 'Run', icon: 'playerPlay' },
                 component: RunDialog,
-                hierarchy: 'primary',
+                hierarchy: ActionHierarchy.PRIMARY,
               },
             ],
             views: [

--- a/javascript/packages/core/router/entity-detail-route.tsx
+++ b/javascript/packages/core/router/entity-detail-route.tsx
@@ -15,6 +15,7 @@ import { useStudioQuery } from '#core/hooks/use-studio-query';
 import { useInterpolationResolver } from '#core/interpolation/use-interpolation-resolver';
 import { capitalizeFirstLetter } from '#core/utils/string-utils';
 
+import type { ActionConfig } from '#core/components/actions/types';
 import type { PhaseConfig } from '#core/types/common/studio-types';
 
 /**
@@ -103,6 +104,9 @@ export function EntityDetailRoute({ phases = PHASES }: { phases?: Record<string,
       subtitle={entityConfig!.name}
       title={entityId}
       onGoBack={returnToEntityList}
+      actions={entityConfig!.actions as ActionConfig[] | undefined}
+      record={entityData}
+      loading={isLoading}
       headerContent={
         <Row items={resolvedDetailViewConfig!.metadata} record={entityData} loading={isLoading} />
       }

--- a/javascript/packages/rpc/handlers.ts
+++ b/javascript/packages/rpc/handlers.ts
@@ -14,6 +14,9 @@ async function createHandlers() {
     GetProject: services.ProjectService.getProject as ExtractUnaryRpc<
       typeof services.ProjectService.getProject
     >,
+    GetPipeline: services.PipelineService.getPipeline as ExtractUnaryRpc<
+      typeof services.PipelineService.getPipeline
+    >,
     ListPipeline: services.PipelineService.listPipeline as ExtractUnaryRpc<
       typeof services.PipelineService.listPipeline
     >,


### PR DESCRIPTION
The per-row actions system rendered actions only in table views. Detail pages had no way to surface entity-level actions, requiring users to navigate back to the list to trigger operations like Run.

DetailViewHeader now accepts actions from the entity config and renders them using ActionsButtons with the same hierarchy system (primary/secondary/tertiary). EntityDetailRoute wires entity config actions through to the detail view automatically.

Pipeline detail page serves as the first consumer: the Run button opens CreatePipelineRunForm from the header. Shared pipeline cell configs (type, state) were extracted to avoid duplication between list and detail views.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
<img width="1200" height="854" alt="visual-verify-target-default" src="https://github.com/user-attachments/assets/f0d2306b-1a5d-41d0-8ec7-ab571429a9ad" />


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
