### PR TITLE
Add trigger configuration support for mactl pipeline create

### DIFF
--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/create.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/create.py
@@ -205,6 +205,11 @@ def convert_crd_metadata_pipeline_create(
         "resourceVersion": "0",
         "uid": str(uuid4()),
     }
+    
+    # Process trigger configurations if present
+    trigger_map = yaml_dict.get("spec", {}).get("triggerMap")
+    if trigger_map:
+        res["spec"]["manifest"]["triggerMap"] = populate_pipeline_spec_with_trigger_configs(trigger_map)
 
     return populate_pipeline_spec_with_workflow_inputs(
         res,
@@ -272,6 +277,98 @@ def handle_workflow_inputs_retrieval(
             "Unexpected registration failure, continuing without uniflow artifacts"
         )
     return workflow_inputs, uniflow_tar_path, workflow_function_name
+
+
+def populate_pipeline_spec_with_trigger_configs(trigger_map: dict) -> dict:
+    """Convert triggerMap from YAML to protobuf-compatible structure.
+    
+    Processes trigger configurations including cron schedules, batch policies,
+    parameters, and concurrency settings for each trigger.
+    
+    Args:
+        trigger_map: Dictionary mapping trigger names to trigger configurations from YAML
+        
+    Returns:
+        Dictionary containing processed trigger configurations ready for protobuf
+        
+    Example YAML structure:
+        triggerMap:
+          training-trigger-cron-every-minute:
+            cronSchedule:
+              cron: "* * * * *"
+            batchPolicy:
+              batchSize: 1
+              wait: "60s"
+            parametersMap:
+              param-set-1:
+                kwArgs:
+                  key: value
+            maxConcurrency: 1
+    """
+    if not trigger_map:
+        _LOG.info("No triggers defined in pipeline spec")
+        return {}
+    
+    converted_trigger_map = {}
+    
+    for trigger_name, trigger_config in trigger_map.items():
+        _LOG.info(f"Processing trigger: {trigger_name}")
+        
+        # Validate that at least one of batchPolicy or maxConcurrency is present
+        has_batch_policy = "batchPolicy" in trigger_config
+        has_max_concurrency = "maxConcurrency" in trigger_config
+        
+        if not has_batch_policy and not has_max_concurrency:
+            raise ValueError(
+                f"Trigger '{trigger_name}' must specify at least one of "
+                "'batchPolicy' or 'maxConcurrency' to control execution"
+            )
+        
+        converted_trigger = {}
+        
+        # Process cron schedule
+        if "cronSchedule" in trigger_config:
+            converted_trigger["cronSchedule"] = {
+                "cron": trigger_config["cronSchedule"]["cron"]
+            }
+        
+        # Process interval schedule
+        if "intervalSchedule" in trigger_config:
+            converted_trigger["intervalSchedule"] = {
+                "interval": trigger_config["intervalSchedule"]["interval"]
+            }
+        
+        # Process batch policy
+        if has_batch_policy:
+            batch_policy = {}
+            
+            # Validate that both batchSize and wait are present
+            if "batchSize" not in trigger_config["batchPolicy"]:
+                raise ValueError(
+                    f"Trigger '{trigger_name}': batchPolicy must include 'batchSize'"
+                )
+            if "wait" not in trigger_config["batchPolicy"]:
+                raise ValueError(
+                    f"Trigger '{trigger_name}': batchPolicy must include 'wait'"
+                )
+            
+            batch_policy["batchSize"] = trigger_config["batchPolicy"]["batchSize"]
+            batch_policy["wait"] = trigger_config["batchPolicy"]["wait"]
+            converted_trigger["batchPolicy"] = batch_policy
+        
+        # Process max concurrency
+        if has_max_concurrency:
+            converted_trigger["maxConcurrency"] = trigger_config["maxConcurrency"]
+
+        # Process parameters map
+        if "parametersMap" in trigger_config:
+            converted_trigger["parametersMap"] = trigger_config["parametersMap"]
+        
+        converted_trigger_map[trigger_name] = converted_trigger
+        _LOG.info(f"Successfully processed trigger: {trigger_name}")
+    
+    _LOG.info(f"Processed {len(trigger_map)} triggers for pipeline manifest")
+    return converted_trigger_map
 
 
 def populate_pipeline_spec_with_workflow_inputs(

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/create.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/create.py
@@ -206,13 +206,6 @@ def convert_crd_metadata_pipeline_create(
         "uid": str(uuid4()),
     }
 
-    # Process trigger configurations if present
-    trigger_map = yaml_dict.get("spec", {}).get("triggerMap")
-    if trigger_map:
-        res["spec"]["manifest"]["triggerMap"] = (
-            populate_pipeline_spec_with_trigger_configs(trigger_map)
-        )
-
     return populate_pipeline_spec_with_workflow_inputs(
         res,
         yaml_dict,
@@ -387,6 +380,13 @@ def populate_pipeline_spec_with_workflow_inputs(
 ) -> dict:
     """Populate pipeline spec with workflow inputs."""
     res["spec"] = deepcopy(yaml_dict["spec"])
+
+    trigger_map = None
+    if "manifest" in res["spec"] and "triggerMap" in res["spec"]["manifest"]:
+        trigger_map = populate_pipeline_spec_with_trigger_configs(
+            res["spec"]["manifest"]["triggerMap"]
+        )
+
     res["spec"]["commit"] = {
         "branch": repo.active_branch.name,
         "git_ref": repo.head.commit.hexsha,
@@ -399,6 +399,10 @@ def populate_pipeline_spec_with_workflow_inputs(
         "filePath": config_file_relative_path,
         "type": "PIPELINE_MANIFEST_TYPE_UNIFLOW",
     }
+
+    if trigger_map:
+        res["spec"]["manifest"]["triggerMap"] = trigger_map
+
     res["spec"]["owner"] = {"name": get_user_name()}
 
     # Add uniflow artifacts if registration succeeded

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/create.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/create.py
@@ -205,11 +205,13 @@ def convert_crd_metadata_pipeline_create(
         "resourceVersion": "0",
         "uid": str(uuid4()),
     }
-    
+
     # Process trigger configurations if present
     trigger_map = yaml_dict.get("spec", {}).get("triggerMap")
     if trigger_map:
-        res["spec"]["manifest"]["triggerMap"] = populate_pipeline_spec_with_trigger_configs(trigger_map)
+        res["spec"]["manifest"]["triggerMap"] = (
+            populate_pipeline_spec_with_trigger_configs(trigger_map)
+        )
 
     return populate_pipeline_spec_with_workflow_inputs(
         res,
@@ -281,16 +283,17 @@ def handle_workflow_inputs_retrieval(
 
 def populate_pipeline_spec_with_trigger_configs(trigger_map: dict) -> dict:
     """Convert triggerMap from YAML to protobuf-compatible structure.
-    
+
     Processes trigger configurations including cron schedules, batch policies,
     parameters, and concurrency settings for each trigger.
-    
+
     Args:
-        trigger_map: Dictionary mapping trigger names to trigger configurations from YAML
-        
+        trigger_map: Dictionary mapping trigger names to trigger configurations
+            from YAML
+
     Returns:
         Dictionary containing processed trigger configurations ready for protobuf
-        
+
     Example YAML structure:
         triggerMap:
           training-trigger-cron-every-minute:
@@ -308,40 +311,40 @@ def populate_pipeline_spec_with_trigger_configs(trigger_map: dict) -> dict:
     if not trigger_map:
         _LOG.info("No triggers defined in pipeline spec")
         return {}
-    
+
     converted_trigger_map = {}
-    
+
     for trigger_name, trigger_config in trigger_map.items():
         _LOG.info(f"Processing trigger: {trigger_name}")
-        
+
         # Validate that at least one of batchPolicy or maxConcurrency is present
         has_batch_policy = "batchPolicy" in trigger_config
         has_max_concurrency = "maxConcurrency" in trigger_config
-        
+
         if not has_batch_policy and not has_max_concurrency:
             raise ValueError(
                 f"Trigger '{trigger_name}' must specify at least one of "
                 "'batchPolicy' or 'maxConcurrency' to control execution"
             )
-        
+
         converted_trigger = {}
-        
+
         # Process cron schedule
         if "cronSchedule" in trigger_config:
             converted_trigger["cronSchedule"] = {
                 "cron": trigger_config["cronSchedule"]["cron"]
             }
-        
+
         # Process interval schedule
         if "intervalSchedule" in trigger_config:
             converted_trigger["intervalSchedule"] = {
                 "interval": trigger_config["intervalSchedule"]["interval"]
             }
-        
+
         # Process batch policy
         if has_batch_policy:
             batch_policy = {}
-            
+
             # Validate that both batchSize and wait are present
             if "batchSize" not in trigger_config["batchPolicy"]:
                 raise ValueError(
@@ -351,11 +354,11 @@ def populate_pipeline_spec_with_trigger_configs(trigger_map: dict) -> dict:
                 raise ValueError(
                     f"Trigger '{trigger_name}': batchPolicy must include 'wait'"
                 )
-            
+
             batch_policy["batchSize"] = trigger_config["batchPolicy"]["batchSize"]
             batch_policy["wait"] = trigger_config["batchPolicy"]["wait"]
             converted_trigger["batchPolicy"] = batch_policy
-        
+
         # Process max concurrency
         if has_max_concurrency:
             converted_trigger["maxConcurrency"] = trigger_config["maxConcurrency"]
@@ -363,10 +366,10 @@ def populate_pipeline_spec_with_trigger_configs(trigger_map: dict) -> dict:
         # Process parameters map
         if "parametersMap" in trigger_config:
             converted_trigger["parametersMap"] = trigger_config["parametersMap"]
-        
+
         converted_trigger_map[trigger_name] = converted_trigger
         _LOG.info(f"Successfully processed trigger: {trigger_name}")
-    
+
     _LOG.info(f"Processed {len(trigger_map)} triggers for pipeline manifest")
     return converted_trigger_map
 

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/create_test.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/create_test.py
@@ -571,7 +571,10 @@ class PipelineCreateTest(TestCase):
         self.assertIn("intervalSchedule", result["trigger-2"])
 
     def test_validation_missing_both_batch_policy_and_max_concurrency(self):
-        """Test validation fails when neither batchPolicy nor maxConcurrency is present."""
+        """Test validation fails when neither batchPolicy nor maxConcurrency is present.
+
+        Ensures proper validation error when trigger lacks execution control.
+        """
         trigger_map = {
             "invalid-trigger": {
                 "cronSchedule": {"cron": "0 0 * * *"},
@@ -633,4 +636,3 @@ class PipelineCreateTest(TestCase):
         self.assertIn("maxConcurrency", result["dual-control"])
         self.assertEqual(result["dual-control"]["batchPolicy"]["batchSize"], 5)
         self.assertEqual(result["dual-control"]["maxConcurrency"], 3)
-

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/create_test.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/create_test.py
@@ -14,6 +14,7 @@ from michelangelo.cli.mactl.plugins.entity.pipeline.create import (
     convert_crd_metadata_pipeline_create,
     get_pipeline_config_and_tar,
     handle_workflow_inputs_retrieval,
+    populate_pipeline_spec_with_trigger_configs,
     populate_pipeline_spec_with_workflow_inputs,
 )
 
@@ -453,3 +454,183 @@ class PipelineCreateTest(TestCase):
                 )
 
             self.assertIn("Error parsing uniflow input JSON", str(context.exception))
+
+    def test_empty_trigger_map(self):
+        """Test with empty trigger map returns empty dict."""
+        result = populate_pipeline_spec_with_trigger_configs({})
+        self.assertEqual(result, {})
+
+    def test_none_trigger_map(self):
+        """Test with None trigger map returns empty dict."""
+        result = populate_pipeline_spec_with_trigger_configs(None)
+        self.assertEqual(result, {})
+
+    def test_trigger_with_cron_and_max_concurrency(self):
+        """Test trigger with cron schedule and maxConcurrency."""
+        trigger_map = {
+            "daily-training": {
+                "cronSchedule": {"cron": "0 8 * * *"},
+                "maxConcurrency": 1,
+            }
+        }
+
+        result = populate_pipeline_spec_with_trigger_configs(trigger_map)
+
+        self.assertIn("daily-training", result)
+        self.assertEqual(result["daily-training"]["cronSchedule"]["cron"], "0 8 * * *")
+        self.assertEqual(result["daily-training"]["maxConcurrency"], 1)
+
+    def test_trigger_with_cron_and_batch_policy(self):
+        """Test trigger with cron schedule and batchPolicy."""
+        trigger_map = {
+            "every-minute": {
+                "cronSchedule": {"cron": "* * * * *"},
+                "batchPolicy": {"batchSize": 5, "wait": "60s"},
+            }
+        }
+
+        result = populate_pipeline_spec_with_trigger_configs(trigger_map)
+
+        self.assertIn("every-minute", result)
+        self.assertEqual(result["every-minute"]["cronSchedule"]["cron"], "* * * * *")
+        self.assertEqual(result["every-minute"]["batchPolicy"]["batchSize"], 5)
+        self.assertEqual(result["every-minute"]["batchPolicy"]["wait"], "60s")
+
+    def test_trigger_with_interval_schedule(self):
+        """Test trigger with interval schedule."""
+        trigger_map = {
+            "hourly-job": {
+                "intervalSchedule": {"interval": "1h"},
+                "maxConcurrency": 2,
+            }
+        }
+
+        result = populate_pipeline_spec_with_trigger_configs(trigger_map)
+
+        self.assertIn("hourly-job", result)
+        self.assertEqual(result["hourly-job"]["intervalSchedule"]["interval"], "1h")
+        self.assertEqual(result["hourly-job"]["maxConcurrency"], 2)
+
+    def test_trigger_with_parameters_map(self):
+        """Test trigger with parametersMap."""
+        trigger_map = {
+            "training-with-params": {
+                "cronSchedule": {"cron": "0 2 * * *"},
+                "maxConcurrency": 3,
+                "parametersMap": {
+                    "sst2-test": {
+                        "kwArgs": {
+                            "path": "glue",
+                            "name": "sst2",
+                            "tokenizer_max_length": 256,
+                        }
+                    },
+                    "cola-test": {
+                        "kwArgs": {
+                            "path": "glue",
+                            "name": "cola",
+                            "tokenizer_max_length": 128,
+                        }
+                    },
+                },
+            }
+        }
+
+        result = populate_pipeline_spec_with_trigger_configs(trigger_map)
+
+        self.assertIn("training-with-params", result)
+        self.assertIn("parametersMap", result["training-with-params"])
+        self.assertIn("sst2-test", result["training-with-params"]["parametersMap"])
+        self.assertIn("cola-test", result["training-with-params"]["parametersMap"])
+        self.assertEqual(
+            result["training-with-params"]["parametersMap"]["sst2-test"]["kwArgs"][
+                "tokenizer_max_length"
+            ],
+            256,
+        )
+
+    def test_multiple_triggers(self):
+        """Test multiple triggers in the map."""
+        trigger_map = {
+            "trigger-1": {
+                "cronSchedule": {"cron": "* * * * *"},
+                "maxConcurrency": 1,
+            },
+            "trigger-2": {
+                "intervalSchedule": {"interval": "30m"},
+                "batchPolicy": {"batchSize": 3, "wait": "30s"},
+            },
+        }
+
+        result = populate_pipeline_spec_with_trigger_configs(trigger_map)
+
+        self.assertEqual(len(result), 2)
+        self.assertIn("trigger-1", result)
+        self.assertIn("trigger-2", result)
+        self.assertIn("cronSchedule", result["trigger-1"])
+        self.assertIn("intervalSchedule", result["trigger-2"])
+
+    def test_validation_missing_both_batch_policy_and_max_concurrency(self):
+        """Test validation fails when neither batchPolicy nor maxConcurrency is present."""
+        trigger_map = {
+            "invalid-trigger": {
+                "cronSchedule": {"cron": "0 0 * * *"},
+            }
+        }
+
+        with self.assertRaises(ValueError) as context:
+            populate_pipeline_spec_with_trigger_configs(trigger_map)
+
+        self.assertIn("invalid-trigger", str(context.exception))
+        self.assertIn("must specify at least one of", str(context.exception))
+        self.assertIn("batchPolicy", str(context.exception))
+        self.assertIn("maxConcurrency", str(context.exception))
+
+    def test_validation_batch_policy_missing_batch_size(self):
+        """Test validation fails when batchPolicy is missing batchSize."""
+        trigger_map = {
+            "incomplete-batch": {
+                "cronSchedule": {"cron": "0 0 * * *"},
+                "batchPolicy": {"wait": "60s"},
+            }
+        }
+
+        with self.assertRaises(ValueError) as context:
+            populate_pipeline_spec_with_trigger_configs(trigger_map)
+
+        self.assertIn("incomplete-batch", str(context.exception))
+        self.assertIn("batchPolicy must include 'batchSize'", str(context.exception))
+
+    def test_validation_batch_policy_missing_wait(self):
+        """Test validation fails when batchPolicy is missing wait."""
+        trigger_map = {
+            "incomplete-batch": {
+                "cronSchedule": {"cron": "0 0 * * *"},
+                "batchPolicy": {"batchSize": 5},
+            }
+        }
+
+        with self.assertRaises(ValueError) as context:
+            populate_pipeline_spec_with_trigger_configs(trigger_map)
+
+        self.assertIn("incomplete-batch", str(context.exception))
+        self.assertIn("batchPolicy must include 'wait'", str(context.exception))
+
+    def test_trigger_with_both_batch_policy_and_max_concurrency(self):
+        """Test trigger can have both batchPolicy and maxConcurrency."""
+        trigger_map = {
+            "dual-control": {
+                "cronSchedule": {"cron": "0 0 * * *"},
+                "batchPolicy": {"batchSize": 5, "wait": "60s"},
+                "maxConcurrency": 3,
+            }
+        }
+
+        result = populate_pipeline_spec_with_trigger_configs(trigger_map)
+
+        self.assertIn("dual-control", result)
+        self.assertIn("batchPolicy", result["dual-control"])
+        self.assertIn("maxConcurrency", result["dual-control"])
+        self.assertEqual(result["dual-control"]["batchPolicy"]["batchSize"], 5)
+        self.assertEqual(result["dual-control"]["maxConcurrency"], 3)
+

--- a/python/michelangelo/cli/sandbox/demo/pipeline/training-pipeline-with-trigger.yaml
+++ b/python/michelangelo/cli/sandbox/demo/pipeline/training-pipeline-with-trigger.yaml
@@ -1,0 +1,46 @@
+apiVersion: michelangelo.api/v2
+kind: Pipeline
+metadata:
+  name: training-pipeline-with-trigger
+  namespace: ma-dev-test
+  annotations:
+   michelangelo/uniflow-image: docker.io/library/examples:latest
+spec:
+  description: Training pipeline for my ML project
+  owner:
+    name: yangfan
+  type: PIPELINE_TYPE_TRAIN
+  manifest:
+    type: PIPELINE_MANIFEST_TYPE_UNIFLOW
+    filePath: examples.bert_cola.bert_cola
+    uniflowTar: s3://default/bert_local.tar
+    triggerMap:
+      training-trigger-cron-every-minute:
+        cronSchedule:
+          cron: "* * * * *"
+        batchPolicy:
+          batchSize: 1
+          wait: "60s"
+        parametersMap:
+          sst2-test:
+            kwArgs:
+              path: 'glue'
+              name: 'sst2'
+              tokenizer_max_length: 256
+          mrpc-test:
+            kwArgs:
+              path: 'glue'
+              name: 'mrpc'
+              tokenizer_max_length: 128
+          cola-test:
+            kwArgs:
+              path: 'glue'
+              name: 'cola'
+              tokenizer_max_length: 128
+      training-trigger-cron-daily-at-8am:
+        cronSchedule:
+          cron: "0 8 * * *"
+        maxConcurrency: 1
+  commit:
+    gitRef: "main"
+    branch: "main"


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
Added support for pipeline trigger configurations in mactl pipeline create command:
- Implemented populate_pipeline_spec_with_trigger_configs() function to parse and convert trigger definitions from YAML to protobuf format
- Added support for cron schedules, interval schedules, batch policies, parameters maps, and max concurrency settings
- Added validation to ensure triggers have proper execution control (batchPolicy or maxConcurrency)
- Added 11 comprehensive unit tests covering all trigger configuration scenarios and validation edge cases


<!-- Tell your future self why have you made these changes -->
**Why?**
To enable users to define pipeline triggers directly in the pipeline YAML manifest, so trigger run creation will be supported through UI and mactl trigger run.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

- Added 11 unit tests in create_test.py covering:
  - Empty and None trigger maps
  - Cron and interval schedules
  - Batch policies with validation
  - Parameters maps
  - Max concurrency settings
  - Multiple triggers
  - All validation error cases
- Tested with example YAML file training-pipeline-with-trigger.yaml
  - Set up MA sandbox environment locally
  - Run `ma pipeline apply -f  michelangelo/cli/sandbox/demo/pipeline/training-pipeline-with-trigger.yaml` to register pipeline with trigger configuration
  - Confirm  the json CR registered successfully
[registered-training-pipeline-with-trigger.json](https://github.com/user-attachments/files/26393282/registered-training-pipeline-with-trigger.json)
   
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Old pipeline created without trigger configs and with trigger running need to be reconfigured

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
Pipeline triggers are now defined in the pipeline YAML manifest using the triggerMap field. Supports cron schedules, interval schedules, batch policies, and dynamic parameters.

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
Will update with trigger docs