### PR TITLE
[MaCTL] Change plugin import timing earlier and preparation for module level override

### DIFF
--- a/python/michelangelo/cli/mactl/mactl.py
+++ b/python/michelangelo/cli/mactl/mactl.py
@@ -288,7 +288,7 @@ def discover_all_plugins() -> dict[str, list[object]]:
     _LOG.info("Discovering all entity plugins...")
 
     registry: dict[str, list[object]] = {}
-    plugin_dirs = [str(DEFAULT_DIR_PLUGINS), *_CONFIG["plugin"]["dirs"]]
+    plugin_dirs = [str(DEFAULT_DIR_PLUGINS), *_CONFIG.get("plugin", {}).get("dirs", [])]
 
     for plugin_dir_path in plugin_dirs:
         plugin_dir = Path(plugin_dir_path)

--- a/python/michelangelo/cli/mactl/mactl.py
+++ b/python/michelangelo/cli/mactl/mactl.py
@@ -272,6 +272,139 @@ def check_crd(crd: CRD, user_command_action: str) -> None:
         sys.exit(1)
 
 
+def discover_all_plugins() -> dict[str, list[object]]:
+    """Discover and import all entity plugins early.
+
+    Scans all plugin directories and imports all entity plugin modules,
+    but does NOT apply them yet (lazy application).
+
+    Returns:
+        dict[str, list[object]]: Plugin registry mapping entity names to modules
+        Example: {
+            'pipeline': [pipeline_plugin_module_0, pipeline_plugin_module_1],
+            'pipeline_run': [pipeline_run_plugin_module_0],
+        }
+    """
+    _LOG.info("Discovering all entity plugins...")
+
+    registry: dict[str, list[object]] = {}
+    plugin_dirs = [str(DEFAULT_DIR_PLUGINS), *_CONFIG["plugin"]["dirs"]]
+
+    for plugin_dir_path in plugin_dirs:
+        plugin_dir = Path(plugin_dir_path)
+        entity_base = plugin_dir / "entity"
+
+        if not entity_base.exists() or not entity_base.is_dir():
+            _LOG.debug("Plugin entity directory not found: %r", entity_base)
+            continue
+
+        _LOG.debug("Scanning plugin directory: %r", entity_base)
+
+        for entity_dir in entity_base.iterdir():
+            if not entity_dir.is_dir():
+                continue
+
+            entity_name = entity_dir.name
+
+            if entity_name.startswith("__"):
+                continue
+
+            _LOG.debug("Found entity plugin: %s", entity_name)
+
+            plugin_module = read_module_from_file(
+                entity_name,
+                plugin_dir,
+                len(registry.get(entity_name, []))
+            )
+
+            if plugin_module is not None:
+                if entity_name not in registry:
+                    registry[entity_name] = []
+                registry[entity_name].append(plugin_module)
+                _LOG.info("Registered plugin for entity '%s'", entity_name)
+
+    _LOG.info(
+        "Plugin discovery complete. Found plugins for %d entities: %s",
+        len(registry),
+        list(registry.keys())
+    )
+
+    return registry
+
+
+def apply_entity_plugins(
+    crd: CRD,
+    channel: Channel,
+    plugin_registry: dict[str, list[object]]
+) -> None:
+    """Apply entity-level plugins from pre-loaded registry.
+
+    Args:
+        crd: CRD instance for the selected entity
+        channel: gRPC channel
+        plugin_registry: Pre-loaded plugin modules from discover_all_plugins()
+    """
+    plugins = plugin_registry.get(crd.name, [])
+
+    if not plugins:
+        _LOG.debug("No entity plugins found for '%s'", crd.name)
+        return
+
+    _LOG.info("Applying %d entity plugin(s) for '%s'", len(plugins), crd.name)
+
+    for i, plugin in enumerate(plugins):
+        _LOG.debug("Applying entity plugin #%d: %r", i, plugin)
+        if hasattr(plugin, "apply_plugins"):
+            plugin.apply_plugins(crd, channel)
+        else:
+            _LOG.debug(
+                "Plugin module %r has no 'apply_plugins' function (skipped)",
+                plugin
+            )
+
+    _LOG.info("Entity plugins applied for '%s'", crd.name)
+
+
+def apply_command_plugins(
+    crd: CRD,
+    action: str,
+    crds: dict[str, CRD],
+    channel: Channel,
+    plugin_registry: dict[str, list[object]]
+) -> None:
+    """Apply command-level plugins from pre-loaded registry.
+
+    Args:
+        crd: CRD instance for the selected entity
+        action: User command action (e.g., "apply", "run")
+        crds: All CRD instances
+        channel: gRPC channel
+        plugin_registry: Pre-loaded plugin modules
+    """
+    plugins = plugin_registry.get(crd.name, [])
+
+    if not plugins:
+        _LOG.debug("No command plugins found for '%s'", crd.name)
+        return
+
+    _LOG.info(
+        "Applying %d command plugin(s) for '%s.%s'",
+        len(plugins), crd.name, action
+    )
+
+    for i, plugin in enumerate(plugins):
+        _LOG.debug("Applying command plugin #%d: %r", i, plugin)
+        if hasattr(plugin, "apply_plugin_command"):
+            plugin.apply_plugin_command(crd, action, crds, channel)
+        else:
+            _LOG.debug(
+                "Plugin module %r has no 'apply_plugin_command' function (skipped)",
+                plugin
+            )
+
+    _LOG.info("Command plugins applied for '%s.%s'", crd.name, action)
+
+
 def discover_crds(channel: Channel) -> dict[str, CRD]:
     """Discover CRDs from the API server."""
     services = list_services(channel, METADATA)
@@ -320,8 +453,13 @@ def handle_crd_action_help(crd: CRD, remaining: list[str]) -> None:
         sys.exit(0)
 
 
-def main(channel: Channel):
-    """Main function for mactl."""
+def main(channel: Channel, plugin_registry: dict[str, list[object]]):
+    """Main function for mactl.
+
+    Args:
+        channel: gRPC channel
+        plugin_registry: Pre-loaded plugin modules from discover_all_plugins()
+    """
     _LOG.debug("Starting mactl...")
 
     # Load config and set environment variables
@@ -334,10 +472,11 @@ def main(channel: Channel):
     namespace, remaining = pre_parse_args(crds)
     user_command_crd = str(namespace.entity)
 
-    # Load plugins for target CRD
-    read_plugins(
+    # Apply entity-level plugins from registry
+    apply_entity_plugins(
         crds[user_command_crd],
         channel,
+        plugin_registry
     )
 
     # Handle CRD-level help (e.g., "ma project --help" or "ma project -h")
@@ -347,12 +486,13 @@ def main(channel: Channel):
     user_command_action = kebab_to_snake(remaining[0])
     check_crd(crds[user_command_crd], user_command_action)
 
-    # Load target function plugin
-    read_plugin_command(
+    # Apply command-level plugins from registry
+    apply_command_plugins(
         crds[user_command_crd],
         user_command_action,
         crds,
         channel,
+        plugin_registry
     )
 
     _LOG.debug(
@@ -395,6 +535,11 @@ def _is_service_name(address: str) -> bool:
 
 def run():
     """Entry point for mactl."""
+    # Discover all plugins early (before connection)
+    _LOG.info("Discovering all plugins...")
+    plugin_registry = discover_all_plugins()
+    _LOG.info("Plugin discovery complete")
+
     proxy_module_path = _CONFIG["plugin"].get("proxy", "")
 
     if _is_service_name(ADDRESS) and proxy_module_path:
@@ -413,7 +558,7 @@ def run():
         )
         # Use secure TLS connection
         with secure_channel(ADDRESS, ssl_channel_credentials()) as channel:
-            return main(channel)
+            return main(channel, plugin_registry)
 
     _LOG.info(
         "Using insecure connection (MACTL_USE_TLS=%r) to connect to %r",
@@ -422,7 +567,7 @@ def run():
     )
     # Use insecure connection for local development
     with insecure_channel(ADDRESS) as channel:
-        return main(channel)
+        return main(channel, plugin_registry)
 
 
 if __name__ == "__main__":

--- a/python/michelangelo/cli/mactl/mactl.py
+++ b/python/michelangelo/cli/mactl/mactl.py
@@ -312,9 +312,7 @@ def discover_all_plugins() -> dict[str, list[object]]:
             _LOG.debug("Found entity plugin: %s", entity_name)
 
             plugin_module = read_module_from_file(
-                entity_name,
-                plugin_dir,
-                len(registry.get(entity_name, []))
+                entity_name, plugin_dir, len(registry.get(entity_name, []))
             )
 
             if plugin_module is not None:
@@ -326,16 +324,14 @@ def discover_all_plugins() -> dict[str, list[object]]:
     _LOG.info(
         "Plugin discovery complete. Found plugins for %d entities: %s",
         len(registry),
-        list(registry.keys())
+        list(registry.keys()),
     )
 
     return registry
 
 
 def apply_entity_plugins(
-    crd: CRD,
-    channel: Channel,
-    plugin_registry: dict[str, list[object]]
+    crd: CRD, channel: Channel, plugin_registry: dict[str, list[object]]
 ) -> None:
     """Apply entity-level plugins from pre-loaded registry.
 
@@ -358,8 +354,7 @@ def apply_entity_plugins(
             plugin.apply_plugins(crd, channel)
         else:
             _LOG.debug(
-                "Plugin module %r has no 'apply_plugins' function (skipped)",
-                plugin
+                "Plugin module %r has no 'apply_plugins' function (skipped)", plugin
             )
 
     _LOG.info("Entity plugins applied for '%s'", crd.name)
@@ -370,7 +365,7 @@ def apply_command_plugins(
     action: str,
     crds: dict[str, CRD],
     channel: Channel,
-    plugin_registry: dict[str, list[object]]
+    plugin_registry: dict[str, list[object]],
 ) -> None:
     """Apply command-level plugins from pre-loaded registry.
 
@@ -388,8 +383,7 @@ def apply_command_plugins(
         return
 
     _LOG.info(
-        "Applying %d command plugin(s) for '%s.%s'",
-        len(plugins), crd.name, action
+        "Applying %d command plugin(s) for '%s.%s'", len(plugins), crd.name, action
     )
 
     for i, plugin in enumerate(plugins):
@@ -399,7 +393,7 @@ def apply_command_plugins(
         else:
             _LOG.debug(
                 "Plugin module %r has no 'apply_plugin_command' function (skipped)",
-                plugin
+                plugin,
             )
 
     _LOG.info("Command plugins applied for '%s.%s'", crd.name, action)
@@ -473,11 +467,7 @@ def main(channel: Channel, plugin_registry: dict[str, list[object]]):
     user_command_crd = str(namespace.entity)
 
     # Apply entity-level plugins from registry
-    apply_entity_plugins(
-        crds[user_command_crd],
-        channel,
-        plugin_registry
-    )
+    apply_entity_plugins(crds[user_command_crd], channel, plugin_registry)
 
     # Handle CRD-level help (e.g., "ma project --help" or "ma project -h")
     handle_crd_action_help(crds[user_command_crd], remaining)
@@ -488,11 +478,7 @@ def main(channel: Channel, plugin_registry: dict[str, list[object]]):
 
     # Apply command-level plugins from registry
     apply_command_plugins(
-        crds[user_command_crd],
-        user_command_action,
-        crds,
-        channel,
-        plugin_registry
+        crds[user_command_crd], user_command_action, crds, channel, plugin_registry
     )
 
     _LOG.debug(

--- a/python/michelangelo/cli/mactl/mactl_test.py
+++ b/python/michelangelo/cli/mactl/mactl_test.py
@@ -920,10 +920,15 @@ PLUGIN_TEST_DIR_2 = PLUGIN_TEST_DIR / "plugins_2"
 class DiscoverAllPluginsTest(TestCase):
     """Tests for discover_all_plugins function."""
 
-    @patch("michelangelo.cli.mactl.mactl._CONFIG", {"plugin": {"dirs": [str(PLUGIN_TEST_DIR_1)]}})
+    @patch(
+        "michelangelo.cli.mactl.mactl._CONFIG",
+        {"plugin": {"dirs": [str(PLUGIN_TEST_DIR_1)]}},
+    )
     def test_discovers_plugins_from_configured_dirs(self):
         """Core: discovers entity plugins from configured plugin directories."""
-        with patch("michelangelo.cli.mactl.mactl.DEFAULT_DIR_PLUGINS", Path("/nonexistent")):
+        with patch(
+            "michelangelo.cli.mactl.mactl.DEFAULT_DIR_PLUGINS", Path("/nonexistent")
+        ):
             registry = discover_all_plugins()
 
         self.assertIn("pipeline", registry)
@@ -934,18 +939,23 @@ class DiscoverAllPluginsTest(TestCase):
     @patch("michelangelo.cli.mactl.mactl._CONFIG", {"plugin": {"dirs": []}})
     def test_returns_empty_registry_when_no_entity_dir(self):
         """Edge: returns empty registry when plugin dir has no entity/ subdirectory."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with patch("michelangelo.cli.mactl.mactl.DEFAULT_DIR_PLUGINS", Path(tmpdir)):
-                registry = discover_all_plugins()
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            patch("michelangelo.cli.mactl.mactl.DEFAULT_DIR_PLUGINS", Path(tmpdir)),
+        ):
+            registry = discover_all_plugins()
 
         self.assertEqual(registry, {})
 
-    @patch("michelangelo.cli.mactl.mactl._CONFIG", {
-        "plugin": {"dirs": [str(PLUGIN_TEST_DIR_1), str(PLUGIN_TEST_DIR_2)]}
-    })
+    @patch(
+        "michelangelo.cli.mactl.mactl._CONFIG",
+        {"plugin": {"dirs": [str(PLUGIN_TEST_DIR_1), str(PLUGIN_TEST_DIR_2)]}},
+    )
     def test_accumulates_plugins_from_multiple_dirs(self):
         """Edge: accumulates plugins from multiple configured directories."""
-        with patch("michelangelo.cli.mactl.mactl.DEFAULT_DIR_PLUGINS", Path("/nonexistent")):
+        with patch(
+            "michelangelo.cli.mactl.mactl.DEFAULT_DIR_PLUGINS", Path("/nonexistent")
+        ):
             registry = discover_all_plugins()
 
         self.assertIn("pipeline", registry)
@@ -954,7 +964,9 @@ class DiscoverAllPluginsTest(TestCase):
     @patch("michelangelo.cli.mactl.mactl._CONFIG", {})
     def test_returns_empty_registry_when_plugin_config_missing(self):
         """Edge: returns empty registry when plugin config key is absent."""
-        with patch("michelangelo.cli.mactl.mactl.DEFAULT_DIR_PLUGINS", Path("/nonexistent")):
+        with patch(
+            "michelangelo.cli.mactl.mactl.DEFAULT_DIR_PLUGINS", Path("/nonexistent")
+        ):
             registry = discover_all_plugins()
 
         self.assertEqual(registry, {})
@@ -1005,9 +1017,13 @@ class ApplyCommandPluginsTest(TestCase):
         mock_crds = {"pipeline": mock_crd}
         mock_plugin = MagicMock(spec=["apply_plugin_command"])
 
-        apply_command_plugins(mock_crd, "create", mock_crds, mock_channel, {"pipeline": [mock_plugin]})
+        apply_command_plugins(
+            mock_crd, "create", mock_crds, mock_channel, {"pipeline": [mock_plugin]}
+        )
 
-        mock_plugin.apply_plugin_command.assert_called_once_with(mock_crd, "create", mock_crds, mock_channel)
+        mock_plugin.apply_plugin_command.assert_called_once_with(
+            mock_crd, "create", mock_crds, mock_channel
+        )
 
     def test_no_op_when_entity_not_in_registry(self):
         """Edge: does nothing when entity has no plugins in registry."""
@@ -1015,7 +1031,9 @@ class ApplyCommandPluginsTest(TestCase):
         mock_crd.name = "model"
         mock_plugin = MagicMock(spec=["apply_plugin_command"])
 
-        apply_command_plugins(mock_crd, "create", {}, MagicMock(), {"pipeline": [mock_plugin]})
+        apply_command_plugins(
+            mock_crd, "create", {}, MagicMock(), {"pipeline": [mock_plugin]}
+        )
 
         mock_plugin.apply_plugin_command.assert_not_called()
 
@@ -1025,5 +1043,7 @@ class ApplyCommandPluginsTest(TestCase):
         mock_crd.name = "pipeline"
         mock_plugin = MagicMock(spec=[])  # no apply_plugin_command
 
-        apply_command_plugins(mock_crd, "create", {}, MagicMock(), {"pipeline": [mock_plugin]})
+        apply_command_plugins(
+            mock_crd, "create", {}, MagicMock(), {"pipeline": [mock_plugin]}
+        )
         # no exception raised, plugin silently skipped

--- a/python/michelangelo/cli/mactl/mactl_test.py
+++ b/python/michelangelo/cli/mactl/mactl_test.py
@@ -7,7 +7,7 @@ from importlib import reload
 from inspect import Parameter
 from pathlib import Path
 from unittest import TestCase
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import ANY, MagicMock, Mock, patch
 
 from michelangelo.cli.mactl import mactl
 from michelangelo.cli.mactl.crd import CRD
@@ -15,8 +15,11 @@ from michelangelo.cli.mactl.mactl import (
     ADDRESS,
     DEFAULT_DIR_PLUGINS,
     _is_service_name,
+    apply_command_plugins,
+    apply_entity_plugins,
     check_crd,
     create_serivce_classes,
+    discover_all_plugins,
     discover_crds,
     handle_crd_action_help,
     pre_parse_args,
@@ -881,7 +884,7 @@ class ProxySupportTest(TestCase):
             run()
 
         mock_insecure_channel.assert_called_once_with("localhost:8080")
-        mock_main.assert_called_once_with(mock_channel)
+        mock_main.assert_called_once_with(mock_channel, ANY)
 
     @patch("michelangelo.cli.mactl.mactl.main")
     @patch("michelangelo.cli.mactl.mactl.insecure_channel")
@@ -907,4 +910,120 @@ class ProxySupportTest(TestCase):
             run()
 
         mock_insecure_channel.assert_called_once_with("my-service")
-        mock_main.assert_called_once_with(mock_channel)
+        mock_main.assert_called_once_with(mock_channel, ANY)
+
+
+PLUGIN_TEST_DIR_1 = PLUGIN_TEST_DIR / "plugins_1"
+PLUGIN_TEST_DIR_2 = PLUGIN_TEST_DIR / "plugins_2"
+
+
+class DiscoverAllPluginsTest(TestCase):
+    """Tests for discover_all_plugins function."""
+
+    @patch("michelangelo.cli.mactl.mactl._CONFIG", {"plugin": {"dirs": [str(PLUGIN_TEST_DIR_1)]}})
+    def test_discovers_plugins_from_configured_dirs(self):
+        """Core: discovers entity plugins from configured plugin directories."""
+        with patch("michelangelo.cli.mactl.mactl.DEFAULT_DIR_PLUGINS", Path("/nonexistent")):
+            registry = discover_all_plugins()
+
+        self.assertIn("pipeline", registry)
+        self.assertEqual(len(registry["pipeline"]), 1)
+        self.assertTrue(hasattr(registry["pipeline"][0], "apply_plugins"))
+        self.assertTrue(hasattr(registry["pipeline"][0], "apply_plugin_command"))
+
+    @patch("michelangelo.cli.mactl.mactl._CONFIG", {"plugin": {"dirs": []}})
+    def test_returns_empty_registry_when_no_entity_dir(self):
+        """Edge: returns empty registry when plugin dir has no entity/ subdirectory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("michelangelo.cli.mactl.mactl.DEFAULT_DIR_PLUGINS", Path(tmpdir)):
+                registry = discover_all_plugins()
+
+        self.assertEqual(registry, {})
+
+    @patch("michelangelo.cli.mactl.mactl._CONFIG", {
+        "plugin": {"dirs": [str(PLUGIN_TEST_DIR_1), str(PLUGIN_TEST_DIR_2)]}
+    })
+    def test_accumulates_plugins_from_multiple_dirs(self):
+        """Edge: accumulates plugins from multiple configured directories."""
+        with patch("michelangelo.cli.mactl.mactl.DEFAULT_DIR_PLUGINS", Path("/nonexistent")):
+            registry = discover_all_plugins()
+
+        self.assertIn("pipeline", registry)
+        self.assertEqual(len(registry["pipeline"]), 2)
+
+    @patch("michelangelo.cli.mactl.mactl._CONFIG", {})
+    def test_returns_empty_registry_when_plugin_config_missing(self):
+        """Edge: returns empty registry when plugin config key is absent."""
+        with patch("michelangelo.cli.mactl.mactl.DEFAULT_DIR_PLUGINS", Path("/nonexistent")):
+            registry = discover_all_plugins()
+
+        self.assertEqual(registry, {})
+
+
+class ApplyEntityPluginsTest(TestCase):
+    """Tests for apply_entity_plugins function."""
+
+    def test_calls_apply_plugins_on_matching_entity(self):
+        """Core: calls apply_plugins() on plugin module matching the entity."""
+        mock_crd = MagicMock()
+        mock_crd.name = "pipeline"
+        mock_channel = MagicMock()
+        mock_plugin = MagicMock(spec=["apply_plugins"])
+
+        apply_entity_plugins(mock_crd, mock_channel, {"pipeline": [mock_plugin]})
+
+        mock_plugin.apply_plugins.assert_called_once_with(mock_crd, mock_channel)
+
+    def test_no_op_when_entity_not_in_registry(self):
+        """Edge: does nothing when entity has no plugins in registry."""
+        mock_crd = MagicMock()
+        mock_crd.name = "model"
+        mock_plugin = MagicMock(spec=["apply_plugins"])
+
+        apply_entity_plugins(mock_crd, MagicMock(), {"pipeline": [mock_plugin]})
+
+        mock_plugin.apply_plugins.assert_not_called()
+
+    def test_skips_plugin_without_apply_plugins_function(self):
+        """Edge: skips plugin module that has no apply_plugins attribute."""
+        mock_crd = MagicMock()
+        mock_crd.name = "pipeline"
+        mock_plugin = MagicMock(spec=[])  # no apply_plugins
+
+        apply_entity_plugins(mock_crd, MagicMock(), {"pipeline": [mock_plugin]})
+        # no exception raised, plugin silently skipped
+
+
+class ApplyCommandPluginsTest(TestCase):
+    """Tests for apply_command_plugins function."""
+
+    def test_calls_apply_plugin_command_on_matching_entity(self):
+        """Core: calls apply_plugin_command() on plugin module matching the entity."""
+        mock_crd = MagicMock()
+        mock_crd.name = "pipeline"
+        mock_channel = MagicMock()
+        mock_crds = {"pipeline": mock_crd}
+        mock_plugin = MagicMock(spec=["apply_plugin_command"])
+
+        apply_command_plugins(mock_crd, "create", mock_crds, mock_channel, {"pipeline": [mock_plugin]})
+
+        mock_plugin.apply_plugin_command.assert_called_once_with(mock_crd, "create", mock_crds, mock_channel)
+
+    def test_no_op_when_entity_not_in_registry(self):
+        """Edge: does nothing when entity has no plugins in registry."""
+        mock_crd = MagicMock()
+        mock_crd.name = "model"
+        mock_plugin = MagicMock(spec=["apply_plugin_command"])
+
+        apply_command_plugins(mock_crd, "create", {}, MagicMock(), {"pipeline": [mock_plugin]})
+
+        mock_plugin.apply_plugin_command.assert_not_called()
+
+    def test_skips_plugin_without_apply_plugin_command_function(self):
+        """Edge: skips plugin module that has no apply_plugin_command attribute."""
+        mock_crd = MagicMock()
+        mock_crd.name = "pipeline"
+        mock_plugin = MagicMock(spec=[])  # no apply_plugin_command
+
+        apply_command_plugins(mock_crd, "create", {}, MagicMock(), {"pipeline": [mock_plugin]})
+        # no exception raised, plugin silently skipped

--- a/python/michelangelo/cli/mactl/mactl_test.py
+++ b/python/michelangelo/cli/mactl/mactl_test.py
@@ -713,20 +713,20 @@ class MainFunctionTest(TestCase):
     @patch("michelangelo.cli.mactl.mactl.setup_minio_env")
     @patch("michelangelo.cli.mactl.mactl.discover_crds")
     @patch("michelangelo.cli.mactl.mactl.pre_parse_args")
-    @patch("michelangelo.cli.mactl.mactl.read_plugins")
+    @patch("michelangelo.cli.mactl.mactl.apply_entity_plugins")
     @patch("michelangelo.cli.mactl.mactl.handle_crd_action_help")
     @patch("michelangelo.cli.mactl.mactl.kebab_to_snake")
     @patch("michelangelo.cli.mactl.mactl.check_crd")
-    @patch("michelangelo.cli.mactl.mactl.read_plugin_command")
+    @patch("michelangelo.cli.mactl.mactl.apply_command_plugins")
     @patch("michelangelo.cli.mactl.mactl.ArgumentParser")
     def test_main_basic_execution_flow(
         self,
         mock_arg_parser_class,
-        mock_read_plugin_command,
+        mock_apply_command_plugins,
         mock_check_crd,
         mock_kebab_to_snake,
         mock_handle_crd_action_help,
-        mock_read_plugins,
+        mock_apply_entity_plugins,
         mock_pre_parse_args,
         mock_discover_crds,
         mock_setup_minio_env,
@@ -734,6 +734,9 @@ class MainFunctionTest(TestCase):
         """Test basic execution flow of main() function."""
         # Setup mock channel
         mock_channel = MagicMock()
+
+        # Setup mock plugin registry
+        mock_plugin_registry = {"project": [MagicMock()]}
 
         # Setup mock CRD
         mock_crd = MagicMock(spec=CRD)
@@ -754,8 +757,8 @@ class MainFunctionTest(TestCase):
         mock_parser_instance.parse_args.return_value = Namespace(name="test")
         mock_arg_parser_class.return_value = mock_parser_instance
 
-        # Execute main
-        mactl.main(mock_channel)
+        # Execute main with plugin_registry
+        mactl.main(mock_channel, mock_plugin_registry)
 
         # Verify Phase 1: Load config and discover CRDs
         mock_setup_minio_env.assert_called_once()
@@ -764,8 +767,10 @@ class MainFunctionTest(TestCase):
         # Verify Phase 2: Pre-parse arguments
         mock_pre_parse_args.assert_called_once_with({"project": mock_crd})
 
-        # Verify Phase 2: Load plugins for target CRD
-        mock_read_plugins.assert_called_once_with(mock_crd, mock_channel)
+        # Verify Phase 2: Apply entity plugins from registry
+        mock_apply_entity_plugins.assert_called_once_with(
+            mock_crd, mock_channel, mock_plugin_registry
+        )
 
         # Verify Phase 2: Handle CRD-level help
         mock_handle_crd_action_help.assert_called_once_with(
@@ -775,8 +780,8 @@ class MainFunctionTest(TestCase):
         # Verify Phase 3: Generate method and configure argparse
         mock_kebab_to_snake.assert_called_once_with("create")
         mock_check_crd.assert_called_once_with(mock_crd, "create")
-        mock_read_plugin_command.assert_called_once_with(
-            mock_crd, "create", {"project": mock_crd}, mock_channel
+        mock_apply_command_plugins.assert_called_once_with(
+            mock_crd, "create", {"project": mock_crd}, mock_channel, mock_plugin_registry
         )
 
         # Verify ArgumentParser was created and used

--- a/python/michelangelo/cli/mactl/mactl_test.py
+++ b/python/michelangelo/cli/mactl/mactl_test.py
@@ -781,7 +781,11 @@ class MainFunctionTest(TestCase):
         mock_kebab_to_snake.assert_called_once_with("create")
         mock_check_crd.assert_called_once_with(mock_crd, "create")
         mock_apply_command_plugins.assert_called_once_with(
-            mock_crd, "create", {"project": mock_crd}, mock_channel, mock_plugin_registry
+            mock_crd,
+            "create",
+            {"project": mock_crd},
+            mock_channel,
+            mock_plugin_registry,
         )
 
         # Verify ArgumentParser was created and used


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [X] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

1) Search plugins at the earliest timing of ma command.
2) Refactor plugin loading command to prepare the module level plugin override.

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Running ma plugin command in local
 - checked pipeline plugin commands
 - checked pipeline registration with tar file upload

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
