### PR TITLE
Add repository field to core package.json for npm provenance

### DIFF
--- a/javascript/packages/core/package.json
+++ b/javascript/packages/core/package.json
@@ -57,6 +57,10 @@
     "styletron-engine-atomic": "^1.0.0",
     "styletron-react": "^6.1.1"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/michelangelo-ai/michelangelo"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
npm Trusted Publishing (OIDC provenance) validates that the repository URL in package.json matches the GitHub repo the workflow runs from. Without this field the publish step fails with a 422 error.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Manually trigger [NPM publish from craig/core-npm-repository branch](https://github.com/michelangelo-ai/michelangelo/actions/runs/23866446504/job/69586763861). [verison 0.1.16 is published to NPM](https://www.npmjs.com/package/@michelangelo-ai/core)

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
