### PR TITLE
docs: add PR process and testing strategy guides

### DIFF
--- a/docs/contributing/pr-process.md
+++ b/docs/contributing/pr-process.md
@@ -1,0 +1,84 @@
+# PR Process
+
+Contributing to Michelangelo follows a standard fork-and-PR workflow. This guide covers everything from branch creation to merge.
+
+## Before You Open a PR
+
+**For small changes** (typos, obvious single-line bug fixes): open a PR directly.
+
+**For larger changes** (new features, API changes, significant refactors): open a GitHub issue first to discuss the approach. This prevents wasted work if the direction needs to change.
+
+Ensure your branch is current before pushing:
+
+```bash
+git fetch origin
+git rebase origin/main
+```
+
+## Branch Naming
+
+Use descriptive, kebab-case branch names with a short prefix indicating the type of change:
+
+| Prefix | Use for |
+|--------|---------|
+| `feat/` | New features |
+| `fix/` | Bug fixes |
+| `docs/` | Documentation |
+| `refactor/` | Refactors with no behavior change |
+| `test/` | Test additions or fixes |
+
+**Examples**: `feat/spark-dynamic-allocation`, `fix/ray-job-timeout`, `docs/mlflow-integration`
+
+## PR Description
+
+A good PR description lets reviewers understand the change without asking questions. Include:
+
+1. **What** — what does this change do?
+2. **Why** — motivation, or link to the GitHub issue (e.g., `Closes #123`)
+3. **How to test** — steps to verify the change works
+4. **Breaking changes** — any migration steps required (API changes, config field renames, etc.)
+
+## Checks That Must Pass
+
+All of the following must pass before a PR is ready for merge:
+
+```bash
+# Go: build, vet, and test
+bazel build //go/...
+bazel test //go/...
+
+# Python: lint and pre-commit hooks
+cd python
+poetry run pre-commit
+poetry run ruff check .
+poetry run ruff format --check .
+poetry run pytest
+```
+
+All CI checks (GitHub Actions) must also be green. See the [CI Guide](ci.md) for how to interpret failures.
+
+## Review Process
+
+- **At least one approving review** is required before merge
+- **Address all comments** — either implement the suggestion or explain why you disagree. Don't leave comments unresolved
+- **Re-request review** after addressing feedback — don't assume the reviewer will re-check on their own
+- **Resolve conversations** once addressed — use the "Resolve" button rather than just replying
+
+Reviewers will check for:
+- Correctness and test coverage
+- Adherence to the [error handling patterns](dev/go/error-handling.md) for Go code
+- Adherence to [Python coding guidelines](dev/python/mactl/coding_guidelines.md) for Python code
+- Documentation for any new user-facing behavior
+
+## Merging
+
+Maintainers merge approved PRs. Preferred strategies:
+
+- **Squash merge** for feature and fix branches — keeps `main` history clean with one commit per logical change
+- **Merge commit** for branches with meaningful commit history that should be preserved
+
+After merge, delete your branch.
+
+## Stacked PRs
+
+If your change is large, consider splitting it into sequential PRs where each builds on the previous. Open them in order, set the base branch of PR 2 to PR 1's branch, and update the base to `main` after each merge. This makes review faster and reduces merge conflicts.

--- a/docs/contributing/pr-process.md
+++ b/docs/contributing/pr-process.md
@@ -55,7 +55,7 @@ poetry run ruff format --check .
 poetry run pytest
 ```
 
-All CI checks (GitHub Actions) must also be green. See the [CI Guide](ci.md) for how to interpret failures.
+All CI checks (GitHub Actions) must also be green.
 
 ## Review Process
 

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -1,0 +1,111 @@
+# Testing Strategy
+
+Michelangelo uses a three-level test strategy. Understanding when to write each type of test — and how to run them — is the most important thing to know before opening a PR.
+
+## Test Levels
+
+### Unit Tests
+
+Unit tests verify individual functions and types in isolation. They run fast and have no external dependencies.
+
+**Go**: Unit tests live in the same package as the code, in `*_test.go` files.
+
+```bash
+# Run all Go unit tests
+bazel test //go/...
+
+# Run tests for a specific package
+bazel test //go/components/jobs/scheduler/...
+
+# With standard go tooling (from go/ directory)
+go test ./...
+go test ./components/jobs/scheduler/...
+```
+
+Use gomock to mock dependencies. See [Using Go Mocks in Unit Tests](use-go-mocks-in-unit-test.md) for patterns.
+
+**Python**: Unit tests live in `python/tests/`.
+
+```bash
+cd python
+poetry run pytest
+
+# Run a specific test file
+poetry run pytest tests/test_uniflow.py
+
+# With verbose output
+poetry run pytest -v
+```
+
+Use `unittest.mock` or `pytest-mock` for mocking Python dependencies.
+
+### Integration Tests (Sandbox)
+
+Integration tests validate end-to-end flows that require the Michelangelo control plane — API server, controller manager, and worker all running together.
+
+**Setup**: The sandbox creates a local Kubernetes cluster (k3d) with all Michelangelo components:
+
+```bash
+cd python
+poetry run ma sandbox create
+```
+
+This takes a few minutes on first run. See [Sandbox Setup](../getting-started/sandbox-setup.md) for full prerequisites.
+
+**Running**: Submit a workflow or API request against the sandbox and verify the result:
+
+```bash
+# Example: run a Uniflow pipeline locally against the sandbox
+poetry run python my_workflow.py
+
+# Example: use the ma CLI against the sandbox
+poetry run ma pipeline list
+```
+
+Integration tests are most important for:
+- New Uniflow plugins (verify the full Go worker → Starlark → Python round-trip)
+- Controller changes (verify the reconcile loop reaches the expected state)
+- API changes (verify the gRPC endpoint and Kubernetes CRD interact correctly)
+
+### End-to-End Tests
+
+E2E tests run full production-like scenarios — typically a complete pipeline execution from submission to completion — in the sandbox or a staging environment. These run as part of CI on PRs that touch core execution paths.
+
+## What to Test for Each Change Type
+
+| Change type | Required tests |
+|---|---|
+| New Go controller | Unit tests for reconcile logic with mocked K8s client; integration test verifying CRD state transitions |
+| New Uniflow plugin | Unit tests for the Starlark module builtins; integration test submitting a workflow that uses the plugin |
+| New API field (proto) | Unit tests for any validation logic; verify the field round-trips through the API server |
+| Python SDK change | Unit tests for the changed behavior; smoke test with `local run` mode |
+| Bug fix | A regression test that fails on the code before your fix and passes after |
+| Refactor | Existing tests should continue to pass unchanged; add tests for any previously untested paths you discover |
+
+## Running Tests Before a PR
+
+Run this locally before pushing to catch failures early:
+
+```bash
+# Go
+bazel build //go/...
+bazel test //go/...
+
+# Python
+cd python
+poetry run pre-commit
+poetry run ruff check .
+poetry run pytest
+```
+
+The `pre-commit` hook runs lint, formatting, and import checks. Fix any issues it reports before committing.
+
+## Test Coverage
+
+There is no enforced coverage percentage, but reviewers will ask for tests if they're missing for new logic. A good rule of thumb: any code path that has business logic (not just delegation or plumbing) should have a test.
+
+Don't add tests purely for coverage. Focus on testing behavior that could break and would be hard to catch manually.
+
+## Flaky Tests
+
+If a test you didn't touch starts failing intermittently on your PR, check the test's history in CI before assuming your change caused it. Flaky tests should be fixed or quarantined separately — don't work around them in your PR.

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -31,7 +31,7 @@ cd python
 poetry run pytest
 
 # Run a specific test file
-poetry run pytest tests/test_uniflow.py
+poetry run pytest tests/uniflow/core/test_build.py
 
 # With verbose output
 poetry run pytest -v


### PR DESCRIPTION
## Summary

Adds two contributor guides addressing the most common onboarding friction points:

**`contributing/pr-process.md`**
- Branch naming conventions with prefix table
- What to include in a PR description
- Which checks must pass locally before pushing (Go: `bazel test`, Python: `pre-commit` + `pytest`)
- Review expectations (address all comments, re-request review, resolve conversations)
- Merge strategy (squash vs merge commit)
- Guidance on stacked PRs for large changes

**`contributing/testing.md`**
- Three-level test strategy: unit tests, integration tests (sandbox), E2E
- How to run Go and Python tests locally
- Per-change-type table: what tests are required for new controllers, plugins, API fields, bug fixes, refactors
- Test coverage philosophy (behavior over percentage)
- Guidance on flaky tests

Part of the operator/contributor guide improvements proposed in #1033.

🤖 Generated with [Claude Code](https://claude.com/claude-code)