### PR TITLE
Allow any localhost port in sandbox CORS config

### DIFF
--- a/python/michelangelo/cli/sandbox/resources/envoy.yaml
+++ b/python/michelangelo/cli/sandbox/resources/envoy.yaml
@@ -73,8 +73,8 @@ data:
                                 max_grpc_timeout: 0s
                           cors:
                             allow_origin_string_match:
-                              - exact: "http://localhost:5173"
-                              - exact: "http://localhost:8090"
+                              - safe_regex:
+                                  regex: "http://localhost:[0-9]+"
                             allow_methods: "GET, POST, OPTIONS"
                             allow_headers: "content-type,context-ttl-ms,grpc-timeout,rpc-caller,rpc-encoding,rpc-service,x-grpc-web,x-user-agent"
                             max_age: "1728000"


### PR DESCRIPTION
Replace two hardcoded localhost port allowances (5173, 8090) with a regex that matches any localhost port. Removes the need to update the allowlist when running on a non-default dev server port.

**What type of PR is this? (check all applicable)**
- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Applied changes to my sandbox, ensured localhost:8090 (michelangelo-ui sandbox) and localhost:517* (dev ports) could connect to sandbox apiserver. 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
