### PR TITLE
Enable ESLint caching for faster local lint runs

### DIFF
--- a/javascript/.gitignore
+++ b/javascript/.gitignore
@@ -32,6 +32,9 @@ dist-ssr
 # Generated files
 gen/
 
+# ESLint cache
+.eslintcache
+
 # Claude skill eval outputs (generated artifacts — commit only evals.json)
 .claude/skills-workspace/eval-*/
 .claude/skills-workspace/history.json

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -17,7 +17,7 @@
     "dev-production": "yarn workspace @michelangelo-ai/core build && yarn workspace @michelangelo/app dev-production",
     "format": "prettier --check .",
     "generate": "../tools/gen-grpc-client.sh --clients javascript",
-    "lint": "eslint .",
+    "lint": "eslint . --cache",
     "prebuild": "yarn generate",
     "setup": "yarn install --frozen-lockfile && yarn generate",
     "typecheck": "tsc -b && tsc --project tsconfig.vitest.json --noEmit",


### PR DESCRIPTION
ESLint re-lints every file on every run by default. With --cache, results are stored in .eslintcache and only files that have changed since the last run are re-linted.

Measured locally: 16s cold → 1.5s warm (10x).

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
