### PR TITLE
Enable mactl trigger_run create from pipeline triggerMap

### DIFF
--- a/python/michelangelo/cli/mactl/plugins/entity/trigger_run/create.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/trigger_run/create.py
@@ -1,0 +1,219 @@
+"""TriggerRun `create` function plugin module."""
+
+import uuid
+from argparse import ArgumentParser
+from inspect import Parameter, Signature
+from logging import getLogger
+from types import MethodType
+
+from google.protobuf.json_format import MessageToDict, ParseDict
+from grpc import Channel, RpcError, StatusCode
+
+from michelangelo.cli.mactl.crd import (
+    CRD,
+    METADATA_STUB,
+    bind_signature,
+    get_single_arg,
+    inject_func_signature,
+)
+from michelangelo.cli.mactl.utils import get_user_name
+
+_LOG = getLogger(__name__)
+
+
+def add_function_signature(crd: CRD) -> None:
+    """Add function signature for trigger_run create command."""
+    inject_func_signature(
+        crd,
+        "create",
+        {
+            "help": "Create a TriggerRun from a pipeline's trigger configuration.",
+            "args": [
+                {
+                    "func_signature": Parameter(
+                        "namespace",
+                        Parameter.POSITIONAL_OR_KEYWORD,
+                    ),
+                    "args": ["-n", "--namespace"],
+                    "kwargs": {
+                        "type": str,
+                        "required": True,
+                        "help": "Namespace of the pipeline and trigger run",
+                    },
+                },
+                {
+                    "func_signature": Parameter(
+                        "pipeline",
+                        Parameter.POSITIONAL_OR_KEYWORD,
+                    ),
+                    "args": ["-p", "--pipeline"],
+                    "kwargs": {
+                        "type": str,
+                        "required": True,
+                        "help": "Name of the pipeline to create a trigger run for",
+                    },
+                },
+                {
+                    "func_signature": Parameter(
+                        "trigger_name",
+                        Parameter.POSITIONAL_OR_KEYWORD,
+                    ),
+                    "args": ["-t", "--trigger-name"],
+                    "kwargs": {
+                        "type": str,
+                        "required": True,
+                        "help": (
+                            "Name of the trigger from the pipeline's "
+                            "registered triggerMap"
+                        ),
+                    },
+                },
+            ],
+        },
+    )
+
+
+def generate_create(crd: CRD, channel: Channel, parser: ArgumentParser):
+    """Generate create function for trigger_run.
+
+    Creates a TriggerRun CR by fetching the pipeline and extracting
+    the trigger configuration from its triggerMap.
+    """
+    _LOG.info("Generating create function for TriggerRun")
+
+    method_name, input_class, output_class = crd._extract_method_info(
+        channel, crd.full_name, "Create"
+    )
+    crd.configure_parser("create", parser)
+    func_signature = crd._read_signatures("create")
+
+    @bind_signature(func_signature)
+    def create_func(bound_args: Signature):
+        """Implementation of trigger_run create command."""
+        _LOG.info("Bound arguments: %r", bound_args.arguments)
+        _self: CRD = bound_args.arguments["self"]
+        namespace = get_single_arg(bound_args.arguments, "namespace")
+        pipeline_name = get_single_arg(bound_args.arguments, "pipeline")
+        trigger_name = get_single_arg(bound_args.arguments, "trigger_name")
+
+        _LOG.info(
+            f"Creating TriggerRun for pipeline={pipeline_name}, "
+            f"trigger={trigger_name}, namespace={namespace}"
+        )
+
+        # Get pipeline using gRPC directly
+        _LOG.info("Fetching pipeline via gRPC")
+        pipeline_method_name, pipeline_input_class, pipeline_output_class = (
+            _self._extract_method_info(
+                channel, "michelangelo.api.v2.PipelineService", "Get"
+            )
+        )
+        get_pipeline_dict = {
+            "name": pipeline_name,
+            "namespace": namespace,
+        }
+        get_pipeline_request = pipeline_input_class()
+        ParseDict(get_pipeline_dict, get_pipeline_request)
+        pipeline_method_fullname = (
+            f"/michelangelo.api.v2.PipelineService/{pipeline_method_name}"
+        )
+        pipeline_stub_method = channel.unary_unary(
+            pipeline_method_fullname,
+            request_serializer=pipeline_input_class.SerializeToString,
+            response_deserializer=pipeline_output_class.FromString,
+        )
+
+        try:
+            pipeline_response = pipeline_stub_method(
+                get_pipeline_request,
+                metadata=METADATA_STUB,
+                timeout=30,
+            )
+            pipeline = pipeline_response.pipeline
+            _LOG.info(f"Retrieved pipeline: {pipeline.metadata.name}")
+        except RpcError as err:
+            _LOG.error(f"gRPC error getting pipeline {pipeline_name}: {err}")
+            if err.code() == StatusCode.NOT_FOUND:
+                raise ValueError(
+                    f"Pipeline '{pipeline_name}' not found in namespace '{namespace}'"
+                ) from err
+            else:
+                raise RuntimeError(
+                    f"Failed to get pipeline '{pipeline_name}': {err.details()}"
+                ) from err
+
+        if not hasattr(pipeline.spec, "manifest") or not hasattr(
+            pipeline.spec.manifest, "trigger_map"
+        ):
+            raise ValueError(
+                f"Pipeline '{pipeline_name}' does not have any triggers configured"
+            )
+        trigger_map = MessageToDict(
+            pipeline.spec.manifest.trigger_map, preserving_proto_field_name=True
+        )
+
+        if trigger_name not in trigger_map:
+            available_triggers = ", ".join(trigger_map.keys())
+            raise ValueError(
+                f"Trigger '{trigger_name}' not found in pipeline '{pipeline_name}'. "
+                f"Available triggers: {available_triggers}"
+            )
+
+        _LOG.info(f"Found trigger configuration for: {trigger_name}")
+
+        # Generate trigger run dict with configurations
+        trigger_config = trigger_map[trigger_name]
+        random_hex = uuid.uuid4().hex[:8]
+        trigger_run_name = f"{trigger_name}_{random_hex}"
+        trigger_run_dict = {
+            "triggerRun": {
+                "metadata": {
+                    "name": trigger_run_name,
+                    "namespace": namespace,
+                },
+                "spec": {
+                    "pipeline": {"name": pipeline_name, "namespace": namespace},
+                    "sourceTriggerName": trigger_name,
+                    "actor": {"name": get_user_name()},
+                    "trigger": trigger_config,
+                },
+            }
+        }
+
+        request_input = input_class()
+        ParseDict(trigger_run_dict, request_input)
+
+        _LOG.info(
+            "Create request input (%r) ready: %r",
+            type(request_input),
+            request_input,
+        )
+
+        method_fullname = f"/{crd.full_name}/{method_name}"
+        _LOG.info("Method fullname for gRPC call: %s", method_fullname)
+
+        stub_method = channel.unary_unary(
+            method_fullname,
+            request_serializer=input_class.SerializeToString,
+            response_deserializer=output_class.FromString,
+        )
+
+        try:
+            response = stub_method(
+                request_input,
+                metadata=METADATA_STUB,
+                timeout=30,
+            )
+        except RpcError as err:
+            _LOG.error(f"gRPC error creating TriggerRun: {err}")
+            raise RuntimeError(
+                f"Failed to create TriggerRun: {err.details()}"
+            ) from err
+
+        _LOG.info(
+            f"Successfully created TriggerRun: {response.trigger_run.metadata.name}"
+        )
+        return response
+
+    create_func.__signature__ = func_signature
+    crd.create = MethodType(create_func, crd)

--- a/python/michelangelo/cli/mactl/plugins/entity/trigger_run/create.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/trigger_run/create.py
@@ -9,21 +9,19 @@ from types import MethodType
 from google.protobuf.json_format import MessageToDict, ParseDict
 from grpc import Channel, RpcError, StatusCode
 
-from michelangelo.cli.mactl.crd import (
-    CRD,
-    METADATA_STUB,
-    bind_signature,
-    get_single_arg,
-    inject_func_signature,
+import michelangelo.cli.mactl.crd as crd_module
+from michelangelo.cli.mactl.grpc_tools import (
+    get_message_class_by_name,
+    get_methods_from_service,
 )
 from michelangelo.cli.mactl.utils import get_user_name
 
 _LOG = getLogger(__name__)
 
 
-def add_function_signature(crd: CRD) -> None:
+def add_function_signature(crd: crd_module.CRD) -> None:
     """Add function signature for trigger_run create command."""
-    inject_func_signature(
+    crd_module.inject_func_signature(
         crd,
         "create",
         {
@@ -73,7 +71,7 @@ def add_function_signature(crd: CRD) -> None:
     )
 
 
-def generate_create(crd: CRD, channel: Channel, parser: ArgumentParser):
+def generate_create(crd: crd_module.CRD, channel: Channel, parser: ArgumentParser):
     """Generate create function for trigger_run.
 
     Creates a TriggerRun CR by fetching the pipeline and extracting
@@ -87,14 +85,16 @@ def generate_create(crd: CRD, channel: Channel, parser: ArgumentParser):
     crd.configure_parser("create", parser)
     func_signature = crd._read_signatures("create")
 
-    @bind_signature(func_signature)
+    @crd_module.bind_signature(func_signature)
     def create_func(bound_args: Signature):
         """Implementation of trigger_run create command."""
         _LOG.info("Bound arguments: %r", bound_args.arguments)
-        _self: CRD = bound_args.arguments["self"]
-        namespace = get_single_arg(bound_args.arguments, "namespace")
-        pipeline_name = get_single_arg(bound_args.arguments, "pipeline")
-        trigger_name = get_single_arg(bound_args.arguments, "trigger_name")
+        _self: crd_module.CRD = bound_args.arguments["self"]
+        namespace = crd_module.get_single_arg(bound_args.arguments, "namespace")
+        pipeline_name = crd_module.get_single_arg(bound_args.arguments, "pipeline")
+        trigger_name = crd_module.get_single_arg(
+            bound_args.arguments, "trigger_name"
+        )
 
         _LOG.info(
             f"Creating TriggerRun for pipeline={pipeline_name}, "
@@ -103,20 +103,25 @@ def generate_create(crd: CRD, channel: Channel, parser: ArgumentParser):
 
         # Get pipeline using gRPC directly
         _LOG.info("Fetching pipeline via gRPC")
-        pipeline_method_name, pipeline_input_class, pipeline_output_class = (
-            _self._extract_method_info(
-                channel, "michelangelo.api.v2.PipelineService", "Get"
-            )
+        pipeline_service = "michelangelo.api.v2.PipelineService"
+        pipeline_methods, pipeline_pool = get_methods_from_service(
+            channel, pipeline_service, _self.metadata
         )
+        pipeline_method = pipeline_methods["GetPipeline"]
+        pipeline_input_class = get_message_class_by_name(
+            pipeline_pool, pipeline_method.input_type[1:]
+        )
+        pipeline_output_class = get_message_class_by_name(
+            pipeline_pool, pipeline_method.output_type[1:]
+        )
+
         get_pipeline_dict = {
             "name": pipeline_name,
             "namespace": namespace,
         }
         get_pipeline_request = pipeline_input_class()
         ParseDict(get_pipeline_dict, get_pipeline_request)
-        pipeline_method_fullname = (
-            f"/michelangelo.api.v2.PipelineService/{pipeline_method_name}"
-        )
+        pipeline_method_fullname = f"/{pipeline_service}/GetPipeline"
         pipeline_stub_method = channel.unary_unary(
             pipeline_method_fullname,
             request_serializer=pipeline_input_class.SerializeToString,
@@ -126,7 +131,7 @@ def generate_create(crd: CRD, channel: Channel, parser: ArgumentParser):
         try:
             pipeline_response = pipeline_stub_method(
                 get_pipeline_request,
-                metadata=METADATA_STUB,
+                metadata=crd_module.METADATA_STUB,
                 timeout=30,
             )
             pipeline = pipeline_response.pipeline
@@ -142,15 +147,18 @@ def generate_create(crd: CRD, channel: Channel, parser: ArgumentParser):
                     f"Failed to get pipeline '{pipeline_name}': {err.details()}"
                 ) from err
 
-        if not hasattr(pipeline.spec, "manifest") or not hasattr(
-            pipeline.spec.manifest, "trigger_map"
-        ):
+        if not hasattr(pipeline.spec, "manifest"):
             raise ValueError(
                 f"Pipeline '{pipeline_name}' does not have any triggers configured"
             )
-        trigger_map = MessageToDict(
-            pipeline.spec.manifest.trigger_map, preserving_proto_field_name=True
+        manifest_dict = MessageToDict(
+            pipeline.spec.manifest, preserving_proto_field_name=True
         )
+        trigger_map = manifest_dict.get("trigger_map", {})
+        if not trigger_map:
+            raise ValueError(
+                f"Pipeline '{pipeline_name}' does not have any triggers configured"
+            )
 
         if trigger_name not in trigger_map:
             available_triggers = ", ".join(trigger_map.keys())
@@ -164,7 +172,7 @@ def generate_create(crd: CRD, channel: Channel, parser: ArgumentParser):
         # Generate trigger run dict with configurations
         trigger_config = trigger_map[trigger_name]
         random_hex = uuid.uuid4().hex[:8]
-        trigger_run_name = f"{trigger_name}_{random_hex}"
+        trigger_run_name = f"{trigger_name}-{random_hex}"
         trigger_run_dict = {
             "triggerRun": {
                 "metadata": {
@@ -201,7 +209,7 @@ def generate_create(crd: CRD, channel: Channel, parser: ArgumentParser):
         try:
             response = stub_method(
                 request_input,
-                metadata=METADATA_STUB,
+                metadata=crd_module.METADATA_STUB,
                 timeout=30,
             )
         except RpcError as err:

--- a/python/michelangelo/cli/mactl/plugins/entity/trigger_run/create.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/trigger_run/create.py
@@ -92,9 +92,7 @@ def generate_create(crd: crd_module.CRD, channel: Channel, parser: ArgumentParse
         _self: crd_module.CRD = bound_args.arguments["self"]
         namespace = crd_module.get_single_arg(bound_args.arguments, "namespace")
         pipeline_name = crd_module.get_single_arg(bound_args.arguments, "pipeline")
-        trigger_name = crd_module.get_single_arg(
-            bound_args.arguments, "trigger_name"
-        )
+        trigger_name = crd_module.get_single_arg(bound_args.arguments, "trigger_name")
 
         _LOG.info(
             f"Creating TriggerRun for pipeline={pipeline_name}, "
@@ -214,9 +212,7 @@ def generate_create(crd: crd_module.CRD, channel: Channel, parser: ArgumentParse
             )
         except RpcError as err:
             _LOG.error(f"gRPC error creating TriggerRun: {err}")
-            raise RuntimeError(
-                f"Failed to create TriggerRun: {err.details()}"
-            ) from err
+            raise RuntimeError(f"Failed to create TriggerRun: {err.details()}") from err
 
         _LOG.info(
             f"Successfully created TriggerRun: {response.trigger_run.metadata.name}"

--- a/python/michelangelo/cli/mactl/plugins/entity/trigger_run/create_test.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/trigger_run/create_test.py
@@ -179,13 +179,12 @@ class GenerateCreateFunctionTest(TestCase):
         pipeline_error=None,
         trigger_run_response=None,
         trigger_run_error=None,
-        trigger_map_dict=None,
     ):
         """Set up mocks, call generate_create, and return the CRD.
 
         This helper builds all the mocks needed to invoke the bound
-        create function.  It patches ParseDict, MessageToDict,
-        get_user_name, and uuid so the closure can run in isolation.
+        create function.  It patches get_methods_from_service and
+        get_message_class_by_name for the PipelineService lookup.
         """
         mock_crd = _make_crd_mock()
         mock_channel = Mock()
@@ -195,12 +194,36 @@ class GenerateCreateFunctionTest(TestCase):
         trigger_run_input_class = Mock()
         trigger_run_output_class = Mock()
 
-        def extract_side_effect(ch, service, method):
-            if "PipelineService" in service:
-                return ("Get", pipeline_input_class, pipeline_output_class)
-            return ("Create", trigger_run_input_class, trigger_run_output_class)
+        mock_crd._extract_method_info.return_value = (
+            "CreateTriggerRun",
+            trigger_run_input_class,
+            trigger_run_output_class,
+        )
 
-        mock_crd._extract_method_info.side_effect = extract_side_effect
+        # Mock PipelineService method lookup
+        mock_pipeline_method = Mock()
+        mock_pipeline_method.input_type = ".GetPipelineRequest"
+        mock_pipeline_method.output_type = ".GetPipelineResponse"
+
+        self._mock_get_methods = patch(
+            f"{_PATCH_PREFIX}.get_methods_from_service",
+            return_value=(
+                {"GetPipeline": mock_pipeline_method},
+                Mock(),
+            ),
+        )
+        self._mock_get_methods.start()
+
+        def get_class_side_effect(pool, name):
+            if "Request" in name:
+                return pipeline_input_class
+            return pipeline_output_class
+
+        self._mock_get_class = patch(
+            f"{_PATCH_PREFIX}.get_message_class_by_name",
+            side_effect=get_class_side_effect,
+        )
+        self._mock_get_class.start()
 
         # Channel stubs
         mock_pipeline_stub = Mock(
@@ -223,6 +246,13 @@ class GenerateCreateFunctionTest(TestCase):
 
         return mock_crd
 
+    def tearDown(self):
+        """Stop patches started by _setup_and_bind."""
+        for p in ("_mock_get_methods", "_mock_get_class"):
+            patcher = getattr(self, p, None)
+            if patcher:
+                patcher.stop()
+
     @patch(f"{_PATCH_PREFIX}.ParseDict")
     @patch(f"{_PATCH_PREFIX}.MessageToDict")
     @patch(f"{_PATCH_PREFIX}.uuid")
@@ -234,7 +264,12 @@ class GenerateCreateFunctionTest(TestCase):
         mock_get_user.return_value = "test-user"
         mock_uuid.uuid4.return_value = Mock(hex="a1b2c3d400000000")
         mock_msg_to_dict.return_value = {
-            "daily-01": {"cronSchedule": {"cron": "0 8 * * *"}, "maxConcurrency": 1}
+            "trigger_map": {
+                "daily-01": {
+                    "cronSchedule": {"cron": "0 8 * * *"},
+                    "maxConcurrency": 1,
+                }
+            }
         }
 
         mock_pipeline = Mock()
@@ -244,7 +279,7 @@ class GenerateCreateFunctionTest(TestCase):
         pipeline_resp.pipeline = mock_pipeline
 
         trigger_run_resp = Mock()
-        trigger_run_resp.trigger_run.metadata.name = "daily-01_a1b2c3d4"
+        trigger_run_resp.trigger_run.metadata.name = "daily-01-a1b2c3d4"
 
         mock_crd = self._setup_and_bind(
             pipeline_response=pipeline_resp,
@@ -262,7 +297,7 @@ class GenerateCreateFunctionTest(TestCase):
         # Second call is the TriggerRun create (first is GetPipelineRequest)
         trigger_run_dict = create_call_args[1][0][0]
         tr = trigger_run_dict["triggerRun"]
-        self.assertEqual(tr["metadata"]["name"], "daily-01_a1b2c3d4")
+        self.assertEqual(tr["metadata"]["name"], "daily-01-a1b2c3d4")
         self.assertEqual(tr["metadata"]["namespace"], "test-ns")
         self.assertEqual(tr["spec"]["sourceTriggerName"], "daily-01")
         self.assertEqual(tr["spec"]["actor"]["name"], "test-user")
@@ -282,7 +317,12 @@ class GenerateCreateFunctionTest(TestCase):
         mock_get_user.return_value = "user"
         mock_uuid.uuid4.return_value = Mock(hex="e70c6f9200000000")
         mock_msg_to_dict.return_value = {
-            "hourly": {"intervalSchedule": {"interval": "1h"}, "maxConcurrency": 2}
+            "trigger_map": {
+                "hourly": {
+                    "intervalSchedule": {"interval": "1h"},
+                    "maxConcurrency": 2,
+                }
+            }
         }
 
         mock_pipeline = Mock()
@@ -291,7 +331,7 @@ class GenerateCreateFunctionTest(TestCase):
         pipeline_resp.pipeline = mock_pipeline
 
         trigger_run_resp = Mock()
-        trigger_run_resp.trigger_run.metadata.name = "hourly_e70c6f92"
+        trigger_run_resp.trigger_run.metadata.name = "hourly-e70c6f92"
 
         mock_crd = self._setup_and_bind(
             pipeline_response=pipeline_resp,
@@ -303,7 +343,7 @@ class GenerateCreateFunctionTest(TestCase):
         create_call_dict = mock_parse_dict.call_args_list[1][0][0]
         self.assertEqual(
             create_call_dict["triggerRun"]["metadata"]["name"],
-            "hourly_e70c6f92",
+            "hourly-e70c6f92",
         )
 
     @patch(f"{_PATCH_PREFIX}.ParseDict")
@@ -363,7 +403,9 @@ class GenerateCreateFunctionTest(TestCase):
     ):
         """Test ValueError when trigger name is not in the trigger map."""
         mock_msg_to_dict.return_value = {
-            "existing-trigger": {"cronSchedule": {"cron": "0 0 * * *"}}
+            "trigger_map": {
+                "existing-trigger": {"cronSchedule": {"cron": "0 0 * * *"}}
+            }
         }
 
         mock_pipeline = Mock()
@@ -397,7 +439,12 @@ class GenerateCreateFunctionTest(TestCase):
         mock_get_user.return_value = "user"
         mock_uuid.uuid4.return_value = Mock(hex="0000000000000000")
         mock_msg_to_dict.return_value = {
-            "t1": {"cronSchedule": {"cron": "* * * * *"}, "maxConcurrency": 1}
+            "trigger_map": {
+                "t1": {
+                    "cronSchedule": {"cron": "* * * * *"},
+                    "maxConcurrency": 1,
+                }
+            }
         }
 
         mock_pipeline = Mock()

--- a/python/michelangelo/cli/mactl/plugins/entity/trigger_run/create_test.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/trigger_run/create_test.py
@@ -403,9 +403,7 @@ class GenerateCreateFunctionTest(TestCase):
     ):
         """Test ValueError when trigger name is not in the trigger map."""
         mock_msg_to_dict.return_value = {
-            "trigger_map": {
-                "existing-trigger": {"cronSchedule": {"cron": "0 0 * * *"}}
-            }
+            "trigger_map": {"existing-trigger": {"cronSchedule": {"cron": "0 0 * * *"}}}
         }
 
         mock_pipeline = Mock()

--- a/python/michelangelo/cli/mactl/plugins/entity/trigger_run/create_test.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/trigger_run/create_test.py
@@ -1,0 +1,418 @@
+"""Unit tests for trigger_run create plugin.
+
+Tests the add_function_signature and generate_create functions.
+"""
+
+from inspect import Parameter, Signature
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from grpc import RpcError
+
+from michelangelo.cli.mactl.plugins.entity.trigger_run.create import (
+    add_function_signature,
+    generate_create,
+)
+
+_PATCH_PREFIX = "michelangelo.cli.mactl.plugins.entity.trigger_run.create"
+
+# Reusable Signature matching the create command's expected parameters
+_CREATE_SIGNATURE = Signature(
+    parameters=[
+        Parameter("self", Parameter.POSITIONAL_OR_KEYWORD),
+        Parameter("namespace", Parameter.POSITIONAL_OR_KEYWORD),
+        Parameter("pipeline", Parameter.POSITIONAL_OR_KEYWORD),
+        Parameter("trigger_name", Parameter.POSITIONAL_OR_KEYWORD),
+    ]
+)
+
+
+class _MockRpcError(RpcError):
+    """Concrete RpcError subclass for testing."""
+
+    def __init__(self, code, details_msg):
+        self._code = code
+        self._details = details_msg
+        super().__init__(details_msg)
+
+    def code(self):
+        return self._code
+
+    def details(self):
+        return self._details
+
+
+def _make_crd_mock():
+    """Build a CRD mock that returns a real Signature from _read_signatures."""
+    mock_crd = Mock()
+    mock_crd.full_name = "michelangelo.api.v2.TriggerRunService"
+    mock_crd._read_signatures.return_value = _CREATE_SIGNATURE
+    mock_crd.configure_parser = Mock()
+    return mock_crd
+
+
+class AddFunctionSignatureTest(TestCase):
+    """Tests for add_function_signature."""
+
+    def test_adds_create_entry(self):
+        """Test that a 'create' entry is added to func_signature."""
+        mock_crd = Mock()
+        mock_crd.func_signature = {}
+
+        add_function_signature(mock_crd)
+
+        self.assertIn("create", mock_crd.func_signature)
+
+    def test_help_text(self):
+        """Test that help text is set correctly."""
+        mock_crd = Mock()
+        mock_crd.func_signature = {}
+
+        add_function_signature(mock_crd)
+
+        sig = mock_crd.func_signature["create"]
+        self.assertEqual(
+            sig["help"],
+            "Create a TriggerRun from a pipeline's trigger configuration.",
+        )
+
+    def test_has_three_args(self):
+        """Test that exactly three args are defined."""
+        mock_crd = Mock()
+        mock_crd.func_signature = {}
+
+        add_function_signature(mock_crd)
+
+        self.assertEqual(len(mock_crd.func_signature["create"]["args"]), 3)
+
+    def test_namespace_arg(self):
+        """Test namespace arg flags and kwargs."""
+        mock_crd = Mock()
+        mock_crd.func_signature = {}
+
+        add_function_signature(mock_crd)
+
+        arg = mock_crd.func_signature["create"]["args"][0]
+        self.assertEqual(arg["args"], ["-n", "--namespace"])
+        self.assertTrue(arg["kwargs"]["required"])
+        self.assertEqual(arg["kwargs"]["type"], str)
+
+    def test_pipeline_arg(self):
+        """Test pipeline arg flags and kwargs."""
+        mock_crd = Mock()
+        mock_crd.func_signature = {}
+
+        add_function_signature(mock_crd)
+
+        arg = mock_crd.func_signature["create"]["args"][1]
+        self.assertEqual(arg["args"], ["-p", "--pipeline"])
+        self.assertTrue(arg["kwargs"]["required"])
+        self.assertEqual(arg["kwargs"]["type"], str)
+
+    def test_trigger_name_arg(self):
+        """Test trigger_name arg flags and kwargs."""
+        mock_crd = Mock()
+        mock_crd.func_signature = {}
+
+        add_function_signature(mock_crd)
+
+        arg = mock_crd.func_signature["create"]["args"][2]
+        self.assertEqual(arg["args"], ["-t", "--trigger-name"])
+        self.assertTrue(arg["kwargs"]["required"])
+        self.assertEqual(arg["kwargs"]["type"], str)
+
+
+class GenerateCreateSetupTest(TestCase):
+    """Tests for generate_create setup phase (before the bound function runs)."""
+
+    def test_calls_extract_method_info(self):
+        """Test that _extract_method_info is called with Create."""
+        mock_crd = _make_crd_mock()
+        mock_crd._extract_method_info.return_value = ("Create", Mock(), Mock())
+        mock_channel = Mock()
+
+        generate_create(mock_crd, mock_channel, Mock())
+
+        mock_crd._extract_method_info.assert_called_once_with(
+            mock_channel, mock_crd.full_name, "Create"
+        )
+
+    def test_calls_configure_parser(self):
+        """Test that configure_parser is called with 'create'."""
+        mock_crd = _make_crd_mock()
+        mock_crd._extract_method_info.return_value = ("Create", Mock(), Mock())
+        mock_channel = Mock()
+        mock_parser = Mock()
+
+        generate_create(mock_crd, mock_channel, mock_parser)
+
+        mock_crd.configure_parser.assert_called_once_with("create", mock_parser)
+
+    def test_calls_read_signatures(self):
+        """Test that _read_signatures is called with 'create'."""
+        mock_crd = _make_crd_mock()
+        mock_crd._extract_method_info.return_value = ("Create", Mock(), Mock())
+        mock_channel = Mock()
+
+        generate_create(mock_crd, mock_channel, Mock())
+
+        mock_crd._read_signatures.assert_called_once_with("create")
+
+    def test_binds_create_method(self):
+        """Test that a callable create method is bound to the CRD."""
+        mock_crd = _make_crd_mock()
+        mock_crd._extract_method_info.return_value = ("Create", Mock(), Mock())
+        mock_channel = Mock()
+
+        generate_create(mock_crd, mock_channel, Mock())
+
+        self.assertTrue(hasattr(mock_crd, "create"))
+        self.assertTrue(callable(mock_crd.create))
+
+
+class GenerateCreateFunctionTest(TestCase):
+    """Tests for the bound create function's runtime behavior."""
+
+    def _setup_and_bind(
+        self,
+        pipeline_response=None,
+        pipeline_error=None,
+        trigger_run_response=None,
+        trigger_run_error=None,
+        trigger_map_dict=None,
+    ):
+        """Set up mocks, call generate_create, and return the CRD.
+
+        This helper builds all the mocks needed to invoke the bound
+        create function.  It patches ParseDict, MessageToDict,
+        get_user_name, and uuid so the closure can run in isolation.
+        """
+        mock_crd = _make_crd_mock()
+        mock_channel = Mock()
+
+        pipeline_input_class = Mock()
+        pipeline_output_class = Mock()
+        trigger_run_input_class = Mock()
+        trigger_run_output_class = Mock()
+
+        def extract_side_effect(ch, service, method):
+            if "PipelineService" in service:
+                return ("Get", pipeline_input_class, pipeline_output_class)
+            return ("Create", trigger_run_input_class, trigger_run_output_class)
+
+        mock_crd._extract_method_info.side_effect = extract_side_effect
+
+        # Channel stubs
+        mock_pipeline_stub = Mock(
+            side_effect=pipeline_error,
+            return_value=pipeline_response,
+        )
+        mock_trigger_run_stub = Mock(
+            side_effect=trigger_run_error,
+            return_value=trigger_run_response,
+        )
+
+        def unary_unary_side_effect(method_fullname, **kwargs):
+            if "PipelineService" in method_fullname:
+                return mock_pipeline_stub
+            return mock_trigger_run_stub
+
+        mock_channel.unary_unary.side_effect = unary_unary_side_effect
+
+        generate_create(mock_crd, mock_channel, Mock())
+
+        return mock_crd
+
+    @patch(f"{_PATCH_PREFIX}.ParseDict")
+    @patch(f"{_PATCH_PREFIX}.MessageToDict")
+    @patch(f"{_PATCH_PREFIX}.uuid")
+    @patch(f"{_PATCH_PREFIX}.get_user_name")
+    def test_successful_create(
+        self, mock_get_user, mock_uuid, mock_msg_to_dict, mock_parse_dict
+    ):
+        """Test a successful trigger run creation end-to-end."""
+        mock_get_user.return_value = "test-user"
+        mock_uuid.uuid4.return_value = Mock(hex="a1b2c3d400000000")
+        mock_msg_to_dict.return_value = {
+            "daily-01": {"cronSchedule": {"cron": "0 8 * * *"}, "maxConcurrency": 1}
+        }
+
+        mock_pipeline = Mock()
+        mock_pipeline.metadata.name = "my-pipeline"
+        mock_pipeline.spec.manifest.trigger_map = Mock()
+        pipeline_resp = Mock()
+        pipeline_resp.pipeline = mock_pipeline
+
+        trigger_run_resp = Mock()
+        trigger_run_resp.trigger_run.metadata.name = "daily-01_a1b2c3d4"
+
+        mock_crd = self._setup_and_bind(
+            pipeline_response=pipeline_resp,
+            trigger_run_response=trigger_run_resp,
+        )
+
+        result = mock_crd.create(
+            namespace="test-ns", pipeline="my-pipeline", trigger_name="daily-01"
+        )
+
+        self.assertIs(result, trigger_run_resp)
+
+        # Verify ParseDict was called to build the TriggerRun request
+        create_call_args = mock_parse_dict.call_args_list
+        # Second call is the TriggerRun create (first is GetPipelineRequest)
+        trigger_run_dict = create_call_args[1][0][0]
+        tr = trigger_run_dict["triggerRun"]
+        self.assertEqual(tr["metadata"]["name"], "daily-01_a1b2c3d4")
+        self.assertEqual(tr["metadata"]["namespace"], "test-ns")
+        self.assertEqual(tr["spec"]["sourceTriggerName"], "daily-01")
+        self.assertEqual(tr["spec"]["actor"]["name"], "test-user")
+        self.assertEqual(
+            tr["spec"]["pipeline"],
+            {"name": "my-pipeline", "namespace": "test-ns"},
+        )
+
+    @patch(f"{_PATCH_PREFIX}.ParseDict")
+    @patch(f"{_PATCH_PREFIX}.MessageToDict")
+    @patch(f"{_PATCH_PREFIX}.uuid")
+    @patch(f"{_PATCH_PREFIX}.get_user_name")
+    def test_trigger_run_name_format(
+        self, mock_get_user, mock_uuid, mock_msg_to_dict, mock_parse_dict
+    ):
+        """Test that trigger run name follows {trigger_name}_{8-hex} format."""
+        mock_get_user.return_value = "user"
+        mock_uuid.uuid4.return_value = Mock(hex="e70c6f9200000000")
+        mock_msg_to_dict.return_value = {
+            "hourly": {"intervalSchedule": {"interval": "1h"}, "maxConcurrency": 2}
+        }
+
+        mock_pipeline = Mock()
+        mock_pipeline.spec.manifest.trigger_map = Mock()
+        pipeline_resp = Mock()
+        pipeline_resp.pipeline = mock_pipeline
+
+        trigger_run_resp = Mock()
+        trigger_run_resp.trigger_run.metadata.name = "hourly_e70c6f92"
+
+        mock_crd = self._setup_and_bind(
+            pipeline_response=pipeline_resp,
+            trigger_run_response=trigger_run_resp,
+        )
+
+        mock_crd.create(namespace="ns", pipeline="pipe", trigger_name="hourly")
+
+        create_call_dict = mock_parse_dict.call_args_list[1][0][0]
+        self.assertEqual(
+            create_call_dict["triggerRun"]["metadata"]["name"],
+            "hourly_e70c6f92",
+        )
+
+    @patch(f"{_PATCH_PREFIX}.ParseDict")
+    def test_pipeline_not_found_raises_value_error(self, mock_parse_dict):
+        """Test ValueError is raised when the pipeline is not found."""
+        from grpc import StatusCode
+
+        error = _MockRpcError(StatusCode.NOT_FOUND, "not found")
+
+        mock_crd = self._setup_and_bind(pipeline_error=error)
+
+        with self.assertRaises(ValueError) as ctx:
+            mock_crd.create(
+                namespace="ns",
+                pipeline="missing-pipeline",
+                trigger_name="t",
+            )
+
+        self.assertIn("not found", str(ctx.exception))
+        self.assertIn("missing-pipeline", str(ctx.exception))
+
+    @patch(f"{_PATCH_PREFIX}.ParseDict")
+    def test_pipeline_grpc_error_raises_runtime_error(self, mock_parse_dict):
+        """Test RuntimeError is raised for non-NOT_FOUND gRPC errors."""
+        from grpc import StatusCode
+
+        error = _MockRpcError(StatusCode.INTERNAL, "server error")
+
+        mock_crd = self._setup_and_bind(pipeline_error=error)
+
+        with self.assertRaises(RuntimeError) as ctx:
+            mock_crd.create(namespace="ns", pipeline="pipe", trigger_name="t")
+
+        self.assertIn("Failed to get pipeline", str(ctx.exception))
+
+    @patch(f"{_PATCH_PREFIX}.ParseDict")
+    def test_pipeline_without_manifest_raises_value_error(self, mock_parse_dict):
+        """Test ValueError when pipeline has no manifest attribute."""
+        mock_pipeline = Mock(spec=["metadata"])
+        mock_pipeline.metadata.name = "pipe"
+        # spec has no 'manifest'
+        mock_pipeline.spec = Mock(spec=[])
+        pipeline_resp = Mock()
+        pipeline_resp.pipeline = mock_pipeline
+
+        mock_crd = self._setup_and_bind(pipeline_response=pipeline_resp)
+
+        with self.assertRaises(ValueError) as ctx:
+            mock_crd.create(namespace="ns", pipeline="pipe", trigger_name="t")
+
+        self.assertIn("does not have any triggers", str(ctx.exception))
+
+    @patch(f"{_PATCH_PREFIX}.ParseDict")
+    @patch(f"{_PATCH_PREFIX}.MessageToDict")
+    def test_trigger_name_not_in_map_raises_value_error(
+        self, mock_msg_to_dict, mock_parse_dict
+    ):
+        """Test ValueError when trigger name is not in the trigger map."""
+        mock_msg_to_dict.return_value = {
+            "existing-trigger": {"cronSchedule": {"cron": "0 0 * * *"}}
+        }
+
+        mock_pipeline = Mock()
+        mock_pipeline.spec.manifest.trigger_map = Mock()
+        pipeline_resp = Mock()
+        pipeline_resp.pipeline = mock_pipeline
+
+        mock_crd = self._setup_and_bind(pipeline_response=pipeline_resp)
+
+        with self.assertRaises(ValueError) as ctx:
+            mock_crd.create(
+                namespace="ns",
+                pipeline="pipe",
+                trigger_name="nonexistent",
+            )
+
+        self.assertIn("nonexistent", str(ctx.exception))
+        self.assertIn("Available triggers", str(ctx.exception))
+        self.assertIn("existing-trigger", str(ctx.exception))
+
+    @patch(f"{_PATCH_PREFIX}.ParseDict")
+    @patch(f"{_PATCH_PREFIX}.MessageToDict")
+    @patch(f"{_PATCH_PREFIX}.uuid")
+    @patch(f"{_PATCH_PREFIX}.get_user_name")
+    def test_trigger_run_grpc_error_raises_runtime_error(
+        self, mock_get_user, mock_uuid, mock_msg_to_dict, mock_parse_dict
+    ):
+        """Test RuntimeError when the TriggerRun gRPC create call fails."""
+        from grpc import StatusCode
+
+        mock_get_user.return_value = "user"
+        mock_uuid.uuid4.return_value = Mock(hex="0000000000000000")
+        mock_msg_to_dict.return_value = {
+            "t1": {"cronSchedule": {"cron": "* * * * *"}, "maxConcurrency": 1}
+        }
+
+        mock_pipeline = Mock()
+        mock_pipeline.spec.manifest.trigger_map = Mock()
+        pipeline_resp = Mock()
+        pipeline_resp.pipeline = mock_pipeline
+
+        error = _MockRpcError(StatusCode.INTERNAL, "internal error")
+
+        mock_crd = self._setup_and_bind(
+            pipeline_response=pipeline_resp,
+            trigger_run_error=error,
+        )
+
+        with self.assertRaises(RuntimeError) as ctx:
+            mock_crd.create(namespace="ns", pipeline="pipe", trigger_name="t1")
+
+        self.assertIn("Failed to create TriggerRun", str(ctx.exception))

--- a/python/michelangelo/cli/mactl/plugins/entity/trigger_run/kill.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/trigger_run/kill.py
@@ -10,20 +10,14 @@ from google.protobuf.json_format import MessageToDict, ParseDict
 from google.protobuf.message import Message
 from grpc import Channel
 
-from michelangelo.cli.mactl.crd import (
-    CRD,
-    METADATA_STUB,
-    bind_signature,
-    get_single_arg,
-    inject_func_signature,
-)
+import michelangelo.cli.mactl.crd as crd_module
 
 _LOG = getLogger(__name__)
 
 
-def add_function_signature(crd: CRD) -> None:
+def add_function_signature(crd: crd_module.CRD) -> None:
     """Add function signature for pipeline kill command."""
-    inject_func_signature(
+    crd_module.inject_func_signature(
         crd,
         "kill",
         {
@@ -73,7 +67,9 @@ def add_function_signature(crd: CRD) -> None:
     )
 
 
-def generate_kill(crd: CRD, channel: Channel, parser: Optional[ArgumentParser] = None):
+def generate_kill(
+    crd: crd_module.CRD, channel: Channel, parser: Optional[ArgumentParser] = None
+):
     """Generate kill function for pipeline_run CRD."""
     _LOG.info("Generating `pipeline_run kill` for: %s", crd)
 
@@ -86,13 +82,13 @@ def generate_kill(crd: CRD, channel: Channel, parser: Optional[ArgumentParser] =
     crd.configure_parser("kill", parser)
     func_signature = crd._read_signatures("kill")
 
-    @bind_signature(func_signature)
+    @crd_module.bind_signature(func_signature)
     def kill_func(bound_args: Signature) -> Message:
         _LOG.info("Start kill_func for pipeline_run")
         _LOG.info("Bound arguments: %r", bound_args.arguments)
-        _self: CRD = bound_args.arguments["self"]
-        _name = get_single_arg(bound_args.arguments, "name")
-        _namespace = get_single_arg(bound_args.arguments, "namespace")
+        _self: crd_module.CRD = bound_args.arguments["self"]
+        _name = crd_module.get_single_arg(bound_args.arguments, "name")
+        _namespace = crd_module.get_single_arg(bound_args.arguments, "namespace")
         _yes = bound_args.arguments.get("yes", False)
 
         if not _yes:
@@ -134,7 +130,7 @@ def generate_kill(crd: CRD, channel: Channel, parser: Optional[ArgumentParser] =
 
         response = stub_method(
             request_input,
-            metadata=METADATA_STUB,
+            metadata=crd_module.METADATA_STUB,
             timeout=30,
         )
 

--- a/python/michelangelo/cli/mactl/plugins/entity/trigger_run/main.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/trigger_run/main.py
@@ -11,7 +11,10 @@ from michelangelo.cli.mactl.plugins.entity.trigger_run.kill import (
     add_function_signature,
     generate_kill,
 )
-
+from michelangelo.cli.mactl.plugins.entity.trigger_run.create import (
+    add_function_signature as add_create_function_signature,
+    generate_create,
+)
 
 _LOG = getLogger(__name__)
 
@@ -26,5 +29,9 @@ def apply_plugins(crd: CRD, channel: Channel):
     add_function_signature(crd)
     crd.generate_kill = MethodType(
         lambda self, ch, parser: generate_kill(self, ch, parser), crd
+    )
+    add_create_function_signature(crd)
+    crd.generate_create = MethodType(
+        lambda self, ch, parser: generate_create(self, ch, parser), crd
     )
     _LOG.info("Plugin entities applied successfully to crd: %s", crd)

--- a/python/michelangelo/cli/mactl/plugins/entity/trigger_run/main_test.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/trigger_run/main_test.py
@@ -7,15 +7,20 @@ from unittest.mock import MagicMock, Mock, patch
 from michelangelo.cli.mactl.plugins.entity.trigger_run.main import apply_plugins
 
 
-class ApplyPluginsTest(TestCase):
+class ApplyPluginsKillTest(TestCase):
     """Tests for apply_plugins function."""
 
+    @patch("michelangelo.cli.mactl.plugins.entity.trigger_run.main.generate_create")
+    @patch(
+        "michelangelo.cli.mactl.plugins.entity.trigger_run.main"
+        ".add_create_function_signature"
+    )
     @patch("michelangelo.cli.mactl.plugins.entity.trigger_run.main.generate_kill")
     @patch(
         "michelangelo.cli.mactl.plugins.entity.trigger_run.main.add_function_signature"
     )
     def test_apply_plugins_adds_function_signature(
-        self, mock_add_function_signature, _
+        self, mock_add_function_signature, _, __, ___
     ):
         """Test that apply_plugins calls add_function_signature with CRD."""
         # Setup
@@ -28,11 +33,16 @@ class ApplyPluginsTest(TestCase):
         # Verify
         mock_add_function_signature.assert_called_once_with(mock_crd)
 
+    @patch("michelangelo.cli.mactl.plugins.entity.trigger_run.main.generate_create")
+    @patch(
+        "michelangelo.cli.mactl.plugins.entity.trigger_run.main"
+        ".add_create_function_signature"
+    )
     @patch("michelangelo.cli.mactl.plugins.entity.trigger_run.main.generate_kill")
     @patch(
         "michelangelo.cli.mactl.plugins.entity.trigger_run.main.add_function_signature"
     )
-    def test_apply_plugins_adds_generate_kill_method(self, _, __):
+    def test_apply_plugins_adds_generate_kill_method(self, _, __, ___, ____):
         """Test that apply_plugins adds generate_kill method to CRD."""
         # Setup
         mock_crd = Mock()
@@ -45,12 +55,17 @@ class ApplyPluginsTest(TestCase):
         self.assertTrue(hasattr(mock_crd, "generate_kill"))
         self.assertIsInstance(mock_crd.generate_kill, MethodType)
 
+    @patch("michelangelo.cli.mactl.plugins.entity.trigger_run.main.generate_create")
+    @patch(
+        "michelangelo.cli.mactl.plugins.entity.trigger_run.main"
+        ".add_create_function_signature"
+    )
     @patch("michelangelo.cli.mactl.plugins.entity.trigger_run.main.generate_kill")
     @patch(
         "michelangelo.cli.mactl.plugins.entity.trigger_run.main.add_function_signature"
     )
     def test_apply_plugins_generate_kill_calls_correct_function(
-        self, _, mock_generate_kill
+        self, _, mock_generate_kill, __, ___
     ):
         """Test that the added generate_kill method calls generate_kill function."""
         # Setup
@@ -104,3 +119,71 @@ class ApplyPluginsTest(TestCase):
         # Verify existing attributes are preserved
         self.assertEqual(mock_crd.existing_attr, "test_value")
         self.assertEqual(mock_crd.existing_method(), "test")
+
+
+class ApplyPluginsCreateTest(TestCase):
+    """Tests for apply_plugins create-related functionality."""
+
+    @patch("michelangelo.cli.mactl.plugins.entity.trigger_run.main.generate_create")
+    @patch(
+        "michelangelo.cli.mactl.plugins.entity.trigger_run.main"
+        ".add_create_function_signature"
+    )
+    @patch("michelangelo.cli.mactl.plugins.entity.trigger_run.main.generate_kill")
+    @patch(
+        "michelangelo.cli.mactl.plugins.entity.trigger_run.main.add_function_signature"
+    )
+    def test_apply_plugins_calls_add_create_function_signature(
+        self, _, __, mock_add_create_sig, ___
+    ):
+        """Test that apply_plugins calls add_create_function_signature."""
+        mock_crd = Mock()
+        mock_channel = Mock()
+
+        apply_plugins(mock_crd, mock_channel)
+
+        mock_add_create_sig.assert_called_once_with(mock_crd)
+
+    @patch("michelangelo.cli.mactl.plugins.entity.trigger_run.main.generate_create")
+    @patch(
+        "michelangelo.cli.mactl.plugins.entity.trigger_run.main"
+        ".add_create_function_signature"
+    )
+    @patch("michelangelo.cli.mactl.plugins.entity.trigger_run.main.generate_kill")
+    @patch(
+        "michelangelo.cli.mactl.plugins.entity.trigger_run.main.add_function_signature"
+    )
+    def test_apply_plugins_adds_generate_create_method(self, _, __, ___, ____):
+        """Test that apply_plugins adds generate_create method to CRD."""
+        mock_crd = Mock()
+        mock_channel = Mock()
+
+        apply_plugins(mock_crd, mock_channel)
+
+        self.assertTrue(hasattr(mock_crd, "generate_create"))
+        self.assertIsInstance(mock_crd.generate_create, MethodType)
+
+    @patch("michelangelo.cli.mactl.plugins.entity.trigger_run.main.generate_create")
+    @patch(
+        "michelangelo.cli.mactl.plugins.entity.trigger_run.main"
+        ".add_create_function_signature"
+    )
+    @patch("michelangelo.cli.mactl.plugins.entity.trigger_run.main.generate_kill")
+    @patch(
+        "michelangelo.cli.mactl.plugins.entity.trigger_run.main.add_function_signature"
+    )
+    def test_generate_create_method_delegates_correctly(
+        self, _, __, ___, mock_generate_create
+    ):
+        """Test that the bound generate_create calls generate_create."""
+        mock_crd = Mock()
+        mock_channel = Mock()
+        mock_parser = Mock()
+
+        apply_plugins(mock_crd, mock_channel)
+
+        mock_crd.generate_create(mock_channel, mock_parser)
+
+        mock_generate_create.assert_called_once_with(
+            mock_crd, mock_channel, mock_parser
+        )

--- a/python/michelangelo/cli/sandbox/demo/pipeline/training-pipeline-with-trigger.yaml
+++ b/python/michelangelo/cli/sandbox/demo/pipeline/training-pipeline-with-trigger.yaml
@@ -37,9 +37,9 @@ spec:
               path: 'glue'
               name: 'cola'
               tokenizer_max_length: 128
-      training-trigger-cron-every-minute-no-params:
+      training-trigger-cron-daily-at-8am:
         cronSchedule:
-          cron: "* * * * *"
+          cron: "0 8 * * *"
         maxConcurrency: 1
   commit:
     gitRef: "main"

--- a/python/michelangelo/cli/sandbox/demo/pipeline/training-pipeline-with-trigger.yaml
+++ b/python/michelangelo/cli/sandbox/demo/pipeline/training-pipeline-with-trigger.yaml
@@ -37,9 +37,9 @@ spec:
               path: 'glue'
               name: 'cola'
               tokenizer_max_length: 128
-      training-trigger-cron-daily-at-8am:
+      training-trigger-cron-every-minute-no-params:
         cronSchedule:
-          cron: "0 8 * * *"
+          cron: "* * * * *"
         maxConcurrency: 1
   commit:
     gitRef: "main"


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
Added a new mactl trigger_run create command that creates a TriggerRun CR directly from a pipeline's registered trigger configuration, replacing the need to manually author and apply TriggerRun YAML files via mactl trigger_run apply --file.

Changes:
- trigger_run/create.py (new): Implements the create command plugin with add_function_signature (registers --namespace, --pipeline, --trigger-name CLI args) and generate_create (fetches the pipeline via gRPC, extracts the trigger config from its triggerMap, constructs a TriggerRun CR with {trigger_name}_{8-digit-hex} naming, and creates it via gRPC). Includes error handling for pipeline not found (ValueError), missing triggers (ValueError), and gRPC failures (RuntimeError).

- trigger_run/create_test.py (new): 17 unit tests across 3 test classes (AddFunctionSignatureTest, GenerateCreateSetupTest, GenerateCreateFunctionTest) covering argument registration, setup phase, successful creation, name format, and all error paths (pipeline not found, no manifest, trigger not in map, gRPC errors).

- trigger_run/main.py: Wires up the new add_create_function_signature and generate_create into apply_plugins, binding generate_create as a method on the CRD.

- trigger_run/main_test.py: Added ApplyPluginsCreateTest class (3 tests) verifying that apply_plugins registers the create signature, binds generate_create as a MethodType, and delegates correctly. Existing kill tests updated to also patch the new create imports to avoid side effects.

<!-- Tell your future self why have you made these changes -->
**Why?**
To make trigger management declarative and versionable by coupling trigger configuration to the pipeline spec. By embedding triggers inside the pipeline's triggerMap, users define their trigger configurations alongside their pipeline definition in a single YAML file, versioned in git. The new mactl trigger_run create --namespace <ns> --pipeline <pipeline> --trigger-name <trigger> command completes this design by letting users create TriggerRun CRs directly from the pipeline's registered trigger configuration, providing the simplest possible experience — no separate TriggerRun YAML files to author or maintain.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- 25 unit tests added and passing (create_test.py: 17 tests, main_test.py: 8 tests)
- E2E testing in local sandbox
   - run ma sandbox, start michelangelo-controllermgr and michelangelo-worker locally
   - register pipeline with `ma pipeline apply -f  michelangelo/cli/sandbox/demo/pipeline/training-pipeline-with-trigger.yaml `
   - run `ma trigger_run create --namespace ma-dev-test --pipeline  training-pipeline-with-trigger --trigger-name training-trigger-cron-daily-at-8am` and `ma trigger_run create --namespace ma-dev-test --pipeline  training-pipeline-with-trigger --trigger-name training-trigger-cron-every-minute`
   - verify trigger is created through localhost UI
   - kill trigger by running `ma trigger_run kill -n ma-dev-test  --name  {trigger_name}`
   - verify trigger is killed through localhost UI
 
<img width="1494" height="924" alt="Screenshot 2026-04-03 at 2 42 44 PM" src="https://github.com/user-attachments/assets/c0d38303-c2d5-4974-bc5e-348836bd84b8" />
<img width="1485" height="941" alt="Screenshot 2026-04-03 at 2 43 01 PM" src="https://github.com/user-attachments/assets/706e39f4-e5f0-4ba3-834f-ebdb0b7a8006" />
<img width="1455" height="816" alt="Screenshot 2026-04-03 at 3 23 49 PM" src="https://github.com/user-attachments/assets/06ca60b3-60a7-4269-8d25-bfe6bef18389" />

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
New CLI command: ma trigger_run create --namespace <ns> --pipeline <pipeline> --trigger-name <trigger> to create TriggerRun CRs directly from a pipeline's trigger configuration.

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
Will come with next PR