### PR TITLE
Amanda/fix pipeline run name format and output

### DIFF
--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/run.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/run.py
@@ -1,8 +1,8 @@
 """Pipeline `run` function plugin module."""
 
-import time
 import uuid
 from argparse import ArgumentParser
+from datetime import datetime, timezone
 from inspect import Parameter, Signature
 from logging import getLogger
 from types import MethodType
@@ -159,6 +159,7 @@ def generate_run(crd: CRD, channel: Channel, parser: Optional[ArgumentParser] = 
             timeout=30,
         )
         _LOG.info("Stub method completed (%r): %r", type(response), response)
+        print(response)
         return response
 
     run_func.__signature__ = func_signature  # type: ignore[attr-defined]
@@ -295,7 +296,11 @@ def parse_resume_from(resume_from: str, namespace: str) -> dict:
 
 
 def generate_pipeline_run_name() -> str:
-    """Generates a pipeline-run name."""
-    timestamp = int(time.time())
+    """Generates a pipeline-run name.
+
+    Format: run-YYYYMMDD-HHMMSS-{uuid8}  (always 28 characters)
+    Example: run-20260402-143022-a3f7c2b1
+    """
+    now = datetime.now(timezone.utc)
     uuid8 = str(uuid.uuid4())[:8]
-    return f"run-{timestamp}-{uuid8}"
+    return f"run-{now.strftime('%Y%m%d-%H%M%S')}-{uuid8}"

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/run.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/run.py
@@ -12,9 +12,9 @@ from google.protobuf.json_format import ParseDict
 from google.protobuf.message import Message
 from grpc import Channel
 
+import michelangelo.cli.mactl.crd as _crd_module
 from michelangelo.cli.mactl.crd import (
     CRD,
-    METADATA_STUB,
     bind_signature,
     get_single_arg,
     inject_func_signature,
@@ -155,7 +155,7 @@ def generate_run(crd: CRD, channel: Channel, parser: Optional[ArgumentParser] = 
         )
         response = stub_method(
             request_input,
-            metadata=METADATA_STUB,
+            metadata=_crd_module.METADATA_STUB,
             timeout=30,
         )
         _LOG.info("Stub method completed (%r): %r", type(response), response)

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/run_test.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/run_test.py
@@ -3,6 +3,7 @@
 Tests helper functions for pipeline run generation.
 """
 
+from datetime import datetime, timezone
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
@@ -18,11 +19,13 @@ from michelangelo.cli.mactl.plugins.entity.pipeline.run import (
 class PipelineRunTest(TestCase):
     """Tests for pipeline run plugin."""
 
-    @patch("michelangelo.cli.mactl.plugins.entity.pipeline.run.time")
     @patch("michelangelo.cli.mactl.plugins.entity.pipeline.run.uuid")
-    def test_generate_pipeline_run_name(self, mock_uuid, mock_time):
-        """Test pipeline run name generation."""
-        mock_time.time.return_value = 1705152000  # 2024-01-13 12:00:00
+    @patch("michelangelo.cli.mactl.plugins.entity.pipeline.run.datetime")
+    def test_generate_pipeline_run_name(self, mock_datetime, mock_uuid):
+        """Test pipeline run name format: run-YYYYMMDD-HHMMSS-{uuid8}."""
+        mock_datetime.now.return_value = datetime(
+            2026, 4, 2, 14, 30, 22, tzinfo=timezone.utc
+        )
         mock_uuid.uuid4.return_value = MagicMock()
         mock_uuid.uuid4.return_value.__str__ = (
             lambda x: "abc123de-f456-7890-1234-567890abcdef"
@@ -30,8 +33,9 @@ class PipelineRunTest(TestCase):
 
         result = generate_pipeline_run_name()
 
-        self.assertEqual(result, "run-1705152000-abc123de")
-        mock_time.time.assert_called_once()
+        self.assertEqual(result, "run-20260402-143022-abc123de")
+        self.assertEqual(len(result), 28)
+        mock_datetime.now.assert_called_once()
         mock_uuid.uuid4.assert_called_once()
 
     @patch("michelangelo.cli.mactl.plugins.entity.pipeline.run.get_user_name")

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/run_test.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/run_test.py
@@ -4,6 +4,7 @@ Tests helper functions for pipeline run generation.
 """
 
 from datetime import datetime, timezone
+from inspect import Parameter, Signature
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
@@ -271,3 +272,55 @@ class PipelineRunTest(TestCase):
         mock_get_methods.assert_called_once_with(
             mock_channel, "michelangelo.api.v2.PipelineRunService", mock_crd.metadata
         )
+
+    @patch("michelangelo.cli.mactl.plugins.entity.pipeline.run.get_service_name")
+    @patch(
+        "michelangelo.cli.mactl.plugins.entity.pipeline.run.get_methods_from_service"
+    )
+    @patch(
+        "michelangelo.cli.mactl.plugins.entity.pipeline.run.get_message_class_by_name"
+    )
+    @patch("michelangelo.cli.mactl.plugins.entity.pipeline.run.ParseDict")
+    def test_run_func_prints_and_returns_response(
+        self,
+        mock_parse_dict,
+        mock_get_message_class,
+        mock_get_methods,
+        mock_get_service_name,
+    ):
+        """Test that the generated run_func prints and returns the gRPC response."""
+        mock_get_service_name.return_value = "michelangelo.api.v2.PipelineRunService"
+
+        mock_method = MagicMock()
+        mock_method.input_type = ".michelangelo.api.v2.CreatePipelineRunRequest"
+        mock_method.output_type = ".michelangelo.api.v2.CreatePipelineRunResponse"
+        mock_pool = MagicMock()
+        mock_get_methods.return_value = ({"CreatePipelineRun": mock_method}, mock_pool)
+
+        mock_input_class = MagicMock()
+        mock_output_class = MagicMock()
+        mock_get_message_class.side_effect = [mock_input_class, mock_output_class]
+
+        mock_response = MagicMock()
+        mock_channel = MagicMock()
+        mock_channel.unary_unary.return_value.return_value = mock_response
+
+        mock_crd = MagicMock()
+        mock_crd.metadata = [("rpc-caller", "test")]
+        mock_crd.func_crd_metadata_converter.return_value = {"pipeline_run": {}}
+        mock_crd._read_signatures.return_value = Signature(
+            [
+                Parameter("self", Parameter.POSITIONAL_OR_KEYWORD),
+                Parameter("namespace", Parameter.POSITIONAL_OR_KEYWORD),
+                Parameter("name", Parameter.POSITIONAL_OR_KEYWORD),
+                Parameter(
+                    "resume_from", Parameter.POSITIONAL_OR_KEYWORD, default=None
+                ),
+            ]
+        )
+
+        generate_run(mock_crd, mock_channel)
+
+        with patch("builtins.print") as mock_print:
+            mock_crd.run(namespace="test-ns", name="test-pipeline")
+            mock_print.assert_called_once_with(mock_response)

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/run_test.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/run_test.py
@@ -313,9 +313,7 @@ class PipelineRunTest(TestCase):
                 Parameter("self", Parameter.POSITIONAL_OR_KEYWORD),
                 Parameter("namespace", Parameter.POSITIONAL_OR_KEYWORD),
                 Parameter("name", Parameter.POSITIONAL_OR_KEYWORD),
-                Parameter(
-                    "resume_from", Parameter.POSITIONAL_OR_KEYWORD, default=None
-                ),
+                Parameter("resume_from", Parameter.POSITIONAL_OR_KEYWORD, default=None),
             ]
         )
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)                                                                                    
  - [ ] Refactor                                                                                                                        
  - [ ] Feature                               
  - [x] Bug Fix                                                                                                                         
  - [ ] Optimization                          
  - [ ] Documentation Update                                                                                                            
                                                                                                                                        
  ## What changed?                                                                                                                      
                                                                                                                                        
  Three fixes to `ma pipeline run`:                                                                                                     
                                                                                                                                      
  1. **Name format** — `generate_pipeline_run_name()` now produces `run-YYYYMMDD-HHMMSS-{uuid8}`                                        
     (e.g. `run-20260406-234828-8cb2d705`, always 28 chars) instead of a unix-timestamp-based name.                                     
                                              
  2. **Missing output** — `run_func` now prints the full gRPC response before returning,                                                
     consistent with every other CLI command (`get`, `create`, `apply`, `delete`).                                                    
                                                                                                                                        
  3. **Stale `METADATA_STUB` import** — `run.py` imported `METADATA_STUB` directly at module load                                       
     time. Because `CRD.__init__` rebinds `crd.METADATA_STUB` to a new list at runtime, the                                             
     module-level reference was always stale (empty). Fixed by importing the module and accessing                                       
     `_crd_module.METADATA_STUB` at call time.                                                                                          
                                                                                                                                        
  ## Why?                                                                                                                               
                                                                                                                                        
  - The datetime-based name is more human-readable and consistent with server-side naming expectations.                                 
  - Without `print(response)`, a successful run produced no CLI output, leaving users uncertain                                         
    whether the command worked.                                                                                                         
  - The stale import caused the gRPC call to send empty metadata, resulting in server-side errors                                       
    about missing service name, caller name, and encoding headers.
                                                                                                                                        
  ## How did you test it?                                                                                                               
                                                                                                                                        
  Unit tests:                                                                                                                           
  - Updated `test_generate_pipeline_run_name` to mock `datetime` and verify the new                                                     
    `run-YYYYMMDD-HHMMSS-{uuid8}` format and fixed 28-char length.                                                                      
                                                                                                                                        
  E2E against local sandbox:                                                                                                          
  - Ran `ma pipeline run -n ma-dev-test --name bert-cola-test`                                                                          
  - Pipeline run `run-20260406-234828-8cb2d705` created successfully                                                                    
  - CLI printed the full `PipelineRun` gRPC response                                                                                    
  - Confirmed run visible via `PipelineRunService`                                                                                      
                                                                                                                                                                                                                                             
                                                                                                                                        
  ## Release notes                                                                                                                      
                                                                                                                                      
  `ma pipeline run` now prints output after creating a run, uses a human-readable                                                       
  `run-YYYYMMDD-HHMMSS-{uuid8}` name format, and correctly sends authentication metadata on the                                         
  gRPC call.                                  
                                                                                                                                        
  ## Documentation Changes                                                                                                            
                                                                                                                                        
  None. 