### PR TITLE
docs: add Helm prerequisite and Colima resource requirements to sandbox setup

### DIFF
--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -242,6 +242,8 @@ A: Yes. Michelangelo enforces:
 - Audit logs for all operations
 - Compliance with SOC 2, GDPR, HIPAA (depending on deployment)
 
+See the [Compliance Guide](../operator-guides/compliance.md) for configuration steps specific to each framework.
+
 **Q: Can I use Michelangelo for regulated industries (healthcare, finance)?**
 A: Yes, with proper configuration. Michelangelo supports:
 - Data residency requirements (region-specific storage)

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -192,7 +192,7 @@ A: Yes. Deploy multiple model versions to the same endpoint with traffic splitti
 A: Uniflow automatically:
 - Retries transient failures (network issues, spot instance preemption)
 - Preserves logs and intermediate outputs for debugging
-- Sends notifications (email, Slack) on terminal state
+- Sends notifications (email, Slack) on terminal state — see [Pipeline Notifications](../user-guides/notifications.md)
 
 ### Monitoring & Operations
 

--- a/docs/getting-started/sandbox-setup.md
+++ b/docs/getting-started/sandbox-setup.md
@@ -13,8 +13,32 @@ Before you begin, make sure you have the following installed. Run each verificat
 | **Docker** | [Get Docker](https://docs.docker.com/get-started/get-docker) or [Colima](https://github.com/abiosoft/colima) | `docker --version` |
 | **kubectl** | `brew install kubectl` or [official guide](https://kubernetes.io/docs/tasks/tools/#kubectl) | `kubectl version --client` |
 | **k3d** | `brew install k3d` | `k3d --version` |
-| **Python 3.11ru+** | [python.org](https://www.python.org/downloads/) | `python3 --version` |
+| **Helm** | `brew install helm` or [official guide](https://helm.sh/docs/intro/install/) | `helm version` |
+| **Python 3.11+** | [python.org](https://www.python.org/downloads/) | `python3 --version` |
 | **Poetry** | `curl -sSL https://install.python-poetry.org \| python3 -` | `poetry --version` |
+
+### Colima resource requirements
+
+If you are using Colima as your Docker runtime, the default VM resources are too limited for the sandbox. Start Colima with at least:
+
+```bash
+colima start --cpu 4 --memory 8 --disk 60
+```
+
+| Resource | Minimum | Recommended |
+|----------|---------|-------------|
+| CPU cores | 4 | 6 |
+| Memory (GB) | 8 | 12 |
+| Disk (GB) | 60 | 100 |
+
+> **Warning:** Starting Colima with the default settings (2 CPU, 2 GB RAM) will cause pods to crash or fail to schedule. Always pass explicit resource flags.
+
+If Colima is already running with insufficient resources, stop it and restart with the new settings:
+
+```bash
+colima stop
+colima start --cpu 4 --memory 8 --disk 60
+```
 
 ### Configure `host.docker.internal`
 

--- a/docs/meta/operator-contributor-guide-improvements.md
+++ b/docs/meta/operator-contributor-guide-improvements.md
@@ -4,7 +4,7 @@ This document proposes improvements to the operator and contributor guides based
 
 ## Background
 
-**Operator guide** targets adopters integrating Michelangelo with external ML systems (MLflow, Kubernetes clusters, schedulers, etc.).
+**Operator guide** targets adopters integrating Michelangelo with external ML systems (experiment tracking servers, Kubernetes clusters, schedulers, etc.).
 **Contributor guide** targets developers contributing features to the codebase.
 
 The analysis below identifies structural gaps and specific missing documents, with priority order and rationale.
@@ -73,17 +73,11 @@ Key patterns worth adopting:
 
 Rename `operator-guides/index.md` → `operator-guides/platform-setup.md` and create a new `index.md` as a navigation hub. The hub should describe operator personas (initial deployment, adding compute capacity, integrating ML tooling, ongoing operations) and link to the relevant guide for each.
 
-#### 2. New: Running MLflow Alongside Michelangelo
+#### 2. New: External Integrations Index
 
-**File:** `operator-guides/integrations/mlflow.md`
+**File:** `operator-guides/integrations/index.md`
 
-Michelangelo does not have a native MLflow integration. However, adopters commonly want to run MLflow alongside Michelangelo so their users can log experiments from Uniflow tasks. This guide covers what operators need to set up:
-- Deploying an MLflow tracking server as a separate Kubernetes service
-- Ensuring network connectivity from Uniflow task pods to the MLflow server
-- Making `MLFLOW_TRACKING_URI` available to users
-- Troubleshooting network policy and S3 artifact permission issues
-
-Users call the standard MLflow Python client from `@uniflow.task()` code directly — Michelangelo does not intercept or coordinate these calls.
+A landing page surfacing Michelangelo's existing extension points as first-class integration surfaces. Links to: custom serving backends (existing), custom job scheduler backends (existing), Kueue/Volcano (existing). Modeled on Flyte's Plugin Setup section — makes these guides discoverable rather than buried sub-pages.
 
 #### 3. New: Monitoring & Observability Guide
 
@@ -133,7 +127,7 @@ The current platform setup doc has a table of "domain settings to update" but no
 
 **File:** `operator-guides/integrations/index.md`
 
-A landing page for all integration guides, modeled on Flyte's Plugin Setup section. Links to: MLflow (new), custom serving backends (existing), custom job scheduler backends (existing), Kueue/Volcano (existing). Makes the existing extension point docs discoverable as first-class integration surfaces rather than buried sub-pages.
+A landing page for all integration guides, modeled on Flyte's Plugin Setup section. Links to: custom serving backends (existing), custom job scheduler backends (existing), Kueue/Volcano (existing). Makes the existing extension point docs discoverable as first-class integration surfaces rather than buried sub-pages.
 
 ---
 
@@ -209,13 +203,12 @@ Add an "Architecture for contributors" section at the top: a diagram or table ma
 
 | Priority | Item | Rationale |
 |---|---|---|
-| 1 | MLflow integration guide | Directly addresses stated adopter use case |
-| 2 | Contributing overview / `CONTRIBUTING.md` | Unblocks external contributors entirely |
-| 3 | Operator guide index restructure | Navigation foundation everything else builds on |
-| 4 | PR process + testing strategy | Most common friction points for first contributors |
-| 5 | Troubleshooting guide | High operator value, fast to write from existing knowledge |
-| 6 | Auth/OIDC guide | Required for any production deployment |
-| 7 | Monitoring & observability | Required for production SLOs |
-| 8 | Network/ingress guide | Unblocks non-Uber deployments |
-| 9 | CI pipeline guide | Contributor quality-of-life |
-| 10 | Go code style guide | Polish, reduces review comments |
+| 1 | Contributing overview / `CONTRIBUTING.md` | Unblocks external contributors entirely |
+| 2 | Operator guide index restructure | Navigation foundation everything else builds on |
+| 3 | PR process + testing strategy | Most common friction points for first contributors |
+| 4 | Troubleshooting guide | High operator value, fast to write from existing knowledge |
+| 5 | Auth/OIDC guide | Required for any production deployment |
+| 6 | Monitoring & observability | Required for production SLOs |
+| 7 | Network/ingress guide | Unblocks non-Uber deployments |
+| 8 | CI pipeline guide | Contributor quality-of-life |
+| 9 | Go code style guide | Polish, reduces review comments |

--- a/docs/meta/operator-contributor-guide-improvements.md
+++ b/docs/meta/operator-contributor-guide-improvements.md
@@ -73,18 +73,17 @@ Key patterns worth adopting:
 
 Rename `operator-guides/index.md` → `operator-guides/platform-setup.md` and create a new `index.md` as a navigation hub. The hub should describe operator personas (initial deployment, adding compute capacity, integrating ML tooling, ongoing operations) and link to the relevant guide for each.
 
-#### 2. New: MLflow Integration Guide
+#### 2. New: Running MLflow Alongside Michelangelo
 
 **File:** `operator-guides/integrations/mlflow.md`
 
-Covers:
-- Configuring the MLflow tracking server endpoint in Michelangelo
-- How experiment runs and metrics from PipelineRuns flow into MLflow
-- Using MLflow for model evaluation — connecting evaluation outputs to MLflow experiments
-- Model registry integration: pushing trained models from Michelangelo to MLflow Model Registry
-- Environment variable and ConfigMap fields for the MLflow connection
+Michelangelo does not have a native MLflow integration. However, adopters commonly want to run MLflow alongside Michelangelo so their users can log experiments from Uniflow tasks. This guide covers what operators need to set up:
+- Deploying an MLflow tracking server as a separate Kubernetes service
+- Ensuring network connectivity from Uniflow task pods to the MLflow server
+- Making `MLFLOW_TRACKING_URI` available to users
+- Troubleshooting network policy and S3 artifact permission issues
 
-This is the most important missing document given that MLflow integration is a primary adopter use case (experiment tracking, evaluation, model registry).
+Users call the standard MLflow Python client from `@uniflow.task()` code directly — Michelangelo does not intercept or coordinate these calls.
 
 #### 3. New: Monitoring & Observability Guide
 

--- a/docs/meta/operator-contributor-guide-improvements.md
+++ b/docs/meta/operator-contributor-guide-improvements.md
@@ -1,0 +1,222 @@
+# Operator & Contributor Guide Improvements
+
+This document proposes improvements to the operator and contributor guides based on a review of current content and comparison with similar open-source ML platforms (Flyte, Ray/KubeRay).
+
+## Background
+
+**Operator guide** targets adopters integrating Michelangelo with external ML systems (MLflow, Kubernetes clusters, schedulers, etc.).
+**Contributor guide** targets developers contributing features to the codebase.
+
+The analysis below identifies structural gaps and specific missing documents, with priority order and rationale.
+
+---
+
+## Current State
+
+### Operator Guide — what exists
+
+| Document | Coverage |
+|---|---|
+| `operator-guides/index.md` | Component ConfigMap reference (API server, controller manager, worker, UI/Envoy) |
+| `operator-guides/jobs/index.md` | Jobs overview — Ray vs Spark, lifecycle, observability |
+| `operator-guides/jobs/register-a-compute-cluster-to-michelangelo-control-plane.md` | Step-by-step cluster registration |
+| `operator-guides/jobs/run-uniflow-pipeline-on-compute-cluster.md` | Running pipelines on a compute cluster |
+| `operator-guides/jobs/extend-michelangelo-batch-job-scheduler-system.md` | Custom scheduler backends (Kueue, Volcano), custom assignment strategies |
+| `operator-guides/serving/index.md` | Serving architecture, InferenceServer + Deployment lifecycle |
+| `operator-guides/serving/cluster-setup.md` | Serving cluster setup for local sandbox |
+| `operator-guides/serving/integrate-custom-backend.md` | Plugin interfaces: Backend, ModelConfigProvider, RouteProvider |
+| `operator-guides/ui/` | UI deployment, local dev, React library |
+| `operator-guides/ingester-design.md` | Ingester architecture |
+| `operator-guides/ingester-sandbox-validation.md` | Ingester sandbox validation |
+| `operator-guides/compliance.md` | SOC 2, GDPR, HIPAA configuration |
+| `operator-guides/api-framework.md` | High-level API architecture overview |
+
+**Structural issue:** `operator-guides/index.md` is the full platform setup reference, not a navigation hub. Operators have no entry point that explains where to start or which guide applies to their situation.
+
+### Contributor Guide — what exists
+
+| Document | Coverage |
+|---|---|
+| `contributing/building-michelangelo-ai-from-source.md` | Build commands for Go components and Python tooling |
+| `contributing/how-to-write-apis.md` | Proto definitions, Gazelle, gRPC code generation |
+| `contributing/manage-go-dependencies.md` | `go mod tidy`, `bazel mod tidy` |
+| `contributing/use-go-mocks-in-unit-test.md` | gomock usage |
+| `contributing/uniflow-plugin-guide.md` | End-to-end plugin development (Go worker → Starlark → Python TaskConfig) |
+| `contributing/documentation-guide.md` | Documentation conventions |
+| `contributing/TERMINOLOGY.md` | Glossary of core concepts |
+| `contributing/dev/go/error-handling.md` | Go error handling patterns and PR checklist |
+| `contributing/dev/python/mactl/coding_guidelines.md` | Python coding guidelines |
+| `contributing/dev/ui/` | UI patterns, components, configuration |
+
+**Structural issue:** No contributing overview or `CONTRIBUTING.md` equivalent. External contributors have no entry point explaining types of contributions, component ownership, or how to submit a PR.
+
+---
+
+## Reference: Flyte and Ray
+
+**Flyte** organizes its operator guide into: Deployment Paths, Plugin Setup, Agent Setup, Cluster Configuration, Configuration Reference, Security Overview. Contributor guide uses a learning-first approach: run examples, understand architecture, then contribute.
+
+**Ray/KubeRay** operator guide covers multiple deployment targets (Kubernetes, cloud VMs), custom resources (RayCluster, RayJob, RayService), ecosystem integrations, troubleshooting, and benchmarks. Contributor guide has 13 sections including: PR process, code style, CI explanation, API compatibility guide, and a committer pathway.
+
+Key patterns worth adopting:
+- Ray's troubleshooting guide is one of its most-visited operator pages
+- Ray's CI transparency (what jobs run, how to interpret failures) meaningfully reduces contributor friction
+- Flyte's plugin/agent setup section directly maps to Michelangelo's serving backend and job scheduler extension points — but those are currently buried rather than surfaced as first-class integration surfaces
+
+---
+
+## Proposed Changes
+
+### Operator Guide
+
+#### 1. Restructure the index (no new content needed)
+
+Rename `operator-guides/index.md` → `operator-guides/platform-setup.md` and create a new `index.md` as a navigation hub. The hub should describe operator personas (initial deployment, adding compute capacity, integrating ML tooling, ongoing operations) and link to the relevant guide for each.
+
+#### 2. New: MLflow Integration Guide
+
+**File:** `operator-guides/integrations/mlflow.md`
+
+Covers:
+- Configuring the MLflow tracking server endpoint in Michelangelo
+- How experiment runs and metrics from PipelineRuns flow into MLflow
+- Using MLflow for model evaluation — connecting evaluation outputs to MLflow experiments
+- Model registry integration: pushing trained models from Michelangelo to MLflow Model Registry
+- Environment variable and ConfigMap fields for the MLflow connection
+
+This is the most important missing document given that MLflow integration is a primary adopter use case (experiment tracking, evaluation, model registry).
+
+#### 3. New: Monitoring & Observability Guide
+
+**File:** `operator-guides/monitoring.md`
+
+Covers:
+- Prometheus scrape targets for each Michelangelo component
+- Key operational metrics: job queue depth, scheduler assignment latency, inference request P99, workflow engine lag
+- Grafana dashboard setup
+- Alert recommendations for production deployments
+
+Ray has dedicated observability documentation and it's among the most referenced pages for operators validating SLOs.
+
+#### 4. New: Authentication & Identity Provider Setup
+
+**File:** `operator-guides/authentication.md`
+
+The compliance guide references RBAC and OIDC but there is no setup guide. Covers:
+- OIDC provider configuration (connecting an enterprise IdP)
+- Service account token flows for compute clusters
+- Multi-tenant namespace isolation
+- Session token expiry configuration
+
+#### 5. New: Troubleshooting Guide
+
+**File:** `operator-guides/troubleshooting.md`
+
+Common failure modes and diagnostic steps for:
+- Jobs: cluster registration failures, scheduler not assigning, Temporal/Cadence connectivity issues, Ray pod crashes
+- Serving: model not loading, HTTPRoute not created, health check failures
+- Worker: API server connectivity, workflow engine connection
+- Shared: storage (S3/MinIO) permission errors, kubeconfig context issues
+
+Ray's troubleshooting guide is one of its most-visited operator pages. A single reference with `kubectl` diagnostic commands and log patterns significantly reduces support burden.
+
+#### 6. New: Network & Ingress Configuration
+
+**File:** `operator-guides/network.md`
+
+The current platform setup doc has a table of "domain settings to update" but no guide. Covers:
+- Envoy proxy configuration (CORS, cluster hostnames)
+- Ingress setup for API server and UI
+- cert-manager TLS configuration
+- Multi-cluster network topology (control plane → compute cluster connectivity requirements)
+
+#### 7. New: External Integrations Index
+
+**File:** `operator-guides/integrations/index.md`
+
+A landing page for all integration guides, modeled on Flyte's Plugin Setup section. Links to: MLflow (new), custom serving backends (existing), custom job scheduler backends (existing), Kueue/Volcano (existing). Makes the existing extension point docs discoverable as first-class integration surfaces rather than buried sub-pages.
+
+---
+
+### Contributor Guide
+
+#### 1. New: Contributing Overview
+
+**File:** `contributing/index.md` (or top-level `CONTRIBUTING.md`)
+
+The single most important missing piece. Modeled on Ray's contributor guide entry point:
+- Types of contributions (new plugins, API extensions, bug fixes, docs)
+- Component map: which directory owns which subsystem
+- How to find work (issue labels, good first issues)
+- Quick-start: fork → build → test → PR in ~5 steps
+- Links to all detailed guides below
+
+Without this, external contributors have no entry point.
+
+#### 2. New: PR & Review Process
+
+**File:** `contributing/pr-process.md`
+
+Covers:
+- Branch naming conventions
+- PR description template
+- What CI jobs run and what must pass before merge
+- Review expectations and SLAs
+- How to handle review feedback
+- Merge criteria
+
+#### 3. New: Testing Strategy
+
+**File:** `contributing/testing.md`
+
+The mocks guide is narrow. A broader guide covers:
+- Test pyramid: unit tests (same package, `_test.go`), integration tests (sandbox), E2E
+- How to run unit tests locally (`bazel test //go/...`)
+- Integration test setup using the sandbox (`ma sandbox create`)
+- Test coverage expectations per layer
+- When to use mocks vs real dependencies (links to existing mocks guide)
+
+#### 4. New: CI Pipeline Guide
+
+**File:** `contributing/ci.md`
+
+Covers:
+- Which jobs run on PRs (linting, unit tests, build checks)
+- How to interpret CI failures
+- How to re-trigger or skip jobs where appropriate
+- Bazel remote caching behavior
+
+Ray's CI transparency is a significant contributor trust-builder. Contributors who can read CI output without needing help unblock themselves.
+
+#### 5. Expand: Building from Source — add architecture section
+
+**File:** `contributing/building-michelangelo-ai-from-source.md` (expand existing)
+
+Add an "Architecture for contributors" section at the top: a diagram or table mapping Go packages to subsystems. The uniflow plugin guide does this well for the plugin layer. Contributors working on the control plane (apiserver, controllermgr, worker) need the equivalent.
+
+#### 6. New: Go Code Style Guide
+
+**File:** `contributing/dev/go/code-style.md`
+
+`error-handling.md` exists and is good. Expand to a broader guide:
+- Package naming and structure conventions
+- Interface design patterns (modeled on the `Backend`/`ModelConfigProvider`/`RouteProvider` patterns already in the codebase)
+- Logging conventions (zap field names, log levels)
+- Test file organization and naming
+
+---
+
+## Priority Order
+
+| Priority | Item | Rationale |
+|---|---|---|
+| 1 | MLflow integration guide | Directly addresses stated adopter use case |
+| 2 | Contributing overview / `CONTRIBUTING.md` | Unblocks external contributors entirely |
+| 3 | Operator guide index restructure | Navigation foundation everything else builds on |
+| 4 | PR process + testing strategy | Most common friction points for first contributors |
+| 5 | Troubleshooting guide | High operator value, fast to write from existing knowledge |
+| 6 | Auth/OIDC guide | Required for any production deployment |
+| 7 | Monitoring & observability | Required for production SLOs |
+| 8 | Network/ingress guide | Unblocks non-Uber deployments |
+| 9 | CI pipeline guide | Contributor quality-of-life |
+| 10 | Go code style guide | Polish, reduces review comments |

--- a/docs/operator-guides/compliance.md
+++ b/docs/operator-guides/compliance.md
@@ -1,0 +1,220 @@
+---
+sidebar_position: 10
+sidebar_label: "Compliance"
+---
+
+# Compliance Guide
+
+Michelangelo supports compliance with SOC 2, GDPR, and HIPAA depending on how you deploy and configure the platform. Achieving compliance requires proper configuration of access controls, encryption, audit logging, and data handling practices described in this guide.
+
+:::warning
+Compliance is a shared responsibility. This guide covers Michelangelo-specific configuration. You are also responsible for ensuring your broader infrastructure, organizational processes, and legal agreements meet each framework's requirements.
+:::
+
+## SOC 2
+
+SOC 2 (System and Organization Controls 2) evaluates controls across five Trust Service Criteria: security, availability, processing integrity, confidentiality, and privacy.
+
+### Access Control
+
+Enable RBAC for all Michelangelo resources and grant least-privilege access — users should only have the permissions required for their role.
+
+```yaml
+apiserver:
+  auth:
+    rbacEnabled: true
+```
+
+- Integrate with your organization's identity provider (IdP) via OIDC/OAuth 2.0
+- Enforce multi-factor authentication (MFA) at the IdP level
+- Set session token expiry appropriate for your security policy
+- Disable any direct database or object store access that bypasses the Michelangelo API
+
+### Encryption
+
+- Enable TLS for all internal and external communication. Set `useTLS: true` in the Worker configuration.
+- Use IAM roles for S3 access rather than hardcoded credentials (`useIam: true` in Controller Manager config)
+- Enforce server-side encryption on your object store bucket (SSE-S3 or SSE-KMS)
+
+### Network Security
+
+- Deploy Michelangelo inside a private VPC with no direct public access to internal services
+- Expose only the Envoy proxy and UI to controlled network segments
+- Restrict Kubernetes API server access to authorized operators using network policies
+
+### Availability
+
+- Enable leader election for the Controller Manager (`leaderElection: true`) to prevent split-brain in HA deployments
+- Run multiple replicas of the API Server and Controller Manager
+- Configure liveness and readiness probes on all components
+- Set up alerting on component health endpoints (`healthProbeBindAddress: 8081`)
+
+### Audit Logging
+
+All operations through the Michelangelo API are captured in audit logs. Ensure logs are:
+
+- Forwarded to a centralized, tamper-resistant log store (e.g., CloudWatch, Splunk, Datadog)
+- Retained for a minimum of 12 months
+- Protected by access controls so only authorized personnel can read or delete them
+
+### Confidentiality
+
+- Restrict model artifacts, datasets, and experiment results using project-level RBAC
+- Ensure object store bucket policies deny public access
+- Rotate credentials and access tokens on a regular schedule
+
+---
+
+## GDPR
+
+The General Data Protection Regulation (GDPR) applies when processing personal data of EU residents. Michelangelo can be configured to meet GDPR requirements around data residency, subject rights, and retention.
+
+### Data Residency
+
+Store all personal data in EU regions by configuring object storage to an EU endpoint:
+
+```yaml
+minio:
+  awsRegion: eu-west-1
+  awsEndpointUrl: s3.eu-west-1.amazonaws.com
+  useIam: true
+```
+
+Ensure your Kubernetes cluster, Temporal/Cadence workflow engine, and any external data sources are also deployed in the same EU region.
+
+### Data Minimization
+
+- Only ingest and store data fields required for the ML task
+- Use Michelangelo's data prep pipelines to strip personally identifiable information (PII) before training
+- Avoid logging raw personal data in pipeline run outputs or model experiment metadata
+
+### Data Subject Rights
+
+**Right to Access**: Michelangelo's audit logs and model lineage tracking let you identify which data was used to train a specific model. Use these records to respond to Data Subject Access Requests (DSARs).
+
+**Right to Erasure**: When a data subject requests deletion:
+1. Identify all datasets, pipeline runs, and model versions that reference their data
+2. Delete or anonymize the source data in your data store
+3. Retrain or retire affected models where the data cannot be removed post-hoc
+4. Document the erasure in your organization's records
+
+**Right to Portability**: Use Michelangelo's export capabilities to produce data in standard formats (Parquet, CSV) when a subject requests their data.
+
+### Retention Policies
+
+- Define dataset and model artifact retention policies appropriate to your use case
+- Periodically review and purge datasets containing personal data no longer needed for the original purpose
+- Configure object store lifecycle rules to automatically expire old artifacts
+
+### Consent and Legal Basis
+
+Michelangelo does not manage consent records. Ensure your organization's consent management system is integrated with your data ingestion pipeline so that only data with a valid legal basis flows into Michelangelo training workflows.
+
+### Data Processing Agreements
+
+If you use cloud infrastructure providers (AWS, GCP, Azure) to host Michelangelo, you must have a Data Processing Agreement (DPA) in place with each provider before processing personal data on their infrastructure.
+
+---
+
+## HIPAA
+
+The Health Insurance Portability and Accountability Act (HIPAA) applies when processing Protected Health Information (PHI). Compliance requires technical, administrative, and physical safeguards.
+
+:::danger
+Do not store PHI in Michelangelo unless your deployment has been reviewed by your compliance and legal teams and all safeguards below are confirmed to be in place. HIPAA violations carry significant legal and financial penalties.
+:::
+
+### Technical Safeguards
+
+**Access Controls**
+
+- Assign unique user IDs to every Michelangelo user — never use shared accounts
+- Enable RBAC and restrict PHI-containing datasets and models to authorized users only
+- Implement automatic session timeouts at the IdP level
+- Audit all access to PHI-containing resources using Michelangelo's audit logs
+
+**Encryption**
+
+| Layer | Requirement | Configuration |
+|-------|-------------|---------------|
+| Data in transit | TLS 1.2+ | Set `useTLS: true` in Worker config; enforce HTTPS on Envoy |
+| Data at rest | AES-256 | Enable SSE-KMS on your S3 bucket |
+| Kubernetes secrets | Encrypted etcd | Enable etcd encryption-at-rest in your cluster configuration |
+
+**Audit Controls**
+
+HIPAA requires audit logs that record access to PHI. Configure your logging pipeline to capture:
+
+- User identity and timestamp for every Michelangelo API call
+- Dataset reads and writes
+- Model training runs that reference PHI datasets
+- Deployment and inference events
+
+Forward logs to a HIPAA-eligible log management service and retain them for a minimum of **6 years**.
+
+**Integrity Controls**
+
+- Enable object versioning on your S3 bucket to detect unauthorized modification of artifacts
+- Use checksums provided by Michelangelo's artifact storage to verify data integrity on read
+- Configure S3 Object Lock (WORM mode) on audit log buckets to prevent tampering
+
+**Transmission Security**
+
+- Route all traffic through the Envoy proxy with TLS termination; disable any plaintext HTTP listeners
+- Use VPN or private network peering for any cross-region traffic that may carry PHI
+
+### Administrative Safeguards
+
+- Designate a HIPAA Privacy Officer and Security Officer for your organization
+- Conduct annual risk assessments that explicitly include your Michelangelo deployment
+- Train all users with access to PHI-containing projects on HIPAA requirements and your organization's privacy policies
+- Establish and enforce a workforce sanctions policy for unauthorized PHI access
+
+### Business Associate Agreements (BAAs)
+
+You must have a signed BAA with:
+
+- Your cloud infrastructure provider (AWS, GCP, Azure)
+- Any third-party services integrated with Michelangelo that may process PHI
+- Your managed Temporal or Cadence service provider, if applicable
+
+### PHI Readiness Checklist
+
+Before processing PHI data in Michelangelo, verify each item:
+
+- [ ] RBAC enabled and scoped to minimum necessary access
+- [ ] TLS enabled on all components (`useTLS: true`)
+- [ ] S3 bucket encryption (SSE-KMS) enabled
+- [ ] S3 Object Lock (WORM) enabled on audit log buckets
+- [ ] Audit logs forwarded to HIPAA-eligible log store with 6-year retention
+- [ ] Automatic session timeout configured at IdP
+- [ ] BAAs signed with all relevant vendors
+- [ ] Annual risk assessment completed and documented
+- [ ] Incident response plan covers PHI breach notification (60-day HIPAA deadline)
+
+---
+
+## General Security Recommendations
+
+These practices improve your security posture across all three frameworks.
+
+### Kubernetes Hardening
+
+- Use Kubernetes Network Policies to restrict pod-to-pod communication to only required paths
+- Apply Pod Security Standards (restricted profile) to Michelangelo workloads
+- Regularly patch Kubernetes nodes and Michelangelo component images
+- Store credentials in Kubernetes Secrets or an external secrets manager (HashiCorp Vault, AWS Secrets Manager) rather than in ConfigMaps
+
+### Monitoring and Alerting
+
+- Monitor the Controller Manager metrics endpoint (`metricsBindAddress: 8091`) for anomalies
+- Alert on failed authentication attempts and privilege escalation events in your IdP logs
+- Alert on unexpected data access patterns such as bulk dataset downloads outside of scheduled pipeline runs
+
+### Incident Response
+
+- Document an incident response runbook that covers Michelangelo-specific scenarios (unauthorized model access, artifact tampering, credential exposure)
+- Test the runbook at least annually with tabletop exercises
+- Ensure your runbook includes breach notification timelines:
+  - **GDPR**: 72 hours to notify supervisory authority
+  - **HIPAA**: 60 days to notify affected individuals and HHS

--- a/docs/user-guides/index.md
+++ b/docs/user-guides/index.md
@@ -50,6 +50,7 @@ Serve predictions in production:
 ### **Advanced Topics**
 
 * [Set Up Pipeline Triggers](./set-up-triggers.md) - Schedule pipelines to run automatically
+* [Pipeline Notifications](./notifications.md) - Get email and Slack alerts on pipeline run outcomes
 * [CLI Reference](./cli.md) - Command-line tools for pipeline and project management
 * [Project Management](./project-management-for-ml-pipelines.md) - Create and manage MA Studio projects
 

--- a/docs/user-guides/notifications.md
+++ b/docs/user-guides/notifications.md
@@ -1,0 +1,161 @@
+---
+sidebar_position: 9
+sidebar_label: "Pipeline Notifications"
+---
+
+# Pipeline Notifications
+
+Michelangelo can send email or Slack notifications when a pipeline run, trigger run, or pipeline reaches a terminal state. Notifications are configured directly in the resource spec YAML — no separate setup is required per pipeline.
+
+:::note
+Notification delivery requires platform-level integration with a Communication API Gateway (CAG). If notifications are not being delivered in your deployment, contact your Michelangelo operator to confirm the integration is configured. See the [operator integration note](#operator-integration) below.
+:::
+
+## Configuration
+
+Add a `notifications` field to any `PipelineRun`, `TriggerRun`, or `Pipeline` spec. Each entry in the list is one notification rule — you can have multiple rules with different event types and destinations.
+
+```yaml
+notifications:
+  - notificationType: NOTIFICATION_TYPE_EMAIL
+    resourceType: RESOURCE_TYPE_PIPELINE_RUN
+    eventTypes:
+      - EVENT_TYPE_PIPELINE_RUN_STATE_SUCCEEDED
+      - EVENT_TYPE_PIPELINE_RUN_STATE_FAILED
+    emails:
+      - "you@example.com"
+      - "team@example.com"
+
+  - notificationType: NOTIFICATION_TYPE_SLACK
+    resourceType: RESOURCE_TYPE_PIPELINE_RUN
+    eventTypes:
+      - EVENT_TYPE_PIPELINE_RUN_STATE_FAILED
+      - EVENT_TYPE_PIPELINE_RUN_STATE_KILLED
+    slackDestinations:
+      - "#ml-alerts"
+```
+
+### Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `notificationType` | Yes | `NOTIFICATION_TYPE_EMAIL` or `NOTIFICATION_TYPE_SLACK` |
+| `resourceType` | Yes | The resource being watched. See [Resource Types](#resource-types). |
+| `eventTypes` | Yes | One or more events that trigger this notification. See [Event Types](#event-types). |
+| `emails` | For email | List of recipient email addresses. |
+| `slackDestinations` | For Slack | List of Slack channel names (e.g. `#alerts`). These are channel names, not webhook URLs — routing is handled by the platform. |
+
+## Event Types
+
+Choose events based on the `resourceType` of the notification:
+
+### Pipeline Run events (`RESOURCE_TYPE_PIPELINE_RUN`)
+
+| Event type | When it fires |
+|------------|---------------|
+| `EVENT_TYPE_PIPELINE_RUN_STATE_SUCCEEDED` | Run completed successfully |
+| `EVENT_TYPE_PIPELINE_RUN_STATE_FAILED` | Run failed |
+| `EVENT_TYPE_PIPELINE_RUN_STATE_KILLED` | Run was manually stopped |
+| `EVENT_TYPE_PIPELINE_RUN_STATE_SKIPPED` | Run was skipped (e.g. by a trigger concurrency policy) |
+
+### Trigger Run events (`RESOURCE_TYPE_TRIGGER_RUN`)
+
+| Event type | When it fires |
+|------------|---------------|
+| `EVENT_TYPE_TRIGGER_RUN_STATE_SUCCEEDED` | Trigger run completed |
+| `EVENT_TYPE_TRIGGER_RUN_STATE_FAILED` | Trigger run failed |
+| `EVENT_TYPE_TRIGGER_RUN_STATE_KILLED` | Trigger run was stopped |
+
+### Pipeline events (`RESOURCE_TYPE_PIPELINE`)
+
+| Event type | When it fires |
+|------------|---------------|
+| `EVENT_TYPE_PIPELINE_STATE_READY` | Pipeline build succeeded and is ready to run |
+| `EVENT_TYPE_PIPELINE_STATE_ERROR` | Pipeline build failed |
+
+## Resource Types
+
+| Resource type | Use with |
+|---------------|----------|
+| `RESOURCE_TYPE_PIPELINE_RUN` | `PipelineRun` spec or any spec that creates runs |
+| `RESOURCE_TYPE_TRIGGER_RUN` | `TriggerRun` spec |
+| `RESOURCE_TYPE_PIPELINE` | `Pipeline` spec (build-time events) |
+
+## Message Format
+
+Both channels receive the same information, formatted for the medium.
+
+**Slack message:**
+```
+Pipeline Run (my-training-run) has completed with state FAILED:
+- Name: my-training-run
+- Project: my-project
+- State: FAILED
+- Pipeline Type: TRAIN
+- <https://michelangelo-studio.example.com/ma/my-project/train/runs/my-training-run|Michelangelo Studio URL>
+```
+
+**Email:**
+- Subject: `Pipeline Run (my-training-run) has completed with state FAILED`
+- Sender: `michelangelo@uber.com`
+- Body contains the same fields as the Slack message, as plain text with a link to MA Studio
+
+For ASL (Amazon States Language) pipelines, a Cadence Log URL is appended to the message.
+
+## Full Example: TriggerRun with Both Channels
+
+This example sends email on success or failure and Slack only on failure or kill:
+
+```yaml
+apiVersion: michelangelo.api/v2
+kind: TriggerRun
+metadata:
+  name: training-pipeline-backfill-trigger
+  namespace: my-project
+spec:
+  pipeline:
+    name: training-pipeline
+    namespace: my-project
+  trigger:
+    cronSchedule:
+      cron: "0 8 * * *"
+    maxConcurrency: 3
+  startTimestamp: 2025-10-01T00:00:00Z
+  endTimestamp: 2025-10-08T00:00:00Z
+  notifications:
+    - notificationType: NOTIFICATION_TYPE_EMAIL
+      resourceType: RESOURCE_TYPE_PIPELINE_RUN
+      eventTypes:
+        - EVENT_TYPE_PIPELINE_RUN_STATE_SUCCEEDED
+        - EVENT_TYPE_PIPELINE_RUN_STATE_FAILED
+      emails:
+        - "you@example.com"
+
+    - notificationType: NOTIFICATION_TYPE_SLACK
+      resourceType: RESOURCE_TYPE_PIPELINE_RUN
+      eventTypes:
+        - EVENT_TYPE_PIPELINE_RUN_STATE_FAILED
+        - EVENT_TYPE_PIPELINE_RUN_STATE_KILLED
+      slackDestinations:
+        - "#ml-alerts"
+```
+
+Apply it with the CLI:
+
+```bash
+ma apply -f trigger.yaml
+```
+
+## Operator Integration
+
+Notification delivery is handled by two Temporal/Cadence activities in the Michelangelo worker:
+
+- `SendMessageToSlackActivity` — sends the formatted message to the specified Slack channel
+- `SendMessageToEmailActivity` — sends the formatted email to all recipients
+
+These activities are stubs that must be connected to a Communication API Gateway (CAG) or equivalent messaging service by your platform operator. The activities receive a `channel` + `text` (Slack) or a full email request struct (`to`, `cc`, `subject`, `html`, `text`, `send_as`) and are responsible for delivery.
+
+If you are an operator implementing this integration, see:
+- `go/worker/activities/notification/activities.go` — activity stubs with the request types and integration comments
+- `go/worker/workflows/notification/workflows.go` — the workflow that calls the activities
+- `go/base/notification/types/types.go` — message generation helpers


### PR DESCRIPTION
## Summary

- Added **Helm** to the prerequisites table (was missing, caused setup failures when tested)
- Added **Colima resource requirements** section with minimum/recommended CPU, memory, and disk specs, and a warning that default Colima settings (2 CPU, 2 GB RAM) will cause pod crashes
- Fixed typo: `Python 3.11ru+` → `Python 3.11+`

## Test plan

- [ ] Verify prerequisites table renders correctly
- [ ] Verify Colima resource requirements section appears between the prerequisites table and the `host.docker.internal` section
- [ ] Run `cd website && bun run build` to confirm no broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)