### PR TITLE
Add MapField component to packages/core

### DIFF
--- a/javascript/packages/core/components/form/fields/map/__tests__/map-field.test.tsx
+++ b/javascript/packages/core/components/form/fields/map/__tests__/map-field.test.tsx
@@ -1,0 +1,273 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+
+import { MapField } from '#core/components/form/fields/map/map-field';
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
+import { getFormProviderWrapper } from '#core/test/wrappers/get-form-provider-wrapper';
+import { getIconProviderWrapper } from '#core/test/wrappers/get-icon-provider-wrapper';
+
+describe('MapField', () => {
+  it('renders with label', () => {
+    render(
+      <MapField name="metadata" label="Metadata" />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getFormProviderWrapper({ onSubmit: vi.fn() }),
+      ])
+    );
+    expect(screen.getByText('Metadata')).toBeInTheDocument();
+  });
+
+  it('shows empty message when no entries exist', () => {
+    render(
+      <MapField name="metadata" label="Metadata" emptyMessage="No entries yet" />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getFormProviderWrapper({ onSubmit: vi.fn() }),
+      ])
+    );
+    expect(screen.getByText('No entries yet')).toBeInTheDocument();
+  });
+
+  it('renders initial values as key-value rows', () => {
+    render(
+      <MapField name="metadata" label="Metadata" />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getFormProviderWrapper({
+          onSubmit: vi.fn(),
+          initialValues: { metadata: { host: 'localhost', port: '8080' } },
+        }),
+      ])
+    );
+
+    const inputs = screen.getAllByRole('textbox');
+    expect(inputs).toHaveLength(4);
+    expect(inputs[0]).toHaveValue('host');
+    expect(inputs[1]).toHaveValue('localhost');
+    expect(inputs[2]).toHaveValue('port');
+    expect(inputs[3]).toHaveValue('8080');
+  });
+
+  it('adds a new row via add button', async () => {
+    const user = userEvent.setup();
+    render(
+      <MapField name="metadata" label="Metadata" />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getFormProviderWrapper({ onSubmit: vi.fn() }),
+      ])
+    );
+
+    await user.click(screen.getByText('Add more'));
+    expect(screen.getAllByRole('textbox')).toHaveLength(2);
+  });
+
+  it('removes a row via delete button', async () => {
+    const user = userEvent.setup();
+    render(
+      <MapField name="metadata" label="Metadata" />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getFormProviderWrapper({
+          onSubmit: vi.fn(),
+          initialValues: { metadata: { a: '1', b: '2' } },
+        }),
+      ])
+    );
+
+    expect(screen.getAllByRole('textbox')).toHaveLength(4);
+    const deleteButtons = screen.getAllByRole('button', { name: 'Delete' });
+    await user.click(deleteButtons[0]);
+
+    const remaining = screen.getAllByRole('textbox');
+    expect(remaining).toHaveLength(2);
+    expect(remaining[0]).toHaveValue('b');
+    expect(remaining[1]).toHaveValue('2');
+  });
+
+  it('submits form with correct Record shape', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(
+      <>
+        <MapField name="metadata" label="Metadata" />
+        <button type="submit">Submit</button>
+      </>,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getFormProviderWrapper({ onSubmit }),
+      ])
+    );
+
+    await user.click(screen.getByText('Add more'));
+    const inputs = screen.getAllByRole('textbox');
+    await user.type(inputs[0], 'host');
+    await user.type(inputs[1], 'localhost');
+
+    await user.click(screen.getByText('Submit'));
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalled();
+      expect(onSubmit.mock.calls[0][0]).toEqual(
+        expect.objectContaining({ metadata: { host: 'localhost' } })
+      );
+    });
+  });
+
+  it('shows required indicator', () => {
+    render(
+      <MapField name="metadata" label="Metadata" required />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getFormProviderWrapper({ onSubmit: vi.fn() }),
+      ])
+    );
+    expect(
+      screen.getAllByText((_, element) => element?.textContent === 'Metadata*').length
+    ).toBeGreaterThan(0);
+  });
+
+  it('singleValue: renders one row with no add/delete buttons', () => {
+    render(
+      <MapField name="metadata" label="Metadata" singleValue />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getFormProviderWrapper({ onSubmit: vi.fn() }),
+      ])
+    );
+
+    expect(screen.getAllByRole('textbox')).toHaveLength(2);
+    expect(screen.queryByText('Add more')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument();
+  });
+
+  it('readOnly: hides add and delete buttons, makes inputs read-only', () => {
+    render(
+      <MapField name="metadata" label="Metadata" readOnly />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getFormProviderWrapper({
+          onSubmit: vi.fn(),
+          initialValues: { metadata: { key: 'val' } },
+        }),
+      ])
+    );
+
+    expect(screen.queryByText('Add more')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument();
+    const inputs = screen.getAllByRole('textbox');
+    for (const input of inputs) {
+      expect(input).toHaveAttribute('readonly');
+    }
+  });
+
+  it('creatable=false: hides add button', () => {
+    render(
+      <MapField name="metadata" label="Metadata" creatable={false} />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getFormProviderWrapper({
+          onSubmit: vi.fn(),
+          initialValues: { metadata: { a: '1' } },
+        }),
+      ])
+    );
+    expect(screen.queryByText('Add more')).not.toBeInTheDocument();
+  });
+
+  it('deletable=false: keeps add button but hides delete buttons', () => {
+    render(
+      <MapField name="metadata" label="Metadata" deletable={false} />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getFormProviderWrapper({
+          onSubmit: vi.fn(),
+          initialValues: { metadata: { a: '1' } },
+        }),
+      ])
+    );
+    expect(screen.getByText('Add more')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument();
+  });
+
+  it('uses custom placeholders from keyConfig and valueConfig', async () => {
+    const user = userEvent.setup();
+    render(
+      <MapField
+        name="metadata"
+        label="Metadata"
+        keyConfig={{ placeholder: 'Feature' }}
+        valueConfig={{ placeholder: 'Transformation' }}
+      />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getFormProviderWrapper({ onSubmit: vi.fn() }),
+      ])
+    );
+
+    await user.click(screen.getByText('Add more'));
+    expect(screen.getByPlaceholderText('Feature')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Transformation')).toBeInTheDocument();
+  });
+
+  it('shows error on duplicate keys', async () => {
+    const user = userEvent.setup();
+    render(
+      <MapField name="metadata" label="Metadata" />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getFormProviderWrapper({
+          onSubmit: vi.fn(),
+          initialValues: { metadata: { a: '1' } },
+        }),
+      ])
+    );
+
+    await user.click(screen.getByText('Add more'));
+    const keyInputs = screen.getAllByRole('textbox').filter((_, i) => i % 2 === 0);
+    await user.type(keyInputs[1], 'a');
+
+    await waitFor(() => {
+      expect(screen.getAllByTitle(/cannot have duplicated values/).length).toBeGreaterThan(0);
+    });
+  });
+
+  it('add then delete then add: renders new empty row', async () => {
+    const user = userEvent.setup();
+    render(
+      <MapField name="metadata" label="Metadata" />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getFormProviderWrapper({ onSubmit: vi.fn() }),
+      ])
+    );
+
+    await user.click(screen.getByText('Add more'));
+    expect(screen.getAllByRole('textbox')).toHaveLength(2);
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+
+    await user.click(screen.getByText('Add more'));
+    const inputs = screen.getAllByRole('textbox');
+    expect(inputs).toHaveLength(2);
+    expect(inputs[0]).toHaveValue('');
+    expect(inputs[1]).toHaveValue('');
+  });
+});

--- a/javascript/packages/core/components/form/fields/map/key-value-row.tsx
+++ b/javascript/packages/core/components/form/fields/map/key-value-row.tsx
@@ -1,0 +1,95 @@
+import { useStyletron } from 'baseui';
+import { Button, KIND, SHAPE } from 'baseui/button';
+import { Input } from 'baseui/input';
+
+import { Icon } from '#core/components/icon/icon';
+import { IconKind } from '#core/components/icon/types';
+
+import type { KeyValueEntry, KeyValueRowConfig } from './types';
+
+interface KeyValueRowProps extends KeyValueRowConfig {
+  row: KeyValueEntry;
+  readOnly?: boolean;
+  disabled?: boolean;
+  keyError?: string;
+  onChange: (row: KeyValueEntry) => void;
+  onDelete: (row: KeyValueEntry) => void;
+  onFocus: () => void;
+  onBlur: () => void;
+}
+
+export function KeyValueRow({
+  row,
+  keyConfig,
+  valueConfig,
+  readOnly,
+  disabled,
+  deletable = true,
+  size,
+  keyError,
+  onChange,
+  onDelete,
+  onFocus,
+  onBlur,
+}: KeyValueRowProps) {
+  const [css, theme] = useStyletron();
+
+  const blurIfRowFilled = row.key && row.value ? onBlur : undefined;
+
+  return (
+    <div
+      className={css({
+        display: 'flex',
+        alignItems: 'flex-start',
+        gap: theme.sizing.scale300,
+        width: '100%',
+      })}
+    >
+      <Input
+        value={row.key}
+        onChange={(e) => onChange({ ...row, key: e.currentTarget.value })}
+        onFocus={onFocus}
+        onBlur={blurIfRowFilled}
+        placeholder={keyConfig?.placeholder ?? 'Key'}
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- false is a valid value, so || is needed to fall through to keyConfig?.readOnly
+        readOnly={readOnly || keyConfig?.readOnly}
+        disabled={disabled}
+        size={size}
+        error={!!keyError}
+        overrides={{
+          Root: {
+            style: { flex: 1 },
+            props: keyError ? { title: keyError } : undefined,
+          },
+        }}
+      />
+      <Input
+        value={row.value}
+        onChange={(e) => onChange({ ...row, value: e.currentTarget.value })}
+        onFocus={onFocus}
+        onBlur={blurIfRowFilled}
+        placeholder={valueConfig?.placeholder ?? 'Value'}
+        readOnly={readOnly}
+        disabled={disabled}
+        size={size}
+        overrides={{ Root: { style: { flex: 3 } } }}
+      />
+      {!readOnly && deletable && (
+        <Button
+          type="button"
+          aria-label="Delete"
+          kind={KIND.tertiary}
+          shape={SHAPE.circle}
+          onClick={() => onDelete(row)}
+          overrides={{
+            BaseButton: {
+              style: { marginBottom: theme.sizing.scale600 },
+            },
+          }}
+        >
+          <Icon name="trashCan" kind={IconKind.TERTIARY} />
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/javascript/packages/core/components/form/fields/map/map-field.tsx
+++ b/javascript/packages/core/components/form/fields/map/map-field.tsx
@@ -1,0 +1,150 @@
+import { useCallback, useRef, useState } from 'react';
+import { useStyletron } from 'baseui';
+
+import { AddButton } from '#core/components/form/components/add-button/add-button';
+import { FormControl } from '#core/components/form/components/form-control';
+import { useField } from '#core/components/form/hooks/use-field';
+import { KeyValueRow } from './key-value-row';
+
+import type { KeyValueEntry, MapFieldProps } from './types';
+
+const EMPTY_RECORD: Record<string, string> = {};
+const DUPLICATE_KEY_ERROR = 'cannot have duplicated values';
+
+export function MapField({
+  name,
+  label,
+  defaultValue,
+  initialValue,
+  required,
+  validate,
+  readOnly,
+  disabled,
+  description,
+  caption,
+  labelEndEnhancer,
+  format,
+  parse,
+  keyConfig,
+  valueConfig,
+  singleValue,
+  creatable = true,
+  deletable = true,
+  emptyMessage,
+  size,
+}: MapFieldProps) {
+  const [css, theme] = useStyletron();
+  const { input, meta } = useField<Record<string, string>>(name, {
+    required,
+    validate,
+    defaultValue: defaultValue ?? EMPTY_RECORD,
+    initialValue,
+    label,
+    format,
+    parse,
+  });
+
+  const rowIdCounter = useRef(0);
+
+  // Rows carry a stable 'id' for React keys that doesn't exist in the form value.
+  const [rows, setRows] = useState<KeyValueEntry[]>(() => {
+    const initial = toRows(input.value);
+    rowIdCounter.current = initial.length;
+    if (singleValue && initial.length === 0) {
+      rowIdCounter.current = 1;
+      return [{ id: 0, key: '', value: '' }];
+    }
+    return initial;
+  });
+
+  const handleRowChange = useCallback(
+    (updated: KeyValueEntry) => {
+      setRows((prev) => {
+        const next = prev.map((r) => (r.id === updated.id ? updated : r));
+        input.onChange(toRecord(next));
+        return next;
+      });
+    },
+    [input]
+  );
+
+  // Empty rows don't affect form state until the user types a key or value.
+  const handleAdd = () => {
+    setRows((prev) => [...prev, { id: rowIdCounter.current++, key: '', value: '' }]);
+  };
+
+  const handleRemove = useCallback(
+    (row: KeyValueEntry) => {
+      setRows((prev) => {
+        const next = prev.filter((r) => r.id !== row.id);
+        input.onChange(toRecord(next));
+        return next;
+      });
+    },
+    [input]
+  );
+
+  const duplicateKeys = new Set(
+    rows.map((r) => r.key).filter((k, i, arr) => k && arr.indexOf(k) !== i)
+  );
+
+  return (
+    <FormControl
+      label={label}
+      required={required}
+      description={description}
+      labelEndEnhancer={labelEndEnhancer}
+      caption={caption}
+      error={meta.touched && meta.error ? meta.error : undefined}
+    >
+      <div
+        className={css({ display: 'flex', flexDirection: 'column', gap: theme.sizing.scale300 })}
+      >
+        {rows.length === 0 && emptyMessage && (
+          <div
+            className={css({
+              ...theme.typography.ParagraphSmall,
+              marginBottom: theme.sizing.scale200,
+            })}
+          >
+            {emptyMessage}
+          </div>
+        )}
+
+        {rows.map((row) => (
+          <KeyValueRow
+            key={row.id}
+            row={row}
+            keyConfig={keyConfig}
+            valueConfig={valueConfig}
+            readOnly={readOnly}
+            disabled={disabled}
+            deletable={deletable && !singleValue}
+            size={size}
+            keyError={
+              duplicateKeys.has(row.key)
+                ? `${keyConfig?.placeholder ?? 'Keys'} ${DUPLICATE_KEY_ERROR}`
+                : undefined
+            }
+            onChange={handleRowChange}
+            onDelete={handleRemove}
+            onFocus={input.onFocus}
+            onBlur={input.onBlur}
+          />
+        ))}
+
+        {!singleValue && !readOnly && creatable && (
+          <AddButton onClick={handleAdd} label="Add more" />
+        )}
+      </div>
+    </FormControl>
+  );
+}
+
+function toRows(value: Record<string, string> | undefined): KeyValueEntry[] {
+  return Object.entries(value ?? {}).map(([key, val], i) => ({ id: i, key, value: val }));
+}
+
+function toRecord(rows: KeyValueEntry[]): Record<string, string> {
+  return Object.fromEntries(rows.map((r) => [r.key, r.value]));
+}

--- a/javascript/packages/core/components/form/fields/map/types.ts
+++ b/javascript/packages/core/components/form/fields/map/types.ts
@@ -1,0 +1,37 @@
+import type { SIZE } from 'baseui/input';
+import type { BaseFieldProps } from '#core/components/form/fields/types';
+
+export interface KeyValueEntry {
+  /** Stable React key — monotonically increasing, never reused after deletion. */
+  id: number;
+  key: string;
+  value: string;
+}
+
+/** Props shared between MapField and KeyValueRow — controls how each row renders. */
+export interface KeyValueRowConfig {
+  /** Configuration for the key input column */
+  keyConfig?: { placeholder?: string; readOnly?: boolean };
+
+  /** Configuration for the value input column */
+  valueConfig?: { placeholder?: string };
+
+  /** Show delete button per row. Defaults to true. */
+  deletable?: boolean;
+
+  /** BaseUI input size variant */
+  size?: keyof typeof SIZE;
+}
+
+export interface MapFieldOwnProps extends KeyValueRowConfig {
+  /** When true, renders exactly one key-value pair with no add/delete controls */
+  singleValue?: boolean;
+
+  /** Show "Add more" button. Defaults to true. */
+  creatable?: boolean;
+
+  /** Message shown when the map is empty */
+  emptyMessage?: string;
+}
+
+export type MapFieldProps = MapFieldOwnProps & BaseFieldProps<Record<string, string>>;

--- a/javascript/packages/core/components/views/sandbox/sandbox.tsx
+++ b/javascript/packages/core/components/views/sandbox/sandbox.tsx
@@ -9,6 +9,7 @@ import { HeadingXXLarge, LabelLarge, ParagraphSmall } from 'baseui/typography';
 import { CellType } from '#core/components/cell/constants';
 import { FormErrorBanner } from '#core/components/form/components/form-error-banner/form-error-banner';
 import { CheckboxField } from '#core/components/form/fields/checkbox/checkbox-field';
+import { MapField } from '#core/components/form/fields/map/map-field';
 import { MarkdownField } from '#core/components/form/fields/markdown/markdown-field';
 import { NumberField } from '#core/components/form/fields/number/number-field';
 import { SelectField } from '#core/components/form/fields/select/select-field';
@@ -762,6 +763,70 @@ export function Sandbox() {
                 Are you sure you want to delete this pipeline? This action cannot be undone.
               </ConfirmDialog>
             </Block>
+          </Block>
+        </Tab>
+
+        <Tab title="Map Field">
+          <Block marginTop="24px" maxWidth="600px">
+            <Form
+              onSubmit={(values) => console.log('Submitted:', values)}
+              initialValues={{
+                existingMap: { host: 'localhost', port: '8080', env: 'production' },
+                readOnlyMap: { region: 'us-east-1', cluster: 'primary' },
+              }}
+            >
+              <FormGroup title="Basic Map Field">
+                <MapField
+                  name="features"
+                  label="Features"
+                  keyConfig={{ placeholder: 'Feature name' }}
+                  valueConfig={{ placeholder: 'Transformation' }}
+                  emptyMessage="No features configured. Click 'Add more' to begin."
+                />
+              </FormGroup>
+
+              <FormGroup title="Pre-populated Map">
+                <MapField
+                  name="existingMap"
+                  label="Configuration"
+                  keyConfig={{ placeholder: 'Key' }}
+                  valueConfig={{ placeholder: 'Value' }}
+                />
+              </FormGroup>
+
+              <FormGroup title="Single Value Mode">
+                <MapField
+                  name="singleEntry"
+                  label="Primary Setting"
+                  singleValue
+                  keyConfig={{ placeholder: 'Setting name' }}
+                  valueConfig={{ placeholder: 'Setting value' }}
+                />
+              </FormGroup>
+
+              <FormGroup title="Read-Only Map">
+                <MapField name="readOnlyMap" label="Deployed Config" readOnly />
+              </FormGroup>
+
+              <Block display="flex" justifyContent="flex-end" marginTop="scale600">
+                <Button type="submit">Submit</Button>
+              </Block>
+
+              <FormSpy subscription={{ values: true }}>
+                {({ values }) => (
+                  <Block
+                    as="pre"
+                    marginTop="scale600"
+                    padding="scale600"
+                    backgroundColor="backgroundSecondary"
+                    font="font300"
+                    overrides={{ Block: { style: { borderRadius: '8px', overflow: 'auto' } } }}
+                  >
+                    {JSON.stringify(values, null, 2)}
+                  </Block>
+                )}
+              </FormSpy>
+            </Form>
           </Block>
         </Tab>
       </Tabs>


### PR DESCRIPTION
Key-value pair editor that stores Record<string, string> in the form. Uses a dual-state pattern: an internal KeyValueEntry[] with stable IDs for React keys, and the form's Record value derived on each mutation via Object.fromEntries.

KeyValueRow is a stateless component — all state and validation logic lives in MapField. Duplicate key detection is computed at render time from the rows array and passed down as a plain error string.

Shared display props (keyConfig, valueConfig, size, deletable) are defined once in KeyValueRowConfig and extended by both MapFieldOwnProps and KeyValueRowProps.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

https://github.com/user-attachments/assets/93cf6d61-5b90-4416-b0af-0bf613bff68f



<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
