### PR TITLE
[CLI] Separate entity `get()` function into raw and user facing part

### DIFF
--- a/python/michelangelo/cli/mactl/crd.py
+++ b/python/michelangelo/cli/mactl/crd.py
@@ -233,25 +233,38 @@ def crd_method_call(crd_method_info, request_input: Message) -> Message:
     return response
 
 
-def get_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Message:
-    """Default common CRD member method implementation for GET method."""
+def _get_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Message:
+    """Raw CRD GET implementation - returns message instance without printing."""
     _LOG.info("Bound arguments: %r", bound_args.arguments)
+
+    return crd_method_call_kwargs(
+        crd_method_info,
+        **{
+            "namespace": get_single_arg(bound_args.arguments, "namespace"),
+            "name": get_single_arg(bound_args.arguments, "name"),
+        },
+    )
+
+
+def get_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Message:
+    """Default common CRD member method implementation for GET method.
+
+    Wrapper around _get that additionally handles list fallback and printing.
+    """
+    _LOG.info("Bound arguments: %r", bound_args.arguments)
+
+    _self: CRD = bound_args.arguments["self"]
 
     if "name" not in bound_args.arguments or not bound_args.arguments["name"]:
         _LOG.debug("No name argument passed. List CRD in the namespace.")
-        _self: CRD = bound_args.arguments["self"]
         _self.generate_list(crd_method_info.channel)
         return _self.list(
             namespace=get_single_arg(bound_args.arguments, "namespace"),
             limit=bound_args.arguments.get("limit", 100),
         )
 
-    call_res = crd_method_call_kwargs(
-        crd_method_info,
-        **{
-            "namespace": get_single_arg(bound_args.arguments, "namespace"),
-            "name": get_single_arg(bound_args.arguments, "name"),
-        },
+    call_res = _self._get(
+        **{k: v for k, v in bound_args.arguments.items() if k != "self"}
     )
     print(call_res)
     return call_res
@@ -391,7 +404,7 @@ def apply_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Me
 
     message_instance = None
     try:
-        message_instance = _self.get(_namespace, _name)
+        message_instance = _self._get(_namespace, _name)
     except RpcError as err:
         _LOG.debug("CRD %r / %r does not exist: %r", _namespace, _name, err)
         if err.code() != StatusCode.NOT_FOUND:
@@ -650,15 +663,16 @@ class CRD:
         _LOG.debug("Generated DELETE injected well: %r", self.delete)
 
     def generate_get(self, channel: Channel, parser: Optional[ArgumentParser] = None):
-        """Generate get function of this class.
+        """Generate get and _get functions of this class.
 
-        Optionally configure argparse parser with arguments.
+        Both share the same signature. _get returns the raw message instance;
+        get is a wrapper that additionally handles list fallback and printing.
 
         Args:
             channel: gRPC channel
             parser: Optional ArgumentParser to configure with --namespace and --name
         """
-        _LOG.info("Generate GET method for %r / %r", self.name, self.full_name)
+        _LOG.info("Generate GET/_GET methods for %r / %r", self.name, self.full_name)
         method_info = CrdMethodInfo(
             channel,
             self.full_name,
@@ -668,10 +682,15 @@ class CRD:
         self.configure_parser("get", parser)
         func_signature = self._read_signatures("get")
 
-        bound_func = partial(get_func_impl, method_info)
-        bound_func = bind_signature(func_signature)(bound_func)
-        self.get = MethodType(bound_func, self)
-        _LOG.debug("Generated GET injected well: %r", self.get)
+        for attr_name, func_impl in [("_get", _get_func_impl), ("get", get_func_impl)]:
+            bound_func = partial(func_impl, method_info)
+            bound_func = bind_signature(func_signature)(bound_func)
+            setattr(self, attr_name, MethodType(bound_func, self))
+            _LOG.debug(
+                "Generated %s injected well: %r",
+                attr_name.upper(),
+                getattr(self, attr_name),
+            )
 
     def generate_apply(self, channel: Channel, parser: Optional[ArgumentParser] = None):
         """Generate apply function of this class."""

--- a/python/michelangelo/cli/mactl/crd.py
+++ b/python/michelangelo/cli/mactl/crd.py
@@ -331,8 +331,8 @@ def print_list_formatted(items: Sequence[Message]):
         )
 
 
-def list_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Message:
-    """Default common CRD member method implementation for LIST method."""
+def _list_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Message:
+    """Raw CRD LIST implementation - returns response without printing."""
     _LOG.info("Bound arguments: %r", bound_args.arguments)
 
     limit = bound_args.arguments.get("limit", 100)
@@ -353,6 +353,23 @@ def list_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Mes
     _LOG.info("ListRequest built: %r", request_input)
     call_res = crd_method_call(crd_method_info, request_input)
     _LOG.debug("Succeed to list CRDs: %r", type(call_res))
+    return call_res
+
+
+def list_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Message:
+    """Default common CRD member method implementation for LIST method.
+
+    Wrapper around _list that additionally handles formatted printing and limit warning.
+    """
+    _LOG.info("Bound arguments: %r", bound_args.arguments)
+
+    _self: CRD = bound_args.arguments["self"]
+    limit = bound_args.arguments.get("limit", 100)
+
+    call_res = _self._list(
+        **{k: v for k, v in bound_args.arguments.items() if k != "self"}
+    )
+
     results = {k.name: v for k, v in call_res.ListFields() if k.name.endswith("_list")}
     _LOG.debug(
         "Extracted keys (%s): %r / %r",
@@ -731,8 +748,13 @@ class CRD:
         _LOG.debug("Generated CREATE injected well: %r", self.create)
 
     def generate_list(self, channel: Channel, parser: Optional[ArgumentParser] = None):
-        """Generate list function of this class."""
-        _LOG.info("Generate LIST method for %r / %r", self.name, self.full_name)
+        """Generate list and _list functions of this class.
+
+        Both share the same signature. _list returns the raw response;
+        list is a wrapper that additionally handles formatted printing
+        and limit warning.
+        """
+        _LOG.info("Generate LIST/_LIST methods for %r / %r", self.name, self.full_name)
 
         method_info = CrdMethodInfo(
             channel,
@@ -749,10 +771,18 @@ class CRD:
             ]
         )
 
-        bound_func = partial(list_func_impl, method_info)
-        bound_func = bind_signature(list_func_signature)(bound_func)
-        self.list = MethodType(bound_func, self)
-        _LOG.debug("Generated LIST injected well: %r", self.list)
+        for attr_name, func_impl in [
+            ("_list", _list_func_impl),
+            ("list", list_func_impl),
+        ]:
+            bound_func = partial(func_impl, method_info)
+            bound_func = bind_signature(list_func_signature)(bound_func)
+            setattr(self, attr_name, MethodType(bound_func, self))
+            _LOG.debug(
+                "Generated %s injected well: %r",
+                attr_name.upper(),
+                getattr(self, attr_name),
+            )
 
     def read_yaml_and_update_crd_request(
         self, input_class: type[Message], yaml_path_string: str, original_crd: Message

--- a/python/michelangelo/cli/mactl/crd_test.py
+++ b/python/michelangelo/cli/mactl/crd_test.py
@@ -551,3 +551,42 @@ class GenerateGetTest(TestCase):
         call_args = mock_crd_method_call_kwargs.call_args
         self.assertEqual(call_args.kwargs["namespace"], "test-ns")
         self.assertEqual(call_args.kwargs["name"], "test-name")
+
+
+class GenerateListTest(TestCase):
+    """Test cases for CRD.generate_list method."""
+
+    @patch.object(CRD, "_extract_method_info")
+    def test_generate_list(self, mock_extract_method_info):
+        """Test generate_list creates both list and _list methods on CRD instance."""
+        mock_channel = Mock()
+        mock_extract_method_info.return_value = ("ListTestCrd", Mock, Mock)
+
+        crd = CRD(name="test_crd", full_name="test.service.TestCrd", metadata=[])
+        crd.generate_list(mock_channel)
+
+        self.assertTrue(hasattr(crd, "list"))
+        self.assertTrue(callable(crd.list))
+        self.assertTrue(hasattr(crd, "_list"))
+        self.assertTrue(callable(crd._list))
+
+    @patch("michelangelo.cli.mactl.crd.crd_method_call")
+    @patch("michelangelo.cli.mactl.crd.ParseDict")
+    @patch.object(CRD, "_extract_method_info")
+    def test_generate_list_raw_execution(
+        self, mock_extract_method_info, mock_parse_dict, mock_crd_method_call
+    ):
+        """Test the generated _list method returns raw response without printing."""
+        mock_channel = Mock()
+        mock_extract_method_info.return_value = ("ListTestCrd", Mock, Mock)
+        mock_response = Mock()
+        mock_crd_method_call.return_value = mock_response
+
+        crd = CRD(name="test_crd", full_name="test.service.TestCrd", metadata=[])
+        crd.generate_list(mock_channel)
+
+        result = crd._list(namespace="test-ns")
+
+        self.assertEqual(result, mock_response)
+        request_dict = mock_parse_dict.call_args[0][0]
+        self.assertEqual(request_dict["namespace"], "test-ns")

--- a/python/michelangelo/cli/mactl/crd_test.py
+++ b/python/michelangelo/cli/mactl/crd_test.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, Mock, patch
 from michelangelo.cli.mactl.crd import (
     CRD,
     CrdMethodInfo,
+    _get_func_impl,
     apply_func_impl,
     bind_signature,
     create_func_impl,
@@ -238,9 +239,12 @@ class DeleteFuncImplTest(TestCase):
 class GetFuncImplTest(TestCase):
     """Test cases for get_func_impl function."""
 
-    @patch("michelangelo.cli.mactl.crd.crd_method_call_kwargs")
-    def test_get_func_impl(self, mock_call_kwargs):
-        """Test get_func_impl with name calls crd_method_call_kwargs."""
+    def test_get_func_impl_with_name_calls_get(self):
+        """Test get_func_impl with name calls _self._get and prints result."""
+        mock_crd = Mock()
+        mock_response = Mock()
+        mock_crd._get.return_value = mock_response
+
         crd_method_info = CrdMethodInfo(
             channel=Mock(),
             crd_full_name="test.Service",
@@ -248,13 +252,13 @@ class GetFuncImplTest(TestCase):
             input_class=Mock,
             output_class=Mock,
         )
-        get_func_impl(
+        result = get_func_impl(
             crd_method_info,
-            Mock(arguments={"namespace": "ns", "name": "proj"}),
+            Mock(arguments={"self": mock_crd, "namespace": "ns", "name": "proj"}),
         )
-        mock_call_kwargs.assert_called_once_with(
-            crd_method_info, namespace="ns", name="proj"
-        )
+
+        mock_crd._get.assert_called_once_with(namespace="ns", name="proj")
+        self.assertEqual(result, mock_response)
 
     def test_get_func_impl_without_name_calls_list(self):
         """Test get_func_impl without name calls list with limit."""
@@ -287,6 +291,33 @@ class GetFuncImplTest(TestCase):
         self.assertEqual(result, "list_result")
 
 
+class GetFuncImplRawTest(TestCase):
+    """Test cases for _get_func_impl function."""
+
+    @patch("michelangelo.cli.mactl.crd.crd_method_call_kwargs")
+    def test_get_func_impl_raw(self, mock_call_kwargs):
+        """Test _get_func_impl calls crd_method_call_kwargs and returns result."""
+        crd_method_info = CrdMethodInfo(
+            channel=Mock(),
+            crd_full_name="test.Service",
+            method_name="Get",
+            input_class=Mock,
+            output_class=Mock,
+        )
+        mock_response = Mock()
+        mock_call_kwargs.return_value = mock_response
+
+        result = _get_func_impl(
+            crd_method_info,
+            Mock(arguments={"namespace": "ns", "name": "proj"}),
+        )
+
+        mock_call_kwargs.assert_called_once_with(
+            crd_method_info, namespace="ns", name="proj"
+        )
+        self.assertEqual(result, mock_response)
+
+
 class ApplyFuncImplTest(TestCase):
     """Test cases for apply_func_impl function."""
 
@@ -303,7 +334,7 @@ class ApplyFuncImplTest(TestCase):
         )
         mock_crd = Mock()
         mock_crd.full_name = "test.Service"
-        mock_crd.get.return_value = Mock()
+        mock_crd._get.return_value = Mock()
         mock_crd.read_yaml_and_update_crd_request.return_value = Mock()
         mock_get_ns.return_value = ("ns", "name")
 
@@ -311,6 +342,7 @@ class ApplyFuncImplTest(TestCase):
             crd_method_info, Mock(arguments={"self": mock_crd, "file": "f.yaml"})
         )
 
+        mock_crd._get.assert_called_once_with("ns", "name")
         mock_crd.read_yaml_and_update_crd_request.assert_called_once()
 
 
@@ -453,7 +485,7 @@ class GenerateGetTest(TestCase):
 
     @patch.object(CRD, "_extract_method_info")
     def test_generate_get(self, mock_extract_method_info):
-        """Test generate_get creates the get method on CRD instance."""
+        """Test generate_get creates both get and _get methods on CRD instance."""
         mock_channel = Mock()
         mock_extract_method_info.return_value = ("GetTestCrd", Mock, Mock)
 
@@ -462,6 +494,8 @@ class GenerateGetTest(TestCase):
 
         self.assertTrue(hasattr(crd, "get"))
         self.assertTrue(callable(crd.get))
+        self.assertTrue(hasattr(crd, "_get"))
+        self.assertTrue(callable(crd._get))
 
     @patch("michelangelo.cli.mactl.crd.crd_method_call_kwargs")
     @patch.object(CRD, "_extract_method_info")

--- a/python/michelangelo/cli/mactl/crd_test.py
+++ b/python/michelangelo/cli/mactl/crd_test.py
@@ -9,6 +9,7 @@ from michelangelo.cli.mactl.crd import (
     CRD,
     CrdMethodInfo,
     _get_func_impl,
+    _list_func_impl,
     apply_func_impl,
     bind_signature,
     create_func_impl,
@@ -132,11 +133,9 @@ class PrepareColumnInfoTest(TestCase):
 class ListFuncImplTest(TestCase):
     """Test cases for list_func_impl function."""
 
-    @patch("michelangelo.cli.mactl.crd.crd_method_call")
     @patch("michelangelo.cli.mactl.crd.ParseDict")
-    def test_list_func_impl(self, mock_parse_dict, mock_call):
-        """Test list_func_impl extracts list fields and formats output."""
-        # Create CrdMethodInfo instance
+    def test_list_func_impl(self, mock_parse_dict):
+        """Test list_func_impl calls _self._list and formats output."""
         crd_method_info = CrdMethodInfo(
             channel=Mock(),
             crd_full_name="michelangelo.api.v2.ProjectService",
@@ -145,7 +144,6 @@ class ListFuncImplTest(TestCase):
             output_class=Mock,
         )
 
-        # Prepare Mock
         mock_item = MagicMock()
         mock_item.metadata.namespace = "test-ns"
         mock_item.metadata.name = "test-project"
@@ -158,23 +156,25 @@ class ListFuncImplTest(TestCase):
                 Mock(items=[mock_item]),
             )
         ]
-        mock_call.return_value = mock_response
 
-        # Execute - should not raise any exceptions
+        mock_crd = Mock()
+        mock_crd._list.return_value = mock_response
+
         list_func_impl(
             crd_method_info,
-            Mock(arguments={"namespace": "test-namespace", "limit": 100}),
+            Mock(
+                arguments={
+                    "self": mock_crd,
+                    "namespace": "test-namespace",
+                    "limit": 100,
+                }
+            ),
         )
 
-        # Verify ParseDict was called with correct request dict
-        call_args = mock_parse_dict.call_args
-        request_dict = call_args[0][0]
-        self.assertEqual(request_dict["namespace"], "test-namespace")
-        self.assertEqual(request_dict["list_options_ext"]["pagination"]["limit"], 100)
+        mock_crd._list.assert_called_once_with(namespace="test-namespace", limit=100)
 
-    @patch("michelangelo.cli.mactl.crd.crd_method_call")
     @patch("michelangelo.cli.mactl.crd.ParseDict")
-    def test_list_func_impl_with_limit_warning(self, mock_parse_dict, mock_call):
+    def test_list_func_impl_with_limit_warning(self, mock_parse_dict):
         """Test list_func_impl shows warning when result count equals limit."""
         crd_method_info = CrdMethodInfo(
             channel=Mock(),
@@ -197,16 +197,50 @@ class ListFuncImplTest(TestCase):
                 Mock(items=mock_items),
             )
         ]
-        mock_call.return_value = mock_response
+
+        mock_crd = Mock()
+        mock_crd._list.return_value = mock_response
 
         list_func_impl(
             crd_method_info,
-            Mock(arguments={"namespace": "test-namespace", "limit": 10}),
+            Mock(
+                arguments={"self": mock_crd, "namespace": "test-namespace", "limit": 10}
+            ),
+        )
+
+        mock_crd._list.assert_called_once_with(namespace="test-namespace", limit=10)
+
+
+class ListFuncImplRawTest(TestCase):
+    """Test cases for _list_func_impl function."""
+
+    @patch("michelangelo.cli.mactl.crd.crd_method_call")
+    @patch("michelangelo.cli.mactl.crd.ParseDict")
+    def test_list_func_impl_raw(self, mock_parse_dict, mock_call):
+        """Test _list_func_impl builds request and returns raw response.
+
+        It tests `_list` func without printing.
+        """
+        crd_method_info = CrdMethodInfo(
+            channel=Mock(),
+            crd_full_name="michelangelo.api.v2.ProjectService",
+            method_name="List",
+            input_class=Mock,
+            output_class=Mock,
+        )
+        mock_response = Mock()
+        mock_call.return_value = mock_response
+
+        result = _list_func_impl(
+            crd_method_info,
+            Mock(arguments={"namespace": "test-namespace", "limit": 100}),
         )
 
         call_args = mock_parse_dict.call_args
         request_dict = call_args[0][0]
-        self.assertEqual(request_dict["list_options_ext"]["pagination"]["limit"], 10)
+        self.assertEqual(request_dict["namespace"], "test-namespace")
+        self.assertEqual(request_dict["list_options_ext"]["pagination"]["limit"], 100)
+        self.assertEqual(result, mock_response)
 
 
 class DeleteFuncImplTest(TestCase):


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

[CLI] Separate entity `get()` function into raw and user facing part

`CRD().get()` function includes the printing part for user cli command, but it's not necessary for internal usage like `apply` function. `CRD().generate_get()` function now will generate `get()` and `_get()` function which has identical function signatures. `get()` function will be a wrapper function of `_get()` function. this function will have other format converting parts in the future.

<!-- Tell your future self why have you made these changes -->
**Why?**

Some internal functions and plugin functions couldn't use `_self.get()` functions to get the current entity, because it printed out unexpected information to users.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
