### PR TITLE
Add ESLint rule: types must live in types.ts files

### DIFF
--- a/javascript/eslint-local-rules/__tests__/types-in-types-file.test.js
+++ b/javascript/eslint-local-rules/__tests__/types-in-types-file.test.js
@@ -139,7 +139,7 @@ tester.run('types-in-types-file', rule, {
         interface Config { label: string; }
         export function MyComponent(props: Config) { return null; }
       `,
-      errors: [{ messageId: 'typesInTypesFile', data: { name: 'Config' } }],
+      errors: [{ messageId: 'inlineType', data: { name: 'Config' } }],
     },
 
     // ── mixed: one valid Props + one invalid non-Props ──
@@ -152,6 +152,62 @@ tester.run('types-in-types-file', rule, {
         export function MyComponent(props: MyComponentProps) { return null; }
       `,
       errors: [{ messageId: 'typesInTypesFile', data: { name: 'HelperType' } }],
+    },
+
+    // ── inlineType: small type alias (≤2 members) used once ──
+    {
+      name: 'small type alias used once → inlineType',
+      filename: 'utils.ts',
+      code: `
+        type Options = { verbose: boolean; limit: number };
+        function run(opts: Options) { return opts; }
+      `,
+      errors: [{ messageId: 'inlineType', data: { name: 'Options' } }],
+    },
+
+    // ── inlineType: small interface (≤2 members) used once ──
+    {
+      name: 'small interface used once → inlineType',
+      filename: 'utils.ts',
+      code: `
+        interface Pair { a: string; b: string }
+        function merge(p: Pair) { return p; }
+      `,
+      errors: [{ messageId: 'inlineType', data: { name: 'Pair' } }],
+    },
+
+    // ── typesInTypesFile: small type used twice ──
+    {
+      name: 'small type used twice → typesInTypesFile',
+      filename: 'utils.ts',
+      code: `
+        type Tag = { label: string };
+        function make(t: Tag) { return t; }
+        function read(t: Tag) { return t; }
+      `,
+      errors: [{ messageId: 'typesInTypesFile', data: { name: 'Tag' } }],
+    },
+
+    // ── typesInTypesFile: large type alias (3+ members) used once ──
+    {
+      name: 'large type alias used once → typesInTypesFile',
+      filename: 'utils.ts',
+      code: `
+        type BigConfig = { a: string; b: number; c: boolean };
+        function init(cfg: BigConfig) { return cfg; }
+      `,
+      errors: [{ messageId: 'typesInTypesFile', data: { name: 'BigConfig' } }],
+    },
+
+    // ── inlineType: small union (≤2 members) used once ──
+    {
+      name: 'small union used once → inlineType',
+      filename: 'utils.ts',
+      code: `
+        type Status = 'on' | 'off';
+        function toggle(s: Status) { return s; }
+      `,
+      errors: [{ messageId: 'inlineType', data: { name: 'Status' } }],
     },
   ],
 });

--- a/javascript/eslint-local-rules/__tests__/types-in-types-file.test.js
+++ b/javascript/eslint-local-rules/__tests__/types-in-types-file.test.js
@@ -1,0 +1,157 @@
+import { RuleTester } from 'eslint';
+import tseslint from 'typescript-eslint';
+
+import rule from '../types-in-types-file.js';
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const tester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+    parser: tseslint.parser,
+  },
+});
+
+tester.run('types-in-types-file', rule, {
+  valid: [
+    // ── types.ts files are always allowed ──
+    {
+      name: 'interface in types.ts',
+      filename: 'types.ts',
+      code: `export interface Foo { bar: string; }`,
+    },
+    {
+      name: 'type alias in types.ts',
+      filename: 'types.ts',
+      code: `export type Foo = { bar: string };`,
+    },
+
+    // ── *-types.ts files are allowed ──
+    {
+      name: 'interface in a *-types.ts file',
+      filename: 'column-types.ts',
+      code: `export interface ColumnDef { name: string; }`,
+    },
+
+    // ── files in types/ directory are allowed ──
+    {
+      name: 'interface in a types/ directory',
+      filename: '/src/components/types/view-types.ts',
+      code: `export interface ViewConfig { layout: string; }`,
+    },
+
+    // ── Props interfaces used as function params are allowed ──
+    {
+      name: 'Props interface used in function declaration',
+      filename: 'component.tsx',
+      code: `
+        interface MyComponentProps { label: string; }
+        export function MyComponent(props: MyComponentProps) { return null; }
+      `,
+    },
+    {
+      name: 'Props interface used with destructured param',
+      filename: 'component.tsx',
+      code: `
+        interface ButtonProps { onClick: () => void; }
+        function Button({ onClick }: ButtonProps) { return null; }
+      `,
+    },
+    {
+      name: 'Props type used in arrow function',
+      filename: 'component.tsx',
+      code: `
+        type CardProps = { title: string; };
+        const Card = (props: CardProps) => null;
+      `,
+    },
+    {
+      name: 'Props type used in forwardRef generic',
+      filename: 'component.tsx',
+      code: `
+        type ItemProps = { label: string; };
+        const Item = forwardRef<HTMLDivElement, ItemProps>((props, ref) => null);
+      `,
+    },
+
+    // ── re-exports are allowed (no declaration) ──
+    {
+      name: 're-export type from types file',
+      filename: 'component.tsx',
+      code: `export type { Foo } from './types';`,
+    },
+
+    // ── non-type exports are fine ──
+    {
+      name: 'exported function in a component file',
+      filename: 'utils.ts',
+      code: `export function foo() { return 1; }`,
+    },
+  ],
+
+  invalid: [
+    // ── local types in non-types files ──
+    {
+      name: 'local interface in component file',
+      filename: 'component.tsx',
+      code: `interface SomeHelper { key: string; }`,
+      errors: [{ messageId: 'typesInTypesFile', data: { name: 'SomeHelper' } }],
+    },
+    {
+      name: 'local type alias in component file',
+      filename: 'utils.ts',
+      code: `type MyType = string | number;`,
+      errors: [{ messageId: 'typesInTypesFile', data: { name: 'MyType' } }],
+    },
+
+    // ── exported types in non-types files ──
+    {
+      name: 'exported interface in component file',
+      filename: 'component.tsx',
+      code: `export interface SomeHelper { key: string; }`,
+      errors: [{ messageId: 'typesInTypesFile', data: { name: 'SomeHelper' } }],
+    },
+    {
+      name: 'exported type alias in component file',
+      filename: 'utils.ts',
+      code: `export type MyType = string | number;`,
+      errors: [{ messageId: 'typesInTypesFile', data: { name: 'MyType' } }],
+    },
+
+    // ── Props name without function param usage ──
+    {
+      name: 'Props interface NOT used as function param',
+      filename: 'component.tsx',
+      code: `
+        interface FooProps { label: string; }
+        export function MyComponent() { return null; }
+      `,
+      errors: [{ messageId: 'typesInTypesFile', data: { name: 'FooProps' } }],
+    },
+
+    // ── non-Props name used as function param ──
+    {
+      name: 'non-Props interface used as function param',
+      filename: 'component.tsx',
+      code: `
+        interface Config { label: string; }
+        export function MyComponent(props: Config) { return null; }
+      `,
+      errors: [{ messageId: 'typesInTypesFile', data: { name: 'Config' } }],
+    },
+
+    // ── mixed: one valid Props + one invalid non-Props ──
+    {
+      name: 'mixed: Props used as param (valid) + helper type (invalid)',
+      filename: 'component.tsx',
+      code: `
+        interface MyComponentProps { label: string; }
+        interface HelperType { key: string; }
+        export function MyComponent(props: MyComponentProps) { return null; }
+      `,
+      errors: [{ messageId: 'typesInTypesFile', data: { name: 'HelperType' } }],
+    },
+  ],
+});

--- a/javascript/eslint-local-rules/types-in-types-file.js
+++ b/javascript/eslint-local-rules/types-in-types-file.js
@@ -8,15 +8,15 @@ const rule = {
     },
     messages: {
       inlineType: [
-        "'{{ name }}' is a type declaration outside of a types.ts file.",
-        'Consider inlining it at the call site instead of declaring it separately.',
+        "'{{ name }}' is a small, single-use type outside of a types.ts file.",
+        'If the name adds clarity, move it to a co-located types.ts.',
+        'Otherwise, consider inlining it at the call site.',
         '',
-        '  // Before',
-        '  type {{ name }} = { ... };',
-        '  function foo(arg: {{ name }}) { ... }',
-        '',
-        '  // After',
+        '  // Inline',
         '  function foo(arg: { ... }) { ... }',
+        '',
+        '  // Or move to types.ts',
+        "  import type { {{ name }} } from './types';",
       ].join('\n'),
       typesInTypesFile: [
         "'{{ name }}' is a type declaration outside of a types.ts file.",

--- a/javascript/eslint-local-rules/types-in-types-file.js
+++ b/javascript/eslint-local-rules/types-in-types-file.js
@@ -1,16 +1,3 @@
-/**
- * @fileoverview Type/interface declarations must live in a types.ts file.
- *
- * Scattering types across component files makes them hard to find and reuse.
- * Keeping them in a co-located types.ts keeps the type surface discoverable.
- *
- * Exceptions:
- *   - Component prop interfaces (name ending in "Props") used as a function
- *     parameter type or forwardRef generic argument in the same file are
- *     allowed — they are tightly coupled to the component.
- *   - Test and fixture files are excluded via ESLint config (not this rule).
- */
-
 /** @type {import('eslint').Rule.RuleModule} */
 const rule = {
   meta: {

--- a/javascript/eslint-local-rules/types-in-types-file.js
+++ b/javascript/eslint-local-rules/types-in-types-file.js
@@ -16,8 +16,7 @@ const rule = {
   meta: {
     type: 'suggestion',
     docs: {
-      description:
-        'Require type/interface declarations to live in a types.ts file',
+      description: 'Require type/interface declarations to live in a types.ts file',
       recommended: true,
     },
     messages: {
@@ -41,7 +40,11 @@ const rule = {
     const basename = filename.split('/').pop() ?? '';
 
     // Allow everything inside types.ts files, files in a types/ directory, or *-types.ts files
-    if (/^types\.[tj]sx?$/.test(basename) || /[\\/]types[\\/]/.test(filename) || /-types\.[tj]sx?$/.test(basename)) {
+    if (
+      /^types\.[tj]sx?$/.test(basename) ||
+      /[\\/]types[\\/]/.test(filename) ||
+      /-types\.[tj]sx?$/.test(basename)
+    ) {
       return {};
     }
 
@@ -69,15 +72,12 @@ const rule = {
 
       // Collect type names used in function parameter annotations
       'FunctionDeclaration > Identifier.params, FunctionDeclaration > ObjectPattern.params, ArrowFunctionExpression > Identifier.params, ArrowFunctionExpression > ObjectPattern.params, FunctionExpression > Identifier.params, FunctionExpression > ObjectPattern.params'(
-        node,
+        node
       ) {
         const annotation = node.typeAnnotation?.typeAnnotation;
         if (!annotation) return;
 
-        if (
-          annotation.type === 'TSTypeReference' &&
-          annotation.typeName?.type === 'Identifier'
-        ) {
+        if (annotation.type === 'TSTypeReference' && annotation.typeName?.type === 'Identifier') {
           paramTypeNames.add(annotation.typeName.name);
         }
       },
@@ -93,10 +93,7 @@ const rule = {
           return;
         }
         for (const typeArg of node.typeArguments.params) {
-          if (
-            typeArg.type === 'TSTypeReference' &&
-            typeArg.typeName?.type === 'Identifier'
-          ) {
+          if (typeArg.type === 'TSTypeReference' && typeArg.typeName?.type === 'Identifier') {
             paramTypeNames.add(typeArg.typeName.name);
           }
         }

--- a/javascript/eslint-local-rules/types-in-types-file.js
+++ b/javascript/eslint-local-rules/types-in-types-file.js
@@ -1,0 +1,121 @@
+/**
+ * @fileoverview Type/interface declarations must live in a types.ts file.
+ *
+ * Scattering types across component files makes them hard to find and reuse.
+ * Keeping them in a co-located types.ts keeps the type surface discoverable.
+ *
+ * Exceptions:
+ *   - Component prop interfaces (name ending in "Props") used as a function
+ *     parameter type or forwardRef generic argument in the same file are
+ *     allowed — they are tightly coupled to the component.
+ *   - Test and fixture files are excluded via ESLint config (not this rule).
+ */
+
+/** @type {import('eslint').Rule.RuleModule} */
+const rule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Require type/interface declarations to live in a types.ts file',
+      recommended: true,
+    },
+    messages: {
+      typesInTypesFile: [
+        "'{{ name }}' is a type declaration outside of a types.ts file.",
+        'Move it to a co-located types.ts and import from there.',
+        '',
+        '  // types.ts',
+        '  export interface {{ name }} { /* ... */ }',
+        '',
+        '  // component.tsx',
+        "  import type { {{ name }} } from './types';",
+        '',
+      ].join('\n'),
+    },
+    schema: [],
+  },
+
+  create(context) {
+    const filename = context.getPhysicalFilename?.() ?? context.filename;
+    const basename = filename.split('/').pop() ?? '';
+
+    // Allow everything inside types.ts files, files in a types/ directory, or *-types.ts files
+    if (/^types\.[tj]sx?$/.test(basename) || /[\\/]types[\\/]/.test(filename) || /-types\.[tj]sx?$/.test(basename)) {
+      return {};
+    }
+
+    // Track all type/interface declarations and their nodes
+    const declaredTypes = [];
+
+    // Track names used as function parameter type annotations
+    const paramTypeNames = new Set();
+
+    return {
+      // Collect all type/interface declarations (exported or local)
+      TSInterfaceDeclaration(node) {
+        const name = node.id?.name;
+        if (name) {
+          declaredTypes.push({ name, node });
+        }
+      },
+
+      TSTypeAliasDeclaration(node) {
+        const name = node.id?.name;
+        if (name) {
+          declaredTypes.push({ name, node });
+        }
+      },
+
+      // Collect type names used in function parameter annotations
+      'FunctionDeclaration > Identifier.params, FunctionDeclaration > ObjectPattern.params, ArrowFunctionExpression > Identifier.params, ArrowFunctionExpression > ObjectPattern.params, FunctionExpression > Identifier.params, FunctionExpression > ObjectPattern.params'(
+        node,
+      ) {
+        const annotation = node.typeAnnotation?.typeAnnotation;
+        if (!annotation) return;
+
+        if (
+          annotation.type === 'TSTypeReference' &&
+          annotation.typeName?.type === 'Identifier'
+        ) {
+          paramTypeNames.add(annotation.typeName.name);
+        }
+      },
+
+      // Collect Props types passed as generic args to forwardRef<Ref, Props>(...)
+      CallExpression(node) {
+        const callee = node.callee;
+        if (
+          callee.type !== 'Identifier' ||
+          callee.name !== 'forwardRef' ||
+          !node.typeArguments?.params
+        ) {
+          return;
+        }
+        for (const typeArg of node.typeArguments.params) {
+          if (
+            typeArg.type === 'TSTypeReference' &&
+            typeArg.typeName?.type === 'Identifier'
+          ) {
+            paramTypeNames.add(typeArg.typeName.name);
+          }
+        }
+      },
+
+      // At program exit, report types that aren't Props interfaces used as params
+      'Program:exit'() {
+        for (const { name, node } of declaredTypes) {
+          if (name.endsWith('Props') && paramTypeNames.has(name)) continue;
+
+          context.report({
+            node,
+            messageId: 'typesInTypesFile',
+            data: { name },
+          });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/javascript/eslint-local-rules/types-in-types-file.js
+++ b/javascript/eslint-local-rules/types-in-types-file.js
@@ -5,29 +5,13 @@ const rule = {
     docs: {
       description: 'Require type/interface declarations to live in a types.ts file',
       recommended: true,
+      url: 'https://github.com/michelangelo-ai/michelangelo/blob/main/javascript/eslint-local-rules/types-in-types-file.md',
     },
     messages: {
-      inlineType: [
-        "'{{ name }}' is a small, single-use type outside of a types.ts file.",
-        'If the name adds clarity, move it to a co-located types.ts.',
-        'Otherwise, consider inlining it at the call site.',
-        '',
-        '  // Inline',
-        '  function foo(arg: { ... }) { ... }',
-        '',
-        '  // Or move to types.ts',
-        "  import type { {{ name }} } from './types';",
-      ].join('\n'),
-      typesInTypesFile: [
-        "'{{ name }}' is a type declaration outside of a types.ts file.",
-        'Move it to a co-located types.ts and import from there.',
-        '',
-        '  // types.ts',
-        '  export interface {{ name }} { /* ... */ }',
-        '',
-        '  // component.tsx',
-        "  import type { {{ name }} } from './types';",
-      ].join('\n'),
+      inlineType:
+        "'{{ name }}' is a small, single-use type outside of a types.ts file. Inline it at the call site, or move it to a co-located types.ts.",
+      typesInTypesFile:
+        "'{{ name }}' is a type declaration outside of a types.ts file. Move it to a co-located types.ts and import from there.",
     },
     schema: [],
   },

--- a/javascript/eslint-local-rules/types-in-types-file.js
+++ b/javascript/eslint-local-rules/types-in-types-file.js
@@ -20,6 +20,17 @@ const rule = {
       recommended: true,
     },
     messages: {
+      inlineType: [
+        "'{{ name }}' is a type declaration outside of a types.ts file.",
+        'Consider inlining it at the call site instead of declaring it separately.',
+        '',
+        '  // Before',
+        '  type {{ name }} = { ... };',
+        '  function foo(arg: {{ name }}) { ... }',
+        '',
+        '  // After',
+        '  function foo(arg: { ... }) { ... }',
+      ].join('\n'),
       typesInTypesFile: [
         "'{{ name }}' is a type declaration outside of a types.ts file.",
         'Move it to a co-located types.ts and import from there.',
@@ -29,7 +40,6 @@ const rule = {
         '',
         '  // component.tsx',
         "  import type { {{ name }} } from './types';",
-        '',
       ].join('\n'),
     },
     schema: [],
@@ -48,14 +58,24 @@ const rule = {
       return {};
     }
 
-    // Track all type/interface declarations and their nodes
     const declaredTypes = [];
-
-    // Track names used as function parameter type annotations
     const paramTypeNames = new Set();
+    const countTypeRefs = new Map();
+
+    function isSmall(node) {
+      if (node.type === 'TSTypeAliasDeclaration') {
+        const t = node.typeAnnotation;
+        if (t.type === 'TSTypeLiteral') return t.members.length <= 2;
+        if (t.type === 'TSUnionType') return t.types.length <= 2;
+        return false;
+      }
+      if (node.type === 'TSInterfaceDeclaration') {
+        return node.body.body.length <= 2;
+      }
+      return false;
+    }
 
     return {
-      // Collect all type/interface declarations (exported or local)
       TSInterfaceDeclaration(node) {
         const name = node.id?.name;
         if (name) {
@@ -70,7 +90,6 @@ const rule = {
         }
       },
 
-      // Collect type names used in function parameter annotations
       'FunctionDeclaration > Identifier.params, FunctionDeclaration > ObjectPattern.params, ArrowFunctionExpression > Identifier.params, ArrowFunctionExpression > ObjectPattern.params, FunctionExpression > Identifier.params, FunctionExpression > ObjectPattern.params'(
         node
       ) {
@@ -82,7 +101,13 @@ const rule = {
         }
       },
 
-      // Collect Props types passed as generic args to forwardRef<Ref, Props>(...)
+      TSTypeReference(node) {
+        if (node.typeName?.type === 'Identifier') {
+          const name = node.typeName.name;
+          countTypeRefs.set(name, (countTypeRefs.get(name) ?? 0) + 1);
+        }
+      },
+
       CallExpression(node) {
         const callee = node.callee;
         if (
@@ -99,14 +124,16 @@ const rule = {
         }
       },
 
-      // At program exit, report types that aren't Props interfaces used as params
       'Program:exit'() {
         for (const { name, node } of declaredTypes) {
           if (name.endsWith('Props') && paramTypeNames.has(name)) continue;
 
+          const isSingleUse = (countTypeRefs.get(name) ?? 0) === 1;
+          const small = isSmall(node);
+
           context.report({
             node,
-            messageId: 'typesInTypesFile',
+            messageId: isSingleUse && small ? 'inlineType' : 'typesInTypesFile',
             data: { name },
           });
         }

--- a/javascript/eslint-local-rules/types-in-types-file.md
+++ b/javascript/eslint-local-rules/types-in-types-file.md
@@ -1,23 +1,12 @@
-# types-in-types-file
+Flags type and interface declarations outside of `types.ts` files.
 
-## Problem
+## Why this rule exists
 
-When type and interface declarations are scattered across component files, they become hard to discover, grep for, and reuse. A developer looking for the shape of a data structure shouldn't have to guess which component file defines it. Centralizing types into dedicated `types.ts` files keeps the type surface of a module predictable and browsable.
-
-## Decision
-
-All `type` and `interface` declarations must live in a `types.ts` file (or a file matching `*-types.ts`, or inside a `types/` directory). The rule reports any declaration found outside these locations.
-
-When a violation is reported, decide how to fix it:
-
-- **Small, single-use types** (one or two members/union branches, referenced once) are often better **inlined** at the call site rather than extracted into `types.ts`. A named type that exists only to annotate one parameter adds indirection without aiding discoverability.
-- **Everything else** should be **moved** to a co-located `types.ts` and imported from there.
-
-The rule detects this automatically: small, single-use types get the inline suggestion; everything else gets the move-to-types.ts suggestion.
+Scattering types across component files makes them hard to discover. Centralizing types into dedicated `types.ts` files keeps the type surface of a module predictable and browseable.
 
 ## The Props exception
 
-Interfaces and types whose name ends in `Props` are exempt when they are used as a function parameter type annotation or `forwardRef` generic argument in the same file. Component props are tightly coupled to the component they describe — they serve as the component's API documentation and almost never benefit from being shared.
+Interfaces and types whose name ends in `Props` are exempt when they are used as a function parameter type annotation or `forwardRef` generic argument in the same file. Component props are tightly coupled to the component they describe — they serve as the component's API documentation and rarely benefit from being shared.
 
 ```typescript
 // Allowed: FooProps is used as a parameter type in the same file
@@ -31,9 +20,11 @@ function Foo({ label, onClick }: FooProps) {
 }
 ```
 
-## Examples
+## How to fix violations
 
-### Violation: move to types.ts
+### Move to types.ts
+
+Most types belong in a co-located `types.ts` and should be imported from there:
 
 ```typescript
 // component.tsx — BEFORE (violation)
@@ -42,9 +33,7 @@ export interface Column {
   label: string;
   sortable: boolean;
 }
-```
 
-```typescript
 // types.ts — AFTER
 export interface Column {
   key: string;
@@ -56,7 +45,9 @@ export interface Column {
 import type { Column } from './types';
 ```
 
-### Violation: inline at call site
+### Inline at the call site
+
+Small, single-use types (one or two members/union branches, referenced once) can often be inlined at the call site. If the type name adds semantic clarity, keeping it named is fine — move it to `types.ts` instead. The rule suggests inlining when it detects a small, single-use type:
 
 ```typescript
 // component.tsx — BEFORE (violation, but type is trivial and used once)
@@ -65,22 +56,9 @@ type Direction = 'asc' | 'desc';
 function sortRows(rows: Row[], dir: Direction) {
   /* ... */
 }
-```
 
-```typescript
 // component.tsx — AFTER (inlined)
 function sortRows(rows: Row[], dir: 'asc' | 'desc') {
   /* ... */
 }
-```
-
-## Escape hatch
-
-For genuine exceptions, disable per-line:
-
-```typescript
-// eslint-disable-next-line @eslint-local-rules/types-in-types-file
-type InternalState = {
-  /* ... */
-};
 ```

--- a/javascript/eslint-local-rules/types-in-types-file.md
+++ b/javascript/eslint-local-rules/types-in-types-file.md
@@ -1,0 +1,86 @@
+# types-in-types-file
+
+## Problem
+
+When type and interface declarations are scattered across component files, they become hard to discover, grep for, and reuse. A developer looking for the shape of a data structure shouldn't have to guess which component file defines it. Centralizing types into dedicated `types.ts` files keeps the type surface of a module predictable and browsable.
+
+## Decision
+
+All `type` and `interface` declarations must live in a `types.ts` file (or a file matching `*-types.ts`, or inside a `types/` directory). The rule reports any declaration found outside these locations.
+
+When a violation is reported, decide how to fix it:
+
+- **Small, single-use types** (one or two members/union branches, referenced once) are often better **inlined** at the call site rather than extracted into `types.ts`. A named type that exists only to annotate one parameter adds indirection without aiding discoverability.
+- **Everything else** should be **moved** to a co-located `types.ts` and imported from there.
+
+The rule detects this automatically: small, single-use types get the inline suggestion; everything else gets the move-to-types.ts suggestion.
+
+## The Props exception
+
+Interfaces and types whose name ends in `Props` are exempt when they are used as a function parameter type annotation or `forwardRef` generic argument in the same file. Component props are tightly coupled to the component they describe — they serve as the component's API documentation and almost never benefit from being shared.
+
+```typescript
+// Allowed: FooProps is used as a parameter type in the same file
+interface FooProps {
+  label: string;
+  onClick: () => void;
+}
+
+function Foo({ label, onClick }: FooProps) {
+  return <button onClick={onClick}>{label}</button>;
+}
+```
+
+## Examples
+
+### Violation: move to types.ts
+
+```typescript
+// component.tsx — BEFORE (violation)
+export interface Column {
+  key: string;
+  label: string;
+  sortable: boolean;
+}
+```
+
+```typescript
+// types.ts — AFTER
+export interface Column {
+  key: string;
+  label: string;
+  sortable: boolean;
+}
+
+// component.tsx
+import type { Column } from './types';
+```
+
+### Violation: inline at call site
+
+```typescript
+// component.tsx — BEFORE (violation, but type is trivial and used once)
+type Direction = 'asc' | 'desc';
+
+function sortRows(rows: Row[], dir: Direction) {
+  /* ... */
+}
+```
+
+```typescript
+// component.tsx — AFTER (inlined)
+function sortRows(rows: Row[], dir: 'asc' | 'desc') {
+  /* ... */
+}
+```
+
+## Escape hatch
+
+For genuine exceptions, disable per-line:
+
+```typescript
+// eslint-disable-next-line @eslint-local-rules/types-in-types-file
+type InternalState = {
+  /* ... */
+};
+```

--- a/javascript/eslint.config.js
+++ b/javascript/eslint.config.js
@@ -4,6 +4,7 @@ import js from '@eslint/js';
 import noBarrelExports from './eslint-local-rules/no-barrel-exports.js';
 import noFixtureConstants from './eslint-local-rules/no-fixture-constants.js';
 import noModuleScopeTestSetup from './eslint-local-rules/no-module-scope-test-setup.js';
+import typesInTypesFile from './eslint-local-rules/types-in-types-file.js';
 import tseslint from 'typescript-eslint';
 import prettierConfig from 'eslint-config-prettier';
 import baseUIEslint from 'eslint-plugin-baseui';
@@ -185,7 +186,7 @@ export default [
     },
   },
 
-  // App and packages — no barrel exports in index files
+  // App and packages — no barrel exports, types must live in types.ts
   {
     files: ['packages/core/**/*.{ts,tsx}', 'packages/rpc/**/*.{ts,tsx}', 'app/**/*.{ts,tsx}'],
     ignores: [
@@ -195,10 +196,16 @@ export default [
       'packages/**/__fixtures__/**/*.{ts,tsx}',
     ],
     plugins: {
-      local: { rules: { 'no-barrel-exports': noBarrelExports } },
+      local: {
+        rules: {
+          'no-barrel-exports': noBarrelExports,
+          'types-in-types-file': typesInTypesFile,
+        },
+      },
     },
     rules: {
       'local/no-barrel-exports': 'error',
+      'local/types-in-types-file': 'error',
     },
   },
 

--- a/javascript/packages/core/components/form/fields/date/types.ts
+++ b/javascript/packages/core/components/form/fields/date/types.ts
@@ -21,8 +21,3 @@ export enum DateFormat {
    */
   ISO_DATE_STRING = 'iso',
 }
-
-export type UseDateFormattersReturn = {
-  format: (value: string) => Date | null;
-  parse: (value: Date | null) => string;
-};

--- a/javascript/packages/core/components/form/fields/date/types.ts
+++ b/javascript/packages/core/components/form/fields/date/types.ts
@@ -21,3 +21,8 @@ export enum DateFormat {
    */
   ISO_DATE_STRING = 'iso',
 }
+
+export type UseDateFormattersReturn = {
+  format: (value: string) => Date | null;
+  parse: (value: Date | null) => string;
+};

--- a/javascript/packages/core/components/form/fields/date/use-date-formatters.ts
+++ b/javascript/packages/core/components/form/fields/date/use-date-formatters.ts
@@ -1,10 +1,7 @@
 import { getDateFromEpochSeconds, getEpochSecondsFromDate } from '#core/utils/time-utils';
 import { DateFormat } from './types';
 
-type UseDateFormattersReturn = {
-  format: (value: string) => Date | null;
-  parse: (value: Date | null) => string;
-};
+import type { UseDateFormattersReturn } from './types';
 
 /**
  * Returns `format` and `parse` functions that translate between date formats

--- a/javascript/packages/core/components/form/fields/date/use-date-formatters.ts
+++ b/javascript/packages/core/components/form/fields/date/use-date-formatters.ts
@@ -1,8 +1,6 @@
 import { getDateFromEpochSeconds, getEpochSecondsFromDate } from '#core/utils/time-utils';
 import { DateFormat } from './types';
 
-import type { UseDateFormattersReturn } from './types';
-
 /**
  * Returns `format` and `parse` functions that translate between date formats
  * (epoch seconds string or ISO string) and the Date objects expected by BaseUI's DatePicker.
@@ -17,7 +15,7 @@ import type { UseDateFormattersReturn } from './types';
  */
 export function useDateFormatters(
   dateFormat: DateFormat = DateFormat.ISO_DATE_STRING
-): UseDateFormattersReturn {
+): { format: (value: string) => Date | null; parse: (value: Date | null) => string } {
   const toDate =
     dateFormat === DateFormat.EPOCH_SECONDS
       ? (value: string) => (value ? getDateFromEpochSeconds(parseInt(value)) : null)

--- a/javascript/packages/core/components/form/fields/date/use-date-formatters.ts
+++ b/javascript/packages/core/components/form/fields/date/use-date-formatters.ts
@@ -13,9 +13,10 @@ import { DateFormat } from './types';
  *
  * @param dateFormat - Controls the persisted date format (epoch or ISO).
  */
-export function useDateFormatters(
-  dateFormat: DateFormat = DateFormat.ISO_DATE_STRING
-): { format: (value: string) => Date | null; parse: (value: Date | null) => string } {
+export function useDateFormatters(dateFormat: DateFormat = DateFormat.ISO_DATE_STRING): {
+  format: (value: string) => Date | null;
+  parse: (value: Date | null) => string;
+} {
   const toDate =
     dateFormat === DateFormat.EPOCH_SECONDS
       ? (value: string) => (value ? getDateFromEpochSeconds(parseInt(value)) : null)

--- a/javascript/packages/core/config/entities/trigger/trigger-run-action-form.tsx
+++ b/javascript/packages/core/config/entities/trigger/trigger-run-action-form.tsx
@@ -16,14 +16,12 @@ const ACTION_CONFIG = {
   kill: { heading: 'Kill Trigger Run', submitLabel: 'Kill' },
 } as const;
 
-type Action = keyof typeof ACTION_CONFIG;
-
 function TriggerRunActionForm({
   record,
   isOpen,
   onClose,
   action,
-}: ActionComponentProps<TriggerRun> & { action: Action }) {
+}: ActionComponentProps<TriggerRun> & { action: keyof typeof ACTION_CONFIG }) {
   const queryClient = useQueryClient();
 
   const config = ACTION_CONFIG[action];

--- a/javascript/packages/rpc/runtime-config.ts
+++ b/javascript/packages/rpc/runtime-config.ts
@@ -1,6 +1,4 @@
-interface RuntimeConfig {
-  apiBaseUrl: string;
-}
+import type { RuntimeConfig } from './types';
 
 // Fetches runtime configuration from /config.json.
 export async function getRuntimeConfig(): Promise<RuntimeConfig> {

--- a/javascript/packages/rpc/runtime-config.ts
+++ b/javascript/packages/rpc/runtime-config.ts
@@ -1,7 +1,5 @@
-import type { RuntimeConfig } from './types';
-
 // Fetches runtime configuration from /config.json.
-export async function getRuntimeConfig(): Promise<RuntimeConfig> {
+export async function getRuntimeConfig(): Promise<{ apiBaseUrl: string }> {
   let response: Response;
   try {
     response = await fetch('/config.json');
@@ -21,9 +19,9 @@ export async function getRuntimeConfig(): Promise<RuntimeConfig> {
     throw createConfigError('Check that config.json is properly mounted.', { cause: response });
   }
 
-  let config: RuntimeConfig;
+  let config: { apiBaseUrl: string };
   try {
-    config = (await response.json()) as RuntimeConfig;
+    config = (await response.json()) as { apiBaseUrl: string };
   } catch (error) {
     console.error(
       `Config JSON parsing failed: ${error instanceof Error ? error.message : 'Invalid JSON'}`

--- a/javascript/packages/rpc/runtime-config.ts
+++ b/javascript/packages/rpc/runtime-config.ts
@@ -1,5 +1,7 @@
+import type { RuntimeConfig } from './types';
+
 // Fetches runtime configuration from /config.json.
-export async function getRuntimeConfig(): Promise<{ apiBaseUrl: string }> {
+export async function getRuntimeConfig(): Promise<RuntimeConfig> {
   let response: Response;
   try {
     response = await fetch('/config.json');
@@ -19,9 +21,9 @@ export async function getRuntimeConfig(): Promise<{ apiBaseUrl: string }> {
     throw createConfigError('Check that config.json is properly mounted.', { cause: response });
   }
 
-  let config: { apiBaseUrl: string };
+  let config: RuntimeConfig;
   try {
-    config = (await response.json()) as { apiBaseUrl: string };
+    config = (await response.json()) as RuntimeConfig;
   } catch (error) {
     console.error(
       `Config JSON parsing failed: ${error instanceof Error ? error.message : 'Invalid JSON'}`

--- a/javascript/packages/rpc/services.ts
+++ b/javascript/packages/rpc/services.ts
@@ -10,6 +10,7 @@ import { TriggerRunService } from './gen/michelangelo/api/v2/trigger_run_svc_pb'
 import { getRuntimeConfig } from './runtime-config';
 
 import type { Interceptor } from '@connectrpc/connect';
+import type { Services } from './types';
 
 // This interceptor is used to set the headers for the RPC request to
 // be compatible with the Michelangelo API yarpc server.
@@ -21,15 +22,6 @@ const callerInterceptor: Interceptor = (next) => async (req) => {
   req.header.set('Rpc-Service', 'ma-apiserver');
 
   return await next(req);
-};
-
-type Services = {
-  DeploymentService: ReturnType<typeof createClient<typeof DeploymentService>>;
-  ProjectService: ReturnType<typeof createClient<typeof ProjectService>>;
-  PipelineService: ReturnType<typeof createClient<typeof PipelineService>>;
-  PipelineRunService: ReturnType<typeof createClient<typeof PipelineRunService>>;
-  TriggerRunService: ReturnType<typeof createClient<typeof TriggerRunService>>;
-  ModelService: ReturnType<typeof createClient<typeof ModelService>>;
 };
 
 let servicesPromise: Promise<Services> | null = null;

--- a/javascript/packages/rpc/types.ts
+++ b/javascript/packages/rpc/types.ts
@@ -7,10 +7,6 @@ import type { ProjectService } from './gen/michelangelo/api/v2/project_svc_pb';
 import type { TriggerRunService } from './gen/michelangelo/api/v2/trigger_run_svc_pb';
 import type { getRpcHandlers } from './handlers';
 
-export interface RuntimeConfig {
-  apiBaseUrl: string;
-}
-
 export type Services = {
   ProjectService: ReturnType<typeof createClient<typeof ProjectService>>;
   PipelineService: ReturnType<typeof createClient<typeof PipelineService>>;

--- a/javascript/packages/rpc/types.ts
+++ b/javascript/packages/rpc/types.ts
@@ -1,5 +1,23 @@
 import type { Message } from '@bufbuild/protobuf';
+import type { createClient } from '@connectrpc/connect';
+import type { ModelService } from './gen/michelangelo/api/v2/model_svc_pb';
+import type { PipelineRunService } from './gen/michelangelo/api/v2/pipeline_run_svc_pb';
+import type { PipelineService } from './gen/michelangelo/api/v2/pipeline_svc_pb';
+import type { ProjectService } from './gen/michelangelo/api/v2/project_svc_pb';
+import type { TriggerRunService } from './gen/michelangelo/api/v2/trigger_run_svc_pb';
 import type { getRpcHandlers } from './handlers';
+
+export interface RuntimeConfig {
+  apiBaseUrl: string;
+}
+
+export type Services = {
+  ProjectService: ReturnType<typeof createClient<typeof ProjectService>>;
+  PipelineService: ReturnType<typeof createClient<typeof PipelineService>>;
+  PipelineRunService: ReturnType<typeof createClient<typeof PipelineRunService>>;
+  TriggerRunService: ReturnType<typeof createClient<typeof TriggerRunService>>;
+  ModelService: ReturnType<typeof createClient<typeof ModelService>>;
+};
 
 /**
  * @see {@link getRpcHandlers}

--- a/javascript/packages/rpc/types.ts
+++ b/javascript/packages/rpc/types.ts
@@ -7,6 +7,10 @@ import type { ProjectService } from './gen/michelangelo/api/v2/project_svc_pb';
 import type { TriggerRunService } from './gen/michelangelo/api/v2/trigger_run_svc_pb';
 import type { getRpcHandlers } from './handlers';
 
+export interface RuntimeConfig {
+  apiBaseUrl: string;
+}
+
 export type Services = {
   ProjectService: ReturnType<typeof createClient<typeof ProjectService>>;
   PipelineService: ReturnType<typeof createClient<typeof PipelineService>>;

--- a/javascript/packages/rpc/types.ts
+++ b/javascript/packages/rpc/types.ts
@@ -1,5 +1,6 @@
 import type { Message } from '@bufbuild/protobuf';
 import type { createClient } from '@connectrpc/connect';
+import type { DeploymentService } from './gen/michelangelo/api/v2/deployment_svc_pb';
 import type { ModelService } from './gen/michelangelo/api/v2/model_svc_pb';
 import type { PipelineRunService } from './gen/michelangelo/api/v2/pipeline_run_svc_pb';
 import type { PipelineService } from './gen/michelangelo/api/v2/pipeline_svc_pb';
@@ -12,6 +13,7 @@ export interface RuntimeConfig {
 }
 
 export type Services = {
+  DeploymentService: ReturnType<typeof createClient<typeof DeploymentService>>;
   ProjectService: ReturnType<typeof createClient<typeof ProjectService>>;
   PipelineService: ReturnType<typeof createClient<typeof PipelineService>>;
   PipelineRunService: ReturnType<typeof createClient<typeof PipelineRunService>>;


### PR DESCRIPTION
Enforces that type/interface declarations belong in types.ts (or *-types.ts, or files in a types/ directory). Only *Props interfaces used as component function parameters or forwardRef generics are exempt.

**What type of PR is this? (check all applicable)**
- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
