### PR TITLE
Add interpolatable action configs for per-row resolution

### DIFF
--- a/javascript/packages/core/components/actions/__tests__/actions-popover.test.tsx
+++ b/javascript/packages/core/components/actions/__tests__/actions-popover.test.tsx
@@ -136,7 +136,7 @@ describe('ActionsPopover', () => {
     const disabledAction = {
       display: { label: 'Delete' },
       component: DeleteDialog,
-      disabled: [{ condition: () => true, message: 'Cannot delete' }],
+      disabled: [{ condition: true, message: 'Cannot delete' }],
     };
 
     it('renders a disabled action as visible in the menu', async () => {
@@ -186,7 +186,7 @@ describe('ActionsPopover', () => {
       });
     });
 
-    it('passes the record to the disabled condition', async () => {
+    it('shows the disabled message when condition is true', async () => {
       const user = userEvent.setup();
       render(
         <ActionsPopover
@@ -194,7 +194,7 @@ describe('ActionsPopover', () => {
             {
               display: { label: 'Delete' },
               component: DeleteDialog,
-              disabled: [{ condition: (r) => r.status === 'locked', message: 'Item is locked' }],
+              disabled: [{ condition: true, message: 'Item is locked' }],
             },
           ]}
           record={{ status: 'locked' }}
@@ -215,8 +215,8 @@ describe('ActionsPopover', () => {
               display: { label: 'Delete' },
               component: DeleteDialog,
               disabled: [
-                { condition: () => false, message: 'Should not appear' },
-                { condition: () => true, message: 'Second rule matches' },
+                { condition: false, message: 'Should not appear' },
+                { condition: true, message: 'Second rule matches' },
               ],
             },
           ]}
@@ -238,12 +238,12 @@ describe('ActionsPopover', () => {
             {
               display: { label: 'Delete' },
               component: DeleteDialog,
-              disabled: [{ condition: () => true, message: 'Cannot delete' }],
+              disabled: [{ condition: true, message: 'Cannot delete' }],
             },
             {
               display: { label: 'Archive' },
               component: DeleteDialog,
-              disabled: [{ condition: () => true, message: 'Cannot archive' }],
+              disabled: [{ condition: true, message: 'Cannot archive' }],
             },
           ]}
           record={{}}
@@ -292,12 +292,12 @@ describe('ActionsPopover', () => {
             {
               display: { label: 'Delete' },
               component: DeleteDialog,
-              disabled: [{ condition: () => true, message: 'Cannot delete' }],
+              disabled: [{ condition: true, message: 'Cannot delete' }],
             },
             {
               display: { label: 'Archive' },
               component: DeleteDialog,
-              disabled: [{ condition: () => true, message: 'Cannot archive' }],
+              disabled: [{ condition: true, message: 'Cannot archive' }],
             },
           ]}
           record={{}}

--- a/javascript/packages/core/components/actions/action-menu/action-menu.tsx
+++ b/javascript/packages/core/components/actions/action-menu/action-menu.tsx
@@ -41,10 +41,10 @@ export function ActionMenu(props: ActionMenuProps) {
   const items = useMemo(
     () =>
       props.actions.map((action) => {
-        const disabledRule = action.disabled?.find((rule) => rule.condition(props.record));
+        const disabledRule = action.disabled?.find((rule) => rule.condition);
         return { ...action, disabled: !!disabledRule, disabledMessage: disabledRule?.message };
       }),
-    [props.actions, props.record]
+    [props.actions]
   );
 
   return (

--- a/javascript/packages/core/components/actions/interpolatable-actions-popover.tsx
+++ b/javascript/packages/core/components/actions/interpolatable-actions-popover.tsx
@@ -18,7 +18,11 @@ type InterpolatableActionsPopoverProps = {
  * Table action render functions aren't React components and can't use hooks, so this thin
  * wrapper provides the per-row resolution boundary that the table view needs.
  */
-export function InterpolatableActionsPopover({ actions, record, ...rest }: InterpolatableActionsPopoverProps) {
+export function InterpolatableActionsPopover({
+  actions,
+  record,
+  ...rest
+}: InterpolatableActionsPopoverProps) {
   const resolve = useInterpolationResolver();
   const resolved = useMemo(
     () => resolve(actions, { row: record }) as ActionConfig[],

--- a/javascript/packages/core/components/actions/interpolatable-actions-popover.tsx
+++ b/javascript/packages/core/components/actions/interpolatable-actions-popover.tsx
@@ -1,0 +1,29 @@
+import { useMemo } from 'react';
+
+import { useInterpolationResolver } from '#core/interpolation/use-interpolation-resolver';
+import { ActionsPopover } from './actions-popover';
+
+import type { BasePopoverProps } from 'baseui/popover';
+import type { ActionConfig, ActionConfigSchema, Data } from './types';
+
+type InterpolatableActionsPopoverProps = {
+  actions: ActionConfigSchema<Data>[];
+  record: Data;
+  popoverProps?: BasePopoverProps;
+};
+
+/**
+ * Resolves interpolated action configs per-row before delegating to {@link ActionsPopover}.
+ *
+ * Table action render functions aren't React components and can't use hooks, so this thin
+ * wrapper provides the per-row resolution boundary that the table view needs.
+ */
+export function InterpolatableActionsPopover({ actions, record, ...rest }: InterpolatableActionsPopoverProps) {
+  const resolve = useInterpolationResolver();
+  const resolved = useMemo(
+    () => resolve(actions, { row: record }) as ActionConfig[],
+    [resolve, actions, record]
+  );
+
+  return <ActionsPopover actions={resolved} record={record} {...rest} />;
+}

--- a/javascript/packages/core/components/actions/types.ts
+++ b/javascript/packages/core/components/actions/types.ts
@@ -1,5 +1,7 @@
 import type { ComponentType } from 'react';
 
+import type { DeepInterpolatable, Interpolatable } from '#core/interpolation/types';
+
 export type ActionConfig<T = Data> = ComponentActionConfig<T>;
 
 /**
@@ -13,7 +15,7 @@ export type ActionConfig<T = Data> = ComponentActionConfig<T>;
  * };
  * ```
  */
-export type ActionConfigBase<T = Data> = {
+export type ActionConfigBase = {
   /**
    * Controls how the action's trigger button is displayed to the user.
    *
@@ -35,7 +37,7 @@ export type ActionConfigBase<T = Data> = {
    * Rules are evaluated in order; the first match disables the item and
    * shows its message as a hover tooltip.
    */
-  disabled?: DisabledRule<T>[];
+  disabled?: DisabledRule[];
 };
 
 /**
@@ -56,7 +58,7 @@ export enum ActionHierarchy {
 
 export type Data = Record<string, unknown>;
 
-export type ComponentActionConfig<T = Data> = ActionConfigBase<T> & {
+export type ComponentActionConfig<T = Data> = ActionConfigBase & {
   component: ComponentType<ActionComponentProps<T>>;
 };
 
@@ -71,8 +73,17 @@ export type SelectedAction = {
   record: Data;
 };
 
+/**
+ * Schema version of {@link ActionConfig} — what config authors write.
+ * All leaf fields accept interpolated values via {@link DeepInterpolatable}.
+ *
+ * Components always receive the resolved {@link ActionConfig} — interpolation
+ * is resolved at the per-row boundary before reaching any rendering code.
+ */
+export type ActionConfigSchema<T = Data> = DeepInterpolatable<ActionConfig<T>>;
+
 /** A condition that disables an action for a specific record, with an optional hover tooltip. */
-type DisabledRule<T = Data> = {
-  condition: (record: T) => boolean;
+type DisabledRule = {
+  condition: Interpolatable<boolean>;
   message?: string;
 };

--- a/javascript/packages/core/components/actions/types.ts
+++ b/javascript/packages/core/components/actions/types.ts
@@ -1,5 +1,5 @@
 import type { ComponentType } from 'react';
-import type { DeepInterpolatable, Interpolatable } from '#core/interpolation/types';
+import type { DeepInterpolatable } from '#core/interpolation/types';
 
 export type ActionConfig<T = Data> = ComponentActionConfig<T>;
 
@@ -83,6 +83,6 @@ export type ActionConfigSchema<T = Data> = DeepInterpolatable<ActionConfig<T>>;
 
 /** A condition that disables an action for a specific record, with an optional hover tooltip. */
 type DisabledRule = {
-  condition: Interpolatable<boolean>;
+  condition: boolean;
   message?: string;
 };

--- a/javascript/packages/core/components/actions/types.ts
+++ b/javascript/packages/core/components/actions/types.ts
@@ -1,5 +1,4 @@
 import type { ComponentType } from 'react';
-
 import type { DeepInterpolatable, Interpolatable } from '#core/interpolation/types';
 
 export type ActionConfig<T = Data> = ComponentActionConfig<T>;

--- a/javascript/packages/core/components/views/detail-view/components/detail-view-header/detail-view-header.tsx
+++ b/javascript/packages/core/components/views/detail-view/components/detail-view-header/detail-view-header.tsx
@@ -1,12 +1,15 @@
+import { useMemo } from 'react';
 import { useStyletron } from 'baseui';
 import { Button, KIND, SHAPE, SIZE } from 'baseui/button';
 
 import { ActionsButtons } from '#core/components/actions/actions-buttons/actions-buttons';
 import { Icon } from '#core/components/icon/icon';
+import { useInterpolationResolver } from '#core/interpolation/use-interpolation-resolver';
 import { ELLIPSIS_STYLES } from '#core/styles/constants';
 import { DetailHeaderContainer } from './styled-components';
 
 import type { Theme } from 'baseui/theme';
+import type { ActionConfig } from '#core/components/actions/types';
 import type { DetailViewHeaderProps } from './types';
 
 export function DetailViewHeader({
@@ -19,6 +22,11 @@ export function DetailViewHeader({
   loading,
 }: DetailViewHeaderProps) {
   const [css, theme] = useStyletron();
+  const resolve = useInterpolationResolver();
+  const resolvedActions = useMemo(
+    () => (actions ? (resolve(actions, { page: record }) as ActionConfig[]) : undefined),
+    [resolve, actions, record]
+  );
 
   return (
     <DetailHeaderContainer>
@@ -72,9 +80,9 @@ export function DetailViewHeader({
             </div>
           </div>
         </h5>
-        {actions && (
+        {resolvedActions && (
           <div className={css({ marginLeft: 'auto', flexShrink: 0 })}>
-            <ActionsButtons actions={actions} record={record ?? {}} loading={loading} />
+            <ActionsButtons actions={resolvedActions} record={record ?? {}} loading={loading} />
           </div>
         )}
       </div>

--- a/javascript/packages/core/components/views/detail-view/types/detail-view-component-types.ts
+++ b/javascript/packages/core/components/views/detail-view/types/detail-view-component-types.ts
@@ -1,4 +1,4 @@
-import type { ActionConfig } from '#core/components/actions/types';
+import type { ActionConfigSchema } from '#core/components/actions/types';
 
 export interface DetailViewProps extends DetailHeaderBaseProps {
   /**
@@ -26,7 +26,7 @@ export interface DetailHeaderBaseProps {
    * operate on the currently viewed entity record. For example, a "Delete" action would delete
    * the currently viewed entity.
    */
-  actions?: ActionConfig[];
+  actions?: ActionConfigSchema<object>[];
 
   /** The data for the currently viewed entity. */
   record?: Record<string, unknown>;

--- a/javascript/packages/core/components/views/phase-entity-view/__tests__/phase-entity-view.test.tsx
+++ b/javascript/packages/core/components/views/phase-entity-view/__tests__/phase-entity-view.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { CellType } from '#core/components/cell/constants';
+import { interpolate } from '#core/interpolation/interpolate';
 import {
   buildEntityConfigFactory,
   buildPhaseConfigFactory,
@@ -115,5 +116,49 @@ describe('PhaseEntityView', () => {
     await user.click(await screen.findByRole('button', { name: 'Actions' }));
     await user.click(await screen.findByRole('option', { name: 'Run' }));
     expect(await screen.findByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('resolves interpolated disabled conditions per-row', async () => {
+    const user = userEvent.setup();
+    const StubDialog = ({ isOpen }: ActionComponentProps) =>
+      isOpen ? <div role="dialog">Stub</div> : null;
+
+    render(
+      <PhaseEntityView
+        phaseConfig={buildPhaseConfig()}
+        entities={[
+          buildPipelineEntityConfig({
+            actions: [
+              {
+                display: { label: 'Delete' },
+                component: StubDialog,
+                disabled: [
+                  {
+                    condition: interpolate(({ data }) => data?.locked === true),
+                    message: 'Record is locked',
+                  },
+                ],
+              },
+            ],
+          }) as ListableEntity,
+        ]}
+      />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getErrorProviderWrapper(),
+        getServiceProviderWrapper({
+          request: createQueryMockRouter({
+            ListPipeline: { pipelineList: { items: [{ locked: true }] } },
+          }),
+        }),
+        getRouterWrapper({ location: '/project-1/training/pipeline' }),
+        getIconProviderWrapper(),
+      ])
+    );
+
+    await user.click(await screen.findByRole('button', { name: 'Actions' }));
+    const option = await screen.findByRole('option', { name: 'Delete' });
+    await user.hover(option);
+    expect(await screen.findByText('Record is locked')).toBeInTheDocument();
   });
 });

--- a/javascript/packages/core/components/views/phase-entity-view/__tests__/phase-entity-view.test.tsx
+++ b/javascript/packages/core/components/views/phase-entity-view/__tests__/phase-entity-view.test.tsx
@@ -134,7 +134,9 @@ describe('PhaseEntityView', () => {
                 component: StubDialog,
                 disabled: [
                   {
-                    condition: interpolate(({ data }) => data?.locked === true),
+                    condition: interpolate(
+                      ({ data }) => (data as { locked?: boolean } | undefined)?.locked === true
+                    ),
                     message: 'Record is locked',
                   },
                 ],

--- a/javascript/packages/core/components/views/types.ts
+++ b/javascript/packages/core/components/views/types.ts
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import type { ActionConfig } from '#core/components/actions/types';
+import type { ActionConfigSchema } from '#core/components/actions/types';
 import type { Cell } from '#core/components/cell/types';
 import type { EmptyState } from '#core/components/table/components/table-empty-state/types';
 import type { PageSizeOption } from '#core/components/table/components/table-pagination/types';
@@ -53,5 +53,5 @@ export interface TableConfig<T extends TableData = TableData> {
   enableStickySides?: boolean;
 
   /** Optional actions to render in each table row */
-  actions?: ActionConfig<T>[];
+  actions?: ActionConfigSchema<T>[];
 }

--- a/javascript/packages/core/components/views/utils/table-view-adapter.tsx
+++ b/javascript/packages/core/components/views/utils/table-view-adapter.tsx
@@ -1,6 +1,6 @@
-import { ActionsPopover } from '#core/components/actions/actions-popover';
+import { InterpolatableActionsPopover } from '#core/components/actions/interpolatable-actions-popover';
 
-import type { ActionConfig, Data } from '#core/components/actions/types';
+import type { ActionConfigSchema, Data } from '#core/components/actions/types';
 import type { TableActionBarConfig } from '#core/components/table/components/table-action-bar/types';
 import type { TableData } from '#core/components/table/types/data-types';
 import type { TableProps } from '#core/components/table/types/table-types';
@@ -37,8 +37,8 @@ export function adaptTableConfigToTableProps<T extends TableData = TableData>(
         ? ({ row }: { row: { record: T } }) => (
             // Actions require Record<string, unknown> but TableData is `unknown` — cast at the
             // table/actions boundary since entity records are always objects in practice.
-            <ActionsPopover
-              actions={config.actions as ActionConfig<Data>[]}
+            <InterpolatableActionsPopover
+              actions={config.actions as ActionConfigSchema<Data>[]}
               record={row.record as Data}
             />
           )

--- a/javascript/packages/core/index.tsx
+++ b/javascript/packages/core/index.tsx
@@ -127,7 +127,6 @@ export type {
   InterpolationContext,
   InterpolationContextExtensions,
   Interpolatable,
-  DeepInterpolatable,
   UserDataSources,
 } from '#core/interpolation/types';
 export { isInterpolation } from '#core/interpolation/utils/is-interpolation';

--- a/javascript/packages/core/index.tsx
+++ b/javascript/packages/core/index.tsx
@@ -127,6 +127,7 @@ export type {
   InterpolationContext,
   InterpolationContextExtensions,
   Interpolatable,
+  DeepInterpolatable,
   UserDataSources,
 } from '#core/interpolation/types';
 export { isInterpolation } from '#core/interpolation/utils/is-interpolation';

--- a/javascript/packages/core/interpolation/types.ts
+++ b/javascript/packages/core/interpolation/types.ts
@@ -1,3 +1,5 @@
+import type { ComponentType } from 'react';
+
 import type { ViewTypeToParamType } from '#core/hooks/routing/use-studio-params/types';
 import type { RepeatedLayoutState } from '#core/providers/repeated-layout-provider/types';
 import type { StudioParamsView } from '#core/types/common/view-types';
@@ -144,6 +146,43 @@ export type Interpolatable<T, U extends StudioParamsView = 'base'> =
   | string
   | FunctionInterpolation<T, U>
   | StringInterpolation<U>;
+
+/**
+ * Recursively wraps all leaf fields of `T` with {@link Interpolatable}, allowing
+ * every property in a config object to accept static values or interpolation patterns.
+ *
+ * - Functions and React components are preserved (not wrapped)
+ * - Arrays recurse into their element type
+ * - Objects recurse into each property
+ * - Primitives become `T | Interpolatable<T>`
+ *
+ * Use this to derive a "schema" version of a resolved config type:
+ *
+ * @example
+ * ```typescript
+ * type ActionConfigSchema = DeepInterpolatable<ActionConfig>;
+ *
+ * // Static values still compile — ActionConfig is assignable to ActionConfigSchema:
+ * const staticConfig: ActionConfigSchema = { hierarchy: ActionHierarchy.PRIMARY };
+ *
+ * // Interpolated values also compile:
+ * const dynamicConfig: ActionConfigSchema = {
+ *   hierarchy: interpolate(({ data }) =>
+ *     data.state === 'PAUSED' ? ActionHierarchy.PRIMARY : ActionHierarchy.TERTIARY
+ *   ),
+ * };
+ * ```
+ */
+export type DeepInterpolatable<T, U extends StudioParamsView = 'base'> =
+  T extends (...args: any[]) => any
+    ? T
+    : T extends ComponentType<any>
+      ? T
+      : T extends Array<infer El>
+        ? Array<DeepInterpolatable<El, U>>
+        : T extends object
+          ? { [K in keyof T]: DeepInterpolatable<T[K], U> }
+          : Interpolatable<T, U>;
 
 /**
  * Function type for checking whether a property should be excluded from interpolation.

--- a/javascript/packages/core/interpolation/types.ts
+++ b/javascript/packages/core/interpolation/types.ts
@@ -1,5 +1,4 @@
 import type { ComponentType } from 'react';
-
 import type { ViewTypeToParamType } from '#core/hooks/routing/use-studio-params/types';
 import type { RepeatedLayoutState } from '#core/providers/repeated-layout-provider/types';
 import type { StudioParamsView } from '#core/types/common/view-types';

--- a/javascript/packages/core/interpolation/types.ts
+++ b/javascript/packages/core/interpolation/types.ts
@@ -173,16 +173,17 @@ export type Interpolatable<T, U extends StudioParamsView = 'base'> =
  * };
  * ```
  */
-export type DeepInterpolatable<T, U extends StudioParamsView = 'base'> =
-  T extends (...args: any[]) => any
+export type DeepInterpolatable<T, U extends StudioParamsView = 'base'> = T extends (
+  ...args: any[]
+) => any
+  ? T
+  : T extends ComponentType<any>
     ? T
-    : T extends ComponentType<any>
-      ? T
-      : T extends Array<infer El>
-        ? Array<DeepInterpolatable<El, U>>
-        : T extends object
-          ? { [K in keyof T]: DeepInterpolatable<T[K], U> }
-          : Interpolatable<T, U>;
+    : T extends Array<infer El>
+      ? Array<DeepInterpolatable<El, U>>
+      : T extends object
+        ? { [K in keyof T]: DeepInterpolatable<T[K], U> }
+        : Interpolatable<T, U>;
 
 /**
  * Function type for checking whether a property should be excluded from interpolation.

--- a/javascript/packages/core/router/__tests__/entity-detail-route.test.tsx
+++ b/javascript/packages/core/router/__tests__/entity-detail-route.test.tsx
@@ -6,6 +6,7 @@ import { ActionHierarchy } from '#core/components/actions/types';
 import { CellType } from '#core/components/cell/constants';
 import { buildTableConfigFactory } from '#core/components/views/__fixtures__/table-config-factory';
 import { buildExecutionSchemaFactory } from '#core/components/views/execution/__fixtures__/execution-schema-factory';
+import { interpolate } from '#core/interpolation/interpolate';
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getErrorProviderWrapper } from '#core/test/wrappers/get-error-provider-wrapper';
 import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
@@ -780,5 +781,59 @@ describe('EntityDetailRoute', () => {
 
     await user.click(screen.getByRole('button', { name: 'Close' }));
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  test('resolves interpolated action hierarchy in the detail page header', async () => {
+    const StubDialog = ({ isOpen }: ActionComponentProps) =>
+      isOpen ? <div role="dialog">Stub</div> : null;
+
+    const testPhases = {
+      train: buildPhase({
+        id: 'train',
+        entities: [
+          buildEntity({
+            actions: [
+              {
+                display: { label: 'Resume' },
+                component: StubDialog,
+                hierarchy: interpolate(({ data }) =>
+                  data?.status?.state === 'PAUSED'
+                    ? ActionHierarchy.PRIMARY
+                    : ActionHierarchy.TERTIARY
+                ),
+              },
+            ],
+            views: [
+              {
+                type: 'detail',
+                metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
+                pages: [
+                  { id: 'execution', label: 'Execution', ...buildExecutionSchema() },
+                ],
+              },
+            ],
+          }),
+        ],
+      }),
+    };
+
+    const mockRequest = vi.fn().mockResolvedValue({
+      pipelineRun: {
+        metadata: { creationTimestamp: { seconds: 1640995200 } },
+        status: { state: 'PAUSED', steps: [] },
+      },
+    });
+
+    render(
+      <EntityDetailRoute phases={testPhases} />,
+      buildWrapper([
+        getErrorProviderWrapper(),
+        getRouterWrapper({ location: '/myproject/train/runs/run-123' }),
+        getServiceProviderWrapper({ request: mockRequest }),
+      ])
+    );
+
+    // Hierarchy resolves to PRIMARY → renders as a direct button, not in overflow menu
+    expect(await screen.findByRole('button', { name: 'Resume' })).toBeInTheDocument();
   });
 });

--- a/javascript/packages/core/router/__tests__/entity-detail-route.test.tsx
+++ b/javascript/packages/core/router/__tests__/entity-detail-route.test.tsx
@@ -796,11 +796,12 @@ describe('EntityDetailRoute', () => {
               {
                 display: { label: 'Resume' },
                 component: StubDialog,
-                hierarchy: interpolate(({ data }) =>
-                  data?.status?.state === 'PAUSED'
+                hierarchy: interpolate(({ data }) => {
+                  const record = data as { status?: { state?: string } } | undefined;
+                  return record?.status?.state === 'PAUSED'
                     ? ActionHierarchy.PRIMARY
-                    : ActionHierarchy.TERTIARY
-                ),
+                    : ActionHierarchy.TERTIARY;
+                }),
               },
             ],
             views: [

--- a/javascript/packages/core/router/__tests__/entity-detail-route.test.tsx
+++ b/javascript/packages/core/router/__tests__/entity-detail-route.test.tsx
@@ -807,9 +807,7 @@ describe('EntityDetailRoute', () => {
               {
                 type: 'detail',
                 metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
-                pages: [
-                  { id: 'execution', label: 'Execution', ...buildExecutionSchema() },
-                ],
+                pages: [{ id: 'execution', label: 'Execution', ...buildExecutionSchema() }],
               },
             ],
           }),

--- a/javascript/packages/core/router/entity-detail-route.tsx
+++ b/javascript/packages/core/router/entity-detail-route.tsx
@@ -15,7 +15,6 @@ import { useStudioQuery } from '#core/hooks/use-studio-query';
 import { useInterpolationResolver } from '#core/interpolation/use-interpolation-resolver';
 import { capitalizeFirstLetter } from '#core/utils/string-utils';
 
-import type { ActionConfig } from '#core/components/actions/types';
 import type { PhaseConfig } from '#core/types/common/studio-types';
 
 /**
@@ -104,7 +103,7 @@ export function EntityDetailRoute({ phases = PHASES }: { phases?: Record<string,
       subtitle={entityConfig!.name}
       title={entityId}
       onGoBack={returnToEntityList}
-      actions={entityConfig!.actions as ActionConfig[] | undefined}
+      actions={entityConfig!.actions}
       record={entityData}
       loading={isLoading}
       headerContent={

--- a/javascript/packages/core/types/common/studio-types.ts
+++ b/javascript/packages/core/types/common/studio-types.ts
@@ -1,4 +1,4 @@
-import type { ActionConfig } from '#core/components/actions/types';
+import type { ActionConfigSchema } from '#core/components/actions/types';
 import type { ViewConfig } from '#core/components/views/types';
 import type { QueryConfig } from '#core/types/query-types';
 
@@ -107,7 +107,7 @@ export interface PhaseEntityConfig<T extends object = object> {
    * Optional actions to render for this entity.
    * Rendered in table rows for list views.
    */
-  actions?: ActionConfig<T>[];
+  actions?: ActionConfigSchema<T>[];
 }
 
 /**


### PR DESCRIPTION
Action configs were static — hierarchy, display, and disabled rules were fixed at config time. Trigger runs need conditional behavior: "Resume" should be primary when paused, "Kill/Pause" primary when running. This requires per-row resolution since each table row represents a different record state.

Introduce DeepInterpolatable<T> to recursively allow interpolation on any leaf field in a config type, and ActionConfigSchema as the schema-level counterpart to the resolved ActionConfig. Config authors write ActionConfigSchema; components receive ActionConfig after resolution at the per-row boundary.

DisabledRule.condition changes from (record: T) => boolean to Interpolatable<boolean>, unifying disabled logic with the same interpolation system used by all other fields.

Resolution happens at two boundaries:
- Table: InterpolatableActionsPopover wraps ActionsPopover with per-row hook resolution (table render props can't use hooks)
- Detail view: DetailViewHeader resolves inline via useInterpolationResolver with page data

**What type of PR is this? (check all applicable)**
- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
