### PR TITLE
Export timezone enum for correctly typed timezone to be passed to UserProvider

### DIFF
--- a/javascript/packages/core/index.tsx
+++ b/javascript/packages/core/index.tsx
@@ -100,6 +100,7 @@ export { useURLQueryString } from '#core/hooks/routing/use-url-query-string';
 export * from '#core/utils/object-utils';
 export * from '#core/utils/string-utils';
 export * from '#core/utils/time-utils';
+export { TimeZone } from '#core/types/time-types';
 
 export * from '#core/types/common/studio-types';
 export * from '#core/types/common/view-types';

--- a/javascript/packages/core/package.json
+++ b/javascript/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@michelangelo-ai/core",
   "license": "Apache-2.0",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "type": "module",
   "main": "./dist/michelangelo-core.js",
   "module": "./dist/michelangelo-core.js",


### PR DESCRIPTION
In order to pass correctly typed timezone to [UserProvider](https://github.com/michelangelo-ai/michelangelo/blob/main/javascript/packages/core/providers/user-provider/user-provider.tsx), timezone enum needs to be exported to specify the type passed to UserProvider.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
