### PR TITLE
fix: add pipefail to docs-check build step

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -53,7 +53,9 @@ jobs:
       - name: Build
         id: build
         continue-on-error: true
-        run: bun run build 2>&1 | tee /tmp/build-output.txt
+        run: |
+          set -o pipefail
+          bun run build 2>&1 | tee /tmp/build-output.txt
 
       - name: Annotate broken links
         if: steps.build.outcome == 'failure'


### PR DESCRIPTION
## What type of PR is this?

- [ ] New feature
- [ ] Enhancement to existing feature
- [x] Bug fix
- [ ] Documentation
- [ ] Refactoring
- [ ] Test
- [ ] Other

## What changed?

Added `set -o pipefail` to the Build step in `docs-check.yml`.

## Why?

The build step pipes `bun run build` through `tee` to capture output for the broken-link annotator. But bash's default behavior uses the exit code of the **last** command in a pipeline — `tee`, which always exits 0. This means `steps.build.outcome` is never `'failure'`, so the "Annotate broken links" and "Fail if build failed" steps are always skipped.

The broken-link check has been completely ineffective since it was added. This was discovered while reviewing PRs #1035–#1040, all of which have broken links that CI should be catching.

## How did you test it?

Confirmed via [CI run logs](https://github.com/michelangelo-ai/michelangelo/actions/runs/23872831112/job/69608835750) on PR #1035 that:
1. `bun run build` exits with code 1 (MDX compilation failure due to broken `testing.md` link)
2. `tee` exits with code 0, masking the failure
3. The "Annotate broken links" and "Fail if build failed" steps are skipped
4. The job reports `success`

After this fix, `set -o pipefail` ensures the pipeline returns `bun run build`'s exit code.

## Potential risks

Docs PRs with broken links that were previously passing CI will now correctly fail. PRs #1035–#1040 will need their broken links fixed before they can merge.

## Release notes

N/A — CI-only change.

## Documentation changes

N/A