### PR TITLE
fix: annotate broken markdown links in docs-check workflow

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -62,10 +62,12 @@ jobs:
         working-directory: .
         run: |
           current_file=""
+          # Regex stored in variable to avoid bash [[ =~ ]] quoting issues
+          mdx_re='Markdown link with URL .([^ ]+). in source file "\.\./([^"]+)" \(([0-9]+):'
           while IFS= read -r line; do
             # Format 1: MDX compilation errors (markdown links caught during build)
             # e.g. Markdown link with URL `testing.md` in source file "../docs/contributing/index.md" (63:21) couldn't be resolved.
-            if [[ "$line" =~ Markdown\ link\ with\ URL\ .(.+).\ in\ source\ file\ \"\.\./(.*)"\ \(([0-9]+): ]]; then
+            if [[ "$line" =~ $mdx_re ]]; then
               broken_link="${BASH_REMATCH[1]}"
               source_file="${BASH_REMATCH[2]}"
               line_num="${BASH_REMATCH[3]}"
@@ -74,7 +76,7 @@ jobs:
 
             # Format 2: Post-build broken route links
             # e.g. - Broken link on source page path = /michelangelo/docs/guides/api:
-            #         -> linking to /docs/nonexistent
+            #         -> linking to /michelangelo/docs/nonexistent
             if [[ "$line" =~ "Broken link on source page path = /michelangelo/"(.*): ]]; then
               page_path="${BASH_REMATCH[1]}"
               page_path="${page_path%/}"
@@ -86,15 +88,27 @@ jobs:
                 current_file=""
               fi
             fi
-            if [[ "$line" =~ "-> linking to "([^[:space:]]+) ]] && [[ -n "$current_file" ]]; then
+            if [[ "$line" =~ "-> linking to "([^[:space:]]+) ]]; then
               broken_link="${BASH_REMATCH[1]}"
-              line_nums=$(grep -n "$broken_link" "$current_file" 2>/dev/null | cut -d: -f1)
-              if [[ -n "$line_nums" ]]; then
-                while IFS= read -r line_num; do
-                  echo "::error file=${current_file},line=${line_num}::Broken link: '${broken_link}' could not be resolved"
-                done <<< "$line_nums"
+              # Strip baseUrl prefix so grep matches source text
+              search_link="${broken_link#/michelangelo}"
+              if [[ -n "$current_file" ]]; then
+                line_nums=$(grep -n "$search_link" "$current_file" 2>/dev/null | cut -d: -f1)
+                if [[ -n "$line_nums" ]]; then
+                  while IFS= read -r line_num; do
+                    echo "::error file=${current_file},line=${line_num}::Broken link: '${search_link}' could not be resolved"
+                  done <<< "$line_nums"
+                else
+                  echo "::error file=${current_file}::Broken link: '${search_link}' could not be resolved"
+                fi
               else
-                echo "::error file=${current_file}::Broken link: '${broken_link}' could not be resolved"
+                # Source file couldn't be resolved (e.g. custom slug), search all docs
+                matches=$(grep -rn "$search_link" docs/ --include='*.md' 2>/dev/null | head -5)
+                if [[ -n "$matches" ]]; then
+                  while IFS=: read -r file line_num _; do
+                    echo "::error file=${file},line=${line_num}::Broken link: '${search_link}' could not be resolved"
+                  done <<< "$matches"
+                fi
               fi
             fi
           done < /tmp/build-output.txt

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -63,6 +63,18 @@ jobs:
         run: |
           current_file=""
           while IFS= read -r line; do
+            # Format 1: MDX compilation errors (markdown links caught during build)
+            # e.g. Markdown link with URL `testing.md` in source file "../docs/contributing/index.md" (63:21) couldn't be resolved.
+            if [[ "$line" =~ Markdown\ link\ with\ URL\ .(.+).\ in\ source\ file\ \"\.\./(.*)"\ \(([0-9]+): ]]; then
+              broken_link="${BASH_REMATCH[1]}"
+              source_file="${BASH_REMATCH[2]}"
+              line_num="${BASH_REMATCH[3]}"
+              echo "::error file=${source_file},line=${line_num}::Broken link: '${broken_link}' could not be resolved"
+            fi
+
+            # Format 2: Post-build broken route links
+            # e.g. - Broken link on source page path = /michelangelo/docs/guides/api:
+            #         -> linking to /docs/nonexistent
             if [[ "$line" =~ "Broken link on source page path = /michelangelo/"(.*): ]]; then
               page_path="${BASH_REMATCH[1]}"
               page_path="${page_path%/}"

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -53,17 +53,37 @@ jobs:
       - name: Build
         id: build
         continue-on-error: true
+        env:
+          CI_LINT: 'true'
+          NO_COLOR: '1'
         run: |
           set -o pipefail
           bun run build 2>&1 | tee /tmp/build-output.txt
 
       - name: Annotate broken links
-        if: steps.build.outcome == 'failure'
+        id: annotate
         working-directory: .
         run: |
           current_file=""
+          found_broken=false
+          declare -A seen_annotations
           # Regex stored in variable to avoid bash [[ =~ ]] quoting issues
           mdx_re='Markdown link with URL .([^ ]+). in source file "\.\./([^"]+)" \(([0-9]+):'
+
+          emit_annotation() {
+            local file="$1" line="$2" link="$3"
+            local key="${file}:${line}:${link}"
+            if [[ -z "${seen_annotations[$key]+x}" ]]; then
+              seen_annotations[$key]=1
+              if [[ -n "$line" ]]; then
+                echo "::error file=${file},line=${line}::Broken link: '${link}' could not be resolved"
+              else
+                echo "::error file=${file}::Broken link: '${link}' could not be resolved"
+              fi
+              found_broken=true
+            fi
+          }
+
           while IFS= read -r line; do
             # Format 1: MDX compilation errors (markdown links caught during build)
             # e.g. Markdown link with URL `testing.md` in source file "../docs/contributing/index.md" (63:21) couldn't be resolved.
@@ -71,7 +91,7 @@ jobs:
               broken_link="${BASH_REMATCH[1]}"
               source_file="${BASH_REMATCH[2]}"
               line_num="${BASH_REMATCH[3]}"
-              echo "::error file=${source_file},line=${line_num}::Broken link: '${broken_link}' could not be resolved"
+              emit_annotation "$source_file" "$line_num" "$broken_link"
             fi
 
             # Format 2: Post-build broken route links
@@ -96,23 +116,35 @@ jobs:
                 line_nums=$(grep -n "$search_link" "$current_file" 2>/dev/null | cut -d: -f1)
                 if [[ -n "$line_nums" ]]; then
                   while IFS= read -r line_num; do
-                    echo "::error file=${current_file},line=${line_num}::Broken link: '${search_link}' could not be resolved"
+                    emit_annotation "$current_file" "$line_num" "$search_link"
                   done <<< "$line_nums"
                 else
-                  echo "::error file=${current_file}::Broken link: '${search_link}' could not be resolved"
+                  emit_annotation "$current_file" "" "$search_link"
                 fi
               else
                 # Source file couldn't be resolved (e.g. custom slug), search all docs
                 matches=$(grep -rn "$search_link" docs/ --include='*.md' 2>/dev/null | head -5)
                 if [[ -n "$matches" ]]; then
                   while IFS=: read -r file line_num _; do
-                    echo "::error file=${file},line=${line_num}::Broken link: '${search_link}' could not be resolved"
+                    emit_annotation "$file" "$line_num" "$search_link"
                   done <<< "$matches"
                 fi
               fi
             fi
           done < /tmp/build-output.txt
 
-      - name: Fail if build failed
-        if: steps.build.outcome == 'failure'
-        run: exit 1
+          if [[ "$found_broken" == "true" ]]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Fail if broken links or build error
+        if: steps.build.outcome == 'failure' || steps.annotate.outputs.found == 'true'
+        run: |
+          if [[ "${{ steps.annotate.outputs.found }}" == "true" ]] && [[ "${{ steps.build.outcome }}" == "failure" ]]; then
+            echo "Build failed and broken links were found. See annotations above for details."
+          elif [[ "${{ steps.annotate.outputs.found }}" == "true" ]]; then
+            echo "Broken links were found. See annotations above for details."
+          else
+            echo "Build failed. Check the build step logs for details."
+          fi
+          exit 1

--- a/docs/user-guides/notifications.md
+++ b/docs/user-guides/notifications.md
@@ -9,7 +9,7 @@ Notifications are configured through YAML specs only. The Michelangelo Studio UI
 :::
 
 :::caution Operator Implementation Required
-Notification delivery is not enabled by default in open-source deployments. The notification workflow fires correctly when pipeline states change, but the email and Slack delivery activities are stubs that must be implemented by your platform operator. See [Enabling Notification Delivery](#enabling-notification-delivery) for details.
+Notification delivery is not enabled by default in open-source deployments. The notification workflow fires correctly when pipeline states change, but the email and Slack delivery activities are stubs that must be implemented by your platform operator. See the reference files below for implementation details.
 :::
 
 ## When to Use Notifications
@@ -57,7 +57,7 @@ You can also combine both in a single spec — see the [full example](#full-exam
 Add a `notifications` field to any `PipelineRun`, `TriggerRun`, or `Pipeline` spec. Each entry in the list is one notification rule, and you can have as many rules as you need with different event types and destinations.
 
 :::tip
-You can configure notifications in your YAML specs at any time. Messages will be delivered once your operator has [enabled notification delivery](#enabling-notification-delivery).
+You can configure notifications in your YAML specs at any time. Messages will be delivered once your operator has enabled notification delivery.
 :::
 
 ### Fields
@@ -195,7 +195,7 @@ To stop receiving notifications, remove the `notifications` block entirely and r
 - Double-check that your `notificationType`, `resourceType`, and `eventTypes` are valid values from the tables above. Typos in enum values will be silently ignored.
 - For email, verify the addresses in `emails` are correct.
 - For Slack, confirm the channel name in `slackDestinations` exists and is accessible by the platform.
-- Notification delivery depends on operator-level implementation. If everything looks correct in your spec but notifications still aren't arriving, check with your platform administrator — see [Enabling Notification Delivery](#enabling-notification-delivery) below.
+- Notification delivery depends on operator-level implementation. If everything looks correct in your spec but notifications still aren't arriving, check with your platform administrator.
 
 **I'm only getting some of my notifications.**
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -18,12 +18,15 @@ const config: Config = {
   organizationName: 'michelangelo-ai',
   projectName: 'michelangelo',
 
-  onBrokenLinks: 'throw',
+  // In CI lint mode, use 'warn' so all broken links are reported at once
+  // rather than failing on the first one. The workflow fails the build after
+  // annotating every broken link.
+  onBrokenLinks: process.env.CI_LINT === 'true' ? 'warn' : 'throw',
 
   markdown: {
     format: 'md',
     hooks: {
-      onBrokenMarkdownLinks: 'throw',
+      onBrokenMarkdownLinks: process.env.CI_LINT === 'true' ? 'warn' : 'throw',
     },
   },
 


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**

Fixed the docs-check workflow to annotate **all** broken links in a single CI run, instead of failing on the first one and hiding the rest.

1. **Warn mode in CI** — Added `CI_LINT` env var to `docusaurus.config.ts` so CI uses `'warn'` instead of `'throw'` for both `onBrokenLinks` and `onBrokenMarkdownLinks`. Local builds still throw immediately. This lets Docusaurus report every broken link before exiting.

2. **Parse both error formats** — The annotation step now handles:
   - **MDX compilation warnings** (broken `.md` file links): includes exact file path and line number
   - **Post-build anchor errors** (broken `#heading` links): resolved via file lookup + grep

3. **Bug fixes in anchor error parsing:**
   - Strip `/michelangelo/` baseUrl prefix from broken URLs so grep matches source text
   - Fall back to searching all docs files when page path can't be resolved to a file (e.g. pages with custom `slug`)

4. **Deduplication** — In warn mode, broken `.md` links are caught by both checks. An associative array tracks emitted annotations to prevent duplicates.

5. **Informative failure message** — The fail step now explains why it failed instead of a bare `exit 1`.

6. **Fixed pre-existing broken anchors in `notifications.md`** — The warn mode surfaced 3 references to a `#enabling-notification-delivery` section that no longer exists. Removed the dead anchor links.

**Why?**

The workflow was producing zero annotations on PRs with broken markdown links (the most common case). Even after fixing that, only one type of broken link could be annotated per run because the first error killed the build. A tech writer with multiple broken links had to fix-push-wait in cycles.

**How did you test it?**

Opened test PR #1080 with both a broken `.md` link and a broken route link in the same file. Verified:
- Both annotations appear in a single run (no more whack-a-mole)
- No duplicate annotations
- Correct file and line numbers for both formats
- Also surfaced 3 pre-existing broken anchor links in `notifications.md`
- Confirmed via GitHub annotations API (`check-runs/{id}/annotations`)

**Potential risks**

- `CI_LINT` env var only affects the CI build step. Local `bun run build` still throws on the first broken link (unchanged DX).
- If Docusaurus changes its warning format, the regex would need updating. The patterns are stable across Docusaurus v3/v4.

**Release notes**

N/A — CI-only change.

**Documentation Changes**

N/A