### PR TITLE
test: verify both broken link annotations (DO NOT MERGE)

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -62,10 +62,12 @@ jobs:
         working-directory: .
         run: |
           current_file=""
+          # Regex stored in variable to avoid bash [[ =~ ]] quoting issues
+          mdx_re='Markdown link with URL .([^ ]+). in source file "\.\./([^"]+)" \(([0-9]+):'
           while IFS= read -r line; do
             # Format 1: MDX compilation errors (markdown links caught during build)
             # e.g. Markdown link with URL `testing.md` in source file "../docs/contributing/index.md" (63:21) couldn't be resolved.
-            if [[ "$line" =~ Markdown\ link\ with\ URL\ .(.+).\ in\ source\ file\ \"\.\./(.*)"\ \(([0-9]+): ]]; then
+            if [[ "$line" =~ $mdx_re ]]; then
               broken_link="${BASH_REMATCH[1]}"
               source_file="${BASH_REMATCH[2]}"
               line_num="${BASH_REMATCH[3]}"
@@ -74,7 +76,7 @@ jobs:
 
             # Format 2: Post-build broken route links
             # e.g. - Broken link on source page path = /michelangelo/docs/guides/api:
-            #         -> linking to /docs/nonexistent
+            #         -> linking to /michelangelo/docs/nonexistent
             if [[ "$line" =~ "Broken link on source page path = /michelangelo/"(.*): ]]; then
               page_path="${BASH_REMATCH[1]}"
               page_path="${page_path%/}"
@@ -86,15 +88,27 @@ jobs:
                 current_file=""
               fi
             fi
-            if [[ "$line" =~ "-> linking to "([^[:space:]]+) ]] && [[ -n "$current_file" ]]; then
+            if [[ "$line" =~ "-> linking to "([^[:space:]]+) ]]; then
               broken_link="${BASH_REMATCH[1]}"
-              line_nums=$(grep -n "$broken_link" "$current_file" 2>/dev/null | cut -d: -f1)
-              if [[ -n "$line_nums" ]]; then
-                while IFS= read -r line_num; do
-                  echo "::error file=${current_file},line=${line_num}::Broken link: '${broken_link}' could not be resolved"
-                done <<< "$line_nums"
+              # Strip baseUrl prefix so grep matches source text
+              search_link="${broken_link#/michelangelo}"
+              if [[ -n "$current_file" ]]; then
+                line_nums=$(grep -n "$search_link" "$current_file" 2>/dev/null | cut -d: -f1)
+                if [[ -n "$line_nums" ]]; then
+                  while IFS= read -r line_num; do
+                    echo "::error file=${current_file},line=${line_num}::Broken link: '${search_link}' could not be resolved"
+                  done <<< "$line_nums"
+                else
+                  echo "::error file=${current_file}::Broken link: '${search_link}' could not be resolved"
+                fi
               else
-                echo "::error file=${current_file}::Broken link: '${broken_link}' could not be resolved"
+                # Source file couldn't be resolved (e.g. custom slug), search all docs
+                matches=$(grep -rn "$search_link" docs/ --include='*.md' 2>/dev/null | head -5)
+                if [[ -n "$matches" ]]; then
+                  while IFS=: read -r file line_num _; do
+                    echo "::error file=${file},line=${line_num}::Broken link: '${search_link}' could not be resolved"
+                  done <<< "$matches"
+                fi
               fi
             fi
           done < /tmp/build-output.txt

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -53,15 +53,19 @@ jobs:
       - name: Build
         id: build
         continue-on-error: true
+        env:
+          CI_LINT: 'true'
+          NO_COLOR: '1'
         run: |
           set -o pipefail
           bun run build 2>&1 | tee /tmp/build-output.txt
 
       - name: Annotate broken links
-        if: steps.build.outcome == 'failure'
+        id: annotate
         working-directory: .
         run: |
           current_file=""
+          found_broken=false
           # Regex stored in variable to avoid bash [[ =~ ]] quoting issues
           mdx_re='Markdown link with URL .([^ ]+). in source file "\.\./([^"]+)" \(([0-9]+):'
           while IFS= read -r line; do
@@ -72,6 +76,7 @@ jobs:
               source_file="${BASH_REMATCH[2]}"
               line_num="${BASH_REMATCH[3]}"
               echo "::error file=${source_file},line=${line_num}::Broken link: '${broken_link}' could not be resolved"
+              found_broken=true
             fi
 
             # Format 2: Post-build broken route links
@@ -110,9 +115,14 @@ jobs:
                   done <<< "$matches"
                 fi
               fi
+              found_broken=true
             fi
           done < /tmp/build-output.txt
 
-      - name: Fail if build failed
-        if: steps.build.outcome == 'failure'
+          if [[ "$found_broken" == "true" ]]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Fail if broken links or build error
+        if: steps.build.outcome == 'failure' || steps.annotate.outputs.found == 'true'
         run: exit 1

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -66,8 +66,24 @@ jobs:
         run: |
           current_file=""
           found_broken=false
+          declare -A seen_annotations
           # Regex stored in variable to avoid bash [[ =~ ]] quoting issues
           mdx_re='Markdown link with URL .([^ ]+). in source file "\.\./([^"]+)" \(([0-9]+):'
+
+          emit_annotation() {
+            local file="$1" line="$2" link="$3"
+            local key="${file}:${line}:${link}"
+            if [[ -z "${seen_annotations[$key]+x}" ]]; then
+              seen_annotations[$key]=1
+              if [[ -n "$line" ]]; then
+                echo "::error file=${file},line=${line}::Broken link: '${link}' could not be resolved"
+              else
+                echo "::error file=${file}::Broken link: '${link}' could not be resolved"
+              fi
+              found_broken=true
+            fi
+          }
+
           while IFS= read -r line; do
             # Format 1: MDX compilation errors (markdown links caught during build)
             # e.g. Markdown link with URL `testing.md` in source file "../docs/contributing/index.md" (63:21) couldn't be resolved.
@@ -75,8 +91,7 @@ jobs:
               broken_link="${BASH_REMATCH[1]}"
               source_file="${BASH_REMATCH[2]}"
               line_num="${BASH_REMATCH[3]}"
-              echo "::error file=${source_file},line=${line_num}::Broken link: '${broken_link}' could not be resolved"
-              found_broken=true
+              emit_annotation "$source_file" "$line_num" "$broken_link"
             fi
 
             # Format 2: Post-build broken route links
@@ -101,21 +116,20 @@ jobs:
                 line_nums=$(grep -n "$search_link" "$current_file" 2>/dev/null | cut -d: -f1)
                 if [[ -n "$line_nums" ]]; then
                   while IFS= read -r line_num; do
-                    echo "::error file=${current_file},line=${line_num}::Broken link: '${search_link}' could not be resolved"
+                    emit_annotation "$current_file" "$line_num" "$search_link"
                   done <<< "$line_nums"
                 else
-                  echo "::error file=${current_file}::Broken link: '${search_link}' could not be resolved"
+                  emit_annotation "$current_file" "" "$search_link"
                 fi
               else
                 # Source file couldn't be resolved (e.g. custom slug), search all docs
                 matches=$(grep -rn "$search_link" docs/ --include='*.md' 2>/dev/null | head -5)
                 if [[ -n "$matches" ]]; then
                   while IFS=: read -r file line_num _; do
-                    echo "::error file=${file},line=${line_num}::Broken link: '${search_link}' could not be resolved"
+                    emit_annotation "$file" "$line_num" "$search_link"
                   done <<< "$matches"
                 fi
               fi
-              found_broken=true
             fi
           done < /tmp/build-output.txt
 

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -63,6 +63,18 @@ jobs:
         run: |
           current_file=""
           while IFS= read -r line; do
+            # Format 1: MDX compilation errors (markdown links caught during build)
+            # e.g. Markdown link with URL `testing.md` in source file "../docs/contributing/index.md" (63:21) couldn't be resolved.
+            if [[ "$line" =~ Markdown\ link\ with\ URL\ .(.+).\ in\ source\ file\ \"\.\./(.*)"\ \(([0-9]+): ]]; then
+              broken_link="${BASH_REMATCH[1]}"
+              source_file="${BASH_REMATCH[2]}"
+              line_num="${BASH_REMATCH[3]}"
+              echo "::error file=${source_file},line=${line_num}::Broken link: '${broken_link}' could not be resolved"
+            fi
+
+            # Format 2: Post-build broken route links
+            # e.g. - Broken link on source page path = /michelangelo/docs/guides/api:
+            #         -> linking to /docs/nonexistent
             if [[ "$line" =~ "Broken link on source page path = /michelangelo/"(.*): ]]; then
               page_path="${BASH_REMATCH[1]}"
               page_path="${page_path%/}"

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -139,4 +139,12 @@ jobs:
 
       - name: Fail if broken links or build error
         if: steps.build.outcome == 'failure' || steps.annotate.outputs.found == 'true'
-        run: exit 1
+        run: |
+          if [[ "${{ steps.annotate.outputs.found }}" == "true" ]] && [[ "${{ steps.build.outcome }}" == "failure" ]]; then
+            echo "Build failed and broken links were found. See annotations above for details."
+          elif [[ "${{ steps.annotate.outputs.found }}" == "true" ]]; then
+            echo "Broken links were found. See annotations above for details."
+          else
+            echo "Build failed. Check the build step logs for details."
+          fi
+          exit 1

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -6,6 +6,10 @@ title: Welcome
 
 # Welcome to Michelangelo
 
+[Broken markdown link - format 1](./this-page-does-not-exist.md)
+
+[Broken route link - format 2](/docs/this-route-does-not-exist)
+
 Michelangelo is an end-to-end ML platform for building, deploying, and managing machine learning models. Born at Uber — where it powers **25,000+ model trainings per month** and **~30 million predictions per second** — now open source.
 
 ## Get started

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -18,12 +18,15 @@ const config: Config = {
   organizationName: 'michelangelo-ai',
   projectName: 'michelangelo',
 
-  onBrokenLinks: 'throw',
+  // In CI lint mode, use 'warn' so all broken links are reported at once
+  // rather than failing on the first one. The workflow fails the build after
+  // annotating every broken link.
+  onBrokenLinks: process.env.CI_LINT === 'true' ? 'warn' : 'throw',
 
   markdown: {
     format: 'md',
     hooks: {
-      onBrokenMarkdownLinks: 'throw',
+      onBrokenMarkdownLinks: process.env.CI_LINT === 'true' ? 'warn' : 'throw',
     },
   },
 


### PR DESCRIPTION
Throwaway PR to verify that both broken link types are annotated in a single CI run. Contains intentionally broken links of both formats.