### PR TITLE
Revert baseUrl to /michelangelo/ until custom domain is verified

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -12,9 +12,9 @@ const config: Config = {
     experimental_faster: true,
   },
 
-  // Custom domain deployment config
-  url: 'https://michelangelo-ai.org',
-  baseUrl: '/',
+  // GitHub Pages project site config (revert to /michelangelo/ until custom domain is verified)
+  url: 'https://michelangelo-ai.github.io',
+  baseUrl: '/michelangelo/',
   organizationName: 'michelangelo-ai',
   projectName: 'michelangelo',
 


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
Reverts `baseUrl` from `/` back to `/michelangelo/` and `url` back to `https://michelangelo-ai.github.io`. This undoes PR #1000.

**Why?**
The custom domain (`michelangelo-ai.org`) cannot be set in GitHub Pages repo settings because the domain hasn't been [verified at the org level](https://docs.github.com/pages/configuring-a-custom-domain-for-your-github-pages-site/verifying-your-custom-domain-for-github-pages) yet. Until verification is complete, the site is broken at both URLs:
- `michelangelo-ai.org` → 404 (GitHub Pages doesn't know about the custom domain)
- `michelangelo-ai.github.io/michelangelo/` → broken assets/links (baseUrl is `/` instead of `/michelangelo/`)

**How did you test it?**
Verified config matches the pre-PR #1000 state that was working.

**Potential risks**
None — restores the previously working configuration.

**Release notes**
Temporarily reverts custom domain config until domain verification is complete.

**Documentation Changes**
None