### PR TITLE
fix(ci): restrict build-examples push trigger to main branch

### DIFF
--- a/.github/workflows/build-examples-image.yaml
+++ b/.github/workflows/build-examples-image.yaml
@@ -5,7 +5,7 @@ name: Build examples Docker image
 # workflow so the integration tests never build from scratch.
 on:
   push:
-    branches: ["**"]
+    branches: [main]
     paths:
       - "python/examples/**"
       - "python/pyproject.toml"


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Changed `branches: ["**"]` to `branches: [main]` on the `push` trigger in `build-examples-image.yaml`.

**Why?**

The `push` trigger with `branches: ["**"]` caused the `build-and-push` job to fire on feature branches when merge commits from main brought in `python/examples/` changes. This resulted in unnecessary Docker builds on unrelated PRs — e.g. docs-only PR #1045 triggered a build-and-push that should never have run.

The `pull_request` trigger already covers PR validation with correct path filtering (it evaluates against the PR diff, not the merge commit diff). The `push` trigger only needs to run on `main` since that's when we actually want to push images to GHCR.

**How did you test it?**

Verified the workflow YAML is valid. The `pull_request` trigger is unchanged so PR validation still works. The `push` trigger now only fires on main, which is the only branch where `push: true` to GHCR is meaningful.

**Potential risks**

None. Feature branch pushes were building and pushing images that were never used. The `pull_request` trigger still covers CI validation on PRs.

**Release notes**

N/A — CI-only change.

**Documentation Changes**

N/A