### PR TITLE
[mactl] load metadata with lazy way in pipeline dev-run plugin

### DIFF
--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/dev_run.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/dev_run.py
@@ -14,7 +14,6 @@ from grpc import Channel
 
 from michelangelo.cli.mactl.crd import (
     CRD,
-    METADATA_STUB,
     bind_signature,
     get_single_arg,
     inject_func_signature,
@@ -218,7 +217,7 @@ def generate_dev_run(
         )
         response = stub_method(
             request_input,
-            metadata=METADATA_STUB,
+            metadata=[*_self.metadata, ("ttl", "600")],
             timeout=30,
         )
         _LOG.info("Stub method completed (%r): %r", type(response), response)

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/dev_run_test.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/dev_run_test.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, Mock, patch
 from michelangelo.cli.mactl.crd import CRD
 from michelangelo.cli.mactl.plugins.entity.pipeline.dev_run import (
     _process_env_variables,
+    add_function_signature,
     convert_crd_metadata_pipeline_dev_run,
     generate_dev_run,
     generate_pipeline_dev_run_object,
@@ -433,6 +434,69 @@ class PipelineDevRunTest(TestCase):
         # Verify get_methods_from_service was called
         mock_get_methods.assert_called_once_with(
             mock_channel, "michelangelo.api.v2.PipelineRunService", mock_crd.metadata
+        )
+
+    @patch("michelangelo.cli.mactl.plugins.entity.pipeline.dev_run.get_service_name")
+    @patch(
+        "michelangelo.cli.mactl.plugins.entity.pipeline.dev_run.get_methods_from_service"
+    )
+    @patch(
+        "michelangelo.cli.mactl.plugins.entity.pipeline.dev_run.get_message_class_by_name"
+    )
+    @patch("michelangelo.cli.mactl.plugins.entity.pipeline.dev_run.ParseDict")
+    @patch("michelangelo.cli.mactl.plugins.entity.pipeline.dev_run.yaml_to_dict")
+    def test_dev_run_grpc_call_uses_crd_metadata(
+        self,
+        mock_yaml_to_dict,
+        mock_parse_dict,
+        mock_get_message_class,
+        mock_get_methods,
+        mock_get_service_name,
+    ):
+        """Regression: stub_method must be called with CRD metadata, not empty list.
+
+        Before the fix, METADATA_STUB was imported from crd.py at module load time
+        (when it was still []), so gRPC calls were sent with empty metadata and the
+        server rejected them with 'missing service name, caller name, encoding'.
+        """
+        crd_metadata = [
+            ("rpc-caller", "grpcurl"),
+            ("rpc-service", "ma-apiserver"),
+            ("rpc-encoding", "proto"),
+        ]
+        crd = CRD(
+            name="pipeline_run",
+            full_name="michelangelo.api.v2.PipelineRunService",
+            metadata=crd_metadata,
+        )
+        add_function_signature(crd)
+        crd.func_crd_metadata_converter = Mock(
+            return_value={"pipeline_run": {"spec": {}}}
+        )
+
+        mock_yaml_to_dict.return_value = {
+            "metadata": {"name": "test-pipeline", "namespace": "test-ns"}
+        }
+
+        mock_get_service_name.return_value = "michelangelo.api.v2.PipelineRunService"
+        mock_method = Mock()
+        mock_method.input_type = ".TestInput"
+        mock_method.output_type = ".TestOutput"
+        mock_get_methods.return_value = ({"CreatePipelineRun": mock_method}, Mock())
+        mock_get_message_class.side_effect = [Mock(), Mock()]
+
+        mock_stub = Mock(return_value=Mock())
+        mock_channel = Mock()
+        mock_channel.unary_unary.return_value = mock_stub
+
+        generate_dev_run(crd, mock_channel)
+        crd.dev_run(file="pipeline.yaml")
+
+        mock_stub.assert_called_once()
+        _, call_kwargs = mock_stub.call_args
+        self.assertEqual(
+            call_kwargs["metadata"],
+            [*crd_metadata, ("ttl", "600")],
         )
 
     def test_dev_run_func_extracts_storage_url_from_bound_args(self):


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


dev_run no longer imports METADATA_STUB from crd.py at module load time. The gRPC stub_method is now called with [*_self.metadata, ("ttl", "600")], resolved from the CRD instance at call time.



<!-- Tell your future self why have you made these changes -->
**Why?**

  METADATA_STUB in crd.py starts as [] and is rebound to a new list in CRD.__init__. Because Python's from module import name captures the binding at import time, dev_run.py always held a reference to the original empty list — causing every dev-run gRPC call to be sent with no
  metadata. The server rejected it with "missing service name, caller name, encoding".

  This was introduced in #537 when mactl.py was split into crd.py, changing from a one-time module-level assignment to a lazy init pattern.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

  - ma pipeline dev-run -f ./examples/bert_cola/pipeline.yaml runs without the gRPC error
  - Added regression test test_dev_run_grpc_call_uses_crd_metadata that asserts stub_method is called with the full CRD metadata


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
