### PR TITLE
fix: use instance metadata in dev_run to fix missing YARPC headers

### DIFF
--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/dev_run.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/dev_run.py
@@ -14,7 +14,6 @@ from grpc import Channel
 
 from michelangelo.cli.mactl.crd import (
     CRD,
-    METADATA_STUB,
     bind_signature,
     get_single_arg,
     inject_func_signature,
@@ -218,7 +217,7 @@ def generate_dev_run(
         )
         response = stub_method(
             request_input,
-            metadata=METADATA_STUB,
+            metadata=[*_self.metadata, ("ttl", "600")],
             timeout=30,
         )
         _LOG.info("Stub method completed (%r): %r", type(response), response)


### PR DESCRIPTION
## Summary

- `METADATA_STUB` in `crd.py` is initialized as `[]` at module level and only set during `CRD.__init__`
- PR #1028 moved plugin imports earlier (before CRD initialization), so `from crd import METADATA_STUB` in `dev_run.py` captured the empty list at import time
- Fix: use `_self.metadata` from the CRD instance directly inside `dev_run_func` instead of the stale module-level import

## Test plan
- [ ] `ma pipeline dev_run -f ./examples/bert_cola/pipeline.yaml` no longer fails with `missing service name, caller name, encoding`
- [ ] CI e2e pipeline run completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)