### PR TITLE
Pass cluster affinity from labels

### DIFF
--- a/go/components/jobs/common/constants/constants.go
+++ b/go/components/jobs/common/constants/constants.go
@@ -281,7 +281,7 @@ const (
 
 // Affinity labels
 const (
-	ClusterAffinityLabelKey string = "ma/affinity-cluster"
+	ClusterAffinityLabelKey string = "michelangelo/cluster-affinity"
 )
 
 // Assignment reasons

--- a/go/components/jobs/scheduler/framework/BUILD.bazel
+++ b/go/components/jobs/scheduler/framework/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "@com_github_go_logr_logr//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/api/resource:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apiserver//pkg/quota/v1:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
         "@org_uber_go_fx//:go_default_library",
@@ -36,6 +37,8 @@ go_test(
         "//go/components/jobs/common/constants:go_default_library",
         "//proto/api/v2:go_default_library",
         "@com_github_go_logr_logr//:go_default_library",
+        "@com_github_go_logr_zapr//:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@org_uber_go_zap//zaptest:go_default_library",
     ],
 )

--- a/go/components/jobs/scheduler/framework/cluster_only_assignment_engine.go
+++ b/go/components/jobs/scheduler/framework/cluster_only_assignment_engine.go
@@ -18,8 +18,11 @@ type ClusterOnlyAssignmentStrategy struct {
 }
 
 // NewClusterOnlyAssignmentStrategy returns a new ClusterOnlyAssignmentStrategy
-func NewClusterOnlyAssignmentStrategy(cache cluster.RegisteredClustersCache) AssignmentStrategy {
-	return ClusterOnlyAssignmentStrategy{ClusterCache: cache}
+func NewClusterOnlyAssignmentStrategy(cache cluster.RegisteredClustersCache, log logr.Logger) AssignmentStrategy {
+	return ClusterOnlyAssignmentStrategy{
+		ClusterCache: cache,
+		log:          log,
+	}
 }
 
 // Select implements Engine.
@@ -33,6 +36,9 @@ func (e ClusterOnlyAssignmentStrategy) Select(_ context.Context, job BatchJob) (
 	if selector != nil && selector.MatchLabels != nil {
 		if name, ok := selector.MatchLabels[constants.ClusterAffinityLabelKey]; ok && name != "" {
 			if c := e.ClusterCache.GetCluster(name); c != nil {
+				e.log.Info("Assigned to the requested cluster",
+					constants.Job, job.GetName(),
+					"requested_cluster", name)
 				return &v2pb.AssignmentInfo{Cluster: name}, true, constants.AssignmentReasonClusterMatchedByAffinity, nil
 			}
 			e.log.Info("Requested cluster not found, using default selection",

--- a/go/components/jobs/scheduler/framework/cluster_only_assignment_engine_test.go
+++ b/go/components/jobs/scheduler/framework/cluster_only_assignment_engine_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"testing"
 
+	"go.uber.org/zap/zaptest"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
 
 	"github.com/michelangelo-ai/michelangelo/go/components/jobs/cluster"
 	"github.com/michelangelo-ai/michelangelo/go/components/jobs/common/constants"
@@ -55,6 +57,16 @@ func TestClusterOnlyEngine_Select(t *testing.T) {
 		return job
 	}
 
+	makeRayClusterJob := func(clusterLabel string) BatchJob {
+		labels := map[string]string{}
+		if clusterLabel != "" {
+			labels[constants.ClusterAffinityLabelKey] = clusterLabel
+		}
+		return BatchRayCluster{RayCluster: &v2pb.RayCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "rc", Namespace: "ns", Labels: labels},
+		}}
+	}
+
 	tests := []struct {
 		name        string
 		cache       cluster.RegisteredClustersCache
@@ -94,11 +106,35 @@ func TestClusterOnlyEngine_Select(t *testing.T) {
 			wantFound:  false,
 			wantReason: "no_clusters_found",
 		},
+		{
+			name:        "ray cluster label matches existing cluster",
+			cache:       newFakeClusterCache(makeCluster("c1"), makeCluster("c2")),
+			job:         makeRayClusterJob("c2"),
+			wantFound:   true,
+			wantReason:  "cluster_matched_by_affinity",
+			wantCluster: "c2",
+		},
+		{
+			name:        "ray cluster label for unknown cluster falls back to default",
+			cache:       newFakeClusterCache(makeCluster("c1")),
+			job:         makeRayClusterJob("unknown"),
+			wantFound:   true,
+			wantReason:  "cluster_default_selected",
+			wantCluster: "c1",
+		},
+		{
+			name:        "ray cluster without label selects first available",
+			cache:       newFakeClusterCache(makeCluster("first")),
+			job:         makeRayClusterJob(""),
+			wantFound:   true,
+			wantReason:  "cluster_default_selected",
+			wantCluster: "first",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			engine := NewClusterOnlyAssignmentStrategy(tt.cache)
+			engine := NewClusterOnlyAssignmentStrategy(tt.cache, zapr.NewLogger(zaptest.NewLogger(t)))
 
 			assign, found, reason, err := engine.Select(context.Background(), tt.job)
 			if err != nil {

--- a/go/components/jobs/scheduler/framework/job.go
+++ b/go/components/jobs/scheduler/framework/job.go
@@ -6,6 +6,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	quotav1 "k8s.io/apiserver/pkg/quota/v1"
 
 	"github.com/michelangelo-ai/michelangelo/go/components/jobs/common/constants"
@@ -51,6 +52,19 @@ var _ BatchJob = BatchRayCluster{}
 // GetAffinity returns the job affinity
 func (r BatchRayCluster) GetAffinity() *v2pb.Affinity {
 	// TODO(#611): Add affinity to RayCluster as part of SKU management
+	// GetAffinity builds an Affinity from the RayCluster's metadata labels.
+	// When SKU management and Scheduling is implemented, we will add affinity to the RayClusterSpec proto.
+	if name, ok := r.Labels[constants.ClusterAffinityLabelKey]; ok && name != "" {
+		return &v2pb.Affinity{
+			ResourceAffinity: &v2pb.ResourceAffinity{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						constants.ClusterAffinityLabelKey: name,
+					},
+				},
+			},
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
- Implemented `BatchRayCluster.GetAffinity()` to build a cluster `Affinity` from the RayCluster's metadata labels, instead of always returning `nil`.
- Renamed the affinity label key constant from `ma/affinity-cluster` to `michelangelo/cluster-affinity`.
- Added unit tests in `cluster_only_assignment_engine_test.go` covering: label matching an existing cluster, label pointing to an unknown cluster (falls back to default), and RayCluster with no affinity label.

**Why?**
RayClusters previously had no way to express cluster affinity to the scheduler, so they always landed on the default cluster. Until SKU management adds an affinity field to the `RayCluster` proto (#611), reading the affinity from a well-known metadata label lets users pin a RayCluster to a specific compute cluster today. The label key was renamed to follow the standard `michelangelo/<name>` convention used elsewhere.

**How did you test it?**
Added three new table-driven unit tests in `TestClusterOnlyEngine_Select` exercising the label-match, unknown-cluster-fallback, and no-label paths.

**Potential risks**
- The label key constant changed from `ma/affinity-cluster` to `michelangelo/cluster-affinity`.  No one uses this label right now. 

**Release notes**
Cluster affinity label key renamed: `ma/affinity-cluster` → `michelangelo/cluster-affinity`. RayCluster scheduling now honors this label to pin a cluster.

**Documentation Changes**
None in this PR. The label key rename should be reflected wherever the previous key is documented (wiki / user-facing scheduling docs) before users adopt it.
