### PR TITLE
fix: normalize Uniflow capitalization

### DIFF
--- a/docs/user-guides/ml-pipelines/reference-system.md
+++ b/docs/user-guides/ml-pipelines/reference-system.md
@@ -1,8 +1,8 @@
-# Data Passing and References in UniFlow
+# Data Passing and References in Uniflow
 
 ## What you'll learn
 
-* How data flows between tasks in UniFlow
+* How data flows between tasks in Uniflow
 * What References are and why they're needed
 * How to work with task outputs and inputs
 * Automatic serialization and deserialization
@@ -12,7 +12,7 @@
 
 ## The Problem: Data Between Tasks
 
-When tasks run on distributed clusters, you can't just pass Python objects directly between them. UniFlow solves this with **References** - a smart system that handles data serialization, storage, and retrieval automatically.
+When tasks run on distributed clusters, you can't just pass Python objects directly between them. Uniflow solves this with **References** - a smart system that handles data serialization, storage, and retrieval automatically.
 
 ```python
 # What you write:
@@ -34,7 +34,7 @@ def my_pipeline(file_path: str):
     return result
 ```
 
-**Behind the scenes**, UniFlow:
+**Behind the scenes**, Uniflow:
 1. Serializes the DataFrame returned by `load_data`
 2. Stores it in your configured storage (S3, GCS, etc.)
 3. Passes a Reference (a URL + metadata) to `process_data`
@@ -45,7 +45,7 @@ def my_pipeline(file_path: str):
 
 ## Understanding References
 
-A **Reference** is UniFlow's internal representation of data that's been stored between tasks. It contains:
+A **Reference** is Uniflow's internal representation of data that's been stored between tasks. It contains:
 
 | Component | What It Is | Example |
 |-----------|-----------|---------|
@@ -69,7 +69,7 @@ from michelangelo.uniflow.plugins.ray import RayTask
 def load_data(file_path: str):
     """
     Returns: pandas DataFrame
-    UniFlow converts to: Reference pointing to stored DataFrame
+    Uniflow converts to: Reference pointing to stored DataFrame
     """
     import pandas as pd
     df = pd.read_csv(file_path)
@@ -80,7 +80,7 @@ def clean_data(data):
     """
     Receives: Reference (automatically deserialized to DataFrame)
     Returns: Cleaned DataFrame
-    UniFlow converts to: Reference pointing to stored cleaned data
+    Uniflow converts to: Reference pointing to stored cleaned data
     """
     # data is a real DataFrame, not a Reference object
     cleaned = data.dropna()
@@ -109,7 +109,7 @@ def training_pipeline(file_path: str):
     return model
 ```
 
-**Key insight:** Each task receives a Reference but works with the original Python object. UniFlow handles all serialization/deserialization.
+**Key insight:** Each task receives a Reference but works with the original Python object. Uniflow handles all serialization/deserialization.
 
 ---
 
@@ -125,7 +125,7 @@ from michelangelo.uniflow.plugins.ray import RayTask
 def split_data(data):
     """
     Returns: Tuple of (train_data, validation_data)
-    UniFlow creates: Reference for each element
+    Uniflow creates: Reference for each element
     """
     from sklearn.model_selection import train_test_split
     train, val = train_test_split(data)
@@ -158,7 +158,7 @@ def training_pipeline(data):
 
 ## Cross-Framework Data Passing (Ray to Spark)
 
-One of UniFlow's powerful features: **seamlessly pass data between Ray and Spark tasks**.
+One of Uniflow's powerful features: **seamlessly pass data between Ray and Spark tasks**.
 
 ```python
 from michelangelo.uniflow.core import task, workflow
@@ -170,7 +170,7 @@ def load_with_ray(file_path: str):
     """
     Task 1: Load with Ray
     Returns: Ray dataset
-    UniFlow creates: Reference
+    Uniflow creates: Reference
     """
     import ray.data
     dataset = ray.data.read_csv(file_path)
@@ -180,7 +180,7 @@ def load_with_ray(file_path: str):
 def process_with_spark(data):
     """
     Task 2: Receives Reference from Ray task
-    UniFlow automatically: Converts Ray dataset to Spark dataframe
+    Uniflow automatically: Converts Ray dataset to Spark dataframe
     Returns: Spark dataframe
     """
     # data is now a Spark DataFrame (automatic conversion!)
@@ -191,7 +191,7 @@ def process_with_spark(data):
 def analyze_with_ray(data):
     """
     Task 3: Receives Reference from Spark task
-    UniFlow automatically: Converts Spark dataframe to Ray dataset
+    Uniflow automatically: Converts Spark dataframe to Ray dataset
     """
     # data is now a Ray dataset (automatic conversion!)
     summary = data.groupby("category").mean()
@@ -215,7 +215,7 @@ def multi_framework_pipeline(file_path: str):
 
 ## Supported Data Types
 
-UniFlow's type system (covered in detail in [Type System Guide](./type-system.md)) supports automatic serialization for:
+Uniflow's type system (covered in detail in [Type System Guide](./type-system.md)) supports automatic serialization for:
 
 **Basic types:**
 - Integers, floats, strings, booleans
@@ -289,7 +289,7 @@ def process_data(data):
     result = some_computation(data)
     return json.dumps(result)  # Don't do this!
 
-# ✅ DO - Let UniFlow handle it
+# ✅ DO - Let Uniflow handle it
 @task(config=RayTask(...))
 def process_data(data):
     result = some_computation(data)
@@ -386,7 +386,7 @@ def expensive_task(input_data):
 
 ### Issue: "Data type not supported"
 
-**Cause:** You're trying to pass a type that isn't registered with UniFlow
+**Cause:** You're trying to pass a type that isn't registered with Uniflow
 
 **Solution:** See [Type System Guide](./type-system.md) for supported types and how to add custom types
 

--- a/docs/user-guides/ml-pipelines/type-system.md
+++ b/docs/user-guides/ml-pipelines/type-system.md
@@ -2,7 +2,7 @@
 
 ## What you'll learn
 
-* What types UniFlow supports natively
+* What types Uniflow supports natively
 * The 5 codec types and when to use each
 * How to serialize custom data types
 * Best practices for type safety in workflows
@@ -10,9 +10,9 @@
 
 ---
 
-## Overview: UniFlow's Type System
+## Overview: Uniflow's Type System
 
-When data flows between tasks, UniFlow automatically **serializes** your Python objects for storage and **deserializes** them when the next task runs. This is powered by a flexible type system supporting 5 built-in codecs.
+When data flows between tasks, Uniflow automatically **serializes** your Python objects for storage and **deserializes** them when the next task runs. This is powered by a flexible type system supporting 5 built-in codecs.
 
 ### The 5 Built-In Codecs
 
@@ -141,7 +141,7 @@ class ModelMetrics:
 def compute_metrics(predictions, ground_truth) -> ModelMetrics:
     """
     Computes metrics and returns dataclass instance
-    UniFlow automatically serializes the entire object
+    Uniflow automatically serializes the entire object
     """
     from sklearn.metrics import accuracy_score, precision_score, recall_score, f1_score
 
@@ -342,7 +342,7 @@ import pickle
 def save_model_binary(model) -> bytes:
     """
     Serialize model to bytes using pickle
-    UniFlow stores and serializes the bytes
+    Uniflow stores and serializes the bytes
     """
     return pickle.dumps(model)
 
@@ -461,7 +461,7 @@ def compute_quality(data: pd.DataFrame) -> DataQualityMetrics:
 
 ### Issue: "Type not serializable"
 
-**Cause:** Trying to return a type UniFlow doesn't know about
+**Cause:** Trying to return a type Uniflow doesn't know about
 
 **Solution:** Use one of the 5 codecs:
 1. Wrap in dataclass

--- a/python/README.md
+++ b/python/README.md
@@ -9,7 +9,7 @@ Michelangelo gives ML engineers and data scientists a unified Python SDK for the
 
 ## Key Features
 
-- **UniFlow Pipeline Framework** — Define ML workflows with `@task` and `@workflow` decorators. Write plain Python functions and Michelangelo handles distributed execution, data passing between tasks, and result caching.
+- **Uniflow Pipeline Framework** — Define ML workflows with `@task` and `@workflow` decorators. Write plain Python functions and Michelangelo handles distributed execution, data passing between tasks, and result caching.
 
 - **Distributed Execution** — Scale tasks across Ray or Spark clusters with a single config change. Specify CPU, memory, GPU, and worker resources per task — no changes to your business logic required.
 
@@ -137,7 +137,7 @@ export MICHELANGELO_API_SERVER="localhost:12345"
 Full documentation is available at **[michelangelo-ai.github.io/michelangelo/docs](https://michelangelo-ai.github.io/michelangelo/docs)**.
 
 - [User Guides](https://michelangelo-ai.github.io/michelangelo/docs/user-guides) — Step-by-step guides for data preparation, training, and deployment
-- [ML Pipelines](https://michelangelo-ai.github.io/michelangelo/docs/user-guides/ml-pipelines) — Deep dive into the UniFlow pipeline framework
+- [ML Pipelines](https://michelangelo-ai.github.io/michelangelo/docs/user-guides/ml-pipelines) — Deep dive into the Uniflow pipeline framework
 - [Set Up Triggers](https://michelangelo-ai.github.io/michelangelo/docs/user-guides/set-up-triggers) — Automate pipeline execution with cron and backfill triggers
 - [CLI Reference](https://michelangelo-ai.github.io/michelangelo/docs/user-guides/cli) — Full command-line interface documentation
 


### PR DESCRIPTION
## Summary

- Replaces all instances of `UniFlow` (incorrect) with `Uniflow` (correct) across docs and README
- Files changed: `docs/user-guides/ml-pipelines/reference-system.md`, `docs/user-guides/ml-pipelines/type-system.md`, `python/README.md`
- Left untouched: `python/michelangelo/cli/mactl/plugins/entity/pipeline/create.py` line 452 — `UniFlowConf` is a protobuf type URL identifier, not prose

## Test plan

- [ ] Verify no remaining `UniFlow` in prose (only `UniFlowConf` in protobuf type URL is acceptable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)