### PR TITLE
docs(website): point Docusaurus at custom domain michelangelo-ai.org

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -12,9 +12,8 @@ const config: Config = {
     experimental_faster: true,
   },
 
-  // GitHub Pages project site config (revert to /michelangelo/ until custom domain is verified)
-  url: 'https://michelangelo-ai.github.io',
-  baseUrl: '/michelangelo/',
+  url: 'https://michelangelo-ai.org',
+  baseUrl: '/',
   organizationName: 'michelangelo-ai',
   projectName: 'michelangelo',
 


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**

Updated `website/docusaurus.config.ts` to serve the docs site from the apex of `michelangelo-ai.org` instead of the project-site path under `michelangelo-ai.github.io`:

- `url: 'https://michelangelo-ai.org'` (was `https://michelangelo-ai.github.io`)
- `baseUrl: '/'` (was `/michelangelo/`)

Removed the stale "revert until custom domain is verified" comment.

**Why?**

DNS A records for `michelangelo-ai.org` already point at GitHub Pages (verified via `dig +short michelangelo-ai.org A` → all four 185.199.10[8-11].153 IPs), `www` is CNAMEd to `michelangelo-ai.github.io`, the GitHub org `michelangelo-ai` is verified, and `website/static/CNAME` already contains `michelangelo-ai.org`. Everything serving-side is ready — this just flips Docusaurus's generated URLs and base path to match.

**How did you test it?**

DNS verified with `dig`. Config diff is minimal and matches Docusaurus's documented custom-domain pattern. Final verification will come from the `Deploy Docs` workflow once this lands and the repo's Pages settings are updated to set Custom Domain = `michelangelo-ai.org`.

**Potential risks**

- Until the repo's **Settings → Pages → Custom domain** is set to `michelangelo-ai.org` and DNS check passes, the site may briefly serve from the old project URL while internal links point at the new root path. GitHub auto-redirects old `michelangelo-ai.github.io/michelangelo/*` URLs to the new domain after the custom-domain switch.
- Any hardcoded `/michelangelo/` paths or `michelangelo-ai.github.io` links in the codebase would break — follow-up cleanup may be needed.

**Release notes**

Docs site is moving from `https://michelangelo-ai.github.io/michelangelo/` to `https://michelangelo-ai.org/`. Old URLs auto-redirect.

**Documentation Changes**

The site itself is the docs. No content changes in this PR.