### PR TITLE
docs: update doc links to michelangelo-ai.org custom domain

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ This project and everyone participating in it is governed by our [Code of Conduc
 
 If you want to ask a question about the project, there are a few options available to you.
 
-* Check and read our [Documentation](https://michelangelo-ai.github.io/michelangelo/)
+* Check and read our [Documentation](https://michelangelo-ai.org/)
 * Search our existing [Issues](https://github.com/michelangelo-ai/michelangelo/issues) as this may also help you.
 * Join our Community (coming soon) to engage with other users and contributors,
 
@@ -70,7 +70,7 @@ This section guides you through submitting an enhancement or new functionality i
 ### Before Submitting an Enhancement or Feature
 
 * Make sure that you are using the latest version of the project.
-* **Read the [documentation](https://michelangelo-ai.github.io/michelangelo/) carefully** and find out if the functionality you’re proposing is already covered, this may well be through configuration.
+* **Read the [documentation](https://michelangelo-ai.org/) carefully** and find out if the functionality you’re proposing is already covered, this may well be through configuration.
 * Perform a [search](https://github.com/michelangelo-ai/michelangelo/issues) to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
 * Consider whether your **idea fits with the scope and aims of the project** and keep in mind that we want features that will be useful to the majority of our users and not just a handful.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ We are **incrementally open-sourcing Michelangelo's core capabilities**, ensurin
 
 ## Installation
 
-Follow the [Sandbox Setup](https://michelangelo-ai.github.io/michelangelo/docs/getting-started/sandbox-setup/) guide to get a fully functional local environment running.
+Follow the [Sandbox Setup](https://michelangelo-ai.org/docs/getting-started/sandbox-setup/) guide to get a fully functional local environment running.
 
 ## Usage
 
@@ -67,15 +67,15 @@ def my_pipeline(learning_rate: float = 0.01):
     model = train(learning_rate=learning_rate)
 ```
 
-For a full walkthrough, see the [Getting Started with ML Pipelines](https://michelangelo-ai.github.io/michelangelo/docs/user-guides/ml-pipelines/getting-started/) guide.
+For a full walkthrough, see the [Getting Started with ML Pipelines](https://michelangelo-ai.org/docs/user-guides/ml-pipelines/getting-started/) guide.
 
 ## Build and Test
 
-See the [User Guides](https://michelangelo-ai.github.io/michelangelo/docs/user-guides/) in the documentation for instructions on running tests and working with the development environment.
+See the [User Guides](https://michelangelo-ai.org/docs/user-guides/) in the documentation for instructions on running tests and working with the development environment.
 
 ## Consuming and Using the Containers
 
-See the [Sandbox Setup](https://michelangelo-ai.github.io/michelangelo/docs/getting-started/sandbox-setup/) guide for instructions on running and importing container images into your local cluster.
+See the [Sandbox Setup](https://michelangelo-ai.org/docs/getting-started/sandbox-setup/) guide for instructions on running and importing container images into your local cluster.
 
 ## Contributing
 

--- a/docs/contributing/documentation-guide.md
+++ b/docs/contributing/documentation-guide.md
@@ -264,4 +264,4 @@ Trigger a deploy manually: GitHub Actions → "Deploy Docs" → "Run workflow"
 ### Checking Status
 
 - **Build status**: Check the Actions tab in GitHub
-- **Live site**: https://michelangelo-ai.github.io/
+- **Live site**: https://michelangelo-ai.org/

--- a/python/README.md
+++ b/python/README.md
@@ -2,7 +2,7 @@
 
 **An end-to-end ML platform for building, training, and registering machine learning models at scale.**
 
-[![Documentation](https://img.shields.io/badge/docs-michelangelo--ai.github.io-blue)](https://michelangelo-ai.github.io/michelangelo/docs)
+[![Documentation](https://img.shields.io/badge/docs-michelangelo--ai.org-blue)](https://michelangelo-ai.org/docs)
 [![GitHub](https://img.shields.io/badge/github-michelangelo--ai%2Fmichelangelo-lightgrey)](https://github.com/michelangelo-ai/michelangelo)
 
 Michelangelo gives ML engineers and data scientists a unified Python SDK for the entire model lifecycle — from data preparation and distributed training to model registration and production deployment. Define your ML workflows as Python functions using simple decorators, and Michelangelo handles orchestration, caching, and scaling across Ray and Spark clusters.
@@ -134,12 +134,12 @@ export MICHELANGELO_API_SERVER="localhost:12345"
 
 ## Documentation
 
-Full documentation is available at **[michelangelo-ai.github.io/michelangelo/docs](https://michelangelo-ai.github.io/michelangelo/docs)**.
+Full documentation is available at **[michelangelo-ai.org/docs](https://michelangelo-ai.org/docs)**.
 
-- [User Guides](https://michelangelo-ai.github.io/michelangelo/docs/user-guides) — Step-by-step guides for data preparation, training, and deployment
-- [ML Pipelines](https://michelangelo-ai.github.io/michelangelo/docs/user-guides/ml-pipelines) — Deep dive into the Uniflow pipeline framework
-- [Set Up Triggers](https://michelangelo-ai.github.io/michelangelo/docs/user-guides/set-up-triggers) — Automate pipeline execution with cron and backfill triggers
-- [CLI Reference](https://michelangelo-ai.github.io/michelangelo/docs/user-guides/cli) — Full command-line interface documentation
+- [User Guides](https://michelangelo-ai.org/docs/user-guides) — Step-by-step guides for data preparation, training, and deployment
+- [ML Pipelines](https://michelangelo-ai.org/docs/user-guides/ml-pipelines) — Deep dive into the Uniflow pipeline framework
+- [Set Up Triggers](https://michelangelo-ai.org/docs/user-guides/set-up-triggers) — Automate pipeline execution with cron and backfill triggers
+- [CLI Reference](https://michelangelo-ai.org/docs/user-guides/cli) — Full command-line interface documentation
 
 ## Contributing
 

--- a/website/static/robots.txt
+++ b/website/static/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://michelangelo-ai.github.io/sitemap.xml
+Sitemap: https://michelangelo-ai.org/sitemap.xml


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**

Replaces all hardcoded `https://michelangelo-ai.github.io/michelangelo/...` (and bare `https://michelangelo-ai.github.io/...`) references with the new custom domain `https://michelangelo-ai.org/...` across:

- `README.md` — 4 doc links (Sandbox Setup, ML Pipelines getting started, User Guides, container images)
- `CONTRIBUTING.md` — 2 documentation links
- `python/README.md` — shields.io badge + 5 doc links (Documentation, User Guides, ML Pipelines, Set Up Triggers, CLI Reference)
- `website/static/robots.txt` — sitemap URL
- `docs/contributing/documentation-guide.md` — "Live site" reference

13 link replacements, 5 files, no behavior changes.

**Why?**

Companion to #1101, which flips Docusaurus's `url`/`baseUrl` to serve from the custom domain. Without this cleanup, the prose in our READMEs and the published `robots.txt` sitemap would still point users (and crawlers) at the old `michelangelo-ai.github.io/michelangelo/` URLs. GitHub will redirect those to the new domain after the Pages settings switch, but having current-domain links in the source is cleaner and avoids relying on the redirect.

**How did you test it?**

- `grep -rn 'michelangelo-ai\.github\.io'` across tracked files comes back empty (the only remaining hit is in `website/docusaurus.config.ts`, which #1101 fixes; `website/build/robots.txt` is a gitignored local build artifact and will regenerate from the updated source).
- All replaced URLs follow the same path structure: `michelangelo-ai.github.io/michelangelo/foo` → `michelangelo-ai.org/foo`.
- No code paths touched.

**Potential risks**

Minimal. The links won't resolve on the new domain until #1101 lands and **Settings → Pages → Custom domain** is set to `michelangelo-ai.org`. In the interim, GitHub auto-redirects old → new once the custom domain is configured, so even if someone clicks a link from the new READMEs before then, it'll redirect correctly.

**Release notes**

Doc URLs in README/CONTRIBUTING/python README updated to the new `michelangelo-ai.org` domain. Sitemap URL in `robots.txt` updated.

**Documentation Changes**

This PR is the documentation change.