### PR TITLE
feat: add PipelineRunManager with List and Kill methods

### DIFF
--- a/go/components/pipelinerun/BUILD.bazel
+++ b/go/components/pipelinerun/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "controller.go",
+        "manager.go",
         "metrics.go",
         "module.go",
     ],
@@ -20,6 +21,7 @@ go_library(
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_sigs_controller_runtime//:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/manager:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/metrics:go_default_library",
         "@org_uber_go_fx//:go_default_library",
@@ -29,7 +31,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["controller_test.go"],
+    srcs = [
+        "controller_test.go",
+        "manager_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//go/api/handler:go_default_library",
@@ -53,6 +58,7 @@ go_test(
         "@io_k8s_sigs_controller_runtime//:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client/fake:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client/interceptor:go_default_library",
         "@org_uber_go_config//:go_default_library",
         "@org_uber_go_zap//zaptest:go_default_library",
     ],

--- a/go/components/pipelinerun/controller.go
+++ b/go/components/pipelinerun/controller.go
@@ -127,8 +127,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	// Check if state changed to terminal state and emit metrics
-	originalIsTerminal := isTerminalState(originalPipelineRun.Status.State)
-	currentIsTerminal := isTerminalState(pipelineRun.Status.State)
+	originalIsTerminal := IsTerminalState(originalPipelineRun.Status.State)
+	currentIsTerminal := IsTerminalState(pipelineRun.Status.State)
 	if !originalIsTerminal && currentIsTerminal {
 		r.emitPipelineRunMetrics(pipelineRun)
 	}
@@ -187,11 +187,17 @@ func (r *Reconciler) Register(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-// isTerminalState checks if a pipeline run state is terminal
-func isTerminalState(state v2pb.PipelineRunState) bool {
+// IsTerminalState checks if a pipeline run state is terminal.
+//
+// Terminal states (SUCCEEDED, FAILED, KILLED, SKIPPED) indicate the pipeline
+// run has reached a final state and will not transition further. SKIPPED is
+// included per the proto contract (proto/api/v2/pipeline_run.proto); omitting
+// it would cause cascade delete to treat SKIPPED runs as active forever.
+func IsTerminalState(state v2pb.PipelineRunState) bool {
 	return state == v2pb.PIPELINE_RUN_STATE_SUCCEEDED ||
 		state == v2pb.PIPELINE_RUN_STATE_FAILED ||
-		state == v2pb.PIPELINE_RUN_STATE_KILLED
+		state == v2pb.PIPELINE_RUN_STATE_KILLED ||
+		state == v2pb.PIPELINE_RUN_STATE_SKIPPED
 }
 
 // emitPipelineRunMetrics emits metrics for completed pipeline runs

--- a/go/components/pipelinerun/manager.go
+++ b/go/components/pipelinerun/manager.go
@@ -1,0 +1,81 @@
+package pipelinerun
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v2pb "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
+)
+
+// Manager provides operations for managing PipelineRun resources
+// associated with a pipeline during cascade delete.
+type Manager interface {
+	ListPipelineRunsForPipeline(ctx context.Context, namespace, pipelineName string) ([]*v2pb.PipelineRun, error)
+	ListActivePipelineRunsForPipeline(ctx context.Context, namespace, pipelineName string) ([]*v2pb.PipelineRun, error)
+	KillPipelineRun(ctx context.Context, pr *v2pb.PipelineRun) error
+}
+
+type managerImpl struct {
+	k8sClient client.Client
+	logger    *zap.Logger
+}
+
+// NewManager creates a new PipelineRun Manager backed by the controller-runtime
+// client. The controller-runtime client is built with the controllermgr's
+// custom scheme (which has v2 types registered), so it does not suffer the
+// global-scheme mismatch that the apiserver-shaped api.Handler has when used
+// from a controller process.
+func NewManager(k8sClient client.Client, logger *zap.Logger) Manager {
+	return &managerImpl{k8sClient: k8sClient, logger: logger}
+}
+
+// ListPipelineRunsForPipeline returns every PipelineRun in the namespace whose
+// spec.pipeline references the given pipeline. Filtering is done in-memory
+// because custom FieldSelectors are not supported uniformly across the
+// metadata storage backend and the controller-runtime cached client.
+func (m *managerImpl) ListPipelineRunsForPipeline(ctx context.Context, namespace, pipelineName string) ([]*v2pb.PipelineRun, error) {
+	list := &v2pb.PipelineRunList{}
+	if err := m.k8sClient.List(ctx, list, client.InNamespace(namespace)); err != nil {
+		return nil, fmt.Errorf("list pipeline runs for pipeline %s/%s: %w", namespace, pipelineName, err)
+	}
+	var result []*v2pb.PipelineRun
+	for i := range list.Items {
+		pr := &list.Items[i]
+		if pr.Spec.Pipeline == nil {
+			continue
+		}
+		if pr.Spec.Pipeline.Name != pipelineName || pr.Spec.Pipeline.Namespace != namespace {
+			continue
+		}
+		result = append(result, pr)
+	}
+	return result, nil
+}
+
+func (m *managerImpl) ListActivePipelineRunsForPipeline(ctx context.Context, namespace, pipelineName string) ([]*v2pb.PipelineRun, error) {
+	all, err := m.ListPipelineRunsForPipeline(ctx, namespace, pipelineName)
+	if err != nil {
+		return nil, err
+	}
+	var active []*v2pb.PipelineRun
+	for _, pr := range all {
+		if !IsTerminalState(pr.Status.State) {
+			active = append(active, pr)
+		}
+	}
+	return active, nil
+}
+
+func (m *managerImpl) KillPipelineRun(ctx context.Context, pr *v2pb.PipelineRun) error {
+	if IsTerminalState(pr.Status.State) {
+		return nil
+	}
+	pr.Spec.Kill = true
+	if err := m.k8sClient.Update(ctx, pr); err != nil {
+		return fmt.Errorf("kill pipeline run %s/%s: %w", pr.Namespace, pr.Name, err)
+	}
+	return nil
+}

--- a/go/components/pipelinerun/manager_test.go
+++ b/go/components/pipelinerun/manager_test.go
@@ -1,0 +1,231 @@
+package pipelinerun
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	apipb "github.com/michelangelo-ai/michelangelo/proto-go/api"
+	v2pb "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
+)
+
+func newTestManager(t *testing.T, objects ...client.Object) (*managerImpl, client.Client) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, v2pb.AddToScheme(scheme))
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		WithStatusSubresource(objects...).
+		Build()
+	mgr := &managerImpl{k8sClient: k8sClient, logger: zaptest.NewLogger(t)}
+	return mgr, k8sClient
+}
+
+// newErroringManager builds a manager whose underlying controller-runtime
+// client returns the configured errors for List/Update. Use a nil error to
+// fall through to the real fake-client behavior.
+func newErroringManager(t *testing.T, listErr, updateErr error, objects ...client.Object) *managerImpl {
+	scheme := runtime.NewScheme()
+	require.NoError(t, v2pb.AddToScheme(scheme))
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		WithStatusSubresource(objects...).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if listErr != nil {
+					return listErr
+				}
+				return c.List(ctx, list, opts...)
+			},
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				if updateErr != nil {
+					return updateErr
+				}
+				return c.Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	return &managerImpl{k8sClient: k8sClient, logger: zaptest.NewLogger(t)}
+}
+
+func makePipelineRun(name, namespace, pipelineName, pipelineNamespace string, state v2pb.PipelineRunState) *v2pb.PipelineRun {
+	return &v2pb.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v2pb.PipelineRunSpec{
+			Pipeline: &apipb.ResourceIdentifier{
+				Name:      pipelineName,
+				Namespace: pipelineNamespace,
+			},
+		},
+		Status: v2pb.PipelineRunStatus{
+			State: state,
+		},
+	}
+}
+
+func TestListPipelineRunsForPipeline(t *testing.T) {
+	pr1 := makePipelineRun("pr-1", "ns", "my-pipeline", "ns", v2pb.PIPELINE_RUN_STATE_RUNNING)
+	pr2 := makePipelineRun("pr-2", "ns", "my-pipeline", "ns", v2pb.PIPELINE_RUN_STATE_SUCCEEDED)
+	prOther := makePipelineRun("pr-other", "ns", "other-pipeline", "ns", v2pb.PIPELINE_RUN_STATE_RUNNING)
+
+	mgr, _ := newTestManager(t, pr1, pr2, prOther)
+	result, err := mgr.ListPipelineRunsForPipeline(context.Background(), "ns", "my-pipeline")
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+	names := []string{result[0].Name, result[1].Name}
+	require.ElementsMatch(t, []string{"pr-1", "pr-2"}, names)
+}
+
+func TestListPipelineRunsForPipeline_Empty(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	result, err := mgr.ListPipelineRunsForPipeline(context.Background(), "ns", "my-pipeline")
+	require.NoError(t, err)
+	require.Empty(t, result)
+}
+
+func TestListPipelineRunsForPipeline_IgnoresOtherPipelines(t *testing.T) {
+	mine := makePipelineRun("pr-mine", "ns", "my-pipeline", "ns", v2pb.PIPELINE_RUN_STATE_RUNNING)
+	other := makePipelineRun("pr-other", "ns", "other-pipeline", "ns", v2pb.PIPELINE_RUN_STATE_RUNNING)
+	crossNs := makePipelineRun("pr-cross-ns", "ns", "my-pipeline", "other-ns", v2pb.PIPELINE_RUN_STATE_RUNNING)
+
+	mgr, _ := newTestManager(t, mine, other, crossNs)
+	result, err := mgr.ListPipelineRunsForPipeline(context.Background(), "ns", "my-pipeline")
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	require.Equal(t, "pr-mine", result[0].Name)
+}
+
+func TestListPipelineRunsForPipeline_IgnoresNilPipeline(t *testing.T) {
+	valid := makePipelineRun("pr-valid", "ns", "my-pipeline", "ns", v2pb.PIPELINE_RUN_STATE_RUNNING)
+	nilPipeline := &v2pb.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "pr-nil", Namespace: "ns"},
+		Status:     v2pb.PipelineRunStatus{State: v2pb.PIPELINE_RUN_STATE_RUNNING},
+	}
+
+	mgr, _ := newTestManager(t, valid, nilPipeline)
+	result, err := mgr.ListPipelineRunsForPipeline(context.Background(), "ns", "my-pipeline")
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	require.Equal(t, "pr-valid", result[0].Name)
+}
+
+func TestListActivePipelineRunsForPipeline(t *testing.T) {
+	pr1 := makePipelineRun("pr-1", "ns", "my-pipeline", "ns", v2pb.PIPELINE_RUN_STATE_RUNNING)
+	pr2 := makePipelineRun("pr-2", "ns", "my-pipeline", "ns", v2pb.PIPELINE_RUN_STATE_SUCCEEDED)
+	pr3 := makePipelineRun("pr-3", "ns", "my-pipeline", "ns", v2pb.PIPELINE_RUN_STATE_KILLED)
+	pr4 := makePipelineRun("pr-4", "ns", "my-pipeline", "ns", v2pb.PIPELINE_RUN_STATE_FAILED)
+
+	mgr, _ := newTestManager(t, pr1, pr2, pr3, pr4)
+	result, err := mgr.ListActivePipelineRunsForPipeline(context.Background(), "ns", "my-pipeline")
+	require.NoError(t, err)
+	for _, pr := range result {
+		require.False(t, IsTerminalState(pr.Status.State), "expected only active PRs, got %s in state %s", pr.Name, pr.Status.State)
+	}
+}
+
+func TestKillPipelineRun_Running(t *testing.T) {
+	pr := makePipelineRun("pr-1", "ns", "my-pipeline", "ns", v2pb.PIPELINE_RUN_STATE_RUNNING)
+	mgr, k8sClient := newTestManager(t, pr)
+
+	err := mgr.KillPipelineRun(context.Background(), pr)
+	require.NoError(t, err)
+
+	updated := &v2pb.PipelineRun{}
+	require.NoError(t, k8sClient.Get(context.Background(), client.ObjectKeyFromObject(pr), updated))
+	require.True(t, updated.Spec.Kill)
+}
+
+func TestKillPipelineRun_AlreadyTerminal(t *testing.T) {
+	for _, state := range []v2pb.PipelineRunState{
+		v2pb.PIPELINE_RUN_STATE_SUCCEEDED,
+		v2pb.PIPELINE_RUN_STATE_FAILED,
+		v2pb.PIPELINE_RUN_STATE_KILLED,
+	} {
+		t.Run(state.String(), func(t *testing.T) {
+			pr := makePipelineRun("pr-1", "ns", "my-pipeline", "ns", state)
+			mgr, _ := newTestManager(t, pr)
+
+			err := mgr.KillPipelineRun(context.Background(), pr)
+			require.NoError(t, err)
+			require.False(t, pr.Spec.Kill)
+		})
+	}
+}
+
+func TestIsTerminalState(t *testing.T) {
+	tests := []struct {
+		state    v2pb.PipelineRunState
+		terminal bool
+	}{
+		{v2pb.PIPELINE_RUN_STATE_INVALID, false},
+		{v2pb.PIPELINE_RUN_STATE_PENDING, false},
+		{v2pb.PIPELINE_RUN_STATE_RUNNING, false},
+		{v2pb.PIPELINE_RUN_STATE_SUCCEEDED, true},
+		{v2pb.PIPELINE_RUN_STATE_FAILED, true},
+		{v2pb.PIPELINE_RUN_STATE_KILLED, true},
+		{v2pb.PIPELINE_RUN_STATE_SKIPPED, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.state.String(), func(t *testing.T) {
+			require.Equal(t, tc.terminal, IsTerminalState(tc.state))
+		})
+	}
+}
+
+func TestNewManager(t *testing.T) {
+	// Exercise the public constructor to ensure it wires dependencies correctly.
+	scheme := runtime.NewScheme()
+	require.NoError(t, v2pb.AddToScheme(scheme))
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	mgr := NewManager(k8sClient, zaptest.NewLogger(t))
+	require.NotNil(t, mgr)
+
+	result, err := mgr.ListPipelineRunsForPipeline(context.Background(), "ns", "my-pipeline")
+	require.NoError(t, err)
+	require.Empty(t, result)
+}
+
+func TestListPipelineRunsForPipeline_ListError(t *testing.T) {
+	listErr := errors.New("boom")
+	mgr := newErroringManager(t, listErr, nil)
+
+	result, err := mgr.ListPipelineRunsForPipeline(context.Background(), "ns", "my-pipeline")
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.ErrorIs(t, err, listErr)
+	require.Contains(t, err.Error(), "list pipeline runs for pipeline ns/my-pipeline")
+}
+
+func TestListActivePipelineRunsForPipeline_PropagatesListError(t *testing.T) {
+	listErr := errors.New("list boom")
+	mgr := newErroringManager(t, listErr, nil)
+
+	result, err := mgr.ListActivePipelineRunsForPipeline(context.Background(), "ns", "my-pipeline")
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.ErrorIs(t, err, listErr)
+}
+
+func TestKillPipelineRun_UpdateError(t *testing.T) {
+	pr := makePipelineRun("pr-1", "ns", "my-pipeline", "ns", v2pb.PIPELINE_RUN_STATE_RUNNING)
+	updateErr := errors.New("update boom")
+	mgr := newErroringManager(t, nil, updateErr, pr)
+
+	err := mgr.KillPipelineRun(context.Background(), pr)
+	require.Error(t, err)
+	require.ErrorIs(t, err, updateErr)
+	require.Contains(t, err.Error(), "kill pipeline run ns/pr-1")
+}


### PR DESCRIPTION

**What type of PR is this? (check all applicable)**
- [x] Feature

**What changed?**
- Introduce `pipelinerun.Manager` interface with `ListPipelineRunsForPipeline`, `ListActivePipelineRunsForPipeline`, and `KillPipelineRun` methods (symmetric with the TriggerRun manager).
- Filter PRs by `Spec.Pipeline.{Name,Namespace}` in-memory.
- `KillPipelineRun` sets `Spec.Kill = true`; the PR controller already honors this flag.
- Add `PIPELINE_RUN_STATE_SKIPPED` to `IsTerminalState` per the proto contract (`proto/api/v2/pipeline_run.proto` documents SKIPPED as a terminal state). Without this fix a SKIPPED PR would be treated as active forever, deadlocking cascade delete.
- Export `isTerminalState → IsTerminalState`.
- Unit tests: list, active-filter, kill, list-ignores-other-pipelines, list-ignores-nil-pipeline, SKIPPED terminal.

**Why?**
Addressing https://github.com/michelangelo-ai/michelangelo/issues/1091.
Cascade delete needs a matching interface for PipelineRuns so the controller can enumerate, kill, and eventually delete them alongside TriggerRuns.

**How did you test it?**
- `bazel test //go/components/pipelinerun/...` — all tests pass.
- `bazel build //go/...` — no build errors.

- End-to-end behavior of the full cascade-delete stack is verified on a sandbox cluster; results are attached on #1114.

**Potential risks**
- `IsTerminalState` now returns `true` for `PIPELINE_RUN_STATE_SKIPPED`. Nothing in OSS currently sets SKIPPED so the risk is latent, but any downstream consumer that checked terminal-ness and assumed SKIPPED was "not yet done" would now see it as done. The proto's documented contract says SKIPPED is terminal, so this aligns code with contract.

**Release notes**
N/A (no user-visible behavior change on its own).

**Documentation Changes**
N/A (user-facing docs land in `feat/cascade-delete-docs`).

---
Stacked on top of #1105.