### PR TITLE
feat: add pipeline finalizer lifecycle

### DIFF
--- a/go/api/api.go
+++ b/go/api/api.go
@@ -17,6 +17,11 @@ const (
 	// all the pre-delete actions are completed before removing this finalizer.
 	IngesterFinalizer = "michelangelo/Ingester"
 
+	// PipelineFinalizer is used as the pre-delete hook for pipeline controller.
+	// The pipeline controller checks if all child resources (TriggerRuns, PipelineRuns)
+	// are terminated and cleaned up before removing this finalizer.
+	PipelineFinalizer = "michelangelo/Pipeline"
+
 	/////////////////////////// K8s Annotations ///////////////////////////
 
 	// DeletingAnnotation is used to mark a CRD object is pending on deletion.

--- a/go/components/pipeline/BUILD.bazel
+++ b/go/components/pipeline/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_sigs_controller_runtime//:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/controller/controllerutil:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/manager:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/metrics:go_default_library",
         "@org_uber_go_fx//:go_default_library",
@@ -31,6 +32,7 @@ go_test(
     srcs = ["controller_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//go/api:go_default_library",
         "//go/api/handler:go_default_library",
         "//go/base/env:go_default_library",
         "//proto/api:go_default_library",
@@ -42,6 +44,7 @@ go_test(
         "@io_k8s_sigs_controller_runtime//:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client/fake:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/controller/controllerutil:go_default_library",
         "@org_uber_go_zap//zaptest:go_default_library",
     ],
 )

--- a/go/components/pipeline/controller.go
+++ b/go/components/pipeline/controller.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 const (
@@ -64,6 +65,26 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if err := r.Get(ctx, req.Namespace, req.Name, &metav1.GetOptions{}, pipeline); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+
+	// Manage finalizer lifecycle for cascade delete
+	if pipeline.GetDeletionTimestamp().IsZero() {
+		if !controllerutil.ContainsFinalizer(pipeline, api.PipelineFinalizer) {
+			controllerutil.AddFinalizer(pipeline, api.PipelineFinalizer)
+			if err := r.Update(ctx, pipeline, &metav1.UpdateOptions{}); err != nil {
+				return ctrl.Result{}, fmt.Errorf("add pipeline finalizer: %w", err)
+			}
+		}
+	} else {
+		// Pipeline is being deleted — remove finalizer to allow deletion
+		// Cascade delete logic will be added in a subsequent PR
+		logger.Info("Pipeline is being deleted, removing finalizer")
+		controllerutil.RemoveFinalizer(pipeline, api.PipelineFinalizer)
+		if err := r.Update(ctx, pipeline, &metav1.UpdateOptions{}); err != nil {
+			return ctrl.Result{}, fmt.Errorf("remove pipeline finalizer: %w", err)
+		}
+		return ctrl.Result{}, nil
+	}
+
 	originalPipeline := pipeline.DeepCopy()
 	state := pipeline.Status.State
 	logger.Info("Reconciling pipeline", zap.Any("PipelineStatusState", state.String()))

--- a/go/components/pipeline/controller_test.go
+++ b/go/components/pipeline/controller_test.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -10,7 +11,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"github.com/michelangelo-ai/michelangelo/go/api"
 	apiHandler "github.com/michelangelo-ai/michelangelo/go/api/handler"
 	"github.com/michelangelo-ai/michelangelo/go/base/env"
 	apipb "github.com/michelangelo-ai/michelangelo/proto-go/api"
@@ -35,8 +38,9 @@ func TestReconcile(t *testing.T) {
 			initialObjects: []client.Object{
 				&v2pb.Pipeline{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-pipeline",
-						Namespace: "test-namespace",
+						Name:       "test-pipeline",
+						Namespace:  "test-namespace",
+						Finalizers: []string{api.PipelineFinalizer},
 					},
 					Spec: v2pb.PipelineSpec{
 						Commit: &v2pb.CommitInfo{
@@ -59,8 +63,9 @@ func TestReconcile(t *testing.T) {
 			initialObjects: []client.Object{
 				&v2pb.Pipeline{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-pipeline",
-						Namespace: "test-namespace",
+						Name:       "test-pipeline",
+						Namespace:  "test-namespace",
+						Finalizers: []string{api.PipelineFinalizer},
 					},
 					Spec: v2pb.PipelineSpec{
 						Commit: &v2pb.CommitInfo{
@@ -90,8 +95,9 @@ func TestReconcile(t *testing.T) {
 			initialObjects: []client.Object{
 				&v2pb.Pipeline{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-pipeline",
-						Namespace: "test-namespace",
+						Name:       "test-pipeline",
+						Namespace:  "test-namespace",
+						Finalizers: []string{api.PipelineFinalizer},
 					},
 					Spec: v2pb.PipelineSpec{
 						Commit: &v2pb.CommitInfo{
@@ -209,6 +215,126 @@ func TestFormatRevisionName(t *testing.T) {
 			require.Equal(t, tc.expectedResult, result)
 		})
 	}
+}
+
+func TestReconcile_AddsFinalizer(t *testing.T) {
+	pipeline := &v2pb.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pipeline",
+			Namespace: "test-namespace",
+		},
+		Spec: v2pb.PipelineSpec{
+			Commit: &v2pb.CommitInfo{GitRef: "abc123", Branch: "main"},
+		},
+	}
+	reconciler := setUpReconciler(t, []client.Object{pipeline}, env.Context{})
+
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-pipeline", Namespace: "test-namespace"},
+	})
+	require.NoError(t, err)
+
+	updated := &v2pb.Pipeline{}
+	require.NoError(t, reconciler.Get(context.Background(), "test-namespace", "test-pipeline", &metav1.GetOptions{}, updated))
+	require.True(t, controllerutil.ContainsFinalizer(updated, api.PipelineFinalizer))
+}
+
+func TestReconcile_RemovesFinalizerOnDelete(t *testing.T) {
+	now := metav1.Now()
+	pipeline := &v2pb.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-pipeline",
+			Namespace:         "test-namespace",
+			Finalizers:        []string{api.PipelineFinalizer},
+			DeletionTimestamp: &now,
+		},
+		Spec: v2pb.PipelineSpec{
+			Commit: &v2pb.CommitInfo{GitRef: "abc123", Branch: "main"},
+		},
+	}
+	reconciler := setUpReconciler(t, []client.Object{pipeline}, env.Context{})
+
+	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-pipeline", Namespace: "test-namespace"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, ctrl.Result{}, result)
+
+	// Verify finalizer was removed (object may or may not still exist depending on fake client behavior)
+	updated := &v2pb.Pipeline{}
+	err = reconciler.Get(context.Background(), "test-namespace", "test-pipeline", &metav1.GetOptions{}, updated)
+	if err == nil {
+		require.False(t, controllerutil.ContainsFinalizer(updated, api.PipelineFinalizer))
+	}
+}
+
+// updateErroringHandler wraps an api.Handler and returns a configured error
+// from Update. Used to exercise finalizer Update error branches.
+type updateErroringHandler struct {
+	api.Handler
+	updateErr error
+}
+
+func (u *updateErroringHandler) Update(ctx context.Context, obj client.Object, opts *metav1.UpdateOptions) error {
+	if u.updateErr != nil {
+		return u.updateErr
+	}
+	return u.Handler.Update(ctx, obj, opts)
+}
+
+func setUpReconcilerWithUpdateErr(t *testing.T, initialObjects []client.Object, updateErr error) *Reconciler {
+	scheme := runtime.NewScheme()
+	require.NoError(t, v2pb.AddToScheme(scheme))
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initialObjects...).WithStatusSubresource(initialObjects...).Build()
+	return &Reconciler{
+		Handler: &updateErroringHandler{Handler: apiHandler.NewFakeAPIHandler(k8sClient), updateErr: updateErr},
+		logger:  zaptest.NewLogger(t),
+	}
+}
+
+func TestReconcile_AddFinalizer_UpdateError(t *testing.T) {
+	pipeline := &v2pb.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pipeline",
+			Namespace: "test-namespace",
+		},
+		Spec: v2pb.PipelineSpec{
+			Commit: &v2pb.CommitInfo{GitRef: "abc123", Branch: "main"},
+		},
+	}
+	updateErr := errors.New("update boom")
+	reconciler := setUpReconcilerWithUpdateErr(t, []client.Object{pipeline}, updateErr)
+
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-pipeline", Namespace: "test-namespace"},
+	})
+	require.Error(t, err)
+	require.ErrorIs(t, err, updateErr)
+	require.Contains(t, err.Error(), "add pipeline finalizer")
+}
+
+func TestReconcile_RemoveFinalizer_UpdateError(t *testing.T) {
+	now := metav1.Now()
+	pipeline := &v2pb.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-pipeline",
+			Namespace:         "test-namespace",
+			Finalizers:        []string{api.PipelineFinalizer},
+			DeletionTimestamp: &now,
+		},
+		Spec: v2pb.PipelineSpec{
+			Commit: &v2pb.CommitInfo{GitRef: "abc123", Branch: "main"},
+		},
+	}
+	updateErr := errors.New("update boom")
+	reconciler := setUpReconcilerWithUpdateErr(t, []client.Object{pipeline}, updateErr)
+
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-pipeline", Namespace: "test-namespace"},
+	})
+	require.Error(t, err)
+	require.ErrorIs(t, err, updateErr)
+	require.Contains(t, err.Error(), "remove pipeline finalizer")
 }
 
 func setUpReconciler(t *testing.T, initialObjects []client.Object, env env.Context) *Reconciler {


### PR DESCRIPTION

**What type of PR is this? (check all applicable)**
- [x] Feature

**What changed?**
- Add `PipelineFinalizer = \"michelangelo/Pipeline\"` constant to `go/api/api.go`.
- Add finalizer-add logic in the Pipeline Reconciler (mirrors the deployment controller pattern).
- Add a placeholder deletion path that removes the finalizer (cascade logic is added in subsequent PRs in this stack).
- Update existing reconcile tests to include the finalizer on initial objects.
- Add `TestReconcile_AddsFinalizer` and `TestReconcile_RemovesFinalizerOnDelete`.

**Why?**
Addressing https://github.com/michelangelo-ai/michelangelo/issues/1091.
Cascade delete requires a finalizer so the controller can intercept deletion and clean up child resources before the Pipeline CR is garbage-collected.

**How did you test it?**
- `bazel test //go/components/pipeline/...` — all tests pass, including new finalizer tests.
- `bazel build //go/...` — no build errors.

- End-to-end behavior of the full cascade-delete stack is verified on a sandbox cluster; results are attached on #1114.

**Potential risks**
- Pipeline deletion becomes asynchronous: `ma pipeline delete` returns immediately but the CR stays in `Terminating` until the controller removes the finalizer. In this PR the removal is immediate (placeholder), so there's no functional regression. The full cascade path is introduced in later PRs in the stack.

**Release notes**
Foundation for cascade-delete behavior added in subsequent commits. Full user-visible impact and migration notes land with the PR that introduces `DeleteAll*` calls.

**Documentation Changes**
N/A (lands in `feat/cascade-delete-docs`).

---
Stacked on top of #1107.