### PR TITLE
feat: add cascade delete observability metrics

### DIFF
--- a/go/components/pipeline/BUILD.bazel
+++ b/go/components/pipeline/BUILD.bazel
@@ -43,6 +43,7 @@ go_test(
         "//go/components/triggerrun:go_default_library",
         "//proto/api:go_default_library",
         "//proto/api/v2:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus/testutil:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",

--- a/go/components/pipeline/controller.go
+++ b/go/components/pipeline/controller.go
@@ -35,6 +35,27 @@ import (
 const (
 	// reconcileInterval defines how frequently non-terminal pipelines are reconciled.
 	reconcileInterval = 10 * time.Second
+
+	// cascadeDeleteKillTimeout bounds how long we wait for child TRs/PRs to reach
+	// a terminal state after we've issued a kill. If a workflow engine is down or
+	// a child is otherwise stuck, we stop looping and proceed with forceful CR
+	// deletion so the Pipeline CR can leave the Terminating state.
+	cascadeDeleteKillTimeout = 30 * time.Minute
+
+	// cascadeDeleteStartedAtAnnotation records when handleDeletion first fired.
+	// Used to gate the "started" counter (B3, one increment per cascade) and to
+	// detect the kill-timeout condition (C1).
+	cascadeDeleteStartedAtAnnotation = "michelangelo/cascade-delete-started-at"
+
+	// Metric reason labels for pipelineCascadeDeleteError.
+	reasonListError   = "list_error"
+	reasonDeleteError = "delete_error"
+	reasonUpdateError = "update_error"
+	reasonKillTimeout = "kill_timeout"
+
+	// Kind labels for pipelineCascadeDeleteActiveChildren.
+	kindTriggerRun  = "trigger_run"
+	kindPipelineRun = "pipeline_run"
 )
 
 // Reconciler implements the controller-runtime Reconciler interface for Pipeline resources.
@@ -146,6 +167,26 @@ func (r *Reconciler) handleDeletion(ctx context.Context, pipeline *v2pb.Pipeline
 	}
 	logger.Info("Pipeline is being deleted, starting cascade delete")
 
+	// Stamp cascade-delete-started-at on the first pass and increment the
+	// "started" counter exactly once per cascade (B3). The annotation is
+	// persisted alongside the next Update so a controller restart mid-cascade
+	// preserves the original start time.
+	firstPass := !hasCascadeStartedAt(pipeline)
+	if firstPass {
+		setCascadeStartedAt(pipeline, time.Now())
+		if err := r.Update(ctx, pipeline, &metav1.UpdateOptions{}); err != nil {
+			logger.Error("Failed to stamp cascade-delete-started-at annotation",
+				zap.Error(err),
+				zap.String("operation", "stamp_cascade_started_at"),
+				zap.String("namespace", pipeline.Namespace),
+				zap.String("name", pipeline.Name))
+			IncCascadeDeleteError(pipeline.Namespace, pipeline.Name, reasonUpdateError)
+			return ctrl.Result{}, fmt.Errorf("stamp cascade-delete-started-at on pipeline %s/%s: %w", pipeline.Namespace, pipeline.Name, err)
+		}
+		IncCascadeDeleteStarted(pipeline.Namespace, pipeline.Name)
+	}
+	killTimedOut := !firstPass && time.Since(getCascadeStartedAt(pipeline)) > cascadeDeleteKillTimeout
+
 	triggerRuns, err := r.triggerRunManager.ListTriggerRunsForPipeline(ctx, pipeline.Namespace, pipeline.Name)
 	if err != nil {
 		logger.Error("Failed to list trigger runs for cascade delete",
@@ -153,6 +194,7 @@ func (r *Reconciler) handleDeletion(ctx context.Context, pipeline *v2pb.Pipeline
 			zap.String("operation", "list_trigger_runs"),
 			zap.String("namespace", pipeline.Namespace),
 			zap.String("name", pipeline.Name))
+		IncCascadeDeleteError(pipeline.Namespace, pipeline.Name, reasonListError)
 		return ctrl.Result{}, fmt.Errorf("list trigger runs for pipeline %s/%s: %w", pipeline.Namespace, pipeline.Name, err)
 	}
 
@@ -163,71 +205,90 @@ func (r *Reconciler) handleDeletion(ctx context.Context, pipeline *v2pb.Pipeline
 			zap.String("operation", "list_pipeline_runs"),
 			zap.String("namespace", pipeline.Namespace),
 			zap.String("name", pipeline.Name))
+		IncCascadeDeleteError(pipeline.Namespace, pipeline.Name, reasonListError)
 		return ctrl.Result{}, fmt.Errorf("list pipeline runs for pipeline %s/%s: %w", pipeline.Namespace, pipeline.Name, err)
 	}
 
 	if len(triggerRuns) == 0 && len(pipelineRuns) == 0 {
 		logger.Info("No children found, removing finalizer")
 		controllerutil.RemoveFinalizer(pipeline, api.PipelineFinalizer)
-		if updateErr := r.Update(ctx, pipeline, &metav1.UpdateOptions{}); updateErr != nil {
+		IncCascadeDeleteCompleted(pipeline.Namespace, pipeline.Name)
+		if err := r.Update(ctx, pipeline, &metav1.UpdateOptions{}); err != nil {
 			logger.Error("Failed to remove finalizer after cascade delete",
-				zap.Error(updateErr),
+				zap.Error(err),
 				zap.String("operation", "remove_finalizer"),
 				zap.String("namespace", pipeline.Namespace),
 				zap.String("name", pipeline.Name))
-			return ctrl.Result{}, fmt.Errorf("remove finalizer on pipeline %s/%s: %w", pipeline.Namespace, pipeline.Name, updateErr)
+			IncCascadeDeleteError(pipeline.Namespace, pipeline.Name, reasonUpdateError)
+			return ctrl.Result{}, fmt.Errorf("remove finalizer on pipeline %s/%s: %w", pipeline.Namespace, pipeline.Name, err)
 		}
 		return ctrl.Result{}, nil
 	}
 
-	// Kill active TriggerRuns (best-effort)
-	activeTRs, err := r.triggerRunManager.ListActiveTriggerRunsForPipeline(ctx, pipeline.Namespace, pipeline.Name)
-	if err != nil {
-		logger.Error("Failed to list active trigger runs for cascade delete",
-			zap.Error(err),
-			zap.String("operation", "list_active_trigger_runs"),
-			zap.String("namespace", pipeline.Namespace),
-			zap.String("name", pipeline.Name))
-		return ctrl.Result{}, fmt.Errorf("list active trigger runs for pipeline %s/%s: %w", pipeline.Namespace, pipeline.Name, err)
-	}
-	if len(activeTRs) > 0 {
-		for _, tr := range activeTRs {
-			if killErr := r.triggerRunManager.KillTriggerRun(ctx, tr); killErr != nil {
-				logger.Error("Failed to kill trigger run during cascade delete",
-					zap.Error(killErr),
-					zap.String("operation", "kill_trigger_run"),
-					zap.String("namespace", tr.Namespace),
-					zap.String("name", tr.Name))
-			}
+	// Kill active TriggerRuns (best-effort) unless we've already timed out waiting.
+	if !killTimedOut {
+		activeTRs, err := r.triggerRunManager.ListActiveTriggerRunsForPipeline(ctx, pipeline.Namespace, pipeline.Name)
+		if err != nil {
+			logger.Error("Failed to list active trigger runs for cascade delete",
+				zap.Error(err),
+				zap.String("operation", "list_active_trigger_runs"),
+				zap.String("namespace", pipeline.Namespace),
+				zap.String("name", pipeline.Name))
+			IncCascadeDeleteError(pipeline.Namespace, pipeline.Name, reasonListError)
+			return ctrl.Result{}, fmt.Errorf("list active trigger runs for pipeline %s/%s: %w", pipeline.Namespace, pipeline.Name, err)
 		}
-		return ctrl.Result{RequeueAfter: reconcileInterval}, nil
+		SetCascadeDeleteActiveChildren(pipeline.Namespace, pipeline.Name, kindTriggerRun, len(activeTRs))
+		if len(activeTRs) > 0 {
+			for _, tr := range activeTRs {
+				if killErr := r.triggerRunManager.KillTriggerRun(ctx, tr); killErr != nil {
+					logger.Error("Failed to kill trigger run during cascade delete",
+						zap.Error(killErr),
+						zap.String("operation", "kill_trigger_run"),
+						zap.String("namespace", tr.Namespace),
+						zap.String("name", tr.Name))
+				}
+			}
+			return ctrl.Result{RequeueAfter: reconcileInterval}, nil
+		}
+
+		// Kill active PipelineRuns (best-effort)
+		activePRs, err := r.pipelineRunManager.ListActivePipelineRunsForPipeline(ctx, pipeline.Namespace, pipeline.Name)
+		if err != nil {
+			logger.Error("Failed to list active pipeline runs for cascade delete",
+				zap.Error(err),
+				zap.String("operation", "list_active_pipeline_runs"),
+				zap.String("namespace", pipeline.Namespace),
+				zap.String("name", pipeline.Name))
+			IncCascadeDeleteError(pipeline.Namespace, pipeline.Name, reasonListError)
+			return ctrl.Result{}, fmt.Errorf("list active pipeline runs for pipeline %s/%s: %w", pipeline.Namespace, pipeline.Name, err)
+		}
+		SetCascadeDeleteActiveChildren(pipeline.Namespace, pipeline.Name, kindPipelineRun, len(activePRs))
+		if len(activePRs) > 0 {
+			for _, pr := range activePRs {
+				if killErr := r.pipelineRunManager.KillPipelineRun(ctx, pr); killErr != nil {
+					logger.Error("Failed to kill pipeline run during cascade delete",
+						zap.Error(killErr),
+						zap.String("operation", "kill_pipeline_run"),
+						zap.String("namespace", pr.Namespace),
+						zap.String("name", pr.Name))
+				}
+			}
+			return ctrl.Result{RequeueAfter: reconcileInterval}, nil
+		}
+	} else {
+		// Kill timed out. Emit a loud warning, record the metric, and proceed with
+		// forceful deletion so the Pipeline CR is not stuck in Terminating forever.
+		logger.Warn("cascade delete kill timed out, proceeding with forceful CR deletion",
+			zap.Duration("timeout", cascadeDeleteKillTimeout),
+			zap.Int("triggerRuns", len(triggerRuns)),
+			zap.Int("pipelineRuns", len(pipelineRuns)))
+		IncCascadeDeleteError(pipeline.Namespace, pipeline.Name, reasonKillTimeout)
 	}
 
-	// Kill active PipelineRuns (best-effort)
-	activePRs, err := r.pipelineRunManager.ListActivePipelineRunsForPipeline(ctx, pipeline.Namespace, pipeline.Name)
-	if err != nil {
-		logger.Error("Failed to list active pipeline runs for cascade delete",
-			zap.Error(err),
-			zap.String("operation", "list_active_pipeline_runs"),
-			zap.String("namespace", pipeline.Namespace),
-			zap.String("name", pipeline.Name))
-		return ctrl.Result{}, fmt.Errorf("list active pipeline runs for pipeline %s/%s: %w", pipeline.Namespace, pipeline.Name, err)
-	}
-	if len(activePRs) > 0 {
-		for _, pr := range activePRs {
-			if err := r.pipelineRunManager.KillPipelineRun(ctx, pr); err != nil {
-				logger.Error("Failed to kill pipeline run during cascade delete",
-					zap.Error(err),
-					zap.String("operation", "kill_pipeline_run"),
-					zap.String("namespace", pr.Namespace),
-					zap.String("name", pr.Name))
-			}
-		}
-		return ctrl.Result{RequeueAfter: reconcileInterval}, nil
-	}
+	SetCascadeDeleteActiveChildren(pipeline.Namespace, pipeline.Name, kindTriggerRun, 0)
+	SetCascadeDeleteActiveChildren(pipeline.Namespace, pipeline.Name, kindPipelineRun, 0)
 
-	// All children are terminal — delete them (fatal: error causes requeue)
-	logger.Info("All children terminal, deleting",
+	logger.Info("All children terminal (or kill timed out), deleting",
 		zap.Int("triggerRuns", len(triggerRuns)),
 		zap.Int("pipelineRuns", len(pipelineRuns)))
 
@@ -237,6 +298,7 @@ func (r *Reconciler) handleDeletion(ctx context.Context, pipeline *v2pb.Pipeline
 			zap.String("operation", "delete_all_trigger_runs"),
 			zap.String("namespace", pipeline.Namespace),
 			zap.String("name", pipeline.Name))
+		IncCascadeDeleteError(pipeline.Namespace, pipeline.Name, reasonDeleteError)
 		return ctrl.Result{}, fmt.Errorf("delete trigger runs for pipeline %s/%s: %w", pipeline.Namespace, pipeline.Name, err)
 	}
 	if err := r.pipelineRunManager.DeleteAllPipelineRuns(ctx, pipeline.Namespace, pipeline.Name); err != nil {
@@ -245,6 +307,7 @@ func (r *Reconciler) handleDeletion(ctx context.Context, pipeline *v2pb.Pipeline
 			zap.String("operation", "delete_all_pipeline_runs"),
 			zap.String("namespace", pipeline.Namespace),
 			zap.String("name", pipeline.Name))
+		IncCascadeDeleteError(pipeline.Namespace, pipeline.Name, reasonDeleteError)
 		return ctrl.Result{}, fmt.Errorf("delete pipeline runs for pipeline %s/%s: %w", pipeline.Namespace, pipeline.Name, err)
 	}
 
@@ -264,6 +327,7 @@ func (r *Reconciler) handleDeletion(ctx context.Context, pipeline *v2pb.Pipeline
 	}
 
 	logger.Info("All children deleted, removing finalizer")
+	IncCascadeDeleteCompleted(pipeline.Namespace, pipeline.Name)
 	controllerutil.RemoveFinalizer(pipeline, api.PipelineFinalizer)
 	if err := r.Update(ctx, pipeline, &metav1.UpdateOptions{}); err != nil {
 		logger.Error("Failed to remove finalizer after cascade delete",
@@ -271,9 +335,41 @@ func (r *Reconciler) handleDeletion(ctx context.Context, pipeline *v2pb.Pipeline
 			zap.String("operation", "remove_finalizer"),
 			zap.String("namespace", pipeline.Namespace),
 			zap.String("name", pipeline.Name))
+		IncCascadeDeleteError(pipeline.Namespace, pipeline.Name, reasonUpdateError)
 		return ctrl.Result{}, fmt.Errorf("remove finalizer on pipeline %s/%s: %w", pipeline.Namespace, pipeline.Name, err)
 	}
 	return ctrl.Result{}, nil
+}
+
+// hasCascadeStartedAt reports whether the cascade-delete-started-at annotation is set.
+func hasCascadeStartedAt(pipeline *v2pb.Pipeline) bool {
+	_, ok := pipeline.GetAnnotations()[cascadeDeleteStartedAtAnnotation]
+	return ok
+}
+
+// setCascadeStartedAt stamps the pipeline with the current time in RFC3339Nano.
+func setCascadeStartedAt(pipeline *v2pb.Pipeline, t time.Time) {
+	ann := pipeline.GetAnnotations()
+	if ann == nil {
+		ann = map[string]string{}
+	}
+	ann[cascadeDeleteStartedAtAnnotation] = t.UTC().Format(time.RFC3339Nano)
+	pipeline.SetAnnotations(ann)
+}
+
+// getCascadeStartedAt returns the parsed started-at timestamp, or the current
+// time if the annotation is missing or malformed (which effectively prevents a
+// false timeout on the first pass that writes it).
+func getCascadeStartedAt(pipeline *v2pb.Pipeline) time.Time {
+	v, ok := pipeline.GetAnnotations()[cascadeDeleteStartedAtAnnotation]
+	if !ok {
+		return time.Now()
+	}
+	t, err := time.Parse(time.RFC3339Nano, v)
+	if err != nil {
+		return time.Now()
+	}
+	return t
 }
 
 // formatRevisionName generates a standardized revision name for a pipeline.

--- a/go/components/pipeline/controller_test.go
+++ b/go/components/pipeline/controller_test.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/stretchr/testify/require"
@@ -283,10 +285,17 @@ type updateErroringHandler struct {
 	// the given type (e.g. "*v2pb.TriggerRunList"). This lets us assert the
 	// controller surfaces the exact failure path we expect.
 	listErrForType string
+	// updateErrAfterN, when > 0, allows that many Update calls to succeed
+	// before returning updateErr. Used to target the last Update in a
+	// multi-step path (e.g. the finalizer-remove at the bottom of
+	// handleDeletion which is preceded by an annotation stamp).
+	updateErrAfterN int
+	updateCalls     int
 }
 
 func (u *updateErroringHandler) Update(ctx context.Context, obj client.Object, opts *metav1.UpdateOptions) error {
-	if u.updateErr != nil {
+	u.updateCalls++
+	if u.updateErr != nil && u.updateCalls > u.updateErrAfterN {
 		return u.updateErr
 	}
 	return u.Handler.Update(ctx, obj, opts)
@@ -304,6 +313,10 @@ func setUpReconcilerWithUpdateErr(t *testing.T, initialObjects []client.Object, 
 }
 
 func setUpReconcilerWithErrors(t *testing.T, initialObjects []client.Object, updateErr, listErr error, listErrForType string) *Reconciler {
+	return setUpReconcilerWithErrorsAfterN(t, initialObjects, updateErr, listErr, listErrForType, 0)
+}
+
+func setUpReconcilerWithErrorsAfterN(t *testing.T, initialObjects []client.Object, updateErr, listErr error, listErrForType string, updateErrAfterN int) *Reconciler {
 	scheme := runtime.NewScheme()
 	require.NoError(t, v2pb.AddToScheme(scheme))
 	// Build the underlying fake client first; then wrap it with an interceptor
@@ -325,16 +338,18 @@ func setUpReconcilerWithErrors(t *testing.T, initialObjects []client.Object, upd
 		Build()
 	logger := zaptest.NewLogger(t)
 	handler := &updateErroringHandler{
-		Handler:        apiHandler.NewFakeAPIHandler(k8sClient),
-		updateErr:      updateErr,
-		listErr:        listErr,
-		listErrForType: listErrForType,
+		Handler:         apiHandler.NewFakeAPIHandler(k8sClient),
+		updateErr:       updateErr,
+		listErr:         listErr,
+		listErrForType:  listErrForType,
+		updateErrAfterN: updateErrAfterN,
 	}
 	return &Reconciler{
 		Handler:            handler,
 		logger:             logger,
 		triggerRunManager:  triggerrun.NewManager(managerClient, logger),
 		pipelineRunManager: pipelinerun.NewManager(managerClient, logger),
+		revisionManager:    revision.NewNoOpManager(),
 	}
 }
 
@@ -473,6 +488,10 @@ func TestCascadeDelete_ListPipelineRunsError(t *testing.T) {
 }
 
 func TestCascadeDelete_RemoveFinalizer_UpdateError(t *testing.T) {
+	// After PR #1113, handleDeletion issues an annotation-stamp Update before
+	// the final finalizer-remove Update. Configure the handler to let the
+	// stamp succeed and only fail the remove-finalizer Update so we still
+	// exercise the original error wrapping under test.
 	now := metav1.Now()
 	pipeline := &v2pb.Pipeline{
 		ObjectMeta: metav1.ObjectMeta{
@@ -486,7 +505,7 @@ func TestCascadeDelete_RemoveFinalizer_UpdateError(t *testing.T) {
 		},
 	}
 	updateErr := errors.New("update boom")
-	reconciler := setUpReconcilerWithErrors(t, []client.Object{pipeline}, updateErr, nil, "")
+	reconciler := setUpReconcilerWithErrorsAfterN(t, []client.Object{pipeline}, updateErr, nil, "", 1)
 
 	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "test-pipeline", Namespace: "test-namespace"},
@@ -1082,13 +1101,19 @@ func TestCascadeDelete_FinalUpdate_ErrorAfterDelete(t *testing.T) {
 		Status: v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_KILLED},
 	}
 	updateErr := errors.New("final update boom")
-	// updateErroringHandler fails all Updates; we rely on the children-exist
-	// path reaching the final r.Update at the bottom of handleDeletion.
+	// updateErroringHandler is configured to let the first Update (stamp
+	// cascade-delete-started-at annotation) succeed and only fail the final
+	// Update (remove finalizer) so the error wrapping we assert on is the
+	// canonical "remove finalizer on pipeline ..." one.
 	scheme := runtime.NewScheme()
 	require.NoError(t, v2pb.AddToScheme(scheme))
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pipeline, killedTR).WithStatusSubresource(pipeline, killedTR).Build()
 	logger := zaptest.NewLogger(t)
-	handler := &updateErroringHandler{Handler: apiHandler.NewFakeAPIHandler(k8sClient), updateErr: updateErr}
+	handler := &updateErroringHandler{
+		Handler:         apiHandler.NewFakeAPIHandler(k8sClient),
+		updateErr:       updateErr,
+		updateErrAfterN: 1, // succeed for the annotation stamp, fail on finalizer remove
+	}
 	reconciler := &Reconciler{
 		Handler:            handler,
 		logger:             logger,
@@ -1103,4 +1128,93 @@ func TestCascadeDelete_FinalUpdate_ErrorAfterDelete(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorIs(t, err, updateErr)
 	require.Contains(t, err.Error(), "remove finalizer on pipeline test-namespace/test-pipeline")
+}
+
+func TestCascadeDelete_KillTimeout(t *testing.T) {
+	// Seed a RUNNING TR. Fast-forward the started-at annotation past the timeout.
+	// Controller must stop killing, emit the kill_timeout metric, delete the CRs
+	// forcefully, and remove the finalizer so the Pipeline CR is not stuck in
+	// Terminating forever.
+	now := metav1.Now()
+	longAgo := time.Now().UTC().Add(-2 * cascadeDeleteKillTimeout).Format(time.RFC3339Nano)
+	pipeline := &v2pb.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-pipeline",
+			Namespace:         "test-namespace",
+			Finalizers:        []string{api.PipelineFinalizer},
+			DeletionTimestamp: &now,
+			Annotations: map[string]string{
+				cascadeDeleteStartedAtAnnotation: longAgo,
+			},
+		},
+		Spec: v2pb.PipelineSpec{
+			Commit: &v2pb.CommitInfo{GitRef: "abc123", Branch: "main"},
+		},
+	}
+	stuckTR := &v2pb.TriggerRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "tr-stuck", Namespace: "test-namespace"},
+		Spec: v2pb.TriggerRunSpec{
+			Pipeline: &apipb.ResourceIdentifier{Name: "test-pipeline", Namespace: "test-namespace"},
+		},
+		Status: v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING},
+	}
+	reconciler := setUpReconciler(t, []client.Object{pipeline, stuckTR}, env.Context{})
+
+	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-pipeline", Namespace: "test-namespace"},
+	})
+	require.NoError(t, err)
+	// Forceful delete path returns empty Result (no requeue) after removing the finalizer.
+	require.Equal(t, ctrl.Result{}, result)
+
+	// The stuck TR must have been force-deleted even though its workflow never terminated.
+	trList := &v2pb.TriggerRunList{}
+	require.NoError(t, reconciler.Handler.List(context.Background(), "test-namespace",
+		&metav1.ListOptions{}, nil, trList))
+	require.Empty(t, trList.Items)
+}
+
+func TestCascadeDelete_CounterIncrementsOncePerCascade(t *testing.T) {
+	// Regression for B3: the "started" counter must fire exactly once per cascade
+	// regardless of requeue count. We run two reconciles against a pipeline with
+	// an active TR. The first reconcile stamps the annotation + increments the
+	// counter; the second must NOT re-increment because the annotation is present.
+	now := metav1.Now()
+	pipeline := &v2pb.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-pipeline",
+			Namespace:         "test-namespace",
+			Finalizers:        []string{api.PipelineFinalizer},
+			DeletionTimestamp: &now,
+		},
+		Spec: v2pb.PipelineSpec{
+			Commit: &v2pb.CommitInfo{GitRef: "abc123", Branch: "main"},
+		},
+	}
+	runningTR := &v2pb.TriggerRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "tr-running", Namespace: "test-namespace"},
+		Spec: v2pb.TriggerRunSpec{
+			Pipeline: &apipb.ResourceIdentifier{Name: "test-pipeline", Namespace: "test-namespace"},
+		},
+		Status: v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING},
+	}
+	reconciler := setUpReconciler(t, []client.Object{pipeline, runningTR}, env.Context{})
+
+	before := testutil.ToFloat64(pipelineCascadeDeleteStarted.WithLabelValues("test-namespace", "test-pipeline"))
+
+	// First reconcile: stamp annotation, increment counter.
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-pipeline", Namespace: "test-namespace"},
+	})
+	require.NoError(t, err)
+	afterFirst := testutil.ToFloat64(pipelineCascadeDeleteStarted.WithLabelValues("test-namespace", "test-pipeline"))
+	require.Equal(t, before+1, afterFirst, "started counter must increment once on first pass")
+
+	// Second reconcile: annotation is present, counter must not increment again.
+	_, err = reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-pipeline", Namespace: "test-namespace"},
+	})
+	require.NoError(t, err)
+	afterSecond := testutil.ToFloat64(pipelineCascadeDeleteStarted.WithLabelValues("test-namespace", "test-pipeline"))
+	require.Equal(t, afterFirst, afterSecond, "started counter must NOT increment on subsequent reconciles")
 }

--- a/go/components/pipeline/metrics.go
+++ b/go/components/pipeline/metrics.go
@@ -32,6 +32,44 @@ var (
 		},
 		[]string{"namespace", "pipeline", "pipeline_type"},
 	)
+
+	// pipelineCascadeDeleteStarted tracks cascade delete initiations
+	pipelineCascadeDeleteStarted = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "pipeline_cascade_delete_started_total",
+			Help: "Total number of pipeline cascade deletes started (one per cascade, not per requeue)",
+		},
+		[]string{"namespace", "pipeline"},
+	)
+
+	// pipelineCascadeDeleteCompleted tracks successful cascade deletes
+	pipelineCascadeDeleteCompleted = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "pipeline_cascade_delete_completed_total",
+			Help: "Total number of pipeline cascade deletes completed",
+		},
+		[]string{"namespace", "pipeline"},
+	)
+
+	// pipelineCascadeDeleteError tracks cascade delete errors by reason
+	pipelineCascadeDeleteError = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "pipeline_cascade_delete_error_total",
+			Help: "Total number of pipeline cascade delete errors, tagged by reason (list_error, delete_error, update_error, kill_timeout)",
+		},
+		[]string{"namespace", "pipeline", "reason"},
+	)
+
+	// pipelineCascadeDeleteActiveChildren tracks active children during cascade delete.
+	// The `kind` label distinguishes between trigger_run and pipeline_run so dashboards
+	// can visualize each independently instead of a toggling single value.
+	pipelineCascadeDeleteActiveChildren = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "pipeline_cascade_delete_active_children",
+			Help: "Number of active children during pipeline cascade delete, broken down by kind",
+		},
+		[]string{"namespace", "pipeline", "kind"},
+	)
 )
 
 // RegisterPipelineMetrics registers all pipeline metrics with the controller-runtime metrics registry
@@ -40,6 +78,10 @@ func RegisterPipelineMetrics() {
 		pipelineReconcileErrors,
 		pipelineReconcileSuccess,
 		pipelineReady,
+		pipelineCascadeDeleteStarted,
+		pipelineCascadeDeleteCompleted,
+		pipelineCascadeDeleteError,
+		pipelineCascadeDeleteActiveChildren,
 	)
 }
 
@@ -58,4 +100,26 @@ func IncPipelineReconcileSuccess(namespace, pipeline string) {
 // IncPipelineReady increments the pipeline ready counter
 func IncPipelineReady(namespace, pipeline, pipelineType string) {
 	pipelineReady.WithLabelValues(namespace, pipeline, pipelineType).Inc()
+}
+
+// IncCascadeDeleteStarted increments the cascade delete started counter
+func IncCascadeDeleteStarted(namespace, pipeline string) {
+	pipelineCascadeDeleteStarted.WithLabelValues(namespace, pipeline).Inc()
+}
+
+// IncCascadeDeleteCompleted increments the cascade delete completed counter
+func IncCascadeDeleteCompleted(namespace, pipeline string) {
+	pipelineCascadeDeleteCompleted.WithLabelValues(namespace, pipeline).Inc()
+}
+
+// IncCascadeDeleteError increments the cascade delete error counter with a
+// reason label (list_error, delete_error, update_error, kill_timeout).
+func IncCascadeDeleteError(namespace, pipeline, reason string) {
+	pipelineCascadeDeleteError.WithLabelValues(namespace, pipeline, reason).Inc()
+}
+
+// SetCascadeDeleteActiveChildren sets the active children gauge for a specific
+// child kind (trigger_run or pipeline_run).
+func SetCascadeDeleteActiveChildren(namespace, pipeline, kind string, count int) {
+	pipelineCascadeDeleteActiveChildren.WithLabelValues(namespace, pipeline, kind).Set(float64(count))
 }

--- a/go/go.mod
+++ b/go/go.mod
@@ -85,6 +85,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/marusama/semaphore/v2 v2.5.0 // indirect
 	github.com/minio/crc64nvme v1.0.0 // indirect


### PR DESCRIPTION

**What type of PR is this? (check all applicable)**
- [x] Feature

**What changed?**
- Add four Prometheus instruments to `go/components/pipeline/metrics.go`:
  - `pipeline_cascade_delete_started_total{namespace, pipeline}`
  - `pipeline_cascade_delete_completed_total{namespace, pipeline}`
  - `pipeline_cascade_delete_error_total{namespace, pipeline, reason}` (reasons: `list_error`, `delete_error`, `update_error`, `kill_timeout`)
  - `pipeline_cascade_delete_active_children{namespace, pipeline, kind}` (kinds: `trigger_run`, `pipeline_run`)
- Emit metrics at each phase transition and error path in `handleDeletion`.
- Add `cascade-delete-started-at` annotation so the \"started\" counter fires exactly once per cascade (not once per requeue).
- Add `cascadeDeleteKillTimeout = 30m`. After the timeout, controller stops killing and forcefully deletes child CRs with `reason=\"kill_timeout\"` on the error counter, so the Pipeline CR never stays stuck in `Terminating` forever.
- Add `TestCascadeDelete_KillTimeout` and `TestCascadeDelete_CounterIncrementsOncePerCascade`.

**Why?**
Addressing https://github.com/michelangelo-ai/michelangelo/issues/1091.
- Observability for cascade-delete operations in dashboards / SLOs.
- Bound the controller's worst-case behavior when child workflows can't reach terminal state.

**How did you test it?**
- `bazel test //go/components/pipeline/...` — all tests pass.
- `bazel build //go/...` — no build errors.

- End-to-end behavior of the full cascade-delete stack is verified on a sandbox cluster; results are attached on #1114.

**Potential risks**
- New metric series. Cardinality is `namespace × pipeline × (reason|kind)`. For typical deployments this is bounded; for operators managing thousands of pipelines the gauge may grow. Uses the same pattern as `go/components/pipelinerun/metrics.go`.
- Forceful delete after 30 minutes: a TR/PR CR may be removed while its underlying workflow is still running. This is intentional — the alternative is holding the pipeline CR in `Terminating` indefinitely. Operators can investigate stuck workflows via logs and the `kill_timeout` metric.

**Release notes**
New metrics emitted under the `pipeline_cascade_delete_*` prefix. No user-facing behavior change beyond the 30-minute kill timeout fallback.

**Documentation Changes**
N/A.

---
Stacked on top of #1112.