### PR TITLE
docs: document pipeline cascade delete behavior

### DIFF
--- a/docs/user-guides/ml-pipelines/pipeline-management.md
+++ b/docs/user-guides/ml-pipelines/pipeline-management.md
@@ -278,3 +278,31 @@ ma pipeline run -n <namespace> --revision <pipeline_revision_name>
 ```bash
 ma pipeline run -n my-project --revision pipeline-simple-custom-train-511e3b3be42f
 ```
+
+## Pipeline deletion
+
+Deleting a pipeline cascades to all of its child resources. The Michelangelo controller will:
+
+1. Kill any active `TriggerRun` resources for the pipeline (`Spec.Action = KILL`).
+2. Kill any active `PipelineRun` resources for the pipeline (`Spec.Kill = true`).
+3. Wait for those children to reach a terminal state (`SUCCEEDED`, `FAILED`, `KILLED`, or `SKIPPED`).
+4. Delete every `TriggerRun`, `PipelineRun`, and `Revision` belonging to the pipeline.
+5. Remove the pipeline finalizer so Kubernetes can finally delete the pipeline CR.
+
+Delete a pipeline:
+
+```bash
+ma pipeline delete --namespace=<namespace> --name=<pipeline_name>
+```
+
+:::warning
+Pipeline deletion is **destructive** and **cascades to all child resources**. All `TriggerRun`s, `PipelineRun`s, and `Revision`s belonging to the pipeline will be deleted. There is no undo.
+:::
+
+:::note
+Deletion is **asynchronous**. The `ma pipeline delete` command returns immediately, but the pipeline CR remains in `Terminating` state until the controller finishes the cascade. For pipelines with many children, this may take several minutes. If a child workflow is stuck and cannot be killed, the controller gives up after 30 minutes and forcefully deletes the child CRs anyway, so the pipeline CR will not stay in `Terminating` indefinitely.
+:::
+
+:::tip
+If you only want to remove the pipeline definition but keep its history (TriggerRuns, PipelineRuns, Revisions) for audit, this cascade behavior is not currently configurable. File a feature request if you need that mode.
+:::


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Documentation Update

**What changed?**
- Add a "Pipeline deletion" section to `docs/user-guides/ml-pipelines/pipeline-management.md`.
- Describe the cascade-delete flow (kill → wait → delete → finalizer removal), the asynchronous nature of deletion, and the 30-minute kill-timeout fallback.
- Admonitions: `:::warning` for destructive cascade, `:::note` for async behavior, `:::tip` for "keep history" feature-request placeholder.

**Why?**
Addressing https://github.com/michelangelo-ai/michelangelo/issues/1091.
Pipeline deletion is now destructive and cascades to child TRs/PRs/Revisions. Users need to understand the new behavior before invoking `ma pipeline delete`.

**How did you test it?**

- `cd website && bun run build` — local docs build passes.
- End-to-end on a k3d sandbox cluster (`ma sandbox sync` with #1104–#1113 deployed) against namespace `ma-dev-test`. Each scenario applied the relevant CRDs, deleted the parent pipeline with `kubectl delete pipeline ...`, and verified final state with `kubectl get pipeline,triggerruns,pipelineruns -n ma-dev-test`:

  1. **Finalizer is attached on create.** `kubectl apply -f training-pipeline.yaml` results in a pipeline whose `.metadata.finalizers` contains `michelangelo/Pipeline` and `.status.state == PIPELINE_STATE_READY`. Confirms the controller wires the cascade-delete finalizer at admission time (#1108).

  2. **Delete with no children — fast path.** `kubectl delete pipeline training-pipeline` returns in <1s and `kubectl get pipeline` reports `NotFound`. The cascade controller short-circuits when the child list is empty and removes the finalizer immediately (#1112).

  3. **Delete with an active TriggerRun — cascade kill.** With `training-pipeline-backfill-trigger` running, `kubectl delete pipeline` patches the TR to `Spec.Kill=true` / `Spec.Action=TRIGGER_RUN_ACTION_KILL`. The TR then transitions to terminal and is deleted, after which the pipeline finalizer drains. End state: `kubectl get pipeline,triggerruns -n ma-dev-test` returns no resources. Confirms the kill-and-wait flow added in #1110.

  4. **Delete with a terminal PipelineRun — cascade cleanup.** With `run-training-pipeline` in `PIPELINE_RUN_STATE_FAILED`, `kubectl delete pipeline` cascade-deletes the PR within ~2s; namespace reports `No resources found`. Confirms terminal-PR cleanup path (#1111 + #1112).

  5. **Both children present — full cascade.** With one active TR and one terminal PR, `kubectl delete pipeline` kills the TR, deletes the PR, and removes the pipeline finalizer in a single cascade. End state is again an empty namespace. Exercises the combined branches of the cascade controller end-to-end.

- **Metrics observability** verified by scraping `michelangelo-controllermgr:8091/metrics`: all four cascade-delete series (`pipeline_cascade_delete_started_total`, `_completed_total`, `_active_children`, `_error_total`) appear with correct labels and HELP/TYPE lines (#1113).

**Potential risks**
None (documentation only).

**Release notes**
N/A.

**Documentation Changes**
This PR is the documentation change for the cascade-delete feature introduced in the preceding PRs in this stack (#1104 – #1113).

---
Stacked on top of #1113. Final PR in the cascade-delete stack.