### PR TITLE
fix: use k8s Secret for MinIO credentials to survive sandbox sync

### DIFF
--- a/.github/scripts/integration-test.sh
+++ b/.github/scripts/integration-test.sh
@@ -18,8 +18,11 @@ set -euo pipefail
 
 NAMESPACE="${MA_NAMESPACE:-ma-dev-test}"
 MINIO_ENDPOINT="${MINIO_ENDPOINT:-http://localhost:9091}"
-MINIO_ACCESS_KEY="${MINIO_ACCESS_KEY:-minioadmin}"
-MINIO_SECRET_KEY="${MINIO_SECRET_KEY:-minioadmin}"
+# Read credentials from the minio-credentials k8s Secret so the script
+# automatically picks up whatever the sandbox VM is configured with.
+# Falls back to minioadmin for local dev where the Secret has defaults.
+MINIO_ACCESS_KEY="${MINIO_ACCESS_KEY:-$(kubectl get secret minio-credentials -o jsonpath='{.data.AWS_ACCESS_KEY_ID}' 2>/dev/null | base64 -d || echo minioadmin)}"
+MINIO_SECRET_KEY="${MINIO_SECRET_KEY:-$(kubectl get secret minio-credentials -o jsonpath='{.data.AWS_SECRET_ACCESS_KEY}' 2>/dev/null | base64 -d || echo minioadmin)}"
 POLL_INTERVAL="${POLL_INTERVAL:-30}"
 TIMEOUT="${TIMEOUT:-1800}"
 

--- a/python/michelangelo/cli/sandbox/resources/michelangelo-controllermgr.yaml
+++ b/python/michelangelo/cli/sandbox/resources/michelangelo-controllermgr.yaml
@@ -10,6 +10,9 @@ spec:
     - name: app
       image: ghcr.io/michelangelo-ai/controllermgr:main
       imagePullPolicy: IfNotPresent
+      envFrom:
+        - secretRef:
+            name: minio-credentials
       volumeMounts:
         - name: config-volume
           mountPath: /config
@@ -56,10 +59,9 @@ data:
 
     minio:
       awsRegion: us-east-1
-      awsAccessKeyId: minioadmin
-      awsSecretAccessKey: minioadmin
+      awsAccessKeyId: ${AWS_ACCESS_KEY_ID::minioadmin}
+      awsSecretAccessKey: ${AWS_SECRET_ACCESS_KEY::minioadmin}
       awsEndpointUrl: minio:9091
-      secure: false
 
     # Reuse the Cadence MySQL service for ingester metadata storage in sandbox.
     metadataStorage:

--- a/python/michelangelo/cli/sandbox/resources/michelangelo-temporal-controllermgr.yaml
+++ b/python/michelangelo/cli/sandbox/resources/michelangelo-temporal-controllermgr.yaml
@@ -9,6 +9,9 @@ spec:
   containers:
     - name: app
       image: ghcr.io/michelangelo-ai/controllermgr:main
+      envFrom:
+        - secretRef:
+            name: minio-credentials
       volumeMounts:
         - name: config-volume
           mountPath: /config
@@ -55,10 +58,9 @@ data:
 
     minio:
       awsRegion: us-east-1
-      awsAccessKeyId: minioadmin
-      awsSecretAccessKey: minioadmin
+      awsAccessKeyId: ${AWS_ACCESS_KEY_ID::minioadmin}
+      awsSecretAccessKey: ${AWS_SECRET_ACCESS_KEY::minioadmin}
       awsEndpointUrl: minio:9091
-      secure: false
     
     workflowClient:
       service: temporal-frontend

--- a/python/michelangelo/cli/sandbox/resources/michelangelo-temporal-worker.yaml
+++ b/python/michelangelo/cli/sandbox/resources/michelangelo-temporal-worker.yaml
@@ -9,6 +9,9 @@ spec:
   containers:
     - name: app
       image: ghcr.io/michelangelo-ai/worker:main
+      envFrom:
+        - secretRef:
+            name: minio-credentials
       volumeMounts:
         - name: worker-config-volume
           mountPath: /config
@@ -52,7 +55,7 @@ data:
 
     minio:
       awsRegion: us-east-1
-      awsAccessKeyId: minioadmin
-      awsSecretAccessKey: minioadmin
+      awsAccessKeyId: ${AWS_ACCESS_KEY_ID::minioadmin}
+      awsSecretAccessKey: ${AWS_SECRET_ACCESS_KEY::minioadmin}
       awsEndpointUrl: minio:9091
       secure: false

--- a/python/michelangelo/cli/sandbox/resources/michelangelo-worker.yaml
+++ b/python/michelangelo/cli/sandbox/resources/michelangelo-worker.yaml
@@ -9,6 +9,9 @@ spec:
   containers:
     - name: app
       image: ghcr.io/michelangelo-ai/worker:main
+      envFrom:
+        - secretRef:
+            name: minio-credentials
       volumeMounts:
         - name: worker-config-volume
           mountPath: /config
@@ -56,7 +59,6 @@ data:
 
     minio:
       awsRegion: us-east-1
-      awsAccessKeyId: minioadmin
-      awsSecretAccessKey: minioadmin
+      awsAccessKeyId: ${AWS_ACCESS_KEY_ID::minioadmin}
+      awsSecretAccessKey: ${AWS_SECRET_ACCESS_KEY::minioadmin}
       awsEndpointUrl: minio:9091
-      secure: false

--- a/python/michelangelo/cli/sandbox/resources/minio-credentials.yaml
+++ b/python/michelangelo/cli/sandbox/resources/minio-credentials.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-credentials
+  namespace: default
+type: Opaque
+stringData:
+  AWS_ACCESS_KEY_ID: minioadmin
+  AWS_SECRET_ACCESS_KEY: minioadmin

--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -1142,7 +1142,8 @@ def _ensure_credentials_secret():
             print(f"Creating {secret_name} Secret from defaults...")
             _kube_apply(_dir / "resources" / yaml_file)
         else:
-            print(f"Secret '{secret_name}' already exists — skipping (preserving VM credentials).")
+            print(f"Secret '{secret_name}' already exists — "
+                  f"skipping (preserving VM credentials).")
 
 
 def _sync_config_from_secret():
@@ -1167,7 +1168,8 @@ def _sync_config_from_secret():
         text=True,
     )
     if result.returncode != 0:
-        return  # Secret doesn't exist yet; will be created by _ensure_credentials_secret
+        # Secret will be created by _ensure_credentials_secret
+        return
 
     import base64
 

--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -318,11 +318,10 @@ def _sync(ns: argparse.Namespace):
             check=False,
             capture_output=True,
         )
-    subprocess.run(
-        ["kubectl", "delete", "secret", "aws-credentials", "--ignore-not-found=true"],
-        check=False,
-        capture_output=True,
-    )
+    # minio-credentials Secret is intentionally NOT deleted here — it is
+    # managed by _ensure_credentials_secret() which creates it only when it
+    # does not already exist. This lets the GCP sandbox VM pre-configure its
+    # own credentials without sync overwriting them each run.
 
     print("Waiting for old app pods to fully terminate...")
     subprocess.run(
@@ -343,7 +342,6 @@ def _deploy_app_services(ns: argparse.Namespace):
     assert ns
     app_resources = [
         "michelangelo-config.yaml",
-        "aws-credentials.yaml",
     ]
     if "apiserver" not in ns.exclude:
         app_resources.append("michelangelo-apiserver.yaml")
@@ -353,6 +351,15 @@ def _deploy_app_services(ns: argparse.Namespace):
 
     for r in app_resources:
         _kube_apply(_dir / "resources" / r)
+
+    # Create credentials secrets only if they don't already exist, so a
+    # pre-configured sandbox VM keeps its own credentials across CI runs.
+    _ensure_credentials_secret()
+
+    # Patch michelangelo-config ConfigMap to match the live secret, so
+    # Ray pods (which consume the ConfigMap via envFrom) also get the
+    # correct credentials.
+    _sync_config_from_secret()
 
     if ns.workflow == "cadence":
         # Domain registration is a one-time setup done by _create.
@@ -385,7 +392,6 @@ def _deploy_services(ns: argparse.Namespace):
         "mysql.yaml",  # MySQL database
         "mysql-ingester.yaml",  # Auto-generated ingester schema from protobuf
         "michelangelo-config.yaml",
-        "aws-credentials.yaml",
     ]
     links = []
 
@@ -481,6 +487,11 @@ def _deploy_services(ns: argparse.Namespace):
     _create_bucket_setup(bucket_names)
     for r in resources:
         _kube_apply(_dir / "resources" / r)
+
+    # Create credentials secrets only if they don't already exist.
+    _ensure_credentials_secret()
+    # Patch michelangelo-config to match the live secret values.
+    _sync_config_from_secret()
 
     _assert_command(
         "helm", "Helm not found, please install it: https://helm.sh/docs/intro/install/"
@@ -1106,6 +1117,78 @@ def _stop(ns: argparse.Namespace):
 
 def _kube_create(path: Path):
     _exec("kubectl", "create", "-f", str(path))
+
+
+def _ensure_credentials_secret():
+    """Create minio-credentials and aws-credentials Secrets only if absent.
+
+    This is deliberately create-only: a sandbox VM that was pre-configured
+    with non-default credentials (e.g. the GCP CI runner) keeps its own
+    values across every ``ma sandbox sync`` run.  Local dev gets the
+    default minioadmin credentials from the YAML files on first create.
+    """
+    for secret_name, yaml_file in [
+        ("minio-credentials", "minio-credentials.yaml"),
+        ("aws-credentials", "aws-credentials.yaml"),
+    ]:
+        exists = (
+            subprocess.run(
+                ["kubectl", "get", "secret", secret_name],
+                capture_output=True,
+            ).returncode
+            == 0
+        )
+        if not exists:
+            print(f"Creating {secret_name} Secret from defaults...")
+            _kube_apply(_dir / "resources" / yaml_file)
+        else:
+            print(f"Secret '{secret_name}' already exists — skipping (preserving VM credentials).")
+
+
+def _sync_config_from_secret():
+    """Patch michelangelo-config ConfigMap credentials from minio-credentials Secret.
+
+    Ray pods consume the michelangelo-config ConfigMap via envFrom. After the
+    ConfigMap is (re)applied from the YAML file (which contains minioadmin
+    defaults), this function overwrites the credential fields with whatever
+    is actually in the minio-credentials Secret, so all consumers see the
+    same credentials.
+    """
+    result = subprocess.run(
+        [
+            "kubectl",
+            "get",
+            "secret",
+            "minio-credentials",
+            "-o",
+            "jsonpath={.data.AWS_ACCESS_KEY_ID} {.data.AWS_SECRET_ACCESS_KEY}",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return  # Secret doesn't exist yet; will be created by _ensure_credentials_secret
+
+    import base64
+
+    parts = result.stdout.strip().split()
+    if len(parts) != 2:
+        return
+    access_key = base64.b64decode(parts[0]).decode()
+    secret_key = base64.b64decode(parts[1]).decode()
+
+    subprocess.run(
+        [
+            "kubectl",
+            "patch",
+            "configmap",
+            "michelangelo-config",
+            "--patch",
+            f'{{"data":{{"AWS_ACCESS_KEY_ID":"{access_key}","AWS_SECRET_ACCESS_KEY":"{secret_key}"}}}}',
+        ],
+        check=False,
+        capture_output=True,
+    )
 
 
 def _kube_apply(path: Path):

--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -1142,8 +1142,10 @@ def _ensure_credentials_secret():
             print(f"Creating {secret_name} Secret from defaults...")
             _kube_apply(_dir / "resources" / yaml_file)
         else:
-            print(f"Secret '{secret_name}' already exists — "
-                  f"skipping (preserving VM credentials).")
+            print(
+                f"Secret '{secret_name}' already exists — "
+                f"skipping (preserving VM credentials)."
+            )
 
 
 def _sync_config_from_secret():


### PR DESCRIPTION
## Summary

- **Root cause of CI failure**: `ma sandbox sync` deleted and re-applied the `aws-credentials` Secret every run, and always applied `michelangelo-config.yaml` with hardcoded `minioadmin` values — wiping any manual credential updates on the GCP VM.
- **New `minio-credentials` k8s Secret** (`minioadmin` defaults in git) stores credentials as env vars (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`).
- **`sandbox sync` is now create-only** for both credential secrets: if a secret already exists on the VM, it is left untouched. The GCP CI runner pre-creates this secret with real credentials once; they survive across all subsequent CI runs.
- **`michelangelo-config` ConfigMap is patched at sync time** from the live secret, so Ray pods (which consume the ConfigMap via `envFrom`) also see the correct credentials.
- **Worker/controllermgr** gain `envFrom: secretRef: minio-credentials` and use `${AWS_ACCESS_KEY_ID::minioadmin}` substitution in `base.yaml`, removing the hardcoded value.
- **`integration-test.sh`** reads `MINIO_ACCESS_KEY`/`MINIO_SECRET_KEY` from the k8s Secret at runtime — no credentials in the script or workflow YAML.

## Test plan

- [ ] Verify local dev: `ma sandbox create` creates both secrets with `minioadmin` defaults, worker/controllermgr start correctly
- [ ] Verify GCP VM: pre-create `minio-credentials` secret with `ma-minio`; run `ma sandbox sync`; confirm secret is NOT overwritten and ConfigMap is patched to `ma-minio`
- [ ] Confirm integration test CI run passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)