### PR TITLE
fix(mysql): fall back to scheme for empty GVK in getTableName

### DIFF
--- a/go/storage/mysql/BUILD.bazel
+++ b/go/storage/mysql/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -13,5 +13,17 @@ go_library(
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime/schema:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["mysql_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//proto/api/v2:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime:go_default_library",
     ],
 )

--- a/go/storage/mysql/mysql.go
+++ b/go/storage/mysql/mysql.go
@@ -87,7 +87,7 @@ func (m *mysqlMetadataStorage) Upsert(ctx context.Context, object runtime.Object
 		return err
 	}
 
-	tableName := getTableName(object)
+	tableName := m.getTableName(object)
 	if tableName == "" {
 		return fmt.Errorf("unable to determine table name for object type")
 	}
@@ -148,7 +148,7 @@ func (m *mysqlMetadataStorage) Upsert(ctx context.Context, object runtime.Object
 
 // GetByName retrieves an object by its namespace and name
 func (m *mysqlMetadataStorage) GetByName(ctx context.Context, namespace string, name string, object runtime.Object) error {
-	tableName := getTableName(object)
+	tableName := m.getTableName(object)
 	if tableName == "" {
 		return fmt.Errorf("unable to determine table name for object type")
 	}
@@ -183,7 +183,7 @@ func (m *mysqlMetadataStorage) GetByName(ctx context.Context, namespace string, 
 
 // GetByID retrieves an object by its UID
 func (m *mysqlMetadataStorage) GetByID(ctx context.Context, uid string, object runtime.Object) error {
-	tableName := getTableName(object)
+	tableName := m.getTableName(object)
 	if tableName == "" {
 		return fmt.Errorf("unable to determine table name for object type")
 	}
@@ -438,8 +438,17 @@ func getObjectMeta(object runtime.Object) (metav1.Object, error) {
 	return metaObj, nil
 }
 
-func getTableName(object runtime.Object) string {
+// getTableName returns the lowercased Kind for the object's table. When the
+// object's TypeMeta is empty (a known controller-runtime quirk —
+// https://github.com/kubernetes-sigs/controller-runtime/issues/1517), it falls
+// back to scheme.ObjectKinds, mirroring the pattern in groupVersionForObject.
+func (m *mysqlMetadataStorage) getTableName(object runtime.Object) string {
 	gvk := object.GetObjectKind().GroupVersionKind()
+	if gvk.Kind == "" && m.scheme != nil {
+		if gvks, _, err := m.scheme.ObjectKinds(object); err == nil && len(gvks) > 0 {
+			gvk = gvks[0]
+		}
+	}
 	return strings.ToLower(gvk.Kind)
 }
 

--- a/go/storage/mysql/mysql_test.go
+++ b/go/storage/mysql/mysql_test.go
@@ -1,0 +1,48 @@
+package mysql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	v2pb "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
+)
+
+func newSchemeWithV2(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, v2pb.AddToScheme(s))
+	return s
+}
+
+func TestGetTableName_GVKPopulated(t *testing.T) {
+	m := &mysqlMetadataStorage{scheme: newSchemeWithV2(t)}
+	obj := &v2pb.TriggerRun{
+		TypeMeta: metav1.TypeMeta{Kind: "TriggerRun", APIVersion: "michelangelo.api/v2"},
+	}
+	require.Equal(t, "triggerrun", m.getTableName(obj))
+}
+
+func TestGetTableName_GVKEmpty_SchemeFallback(t *testing.T) {
+	// controller-runtime returns objects with empty TypeMeta (issue #1517);
+	// the scheme fallback must resolve the Kind from the registered type.
+	m := &mysqlMetadataStorage{scheme: newSchemeWithV2(t)}
+	obj := &v2pb.TriggerRun{}
+	require.Equal(t, "triggerrun", m.getTableName(obj))
+}
+
+func TestGetTableName_GVKEmpty_NilScheme(t *testing.T) {
+	// No scheme configured + empty GVK = "" (caller decides). Must not panic.
+	m := &mysqlMetadataStorage{scheme: nil}
+	obj := &v2pb.TriggerRun{}
+	require.Equal(t, "", m.getTableName(obj))
+}
+
+func TestGetTableName_GVKEmpty_UnknownToScheme(t *testing.T) {
+	// Scheme exists but doesn't know this type → falls through to "".
+	m := &mysqlMetadataStorage{scheme: runtime.NewScheme()}
+	obj := &v2pb.TriggerRun{}
+	require.Equal(t, "", m.getTableName(obj))
+}


### PR DESCRIPTION

## What
Convert `getTableName` to a method on `*mysqlMetadataStorage` so it can fall back to `scheme.ObjectKinds()` when the object's TypeMeta has no Kind populated. Adds 4 unit tests.

## Why
Controller-runtime returns objects with empty `TypeMeta` (see [kubernetes-sigs/controller-runtime#1517](https://github.com/kubernetes-sigs/controller-runtime/issues/1517)). Without this fallback, every TR/PR/Pipeline reconcile that hits the metadata-storage path errors with `unable to determine table name for object type`. This blocks any environment with `enableMetadataStorage: true` (e.g. the OSS sandbox) and is a prerequisite for the cascade-delete PR stack (#1104–#1114).

The same scheme-fallback pattern already exists in `groupVersionForObject` further down in the same file — this fix mirrors it.

## How to test
\`\`\`bash
./tools/bazel test //go/storage/mysql:go_default_test
\`\`\`
4 unit tests cover: GVK populated, empty GVK with scheme fallback, nil scheme, unknown-to-scheme.

End-to-end verified against a sandbox cluster running the full cascade-delete stack: prior to this fix the TR controller error-loops with the table-name error; with it, reconciles complete normally. Full cascade-delete e2e results are attached on #1114.

## Breaking changes
None. `getTableName` is package-private; the receiver-conversion is a pure refactor.