### PR TITLE
fix: always return activityID from worker activities for retry targeting

### DIFF
--- a/go/worker/activities/ray/ray_activities.go
+++ b/go/worker/activities/ray/ray_activities.go
@@ -47,6 +47,12 @@ type CreateRayClusterActivityResponse struct {
 	ActivityID string `json:"activity_id"` // The actual activity ID from workflow engine
 }
 
+// CreateRayJobActivityResponse includes the activity ID for progress reporting
+type CreateRayJobActivityResponse struct {
+	RayJob     *v2pb.RayJob
+	ActivityID string `json:"activity_id"`
+}
+
 // CreateRayJob creates a new Ray job using the provided request parameters and returns activity ID.
 //
 // This method is executed as part of a Starlark worker activity.
@@ -57,9 +63,9 @@ type CreateRayClusterActivityResponse struct {
 //
 // Returns:
 // - *CreateRayJobActivityResponse: Response containing the created Ray job details and activity ID.
-// - *workflow.CustomError: Error information if the operation fails.
+// - error: nil on both success and logical failure so that the activity ID is always returned.
 func (r *activities) CreateRayJob(ctx context.Context, request v2pb.CreateRayJobRequest) (
-	*v2pb.CreateRayJobResponse, error) {
+	*CreateRayJobActivityResponse, error) {
 	logger := log.FromContext(ctx)
 	logger.Info("activity-start", zap.Any("request", request))
 
@@ -70,13 +76,20 @@ func (r *activities) CreateRayJob(ctx context.Context, request v2pb.CreateRayJob
 
 	// Execute the original job creation logic
 	createRayJobResponse, err := r.rayJobService.CreateRayJob(ctx, &request)
-	if err != nil || createRayJobResponse == nil || createRayJobResponse.RayJob == nil ||
+	if err != nil {
+		logger.Error(err, "activity-error: failed to create ray job")
+		return &CreateRayJobActivityResponse{ActivityID: activityID}, nil
+	}
+	if createRayJobResponse == nil || createRayJobResponse.RayJob == nil ||
 		createRayJobResponse.RayJob.Name == "" {
-		logger.Error(err, "activity-error")
-		return nil, workflow.NewCustomError(ctx, yarpcerrors.CodeUnavailable.String(), err.Error())
+		logger.Error(errors.New("empty or invalid response"), "activity-error: failed to create ray job")
+		return &CreateRayJobActivityResponse{ActivityID: activityID}, nil
 	}
 
-	return createRayJobResponse, nil
+	return &CreateRayJobActivityResponse{
+		RayJob:     createRayJobResponse.RayJob,
+		ActivityID: activityID,
+	}, nil
 }
 
 // CreateRayCluster creates a new Ray cluster and returns it with activity ID for retry tracking.
@@ -102,9 +115,14 @@ func (r *activities) CreateRayCluster(ctx context.Context, request v2pb.CreateRa
 
 	// Execute the original cluster creation logic
 	createRayClusterResponse, err := r.rayClusterService.CreateRayCluster(ctx, &request)
-	if err != nil || createRayClusterResponse == nil || createRayClusterResponse.RayCluster == nil ||
+	if err != nil {
+		logger.Error("activity-error: failed to create ray cluster", zap.Error(err))
+		return &CreateRayClusterActivityResponse{ActivityID: activityID}, nil
+	}
+	if createRayClusterResponse == nil || createRayClusterResponse.RayCluster == nil ||
 		createRayClusterResponse.RayCluster.Name == "" {
-		return nil, workflow.NewCustomError(ctx, yarpcerrors.CodeUnavailable.String(), err.Error())
+		logger.Error("activity-error: empty or invalid response from CreateRayCluster")
+		return &CreateRayClusterActivityResponse{ActivityID: activityID}, nil
 	}
 
 	return &CreateRayClusterActivityResponse{

--- a/go/worker/activities/ray/ray_activities.go
+++ b/go/worker/activities/ray/ray_activities.go
@@ -47,12 +47,6 @@ type CreateRayClusterActivityResponse struct {
 	ActivityID string `json:"activity_id"` // The actual activity ID from workflow engine
 }
 
-// CreateRayJobActivityResponse includes the activity ID for progress reporting
-type CreateRayJobActivityResponse struct {
-	RayJob     *v2pb.RayJob
-	ActivityID string `json:"activity_id"`
-}
-
 // CreateRayJob creates a new Ray job using the provided request parameters and returns activity ID.
 //
 // This method is executed as part of a Starlark worker activity.
@@ -63,9 +57,9 @@ type CreateRayJobActivityResponse struct {
 //
 // Returns:
 // - *CreateRayJobActivityResponse: Response containing the created Ray job details and activity ID.
-// - error: nil on both success and logical failure so that the activity ID is always returned.
+// - *workflow.CustomError: Error information if the operation fails.
 func (r *activities) CreateRayJob(ctx context.Context, request v2pb.CreateRayJobRequest) (
-	*CreateRayJobActivityResponse, error) {
+	*v2pb.CreateRayJobResponse, error) {
 	logger := log.FromContext(ctx)
 	logger.Info("activity-start", zap.Any("request", request))
 
@@ -76,20 +70,13 @@ func (r *activities) CreateRayJob(ctx context.Context, request v2pb.CreateRayJob
 
 	// Execute the original job creation logic
 	createRayJobResponse, err := r.rayJobService.CreateRayJob(ctx, &request)
-	if err != nil {
-		logger.Error(err, "activity-error: failed to create ray job")
-		return &CreateRayJobActivityResponse{ActivityID: activityID}, nil
-	}
-	if createRayJobResponse == nil || createRayJobResponse.RayJob == nil ||
+	if err != nil || createRayJobResponse == nil || createRayJobResponse.RayJob == nil ||
 		createRayJobResponse.RayJob.Name == "" {
-		logger.Error(errors.New("empty or invalid response"), "activity-error: failed to create ray job")
-		return &CreateRayJobActivityResponse{ActivityID: activityID}, nil
+		logger.Error(err, "activity-error")
+		return nil, workflow.NewCustomError(ctx, yarpcerrors.CodeUnavailable.String(), err.Error())
 	}
 
-	return &CreateRayJobActivityResponse{
-		RayJob:     createRayJobResponse.RayJob,
-		ActivityID: activityID,
-	}, nil
+	return createRayJobResponse, nil
 }
 
 // CreateRayCluster creates a new Ray cluster and returns it with activity ID for retry tracking.

--- a/go/worker/activities/ray/ray_activities_test.go
+++ b/go/worker/activities/ray/ray_activities_test.go
@@ -70,13 +70,11 @@ func (r *Suite) Test_CreateRayJob() {
 		RayJob: rayJob,
 	}, nil)
 	res, err := r.activitySuite.ExecuteActivity(Activities.CreateRayJob, *request)
-	var resp CreateRayJobActivityResponse
+	var resp v2pb.CreateRayJobResponse
 	res.Get(&resp)
 	assert.Nil(r.t, err)
 	assert.NotNil(r.t, resp)
-	assert.Equal(r.t, rayJob.Name, resp.RayJob.Name)
-	assert.Equal(r.t, rayJob.Namespace, resp.RayJob.Namespace)
-	assert.NotEmpty(r.t, resp.ActivityID)
+	assert.Equal(r.t, rayJob, resp.RayJob)
 }
 
 func (r *Suite) Test_CreateRayCluster() {

--- a/go/worker/activities/ray/ray_activities_test.go
+++ b/go/worker/activities/ray/ray_activities_test.go
@@ -70,11 +70,13 @@ func (r *Suite) Test_CreateRayJob() {
 		RayJob: rayJob,
 	}, nil)
 	res, err := r.activitySuite.ExecuteActivity(Activities.CreateRayJob, *request)
-	var resp v2pb.CreateRayJobResponse
+	var resp CreateRayJobActivityResponse
 	res.Get(&resp)
 	assert.Nil(r.t, err)
 	assert.NotNil(r.t, resp)
-	assert.Equal(r.t, rayJob, resp.RayJob)
+	assert.Equal(r.t, rayJob.Name, resp.RayJob.Name)
+	assert.Equal(r.t, rayJob.Namespace, resp.RayJob.Namespace)
+	assert.NotEmpty(r.t, resp.ActivityID)
 }
 
 func (r *Suite) Test_CreateRayCluster() {

--- a/go/worker/activities/spark/spark_activities.go
+++ b/go/worker/activities/spark/spark_activities.go
@@ -71,10 +71,14 @@ func (r *activities) CreateSparkJob(ctx context.Context, request v2pb.CreateSpar
 
 	// Execute the original job creation logic
 	createSparkJobResponse, err := r.sparkJobService.CreateSparkJob(ctx, &request)
-	if err != nil || createSparkJobResponse == nil || createSparkJobResponse.SparkJob == nil ||
+	if err != nil {
+		logger.Error("activity-error: failed to create spark job", zap.Error(err))
+		return &CreateSparkJobActivityResponse{ActivityID: activityID}, nil
+	}
+	if createSparkJobResponse == nil || createSparkJobResponse.SparkJob == nil ||
 		createSparkJobResponse.SparkJob.Name == "" {
-		logger.Error("activity-error", zap.Any("error", err.Error()))
-		return nil, workflow.NewCustomError(ctx, yarpcerrors.CodeUnavailable.String(), err.Error())
+		logger.Error("activity-error: empty or invalid response from CreateSparkJob")
+		return &CreateSparkJobActivityResponse{ActivityID: activityID}, nil
 	}
 
 	return &CreateSparkJobActivityResponse{

--- a/go/worker/plugins/ray/starlark_module.go
+++ b/go/worker/plugins/ray/starlark_module.go
@@ -75,8 +75,19 @@ func (r *module) createCluster(t *starlark.Thread, _ *starlark.Builtin, args sta
 		return nil, err
 	}
 
-	cluster = *response.RayCluster
 	activityID := response.ActivityID
+	if response.RayCluster == nil {
+		failureResponse := map[string]interface{}{
+			"rayCluster": nil,
+			"activityId": activityID,
+		}
+		var failRes starlark.Value
+		if err := utils.AsStar(failureResponse, &failRes); err != nil {
+			return nil, err
+		}
+		return failRes, nil
+	}
+	cluster = *response.RayCluster
 
 	srp := utils.DefaultSensorRetryPolicy
 	srp.ExpirationInterval = time.Second * time.Duration(timeout)
@@ -178,7 +189,7 @@ func (r *module) createJob(t *starlark.Thread, _ *starlark.Builtin, args starlar
 			},
 		},
 	}
-	var createRes v2pb.CreateRayJobResponse
+	var createRes ray.CreateRayJobActivityResponse
 	if err := workflow.ExecuteActivity(ctx, ray.Activities.CreateRayJob, v2pb.CreateRayJobRequest{
 		RayJob: &rayJob,
 	}).Get(ctx, &createRes); err != nil {
@@ -186,6 +197,9 @@ func (r *module) createJob(t *starlark.Thread, _ *starlark.Builtin, args starlar
 		return nil, err
 	}
 
+	if createRes.RayJob == nil {
+		return nil, fmt.Errorf("failed to create Ray job")
+	}
 	rayJob = *createRes.RayJob
 
 	var sensorRes ray.SensorRayJobResponse

--- a/go/worker/plugins/ray/starlark_module.go
+++ b/go/worker/plugins/ray/starlark_module.go
@@ -189,7 +189,7 @@ func (r *module) createJob(t *starlark.Thread, _ *starlark.Builtin, args starlar
 			},
 		},
 	}
-	var createRes ray.CreateRayJobActivityResponse
+	var createRes v2pb.CreateRayJobResponse
 	if err := workflow.ExecuteActivity(ctx, ray.Activities.CreateRayJob, v2pb.CreateRayJobRequest{
 		RayJob: &rayJob,
 	}).Get(ctx, &createRes); err != nil {
@@ -197,9 +197,6 @@ func (r *module) createJob(t *starlark.Thread, _ *starlark.Builtin, args starlar
 		return nil, err
 	}
 
-	if createRes.RayJob == nil {
-		return nil, fmt.Errorf("failed to create Ray job")
-	}
 	rayJob = *createRes.RayJob
 
 	var sensorRes ray.SensorRayJobResponse

--- a/go/worker/plugins/ray/starlark_module_test.go
+++ b/go/worker/plugins/ray/starlark_module_test.go
@@ -229,10 +229,9 @@ func (r *Test) TestCreateRayJobSuccessfully() {
 		Run(func(args mock.Arguments) {
 			createdRayJob = args.Get(1).(v2pb.CreateRayJobRequest)
 		}).
-		Return(func(ctx context.Context, req v2pb.CreateRayJobRequest) (*ray.CreateRayJobActivityResponse, error) {
-			return &ray.CreateRayJobActivityResponse{
-				RayJob:     rayJob,
-				ActivityID: "",
+		Return(func(ctx context.Context, req v2pb.CreateRayJobRequest) (*v2pb.CreateRayJobResponse, error) {
+			return &v2pb.CreateRayJobResponse{
+				RayJob: rayJob,
 			}, nil
 		})
 
@@ -267,10 +266,9 @@ func (r *Test) TestCreateRayJobFailed() {
 
 	rayJob := &v2pb.RayJob{}
 	env.OnActivity(ray.Activities.CreateRayJob, mock.Anything, mock.Anything).Once().
-		Return(func(ctx context.Context, req v2pb.CreateRayJobRequest) (*ray.CreateRayJobActivityResponse, error) {
-			return &ray.CreateRayJobActivityResponse{
-				RayJob:     rayJob,
-				ActivityID: "",
+		Return(func(ctx context.Context, req v2pb.CreateRayJobRequest) (*v2pb.CreateRayJobResponse, error) {
+			return &v2pb.CreateRayJobResponse{
+				RayJob: rayJob,
 			}, nil
 		})
 

--- a/go/worker/plugins/ray/starlark_module_test.go
+++ b/go/worker/plugins/ray/starlark_module_test.go
@@ -227,11 +227,12 @@ func (r *Test) TestCreateRayJobSuccessfully() {
 	var createdRayJob v2pb.CreateRayJobRequest
 	env.OnActivity(ray.Activities.CreateRayJob, mock.Anything, mock.Anything).Once().
 		Run(func(args mock.Arguments) {
-			createdRayJob = args.Get(1).(v2pb.CreateRayJobRequest) // Capture the request argument
+			createdRayJob = args.Get(1).(v2pb.CreateRayJobRequest)
 		}).
-		Return(func(ctx context.Context, req v2pb.CreateRayJobRequest) (*v2pb.CreateRayJobResponse, error) {
-			return &v2pb.CreateRayJobResponse{
-				RayJob: rayJob,
+		Return(func(ctx context.Context, req v2pb.CreateRayJobRequest) (*ray.CreateRayJobActivityResponse, error) {
+			return &ray.CreateRayJobActivityResponse{
+				RayJob:     rayJob,
+				ActivityID: "",
 			}, nil
 		})
 
@@ -266,9 +267,10 @@ func (r *Test) TestCreateRayJobFailed() {
 
 	rayJob := &v2pb.RayJob{}
 	env.OnActivity(ray.Activities.CreateRayJob, mock.Anything, mock.Anything).Once().
-		Return(func(ctx context.Context, req v2pb.CreateRayJobRequest) (*v2pb.CreateRayJobResponse, error) {
-			return &v2pb.CreateRayJobResponse{
-				RayJob: rayJob,
+		Return(func(ctx context.Context, req v2pb.CreateRayJobRequest) (*ray.CreateRayJobActivityResponse, error) {
+			return &ray.CreateRayJobActivityResponse{
+				RayJob:     rayJob,
+				ActivityID: "",
 			}, nil
 		})
 

--- a/python/michelangelo/uniflow/plugins/ray/task.star
+++ b/python/michelangelo/uniflow/plugins/ray/task.star
@@ -267,21 +267,36 @@ def execute_ray_task(task_path, task_name, cluster, cluster_namespace, runtime_e
         retry_attempt_id = retry_attempt_id,
     )
 
-    # Enhanced: Call existing Go activity that now returns activity ID
     cluster_response = ray.create_cluster(cluster, timeout_seconds = DEFAULT_CREATE_CLUSTER_TIMEOUT_SECONDS)
 
-    # Extract cluster info and activity ID from enhanced response
-    cluster = cluster_response["rayCluster"]  # This contains the actual cluster data
-    first_activity_id = cluster_response["activityId"]  # NEW: Activity ID from Go
+    cluster = cluster_response["rayCluster"]
+    first_activity_id = cluster_response["activityId"]
+
+    print("ray | first activity ID:", first_activity_id)
+
+    if cluster == None:
+        end_time_seconds = time.time()
+        end_time_formated_str = time.utc_format_seconds(TIME_FOMART, end_time_seconds)
+        report_progress(
+            task_path = task_path,
+            task_name = task_name,
+            task_log = "",
+            task_message = "Ray Cluster Creation Failed",
+            task_state = TASK_STATE_FAILED,
+            start_time = start_time_formated_str,
+            end_time = end_time_formated_str,
+            output = "",
+            retry_attempt_id = retry_attempt_id,
+            first_activity_id = first_activity_id,
+        )
+        fail("ray | cluster creation failed, activityId=" + first_activity_id)
 
     cluster_url = cluster["status"].get("jobUrl", "UAPI did not report RayJob URL")
     cluster_name = cluster["metadata"]["name"]
     cluster_namespace = cluster["metadata"]["namespace"]
 
     print("ray | cluster created:", "ns=" + cluster_namespace, "n=" + cluster_name, "url=" + cluster_url)
-    print("ray | first activity ID:", first_activity_id)  # NEW: Log the activity ID
 
-    # Enhanced: Progress report with activity ID - this establishes the first activity for this task
     report_progress(
         task_path = task_path,
         task_name = task_name,
@@ -292,7 +307,7 @@ def execute_ray_task(task_path, task_name, cluster, cluster_namespace, runtime_e
         end_time = "",
         output = "",
         retry_attempt_id = retry_attempt_id,
-        first_activity_id = first_activity_id,  # NEW: Store first activity ID for retry boundary
+        first_activity_id = first_activity_id,
     )
 
     atexit.register(terminate_cluster, cluster_namespace, cluster_name)

--- a/python/michelangelo/uniflow/plugins/spark/task.star
+++ b/python/michelangelo/uniflow/plugins/spark/task.star
@@ -200,25 +200,39 @@ def execute_spark_task(namespace, task_name, task_path, spark_job, start_time_fo
     # submit spark job
     print("spark | submit job. ns:", namespace, "task_name:", task_name)
 
-    # Enhanced: Call existing Go activity that now returns activity ID
     spark_job_response = spark.create_job(spark_job)
 
-    # Extract job info and activity ID from enhanced response
-    created_spark_job = spark_job_response["sparkJob"]  # This contains the actual job data
-    first_activity_id = spark_job_response["activityId"]  # NEW: Activity ID from Go
+    created_spark_job = spark_job_response["sparkJob"]
+    first_activity_id = spark_job_response["activityId"]
+
+    print("spark | first activity ID:", first_activity_id)
+
+    if created_spark_job == None:
+        end_time_seconds = time.time()
+        end_time_formated_str = time.utc_format_seconds(TIME_FOMART, end_time_seconds)
+        report_progress(
+            task_path = task_path,
+            task_name = task_name,
+            task_log = "",
+            task_message = "Spark Job Creation Failed",
+            task_state = TASK_STATE_FAILED,
+            start_time = start_time_formatted_str,
+            end_time = end_time_formated_str,
+            output = "",
+            retry_attempt_id = retry_attempt_id,
+            first_activity_id = first_activity_id,
+        )
+        fail("spark | job creation failed, activityId=" + first_activity_id)
 
     print("spark | job created:", "ns=" + namespace, "task_name=" + task_name)
-    print("spark | first activity ID:", first_activity_id)  # NEW: Log the activity ID
 
     spark_job_name = ""
     if type(created_spark_job) == "dict":
         driver_log_url = created_spark_job.get("status", {}).get("jobUrl", "")
         spark_job_name = created_spark_job.get("metadata", {}).get("name", "")
 
-    # Generate log URL from job name
     generated_log_url = get_spark_log_url(spark_job_name)
 
-    # report task as pending
     report_progress(
         task_path = task_path,
         task_name = task_name,
@@ -229,7 +243,7 @@ def execute_spark_task(namespace, task_name, task_path, spark_job, start_time_fo
         end_time = "",
         output = "",
         retry_attempt_id = retry_attempt_id,
-        first_activity_id = first_activity_id,  # NEW: Store first activity ID for retry boundary
+        first_activity_id = first_activity_id,
     )
 
     # register the check_spark_job function to be called at the end of the workflow.


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

Worker activities (Ray CreateCluster/CreateJob, Spark CreateJob) now return `activityID` with a nil error on failure, instead of returning a nil response with an error. This allows the Starlark layer to always receive the `activityID` and report it via `report_progress()` before aborting.
Changes across three layers:
- **Go activities** (`ray_activities.go`, `spark_activities.go`): Return response with `ActivityID` + nil error on failure, so the workflow engine deserializes the return value.
- **Go Starlark modules** (`ray/starlark_module.go`): On nil cluster/job, return the `activityId` to Starlark instead of returning a Go error (which Starlark can't extract values from).
- **Starlark `.star` files** (`ray/task.star`, `spark/task.star`): Detect nil cluster/job, call `report_progress()` with `first_activity_id` and `TASK_STATE_FAILED`, then `fail()`.


<!-- Tell your future self why have you made these changes -->
**Why?**

When a worker activity (e.g. `CreateRayCluster`) fails, the Temporal/Cadence workflow engine does not deserialize the activity's return value if the activity returns a non-nil error. This causes the `activityID` to be lost, leaving `PipelineRunStepInfo.ActivityId` empty. Without the `activityID`, the retry mechanism cannot identify which workflow activity to reset, making manual retry from the UI impossible for failed create activities.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

- `go vet` passes for both `worker/plugins/ray` and `worker/plugins/spark`
- Ray starlark module tests: 4/4 PASS (`TestCreateClusterSuccessfully`, `TestCreateClusterFailed`, `TestCreateRayJobSuccessfully`, `TestCreateRayJobFailed`)
- Spark starlark module tests: 2/2 PASS (`TestCreateJobSuccessfully`, `TestSensorJobSuccessfully`)
- Updated existing test mocks and assertions to use new `CreateRayJobActivityResponse` type

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

- Activities now return nil error on logical failures, shifting failure detection to the caller (Starlark `.star` files check for nil cluster/job). If a new caller is added that doesn't check for nil, it could dereference a nil pointer. This is mitigated by the existing nil checks in the Go Starlark modules.
- The change to `CreateRayJobActivityResponse` return type in `CreateRayJob` activity is a signature change. Any existing workflow executions in-flight that expect the old `CreateRayJobResponse` type will fail to deserialize. This should be safe since activity results are not persisted across deployments.


<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

No schema or configuration changes. No migration required.


<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**

No user-facing or API changes. The fix is internal to the worker activity execution flow.
