### PR TITLE
feat: add PipelineNameLabel to trigger-created pipeline runs

### DIFF
--- a/go/worker/workflows/trigger/cron_trigger_workflows.go
+++ b/go/worker/workflows/trigger/cron_trigger_workflows.go
@@ -59,6 +59,9 @@ var (
 	// PipelineManifestTypeLabel is to indicate the manifest type of this pipeline
 	PipelineManifestTypeLabel = "pipeline.michelangelo/PipelineManifestType"
 
+	// PipelineNameLabel stores the pipeline name for filtering pipeline runs
+	PipelineNameLabel = "pipelinerun.michelangelo/pipeline-name"
+
 	// activityOptionsDefault is the default activity options for the trigger workflow
 	activityOptionsDefault = workflow.ActivityOptions{
 		ScheduleToStartTimeout: time.Second * 30,
@@ -295,6 +298,7 @@ func generatePipelineRunRequest(
 		PipelineRunExecutionTimestampLabel: fmt.Sprintf("%d", ts.Unix()),
 		TriggerredByLabel:                  triggerRun.Name,
 		SourceTriggerLabel:                 triggerRun.Name,
+		PipelineNameLabel:                  triggerRun.Spec.Pipeline.Name,
 	}
 	if env, ok := triggerRun.ObjectMeta.Labels[EnvironmentLabel]; ok {
 		labels[EnvironmentLabel] = env

--- a/go/worker/workflows/trigger/cron_trigger_workflows_test.go
+++ b/go/worker/workflows/trigger/cron_trigger_workflows_test.go
@@ -127,6 +127,9 @@ func TestGeneratePipelineRunRequest(t *testing.T) {
 				expectedLabel := tt.expectedGeneratePipelineRunRequest.PipelineRun.ObjectMeta.Labels[ParameterIDLabel]
 				actualLabel := result.PipelineRun.ObjectMeta.Labels[ParameterIDLabel]
 				assert.Equal(t, expectedLabel, actualLabel)
+
+				// Validate PipelineNameLabel
+				assert.Equal(t, tt.triggerRun.Spec.Pipeline.Name, result.PipelineRun.ObjectMeta.Labels[PipelineNameLabel])
 			}
 		})
 	}


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

Added a new `PipelineNameLabel` (`pipelinerun.michelangelo/pipeline-name`) to pipeline runs created by trigger workflows. The label is populated with `triggerRun.Spec.Pipeline.Name` in `generatePipelineRunRequest()`.


<!-- Tell your future self why have you made these changes -->
**Why?**

Trigger-created pipeline runs currently lack a label identifying which pipeline they belong to. This makes it difficult to filter or query pipeline runs by pipeline name. Adding this label enables straightforward filtering.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

- Added assertion in `TestGeneratePipelineRunRequest` to validate the label is correctly populated
- All 3 existing test cases pass locally (`go test ./worker/workflows/trigger/... -v`)

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

Minimal. This only adds a new label to the labels map — no existing labels or behavior are modified. Existing consumers that don't use this label are unaffected.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

Pipeline runs created by triggers now include a `pipelinerun.michelangelo/pipeline-name` label for filtering.

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**

N/A — no user-facing API change, no configuration or schema migration required.
