### PR TITLE
docs(website): add Algolia DocSearch to docs site

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -110,6 +110,12 @@ const config: Config = {
       darkTheme: prismThemes.dracula,
       additionalLanguages: ['go', 'python', 'bash', 'yaml', 'json'],
     },
+    algolia: {
+      appId: 'VHQ78WWU1A',
+      apiKey: '29f48511d08dbcbe1c808676879f24eb',
+      indexName: 'docs-crawler',
+      contextualSearch: true,
+    },
   } satisfies Preset.ThemeConfig,
 };
 


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**

Wires the existing `docs-crawler` Algolia index into the Docusaurus site by adding an `algolia` block to `themeConfig` in `website/docusaurus.config.ts`. No new dependencies — `@docusaurus/theme-search-algolia` already ships with `@docusaurus/preset-classic`.

**Why?**

Adds full-text search across the docs so users can find content faster than navigating the sidebar. The Algolia crawler is already running and indexing the site.

**How did you test it?**

- `bun run typecheck` — passes
- `bun run build` — passes, no Algolia-related warnings
- `bun run docusaurus serve --dir build` — confirmed the search box renders in the navbar (top right with `⌘K` shortcut) and that `appId` / `indexName` are present in the served JS bundle.


https://github.com/user-attachments/assets/63fb8acc-3437-4c94-baa1-9fb2ecf41f95




**Potential risks**

Low. If the Algolia API key or index name is wrong, the search dropdown silently shows no results — the rest of the site is unaffected. The `apiKey` here is a public search-only key (Algolia's standard pattern), safe to commit.

**Release notes**

Adds in-product search to the docs site, powered by Algolia DocSearch.

**Documentation Changes**

None — this is the documentation site itself.