### PR TITLE
Introduce controlled expanded state to form-group

### DIFF
--- a/javascript/packages/core/components/form/layout/form-group/__tests__/form-group.test.tsx
+++ b/javascript/packages/core/components/form/layout/form-group/__tests__/form-group.test.tsx
@@ -70,4 +70,38 @@ describe('FormGroup', () => {
     await user.click(header);
     expect(screen.getByText('Expandable content')).toBeInTheDocument();
   });
+
+  it('supports controlled expanded state', () => {
+    const { rerender } = render(
+      <FormGroup title="Controlled" collapsible expanded={false}>
+        <div>Content</div>
+      </FormGroup>,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+    );
+
+    expect(screen.queryByText('Content')).not.toBeInTheDocument();
+
+    rerender(
+      <FormGroup title="Controlled" collapsible expanded={true}>
+        <div>Content</div>
+      </FormGroup>
+    );
+
+    expect(screen.getByText('Content')).toBeInTheDocument();
+  });
+
+  it('invokes onToggle callback when toggled', async () => {
+    const user = userEvent.setup();
+    const onToggle = vi.fn();
+
+    render(
+      <FormGroup title="Toggle" collapsible expanded={false} onToggle={onToggle}>
+        <div>Content</div>
+      </FormGroup>,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+    );
+
+    await user.click(screen.getByRole('button'));
+    expect(onToggle).toHaveBeenCalledWith(true);
+  });
 });

--- a/javascript/packages/core/components/form/layout/form-group/form-group.tsx
+++ b/javascript/packages/core/components/form/layout/form-group/form-group.tsx
@@ -13,6 +13,8 @@ export const FormGroup: React.FC<FormGroupProps> = ({
   description,
   tooltip,
   collapsible = false,
+  expanded,
+  onToggle,
   endEnhancer,
   overrides = {},
   children,
@@ -53,7 +55,9 @@ export const FormGroup: React.FC<FormGroupProps> = ({
       <CollapsibleBox
         title={enhancedTitle}
         description={enhancedDescription}
+        expanded={expanded}
         defaultExpanded={false}
+        onToggle={onToggle}
         overrides={{
           Content: {
             style: {

--- a/javascript/packages/core/components/form/layout/form-group/types.ts
+++ b/javascript/packages/core/components/form/layout/form-group/types.ts
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import type { BoxOverrides } from '#core/components/box/types';
 
-export interface FormGroupProps {
+interface FormGroupBaseProps {
   title?: string;
 
   /** Text displayed below title, **Markdown supported** */
@@ -9,19 +9,6 @@ export interface FormGroupProps {
 
   /** Help tooltip text, displayed next to title. **Markdown supported** */
   tooltip?: string;
-
-  /**
-   * Controls whether the group can be collapsed to hide its children
-   *
-   * @default false
-   */
-  collapsible?: boolean;
-
-  /** Controlled expanded state — requires `onToggle` to respond to user interaction */
-  expanded?: boolean;
-
-  /** Called when the user toggles the collapsible group */
-  onToggle?: (expanded: boolean) => void;
 
   /** Additional content for the header (e.g., action buttons) */
   endEnhancer?: ReactNode;
@@ -31,3 +18,22 @@ export interface FormGroupProps {
 
   children: ReactNode;
 }
+
+interface StaticFormGroupProps extends FormGroupBaseProps {
+  collapsible?: false;
+  expanded?: never;
+  onToggle?: never;
+}
+
+interface CollapsibleFormGroupProps extends FormGroupBaseProps {
+  /** Enables collapsing the group to hide its children */
+  collapsible: true;
+
+  /** Controlled expanded state — requires `onToggle` to respond to user interaction */
+  expanded?: boolean;
+
+  /** Called when the collapsible group is toggled */
+  onToggle?: (expanded: boolean) => void;
+}
+
+export type FormGroupProps = StaticFormGroupProps | CollapsibleFormGroupProps;

--- a/javascript/packages/core/components/form/layout/form-group/types.ts
+++ b/javascript/packages/core/components/form/layout/form-group/types.ts
@@ -17,6 +17,12 @@ export interface FormGroupProps {
    */
   collapsible?: boolean;
 
+  /** Controlled expanded state — requires `onToggle` to respond to user interaction */
+  expanded?: boolean;
+
+  /** Called when the user toggles the collapsible group */
+  onToggle?: (expanded: boolean) => void;
+
   /** Additional content for the header (e.g., action buttons) */
   endEnhancer?: ReactNode;
 


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Summary
Updates `FormGroup` component to accept two new props:

- `expanded?: boolean` — To allow consumers of the component to control expanded state of the group inside their own logic
- `onToggle?: (expanded: boolean) => void` — To notify consumers of the component about the changes of the expanded state. This prop is especially needed for consumers controlling the expanded state from their own logic

## Test plan
Two new test cases which tests the expected behaviors of the newly defined props