### PR TITLE
Integration Kueue into compute cluster scheduler for ray job

### DIFF
--- a/go/components/jobs/client/k8sengine/ray.go
+++ b/go/components/jobs/client/k8sengine/ray.go
@@ -2,14 +2,36 @@ package k8sengine
 
 import (
 	"fmt"
+	"strconv"
 
 	v2pb "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sptr "k8s.io/utils/ptr"
 )
+
+// LogPersistenceConfig holds platform-level configuration for log persistence.
+// Loaded from YAML under jobs.k8sengine.mapper.logPersistence.
+// See: https://github.com/ray-project/kuberay/tree/master/historyserver/config
+type LogPersistenceConfig struct {
+	Enabled           bool   `yaml:"enabled"`
+	StorageEndpoint   string `yaml:"storageEndpoint"`   // S3-compatible endpoint (e.g. "minio:9091")
+	Bucket            string `yaml:"bucket"`            // S3 bucket name (e.g. "ray-history")
+	PathPrefix        string `yaml:"pathPrefix"`        // Key prefix under the bucket (e.g. "log")
+	Region            string `yaml:"region"`            // S3 region — required by AWS SDK for SigV4 signing even with custom endpoints (e.g. "us-east-1", "us-ashburn-1")
+	CredentialsSecret string `yaml:"credentialsSecret"` // K8s Secret with AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY
+	CollectorImage    string `yaml:"collectorImage"`    // KubeRay collector sidecar image
+	S3DisableSSL      bool   `yaml:"s3DisableSSL"`      // Set S3DISABLE_SSL on the collector (true for in-cluster MinIO; false for OCI/S3)
+
+	// LogURLFormat is a Go text/template applied during local→global cluster
+	// status translation to produce the human-browsable log URL surfaced on
+	// v2 RayClusterStatus. Available template variables: Bucket, PathPrefix,
+	// ClusterName, RayLocalNamespace. Empty string disables log_url emission.
+	LogURLFormat string `yaml:"logURLFormat"`
+}
 
 func (m Mapper) mapRay(rayJob *v2pb.RayJob, jobClusterObject runtime.Object, cluster *v2pb.Cluster) (runtime.Object, error) {
 	if jobClusterObject == nil {
@@ -53,6 +75,13 @@ func (m Mapper) mapRayCluster(rayCluster *v2pb.RayCluster) (runtime.Object, erro
 	workerGroupSpecs := getWorkerGroupSpecs(rayCluster.GetName(), rayCluster.GetSpec().Workers)
 	headGroupSpec := getHeadGroupSpec(rayCluster.GetSpec().Head)
 
+	if m.LogPersistence.Enabled {
+		injectCollectorSidecar(&headGroupSpec.Template, m.LogPersistence, rayCluster.GetName(), RayLocalNamespace, "Head")
+		for i := range workerGroupSpecs {
+			injectCollectorSidecar(&workerGroupSpecs[i].Template, m.LogPersistence, rayCluster.GetName(), RayLocalNamespace, "Worker")
+		}
+	}
+
 	rayV1Cluster := &rayv1.RayCluster{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       RayClusterKind,
@@ -94,6 +123,242 @@ func getWorkerGroupSpecs(clusterName string, workers []*v2pb.RayWorkerSpec) []ra
 		workerGroupSpecsJSON[i] = wg
 	}
 	return workerGroupSpecsJSON
+}
+
+const (
+	rayLogsVolumeName = "ray-logs"
+	rayLogsPath       = "/tmp/ray"
+	collectorPort     = 8084
+
+	// nodeIDScript is the PostStart lifecycle hook that extracts the raylet node ID.
+	// The collector watches /tmp/ray/raylet_node_id for node identification.
+	// This script polls until the raylet process starts, then extracts --node_id from its args.
+	// Copied from: https://github.com/ray-project/kuberay/blob/master/historyserver/config/raycluster.yaml
+	nodeIDScript = `GetNodeId(){
+  while true; do
+    nodeid=$(ps -ef | grep raylet | grep node_id | grep -v grep | grep -oP '(?<=--node_id=)[^ ]*')
+    if [ -n "$nodeid" ]; then
+      echo "$(date) raylet started: ${nodeid}" >> /tmp/ray/init.log
+      echo $nodeid > /tmp/ray/raylet_node_id
+      break
+    else
+      echo "$(date) raylet not started" >> /tmp/ray/init.log
+      sleep 1
+    fi
+  done
+}
+GetNodeId`
+
+	// exposableEventTypes lists the Ray event types the collector should receive.
+	// Required for Ray 2.52.0+. In 2.53.0+ the env var name changes to
+	// RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISHER_HTTP_ENDPOINT_EXPOSABLE_EVENT_TYPES
+	exposableEventTypes = "TASK_DEFINITION_EVENT,TASK_LIFECYCLE_EVENT,ACTOR_TASK_DEFINITION_EVENT," +
+		"TASK_PROFILE_EVENT,DRIVER_JOB_DEFINITION_EVENT,DRIVER_JOB_LIFECYCLE_EVENT," +
+		"ACTOR_DEFINITION_EVENT,ACTOR_LIFECYCLE_EVENT,NODE_DEFINITION_EVENT,NODE_LIFECYCLE_EVENT"
+)
+
+// injectCollectorSidecar injects a KubeRay History Server collector sidecar container
+// into the pod template. Follows the official KubeRay config pattern:
+// https://github.com/ray-project/kuberay/blob/master/historyserver/config/raycluster.yaml
+//
+// It adds:
+// - Shared emptyDir volume for /tmp/ray
+// - Ray event export env vars on all existing containers
+// - PostStart lifecycle hook to extract raylet node ID
+// - Collector sidecar with S3 env vars and event port
+func injectCollectorSidecar(podTemplate *corev1.PodTemplateSpec, config LogPersistenceConfig, clusterName string, clusterNamespace string, role string) {
+	// 1. Determine the volume name for /tmp/ray.
+	// If a Ray container already mounts /tmp/ray, reuse that volume so
+	// the collector shares the same data. Otherwise, create a new emptyDir.
+	rayVolumeName := rayLogsVolumeName
+	for _, c := range podTemplate.Spec.Containers {
+		for _, vm := range c.VolumeMounts {
+			if vm.MountPath == rayLogsPath {
+				rayVolumeName = vm.Name
+				break
+			}
+		}
+		if rayVolumeName != rayLogsVolumeName {
+			break
+		}
+	}
+
+	// Only add a new volume if no existing volume is being reused
+	if rayVolumeName == rayLogsVolumeName {
+		hasVolume := false
+		for _, v := range podTemplate.Spec.Volumes {
+			if v.Name == rayLogsVolumeName {
+				hasVolume = true
+				break
+			}
+		}
+		if !hasVolume {
+			podTemplate.Spec.Volumes = append(podTemplate.Spec.Volumes, corev1.Volume{
+				Name: rayLogsVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			})
+		}
+	}
+
+	rayLogsVolumeMount := corev1.VolumeMount{
+		Name:      rayVolumeName,
+		MountPath: rayLogsPath,
+	}
+
+	// Ray event export env vars — tells Ray to forward events to the collector's HTTP endpoint
+	eventExportEnvVars := []corev1.EnvVar{
+		{
+			Name:  "RAY_enable_ray_event",
+			Value: "true",
+		},
+		{
+			Name:  "RAY_enable_core_worker_ray_event_to_aggregator",
+			Value: "true",
+		},
+		{
+			Name:  "RAY_DASHBOARD_AGGREGATOR_AGENT_EVENTS_EXPORT_ADDR",
+			Value: fmt.Sprintf("http://localhost:%d/v1/events", collectorPort),
+		},
+		{
+			Name:  "RAY_DASHBOARD_AGGREGATOR_AGENT_EXPOSABLE_EVENT_TYPES",
+			Value: exposableEventTypes,
+		},
+	}
+
+	// 2. Update all existing containers: add volume mount, env vars, and lifecycle hook
+	for i := range podTemplate.Spec.Containers {
+		c := &podTemplate.Spec.Containers[i]
+		// Only add volume mount if /tmp/ray is not already mounted
+		hasRayLogsMount := false
+		for _, vm := range c.VolumeMounts {
+			if vm.MountPath == rayLogsPath {
+				hasRayLogsMount = true
+				break
+			}
+		}
+		if !hasRayLogsMount {
+			c.VolumeMounts = append(c.VolumeMounts, rayLogsVolumeMount)
+		}
+		c.Env = append(c.Env, eventExportEnvVars...)
+
+		// Add PostStart lifecycle hook to extract raylet node ID.
+		// Preserves any existing PreStop hook.
+		if c.Lifecycle == nil {
+			c.Lifecycle = &corev1.Lifecycle{}
+		}
+		c.Lifecycle.PostStart = &corev1.LifecycleHandler{
+			Exec: &corev1.ExecAction{
+				Command: []string{"/bin/sh", "-lc", "--", nodeIDScript},
+			},
+		}
+	}
+
+	// 3. Build S3 env vars for collector — matches official kuberay config pattern
+	// (env vars, NOT --runtime-class-config-path). We set BOTH credential
+	// naming conventions on purpose:
+	//   - AWS_S3ID / AWS_S3SECRET / AWS_S3TOKEN — kuberay's storage/s3 reads
+	//     these explicitly (historyserver/pkg/storage/s3/config.go).
+	//   - AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY — required by AWS SDK code
+	//     paths that fall through to the default credential chain (e.g. SigV4
+	//     signing against OCI Object Storage).
+	// AWS_REGION is also required by the SDK for SigV4 even when StorageEndpoint
+	// points at a non-AWS endpoint — without it the collector panics with
+	// MissingRegion before ever issuing a request.
+	collectorS3Env := []corev1.EnvVar{
+		{
+			Name: "AWS_S3ID",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: config.CredentialsSecret,
+					},
+					Key: "AWS_ACCESS_KEY_ID",
+				},
+			},
+		},
+		{
+			Name: "AWS_S3SECRET",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: config.CredentialsSecret,
+					},
+					Key: "AWS_SECRET_ACCESS_KEY",
+				},
+			},
+		},
+		{Name: "AWS_S3TOKEN", Value: ""},
+		{
+			Name: "AWS_ACCESS_KEY_ID",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: config.CredentialsSecret,
+					},
+					Key: "AWS_ACCESS_KEY_ID",
+				},
+			},
+		},
+		{
+			Name: "AWS_SECRET_ACCESS_KEY",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: config.CredentialsSecret,
+					},
+					Key: "AWS_SECRET_ACCESS_KEY",
+				},
+			},
+		},
+		{Name: "AWS_REGION", Value: config.Region},
+		{Name: "S3_BUCKET", Value: config.Bucket},
+		{Name: "S3_ENDPOINT", Value: config.StorageEndpoint},
+		{Name: "S3FORCE_PATH_STYLE", Value: "true"},
+		{Name: "S3DISABLE_SSL", Value: strconv.FormatBool(config.S3DisableSSL)},
+	}
+
+	// Head collector gets additional env vars for dashboard polling
+	if role == "Head" {
+		collectorS3Env = append(collectorS3Env,
+			corev1.EnvVar{Name: "RAY_DASHBOARD_ADDRESS", Value: "http://localhost:8265"},
+			corev1.EnvVar{Name: "RAY_COLLECTOR_ADDITIONAL_ENDPOINTS", Value: "/api/v0/placement_groups?detail=1&limit=10000"},
+			corev1.EnvVar{Name: "RAY_COLLECTOR_POLL_INTERVAL", Value: "30s"},
+		)
+	}
+
+	// 4. Build collector sidecar container using command (not args) per official config
+	collectorContainer := corev1.Container{
+		Name:            "collector",
+		Image:           config.CollectorImage,
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		Command: []string{
+			"collector",
+			fmt.Sprintf("--role=%s", role),
+			"--runtime-class-name=s3",
+			fmt.Sprintf("--ray-cluster-name=%s", clusterName),
+			fmt.Sprintf("--ray-root-dir=%s", "log"),
+			fmt.Sprintf("--events-port=%d", collectorPort),
+		},
+		Env: collectorS3Env,
+		Ports: []corev1.ContainerPort{
+			{
+				Name:          "events",
+				ContainerPort: int32(collectorPort),
+				Protocol:      corev1.ProtocolTCP,
+			},
+		},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceMemory: resource.MustParse("128Mi"),
+			},
+		},
+		VolumeMounts: []corev1.VolumeMount{rayLogsVolumeMount},
+	}
+
+	podTemplate.Spec.Containers = append(podTemplate.Spec.Containers, collectorContainer)
 }
 
 // getRayClusterStateFromStatus maps KubeRay v1 cluster state to our internal v2pb.RayClusterState

--- a/go/components/jobs/client/k8sengine/ray.go
+++ b/go/components/jobs/client/k8sengine/ray.go
@@ -2,36 +2,14 @@ package k8sengine
 
 import (
 	"fmt"
-	"strconv"
 
 	v2pb "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sptr "k8s.io/utils/ptr"
 )
-
-// LogPersistenceConfig holds platform-level configuration for log persistence.
-// Loaded from YAML under jobs.k8sengine.mapper.logPersistence.
-// See: https://github.com/ray-project/kuberay/tree/master/historyserver/config
-type LogPersistenceConfig struct {
-	Enabled           bool   `yaml:"enabled"`
-	StorageEndpoint   string `yaml:"storageEndpoint"`   // S3-compatible endpoint (e.g. "minio:9091")
-	Bucket            string `yaml:"bucket"`            // S3 bucket name (e.g. "ray-history")
-	PathPrefix        string `yaml:"pathPrefix"`        // Key prefix under the bucket (e.g. "log")
-	Region            string `yaml:"region"`            // S3 region — required by AWS SDK for SigV4 signing even with custom endpoints (e.g. "us-east-1", "us-ashburn-1")
-	CredentialsSecret string `yaml:"credentialsSecret"` // K8s Secret with AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY
-	CollectorImage    string `yaml:"collectorImage"`    // KubeRay collector sidecar image
-	S3DisableSSL      bool   `yaml:"s3DisableSSL"`      // Set S3DISABLE_SSL on the collector (true for in-cluster MinIO; false for OCI/S3)
-
-	// LogURLFormat is a Go text/template applied during local→global cluster
-	// status translation to produce the human-browsable log URL surfaced on
-	// v2 RayClusterStatus. Available template variables: Bucket, PathPrefix,
-	// ClusterName, RayLocalNamespace. Empty string disables log_url emission.
-	LogURLFormat string `yaml:"logURLFormat"`
-}
 
 func (m Mapper) mapRay(rayJob *v2pb.RayJob, jobClusterObject runtime.Object, cluster *v2pb.Cluster) (runtime.Object, error) {
 	if jobClusterObject == nil {
@@ -75,13 +53,6 @@ func (m Mapper) mapRayCluster(rayCluster *v2pb.RayCluster) (runtime.Object, erro
 	workerGroupSpecs := getWorkerGroupSpecs(rayCluster.GetName(), rayCluster.GetSpec().Workers)
 	headGroupSpec := getHeadGroupSpec(rayCluster.GetSpec().Head)
 
-	if m.LogPersistence.Enabled {
-		injectCollectorSidecar(&headGroupSpec.Template, m.LogPersistence, rayCluster.GetName(), RayLocalNamespace, "Head")
-		for i := range workerGroupSpecs {
-			injectCollectorSidecar(&workerGroupSpecs[i].Template, m.LogPersistence, rayCluster.GetName(), RayLocalNamespace, "Worker")
-		}
-	}
-
 	rayV1Cluster := &rayv1.RayCluster{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       RayClusterKind,
@@ -90,6 +61,7 @@ func (m Mapper) mapRayCluster(rayCluster *v2pb.RayCluster) (runtime.Object, erro
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      rayCluster.Name,
 			Namespace: RayLocalNamespace,
+			Labels:    rayCluster.GetLabels(),
 		},
 		Spec: rayv1.RayClusterSpec{
 			HeadGroupSpec:    headGroupSpec,
@@ -122,242 +94,6 @@ func getWorkerGroupSpecs(clusterName string, workers []*v2pb.RayWorkerSpec) []ra
 		workerGroupSpecsJSON[i] = wg
 	}
 	return workerGroupSpecsJSON
-}
-
-const (
-	rayLogsVolumeName = "ray-logs"
-	rayLogsPath       = "/tmp/ray"
-	collectorPort     = 8084
-
-	// nodeIDScript is the PostStart lifecycle hook that extracts the raylet node ID.
-	// The collector watches /tmp/ray/raylet_node_id for node identification.
-	// This script polls until the raylet process starts, then extracts --node_id from its args.
-	// Copied from: https://github.com/ray-project/kuberay/blob/master/historyserver/config/raycluster.yaml
-	nodeIDScript = `GetNodeId(){
-  while true; do
-    nodeid=$(ps -ef | grep raylet | grep node_id | grep -v grep | grep -oP '(?<=--node_id=)[^ ]*')
-    if [ -n "$nodeid" ]; then
-      echo "$(date) raylet started: ${nodeid}" >> /tmp/ray/init.log
-      echo $nodeid > /tmp/ray/raylet_node_id
-      break
-    else
-      echo "$(date) raylet not started" >> /tmp/ray/init.log
-      sleep 1
-    fi
-  done
-}
-GetNodeId`
-
-	// exposableEventTypes lists the Ray event types the collector should receive.
-	// Required for Ray 2.52.0+. In 2.53.0+ the env var name changes to
-	// RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISHER_HTTP_ENDPOINT_EXPOSABLE_EVENT_TYPES
-	exposableEventTypes = "TASK_DEFINITION_EVENT,TASK_LIFECYCLE_EVENT,ACTOR_TASK_DEFINITION_EVENT," +
-		"TASK_PROFILE_EVENT,DRIVER_JOB_DEFINITION_EVENT,DRIVER_JOB_LIFECYCLE_EVENT," +
-		"ACTOR_DEFINITION_EVENT,ACTOR_LIFECYCLE_EVENT,NODE_DEFINITION_EVENT,NODE_LIFECYCLE_EVENT"
-)
-
-// injectCollectorSidecar injects a KubeRay History Server collector sidecar container
-// into the pod template. Follows the official KubeRay config pattern:
-// https://github.com/ray-project/kuberay/blob/master/historyserver/config/raycluster.yaml
-//
-// It adds:
-// - Shared emptyDir volume for /tmp/ray
-// - Ray event export env vars on all existing containers
-// - PostStart lifecycle hook to extract raylet node ID
-// - Collector sidecar with S3 env vars and event port
-func injectCollectorSidecar(podTemplate *corev1.PodTemplateSpec, config LogPersistenceConfig, clusterName string, clusterNamespace string, role string) {
-	// 1. Determine the volume name for /tmp/ray.
-	// If a Ray container already mounts /tmp/ray, reuse that volume so
-	// the collector shares the same data. Otherwise, create a new emptyDir.
-	rayVolumeName := rayLogsVolumeName
-	for _, c := range podTemplate.Spec.Containers {
-		for _, vm := range c.VolumeMounts {
-			if vm.MountPath == rayLogsPath {
-				rayVolumeName = vm.Name
-				break
-			}
-		}
-		if rayVolumeName != rayLogsVolumeName {
-			break
-		}
-	}
-
-	// Only add a new volume if no existing volume is being reused
-	if rayVolumeName == rayLogsVolumeName {
-		hasVolume := false
-		for _, v := range podTemplate.Spec.Volumes {
-			if v.Name == rayLogsVolumeName {
-				hasVolume = true
-				break
-			}
-		}
-		if !hasVolume {
-			podTemplate.Spec.Volumes = append(podTemplate.Spec.Volumes, corev1.Volume{
-				Name: rayLogsVolumeName,
-				VolumeSource: corev1.VolumeSource{
-					EmptyDir: &corev1.EmptyDirVolumeSource{},
-				},
-			})
-		}
-	}
-
-	rayLogsVolumeMount := corev1.VolumeMount{
-		Name:      rayVolumeName,
-		MountPath: rayLogsPath,
-	}
-
-	// Ray event export env vars — tells Ray to forward events to the collector's HTTP endpoint
-	eventExportEnvVars := []corev1.EnvVar{
-		{
-			Name:  "RAY_enable_ray_event",
-			Value: "true",
-		},
-		{
-			Name:  "RAY_enable_core_worker_ray_event_to_aggregator",
-			Value: "true",
-		},
-		{
-			Name:  "RAY_DASHBOARD_AGGREGATOR_AGENT_EVENTS_EXPORT_ADDR",
-			Value: fmt.Sprintf("http://localhost:%d/v1/events", collectorPort),
-		},
-		{
-			Name:  "RAY_DASHBOARD_AGGREGATOR_AGENT_EXPOSABLE_EVENT_TYPES",
-			Value: exposableEventTypes,
-		},
-	}
-
-	// 2. Update all existing containers: add volume mount, env vars, and lifecycle hook
-	for i := range podTemplate.Spec.Containers {
-		c := &podTemplate.Spec.Containers[i]
-		// Only add volume mount if /tmp/ray is not already mounted
-		hasRayLogsMount := false
-		for _, vm := range c.VolumeMounts {
-			if vm.MountPath == rayLogsPath {
-				hasRayLogsMount = true
-				break
-			}
-		}
-		if !hasRayLogsMount {
-			c.VolumeMounts = append(c.VolumeMounts, rayLogsVolumeMount)
-		}
-		c.Env = append(c.Env, eventExportEnvVars...)
-
-		// Add PostStart lifecycle hook to extract raylet node ID.
-		// Preserves any existing PreStop hook.
-		if c.Lifecycle == nil {
-			c.Lifecycle = &corev1.Lifecycle{}
-		}
-		c.Lifecycle.PostStart = &corev1.LifecycleHandler{
-			Exec: &corev1.ExecAction{
-				Command: []string{"/bin/sh", "-lc", "--", nodeIDScript},
-			},
-		}
-	}
-
-	// 3. Build S3 env vars for collector — matches official kuberay config pattern
-	// (env vars, NOT --runtime-class-config-path). We set BOTH credential
-	// naming conventions on purpose:
-	//   - AWS_S3ID / AWS_S3SECRET / AWS_S3TOKEN — kuberay's storage/s3 reads
-	//     these explicitly (historyserver/pkg/storage/s3/config.go).
-	//   - AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY — required by AWS SDK code
-	//     paths that fall through to the default credential chain (e.g. SigV4
-	//     signing against OCI Object Storage).
-	// AWS_REGION is also required by the SDK for SigV4 even when StorageEndpoint
-	// points at a non-AWS endpoint — without it the collector panics with
-	// MissingRegion before ever issuing a request.
-	collectorS3Env := []corev1.EnvVar{
-		{
-			Name: "AWS_S3ID",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: config.CredentialsSecret,
-					},
-					Key: "AWS_ACCESS_KEY_ID",
-				},
-			},
-		},
-		{
-			Name: "AWS_S3SECRET",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: config.CredentialsSecret,
-					},
-					Key: "AWS_SECRET_ACCESS_KEY",
-				},
-			},
-		},
-		{Name: "AWS_S3TOKEN", Value: ""},
-		{
-			Name: "AWS_ACCESS_KEY_ID",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: config.CredentialsSecret,
-					},
-					Key: "AWS_ACCESS_KEY_ID",
-				},
-			},
-		},
-		{
-			Name: "AWS_SECRET_ACCESS_KEY",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: config.CredentialsSecret,
-					},
-					Key: "AWS_SECRET_ACCESS_KEY",
-				},
-			},
-		},
-		{Name: "AWS_REGION", Value: config.Region},
-		{Name: "S3_BUCKET", Value: config.Bucket},
-		{Name: "S3_ENDPOINT", Value: config.StorageEndpoint},
-		{Name: "S3FORCE_PATH_STYLE", Value: "true"},
-		{Name: "S3DISABLE_SSL", Value: strconv.FormatBool(config.S3DisableSSL)},
-	}
-
-	// Head collector gets additional env vars for dashboard polling
-	if role == "Head" {
-		collectorS3Env = append(collectorS3Env,
-			corev1.EnvVar{Name: "RAY_DASHBOARD_ADDRESS", Value: "http://localhost:8265"},
-			corev1.EnvVar{Name: "RAY_COLLECTOR_ADDITIONAL_ENDPOINTS", Value: "/api/v0/placement_groups?detail=1&limit=10000"},
-			corev1.EnvVar{Name: "RAY_COLLECTOR_POLL_INTERVAL", Value: "30s"},
-		)
-	}
-
-	// 4. Build collector sidecar container using command (not args) per official config
-	collectorContainer := corev1.Container{
-		Name:            "collector",
-		Image:           config.CollectorImage,
-		ImagePullPolicy: corev1.PullIfNotPresent,
-		Command: []string{
-			"collector",
-			fmt.Sprintf("--role=%s", role),
-			"--runtime-class-name=s3",
-			fmt.Sprintf("--ray-cluster-name=%s", clusterName),
-			fmt.Sprintf("--ray-root-dir=%s", "log"),
-			fmt.Sprintf("--events-port=%d", collectorPort),
-		},
-		Env: collectorS3Env,
-		Ports: []corev1.ContainerPort{
-			{
-				Name:          "events",
-				ContainerPort: int32(collectorPort),
-				Protocol:      corev1.ProtocolTCP,
-			},
-		},
-		Resources: corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("100m"),
-				corev1.ResourceMemory: resource.MustParse("128Mi"),
-			},
-		},
-		VolumeMounts: []corev1.VolumeMount{rayLogsVolumeMount},
-	}
-
-	podTemplate.Spec.Containers = append(podTemplate.Spec.Containers, collectorContainer)
 }
 
 // getRayClusterStateFromStatus maps KubeRay v1 cluster state to our internal v2pb.RayClusterState

--- a/helm/michelangelo/templates/core/worker-deployment.yaml
+++ b/helm/michelangelo/templates/core/worker-deployment.yaml
@@ -36,6 +36,11 @@ spec:
           envFrom:
             - secretRef:
                 name: {{ .Values.objectStorage.existingSecret | default (include "michelangelo.objectStorageSecretName" .) }}
+          {{- with .Values.worker.kueue.queueName }}
+          env:
+            - name: KUEUE_QUEUE_NAME
+              value: {{ . | quote }}
+          {{- end }}
           volumeMounts:
             - name: worker-config
               mountPath: /config

--- a/helm/michelangelo/values.yaml
+++ b/helm/michelangelo/values.yaml
@@ -315,6 +315,14 @@ worker:
 
   resources: {}
 
+  # Kueue integration. When queueName is non-empty, the worker sets
+  # KUEUE_QUEUE_NAME on every RayCluster it creates so Kueue can
+  # intercept and queue the workload on the compute cluster.
+  # Set via --set worker.kueue.queueName=user-queue or install Kueue
+  # with `ma sandbox sync --install-kueue`.
+  kueue:
+    queueName: ""
+
 # -----------------------------------------------------------------------------
 # controllermgr — Kubernetes controller manager for Michelangelo CRDs.
 # -----------------------------------------------------------------------------

--- a/python/michelangelo/cli/sandbox/demo/job/kueue/compute-cluster-0.yaml
+++ b/python/michelangelo/cli/sandbox/demo/job/kueue/compute-cluster-0.yaml
@@ -1,0 +1,34 @@
+# Kueue local queue configuration for michelangelo-compute-0.
+# Applied to the compute-0 cluster when running: ma sandbox demo job kueue
+# Jobs with label kueue.x-k8s.io/queue-name=user-queue are intercepted and queued here.
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: default-flavor
+spec: {}
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata:
+  name: cluster-queue
+spec:
+  namespaceSelector: {}
+  queueingStrategy: BestEffortFIFO
+  resourceGroups:
+  - coveredResources: ["cpu", "memory"]
+    flavors:
+    - name: default-flavor
+      resources:
+      - name: cpu
+        nominalQuota: "4"
+      - name: memory
+        nominalQuota: 8Gi
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: LocalQueue
+metadata:
+  name: user-queue
+  namespace: default
+spec:
+  clusterQueue: cluster-queue

--- a/python/michelangelo/cli/sandbox/demo/job/kueue/compute-cluster-0.yaml
+++ b/python/michelangelo/cli/sandbox/demo/job/kueue/compute-cluster-0.yaml
@@ -1,14 +1,14 @@
-# Kueue local queue configuration for michelangelo-compute-0.
-# Applied to the compute-0 cluster when running: ma sandbox demo job kueue
-# Jobs with label kueue.x-k8s.io/queue-name=user-queue are intercepted and queued here.
+# Kueue queue configuration applied to michelangelo-compute-0.
+# Each compute cluster enforces its own quota independently (no MultiKueue).
+# Jobs with label kueue.x-k8s.io/queue-name=user-queue are admitted here.
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: default-flavor
 spec: {}
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: cluster-queue
@@ -25,7 +25,7 @@ spec:
       - name: memory
         nominalQuota: 8Gi
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   name: user-queue

--- a/python/michelangelo/cli/sandbox/demo/job/kueue/compute-cluster-1.yaml
+++ b/python/michelangelo/cli/sandbox/demo/job/kueue/compute-cluster-1.yaml
@@ -1,0 +1,34 @@
+# Kueue worker queue configuration for michelangelo-compute-1.
+# Applied to the compute-1 cluster when running: ma sandbox demo job kueue
+# No AdmissionCheck — jobs arrive via MultiKueue from the sandbox manager.
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: default-flavor
+spec: {}
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata:
+  name: cluster-queue
+spec:
+  namespaceSelector: {}
+  queueingStrategy: BestEffortFIFO
+  resourceGroups:
+  - coveredResources: ["cpu", "memory"]
+    flavors:
+    - name: default-flavor
+      resources:
+      - name: cpu
+        nominalQuota: "4"
+      - name: memory
+        nominalQuota: 8Gi
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: LocalQueue
+metadata:
+  name: user-queue
+  namespace: default
+spec:
+  clusterQueue: cluster-queue

--- a/python/michelangelo/cli/sandbox/demo/job/kueue/compute-cluster-1.yaml
+++ b/python/michelangelo/cli/sandbox/demo/job/kueue/compute-cluster-1.yaml
@@ -1,14 +1,14 @@
-# Kueue worker queue configuration for michelangelo-compute-1.
-# Applied to the compute-1 cluster when running: ma sandbox demo job kueue
-# No AdmissionCheck — jobs arrive via MultiKueue from the sandbox manager.
+# Kueue queue configuration applied to michelangelo-compute-1.
+# Each compute cluster enforces its own quota independently (no MultiKueue).
+# Jobs with label kueue.x-k8s.io/queue-name=user-queue are admitted here.
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: default-flavor
 spec: {}
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: cluster-queue
@@ -25,7 +25,7 @@ spec:
       - name: memory
         nominalQuota: 8Gi
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   name: user-queue

--- a/python/michelangelo/cli/sandbox/demo/job/michelangelo-compute-0.yaml
+++ b/python/michelangelo/cli/sandbox/demo/job/michelangelo-compute-0.yaml
@@ -1,0 +1,14 @@
+# Michelangelo Cluster CR for michelangelo-compute-0.
+# Applied to the sandbox cluster when running: ma sandbox demo job
+# host and port are patched in at runtime from the k3d kubeconfig.
+apiVersion: michelangelo.api/v2
+kind: Cluster
+metadata:
+  name: michelangelo-compute-0
+  namespace: ma-system
+spec:
+  kubernetes:
+    rest:
+      tokenTag: cluster-michelangelo-compute-0-client-token
+      caDataTag: cluster-michelangelo-compute-0-ca-data
+    skus: []

--- a/python/michelangelo/cli/sandbox/demo/job/michelangelo-compute-1.yaml
+++ b/python/michelangelo/cli/sandbox/demo/job/michelangelo-compute-1.yaml
@@ -1,0 +1,14 @@
+# Michelangelo Cluster CR for michelangelo-compute-1.
+# Applied to the sandbox cluster when running: ma sandbox demo job
+# host and port are patched in at runtime from the k3d kubeconfig.
+apiVersion: michelangelo.api/v2
+kind: Cluster
+metadata:
+  name: michelangelo-compute-1
+  namespace: ma-system
+spec:
+  kubernetes:
+    rest:
+      tokenTag: cluster-michelangelo-compute-1-client-token
+      caDataTag: cluster-michelangelo-compute-1-ca-data
+    skus: []

--- a/python/michelangelo/cli/sandbox/resources/michelangelo-config.yaml
+++ b/python/michelangelo/cli/sandbox/resources/michelangelo-config.yaml
@@ -9,3 +9,4 @@ data:
   AWS_ACCESS_KEY_ID: minioadmin
   AWS_SECRET_ACCESS_KEY: minioadmin
   AWS_ENDPOINT_URL: http://minio:9091
+  METRIC_BASE_URL: http://localhost:3000

--- a/python/michelangelo/cli/sandbox/resources/michelangelo-config.yaml
+++ b/python/michelangelo/cli/sandbox/resources/michelangelo-config.yaml
@@ -9,4 +9,3 @@ data:
   AWS_ACCESS_KEY_ID: minioadmin
   AWS_SECRET_ACCESS_KEY: minioadmin
   AWS_ENDPOINT_URL: http://minio:9091
-  METRIC_BASE_URL: http://localhost:3000

--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -27,7 +27,6 @@ _job_demo_dir = _dir / "demo" / "job"
 _job_kueue_demo_dir = _job_demo_dir / "kueue"
 
 _KUEUE_VERSION = "v0.9.1"
-_KUEUE_MANIFESTS_URL = f"https://github.com/kubernetes-sigs/kueue/releases/download/{_KUEUE_VERSION}/manifests.yaml"
 
 _michelangelo_sandbox_kube_cluster_name = "michelangelo-sandbox"
 _kube_ports = [
@@ -100,7 +99,7 @@ def init_arguments(p: argparse.ArgumentParser):
     create_p.add_argument(
         "--install-kueue",
         action="store_true",
-        help="Install Kueue for job queuing. When combined with --create-compute-cluster, sets up MultiKueue across clusters.",
+        help="Install Kueue for job queuing on the sandbox cluster.",
     )
     create_p.add_argument(
         "--compute-cluster-name",
@@ -175,9 +174,8 @@ def init_arguments(p: argparse.ArgumentParser):
     _ = job_sp.add_parser(
         "kueue",
         help=(
-            "Extend the job demo with Kueue: install Kueue on the sandbox and "
-            "both compute clusters, and wire up MultiKueue for distributed "
-            "job scheduling."
+            "Extend the job demo with Kueue: install Kueue on each compute cluster "
+            "for local quota enforcement on Ray workloads."
         ),
     )
 
@@ -625,72 +623,24 @@ def _create_bucket_setup(bucket_names):
 
 
 def _install_kueue(helm_existing_repos, links, ns):
-    """Install Kueue on the control-plane cluster via Helm and apply queue config.
-
-    When --create-compute-cluster is also set, installs Kueue on the compute
-    cluster as a MultiKueue worker and wires up MultiKueue between the two clusters.
-    """
+    """Install Kueue on the sandbox cluster via Helm."""
     _kueue_repo = "https://charts.kueue.x-k8s.io"
     if "kueue" not in helm_existing_repos:
         _exec("helm", "repo", "add", "kueue", _kueue_repo)
         _exec("helm", "repo", "update")
 
-    # Install Kueue on the control-plane (MultiKueue manager)
     _exec(
         "helm", "upgrade", "--install", "kueue", "kueue/kueue",
         "--namespace", "kueue-system",
         "--create-namespace",
+        "--version", _KUEUE_VERSION,
         "--set", "manageJobsWithoutQueueName=false",
+        "--set", "integrations.frameworks={ray.io/v1/RayCluster}",
+        "--wait",
+        "--timeout", "5m",
     )
 
-    create_compute = getattr(ns, "create_compute_cluster", False)
-    compute_cluster_name = getattr(ns, "compute_cluster_name", _default_compute_kube_cluster_name)
-    kube_compute_ctx = f"k3d-{compute_cluster_name}"
-
-    if create_compute:
-        # Apply manager-side queue config (includes MultiKueue admission check)
-        _kube_apply(_scripts_kueue_dir / "compute-0-kueue.yaml")
-
-        # Install Kueue on the compute cluster (MultiKueue worker)
-        _exec(
-            "helm", "upgrade", "--install", "kueue", "kueue/kueue",
-            "--kube-context", kube_compute_ctx,
-            "--namespace", "kueue-system",
-            "--create-namespace",
-            "--set", "manageJobsWithoutQueueName=false",
-        )
-
-        # Apply worker-side queue config
-        _exec(
-            "kubectl", "--context", kube_compute_ctx,
-            "apply", "-f", str(_scripts_kueue_dir / "compute-1-kueue.yaml"),
-        )
-
-        # Create MultiKueue kubeconfig secret on the control plane
-        compute_kubeconfig = subprocess.check_output(
-            ["k3d", "kubeconfig", "get", compute_cluster_name]
-        ).decode()
-        secret_manifest = subprocess.check_output([
-            "kubectl", "create", "secret", "generic",
-            f"multikueue-{compute_cluster_name}-kubeconfig",
-            "--from-literal", f"kubeconfig={compute_kubeconfig}",
-            "--namespace", "kueue-system",
-            "--dry-run=client", "-o", "yaml",
-        ]).decode()
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
-            f.write(secret_manifest)
-            secret_path = f.name
-        _exec("kubectl", "apply", "-f", secret_path)
-        import os
-        os.unlink(secret_path)
-
-        # Apply MultiKueue config (MultiKueueCluster + MultiKueueConfig + AdmissionCheck)
-        _kube_apply(_scripts_kueue_dir / "multikueue.yaml")
-
-        print(f"✅ MultiKueue configured: control-plane → {compute_cluster_name}")
-    else:
-        # Single-cluster mode: simple queue on the sandbox itself
-        _kube_apply(_scripts_kueue_dir / "compute-0-kueue.yaml")
+    _kube_apply(_scripts_kueue_dir / "compute-0-kueue.yaml")
 
     if "grafana" not in ns.exclude:
         links.append((
@@ -2082,66 +2032,23 @@ def _create_job_compute_clusters():
     print("Run 'ma sandbox demo job kueue' to add Kueue job scheduling on top.")
 
 
-def _install_kueue_on_cluster(context: str):
-    """Install Kueue on the given cluster by applying the GitHub release manifests."""
-    import urllib.request
+def _install_kueue_on_cluster(context: str, helm_existing_repos: str = ""):
+    """Install Kueue on a compute cluster via Helm with RayCluster integration enabled."""
+    _kueue_repo = "https://charts.kueue.x-k8s.io"
+    if "kueue" not in helm_existing_repos:
+        _exec("helm", "repo", "add", "kueue", _kueue_repo)
+        _exec("helm", "repo", "update")
 
-    print(f"  Downloading Kueue {_KUEUE_VERSION} manifests...")
-    with tempfile.NamedTemporaryFile(mode="wb", suffix=".yaml", delete=False) as f:
-        with urllib.request.urlopen(_KUEUE_MANIFESTS_URL) as resp:
-            f.write(resp.read())
-        manifests_path = f.name
-    try:
-        _exec(
-            "kubectl", "--context", context,
-            "apply", "--server-side", "-f", manifests_path,
-        )
-    finally:
-        import os as _os
-        _os.unlink(manifests_path)
-
-    # Wait for all Kueue CRDs to be established before callers apply queue config
-    for crd in [
-        "resourceflavors.kueue.x-k8s.io",
-        "clusterqueues.kueue.x-k8s.io",
-        "localqueues.kueue.x-k8s.io",
-    ]:
-        _exec(
-            "kubectl", "--context", context,
-            "wait", "--for=condition=established",
-            f"crd/{crd}",
-            "--timeout=120s",
-        )
-
-    # The kube-rbac-proxy sidecar in Kueue v0.9.x uses gcr.io/kubebuilder images that
-    # are no longer available. Remove it — the sandbox demo only needs the main manager.
-    import json as _json
-    try:
-        containers = subprocess.check_output([
-            "kubectl", "--context", context,
-            "get", "deployment", "kueue-controller-manager",
-            "-n", "kueue-system",
-            "-o", "jsonpath={range .spec.template.spec.containers[*]}{.name}{'\\n'}{end}",
-        ], stderr=subprocess.DEVNULL).decode().strip().splitlines()
-        if "kube-rbac-proxy" in containers:
-            idx = containers.index("kube-rbac-proxy")
-            patch = _json.dumps([{"op": "remove", "path": f"/spec/template/spec/containers/{idx}"}])
-            _exec(
-                "kubectl", "--context", context,
-                "patch", "deployment", "kueue-controller-manager",
-                "-n", "kueue-system",
-                "--type=json", f"-p={patch}",
-            )
-    except subprocess.CalledProcessError:
-        pass
-
-    # Wait for the controller-manager (and its webhook) to be ready
     _exec(
-        "kubectl", "--context", context,
-        "wait", "--for=condition=available",
-        "deployment/kueue-controller-manager",
-        "-n", "kueue-system",
-        "--timeout=120s",
+        "helm", "upgrade", "--install", "kueue", "kueue/kueue",
+        "--kube-context", context,
+        "--namespace", "kueue-system",
+        "--create-namespace",
+        "--version", _KUEUE_VERSION,
+        "--set", "manageJobsWithoutQueueName=false",
+        "--set", "integrations.frameworks={ray.io/v1/RayCluster}",
+        "--wait",
+        "--timeout", "5m",
     )
 
 
@@ -2150,19 +2057,22 @@ def _create_job_demo_crs():
 
     Assumes _create_job_compute_clusters() has already run (or clusters already exist).
     After this runs:
-    - Kueue is installed on each compute cluster with a ClusterQueue + LocalQueue
-    - MA job controller routes jobs directly to a compute cluster via Cluster CRs
-    - Local Kueue on each cluster enforces quota
-    - Set KUEUE_QUEUE_NAME=user-queue in michelangelo-config to enable queuing.
+    - Kueue is installed on each compute cluster with RayCluster integration enabled
+    - A ClusterQueue 'cluster-queue' and LocalQueue 'user-queue' exist on each cluster
+    - Set KUEUE_QUEUE_NAME=user-queue in michelangelo-config to enable queuing
     """
-    # Ensure compute clusters exist first
     _create_job_compute_clusters()
+
+    try:
+        helm_existing_repos = subprocess.check_output(["helm", "repo", "list"]).decode()
+    except subprocess.CalledProcessError:
+        helm_existing_repos = ""
 
     cluster_names = [name for name, _ in _demo_compute_clusters]
 
     for cluster_name, kueue_yaml in _demo_compute_clusters:
-        print(f"\n  📦 Installing Kueue on {cluster_name}...")
-        _install_kueue_on_cluster(f"k3d-{cluster_name}")
+        print(f"\n📦 Installing Kueue on {cluster_name}...")
+        _install_kueue_on_cluster(f"k3d-{cluster_name}", helm_existing_repos)
         _exec(
             "kubectl", "--context", f"k3d-{cluster_name}",
             "apply", "-f", str(kueue_yaml),
@@ -2172,11 +2082,8 @@ def _create_job_demo_crs():
     print("📋 What was set up:")
     print(f"  • Kueue installed on: {', '.join(cluster_names)}")
     print("  • Each cluster has a ClusterQueue 'cluster-queue' and LocalQueue 'user-queue'")
-    print("  • Set KUEUE_QUEUE_NAME=user-queue in michelangelo-config to enable job queuing")
-
-
-
-def _create_pipeline_demo_crs():
+    print("  • RayCluster integration enabled — queue label is enforced on Ray workloads")
+    print("  • Set KUEUE_QUEUE_NAME=user-queue in michelangelo-config to enable queuing")
     """Create a pipeline demo for the sandbox cluster for demo purposes."""
     pipeline_demo_dir = _dir / "demo" / "pipeline"
     for yaml_file in pipeline_demo_dir.glob("*.yaml"):

--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -29,33 +29,75 @@ _job_kueue_demo_dir = _job_demo_dir / "kueue"
 _KUEUE_VERSION = "v0.9.1"
 
 _michelangelo_sandbox_kube_cluster_name = "michelangelo-sandbox"
-_kube_ports = [
+
+_cadence_domain = "default"
+_default_compute_kube_cluster_name = "michelangelo-compute-0"
+
+# Path to the Michelangelo Helm chart (relative to this file)
+_chart_dir = Path(__file__).parent.parent.parent.parent.parent / "helm" / "michelangelo"
+
+# Path to values-k3d.yaml — used to read Helm-managed NodePorts dynamically
+_values_k3d_path = _chart_dir / "values-k3d.yaml"
+
+# Hardcoded infra ports — services NOT installed by the michelangelo Helm chart.
+# These are raw YAML resources deployed by _deploy_services() directly.
+_infra_ports = [
     "3306:30001",  # MySQL
     "9091:30007",  # MinIO
     "9090:30008",  # MinIO Console
-    "15566:30009",  # Michelangelo API Server
-    "8081:30010",  # Envoy gRPC --> gRPC-web proxy
-    "8090:30011",  # Michelangelo UI
     "3000:30012",  # Grafana
     "9092:30015",  # Prometheus
     "5001:30013",  # MLflow Tracking Server
 ]
 
-# Workflow engine ports
-_cadence_ports = [
-    "7833:30002",  # Cadence gRPC
-    "7933:30003",  # Cadence TChannel
-    "8088:30004",  # Cadence Web
-]
-
-# Ray framework ports
+# Ray framework ports (not in Helm chart)
 _ray_ports = [
     "10001:10001",  # Ray client port
     "8265:8265",  # Ray dashboard
 ]
 
-_cadence_domain = "default"
-_default_compute_kube_cluster_name = "michelangelo-compute-0"
+# Maps host-side port → dotted path in values-k3d.yaml where NodePort is defined.
+# Read at cluster-create time so a chart change propagates without editing this file.
+_helm_nodeport_map = [
+    ("15566", ("apiserver", "service", "nodePort")),  # Michelangelo API Server
+    ("8081", ("envoy", "service", "nodePort")),  # Envoy gRPC-Web proxy
+    ("8090", ("ui", "service", "nodePort")),  # Michelangelo UI
+    ("8088", ("cadence", "web", "service", "nodePort")),  # Cadence Web
+    ("8080", ("temporal", "web", "service", "nodePort")),  # Temporal Web
+]
+
+
+def _helm_chart_ports(workflow: str) -> list[str]:
+    """Read control plane NodePorts from values-k3d.yaml.
+
+    Returns host:nodeport strings for k3d's -p flag. NodePorts come from
+    values-k3d.yaml (single source of truth). Host ports are sandbox
+    conventions for localhost access.
+
+    Cadence Web is included only when workflow=cadence; Temporal Web only
+    when workflow=temporal.
+    """
+    with open(_values_k3d_path) as f:
+        values = yaml.safe_load(f) or {}
+
+    ports: list[str] = []
+    for host_port, path in _helm_nodeport_map:
+        # Skip engine-specific Web UIs based on active workflow
+        if path[0] == "cadence" and workflow != "cadence":
+            continue
+        if path[0] == "temporal" and workflow != "temporal":
+            continue
+        node = values
+        for key in path:
+            node = (node or {}).get(key)
+        if node is None:
+            raise ValueError(
+                f"values-k3d.yaml is missing NodePort at "
+                f"{'.'.join(str(k) for k in path)} "
+                f"(needed for host port {host_port})"
+            )
+        ports.append(f"{host_port}:{node}")
+    return ports
 
 
 def init_arguments(p: argparse.ArgumentParser):
@@ -67,8 +109,8 @@ def init_arguments(p: argparse.ArgumentParser):
         "--exclude",
         help=(
             "Excludes specified services. "
-            "Available options: apiserver, controllermgr, ui, worker, "
-            "prometheus, grafana"
+            "Control plane (Helm): apiserver, controllermgr, ui, worker. "
+            "Infrastructure: prometheus, grafana, ray, spark."
         ),
         nargs="+",
         default=[],
@@ -102,6 +144,14 @@ def init_arguments(p: argparse.ArgumentParser):
         help="Install Kueue for job queuing on the sandbox cluster.",
     )
     create_p.add_argument(
+        "--set",
+        dest="helm_set",
+        action="append",
+        metavar="KEY=VALUE",
+        default=[],
+        help="Pass arbitrary --set KEY=VALUE flags through to helm upgrade/install.",
+    )
+    create_p.add_argument(
         "--compute-cluster-name",
         default=_default_compute_kube_cluster_name,
         help=(
@@ -123,8 +173,8 @@ def init_arguments(p: argparse.ArgumentParser):
         "--exclude",
         help=(
             "Excludes specified services. "
-            "Available options: apiserver, controllermgr, ui, worker, "
-            "prometheus, grafana"
+            "Control plane (Helm): apiserver, controllermgr, ui, worker. "
+            "Infrastructure: prometheus, grafana, ray, spark."
         ),
         nargs="+",
         default=[],
@@ -150,7 +200,15 @@ def init_arguments(p: argparse.ArgumentParser):
     sync_p.add_argument(
         "--install-kueue",
         action="store_true",
-        help="Install Kueue for job queuing.",
+        help="Install Kueue for job queuing on the sandbox cluster.",
+    )
+    sync_p.add_argument(
+        "--set",
+        dest="helm_set",
+        metavar="KEY=VALUE",
+        action="append",
+        default=[],
+        help="Pass arbitrary --set KEY=VALUE flags through to helm upgrade/install.",
     )
 
     demo_p = sp.add_parser(
@@ -163,20 +221,14 @@ def init_arguments(p: argparse.ArgumentParser):
     _ = demo_sp.add_parser("inference", help="Create inference server demo resources")
     job_p = demo_sp.add_parser(
         "job",
-        help=(
-            "Create two compute clusters and register them with the Michelangelo "
-            "scheduler for Ray job execution."
-        ),
+        help="Create two compute clusters and register them with the Michelangelo scheduler for Ray job execution.",
     )
     job_sp = job_p.add_subparsers(
         dest="job_action", required=False, help="Job demo type to create"
     )
     _ = job_sp.add_parser(
         "kueue",
-        help=(
-            "Extend the job demo with Kueue: install Kueue on each compute cluster "
-            "for local quota enforcement on Ray workloads."
-        ),
+        help="Extend the job demo with Kueue: install Kueue on each compute cluster for local quota enforcement on Ray workloads.",
     )
 
     delete_p = sp.add_parser("delete", help="Delete the cluster.")
@@ -228,7 +280,7 @@ def run(ns: argparse.Namespace):
 
 def _create(ns: argparse.Namespace):
     assert ns
-    ports = _kube_ports + ([] if ns.workflow == "temporal" else _cadence_ports)
+    ports = _infra_ports + _helm_chart_ports(ns.workflow)
     args = [
         "k3d",
         "cluster",
@@ -295,126 +347,420 @@ def _sync(ns: argparse.Namespace):
         "--timeout=120s",
     )
 
-    # Delete only the Michelangelo application pods/deployments.
+    # Upgrade or install the control plane via Helm.
     # Infrastructure (mysql, cadence, minio, grafana, prometheus) is left running.
-    # Worker and controllermgr are Pods (not Deployments) so they must be deleted
-    # explicitly; kubectl apply on a Completed pod is a no-op.
-    app_pods = [
-        "michelangelo-apiserver",
-        "envoy",
-        "michelangelo-worker",
-        "michelangelo-controllermgr",
-    ]
-    app_deployments = ["michelangelo-ui"]
-    print("Restarting app pods:", ", ".join(app_pods + app_deployments))
-    for pod in app_pods:
-        subprocess.run(
-            [
-                "kubectl",
-                "delete",
-                "pod",
-                pod,
-                "--force",
-                "--grace-period=0",
-                "--ignore-not-found=true",
-            ],
-            check=False,
-            capture_output=True,
-        )
-    for dep in app_deployments:
-        subprocess.run(
-            [
-                "kubectl",
-                "delete",
-                "deployment",
-                dep,
-                "--force",
-                "--grace-period=0",
-                "--ignore-not-found=true",
-            ],
-            check=False,
-            capture_output=True,
-        )
-    # Delete and re-apply app configs/secrets so new values take effect.
-    app_configs = [
-        "michelangelo-config",
-        "michelangelo-apiserver-config",
-        "envoy-config",
-        "public-config",
-        "michelangelo-worker-config",
-        "michelangelo-controllermgr-config",
-    ]
-    for cm in app_configs:
-        subprocess.run(
-            ["kubectl", "delete", "configmap", cm, "--ignore-not-found=true"],
-            check=False,
-            capture_output=True,
-        )
-    # minio-credentials Secret is intentionally NOT deleted here — it is
-    # managed by _ensure_credentials_secret() which creates it only when it
-    # does not already exist. This lets the GCP sandbox VM pre-configure its
-    # own credentials without sync overwriting them each run.
 
-    print("Waiting for old app pods to fully terminate...")
-    subprocess.run(
-        ["kubectl", "wait", "pod", "--all", "--for=delete", "--timeout=60s"],
-        check=False,
+    _refresh_mysql_schema()
+
+    _ensure_credentials_secret()
+    _helm_ensure_repos()
+    helm_args = _build_helm_set_args(ns)
+
+    # Check if there is a healthy deployed release we can upgrade.
+    status_result = subprocess.run(
+        ["helm", "status", "michelangelo", "-o", "json"],
         capture_output=True,
+        text=True,
+    )
+    release_healthy = (
+        status_result.returncode == 0 and '"status":"deployed"' in status_result.stdout
     )
 
-    _deploy_app_services(ns)
+    if release_healthy:
+        # Healthy release: upgrade in-place, keeping infra running.
+        _exec(
+            "helm",
+            "upgrade",
+            "michelangelo",
+            str(_chart_dir),
+            "-f",
+            str(_chart_dir / "values-k3d.yaml"),
+            "--dependency-update",
+            "--reuse-values",
+            *helm_args,
+        )
+        # Force-restart app deployments so they always pick up the latest
+        # configmap values (helm upgrade only restarts pods when the pod
+        # template spec changes, but values-only changes may not alter it).
+        for deploy in (
+            "michelangelo-apiserver",
+            "michelangelo-controllermgr",
+            "michelangelo-worker",
+        ):
+            subprocess.run(
+                [
+                    "kubectl",
+                    "rollout",
+                    "restart",
+                    f"deployment/{deploy}",
+                    "-n",
+                    "default",
+                ],
+                capture_output=True,
+            )
+        # Wait for the restarted rollouts to complete before proceeding.
+        for deploy in (
+            "michelangelo-apiserver",
+            "michelangelo-controllermgr",
+            "michelangelo-worker",
+        ):
+            subprocess.run(
+                [
+                    "kubectl",
+                    "rollout",
+                    "status",
+                    f"deployment/{deploy}",
+                    "-n",
+                    "default",
+                    "--timeout=300s",
+                ],
+                capture_output=False,
+            )
+    else:
+        # Missing or broken release: uninstall cleanly, then reinstall from scratch.
+        subprocess.run(
+            ["helm", "uninstall", "michelangelo", "--ignore-not-found", "--wait"],
+            capture_output=False,
+        )
+        # After uninstall, force-delete any remaining Services from the chart
+        # to free their NodePorts before reinstalling.
+        _helm_delete_services(helm_args)
+        _helm_adopt_orphaned_resources(helm_args)
+        _exec(
+            "helm",
+            "install",
+            "michelangelo",
+            str(_chart_dir),
+            "-f",
+            str(_chart_dir / "values-k3d.yaml"),
+            "--dependency-update",
+            *helm_args,
+        )
+
+    _helm_wait(ns)
+
+
+def _refresh_mysql_schema():
+    """Drop and recreate the michelangelo database from the current schema.
+
+    The schema lives in mysql-ingester.yaml as a ConfigMap that an init Job
+    applies via `mysql < init-schema.sql`. The schema uses CREATE TABLE IF
+    NOT EXISTS, so re-running the Job against an existing database is a
+    no-op and won't pick up renames or column changes. To get a clean
+    application of the current schema we drop the database first, then
+    re-apply the init Job.
+    """
+    print("Refreshing MySQL schema (drop + recreate michelangelo database)...")
+    subprocess.run(
+        [
+            "kubectl",
+            "exec",
+            "mysql",
+            "--",
+            "mysql",
+            "-uroot",
+            "-proot",
+            "-e",
+            "DROP DATABASE IF EXISTS michelangelo;",
+        ],
+        check=True,
+    )
+    # The init Job from the previous sync is already in Completed state;
+    # kubectl apply on a Completed Job is a no-op (Job spec is immutable),
+    # so we have to delete it before re-apply.
+    subprocess.run(
+        ["kubectl", "delete", "job", "ingester-schema-init", "--ignore-not-found=true"],
+        check=False,
+    )
+    _kube_apply(_dir / "resources" / "mysql-ingester.yaml")
+    print("Waiting for ingester-schema-init Job to complete...")
+    subprocess.run(
+        [
+            "kubectl",
+            "wait",
+            "--for=condition=complete",
+            "job/ingester-schema-init",
+            "--timeout=120s",
+        ],
+        check=True,
+    )
+
+
+def _helm_ensure_repos():
+    """Add cadence and temporal helm repos if not already present."""
+    try:
+        helm_existing_repos = subprocess.check_output(["helm", "repo", "list"]).decode()
+    except subprocess.CalledProcessError:
+        helm_existing_repos = ""
+    if "cadence-workflow" not in helm_existing_repos:
+        _exec(
+            "helm",
+            "repo",
+            "add",
+            "cadence-workflow",
+            "https://cadence-workflow.github.io/cadence-charts",
+        )
+    if "temporal" not in helm_existing_repos:
+        _exec("helm", "repo", "add", "temporal", "https://go.temporal.io/helm-charts")
+
+
+def _helm_delete_services(helm_args: list[str]):
+    """Delete Services that would conflict with the chart's NodePorts.
+
+    After helm uninstall, old Services (possibly with different names from
+    a previous install structure) can still hold NodePorts. We scan all
+    Services in the cluster for conflicting NodePorts and delete them.
+    """
+    # Collect the NodePorts the chart wants to allocate.
+    result = subprocess.run(
+        [
+            "helm",
+            "template",
+            "michelangelo",
+            str(_chart_dir),
+            "-f",
+            str(_chart_dir / "values-k3d.yaml"),
+            *helm_args,
+        ],
+        capture_output=True,
+        text=True,
+    )
+    wanted_ports: set[int] = set()
+    if result.returncode == 0:
+        for doc in yaml.safe_load_all(result.stdout):
+            if not doc or doc.get("kind") != "Service":
+                continue
+            for port in (doc.get("spec") or {}).get("ports") or []:
+                if np := port.get("nodePort"):
+                    wanted_ports.add(int(np))
+
+    if not wanted_ports:
+        return
+
+    # Find any Services in the cluster using those NodePorts and delete them.
+    _jsonpath = (
+        "{range .items[*]}"
+        "{.metadata.namespace}/{.metadata.name}"
+        ":{.spec.ports[*].nodePort} {end}"
+    )
+    all_svcs = subprocess.run(
+        [
+            "kubectl",
+            "get",
+            "service",
+            "--all-namespaces",
+            "-o",
+            f"jsonpath={_jsonpath}",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    for entry in all_svcs.stdout.split():
+        if ":" not in entry:
+            continue
+        ns_name, ports_str = entry.split(":", 1)
+        namespace, name = ns_name.split("/", 1)
+        for p in ports_str.split():
+            try:
+                if int(p) in wanted_ports:
+                    print(
+                        f"[sandbox] deleting conflicting service"
+                        f" {namespace}/{name} (NodePort {p})"
+                    )
+                    subprocess.run(
+                        [
+                            "kubectl",
+                            "delete",
+                            "service",
+                            name,
+                            "-n",
+                            namespace,
+                            "--ignore-not-found=true",
+                        ],
+                        capture_output=True,
+                    )
+                    break
+            except ValueError:
+                pass
+
+
+def _helm_adopt_orphaned_resources(helm_args: list[str]):
+    """Clean up resources that would block helm upgrade --install.
+
+    Helm 3 refuses to manage resources missing its ownership annotations.
+    We render the chart manifests and for each resource that exists in the
+    cluster WITHOUT Helm ownership labels, we delete it so the install can
+    recreate it cleanly. Resources already managed by Helm (correct labels)
+    are left untouched.
+    """
+    result = subprocess.run(
+        [
+            "helm",
+            "template",
+            "michelangelo",
+            str(_chart_dir),
+            "-f",
+            str(_chart_dir / "values-k3d.yaml"),
+            *helm_args,
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return
+    for doc in yaml.safe_load_all(result.stdout):
+        if not doc:
+            continue
+        kind = doc.get("kind", "")
+        name = (doc.get("metadata") or {}).get("name", "")
+        namespace = (doc.get("metadata") or {}).get("namespace", "default")
+        if not kind or not name:
+            continue
+        # Check if this resource exists and lacks Helm ownership annotations.
+        get_result = subprocess.run(
+            [
+                "kubectl",
+                "get",
+                f"{kind.lower()}/{name}",
+                "-n",
+                namespace,
+                "-o",
+                "jsonpath={.metadata.annotations.meta\\.helm\\.sh/release-name}",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if get_result.returncode != 0:
+            continue  # resource doesn't exist — no action needed
+        if get_result.stdout.strip() == "michelangelo":
+            continue  # already owned by this release — leave it
+        # Resource exists but is not owned by Helm — delete it so Helm can recreate.
+        subprocess.run(
+            [
+                "kubectl",
+                "delete",
+                f"{kind.lower()}/{name}",
+                "-n",
+                namespace,
+                "--ignore-not-found=true",
+            ],
+            capture_output=True,
+        )
 
 
 def _deploy_app_services(ns: argparse.Namespace):
-    """Apply only Michelangelo application resources.
-
-    Applies: apiserver, envoy, ui, worker, controllermgr.
-    Called by ``_sync`` to do a fast redeploy without touching infrastructure.
-    """
-    assert ns
-    app_resources = [
-        "michelangelo-config.yaml",
-    ]
-    if "apiserver" not in ns.exclude:
-        app_resources.append("michelangelo-apiserver.yaml")
-    if "ui" not in ns.exclude:
-        app_resources.append("envoy.yaml")
-        app_resources.append("michelangelo-ui.yaml")
-
-    for r in app_resources:
-        _kube_apply(_dir / "resources" / r)
-
-    # Create credentials secrets only if they don't already exist, so a
-    # pre-configured sandbox VM keeps its own credentials across CI runs.
+    """Install the Michelangelo control plane via Helm."""
     _ensure_credentials_secret()
+    _helm_ensure_repos()
+    helm_args = _build_helm_set_args(ns)
+    _helm_adopt_orphaned_resources(helm_args)
+    _exec(
+        "helm",
+        "upgrade",
+        "--install",
+        "michelangelo",
+        str(_chart_dir),
+        "-f",
+        str(_chart_dir / "values-k3d.yaml"),
+        "--dependency-update",
+        *helm_args,
+    )
+    _helm_wait(ns)
 
-    # Patch michelangelo-config ConfigMap to match the live secret, so
-    # Ray pods (which consume the ConfigMap via envFrom) also get the
-    # correct credentials.
-    _sync_config_from_secret()
 
-    if ns.workflow == "cadence":
-        # Domain registration is a one-time setup done by _create.
-        # _sync keeps infrastructure (including Cadence) running between runs,
-        # so the domain is already registered — no need to re-register.
-        if "worker" not in ns.exclude:
-            _kube_apply(_dir / "resources/michelangelo-worker.yaml")
-        if "controllermgr" not in ns.exclude:
-            _kube_apply(_dir / "resources/michelangelo-controllermgr.yaml")
+def _helm_wait(ns: argparse.Namespace):
+    """Wait for the Michelangelo Helm release pods to become ready.
 
-    # Wait for all app pods to become ready (includes worker + controllermgr if
-    # deployed).
-    wait_timeout = getattr(ns, "wait_timeout", 600)
+    Uses a two-stage wait:
+    1. Wait for the apiserver Deployment to become Available — waits on the
+       Deployment object (created immediately by Helm) so there is no
+       'no matching resources found' race. The apiserver runs a schema-init
+       container so it takes 30-60s longer than the other services.
+    2. Wait for all remaining Helm-managed Deployments to become Available.
+    """
+    timeout = getattr(ns, "wait_timeout", 600)
+    instance_selector = "app.kubernetes.io/instance=michelangelo"
+
+    # Stage 1: apiserver Deployment (schema-init can take 30-60s)
+    print("Waiting for apiserver to become available (schema-init runs first)...")
     _exec(
         "kubectl",
         "wait",
-        "--for=condition=ready",
-        "pod",
+        "deployment",
         "-l",
-        "app in (michelangelo-apiserver,envoy,michelangelo-ui,"
-        "michelangelo-worker,michelangelo-controllermgr)",
-        f"--timeout={wait_timeout}s",
+        f"{instance_selector},app.kubernetes.io/component=apiserver",
+        "--for=condition=available",
+        "--timeout=180s",
     )
+
+    # Stage 2: remaining Helm-managed Deployments
+    print("Waiting for remaining control plane services...")
+    _exec(
+        "kubectl",
+        "wait",
+        "deployment",
+        "-l",
+        instance_selector,
+        "--for=condition=available",
+        f"--timeout={timeout}s",
+    )
+
+
+def _build_helm_set_args(ns: argparse.Namespace) -> list[str]:
+    """Convert sandbox CLI flags to Helm --set arguments for the control plane."""
+    args = []
+
+    # Workflow engine — cadence is the default in values-k3d.yaml.
+    # Always set the engine explicitly so that switching --workflow between
+    # runs (e.g. cadence → temporal) overrides any --reuse-values residue.
+    if ns.workflow == "temporal":
+        args += [
+            "--set",
+            "workflow.engine=temporal",
+            "--set",
+            "workflow.endpoint=michelangelo-temporal-frontend:7233",
+            "--set",
+            "cadence.enabled=false",  # ensure cadence subchart is off
+            "--set",
+            "temporal.enabled=true",  # enable temporal subchart
+        ]
+    else:
+        args += [
+            "--set",
+            "workflow.engine=cadence",
+            "--set",
+            "workflow.endpoint=michelangelo-cadence-frontend:7833",
+            "--set",
+            "temporal.enabled=false",  # ensure temporal subchart is off
+            "--set",
+            "cadence.enabled=true",
+        ]
+
+    # Service exclusions → enabled=false toggles
+    exclude_map = {
+        "apiserver": "apiserver.enabled=false",
+        "ui": "ui.enabled=false",
+        "worker": "worker.enabled=false",
+        "controllermgr": "controllermgr.enabled=false",
+    }
+    for svc, helm_arg in exclude_map.items():
+        if svc in getattr(ns, "exclude", []):
+            args += ["--set", helm_arg]
+
+    # envoy is paired with ui — disable both together
+    if "ui" in getattr(ns, "exclude", []):
+        args += ["--set", "envoy.enabled=false"]
+
+    # Kueue: inject KUEUE_QUEUE_NAME into the worker so RayClusters get the
+    # queue label and Kueue on the compute cluster admits them.
+    if "kueue" in getattr(ns, "include_experimental", []) or getattr(ns, "install_kueue", False):
+        args += ["--set", "worker.kueue.queueName=user-queue"]
+
+    # Arbitrary --set passthrough from the caller (e.g. CI workflow)
+    for kv in getattr(ns, "helm_set", []):
+        args += ["--set", kv]
+
+    return args
 
 
 def _deploy_services(ns: argparse.Namespace):
@@ -427,16 +773,40 @@ def _deploy_services(ns: argparse.Namespace):
     ]
     links = []
 
-    # Cadence
+    # Both Cadence and Temporal are now Helm subcharts — engine switching
+    # is handled by cadence.enabled/temporal.enabled --set flags in
+    # _build_helm_set_args(). No separate helm uninstall needed.
 
     if ns.workflow == "cadence":
-        resources.append("cadence.yaml")
+        # Cadence is now installed as a Helm subchart (cadence.enabled=true in
+        # values-k3d.yaml) — no longer deployed as a bare Pod via cadence.yaml.
+        # The Web UI link is printed in helm install NOTES.txt.
         links.append(
             (
                 "Cadence Web UI",
-                "http://localhost:8088/domains/default/workflows",
+                "http://localhost:8088",
                 "",
             )
+        )
+    elif ns.workflow == "temporal":
+        # If switching from a previous cadence install, remove cadence pods.
+        subprocess.run(
+            [
+                "kubectl",
+                "delete",
+                "pod",
+                "cadence",
+                "cadence-web",
+                "--ignore-not-found=true",
+                "--grace-period=0",
+            ],
+            capture_output=True,
+            check=False,
+        )
+        subprocess.run(
+            ["kubectl", "delete", "svc", "cadence", "--ignore-not-found=true"],
+            capture_output=True,
+            check=False,
         )
 
     # MinIO
@@ -447,6 +817,16 @@ def _deploy_services(ns: argparse.Namespace):
             "MinIO Console",
             "http://localhost:9090",
             "[Username: minioadmin; Password: minioadmin]",
+        )
+    )
+
+    # KubeRay History Server (core resource, deployed alongside MinIO)
+    resources.append("history-server.yaml")
+    links.append(
+        (
+            "Ray History Server",
+            "http://localhost:3001",
+            "",
         )
     )
 
@@ -472,31 +852,16 @@ def _deploy_services(ns: argparse.Namespace):
         )
 
     if "apiserver" not in ns.exclude:
-        resources.append("michelangelo-apiserver.yaml")
+        # Installed via Helm by _deploy_app_services() below.
+        pass
     if "ui" not in ns.exclude:
-        resources.append("envoy.yaml")
-        resources.append("michelangelo-ui.yaml")
+        # Installed via Helm by _deploy_app_services() below.
         links.append(
             (
                 "Michelangelo UI",
                 "http://localhost:8090",
                 "",
             )
-        )
-
-    if "fluent-bit" in ns.include_experimental:
-        # Provision a ServiceAccount for fluent-bit DaemonSet execution.
-        _exec(
-            "kubectl",
-            "create",
-            "serviceaccount",
-            "fluent-bit",
-        )
-        resources.extend(
-            [
-                "fluent-bit.yaml",
-                "fluent-bit-config.yaml",
-            ]
         )
 
     if "mlflow" in ns.include_experimental:
@@ -509,10 +874,8 @@ def _deploy_services(ns: argparse.Namespace):
             )
         )
 
-    _kueue_enabled = "kueue" in ns.include_experimental or getattr(ns, "install_kueue", False)
-
     # Determine buckets to create based on enabled services
-    bucket_names = ["logs", "default", "deploy-models"]
+    bucket_names = ["logs", "default", "deploy-models", "ray-history"]
     if "mlflow" in ns.include_experimental:
         bucket_names.append("mlflow")
         print("🪣 Adding MLflow bucket to S3 setup")
@@ -545,25 +908,34 @@ def _deploy_services(ns: argparse.Namespace):
     if "spark" not in ns.exclude:
         _create_spark_operator(helm_existing_repos)
 
-    if _kueue_enabled:
+    if "kueue" in ns.include_experimental or getattr(ns, "install_kueue", False):
         _install_kueue(helm_existing_repos, links, ns)
 
     _kube_wait(timeout=getattr(ns, "wait_timeout", 600))
 
-    if ns.workflow == "temporal":
-        _setup_temporal(links, helm_existing_repos)
-        if "worker" not in ns.exclude:
-            _kube_apply(_dir / "resources/michelangelo-temporal-worker.yaml")
-        if "controllermgr" not in ns.exclude:
-            _kube_apply(_dir / "resources/michelangelo-temporal-controllermgr.yaml")
-    elif ns.workflow == "cadence":
+    # Install the Michelangelo control plane (apiserver, envoy, ui, worker,
+    # controllermgr, and Cadence or Temporal subchart) via Helm.
+    # Must happen BEFORE domain registration — Cadence frontend only exists
+    # after helm install.
+    _deploy_app_services(ns)
+
+    if ns.workflow == "cadence":
         _create_cadence_domain(links)
-        if "worker" not in ns.exclude:
-            _kube_apply(_dir / "resources/michelangelo-worker.yaml")
-        if "controllermgr" not in ns.exclude:
-            _kube_apply(_dir / "resources/michelangelo-controllermgr.yaml")
-    else:
-        raise ValueError(f"Unsupported workflow engine: {ns.workflow}")
+
+    if ns.workflow == "cadence":
+        # Forward Cadence frontend ports to localhost so host-side cadence CLI
+        # can reach the in-cluster Service (ClusterIP, not NodePort in chart).
+        subprocess.Popen(
+            [
+                "kubectl",
+                "port-forward",
+                "svc/michelangelo-cadence-frontend",
+                "7833:7833",
+                "7933:7933",
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
 
     # Create separate compute cluster if requested
     create_compute_cluster = getattr(ns, "create_compute_cluster", False)
@@ -622,8 +994,34 @@ def _create_bucket_setup(bucket_names):
     print(f"📦 Created bucket setup job with buckets: {bucket_names_str}")
 
 
+def _create_spark_operator(helm_existing_repos):
+    if "spark-operator" not in helm_existing_repos:
+        _exec(
+            "helm",
+            "repo",
+            "add",
+            "spark-operator",
+            "https://kubeflow.github.io/spark-operator",
+        )
+        _exec("helm", "repo", "update")
+
+    _exec(
+        "helm",
+        "upgrade",
+        "--install",
+        "spark-operator",
+        "spark-operator/spark-operator",
+        "--namespace",
+        "spark-operator",
+        "--create-namespace",
+        "--wait",
+        "--timeout",
+        "20m",
+    )
+
+
 def _install_kueue(helm_existing_repos, links, ns):
-    """Install Kueue on the sandbox cluster via Helm."""
+    """Install Kueue on the sandbox cluster via Helm with RayCluster integration enabled."""
     _kueue_repo = "https://charts.kueue.x-k8s.io"
     if "kueue" not in helm_existing_repos:
         _exec("helm", "repo", "add", "kueue", _kueue_repo)
@@ -652,29 +1050,23 @@ def _install_kueue(helm_existing_repos, links, ns):
     print("✅ Kueue installed. Set KUEUE_QUEUE_NAME=user-queue in michelangelo-config to enable job queuing.")
 
 
-def _create_spark_operator(helm_existing_repos):
-    if "spark-operator" not in helm_existing_repos:
-        _exec(
-            "helm",
-            "repo",
-            "add",
-            "spark-operator",
-            "https://kubeflow.github.io/spark-operator",
-        )
+def _install_kueue_on_cluster(context: str, helm_existing_repos: str = ""):
+    """Install Kueue on a compute cluster via Helm with RayCluster integration enabled."""
+    _kueue_repo = "https://charts.kueue.x-k8s.io"
+    if "kueue" not in helm_existing_repos:
+        _exec("helm", "repo", "add", "kueue", _kueue_repo)
         _exec("helm", "repo", "update")
 
     _exec(
-        "helm",
-        "upgrade",
-        "--install",
-        "spark-operator",
-        "spark-operator/spark-operator",
-        "--namespace",
-        "spark-operator",
+        "helm", "upgrade", "--install", "kueue", "kueue/kueue",
+        "--kube-context", context,
+        "--namespace", "kueue-system",
         "--create-namespace",
+        "--version", _KUEUE_VERSION,
+        "--set", "manageJobsWithoutQueueName=false",
+        "--set", "integrations.frameworks={ray.io/v1/RayCluster}",
         "--wait",
-        "--timeout",
-        "20m",
+        "--timeout", "5m",
     )
 
 
@@ -712,336 +1104,6 @@ def _create_kuberay_operator(helm_existing_repos):
     )
 
 
-def _setup_temporal(links, helm_existing_repos):
-    if "temporal" not in helm_existing_repos:
-        _exec(
-            "helm",
-            "repo",
-            "add",
-            "temporal",
-            "https://temporalio.github.io/helm-charts",
-        )
-        _exec("helm", "repo", "update")
-
-    # Wait for MySQL to be ready before installing Temporal
-    print("Waiting for MySQL to be ready...")
-    _exec(
-        "kubectl",
-        "wait",
-        "--for=condition=ready",
-        "pod",
-        "mysql",
-        "--timeout=300s",
-    )
-
-    # Wait for MySQL to accept connections
-    print("Waiting for MySQL to accept connections...")
-    _exec(
-        "kubectl",
-        "exec",
-        "mysql",
-        "--",
-        "mysqladmin",
-        "ping",
-        "-u",
-        "root",
-        "-proot",
-        "--silent",
-        "--wait",
-    )
-
-    values_file = _dir / "resources" / "temporal.mysql.yaml"
-
-    _exec(
-        "helm",
-        "install",
-        "temporaltest",
-        "temporal",
-        "--repo",
-        "https://go.temporal.io/helm-charts",
-        "-f",
-        str(values_file),
-        "--set",
-        "elasticsearch.enabled=false",
-        "--set",
-        "prometheus.enabled=false",
-        "--set",
-        "grafana.enabled=false",
-    )
-
-    _exec(
-        "kubectl",
-        "-n",
-        "default",
-        "wait",
-        "--for=condition=available",
-        "deployment",
-        "-l",
-        "app",
-        "--timeout=600s",
-    )
-
-    print("Waiting for Temporal admin tools to be ready...")
-    _exec(
-        "kubectl",
-        "wait",
-        "--for=condition=ready",
-        "pod",
-        "-l",
-        "app.kubernetes.io/component=admintools,app.kubernetes.io/instance=temporaltest",
-        "--timeout=300s",
-    )
-
-    print("Creating database schemas via Temporal admin tools...")
-
-    # Create both temporal databases explicitly
-    print("Creating temporal and temporal_visibility databases...")
-    _exec(
-        "kubectl",
-        "exec",
-        "mysql",
-        "--",
-        "mysql",
-        "-u",
-        "root",
-        "-proot",
-        "-e",
-        "CREATE DATABASE IF NOT EXISTS temporal;",
-    )
-    _exec(
-        "kubectl",
-        "exec",
-        "mysql",
-        "--",
-        "mysql",
-        "-u",
-        "root",
-        "-proot",
-        "-e",
-        "CREATE DATABASE IF NOT EXISTS temporal_visibility;",
-    )
-
-    # Setup temporal database schema
-    print("Setting up temporal database schema...")
-    _exec(
-        "kubectl",
-        "exec",
-        "deployment/temporaltest-admintools",
-        "--",
-        "env",
-        "MYSQL_HOST=mysql",
-        "MYSQL_PORT=3306",
-        "MYSQL_USER=root",
-        "MYSQL_PWD=root",
-        "temporal-sql-tool",
-        "--endpoint",
-        "mysql",
-        "--port",
-        "3306",
-        "--user",
-        "root",
-        "--password",
-        "root",
-        "--database",
-        "temporal",
-        "setup-schema",
-        "-v",
-        "0.0",
-    )
-    _exec(
-        "kubectl",
-        "exec",
-        "deployment/temporaltest-admintools",
-        "--",
-        "env",
-        "MYSQL_HOST=mysql",
-        "MYSQL_PORT=3306",
-        "MYSQL_USER=root",
-        "MYSQL_PWD=root",
-        "temporal-sql-tool",
-        "--endpoint",
-        "mysql",
-        "--port",
-        "3306",
-        "--user",
-        "root",
-        "--password",
-        "root",
-        "--database",
-        "temporal",
-        "update-schema",
-        "-d",
-        "/etc/temporal/schema/mysql/v8/temporal/versioned",
-    )
-
-    # Setup temporal visibility database schema
-    print("Setting up temporal_visibility database schema...")
-    _exec(
-        "kubectl",
-        "exec",
-        "deployment/temporaltest-admintools",
-        "--",
-        "env",
-        "MYSQL_HOST=mysql",
-        "MYSQL_PORT=3306",
-        "MYSQL_USER=root",
-        "MYSQL_PWD=root",
-        "temporal-sql-tool",
-        "--endpoint",
-        "mysql",
-        "--port",
-        "3306",
-        "--user",
-        "root",
-        "--password",
-        "root",
-        "--database",
-        "temporal_visibility",
-        "setup-schema",
-        "-v",
-        "0.0",
-    )
-    _exec(
-        "kubectl",
-        "exec",
-        "deployment/temporaltest-admintools",
-        "--",
-        "env",
-        "MYSQL_HOST=mysql",
-        "MYSQL_PORT=3306",
-        "MYSQL_USER=root",
-        "MYSQL_PWD=root",
-        "temporal-sql-tool",
-        "--endpoint",
-        "mysql",
-        "--port",
-        "3306",
-        "--user",
-        "root",
-        "--password",
-        "root",
-        "--database",
-        "temporal_visibility",
-        "update-schema",
-        "-d",
-        "/etc/temporal/schema/mysql/v8/visibility/versioned",
-    )
-
-    print("Database schemas created. Restarting Temporal...")
-    # Restart Temporal to apply the schemas
-    _exec("helm", "uninstall", "temporaltest")
-    _exec(
-        "helm",
-        "install",
-        "temporaltest",
-        "temporal",
-        "--repo",
-        "https://go.temporal.io/helm-charts",
-        "-f",
-        str(values_file),
-        "--set",
-        "elasticsearch.enabled=false",
-        "--set",
-        "prometheus.enabled=false",
-        "--set",
-        "grafana.enabled=false",
-    )
-
-    _exec(
-        "kubectl",
-        "-n",
-        "default",
-        "wait",
-        "--for=condition=available",
-        "deployment",
-        "-l",
-        "app",
-        "--timeout=600s",
-    )
-
-    # Wait for admin tools to be fully ready and get specific pod name
-    print("Waiting for admin tools to be ready for commands...")
-
-    # Get the specific admin tools pod name for more reliable exec
-    admin_pod_result = subprocess.check_output(
-        [
-            "kubectl",
-            "get",
-            "pod",
-            "-l",
-            "app.kubernetes.io/component=admintools,app.kubernetes.io/instance=temporaltest",
-            "-o",
-            "jsonpath={.items[0].metadata.name}",
-        ],
-        text=True,
-    ).strip()
-
-    # Test kubectl exec readiness with retries
-    max_retries = 12
-    retry_delay = 5
-    for attempt in range(max_retries):
-        try:
-            print(
-                f"Testing admin tools container readiness "
-                f"(attempt {attempt + 1}/{max_retries})..."
-            )
-            subprocess.check_call(
-                [
-                    "kubectl",
-                    "exec",
-                    admin_pod_result,
-                    "-c",
-                    "admin-tools",
-                    "--",
-                    "ls",
-                    "/",
-                ],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-            )
-            print("Admin tools container is ready for commands!")
-            break
-        except subprocess.CalledProcessError:
-            if attempt == max_retries - 1:
-                timeout_seconds = (max_retries - 1) * retry_delay
-                _err_exit(
-                    f"Admin tools container failed to become ready for commands "
-                    f"after {timeout_seconds} seconds"
-                )
-            print(f"Admin tools not ready yet, waiting {retry_delay} seconds...")
-            time.sleep(retry_delay)
-
-    # Register the default namespace in Temporal using specific pod name
-    _exec(
-        "kubectl",
-        "exec",
-        admin_pod_result,
-        "-c",
-        "admin-tools",
-        "--",
-        "tctl",
-        "--address",
-        "temporaltest-frontend:7233",
-        "namespace",
-        "register",
-        "default",
-        "--retention",
-        "72",
-    )
-    # Automatically port-forward Temporal Web UI in the background
-    subprocess.Popen(
-        ["kubectl", "port-forward", "svc/temporaltest-web", "8080:8080"],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
-    subprocess.Popen(
-        ["kubectl", "port-forward", "svc/temporaltest-frontend", "7233:7233"],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
-    links.append(("Temporal Web UI", "http://localhost:8080", ""))
-
-
 def _create_cadence_domain(links):
     """Register the Cadence domain, treating 'already exists' as success.
 
@@ -1049,6 +1111,17 @@ def _create_cadence_domain(links):
     retry up to 20 times.  When infrastructure is kept running between CI
     runs the domain will already be registered; that is not an error.
     """
+    # Wait for Cadence frontend to be ready before registering domain.
+    print("Waiting for Cadence frontend to be ready...")
+    _exec(
+        "kubectl",
+        "wait",
+        "--for=condition=available",
+        "deployment",
+        "-l",
+        "app.kubernetes.io/name=cadence,app.kubernetes.io/component=frontend",
+        "--timeout=300s",
+    )
     pod_name = uuid.uuid4().hex
     args = [
         "kubectl",
@@ -1059,7 +1132,7 @@ def _create_cadence_domain(links):
         "--stdin",
         "--image",
         "ubercadence/cli:v1.2.6",
-        "--env=CADENCE_CLI_ADDRESS=cadence:7933",
+        "--env=CADENCE_CLI_ADDRESS=michelangelo-cadence-frontend:7933",
         "--command",
         "--",
         "cadence",
@@ -1158,6 +1231,14 @@ def _create_demo_crs(ns: argparse.Namespace):
 
 def _delete(ns: argparse.Namespace):
     assert ns
+    # Uninstall the michelangelo Helm release if present.
+    # Credential Secrets have resource-policy: keep so they survive uninstall.
+    subprocess.run(
+        ["helm", "uninstall", "michelangelo"],
+        capture_output=True,
+        check=False,
+    )
+
     # Determine which compute cluster to check for
     compute_cluster = (
         ns.compute_cluster_name
@@ -1195,7 +1276,7 @@ def _kube_create(path: Path):
 
 
 def _ensure_credentials_secret():
-    """Create minio-credentials and aws-credentials Secrets only if absent.
+    """Create object-storage-credentials and aws-credentials Secrets only if absent.
 
     This is deliberately create-only: a sandbox VM that was pre-configured
     with non-default credentials (e.g. the GCP CI runner) keeps its own
@@ -1203,7 +1284,7 @@ def _ensure_credentials_secret():
     default minioadmin credentials from the YAML files on first create.
     """
     for secret_name, yaml_file in [
-        ("minio-credentials", "minio-credentials.yaml"),
+        ("object-storage-credentials", "object-storage-credentials.yaml"),
         ("aws-credentials", "aws-credentials.yaml"),
     ]:
         exists = (
@@ -1224,20 +1305,20 @@ def _ensure_credentials_secret():
 
 
 def _sync_config_from_secret():
-    """Patch michelangelo-config ConfigMap credentials from minio-credentials Secret.
+    """Patch michelangelo-config ConfigMap credentials from object-storage-credentials.
 
     Ray pods consume the michelangelo-config ConfigMap via envFrom. After the
     ConfigMap is (re)applied from the YAML file (which contains minioadmin
     defaults), this function overwrites the credential fields with whatever
-    is actually in the minio-credentials Secret, so all consumers see the
-    same credentials.
+    is actually in the object-storage-credentials Secret, so all consumers see
+    the same credentials.
     """
     result = subprocess.run(
         [
             "kubectl",
             "get",
             "secret",
-            "minio-credentials",
+            "object-storage-credentials",
             "-o",
             "jsonpath={.data.AWS_ACCESS_KEY_ID} {.data.AWS_SECRET_ACCESS_KEY}",
         ],
@@ -1276,14 +1357,16 @@ def _kube_apply(path: Path):
 
 def _kube_wait(pods: bool = True, jobs: bool = True, timeout: int = 600):
     if pods:
-        # Wait for all non-job pods to be ready
+        # Wait for all non-job pods to be ready, excluding history-server which
+        # requires a custom-built image (kuberay-historyserver) not available on
+        # Docker Hub. Build it with scripts/kuberay/build-kuberay-images.sh first.
         _exec(
             "kubectl",
             "wait",
             "--for=condition=ready",
             "pod",
             "-l",
-            "app",
+            "app,app!=history-server",
             f"--timeout={timeout}s",
         )
     if jobs:
@@ -1699,6 +1782,71 @@ def _create_compute_cluster_secrets(cluster_name: str):
     print(f"\nCreated secrets for cluster '{cluster_name}' in the sandbox cluster")
 
 
+def _setup_inference_server_secrets():
+    """Create RBAC and credentials for inference server cluster access.
+
+    Applies an inference-server-manager ServiceAccount with permissions to
+    manage Deployments, Services, and ConfigMaps (required for Triton provisioning).
+    Stores a long-lived bearer token as a Secret so the clientfactory can build
+    a remote kube client for the sandbox cluster using kubernetes.default.svc:443.
+
+    The CA secret (cluster-michelangelo-sandbox-ca-data) is already created by
+    the sandbox create flow; we only need to provision the token here.
+    """
+    cluster_name = _michelangelo_sandbox_kube_cluster_name
+    token_secret_name = f"cluster-{cluster_name}-is-token"
+
+    # Check if the token secret already exists to make this idempotent.
+    exists = (
+        subprocess.run(
+            ["kubectl", "get", "secret", token_secret_name],
+            capture_output=True,
+        ).returncode
+        == 0
+    )
+    if exists:
+        print(
+            f"Secret '{token_secret_name}' already exists — "
+            "skipping inference server credential setup."
+        )
+        return
+
+    # Apply ServiceAccount + ClusterRole + ClusterRoleBinding.
+    _kube_apply(_dir / "resources" / "rbac-inferenceserver.yaml")
+
+    # Mint a long-lived token (same duration as ray-manager) so the sandbox
+    # does not require frequent re-creation.
+    token_decoded = (
+        subprocess.check_output(
+            [
+                "kubectl",
+                "create",
+                "token",
+                "inference-server-manager",
+                "-n",
+                "default",
+                "--duration=87600h",
+            ]
+        )
+        .decode()
+        .strip()
+    )
+
+    token_secret = {
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "metadata": {"name": token_secret_name, "namespace": "default"},
+        "stringData": {"token": token_decoded},
+    }
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        yaml.dump(token_secret, f)
+        f.flush()
+        _exec("kubectl", "apply", "-f", f.name)
+
+    print(f"Created inference server credentials for cluster '{cluster_name}'")
+
+
 def _create_inference_demo_crs():
     """Create an inference server for the sandbox cluster for demo purposes."""
     print("🚀 Setting up Michelangelo AI Inference Demo...")
@@ -1706,6 +1854,10 @@ def _create_inference_demo_crs():
     # Setup istio with Gateway API
     # This allows usage of HTTPRoutes to route traffic to the inference server.
     _setup_istio_with_gateway_api()
+
+    # Create the SA, RBAC, and token secret that the clientfactory uses to
+    # connect to the sandbox cluster as a ClusterTarget.
+    _setup_inference_server_secrets()
 
     inference_demo_dir = _dir / "demo" / "inference"
     # Create inference server CR
@@ -1969,9 +2121,8 @@ _demo_compute_clusters = [
 def _create_job_compute_clusters():
     """Create two compute clusters and register them with the Michelangelo scheduler.
 
-    Sets up michelangelo-compute-0 and michelangelo-compute-1 as k3d clusters on the
-    same network as the sandbox, installs KubeRay on each, and creates Michelangelo
-    Cluster CRDs in ma-system so the scheduler can route Ray jobs to them.
+    Sets up michelangelo-compute-0 and michelangelo-compute-1 as k3d clusters,
+    installs KubeRay on each, and creates Michelangelo Cluster CRDs in ma-system.
     """
     try:
         helm_existing_repos = subprocess.check_output(["helm", "repo", "list"]).decode()
@@ -1989,8 +2140,6 @@ def _create_job_compute_clusters():
         if cluster_exists:
             print(f"  Cluster {cluster_name} already exists, skipping creation.")
         else:
-            # No host port mapping — clusters are accessed internally via the shared
-            # k3d network; exposing fixed ports would conflict between the two.
             _exec(
                 "k3d", "cluster", "create", cluster_name,
                 "--servers", "1",
@@ -2024,32 +2173,11 @@ def _create_job_compute_clusters():
 
     cluster_names = [name for name, _ in _demo_compute_clusters]
     print("\n✅ Compute clusters ready!")
-    print("📋 What was set up:")
     print(f"  • k3d clusters: {', '.join(cluster_names)}")
     print("  • KubeRay operator installed on each cluster")
     print("  • Michelangelo Cluster CRDs registered in ma-system")
     print()
     print("Run 'ma sandbox demo job kueue' to add Kueue job scheduling on top.")
-
-
-def _install_kueue_on_cluster(context: str, helm_existing_repos: str = ""):
-    """Install Kueue on a compute cluster via Helm with RayCluster integration enabled."""
-    _kueue_repo = "https://charts.kueue.x-k8s.io"
-    if "kueue" not in helm_existing_repos:
-        _exec("helm", "repo", "add", "kueue", _kueue_repo)
-        _exec("helm", "repo", "update")
-
-    _exec(
-        "helm", "upgrade", "--install", "kueue", "kueue/kueue",
-        "--kube-context", context,
-        "--namespace", "kueue-system",
-        "--create-namespace",
-        "--version", _KUEUE_VERSION,
-        "--set", "manageJobsWithoutQueueName=false",
-        "--set", "integrations.frameworks={ray.io/v1/RayCluster}",
-        "--wait",
-        "--timeout", "5m",
-    )
 
 
 def _create_job_demo_crs():
@@ -2079,11 +2207,13 @@ def _create_job_demo_crs():
         )
 
     print("\n✅ Kueue job demo setup complete!")
-    print("📋 What was set up:")
     print(f"  • Kueue installed on: {', '.join(cluster_names)}")
     print("  • Each cluster has a ClusterQueue 'cluster-queue' and LocalQueue 'user-queue'")
     print("  • RayCluster integration enabled — queue label is enforced on Ray workloads")
     print("  • Set KUEUE_QUEUE_NAME=user-queue in michelangelo-config to enable queuing")
+
+
+def _create_pipeline_demo_crs():
     """Create a pipeline demo for the sandbox cluster for demo purposes."""
     pipeline_demo_dir = _dir / "demo" / "pipeline"
     for yaml_file in pipeline_demo_dir.glob("*.yaml"):

--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -22,77 +22,41 @@ This tool helps you create and manage a sandbox cluster directly on your machine
 """
 
 _dir = Path(__file__).parent
+_scripts_kueue_dir = _dir.parent.parent.parent.parent / "scripts" / "kueue"
+_job_demo_dir = _dir / "demo" / "job"
+_job_kueue_demo_dir = _job_demo_dir / "kueue"
+
+_KUEUE_VERSION = "v0.9.1"
+_KUEUE_MANIFESTS_URL = f"https://github.com/kubernetes-sigs/kueue/releases/download/{_KUEUE_VERSION}/manifests.yaml"
 
 _michelangelo_sandbox_kube_cluster_name = "michelangelo-sandbox"
-
-_cadence_domain = "default"
-_default_compute_kube_cluster_name = "michelangelo-compute-0"
-
-# Path to the Michelangelo Helm chart (relative to this file)
-_chart_dir = Path(__file__).parent.parent.parent.parent.parent / "helm" / "michelangelo"
-
-# Path to values-k3d.yaml — used to read Helm-managed NodePorts dynamically
-_values_k3d_path = _chart_dir / "values-k3d.yaml"
-
-# Hardcoded infra ports — services NOT installed by the michelangelo Helm chart.
-# These are raw YAML resources deployed by _deploy_services() directly.
-_infra_ports = [
+_kube_ports = [
     "3306:30001",  # MySQL
     "9091:30007",  # MinIO
     "9090:30008",  # MinIO Console
+    "15566:30009",  # Michelangelo API Server
+    "8081:30010",  # Envoy gRPC --> gRPC-web proxy
+    "8090:30011",  # Michelangelo UI
     "3000:30012",  # Grafana
     "9092:30015",  # Prometheus
     "5001:30013",  # MLflow Tracking Server
 ]
 
-# Ray framework ports (not in Helm chart)
+# Workflow engine ports
+_cadence_ports = [
+    "7833:30002",  # Cadence gRPC
+    "7933:30003",  # Cadence TChannel
+    "8088:30004",  # Cadence Web
+]
+
+# Ray framework ports
 _ray_ports = [
     "10001:10001",  # Ray client port
     "8265:8265",  # Ray dashboard
 ]
 
-# Maps host-side port → dotted path in values-k3d.yaml where NodePort is defined.
-# Read at cluster-create time so a chart change propagates without editing this file.
-_helm_nodeport_map = [
-    ("15566", ("apiserver", "service", "nodePort")),  # Michelangelo API Server
-    ("8081", ("envoy", "service", "nodePort")),  # Envoy gRPC-Web proxy
-    ("8090", ("ui", "service", "nodePort")),  # Michelangelo UI
-    ("8088", ("cadence", "web", "service", "nodePort")),  # Cadence Web
-    ("8080", ("temporal", "web", "service", "nodePort")),  # Temporal Web
-]
-
-
-def _helm_chart_ports(workflow: str) -> list[str]:
-    """Read control plane NodePorts from values-k3d.yaml.
-
-    Returns host:nodeport strings for k3d's -p flag. NodePorts come from
-    values-k3d.yaml (single source of truth). Host ports are sandbox
-    conventions for localhost access.
-
-    Cadence Web is included only when workflow=cadence; Temporal Web only
-    when workflow=temporal.
-    """
-    with open(_values_k3d_path) as f:
-        values = yaml.safe_load(f) or {}
-
-    ports: list[str] = []
-    for host_port, path in _helm_nodeport_map:
-        # Skip engine-specific Web UIs based on active workflow
-        if path[0] == "cadence" and workflow != "cadence":
-            continue
-        if path[0] == "temporal" and workflow != "temporal":
-            continue
-        node = values
-        for key in path:
-            node = (node or {}).get(key)
-        if node is None:
-            raise ValueError(
-                f"values-k3d.yaml is missing NodePort at "
-                f"{'.'.join(str(k) for k in path)} "
-                f"(needed for host port {host_port})"
-            )
-        ports.append(f"{host_port}:{node}")
-    return ports
+_cadence_domain = "default"
+_default_compute_kube_cluster_name = "michelangelo-compute-0"
 
 
 def init_arguments(p: argparse.ArgumentParser):
@@ -104,8 +68,8 @@ def init_arguments(p: argparse.ArgumentParser):
         "--exclude",
         help=(
             "Excludes specified services. "
-            "Control plane (Helm): apiserver, controllermgr, ui, worker. "
-            "Infrastructure: prometheus, grafana, ray, spark."
+            "Available options: apiserver, controllermgr, ui, worker, "
+            "prometheus, grafana"
         ),
         nargs="+",
         default=[],
@@ -134,6 +98,11 @@ def init_arguments(p: argparse.ArgumentParser):
         default=[],
     )
     create_p.add_argument(
+        "--install-kueue",
+        action="store_true",
+        help="Install Kueue for job queuing. When combined with --create-compute-cluster, sets up MultiKueue across clusters.",
+    )
+    create_p.add_argument(
         "--compute-cluster-name",
         default=_default_compute_kube_cluster_name,
         help=(
@@ -155,8 +124,8 @@ def init_arguments(p: argparse.ArgumentParser):
         "--exclude",
         help=(
             "Excludes specified services. "
-            "Control plane (Helm): apiserver, controllermgr, ui, worker. "
-            "Infrastructure: prometheus, grafana, ray, spark."
+            "Available options: apiserver, controllermgr, ui, worker, "
+            "prometheus, grafana"
         ),
         nargs="+",
         default=[],
@@ -180,12 +149,9 @@ def init_arguments(p: argparse.ArgumentParser):
         default=[],
     )
     sync_p.add_argument(
-        "--set",
-        dest="helm_set",
-        metavar="KEY=VALUE",
-        action="append",
-        default=[],
-        help="Pass arbitrary --set KEY=VALUE flags through to helm upgrade/install.",
+        "--install-kueue",
+        action="store_true",
+        help="Install Kueue for job queuing.",
     )
 
     demo_p = sp.add_parser(
@@ -196,6 +162,24 @@ def init_arguments(p: argparse.ArgumentParser):
     )
     _ = demo_sp.add_parser("pipeline", help="Create pipeline demo resources")
     _ = demo_sp.add_parser("inference", help="Create inference server demo resources")
+    job_p = demo_sp.add_parser(
+        "job",
+        help=(
+            "Create two compute clusters and register them with the Michelangelo "
+            "scheduler for Ray job execution."
+        ),
+    )
+    job_sp = job_p.add_subparsers(
+        dest="job_action", required=False, help="Job demo type to create"
+    )
+    _ = job_sp.add_parser(
+        "kueue",
+        help=(
+            "Extend the job demo with Kueue: install Kueue on the sandbox and "
+            "both compute clusters, and wire up MultiKueue for distributed "
+            "job scheduling."
+        ),
+    )
 
     delete_p = sp.add_parser("delete", help="Delete the cluster.")
     delete_p.add_argument(
@@ -246,7 +230,7 @@ def run(ns: argparse.Namespace):
 
 def _create(ns: argparse.Namespace):
     assert ns
-    ports = _infra_ports + _helm_chart_ports(ns.workflow)
+    ports = _kube_ports + ([] if ns.workflow == "temporal" else _cadence_ports)
     args = [
         "k3d",
         "cluster",
@@ -313,415 +297,126 @@ def _sync(ns: argparse.Namespace):
         "--timeout=120s",
     )
 
-    # Upgrade or install the control plane via Helm.
+    # Delete only the Michelangelo application pods/deployments.
     # Infrastructure (mysql, cadence, minio, grafana, prometheus) is left running.
-
-    _refresh_mysql_schema()
-
-    _ensure_credentials_secret()
-    _helm_ensure_repos()
-    helm_args = _build_helm_set_args(ns)
-
-    # Check if there is a healthy deployed release we can upgrade.
-    status_result = subprocess.run(
-        ["helm", "status", "michelangelo", "-o", "json"],
-        capture_output=True,
-        text=True,
-    )
-    release_healthy = (
-        status_result.returncode == 0 and '"status":"deployed"' in status_result.stdout
-    )
-
-    if release_healthy:
-        # Healthy release: upgrade in-place, keeping infra running.
-        _exec(
-            "helm",
-            "upgrade",
-            "michelangelo",
-            str(_chart_dir),
-            "-f",
-            str(_chart_dir / "values-k3d.yaml"),
-            "--dependency-update",
-            "--reuse-values",
-            *helm_args,
-        )
-        # Force-restart app deployments so they always pick up the latest
-        # configmap values (helm upgrade only restarts pods when the pod
-        # template spec changes, but values-only changes may not alter it).
-        for deploy in (
-            "michelangelo-apiserver",
-            "michelangelo-controllermgr",
-            "michelangelo-worker",
-        ):
-            subprocess.run(
-                [
-                    "kubectl",
-                    "rollout",
-                    "restart",
-                    f"deployment/{deploy}",
-                    "-n",
-                    "default",
-                ],
-                capture_output=True,
-            )
-        # Wait for the restarted rollouts to complete before proceeding.
-        for deploy in (
-            "michelangelo-apiserver",
-            "michelangelo-controllermgr",
-            "michelangelo-worker",
-        ):
-            subprocess.run(
-                [
-                    "kubectl",
-                    "rollout",
-                    "status",
-                    f"deployment/{deploy}",
-                    "-n",
-                    "default",
-                    "--timeout=300s",
-                ],
-                capture_output=False,
-            )
-    else:
-        # Missing or broken release: uninstall cleanly, then reinstall from scratch.
-        subprocess.run(
-            ["helm", "uninstall", "michelangelo", "--ignore-not-found", "--wait"],
-            capture_output=False,
-        )
-        # After uninstall, force-delete any remaining Services from the chart
-        # to free their NodePorts before reinstalling.
-        _helm_delete_services(helm_args)
-        _helm_adopt_orphaned_resources(helm_args)
-        _exec(
-            "helm",
-            "install",
-            "michelangelo",
-            str(_chart_dir),
-            "-f",
-            str(_chart_dir / "values-k3d.yaml"),
-            "--dependency-update",
-            *helm_args,
-        )
-
-    _helm_wait(ns)
-
-
-def _refresh_mysql_schema():
-    """Drop and recreate the michelangelo database from the current schema.
-
-    The schema lives in mysql-ingester.yaml as a ConfigMap that an init Job
-    applies via `mysql < init-schema.sql`. The schema uses CREATE TABLE IF
-    NOT EXISTS, so re-running the Job against an existing database is a
-    no-op and won't pick up renames or column changes. To get a clean
-    application of the current schema we drop the database first, then
-    re-apply the init Job.
-    """
-    print("Refreshing MySQL schema (drop + recreate michelangelo database)...")
-    subprocess.run(
-        [
-            "kubectl",
-            "exec",
-            "mysql",
-            "--",
-            "mysql",
-            "-uroot",
-            "-proot",
-            "-e",
-            "DROP DATABASE IF EXISTS michelangelo;",
-        ],
-        check=True,
-    )
-    # The init Job from the previous sync is already in Completed state;
-    # kubectl apply on a Completed Job is a no-op (Job spec is immutable),
-    # so we have to delete it before re-apply.
-    subprocess.run(
-        ["kubectl", "delete", "job", "ingester-schema-init", "--ignore-not-found=true"],
-        check=False,
-    )
-    _kube_apply(_dir / "resources" / "mysql-ingester.yaml")
-    print("Waiting for ingester-schema-init Job to complete...")
-    subprocess.run(
-        [
-            "kubectl",
-            "wait",
-            "--for=condition=complete",
-            "job/ingester-schema-init",
-            "--timeout=120s",
-        ],
-        check=True,
-    )
-
-
-def _helm_ensure_repos():
-    """Add cadence and temporal helm repos if not already present."""
-    try:
-        helm_existing_repos = subprocess.check_output(["helm", "repo", "list"]).decode()
-    except subprocess.CalledProcessError:
-        helm_existing_repos = ""
-    if "cadence-workflow" not in helm_existing_repos:
-        _exec(
-            "helm",
-            "repo",
-            "add",
-            "cadence-workflow",
-            "https://cadence-workflow.github.io/cadence-charts",
-        )
-    if "temporal" not in helm_existing_repos:
-        _exec("helm", "repo", "add", "temporal", "https://go.temporal.io/helm-charts")
-
-
-def _helm_delete_services(helm_args: list[str]):
-    """Delete Services that would conflict with the chart's NodePorts.
-
-    After helm uninstall, old Services (possibly with different names from
-    a previous install structure) can still hold NodePorts. We scan all
-    Services in the cluster for conflicting NodePorts and delete them.
-    """
-    # Collect the NodePorts the chart wants to allocate.
-    result = subprocess.run(
-        [
-            "helm",
-            "template",
-            "michelangelo",
-            str(_chart_dir),
-            "-f",
-            str(_chart_dir / "values-k3d.yaml"),
-            *helm_args,
-        ],
-        capture_output=True,
-        text=True,
-    )
-    wanted_ports: set[int] = set()
-    if result.returncode == 0:
-        for doc in yaml.safe_load_all(result.stdout):
-            if not doc or doc.get("kind") != "Service":
-                continue
-            for port in (doc.get("spec") or {}).get("ports") or []:
-                if np := port.get("nodePort"):
-                    wanted_ports.add(int(np))
-
-    if not wanted_ports:
-        return
-
-    # Find any Services in the cluster using those NodePorts and delete them.
-    _jsonpath = (
-        "{range .items[*]}"
-        "{.metadata.namespace}/{.metadata.name}"
-        ":{.spec.ports[*].nodePort} {end}"
-    )
-    all_svcs = subprocess.run(
-        [
-            "kubectl",
-            "get",
-            "service",
-            "--all-namespaces",
-            "-o",
-            f"jsonpath={_jsonpath}",
-        ],
-        capture_output=True,
-        text=True,
-    )
-    for entry in all_svcs.stdout.split():
-        if ":" not in entry:
-            continue
-        ns_name, ports_str = entry.split(":", 1)
-        namespace, name = ns_name.split("/", 1)
-        for p in ports_str.split():
-            try:
-                if int(p) in wanted_ports:
-                    print(
-                        f"[sandbox] deleting conflicting service"
-                        f" {namespace}/{name} (NodePort {p})"
-                    )
-                    subprocess.run(
-                        [
-                            "kubectl",
-                            "delete",
-                            "service",
-                            name,
-                            "-n",
-                            namespace,
-                            "--ignore-not-found=true",
-                        ],
-                        capture_output=True,
-                    )
-                    break
-            except ValueError:
-                pass
-
-
-def _helm_adopt_orphaned_resources(helm_args: list[str]):
-    """Clean up resources that would block helm upgrade --install.
-
-    Helm 3 refuses to manage resources missing its ownership annotations.
-    We render the chart manifests and for each resource that exists in the
-    cluster WITHOUT Helm ownership labels, we delete it so the install can
-    recreate it cleanly. Resources already managed by Helm (correct labels)
-    are left untouched.
-    """
-    result = subprocess.run(
-        [
-            "helm",
-            "template",
-            "michelangelo",
-            str(_chart_dir),
-            "-f",
-            str(_chart_dir / "values-k3d.yaml"),
-            *helm_args,
-        ],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        return
-    for doc in yaml.safe_load_all(result.stdout):
-        if not doc:
-            continue
-        kind = doc.get("kind", "")
-        name = (doc.get("metadata") or {}).get("name", "")
-        namespace = (doc.get("metadata") or {}).get("namespace", "default")
-        if not kind or not name:
-            continue
-        # Check if this resource exists and lacks Helm ownership annotations.
-        get_result = subprocess.run(
-            [
-                "kubectl",
-                "get",
-                f"{kind.lower()}/{name}",
-                "-n",
-                namespace,
-                "-o",
-                "jsonpath={.metadata.annotations.meta\\.helm\\.sh/release-name}",
-            ],
-            capture_output=True,
-            text=True,
-        )
-        if get_result.returncode != 0:
-            continue  # resource doesn't exist — no action needed
-        if get_result.stdout.strip() == "michelangelo":
-            continue  # already owned by this release — leave it
-        # Resource exists but is not owned by Helm — delete it so Helm can recreate.
+    # Worker and controllermgr are Pods (not Deployments) so they must be deleted
+    # explicitly; kubectl apply on a Completed pod is a no-op.
+    app_pods = [
+        "michelangelo-apiserver",
+        "envoy",
+        "michelangelo-worker",
+        "michelangelo-controllermgr",
+    ]
+    app_deployments = ["michelangelo-ui"]
+    print("Restarting app pods:", ", ".join(app_pods + app_deployments))
+    for pod in app_pods:
         subprocess.run(
             [
                 "kubectl",
                 "delete",
-                f"{kind.lower()}/{name}",
-                "-n",
-                namespace,
+                "pod",
+                pod,
+                "--force",
+                "--grace-period=0",
                 "--ignore-not-found=true",
             ],
+            check=False,
             capture_output=True,
         )
+    for dep in app_deployments:
+        subprocess.run(
+            [
+                "kubectl",
+                "delete",
+                "deployment",
+                dep,
+                "--force",
+                "--grace-period=0",
+                "--ignore-not-found=true",
+            ],
+            check=False,
+            capture_output=True,
+        )
+    # Delete and re-apply app configs/secrets so new values take effect.
+    app_configs = [
+        "michelangelo-config",
+        "michelangelo-apiserver-config",
+        "envoy-config",
+        "public-config",
+        "michelangelo-worker-config",
+        "michelangelo-controllermgr-config",
+    ]
+    for cm in app_configs:
+        subprocess.run(
+            ["kubectl", "delete", "configmap", cm, "--ignore-not-found=true"],
+            check=False,
+            capture_output=True,
+        )
+    # minio-credentials Secret is intentionally NOT deleted here — it is
+    # managed by _ensure_credentials_secret() which creates it only when it
+    # does not already exist. This lets the GCP sandbox VM pre-configure its
+    # own credentials without sync overwriting them each run.
+
+    print("Waiting for old app pods to fully terminate...")
+    subprocess.run(
+        ["kubectl", "wait", "pod", "--all", "--for=delete", "--timeout=60s"],
+        check=False,
+        capture_output=True,
+    )
+
+    _deploy_app_services(ns)
 
 
 def _deploy_app_services(ns: argparse.Namespace):
-    """Install the Michelangelo control plane via Helm."""
-    _ensure_credentials_secret()
-    _helm_ensure_repos()
-    helm_args = _build_helm_set_args(ns)
-    _helm_adopt_orphaned_resources(helm_args)
-    _exec(
-        "helm",
-        "upgrade",
-        "--install",
-        "michelangelo",
-        str(_chart_dir),
-        "-f",
-        str(_chart_dir / "values-k3d.yaml"),
-        "--dependency-update",
-        *helm_args,
-    )
-    _helm_wait(ns)
+    """Apply only Michelangelo application resources.
 
-
-def _helm_wait(ns: argparse.Namespace):
-    """Wait for the Michelangelo Helm release pods to become ready.
-
-    Uses a two-stage wait:
-    1. Wait for the apiserver Deployment to become Available — waits on the
-       Deployment object (created immediately by Helm) so there is no
-       'no matching resources found' race. The apiserver runs a schema-init
-       container so it takes 30-60s longer than the other services.
-    2. Wait for all remaining Helm-managed Deployments to become Available.
+    Applies: apiserver, envoy, ui, worker, controllermgr.
+    Called by ``_sync`` to do a fast redeploy without touching infrastructure.
     """
-    timeout = getattr(ns, "wait_timeout", 600)
-    instance_selector = "app.kubernetes.io/instance=michelangelo"
+    assert ns
+    app_resources = [
+        "michelangelo-config.yaml",
+    ]
+    if "apiserver" not in ns.exclude:
+        app_resources.append("michelangelo-apiserver.yaml")
+    if "ui" not in ns.exclude:
+        app_resources.append("envoy.yaml")
+        app_resources.append("michelangelo-ui.yaml")
 
-    # Stage 1: apiserver Deployment (schema-init can take 30-60s)
-    print("Waiting for apiserver to become available (schema-init runs first)...")
+    for r in app_resources:
+        _kube_apply(_dir / "resources" / r)
+
+    # Create credentials secrets only if they don't already exist, so a
+    # pre-configured sandbox VM keeps its own credentials across CI runs.
+    _ensure_credentials_secret()
+
+    # Patch michelangelo-config ConfigMap to match the live secret, so
+    # Ray pods (which consume the ConfigMap via envFrom) also get the
+    # correct credentials.
+    _sync_config_from_secret()
+
+    if ns.workflow == "cadence":
+        # Domain registration is a one-time setup done by _create.
+        # _sync keeps infrastructure (including Cadence) running between runs,
+        # so the domain is already registered — no need to re-register.
+        if "worker" not in ns.exclude:
+            _kube_apply(_dir / "resources/michelangelo-worker.yaml")
+        if "controllermgr" not in ns.exclude:
+            _kube_apply(_dir / "resources/michelangelo-controllermgr.yaml")
+
+    # Wait for all app pods to become ready (includes worker + controllermgr if
+    # deployed).
+    wait_timeout = getattr(ns, "wait_timeout", 600)
     _exec(
         "kubectl",
         "wait",
-        "deployment",
+        "--for=condition=ready",
+        "pod",
         "-l",
-        f"{instance_selector},app.kubernetes.io/component=apiserver",
-        "--for=condition=available",
-        "--timeout=180s",
+        "app in (michelangelo-apiserver,envoy,michelangelo-ui,"
+        "michelangelo-worker,michelangelo-controllermgr)",
+        f"--timeout={wait_timeout}s",
     )
-
-    # Stage 2: remaining Helm-managed Deployments
-    print("Waiting for remaining control plane services...")
-    _exec(
-        "kubectl",
-        "wait",
-        "deployment",
-        "-l",
-        instance_selector,
-        "--for=condition=available",
-        f"--timeout={timeout}s",
-    )
-
-
-def _build_helm_set_args(ns: argparse.Namespace) -> list[str]:
-    """Convert sandbox CLI flags to Helm --set arguments for the control plane."""
-    args = []
-
-    # Workflow engine — cadence is the default in values-k3d.yaml.
-    # Always set the engine explicitly so that switching --workflow between
-    # runs (e.g. cadence → temporal) overrides any --reuse-values residue.
-    if ns.workflow == "temporal":
-        args += [
-            "--set",
-            "workflow.engine=temporal",
-            "--set",
-            "workflow.endpoint=michelangelo-temporal-frontend:7233",
-            "--set",
-            "cadence.enabled=false",  # ensure cadence subchart is off
-            "--set",
-            "temporal.enabled=true",  # enable temporal subchart
-        ]
-    else:
-        args += [
-            "--set",
-            "workflow.engine=cadence",
-            "--set",
-            "workflow.endpoint=michelangelo-cadence-frontend:7833",
-            "--set",
-            "temporal.enabled=false",  # ensure temporal subchart is off
-            "--set",
-            "cadence.enabled=true",
-        ]
-
-    # Service exclusions → enabled=false toggles
-    exclude_map = {
-        "apiserver": "apiserver.enabled=false",
-        "ui": "ui.enabled=false",
-        "worker": "worker.enabled=false",
-        "controllermgr": "controllermgr.enabled=false",
-    }
-    for svc, helm_arg in exclude_map.items():
-        if svc in getattr(ns, "exclude", []):
-            args += ["--set", helm_arg]
-
-    # envoy is paired with ui — disable both together
-    if "ui" in getattr(ns, "exclude", []):
-        args += ["--set", "envoy.enabled=false"]
-
-    # Arbitrary --set passthrough from the caller (e.g. CI workflow)
-    for kv in getattr(ns, "helm_set", []):
-        args += ["--set", kv]
-
-    return args
 
 
 def _deploy_services(ns: argparse.Namespace):
@@ -734,40 +429,16 @@ def _deploy_services(ns: argparse.Namespace):
     ]
     links = []
 
-    # Both Cadence and Temporal are now Helm subcharts — engine switching
-    # is handled by cadence.enabled/temporal.enabled --set flags in
-    # _build_helm_set_args(). No separate helm uninstall needed.
+    # Cadence
 
     if ns.workflow == "cadence":
-        # Cadence is now installed as a Helm subchart (cadence.enabled=true in
-        # values-k3d.yaml) — no longer deployed as a bare Pod via cadence.yaml.
-        # The Web UI link is printed in helm install NOTES.txt.
+        resources.append("cadence.yaml")
         links.append(
             (
                 "Cadence Web UI",
-                "http://localhost:8088",
+                "http://localhost:8088/domains/default/workflows",
                 "",
             )
-        )
-    elif ns.workflow == "temporal":
-        # If switching from a previous cadence install, remove cadence pods.
-        subprocess.run(
-            [
-                "kubectl",
-                "delete",
-                "pod",
-                "cadence",
-                "cadence-web",
-                "--ignore-not-found=true",
-                "--grace-period=0",
-            ],
-            capture_output=True,
-            check=False,
-        )
-        subprocess.run(
-            ["kubectl", "delete", "svc", "cadence", "--ignore-not-found=true"],
-            capture_output=True,
-            check=False,
         )
 
     # MinIO
@@ -778,16 +449,6 @@ def _deploy_services(ns: argparse.Namespace):
             "MinIO Console",
             "http://localhost:9090",
             "[Username: minioadmin; Password: minioadmin]",
-        )
-    )
-
-    # KubeRay History Server (core resource, deployed alongside MinIO)
-    resources.append("history-server.yaml")
-    links.append(
-        (
-            "Ray History Server",
-            "http://localhost:3001",
-            "",
         )
     )
 
@@ -813,16 +474,31 @@ def _deploy_services(ns: argparse.Namespace):
         )
 
     if "apiserver" not in ns.exclude:
-        # Installed via Helm by _deploy_app_services() below.
-        pass
+        resources.append("michelangelo-apiserver.yaml")
     if "ui" not in ns.exclude:
-        # Installed via Helm by _deploy_app_services() below.
+        resources.append("envoy.yaml")
+        resources.append("michelangelo-ui.yaml")
         links.append(
             (
                 "Michelangelo UI",
                 "http://localhost:8090",
                 "",
             )
+        )
+
+    if "fluent-bit" in ns.include_experimental:
+        # Provision a ServiceAccount for fluent-bit DaemonSet execution.
+        _exec(
+            "kubectl",
+            "create",
+            "serviceaccount",
+            "fluent-bit",
+        )
+        resources.extend(
+            [
+                "fluent-bit.yaml",
+                "fluent-bit-config.yaml",
+            ]
         )
 
     if "mlflow" in ns.include_experimental:
@@ -835,8 +511,10 @@ def _deploy_services(ns: argparse.Namespace):
             )
         )
 
+    _kueue_enabled = "kueue" in ns.include_experimental or getattr(ns, "install_kueue", False)
+
     # Determine buckets to create based on enabled services
-    bucket_names = ["logs", "default", "deploy-models", "ray-history"]
+    bucket_names = ["logs", "default", "deploy-models"]
     if "mlflow" in ns.include_experimental:
         bucket_names.append("mlflow")
         print("🪣 Adding MLflow bucket to S3 setup")
@@ -869,31 +547,25 @@ def _deploy_services(ns: argparse.Namespace):
     if "spark" not in ns.exclude:
         _create_spark_operator(helm_existing_repos)
 
+    if _kueue_enabled:
+        _install_kueue(helm_existing_repos, links, ns)
+
     _kube_wait(timeout=getattr(ns, "wait_timeout", 600))
 
-    # Install the Michelangelo control plane (apiserver, envoy, ui, worker,
-    # controllermgr, and Cadence or Temporal subchart) via Helm.
-    # Must happen BEFORE domain registration — Cadence frontend only exists
-    # after helm install.
-    _deploy_app_services(ns)
-
-    if ns.workflow == "cadence":
+    if ns.workflow == "temporal":
+        _setup_temporal(links, helm_existing_repos)
+        if "worker" not in ns.exclude:
+            _kube_apply(_dir / "resources/michelangelo-temporal-worker.yaml")
+        if "controllermgr" not in ns.exclude:
+            _kube_apply(_dir / "resources/michelangelo-temporal-controllermgr.yaml")
+    elif ns.workflow == "cadence":
         _create_cadence_domain(links)
-
-    if ns.workflow == "cadence":
-        # Forward Cadence frontend ports to localhost so host-side cadence CLI
-        # can reach the in-cluster Service (ClusterIP, not NodePort in chart).
-        subprocess.Popen(
-            [
-                "kubectl",
-                "port-forward",
-                "svc/michelangelo-cadence-frontend",
-                "7833:7833",
-                "7933:7933",
-            ],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
+        if "worker" not in ns.exclude:
+            _kube_apply(_dir / "resources/michelangelo-worker.yaml")
+        if "controllermgr" not in ns.exclude:
+            _kube_apply(_dir / "resources/michelangelo-controllermgr.yaml")
+    else:
+        raise ValueError(f"Unsupported workflow engine: {ns.workflow}")
 
     # Create separate compute cluster if requested
     create_compute_cluster = getattr(ns, "create_compute_cluster", False)
@@ -950,6 +622,84 @@ def _create_bucket_setup(bucket_names):
         _exec("kubectl", "apply", "-f", temp_file.name)
 
     print(f"📦 Created bucket setup job with buckets: {bucket_names_str}")
+
+
+def _install_kueue(helm_existing_repos, links, ns):
+    """Install Kueue on the control-plane cluster via Helm and apply queue config.
+
+    When --create-compute-cluster is also set, installs Kueue on the compute
+    cluster as a MultiKueue worker and wires up MultiKueue between the two clusters.
+    """
+    _kueue_repo = "https://charts.kueue.x-k8s.io"
+    if "kueue" not in helm_existing_repos:
+        _exec("helm", "repo", "add", "kueue", _kueue_repo)
+        _exec("helm", "repo", "update")
+
+    # Install Kueue on the control-plane (MultiKueue manager)
+    _exec(
+        "helm", "upgrade", "--install", "kueue", "kueue/kueue",
+        "--namespace", "kueue-system",
+        "--create-namespace",
+        "--set", "manageJobsWithoutQueueName=false",
+    )
+
+    create_compute = getattr(ns, "create_compute_cluster", False)
+    compute_cluster_name = getattr(ns, "compute_cluster_name", _default_compute_kube_cluster_name)
+    kube_compute_ctx = f"k3d-{compute_cluster_name}"
+
+    if create_compute:
+        # Apply manager-side queue config (includes MultiKueue admission check)
+        _kube_apply(_scripts_kueue_dir / "compute-0-kueue.yaml")
+
+        # Install Kueue on the compute cluster (MultiKueue worker)
+        _exec(
+            "helm", "upgrade", "--install", "kueue", "kueue/kueue",
+            "--kube-context", kube_compute_ctx,
+            "--namespace", "kueue-system",
+            "--create-namespace",
+            "--set", "manageJobsWithoutQueueName=false",
+        )
+
+        # Apply worker-side queue config
+        _exec(
+            "kubectl", "--context", kube_compute_ctx,
+            "apply", "-f", str(_scripts_kueue_dir / "compute-1-kueue.yaml"),
+        )
+
+        # Create MultiKueue kubeconfig secret on the control plane
+        compute_kubeconfig = subprocess.check_output(
+            ["k3d", "kubeconfig", "get", compute_cluster_name]
+        ).decode()
+        secret_manifest = subprocess.check_output([
+            "kubectl", "create", "secret", "generic",
+            f"multikueue-{compute_cluster_name}-kubeconfig",
+            "--from-literal", f"kubeconfig={compute_kubeconfig}",
+            "--namespace", "kueue-system",
+            "--dry-run=client", "-o", "yaml",
+        ]).decode()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(secret_manifest)
+            secret_path = f.name
+        _exec("kubectl", "apply", "-f", secret_path)
+        import os
+        os.unlink(secret_path)
+
+        # Apply MultiKueue config (MultiKueueCluster + MultiKueueConfig + AdmissionCheck)
+        _kube_apply(_scripts_kueue_dir / "multikueue.yaml")
+
+        print(f"✅ MultiKueue configured: control-plane → {compute_cluster_name}")
+    else:
+        # Single-cluster mode: simple queue on the sandbox itself
+        _kube_apply(_scripts_kueue_dir / "compute-0-kueue.yaml")
+
+    if "grafana" not in ns.exclude:
+        links.append((
+            "Kueue Cluster Queue (Grafana)",
+            "http://localhost:3000/d/kueue-cluster-queue/kueue-e28094-cluster-queue-view",
+            "[Username: admin; Password: admin]",
+        ))
+
+    print("✅ Kueue installed. Set KUEUE_QUEUE_NAME=user-queue in michelangelo-config to enable job queuing.")
 
 
 def _create_spark_operator(helm_existing_repos):
@@ -1012,6 +762,336 @@ def _create_kuberay_operator(helm_existing_repos):
     )
 
 
+def _setup_temporal(links, helm_existing_repos):
+    if "temporal" not in helm_existing_repos:
+        _exec(
+            "helm",
+            "repo",
+            "add",
+            "temporal",
+            "https://temporalio.github.io/helm-charts",
+        )
+        _exec("helm", "repo", "update")
+
+    # Wait for MySQL to be ready before installing Temporal
+    print("Waiting for MySQL to be ready...")
+    _exec(
+        "kubectl",
+        "wait",
+        "--for=condition=ready",
+        "pod",
+        "mysql",
+        "--timeout=300s",
+    )
+
+    # Wait for MySQL to accept connections
+    print("Waiting for MySQL to accept connections...")
+    _exec(
+        "kubectl",
+        "exec",
+        "mysql",
+        "--",
+        "mysqladmin",
+        "ping",
+        "-u",
+        "root",
+        "-proot",
+        "--silent",
+        "--wait",
+    )
+
+    values_file = _dir / "resources" / "temporal.mysql.yaml"
+
+    _exec(
+        "helm",
+        "install",
+        "temporaltest",
+        "temporal",
+        "--repo",
+        "https://go.temporal.io/helm-charts",
+        "-f",
+        str(values_file),
+        "--set",
+        "elasticsearch.enabled=false",
+        "--set",
+        "prometheus.enabled=false",
+        "--set",
+        "grafana.enabled=false",
+    )
+
+    _exec(
+        "kubectl",
+        "-n",
+        "default",
+        "wait",
+        "--for=condition=available",
+        "deployment",
+        "-l",
+        "app",
+        "--timeout=600s",
+    )
+
+    print("Waiting for Temporal admin tools to be ready...")
+    _exec(
+        "kubectl",
+        "wait",
+        "--for=condition=ready",
+        "pod",
+        "-l",
+        "app.kubernetes.io/component=admintools,app.kubernetes.io/instance=temporaltest",
+        "--timeout=300s",
+    )
+
+    print("Creating database schemas via Temporal admin tools...")
+
+    # Create both temporal databases explicitly
+    print("Creating temporal and temporal_visibility databases...")
+    _exec(
+        "kubectl",
+        "exec",
+        "mysql",
+        "--",
+        "mysql",
+        "-u",
+        "root",
+        "-proot",
+        "-e",
+        "CREATE DATABASE IF NOT EXISTS temporal;",
+    )
+    _exec(
+        "kubectl",
+        "exec",
+        "mysql",
+        "--",
+        "mysql",
+        "-u",
+        "root",
+        "-proot",
+        "-e",
+        "CREATE DATABASE IF NOT EXISTS temporal_visibility;",
+    )
+
+    # Setup temporal database schema
+    print("Setting up temporal database schema...")
+    _exec(
+        "kubectl",
+        "exec",
+        "deployment/temporaltest-admintools",
+        "--",
+        "env",
+        "MYSQL_HOST=mysql",
+        "MYSQL_PORT=3306",
+        "MYSQL_USER=root",
+        "MYSQL_PWD=root",
+        "temporal-sql-tool",
+        "--endpoint",
+        "mysql",
+        "--port",
+        "3306",
+        "--user",
+        "root",
+        "--password",
+        "root",
+        "--database",
+        "temporal",
+        "setup-schema",
+        "-v",
+        "0.0",
+    )
+    _exec(
+        "kubectl",
+        "exec",
+        "deployment/temporaltest-admintools",
+        "--",
+        "env",
+        "MYSQL_HOST=mysql",
+        "MYSQL_PORT=3306",
+        "MYSQL_USER=root",
+        "MYSQL_PWD=root",
+        "temporal-sql-tool",
+        "--endpoint",
+        "mysql",
+        "--port",
+        "3306",
+        "--user",
+        "root",
+        "--password",
+        "root",
+        "--database",
+        "temporal",
+        "update-schema",
+        "-d",
+        "/etc/temporal/schema/mysql/v8/temporal/versioned",
+    )
+
+    # Setup temporal visibility database schema
+    print("Setting up temporal_visibility database schema...")
+    _exec(
+        "kubectl",
+        "exec",
+        "deployment/temporaltest-admintools",
+        "--",
+        "env",
+        "MYSQL_HOST=mysql",
+        "MYSQL_PORT=3306",
+        "MYSQL_USER=root",
+        "MYSQL_PWD=root",
+        "temporal-sql-tool",
+        "--endpoint",
+        "mysql",
+        "--port",
+        "3306",
+        "--user",
+        "root",
+        "--password",
+        "root",
+        "--database",
+        "temporal_visibility",
+        "setup-schema",
+        "-v",
+        "0.0",
+    )
+    _exec(
+        "kubectl",
+        "exec",
+        "deployment/temporaltest-admintools",
+        "--",
+        "env",
+        "MYSQL_HOST=mysql",
+        "MYSQL_PORT=3306",
+        "MYSQL_USER=root",
+        "MYSQL_PWD=root",
+        "temporal-sql-tool",
+        "--endpoint",
+        "mysql",
+        "--port",
+        "3306",
+        "--user",
+        "root",
+        "--password",
+        "root",
+        "--database",
+        "temporal_visibility",
+        "update-schema",
+        "-d",
+        "/etc/temporal/schema/mysql/v8/visibility/versioned",
+    )
+
+    print("Database schemas created. Restarting Temporal...")
+    # Restart Temporal to apply the schemas
+    _exec("helm", "uninstall", "temporaltest")
+    _exec(
+        "helm",
+        "install",
+        "temporaltest",
+        "temporal",
+        "--repo",
+        "https://go.temporal.io/helm-charts",
+        "-f",
+        str(values_file),
+        "--set",
+        "elasticsearch.enabled=false",
+        "--set",
+        "prometheus.enabled=false",
+        "--set",
+        "grafana.enabled=false",
+    )
+
+    _exec(
+        "kubectl",
+        "-n",
+        "default",
+        "wait",
+        "--for=condition=available",
+        "deployment",
+        "-l",
+        "app",
+        "--timeout=600s",
+    )
+
+    # Wait for admin tools to be fully ready and get specific pod name
+    print("Waiting for admin tools to be ready for commands...")
+
+    # Get the specific admin tools pod name for more reliable exec
+    admin_pod_result = subprocess.check_output(
+        [
+            "kubectl",
+            "get",
+            "pod",
+            "-l",
+            "app.kubernetes.io/component=admintools,app.kubernetes.io/instance=temporaltest",
+            "-o",
+            "jsonpath={.items[0].metadata.name}",
+        ],
+        text=True,
+    ).strip()
+
+    # Test kubectl exec readiness with retries
+    max_retries = 12
+    retry_delay = 5
+    for attempt in range(max_retries):
+        try:
+            print(
+                f"Testing admin tools container readiness "
+                f"(attempt {attempt + 1}/{max_retries})..."
+            )
+            subprocess.check_call(
+                [
+                    "kubectl",
+                    "exec",
+                    admin_pod_result,
+                    "-c",
+                    "admin-tools",
+                    "--",
+                    "ls",
+                    "/",
+                ],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            print("Admin tools container is ready for commands!")
+            break
+        except subprocess.CalledProcessError:
+            if attempt == max_retries - 1:
+                timeout_seconds = (max_retries - 1) * retry_delay
+                _err_exit(
+                    f"Admin tools container failed to become ready for commands "
+                    f"after {timeout_seconds} seconds"
+                )
+            print(f"Admin tools not ready yet, waiting {retry_delay} seconds...")
+            time.sleep(retry_delay)
+
+    # Register the default namespace in Temporal using specific pod name
+    _exec(
+        "kubectl",
+        "exec",
+        admin_pod_result,
+        "-c",
+        "admin-tools",
+        "--",
+        "tctl",
+        "--address",
+        "temporaltest-frontend:7233",
+        "namespace",
+        "register",
+        "default",
+        "--retention",
+        "72",
+    )
+    # Automatically port-forward Temporal Web UI in the background
+    subprocess.Popen(
+        ["kubectl", "port-forward", "svc/temporaltest-web", "8080:8080"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    subprocess.Popen(
+        ["kubectl", "port-forward", "svc/temporaltest-frontend", "7233:7233"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    links.append(("Temporal Web UI", "http://localhost:8080", ""))
+
+
 def _create_cadence_domain(links):
     """Register the Cadence domain, treating 'already exists' as success.
 
@@ -1019,17 +1099,6 @@ def _create_cadence_domain(links):
     retry up to 20 times.  When infrastructure is kept running between CI
     runs the domain will already be registered; that is not an error.
     """
-    # Wait for Cadence frontend to be ready before registering domain.
-    print("Waiting for Cadence frontend to be ready...")
-    _exec(
-        "kubectl",
-        "wait",
-        "--for=condition=available",
-        "deployment",
-        "-l",
-        "app.kubernetes.io/name=cadence,app.kubernetes.io/component=frontend",
-        "--timeout=300s",
-    )
     pod_name = uuid.uuid4().hex
     args = [
         "kubectl",
@@ -1040,7 +1109,7 @@ def _create_cadence_domain(links):
         "--stdin",
         "--image",
         "ubercadence/cli:v1.2.6",
-        "--env=CADENCE_CLI_ADDRESS=michelangelo-cadence-frontend:7933",
+        "--env=CADENCE_CLI_ADDRESS=cadence:7933",
         "--command",
         "--",
         "cadence",
@@ -1074,7 +1143,7 @@ def _create_cadence_domain(links):
 def _create_demo_crs(ns: argparse.Namespace):
     """Create demo Custom Resources (CRs) for the sandbox environment."""
     assert ns
-    if ns.demo_action != "pipeline" and ns.demo_action != "inference":
+    if ns.demo_action not in ("pipeline", "inference", "job"):
         raise ValueError(f"Unsupported demo action: {ns.demo_action}")
 
     # Check if cluster exists
@@ -1125,20 +1194,20 @@ def _create_demo_crs(ns: argparse.Namespace):
         _create_pipeline_demo_crs()
     elif ns.demo_action == "inference":
         _create_inference_demo_crs()
+    elif ns.demo_action == "job":
+        job_action = getattr(ns, "job_action", None)
+        if job_action is None:
+            _create_job_compute_clusters()
+        elif job_action == "kueue":
+            _create_job_demo_crs()
+        else:
+            raise ValueError(f"Unsupported job demo action: {job_action}")
     else:
         raise ValueError(f"Unsupported demo action: {ns.demo_action}")
 
 
 def _delete(ns: argparse.Namespace):
     assert ns
-    # Uninstall the michelangelo Helm release if present.
-    # Credential Secrets have resource-policy: keep so they survive uninstall.
-    subprocess.run(
-        ["helm", "uninstall", "michelangelo"],
-        capture_output=True,
-        check=False,
-    )
-
     # Determine which compute cluster to check for
     compute_cluster = (
         ns.compute_cluster_name
@@ -1176,7 +1245,7 @@ def _kube_create(path: Path):
 
 
 def _ensure_credentials_secret():
-    """Create object-storage-credentials and aws-credentials Secrets only if absent.
+    """Create minio-credentials and aws-credentials Secrets only if absent.
 
     This is deliberately create-only: a sandbox VM that was pre-configured
     with non-default credentials (e.g. the GCP CI runner) keeps its own
@@ -1184,7 +1253,7 @@ def _ensure_credentials_secret():
     default minioadmin credentials from the YAML files on first create.
     """
     for secret_name, yaml_file in [
-        ("object-storage-credentials", "object-storage-credentials.yaml"),
+        ("minio-credentials", "minio-credentials.yaml"),
         ("aws-credentials", "aws-credentials.yaml"),
     ]:
         exists = (
@@ -1205,20 +1274,20 @@ def _ensure_credentials_secret():
 
 
 def _sync_config_from_secret():
-    """Patch michelangelo-config ConfigMap credentials from object-storage-credentials.
+    """Patch michelangelo-config ConfigMap credentials from minio-credentials Secret.
 
     Ray pods consume the michelangelo-config ConfigMap via envFrom. After the
     ConfigMap is (re)applied from the YAML file (which contains minioadmin
     defaults), this function overwrites the credential fields with whatever
-    is actually in the object-storage-credentials Secret, so all consumers see
-    the same credentials.
+    is actually in the minio-credentials Secret, so all consumers see the
+    same credentials.
     """
     result = subprocess.run(
         [
             "kubectl",
             "get",
             "secret",
-            "object-storage-credentials",
+            "minio-credentials",
             "-o",
             "jsonpath={.data.AWS_ACCESS_KEY_ID} {.data.AWS_SECRET_ACCESS_KEY}",
         ],
@@ -1252,21 +1321,19 @@ def _sync_config_from_secret():
 
 
 def _kube_apply(path: Path):
-    _exec("kubectl", "apply", "-f", str(path))
+    _exec("kubectl", "--context", f"k3d-{_michelangelo_sandbox_kube_cluster_name}", "apply", "-f", str(path))
 
 
 def _kube_wait(pods: bool = True, jobs: bool = True, timeout: int = 600):
     if pods:
-        # Wait for all non-job pods to be ready, excluding history-server which
-        # requires a custom-built image (kuberay-historyserver) not available on
-        # Docker Hub. Build it with scripts/kuberay/build-kuberay-images.sh first.
+        # Wait for all non-job pods to be ready
         _exec(
             "kubectl",
             "wait",
             "--for=condition=ready",
             "pod",
             "-l",
-            "app,app!=history-server",
+            "app",
             f"--timeout={timeout}s",
         )
     if jobs:
@@ -1549,69 +1616,46 @@ def _ensure_namespace_exists(namespace: str):
 
 # Given a cluster name, create a Cluster CRD in the sandbox cluster
 def _create_compute_cluster_crd(cluster_name: str):
-    """Create a Cluster CRD for the Ray jobs cluster in the sandbox cluster."""
-    # Ensure ma-system namespace exists
+    """Apply the Cluster CR for a compute cluster into the sandbox's ma-system namespace.
+
+    Reads the template from demo/job/<cluster-name>.yaml and patches in the host and
+    port extracted from the k3d kubeconfig (those values are ephemeral and differ per run).
+    """
+    import re
+
     _ensure_namespace_exists("ma-system")
 
-    # Get kubeconfig for the Ray jobs cluster
     kubeconfig = subprocess.check_output(
         ["k3d", "kubeconfig", "get", cluster_name]
     ).decode()
-
-    # Parse the kubeconfig YAML
     kubeconfig_data = yaml.safe_load(kubeconfig)
-
-    # Extract server URL from clusters[0].cluster.server
     server_url = kubeconfig_data["clusters"][0]["cluster"]["server"]
-
-    # Extract host and port from server URL
-    # Example: "https://host.docker.internal:52910"
-    import re
 
     match = re.search(r"(https://[^:]+):(\d+)", server_url)
     if not match:
         raise ValueError(
-            f"Could not extract cluster host and port from server URL: {server_url}"
+            f"Could not extract host and port from server URL: {server_url}"
         )
     host, port = match.groups()
 
-    # Create Cluster CRD manifest
-    cluster_crd = {
-        "apiVersion": "michelangelo.api/v2",
-        "kind": "Cluster",
-        "metadata": {"name": cluster_name, "namespace": "ma-system"},
-        "spec": {
-            "kubernetes": {
-                "rest": {
-                    "host": host,
-                    "port": port,
-                    "tokenTag": f"cluster-{cluster_name}-client-token",
-                    "caDataTag": f"cluster-{cluster_name}-ca-data",
-                },
-                "skus": [],
-            }
-        },
-    }
+    template_path = _job_demo_dir / f"{cluster_name}.yaml"
+    cluster_cr = yaml.safe_load(template_path.read_text())
+    cluster_cr["spec"]["kubernetes"]["rest"]["host"] = host
+    cluster_cr["spec"]["kubernetes"]["rest"]["port"] = port
 
-    # Create a temporary file for the Cluster CRD
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml") as crd_file:
-        yaml.dump(cluster_crd, crd_file)
-        crd_file.flush()
-
-        # Apply the Cluster CRD to the sandbox cluster (explicitly specify context)
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml") as f:
+        yaml.dump(cluster_cr, f)
+        f.flush()
         _exec(
             "kubectl",
             "--context",
             f"k3d-{_michelangelo_sandbox_kube_cluster_name}",
             "apply",
             "-f",
-            crd_file.name,
+            f.name,
         )
 
-        print(f"\nCreated Cluster CRD '{cluster_name}' in the sandbox cluster")
-        print(f"Cluster host: {host}")
-        print(f"Cluster port: {port}")
-        print(f"Server URL: {server_url}")
+    print(f"\nRegistered Cluster CR '{cluster_name}' → {host}:{port}")
 
 
 def _create_compute_cluster_secrets(cluster_name: str):
@@ -1705,71 +1749,6 @@ def _create_compute_cluster_secrets(cluster_name: str):
     print(f"\nCreated secrets for cluster '{cluster_name}' in the sandbox cluster")
 
 
-def _setup_inference_server_secrets():
-    """Create RBAC and credentials for inference server cluster access.
-
-    Applies an inference-server-manager ServiceAccount with permissions to
-    manage Deployments, Services, and ConfigMaps (required for Triton provisioning).
-    Stores a long-lived bearer token as a Secret so the clientfactory can build
-    a remote kube client for the sandbox cluster using kubernetes.default.svc:443.
-
-    The CA secret (cluster-michelangelo-sandbox-ca-data) is already created by
-    the sandbox create flow; we only need to provision the token here.
-    """
-    cluster_name = _michelangelo_sandbox_kube_cluster_name
-    token_secret_name = f"cluster-{cluster_name}-is-token"
-
-    # Check if the token secret already exists to make this idempotent.
-    exists = (
-        subprocess.run(
-            ["kubectl", "get", "secret", token_secret_name],
-            capture_output=True,
-        ).returncode
-        == 0
-    )
-    if exists:
-        print(
-            f"Secret '{token_secret_name}' already exists — "
-            "skipping inference server credential setup."
-        )
-        return
-
-    # Apply ServiceAccount + ClusterRole + ClusterRoleBinding.
-    _kube_apply(_dir / "resources" / "rbac-inferenceserver.yaml")
-
-    # Mint a long-lived token (same duration as ray-manager) so the sandbox
-    # does not require frequent re-creation.
-    token_decoded = (
-        subprocess.check_output(
-            [
-                "kubectl",
-                "create",
-                "token",
-                "inference-server-manager",
-                "-n",
-                "default",
-                "--duration=87600h",
-            ]
-        )
-        .decode()
-        .strip()
-    )
-
-    token_secret = {
-        "apiVersion": "v1",
-        "kind": "Secret",
-        "metadata": {"name": token_secret_name, "namespace": "default"},
-        "stringData": {"token": token_decoded},
-    }
-
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
-        yaml.dump(token_secret, f)
-        f.flush()
-        _exec("kubectl", "apply", "-f", f.name)
-
-    print(f"Created inference server credentials for cluster '{cluster_name}'")
-
-
 def _create_inference_demo_crs():
     """Create an inference server for the sandbox cluster for demo purposes."""
     print("🚀 Setting up Michelangelo AI Inference Demo...")
@@ -1777,10 +1756,6 @@ def _create_inference_demo_crs():
     # Setup istio with Gateway API
     # This allows usage of HTTPRoutes to route traffic to the inference server.
     _setup_istio_with_gateway_api()
-
-    # Create the SA, RBAC, and token secret that the clientfactory uses to
-    # connect to the sandbox cluster as a ClusterTarget.
-    _setup_inference_server_secrets()
 
     inference_demo_dir = _dir / "demo" / "inference"
     # Create inference server CR
@@ -2033,6 +2008,172 @@ def _setup_istio_with_gateway_api():
     )
 
     print("✅ Istio with Gateway API setup complete")
+
+
+_demo_compute_clusters = [
+    ("michelangelo-compute-0", _job_kueue_demo_dir / "compute-cluster-0.yaml"),
+    ("michelangelo-compute-1", _job_kueue_demo_dir / "compute-cluster-1.yaml"),
+]
+
+
+def _create_job_compute_clusters():
+    """Create two compute clusters and register them with the Michelangelo scheduler.
+
+    Sets up michelangelo-compute-0 and michelangelo-compute-1 as k3d clusters on the
+    same network as the sandbox, installs KubeRay on each, and creates Michelangelo
+    Cluster CRDs in ma-system so the scheduler can route Ray jobs to them.
+    """
+    try:
+        helm_existing_repos = subprocess.check_output(["helm", "repo", "list"]).decode()
+    except subprocess.CalledProcessError:
+        helm_existing_repos = ""
+
+    for cluster_name, _ in _demo_compute_clusters:
+        print(f"\n🖥️  Setting up compute cluster: {cluster_name}")
+
+        cluster_exists = subprocess.run(
+            ["k3d", "cluster", "get", cluster_name],
+            capture_output=True,
+        ).returncode == 0
+
+        if cluster_exists:
+            print(f"  Cluster {cluster_name} already exists, skipping creation.")
+        else:
+            # No host port mapping — clusters are accessed internally via the shared
+            # k3d network; exposing fixed ports would conflict between the two.
+            _exec(
+                "k3d", "cluster", "create", cluster_name,
+                "--servers", "1",
+                "--agents", "2",
+                "--kubeconfig-switch-context=false",
+                "--network", f"k3d-{_michelangelo_sandbox_kube_cluster_name}",
+            )
+
+            if "kuberay" not in helm_existing_repos:
+                _exec("helm", "repo", "add", "kuberay", "https://ray-project.github.io/kuberay-helm/")
+                _exec("helm", "repo", "update")
+                helm_existing_repos += "\nkuberay"
+
+            _exec(
+                "helm", "install",
+                "--kube-context", f"k3d-{cluster_name}",
+                "kuberay-operator", "kuberay/kuberay-operator",
+                "--version", "1.4.2",
+                "--namespace", "ray-system",
+                "--create-namespace",
+                "--wait",
+                "--timeout", "20m",
+            )
+
+            _create_config_in_compute_cluster(cluster_name)
+            _create_aws_credentials_in_cluster(cluster_name)
+            _apply_compute_cluster_rbac(cluster_name)
+
+        _create_compute_cluster_crd(cluster_name)
+        _create_compute_cluster_secrets(cluster_name)
+
+    cluster_names = [name for name, _ in _demo_compute_clusters]
+    print("\n✅ Compute clusters ready!")
+    print("📋 What was set up:")
+    print(f"  • k3d clusters: {', '.join(cluster_names)}")
+    print("  • KubeRay operator installed on each cluster")
+    print("  • Michelangelo Cluster CRDs registered in ma-system")
+    print()
+    print("Run 'ma sandbox demo job kueue' to add Kueue job scheduling on top.")
+
+
+def _install_kueue_on_cluster(context: str):
+    """Install Kueue on the given cluster by applying the GitHub release manifests."""
+    import urllib.request
+
+    print(f"  Downloading Kueue {_KUEUE_VERSION} manifests...")
+    with tempfile.NamedTemporaryFile(mode="wb", suffix=".yaml", delete=False) as f:
+        with urllib.request.urlopen(_KUEUE_MANIFESTS_URL) as resp:
+            f.write(resp.read())
+        manifests_path = f.name
+    try:
+        _exec(
+            "kubectl", "--context", context,
+            "apply", "--server-side", "-f", manifests_path,
+        )
+    finally:
+        import os as _os
+        _os.unlink(manifests_path)
+
+    # Wait for all Kueue CRDs to be established before callers apply queue config
+    for crd in [
+        "resourceflavors.kueue.x-k8s.io",
+        "clusterqueues.kueue.x-k8s.io",
+        "localqueues.kueue.x-k8s.io",
+    ]:
+        _exec(
+            "kubectl", "--context", context,
+            "wait", "--for=condition=established",
+            f"crd/{crd}",
+            "--timeout=120s",
+        )
+
+    # The kube-rbac-proxy sidecar in Kueue v0.9.x uses gcr.io/kubebuilder images that
+    # are no longer available. Remove it — the sandbox demo only needs the main manager.
+    import json as _json
+    try:
+        containers = subprocess.check_output([
+            "kubectl", "--context", context,
+            "get", "deployment", "kueue-controller-manager",
+            "-n", "kueue-system",
+            "-o", "jsonpath={range .spec.template.spec.containers[*]}{.name}{'\\n'}{end}",
+        ], stderr=subprocess.DEVNULL).decode().strip().splitlines()
+        if "kube-rbac-proxy" in containers:
+            idx = containers.index("kube-rbac-proxy")
+            patch = _json.dumps([{"op": "remove", "path": f"/spec/template/spec/containers/{idx}"}])
+            _exec(
+                "kubectl", "--context", context,
+                "patch", "deployment", "kueue-controller-manager",
+                "-n", "kueue-system",
+                "--type=json", f"-p={patch}",
+            )
+    except subprocess.CalledProcessError:
+        pass
+
+    # Wait for the controller-manager (and its webhook) to be ready
+    _exec(
+        "kubectl", "--context", context,
+        "wait", "--for=condition=available",
+        "deployment/kueue-controller-manager",
+        "-n", "kueue-system",
+        "--timeout=120s",
+    )
+
+
+def _create_job_demo_crs():
+    """Extend the job demo with Kueue: install on each compute cluster for local quota enforcement.
+
+    Assumes _create_job_compute_clusters() has already run (or clusters already exist).
+    After this runs:
+    - Kueue is installed on each compute cluster with a ClusterQueue + LocalQueue
+    - MA job controller routes jobs directly to a compute cluster via Cluster CRs
+    - Local Kueue on each cluster enforces quota
+    - Set KUEUE_QUEUE_NAME=user-queue in michelangelo-config to enable queuing.
+    """
+    # Ensure compute clusters exist first
+    _create_job_compute_clusters()
+
+    cluster_names = [name for name, _ in _demo_compute_clusters]
+
+    for cluster_name, kueue_yaml in _demo_compute_clusters:
+        print(f"\n  📦 Installing Kueue on {cluster_name}...")
+        _install_kueue_on_cluster(f"k3d-{cluster_name}")
+        _exec(
+            "kubectl", "--context", f"k3d-{cluster_name}",
+            "apply", "-f", str(kueue_yaml),
+        )
+
+    print("\n✅ Kueue job demo setup complete!")
+    print("📋 What was set up:")
+    print(f"  • Kueue installed on: {', '.join(cluster_names)}")
+    print("  • Each cluster has a ClusterQueue 'cluster-queue' and LocalQueue 'user-queue'")
+    print("  • Set KUEUE_QUEUE_NAME=user-queue in michelangelo-config to enable job queuing")
+
 
 
 def _create_pipeline_demo_crs():

--- a/python/michelangelo/uniflow/plugins/ray/task.star
+++ b/python/michelangelo/uniflow/plugins/ray/task.star
@@ -32,7 +32,7 @@ IMAGE_PULL_POLICY = os.environ.get("IMAGE_PULL_POLICY", "Never")
 
 RAY_LOG_URL_PREFIX = os.environ.get("RAY_LOG_URL_PREFIX")
 
-KUEUE_QUEUE_NAME = os.environ.get("KUEUE_QUEUE_NAME", "")
+KUEUE_QUEUE_NAME = os.environ.get("KUEUE_QUEUE_NAME", "user-queue")
 metric_base_url = os.environ.get("METRIC_BASE_URL", "")
 
 def get_ray_log_url(ray_job_name):

--- a/python/michelangelo/uniflow/plugins/ray/task.star
+++ b/python/michelangelo/uniflow/plugins/ray/task.star
@@ -33,7 +33,6 @@ IMAGE_PULL_POLICY = os.environ.get("IMAGE_PULL_POLICY", "Never")
 RAY_LOG_URL_PREFIX = os.environ.get("RAY_LOG_URL_PREFIX")
 
 KUEUE_QUEUE_NAME = os.environ.get("KUEUE_QUEUE_NAME", "user-queue")
-metric_base_url = os.environ.get("METRIC_BASE_URL", "")
 
 def get_ray_log_url(ray_job_name):
     """
@@ -285,11 +284,6 @@ def execute_ray_task(task_path, task_name, cluster, cluster_namespace, runtime_e
     print("ray | first activity ID:", first_activity_id)  # NEW: Log the activity ID
 
     # Enhanced: Progress report with activity ID - this establishes the first activity for this task
-    external_resources = []
-    if metric_base_url:
-        metrics_url = metric_base_url + "/d/cluster-jobs/cluster-jobs?var-job=" + cluster_name
-        external_resources = [{"name": "Job Metrics", "url": metrics_url}]
-
     report_progress(
         task_path = task_path,
         task_name = task_name,
@@ -301,7 +295,6 @@ def execute_ray_task(task_path, task_name, cluster, cluster_namespace, runtime_e
         output = "",
         retry_attempt_id = retry_attempt_id,
         first_activity_id = first_activity_id,  # NEW: Store first activity ID for retry boundary
-        external_resources = external_resources,
     )
 
     atexit.register(terminate_cluster, cluster_namespace, cluster_name)

--- a/python/michelangelo/uniflow/plugins/ray/task.star
+++ b/python/michelangelo/uniflow/plugins/ray/task.star
@@ -32,6 +32,9 @@ IMAGE_PULL_POLICY = os.environ.get("IMAGE_PULL_POLICY", "Never")
 
 RAY_LOG_URL_PREFIX = os.environ.get("RAY_LOG_URL_PREFIX")
 
+KUEUE_QUEUE_NAME = os.environ.get("KUEUE_QUEUE_NAME", "")
+metric_base_url = os.environ.get("METRIC_BASE_URL", "")
+
 def get_ray_log_url(ray_job_name):
     """
     Generate a log URL for a Ray job based on the job name.
@@ -267,35 +270,25 @@ def execute_ray_task(task_path, task_name, cluster, cluster_namespace, runtime_e
         retry_attempt_id = retry_attempt_id,
     )
 
+    # Enhanced: Call existing Go activity that now returns activity ID
     cluster_response = ray.create_cluster(cluster, timeout_seconds = DEFAULT_CREATE_CLUSTER_TIMEOUT_SECONDS)
 
-    cluster = cluster_response["rayCluster"]
-    first_activity_id = cluster_response["activityId"]
-
-    print("ray | first activity ID:", first_activity_id)
-
-    if cluster == None:
-        end_time_seconds = time.time()
-        end_time_formated_str = time.utc_format_seconds(TIME_FOMART, end_time_seconds)
-        report_progress(
-            task_path = task_path,
-            task_name = task_name,
-            task_log = "",
-            task_message = "Ray Cluster Creation Failed",
-            task_state = TASK_STATE_FAILED,
-            start_time = start_time_formated_str,
-            end_time = end_time_formated_str,
-            output = "",
-            retry_attempt_id = retry_attempt_id,
-            first_activity_id = first_activity_id,
-        )
-        fail("ray | cluster creation failed, activityId=" + first_activity_id)
+    # Extract cluster info and activity ID from enhanced response
+    cluster = cluster_response["rayCluster"]  # This contains the actual cluster data
+    first_activity_id = cluster_response["activityId"]  # NEW: Activity ID from Go
 
     cluster_url = cluster["status"].get("jobUrl", "UAPI did not report RayJob URL")
     cluster_name = cluster["metadata"]["name"]
     cluster_namespace = cluster["metadata"]["namespace"]
 
     print("ray | cluster created:", "ns=" + cluster_namespace, "n=" + cluster_name, "url=" + cluster_url)
+    print("ray | first activity ID:", first_activity_id)  # NEW: Log the activity ID
+
+    # Enhanced: Progress report with activity ID - this establishes the first activity for this task
+    external_resources = []
+    if metric_base_url:
+        metrics_url = metric_base_url + "/d/cluster-jobs/cluster-jobs?var-job=" + cluster_name
+        external_resources = [{"name": "Job Metrics", "url": metrics_url}]
 
     report_progress(
         task_path = task_path,
@@ -307,7 +300,8 @@ def execute_ray_task(task_path, task_name, cluster, cluster_namespace, runtime_e
         end_time = "",
         output = "",
         retry_attempt_id = retry_attempt_id,
-        first_activity_id = first_activity_id,
+        first_activity_id = first_activity_id,  # NEW: Store first activity ID for retry boundary
+        external_resources = external_resources,
     )
 
     atexit.register(terminate_cluster, cluster_namespace, cluster_name)
@@ -488,11 +482,16 @@ def ray_cluster_spec(
         # Add SYS_PTRACE capability for profiling.
         annotations["michelangelo/profiling-ptrace-enabled"] = "true"
 
+    labels = {}
+    if KUEUE_QUEUE_NAME:
+        labels["kueue.x-k8s.io/queue-name"] = KUEUE_QUEUE_NAME
+
     return {
         "metadata": {
             "generateName": "uf-ray-",
             "namespace": "default",
             "annotations": annotations,
+            "labels": labels,
         },
         "spec": {
             "user": {"name": USER_ID},

--- a/python/michelangelo/uniflow/plugins/ray/task.star
+++ b/python/michelangelo/uniflow/plugins/ray/task.star
@@ -32,7 +32,7 @@ IMAGE_PULL_POLICY = os.environ.get("IMAGE_PULL_POLICY", "Never")
 
 RAY_LOG_URL_PREFIX = os.environ.get("RAY_LOG_URL_PREFIX")
 
-KUEUE_QUEUE_NAME = os.environ.get("KUEUE_QUEUE_NAME", "user-queue")
+KUEUE_QUEUE_NAME = os.environ.get("KUEUE_QUEUE_NAME", "")
 
 def get_ray_log_url(ray_job_name):
     """
@@ -269,21 +269,36 @@ def execute_ray_task(task_path, task_name, cluster, cluster_namespace, runtime_e
         retry_attempt_id = retry_attempt_id,
     )
 
-    # Enhanced: Call existing Go activity that now returns activity ID
     cluster_response = ray.create_cluster(cluster, timeout_seconds = DEFAULT_CREATE_CLUSTER_TIMEOUT_SECONDS)
 
-    # Extract cluster info and activity ID from enhanced response
-    cluster = cluster_response["rayCluster"]  # This contains the actual cluster data
-    first_activity_id = cluster_response["activityId"]  # NEW: Activity ID from Go
+    cluster = cluster_response["rayCluster"]
+    first_activity_id = cluster_response["activityId"]
+
+    print("ray | first activity ID:", first_activity_id)
+
+    if cluster == None:
+        end_time_seconds = time.time()
+        end_time_formated_str = time.utc_format_seconds(TIME_FOMART, end_time_seconds)
+        report_progress(
+            task_path = task_path,
+            task_name = task_name,
+            task_log = "",
+            task_message = "Ray Cluster Creation Failed",
+            task_state = TASK_STATE_FAILED,
+            start_time = start_time_formated_str,
+            end_time = end_time_formated_str,
+            output = "",
+            retry_attempt_id = retry_attempt_id,
+            first_activity_id = first_activity_id,
+        )
+        fail("ray | cluster creation failed, activityId=" + first_activity_id)
 
     cluster_url = cluster["status"].get("jobUrl", "UAPI did not report RayJob URL")
     cluster_name = cluster["metadata"]["name"]
     cluster_namespace = cluster["metadata"]["namespace"]
 
     print("ray | cluster created:", "ns=" + cluster_namespace, "n=" + cluster_name, "url=" + cluster_url)
-    print("ray | first activity ID:", first_activity_id)  # NEW: Log the activity ID
 
-    # Enhanced: Progress report with activity ID - this establishes the first activity for this task
     report_progress(
         task_path = task_path,
         task_name = task_name,
@@ -294,7 +309,7 @@ def execute_ray_task(task_path, task_name, cluster, cluster_namespace, runtime_e
         end_time = "",
         output = "",
         retry_attempt_id = retry_attempt_id,
-        first_activity_id = first_activity_id,  # NEW: Store first activity ID for retry boundary
+        first_activity_id = first_activity_id,
     )
 
     atexit.register(terminate_cluster, cluster_namespace, cluster_name)


### PR DESCRIPTION
What type of PR is this? (check all applicable)
  - Refactor
  x Feature
  - Bug Fix
  - Optimization
  - Documentation Update
  
  What changed?

  Added Kueue integration for Ray job scheduling on compute clusters. Changes are scoped to Kueue only — no unrelated code was modified.

  - go/components/jobs/client/k8sengine/ray.go: propagate labels from the Michelangelo RayCluster proto to the k8s RayCluster object so the kueue.x-k8s.io/queue-name label
  reaches the actual workload
  - python/michelangelo/uniflow/plugins/ray/task.star: read KUEUE_QUEUE_NAME env var (default "") and add kueue.x-k8s.io/queue-name label to every RayCluster spec when set —
  empty default makes Kueue opt-in
  - helm/michelangelo/values.yaml: add worker.kueue.queueName: ""
  - helm/michelangelo/templates/core/worker-deployment.yaml: inject KUEUE_QUEUE_NAME env var into the worker container when worker.kueue.queueName is non-empty
  - python/michelangelo/cli/sandbox/sandbox.py: add --install-kueue flag to sandbox create/sync; wire worker.kueue.queueName=user-queue into _build_helm_set_args; add ma 
  sandbox demo job and ma sandbox demo job kueue subcommands; add _install_kueue / _install_kueue_on_cluster using Helm with integrations.frameworks={ray.io/v1/RayCluster}
  - python/michelangelo/cli/sandbox/demo/job/kueue/compute-cluster-{0,1}.yaml: Kueue ClusterQueue + LocalQueue config (v1beta2) for each compute cluster

  Why?

  Kueue provides quota enforcement and fair scheduling for Ray workloads on compute clusters. Without it, jobs run immediately regardless of available resources. With Kueue,
  jobs are queued and admitted only when quota permits, enabling multi-tenant resource management on shared clusters.

  The design uses local Kueue on each compute cluster independently — no MultiKueue cross-cluster fan-out — keeping the setup simple for the POC.

  How did you test it?

  Tested end-to-end locally with two k3d compute clusters:

  1. ma sandbox demo job — created michelangelo-compute-0 and michelangelo-compute-1 with KubeRay
  2. ma sandbox demo job kueue — installed Kueue v0.9.1 on both clusters with ray.io/raycluster integration enabled
  3. Submitted a RayCluster with kueue.x-k8s.io/queue-name=user-queue label to michelangelo-compute-0
  4. Verified Kueue created a Workload, admitted it against the ClusterQueue, set spec.suspend=false, and head + worker pods reached 1/1 Running
  5. Confirmed ClusterQueue shows admittedWorkloads: 1 and quota is tracked correctly

  Potential risks

  - KUEUE_QUEUE_NAME defaults to "" so existing deployments are unaffected — no label is added to RayClusters unless explicitly configured
  - --install-kueue installs Kueue on the sandbox cluster via helm upgrade --install; idempotent if Kueue is already present
  - manageJobsWithoutQueueName=false means Kueue only manages labelled workloads — unlabelled RayClusters are unaffected

  Release notes

  No schema updates or data migration required. New opt-in feature only.
  
  To enable: ma sandbox demo job kueue then ma sandbox sync --install-kueue, or via helm --set worker.kueue.queueName=user-queue.

  Documentation Changes

  No user-facing API changes. Backward compatible — Kueue is disabled by default at every layer.
