### PR TITLE
Add log persistence config and populate log_url in RayCluster controller

### DIFF
--- a/go/cmd/controllermgr/config/base.yaml
+++ b/go/cmd/controllermgr/config/base.yaml
@@ -23,9 +23,18 @@ controllers:
   rayCluster:
     k8sQps: 300
     k8sBurst: 600
+    logPersistence:
+      enabled: true
+      storageEndpoint: "k3d-michelangelo-sandbox-agent-0:30007"
+      bucket: ray-history
+      pathPrefix: clusters/
+      region: us-east-1
+      credentialsSecret: aws-credentials
+      collectorImage: kuberay-collector:v0.1.0
 
 minio:
   awsRegion: us-east-1
   awsAccessKeyId: minioadmin
   awsSecretAccessKey: minioadmin
-  awsEndpointUrl: localhost:9091
+  awsEndpointUrl: minio:9091
+  secure: false

--- a/go/components/jobs/client/client_test.go
+++ b/go/components/jobs/client/client_test.go
@@ -188,7 +188,7 @@ func TestDeleteJob(t *testing.T) {
 			k8sc := Client{
 				factory: f,
 				helper:  NewHelper(),
-				mapper:  k8sengine.NewMapper().Mapper,
+				mapper:  k8sengine.NewMapper(k8sengine.LogPersistenceConfig{}).Mapper,
 			}
 
 			// test
@@ -255,7 +255,7 @@ func TestDeletePromConfigMap(t *testing.T) {
 			k8sc := Client{
 				factory: f,
 				helper:  NewHelper(),
-				mapper:  k8sengine.NewMapper().Mapper,
+				mapper:  k8sengine.NewMapper(k8sengine.LogPersistenceConfig{}).Mapper,
 			}
 
 			// test
@@ -322,7 +322,7 @@ func TestDeleteSecret(t *testing.T) {
 			k8sc := Client{
 				factory: f,
 				helper:  NewHelper(),
-				mapper:  k8sengine.NewMapper().Mapper,
+				mapper:  k8sengine.NewMapper(k8sengine.LogPersistenceConfig{}).Mapper,
 			}
 
 			// test
@@ -419,7 +419,7 @@ func TestCreatePromConfigMap(t *testing.T) {
 				return NewClient(Params{
 					Factory: f,
 					Logger:  zaptest.NewLogger(t),
-					Mapper:  k8sengine.NewMapper().Mapper,
+					Mapper:  k8sengine.NewMapper(k8sengine.LogPersistenceConfig{}).Mapper,
 					Helper:  NewHelper(),
 				})
 			},
@@ -440,7 +440,7 @@ func TestCreatePromConfigMap(t *testing.T) {
 					Factory: f,
 					Logger:  zaptest.NewLogger(t),
 					Helper:  NewHelper(),
-					Mapper:  k8sengine.NewMapper().Mapper,
+					Mapper:  k8sengine.NewMapper(k8sengine.LogPersistenceConfig{}).Mapper,
 				})
 			},
 			wantError: true,
@@ -476,7 +476,7 @@ func TestCreatePromConfigMap(t *testing.T) {
 					Factory: f,
 					Logger:  zaptest.NewLogger(t),
 					Helper:  NewHelper(),
-					Mapper:  k8sengine.NewMapper().Mapper,
+					Mapper:  k8sengine.NewMapper(k8sengine.LogPersistenceConfig{}).Mapper,
 				})
 			},
 			// file path will be created as temp file in test body
@@ -570,7 +570,7 @@ func TestCreateSecret(t *testing.T) {
 				factory:         f,
 				helper:          NewHelper(),
 				secretsProvider: provider,
-				mapper:          k8sengine.NewMapper().Mapper,
+				mapper:          k8sengine.NewMapper(k8sengine.LogPersistenceConfig{}).Mapper,
 			}
 
 			// test
@@ -639,7 +639,7 @@ func TestGetJobStatus(t *testing.T) {
 				gctrl := gomock.NewController(t)
 				defer gctrl.Finish()
 				f := computemocks.NewMockFactory(gctrl)
-				cl := &Client{factory: f, helper: NewHelper(), mapper: k8sengine.NewMapper().Mapper, logger: zaptest.NewLogger(t)}
+				cl := &Client{factory: f, helper: NewHelper(), mapper: k8sengine.NewMapper(k8sengine.LogPersistenceConfig{}).Mapper, logger: zaptest.NewLogger(t)}
 				if tt.setupFactory != nil {
 					tt.setupFactory(f)
 				}
@@ -661,7 +661,7 @@ func TestGetJobStatus(t *testing.T) {
 				return
 			}
 			// When not using GetJobStatus path, validate mapper-based conversion on local RayJob object
-			js, err := k8sengine.NewMapper().Mapper.MapLocalJobStatusToGlobal(tt.jobObject)
+			js, err := k8sengine.NewMapper(k8sengine.LogPersistenceConfig{}).Mapper.MapLocalJobStatusToGlobal(tt.jobObject)
 			require.NoError(t, err)
 			if js != nil && js.Ray != nil {
 				assert.Equal(t, tt.expectStatus, js.Ray.JobStatus)
@@ -753,7 +753,7 @@ func TestCreateJob(t *testing.T) {
 			k8sc := Client{
 				factory: f,
 				helper:  NewHelper(),
-				mapper:  k8sengine.NewMapper().Mapper,
+				mapper:  k8sengine.NewMapper(k8sengine.LogPersistenceConfig{}).Mapper,
 			}
 
 			// test
@@ -772,7 +772,7 @@ func TestCreateJob(t *testing.T) {
 func TestGetJobClusterStatus_ClientSetError(t *testing.T) {
 	g := gomock.NewController(t)
 	f := computemocks.NewMockFactory(g)
-	cl := &Client{factory: f, helper: NewHelper(), mapper: k8sengine.NewMapper().Mapper}
+	cl := &Client{factory: f, helper: NewHelper(), mapper: k8sengine.NewMapper(k8sengine.LogPersistenceConfig{}).Mapper}
 	jobCluster := &v2pb.RayCluster{ObjectMeta: metav1.ObjectMeta{Name: "rc1"}}
 	cluster := &v2pb.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "c1"}}
 

--- a/go/components/jobs/client/k8sengine/BUILD.bazel
+++ b/go/components/jobs/client/k8sengine/BUILD.bazel
@@ -15,16 +15,21 @@ go_library(
         "//proto/api/v2:go_default_library",
         "@com_github_ray_project_kuberay_ray_operator//apis/ray/v1:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/api/resource:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_utils//ptr:go_default_library",
+        "@org_uber_go_config//:go_default_library",
         "@org_uber_go_fx//:go_default_library",
     ],
 )
 
 go_test(
     name = "go_default_test",
-    srcs = ["mapper_test.go"],
+    srcs = [
+        "mapper_test.go",
+        "ray_collector_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//proto/api/v2:go_default_library",
@@ -32,6 +37,7 @@ go_test(
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/api/resource:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
     ],

--- a/go/components/jobs/client/k8sengine/mapper.go
+++ b/go/components/jobs/client/k8sengine/mapper.go
@@ -6,12 +6,15 @@ import (
 	"github.com/michelangelo-ai/michelangelo/go/components/jobs/common/types"
 	v2pb "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	"go.uber.org/config"
 	"go.uber.org/fx"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // Mapper helps to map global to local crds and vice versa
-type Mapper struct{}
+type Mapper struct {
+	LogPersistence LogPersistenceConfig
+}
 
 // MapperResult has Mapper result
 type MapperResult struct {
@@ -22,10 +25,23 @@ type MapperResult struct {
 
 const _mapperName = "k8sengineMapper"
 
+const logPersistenceConfigKey = "controllers.rayCluster.logPersistence"
+
+// NewLogPersistenceConfig loads LogPersistenceConfig from YAML config provider.
+func NewLogPersistenceConfig(provider config.Provider) (LogPersistenceConfig, error) {
+	conf := LogPersistenceConfig{}
+	err := provider.Get(logPersistenceConfigKey).Populate(&conf)
+	if err != nil {
+		// Config is optional — return zero-value (disabled) if not present
+		return LogPersistenceConfig{}, nil
+	}
+	return conf, nil
+}
+
 // NewMapper constructs the Mapper
-func NewMapper() MapperResult {
+func NewMapper(logPersistence LogPersistenceConfig) MapperResult {
 	return MapperResult{
-		Mapper: Mapper{},
+		Mapper: Mapper{LogPersistence: logPersistence},
 	}
 }
 

--- a/go/components/jobs/client/k8sengine/ray.go
+++ b/go/components/jobs/client/k8sengine/ray.go
@@ -6,10 +6,24 @@ import (
 	v2pb "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sptr "k8s.io/utils/ptr"
 )
+
+// LogPersistenceConfig holds platform-level configuration for log persistence.
+// This is loaded from YAML config under controllers.rayCluster.logPersistence.
+// See: https://github.com/ray-project/kuberay/tree/master/historyserver/config
+type LogPersistenceConfig struct {
+	Enabled           bool   `yaml:"enabled"`
+	StorageEndpoint   string `yaml:"storageEndpoint"`   // S3-compatible endpoint (e.g. "minio:9091")
+	Bucket            string `yaml:"bucket"`             // S3 bucket name (e.g. "ray-history")
+	PathPrefix        string `yaml:"pathPrefix"`         // Key prefix under the bucket (e.g. "clusters/")
+	Region            string `yaml:"region"`             // S3 region (e.g. "us-east-1")
+	CredentialsSecret string `yaml:"credentialsSecret"`  // K8s Secret with AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY
+	CollectorImage    string `yaml:"collectorImage"`     // KubeRay collector sidecar image
+}
 
 func (m Mapper) mapRay(rayJob *v2pb.RayJob, jobClusterObject runtime.Object, cluster *v2pb.Cluster) (runtime.Object, error) {
 	if jobClusterObject == nil {
@@ -52,6 +66,14 @@ func (m Mapper) mapRay(rayJob *v2pb.RayJob, jobClusterObject runtime.Object, clu
 func (m Mapper) mapRayCluster(rayCluster *v2pb.RayCluster) (runtime.Object, error) {
 	workerGroupSpecs := getWorkerGroupSpecs(rayCluster.GetName(), rayCluster.GetSpec().Workers)
 	headGroupSpec := getHeadGroupSpec(rayCluster.GetSpec().Head)
+
+	if m.LogPersistence.Enabled {
+		injectCollectorSidecar(&headGroupSpec.Template, m.LogPersistence, rayCluster.GetName(), RayLocalNamespace, "Head")
+		for i := range workerGroupSpecs {
+			injectCollectorSidecar(&workerGroupSpecs[i].Template, m.LogPersistence, rayCluster.GetName(), RayLocalNamespace, "Worker")
+		}
+	}
+
 	rayV1Cluster := &rayv1.RayCluster{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       RayClusterKind,
@@ -92,6 +114,211 @@ func getWorkerGroupSpecs(clusterName string, workers []*v2pb.RayWorkerSpec) []ra
 		workerGroupSpecsJSON[i] = wg
 	}
 	return workerGroupSpecsJSON
+}
+
+const (
+	rayLogsVolumeName = "ray-logs"
+	rayLogsPath       = "/tmp/ray"
+	collectorPort     = 8084
+
+	// nodeIDScript is the PostStart lifecycle hook that extracts the raylet node ID.
+	// The collector watches /tmp/ray/raylet_node_id for node identification.
+	// This script polls until the raylet process starts, then extracts --node_id from its args.
+	// Copied from: https://github.com/ray-project/kuberay/blob/master/historyserver/config/raycluster.yaml
+	nodeIDScript = `GetNodeId(){
+  while true; do
+    nodeid=$(ps -ef | grep raylet | grep node_id | grep -v grep | grep -oP '(?<=--node_id=)[^ ]*')
+    if [ -n "$nodeid" ]; then
+      echo "$(date) raylet started: ${nodeid}" >> /tmp/ray/init.log
+      echo $nodeid > /tmp/ray/raylet_node_id
+      break
+    else
+      echo "$(date) raylet not started" >> /tmp/ray/init.log
+      sleep 1
+    fi
+  done
+}
+GetNodeId`
+
+	// exposableEventTypes lists the Ray event types the collector should receive.
+	// Required for Ray 2.52.0+. In 2.53.0+ the env var name changes to
+	// RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISHER_HTTP_ENDPOINT_EXPOSABLE_EVENT_TYPES
+	exposableEventTypes = "TASK_DEFINITION_EVENT,TASK_LIFECYCLE_EVENT,ACTOR_TASK_DEFINITION_EVENT," +
+		"TASK_PROFILE_EVENT,DRIVER_JOB_DEFINITION_EVENT,DRIVER_JOB_LIFECYCLE_EVENT," +
+		"ACTOR_DEFINITION_EVENT,ACTOR_LIFECYCLE_EVENT,NODE_DEFINITION_EVENT,NODE_LIFECYCLE_EVENT"
+)
+
+// injectCollectorSidecar injects a KubeRay History Server collector sidecar container
+// into the pod template. Follows the official KubeRay config pattern:
+// https://github.com/ray-project/kuberay/blob/master/historyserver/config/raycluster.yaml
+//
+// It adds:
+// - Shared emptyDir volume for /tmp/ray
+// - Ray event export env vars on all existing containers
+// - PostStart lifecycle hook to extract raylet node ID
+// - Collector sidecar with S3 env vars and event port
+func injectCollectorSidecar(podTemplate *corev1.PodTemplateSpec, config LogPersistenceConfig, clusterName string, clusterNamespace string, role string) {
+	// 1. Determine the volume name for /tmp/ray.
+	// If a Ray container already mounts /tmp/ray, reuse that volume so
+	// the collector shares the same data. Otherwise, create a new emptyDir.
+	rayVolumeName := rayLogsVolumeName
+	for _, c := range podTemplate.Spec.Containers {
+		for _, vm := range c.VolumeMounts {
+			if vm.MountPath == rayLogsPath {
+				rayVolumeName = vm.Name
+				break
+			}
+		}
+		if rayVolumeName != rayLogsVolumeName {
+			break
+		}
+	}
+
+	// Only add a new volume if no existing volume is being reused
+	if rayVolumeName == rayLogsVolumeName {
+		hasVolume := false
+		for _, v := range podTemplate.Spec.Volumes {
+			if v.Name == rayLogsVolumeName {
+				hasVolume = true
+				break
+			}
+		}
+		if !hasVolume {
+			podTemplate.Spec.Volumes = append(podTemplate.Spec.Volumes, corev1.Volume{
+				Name: rayLogsVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			})
+		}
+	}
+
+	rayLogsVolumeMount := corev1.VolumeMount{
+		Name:      rayVolumeName,
+		MountPath: rayLogsPath,
+	}
+
+	// Ray event export env vars — tells Ray to forward events to the collector's HTTP endpoint
+	eventExportEnvVars := []corev1.EnvVar{
+		{
+			Name:  "RAY_enable_ray_event",
+			Value: "true",
+		},
+		{
+			Name:  "RAY_enable_core_worker_ray_event_to_aggregator",
+			Value: "true",
+		},
+		{
+			Name:  "RAY_DASHBOARD_AGGREGATOR_AGENT_EVENTS_EXPORT_ADDR",
+			Value: fmt.Sprintf("http://localhost:%d/v1/events", collectorPort),
+		},
+		{
+			Name:  "RAY_DASHBOARD_AGGREGATOR_AGENT_EXPOSABLE_EVENT_TYPES",
+			Value: exposableEventTypes,
+		},
+	}
+
+	// 2. Update all existing containers: add volume mount, env vars, and lifecycle hook
+	for i := range podTemplate.Spec.Containers {
+		c := &podTemplate.Spec.Containers[i]
+		// Only add volume mount if /tmp/ray is not already mounted
+		hasRayLogsMount := false
+		for _, vm := range c.VolumeMounts {
+			if vm.MountPath == rayLogsPath {
+				hasRayLogsMount = true
+				break
+			}
+		}
+		if !hasRayLogsMount {
+			c.VolumeMounts = append(c.VolumeMounts, rayLogsVolumeMount)
+		}
+		c.Env = append(c.Env, eventExportEnvVars...)
+
+		// Add PostStart lifecycle hook to extract raylet node ID.
+		// Preserves any existing PreStop hook.
+		if c.Lifecycle == nil {
+			c.Lifecycle = &corev1.Lifecycle{}
+		}
+		c.Lifecycle.PostStart = &corev1.LifecycleHandler{
+			Exec: &corev1.ExecAction{
+				Command: []string{"/bin/sh", "-lc", "--", nodeIDScript},
+			},
+		}
+	}
+
+	// 3. Build S3 env vars for collector — matches official kuberay config pattern
+	// (env vars, NOT --runtime-class-config-path)
+	collectorS3Env := []corev1.EnvVar{
+		{
+			Name: "AWS_ACCESS_KEY_ID",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: config.CredentialsSecret,
+					},
+					Key: "AWS_ACCESS_KEY_ID",
+				},
+			},
+		},
+		{
+			Name: "AWS_SECRET_ACCESS_KEY",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: config.CredentialsSecret,
+					},
+					Key: "AWS_SECRET_ACCESS_KEY",
+				},
+			},
+		},
+		{Name: "AWS_SESSION_TOKEN", Value: ""},
+		{Name: "S3_BUCKET", Value: config.Bucket},
+		{Name: "S3_ENDPOINT", Value: config.StorageEndpoint},
+		{Name: "S3_REGION", Value: config.Region},
+		{Name: "S3FORCE_PATH_STYLE", Value: "true"},
+		{Name: "S3DISABLE_SSL", Value: "true"},
+	}
+
+	// Head collector gets additional env vars for dashboard polling
+	if role == "Head" {
+		collectorS3Env = append(collectorS3Env,
+			corev1.EnvVar{Name: "RAY_DASHBOARD_ADDRESS", Value: "http://localhost:8265"},
+			corev1.EnvVar{Name: "RAY_COLLECTOR_ADDITIONAL_ENDPOINTS", Value: "/api/v0/placement_groups?detail=1&limit=10000"},
+			corev1.EnvVar{Name: "RAY_COLLECTOR_POLL_INTERVAL", Value: "30s"},
+		)
+	}
+
+	// 4. Build collector sidecar container using command (not args) per official config
+	collectorContainer := corev1.Container{
+		Name:            "collector",
+		Image:           config.CollectorImage,
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		Command: []string{
+			"collector",
+			fmt.Sprintf("--role=%s", role),
+			"--runtime-class-name=s3",
+			fmt.Sprintf("--ray-cluster-name=%s", clusterName),
+			fmt.Sprintf("--ray-root-dir=%s", "log"),
+			fmt.Sprintf("--events-port=%d", collectorPort),
+		},
+		Env: collectorS3Env,
+		Ports: []corev1.ContainerPort{
+			{
+				Name:          "events",
+				ContainerPort: int32(collectorPort),
+				Protocol:      corev1.ProtocolTCP,
+			},
+		},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceMemory: resource.MustParse("128Mi"),
+			},
+		},
+		VolumeMounts: []corev1.VolumeMount{rayLogsVolumeMount},
+	}
+
+	podTemplate.Spec.Containers = append(podTemplate.Spec.Containers, collectorContainer)
 }
 
 // getRayClusterStateFromStatus maps KubeRay v1 cluster state to our internal v2pb.RayClusterState

--- a/go/components/jobs/client/k8sengine/ray_collector_test.go
+++ b/go/components/jobs/client/k8sengine/ray_collector_test.go
@@ -1,0 +1,246 @@
+package k8sengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestInjectCollectorSidecar(t *testing.T) {
+	config := LogPersistenceConfig{
+		Enabled:           true,
+		StorageEndpoint:   "minio:9091",
+		Bucket:            "ray-history",
+		PathPrefix:        "clusters/",
+		Region:            "us-east-1",
+		CredentialsSecret: "aws-credentials",
+		CollectorImage:    "kuberay-collector:local",
+	}
+
+	tests := []struct {
+		name             string
+		role             string
+		clusterName      string
+		clusterNamespace string
+		podTemplate      corev1.PodTemplateSpec
+	}{
+		{
+			name:             "head pod gets collector sidecar",
+			role:             "Head",
+			clusterName:      "test-cluster",
+			clusterNamespace: "default",
+			podTemplate: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "ray-head", Image: "rayproject/ray:2.10.0"},
+					},
+				},
+			},
+		},
+		{
+			name:             "worker pod gets collector sidecar",
+			role:             "Worker",
+			clusterName:      "test-cluster",
+			clusterNamespace: "default",
+			podTemplate: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "ray-worker", Image: "rayproject/ray:2.10.0"},
+					},
+				},
+			},
+		},
+		{
+			name:             "pod with multiple containers",
+			role:             "Head",
+			clusterName:      "multi-container-cluster",
+			clusterNamespace: "test-ns",
+			podTemplate: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "ray-head", Image: "rayproject/ray:2.10.0"},
+						{Name: "sidecar", Image: "some-sidecar:latest"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pt := tt.podTemplate.DeepCopy()
+			originalContainerCount := len(pt.Spec.Containers)
+
+			injectCollectorSidecar(pt, config, tt.clusterName, tt.clusterNamespace, tt.role)
+
+			// Verify ray-logs emptyDir volume added (only 1 volume)
+			require.Len(t, pt.Spec.Volumes, 1, "should have ray-logs volume only")
+			assert.Equal(t, "ray-logs", pt.Spec.Volumes[0].Name)
+			require.NotNil(t, pt.Spec.Volumes[0].VolumeSource.EmptyDir)
+
+			// Verify all original containers have volume mount, env vars, and lifecycle hook
+			for i := 0; i < originalContainerCount; i++ {
+				c := pt.Spec.Containers[i]
+
+				// Volume mount
+				hasMount := false
+				for _, vm := range c.VolumeMounts {
+					if vm.Name == "ray-logs" && vm.MountPath == "/tmp/ray" {
+						hasMount = true
+						break
+					}
+				}
+				assert.True(t, hasMount, "container %s should have ray-logs volume mount", c.Name)
+
+				// Env vars for Ray event export
+				envMap := make(map[string]string)
+				for _, e := range c.Env {
+					envMap[e.Name] = e.Value
+				}
+				assert.Equal(t, "true", envMap["RAY_enable_ray_event"])
+				assert.Equal(t, "true", envMap["RAY_enable_core_worker_ray_event_to_aggregator"])
+				assert.Equal(t, fmt.Sprintf("http://localhost:%d/v1/events", collectorPort), envMap["RAY_DASHBOARD_AGGREGATOR_AGENT_EVENTS_EXPORT_ADDR"])
+				assert.NotEmpty(t, envMap["RAY_DASHBOARD_AGGREGATOR_AGENT_EXPOSABLE_EVENT_TYPES"])
+
+				// PostStart lifecycle hook for raylet node ID extraction
+				require.NotNil(t, c.Lifecycle, "container %s should have lifecycle", c.Name)
+				require.NotNil(t, c.Lifecycle.PostStart, "container %s should have PostStart hook", c.Name)
+				require.NotNil(t, c.Lifecycle.PostStart.Exec)
+				assert.Contains(t, c.Lifecycle.PostStart.Exec.Command[3], "raylet_node_id")
+			}
+
+			// Verify collector sidecar container added
+			require.Len(t, pt.Spec.Containers, originalContainerCount+1)
+			collector := pt.Spec.Containers[originalContainerCount]
+			assert.Equal(t, "collector", collector.Name)
+			assert.Equal(t, config.CollectorImage, collector.Image)
+
+			// Verify collector command (not args) matches kuberay historyserver pattern
+			expectedCommand := []string{
+				"collector",
+				"--role=" + tt.role,
+				"--runtime-class-name=s3",
+				"--ray-cluster-name=" + tt.clusterName,
+				"--ray-root-dir=log",
+				fmt.Sprintf("--events-port=%d", collectorPort),
+			}
+			assert.Equal(t, expectedCommand, collector.Command)
+
+			// Verify S3 env vars on collector (env var pattern, not ConfigMap)
+			collectorEnvMap := make(map[string]string)
+			collectorSecretEnvs := make(map[string]string) // name -> secret name
+			for _, e := range collector.Env {
+				if e.ValueFrom != nil && e.ValueFrom.SecretKeyRef != nil {
+					collectorSecretEnvs[e.Name] = e.ValueFrom.SecretKeyRef.Name
+				} else {
+					collectorEnvMap[e.Name] = e.Value
+				}
+			}
+
+			// AWS credentials from secret
+			assert.Equal(t, "aws-credentials", collectorSecretEnvs["AWS_ACCESS_KEY_ID"])
+			assert.Equal(t, "aws-credentials", collectorSecretEnvs["AWS_SECRET_ACCESS_KEY"])
+
+			// S3 config env vars
+			assert.Equal(t, "", collectorEnvMap["AWS_SESSION_TOKEN"])
+			assert.Equal(t, "ray-history", collectorEnvMap["S3_BUCKET"])
+			assert.Equal(t, "minio:9091", collectorEnvMap["S3_ENDPOINT"])
+			assert.Equal(t, "us-east-1", collectorEnvMap["S3_REGION"])
+			assert.Equal(t, "true", collectorEnvMap["S3FORCE_PATH_STYLE"])
+			assert.Equal(t, "true", collectorEnvMap["S3DISABLE_SSL"])
+
+			// Head-specific env vars
+			if tt.role == "Head" {
+				assert.Equal(t, "http://localhost:8265", collectorEnvMap["RAY_DASHBOARD_ADDRESS"])
+				assert.NotEmpty(t, collectorEnvMap["RAY_COLLECTOR_ADDITIONAL_ENDPOINTS"])
+				assert.Equal(t, "30s", collectorEnvMap["RAY_COLLECTOR_POLL_INTERVAL"])
+			} else {
+				_, hasDashboard := collectorEnvMap["RAY_DASHBOARD_ADDRESS"]
+				assert.False(t, hasDashboard, "worker collector should not have RAY_DASHBOARD_ADDRESS")
+			}
+
+			// Verify collector port
+			require.Len(t, collector.Ports, 1)
+			assert.Equal(t, "events", collector.Ports[0].Name)
+			assert.Equal(t, int32(collectorPort), collector.Ports[0].ContainerPort)
+
+			// Verify collector resources
+			assert.Equal(t, resource.MustParse("100m"), collector.Resources.Requests[corev1.ResourceCPU])
+			assert.Equal(t, resource.MustParse("128Mi"), collector.Resources.Requests[corev1.ResourceMemory])
+
+			// Verify collector volume mounts (ray-logs only, no ConfigMap)
+			require.Len(t, collector.VolumeMounts, 1)
+			assert.Equal(t, "ray-logs", collector.VolumeMounts[0].Name)
+			assert.Equal(t, "/tmp/ray", collector.VolumeMounts[0].MountPath)
+		})
+	}
+}
+
+func TestInjectCollectorSidecar_PreservesExistingLifecycle(t *testing.T) {
+	config := LogPersistenceConfig{
+		Enabled:           true,
+		StorageEndpoint:   "minio:9091",
+		Bucket:            "ray-history",
+		Region:            "us-east-1",
+		CredentialsSecret: "aws-credentials",
+		CollectorImage:    "kuberay-collector:local",
+	}
+
+	pt := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "ray-head",
+					Image: "rayproject/ray:2.10.0",
+					Lifecycle: &corev1.Lifecycle{
+						PreStop: &corev1.LifecycleHandler{
+							Exec: &corev1.ExecAction{
+								Command: []string{"/bin/sh", "-c", "ray stop"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	injectCollectorSidecar(pt, config, "test-cluster", "default", "Head")
+
+	// PostStart should be set
+	require.NotNil(t, pt.Spec.Containers[0].Lifecycle.PostStart)
+	// PreStop should be preserved
+	require.NotNil(t, pt.Spec.Containers[0].Lifecycle.PreStop)
+	assert.Equal(t, []string{"/bin/sh", "-c", "ray stop"}, pt.Spec.Containers[0].Lifecycle.PreStop.Exec.Command)
+}
+
+func TestInjectCollectorSidecar_DisabledConfig(t *testing.T) {
+	// When config.Enabled is false, the caller (mapRayCluster) should not call injectCollectorSidecar.
+	// This test verifies injectCollectorSidecar still works correctly if called — it always injects.
+	config := LogPersistenceConfig{
+		Enabled:           false,
+		StorageEndpoint:   "minio:9091",
+		Bucket:            "ray-history",
+		Region:            "us-east-1",
+		CredentialsSecret: "aws-credentials",
+		CollectorImage:    "kuberay-collector:local",
+	}
+
+	pt := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "ray-head", Image: "rayproject/ray:2.10.0"},
+			},
+		},
+	}
+
+	injectCollectorSidecar(pt, config, "test-cluster", "default", "Head")
+
+	// Function always injects when called — the enabled check is the caller's responsibility
+	require.Len(t, pt.Spec.Containers, 2)
+	assert.Equal(t, "collector", pt.Spec.Containers[1].Name)
+}

--- a/go/components/jobs/client/module.go
+++ b/go/components/jobs/client/module.go
@@ -11,6 +11,7 @@ import (
 // related operations
 var Module = fx.Options(
 	fx.Provide(NewClient),
+	fx.Provide(k8sengine.NewLogPersistenceConfig),
 	fx.Provide(k8sengine.NewMapper),
 	fx.Provide(NewHelper),
 	compute.Module,

--- a/go/components/ray/cluster/config.go
+++ b/go/components/ray/cluster/config.go
@@ -12,6 +12,19 @@ type (
 	Config struct {
 		QPS   float32 `yaml:"k8sQps"`
 		Burst int     `yaml:"k8sBurst"`
+
+		// Log persistence platform-level config (for computing log_url on cluster status)
+		LogPersistence LogPersistenceConfig `yaml:"logPersistence"`
+	}
+
+	LogPersistenceConfig struct {
+		Enabled           bool   `yaml:"enabled"`
+		Bucket            string `yaml:"bucket"`             // S3 bucket name (e.g. "ray-history")
+		PathPrefix        string `yaml:"pathPrefix"`         // Key prefix under the bucket (e.g. "clusters/")
+		StorageEndpoint   string `yaml:"storageEndpoint"`   // S3-compatible endpoint (used by mapper)
+		Region            string `yaml:"region"`             // S3 region (used by mapper)
+		CredentialsSecret string `yaml:"credentialsSecret"`  // K8s Secret name (used by mapper)
+		CollectorImage    string `yaml:"collectorImage"`     // Collector sidecar image (used by mapper)
 	}
 )
 

--- a/go/components/ray/cluster/controller.go
+++ b/go/components/ray/cluster/controller.go
@@ -49,6 +49,7 @@ const (
 type Reconciler struct {
 	api.Handler // API client for managing API objects
 
+	config            Config                              // Controller configuration including log persistence
 	logger            logr.Logger                         // Logger for the controller
 	apiHandlerFactory apiHandler.Factory                  // Factory for creating API handlers
 	env               env.Context                         // Environment context for configuration
@@ -62,6 +63,7 @@ type Reconciler struct {
 // This provides a stable construction API for downstream users so they do not
 // need to rely on reflection to set unexported fields.
 func NewReconciler(
+	config Config,
 	logger logr.Logger,
 	apiHandlerFactory apiHandler.Factory,
 	env env.Context,
@@ -70,6 +72,7 @@ func NewReconciler(
 	clusterCache jobscluster.RegisteredClustersCache,
 ) *Reconciler {
 	return &Reconciler{
+		config:            config,
 		logger:            logger,
 		apiHandlerFactory: apiHandlerFactory,
 		env:               env,
@@ -174,6 +177,17 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			func(obj client.Object) {
 				cluster := obj.(*v2pb.RayCluster)
 				cluster.Status.State = v2pb.RAY_CLUSTER_STATE_PROVISIONING
+
+				// Set log_url when log persistence is enabled
+				if r.config.LogPersistence.Enabled {
+					cluster.Status.LogUrl = fmt.Sprintf("s3://%s/%s%s/%s/",
+						r.config.LogPersistence.Bucket,
+						r.config.LogPersistence.PathPrefix,
+						cluster.GetNamespace(),
+						cluster.GetName(),
+					)
+				}
+
 				launchedCond := jobsutils.GetCondition(&cluster.Status.StatusConditions, LaunchedCondition, cluster.Generation)
 				jobsutils.UpdateCondition(launchedCond, jobsutils.ConditionUpdateParams{
 					Status:     apipb.CONDITION_STATUS_TRUE,

--- a/go/components/ray/cluster/controller_test.go
+++ b/go/components/ray/cluster/controller_test.go
@@ -170,6 +170,7 @@ func TestReconcilerReconcile(t *testing.T) {
 	// Test cases
 	tests := []struct {
 		name             string
+		config           Config
 		setup            func() []client.Object
 		setupMocks       func(*clientmocks.MockFederatedClient, *mockClusterCache, *mockSchedulerQueue)
 		expectedState    v2pb.RayClusterState
@@ -920,6 +921,109 @@ func TestReconcilerReconcile(t *testing.T) {
 				assert.Equal(t, apipb.CONDITION_STATUS_TRUE, killedCond.Status)
 			},
 		},
+		{
+			name: "Cluster created with log persistence enabled - log_url set in status",
+			config: Config{
+				LogPersistence: LogPersistenceConfig{
+					Enabled:    true,
+					Bucket:     "ray-history",
+					PathPrefix: "clusters/",
+				},
+			},
+			setup: func() []client.Object {
+				objects := make([]client.Object, 0)
+				cluster := &v2pb.RayCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       rayClusterName,
+						Namespace:  testNamespace,
+						Generation: 1,
+					},
+					Spec: createRayClusterSpec(),
+					Status: v2pb.RayClusterStatus{
+						StatusConditions: []*apipb.Condition{
+							{
+								Type:   EnqueuedCondition,
+								Status: apipb.CONDITION_STATUS_TRUE,
+							},
+							{
+								Type:   ScheduledCondition,
+								Status: apipb.CONDITION_STATUS_TRUE,
+							},
+						},
+						Assignment: &v2pb.AssignmentInfo{
+							Cluster: assignedCluster,
+						},
+					},
+				}
+				objects = append(objects, cluster)
+				return objects
+			},
+			setupMocks: func(mfc *clientmocks.MockFederatedClient, mcc *mockClusterCache, msq *mockSchedulerQueue) {
+				mcc.addCluster(assignedCluster, &v2pb.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: assignedCluster,
+					},
+				})
+				mfc.EXPECT().CreateJobCluster(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			},
+			expectedState:   v2pb.RAY_CLUSTER_STATE_PROVISIONING,
+			expectedMessage: "",
+			errorAssertion:  require.NoError,
+			postCheck: func(res ctrl.Result) {
+				assert.Equal(t, requeueAfter, res.RequeueAfter)
+			},
+			verifyConditions: func(t *testing.T, cluster *v2pb.RayCluster) {
+				assert.Equal(t, "s3://ray-history/clusters/default/test-cluster/", cluster.Status.LogUrl)
+			},
+		},
+		{
+			name: "Cluster created without log persistence - log_url not set",
+			setup: func() []client.Object {
+				objects := make([]client.Object, 0)
+				cluster := &v2pb.RayCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       rayClusterName,
+						Namespace:  testNamespace,
+						Generation: 1,
+					},
+					Spec: createRayClusterSpec(),
+					Status: v2pb.RayClusterStatus{
+						StatusConditions: []*apipb.Condition{
+							{
+								Type:   EnqueuedCondition,
+								Status: apipb.CONDITION_STATUS_TRUE,
+							},
+							{
+								Type:   ScheduledCondition,
+								Status: apipb.CONDITION_STATUS_TRUE,
+							},
+						},
+						Assignment: &v2pb.AssignmentInfo{
+							Cluster: assignedCluster,
+						},
+					},
+				}
+				objects = append(objects, cluster)
+				return objects
+			},
+			setupMocks: func(mfc *clientmocks.MockFederatedClient, mcc *mockClusterCache, msq *mockSchedulerQueue) {
+				mcc.addCluster(assignedCluster, &v2pb.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: assignedCluster,
+					},
+				})
+				mfc.EXPECT().CreateJobCluster(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			},
+			expectedState:   v2pb.RAY_CLUSTER_STATE_PROVISIONING,
+			expectedMessage: "",
+			errorAssertion:  require.NoError,
+			postCheck: func(res ctrl.Result) {
+				assert.Equal(t, requeueAfter, res.RequeueAfter)
+			},
+			verifyConditions: func(t *testing.T, cluster *v2pb.RayCluster) {
+				assert.Empty(t, cluster.Status.LogUrl)
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -940,6 +1044,7 @@ func TestReconcilerReconcile(t *testing.T) {
 
 			r := &Reconciler{
 				Handler:         apiHandler,
+				config:          tc.config,
 				federatedClient: mockFedClient,
 				clusterCache:    mockCache,
 				schedulerQueue:  mockQueue,

--- a/go/components/ray/cluster/module.go
+++ b/go/components/ray/cluster/module.go
@@ -29,6 +29,7 @@ func register(
 	clusterCache cluster.RegisteredClustersCache,
 ) error {
 	return NewReconciler(
+		conf,
 		logger,
 		apiHandlerFactory,
 		env,

--- a/proto-go/api/v2/ray_cluster.pb.go
+++ b/proto-go/api/v2/ray_cluster.pb.go
@@ -211,13 +211,13 @@ func (m *RayWorkerSpec) GetRayStartParams() map[string]string {
 }
 
 type RayClusterSpec struct {
-	User        *UserInfo         `protobuf:"bytes,1,opt,name=user,proto3" json:"user,omitempty"`
-	RayVersion  string            `protobuf:"bytes,2,opt,name=ray_version,json=rayVersion,proto3" json:"rayVersion,omitempty"`
-	Head        *RayHeadSpec      `protobuf:"bytes,3,opt,name=head,proto3" json:"head,omitempty"`
-	Workers     []*RayWorkerSpec  `protobuf:"bytes,4,rep,name=workers,proto3" json:"workers,omitempty"`
-	RayConf     map[string]string `protobuf:"bytes,5,rep,name=ray_conf,json=rayConf,proto3" json:"rayConf,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	Termination *TerminationSpec  `protobuf:"bytes,6,opt,name=termination,proto3" json:"termination,omitempty"`
-	Scheduling  *SchedulingSpec   `protobuf:"bytes,7,opt,name=scheduling,proto3" json:"scheduling,omitempty"`
+	User           *UserInfo           `protobuf:"bytes,1,opt,name=user,proto3" json:"user,omitempty"`
+	RayVersion     string              `protobuf:"bytes,2,opt,name=ray_version,json=rayVersion,proto3" json:"rayVersion,omitempty"`
+	Head           *RayHeadSpec        `protobuf:"bytes,3,opt,name=head,proto3" json:"head,omitempty"`
+	Workers        []*RayWorkerSpec    `protobuf:"bytes,4,rep,name=workers,proto3" json:"workers,omitempty"`
+	RayConf        map[string]string   `protobuf:"bytes,5,rep,name=ray_conf,json=rayConf,proto3" json:"rayConf,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	Termination    *TerminationSpec    `protobuf:"bytes,6,opt,name=termination,proto3" json:"termination,omitempty"`
+	Scheduling     *SchedulingSpec     `protobuf:"bytes,7,opt,name=scheduling,proto3" json:"scheduling,omitempty"`
 }
 
 func (m *RayClusterSpec) Reset()      { *m = RayClusterSpec{} }
@@ -460,6 +460,7 @@ type RayClusterStatus struct {
 	StatusConditions []*api.Condition `protobuf:"bytes,7,rep,name=status_conditions,json=statusConditions,proto3" json:"statusConditions,omitempty"`
 	JobUrl           string           `protobuf:"bytes,8,opt,name=job_url,json=jobUrl,proto3" json:"jobUrl,omitempty"`
 	PodErrors        []*PodErrors     `protobuf:"bytes,9,rep,name=pod_errors,json=podErrors,proto3" json:"podErrors,omitempty"`
+	LogUrl           string           `protobuf:"bytes,10,opt,name=log_url,json=logUrl,proto3" json:"logUrl,omitempty"`
 }
 
 func (m *RayClusterStatus) Reset()      { *m = RayClusterStatus{} }
@@ -548,6 +549,13 @@ func (m *RayClusterStatus) GetPodErrors() []*PodErrors {
 		return m.PodErrors
 	}
 	return nil
+}
+
+func (m *RayClusterStatus) GetLogUrl() string {
+	if m != nil {
+		return m.LogUrl
+	}
+	return ""
 }
 
 func (m *RayCluster) Reset()      { *m = RayCluster{} }

--- a/proto/api/v2/ray_cluster.proto
+++ b/proto/api/v2/ray_cluster.proto
@@ -227,6 +227,10 @@ message RayClusterStatus {
   // Each error entry provides detailed context, such as error type, associated pod name, and timestamps of occurrences.
   // This information aids in root cause analysis and accelerates resolution of cluster failures.
   repeated PodErrors pod_errors = 9;
+
+  // URL to the History Server UI for viewing persisted logs and cluster metadata.
+  // Populated when log persistence is enabled and the History Server is available.
+  string log_url = 10;
 }
 
 


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
- Add `LogPersistenceConfig` struct with all S3 backend fields (bucket,
  pathPrefix, storageEndpoint, region, credentialsSecret, collectorImage)
  in `go/components/ray/cluster/config.go`
- Wire `LogPersistenceConfig` into the RayCluster `Reconciler` via the
  FX module (`go/components/ray/cluster/module.go`); `NewReconciler` now
  takes the config as a constructor parameter
- In `Reconciler.Reconcile()`, when `config.LogPersistence.Enabled` is
  true, populate `cluster.Status.LogUrl` with a deterministic S3 path —
  `s3://<bucket>/<pathPrefix><namespace>/<cluster>/` — so clients
  (apiserver / UI) can show users where their cluster's logs are persisted
- Provide controllermgr `base.yaml` defaults pointing at the sandbox MinIO
  (endpoint `minio:9091`, bucket `ray-history`, prefix `clusters/`,
  collector image `kuberay-collector:local`)
- Unit tests in `controller_test.go` cover both the enabled and disabled
  paths for `LogUrl` population

**Why?**
Enable RayHistoryServer for RayClusters

**How did you test it?**
- Unit tests in `controller_test.go
- End-to-end validation runs in the upcoming sandbox PR 

**Potential risks**
NA — 

**Release notes**

- New `controllers.rayCluster.logPersistence` config block in
  controllermgr (default values target the OSS sandbox MinIO; production
  deployments must override via a `prod.yaml` overlay — tracked in PR
  #6 production-rollout-plan)
- New `log_url` field on `RayClusterStatus` (proto field added in #1
  proto-log-persistence; populated by this PR when log persistence is
  enabled)
  proto field

**Documentation Changes**
NA