### PR TITLE
docs: add MLflow integration guide

### DIFF
--- a/docs/operator-guides/integrations/index.md
+++ b/docs/operator-guides/integrations/index.md
@@ -17,6 +17,7 @@ These guides cover connecting Michelangelo to systems your organization already 
 | Guide | Description |
 |-------|-------------|
 | [Experiment Tracking](experiment-tracking.md) | Expose an external experiment tracking server to task pods — network setup, URI injection, and operator/user boundary |
+| [MLflow](mlflow.md) | Connect a self-hosted or managed MLflow Tracking Server — ConfigMap injection, authentication, and registry comparison |
 
 ## Extending Built-in Components
 

--- a/docs/operator-guides/integrations/mlflow.md
+++ b/docs/operator-guides/integrations/mlflow.md
@@ -1,6 +1,6 @@
 # MLflow Integration
 
-This guide explains how platform operators can connect MLflow to Michelangelo workloads. MLflow overlaps with two Michelangelo capabilities — experiment tracking and the model registry — so this guide covers both, along with the boundary between what operators configure and what users do in their `@uniflow.task()` code.
+This guide explains how platform operators can connect an [MLflow Tracking Server](https://mlflow.org/docs/latest/tracking.html) to Michelangelo workloads. MLflow overlaps with two Michelangelo capabilities — experiment tracking and the model registry — so this guide covers both, along with the boundary between what operators configure and what users do in their `@uniflow.task()` code.
 
 Michelangelo does not bundle an MLflow server. This guide assumes you are running a self-hosted MLflow Tracking Server or a managed endpoint (such as Databricks Managed MLflow).
 
@@ -30,10 +30,9 @@ Michelangelo does not intercept or wrap MLflow calls. Users call the MLflow clie
 
 ## Prerequisites
 
-- A running MLflow Tracking Server accessible from your Kubernetes cluster.
-- The server URI (e.g., `http://mlflow.internal:5000` or a managed endpoint URL).
+- A running MLflow Tracking Server accessible from your Kubernetes cluster. Replace `http://mlflow.example.com:5000` in the examples below with your actual server address.
 - Sufficient RBAC to create ConfigMaps and patch namespace-scoped resources in the compute cluster namespace.
-- The `mlflow` Python package available in the task's Docker image.
+- The `mlflow` Python package available in the task's Docker image (users add this to their `requirements.txt`).
 
 ---
 
@@ -47,10 +46,10 @@ kubectl run mlflow-connectivity-test \
   --namespace=<compute-namespace> \
   --restart=Never \
   --rm -it -- \
-  curl -sv http://mlflow.internal:5000/health
+  curl -sv http://mlflow.example.com:5000/health
 ```
 
-A `200 OK` response confirms reachability. If the MLflow server is outside the cluster (e.g., Databricks or a SaaS endpoint), also confirm egress is allowed by any NetworkPolicy rules on the namespace.
+A `200 OK` response confirms reachability. If the MLflow server is outside the cluster (for example, Databricks or a SaaS endpoint), also confirm egress is allowed by any NetworkPolicy rules on the namespace.
 
 If you need to add an egress rule for task pods:
 
@@ -67,11 +66,13 @@ spec:
   policyTypes:
     - Egress
   egress:
+    # Allow DNS resolution
     - ports:
         - protocol: UDP
           port: 53
         - protocol: TCP
           port: 53
+    # Allow egress to the MLflow server
     - to:
         - ipBlock:
             cidr: <mlflow-server-ip>/32
@@ -92,7 +93,7 @@ Michelangelo injects the `michelangelo-config` ConfigMap as an `envFrom` source 
 kubectl patch configmap michelangelo-config \
   --namespace=<compute-namespace> \
   --type=merge \
-  -p '{"data":{"MLFLOW_TRACKING_URI":"http://mlflow.internal:5000"}}'
+  -p '{"data":{"MLFLOW_TRACKING_URI":"http://mlflow.example.com:5000"}}'
 ```
 
 Or add it to your existing declarative ConfigMap manifest:
@@ -111,13 +112,13 @@ data:
   AWS_SECRET_ACCESS_KEY: <your-secret-access-key>
   AWS_ENDPOINT_URL: <your-storage-endpoint>
   # MLflow
-  MLFLOW_TRACKING_URI: "http://mlflow.internal:5000"
+  MLFLOW_TRACKING_URI: "http://mlflow.example.com:5000"
 ```
 
 New pods pick up the change automatically. Already-running pods will not see the update until they are replaced.
 
 :::tip
-`MLFLOW_TRACKING_URI` is the environment variable that MLflow's client reads natively — no extra configuration is needed in user task code.
+`MLFLOW_TRACKING_URI` is the environment variable that MLflow's Python client reads natively — no extra configuration is needed in user task code.
 :::
 
 ---
@@ -133,7 +134,7 @@ kubectl patch configmap michelangelo-config \
   --namespace=<compute-namespace> \
   --type=merge \
   -p '{"data":{
-    "MLFLOW_TRACKING_URI":"http://mlflow.internal:5000",
+    "MLFLOW_TRACKING_URI":"http://mlflow.example.com:5000",
     "MLFLOW_TRACKING_USERNAME":"<username>",
     "MLFLOW_TRACKING_PASSWORD":"<password>"
   }}'
@@ -190,13 +191,13 @@ def train_model(train_data, config: dict):
 Users are responsible for:
 - Including `mlflow` in their task's Docker image (add to `requirements.txt` or the project Dockerfile).
 - Starting and ending MLflow runs inside the task function.
-- Ensuring their `mlflow` client version is compatible with the server version your organization runs.
+- Ensuring their `mlflow` client version is compatible with the server version your organization runs. See the [MLflow compatibility matrix](https://mlflow.org/docs/latest/getting-started/index.html) for details.
 
 ---
 
 ## MLflow Model Registry vs Michelangelo Model Registry
 
-MLflow includes its own model registry. Michelangelo also has a built-in model registry backed by a `Model` Kubernetes custom resource. The two are independent.
+MLflow includes its own model registry. Michelangelo also has a built-in model registry backed by a `Model` Kubernetes custom resource. The two are independent and can be used simultaneously.
 
 | | MLflow Model Registry | Michelangelo Model Registry |
 |---|---|---|
@@ -221,7 +222,7 @@ After applying the configuration, confirm the environment variable is visible in
 kubectl exec -it <task-pod-name> -n <compute-namespace> -- env | grep MLFLOW
 ```
 
-You can also run a minimal test task that validates connectivity end-to-end:
+You can also run a minimal test task that validates connectivity end-to-end. Submit it using your normal pipeline execution method, then check the logs for the output:
 
 ```python
 import os
@@ -255,9 +256,10 @@ def check_mlflow_connection():
 
 ---
 
-## Related
+## Next Steps
 
-- [Experiment Tracking Integration](experiment-tracking.md) — general guide for connecting any experiment tracking server
-- [Model Registry Integration](model-registry.md) — Michelangelo's built-in model registry
-- [Register a Compute Cluster](../jobs/register-a-compute-cluster-to-michelangelo-control-plane.md)
-- [Platform Setup](../platform-setup.md)
+- [Experiment Tracking Integration](experiment-tracking.md) — general guide for connecting any experiment tracking server to Michelangelo
+- [Model Registry Integration](model-registry.md) — Michelangelo's built-in model registry: storage configuration, RBAC, and serving integration
+- [Register a Compute Cluster](../jobs/register-a-compute-cluster-to-michelangelo-control-plane.md) — how to add a Kubernetes cluster so Michelangelo can dispatch jobs to it
+- [Platform Setup](../platform-setup.md) — full ConfigMap reference for all Michelangelo components
+- [MLflow Documentation](https://mlflow.org/docs/latest/) — official MLflow docs for tracking, model registry, and deployment

--- a/docs/operator-guides/integrations/mlflow.md
+++ b/docs/operator-guides/integrations/mlflow.md
@@ -222,24 +222,14 @@ After applying the configuration, confirm the environment variable is visible in
 kubectl exec -it <task-pod-name> -n <compute-namespace> -- env | grep MLFLOW
 ```
 
-You can also run a minimal test task that validates connectivity end-to-end. Submit it using your normal pipeline execution method, then check the logs for the output:
+You can also verify end-to-end reachability from a task pod by running a connectivity check against the MLflow health endpoint:
 
-```python
-import os
-import mlflow
-import michelangelo.uniflow.core as uniflow
-from michelangelo.uniflow.plugins.ray import RayTask
-
-@uniflow.task(config=RayTask(head_cpu=1, head_memory="1Gi"))
-def check_mlflow_connection():
-    uri = os.environ.get("MLFLOW_TRACKING_URI", "NOT SET")
-    print(f"MLflow tracking URI: {uri}")
-    if uri == "NOT SET":
-        raise ValueError("MLFLOW_TRACKING_URI is not set")
-    client = mlflow.MlflowClient()
-    experiments = client.search_experiments()
-    print(f"Reachable — found {len(experiments)} experiment(s)")
+```bash
+kubectl exec -it <task-pod-name> -n <compute-namespace> -- \
+  curl -sv http://mlflow.example.com:5000/health
 ```
+
+A `200 OK` response confirms both the environment variable injection and network reachability are working correctly.
 
 ---
 

--- a/docs/operator-guides/integrations/mlflow.md
+++ b/docs/operator-guides/integrations/mlflow.md
@@ -1,0 +1,263 @@
+# MLflow Integration
+
+This guide explains how platform operators can connect MLflow to Michelangelo workloads. MLflow overlaps with two Michelangelo capabilities — experiment tracking and the model registry — so this guide covers both, along with the boundary between what operators configure and what users do in their `@uniflow.task()` code.
+
+Michelangelo does not bundle an MLflow server. This guide assumes you are running a self-hosted MLflow Tracking Server or a managed endpoint (such as Databricks Managed MLflow).
+
+---
+
+## How MLflow Works with Michelangelo
+
+```
+┌─────────────────────────────────────────────┐
+│ Operator Responsibility                     │
+│ ├─ Deploy or point to an MLflow server      │
+│ ├─ Ensure network reachability from pods    │
+│ └─ Inject MLFLOW_TRACKING_URI via ConfigMap │
+└─────────────────────────────────────────────┘
+                     ↓
+┌─────────────────────────────────────────────┐
+│ User Responsibility (task code)             │
+│ ├─ Import mlflow inside @uniflow.task()     │
+│ ├─ Read URI from environment variable       │
+│ └─ Log runs, params, metrics, artifacts     │
+└─────────────────────────────────────────────┘
+```
+
+Michelangelo does not intercept or wrap MLflow calls. Users call the MLflow client directly inside `@uniflow.task()` functions; Michelangelo provides the environment variable injection and network access.
+
+---
+
+## Prerequisites
+
+- A running MLflow Tracking Server accessible from your Kubernetes cluster.
+- The server URI (e.g., `http://mlflow.internal:5000` or a managed endpoint URL).
+- Sufficient RBAC to create ConfigMaps and patch namespace-scoped resources in the compute cluster namespace.
+- The `mlflow` Python package available in the task's Docker image.
+
+---
+
+## Step 1: Verify Network Reachability
+
+Task pods run inside the compute cluster namespace registered with Michelangelo. Confirm that pods in that namespace can reach your MLflow server before proceeding.
+
+```bash
+kubectl run mlflow-connectivity-test \
+  --image=curlimages/curl \
+  --namespace=<compute-namespace> \
+  --restart=Never \
+  --rm -it -- \
+  curl -sv http://mlflow.internal:5000/health
+```
+
+A `200 OK` response confirms reachability. If the MLflow server is outside the cluster (e.g., Databricks or a SaaS endpoint), also confirm egress is allowed by any NetworkPolicy rules on the namespace.
+
+If you need to add an egress rule for task pods:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-mlflow-egress
+  namespace: <compute-namespace>
+spec:
+  podSelector:
+    matchLabels:
+      <your-pod-selector-label>: <your-value>
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - ipBlock:
+            cidr: <mlflow-server-ip>/32
+      ports:
+        - protocol: TCP
+          port: 5000
+```
+
+Replace `<your-pod-selector-label>` with labels that match your task pods. Check the actual labels with `kubectl get pods -n <compute-namespace> --show-labels`.
+
+---
+
+## Step 2: Inject the Tracking URI into the ConfigMap
+
+Michelangelo injects the `michelangelo-config` ConfigMap as an `envFrom` source into every task pod. Adding a key here makes it available as an environment variable in all Ray and Spark pods dispatched by Michelangelo.
+
+```bash
+kubectl patch configmap michelangelo-config \
+  --namespace=<compute-namespace> \
+  --type=merge \
+  -p '{"data":{"MLFLOW_TRACKING_URI":"http://mlflow.internal:5000"}}'
+```
+
+Or add it to your existing declarative ConfigMap manifest:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: michelangelo-config
+  namespace: <compute-namespace>
+data:
+  # Existing keys
+  MA_FILE_SYSTEM: s3://default
+  MA_FILE_SYSTEM_S3_SCHEME: http
+  AWS_ACCESS_KEY_ID: <your-access-key-id>
+  AWS_SECRET_ACCESS_KEY: <your-secret-access-key>
+  AWS_ENDPOINT_URL: <your-storage-endpoint>
+  # MLflow
+  MLFLOW_TRACKING_URI: "http://mlflow.internal:5000"
+```
+
+New pods pick up the change automatically. Already-running pods will not see the update until they are replaced.
+
+:::tip
+`MLFLOW_TRACKING_URI` is the environment variable that MLflow's client reads natively — no extra configuration is needed in user task code.
+:::
+
+---
+
+## Step 3: Handle Authentication
+
+### Self-hosted MLflow with basic auth
+
+If your MLflow server requires HTTP basic authentication, add the credentials to the ConfigMap:
+
+```bash
+kubectl patch configmap michelangelo-config \
+  --namespace=<compute-namespace> \
+  --type=merge \
+  -p '{"data":{
+    "MLFLOW_TRACKING_URI":"http://mlflow.internal:5000",
+    "MLFLOW_TRACKING_USERNAME":"<username>",
+    "MLFLOW_TRACKING_PASSWORD":"<password>"
+  }}'
+```
+
+MLflow's client reads `MLFLOW_TRACKING_USERNAME` and `MLFLOW_TRACKING_PASSWORD` natively.
+
+:::warning
+`michelangelo-config` is a ConfigMap, not a Secret — values are stored in plaintext in etcd. For production environments, consider using [workload identity](https://kubernetes.io/docs/concepts/security/service-accounts/) (IRSA on AWS, Workload Identity on GKE) so that task pods authenticate to MLflow via IAM roles rather than static credentials.
+:::
+
+### Databricks Managed MLflow
+
+If you are using Databricks Managed MLflow, set the following keys:
+
+```bash
+kubectl patch configmap michelangelo-config \
+  --namespace=<compute-namespace> \
+  --type=merge \
+  -p '{"data":{
+    "MLFLOW_TRACKING_URI":"databricks",
+    "DATABRICKS_HOST":"https://<your-workspace>.azuredatabricks.net",
+    "DATABRICKS_TOKEN":"<your-personal-access-token>"
+  }}'
+```
+
+---
+
+## What Users Do (Task Code)
+
+Once the operator has completed the steps above, users can use MLflow from any `@uniflow.task()` function without any extra configuration — the MLflow client reads `MLFLOW_TRACKING_URI` from the environment automatically.
+
+```python
+import mlflow
+import michelangelo.uniflow.core as uniflow
+from michelangelo.uniflow.plugins.ray import RayTask
+
+@uniflow.task(config=RayTask(head_cpu=2, head_memory="4Gi"))
+def train_model(train_data, config: dict):
+    mlflow.set_experiment("fraud-detection")
+
+    with mlflow.start_run(run_name="xgboost-baseline"):
+        mlflow.log_params(config)
+
+        model = _train(train_data, config)
+
+        mlflow.log_metric("auc", model.auc)
+        mlflow.log_metric("precision", model.precision)
+        mlflow.sklearn.log_model(model, artifact_path="model")
+
+    return model
+```
+
+Users are responsible for:
+- Including `mlflow` in their task's Docker image (add to `requirements.txt` or the project Dockerfile).
+- Starting and ending MLflow runs inside the task function.
+- Ensuring their `mlflow` client version is compatible with the server version your organization runs.
+
+---
+
+## MLflow Model Registry vs Michelangelo Model Registry
+
+MLflow includes its own model registry. Michelangelo also has a built-in model registry backed by a `Model` Kubernetes custom resource. The two are independent.
+
+| | MLflow Model Registry | Michelangelo Model Registry |
+|---|---|---|
+| Backed by | MLflow Tracking Server database | Kubernetes `Model` CRD + S3 |
+| Queried via | MLflow client / MLflow UI | `kubectl get models` / `ma model get` |
+| Integrates with serving | MLflow serving (`mlflow models serve`) | Michelangelo `InferenceServer` |
+| Required for Michelangelo pipelines? | No | No |
+
+**When to use MLflow's registry:** If your organization already uses MLflow for model governance, lineage, and stage transitions (Staging → Production), continue using it. Michelangelo does not require you to use its own registry.
+
+**When to use Michelangelo's registry:** If you want models to be deployable via Michelangelo's `InferenceServer` (Triton, vLLM, etc.), register them in Michelangelo's registry using the `@uniflow.task()` model registration API. You can do this in addition to logging to MLflow.
+
+**Using both:** Log experiments and register models to MLflow for lineage and governance, and separately register the deployable artifact to Michelangelo for serving. Both calls can live in the same task function.
+
+---
+
+## Verification
+
+After applying the configuration, confirm the environment variable is visible inside a task pod:
+
+```bash
+kubectl exec -it <task-pod-name> -n <compute-namespace> -- env | grep MLFLOW
+```
+
+You can also run a minimal test task that validates connectivity end-to-end:
+
+```python
+import os
+import mlflow
+import michelangelo.uniflow.core as uniflow
+from michelangelo.uniflow.plugins.ray import RayTask
+
+@uniflow.task(config=RayTask(head_cpu=1, head_memory="1Gi"))
+def check_mlflow_connection():
+    uri = os.environ.get("MLFLOW_TRACKING_URI", "NOT SET")
+    print(f"MLflow tracking URI: {uri}")
+    if uri == "NOT SET":
+        raise ValueError("MLFLOW_TRACKING_URI is not set")
+    client = mlflow.MlflowClient()
+    experiments = client.search_experiments()
+    print(f"Reachable — found {len(experiments)} experiment(s)")
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Resolution |
+|---|---|---|
+| `MLFLOW_TRACKING_URI` not set in pod | ConfigMap patch not applied, or pod predates the patch | Verify with `kubectl get configmap michelangelo-config -n <compute-namespace> -o yaml`; restart pods if needed |
+| `ConnectionRefusedError` or `requests.exceptions.ConnectionError` | MLflow server unreachable from pod | Re-run the connectivity test from Step 1; check NetworkPolicy and firewall rules |
+| `RestException: PERMISSION_DENIED` | Credentials missing or incorrect | Verify `MLFLOW_TRACKING_USERNAME` / `MLFLOW_TRACKING_PASSWORD` are set; check MLflow server auth config |
+| `mlflow: command not found` / `ModuleNotFoundError` | `mlflow` not in task's Docker image | Add `mlflow` to `requirements.txt` or the project Dockerfile |
+| MLflow run logged but artifacts missing | Artifact store (S3/GCS) unreachable from pod | Confirm task pod has access to the artifact store configured in the MLflow server |
+| `INVALID_PARAMETER_VALUE` on `log_model` | Client/server version mismatch | Pin `mlflow` to the same major version as the server |
+
+---
+
+## Related
+
+- [Experiment Tracking Integration](experiment-tracking.md) — general guide for connecting any experiment tracking server
+- [Model Registry Integration](model-registry.md) — Michelangelo's built-in model registry
+- [Register a Compute Cluster](../jobs/register-a-compute-cluster-to-michelangelo-control-plane.md)
+- [Platform Setup](../platform-setup.md)

--- a/docs/operator-guides/integrations/mlflow.md
+++ b/docs/operator-guides/integrations/mlflow.md
@@ -12,26 +12,25 @@ Michelangelo does not bundle an MLflow server. This guide assumes you are runnin
 ┌─────────────────────────────────────────────┐
 │ Operator Responsibility                     │
 │ ├─ Deploy or point to an MLflow server      │
-│ ├─ Ensure network reachability from pods    │
-│ └─ Inject MLFLOW_TRACKING_URI via ConfigMap │
+│ └─ Ensure network reachability from pods    │
 └─────────────────────────────────────────────┘
                      ↓
 ┌─────────────────────────────────────────────┐
 │ User Responsibility (task code)             │
+│ ├─ Set MLFLOW_TRACKING_URI in workflow code │
 │ ├─ Import mlflow inside @uniflow.task()     │
-│ ├─ Read URI from environment variable       │
 │ └─ Log runs, params, metrics, artifacts     │
 └─────────────────────────────────────────────┘
 ```
 
-Michelangelo does not intercept or wrap MLflow calls. Users call the MLflow client directly inside `@uniflow.task()` functions; Michelangelo provides the environment variable injection and network access.
+Michelangelo does not intercept or wrap MLflow calls. Users call the MLflow client directly inside `@uniflow.task()` functions and configure the tracking URI themselves. The operator's job is to ensure the MLflow server is reachable from task pods.
 
 ---
 
 ## Prerequisites
 
 - A running MLflow Tracking Server accessible from your Kubernetes cluster. Replace `http://mlflow.example.com:5000` in the examples below with your actual server address.
-- Sufficient RBAC to create ConfigMaps and patch namespace-scoped resources in the compute cluster namespace.
+- Sufficient RBAC to create NetworkPolicy resources in the compute cluster namespace if egress rules are needed.
 - The `mlflow` Python package available in the task's Docker image (users add this to their `requirements.txt`).
 
 ---
@@ -85,41 +84,35 @@ Replace `<your-pod-selector-label>` with labels that match your task pods. Check
 
 ---
 
-## Step 2: Inject the Tracking URI into the ConfigMap
+## Step 2: Configure the Tracking URI
 
-Michelangelo injects the `michelangelo-config` ConfigMap as an `envFrom` source into every task pod. Adding a key here makes it available as an environment variable in all Ray and Spark pods dispatched by Michelangelo.
+`MLFLOW_TRACKING_URI` is a user-space configuration — it belongs in workflow code or the Ray job pod environment, not in the Michelangelo system ConfigMap. Users should set it themselves using one of these approaches.
+
+### Option A: Set in workflow code
+
+The simplest approach is to call `mlflow.set_tracking_uri()` directly in the task or at the top of the workflow module:
+
+```python
+import mlflow
+import michelangelo.uniflow.core as uniflow
+from michelangelo.uniflow.plugins.ray import RayTask
+
+@uniflow.task(config=RayTask(head_cpu=2, head_memory="4Gi"))
+def train_model(train_data, config: dict):
+    mlflow.set_tracking_uri("http://mlflow.example.com:5000")
+    mlflow.set_experiment("fraud-detection")
+    ...
+```
+
+### Option B: Set via pipeline environment
+
+Users can pass `MLFLOW_TRACKING_URI` as an environment variable when submitting a pipeline run, keeping the URI out of source code:
 
 ```bash
-kubectl patch configmap michelangelo-config \
-  --namespace=<compute-namespace> \
-  --type=merge \
-  -p '{"data":{"MLFLOW_TRACKING_URI":"http://mlflow.example.com:5000"}}'
+ma pipeline dev-run -f pipeline.yaml --env MLFLOW_TRACKING_URI=http://mlflow.example.com:5000
 ```
 
-Or add it to your existing declarative ConfigMap manifest:
-
-```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: michelangelo-config
-  namespace: <compute-namespace>
-data:
-  # Existing keys
-  MA_FILE_SYSTEM: s3://default
-  MA_FILE_SYSTEM_S3_SCHEME: http
-  AWS_ACCESS_KEY_ID: <your-access-key-id>
-  AWS_SECRET_ACCESS_KEY: <your-secret-access-key>
-  AWS_ENDPOINT_URL: <your-storage-endpoint>
-  # MLflow
-  MLFLOW_TRACKING_URI: "http://mlflow.example.com:5000"
-```
-
-New pods pick up the change automatically. Already-running pods will not see the update until they are replaced.
-
-:::tip
-`MLFLOW_TRACKING_URI` is the environment variable that MLflow's Python client reads natively — no extra configuration is needed in user task code.
-:::
+In task code, MLflow reads `MLFLOW_TRACKING_URI` from the environment automatically — no explicit `set_tracking_uri()` call is needed when the variable is set.
 
 ---
 
@@ -127,45 +120,37 @@ New pods pick up the change automatically. Already-running pods will not see the
 
 ### Self-hosted MLflow with basic auth
 
-If your MLflow server requires HTTP basic authentication, add the credentials to the ConfigMap:
+If your MLflow server requires HTTP basic authentication, pass the credentials as pipeline environment variables:
 
 ```bash
-kubectl patch configmap michelangelo-config \
-  --namespace=<compute-namespace> \
-  --type=merge \
-  -p '{"data":{
-    "MLFLOW_TRACKING_URI":"http://mlflow.example.com:5000",
-    "MLFLOW_TRACKING_USERNAME":"<username>",
-    "MLFLOW_TRACKING_PASSWORD":"<password>"
-  }}'
+ma pipeline dev-run -f pipeline.yaml \
+  --env MLFLOW_TRACKING_URI=http://mlflow.example.com:5000 \
+  --env MLFLOW_TRACKING_USERNAME=<username> \
+  --env MLFLOW_TRACKING_PASSWORD=<password>
 ```
 
 MLflow's client reads `MLFLOW_TRACKING_USERNAME` and `MLFLOW_TRACKING_PASSWORD` natively.
 
 :::warning
-`michelangelo-config` is a ConfigMap, not a Secret — values are stored in plaintext in etcd. For production environments, consider using [workload identity](https://kubernetes.io/docs/concepts/security/service-accounts/) (IRSA on AWS, Workload Identity on GKE) so that task pods authenticate to MLflow via IAM roles rather than static credentials.
+Avoid hardcoding credentials in source code or pipeline YAML files committed to version control. Pass them at runtime via `--env` or a secrets manager integrated with your CI/CD system.
 :::
 
 ### Databricks Managed MLflow
 
-If you are using Databricks Managed MLflow, set the following keys:
+If you are using Databricks Managed MLflow, pass the following environment variables at pipeline submission time:
 
 ```bash
-kubectl patch configmap michelangelo-config \
-  --namespace=<compute-namespace> \
-  --type=merge \
-  -p '{"data":{
-    "MLFLOW_TRACKING_URI":"databricks",
-    "DATABRICKS_HOST":"https://<your-workspace>.azuredatabricks.net",
-    "DATABRICKS_TOKEN":"<your-personal-access-token>"
-  }}'
+ma pipeline dev-run -f pipeline.yaml \
+  --env MLFLOW_TRACKING_URI=databricks \
+  --env DATABRICKS_HOST=https://<your-workspace>.azuredatabricks.net \
+  --env DATABRICKS_TOKEN=<your-personal-access-token>
 ```
 
 ---
 
 ## What Users Do (Task Code)
 
-Once the operator has completed the steps above, users can use MLflow from any `@uniflow.task()` function without any extra configuration — the MLflow client reads `MLFLOW_TRACKING_URI` from the environment automatically.
+Once the operator has confirmed network reachability (Step 1), users configure their MLflow tracking URI and log experiments from any `@uniflow.task()` function.
 
 ```python
 import mlflow
@@ -216,20 +201,18 @@ MLflow includes its own model registry. Michelangelo also has a built-in model r
 
 ## Verification
 
-After applying the configuration, confirm the environment variable is visible inside a task pod:
+Verify network reachability from within the compute namespace using a temporary curl pod — the same approach as Step 1:
 
 ```bash
-kubectl exec -it <task-pod-name> -n <compute-namespace> -- env | grep MLFLOW
-```
-
-You can also verify end-to-end reachability from a task pod by running a connectivity check against the MLflow health endpoint:
-
-```bash
-kubectl exec -it <task-pod-name> -n <compute-namespace> -- \
+kubectl run mlflow-verify \
+  --image=curlimages/curl \
+  --namespace=<compute-namespace> \
+  --restart=Never \
+  --rm -it -- \
   curl -sv http://mlflow.example.com:5000/health
 ```
 
-A `200 OK` response confirms both the environment variable injection and network reachability are working correctly.
+A `200 OK` response confirms task pods in that namespace can reach the MLflow server. The pod is automatically deleted after the check (`--rm`).
 
 ---
 
@@ -237,9 +220,8 @@ A `200 OK` response confirms both the environment variable injection and network
 
 | Symptom | Likely cause | Resolution |
 |---|---|---|
-| `MLFLOW_TRACKING_URI` not set in pod | ConfigMap patch not applied, or pod predates the patch | Verify with `kubectl get configmap michelangelo-config -n <compute-namespace> -o yaml`; restart pods if needed |
 | `ConnectionRefusedError` or `requests.exceptions.ConnectionError` | MLflow server unreachable from pod | Re-run the connectivity test from Step 1; check NetworkPolicy and firewall rules |
-| `RestException: PERMISSION_DENIED` | Credentials missing or incorrect | Verify `MLFLOW_TRACKING_USERNAME` / `MLFLOW_TRACKING_PASSWORD` are set; check MLflow server auth config |
+| `RestException: PERMISSION_DENIED` | Credentials missing or incorrect | Verify `MLFLOW_TRACKING_USERNAME` / `MLFLOW_TRACKING_PASSWORD` are set at pipeline submission time |
 | `mlflow: command not found` / `ModuleNotFoundError` | `mlflow` not in task's Docker image | Add `mlflow` to `requirements.txt` or the project Dockerfile |
 | MLflow run logged but artifacts missing | Artifact store (S3/GCS) unreachable from pod | Confirm task pod has access to the artifact store configured in the MLflow server |
 | `INVALID_PARAMETER_VALUE` on `log_model` | Client/server version mismatch | Pin `mlflow` to the same major version as the server |


### PR DESCRIPTION
## Summary

- Adds `docs/operator-guides/integrations/mlflow.md` — a new operator guide for connecting MLflow to Michelangelo workloads
- Covers experiment tracking (network setup, ConfigMap injection, auth for self-hosted and Databricks Managed MLflow) and model registry (MLflow vs Michelangelo registry trade-offs)
- Follows the operator/user responsibility separation pattern established in the existing experiment-tracking and model-registry guides

## Test plan

- [ ] Run `cd website && bun run build` to verify no broken links
- [ ] Confirm page appears in the Integrations sidebar
- [ ] Verify all internal cross-links resolve correctly
- [ ] Review technical accuracy of MLflow env var names (`MLFLOW_TRACKING_URI`, `MLFLOW_TRACKING_USERNAME`, `MLFLOW_TRACKING_PASSWORD`, `DATABRICKS_HOST`, `DATABRICKS_TOKEN`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)