### PR TITLE
Add deployment details page

### DIFF
--- a/javascript/packages/core/config/entities/deployment/__tests__/deployment-page.test.tsx
+++ b/javascript/packages/core/config/entities/deployment/__tests__/deployment-page.test.tsx
@@ -1,6 +1,11 @@
 import { render, screen } from '@testing-library/react';
 import { vi } from 'vitest';
 
+import {
+  DEPLOYMENT_CONDITION_STATUS,
+  DEPLOYMENT_STAGE,
+  DEPLOYMENT_STATE,
+} from '#core/config/entities/deployment/shared';
 import { DEPLOY_PHASE } from '#core/config/phases/deploy';
 import { EntityDetailRoute } from '#core/router/entity-detail-route';
 import { PhaseListRoute } from '#core/router/phase-list-route';
@@ -71,7 +76,6 @@ describe('Deployment list page', () => {
 });
 
 describe('Deployment detail page', () => {
-
   const mockDeployment = {
     metadata: {
       name: 'sentiment-deployment',
@@ -81,17 +85,17 @@ describe('Deployment detail page', () => {
       },
     },
     status: {
-      state: 2, // Healthy
-      stage: 4, // Rollout complete
+      state: DEPLOYMENT_STATE.HEALTHY,
+      stage: DEPLOYMENT_STAGE.ROLLOUT_COMPLETE,
       conditions: [
         {
           type: 'Validation',
-          status: 1, // CONDITION_STATUS_TRUE → SUCCESS
+          status: DEPLOYMENT_CONDITION_STATUS.TRUE,
           lastUpdatedTimestamp: '1746000600000',
         },
         {
           type: 'Placement',
-          status: 0, // CONDITION_STATUS_UNKNOWN → RUNNING (focused)
+          status: DEPLOYMENT_CONDITION_STATUS.UNKNOWN,
           message: 'Placing on inference server.',
           reason: 'PlacementInProgress',
           lastUpdatedTimestamp: '1746002400000',

--- a/javascript/packages/core/config/entities/deployment/__tests__/deployment-page.test.tsx
+++ b/javascript/packages/core/config/entities/deployment/__tests__/deployment-page.test.tsx
@@ -2,11 +2,15 @@ import { render, screen } from '@testing-library/react';
 import { vi } from 'vitest';
 
 import { DEPLOY_PHASE } from '#core/config/phases/deploy';
+import { EntityDetailRoute } from '#core/router/entity-detail-route';
 import { PhaseListRoute } from '#core/router/phase-list-route';
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getErrorProviderWrapper } from '#core/test/wrappers/get-error-provider-wrapper';
 import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
-import { getServiceProviderWrapper } from '#core/test/wrappers/get-service-provider-wrapper';
+import {
+  createQueryMockRouter,
+  getServiceProviderWrapper,
+} from '#core/test/wrappers/get-service-provider-wrapper';
 
 describe('Deployment list page', () => {
   it('renders the Deployments tab', () => {
@@ -43,5 +47,99 @@ describe('Deployment list page', () => {
     expect(screen.getByRole('columnheader', { name: 'Target' })).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: 'Owner' })).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: 'State' })).toBeInTheDocument();
+  });
+
+  it('renders a link to the deployment detail page on the deployment name', async () => {
+    render(
+      <PhaseListRoute phases={{ deploy: DEPLOY_PHASE }} />,
+      buildWrapper([
+        getErrorProviderWrapper(),
+        getRouterWrapper({ location: '/myproject/deploy/deployments' }),
+        getServiceProviderWrapper({
+          request: vi.fn().mockResolvedValue({
+            deploymentList: {
+              items: [{ metadata: { name: 'sentiment-deployment' } }],
+            },
+          }),
+        }),
+      ])
+    );
+
+    const link = await screen.findByRole('link', { name: 'sentiment-deployment' });
+    expect(link).toHaveAttribute('href', '/myproject/deploy/deployments/sentiment-deployment');
+  });
+});
+
+describe('Deployment detail page', () => {
+
+  const mockDeployment = {
+    metadata: {
+      name: 'sentiment-deployment',
+      creationTimestamp: { seconds: 1746000000 },
+      labels: {
+        'michelangelo/owner': 'user-example',
+      },
+    },
+    status: {
+      state: 2, // Healthy
+      stage: 4, // Rollout complete
+      conditions: [
+        {
+          type: 'Validation',
+          status: 1, // CONDITION_STATUS_TRUE → SUCCESS
+          lastUpdatedTimestamp: '1746000600000',
+        },
+        {
+          type: 'Placement',
+          status: 0, // CONDITION_STATUS_UNKNOWN → RUNNING (focused)
+          message: 'Placing on inference server.',
+          reason: 'PlacementInProgress',
+          lastUpdatedTimestamp: '1746002400000',
+        },
+      ],
+    },
+  };
+
+  const renderDetailPage = () =>
+    render(
+      <EntityDetailRoute phases={{ deploy: DEPLOY_PHASE }} />,
+      buildWrapper([
+        getErrorProviderWrapper(),
+        getRouterWrapper({
+          location: '/myproject/deploy/deployments/sentiment-deployment/stages',
+        }),
+        getServiceProviderWrapper({
+          request: createQueryMockRouter({
+            GetDeployment: { deployment: mockDeployment },
+          }),
+        }),
+      ])
+    );
+
+  it('renders details for deployment', async () => {
+    renderDetailPage();
+
+    expect(screen.getByText('sentiment-deployment')).toBeInTheDocument();
+    expect(await screen.findByText('Created')).toBeInTheDocument();
+    expect(screen.getByText('Owner')).toBeInTheDocument();
+    expect(screen.getByText('Stage')).toBeInTheDocument();
+    expect(screen.getByText('State')).toBeInTheDocument();
+  });
+
+  it('renders the stages for the deployment', async () => {
+    renderDetailPage();
+
+    expect(await screen.findByRole('tab', { name: 'Stages' })).toBeInTheDocument();
+    await screen.findAllByText('Validation');
+    await screen.findAllByText('Placement');
+  });
+
+  it('renders the Information and Details fields within a deployment stage', async () => {
+    renderDetailPage();
+
+    expect(await screen.findByText('Information')).toBeInTheDocument();
+    expect(screen.getByText('Placing on inference server.')).toBeInTheDocument();
+    expect(screen.getByText('Details')).toBeInTheDocument();
+    expect(screen.getByText('PlacementInProgress')).toBeInTheDocument();
   });
 });

--- a/javascript/packages/core/config/entities/deployment/__tests__/deployment-page.test.tsx
+++ b/javascript/packages/core/config/entities/deployment/__tests__/deployment-page.test.tsx
@@ -76,35 +76,21 @@ describe('Deployment list page', () => {
 });
 
 describe('Deployment detail page', () => {
-  const mockDeployment = {
+  const buildDeployment = (overrides = {}) => ({
     metadata: {
       name: 'sentiment-deployment',
       creationTimestamp: { seconds: 1746000000 },
-      labels: {
-        'michelangelo/owner': 'user-example',
-      },
+      labels: { 'michelangelo/owner': 'user-example' },
     },
     status: {
       state: DEPLOYMENT_STATE.HEALTHY,
       stage: DEPLOYMENT_STAGE.ROLLOUT_COMPLETE,
-      conditions: [
-        {
-          type: 'Validation',
-          status: DEPLOYMENT_CONDITION_STATUS.TRUE,
-          lastUpdatedTimestamp: '1746000600000',
-        },
-        {
-          type: 'Placement',
-          status: DEPLOYMENT_CONDITION_STATUS.UNKNOWN,
-          message: 'Placing on inference server.',
-          reason: 'PlacementInProgress',
-          lastUpdatedTimestamp: '1746002400000',
-        },
-      ],
+      conditions: [] as object[],
     },
-  };
+    ...overrides,
+  });
 
-  const renderDetailPage = () =>
+  it('renders details for deployment', async () => {
     render(
       <EntityDetailRoute phases={{ deploy: DEPLOY_PHASE }} />,
       buildWrapper([
@@ -114,14 +100,11 @@ describe('Deployment detail page', () => {
         }),
         getServiceProviderWrapper({
           request: createQueryMockRouter({
-            GetDeployment: { deployment: mockDeployment },
+            GetDeployment: { deployment: buildDeployment() },
           }),
         }),
       ])
     );
-
-  it('renders details for deployment', async () => {
-    renderDetailPage();
 
     expect(screen.getByText('sentiment-deployment')).toBeInTheDocument();
     expect(await screen.findByText('Created')).toBeInTheDocument();
@@ -131,7 +114,41 @@ describe('Deployment detail page', () => {
   });
 
   it('renders the stages for the deployment', async () => {
-    renderDetailPage();
+    render(
+      <EntityDetailRoute phases={{ deploy: DEPLOY_PHASE }} />,
+      buildWrapper([
+        getErrorProviderWrapper(),
+        getRouterWrapper({
+          location: '/myproject/deploy/deployments/sentiment-deployment/stages',
+        }),
+        getServiceProviderWrapper({
+          request: createQueryMockRouter({
+            GetDeployment: {
+              deployment: buildDeployment({
+                status: {
+                  state: DEPLOYMENT_STATE.HEALTHY,
+                  stage: DEPLOYMENT_STAGE.ROLLOUT_COMPLETE,
+                  conditions: [
+                    {
+                      type: 'Validation',
+                      status: DEPLOYMENT_CONDITION_STATUS.TRUE,
+                      lastUpdatedTimestamp: '1746000600000',
+                    },
+                    {
+                      type: 'Placement',
+                      status: DEPLOYMENT_CONDITION_STATUS.UNKNOWN,
+                      message: 'Placing on inference server.',
+                      reason: 'PlacementInProgress',
+                      lastUpdatedTimestamp: '1746002400000',
+                    },
+                  ],
+                },
+              }),
+            },
+          }),
+        }),
+      ])
+    );
 
     expect(await screen.findByRole('tab', { name: 'Stages' })).toBeInTheDocument();
     await screen.findAllByText('Validation');
@@ -139,7 +156,36 @@ describe('Deployment detail page', () => {
   });
 
   it('renders the Information and Details fields within a deployment stage', async () => {
-    renderDetailPage();
+    render(
+      <EntityDetailRoute phases={{ deploy: DEPLOY_PHASE }} />,
+      buildWrapper([
+        getErrorProviderWrapper(),
+        getRouterWrapper({
+          location: '/myproject/deploy/deployments/sentiment-deployment/stages',
+        }),
+        getServiceProviderWrapper({
+          request: createQueryMockRouter({
+            GetDeployment: {
+              deployment: buildDeployment({
+                status: {
+                  state: DEPLOYMENT_STATE.HEALTHY,
+                  stage: DEPLOYMENT_STAGE.ROLLOUT_COMPLETE,
+                  conditions: [
+                    {
+                      type: 'Placement',
+                      status: DEPLOYMENT_CONDITION_STATUS.UNKNOWN,
+                      message: 'Placing on inference server.',
+                      reason: 'PlacementInProgress',
+                      lastUpdatedTimestamp: '1746002400000',
+                    },
+                  ],
+                },
+              }),
+            },
+          }),
+        }),
+      ])
+    );
 
     expect(await screen.findByText('Information')).toBeInTheDocument();
     expect(screen.getByText('Placing on inference server.')).toBeInTheDocument();

--- a/javascript/packages/core/config/entities/deployment/deployment.ts
+++ b/javascript/packages/core/config/entities/deployment/deployment.ts
@@ -1,3 +1,4 @@
+import { DEPLOYMENT_DETAIL_CONFIG } from './detail';
 import { DEPLOYMENT_LIST_CONFIG } from './list';
 
 import type { PhaseEntityConfig } from '#core/types/common/studio-types';
@@ -7,5 +8,5 @@ export const DEPLOYMENT_ENTITY_CONFIG: PhaseEntityConfig = {
   name: 'Deployments',
   service: 'deployment',
   state: 'active',
-  views: [DEPLOYMENT_LIST_CONFIG],
+  views: [DEPLOYMENT_LIST_CONFIG, DEPLOYMENT_DETAIL_CONFIG],
 };

--- a/javascript/packages/core/config/entities/deployment/detail.ts
+++ b/javascript/packages/core/config/entities/deployment/detail.ts
@@ -1,6 +1,10 @@
 import { CellType } from '#core/components/cell/constants';
 import { TASK_STATE } from '#core/components/views/execution/constants';
-import { DEPLOYMENT_CONDITION_STATUS, DEPLOYMENT_STAGE_CELL, DEPLOYMENT_STATE_CELL } from './shared';
+import {
+  DEPLOYMENT_CONDITION_STATUS,
+  DEPLOYMENT_STAGE_CELL,
+  DEPLOYMENT_STATE_CELL,
+} from './shared';
 
 import type { DetailViewConfig } from '#core/components/views/types';
 

--- a/javascript/packages/core/config/entities/deployment/detail.ts
+++ b/javascript/packages/core/config/entities/deployment/detail.ts
@@ -1,0 +1,68 @@
+import { CellType } from '#core/components/cell/constants';
+import { TASK_STATE } from '#core/components/views/execution/constants';
+import { DEPLOYMENT_STAGE_CELL, DEPLOYMENT_STATE_CELL } from './shared';
+
+import type { DetailViewConfig } from '#core/components/views/types';
+
+export const DEPLOYMENT_DETAIL_CONFIG: DetailViewConfig = {
+  type: 'detail',
+  metadata: [
+    { id: 'metadata.creationTimestamp.seconds', label: 'Created', type: CellType.DATE },
+    { id: 'metadata.labels["michelangelo/owner"]', label: 'Owner', type: CellType.TEXT },
+    DEPLOYMENT_STAGE_CELL,
+    DEPLOYMENT_STATE_CELL,
+  ],
+  pages: [
+    {
+      id: 'stages',
+      label: 'Stages',
+      type: 'execution',
+      emptyState: {
+        title: 'No deployment rollout in progress',
+        description: 'Stages will appear here when a deployment rollout is in progress',
+      },
+      tasks: {
+        accessor: 'status.conditions',
+        header: {
+          heading: 'type',
+          metadata: [
+            {
+              id: 'lastUpdatedTimestamp',
+              label: 'Last updated',
+              type: CellType.DATE,
+              accessor: (record: { lastUpdatedTimestamp?: string | number | bigint }) => {
+                const ts = record.lastUpdatedTimestamp;
+                return ts ? Math.floor(Number(ts) / 1000) : undefined;
+              },
+            },
+          ],
+        },
+        body: [
+          {
+            type: 'textarea',
+            label: 'Information',
+            accessor: 'message',
+            markdown: false,
+          },
+          {
+            type: 'textarea',
+            label: 'Details',
+            accessor: 'reason',
+            markdown: false,
+          },
+        ],
+        stateBuilder: (record: { status: number }) => {
+          switch (record.status) {
+            case 1: // CONDITION_STATUS_TRUE
+              return TASK_STATE.SUCCESS;
+            case 2: // CONDITION_STATUS_FALSE
+              return TASK_STATE.ERROR;
+            case 0: // CONDITION_STATUS_UNKNOWN
+            default:
+              return TASK_STATE.RUNNING;
+          }
+        },
+      },
+    },
+  ],
+};

--- a/javascript/packages/core/config/entities/deployment/detail.ts
+++ b/javascript/packages/core/config/entities/deployment/detail.ts
@@ -1,6 +1,6 @@
 import { CellType } from '#core/components/cell/constants';
 import { TASK_STATE } from '#core/components/views/execution/constants';
-import { DEPLOYMENT_STAGE_CELL, DEPLOYMENT_STATE_CELL } from './shared';
+import { DEPLOYMENT_CONDITION_STATUS, DEPLOYMENT_STAGE_CELL, DEPLOYMENT_STATE_CELL } from './shared';
 
 import type { DetailViewConfig } from '#core/components/views/types';
 
@@ -53,11 +53,11 @@ export const DEPLOYMENT_DETAIL_CONFIG: DetailViewConfig = {
         ],
         stateBuilder: (record: { status: number }) => {
           switch (record.status) {
-            case 1: // CONDITION_STATUS_TRUE
+            case DEPLOYMENT_CONDITION_STATUS.TRUE:
               return TASK_STATE.SUCCESS;
-            case 2: // CONDITION_STATUS_FALSE
+            case DEPLOYMENT_CONDITION_STATUS.FALSE:
               return TASK_STATE.ERROR;
-            case 0: // CONDITION_STATUS_UNKNOWN
+            case DEPLOYMENT_CONDITION_STATUS.UNKNOWN:
             default:
               return TASK_STATE.RUNNING;
           }

--- a/javascript/packages/core/config/entities/deployment/list.ts
+++ b/javascript/packages/core/config/entities/deployment/list.ts
@@ -9,6 +9,7 @@ const DEPLOYMENT_COLUMNS: ColumnConfig<object>[] = [
     id: 'metadata.name',
     label: 'Name',
     type: CellType.TEXT,
+    url: '/${studio.projectId}/${studio.phase}/deployments/${row.metadata.name}',
   },
   {
     id: 'status.currentRevision.name',

--- a/javascript/packages/core/config/entities/deployment/shared.ts
+++ b/javascript/packages/core/config/entities/deployment/shared.ts
@@ -2,23 +2,52 @@ import { CellType } from '#core/components/cell/constants';
 
 import type { Cell } from '#core/components/cell/types';
 
+export const DEPLOYMENT_CONDITION_STATUS = {
+  UNKNOWN: 0,
+  TRUE: 1,
+  FALSE: 2,
+} as const;
+
+export const DEPLOYMENT_STAGE = {
+  INVALID: 0,
+  VALIDATION: 1,
+  PLACEMENT: 2,
+  RESOURCE_ACQUISITION: 3,
+  ROLLOUT_COMPLETE: 4,
+  ROLLOUT_FAILED: 5,
+  ROLLBACK_IN_PROGRESS: 6,
+  ROLLBACK_COMPLETE: 7,
+  ROLLBACK_FAILED: 8,
+  CLEAN_UP_IN_PROGRESS: 9,
+  CLEAN_UP_COMPLETE: 10,
+  CLEAN_UP_FAILED: 11,
+} as const;
+
+export const DEPLOYMENT_STATE = {
+  INVALID: 0,
+  INITIALIZING: 1,
+  HEALTHY: 2,
+  UNHEALTHY: 3,
+  EMPTY: 4,
+} as const;
+
 export const DEPLOYMENT_STAGE_CELL: Cell = {
   id: 'status.stage',
   label: 'Stage',
   type: CellType.TYPE,
   typeTextMap: {
-    0: 'Invalid',
-    1: 'Validation',
-    2: 'Placement',
-    3: 'Resource acquisition',
-    4: 'Rollout complete',
-    5: 'Rollout failed',
-    6: 'Rollback in progress',
-    7: 'Rollback complete',
-    8: 'Rollback failed',
-    9: 'Clean up in progress',
-    10: 'Clean up complete',
-    11: 'Clean up failed',
+    [DEPLOYMENT_STAGE.INVALID]: 'Invalid',
+    [DEPLOYMENT_STAGE.VALIDATION]: 'Validation',
+    [DEPLOYMENT_STAGE.PLACEMENT]: 'Placement',
+    [DEPLOYMENT_STAGE.RESOURCE_ACQUISITION]: 'Resource acquisition',
+    [DEPLOYMENT_STAGE.ROLLOUT_COMPLETE]: 'Rollout complete',
+    [DEPLOYMENT_STAGE.ROLLOUT_FAILED]: 'Rollout failed',
+    [DEPLOYMENT_STAGE.ROLLBACK_IN_PROGRESS]: 'Rollback in progress',
+    [DEPLOYMENT_STAGE.ROLLBACK_COMPLETE]: 'Rollback complete',
+    [DEPLOYMENT_STAGE.ROLLBACK_FAILED]: 'Rollback failed',
+    [DEPLOYMENT_STAGE.CLEAN_UP_IN_PROGRESS]: 'Clean up in progress',
+    [DEPLOYMENT_STAGE.CLEAN_UP_COMPLETE]: 'Clean up complete',
+    [DEPLOYMENT_STAGE.CLEAN_UP_FAILED]: 'Clean up failed',
   },
 };
 
@@ -26,6 +55,18 @@ export const DEPLOYMENT_STATE_CELL: Cell = {
   id: 'status.state',
   label: 'State',
   type: CellType.STATE,
-  stateTextMap: { 0: 'Invalid', 1: 'Initializing', 2: 'Healthy', 3: 'Unhealthy', 4: 'Empty' },
-  stateColorMap: { 0: 'gray', 1: 'blue', 2: 'green', 3: 'red', 4: 'gray' },
+  stateTextMap: {
+    [DEPLOYMENT_STATE.INVALID]: 'Invalid',
+    [DEPLOYMENT_STATE.INITIALIZING]: 'Initializing',
+    [DEPLOYMENT_STATE.HEALTHY]: 'Healthy',
+    [DEPLOYMENT_STATE.UNHEALTHY]: 'Unhealthy',
+    [DEPLOYMENT_STATE.EMPTY]: 'Empty',
+  },
+  stateColorMap: {
+    [DEPLOYMENT_STATE.INVALID]: 'gray',
+    [DEPLOYMENT_STATE.INITIALIZING]: 'blue',
+    [DEPLOYMENT_STATE.HEALTHY]: 'green',
+    [DEPLOYMENT_STATE.UNHEALTHY]: 'red',
+    [DEPLOYMENT_STATE.EMPTY]: 'gray',
+  },
 };

--- a/javascript/packages/rpc/handlers.ts
+++ b/javascript/packages/rpc/handlers.ts
@@ -11,6 +11,9 @@ async function createHandlers() {
     ListDeployment: services.DeploymentService.listDeployment as ExtractUnaryRpc<
       typeof services.DeploymentService.listDeployment
     >,
+    GetDeployment: services.DeploymentService.getDeployment as ExtractUnaryRpc<
+      typeof services.DeploymentService.getDeployment
+    >,
     ListProject: services.ProjectService.listProject as ExtractUnaryRpc<
       typeof services.ProjectService.listProject
     >,


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
We added a deployment details page. The page is at `/<project_name>/deploy/deployments/<deployment_name>/stages`. User will be able to view the stages of a deployment along with other details.

https://github.com/user-attachments/assets/e824fc4e-eb56-454b-9203-2de067d43530




<!-- Tell your future self why have you made these changes -->
**Why?**
Users should be able to see the details of a deployment.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Added unit tests to verify that the correct fields were visible. 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
None

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
