### PR TITLE
Add useSchemaMiddleware hook

### DIFF
--- a/javascript/packages/core/hooks/use-schema-middleware/__tests__/use-schema-middleware.test.ts
+++ b/javascript/packages/core/hooks/use-schema-middleware/__tests__/use-schema-middleware.test.ts
@@ -43,9 +43,7 @@ describe('useSchemaMiddleware', () => {
     const { result } = renderHook(
       () =>
         useSchemaMiddleware({
-          operations: [
-            { source: 'spec.missing', destination: 'spec.action', default: 'fallback' },
-          ],
+          operations: [{ source: 'spec.missing', destination: 'spec.action', default: 'fallback' }],
         }),
       { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
     );
@@ -254,9 +252,7 @@ describe('useSchemaMiddleware', () => {
     const { result } = renderHook(
       () =>
         useSchemaMiddleware({
-          operations: [
-            { source: 'spec.missing', destination: 'spec.action', default: 'fallback' },
-          ],
+          operations: [{ source: 'spec.missing', destination: 'spec.action', default: 'fallback' }],
         }),
       { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
     );

--- a/javascript/packages/core/hooks/use-schema-middleware/__tests__/use-schema-middleware.test.ts
+++ b/javascript/packages/core/hooks/use-schema-middleware/__tests__/use-schema-middleware.test.ts
@@ -1,0 +1,223 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { useSchemaMiddleware } from '#core/hooks/use-schema-middleware/use-schema-middleware';
+import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
+
+import type { StudioParamsBase } from '#core/hooks/routing/use-studio-params/types';
+
+const wrapper = getRouterWrapper({ location: '/test-project/train/model' });
+
+describe('useSchemaMiddleware', () => {
+  describe('when schema is absent', () => {
+    it('returns the original data unchanged when schema is null', () => {
+      const { result } = renderHook(() => useSchemaMiddleware(null), { wrapper });
+      const data = { metadata: { name: 'foo' } };
+      expect(result.current.applyMiddleware(data)).toEqual(data);
+    });
+
+    it('returns the original data unchanged when schema is undefined', () => {
+      const { result } = renderHook(() => useSchemaMiddleware(undefined), { wrapper });
+      const data = { metadata: { name: 'foo' } };
+      expect(result.current.applyMiddleware(data)).toEqual(data);
+    });
+
+    it('returns the original data unchanged when operations is empty', () => {
+      const { result } = renderHook(() => useSchemaMiddleware({ operations: [] }), { wrapper });
+      const data = { metadata: { name: 'foo' } };
+      expect(result.current.applyMiddleware(data)).toEqual(data);
+    });
+  });
+
+  describe('static default', () => {
+    it('sets destination to default value when source is absent', () => {
+      const { result } = renderHook(
+        () => useSchemaMiddleware({ operations: [{ destination: 'spec.action', default: 1 }] }),
+        { wrapper }
+      );
+      expect(result.current.applyMiddleware({ spec: {} })).toMatchObject({ spec: { action: 1 } });
+    });
+
+    it('sets destination to default value when source path resolves to nil', () => {
+      const { result } = renderHook(
+        () =>
+          useSchemaMiddleware({
+            operations: [
+              { source: 'spec.missing', destination: 'spec.action', default: 'fallback' },
+            ],
+          }),
+        { wrapper }
+      );
+      expect(result.current.applyMiddleware({ spec: {} })).toMatchObject({
+        spec: { action: 'fallback' },
+      });
+    });
+
+    it('does not write destination when source is nil and no default is defined', () => {
+      const { result } = renderHook(
+        () =>
+          useSchemaMiddleware({
+            operations: [{ source: 'spec.missing', destination: 'spec.action' }],
+          }),
+        { wrapper }
+      );
+      expect(result.current.applyMiddleware({ spec: {} })).toEqual({ spec: {} });
+    });
+  });
+
+  describe('transformation', () => {
+    it('applies transformation function to source value', () => {
+      const { result } = renderHook(
+        () =>
+          useSchemaMiddleware({
+            operations: [
+              {
+                source: 'metadata.name',
+                destination: 'metadata.displayName',
+                transformation: (name) => (name as string).toUpperCase(),
+              },
+            ],
+          }),
+        { wrapper }
+      );
+      expect(result.current.applyMiddleware({ metadata: { name: 'foo' } })).toMatchObject({
+        metadata: { name: 'foo', displayName: 'FOO' },
+      });
+    });
+
+    it('uses default instead of transformation when source is nil', () => {
+      const { result } = renderHook(
+        () =>
+          useSchemaMiddleware({
+            operations: [
+              {
+                source: 'metadata.missing',
+                destination: 'metadata.displayName',
+                default: 'unnamed',
+                transformation: (name) => (name as string).toUpperCase(),
+              },
+            ],
+          }),
+        { wrapper }
+      );
+      expect(result.current.applyMiddleware({ metadata: {} })).toMatchObject({
+        metadata: { displayName: 'unnamed' },
+      });
+    });
+
+    it('unsets destination path when transformation is "unset"', () => {
+      const { result } = renderHook(
+        () =>
+          useSchemaMiddleware({
+            operations: [{ destination: 'spec.deprecated', transformation: 'unset' }],
+          }),
+        { wrapper }
+      );
+      expect(
+        result.current.applyMiddleware({ spec: { deprecated: true, keep: 'yes' } })
+      ).toEqual({ spec: { keep: 'yes' } });
+    });
+
+    it('does not write destination when source is present but no transformation is defined', () => {
+      const { result } = renderHook(
+        () =>
+          useSchemaMiddleware({
+            operations: [{ source: 'spec.action', destination: 'spec.result' }],
+          }),
+        { wrapper }
+      );
+      expect(result.current.applyMiddleware({ spec: { action: 'run' } })).toEqual({
+        spec: { action: 'run' },
+      });
+    });
+  });
+
+  describe('falsy source value handling', () => {
+    const schema = {
+      operations: [
+        {
+          source: 'source',
+          destination: 'destination',
+          default: 'defaultValue',
+          transformation: (v: unknown) => v,
+        },
+      ],
+    };
+
+    it('uses default when source value is null', () => {
+      const { result } = renderHook(() => useSchemaMiddleware(schema), { wrapper });
+      expect(result.current.applyMiddleware({ source: null })).toEqual({
+        source: null,
+        destination: 'defaultValue',
+      });
+    });
+
+    it('copies source to destination when source value is false', () => {
+      const { result } = renderHook(() => useSchemaMiddleware(schema), { wrapper });
+      expect(result.current.applyMiddleware({ source: false })).toEqual({
+        source: false,
+        destination: false,
+      });
+    });
+
+    it('copies source to destination when source value is 0', () => {
+      const { result } = renderHook(() => useSchemaMiddleware(schema), { wrapper });
+      expect(result.current.applyMiddleware({ source: 0 })).toEqual({
+        source: 0,
+        destination: 0,
+      });
+    });
+  });
+
+  describe('context-computed default', () => {
+    it('calls default function with studio params when source is nil', () => {
+      const { result } = renderHook(
+        () =>
+          useSchemaMiddleware({
+            operations: [
+              {
+                destination: 'metadata.namespace',
+                default: ({ studio }: { studio: StudioParamsBase }) => studio.projectId,
+              },
+            ],
+          }),
+        { wrapper: getRouterWrapper({ location: '/my-project/train/model' }) }
+      );
+      expect(result.current.applyMiddleware({ metadata: {} })).toMatchObject({
+        metadata: { namespace: 'my-project' },
+      });
+    });
+  });
+
+  describe('multiple operations', () => {
+    it('applies all operations in order', () => {
+      const { result } = renderHook(
+        () =>
+          useSchemaMiddleware({
+            operations: [
+              { destination: 'spec.action', default: 1 },
+              { destination: 'spec.kill', default: true },
+              { destination: 'spec.deprecated', transformation: 'unset' },
+            ],
+          }),
+        { wrapper }
+      );
+      expect(result.current.applyMiddleware({ spec: { deprecated: true } })).toEqual({
+        spec: { action: 1, kill: true },
+      });
+    });
+  });
+
+  describe('immutability', () => {
+    it('does not mutate the original record', () => {
+      const { result } = renderHook(
+        () =>
+          useSchemaMiddleware({ operations: [{ destination: 'spec.action', default: 1 }] }),
+        { wrapper }
+      );
+      const original = { spec: {} };
+      result.current.applyMiddleware(original);
+      expect(original).toEqual({ spec: {} });
+    });
+  });
+});

--- a/javascript/packages/core/hooks/use-schema-middleware/__tests__/use-schema-middleware.test.ts
+++ b/javascript/packages/core/hooks/use-schema-middleware/__tests__/use-schema-middleware.test.ts
@@ -6,24 +6,28 @@ import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
 
 import type { StudioParamsBase } from '#core/hooks/routing/use-studio-params/types';
 
-const wrapper = getRouterWrapper({ location: '/test-project/train/model' });
-
 describe('useSchemaMiddleware', () => {
   describe('when schema is absent', () => {
     it('returns the original data unchanged when schema is null', () => {
-      const { result } = renderHook(() => useSchemaMiddleware(null), { wrapper });
+      const { result } = renderHook(() => useSchemaMiddleware(null), {
+        wrapper: getRouterWrapper({ location: '/test-project/train/model' }),
+      });
       const data = { metadata: { name: 'foo' } };
       expect(result.current.applyMiddleware(data)).toEqual(data);
     });
 
     it('returns the original data unchanged when schema is undefined', () => {
-      const { result } = renderHook(() => useSchemaMiddleware(undefined), { wrapper });
+      const { result } = renderHook(() => useSchemaMiddleware(undefined), {
+        wrapper: getRouterWrapper({ location: '/test-project/train/model' }),
+      });
       const data = { metadata: { name: 'foo' } };
       expect(result.current.applyMiddleware(data)).toEqual(data);
     });
 
     it('returns the original data unchanged when operations is empty', () => {
-      const { result } = renderHook(() => useSchemaMiddleware({ operations: [] }), { wrapper });
+      const { result } = renderHook(() => useSchemaMiddleware({ operations: [] }), {
+        wrapper: getRouterWrapper({ location: '/test-project/train/model' }),
+      });
       const data = { metadata: { name: 'foo' } };
       expect(result.current.applyMiddleware(data)).toEqual(data);
     });
@@ -33,7 +37,7 @@ describe('useSchemaMiddleware', () => {
     it('sets destination to default value when source is absent', () => {
       const { result } = renderHook(
         () => useSchemaMiddleware({ operations: [{ destination: 'spec.action', default: 1 }] }),
-        { wrapper }
+        { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
       );
       expect(result.current.applyMiddleware({ spec: {} })).toMatchObject({ spec: { action: 1 } });
     });
@@ -46,7 +50,7 @@ describe('useSchemaMiddleware', () => {
               { source: 'spec.missing', destination: 'spec.action', default: 'fallback' },
             ],
           }),
-        { wrapper }
+        { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
       );
       expect(result.current.applyMiddleware({ spec: {} })).toMatchObject({
         spec: { action: 'fallback' },
@@ -59,7 +63,7 @@ describe('useSchemaMiddleware', () => {
           useSchemaMiddleware({
             operations: [{ source: 'spec.missing', destination: 'spec.action' }],
           }),
-        { wrapper }
+        { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
       );
       expect(result.current.applyMiddleware({ spec: {} })).toEqual({ spec: {} });
     });
@@ -78,7 +82,7 @@ describe('useSchemaMiddleware', () => {
               },
             ],
           }),
-        { wrapper }
+        { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
       );
       expect(result.current.applyMiddleware({ metadata: { name: 'foo' } })).toMatchObject({
         metadata: { name: 'foo', displayName: 'FOO' },
@@ -98,7 +102,7 @@ describe('useSchemaMiddleware', () => {
               },
             ],
           }),
-        { wrapper }
+        { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
       );
       expect(result.current.applyMiddleware({ metadata: {} })).toMatchObject({
         metadata: { displayName: 'unnamed' },
@@ -111,7 +115,7 @@ describe('useSchemaMiddleware', () => {
           useSchemaMiddleware({
             operations: [{ destination: 'spec.deprecated', transformation: 'unset' }],
           }),
-        { wrapper }
+        { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
       );
       expect(result.current.applyMiddleware({ spec: { deprecated: true, keep: 'yes' } })).toEqual({
         spec: { keep: 'yes' },
@@ -124,7 +128,7 @@ describe('useSchemaMiddleware', () => {
           useSchemaMiddleware({
             operations: [{ source: 'spec.action', destination: 'spec.result' }],
           }),
-        { wrapper }
+        { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
       );
       expect(result.current.applyMiddleware({ spec: { action: 'run' } })).toEqual({
         spec: { action: 'run' },
@@ -145,7 +149,9 @@ describe('useSchemaMiddleware', () => {
     };
 
     it('uses default when source value is null', () => {
-      const { result } = renderHook(() => useSchemaMiddleware(schema), { wrapper });
+      const { result } = renderHook(() => useSchemaMiddleware(schema), {
+        wrapper: getRouterWrapper({ location: '/test-project/train/model' }),
+      });
       expect(result.current.applyMiddleware({ source: null })).toEqual({
         source: null,
         destination: 'defaultValue',
@@ -153,7 +159,9 @@ describe('useSchemaMiddleware', () => {
     });
 
     it('copies source to destination when source value is false', () => {
-      const { result } = renderHook(() => useSchemaMiddleware(schema), { wrapper });
+      const { result } = renderHook(() => useSchemaMiddleware(schema), {
+        wrapper: getRouterWrapper({ location: '/test-project/train/model' }),
+      });
       expect(result.current.applyMiddleware({ source: false })).toEqual({
         source: false,
         destination: false,
@@ -161,7 +169,9 @@ describe('useSchemaMiddleware', () => {
     });
 
     it('copies source to destination when source value is 0', () => {
-      const { result } = renderHook(() => useSchemaMiddleware(schema), { wrapper });
+      const { result } = renderHook(() => useSchemaMiddleware(schema), {
+        wrapper: getRouterWrapper({ location: '/test-project/train/model' }),
+      });
       expect(result.current.applyMiddleware({ source: 0 })).toEqual({
         source: 0,
         destination: 0,
@@ -200,7 +210,7 @@ describe('useSchemaMiddleware', () => {
               { destination: 'spec.deprecated', transformation: 'unset' },
             ],
           }),
-        { wrapper }
+        { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
       );
       expect(result.current.applyMiddleware({ spec: { deprecated: true } })).toEqual({
         spec: { action: 1, kill: true },
@@ -221,7 +231,7 @@ describe('useSchemaMiddleware', () => {
               },
             ],
           }),
-        { wrapper }
+        { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
       );
       const data = { spec: { name: 'from-data' } };
       const sourceFromObject = { spec: { name: 'from-source' } };
@@ -242,7 +252,7 @@ describe('useSchemaMiddleware', () => {
               },
             ],
           }),
-        { wrapper }
+        { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
       );
       const data = { existing: true };
       const sourceFromObject = { value: 'hello' };
@@ -259,7 +269,7 @@ describe('useSchemaMiddleware', () => {
               { source: 'spec.missing', destination: 'spec.action', default: 'fallback' },
             ],
           }),
-        { wrapper }
+        { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
       );
       expect(
         result.current.applyMiddleware({ spec: {} }, { sourceFromObject: { spec: {} } })
@@ -271,7 +281,7 @@ describe('useSchemaMiddleware', () => {
     it('does not mutate the original record', () => {
       const { result } = renderHook(
         () => useSchemaMiddleware({ operations: [{ destination: 'spec.action', default: 1 }] }),
-        { wrapper }
+        { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
       );
       const original = { spec: {} };
       result.current.applyMiddleware(original);

--- a/javascript/packages/core/hooks/use-schema-middleware/__tests__/use-schema-middleware.test.ts
+++ b/javascript/packages/core/hooks/use-schema-middleware/__tests__/use-schema-middleware.test.ts
@@ -7,132 +7,126 @@ import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
 import type { StudioParamsBase } from '#core/hooks/routing/use-studio-params/types';
 
 describe('useSchemaMiddleware', () => {
-  describe('when schema is absent', () => {
-    it('returns the original data unchanged when schema is null', () => {
-      const { result } = renderHook(() => useSchemaMiddleware(null), {
-        wrapper: getRouterWrapper({ location: '/test-project/train/model' }),
-      });
-      const data = { metadata: { name: 'foo' } };
-      expect(result.current.applyMiddleware(data)).toEqual(data);
+  it('returns the original data unchanged when schema is null', () => {
+    const { result } = renderHook(() => useSchemaMiddleware(null), {
+      wrapper: getRouterWrapper({ location: '/test-project/train/model' }),
     });
+    const data = { metadata: { name: 'foo' } };
+    expect(result.current.applyMiddleware(data)).toEqual(data);
+  });
 
-    it('returns the original data unchanged when schema is undefined', () => {
-      const { result } = renderHook(() => useSchemaMiddleware(undefined), {
-        wrapper: getRouterWrapper({ location: '/test-project/train/model' }),
-      });
-      const data = { metadata: { name: 'foo' } };
-      expect(result.current.applyMiddleware(data)).toEqual(data);
+  it('returns the original data unchanged when schema is undefined', () => {
+    const { result } = renderHook(() => useSchemaMiddleware(undefined), {
+      wrapper: getRouterWrapper({ location: '/test-project/train/model' }),
     });
+    const data = { metadata: { name: 'foo' } };
+    expect(result.current.applyMiddleware(data)).toEqual(data);
+  });
 
-    it('returns the original data unchanged when operations is empty', () => {
-      const { result } = renderHook(() => useSchemaMiddleware({ operations: [] }), {
-        wrapper: getRouterWrapper({ location: '/test-project/train/model' }),
-      });
-      const data = { metadata: { name: 'foo' } };
-      expect(result.current.applyMiddleware(data)).toEqual(data);
+  it('returns the original data unchanged when operations is empty', () => {
+    const { result } = renderHook(() => useSchemaMiddleware({ operations: [] }), {
+      wrapper: getRouterWrapper({ location: '/test-project/train/model' }),
+    });
+    const data = { metadata: { name: 'foo' } };
+    expect(result.current.applyMiddleware(data)).toEqual(data);
+  });
+
+  it('sets destination to default value when source is absent', () => {
+    const { result } = renderHook(
+      () => useSchemaMiddleware({ operations: [{ destination: 'spec.action', default: 1 }] }),
+      { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
+    );
+    expect(result.current.applyMiddleware({ spec: {} })).toMatchObject({ spec: { action: 1 } });
+  });
+
+  it('sets destination to default value when source path resolves to nil', () => {
+    const { result } = renderHook(
+      () =>
+        useSchemaMiddleware({
+          operations: [
+            { source: 'spec.missing', destination: 'spec.action', default: 'fallback' },
+          ],
+        }),
+      { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
+    );
+    expect(result.current.applyMiddleware({ spec: {} })).toMatchObject({
+      spec: { action: 'fallback' },
     });
   });
 
-  describe('static default', () => {
-    it('sets destination to default value when source is absent', () => {
-      const { result } = renderHook(
-        () => useSchemaMiddleware({ operations: [{ destination: 'spec.action', default: 1 }] }),
-        { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
-      );
-      expect(result.current.applyMiddleware({ spec: {} })).toMatchObject({ spec: { action: 1 } });
-    });
+  it('does not write destination when source is nil and no default is defined', () => {
+    const { result } = renderHook(
+      () =>
+        useSchemaMiddleware({
+          operations: [{ source: 'spec.missing', destination: 'spec.action' }],
+        }),
+      { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
+    );
+    expect(result.current.applyMiddleware({ spec: {} })).toEqual({ spec: {} });
+  });
 
-    it('sets destination to default value when source path resolves to nil', () => {
-      const { result } = renderHook(
-        () =>
-          useSchemaMiddleware({
-            operations: [
-              { source: 'spec.missing', destination: 'spec.action', default: 'fallback' },
-            ],
-          }),
-        { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
-      );
-      expect(result.current.applyMiddleware({ spec: {} })).toMatchObject({
-        spec: { action: 'fallback' },
-      });
-    });
-
-    it('does not write destination when source is nil and no default is defined', () => {
-      const { result } = renderHook(
-        () =>
-          useSchemaMiddleware({
-            operations: [{ source: 'spec.missing', destination: 'spec.action' }],
-          }),
-        { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
-      );
-      expect(result.current.applyMiddleware({ spec: {} })).toEqual({ spec: {} });
+  it('applies transformation function to source value', () => {
+    const { result } = renderHook(
+      () =>
+        useSchemaMiddleware({
+          operations: [
+            {
+              source: 'metadata.name',
+              destination: 'metadata.displayName',
+              transformation: (name) => (name as string).toUpperCase(),
+            },
+          ],
+        }),
+      { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
+    );
+    expect(result.current.applyMiddleware({ metadata: { name: 'foo' } })).toMatchObject({
+      metadata: { name: 'foo', displayName: 'FOO' },
     });
   });
 
-  describe('transformation', () => {
-    it('applies transformation function to source value', () => {
-      const { result } = renderHook(
-        () =>
-          useSchemaMiddleware({
-            operations: [
-              {
-                source: 'metadata.name',
-                destination: 'metadata.displayName',
-                transformation: (name) => (name as string).toUpperCase(),
-              },
-            ],
-          }),
-        { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
-      );
-      expect(result.current.applyMiddleware({ metadata: { name: 'foo' } })).toMatchObject({
-        metadata: { name: 'foo', displayName: 'FOO' },
-      });
+  it('uses default instead of transformation when source is nil', () => {
+    const { result } = renderHook(
+      () =>
+        useSchemaMiddleware({
+          operations: [
+            {
+              source: 'metadata.missing',
+              destination: 'metadata.displayName',
+              default: 'unnamed',
+              transformation: (name) => (name as string).toUpperCase(),
+            },
+          ],
+        }),
+      { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
+    );
+    expect(result.current.applyMiddleware({ metadata: {} })).toMatchObject({
+      metadata: { displayName: 'unnamed' },
     });
+  });
 
-    it('uses default instead of transformation when source is nil', () => {
-      const { result } = renderHook(
-        () =>
-          useSchemaMiddleware({
-            operations: [
-              {
-                source: 'metadata.missing',
-                destination: 'metadata.displayName',
-                default: 'unnamed',
-                transformation: (name) => (name as string).toUpperCase(),
-              },
-            ],
-          }),
-        { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
-      );
-      expect(result.current.applyMiddleware({ metadata: {} })).toMatchObject({
-        metadata: { displayName: 'unnamed' },
-      });
+  it('unsets destination path when transformation is "unset"', () => {
+    const { result } = renderHook(
+      () =>
+        useSchemaMiddleware({
+          operations: [{ destination: 'spec.deprecated', transformation: 'unset' }],
+        }),
+      { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
+    );
+    expect(result.current.applyMiddleware({ spec: { deprecated: true, keep: 'yes' } })).toEqual({
+      spec: { keep: 'yes' },
     });
+  });
 
-    it('unsets destination path when transformation is "unset"', () => {
-      const { result } = renderHook(
-        () =>
-          useSchemaMiddleware({
-            operations: [{ destination: 'spec.deprecated', transformation: 'unset' }],
-          }),
-        { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
-      );
-      expect(result.current.applyMiddleware({ spec: { deprecated: true, keep: 'yes' } })).toEqual({
-        spec: { keep: 'yes' },
-      });
-    });
-
-    it('does not write destination when source is present but no transformation is defined', () => {
-      const { result } = renderHook(
-        () =>
-          useSchemaMiddleware({
-            operations: [{ source: 'spec.action', destination: 'spec.result' }],
-          }),
-        { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
-      );
-      expect(result.current.applyMiddleware({ spec: { action: 'run' } })).toEqual({
-        spec: { action: 'run' },
-      });
+  it('does not write destination when source is present but no transformation is defined', () => {
+    const { result } = renderHook(
+      () =>
+        useSchemaMiddleware({
+          operations: [{ source: 'spec.action', destination: 'spec.result' }],
+        }),
+      { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
+    );
+    expect(result.current.applyMiddleware({ spec: { action: 'run' } })).toEqual({
+      spec: { action: 'run' },
     });
   });
 
@@ -179,113 +173,105 @@ describe('useSchemaMiddleware', () => {
     });
   });
 
-  describe('context-computed default', () => {
-    it('calls default function with studio params when source is nil', () => {
-      const { result } = renderHook(
-        () =>
-          useSchemaMiddleware({
-            operations: [
-              {
-                destination: 'metadata.namespace',
-                default: ({ studio }: { studio: StudioParamsBase }) => studio.projectId,
-              },
-            ],
-          }),
-        { wrapper: getRouterWrapper({ location: '/my-project/train/model' }) }
-      );
-      expect(result.current.applyMiddleware({ metadata: {} })).toMatchObject({
-        metadata: { namespace: 'my-project' },
-      });
+  it('calls default function with studio params when source is nil', () => {
+    const { result } = renderHook(
+      () =>
+        useSchemaMiddleware({
+          operations: [
+            {
+              destination: 'metadata.namespace',
+              default: ({ studio }: { studio: StudioParamsBase }) => studio.projectId,
+            },
+          ],
+        }),
+      { wrapper: getRouterWrapper({ location: '/my-project/train/model' }) }
+    );
+    expect(result.current.applyMiddleware({ metadata: {} })).toMatchObject({
+      metadata: { namespace: 'my-project' },
     });
   });
 
-  describe('multiple operations', () => {
-    it('applies all operations in order', () => {
-      const { result } = renderHook(
-        () =>
-          useSchemaMiddleware({
-            operations: [
-              { destination: 'spec.action', default: 1 },
-              { destination: 'spec.kill', default: true },
-              { destination: 'spec.deprecated', transformation: 'unset' },
-            ],
-          }),
-        { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
-      );
-      expect(result.current.applyMiddleware({ spec: { deprecated: true } })).toEqual({
-        spec: { action: 1, kill: true },
-      });
+  it('applies all operations in order', () => {
+    const { result } = renderHook(
+      () =>
+        useSchemaMiddleware({
+          operations: [
+            { destination: 'spec.action', default: 1 },
+            { destination: 'spec.kill', default: true },
+            { destination: 'spec.deprecated', transformation: 'unset' },
+          ],
+        }),
+      { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
+    );
+    expect(result.current.applyMiddleware({ spec: { deprecated: true } })).toEqual({
+      spec: { action: 1, kill: true },
     });
   });
 
-  describe('sourceFromObject', () => {
-    it('reads operation source from sourceFromObject instead of data', () => {
-      const { result } = renderHook(
-        () =>
-          useSchemaMiddleware({
-            operations: [
-              {
-                source: 'spec.name',
-                destination: 'spec.displayName',
-                transformation: (v) => (v as string).toUpperCase(),
-              },
-            ],
-          }),
-        { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
-      );
-      const data = { spec: { name: 'from-data' } };
-      const sourceFromObject = { spec: { name: 'from-source' } };
-      expect(result.current.applyMiddleware(data, { sourceFromObject })).toMatchObject({
-        spec: { displayName: 'FROM-SOURCE' },
-      });
-    });
-
-    it('writes the result to data, not sourceFromObject', () => {
-      const { result } = renderHook(
-        () =>
-          useSchemaMiddleware({
-            operations: [
-              {
-                source: 'value',
-                destination: 'derived',
-                transformation: (v) => v,
-              },
-            ],
-          }),
-        { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
-      );
-      const data = { existing: true };
-      const sourceFromObject = { value: 'hello' };
-      const output = result.current.applyMiddleware(data, { sourceFromObject });
-      expect(output).toMatchObject({ existing: true, derived: 'hello' });
-      expect(output).not.toHaveProperty('value');
-    });
-
-    it('falls back to default when source path is absent in sourceFromObject', () => {
-      const { result } = renderHook(
-        () =>
-          useSchemaMiddleware({
-            operations: [
-              { source: 'spec.missing', destination: 'spec.action', default: 'fallback' },
-            ],
-          }),
-        { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
-      );
-      expect(
-        result.current.applyMiddleware({ spec: {} }, { sourceFromObject: { spec: {} } })
-      ).toMatchObject({ spec: { action: 'fallback' } });
+  it('reads operation source from sourceFromObject instead of data', () => {
+    const { result } = renderHook(
+      () =>
+        useSchemaMiddleware({
+          operations: [
+            {
+              source: 'spec.name',
+              destination: 'spec.displayName',
+              transformation: (v) => (v as string).toUpperCase(),
+            },
+          ],
+        }),
+      { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
+    );
+    const data = { spec: { name: 'from-data' } };
+    const sourceFromObject = { spec: { name: 'from-source' } };
+    expect(result.current.applyMiddleware(data, { sourceFromObject })).toMatchObject({
+      spec: { displayName: 'FROM-SOURCE' },
     });
   });
 
-  describe('immutability', () => {
-    it('does not mutate the original record', () => {
-      const { result } = renderHook(
-        () => useSchemaMiddleware({ operations: [{ destination: 'spec.action', default: 1 }] }),
-        { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
-      );
-      const original = { spec: {} };
-      result.current.applyMiddleware(original);
-      expect(original).toEqual({ spec: {} });
-    });
+  it('writes the result to data, not sourceFromObject', () => {
+    const { result } = renderHook(
+      () =>
+        useSchemaMiddleware({
+          operations: [
+            {
+              source: 'value',
+              destination: 'derived',
+              transformation: (v) => v,
+            },
+          ],
+        }),
+      { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
+    );
+    const data = { existing: true };
+    const sourceFromObject = { value: 'hello' };
+    const output = result.current.applyMiddleware(data, { sourceFromObject });
+    expect(output).toMatchObject({ existing: true, derived: 'hello' });
+    expect(output).not.toHaveProperty('value');
+  });
+
+  it('falls back to default when source path is absent in sourceFromObject', () => {
+    const { result } = renderHook(
+      () =>
+        useSchemaMiddleware({
+          operations: [
+            { source: 'spec.missing', destination: 'spec.action', default: 'fallback' },
+          ],
+        }),
+      { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
+    );
+    expect(
+      result.current.applyMiddleware({ spec: {} }, { sourceFromObject: { spec: {} } })
+    ).toMatchObject({ spec: { action: 'fallback' } });
+  });
+
+  it('does not mutate the original record', () => {
+    const { result } = renderHook(
+      () => useSchemaMiddleware({ operations: [{ destination: 'spec.action', default: 1 }] }),
+      { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
+    );
+    const original = { spec: {} };
+    result.current.applyMiddleware(original);
+    expect(original).toEqual({ spec: {} });
   });
 });

--- a/javascript/packages/core/hooks/use-schema-middleware/__tests__/use-schema-middleware.test.ts
+++ b/javascript/packages/core/hooks/use-schema-middleware/__tests__/use-schema-middleware.test.ts
@@ -208,6 +208,65 @@ describe('useSchemaMiddleware', () => {
     });
   });
 
+  describe('sourceFromObject', () => {
+    it('reads operation source from sourceFromObject instead of data', () => {
+      const { result } = renderHook(
+        () =>
+          useSchemaMiddleware({
+            operations: [
+              {
+                source: 'spec.name',
+                destination: 'spec.displayName',
+                transformation: (v) => (v as string).toUpperCase(),
+              },
+            ],
+          }),
+        { wrapper }
+      );
+      const data = { spec: { name: 'from-data' } };
+      const sourceFromObject = { spec: { name: 'from-source' } };
+      expect(result.current.applyMiddleware(data, { sourceFromObject })).toMatchObject({
+        spec: { displayName: 'FROM-SOURCE' },
+      });
+    });
+
+    it('writes the result to data, not sourceFromObject', () => {
+      const { result } = renderHook(
+        () =>
+          useSchemaMiddleware({
+            operations: [
+              {
+                source: 'value',
+                destination: 'derived',
+                transformation: (v) => v,
+              },
+            ],
+          }),
+        { wrapper }
+      );
+      const data = { existing: true };
+      const sourceFromObject = { value: 'hello' };
+      const output = result.current.applyMiddleware(data, { sourceFromObject });
+      expect(output).toMatchObject({ existing: true, derived: 'hello' });
+      expect(output).not.toHaveProperty('value');
+    });
+
+    it('falls back to default when source path is absent in sourceFromObject', () => {
+      const { result } = renderHook(
+        () =>
+          useSchemaMiddleware({
+            operations: [
+              { source: 'spec.missing', destination: 'spec.action', default: 'fallback' },
+            ],
+          }),
+        { wrapper }
+      );
+      expect(
+        result.current.applyMiddleware({ spec: {} }, { sourceFromObject: { spec: {} } })
+      ).toMatchObject({ spec: { action: 'fallback' } });
+    });
+  });
+
   describe('immutability', () => {
     it('does not mutate the original record', () => {
       const { result } = renderHook(

--- a/javascript/packages/core/hooks/use-schema-middleware/__tests__/use-schema-middleware.test.ts
+++ b/javascript/packages/core/hooks/use-schema-middleware/__tests__/use-schema-middleware.test.ts
@@ -113,9 +113,9 @@ describe('useSchemaMiddleware', () => {
           }),
         { wrapper }
       );
-      expect(
-        result.current.applyMiddleware({ spec: { deprecated: true, keep: 'yes' } })
-      ).toEqual({ spec: { keep: 'yes' } });
+      expect(result.current.applyMiddleware({ spec: { deprecated: true, keep: 'yes' } })).toEqual({
+        spec: { keep: 'yes' },
+      });
     });
 
     it('does not write destination when source is present but no transformation is defined', () => {
@@ -270,8 +270,7 @@ describe('useSchemaMiddleware', () => {
   describe('immutability', () => {
     it('does not mutate the original record', () => {
       const { result } = renderHook(
-        () =>
-          useSchemaMiddleware({ operations: [{ destination: 'spec.action', default: 1 }] }),
+        () => useSchemaMiddleware({ operations: [{ destination: 'spec.action', default: 1 }] }),
         { wrapper }
       );
       const original = { spec: {} };

--- a/javascript/packages/core/hooks/use-schema-middleware/apply-middleware.ts
+++ b/javascript/packages/core/hooks/use-schema-middleware/apply-middleware.ts
@@ -1,0 +1,35 @@
+import { cloneDeep, get, isNil, set, unset } from 'lodash';
+
+import type { StudioParamsBase } from '#core/hooks/routing/use-studio-params/types';
+import type { MiddlewareSchema } from './types';
+
+export function applyMiddleware<T extends object>(
+  record: T,
+  schema: MiddlewareSchema,
+  context?: StudioParamsBase
+): T {
+  const clone = cloneDeep(record);
+
+  if (!schema.operations) return clone;
+
+  for (const op of schema.operations) {
+    if (op.transformation === 'unset') {
+      unset(clone, op.destination);
+      continue;
+    }
+
+    const sourceValue: unknown = op.source !== undefined ? get(clone, op.source) : undefined;
+
+    if (!isNil(sourceValue) && typeof op.transformation === 'function') {
+      set(clone, op.destination, op.transformation(sourceValue));
+    } else if (isNil(sourceValue) && 'default' in op) {
+      const defaultVal =
+        typeof op.default === 'function'
+          ? (op.default as (args: { studio: StudioParamsBase }) => unknown)({ studio: context! })
+          : op.default;
+      set(clone, op.destination, defaultVal);
+    }
+  }
+
+  return clone;
+}

--- a/javascript/packages/core/hooks/use-schema-middleware/apply-middleware.ts
+++ b/javascript/packages/core/hooks/use-schema-middleware/apply-middleware.ts
@@ -1,16 +1,19 @@
 import { cloneDeep, get, isNil, set, unset } from 'lodash';
 
 import type { StudioParamsBase } from '#core/hooks/routing/use-studio-params/types';
-import type { MiddlewareSchema } from './types';
+import type { MiddlewareOptions, MiddlewareSchema } from './types';
 
 export function applyMiddleware<T extends object>(
   record: T,
   schema: MiddlewareSchema,
-  context?: StudioParamsBase
+  context?: StudioParamsBase,
+  options?: MiddlewareOptions
 ): T {
   const clone = cloneDeep(record);
 
   if (!schema.operations) return clone;
+
+  const sourceObject = options?.sourceFromObject ?? clone;
 
   for (const op of schema.operations) {
     if (op.transformation === 'unset') {
@@ -18,7 +21,7 @@ export function applyMiddleware<T extends object>(
       continue;
     }
 
-    const sourceValue: unknown = op.source !== undefined ? get(clone, op.source) : undefined;
+    const sourceValue: unknown = op.source !== undefined ? get(sourceObject, op.source) : undefined;
 
     if (!isNil(sourceValue) && typeof op.transformation === 'function') {
       set(clone, op.destination, op.transformation(sourceValue));

--- a/javascript/packages/core/hooks/use-schema-middleware/types.ts
+++ b/javascript/packages/core/hooks/use-schema-middleware/types.ts
@@ -8,3 +8,7 @@ export type MiddlewareOperation = {
 export type MiddlewareSchema = {
   operations?: MiddlewareOperation[];
 };
+
+export type MiddlewareOptions = {
+  sourceFromObject?: object;
+};

--- a/javascript/packages/core/hooks/use-schema-middleware/types.ts
+++ b/javascript/packages/core/hooks/use-schema-middleware/types.ts
@@ -1,0 +1,10 @@
+export type MiddlewareOperation = {
+  source?: string;
+  destination: string;
+  default?: unknown;
+  transformation?: 'unset' | ((source: unknown) => unknown);
+};
+
+export type MiddlewareSchema = {
+  operations?: MiddlewareOperation[];
+};

--- a/javascript/packages/core/hooks/use-schema-middleware/use-schema-middleware.ts
+++ b/javascript/packages/core/hooks/use-schema-middleware/use-schema-middleware.ts
@@ -1,0 +1,15 @@
+import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
+import { applyMiddleware as applyMiddlewareFn } from './apply-middleware';
+
+import type { MiddlewareSchema } from './types';
+
+export function useSchemaMiddleware(schema?: MiddlewareSchema | null) {
+  const studio = useStudioParams('base');
+
+  function applyMiddleware<T extends object>(data: T): T {
+    if (!schema) return data;
+    return applyMiddlewareFn(data, schema, studio);
+  }
+
+  return { applyMiddleware };
+}

--- a/javascript/packages/core/hooks/use-schema-middleware/use-schema-middleware.ts
+++ b/javascript/packages/core/hooks/use-schema-middleware/use-schema-middleware.ts
@@ -1,14 +1,14 @@
 import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
 import { applyMiddleware as applyMiddlewareFn } from './apply-middleware';
 
-import type { MiddlewareSchema } from './types';
+import type { MiddlewareOptions, MiddlewareSchema } from './types';
 
 export function useSchemaMiddleware(schema?: MiddlewareSchema | null) {
   const studio = useStudioParams('base');
 
-  function applyMiddleware<T extends object>(data: T): T {
+  function applyMiddleware<T extends object>(data: T, options?: MiddlewareOptions): T {
     if (!schema) return data;
-    return applyMiddlewareFn(data, schema, studio);
+    return applyMiddlewareFn(data, schema, studio, options);
   }
 
   return { applyMiddleware };


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Feature

**What changed?**

New hook at `packages/core/hooks/use-schema-middleware/` that applies a declarative schema of data transformation operations to a record before submission. Includes:

- `applyMiddleware` pure function supporting static defaults, source→destination copy, transformation functions, `'unset'`, and context-computed defaults via `({ studio }) => ...` using routing context from `useStudioParams`
- `sourceFromObject` option on `applyMiddleware` — lets callers supply a separate object as the read source for operations, keeping the write target (the record) independent of where values are sourced from

**Why?**

Configs need a declarative way to shape data before persisting in Unified API — copying fields between paths, setting context-aware defaults from routing params, unsetting deprecated keys — without embedding that logic in components.

`sourceFromObject` solves a specific ordering problem: when an operation sources a large sub-object and writes it back (e.g. `source: 'spec', destination: 'spec'`), it would overwrite any keys set by scaffold on that object. Keeping source and destination objects separate avoids the conflict.

**How did you test it?**

Unit tests

**Potential risks**

None — new files only, no existing code modified.

**Release notes**

N/A

**Documentation Changes**

N/A