### PR TITLE
Add YAML scaffold support to useSchemaMiddleware

### DIFF
--- a/javascript/packages/core/hooks/use-schema-middleware/__tests__/use-schema-middleware.test.ts
+++ b/javascript/packages/core/hooks/use-schema-middleware/__tests__/use-schema-middleware.test.ts
@@ -328,10 +328,9 @@ describe('useSchemaMiddleware', () => {
   });
 
   it('throws a descriptive error for invalid YAML', () => {
-    const { result } = renderHook(
-      () => useSchemaMiddleware({ scaffold: 'key: [unclosed' }),
-      { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
-    );
+    const { result } = renderHook(() => useSchemaMiddleware({ scaffold: 'key: [unclosed' }), {
+      wrapper: getRouterWrapper({ location: '/test-project/train/model' }),
+    });
     expect(() => result.current.applyMiddleware({})).toThrow(
       'Request requires scaffolding, but found invalid YAML scaffold'
     );

--- a/javascript/packages/core/hooks/use-schema-middleware/__tests__/use-schema-middleware.test.ts
+++ b/javascript/packages/core/hooks/use-schema-middleware/__tests__/use-schema-middleware.test.ts
@@ -261,6 +261,132 @@ describe('useSchemaMiddleware', () => {
     ).toMatchObject({ spec: { action: 'fallback' } });
   });
 
+  it('merges scaffold YAML into the record before operations run', () => {
+    const { result } = renderHook(
+      () =>
+        useSchemaMiddleware({
+          scaffold: 'spec:\n  proto_module: default-module',
+        }),
+      { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
+    );
+    expect(result.current.applyMiddleware({ spec: {} })).toMatchObject({
+      spec: { proto_module: 'default-module' },
+    });
+  });
+
+  it('data values win over scaffold defaults', () => {
+    const { result } = renderHook(
+      () =>
+        useSchemaMiddleware({
+          scaffold: 'spec:\n  proto_module: scaffold-value',
+        }),
+      { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
+    );
+    expect(
+      result.current.applyMiddleware({ spec: { proto_module: 'existing-value' } })
+    ).toMatchObject({ spec: { proto_module: 'existing-value' } });
+  });
+
+  it('applies the matching subType scaffold from scaffoldBySubType', () => {
+    const { result } = renderHook(
+      () =>
+        useSchemaMiddleware({
+          subTypePath: 'spec.subType',
+          scaffoldBySubType: {
+            regression: 'spec:\n  scaffoldedId: regression-scaffold',
+            classification: 'spec:\n  scaffoldedId: classification-scaffold',
+          },
+        }),
+      { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
+    );
+    expect(result.current.applyMiddleware({ spec: { subType: 'regression' } })).toMatchObject({
+      spec: { scaffoldedId: 'regression-scaffold' },
+    });
+    expect(result.current.applyMiddleware({ spec: { subType: 'classification' } })).toMatchObject({
+      spec: { scaffoldedId: 'classification-scaffold' },
+    });
+  });
+
+  it('operations can source values set by scaffold', () => {
+    const { result } = renderHook(
+      () =>
+        useSchemaMiddleware({
+          scaffold: 'spec:\n  scaffoldedProp: scaffoldedValue',
+          operations: [
+            {
+              source: 'spec.scaffoldedProp',
+              destination: 'spec.transformed',
+              transformation: (v) => `${v as string}-transformed`,
+            },
+          ],
+        }),
+      { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
+    );
+    expect(result.current.applyMiddleware({ spec: {} })).toMatchObject({
+      spec: { scaffoldedProp: 'scaffoldedValue', transformed: 'scaffoldedValue-transformed' },
+    });
+  });
+
+  it('throws a descriptive error for invalid YAML', () => {
+    const { result } = renderHook(
+      () => useSchemaMiddleware({ scaffold: 'key: [unclosed' }),
+      { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
+    );
+    expect(() => result.current.applyMiddleware({})).toThrow(
+      'Request requires scaffolding, but found invalid YAML scaffold'
+    );
+  });
+
+  describe('subTypes filtering', () => {
+    const subTypePath = 'spec.subType';
+
+    it('runs an operation only for its declared subTypes', () => {
+      const { result } = renderHook(
+        () =>
+          useSchemaMiddleware({
+            subTypePath,
+            operations: [
+              {
+                subTypes: ['regression'],
+                destination: 'spec.regressionOnly',
+                default: 'regression-default',
+              },
+            ],
+          }),
+        { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
+      );
+      expect(result.current.applyMiddleware({ spec: { subType: 'regression' } })).toMatchObject({
+        spec: { regressionOnly: 'regression-default' },
+      });
+      expect(result.current.applyMiddleware({ spec: { subType: 'classification' } })).toEqual({
+        spec: { subType: 'classification' },
+      });
+    });
+
+    it('runs an operation for all listed subTypes', () => {
+      const { result } = renderHook(
+        () =>
+          useSchemaMiddleware({
+            subTypePath,
+            operations: [
+              {
+                subTypes: ['classification', 'regression'],
+                destination: 'spec.shared',
+                default: 'shared-default',
+              },
+            ],
+          }),
+        { wrapper: getRouterWrapper({ location: '/test-project/train/model' }) }
+      );
+      expect(result.current.applyMiddleware({ spec: { subType: 'classification' } })).toMatchObject(
+        { spec: { shared: 'shared-default' } }
+      );
+      expect(result.current.applyMiddleware({ spec: { subType: 'regression' } })).toMatchObject({
+        spec: { shared: 'shared-default' },
+      });
+    });
+  });
+
   it('does not mutate the original record', () => {
     const { result } = renderHook(
       () => useSchemaMiddleware({ operations: [{ destination: 'spec.action', default: 1 }] }),

--- a/javascript/packages/core/hooks/use-schema-middleware/apply-middleware.ts
+++ b/javascript/packages/core/hooks/use-schema-middleware/apply-middleware.ts
@@ -1,6 +1,7 @@
 import { cloneDeep, get, isNil, set, unset } from 'lodash';
 
 import type { StudioParamsBase } from '#core/hooks/routing/use-studio-params/types';
+import { applyScaffold } from './apply-scaffold';
 import type { MiddlewareOptions, MiddlewareSchema } from './types';
 
 export function applyMiddleware<T extends object>(
@@ -9,13 +10,17 @@ export function applyMiddleware<T extends object>(
   context?: StudioParamsBase,
   options?: MiddlewareOptions
 ): T {
-  const clone = cloneDeep(record);
+  const clone = applyScaffold(cloneDeep(record), schema);
 
   if (!schema.operations) return clone;
 
   const sourceObject = options?.sourceFromObject ?? clone;
 
   for (const op of schema.operations) {
+    if (op.subTypes && !op.subTypes.includes(get(clone, schema.subTypePath!) as string)) {
+      continue;
+    }
+
     if (op.transformation === 'unset') {
       unset(clone, op.destination);
       continue;

--- a/javascript/packages/core/hooks/use-schema-middleware/apply-middleware.ts
+++ b/javascript/packages/core/hooks/use-schema-middleware/apply-middleware.ts
@@ -1,7 +1,8 @@
 import { cloneDeep, get, isNil, set, unset } from 'lodash';
 
-import type { StudioParamsBase } from '#core/hooks/routing/use-studio-params/types';
 import { applyScaffold } from './apply-scaffold';
+
+import type { StudioParamsBase } from '#core/hooks/routing/use-studio-params/types';
 import type { MiddlewareOptions, MiddlewareSchema } from './types';
 
 export function applyMiddleware<T extends object>(

--- a/javascript/packages/core/hooks/use-schema-middleware/apply-scaffold.ts
+++ b/javascript/packages/core/hooks/use-schema-middleware/apply-scaffold.ts
@@ -1,0 +1,27 @@
+import YAML from 'yaml';
+import { YAMLError } from 'yaml/util';
+import { get, merge } from 'lodash';
+
+import type { MiddlewareSchema } from './types';
+
+export function applyScaffold<T extends object>(data: T, schema: MiddlewareSchema): T {
+  if (!schema.scaffold && !schema.scaffoldBySubType) return data;
+
+  if (schema.scaffoldBySubType) {
+    const subType = get(data, schema.subTypePath!) as string;
+    return merge({}, parseYaml(schema.scaffoldBySubType[subType]), data);
+  }
+
+  return merge({}, parseYaml(schema.scaffold!), data);
+}
+
+function parseYaml(scaffold: string): unknown {
+  try {
+    return YAML.parse(scaffold);
+  } catch (error) {
+    if (error instanceof YAMLError) {
+      throw new Error('Request requires scaffolding, but found invalid YAML scaffold');
+    }
+    throw error;
+  }
+}

--- a/javascript/packages/core/hooks/use-schema-middleware/apply-scaffold.ts
+++ b/javascript/packages/core/hooks/use-schema-middleware/apply-scaffold.ts
@@ -1,6 +1,6 @@
+import { get, merge } from 'lodash';
 import YAML from 'yaml';
 import { YAMLError } from 'yaml/util';
-import { get, merge } from 'lodash';
 
 import type { MiddlewareSchema } from './types';
 

--- a/javascript/packages/core/hooks/use-schema-middleware/types.ts
+++ b/javascript/packages/core/hooks/use-schema-middleware/types.ts
@@ -1,18 +1,43 @@
 export type MiddlewareOperation = {
   source?: string;
   destination: string;
+  /**
+   * Value to set when `source` is absent or resolves to nil.
+   * Can be a function `({ studio }) => value` to derive the default from routing context.
+   */
   default?: unknown;
+  /**
+   * Function applied to the source value before writing to `destination`.
+   * Use `'unset'` to delete the destination path from the record entirely.
+   */
   transformation?: 'unset' | ((source: unknown) => unknown);
+  /**
+   * When set, this operation only runs if the record's subType (at `subTypePath`) is one of these values.
+   * Requires `subTypePath` on the schema.
+   */
   subTypes?: string[];
 };
 
 export type MiddlewareSchema = {
   operations?: MiddlewareOperation[];
+  /**
+   * YAML string merged into the record as defaults before operations run.
+   * Existing data values always win over scaffold values.
+   */
   scaffold?: string;
+  /**
+   * Per-subType YAML scaffolds, keyed by the value at `subTypePath`.
+   * Requires `subTypePath`.
+   */
   scaffoldBySubType?: Record<string, string>;
+  /** Dot-path into the record used to read the subType for `subTypes` filtering and `scaffoldBySubType`. */
   subTypePath?: string;
 };
 
 export type MiddlewareOptions = {
+  /**
+   * When provided, operation `source` paths are read from this object instead of the data record.
+   * Results are still written to the data record.
+   */
   sourceFromObject?: object;
 };

--- a/javascript/packages/core/hooks/use-schema-middleware/types.ts
+++ b/javascript/packages/core/hooks/use-schema-middleware/types.ts
@@ -3,10 +3,14 @@ export type MiddlewareOperation = {
   destination: string;
   default?: unknown;
   transformation?: 'unset' | ((source: unknown) => unknown);
+  subTypes?: string[];
 };
 
 export type MiddlewareSchema = {
   operations?: MiddlewareOperation[];
+  scaffold?: string;
+  scaffoldBySubType?: Record<string, string>;
+  subTypePath?: string;
 };
 
 export type MiddlewareOptions = {

--- a/javascript/packages/core/package.json
+++ b/javascript/packages/core/package.json
@@ -27,6 +27,7 @@
     "final-form-arrays": "^1.1.2",
     "final-form-focus": "^1.1.2",
     "lodash": "^4.17.21",
+    "yaml": "^1.10.2",
     "markdown-to-jsx": "7.4.7",
     "pluralize": "^8.0.0",
     "react": "18.3.1",


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Feature

**What changed?**

Extends `useSchemaMiddleware` with YAML scaffold support:

- `scaffold` field on `MiddlewareSchema` — a YAML string merged into the record as defaults before any operations run
- `scaffoldBySubType` — a map of YAML strings keyed by subType value, so different record variants can declare different default shapes
- `subTypePath` — dot notation path to the subType discriminator on the record.
- `subTypes` field on `MiddlewareOperation` — restricts an operation to only run for specific subType values

**Why?**

Operations work well for one-by-one field defaults, but schemas with complex initial shapes need to declare an entire structure rather than listing every path individually. A YAML document is a natural fit for expressing nested default shapes — it's compact, readable, and already familiar to anyone writing Michelangelo configs.

Scaffold runs before operations so operations can treat scaffolded paths as guaranteed sources. `scaffoldBySubType` supports schemas where different record variants have structurally different defaults. `subTypes` on operations avoids needing a separate schema per variant when most operations are shared.

**How did you test it?**

7 new tests on top of the existing 19 (26 total): simple scaffold merge, data-wins-over-scaffold precedence, `scaffoldBySubType` subType selection, scaffold values as operation sources, invalid YAML error message, and `subTypes` filtering for single and multiple subTypes.

**Potential risks**

Adds `yaml` as an explicit `packages/core` dependency. The package was already in `node_modules` as a transitive dependency of `jsdom`; this makes the usage declared.

**Release notes**

N/A

**Documentation Changes**

N/A