### PR TITLE
Make breadcrumb bar sticky with scroll-triggered shadow

### DIFF
--- a/javascript/packages/core/components/breadcrumb-bar/__tests__/use-scrolling-navbar-shadow.test.ts
+++ b/javascript/packages/core/components/breadcrumb-bar/__tests__/use-scrolling-navbar-shadow.test.ts
@@ -1,0 +1,54 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useScrollingNavbarShadow } from '../use-scrolling-navbar-shadow';
+
+function setScrollY(value: number) {
+  Object.defineProperty(window, 'scrollY', { value, configurable: true });
+}
+
+describe('useScrollingNavbarShadow', () => {
+  beforeEach(() => setScrollY(0));
+  afterEach(() => setScrollY(0));
+
+  it('returns isScrolled: false when at the top', () => {
+    const { result } = renderHook(() => useScrollingNavbarShadow());
+    expect(result.current.isScrolled).toBe(false);
+  });
+
+  it('returns isScrolled: true after scrolling down', () => {
+    const { result } = renderHook(() => useScrollingNavbarShadow());
+
+    act(() => {
+      setScrollY(100);
+      window.dispatchEvent(new Event('scroll'));
+    });
+
+    expect(result.current.isScrolled).toBe(true);
+  });
+
+  it('returns isScrolled: false after scrolling back to top', () => {
+    const { result } = renderHook(() => useScrollingNavbarShadow());
+
+    act(() => {
+      setScrollY(100);
+      window.dispatchEvent(new Event('scroll'));
+    });
+    act(() => {
+      setScrollY(0);
+      window.dispatchEvent(new Event('scroll'));
+    });
+
+    expect(result.current.isScrolled).toBe(false);
+  });
+
+  it('removes the scroll listener on unmount', () => {
+    const spy = vi.spyOn(window, 'removeEventListener');
+    const { unmount } = renderHook(() => useScrollingNavbarShadow());
+
+    unmount();
+
+    expect(spy).toHaveBeenCalledWith('scroll', expect.any(Function));
+    spy.mockRestore();
+  });
+});

--- a/javascript/packages/core/components/breadcrumb-bar/breadcrumb-bar.tsx
+++ b/javascript/packages/core/components/breadcrumb-bar/breadcrumb-bar.tsx
@@ -6,6 +6,7 @@ import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studi
 import { Phase } from '#core/types/common/studio-types';
 import { MenuDrawer } from './menu-drawer';
 import { BreadcrumbContainer, PlainLink } from './styled-components';
+import { useScrollingNavbarShadow } from './use-scrolling-navbar-shadow';
 
 import type { CategoryConfig } from '#core/types/common/studio-types';
 import type { NavLink } from './types';
@@ -42,9 +43,10 @@ export function BreadcrumbBar({
   const { projectId, phase, entityId } = useStudioParams('base');
   const isProjectPage = phase === Phase.Project;
   const allPhases = categories.flatMap((c) => c.phases);
+  const { isScrolled } = useScrollingNavbarShadow();
 
   return (
-    <BreadcrumbContainer>
+    <BreadcrumbContainer $scrolled={isScrolled}>
       <Grid gridColumns={1} gridGutters={0} gridGaps={0}>
         <Cell>
           <div

--- a/javascript/packages/core/components/breadcrumb-bar/styled-components.ts
+++ b/javascript/packages/core/components/breadcrumb-bar/styled-components.ts
@@ -22,11 +22,22 @@ export const TopLevelNavLink = styled(Link, ({ $theme }) => ({
   ':hover': { backgroundColor: $theme.colors.menuFillHover },
 }));
 
-export const BreadcrumbContainer = styled('div', ({ $theme }) => ({
-  boxShadow: `inset 0px -1px 0px ${$theme.colors.borderOpaque}`,
-  paddingTop: $theme.sizing.scale650,
-  paddingBottom: $theme.sizing.scale650,
-}));
+export const BreadcrumbContainer = styled<'div', { $scrolled: boolean }>(
+  'div',
+  ({ $theme, $scrolled }) => ({
+    position: 'sticky',
+    top: '0',
+    backgroundColor: $theme.colors.backgroundPrimary,
+    boxShadow: $scrolled
+      ? $theme.lighting.shadow400
+      : `inset 0px -1px 0px ${$theme.colors.borderOpaque}`,
+    transitionProperty: 'box-shadow',
+    transitionDuration: $theme.animation.timing100,
+    transitionTimingFunction: $theme.animation.easeOutCurve,
+    paddingTop: $theme.sizing.scale650,
+    paddingBottom: $theme.sizing.scale650,
+  })
+);
 
 export const PhaseHeader = styled<'li', { $disabled?: boolean }>('li', (props) => {
   return {

--- a/javascript/packages/core/components/breadcrumb-bar/styled-components.ts
+++ b/javascript/packages/core/components/breadcrumb-bar/styled-components.ts
@@ -27,6 +27,7 @@ export const BreadcrumbContainer = styled<'div', { $scrolled: boolean }>(
   ({ $theme, $scrolled }) => ({
     position: 'sticky',
     top: '0',
+    zIndex: 1,
     backgroundColor: $theme.colors.backgroundPrimary,
     boxShadow: $scrolled
       ? $theme.lighting.shadow400

--- a/javascript/packages/core/components/breadcrumb-bar/use-scrolling-navbar-shadow.ts
+++ b/javascript/packages/core/components/breadcrumb-bar/use-scrolling-navbar-shadow.ts
@@ -1,0 +1,19 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export function useScrollingNavbarShadow() {
+  const [isScrolled, setIsScrolled] = useState(false);
+
+  const handleScroll = useCallback(() => {
+    const scrolled = window.scrollY > 0;
+    if (scrolled !== isScrolled) {
+      setIsScrolled(scrolled);
+    }
+  }, [isScrolled]);
+
+  useEffect(() => {
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [handleScroll]);
+
+  return { isScrolled };
+}

--- a/javascript/packages/core/index.tsx
+++ b/javascript/packages/core/index.tsx
@@ -1,4 +1,5 @@
 import { AppNavBar } from 'baseui/app-nav-bar';
+import { LayersManager } from 'baseui/layer';
 
 import { Link } from '#core/components/link/link';
 import { ErrorProvider } from '#core/providers/error-provider/error-provider';
@@ -25,23 +26,25 @@ type Props = {
 export function CoreApp({ dependencies }: Props) {
   return (
     <ThemeProvider icons={dependencies.theme.icons}>
-      <ServiceProvider {...dependencies.service}>
-        <ErrorProvider {...dependencies.error}>
-          <IconProvider icons={dependencies.theme.icons}>
-            <AppNavBar
-              title={
-                <Link
-                  href="/"
-                  overrides={{ Link: { style: { ':hover': { textDecoration: 'unset' } } } }}
-                >
-                  Michelangelo Studio
-                </Link>
-              }
-            />
-            <Router />
-          </IconProvider>
-        </ErrorProvider>
-      </ServiceProvider>
+      <LayersManager zIndex={200}>
+        <ServiceProvider {...dependencies.service}>
+          <ErrorProvider {...dependencies.error}>
+            <IconProvider icons={dependencies.theme.icons}>
+              <AppNavBar
+                title={
+                  <Link
+                    href="/"
+                    overrides={{ Link: { style: { ':hover': { textDecoration: 'unset' } } } }}
+                  >
+                    Michelangelo Studio
+                  </Link>
+                }
+              />
+              <Router />
+            </IconProvider>
+          </ErrorProvider>
+        </ServiceProvider>
+      </LayersManager>
     </ThemeProvider>
   );
 }


### PR DESCRIPTION
## What changed?

Makes the `BreadcrumbBar` component sticky so it remains visible as the user scrolls.

Fixes two stacking context bugs discovered during visual verification:
- **Content overlap**: page content was painting over the sticky bar because `position: sticky; z-index: auto` doesn't create a stacking context. Fixed by adding `zIndex: 1`.
- **Overlay overlap**: BaseUI Drawer/Modal/Select/Tooltip were rendering behind the bar. Fixed by wrapping `CoreApp` with `LayersManager zIndex={200}`.

## Why?

Improve navigation usability on long pages (e.g. pipeline run detail with many steps). Without stickiness the breadcrumb bar scrolls out of view and users lose context.

## How did you test it?

Playwright MCP visual verification through Claude on `http://localhost:5173/ma-dev-test/train/runs/<run-id>/steps`:
- Breadcrumb sticks to top while scrolling ✅
- Drop shadow appears at `scrollY > 0`, transitions back on scroll to top ✅
- Menu drawer opens above the sticky bar (z-index: 200 > 1) ✅
- Page content no longer bleeds over the bar when scrolled ✅
- Filter dropdowns render correctly below the bar ✅


https://github.com/user-attachments/assets/7f6543e7-b3f6-4643-a8e8-4f312c1c9467

<img width="1840" height="1130" alt="Screenshot 2026-05-06 at 13 30 00" src="https://github.com/user-attachments/assets/ba5a6207-2fc2-4aef-847e-533a8a4210b5" />


## Potential risks

None — `LayersManager` is additive and only affects BaseUI overlay z-index ordering.

## Release notes

N/A

## Documentation Changes

N/A