### PR TITLE
feat: add Ingress support for UI, Envoy, and apiserver

### DIFF
--- a/helm/michelangelo/Chart.lock
+++ b/helm/michelangelo/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: cadence
+  repository: https://cadence-workflow.github.io/cadence-charts
+  version: 1.1.0
+digest: sha256:2217bb01dcdd9d9869aed7434e6b141ee600f022ff5eb8e98d39535621be0fff
+generated: "2026-05-06T20:22:02.517193-07:00"

--- a/helm/michelangelo/README.md
+++ b/helm/michelangelo/README.md
@@ -15,7 +15,7 @@ The chart owns only the **control plane**. Infrastructure (metadata storage, obj
 | Metadata storage | MySQL 8.0 or PostgreSQL 14+ | The chart provisions schema via an init container; you provide a reachable host and root credentials. |
 | Object storage | S3-compatible | S3, GCS (HMAC), MinIO, or any S3-API endpoint. The chart consumes `endpoint`, access key, and secret key. |
 | Workflow engine | Cadence or Temporal | Bring your own (any reachable host:port), or set `cadence.enabled=true` to install the official Cadence chart as a subchart. See [Bundled Cadence](#bundled-cadence-optional-subchart). |
-| Helm dependencies | – | Run `helm dependency update ./helm/michelangelo` once before the first install if you enable any subchart (`cadence.enabled=true`). |
+| Helm dependencies | – | Run `helm dependency build ./helm/michelangelo` once before the first install if you enable any subchart (`cadence.enabled=true`). |
 | Optional: cluster operators | KubeRay, Spark Operator | Required only if your pipelines use Ray or Spark tasks. Install separately from their upstream charts. |
 
 ## Quick Install
@@ -68,8 +68,10 @@ The bundled subchart is **not** used by `michelangelo sandbox up`. The local san
 ### Prerequisite: download the subchart
 
 ```bash
-helm dependency update ./helm/michelangelo
+helm dependency build ./helm/michelangelo
 ```
+
+`Chart.lock` is committed, so `build` fetches the locked Cadence version exactly. Use `helm dependency update` only when you intentionally want to re-resolve and rewrite the lock (e.g., bumping the subchart version in `Chart.yaml`).
 
 Skipping this step produces: `Error: found in Chart.yaml, but missing in charts/ directory: cadence`
 
@@ -78,7 +80,7 @@ Skipping this step produces: `Error: found in Chart.yaml, but missing in charts/
 Step 1 — fetch the subchart:
 
 ```bash
-helm dependency update ./helm/michelangelo
+helm dependency build ./helm/michelangelo
 ```
 
 Step 2 — install:
@@ -184,6 +186,125 @@ Top-level keys. See [`values.yaml`](./values.yaml) for the full annotated schema
 | `tolerations` | list | `[]` | no | |
 | `affinity` | object | `{}` | no | |
 
+## Ingress
+
+Use Ingress when you want the UI and API reachable on a real hostname. For one-off access to a ClusterIP install, prefer `kubectl port-forward`. NodePort and LoadBalancer Services still work, but Ingress gives you TLS termination, hostname-based routing, and a single load balancer across many releases.
+
+The chart ships three independent Ingress objects — all disabled by default: `ui.ingress` (HTTP/1.1, the React app), `envoy.ingress` (gRPC-Web, the browser API path), and `apiserver.ingress` (gRPC, for external CLI/SDK clients). Most users need only the first two.
+
+> **Heads up: set `envoy.corsOrigins` whenever you enable Ingress.**
+> Without it, the UI loads but every API call fails with a CORS error.
+> The value is a regex — escape literal dots:
+>   --set 'envoy.corsOrigins=https://michelangelo\.example\.com'
+
+### Phase A — UI + Envoy on one hostname (nginx, path-split)
+
+```bash
+helm upgrade --install michelangelo ./helm/michelangelo \
+  --namespace michelangelo --create-namespace \
+  -f values-prod.yaml \
+  --set ui.ingress.enabled=true \
+  --set ui.ingress.hostname=michelangelo.example.com \
+  --set ui.ingress.ingressClassName=nginx \
+  --set 'ui.ingress.tls[0].hosts[0]=michelangelo.example.com' \
+  --set 'ui.ingress.tls[0].secretName=michelangelo-tls' \
+  --set envoy.ingress.enabled=true \
+  --set envoy.ingress.hostname=michelangelo.example.com \
+  --set 'envoy.ingress.path=/api(/|$)(.*)' \
+  --set envoy.ingress.ingressClassName=nginx \
+  --set 'envoy.ingress.annotations.nginx\.ingress\.kubernetes\.io/rewrite-target=/$2' \
+  --set 'envoy.ingress.annotations.nginx\.ingress\.kubernetes\.io/use-regex=true' \
+  --set 'envoy.ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-read-timeout=600' \
+  --set 'envoy.ingress.tls[0].hosts[0]=michelangelo.example.com' \
+  --set 'envoy.ingress.tls[0].secretName=michelangelo-tls' \
+  --set 'envoy.corsOrigins=https://michelangelo\.example\.com'
+```
+
+`ui.apiBaseUrl` is auto-derived from `envoy.ingress` — leave it empty.
+
+### Phase A — Envoy on a dedicated subdomain
+
+```bash
+helm upgrade --install michelangelo ./helm/michelangelo \
+  --namespace michelangelo --create-namespace \
+  -f values-prod.yaml \
+  --set ui.ingress.enabled=true \
+  --set ui.ingress.hostname=michelangelo.example.com \
+  --set envoy.ingress.enabled=true \
+  --set envoy.ingress.hostname=api.michelangelo.example.com \
+  --set 'envoy.corsOrigins=https://michelangelo\.example\.com'
+```
+
+### Phase A on other controllers
+
+| Controller | Path strip pattern |
+|---|---|
+| nginx | `path: /api(/|$)(.*)` + `rewrite-target: /$2` + `use-regex: "true"` |
+| Traefik | Requires a `Middleware` CRD with `stripPrefix` — define out-of-band and reference via `traefik.ingress.kubernetes.io/router.middlewares`. See Traefik StripPrefix docs. |
+| Contour | `HTTPProxy` resource with `pathRewritePolicy.replacePrefix` instead of Ingress. |
+| Emissary | `Mapping` resource with `prefix` and `rewrite` instead of Ingress. |
+
+The dedicated-subdomain pattern (envoy on its own hostname) avoids all path stripping — use it for controller-agnostic installs.
+
+### Phase B — apiserver gRPC (recommended: mode: grpc)
+
+Expose the raw gRPC apiserver to external CLI/SDK clients. `mode: grpc` lets the controller terminate TLS — the Pod stays plaintext, no pod TLS Secret needed:
+
+```bash
+helm upgrade michelangelo ./helm/michelangelo --reuse-values \
+  --set apiserver.ingress.enabled=true \
+  --set apiserver.ingress.mode=grpc \
+  --set apiserver.ingress.hostname=grpc.michelangelo.example.com \
+  --set apiserver.ingress.ingressClassName=nginx \
+  --set 'apiserver.ingress.tls[0].hosts[0]=grpc.michelangelo.example.com' \
+  --set 'apiserver.ingress.tls[0].secretName=apiserver-grpc-tls'
+```
+
+The chart auto-injects `nginx.ingress.kubernetes.io/backend-protocol: GRPC`.
+
+### Phase B — apiserver gRPC (end-to-end TLS: mode: passthrough)
+
+Use when you need TLS to terminate inside the Pod (mTLS, compliance).
+
+Two preconditions:
+1. `apiserver.tls.enabled=true` (pod must terminate TLS)
+2. The nginx-ingress controller must be started with `--enable-ssl-passthrough` at the cluster level (NOT a chart annotation — a controller startup flag). Without it, the annotation is silently ignored.
+
+Verify:
+
+```bash
+kubectl -n ingress-nginx get deploy ingress-nginx-controller \
+  -o jsonpath='{.spec.template.spec.containers[0].args}' | tr ',' '\n' | grep ssl-passthrough
+```
+
+```bash
+kubectl create secret tls apiserver-tls --cert=server.crt --key=server.key -n michelangelo
+helm upgrade michelangelo ./helm/michelangelo --reuse-values \
+  --set apiserver.tls.enabled=true \
+  --set apiserver.tls.secretName=apiserver-tls \
+  --set apiserver.ingress.enabled=true \
+  --set apiserver.ingress.mode=passthrough \
+  --set apiserver.ingress.hostname=grpc.michelangelo.example.com
+```
+
+The apiserver hostname must be **different** from the UI/envoy hostname.
+
+### apiBaseUrl auto-derive
+
+Leave `ui.apiBaseUrl` empty when `envoy.ingress.enabled=true` and `envoy.ingress.hostname` is set — the chart derives it as `<scheme>://<hostname><path>` (https when `envoy.ingress.tls` is non-empty).
+
+| hostname | path | tls | derived apiBaseUrl |
+|---|---|---|---|
+| `michelangelo.example.com` | `/` | `[]` | `http://michelangelo.example.com` |
+| `michelangelo.example.com` | `/api` | non-empty | `https://michelangelo.example.com/api` |
+| `api.michelangelo.example.com` | `/` | non-empty | `https://api.michelangelo.example.com` |
+
+Set `ui.apiBaseUrl` explicitly when envoy is on NodePort/LoadBalancer, or when scheme/path differs.
+
+Auto-derive does NOT activate when `ui.ingress` is enabled but `envoy.ingress` is disabled — a UI Ingress alone gives the browser nowhere to send gRPC-Web traffic. Set `ui.apiBaseUrl` explicitly to point at wherever envoy is exposed.
+
+See [`values.yaml`](./values.yaml) for the full annotated schema.
+
 ## Upgrade
 
 ```bash
@@ -254,7 +375,7 @@ Set distinct release names. All resources are prefixed with `{{ include "michela
 
 **`helm install` fails with `found in Chart.yaml, but missing in charts/ directory: cadence`.**
 
-Run `helm dependency update ./helm/michelangelo` first. Re-run it whenever the Cadence version in `Chart.yaml` changes.
+Run `helm dependency build ./helm/michelangelo` first. `Chart.lock` is committed, so `build` fetches the locked Cadence version. Use `helm dependency update` only when you intentionally want to re-resolve and rewrite the lock (e.g., bumping the subchart version in `Chart.yaml`).
 
 **`<release>-cadence-schema` Job fails with `Access denied ... CREATE DATABASE`.**
 
@@ -295,6 +416,48 @@ kubectl --namespace michelangelo wait --for=condition=ready pod \
 ```
 
 If pods never become ready, check the schema job logs first.
+
+**UI loads through Ingress but the browser console shows "Failed to fetch" or CORS errors.**
+
+`envoy.corsOrigins` does not match the browser's `Origin` header. The value is a regex — escape dots and include the full scheme. For `https://michelangelo.example.com`:
+
+```bash
+--set 'envoy.corsOrigins=https://michelangelo\.example\.com'
+```
+
+Confirm by checking the browser's network tab for a 403 from envoy with `Access-Control-Allow-Origin: null`.
+
+**`helm install` fails with `ui.ingress.hostname is required when ui.ingress.enabled=true`.**
+
+Set `--set ui.ingress.hostname=<your-hostname>`. Same applies to `envoy.ingress.hostname` and `apiserver.ingress.hostname`.
+
+**`helm install` fails with `apiserver.tls.enabled must be true when apiserver.ingress.mode=passthrough`.**
+
+Switch to `mode: grpc` (simpler, no pod TLS needed) or enable pod TLS:
+
+```bash
+kubectl create secret tls apiserver-tls --cert=server.crt --key=server.key -n michelangelo
+helm upgrade ... --set apiserver.tls.enabled=true --set apiserver.tls.secretName=apiserver-tls
+```
+
+**`apiserver.ingress.mode=grpc` returns 502 or the controller never speaks HTTP/2 to the Pod.**
+
+Your controller does not support `nginx.ingress.kubernetes.io/backend-protocol: GRPC`. For non-nginx controllers, add the equivalent in `apiserver.ingress.annotations` (Contour: `projectcontour.io/upstream-protocol.h2c`; Emissary: `getambassador.io/config` with `grpc: true`). As a last resort, use `mode: passthrough`.
+
+**`ui.apiBaseUrl` is empty and install fails with `ui.apiBaseUrl is required`.**
+
+Auto-derive activates only when `envoy.ingress.enabled=true` AND `envoy.ingress.hostname` is set. If envoy is on NodePort/LoadBalancer (no Ingress), or if `ui.ingress` is enabled but `envoy.ingress` is disabled, set `ui.apiBaseUrl` explicitly to point at wherever envoy is exposed.
+
+**Ingress created but every request returns 404.**
+
+No controller is reconciling the Ingress. Verify:
+
+```bash
+kubectl get ingressclass
+kubectl describe ingress <release>-ui -n <namespace>
+```
+
+If `ADDRESS` is empty, set `ingressClassName` to a class that exists or install an Ingress controller (`helm install ingress-nginx ingress-nginx/ingress-nginx`).
 
 ## Contributing
 

--- a/helm/michelangelo/templates/NOTES.txt
+++ b/helm/michelangelo/templates/NOTES.txt
@@ -77,7 +77,18 @@ if it stays in Init:0/1, your metadata storage is unreachable.
 ────────────────────────────────────────────────────────────────────────
 
 {{- if .Values.ui.enabled }}
-{{- if eq .Values.ui.service.type "NodePort" }}
+{{- if .Values.ui.ingress.enabled }}
+
+  This release exposes the UI through an Ingress at:
+
+      {{ if .Values.ui.ingress.tls }}https{{ else }}http{{ end }}://{{ .Values.ui.ingress.hostname }}/
+
+  DNS for "{{ .Values.ui.ingress.hostname }}" must point at your Ingress
+  controller's external address. Verify with:
+
+      kubectl --namespace {{ .Release.Namespace }} get ingress {{ include "michelangelo.fullname" . }}-ui
+
+{{- else if eq .Values.ui.service.type "NodePort" }}
 
   This release exposes the UI on NodePort {{ .Values.ui.service.nodePort }}.
   If your cluster publishes node ports to localhost (e.g. k3d with --port),
@@ -103,12 +114,50 @@ if it stays in Init:0/1, your metadata storage is unreachable.
 
   Then open http://localhost:8090
 
+  To expose the UI externally, enable Ingress:
+
+      --set ui.ingress.enabled=true \
+      --set ui.ingress.hostname=michelangelo.example.com \
+      --set envoy.ingress.enabled=true \
+      --set envoy.ingress.hostname=michelangelo.example.com
+
 {{- end }}
 {{- else }}
 
   The UI is disabled in this release (ui.enabled=false). Re-enable with:
 
       helm upgrade {{ .Release.Name }} michelangelo/michelangelo --reuse-values --set ui.enabled=true
+
+{{- end }}
+
+{{- if .Values.envoy.ingress.enabled }}
+
+  The browser UI calls the apiserver through envoy at:
+
+      {{ if .Values.envoy.ingress.tls }}https{{ else }}http{{ end }}://{{ .Values.envoy.ingress.hostname }}{{ .Values.envoy.ingress.path | default "/" | trimSuffix "/" }}
+
+  {{- if not .Values.ui.apiBaseUrl }}
+  (Auto-derived into ui.apiBaseUrl from envoy.ingress — no explicit value needed.)
+  {{- end }}
+
+  Confirm the envoy Ingress is admitted:
+
+      kubectl --namespace {{ .Release.Namespace }} get ingress {{ include "michelangelo.fullname" . }}-envoy
+
+{{- end }}
+
+{{- if .Values.apiserver.ingress.enabled }}
+
+  The apiserver gRPC endpoint is exposed at:
+
+      {{ .Values.apiserver.ingress.hostname }}:443   (mode: {{ .Values.apiserver.ingress.mode }})
+
+  Use this from external gRPC clients (CLI, SDK, CI). The hostname must be
+  DIFFERENT from ui.ingress.hostname and envoy.ingress.hostname.
+
+  Test with grpcurl:
+
+      grpcurl {{ .Values.apiserver.ingress.hostname }}:443 list
 
 {{- end }}
 

--- a/helm/michelangelo/templates/core/apiserver-deployment.yaml
+++ b/helm/michelangelo/templates/core/apiserver-deployment.yaml
@@ -113,12 +113,17 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           ports:
-            - name: grpc
+            - name: {{ if .Values.apiserver.tls.enabled }}grpcs{{ else }}grpc{{ end }}
               containerPort: {{ .Values.apiserver.port }}
               protocol: TCP
           volumeMounts:
             - name: config
               mountPath: /config
+            {{- if .Values.apiserver.tls.enabled }}
+            - name: tls
+              mountPath: {{ .Values.apiserver.tls.mountPath | default "/tls" }}
+              readOnly: true
+            {{- end }}
           {{- with (or .Values.apiserver.resources .Values.resources) }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -130,6 +135,11 @@ spec:
         - name: schema
           configMap:
             name: {{ include "michelangelo.schemaInitConfigMapName" . }}
+        {{- if .Values.apiserver.tls.enabled }}
+        - name: tls
+          secret:
+            secretName: {{ required "apiserver.tls.secretName is required when apiserver.tls.enabled=true" .Values.apiserver.tls.secretName }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/michelangelo/templates/core/apiserver-ingress.yaml
+++ b/helm/michelangelo/templates/core/apiserver-ingress.yaml
@@ -1,0 +1,46 @@
+{{- if and .Values.apiserver.enabled .Values.apiserver.ingress.enabled }}
+{{- if eq .Values.apiserver.ingress.mode "passthrough" }}
+  {{- if not .Values.apiserver.tls.enabled }}
+    {{- fail "apiserver.tls.enabled must be true when apiserver.ingress.mode=passthrough" }}
+  {{- end }}
+{{- end }}
+{{- $hostname := required "apiserver.ingress.hostname is required when apiserver.ingress.enabled=true" .Values.apiserver.ingress.hostname }}
+{{- $mode := .Values.apiserver.ingress.mode | default "passthrough" }}
+{{- $modeAnnotations := dict }}
+{{- if eq $mode "passthrough" }}
+  {{- $_ := set $modeAnnotations "nginx.ingress.kubernetes.io/ssl-passthrough" "true" }}
+{{- else if eq $mode "grpc" }}
+  {{- $_ := set $modeAnnotations "nginx.ingress.kubernetes.io/backend-protocol" "GRPC" }}
+{{- end }}
+{{- $allAnnotations := merge $modeAnnotations (.Values.apiserver.ingress.annotations | default dict) .Values.commonAnnotations }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "michelangelo.componentFullname" (dict "context" . "component" "apiserver") }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "michelangelo.componentLabels" (dict "context" . "component" "apiserver") | nindent 4 }}
+  {{- with $allAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.apiserver.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.apiserver.ingress.ingressClassName | quote }}
+  {{- end }}
+  {{- if .Values.apiserver.ingress.tls }}
+  tls:
+    {{- toYaml .Values.apiserver.ingress.tls | nindent 4 }}
+  {{- end }}
+  rules:
+    - host: {{ $hostname | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "michelangelo.componentFullname" (dict "context" . "component" "apiserver") }}
+                port:
+                  name: {{ if .Values.apiserver.tls.enabled }}grpcs{{ else }}grpc{{ end }}
+{{- end }}

--- a/helm/michelangelo/templates/core/apiserver-service.yaml
+++ b/helm/michelangelo/templates/core/apiserver-service.yaml
@@ -11,9 +11,9 @@ spec:
   selector:
     {{- include "michelangelo.componentSelectorLabels" (dict "context" . "component" "apiserver") | nindent 4 }}
   ports:
-    - name: grpc
+    - name: {{ if .Values.apiserver.tls.enabled }}grpcs{{ else }}grpc{{ end }}
       port: {{ .Values.apiserver.port }}
-      targetPort: grpc
+      targetPort: {{ if .Values.apiserver.tls.enabled }}grpcs{{ else }}grpc{{ end }}
       {{- if eq .Values.apiserver.service.type "NodePort" }}
       nodePort: {{ required "apiserver.service.nodePort is required when apiserver.service.type=NodePort" .Values.apiserver.service.nodePort }}
       {{- end }}

--- a/helm/michelangelo/templates/core/envoy-configmap.yaml
+++ b/helm/michelangelo/templates/core/envoy-configmap.yaml
@@ -54,6 +54,15 @@ data:
           connect_timeout: 1s
           type: LOGICAL_DNS
           http2_protocol_options: {}
+          {{- if .Values.apiserver.tls.enabled }}
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              common_tls_context:
+                validation_context:
+                  trust_chain_verification: ACCEPT_UNTRUSTED
+          {{- end }}
           lb_policy: ROUND_ROBIN
           load_assignment:
             cluster_name: michelangelo-apiserver

--- a/helm/michelangelo/templates/core/envoy-ingress.yaml
+++ b/helm/michelangelo/templates/core/envoy-ingress.yaml
@@ -1,0 +1,32 @@
+{{- if and .Values.envoy.enabled .Values.envoy.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "michelangelo.componentFullname" (dict "context" . "component" "envoy") }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "michelangelo.componentLabels" (dict "context" . "component" "envoy") | nindent 4 }}
+  {{- with merge (.Values.envoy.ingress.annotations | default dict) .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.envoy.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.envoy.ingress.ingressClassName | quote }}
+  {{- end }}
+  {{- if .Values.envoy.ingress.tls }}
+  tls:
+    {{- toYaml .Values.envoy.ingress.tls | nindent 4 }}
+  {{- end }}
+  rules:
+    - host: {{ required "envoy.ingress.hostname is required when envoy.ingress.enabled=true" .Values.envoy.ingress.hostname | quote }}
+      http:
+        paths:
+          - path: {{ .Values.envoy.ingress.path | default "/" | quote }}
+            pathType: {{ .Values.envoy.ingress.pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ include "michelangelo.componentFullname" (dict "context" . "component" "envoy") }}
+                port:
+                  name: http
+{{- end }}

--- a/helm/michelangelo/templates/core/ui-configmap.yaml
+++ b/helm/michelangelo/templates/core/ui-configmap.yaml
@@ -1,4 +1,16 @@
 {{- if .Values.ui.enabled }}
+{{- $apiBaseUrl := .Values.ui.apiBaseUrl -}}
+{{- if and (not $apiBaseUrl) .Values.envoy.ingress.enabled .Values.envoy.ingress.hostname -}}
+  {{- $scheme := "http" -}}
+  {{- if .Values.envoy.ingress.tls -}}
+    {{- $scheme = "https" -}}
+  {{- end -}}
+  {{- $path := .Values.envoy.ingress.path | default "/" | trimSuffix "/" -}}
+  {{- $apiBaseUrl = printf "%s://%s%s" $scheme .Values.envoy.ingress.hostname $path -}}
+{{- end -}}
+{{- if not $apiBaseUrl -}}
+  {{- fail "ui.apiBaseUrl is required when ui.enabled=true — set ui.apiBaseUrl explicitly or enable envoy.ingress with envoy.ingress.hostname" -}}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,6 +21,6 @@ metadata:
 data:
   config.json: |
     {
-      "apiBaseUrl": {{ required "ui.apiBaseUrl is required when ui.enabled=true — see helm/michelangelo/README.md#values-reference" .Values.ui.apiBaseUrl | quote }}
+      "apiBaseUrl": {{ $apiBaseUrl | quote }}
     }
 {{- end }}

--- a/helm/michelangelo/templates/core/ui-ingress.yaml
+++ b/helm/michelangelo/templates/core/ui-ingress.yaml
@@ -1,0 +1,32 @@
+{{- if and .Values.ui.enabled .Values.ui.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "michelangelo.componentFullname" (dict "context" . "component" "ui") }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "michelangelo.componentLabels" (dict "context" . "component" "ui") | nindent 4 }}
+  {{- with merge (.Values.ui.ingress.annotations | default dict) .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ui.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ui.ingress.ingressClassName | quote }}
+  {{- end }}
+  {{- if .Values.ui.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ui.ingress.tls | nindent 4 }}
+  {{- end }}
+  rules:
+    - host: {{ required "ui.ingress.hostname is required when ui.ingress.enabled=true" .Values.ui.ingress.hostname | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "michelangelo.componentFullname" (dict "context" . "component" "ui") }}
+                port:
+                  name: http
+{{- end }}

--- a/helm/michelangelo/values.yaml
+++ b/helm/michelangelo/values.yaml
@@ -149,17 +149,78 @@ apiserver:
     # Required when type=NodePort. Ignored otherwise.
     nodePort: null
 
+  # ---------------------------------------------------------------------------
+  # TLS for the apiserver gRPC port. Independent of Ingress — turn this on if
+  # you want pod-level TLS (e.g. mesh mTLS, or apiserver.ingress.mode=passthrough
+  # which terminates TLS at the pod, not the controller).
+  # ---------------------------------------------------------------------------
   tls:
+    # Toggle TLS on the gRPC listener. When true, the Service exposes a
+    # `grpcs` port and the apiserver loads `tls.crt` + `tls.key` from
+    # `secretName` mounted at `mountPath`.
     enabled: false
+
+    # REQUIRED when tls.enabled=true. Name of a kubernetes.io/tls Secret in
+    # the release namespace containing `tls.crt` and `tls.key`. Create with:
+    #   kubectl create secret tls apiserver-tls --cert=server.crt --key=server.key
     secretName: ""
+
+    # Where the Secret is mounted inside the apiserver container. The
+    # apiserver looks for tls.crt and tls.key under this path.
     mountPath: /tls
 
+  # ---------------------------------------------------------------------------
+  # Ingress for the apiserver gRPC port. Use this only when an external
+  # gRPC client (CLI, SDK, CI runner) outside the cluster needs to reach the
+  # apiserver directly. The browser UI does NOT use this path — it goes
+  # through envoy (gRPC-Web). Most users can leave this disabled.
+  # ---------------------------------------------------------------------------
   ingress:
+    # Toggle the apiserver Ingress. Default off.
     enabled: false
-    mode: passthrough
+
+    # How the Ingress controller forwards gRPC to the apiserver Pod:
+    #
+    #   "grpc"        — Controller terminates TLS, then re-originates an
+    #                   HTTP/2 (h2c) connection to the Pod. Requires a
+    #                   controller that supports the GRPC backend protocol
+    #                   (nginx, Contour, Emissary). The apiserver Pod can
+    #                   stay plaintext (apiserver.tls.enabled=false). This
+    #                   is the simpler, recommended path for nginx users.
+    #
+    #   "passthrough" — Controller forwards the raw TLS bytes to the Pod
+    #                   without decrypting. The apiserver Pod MUST terminate
+    #                   TLS itself (apiserver.tls.enabled=true required, or
+    #                   `helm install` fails fast). Use this when you need
+    #                   end-to-end TLS, mTLS, or your controller cannot
+    #                   re-originate gRPC.
+    mode: grpc
+
+    # IngressClass name. Leave empty to use the cluster default. Set to
+    # "nginx", "contour", "traefik", etc. to target a specific controller.
     ingressClassName: ""
+
+    # REQUIRED when ingress.enabled=true. Hostname clients connect to.
+    # Must be DIFFERENT from ui.ingress.hostname and envoy.ingress.hostname
+    # — gRPC and HTTP/1.1 cannot share a host on most controllers, and
+    # passthrough mode hijacks the TLS SNI for the entire host.
+    # Example: "grpc.michelangelo.example.com"
     hostname: ""
+
+    # Extra controller-specific annotations. The chart auto-injects the
+    # mode annotation:
+    #   mode=passthrough → nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    #   mode=grpc        → nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+    # Override or add others here, e.g.:
+    #   cert-manager.io/cluster-issuer: letsencrypt-prod
     annotations: {}
+
+    # TLS block, copied verbatim into spec.tls. Required for "grpc" mode
+    # (the controller terminates TLS) and ignored for "passthrough" mode
+    # (TLS terminates at the pod). Example:
+    #   tls:
+    #     - hosts: ["grpc.michelangelo.example.com"]
+    #       secretName: apiserver-ingress-tls
     tls: []
 
 # -----------------------------------------------------------------------------
@@ -171,9 +232,18 @@ envoy:
   # gRPC-Web port. The UI's `apiBaseUrl` should point here.
   port: 8081
 
-  # CORS origin regex. The UI must be served from an origin that matches.
-  # Local dev: "http://localhost:[0-9]+"
-  # Production: "https://michelangelo\\.example\\.com"
+  # CORS origin regex. Required whenever the UI runs on a different origin
+  # than envoy — which means EVERY Ingress install. The browser refuses to
+  # call envoy if its Access-Control-Allow-Origin header doesn't match the
+  # UI's origin. Symptom: UI loads, every API call fails with a CORS error.
+  #
+  # The value is a Go regex — escape literal dots as `\.`:
+  # Local dev:      "http://localhost:[0-9]+"
+  # Single host:    "https://michelangelo\\.example\\.com"
+  # Multiple:       "https://(michelangelo|staging)\\.example\\.com"
+  #
+  # When envoy.ingress.enabled=true, this MUST match the scheme + host
+  # of ui.ingress.hostname.
   corsOrigins: ""
 
   resources: {}
@@ -182,13 +252,48 @@ envoy:
     type: ClusterIP
     nodePort: null
 
+  # ---------------------------------------------------------------------------
+  # Ingress for the envoy gRPC-Web proxy. This is the path the browser UI
+  # uses to talk to the apiserver, so enable this whenever the UI is exposed
+  # outside the cluster. Pairs with ui.ingress (UI + envoy on one hostname)
+  # or stands alone on its own subdomain.
+  # ---------------------------------------------------------------------------
   ingress:
+    # Toggle the envoy Ingress. Default off.
     enabled: false
+
+    # IngressClass. Leave empty for cluster default.
     ingressClassName: ""
+
+    # REQUIRED when ingress.enabled=true. Hostname the UI's apiBaseUrl
+    # resolves to. May be shared with ui.ingress.hostname (same host, split
+    # by path — see annotations) or set to a dedicated subdomain like
+    # "api.michelangelo.example.com".
     hostname: ""
+
+    # Path prefix for envoy. Use "/" for a dedicated hostname, or "/api(/|$)(.*)"
+    # when sharing a hostname with ui.ingress (requires nginx rewrite
+    # annotation, see below).
     path: "/"
+
+    # PathType — Prefix (default), Exact, or ImplementationSpecific.
     pathType: Prefix
+
+    # Controller-specific annotations. Common patterns:
+    #   # nginx — strip the /api prefix when shared with the UI
+    #   nginx.ingress.kubernetes.io/rewrite-target: /$2
+    #   nginx.ingress.kubernetes.io/use-regex: "true"
+    #   nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+    #   nginx.ingress.kubernetes.io/proxy-body-size: "100m"
+    #   # cert-manager — auto-issue TLS
+    #   cert-manager.io/cluster-issuer: letsencrypt-prod
     annotations: {}
+
+    # spec.tls block. When the envoy ingress has TLS, the chart auto-derives
+    # ui.apiBaseUrl as https://<hostname><path>. Example:
+    #   tls:
+    #     - hosts: ["michelangelo.example.com"]
+    #       secretName: michelangelo-tls
     tls: []
 
 # -----------------------------------------------------------------------------
@@ -218,11 +323,34 @@ ui:
     port: 80
     nodePort: null
 
+  # ---------------------------------------------------------------------------
+  # Ingress for the UI. Standard HTTP/1.1 traffic, served at the root of
+  # the hostname. Pair with envoy.ingress on the same hostname (path-split)
+  # or on a dedicated subdomain.
+  # ---------------------------------------------------------------------------
   ingress:
+    # Toggle the UI Ingress. Default off — fall back to NodePort/LoadBalancer
+    # via ui.service.type, or port-forward.
     enabled: false
+
+    # IngressClass. Leave empty for cluster default.
     ingressClassName: ""
+
+    # REQUIRED when ingress.enabled=true. Hostname users open in the browser.
+    # Example: "michelangelo.example.com"
     hostname: ""
+
+    # Controller-specific annotations. Common patterns:
+    #   # nginx — needed when sharing a host with envoy.ingress at /api
+    #   nginx.ingress.kubernetes.io/use-regex: "true"
+    #   # cert-manager — auto-issue TLS
+    #   cert-manager.io/cluster-issuer: letsencrypt-prod
     annotations: {}
+
+    # spec.tls block. Example:
+    #   tls:
+    #     - hosts: ["michelangelo.example.com"]
+    #       secretName: michelangelo-tls
     tls: []
 
 # -----------------------------------------------------------------------------

--- a/helm/michelangelo/values.yaml
+++ b/helm/michelangelo/values.yaml
@@ -149,6 +149,19 @@ apiserver:
     # Required when type=NodePort. Ignored otherwise.
     nodePort: null
 
+  tls:
+    enabled: false
+    secretName: ""
+    mountPath: /tls
+
+  ingress:
+    enabled: false
+    mode: passthrough
+    ingressClassName: ""
+    hostname: ""
+    annotations: {}
+    tls: []
+
 # -----------------------------------------------------------------------------
 # envoy — gRPC-Web proxy. Required for the browser UI.
 # -----------------------------------------------------------------------------
@@ -168,6 +181,15 @@ envoy:
   service:
     type: ClusterIP
     nodePort: null
+
+  ingress:
+    enabled: false
+    ingressClassName: ""
+    hostname: ""
+    path: "/"
+    pathType: Prefix
+    annotations: {}
+    tls: []
 
 # -----------------------------------------------------------------------------
 # ui — React frontend served by nginx.
@@ -195,6 +217,13 @@ ui:
     type: ClusterIP
     port: 80
     nodePort: null
+
+  ingress:
+    enabled: false
+    ingressClassName: ""
+    hostname: ""
+    annotations: {}
+    tls: []
 
 # -----------------------------------------------------------------------------
 # worker — Cadence/Temporal workflow client. Executes pipeline runs.


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Adds Ingress support to `helm/michelangelo` across three services — all disabled by default:

- **Phase A — UI + Envoy**: `ui-ingress.yaml` and `envoy-ingress.yaml` expose the React frontend and gRPC-Web proxy through standard Kubernetes Ingress. `ui-configmap.yaml` auto-derives `apiBaseUrl` from `envoy.ingress` hostname + path + TLS state when not set explicitly.
- **Phase B — Apiserver gRPC**: `apiserver-ingress.yaml` exposes the raw gRPC apiserver in two selectable modes: `grpc` (recommended — controller terminates TLS, pod stays plaintext) and `passthrough` (end-to-end TLS, requires `apiserver.tls.enabled=true`). The chart auto-injects mode-specific annotations and fails fast on invalid combinations.
- All values blocks are fully commented with annotation examples, required key markers, and mode explanations. `envoy.corsOrigins` comment prominently warns it is required for every Ingress install.
- README has a new `## Ingress` section with 4 worked examples (path-split, subdomain, grpc mode, passthrough), a controller comparison table (nginx/Traefik/Contour/Emissary), apiBaseUrl auto-derive derivation table, CORS callout, and 6 troubleshooting entries.
- `helm dependency build` replaces `helm dependency update` throughout (Chart.lock is committed).

**Why?**

Community request — production users need a standard way to expose Michelangelo through an Ingress controller rather than NodePort/LoadBalancer. Ingress enables TLS termination, hostname-based routing, and a single load balancer across releases. Closes #1136.

**How did you test it?**

- `helm lint` → 0 errors, 0 failures
- `helm template -f values-k3d.yaml` → 21 resources (baseline unchanged, all Ingress disabled)
- `helm template --set ui.ingress.enabled=true --set envoy.ingress.enabled=true ...` → 23 resources (+2 Ingress)
- `apiBaseUrl` auto-derive from `envoy.ingress.hostname` renders correctly
- `apiserver.ingress.mode=passthrough` without `apiserver.tls.enabled=true` → fails fast
- `apiserver.ingress.mode=grpc` (new default) → renders with `GRPC` backend-protocol annotation
- `helm install -f values-k3d.yaml` against live k3d → all 5 pods Running within 22s
- `helm test` → Phase: Succeeded
- `helm upgrade --reuse-values` → zero pod restarts
- `helm uninstall` → both credential Secrets survive

**Potential risks**

Low — all Ingress and TLS features are disabled by default. Existing installs using `values-k3d.yaml` are unaffected. The `mode` default changed from `passthrough` to `grpc` — only affects users who had explicitly set `apiserver.ingress.enabled=true`, which was not possible before this PR since the values block didn't exist.

**Release notes**

N/A — all opt-in, no migration required.

**Documentation Changes**

`values.yaml` fully commented for all new keys. `helm/michelangelo/README.md` updated with Ingress section, troubleshooting, and `helm dependency build` guidance.