### PR TITLE
Add target list page

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -3,7 +3,7 @@ name: Dev Release
 on:
   workflow_dispatch:
   push:
-    branches: [ donovanlopez/add-target-list-page ]
+    branches: [ main ]
     paths-ignore:
       - 'docs/**'
       - 'website/**'

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -3,7 +3,7 @@ name: Dev Release
 on:
   workflow_dispatch:
   push:
-    branches: [ main ]
+    branches: [ donovanlopez/add-target-list-page ]
     paths-ignore:
       - 'docs/**'
       - 'website/**'

--- a/go/cmd/apiserver/main.go
+++ b/go/cmd/apiserver/main.go
@@ -45,6 +45,7 @@ func opts() fx.Option {
 		v2pb.CachedOutputSvcModule,
 		v2pb.ClusterSvcModule,
 		v2pb.DeploymentSvcModule,
+		v2pb.InferenceServerSvcModule,
 		v2pb.ModelFamilySvcModule,
 		v2pb.ModelSvcModule,
 		v2pb.PipelineRunSvcModule,

--- a/javascript/packages/core/config/entities/targets/__tests__/target-page.test.tsx
+++ b/javascript/packages/core/config/entities/targets/__tests__/target-page.test.tsx
@@ -36,7 +36,7 @@ describe('Target list page', () => {
       ])
     );
 
-    expect(await screen.findByRole('columnheader', { name: 'Name' })).toBeInTheDocument();
+    expect(await screen.findByRole('columnheader', { name: 'Target name' })).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: 'Last updated' })).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: 'Type' })).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: 'State' })).toBeInTheDocument();

--- a/javascript/packages/core/config/entities/targets/__tests__/target-page.test.tsx
+++ b/javascript/packages/core/config/entities/targets/__tests__/target-page.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+
+import { DEPLOY_PHASE } from '#core/config/phases/deploy';
+import { PhaseListRoute } from '#core/router/phase-list-route';
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getErrorProviderWrapper } from '#core/test/wrappers/get-error-provider-wrapper';
+import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
+import { getServiceProviderWrapper } from '#core/test/wrappers/get-service-provider-wrapper';
+
+describe('Target list page', () => {
+  it('renders the Targets tab', () => {
+    render(
+      <PhaseListRoute phases={{ deploy: DEPLOY_PHASE }} />,
+      buildWrapper([
+        getErrorProviderWrapper(),
+        getRouterWrapper({ location: '/myproject/deploy/targets' }),
+        getServiceProviderWrapper({
+          request: vi.fn().mockResolvedValue({ inferenceServerList: { items: [] } }),
+        }),
+      ])
+    );
+
+    expect(screen.getByRole('tab', { name: 'Targets' })).toBeInTheDocument();
+  });
+
+  it('renders the correct column headers', async () => {
+    render(
+      <PhaseListRoute phases={{ deploy: DEPLOY_PHASE }} />,
+      buildWrapper([
+        getErrorProviderWrapper(),
+        getRouterWrapper({ location: '/myproject/deploy/targets' }),
+        getServiceProviderWrapper({
+          request: vi.fn().mockResolvedValue({ inferenceServerList: { items: [] } }),
+        }),
+      ])
+    );
+
+    expect(await screen.findByRole('columnheader', { name: 'Name' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Last updated' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Type' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'State' })).toBeInTheDocument();
+  });
+});

--- a/javascript/packages/core/config/entities/targets/list.ts
+++ b/javascript/packages/core/config/entities/targets/list.ts
@@ -18,7 +18,7 @@ export const INFERENCE_SERVER_STATE = {
 const TARGET_COLUMNS: ColumnConfig<object>[] = [
   {
     id: 'metadata.name',
-    label: 'Name',
+    label: 'Target name',
     type: CellType.TEXT,
   },
   {

--- a/javascript/packages/core/config/entities/targets/list.ts
+++ b/javascript/packages/core/config/entities/targets/list.ts
@@ -1,0 +1,73 @@
+import { CellType } from '#core/components/cell/constants';
+
+import type { ColumnConfig } from '#core/components/table/types/column-types';
+import type { ListViewConfig } from '#core/components/views/types';
+
+export const INFERENCE_SERVER_STATE = {
+  INVALID: 0,
+  INITIALIZED: 1,
+  CREATE_PENDING: 2,
+  SERVING: 3,
+  FAILED: 4,
+  DELETE_PENDING: 5,
+  CREATING: 6,
+  DELETING: 7,
+  DELETED: 8,
+} as const;
+
+const TARGET_COLUMNS: ColumnConfig<object>[] = [
+  {
+    id: 'metadata.name',
+    label: 'Name',
+    type: CellType.TEXT,
+  },
+  {
+    id: 'status.updateTime',
+    label: 'Last updated',
+    type: CellType.DATE,
+    accessor: (data: unknown) => {
+      const ts = (data as { status?: { updateTime?: string } })?.status?.updateTime;
+      return ts ? Math.floor(new Date(ts).getTime() / 1000) : undefined;
+    },
+  },
+  {
+    id: 'type',
+    label: 'Type',
+    type: CellType.TAG,
+    accessor: () => 'Inference Server',
+  },
+  {
+    id: 'status.state',
+    label: 'State',
+    type: CellType.STATE,
+    stateTextMap: {
+      [INFERENCE_SERVER_STATE.INVALID]: 'Invalid',
+      [INFERENCE_SERVER_STATE.INITIALIZED]: 'Initialized',
+      [INFERENCE_SERVER_STATE.CREATE_PENDING]: 'Create pending',
+      [INFERENCE_SERVER_STATE.SERVING]: 'Serving',
+      [INFERENCE_SERVER_STATE.FAILED]: 'Failed',
+      [INFERENCE_SERVER_STATE.DELETE_PENDING]: 'Delete pending',
+      [INFERENCE_SERVER_STATE.CREATING]: 'Creating',
+      [INFERENCE_SERVER_STATE.DELETING]: 'Deleting',
+      [INFERENCE_SERVER_STATE.DELETED]: 'Deleted',
+    },
+    stateColorMap: {
+      [INFERENCE_SERVER_STATE.INVALID]: 'gray',
+      [INFERENCE_SERVER_STATE.INITIALIZED]: 'blue',
+      [INFERENCE_SERVER_STATE.CREATE_PENDING]: 'blue',
+      [INFERENCE_SERVER_STATE.SERVING]: 'green',
+      [INFERENCE_SERVER_STATE.FAILED]: 'red',
+      [INFERENCE_SERVER_STATE.DELETE_PENDING]: 'blue',
+      [INFERENCE_SERVER_STATE.CREATING]: 'blue',
+      [INFERENCE_SERVER_STATE.DELETING]: 'blue',
+      [INFERENCE_SERVER_STATE.DELETED]: 'gray',
+    },
+  },
+];
+
+export const TARGET_LIST_CONFIG: ListViewConfig<object> = {
+  type: 'list',
+  tableConfig: {
+    columns: TARGET_COLUMNS,
+  },
+};

--- a/javascript/packages/core/config/entities/targets/target.ts
+++ b/javascript/packages/core/config/entities/targets/target.ts
@@ -1,0 +1,11 @@
+import { TARGET_LIST_CONFIG } from './list';
+
+import type { PhaseEntityConfig } from '#core/types/common/studio-types';
+
+export const TARGET_ENTITY_CONFIG: PhaseEntityConfig = {
+  id: 'targets',
+  name: 'Targets',
+  service: 'inferenceServer',
+  state: 'active',
+  views: [TARGET_LIST_CONFIG],
+};

--- a/javascript/packages/core/config/phases/deploy.ts
+++ b/javascript/packages/core/config/phases/deploy.ts
@@ -1,4 +1,5 @@
 import { DEPLOYMENT_ENTITY_CONFIG } from '#core/config/entities/deployment/deployment';
+import { TARGET_ENTITY_CONFIG } from '#core/config/entities/target/target';
 
 import type { PhaseConfig } from '#core/types/common/studio-types';
 
@@ -9,5 +10,5 @@ export const DEPLOY_PHASE: PhaseConfig = {
   description: 'Deploy your models and predict new data',
   docUrl: 'https://example.com/docs/deploy',
   state: 'comingSoon' as const,
-  entities: [DEPLOYMENT_ENTITY_CONFIG],
+  entities: [TARGET_ENTITY_CONFIG, DEPLOYMENT_ENTITY_CONFIG],
 };

--- a/javascript/packages/core/config/phases/deploy.ts
+++ b/javascript/packages/core/config/phases/deploy.ts
@@ -1,5 +1,5 @@
 import { DEPLOYMENT_ENTITY_CONFIG } from '#core/config/entities/deployment/deployment';
-import { TARGET_ENTITY_CONFIG } from '#core/config/entities/target/target';
+import { TARGET_ENTITY_CONFIG } from '#core/config/entities/targets/target';
 
 import type { PhaseConfig } from '#core/types/common/studio-types';
 

--- a/javascript/packages/rpc/handlers.ts
+++ b/javascript/packages/rpc/handlers.ts
@@ -14,6 +14,9 @@ async function createHandlers() {
     GetDeployment: services.DeploymentService.getDeployment as ExtractUnaryRpc<
       typeof services.DeploymentService.getDeployment
     >,
+    ListInferenceServer: services.InferenceServerService.listInferenceServer as ExtractUnaryRpc<
+      typeof services.InferenceServerService.listInferenceServer
+    >,
     ListProject: services.ProjectService.listProject as ExtractUnaryRpc<
       typeof services.ProjectService.listProject
     >,

--- a/javascript/packages/rpc/services.ts
+++ b/javascript/packages/rpc/services.ts
@@ -2,6 +2,7 @@ import { createClient } from '@connectrpc/connect';
 import { createGrpcWebTransport } from '@connectrpc/connect-web';
 
 import { DeploymentService } from './gen/michelangelo/api/v2/deployment_svc_pb';
+import { InferenceServerService } from './gen/michelangelo/api/v2/inference_server_svc_pb';
 import { ModelService } from './gen/michelangelo/api/v2/model_svc_pb';
 import { PipelineRunService } from './gen/michelangelo/api/v2/pipeline_run_svc_pb';
 import { PipelineService } from './gen/michelangelo/api/v2/pipeline_svc_pb';
@@ -39,6 +40,7 @@ async function createServices(): Promise<Services> {
 
   return {
     DeploymentService: createClient(DeploymentService, transport),
+    InferenceServerService: createClient(InferenceServerService, transport),
     ProjectService: createClient(ProjectService, transport),
     PipelineService: createClient(PipelineService, transport),
     PipelineRunService: createClient(PipelineRunService, transport),

--- a/javascript/packages/rpc/types.ts
+++ b/javascript/packages/rpc/types.ts
@@ -1,6 +1,7 @@
 import type { Message } from '@bufbuild/protobuf';
 import type { createClient } from '@connectrpc/connect';
 import type { DeploymentService } from './gen/michelangelo/api/v2/deployment_svc_pb';
+import type { InferenceServerService } from './gen/michelangelo/api/v2/inference_server_svc_pb';
 import type { ModelService } from './gen/michelangelo/api/v2/model_svc_pb';
 import type { PipelineRunService } from './gen/michelangelo/api/v2/pipeline_run_svc_pb';
 import type { PipelineService } from './gen/michelangelo/api/v2/pipeline_svc_pb';
@@ -14,6 +15,7 @@ export interface RuntimeConfig {
 
 export type Services = {
   DeploymentService: ReturnType<typeof createClient<typeof DeploymentService>>;
+  InferenceServerService: ReturnType<typeof createClient<typeof InferenceServerService>>;
   ProjectService: ReturnType<typeof createClient<typeof ProjectService>>;
   PipelineService: ReturnType<typeof createClient<typeof PipelineService>>;
   PipelineRunService: ReturnType<typeof createClient<typeof PipelineRunService>>;


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update


This PR adds a Targets list view when on the Deploy & Predict phase.
<img width="1506" height="618" alt="image" src="https://github.com/user-attachments/assets/d3a3aff6-9481-4e3b-9749-7d2303f8b0c7" />


<!-- Tell your future self why have you made these changes -->
**Why?**
Users needed visibility into inference server targets from the MA Studio UI. Previously there was no way to view or monitor targets.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Added unit tests and tested locally.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
This PR adds `InferenceServerSvcModule` in the apiserver. If the InferenceServer CRD is not present in a cluster, the apiserver may fail to start. Existing clusters running the sandbox should be unaffected as the CRD is bundled.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
N/A

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
N/A
