### PR TITLE
Add deployment history list page

### DIFF
--- a/javascript/packages/core/config/entities/deployment/__tests__/deployment-page.test.tsx
+++ b/javascript/packages/core/config/entities/deployment/__tests__/deployment-page.test.tsx
@@ -230,7 +230,7 @@ describe('Deployment detail page', () => {
       ])
     );
 
-    expect(await screen.findByRole('columnheader', { name: 'Revision' })).toBeInTheDocument();
+    expect(await screen.findByRole('columnheader', { name: 'Deployment revision' })).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: 'Owner' })).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: 'Created' })).toBeInTheDocument();
   });

--- a/javascript/packages/core/config/entities/deployment/__tests__/deployment-page.test.tsx
+++ b/javascript/packages/core/config/entities/deployment/__tests__/deployment-page.test.tsx
@@ -230,7 +230,9 @@ describe('Deployment detail page', () => {
       ])
     );
 
-    expect(await screen.findByRole('columnheader', { name: 'Deployment revision' })).toBeInTheDocument();
+    expect(
+      await screen.findByRole('columnheader', { name: 'Deployment revision' })
+    ).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: 'Owner' })).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: 'Created' })).toBeInTheDocument();
   });

--- a/javascript/packages/core/config/entities/deployment/__tests__/deployment-page.test.tsx
+++ b/javascript/packages/core/config/entities/deployment/__tests__/deployment-page.test.tsx
@@ -192,4 +192,46 @@ describe('Deployment detail page', () => {
     expect(screen.getByText('Details')).toBeInTheDocument();
     expect(screen.getByText('PlacementInProgress')).toBeInTheDocument();
   });
+
+  it('renders the Deployment history tab', async () => {
+    render(
+      <EntityDetailRoute phases={{ deploy: DEPLOY_PHASE }} />,
+      buildWrapper([
+        getErrorProviderWrapper(),
+        getRouterWrapper({
+          location: '/myproject/deploy/deployments/sentiment-deployment/history',
+        }),
+        getServiceProviderWrapper({
+          request: createQueryMockRouter({
+            GetDeployment: { deployment: buildDeployment() },
+            ListRevision: { revisionList: { items: [] } },
+          }),
+        }),
+      ])
+    );
+
+    expect(await screen.findByRole('tab', { name: 'Deployment history' })).toBeInTheDocument();
+  });
+
+  it('renders the correct column headers for the deployment history tab', async () => {
+    render(
+      <EntityDetailRoute phases={{ deploy: DEPLOY_PHASE }} />,
+      buildWrapper([
+        getErrorProviderWrapper(),
+        getRouterWrapper({
+          location: '/myproject/deploy/deployments/sentiment-deployment/history',
+        }),
+        getServiceProviderWrapper({
+          request: createQueryMockRouter({
+            GetDeployment: { deployment: buildDeployment() },
+            ListRevision: { revisionList: { items: [] } },
+          }),
+        }),
+      ])
+    );
+
+    expect(await screen.findByRole('columnheader', { name: 'Revision' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Owner' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Created' })).toBeInTheDocument();
+  });
 });

--- a/javascript/packages/core/config/entities/deployment/detail.ts
+++ b/javascript/packages/core/config/entities/deployment/detail.ts
@@ -32,7 +32,7 @@ export const DEPLOYMENT_DETAIL_CONFIG: DetailViewConfig = {
       },
       tableConfig: {
         columns: [
-          { id: 'metadata.name', label: 'Revision', type: CellType.TEXT },
+          { id: 'metadata.name', label: 'Deployment revision', type: CellType.TEXT },
           { id: 'spec.owner.name', label: 'Owner', type: CellType.TEXT },
           { id: 'metadata.creationTimestamp.seconds', label: 'Created', type: CellType.DATE },
         ],

--- a/javascript/packages/core/config/entities/deployment/detail.ts
+++ b/javascript/packages/core/config/entities/deployment/detail.ts
@@ -18,6 +18,27 @@ export const DEPLOYMENT_DETAIL_CONFIG: DetailViewConfig = {
   ],
   pages: [
     {
+      id: 'history',
+      label: 'Deployment history',
+      type: 'table',
+      queryConfig: {
+        endpoint: 'list',
+        service: 'revision',
+        serviceOptions: {
+          listOptions: {
+            labelSelector: 'michelangelo/deployment=${page.metadata.name}',
+          },
+        },
+      },
+      tableConfig: {
+        columns: [
+          { id: 'metadata.name', label: 'Revision', type: CellType.TEXT },
+          { id: 'spec.owner.name', label: 'Owner', type: CellType.TEXT },
+          { id: 'metadata.creationTimestamp.seconds', label: 'Created', type: CellType.DATE },
+        ],
+      },
+    },
+    {
       id: 'stages',
       label: 'Stages',
       type: 'execution',

--- a/javascript/packages/rpc/handlers.ts
+++ b/javascript/packages/rpc/handlers.ts
@@ -50,6 +50,9 @@ async function createHandlers() {
     ListModel: services.ModelService.listModel as ExtractUnaryRpc<
       typeof services.ModelService.listModel
     >,
+    ListRevision: services.RevisionService.listRevision as ExtractUnaryRpc<
+      typeof services.RevisionService.listRevision
+    >,
   } as const;
 }
 

--- a/javascript/packages/rpc/services.ts
+++ b/javascript/packages/rpc/services.ts
@@ -6,6 +6,7 @@ import { ModelService } from './gen/michelangelo/api/v2/model_svc_pb';
 import { PipelineRunService } from './gen/michelangelo/api/v2/pipeline_run_svc_pb';
 import { PipelineService } from './gen/michelangelo/api/v2/pipeline_svc_pb';
 import { ProjectService } from './gen/michelangelo/api/v2/project_svc_pb';
+import { RevisionService } from './gen/michelangelo/api/v2/revision_svc_pb';
 import { TriggerRunService } from './gen/michelangelo/api/v2/trigger_run_svc_pb';
 import { getRuntimeConfig } from './runtime-config';
 
@@ -42,6 +43,7 @@ async function createServices(): Promise<Services> {
     ProjectService: createClient(ProjectService, transport),
     PipelineService: createClient(PipelineService, transport),
     PipelineRunService: createClient(PipelineRunService, transport),
+    RevisionService: createClient(RevisionService, transport),
     TriggerRunService: createClient(TriggerRunService, transport),
     ModelService: createClient(ModelService, transport),
   } as const;

--- a/javascript/packages/rpc/types.ts
+++ b/javascript/packages/rpc/types.ts
@@ -5,6 +5,7 @@ import type { ModelService } from './gen/michelangelo/api/v2/model_svc_pb';
 import type { PipelineRunService } from './gen/michelangelo/api/v2/pipeline_run_svc_pb';
 import type { PipelineService } from './gen/michelangelo/api/v2/pipeline_svc_pb';
 import type { ProjectService } from './gen/michelangelo/api/v2/project_svc_pb';
+import type { RevisionService } from './gen/michelangelo/api/v2/revision_svc_pb';
 import type { TriggerRunService } from './gen/michelangelo/api/v2/trigger_run_svc_pb';
 import type { getRpcHandlers } from './handlers';
 
@@ -17,6 +18,7 @@ export type Services = {
   ProjectService: ReturnType<typeof createClient<typeof ProjectService>>;
   PipelineService: ReturnType<typeof createClient<typeof PipelineService>>;
   PipelineRunService: ReturnType<typeof createClient<typeof PipelineRunService>>;
+  RevisionService: ReturnType<typeof createClient<typeof RevisionService>>;
   TriggerRunService: ReturnType<typeof createClient<typeof TriggerRunService>>;
   ModelService: ReturnType<typeof createClient<typeof ModelService>>;
 };


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
<img width="1508" height="823" alt="image" src="https://github.com/user-attachments/assets/b87c038c-3a40-4cb3-b202-1a21602f828a" />


<!-- Tell your future self why have you made these changes -->
**Why?**
Under the Deployments detail page, we want to add a new tab for the Deployment history as we further flesh out the Deployments page.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I have unit tests to test the correct fields for the Deployment history page are visible. Plus I checked the UI.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
None.
