### PR TITLE
feat: add Temporal optional subchart with fail-fast validation

### DIFF
--- a/helm/michelangelo/Chart.lock
+++ b/helm/michelangelo/Chart.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: cadence
   repository: https://cadence-workflow.github.io/cadence-charts
   version: 1.1.0
-digest: sha256:2217bb01dcdd9d9869aed7434e6b141ee600f022ff5eb8e98d39535621be0fff
-generated: "2026-05-06T20:22:02.517193-07:00"
+- name: temporal
+  repository: https://go.temporal.io/helm-charts
+  version: 0.44.0
+digest: sha256:57b6eb9685f40a10a9ee2799e559c85b8a3e236bf1817ffa5b9c9d37c632379a
+generated: "2026-05-07T20:22:04.950638-07:00"

--- a/helm/michelangelo/Chart.yaml
+++ b/helm/michelangelo/Chart.yaml
@@ -16,6 +16,10 @@ dependencies:
     version: "1.1.0"
     repository: https://cadence-workflow.github.io/cadence-charts
     condition: cadence.enabled
+  - name: temporal
+    version: "0.44.0"
+    repository: https://go.temporal.io/helm-charts
+    condition: temporal.enabled
 
 home: https://github.com/michelangelo-ai/michelangelo
 icon: https://raw.githubusercontent.com/michelangelo-ai/michelangelo/main/docs/assets/logo.png

--- a/helm/michelangelo/README.md
+++ b/helm/michelangelo/README.md
@@ -131,6 +131,107 @@ The Michelangelo control plane uses the `michelangelo` database — there is no 
 
 `cadence.enabled=true` with `workflow.engine=temporal` is a misconfiguration — the Cadence pods install but the worker ignores them. The chart prints a warning in `NOTES.txt` if both are set.
 
+## Bundled Temporal (optional subchart)
+
+If you prefer Temporal over Cadence, you can install the official [Temporal Helm chart](https://github.com/temporalio/helm-charts) (`temporalio/temporal` v0.44.0) as part of this release by setting `temporal.enabled=true`. Users with an existing managed Temporal service should leave it disabled (default) and point `workflow.endpoint` at their own service.
+
+The bundled subchart is **not** used by `michelangelo sandbox up`. The local sandbox provisions its own Temporal outside the chart.
+
+**Do not enable both `cadence.enabled=true` and `temporal.enabled=true`** — pick one workflow engine per release.
+
+### When to use it
+
+| You have… | Setting |
+|---|---|
+| A managed Temporal cluster | `temporal.enabled=false` (default) |
+| A managed Cadence cluster | `temporal.enabled=false`, set `workflow.engine=cadence` |
+| Nothing — fully self-contained install | `temporal.enabled=true` |
+
+### Prerequisite: download the subchart
+
+```bash
+helm dependency build ./helm/michelangelo
+```
+
+Skipping produces: `Error: found in Chart.yaml, but missing in charts/ directory: temporal`
+
+### Install command
+
+Step 1 — fetch the subchart:
+
+```bash
+helm dependency build ./helm/michelangelo
+```
+
+Step 2 — install:
+
+```bash
+helm install michelangelo ./helm/michelangelo \
+  --namespace michelangelo --create-namespace \
+  --set temporal.enabled=true \
+  --set workflow.engine=temporal \
+  --set workflow.endpoint=michelangelo-temporal-frontend:7233 \
+  --set metadataStorage.host=my-mysql.example.com \
+  --set metadataStorage.rootPassword=$METADATA_ROOT_PASSWORD \
+  --set temporal.server.config.persistence.default.sql.host=my-mysql.example.com \
+  --set temporal.server.config.persistence.default.sql.password=$METADATA_ROOT_PASSWORD \
+  --set temporal.server.config.persistence.visibility.sql.host=my-mysql.example.com \
+  --set temporal.server.config.persistence.visibility.sql.password=$METADATA_ROOT_PASSWORD \
+  --set objectStorage.endpoint=s3.amazonaws.com \
+  --set objectStorage.accessKeyId=$AWS_ACCESS_KEY_ID \
+  --set objectStorage.secretAccessKey=$AWS_SECRET_ACCESS_KEY \
+  --set ui.apiBaseUrl=https://michelangelo.example.com/api
+```
+
+### Key differences from the Cadence subchart
+
+| | Cadence | Temporal |
+|---|---|---|
+| MySQL driver | `"mysql"` | **`"mysql8"`** (different string — do not use `"mysql"`) |
+| Frontend port | `7833` | `7233` |
+| Frontend Service | `<release>-cadence-frontend` | `<release>-temporal-frontend` |
+| Main database | `cadence` | `temporal` |
+| Visibility database | `cadence_visibility` | `temporal_visibility` |
+| Persistence key path | `config.persistence.database.sql.*` | `server.config.persistence.default.sql.*` |
+
+### MySQL setup
+
+Temporal creates two databases — same privilege requirements as Cadence:
+
+| Database | Purpose |
+|---|---|
+| `temporal` | Workflow history, task queues, namespaces |
+| `temporal_visibility` | Workflow list/search queries |
+
+Pre-create if your MySQL user lacks `CREATE DATABASE`:
+
+```sql
+CREATE DATABASE temporal;
+CREATE DATABASE temporal_visibility;
+GRANT ALL PRIVILEGES ON temporal.* TO 'your_user'@'%';
+GRANT ALL PRIVILEGES ON temporal_visibility.* TO 'your_user'@'%';
+```
+
+### Troubleshooting
+
+**Schema job fails with `Access denied ... CREATE DATABASE`.**
+
+Grant `CREATE DATABASE` or pre-create both databases (see above). Then delete the failed job and re-upgrade:
+
+```bash
+kubectl delete job -l app.kubernetes.io/name=temporal -n michelangelo
+helm upgrade michelangelo ./helm/michelangelo --reuse-values
+```
+
+**Worker logs `connection refused` to `<release>-temporal-frontend:7233`.**
+
+Wait for Temporal to finish initializing (~60s):
+
+```bash
+kubectl --namespace michelangelo wait --for=condition=ready pod \
+  -l app.kubernetes.io/name=temporal --timeout=5m
+```
+
 ## Values Reference
 
 Top-level keys. See [`values.yaml`](./values.yaml) for the full annotated schema.

--- a/helm/michelangelo/templates/NOTES.txt
+++ b/helm/michelangelo/templates/NOTES.txt
@@ -61,6 +61,63 @@ Open the Cadence Web UI:
 {{- end }}
 {{- end }}
 
+{{- if .Values.temporal.enabled }}
+{{- if eq .Values.workflow.engine "cadence" }}
+
+────────────────────────────────────────────────────────────────────────
+WARNING: Mismatched workflow configuration
+────────────────────────────────────────────────────────────────────────
+
+You set `temporal.enabled=true` AND `workflow.engine=cadence`.
+
+The Temporal subchart will install, but the Michelangelo worker is
+configured for Cadence and will ignore it. Pick one:
+
+  • To use the bundled Temporal:
+        --set workflow.engine=temporal
+        --set workflow.endpoint={{ .Release.Name }}-temporal-frontend:7233
+  • To use Cadence:
+        --set temporal.enabled=false
+        --set workflow.endpoint=<your-cadence-frontend>:7833
+
+{{- else }}
+
+────────────────────────────────────────────────────────────────────────
+Bundled Temporal installed alongside the control plane
+────────────────────────────────────────────────────────────────────────
+
+  Frontend:  {{ .Release.Name }}-temporal-frontend (gRPC :7233)
+  Databases: temporal + temporal_visibility (in {{ .Values.temporal.server.config.persistence.default.sql.host | default "your MySQL host" }})
+  MySQL driver: mysql8 (NOT "mysql" — Temporal uses a different driver string than Cadence)
+
+Wait for the schema job before running pipelines:
+
+    kubectl --namespace {{ .Release.Namespace }} wait --for=condition=complete \
+      job -l app.kubernetes.io/name=temporal,app.kubernetes.io/component=schema \
+      --timeout=5m
+
+Open the Temporal Web UI:
+
+    kubectl --namespace {{ .Release.Namespace }} port-forward \
+      svc/{{ .Release.Name }}-temporal-web 8080:8080
+    open http://localhost:8080
+
+{{- end }}
+{{- end }}
+
+{{- if and .Values.temporal.enabled .Values.cadence.enabled }}
+
+────────────────────────────────────────────────────────────────────────
+WARNING: Both cadence.enabled and temporal.enabled are true
+────────────────────────────────────────────────────────────────────────
+
+Both workflow engine subcharts are enabled simultaneously. Pick one:
+
+  • Cadence:  --set temporal.enabled=false --set workflow.engine=cadence
+  • Temporal: --set cadence.enabled=false  --set workflow.engine=temporal
+
+{{- end }}
+
 ────────────────────────────────────────────────────────────────────────
 1. Verify the install
 ────────────────────────────────────────────────────────────────────────

--- a/helm/michelangelo/templates/validations.yaml
+++ b/helm/michelangelo/templates/validations.yaml
@@ -1,0 +1,7 @@
+{{/*
+Fail fast on invalid value combinations before any resource is created.
+This file renders to empty YAML when all checks pass.
+*/}}
+{{- if and .Values.cadence.enabled .Values.temporal.enabled -}}
+{{- fail "cadence.enabled and temporal.enabled cannot both be true — pick one workflow engine per release. Set workflow.engine=cadence + cadence.enabled=true, OR workflow.engine=temporal + temporal.enabled=true. See helm/michelangelo/README.md." -}}
+{{- end -}}

--- a/helm/michelangelo/values.yaml
+++ b/helm/michelangelo/values.yaml
@@ -537,3 +537,104 @@ cadence:
   # Cadence web UI. Useful for inspecting workflows. Disable to save a pod.
   web:
     enabled: true
+
+# -----------------------------------------------------------------------------
+# Temporal — optional bundled workflow engine.
+#
+# When enabled, the official Temporal Helm chart (temporalio/temporal v0.44.0)
+# is installed as a subchart of this release. Disabled by default — bring
+# your own Cadence or Temporal in production.
+#
+# Prerequisite: run `helm dependency build ./helm/michelangelo` once before
+# the first install with temporal.enabled=true.
+#
+# When enabled, set workflow.engine=temporal and
+# workflow.endpoint=<release>-temporal-frontend:7233
+#
+# IMPORTANT: temporal.enabled=true and cadence.enabled=true must not be
+# set together — pick one workflow engine per release.
+# -----------------------------------------------------------------------------
+temporal:
+  # Toggle bundled Temporal. Default off — set true for self-contained installs.
+  enabled: false
+
+  # IMPORTANT: temporal.enabled=true and cadence.enabled=true are mutually
+  # exclusive. Setting both installs both subcharts but the worker only
+  # talks to whichever workflow.engine names — the other sits idle and
+  # wastes cluster resources. The chart fails fast if both are set.
+
+  server:
+    config:
+      persistence:
+        # ---------------------------------------------------------------------------
+        # Point Temporal at the same MySQL instance the control plane uses.
+        # Temporal creates TWO databases: `temporal` (workflow history) and
+        # `temporal_visibility` (search/list queries). The MySQL user needs
+        # CREATE DATABASE privilege, or pre-create both databases manually.
+        #
+        # IMPORTANT: Use driver "mysql8" (not "mysql") — the Temporal chart uses
+        # a different driver string than the Cadence chart. Using "mysql" will
+        # cause the schema tool to use a deprecated code path.
+        # ---------------------------------------------------------------------------
+        default:
+          driver: sql
+          sql:
+            # "mysql8" for MySQL 8.x. Do NOT use "mysql" — that is the legacy driver.
+            driver: mysql8
+
+            # Hostname of the MySQL server. Can be the same as metadataStorage.host.
+            host: ""
+
+            # MySQL port.
+            port: 3306
+
+            # Workflow history database. Auto-created by the Temporal schema job.
+            database: temporal
+
+            # MySQL user. Needs CREATE DATABASE privilege (or pre-create the DB).
+            user: root
+
+            # MySQL password. Same as metadataStorage.rootPassword if sharing MySQL.
+            # Pass via --set — never commit.
+            password: ""
+
+        visibility:
+          driver: sql
+          sql:
+            # Same driver as default — must match. Use "mysql8", NOT "mysql".
+            driver: mysql8
+
+            # Same host as default. Mismatched hosts across default/visibility
+            # cause half-broken installs (history works, list/search fails).
+            host: ""
+
+            port: 3306
+
+            # Visibility (list/search) database. Auto-created by the schema job.
+            # Required — Temporal will not start without it.
+            database: temporal_visibility
+
+            # MySQL user. Same as default.sql.user when sharing one MySQL.
+            user: root
+
+            # Same password as default.sql.password when sharing one MySQL.
+            # Pass via --set — never commit.
+            password: ""
+
+  # Disable embedded Cassandra, PostgreSQL, and other backends —
+  # we bring our own MySQL.
+  cassandra:
+    enabled: false
+
+  mysql:
+    enabled: false
+
+  postgresql:
+    enabled: false
+
+  elasticsearch:
+    enabled: false
+
+  # Temporal web UI. Useful for inspecting workflow runs. Disable to save a pod.
+  web:
+    enabled: true


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Adds `temporalio/temporal` v0.44.0 as an optional conditional dependency (`temporal.enabled=false` by default), mirroring the existing Cadence subchart pattern. Also adds a new `templates/validations.yaml` that fails fast when both `cadence.enabled` and `temporal.enabled` are set simultaneously — before any Kubernetes resource is created.

Key implementation details:
- `Chart.yaml` + `Chart.lock`: temporal dependency at `https://go.temporal.io/helm-charts` v0.44.0
- `values.yaml`: fully annotated `temporal:` block with **`mysql8` driver** warning (the #1 gotcha vs Cadence), separate `default` + `visibility` persistence blocks, and mutual-exclusivity callout
- `templates/validations.yaml` (new): rendered template (not an underscore file — Helm does not auto-execute top-level code in `_*.tpl` files) that `fail`s with a clear error if both subcharts are enabled
- `NOTES.txt`: three-way guard — engine/subchart mismatch warning, bundled-Temporal success block with `mysql8` reminder, both-enabled warning
- `README.md`: "Bundled Temporal" section with when-to-use table, two-step install command, key differences table vs Cadence, MySQL two-database setup, troubleshooting entries

**Why?**

Community request and parity with the Cadence optional subchart. Users who want a self-contained Temporal install should not have to install the Temporal chart separately and wire it manually. Closes #1136.

**How did you test it?**

- `helm lint helm/michelangelo` → 0 errors, 0 failures
- `helm template -f values-k3d.yaml` → 21 resources (baseline unchanged, temporal disabled by default)
- `helm template --set temporal.enabled=true ...` → ~69 resources (21 control plane + ~48 Temporal subchart)
- `helm template --set temporal.enabled=true --set cadence.enabled=true ...` → fails fast with `cadence.enabled and temporal.enabled cannot both be true` before any resource renders
- NOTES.txt mismatch warning (temporal.enabled + engine=cadence) verified via `helm install --dry-run`
- NOTES.txt both-enabled warning verified via `helm install --dry-run`

**Potential risks**

Low — `temporal.enabled=false` by default. Existing installs are unaffected. The `validations.yaml` guard only fires when both flags are explicitly set; it has no effect on any existing install. The `mysql8` driver string (vs `mysql` for Cadence) is prominently documented to prevent silent misconfiguration.

**Release notes**

N/A — opt-in feature, no migration required.

**Documentation Changes**

`values.yaml` fully annotated. `helm/michelangelo/README.md` updated with "Bundled Temporal" section, key differences table vs Cadence, and troubleshooting entries.