### PR TITLE
ci: add helm lint + template CI gate for helm/ PRs

### DIFF
--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -31,7 +31,9 @@ jobs:
           helm repo update
 
       - name: Build chart dependencies
-        run: helm dependency build helm/michelangelo
+        run: |
+          helm dependency update helm/michelangelo
+          ls helm/michelangelo/charts/
 
       - name: Lint
         run: helm lint helm/michelangelo

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -62,6 +62,7 @@ jobs:
             -f helm/michelangelo/values-k3d.yaml \
             --set cadence.enabled=true \
             --set cadence.config.persistence.database.sql.hosts=mysql \
+            --set cadence.config.persistence.database.sql.user=root \
             --set cadence.config.persistence.database.sql.password=root \
             --debug \
             > /dev/null
@@ -72,8 +73,10 @@ jobs:
             -f helm/michelangelo/values-k3d.yaml \
             --set temporal.enabled=true \
             --set temporal.server.config.persistence.default.sql.host=mysql \
+            --set temporal.server.config.persistence.default.sql.user=root \
             --set temporal.server.config.persistence.default.sql.password=root \
             --set temporal.server.config.persistence.visibility.sql.host=mysql \
+            --set temporal.server.config.persistence.visibility.sql.user=root \
             --set temporal.server.config.persistence.visibility.sql.password=root \
             --set workflow.engine=temporal \
             --set workflow.endpoint=michelangelo-temporal-frontend:7233 \

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -1,0 +1,95 @@
+name: Helm lint
+
+on:
+  pull_request:
+    paths:
+      - 'helm/**'
+  push:
+    branches:
+      - main
+    paths:
+      - 'helm/**'
+
+jobs:
+  lint:
+    name: Lint and template check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: '3.17.0'
+
+      - name: Add Helm repos (for dependency build)
+        run: |
+          helm repo add cadence-workflow https://cadence-workflow.github.io/cadence-charts
+          helm repo add temporal https://go.temporal.io/helm-charts
+          helm repo update
+
+      - name: Build chart dependencies
+        run: helm dependency build helm/michelangelo
+
+      - name: Lint
+        run: helm lint helm/michelangelo
+
+      - name: Template — k3d profile (Cadence, all Ingress disabled)
+        run: |
+          helm template michelangelo helm/michelangelo \
+            -f helm/michelangelo/values-k3d.yaml \
+            --debug \
+            > /dev/null
+
+      - name: Template — production profile (Temporal engine)
+        run: |
+          helm template michelangelo helm/michelangelo \
+            --set metadataStorage.host=rds.example.com \
+            --set metadataStorage.rootPassword=secret \
+            --set objectStorage.endpoint=s3.amazonaws.com \
+            --set objectStorage.accessKeyId=AKID \
+            --set objectStorage.secretAccessKey=SECRET \
+            --set workflow.engine=temporal \
+            --set workflow.endpoint=temporal-frontend:7233 \
+            --set ui.apiBaseUrl=https://michelangelo.example.com/api \
+            --debug \
+            > /dev/null
+
+      - name: Template — Cadence subchart enabled
+        run: |
+          helm template michelangelo helm/michelangelo \
+            -f helm/michelangelo/values-k3d.yaml \
+            --set cadence.enabled=true \
+            --set cadence.config.persistence.database.sql.hosts=mysql \
+            --set cadence.config.persistence.database.sql.password=root \
+            --debug \
+            > /dev/null
+
+      - name: Template — Temporal subchart enabled
+        run: |
+          helm template michelangelo helm/michelangelo \
+            -f helm/michelangelo/values-k3d.yaml \
+            --set temporal.enabled=true \
+            --set temporal.server.config.persistence.default.sql.host=mysql \
+            --set temporal.server.config.persistence.default.sql.password=root \
+            --set temporal.server.config.persistence.visibility.sql.host=mysql \
+            --set temporal.server.config.persistence.visibility.sql.password=root \
+            --set workflow.engine=temporal \
+            --set workflow.endpoint=michelangelo-temporal-frontend:7233 \
+            --debug \
+            > /dev/null
+
+      - name: Validate fail-fast guard (both subcharts enabled must fail)
+        run: |
+          ! helm template michelangelo helm/michelangelo \
+            -f helm/michelangelo/values-k3d.yaml \
+            --set cadence.enabled=true \
+            --set temporal.enabled=true \
+            --set cadence.config.persistence.database.sql.hosts=mysql \
+            --set cadence.config.persistence.database.sql.password=root \
+            --set temporal.server.config.persistence.default.sql.host=mysql \
+            --set temporal.server.config.persistence.default.sql.password=root \
+            --set temporal.server.config.persistence.visibility.sql.host=mysql \
+            --set temporal.server.config.persistence.visibility.sql.password=root \
+            2>/dev/null

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -33,6 +33,10 @@ jobs:
       - name: Build chart dependencies
         run: |
           helm dependency update helm/michelangelo
+          # Extract tarballs so helm template can resolve them as directories
+          for f in helm/michelangelo/charts/*.tgz; do
+            tar xzf "$f" -C helm/michelangelo/charts/
+          done
           ls helm/michelangelo/charts/
 
       - name: Lint

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -103,3 +103,37 @@ jobs:
             --set temporal.server.config.persistence.visibility.sql.host=mysql \
             --set temporal.server.config.persistence.visibility.sql.password=root \
             2>/dev/null
+
+      - name: Template — Ingress enabled (UI + Envoy, hosts[] syntax)
+        run: |
+          helm template michelangelo helm/michelangelo \
+            -f helm/michelangelo/values-k3d.yaml \
+            --set ui.ingress.enabled=true \
+            --set 'ui.ingress.hosts[0].host=michelangelo.example.com' \
+            --set 'ui.ingress.hosts[0].paths[0].path=/' \
+            --set envoy.ingress.enabled=true \
+            --set 'envoy.ingress.hosts[0].host=michelangelo.example.com' \
+            --set 'envoy.ingress.hosts[0].paths[0].path=/api' \
+            --debug \
+            > /dev/null
+
+      - name: Template — apiserver Ingress grpc mode
+        run: |
+          helm template michelangelo helm/michelangelo \
+            -f helm/michelangelo/values-k3d.yaml \
+            --set apiserver.ingress.enabled=true \
+            --set apiserver.ingress.mode=grpc \
+            --set 'apiserver.ingress.hosts[0].host=grpc.michelangelo.example.com' \
+            --set 'apiserver.ingress.hosts[0].paths[0].path=/' \
+            --debug \
+            | grep 'backend-protocol'
+
+      - name: Validate apiserver passthrough without TLS must fail
+        run: |
+          ! helm template michelangelo helm/michelangelo \
+            -f helm/michelangelo/values-k3d.yaml \
+            --set apiserver.ingress.enabled=true \
+            --set apiserver.ingress.mode=passthrough \
+            --set 'apiserver.ingress.hosts[0].host=grpc.michelangelo.example.com' \
+            --set 'apiserver.ingress.hosts[0].paths[0].path=/' \
+            2>/dev/null

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -1,6 +1,7 @@
 name: Helm lint
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - 'helm/**'

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -97,10 +97,13 @@ jobs:
             --set cadence.enabled=true \
             --set temporal.enabled=true \
             --set cadence.config.persistence.database.sql.hosts=mysql \
+            --set cadence.config.persistence.database.sql.user=root \
             --set cadence.config.persistence.database.sql.password=root \
             --set temporal.server.config.persistence.default.sql.host=mysql \
+            --set temporal.server.config.persistence.default.sql.user=root \
             --set temporal.server.config.persistence.default.sql.password=root \
             --set temporal.server.config.persistence.visibility.sql.host=mysql \
+            --set temporal.server.config.persistence.visibility.sql.user=root \
             --set temporal.server.config.persistence.visibility.sql.password=root \
             2>/dev/null
 


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**

Adds `.github/workflows/helm-lint.yaml` — a CI gate that runs on every PR and push to `main` touching `helm/**`. The workflow:
- Runs `helm lint` on the `helm/michelangelo` chart
- Renders 9 `helm template` scenarios: k3d profile, production (Temporal), Cadence subchart, Temporal subchart, both-subcharts fail-fast guard, UI+Envoy Ingress with `hosts[]` syntax, apiserver Ingress in `grpc` mode (verifies `backend-protocol` annotation is injected), and apiserver `passthrough` without TLS (must fail)

**Why?**

The `helm/michelangelo` chart had no CI coverage. Without it, template regressions (broken values keys, bad subchart flags, missing annotations) can merge silently. Ingress scenarios were added to cover the `hosts[]`-based Ingress structure introduced in the chart.

**How did you test it?**

All 9 scenarios verified locally with `helm lint` and `helm template` using Helm 3.17.

**Potential risks**

None — CI-only change, no runtime impact.
https://github.com/michelangelo-ai/michelangelo/actions/runs/25705171150 

**Release notes**

N/A

**Documentation Changes**

N/A

Closes #1136