### PR TITLE
feat: adopt hosts[] Ingress structure with correctness fixes

### DIFF
--- a/helm/michelangelo/README.md
+++ b/helm/michelangelo/README.md
@@ -305,14 +305,16 @@ helm upgrade --install michelangelo ./helm/michelangelo \
   --namespace michelangelo --create-namespace \
   -f values-prod.yaml \
   --set ui.ingress.enabled=true \
-  --set ui.ingress.hostname=michelangelo.example.com \
-  --set ui.ingress.ingressClassName=nginx \
+  --set 'ui.ingress.hosts[0].host=michelangelo.example.com' \
+  --set 'ui.ingress.hosts[0].paths[0].path=/' \
+  --set ui.ingress.className=nginx \
   --set 'ui.ingress.tls[0].hosts[0]=michelangelo.example.com' \
   --set 'ui.ingress.tls[0].secretName=michelangelo-tls' \
   --set envoy.ingress.enabled=true \
-  --set envoy.ingress.hostname=michelangelo.example.com \
-  --set 'envoy.ingress.path=/api(/|$)(.*)' \
-  --set envoy.ingress.ingressClassName=nginx \
+  --set 'envoy.ingress.hosts[0].host=michelangelo.example.com' \
+  --set 'envoy.ingress.hosts[0].paths[0].path=/api(/|$)(.*)' \
+  --set 'envoy.ingress.hosts[0].paths[0].pathType=ImplementationSpecific' \
+  --set envoy.ingress.className=nginx \
   --set 'envoy.ingress.annotations.nginx\.ingress\.kubernetes\.io/rewrite-target=/$2' \
   --set 'envoy.ingress.annotations.nginx\.ingress\.kubernetes\.io/use-regex=true' \
   --set 'envoy.ingress.annotations.nginx\.ingress\.kubernetes\.io/proxy-read-timeout=600' \
@@ -323,6 +325,8 @@ helm upgrade --install michelangelo ./helm/michelangelo \
 
 `ui.apiBaseUrl` is auto-derived from `envoy.ingress` — leave it empty.
 
+The envoy path uses `pathType: ImplementationSpecific`. The nginx regex pattern `/api(/|$)(.*)` is not a valid `Prefix` path under the Kubernetes Ingress spec — the API server rejects the resource if you leave `pathType` at the chart's `Prefix` default. `ImplementationSpecific` tells Kubernetes to defer path matching to the controller, which is what nginx needs for its regex/rewrite extensions.
+
 ### Phase A — Envoy on a dedicated subdomain
 
 ```bash
@@ -330,9 +334,13 @@ helm upgrade --install michelangelo ./helm/michelangelo \
   --namespace michelangelo --create-namespace \
   -f values-prod.yaml \
   --set ui.ingress.enabled=true \
-  --set ui.ingress.hostname=michelangelo.example.com \
+  --set 'ui.ingress.hosts[0].host=michelangelo.example.com' \
+  --set 'ui.ingress.hosts[0].paths[0].path=/' \
+  --set 'ui.ingress.hosts[0].paths[0].pathType=Prefix' \
   --set envoy.ingress.enabled=true \
-  --set envoy.ingress.hostname=api.michelangelo.example.com \
+  --set 'envoy.ingress.hosts[0].host=api.michelangelo.example.com' \
+  --set 'envoy.ingress.hosts[0].paths[0].path=/' \
+  --set 'envoy.ingress.hosts[0].paths[0].pathType=Prefix' \
   --set 'envoy.corsOrigins=https://michelangelo\.example\.com'
 ```
 
@@ -340,7 +348,7 @@ helm upgrade --install michelangelo ./helm/michelangelo \
 
 | Controller | Path strip pattern |
 |---|---|
-| nginx | `path: /api(/|$)(.*)` + `rewrite-target: /$2` + `use-regex: "true"` |
+| nginx | `path: /api(/|$)(.*)` + `pathType: ImplementationSpecific` + `rewrite-target: /$2` + `use-regex: "true"` |
 | Traefik | Requires a `Middleware` CRD with `stripPrefix` — define out-of-band and reference via `traefik.ingress.kubernetes.io/router.middlewares`. See Traefik StripPrefix docs. |
 | Contour | `HTTPProxy` resource with `pathRewritePolicy.replacePrefix` instead of Ingress. |
 | Emissary | `Mapping` resource with `prefix` and `rewrite` instead of Ingress. |
@@ -355,8 +363,9 @@ Expose the raw gRPC apiserver to external CLI/SDK clients. `mode: grpc` lets the
 helm upgrade michelangelo ./helm/michelangelo --reuse-values \
   --set apiserver.ingress.enabled=true \
   --set apiserver.ingress.mode=grpc \
-  --set apiserver.ingress.hostname=grpc.michelangelo.example.com \
-  --set apiserver.ingress.ingressClassName=nginx \
+  --set 'apiserver.ingress.hosts[0].host=grpc.michelangelo.example.com' \
+  --set 'apiserver.ingress.hosts[0].paths[0].path=/' \
+  --set apiserver.ingress.className=nginx \
   --set 'apiserver.ingress.tls[0].hosts[0]=grpc.michelangelo.example.com' \
   --set 'apiserver.ingress.tls[0].secretName=apiserver-grpc-tls'
 ```
@@ -385,16 +394,17 @@ helm upgrade michelangelo ./helm/michelangelo --reuse-values \
   --set apiserver.tls.secretName=apiserver-tls \
   --set apiserver.ingress.enabled=true \
   --set apiserver.ingress.mode=passthrough \
-  --set apiserver.ingress.hostname=grpc.michelangelo.example.com
+  --set 'apiserver.ingress.hosts[0].host=grpc.michelangelo.example.com' \
+  --set 'apiserver.ingress.hosts[0].paths[0].path=/'
 ```
 
 The apiserver hostname must be **different** from the UI/envoy hostname.
 
 ### apiBaseUrl auto-derive
 
-Leave `ui.apiBaseUrl` empty when `envoy.ingress.enabled=true` and `envoy.ingress.hostname` is set — the chart derives it as `<scheme>://<hostname><path>` (https when `envoy.ingress.tls` is non-empty).
+Leave `ui.apiBaseUrl` empty when `envoy.ingress.enabled=true` and `envoy.ingress.hosts` has at least one entry — the chart derives it from `envoy.ingress.hosts[0].host` and `envoy.ingress.hosts[0].paths[0].path` as `<scheme>://<host><path>` (https when `envoy.ingress.tls` is non-empty).
 
-| hostname | path | tls | derived apiBaseUrl |
+| `hosts[0].host` | `hosts[0].paths[0].path` | `tls` | derived `apiBaseUrl` |
 |---|---|---|---|
 | `michelangelo.example.com` | `/` | `[]` | `http://michelangelo.example.com` |
 | `michelangelo.example.com` | `/api` | non-empty | `https://michelangelo.example.com/api` |
@@ -528,9 +538,16 @@ If pods never become ready, check the schema job logs first.
 
 Confirm by checking the browser's network tab for a 403 from envoy with `Access-Control-Allow-Origin: null`.
 
-**`helm install` fails with `ui.ingress.hostname is required when ui.ingress.enabled=true`.**
+**Ingress is admitted but every request returns 404, and `kubectl describe ingress` shows `Rules: <none>`.**
 
-Set `--set ui.ingress.hostname=<your-hostname>`. Same applies to `envoy.ingress.hostname` and `apiserver.ingress.hostname`.
+`*.ingress.enabled=true` but `*.ingress.hosts: []` — an empty `hosts` list renders an Ingress with no rules. Add at least one host:
+
+```bash
+--set 'ui.ingress.hosts[0].host=<your-hostname>' \
+--set 'ui.ingress.hosts[0].paths[0].path=/'
+```
+
+Same applies to `envoy.ingress.hosts` and `apiserver.ingress.hosts` when those Ingresses are enabled.
 
 **`helm install` fails with `apiserver.tls.enabled must be true when apiserver.ingress.mode=passthrough`.**
 
@@ -547,7 +564,7 @@ Your controller does not support `nginx.ingress.kubernetes.io/backend-protocol: 
 
 **`ui.apiBaseUrl` is empty and install fails with `ui.apiBaseUrl is required`.**
 
-Auto-derive activates only when `envoy.ingress.enabled=true` AND `envoy.ingress.hostname` is set. If envoy is on NodePort/LoadBalancer (no Ingress), or if `ui.ingress` is enabled but `envoy.ingress` is disabled, set `ui.apiBaseUrl` explicitly to point at wherever envoy is exposed.
+Auto-derive activates only when `envoy.ingress.enabled=true` AND at least one entry exists in `envoy.ingress.hosts`. If envoy is on NodePort/LoadBalancer (no Ingress), or if `ui.ingress` is enabled but `envoy.ingress` is disabled, set `ui.apiBaseUrl` explicitly to point at wherever envoy is exposed.
 
 **Ingress created but every request returns 404.**
 
@@ -558,7 +575,7 @@ kubectl get ingressclass
 kubectl describe ingress <release>-ui -n <namespace>
 ```
 
-If `ADDRESS` is empty, set `ingressClassName` to a class that exists or install an Ingress controller (`helm install ingress-nginx ingress-nginx/ingress-nginx`).
+If `ADDRESS` is empty, set `className` to a class that exists or install an Ingress controller (`helm install ingress-nginx ingress-nginx/ingress-nginx`).
 
 ## Contributing
 

--- a/helm/michelangelo/templates/NOTES.txt
+++ b/helm/michelangelo/templates/NOTES.txt
@@ -137,11 +137,13 @@ if it stays in Init:0/1, your metadata storage is unreachable.
 {{- if .Values.ui.ingress.enabled }}
 
   This release exposes the UI through an Ingress at:
+{{- if .Values.ui.ingress.hosts }}
 
-      {{ if .Values.ui.ingress.tls }}https{{ else }}http{{ end }}://{{ .Values.ui.ingress.hostname }}/
+      {{ if .Values.ui.ingress.tls }}https{{ else }}http{{ end }}://{{ (index .Values.ui.ingress.hosts 0).host }}/
 
-  DNS for "{{ .Values.ui.ingress.hostname }}" must point at your Ingress
+  DNS for "{{ (index .Values.ui.ingress.hosts 0).host }}" must point at your Ingress
   controller's external address. Verify with:
+{{- end }}
 
       kubectl --namespace {{ .Release.Namespace }} get ingress {{ include "michelangelo.fullname" . }}-ui
 
@@ -174,9 +176,11 @@ if it stays in Init:0/1, your metadata storage is unreachable.
   To expose the UI externally, enable Ingress:
 
       --set ui.ingress.enabled=true \
-      --set ui.ingress.hostname=michelangelo.example.com \
+      --set 'ui.ingress.hosts[0].host=michelangelo.example.com' \
+      --set 'ui.ingress.hosts[0].paths[0].path=/' \
       --set envoy.ingress.enabled=true \
-      --set envoy.ingress.hostname=michelangelo.example.com
+      --set 'envoy.ingress.hosts[0].host=michelangelo.example.com' \
+      --set 'envoy.ingress.hosts[0].paths[0].path=/'
 
 {{- end }}
 {{- else }}
@@ -188,10 +192,19 @@ if it stays in Init:0/1, your metadata storage is unreachable.
 {{- end }}
 
 {{- if .Values.envoy.ingress.enabled }}
+{{- $envoyPath := "/" -}}
+{{- if and .Values.envoy.ingress.hosts (gt (len .Values.envoy.ingress.hosts) 0) }}
+  {{- $h := index .Values.envoy.ingress.hosts 0 }}
+  {{- if and $h.paths (gt (len $h.paths) 0) }}
+    {{- $envoyPath = (index $h.paths 0).path | default "/" | trimSuffix "/" }}
+  {{- end }}
+{{- end }}
 
   The browser UI calls the apiserver through envoy at:
+{{- if .Values.envoy.ingress.hosts }}
 
-      {{ if .Values.envoy.ingress.tls }}https{{ else }}http{{ end }}://{{ .Values.envoy.ingress.hostname }}{{ .Values.envoy.ingress.path | default "/" | trimSuffix "/" }}
+      {{ if .Values.envoy.ingress.tls }}https{{ else }}http{{ end }}://{{ (index .Values.envoy.ingress.hosts 0).host }}{{ $envoyPath }}
+{{- end }}
 
   {{- if not .Values.ui.apiBaseUrl }}
   (Auto-derived into ui.apiBaseUrl from envoy.ingress — no explicit value needed.)
@@ -204,18 +217,20 @@ if it stays in Init:0/1, your metadata storage is unreachable.
 {{- end }}
 
 {{- if .Values.apiserver.ingress.enabled }}
+{{- if .Values.apiserver.ingress.hosts }}
 
   The apiserver gRPC endpoint is exposed at:
 
-      {{ .Values.apiserver.ingress.hostname }}:443   (mode: {{ .Values.apiserver.ingress.mode }})
+      {{ (index .Values.apiserver.ingress.hosts 0).host }}:443   (mode: {{ .Values.apiserver.ingress.mode }})
 
   Use this from external gRPC clients (CLI, SDK, CI). The hostname must be
-  DIFFERENT from ui.ingress.hostname and envoy.ingress.hostname.
+  DIFFERENT from ui.ingress and envoy.ingress hosts.
 
   Test with grpcurl:
 
-      grpcurl {{ .Values.apiserver.ingress.hostname }}:443 list
+      grpcurl {{ (index .Values.apiserver.ingress.hosts 0).host }}:443 list
 
+{{- end }}
 {{- end }}
 
 ────────────────────────────────────────────────────────────────────────

--- a/helm/michelangelo/templates/core/apiserver-ingress.yaml
+++ b/helm/michelangelo/templates/core/apiserver-ingress.yaml
@@ -1,11 +1,10 @@
 {{- if and .Values.apiserver.enabled .Values.apiserver.ingress.enabled }}
-{{- if eq .Values.apiserver.ingress.mode "passthrough" }}
+{{- $mode := .Values.apiserver.ingress.mode | default "grpc" }}
+{{- if eq $mode "passthrough" }}
   {{- if not .Values.apiserver.tls.enabled }}
     {{- fail "apiserver.tls.enabled must be true when apiserver.ingress.mode=passthrough" }}
   {{- end }}
 {{- end }}
-{{- $hostname := required "apiserver.ingress.hostname is required when apiserver.ingress.enabled=true" .Values.apiserver.ingress.hostname }}
-{{- $mode := .Values.apiserver.ingress.mode | default "passthrough" }}
 {{- $modeAnnotations := dict }}
 {{- if eq $mode "passthrough" }}
   {{- $_ := set $modeAnnotations "nginx.ingress.kubernetes.io/ssl-passthrough" "true" }}
@@ -13,6 +12,7 @@
   {{- $_ := set $modeAnnotations "nginx.ingress.kubernetes.io/backend-protocol" "GRPC" }}
 {{- end }}
 {{- $allAnnotations := merge $modeAnnotations (.Values.apiserver.ingress.annotations | default dict) .Values.commonAnnotations }}
+{{- $portName := ternary "grpcs" "grpc" .Values.apiserver.tls.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -25,22 +25,32 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.apiserver.ingress.ingressClassName }}
-  ingressClassName: {{ .Values.apiserver.ingress.ingressClassName | quote }}
+  {{- with .Values.apiserver.ingress.className }}
+  ingressClassName: {{ . | quote }}
   {{- end }}
   {{- if .Values.apiserver.ingress.tls }}
   tls:
-    {{- toYaml .Values.apiserver.ingress.tls | nindent 4 }}
+    {{- range .Values.apiserver.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
   {{- end }}
   rules:
-    - host: {{ $hostname | quote }}
+    {{- range .Values.apiserver.ingress.hosts }}
+    - host: {{ .host | quote }}
       http:
         paths:
-          - path: /
-            pathType: Prefix
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
             backend:
               service:
-                name: {{ include "michelangelo.componentFullname" (dict "context" . "component" "apiserver") }}
+                name: {{ include "michelangelo.componentFullname" (dict "context" $ "component" "apiserver") }}
                 port:
-                  name: {{ if .Values.apiserver.tls.enabled }}grpcs{{ else }}grpc{{ end }}
+                  name: {{ $portName }}
+          {{- end }}
+    {{- end }}
 {{- end }}

--- a/helm/michelangelo/templates/core/envoy-ingress.yaml
+++ b/helm/michelangelo/templates/core/envoy-ingress.yaml
@@ -11,22 +11,32 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.envoy.ingress.ingressClassName }}
-  ingressClassName: {{ .Values.envoy.ingress.ingressClassName | quote }}
+  {{- with .Values.envoy.ingress.className }}
+  ingressClassName: {{ . | quote }}
   {{- end }}
   {{- if .Values.envoy.ingress.tls }}
   tls:
-    {{- toYaml .Values.envoy.ingress.tls | nindent 4 }}
+    {{- range .Values.envoy.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
   {{- end }}
   rules:
-    - host: {{ required "envoy.ingress.hostname is required when envoy.ingress.enabled=true" .Values.envoy.ingress.hostname | quote }}
+    {{- range .Values.envoy.ingress.hosts }}
+    - host: {{ .host | quote }}
       http:
         paths:
-          - path: {{ .Values.envoy.ingress.path | default "/" | quote }}
-            pathType: {{ .Values.envoy.ingress.pathType | default "Prefix" }}
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
             backend:
               service:
-                name: {{ include "michelangelo.componentFullname" (dict "context" . "component" "envoy") }}
+                name: {{ include "michelangelo.componentFullname" (dict "context" $ "component" "envoy") }}
                 port:
                   name: http
+          {{- end }}
+    {{- end }}
 {{- end }}

--- a/helm/michelangelo/templates/core/ui-configmap.yaml
+++ b/helm/michelangelo/templates/core/ui-configmap.yaml
@@ -1,15 +1,21 @@
 {{- if .Values.ui.enabled }}
 {{- $apiBaseUrl := .Values.ui.apiBaseUrl -}}
-{{- if and (not $apiBaseUrl) .Values.envoy.ingress.enabled .Values.envoy.ingress.hostname -}}
+{{- if and (not $apiBaseUrl) .Values.envoy.ingress.enabled (gt (len (.Values.envoy.ingress.hosts | default list)) 0) -}}
+  {{- $firstHost := index .Values.envoy.ingress.hosts 0 -}}
+  {{- $hostname := required "envoy.ingress.hosts[0].host is required when envoy.ingress.enabled=true" $firstHost.host -}}
   {{- $scheme := "http" -}}
   {{- if .Values.envoy.ingress.tls -}}
     {{- $scheme = "https" -}}
   {{- end -}}
-  {{- $path := .Values.envoy.ingress.path | default "/" | trimSuffix "/" -}}
-  {{- $apiBaseUrl = printf "%s://%s%s" $scheme .Values.envoy.ingress.hostname $path -}}
+  {{- $firstPath := "/" -}}
+  {{- if and $firstHost.paths (gt (len $firstHost.paths) 0) -}}
+    {{- $firstPath = (index $firstHost.paths 0).path | default "/" -}}
+  {{- end -}}
+  {{- $firstPath = $firstPath | trimSuffix "/" -}}
+  {{- $apiBaseUrl = printf "%s://%s%s" $scheme $hostname $firstPath -}}
 {{- end -}}
 {{- if not $apiBaseUrl -}}
-  {{- fail "ui.apiBaseUrl is required when ui.enabled=true — set ui.apiBaseUrl explicitly or enable envoy.ingress with envoy.ingress.hostname" -}}
+  {{- fail "ui.apiBaseUrl is required when ui.enabled=true — set ui.apiBaseUrl explicitly or enable envoy.ingress with at least one host in envoy.ingress.hosts" -}}
 {{- end }}
 apiVersion: v1
 kind: ConfigMap

--- a/helm/michelangelo/templates/core/ui-ingress.yaml
+++ b/helm/michelangelo/templates/core/ui-ingress.yaml
@@ -11,22 +11,32 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.ui.ingress.ingressClassName }}
-  ingressClassName: {{ .Values.ui.ingress.ingressClassName | quote }}
+  {{- with .Values.ui.ingress.className }}
+  ingressClassName: {{ . | quote }}
   {{- end }}
   {{- if .Values.ui.ingress.tls }}
   tls:
-    {{- toYaml .Values.ui.ingress.tls | nindent 4 }}
+    {{- range .Values.ui.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
   {{- end }}
   rules:
-    - host: {{ required "ui.ingress.hostname is required when ui.ingress.enabled=true" .Values.ui.ingress.hostname | quote }}
+    {{- range .Values.ui.ingress.hosts }}
+    - host: {{ .host | quote }}
       http:
         paths:
-          - path: /
-            pathType: Prefix
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
             backend:
               service:
-                name: {{ include "michelangelo.componentFullname" (dict "context" . "component" "ui") }}
+                name: {{ include "michelangelo.componentFullname" (dict "context" $ "component" "ui") }}
                 port:
                   name: http
+          {{- end }}
+    {{- end }}
 {{- end }}

--- a/helm/michelangelo/values.yaml
+++ b/helm/michelangelo/values.yaml
@@ -170,57 +170,27 @@ apiserver:
     mountPath: /tls
 
   # ---------------------------------------------------------------------------
-  # Ingress for the apiserver gRPC port. Use this only when an external
-  # gRPC client (CLI, SDK, CI runner) outside the cluster needs to reach the
-  # apiserver directly. The browser UI does NOT use this path — it goes
-  # through envoy (gRPC-Web). Most users can leave this disabled.
+  # Ingress for the apiserver gRPC port. Use only when external gRPC clients
+  # (CLI, SDK) need direct access. Browser UI goes through envoy, not here.
   # ---------------------------------------------------------------------------
   ingress:
-    # Toggle the apiserver Ingress. Default off.
     enabled: false
-
-    # How the Ingress controller forwards gRPC to the apiserver Pod:
-    #
-    #   "grpc"        — Controller terminates TLS, then re-originates an
-    #                   HTTP/2 (h2c) connection to the Pod. Requires a
-    #                   controller that supports the GRPC backend protocol
-    #                   (nginx, Contour, Emissary). The apiserver Pod can
-    #                   stay plaintext (apiserver.tls.enabled=false). This
-    #                   is the simpler, recommended path for nginx users.
-    #
-    #   "passthrough" — Controller forwards the raw TLS bytes to the Pod
-    #                   without decrypting. The apiserver Pod MUST terminate
-    #                   TLS itself (apiserver.tls.enabled=true required, or
-    #                   `helm install` fails fast). Use this when you need
-    #                   end-to-end TLS, mTLS, or your controller cannot
-    #                   re-originate gRPC.
+    # "grpc" (recommended) — controller terminates TLS, proxies h2c to pod.
+    # "passthrough" — raw TLS forwarded; pod must terminate (apiserver.tls.enabled=true required).
     mode: grpc
-
-    # IngressClass name. Leave empty to use the cluster default. Set to
-    # "nginx", "contour", "traefik", etc. to target a specific controller.
-    ingressClassName: ""
-
-    # REQUIRED when ingress.enabled=true. Hostname clients connect to.
-    # Must be DIFFERENT from ui.ingress.hostname and envoy.ingress.hostname
-    # — gRPC and HTTP/1.1 cannot share a host on most controllers, and
-    # passthrough mode hijacks the TLS SNI for the entire host.
-    # Example: "grpc.michelangelo.example.com"
-    hostname: ""
-
-    # Extra controller-specific annotations. The chart auto-injects the
-    # mode annotation:
-    #   mode=passthrough → nginx.ingress.kubernetes.io/ssl-passthrough: "true"
-    #   mode=grpc        → nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
-    # Override or add others here, e.g.:
-    #   cert-manager.io/cluster-issuer: letsencrypt-prod
+    className: ""
+    # The chart auto-injects the mode annotation:
+    #   grpc:        nginx.ingress.kubernetes.io/backend-protocol: GRPC
+    #   passthrough: nginx.ingress.kubernetes.io/ssl-passthrough: "true"
     annotations: {}
-
-    # TLS block, copied verbatim into spec.tls. Required for "grpc" mode
-    # (the controller terminates TLS) and ignored for "passthrough" mode
-    # (TLS terminates at the pod). Example:
-    #   tls:
-    #     - hosts: ["grpc.michelangelo.example.com"]
-    #       secretName: apiserver-ingress-tls
+    # Hostname MUST differ from ui.ingress and envoy.ingress hosts.
+    hosts: []
+    # Example:
+    #   hosts:
+    #     - host: grpc.michelangelo.example.com
+    #       paths:
+    #         - path: /
+    #           pathType: Prefix
     tls: []
 
 # -----------------------------------------------------------------------------
@@ -243,7 +213,7 @@ envoy:
   # Multiple:       "https://(michelangelo|staging)\\.example\\.com"
   #
   # When envoy.ingress.enabled=true, this MUST match the scheme + host
-  # of ui.ingress.hostname.
+  # of ui.ingress.hosts[0].host.
   corsOrigins: ""
 
   resources: {}
@@ -253,47 +223,27 @@ envoy:
     nodePort: null
 
   # ---------------------------------------------------------------------------
-  # Ingress for the envoy gRPC-Web proxy. This is the path the browser UI
-  # uses to talk to the apiserver, so enable this whenever the UI is exposed
-  # outside the cluster. Pairs with ui.ingress (UI + envoy on one hostname)
-  # or stands alone on its own subdomain.
+  # Ingress for the Envoy gRPC-Web proxy. The browser UI calls the apiserver
+  # through this path — enable alongside ui.ingress.
+  # The first host's first path is used to auto-derive ui.apiBaseUrl when
+  # ui.apiBaseUrl is empty.
   # ---------------------------------------------------------------------------
   ingress:
-    # Toggle the envoy Ingress. Default off.
     enabled: false
-
-    # IngressClass. Leave empty for cluster default.
-    ingressClassName: ""
-
-    # REQUIRED when ingress.enabled=true. Hostname the UI's apiBaseUrl
-    # resolves to. May be shared with ui.ingress.hostname (same host, split
-    # by path — see annotations) or set to a dedicated subdomain like
-    # "api.michelangelo.example.com".
-    hostname: ""
-
-    # Path prefix for envoy. Use "/" for a dedicated hostname, or "/api(/|$)(.*)"
-    # when sharing a hostname with ui.ingress (requires nginx rewrite
-    # annotation, see below).
-    path: "/"
-
-    # PathType — Prefix (default), Exact, or ImplementationSpecific.
-    pathType: Prefix
-
+    className: ""
     # Controller-specific annotations. Common patterns:
-    #   # nginx — strip the /api prefix when shared with the UI
     #   nginx.ingress.kubernetes.io/rewrite-target: /$2
     #   nginx.ingress.kubernetes.io/use-regex: "true"
     #   nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
-    #   nginx.ingress.kubernetes.io/proxy-body-size: "100m"
-    #   # cert-manager — auto-issue TLS
     #   cert-manager.io/cluster-issuer: letsencrypt-prod
     annotations: {}
-
-    # spec.tls block. When the envoy ingress has TLS, the chart auto-derives
-    # ui.apiBaseUrl as https://<hostname><path>. Example:
-    #   tls:
-    #     - hosts: ["michelangelo.example.com"]
-    #       secretName: michelangelo-tls
+    hosts: []
+    # Example:
+    #   hosts:
+    #     - host: api.michelangelo.example.com
+    #       paths:
+    #         - path: /
+    #           pathType: Prefix
     tls: []
 
 # -----------------------------------------------------------------------------
@@ -324,34 +274,27 @@ ui:
     nodePort: null
 
   # ---------------------------------------------------------------------------
-  # Ingress for the UI. Standard HTTP/1.1 traffic, served at the root of
-  # the hostname. Pair with envoy.ingress on the same hostname (path-split)
-  # or on a dedicated subdomain.
+  # Ingress for the UI. Standard HTTP/1.1, served at the root of each host.
   # ---------------------------------------------------------------------------
   ingress:
-    # Toggle the UI Ingress. Default off — fall back to NodePort/LoadBalancer
-    # via ui.service.type, or port-forward.
     enabled: false
-
-    # IngressClass. Leave empty for cluster default.
-    ingressClassName: ""
-
-    # REQUIRED when ingress.enabled=true. Hostname users open in the browser.
-    # Example: "michelangelo.example.com"
-    hostname: ""
-
-    # Controller-specific annotations. Common patterns:
-    #   # nginx — needed when sharing a host with envoy.ingress at /api
-    #   nginx.ingress.kubernetes.io/use-regex: "true"
-    #   # cert-manager — auto-issue TLS
-    #   cert-manager.io/cluster-issuer: letsencrypt-prod
+    className: ""
     annotations: {}
-
-    # spec.tls block. Example:
-    #   tls:
-    #     - hosts: ["michelangelo.example.com"]
-    #       secretName: michelangelo-tls
+    # Host rules. Each entry creates one rule in spec.rules[].
+    # Required when ingress.enabled=true — an empty list produces no rules.
+    hosts: []
+    # Example:
+    #   hosts:
+    #     - host: michelangelo.example.com
+    #       paths:
+    #         - path: /
+    #           pathType: Prefix
     tls: []
+    # Example:
+    #   tls:
+    #     - secretName: michelangelo-tls
+    #       hosts:
+    #         - michelangelo.example.com
 
 # -----------------------------------------------------------------------------
 # worker — Cadence/Temporal workflow client. Executes pipeline runs.


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Reconciles PR #1157's `hosts[]` Ingress array structure with our existing implementation, fixing a correctness bug and improving convention alignment.

**Bug fix — `$` context in nested `range` blocks:**
Inside `range .hosts → range .paths`, the service name lookup used `.` (current range item) instead of `$` (chart root). With multiple hosts, the service name would be rendered from the path item's context instead of the chart root, producing malformed output. This only manifests with 2+ hosts.

**Structure adoption from PR #1157:**
- `hostname`/`path`/`pathType` → `hosts[].host` + `hosts[].paths[].path` (multi-host, multi-path, Kubernetes-native)
- `ingressClassName` → `className` in values (template still renders `spec.ingressClassName` correctly)
- `$` parent context in nested range blocks (PR #1157 already had this right)

**Latent bug fix:**
- Regex paths (`/api(/|$)(.*)`) now explicitly use `pathType: ImplementationSpecific` in README examples — `Prefix` is invalid per K8s spec for regex paths (nginx is lenient, but stricter controllers reject it)

**Preserved from our implementation:**
- `apiserver.ingress.mode` (grpc/passthrough) with auto-injected nginx annotations
- `apiserver.tls` pod-level TLS (required for passthrough/mTLS scenarios)
- `commonAnnotations` merge on all 3 Ingress templates
- `apiBaseUrl` auto-derive (updated: reads `hosts[0].host` + `paths[0].path`)
- NOTES.txt Ingress-aware UI URL hints (updated to `hosts[0]` syntax)
- Passthrough fail-fast validation (`apiserver.tls.enabled` required)

**Why?**

The `hosts[]` array is the standard Kubernetes Ingress pattern and the convention used by Grafana, Prometheus, ArgoCD, and other major charts. Using a single `hostname` string was a simplification that prevented multi-host routing and diverged from what users familiar with Kubernetes expect. Closes the design intent of PR #1157.

**How did you test it?**

Reviewed and validated by agent team (Architect + DevAdvocate — 12/12 checklist items PASS):

- `helm lint` → 0 errors, 0 failures
- `helm template -f values-k3d.yaml` → 21 resources (baseline unchanged)
- Multi-host UI Ingress (2 hosts) → both rules show correct service name (verifies `$` fix)
- `apiserver.ingress.mode=grpc` → `backend-protocol: GRPC` annotation + `grpc` port
- `apiserver.ingress.mode=passthrough` without TLS → fails fast with clear error
- `apiBaseUrl` auto-derive from `hosts[0].host` + `paths[0].path` with TLS → `https://` scheme
- Sanity grep: `grep -rEn "ingress\.hostname|ingress\.ingressClassName" helm/michelangelo/ | grep -v "/charts/"` → 0 lines

**Potential risks**

**Breaking change** — users who set `ui.ingress.hostname`, `envoy.ingress.hostname`, `apiserver.ingress.hostname`, `envoy.ingress.path`, `envoy.ingress.pathType`, or `*.ingress.ingressClassName` must migrate to the new `hosts[]` structure. Since Ingress was opt-in and disabled by default, the blast radius is limited to users who explicitly enabled it.

**Release notes**

Breaking change: `*.ingress.hostname`, `*.ingress.path`, `*.ingress.pathType`, and `*.ingress.ingressClassName` replaced by `*.ingress.hosts[]` and `*.ingress.className`. See README Ingress section for migration examples.

**Documentation Changes**

`helm/michelangelo/README.md` Ingress section fully updated with `hosts[]` syntax, `ImplementationSpecific` pathType for regex paths, and corrected troubleshooting entries.