### PR TITLE
docs: reorder getting started sidebar

### DIFF
--- a/docs/getting-started/core-concepts-and-key-terms.md
+++ b/docs/getting-started/core-concepts-and-key-terms.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 2
+---
+
 # Core Concepts and Key Terms
 
 ## Overview

--- a/docs/getting-started/faq.md
+++ b/docs/getting-started/faq.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 5
 ---
 
 # Frequently Asked Questions

--- a/docs/getting-started/ma-sandbox-ports-and-endpoints.md
+++ b/docs/getting-started/ma-sandbox-ports-and-endpoints.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 6
+---
+
 # MA Sandbox Ports and Endpoints
 
 Use this reference when connecting to services in your local Michelangelo sandbox. The sandbox maps ports from the K3d cluster to localhost so you can access all services directly from your browser or CLI.

--- a/docs/getting-started/sandbox-setup.md
+++ b/docs/getting-started/sandbox-setup.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 3
+---
+
 # Sandbox Setup
 
 Set up a local Michelangelo environment on your machine. This gives you a fully functional cluster with the API server, controller manager, workflow engine, object storage, and all supporting services.

--- a/docs/getting-started/setup-python-ide.md
+++ b/docs/getting-started/setup-python-ide.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 4
+---
+
 # Set Up Your Python IDE
 
 Get your editor configured for building ML pipelines with the Michelangelo SDK. This takes about 5 minutes if you've already run `poetry install`.


### PR DESCRIPTION
## Summary

Reorders the Getting Started docs sidebar so the first-read path is clearer:

- Overview
- Core Concepts and Key Terms
- Sandbox Setup
- Set Up Your Python IDE
- Frequently Asked Questions
- MA Sandbox Ports and Endpoints

Fixes #824.

## Testing

- `bun install --frozen-lockfile && bun run build` from `website`
- Verified the generated sidebar order in `website/build/docs/index.html`