### PR TITLE
Fix Studio phase documentation links

### DIFF
--- a/javascript/packages/core/config/phases/data.ts
+++ b/javascript/packages/core/config/phases/data.ts
@@ -8,7 +8,7 @@ export const DATA_PHASE: PhaseConfig = {
   icon: 'database',
   name: 'Prepare & Analyze Data',
   description: 'Create data pipelines and analyze your datasets',
-  docUrl: 'https://example.com/docs/data',
+  docUrl: 'https://michelangelo-ai.org/docs/user-guides/prepare-your-data/',
   state: 'disabled' as const,
   entities: [
     { ...PIPELINE_ENTITY_CONFIG, state: 'disabled' },

--- a/javascript/packages/core/config/phases/deploy.ts
+++ b/javascript/packages/core/config/phases/deploy.ts
@@ -7,7 +7,6 @@ export const DEPLOY_PHASE: PhaseConfig = {
   icon: 'deploy',
   name: 'Deploy & Predict',
   description: 'Deploy your models and predict new data',
-  docUrl: 'https://example.com/docs/deploy',
   state: 'comingSoon' as const,
   entities: [DEPLOYMENT_ENTITY_CONFIG],
 };

--- a/javascript/packages/core/config/phases/train.ts
+++ b/javascript/packages/core/config/phases/train.ts
@@ -10,7 +10,7 @@ export const TRAIN_PHASE: PhaseConfig = {
   icon: 'chartLine',
   name: 'Train & Evaluate',
   description: 'Train machine learning models and evaluate their performance',
-  docUrl: 'https://example.com/docs/train',
+  docUrl: 'https://michelangelo-ai.org/docs/user-guides/train-and-register-a-model/',
   state: 'active' as const,
   entities: [
     PIPELINE_ENTITY_CONFIG,


### PR DESCRIPTION
Fixes #949.

## Summary
Studio phase cards and phase headers expose Learn More links through each phase `docUrl`. Those values still pointed at placeholder `example.com` URLs, which is not acceptable for public docs readiness.

This replaces the Data and Train placeholders with user-facing public docs pages:
- Data: Prepare Your Data
- Train: Train and Register a Model

The Deploy placeholder is removed instead of linking to operator-facing serving docs. Follow-up issue #1179 tracks adding a user-facing deploy guide that the Deploy phase can link to later.

## Validation
The two linked docs targets resolve successfully. Local validation passed for format, typecheck, and lint. CI is green for format, lint/typecheck, unit tests, JavaScript coverage, and CLA. Local lint only reports the repo's existing Fast Refresh warnings.
