### PR TITLE
Add Studio Docs navigation link

### DIFF
--- a/javascript/packages/core/components/studio-app-nav-bar/__tests__/studio-app-nav-bar.test.tsx
+++ b/javascript/packages/core/components/studio-app-nav-bar/__tests__/studio-app-nav-bar.test.tsx
@@ -1,4 +1,4 @@
-import { render, within } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
@@ -8,20 +8,12 @@ import { StudioAppNavBar } from '../studio-app-nav-bar';
 
 describe('StudioAppNavBar', () => {
   it('renders the Docs link in the app nav', () => {
-    const { container } = render(
+    render(
       <StudioAppNavBar />,
       buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getRouterWrapper()])
     );
 
-    const mainNavigation = container.querySelector(
-      '[role="navigation"][aria-label="Main navigation"]'
-    );
-    expect(mainNavigation).not.toBeNull();
-
-    const docsLink = within(mainNavigation as HTMLElement).getByRole('link', {
-      hidden: true,
-      name: /docs/i,
-    });
+    const docsLink = screen.getByRole('link', { hidden: true, name: /docs/i });
 
     expect(docsLink).toHaveAttribute('href', 'https://michelangelo-ai.org/docs/');
     expect(docsLink).toHaveAttribute('target', '_blank');

--- a/javascript/packages/core/components/studio-app-nav-bar/__tests__/studio-app-nav-bar.test.tsx
+++ b/javascript/packages/core/components/studio-app-nav-bar/__tests__/studio-app-nav-bar.test.tsx
@@ -1,0 +1,30 @@
+import { render, within } from '@testing-library/react';
+
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
+import { getIconProviderWrapper } from '#core/test/wrappers/get-icon-provider-wrapper';
+import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
+import { StudioAppNavBar } from '../studio-app-nav-bar';
+
+describe('StudioAppNavBar', () => {
+  it('renders the Docs link in the app nav', () => {
+    const { container } = render(
+      <StudioAppNavBar />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getRouterWrapper()])
+    );
+
+    const mainNavigation = container.querySelector(
+      '[role="navigation"][aria-label="Main navigation"]'
+    );
+    expect(mainNavigation).not.toBeNull();
+
+    const docsLink = within(mainNavigation as HTMLElement).getByRole('link', {
+      hidden: true,
+      name: /docs/i,
+    });
+
+    expect(docsLink).toHaveAttribute('href', 'https://michelangelo-ai.org/docs/');
+    expect(docsLink).toHaveAttribute('target', '_blank');
+    expect(docsLink).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+});

--- a/javascript/packages/core/components/studio-app-nav-bar/studio-app-nav-bar.tsx
+++ b/javascript/packages/core/components/studio-app-nav-bar/studio-app-nav-bar.tsx
@@ -1,0 +1,46 @@
+import { AppNavBar } from 'baseui/app-nav-bar';
+
+import { Link } from '#core/components/link/link';
+
+import type { NavItem } from 'baseui/app-nav-bar';
+
+const DOCS_URL = 'https://michelangelo-ai.org/docs/';
+const DOCS_NAV_ITEM = { label: 'Docs' };
+const MAIN_NAV_ITEMS: NavItem[] = [DOCS_NAV_ITEM];
+
+function mapMainNavItemToNode(item: NavItem) {
+  if (item.label === DOCS_NAV_ITEM.label) {
+    return (
+      <Link
+        href={DOCS_URL}
+        overrides={{
+          Link: {
+            style: {
+              color: 'inherit',
+              ':hover': { color: 'inherit' },
+              ':visited': { color: 'inherit' },
+            },
+          },
+        }}
+      >
+        Docs
+      </Link>
+    );
+  }
+
+  return item.label;
+}
+
+export function StudioAppNavBar() {
+  return (
+    <AppNavBar
+      mainItems={MAIN_NAV_ITEMS}
+      mapItemToNode={mapMainNavItemToNode}
+      title={
+        <Link href="/" overrides={{ Link: { style: { ':hover': { textDecoration: 'unset' } } } }}>
+          Michelangelo Studio
+        </Link>
+      }
+    />
+  );
+}

--- a/javascript/packages/core/components/studio-app-nav-bar/studio-app-nav-bar.tsx
+++ b/javascript/packages/core/components/studio-app-nav-bar/studio-app-nav-bar.tsx
@@ -11,20 +11,14 @@ const MAIN_NAV_ITEMS: NavItem[] = [DOCS_NAV_ITEM];
 function mapMainNavItemToNode(item: NavItem) {
   if (item.label === DOCS_NAV_ITEM.label) {
     return (
-      <Link
+      <a
         href={DOCS_URL}
-        overrides={{
-          Link: {
-            style: {
-              color: 'inherit',
-              ':hover': { color: 'inherit' },
-              ':visited': { color: 'inherit' },
-            },
-          },
-        }}
+        target="_blank"
+        rel="noopener noreferrer"
+        style={{ color: 'inherit', textDecoration: 'none' }}
       >
-        Docs
-      </Link>
+        {item.label}
+      </a>
     );
   }
 

--- a/javascript/packages/core/index.tsx
+++ b/javascript/packages/core/index.tsx
@@ -1,7 +1,6 @@
-import { AppNavBar } from 'baseui/app-nav-bar';
 import { LayersManager } from 'baseui/layer';
 
-import { Link } from '#core/components/link/link';
+import { StudioAppNavBar } from '#core/components/studio-app-nav-bar/studio-app-nav-bar';
 import { ErrorProvider } from '#core/providers/error-provider/error-provider';
 import { IconProvider } from '#core/providers/icon-provider/icon-provider';
 import { ServiceProvider } from '#core/providers/service-provider/service-provider';
@@ -30,16 +29,7 @@ export function CoreApp({ dependencies }: Props) {
         <ServiceProvider {...dependencies.service}>
           <ErrorProvider {...dependencies.error}>
             <IconProvider icons={dependencies.theme.icons}>
-              <AppNavBar
-                title={
-                  <Link
-                    href="/"
-                    overrides={{ Link: { style: { ':hover': { textDecoration: 'unset' } } } }}
-                  >
-                    Michelangelo Studio
-                  </Link>
-                }
-              />
+              <StudioAppNavBar />
               <Router />
             </IconProvider>
           </ErrorProvider>


### PR DESCRIPTION
Fixes #950.

## Summary
The Studio app header now renders a Docs link in the AppNavBar's right-side main navigation. The link uses the shared `Link` component, so external-link behavior stays centralized.

This keeps the project drawer and breadcrumb bar focused on project navigation.

## Screenshot
![Studio top nav with Docs link](https://raw.githubusercontent.com/michelangelo-ai/michelangelo/8a9b4f7a3f6439ecd9f58d5ee802be30fa76b86d/michelangelo-studio-docs-app-nav.png)

## Validation
The public docs root resolves successfully. Local validation passed for format, typecheck, lint, and the Studio app-navbar unit test. CI is green for format, lint/typecheck, unit tests, JavaScript coverage, and CLA. Local lint only reports the repo's existing Fast Refresh warnings.
