### PR TITLE
docs: add user-facing deploy guide

### DIFF
--- a/docs/user-guides/deploy-a-model.md
+++ b/docs/user-guides/deploy-a-model.md
@@ -1,0 +1,218 @@
+# Deploy a Model
+
+Serve a trained model from Michelangelo so applications can call it for predictions.
+
+This guide walks through the end-user deploy workflow: pointing a registered model at an inference server, applying the deployment, and confirming the model is serving requests. This guide assumes your platform team has already set up the cluster and serving infrastructure — see [Next Steps](#next-steps) for the operator-facing setup docs.
+
+:::note
+**Michelangelo Studio** is the browser-based UI for Michelangelo. Its **Deploy & Predict** phase will provide a UI for the workflow described in this guide — creating deployments, managing rollouts, and sending test predictions from the browser. This phase is currently in development; until it ships, use the CLI flow below. The same `Deployment` and `InferenceServer` resources you create with `ma` will appear in Studio once the UI is enabled.
+:::
+
+## What You'll Learn
+
+- How a deployment ties a registered model to an inference server
+- How to define an `InferenceServer` and a `Deployment` in YAML
+- How to apply both with the `ma` CLI
+- How to send a prediction request to verify the model is serving
+- How to try the full flow on the local sandbox in a few minutes
+
+## Prerequisites
+
+Before deploying, you need:
+
+- **A packaged model.** Your trained model must be packaged as a Triton-compatible artifact and uploaded to model storage (the `deploy-models` bucket on the sandbox, or your platform's configured object store). See the [Model Registry Guide](./model-registry-guide.md) for how to produce a deployable package.
+- **A registered model revision.** Deployments target a specific `Revision` of a `Model`. The Model Registry guide covers registration. To list available revisions in your namespace, run `ma revision get -n <your-namespace>`.
+- **Access to a cluster with serving installed.** Either a local sandbox (covered below) or a remote cluster set up by your operator team.
+- **The `ma` CLI on your PATH.** From the `python/` directory, run `poetry install && source .venv/bin/activate`. See the [CLI Reference](./cli.md) for details. Run all `ma` commands below from the `python/` directory.
+
+## Try It on the Sandbox
+
+The fastest way to see a working deployment end-to-end is the built-in sandbox demo. From a clean sandbox:
+
+```bash
+ma sandbox create
+ma sandbox demo inference
+```
+
+`ma sandbox demo inference` provisions an `InferenceServer` named `inference-server-example` in the `default` namespace, plus the model config and gateway routes needed to serve predictions. From there you can apply your own `Deployment` against it and start sending inference requests.
+
+For the full local walkthrough — including uploading a model artifact and sending a sample request — see [Sandbox Setup](../getting-started/sandbox-setup.md).
+
+## The Two Resources You Need
+
+A working deployment requires two Michelangelo resources:
+
+| Resource | Purpose | Who Creates It |
+|----------|---------|----------------|
+| **`InferenceServer`** | A long-lived runtime that hosts one or more models. Defines the backend (Triton, vLLM, etc.), CPU/memory/GPU, and how many replicas to run. | Often shared across a team — created once and reused for many models |
+| **`Deployment`** | A model-to-server binding. Points a specific model `Revision` at an `InferenceServer` and controls rollout strategy. | Created per model (and updated per new revision) |
+
+If a suitable `InferenceServer` already exists in your project, you only need to create a `Deployment`. Run `ma inference_server get -n <your-namespace>` to find it — ask your platform operator if you're unsure.
+
+## Step 1: Define an InferenceServer (if one doesn't exist)
+
+Create `inferenceserver.yaml`:
+
+```yaml
+apiVersion: michelangelo.api/v2
+kind: InferenceServer
+metadata:
+  name: my-inference-server
+  namespace: my-project
+  labels:
+    app: my-inference-server
+spec:
+  backendType: BACKEND_TYPE_TRITON
+  initSpec:
+    resourceSpec:
+      cpu: 2
+      memory: "4Gi"
+    numInstances: 1
+  owner:
+    name: "your-username"  # your Michelangelo username or team identifier
+  clusterTargets:
+  - clusterId: <cluster-id>  # cluster identifier provided by your platform team
+    kubernetes:
+      host: https://kubernetes.default.svc
+      port: "443"
+      tokenTag: <token-secret-tag>
+      caDataTag: <ca-data-secret-tag>
+```
+
+Key fields:
+
+- **`backendType`** — the serving framework. `BACKEND_TYPE_TRITON` is the default for most use cases. Other backends (`BACKEND_TYPE_LLM_D`, `BACKEND_TYPE_DYNAMO`, `BACKEND_TYPE_TORCHSERVE`) are available depending on your platform setup.
+- **`initSpec.resourceSpec`** — CPU and memory per replica. Size based on your model's needs.
+- **`initSpec.numInstances`** — how many replicas to run for availability and throughput.
+- **`owner.name`** — your Michelangelo username or team identifier. Ask your platform operator if you don't know what value to use.
+- **`clusterTargets`** — required. Specifies which cluster(s) the server is provisioned on. The `clusterId` and secret tags come from your platform team. See the [Michelangelo Serving overview](../operator-guides/serving/index.md) for how operators configure cluster targets.
+
+## Step 2: Define a Deployment
+
+Create `deployment.yaml`:
+
+```yaml
+apiVersion: michelangelo.api/v2
+kind: Deployment
+metadata:
+  name: my-model-deployment
+  namespace: my-project
+spec:
+  inferenceServer:
+    name: my-inference-server
+    namespace: my-project
+  desiredRevision:
+    name: <your-revision-name>
+    namespace: my-project
+```
+
+Key fields:
+
+- **`inferenceServer`** — the `InferenceServer` to load the model on. Must already exist.
+- **`desiredRevision`** — the model `Revision` you want to serve. Update this field and re-apply to roll out a new model version.
+
+For a more complete example with explicit rollout strategy and target type, see the [`Deployment` reference in the operator serving guide](../operator-guides/serving/index.md).
+
+## Step 3: Apply Both Resources
+
+Use the `ma` CLI to create or update each resource.
+
+:::tip
+`apply` works as an upsert — it creates the resource if it doesn't exist, or updates it if it does.
+:::
+
+```bash
+ma inference_server apply -f inferenceserver.yaml
+ma deployment apply -f deployment.yaml
+```
+
+Check status:
+
+```bash
+ma inference_server get -n <your-namespace> --name my-inference-server
+ma deployment get -n <your-namespace> --name my-model-deployment
+```
+
+A healthy deployment progresses through validation, asset preparation, resource acquisition, model traffic routing, and finally `Rollout Complete`. The [Deployment Lifecycle section in the serving overview](../operator-guides/serving/index.md#deployment-lifecycle) explains each stage.
+
+## Step 4: Send a Prediction Request
+
+Once the deployment is complete, the model is reachable through the gateway. The exact URL depends on your environment — on the sandbox the gateway is exposed at `localhost:8080`. The path follows this pattern:
+
+```
+http://<gateway-host>/<inference-server-name>/<deployment-name>/infer
+```
+
+Send a request with the input shape your model expects:
+
+```bash
+curl -X POST http://localhost:8080/my-inference-server/my-model-deployment/infer \
+  -H "Content-Type: application/json" \
+  -d '{
+    "inputs": [
+      {
+        "name": "input_ids",
+        "shape": [1, 10],
+        "datatype": "INT64",
+        "data": [101, 7592, 999, 102, 0, 0, 0, 0, 0, 0]
+      }
+    ]
+  }'
+```
+
+Replace the input names, shape, and data with whatever matches the `ModelSchema` you defined when packaging the model.
+
+**A `200 OK` response with the predicted outputs confirms the model is serving.**
+
+:::tip
+The request and response payloads follow the [Triton inference protocol](https://github.com/triton-inference-server/server/blob/main/docs/protocol/extension_binary_data.md). Each input/output corresponds to a `ModelSchemaItem` in your packaged model.
+:::
+
+## Updating a Deployment
+
+To roll out a new model version, update `desiredRevision.name` in `deployment.yaml` and re-apply:
+
+```bash
+ma deployment apply -f deployment.yaml
+```
+
+The Deployment controller handles the rollout, including rollback if the new revision fails health checks.
+
+## Deleting a Deployment
+
+```bash
+ma deployment delete -n <your-namespace> --name my-model-deployment
+```
+
+Deleting the `Deployment` removes the model from the inference server but leaves the `InferenceServer` and the underlying model artifacts intact. To tear down the server too:
+
+```bash
+ma inference_server delete -n <your-namespace> --name my-inference-server
+```
+
+## Troubleshooting
+
+### Deployment stuck in `Validation`
+
+The model `Revision` or target `InferenceServer` couldn't be resolved. Confirm both exist with `ma revision get` and `ma inference_server get`, and that the namespace fields in the Deployment spec match.
+
+### Deployment reaches `Rollout Complete` but predictions return 404
+
+The gateway route may not be ready yet, or the URL path is incorrect. The path is `/<inference-server-name>/<deployment-name>/infer` — both names must match exactly (case-sensitive) and use the metadata `name` field, not the model name.
+
+### Predictions return a schema validation error
+
+The request payload doesn't match the model's `ModelSchema`. Re-check the input names, shapes, and dtypes against the schema you defined when packaging the model. See [Schema validation errors in the Model Registry guide](./model-registry-guide.md#schema-validation-errors) for details.
+
+### Model artifact not found
+
+The Deployment can't locate the packaged model in storage. Verify the artifact was uploaded to the configured bucket (`deploy-models` on the sandbox) and that the `Revision` references the correct path.
+
+## Next Steps
+
+This guide covers the end-user workflow assuming serving infrastructure is already in place. For platform-level concerns:
+
+- **[Michelangelo Serving overview](../operator-guides/serving/index.md)** — architecture, controller lifecycles, and core concepts
+- **[Sandbox Setup](../getting-started/sandbox-setup.md)** — full walkthrough with model upload and inference on a local sandbox
+- **[Integrate with a Custom Backend](../operator-guides/serving/integrate-custom-backend.md)** — add support for new serving frameworks
+- **[CLI Reference](./cli.md)** — every `ma` command, including the full list of supported flags

--- a/docs/user-guides/deploy-a-model.md
+++ b/docs/user-guides/deploy-a-model.md
@@ -1,11 +1,17 @@
+---
+sidebar_position: 5
+---
+
 # Deploy a Model
 
 Serve a trained model from Michelangelo so applications can call it for predictions.
 
-This guide walks through the end-user deploy workflow: pointing a registered model at an inference server, applying the deployment, and confirming the model is serving requests. This guide assumes your platform team has already set up the cluster and serving infrastructure — see [Next Steps](#next-steps) for the operator-facing setup docs.
+By the end, you'll have a model running on an inference server and a working `curl` request to prove it. This guide assumes your platform operator has already set up the cluster and serving infrastructure — see [Next Steps](#next-steps) for the operator-facing setup docs.
 
 :::note
-**Michelangelo Studio** is the browser-based UI for Michelangelo. Its **Deploy & Predict** phase will provide a UI for the workflow described in this guide — creating deployments, managing rollouts, and sending test predictions from the browser. This phase is currently in development; until it ships, use the CLI flow below. The same `Deployment` and `InferenceServer` resources you create with `ma` will appear in Studio once the UI is enabled.
+Studio's **Deploy & Predict** phase is on the roadmap. While the UI is in development, the `ma` CLI is the supported way to deploy. Everything you create here — `InferenceServer` and `Deployment` resources — will appear in Studio once the phase ships.
+
+If you arrived from the Studio Deploy & Predict card, you're in the right place — use the CLI flow below until the UI ships.
 :::
 
 ## What You'll Learn
@@ -21,9 +27,20 @@ This guide walks through the end-user deploy workflow: pointing a registered mod
 Before deploying, you need:
 
 - **A packaged model.** Your trained model must be packaged as a Triton-compatible artifact and uploaded to model storage (the `deploy-models` bucket on the sandbox, or your platform's configured object store). See the [Model Registry Guide](./model-registry-guide.md) for how to produce a deployable package.
-- **A registered model revision.** Deployments target a specific `Revision` of a `Model`. The Model Registry guide covers registration. To list available revisions in your namespace, run `ma revision get -n <your-namespace>`.
-- **Access to a cluster with serving installed.** Either a local sandbox (covered below) or a remote cluster set up by your operator team.
-- **The `ma` CLI on your PATH.** From the `python/` directory, run `poetry install && source .venv/bin/activate`. See the [CLI Reference](./cli.md) for details. Run all `ma` commands below from the `python/` directory.
+- **A registered model revision.** Deployments target a specific `Revision` of a `Model`. See [Register a Revision](./model-registry-guide.md#register-a-revision) for how to create one. To list available revisions in your namespace, run `ma revision get -n <your-namespace>`.
+- **Access to a cluster with serving installed.** Either a local sandbox (covered below) or a remote cluster set up by your platform operator.
+- **The `ma` CLI on your PATH.** Clone the repository, then from the `python/` directory run `poetry install && source .venv/bin/activate`. Once the virtualenv is active, `ma` works from any directory. See the [CLI Reference](./cli.md) for details.
+
+## The Two Resources You Need
+
+A working deployment requires two Michelangelo resources:
+
+| Resource | Purpose | Who Creates It |
+|----------|---------|----------------|
+| **`InferenceServer`** | A long-lived runtime that hosts one or more models. Defines the backend (Triton, LLM-D, etc.), CPU/memory/GPU, and how many replicas to run. | Often shared across a team — created once and reused for many models |
+| **`Deployment`** | A model-to-server binding. Points a specific model `Revision` at an `InferenceServer` and controls rollout strategy. | Created per model (and updated per new revision) |
+
+If a suitable `InferenceServer` already exists in your project, you only need to create a `Deployment`. Run `ma inference_server get -n <your-namespace>` to find it — ask your platform operator if you're unsure.
 
 ## Try It on the Sandbox
 
@@ -34,24 +51,21 @@ ma sandbox create
 ma sandbox demo inference
 ```
 
-`ma sandbox demo inference` provisions an `InferenceServer` named `inference-server-example` in the `default` namespace, plus the model config and gateway routes needed to serve predictions. From there you can apply your own `Deployment` against it and start sending inference requests.
+`ma sandbox demo inference` provisions an `InferenceServer` named `inference-server-example` in the `default` namespace, plus the model config and gateway routes needed to serve predictions. The port-forward to `localhost:8080` is active for the lifetime of that terminal session. If you used `--workflow temporal` when creating the sandbox, that port may collide with the Temporal Web UI — use a separate terminal for inference testing.
 
-For the full local walkthrough — including uploading a model artifact and sending a sample request — see [Sandbox Setup](../getting-started/sandbox-setup.md).
+From there you can apply your own `Deployment` against the provisioned server and start sending inference requests.
 
-## The Two Resources You Need
+:::note
+If you're using the sandbox, `ma sandbox demo inference` already created an `InferenceServer` for you. Skip Step 1 and start at Step 2 using `inferenceServer.name: inference-server-example` and `inferenceServer.namespace: default`.
+:::
 
-A working deployment requires two Michelangelo resources:
-
-| Resource | Purpose | Who Creates It |
-|----------|---------|----------------|
-| **`InferenceServer`** | A long-lived runtime that hosts one or more models. Defines the backend (Triton, vLLM, etc.), CPU/memory/GPU, and how many replicas to run. | Often shared across a team — created once and reused for many models |
-| **`Deployment`** | A model-to-server binding. Points a specific model `Revision` at an `InferenceServer` and controls rollout strategy. | Created per model (and updated per new revision) |
-
-If a suitable `InferenceServer` already exists in your project, you only need to create a `Deployment`. Run `ma inference_server get -n <your-namespace>` to find it — ask your platform operator if you're unsure.
-
-## Step 1: Define an InferenceServer (if one doesn't exist)
+## Step 1: Define an InferenceServer
 
 Create `inferenceserver.yaml`:
+
+:::note
+If you set up Michelangelo on your own cluster, you are also the operator. The `clusterId`, `tokenTag`, and `caDataTag` values are the identifiers you assigned when registering the cluster with the control plane — see [the cluster setup guide](../operator-guides/serving/cluster-setup.md) for details.
+:::
 
 ```yaml
 apiVersion: michelangelo.api/v2
@@ -69,9 +83,9 @@ spec:
       memory: "4Gi"
     numInstances: 1
   owner:
-    name: "your-username"  # your Michelangelo username or team identifier
+    name: "<your-username>"  # your username as configured by your platform operator (used for auditing)
   clusterTargets:
-  - clusterId: <cluster-id>  # cluster identifier provided by your platform team
+  - clusterId: <cluster-id>  # cluster identifier provided by your platform operator
     kubernetes:
       host: https://kubernetes.default.svc
       port: "443"
@@ -81,11 +95,11 @@ spec:
 
 Key fields:
 
-- **`backendType`** — the serving framework. `BACKEND_TYPE_TRITON` is the default for most use cases. Other backends (`BACKEND_TYPE_LLM_D`, `BACKEND_TYPE_DYNAMO`, `BACKEND_TYPE_TORCHSERVE`) are available depending on your platform setup.
-- **`initSpec.resourceSpec`** — CPU and memory per replica. Size based on your model's needs.
+- **`backendType`** — required. The serving framework. `BACKEND_TYPE_TRITON` is the most common choice for general ML models. Ask your platform operator about the others: `BACKEND_TYPE_LLM_D` and `BACKEND_TYPE_DYNAMO` are optimized for LLM workloads; `BACKEND_TYPE_TORCHSERVE` is PyTorch-specific.
+- **`initSpec.resourceSpec`** — CPU and memory per replica. A lightweight model typically needs 2 CPU / 4 Gi; a large deep learning model may need a GPU node — check with your platform operator if you're unsure.
 - **`initSpec.numInstances`** — how many replicas to run for availability and throughput.
-- **`owner.name`** — your Michelangelo username or team identifier. Ask your platform operator if you don't know what value to use.
-- **`clusterTargets`** — required. Specifies which cluster(s) the server is provisioned on. The `clusterId` and secret tags come from your platform team. See the [Michelangelo Serving overview](../operator-guides/serving/index.md) for how operators configure cluster targets.
+- **`owner.name`** — your username as configured by your platform operator, used for audit purposes. For multi-tenant deployments, your platform operator will configure `ownerSpec` (team identifiers, groups, and tier) separately — ask them if you need to set ownership for capacity attribution.
+- **`clusterTargets`** — required. Specifies which cluster(s) the server is provisioned on. The `clusterId` and secret tags come from your platform operator. See the [Michelangelo Serving overview](../operator-guides/serving/index.md) for how operators configure cluster targets.
 
 ## Step 2: Define a Deployment
 
@@ -104,22 +118,23 @@ spec:
   desiredRevision:
     name: <your-revision-name>
     namespace: my-project
+  strategy:
+    blast: {}
 ```
 
 Key fields:
 
 - **`inferenceServer`** — the `InferenceServer` to load the model on. Must already exist.
 - **`desiredRevision`** — the model `Revision` you want to serve. Update this field and re-apply to roll out a new model version.
+- **`strategy`** — required. Controls how the rollout proceeds across server instances. `blast: {}` loads the new model on all instances simultaneously (simplest option). Other strategies — `zonal`, `rolling`, and `red_black` — let you stage rollouts progressively. See the [`Deployment` reference in the operator serving guide](../operator-guides/serving/index.md) for strategy details.
 
-For a more complete example with explicit rollout strategy and target type, see the [`Deployment` reference in the operator serving guide](../operator-guides/serving/index.md).
+:::tip
+`ma apply` sends resources to the Michelangelo API server, which manages the deployment lifecycle. This is different from `kubectl apply`, which writes directly to Kubernetes.
+:::
 
 ## Step 3: Apply Both Resources
 
-Use the `ma` CLI to create or update each resource.
-
-:::tip
-`apply` works as an upsert — it creates the resource if it doesn't exist, or updates it if it does.
-:::
+Apply each resource with `ma` — `apply` creates the resource if it doesn't exist, or updates it if it does.
 
 ```bash
 ma inference_server apply -f inferenceserver.yaml
@@ -133,17 +148,21 @@ ma inference_server get -n <your-namespace> --name my-inference-server
 ma deployment get -n <your-namespace> --name my-model-deployment
 ```
 
-A healthy deployment progresses through validation, asset preparation, resource acquisition, model traffic routing, and finally `Rollout Complete`. The [Deployment Lifecycle section in the serving overview](../operator-guides/serving/index.md#deployment-lifecycle) explains each stage.
+A healthy deployment progresses through these stages:
+
+`Validation → Placement → Resource Acquisition → Rollout Complete`
+
+The [Deployment Lifecycle section in the serving overview](../operator-guides/serving/index.md#deployment-lifecycle) explains each stage.
 
 ## Step 4: Send a Prediction Request
 
-Once the deployment is complete, the model is reachable through the gateway. The exact URL depends on your environment — on the sandbox the gateway is exposed at `localhost:8080`. The path follows this pattern:
+Once the deployment reaches `Rollout Complete`, the model is reachable through the gateway. The path follows this pattern:
 
-```
+```text
 http://<gateway-host>/<inference-server-name>/<deployment-name>/infer
 ```
 
-Send a request with the input shape your model expects:
+On the sandbox, `ma sandbox demo inference` port-forwards the gateway to `localhost:8080` for the lifetime of the terminal session. Send a request with the input shape your model expects:
 
 ```bash
 curl -X POST http://localhost:8080/my-inference-server/my-model-deployment/infer \
@@ -165,10 +184,12 @@ Replace the input names, shape, and data with whatever matches the `ModelSchema`
 **A `200 OK` response with the predicted outputs confirms the model is serving.**
 
 :::tip
-The request and response payloads follow the [Triton inference protocol](https://github.com/triton-inference-server/server/blob/main/docs/protocol/extension_binary_data.md). Each input/output corresponds to a `ModelSchemaItem` in your packaged model.
+The request and response payloads follow the [KServe v2 inference protocol](https://kserve.github.io/website/latest/modelserving/inference_api/). Each input/output corresponds to a `ModelSchemaItem` in your packaged model.
 :::
 
-## Updating a Deployment
+## Manage Your Deployment
+
+### Updating a Deployment
 
 To roll out a new model version, update `desiredRevision.name` in `deployment.yaml` and re-apply:
 
@@ -178,7 +199,7 @@ ma deployment apply -f deployment.yaml
 
 The Deployment controller handles the rollout, including rollback if the new revision fails health checks.
 
-## Deleting a Deployment
+### Deleting a Deployment
 
 ```bash
 ma deployment delete -n <your-namespace> --name my-model-deployment
@@ -190,29 +211,24 @@ Deleting the `Deployment` removes the model from the inference server but leaves
 ma inference_server delete -n <your-namespace> --name my-inference-server
 ```
 
+:::warning
+Delete all `Deployment` resources that reference an `InferenceServer` before deleting the server itself. Deleting an `InferenceServer` while active Deployments still reference it leaves those Deployments in a stuck state.
+:::
+
 ## Troubleshooting
 
-### Deployment stuck in `Validation`
-
-The model `Revision` or target `InferenceServer` couldn't be resolved. Confirm both exist with `ma revision get` and `ma inference_server get`, and that the namespace fields in the Deployment spec match.
-
-### Deployment reaches `Rollout Complete` but predictions return 404
-
-The gateway route may not be ready yet, or the URL path is incorrect. The path is `/<inference-server-name>/<deployment-name>/infer` — both names must match exactly (case-sensitive) and use the metadata `name` field, not the model name.
-
-### Predictions return a schema validation error
-
-The request payload doesn't match the model's `ModelSchema`. Re-check the input names, shapes, and dtypes against the schema you defined when packaging the model. See [Schema validation errors in the Model Registry guide](./model-registry-guide.md#schema-validation-errors) for details.
-
-### Model artifact not found
-
-The Deployment can't locate the packaged model in storage. Verify the artifact was uploaded to the configured bucket (`deploy-models` on the sandbox) and that the `Revision` references the correct path.
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| Deployment stuck in `Validation` | The model `Revision` or target `InferenceServer` couldn't be resolved | Confirm both exist with `ma revision get` and `ma inference_server get`; check that namespace fields in the Deployment spec match |
+| Reaches `Rollout Complete` but predictions return 404 | Gateway route not ready, or URL path is incorrect | Wait a moment and retry; confirm the path is `/<inference-server-name>/<deployment-name>/infer` (case-sensitive, uses metadata `name` fields) |
+| Predictions return a schema validation error | Request payload doesn't match the model's `ModelSchema` | Re-check input names, shapes, and dtypes against the schema you defined when packaging. See [Schema validation errors in the Model Registry guide](./model-registry-guide.md#schema-validation-errors) |
+| Model artifact not found | The packaged model can't be located in storage | Verify the artifact was uploaded to the configured bucket (`deploy-models` on the sandbox) and that the `Revision` references the correct path |
 
 ## Next Steps
 
 This guide covers the end-user workflow assuming serving infrastructure is already in place. For platform-level concerns:
 
 - **[Michelangelo Serving overview](../operator-guides/serving/index.md)** — architecture, controller lifecycles, and core concepts
-- **[Sandbox Setup](../getting-started/sandbox-setup.md)** — full walkthrough with model upload and inference on a local sandbox
+- **[Model Registry Guide](./model-registry-guide.md)** — package and register a model before deploying
 - **[Integrate with a Custom Backend](../operator-guides/serving/integrate-custom-backend.md)** — add support for new serving frameworks
 - **[CLI Reference](./cli.md)** — every `ma` command, including the full list of supported flags

--- a/docs/user-guides/index.md
+++ b/docs/user-guides/index.md
@@ -25,7 +25,7 @@ Version and organize trained models:
 
 ### **5. Deploy Your Model**
 Serve predictions in production:
-* [**Deploy Models**](../operator-guides/serving/index.md) - Deploy models for real-time inference and batch scoring
+* [**Deploy a Model**](./deploy-a-model.md) - Bind a registered model to an inference server and validate predictions
 
 ---
 
@@ -45,7 +45,7 @@ Serve predictions in production:
 * [Prepare your data](./prepare-your-data.md)
 * [Train a model](./train-and-register-a-model.md)
 * [Manage your models](./model-registry-guide.md)
-* [Deploy models](../operator-guides/serving/index.md)
+* [Deploy a model](./deploy-a-model.md)
 
 ### **Advanced Topics**
 
@@ -86,3 +86,4 @@ Choose a tutorial based on your ML domain:
 - **New to ML Pipelines?** Start with the [ML Pipelines Overview](./ml-pipelines/index.md), then follow [Getting Started with Pipelines](./ml-pipelines/getting-started.md)
 - **Have your pipeline running?** Learn about [Pipeline Running Modes](./ml-pipelines/pipeline-running-modes.md) and [Caching and Resume](./ml-pipelines/cache-and-pipelinerun-resume-form.md)
 - **Ready for production?** Set up [Pipeline Triggers](./set-up-triggers.md) for automated scheduling
+- **Ready to serve predictions?** Deploy your registered model — see [Deploy a Model](./deploy-a-model.md)

--- a/docs/user-guides/model-registry-guide.md
+++ b/docs/user-guides/model-registry-guide.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 4
+---
+
 # Model Registry Guide
 
 Save, version, and manage trained models using Michelangelo's model packaging system.
@@ -441,8 +445,52 @@ Your model class must:
 * Extend `michelangelo.lib.model_manager.interface.custom_model.Model`
 * Implement all three abstract methods: `save`, `load`, and `predict`
 
+## Register a Revision
+
+A `Revision` is a versioned snapshot of a `Model` resource. One `Model` can have many `Revision`s — each one represents a distinct training run or artifact version. When you deploy a model, you target a specific `Revision`, not the `Model` directly. This lets you roll out new versions and roll back independently of the model definition itself.
+
+### Create a revision.yaml
+
+```yaml
+apiVersion: michelangelo.api/v2
+kind: Revision
+metadata:
+  name: my-model-v1
+  namespace: my-project
+spec:
+  baseType:
+    kind: Model
+    apiVersion: michelangelo.api/v2
+  baseResource:
+    name: my-model
+    namespace: my-project
+  owner:
+    name: <your-username>
+```
+
+The `baseResource.name` and `baseResource.namespace` must match an existing `Model` resource in your project. `owner.name` is the username configured by your platform operator.
+
+### Apply and verify
+
+Apply the revision to the control plane:
+
+```bash
+ma revision apply -f revision.yaml
+```
+
+List revisions in your namespace to confirm it was registered:
+
+```bash
+ma revision get -n my-project
+```
+
+### When to create a new Revision vs. update
+
+Create a new `Revision` whenever you have a new training run or a new artifact — each Revision should correspond to a distinct, reproducible artifact. Update an existing Revision only to fix metadata (such as the owner field); changing the underlying artifact warrants a new Revision so your deployment history stays traceable.
+
 ## Next Steps
 
 * See working examples in [`python/examples/model_manager/`](https://github.com/michelangelo-ai/michelangelo/tree/main/python/examples/model_manager)
 * Learn about [model training](./train-and-register-a-model.md) to prepare models for packaging
 * Learn about [data preparation](./prepare-your-data.md) for your training pipeline
+* Continue to [Deploy a Model](./deploy-a-model.md) to put your registered model into serving

--- a/docs/user-guides/train-and-register-a-model.md
+++ b/docs/user-guides/train-and-register-a-model.md
@@ -199,7 +199,7 @@ The SDK automates all distributed concerns.
 Your models are now ready to move forward:
 
 * Continue to [**Model Registry**](./model-registry-guide.md) to save and version
-* Continue to **Model Deployment** _(Coming Soon)_ for inference
+* Continue to [**Deploy a Model**](./deploy-a-model.md) for inference
 
 ## Troubleshooting
 


### PR DESCRIPTION
Closes #1179

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**

- New guide at `docs/user-guides/deploy-a-model.md` — end-user walkthrough that covers prerequisites after training/registering a model, defining `InferenceServer` and `Deployment` YAMLs (with required `strategy` field), applying them with `ma`, and validating with a curl call to the inference endpoint.
- `docs/user-guides/model-registry-guide.md` — new **Register a Revision** section that closes the missing upstream step in the user journey from packaging to deploying. Also adds `sidebar_position: 4` so it slots before the deploy guide in the sidebar.
- `docs/user-guides/index.md` — the **5. Deploy Your Model** step and the **Specific Tasks** entry now link to the new guide instead of sending users straight to the operator-facing serving docs.
- `docs/user-guides/train-and-register-a-model.md` — replaced the "Model Deployment _(Coming Soon)_" placeholder with a real link to the new guide.

The guide intentionally points readers to the operator docs (`operator-guides/serving/...`) for cluster setup, backend integration, and architecture — those are out of scope for an end user but linked from a "Where to go next" section. A signpost in Step 1 tells solo-operator readers where the `clusterTargets` secret-tag values come from.

**Why?**

Studio's Data, Train, and Deploy phase cards each link to public docs via a `docUrl`. Data and Train have user-facing guides; Deploy currently has only the operator-facing Michelangelo Serving docs, which are written for platform operators and contributors and aren't the right target for a Studio user clicking **Learn More** from the Deploy phase. This PR fills that gap so the Deploy phase `docUrl` can safely point to a user-appropriate page.

**How did you test it?**

- `cd website && bun run build` — clean build, no broken internal links.
- Reviewed against the existing user-guide patterns (`prepare-your-data.md`, `train-and-register-a-model.md`, `model-registry-guide.md`) for tone and structure.
- Cross-checked CLI commands against `docs/user-guides/cli.md` and the `InferenceServer` / `Deployment` / `Revision` proto specs.
- Cross-checked YAML examples against the canonical sandbox demo (`python/michelangelo/cli/sandbox/demo/inference/inferenceserver.yaml`), the operator serving walkthrough (`docs/operator-guides/serving/cluster-setup.md`), and the test fixtures under `scripts/ingester/ingester-test-crs/`.
- Verified that `spec.strategy` is required at the proto level, that `ma` works from any cwd after venv activation, and that `ma revision apply -f revision.yaml` is the supported Revision-creation path.

**Potential risks**

Docs-only change. No code or runtime impact.

**Release notes**

Adds a user-facing guide for deploying models and a new "Register a Revision" section in the Model Registry guide. After this lands, the Studio Deploy phase `docUrl` (`javascript/packages/core/config/phases/deploy.ts`) can be updated from the `https://example.com/docs/deploy` placeholder to the published URL of `/user-guides/deploy-a-model`.

**Documentation Changes**

This PR is the documentation change.