### PR TITLE
Add logo above landing hero title

### DIFF
--- a/website/src/components/Landing/Hero.tsx
+++ b/website/src/components/Landing/Hero.tsx
@@ -1,12 +1,20 @@
 import React from 'react';
 import Link from '@docusaurus/Link';
+import useBaseUrl from '@docusaurus/useBaseUrl';
 import AnimatedText from './AnimatedText';
 import styles from '../../css/landing.module.css';
 
 export default function Hero(): React.ReactElement {
+  const logoSrc = useBaseUrl('/img/michelangelo-logo-color.svg');
+
   return (
     <section className={styles.hero}>
       <div className={styles.heroContent}>
+        <img
+          className={styles.heroLogo}
+          src={logoSrc}
+          alt="Michelangelo logo"
+        />
         <h1 className={styles.heroTitle}>
           ML at Scale.
           <br />

--- a/website/src/css/landing.module.css
+++ b/website/src/css/landing.module.css
@@ -73,10 +73,19 @@
   text-align: center;
 }
 
+.heroLogo {
+  display: block;
+  width: clamp(5.5rem, 12vw, 8rem);
+  height: auto;
+  margin: 0 auto 1.5rem;
+  filter: drop-shadow(0 12px 24px rgba(0, 0, 0, 0.25));
+}
+
 .heroTitle {
   font-size: clamp(2.5rem, 8vw, 5rem);
   font-weight: 800;
   line-height: 1.1;
+  margin-top: 0;
   margin-bottom: 1.5rem;
   color: var(--ifm-font-color-base);
 }
@@ -368,6 +377,11 @@
   .hero {
     padding: 3rem 1.5rem;
     min-height: auto;
+  }
+
+  .heroLogo {
+    width: clamp(4.75rem, 28vw, 6.5rem);
+    margin-bottom: 1.25rem;
   }
 
   .heroCtas {


### PR DESCRIPTION
## Summary

- Add the Michelangelo logo above the landing page hero title
- Add responsive sizing and spacing so the logo remains centered on desktop and mobile

Fixes #826.

## Validation

- `bun run build`
- `bun run typecheck`
- Captured local rendered screenshot: `website/build/hero-logo-screenshot.png`

<img width="1272" height="720" alt="image" src="https://github.com/user-attachments/assets/fbe8b4c0-dad2-4327-9d94-d048f6b6d23f" />
