### PR TITLE
Add targeted JavaScript API docs

### DIFF
--- a/javascript/packages/core/providers/icon-provider/icon-provider.tsx
+++ b/javascript/packages/core/providers/icon-provider/icon-provider.tsx
@@ -4,6 +4,9 @@ import { IconContext } from './icon-context';
 
 import type { IconProviderContext } from './types';
 
+/**
+ * Provides the icon registry used by Icon and icon-backed controls.
+ */
 export const IconProvider: React.FC<{ children: React.ReactNode } & IconProviderContext> = ({
   children,
   ...iconContext

--- a/javascript/packages/core/providers/user-provider/user-provider.tsx
+++ b/javascript/packages/core/providers/user-provider/user-provider.tsx
@@ -2,6 +2,9 @@ import { UserContext } from './user-context';
 
 import type { UserContextType } from './types';
 
+/**
+ * Provides authenticated user data to components that render user-aware UI.
+ */
 export const UserProvider = ({
   children,
   ...userContext

--- a/javascript/packages/core/utils/object-utils.ts
+++ b/javascript/packages/core/utils/object-utils.ts
@@ -39,6 +39,12 @@ export function toFlatDotPathMap(
   return result;
 }
 
+/**
+ * Reads a value from an object using either a function accessor or a lodash-style path.
+ *
+ * Returns the provided default when the accessor resolves to nullish, and returns
+ * undefined when the accessor is not callable or path-like.
+ */
 export function getObjectValue<K>(
   obj: unknown,
   accessor: Accessor<K>,
@@ -55,6 +61,12 @@ export function getObjectValue<K>(
   return undefined;
 }
 
+/**
+ * Copies an object's symbol-keyed properties into a plain symbol record.
+ *
+ * React and third-party libraries sometimes attach metadata by symbol; this
+ * helper preserves those values when object data is transformed.
+ */
 export function getObjectSymbols(obj: unknown): Record<symbol, unknown> {
   if (typeof obj !== 'object' || obj === null) {
     return {};

--- a/javascript/packages/core/utils/string-utils.ts
+++ b/javascript/packages/core/utils/string-utils.ts
@@ -3,6 +3,9 @@ import { isURL } from 'validator';
 export const capitalizeFirstLetter = (str: string): string =>
   str.charAt(0).toUpperCase() + str.slice(1);
 
+/**
+ * Checks for absolute URLs, including localhost values without a public TLD.
+ */
 export const isAbsoluteURL = (value: string) =>
   isURL(encodeURI(value), { require_protocol: true, require_tld: false });
 


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**
Added targeted JSDoc for remaining JavaScript public API gaps that match the repo's selective documentation standard:
- `getObjectValue` and `getObjectSymbols`, where behavior is not obvious from the signature
- `isAbsoluteURL`, because it intentionally accepts localhost URLs without a public TLD
- `IconProvider` and `UserProvider`, matching the documented provider pattern used by neighboring provider APIs

Left Craig-authored components, form fields/layouts, styled exports, and type-only exports alone where the implementation is self-describing and existing standards do not require blanket JSDoc.

**Why?**
#652's first two phases already covered hooks and components. A targeted audit of the remaining phases found only a small set of docs worth adding under the current `documenting-code` guidance.

Closes #652

**How did you test it?**
- `git diff --check origin/main...HEAD`
- `yarn format`
- ESLint on changed files
- `./node_modules/.bin/tsc -b --clean && yarn typecheck`

**Potential risks**
Low. Documentation-only JSDoc changes; no runtime behavior changes.

**Release notes**
None.

**Documentation Changes**
This PR updates API documentation comments in the JavaScript package source.
