### PR TITLE
docs: restructure operator-guides integrations section

### DIFF
--- a/docs/operator-guides/experiment-tracking.md
+++ b/docs/operator-guides/experiment-tracking.md
@@ -1,8 +1,8 @@
 # Experiment Tracking Setup
 
-This guide explains how platform operators can make an experiment tracking server available to Michelangelo workloads. It covers network setup, configuration injection, and the boundary between what operators configure and what users do in their `@uniflow.task()` code.
+Michelangelo does not bundle an experiment tracking server — it connects to one you already run. This guide shows platform operators how to expose that server to task pods running inside Michelangelo's compute clusters.
 
-Michelangelo does not bundle an experiment tracking server. If your organization runs one — such as a self-hosted tracking server or a managed SaaS endpoint — this guide explains how to expose it to task pods running inside Michelangelo's compute clusters.
+It covers network setup, ConfigMap injection, credential handling, and the boundary between what operators configure and what users do in their `@uniflow.task()` code.
 
 ---
 
@@ -13,7 +13,7 @@ Experiment tracking in Michelangelo follows a clear separation of concerns:
 - **Operators** configure network access and make the tracking server URI available to task pods via environment variables or ConfigMaps.
 - **Users** call their tracking server's client library inside `@uniflow.task()` functions. Michelangelo does not intercept or wrap these calls.
 
-```
+```text
 ┌─────────────────────────────────────────────┐
 │ Operator Responsibility                     │
 │ ├─ Deploy or configure tracking server      │
@@ -220,7 +220,8 @@ def check_tracking_config():
 
 ---
 
-## Related
+## Next Steps
 
-- [Register a Compute Cluster](jobs/register-a-compute-cluster-to-michelangelo-control-plane.md)
-- [Worker Configuration](platform-setup.md#worker-configuration)
+- [Register a Compute Cluster](jobs/register-a-compute-cluster-to-michelangelo-control-plane.md) — register the compute namespace where this tracking config will be injected.
+- [Worker Configuration](platform-setup.md#worker-configuration) — review environment variable injection and pod configuration options.
+- [Model Registry](model-registry.md) — store and serve models produced by tracked runs.

--- a/docs/operator-guides/experiment-tracking.md
+++ b/docs/operator-guides/experiment-tracking.md
@@ -1,4 +1,4 @@
-# Experiment Tracking Integration
+# Experiment Tracking Setup
 
 This guide explains how platform operators can make an experiment tracking server available to Michelangelo workloads. It covers network setup, configuration injection, and the boundary between what operators configure and what users do in their `@uniflow.task()` code.
 
@@ -41,7 +41,7 @@ Experiment tracking in Michelangelo follows a clear separation of concerns:
 
 ## Step 1: Verify Network Reachability
 
-Task pods run inside the compute cluster namespace registered with Michelangelo (see [Register a Compute Cluster](../jobs/register-a-compute-cluster-to-michelangelo-control-plane.md)). Confirm that pods in that namespace can reach your tracking server.
+Task pods run inside the compute cluster namespace registered with Michelangelo (see [Register a Compute Cluster](jobs/register-a-compute-cluster-to-michelangelo-control-plane.md)). Confirm that pods in that namespace can reach your tracking server.
 
 ```bash
 # Run a connectivity test from a pod in the compute namespace
@@ -94,7 +94,7 @@ spec:
 
 Michelangelo injects environment variables into every task pod (Ray head, Ray workers, Spark drivers, and Spark executors) via the `michelangelo-config` ConfigMap. This ConfigMap is mounted as an `envFrom` source, so every key in it becomes an environment variable in the pod.
 
-You created this ConfigMap when you [registered the compute cluster](../jobs/register-a-compute-cluster-to-michelangelo-control-plane.md). Add the tracking server URI as a new key:
+You created this ConfigMap when you [registered the compute cluster](jobs/register-a-compute-cluster-to-michelangelo-control-plane.md). Add the tracking server URI as a new key:
 
 ```bash
 kubectl patch configmap michelangelo-config \
@@ -222,5 +222,5 @@ def check_tracking_config():
 
 ## Related
 
-- [Register a Compute Cluster](../jobs/register-a-compute-cluster-to-michelangelo-control-plane.md)
-- [Worker Configuration](../platform-setup.md#worker-configuration)
+- [Register a Compute Cluster](jobs/register-a-compute-cluster-to-michelangelo-control-plane.md)
+- [Worker Configuration](platform-setup.md#worker-configuration)

--- a/docs/operator-guides/index.md
+++ b/docs/operator-guides/index.md
@@ -50,8 +50,9 @@ Michelangelo is designed to be adopted alongside existing ML infrastructure. The
 
 | Guide | Description |
 |-------|-------------|
-| [Model Registry](integrations/model-registry.md) | Operate Michelangelo's built-in model registry, configure storage and RBAC, and integrate with serving and CI/CD |
-| [Experiment Tracking](integrations/experiment-tracking.md) | Connect an external experiment tracking server to Michelangelo task pods |
+| [Model Registry](model-registry.md) | Operate Michelangelo's built-in model registry, configure storage and RBAC, and integrate with serving and CI/CD |
+| [Experiment Tracking Setup](experiment-tracking.md) | Make an experiment tracking server reachable from task pods — network, ConfigMap injection, auth, and operator/user boundary |
+| [Third-Party Integrations](integrations/index.md) | Connect external tools (MLflow, and more) to Michelangelo workloads |
 | [Custom Serving Backend](serving/integrate-custom-backend.md) | Add support for any inference framework — Triton, vLLM, TensorRT-LLM, or your own |
 | [Custom Job Scheduler](jobs/extend-michelangelo-batch-job-scheduler-system.md) | Replace or extend the job scheduler — integrate Kueue, Volcano, or a custom assignment strategy |
 | [Register a Compute Cluster](jobs/register-a-compute-cluster-to-michelangelo-control-plane.md) | Connect an existing Kubernetes cluster so Michelangelo can dispatch jobs to it |

--- a/docs/operator-guides/integrations/_category_.json
+++ b/docs/operator-guides/integrations/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Third-Party Integrations",
+  "collapsed": true,
+  "link": {
+    "type": "doc",
+    "id": "operator-guides/integrations/index"
+  }
+}

--- a/docs/operator-guides/integrations/index.md
+++ b/docs/operator-guides/integrations/index.md
@@ -1,38 +1,16 @@
-# Integrations
+# Third-Party Integrations
 
-Michelangelo runs alongside the ML infrastructure your organization already has. This page is the operator reference for connecting external systems and extending Michelangelo's built-in components. It targets platform engineers responsible for running Michelangelo in production.
+This section covers connecting third-party tools to Michelangelo. If you are looking for documentation on Michelangelo's own components — the model registry, experiment tracking setup, serving infrastructure, or job scheduler — see the [Operator Guides index](../index.md).
 
-## Built-in Components
-
-These guides cover components that ship with Michelangelo. Operators configure them; they are not external systems.
+## Experiment Tracking
 
 | Guide | Description |
 |-------|-------------|
-| [Model Registry](model-registry.md) | Verify the registry is healthy, configure object store and RBAC, and integrate registered models with serving and CI/CD |
-
-## External System Integrations
-
-These guides cover connecting Michelangelo to systems your organization already runs.
-
-| Guide | Description |
-|-------|-------------|
-| [Experiment Tracking](experiment-tracking.md) | Expose an external experiment tracking server to task pods — network setup, URI injection, and operator/user boundary |
-| [MLflow](mlflow.md) | Connect a self-hosted or managed MLflow Tracking Server — ConfigMap injection, authentication, and registry comparison |
-
-## Extending Built-in Components
-
-Michelangelo exposes extension points for replacing or augmenting its core subsystems. Use these when the defaults don't fit your infrastructure.
-
-| Guide | Description |
-|-------|-------------|
-| [Custom Serving Backend](../serving/integrate-custom-backend.md) | Add support for any inference framework — Triton, vLLM, TensorRT-LLM, or your own |
-| [Extend the Job Scheduler](../jobs/extend-michelangelo-batch-job-scheduler-system.md) | Replace or extend the scheduler — integrate Kueue, Volcano, or implement a custom `JobQueue` and `AssignmentStrategy` |
-| [Register a Compute Cluster](../jobs/register-a-compute-cluster-to-michelangelo-control-plane.md) | Connect an existing Kubernetes cluster so Michelangelo can dispatch Ray jobs to it |
+| [Experiment Tracking Setup](../experiment-tracking.md) | Platform-level setup: network reachability, ConfigMap injection, auth, and operator/user boundary — read this before any tool-specific guide |
+| [MLflow](mlflow.md) | Connect a self-hosted or Databricks-managed MLflow Tracking Server — network setup, auth, and MLflow vs Michelangelo registry comparison |
 
 ## Next Steps
 
-- [Platform Setup](../platform-setup.md) — ConfigMap reference for all components
-- [Authentication](../authentication.md) — OIDC, RBAC, and service-to-service auth
-- [Network & Ingress](../network.md) — Ingress setup, Envoy proxy config, TLS, multi-cluster networking
-- [Monitoring](../monitoring.md) — Prometheus metrics, alerting, Grafana dashboards
-- [Troubleshooting](../troubleshooting.md) — Common failure modes and `kubectl` diagnostic commands
+- [Network & Ingress](../network.md) — Envoy proxy, ingress, TLS, and multi-cluster networking context for egress rules
+- [Authentication](../authentication.md) — secrets, workload identity, and RBAC for credential management
+- [Troubleshooting](../troubleshooting.md) — common failure modes and `kubectl` diagnostic commands

--- a/docs/operator-guides/integrations/index.md
+++ b/docs/operator-guides/integrations/index.md
@@ -2,15 +2,14 @@
 
 This section covers connecting third-party tools to Michelangelo. If you are looking for documentation on Michelangelo's own components — the model registry, experiment tracking setup, serving infrastructure, or job scheduler — see the [Operator Guides index](../index.md).
 
-## Experiment Tracking
+Before configuring any tool below, complete [Experiment Tracking Setup](../experiment-tracking.md) — the platform-level guide for network reachability, ConfigMap injection, auth, and the operator/user boundary that applies to all third-party tracking integrations.
 
 | Guide | Description |
 |-------|-------------|
-| [Experiment Tracking Setup](../experiment-tracking.md) | Platform-level setup: network reachability, ConfigMap injection, auth, and operator/user boundary — read this before any tool-specific guide |
 | [MLflow](mlflow.md) | Connect a self-hosted or Databricks-managed MLflow Tracking Server — network setup, auth, and MLflow vs Michelangelo registry comparison |
 
 ## Next Steps
 
-- [Network & Ingress](../network.md) — Envoy proxy, ingress, TLS, and multi-cluster networking context for egress rules
-- [Authentication](../authentication.md) — secrets, workload identity, and RBAC for credential management
-- [Troubleshooting](../troubleshooting.md) — common failure modes and `kubectl` diagnostic commands
+- [Network & Ingress](../network.md) — configure egress rules, Envoy proxy, ingress, TLS, and multi-cluster networking
+- [Authentication](../authentication.md) — manage secrets, workload identity, and RBAC for credential handling
+- [Troubleshooting](../troubleshooting.md) — diagnose common failure modes with `kubectl` diagnostic commands

--- a/docs/operator-guides/integrations/mlflow.md
+++ b/docs/operator-guides/integrations/mlflow.md
@@ -230,8 +230,8 @@ A `200 OK` response confirms task pods in that namespace can reach the MLflow se
 
 ## Next Steps
 
-- [Experiment Tracking Integration](experiment-tracking.md) — general guide for connecting any experiment tracking server to Michelangelo
-- [Model Registry Integration](model-registry.md) — Michelangelo's built-in model registry: storage configuration, RBAC, and serving integration
+- [Experiment Tracking Setup](../experiment-tracking.md) — platform-level setup guide: network reachability, ConfigMap injection, and auth patterns for any tracking server
+- [Model Registry](../model-registry.md) — Michelangelo's built-in model registry: storage configuration, RBAC, and serving integration
 - [Register a Compute Cluster](../jobs/register-a-compute-cluster-to-michelangelo-control-plane.md) — how to add a Kubernetes cluster so Michelangelo can dispatch jobs to it
 - [Platform Setup](../platform-setup.md) — full ConfigMap reference for all Michelangelo components
 - [MLflow Documentation](https://mlflow.org/docs/latest/) — official MLflow docs for tracking, model registry, and deployment

--- a/docs/operator-guides/integrations/mlflow.md
+++ b/docs/operator-guides/integrations/mlflow.md
@@ -1,14 +1,16 @@
-# MLflow Integration
+# MLflow
 
 This guide explains how platform operators can connect an [MLflow Tracking Server](https://mlflow.org/docs/latest/tracking.html) to Michelangelo workloads. MLflow overlaps with two Michelangelo capabilities — experiment tracking and the model registry — so this guide covers both, along with the boundary between what operators configure and what users do in their `@uniflow.task()` code.
 
 Michelangelo does not bundle an MLflow server. This guide assumes you are running a self-hosted MLflow Tracking Server or a managed endpoint (such as Databricks Managed MLflow).
 
+> **Before you begin:** Complete [Experiment Tracking Setup](../experiment-tracking.md) — the platform-level guide for network reachability, ConfigMap injection, and auth. This MLflow guide builds on those foundations.
+
 ---
 
 ## How MLflow Works with Michelangelo
 
-```
+```text
 ┌─────────────────────────────────────────────┐
 │ Operator Responsibility                     │
 │ ├─ Deploy or point to an MLflow server      │
@@ -230,7 +232,6 @@ A `200 OK` response confirms task pods in that namespace can reach the MLflow se
 
 ## Next Steps
 
-- [Experiment Tracking Setup](../experiment-tracking.md) — platform-level setup guide: network reachability, ConfigMap injection, and auth patterns for any tracking server
 - [Model Registry](../model-registry.md) — Michelangelo's built-in model registry: storage configuration, RBAC, and serving integration
 - [Register a Compute Cluster](../jobs/register-a-compute-cluster-to-michelangelo-control-plane.md) — how to add a Kubernetes cluster so Michelangelo can dispatch jobs to it
 - [Platform Setup](../platform-setup.md) — full ConfigMap reference for all Michelangelo components

--- a/docs/operator-guides/model-registry.md
+++ b/docs/operator-guides/model-registry.md
@@ -1,6 +1,6 @@
 # Model Registry
 
-Unlike experiment tracking — where operators connect an external server — Michelangelo includes a built-in model registry. This guide explains how operators verify the registry is healthy, configure storage and access, and integrate registered models with downstream serving and CI/CD systems.
+Michelangelo ships a built-in model registry — no external server required. This guide explains how operators verify the registry is healthy, configure storage and access, and integrate registered models with downstream serving and CI/CD systems.
 
 ---
 
@@ -8,7 +8,7 @@ Unlike experiment tracking — where operators connect an external server — Mi
 
 The registry separates operator and user responsibilities cleanly:
 
-```
+```text
 ┌──────────────────────────────────────────────────────────┐
 │ Operator Responsibility                                  │
 │ ├─ Provision the object store bucket and IAM policy      │
@@ -388,7 +388,7 @@ Model artifacts in S3 are not automatically removed when a `Model` resource is d
 
 | Symptom | Likely cause | Resolution |
 |---|---|---|
-| `error: the server doesn't have a resource type "models"` | CRD not installed | Re-run the Michelangelo CRD installation step (see [Platform Setup](../platform-setup.md)) |
+| `error: the server doesn't have a resource type "models"` | CRD not installed | Re-run the Michelangelo CRD installation step (see [Platform Setup](platform-setup.md)) |
 | `kubectl get models` returns `No resources found` but CRD is present | No models registered yet, or wrong namespace | Confirm a registration task has run; check the namespace |
 | `spec.model_artifact_uri` empty after registration | Controller Manager lacks S3 write permissions, or the registration task failed | Check Controller Manager logs; verify IAM policy on the bucket |
 | `spec.deployable_artifact_uri` empty | Packaging step did not run or failed | Inspect the pipeline run logs for the registration task |
@@ -400,7 +400,7 @@ For deeper diagnostic trees, see the [Troubleshooting Guide](troubleshooting.md)
 
 ---
 
-## What's Next
+## Next Steps
 
 - [Integrate a Custom Backend](serving/integrate-custom-backend.md) — configure Triton, vLLM, TensorRT-LLM, or a custom inference framework to serve registered models.
 - [Authentication and RBAC](authentication.md) — cluster-wide RBAC patterns and identity-provider setup.

--- a/docs/operator-guides/model-registry.md
+++ b/docs/operator-guides/model-registry.md
@@ -1,4 +1,4 @@
-# Model Registry Integration
+# Model Registry
 
 Unlike experiment tracking — where operators connect an external server — Michelangelo includes a built-in model registry. This guide explains how operators verify the registry is healthy, configure storage and access, and integrate registered models with downstream serving and CI/CD systems.
 
@@ -38,7 +38,7 @@ The registry is backed by a single Kubernetes Custom Resource: `Model` (CRD name
 
 Before working through this guide, ensure you have completed:
 
-- **[Platform Setup](../platform-setup.md#object-store-configuration)** — the Controller Manager's `minio.*` fields must point to a reachable S3-compatible object store.
+- **[Platform Setup](platform-setup.md#object-store-configuration)** — the Controller Manager's `minio.*` fields must point to a reachable S3-compatible object store.
 - **Compute cluster registration** — at least one compute cluster registered with the Michelangelo control plane, so Uniflow tasks have somewhere to run.
 - Sufficient cluster permissions to create Roles and RoleBindings, and to inspect Custom Resource Definitions.
 
@@ -52,7 +52,7 @@ Confirm the `Model` CRD is present in the cluster before expecting any registrat
 kubectl get crd models.michelangelo.api
 ```
 
-If the CRD is missing, re-run the Michelangelo CRD installation step described in [Platform Setup](../platform-setup.md).
+If the CRD is missing, re-run the Michelangelo CRD installation step described in [Platform Setup](platform-setup.md).
 
 You can also spot-check a namespace for any existing models:
 
@@ -136,7 +136,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ```
 
-For cluster-wide patterns and multi-tenant isolation, see [Authentication and RBAC](../authentication.md).
+For cluster-wide patterns and multi-tenant isolation, see [Authentication and RBAC](authentication.md).
 
 ---
 
@@ -396,13 +396,13 @@ Model artifacts in S3 are not automatically removed when a `Model` resource is d
 | `kubectl wait --for=condition=Ready` hangs on a Model | Model has no status conditions | Don't gate on Model conditions; use `spec.deployable_artifact_uri[0]` non-empty as the readiness signal, or wait on a downstream `InferenceServer` |
 | `InferenceServer` does not start serving | `backendType` set to lowercase string `"triton"` instead of enum value | Use `backendType: BACKEND_TYPE_TRITON` |
 
-For deeper diagnostic trees, see the [Troubleshooting Guide](../troubleshooting.md).
+For deeper diagnostic trees, see the [Troubleshooting Guide](troubleshooting.md).
 
 ---
 
 ## What's Next
 
-- [Integrate a Custom Backend](../serving/integrate-custom-backend.md) — configure Triton, vLLM, TensorRT-LLM, or a custom inference framework to serve registered models.
-- [Authentication and RBAC](../authentication.md) — cluster-wide RBAC patterns and identity-provider setup.
-- [Experiment Tracking Integration](experiment-tracking.md) — connect an external experiment tracking server to link training runs to the models they produce.
-- [Object Store Configuration](../platform-setup.md#object-store-configuration) — review the full `minio.*` configuration reference.
+- [Integrate a Custom Backend](serving/integrate-custom-backend.md) — configure Triton, vLLM, TensorRT-LLM, or a custom inference framework to serve registered models.
+- [Authentication and RBAC](authentication.md) — cluster-wide RBAC patterns and identity-provider setup.
+- [Experiment Tracking Setup](experiment-tracking.md) — connect an external experiment tracking server to link training runs to the models they produce.
+- [Object Store Configuration](platform-setup.md#object-store-configuration) — review the full `minio.*` configuration reference.

--- a/docs/operator-guides/model-registry.md
+++ b/docs/operator-guides/model-registry.md
@@ -312,7 +312,7 @@ Key fields:
 
 The `InferenceServer` controller emits these conditions: `Cleanup`, `HealthCheck`, `BackendProvision`, `ModelConfigProvision`, `Validation`. There is no `Ready` condition; gate readiness on `BackendProvision` and `ModelConfigProvision` instead.
 
-For backend selection and configuration, see [Integrate a Custom Backend](../serving/integrate-custom-backend.md).
+For backend selection and configuration, see [Integrate a Custom Backend](serving/integrate-custom-backend.md).
 
 ---
 


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**

Separates third-party tool integrations from built-in Michelangelo component docs in the operator-guides section. Moves `model-registry.md` and `experiment-tracking.md` out of `integrations/` to the operator-guides root, renames the integrations sidebar label to "Third-Party Integrations", and rewrites `integrations/index.md` to focus exclusively on external tools.

**Why?**

The `integrations/` section mixed two unrelated categories — built-in components (model registry, experiment tracking setup) and third-party tool connections (MLflow). This created confusion for operators and won't scale cleanly as more external integrations (W&B, Neptune, etc.) are added.

**How did you test it?**

No functional changes — documentation only. Link integrity verified by grepping for stale `integrations/model-registry` and `integrations/experiment-tracking` references (none found).

**Potential risks**

None. Docusaurus handles renamed `.md` files via relative links; all internal links have been updated.

**Release notes**

N/A

**Documentation Changes**

- `integrations/model-registry.md` → `operator-guides/model-registry.md` (title: "Model Registry")
- `integrations/experiment-tracking.md` → `operator-guides/experiment-tracking.md` (title: "Experiment Tracking Setup")
- `integrations/_category_.json` created with label "Third-Party Integrations"
- `integrations/index.md` rewritten: removed Built-in Components and Extending Built-in Components sections
- `operator-guides/index.md` updated with flat links to moved files
- `integrations/mlflow.md` Next Steps restored with links to moved pages