### PR TITLE
docs: developer reference — protobuf, bazel, python utilities, shell scripts, YAML config

### DIFF
--- a/docs/contributing/dev/_category_.json
+++ b/docs/contributing/dev/_category_.json
@@ -1,9 +1,9 @@
 {
-  "label": "Developer Reference",
+  "label": "Build and Tooling Reference",
   "position": 7,
   "collapsed": true,
   "link": {
     "type": "generated-index",
-    "title": "Developer Reference"
+    "title": "Build and Tooling Reference"
   }
 }

--- a/docs/contributing/dev/bazel.md
+++ b/docs/contributing/dev/bazel.md
@@ -5,7 +5,7 @@ sidebar_label: "Bazel Build System"
 
 # Bazel Build System
 
-## Why Bazel
+## Overview
 
 Michelangelo uses Bazel (version 7.4.1, see `.bazelversion`) for building all Go binaries, generating proto bindings, and running tests. Bazel's hermetic, reproducible builds mean that `bazel build` produces the same output regardless of what is installed on your machine — no implicit toolchain dependencies.
 
@@ -42,8 +42,8 @@ bazel run //go/cmd/apiserver
 # Build all proto targets
 bazel build //proto/...
 
-# Run all Go tests
-bazel test //go/...
+# Run all Go and proto tests (matches CI)
+bazel test //go/... //proto/... --build_tests_only
 
 # Update Bazel module dependencies
 bazel mod tidy

--- a/docs/contributing/dev/bazel.md
+++ b/docs/contributing/dev/bazel.md
@@ -1,0 +1,79 @@
+---
+sidebar_position: 2
+sidebar_label: "Bazel Build System"
+---
+
+# Bazel Build System
+
+## Why Bazel
+
+Michelangelo uses Bazel (version 7.4.1, see `.bazelversion`) for building all Go binaries, generating proto bindings, and running tests. Bazel's hermetic, reproducible builds mean that `bazel build` produces the same output regardless of what is installed on your machine — no implicit toolchain dependencies.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `MODULE.bazel` | Dependency declarations (Bazel modules) |
+| `BUILD.bazel` (root) | Workspace-level rules, Gazelle config, nogo linting setup |
+| `go/BUILD.bazel` | Go workspace build targets |
+| `proto/BUILD.bazel` | Proto workspace build targets |
+
+Each subdirectory that contains Go packages or proto definitions has its own `BUILD.bazel` file managed by Gazelle.
+
+## Gazelle
+
+Gazelle auto-generates and updates `BUILD.bazel` files for Go packages and proto targets. Run it after adding or removing Go files or proto files:
+
+```bash
+tools/gazelle
+```
+
+**Never manually edit Go or proto BUILD targets** — Gazelle owns them and will overwrite manual changes on the next run. Non-Go, non-proto targets (custom rules, macros) can be added to `BUILD.bazel` files alongside Gazelle-managed targets, but must be placed in sections that Gazelle will not touch.
+
+## Common Commands
+
+```bash
+# Build a specific target
+bazel build //go/cmd/apiserver
+
+# Run a binary
+bazel run //go/cmd/apiserver
+
+# Build all proto targets
+bazel build //proto/...
+
+# Run all Go tests
+bazel test //go/...
+
+# Update Bazel module dependencies
+bazel mod tidy
+```
+
+## Go + Bazel Together
+
+Go modules and Bazel modules are separate dependency systems that must be kept in sync. After changing Go dependencies with `go mod tidy`, also run:
+
+```bash
+bazel mod tidy
+```
+
+from the repo root. See [Managing Go Dependencies](../manage-go-dependencies.md) for the full workflow.
+
+## macOS Note
+
+If Bazel fails with C++ toolchain errors on macOS, set the following environment variables before running Bazel commands:
+
+```bash
+export CC=clang
+export CXX=clang++
+```
+
+Adding these to your shell profile (`.zshrc` or `.bashrc`) avoids having to set them for each session.
+
+## Related
+
+- [Managing Go Dependencies](../manage-go-dependencies.md)
+- [Building from Source](../building-michelangelo-ai-from-source.md)
+- [How to Write APIs](../how-to-write-apis.md)
+- [Protocol Buffers](protobuf.md)
+- [Shell Scripts Reference](shell-scripts.md)

--- a/docs/contributing/dev/protobuf.md
+++ b/docs/contributing/dev/protobuf.md
@@ -3,9 +3,9 @@ sidebar_position: 1
 sidebar_label: "Protocol Buffers"
 ---
 
-# Protocol Buffers in Michelangelo
+# Protocol Buffers
 
-## Role
+## Overview
 
 All Michelangelo API resources are defined in `.proto` files. The gRPC API, message types, and service contracts all live here. Proto files are the source of truth for what resources exist, what fields they have, and what operations the API server supports.
 
@@ -21,13 +21,11 @@ The `proto-go/` directory is checked into the repo for convenience (so Go tools 
 
 After editing any `.proto` file, regenerate the Go bindings:
 
-1. Edit `.proto` files in `proto/api/v2/`
+1. If creating a new service: scaffold the proto file with `tools/grpc-svc-gen.sh [Entity]`, then edit the generated file. Otherwise, edit the existing `.proto` file in `proto/api/v2/` directly.
 2. Run `tools/gazelle` to update BUILD targets
 3. Run `bazel build //proto/...` to compile
-4. Run `tools/gen-proto-go.sh` to regenerate `proto-go/` and keep it in sync
+4. Run `tools/gen-proto-go.sh` to regenerate alias `BUILD.bazel` files under `proto-go/`, sync dependency versions from `go/go.mod` into `proto-go/go.mod`, and run `go mod tidy` in `proto-go/`
 5. Check in both the `.proto` changes and the generated `proto-go/` changes
-
-Both the proto source and the generated output must be committed together so that the repo is always in a consistent state.
 
 ## Service Pattern
 

--- a/docs/contributing/dev/protobuf.md
+++ b/docs/contributing/dev/protobuf.md
@@ -1,0 +1,63 @@
+---
+sidebar_position: 1
+sidebar_label: "Protocol Buffers"
+---
+
+# Protocol Buffers in Michelangelo
+
+## Role
+
+All Michelangelo API resources are defined in `.proto` files. The gRPC API, message types, and service contracts all live here. Proto files are the source of truth for what resources exist, what fields they have, and what operations the API server supports.
+
+## Module Structure
+
+- `proto/api/v2/` — source of truth for all service and message definitions
+- `proto-go/` — generated Go bindings, **never edit directly**
+- Proto files are organized per resource type: `pipeline_svc.proto`, `project_svc.proto`, etc.
+
+The `proto-go/` directory is checked into the repo for convenience (so Go tools can consume the bindings without running Bazel), but it is always derived from `proto/api/v2/`. Any manual edits to `proto-go/` will be overwritten by the next code generation run.
+
+## Code Generation Workflow
+
+After editing any `.proto` file, regenerate the Go bindings:
+
+1. Edit `.proto` files in `proto/api/v2/`
+2. Run `tools/gazelle` to update BUILD targets
+3. Run `bazel build //proto/...` to compile
+4. Run `tools/gen-proto-go.sh` to regenerate `proto-go/` and keep it in sync
+5. Check in both the `.proto` changes and the generated `proto-go/` changes
+
+Both the proto source and the generated output must be committed together so that the repo is always in a consistent state.
+
+## Service Pattern
+
+Each ML entity (Pipeline, InferenceServer, Model, etc.) has a corresponding `*_svc.proto` file that defines a gRPC service with standard CRUD methods. For example, `pipeline_svc.proto` defines `PipelineService` with `CreatePipeline`, `GetPipeline`, `ListPipelines`, `UpdatePipeline`, and `DeletePipeline` RPCs.
+
+When adding a new API resource, follow this same pattern. The new entity gets its own `*_svc.proto` file in `proto/api/v2/`.
+
+## gRPC Service Generation
+
+Use `tools/grpc-svc-gen.sh` to scaffold a new service rather than copying and editing an existing file by hand:
+
+```bash
+tools/grpc-svc-gen.sh [EntityName]
+```
+
+Example:
+
+```bash
+tools/grpc-svc-gen.sh Pipeline
+```
+
+Run the script without arguments to see its full usage message.
+
+## Versioning
+
+All current APIs live under `proto/api/v2`. Breaking changes (field removals, type changes, incompatible method signature changes) require a new version directory (e.g., `proto/api/v3`). Additive changes (new fields, new RPCs) can go into the existing version.
+
+## Related
+
+- [How to Write APIs](../how-to-write-apis.md)
+- [Building from Source](../building-michelangelo-ai-from-source.md)
+- [Bazel Build System](bazel.md)
+- [Shell Scripts Reference](shell-scripts.md)

--- a/docs/contributing/dev/python-utilities.md
+++ b/docs/contributing/dev/python-utilities.md
@@ -1,0 +1,85 @@
+---
+sidebar_position: 3
+sidebar_label: "Python Utilities"
+---
+
+# Python Utilities and Scripts
+
+## Scope
+
+This page covers Python code in the repo that supports development workflows — tooling, linting, testing infrastructure. For the user-facing Uniflow SDK and `ma` CLI, see [Python Coding Guidelines](python/mactl/coding_guidelines.md).
+
+## Package Manager
+
+All Python work uses Poetry. The `pyproject.toml` lives in `python/`. To set up the full development environment:
+
+```bash
+cd python
+poetry install -E dev
+```
+
+## Key Python Directories
+
+| Directory | Contents |
+|-----------|---------|
+| `python/michelangelo/uniflow/` | Uniflow SDK (`@task`, `@workflow` decorators, task configs) |
+| `python/michelangelo/cli/` | `ma` CLI tool |
+| `python/michelangelo/uniflow/plugins/` | Python layer of each Uniflow plugin (RayTask, SparkTask, etc.) |
+
+## Pre-commit Hooks
+
+Pre-commit hooks are configured in `.pre-commit-config.yaml`. Hooks run ruff linting and formatting, trailing whitespace checks, and YAML validation. To run hooks manually before committing:
+
+```bash
+cd python
+poetry run pre-commit
+```
+
+To install the hooks so they run automatically on `git commit`:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+## Linting and Formatting
+
+```bash
+cd python
+poetry run ruff check path/to/file.py   # lint
+poetry run ruff format path/to/file.py  # format
+```
+
+Ruff configuration lives in `python/pyproject.toml`.
+
+## Testing Python Code
+
+```bash
+cd python
+poetry run pytest path/to/test_file.py
+```
+
+For running all tests:
+
+```bash
+cd python
+poetry run pytest
+```
+
+## Dependencies
+
+Add dependencies to `python/pyproject.toml`. Use extras (e.g., `-E ray`, `-E spark`) for optional dependencies that should not be required for all users. After changing `pyproject.toml`, regenerate the lockfile:
+
+```bash
+cd python
+poetry lock
+```
+
+Check in both `pyproject.toml` and `poetry.lock` together.
+
+## Related
+
+- [Python Coding Guidelines](python/mactl/coding_guidelines.md)
+- [Uniflow Plugin Guide](../uniflow-plugin-guide.md)
+- [Testing Strategy](../testing.md)
+- [YAML Configuration](yaml-configuration.md)

--- a/docs/contributing/dev/python-utilities.md
+++ b/docs/contributing/dev/python-utilities.md
@@ -5,7 +5,7 @@ sidebar_label: "Python Utilities"
 
 # Python Utilities and Scripts
 
-## Scope
+## Overview
 
 This page covers Python code in the repo that supports development workflows — tooling, linting, testing infrastructure. For the user-facing Uniflow SDK and `ma` CLI, see [Python Coding Guidelines](python/mactl/coding_guidelines.md).
 
@@ -28,18 +28,16 @@ poetry install -E dev
 
 ## Pre-commit Hooks
 
-Pre-commit hooks are configured in `.pre-commit-config.yaml`. Hooks run ruff linting and formatting, trailing whitespace checks, and YAML validation. To run hooks manually before committing:
+Pre-commit hooks are configured in `.pre-commit-config.yaml`. Three hooks run automatically on `git commit`: `ruff-lint` (Python linting), `ruff-format` (Python formatting), and `prettier` (formatting for JS/TS/JSON/CSS/YAML/Markdown). To run hooks manually before committing:
 
 ```bash
-cd python
-poetry run pre-commit
+cd python && poetry run pre-commit run --all-files
 ```
 
 To install the hooks so they run automatically on `git commit`:
 
 ```bash
-pip install pre-commit
-pre-commit install
+cd python && poetry run pre-commit install
 ```
 
 ## Linting and Formatting
@@ -56,14 +54,8 @@ Ruff configuration lives in `python/pyproject.toml`.
 
 ```bash
 cd python
-poetry run pytest path/to/test_file.py
-```
-
-For running all tests:
-
-```bash
-cd python
-poetry run pytest
+poetry run pytest                        # all tests
+poetry run pytest path/to/test_file.py   # single file
 ```
 
 ## Dependencies

--- a/docs/contributing/dev/shell-scripts.md
+++ b/docs/contributing/dev/shell-scripts.md
@@ -14,25 +14,26 @@ Shell scripts in `tools/` automate code generation and development workflows. Th
 | Script | Purpose | When to run |
 |--------|---------|-------------|
 | `tools/gen-proto-go.sh` | Regenerates `proto-go/` from `.proto` sources | After any `.proto` file change |
+| `tools/gen-grpc-client.sh` | Generates gRPC client code (Python and JavaScript) from protobuf files | After proto changes that affect client stubs |
 | `tools/grpc-svc-gen.sh [Entity]` | Scaffolds a new gRPC service definition for a CRD type | When adding a new API resource |
 | `tools/gazelle` | Updates Bazel BUILD files for Go packages and proto targets | After adding/removing Go files or proto definitions |
+| `tools/goimports` | Bazel wrapper that runs goimports for Go import formatting | When reformatting Go imports |
+| `tools/mamockgen` | Generates mocks for specified Go interfaces (invoked via `go generate`) | When adding or updating interface mocks |
 | `tools/test/generate-certs.sh` | Generates test certificates | For local TLS testing |
 
 ## gen-proto-go.sh
-
-Builds `//proto/...` with Bazel, copies the generated `.pb.go` files into `proto-go/`, syncs dependency versions from `go/go.mod` into `proto-go/go.mod`, and runs `go mod tidy` in `proto-go/`.
-
-Always run this after editing `.proto` files and check in both the proto change and the generated output together:
 
 ```bash
 tools/gen-proto-go.sh
 ```
 
+Builds `//proto/...` with Bazel, copies the generated `.pb.go` files into `proto-go/`, generates alias `BUILD.bazel` files under `proto-go/`, syncs dependency versions from `go/go.mod` into `proto-go/go.mod`, and runs `go mod tidy` in `proto-go/`.
+
+Check in both the proto change and the generated output together.
+
 See [Protocol Buffers](protobuf.md) for the full code generation workflow.
 
 ## grpc-svc-gen.sh
-
-Takes an entity name (e.g., `Pipeline`) and generates the scaffolding for a new gRPC service definition. This is the starting point when adding a new API resource type.
 
 ```bash
 tools/grpc-svc-gen.sh [EntityName]
@@ -48,13 +49,35 @@ Run without arguments to see the full usage message.
 
 ## gazelle
 
-A symlink to the Bazel-managed Gazelle binary. Scans Go packages and proto directories and updates BUILD targets. Run from the repo root:
-
 ```bash
 tools/gazelle
 ```
 
 See [Bazel Build System](bazel.md) for context on when to run Gazelle.
+
+## gen-grpc-client.sh
+
+```bash
+tools/gen-grpc-client.sh
+```
+
+Generates gRPC client stubs for Python and JavaScript from the compiled proto definitions. Run this after proto changes when client-side stubs need to be regenerated.
+
+## goimports
+
+```bash
+tools/goimports [flags] [files]
+```
+
+A Bazel wrapper that runs `goimports` (`@org_golang_x_tools//cmd/goimports`) on Go files. Use it to format Go imports consistently without requiring a separate goimports installation.
+
+## mamockgen
+
+```bash
+go generate ./...
+```
+
+`mamockgen` is invoked via `go generate` directives. It reads the `GOPACKAGE` and `GOFILE` environment variables set by `go generate` and produces mock implementations for each interface listed as an argument. Generated mocks are written to a `<package>mocks/` directory alongside the source file.
 
 ## Conventions
 

--- a/docs/contributing/dev/shell-scripts.md
+++ b/docs/contributing/dev/shell-scripts.md
@@ -1,0 +1,70 @@
+---
+sidebar_position: 4
+sidebar_label: "Shell Scripts"
+---
+
+# Shell Scripts Reference
+
+## Overview
+
+Shell scripts in `tools/` automate code generation and development workflows. They are not general-purpose utilities — each has a specific, documented purpose and is designed to be run at a particular point in a development workflow.
+
+## Script Reference
+
+| Script | Purpose | When to run |
+|--------|---------|-------------|
+| `tools/gen-proto-go.sh` | Regenerates `proto-go/` from `.proto` sources | After any `.proto` file change |
+| `tools/grpc-svc-gen.sh [Entity]` | Scaffolds a new gRPC service definition for a CRD type | When adding a new API resource |
+| `tools/gazelle` | Updates Bazel BUILD files for Go packages and proto targets | After adding/removing Go files or proto definitions |
+| `tools/test/generate-certs.sh` | Generates test certificates | For local TLS testing |
+
+## gen-proto-go.sh
+
+Builds `//proto/...` with Bazel, copies the generated `.pb.go` files into `proto-go/`, syncs dependency versions from `go/go.mod` into `proto-go/go.mod`, and runs `go mod tidy` in `proto-go/`.
+
+Always run this after editing `.proto` files and check in both the proto change and the generated output together:
+
+```bash
+tools/gen-proto-go.sh
+```
+
+See [Protocol Buffers](protobuf.md) for the full code generation workflow.
+
+## grpc-svc-gen.sh
+
+Takes an entity name (e.g., `Pipeline`) and generates the scaffolding for a new gRPC service definition. This is the starting point when adding a new API resource type.
+
+```bash
+tools/grpc-svc-gen.sh [EntityName]
+```
+
+Example:
+
+```bash
+tools/grpc-svc-gen.sh Pipeline
+```
+
+Run without arguments to see the full usage message.
+
+## gazelle
+
+A symlink to the Bazel-managed Gazelle binary. Scans Go packages and proto directories and updates BUILD targets. Run from the repo root:
+
+```bash
+tools/gazelle
+```
+
+See [Bazel Build System](bazel.md) for context on when to run Gazelle.
+
+## Conventions
+
+- Scripts use bash.
+- Each script includes a usage message — run any script without arguments to see it.
+- Scripts are self-contained: there is no shared shell function library. Each script carries everything it needs.
+- Do not add shared utilities across scripts; keep them independent.
+
+## Related
+
+- [How to Write APIs](../how-to-write-apis.md)
+- [Bazel Build System](bazel.md)
+- [Protocol Buffers](protobuf.md)

--- a/docs/contributing/dev/yaml-configuration.md
+++ b/docs/contributing/dev/yaml-configuration.md
@@ -1,0 +1,80 @@
+---
+sidebar_position: 5
+sidebar_label: "YAML Configuration"
+---
+
+# YAML Configuration Reference
+
+## Overview
+
+YAML is used throughout the repo for build configuration, CI/CD pipelines, linting rules, and Kubernetes manifests. This page catalogs the key files and their purposes so contributors know where to look when modifying tooling or deployment configuration.
+
+## Configuration Files
+
+| File | Purpose |
+|------|---------|
+| `.pre-commit-config.yaml` | Pre-commit hook definitions — ruff lint/format, trailing whitespace, YAML validation |
+| `go/.golangci.yml` | Go linting rules for golangci-lint: enabled linters, per-linter settings, excluded paths |
+| `.github/codecov.yml` | Codecov settings for test coverage reporting |
+| `.github/workflows/` | GitHub Actions CI/CD pipelines — build, test, lint, docs |
+| `.bazelversion` | Pins the Bazel version for the repo (currently 7.4.1) |
+
+## Go Linting (golangci-lint)
+
+Go linting is configured in `go/.golangci.yml`. Key enabled linters:
+
+- `godox` — enforces `TODO(#issue)` format (TODOs without an issue number fail CI)
+- `gofmt` — formatting check
+- `govet` — Go vet checks
+- `errcheck` — enforces that errors are not silently discarded
+
+To run golangci-lint locally:
+
+```bash
+cd go
+golangci-lint run ./...
+```
+
+Requires golangci-lint to be installed. See the [golangci-lint installation docs](https://golangci-lint.run/welcome/install/) for options.
+
+## Pre-commit
+
+`.pre-commit-config.yaml` runs automatically on `git commit` if pre-commit is installed. Hooks include ruff lint and format checks for Python, trailing whitespace removal, and YAML syntax validation.
+
+To install and activate:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+For manual runs without committing:
+
+```bash
+cd python
+poetry run pre-commit
+```
+
+See [Python Utilities](python-utilities.md) for more on the Python tooling setup.
+
+## Kubernetes Manifests
+
+Kubernetes resource definitions (Deployments, Services, ConfigMaps) for local sandbox setup live in `python/michelangelo/sandbox/`. These are applied by `sandbox.py` via `kubectl apply` during `ma sandbox create`. Modifying these files changes what gets deployed when a contributor creates a local sandbox.
+
+## Helm Chart Values
+
+The Michelangelo Helm chart lives in `helm/michelangelo/`. Key files:
+
+| File | Purpose |
+|------|---------|
+| `helm/michelangelo/values.yaml` | Production defaults |
+| `helm/michelangelo/values-k3d.yaml` | Local k3d overrides for development |
+
+See the [Platform Setup guide](../../operator-guides/platform-setup.md) for Helm configuration details.
+
+## Related
+
+- [Building from Source](../building-michelangelo-ai-from-source.md)
+- [Bazel Build System](bazel.md)
+- [Python Utilities](python-utilities.md)
+- [Platform Setup](../../operator-guides/platform-setup.md)

--- a/docs/contributing/dev/yaml-configuration.md
+++ b/docs/contributing/dev/yaml-configuration.md
@@ -13,7 +13,7 @@ YAML is used throughout the repo for build configuration, CI/CD pipelines, linti
 
 | File | Purpose |
 |------|---------|
-| `.pre-commit-config.yaml` | Pre-commit hook definitions — ruff lint/format, trailing whitespace, YAML validation |
+| `.pre-commit-config.yaml` | Pre-commit hook definitions — ruff lint, ruff format, prettier |
 | `go/.golangci.yml` | Go linting rules for golangci-lint: enabled linters, per-linter settings, excluded paths |
 | `.github/codecov.yml` | Codecov settings for test coverage reporting |
 | `.github/workflows/` | GitHub Actions CI/CD pipelines — build, test, lint, docs |
@@ -21,12 +21,7 @@ YAML is used throughout the repo for build configuration, CI/CD pipelines, linti
 
 ## Go Linting (golangci-lint)
 
-Go linting is configured in `go/.golangci.yml`. Key enabled linters:
-
-- `godox` — enforces `TODO(#issue)` format (TODOs without an issue number fail CI)
-- `gofmt` — formatting check
-- `govet` — Go vet checks
-- `errcheck` — enforces that errors are not silently discarded
+Go linting is configured in `go/.golangci.yml`. All linters are disabled except `godox`, which enforces that every TODO/FIXME comment references a GitHub issue number (`TODO(#123): description`). TODOs without an issue reference fail CI.
 
 To run golangci-lint locally:
 
@@ -39,27 +34,25 @@ Requires golangci-lint to be installed. See the [golangci-lint installation docs
 
 ## Pre-commit
 
-`.pre-commit-config.yaml` runs automatically on `git commit` if pre-commit is installed. Hooks include ruff lint and format checks for Python, trailing whitespace removal, and YAML syntax validation.
+`.pre-commit-config.yaml` runs automatically on `git commit` if pre-commit is installed. Three hooks are defined: `ruff-lint` (Python linting), `ruff-format` (Python formatting), and `prettier` (formatter for JS/TS/JSON/CSS/YAML/Markdown).
 
-To install and activate:
+To install and activate (assumes `poetry install -E dev` has been run — see [Python Utilities](python-utilities.md)):
 
 ```bash
-pip install pre-commit
-pre-commit install
+cd python && poetry run pre-commit install
 ```
 
 For manual runs without committing:
 
 ```bash
-cd python
-poetry run pre-commit
+cd python && poetry run pre-commit run --all-files
 ```
 
 See [Python Utilities](python-utilities.md) for more on the Python tooling setup.
 
 ## Kubernetes Manifests
 
-Kubernetes resource definitions (Deployments, Services, ConfigMaps) for local sandbox setup live in `python/michelangelo/sandbox/`. These are applied by `sandbox.py` via `kubectl apply` during `ma sandbox create`. Modifying these files changes what gets deployed when a contributor creates a local sandbox.
+Kubernetes resource definitions (Deployments, Services, ConfigMaps) for local sandbox setup live in `python/michelangelo/cli/sandbox/resources/`. These are applied by `sandbox.py` via `kubectl apply` during `ma sandbox create`. Modifying these files changes what gets deployed when a contributor creates a local sandbox.
 
 ## Helm Chart Values
 
@@ -70,11 +63,11 @@ The Michelangelo Helm chart lives in `helm/michelangelo/`. Key files:
 | `helm/michelangelo/values.yaml` | Production defaults |
 | `helm/michelangelo/values-k3d.yaml` | Local k3d overrides for development |
 
-See the [Platform Setup guide](../../operator-guides/setup/platform-setup.md) for Helm configuration details.
+See the [Platform Setup guide](../../operator-guides/platform-setup.md) for Helm configuration details.
 
 ## Related
 
 - [Building from Source](../building-michelangelo-ai-from-source.md)
 - [Bazel Build System](bazel.md)
 - [Python Utilities](python-utilities.md)
-- [Platform Setup](../../operator-guides/setup/platform-setup.md)
+- [Platform Setup](../../operator-guides/platform-setup.md)

--- a/docs/contributing/dev/yaml-configuration.md
+++ b/docs/contributing/dev/yaml-configuration.md
@@ -70,11 +70,11 @@ The Michelangelo Helm chart lives in `helm/michelangelo/`. Key files:
 | `helm/michelangelo/values.yaml` | Production defaults |
 | `helm/michelangelo/values-k3d.yaml` | Local k3d overrides for development |
 
-See the [Platform Setup guide](../../operator-guides/platform-setup.md) for Helm configuration details.
+See the [Platform Setup guide](../../operator-guides/setup/platform-setup.md) for Helm configuration details.
 
 ## Related
 
 - [Building from Source](../building-michelangelo-ai-from-source.md)
 - [Bazel Build System](bazel.md)
 - [Python Utilities](python-utilities.md)
-- [Platform Setup](../../operator-guides/platform-setup.md)
+- [Platform Setup](../../operator-guides/setup/platform-setup.md)

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -81,6 +81,16 @@ For changes to the API server, controller manager, worker, or shared components.
 → **[Managing Go Dependencies](manage-go-dependencies.md)** — `go mod tidy` + `bazel mod tidy`
 → **[Using Go Mocks in Tests](use-go-mocks-in-unit-test.md)** — gomock patterns
 
+### Developer Reference
+
+Language and tooling reference for contributors.
+
+→ **[Protocol Buffers](dev/protobuf.md)** — proto module structure, code generation, service patterns
+→ **[Bazel Build System](dev/bazel.md)** — BUILD files, Gazelle, common commands
+→ **[Python Utilities](dev/python-utilities.md)** — Poetry setup, linting, testing Python code
+→ **[Shell Scripts](dev/shell-scripts.md)** — tools/ script reference
+→ **[YAML Configuration](dev/yaml-configuration.md)** — linting, CI, Kubernetes manifests, Helm values
+
 ### Python SDK changes
 For changes to the Uniflow decorators, task types, or the `ma` CLI.
 

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -81,7 +81,7 @@ For changes to the API server, controller manager, worker, or shared components.
 → **[Managing Go Dependencies](manage-go-dependencies.md)** — `go mod tidy` + `bazel mod tidy`
 → **[Using Go Mocks in Tests](use-go-mocks-in-unit-test.md)** — gomock patterns
 
-### Developer Reference
+### Build and tooling reference
 
 Language and tooling reference for contributors.
 


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**

Adds five new developer reference pages under `docs/contributing/dev/` covering the tools and languages used across the Michelangelo codebase: Protocol Buffers, Bazel build system, Python utilities, shell scripts, and YAML configuration. Adds a new "Developer Reference" section to `docs/contributing/index.md` linking to all five pages.

**Why?**

Closes #764, #765, #766, #767, #770. These five areas had no dedicated contributor documentation. Contributors working on proto definitions, Bazel BUILD files, or Python tooling had to piece together context from README files, build scripts, and tribal knowledge. Each new page consolidates that scattered information into a scannable reference with common commands, key file locations, and links to deeper guides.

**How did you test it?**

Documentation only. `bun run build` passes with no broken link warnings. Internal links between new pages and existing guides manually verified.

**Potential risks**

None. All new files — no existing content removed or renamed.

**Release notes**

N/A

**Documentation Changes**

- `docs/contributing/dev/protobuf.md` — new: proto module structure, 5-step code generation workflow, service patterns, versioning
- `docs/contributing/dev/bazel.md` — new: key files, Gazelle ownership rules, common commands, Go+Bazel sync workflow
- `docs/contributing/dev/python-utilities.md` — new: Poetry setup, key directories, pre-commit, ruff lint/format, pytest
- `docs/contributing/dev/shell-scripts.md` — new: reference table for all `tools/` scripts with usage detail
- `docs/contributing/dev/yaml-configuration.md` — new: config file catalog, golangci-lint, pre-commit, Kubernetes manifests, Helm values
- `docs/contributing/index.md` — added "Developer Reference" section linking to all five new pages