### PR TITLE
website: update landing page hero copy and add stats bar

### DIFF
--- a/website/src/components/Landing/AnimatedText.tsx
+++ b/website/src/components/Landing/AnimatedText.tsx
@@ -5,7 +5,7 @@ const phrases = [
   'Python-First: Native developer experience.',
   'Rapid Development: Near-zero learning curve and instant iteration.',
   '3rd-party Integrations: Pluggable architecture for the modern ML stack.',
-  'Battle tested.',
+  'Battle Tested: A decade in production at Uber.',
 ];
 
 export default function AnimatedText(): React.ReactElement {

--- a/website/src/components/Landing/AnimatedText.tsx
+++ b/website/src/components/Landing/AnimatedText.tsx
@@ -2,10 +2,10 @@ import React, {useState, useEffect} from 'react';
 import styles from '../../css/landing.module.css';
 
 const phrases = [
-  'Feature Management',
-  'Model Training',
-  'Model Deployment',
-  'Production Monitoring',
+  'Python-First: Native developer experience.',
+  'Rapid Development: Near-zero learning curve and instant iteration.',
+  '3rd-party Integrations: Pluggable architecture for the modern ML stack.',
+  'Battle tested.',
 ];
 
 export default function AnimatedText(): React.ReactElement {

--- a/website/src/components/Landing/AnimatedText.tsx
+++ b/website/src/components/Landing/AnimatedText.tsx
@@ -2,10 +2,10 @@ import React, {useState, useEffect} from 'react';
 import styles from '../../css/landing.module.css';
 
 const phrases = [
-  'Python-First: Native developer experience.',
-  'Rapid Development: Near-zero learning curve and instant iteration.',
-  '3rd-party Integrations: Pluggable architecture for the modern ML stack.',
-  'Battle Tested: A decade in production at Uber.',
+  'Python-native.',
+  'Ship faster.',
+  'Plug in anything.',
+  'Uber-proven.',
 ];
 
 export default function AnimatedText(): React.ReactElement {

--- a/website/src/components/Landing/CodeExample.tsx
+++ b/website/src/components/Landing/CodeExample.tsx
@@ -121,7 +121,7 @@ export default function CodeExample(): React.ReactElement {
       <div className={styles.codeExampleContainer}>
         <h2 className={styles.codeExampleTitle}>Simple, powerful API</h2>
         <p className={styles.codeExampleSubtitle}>
-          From training to production in minutes, not months
+          From training to production in minutes
         </p>
 
         <div className={styles.codeBlock}>

--- a/website/src/components/Landing/Features.tsx
+++ b/website/src/components/Landing/Features.tsx
@@ -40,6 +40,7 @@ const features: Feature[] = [
     description:
       'Real-time model monitoring with drift detection, alerting, and observability for production ML systems.',
     icon: <EyeIcon />,
+    comingSoon: true,
   },
 ];
 

--- a/website/src/components/Landing/Features.tsx
+++ b/website/src/components/Landing/Features.tsx
@@ -5,6 +5,7 @@ interface Feature {
   title: string;
   description: string;
   icon: React.ReactNode;
+  comingSoon?: boolean;
 }
 
 const features: Feature[] = [
@@ -13,6 +14,7 @@ const features: Feature[] = [
     description:
       'Centralized feature store with versioning, lineage tracking, and real-time serving for consistent ML features across training and inference.',
     icon: <DatabaseIcon />,
+    comingSoon: true,
   },
   {
     title: 'Model Training',
@@ -25,6 +27,7 @@ const features: Feature[] = [
     description:
       'Comprehensive model evaluation with automated metrics, A/B testing, and performance benchmarking across datasets.',
     icon: <ChartIcon />,
+    comingSoon: true,
   },
   {
     title: 'Deployment',
@@ -35,7 +38,7 @@ const features: Feature[] = [
   {
     title: 'Monitoring',
     description:
-      'Real-time model monitoring with drift detection, alerting, and observability for production ML systems.',
+      'Model observability with Prometheus metrics, alerting rules, Grafana dashboards, and structured logging for production ML systems.',
     icon: <EyeIcon />,
   },
 ];
@@ -101,7 +104,12 @@ function FeatureCard({
       style={{transitionDelay: `${index * 100}ms`}}
     >
       <div className={styles.featureIcon}>{feature.icon}</div>
-      <h3 className={styles.featureTitle}>{feature.title}</h3>
+      <div className={styles.featureTitleRow}>
+        <h3 className={styles.featureTitle}>{feature.title}</h3>
+        {feature.comingSoon && (
+          <span className={styles.comingSoonBadge}>Coming Soon</span>
+        )}
+      </div>
       <p className={styles.featureDescription}>{feature.description}</p>
     </div>
   );

--- a/website/src/components/Landing/Features.tsx
+++ b/website/src/components/Landing/Features.tsx
@@ -38,7 +38,7 @@ const features: Feature[] = [
   {
     title: 'Monitoring',
     description:
-      'Model observability with Prometheus metrics, alerting rules, Grafana dashboards, and structured logging for production ML systems.',
+      'Real-time model monitoring with drift detection, alerting, and observability for production ML systems.',
     icon: <EyeIcon />,
   },
 ];

--- a/website/src/components/Landing/Hero.tsx
+++ b/website/src/components/Landing/Hero.tsx
@@ -16,16 +16,12 @@ export default function Hero(): React.ReactElement {
           alt="Michelangelo logo"
         />
         <h1 className={styles.heroTitle}>
-          ML at Scale.
-          <br />
-          <span className={styles.heroTitleAccent}>Open Source.</span>
+          The ML Platform Behind Uber&apos;s AI.
         </h1>
         <p className={styles.heroSubtitle}>
-          The end-to-end platform for building, deploying, and monitoring ML
-          models
+          Open source and production-ready.
         </p>
         <div className={styles.heroTagline}>
-          <span className={styles.heroTaglinePrefix}>Built for</span>{' '}
           <AnimatedText />
         </div>
         <div className={styles.heroCtas}>

--- a/website/src/components/Landing/Stats.tsx
+++ b/website/src/components/Landing/Stats.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import styles from '../../css/landing.module.css';
+
+const stats = [
+  {value: '400+', label: 'Active ML projects'},
+  {value: '20K+', label: 'Model training jobs / month'},
+  {value: '5K+', label: 'Models in production'},
+  {value: '45M+', label: 'Real-time predictions / sec (peak)'},
+];
+
+export default function Stats(): React.ReactElement {
+  return (
+    <section className={styles.statsBar}>
+      {stats.map(({value, label}) => (
+        <div key={label} className={styles.statItem}>
+          <span className={styles.statValue}>{value}</span>
+          <span className={styles.statLabel}>{label}</span>
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/website/src/components/Landing/Stats.tsx
+++ b/website/src/components/Landing/Stats.tsx
@@ -11,12 +11,15 @@ const stats = [
 export default function Stats(): React.ReactElement {
   return (
     <section className={styles.statsBar}>
-      {stats.map(({value, label}) => (
-        <div key={label} className={styles.statItem}>
-          <span className={styles.statValue}>{value}</span>
-          <span className={styles.statLabel}>{label}</span>
-        </div>
-      ))}
+      <p className={styles.statsHeadline}>Proven at Uber Scale</p>
+      <div className={styles.statsRow}>
+        {stats.map(({value, label}) => (
+          <div key={label} className={styles.statItem}>
+            <span className={styles.statValue}>{value}</span>
+            <span className={styles.statLabel}>{label}</span>
+          </div>
+        ))}
+      </div>
     </section>
   );
 }

--- a/website/src/css/landing.module.css
+++ b/website/src/css/landing.module.css
@@ -62,11 +62,27 @@
 /* Stats Bar */
 .statsBar {
   display: flex;
-  justify-content: center;
-  gap: 0;
+  flex-direction: column;
+  align-items: center;
   background: #0f0f0f;
   padding: 48px 24px;
+}
+
+.statsHeadline {
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.4);
+  margin: 0 0 36px;
+}
+
+.statsRow {
+  display: flex;
+  justify-content: center;
   flex-wrap: wrap;
+  gap: 0;
+  width: 100%;
 }
 
 .statItem {
@@ -330,11 +346,32 @@
   color: #ffffff;
 }
 
+.featureTitleRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 0.75rem;
+  flex-wrap: wrap;
+}
+
 .featureTitle {
   font-size: 1.25rem;
   font-weight: 600;
-  margin-bottom: 0.75rem;
+  margin: 0;
   color: var(--ifm-font-color-base);
+}
+
+.comingSoonBadge {
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ifm-color-primary);
+  border: 1px solid var(--ifm-color-primary);
+  border-radius: 4px;
+  padding: 2px 6px;
+  white-space: nowrap;
+  opacity: 0.8;
 }
 
 .featureDescription {

--- a/website/src/css/landing.module.css
+++ b/website/src/css/landing.module.css
@@ -59,6 +59,61 @@
   }
 }
 
+/* Stats Bar */
+.statsBar {
+  display: flex;
+  justify-content: center;
+  gap: 0;
+  background: #0f0f0f;
+  padding: 48px 24px;
+  flex-wrap: wrap;
+}
+
+.statItem {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0 48px;
+  border-right: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.statItem:last-child {
+  border-right: none;
+}
+
+.statValue {
+  font-size: 2.75rem;
+  font-weight: 700;
+  color: #ffffff;
+  line-height: 1;
+  letter-spacing: -0.02em;
+}
+
+.statLabel {
+  margin-top: 8px;
+  font-size: 0.875rem;
+  color: rgba(255, 255, 255, 0.55);
+  text-align: center;
+  letter-spacing: 0.01em;
+}
+
+@media (max-width: 768px) {
+  .statItem {
+    padding: 20px 24px;
+    border-right: none;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    width: 50%;
+  }
+
+  .statItem:nth-child(odd) {
+    border-right: 1px solid rgba(255, 255, 255, 0.12);
+  }
+
+  .statItem:last-child {
+    border-bottom: none;
+  }
+}
+
 /* Hero Section */
 .hero {
   min-height: calc(100vh - 60px);

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import Layout from '@theme/Layout';
 import GradientBackground from '../components/Landing/GradientBackground';
 import Hero from '../components/Landing/Hero';
+import Stats from '../components/Landing/Stats';
 import Features from '../components/Landing/Features';
 import CodeExample from '../components/Landing/CodeExample';
 import styles from '../css/landing.module.css';
@@ -16,12 +17,13 @@ export default function Home(): React.ReactElement {
 
   return (
     <Layout
-      title="ML at Scale. Open Source."
-      description="The end-to-end platform for building, deploying, and monitoring ML models"
+      title="The ML Platform Behind Uber's AI"
+      description="Open source and production-ready."
     >
       <main className={styles.landing}>
         <GradientBackground />
         <Hero />
+        <Stats />
         <Features />
         <CodeExample />
       </main>


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**

Two landing page updates: (1) Hero copy sharpened to lead with the Uber proof point — headline becomes "The ML Platform Behind Uber's AI.", subtitle "Open source and production-ready.", and the AnimatedText typewriter cycles through differentiated value props instead of generic ML capabilities. (2) New Stats bar component inserted between Hero and Features — a dark full-width band showing Uber-scale numbers (400+ projects, 20K+ training jobs/mo, 5K+ models in production, 45M+ predictions/sec peak).

**Why?**

The previous headline ("ML at Scale. Open Source.") is generic and does not differentiate Michelangelo. The Uber scale stats are the strongest credibility signal available and should be above the fold.

**How did you test it?**

Type check passes. UI review via dev server.

**Potential risks**

None — UI-only changes, no API or data changes.

**Release notes**

N/A

**Documentation Changes**

N/A