### PR TITLE
docs: review polish for Go key concepts page (stacked on #1185)

### DIFF
--- a/docs/contributing/building-michelangelo-ai-from-source.md
+++ b/docs/contributing/building-michelangelo-ai-from-source.md
@@ -195,5 +195,9 @@ $ poetry run ruff format $PYTHON_FILE_NAME
 
 For IDE configuration (VS Code, Cursor, GoLand), see the [IDE and Bazel Setup Guide](./dev-environment.md).
 
+## Related
+
+- [Go Key Concepts and Terms](dev/go/key-concepts-and-terms.md) — package map, key types, and patterns for the Go backend
+
 
 

--- a/docs/contributing/dev/go/code-style.md
+++ b/docs/contributing/dev/go/code-style.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 2
+---
+
 # Go Code Style Guide
 
 This guide covers Go code conventions used across the Michelangelo codebase. It complements the [error handling guide](error-handling.md) with broader patterns: package structure, interface design, logging, and test organization.
@@ -287,7 +291,7 @@ func TestValidateModelName(t *testing.T) {
 
 ## Related
 
-- [Go Key Concepts & Terms](key-concepts-and-terms.md) — package structure, key types, patterns, and terminology
+- [Go Key Concepts and Terms](key-concepts-and-terms.md) — package map, key types, patterns, and terminology
 - [Error Handling](error-handling.md) — error wrapping, logging strategy, PR review checklist
 - [Using Go Mocks in Unit Tests](../../use-go-mocks-in-unit-test.md) — mock generation and usage
 - [Managing Go Dependencies](../../manage-go-dependencies.md) — `go mod tidy`, `bazel mod tidy`

--- a/docs/contributing/dev/go/error-handling.md
+++ b/docs/contributing/dev/go/error-handling.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 3
+---
+
 # Golang Error Handling Code Review Checklist
 
 ## Core Principles
@@ -450,6 +454,6 @@ func validateInput(input string) error {
 
 ## Related
 
-- [Go Key Concepts & Terms](key-concepts-and-terms.md) — package structure, key types, patterns, and Starlark execution model
+- [Go Key Concepts and Terms](key-concepts-and-terms.md) — package map, key types, patterns, and terminology
 - [Code Style Guide](code-style.md) — package naming, interface design, logging conventions, test organization
 - [Uniflow Plugin Guide](../../uniflow-plugin-guide.md) — how to build a new Go worker plugin

--- a/docs/contributing/dev/go/key-concepts-and-terms.md
+++ b/docs/contributing/dev/go/key-concepts-and-terms.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-sidebar_label: "Key Concepts & Terms"
+sidebar_label: "Key Concepts and Terms"
 ---
 
 # Go Key Concepts and Terms
@@ -11,7 +11,7 @@ This page is the entry point for contributors working on the Go backend. It maps
 
 ## Codebase Role
 
-Go is the primary backend language — approximately 283K lines, 71% of the codebase. It implements the three main server-side services: API server, controller manager, and worker. The Python SDK and CLI are thin clients; all persistent state and compute orchestration runs in Go.
+Go is the primary backend language — approximately 299K lines of the codebase. It implements the three main server-side services: API server, controller manager, and worker. The Python SDK and CLI are thin clients; all persistent state and compute orchestration runs in Go.
 
 ---
 
@@ -22,19 +22,20 @@ go/
 ├── cmd/                      # Binary entry points — one subdirectory per binary
 │   ├── apiserver/            # gRPC API server
 │   ├── controllermgr/        # Kubernetes controller manager
-│   └── worker/               # Temporal/Cadence workflow and activity workers
+│   └── worker/               # Cadence workflow and activity workers
 ├── components/               # Reusable packages with business logic
 │   ├── inferenceserver/      # InferenceServer reconciliation, backends, endpoints
 │   │   └── backends/         # Backend interface + registry + implementations (Triton, vLLM)
-│   ├── scheduler/            # Job scheduling abstraction (Kueue, Volcano)
 │   ├── jobs/                 # Ray and Spark job client logic
+│   │   └── scheduler/        # Job scheduling abstraction and AssignmentStrategy framework
 │   ├── pipelinerun/          # PipelineRun actors and workflow execution
 │   └── ingester/             # Data ingestion, finalizer logic
-├── gen/                      # Generated code — never edit
 ├── storage/                  # Database access (MySQL)
 └── worker/
     └── plugins/              # Uniflow worker plugins (Ray, Spark, Pipeline)
 ```
+
+Other top-level directories include `api/`, `auth/`, `base/`, `kubeproto/`, `logging/`, and `thirdparty/`.
 
 **Rule:** `cmd/` packages wire dependencies and call into `components/`. Business logic belongs in `components/`, not `cmd/`. See [Code Style Guide](code-style.md) for package naming and interface design conventions.
 
@@ -44,15 +45,15 @@ go/
 
 ### API Server (`go/cmd/apiserver/`)
 
-Central gRPC server that acts as the control plane API. It validates resources, stores them as Kubernetes Custom Resource Definitions (CRDs) via the Kubernetes API, and invokes registered API hooks on mutating operations. All Michelangelo resources (InferenceServer, Pipeline, Job, etc.) flow through the API server before being persisted.
+Central gRPC server that acts as the control plane API. It validates resources, stores them as Kubernetes Custom Resource Definitions (CRDs) via the Kubernetes API, and invokes registered API hooks on mutating operations. All Michelangelo resources (InferenceServer, Pipeline, RayJob, SparkJob, etc.) flow through the API server before being persisted.
 
 ### Controller Manager (`go/cmd/controllermgr/`)
 
-Runs Kubernetes controllers for each ML resource type: RayCluster, SparkJob, InferenceServer, Deployment, Pipeline, and others. Each controller implements a reconcile loop that continuously brings the actual state of the cluster into alignment with the desired state stored in etcd. Controllers are the primary place where compute resources are created, updated, and deleted.
+Runs Kubernetes controllers for each ML resource type: RayCluster, SparkJob, InferenceServer, Deployment, Pipeline, PipelineRun, Ingester, and others. Each controller implements a reconcile loop that continuously brings the actual state of the cluster into alignment with the desired state stored in Kubernetes (etcd) and the metadata store (MySQL). Controllers are the primary place where compute resources are created, updated, and deleted.
 
 ### Worker (`go/cmd/worker/`, `go/worker/plugins/`)
 
-Hosts Temporal/Cadence workflow and activity workers. Uniflow plugins in `go/worker/plugins/` extend the worker with domain-specific Starlark builtins — for example, the Ray plugin exposes Ray cluster lifecycle operations as Starlark functions that can be called from a transpiled Pipeline workflow.
+Hosts Cadence workflow and activity workers. Uniflow plugins in `go/worker/plugins/` extend the worker with domain-specific Starlark builtins — for example, the Ray plugin exposes Ray cluster lifecycle operations as Starlark functions that can be called from a transpiled Pipeline workflow.
 
 ---
 
@@ -63,10 +64,11 @@ Hosts Temporal/Cadence workflow and activity workers. Uniflow plugins in `go/wor
 | `InferenceServer` | `proto-go/api/v2/` | Protobuf resource for a deployed model serving endpoint |
 | `Pipeline` | `proto-go/api/v2/` | Protobuf resource representing a Uniflow workflow definition |
 | `PipelineRun` | `proto-go/api/v2/` | Single execution of a Pipeline; created on each submission |
-| `Job` | `proto-go/api/v2/` | Compute job resource (Ray or Spark) |
+| `RayJob` | `proto-go/api/v2/` | Compute job resource for Ray workloads |
+| `SparkJob` | `proto-go/api/v2/` | Compute job resource for Spark workloads |
 | `Backend` | `go/components/inferenceserver/backends/` | Interface for an inference framework plugin (Triton, vLLM, etc.) |
-| `JobQueue` | `go/components/scheduler/` | Interface for a job scheduling backend (Kueue, Volcano) |
-| `IPlugin` | `go/worker/plugins/` | Interface for a Uniflow worker plugin |
+| `JobQueue` | `go/components/jobs/scheduler/` | Interface for a job scheduling backend; the real extension point is `AssignmentStrategy` in `go/components/jobs/scheduler/framework/` |
+| `IPlugin` | `github.com/cadence-workflow/starlark-worker/service` | Interface for a Uniflow worker plugin (defined in the external dependency); implementations live in `go/worker/plugins/` |
 
 ---
 
@@ -76,7 +78,12 @@ Hosts Temporal/Cadence workflow and activity workers. Uniflow plugins in `go/wor
 
 Controllers implement `Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error)` from [controller-runtime](https://pkg.go.dev/sigs.k8s.io/controller-runtime). The framework calls this method whenever the observed state may differ from the desired state. Implementations must be **idempotent** — calling `Reconcile` multiple times with the same input must produce the same result without side effects.
 
+A reconcile loop typically has three phases: fetch the current resource, compare to the desired state, and actuate any required changes.
+
 ```go
+// go/components/<resource>/controller.go
+import "sigs.k8s.io/controller-runtime/pkg/log"
+
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
     logger := log.FromContext(ctx).WithValues("resource", req.NamespacedName)
     // fetch, compare, actuate — safe to call repeatedly
@@ -89,12 +96,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 Interfaces are defined in the package that uses them, not the package that implements them. This keeps dependencies pointing inward (consumer → interface, implementation → interface) and makes the consumer independently testable.
 
 ```go
-// go/components/scheduler/scheduler.go — defined where it is used
+// go/components/jobs/scheduler/scheduler.go — defined where it is used
 type JobQueue interface {
-    Enqueue(ctx context.Context, job *Job) error
-    Dequeue(ctx context.Context) (*Job, error)
+    Enqueue(ctx context.Context, job matypes.SchedulableJob) error
 }
-// Implementations (kueue/, volcano/) import scheduler, not the other way around.
+// The Scheduler struct in the same package implements this interface.
+// AssignmentStrategy (go/components/jobs/scheduler/framework/interface.go) is the extension point for custom scheduling logic.
 ```
 
 See [Code Style Guide](code-style.md#interface-design) for full interface design conventions.
@@ -105,7 +112,8 @@ Extensible subsystems (backends, schedulers, plugins) use a registry: a map from
 
 ```go
 // Registration at startup (simplified)
-registry.Register(v2pb.BackendType_TRITON, tritonBackend)
+// tritonBackend = NewTritonBackend(...)
+registry.Register(v2pb.BACKEND_TYPE_TRITON, tritonBackend)
 
 // Lookup at call time
 backend, err := registry.GetBackend(inferenceServer.Spec.BackendType)
@@ -113,35 +121,37 @@ backend, err := registry.GetBackend(inferenceServer.Spec.BackendType)
 
 ### Starlark Execution Model
 
-Python Uniflow workflows are transpiled to [Starlark](https://github.com/google/starlark-go) at submission time. The worker executes this Starlark bytecode and calls Go plugin builtins for each task step. Plugin builtins are registered as Temporal activities, so the execution is durable and resumable across worker restarts.
+Python Uniflow workflows are transpiled to [Starlark](https://pkg.go.dev/go.starlark.net/starlark) (`go.starlark.net/starlark`) at submission time. The worker executes this Starlark bytecode and calls Go plugin builtins for each task step. Plugin builtins are registered as Cadence activities, so the execution is durable and resumable across worker restarts.
 
 See [Uniflow Plugin Guide](../../uniflow-plugin-guide.md) for a full walkthrough of building a new plugin, including how to expose Go functions as Starlark builtins.
 
 ---
 
-## Terminology
+## Go-Specific Terminology
+
+For platform-wide terms (Pipeline, Workflow, Task, etc.), see [TERMINOLOGY.md](../../TERMINOLOGY.md).
 
 | Term | Meaning |
 |------|---------|
-| **Reconciler** | A Kubernetes controller that brings actual cluster state to the desired state stored in etcd. Must be idempotent. |
-| **CRD** | Custom Resource Definition — Michelangelo resources (InferenceServer, Pipeline, Job, etc.) are stored as K8s CRDs. |
+| **Uniflow** | The Python-authored workflow framework. Workflows are transpiled to Starlark and executed by the worker. |
+| **Reconciler** | A Kubernetes controller that brings actual cluster state to the desired state stored in Kubernetes (etcd) and the metadata store (MySQL). Must be idempotent. |
+| **CRD** | Custom Resource Definition — Michelangelo resources (InferenceServer, Pipeline, RayJob, SparkJob, etc.) are stored as K8s CRDs. |
 | **Finalizer** | A Kubernetes mechanism that prevents object deletion until a cleanup step completes. Used by the ingester to drain in-flight data before a resource is removed. |
-| **Activity** | A Temporal/Cadence unit of work, corresponding to a single task step in a Uniflow workflow. Activities are retried independently on failure. |
+| **Activity** | A Cadence unit of work, corresponding to a single task step in a Uniflow workflow. Activities are retried independently on failure. |
 | **Starlark** | A deterministic, Python-like scripting language used as the intermediate representation for Uniflow workflows. Determinism guarantees replay correctness. |
 | **Plugin** | A Go package in `go/worker/plugins/` that extends the Starlark execution environment with domain-specific builtins (e.g., `ray.create_cluster`). |
-| **fx** | [Uber's dependency injection framework](https://github.com/uber-go/fx) (`go.uber.org/fx`). Components declare their dependencies via `fx.Provide`, and the framework wires them at startup. |
-| **logr** | The logging interface from controller-runtime (`sigs.k8s.io/controller-runtime/pkg/log`). Used in controllers. Distinct from `go.uber.org/zap` used in most other components. |
-| **mamockgen** | Michelangelo's wrapper around `mockgen`. Generates Go mocks from interface definitions. Invoked via `//go:generate mamockgen <InterfaceName>`. |
+| **fx** | Dependency injection framework (`go.uber.org/fx`). Components declare their dependencies via `fx.Provide`, and the framework wires them at startup. |
+| **logr** | The logging interface from controller-runtime (`sigs.k8s.io/controller-runtime/pkg/log`). Used in some controllers (e.g., the ingester); other controllers and most components use `go.uber.org/zap`. |
+| **mamockgen** | Michelangelo's wrapper around `mockgen`. Generates Go mocks from interface definitions. Lives at `tools/mamockgen` in the repo. Invoked via `//go:generate mamockgen Backend` (also accepts multiple names, e.g., `//go:generate mamockgen Publisher Provider`). See [Using Go Mocks in Unit Tests](../../use-go-mocks-in-unit-test.md) for setup. |
 
 ---
 
 ## Generated Code
 
-Two directories contain generated code. Never edit files in either location — changes will be overwritten on the next generation run.
+The following directories contain auto-generated code. Edits made here will be silently overwritten the next time generation runs — make changes to the source definitions instead.
 
 | Directory | Source | Regenerate with |
 |-----------|--------|-----------------|
-| `go/gen/` | Internal tooling | Internal build targets |
 | `proto-go/` | `.proto` files in `proto/` | `tools/gen-proto-go.sh` |
 
 For adding or modifying proto definitions and regenerating bindings, see [How to Write APIs](../../how-to-write-apis.md).

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -45,8 +45,9 @@ Understanding which directory owns which subsystem helps you find the right code
 
 1. **Fork and clone** the repository
 2. **Read [TERMINOLOGY.md](TERMINOLOGY.md)** — understand the vocabulary (Task, Workflow, Pipeline, PipelineRun, etc.) before reading code
-3. **Build from source** — follow [Building from Source](building-michelangelo-ai-from-source.md) to ensure your environment is working
-4. **Set up the sandbox** — `poetry run ma sandbox create` gives you a local Kubernetes cluster with all Michelangelo components running. Most integration tests and manual testing use this.
+3. **Go backend contributors**: read [Go Key Concepts and Terms](dev/go/key-concepts-and-terms.md) for the package map, key types, and patterns before making changes
+4. **Build from source** — follow [Building from Source](building-michelangelo-ai-from-source.md) to ensure your environment is working
+5. **Set up the sandbox** — `poetry run ma sandbox create` gives you a local Kubernetes cluster with all Michelangelo components running. Most integration tests and manual testing use this.
 
 ## Finding Work
 
@@ -77,7 +78,7 @@ Adding a new ML resource type requires proto definitions, a gRPC service, and a 
 ### Go backend changes
 For changes to the API server, controller manager, worker, or shared components.
 
-→ **[Go Key Concepts & Terms](dev/go/key-concepts-and-terms.md)** — package map, key types, patterns, and terminology
+→ **[Go Key Concepts and Terms](dev/go/key-concepts-and-terms.md)** — package map, key types, patterns, and terminology
 → **[Error Handling](dev/go/error-handling.md)** — required patterns for controllers and services
 → **[Managing Go Dependencies](manage-go-dependencies.md)** — `go mod tidy` + `bazel mod tidy`
 → **[Using Go Mocks in Tests](use-go-mocks-in-unit-test.md)** — gomock patterns

--- a/docs/contributing/ingester-internals.md
+++ b/docs/contributing/ingester-internals.md
@@ -544,3 +544,4 @@ With 13 CRDs and `concurrentReconciles: 1`, there are 13 independent work queues
 - Review [Ingester Configuration and Operations](../operator-guides/ingester-configuration.md) for operational documentation
 - Reference test CRs in `scripts/ingester-test-crs/` for integration testing examples
 - See the code at `go/components/ingester/` for the full implementation
+- [Go Key Concepts and Terms](dev/go/key-concepts-and-terms.md) — package map, key types, and patterns for the broader Go backend

--- a/docs/contributing/uniflow-plugin-guide.md
+++ b/docs/contributing/uniflow-plugin-guide.md
@@ -216,3 +216,4 @@ When creating a new plugin, you'll touch these files:
 - [Starlark Worker README](https://github.com/michelangelo-ai/michelangelo/blob/main/go/worker/starlark/README.md) — running and testing Starlark workflows locally
 - [Pipeline Plugin README](https://github.com/michelangelo-ai/michelangelo/blob/main/python/michelangelo/uniflow/plugins/pipeline/README.md) — detailed API reference for the pipeline plugin
 - [Starlark Language Spec](https://github.com/google/starlark-go/blob/master/doc/spec.md) — Starlark language reference
+- [Go Key Concepts and Terms](dev/go/key-concepts-and-terms.md) — package map, key types, and patterns for the broader Go backend


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Documentation Update

**What changed?**

Stacked on top of #1185. Builds on Zach's new Go key concepts & terms page with a few accuracy refinements and discoverability improvements after a multi-reviewer pass.

In the new page (`key-concepts-and-terms.md`):
- Aligned package paths, interface names, method signatures, and proto references with the current code (`JobQueue`, `IPlugin`, `RayJob`/`SparkJob`, `BACKEND_TYPE_TRITON` enum, starlark module path).
- Adjusted the worker description to Cadence-only (Temporal is used in the controller manager, not the worker binary).
- Expanded the controller list and noted the dual etcd + MySQL state model.
- Softened the logr/zap split and de-branded the `fx` description for open-source readers.
- Renamed "Terminology" → "Go-Specific Terminology" and added a pointer to the broader `TERMINOLOGY.md` so the two glossaries stay in their lanes.
- Added installation pointer for `mamockgen`, defined Uniflow in the glossary, and added scaffolding (file path comment + imports) to the Reconcile snippet so a first-time reader can orient.

In neighbor files:
- Pinned `sidebar_position` on `code-style.md` (2) and `error-handling.md` (3) so future additions don't displace the order Zach intended.
- Added a Go-contributor pointer in the "Before You Start" block of `contributing/index.md`.
- Added reciprocal links from `uniflow-plugin-guide.md`, `ingester-internals.md`, and `building-michelangelo-ai-from-source.md` back to the new page (the original PR linked outward but not inward).

Standardized the link description to "package map, key types, patterns, and terminology" everywhere it appears.

**Why?**

Ran a 12-reviewer doc audit on #1185 (4 engineers verifying technical claims against the code, 4 PMs checking audience and architecture fit, 4 tech-writers checking tone, structure, and link integrity). Consensus suggested these tweaks would help the page land cleanly for external Go contributors. Wanted to keep Zach's commit intact and surface the changes as a separate, reviewable diff rather than overwrite his branch.

**How did you test it?**

- `cd website && bun run build` — passes cleanly, no new broken-link errors
- All 37 internal markdown links in the modified files resolve to existing targets
- Verified each technical correction against the cited source (file:line) before changing the doc

**Potential risks**

Low. Documentation-only change. The substantive corrections are the type, path, and method-signature claims in the new page — anyone reading the doc-as-merged will get accurate guidance.

**Release notes**

N/A (documentation update, no user-facing or API change).

**Documentation Changes**

This PR _is_ the documentation change. No external wiki updates needed.

---

🤖 Drafted with help from Claude Code after a doc-review-team pass.