### PR TITLE
Fix navigation when on detail page

### DIFF
--- a/javascript/packages/core/router/__tests__/entity-detail-route.test.tsx
+++ b/javascript/packages/core/router/__tests__/entity-detail-route.test.tsx
@@ -951,7 +951,7 @@ describe('EntityDetailRoute', () => {
       ).toBeInTheDocument();
     });
 
-    test('pressing forward after back returns to the detail page, not to the tab-less URL', async () => {
+    test('pressing forward after back returns to the detail page', async () => {
       const user = userEvent.setup();
       const mockRequest = vi.fn().mockResolvedValue({
         pipelineRun: {

--- a/javascript/packages/core/router/__tests__/entity-detail-route.test.tsx
+++ b/javascript/packages/core/router/__tests__/entity-detail-route.test.tsx
@@ -837,7 +837,7 @@ describe('EntityDetailRoute', () => {
     expect(await screen.findByRole('button', { name: 'Resume' })).toBeInTheDocument();
   });
 
-  describe('back navigation', () => {
+  describe('page navigation', () => {
     const detailPhases = {
       train: buildPhase({
         id: 'train',
@@ -887,7 +887,7 @@ describe('EntityDetailRoute', () => {
       );
     }
 
-    test('pressing back from the detail page returns to the list, not to the intermediate tab-less URL', async () => {
+    test('pressing back from the detail page returns to the list', async () => {
       const user = userEvent.setup();
       const mockRequest = vi.fn().mockResolvedValue({
         pipelineRun: {

--- a/javascript/packages/core/router/__tests__/entity-detail-route.test.tsx
+++ b/javascript/packages/core/router/__tests__/entity-detail-route.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-router-dom-v5-compat';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 
@@ -834,5 +835,194 @@ describe('EntityDetailRoute', () => {
 
     // Hierarchy resolves to PRIMARY → renders as a direct button, not in overflow menu
     expect(await screen.findByRole('button', { name: 'Resume' })).toBeInTheDocument();
+  });
+
+  describe('back navigation', () => {
+    const detailPhases = {
+      train: buildPhase({
+        id: 'train',
+        entities: [
+          buildEntity({
+            views: [
+              {
+                type: 'detail',
+                metadata: [],
+                pages: [
+                  {
+                    id: 'overview',
+                    label: 'Overview',
+                    type: 'custom',
+                    component: () => <div>Overview content</div>,
+                  } as CustomDetailPageConfig,
+                  {
+                    id: 'logs',
+                    label: 'Logs',
+                    type: 'custom',
+                    component: () => <div>Logs content</div>,
+                  } as CustomDetailPageConfig,
+                ],
+              },
+            ],
+          }),
+        ],
+      }),
+    };
+
+    function TestApp({ phases }: { phases: typeof detailPhases }) {
+      const location = useLocation();
+      const navigate = useNavigate();
+      return (
+        <>
+          <span>Current pathname: {location.pathname}</span>
+          <button onClick={() => navigate(-1)}>Browser back</button>
+          <button onClick={() => navigate(1)}>Browser forward</button>
+          <Routes>
+            <Route
+              path=":projectId/:phase/:entity/:entityId/:entityTab?"
+              element={<EntityDetailRoute phases={phases} />}
+            />
+            <Route path=":projectId/:phase/:entity" element={<div>List page</div>} />
+          </Routes>
+        </>
+      );
+    }
+
+    test('pressing back from the detail page returns to the list, not to the intermediate tab-less URL', async () => {
+      const user = userEvent.setup();
+      const mockRequest = vi.fn().mockResolvedValue({
+        pipelineRun: {
+          metadata: { creationTimestamp: { seconds: 1640995200 } },
+          status: { state: 'SUCCESS' },
+        },
+      });
+
+      render(
+        <MemoryRouter
+          initialEntries={['/myproject/train/runs', '/myproject/train/runs/run-123']}
+          initialIndex={1}
+        >
+          <TestApp phases={detailPhases} />
+        </MemoryRouter>,
+        buildWrapper([
+          getErrorProviderWrapper(),
+          getServiceProviderWrapper({ request: mockRequest }),
+        ])
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Current pathname: /myproject/train/runs/run-123/overview')
+        ).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: 'Browser back' }));
+
+      expect(screen.getByText('Current pathname: /myproject/train/runs')).toBeInTheDocument();
+      expect(screen.getByText('List page')).toBeInTheDocument();
+    });
+
+    test('switching tabs adds history entries so back navigates between tabs', async () => {
+      const user = userEvent.setup();
+      const mockRequest = vi.fn().mockResolvedValue({
+        pipelineRun: {
+          metadata: { creationTimestamp: { seconds: 1640995200 } },
+          status: { state: 'SUCCESS' },
+        },
+      });
+
+      render(
+        <MemoryRouter initialEntries={['/myproject/train/runs/run-123/overview']} initialIndex={0}>
+          <TestApp phases={detailPhases} />
+        </MemoryRouter>,
+        buildWrapper([
+          getErrorProviderWrapper(),
+          getServiceProviderWrapper({ request: mockRequest }),
+        ])
+      );
+
+      await user.click(await screen.findByText('Logs'));
+      expect(
+        screen.getByText('Current pathname: /myproject/train/runs/run-123/logs')
+      ).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Browser back' }));
+      expect(
+        screen.getByText('Current pathname: /myproject/train/runs/run-123/overview')
+      ).toBeInTheDocument();
+    });
+
+    test('pressing forward after back returns to the detail page, not to the tab-less URL', async () => {
+      const user = userEvent.setup();
+      const mockRequest = vi.fn().mockResolvedValue({
+        pipelineRun: {
+          metadata: { creationTimestamp: { seconds: 1640995200 } },
+          status: { state: 'SUCCESS' },
+        },
+      });
+
+      render(
+        <MemoryRouter
+          initialEntries={['/myproject/train/runs', '/myproject/train/runs/run-123']}
+          initialIndex={1}
+        >
+          <TestApp phases={detailPhases} />
+        </MemoryRouter>,
+        buildWrapper([
+          getErrorProviderWrapper(),
+          getServiceProviderWrapper({ request: mockRequest }),
+        ])
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Current pathname: /myproject/train/runs/run-123/overview')
+        ).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: 'Browser back' }));
+      expect(screen.getByText('Current pathname: /myproject/train/runs')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Browser forward' }));
+
+      expect(
+        screen.getByText('Current pathname: /myproject/train/runs/run-123/overview')
+      ).toBeInTheDocument();
+      expect(screen.getByText('Overview content')).toBeInTheDocument();
+    });
+
+    test('pressing forward after tab back navigates between tabs', async () => {
+      const user = userEvent.setup();
+      const mockRequest = vi.fn().mockResolvedValue({
+        pipelineRun: {
+          metadata: { creationTimestamp: { seconds: 1640995200 } },
+          status: { state: 'SUCCESS' },
+        },
+      });
+
+      render(
+        <MemoryRouter initialEntries={['/myproject/train/runs/run-123/overview']} initialIndex={0}>
+          <TestApp phases={detailPhases} />
+        </MemoryRouter>,
+        buildWrapper([
+          getErrorProviderWrapper(),
+          getServiceProviderWrapper({ request: mockRequest }),
+        ])
+      );
+
+      await user.click(await screen.findByText('Logs'));
+      expect(
+        screen.getByText('Current pathname: /myproject/train/runs/run-123/logs')
+      ).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Browser back' }));
+      expect(
+        screen.getByText('Current pathname: /myproject/train/runs/run-123/overview')
+      ).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Browser forward' }));
+      expect(
+        screen.getByText('Current pathname: /myproject/train/runs/run-123/logs')
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/javascript/packages/core/router/__tests__/entity-detail-route.test.tsx
+++ b/javascript/packages/core/router/__tests__/entity-detail-route.test.tsx
@@ -1,4 +1,3 @@
-import { MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
@@ -868,25 +867,6 @@ describe('EntityDetailRoute', () => {
       }),
     };
 
-    function TestApp({ phases }: { phases: typeof detailPhases }) {
-      const location = useLocation();
-      const navigate = useNavigate();
-      return (
-        <>
-          <span>Current pathname: {location.pathname}</span>
-          <button onClick={() => navigate(-1)}>Browser back</button>
-          <button onClick={() => navigate(1)}>Browser forward</button>
-          <Routes>
-            <Route
-              path=":projectId/:phase/:entity/:entityId/:entityTab?"
-              element={<EntityDetailRoute phases={phases} />}
-            />
-            <Route path=":projectId/:phase/:entity" element={<div>List page</div>} />
-          </Routes>
-        </>
-      );
-    }
-
     test('pressing back from the detail page returns to the list', async () => {
       const user = userEvent.setup();
       const mockRequest = vi.fn().mockResolvedValue({
@@ -897,14 +877,14 @@ describe('EntityDetailRoute', () => {
       });
 
       render(
-        <MemoryRouter
-          initialEntries={['/myproject/train/runs', '/myproject/train/runs/run-123']}
-          initialIndex={1}
-        >
-          <TestApp phases={detailPhases} />
-        </MemoryRouter>,
+        <EntityDetailRoute phases={detailPhases} />,
         buildWrapper([
           getErrorProviderWrapper(),
+          getRouterWrapper({
+            initialEntries: ['/myproject/train/runs', '/myproject/train/runs/run-123'],
+            initialIndex: 1,
+            showNavButtons: true,
+          }),
           getServiceProviderWrapper({ request: mockRequest }),
         ])
       );
@@ -918,7 +898,6 @@ describe('EntityDetailRoute', () => {
       await user.click(screen.getByRole('button', { name: 'Browser back' }));
 
       expect(screen.getByText('Current pathname: /myproject/train/runs')).toBeInTheDocument();
-      expect(screen.getByText('List page')).toBeInTheDocument();
     });
 
     test('switching tabs adds history entries so back navigates between tabs', async () => {
@@ -931,11 +910,13 @@ describe('EntityDetailRoute', () => {
       });
 
       render(
-        <MemoryRouter initialEntries={['/myproject/train/runs/run-123/overview']} initialIndex={0}>
-          <TestApp phases={detailPhases} />
-        </MemoryRouter>,
+        <EntityDetailRoute phases={detailPhases} />,
         buildWrapper([
           getErrorProviderWrapper(),
+          getRouterWrapper({
+            initialEntries: ['/myproject/train/runs/run-123/overview'],
+            showNavButtons: true,
+          }),
           getServiceProviderWrapper({ request: mockRequest }),
         ])
       );
@@ -961,14 +942,14 @@ describe('EntityDetailRoute', () => {
       });
 
       render(
-        <MemoryRouter
-          initialEntries={['/myproject/train/runs', '/myproject/train/runs/run-123']}
-          initialIndex={1}
-        >
-          <TestApp phases={detailPhases} />
-        </MemoryRouter>,
+        <EntityDetailRoute phases={detailPhases} />,
         buildWrapper([
           getErrorProviderWrapper(),
+          getRouterWrapper({
+            initialEntries: ['/myproject/train/runs', '/myproject/train/runs/run-123'],
+            initialIndex: 1,
+            showNavButtons: true,
+          }),
           getServiceProviderWrapper({ request: mockRequest }),
         ])
       );
@@ -1000,11 +981,13 @@ describe('EntityDetailRoute', () => {
       });
 
       render(
-        <MemoryRouter initialEntries={['/myproject/train/runs/run-123/overview']} initialIndex={0}>
-          <TestApp phases={detailPhases} />
-        </MemoryRouter>,
+        <EntityDetailRoute phases={detailPhases} />,
         buildWrapper([
           getErrorProviderWrapper(),
+          getRouterWrapper({
+            initialEntries: ['/myproject/train/runs/run-123/overview'],
+            showNavButtons: true,
+          }),
           getServiceProviderWrapper({ request: mockRequest }),
         ])
       );

--- a/javascript/packages/core/router/entity-detail-route.tsx
+++ b/javascript/packages/core/router/entity-detail-route.tsx
@@ -68,8 +68,10 @@ export function EntityDetailRoute({ phases = PHASES }: { phases?: Record<string,
     const firstTabId = validTabIds[0];
 
     if (!entityTab) {
+      // No tab specified - redirect to first tab
       navigateToTab(firstTabId, { replace: true });
     } else if (!validTabIds.includes(entityTab)) {
+      // Invalid tab - redirect to first tab
       navigateToTab(firstTabId, { replace: true });
     }
   }, [entityTab, detailViewConfig, isLoading, error, navigateToTab]);

--- a/javascript/packages/core/router/entity-detail-route.tsx
+++ b/javascript/packages/core/router/entity-detail-route.tsx
@@ -68,7 +68,6 @@ export function EntityDetailRoute({ phases = PHASES }: { phases?: Record<string,
     const firstTabId = validTabIds[0];
 
     if (!entityTab) {
-      // replace so the no-tab URL doesn't block back navigation to the list
       navigateToTab(firstTabId, { replace: true });
     } else if (!validTabIds.includes(entityTab)) {
       navigateToTab(firstTabId, { replace: true });

--- a/javascript/packages/core/router/entity-detail-route.tsx
+++ b/javascript/packages/core/router/entity-detail-route.tsx
@@ -45,8 +45,8 @@ export function EntityDetailRoute({ phases = PHASES }: { phases?: Record<string,
   });
 
   const navigateToTab = React.useCallback(
-    (tabId: string) => {
-      navigate(`/${projectId}/${phase}/${entity}/${entityId}/${tabId}`);
+    (tabId: string, options?: { replace?: boolean }) => {
+      navigate(`/${projectId}/${phase}/${entity}/${entityId}/${tabId}`, options);
     },
     [navigate, projectId, phase, entity, entityId]
   );
@@ -68,11 +68,10 @@ export function EntityDetailRoute({ phases = PHASES }: { phases?: Record<string,
     const firstTabId = validTabIds[0];
 
     if (!entityTab) {
-      // No tab specified - redirect to first tab
-      navigateToTab(firstTabId);
+      // replace so the no-tab URL doesn't block back navigation to the list
+      navigateToTab(firstTabId, { replace: true });
     } else if (!validTabIds.includes(entityTab)) {
-      // Invalid tab - redirect to first tab
-      navigateToTab(firstTabId);
+      navigateToTab(firstTabId, { replace: true });
     }
   }, [entityTab, detailViewConfig, isLoading, error, navigateToTab]);
 

--- a/javascript/packages/core/router/entity-detail-route.tsx
+++ b/javascript/packages/core/router/entity-detail-route.tsx
@@ -62,7 +62,7 @@ export function EntityDetailRoute({ phases = PHASES }: { phases?: Record<string,
   React.useEffect(() => {
     if (error || isLoading) return;
 
-    if (!detailViewConfig?.pages?.length) return;
+    if (!entityId || !detailViewConfig?.pages?.length) return;
 
     const validTabIds = detailViewConfig.pages.map((page) => page.id);
     const firstTabId = validTabIds[0];

--- a/javascript/packages/core/test/wrappers/get-router-wrapper.tsx
+++ b/javascript/packages/core/test/wrappers/get-router-wrapper.tsx
@@ -1,4 +1,4 @@
-import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom-v5-compat';
+import { MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-router-dom-v5-compat';
 
 import type { WrapperComponentProps } from './types';
 
@@ -10,6 +10,9 @@ import type { WrapperComponentProps } from './types';
  *
  * @param options - Configuration options for the router
  * @param options.location - Initial URL path to render (defaults to '/')
+ * @param options.initialEntries - Full history stack for the router (overrides location)
+ * @param options.initialIndex - Index into initialEntries to start at (defaults to last entry)
+ * @param options.showNavButtons - Render "Browser back" and "Browser forward" buttons for navigation testing
  * @returns A wrapper component that provides routing context to its children
  *
  * @example
@@ -21,24 +24,32 @@ import type { WrapperComponentProps } from './types';
  *
  * @example
  * ```tsx
- * // Complex usage with multiple wrappers
- * const routerWrapper = getRouterWrapper({
- *   location: '/projects/123/assistants/chat'
- * });
- * const themeWrapper = getThemeWrapper();
- *
- * const wrapper = buildWrapper([themeWrapper, routerWrapper]);
+ * // Testing back/forward navigation with a pre-populated history stack
  * render(
- *   <ComponentUsingBothRouterAndTheme />,
- *   { wrapper }
+ *   <MyComponent />,
+ *   buildWrapper([
+ *     getRouterWrapper({
+ *       initialEntries: ['/projects', '/projects/123'],
+ *       initialIndex: 1,
+ *       showNavButtons: true,
+ *     }),
+ *   ])
  * );
+ * await user.click(screen.getByRole('button', { name: 'Browser back' }));
  * ```
  */
-export function getRouterWrapper(options?: { location?: string }) {
-  const { location = '/' } = options ?? {};
+export function getRouterWrapper(options?: {
+  location?: string;
+  initialEntries?: string[];
+  initialIndex?: number;
+  showNavButtons?: boolean;
+}) {
+  const { location = '/', initialEntries, initialIndex, showNavButtons = false } = options ?? {};
+  const entries = initialEntries ?? [location];
+
   return function RouterWrapper({ children }: WrapperComponentProps) {
     return (
-      <MemoryRouter initialEntries={[location]}>
+      <MemoryRouter initialEntries={entries} initialIndex={initialIndex}>
         <Routes>
           {[
             ':projectId/:phase/:entity/:entityId/:entityTab?',
@@ -51,7 +62,7 @@ export function getRouterWrapper(options?: { location?: string }) {
               path={path}
               element={
                 <>
-                  <ShowLocation />
+                  <ShowLocation showNavButtons={showNavButtons} />
                   {children}
                 </>
               }
@@ -63,14 +74,21 @@ export function getRouterWrapper(options?: { location?: string }) {
   };
 }
 
-function ShowLocation() {
+function ShowLocation({ showNavButtons }: { showNavButtons: boolean }) {
   const location = useLocation();
+  const navigate = useNavigate();
   return (
     <div>
       <span>
         Current pathname: {location.pathname} {location.search}
       </span>
       <span>Current search: {location.search}</span>
+      {showNavButtons && (
+        <>
+          <button onClick={() => navigate(-1)}>Browser back</button>
+          <button onClick={() => navigate(1)}>Browser forward</button>
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
Previously, when navigating to a detail page (such as the Pipeline run detail page), when clicking "Back" on the browser, the page stays on the detail page.

This is because if we land on a detail page with no tab specified, we would append the first tab to the URL path using React Router's `navigate`. However this adds to the history stack so if we try to click "Back", it would go to the detail page path but we would again add the first tab to the URL which would result in a loop. The history stack would look something like this:

1. `/ma-dev-test/train/runs/`
2. `/ma-dev-test/train/runs/run-123`
3. `/ma-dev-test/train/runs/run-123/<first-tab>`


Now we will add `{ replace: true }` instead of a regular push which will instead remove the `/ma-dev-test/train/runs/run-123` entry with `/ma-dev-test/train/runs/run-123/<first-tab>`. This prevents the tab-less URL from being added to browser history so pressing back from the detail page.


<!-- Tell your future self why have you made these changes -->
**Why?**
I expect to be able to use the Back and Forward buttons as expected.

## Before
https://github.com/user-attachments/assets/8afcd9ea-303d-4cdc-abe9-b5319915b1e0



## After


https://github.com/user-attachments/assets/e943935e-c8a0-43a4-b3c3-04050b445fbe



<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
With unit tests and manually tested

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
This could mess with navigation of the pages even more but it's already messed up.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
N/A

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
N/A