### PR TITLE
refactor: introduce MutationConfig and wrap mutation envelopes

### DIFF
--- a/javascript/packages/core/components/cell/renderers/retry/__tests__/retry-cell.tests.tsx
+++ b/javascript/packages/core/components/cell/renderers/retry/__tests__/retry-cell.tests.tsx
@@ -120,8 +120,9 @@ describe('RetryCell', () => {
     await user.click(within(dialog).getByRole('button', { name: 'Retry Task' }));
 
     await waitFor(() => {
-      expect(mockRequest).toHaveBeenCalledWith('UpdatePipelineRun', {
-        pipelineRun: expect.objectContaining({
+      expect(mockRequest).toHaveBeenCalledWith(
+        'UpdatePipelineRun',
+        expect.objectContaining({
           spec: expect.objectContaining({
             existingKey: 'existingValue',
             retryInfo: {
@@ -131,8 +132,8 @@ describe('RetryCell', () => {
               reason: 'Manual retry from UI',
             },
           }) as Record<string, unknown>,
-        }) as Record<string, unknown>,
-      });
+        })
+      );
     });
 
     await waitFor(() => {
@@ -176,15 +177,16 @@ describe('RetryCell', () => {
     await user.click(within(dialog).getByRole('button', { name: 'Retry Task' }));
 
     await waitFor(() => {
-      expect(mockRequest).toHaveBeenCalledWith('UpdatePipelineRun', {
-        pipelineRun: expect.objectContaining({
+      expect(mockRequest).toHaveBeenCalledWith(
+        'UpdatePipelineRun',
+        expect.objectContaining({
           spec: expect.objectContaining({
             retryInfo: expect.objectContaining({
               reason: 'Pipeline failed due to OOM',
             }) as Record<string, unknown>,
           }) as Record<string, unknown>,
-        }) as Record<string, unknown>,
-      });
+        })
+      );
     });
   });
 

--- a/javascript/packages/core/components/cell/renderers/retry/retry-cell.tsx
+++ b/javascript/packages/core/components/cell/renderers/retry/retry-cell.tsx
@@ -35,8 +35,8 @@ export const RetryCell = (props: CellRendererProps<string>) => {
   });
 
   const updatePipelineRunMutation = useStudioMutation<
-    { pipelineRun: Record<string, unknown> },
-    { pipelineRun: Record<string, unknown> }
+    Record<string, unknown>,
+    Record<string, unknown>
   >({ mutationName: 'UpdatePipelineRun' });
 
   const hasActivityId = !!value;
@@ -75,7 +75,7 @@ export const RetryCell = (props: CellRendererProps<string>) => {
     };
 
     try {
-      await updatePipelineRunMutation.mutateAsync({ pipelineRun: updatedPipelineRun });
+      await updatePipelineRunMutation.mutateAsync(updatedPipelineRun);
       setShowRetryModal(false);
       setRetryReason('Manual retry from UI');
 

--- a/javascript/packages/core/config/entities/pipeline/__tests__/create-pipeline-run-form.test.tsx
+++ b/javascript/packages/core/config/entities/pipeline/__tests__/create-pipeline-run-form.test.tsx
@@ -50,8 +50,9 @@ describe('CreatePipelineRunForm', () => {
     await user.click(submitButton);
 
     await waitFor(() => {
-      expect(mockRequest).toHaveBeenCalledWith('CreatePipelineRun', {
-        pipelineRun: expect.objectContaining({
+      expect(mockRequest).toHaveBeenCalledWith(
+        'CreatePipelineRun',
+        expect.objectContaining({
           metadata: expect.objectContaining({
             name: expect.stringMatching(/^run-\d{8}-\d{6}-.+$/) as string,
             namespace: 'ma-dev-test',
@@ -65,8 +66,8 @@ describe('CreatePipelineRunForm', () => {
               namespace: 'ma-dev-test',
             },
           }) as Record<string, unknown>,
-        }) as Record<string, unknown>,
-      });
+        })
+      );
     });
 
     await waitFor(() => {

--- a/javascript/packages/core/config/entities/pipeline/create-pipeline-run-form.tsx
+++ b/javascript/packages/core/config/entities/pipeline/create-pipeline-run-form.tsx
@@ -15,17 +15,16 @@ export const CreatePipelineRunForm = ({
 }: ActionComponentProps<Pipeline>) => {
   const { projectId } = useStudioParams('base');
 
-  const createPipelineRunMutation = useStudioMutation<
-    { pipelineRun: PipelineRun },
-    { pipelineRun: PipelineRun }
-  >({ mutationName: 'CreatePipelineRun' });
+  const createPipelineRunMutation = useStudioMutation<PipelineRun, PipelineRun>({
+    mutationName: 'CreatePipelineRun',
+  });
 
   const handleRunSubmit = async (values: PipelineRun) => {
     if (createPipelineRunMutation.isPending) {
       return;
     }
 
-    await createPipelineRunMutation.mutateAsync({ pipelineRun: values });
+    await createPipelineRunMutation.mutateAsync(values);
   };
 
   const initialValues = {

--- a/javascript/packages/core/config/entities/trigger/__tests__/trigger-run-action-form.test.tsx
+++ b/javascript/packages/core/config/entities/trigger/__tests__/trigger-run-action-form.test.tsx
@@ -74,9 +74,7 @@ it.each([
       expect(mockRequest).toHaveBeenCalledWith(
         'UpdateTriggerRun',
         expect.objectContaining({
-          triggerRun: expect.objectContaining({
-            spec: expect.objectContaining({ action }) as Record<string, unknown>,
-          }) as Record<string, unknown>,
+          spec: expect.objectContaining({ action }) as Record<string, unknown>,
         })
       );
     });

--- a/javascript/packages/core/config/entities/trigger/trigger-run-action-form.tsx
+++ b/javascript/packages/core/config/entities/trigger/trigger-run-action-form.tsx
@@ -26,7 +26,7 @@ function TriggerRunActionForm({
 
   const config = ACTION_CONFIG[action];
 
-  const mutation = useStudioMutation<{ triggerRun: TriggerRun }, { triggerRun: TriggerRun }>({
+  const mutation = useStudioMutation<TriggerRun, TriggerRun>({
     mutationName: 'UpdateTriggerRun',
   });
 
@@ -36,7 +36,7 @@ function TriggerRunActionForm({
   };
 
   const handleSubmit = async (values: TriggerRun) => {
-    await mutation.mutateAsync({ triggerRun: values });
+    await mutation.mutateAsync(values);
 
     // We wait a few seconds before invalidating the queries so that the action can be processed
     setTimeout(() => {

--- a/javascript/packages/core/hooks/__tests__/use-studio-mutation.test.ts
+++ b/javascript/packages/core/hooks/__tests__/use-studio-mutation.test.ts
@@ -30,12 +30,10 @@ describe('useStudioMutation', () => {
       ])
     );
 
-    result.current.mutate({ pipelineRun: { name: 'test-run' } });
+    result.current.mutate({ name: 'test-run' });
 
     await waitFor(() => {
-      expect(mockRequest).toHaveBeenCalledWith('CreatePipelineRun', {
-        pipelineRun: { name: 'test-run' },
-      });
+      expect(mockRequest).toHaveBeenCalledWith('CreatePipelineRun', { name: 'test-run' });
     });
   });
 
@@ -54,7 +52,7 @@ describe('useStudioMutation', () => {
       ])
     );
 
-    result.current.mutate({ pipelineRun: { name: 'test-run' } });
+    result.current.mutate({ name: 'test-run' });
 
     await waitFor(() => {
       expect(result.current.data).toEqual(mockResponse);
@@ -62,7 +60,7 @@ describe('useStudioMutation', () => {
     });
   });
 
-  test('passes onSuccess callback with correct parameters', async () => {
+  test('passes onSuccess callback with response data', async () => {
     const mockResponse = { id: 'test-id' };
     const onSuccess = vi.fn();
     const mockRequest = createQueryMockRouter({
@@ -82,11 +80,11 @@ describe('useStudioMutation', () => {
       ])
     );
 
-    const testVariables = { pipelineRun: { name: 'test-run' } };
-    result.current.mutate(testVariables);
+    result.current.mutate({ name: 'test-run' });
 
     await waitFor(() => {
-      expect(onSuccess).toHaveBeenCalledWith(mockResponse, testVariables, undefined);
+      expect(onSuccess).toHaveBeenCalled();
+      expect(onSuccess.mock.calls[0][0]).toEqual(mockResponse);
     });
   });
 
@@ -110,11 +108,11 @@ describe('useStudioMutation', () => {
       ])
     );
 
-    const testVariables = { pipelineRun: { name: 'test-run' } };
-    result.current.mutate(testVariables);
+    result.current.mutate({ name: 'test-run' });
 
     await waitFor(() => {
-      expect(onError).toHaveBeenCalledWith(expect.any(ApplicationError), testVariables, undefined);
+      expect(onError).toHaveBeenCalled();
+      expect(onError.mock.calls[0][0]).toBeInstanceOf(ApplicationError);
     });
   });
 
@@ -148,7 +146,7 @@ describe('useStudioMutation', () => {
       ])
     );
 
-    result.current.mutate({ pipelineRun: { name: 'test-run' } });
+    result.current.mutate({ name: 'test-run' });
 
     await waitFor(() => {
       expect(result.current.error).not.toBeNull();

--- a/javascript/packages/core/hooks/__tests__/use-studio-mutation.test.ts
+++ b/javascript/packages/core/hooks/__tests__/use-studio-mutation.test.ts
@@ -83,8 +83,7 @@ describe('useStudioMutation', () => {
     result.current.mutate({ name: 'test-run' });
 
     await waitFor(() => {
-      expect(onSuccess).toHaveBeenCalled();
-      expect(onSuccess.mock.calls[0][0]).toEqual(mockResponse);
+      expect(onSuccess).toHaveBeenCalledWith(mockResponse);
     });
   });
 
@@ -111,8 +110,7 @@ describe('useStudioMutation', () => {
     result.current.mutate({ name: 'test-run' });
 
     await waitFor(() => {
-      expect(onError).toHaveBeenCalled();
-      expect(onError.mock.calls[0][0]).toBeInstanceOf(ApplicationError);
+      expect(onError).toHaveBeenCalledWith(expect.any(ApplicationError));
     });
   });
 

--- a/javascript/packages/core/hooks/use-studio-mutation.ts
+++ b/javascript/packages/core/hooks/use-studio-mutation.ts
@@ -5,13 +5,12 @@ import { useServiceProvider } from '#core/providers/service-provider/use-service
 
 import type { UseMutationResult } from '@tanstack/react-query';
 import type { ApplicationError } from '#core/types/error-types';
-import type { MutationOptions } from '#core/types/query-types';
+import type { MutationConfig } from '#core/types/query-types';
 
-export const useStudioMutation = <TData, TVariables extends Record<string, unknown>>(args: {
-  mutationName: string;
-  clientOptions?: MutationOptions<TData, TVariables>;
-}): UseMutationResult<TData, ApplicationError, TVariables> => {
-  const { mutationName, clientOptions } = args;
+export const useStudioMutation = <TData, TVariables extends Record<string, unknown>>(
+  config: MutationConfig
+): UseMutationResult<TData, ApplicationError, TVariables> => {
+  const { mutationName, clientOptions } = config;
   const { request } = useServiceProvider();
   const normalizeError = useErrorNormalizer();
 

--- a/javascript/packages/core/hooks/use-studio-mutation.ts
+++ b/javascript/packages/core/hooks/use-studio-mutation.ts
@@ -23,7 +23,7 @@ export const useStudioMutation = <TData, TVariables extends Record<string, unkno
         throw normalizeError(error)!;
       }
     },
-    onSuccess: clientOptions?.onSuccess,
-    onError: clientOptions?.onError,
+    onSuccess: clientOptions?.onSuccess ? (data) => clientOptions.onSuccess!(data) : undefined,
+    onError: clientOptions?.onError ? (error) => clientOptions.onError!(error) : undefined,
   });
 };

--- a/javascript/packages/core/types/query-types.ts
+++ b/javascript/packages/core/types/query-types.ts
@@ -1,3 +1,4 @@
+import { useStudioMutation as _useStudioMutation } from '#core/hooks/use-studio-mutation';
 import { useStudioQuery as _useStudioQuery } from '#core/hooks/use-studio-query';
 
 import type { ApplicationError } from '#core/types/error-types';
@@ -28,9 +29,26 @@ export type QueryOptions = {
 };
 
 /**
- * Options that can be passed to mutation hooks.
+ * Configuration for a mutation that can be used by {@link _useStudioMutation}.
  */
-export type MutationOptions<TData = unknown, TVariables = unknown> = {
-  onSuccess?: (data: TData, variables: TVariables, context?: unknown) => void;
-  onError?: (error: ApplicationError, variables: TVariables, context?: unknown) => void;
+export interface MutationConfig {
+  /** Name of the RPC mutation handler to call, e.g. 'CreatePipelineRun' */
+  mutationName: string;
+
+  /** Options to pass to the mutation, e.g. 'onSuccess', 'onError' */
+  clientOptions?: MutationOptions;
+}
+
+/**
+ * Options that can be passed to mutation hooks.
+ *
+ * Callbacks expose simplified signatures — callers don't see React Query's
+ * full `(data, variables, context?)` shape.
+ */
+export type MutationOptions = {
+  /** Called with the mutation response when the request succeeds */
+  onSuccess?: (data: unknown) => void;
+
+  /** Called with the normalized error when the request fails */
+  onError?: (error: ApplicationError) => void;
 };

--- a/javascript/packages/rpc/__tests__/handlers.test.ts
+++ b/javascript/packages/rpc/__tests__/handlers.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../services', () => ({
+  getServices: vi.fn(),
+}));
+
+const { getServices } = await import('../services');
+const { getRpcHandlers } = await import('../handlers');
+const mockGetServices = getServices as ReturnType<typeof vi.fn>;
+
+// Single shared service mock — handlers are cached at module scope, so all
+// three test cases share the same handler instances built from this one mock.
+const createPipelineRun = vi.fn().mockResolvedValue({});
+const updatePipelineRun = vi.fn().mockResolvedValue({});
+const updateTriggerRun = vi.fn().mockResolvedValue({});
+
+mockGetServices.mockResolvedValue(
+  // Proxy returns vi.fn() for any unaccessed service method, so the handlers
+  // module's full sweep of services at construction time doesn't crash.
+  new Proxy({} as Record<string, Record<string, unknown>>, {
+    get(_, serviceName: string) {
+      if (serviceName === 'PipelineRunService') {
+        return { createPipelineRun, updatePipelineRun };
+      }
+      if (serviceName === 'TriggerRunService') {
+        return { updateTriggerRun };
+      }
+      return new Proxy({}, { get: () => vi.fn().mockResolvedValue({}) });
+    },
+  })
+);
+
+describe('rpc handlers — mutation envelope wrapping', () => {
+  it('CreatePipelineRun wraps the bare record in a pipelineRun envelope', async () => {
+    const handlers = await getRpcHandlers();
+    const record = { metadata: { name: 'test-run' } };
+    await handlers.CreatePipelineRun(record as never);
+
+    expect(createPipelineRun).toHaveBeenCalledWith({ pipelineRun: record });
+  });
+
+  it('UpdatePipelineRun wraps the bare record in a pipelineRun envelope', async () => {
+    const handlers = await getRpcHandlers();
+    const record = { metadata: { name: 'updated-run' } };
+    await handlers.UpdatePipelineRun(record as never);
+
+    expect(updatePipelineRun).toHaveBeenCalledWith({ pipelineRun: record });
+  });
+
+  it('UpdateTriggerRun wraps the bare record in a triggerRun envelope', async () => {
+    const handlers = await getRpcHandlers();
+    const record = { metadata: { name: 'kill-target' } };
+    await handlers.UpdateTriggerRun(record as never);
+
+    expect(updateTriggerRun).toHaveBeenCalledWith({ triggerRun: record });
+  });
+});

--- a/javascript/packages/rpc/__tests__/handlers.test.ts
+++ b/javascript/packages/rpc/__tests__/handlers.test.ts
@@ -1,22 +1,14 @@
 import { describe, expect, it, vi } from 'vitest';
+import { getRpcHandlers } from '../handlers';
 
-vi.mock('../services', () => ({
-  getServices: vi.fn(),
-}));
+const mockGetServices = vi.hoisted(() => vi.fn());
+vi.mock('../services', () => ({ getServices: mockGetServices }));
 
-const { getServices } = await import('../services');
-const { getRpcHandlers } = await import('../handlers');
-const mockGetServices = getServices as ReturnType<typeof vi.fn>;
-
-// Single shared service mock — handlers are cached at module scope, so all
-// three test cases share the same handler instances built from this one mock.
 const createPipelineRun = vi.fn().mockResolvedValue({});
 const updatePipelineRun = vi.fn().mockResolvedValue({});
 const updateTriggerRun = vi.fn().mockResolvedValue({});
 
 mockGetServices.mockResolvedValue(
-  // Proxy returns vi.fn() for any unaccessed service method, so the handlers
-  // module's full sweep of services at construction time doesn't crash.
   new Proxy({} as Record<string, Record<string, unknown>>, {
     get(_, serviceName: string) {
       if (serviceName === 'PipelineRunService') {

--- a/javascript/packages/rpc/__tests__/handlers.test.ts
+++ b/javascript/packages/rpc/__tests__/handlers.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+
 import { getRpcHandlers } from '../handlers';
 
 const mockGetServices = vi.hoisted(() => vi.fn());

--- a/javascript/packages/rpc/handlers.ts
+++ b/javascript/packages/rpc/handlers.ts
@@ -1,5 +1,7 @@
 import { getServices } from './services';
 
+import type { PipelineRun } from './gen/michelangelo/api/v2/pipeline_run_pb';
+import type { TriggerRun } from './gen/michelangelo/api/v2/trigger_run_pb';
 import type { ExtractUnaryRpc } from './types';
 
 let handlersPromise: Promise<Awaited<ReturnType<typeof createHandlers>>> | null = null;
@@ -44,15 +46,12 @@ async function createHandlers() {
     GetTriggerRun: services.TriggerRunService.getTriggerRun as ExtractUnaryRpc<
       typeof services.TriggerRunService.getTriggerRun
     >,
-    UpdateTriggerRun: services.TriggerRunService.updateTriggerRun as ExtractUnaryRpc<
-      typeof services.TriggerRunService.updateTriggerRun
-    >,
-    CreatePipelineRun: services.PipelineRunService.createPipelineRun as ExtractUnaryRpc<
-      typeof services.PipelineRunService.createPipelineRun
-    >,
-    UpdatePipelineRun: services.PipelineRunService.updatePipelineRun as ExtractUnaryRpc<
-      typeof services.PipelineRunService.updatePipelineRun
-    >,
+    UpdateTriggerRun: (record: TriggerRun) =>
+      services.TriggerRunService.updateTriggerRun({ triggerRun: record }),
+    CreatePipelineRun: (record: PipelineRun) =>
+      services.PipelineRunService.createPipelineRun({ pipelineRun: record }),
+    UpdatePipelineRun: (record: PipelineRun) =>
+      services.PipelineRunService.updatePipelineRun({ pipelineRun: record }),
     ListModel: services.ModelService.listModel as ExtractUnaryRpc<
       typeof services.ModelService.listModel
     >,

--- a/javascript/packages/rpc/request.ts
+++ b/javascript/packages/rpc/request.ts
@@ -24,7 +24,10 @@ export async function request<RpcId extends keyof RpcHandlerType>(
   args: OmitTypeName<Parameters<RpcHandlerType[RpcId]>[0]>
 ): Promise<OmitTypeName<Awaited<ReturnType<RpcHandlerType[RpcId]>>>> {
   const handlers = await getRpcHandlers();
-  const response = (await handlers[rpcId](args)) as Awaited<ReturnType<RpcHandlerType[RpcId]>>;
+  // Handlers have heterogeneous input types; calling through the union requires
+  // a loose cast here. The public `request` signature still narrows args by RpcId.
+  const handler = handlers[rpcId] as (a: unknown) => Promise<unknown>;
+  const response = (await handler(args)) as Awaited<ReturnType<RpcHandlerType[RpcId]>>;
   return toPlainObject(response) as OmitTypeName<Awaited<ReturnType<RpcHandlerType[RpcId]>>>;
 }
 

--- a/javascript/packages/rpc/request.ts
+++ b/javascript/packages/rpc/request.ts
@@ -24,8 +24,6 @@ export async function request<RpcId extends keyof RpcHandlerType>(
   args: OmitTypeName<Parameters<RpcHandlerType[RpcId]>[0]>
 ): Promise<OmitTypeName<Awaited<ReturnType<RpcHandlerType[RpcId]>>>> {
   const handlers = await getRpcHandlers();
-  // Handlers have heterogeneous input types; calling through the union requires
-  // a loose cast here. The public `request` signature still narrows args by RpcId.
   const handler = handlers[rpcId] as (a: unknown) => Promise<unknown>;
   const response = (await handler(args)) as Awaited<ReturnType<RpcHandlerType[RpcId]>>;
   return toPlainObject(response) as OmitTypeName<Awaited<ReturnType<RpcHandlerType[RpcId]>>>;


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Refactor

**What changed?**

- `useStudioMutation` now takes a `MutationConfig` object, matching how `useStudioQuery` takes `QueryConfig`. Mutation callbacks (`onSuccess`, `onError`) are typed to expose only the data/error argument — the extra args React Query passes at runtime are wrapped away.
- RPC mutation handlers (`CreatePipelineRun`, `UpdatePipelineRun`, `UpdateTriggerRun`) wrap protobuf envelopes internally. Callers pass bare records instead of constructing `{ pipelineRun: record }` themselves.
- Three call sites updated to pass bare records: `create-pipeline-run-form.tsx`, `trigger-run-action-form.tsx`, `retry-cell.tsx` (and their tests).
- `packages/rpc/request.ts` uses a loose cast at the dispatch site because the union of all handler input types is too wide for TypeScript to narrow. The public `request<RpcId>(...)` signature still enforces correct args per RPC.

**Why?**

Plumbing for configuration-driven actions. The action dispatcher needs to declare `mutation: MutationConfig` as data and call `useStudioMutation(config)` — that requires the hook to accept a config object. Moving envelope wrapping into the RPC handlers is the other half: action configs reference bare records from the action context, not pre-wrapped requests.

**How did you test it?**

1. Created pipeline run
2. Retried pipeline run via steps view (calls UpdatePipelineRun)
3. Killed running trigger (called UpdateTriggerRun)\

**Documentation Changes**

N/A.


🤖 Generated with [Claude Code](https://claude.com/claude-code)