### PR TITLE
docs: improve sandbox setup and ports-and-endpoints guides

### DIFF
--- a/docs/getting-started/ma-sandbox-ports-and-endpoints.md
+++ b/docs/getting-started/ma-sandbox-ports-and-endpoints.md
@@ -2,89 +2,136 @@
 sidebar_position: 6
 ---
 
-# MA Sandbox Ports and Endpoints
+# Sandbox Ports and Endpoints
 
-Use this reference when connecting to services in your local Michelangelo sandbox. The sandbox maps ports from the K3d cluster to localhost so you can access all services directly from your browser or CLI.
+This is a quick reference for the URLs and ports your local Michelangelo sandbox exposes on `localhost`. After `ma sandbox create` finishes, use this page to find where to point your browser, your CLI, or your SDK client.
 
-### Default (Cadence) mode
+If you haven't set up the sandbox yet, start with [Sandbox Setup](./sandbox-setup.md) first.
 
-The sandbox maps NodePorts from the k3d cluster to localhost for easy access.
+## Quick links
 
-| Service | Host port | NodePort | In-cluster service | Container port | Purpose |
+The most common URLs you'll open after the sandbox is up:
+
+| Service | URL | Default credentials |
+|---|---|---|
+| Michelangelo UI | http://localhost:8090 | none |
+| MinIO Console | http://localhost:9090 | `minioadmin` / `minioadmin` |
+| Cadence Web (default) | http://localhost:8088 | none |
+| Temporal Web (with `--workflow temporal`) | http://localhost:8080 | none |
+| Grafana | http://localhost:3000 | none (anonymous access) |
+| Prometheus | http://localhost:9092 | none |
+| MLflow Tracking (with `--include-experimental mlflow`) | http://localhost:5001 | none |
+| Ray Dashboard (with `--create-compute-cluster`) | http://localhost:8265 | none |
+
+The MySQL root password is `root` (database: `temporal`). Connect with `mysql -h 127.0.0.1 -P 3306 -u root -proot`.
+
+> **Heads up:** these credentials are intentionally trivial because the sandbox is meant for local development on your machine only. Do not reuse them anywhere else.
+
+## All exposed ports
+
+Every port below is mapped from the k3d cluster to your host so you can reach it directly from `localhost`.
+
+### Default sandbox (Cadence workflow engine)
+
+These mappings are created automatically by `ma sandbox create`:
+
+| Service | Host port | NodePort | In-cluster service | Container port | What it's for |
 |---|---:|---:|---|---:|---|
-| MySQL | 3306 | 30001 | `mysql` | 3306 | Storage for Cadence/Temporal |
-| MinIO (Console) | 9090 | 30008 | `minio` | 9090 | Web UI for MinIO |
-| MinIO (S3 API) | 9091 | 30007 | `minio` | 9091 | S3-compatible API endpoint |
-| Michelangelo API Server | 15566 | 30009 | `ma-apiserver` | 15566 | gRPC API (YARPC) |
-| Envoy (gRPC-web proxy) | 8081 | 30010 | `envoy` | 8081 | gRPC-web → gRPC proxy for UI/clients |
-| Cadence Frontend (gRPC) | 7833 | 30002 | `cadence` | 7833 | Cadence SDK/clients |
-| Cadence Frontend (TChannel) | 7933 | 30003 | `cadence` | 7933 | Cadence internal comms |
-| Cadence Web | 8088 | 30004 | `cadence-web` | 8088 | Web UI for Cadence |
+| Michelangelo UI | 8090 | 30011 | `michelangelo-ui` | 8090 | Web UI — your main entry point |
+| Michelangelo API Server | 15566 | 30009 | `michelangelo-apiserver` | 15566 | gRPC API (YARPC) for SDK and CLI clients |
+| Envoy (gRPC-web proxy) | 8081 | 30010 | `michelangelo-envoy` | 8081 | gRPC-web → gRPC bridge used by the UI |
+| Cadence Web | 8088 | 30004 | `michelangelo-cadence-web` | 8088 | Inspect, retry, and debug Cadence workflow runs |
+| Cadence Frontend (gRPC) | 7833 | 30002 | `michelangelo-cadence` | 7833 | Cadence SDK and client connections |
+| Cadence Frontend (TChannel) | 7933 | 30003 | `michelangelo-cadence` | 7933 | Cadence internal RPC |
+| MySQL | 3306 | 30001 | `mysql` | 3306 | Metadata storage for the workflow engine |
+| MinIO (S3 API) | 9091 | 30007 | `minio` | 9091 | S3-compatible object storage endpoint |
+| MinIO (Console) | 9090 | 30008 | `minio` | 9090 | Web UI for browsing buckets |
+| Grafana | 3000 | 30012 | `grafana` | 3000 | Dashboards (skipped with `--exclude grafana`) |
+| Prometheus | 9092 | 30015 | `prometheus` | 9090 | Metrics (skipped with `--exclude prometheus`) |
+| MLflow Tracking | 5001 | 30013 | `mlflow` | 5000 | Experiment tracking (only deployed with `--include-experimental mlflow`) |
 
-Quick links:
+### Temporal workflow engine
 
-- MinIO Console: `http://localhost:9090`
-- Michelangelo API (Envoy gRPC-web): `http://localhost:8081`
-- Cadence Web UI: `http://localhost:8088`
+When you pass `--workflow temporal`, the sandbox swaps the Cadence-specific mappings for Temporal ones at cluster-create time. The Cadence Web port is not exposed; everything else above (UI, API Server, MinIO, MySQL, Grafana, Prometheus, MLflow) stays the same.
 
-Notes:
+| Service | Host port | NodePort | In-cluster service | What it's for |
+|---|---:|---:|---|---|
+| Temporal Web | 8080 | 30005 | `michelangelo-temporal-web` | Inspect, retry, and debug Temporal workflow runs |
 
-- Envoy is applied unless `--exclude ui` is used. If excluded, the 8081 mapping may be unused.
-- The API server is reachable inside the cluster at `michelangelo-apiserver:15566` and externally via `localhost:15566`.
+> **Note:** the Temporal frontend gRPC service (`michelangelo-temporal-frontend:7233`) is reachable inside the cluster but is **not** auto-exposed on the host. If you need direct host access for SDK testing, port-forward it manually:
+>
+> ```bash
+> kubectl port-forward svc/michelangelo-temporal-frontend 7233:7233
+> ```
 
-### Temporal mode
+### Optional Ray compute cluster
 
-When `--workflow temporal` is used, Cadence services are not exposed. Instead, the script automatically port-forwards Temporal services:
+If you ran `ma sandbox create --create-compute-cluster`, a second k3d cluster is created for Ray jobs with these mappings:
 
-| Service | Host port | Access | In-cluster service | Purpose |
-|---|---:|---|---|---|
-| Temporal Web | 8080 | `kubectl port-forward svc/temporaltest-web 8080:8080` | `temporaltest-web` | Web UI |
-| Temporal Frontend (gRPC) | 7233 | `kubectl port-forward svc/temporaltest-frontend 7233:7233` | `temporaltest-frontend` | Temporal SDK/clients |
-
-Quick links:
-
-- Temporal Web UI: `http://localhost:8080`
-
-All other sandbox ports (MySQL, MinIO, API Server, Envoy) remain the same as in the Cadence table.
-
-### Optional Ray jobs cluster
-
-If you pass `--create-compute-cluster`, a dedicated k3d cluster for Ray jobs is created with the following host mappings:
-
-| Service | Host port | Purpose |
+| Service | Host port | What it's for |
 |---|---:|---|
-| Ray Client | 10001 | Ray client (ray job submission / client API) |
-| Ray Dashboard | 8265 | Ray Dashboard UI |
+| Ray Dashboard | 8265 | Browse Ray jobs, actors, and resources |
+| Ray Client | 10001 | Submit jobs from a Ray client |
 
-Quick links:
+Without `--create-compute-cluster`, the main sandbox cluster itself acts as the Ray target — you can still run Ray workloads, just not in an isolated cluster.
 
-- Ray Dashboard: `http://localhost:8265`
+## Connecting from outside the cluster
 
-### Internal (in-cluster) ports reference
-
-These ports are primarily for intra-cluster communication but are listed for reference:
-
-- `michelangelo-controllermgr`
-  - Controller Manager webhook/manager: 9443
-  - Metrics: 8080
-  - Health probe: 8081
-- `michelangelo-apiserver` (service `ma-apiserver`): 15566
-- `minio`: 9090 (console), 9091 (S3 API)
-- `mysql`: 3306
-- `cadence`: 7833 (gRPC), 7933 (TChannel)
-- `cadence-web`: 8088
-- `envoy`: 8081
-
-### Troubleshooting port conflicts
-
-If a service fails to start because its port is already in use, find and stop the conflicting process:
+A few common patterns once the sandbox is up:
 
 ```bash
-# Find what's using a port (e.g., 9090)
+# Open the Michelangelo UI
+open http://localhost:8090
+
+# Talk to the API server with grpcurl
+grpcurl -plaintext localhost:15566 list
+
+# Connect to MySQL
+mysql -h 127.0.0.1 -P 3306 -u root -proot temporal
+
+# Use MinIO with the AWS CLI (S3-compatible)
+AWS_ACCESS_KEY_ID=minioadmin AWS_SECRET_ACCESS_KEY=minioadmin \
+  aws --endpoint-url http://localhost:9091 --region us-east-1 s3 ls
+```
+
+## Troubleshooting port conflicts
+
+If `ma sandbox create` fails because a host port is already bound, find what's holding it and free it up:
+
+```bash
+# Find the process using a port (e.g., 9090)
 lsof -i :9090
 
-# Stop the process if safe to do so
+# Stop it if it's safe to do so
 kill <PID>
 ```
 
-Then restart your sandbox with `ma sandbox delete && ma sandbox create`.
+Then retry:
+
+```bash
+# Non-destructive — preserves existing sandbox state
+ma sandbox stop && ma sandbox start
+
+# Destructive — wipes the cluster and starts fresh
+ma sandbox delete && ma sandbox create
+```
+
+For other sandbox issues (image pulls, crashing pods, Temporal namespace errors), see the [Troubleshooting section in Sandbox Setup](./sandbox-setup.md#troubleshooting).
+
+## Advanced: in-cluster ports
+
+You usually don't need these — they're for developers debugging Kubernetes networking, writing controllers, or running probes from inside the cluster.
+
+| Component | Port | Purpose |
+|---|---:|---|
+| `michelangelo-controllermgr` | 8091 | Controller manager metrics |
+| `michelangelo-controllermgr` | 8081 | Controller manager health probe |
+| `michelangelo-apiserver` | 15566 | gRPC API |
+| `michelangelo-envoy` | 8081 | gRPC-web proxy |
+| `michelangelo-cadence` | 7833 | Cadence frontend (gRPC) |
+| `michelangelo-cadence` | 7933 | Cadence frontend (TChannel) |
+| `michelangelo-cadence-web` | 8088 | Cadence Web UI |
+| `michelangelo-temporal-frontend` | 7233 | Temporal frontend (gRPC) |
+| `michelangelo-temporal-web` | 8080 | Temporal Web UI |
+| `minio` | 9090 / 9091 | Console / S3 API |
+| `mysql` | 3306 | MySQL |

--- a/docs/getting-started/sandbox-setup.md
+++ b/docs/getting-started/sandbox-setup.md
@@ -4,28 +4,44 @@ sidebar_position: 3
 
 # Sandbox Setup
 
-Set up a local Michelangelo environment on your machine. This gives you a fully functional cluster with the API server, controller manager, workflow engine, object storage, and all supporting services.
+This guide walks you through setting up a local Michelangelo environment on your laptop. The sandbox runs a fully functional cluster — API server, controller manager, workflow engine, object storage, and supporting services — entirely on your machine, so you can explore Michelangelo or develop against it without any cloud infrastructure.
 
-**Time estimate**: ~20 minutes (assuming prerequisites are installed).
+**Who this is for:** ML engineers, platform engineers, and contributors who want to try Michelangelo locally or develop new features against it.
+
+**What you'll have at the end:** a running sandbox cluster and a successful demo pipeline run, ready for you to build your own workflows on top of.
+
+**Time estimate:** ~20 minutes (assuming prerequisites are installed; first-time pulls of container images can add 5–10 minutes).
+
+**Supported platforms:** macOS (Apple Silicon and Intel) and Linux. Windows is not officially supported, but WSL2 with Docker Desktop should work for most steps.
+
+## Get the code
+
+Clone the Michelangelo repository to your machine:
+
+```bash
+git clone https://github.com/michelangelo-ai/michelangelo.git
+cd michelangelo
+```
+
+Throughout this guide, `<repo-root>` refers to the directory you just cloned (for example, `~/michelangelo`).
 
 ## Prerequisites
 
-Before you begin, make sure you have the following installed. Run each verification command to confirm:
+Before you begin, make sure you have the following installed. Install commands below show macOS (Homebrew) and Linux options where they differ; on Linux, follow the linked official guide if you don't see a direct command. Run each verification command to confirm:
 
-| Tool | Install | Verify |
-|------|---------|--------|
-| **Docker** | [Get Docker](https://docs.docker.com/get-started/get-docker) or [Colima](https://github.com/abiosoft/colima) | `docker --version` |
-| **kubectl** | `brew install kubectl` or [official guide](https://kubernetes.io/docs/tasks/tools/#kubectl) | `kubectl version --client` |
-| **k3d** | `brew install k3d` | `k3d --version` |
-| **Helm** | `brew install helm` or [official guide](https://helm.sh/docs/intro/install/) | `helm version` |
-| **Python 3.9+** | [python.org](https://www.python.org/downloads/) | `python3 --version` |
-| **Poetry** | `curl -sSL https://install.python-poetry.org \| python3 -` | `poetry --version` |
-| **cadence** *(Cadence only)* | `brew install cadence-workflow` | `cadence --version` |
-| **temporal** *(Temporal only)* | `brew install temporal` | `temporal --version` |
+| Tool | Install (macOS) | Install (Linux) | Verify |
+|------|-----------------|-----------------|--------|
+| **Docker** | [Docker Desktop](https://docs.docker.com/get-started/get-docker) or [Colima](https://github.com/abiosoft/colima) | [Docker Engine](https://docs.docker.com/engine/install/) | `docker --version` |
+| **kubectl** | `brew install kubectl` | [official guide](https://kubernetes.io/docs/tasks/tools/#kubectl) | `kubectl version --client` |
+| **k3d** | `brew install k3d` | [official guide](https://k3d.io/#installation) | `k3d --version` |
+| **Helm** | `brew install helm` | [official guide](https://helm.sh/docs/intro/install/) | `helm version` |
+| **Python 3.9+** | [python.org](https://www.python.org/downloads/) or `brew install python@3.11` | distro package manager (e.g., `apt install python3`) | `python3 --version` |
+| **Poetry** | `curl -sSL https://install.python-poetry.org \| python3 -` | same as macOS | `poetry --version` |
+| **temporal** *(Temporal only)* | `brew install temporal` | [official guide](https://docs.temporal.io/cli#install) | `temporal --version` |
 
-### Colima resource requirements
+### Colima resource requirements (macOS only)
 
-If you are using Colima as your Docker runtime, the default VM resources are too limited for the sandbox. Start Colima with at least:
+If you are on macOS and using Colima as your Docker runtime, the default VM resources are too limited for the sandbox. Start Colima with at least:
 
 ```bash
 colima start --cpu 4 --memory 8 --disk 60
@@ -59,41 +75,47 @@ Docker containers need to communicate with services on your host machine. Verify
 
 ### Install Python dependencies
 
-From the repository root, install the Michelangelo Python packages:
+From the repository you cloned, install the Michelangelo Python packages:
 
 ```bash
 cd <repo-root>/python
 poetry install
 ```
 
-> **Tip**: Replace `<repo-root>` with the path where you cloned the Michelangelo repository (e.g., `~/michelangelo`).
-
 ---
 
 ## Quick start
 
-The fastest way to get a working Michelangelo environment:
+Once prerequisites and Python dependencies are installed, the sandbox is three commands away:
 
 ```bash
-# 1. Install dependencies (from the repository root)
-cd <repo-root>/python
-poetry install
+# 1. Activate the Poetry virtual environment (from <repo-root>/python)
 source .venv/bin/activate
 
-# 2. Create the sandbox (~10-15 min on first run)
+# 2. Create the sandbox (~10–15 min on first run)
 ma sandbox create
 
 # 3. Verify everything works by running the demo pipeline
 ma sandbox demo pipeline
 ```
 
-When `ma sandbox create` completes successfully, you should see all Michelangelo services starting up in your K3d cluster. You can verify with:
+> **Tip:** If you prefer not to activate the venv, you can prefix each command with `poetry run` (e.g., `poetry run ma sandbox create`).
+
+### Choosing a workflow engine
+
+`ma sandbox create` defaults to **Cadence**, which is the recommended choice for most users — it's the most-tested path and matches the examples in this guide. Pass `--workflow temporal` only if you specifically want to develop or test against Temporal (for example, if your team is migrating to it). The two engines are interchangeable from a workflow-author perspective; the choice mainly affects which web UI and CLI you use.
+
+### Verifying success
+
+When `ma sandbox create` completes, all Michelangelo services start in your k3d cluster. Verify with:
 
 ```bash
 kubectl get pods
 ```
 
-All pods should show `Running` status. See [Sandbox Ports and Endpoints](./ma-sandbox-ports-and-endpoints.md) for the full list of services and their URLs.
+You should see roughly 10–15 pods (the exact count depends on which engine you chose and any `--exclude` flags). All pods should reach `Running` status within 2–3 minutes; some pods may briefly show `ContainerCreating` or `Init` while images pull.
+
+Then open the **Michelangelo UI at [http://localhost:8090](http://localhost:8090)** — if the dashboard loads, your sandbox is healthy. See [Sandbox Ports and Endpoints](./ma-sandbox-ports-and-endpoints.md) for the full list of services and their URLs.
 
 ---
 
@@ -166,13 +188,9 @@ ma sandbox demo inference   # sets up demo inference server
 
 ---
 
-## Running your first workflow
+## Smoke test: run the BERT CoLA example
 
-Once your sandbox is running, you can run Uniflow workflows locally or remotely.
-
-### Local execution
-
-Local execution runs workflows directly in your Python environment -- great for rapid development and debugging.
+After `ma sandbox demo pipeline` succeeds, you've already proven the sandbox works end to end. If you'd like to run a real example workflow against it before moving on, the BERT CoLA text-classification example is a quick way to confirm local execution works:
 
 ```bash
 cd <repo-root>/python
@@ -180,96 +198,14 @@ poetry install --extras example
 PYTHONPATH=. poetry run python ./examples/bert_cola/bert_cola.py
 ```
 
-> **Note**: Local execution doesn't support caching, retries, or resource constraints. Use remote execution for production-like behavior.
+You should see workflow logs in your terminal and, when it finishes, a trained model artifact written to local storage.
 
-### Remote execution
+For the full story on local vs. remote execution, building Docker images, configuring storage, and using either workflow engine end to end, see:
 
-Remote execution deploys workflows to your sandbox's Kubernetes cluster, with full caching, retries, and resource management.
+- [Pipeline Running Modes](../user-guides/ml-pipelines/pipeline-running-modes.md) — the four execution modes Michelangelo supports
+- [Getting Started with ML Pipelines](../user-guides/ml-pipelines/getting-started.md) — write and run your own workflow
 
-**Setup:**
-
-1. Build a Docker image with your workflow code:
-   ```bash
-   cd <repo-root>/python
-   docker build -t examples:latest -f ./examples/Dockerfile .
-   ```
-
-2. Import the image into your K3d cluster:
-   ```bash
-   k3d image import examples:latest -c michelangelo-sandbox
-   ```
-
-3. Set up MinIO storage (object storage for workflow artifacts):
-   - Open the MinIO Console at http://localhost:9090
-   - Log in with username `minioadmin` and password `minioadmin` (these are default sandbox credentials, not for production use)
-   - Click "Create Bucket" and create a bucket named `default`
-
-4. Set up the workflow engine namespace/domain:
-
-   **Cadence** (default):
-   ```bash
-   brew install cadence-workflow
-   cadence --do default d re
-   ```
-
-   **Temporal** (if you created the sandbox with `--workflow temporal`):
-
-   First, port-forward the Temporal frontend so the local CLI can reach it:
-   ```bash
-   kubectl port-forward svc/michelangelo-temporal-frontend 7233:7233 &
-   ```
-
-   Then register the `default` namespace:
-   ```bash
-   brew install temporal
-   temporal operator namespace create default
-   ```
-
-   Finally, restart the worker to pick up the registered namespace:
-   ```bash
-   kubectl rollout restart deployment/michelangelo-worker
-   ```
-
-5. Run your workflow:
-
-   **Cadence** (default):
-   ```bash
-   PYTHONPATH=. poetry run python ./examples/bert_cola/bert_cola.py \
-     remote-run \
-     --image docker.io/library/examples:latest \
-     --storage-url s3://default \
-     --yes
-   ```
-
-   **Temporal**:
-   ```bash
-   # Ensure the port-forward from step 4 is still running, then:
-   TEMPORAL_ADDRESS=localhost:7233 \
-   PYTHONPATH=. poetry run python ./examples/bert_cola/bert_cola.py \
-     remote-run \
-     --workflow temporal \
-     --image docker.io/library/examples:latest \
-     --storage-url s3://default \
-     --yes
-   ```
-
-   > **Note**: The `--workflow` flag here must match the engine used when you ran `ma sandbox create --workflow <engine>`.
-
-**Monitoring your workflow:**
-
-| Service | URL | Sandbox engine |
-|---------|-----|----------------|
-| Cadence Web UI | http://localhost:8088/domains/default/workflows | Cadence |
-| Temporal Web UI | http://localhost:8080/namespaces/default/workflows | Temporal |
-| MinIO Console | http://localhost:9090/browser/default | Both |
-| Ray Dashboard | http://localhost:8265 | Both (requires port-forward, see below) |
-
-To access the Ray Dashboard for tasks running in the cluster:
-
-1. Find the Ray head service: `kubectl get svc | grep ray`
-2. Port-forward it: `kubectl port-forward svc/<ray-head-svc-name> 8265:8265 -n default`
-
-For more details on execution modes, see [Pipeline Running Modes](../user-guides/ml-pipelines/pipeline-running-modes.md).
+> **Note:** Local execution doesn't support caching, retries, or resource constraints. Use remote execution (covered in the ML Pipelines guides) for production-like behavior.
 
 ---
 
@@ -326,11 +262,17 @@ A service is starting but immediately crashing. Check its logs:
 kubectl logs <pod-name>
 ```
 
-To restart a single service (e.g., MinIO):
+If a single service is wedged, the simplest recovery is to delete the pod and let Kubernetes recreate it:
 
 ```bash
-kubectl delete pod minio
-kubectl apply -f <repo-root>/python/michelangelo/cli/sandbox/resources/minio.yaml
+kubectl delete pod <pod-name>
+```
+
+If that doesn't help, recreate the sandbox cleanly:
+
+```bash
+ma sandbox delete
+ma sandbox create
 ```
 
 ### Port already in use

--- a/docs/getting-started/sandbox-setup.md
+++ b/docs/getting-started/sandbox-setup.md
@@ -20,6 +20,8 @@ Before you begin, make sure you have the following installed. Run each verificat
 | **Helm** | `brew install helm` or [official guide](https://helm.sh/docs/intro/install/) | `helm version` |
 | **Python 3.9+** | [python.org](https://www.python.org/downloads/) | `python3 --version` |
 | **Poetry** | `curl -sSL https://install.python-poetry.org \| python3 -` | `poetry --version` |
+| **cadence** *(Cadence only)* | `brew install cadence-workflow` | `cadence --version` |
+| **temporal** *(Temporal only)* | `brew install temporal` | `temporal --version` |
 
 ### Colima resource requirements
 
@@ -202,13 +204,35 @@ Remote execution deploys workflows to your sandbox's Kubernetes cluster, with fu
    - Log in with username `minioadmin` and password `minioadmin` (these are default sandbox credentials, not for production use)
    - Click "Create Bucket" and create a bucket named `default`
 
-4. Set up the Cadence workflow domain (if using Cadence):
+4. Set up the workflow engine namespace/domain:
+
+   **Cadence** (default):
    ```bash
    brew install cadence-workflow
    cadence --do default d re
    ```
 
+   **Temporal** (if you created the sandbox with `--workflow temporal`):
+
+   First, port-forward the Temporal frontend so the local CLI can reach it:
+   ```bash
+   kubectl port-forward svc/michelangelo-temporal-frontend 7233:7233 &
+   ```
+
+   Then register the `default` namespace:
+   ```bash
+   brew install temporal
+   temporal operator namespace create default
+   ```
+
+   Finally, restart the worker to pick up the registered namespace:
+   ```bash
+   kubectl rollout restart deployment/michelangelo-worker
+   ```
+
 5. Run your workflow:
+
+   **Cadence** (default):
    ```bash
    PYTHONPATH=. poetry run python ./examples/bert_cola/bert_cola.py \
      remote-run \
@@ -217,13 +241,28 @@ Remote execution deploys workflows to your sandbox's Kubernetes cluster, with fu
      --yes
    ```
 
+   **Temporal**:
+   ```bash
+   # Ensure the port-forward from step 4 is still running, then:
+   TEMPORAL_ADDRESS=localhost:7233 \
+   PYTHONPATH=. poetry run python ./examples/bert_cola/bert_cola.py \
+     remote-run \
+     --workflow temporal \
+     --image docker.io/library/examples:latest \
+     --storage-url s3://default \
+     --yes
+   ```
+
+   > **Note**: The `--workflow` flag here must match the engine used when you ran `ma sandbox create --workflow <engine>`.
+
 **Monitoring your workflow:**
 
-| Service | URL | What to check |
-|---------|-----|---------------|
-| Cadence Web UI | http://localhost:8088/domains/default/workflows | Workflow status and history |
-| MinIO Console | http://localhost:9090/browser/default | Stored artifacts and data |
-| Ray Dashboard | http://localhost:8265 | Ray task execution (requires port-forward, see below) |
+| Service | URL | Sandbox engine |
+|---------|-----|----------------|
+| Cadence Web UI | http://localhost:8088/domains/default/workflows | Cadence |
+| Temporal Web UI | http://localhost:8080/namespaces/default/workflows | Temporal |
+| MinIO Console | http://localhost:9090/browser/default | Both |
+| Ray Dashboard | http://localhost:8265 | Both (requires port-forward, see below) |
 
 To access the Ray Dashboard for tasks running in the cluster:
 
@@ -263,6 +302,21 @@ kubectl describe pod <pod-name> | grep -A 5 "Events"
 Common causes:
 - **Network issues**: Ensure Docker can reach `ghcr.io` (try `docker pull ghcr.io/michelangelo-ai/worker:latest`)
 - **Image doesn't exist**: Verify the image tag matches what's available in the registry
+
+### Worker crashes with `Namespace default is not found` (Temporal only)
+
+The Temporal `default` namespace must be registered after the sandbox starts. If the worker is in `CrashLoopBackOff`:
+
+```bash
+# Port-forward the Temporal frontend
+kubectl port-forward svc/michelangelo-temporal-frontend 7233:7233 &
+
+# Register the default namespace
+temporal operator namespace create default
+
+# Restart the worker to pick it up
+kubectl rollout restart deployment/michelangelo-worker
+```
 
 ### Pods stuck in `CrashLoopBackOff`
 


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**

Rewrote two getting-started guides based on a full technical audit against the codebase:

`sandbox-setup.md`:
- Added `git clone` step, audience callout, OS support statement, and "What you'll have at the end" success picture
- Added Cadence-as-default guidance (with when-to-use-Temporal note) and Michelangelo UI URL as the visible verification signal
- Removed `cadence-workflow` CLI prerequisite — domain registration is automatic via `ma sandbox create` (`sandbox.py:774-830`)
- Added Linux install alternatives for all prerequisites; replaced 100-line remote-run section with a smoke test + links out to ml-pipelines guides; clarified pod count (10–15) and startup timing (2–3 min)

`ma-sandbox-ports-and-endpoints.md`:
- Fixed Temporal section: removed manual port-forward instructions to nonexistent `temporaltest-*` services; Temporal Web is auto-mapped to host 8080 by k3d at create time
- Fixed in-cluster service names throughout (`ma-apiserver` → `michelangelo-apiserver`, etc. per `_helpers.tpl:75-82`)
- Fixed controllermgr metrics port (8080 → 8091 per `values.yaml`); removed nonexistent webhook port 9443
- Added four missing services: Michelangelo UI (8090), Grafana (3000), Prometheus (9092), MLflow (5001, conditional on `--include-experimental`)
- Added MinIO/MySQL login credentials, quick-links table, connection examples, and fixed heading hierarchy

**Why?**

Technical audit revealed factually wrong content (wrong service names, a port-forward that doesn't work, a prerequisite CLI that's never used) and missing content that would block external users (no git clone step, no UI URL, no credentials). These are getting-started guides that OSS users hit first.

**How did you test it?**

Ran `cd website && bun run start` and verified both pages render correctly. Ran `bun run build` — only pre-existing broken link in `contributing/system-design/` flagged; both edited files build clean.

**Potential risks**

None — documentation only.

**Release notes**

N/A

**Documentation Changes**

- `docs/getting-started/sandbox-setup.md` — rewritten for OSS quality and technical accuracy
- `docs/getting-started/ma-sandbox-ports-and-endpoints.md` — rewritten for OSS quality and technical accuracy