### PR TITLE
chore: add missing yaml@^1.10.2 yarn.lock entry

### DIFF
--- a/javascript/yarn.lock
+++ b/javascript/yarn.lock
@@ -5401,6 +5401,11 @@ yaml@^1.10.0:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
+yaml@^1.10.2:
+  version "1.10.3"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.3.tgz#76e407ed95c42684fb8e14641e5de62fe65bbcb3"
+  integrity sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==
+
 yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"


### PR DESCRIPTION
## Summary

PR #1161 added `yaml@^1.10.2` as an explicit dep in `packages/core/package.json` but its lockfile update only included the `yaml@^1.10.0` resolution. Both ranges resolved compatibly so nothing broke, but `yarn install` now consistently regenerates the `^1.10.2` entry — producing dirty lockfile diffs in any branch where someone runs install.

This lands the entry that `yarn install` already wants, so the lockfile stops drifting.

## Test plan

- [x] `yarn install` reports `Already up-to-date.` after the patched state
- [ ] CI's `format` / `lint` / `unit-tests` jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)