### PR TITLE
fix: bracket-notation slash keys missing from error banner

### DIFF
--- a/javascript/packages/core/components/form/__tests__/form.test.tsx
+++ b/javascript/packages/core/components/form/__tests__/form.test.tsx
@@ -822,6 +822,24 @@ describe('Form', () => {
       expect(within(errorDisplay).getByText('This field is required.')).toBeInTheDocument();
       expect(within(errorDisplay).queryByRole('button')).not.toBeInTheDocument();
     });
+
+    it('shows error in banner for a field with a bracket-notation slash key', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <Form onSubmit={vi.fn()}>
+          <StringField name="labels[some/key]" label="Label" required />
+          <FormErrorBanner />
+          <button type="submit">Submit</button>
+        </Form>,
+        wrapper
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      const banner = await screen.findByRole('complementary');
+      expect(within(banner).getByText('This field is required.')).toBeInTheDocument();
+    });
   });
 
   describe('FormDialog', () => {

--- a/javascript/packages/core/components/form/components/form-error-banner/use-form-error-list.ts
+++ b/javascript/packages/core/components/form/components/form-error-banner/use-form-error-list.ts
@@ -1,8 +1,7 @@
-import { FORM_ERROR } from 'final-form';
+import { FORM_ERROR, getIn } from 'final-form';
 
 import { useFormContext } from '#core/components/form/form-context';
 import { useFormState } from '#core/components/form/hooks/use-form-state';
-import { toFlatDotPathMap } from '#core/utils/object-utils';
 
 import type { ErrorEntry } from './types';
 
@@ -27,9 +26,11 @@ export function useFormErrorList(): ErrorEntry[] {
 
   const fieldEntries: ErrorEntry[] = [];
 
-  for (const [fieldPath, errorMessage] of Object.entries(toFlatDotPathMap(errors))) {
+  for (const [fieldPath, isTouched] of Object.entries(touched ?? {})) {
+    if (!isTouched) continue;
+
+    const errorMessage = getIn(errors, fieldPath);
     if (typeof errorMessage !== 'string') continue;
-    if (!touched?.[fieldPath]) continue;
 
     fieldEntries.push({
       fieldPath,

--- a/javascript/packages/core/components/form/components/form-error-banner/use-form-error-list.ts
+++ b/javascript/packages/core/components/form/components/form-error-banner/use-form-error-list.ts
@@ -29,7 +29,7 @@ export function useFormErrorList(): ErrorEntry[] {
   for (const [fieldPath, isTouched] of Object.entries(touched ?? {})) {
     if (!isTouched) continue;
 
-    const errorMessage = getIn(errors, fieldPath);
+    const errorMessage: unknown = getIn(errors, fieldPath);
     if (typeof errorMessage !== 'string') continue;
 
     fieldEntries.push({


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Bug Fix

**What changed?**
`use-form-error-list.ts` now iterates over `touched` keys and uses final-form's `getIn` to resolve each field's error, replacing the previous approach of flattening `errors` with `toFlatDotPathMap` and looking up each key in `touched`.

**Why?**
Fields registered with bracket-notation paths containing a `/` (e.g. `labels[some/key]`) were silently dropped from the `FormErrorBanner` after submit.

final-form's `setIn` parses bracket-notation paths into nested objects, so a field named `labels[some/key]` produces an errors object shaped as `{ labels: { 'some/key': 'Required' } }`. `toFlatDotPathMap` flattened this to `'labels.some/key'`, which never matched the `touched` key `'labels[some/key]'` — so the field was always filtered out and the error never appeared in the banner.

**How did you test it?**
Added a regression test that fails when I revert the use-form-error-list hook changes.

**Potential risks**
Low. The change is isolated to `use-form-error-list.ts`. The new iteration is logically equivalent for the common case (simple dot-notation paths) and correct for the bracket-notation slash case that was previously broken.

**Release notes**
None required.

**Documentation Changes**
None.