### PR TITLE
Register auto generated version conversion functions to k8s scheme

### DIFF
--- a/bazel/rules/proto/BUILD.bazel
+++ b/bazel/rules/proto/BUILD.bazel
@@ -57,6 +57,8 @@ go_proto_compiler(
     visibility = ["//visibility:public"],
     deps = [
         "@com_github_gogo_protobuf//proto:go_default_library",
+        "@io_k8s_apimachinery//pkg/conversion:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/conversion:go_default_library",
         "@org_golang_google_protobuf//types/descriptorpb:go_default_library",
         "@org_golang_google_protobuf//types/pluginpb:go_default_library",

--- a/go/cmd/kubeproto/protoc-gen-kubeconversion/README.md
+++ b/go/cmd/kubeproto/protoc-gen-kubeconversion/README.md
@@ -16,12 +16,66 @@ The goal is to **avoid hand-written converters** and ensure mappings are
   - The conversion logic can be customized with protobuf options below.
   - Developers can write custom conversion logic by implementing the generated convertor interfaces.
 
+- **Automatic scheme registration**:
+  - For each top-level CRD type in a spoke version, the generated code registers the conversion functions into the package-level `SchemeBuilder` via an `init()` function.
+  - No changes are needed in application code: the existing `AddToScheme` call automatically applies the registered conversion functions to the scheme.
+  - This enables scheme-based conversion via `scheme.ConvertToVersion()`, in addition to the direct `ConvertTo`/`ConvertFrom` interface used by the controller-runtime webhook server.
+  - Hub versions do not emit any scheme registration.
+
 - **Hub & Spoke versions**:
   - The generated code follows the Hub & Spoke model in version conversion ([Conversion concepts](https://book.kubebuilder.io/multiversion-tutorial/conversion-concepts)).
   - For spoke versions (where `version != hub_version`), the generated code implements [controller-runtime](https://github.com/kubernetes-sigs/controller-runtime)'s conversion.Convertible interface.
   - For hub versions (where `version == hub_version`), the generated code implements [controller-runtime](https://github.com/kubernetes-sigs/controller-runtime)'s conversion.Hub interface.
 
-- **Conversion rules**:
+---
+
+## Scheme Registration
+
+For each top-level CRD type in a spoke version, the generator emits an `init()` function that appends a conversion-registration callback to the package-level `SchemeBuilder`.
+
+### Generated code (spoke version)
+
+```go
+func init() {
+    SchemeBuilder.SchemeBuilder.Register(func(s *runtime.Scheme) error {
+        if err := s.AddGeneratedConversionFunc((*v1.Project)(nil), (*v2.Project)(nil),
+            func(a, b interface{}, _ conversion.Scope) error {
+                return a.(*v1.Project).ConvertTo(b.(crconversion.Hub))
+            }); err != nil {
+            return err
+        }
+        return s.AddGeneratedConversionFunc((*v2.Project)(nil), (*v1.Project)(nil),
+            func(a, b interface{}, _ conversion.Scope) error {
+                return b.(*v1.Project).ConvertFrom(a.(crconversion.Hub))
+            })
+    })
+}
+```
+
+`SchemeBuilder` is the package-level `*scheme.Builder` generated from `groupversion_info.proto`. Because `scheme.Builder` embeds `runtime.SchemeBuilder`, the callback is automatically invoked when `AddToScheme` is called — no extra wiring is needed in application code.
+
+### Usage
+
+```go
+scheme := runtime.NewScheme()
+// Registers CRD types AND conversion functions for all spoke CRDs.
+if err := v1.AddToScheme(scheme); err != nil { ... }
+if err := v2.AddToScheme(scheme); err != nil { ... }
+
+// Scheme-based conversion now works in both directions.
+out, err := scheme.ConvertToVersion(v1obj, v2.GroupVersion)
+```
+
+:::note
+This registration only covers top-level CRD types (those marked `resource.conversion = true`). Sub-messages do not get scheme registration because their conversion is handled internally by the top-level `ConvertTo`/`ConvertFrom` methods.
+
+Hub versions emit no registration at all.
+:::
+
+---
+
+## Conversion Rules
+
   - Fields with the same name and compatible type are auto-mapped.
   - Renamed or moved fields can be mapped via Protobuf options.
   - Unmapped fields must be explicitly ignored; otherwise a build error is raised.

--- a/go/kubeproto/conversion/BUILD.bazel
+++ b/go/kubeproto/conversion/BUILD.bazel
@@ -27,6 +27,7 @@ go_test(
         "//proto/test/kubeproto/conversion/v2:go_default_library",
         "@com_github_r3labs_diff_v3//:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/conversion:go_default_library",
     ],
 )

--- a/go/kubeproto/conversion/version_conversion.go
+++ b/go/kubeproto/conversion/version_conversion.go
@@ -711,6 +711,22 @@ func generateFileSpoke(gen *protogen.Plugin, targets map[string]*protogen.Messag
 			g.P("return nil")
 			g.P("}")
 			g.P()
+
+			k8sRuntimeSchemeIdent := protogen.GoIdent{GoImportPath: "k8s.io/apimachinery/pkg/runtime", GoName: "Scheme"}
+			k8sConversionScopeIdent := protogen.GoIdent{GoImportPath: "k8s.io/apimachinery/pkg/conversion", GoName: "Scope"}
+			g.P("func init() {")
+			g.P("SchemeBuilder.SchemeBuilder.Register(func(s *", k8sRuntimeSchemeIdent, ") error {")
+			g.P("if err := s.AddGeneratedConversionFunc((*", g.QualifiedGoIdent(spokeMsg.GoIdent), ")(nil), (*", g.QualifiedGoIdent(hubMsg.GoIdent), ")(nil), func(a, b interface{}, _ ", g.QualifiedGoIdent(k8sConversionScopeIdent), ") error {")
+			g.P("return a.(*", g.QualifiedGoIdent(spokeMsg.GoIdent), ").ConvertTo(b.(", g.QualifiedGoIdent(hubTypeIndet), "))")
+			g.P("}); err != nil {")
+			g.P("return err")
+			g.P("}")
+			g.P("return s.AddGeneratedConversionFunc((*", g.QualifiedGoIdent(hubMsg.GoIdent), ")(nil), (*", g.QualifiedGoIdent(spokeMsg.GoIdent), ")(nil), func(a, b interface{}, _ ", g.QualifiedGoIdent(k8sConversionScopeIdent), ") error {")
+			g.P("return b.(*", g.QualifiedGoIdent(spokeMsg.GoIdent), ").ConvertFrom(a.(", g.QualifiedGoIdent(hubTypeIndet), "))")
+			g.P("})")
+			g.P("})")
+			g.P("}")
+			g.P()
 		} else {
 			// Forward
 			g.P("func Convert", name, "ToHub", "(in *", name, ", out *", g.QualifiedGoIdent(hubMsg.GoIdent), ") error {")

--- a/go/kubeproto/conversion/version_conversion_test.go
+++ b/go/kubeproto/conversion/version_conversion_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/r3labs/diff/v3"
 	"github.com/stretchr/testify/assert"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
 	v1pb "github.com/michelangelo-ai/michelangelo/proto-go/test/kubeproto/conversion/v1"
@@ -20,6 +21,46 @@ func TestGen(t *testing.T) {
 	data2 := v2pb.GetProtocReqData()
 	resp2 := Generate(data2)
 	assert.NotNil(t, resp2)
+}
+
+// TestSchemeConvertToVersion verifies that AddToScheme registers the generated conversion
+// functions so that scheme.ConvertToVersion can convert between spoke and hub versions.
+func TestSchemeConvertToVersion(t *testing.T) {
+	s := k8sruntime.NewScheme()
+	assert.NoError(t, v1pb.AddToScheme(s))
+	assert.NoError(t, v2pb.AddToScheme(s))
+
+	v1obj := &v1pb.TestObject{
+		Spec: v1pb.TestObjectSpec{
+			F1: 42,
+			F2: []string{"hello", "world"},
+			F3: &v1pb.M1{
+				F1: []v1pb.E1{v1pb.E1_2, v1pb.E1_3},
+				F2: map[string]string{"k": "v"},
+			},
+		},
+		Status: v1pb.TestObjectStatus{F1: v1pb.E1_2},
+	}
+
+	// spoke → hub
+	out, err := s.ConvertToVersion(v1obj, v2pb.GroupVersion)
+	assert.NoError(t, err)
+	v2obj, ok := out.(*v2pb.TestObject)
+	assert.True(t, ok)
+	assert.Equal(t, int32(42), v2obj.Spec.F1)
+	assert.Equal(t, []string{"hello", "world"}, v2obj.Spec.F2)
+	assert.Equal(t, []v2pb.E1{v2pb.E1_2, v2pb.E1_3}, v2obj.Spec.F3.F1)
+	assert.Equal(t, v2pb.E1_2, v2obj.Status.F1)
+
+	// hub → spoke
+	out2, err := s.ConvertToVersion(v2obj, v1pb.GroupVersion)
+	assert.NoError(t, err)
+	v1objres, ok := out2.(*v1pb.TestObject)
+	assert.True(t, ok)
+	assert.Equal(t, int32(42), v1objres.Spec.F1)
+	assert.Equal(t, []string{"hello", "world"}, v1objres.Spec.F2)
+	assert.Equal(t, []v1pb.E1{v1pb.E1_2, v1pb.E1_3}, v1objres.Spec.F3.F1)
+	assert.Equal(t, v1pb.E1_2, v1objres.Status.F1)
 }
 
 func TestConvert(t *testing.T) {

--- a/proto-go/test/api/v2alpha1/project.conversion.pb.go
+++ b/proto-go/test/api/v2alpha1/project.conversion.pb.go
@@ -5,6 +5,8 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	types "github.com/gogo/protobuf/types"
 	v2 "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
+	conversion1 "k8s.io/apimachinery/pkg/conversion"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	conversion "sigs.k8s.io/controller-runtime/pkg/conversion"
 )
 
@@ -101,6 +103,19 @@ func (dst *Project) ConvertFrom(srcRaw conversion.Hub) error {
 		return customProjectConvertor.ConvertFromHub(src, dst)
 	}
 	return nil
+}
+
+func init() {
+	SchemeBuilder.SchemeBuilder.Register(func(s *runtime.Scheme) error {
+		if err := s.AddGeneratedConversionFunc((*Project)(nil), (*v2.Project)(nil), func(a, b interface{}, _ conversion1.Scope) error {
+			return a.(*Project).ConvertTo(b.(conversion.Hub))
+		}); err != nil {
+			return err
+		}
+		return s.AddGeneratedConversionFunc((*v2.Project)(nil), (*Project)(nil), func(a, b interface{}, _ conversion1.Scope) error {
+			return b.(*Project).ConvertFrom(a.(conversion.Hub))
+		})
+	})
 }
 
 func ConvertProjectSpecToHub(in *ProjectSpec, out *v2.ProjectSpec) error {

--- a/proto-go/test/kubeproto/conversion/v1/testobject.conversion.pb.go
+++ b/proto-go/test/kubeproto/conversion/v1/testobject.conversion.pb.go
@@ -3,6 +3,8 @@ package v1
 
 import (
 	v2 "github.com/michelangelo-ai/michelangelo/proto-go/test/kubeproto/conversion/v2"
+	conversion1 "k8s.io/apimachinery/pkg/conversion"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	conversion "sigs.k8s.io/controller-runtime/pkg/conversion"
 )
 
@@ -185,6 +187,19 @@ func (dst *TestObject) ConvertFrom(srcRaw conversion.Hub) error {
 		return customTestObjectConvertor.ConvertFromHub(src, dst)
 	}
 	return nil
+}
+
+func init() {
+	SchemeBuilder.SchemeBuilder.Register(func(s *runtime.Scheme) error {
+		if err := s.AddGeneratedConversionFunc((*TestObject)(nil), (*v2.TestObject)(nil), func(a, b interface{}, _ conversion1.Scope) error {
+			return a.(*TestObject).ConvertTo(b.(conversion.Hub))
+		}); err != nil {
+			return err
+		}
+		return s.AddGeneratedConversionFunc((*v2.TestObject)(nil), (*TestObject)(nil), func(a, b interface{}, _ conversion1.Scope) error {
+			return b.(*TestObject).ConvertFrom(a.(conversion.Hub))
+		})
+	})
 }
 
 func ConvertTestObjectSpecToHub(in *TestObjectSpec, out *v2.TestObjectSpec) error {


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
register the generated CRD version conversion functions to k8s scheme

<!-- Tell your future self why have you made these changes -->
**Why?**
When handling multiple versions in mysql storage and other modules, it's more convenient to use the high level version conversion utils (e.g. ConvertToVersion function) provided by k8s scheme, rather than calling the CRD/version specific conversion functions directly

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
README.md changes are included