### PR TITLE
fix: honor --exclude in sandbox k3d port forwards

### DIFF
--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -45,6 +45,14 @@ _infra_ports = [
     "5001:30013",  # MLflow Tracking Server
 ]
 
+# Infra ports owned by optionally-excluded services. When the user passes
+# --exclude {svc}, the corresponding host port is dropped from k3d's port
+# forwards so it doesn't conflict with other processes on the host.
+_infra_port_owner = {
+    "3000:30012": "grafana",
+    "9092:30015": "prometheus",
+}
+
 # Ray framework ports (not in Helm chart)
 _ray_ports = [
     "10001:10001",  # Ray client port
@@ -238,7 +246,8 @@ def run(ns: argparse.Namespace):
 
 def _create(ns: argparse.Namespace):
     assert ns
-    ports = _infra_ports + _helm_chart_ports(ns.workflow)
+    infra_ports = [p for p in _infra_ports if _infra_port_owner.get(p) not in ns.exclude]
+    ports = infra_ports + _helm_chart_ports(ns.workflow)
     args = [
         "k3d",
         "cluster",

--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -246,7 +246,9 @@ def run(ns: argparse.Namespace):
 
 def _create(ns: argparse.Namespace):
     assert ns
-    infra_ports = [p for p in _infra_ports if _infra_port_owner.get(p) not in ns.exclude]
+    infra_ports = [
+        p for p in _infra_ports if _infra_port_owner.get(p) not in ns.exclude
+    ]
     ports = infra_ports + _helm_chart_ports(ns.workflow)
     args = [
         "k3d",


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Bug Fix

<!-- Describe what has changed in this PR -->
**What changed?**

`ma sandbox create --exclude {grafana|prometheus}` now also drops the corresponding host port from the k3d cluster's port-forward list, so the cluster spec matches the services that are actually being deployed.

<!-- Tell your future self why have you made these changes -->
**Why?**

`--exclude grafana` and `--exclude prometheus` skipped deploying those services but left their host port mappings in the k3d cluster spec. The cluster still tried to bind ports 3000 and 9092 on the host at start time, and if anything else on the developer's machine was already listening on either port, `sandbox create` would fail with a bind error during cluster startup.

The port mapping and the deploy step are two halves of the same decision; they should be driven from the same source of truth.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

With port 3000 held by local dev server, ran the patched `ma sandbox create --exclude grafana`. k3d cluster came up cleanly — port 3000 was no longer in the `-p` list passed to `k3d cluster create`, so no bind attempt, no conflict. The create proceeded all the way through helm install michelangelo and ended with `🚀 Sandbox created successfully`.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

Local-developer-only change — the sandbox CLI isn't part of any deployed artifact. Mapping is keyed on the exact `host:nodeport` string, so any future change to those port strings in `_infra_ports` needs a matching update to `_infra_port_owner`.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

N/A — local developer tooling.

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**

N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)