### PR TITLE
Add rollout fail stage

### DIFF
--- a/javascript/packages/core/config/entities/deployment/__tests__/deployment-page.test.tsx
+++ b/javascript/packages/core/config/entities/deployment/__tests__/deployment-page.test.tsx
@@ -208,13 +208,7 @@ describe('Deployment detail page', () => {
                 status: {
                   state: DEPLOYMENT_STATE.UNHEALTHY,
                   stage: DEPLOYMENT_STAGE.ROLLOUT_FAILED,
-                  conditions: [
-                    {
-                      type: 'CurrentCondition',
-                      status: DEPLOYMENT_CONDITION_STATUS.UNKNOWN,
-                      lastUpdatedTimestamp: '1746002400000',
-                    },
-                  ],
+                  conditions: [],
                   conditionsSnapshot: [
                     {
                       type: 'SnapshotValidation',
@@ -239,6 +233,6 @@ describe('Deployment detail page', () => {
 
     await screen.findAllByText('SnapshotValidation');
     await screen.findAllByText('SnapshotPlacement');
-    expect(screen.queryByText('CurrentCondition')).not.toBeInTheDocument();
+    await screen.findByText('NoCapacity')
   });
 });

--- a/javascript/packages/core/config/entities/deployment/__tests__/deployment-page.test.tsx
+++ b/javascript/packages/core/config/entities/deployment/__tests__/deployment-page.test.tsx
@@ -192,4 +192,53 @@ describe('Deployment detail page', () => {
     expect(screen.getByText('Details')).toBeInTheDocument();
     expect(screen.getByText('PlacementInProgress')).toBeInTheDocument();
   });
+
+  it('renders stages when rollout has failed', async () => {
+    render(
+      <EntityDetailRoute phases={{ deploy: DEPLOY_PHASE }} />,
+      buildWrapper([
+        getErrorProviderWrapper(),
+        getRouterWrapper({
+          location: '/myproject/deploy/deployments/sentiment-deployment/stages',
+        }),
+        getServiceProviderWrapper({
+          request: createQueryMockRouter({
+            GetDeployment: {
+              deployment: buildDeployment({
+                status: {
+                  state: DEPLOYMENT_STATE.UNHEALTHY,
+                  stage: DEPLOYMENT_STAGE.ROLLOUT_FAILED,
+                  conditions: [
+                    {
+                      type: 'CurrentCondition',
+                      status: DEPLOYMENT_CONDITION_STATUS.UNKNOWN,
+                      lastUpdatedTimestamp: '1746002400000',
+                    },
+                  ],
+                  conditionsSnapshot: [
+                    {
+                      type: 'SnapshotValidation',
+                      status: DEPLOYMENT_CONDITION_STATUS.TRUE,
+                      lastUpdatedTimestamp: '1746000600000',
+                    },
+                    {
+                      type: 'SnapshotPlacement',
+                      status: DEPLOYMENT_CONDITION_STATUS.FALSE,
+                      message: 'Failed to place on inference server.',
+                      reason: 'NoCapacity',
+                      lastUpdatedTimestamp: '1746001200000',
+                    },
+                  ],
+                },
+              }),
+            },
+          }),
+        }),
+      ])
+    );
+
+    await screen.findAllByText('SnapshotValidation');
+    await screen.findAllByText('SnapshotPlacement');
+    expect(screen.queryByText('CurrentCondition')).not.toBeInTheDocument();
+  });
 });

--- a/javascript/packages/core/config/entities/deployment/__tests__/deployment-page.test.tsx
+++ b/javascript/packages/core/config/entities/deployment/__tests__/deployment-page.test.tsx
@@ -233,6 +233,6 @@ describe('Deployment detail page', () => {
 
     await screen.findAllByText('SnapshotValidation');
     await screen.findAllByText('SnapshotPlacement');
-    await screen.findByText('NoCapacity')
+    await screen.findByText('NoCapacity');
   });
 });

--- a/javascript/packages/core/config/entities/deployment/detail.ts
+++ b/javascript/packages/core/config/entities/deployment/detail.ts
@@ -2,6 +2,7 @@ import { CellType } from '#core/components/cell/constants';
 import { TASK_STATE } from '#core/components/views/execution/constants';
 import {
   DEPLOYMENT_CONDITION_STATUS,
+  DEPLOYMENT_STAGE,
   DEPLOYMENT_STAGE_CELL,
   DEPLOYMENT_STATE_CELL,
 } from './shared';
@@ -26,7 +27,14 @@ export const DEPLOYMENT_DETAIL_CONFIG: DetailViewConfig = {
         description: 'Stages will appear here when a deployment rollout is in progress',
       },
       tasks: {
-        accessor: 'status.conditions',
+        accessor: (data: {
+          status?: { stage?: number; conditions?: object[]; conditionsSnapshot?: object[] };
+        }) => {
+          if (data?.status?.stage === DEPLOYMENT_STAGE.ROLLOUT_FAILED) {
+            return data?.status?.conditionsSnapshot ?? [];
+          }
+          return data?.status?.conditions ?? [];
+        },
         header: {
           heading: 'type',
           metadata: [

--- a/javascript/packages/core/config/entities/deployment/detail.ts
+++ b/javascript/packages/core/config/entities/deployment/detail.ts
@@ -30,10 +30,11 @@ export const DEPLOYMENT_DETAIL_CONFIG: DetailViewConfig = {
         accessor: (data: {
           status?: { stage?: number; conditions?: object[]; conditionsSnapshot?: object[] };
         }) => {
-          if (data?.status?.stage === DEPLOYMENT_STAGE.ROLLOUT_FAILED) {
-            return data?.status?.conditionsSnapshot ?? [];
-          }
-          return data?.status?.conditions ?? [];
+          const conditions =
+            data?.status?.stage === DEPLOYMENT_STAGE.ROLLOUT_FAILED
+              ? data?.status?.conditionsSnapshot
+              : data?.status?.conditions;
+          return conditions ?? [];
         },
         header: {
           heading: 'type',


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
In the case of a failed rollout for a deployment, we will use `status.conditionsSnapshot` rather than `status.conditions`.

<img width="600"  alt="image" src="https://github.com/user-attachments/assets/273eb943-4336-4e06-8f63-ba3879d859ac" />



<!-- Tell your future self why have you made these changes -->
**Why?**
For failed rollouts, we preserve the conditions of the failure in `conditionsSnapshot` rather than `conditions` so we want to properly represent that here.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests and checking the UI

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
None

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
N/A
<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
N/A