### PR TITLE
fix(pipelinerun): TTLDays=0 should disable eviction, not trigger immediately

### DIFF
--- a/go/components/pipelinerun/controller.go
+++ b/go/components/pipelinerun/controller.go
@@ -180,6 +180,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 //   - done=true: TTL has elapsed; annotation was set (or was already set).
 //   - done=false: TTL has not elapsed yet; caller should requeue after requeueAfter.
 func (r *Reconciler) markImmutableIfExpired(ctx context.Context, logger *zap.Logger, pipelineRun *v2pb.PipelineRun) (time.Duration, bool) {
+	// TTLDays == 0 means eviction is disabled.
+	if r.config.TTLDays == 0 {
+		return 0, true
+	}
+
 	var lastUpdate time.Time
 	if endTime := pipelineRun.Status.GetEndTime(); endTime != nil {
 		lastUpdate = time.Unix(endTime.Seconds, int64(endTime.Nanos))


### PR DESCRIPTION
## Summary

- `TTLDays=0` (the default, unset) was being treated as "expire immediately" because `expireAt = lastUpdate + 0` is already in the past
- This caused every terminal PipelineRun to be marked `michelangelo/Immutable=true` on the same reconcile it became terminal — the opposite of the documented behavior
- Added an explicit early-return guard when `TTLDays == 0`

## Test plan
- [ ] `go test ./go/components/pipelinerun/...` passes
- [ ] Integration test CLI e2e passes (this bug was causing FAILED pipeline runs to be evicted from ETCD immediately, interfering with test assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)