### PR TITLE
docs: add roadmap page

### DIFF
--- a/docs/about/roadmap.md
+++ b/docs/about/roadmap.md
@@ -21,7 +21,7 @@ The OSS release is staged so each version makes a specific, scoped promise rathe
 
 Michelangelo follows [Semantic Versioning 2.0.0](https://semver.org/) with stability declared per component, not per repository.
 
-| Tier | Guarantee |
+| Stability Level | Guarantee |
 |---|---|
 | **stable** | Backwards-compatible across all minor and patch versions within a major. Breaking changes only at the next major. |
 | **beta** | API may change between minor versions. Migration notes required in CHANGELOG. Breaking changes called out explicitly. |

--- a/docs/about/roadmap.md
+++ b/docs/about/roadmap.md
@@ -13,9 +13,9 @@ The OSS release is staged so each version makes a specific, scoped promise rathe
 
 | Version | Target | Focus |
 |---|---|---|
-| **0.1.2** | June 2026 | Core pipeline platform — UniFlow, Ray, pipeline and run management, MA CLI and Studio |
-| **1.0** | July 2026 | End-to-end LLM model management — fine-tuning, model registry, progressive serving, full lineage |
-| **1.1** | Q3 2026 | Agent + LLM Gateway — K8s-native containerized agent jobs, deployment-aware LLM routing |
+| **0.1.2** | 2026 | Core pipeline platform — UniFlow, Ray, pipeline and run management, MA CLI and Studio |
+| **1.0** | 2026 | End-to-end LLM model management — fine-tuning, model registry, progressive serving, full lineage |
+| **1.1** | 2026 | Agent + LLM Gateway — K8s-native containerized agent jobs, deployment-aware LLM routing |
 
 ## Versioning Policy
 

--- a/docs/about/roadmap.md
+++ b/docs/about/roadmap.md
@@ -5,7 +5,7 @@ sidebar_label: "Roadmap"
 
 # Roadmap
 
-Michelangelo is under active development. This page captures the current state of the platform and the direction we're headed — it is intentionally not a detailed spec or a delivery commitment. Things will shift as priorities evolve and the community gives feedback.
+Michelangelo is under active development. This page captures the current state of the platform and the direction we're headed. Things will shift as priorities evolve and the community gives feedback.
 
 ## Available Now
 
@@ -73,7 +73,7 @@ These features are actively being built and will land in upcoming releases.
 
 ## On the Radar
 
-These are areas we expect Michelangelo to grow into. None of them are committed features yet — they signal direction, not a fixed schedule.
+These are planned enhancencements that we are working towards adding down the road.
 
 **Generative AI & LLM**
 - GenAI service deployment: first-class support for deploying and managing LLM-backed services within the Michelangelo lifecycle.

--- a/docs/about/roadmap.md
+++ b/docs/about/roadmap.md
@@ -13,9 +13,9 @@ The OSS release is staged so each version makes a specific, scoped promise rathe
 
 | Version | Target | Focus |
 |---|---|---|
-| **0.1.2** | 2026 | Core pipeline platform — UniFlow, Ray, pipeline and run management, MA CLI and Studio |
-| **1.0** | 2026 | End-to-end LLM model management — fine-tuning, model registry, progressive serving, full lineage |
-| **1.1** | 2026 | Agent + LLM Gateway — K8s-native containerized agent jobs, deployment-aware LLM routing |
+| **0.1.2** | June 2026 | Release management + core pipeline platform — UniFlow, Ray, pipeline/run/trigger management, MA commands, MA Studio |
+| **0.2.0** | July 2026 | End-to-end LLM model management — Foundation Model fine-tuning, model registry, offline inference, progressive serving |
+| **0.3.0** | Q3 FY26 | Agent + LLM Gateway — K8s-native containerized agent (Agent Job API + Controller Manager) + LLM Gateway (LiteLLM or Bifrost, CRD-sync routing) |
 
 ## Versioning Policy
 

--- a/docs/about/roadmap.md
+++ b/docs/about/roadmap.md
@@ -13,10 +13,10 @@ These capabilities are shipped and available in the current release.
 
 **Project & Pipeline Management**
 - Project creation and lifecycle management
-- Pipeline authoring in YAML, Python, and ASL/Uniflow
+- Pipeline authoring in YAML, Python, and Uniflow
 - Revision management and versioning
-- Overridable parameters via Terrablob URLs
-- Auto-flip triggers on master branch merge
+- Overridable parameters via S3/GCS URLs
+- Auto-flip triggers on main branch merge
 
 **Pipeline Execution**
 - Pipeline run execution
@@ -26,20 +26,20 @@ These capabilities are shipped and available in the current release.
 
 **Distributed Training**
 - Ray job launch and management
-- Spark job launch on Kubernetes and Peloton
+- Spark job launch on Kubernetes
 - Persistent Ray clusters via RayCluster CRD
-- Federated multi-cluster dispatch and status sync
+- Federated multi-cluster dispatch
 
 **Model Serving**
 - Inference server creation
-- Deployment rollout strategies
+- Deployment rollout strategies (Blast, Rolling, Zonal, Shadow/A-B)
 - Endpoint traffic splitting and shadow routing
 - Training insights
 
 **Infrastructure & Compute**
 - Compute cluster registration
 - Resource pool selection
-- Storage management via Terrablob
+- Storage management via S3/GCS
 
 **Automation & Self-Healing**
 - Revision-gated state transitions
@@ -52,7 +52,7 @@ These features are actively being built and will land in upcoming releases.
 
 **Project Management**
 - GenAI project flavor support
-- Team ownership via uOwn
+- Team ownership via OSS ownership model (CODEOWNERS)
 
 **Pipeline Authoring**
 - Draft-based authoring workflow
@@ -63,26 +63,80 @@ These features are actively being built and will land in upcoming releases.
 - Decommission workflow with no-traffic validation gate
 - DeploymentEvent tracking
 
+**Generative AI & LLM**
+- GenAI service deployment: first-class support for deploying and managing LLM-backed inference endpoints
+
+**Evaluation & Reporting**
+- Experiment reports
+
+**Alerting & Monitoring**
+- Alert-triggered auto rollback
+- Dashboard management via OSS Grafana operator
+- Prometheus-based alerting for decommission gating
+
 **Infrastructure**
 - Notebook (Jupyter) sessions
-- Docker image builds via ImageBuild CRD
+- Docker image builds via Kaniko/BuildKit
 
-**Observability**
-- Dashboard management
-- Experiment reports
+**Automation**
+- Finalizer-based cascade deletion (Pipeline → Revisions; FeatureGroup → Datasets)
 
 ## On the Radar
 
-These are planned enhancencements that we are working towards adding down the road.
+These are planned capabilities we are working towards adding down the road.
+
+**Project Management**
+- Cloud zone annotations for multi-cloud routing
+- Git repository migration allowlist
+- Routing affinity inheritance (parent-to-child annotation propagation)
+
+**Pipeline Authoring & Execution**
+- Concurrent update protection via optimistic locking
+- Canvas release version validation
+- Block dev-branch runs in production (safety gate enforcement)
+
+**Distributed Training**
+- GPU SKU normalization and validation via ConfigMap
+- mTLS injection via cert-manager or OSS SPIFFE
+- Prometheus ConfigMap auto-creation per job
+- Job immutability (15-minute lock after kill)
+- Spark obsolescence enforcement (7-day auto-kill for runaway jobs)
+- Resource usage metrics emission
+
+**Model Deployment**
+- Lockdown self-healing: detect and auto-remediate cluster lockdown conditions
+- Traffic routing via Istio/Envoy OSS gateway
+- Compute lockdown detection
+- Global endpoint name uniqueness (cross-namespace validation)
+
+**Feature Store**
+- Feature and feature group management
+- Online feature store (low-latency feature serving)
+- Offline feature datasets
+- Feature serving groups
+- Feature monitor with drift detection (Wasserstein, KL-divergence, PSI, LOF)
+- Feature quality metrics
+- Lineage event tracking on create/delete via OpenLineage
+- Cascading deletion (FeatureGroup → Dataset)
 
 **Generative AI & LLM**
-- GenAI service deployment: first-class support for deploying and managing LLM-backed services within the Michelangelo lifecycle.
+- AI agent management with declarative agent definitions and LLM registry
+- Prompt template management
+- Guardrail policies (input/output safety filtering, bias detection)
 
-**Evaluation & Experimentation**
-- A structured evaluation framework for comparing training runs, tracking metrics across experiments, and producing shareable experiment reports.
+**Evaluation & Reporting**
+- Structured evaluation reports
+- Model cards
 
 **Alerting & Monitoring**
-- Full uMonitor integration for decommission gating and alert-driven automation across the deployment lifecycle.
+- Alert CRD management
+- Default cron schedules by alert type
+
+**Infrastructure & Compute**
+- Vector dataset management for embedding and RAG/similarity search
+
+**Automation & Self-Healing**
+- Lockdown self-healing: detect and auto-remediate cluster lockdown conditions
 
 ---
 

--- a/docs/about/roadmap.md
+++ b/docs/about/roadmap.md
@@ -7,6 +7,26 @@ sidebar_label: "Roadmap"
 
 Michelangelo is under active development. This page captures the current state of the platform and the direction we're headed. Things will shift as priorities evolve and the community gives feedback.
 
+## Release Milestones
+
+The OSS release is staged so each version makes a specific, scoped promise rather than trying to be everything at once.
+
+| Version | Target | Focus |
+|---|---|---|
+| **0.1.2** | June 2026 | Core pipeline platform — UniFlow, Ray, pipeline and run management, MA CLI and Studio |
+| **1.0** | July 2026 | End-to-end LLM model management — fine-tuning, model registry, progressive serving, full lineage |
+| **1.1** | Q3 2026 | Agent + LLM Gateway — K8s-native containerized agent jobs, deployment-aware LLM routing |
+
+## Versioning Policy
+
+Michelangelo follows [Semantic Versioning 2.0.0](https://semver.org/) with stability declared per component, not per repository.
+
+| Tier | Guarantee |
+|---|---|
+| **stable** | Backwards-compatible across all minor and patch versions within a major. Breaking changes only at the next major. |
+| **beta** | API may change between minor versions. Migration notes required in CHANGELOG. Breaking changes called out explicitly. |
+| **alpha** | Anything goes. Use for experiments and previews. May be removed without deprecation notice. |
+
 ## Available Now
 
 These capabilities are shipped and available in the current release.

--- a/docs/about/roadmap.md
+++ b/docs/about/roadmap.md
@@ -1,0 +1,89 @@
+---
+sidebar_position: 2
+sidebar_label: "Roadmap"
+---
+
+# Roadmap
+
+Michelangelo is under active development. This page captures the current state of the platform and the direction we're headed — it is intentionally not a detailed spec or a delivery commitment. Things will shift as priorities evolve and the community gives feedback.
+
+## Available Now
+
+These capabilities are shipped and available in the current release.
+
+**Project & Pipeline Management**
+- Project creation and lifecycle management
+- Pipeline authoring in YAML, Python, and ASL/Uniflow
+- Revision management and versioning
+- Overridable parameters via Terrablob URLs
+- Auto-flip triggers on master branch merge
+
+**Pipeline Execution**
+- Pipeline run execution
+- Trigger-based runs (cron, interval, and batch rerun)
+- Backfill runs
+- Batch rerun
+
+**Distributed Training**
+- Ray job launch and management
+- Spark job launch on Kubernetes and Peloton
+- Persistent Ray clusters via RayCluster CRD
+- Federated multi-cluster dispatch and status sync
+
+**Model Serving**
+- Inference server creation
+- Deployment rollout strategies
+- Endpoint traffic splitting and shadow routing
+- Training insights
+
+**Infrastructure & Compute**
+- Compute cluster registration
+- Resource pool selection
+- Storage management via Terrablob
+
+**Automation & Self-Healing**
+- Revision-gated state transitions
+- Condition engine pattern
+- Federated multi-cluster status sync
+
+## In Progress
+
+These features are actively being built and will land in upcoming releases.
+
+**Project Management**
+- GenAI project flavor support
+- Team ownership via uOwn
+
+**Pipeline Authoring**
+- Draft-based authoring workflow
+- Dev/Prod environment labels derived from git branch
+
+**Model Deployment**
+- Automatic rollback on alert firing
+- Decommission workflow with no-traffic validation gate
+- DeploymentEvent tracking
+
+**Infrastructure**
+- Notebook (Jupyter) sessions
+- Docker image builds via ImageBuild CRD
+
+**Observability**
+- Dashboard management
+- Experiment reports
+
+## On the Radar
+
+These are areas we expect Michelangelo to grow into. None of them are committed features yet — they signal direction, not a fixed schedule.
+
+**Generative AI & LLM**
+- GenAI service deployment: first-class support for deploying and managing LLM-backed services within the Michelangelo lifecycle.
+
+**Evaluation & Experimentation**
+- A structured evaluation framework for comparing training runs, tracking metrics across experiments, and producing shareable experiment reports.
+
+**Alerting & Monitoring**
+- Full uMonitor integration for decommission gating and alert-driven automation across the deployment lifecycle.
+
+---
+
+The best way to influence what comes next is to open a GitHub issue or discussion with your use case. We treat this page as a living document and update it as concrete designs emerge.

--- a/docs/about/roadmap.md
+++ b/docs/about/roadmap.md
@@ -13,9 +13,9 @@ The OSS release is staged so each version makes a specific, scoped promise rathe
 
 | Version | Target | Focus |
 |---|---|---|
-| **0.4.0** | July 2026 | Release management + core pipeline platform — UniFlow, Ray/ Spark integration, pipeline/run/trigger management, MA commands, MA Studio |
+| **0.4.0** | July 2026 | Release management + core pipeline platform — UniFlow, Ray/Spark integration, pipeline/run/trigger management, Michelangelo CLI, Michelangelo Studio |
 | **0.5.0** | Q3 2026 | End-to-end LLM model management — Foundation Model fine-tuning, model registry, offline inference, progressive serving |
-| **TBD** | H2 FY26 | Agent Infrastructure |
+| **TBD** | H2 2026 | Agent Infrastructure |
 
 ## Versioning Policy
 
@@ -29,20 +29,20 @@ Michelangelo follows [Semantic Versioning 2.0.0](https://semver.org/) with stabi
 
 ## Available Now
 
-These capabilities are shipped and available in the current release.
+These capabilities are shipped and available in the current release. Individual guides are the source of truth for detailed feature availability.
 
 **Project & Pipeline Management**
 - Project creation and lifecycle management
-- Pipeline authoring in K3s CRD YAML, Python, and Uniflow
+- Pipeline authoring in YAML and UniFlow (Python DSL)
 - Revision management and versioning
-- Overridable parameters via S3/GCS URLs
-- Auto-flip triggers on main branch merge
+- Overridable parameters via blobstore URL
+- Pipeline deletion with cascade cleanup (Pipeline → PipelineRun, TriggerRun)
 
 **Pipeline Execution**
 - Pipeline run execution
-- Trigger-based runs (cron, interval, and batch rerun)
+- Trigger-based runs (cron schedule)
 - Backfill runs
-- Batch rerun
+- Pipeline notifications (email and Slack on run outcomes)
 
 **Distributed Training**
 - Ray job launch and management
@@ -52,9 +52,8 @@ These capabilities are shipped and available in the current release.
 
 **Model Serving**
 - Inference server creation
-- Deployment rollout strategies (Blast, Rolling, Zonal, Shadow/A-B)
-- Endpoint traffic splitting and shadow routing
-- Training insights
+- Rolling deployment strategy
+- Traffic routing
 
 **Infrastructure & Compute**
 - Compute cluster registration
@@ -65,6 +64,7 @@ These capabilities are shipped and available in the current release.
 - Revision-gated state transitions
 - Condition engine pattern
 - Federated multi-cluster status sync
+- Finalizer-based cascade deletion
 
 ## In Progress
 
@@ -73,25 +73,24 @@ These features are actively being built and will land in upcoming releases.
 **Pipeline Management**
 - Draft-based authoring workflow
 - Dev/Prod environment labels derived from git branch
-- Pipeline deletion
+- Auto-flip triggers (automatic revision switching on new revision)
+- Interval and batch rerun trigger types
 
 **Model Deployment**
+- Deployment rollout strategies (Blast, Zonal, Shadow/A-B)
+- Endpoint traffic splitting and shadow routing
 - Automatic rollback on alert firing
 - Decommission workflow with no-traffic validation gate
 
 **Generative AI & LLM**
-- GenAI service deployment: first-class support for deploying and managing LLM-backed inference 
+- GenAI service deployment: first-class support for deploying and managing LLM-backed inference
 
 **Evaluation & Reporting**
 - Experiment reports
 
 **Alerting & Monitoring**
-- Alert-triggered auto rollback
 - Dashboard management via OSS Grafana operator
 - Prometheus-based alerting for decommission gating
-
-**Automation**
-- Finalizer-based cascade deletion (Pipeline → Revisions; FeatureGroup → Datasets)
 
 ## On the Radar
 
@@ -117,7 +116,6 @@ These are planned capabilities we are working towards adding down the road.
 - Resource usage metrics emission
 
 **Model Deployment**
-- Lockdown self-healing: detect and auto-remediate cluster lockdown conditions
 - Traffic routing via Istio/Envoy OSS gateway
 - Compute lockdown detection
 - Global endpoint name uniqueness (cross-namespace validation)

--- a/docs/about/roadmap.md
+++ b/docs/about/roadmap.md
@@ -70,10 +70,6 @@ These capabilities are shipped and available in the current release.
 
 These features are actively being built and will land in upcoming releases.
 
-**Project Management**
-- GenAI project flavor support
-- Team ownership via OSS ownership model (CODEOWNERS)
-
 **Pipeline Authoring**
 - Draft-based authoring workflow
 - Dev/Prod environment labels derived from git branch
@@ -106,6 +102,8 @@ These features are actively being built and will land in upcoming releases.
 These are planned capabilities we are working towards adding down the road.
 
 **Project Management**
+- GenAI project flavor support
+- Team ownership via OSS ownership model (CODEOWNERS)
 - Cloud zone annotations for multi-cloud routing
 - Git repository migration allowlist
 - Routing affinity inheritance (parent-to-child annotation propagation)

--- a/docs/about/roadmap.md
+++ b/docs/about/roadmap.md
@@ -35,30 +35,27 @@ These capabilities are shipped and available in the current release. Individual 
 - Project creation and lifecycle management
 - Pipeline authoring in YAML and UniFlow (Python DSL)
 - Revision management and versioning
-- Overridable parameters via blobstore URL
 - Pipeline deletion with cascade cleanup (Pipeline → PipelineRun, TriggerRun)
 
 **Pipeline Execution**
 - Pipeline run execution
 - Trigger-based runs (cron schedule)
 - Backfill runs
-- Pipeline notifications (email and Slack on run outcomes)
+- Pipeline notifications (email and Slack via custom action setup)
 
 **Distributed Training**
 - Ray job launch and management
-- Spark job launch on Kubernetes
 - Persistent Ray clusters via RayCluster CRD
 - Federated multi-cluster dispatch
 
 **Model Serving**
-- Inference server creation
+- Inference server creation (Triton backend)
 - Rolling deployment strategy
 - Traffic routing
 
 **Infrastructure & Compute**
 - Compute cluster registration
-- Resource pool selection
-- Storage management via S3/GCS
+- Storage management via S3/MinIO
 
 **Automation & Self-Healing**
 - Revision-gated state transitions
@@ -66,48 +63,31 @@ These capabilities are shipped and available in the current release. Individual 
 - Federated multi-cluster status sync
 - Finalizer-based cascade deletion
 
-## In Progress
+## Planned
 
-These features are actively being built and will land in upcoming releases.
+These are capabilities we intend to build. Items closer to the top of each section are nearer-term.
 
 **Pipeline Management**
 - Draft-based authoring workflow
 - Dev/Prod environment labels derived from git branch
 - Auto-flip triggers (automatic revision switching on new revision)
 - Interval and batch rerun trigger types
+- Overridable parameters via blobstore URL
+- Concurrent update protection via optimistic locking
+- Canvas release version validation
+- Block dev-branch runs in production (safety gate enforcement)
 
 **Model Deployment**
 - Deployment rollout strategies (Blast, Zonal, Shadow/A-B)
 - Endpoint traffic splitting and shadow routing
 - Automatic rollback on alert firing
 - Decommission workflow with no-traffic validation gate
-
-**Generative AI & LLM**
-- GenAI service deployment: first-class support for deploying and managing LLM-backed inference
-
-**Evaluation & Reporting**
-- Experiment reports
-
-**Alerting & Monitoring**
-- Dashboard management via OSS Grafana operator
-- Prometheus-based alerting for decommission gating
-
-## On the Radar
-
-These are planned capabilities we are working towards adding down the road.
-
-**Project Management**
-- Team ownership via OSS ownership model (CODEOWNERS)
-- Cloud zone annotations for multi-cloud routing
-- Git repository migration allowlist
-- Routing affinity inheritance (parent-to-child annotation propagation)
-
-**Pipeline Authoring & Execution**
-- Concurrent update protection via optimistic locking
-- Canvas release version validation
-- Block dev-branch runs in production (safety gate enforcement)
+- Traffic routing via Istio/Envoy OSS gateway
+- Compute lockdown detection
+- Global endpoint name uniqueness (cross-namespace validation)
 
 **Distributed Training**
+- Spark job launch on Kubernetes
 - GPU SKU normalization and validation via ConfigMap
 - mTLS injection via cert-manager or OSS SPIFFE
 - Prometheus ConfigMap auto-creation per job
@@ -115,10 +95,16 @@ These are planned capabilities we are working towards adding down the road.
 - Spark obsolescence enforcement (7-day auto-kill for runaway jobs)
 - Resource usage metrics emission
 
-**Model Deployment**
-- Traffic routing via Istio/Envoy OSS gateway
-- Compute lockdown detection
-- Global endpoint name uniqueness (cross-namespace validation)
+**Generative AI & LLM**
+- GenAI service deployment: first-class support for deploying and managing LLM-backed inference
+- AI agent management with declarative agent definitions and LLM registry
+- Prompt template management
+- Guardrail policies (input/output safety filtering, bias detection)
+
+**Infrastructure & Compute**
+- GCS storage support
+- Resource pool selection
+- Vector dataset management for embedding and RAG/similarity search
 
 **Feature Store**
 - Feature and feature group management
@@ -130,21 +116,22 @@ These are planned capabilities we are working towards adding down the road.
 - Lineage event tracking on create/delete via OpenLineage
 - Cascading deletion (FeatureGroup → Dataset)
 
-**Generative AI & LLM**
-- AI agent management with declarative agent definitions and LLM registry
-- Prompt template management
-- Guardrail policies (input/output safety filtering, bias detection)
-
 **Evaluation & Reporting**
+- Experiment reports
 - Structured evaluation reports
 - Model cards
 
 **Alerting & Monitoring**
+- Dashboard management via OSS Grafana operator
+- Prometheus-based alerting for decommission gating
 - Alert CRD management
 - Default cron schedules by alert type
 
-**Infrastructure & Compute**
-- Vector dataset management for embedding and RAG/similarity search
+**Project Management**
+- Team ownership via OSS ownership model (CODEOWNERS)
+- Cloud zone annotations for multi-cloud routing
+- Git repository migration allowlist
+- Routing affinity inheritance (parent-to-child annotation propagation)
 
 **Automation & Self-Healing**
 - Lockdown self-healing: detect and auto-remediate cluster lockdown conditions

--- a/docs/about/roadmap.md
+++ b/docs/about/roadmap.md
@@ -13,9 +13,9 @@ The OSS release is staged so each version makes a specific, scoped promise rathe
 
 | Version | Target | Focus |
 |---|---|---|
-| **0.1.2** | June 2026 | Release management + core pipeline platform — UniFlow, Ray, pipeline/run/trigger management, MA commands, MA Studio |
-| **0.2.0** | July 2026 | End-to-end LLM model management — Foundation Model fine-tuning, model registry, offline inference, progressive serving |
-| **0.3.0** | Q3 FY26 | Agent + LLM Gateway — K8s-native containerized agent (Agent Job API + Controller Manager) + LLM Gateway (LiteLLM or Bifrost, CRD-sync routing) |
+| **0.2.0** | June 2026 | Release management + core pipeline platform — UniFlow, Ray/ Spark integration, pipeline/run/trigger management, MA commands, MA Studio |
+| **0.3.0** | July 2026 | End-to-end LLM model management — Foundation Model fine-tuning, model registry, offline inference, progressive serving |
+| **0.4.0** | H2 FY26 | Agent + LLM Gateway — K8s-native containerized agent (Agent Job API + Controller Manager) + LLM Gateway (LiteLLM or Bifrost, CRD-sync routing) |
 
 ## Versioning Policy
 
@@ -33,7 +33,7 @@ These capabilities are shipped and available in the current release.
 
 **Project & Pipeline Management**
 - Project creation and lifecycle management
-- Pipeline authoring in YAML, Python, and Uniflow
+- Pipeline authoring in K3s CRD YAML, Python, and Uniflow
 - Revision management and versioning
 - Overridable parameters via S3/GCS URLs
 - Auto-flip triggers on main branch merge

--- a/docs/about/roadmap.md
+++ b/docs/about/roadmap.md
@@ -70,17 +70,17 @@ These capabilities are shipped and available in the current release.
 
 These features are actively being built and will land in upcoming releases.
 
-**Pipeline Authoring**
+**Pipeline Management**
 - Draft-based authoring workflow
 - Dev/Prod environment labels derived from git branch
+- Pipeline deletion
 
 **Model Deployment**
 - Automatic rollback on alert firing
 - Decommission workflow with no-traffic validation gate
-- DeploymentEvent tracking
 
 **Generative AI & LLM**
-- GenAI service deployment: first-class support for deploying and managing LLM-backed inference endpoints
+- GenAI service deployment: first-class support for deploying and managing LLM-backed inference 
 
 **Evaluation & Reporting**
 - Experiment reports
@@ -90,10 +90,6 @@ These features are actively being built and will land in upcoming releases.
 - Dashboard management via OSS Grafana operator
 - Prometheus-based alerting for decommission gating
 
-**Infrastructure**
-- Notebook (Jupyter) sessions
-- Docker image builds via Kaniko/BuildKit
-
 **Automation**
 - Finalizer-based cascade deletion (Pipeline → Revisions; FeatureGroup → Datasets)
 
@@ -102,7 +98,6 @@ These features are actively being built and will land in upcoming releases.
 These are planned capabilities we are working towards adding down the road.
 
 **Project Management**
-- GenAI project flavor support
 - Team ownership via OSS ownership model (CODEOWNERS)
 - Cloud zone annotations for multi-cloud routing
 - Git repository migration allowlist

--- a/docs/about/roadmap.md
+++ b/docs/about/roadmap.md
@@ -117,11 +117,16 @@ These are capabilities we intend to build. Items closer to the top of each secti
 - Cascading deletion (FeatureGroup → Dataset)
 
 **Evaluation & Reporting**
+- Model explainability (TreeSHAP, Integrated Gradients, Permutation Feature Importance, KernelSHAP)
 - Experiment reports
 - Structured evaluation reports
 - Model cards
 
 **Alerting & Monitoring**
+- Near-real-time feature drift monitoring (Wasserstein, KL divergence, PSI)
+- Feature consistency monitoring (online vs. offline skew detection)
+- Batch feature drift detection
+- Auto-generated drift and availability alerts
 - Dashboard management via OSS Grafana operator
 - Prometheus-based alerting for decommission gating
 - Alert CRD management

--- a/docs/about/roadmap.md
+++ b/docs/about/roadmap.md
@@ -13,9 +13,9 @@ The OSS release is staged so each version makes a specific, scoped promise rathe
 
 | Version | Target | Focus |
 |---|---|---|
-| **0.2.0** | June 2026 | Release management + core pipeline platform — UniFlow, Ray/ Spark integration, pipeline/run/trigger management, MA commands, MA Studio |
-| **0.3.0** | July 2026 | End-to-end LLM model management — Foundation Model fine-tuning, model registry, offline inference, progressive serving |
-| **0.4.0** | H2 FY26 | Agent + LLM Gateway — K8s-native containerized agent (Agent Job API + Controller Manager) + LLM Gateway (LiteLLM or Bifrost, CRD-sync routing) |
+| **0.4.0** | July 2026 | Release management + core pipeline platform — UniFlow, Ray/ Spark integration, pipeline/run/trigger management, MA commands, MA Studio |
+| **0.5.0** | Q3 2026 | End-to-end LLM model management — Foundation Model fine-tuning, model registry, offline inference, progressive serving |
+| **TBD** | H2 FY26 | Agent Infrastructure |
 
 ## Versioning Policy
 

--- a/docs/about/roadmap.md
+++ b/docs/about/roadmap.md
@@ -33,7 +33,7 @@ These capabilities are shipped and available in the current release. Individual 
 
 **Project & Pipeline Management**
 - Project creation and lifecycle management
-- Pipeline authoring in YAML and UniFlow (Python DSL)
+- Pipeline authoring via UniFlow (Python DSL) with YAML-based configuration
 - Revision management and versioning
 - Pipeline deletion with cascade cleanup (Pipeline → PipelineRun, TriggerRun)
 
@@ -55,7 +55,7 @@ These capabilities are shipped and available in the current release. Individual 
 
 **Infrastructure & Compute**
 - Compute cluster registration
-- Storage management via S3/MinIO
+- Storage management via any S3-compatible object store
 
 **Automation & Self-Healing**
 - Revision-gated state transitions

--- a/docs/operator-guides/serving/integrate-custom-backend.md
+++ b/docs/operator-guides/serving/integrate-custom-backend.md
@@ -20,7 +20,7 @@ Each interface is designed to be idempotent—implementations should handle repe
 
 The `Backend` interface abstracts inference server provisioning for different frameworks (Triton, vLLM, TensorRT-LLM, etc.).
 
-**Interface:** [`go/components/inferenceserver/backends/interface.go`](../../../go/components/inferenceserver/backends/interface.go)
+**Interface:** [`go/components/inferenceserver/backends/interface.go`](https://github.com/michelangelo-ai/michelangelo/blob/main/go/components/inferenceserver/backends/interface.go)
 
 ```go
 type Backend interface {
@@ -32,9 +32,9 @@ type Backend interface {
 }
 ```
 
-**Reference Implementation:** [`go/components/inferenceserver/backends/triton.go`](../../../go/components/inferenceserver/backends/triton.go)
+**Reference Implementation:** [`go/components/inferenceserver/backends/triton.go`](https://github.com/michelangelo-ai/michelangelo/blob/main/go/components/inferenceserver/backends/triton.go)
 
-**Registry:** [`go/components/inferenceserver/backends/registry.go`](../../../go/components/inferenceserver/backends/registry.go)
+**Registry:** [`go/components/inferenceserver/backends/registry.go`](https://github.com/michelangelo-ai/michelangelo/blob/main/go/components/inferenceserver/backends/registry.go)
 
 ### To add a new backend:
 
@@ -47,7 +47,7 @@ type Backend interface {
 
 The `ModelConfigProvider` manages model configurations for inference servers. This enables a sidecar pattern where a sidecar container watches the config and loads/unloads models accordingly.
 
-**Interface:** [`go/components/inferenceserver/modelconfig/interface.go`](../../../go/components/inferenceserver/modelconfig/interface.go)
+**Interface:** [`go/components/inferenceserver/modelconfig/interface.go`](https://github.com/michelangelo-ai/michelangelo/blob/main/go/components/inferenceserver/modelconfig/interface.go)
 
 ```go
 type ModelConfigProvider interface {
@@ -60,7 +60,7 @@ type ModelConfigProvider interface {
 }
 ```
 
-**Reference Implementation:** [`go/components/inferenceserver/modelconfig/provider.go`](../../../go/components/inferenceserver/modelconfig/provider.go)
+**Reference Implementation:** [`go/components/inferenceserver/modelconfig/provider.go`](https://github.com/michelangelo-ai/michelangelo/blob/main/go/components/inferenceserver/modelconfig/provider.go)
 
 ### How It Works
 
@@ -75,7 +75,7 @@ The InferenceServer controller creates/deletes the model config, while the Deplo
 
 The `RouteProvider` manages traffic routing to deployed models.
 
-**Interface:** [`go/components/deployment/route/interface.go`](../../../go/components/deployment/route/interface.go)
+**Interface:** [`go/components/deployment/route/interface.go`](https://github.com/michelangelo-ai/michelangelo/blob/main/go/components/deployment/route/interface.go)
 
 ```go
 type RouteProvider interface {
@@ -86,7 +86,7 @@ type RouteProvider interface {
 }
 ```
 
-**Reference Implementation:** [`go/components/deployment/route/httproute.go`](../../../go/components/deployment/route/httproute.go)
+**Reference Implementation:** [`go/components/deployment/route/httproute.go`](https://github.com/michelangelo-ai/michelangelo/blob/main/go/components/deployment/route/httproute.go)
 
 ### Default Behavior
 


### PR DESCRIPTION
## Summary
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**

Adds `docs/about/roadmap.md` — a new roadmap page for the docs site. Uses a three-bucket structure (Available Now, In Progress, On the Radar) organized by capability area: project management, pipeline authoring, distributed training, model serving, infrastructure, and automation.

**Why?**

Gives users and evaluators a transparent view of what the platform can do today and where it's headed, without making date-based commitments. Inspired by Kale's roadmap format.

**How did you test it?**

Reviewed page content and structure manually. No functional code changes.

**Potential risks**

None.

**Release notes**

N/A

**Documentation Changes**

- `docs/about/roadmap.md` — new roadmap page with three date-free buckets covering all major feature areas

## Test Plan


## Issues

