### PR TITLE
docs: add blog with open-source launch announcement

### DIFF
--- a/docs/operator-guides/serving/integrate-custom-backend.md
+++ b/docs/operator-guides/serving/integrate-custom-backend.md
@@ -75,7 +75,7 @@ The InferenceServer controller creates/deletes the model config, while the Deplo
 
 The `RouteProvider` manages traffic routing to deployed models.
 
-**Interface:** [`go/components/deployment/route/interface.go`](../../../go/components/deployment/route/interface.go)
+**Interface:** [`go/components/deployment/route/interface.go`](https://github.com/michelangelo-ai/michelangelo/blob/main/go/components/deployment/route/interface.go)
 
 ```go
 type RouteProvider interface {
@@ -86,7 +86,7 @@ type RouteProvider interface {
 }
 ```
 
-**Reference Implementation:** [`go/components/deployment/route/httproute.go`](../../../go/components/deployment/route/httproute.go)
+**Reference Implementation:** [`go/components/deployment/route/httproute.go`](https://github.com/michelangelo-ai/michelangelo/blob/main/go/components/deployment/route/httproute.go)
 
 ### Default Behavior
 

--- a/website/blog/2026-05-20-open-source-launch.md
+++ b/website/blog/2026-05-20-open-source-launch.md
@@ -1,0 +1,16 @@
+---
+slug: open-source-launch
+title: Michelangelo is Now Open Source
+authors: [michelangelo-team]
+tags: [announcement]
+---
+
+Michelangelo, Uber's ML platform, is now open source.
+
+<!-- truncate -->
+
+Since 2016, Michelangelo has been the system Uber engineers use to build, train, and deploy machine learning models at scale — from fraud detection to pricing to ETAs. Today we're making it available to everyone.
+
+The open-source release includes the core platform: the pipeline framework (Uniflow), the API server, the controller, the local sandbox, and the CLI. You can run it on a laptop with `ma sandbox up` or on a Kubernetes cluster you already operate.
+
+If you're interested in contributing, take a look at the [contributing guide](/docs/contributing) or browse the [GitHub repository](https://github.com/michelangelo-ai/michelangelo). For questions, open an issue or start a discussion on GitHub.

--- a/website/blog/2026-05-20-open-source-launch.md
+++ b/website/blog/2026-05-20-open-source-launch.md
@@ -9,7 +9,7 @@ Michelangelo, Uber's ML platform, is now open source.
 
 <!-- truncate -->
 
-Since 2016, Michelangelo has been the system Uber engineers use to build, train, and deploy machine learning models at scale — from fraud detection to pricing to ETAs. Today we're making it available to everyone.
+Since 2016, Michelangelo has been the system that Uber engineers use to build, train, and deploy machine learning models at scale — from fraud detection to pricing to ETAs. Today we're making it available to everyone.
 
 The open-source release includes the core platform: the pipeline framework (Uniflow), the API server, the controller, the local sandbox, and the CLI. You can run it on a laptop with `ma sandbox create` or on a Kubernetes cluster you already operate.
 

--- a/website/blog/2026-05-20-open-source-launch.md
+++ b/website/blog/2026-05-20-open-source-launch.md
@@ -11,6 +11,6 @@ Michelangelo, Uber's ML platform, is now open source.
 
 Since 2016, Michelangelo has been the system Uber engineers use to build, train, and deploy machine learning models at scale — from fraud detection to pricing to ETAs. Today we're making it available to everyone.
 
-The open-source release includes the core platform: the pipeline framework (Uniflow), the API server, the controller, the local sandbox, and the CLI. You can run it on a laptop with `ma sandbox up` or on a Kubernetes cluster you already operate.
+The open-source release includes the core platform: the pipeline framework (Uniflow), the API server, the controller, the local sandbox, and the CLI. You can run it on a laptop with `ma sandbox create` or on a Kubernetes cluster you already operate.
 
 If you're interested in contributing, take a look at the [contributing guide](/docs/contributing) or browse the [GitHub repository](https://github.com/michelangelo-ai/michelangelo). For questions, open an issue or start a discussion on GitHub.

--- a/website/blog/authors.yml
+++ b/website/blog/authors.yml
@@ -1,0 +1,5 @@
+michelangelo-team:
+  name: Michelangelo Team
+  title: Uber AI Platform
+  url: https://github.com/michelangelo-ai
+  image_url: https://github.com/michelangelo-ai.png

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -44,7 +44,11 @@ const config: Config = {
           sidebarPath: './sidebars.ts',
           editUrl: 'https://github.com/michelangelo-ai/michelangelo/tree/main/website/',
         },
-        blog: false,
+        blog: {
+          showReadingTime: false,
+          blogSidebarCount: 0,
+          postsPerPage: 'ALL',
+        },
         theme: {
           customCss: './src/css/custom.css',
         },
@@ -71,6 +75,11 @@ const config: Config = {
           sidebarId: 'docsSidebar',
           position: 'left',
           label: 'Docs',
+        },
+        {
+          to: '/blog',
+          label: 'Blog',
+          position: 'left',
         },
         {
           href: 'https://github.com/michelangelo-ai/michelangelo',


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**

Enables the Docusaurus blog feature and adds the first post announcing Michelangelo is now open source. Adds a Blog link to the navbar.

**Why?**

Closes #829. We need a place for release notes, announcements, and community updates. The Docusaurus blog feature is purpose-built for this — date-stamped posts, author metadata, RSS feed, and a list view out of the box.

**How did you test it?**

`bun run build` passes cleanly.

**Potential risks**

None.

**Release notes**

N/A

**Documentation Changes**

- `website/docusaurus.config.ts` — enable blog, add Blog navbar link
- `website/blog/authors.yml` — author metadata for michelangelo-team
- `website/blog/2026-05-20-open-source-launch.md` — launch announcement post