### PR TITLE
Add missing tls config for temporal

### DIFF
--- a/go/worker/workflowfx/module.go
+++ b/go/worker/workflowfx/module.go
@@ -99,7 +99,7 @@ func provide(in In) (Out, error) {
 		out.Workflow = cadence.NewWorkflow()
 	} else if conf.Provider == ProviderTemporal {
 		var err error
-		out.Workers, err = newTemporalWorker(in.TemporalFactory, in.Config, in.Logger)
+		out.Workers, err = newTemporalWorker(in.TemporalFactory, in.Config, in.TLSConfig, in.Logger)
 		if err != nil {
 			return out, err
 		}
@@ -183,18 +183,29 @@ func newCadenceClient(conf Config, tlsConfig *tls.Config) (workflowserviceclient
 }
 
 // newTemporalWorker creates a new Temporal worker.
-func newTemporalWorker(factory TemporalClientFactory, conf Config, log *zap.Logger) ([]sworker.Worker, error) {
+func newTemporalWorker(factory TemporalClientFactory, conf Config, tlsConfig *tls.Config, log *zap.Logger) ([]sworker.Worker, error) {
 	scope, _ := tallyv4.NewRootScope(tallyv4.ScopeOptions{
 		Prefix: "temporal",
 	}, time.Second)
 	// Create Temporal client
-	c, err := factory.NewTemporalClient(tempclient.Options{
+	opts := tempclient.Options{
 		HostPort:       conf.Host,
 		Namespace:      conf.Client.Domain,
 		DataConverter:  temporal.DataConverter{},
 		MetricsHandler: temptally.NewMetricsHandler(scope),
 		Logger:         temporal.NewZapLoggerAdapter(log),
-	})
+	}
+	// Add TLS connection options if UseTLS is enabled
+	if conf.UseTLS {
+		// Use the injected TLS configuration, or create a default one if not provided
+		if tlsConfig == nil {
+			tlsConfig = &tls.Config{}
+		}
+		opts.ConnectionOptions = tempclient.ConnectionOptions{
+			TLS: tlsConfig,
+		}
+	}
+	c, err := factory.NewTemporalClient(opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temporal client: %w", err)
 	}

--- a/go/worker/workflowfx/module_test.go
+++ b/go/worker/workflowfx/module_test.go
@@ -25,9 +25,11 @@ func (m *MockTemporalClient) Close() {
 
 type MockTemporalClientFactory struct {
 	mock.Mock
+	CapturedOpts *tempclient.Options
 }
 
 func (m *MockTemporalClientFactory) NewTemporalClient(opts tempclient.Options) (tempclient.Client, error) {
+	m.CapturedOpts = &opts
 	return tempclient.NewLazyClient(opts)
 }
 
@@ -314,6 +316,9 @@ func TestNewTemporalWorker_TLS(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Len(t, workers, 1)
+		assert.NotNil(t, mockFactory.CapturedOpts)
+		assert.NotNil(t, mockFactory.CapturedOpts.ConnectionOptions.TLS)
+		assert.Equal(t, customTLSConfig, mockFactory.CapturedOpts.ConnectionOptions.TLS)
 	})
 
 	t.Run("creates temporal worker with TLS enabled and nil config", func(t *testing.T) {
@@ -333,6 +338,9 @@ func TestNewTemporalWorker_TLS(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Len(t, workers, 1)
+		assert.NotNil(t, mockFactory.CapturedOpts)
+		assert.NotNil(t, mockFactory.CapturedOpts.ConnectionOptions.TLS)
+		// When nil TLS config is passed with UseTLS=true, a default &tls.Config{} should be used
 	})
 
 	t.Run("creates temporal worker with TLS disabled", func(t *testing.T) {
@@ -355,6 +363,9 @@ func TestNewTemporalWorker_TLS(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Len(t, workers, 1)
+		assert.NotNil(t, mockFactory.CapturedOpts)
+		assert.Nil(t, mockFactory.CapturedOpts.ConnectionOptions.TLS)
+		// When UseTLS=false, TLS config should not be set even if provided
 	})
 
 	t.Run("creates temporal worker with multiple workers", func(t *testing.T) {
@@ -381,6 +392,9 @@ func TestNewTemporalWorker_TLS(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Len(t, workers, 3)
+		assert.NotNil(t, mockFactory.CapturedOpts)
+		assert.NotNil(t, mockFactory.CapturedOpts.ConnectionOptions.TLS)
+		assert.Equal(t, customTLSConfig, mockFactory.CapturedOpts.ConnectionOptions.TLS)
 	})
 }
 

--- a/go/worker/workflowfx/module_test.go
+++ b/go/worker/workflowfx/module_test.go
@@ -292,3 +292,155 @@ func TestNewCadenceClient_TLSFlow(t *testing.T) {
 		}
 	})
 }
+
+func TestNewTemporalWorker_TLS(t *testing.T) {
+	t.Run("creates temporal worker with TLS enabled and custom config", func(t *testing.T) {
+		conf := Config{
+			Host:   "temporal.example.com:7233",
+			UseTLS: true,
+			Client: ClientConfig{
+				Domain: "test-domain",
+			},
+			Workers: []WorkerConfig{{TaskList: "test-tasklist"}},
+		}
+
+		logger := zap.NewNop()
+		mockFactory := &MockTemporalClientFactory{}
+		customTLSConfig := &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		}
+
+		workers, err := newTemporalWorker(mockFactory, conf, customTLSConfig, logger)
+
+		assert.NoError(t, err)
+		assert.Len(t, workers, 1)
+	})
+
+	t.Run("creates temporal worker with TLS enabled and nil config", func(t *testing.T) {
+		conf := Config{
+			Host:   "temporal.example.com:7233",
+			UseTLS: true,
+			Client: ClientConfig{
+				Domain: "test-domain",
+			},
+			Workers: []WorkerConfig{{TaskList: "test-tasklist"}},
+		}
+
+		logger := zap.NewNop()
+		mockFactory := &MockTemporalClientFactory{}
+
+		workers, err := newTemporalWorker(mockFactory, conf, nil, logger)
+
+		assert.NoError(t, err)
+		assert.Len(t, workers, 1)
+	})
+
+	t.Run("creates temporal worker with TLS disabled", func(t *testing.T) {
+		conf := Config{
+			Host:   "localhost:7233",
+			UseTLS: false,
+			Client: ClientConfig{
+				Domain: "test-domain",
+			},
+			Workers: []WorkerConfig{{TaskList: "test-tasklist"}},
+		}
+
+		logger := zap.NewNop()
+		mockFactory := &MockTemporalClientFactory{}
+		customTLSConfig := &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		}
+
+		workers, err := newTemporalWorker(mockFactory, conf, customTLSConfig, logger)
+
+		assert.NoError(t, err)
+		assert.Len(t, workers, 1)
+	})
+
+	t.Run("creates temporal worker with multiple workers", func(t *testing.T) {
+		conf := Config{
+			Host:   "temporal.example.com:7233",
+			UseTLS: true,
+			Client: ClientConfig{
+				Domain: "test-domain",
+			},
+			Workers: []WorkerConfig{
+				{TaskList: "test-tasklist-1"},
+				{TaskList: "test-tasklist-2"},
+				{TaskList: "test-tasklist-3"},
+			},
+		}
+
+		logger := zap.NewNop()
+		mockFactory := &MockTemporalClientFactory{}
+		customTLSConfig := &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		}
+
+		workers, err := newTemporalWorker(mockFactory, conf, customTLSConfig, logger)
+
+		assert.NoError(t, err)
+		assert.Len(t, workers, 3)
+	})
+}
+
+func TestProvide_TemporalWithTLS(t *testing.T) {
+	t.Run("provide calls newTemporalWorker with TLS config", func(t *testing.T) {
+		conf := Config{
+			Provider: "temporal",
+			Host:     "temporal.example.com:7233",
+			UseTLS:   true,
+			Client: ClientConfig{
+				Domain: "test-domain",
+			},
+			Workers: []WorkerConfig{{TaskList: "test-tasklist"}},
+		}
+
+		logger := zap.NewNop()
+		mockTemporalFactory := &MockTemporalClientFactory{}
+		customTLSConfig := &tls.Config{
+			MinVersion: tls.VersionTLS13,
+		}
+
+		in := In{
+			Config:          conf,
+			Logger:          logger,
+			TemporalFactory: mockTemporalFactory,
+			TLSConfig:       customTLSConfig,
+		}
+
+		out, err := provide(in)
+
+		assert.NoError(t, err)
+		assert.Equal(t, service.BackendType("temporal"), out.Backend)
+		assert.Len(t, out.Workers, 1)
+	})
+
+	t.Run("provide calls newTemporalWorker without TLS config", func(t *testing.T) {
+		conf := Config{
+			Provider: "temporal",
+			Host:     "localhost:7233",
+			UseTLS:   false,
+			Client: ClientConfig{
+				Domain: "test-domain",
+			},
+			Workers: []WorkerConfig{{TaskList: "test-tasklist"}},
+		}
+
+		logger := zap.NewNop()
+		mockTemporalFactory := &MockTemporalClientFactory{}
+
+		in := In{
+			Config:          conf,
+			Logger:          logger,
+			TemporalFactory: mockTemporalFactory,
+			TLSConfig:       nil,
+		}
+
+		out, err := provide(in)
+
+		assert.NoError(t, err)
+		assert.Equal(t, service.BackendType("temporal"), out.Backend)
+		assert.Len(t, out.Workers, 1)
+	})
+}


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

 What changed?

  - Fixed newTemporalWorker function to accept and apply TLS configuration via a new tlsConfig *tls.Config parameter
  - Updated provide function to pass in.TLSConfig to newTemporalWorker (this was missing, causing TLS config to be ignored for Temporal workers)
  - Added TLS connection options to Temporal client when conf.UseTLS is enabled
  - Added comprehensive unit tests covering TLS scenarios:
    - TestNewTemporalWorker_TLS: Tests worker creation with TLS enabled/disabled, custom/nil TLS config, and multiple workers
    - TestProvide_TemporalWithTLS: Tests the integration through the provide function with and without TLS config

  Why?

  The Temporal worker was not respecting TLS configuration even though:
  - The In struct had a TLSConfig field for user-provided custom TLS config
  - The Config struct had a UseTLS flag 
  - The Cadence worker implementation already supported TLS configuration
  
  The bug was in the provide function at line 102, which called newTemporalWorker without passing the tlsConfig parameter. This meant Temporal workers could not connect to
  TLS-enabled Temporal servers, breaking parity with the Cadence implementation.

  How did you test it?

  - Added unit tests that verify TLS configuration is properly applied in various scenarios
  - Ran all tests in the module: bazel test //go/worker/workflowfx:go_default_test - all tests pass
  - Tested with TLS enabled/disabled, custom TLS config, and nil TLS config (defaults to &tls.Config{})

  Potential risks

  - Low risk: This is a bug fix that makes Temporal workers work correctly with TLS configuration
  - The change is backward compatible - if UseTLS is false, behavior is unchanged
  - If UseTLS is true and TLSConfig is nil, a default &tls.Config{} is used (same as Cadence implementation)
  - Existing deployments without TLS are unaffected

  Release notes

  Bug fix: Temporal workers now properly respect TLS configuration when useTLS: true is set in the workflow-engine config.

  Documentation Changes

  No documentation changes required. The configuration format remains the same - this fix makes the existing useTLS configuration option work correctly for Temporal workers.
