### PR TITLE
[MA-CLI] Require *args, **kwargs in plugin function signatures

### DIFF
--- a/docs/user-guides/cli.md
+++ b/docs/user-guides/cli.md
@@ -474,8 +474,10 @@ my-plugins/
 
 **Required plugin functions**: Plugin modules should implement one or both of these functions:
 
-- `apply_plugins(crd: CRD, channel: Channel)` - Adds custom command signatures to the entity
-- `apply_plugin_command(crd: CRD, target_command: str, crds: dict[str, CRD], channel: Channel)` - Applies logic for specific commands (e.g., `apply`, `create`)
+- `apply_plugins(crd: CRD, channel: Channel, *args, **kwargs)` - Adds custom command signatures to the entity
+- `apply_plugin_command(crd: CRD, target_command: str, crds: dict[str, CRD], channel: Channel, *args, **kwargs)` - Applies logic for specific commands (e.g., `apply`, `create`)
+
+> **Note**: Always include `*args, **kwargs` in your plugin function signatures. This ensures your plugin remains compatible with future mactl versions that may pass additional context. If it's not used, you may use `*_, **__` as a convention to indicate unused parameters.
 
 **Note**: Support for per-module plugin configuration via `plugin.modules` is coming soon.
 

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/main.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/main.py
@@ -30,7 +30,7 @@ from michelangelo.cli.mactl.plugins.entity.pipeline.run import (
 _LOG = getLogger(__name__)
 
 
-def apply_plugins(crd: CRD, channel: Channel):
+def apply_plugins(crd: CRD, channel: Channel, *_, **__):
     """Apply plugin entity function signatures to the CRD.
 
     It adds the necessary function signatures and methods for user commands
@@ -49,7 +49,12 @@ def apply_plugins(crd: CRD, channel: Channel):
 
 
 def apply_plugin_command(
-    crd: CRD, target_command: str, crds: dict[str, CRD], channel: Channel
+    crd: CRD,
+    target_command: str,
+    crds: dict[str, CRD],
+    channel: Channel,
+    *_,
+    **__,
 ):
     """Apply specific target command plugins to the crd."""
     _LOG.info("Applying plugins to crd: %r / %r", crd, target_command)

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline_run/main.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline_run/main.py
@@ -14,7 +14,7 @@ from michelangelo.cli.mactl.plugins.entity.pipeline.kill import generate_kill
 _LOG = getLogger(__name__)
 
 
-def apply_plugins(crd: CRD, channel: Channel):
+def apply_plugins(crd: CRD, channel: Channel, *_, **__):
     """Apply plugin entity function signatures to the CRD.
 
     This adds the kill function signature for pipeline_run entity.

--- a/python/michelangelo/cli/mactl/plugins/entity/trigger_run/main.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/trigger_run/main.py
@@ -19,7 +19,7 @@ from michelangelo.cli.mactl.plugins.entity.trigger_run.create import (
 _LOG = getLogger(__name__)
 
 
-def apply_plugins(crd: CRD, channel: Channel):
+def apply_plugins(crd: CRD, channel: Channel, *_, **__):
     """Apply plugin entity function signatures to the CRD.
 
     It adds the necessary function signatures and methods for user commands

--- a/python/michelangelo/cli/mactl/test/plugin_test/plugins_1/entity/pipeline/main.py
+++ b/python/michelangelo/cli/mactl/test/plugin_test/plugins_1/entity/pipeline/main.py
@@ -18,7 +18,7 @@ from michelangelo.cli.mactl.test.plugin_test.plugins_1.entity.pipeline.fly impor
 _LOG = getLogger(__name__)
 
 
-def apply_plugins(crd: CRD, channel: Channel):
+def apply_plugins(crd: CRD, channel: Channel, *_, **__):
     """Apply plugin entity function signatures to the CRD.
 
     It adds the necessary function signatures and methods for user commands
@@ -30,7 +30,7 @@ def apply_plugins(crd: CRD, channel: Channel):
 
 
 def apply_plugin_command(
-    crd: CRD, target_command: str, crds: dict[str, CRD], channel: Channel
+    crd: CRD, target_command: str, crds: dict[str, CRD], channel: Channel, *_, **__
 ):
     """Apply specific target command plugins to the crd."""
     _LOG.info("Applying plugins to crd: %r / %r", crd, target_command)


### PR DESCRIPTION
  **What type of PR is this?**
  - [ ] Refactor
  - [x] Feature
  - [ ] Bug Fix
  - [ ] Optimization
  - [x] Documentation Update

  **What changed?**
  All plugin function signatures (`apply_plugins`, `apply_plugin_command`) now include `*args, **kwargs` to accept extra positional and keyword arguments. Updated plugin documentation in `docs/user-guides/cli.md` to reflect the new standard.

  **Why?**
  Third-party plugin functions were tightly coupled to mactl's current calling convention. If mactl passes additional context in a future version, existing plugins without `*args, **kwargs` would raise `TypeError`. This change establishes a forward-compatible plugin contract.

  **How did you test it?**
  All 73 existing tests pass. The change is backward compatible; callers still pass the same arguments, so no behavioral difference.

  **Potential risks**
  None for existing plugins. External plugins written without `*args, **kwargs` will still work today, but the documentation now recommends adopting this pattern.

  **Release notes**
  Plugin authors should add `*args, **kwargs` to their `apply_plugins` and `apply_plugin_command` signatures for future compatibility.

  **Documentation Changes**
  Updated `docs/user-guides/cli.md`: plugin function signatures now show `*args, **kwargs`, with a note explaining why.