### PR TITLE
fix: replace broken relative Go links with GitHub URLs and add workflow_dispatch to docs-check

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,6 +1,7 @@
 name: Docs Check
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [main]
     paths:

--- a/docs/operator-guides/serving/integrate-custom-backend.md
+++ b/docs/operator-guides/serving/integrate-custom-backend.md
@@ -20,7 +20,7 @@ Each interface is designed to be idempotent—implementations should handle repe
 
 The `Backend` interface abstracts inference server provisioning for different frameworks (Triton, vLLM, TensorRT-LLM, etc.).
 
-**Interface:** [`go/components/inferenceserver/backends/interface.go`](../../../go/components/inferenceserver/backends/interface.go)
+**Interface:** [`go/components/inferenceserver/backends/interface.go`](https://github.com/michelangelo-ai/michelangelo/blob/main/go/components/inferenceserver/backends/interface.go)
 
 ```go
 type Backend interface {
@@ -32,9 +32,9 @@ type Backend interface {
 }
 ```
 
-**Reference Implementation:** [`go/components/inferenceserver/backends/triton.go`](../../../go/components/inferenceserver/backends/triton.go)
+**Reference Implementation:** [`go/components/inferenceserver/backends/triton.go`](https://github.com/michelangelo-ai/michelangelo/blob/main/go/components/inferenceserver/backends/triton.go)
 
-**Registry:** [`go/components/inferenceserver/backends/registry.go`](../../../go/components/inferenceserver/backends/registry.go)
+**Registry:** [`go/components/inferenceserver/backends/registry.go`](https://github.com/michelangelo-ai/michelangelo/blob/main/go/components/inferenceserver/backends/registry.go)
 
 ### To add a new backend:
 
@@ -47,7 +47,7 @@ type Backend interface {
 
 The `ModelConfigProvider` manages model configurations for inference servers. This enables a sidecar pattern where a sidecar container watches the config and loads/unloads models accordingly.
 
-**Interface:** [`go/components/inferenceserver/modelconfig/interface.go`](../../../go/components/inferenceserver/modelconfig/interface.go)
+**Interface:** [`go/components/inferenceserver/modelconfig/interface.go`](https://github.com/michelangelo-ai/michelangelo/blob/main/go/components/inferenceserver/modelconfig/interface.go)
 
 ```go
 type ModelConfigProvider interface {
@@ -60,7 +60,7 @@ type ModelConfigProvider interface {
 }
 ```
 
-**Reference Implementation:** [`go/components/inferenceserver/modelconfig/provider.go`](../../../go/components/inferenceserver/modelconfig/provider.go)
+**Reference Implementation:** [`go/components/inferenceserver/modelconfig/provider.go`](https://github.com/michelangelo-ai/michelangelo/blob/main/go/components/inferenceserver/modelconfig/provider.go)
 
 ### How It Works
 
@@ -75,7 +75,7 @@ The InferenceServer controller creates/deletes the model config, while the Deplo
 
 The `RouteProvider` manages traffic routing to deployed models.
 
-**Interface:** [`go/components/deployment/route/interface.go`](../../../go/components/deployment/route/interface.go)
+**Interface:** [`go/components/deployment/route/interface.go`](https://github.com/michelangelo-ai/michelangelo/blob/main/go/components/deployment/route/interface.go)
 
 ```go
 type RouteProvider interface {
@@ -86,7 +86,7 @@ type RouteProvider interface {
 }
 ```
 
-**Reference Implementation:** [`go/components/deployment/route/httproute.go`](../../../go/components/deployment/route/httproute.go)
+**Reference Implementation:** [`go/components/deployment/route/httproute.go`](https://github.com/michelangelo-ai/michelangelo/blob/main/go/components/deployment/route/httproute.go)
 
 ### Default Behavior
 


### PR DESCRIPTION

**What type of PR is this?**
  - [ ] Refactor
  - [ ] Feature
  - [x] Bug Fix
  - [ ] Optimization
  - [x] Documentation Update

  **What changed?**
  - Replaced 7 relative Go source file links (`../../../go/...`) in `integrate-custom-backend.md` with absolute GitHub blob URLs, matching the convention used in all other docs.
  - Added `workflow_dispatch` trigger to `docs-check.yml` so the workflow can be run manually from the GitHub Actions UI.

  **Why?**

  ### Investigation

  The `validate-docs` CI started failing on unrelated docs PRs (e.g., #1225) due to broken links in `integrate-custom-backend.md`. Investigation traced the issue through the following timeline:

  1. **PR #855** (2026-02-23) — Added `docs-check.yml` with Docusaurus broken link detection. The workflow only triggers on PRs that change `docs/**` or `website/**`.

  2. **PR #816** (2026-03-19) — Introduced `integrate-custom-backend.md` with 7 relative links to Go source files (`../../../go/components/...`). These resolve outside the Docusaurus docs directory and are invalid as doc routes. However, the `validate-docs` check did **not run** on
  this PR — only a generic `build` check appeared, likely because the PR's last CI run predated the workflow being merged to `main`.

  3. **PR #1146, #1196** (2026-05-15~16) — Both touched `docs/`, both triggered `validate-docs`, both **passed**. Docusaurus did not report the broken links in these runs despite identical environment (Docusaurus 3.9.2, Bun 1.3.14, same runner image). Root cause of the inconsistency
   is unclear — likely non-deterministic Docusaurus link validation behavior depending on the route graph at build time.

  4. **PR #1225** (2026-05-21) — Changed `docs/user-guides/cli.md` (unrelated to serving docs), triggered `validate-docs`, and Docusaurus reported the broken links for the first time. CI failed on a pre-existing issue the PR author did not introduce.

  ### Root causes

  - **Broken links**: Relative paths to `.go` files resolve outside the Docusaurus docs directory. Other docs in this repo (`uniflow-plugin-guide.md`, `use-go-mocks-in-unit-test.md`) use absolute GitHub blob URLs for the same purpose.
  - **No proactive validation**: `docs-check.yml` has no `workflow_dispatch` trigger, so there is no way to validate docs on `main` without a PR that touches `docs/`. Broken links can silently accumulate until an unrelated PR surfaces them.

  **How did you test it?**
  Verified no relative `../` paths remain in the file. All replacement URLs follow the existing pattern used in `uniflow-plugin-guide.md` and `use-go-mocks-in-unit-test.md`.

  **Potential risks**
  None. Links now point to the same files on GitHub `main` branch.

  **Release notes**
  N/A

  **Documentation Changes**
  Updated `docs/operator-guides/serving/integrate-custom-backend.md` — Go source links now use GitHub URLs.