### PR TITLE
fix(sandbox): disable unused Cadence kafka subchart

### DIFF
--- a/helm/michelangelo/values-k3d.yaml
+++ b/helm/michelangelo/values-k3d.yaml
@@ -121,18 +121,8 @@ cadence:
     enabled: false
   postgresql:
     enabled: false
-
-  # Bitnami discontinued their free community image catalog in mid-2025 and
-  # removed the docker.io/bitnami/kafka tags the Cadence subchart pins
-  # (3.8.1-debian-12-r0). Without this override, kafka pods sit forever in
-  # ImagePullBackOff and the workflow engine never gets the queue it needs,
-  # so every PipelineRun fails with Execute Workflow stuck PENDING.
-  # bitnamilegacy/* is Bitnami's transition repo and still serves the same
-  # image digest under the old tag.
   kafka:
-    image:
-      repository: bitnamilegacy/kafka
-      tag: 3.8.1-debian-12-r0
+    enabled: false
 
   # Cadence Web UI exposed via NodePort 30004 → host port 8088.
   web:

--- a/helm/michelangelo/values-k3d.yaml
+++ b/helm/michelangelo/values-k3d.yaml
@@ -122,6 +122,18 @@ cadence:
   postgresql:
     enabled: false
 
+  # Bitnami discontinued their free community image catalog in mid-2025 and
+  # removed the docker.io/bitnami/kafka tags the Cadence subchart pins
+  # (3.8.1-debian-12-r0). Without this override, kafka pods sit forever in
+  # ImagePullBackOff and the workflow engine never gets the queue it needs,
+  # so every PipelineRun fails with Execute Workflow stuck PENDING.
+  # bitnamilegacy/* is Bitnami's transition repo and still serves the same
+  # image digest under the old tag.
+  kafka:
+    image:
+      repository: bitnamilegacy/kafka
+      tag: 3.8.1-debian-12-r0
+
   # Cadence Web UI exposed via NodePort 30004 → host port 8088.
   web:
     enabled: true


### PR DESCRIPTION
## Summary

The Cadence Helm chart's `Chart.yaml` declares its kafka subchart with
`condition: kafka.enabled`, but its `values.yaml` has no top-level
`kafka:` block. Helm treats a missing condition value as enabled, so
the kafka subchart shipped by default in our sandbox even though we
never use it — visibility runs through MySQL (`cadence_visibility`).

On top of being dead weight, the bundled Bitnami Kafka chart pins
`docker.io/bitnami/kafka:3.8.1-debian-12-r0`, a tag Bitnami removed
from Docker Hub in mid-2025. So the kafka pods sat in
`ImagePullBackOff` forever and `ma sandbox create` never converged.

## Test plan

I reproduced the regression on `main`:
```bash
ma sandbox delete && ma sandbox create --exclude grafana
kubectl get pods -A | grep kafka
```
All three kafka pods stuck in `Init:ImagePullBackOff`:
```
default   michelangelo-kafka-controller-0   0/1   Init:ImagePullBackOff
default   michelangelo-kafka-controller-1   0/1   Init:ImagePullBackOff
default   michelangelo-kafka-controller-2   0/1   Init:ImagePullBackOff
```
```bash
kubectl describe pod -n default -l app.kubernetes.io/name=kafka | grep "Failed to pull"
# Failed to pull image "docker.io/bitnami/kafka:3.8.1-debian-12-r0": not found
```

I verified the fix on this branch:
```bash
ma sandbox delete && ma sandbox create --exclude grafana
kubectl get pods -A | grep kafka
```

```bash
(michelangelo-py3.14) ➜  python git:(craig.marker/kafka-helm-bitnami-legacy-fix) ✗ kubectl get pods | grep kafka
(michelangelo-py3.14) ➜  python git:(craig.marker/kafka-helm-bitnami-legacy-fix) ✗
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)