### PR TITLE
fix(sandbox): enable Cadence strongly-consistent queries in helm sandbox

### DIFF
--- a/helm/michelangelo/values-k3d.yaml
+++ b/helm/michelangelo/values-k3d.yaml
@@ -131,6 +131,40 @@ cadence:
       type: NodePort
       nodePort: 30004
 
+  # Dynamic config overrides.
+  #
+  # The upstream Cadence helm subchart ships a minimal dynamicconfig that only
+  # sets retention + visibility store. It does NOT enable strongly-consistent
+  # queries, which Cadence's default is "off".
+  #
+  # The michelangelo controller hardcodes QueryConsistencyLevelStrong when
+  # querying the `task_progress` workflow handler on every reconcile loop
+  # (cadenceclient.go). Without this flag, every query fails with:
+  #   BadRequestError: cluster or domain does not enable strongly consistent
+  #   query but strongly consistent query was requested
+  # This leaves PipelineRun.status.steps[].subSteps[].activityId always empty,
+  # so the Retry button never appears even for terminated runs.
+  #
+  # The previous (pre-2026-05-13) sandbox used ubercadence/server:auto-setup,
+  # whose bundled development.yaml enables this by default. The helm migration
+  # silently dropped it.
+  #
+  # Key names must be exact: history.EnableConsistentQuery (capital E, history.
+  # prefix). Wrong prefix (system.) or wrong case are silently ignored.
+  dynamicConfig:
+    values:
+      system.minRetentionDays:
+        - value: 0
+          constraints: {}
+      system.writeVisibilityStoreName:
+        - value: "db"
+      system.readVisibilityStoreName:
+        - value: "db"
+      history.EnableConsistentQuery:
+        - value: true
+      history.EnableConsistentQueryByDomain:
+        - value: true
+
 # -----------------------------------------------------------------------------
 # Temporal subchart — bundled workflow engine for --workflow temporal.
 #


### PR DESCRIPTION
## What

The michelangelo controller hardcodes `QueryConsistencyLevelStrong` when querying
the `task_progress` workflow handler on every reconcile loop. Cadence requires
this to be explicitly enabled at the cluster level.

The helm migration in #1162 switched the sandbox from `ubercadence/server:auto-setup`
(which bundled a `development.yaml` with this flag on by default) to the Cadence
helm subchart (which ships only a minimal dynamicconfig). Every `task_progress`
query started failing with:

```
BadRequestError: cluster or domain does not enable strongly consistent
query but strongly consistent query was requested
```

Since `constructPipelineRunStepInfo` is the only path that populates substep
state and advances the workflow-level state machine, pipeline runs in the helm
sandbox no longer made it past `Running` — even after the underlying Cadence
workflow completed.

## Test plan

### Before (on `craig.marker/kafka-helm-bitnami-legacy-fix`)

I tried to run a pipeline; it never reached a terminal state. `controllermgr`
logs showed the BadRequestError on every reconcile:

```bash
kubectl logs deployment/michelangelo-controllermgr | grep "strongly consistent query"
```

### After (on this branch)

I recreated the sandbox on this branch:

```bash
ma sandbox delete && ma sandbox create --exclude grafana
```

Then ran a pipeline to completion and verified:

1. No `strongly consistent query` errors:
   ```bash
   kubectl logs deployment/michelangelo-controllermgr | grep "strongly consistent query"
   # (no output)
   ```

2. Step `activityId` fields are populated:
   ```bash
   kubectl get pipelinerun -n ma-dev-test <run-name> \
     -o jsonpath='{.status.steps[*].subSteps[*].activityId}'
   # 1 10
   ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)