### PR TITLE
feat: switch browser RPC from gRPC-Web to Connect protocol

### DIFF
--- a/helm/michelangelo/templates/core/envoy-configmap.yaml
+++ b/helm/michelangelo/templates/core/envoy-configmap.yaml
@@ -36,13 +36,13 @@ data:
                               - safe_regex:
                                   regex: {{ .Values.envoy.corsOrigins | default ".*" | quote }}
                             allow_methods: "GET, POST, OPTIONS"
-                            allow_headers: "content-type,context-ttl-ms,grpc-timeout,rpc-caller,rpc-encoding,rpc-service,x-grpc-web,x-user-agent"
+                            allow_headers: "connect-protocol-version,connect-timeout-ms,content-type,context-ttl-ms,grpc-timeout,rpc-caller,rpc-encoding,rpc-service,x-grpc-web,x-user-agent"
                             max_age: "1728000"
                             expose_headers: "grpc-status,grpc-message"
                     http_filters:
-                      - name: envoy.filters.http.grpc_web
+                      - name: envoy.filters.http.connect_grpc_bridge
                         typed_config:
-                          "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.connect_grpc_bridge.v3.FilterConfig
                       - name: envoy.filters.http.cors
                         typed_config:
                           "@type": type.googleapis.com/envoy.extensions.filters.http.cors.v3.Cors

--- a/javascript/packages/rpc/services.ts
+++ b/javascript/packages/rpc/services.ts
@@ -1,5 +1,5 @@
 import { createClient } from '@connectrpc/connect';
-import { createGrpcWebTransport } from '@connectrpc/connect-web';
+import { createConnectTransport } from '@connectrpc/connect-web';
 
 import { DeploymentService } from './gen/michelangelo/api/v2/deployment_svc_pb';
 import { InferenceServerService } from './gen/michelangelo/api/v2/inference_server_svc_pb';
@@ -19,7 +19,6 @@ const callerInterceptor: Interceptor = (next) => async (req) => {
   req.header.set('context-Ttl-Ms', '10000');
   req.header.set('grpc-timeout', '1000000m');
   req.header.set('Rpc-Caller', 'ma-studio');
-  req.header.set('Rpc-Encoding', 'proto');
   req.header.set('Rpc-Service', 'ma-apiserver');
 
   return await next(req);
@@ -30,12 +29,9 @@ let servicesPromise: Promise<Services> | null = null;
 async function createServices(): Promise<Services> {
   const { apiBaseUrl } = await getRuntimeConfig();
 
-  // This transport is used to connect to the Envoy proxy that proxies gRPC web requests
-  // to gRPC services.
-  const transport = createGrpcWebTransport({
+  const transport = createConnectTransport({
     baseUrl: apiBaseUrl,
     interceptors: [callerInterceptor],
-    useBinaryFormat: true,
   });
 
   return {


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Feature
- [x] Optimization

**What changed?**

Replaced gRPC-Web with the [Connect protocol](https://connectrpc.com/docs/protocol/) for browser-to-server RPC communication.

- **Client** (`packages/rpc/services.ts`): swapped `createGrpcWebTransport` for `createConnectTransport`. Removed `Rpc-Encoding: proto` header and `useBinaryFormat: true` — Connect uses JSON by default.
- **Envoy** (`envoy-configmap.yaml`): replaced `envoy.filters.http.grpc_web` with `envoy.filters.http.connect_grpc_bridge`. Added `connect-protocol-version` and `connect-timeout-ms` to CORS allowed headers.

**Why?**

gRPC-Web uses binary protobuf on the wire. Chrome DevTools shows these payloads as raw bytes, making API debugging painful — you can't inspect request or response bodies without external tooling.

The Connect protocol sends plain `application/json`, so every RPC call is natively readable in the Network tab. Envoy's `connect_grpc_bridge` filter (v1.26+) translates Connect JSON into native gRPC+proto upstream, so YARPC and the Go apiserver require zero changes.

**How did you test it?**

I ran the local sandbox (k3d + Helm), patched the Envoy configmap, restarted the envoy pod, and confirmed in Chrome DevTools that RPC responses now display as readable JSON in the Network tab. Verified the app loads and ListProject calls succeed end-to-end.

**Production** (8090)
<img width="1728" height="1117" alt="Screenshot 2026-05-25 at 15 02 55" src="https://github.com/user-attachments/assets/aa088981-17a1-4007-85f2-c5aec06f6d31" />

**Dev** (5173)
<img width="1728" height="1117" alt="Screenshot 2026-05-25 at 15 01 08" src="https://github.com/user-attachments/assets/67be27ac-64f6-4cfe-9886-462039c3399b" />


**Potential risks**

- The `connect_grpc_bridge` filter is newer than `grpc_web` — Envoy docs note it is "functional but has not had substantial production burn time." Our Envoy image is v1.29 which includes it.
- Connect protocol does not support client-streaming or bidi-streaming over HTTP/1.1 (server-streaming and unary are supported). All current browser RPCs are unary, so this is not a concern today.

**Release notes**

Browser RPC debugging is now significantly easier — API request and response payloads are visible as JSON in Chrome DevTools Network tab.

**Documentation Changes**

No user-facing API changes. The transport switch is internal to the UI client and Envoy proxy layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)