### PR TITLE
cli: print dev_run response so it is visible at default log level

### DIFF
--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/dev_run.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/dev_run.py
@@ -221,6 +221,10 @@ def generate_dev_run(
             timeout=30,
         )
         _LOG.info("Stub method completed (%r): %r", type(response), response)
+        # Print the response so users see the created PipelineRun even at the
+        # default WARNING log level (matches behavior of `mactl pipelinerun`
+        # and `ma pipeline {apply,create,get,run}`).
+        print(response)
         return response
 
     dev_run_func.__signature__ = func_signature  # type: ignore[attr-defined]


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
Currently \`ma pipeline dev_run\` only logs the response via \`_LOG.info(...)\`. The default log level (set by \`mactl.py\` to WARNING) suppresses it, so \`ma pipeline dev_run -f <yaml>\` returns exit 0 with **zero output** even on success — looks like a silent no-op.

This adds a one-line \`print(response)\` after the existing log call, matching the behavior of \`mactl pipelinerun\` and \`ma pipeline {apply, create, get, run}\` which all print results regardless of log level.


  ## Test plan
  - [x] All 16 existing \`dev_run_test.py\` cases still pass

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
