### PR TITLE
docs: expand Why Michelangelo narrative in intro and history pages

### DIFF
--- a/docs/about/history-and-evolution.md
+++ b/docs/about/history-and-evolution.md
@@ -5,11 +5,41 @@ sidebar_label: "History & Evolution"
 
 # History and Evolution of Michelangelo
 
-Michelangelo has evolved significantly since its launch in 2016 — from a centralized platform for classical ML to a full-stack system supporting deep learning, generative AI, and agentic workflows. To learn more about that journey, explore the resources below.
+## The problem that started it
 
-## Further Reading
+Before 2016, building and shipping a machine learning model at Uber meant starting from scratch every time. Applied scientists trained models in Jupyter notebooks. Engineers built custom serving containers for each project. There was no shared feature store, no standard deployment path, and no way for one team's infrastructure work to benefit any other. Every model that went to production was a one-off — and maintaining it was the team's own problem.
 
-- [From Predictive to Generative AI](https://www.uber.com/us/en/blog/from-predictive-to-generative-ai/) — Uber Engineering blog post covering Michelangelo's architecture evolution in depth
+This wasn't a small inconvenience. Uber's business depends on ML: pricing, ETAs, maps, search, fraud detection, recommendations. Each of those domains was building its own version of the same infrastructure, in parallel, at increasing cost.
+
+## What Michelangelo was built to do
+
+Michelangelo was created in 2016 to solve the fragmentation problem at scale. The bet was that standardizing the end-to-end ML lifecycle — from feature engineering and training through deployment and monitoring — would let every team at Uber ship high-quality ML without reinventing infrastructure. A team working on Eats recommendations should be able to reuse the same platform primitives as a team working on fraud detection, with production-grade reliability built in.
+
+That centralized model proved out. Over the following years, Michelangelo grew to serve thousands of models across hundreds of active projects, handling tens of millions of real-time predictions per second at peak.
+
+## Eight years of evolution
+
+What started as a platform for tabular ML and gradient-boosted trees expanded significantly as Uber's ML needs evolved:
+
+- **Classical ML and XGBoost** (2016–2018) — The initial focus: standardizing feature pipelines, training jobs, and model serving for structured data problems.
+- **Deep learning at scale** (2019–2021) — As neural networks became central to ranking, NLP, and computer vision use cases, Michelangelo added distributed training infrastructure, GPU support, and model architectures beyond XGBoost.
+- **LLMOps and generative AI** (2022–present) — Foundation models, fine-tuning pipelines, retrieval-augmented generation, and agent-based workflows joined the platform as generative AI moved from experiment to production.
+
+Each evolution built on the same core insight: platform investment compounds. The feature store, model registry, and deployment infrastructure that served classical ML became the foundation for deep learning — and is now the foundation for generative AI workflows.
+
+## Why open source, and why now
+
+The broader ML community has standardized on open, composable infrastructure: PyTorch for training, Ray for distributed compute, vLLM for inference. But there is still no dominant open-source end-to-end ML platform — no single place that organizes those building blocks into a coherent, production-ready system.
+
+Open sourcing Michelangelo extends its original mission outward. The platform was built on a modular, plug-and-play architecture that cleanly separates platform primitives from Uber-specific internals. That design was intentional: it makes Michelangelo composable, so teams can adopt the full platform or integrate individual components into an existing stack.
+
+This follows a pattern that has worked before. Google open sourced Kubernetes and it became the standard for container orchestration. Meta open sourced PyTorch and it became the standard language for ML research and production. Spotify open sourced Backstage and it became the default developer portal framework. In each case, the organization that open sourced a solved internal problem became the center of an ecosystem rather than a maintenance burden fighting ecosystem drift.
+
+Michelangelo has already paid the hardest costs — platform design, operational hardening, battle-testing across thousands of models and use cases over eight years. The open source project packages those lessons so any engineering organization facing the same fragmentation problem can build on a foundation that has already been proven at scale.
+
+## Further reading
+
+- [From Predictive to Generative AI](https://www.uber.com/us/en/blog/from-predictive-to-generative-ai/) — Uber Engineering blog covering Michelangelo's architecture evolution in depth
 - [From Monolith to Global Mesh: How Uber Standardized ML at Scale](https://thenewstack.io/uber-standardized-ml-scale/) — The New Stack on how Uber scaled ML across the organization
 - [Michelangelo Deep Dive: Interview with Uber AI Platform PM](https://www.youtube.com/watch?v=x5cIMPmYAzw) — Interview covering history, GenAI use cases, tiering strategy, and open-source plans
 - [Michelangelo Live Demo](https://www.youtube.com/watch?v=KJe8_FLMRx4) — Conference walkthrough of the full ML lifecycle, from project creation to deployment

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -8,6 +8,12 @@ title: Welcome
 
 Michelangelo is an end-to-end ML platform for building, deploying, and managing machine learning models. Born at Uber — where it powers **25,000+ model trainings per month** and **~30 million predictions per second** — now open source.
 
+## Why Michelangelo exists
+
+Before Michelangelo, Uber's ML teams each built their own infrastructure: custom training pipelines, bespoke serving containers, no shared path to production. Every model was a one-off, and maintaining it was the team's problem alone. Michelangelo was created to solve that fragmentation — standardizing the full ML lifecycle so any team could ship production-quality ML without reinventing the stack.
+
+Over eight years it evolved from tabular ML to deep learning to full LLMOps support, battle-tested across thousands of models and use cases. Open sourcing it extends that same mission: the platform is built on a modular, plug-and-play architecture so any engineering organization facing the same fragmentation problem can build on a foundation that has already been proven at scale. For the full story, see [History and Evolution](./about/history-and-evolution.md).
+
 ## Get started
 
 ### I'm evaluating Michelangelo


### PR DESCRIPTION
## Summary
Intent:
- Add origin story and "why we built this" narrative to the docs site so evaluators understand the problem Michelangelo solves, not just what it does
- Transform the history-and-evolution stub into a substantive page covering Uber's pre-2016 fragmentation, the platform's founding mission, eight years of evolution, and the rationale for open sourcing

Changes:
- Expanded docs/about/history-and-evolution.md from a 17-line link stub into a full narrative page with four sections: the problem that started it, what Michelangelo was built to do, eight years of evolution (tabular ML → deep learning → LLMOps), and why open source now
- Added a "Why Michelangelo exists" section to docs/intro.md (Welcome page) with a 2-paragraph narrative hook above the Get started navigation, linking through to the full history page

## Test Plan
Verified both files render correctly with proper frontmatter, headings, and links. No build step required for markdown-only changes.

## Revert Plan
Revert this PR via `git revert <commit_sha>`.

## Issues


## Stack
1. #1211
1. @ #1241
