### PR TITLE
feat(core): orthogonal ActionConfig union with mutation/route confirm dispatchers

### DIFF
--- a/javascript/packages/core/components/actions/__tests__/actions-popover.test.tsx
+++ b/javascript/packages/core/components/actions/__tests__/actions-popover.test.tsx
@@ -1,26 +1,33 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { ActionMenu } from '#core/components/actions/action-menu/action-menu';
 import { ActionsPopover } from '#core/components/actions/actions-popover';
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
+import { getErrorProviderWrapper } from '#core/test/wrappers/get-error-provider-wrapper';
 import { getIconProviderWrapper } from '#core/test/wrappers/get-icon-provider-wrapper';
+import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
+import {
+  createQueryMockRouter,
+  getServiceProviderWrapper,
+} from '#core/test/wrappers/get-service-provider-wrapper';
 
 import type { ActionComponentProps } from '#core/components/actions/types';
 
 describe('ActionsPopover', () => {
-  function DeleteDialog({ isOpen }: ActionComponentProps) {
-    return isOpen ? <div role="dialog">Delete dialog</div> : null;
+  function DeleteDialog({ record }: ActionComponentProps) {
+    const id = typeof record.id === 'string' ? record.id : '';
+    return <div role="dialog">Delete dialog {id}</div>;
   }
 
   it('renders an "Actions" trigger button', () => {
     render(
       <ActionsPopover
-        actions={[{ display: { label: 'Delete' }, component: DeleteDialog }]}
+        actions={[{ display: { label: 'Delete' }, modal: { type: 'custom', component: DeleteDialog } }]}
         record={{}}
       />,
-      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getRouterWrapper()])
     );
     expect(screen.getByRole('button', { name: 'Actions' })).toBeInTheDocument();
   });
@@ -28,10 +35,10 @@ describe('ActionsPopover', () => {
   it('does not show menu items before the trigger is clicked', () => {
     render(
       <ActionsPopover
-        actions={[{ display: { label: 'Delete' }, component: DeleteDialog }]}
+        actions={[{ display: { label: 'Delete' }, modal: { type: 'custom', component: DeleteDialog } }]}
         record={{}}
       />,
-      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getRouterWrapper()])
     );
     expect(screen.queryByRole('option', { name: 'Delete' })).not.toBeInTheDocument();
   });
@@ -40,10 +47,10 @@ describe('ActionsPopover', () => {
     const user = userEvent.setup();
     render(
       <ActionsPopover
-        actions={[{ display: { label: 'Delete' }, component: DeleteDialog }]}
+        actions={[{ display: { label: 'Delete' }, modal: { type: 'custom', component: DeleteDialog } }]}
         record={{}}
       />,
-      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getRouterWrapper()])
     );
     await user.click(screen.getByRole('button', { name: 'Actions' }));
     expect(await screen.findByRole('option', { name: 'Delete' })).toBeInTheDocument();
@@ -56,7 +63,7 @@ describe('ActionsPopover', () => {
         actions={[
           {
             display: { label: 'Delete', icon: 'trash' },
-            component: DeleteDialog,
+            modal: { type: 'custom', component: DeleteDialog },
           },
         ]}
         record={{}}
@@ -64,6 +71,7 @@ describe('ActionsPopover', () => {
       buildWrapper([
         getBaseProviderWrapper(),
         getIconProviderWrapper({ icons: { trash: () => <div>Trash</div> } }),
+        getRouterWrapper(),
       ])
     );
 
@@ -75,10 +83,10 @@ describe('ActionsPopover', () => {
     const user = userEvent.setup();
     render(
       <ActionsPopover
-        actions={[{ display: { label: 'Delete' }, component: DeleteDialog }]}
+        actions={[{ display: { label: 'Delete' }, modal: { type: 'custom', component: DeleteDialog } }]}
         record={{}}
       />,
-      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getRouterWrapper()])
     );
     await user.click(screen.getByRole('button', { name: 'Actions' }));
     await user.click(await screen.findByRole('option', { name: 'Delete' }));
@@ -90,15 +98,15 @@ describe('ActionsPopover', () => {
 
   it('passes data to the action component', async () => {
     const user = userEvent.setup();
-    const Component = ({ record, isOpen }: ActionComponentProps) =>
-      isOpen ? <div role="dialog">{String(record.id)}</div> : null;
+    const Component = ({ record }: ActionComponentProps) =>
+      <div role="dialog">{String(record.id)}</div>;
     const data = { id: '42', type: 'pipeline' };
     render(
       <ActionsPopover
-        actions={[{ display: { label: 'Run' }, component: Component }]}
+        actions={[{ display: { label: 'Run' }, modal: { type: 'custom', component: Component } }]}
         record={data}
       />,
-      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getRouterWrapper()])
     );
     await user.click(screen.getByRole('button', { name: 'Actions' }));
     await user.click(await screen.findByRole('option', { name: 'Run' }));
@@ -109,10 +117,10 @@ describe('ActionsPopover', () => {
     const user = userEvent.setup();
     const { unmount } = render(
       <ActionsPopover
-        actions={[{ display: { label: 'Delete' }, component: DeleteDialog }]}
+        actions={[{ display: { label: 'Delete' }, modal: { type: 'custom', component: DeleteDialog } }]}
         record={{}}
       />,
-      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getRouterWrapper()])
     );
     await user.click(screen.getByRole('button', { name: 'Actions' }));
     expect(document.body.style.overflow).toBe('hidden');
@@ -124,10 +132,10 @@ describe('ActionsPopover', () => {
     const user = userEvent.setup();
     render(
       <ActionsPopover
-        actions={[{ display: { label: 'Delete' }, component: DeleteDialog }]}
+        actions={[{ display: { label: 'Delete' }, modal: { type: 'custom', component: DeleteDialog } }]}
         record={{}}
       />,
-      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getRouterWrapper()])
     );
     await user.click(screen.getByRole('button', { name: 'Actions' }));
     expect(await screen.findByRole('option', { name: 'Delete' })).toBeInTheDocument();
@@ -140,7 +148,7 @@ describe('ActionsPopover', () => {
   describe('disabled actions', () => {
     const disabledAction = {
       display: { label: 'Delete' },
-      component: DeleteDialog,
+      modal: { type: 'custom' as const, component: DeleteDialog },
       disabled: [{ condition: true, message: 'Cannot delete' }],
     };
 
@@ -148,7 +156,7 @@ describe('ActionsPopover', () => {
       const user = userEvent.setup();
       render(
         <ActionsPopover actions={[disabledAction]} record={{}} />,
-        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getRouterWrapper()])
       );
       await user.click(screen.getByRole('button', { name: 'Actions' }));
       expect(await screen.findByRole('option', { name: 'Delete' })).toBeInTheDocument();
@@ -158,7 +166,7 @@ describe('ActionsPopover', () => {
       const user = userEvent.setup();
       render(
         <ActionsPopover actions={[disabledAction]} record={{}} />,
-        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getRouterWrapper()])
       );
       await user.click(screen.getByRole('button', { name: 'Actions' }));
       await user.click(await screen.findByRole('option', { name: 'Delete' }));
@@ -169,7 +177,7 @@ describe('ActionsPopover', () => {
       const user = userEvent.setup();
       render(
         <ActionsPopover actions={[disabledAction]} record={{}} />,
-        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getRouterWrapper()])
       );
       await user.click(screen.getByRole('button', { name: 'Actions' }));
       await user.hover(await screen.findByRole('option', { name: 'Delete' }));
@@ -180,7 +188,7 @@ describe('ActionsPopover', () => {
       const user = userEvent.setup();
       render(
         <ActionsPopover actions={[disabledAction]} record={{}} />,
-        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getRouterWrapper()])
       );
       await user.click(screen.getByRole('button', { name: 'Actions' }));
       await user.hover(await screen.findByRole('option', { name: 'Delete' }));
@@ -189,50 +197,6 @@ describe('ActionsPopover', () => {
       await waitFor(() => {
         expect(screen.queryByRole('option', { name: 'Delete' })).not.toBeInTheDocument();
       });
-    });
-
-    it('shows the disabled message when condition is true', async () => {
-      const user = userEvent.setup();
-      render(
-        <ActionsPopover
-          actions={[
-            {
-              display: { label: 'Delete' },
-              component: DeleteDialog,
-              disabled: [{ condition: true, message: 'Item is locked' }],
-            },
-          ]}
-          record={{ status: 'locked' }}
-        />,
-        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
-      );
-      await user.click(screen.getByRole('button', { name: 'Actions' }));
-      await user.hover(await screen.findByRole('option', { name: 'Delete' }));
-      expect(await screen.findByText('Item is locked')).toBeInTheDocument();
-    });
-
-    it('uses the first matching rule message', async () => {
-      const user = userEvent.setup();
-      render(
-        <ActionsPopover
-          actions={[
-            {
-              display: { label: 'Delete' },
-              component: DeleteDialog,
-              disabled: [
-                { condition: false, message: 'Should not appear' },
-                { condition: true, message: 'Second rule matches' },
-              ],
-            },
-          ]}
-          record={{}}
-        />,
-        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
-      );
-      await user.click(screen.getByRole('button', { name: 'Actions' }));
-      await user.hover(await screen.findByRole('option', { name: 'Delete' }));
-      expect(await screen.findByText('Second rule matches')).toBeInTheDocument();
-      expect(screen.queryByText('Should not appear')).not.toBeInTheDocument();
     });
 
     it('shows only one tooltip at a time when hovering between two disabled items', async () => {
@@ -313,15 +277,90 @@ describe('ActionsPopover', () => {
         <ActionsPopover
           actions={[
             disabledAction,
-            { display: { label: 'Edit' }, component: DeleteDialog },
+            { display: { label: 'Edit' }, modal: { type: 'custom', component: DeleteDialog } },
           ]}
           record={{}}
         />,
-        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getRouterWrapper()])
       );
       await user.click(screen.getByRole('button', { name: 'Actions' }));
       await user.click(await screen.findByRole('option', { name: 'Edit' }));
       expect(await screen.findByRole('dialog')).toBeInTheDocument();
     });
+  });
+
+  it('mutation-confirm action: shows confirm dialog and fires mutation on confirm', async () => {
+    const user = userEvent.setup();
+    const mockRequest = createQueryMockRouter({ UpdateTriggerRun: { triggerRun: {} } });
+
+    render(
+      <ActionsPopover
+        actions={[
+          {
+            display: { label: 'Kill' },
+            action: { type: 'mutation', mutation: { mutationName: 'UpdateTriggerRun' } },
+            modal: {
+              type: 'confirm',
+              header: { title: 'Confirm kill?' },
+              button: { label: 'Kill it' },
+              destructive: true,
+            },
+          },
+        ]}
+        record={{ id: 'run-1' }}
+      />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getErrorProviderWrapper(),
+        getRouterWrapper(),
+        getServiceProviderWrapper({ request: mockRequest }),
+      ])
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Actions' }));
+    await user.click(await screen.findByRole('option', { name: 'Kill' }));
+    const dialog = await screen.findByRole('dialog', { name: 'Confirm kill?' });
+    await user.click(within(dialog).getByRole('button', { name: 'Kill it' }));
+
+    await waitFor(() => {
+      expect(mockRequest).toHaveBeenCalledWith('UpdateTriggerRun', { id: 'run-1' });
+    });
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  it('route-confirm action: shows confirm dialog and navigates on confirm', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ActionsPopover
+        actions={[
+          {
+            display: { label: 'Open detail' },
+            action: { type: 'route', route: '/dest/page' },
+            modal: {
+              type: 'confirm',
+              header: { title: 'Open detail page?' },
+              button: { label: 'Open' },
+            },
+          },
+        ]}
+        record={{}}
+      />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getRouterWrapper({ location: '/start' }),
+      ])
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Actions' }));
+    await user.click(await screen.findByRole('option', { name: 'Open detail' }));
+    const dialog = await screen.findByRole('dialog', { name: 'Open detail page?' });
+    await user.click(within(dialog).getByRole('button', { name: 'Open' }));
+
+    expect(screen.getByText(/Current pathname: \/dest\/page/)).toBeInTheDocument();
   });
 });

--- a/javascript/packages/core/components/actions/__tests__/actions-popover.test.tsx
+++ b/javascript/packages/core/components/actions/__tests__/actions-popover.test.tsx
@@ -53,7 +53,12 @@ describe('ActionsPopover', () => {
     const user = userEvent.setup();
     render(
       <ActionsPopover
-        actions={[{ display: { label: 'Delete', icon: 'trash' }, component: DeleteDialog }]}
+        actions={[
+          {
+            display: { label: 'Delete', icon: 'trash' },
+            component: DeleteDialog,
+          },
+        ]}
         record={{}}
       />,
       buildWrapper([
@@ -235,18 +240,9 @@ describe('ActionsPopover', () => {
       render(
         <ActionMenu
           actions={[
-            {
-              display: { label: 'Delete' },
-              component: DeleteDialog,
-              disabled: [{ condition: true, message: 'Cannot delete' }],
-            },
-            {
-              display: { label: 'Archive' },
-              component: DeleteDialog,
-              disabled: [{ condition: true, message: 'Cannot archive' }],
-            },
+            { display: { label: 'Delete' }, disabled: true, disabledMessage: 'Cannot delete', onClick: vi.fn() },
+            { display: { label: 'Archive' }, disabled: true, disabledMessage: 'Cannot archive', onClick: vi.fn() },
           ]}
-          record={{}}
           onSelectAction={vi.fn()}
         />,
         buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
@@ -264,7 +260,10 @@ describe('ActionsPopover', () => {
 
     it('does not show the tooltip from auto-highlight when the menu opens', async () => {
       render(
-        <ActionMenu actions={[disabledAction]} record={{}} onSelectAction={vi.fn()} />,
+        <ActionMenu
+          actions={[{ display: { label: 'Delete' }, disabled: true, disabledMessage: 'Cannot delete', onClick: vi.fn() }]}
+          onSelectAction={vi.fn()}
+        />,
         buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
       );
       await screen.findByRole('option', { name: 'Delete' });
@@ -275,8 +274,10 @@ describe('ActionsPopover', () => {
       const user = userEvent.setup();
       render(
         <ActionMenu
-          actions={[{ display: { label: 'Edit' }, component: DeleteDialog }, disabledAction]}
-          record={{}}
+          actions={[
+            { display: { label: 'Edit' }, disabled: false, onClick: vi.fn() },
+            { display: { label: 'Delete' }, disabled: true, disabledMessage: 'Cannot delete', onClick: vi.fn() },
+          ]}
           onSelectAction={vi.fn()}
         />,
         buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
@@ -291,18 +292,9 @@ describe('ActionsPopover', () => {
       render(
         <ActionMenu
           actions={[
-            {
-              display: { label: 'Delete' },
-              component: DeleteDialog,
-              disabled: [{ condition: true, message: 'Cannot delete' }],
-            },
-            {
-              display: { label: 'Archive' },
-              component: DeleteDialog,
-              disabled: [{ condition: true, message: 'Cannot archive' }],
-            },
+            { display: { label: 'Delete' }, disabled: true, disabledMessage: 'Cannot delete', onClick: vi.fn() },
+            { display: { label: 'Archive' }, disabled: true, disabledMessage: 'Cannot archive', onClick: vi.fn() },
           ]}
-          record={{}}
           onSelectAction={vi.fn()}
         />,
         buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
@@ -319,7 +311,10 @@ describe('ActionsPopover', () => {
       const user = userEvent.setup();
       render(
         <ActionsPopover
-          actions={[disabledAction, { display: { label: 'Edit' }, component: DeleteDialog }]}
+          actions={[
+            disabledAction,
+            { display: { label: 'Edit' }, component: DeleteDialog },
+          ]}
           record={{}}
         />,
         buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])

--- a/javascript/packages/core/components/actions/__tests__/use-resolved-action-items.test.ts
+++ b/javascript/packages/core/components/actions/__tests__/use-resolved-action-items.test.ts
@@ -1,0 +1,51 @@
+import { renderHook } from '@testing-library/react';
+
+import { useResolvedActionItems } from '#core/components/actions/use-resolved-action-items';
+
+import type { ActionConfig } from '#core/components/actions/types';
+
+const customAction = (label: string, disabled?: { condition: boolean; message?: string }[]) =>
+  ({
+    display: { label },
+    modal: { type: 'custom', component: () => null },
+    ...(disabled ? { disabled } : {}),
+  }) as ActionConfig;
+
+describe('useResolvedActionItems', () => {
+  it('returns one item per action with display and onClick wired to onSelect', () => {
+    const onSelect = vi.fn();
+    const action = customAction('Delete');
+    const { result } = renderHook(() => useResolvedActionItems([action], onSelect));
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].display).toEqual({ label: 'Delete' });
+    expect(result.current[0].disabled).toBe(false);
+    expect(result.current[0].disabledMessage).toBeUndefined();
+
+    result.current[0].onClick();
+    expect(onSelect).toHaveBeenCalledWith(action);
+  });
+
+  it('extracts the first matching disabled rule into the resolved item', () => {
+    const onSelect = vi.fn();
+    const action = customAction('Edit', [
+      { condition: false, message: 'Should not appear' },
+      { condition: true, message: 'Read-only' },
+      { condition: true, message: 'Should not appear either' },
+    ]);
+    const { result } = renderHook(() => useResolvedActionItems([action], onSelect));
+
+    expect(result.current[0].disabled).toBe(true);
+    expect(result.current[0].disabledMessage).toBe('Read-only');
+  });
+
+  it('each item resolves onClick to its own action', () => {
+    const onSelect = vi.fn();
+    const a = customAction('A');
+    const b = customAction('B');
+    const { result } = renderHook(() => useResolvedActionItems([a, b], onSelect));
+
+    result.current[1].onClick();
+    expect(onSelect).toHaveBeenCalledWith(b);
+  });
+});

--- a/javascript/packages/core/components/actions/action-dispatcher.tsx
+++ b/javascript/packages/core/components/actions/action-dispatcher.tsx
@@ -1,0 +1,41 @@
+import { MutationConfirmDispatcher } from './mutation-confirm-dispatcher';
+import { RouteConfirmDispatcher } from './route-confirm-dispatcher';
+
+import type { ActionConfig, Data } from './types';
+
+type Props<T extends Data> = {
+  action: ActionConfig<T>;
+  record: T;
+  onClose: () => void;
+};
+
+/**
+ * Branches on the modal + action type and delegates to the appropriate
+ * dispatcher. Each sub-dispatcher only calls the hooks it needs, so we
+ * avoid rules-of-hooks violations from a single component branching on
+ * config shape.
+ */
+export function ActionDispatcher<T extends Data>({ action, record, onClose }: Props<T>) {
+  if (action.modal?.type === 'custom') {
+    const Component = action.modal.component;
+    return <Component record={record} onClose={onClose} />;
+  }
+  if (action.modal?.type === 'confirm' && action.action?.type === 'mutation') {
+    return (
+      <MutationConfirmDispatcher
+        action={{ ...action, action: action.action, modal: action.modal }}
+        record={record}
+        onClose={onClose}
+      />
+    );
+  }
+  if (action.modal?.type === 'confirm' && action.action?.type === 'route') {
+    return (
+      <RouteConfirmDispatcher
+        action={{ ...action, action: action.action, modal: action.modal }}
+        onClose={onClose}
+      />
+    );
+  }
+  return null;
+}

--- a/javascript/packages/core/components/actions/action-menu/action-menu-item.tsx
+++ b/javascript/packages/core/components/actions/action-menu/action-menu-item.tsx
@@ -5,7 +5,7 @@ import { ACCESSIBILITY_TYPE, PLACEMENT, Tooltip } from 'baseui/tooltip';
 import { Icon } from '#core/components/icon/icon';
 
 import type { MenuAdapterProps } from 'baseui/list';
-import type { ComponentActionConfig, Data, SelectedAction } from '#core/components/actions/types';
+import type { ResolvedActionItem } from '#core/components/actions/types';
 
 /**
  * Props for ActionMenuItem, combining BaseUI's MenuAdapter props with
@@ -16,20 +16,13 @@ import type { ComponentActionConfig, Data, SelectedAction } from '#core/componen
  * are passed from ActionMenu through the override's `props` field.
  */
 type ActionMenuItemProps = {
-  /**
-   * Item is the action configuration defined for a specific action in
-   * the ActionMenu list, passed as `item` per baseui MenuAdapter props.
-   */
-  item: Omit<ComponentActionConfig, 'disabled'> & {
-    disabled: boolean;
-    disabledMessage: string | undefined;
-  };
-  record: Data;
-  onSelectAction: (action: SelectedAction) => void;
+  /** Item is the resolved action data, passed as `item` per baseui MenuAdapter props. */
+  item: ResolvedActionItem;
+  onSelectAction: (action: ResolvedActionItem) => void;
   onClose?: () => void;
   /**
-   * The action currently under the mouse cursor, or null.
-   * Compared by object identity against `action` to derive `isHovered`.
+   * The action item currently under the mouse cursor, or null.
+   * Compared by object identity against `item` to derive `isHovered`.
    */
   hoveredItem: object | null;
   setHoveredItem: (item: object | null) => void;
@@ -44,8 +37,7 @@ type ActionMenuItemProps = {
 
 export const ActionMenuItem = forwardRef<HTMLLIElement, ActionMenuItemProps>((props, ref) => {
   const {
-    item: action,
-    record,
+    item,
     onSelectAction,
     onClose,
     hoveredItem,
@@ -54,7 +46,7 @@ export const ActionMenuItem = forwardRef<HTMLLIElement, ActionMenuItemProps>((pr
     setKeyboardActive,
     ...baseMenuProps
   } = props;
-  const isHovered = hoveredItem === action;
+  const isHovered = hoveredItem === item;
 
   const menuItem = (
     <MenuAdapter
@@ -65,29 +57,27 @@ export const ActionMenuItem = forwardRef<HTMLLIElement, ActionMenuItemProps>((pr
       ref={ref}
       role="option"
       artwork={
-        action.display.icon
-          ? ({ size }: { size: number }) => <Icon name={action.display.icon} size={`${size}px`} />
+        item.display.icon
+          ? ({ size }: { size: number }) => <Icon name={item.display.icon} size={`${size}px`} />
           : undefined
       }
       artworkSize={ARTWORK_SIZES.MEDIUM}
       // Opacity rather than $theme.colors.menuFontDisabled because ListItemLabel's
       // <p> sets its own color (contentPrimary), blocking CSS inheritance from the <li>.
       // Opacity dims the entire item (icon + text) uniformly.
-      overrides={{ Root: { style: { height: '44px', opacity: action.disabled ? 0.4 : 1 } } }}
-      $disabled={action.disabled}
-      onClick={
-        action.disabled ? undefined : () => onSelectAction({ component: action.component, record })
-      }
+      overrides={{ Root: { style: { height: '44px', opacity: item.disabled ? 0.4 : 1 } } }}
+      $disabled={item.disabled}
+      onClick={item.disabled ? undefined : () => onSelectAction(item)}
     >
-      <ListItemLabel>{action.display.label}</ListItemLabel>
+      <ListItemLabel>{item.display.label}</ListItemLabel>
     </MenuAdapter>
   );
 
-  if (!action.disabled || !action.disabledMessage) return menuItem;
+  if (!item.disabled || !item.disabledMessage) return menuItem;
 
   return (
     <Tooltip
-      content={action.disabledMessage}
+      content={item.disabledMessage}
       autoFocus={false}
       accessibilityType={ACCESSIBILITY_TYPE.tooltip}
       showArrow
@@ -107,7 +97,7 @@ export const ActionMenuItem = forwardRef<HTMLLIElement, ActionMenuItemProps>((pr
       // Entering mouse mode: track this item as hovered and disable the keyboard
       // path so the previously arrow-key-highlighted item's tooltip hides.
       onMouseEnter={() => {
-        setHoveredItem(action);
+        setHoveredItem(item);
         setKeyboardActive(false);
       }}
       onMouseLeave={() => setHoveredItem(null)}

--- a/javascript/packages/core/components/actions/action-menu/action-menu.tsx
+++ b/javascript/packages/core/components/actions/action-menu/action-menu.tsx
@@ -1,20 +1,16 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { StatefulMenu } from 'baseui/menu';
 
 import { ActionMenuItem } from './action-menu-item';
 
 import type { Theme } from 'baseui';
-import type {
-  ActionConfig,
-  ComponentActionConfig,
-  Data,
-  SelectedAction,
-} from '#core/components/actions/types';
+import type { ResolvedActionItem } from '#core/components/actions/types';
 
 type ActionMenuProps = {
-  actions: ActionConfig[];
-  record: Data;
-  onSelectAction: (action: SelectedAction) => void;
+  actions: ResolvedActionItem[];
+  /** Called when the user selects an action (mouse click or keyboard enter). */
+  onSelectAction: (action: ResolvedActionItem) => void;
+  /** Called when the menu should close (e.g. Escape key). Distinct from onSelectAction. */
   onClose?: () => void;
 };
 
@@ -32,20 +28,9 @@ type ActionMenuProps = {
  *   the auto-highlight on focus. Set to `true` on any keydown inside the
  *   menu, reset to `false` on mouse enter.
  */
-export function ActionMenu(props: ActionMenuProps) {
+export function ActionMenu({ actions, onSelectAction, onClose }: ActionMenuProps) {
   const [hoveredItem, setHoveredItem] = useState<object | null>(null);
   const [keyboardActive, setKeyboardActive] = useState(false);
-
-  // ActionConfig.disabled is a rule array; StatefulMenu expects a boolean item.disabled.
-  // Pre-compute here and carry the message forward for ActionMenuItem's tooltip.
-  const items = useMemo(
-    () =>
-      props.actions.map((action) => {
-        const disabledRule = action.disabled?.find((rule) => rule.condition);
-        return { ...action, disabled: !!disabledRule, disabledMessage: disabledRule?.message };
-      }),
-    [props.actions]
-  );
 
   return (
     // Wrapper div: onKeyDown fires via bubbling AFTER StatefulMenu's arrow-key
@@ -58,17 +43,16 @@ export function ActionMenu(props: ActionMenuProps) {
       }}
     >
       <StatefulMenu
-        items={items}
-        onItemSelect={({ item: action }: { item: ComponentActionConfig }) => {
-          props.onSelectAction({ component: action.component, record: props.record });
+        items={actions}
+        onItemSelect={({ item }: { item: ResolvedActionItem }) => {
+          if (!item.disabled) onSelectAction(item);
         }}
         overrides={{
           Option: {
             component: ActionMenuItem,
             props: {
-              record: props.record,
-              onSelectAction: props.onSelectAction,
-              onClose: props.onClose,
+              onSelectAction,
+              onClose,
               hoveredItem,
               setHoveredItem,
               keyboardActive,

--- a/javascript/packages/core/components/actions/actions-buttons/actions-buttons.tsx
+++ b/javascript/packages/core/components/actions/actions-buttons/actions-buttons.tsx
@@ -1,8 +1,10 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { useStyletron } from 'baseui';
 import { Button, KIND, SHAPE, SIZE } from 'baseui/button';
 import { PLACEMENT } from 'baseui/popover';
 
+import { ActionDispatcher } from '#core/components/actions/action-dispatcher';
 import { ActionsPopover } from '#core/components/actions/actions-popover';
 import { Icon } from '#core/components/icon/icon';
 import { partitionActions } from './utils';
@@ -28,11 +30,19 @@ export function ActionsButtons<T extends Data>({
 }: ActionsButtonsProps<T>) {
   const [css, theme] = useStyletron();
   const [activeAction, setActiveAction] = useState<ActionConfig<T> | null>(null);
+  const navigate = useNavigate();
 
   if (actions.length === 0) return null;
 
   const { primary, secondary, tertiary } = partitionActions(actions);
-  const ActiveComponent = activeAction?.component;
+
+  const activateAction = (action: ActionConfig<T>) => {
+    if (action.modal) {
+      setActiveAction(action);
+    } else if (action.action?.type === 'route') {
+      navigate(action.action.route);
+    }
+  };
 
   return (
     <>
@@ -54,7 +64,7 @@ export function ActionsButtons<T extends Data>({
                   )
                 : undefined
             }
-            onClick={() => setActiveAction(primary)}
+            onClick={() => activateAction(primary)}
           >
             {primary.display.label}
           </Button>
@@ -73,7 +83,7 @@ export function ActionsButtons<T extends Data>({
                   )
                 : undefined
             }
-            onClick={() => setActiveAction(action)}
+            onClick={() => activateAction(action)}
           >
             {action.display.label}
           </Button>
@@ -86,8 +96,12 @@ export function ActionsButtons<T extends Data>({
           />
         )}
       </div>
-      {activeAction && ActiveComponent && (
-        <ActiveComponent record={record} isOpen onClose={() => setActiveAction(null)} />
+      {activeAction && (
+        <ActionDispatcher
+          action={activeAction}
+          record={record}
+          onClose={() => setActiveAction(null)}
+        />
       )}
     </>
   );

--- a/javascript/packages/core/components/actions/actions-buttons/actions-buttons.tsx
+++ b/javascript/packages/core/components/actions/actions-buttons/actions-buttons.tsx
@@ -7,7 +7,7 @@ import { ActionsPopover } from '#core/components/actions/actions-popover';
 import { Icon } from '#core/components/icon/icon';
 import { partitionActions } from './utils';
 
-import type { ActionConfig, Data, SelectedAction } from '#core/components/actions/types';
+import type { ActionConfig, Data } from '#core/components/actions/types';
 
 type ActionsButtonsProps<T extends Data = Data> = {
   actions: ActionConfig<T>[];
@@ -27,12 +27,12 @@ export function ActionsButtons<T extends Data>({
   loading,
 }: ActionsButtonsProps<T>) {
   const [css, theme] = useStyletron();
-  const [selectedAction, setSelectedAction] = useState<SelectedAction | null>(null);
+  const [activeAction, setActiveAction] = useState<ActionConfig<T> | null>(null);
 
   if (actions.length === 0) return null;
 
   const { primary, secondary, tertiary } = partitionActions(actions);
-  const ActiveComponent = selectedAction?.component;
+  const ActiveComponent = activeAction?.component;
 
   return (
     <>
@@ -54,7 +54,7 @@ export function ActionsButtons<T extends Data>({
                   )
                 : undefined
             }
-            onClick={() => setSelectedAction({ component: primary.component, record })}
+            onClick={() => setActiveAction(primary)}
           >
             {primary.display.label}
           </Button>
@@ -73,7 +73,7 @@ export function ActionsButtons<T extends Data>({
                   )
                 : undefined
             }
-            onClick={() => setSelectedAction({ component: action.component, record })}
+            onClick={() => setActiveAction(action)}
           >
             {action.display.label}
           </Button>
@@ -86,12 +86,8 @@ export function ActionsButtons<T extends Data>({
           />
         )}
       </div>
-      {selectedAction && ActiveComponent && (
-        <ActiveComponent
-          record={selectedAction.record}
-          isOpen
-          onClose={() => setSelectedAction(null)}
-        />
+      {activeAction && ActiveComponent && (
+        <ActiveComponent record={record} isOpen onClose={() => setActiveAction(null)} />
       )}
     </>
   );

--- a/javascript/packages/core/components/actions/actions-popover.tsx
+++ b/javascript/packages/core/components/actions/actions-popover.tsx
@@ -5,11 +5,11 @@ import { PLACEMENT, StatefulPopover } from 'baseui/popover';
 
 import { Icon } from '#core/components/icon/icon';
 import { ActionMenu } from './action-menu/action-menu';
+import { useResolvedActionItems } from './use-resolved-action-items';
 
 import type { ButtonProps } from 'baseui/button';
 import type { BasePopoverProps } from 'baseui/popover';
-import type { ComponentType } from 'react';
-import type { ActionComponentProps, ActionConfig, Data } from './types';
+import type { ActionConfig, Data } from './types';
 
 type ActionsPopoverProps<T extends Data> = {
   actions: ActionConfig<T>[];
@@ -25,11 +25,10 @@ export function ActionsPopover<T extends Data>({
   popoverProps,
 }: ActionsPopoverProps<T>) {
   const scrollDisabledRef = useRef(false);
-  const [activeAction, setActiveAction] = useState<{
-    component: ComponentType<ActionComponentProps>;
-    record: Data;
-  } | null>(null);
+  const [activeAction, setActiveAction] = useState<ActionConfig<T> | null>(null);
   const [, theme] = useStyletron();
+
+  const items = useResolvedActionItems(actions, setActiveAction);
 
   const disableScroll = () => {
     document.body.style.overflow = 'hidden';
@@ -64,10 +63,9 @@ export function ActionsPopover<T extends Data>({
         {...popoverProps}
         content={({ close }) => (
           <ActionMenu
-            actions={actions as ActionConfig[]}
-            record={record}
+            actions={items}
             onSelectAction={(action) => {
-              setActiveAction(action);
+              action.onClick();
               close();
             }}
             onClose={close}
@@ -93,11 +91,7 @@ export function ActionsPopover<T extends Data>({
         </Button>
       </StatefulPopover>
       {ActiveComponent && (
-        <ActiveComponent
-          record={activeAction.record}
-          isOpen
-          onClose={() => setActiveAction(null)}
-        />
+        <ActiveComponent record={record} isOpen onClose={() => setActiveAction(null)} />
       )}
     </>
   );

--- a/javascript/packages/core/components/actions/actions-popover.tsx
+++ b/javascript/packages/core/components/actions/actions-popover.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { useStyletron } from 'baseui';
 import { Button, KIND, SHAPE, SIZE } from 'baseui/button';
 import { PLACEMENT, StatefulPopover } from 'baseui/popover';
 
 import { Icon } from '#core/components/icon/icon';
+import { ActionDispatcher } from './action-dispatcher';
 import { ActionMenu } from './action-menu/action-menu';
 import { useResolvedActionItems } from './use-resolved-action-items';
 
@@ -26,9 +28,16 @@ export function ActionsPopover<T extends Data>({
 }: ActionsPopoverProps<T>) {
   const scrollDisabledRef = useRef(false);
   const [activeAction, setActiveAction] = useState<ActionConfig<T> | null>(null);
+  const navigate = useNavigate();
   const [, theme] = useStyletron();
 
-  const items = useResolvedActionItems(actions, setActiveAction);
+  const items = useResolvedActionItems(actions, (action) => {
+    if (action.modal) {
+      setActiveAction(action);
+    } else if (action.action?.type === 'route') {
+      navigate(action.action.route);
+    }
+  });
 
   const disableScroll = () => {
     document.body.style.overflow = 'hidden';
@@ -47,8 +56,6 @@ export function ActionsPopover<T extends Data>({
       }
     };
   }, []);
-
-  const ActiveComponent = activeAction?.component;
 
   return (
     <>
@@ -90,8 +97,12 @@ export function ActionsPopover<T extends Data>({
           <Icon name="overflowMenu" />
         </Button>
       </StatefulPopover>
-      {ActiveComponent && (
-        <ActiveComponent record={record} isOpen onClose={() => setActiveAction(null)} />
+      {activeAction && (
+        <ActionDispatcher
+          action={activeAction}
+          record={record}
+          onClose={() => setActiveAction(null)}
+        />
       )}
     </>
   );

--- a/javascript/packages/core/components/actions/mutation-confirm-dispatcher.tsx
+++ b/javascript/packages/core/components/actions/mutation-confirm-dispatcher.tsx
@@ -1,0 +1,53 @@
+import { ARTWORK_TYPE } from 'baseui/banner';
+
+import { Banner } from '#core/components/banner/banner';
+import { ConfirmDialog } from '#core/components/modal/confirm-dialog/confirm-dialog';
+import { Icon } from '#core/components/icon/icon';
+import { useSchemaMiddleware } from '#core/hooks/use-schema-middleware/use-schema-middleware';
+import { useStudioMutation } from '#core/hooks/use-studio-mutation';
+
+import type { ActionConfig, ConfirmModalConfig, Data, MutationActionConfig } from './types';
+
+type Props<T extends Data> = {
+  action: ActionConfig<T> & { action: MutationActionConfig; modal: ConfirmModalConfig };
+  record: T;
+  onClose: () => void;
+};
+
+/**
+ * Renders a {@link ConfirmDialog} for an action that fires a mutation. Applies
+ * any declared middleware to the record before submission. The dialog
+ * auto-closes on success and stays open with an error banner on failure.
+ */
+export function MutationConfirmDispatcher<T extends Data>({ action, record, onClose }: Props<T>) {
+  const { applyMiddleware } = useSchemaMiddleware(action.action.middleware ?? null);
+  const mutation = useStudioMutation<unknown, T>(action.action.mutation);
+
+  return (
+    <ConfirmDialog
+      isOpen
+      onDismiss={onClose}
+      onConfirm={async () => {
+        await mutation.mutateAsync(applyMiddleware(record));
+      }}
+      heading={action.modal.header.title}
+      confirmLabel={action.modal.button.label}
+      destructive={action.modal.destructive}
+      size={action.modal.size}
+    >
+      {action.modal.banner && (
+        <Banner
+          kind={action.modal.banner.kind}
+          artwork={
+            action.modal.banner.icon
+              ? { type: ARTWORK_TYPE.icon, icon: () => <Icon name={action.modal.banner!.icon!} /> }
+              : undefined
+          }
+        >
+          {action.modal.banner.content}
+        </Banner>
+      )}
+      {action.modal.body}
+    </ConfirmDialog>
+  );
+}

--- a/javascript/packages/core/components/actions/route-confirm-dispatcher.tsx
+++ b/javascript/packages/core/components/actions/route-confirm-dispatcher.tsx
@@ -1,0 +1,46 @@
+import { useNavigate } from 'react-router-dom-v5-compat';
+import { ARTWORK_TYPE } from 'baseui/banner';
+
+import { Banner } from '#core/components/banner/banner';
+import { ConfirmDialog } from '#core/components/modal/confirm-dialog/confirm-dialog';
+import { Icon } from '#core/components/icon/icon';
+
+import type { ActionConfig, ConfirmModalConfig, Data, RouteActionConfig } from './types';
+
+type Props<T extends Data> = {
+  action: ActionConfig<T> & { action: RouteActionConfig; modal: ConfirmModalConfig };
+  onClose: () => void;
+};
+
+/**
+ * Renders a {@link ConfirmDialog} for an action that navigates to a route.
+ */
+export function RouteConfirmDispatcher<T extends Data>({ action, onClose }: Props<T>) {
+  const navigate = useNavigate();
+
+  return (
+    <ConfirmDialog
+      isOpen
+      onDismiss={onClose}
+      onConfirm={() => navigate(action.action.route)}
+      heading={action.modal.header.title}
+      confirmLabel={action.modal.button.label}
+      destructive={action.modal.destructive}
+      size={action.modal.size}
+    >
+      {action.modal.banner && (
+        <Banner
+          kind={action.modal.banner.kind}
+          artwork={
+            action.modal.banner.icon
+              ? { type: ARTWORK_TYPE.icon, icon: () => <Icon name={action.modal.banner!.icon!} /> }
+              : undefined
+          }
+        >
+          {action.modal.banner.content}
+        </Banner>
+      )}
+      {action.modal.body}
+    </ConfirmDialog>
+  );
+}

--- a/javascript/packages/core/components/actions/types.ts
+++ b/javascript/packages/core/components/actions/types.ts
@@ -1,33 +1,34 @@
-import type { ComponentType } from 'react';
+import type { BannerProps } from 'baseui/banner';
+import type { Size as DialogSize } from 'baseui/dialog';
+import type { ComponentType, ReactNode } from 'react';
+import type { MiddlewareSchema } from '#core/hooks/use-schema-middleware/types';
 import type { DeepInterpolatable } from '#core/interpolation/types';
+import type { MutationConfig } from '#core/types/query-types';
 
-export type ActionConfig<T = Data> = ComponentActionConfig<T>;
+export type Data = Record<string, unknown>;
 
 /**
- * Base fields shared by all action configurations.
+ * An action exposed on an entity (e.g. a row's overflow menu, a header button).
  *
- * @example
- * ```ts
- * const deleteAction: ComponentActionConfig<Pipeline> = {
- *   display: { label: 'Delete', icon: 'trash' },
- *   component: DeleteDialog,
- * };
- * ```
+ * Two shapes:
+ * - **Action + optional confirm modal** — dispatches a mutation or route, optionally
+ *   gated by a confirm dialog.
+ * - **Custom modal** — opens a custom React component (a form, a wizard, etc.).
+ *   Cannot pair with `action`; the component owns its own submit flow.
  */
+export type ActionConfig<T = Data> = ActionConfigBase &
+  (
+    | { action: MutationActionConfig | RouteActionConfig; modal?: ConfirmModalConfig }
+    | { modal: CustomModalConfig<T>; action?: never }
+  );
+
 export type ActionConfigBase = {
-  /**
-   * Controls how the action's trigger button is displayed to the user.
-   *
-   * @see {@link ActionTriggerDisplay}
-   */
+  /** Controls how the action's trigger button is displayed to the user. */
   display: ActionTriggerDisplay;
 
   /**
-   * Visual hierarchy of the action's trigger button
-   *
-   * @note Actions without an explicit hierarchy default to tertiary (overflow menu).
-   *
-   * @see {@link ActionHierarchy}
+   * Visual hierarchy of the action's trigger button.
+   * Actions without an explicit hierarchy default to tertiary (overflow menu).
    */
   hierarchy?: ActionHierarchy;
 
@@ -39,40 +40,46 @@ export type ActionConfigBase = {
   disabled?: DisabledRule[];
 };
 
-/**
- * How the action's trigger button is displayed to the user
- *
- * @note icon is a string reference to an icon in the icon provider
- */
-type ActionTriggerDisplay = {
-  label: string;
-  icon?: string;
+/** Action that fires a mutation against the API, with optional middleware to shape the record first. */
+export type MutationActionConfig = {
+  type: 'mutation';
+  mutation: MutationConfig;
+  middleware?: MiddlewareSchema;
 };
 
-export enum ActionHierarchy {
-  PRIMARY = 'primary',
-  SECONDARY = 'secondary',
-  TERTIARY = 'tertiary',
-}
+export type RouteActionConfig = {
+  type: 'route';
+  route: string;
+};
 
-export type Data = Record<string, unknown>;
+/** Confirm dialog gating a mutation or route action. */
+export type ConfirmModalConfig = {
+  type: 'confirm';
+  header: { title: string };
+  body?: ReactNode;
+  banner?: BannerConfig;
+  button: { label: string; icon?: string };
+  /** Renders the confirm button in red. Use for irreversible actions (e.g. delete). */
+  destructive?: boolean;
+  size?: DialogSize;
+};
 
-export type ComponentActionConfig<T = Data> = ActionConfigBase & {
+/** Custom React component opened in a modal — owns its own submit flow. */
+export type CustomModalConfig<T> = {
+  type: 'custom';
   component: ComponentType<ActionComponentProps<T>>;
 };
 
-export type ActionComponentProps<T = Data> = {
-  record: T;
-  isOpen: boolean;
-  onClose: () => void;
+export type BannerConfig = {
+  content: ReactNode;
+  kind?: BannerProps['kind'];
+  icon?: string;
 };
 
-export type ResolvedActionItem = {
-  display: ActionTriggerDisplay;
-  hierarchy?: ActionHierarchy;
-  disabled: boolean;
-  disabledMessage?: string;
-  onClick: () => void;
+/** Props passed to a component rendered by {@link CustomModalConfig}. */
+export type ActionComponentProps<T = Data> = {
+  record: T;
+  onClose: () => void;
 };
 
 /**
@@ -83,6 +90,33 @@ export type ResolvedActionItem = {
  * is resolved at the per-row boundary before reaching any rendering code.
  */
 export type ActionConfigSchema<T = Data> = DeepInterpolatable<ActionConfig<T>>;
+
+export enum ActionHierarchy {
+  PRIMARY = 'primary',
+  SECONDARY = 'secondary',
+  TERTIARY = 'tertiary',
+}
+
+/**
+ * Item shape consumed by action renderers (see `useResolvedActionItems`).
+ * Only display + `onClick` — no action-type knowledge. The `onClick`
+ * delegates to whatever `onSelect` the renderer provided when the item
+ * was resolved.
+ */
+export type ResolvedActionItem = {
+  display: ActionTriggerDisplay;
+  hierarchy?: ActionHierarchy;
+  /** True if any of the source action's disabled rules matched. */
+  disabled: boolean;
+  /** Tooltip shown on hover/keyboard navigation when `disabled` is true. */
+  disabledMessage?: string;
+  onClick: () => void;
+};
+
+type ActionTriggerDisplay = {
+  label: string;
+  icon?: string;
+};
 
 /** A condition that disables an action for a specific record, with an optional hover tooltip. */
 type DisabledRule = {

--- a/javascript/packages/core/components/actions/types.ts
+++ b/javascript/packages/core/components/actions/types.ts
@@ -67,9 +67,12 @@ export type ActionComponentProps<T = Data> = {
   onClose: () => void;
 };
 
-export type SelectedAction = {
-  component: ComponentType<ActionComponentProps>;
-  record: Data;
+export type ResolvedActionItem = {
+  display: ActionTriggerDisplay;
+  hierarchy?: ActionHierarchy;
+  disabled: boolean;
+  disabledMessage?: string;
+  onClick: () => void;
 };
 
 /**

--- a/javascript/packages/core/components/actions/use-resolved-action-items.ts
+++ b/javascript/packages/core/components/actions/use-resolved-action-items.ts
@@ -1,0 +1,32 @@
+import { useMemo } from 'react';
+
+import type { ActionConfig, Data, ResolvedActionItem } from './types';
+
+/**
+ * Resolves an array of {@link ActionConfig} into render-ready items. Pure —
+ * does not navigate, mount components, or trigger mutations. The renderer's
+ * `onSelect` callback decides what to do when an item is clicked.
+ *
+ * The returned items have stable identity across renders (memoized on
+ * `actions`/`onSelect`) so consumers can compare items by reference — for
+ * example, to track which item is hovered.
+ */
+export function useResolvedActionItems<T extends Data>(
+  actions: ActionConfig<T>[],
+  onSelect: (action: ActionConfig<T>) => void
+): ResolvedActionItem[] {
+  return useMemo(
+    () =>
+      actions.map((action) => {
+        const matchingRule = action.disabled?.find((rule) => rule.condition);
+        return {
+          display: action.display,
+          hierarchy: action.hierarchy,
+          disabled: !!matchingRule,
+          disabledMessage: matchingRule?.message,
+          onClick: () => onSelect(action),
+        };
+      }),
+    [actions, onSelect]
+  );
+}

--- a/javascript/packages/core/components/views/phase-entity-view/__tests__/phase-entity-view.test.tsx
+++ b/javascript/packages/core/components/views/phase-entity-view/__tests__/phase-entity-view.test.tsx
@@ -18,7 +18,6 @@ import {
 } from '#core/test/wrappers/get-service-provider-wrapper';
 import { PhaseEntityView } from '../phase-entity-view';
 
-import type { ActionComponentProps } from '#core/components/actions/types';
 import type { ListableEntity } from '../types';
 
 describe('PhaseEntityView', () => {
@@ -88,15 +87,16 @@ describe('PhaseEntityView', () => {
 
   it('opens the action component when an action menu item is clicked', async () => {
     const user = userEvent.setup();
-    const RunDialog = ({ isOpen }: ActionComponentProps) =>
-      isOpen ? <div role="dialog">Run dialog</div> : null;
+    const RunDialog = () => <div role="dialog">Run dialog</div>;
 
     render(
       <PhaseEntityView
         phaseConfig={buildPhaseConfig()}
         entities={[
           buildPipelineEntityConfig({
-            actions: [{ display: { label: 'Run' }, component: RunDialog }],
+            actions: [
+              { display: { label: 'Run' }, modal: { type: 'custom', component: RunDialog } },
+            ],
           }) as ListableEntity,
         ]}
       />,
@@ -120,8 +120,7 @@ describe('PhaseEntityView', () => {
 
   it('resolves interpolated disabled conditions per-row', async () => {
     const user = userEvent.setup();
-    const StubDialog = ({ isOpen }: ActionComponentProps) =>
-      isOpen ? <div role="dialog">Stub</div> : null;
+    const StubDialog = () => <div role="dialog">Stub</div>;
 
     render(
       <PhaseEntityView
@@ -131,7 +130,7 @@ describe('PhaseEntityView', () => {
             actions: [
               {
                 display: { label: 'Delete' },
-                component: StubDialog,
+                modal: { type: 'custom', component: StubDialog },
                 disabled: [
                   {
                     condition: interpolate(

--- a/javascript/packages/core/components/views/utils/__tests__/table-view-adapter.test.ts
+++ b/javascript/packages/core/components/views/utils/__tests__/table-view-adapter.test.ts
@@ -87,7 +87,7 @@ describe('adaptTableConfigToTableProps', () => {
   it('returns a render function when actions are configured', () => {
     // Full actions interaction is tested at the PhaseEntityView level.
     const tableConfig = buildTableConfig({
-      actions: [{ display: { label: 'Delete' }, component: () => null }],
+      actions: [{ display: { label: 'Delete' }, modal: { type: 'custom', component: () => null } }],
     });
     const result = adaptTableConfigToTableProps(tableConfig, {
       data: [{ name: 'Item 1', status: 'Active' }],

--- a/javascript/packages/core/config/entities/pipeline/__tests__/create-pipeline-run-form.test.tsx
+++ b/javascript/packages/core/config/entities/pipeline/__tests__/create-pipeline-run-form.test.tsx
@@ -15,15 +15,16 @@ import {
 } from '#core/test/wrappers/get-service-provider-wrapper';
 
 describe('CreatePipelineRunForm', () => {
-  // Stateful wrapper providing real isOpen state so FormDialog can close on success.
-  // Defined inside describe (not module level) and data is co-located.
+  // Mount-when-visible pattern: the dispatcher mounts the component while open and
+  // unmounts on close. This wrapper mirrors that — unmounting on onClose.
   function FormWrapper() {
-    const [isOpen, setIsOpen] = useState(true);
+    const [mounted, setMounted] = useState(true);
     const data = {
       metadata: { name: 'test-pipeline', namespace: 'test-namespace' },
       spec: { owner: { name: 'test-owner' } },
     };
-    return <CreatePipelineRunForm record={data} isOpen={isOpen} onClose={() => setIsOpen(false)} />;
+    if (!mounted) return null;
+    return <CreatePipelineRunForm record={data} onClose={() => setMounted(false)} />;
   }
 
   it('submits pipeline run with correct data structure and closes dialog', async () => {

--- a/javascript/packages/core/config/entities/pipeline/create-pipeline-run-form.tsx
+++ b/javascript/packages/core/config/entities/pipeline/create-pipeline-run-form.tsx
@@ -8,11 +8,7 @@ import type { ActionComponentProps } from '#core/components/actions/types';
 import type { Pipeline } from '#core/config/entities/pipeline/types';
 import type { PipelineRun } from '#core/config/entities/run/types';
 
-export const CreatePipelineRunForm = ({
-  record,
-  isOpen,
-  onClose,
-}: ActionComponentProps<Pipeline>) => {
+export const CreatePipelineRunForm = ({ record, onClose }: ActionComponentProps<Pipeline>) => {
   const { projectId } = useStudioParams('base');
 
   const createPipelineRunMutation = useStudioMutation<PipelineRun, PipelineRun>({
@@ -45,7 +41,7 @@ export const CreatePipelineRunForm = ({
 
   return (
     <FormDialog<PipelineRun>
-      isOpen={isOpen}
+      isOpen
       onDismiss={onClose}
       heading="Start new pipeline run"
       onSubmit={handleRunSubmit}

--- a/javascript/packages/core/config/entities/pipeline/pipeline.ts
+++ b/javascript/packages/core/config/entities/pipeline/pipeline.ts
@@ -15,7 +15,7 @@ export const PIPELINE_ENTITY_CONFIG: PhaseEntityConfig = {
     {
       display: { label: 'Run', icon: 'playerPlay' },
       hierarchy: ActionHierarchy.PRIMARY,
-      component: CreatePipelineRunForm,
+      modal: { type: 'custom', component: CreatePipelineRunForm },
     },
   ],
 };

--- a/javascript/packages/core/config/entities/trigger/__tests__/trigger-run-action-form.test.tsx
+++ b/javascript/packages/core/config/entities/trigger/__tests__/trigger-run-action-form.test.tsx
@@ -17,13 +17,13 @@ import { TriggerRunAction, TriggerRunState } from '../types';
 import type { ActionComponentProps } from '#core/components/actions/types';
 import type { TriggerRun } from '../types';
 
-// Provides real isOpen state so FormDialog can close on success.
+// Mount-when-visible pattern matching the dispatcher's lifecycle: unmount on close.
 function FormWrapper({
   Form,
 }: {
   Form: (props: ActionComponentProps<TriggerRun>) => React.ReactElement | null;
 }) {
-  const [isOpen, setIsOpen] = useState(true);
+  const [mounted, setMounted] = useState(true);
   const record: TriggerRun = {
     metadata: { name: 'my-trigger', namespace: 'test-ns' },
     spec: {
@@ -38,7 +38,8 @@ function FormWrapper({
     },
     status: { state: TriggerRunState.RUNNING },
   };
-  return <Form record={record} isOpen={isOpen} onClose={() => setIsOpen(false)} />;
+  if (!mounted) return null;
+  return <Form record={record} onClose={() => setMounted(false)} />;
 }
 
 it.each([

--- a/javascript/packages/core/config/entities/trigger/trigger-run-action-form.tsx
+++ b/javascript/packages/core/config/entities/trigger/trigger-run-action-form.tsx
@@ -18,7 +18,6 @@ const ACTION_CONFIG = {
 
 function TriggerRunActionForm({
   record,
-  isOpen,
   onClose,
   action,
 }: ActionComponentProps<TriggerRun> & { action: keyof typeof ACTION_CONFIG }) {
@@ -52,7 +51,7 @@ function TriggerRunActionForm({
 
   return (
     <FormDialog<TriggerRun>
-      isOpen={isOpen}
+      isOpen
       onDismiss={onClose}
       heading={config.heading}
       onSubmit={handleSubmit}

--- a/javascript/packages/core/config/entities/trigger/trigger.ts
+++ b/javascript/packages/core/config/entities/trigger/trigger.ts
@@ -22,7 +22,7 @@ export const TRIGGER_ENTITY_CONFIG: PhaseEntityConfig = {
   actions: [
     {
       display: { label: 'Kill', icon: 'stopCircle' },
-      component: KillTriggerRunForm,
+      modal: { type: 'custom', component: KillTriggerRunForm },
       hierarchy: interpolate(({ data }) =>
         isKillable(data) ? ActionHierarchy.SECONDARY : ActionHierarchy.TERTIARY
       ),

--- a/javascript/packages/core/router/__tests__/entity-detail-route.test.tsx
+++ b/javascript/packages/core/router/__tests__/entity-detail-route.test.tsx
@@ -720,12 +720,11 @@ describe('EntityDetailRoute', () => {
 
   test('renders entity-level actions in the detail page header', async () => {
     const user = userEvent.setup();
-    const RunDialog = ({ isOpen, onClose }: ActionComponentProps) =>
-      isOpen ? (
-        <div role="dialog">
-          Run form <button onClick={onClose}>Close</button>
-        </div>
-      ) : null;
+    const RunDialog = ({ onClose }: ActionComponentProps) => (
+      <div role="dialog">
+        Run form <button onClick={onClose}>Close</button>
+      </div>
+    );
 
     const testPhases = {
       train: buildPhase({
@@ -735,7 +734,7 @@ describe('EntityDetailRoute', () => {
             actions: [
               {
                 display: { label: 'Run', icon: 'playerPlay' },
-                component: RunDialog,
+                modal: { type: 'custom', component: RunDialog },
                 hierarchy: ActionHierarchy.PRIMARY,
               },
             ],
@@ -784,8 +783,7 @@ describe('EntityDetailRoute', () => {
   });
 
   test('resolves interpolated action hierarchy in the detail page header', async () => {
-    const StubDialog = ({ isOpen }: ActionComponentProps) =>
-      isOpen ? <div role="dialog">Stub</div> : null;
+    const StubDialog = () => <div role="dialog">Stub</div>;
 
     const testPhases = {
       train: buildPhase({
@@ -795,7 +793,7 @@ describe('EntityDetailRoute', () => {
             actions: [
               {
                 display: { label: 'Resume' },
-                component: StubDialog,
+                modal: { type: 'custom', component: StubDialog },
                 hierarchy: interpolate(({ data }) => {
                   const record = data as { status?: { state?: string } } | undefined;
                   return record?.status?.state === 'PAUSED'


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Refactor
- [x] Feature

**What changed?**

Restructures `ActionConfig` from a flat `component` field into an orthogonal `action × modal` union, and introduces typed dispatcher components that close the loop between action configuration and execution.

- `ActionConfig` is now a discriminated union: `{ action: Mutation|Route; modal?: Confirm }` or `{ modal: Custom }` — `action` and `modal` are independent axes
- Named subtypes exported: `MutationActionConfig`, `RouteActionConfig`, `ConfirmModalConfig`, `CustomModalConfig`
- `ActionDispatcher` routes to `MutationConfirmDispatcher` or `RouteConfirmDispatcher` based on the action/modal combination; both sub-dispatchers are private
- `MutationConfirmDispatcher` renders a `ConfirmDialog`, applies optional middleware, fires the mutation on confirm, and auto-closes on success
- `RouteConfirmDispatcher` renders a `ConfirmDialog` and navigates on confirm
- `ActionsPopover` and `ActionsButtons` add `useNavigate`; route-only actions navigate directly without opening a modal
- `ActionComponentProps` drops `isOpen` — components mount only when active, so the prop was always `true` and components can now use `isOpen` for their own internal state if needed
- All existing callsites updated: `component: Foo` → `modal: { type: 'custom', component: Foo }`
- Integration tests added for the full mutation-confirm and route-confirm paths through `ActionsPopover`

**Why?**

The original `ActionConfig` shape — `{ display, component, disabled? }` — treated "open a form component" as the only action type. Adding mutation dispatch or route navigation would have required bolting on separate fields outside the existing structure, with no way to express a confirm gate in front of them.

The orthogonal union makes the two concerns explicit: `action` is what happens (mutate, navigate), `modal` is whether and how it's confirmed (confirm dialog, custom form). A `custom` modal owns its own submit flow and cannot pair with `action`; this constraint is encoded in the type rather than enforced by convention.

`isOpen` was a phantom prop: `ActionComponentProps` declared it, but the dispatchers always passed `true` since components only mount when active. Removing it simplifies the interface for component authors and eliminates a class of defensive `isOpen ?` checks in test stubs.

**How did you test it?**

I ran `yarn test:core -- components/actions` and all tests passed. The two new integration tests cover the full mutation-confirm path (click trigger → click menu item → confirm dialog appears → click confirm → mutation fires → dialog auto-closes) and the route-confirm path (click trigger → click menu item → confirm dialog → click confirm → `ShowLocation` reflects new pathname). Both paths exercise `ActionDispatcher`, the sub-dispatchers, and `ConfirmDialog`'s auto-dismiss behavior.

I ran `yarn test:core -- config/entities` and all pipeline/trigger form tests passed with the updated `ActionComponentProps` interface — the `FormWrapper` test harness now mirrors the dispatcher's mount-when-visible lifecycle instead of managing `isOpen` state.

I ran `yarn typecheck` and it completed without errors.

**Potential risks**

`ActionComponentProps` is a breaking change for any consumer that passes `isOpen` to a custom action component. Within this repo all callers have been updated. Downstream consumers wrapping `CoreApp` with custom action components will need to remove the `isOpen` prop from their component signatures.

**Release notes**

Breaking: `ActionComponentProps` no longer includes `isOpen`. Action components that previously used `isOpen` to conditionally render should be updated to render unconditionally, as components are only mounted while the action is active.

**Documentation Changes**

None.