### PR TITLE
docs: add Why Michelangelo value proposition section to Welcome page

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -10,7 +10,7 @@ Michelangelo is an end-to-end ML platform for building, deploying, and managing 
 
 ## Why Michelangelo
 
-Most ML teams spend more engineering time on infrastructure than on models. Training pipelines break in production. Feature logic gets duplicated across teams. Serving containers are hand-rolled for each project. Stitching together PyTorch, MLflow, Airflow, and a custom serving layer works until it doesn't — and when it breaks, it's your problem to fix.
+Most ML teams spend more engineering time on infrastructure than on models. Training pipelines break in production. Feature logic gets duplicated across teams. Serving containers are hand-rolled for each project. Stitching together a training framework, an experiment tracker, an orchestrator, and a custom serving layer works until it doesn't — and when it breaks, it's your problem to fix.
 
 Michelangelo exists so you don't have to build that stack from scratch. It covers the full ML lifecycle — data preparation, training, evaluation, deployment, and monitoring — in a single system that has been running in production at Uber's scale for eight years. Not a proof of concept. Not a framework you assemble yourself. A complete platform, battle-tested across thousands of models, now available for any team to adopt.
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -12,7 +12,7 @@ Michelangelo is an end-to-end ML platform for building, deploying, and managing 
 
 Most ML teams spend more engineering time on infrastructure than on models. Training pipelines break in production. Feature logic gets duplicated across teams. Serving containers are hand-rolled for each project. Stitching together a training framework, an experiment tracker, an orchestrator, and a custom serving layer works until it doesn't — and when it breaks, it's your problem to fix.
 
-Michelangelo exists so you don't have to build that stack from scratch. It covers the full ML lifecycle — data preparation, training, evaluation, deployment, and monitoring — in a single system that has been running in production at Uber's scale for eight years. Not a proof of concept. Not a framework you assemble yourself. A complete platform, battle-tested across thousands of models, now available for any team to adopt.
+Michelangelo exists so you don't have to build that stack from scratch. It covers the full ML lifecycle — data preparation, training, evaluation, deployment, and monitoring — in a single system that has been running in production at Uber's scale for eight years. A complete platform, battle-tested across thousands of models, now available for any team to adopt.
 
 **Michelangelo is worth considering if:**
 - Your ML team is spending more time on infrastructure than on models

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -8,6 +8,21 @@ title: Welcome
 
 Michelangelo is an end-to-end ML platform for building, deploying, and managing machine learning models. Born at Uber — where it powers **25,000+ model trainings per month** and **~30 million predictions per second** — now open source.
 
+## Why Michelangelo
+
+Most ML teams spend more engineering time on infrastructure than on models. Training pipelines break in production. Feature logic gets duplicated across teams. Serving containers are hand-rolled for each project. Stitching together PyTorch, MLflow, Airflow, and a custom serving layer works until it doesn't — and when it breaks, it's your problem to fix.
+
+Michelangelo exists so you don't have to build that stack from scratch. It covers the full ML lifecycle — data preparation, training, evaluation, deployment, and monitoring — in a single system that has been running in production at Uber's scale for eight years. Not a proof of concept. Not a framework you assemble yourself. A complete platform, battle-tested across thousands of models, now available for any team to adopt.
+
+**Michelangelo is worth considering if:**
+- Your ML team is spending more time on infrastructure than on models
+- You're managing a patchwork of tools with brittle integrations between them
+- You want a platform that handles classic ML, deep learning, and generative AI workflows without switching systems
+- You're building or inheriting an ML platform and want a proven foundation rather than starting from scratch
+- You want to contribute to — or build on — an open-source ML platform with real production history behind it
+
+The platform is modular: adopt the full stack or integrate individual components (feature store, model registry, serving) into your existing infrastructure. It's designed to be extended, not to lock you in.
+
 ## Get started
 
 ### I'm evaluating Michelangelo


### PR DESCRIPTION
## Summary
Intent:
- Give site visitors — engineers evaluating, adopting, or considering contributing to Michelangelo — a clear, problem-first answer to "why should I care about this platform" before they dive into the how

Changes:
- Added a "Why Michelangelo" section to docs/intro.md, above the Get started navigation, framing the platform as a solution to the ML infrastructure fragmentation problem
- Section leads with the pain (bespoke pipelines, brittle tool integrations, infrastructure stealing time from model work), presents the platform's scale proof, and closes with a bulleted list of signals that Michelangelo is a good fit — including adopters, platform builders, and contributors

## Test Plan
Markdown-only change. Verified frontmatter, heading hierarchy, and link integrity.

## Revert Plan
Revert this PR via `git revert <commit_sha>`.

## Issues

