### PR TITLE
docs: add RFC process to contributing guide and architecture section

### DIFF
--- a/docs/architecture/_category_.json
+++ b/docs/architecture/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Architecture",
+  "position": 5,
+  "link": {
+    "type": "doc",
+    "id": "architecture/index"
+  }
+}

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -1,0 +1,17 @@
+---
+sidebar_position: 1
+---
+
+# Architecture
+
+This section documents the architectural decisions behind Michelangelo — how the platform is designed, why key choices were made, and where the design is heading.
+
+## RFCs
+
+Significant changes to Michelangelo go through a public Request for Comments (RFC) process before implementation. RFCs cover architecture proposals that affect public APIs, CRDs, operator contracts, or core platform behavior — anything where community visibility and design discussion adds value before code is written.
+
+→ **[Browse RFCs](./rfcs/index.md)**
+
+## Contributing an RFC
+
+If you are proposing a large feature or architectural change, start with an RFC rather than a pull request. See the [Contributing guide](../contributing/index.md#architectural-proposals-rfcs) for when an RFC is required and how to submit one.

--- a/docs/architecture/rfcs/_category_.json
+++ b/docs/architecture/rfcs/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "RFCs",
+  "position": 1,
+  "link": {
+    "type": "doc",
+    "id": "architecture/rfcs/index"
+  }
+}

--- a/docs/architecture/rfcs/index.md
+++ b/docs/architecture/rfcs/index.md
@@ -1,0 +1,41 @@
+---
+sidebar_position: 1
+sidebar_label: "RFCs"
+---
+
+# Michelangelo RFCs
+
+Requests for Comments (RFCs) are the primary venue for community-visible design discussions. An RFC documents the problem, the proposed architecture, alternatives considered, and open questions — before implementation begins.
+
+RFCs are maintained in the **[michelangelo-ai/enhancements](https://github.com/michelangelo-ai/enhancements)** repository on GitHub.
+
+## RFC lifecycle
+
+```
+Idea → Draft PR → Community Review → Accepted / Withdrawn → Implementation
+```
+
+| Stage | What it means |
+|---|---|
+| **Draft** | RFC PR is open; design is in progress |
+| **In Review** | RFC is complete and under active community review |
+| **Accepted** | PR is merged; implementation PRs link back to the RFC |
+| **Withdrawn** | PR is closed with a summary of why |
+
+## Current RFCs
+
+| RFC | Title | Status | Created |
+|-----|-------|--------|---------|
+| [20260427](https://github.com/michelangelo-ai/enhancements/blob/main/rfcs/20260427-michelangelo-helmchart/20260427-michelangelo-helmchart.md) | Michelangelo Control Plane Helm Chart | Accepted | 2026-04-27 |
+
+## Writing an RFC
+
+1. Copy the [RFC template](https://github.com/michelangelo-ai/enhancements/blob/main/rfcs/20260101-template.md) to `rfcs/YYYYMMDD-<short-name>.md` in the enhancements repo
+2. Fill in each section — problem statement, motivation, goals, architecture, APIs, alternatives, open questions, and rollout strategy
+3. Open a draft PR in [michelangelo-ai/enhancements](https://github.com/michelangelo-ai/enhancements)
+4. Use GitHub PR comments for architecture discussion; link the PR in GitHub Discussions for broader input
+5. Once accepted, link implementation PRs back to the RFC
+
+Keep RFCs focused on architecture. Full implementation details and large code blocks belong in the implementation PRs.
+
+For early-stage ideas that aren't ready for a formal RFC, open a [GitHub Issue](https://github.com/michelangelo-ai/michelangelo/issues) first to validate the direction.

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -13,7 +13,7 @@ Michelangelo welcomes contributions from the community. This guide is your entry
 | UI improvements | New pages, component library additions |
 | Testing | Integration tests, test coverage gaps |
 
-For small fixes (typos, obvious bugs), open a PR directly. For new features or significant changes, open a GitHub issue first to discuss the approach before writing code.
+For small fixes (typos, obvious bugs), open a PR directly. For new features or significant changes, open a GitHub issue first to discuss the approach before writing code. For large architectural changes, see [Architectural proposals (RFCs)](#architectural-proposals-rfcs) below.
 
 ## Component Map
 
@@ -112,3 +112,20 @@ For adding or improving guides, references, or examples.
 
 - **GitHub Issues** — for bug reports and feature requests
 - **GitHub Discussions** — for questions about the codebase, design discussions, and community Q&A
+
+## Architectural proposals (RFCs)
+
+Large features or changes that affect public APIs, CRDs, operator contracts, or core platform behavior go through a public RFC process before implementation. An RFC documents the problem, proposed architecture, alternatives considered, and open questions — giving the community visibility and the chance to weigh in before code is written.
+
+**When to write an RFC instead of opening an issue:**
+- Your change affects a public API, CRD, or operator contract
+- Your change requires coordinating across multiple components
+- You want community input on the design before investing in implementation
+- You're an external contributor proposing a significant new capability
+
+**How to submit an RFC:**
+1. Copy the [RFC template](https://github.com/michelangelo-ai/enhancements/blob/main/rfcs/20260101-template.md) to `rfcs/YYYYMMDD-<short-name>.md` in the [michelangelo-ai/enhancements](https://github.com/michelangelo-ai/enhancements) repo
+2. Open a draft PR there and use GitHub PR comments for design discussion
+3. Once accepted, link your implementation PRs back to the RFC
+
+→ **[Browse existing RFCs](../architecture/rfcs/index.md)**


### PR DESCRIPTION
## Summary
Intent:
- Surface the RFC process for contributors who have large architectural proposals — currently CONTRIBUTING.md points only to GitHub Issues, leaving no clear path for significant changes
- Establish a docs/architecture/ section that indexes existing RFCs and explains the process, following the suggested repo structure

Changes:
- Added "Architectural proposals (RFCs)" section to docs/contributing/index.md with when-to-RFC guidance, a 3-step submission flow, and a link to the architecture section
- Created docs/architecture/index.md as the landing page for the new Architecture section
- Created docs/architecture/rfcs/index.md with the RFC lifecycle table, current RFC index (Helm Chart RFC, Accepted), and writing guidance linking to the enhancements repo and template
- Added _category_.json files for both new sidebar sections

## Test Plan
Markdown-only change. Verified all cross-links between contributing guide and architecture section are consistent. External links point to the correct enhancements repo paths.

## Revert Plan
Revert this PR via `git revert <commit_sha>`.

## Issues

