### PR TITLE
fix: remove unnecessary PyFileSystem wrapping in RayDatasetIO

### DIFF
--- a/python/michelangelo/uniflow/plugins/ray/io.py
+++ b/python/michelangelo/uniflow/plugins/ray/io.py
@@ -6,8 +6,8 @@ for the PyArrow nested-data bug (https://github.com/ray-project/ray/issues/61675
 
 Filesystem backend is selected via ``UF_PLUGIN_RAY_USE_FSSPEC``:
 
-- ``"1"`` — fsspec (flexible: local, S3, GCS, etc.), wrapped via
-  ``pyarrow.fs.PyFileSystem`` for Ray compatibility.
+- ``"1"`` — fsspec (flexible: local, S3, GCS, etc.). PyArrow accepts fsspec
+  filesystems directly and wraps them transparently via ``FSSpecHandler``.
 - ``"0"`` (default) — native PyArrow filesystem (S3 with MinIO credential support)
 """
 
@@ -20,7 +20,6 @@ from typing import Any
 
 import fsspec.core
 import ray
-from pyarrow.fs import FSSpecHandler, PyFileSystem
 from ray.data import Dataset, ReadTask
 from ray.data.block import BlockMetadata
 
@@ -249,13 +248,10 @@ class RayDatasetIO(IO[Dataset]):
             int(os.environ.get(UF_PLUGIN_RAY_FILTER_WORKERS, _FILTER_WORKERS_DEFAULT)),
             len(candidates),
         )
-        # Wrap fsspec FS so pq.read_metadata receives a pyarrow.fs.FileSystem.
-        pyarrow_fs = PyFileSystem(FSSpecHandler(fsspec_fs))
         with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
             has_data = list(
-                pool.map(lambda f: _has_row_groups(f, pyarrow_fs), candidates)
+                pool.map(lambda f: _has_row_groups(f, fsspec_fs), candidates)
             )
-
         non_empty = [f for f, ok in zip(candidates, has_data) if ok]
         _logger.info(
             "Row-group check: %d have data, %d empty.",
@@ -271,15 +267,14 @@ class RayDatasetIO(IO[Dataset]):
 
 
 def _fs_path(url: str) -> tuple[Any, str]:
-    """Return a (PyArrow filesystem, path) tuple for *url*.
+    """Return a (filesystem, path) tuple for *url*.
 
-    When ``UF_PLUGIN_RAY_USE_FSSPEC=1``, the fsspec filesystem is wrapped via
-    ``pyarrow.fs.PyFileSystem`` so it is compatible with Ray's ``filesystem=``
-    parameter, which requires a ``pyarrow.fs.FileSystem``.
+    When ``UF_PLUGIN_RAY_USE_FSSPEC=1``, returns an fsspec filesystem. PyArrow
+    accepts fsspec filesystems directly and wraps them transparently at the C++
+    layer via ``FSSpecHandler`` — no manual wrapping required.
     """
     if os.environ.get(UF_PLUGIN_RAY_USE_FSSPEC, "0") == "1":
-        fsspec_fs, path = fsspec.core.url_to_fs(url)
-        return PyFileSystem(FSSpecHandler(fsspec_fs)), path
+        return fsspec.core.url_to_fs(url)
     return resolve_fs(url.split("://")[0]), url
 
 

--- a/python/michelangelo/uniflow/plugins/ray/tests/ray_io_test.py
+++ b/python/michelangelo/uniflow/plugins/ray/tests/ray_io_test.py
@@ -326,9 +326,7 @@ class TestFsPathAndResolveFs(TestCase):
     """Tests for _fs_path() env-var switching and resolve_fs() S3 branch."""
 
     def test_fs_path_uses_fsspec_when_env_set(self):
-        """_fs_path() returns a PyFileSystem when UF_PLUGIN_RAY_USE_FSSPEC=1."""
-        from pyarrow.fs import PyFileSystem
-
+        """_fs_path() returns the raw fsspec FS when UF_PLUGIN_RAY_USE_FSSPEC=1."""
         from michelangelo.uniflow.plugins.ray.io import (
             UF_PLUGIN_RAY_USE_FSSPEC,
             _fs_path,
@@ -341,7 +339,7 @@ class TestFsPathAndResolveFs(TestCase):
         ):
             fs, path = _fs_path("s3://bucket/d")
         mock_url.assert_called_once_with("s3://bucket/d")
-        self.assertIsInstance(fs, PyFileSystem)
+        self.assertIs(fs, mock_fs)
         self.assertEqual(path, "/d")
 
     def test_fs_path_uses_pyarrow_by_default(self):


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
- `ray/io.py`: removed manual `PyFileSystem(FSSpecHandler(...))` wrapping in `_fs_path` and `filter_empty_data` — fsspec filesystems are now passed directly to PyArrow/Ray
- `ray_io_test.py`: updated `test_fs_path_uses_fsspec_when_env_set` to assert the raw fsspec FS is returned instead of a `PyFileSystem` instance

<!-- Tell your future self why have you made these changes -->
**Why?**
An earlier revision wrapped fsspec filesystems with `PyFileSystem(FSSpecHandler(...))` before passing to Ray, assuming it required a strict `pyarrow.fs.FileSystem`. Investigation confirmed this is unnecessary: PyArrow transparently wraps fsspec filesystems at the C++ layer when passed to any PyArrow function. Ray's own documentation demonstrates this with `HfFileSystem` (an `fsspec.AbstractFileSystem` subclass) passed directly to `ray.data.read_parquet`. Uber internal code (e.g. CHEAT) does the same.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Updated test asserts the raw fsspec FS is returned from `_fs_path` when `UF_PLUGIN_RAY_USE_FSSPEC=1`
- Confirmed via PyArrow docs and Ray docs that fsspec auto-wrapping is the expected behaviour

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
None — removing a redundant wrap that PyArrow was already doing internally.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
N/A

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
Updated `_fs_path` docstring to explain PyArrow's transparent fsspec wrapping behaviour.