### PR TITLE
fix(helm): remove .helmignore that blocks subchart loading

### DIFF
--- a/helm/michelangelo/.helmignore
+++ b/helm/michelangelo/.helmignore
@@ -1,2 +1,0 @@
-# Exclude downloaded dependency tarballs from packaged chart
-charts/*.tgz


### PR DESCRIPTION
## Summary

`.helmignore` with `charts/*.tgz` prevents Helm from loading subchart tarballs during local installs — `ma sandbox create` fails at "Waiting for Cadence frontend to be ready" because the Cadence subchart never renders. This is because `.helmignore` applies to all Helm operations, not just `helm package` ([helm-www#1171](https://github.com/helm/helm-www/issues/1171)).

## Test plan

I ran `ma sandbox create --exclude grafana` on main, which fails: zero Cadence pods, hangs at frontend wait.
<img width="976" height="1196" alt="Screenshot 2026-05-28 at 11 01 11" src="https://github.com/user-attachments/assets/225d100e-3e5c-48c3-8a4c-5130bf9366f3" />

After this change: sandbox completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)