### PR TITLE
docs: add missing libomp macOS prerequisite to getting-started guide

### DIFF
--- a/docs/user-guides/getting-started/getting-started.md
+++ b/docs/user-guides/getting-started/getting-started.md
@@ -28,6 +28,7 @@ Each step runs as an isolated, containerized task. Michelangelo AI handles data 
 * Java 17 with `JAVA_HOME` set — required for the Spark preprocessing step. Java 21 is not compatible with PySpark 3.5 + Hadoop 3.3 (`getSubject is not supported` error). On macOS: `brew install openjdk@17` then `export JAVA_HOME=$(brew --prefix openjdk@17)/libexec/openjdk.jdk/Contents/Home`
 * For remote runs: Docker and access to a Kubernetes cluster (or use the [local sandbox](../../getting-started/sandbox-setup.md))
 * [Create a project](./project-management-for-ml-pipelines.md)
+* **macOS only**: XGBoost requires OpenMP (`libomp.dylib`), which is not installed by default. Run `brew install libomp` before installing dependencies.
 
 ## Environment setup
 


### PR DESCRIPTION
## Summary
Intent:
- Fix a missing prerequisite that causes XGBoost to fail silently on macOS
- Surface the fix (`brew install libomp`) directly in the docs so users don't have to debug it themselves

Changes:
- Added a macOS-scoped bullet to the Prerequisites section noting that XGBoost requires OpenMP (`libomp.dylib`) and that `brew install libomp` resolves it

## Test Plan
Verified the bullet renders correctly in the local Docusaurus preview.

## Revert Plan
Revert this PR via `git revert 82e4ffdd`.

---

<sub>Generated by the 🪄 pr-create skill</sub>

## Issues

