### PR TITLE
fix: resolve WORKSPACE_ROOT to worktree path in gen-grpc-client.sh

### DIFF
--- a/.github/workflows/ui-pre-land.yaml
+++ b/.github/workflows/ui-pre-land.yaml
@@ -37,8 +37,6 @@ jobs:
 
       - name: Install dependencies
         run: yarn setup
-        env:
-          WORKSPACE_ROOT: ${{ github.workspace }}
 
       - name: Build Core package for type resolution
         run: yarn workspace @michelangelo-ai/core build
@@ -70,8 +68,6 @@ jobs:
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-        env:
-          WORKSPACE_ROOT: ${{ github.workspace }}
 
       - name: Check formatting
         run: yarn format
@@ -102,8 +98,6 @@ jobs:
 
       - name: Install dependencies
         run: yarn setup
-        env:
-          WORKSPACE_ROOT: ${{ github.workspace }}
 
       - name: Run unit tests
         run: yarn test

--- a/.github/workflows/ui-release.yml
+++ b/.github/workflows/ui-release.yml
@@ -94,8 +94,6 @@ jobs:
           cd javascript
           yarn setup
           yarn workspace @michelangelo/app build
-        env:
-          WORKSPACE_ROOT: ${{ github.workspace }}
 
       - name: Build & Push UI Image
         uses: docker/build-push-action@v6

--- a/tools/gen-grpc-client.sh
+++ b/tools/gen-grpc-client.sh
@@ -3,7 +3,7 @@
 set -e
 set -x
 
-WORKSPACE_ROOT="${WORKSPACE_ROOT:-$(git rev-parse --show-toplevel)}"
+WORKSPACE_ROOT="$(git rev-parse --show-toplevel)"
 
 # Function to move generated files for any client
 move_generated_files() {


### PR DESCRIPTION
## Summary

- `gen-grpc-client.sh` set `WORKSPACE_ROOT` with a `:-` fallback, so any pre-set env var wins
- Both repo roots have an `.envrc` that exports `WORKSPACE_ROOT=$(pwd)` via direnv. If your shell (or Claude Code session) was last in the main repo, that value persists — the `:-` fallback never fires and gen files get written to the main repo's `packages/rpc/gen` instead of the worktree's
- The fix is to drop the env var check entirely: `git rev-parse --show-toplevel` always returns the root of whichever working tree the CWD belongs to. Since all callers (`yarn generate`, `yarn setup`) run from `javascript/`, git computes the right answer without needing the environment
- The `WORKSPACE_ROOT: ${{ github.workspace }}` env blocks in the workflows were passing the same value git would have computed — they are removed as part of this cleanup

## Test plan

I ran `bash -x tools/gen-grpc-client.sh --clients javascript` from within a worktree whose shell had a stale `WORKSPACE_ROOT` pointing at the main repo and confirmed gen files now land in the worktree's `javascript/packages/rpc/gen`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)