### PR TITLE
design: adopt UberMove fonts, remove bg animation, tighten navbar

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -170,14 +170,16 @@
 }
 
 .navbar__title {
-  font-weight: 600;
+  font-family: var(--ifm-heading-font-family);
+  font-weight: 500;
   color: #ffffff;
 }
 
 .navbar__link {
+  font-family: var(--ifm-heading-font-family);
   font-weight: 500;
   border-radius: 9999px;
-  padding: 0.5rem 1rem;
+  padding: 0.25rem 0.75rem;
   transition: background-color 0.15s ease, color 0.15s ease;
   color: #ffffff;
 }

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -4,6 +4,82 @@
  */
 
 /* ============================================
+   Brand Fonts (UberMove / UberMoveText)
+   ============================================ */
+
+@font-face {
+  font-family: 'UberMove';
+  font-weight: 300;
+  font-style: normal;
+  font-display: swap;
+  src: url('https://tb-static.uber.com/prod/uber-static/UberMove-Light.woff2') format('woff2'),
+    url('https://tb-static.uber.com/prod/uber-static/UberMove-Light.woff') format('woff');
+}
+
+@font-face {
+  font-family: 'UberMove';
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+  src: url('https://tb-static.uber.com/prod/uber-static/UberMove-Regular.woff2') format('woff2'),
+    url('https://tb-static.uber.com/prod/uber-static/UberMove-Regular.woff') format('woff');
+}
+
+@font-face {
+  font-family: 'UberMove';
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+  src: url('https://tb-static.uber.com/prod/uber-static/UberMove-Medium.woff2') format('woff2'),
+    url('https://tb-static.uber.com/prod/uber-static/UberMove-Medium.woff') format('woff');
+}
+
+@font-face {
+  font-family: 'UberMove';
+  font-weight: 700;
+  font-style: normal;
+  font-display: swap;
+  src: url('https://tb-static.uber.com/prod/uber-static/UberMove-Bold.woff2') format('woff2'),
+    url('https://tb-static.uber.com/prod/uber-static/UberMove-Bold.woff') format('woff');
+}
+
+@font-face {
+  font-family: 'UberMoveText';
+  font-weight: 300;
+  font-style: normal;
+  font-display: swap;
+  src: url('https://tb-static.uber.com/prod/uber-static/UberMoveText-Light.woff2') format('woff2'),
+    url('https://tb-static.uber.com/prod/uber-static/UberMoveText-Light.woff') format('woff');
+}
+
+@font-face {
+  font-family: 'UberMoveText';
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+  src: url('https://tb-static.uber.com/prod/uber-static/UberMoveText-Regular.woff2') format('woff2'),
+    url('https://tb-static.uber.com/prod/uber-static/UberMoveText-Regular.woff') format('woff');
+}
+
+@font-face {
+  font-family: 'UberMoveText';
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+  src: url('https://tb-static.uber.com/prod/uber-static/UberMoveText-Medium.woff2') format('woff2'),
+    url('https://tb-static.uber.com/prod/uber-static/UberMoveText-Medium.woff') format('woff');
+}
+
+@font-face {
+  font-family: 'UberMoveText';
+  font-weight: 700;
+  font-style: normal;
+  font-display: swap;
+  src: url('https://tb-static.uber.com/prod/uber-static/UberMoveText-Bold.woff2') format('woff2'),
+    url('https://tb-static.uber.com/prod/uber-static/UberMoveText-Bold.woff') format('woff');
+}
+
+/* ============================================
    CSS Variables & Theme
    ============================================ */
 
@@ -22,8 +98,10 @@
   --ifm-font-color-base: #000000;
 
   /* Typography */
-  --ifm-font-family-base: system-ui, -apple-system, 'Segoe UI', Roboto,
-    'Helvetica Neue', Arial, sans-serif;
+  --ifm-font-family-base: 'UberMoveText', system-ui, -apple-system, 'Segoe UI',
+    Roboto, 'Helvetica Neue', Arial, sans-serif;
+  --ifm-heading-font-family: 'UberMove', 'UberMoveText', system-ui, -apple-system,
+    'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
   --ifm-font-family-monospace: 'SF Mono', SFMono-Regular, ui-monospace, Menlo,
     Monaco, Consolas, 'Liberation Mono', monospace;
   --ifm-heading-font-weight: 600;

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -83,6 +83,12 @@
    CSS Variables & Theme
    ============================================ */
 
+html,
+body {
+  -webkit-font-smoothing: auto;
+  -moz-osx-font-smoothing: auto;
+}
+
 :root {
   /* Uber brand colors */
   --ifm-color-primary: #276ef1;
@@ -171,7 +177,8 @@
 
 .navbar__title {
   font-family: var(--ifm-heading-font-family);
-  font-weight: 500;
+  font-size: 1.5rem;
+  font-weight: 400;
   color: #ffffff;
 }
 

--- a/website/src/css/landing.module.css
+++ b/website/src/css/landing.module.css
@@ -79,7 +79,6 @@
 /* Hero Section */
 .hero {
   position: relative;
-  overflow: hidden;
   min-height: calc(100vh - 60px);
   display: flex;
   align-items: center;
@@ -88,63 +87,10 @@
   background-color: var(--landing-hero-bg);
 }
 
-.hero::before,
-.hero::after {
-  content: '';
-  position: absolute;
-  inset: -100%;
-  background-color: var(--landing-hero-bg);
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 120 40'%3E%3Cpath d='M0,20 Q30,0 60,20 T120,20' fill='none' stroke='%239c9c9c' stroke-width='3'/%3E%3C/svg%3E");
-  background-size: 120px 40px;
-  background-repeat: repeat;
-  pointer-events: none;
-  z-index: 0;
-}
-
-:global([data-theme='dark']) .hero::before,
-:global([data-theme='dark']) .hero::after {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 120 40'%3E%3Cpath d='M0,20 Q30,0 60,20 T120,20' fill='none' stroke='%23828282' stroke-width='3'/%3E%3C/svg%3E");
-}
-
-.hero::after {
-  animation: moireRotate 300s linear infinite;
-  mix-blend-mode: screen;
-}
-
-:global([data-theme='dark']) .hero::after {
-  mix-blend-mode: multiply;
-}
-
-@keyframes moireRotate {
-  from { transform: rotate(20deg); }
-  to { transform: rotate(380deg); }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .hero::after {
-    animation: none;
-    transform: rotate(20deg);
-  }
-}
-
 .heroContent {
   position: relative;
-  z-index: 1;
   max-width: 900px;
   text-align: center;
-}
-
-.heroContent::before {
-  content: '';
-  position: absolute;
-  inset: -8% -10%;
-  background: radial-gradient(ellipse at center, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 0) 70%);
-  z-index: -1;
-  pointer-events: none;
-}
-
-:global([data-theme='dark']) .heroContent::before {
-  background: radial-gradient(ellipse at center, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 0) 70%);
 }
 
 .heroLogo {


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

- Added `@font-face` declarations for UberMove and UberMoveText (Light/Regular/Medium/Bold) hotlinked to `tb-static.uber.com`.
- Set `--ifm-font-family-base` to UberMoveText and added `--ifm-heading-font-family` using UberMove so headings inherit the display face via Infima.
- Restyled the navbar to use UberMove and tightened link padding so the bar reads as the same family as headings and links sit closer to the wordmark. Hover pill behavior is preserved.
- Removed the animated background from the landing hero, along with the radial gradient mask, overflow clipping, and reduced-motion override that only existed to support it.

**Why?**

Bring the docs site closer to Uber's brand presentation (typography + navbar feel align with [uber.com/blog](https://www.uber.com/us/en/blog/)) and simplify the hero to a clean white/black aesthetic.

**How did you test it?**

- `bun run typecheck` and `bun run build` both green.
- Verified visually in the dev server: UberMove rendering on the headline, typing animation still cycling, navbar tighter and in the display font, hero background clean.

**Potential risks**

Fonts are loaded from `tb-static.uber.com`. If those URLs ever change or the CDN goes down, the site falls back to the `system-ui` stack via the `@font-face` `src` chain and `font-family` fallbacks — no broken layout.

**Release notes**

N/A

**Documentation Changes**

N/A — styling only, no doc content changes.

---

New
<img width="1162" height="840" alt="image" src="https://github.com/user-attachments/assets/92cf9beb-6e5f-46e8-b167-b5d7cb8025d4" />

Old
<img width="1161" height="836" alt="image" src="https://github.com/user-attachments/assets/2a5962af-626f-4e24-ac29-2774712633c9" />
