### PR TITLE
ci: replace QEMU cross-arch build with native runners

### DIFF
--- a/.github/workflows/build-examples-image.yaml
+++ b/.github/workflows/build-examples-image.yaml
@@ -3,6 +3,11 @@ name: Build examples Docker image
 # Rebuild and push the examples image whenever its inputs change.
 # The image is pushed to GHCR and consumed by the integration-test-sandbox
 # workflow so the integration tests never build from scratch.
+#
+# Multi-arch strategy: each platform is built on its native runner (no QEMU),
+# pushed by digest, then merged into a single multi-arch manifest.  This
+# eliminates the QEMU-induced apt-get failures seen with the previous single-
+# runner + emulation approach.
 on:
   push:
     branches: [main]
@@ -22,15 +27,90 @@ env:
   IMAGE_NAME: ${{ github.repository_owner }}/examples
 
 jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
+  build:
+    name: Build (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
-      packages: write   # needed to push to GHCR
+      packages: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+
+      - name: Prepare platform slug
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_SLUG=${platform//\//-}" >> "$GITHUB_ENV"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: ./python
+          file: ./python/examples/Dockerfile
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Scope the GHA cache per platform so amd64 and arm64 layers do not
+          # overwrite each other.
+          cache-from: type=gha,scope=${{ env.PLATFORM_SLUG }}
+          cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_SLUG }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_SLUG }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge multi-arch manifest
+    runs-on: ubuntu-latest
+    needs: [build]
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Download all digest artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -52,16 +132,14 @@ jobs:
             type=ref,event=branch
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
-      # Build with GitHub Actions layer cache so repeated builds reuse cached
-      # layers (Python compilation, Spark download, pip installs).
-      - name: Build and push
-        uses: docker/build-push-action@v5
-        with:
-          context: ./python
-          file: ./python/examples/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Create and push multi-arch manifest
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect final image
+        run: |
+          docker buildx imagetools inspect \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/python/examples/Dockerfile
+++ b/python/examples/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 ###############################################################################
 # $ cd $REPO_ROOT/python
 # $ docker build -t <IMAGE_NAME> -f ./examples/bert_cola/Dockerfile .
@@ -6,10 +7,13 @@
 # Use a base image with Python installed
 FROM nvidia/cuda:12.8.0-base-ubuntu22.04
 
-# Install all system dependencies in a single layer to minimise image size and
-# avoid running apt-get update more than once (extra runs are a common source
-# of flakiness in emulated/QEMU builds).
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Install all system dependencies in a single layer.
+# --mount=type=cache persists the apt cache across builds so packages are not
+# re-downloaded on every run. sharing=locked prevents cache corruption when
+# two platform builds run concurrently on the same runner.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends \
     curl \
     software-properties-common \
     vim \
@@ -22,8 +26,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libffi-dev \
     liblzma-dev \
     zlib1g-dev \
-    openjdk-11-jdk \
-    && rm -rf /var/lib/apt/lists/*
+    openjdk-11-jdk
 
 # Set Python version
 ENV PYTHON_VERSION=3.9.18

--- a/python/examples/Dockerfile
+++ b/python/examples/Dockerfile
@@ -6,8 +6,10 @@
 # Use a base image with Python installed
 FROM nvidia/cuda:12.8.0-base-ubuntu22.04
 
-# Install dependencies required for building Python
-RUN apt-get update && apt-get install -y \
+# Install all system dependencies in a single layer to minimise image size and
+# avoid running apt-get update more than once (extra runs are a common source
+# of flakiness in emulated/QEMU builds).
+RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     software-properties-common \
     vim \
@@ -20,6 +22,7 @@ RUN apt-get update && apt-get install -y \
     libffi-dev \
     liblzma-dev \
     zlib1g-dev \
+    openjdk-11-jdk \
     && rm -rf /var/lib/apt/lists/*
 
 # Set Python version
@@ -77,8 +80,6 @@ RUN mkdir -p ${SPARK_HOME}/conf && \
 ###
 ### Install Java
 ###
-# Install OpenJDK 11 (multi-arch compatible and open-source)
-RUN apt-get update && apt-get install -y openjdk-11-jdk
 
 # Detect JAVA_HOME at build time so the image works on both arm64 and amd64.
 RUN JAVA_HOME=$(dirname $(dirname $(readlink -f $(which java)))) && \


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
- `build-examples-image.yaml`: replaced the single-runner QEMU-emulated multi-arch build with a matrix of two native runners (`ubuntu-latest` for `linux/amd64`, `ubuntu-24.04-arm` for `linux/arm64`). Each platform builds independently, pushes by digest, and a follow-up `merge` job assembles the final multi-arch manifest via `docker buildx imagetools create`. GHA layer cache is scoped per platform.
- `python/examples/Dockerfile`: added `# syntax=docker/dockerfile:1` and switched to `--mount=type=cache,target=/var/cache/apt,sharing=locked` + `--mount=type=cache,target=/var/lib/apt,sharing=locked` on the apt install step. Also merged the two previously separate `apt-get update && apt-get install` `RUN` statements into one (including `openjdk-11-jdk`) and added `--no-install-recommends`.

<!-- Tell your future self why have you made these changes -->
**Why?**
The `Build examples Docker image` CI job intermittently failed with `exit code: 100` from `apt-get update && apt-get install -y openjdk-11-jdk` running inside QEMU's cross-arch emulator. QEMU network syscall emulation is unreliable and causes `apt-get` to fail sporadically with no code change. The apt BuildKit cache mount further reduces network dependency on subsequent builds by reusing previously downloaded packages. Tracked in issue #1269.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Verified the Dockerfile still builds correctly locally for `linux/amd64` (`docker build -f python/examples/Dockerfile python/`).
- Confirmed `ubuntu-24.04-arm` is a supported GitHub-hosted runner for public repos (native arm64, no QEMU).
- The digest-merge pattern follows the official Docker multi-platform build documentation.
- `--mount=type=cache` with `sharing=locked` is the standard BuildKit pattern for concurrent-safe apt caching.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- `ubuntu-24.04-arm` runner availability: if GitHub's arm64 runners are unavailable the arm64 build leg will fail, but `fail-fast: false` lets the amd64 leg complete independently. The `merge` job will then fail on a missing digest — acceptable since the amd64 image is still pushed.
- BuildKit cache mounts are not baked into the image layer, so `rm -rf /var/lib/apt/lists/*` is no longer needed; the final image size is unaffected.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
Closes #1269 — CI infrastructure change only, no user-facing or API changes.

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
N/A