### PR TITLE
fix(pre-commit): fix prettier hook and document install step

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,8 +13,7 @@ repos:
         types: [python]
       - id: prettier
         name: prettier formatter
-        entry: bash -c 'cd javascript && yarn prettier --write "${@#javascript/}"' --
+        entry: bash -c 'cd javascript && yarn prettier --write --log-level warn .'
         language: system
-        types_or: [ts, tsx, javascript, jsx, json, css, yaml, markdown]
         files: ^javascript/
-        pass_filenames: true
+        pass_filenames: false

--- a/docs/contributing/building-michelangelo-ai-from-source.md
+++ b/docs/contributing/building-michelangelo-ai-from-source.md
@@ -146,6 +146,9 @@ Python packages and CLI tools are managed with Poetry under the `python/` direct
 ```bash
 cd $REPO_ROOT/python
 poetry install -E dev
+
+# Activate pre-commit hooks (runs prettier and ruff on each commit — do this once after cloning)
+poetry run pre-commit install
 ```
 
 ### Linting and Formatting
@@ -153,13 +156,13 @@ poetry install -E dev
 ```bash
 cd $REPO_ROOT/python
 
-# Pre-commit checks
-poetry run pre-commit
+# Run all pre-commit checks manually
+poetry run pre-commit run --all-files
 
-# Lint
+# Lint a specific file
 poetry run ruff check $FILE
 
-# Format
+# Format a specific file
 poetry run ruff format $FILE
 ```
 
@@ -171,25 +174,6 @@ poetry run ma sandbox create
 ```
 
 For more detail, see the [Sandbox Setup Guide](../getting-started/sandbox-setup.md).
-
-### Check before create commit
-
-```bash
-# under `$REPO_ROOT/python` directory
-$ poetry run pre-commit
-```
-
-### Check in manual
-
-```bash
-# under `$REPO_ROOT/python` directory
-# lint check
-$ poetry run ruff check $PYTHON_FILE_NAME
-
-# Run formatter
-$ poetry run ruff format $PYTHON_FILE_NAME
-```
-
 
 ## IDE Setup
 


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Bug Fix
- [x] Documentation Update

**What changed?**

- Fixes the prettier pre-commit hook to actually work: it now runs `prettier --write` over the whole `javascript/` directory when any JS/TS file is staged, automatically fixing formatting issues in place.
- Adds `poetry run pre-commit install` to the Python setup docs so contributors know to activate hooks after cloning. Consolidates duplicated linting sections.

**Why?**

The repo already had a `.pre-commit-config.yaml` with a prettier hook, but the hook silently no-op'd on every commit — the entry script received repo-root-relative paths that prettier couldn't find after `cd javascript`. Formatting errors only surfaced in CI after pushing.

**How did you test it?**

Staged a badly-formatted TypeScript file and confirmed the hook auto-fixes it and blocks the commit:
```
prettier formatter..........Failed
- files were modified by this hook
```
Re-staging the auto-fixed file and retrying succeeds.

**Potential risks**

None. The hook formats all JS files on each commit (not just staged ones), which is intentional — assumes `main` is always clean, which CI enforces.

**Release notes**

N/A

**Documentation Changes**

`docs/contributing/building-michelangelo-ai-from-source.md` — added `pre-commit install` to setup, consolidated duplicated linting sections.