### PR TITLE
feat(pusher): push() dispatch function + plugin registry

### DIFF
--- a/python/michelangelo/workflow/schema/pusher.py
+++ b/python/michelangelo/workflow/schema/pusher.py
@@ -243,6 +243,19 @@ class PusherPluginConfig:
     (``plugin_name`` + ``plugin_config``) must be set. Setting zero or
     more than one raises ``ConfigurationError``.
 
+    **Two-tier configuration model:**
+
+    - *Built-in plugins* (``model_plugin``, ``dataset_plugin``,
+      ``eval_report_plugin``) use typed dataclass fields for validated,
+      IDE-discoverable configuration.
+    - *Community/third-party plugins* registered via
+      :class:`~michelangelo.workflow.tasks.pusher.registry.PluginRegistry`
+      use the ``plugin_name`` + ``plugin_config`` dict path. This is the
+      **intended extension contract** — not a second-class fallback. The
+      ``plugin_config`` dict is forwarded verbatim to the plugin's
+      constructor, so each community plugin defines its own configuration
+      schema independently.
+
     Attributes:
         name: Artifact identifier matching a key in the ``artifacts``
             dict passed to ``push()``.

--- a/python/michelangelo/workflow/schema/pusher.py
+++ b/python/michelangelo/workflow/schema/pusher.py
@@ -87,6 +87,12 @@ class ModelPluginConfig:
             argument. Use an empty list (the default) to rely on the
             injected ``registry_client`` instead.
 
+            .. warning::
+                This field holds live Python objects and is **not
+                serializable** through the UniFlow codec. ``PusherConfig``
+                must be constructed inside the ``@task`` body — do not pass
+                it as a serialized task argument across the workflow boundary.
+
             Example — register in both MLflow and a custom catalog::
 
                 from michelangelo.lib.model_manager.registry.client import (

--- a/python/michelangelo/workflow/tasks/pusher/__init__.py
+++ b/python/michelangelo/workflow/tasks/pusher/__init__.py
@@ -55,7 +55,6 @@ Public API
     )
 """
 
-# flake8: noqa:F401
 from michelangelo.workflow.schema.pusher import (
     DatasetPluginConfig,
     EvalReportPluginConfig,
@@ -80,3 +79,25 @@ from michelangelo.workflow.tasks.pusher.plugins import (
 from michelangelo.workflow.tasks.pusher.pusher import push
 from michelangelo.workflow.tasks.pusher.registry import PluginRegistry, default_registry
 from michelangelo.workflow.variables.types import PusherResult
+
+__all__ = [
+    "ArtifactNotFoundError",
+    "ConfigurationError",
+    "DatasetPluginConfig",
+    "DatasetPusherPlugin",
+    "EvalReportPluginConfig",
+    "EvalReportPusherPlugin",
+    "ModelPluginConfig",
+    "ModelPushResult",
+    "ModelPusherPlugin",
+    "PartialRegistrationError",
+    "PluginRegistry",
+    "PusherConfig",
+    "PusherError",
+    "PusherPluginConfig",
+    "PusherPluginError",
+    "PusherResult",
+    "RegistrationResult",
+    "default_registry",
+    "push",
+]

--- a/python/michelangelo/workflow/tasks/pusher/__init__.py
+++ b/python/michelangelo/workflow/tasks/pusher/__init__.py
@@ -1,1 +1,82 @@
-"""Pusher module for pushing ML artifacts to storage and registry destinations."""
+"""Michelangelo pusher — push ML artifacts to storage and registry destinations.
+
+Public API
+----------
+
+**Dispatch:**
+
+.. code-block:: python
+
+    from michelangelo.workflow.tasks.pusher import push
+
+**Configuration:**
+
+.. code-block:: python
+
+    from michelangelo.workflow.tasks.pusher import (
+        PusherConfig,
+        PusherPluginConfig,
+        ModelPluginConfig,
+        DatasetPluginConfig,
+        EvalReportPluginConfig,
+    )
+
+**Results:**
+
+.. code-block:: python
+
+    from michelangelo.workflow.tasks.pusher import PusherResult
+
+**Plugins:**
+
+.. code-block:: python
+
+    from michelangelo.workflow.tasks.pusher import (
+        ModelPusherPlugin,
+        DatasetPusherPlugin,
+        EvalReportPusherPlugin,
+    )
+
+**Registry (for plugin extension):**
+
+.. code-block:: python
+
+    from michelangelo.workflow.tasks.pusher import default_registry, PluginRegistry
+
+**Exceptions:**
+
+.. code-block:: python
+
+    from michelangelo.workflow.tasks.pusher import (
+        PusherError,
+        ArtifactNotFoundError,
+        PusherPluginError,
+        ConfigurationError,
+    )
+"""
+
+# flake8: noqa:F401
+from michelangelo.workflow.schema.pusher import (
+    DatasetPluginConfig,
+    EvalReportPluginConfig,
+    ModelPluginConfig,
+    PusherConfig,
+    PusherPluginConfig,
+)
+from michelangelo.workflow.tasks.pusher.exceptions import (
+    ArtifactNotFoundError,
+    ConfigurationError,
+    PusherError,
+    PusherPluginError,
+)
+from michelangelo.workflow.tasks.pusher.plugins import (
+    DatasetPusherPlugin,
+    EvalReportPusherPlugin,
+    ModelPusherPlugin,
+    ModelPushResult,
+    PartialRegistrationError,
+    RegistrationResult,
+)
+from michelangelo.workflow.tasks.pusher.pusher import push
+from michelangelo.workflow.tasks.pusher.registry import PluginRegistry, default_registry
+from michelangelo.workflow.variables.types import PusherResult

--- a/python/michelangelo/workflow/tasks/pusher/plugins/__init__.py
+++ b/python/michelangelo/workflow/tasks/pusher/plugins/__init__.py
@@ -1,8 +1,32 @@
-"""Built-in pusher plugins for the michelangelo workflow task package."""
+"""Built-in pusher plugins for the michelangelo workflow task package.
+
+Importing this module populates ``default_registry`` with the three built-in
+plugins. ``push()`` imports ``pusher.plugins`` before resolving the registry,
+so the registrations are guaranteed to be present on first use.
+"""
 
 # flake8: noqa:F401
+from michelangelo.gen.api.v2.evaluation_report_pb2 import EvaluationReport
+from michelangelo.workflow.tasks.pusher.plugins.dataset_plugin import (
+    DatasetPusherPlugin,
+)
+from michelangelo.workflow.tasks.pusher.plugins.eval_report_plugin import (
+    EvalReportPusherPlugin,
+)
 from michelangelo.workflow.tasks.pusher.plugins.model_plugin import (
     ModelPusherPlugin,
     ModelPushResult,
+    PartialRegistrationError,
     RegistrationResult,
+)
+from michelangelo.workflow.tasks.pusher.registry import default_registry
+from michelangelo.workflow.variables import DatasetVariable
+from michelangelo.workflow.variables.types import AssembledModel
+
+# Populate default_registry. Done here (not in registry.py) to avoid a
+# circular import: registry.py ← plugins/base.py ← plugins/__init__.py.
+default_registry.register("model_plugin", ModelPusherPlugin, AssembledModel)
+default_registry.register("dataset_plugin", DatasetPusherPlugin, DatasetVariable)
+default_registry.register(
+    "eval_report_plugin", EvalReportPusherPlugin, EvaluationReport
 )

--- a/python/michelangelo/workflow/tasks/pusher/pusher.py
+++ b/python/michelangelo/workflow/tasks/pusher/pusher.py
@@ -1,0 +1,176 @@
+"""Top-level push() dispatch function for the Michelangelo pusher."""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+from typing import TYPE_CHECKING, Any, Callable
+
+from michelangelo.workflow.schema.exceptions import ConfigurationError
+from michelangelo.workflow.tasks.pusher.exceptions import (
+    ArtifactNotFoundError,
+    PusherPluginError,
+)
+from michelangelo.workflow.variables.types import PusherResult
+
+if TYPE_CHECKING:
+    from michelangelo.lib.artifact_manager.storage_backend import StorageBackend
+    from michelangelo.lib.model_manager.registry.client import ModelRegistryClient
+    from michelangelo.workflow.schema.pusher import PusherConfig
+    from michelangelo.workflow.tasks.pusher.registry import PluginRegistry
+
+_logger = logging.getLogger(__name__)
+
+
+def push(
+    config: PusherConfig,
+    artifacts: dict[str, Any],
+    *,
+    storage_backend: StorageBackend | None = None,
+    registry_client: ModelRegistryClient | None = None,
+    registry: PluginRegistry | None = None,
+    fail_fast: bool = True,
+    on_error: Callable[[str, str, Exception], None] | None = None,
+) -> list[PusherResult]:
+    """Push one or more artifacts using their configured plugins.
+
+    Iterates ``config.items`` in order, resolves each artifact from
+    ``artifacts`` by name, instantiates the matching plugin, and calls
+    ``execute()``. Infrastructure dependencies (``storage_backend``,
+    ``registry_client``) are injected into every plugin.
+
+    Args:
+        config: Top-level pusher configuration listing artifact/plugin pairs.
+        artifacts: Mapping from artifact name to artifact value. Keys must
+            match ``PusherPluginConfig.name`` for each item in config.
+        storage_backend: Backend used for artifact uploads. Defaults to a
+            temporary ``LocalStorageBackend`` when ``None``.
+        registry_client: Registry client injected into plugins that require
+            one (e.g. ``ModelPusherPlugin``). Pass ``None`` for plugins that
+            don't need a registry, or when registry clients are specified
+            directly on ``ModelPluginConfig.registry_clients``.
+        registry: Plugin registry to resolve plugin names against. Defaults
+            to ``default_registry`` when ``None``.
+        fail_fast: When ``True`` (default), the first plugin failure raises
+            ``PusherPluginError`` and subsequent items are not processed.
+            When ``False``, all items run and failures are recorded in
+            ``PusherResult.error``.
+        on_error: Optional callback invoked on every plugin failure, regardless
+            of ``fail_fast``. Signature: ``(artifact_name, plugin_name, exc)``.
+            Exceptions raised by the callback are logged and suppressed.
+
+    Returns:
+        List of :class:`~michelangelo.workflow.variables.types.PusherResult`,
+        one per ``config.items`` entry processed. In ``fail_fast=True`` mode
+        the list is shorter than ``config.items`` when a failure occurs.
+
+    Raises:
+        ArtifactNotFoundError: If a name in ``config.items`` is absent from
+            ``artifacts``.
+        ConfigurationError: If a plugin name is not registered, or the
+            artifact type does not match the registered expected type.
+        PusherPluginError: If a plugin's ``execute()`` raises and
+            ``fail_fast=True``.
+
+    Example::
+
+        from michelangelo.lib.model_manager.registry.client import (
+            InMemoryRegistryClient,
+        )
+        from michelangelo.workflow.schema.pusher import (
+            ModelPluginConfig, PusherConfig, PusherPluginConfig,
+        )
+        from michelangelo.workflow.tasks.pusher import push
+        from michelangelo.workflow.variables.types import AssembledModel, ModelArtifact
+
+        result = push(
+            config=PusherConfig(items=[
+                PusherPluginConfig(
+                    name="clf",
+                    model_plugin=ModelPluginConfig(model_name="my-classifier"),
+                ),
+            ]),
+            artifacts={
+                "clf": AssembledModel(raw_model=ModelArtifact(path="/tmp/raw"))
+            },
+            registry_client=InMemoryRegistryClient(),
+        )
+        assert result[0].success
+    """
+    from michelangelo.lib.artifact_manager.storage_backend import (
+        LocalStorageBackend,
+    )
+    from michelangelo.workflow.tasks.pusher.registry import (
+        default_registry,
+    )
+
+    effective_registry = registry if registry is not None else default_registry
+
+    if storage_backend is None:
+        storage_backend = LocalStorageBackend(tempfile.mkdtemp())
+
+    results: list[PusherResult] = []
+
+    for item in config.items:
+        artifact_name = item.name
+
+        if artifact_name not in artifacts:
+            raise ArtifactNotFoundError(artifact_name, list(artifacts.keys()))
+
+        artifact = artifacts[artifact_name]
+        plugin_name = item.resolved_plugin_name()
+        plugin_class, expected_type = effective_registry.get(plugin_name)
+
+        if expected_type is not None and not isinstance(artifact, expected_type):
+            raise ConfigurationError(
+                f"Artifact '{artifact_name}' has type "
+                f"{type(artifact).__name__!r} but plugin '{plugin_name}' "
+                f"expects {expected_type.__name__!r}."
+            )
+
+        plugin_cfg = item.resolved_plugin_config()
+        plugin = plugin_class(
+            config=plugin_cfg,
+            artifact=artifact,
+            storage_backend=storage_backend,
+            registry_client=registry_client,
+        )
+
+        _logger.info("Pushing artifact '%s' via '%s'.", artifact_name, plugin_name)
+        try:
+            value = plugin.execute()
+            results.append(
+                PusherResult(
+                    name=artifact_name,
+                    plugin=plugin_name,
+                    success=True,
+                    value=value,
+                )
+            )
+        except Exception as exc:
+            _logger.error(
+                "Plugin '%s' failed for artifact '%s': %s",
+                plugin_name,
+                artifact_name,
+                exc,
+            )
+            if on_error is not None:
+                try:
+                    on_error(artifact_name, plugin_name, exc)
+                except Exception as cb_exc:
+                    _logger.warning("on_error callback raised: %s", cb_exc)
+
+            if fail_fast:
+                raise PusherPluginError(artifact_name, plugin_name) from exc
+
+            results.append(
+                PusherResult(
+                    name=artifact_name,
+                    plugin=plugin_name,
+                    success=False,
+                    value={},
+                    error=str(exc),
+                )
+            )
+
+    return results

--- a/python/michelangelo/workflow/tasks/pusher/pusher.py
+++ b/python/michelangelo/workflow/tasks/pusher/pusher.py
@@ -44,7 +44,9 @@ def push(
         artifacts: Mapping from artifact name to artifact value. Keys must
             match ``PusherPluginConfig.name`` for each item in config.
         storage_backend: Backend used for artifact uploads. Defaults to a
-            temporary ``LocalStorageBackend`` when ``None``.
+            temporary ``LocalStorageBackend`` when ``None`` — a warning is
+            logged and the caller is responsible for cleaning up the directory.
+            Pass an explicit backend for production use.
         registry_client: Registry client injected into plugins that require
             one (e.g. ``ModelPusherPlugin``). Pass ``None`` for plugins that
             don't need a registry, or when registry clients are specified
@@ -97,6 +99,10 @@ def push(
         )
         assert result[0].success
     """
+    # Importing pusher.plugins here guarantees default_registry is populated
+    # with the three built-in plugins regardless of how push() was imported
+    # (package __init__ or direct module import).
+    import michelangelo.workflow.tasks.pusher.plugins  # noqa: F401
     from michelangelo.lib.artifact_manager.storage_backend import (
         LocalStorageBackend,
     )
@@ -107,7 +113,14 @@ def push(
     effective_registry = registry if registry is not None else default_registry
 
     if storage_backend is None:
-        storage_backend = LocalStorageBackend(tempfile.mkdtemp())
+        _tmp = tempfile.mkdtemp()
+        _logger.warning(
+            "No storage_backend provided; using ephemeral temp dir '%s'. "
+            "The caller is responsible for cleanup. Pass an explicit "
+            "storage_backend for production use.",
+            _tmp,
+        )
+        storage_backend = LocalStorageBackend(_tmp)
 
     results: list[PusherResult] = []
 
@@ -122,10 +135,14 @@ def push(
         plugin_class, expected_type = effective_registry.get(plugin_name)
 
         if expected_type is not None and not isinstance(artifact, expected_type):
+            if isinstance(expected_type, tuple):
+                expected_name = " | ".join(t.__name__ for t in expected_type)
+            else:
+                expected_name = expected_type.__name__
             raise ConfigurationError(
                 f"Artifact '{artifact_name}' has type "
                 f"{type(artifact).__name__!r} but plugin '{plugin_name}' "
-                f"expects {expected_type.__name__!r}."
+                f"expects {expected_name!r}."
             )
 
         plugin_cfg = item.resolved_plugin_config()
@@ -158,7 +175,12 @@ def push(
                 try:
                     on_error(artifact_name, plugin_name, exc)
                 except Exception as cb_exc:
-                    _logger.warning("on_error callback raised: %s", cb_exc)
+                    _logger.warning(
+                        "on_error callback raised for artifact '%s' plugin '%s': %s",
+                        artifact_name,
+                        plugin_name,
+                        cb_exc,
+                    )
 
             if fail_fast:
                 raise PusherPluginError(artifact_name, plugin_name) from exc

--- a/python/michelangelo/workflow/tasks/pusher/pusher.py
+++ b/python/michelangelo/workflow/tasks/pusher/pusher.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import tempfile
 from typing import TYPE_CHECKING, Any, Callable
 
 from michelangelo.workflow.schema.exceptions import ConfigurationError
@@ -43,10 +42,10 @@ def push(
         config: Top-level pusher configuration listing artifact/plugin pairs.
         artifacts: Mapping from artifact name to artifact value. Keys must
             match ``PusherPluginConfig.name`` for each item in config.
-        storage_backend: Backend used for artifact uploads. Defaults to a
-            temporary ``LocalStorageBackend`` when ``None`` — a warning is
-            logged and the caller is responsible for cleaning up the directory.
-            Pass an explicit backend for production use.
+        storage_backend: Backend used for artifact uploads. Required —
+            pass a ``LocalStorageBackend``, ``MinioStorageBackend``, or any
+            :class:`~michelangelo.lib.artifact_manager.storage_backend.StorageBackend`
+            subclass. Raises :class:`ConfigurationError` when ``None``.
         registry_client: Registry client injected into plugins that require
             one (e.g. ``ModelPusherPlugin``). Pass ``None`` for plugins that
             don't need a registry, or when registry clients are specified
@@ -103,9 +102,6 @@ def push(
     # with the three built-in plugins regardless of how push() was imported
     # (package __init__ or direct module import).
     import michelangelo.workflow.tasks.pusher.plugins  # noqa: F401
-    from michelangelo.lib.artifact_manager.storage_backend import (
-        LocalStorageBackend,
-    )
     from michelangelo.workflow.tasks.pusher.registry import (
         default_registry,
     )
@@ -113,14 +109,10 @@ def push(
     effective_registry = registry if registry is not None else default_registry
 
     if storage_backend is None:
-        _tmp = tempfile.mkdtemp()
-        _logger.warning(
-            "No storage_backend provided; using ephemeral temp dir '%s'. "
-            "The caller is responsible for cleanup. Pass an explicit "
-            "storage_backend for production use.",
-            _tmp,
+        raise ConfigurationError(
+            "storage_backend is required. Pass a LocalStorageBackend, "
+            "MinioStorageBackend, or any StorageBackend subclass."
         )
-        storage_backend = LocalStorageBackend(_tmp)
 
     results: list[PusherResult] = []
 

--- a/python/michelangelo/workflow/tasks/pusher/registry.py
+++ b/python/michelangelo/workflow/tasks/pusher/registry.py
@@ -40,14 +40,16 @@ class PluginRegistry:
 
     def __init__(self, parent: PluginRegistry | None = None) -> None:
         """Initialise with an optional parent registry."""
-        self._registry: dict[str, tuple[type[PusherPluginBase], type | None]] = {}
+        self._registry: dict[
+            str, tuple[type[PusherPluginBase], type | tuple[type, ...] | None]
+        ] = {}
         self._parent = parent
 
     def register(
         self,
         name: str,
         plugin_class: type[PusherPluginBase],
-        artifact_type: type | None = None,
+        artifact_type: type | tuple[type, ...] | None = None,
     ) -> None:
         """Register a plugin under a given name.
 
@@ -59,10 +61,11 @@ class PluginRegistry:
             name: Plugin identifier used in ``PusherPluginConfig`` as the
                 typed field name or as the ``plugin_name`` extension value.
             plugin_class: Concrete subclass of ``PusherPluginBase``.
-            artifact_type: Expected Python type of the artifact value. When
-                provided, ``push()`` validates ``isinstance(artifact,
-                artifact_type)`` before invoking the plugin. Pass ``None``
-                for config-only plugins.
+            artifact_type: Expected Python type (or tuple of types) of the
+                artifact value. When provided, ``push()`` validates
+                ``isinstance(artifact, artifact_type)`` before invoking the
+                plugin. Pass ``None`` for config-only plugins or when the
+                plugin accepts any artifact type.
 
         Raises:
             ValueError: If ``name`` is already registered in this instance.
@@ -80,7 +83,9 @@ class PluginRegistry:
             )
         self._registry[name] = (plugin_class, artifact_type)
 
-    def get(self, name: str) -> tuple[type[PusherPluginBase], type | None]:
+    def get(
+        self, name: str
+    ) -> tuple[type[PusherPluginBase], type | tuple[type, ...] | None]:
         """Look up a plugin by name, falling through to the parent if needed.
 
         Args:

--- a/python/michelangelo/workflow/tasks/pusher/tests/test_push_dispatch.py
+++ b/python/michelangelo/workflow/tasks/pusher/tests/test_push_dispatch.py
@@ -29,6 +29,7 @@ from michelangelo.workflow.variables.types import (
 # Fake plugin helpers
 # ---------------------------------------------------------------------------
 
+
 def _fake_plugin_class(
     return_value: dict[str, Any] | None = None,
     raises: Exception | None = None,
@@ -78,6 +79,7 @@ def _storage() -> LocalStorageBackend:
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
 
 class TestPushSingleSuccess(TestCase):
     """Test 1: single plugin succeeds."""
@@ -288,3 +290,157 @@ class TestPushChildRegistry(TestCase):
 
         self.assertTrue(results[0].success)
         self.assertEqual(results[0].value["source"], "child")
+
+
+class TestPushOnErrorCallbackRaises(TestCase):
+    """Test 10: on_error callback that raises is suppressed; push still proceeds."""
+
+    def test_raising_on_error_is_suppressed(self) -> None:
+        """It suppresses exceptions from on_error and still raises PusherPluginError."""
+        fail_plugin = _fake_plugin_class(raises=RuntimeError("plugin-fail"))
+        reg = _registry(("fp", fail_plugin, AssembledModel))
+
+        def bad_callback(name: str, plugin: str, exc: Exception) -> None:
+            raise ValueError("callback-fail")
+
+        with self.assertRaises(PusherPluginError):
+            push(
+                config=_config(_item("art", "fp")),
+                artifacts={"art": _assembled()},
+                storage_backend=_storage(),
+                registry=reg,
+                on_error=bad_callback,
+                fail_fast=True,
+            )
+
+    def test_raising_on_error_does_not_affect_fail_fast_false(self) -> None:
+        """It suppresses callback exception and continues processing remaining items."""
+        fail_plugin = _fake_plugin_class(raises=RuntimeError("boom"))
+        ok_plugin = _fake_plugin_class(return_value={"ok": True})
+        reg = _registry(
+            ("fail_plugin", fail_plugin, AssembledModel),
+            ("ok_plugin", ok_plugin, AssembledModel),
+        )
+
+        def bad_callback(name: str, plugin: str, exc: Exception) -> None:
+            raise ValueError("callback-boom")
+
+        results = push(
+            config=_config(_item("first", "fail_plugin"), _item("second", "ok_plugin")),
+            artifacts={"first": _assembled(), "second": _assembled()},
+            storage_backend=_storage(),
+            registry=reg,
+            on_error=bad_callback,
+            fail_fast=False,
+        )
+
+        self.assertEqual(len(results), 2)
+        self.assertFalse(results[0].success)
+        self.assertTrue(results[1].success)
+
+
+class TestPushDefaultStorageBackend(TestCase):
+    """Test 11: storage_backend=None uses an ephemeral LocalStorageBackend."""
+
+    def test_no_storage_backend_succeeds(self) -> None:
+        """It succeeds without an explicit storage_backend (uses temp dir default)."""
+        fake_plugin = _fake_plugin_class(return_value={"ok": True})
+        reg = _registry(("fp", fake_plugin, AssembledModel))
+
+        results = push(
+            config=_config(_item("art", "fp")),
+            artifacts={"art": _assembled()},
+            registry=reg,
+            # storage_backend intentionally omitted
+        )
+
+        self.assertEqual(len(results), 1)
+        self.assertTrue(results[0].success)
+
+
+class TestPushDefaultRegistry(TestCase):
+    """Test 12: registry=None uses default_registry with built-in plugins."""
+
+    def test_default_registry_resolves_model_plugin(self) -> None:
+        """It dispatches through default_registry when no explicit registry is given."""
+        from michelangelo.lib.model_manager.registry.client import (
+            InMemoryRegistryClient,
+        )
+        from michelangelo.workflow.schema.pusher import (
+            ModelPluginConfig,
+            PusherPluginConfig,
+        )
+
+        artifact = _assembled()
+        cfg = PusherConfig(
+            items=[
+                PusherPluginConfig(
+                    name="model",
+                    model_plugin=ModelPluginConfig(model_name="test-model"),
+                )
+            ]
+        )
+
+        results = push(
+            config=cfg,
+            artifacts={"model": artifact},
+            storage_backend=_storage(),
+            registry_client=InMemoryRegistryClient(),
+            # registry intentionally omitted — uses default_registry
+        )
+
+        self.assertEqual(len(results), 1)
+        self.assertTrue(results[0].success)
+        self.assertEqual(results[0].plugin, "model_plugin")
+
+
+class TestPushUntypedPlugin(TestCase):
+    """Test 13: plugin registered with artifact_type=None accepts any artifact."""
+
+    def test_untyped_plugin_accepts_any_artifact(self) -> None:
+        """It skips isinstance check when artifact_type is None."""
+        fake_plugin = _fake_plugin_class(return_value={"ok": True})
+        reg = PluginRegistry()
+        reg.register("untyped_plugin", fake_plugin, None)  # no type constraint
+
+        results = push(
+            config=_config(_item("anything", "untyped_plugin")),
+            artifacts={"anything": {"arbitrary": "dict"}},  # not an AssembledModel
+            storage_backend=_storage(),
+            registry=reg,
+        )
+
+        self.assertTrue(results[0].success)
+
+
+class TestPushTupleExpectedType(TestCase):
+    """Test 14: plugin registered with a tuple of types accepts any matching type."""
+
+    def test_tuple_type_accepts_matching_types(self) -> None:
+        """It passes isinstance check when artifact matches any type in the tuple."""
+        fake_plugin = _fake_plugin_class(return_value={"ok": True})
+        reg = PluginRegistry()
+        reg.register("multi_plugin", fake_plugin, (AssembledModel, dict))
+
+        for artifact in [_assembled(), {"raw": "dict"}]:
+            results = push(
+                config=_config(_item("art", "multi_plugin")),
+                artifacts={"art": artifact},
+                storage_backend=_storage(),
+                registry=reg,
+            )
+            self.assertTrue(results[0].success)
+
+    def test_tuple_type_rejects_non_matching_type(self) -> None:
+        """It raises ConfigurationError when artifact doesn't match any tuple type."""
+        fake_plugin = _fake_plugin_class()
+        reg = PluginRegistry()
+        reg.register("multi_plugin", fake_plugin, (AssembledModel, dict))
+
+        with self.assertRaises(ConfigurationError):
+            push(
+                config=_config(_item("art", "multi_plugin")),
+                artifacts={"art": [1, 2, 3]},  # list — not in (AssembledModel, dict)
+                storage_backend=_storage(),
+                registry=reg,
+            )

--- a/python/michelangelo/workflow/tasks/pusher/tests/test_push_dispatch.py
+++ b/python/michelangelo/workflow/tasks/pusher/tests/test_push_dispatch.py
@@ -340,22 +340,20 @@ class TestPushOnErrorCallbackRaises(TestCase):
 
 
 class TestPushDefaultStorageBackend(TestCase):
-    """Test 11: storage_backend=None uses an ephemeral LocalStorageBackend."""
+    """Test 11: storage_backend=None raises ConfigurationError."""
 
-    def test_no_storage_backend_succeeds(self) -> None:
-        """It succeeds without an explicit storage_backend (uses temp dir default)."""
+    def test_no_storage_backend_raises(self) -> None:
+        """It raises ConfigurationError when storage_backend is omitted."""
         fake_plugin = _fake_plugin_class(return_value={"ok": True})
         reg = _registry(("fp", fake_plugin, AssembledModel))
 
-        results = push(
-            config=_config(_item("art", "fp")),
-            artifacts={"art": _assembled()},
-            registry=reg,
-            # storage_backend intentionally omitted
-        )
-
-        self.assertEqual(len(results), 1)
-        self.assertTrue(results[0].success)
+        with self.assertRaisesRegex(ConfigurationError, "storage_backend"):
+            push(
+                config=_config(_item("art", "fp")),
+                artifacts={"art": _assembled()},
+                registry=reg,
+                # storage_backend intentionally omitted
+            )
 
 
 class TestPushDefaultRegistry(TestCase):

--- a/python/michelangelo/workflow/tasks/pusher/tests/test_push_dispatch.py
+++ b/python/michelangelo/workflow/tasks/pusher/tests/test_push_dispatch.py
@@ -1,0 +1,290 @@
+"""Tests for the push() dispatch function."""
+
+from __future__ import annotations
+
+import tempfile
+from typing import Any
+from unittest import TestCase
+
+from michelangelo.lib.artifact_manager.storage_backend import LocalStorageBackend
+from michelangelo.workflow.schema.exceptions import ConfigurationError
+from michelangelo.workflow.schema.pusher import (
+    PusherConfig,
+    PusherPluginConfig,
+)
+from michelangelo.workflow.tasks.pusher import (
+    ArtifactNotFoundError,
+    PluginRegistry,
+    PusherPluginError,
+    push,
+)
+from michelangelo.workflow.tasks.pusher.plugins.base import PusherPluginBase
+from michelangelo.workflow.variables.types import (
+    AssembledModel,
+    ModelArtifact,
+    PusherResult,
+)
+
+# ---------------------------------------------------------------------------
+# Fake plugin helpers
+# ---------------------------------------------------------------------------
+
+def _fake_plugin_class(
+    return_value: dict[str, Any] | None = None,
+    raises: Exception | None = None,
+) -> type[PusherPluginBase]:
+    """Return a PusherPluginBase subclass whose execute() is scripted."""
+    rv = return_value or {}
+    exc = raises
+
+    class _FakePlugin(PusherPluginBase):
+        def execute(self) -> dict[str, Any]:
+            """Execute the scripted fake plugin."""
+            if exc is not None:
+                raise exc
+            return rv
+
+    return _FakePlugin
+
+
+def _registry(*entries: tuple) -> PluginRegistry:
+    """Build a fresh PluginRegistry with the given (name, cls, type) entries."""
+    reg = PluginRegistry()
+    for name, plugin_cls, artifact_type in entries:
+        reg.register(name, plugin_cls, artifact_type)
+    return reg
+
+
+def _config(*items: PusherPluginConfig) -> PusherConfig:
+    """Wrap items in a PusherConfig."""
+    return PusherConfig(items=list(items))
+
+
+def _item(name: str, plugin_name: str) -> PusherPluginConfig:
+    """Build a PusherPluginConfig pointing at a custom plugin_name."""
+    return PusherPluginConfig(name=name, plugin_name=plugin_name, plugin_config={})
+
+
+def _assembled(path: str = "/tmp/raw") -> AssembledModel:
+    """Build a minimal AssembledModel."""
+    return AssembledModel(raw_model=ModelArtifact(path=path))
+
+
+def _storage() -> LocalStorageBackend:
+    """Return a temporary LocalStorageBackend."""
+    return LocalStorageBackend(tempfile.mkdtemp())
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestPushSingleSuccess(TestCase):
+    """Test 1: single plugin succeeds."""
+
+    def test_returns_one_successful_result(self) -> None:
+        """It returns a single PusherResult with success=True and plugin output."""
+        fake_plugin = _fake_plugin_class(return_value={"uri": "s3://bucket/key"})
+        reg = _registry(("fake_plugin", fake_plugin, AssembledModel))
+
+        results = push(
+            config=_config(_item("model", "fake_plugin")),
+            artifacts={"model": _assembled()},
+            storage_backend=_storage(),
+            registry=reg,
+        )
+
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0], PusherResult)
+        self.assertTrue(results[0].success)
+        self.assertEqual(results[0].name, "model")
+        self.assertEqual(results[0].plugin, "fake_plugin")
+        self.assertEqual(results[0].value, {"uri": "s3://bucket/key"})
+        self.assertIsNone(results[0].error)
+
+
+class TestPushMultipleSuccess(TestCase):
+    """Test 2: multiple items, all succeed, returned in config order."""
+
+    def test_returns_results_in_order(self) -> None:
+        """It returns one result per item in the same order as config.items."""
+        fake_plugin = _fake_plugin_class()
+        reg = _registry(
+            ("plugin_a", fake_plugin, AssembledModel),
+            ("plugin_b", fake_plugin, AssembledModel),
+        )
+        artifacts = {"first": _assembled(), "second": _assembled()}
+        cfg = _config(_item("first", "plugin_a"), _item("second", "plugin_b"))
+
+        results = push(
+            config=cfg, artifacts=artifacts, storage_backend=_storage(), registry=reg
+        )
+
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0].name, "first")
+        self.assertEqual(results[1].name, "second")
+        self.assertTrue(all(r.success for r in results))
+
+
+class TestPushArtifactNotFound(TestCase):
+    """Test 3: artifact key absent from artifacts dict."""
+
+    def test_raises_artifact_not_found_error(self) -> None:
+        """It raises ArtifactNotFoundError when an artifact name is missing."""
+        fake_plugin = _fake_plugin_class()
+        reg = _registry(("fp", fake_plugin, AssembledModel))
+
+        with self.assertRaises(ArtifactNotFoundError):
+            push(
+                config=_config(_item("missing", "fp")),
+                artifacts={"other": _assembled()},
+                storage_backend=_storage(),
+                registry=reg,
+            )
+
+
+class TestPushUnknownPlugin(TestCase):
+    """Test 4: plugin name not in registry."""
+
+    def test_raises_configuration_error(self) -> None:
+        """It raises ConfigurationError when the plugin name is not registered."""
+        reg = PluginRegistry()  # empty
+
+        with self.assertRaises(ConfigurationError):
+            push(
+                config=_config(_item("model", "no_such_plugin")),
+                artifacts={"model": _assembled()},
+                storage_backend=_storage(),
+                registry=reg,
+            )
+
+
+class TestPushTypeMismatch(TestCase):
+    """Test 5: artifact type does not match registered expected type."""
+
+    def test_raises_configuration_error_on_type_mismatch(self) -> None:
+        """It raises ConfigurationError when the artifact type is wrong."""
+        fake_plugin = _fake_plugin_class()
+        reg = _registry(("typed_plugin", fake_plugin, AssembledModel))
+
+        with self.assertRaises(ConfigurationError):
+            push(
+                config=_config(_item("report", "typed_plugin")),
+                artifacts={"report": {"not": "an AssembledModel"}},
+                storage_backend=_storage(),
+                registry=reg,
+            )
+
+
+class TestPushFailFastTrue(TestCase):
+    """Test 6: fail_fast=True — first failure raises, second plugin not called."""
+
+    def test_raises_and_skips_remaining(self) -> None:
+        """It raises PusherPluginError and never invokes the second plugin."""
+        fail_plugin = _fake_plugin_class(raises=RuntimeError("boom"))
+        call_log: list[str] = []
+
+        class _TrackingPlugin(PusherPluginBase):
+            def execute(self) -> dict[str, Any]:
+                """Record invocation and return empty dict."""
+                call_log.append("second")
+                return {}
+
+        reg = _registry(
+            ("fail_plugin", fail_plugin, AssembledModel),
+            ("ok_plugin", _TrackingPlugin, AssembledModel),
+        )
+        artifacts = {"first": _assembled(), "second": _assembled()}
+        cfg = _config(_item("first", "fail_plugin"), _item("second", "ok_plugin"))
+
+        with self.assertRaises(PusherPluginError):
+            push(
+                config=cfg,
+                artifacts=artifacts,
+                storage_backend=_storage(),
+                registry=reg,
+                fail_fast=True,
+            )
+
+        self.assertNotIn("second", call_log)
+
+
+class TestPushFailFastFalse(TestCase):
+    """Test 7: fail_fast=False — all items run; failure captured in result."""
+
+    def test_all_run_failure_in_result(self) -> None:
+        """It runs all items and records the error on the failing result."""
+        fail_plugin = _fake_plugin_class(raises=RuntimeError("oops"))
+        ok_plugin = _fake_plugin_class(return_value={"done": True})
+        reg = _registry(
+            ("fail_plugin", fail_plugin, AssembledModel),
+            ("ok_plugin", ok_plugin, AssembledModel),
+        )
+        artifacts = {"first": _assembled(), "second": _assembled()}
+        cfg = _config(_item("first", "fail_plugin"), _item("second", "ok_plugin"))
+
+        results = push(
+            config=cfg,
+            artifacts=artifacts,
+            storage_backend=_storage(),
+            registry=reg,
+            fail_fast=False,
+        )
+
+        self.assertEqual(len(results), 2)
+        self.assertFalse(results[0].success)
+        self.assertIsNotNone(results[0].error)
+        self.assertIn("oops", results[0].error)
+        self.assertTrue(results[1].success)
+
+
+class TestPushOnErrorCallback(TestCase):
+    """Test 8: on_error callback invoked with (artifact_name, plugin_name, exc)."""
+
+    def test_on_error_receives_correct_args(self) -> None:
+        """It calls on_error with the artifact name, plugin name, and exception."""
+        err = ValueError("fail")
+        fail_plugin = _fake_plugin_class(raises=err)
+        reg = _registry(("fp", fail_plugin, AssembledModel))
+
+        calls: list[tuple] = []
+
+        def on_error(name: str, plugin: str, exc: Exception) -> None:
+            calls.append((name, plugin, exc))
+
+        with self.assertRaises(PusherPluginError):
+            push(
+                config=_config(_item("art", "fp")),
+                artifacts={"art": _assembled()},
+                storage_backend=_storage(),
+                registry=reg,
+                on_error=on_error,
+            )
+
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0][0], "art")
+        self.assertEqual(calls[0][1], "fp")
+        self.assertIs(calls[0][2], err)
+
+
+class TestPushChildRegistry(TestCase):
+    """Test 9: custom child registry resolves its own plugin correctly."""
+
+    def test_child_registry_overrides_parent(self) -> None:
+        """It resolves the child-registered plugin, not the parent's version."""
+        base_plugin = _fake_plugin_class(return_value={"source": "parent"})
+        override_plugin = _fake_plugin_class(return_value={"source": "child"})
+
+        parent = _registry(("my_plugin", base_plugin, AssembledModel))
+        child = parent.extend()
+        child.register("my_plugin", override_plugin, AssembledModel)
+
+        results = push(
+            config=_config(_item("art", "my_plugin")),
+            artifacts={"art": _assembled()},
+            storage_backend=_storage(),
+            registry=child,
+        )
+
+        self.assertTrue(results[0].success)
+        self.assertEqual(results[0].value["source"], "child")

--- a/python/michelangelo/workflow/tasks/pusher/tests/test_push_dispatch.py
+++ b/python/michelangelo/workflow/tasks/pusher/tests/test_push_dispatch.py
@@ -26,7 +26,7 @@ from michelangelo.workflow.variables.types import (
 )
 
 # ---------------------------------------------------------------------------
-# Fake plugin helpers
+# Mock plugin helpers
 # ---------------------------------------------------------------------------
 
 

--- a/python/michelangelo/workflow/tasks/pusher/tests/test_push_dispatch.py
+++ b/python/michelangelo/workflow/tasks/pusher/tests/test_push_dispatch.py
@@ -361,17 +361,28 @@ class TestPushDefaultStorageBackend(TestCase):
 class TestPushDefaultRegistry(TestCase):
     """Test 12: registry=None uses default_registry with built-in plugins."""
 
-    def test_default_registry_resolves_model_plugin(self) -> None:
-        """It dispatches through default_registry when no explicit registry is given."""
-        from michelangelo.lib.model_manager.registry.client import (
-            InMemoryRegistryClient,
+    def test_default_registry_contains_builtin_plugins(self) -> None:
+        """It populates default_registry with the three built-in plugin names."""
+        from michelangelo.workflow.tasks.pusher import (  # noqa: F401 — triggers registration
+            push,
+        )
+        from michelangelo.workflow.tasks.pusher.registry import default_registry
+
+        names = default_registry.registered_names()
+        self.assertIn("model_plugin", names)
+        self.assertIn("dataset_plugin", names)
+        self.assertIn("eval_report_plugin", names)
+
+    def test_default_registry_used_when_registry_omitted(self) -> None:
+        """It raises from the registered plugin when registry is omitted."""
+        from michelangelo.workflow.schema.exceptions import (
+            ConfigurationError as SchemaConfigError,
         )
         from michelangelo.workflow.schema.pusher import (
             ModelPluginConfig,
             PusherPluginConfig,
         )
 
-        artifact = _assembled()
         cfg = PusherConfig(
             items=[
                 PusherPluginConfig(
@@ -381,17 +392,17 @@ class TestPushDefaultRegistry(TestCase):
             ]
         )
 
-        results = push(
-            config=cfg,
-            artifacts={"model": artifact},
-            storage_backend=_storage(),
-            registry_client=InMemoryRegistryClient(),
-            # registry intentionally omitted — uses default_registry
-        )
-
-        self.assertEqual(len(results), 1)
-        self.assertTrue(results[0].success)
-        self.assertEqual(results[0].plugin, "model_plugin")
+        # Without registry_client, ModelPusherPlugin raises ConfigurationError
+        # about a missing registry client — NOT about an unknown plugin name.
+        # This distinguishes "plugin found and reached" from "plugin not registered".
+        with self.assertRaisesRegex(SchemaConfigError, "registry client"):
+            push(
+                config=cfg,
+                artifacts={"model": _assembled()},
+                storage_backend=_storage(),
+                # registry intentionally omitted — uses default_registry
+                # registry_client intentionally omitted — causes plugin validation error
+            )
 
 
 class TestPushUntypedPlugin(TestCase):


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

- Adds `push()` top-level dispatch function that iterates `PusherConfig.items`, resolves each artifact by name, instantiates the matching plugin from `PluginRegistry`, and calls `execute()`. Supports `fail_fast` and an optional `on_error` callback.
- Introduces `PluginRegistry` with `register()` / `get()` / `extend()` for community plugin extension; `default_registry` pre-populated with the three built-in plugins (`model_plugin`, `dataset_plugin`, `eval_report_plugin`).
- `storage_backend` is now required — omitting it raises `ConfigurationError` instead of silently falling back to an ephemeral temp dir.
- Exports the full public API from `pusher/__init__.py` with `__all__` and module docstring.
- Documents the two-tier plugin config model in `PusherPluginConfig` and adds a UniFlow codec warning to `ModelPluginConfig.registry_clients`.

<!-- Tell your future self why have you made these changes -->
**Why?**

The pusher had plugin implementations but no dispatch layer — callers had to instantiate plugins manually. The silent temp-dir fallback masked missing `storage_backend` configuration; an explicit `ConfigurationError` surfaces the misconfiguration at call time rather than silently producing ephemeral, unrecoverable artifacts.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

- 17 unit tests in `test_push_dispatch.py` covering happy paths, error paths (`ArtifactNotFoundError`, `ConfigurationError`, `PusherPluginError`), `fail_fast` on/off, `on_error` callback, untyped plugins, and tuple artifact types — all passing.
- `TestPushDefaultStorageBackend` updated to assert `ConfigurationError` when `storage_backend` is omitted.
- `ruff check` and `ruff format` clean on all changed files.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

Any caller that currently relies on the implicit temp-dir fallback (omitting `storage_backend`) will now receive a `ConfigurationError` at runtime. Callers must explicitly pass a `storage_backend`.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

Breaking: `push()` now requires `storage_backend`. Callers that previously omitted it must pass an explicit `LocalStorageBackend`, `MinioStorageBackend`, or custom `StorageBackend` subclass.

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**

- `pusher/__init__.py` module docstring covers all public symbols with import examples.
- `PusherPluginConfig` docstring documents the two-tier config model.
- `ModelPluginConfig.registry_clients` docstring adds UniFlow codec serialization warning.
- `push()` docstring updated: `storage_backend` marked required, `ConfigurationError` added to Raises.