### PR TITLE
fix(url-field): support relative paths as navigable links

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,8 @@ repos:
         types: [python]
       - id: prettier
         name: prettier formatter
-        entry: bash -c 'cd javascript && yarn prettier --write "$@"' --
+        entry: bash -c 'cd javascript && yarn prettier --write "${@#javascript/}"' --
         language: system
         types_or: [ts, tsx, javascript, jsx, json, css, yaml, markdown]
+        files: ^javascript/
         pass_filenames: true

--- a/javascript/CLAUDE.md
+++ b/javascript/CLAUDE.md
@@ -53,6 +53,8 @@ Run from the `javascript/` directory:
 | `yarn generate`   | Regenerate gRPC clients from protobuf definitions                  |
 | `yarn setup`      | Fresh install + generate (use after cloning or switching branches) |
 
+**Test output:** vitest is configured with `silent: 'passed-only'` — passing tests produce no output; only failures are printed. Run commands as-is with no `--reporter` flag. Adding `--reporter=verbose` defeats this and floods output.
+
 ---
 
 ## Skills

--- a/javascript/packages/core/components/form/fields/url/url-field.tsx
+++ b/javascript/packages/core/components/form/fields/url/url-field.tsx
@@ -4,7 +4,7 @@ import { FormControl } from '#core/components/form/components/form-control';
 import { useField } from '#core/components/form/hooks/use-field';
 import { Link } from '#core/components/link/link';
 import { TruncatedText } from '#core/components/truncated-text/truncated-text';
-import { isAbsoluteURL } from '#core/utils/string-utils';
+import { isNavigableURL } from '#core/utils/string-utils';
 
 import type { UrlFieldProps } from './types';
 
@@ -44,7 +44,7 @@ export const UrlField: React.FC<UrlFieldProps> = ({
       caption={caption}
       error={meta.touched && meta.error ? meta.error : undefined}
     >
-      {isAbsoluteURL(value) ? (
+      {isNavigableURL(value) ? (
         <Link href={value}>
           <TruncatedText>{urlName ?? label ?? value}</TruncatedText>
         </Link>

--- a/javascript/packages/core/utils/__tests__/string-utils.tests.ts
+++ b/javascript/packages/core/utils/__tests__/string-utils.tests.ts
@@ -1,6 +1,7 @@
 import {
   capitalizeFirstLetter,
   isAbsoluteURL,
+  isNavigableURL,
   safeStringify,
   sentenceCaseEnumValue,
 } from '../string-utils';
@@ -39,6 +40,25 @@ describe('isAbsoluteURL', () => {
 
   it('should return false if the string is not a valid absolute URL', () => {
     expect(isAbsoluteURL('something')).toBe(false);
+  });
+});
+
+describe('isNavigableURL', () => {
+  it('should return true for absolute URLs', () => {
+    expect(isNavigableURL('https://www.google.com')).toBe(true);
+    expect(isNavigableURL('http://localhost:3000')).toBe(true);
+  });
+
+  it('should return true for root-relative paths', () => {
+    expect(isNavigableURL('/pipelines/my-pipeline')).toBe(true);
+    expect(isNavigableURL('/namespace/models/foo')).toBe(true);
+    expect(isNavigableURL('/')).toBe(true);
+  });
+
+  it('should return false for non-URL strings', () => {
+    expect(isNavigableURL('not_a_url')).toBe(false);
+    expect(isNavigableURL('www.google.com')).toBe(false);
+    expect(isNavigableURL('')).toBe(false);
   });
 });
 

--- a/javascript/packages/core/utils/string-utils.ts
+++ b/javascript/packages/core/utils/string-utils.ts
@@ -10,6 +10,17 @@ export const isAbsoluteURL = (value: string) =>
   isURL(encodeURI(value), { require_protocol: true, require_tld: false });
 
 /**
+ * Checks whether a value is a navigable URL — either an absolute URL or a
+ * root-relative path. Use this to decide whether to render a value as a link.
+ *
+ * Distinct from {@link isAbsoluteURL}, which rejects relative paths and is
+ * appropriate for validation (e.g., requiring a fully-qualified URL in a form
+ * field). This function is appropriate for display logic where internal
+ * navigation paths like `/{namespace}/models/foo` are valid link targets.
+ */
+export const isNavigableURL = (value: string) => isAbsoluteURL(value) || value.startsWith('/');
+
+/**
  * @description
  * Transforms a string value into a sentence case format. Special handling for
  * enum values is provided to strip enum value prefixes.


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Bug Fix

**What changed?**

`UrlField` only rendered absolute URLs as a clickable link—valid internal paths like \`/{namespace}/models/foo\` silently fell through to a placeholder span with no link rendered. Introduces utility which detects absolute URLs and root-relative paths (\`/...\`) and updates \`UrlField\` now to use this.

**Why?**

Consumers storing app paths (e.g. \`/{namespace}/models/foo\`) as \`UrlField\` values had no way to render them as links. The original absolute guard was only meant to distinguish navigable hrefs from garbage values.

**How did you test it?**

* Added unit tests
* Verified visually in Sandbox with the following code:

```tsx
<Form initialValues={{ absUrl: 'https://example.com', relUrl: '/pipelines/my-pipeline', invalid: 'not-a-url' }} onSubmit={() => {}}>
  <UrlField name="absUrl" label="Absolute URL" urlName="Example site" />
  <UrlField name="relUrl" label="Relative path" />
  <UrlField name="invalid" label="Non-URL value" placeholder="(no link)" />
</Form>
```

https://github.com/user-attachments/assets/d502388a-e467-4f71-8c83-292e5f4ccc9b


**Potential risks**

`UrlField` will now render any root-relative string as a link. The change is additive — absolute URL behavior is unchanged.

**Release notes**

`UrlField` now renders root-relative paths (e.g. \`/{namespace}/models/foo\`) as internal links.

**Documentation Changes**

None.