### PR TITLE
refactor(types): type the accessor input so callers don't have to cast records

### DIFF
--- a/javascript/packages/core/components/cell/renderers/description/types.ts
+++ b/javascript/packages/core/components/cell/renderers/description/types.ts
@@ -1,7 +1,7 @@
 import type { SharedCell } from '#core/components/cell/types';
 import type { DescriptionHierarchy } from './constants';
 
-export type DescriptionCellConfig = SharedCell & {
+export type DescriptionCellConfig<TRecord = unknown> = SharedCell<TRecord> & {
   /**
    * @description Used to control cell styling – e.g. color, font-size, etc.
    */

--- a/javascript/packages/core/components/cell/renderers/link/types.ts
+++ b/javascript/packages/core/components/cell/renderers/link/types.ts
@@ -1,6 +1,6 @@
 import type { SharedCell } from '#core/components/cell/types';
 
-export type LinkCellConfig = SharedCell<string> & {
+export type LinkCellConfig<TRecord = unknown> = SharedCell<TRecord, string> & {
   /**
    * @description When provided, the cell will display a link to the provided url
    */

--- a/javascript/packages/core/components/cell/renderers/multi/types.ts
+++ b/javascript/packages/core/components/cell/renderers/multi/types.ts
@@ -1,6 +1,6 @@
 import type { Cell, SharedCell } from '#core/components/cell/types';
 
-export type MultiCellConfig = SharedCell<unknown> & {
+export type MultiCellConfig = SharedCell & {
   /**
    * @description Used to render the cell with multiple lines with different values
    * e.g. First line with Pipeline name and second line with revision identifier

--- a/javascript/packages/core/components/cell/renderers/state/types.ts
+++ b/javascript/packages/core/components/cell/renderers/state/types.ts
@@ -1,7 +1,7 @@
 import type { SharedCell } from '#core/components/cell/types';
 import type { TagColor } from '#core/components/tag/types';
 
-export type StateCellConfig = SharedCell<string> & {
+export type StateCellConfig<TRecord = unknown> = SharedCell<TRecord, string> & {
   /**
    * @description A map of state values to their display text
    * @example

--- a/javascript/packages/core/components/cell/renderers/tag/types.ts
+++ b/javascript/packages/core/components/cell/renderers/tag/types.ts
@@ -1,7 +1,7 @@
 import type { SharedCell } from '#core/components/cell/types';
 import type { TagColor } from '#core/components/tag/types';
 
-export type TagCellConfig = SharedCell<string> & {
+export type TagCellConfig<TRecord = unknown> = SharedCell<TRecord, string> & {
   /**
    * @description The color of the tag
    * @default COLOR.gray

--- a/javascript/packages/core/components/cell/renderers/type/types.ts
+++ b/javascript/packages/core/components/cell/renderers/type/types.ts
@@ -1,6 +1,6 @@
 import type { SharedCell } from '#core/components/cell/types';
 
-export type TypeCellConfig = SharedCell<string> & {
+export type TypeCellConfig<TRecord = unknown> = SharedCell<TRecord, string> & {
   /**
    * @description A map of type values to their display text
    */

--- a/javascript/packages/core/components/cell/types.ts
+++ b/javascript/packages/core/components/cell/types.ts
@@ -18,10 +18,16 @@ import type { TypeCellConfig } from './renderers/type/types';
  * @see {@link LinkCellConfig}
  * @see {@link MultiCellConfig}
  */
-export type Cell<T = unknown> = SharedCell<T> &
-  (DescriptionCellConfig | LinkCellConfig | MultiCellConfig | StateCellConfig | TypeCellConfig);
+export type Cell<TRecord = unknown, TValue = unknown> = SharedCell<TRecord, TValue> &
+  (
+    | DescriptionCellConfig<TRecord>
+    | LinkCellConfig<TRecord>
+    | MultiCellConfig
+    | StateCellConfig<TRecord>
+    | TypeCellConfig<TRecord>
+  );
 
-export interface SharedCell<T = unknown> {
+export interface SharedCell<TRecord = unknown, TValue = unknown> {
   /**
    * @description Unique identifier for the column
    * If no accessor is provided, this id will be used to access the data
@@ -34,7 +40,7 @@ export interface SharedCell<T = unknown> {
    * @example 'spec.content.metadata.name'
    * @example (row) => `Revision ${row?.spec?.revisionId}`,
    */
-  accessor?: Accessor<unknown>;
+  accessor?: Accessor<TRecord, TValue>;
 
   /**
    * @description Label to be displayed in the table header
@@ -84,7 +90,7 @@ export interface SharedCell<T = unknown> {
    * @default
    * @see src/components/cell/renderers/default/column-renderer.tsx
    */
-  Cell?: CellRenderer<T>;
+  Cell?: CellRenderer<TValue>;
 
   /**
    * @description Style overrides to be applied to each cell
@@ -124,7 +130,7 @@ export type CellTooltip = {
  */
 export type CellStyleFunction = (args: { record: unknown; theme: Theme }) => StyleObject;
 
-export type CellRenderer<T, CellConfig = SharedCell<T>> = {
+export type CellRenderer<T, CellConfig = SharedCell<unknown, T>> = {
   (props: CellRendererProps<T, CellConfig>): ReactNode | null;
 
   /**
@@ -134,7 +140,7 @@ export type CellRenderer<T, CellConfig = SharedCell<T>> = {
   toString?: (props: CellRendererProps<T, CellConfig>) => string;
 };
 
-export interface CellRendererProps<T = unknown, CellConfig = SharedCell<T>> {
+export interface CellRendererProps<T = unknown, CellConfig = SharedCell<unknown, T>> {
   column: CellConfig;
 
   /**

--- a/javascript/packages/core/components/views/execution/components/task-details/renderers/types.ts
+++ b/javascript/packages/core/components/views/execution/components/task-details/renderers/types.ts
@@ -23,7 +23,7 @@ export interface TaskBodyStructSchema extends SharedTaskBodySchema {
    * @example 'spec.content.metadata.name'
    * @example (task) => task.input
    */
-  accessor: Accessor<object>;
+  accessor: Accessor<unknown, object>;
 }
 
 export interface TaskBodyTextareaSchema extends SharedTaskBodySchema {
@@ -38,7 +38,7 @@ export interface TaskBodyTextareaSchema extends SharedTaskBodySchema {
    * @example 'spec.content.metadata.name'
    * @example (task) => task.input
    */
-  accessor: Accessor<string>;
+  accessor: Accessor<unknown, string>;
 }
 
 export interface TaskBodyMetadataSchema extends SharedTaskBodySchema {

--- a/javascript/packages/core/components/views/execution/types.ts
+++ b/javascript/packages/core/components/views/execution/types.ts
@@ -73,7 +73,7 @@ export type ExecutionDetailViewSchema<
      * accessor: (data) => data.workflow?.tasks || []
      * ```
      */
-    accessor: Accessor<TTaskRecord[]>;
+    accessor: Accessor<unknown, TTaskRecord[]>;
 
     /**
      * Optional accessor to extract child tasks from each task record.
@@ -89,7 +89,7 @@ export type ExecutionDetailViewSchema<
      * subTasksAccessor: (task) => task.children?.filter(child => child.visible)
      * ```
      */
-    subTasksAccessor?: Accessor<TTaskRecord[]>;
+    subTasksAccessor?: Accessor<unknown, TTaskRecord[]>;
 
     /**
      * Configuration for extracting display information from task records.
@@ -108,7 +108,7 @@ export type ExecutionDetailViewSchema<
        * heading: (task) => `${task.type}: ${task.name}`
        * ```
        */
-      heading: Accessor<string>;
+      heading: Accessor<unknown, string>;
 
       /**
        * Optional metadata fields to display as rich content below the task heading.

--- a/javascript/packages/core/types/common/studio-types.ts
+++ b/javascript/packages/core/types/common/studio-types.ts
@@ -191,10 +191,10 @@ export type PhaseEntityState = 'active' | 'disabled';
  * const accessor: Accessor = 'users[0].name';
  * accessor({ users: [{ name: 'John' }] }); // 'John'
  *
- * const accessor: Accessor<string> = (object) => object.name;
+ * const accessor: Accessor<{ name: string }, string> = (object) => object.name;
  * accessor({ name: 'John' }); // 'John'
  * ```
  */
-export type Accessor<K = unknown> = AccessorFn<K> | string;
+export type Accessor<TIn = unknown, TOut = unknown> = AccessorFn<TIn, TOut> | string;
 
-export type AccessorFn<T = unknown> = (object: unknown) => T | undefined;
+export type AccessorFn<TIn = unknown, TOut = unknown> = (object: TIn) => TOut | undefined;

--- a/javascript/packages/core/utils/object-utils.ts
+++ b/javascript/packages/core/utils/object-utils.ts
@@ -47,7 +47,7 @@ export function toFlatDotPathMap(
  */
 export function getObjectValue<K>(
   obj: unknown,
-  accessor: Accessor<K>,
+  accessor: Accessor<unknown, K>,
   defaultValue?: K
 ): K | undefined {
   if (typeof accessor === 'function') {


### PR DESCRIPTION
**Summary**

Function accessors on cell columns previously had no way to know the type of the record being accessed. To extract a typed field, callers were forced to cast the parameter, even when the column's record type was known at the call site. This change makes the accessor's input type a first-class generic so those casts are no longer needed.

**Test Plan**

Installed into consumer of michelangelo-ai/core and confirmed no regressions.

**Potential risks**

Breaking for any external consumer who passed a single type argument to `SharedCell<T>` or `Cell<T>` — that argument previously meant the value type and now means the record type.