### PR TITLE
ma cli: support MACTL_RPC_SERVICE env override

### DIFF
--- a/python/michelangelo/cli/mactl/config.py
+++ b/python/michelangelo/cli/mactl/config.py
@@ -69,6 +69,9 @@ def _apply_env_overrides(config: dict) -> dict:
     if getenv("MACTL_ADDRESS"):
         result["address"] = getenv("MACTL_ADDRESS")
 
+    if getenv("MACTL_RPC_SERVICE"):
+        result["metadata"]["rpc-service"] = getenv("MACTL_RPC_SERVICE")
+
     if getenv("MACTL_USE_TLS"):
         use_tls_str = getenv("MACTL_USE_TLS")
         result["use_tls"] = use_tls_str.lower() in ("true", "1", "yes", "y")
@@ -90,7 +93,7 @@ def load_config() -> dict:
     """Load complete configuration as dictionary with layered merging.
 
     Priority (highest to lowest):
-    1. Environment variables (MACTL_ADDRESS, MACTL_USE_TLS, AWS_*)
+    1. Environment variables (MACTL_ADDRESS, MACTL_RPC_SERVICE, MACTL_USE_TLS, AWS_*)
     2. ~/.ma/user_config.toml (user overrides)
     3. ~/.ma/config.toml (project defaults)
     4. Built-in DEFAULT_CONFIG

--- a/python/michelangelo/cli/mactl/config_test.py
+++ b/python/michelangelo/cli/mactl/config_test.py
@@ -95,6 +95,51 @@ class ApplyEnvOverridesTest(TestCase):
         self.assertEqual(result["address"], "env-address:9999")
 
     @patch("michelangelo.cli.mactl.config.getenv")
+    def test_apply_env_overrides_mactl_rpc_service(self, mock_getenv):
+        """Test env override for MACTL_RPC_SERVICE."""
+
+        def getenv_side_effect(key, default=None):
+            if key == "MACTL_RPC_SERVICE":
+                return "michelangelo-apiserver-staging"
+            return None
+
+        mock_getenv.side_effect = getenv_side_effect
+
+        config = {
+            "address": "default",
+            "metadata": {"rpc-service": "ma-apiserver"},
+        }
+        result = _apply_env_overrides(config)
+
+        self.assertEqual(
+            result["metadata"]["rpc-service"], "michelangelo-apiserver-staging"
+        )
+
+    @patch("michelangelo.cli.mactl.config.getenv")
+    def test_apply_env_overrides_mactl_address_and_rpc_service(self, mock_getenv):
+        """MACTL_ADDRESS and MACTL_RPC_SERVICE apply independently."""
+
+        def getenv_side_effect(key, default=None):
+            env_map = {
+                "MACTL_ADDRESS": "env-address:9999",
+                "MACTL_RPC_SERVICE": "michelangelo-apiserver-dev-3",
+            }
+            return env_map.get(key)
+
+        mock_getenv.side_effect = getenv_side_effect
+
+        config = {
+            "address": "default",
+            "metadata": {"rpc-service": "ma-apiserver"},
+        }
+        result = _apply_env_overrides(config)
+
+        self.assertEqual(result["address"], "env-address:9999")
+        self.assertEqual(
+            result["metadata"]["rpc-service"], "michelangelo-apiserver-dev-3"
+        )
+
+    @patch("michelangelo.cli.mactl.config.getenv")
     def test_apply_env_overrides_mactl_use_tls(self, mock_getenv):
         """Test env override for MACTL_USE_TLS."""
 


### PR DESCRIPTION
## Summary
Adds MACTL_RPC_SERVICE env-var override in _apply_env_overrides, mirroring
the existing MACTL_ADDRESS pattern. Lets callers set both address and
metadata.rpc-service together 

## Context
Today MACTL_ADDRESS only overrides config["address"]. metadata["rpc-service"]
is read separately and stays at whatever user_config.toml/config.toml has —
so when an external caller changes the address per invocation, the resulting
mismatch causes "UNIMPLEMENTED unrecognized service name" from the apiserver.


## Test plan
Unit tests in config_test.py cover:
- MACTL_RPC_SERVICE set → result.metadata.rpc-service equals it
- MACTL_RPC_SERVICE absent → falls through to existing config
- both MACTL_ADDRESS and MACTL_RPC_SERVICE set → both applied independently...
