### PR TITLE
Add ability to customize detail view header via titleEnhancer

### DIFF
--- a/javascript/packages/core/components/views/detail-view/components/detail-view-header/detail-view-header.tsx
+++ b/javascript/packages/core/components/views/detail-view/components/detail-view-header/detail-view-header.tsx
@@ -15,6 +15,7 @@ import type { DetailViewHeaderProps } from './types';
 export function DetailViewHeader({
   subtitle,
   title,
+  titleEnhancer,
   onGoBack,
   children,
   actions,
@@ -35,7 +36,7 @@ export function DetailViewHeader({
           display: 'flex',
           gap: theme.sizing.scale800,
           justifyContent: 'flex-start',
-          alignItems: 'center',
+          alignItems: 'flex-end',
         })}
       >
         <h5 className={css({ margin: 0, maxWidth: '50%' })}>
@@ -80,6 +81,7 @@ export function DetailViewHeader({
             </div>
           </div>
         </h5>
+        {titleEnhancer}
         {resolvedActions && (
           <div className={css({ marginLeft: 'auto', flexShrink: 0 })}>
             <ActionsButtons actions={resolvedActions} record={record ?? {}} loading={loading} />

--- a/javascript/packages/core/components/views/detail-view/detail-view.tsx
+++ b/javascript/packages/core/components/views/detail-view/detail-view.tsx
@@ -13,6 +13,7 @@ export function DetailView({
   actions,
   record,
   loading,
+  titleEnhancer
 }: DetailViewProps) {
   const [css, theme] = useStyletron();
 
@@ -21,6 +22,7 @@ export function DetailView({
       <DetailViewHeader
         title={title}
         subtitle={subtitle}
+        titleEnhancer={titleEnhancer}
         onGoBack={onGoBack}
         actions={actions}
         record={record}

--- a/javascript/packages/core/components/views/detail-view/detail-view.tsx
+++ b/javascript/packages/core/components/views/detail-view/detail-view.tsx
@@ -13,7 +13,7 @@ export function DetailView({
   actions,
   record,
   loading,
-  titleEnhancer
+  titleEnhancer,
 }: DetailViewProps) {
   const [css, theme] = useStyletron();
 

--- a/javascript/packages/core/components/views/detail-view/types/detail-view-component-types.ts
+++ b/javascript/packages/core/components/views/detail-view/types/detail-view-component-types.ts
@@ -19,6 +19,11 @@ export interface DetailHeaderBaseProps {
    * Main heading displayed next to the back button
    */
   title?: string;
+
+  /**
+   * ReactNode to be rendered next to the title in the header
+   */
+  titleEnhancer?: React.ReactNode;
   onGoBack?: () => void;
 
   /**

--- a/javascript/packages/core/index.tsx
+++ b/javascript/packages/core/index.tsx
@@ -197,6 +197,9 @@ export { FormStep } from '#core/components/form/layout/form-step/form-step';
 export { ArrayFormRow } from '#core/components/form/layout/array-form-row/array-form-row';
 export { ArrayFormGroup } from '#core/components/form/layout/array-form-group/array-form-group';
 
+// Actions
+export { ActionHierarchy } from '#core/components/actions/types';
+
 // Detail View
 export { DetailView } from '#core/components/views/detail-view/detail-view';
 export { DetailViewPages } from '#core/components/views/detail-view/components/detail-view-pages/detail-view-pages';

--- a/javascript/packages/core/package.json
+++ b/javascript/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@michelangelo-ai/core",
   "license": "Apache-2.0",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "main": "./dist/michelangelo-core.js",
   "module": "./dist/michelangelo-core.js",


### PR DESCRIPTION
**Summary**

Introduces a new prop `titleEnhancer` which brings the ability to customize the title by passing a component.
On top of this change also updated component alignment on DetailViewHeader as `flex-end`.

Also, exported `ActionHierarchy` for any consumer to be able to pass hierarchy with their actions.