### PR TITLE
cli: fix get --name flag silently listing instead of fetching

### DIFF
--- a/python/michelangelo/cli/mactl/crd.py
+++ b/python/michelangelo/cli/mactl/crd.py
@@ -253,7 +253,7 @@ def _get_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Mes
         crd_method_info,
         **{
             "namespace": get_single_arg(bound_args.arguments, "namespace"),
-            "name": _resolve_name_arg(bound_args.arguments),
+            "name": get_single_arg(bound_args.arguments, "name"),
         },
     )
 

--- a/python/michelangelo/cli/mactl/crd.py
+++ b/python/michelangelo/cli/mactl/crd.py
@@ -233,6 +233,18 @@ def crd_method_call(crd_method_info, request_input: Message) -> Message:
     return response
 
 
+def _resolve_name_arg(arguments: dict) -> str:
+    """Merge positional `name` and --name flag (`name_flag`) for the get action.
+
+    Positional takes precedence; either may be empty. The `--name` flag is
+    bound to a separate dest to avoid an argparse override that silently
+    blanks the positional value.
+    """
+    positional = arguments.get("name") or ""
+    flag = arguments.get("name_flag") or ""
+    return positional or flag
+
+
 def _get_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Message:
     """Raw CRD GET implementation - returns message instance without printing."""
     _LOG.info("Bound arguments: %r", bound_args.arguments)
@@ -241,7 +253,7 @@ def _get_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Mes
         crd_method_info,
         **{
             "namespace": get_single_arg(bound_args.arguments, "namespace"),
-            "name": get_single_arg(bound_args.arguments, "name"),
+            "name": _resolve_name_arg(bound_args.arguments),
         },
     )
 
@@ -254,8 +266,9 @@ def get_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Mess
     _LOG.info("Bound arguments: %r", bound_args.arguments)
 
     _self: CRD = bound_args.arguments["self"]
+    name = _resolve_name_arg(bound_args.arguments)
 
-    if "name" not in bound_args.arguments or not bound_args.arguments["name"]:
+    if not name:
         _LOG.debug("No name argument passed. List CRD in the namespace.")
         _self.generate_list(crd_method_info.channel)
         return _self.list(
@@ -264,7 +277,8 @@ def get_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Mess
         )
 
     call_res = _self._get(
-        **{k: v for k, v in bound_args.arguments.items() if k != "self"}
+        namespace=get_single_arg(bound_args.arguments, "namespace"),
+        name=name,
     )
     print(call_res)
     return call_res
@@ -527,16 +541,6 @@ class CRD:
                 "help": "Get an Entity or list all entities in the namespace",
                 "args": [
                     {
-                        "args": ["name"],
-                        "kwargs": {
-                            "nargs": "?",
-                            "type": str,
-                            "help": (
-                                "Name of the resource (can be configured with --name)"
-                            ),
-                        },
-                    },
-                    {
                         "func_signature": Parameter(
                             "namespace", Parameter.POSITIONAL_OR_KEYWORD
                         ),
@@ -553,12 +557,32 @@ class CRD:
                             Parameter.POSITIONAL_OR_KEYWORD,
                             default="",
                         ),
+                        "args": ["name"],
+                        "kwargs": {
+                            "nargs": "?",
+                            "type": str,
+                            "default": "",
+                            "help": (
+                                "Name of the resource (can also be supplied as "
+                                "--name; omit both to list all)"
+                            ),
+                        },
+                    },
+                    {
+                        "func_signature": Parameter(
+                            "name_flag",
+                            Parameter.POSITIONAL_OR_KEYWORD,
+                            default="",
+                        ),
                         "args": ["--name"],
                         "kwargs": {
-                            "dest": "name",
+                            "dest": "name_flag",
                             "type": str,
+                            "default": "",
                             "required": False,
-                            "help": "Name of the resource",
+                            "help": (
+                                "Name of the resource (alternative to positional)"
+                            ),
                         },
                     },
                     {

--- a/python/michelangelo/cli/mactl/crd_test.py
+++ b/python/michelangelo/cli/mactl/crd_test.py
@@ -346,9 +346,7 @@ class GetFuncImplTest(TestCase):
             ),
         )
 
-        mock_crd._get.assert_called_once_with(
-            namespace="ns", name="from-positional"
-        )
+        mock_crd._get.assert_called_once_with(namespace="ns", name="from-positional")
 
     def test_get_func_impl_without_name_calls_list(self):
         """Test get_func_impl without name calls list with limit."""

--- a/python/michelangelo/cli/mactl/crd_test.py
+++ b/python/michelangelo/cli/mactl/crd_test.py
@@ -368,7 +368,8 @@ class GetFuncImplTest(TestCase):
                 arguments={
                     "self": mock_crd,
                     "namespace": "ns",
-                    "name": None,
+                    "name": "",
+                    "name_flag": "",
                     "limit": 50,
                 }
             ),
@@ -600,6 +601,31 @@ class GenerateGetTest(TestCase):
         crd.generate_get(mock_channel)
 
         result = crd.get(namespace="test-ns", name="test-name")
+
+        self.assertEqual(result, mock_response)
+        call_args = mock_crd_method_call_kwargs.call_args
+        self.assertEqual(call_args.kwargs["namespace"], "test-ns")
+        self.assertEqual(call_args.kwargs["name"], "test-name")
+
+    @patch("michelangelo.cli.mactl.crd.crd_method_call_kwargs")
+    @patch.object(CRD, "_extract_method_info")
+    def test_generate_get_execution_via_name_flag(
+        self, mock_extract_method_info, mock_crd_method_call_kwargs
+    ):
+        """Generated `get` resolves the --name flag (dest=name_flag) like positional.
+
+        Exercises the full bind_signature path with `name=""` and `name_flag="X"`,
+        the binding state that argparse produces when the user supplies --name only.
+        """
+        mock_channel = Mock()
+        mock_extract_method_info.return_value = ("GetTestCrd", Mock, Mock)
+        mock_response = Mock()
+        mock_crd_method_call_kwargs.return_value = mock_response
+
+        crd = CRD(name="test_crd", full_name="test.service.TestCrd", metadata=[])
+        crd.generate_get(mock_channel)
+
+        result = crd.get(namespace="test-ns", name_flag="test-name")
 
         self.assertEqual(result, mock_response)
         call_args = mock_crd_method_call_kwargs.call_args

--- a/python/michelangelo/cli/mactl/crd_test.py
+++ b/python/michelangelo/cli/mactl/crd_test.py
@@ -294,6 +294,62 @@ class GetFuncImplTest(TestCase):
         mock_crd._get.assert_called_once_with(namespace="ns", name="proj")
         self.assertEqual(result, mock_response)
 
+    def test_get_func_impl_with_name_flag_calls_get(self):
+        """`--name X` (dest=name_flag) routes through _get just like positional."""
+        mock_crd = Mock()
+        mock_response = Mock()
+        mock_crd._get.return_value = mock_response
+
+        crd_method_info = CrdMethodInfo(
+            channel=Mock(),
+            crd_full_name="test.Service",
+            method_name="Get",
+            input_class=Mock,
+            output_class=Mock,
+        )
+        result = get_func_impl(
+            crd_method_info,
+            Mock(
+                arguments={
+                    "self": mock_crd,
+                    "namespace": "ns",
+                    "name": "",
+                    "name_flag": "proj",
+                }
+            ),
+        )
+
+        mock_crd._get.assert_called_once_with(namespace="ns", name="proj")
+        self.assertEqual(result, mock_response)
+
+    def test_get_func_impl_positional_overrides_name_flag(self):
+        """Positional `name` wins when both are supplied."""
+        mock_crd = Mock()
+        mock_crd._get.return_value = Mock()
+
+        crd_method_info = CrdMethodInfo(
+            channel=Mock(),
+            crd_full_name="test.Service",
+            method_name="Get",
+            input_class=Mock,
+            output_class=Mock,
+        )
+        get_func_impl(
+            crd_method_info,
+            Mock(
+                arguments={
+                    "self": mock_crd,
+                    "namespace": "ns",
+                    "name": "from-positional",
+                    "name_flag": "from-flag",
+                }
+            ),
+        )
+
+        mock_crd._get.assert_called_once_with(
+            namespace="ns", name="from-positional"
+        )
+
     def test_get_func_impl_without_name_calls_list(self):
         """Test get_func_impl without name calls list with limit."""
         mock_crd = Mock()


### PR DESCRIPTION
## Problem

`ma <crd> get --name X --namespace Y` silently lists every CRD in the namespace instead of fetching the named one.

## Root cause

`crd.py` `get` action registers `name` twice with the same dest: a positional with `nargs="?"` and an optional `--name` flag. argparse processes the optional first (sets `ns.name="X"`), then processes the missing positional and overwrites `ns.name=None`. `get_func_impl` sees a falsy name and falls back to the list path.

## Fix

Rebind the `--name` flag to `dest="name_flag"` and merge the two sources in `_resolve_name_arg` (positional wins when both are supplied). Both forms now work:

| Input | Behavior |
|---|---|
| `get NAME -n NS` | fetch (positional) |
| `get --name NAME -n NS` | fetch (flag — previously broken) |
| `get -n NS` | list fallback |
| `get NAME --name OTHER -n NS` | fetch NAME (positional wins) |

## Tests

Unit: `python -m pytest python/michelangelo/cli/mactl/crd_test.py` → **22/22 pass** (20 existing + 2 new regressions for the `--name` flag path and positional-precedence).

E2E against staging (patched wheel locally, ran live `ma` against av-labs-sandbox):

```
$ ma pipeline get --name hello-pipeline --namespace av-labs-sandbox
pipeline { metadata { name: "hello-pipeline" namespace: "av-labs-sandbox" ... } }   # ✓ single proto (was: list of 7)

$ ma pipeline get hello-pipeline --namespace av-labs-sandbox
pipeline { metadata { name: "hello-pipeline" ... } }                                  # ✓ positional still works

$ ma pipeline get --namespace av-labs-sandbox
NAMESPACE        NAME                         LAST_UPDATED_SPEC
av-labs-sandbox  example-crane-cpu            2026-06-03_21:16:14
... (7 rows)                                                                          # ✓ list fallback intact
```