### PR TITLE
fix(sandbox): pin k3s version and document Ray extras

### DIFF
--- a/docs/contributing/building-michelangelo-ai-from-source.md
+++ b/docs/contributing/building-michelangelo-ai-from-source.md
@@ -52,6 +52,7 @@ Ensure you have the following installed before building:
 - **[Go](https://go.dev/doc/install)** — version `1.24.0+` (see `go/go.mod`)
 - **[Python](https://www.python.org/downloads/)** — version `3.9+`
 - **[Poetry](https://python-poetry.org/docs/#installation)** — for Python dependency management
+- **Bash 4+** — the pre-commit hooks use `readarray` which requires bash 4+. macOS ships bash 3.2; install a newer version with `brew install bash` and ensure it precedes `/bin/bash` on your `PATH`.
 
 For the full sandbox environment (Docker, kubectl, k3d, GitHub token), see the [Sandbox Setup Guide](../getting-started/sandbox-setup.md).
 

--- a/docs/getting-started/sandbox-setup.md
+++ b/docs/getting-started/sandbox-setup.md
@@ -82,6 +82,14 @@ cd <repo-root>/python
 poetry install
 ```
 
+**Development extras:** If you plan to work on pipelines that use Ray or Spark compute, install the `plugin` extra:
+
+```bash
+poetry install --extras plugin
+```
+
+This adds `ray` and `pyspark` to your environment. Skip this if you're only doing UI or apiserver work.
+
 ---
 
 ## Quick start


### PR DESCRIPTION
## Summary
fix(sandbox): pin k3s version and document Ray extras

## Test Plan
I ran `ma sandbox create` end-to-end on a fresh k3d 5.9.0 install with the
pinned image. All core services reached Running

## Issues

