### PR TITLE
Add torch Triton model packager

### DIFF
--- a/python/michelangelo/lib/model_manager/_private/packager/custom_triton/config_pbtxt.py
+++ b/python/michelangelo/lib/model_manager/_private/packager/custom_triton/config_pbtxt.py
@@ -35,17 +35,20 @@ def generate_config_pbtxt_content(
     ):
         model_name = f"{model_name}-{model_revision}"
 
-    return gen.render(
-        "config.pbtxt.tmpl",
-        {
-            "model_name": model_name,
-            "backend": TritonBackendType.PYTHON,
-            "max_batch_size": 256,
-            "enable_dynamic_batching": True,
-            "preferred_batch_size": 10,
-            "max_queue_delay_microseconds": 300,
-            "instance_count": 1,
-            "inputs": input_schema,
-            "outputs": output_schema,
-        },
+    return (
+        gen.render(
+            "config.pbtxt.tmpl",
+            {
+                "model_name": model_name,
+                "backend": TritonBackendType.PYTHON,
+                "max_batch_size": 256,
+                "enable_dynamic_batching": True,
+                "preferred_batch_size": 10,
+                "max_queue_delay_microseconds": 300,
+                "instance_count": 1,
+                "inputs": input_schema,
+                "outputs": output_schema,
+            },
+        ).rstrip()
+        + "\n"
     )

--- a/python/michelangelo/lib/model_manager/_private/packager/custom_triton/model_class.py
+++ b/python/michelangelo/lib/model_manager/_private/packager/custom_triton/model_class.py
@@ -17,6 +17,8 @@ def serialize_model_class(
     target_dir: str,
     model_file_name: str,
     include_import_prefixes: Optional[list[str]] = None,
+    serialize_interface: bool = True,
+    write_txt_file: bool = True,
 ):
     """Serialize the model class to the target dir.
 
@@ -37,6 +39,10 @@ def serialize_model_class(
             e.g. ['uber', 'data.michelangelo'] only imports starting
             with 'uber' or 'data.michelangelo' will be saved in the
             model package. If not specified, save all imports
+        serialize_interface: Whether to include the custom model interface
+            compatibility files in the serialized definition directory.
+        write_txt_file: Whether to write the text file containing
+            ``model_class``. Set to False when serializing dependency classes.
 
     Returns:
         None
@@ -50,9 +56,11 @@ def serialize_model_class(
     files = find_dependency_files(module_def, prefixes=include_import_prefixes)
     save_module_files(files, target_dir)
 
-    # create the model class file
-    with open(os.path.join(target_dir, model_file_name), "w") as f:
-        f.write(model_class)
+    if write_txt_file:
+        # create the model class file
+        with open(os.path.join(target_dir, model_file_name), "w") as f:
+            f.write(model_class)
 
-    # serialize the model interface
-    serialize_model_interface(target_dir)
+    if serialize_interface:
+        # serialize the model interface
+        serialize_model_interface(target_dir)

--- a/python/michelangelo/lib/model_manager/_private/packager/custom_triton/model_package.py
+++ b/python/michelangelo/lib/model_manager/_private/packager/custom_triton/model_package.py
@@ -1,8 +1,10 @@
 """Generate the model package content."""
 
+from __future__ import annotations
+
 import os
 import tempfile
-from typing import Optional
+from typing import TYPE_CHECKING
 
 from michelangelo.lib.model_manager._private.packager.custom_triton.config_pbtxt import (  # noqa: E501
     generate_config_pbtxt_content,
@@ -28,11 +30,14 @@ from michelangelo.lib.model_manager._private.packager.custom_triton.user_model_p
 from michelangelo.lib.model_manager._private.packager.custom_triton.validation import (
     validate_model_files,
 )
-from michelangelo.lib.model_manager._private.packager.template_renderer import (
-    TritonTemplateRenderer,
-)
 from michelangelo.lib.model_manager._private.utils.asset_utils import download_assets
 from michelangelo.lib.model_manager.constants import StorageType
+
+if TYPE_CHECKING:
+    from michelangelo.lib.artifact_manager import StorageBackend
+    from michelangelo.lib.model_manager._private.packager.template_renderer import (
+        TritonTemplateRenderer,
+    )
 
 
 def generate_model_package_content(
@@ -43,10 +48,11 @@ def generate_model_package_content(
     model_class: str,
     input_schema: dict,
     output_schema: dict,
-    model_path_source_type: Optional[str] = StorageType.LOCAL,
-    root_path: Optional[str] = None,
-    include_import_prefixes: Optional[list[str]] = None,
-    custom_batch_processing: Optional[bool] = False,
+    model_path_source_type: str | None = StorageType.LOCAL,
+    root_path: str | None = None,
+    include_import_prefixes: list[str] | None = None,
+    custom_batch_processing: bool | None = False,
+    storage_backend: StorageBackend | None = None,
 ) -> dict:
     """Generate the model package content.
 
@@ -72,6 +78,8 @@ def generate_model_package_content(
             class, and the model input/output will have an additional batch
             dimension on top of the existing model schema. For example, the
             schema shape [1] will be converted to [-1, 1].
+        storage_backend: Optional storage backend used to download ``model_path``
+            when it is not a local filesystem path.
 
     Returns:
         The model package content as a dictionary
@@ -106,6 +114,7 @@ def generate_model_package_content(
         model_path,
         target_model_path,
         model_path_source_type,
+        storage_backend=storage_backend,
     )
 
     os.makedirs(target_model_path, exist_ok=True)

--- a/python/michelangelo/lib/model_manager/_private/packager/custom_triton/raw_model_package.py
+++ b/python/michelangelo/lib/model_manager/_private/packager/custom_triton/raw_model_package.py
@@ -1,10 +1,10 @@
 """Generate the raw model package content."""
 
+from __future__ import annotations
+
 import os
 import tempfile
-from typing import Optional, Union
-
-from numpy import ndarray
+from typing import TYPE_CHECKING
 
 from michelangelo.lib.model_manager._private.packager.custom_triton.constants import (
     MODEL_CLASS_FILE_NAME,
@@ -28,7 +28,12 @@ from michelangelo.lib.model_manager._private.schema.common import schema_to_yaml
 from michelangelo.lib.model_manager._private.serde.data import dump_model_data
 from michelangelo.lib.model_manager._private.utils.asset_utils import download_assets
 from michelangelo.lib.model_manager.constants import StorageType
-from michelangelo.lib.model_manager.schema import ModelSchema
+
+if TYPE_CHECKING:
+    from numpy import ndarray
+
+    from michelangelo.lib.artifact_manager import StorageBackend
+    from michelangelo.lib.model_manager.schema import ModelSchema
 
 
 def generate_raw_model_package_content(
@@ -36,11 +41,12 @@ def generate_raw_model_package_content(
     model_class: str,
     model_schema: ModelSchema,
     sample_data: list[dict[str, ndarray]],
-    model_path_source_type: Optional[str] = StorageType.LOCAL,
-    requirements: Optional[Union[list[str], str]] = None,
-    root_path: Optional[str] = None,
-    include_import_prefixes: Optional[list[str]] = None,
-    batch_inference: Optional[bool] = False,
+    model_path_source_type: str | None = StorageType.LOCAL,
+    requirements: list[str] | str | None = None,
+    root_path: str | None = None,
+    include_import_prefixes: list[str] | None = None,
+    batch_inference: bool | None = False,
+    storage_backend: StorageBackend | None = None,
 ) -> dict:
     """Generate the raw model package content.
 
@@ -72,6 +78,8 @@ def generate_raw_model_package_content(
             batch dimension on top of the existing model schema.
             For example, if the model schema specifies the input shape to be
             [n, m], the model expects the input shape to be [-1, n, m].
+        storage_backend: Optional storage backend used to download ``model_path``
+            when it is not a local filesystem path.
 
     Returns:
         The raw model package content
@@ -87,6 +95,7 @@ def generate_raw_model_package_content(
         model_path,
         target_model_path,
         model_path_source_type,
+        storage_backend=storage_backend,
     )
 
     os.makedirs(target_model_path, exist_ok=True)

--- a/python/michelangelo/lib/model_manager/_private/packager/templates/triton/config.pbtxt.tmpl
+++ b/python/michelangelo/lib/model_manager/_private/packager/templates/triton/config.pbtxt.tmpl
@@ -2,12 +2,12 @@
 name: "{{model_name}}"
 {% endif -%}
 backend: "{{backend}}"
-max_batch_size: 256
+max_batch_size: {{max_batch_size | default(256)}}
 {%- if enable_dynamic_batching %}
 dynamic_batching: {
 {%- if preferred_batch_size %}
   preferred_batch_size: {{preferred_batch_size}},
-{%- endif %}
+{%- endif -%}
 {%- if max_queue_delay_microseconds %}
   max_queue_delay_microseconds: {{max_queue_delay_microseconds}},
   preserve_ordering: true

--- a/python/michelangelo/lib/model_manager/_private/packager/templates/triton/torch_python/user_model.py.tmpl
+++ b/python/michelangelo/lib/model_manager/_private/packager/templates/triton/torch_python/user_model.py.tmpl
@@ -1,0 +1,91 @@
+import importlib
+import json
+import os
+
+import numpy as np
+import torch
+import yaml
+
+
+def _instantiate(spec):
+    if not isinstance(spec, dict) or "_target_" not in spec:
+        return spec
+    target = spec["_target_"]
+    module_name, class_name = target.rsplit(".", 1)
+    model_type = getattr(importlib.import_module(module_name), class_name)
+    kwargs = {
+        key: _instantiate(value) if isinstance(value, dict) else value
+        for key, value in spec.items()
+        if key != "_target_"
+    }
+    return model_type(**kwargs)
+
+
+def load_model(model_path):
+    with open(os.path.join(model_path, "model_class.txt")) as f:
+        model_class = f.read().strip()
+    module_name, class_name = model_class.rsplit(".", 1)
+    model_type = getattr(importlib.import_module(module_name), class_name)
+
+    skeleton_path = os.path.join(model_path, "skeleton.yaml")
+    legacy_hyperparameters_path = os.path.join(model_path, "hyperparameters.json")
+    if os.path.exists(skeleton_path):
+        with open(skeleton_path) as f:
+            spec = yaml.safe_load(f) or {}
+    elif os.path.exists(legacy_hyperparameters_path):
+        with open(legacy_hyperparameters_path) as f:
+            spec = json.load(f) or {}
+    else:
+        spec = {}
+
+    model = _instantiate(spec) if "_target_" in spec else model_type(**spec)
+    state_dict = torch.load(
+        os.path.join(model_path, "model", "model.pt"),
+        map_location="cpu",
+        weights_only=True,
+    )
+    model.load_state_dict(state_dict)
+    model.eval()
+    return model
+
+
+class Model:
+    def __init__(self):
+        self.model_path = os.path.dirname(os.path.realpath(__file__))
+        self.model = load_model(self.model_path)
+
+    def execute(self, inputs):
+        tensor_inputs = {
+            name: torch.from_numpy(value) if isinstance(value, np.ndarray) else value
+            for name, value in inputs.items()
+        }
+        with torch.no_grad():
+            output = self.model(**tensor_inputs)
+
+        output_names = {{ output_names }}
+        if isinstance(output, dict):
+            return {
+                key: value.detach().cpu().numpy()
+                if isinstance(value, torch.Tensor)
+                else value
+                for key, value in output.items()
+            }
+        if isinstance(output, (tuple, list)):
+            return {
+                output_names[index] if index < len(output_names) else f"output_{index}": (
+                    value.detach().cpu().numpy()
+                    if isinstance(value, torch.Tensor)
+                    else value
+                )
+                for index, value in enumerate(output)
+            }
+        name = output_names[0] if output_names else "output"
+        return {
+            name: output.detach().cpu().numpy()
+            if isinstance(output, torch.Tensor)
+            else output
+        }
+
+
+def get_model():
+    return Model()

--- a/python/michelangelo/lib/model_manager/_private/packager/torch_triton/__init__.py
+++ b/python/michelangelo/lib/model_manager/_private/packager/torch_triton/__init__.py
@@ -1,0 +1,15 @@
+"""Torch Triton packager internals."""
+
+# flake8: noqa:F401
+from .config_pbtxt import generate_config_pbtxt_content
+from .model_package import generate_model_package_content
+from .raw_model_package import convert_to_state_dict, generate_raw_model_package_content
+from .type_yaml import generate_type_yaml
+from .user_model_py import generate_torch_python_user_model_content
+from .validation import (
+    validate_model_class,
+    validate_raw_model_file,
+    validate_raw_model_package,
+    validate_state_dict_file,
+    validate_torchscript_file,
+)

--- a/python/michelangelo/lib/model_manager/_private/packager/torch_triton/config_pbtxt.py
+++ b/python/michelangelo/lib/model_manager/_private/packager/torch_triton/config_pbtxt.py
@@ -1,0 +1,56 @@
+"""Generate Triton config.pbtxt content for torch packages."""
+
+from typing import Any, Optional
+
+from michelangelo.lib.model_manager._private.constants import TritonBackendType
+from michelangelo.lib.model_manager._private.packager.template_renderer import (
+    TritonTemplateRenderer,
+)
+from michelangelo.lib.model_manager._private.schema.triton import convert_model_schema
+from michelangelo.lib.model_manager.schema import ModelSchema
+
+
+def generate_config_pbtxt_content(
+    gen: TritonTemplateRenderer,
+    model_name: str,
+    model_revision: Optional[str],
+    model_schema: ModelSchema,
+    backend: str = TritonBackendType.TORCH,
+    enable_dynamic_batching: bool = True,
+    triton_parameters: Optional[dict[str, Any]] = None,
+) -> str:
+    """Generate Triton model configuration for a torch deployable package.
+
+    Args:
+        gen: Triton template renderer.
+        model_name: Model name to place in the Triton config.
+        model_revision: Optional revision suffix for the model name.
+        model_schema: Michelangelo model schema.
+        backend: Triton backend name.
+        enable_dynamic_batching: Whether to enable Triton dynamic batching.
+        triton_parameters: Optional template overrides such as
+            ``preferred_batch_size`` or ``instance_count``.
+
+    Returns:
+        Rendered ``config.pbtxt`` content.
+    """
+    input_schema, output_schema = convert_model_schema(model_schema)
+
+    if model_name and model_revision:
+        model_name = f"{model_name}-{model_revision}"
+
+    template_vars: dict[str, Any] = {
+        "model_name": model_name,
+        "backend": backend,
+        "max_batch_size": 256 if enable_dynamic_batching else 0,
+        "enable_dynamic_batching": enable_dynamic_batching,
+        "instance_count": 1,
+        "inputs": input_schema,
+        "outputs": output_schema,
+    }
+    if enable_dynamic_batching:
+        template_vars["max_queue_delay_microseconds"] = 300
+    if triton_parameters:
+        template_vars.update(triton_parameters)
+
+    return gen.render("config.pbtxt.tmpl", template_vars).rstrip() + "\n"

--- a/python/michelangelo/lib/model_manager/_private/packager/torch_triton/constants.py
+++ b/python/michelangelo/lib/model_manager/_private/packager/torch_triton/constants.py
@@ -1,0 +1,16 @@
+"""Constants for torch Triton packaging."""
+
+MODEL_PT_FILE_NAME = "model.pt"
+MODEL_CLASS_FILE_NAME = "model_class.txt"
+
+DEPLOYABLE_CONFIG_FILE_NAME = "config.pbtxt"
+DEPLOYABLE_MODEL_ONNX_FILE_NAME = "model.onnx"
+DEPLOYABLE_MODEL_PY_FILE_NAME = "model.py"
+DEPLOYABLE_USER_MODEL_PY_FILE_NAME = "user_model.py"
+DEPLOYABLE_SKELETON_FILE_NAME = "skeleton.yaml"
+
+RAW_TYPE_FILE_NAME = "type.yaml"
+RAW_SCHEMA_FILE_NAME = "schema.yaml"
+RAW_SAMPLE_DATA_FILE_NAME = "sample_data.json"
+RAW_HYPERPARAMETERS_FILE_NAME = "hyperparameters.yaml"
+RAW_REQUIREMENTS_FILE_NAME = "requirements.txt"

--- a/python/michelangelo/lib/model_manager/_private/packager/torch_triton/model_package.py
+++ b/python/michelangelo/lib/model_manager/_private/packager/torch_triton/model_package.py
@@ -1,0 +1,227 @@
+"""Generate deployable Triton packages for torch models."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+from michelangelo.lib.model_manager._private.constants import TritonBackendType
+from michelangelo.lib.model_manager._private.packager.custom_triton.model_class import (
+    serialize_model_class,
+)
+from michelangelo.lib.model_manager._private.packager.custom_triton.model_py import (
+    generate_model_py_content,
+)
+from michelangelo.lib.model_manager._private.packager.torch_triton.config_pbtxt import (
+    generate_config_pbtxt_content,
+)
+from michelangelo.lib.model_manager._private.packager.torch_triton.constants import (
+    DEPLOYABLE_CONFIG_FILE_NAME,
+    DEPLOYABLE_MODEL_ONNX_FILE_NAME,
+    DEPLOYABLE_MODEL_PY_FILE_NAME,
+    DEPLOYABLE_SKELETON_FILE_NAME,
+    DEPLOYABLE_USER_MODEL_PY_FILE_NAME,
+    MODEL_CLASS_FILE_NAME,
+    MODEL_PT_FILE_NAME,
+)
+from michelangelo.lib.model_manager._private.utils.asset_utils import download_assets
+from michelangelo.lib.model_manager.constants import StorageType
+
+from .onnx_conversion import convert_to_onnx
+from .raw_model_package import convert_to_state_dict
+from .torchscript_conversion import convert_to_torchscript
+from .user_model_py import generate_torch_python_user_model_content
+from .validation import validate_raw_model_file
+
+if TYPE_CHECKING:
+    from michelangelo.lib.artifact_manager import StorageBackend
+    from michelangelo.lib.model_manager._private.packager.template_renderer import (
+        TritonTemplateRenderer,
+    )
+    from michelangelo.lib.model_manager.schema import ModelSchema
+
+
+def _download_model_file(
+    model_path: str,
+    target_model_path: str,
+    model_path_source_type: str,
+    storage_backend: StorageBackend | None,
+) -> None:
+    """Download a model artifact into a target local file path."""
+    download_assets(
+        model_path,
+        target_model_path,
+        model_path_source_type,
+        storage_backend=storage_backend,
+    )
+
+
+def _serialize_model_definition(
+    model_class: str,
+    model_version_dir: str,
+    hyperparameters: dict | None,
+    include_import_prefixes: list[str] | None,
+) -> dict:
+    """Serialize model class metadata for Python-backend deployable packages."""
+    serialize_model_class(
+        model_class,
+        model_version_dir,
+        MODEL_CLASS_FILE_NAME,
+        include_import_prefixes=include_import_prefixes,
+        serialize_interface=False,
+    )
+    skeleton = (
+        hyperparameters
+        if hyperparameters and "_target_" in hyperparameters
+        else {"_target_": model_class, **(hyperparameters or {})}
+    )
+    skeleton_path = os.path.join(model_version_dir, DEPLOYABLE_SKELETON_FILE_NAME)
+    with open(skeleton_path, "w") as f:
+        yaml.safe_dump(skeleton, f, default_flow_style=False, sort_keys=False)
+    return {
+        MODEL_CLASS_FILE_NAME: (
+            f"file://{os.path.join(model_version_dir, MODEL_CLASS_FILE_NAME)}"
+        ),
+        DEPLOYABLE_SKELETON_FILE_NAME: f"file://{skeleton_path}",
+    }
+
+
+def _generate_python_backend_wrappers(
+    gen: TritonTemplateRenderer,
+    model_schema: ModelSchema,
+) -> dict:
+    """Generate Triton Python backend wrapper files."""
+    output_names = [item.name for item in model_schema.output_schema]
+    return {
+        DEPLOYABLE_MODEL_PY_FILE_NAME: generate_model_py_content(gen),
+        DEPLOYABLE_USER_MODEL_PY_FILE_NAME: generate_torch_python_user_model_content(
+            gen,
+            output_names,
+        ),
+    }
+
+
+def generate_model_package_content(
+    gen: TritonTemplateRenderer,
+    model_path: str,
+    model_name: str,
+    model_revision: str,
+    model_schema: ModelSchema,
+    model_path_source_type: str | None = StorageType.LOCAL,
+    root_path: str | None = None,
+    enable_dynamic_batching: bool = True,
+    model_class: str | None = None,
+    hyperparameters: dict | None = None,
+    backend: str | None = None,
+    include_import_prefixes: list[str] | None = None,
+    sample_data: list[dict[str, Any]] | None = None,
+    triton_parameters: dict[str, Any] | None = None,
+    storage_backend: StorageBackend | None = None,
+) -> dict:
+    """Generate deployable Triton package content for a torch model.
+
+    Args:
+        gen: Triton template renderer.
+        model_path: Path or storage URI for a torch or ONNX artifact.
+        model_name: Model name to place in ``config.pbtxt``.
+        model_revision: Optional revision suffix.
+        model_schema: Model schema for Triton config generation.
+        model_path_source_type: Source type for local artifacts.
+        root_path: Root directory used to stage package files.
+        enable_dynamic_batching: Whether to enable Triton dynamic batching.
+        model_class: Required for Python backend and state-dict conversion.
+        hyperparameters: Constructor keyword arguments for ``model_class``.
+        backend: Triton backend. Defaults to ``pytorch``.
+        include_import_prefixes: Import prefixes to include for Python backend.
+        sample_data: Optional sample input for ONNX export.
+        triton_parameters: Optional Triton config template overrides.
+        storage_backend: Optional backend used to download remote artifacts.
+
+    Returns:
+        Folder content dictionary consumable by ``generate_folder``.
+    """
+    if not root_path:
+        root_path = tempfile.mkdtemp()
+    if backend is None:
+        backend = TritonBackendType.TORCH
+
+    config_pbtxt = generate_config_pbtxt_content(
+        gen,
+        model_name,
+        model_revision,
+        model_schema,
+        backend=backend,
+        enable_dynamic_batching=enable_dynamic_batching,
+        triton_parameters=triton_parameters,
+    )
+
+    model_version_dir = os.path.join(root_path, "0")
+    os.makedirs(model_version_dir, exist_ok=True)
+    content: dict[str, Any] = {DEPLOYABLE_CONFIG_FILE_NAME: config_pbtxt, "0": {}}
+
+    if backend == TritonBackendType.PYTHON:
+        target_model_path = os.path.join(model_version_dir, MODEL_PT_FILE_NAME)
+        _download_model_file(
+            model_path,
+            target_model_path,
+            model_path_source_type,
+            storage_backend,
+        )
+        is_valid, error = validate_raw_model_file(target_model_path)
+        if not is_valid:
+            raise error
+        convert_to_state_dict(target_model_path)
+
+        model_subdir = os.path.join(model_version_dir, "model")
+        os.makedirs(model_subdir, exist_ok=True)
+        final_model_path = os.path.join(model_subdir, MODEL_PT_FILE_NAME)
+        os.replace(target_model_path, final_model_path)
+
+        content["0"].update(
+            _serialize_model_definition(
+                model_class,
+                model_version_dir,
+                hyperparameters,
+                include_import_prefixes,
+            )
+        )
+        content["0"].update(_generate_python_backend_wrappers(gen, model_schema))
+        content["0"]["model"] = {MODEL_PT_FILE_NAME: f"file://{final_model_path}"}
+    elif backend == TritonBackendType.ONNX:
+        with tempfile.TemporaryDirectory() as staging_dir:
+            staging_path = os.path.join(staging_dir, "model")
+            _download_model_file(
+                model_path,
+                staging_path,
+                model_path_source_type,
+                storage_backend,
+            )
+            final_onnx_path = os.path.join(
+                model_version_dir,
+                DEPLOYABLE_MODEL_ONNX_FILE_NAME,
+            )
+            convert_to_onnx(
+                staging_path,
+                final_onnx_path,
+                model_schema,
+                sample_data=sample_data[0] if sample_data else None,
+                model_class=model_class,
+                hyperparameters=hyperparameters,
+                enable_dynamic_batching=enable_dynamic_batching,
+            )
+        content["0"][DEPLOYABLE_MODEL_ONNX_FILE_NAME] = f"file://{final_onnx_path}"
+    else:
+        target_model_path = os.path.join(model_version_dir, MODEL_PT_FILE_NAME)
+        _download_model_file(
+            model_path,
+            target_model_path,
+            model_path_source_type,
+            storage_backend,
+        )
+        convert_to_torchscript(target_model_path, model_class, hyperparameters)
+        content["0"][MODEL_PT_FILE_NAME] = f"file://{target_model_path}"
+
+    return content

--- a/python/michelangelo/lib/model_manager/_private/packager/torch_triton/onnx_conversion.py
+++ b/python/michelangelo/lib/model_manager/_private/packager/torch_triton/onnx_conversion.py
@@ -1,0 +1,114 @@
+"""Utilities for preparing ONNX deployable artifacts."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import torch
+
+from michelangelo._internal.utils.reflection_utils import get_module_attr
+
+from .torchscript_conversion import is_state_dict
+
+if TYPE_CHECKING:
+    from michelangelo.lib.model_manager.schema import ModelSchema
+
+OPSET_VERSION = 14
+
+
+def _load_torch_model(
+    source_model_path: str,
+    model_class: str | None,
+    hyperparameters: dict | None,
+) -> torch.nn.Module:
+    """Load a torch module from a local artifact."""
+    loaded_model = torch.load(source_model_path, map_location="cpu", weights_only=False)
+    if is_state_dict(loaded_model):
+        if not model_class:
+            raise ValueError("model_class is required when exporting a state_dict")
+        model_type = get_module_attr(model_class)
+        model = model_type(**(hyperparameters or {}))
+        model.load_state_dict(loaded_model)
+    else:
+        model = loaded_model
+
+    if not isinstance(model, torch.nn.Module):
+        raise TypeError(f"Artifact is not a torch.nn.Module: {source_model_path}")
+
+    model.eval()
+    return model
+
+
+def _prepare_sample_inputs(
+    input_names: list[str],
+    sample_data: dict[str, Any],
+) -> tuple[torch.Tensor, ...]:
+    """Convert sample data into tracing inputs in schema order."""
+    sample_inputs: list[torch.Tensor] = []
+    for name in input_names:
+        if name not in sample_data:
+            raise ValueError(f"sample_data missing required input {name!r}")
+        value = sample_data[name]
+        if isinstance(value, torch.Tensor):
+            tensor = value
+        elif isinstance(value, np.ndarray):
+            tensor = torch.from_numpy(value)
+        else:
+            raise TypeError(
+                f"Sample data for {name!r} must be torch.Tensor or numpy.ndarray"
+            )
+        if tensor.ndim == len(tensor.shape):
+            tensor = tensor.unsqueeze(0)
+        sample_inputs.append(tensor)
+    return tuple(sample_inputs)
+
+
+def convert_to_onnx(
+    source_model_path: str,
+    dest_onnx_path: str,
+    model_schema: ModelSchema,
+    sample_data: dict[str, Any] | None = None,
+    model_class: str | None = None,
+    hyperparameters: dict | None = None,
+    enable_dynamic_batching: bool = True,
+) -> None:
+    """Copy or export a torch artifact into ONNX format.
+
+    Args:
+        source_model_path: Local source artifact path.
+        dest_onnx_path: Destination ``model.onnx`` path.
+        model_schema: Model schema used for input and output names.
+        sample_data: Sample input batch used for torch-to-ONNX tracing.
+        model_class: Import path for state-dict artifacts.
+        hyperparameters: Constructor keyword arguments for ``model_class``.
+        enable_dynamic_batching: Whether to mark batch dimension as dynamic.
+    """
+    if source_model_path.endswith(".onnx"):
+        shutil.copy2(source_model_path, dest_onnx_path)
+        return
+
+    if not sample_data:
+        raise ValueError("sample_data is required to export a torch artifact to ONNX")
+
+    model = _load_torch_model(source_model_path, model_class, hyperparameters)
+    input_names = [item.name for item in model_schema.input_schema]
+    output_names = [item.name for item in model_schema.output_schema]
+    sample_inputs = _prepare_sample_inputs(input_names, sample_data)
+    dynamic_axes = (
+        {name: {0: "batch"} for name in [*input_names, *output_names]}
+        if enable_dynamic_batching
+        else None
+    )
+    os.makedirs(os.path.dirname(dest_onnx_path), exist_ok=True)
+    torch.onnx.export(
+        model,
+        sample_inputs,
+        dest_onnx_path,
+        input_names=input_names,
+        output_names=output_names,
+        opset_version=OPSET_VERSION,
+        dynamic_axes=dynamic_axes,
+    )

--- a/python/michelangelo/lib/model_manager/_private/packager/torch_triton/raw_model_package.py
+++ b/python/michelangelo/lib/model_manager/_private/packager/torch_triton/raw_model_package.py
@@ -1,0 +1,188 @@
+"""Generate raw model packages for torch models."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from typing import TYPE_CHECKING
+
+import torch
+import yaml
+
+from michelangelo.lib.model_manager._private.packager.custom_triton.model_class import (
+    serialize_model_class,
+)
+from michelangelo.lib.model_manager._private.packager.custom_triton.requirements_txt import (  # noqa: E501
+    generate_requirements_txt,
+)
+from michelangelo.lib.model_manager._private.packager.torch_triton.constants import (
+    MODEL_CLASS_FILE_NAME,
+    MODEL_PT_FILE_NAME,
+    RAW_HYPERPARAMETERS_FILE_NAME,
+    RAW_REQUIREMENTS_FILE_NAME,
+    RAW_SAMPLE_DATA_FILE_NAME,
+    RAW_SCHEMA_FILE_NAME,
+    RAW_TYPE_FILE_NAME,
+)
+from michelangelo.lib.model_manager._private.packager.torch_triton.type_yaml import (
+    generate_type_yaml,
+)
+from michelangelo.lib.model_manager._private.packager.torch_triton.validation import (
+    validate_raw_model_file,
+)
+from michelangelo.lib.model_manager._private.schema.common import schema_to_yaml
+from michelangelo.lib.model_manager._private.serde.data import dump_model_data
+from michelangelo.lib.model_manager._private.utils.asset_utils import download_assets
+from michelangelo.lib.model_manager.constants import StorageType
+
+if TYPE_CHECKING:
+    from numpy import ndarray
+
+    from michelangelo.lib.artifact_manager import StorageBackend
+    from michelangelo.lib.model_manager.schema import ModelSchema
+
+
+def convert_to_state_dict(model_path: str) -> None:
+    """Convert a saved torch module to state-dict format in place if needed.
+
+    Args:
+        model_path: Local path to a torch ``.pt`` or ``.pth`` artifact.
+
+    Raises:
+        FileNotFoundError: If ``model_path`` does not exist.
+        ValueError: If the artifact cannot be represented as a state dict.
+    """
+    if not os.path.exists(model_path):
+        raise FileNotFoundError(f"File does not exist: {model_path}")
+
+    try:
+        state_dict = torch.load(model_path, map_location="cpu", weights_only=True)
+        if isinstance(state_dict, dict):
+            return
+    except Exception:
+        pass
+
+    try:
+        model = torch.load(model_path, map_location="cpu", weights_only=False)
+        if not hasattr(model, "state_dict"):
+            raise ValueError(f"File does not contain a convertible model: {model_path}")
+        torch.save(model.state_dict(), model_path)
+    except Exception as exc:
+        raise ValueError(
+            f"File does not contain a convertible model: {model_path}"
+        ) from exc
+
+
+def _stage_model_file(
+    model_path: str,
+    model_path_source_type: str,
+    model_dir: str,
+    storage_backend: StorageBackend | None,
+) -> str:
+    """Download and normalize a torch artifact into ``model/model.pt``."""
+    model_file_path = os.path.join(model_dir, MODEL_PT_FILE_NAME)
+    with tempfile.TemporaryDirectory() as temp_dir:
+        downloaded_model = os.path.join(temp_dir, "model")
+        download_assets(
+            model_path,
+            downloaded_model,
+            model_path_source_type,
+            storage_backend=storage_backend,
+        )
+        if os.path.isdir(downloaded_model):
+            pt_files = [
+                name for name in os.listdir(downloaded_model) if name.endswith(".pt")
+            ]
+            if not pt_files:
+                raise ValueError(f"No .pt files found in {downloaded_model}")
+            if len(pt_files) > 1:
+                raise ValueError(
+                    f"Multiple .pt files found in {downloaded_model}: {pt_files}"
+                )
+            shutil.move(os.path.join(downloaded_model, pt_files[0]), model_file_path)
+        else:
+            shutil.move(downloaded_model, model_file_path)
+    return model_file_path
+
+
+def generate_raw_model_package_content(
+    model_path: str,
+    model_class: str,
+    model_schema: ModelSchema,
+    sample_data: list[dict[str, ndarray]],
+    model_path_source_type: str | None = StorageType.LOCAL,
+    requirements: list[str] | str | None = None,
+    root_path: str | None = None,
+    include_import_prefixes: list[str] | None = None,
+    hyperparameters: dict | None = None,
+    storage_backend: StorageBackend | None = None,
+) -> dict:
+    """Generate raw model package content for a torch model.
+
+    Args:
+        model_path: Path or storage URI for a torch artifact.
+        model_class: Fully qualified ``torch.nn.Module`` class path.
+        model_schema: Model schema for metadata and validation.
+        sample_data: Sample inputs used by validators and downstream tooling.
+        model_path_source_type: Source type for local artifacts.
+        requirements: Optional requirements list or requirements file path.
+        root_path: Root directory used to stage package files.
+        include_import_prefixes: Import prefixes to include in ``defs``.
+        hyperparameters: Constructor keyword arguments for ``model_class``.
+        storage_backend: Optional backend used to download remote artifacts.
+
+    Returns:
+        Folder content dictionary consumable by ``generate_folder``.
+    """
+    if not root_path:
+        root_path = tempfile.mkdtemp()
+
+    model_dir = os.path.join(root_path, "model")
+    os.makedirs(model_dir, exist_ok=True)
+    model_file_path = _stage_model_file(
+        model_path,
+        model_path_source_type,
+        model_dir,
+        storage_backend,
+    )
+
+    is_valid, error = validate_raw_model_file(model_file_path)
+    if not is_valid:
+        raise error
+    convert_to_state_dict(model_file_path)
+
+    defs_path = os.path.join(root_path, "defs")
+    serialize_model_class(
+        model_class,
+        defs_path,
+        MODEL_CLASS_FILE_NAME,
+        include_import_prefixes=include_import_prefixes,
+        serialize_interface=False,
+    )
+
+    metadata_content = {
+        RAW_TYPE_FILE_NAME: generate_type_yaml(),
+        RAW_SCHEMA_FILE_NAME: schema_to_yaml(model_schema),
+        RAW_SAMPLE_DATA_FILE_NAME: dump_model_data(sample_data),
+    }
+    if hyperparameters is not None:
+        metadata_content[RAW_HYPERPARAMETERS_FILE_NAME] = yaml.safe_dump(
+            hyperparameters,
+            default_flow_style=False,
+            sort_keys=False,
+        )
+
+    if requirements is None:
+        requirements = ["torch"]
+    elif isinstance(requirements, list) and "torch" not in requirements:
+        requirements = [*requirements, "torch"]
+
+    return {
+        "metadata": metadata_content,
+        "model": f"dir://{model_dir}",
+        "defs": f"dir://{defs_path}",
+        "dependencies": {
+            RAW_REQUIREMENTS_FILE_NAME: generate_requirements_txt(requirements),
+        },
+    }

--- a/python/michelangelo/lib/model_manager/_private/packager/torch_triton/torchscript_conversion.py
+++ b/python/michelangelo/lib/model_manager/_private/packager/torch_triton/torchscript_conversion.py
@@ -1,0 +1,62 @@
+"""Utilities for preparing torchscript deployable artifacts."""
+
+import os
+from typing import Optional
+
+import torch
+
+from michelangelo._internal.utils.reflection_utils import get_module_attr
+
+
+def is_state_dict(value: object) -> bool:
+    """Return whether a loaded torch object looks like a state dict."""
+    return isinstance(value, dict) and all(isinstance(key, str) for key in value)
+
+
+def convert_to_torchscript(
+    model_path: str,
+    model_class: Optional[str] = None,
+    hyperparameters: Optional[dict] = None,
+) -> None:
+    """Convert a torch artifact in place to torchscript when needed.
+
+    Args:
+        model_path: Local path to a ``.pt`` or ``.pth`` artifact.
+        model_class: Import path for the model class when ``model_path``
+            contains a state dict.
+        hyperparameters: Constructor keyword arguments for ``model_class``.
+
+    Raises:
+        FileNotFoundError: If ``model_path`` does not exist.
+        TypeError: If the artifact cannot be converted to torchscript.
+        ValueError: If a state dict is provided without ``model_class``.
+    """
+    if not os.path.exists(model_path):
+        raise FileNotFoundError(f"File does not exist: {model_path}")
+
+    try:
+        torch.jit.load(model_path, map_location="cpu")
+        return
+    except Exception:
+        pass
+
+    try:
+        loaded_model = torch.load(model_path, map_location="cpu", weights_only=False)
+        if is_state_dict(loaded_model):
+            if not model_class:
+                raise ValueError("model_class is required for state_dict artifacts")
+            model_type = get_module_attr(model_class)
+            model = model_type(**(hyperparameters or {}))
+            model.load_state_dict(loaded_model)
+        else:
+            model = loaded_model
+
+        if not isinstance(model, torch.nn.Module):
+            raise TypeError("Artifact does not contain a torch.nn.Module")
+
+        model.eval()
+        torch.jit.save(torch.jit.script(model), model_path)
+    except Exception as exc:
+        raise TypeError(
+            f"File does not contain a torchscript-convertible model: {model_path}"
+        ) from exc

--- a/python/michelangelo/lib/model_manager/_private/packager/torch_triton/type_yaml.py
+++ b/python/michelangelo/lib/model_manager/_private/packager/torch_triton/type_yaml.py
@@ -1,0 +1,12 @@
+"""Generate metadata for torch raw model packages."""
+
+from michelangelo.lib.model_manager.constants import RawModelType
+
+
+def generate_type_yaml() -> str:
+    """Generate the raw model type metadata.
+
+    Returns:
+        YAML content describing the raw package as a torch model.
+    """
+    return f"type: {RawModelType.TORCH}\n"

--- a/python/michelangelo/lib/model_manager/_private/packager/torch_triton/user_model_py.py
+++ b/python/michelangelo/lib/model_manager/_private/packager/torch_triton/user_model_py.py
@@ -1,0 +1,21 @@
+"""Generate Triton Python backend user model wrapper for torch models."""
+
+from michelangelo.lib.model_manager._private.packager.template_renderer import (
+    TritonTemplateRenderer,
+)
+
+
+def generate_torch_python_user_model_content(
+    gen: TritonTemplateRenderer,
+    output_names: list[str],
+) -> str:
+    """Generate ``user_model.py`` content for the torch Python backend.
+
+    Args:
+        gen: Triton template renderer.
+        output_names: Output field names from the model schema.
+
+    Returns:
+        Rendered Python backend wrapper content.
+    """
+    return gen.render("torch_python/user_model.py.tmpl", {"output_names": output_names})

--- a/python/michelangelo/lib/model_manager/_private/packager/torch_triton/validation.py
+++ b/python/michelangelo/lib/model_manager/_private/packager/torch_triton/validation.py
@@ -1,0 +1,200 @@
+"""Validation utilities for torch Triton packages."""
+
+from __future__ import annotations
+
+import inspect
+import os
+from typing import TYPE_CHECKING, Any
+
+import torch
+from numpy import ndarray
+
+from michelangelo._internal.utils.reflection_utils import get_module_attr
+from michelangelo.lib.model_manager._private.utils.data_utils import (
+    validate_output_data,
+    validate_output_data_with_model_schema,
+)
+from michelangelo.lib.model_manager.serde.model import load_raw_model
+
+if TYPE_CHECKING:
+    from michelangelo.lib.model_manager.schema import ModelSchema, ModelSchemaItem
+
+
+def _validate_file_basics(
+    file_path: str,
+    allowed_extensions: tuple[str, ...] = (".pt", ".pth"),
+) -> Exception | None:
+    """Validate common torch artifact file properties."""
+    if not os.path.exists(file_path):
+        return FileNotFoundError(f"Torch file not found: {file_path}")
+    if os.path.isdir(file_path):
+        return ValueError(f"Path is not a file: {file_path}")
+    if not file_path.endswith(allowed_extensions):
+        return ValueError(f"File must have {allowed_extensions} extension: {file_path}")
+    if os.path.getsize(file_path) == 0:
+        return ValueError(f"File is empty: {file_path}")
+    return None
+
+
+def validate_state_dict_file(model_path: str) -> tuple[bool, Exception | None]:
+    """Validate that a torch artifact contains a state dict."""
+    try:
+        if error := _validate_file_basics(model_path):
+            return False, error
+        state_dict = torch.load(model_path, map_location="cpu", weights_only=True)
+        if isinstance(state_dict, dict):
+            return True, None
+        return False, ValueError(f"File does not contain a state dict: {model_path}")
+    except Exception as exc:
+        return False, RuntimeError(f"Cannot load file as state dict: {exc}")
+
+
+def validate_torchscript_file(model_path: str) -> tuple[bool, Exception | None]:
+    """Validate that a torch artifact is loadable as torchscript."""
+    try:
+        if error := _validate_file_basics(model_path):
+            return False, error
+        torch.jit.load(model_path, map_location="cpu")
+    except Exception as exc:
+        return False, RuntimeError(f"File is not valid torchscript: {exc}")
+    return True, None
+
+
+def validate_pytorch_model_file(model_path: str) -> tuple[bool, Exception | None]:
+    """Validate that a torch artifact contains a ``torch.nn.Module``."""
+    try:
+        if error := _validate_file_basics(model_path):
+            return False, error
+        model = torch.load(model_path, map_location="cpu", weights_only=False)
+        if not isinstance(model, torch.nn.Module) and not isinstance(model, dict):
+            return False, ValueError("File must contain a torch module or state dict")
+    except Exception as exc:
+        return False, RuntimeError(f"Cannot load as a torch model: {exc}")
+    return True, None
+
+
+def validate_raw_model_file(model_path: str) -> tuple[bool, Exception | None]:
+    """Validate a torch file for raw-model packaging."""
+    is_state_dict, _ = validate_state_dict_file(model_path)
+    if is_state_dict:
+        return True, None
+    return validate_pytorch_model_file(model_path)
+
+
+def validate_model_class(model_class: str) -> tuple[bool, Exception | None]:
+    """Validate that ``model_class`` is an importable ``torch.nn.Module`` type."""
+    try:
+        model_type = get_module_attr(model_class)
+    except (AttributeError, ImportError, ValueError) as exc:
+        return False, exc
+    if not inspect.isclass(model_type) or not issubclass(model_type, torch.nn.Module):
+        return False, TypeError(
+            f"Model class {model_class} must subclass torch.nn.Module"
+        )
+    return True, None
+
+
+def _add_batch_dimension(value: Any) -> Any:
+    """Add a batch dimension to ndarray/tensor sample values."""
+    if isinstance(value, ndarray):
+        return torch.from_numpy(value).unsqueeze(0)
+    if isinstance(value, torch.Tensor):
+        return value.unsqueeze(0)
+    raise TypeError(
+        f"Torch sample values must be numpy.ndarray or torch.Tensor, got {type(value)}"
+    )
+
+
+def _remove_batch_dimension(
+    output: torch.Tensor,
+    output_schema: ModelSchemaItem | None,
+) -> ndarray:
+    """Convert batched tensor output to an ndarray matching schema rank."""
+    output_array = output.squeeze(0).detach().cpu().numpy()
+    expected_ndim = len(output_schema.shape) if output_schema else 1
+    if output_array.ndim == 0 and expected_ndim > 0:
+        output_array = output_array.reshape(-1)
+    return output_array
+
+
+def _normalize_output(output: Any, model_schema: ModelSchema) -> dict[str, Any]:
+    """Normalize torch outputs into a schema-keyed dictionary."""
+    if isinstance(output, dict):
+        return {
+            key: value.detach().cpu().numpy()
+            if isinstance(value, torch.Tensor)
+            else value
+            for key, value in output.items()
+        }
+    if isinstance(output, torch.Tensor):
+        schema_item = (
+            model_schema.output_schema[0] if model_schema.output_schema else None
+        )
+        output_name = schema_item.name if schema_item else "output"
+        return {output_name: _remove_batch_dimension(output, schema_item)}
+    if isinstance(output, (tuple, list)):
+        result = {}
+        for index, value in enumerate(output):
+            schema_item = (
+                model_schema.output_schema[index]
+                if index < len(model_schema.output_schema)
+                else None
+            )
+            output_name = schema_item.name if schema_item else f"output_{index}"
+            result[output_name] = (
+                _remove_batch_dimension(value, schema_item)
+                if isinstance(value, torch.Tensor)
+                else value
+            )
+        return result
+    raise TypeError(f"Unsupported torch model output type: {type(output)}")
+
+
+def _invoke_model(model: torch.nn.Module, batch_dict: dict[str, Any]) -> Any:
+    """Invoke a torch model using keyword inputs or a single dict input."""
+    try:
+        return model(**batch_dict)
+    except TypeError:
+        return model(batch_dict)
+
+
+def validate_raw_model_package(
+    package_path: str,
+    sample_data: list[dict[str, ndarray]] | dict[str, ndarray] | None = None,
+    model_schema: ModelSchema | None = None,
+) -> None:
+    """Validate a generated torch raw model package.
+
+    Args:
+        package_path: Path to the generated package directory.
+        sample_data: Optional sample data used to run a forward pass.
+        model_schema: Optional schema used to validate forward-pass output.
+    """
+    model_dir = os.path.join(package_path, "model")
+    defs_path = os.path.join(package_path, "defs")
+    if not os.path.isdir(model_dir):
+        raise FileNotFoundError(f"Required directory missing: {model_dir}")
+    if not os.path.exists(os.path.join(defs_path, "model_class.txt")):
+        raise FileNotFoundError("Missing defs/model_class.txt in torch package")
+
+    pt_files = [name for name in os.listdir(model_dir) if name.endswith(".pt")]
+    if not pt_files:
+        raise FileNotFoundError(f"No .pt file found in {model_dir}")
+    is_valid, error = validate_raw_model_file(os.path.join(model_dir, pt_files[0]))
+    if not is_valid:
+        raise RuntimeError(f"Invalid raw model file: {error}") from error
+
+    if sample_data and model_schema:
+        model = load_raw_model(package_path)
+        model.eval()
+        data = sample_data[0] if isinstance(sample_data, list) else sample_data
+        batch_dict = {key: _add_batch_dimension(value) for key, value in data.items()}
+        with torch.no_grad():
+            output = _normalize_output(_invoke_model(model, batch_dict), model_schema)
+
+        is_valid, error = validate_output_data(output)
+        if not is_valid:
+            raise error
+        is_valid, error = validate_output_data_with_model_schema(output, model_schema)
+        if not is_valid:
+            raise error

--- a/python/michelangelo/lib/model_manager/_private/serde/loader/torch_model_loader.py
+++ b/python/michelangelo/lib/model_manager/_private/serde/loader/torch_model_loader.py
@@ -1,0 +1,64 @@
+"""Torch model loader for raw model packages."""
+
+import os
+from typing import Optional
+
+import torch
+
+
+def _instantiate(spec: dict):
+    """Instantiate a simple Hydra-style ``{"_target_": ...}`` spec."""
+    if "_target_" not in spec:
+        return spec
+    import importlib
+
+    target = spec["_target_"]
+    module_name, class_name = target.rsplit(".", 1)
+    model_type = getattr(importlib.import_module(module_name), class_name)
+    kwargs = {
+        key: _instantiate(value) if isinstance(value, dict) else value
+        for key, value in spec.items()
+        if key != "_target_"
+    }
+    return model_type(**kwargs)
+
+
+def load_torch_model(
+    model_bin_path: str,
+    model_class: type,
+    spec: Optional[dict] = None,
+) -> torch.nn.Module:
+    """Load a torch model from a state-dict raw package.
+
+    Args:
+        model_bin_path: Path to the package ``model`` directory.
+        model_class: ``torch.nn.Module`` class to instantiate.
+        spec: Optional constructor kwargs or Hydra-style target spec.
+
+    Returns:
+        Loaded model in eval mode.
+    """
+    pt_files = [name for name in os.listdir(model_bin_path) if name.endswith(".pt")]
+    if not pt_files:
+        raise FileNotFoundError(f"No .pt file found in {model_bin_path}")
+
+    model_file_path = os.path.join(model_bin_path, pt_files[0])
+    try:
+        state_dict = torch.load(model_file_path, map_location="cpu", weights_only=True)
+    except Exception as exc:
+        raise RuntimeError(
+            f"Failed to load state_dict from {model_file_path}: {exc}"
+        ) from exc
+    if not isinstance(state_dict, dict):
+        raise TypeError(f"Expected state_dict format, got {type(state_dict)}")
+
+    if spec and "_target_" in spec:
+        model = _instantiate(spec)
+    elif spec:
+        model = model_class(**spec)
+    else:
+        model = model_class()
+
+    model.load_state_dict(state_dict)
+    model.eval()
+    return model

--- a/python/michelangelo/lib/model_manager/_private/serde/model/__init__.py
+++ b/python/michelangelo/lib/model_manager/_private/serde/model/__init__.py
@@ -3,3 +3,4 @@
 # flake8: noqa:F401
 from .custom_raw_model import load_custom_raw_model
 from .raw_model_type import get_raw_model_type
+from .torch_raw_model import load_torch_raw_model

--- a/python/michelangelo/lib/model_manager/_private/serde/model/torch_raw_model.py
+++ b/python/michelangelo/lib/model_manager/_private/serde/model/torch_raw_model.py
@@ -1,0 +1,85 @@
+"""Torch raw model loader."""
+
+import os
+import sys
+from typing import Optional
+
+import yaml
+
+from michelangelo.lib.model_manager._private.serde.loader.torch_model_loader import (
+    load_torch_model,
+)
+from michelangelo.lib.model_manager._private.serde.model.custom_raw_model import (
+    create_alternative_defs,
+)
+
+
+def _import_model_class(defs_path: str, model_class: str) -> type:
+    """Import a model class from the environment or packaged definitions."""
+    module_name, _, class_name = model_class.rpartition(".")
+    if not module_name or not class_name:
+        raise ValueError(
+            f"Invalid model class definition {model_class}. "
+            "Please specify the full import path to the model class."
+        )
+
+    try:
+        module = __import__(module_name, fromlist=[class_name])
+    except (ImportError, ModuleNotFoundError):
+        sys.path.append(os.path.abspath(defs_path))
+        try:
+            module = __import__(module_name, fromlist=[class_name])
+        except (ImportError, ModuleNotFoundError):
+            new_defs_path, wrapper_name = create_alternative_defs(defs_path)
+            sys.path.append(new_defs_path)
+            module = __import__(
+                f"{wrapper_name}.defs.{module_name}",
+                fromlist=[class_name],
+            )
+
+    try:
+        return getattr(module, class_name)
+    except AttributeError as exc:
+        raise AttributeError(
+            f"Class {class_name} not found in module {module_name}."
+        ) from exc
+
+
+def load_torch_raw_model(
+    model_path: str,
+    submodule: Optional[str] = None,
+):
+    """Load a torch raw model package.
+
+    Args:
+        model_path: Path to the raw model package.
+        submodule: Reserved for compatibility with existing callers. Submodule
+            extraction is not supported in OSS yet.
+
+    Returns:
+        Loaded ``torch.nn.Module`` instance.
+    """
+    if submodule is not None:
+        raise NotImplementedError("submodule loading is not supported in OSS yet")
+
+    model_bin_path = os.path.join(model_path, "model")
+    defs_path = os.path.join(model_path, "defs")
+    model_class_path = os.path.join(defs_path, "model_class.txt")
+    if not os.path.exists(model_class_path):
+        raise ValueError("Missing defs/model_class.txt in the model package.")
+
+    with open(model_class_path) as f:
+        model_class = f.read().strip()
+    if not model_class:
+        raise ValueError("defs/model_class.txt is empty in the model package.")
+
+    spec = None
+    hyperparameters_path = os.path.join(model_path, "metadata", "hyperparameters.yaml")
+    if os.path.exists(hyperparameters_path):
+        with open(hyperparameters_path) as f:
+            spec = yaml.safe_load(f) or {}
+        if spec and "_target_" in spec:
+            model_class = spec["_target_"]
+
+    model_type = _import_model_class(defs_path, model_class)
+    return load_torch_model(model_bin_path, model_type, spec=spec)

--- a/python/michelangelo/lib/model_manager/_private/utils/asset_utils/download.py
+++ b/python/michelangelo/lib/model_manager/_private/utils/asset_utils/download.py
@@ -1,15 +1,22 @@
 """Asset download module."""
 
+from __future__ import annotations
+
 import os
 import shutil
+from typing import TYPE_CHECKING
 
 from michelangelo.lib.model_manager.constants import StorageType
+
+if TYPE_CHECKING:
+    from michelangelo.lib.artifact_manager import StorageBackend
 
 
 def download_assets(
     src: str,
     des: str,
     source_type: str,
+    storage_backend: StorageBackend | None = None,
 ):
     """Download the assets from source to destination.
 
@@ -17,10 +24,24 @@ def download_assets(
         src: The path of the source
         des: The destination path to store the assets.
         source_type: The source type of the source path,
-            either 'hdfs', 'terrablob' or 'local'
+            currently only ``StorageType.LOCAL`` is supported without an
+            injected storage backend.
+        storage_backend: Optional storage backend used to download non-local
+            artifact URIs. This mirrors the pusher's storage abstraction.
     """
+    if storage_backend is not None:
+        storage_backend.download(src, des)
+        return
+
     if source_type == StorageType.LOCAL and src != des:
         if os.path.isdir(src):
             shutil.copytree(src, des, dirs_exist_ok=True)
         else:
             shutil.copy(src, des)
+        return
+
+    if source_type != StorageType.LOCAL:
+        raise ValueError(
+            f"Unsupported source_type {source_type!r}. Pass a StorageBackend "
+            "to download remote artifacts."
+        )

--- a/python/michelangelo/lib/model_manager/packager/custom_triton/custom_triton_packager.py
+++ b/python/michelangelo/lib/model_manager/packager/custom_triton/custom_triton_packager.py
@@ -1,6 +1,9 @@
 """Packager for custom Triton models."""
 
+from __future__ import annotations
+
 import tempfile
+from typing import TYPE_CHECKING
 from typing import Optional, Union
 
 from numpy import ndarray
@@ -26,6 +29,9 @@ from michelangelo.lib.model_manager._private.utils.data_utils import (
 from michelangelo.lib.model_manager.constants import StorageType
 from michelangelo.lib.model_manager.schema import ModelSchema
 
+if TYPE_CHECKING:
+    from michelangelo.lib.artifact_manager import StorageBackend
+
 
 class CustomTritonPackager:
     """Packager for custom Triton Python models.
@@ -45,7 +51,11 @@ class CustomTritonPackager:
             the model implementation.
     """
 
-    def __init__(self, custom_batch_processing: Optional[bool] = False):
+    def __init__(
+        self,
+        custom_batch_processing: Optional[bool] = False,
+        storage_backend: StorageBackend | None = None,
+    ):
         """Create a CustomTritonPackager instance.
 
         Args:
@@ -61,9 +71,13 @@ class CustomTritonPackager:
                 additional leading batch dimension. For example, if the schema
                 specifies shape [n, ..., m], the actual input shape will be
                 [batch_size, n, ..., m].
+            storage_backend: Optional storage backend used to download model
+                artifacts when ``model_path`` is a backend URI. If omitted,
+                ``model_path`` is treated as a local filesystem path.
         """
         self.gen = TritonTemplateRenderer()
         self.custom_batch_processing = custom_batch_processing
+        self.storage_backend = storage_backend
 
     def create_model_package(
         self,
@@ -109,6 +123,10 @@ class CustomTritonPackager:
                 example, ['uber', 'data.michelangelo'] will only include modules
                 starting with 'uber' or 'data.michelangelo'. If None or empty,
                 all imported modules will be included.
+            storage_backend: Configure this on the packager constructor when
+                ``model_path`` points to non-local artifact storage. The
+                packager downloads through that backend and still returns a
+                local package path for pusher upload.
 
         Returns:
             The absolute path to the generated model package directory.
@@ -146,6 +164,7 @@ class CustomTritonPackager:
             root_path=dest_model_path,
             include_import_prefixes=include_import_prefixes,
             custom_batch_processing=self.custom_batch_processing,
+            storage_backend=self.storage_backend,
         )
 
         generate_folder(content, dest_model_path)
@@ -207,6 +226,10 @@ class CustomTritonPackager:
                 example, ['uber', 'data.michelangelo'] will only include modules
                 starting with 'uber' or 'data.michelangelo'. If None or empty,
                 all imported modules will be included.
+            storage_backend: Configure this on the packager constructor when
+                ``model_path`` points to non-local artifact storage. The
+                packager downloads through that backend and still returns a
+                local package path for pusher upload.
 
         Returns:
             The absolute path to the generated raw model package directory.
@@ -257,6 +280,7 @@ class CustomTritonPackager:
             root_path=dest_model_path,
             include_import_prefixes=include_import_prefixes,
             batch_inference=batch_inference,
+            storage_backend=self.storage_backend,
         )
 
         generate_folder(content, dest_model_path)

--- a/python/michelangelo/lib/model_manager/packager/torch_triton/__init__.py
+++ b/python/michelangelo/lib/model_manager/packager/torch_triton/__init__.py
@@ -1,0 +1,4 @@
+"""Torch Triton model packager."""
+
+# flake8: noqa:F401
+from .torch_triton_packager import TorchTritonPackager

--- a/python/michelangelo/lib/model_manager/packager/torch_triton/tests/fixtures/__init__.py
+++ b/python/michelangelo/lib/model_manager/packager/torch_triton/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Fixtures for torch Triton packager tests."""

--- a/python/michelangelo/lib/model_manager/packager/torch_triton/tests/fixtures/simple_model.py
+++ b/python/michelangelo/lib/model_manager/packager/torch_triton/tests/fixtures/simple_model.py
@@ -1,0 +1,26 @@
+"""Torch model fixtures for packager tests."""
+
+import torch
+
+
+class SimpleTorchModel(torch.nn.Module):
+    """Small deterministic torch module used by packager tests."""
+
+    def __init__(self):
+        """Initialize a linear model with deterministic parameters."""
+        super().__init__()
+        self.linear = torch.nn.Linear(2, 1)
+        with torch.no_grad():
+            self.linear.weight.fill_(1.0)
+            self.linear.bias.fill_(0.0)
+
+    def forward(self, x):
+        """Run a forward pass.
+
+        Args:
+            x: Input tensor of shape ``[batch_size, 2]``.
+
+        Returns:
+            Output tensor of shape ``[batch_size, 1]``.
+        """
+        return self.linear(x.float())

--- a/python/michelangelo/lib/model_manager/packager/torch_triton/tests/torch_triton_packager_test.py
+++ b/python/michelangelo/lib/model_manager/packager/torch_triton/tests/torch_triton_packager_test.py
@@ -1,0 +1,141 @@
+"""Tests for TorchTritonPackager."""
+
+import os
+import tempfile
+from unittest import TestCase
+
+import numpy as np
+import torch
+
+from michelangelo.lib.model_manager._private.constants import TritonBackendType
+from michelangelo.lib.model_manager.constants import RawModelType
+from michelangelo.lib.model_manager.packager.torch_triton import TorchTritonPackager
+from michelangelo.lib.model_manager.packager.torch_triton.tests.fixtures.simple_model import (  # noqa: E501
+    SimpleTorchModel,
+)
+from michelangelo.lib.model_manager.schema import DataType, ModelSchema, ModelSchemaItem
+from michelangelo.lib.model_manager.serde.model import load_raw_model
+
+MODEL_CLASS = (
+    "michelangelo.lib.model_manager.packager.torch_triton.tests.fixtures."
+    "simple_model.SimpleTorchModel"
+)
+
+
+class TorchTritonPackagerTest(TestCase):
+    """Tests torch Triton packager workflows."""
+
+    def setUp(self):
+        """Set up model schema and sample data."""
+        self.model_schema = ModelSchema(
+            input_schema=[
+                ModelSchemaItem(name="x", data_type=DataType.FLOAT, shape=[2]),
+            ],
+            output_schema=[
+                ModelSchemaItem(name="y", data_type=DataType.FLOAT, shape=[1]),
+            ],
+        )
+        self.sample_data = [{"x": np.array([1.0, 2.0], dtype=np.float32)}]
+
+    def _write_state_dict(self, path: str) -> None:
+        """Write a deterministic state dict to ``path``."""
+        torch.save(SimpleTorchModel().state_dict(), path)
+
+    def _write_torchscript(self, path: str) -> None:
+        """Write a deterministic torchscript model to ``path``."""
+        torch.jit.save(torch.jit.script(SimpleTorchModel()), path)
+
+    def test_create_raw_model_package(self):
+        """It creates a raw torch model package and loads it back."""
+        packager = TorchTritonPackager()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            model_path = os.path.join(temp_dir, "model.pt")
+            dest_model_path = os.path.join(temp_dir, "raw_model")
+            self._write_state_dict(model_path)
+
+            result_path = packager.create_raw_model_package(
+                model_path=model_path,
+                model_class=MODEL_CLASS,
+                model_schema=self.model_schema,
+                sample_data=self.sample_data,
+                dest_model_path=dest_model_path,
+                include_import_prefixes=[
+                    "michelangelo.lib.model_manager.packager.torch_triton.tests"
+                ],
+            )
+
+            self.assertEqual(result_path, dest_model_path)
+            self.assertTrue(os.path.exists(os.path.join(result_path, "model")))
+            self.assertTrue(os.path.exists(os.path.join(result_path, "defs")))
+            with open(os.path.join(result_path, "metadata", "type.yaml")) as f:
+                self.assertEqual(f.read(), f"type: {RawModelType.TORCH}\n")
+
+            loaded_model = load_raw_model(result_path)
+            self.assertIsInstance(loaded_model, SimpleTorchModel)
+            with torch.no_grad():
+                output = loaded_model(torch.tensor([[1.0, 2.0]]))
+            self.assertEqual(output.detach().numpy().tolist(), [[3.0]])
+
+    def test_create_torchscript_model_package(self):
+        """It creates a PyTorch backend deployable package."""
+        packager = TorchTritonPackager()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            model_path = os.path.join(temp_dir, "scripted.pt")
+            dest_model_path = os.path.join(temp_dir, "deployable_model")
+            self._write_torchscript(model_path)
+
+            result_path = packager.create_model_package(
+                model_path=model_path,
+                model_schema=self.model_schema,
+                model_name="torch-model",
+                dest_model_path=dest_model_path,
+                backend=TritonBackendType.TORCH,
+            )
+
+            self.assertEqual(result_path, dest_model_path)
+            self.assertTrue(os.path.exists(os.path.join(result_path, "0", "model.pt")))
+            with open(os.path.join(result_path, "config.pbtxt")) as f:
+                config = f.read()
+            self.assertIn('name: "torch-model-0"', config)
+            self.assertIn('backend: "pytorch"', config)
+
+    def test_create_python_backend_model_package(self):
+        """It creates a Python backend deployable torch package."""
+        packager = TorchTritonPackager()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            model_path = os.path.join(temp_dir, "model.pt")
+            dest_model_path = os.path.join(temp_dir, "python_model")
+            self._write_state_dict(model_path)
+
+            result_path = packager.create_model_package(
+                model_path=model_path,
+                model_schema=self.model_schema,
+                model_name="torch-python-model",
+                dest_model_path=dest_model_path,
+                backend=TritonBackendType.PYTHON,
+                model_class=MODEL_CLASS,
+                include_import_prefixes=[
+                    "michelangelo.lib.model_manager.packager.torch_triton.tests"
+                ],
+            )
+
+            self.assertTrue(os.path.exists(os.path.join(result_path, "0", "model.py")))
+            self.assertTrue(
+                os.path.exists(os.path.join(result_path, "0", "user_model.py"))
+            )
+            self.assertTrue(
+                os.path.exists(os.path.join(result_path, "0", "model", "model.pt"))
+            )
+            with open(os.path.join(result_path, "config.pbtxt")) as f:
+                config = f.read()
+            self.assertIn('backend: "python"', config)
+
+    def test_create_model_package_rejects_tensorrt_backend(self):
+        """It rejects TensorRT because OSS does not ship TensorRT conversion."""
+        packager = TorchTritonPackager()
+        with self.assertRaises(ValueError):
+            packager.create_model_package(
+                model_path="/tmp/model.pt",
+                model_schema=self.model_schema,
+                backend=TritonBackendType.TENSORRT,
+            )

--- a/python/michelangelo/lib/model_manager/packager/torch_triton/torch_triton_packager.py
+++ b/python/michelangelo/lib/model_manager/packager/torch_triton/torch_triton_packager.py
@@ -1,0 +1,248 @@
+"""Packager for torch Triton models."""
+
+from __future__ import annotations
+
+import tempfile
+from typing import TYPE_CHECKING, Any
+
+from michelangelo._internal.utils.file_utils import generate_folder
+from michelangelo.lib.model_manager._private.constants import TritonBackendType
+from michelangelo.lib.model_manager._private.packager.template_renderer import (
+    TritonTemplateRenderer,
+)
+from michelangelo.lib.model_manager._private.packager.torch_triton import (
+    generate_model_package_content,
+    generate_raw_model_package_content,
+    validate_model_class,
+    validate_raw_model_file,
+    validate_raw_model_package,
+)
+from michelangelo.lib.model_manager._private.schema.triton import validate_model_schema
+from michelangelo.lib.model_manager._private.utils.data_utils import (
+    validate_sample_data,
+    validate_sample_data_with_model_schema,
+)
+from michelangelo.lib.model_manager.constants import StorageType
+
+if TYPE_CHECKING:
+    from numpy import ndarray
+
+    from michelangelo.lib.artifact_manager import StorageBackend
+    from michelangelo.lib.model_manager.schema import ModelSchema
+
+_SUPPORTED_BACKENDS = {
+    TritonBackendType.TORCH,
+    TritonBackendType.PYTHON,
+    TritonBackendType.ONNX,
+}
+
+
+class TorchTritonPackager:
+    """Package PyTorch models for Triton and Michelangelo workflow artifacts.
+
+    The packager creates local package directories. Uploading those directories
+    to local, MinIO, S3-compatible, or other artifact storage is the pusher's
+    responsibility through ``StorageBackend``.
+    """
+
+    def __init__(self, storage_backend: StorageBackend | None = None):
+        """Create a torch Triton packager.
+
+        Args:
+            storage_backend: Optional storage backend used to download
+                ``model_path`` when it is a backend URI. If omitted,
+                ``model_path`` is treated as a local filesystem path.
+        """
+        self.gen = TritonTemplateRenderer()
+        self.storage_backend = storage_backend
+
+    def create_model_package(
+        self,
+        model_path: str,
+        model_schema: ModelSchema,
+        model_name: str | None = None,
+        dest_model_path: str | None = None,
+        model_revision: str | None = "0",
+        model_path_source_type: str | None = StorageType.LOCAL,
+        sample_data: list[dict[str, ndarray]] | None = None,
+        model_class: str | None = None,
+        hyperparameters: dict | None = None,
+        enable_dynamic_batching: bool = True,
+        backend: str | None = None,
+        include_import_prefixes: list[str] | None = None,
+        triton_parameters: dict[str, Any] | None = None,
+    ) -> str:
+        """Create a deployable Triton model package.
+
+        Args:
+            model_path: Local path or storage URI for a torch artifact. For
+                the default PyTorch backend this should be a torchscript file
+                or a torch module/state-dict convertible to torchscript. For
+                the Python backend this should be a torch module/state-dict.
+                For ONNX Runtime this may be an ``.onnx`` file or a torch
+                artifact exportable with ``sample_data``.
+            model_schema: Model input/output schema.
+            model_name: Optional model name written to ``config.pbtxt``.
+            dest_model_path: Destination package directory. A temporary
+                directory is created when omitted.
+            model_revision: Optional model revision suffix. Defaults to ``"0"``.
+            model_path_source_type: Source type for local artifacts. Defaults
+                to ``StorageType.LOCAL``.
+            sample_data: Optional sample inputs. Required when exporting a
+                torch artifact to ONNX.
+            model_class: Required for Python backend and state-dict conversion.
+            hyperparameters: Constructor keyword arguments for ``model_class``.
+            enable_dynamic_batching: Whether to enable Triton dynamic batching.
+            backend: Triton backend. Supports ``pytorch``, ``python``, and
+                ``onnxruntime``. Defaults to ``pytorch``.
+            include_import_prefixes: Module prefixes to include when bundling
+                Python backend model definitions. If ``None`` or empty, all
+                discovered local imports are included.
+            triton_parameters: Optional Triton config template overrides.
+
+        Returns:
+            Absolute path to the generated local package directory.
+        """
+        if not model_path:
+            raise ValueError("model_path is required")
+        if not model_schema:
+            raise ValueError("model_schema is required")
+
+        backend = backend or TritonBackendType.TORCH
+        if backend not in _SUPPORTED_BACKENDS:
+            raise ValueError(
+                f"Unsupported backend: {backend!r}. "
+                f"Supported backends are: {sorted(_SUPPORTED_BACKENDS)}"
+            )
+
+        is_schema_valid, error = validate_model_schema(model_schema)
+        if not is_schema_valid:
+            raise error
+
+        if backend == TritonBackendType.PYTHON and not model_class:
+            raise ValueError("model_class is required for Python backend")
+        if model_class:
+            is_model_class_valid, error = validate_model_class(model_class)
+            if not is_model_class_valid:
+                raise error
+
+        if sample_data:
+            is_sample_data_valid, error = validate_sample_data(sample_data)
+            if not is_sample_data_valid:
+                raise error
+            is_sample_data_with_schema_valid, error = (
+                validate_sample_data_with_model_schema(sample_data, model_schema)
+            )
+            if not is_sample_data_with_schema_valid:
+                raise error
+
+        if not dest_model_path:
+            dest_model_path = tempfile.mkdtemp()
+
+        content = generate_model_package_content(
+            self.gen,
+            model_path,
+            model_name,
+            model_revision,
+            model_schema,
+            model_path_source_type=model_path_source_type,
+            root_path=dest_model_path,
+            enable_dynamic_batching=enable_dynamic_batching,
+            model_class=model_class,
+            hyperparameters=hyperparameters,
+            backend=backend,
+            include_import_prefixes=include_import_prefixes,
+            sample_data=sample_data,
+            triton_parameters=triton_parameters,
+            storage_backend=self.storage_backend,
+        )
+
+        generate_folder(content, dest_model_path)
+        return dest_model_path
+
+    def create_raw_model_package(
+        self,
+        model_path: str,
+        model_class: str,
+        model_schema: ModelSchema,
+        sample_data: list[dict[str, ndarray]],
+        dest_model_path: str | None = None,
+        model_path_source_type: str | None = StorageType.LOCAL,
+        requirements: list[str] | str | None = None,
+        include_import_prefixes: list[str] | None = None,
+        hyperparameters: dict | None = None,
+    ) -> str:
+        """Create a raw torch model package.
+
+        Args:
+            model_path: Local path or storage URI for a torch ``.pt`` or
+                ``.pth`` artifact.
+            model_class: Fully qualified ``torch.nn.Module`` class path.
+            model_schema: Model schema for package metadata and validation.
+            sample_data: Sample inputs used for metadata and validation.
+            dest_model_path: Destination package directory. A temporary
+                directory is created when omitted.
+            model_path_source_type: Source type for local artifacts. Defaults
+                to ``StorageType.LOCAL``.
+            requirements: Optional requirements list or requirements file path.
+            include_import_prefixes: Module prefixes to include in ``defs``.
+                If ``None`` or empty, all discovered local imports are included.
+            hyperparameters: Constructor keyword arguments for ``model_class``.
+
+        Returns:
+            Absolute path to the generated local package directory.
+        """
+        if not model_path:
+            raise ValueError("model_path is required")
+        if not model_class:
+            raise ValueError("model_class is required")
+        if not model_schema:
+            raise ValueError("model_schema is required")
+
+        is_model_class_valid, error = validate_model_class(model_class)
+        if not is_model_class_valid:
+            raise error
+
+        is_schema_valid, error = validate_model_schema(model_schema)
+        if not is_schema_valid:
+            raise error
+
+        if sample_data:
+            is_sample_data_valid, error = validate_sample_data(sample_data)
+            if not is_sample_data_valid:
+                raise error
+            is_sample_data_with_schema_valid, error = (
+                validate_sample_data_with_model_schema(sample_data, model_schema)
+            )
+            if not is_sample_data_with_schema_valid:
+                raise error
+
+        if not dest_model_path:
+            dest_model_path = tempfile.mkdtemp()
+
+        content = generate_raw_model_package_content(
+            model_path,
+            model_class,
+            model_schema,
+            sample_data,
+            model_path_source_type=model_path_source_type,
+            requirements=requirements,
+            root_path=dest_model_path,
+            include_import_prefixes=include_import_prefixes,
+            hyperparameters=hyperparameters,
+            storage_backend=self.storage_backend,
+        )
+
+        generate_folder(content, dest_model_path)
+        validate_raw_model_package(dest_model_path, sample_data, model_schema)
+        return dest_model_path
+
+    def validate_raw_model_file(self, model_path: str) -> None:
+        """Validate that a local torch artifact can be used as a raw model file.
+
+        Args:
+            model_path: Path to a local ``.pt`` or ``.pth`` artifact.
+        """
+        is_valid, error = validate_raw_model_file(model_path)
+        if not is_valid:
+            raise error

--- a/python/michelangelo/lib/model_manager/serde/model/raw_model.py
+++ b/python/michelangelo/lib/model_manager/serde/model/raw_model.py
@@ -1,22 +1,28 @@
 """Raw model loader."""
 
-from typing import Union
+from typing import Optional, Union
 
 import torch
 
 from michelangelo.lib.model_manager._private.serde.model import (
     get_raw_model_type,
     load_custom_raw_model,
+    load_torch_raw_model,
 )
 from michelangelo.lib.model_manager.constants import RawModelType
 from michelangelo.lib.model_manager.interface.custom_model import Model
 
 
-def load_raw_model(model_path: str) -> Union[Model, torch.nn.Module]:
+def load_raw_model(
+    model_path: str,
+    submodule: Optional[str] = None,
+) -> Union[Model, torch.nn.Module]:
     """Load the raw model from the model package.
 
     Args:
         model_path: The model package path
+        submodule: Optional dotted submodule path for torch models. This is
+            reserved for compatibility and is not supported for custom models.
 
     Returns:
         The raw model
@@ -26,7 +32,11 @@ def load_raw_model(model_path: str) -> Union[Model, torch.nn.Module]:
     raw_model_type = get_raw_model_type(model_path)
 
     if raw_model_type == RawModelType.CUSTOM_PYTHON:
+        if submodule is not None:
+            raise ValueError("submodule is not supported for custom python models.")
         return load_custom_raw_model(model_path)
+    if raw_model_type == RawModelType.TORCH:
+        return load_torch_raw_model(model_path, submodule=submodule)
 
     raise NotImplementedError(
         f"The loader for {raw_model_type} model is not supported yet. "


### PR DESCRIPTION
## Summary
- Adds `TorchTritonPackager` for raw torch packages and Triton deployable packages.
- Supports `pytorch` and `python` Triton backends, with ONNX helper support.
- Adds raw torch model loading through `load_raw_model` for `RawModelType.TORCH`.
- Extends packager artifact download support through `StorageBackend` while keeping uploads in the pusher layer.

## Notes
- TensorRT is explicitly rejected for now because this package does not ship TensorRT conversion utilities.
- Packagers return local package paths; pusher remains responsible for artifact upload and registration.

## Validation
- `poetry run pytest` for torch Triton packager tests and custom Triton packager tests.
- `poetry run pytest` for raw model loader and raw model type tests.
- `poetry run ruff check` for changed model-manager Python paths.