### PR TITLE
refactor(registry): APIRegistryClient delegates to APIClient.ModelService

### DIFF
--- a/python/examples/california_housing_xgb/README.md
+++ b/python/examples/california_housing_xgb/README.md
@@ -195,6 +195,7 @@ kubectl delete cachedoutputs --all   # clear stale cached task outputs
 | `MINIO_SECRET_KEY` | If `MINIO_ENDPOINT` set | — | Secret access key |
 | `MINIO_SECURE` | No | `true` | Set `false` for plaintext (non-TLS) endpoints |
 | `REGISTRY_ENDPOINT` | No | — | Model registry gRPC endpoint (`host:port`). Unset → in-memory only |
+| `REGISTRY_INSECURE` | No | `true` | Set `false` to enable TLS for the registry connection |
 | `REGISTRY_NAMESPACE` | No | `default` | Model registry namespace |
 
 With `MINIO_ENDPOINT` set, `push_step` uploads all artifacts to MinIO:

--- a/python/examples/california_housing_xgb/README.md
+++ b/python/examples/california_housing_xgb/README.md
@@ -156,7 +156,6 @@ PYTHONPATH=. poetry run python examples/california_housing_xgb/california_housin
   --environ MINIO_SECRET_KEY=your-secret-key \
   --environ MINIO_SECURE=false \
   --environ REGISTRY_ENDPOINT=your-apiserver-host:15566 \
-  --environ REGISTRY_INSECURE=true \
   --yes
 ```
 
@@ -175,7 +174,6 @@ PYTHONPATH=. poetry run python examples/california_housing_xgb/california_housin
   --environ MINIO_SECRET_KEY=minioadmin \
   --environ MINIO_SECURE=false \
   --environ REGISTRY_ENDPOINT=michelangelo-apiserver:15566 \
-  --environ REGISTRY_INSECURE=true \
   --yes
 ```
 
@@ -197,7 +195,6 @@ kubectl delete cachedoutputs --all   # clear stale cached task outputs
 | `MINIO_SECRET_KEY` | If `MINIO_ENDPOINT` set | — | Secret access key |
 | `MINIO_SECURE` | No | `true` | Set `false` for plaintext (non-TLS) endpoints |
 | `REGISTRY_ENDPOINT` | No | — | Model registry gRPC endpoint (`host:port`). Unset → in-memory only |
-| `REGISTRY_INSECURE` | No | `true` | Set `false` to enable TLS for the registry connection |
 | `REGISTRY_NAMESPACE` | No | `default` | Model registry namespace |
 
 With `MINIO_ENDPOINT` set, `push_step` uploads all artifacts to MinIO:

--- a/python/examples/california_housing_xgb/push.py
+++ b/python/examples/california_housing_xgb/push.py
@@ -221,12 +221,22 @@ def push_step(
     # REGISTRY_ENDPOINT → APIRegistryClient (remote); else InMemoryRegistryClient.
     registry_endpoint = os.environ.get("REGISTRY_ENDPOINT")
     if registry_endpoint:
+        import grpc as _grpc
+
         from michelangelo.api.v2 import APIClient
         from michelangelo.lib.model_manager.registry.api_client import APIRegistryClient
 
+        _insecure = os.environ.get("REGISTRY_INSECURE", "true").lower() != "false"
+        _credentials = None if _insecure else _grpc.ssl_channel_credentials()
+        _channel = (
+            _grpc.insecure_channel(registry_endpoint)
+            if _insecure
+            else _grpc.secure_channel(registry_endpoint, _credentials)
+        )
         _api_client = APIClient(
             endpoint=registry_endpoint,
             caller="california-housing-push-step",
+            channel=_channel,
         )
         registry_client = APIRegistryClient(
             svc=_api_client.ModelService,

--- a/python/examples/california_housing_xgb/push.py
+++ b/python/examples/california_housing_xgb/push.py
@@ -221,14 +221,16 @@ def push_step(
     # REGISTRY_ENDPOINT → APIRegistryClient (remote); else InMemoryRegistryClient.
     registry_endpoint = os.environ.get("REGISTRY_ENDPOINT")
     if registry_endpoint:
-        from michelangelo.lib.model_manager.registry.api_client import (
-            APIRegistryClient,
-        )
+        from michelangelo.api.v2 import APIClient
+        from michelangelo.lib.model_manager.registry.api_client import APIRegistryClient
 
-        registry_client = APIRegistryClient(
+        _api_client = APIClient(
             endpoint=registry_endpoint,
+            caller="california-housing-push-step",
+        )
+        registry_client = APIRegistryClient(
+            svc=_api_client.ModelService,
             namespace=os.environ.get("REGISTRY_NAMESPACE", "default"),
-            insecure=os.environ.get("REGISTRY_INSECURE", "true").lower() != "false",
         )
         log.info("push_step: using APIRegistryClient at %s", registry_endpoint)
     else:

--- a/python/examples/california_housing_xgb/push.py
+++ b/python/examples/california_housing_xgb/push.py
@@ -234,7 +234,6 @@ def push_step(
             else _grpc.secure_channel(registry_endpoint, _credentials)
         )
         _api_client = APIClient(
-            endpoint=registry_endpoint,
             caller="california-housing-push-step",
             channel=_channel,
         )

--- a/python/michelangelo/lib/model_manager/registry/api_client.py
+++ b/python/michelangelo/lib/model_manager/registry/api_client.py
@@ -1,35 +1,40 @@
-"""Michelangelo gRPC model service registry client.
+"""ModelRegistryClient backed by ``APIClient.ModelService``.
 
-.. note::
-    **Internal adapter — requires a running Michelangelo ModelService.**
-    This client imports ``michelangelo.gen.api.v2`` gRPC stubs that are generated
-    from Michelangelo's internal protobuf definitions. It is intended for use
-    within a Michelangelo deployment. External adopters using a different model
-    registry should implement
-    :class:`~michelangelo.lib.model_manager.registry.client.ModelRegistryClient`
-    directly (e.g.
-    :class:`~michelangelo.lib.model_manager.registry.client.InMemoryRegistryClient`
-    for testing).
-
-Implements :class:`~michelangelo.lib.model_manager.registry.client.ModelRegistryClient`
-by calling Michelangelo's ``ModelService`` gRPC API. Works against any running
-``ModelService`` endpoint — a local sandbox API server (``insecure=True``) or
-a production cluster (``insecure=False`` with TLS).
-
-The ``grpcio`` package is a required dependency and is always available.
+Delegates all gRPC calls to the shared ``APIClient`` channel, which manages
+connection lifecycle and automatically injects the YARPC transport headers
+(``rpc-caller``, ``rpc-service``, ``rpc-encoding``) required by the
+Michelangelo apiserver via ``DefaultHeaderProvider``.
 
 Typical usage::
 
+    from michelangelo.api.v2 import APIClient
     from michelangelo.lib.model_manager.registry.api_client import APIRegistryClient
 
-    with APIRegistryClient(endpoint="localhost:50051", namespace="sandbox") as client:
-        registered = client.register_model(
-            name="my-classifier",
-            artifact_uri="s3://bucket/models/my-classifier/abc123/raw",
-            labels={"training_framework": "xgboost"},
-            metadata={"run_id": "mlflow-run-abc"},
-        )
-        print(registered.version, registered.registry_uri)
+    # One APIClient per process — it manages the shared gRPC channel.
+    client = APIClient(endpoint="localhost:15566", caller="my-pipeline")
+    registry = APIRegistryClient(svc=client.ModelService, namespace="default")
+    registered = registry.register_model(
+        name="my-classifier",
+        artifact_uri="s3://bucket/models/my-classifier/abc123/raw/model.ubj",
+        labels={"framework": "xgboost"},
+        metadata={"rmse": 0.87},
+    )
+    print(registered.version, registered.registry_uri)
+
+To target the singleton channel (``MA_API_SERVER`` env var)::
+
+    import os
+    os.environ["MA_API_SERVER"] = "localhost:15566"
+
+    from michelangelo.api.v2 import APIClient
+    APIClient.set_caller("my-pipeline")
+
+    from michelangelo.lib.model_manager.registry.api_client import APIRegistryClient
+    registry = APIRegistryClient(namespace="default")
+    registered = registry.register_model("my-model", "s3://bucket/raw/model.ubj")
+
+For testing without a real server, use
+:class:`~michelangelo.lib.model_manager.registry.client.InMemoryRegistryClient`.
 """
 
 from __future__ import annotations
@@ -40,9 +45,7 @@ from typing import TYPE_CHECKING, Any
 
 import grpc
 
-from michelangelo.gen.api.v2 import model_pb2, model_svc_pb2
-from michelangelo.gen.api.v2.model_svc_pb2_grpc import ModelServiceStub
-from michelangelo.lib.exceptions import ConfigurationError
+from michelangelo.gen.api.v2 import model_pb2
 from michelangelo.lib.model_manager.registry.client import (
     ModelRegistryClient,
     RegisteredModel,
@@ -51,41 +54,12 @@ from michelangelo.lib.model_manager.registry.client import (
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
+    from michelangelo.api.v2.services.gen.model import ModelService as _ModelServiceType
+
 _logger = logging.getLogger(__name__)
 
-_YARPC_METADATA = (
-    ("rpc-caller", "michelangelo-python-client"),
-    ("rpc-service", "ma-apiserver"),
-    ("rpc-encoding", "proto"),
-)
-
-
-class _YARPCInterceptor(grpc.UnaryUnaryClientInterceptor):
-    """Inject YARPC transport headers into every unary gRPC call.
-
-    The Michelangelo apiserver uses YARPC, which requires ``rpc-caller``,
-    ``rpc-service``, and ``rpc-encoding`` metadata on every request.
-    Plain gRPC clients omit these, causing the server to reject the call with
-    "missing service name, caller name, encoding".
-    """
-
-    def intercept_unary_unary(self, continuation, client_call_details, request):
-        existing = list(client_call_details.metadata or [])
-        new_details = grpc.ClientCallDetails()
-        new_details.method = client_call_details.method
-        new_details.timeout = client_call_details.timeout
-        new_details.credentials = client_call_details.credentials
-        new_details.wait_for_ready = getattr(
-            client_call_details, "wait_for_ready", None
-        )
-        new_details.compression = getattr(client_call_details, "compression", None)
-        new_details.metadata = existing + list(_YARPC_METADATA)
-        return continuation(new_details, request)
-
-
 METADATA_ANNOTATION_KEY = "michelangelo.io/metadata"
-"""Annotation key under which free-form metadata is JSON-serialised
-in the ModelService API."""
+"""Annotation key under which free-form metadata is JSON-serialised."""
 
 _MAX_REGISTER_RETRIES = 3
 
@@ -93,117 +67,79 @@ __all__ = ["METADATA_ANNOTATION_KEY", "APIRegistryClient"]
 
 
 class APIRegistryClient(ModelRegistryClient):
-    """ModelRegistryClient backed by Michelangelo's gRPC ``ModelService`` API.
+    """ModelRegistryClient that delegates to ``APIClient.ModelService``.
 
-    .. note::
-        This client depends on ``michelangelo.gen.api.v2`` gRPC stubs generated
-        from Michelangelo's internal protobuf definitions. It requires a running
-        ``ModelService`` endpoint. External adopters should implement
-        :class:`ModelRegistryClient` directly rather than using this class.
-
-    Connects to any running ``ModelService`` endpoint. For local sandbox use,
-    point ``endpoint`` at a locally running API server with ``insecure=True``.
-    For production, set ``insecure=False`` and provide a TLS-enabled endpoint.
+    Reuses the ``APIClient`` channel already managed by the calling process —
+    no additional gRPC channel is opened or closed. ``APIClient`` injects the
+    required YARPC transport headers (``rpc-caller``, ``rpc-service``,
+    ``rpc-encoding``) on every call via ``DefaultHeaderProvider``, eliminating
+    the need for a manual interceptor.
 
     **Create vs. update (with retry):** :meth:`register_model` attempts
-    ``CreateModel`` first. If the server responds with ``ALREADY_EXISTS``, the
-    client fetches the current ``resourceVersion`` and calls ``UpdateModel``
-    instead. If ``UpdateModel`` fails with ``FAILED_PRECONDITION`` (a concurrent
-    writer updated the resource between our ``GetModel`` and ``UpdateModel``),
-    the whole sequence is retried up to :data:`_MAX_REGISTER_RETRIES` times.
+    ``create_model`` first. On ``ALREADY_EXISTS`` it fetches ``resourceVersion``
+    via ``get_model`` and retries as ``update_model``. On ``FAILED_PRECONDITION``
+    (concurrent write) the whole sequence retries up to
+    :data:`_MAX_REGISTER_RETRIES` times.
 
-    **registry_uri format:** The ``registry_uri`` field of the returned
-    :class:`RegisteredModel` uses the Michelangelo-internal format
-    ``models:/{namespace}/{name}/{version}`` — *not* the MLflow two-segment
-    format ``models:/{name}/{version}``. Do not pass this URI to MLflow
-    client libraries.
-
-    **Labels** are stored in ``model.metadata.labels`` (indexed, filterable
-    string key-value pairs). **Metadata** is JSON-serialised and stored under
-    the annotation key ``michelangelo.io/metadata``.
-
-    **Channel lifecycle:** The underlying gRPC channel holds native threads and
-    TCP connections. Call :meth:`close` when done, or use the client as a
-    context manager (``with APIRegistryClient(...) as client:``).
+    **registry_uri format:** ``models:/{namespace}/{name}/{version}`` —
+    Michelangelo's three-segment format, not the two-segment MLflow format.
 
     Args:
-        endpoint: gRPC server address without the scheme
-            (e.g. ``"localhost:50051"`` or ``"api.michelangelo.io:443"``).
-        namespace: Kubernetes namespace used for model resources. Leave empty
-            to use the server's default namespace.
-        insecure: Use a plaintext gRPC channel (no TLS). Set ``True`` for a
-            local sandbox API server, ``False`` for any TLS-protected endpoint.
-        timeout_seconds: Per-call deadline in seconds.
+        svc: Pre-built ``ModelService`` instance (e.g. ``client.ModelService``).
+            When ``None``, the singleton ``APIClient.ModelService`` is used —
+            requires ``MA_API_SERVER`` to be set in the environment.
+        namespace: Kubernetes namespace for model resources. Defaults to
+            ``"default"``.
 
     Raises:
-        ConfigurationError: If ``endpoint`` is empty.
+        RuntimeError: If ``svc`` is ``None`` and ``APIClient.ModelService`` has
+            not been initialised (``MA_API_SERVER`` not set).
 
     Example::
 
+        from michelangelo.api.v2 import APIClient
         from michelangelo.lib.model_manager.registry.api_client import APIRegistryClient
 
-        with APIRegistryClient(
-            endpoint="localhost:50051", namespace="sandbox"
-        ) as client:
-            reg = client.register_model(
-                name="boston-xgb",
-                artifact_uri="s3://bucket/models/boston-xgb/abc123/raw",
-                deployable_artifact_uri=(
-                    "s3://bucket/models/boston-xgb/abc123/deployable"
-                ),
-                description="XGBoost model trained on Boston housing data",
-                labels={"training_framework": "xgboost"},
-                metadata={"run_id": "mlflow-run-abc", "rmse": 2.41},
-            )
-            print(reg.version)       # "1"
-            print(reg.registry_uri)  # "models:/sandbox/boston-xgb/1"
+        client = APIClient(endpoint="apiserver:15566", caller="push-step")
+        registry = APIRegistryClient(svc=client.ModelService, namespace="my-project")
+        reg = registry.register_model(
+            name="california-housing-xgb",
+            artifact_uri="s3://bucket/models/california-housing-xgb/abc/raw/model.ubj",
+            labels={"framework": "xgboost"},
+            metadata={"validation-rmse": 0.876},
+        )
+        print(reg.registry_uri)  # "models:/my-project/california-housing-xgb/1"
     """
 
     def __init__(
         self,
-        endpoint: str,
-        namespace: str = "",
-        insecure: bool = True,
-        timeout_seconds: int = 30,
+        svc: _ModelServiceType | None = None,
+        namespace: str = "default",
     ) -> None:
-        """Open a gRPC channel and create the ModelService stub.
+        """Bind to a ``ModelService`` instance.
 
         Args:
-            endpoint: gRPC server address without the scheme.
+            svc: Optional pre-built ``ModelService``. When ``None``, taken from
+                ``APIClient.ModelService`` (requires ``MA_API_SERVER``).
             namespace: Kubernetes namespace for model resources.
-            insecure: Use plaintext gRPC (no TLS). Defaults to ``True``.
-            timeout_seconds: Per-call deadline in seconds. Defaults to ``30``.
 
         Raises:
-            ConfigurationError: If ``endpoint`` is empty.
+            RuntimeError: If ``svc`` is ``None`` and ``APIClient.ModelService``
+                is not initialised.
         """
-        if not endpoint:
-            raise ConfigurationError(
-                "APIRegistryClient endpoint must be non-empty. "
-                "Provide the gRPC server address, e.g. 'localhost:50051'."
-            )
-        self._namespace = namespace
-        self._timeout_seconds = timeout_seconds
-        if insecure:
-            channel = grpc.insecure_channel(endpoint)
+        if svc is not None:
+            self._svc = svc
         else:
-            credentials = grpc.ssl_channel_credentials()
-            channel = grpc.secure_channel(endpoint, credentials)
-        channel = grpc.intercept_channel(channel, _YARPCInterceptor())
-        self._channel = channel
-        self._stub = ModelServiceStub(channel)
+            from michelangelo.api.v2 import APIClient
 
-    def close(self) -> None:
-        """Close the underlying gRPC channel, releasing threads and connections."""
-        self._channel.close()
-
-    def __enter__(self) -> APIRegistryClient:
-        """Enter the context manager, returning self."""
-        return self
-
-    def __exit__(self, *_: object) -> None:
-        """Exit the context manager, closing the gRPC channel."""
-        self.close()
+            self._svc = APIClient.ModelService
+            if self._svc is None:
+                raise RuntimeError(
+                    "APIClient.ModelService is not initialised. "
+                    "Set MA_API_SERVER in the environment before constructing "
+                    "APIRegistryClient, or pass an explicit svc= argument."
+                )
+        self._namespace = namespace
 
     def register_model(
         self,
@@ -215,42 +151,25 @@ class APIRegistryClient(ModelRegistryClient):
         labels: Mapping[str, str] | None = None,
         metadata: Mapping[str, Any] | None = None,
     ) -> RegisteredModel:
-        """Register a model via ``CreateModel``, falling back to ``UpdateModel``.
-
-        Builds a ``Model`` CRD proto from the supplied arguments and calls
-        ``CreateModel``. If the server returns ``ALREADY_EXISTS``, the current
-        ``resourceVersion`` is fetched via ``GetModel`` and the call is retried
-        as ``UpdateModel``. If a concurrent writer causes ``UpdateModel`` to
-        return ``FAILED_PRECONDITION``, the whole sequence is retried up to
-        :data:`_MAX_REGISTER_RETRIES` times.
+        """Register a model via ``create_model``, falling back to ``update_model``.
 
         Args:
-            name: Model name to register. Used as ``model.metadata.name``.
-            artifact_uri: URI of the raw model artifact (e.g. an S3 URI
-                returned by ``StorageBackend.upload()``). Stored in
-                ``spec.model_artifact_uri``.
+            name: Model name. Used as ``model.metadata.name``.
+            artifact_uri: URI of the raw model artifact.
             deployable_artifact_uri: Optional URI of the serving-ready bundle.
-                Stored in ``spec.deployable_artifact_uri`` when provided.
-            description: Optional human-readable description stored in
-                ``spec.description``.
-            schema: Ignored. The ``ModelService`` API does not expose a
-                dedicated schema field; subclasses may override this method to
-                embed schema in ``spec.input_schema`` / ``spec.output_schema``.
-            labels: String key-value pairs stored in ``model.metadata.labels``
-                (indexed and filterable via the API).
-            metadata: Arbitrary JSON-serializable key-value pairs stored as the
-                annotation ``michelangelo.io/metadata``.
+            description: Optional human-readable description.
+            schema: Ignored — ``ModelService`` has no dedicated schema field.
+            labels: String key-value pairs stored in ``model.metadata.labels``.
+            metadata: Arbitrary JSON-serializable key-value pairs stored under
+                the annotation ``michelangelo.io/metadata``.
 
         Returns:
-            A :class:`~michelangelo.lib.model_manager.registry.client.RegisteredModel`
-            built from the service response.
+            :class:`~michelangelo.lib.model_manager.registry.client.RegisteredModel`
 
         Raises:
-            grpc.RpcError: If the gRPC call fails for any reason other than
-                ``ALREADY_EXISTS`` / ``FAILED_PRECONDITION`` handled by the
-                retry loop.
-            RuntimeError: If all :data:`_MAX_REGISTER_RETRIES` attempts are
-                exhausted due to repeated concurrent writes.
+            grpc.RpcError: On gRPC errors other than ``ALREADY_EXISTS`` /
+                ``FAILED_PRECONDITION`` handled by the retry loop.
+            RuntimeError: After exhausting :data:`_MAX_REGISTER_RETRIES` retries.
         """
         for attempt in range(1, _MAX_REGISTER_RETRIES + 1):
             model = self._build_model_proto(
@@ -262,17 +181,13 @@ class APIRegistryClient(ModelRegistryClient):
                 metadata=metadata,
             )
             try:
-                _logger.info("Calling CreateModel for '%s'.", name)
-                resp = self._stub.CreateModel(
-                    model_svc_pb2.CreateModelRequest(model=model),
-                    timeout=self._timeout_seconds,
-                )
-                return self._to_registered_model(resp.model)
+                _logger.info("Calling create_model for '%s'.", name)
+                created = self._svc.create_model(model)
+                return self._to_registered_model(created)
             except grpc.RpcError as exc:
                 if exc.code() != grpc.StatusCode.ALREADY_EXISTS:
                     raise
 
-            # ALREADY_EXISTS — fetch resourceVersion and update instead
             _logger.warning(
                 "Model '%s' already exists — fetching resourceVersion and "
                 "updating (attempt %d/%d).",
@@ -280,25 +195,16 @@ class APIRegistryClient(ModelRegistryClient):
                 attempt,
                 _MAX_REGISTER_RETRIES,
             )
-            get_resp = self._stub.GetModel(
-                model_svc_pb2.GetModelRequest(
-                    name=name,
-                    namespace=self._namespace,
-                ),
-                timeout=self._timeout_seconds,
-            )
-            model.metadata.resourceVersion = get_resp.model.metadata.resourceVersion
+            existing = self._svc.get_model(self._namespace, name)
+            model.metadata.resourceVersion = existing.metadata.resourceVersion
             try:
-                upd_resp = self._stub.UpdateModel(
-                    model_svc_pb2.UpdateModelRequest(model=model),
-                    timeout=self._timeout_seconds,
-                )
-                return self._to_registered_model(upd_resp.model)
+                updated = self._svc.update_model(model)
+                return self._to_registered_model(updated)
             except grpc.RpcError as upd_exc:
                 if upd_exc.code() == grpc.StatusCode.FAILED_PRECONDITION:
                     if attempt < _MAX_REGISTER_RETRIES:
                         _logger.warning(
-                            "UpdateModel for '%s' hit FAILED_PRECONDITION — "
+                            "update_model for '%s' hit FAILED_PRECONDITION — "
                             "concurrent write detected, retrying (%d/%d).",
                             name,
                             attempt,
@@ -307,29 +213,20 @@ class APIRegistryClient(ModelRegistryClient):
                         continue
                     raise RuntimeError(
                         f"register_model: exhausted {_MAX_REGISTER_RETRIES} retries "
-                        f"for {name!r} due to repeated concurrent writes. "
-                        "Call register_model() again to retry."
+                        f"for {name!r} due to repeated concurrent writes."
                     ) from upd_exc
                 raise
 
     def get_model(self, name: str, version: str | None = None) -> RegisteredModel:
         """Retrieve the latest model registration by name.
 
-        .. note::
-            The ``ModelService`` API does not support per-revision lookup — it
-            always returns the current (latest) model record. Passing a
-            non-``None`` ``version`` emits a warning and the latest revision is
-            returned regardless.
-
         Args:
             name: Model name to look up.
-            version: If provided, a warning is emitted because per-revision
-                lookup is not supported by the ``ModelService`` API. The latest
-                revision is returned in all cases.
+            version: Emits a warning if provided — ``ModelService`` always
+                returns the latest revision.
 
         Returns:
-            A :class:`~michelangelo.lib.model_manager.registry.client.RegisteredModel`
-            built from the service response.
+            :class:`~michelangelo.lib.model_manager.registry.client.RegisteredModel`
 
         Raises:
             grpc.RpcError: If the model is not found or the call fails.
@@ -337,20 +234,13 @@ class APIRegistryClient(ModelRegistryClient):
         if version is not None:
             _logger.warning(
                 "APIRegistryClient.get_model() does not support per-revision "
-                "lookup (requested version=%r for model '%s'). "
-                "The ModelService API always returns the latest revision.",
+                "lookup (version=%r for '%s'). Returning the latest revision.",
                 version,
                 name,
             )
-        _logger.info("Calling GetModel for '%s'.", name)
-        resp = self._stub.GetModel(
-            model_svc_pb2.GetModelRequest(
-                name=name,
-                namespace=self._namespace,
-            ),
-            timeout=self._timeout_seconds,
-        )
-        return self._to_registered_model(resp.model)
+        _logger.info("Calling get_model for '%s'.", name)
+        model = self._svc.get_model(self._namespace, name)
+        return self._to_registered_model(model)
 
     # ── Private helpers ──────────────────────────────────────────────────────
 
@@ -363,12 +253,10 @@ class APIRegistryClient(ModelRegistryClient):
         labels: Mapping[str, str] | None,
         metadata: Mapping[str, Any] | None,
     ) -> model_pb2.Model:
-        """Construct a ``Model`` CRD proto from registration arguments."""
         model = model_pb2.Model()
         model.metadata.name = name
         if self._namespace:
             model.metadata.namespace = self._namespace
-
         model.spec.model_artifact_uri.append(artifact_uri)
         if deployable_artifact_uri:
             model.spec.deployable_artifact_uri.append(deployable_artifact_uri)
@@ -383,11 +271,9 @@ class APIRegistryClient(ModelRegistryClient):
         return model
 
     def _to_registered_model(self, model: model_pb2.Model) -> RegisteredModel:
-        """Map a ``Model`` proto response to a :class:`RegisteredModel`."""
         name = model.metadata.name
         namespace = model.metadata.namespace or self._namespace
         version = str(model.spec.revision_id)
-
         artifact_uri = (
             model.spec.model_artifact_uri[0] if model.spec.model_artifact_uri else None
         )
@@ -397,7 +283,6 @@ class APIRegistryClient(ModelRegistryClient):
             else None
         )
         labels = dict(model.metadata.labels)
-
         metadata_str = dict(model.metadata.annotations).get(METADATA_ANNOTATION_KEY)
         if metadata_str:
             try:
@@ -409,9 +294,6 @@ class APIRegistryClient(ModelRegistryClient):
                 ) from exc
         else:
             metadata = {}
-
-        # registry_uri uses Michelangelo's internal three-segment format
-        # "models:/{namespace}/{name}/{version}" — not the two-segment MLflow format.
         return RegisteredModel(
             name=name,
             version=version,

--- a/python/michelangelo/lib/model_manager/registry/tests/api_client_test.py
+++ b/python/michelangelo/lib/model_manager/registry/tests/api_client_test.py
@@ -4,24 +4,19 @@ from __future__ import annotations
 
 import json
 from unittest import TestCase
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import grpc
 
 from michelangelo.gen.api.v2 import model_pb2
-from michelangelo.lib.exceptions import ConfigurationError
 from michelangelo.lib.model_manager.registry.api_client import (
-    _YARPC_METADATA,
     METADATA_ANNOTATION_KEY,
     APIRegistryClient,
-    _YARPCInterceptor,
 )
-
-_STUB_PATH = "michelangelo.lib.model_manager.registry.api_client.ModelServiceStub"
 
 
 class _RpcError(grpc.RpcError):
-    """Minimal RpcError subclass for tests — grpc.RpcError itself is not raiseable."""
+    """Minimal RpcError subclass — grpc.RpcError itself is not raiseable."""
 
     def __init__(self, status_code: grpc.StatusCode) -> None:
         self._code = status_code
@@ -30,17 +25,11 @@ class _RpcError(grpc.RpcError):
         return self._code
 
 
-def _kwargs(**overrides) -> dict:
-    defaults = {"endpoint": "localhost:50051", "namespace": "test-ns"}
-    defaults.update(overrides)
-    return defaults
-
-
-def _make_response_model(
+def _model(
     name: str = "my-model",
-    namespace: str = "test-ns",
+    namespace: str = "default",
     revision_id: int = 1,
-    artifact_uri: str = "s3://bucket/raw",
+    artifact_uri: str = "s3://bucket/raw/model.ubj",
     deployable_uri: str | None = None,
 ) -> model_pb2.Model:
     """Build a minimal Model proto that mimics a service response."""
@@ -54,350 +43,216 @@ def _make_response_model(
     return m
 
 
-def _make_stub(
-    response_model: model_pb2.Model | None = None,
-    get_model: model_pb2.Model | None = None,
-    update_model: model_pb2.Model | None = None,
+def _mock_svc(
+    create_return: model_pb2.Model | None = None,
+    get_return: model_pb2.Model | None = None,
+    update_return: model_pb2.Model | None = None,
 ) -> MagicMock:
-    stub = MagicMock()
-    resp_model = response_model or _make_response_model()
-    create_resp = MagicMock()
-    create_resp.model = resp_model
-    stub.CreateModel.return_value = create_resp
-
-    get_resp = MagicMock()
-    get_resp.model = get_model or _make_response_model()
-    stub.GetModel.return_value = get_resp
-
-    update_resp = MagicMock()
-    update_resp.model = update_model or _make_response_model()
-    stub.UpdateModel.return_value = update_resp
-    return stub
+    """Return a mock ModelService with sensible defaults."""
+    svc = MagicMock()
+    svc.create_model.return_value = create_return or _model()
+    svc.get_model.return_value = get_return or _model()
+    svc.update_model.return_value = update_return or _model()
+    return svc
 
 
-class TestAPIRegistryClientValidation(TestCase):
-    """Tests for APIRegistryClient constructor validation and defaults."""
+def _client(svc=None, namespace="default") -> APIRegistryClient:
+    return APIRegistryClient(svc=svc or _mock_svc(), namespace=namespace)
 
-    def test_raises_on_empty_endpoint(self):
-        """It raises ConfigurationError when endpoint is empty."""
-        with self.assertRaises(ConfigurationError), patch(_STUB_PATH):
-            APIRegistryClient(endpoint="")
 
-    def test_defaults(self):
-        """It defaults to insecure=True, empty namespace, 30s timeout."""
-        stub = _make_stub()
-        with (
-            patch(_STUB_PATH, return_value=stub),
-            patch("grpc.insecure_channel", return_value=MagicMock()),
-        ):
-            client = APIRegistryClient(endpoint="localhost:50051")
-        self.assertEqual(client._namespace, "")
-        self.assertEqual(client._timeout_seconds, 30)
+# ---------------------------------------------------------------------------
+# Constructor
+# ---------------------------------------------------------------------------
+
+
+class TestAPIRegistryClientConstructor(TestCase):
+    """Tests for APIRegistryClient.__init__()."""
+
+    def test_accepts_explicit_svc(self):
+        """It stores the supplied ModelService and does not call APIClient."""
+        svc = _mock_svc()
+        client = APIRegistryClient(svc=svc, namespace="ns")
+        self.assertIs(client._svc, svc)
+        self.assertEqual(client._namespace, "ns")
+
+    def test_default_namespace_is_default(self):
+        """Namespace defaults to 'default' when not supplied."""
+        client = APIRegistryClient(svc=_mock_svc())
+        self.assertEqual(client._namespace, "default")
+
+    def test_singleton_raises_when_model_service_not_initialised(self):
+        """It raises RuntimeError when APIClient.ModelService is None."""
+        import unittest.mock as mock
+
+        with mock.patch("michelangelo.api.v2.APIClient") as mock_api:
+            mock_api.ModelService = None
+            with self.assertRaises(RuntimeError) as ctx:
+                APIRegistryClient()
+            self.assertIn("MA_API_SERVER", str(ctx.exception))
+
+
+# ---------------------------------------------------------------------------
+# register_model — happy path
+# ---------------------------------------------------------------------------
 
 
 class TestAPIRegistryClientRegisterModel(TestCase):
-    """Tests for APIRegistryClient.register_model()."""
+    """Tests for APIRegistryClient.register_model() happy path."""
 
     def test_calls_create_model_and_returns_registered_model(self):
-        """It calls CreateModel and maps the response to RegisteredModel."""
-        stub = _make_stub(_make_response_model("my-model", revision_id=1))
-        with patch(_STUB_PATH, return_value=stub):
-            client = APIRegistryClient(**_kwargs())
-            reg = client.register_model("my-model", "s3://bucket/raw")
-        stub.CreateModel.assert_called_once()
+        """It calls create_model() and maps the response to RegisteredModel."""
+        svc = _mock_svc(_model("my-model", revision_id=1))
+        reg = _client(svc).register_model("my-model", "s3://bucket/raw/model.ubj")
+        svc.create_model.assert_called_once()
         self.assertEqual(reg.name, "my-model")
         self.assertEqual(reg.version, "1")
-        self.assertEqual(reg.artifact_uri, "s3://bucket/raw")
+        self.assertEqual(reg.artifact_uri, "s3://bucket/raw/model.ubj")
 
     def test_registry_uri_format(self):
-        """It builds registry_uri as 'models:/{namespace}/{name}/{version}'."""
-        stub = _make_stub(_make_response_model("clf", namespace="ns", revision_id=3))
-        with patch(_STUB_PATH, return_value=stub):
-            client = APIRegistryClient(**_kwargs(namespace="ns"))
-            reg = client.register_model("clf", "s3://b/raw")
+        """registry_uri uses models:/{namespace}/{name}/{version} format."""
+        svc = _mock_svc(_model("clf", namespace="ns", revision_id=3))
+        reg = _client(svc, namespace="ns").register_model("clf", "s3://b/raw")
         self.assertEqual(reg.registry_uri, "models:/ns/clf/3")
 
-    def test_namespace_injected_into_model_proto(self):
-        """It sets model.metadata.namespace from the namespace arg."""
-        stub = _make_stub()
-        with patch(_STUB_PATH, return_value=stub):
-            client = APIRegistryClient(**_kwargs(namespace="my-ns"))
-            client.register_model("m", "s3://b/raw")
-        request = stub.CreateModel.call_args[0][0]
-        self.assertEqual(request.model.metadata.namespace, "my-ns")
+    def test_namespace_set_on_model_proto(self):
+        """The namespace is written to model.metadata.namespace."""
+        svc = _mock_svc()
+        _client(svc, namespace="my-ns").register_model("m", "s3://b/raw")
+        created_model = svc.create_model.call_args[0][0]
+        self.assertEqual(created_model.metadata.namespace, "my-ns")
 
     def test_labels_set_on_model_metadata(self):
-        """It stores labels on model.metadata.labels."""
-        stub = _make_stub()
-        with patch(_STUB_PATH, return_value=stub):
-            client = APIRegistryClient(**_kwargs())
-            client.register_model("m", "s3://b/raw", labels={"fw": "xgboost"})
-        request = stub.CreateModel.call_args[0][0]
-        self.assertEqual(request.model.metadata.labels["fw"], "xgboost")
+        """Labels are stored in model.metadata.labels."""
+        svc = _mock_svc()
+        _client(svc).register_model("m", "s3://b/raw", labels={"fw": "xgboost"})
+        created_model = svc.create_model.call_args[0][0]
+        self.assertEqual(created_model.metadata.labels["fw"], "xgboost")
 
     def test_metadata_stored_as_annotation(self):
-        """It JSON-encodes metadata under the michelangelo.io/metadata annotation."""
-        stub = _make_stub()
-        with patch(_STUB_PATH, return_value=stub):
-            client = APIRegistryClient(**_kwargs())
-            client.register_model(
-                "m", "s3://b/raw", metadata={"run_id": "r1", "rmse": 2.4}
-            )
-        request = stub.CreateModel.call_args[0][0]
-        raw = request.model.metadata.annotations[METADATA_ANNOTATION_KEY]
+        """Metadata is JSON-encoded under the michelangelo.io/metadata annotation."""
+        svc = _mock_svc()
+        _client(svc).register_model(
+            "m", "s3://b/raw", metadata={"run_id": "r1", "rmse": 2.4}
+        )
+        created_model = svc.create_model.call_args[0][0]
+        raw = created_model.metadata.annotations[METADATA_ANNOTATION_KEY]
         parsed = json.loads(raw)
         self.assertEqual(parsed["run_id"], "r1")
         self.assertAlmostEqual(parsed["rmse"], 2.4)
 
     def test_deployable_artifact_uri_set_when_provided(self):
-        """It appends deployable_artifact_uri to spec when provided."""
-        stub = _make_stub()
-        with patch(_STUB_PATH, return_value=stub):
-            client = APIRegistryClient(**_kwargs())
-            client.register_model(
-                "m", "s3://b/raw", deployable_artifact_uri="s3://b/dep"
-            )
-        request = stub.CreateModel.call_args[0][0]
-        self.assertIn("s3://b/dep", list(request.model.spec.deployable_artifact_uri))
+        """deployable_artifact_uri is appended to spec when provided."""
+        svc = _mock_svc()
+        _client(svc).register_model(
+            "m", "s3://b/raw", deployable_artifact_uri="s3://b/dep"
+        )
+        created_model = svc.create_model.call_args[0][0]
+        self.assertIn("s3://b/dep", list(created_model.spec.deployable_artifact_uri))
 
     def test_deployable_artifact_uri_absent_when_none(self):
-        """It leaves spec.deployable_artifact_uri empty when not provided."""
-        stub = _make_stub()
-        with patch(_STUB_PATH, return_value=stub):
-            client = APIRegistryClient(**_kwargs())
-            client.register_model("m", "s3://b/raw")
-        request = stub.CreateModel.call_args[0][0]
-        self.assertEqual(len(request.model.spec.deployable_artifact_uri), 0)
+        """spec.deployable_artifact_uri is empty when not provided."""
+        svc = _mock_svc()
+        _client(svc).register_model("m", "s3://b/raw")
+        created_model = svc.create_model.call_args[0][0]
+        self.assertEqual(len(created_model.spec.deployable_artifact_uri), 0)
 
-    def test_already_exists_falls_back_to_get_then_update(self):
-        """On ALREADY_EXISTS, it fetches resourceVersion and calls UpdateModel."""
-        mock_error = _RpcError(grpc.StatusCode.ALREADY_EXISTS)
 
-        existing = _make_response_model("m", revision_id=2)
+# ---------------------------------------------------------------------------
+# register_model — ALREADY_EXISTS retry
+# ---------------------------------------------------------------------------
+
+
+class TestAPIRegistryClientAlreadyExists(TestCase):
+    """Tests for the ALREADY_EXISTS → get + update retry path."""
+
+    def test_falls_back_to_get_then_update_on_already_exists(self):
+        """On ALREADY_EXISTS it fetches resourceVersion and calls update_model."""
+        existing = _model("m", revision_id=2)
         existing.metadata.resourceVersion = "rv-42"
-        stub = _make_stub(
-            get_model=existing,
-            update_model=_make_response_model("m", revision_id=3),
+
+        svc = _mock_svc(
+            get_return=existing,
+            update_return=_model("m", revision_id=3),
         )
-        stub.CreateModel.side_effect = mock_error
+        svc.create_model.side_effect = _RpcError(grpc.StatusCode.ALREADY_EXISTS)
 
-        with patch(_STUB_PATH, return_value=stub):
-            client = APIRegistryClient(**_kwargs())
-            reg = client.register_model("m", "s3://b/raw")
+        reg = _client(svc).register_model("m", "s3://b/raw")
 
-        stub.GetModel.assert_called_once()
-        stub.UpdateModel.assert_called_once()
-        update_model = stub.UpdateModel.call_args[0][0].model
-        self.assertEqual(update_model.metadata.resourceVersion, "rv-42")
+        svc.get_model.assert_called_once()
+        svc.update_model.assert_called_once()
         self.assertEqual(reg.version, "3")
+
+    def test_resource_version_propagated_to_update(self):
+        """The resourceVersion from get_model is set on the update proto."""
+        existing = _model("m")
+        existing.metadata.resourceVersion = "rv-99"
+
+        svc = _mock_svc(get_return=existing)
+        svc.create_model.side_effect = _RpcError(grpc.StatusCode.ALREADY_EXISTS)
+
+        _client(svc).register_model("m", "s3://b/raw")
+
+        updated_model = svc.update_model.call_args[0][0]
+        self.assertEqual(updated_model.metadata.resourceVersion, "rv-99")
+
+    def test_non_already_exists_error_is_reraised(self):
+        """Non-ALREADY_EXISTS gRPC errors propagate immediately."""
+        svc = _mock_svc()
+        svc.create_model.side_effect = _RpcError(grpc.StatusCode.UNAVAILABLE)
+        with self.assertRaises(grpc.RpcError):
+            _client(svc).register_model("m", "s3://b/raw")
+        svc.get_model.assert_not_called()
 
     def test_failed_precondition_retries_up_to_max(self):
-        """On FAILED_PRECONDITION from UpdateModel, it retries CreateModel→Update."""
-        already_exists = _RpcError(grpc.StatusCode.ALREADY_EXISTS)
-        failed_precondition = _RpcError(grpc.StatusCode.FAILED_PRECONDITION)
-
-        existing = _make_response_model("m", revision_id=2)
-        existing.metadata.resourceVersion = "rv-1"
-        final = _make_response_model("m", revision_id=3)
-
-        stub = MagicMock()
-        stub.CreateModel.side_effect = already_exists
-        get_resp = MagicMock()
-        get_resp.model = existing
-        stub.GetModel.return_value = get_resp
-        upd_resp = MagicMock()
-        upd_resp.model = final
-        stub.UpdateModel.side_effect = [
-            failed_precondition,
-            failed_precondition,
-            upd_resp,
+        """FAILED_PRECONDITION on update retries the full sequence."""
+        existing = _model("m")
+        svc = _mock_svc(
+            get_return=existing,
+            update_return=_model("m", revision_id=5),
+        )
+        svc.create_model.side_effect = _RpcError(grpc.StatusCode.ALREADY_EXISTS)
+        # Fail twice with FAILED_PRECONDITION, succeed on third attempt.
+        svc.update_model.side_effect = [
+            _RpcError(grpc.StatusCode.FAILED_PRECONDITION),
+            _RpcError(grpc.StatusCode.FAILED_PRECONDITION),
+            _model("m", revision_id=5),
         ]
 
-        with patch(_STUB_PATH, return_value=stub):
-            client = APIRegistryClient(**_kwargs())
-            reg = client.register_model("m", "s3://b/raw")
+        reg = _client(svc).register_model("m", "s3://b/raw")
+        self.assertEqual(reg.version, "5")
+        self.assertEqual(svc.update_model.call_count, 3)
 
-        self.assertEqual(stub.UpdateModel.call_count, 3)
-        self.assertEqual(reg.version, "3")
+    def test_exhausted_retries_raises_runtime_error(self):
+        """Exhausting all FAILED_PRECONDITION retries raises RuntimeError."""
+        svc = _mock_svc()
+        svc.create_model.side_effect = _RpcError(grpc.StatusCode.ALREADY_EXISTS)
+        svc.update_model.side_effect = _RpcError(grpc.StatusCode.FAILED_PRECONDITION)
 
-    def test_failed_precondition_raises_after_max_retries(self):
-        """It raises RuntimeError when all retries are exhausted."""
-        already_exists = _RpcError(grpc.StatusCode.ALREADY_EXISTS)
-        failed_precondition = _RpcError(grpc.StatusCode.FAILED_PRECONDITION)
+        with self.assertRaises(RuntimeError):
+            _client(svc).register_model("m", "s3://b/raw")
 
-        existing = _make_response_model("m")
-        stub = MagicMock()
-        stub.CreateModel.side_effect = already_exists
-        get_resp = MagicMock()
-        get_resp.model = existing
-        stub.GetModel.return_value = get_resp
-        stub.UpdateModel.side_effect = failed_precondition
 
-        with patch(_STUB_PATH, return_value=stub):
-            client = APIRegistryClient(**_kwargs())
-            with self.assertRaises(RuntimeError):
-                client.register_model("m", "s3://b/raw")
-
-    def test_grpc_error_propagates_on_non_already_exists(self):
-        """It re-raises gRPC errors other than ALREADY_EXISTS."""
-        mock_error = _RpcError(grpc.StatusCode.INTERNAL)
-        stub = MagicMock()
-        stub.CreateModel.side_effect = mock_error
-
-        with patch(_STUB_PATH, return_value=stub):
-            client = APIRegistryClient(**_kwargs())
-            with self.assertRaises(grpc.RpcError):
-                client.register_model("m", "s3://b/raw")
+# ---------------------------------------------------------------------------
+# get_model
+# ---------------------------------------------------------------------------
 
 
 class TestAPIRegistryClientGetModel(TestCase):
     """Tests for APIRegistryClient.get_model()."""
 
-    def test_get_model_calls_stub_and_returns_registered_model(self):
-        """It calls GetModel and maps the response correctly."""
-        response_model = _make_response_model("clf", namespace="ns", revision_id=5)
-        stub = _make_stub(get_model=response_model)
-        with patch(_STUB_PATH, return_value=stub):
-            client = APIRegistryClient(**_kwargs(namespace="ns"))
-            reg = client.get_model("clf")
-        stub.GetModel.assert_called_once()
+    def test_calls_get_model_and_returns_registered_model(self):
+        """It delegates to svc.get_model() and maps the response."""
+        svc = _mock_svc(get_return=_model("clf", revision_id=7))
+        reg = _client(svc, namespace="ns").get_model("clf")
+        svc.get_model.assert_called_once_with("ns", "clf")
         self.assertEqual(reg.name, "clf")
-        self.assertEqual(reg.version, "5")
+        self.assertEqual(reg.version, "7")
 
-    def test_corrupt_metadata_annotation_raises_value_error(self):
-        """It raises ValueError when the metadata annotation contains invalid JSON."""
-        response_model = _make_response_model("bad-model")
-        response_model.metadata.annotations[METADATA_ANNOTATION_KEY] = "not-json{"
-        stub = _make_stub(get_model=response_model)
-        with patch(_STUB_PATH, return_value=stub):
-            client = APIRegistryClient(**_kwargs())
-            with self.assertRaises(ValueError) as ctx:
-                client.get_model("bad-model")
-        self.assertIn("bad-model", str(ctx.exception))
-        self.assertIn(METADATA_ANNOTATION_KEY, str(ctx.exception))
-
-    def test_get_model_with_version_emits_warning(self):
-        """It logs a warning when a version argument is passed."""
-        stub = _make_stub(get_model=_make_response_model("m"))
-        with (
-            patch(_STUB_PATH, return_value=stub),
-            self.assertLogs(
-                "michelangelo.lib.model_manager.registry.api_client",
-                level="WARNING",
-            ) as log_ctx,
-        ):
-            client = APIRegistryClient(**_kwargs())
-            client.get_model("m", version="3")
-        self.assertTrue(
-            any("version=" in msg for msg in log_ctx.output),
-            msg=f"Expected version warning in logs: {log_ctx.output}",
-        )
-
-    def test_get_model_without_version_no_warning(self):
-        """It does not emit a warning when version is None."""
-        stub = _make_stub(get_model=_make_response_model("m"))
-        with patch(_STUB_PATH, return_value=stub):
-            client = APIRegistryClient(**_kwargs())
-            reg = client.get_model("m")
-        self.assertEqual(reg.name, "m")
-
-    def test_insecure_false_uses_secure_channel(self):
-        """It creates a secure channel when insecure=False."""
-        stub = _make_stub()
-        with (
-            patch(_STUB_PATH, return_value=stub),
-            patch("grpc.secure_channel") as mock_secure,
-            patch("grpc.ssl_channel_credentials", return_value=MagicMock()),
-        ):
-            APIRegistryClient(**_kwargs(insecure=False))
-        mock_secure.assert_called_once()
-
-    def test_close_calls_channel_close(self):
-        """close() releases the underlying gRPC channel."""
-        stub = _make_stub()
-        mock_channel = MagicMock()
-        with (
-            patch(_STUB_PATH, return_value=stub),
-            patch("grpc.insecure_channel", return_value=mock_channel),
-        ):
-            client = APIRegistryClient(**_kwargs())
-            client.close()
-        mock_channel.close.assert_called_once()
-
-    def test_context_manager_closes_channel_on_exit(self):
-        """The context manager calls close() on __exit__."""
-        stub = _make_stub()
-        mock_channel = MagicMock()
-        with (
-            patch(_STUB_PATH, return_value=stub),
-            patch("grpc.insecure_channel", return_value=mock_channel),
-            APIRegistryClient(**_kwargs()),
-        ):
-            pass
-        mock_channel.close.assert_called_once()
-
-
-# ---------------------------------------------------------------------------
-# _YARPCInterceptor
-# ---------------------------------------------------------------------------
-
-
-class TestYARPCInterceptor(TestCase):
-    """Tests for _YARPCInterceptor metadata injection."""
-
-    def _make_details(self, metadata=None):
-        details = grpc.ClientCallDetails()
-        details.metadata = metadata or []
-        details.method = "/svc/Method"
-        details.timeout = None
-        details.credentials = None
-        return details
-
-    def test_yarpc_headers_appended_to_metadata(self):
-        """Interceptor appends all three YARPC headers to call metadata."""
-        interceptor = _YARPCInterceptor()
-        captured = {}
-
-        def continuation(details, request):
-            captured["metadata"] = dict(details.metadata)
-            return MagicMock()
-
-        interceptor.intercept_unary_unary(continuation, self._make_details(), object())
-
-        for key, value in _YARPC_METADATA:
-            self.assertEqual(captured["metadata"][key], value)
-
-    def test_existing_metadata_preserved(self):
-        """Interceptor keeps caller-supplied metadata alongside YARPC headers."""
-        interceptor = _YARPCInterceptor()
-        captured = {}
-
-        def continuation(details, request):
-            captured["metadata"] = list(details.metadata)
-            return MagicMock()
-
-        existing = [("x-custom", "val")]
-        interceptor.intercept_unary_unary(
-            continuation, self._make_details(metadata=existing), object()
-        )
-
-        keys = [k for k, _ in captured["metadata"]]
-        self.assertIn("x-custom", keys)
-        self.assertIn("rpc-caller", keys)
-
-    def test_none_metadata_treated_as_empty(self):
-        """Interceptor handles None metadata without error."""
-        interceptor = _YARPCInterceptor()
-        called = []
-
-        def continuation(details, request):
-            called.append(list(details.metadata))
-            return MagicMock()
-
-        details = self._make_details(metadata=None)
-        details.metadata = None
-        interceptor.intercept_unary_unary(continuation, details, object())
-
-        yarpc_keys = {k for k, _ in _YARPC_METADATA}
-        result_keys = {k for k, _ in called[0]}
-        self.assertTrue(yarpc_keys.issubset(result_keys))
+    def test_version_arg_emits_warning(self):
+        """Passing a version emits a log warning (per-revision lookup unsupported)."""
+        svc = _mock_svc()
+        with self.assertLogs(
+            "michelangelo.lib.model_manager.registry.api_client", level="WARNING"
+        ) as cm:
+            _client(svc).get_model("m", version="2")
+        self.assertTrue(any("version" in msg.lower() for msg in cm.output))


### PR DESCRIPTION
**What type of PR is this?**
- [x] Refactor

**What changed?**

`APIRegistryClient` previously opened its own raw gRPC channel and injected YARPC transport headers (`rpc-caller`, `rpc-service`, `rpc-encoding`) via a hand-written `_YARPCInterceptor`. This duplicated infrastructure that `APIClient` already provides through `DefaultHeaderProvider` and `BaseService._get_metadata()`.

This refactor makes `APIRegistryClient` follow the same pattern as `APIClientEvalReportSink` — it delegates to `APIClient.ModelService` instead of managing its own channel.

### Before

```python
# APIRegistryClient opened its own channel and injected YARPC headers manually
registry = APIRegistryClient(
    endpoint="apiserver:15566",
    namespace="default",
    insecure=True,
)
```

Internally:
- `grpc.insecure_channel(endpoint)` + `grpc.intercept_channel(channel, _YARPCInterceptor())`
- Manual `_YARPCInterceptor.intercept_unary_unary()` setting `rpc-caller`, `rpc-service`, `rpc-encoding`
- Caller responsible for `close()` / context-manager cleanup
- `ModelServiceStub` built and called directly

### After

```python
from michelangelo.api.v2 import APIClient
from michelangelo.lib.model_manager.registry.api_client import APIRegistryClient

client = APIClient(endpoint="apiserver:15566", caller="my-pipeline")
registry = APIRegistryClient(svc=client.ModelService, namespace="default")
```

Or using the singleton channel (`MA_API_SERVER` env var):

```python
registry = APIRegistryClient(namespace="default")  # svc defaults to APIClient.ModelService
```

Internally:
- Delegates `create_model` / `get_model` / `update_model` to `ModelService`
- YARPC headers injected automatically by `DefaultHeaderProvider` via `BaseService._get_metadata()`
- Channel lifecycle owned by `APIClient` (shared, no `close()` needed)
- Removes `_YARPCInterceptor`, `_YARPC_METADATA`, raw channel management

### What stays the same
- `register_model()` signature and retry logic (ALREADY_EXISTS → get + update, FAILED_PRECONDITION retry)
- `get_model()` signature and behaviour
- `_build_model_proto()` and `_to_registered_model()` helpers
- `METADATA_ANNOTATION_KEY` constant and `__all__`

**How did you test it?**

- 17 unit tests rewritten to mock `ModelService` directly (instead of gRPC stubs)
- Tests cover: constructor, register_model happy path, ALREADY_EXISTS + resourceVersion propagation, FAILED_PRECONDITION retry exhaustion, get_model with version warning
- `ruff check` + `ruff format --check` — clean

**Migration**

Callers using the old constructor must migrate:

```python
# Old
registry = APIRegistryClient(endpoint=ep, namespace=ns, insecure=True)

# New
from michelangelo.api.v2 import APIClient
client = APIClient(endpoint=ep, caller="my-service")
registry = APIRegistryClient(svc=client.ModelService, namespace=ns)
```

**Related**

Follows up on PR #1282 which introduced `_YARPCInterceptor` as a workaround. This PR replaces that workaround with the correct architectural pattern.

**Release notes**

N/A — internal library change. No public API surface changes except the `APIRegistryClient` constructor signature.

Closes #1228