### PR TITLE
fix(spark): persist SparkJob status before immutable Update on termination

### DIFF
--- a/go/components/spark/job/controller.go
+++ b/go/components/spark/job/controller.go
@@ -314,9 +314,18 @@ func (r *Reconciler) handleTermination(ctx context.Context, logger logr.Logger, 
 		Reason:     job.Spec.Termination.Reason,
 	})
 
+	// Persist conditions before the immutable Update(): the status subresource
+	// means a later Update() would overwrite them with the stored status.
+	if err := r.Status().Update(ctx, job); err != nil {
+		logger.Error(err, "failed to update SparkJob status",
+			"operation", "update_status",
+			"namespace", job.Namespace,
+			"name", job.Name)
+		res.RequeueAfter = requeueAfter
+		return res, fmt.Errorf("update spark job status for %q/%q: %w", job.Namespace, job.Name, err)
+	}
+
 	// Mark the SparkJob immutable so it cannot transition further once killed.
-	// Update() persists the annotation; Status().Update() persists the status
-	// conditions. Both are needed because the CRD has a status subresource.
 	utils.MarkImmutable(job)
 	if err := r.Update(ctx, job); err != nil {
 		logger.Error(err, "failed to update SparkJob",
@@ -325,14 +334,6 @@ func (r *Reconciler) handleTermination(ctx context.Context, logger logr.Logger, 
 			"name", job.Name)
 		res.RequeueAfter = requeueAfter
 		return res, fmt.Errorf("update spark job for %q/%q: %w", job.Namespace, job.Name, err)
-	}
-	if err := r.Status().Update(ctx, job); err != nil {
-		logger.Error(err, "failed to update SparkJob status",
-			"operation", "update_status",
-			"namespace", job.Namespace,
-			"name", job.Name)
-		res.RequeueAfter = requeueAfter
-		return res, fmt.Errorf("update spark job status for %q/%q: %w", job.Namespace, job.Name, err)
 	}
 
 	logger.Info("SparkJob terminated", "name", job.Name, "namespace", job.Namespace)

--- a/go/components/spark/job/controller_test.go
+++ b/go/components/spark/job/controller_test.go
@@ -189,15 +189,17 @@ func TestReconciler_Reconcile_Termination(t *testing.T) {
 				},
 			}
 
-			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(sparkJob).Build()
-			fakeClientWrapper := testfakes.NewFakeClientWrapper(fakeClient)
+			// WithStatusSubresource makes a plain Update() behave like production
+			// (status not persisted), guarding the termination ordering regression.
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+				WithObjects(sparkJob).WithStatusSubresource(sparkJob).Build()
 
 			mockClient := jobmocks.NewMockClient(mockCtrl)
 			mockClient.EXPECT().DeleteJob(gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(tc.deleteJobErr)
 
 			r := &Reconciler{
-				Client:      fakeClientWrapper,
+				Client:      fakeClient,
 				sparkClient: mockClient,
 			}
 


### PR DESCRIPTION
## Problem

On a real API server the SparkJob `Killed` condition was never persisted on cascade termination. `handleTermination` set the `Killed`/`Succeeded` conditions, then called `Update()` (for the immutable annotation) **before** `Status().Update()`. Because the SparkJob CRD has a status subresource, `Update()` returns the server's stored status and writes it back into the in-memory object, clobbering the just-set conditions; the subsequent `Status().Update()` then persisted the stale status.

Consequences:
- The SparkJob never reached `Killed=TRUE` (it stayed `SparkAppRunning`).
- `isSparkJobKilled` therefore stayed false, so the reconciler re-entered `handleTermination` on every reconcile, repeatedly trying to delete the already-gone SparkApplication.

## Fix

Reorder so `Status().Update()` (status conditions) runs **before** `Update()` (metadata/immutable annotation). `Update()` does not touch the status subresource, so the persisted `Killed`/`Succeeded` conditions survive.

## Test

`controller_test.go` now builds its fake client `WithStatusSubresource(...)`, which makes a plain `Update()` behave like production (drops status, writes the stored status back). This reproduces the clobber, so the test **fails on the old ordering** (`Killed condition should be set`) and passes with the fix.

Also verified end-to-end on a local k3d sandbox: with the fix deployed, a Spark cascade-delete drives the SparkJob to `Killed=TRUE`; before the fix it stayed `SparkAppRunning`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)