### PR TITLE
Create NewReconciler constructor for Pipeline

### DIFF
--- a/go/components/pipeline/controller.go
+++ b/go/components/pipeline/controller.go
@@ -45,6 +45,22 @@ type Reconciler struct {
 	apiHandlerFactory apiHandler.Factory
 }
 
+// NewReconciler constructs a Reconciler with required dependencies.
+//
+// This provides a stable construction API for downstream users so they do not
+// need to rely on reflection to set unexported fields.
+func NewReconciler(
+	env env.Context,
+	apiHandlerFactory apiHandler.Factory,
+	logger *zap.Logger,
+) *Reconciler {
+	return &Reconciler{
+		env:               env,
+		apiHandlerFactory: apiHandlerFactory,
+		logger:            logger,
+	}
+}
+
 // Reconcile is the main reconciliation loop entry point for Pipeline resources.
 //
 // It processes reconciliation requests for Pipeline objects by:

--- a/go/components/pipeline/module.go
+++ b/go/components/pipeline/module.go
@@ -52,9 +52,5 @@ func register(
 	apiHandlerFactory apiHandler.Factory,
 	logger *zap.Logger,
 ) error {
-	return (&Reconciler{
-		env:               env,
-		apiHandlerFactory: apiHandlerFactory,
-		logger:            logger,
-	}).Register(mgr)
+	return NewReconciler(env, apiHandlerFactory, logger).Register(mgr)
 }


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
- Added an exported `NewReconciler(...)` constructor for `go/components/pipeline.Reconciler`.
- Updated `go/components/pipeline/module.go` to use `pipeline.NewReconciler(...)` instead of directly instantiating `Reconciler`, keeping a single construction path.

**Why?**
- Provide a stable, supported construction API so downstream consumers can import and construct the Pipeline reconciler without relying on unexported fields (or reflection). This mirrors the RayJob/RayCluster constructors added in #837.

**How did you test it?**
- `bazel build //go/components/pipeline:go_default_library`
- `bazel test //go/components/pipeline:go_default_test` (1/1 passing)
- Ran `./tools/gen-proto-go.sh` — no diff produced (this PR touches no `.proto`, so generated code is unaffected).
- Pure refactor: `register` produces an identical `Reconciler`; no behavior change.

**Potential risks**
- Low. Constructor wiring mistakes could cause nil dependency usage at runtime (controller startup/reconcile), but behavior is unchanged for the existing call site.

**Release notes**
- None.

**Documentation Changes**
- None.