### PR TITLE
cli: isolate per-plugin load failures so one broken plugin can't crash the CLI

### DIFF
--- a/python/michelangelo/cli/mactl/mactl.py
+++ b/python/michelangelo/cli/mactl/mactl.py
@@ -117,7 +117,13 @@ def read_module_from_file(
     if plugin_module is None:
         _LOG.error("Failed to create plugin module for %r", spec)
         return
-    spec.loader.exec_module(plugin_module)  # type: ignore[attr-defined]
+    try:
+        spec.loader.exec_module(plugin_module)  # type: ignore[attr-defined]
+    except Exception as e:
+        _LOG.error(
+            "Failed to load plugin %r (skipped): %s", plugin_main, e, exc_info=True
+        )
+        return None
     _LOG.info("Loaded plugin module: %r", plugin_module)
     return plugin_module
 
@@ -411,7 +417,13 @@ def apply_entity_plugins(
     for i, plugin in enumerate(plugins):
         _LOG.debug("Applying entity plugin #%d: %r", i, plugin)
         if hasattr(plugin, "apply_plugins"):
-            plugin.apply_plugins(crd, channel)
+            try:
+                plugin.apply_plugins(crd, channel)
+            except Exception as e:
+                _LOG.error(
+                    "Plugin %r apply_plugins failed (skipped): %s",
+                    plugin, e, exc_info=True,
+                )
         else:
             _LOG.debug(
                 "Plugin module %r has no 'apply_plugins' function (skipped)", plugin
@@ -449,7 +461,13 @@ def apply_command_plugins(
     for i, plugin in enumerate(plugins):
         _LOG.debug("Applying command plugin #%d: %r", i, plugin)
         if hasattr(plugin, "apply_plugin_command"):
-            plugin.apply_plugin_command(crd, action, crds, channel)
+            try:
+                plugin.apply_plugin_command(crd, action, crds, channel)
+            except Exception as e:
+                _LOG.error(
+                    "Plugin %r apply_plugin_command failed (skipped): %s",
+                    plugin, e, exc_info=True,
+                )
         else:
             _LOG.debug(
                 "Plugin module %r has no 'apply_plugin_command' function (skipped)",

--- a/python/michelangelo/cli/mactl/mactl.py
+++ b/python/michelangelo/cli/mactl/mactl.py
@@ -422,7 +422,9 @@ def apply_entity_plugins(
             except Exception as e:
                 _LOG.error(
                     "Plugin %r apply_plugins failed (skipped): %s",
-                    plugin, e, exc_info=True,
+                    plugin,
+                    e,
+                    exc_info=True,
                 )
         else:
             _LOG.debug(
@@ -466,7 +468,9 @@ def apply_command_plugins(
             except Exception as e:
                 _LOG.error(
                     "Plugin %r apply_plugin_command failed (skipped): %s",
-                    plugin, e, exc_info=True,
+                    plugin,
+                    e,
+                    exc_info=True,
                 )
         else:
             _LOG.debug(

--- a/python/michelangelo/cli/mactl/mactl_test.py
+++ b/python/michelangelo/cli/mactl/mactl_test.py
@@ -1038,7 +1038,7 @@ class ApplyEntityPluginsTest(TestCase):
         # no exception raised, plugin silently skipped
 
     def test_one_failing_plugin_does_not_block_others(self):
-        """Resilience: exception from one apply_plugins is logged and others still run."""
+        """Resilience: a failing apply_plugins is logged and others still run."""
         mock_crd = MagicMock()
         mock_crd.name = "pipeline"
         bad = MagicMock(spec=["apply_plugins"])
@@ -1046,9 +1046,7 @@ class ApplyEntityPluginsTest(TestCase):
         good = MagicMock(spec=["apply_plugins"])
 
         with patch("michelangelo.cli.mactl.mactl._LOG") as mock_log:
-            apply_entity_plugins(
-                mock_crd, MagicMock(), {"pipeline": [bad, good]}
-            )
+            apply_entity_plugins(mock_crd, MagicMock(), {"pipeline": [bad, good]})
 
         bad.apply_plugins.assert_called_once()
         good.apply_plugins.assert_called_once()
@@ -1099,7 +1097,7 @@ class ApplyCommandPluginsTest(TestCase):
         # no exception raised, plugin silently skipped
 
     def test_one_failing_plugin_does_not_block_others(self):
-        """Resilience: exception from one apply_plugin_command is logged and others still run."""
+        """Resilience: a failing apply_plugin_command is logged and others still run."""
         mock_crd = MagicMock()
         mock_crd.name = "pipeline"
         bad = MagicMock(spec=["apply_plugin_command"])

--- a/python/michelangelo/cli/mactl/mactl_test.py
+++ b/python/michelangelo/cli/mactl/mactl_test.py
@@ -535,6 +535,35 @@ class ReadModuleFromFileTest(TestCase):
             # Verify returns None
             self.assertIsNone(result)
 
+    def test_returns_none_when_plugin_raises_import_error(self):
+        """Resilience: a broken plugin (ImportError on exec) is skipped, not raised."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            plugin_dir = Path(tmpdir) / "entity" / "broken_entity"
+            plugin_dir.mkdir(parents=True)
+            (plugin_dir / "main.py").write_text(
+                "import this_module_definitely_does_not_exist_12345\n"
+            )
+
+            with patch("michelangelo.cli.mactl.mactl._LOG") as mock_log:
+                result = read_module_from_file("broken_entity", Path(tmpdir))
+
+            self.assertIsNone(result)
+            mock_log.error.assert_called_once()
+            self.assertTrue(mock_log.error.call_args.kwargs.get("exc_info"))
+
+    def test_returns_none_when_plugin_raises_at_top_level(self):
+        """Resilience: any top-level exception in a plugin is contained."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            plugin_dir = Path(tmpdir) / "entity" / "raises_entity"
+            plugin_dir.mkdir(parents=True)
+            (plugin_dir / "main.py").write_text(
+                "raise RuntimeError('plugin top-level boom')\n"
+            )
+
+            result = read_module_from_file("raises_entity", Path(tmpdir))
+
+            self.assertIsNone(result)
+
 
 class DiscoverCrdsTest(TestCase):
     """Tests for discover_crds function."""
@@ -1008,6 +1037,24 @@ class ApplyEntityPluginsTest(TestCase):
         apply_entity_plugins(mock_crd, MagicMock(), {"pipeline": [mock_plugin]})
         # no exception raised, plugin silently skipped
 
+    def test_one_failing_plugin_does_not_block_others(self):
+        """Resilience: exception from one apply_plugins is logged and others still run."""
+        mock_crd = MagicMock()
+        mock_crd.name = "pipeline"
+        bad = MagicMock(spec=["apply_plugins"])
+        bad.apply_plugins.side_effect = RuntimeError("boom")
+        good = MagicMock(spec=["apply_plugins"])
+
+        with patch("michelangelo.cli.mactl.mactl._LOG") as mock_log:
+            apply_entity_plugins(
+                mock_crd, MagicMock(), {"pipeline": [bad, good]}
+            )
+
+        bad.apply_plugins.assert_called_once()
+        good.apply_plugins.assert_called_once()
+        mock_log.error.assert_called_once()
+        self.assertTrue(mock_log.error.call_args.kwargs.get("exc_info"))
+
 
 class ApplyCommandPluginsTest(TestCase):
     """Tests for apply_command_plugins function."""
@@ -1050,6 +1097,24 @@ class ApplyCommandPluginsTest(TestCase):
             mock_crd, "create", {}, MagicMock(), {"pipeline": [mock_plugin]}
         )
         # no exception raised, plugin silently skipped
+
+    def test_one_failing_plugin_does_not_block_others(self):
+        """Resilience: exception from one apply_plugin_command is logged and others still run."""
+        mock_crd = MagicMock()
+        mock_crd.name = "pipeline"
+        bad = MagicMock(spec=["apply_plugin_command"])
+        bad.apply_plugin_command.side_effect = RuntimeError("boom")
+        good = MagicMock(spec=["apply_plugin_command"])
+
+        with patch("michelangelo.cli.mactl.mactl._LOG") as mock_log:
+            apply_command_plugins(
+                mock_crd, "create", {}, MagicMock(), {"pipeline": [bad, good]}
+            )
+
+        bad.apply_plugin_command.assert_called_once()
+        good.apply_plugin_command.assert_called_once()
+        mock_log.error.assert_called_once()
+        self.assertTrue(mock_log.error.call_args.kwargs.get("exc_info"))
 
 
 class AddPluginDirsToSyspathTest(TestCase):


### PR DESCRIPTION
## Problem

One broken CRD plugin crashes ALL `ma` commands at startup. A single `ImportError`, syntax error, or top-level `register_command()` failure inside any `entity/*/main.py` propagates to the CLI entrypoint and breaks `ma --help` and every CRD — not just the broken one.

## Root cause

`read_module_from_file` (line 120) calls `spec.loader.exec_module(plugin_module)` with no try/except, and `discover_all_plugins()` is eager — it imports every `entity/*/main.py` on every CLI invocation, before argv parsing. Same gap on the apply side: `apply_entity_plugins` and `apply_command_plugins` invoke `plugin.apply_plugins()` / `plugin.apply_plugin_command()` without per-plugin isolation.


## Fix

Three `try/except Exception` wraps in `mactl.py`, each logging with `_LOG.error(..., exc_info=True)` and continuing:

1. `read_module_from_file` — `exec_module()` failure returns `None`; the broken plugin is skipped, others keep loading.
2. `apply_entity_plugins` — per-plugin wrap; one failing `apply_plugins()` doesn't abort the others for the same CRD.
3. `apply_command_plugins` — per-plugin wrap on `apply_plugin_command()`.

| Failure mode | Before | After |
|---|---|---|
| Plugin A has `ImportError` at top level | `ma --help` crashes; no CRD usable | A is skipped (logged); all other CRDs work |
| Plugin A's `apply_plugins()` raises | crash for A's CRD | A skipped; other plugins for same CRD still run |
| Plugin A's `apply_plugin_command()` raises | crash on every command for A's CRD | A skipped; user can still invoke other CRDs |
| User invokes broken CRD | crash | generic "unknown command" |

Not in this PR (intentionally): a "plugin X failed — run with `--log-level=DEBUG`" hint when the user invokes a failed-to-load CRD, and lazy loading. Both are cleanly stackable.

## Tests

`python -m pytest python/michelangelo/cli/mactl/mactl_test.py` → **60/60 pass** (55 existing + 5 new), 1 pre-existing TLS-env-leakage failure unrelated to this PR (deselected; reproduces on `origin/main` HEAD).

New regressions:

| Test | What it locks in |
|---|---|
| `ReadModuleFromFileTest::test_returns_none_when_plugin_raises_import_error` | broken plugin (ImportError on exec) is skipped, `_LOG.error` called with `exc_info=True` |
| `ReadModuleFromFileTest::test_returns_none_when_plugin_raises_at_top_level` | any top-level exception (RuntimeError) is contained |
| `ApplyEntityPluginsTest::test_one_failing_plugin_does_not_block_others` | `bad.apply_plugins()` raises → `good.apply_plugins()` still called; error logged with `exc_info=True` |
| `ApplyCommandPluginsTest::test_one_failing_plugin_does_not_block_others` | same shape for `apply_plugin_command()` |