### PR TITLE
Fix/resilient cache sync

### DIFF
--- a/go/controllermgr/BUILD.bazel
+++ b/go/controllermgr/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//go/base/blobstore:go_default_library",
         "//go/base/blobstore/minio:go_default_library",
+        "//go/controllermgr/resilientcache:go_default_library",
         "//go/kubeproto/metrics:go_default_library",
         "@com_github_uber_go_tally//:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",

--- a/go/controllermgr/module.go
+++ b/go/controllermgr/module.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/michelangelo-ai/michelangelo/go/base/blobstore"
 	"github.com/michelangelo-ai/michelangelo/go/base/blobstore/minio"
+	"github.com/michelangelo-ai/michelangelo/go/controllermgr/resilientcache"
 	"github.com/michelangelo-ai/michelangelo/go/kubeproto/metrics"
 )
 
@@ -77,6 +78,7 @@ func create(p params) (result, error) {
 		HealthProbeBindAddress: p.Config.HealthProbeBindAddress,
 		LeaderElection:         p.Config.LeaderElection,
 		LeaderElectionID:       p.Config.LeaderElectionID,
+		NewCache:               resilientcache.NewCacheFunc(),
 	})
 	if err != nil {
 		return result{}, err

--- a/go/controllermgr/module.go
+++ b/go/controllermgr/module.go
@@ -78,7 +78,7 @@ func create(p params) (result, error) {
 		HealthProbeBindAddress: p.Config.HealthProbeBindAddress,
 		LeaderElection:         p.Config.LeaderElection,
 		LeaderElectionID:       p.Config.LeaderElectionID,
-		NewCache:               resilientcache.NewCacheFunc(),
+		NewCache:               resilientcache.NewCacheFunc(ctrl.Log.WithName("cache")),
 	})
 	if err != nil {
 		return result{}, err

--- a/go/controllermgr/resilientcache/BUILD.bazel
+++ b/go/controllermgr/resilientcache/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["resilientcache.go"],
+    importpath = "github.com/michelangelo-ai/michelangelo/go/controllermgr/resilientcache",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@io_k8s_client_go//rest:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/cache:go_default_library",
+    ],
+)

--- a/go/controllermgr/resilientcache/BUILD.bazel
+++ b/go/controllermgr/resilientcache/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/michelangelo-ai/michelangelo/go/controllermgr/resilientcache",
     visibility = ["//visibility:public"],
     deps = [
+        "@com_github_go_logr_logr//:go_default_library",
         "@io_k8s_client_go//rest:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/cache:go_default_library",
     ],

--- a/go/controllermgr/resilientcache/resilientcache.go
+++ b/go/controllermgr/resilientcache/resilientcache.go
@@ -1,0 +1,51 @@
+package resilientcache
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+)
+
+const syncTimeout = 2 * time.Minute
+
+type resilientCache struct {
+	cache.Cache
+
+	once       sync.Once
+	timedOut   bool
+}
+
+func (c *resilientCache) WaitForCacheSync(ctx context.Context) bool {
+	if c.timedOut {
+		return true
+	}
+
+	syncCtx, cancel := context.WithTimeout(ctx, syncTimeout)
+	defer cancel()
+
+	if c.Cache.WaitForCacheSync(syncCtx) {
+		return true
+	}
+
+	c.once.Do(func() {
+		c.timedOut = true
+		fmt.Printf("WARNING: cache sync timed out after %s — some informers failed to sync, proceeding in degraded mode\n", syncTimeout)
+	})
+	return true
+}
+
+// NewCacheFunc returns a cache.NewCacheFunc that wraps the default cache
+// with a sync timeout so one bad CR cannot block the entire controller manager.
+func NewCacheFunc() cache.NewCacheFunc {
+	return func(config *rest.Config, opts cache.Options) (cache.Cache, error) {
+		c, err := cache.New(config, opts)
+		if err != nil {
+			return nil, err
+		}
+		return &resilientCache{Cache: c}, nil
+	}
+}

--- a/go/controllermgr/resilientcache/resilientcache.go
+++ b/go/controllermgr/resilientcache/resilientcache.go
@@ -2,10 +2,10 @@ package resilientcache
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
+	"github.com/go-logr/logr"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 )
@@ -14,9 +14,9 @@ const syncTimeout = 2 * time.Minute
 
 type resilientCache struct {
 	cache.Cache
-
-	once       sync.Once
-	timedOut   bool
+	logger   logr.Logger
+	once     sync.Once
+	timedOut bool
 }
 
 func (c *resilientCache) WaitForCacheSync(ctx context.Context) bool {
@@ -33,19 +33,19 @@ func (c *resilientCache) WaitForCacheSync(ctx context.Context) bool {
 
 	c.once.Do(func() {
 		c.timedOut = true
-		fmt.Printf("WARNING: cache sync timed out after %s — some informers failed to sync, proceeding in degraded mode\n", syncTimeout)
+		c.logger.Error(nil, "cache sync timed out — some informers failed to sync, proceeding in degraded mode", "timeout", syncTimeout)
 	})
 	return true
 }
 
 // NewCacheFunc returns a cache.NewCacheFunc that wraps the default cache
 // with a sync timeout so one bad CR cannot block the entire controller manager.
-func NewCacheFunc() cache.NewCacheFunc {
+func NewCacheFunc(logger logr.Logger) cache.NewCacheFunc {
 	return func(config *rest.Config, opts cache.Options) (cache.Cache, error) {
 		c, err := cache.New(config, opts)
 		if err != nil {
 			return nil, err
 		}
-		return &resilientCache{Cache: c}, nil
+		return &resilientCache{Cache: c, logger: logger}, nil
 	}
 }


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

What changed?
Added a resilient cache wrapper (go/controllermgr/resilientcache/) that enforces a 2-minute timeout on WaitForCacheSync. If the timeout expires, the controller manager proceeds in degraded mode instead of blocking forever. A timedOut flag ensures subsequent sync checks from per-controller source watchers return immediately. Wired into the manager via the NewCache option — one line in module.go.

Why?
A single malformed CRD object (e.g. a Deployment with shadowSpec.duration: "99999999999999s") causes the Deployment informer's List to fail on JSON unmarshal (time.ParseDuration overflows for values > 292 years). Since all controllers share one cache and WaitForCacheSync blocks until every informer syncs, this one bad object prevents every controller (PipelineRun, InferenceServer, RayJob, TriggerRun, etc.) from starting — not just Deployment. This was the root cause of the incident on 2026-06-12.
                                                                                                                                                                                
  How did you test it?                                                                                                                                                          
  1. Applied a poisoned Deployment with shadowSpec.duration: "99999999999999s" to the sandbox cluster                                                                           
  2. Ran the controller manager locally (bazel run //go/cmd/controllermgr)                                                                                                      
  3. Before fix: verified all controllers blocked forever — no Starting workers log, no reconciliation for any resource type                                                    
  4. After fix: verified the WARNING is logged after 2 minutes, all controllers start their workers, and a newly created PipelineRun is reconciled successfully while the Deployment informer continues retrying in the background                                                                                                                      
  5. Verified recovery: after deleting the bad Deployment, the Deployment informer syncs and reconciliation resumes                                                             

Potential risks                                                                                                                                                               
  - Controllers whose informer failed to sync will operate in degraded mode: individual Get()/List() calls may return stale or empty results until the informer recovers. This  
  is strictly better than the current behavior where ALL controllers are permanently dead.                                                                                      
  - The 2-minute timeout is hardcoded. In production, this means a ~2 minute delay at startup before unaffected controllers begin processing if any CRD has a bad object.       
                                                                                                                                                                                
  Release notes                                                                                                                                                                 
  No schema, configuration, or data migration changes. The controller manager now tolerates informer sync failures at startup instead of blocking indefinitely.                 
                                                                                                                                                                                
  Documentation Changes                                                                                                                                                         
  None. No user-facing or API changes. The fix is internal to controller manager startup behavior.                                                                              
                                     