### PR TITLE
Enforce semantic testing-library queries in core tests

### DIFF
--- a/javascript/eslint.config.js
+++ b/javascript/eslint.config.js
@@ -8,6 +8,7 @@ import typesInTypesFile from './eslint-local-rules/types-in-types-file.js';
 import tseslint from 'typescript-eslint';
 import prettierConfig from 'eslint-config-prettier';
 import baseUIEslint from 'eslint-plugin-baseui';
+import testingLibrary from 'eslint-plugin-testing-library';
 import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
 import simpleImportSort from 'eslint-plugin-simple-import-sort';
@@ -172,6 +173,18 @@ export default [
     },
     rules: {
       'local/no-module-scope-test-setup': 'error',
+    },
+  },
+
+  // All package tests — testing-library query and testid conventions
+  {
+    files: ['packages/**/__tests__/**/*.{ts,tsx}'],
+    plugins: {
+      'testing-library': testingLibrary,
+    },
+    rules: {
+      'testing-library/no-test-id-queries': 'error',
+      'testing-library/prefer-screen-queries': 'error',
     },
   },
 

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -41,6 +41,7 @@
     "eslint-plugin-react-hooks": "^5.1.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "eslint-plugin-simple-import-sort": "^12.1.1",
+    "eslint-plugin-testing-library": "^7.16.2",
     "globals": "^15.15.0",
     "prettier": "^3.5.3",
     "typescript": "~5.7.2",

--- a/javascript/packages/core/components/banner/__tests__/banner.test.tsx
+++ b/javascript/packages/core/components/banner/__tests__/banner.test.tsx
@@ -41,7 +41,7 @@ describe('Banner', () => {
       buildWrapper([getBaseProviderWrapper()])
     );
 
-    const banner = screen.getByTestId('custom-banner');
+    const banner = screen.getByRole('complementary');
     expect(banner).toHaveAttribute('role', 'complementary');
   });
 
@@ -60,7 +60,7 @@ describe('Banner', () => {
       buildWrapper([getBaseProviderWrapper()])
     );
 
-    const banner = screen.getByTestId('custom-root');
+    const banner = screen.getByRole('complementary');
     expect(banner).toHaveStyle({
       marginTop: '0px',
       marginRight: '0px',

--- a/javascript/packages/core/components/box/__tests__/collapsible-box.test.tsx
+++ b/javascript/packages/core/components/box/__tests__/collapsible-box.test.tsx
@@ -192,14 +192,12 @@ describe('CollapsibleBox', () => {
   });
 
   it('applies overrides to elements', () => {
-    const testId = 'test-container';
-
     render(
       <CollapsibleBox
         title="Override Test"
         overrides={{
           Container: {
-            props: { 'data-testid': testId },
+            props: { 'data-testid': 'test-container' },
           },
           HeaderTitle: {
             props: { 'data-testid': 'test-title' },
@@ -211,7 +209,8 @@ describe('CollapsibleBox', () => {
       buildWrapper([getBaseProviderWrapper()])
     );
 
-    expect(screen.getByTestId(testId)).toBeInTheDocument();
-    expect(screen.getByTestId('test-title')).toHaveTextContent('Override Test');
+    // eslint-disable-next-line testing-library/no-test-id-queries -- generic div, no accessible identity
+    expect(screen.getByTestId('test-container')).toBeInTheDocument();
+    expect(screen.getByText('Override Test')).toBeInTheDocument();
   });
 });

--- a/javascript/packages/core/components/cell/__tests__/use-get-cell-renderer.tests.tsx
+++ b/javascript/packages/core/components/cell/__tests__/use-get-cell-renderer.tests.tsx
@@ -176,7 +176,6 @@ describe('useGetCellRenderer', () => {
         ])
       );
 
-      expect(screen.getByTestId('custom-badge')).toBeInTheDocument();
       expect(screen.getByText('Badge: test value')).toBeInTheDocument();
     });
 
@@ -262,7 +261,7 @@ describe('useGetCellRenderer', () => {
       );
 
       expect(screen.getByText('Column Custom: test value')).toBeInTheDocument();
-      expect(screen.queryByTestId('custom-badge')).not.toBeInTheDocument();
+      expect(screen.queryByText('Badge: test value')).not.toBeInTheDocument();
     });
 
     it('should prioritize provider custom renderers over built-in renderers', () => {
@@ -289,7 +288,6 @@ describe('useGetCellRenderer', () => {
         ])
       );
 
-      expect(screen.getByTestId('custom-text')).toBeInTheDocument();
       expect(screen.getByText('Custom Text: test value')).toBeInTheDocument();
     });
 

--- a/javascript/packages/core/components/form/__tests__/form.test.tsx
+++ b/javascript/packages/core/components/form/__tests__/form.test.tsx
@@ -235,10 +235,10 @@ describe('Form', () => {
           id="wrapped-form"
           onSubmit={onSubmit}
           render={(formElement) => (
-            <div data-testid="wrapper">
-              <div data-testid="header">Header Content</div>
+            <div>
+              <div>Header Content</div>
               {formElement}
-              <div data-testid="footer">Footer Content</div>
+              <div>Footer Content</div>
             </div>
           )}
         >
@@ -248,9 +248,8 @@ describe('Form', () => {
         buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
       );
 
-      expect(screen.getByTestId('wrapper')).toBeInTheDocument();
-      expect(screen.getByTestId('header')).toHaveTextContent('Header Content');
-      expect(screen.getByTestId('footer')).toHaveTextContent('Footer Content');
+      expect(screen.getByText('Header Content')).toBeInTheDocument();
+      expect(screen.getByText('Footer Content')).toBeInTheDocument();
       expect(screen.getByLabelText('Email')).toBeInTheDocument();
 
       await user.type(screen.getByLabelText('Email'), 'test@example.com');
@@ -438,12 +437,12 @@ describe('Form', () => {
 
     it('renders custom footer ReactNode directly', () => {
       render(
-        <Form onSubmit={vi.fn()} footer={<div data-testid="custom-footer">Custom</div>}>
+        <Form onSubmit={vi.fn()} footer={<div>Custom</div>}>
           <StringField name="email" label="Email" />
         </Form>,
         buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
       );
-      expect(screen.getByTestId('custom-footer')).toBeInTheDocument();
+      expect(screen.getByText('Custom')).toBeInTheDocument();
     });
 
     describe('Repeated layouts', () => {

--- a/javascript/packages/core/components/form/layout/form-banner/__tests__/form-banner.test.tsx
+++ b/javascript/packages/core/components/form/layout/form-banner/__tests__/form-banner.test.tsx
@@ -69,6 +69,6 @@ describe('FormBanner', () => {
       buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
     );
 
-    expect(screen.getByTestId('custom-content')).toBeInTheDocument();
+    expect(screen.getByText('Custom element')).toBeInTheDocument();
   });
 });

--- a/javascript/packages/core/components/illustrations/circle-exclamation-mark/circle-exclamation-mark.tsx
+++ b/javascript/packages/core/components/illustrations/circle-exclamation-mark/circle-exclamation-mark.tsx
@@ -17,6 +17,7 @@ export function CircleExclamationMark({
 
   return (
     <svg
+      role="img"
       aria-label="Circle Exclamation Mark icon"
       viewBox="0 0 38 38"
       width={width}

--- a/javascript/packages/core/components/link/__tests__/link.test.tsx
+++ b/javascript/packages/core/components/link/__tests__/link.test.tsx
@@ -90,10 +90,11 @@ describe('Link', () => {
     });
 
     it('should render custom link component', () => {
-      expect(screen.getByTestId('custom-link')).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'Custom Link' })).toBeInTheDocument();
     });
 
     it('should render custom icon component', () => {
+      // eslint-disable-next-line testing-library/no-test-id-queries -- bare span, no accessible identity
       expect(screen.getByTestId('custom-icon')).toBeInTheDocument();
     });
   });

--- a/javascript/packages/core/components/row/__tests__/row.test.tsx
+++ b/javascript/packages/core/components/row/__tests__/row.test.tsx
@@ -14,6 +14,7 @@ describe('Row', () => {
         loading={true}
       />
     );
+    // eslint-disable-next-line testing-library/no-test-id-queries -- Skeleton has no accessible role
     const skeletons = screen.getAllByTestId('loading');
     expect(skeletons).toHaveLength(3);
   });
@@ -64,6 +65,7 @@ describe('Row', () => {
     };
 
     render(<Row items={[{ id: 'name', label: 'Name' }]} overrides={overrides} />);
+    // eslint-disable-next-line testing-library/no-test-id-queries -- generic div, no accessible identity
     expect(screen.getByTestId('custom-container')).toBeInTheDocument();
   });
 

--- a/javascript/packages/core/components/table/__tests__/table.test.tsx
+++ b/javascript/packages/core/components/table/__tests__/table.test.tsx
@@ -157,7 +157,7 @@ describe('Table', () => {
     });
 
     it('renders the default loading state', () => {
-      expect(screen.getByTestId('table-loading-state')).toBeInTheDocument();
+      expect(screen.getByRole('rowgroup', { name: 'Loading' })).toBeInTheDocument();
     });
 
     it('renders column headers when loading', () => {
@@ -189,7 +189,7 @@ describe('Table', () => {
     });
 
     it('does not render the default loading state', () => {
-      expect(screen.queryByTestId('table-loading-state')).not.toBeInTheDocument();
+      expect(screen.queryByRole('rowgroup', { name: 'Loading' })).not.toBeInTheDocument();
     });
 
     it('renders column headers when loading', () => {
@@ -543,7 +543,7 @@ describe('Table', () => {
         await user.click(addFilterButton);
 
         // Step 2: Select department column
-        const departmentOption = screen.getByTestId('filter-option-Department');
+        const departmentOption = screen.getByRole('option', { name: 'Department' });
         await user.click(departmentOption);
 
         // Step 3: Select Engineering value in categorical filter
@@ -578,7 +578,7 @@ describe('Table', () => {
 
         // Apply a filter first
         await user.click(screen.getByRole('button', { name: 'Add filter' }));
-        await user.click(screen.getByTestId('filter-option-Department'));
+        await user.click(screen.getByRole('option', { name: 'Department' }));
         await user.click(screen.getByLabelText('Engineering'));
         await user.click(screen.getByRole('button', { name: 'Apply' }));
 
@@ -589,7 +589,7 @@ describe('Table', () => {
 
         // Open filter menu again and remove filter
         await user.click(screen.getByRole('button', { name: 'Add filter' }));
-        await user.click(screen.getByTestId('filter-option-Department'));
+        await user.click(screen.getByRole('option', { name: 'Department' }));
         await user.click(screen.getByLabelText('Engineering')); // Uncheck
         await user.click(screen.getByRole('button', { name: 'Apply' }));
 
@@ -604,7 +604,7 @@ describe('Table', () => {
 
         // Open filter menu and select Department column
         await user.click(screen.getByRole('button', { name: 'Add filter' }));
-        await user.click(screen.getByTestId('filter-option-Department'));
+        await user.click(screen.getByRole('option', { name: 'Department' }));
 
         // Select Marketing (we want to exclude this)
         await user.click(screen.getByLabelText('Marketing'));
@@ -666,7 +666,7 @@ describe('Table', () => {
 
         // But filter options should include all departments from unFilteredData
         await user.click(screen.getByRole('button', { name: 'Add filter' }));
-        await user.click(screen.getByTestId('filter-option-Department'));
+        await user.click(screen.getByRole('option', { name: 'Department' }));
 
         // Should have all department options available (Engineering, Marketing, Sales)
         expect(screen.getByLabelText('Engineering')).toBeInTheDocument();
@@ -704,7 +704,7 @@ describe('Table', () => {
         );
 
         await user.click(screen.getByRole('button', { name: 'Add filter' }));
-        await user.click(screen.getByTestId('filter-option-Department'));
+        await user.click(screen.getByRole('option', { name: 'Department' }));
 
         await waitFor(() => {
           expect(screen.getAllByText('Dept: Engineering')).toHaveLength(2);
@@ -758,7 +758,7 @@ describe('Table', () => {
         expect(screen.getByText('ML training pipeline')).toBeInTheDocument();
 
         await user.click(screen.getByRole('button', { name: 'Add filter' }));
-        await user.click(screen.getByTestId('filter-option-Pipeline'));
+        await user.click(screen.getByRole('option', { name: 'Pipeline' }));
         await waitFor(() => {
           expect(screen.getAllByText('my-ml-pipeline')).toHaveLength(2);
           expect(screen.getAllByText('data-processing')).toHaveLength(2);
@@ -798,11 +798,11 @@ describe('Table', () => {
         await user.click(screen.getByRole('button', { name: 'Add filter' }));
 
         // Should show CLIENT and SERVER mode columns
-        expect(screen.getByTestId('filter-option-Name')).toBeInTheDocument();
-        expect(screen.getByTestId('filter-option-Department')).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'Name' })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'Department' })).toBeInTheDocument();
 
         // Should NOT show NONE mode column
-        expect(screen.queryByTestId('filter-option-Notes')).not.toBeInTheDocument();
+        expect(screen.queryByRole('option', { name: 'Notes' })).not.toBeInTheDocument();
       });
 
       it('hides filter menu entirely when all columns have FilterMode.NONE', () => {
@@ -868,7 +868,7 @@ describe('Table', () => {
 
       // Open filter menu and select DATE column
       await user.click(screen.getByRole('button', { name: 'Add filter' }));
-      await user.click(screen.getByTestId('filter-option-Created At'));
+      await user.click(screen.getByRole('option', { name: 'Created At' }));
 
       // Should open datetime filter (not categorical filter)
       // DatetimeFilter should render with Apply button
@@ -1123,7 +1123,7 @@ describe('Table', () => {
 
     it('renders custom pagination component instead of default', () => {
       const CustomPaginationComponent = (props: TablePaginationProps) => (
-        <div data-testid="custom-pagination">
+        <div>
           <span>Custom Pagination - Page {props.state.pageIndex + 1}</span>
           <button onClick={() => props.gotoPage(props.state.pageIndex + 1)}>Custom Next</button>
         </div>
@@ -1142,14 +1142,13 @@ describe('Table', () => {
         ])
       );
 
-      expect(screen.getByTestId('custom-pagination')).toBeInTheDocument();
       expect(screen.getByText('Custom Pagination - Page 1')).toBeInTheDocument();
       expect(screen.queryByText('Page 1 of')).not.toBeInTheDocument();
     });
 
     it('respects disablePagination even with custom component', () => {
       const CustomPaginationComponent = (props: TablePaginationProps) => (
-        <div data-testid="custom-pagination">
+        <div>
           Custom Pagination - Page {props.state.pageIndex + 1}
         </div>
       );
@@ -1168,7 +1167,7 @@ describe('Table', () => {
         ])
       );
 
-      expect(screen.queryByTestId('custom-pagination')).not.toBeInTheDocument();
+      expect(screen.queryByText(/Custom Pagination/)).not.toBeInTheDocument();
       expect(screen.getAllByRole('row')).toHaveLength(16);
     });
 
@@ -1391,7 +1390,7 @@ describe('Table', () => {
 
         // Apply column filter that drastically reduces results
         await user.click(screen.getByRole('button', { name: 'Add filter' }));
-        await user.click(screen.getByTestId('filter-option-Column1'));
+        await user.click(screen.getByRole('option', { name: 'Column1' }));
         await user.click(screen.getByLabelText('row1-col1-data'));
         await user.click(screen.getByRole('button', { name: 'Apply' }));
 
@@ -1425,7 +1424,7 @@ describe('Table', () => {
 
         // Apply filter that still leaves 2 pages (4 rows with pageSize=3 → 2 pages)
         await user.click(screen.getByRole('button', { name: 'Add filter' }));
-        await user.click(screen.getByTestId('filter-option-Column1'));
+        await user.click(screen.getByRole('option', { name: 'Column1' }));
         await user.click(screen.getByLabelText('row1-col1-data'));
         await user.click(screen.getByLabelText('row2-col1-data'));
         await user.click(screen.getByLabelText('row3-col1-data'));
@@ -2121,6 +2120,7 @@ describe('Table', () => {
 
       // Check for sticky column test IDs that the withStickySides HOC adds
       // Should have sticky cells for both header and data rows in first column
+      // eslint-disable-next-line testing-library/no-test-id-queries -- HOC-injected testid, no accessible identity on these cells
       const stickyCells = screen.getAllByTestId('sticky-cell-left-sticky');
       expect(stickyCells.length).toBeGreaterThan(0);
     });
@@ -2132,6 +2132,7 @@ describe('Table', () => {
       );
 
       // Should not have sticky cell test IDs
+      // eslint-disable-next-line testing-library/no-test-id-queries -- HOC-injected testid, no accessible identity on these cells
       expect(screen.queryByTestId('sticky-cell-left-sticky')).not.toBeInTheDocument();
     });
   });

--- a/javascript/packages/core/components/table/__tests__/table.test.tsx
+++ b/javascript/packages/core/components/table/__tests__/table.test.tsx
@@ -543,7 +543,7 @@ describe('Table', () => {
         await user.click(addFilterButton);
 
         // Step 2: Select department column
-        const departmentOption = screen.getByTestId('filter-option-Department');
+        const departmentOption = screen.getByRole('option', { name: 'Department' });
         await user.click(departmentOption);
 
         // Step 3: Select Engineering value in categorical filter
@@ -578,7 +578,7 @@ describe('Table', () => {
 
         // Apply a filter first
         await user.click(screen.getByRole('button', { name: 'Add filter' }));
-        await user.click(screen.getByTestId('filter-option-Department'));
+        await user.click(screen.getByRole('option', { name: 'Department' }));
         await user.click(screen.getByLabelText('Engineering'));
         await user.click(screen.getByRole('button', { name: 'Apply' }));
 
@@ -589,7 +589,7 @@ describe('Table', () => {
 
         // Open filter menu again and remove filter
         await user.click(screen.getByRole('button', { name: 'Add filter' }));
-        await user.click(screen.getByTestId('filter-option-Department'));
+        await user.click(screen.getByRole('option', { name: 'Department' }));
         await user.click(screen.getByLabelText('Engineering')); // Uncheck
         await user.click(screen.getByRole('button', { name: 'Apply' }));
 
@@ -604,7 +604,7 @@ describe('Table', () => {
 
         // Open filter menu and select Department column
         await user.click(screen.getByRole('button', { name: 'Add filter' }));
-        await user.click(screen.getByTestId('filter-option-Department'));
+        await user.click(screen.getByRole('option', { name: 'Department' }));
 
         // Select Marketing (we want to exclude this)
         await user.click(screen.getByLabelText('Marketing'));
@@ -666,7 +666,7 @@ describe('Table', () => {
 
         // But filter options should include all departments from unFilteredData
         await user.click(screen.getByRole('button', { name: 'Add filter' }));
-        await user.click(screen.getByTestId('filter-option-Department'));
+        await user.click(screen.getByRole('option', { name: 'Department' }));
 
         // Should have all department options available (Engineering, Marketing, Sales)
         expect(screen.getByLabelText('Engineering')).toBeInTheDocument();
@@ -704,7 +704,7 @@ describe('Table', () => {
         );
 
         await user.click(screen.getByRole('button', { name: 'Add filter' }));
-        await user.click(screen.getByTestId('filter-option-Department'));
+        await user.click(screen.getByRole('option', { name: 'Department' }));
 
         await waitFor(() => {
           expect(screen.getAllByText('Dept: Engineering')).toHaveLength(2);
@@ -758,7 +758,7 @@ describe('Table', () => {
         expect(screen.getByText('ML training pipeline')).toBeInTheDocument();
 
         await user.click(screen.getByRole('button', { name: 'Add filter' }));
-        await user.click(screen.getByTestId('filter-option-Pipeline'));
+        await user.click(screen.getByRole('option', { name: 'Pipeline' }));
         await waitFor(() => {
           expect(screen.getAllByText('my-ml-pipeline')).toHaveLength(2);
           expect(screen.getAllByText('data-processing')).toHaveLength(2);
@@ -798,11 +798,11 @@ describe('Table', () => {
         await user.click(screen.getByRole('button', { name: 'Add filter' }));
 
         // Should show CLIENT and SERVER mode columns
-        expect(screen.getByTestId('filter-option-Name')).toBeInTheDocument();
-        expect(screen.getByTestId('filter-option-Department')).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'Name' })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'Department' })).toBeInTheDocument();
 
         // Should NOT show NONE mode column
-        expect(screen.queryByTestId('filter-option-Notes')).not.toBeInTheDocument();
+        expect(screen.queryByRole('option', { name: 'Notes' })).not.toBeInTheDocument();
       });
 
       it('hides filter menu entirely when all columns have FilterMode.NONE', () => {
@@ -868,7 +868,7 @@ describe('Table', () => {
 
       // Open filter menu and select DATE column
       await user.click(screen.getByRole('button', { name: 'Add filter' }));
-      await user.click(screen.getByTestId('filter-option-Created At'));
+      await user.click(screen.getByRole('option', { name: 'Created At' }));
 
       // Should open datetime filter (not categorical filter)
       // DatetimeFilter should render with Apply button
@@ -1148,9 +1148,7 @@ describe('Table', () => {
 
     it('respects disablePagination even with custom component', () => {
       const CustomPaginationComponent = (props: TablePaginationProps) => (
-        <div>
-          Custom Pagination - Page {props.state.pageIndex + 1}
-        </div>
+        <div>Custom Pagination - Page {props.state.pageIndex + 1}</div>
       );
 
       render(
@@ -1390,6 +1388,7 @@ describe('Table', () => {
 
         // Apply column filter that drastically reduces results
         await user.click(screen.getByRole('button', { name: 'Add filter' }));
+        // eslint-disable-next-line testing-library/no-test-id-queries -- BaseUI popover animation leaves options visibility:hidden in jsdom after pagination renders; getByRole cannot find them
         await user.click(screen.getByTestId('filter-option-Column1'));
         await user.click(screen.getByLabelText('row1-col1-data'));
         await user.click(screen.getByRole('button', { name: 'Apply' }));
@@ -1424,6 +1423,7 @@ describe('Table', () => {
 
         // Apply filter that still leaves 2 pages (4 rows with pageSize=3 → 2 pages)
         await user.click(screen.getByRole('button', { name: 'Add filter' }));
+        // eslint-disable-next-line testing-library/no-test-id-queries -- BaseUI popover animation leaves options visibility:hidden in jsdom after pagination renders; getByRole cannot find them
         await user.click(screen.getByTestId('filter-option-Column1'));
         await user.click(screen.getByLabelText('row1-col1-data'));
         await user.click(screen.getByLabelText('row2-col1-data'));

--- a/javascript/packages/core/components/table/__tests__/table.test.tsx
+++ b/javascript/packages/core/components/table/__tests__/table.test.tsx
@@ -543,7 +543,7 @@ describe('Table', () => {
         await user.click(addFilterButton);
 
         // Step 2: Select department column
-        const departmentOption = screen.getByRole('option', { name: 'Department' });
+        const departmentOption = screen.getByTestId('filter-option-Department');
         await user.click(departmentOption);
 
         // Step 3: Select Engineering value in categorical filter
@@ -578,7 +578,7 @@ describe('Table', () => {
 
         // Apply a filter first
         await user.click(screen.getByRole('button', { name: 'Add filter' }));
-        await user.click(screen.getByRole('option', { name: 'Department' }));
+        await user.click(screen.getByTestId('filter-option-Department'));
         await user.click(screen.getByLabelText('Engineering'));
         await user.click(screen.getByRole('button', { name: 'Apply' }));
 
@@ -589,7 +589,7 @@ describe('Table', () => {
 
         // Open filter menu again and remove filter
         await user.click(screen.getByRole('button', { name: 'Add filter' }));
-        await user.click(screen.getByRole('option', { name: 'Department' }));
+        await user.click(screen.getByTestId('filter-option-Department'));
         await user.click(screen.getByLabelText('Engineering')); // Uncheck
         await user.click(screen.getByRole('button', { name: 'Apply' }));
 
@@ -604,7 +604,7 @@ describe('Table', () => {
 
         // Open filter menu and select Department column
         await user.click(screen.getByRole('button', { name: 'Add filter' }));
-        await user.click(screen.getByRole('option', { name: 'Department' }));
+        await user.click(screen.getByTestId('filter-option-Department'));
 
         // Select Marketing (we want to exclude this)
         await user.click(screen.getByLabelText('Marketing'));
@@ -666,7 +666,7 @@ describe('Table', () => {
 
         // But filter options should include all departments from unFilteredData
         await user.click(screen.getByRole('button', { name: 'Add filter' }));
-        await user.click(screen.getByRole('option', { name: 'Department' }));
+        await user.click(screen.getByTestId('filter-option-Department'));
 
         // Should have all department options available (Engineering, Marketing, Sales)
         expect(screen.getByLabelText('Engineering')).toBeInTheDocument();
@@ -704,7 +704,7 @@ describe('Table', () => {
         );
 
         await user.click(screen.getByRole('button', { name: 'Add filter' }));
-        await user.click(screen.getByRole('option', { name: 'Department' }));
+        await user.click(screen.getByTestId('filter-option-Department'));
 
         await waitFor(() => {
           expect(screen.getAllByText('Dept: Engineering')).toHaveLength(2);
@@ -758,7 +758,7 @@ describe('Table', () => {
         expect(screen.getByText('ML training pipeline')).toBeInTheDocument();
 
         await user.click(screen.getByRole('button', { name: 'Add filter' }));
-        await user.click(screen.getByRole('option', { name: 'Pipeline' }));
+        await user.click(screen.getByTestId('filter-option-Pipeline'));
         await waitFor(() => {
           expect(screen.getAllByText('my-ml-pipeline')).toHaveLength(2);
           expect(screen.getAllByText('data-processing')).toHaveLength(2);
@@ -798,11 +798,11 @@ describe('Table', () => {
         await user.click(screen.getByRole('button', { name: 'Add filter' }));
 
         // Should show CLIENT and SERVER mode columns
-        expect(screen.getByRole('option', { name: 'Name' })).toBeInTheDocument();
-        expect(screen.getByRole('option', { name: 'Department' })).toBeInTheDocument();
+        expect(screen.getByTestId('filter-option-Name')).toBeInTheDocument();
+        expect(screen.getByTestId('filter-option-Department')).toBeInTheDocument();
 
         // Should NOT show NONE mode column
-        expect(screen.queryByRole('option', { name: 'Notes' })).not.toBeInTheDocument();
+        expect(screen.queryByTestId('filter-option-Notes')).not.toBeInTheDocument();
       });
 
       it('hides filter menu entirely when all columns have FilterMode.NONE', () => {
@@ -868,7 +868,7 @@ describe('Table', () => {
 
       // Open filter menu and select DATE column
       await user.click(screen.getByRole('button', { name: 'Add filter' }));
-      await user.click(screen.getByRole('option', { name: 'Created At' }));
+      await user.click(screen.getByTestId('filter-option-Created At'));
 
       // Should open datetime filter (not categorical filter)
       // DatetimeFilter should render with Apply button
@@ -1390,7 +1390,7 @@ describe('Table', () => {
 
         // Apply column filter that drastically reduces results
         await user.click(screen.getByRole('button', { name: 'Add filter' }));
-        await user.click(await screen.findByRole('option', { name: 'Column1' }));
+        await user.click(screen.getByTestId('filter-option-Column1'));
         await user.click(screen.getByLabelText('row1-col1-data'));
         await user.click(screen.getByRole('button', { name: 'Apply' }));
 
@@ -1424,7 +1424,7 @@ describe('Table', () => {
 
         // Apply filter that still leaves 2 pages (4 rows with pageSize=3 → 2 pages)
         await user.click(screen.getByRole('button', { name: 'Add filter' }));
-        await user.click(await screen.findByRole('option', { name: 'Column1' }));
+        await user.click(screen.getByTestId('filter-option-Column1'));
         await user.click(screen.getByLabelText('row1-col1-data'));
         await user.click(screen.getByLabelText('row2-col1-data'));
         await user.click(screen.getByLabelText('row3-col1-data'));

--- a/javascript/packages/core/components/table/__tests__/table.test.tsx
+++ b/javascript/packages/core/components/table/__tests__/table.test.tsx
@@ -1390,7 +1390,7 @@ describe('Table', () => {
 
         // Apply column filter that drastically reduces results
         await user.click(screen.getByRole('button', { name: 'Add filter' }));
-        await user.click(screen.getByRole('option', { name: 'Column1' }));
+        await user.click(await screen.findByRole('option', { name: 'Column1' }));
         await user.click(screen.getByLabelText('row1-col1-data'));
         await user.click(screen.getByRole('button', { name: 'Apply' }));
 
@@ -1424,7 +1424,7 @@ describe('Table', () => {
 
         // Apply filter that still leaves 2 pages (4 rows with pageSize=3 → 2 pages)
         await user.click(screen.getByRole('button', { name: 'Add filter' }));
-        await user.click(screen.getByRole('option', { name: 'Column1' }));
+        await user.click(await screen.findByRole('option', { name: 'Column1' }));
         await user.click(screen.getByLabelText('row1-col1-data'));
         await user.click(screen.getByLabelText('row2-col1-data'));
         await user.click(screen.getByLabelText('row3-col1-data'));

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-option-list/table-filter-option-list.tsx
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-option-list/table-filter-option-list.tsx
@@ -33,7 +33,7 @@ export function TableFilterOptionList<T extends TableData = TableData>({
       >
         Select column to filter
       </div>
-      <ListContainer>
+      <ListContainer role="listbox">
         {filterableColumns.map((column) => (
           <TableFilterOption
             key={column.id}

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-option-list/table-filter-option-list.tsx
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-option-list/table-filter-option-list.tsx
@@ -33,7 +33,7 @@ export function TableFilterOptionList<T extends TableData = TableData>({
       >
         Select column to filter
       </div>
-      <ListContainer role="listbox">
+      <ListContainer>
         {filterableColumns.map((column) => (
           <TableFilterOption
             key={column.id}

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-option/table-filter-option.tsx
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-option/table-filter-option.tsx
@@ -5,7 +5,12 @@ import type { TableFilterOptionProps } from './types';
 
 export function TableFilterOption({ label, onClick }: TableFilterOptionProps) {
   return (
-    <FilterOptionItem onClick={onClick} data-testid={`filter-option-${label}`}>
+    <FilterOptionItem
+      onClick={onClick}
+      role="option"
+      aria-label={label}
+      data-testid={`filter-option-${label}`}
+    >
       {label}
       <Icon name="chevronRight" />
     </FilterOptionItem>

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-option/table-filter-option.tsx
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-option/table-filter-option.tsx
@@ -5,7 +5,7 @@ import type { TableFilterOptionProps } from './types';
 
 export function TableFilterOption({ label, onClick }: TableFilterOptionProps) {
   return (
-    <FilterOptionItem onClick={onClick} role="option" aria-label={label}>
+    <FilterOptionItem onClick={onClick} data-testid={`filter-option-${label}`}>
       {label}
       <Icon name="chevronRight" />
     </FilterOptionItem>

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-option/table-filter-option.tsx
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-filter-menu/components/table-filter-option/table-filter-option.tsx
@@ -5,7 +5,7 @@ import type { TableFilterOptionProps } from './types';
 
 export function TableFilterOption({ label, onClick }: TableFilterOptionProps) {
   return (
-    <FilterOptionItem onClick={onClick} data-testid={`filter-option-${label}`}>
+    <FilterOptionItem onClick={onClick} role="option" aria-label={label}>
       {label}
       <Icon name="chevronRight" />
     </FilterOptionItem>

--- a/javascript/packages/core/components/table/components/table-cell/__tests__/table-cell.test.tsx
+++ b/javascript/packages/core/components/table/components/table-cell/__tests__/table-cell.test.tsx
@@ -110,6 +110,7 @@ describe('TableCell', () => {
       );
 
       expect(screen.getByText('test-value')).toBeInTheDocument();
+      // eslint-disable-next-line testing-library/no-test-id-queries -- bare hover div, no accessible identity
       expect(screen.queryByTestId('tooltip-hover-container')).not.toBeInTheDocument();
     });
 
@@ -133,6 +134,7 @@ describe('TableCell', () => {
       );
 
       expect(screen.getByText('test-value')).toBeInTheDocument();
+      // eslint-disable-next-line testing-library/no-test-id-queries -- bare hover div, no accessible identity
       expect(screen.getByTestId('tooltip-hover-container')).toBeInTheDocument();
     });
 
@@ -213,6 +215,7 @@ describe('TableCell', () => {
       );
 
       expect(screen.getByText('test-value')).toBeInTheDocument();
+      // eslint-disable-next-line testing-library/no-test-id-queries -- bare hover div, no accessible identity
       expect(screen.queryByTestId('tooltip-hover-container')).not.toBeInTheDocument();
     });
 

--- a/javascript/packages/core/components/table/components/table-empty-state/__tests__/table-empty-state.test.tsx
+++ b/javascript/packages/core/components/table/components/table-empty-state/__tests__/table-empty-state.test.tsx
@@ -39,7 +39,7 @@ describe('TableEmptyState', () => {
     render(<TableEmptyState emptyState={emptyState} />);
 
     expect(screen.getByRole('heading', { name: 'Empty table' })).toBeInTheDocument();
-    expect(screen.getByTestId('empty-icon')).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'Circle Exclamation Mark icon' })).toBeInTheDocument();
   });
 
   it('should render with all props provided', () => {
@@ -57,6 +57,6 @@ describe('TableEmptyState', () => {
 
     expect(screen.getByRole('heading', { name: 'No data' })).toBeInTheDocument();
     expect(screen.getByText('No data is present.')).toBeInTheDocument();
-    expect(screen.getByTestId('complete-icon')).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'Circle Exclamation Mark icon' })).toBeInTheDocument();
   });
 });

--- a/javascript/packages/core/components/table/components/table-loading-state.tsx
+++ b/javascript/packages/core/components/table/components/table-loading-state.tsx
@@ -8,7 +8,7 @@ import {
 
 export function TableLoadingState() {
   return (
-    <StyledTableBody data-testid="table-loading-state">
+    <StyledTableBody aria-label="Loading">
       {[1, 2, 3].map((row) => (
         <StyledTableBodyRow key={row}>
           <StyledTableBodyCell colSpan={100}>

--- a/javascript/packages/core/components/table/components/with-sticky-sides/__tests__/with-sticky-sides.test.tsx
+++ b/javascript/packages/core/components/table/components/with-sticky-sides/__tests__/with-sticky-sides.test.tsx
@@ -27,6 +27,9 @@ describe('withStickySides integration tests', () => {
       </StickySidesRow>
     );
 
+    // No semantic query can distinguish "is this cell sticky" — the HOC sets
+    // data-testid as the only marker of sticky identity on otherwise generic <td> elements.
+    // eslint-disable-next-line testing-library/no-test-id-queries
     expect(screen.queryByTestId(/^sticky-cell-/)).not.toBeInTheDocument();
   });
 
@@ -46,8 +49,11 @@ describe('withStickySides integration tests', () => {
       </StickySidesRow>
     );
 
-    // Should have sticky: selection (0) + first data (1) + config (3)
+    // No semantic query can distinguish sticky-left from sticky-right — the HOC
+    // injects data-testid as the sole marker of sticky side on generic <td> elements.
+    // eslint-disable-next-line testing-library/no-test-id-queries
     expect(screen.getAllByTestId('sticky-cell-left-sticky')).toHaveLength(2);
+    // eslint-disable-next-line testing-library/no-test-id-queries
     expect(screen.getAllByTestId('sticky-cell-right-sticky')).toHaveLength(1);
   });
 
@@ -66,8 +72,11 @@ describe('withStickySides integration tests', () => {
       </StickySidesRow>
     );
 
-    // Should have sticky: first data (0) + config (2)
+    // No semantic query can distinguish sticky-left from sticky-right — the HOC
+    // injects data-testid as the sole marker of sticky side on generic <td> elements.
+    // eslint-disable-next-line testing-library/no-test-id-queries
     expect(screen.getAllByTestId('sticky-cell-left-sticky')).toHaveLength(1);
+    // eslint-disable-next-line testing-library/no-test-id-queries
     expect(screen.getAllByTestId('sticky-cell-right-sticky')).toHaveLength(1);
   });
 

--- a/javascript/packages/core/components/table/types/column-types.ts
+++ b/javascript/packages/core/components/table/types/column-types.ts
@@ -10,7 +10,7 @@ import type { TableRow } from './row-types';
 
 declare module '@tanstack/react-table' {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-object-type
-  interface ColumnMeta<TData extends TableData, TValue> extends ColumnConfig<TData> {}
+  interface ColumnMeta<TData extends TableData, TValue> {}
 }
 
 export type ColumnConfig<TData = TableData> = DistributiveOmit<Cell<TData>, 'tooltip'> & {

--- a/javascript/packages/core/components/views/detail-view/components/detail-view-page-renderer/pages/detail-view-table-page/__tests__/detail-view-table-page.test.tsx
+++ b/javascript/packages/core/components/views/detail-view/components/detail-view-page-renderer/pages/detail-view-table-page/__tests__/detail-view-table-page.test.tsx
@@ -70,7 +70,7 @@ describe('DetailViewTablePage', () => {
     expect(mockRequest).not.toHaveBeenCalledWith('ListPipelineRun', expect.anything());
 
     expect(screen.queryByText('Should Not Appear')).not.toBeInTheDocument();
-    expect(screen.getByTestId('table-loading-state')).toBeInTheDocument();
+    expect(screen.getByRole('rowgroup', { name: 'Loading' })).toBeInTheDocument();
   });
 
   test('respects query clientOptions.enabled when detail view is not loading', () => {

--- a/javascript/packages/core/hooks/__tests__/use-hover.test.tsx
+++ b/javascript/packages/core/hooks/__tests__/use-hover.test.tsx
@@ -34,7 +34,8 @@ describe('useHover', () => {
     const user = userEvent.setup();
     render(<TestHoverComponent />);
 
-    const target = screen.getByTestId('hover-target');
+    const target = screen.getByText('Hover me');
+    // eslint-disable-next-line testing-library/no-test-id-queries -- plain div, element identity needed to read textContent across state changes
     const status = screen.getByTestId('hover-status');
 
     expect(status.textContent).toBe('not-hovered');

--- a/javascript/yarn.lock
+++ b/javascript/yarn.lock
@@ -590,6 +590,13 @@
   dependencies:
     eslint-visitor-keys "^3.4.3"
 
+"@eslint-community/eslint-utils@^4.9.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz#4e90af67bc51ddee6cdef5284edf572ec376b595"
+  integrity sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==
+  dependencies:
+    eslint-visitor-keys "^3.4.3"
+
 "@eslint-community/regexpp@^4.10.0", "@eslint-community/regexpp@^4.12.1":
   version "4.12.2"
   resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.12.2.tgz#bccdf615bcf7b6e8db830ec0b8d21c9a25de597b"
@@ -1380,6 +1387,15 @@
     "@typescript-eslint/types" "^8.46.4"
     debug "^4.3.4"
 
+"@typescript-eslint/project-service@8.61.0":
+  version "8.61.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/project-service/-/project-service-8.61.0.tgz#417a2feac32e8ebd336d63f068c3b42b736ea1ac"
+  integrity sha512-DV42F7MLJO6Rax7SK1yg43tcnEfGUrurSpSxKuVX+a3RCTzBlH3fuxprrOJXKCJGAaw82xXocikJ0uQaqwXgGA==
+  dependencies:
+    "@typescript-eslint/tsconfig-utils" "^8.61.0"
+    "@typescript-eslint/types" "^8.61.0"
+    debug "^4.4.3"
+
 "@typescript-eslint/scope-manager@8.46.4":
   version "8.46.4"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.46.4.tgz#78c9b4856c0094def64ffa53ea955b46bec13304"
@@ -1388,10 +1404,23 @@
     "@typescript-eslint/types" "8.46.4"
     "@typescript-eslint/visitor-keys" "8.46.4"
 
+"@typescript-eslint/scope-manager@8.61.0", "@typescript-eslint/scope-manager@^8.56.0":
+  version "8.61.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.61.0.tgz#93c2520d05653fe65eb9ee98efc74fd0134a7852"
+  integrity sha512-IWdXFHFSb6mlC3HPc7QsLDm5zYEbUla6trDEHf32D3/dnuUyXd87plScSNXSbm0/RxMvObpI17sv/EDTGrGZkA==
+  dependencies:
+    "@typescript-eslint/types" "8.61.0"
+    "@typescript-eslint/visitor-keys" "8.61.0"
+
 "@typescript-eslint/tsconfig-utils@8.46.4", "@typescript-eslint/tsconfig-utils@^8.46.4":
   version "8.46.4"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.46.4.tgz#989a338093b6b91b0552f1f51331d89ec6980382"
   integrity sha512-+/XqaZPIAk6Cjg7NWgSGe27X4zMGqrFqZ8atJsX3CWxH/jACqWnrWI68h7nHQld0y+k9eTTjb9r+KU4twLoo9A==
+
+"@typescript-eslint/tsconfig-utils@8.61.0", "@typescript-eslint/tsconfig-utils@^8.61.0":
+  version "8.61.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.0.tgz#05d6e3ff20001674ebcd22d03dac29ee448043ba"
+  integrity sha512-O5Amvdv9ztMpxpf+vmFULGG78IE6Qwdr3bCGvqwG4nwc9H2qXkOYJJnRbRHyMkQTjv1d03olqwwwzHLMqpFePQ==
 
 "@typescript-eslint/type-utils@8.46.4":
   version "8.46.4"
@@ -1409,6 +1438,11 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.46.4.tgz#38022bfda051be80e4120eeefcd2b6e3e630a69b"
   integrity sha512-USjyxm3gQEePdUwJBFjjGNG18xY9A2grDVGuk7/9AkjIF1L+ZrVnwR5VAU5JXtUnBL/Nwt3H31KlRDaksnM7/w==
 
+"@typescript-eslint/types@8.61.0", "@typescript-eslint/types@^8.61.0":
+  version "8.61.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.61.0.tgz#0ddb46e012a4288292950bdd253db42f278ce64d"
+  integrity sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==
+
 "@typescript-eslint/typescript-estree@8.46.4":
   version "8.46.4"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.46.4.tgz#6a9eeab0da45bf400f22c818e0f47102a980ceaa"
@@ -1425,6 +1459,21 @@
     semver "^7.6.0"
     ts-api-utils "^2.1.0"
 
+"@typescript-eslint/typescript-estree@8.61.0":
+  version "8.61.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.0.tgz#98ca47260bbf627fc28f018b3a0abf00e3090690"
+  integrity sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA==
+  dependencies:
+    "@typescript-eslint/project-service" "8.61.0"
+    "@typescript-eslint/tsconfig-utils" "8.61.0"
+    "@typescript-eslint/types" "8.61.0"
+    "@typescript-eslint/visitor-keys" "8.61.0"
+    debug "^4.4.3"
+    minimatch "^10.2.2"
+    semver "^7.7.3"
+    tinyglobby "^0.2.15"
+    ts-api-utils "^2.5.0"
+
 "@typescript-eslint/utils@8.46.4":
   version "8.46.4"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.46.4.tgz#ea7878ddd625948cad4424dc2752b1be236556f5"
@@ -1435,6 +1484,16 @@
     "@typescript-eslint/types" "8.46.4"
     "@typescript-eslint/typescript-estree" "8.46.4"
 
+"@typescript-eslint/utils@^8.56.0":
+  version "8.61.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.61.0.tgz#ed3546a052787e84ea6c5064d0919fc5eea8522f"
+  integrity sha512-3bzFt7ImFMW/jVYwJamDoe/dMOdFLSC6pom6rRjdh4SZJEYupyMzem8e7vKZLclLfpHjlwSAXOUxtKxGXUiLqA==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.9.1"
+    "@typescript-eslint/scope-manager" "8.61.0"
+    "@typescript-eslint/types" "8.61.0"
+    "@typescript-eslint/typescript-estree" "8.61.0"
+
 "@typescript-eslint/visitor-keys@8.46.4":
   version "8.46.4"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.46.4.tgz#07031bd8d3ca6474e121221dae1055daead888f1"
@@ -1442,6 +1501,14 @@
   dependencies:
     "@typescript-eslint/types" "8.46.4"
     eslint-visitor-keys "^4.2.1"
+
+"@typescript-eslint/visitor-keys@8.61.0":
+  version "8.61.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.0.tgz#39b4e1ab8936d23bea973d39fd092f9aa21f275e"
+  integrity sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==
+  dependencies:
+    "@typescript-eslint/types" "8.61.0"
+    eslint-visitor-keys "^5.0.0"
 
 "@uiw/codemirror-extensions-basic-setup@4.25.3":
   version "4.25.3"
@@ -1747,6 +1814,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+balanced-match@^4.0.2:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
+  integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
+
 baseline-browser-mapping@^2.8.25:
   version "2.8.28"
   resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.8.28.tgz#9ef511f5a7c19d74a94cafcbf951608398e9bdb3"
@@ -1808,6 +1880,13 @@ brace-expansion@^2.0.1:
   integrity sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==
   dependencies:
     balanced-match "^1.0.0"
+
+brace-expansion@^5.0.5:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.6.tgz#ec68fe0a641a29d8711579caf641d05bae1f2285"
+  integrity sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==
+  dependencies:
+    balanced-match "^4.0.2"
 
 braces@^3.0.3, braces@~3.0.2:
   version "3.0.3"
@@ -2346,7 +2425,7 @@ date-fns@^2.28.0:
   dependencies:
     "@babel/runtime" "^7.21.0"
 
-debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.1:
+debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.1, debug@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
@@ -2667,6 +2746,14 @@ eslint-plugin-simple-import-sort@^12.1.1:
   resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.1.1.tgz#e64bfdaf91c5b98a298619aa634a9f7aa43b709e"
   integrity sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==
 
+eslint-plugin-testing-library@^7.16.2:
+  version "7.16.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-testing-library/-/eslint-plugin-testing-library-7.16.2.tgz#b59738085db6bb3b2fed0294c70c9098b45bbf90"
+  integrity sha512-8gleGnQXK2ZA3hHwjCwpYTZvM+9VsrJ+/9kDI8CjqAQGAdMQOdn/rJNu7ZySENuiWlGKQWyZJ4ZjEg2zamaRHw==
+  dependencies:
+    "@typescript-eslint/scope-manager" "^8.56.0"
+    "@typescript-eslint/utils" "^8.56.0"
+
 eslint-scope@^8.4.0:
   version "8.4.0"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-8.4.0.tgz#88e646a207fad61436ffa39eb505147200655c82"
@@ -2684,6 +2771,11 @@ eslint-visitor-keys@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz#4cfea60fe7dd0ad8e816e1ed026c1d5251b512c1"
   integrity sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==
+
+eslint-visitor-keys@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz#9e3c9489697824d2d4ce3a8ad12628f91e9f59be"
+  integrity sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==
 
 eslint@^9.23.0:
   version "9.39.1"
@@ -3830,6 +3922,13 @@ min-indent@^1.0.0:
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
+minimatch@^10.2.2:
+  version "10.2.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.5.tgz#bd48687a0be38ed2961399105600f832095861d1"
+  integrity sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==
+  dependencies:
+    brace-expansion "^5.0.5"
+
 minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
@@ -4085,6 +4184,11 @@ picomatch@^4.0.2, picomatch@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.3.tgz#796c76136d1eead715db1e7bad785dedd695a042"
   integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
+
+picomatch@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
+  integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
 
 plimit-lit@^1.2.6:
   version "1.6.1"
@@ -4614,6 +4718,11 @@ semver@^7.5.3, semver@^7.6.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.3.tgz#4b5f4143d007633a8dc671cd0a6ef9147b8bb946"
   integrity sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==
 
+semver@^7.7.3:
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.4.tgz#c73eceebae0616934be8dff28a7fd70757c8e696"
+  integrity sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==
+
 set-function-length@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.2.2.tgz#aac72314198eaed975cf77b2c3b6b880695e5449"
@@ -4958,6 +5067,14 @@ tinyglobby@^0.2.13, tinyglobby@^0.2.14:
     fdir "^6.5.0"
     picomatch "^4.0.3"
 
+tinyglobby@^0.2.15:
+  version "0.2.17"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.17.tgz#562a9a6c9eb2b3b123d39719f9af5bb44fcd7631"
+  integrity sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==
+  dependencies:
+    fdir "^6.5.0"
+    picomatch "^4.0.4"
+
 tinypool@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-1.1.1.tgz#059f2d042bd37567fbc017d3d426bdd2a2612591"
@@ -5020,6 +5137,11 @@ ts-api-utils@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-2.1.0.tgz#595f7094e46eed364c13fd23e75f9513d29baf91"
   integrity sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==
+
+ts-api-utils@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-2.5.0.tgz#4acd4a155e22734990a5ed1fe9e97f113bcb37c1"
+  integrity sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==
 
 tsc-alias@^1.8.16:
   version "1.8.16"


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Refactor

**What changed?**

Adds `eslint-plugin-testing-library` with two rules enforced across all `packages/**/__tests__` files:
- `no-test-id-queries` — disallows `getByTestId` / `queryByTestId` / `findByTestId`
- `prefer-screen-queries` — requires queries to go through `screen`

Tests were migrated to semantic queries (`getByRole`, `getByText`, `getByLabelText`, etc.). Three components also gained ARIA attributes that were appropriate regardless of the test change: filter option items now carry `role="option"` and their container `role="listbox"`, and the table loading state carries `aria-label="Loading"`. Where no semantic query exists — bare hover divs, HOC-injected sticky cell testids, Skeleton components — queries are suppressed with a short explanation.

**Why?**

`getByTestId` queries couple tests to `data-testid` attributes, which are implementation details with no meaning to users or assistive technology. Semantic queries test the interface users actually interact with — they catch regressions in accessible behavior and are resilient to internal markup changes.

**How did you test it?**

I ran `yarn lint --quiet` (zero errors) and `yarn test` across the affected packages. The pre-existing typecheck failure in `column-types.ts` is unrelated to this change and present on main.

**Potential risks**

None. Test-only and lint config changes; no runtime behavior affected. Component ARIA additions are purely additive.

**Release notes**

None.

**Documentation Changes**

None.