### PR TITLE
Add ModelVariable to workflow/variables/_private

### DIFF
--- a/python/michelangelo/workflow/variables/__init__.py
+++ b/python/michelangelo/workflow/variables/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from michelangelo.workflow.variables._private.dataset import DatasetVariable
+from michelangelo.workflow.variables._private.model import ModelVariable
 from michelangelo.workflow.variables.metadata import ModelMetadata
 from michelangelo.workflow.variables.types import (
     AssembledModel,
@@ -15,5 +16,6 @@ __all__ = [
     "DatasetVariable",
     "ModelArtifact",
     "ModelMetadata",
+    "ModelVariable",
     "PusherResult",
 ]

--- a/python/michelangelo/workflow/variables/_private/model.py
+++ b/python/michelangelo/workflow/variables/_private/model.py
@@ -1,8 +1,8 @@
 """ModelVariable — trained-model variable for ML workflow tasks.
 
-Mirrors the internal ``ModelVariable`` design exactly: subclasses ``Variable``,
-wraps a storage path and a transient in-memory value, and dispatches save/load
-to format-specific handlers based on ``metadata.training_framework``.
+Subclasses ``Variable``, wraps a storage path and a transient in-memory value,
+and dispatches save/load to format-specific handlers based on
+``metadata.training_framework``.
 
 Three frameworks are supported as first-class citizens:
 
@@ -21,7 +21,6 @@ Three frameworks are supported as first-class citizens:
     Import ``ModelVariable`` from ``michelangelo.workflow.variables`` instead.
 """
 
-# ruff: noqa: I001
 from __future__ import annotations
 
 import logging
@@ -48,8 +47,7 @@ _logger = logging.getLogger(__name__)
 class ModelVariable(Variable):
     """A model variable flowing between workflow tasks.
 
-    Subclasses ``Variable`` — the same base used by the internal
-    ``ModelVariable``. Underlying it could be a PyTorch model, a Lightning
+    Subclasses ``Variable``. Underlying it could be a PyTorch model, a Lightning
     module, or a user-defined ``CustomModel``. Persistence is delegated to
     framework-specific handlers; dispatch is keyed on
     ``metadata.training_framework``.
@@ -104,8 +102,6 @@ class ModelVariable(Variable):
         except ImportError:
             pass
 
-        # TODO: implement other models
-
         return res
 
     def _load(self):
@@ -131,10 +127,13 @@ class ModelVariable(Variable):
         """Save value to variable path, dispatched on training_framework.
 
         Raises:
-            ValueError: If ``metadata.training_framework`` is unset or
-                unrecognised. Call the framework-specific ``save_*`` method
-                directly when auto-dispatch is not possible.
+            ValueError: If no value has been set on this variable, or if
+                ``metadata.training_framework`` is unset or unrecognised. Call
+                the framework-specific ``save_*`` method directly when
+                auto-dispatch is not possible.
         """
+        if self._value is None:
+            raise ValueError("Cannot save: no value has been set on this variable.")
         if self.metadata.training_framework == TRAINING_FRAMEWORK_CUSTOM:
             self.save_custom_model()
         elif self.metadata.training_framework == TRAINING_FRAMEWORK_PYTORCH:
@@ -157,11 +156,11 @@ class ModelVariable(Variable):
         directory tree to ``self.path`` via fsspec. No-ops when the value has
         already been saved.
         """
-        _logger.info(f"Saving custom model for {self.path}")
+        _logger.info("Saving custom model for %s", self.path)
 
         if self._saved:
             _logger.info(
-                f"Custom model value already saved for {self.path}. Skipping saving."
+                "Custom model value already saved for %s. Skipping saving.", self.path
             )
             return
 
@@ -178,8 +177,16 @@ class ModelVariable(Variable):
         Imports the model class from ``metadata.model_class``, downloads the
         artifact tree from ``self.path`` to a temporary directory, and calls
         ``model_class.load(temp_path)``.
+
+        Raises:
+            ValueError: If ``metadata.model_class`` is not set.
         """
-        _logger.info(f"Loading custom model from {self.path}")
+        _logger.info("Loading custom model from %s", self.path)
+
+        if not self.metadata.model_class:
+            raise ValueError(
+                "model_class must be set in metadata to load a custom model."
+            )
 
         model_class = import_attribute(self.metadata.model_class)
 
@@ -198,15 +205,17 @@ class ModelVariable(Variable):
         """Save a ``torch.nn.Module`` to ``self.path`` with a ``.pt`` suffix.
 
         The ``.pt`` extension is appended when missing — required for
-        compatibility with the Triton torch packager.
+        compatibility with the Triton torch packager. The full model object
+        is pickled via ``torch.save(self._value, ...)``; loading therefore
+        requires ``weights_only=False`` (see ``load_torch_model``).
         """
         import torch
 
-        _logger.info(f"Saving PyTorch model for {self.path}")
+        _logger.info("Saving PyTorch model for %s", self.path)
 
         if self._saved:
             _logger.info(
-                f"PyTorch model value already saved for {self.path}. Skipping saving."
+                "PyTorch model value already saved for %s. Skipping saving.", self.path
             )
             return
 
@@ -221,21 +230,36 @@ class ModelVariable(Variable):
 
         self._saved = True
 
-    def load_torch_model(self):
+    def load_torch_model(self, weights_only: bool = True):
         """Load a ``torch.nn.Module`` via ``torch.load`` (CPU map-location).
 
-        Uses ``weights_only=False`` to permit full pickle loading — callers
-        must trust the artifact source.
+        Args:
+            weights_only: Forwarded to ``torch.load``. Defaults to ``True`` —
+                the safer mode that refuses to execute arbitrary pickle
+                opcodes. Pass ``weights_only=False`` when loading artifacts
+                produced by ``save_torch_model``, which pickle the full
+                ``nn.Module`` object (state_dict-only artifacts work with
+                the default).
+
+        Security:
+            ``weights_only=False`` permits arbitrary code execution from the
+            pickle stream. Only set it when the artifact source is trusted.
         """
         import torch
 
-        _logger.info(f"Loading PyTorch model from {self.path}")
+        _logger.info(
+            "Loading PyTorch model from %s (weights_only=%s)",
+            self.path,
+            weights_only,
+        )
 
         fs, path = fsspec.core.url_to_fs(self.path)
         with tempfile.TemporaryDirectory() as temp_dir:
             model_path = os.path.join(temp_dir, "model")
             fs.get(path, model_path, recursive=True)
-            self._value = torch.load(model_path, map_location="cpu", weights_only=False)
+            self._value = torch.load(
+                model_path, map_location="cpu", weights_only=weights_only
+            )
         self._saved = True
 
     # ------------------------------------------------------------------
@@ -251,11 +275,12 @@ class ModelVariable(Variable):
         """
         import torch
 
-        _logger.info(f"Saving Lightning model for {self.path}")
+        _logger.info("Saving Lightning model for %s", self.path)
 
         if self._saved:
             _logger.info(
-                f"Lightning model value already saved for {self.path}. Skipping saving."
+                "Lightning model value already saved for %s. Skipping saving.",
+                self.path,
             )
             return
 
@@ -276,20 +301,21 @@ class ModelVariable(Variable):
         2. Construct an instance via ``model_class(**metadata.hyperparameters)``
            (empty dict when ``hyperparameters`` is ``None``).
         3. Download the ``state_dict`` from ``self.path`` and apply
-           ``load_state_dict`` (``weights_only=True`` for safety).
+           ``load_state_dict`` (``weights_only=True`` — only tensors are
+           unpickled, so the call is safe against malicious artifacts).
         4. Call ``model.eval()`` and store as ``self._value``.
 
         Raises:
             ValueError: If ``metadata.model_class`` is not set.
         """
-        import torch
-
-        _logger.info(f"Loading Lightning model from {self.path}")
-
         if not self.metadata.model_class:
             raise ValueError(
                 "model_class must be set in metadata to load Lightning model"
             )
+
+        import torch
+
+        _logger.info("Loading Lightning model from %s", self.path)
 
         model_class = import_attribute(self.metadata.model_class)
         hyperparameters = self.metadata.hyperparameters or {}

--- a/python/michelangelo/workflow/variables/_private/model.py
+++ b/python/michelangelo/workflow/variables/_private/model.py
@@ -1,0 +1,307 @@
+"""ModelVariable — trained-model variable for ML workflow tasks.
+
+Mirrors the internal ``ModelVariable`` design exactly: subclasses ``Variable``,
+wraps a storage path and a transient in-memory value, and dispatches save/load
+to format-specific handlers based on ``metadata.training_framework``.
+
+Three frameworks are supported as first-class citizens:
+
+- ``"custom"`` — user-defined ``Model`` subclasses (``CustomModel.save`` /
+  ``CustomModel.load``) from
+  ``michelangelo.lib.model_manager.interface.custom_model``.
+- ``"pytorch"`` — generic ``torch.nn.Module`` via ``torch.save`` /
+  ``torch.load``. The storage path is auto-suffixed with ``.pt`` for
+  compatibility with the Triton torch packager.
+- ``"lightning"`` — ``pytorch_lightning.LightningModule`` via
+  ``state_dict`` round-trip; loading re-instantiates ``metadata.model_class``
+  with ``metadata.hyperparameters`` and applies ``load_state_dict``.
+
+``_private/`` convention:
+    This file lives in ``_private/`` — do not import directly from this path.
+    Import ``ModelVariable`` from ``michelangelo.workflow.variables`` instead.
+"""
+
+# ruff: noqa: I001
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from dataclasses import dataclass
+from typing import Any
+
+import fsspec
+
+from michelangelo.uniflow.core.utils import dot_path, import_attribute
+from michelangelo.workflow.variables._private.base import Variable
+from michelangelo.workflow.variables.metadata import (
+    TRAINING_FRAMEWORK_CUSTOM,
+    TRAINING_FRAMEWORK_LIGHTNING,
+    TRAINING_FRAMEWORK_PYTORCH,
+    ModelMetadata,
+)
+
+_logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ModelVariable(Variable):
+    """A model variable flowing between workflow tasks.
+
+    Subclasses ``Variable`` — the same base used by the internal
+    ``ModelVariable``. Underlying it could be a PyTorch model, a Lightning
+    module, or a user-defined ``CustomModel``. Persistence is delegated to
+    framework-specific handlers; dispatch is keyed on
+    ``metadata.training_framework``.
+    """
+
+    @classmethod
+    def create(cls, value: Any) -> ModelVariable:
+        """Create a ``ModelVariable`` and auto-detect the training framework.
+
+        The framework is set to ``"custom"`` when ``value`` implements the
+        ``CustomModel`` ABC, ``"pytorch"`` when it's a ``torch.nn.Module``,
+        and otherwise left unset (callers must populate ``metadata`` manually
+        before calling ``save()``).
+
+        Args:
+            value: The in-memory model. ``CustomModel`` and ``torch.nn.Module``
+                instances are recognised automatically; other framework types
+                require manual ``metadata.training_framework`` setup.
+
+        Returns:
+            A new ``ModelVariable`` with ``value`` ready in memory and
+            ``metadata`` populated with framework + ``model_class``.
+
+        Example:
+            >>> import torch  # doctest: +SKIP
+            >>> var = ModelVariable.create(torch.nn.Linear(2, 1))  # doctest: +SKIP
+            >>> var.metadata.training_framework  # doctest: +SKIP
+            'pytorch'
+        """
+        res = super().create(value)
+        res.metadata = ModelMetadata()
+
+        try:
+            from michelangelo.lib.model_manager.interface.custom_model import (
+                Model as CustomModel,
+            )
+
+            if isinstance(value, CustomModel):
+                res.metadata.training_framework = TRAINING_FRAMEWORK_CUSTOM
+                res.metadata.model_class = dot_path(type(value))
+                return res
+        except ImportError:
+            pass
+
+        try:
+            import torch
+
+            if isinstance(value, torch.nn.Module):
+                res.metadata.training_framework = TRAINING_FRAMEWORK_PYTORCH
+                res.metadata.model_class = dot_path(type(value))
+                return res
+        except ImportError:
+            pass
+
+        # TODO: implement other models
+
+        return res
+
+    def _load(self):
+        """Load value from variable path, dispatched on training_framework.
+
+        Raises:
+            ValueError: If ``metadata.training_framework`` is unset or
+                unrecognised. Call the framework-specific ``load_*`` method
+                directly when auto-dispatch is not possible.
+        """
+        if self.metadata.training_framework == TRAINING_FRAMEWORK_CUSTOM:
+            self.load_custom_model()
+        elif self.metadata.training_framework == TRAINING_FRAMEWORK_PYTORCH:
+            self.load_torch_model()
+        elif self.metadata.training_framework == TRAINING_FRAMEWORK_LIGHTNING:
+            self.load_lightning_model()
+        else:
+            raise ValueError(
+                f"Unrecognized training framework: {self.metadata.training_framework}"
+            )
+
+    def save(self):
+        """Save value to variable path, dispatched on training_framework.
+
+        Raises:
+            ValueError: If ``metadata.training_framework`` is unset or
+                unrecognised. Call the framework-specific ``save_*`` method
+                directly when auto-dispatch is not possible.
+        """
+        if self.metadata.training_framework == TRAINING_FRAMEWORK_CUSTOM:
+            self.save_custom_model()
+        elif self.metadata.training_framework == TRAINING_FRAMEWORK_PYTORCH:
+            self.save_torch_model()
+        elif self.metadata.training_framework == TRAINING_FRAMEWORK_LIGHTNING:
+            self.save_lightning_model()
+        else:
+            raise ValueError(
+                f"Unrecognized training framework: {self.metadata.training_framework}"
+            )
+
+    # ------------------------------------------------------------------
+    # Custom model
+    # ------------------------------------------------------------------
+
+    def save_custom_model(self):
+        """Save a ``CustomModel`` instance via its ``.save(path)`` method.
+
+        Materialises the model into a temporary directory and uploads the
+        directory tree to ``self.path`` via fsspec. No-ops when the value has
+        already been saved.
+        """
+        _logger.info(f"Saving custom model for {self.path}")
+
+        if self._saved:
+            _logger.info(
+                f"Custom model value already saved for {self.path}. Skipping saving."
+            )
+            return
+
+        fs, path = fsspec.core.url_to_fs(self.path)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self._value.save(temp_dir)
+            fs.put(temp_dir, path, recursive=True)
+
+        self._saved = True
+
+    def load_custom_model(self):
+        """Load a ``CustomModel`` via its ``.load(path)`` classmethod.
+
+        Imports the model class from ``metadata.model_class``, downloads the
+        artifact tree from ``self.path`` to a temporary directory, and calls
+        ``model_class.load(temp_path)``.
+        """
+        _logger.info(f"Loading custom model from {self.path}")
+
+        model_class = import_attribute(self.metadata.model_class)
+
+        fs, path = fsspec.core.url_to_fs(self.path)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            model_path = os.path.join(temp_dir, "model")
+            fs.get(path, model_path, recursive=True)
+            self._value = model_class.load(model_path)
+        self._saved = True
+
+    # ------------------------------------------------------------------
+    # PyTorch model
+    # ------------------------------------------------------------------
+
+    def save_torch_model(self):
+        """Save a ``torch.nn.Module`` to ``self.path`` with a ``.pt`` suffix.
+
+        The ``.pt`` extension is appended when missing — required for
+        compatibility with the Triton torch packager.
+        """
+        import torch
+
+        _logger.info(f"Saving PyTorch model for {self.path}")
+
+        if self._saved:
+            _logger.info(
+                f"PyTorch model value already saved for {self.path}. Skipping saving."
+            )
+            return
+
+        if not self.path.endswith(".pt"):
+            self.path = f"{self.path}.pt"
+
+        fs, path = fsspec.core.url_to_fs(self.path)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            model_file = os.path.join(temp_dir, "model.pt")
+            torch.save(self._value, model_file)
+            fs.put(model_file, path)
+
+        self._saved = True
+
+    def load_torch_model(self):
+        """Load a ``torch.nn.Module`` via ``torch.load`` (CPU map-location).
+
+        Uses ``weights_only=False`` to permit full pickle loading — callers
+        must trust the artifact source.
+        """
+        import torch
+
+        _logger.info(f"Loading PyTorch model from {self.path}")
+
+        fs, path = fsspec.core.url_to_fs(self.path)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            model_path = os.path.join(temp_dir, "model")
+            fs.get(path, model_path, recursive=True)
+            self._value = torch.load(model_path, map_location="cpu", weights_only=False)
+        self._saved = True
+
+    # ------------------------------------------------------------------
+    # PyTorch Lightning model
+    # ------------------------------------------------------------------
+
+    def save_lightning_model(self):
+        """Save a Lightning module's ``state_dict`` via ``torch.save``.
+
+        Stores only the ``state_dict``; the model class itself is not
+        serialised. Loading requires ``metadata.model_class`` to be set so
+        the class can be re-instantiated.
+        """
+        import torch
+
+        _logger.info(f"Saving Lightning model for {self.path}")
+
+        if self._saved:
+            _logger.info(
+                f"Lightning model value already saved for {self.path}. Skipping saving."
+            )
+            return
+
+        fs, path = fsspec.core.url_to_fs(self.path)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            model_file = os.path.join(temp_dir, "model.pt")
+            torch.save(self._value.state_dict(), model_file)
+            fs.put(model_file, path, recursive=True)
+
+        self._saved = True
+
+    def load_lightning_model(self):
+        """Load a Lightning module by re-instantiating ``model_class``.
+
+        Steps:
+
+        1. Import the class from ``metadata.model_class``.
+        2. Construct an instance via ``model_class(**metadata.hyperparameters)``
+           (empty dict when ``hyperparameters`` is ``None``).
+        3. Download the ``state_dict`` from ``self.path`` and apply
+           ``load_state_dict`` (``weights_only=True`` for safety).
+        4. Call ``model.eval()`` and store as ``self._value``.
+
+        Raises:
+            ValueError: If ``metadata.model_class`` is not set.
+        """
+        import torch
+
+        _logger.info(f"Loading Lightning model from {self.path}")
+
+        if not self.metadata.model_class:
+            raise ValueError(
+                "model_class must be set in metadata to load Lightning model"
+            )
+
+        model_class = import_attribute(self.metadata.model_class)
+        hyperparameters = self.metadata.hyperparameters or {}
+        model = model_class(**hyperparameters)
+
+        fs, path = fsspec.core.url_to_fs(self.path)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            model_file = os.path.join(temp_dir, "model.pt")
+            fs.get(path, model_file, recursive=True)
+            state_dict = torch.load(model_file, map_location="cpu", weights_only=True)
+            model.load_state_dict(state_dict)
+
+        model.eval()
+        self._value = model
+        self._saved = True

--- a/python/michelangelo/workflow/variables/_private/model.py
+++ b/python/michelangelo/workflow/variables/_private/model.py
@@ -10,19 +10,17 @@ Three frameworks are supported as first-class citizens:
   ``CustomModel.load``) from
   ``michelangelo.lib.model_manager.interface.custom_model``. Artifact layout
   is a directory tree controlled by the user's ``save()`` implementation.
-- ``"pytorch"`` — generic ``torch.nn.Module`` via ``torch.save(state_dict())``
-  and ``torch.load(..., weights_only=True)``. Re-instantiation on load is
-  driven by ``metadata.model_class`` plus optional
-  ``metadata.hyperparameters`` — mirroring the PyTorch documented
-  state_dict + class-name pattern.
-- ``"lightning"`` — ``pytorch_lightning.LightningModule`` via the same
+- ``"pytorch"`` — generic ``torch.nn.Module`` via ``torch.save`` /
+  ``torch.load``. The full ``nn.Module`` object is pickled so fused models
+  with nested submodules (and any non-trivial constructor signature) round
+  trip without requiring callers to re-supply constructor arguments.
+  ``ModelVariable`` is for intra-workflow scratch storage of task
+  intermediates within the same trusted pipeline run — for long-term
+  registry artifacts, prefer the ``state_dict`` + ``ModelMetadata``
+  pattern (see ``save_lightning_model``).
+- ``"lightning"`` — ``pytorch_lightning.LightningModule`` via the
   ``state_dict`` round-trip; ``metadata.model_class`` and
   ``metadata.hyperparameters`` drive reconstruction.
-
-The state_dict + ``model_class`` pattern is the community standard (see
-MLflow's ``mlflow.pytorch`` flavor, BentoML's PyTorch integration, and the
-PyTorch documentation on saving and loading models). It loads safely with
-``weights_only=True`` and avoids pickling user code into the artifact.
 
 ``_private/`` convention:
     This file lives in ``_private/`` — do not import directly from this path.
@@ -279,15 +277,17 @@ class ModelVariable(Variable):
     # ------------------------------------------------------------------
 
     def save_torch_model(self):
-        """Save a ``torch.nn.Module``'s ``state_dict`` to ``self.path``.
+        """Save a ``torch.nn.Module`` to ``self.path`` via ``torch.save``.
 
-        Persists only the ``state_dict`` (not the full ``nn.Module``
-        object). This matches the PyTorch-recommended serialization pattern
-        and lets the artifact be loaded safely with ``weights_only=True``.
-
-        Reconstruction on load requires ``metadata.model_class`` (set
-        automatically by ``ModelVariable.create()``) and, when the class
-        constructor needs arguments, ``metadata.hyperparameters``.
+        Persists the full ``nn.Module`` object — including any nested
+        submodules and bound state that a state_dict alone could not
+        capture. ``ModelVariable`` is intended for intra-workflow scratch
+        storage of task intermediates (not for long-term registry
+        artifacts), so the simpler full-pickle pattern is preferred over a
+        state_dict + class-reconstruction step that cannot represent fused
+        models with non-trivial constructors. Lightning modules, which have
+        a canonical ``state_dict`` + class re-instantiation path, go
+        through ``save_lightning_model`` / ``load_lightning_model``.
         """
         import torch
 
@@ -299,65 +299,65 @@ class ModelVariable(Variable):
             )
             return
 
-        if not self.metadata.model_class:
-            self.metadata.model_class = dot_path(type(self._value))
-
         fs, path = fsspec.core.url_to_fs(self.path)
         with tempfile.TemporaryDirectory() as temp_dir:
             model_file = os.path.join(temp_dir, "model.pt")
-            torch.save(self._value.state_dict(), model_file)
+            torch.save(self._value, model_file)
             fs.put(model_file, path)
 
         self._saved = True
 
-    def load_torch_model(self):
-        """Load a ``torch.nn.Module`` by re-instantiating ``model_class``.
+    def load_torch_model(
+        self,
+        weights_only: bool = False,
+        map_location: Any = "cpu",
+    ):
+        """Load a ``torch.nn.Module`` from ``self.path`` via ``torch.load``.
 
-        Steps:
+        Args:
+            weights_only: Forwarded to ``torch.load``. Defaults to ``False``
+                because ``save_torch_model`` pickles the full
+                ``nn.Module``; loading the artifact this class wrote
+                requires the unsafe mode. Pass ``weights_only=True`` only
+                when you know the artifact at ``self.path`` is a
+                state_dict-only file written by an external producer.
+            map_location: Forwarded to ``torch.load``. Defaults to ``"cpu"``
+                so that an artifact pickled from a CUDA device on the
+                producer host always loads on consumers without matching
+                GPU topology (otherwise ``torch.load`` raises
+                ``RuntimeError`` if the recorded CUDA device is not
+                available). Pass ``None`` to use ``torch.load``'s default
+                (restore tensors to their original device), a device
+                string such as ``"cuda:0"`` to pin to a specific device,
+                a ``torch.device``, a ``{src: dst}`` device-map dict, or
+                a callable — anything ``torch.load`` accepts.
 
-        1. Import the class from ``metadata.model_class``.
-        2. Construct an instance via
-           ``model_class(**metadata.hyperparameters)`` (empty dict when
-           ``hyperparameters`` is ``None``).
-        3. Download the ``state_dict`` from ``self.path`` and apply
-           ``load_state_dict`` (``weights_only=True`` — only tensors are
-           unpickled, so the call is safe against malicious artifacts).
-
-        Raises:
-            ValueError: If ``metadata.model_class`` is not set, or if the
-                class constructor requires arguments not supplied via
-                ``metadata.hyperparameters``.
+        Security:
+            ``weights_only=False`` permits arbitrary code execution from
+            the pickle stream. ``ModelVariable`` is designed for
+            intra-workflow scratch storage where the producer and consumer
+            are part of the same trusted pipeline run; do not load
+            artifacts from untrusted sources without setting
+            ``weights_only=True``.
         """
-        if not self.metadata.model_class:
-            raise ValueError(
-                "metadata.model_class must be set to load a PyTorch model "
-                "(ModelVariable.create(value) sets it automatically for "
-                "torch.nn.Module instances)."
-            )
-
         import torch
 
-        _logger.info("Loading PyTorch model from %s", self.path)
-
-        model_class = import_attribute(self.metadata.model_class)
-        hyperparameters = self.metadata.hyperparameters or {}
-        try:
-            model = model_class(**hyperparameters)
-        except TypeError as e:
-            raise ValueError(
-                f"Cannot reconstruct {self.metadata.model_class}: {e}. "
-                "Set metadata.hyperparameters before save() with the kwargs "
-                "required by the model constructor."
-            ) from e
+        _logger.info(
+            "Loading PyTorch model from %s (weights_only=%s, map_location=%s)",
+            self.path,
+            weights_only,
+            map_location,
+        )
 
         fs, path = fsspec.core.url_to_fs(self.path)
         with tempfile.TemporaryDirectory() as temp_dir:
             model_file = os.path.join(temp_dir, "model.pt")
             fs.get(path, model_file)
-            state_dict = torch.load(model_file, map_location="cpu", weights_only=True)
-            model.load_state_dict(state_dict)
-
-        self._value = model
+            self._value = torch.load(
+                model_file,
+                map_location=map_location,
+                weights_only=weights_only,
+            )
         self._saved = True
 
     # ------------------------------------------------------------------
@@ -393,7 +393,7 @@ class ModelVariable(Variable):
 
         self._saved = True
 
-    def load_lightning_model(self):
+    def load_lightning_model(self, map_location: Any = "cpu"):
         """Load a Lightning module by re-instantiating ``model_class``.
 
         Steps:
@@ -406,6 +406,13 @@ class ModelVariable(Variable):
            ``load_state_dict`` (``weights_only=True`` — only tensors are
            unpickled, so the call is safe against malicious artifacts).
         4. Call ``model.eval()`` and store as ``self._value``.
+
+        Args:
+            map_location: Forwarded to ``torch.load``. Defaults to ``"cpu"``
+                so artifacts saved on a CUDA device load on consumers
+                without matching GPU topology. Accepts the same value
+                shapes as ``torch.load`` (device string, ``torch.device``,
+                ``{src: dst}`` device-map dict, callable, or ``None``).
 
         Raises:
             ValueError: If ``metadata.model_class`` is not set, or if the
@@ -421,7 +428,11 @@ class ModelVariable(Variable):
 
         import torch
 
-        _logger.info("Loading Lightning model from %s", self.path)
+        _logger.info(
+            "Loading Lightning model from %s (map_location=%s)",
+            self.path,
+            map_location,
+        )
 
         model_class = import_attribute(self.metadata.model_class)
         hyperparameters = self.metadata.hyperparameters or {}
@@ -438,7 +449,9 @@ class ModelVariable(Variable):
         with tempfile.TemporaryDirectory() as temp_dir:
             model_file = os.path.join(temp_dir, "model.pt")
             fs.get(path, model_file)
-            state_dict = torch.load(model_file, map_location="cpu", weights_only=True)
+            state_dict = torch.load(
+                model_file, map_location=map_location, weights_only=True
+            )
             model.load_state_dict(state_dict)
 
         model.eval()

--- a/python/michelangelo/workflow/variables/_private/model.py
+++ b/python/michelangelo/workflow/variables/_private/model.py
@@ -8,13 +8,21 @@ Three frameworks are supported as first-class citizens:
 
 - ``"custom"`` — user-defined ``Model`` subclasses (``CustomModel.save`` /
   ``CustomModel.load``) from
-  ``michelangelo.lib.model_manager.interface.custom_model``.
-- ``"pytorch"`` — generic ``torch.nn.Module`` via ``torch.save`` /
-  ``torch.load``. The storage path is auto-suffixed with ``.pt`` for
-  compatibility with the Triton torch packager.
-- ``"lightning"`` — ``pytorch_lightning.LightningModule`` via
-  ``state_dict`` round-trip; loading re-instantiates ``metadata.model_class``
-  with ``metadata.hyperparameters`` and applies ``load_state_dict``.
+  ``michelangelo.lib.model_manager.interface.custom_model``. Artifact layout
+  is a directory tree controlled by the user's ``save()`` implementation.
+- ``"pytorch"`` — generic ``torch.nn.Module`` via ``torch.save(state_dict())``
+  and ``torch.load(..., weights_only=True)``. Re-instantiation on load is
+  driven by ``metadata.model_class`` plus optional
+  ``metadata.hyperparameters`` — mirroring the PyTorch documented
+  state_dict + class-name pattern.
+- ``"lightning"`` — ``pytorch_lightning.LightningModule`` via the same
+  ``state_dict`` round-trip; ``metadata.model_class`` and
+  ``metadata.hyperparameters`` drive reconstruction.
+
+The state_dict + ``model_class`` pattern is the community standard (see
+MLflow's ``mlflow.pytorch`` flavor, BentoML's PyTorch integration, and the
+PyTorch documentation on saving and loading models). It loads safely with
+``weights_only=True`` and avoids pickling user code into the artifact.
 
 ``_private/`` convention:
     This file lives in ``_private/`` — do not import directly from this path.
@@ -26,7 +34,6 @@ from __future__ import annotations
 import logging
 import os
 import tempfile
-from dataclasses import dataclass
 from typing import Any
 
 import fsspec
@@ -43,39 +50,89 @@ from michelangelo.workflow.variables.metadata import (
 _logger = logging.getLogger(__name__)
 
 
-@dataclass
 class ModelVariable(Variable):
     """A model variable flowing between workflow tasks.
 
-    Subclasses ``Variable``. Underlying it could be a PyTorch model, a Lightning
-    module, or a user-defined ``CustomModel``. Persistence is delegated to
-    framework-specific handlers; dispatch is keyed on
+    Subclasses ``Variable``. Underlying it could be a PyTorch model, a
+    Lightning module, or a user-defined ``CustomModel``. Persistence is
+    delegated to framework-specific handlers; dispatch is keyed on
     ``metadata.training_framework``.
+
+    Example:
+        >>> import torch  # doctest: +SKIP
+        >>> model = torch.nn.Linear(2, 1)  # doctest: +SKIP
+        >>> var = ModelVariable.create(model)  # doctest: +SKIP
+        >>> var.metadata.training_framework  # doctest: +SKIP
+        'pytorch'
+        >>> var.save()  # doctest: +SKIP
+        >>> restored = ModelVariable(path=var.path, metadata=var.metadata)
+        >>> isinstance(restored.value, torch.nn.Linear)  # doctest: +SKIP
+        True
     """
+
+    def __init__(
+        self,
+        value: Any = None,
+        path: str | None = None,
+        metadata: Any = None,
+        _io_metadata: Any = None,
+    ) -> None:
+        """Initialise with an optional in-memory value and/or storage path.
+
+        Args:
+            value: The in-memory model. When provided, ``save()`` persists it
+                to ``path``. When ``None``, accessing ``value`` triggers a
+                lazy load.
+            path: Storage path (local or fsspec URL). Auto-generated from the
+                ``UF_STORAGE_URL`` env var (default ``memory://storage``)
+                when not provided.
+            metadata: Optional ``ModelMetadata`` instance. Defaults to an
+                empty ``ModelMetadata()`` so that ``save()`` / ``_load()``
+                can raise a clear ``ValueError`` instead of an
+                ``AttributeError`` when ``training_framework`` is unset.
+            _io_metadata: Internal metadata written by the IO layer after a
+                save. Passed through by the UniFlow codec when reconstructing
+                a ``ModelVariable`` from a task result.
+        """
+        import uuid
+
+        if path is None:
+            path = (
+                f"{os.environ.get('UF_STORAGE_URL', 'memory://storage')}/"
+                f"{uuid.uuid4().hex}"
+            )
+        if metadata is None:
+            metadata = ModelMetadata()
+        super().__init__(path=path, metadata=metadata, _io_metadata=_io_metadata)
+        self._value = value
 
     @classmethod
     def create(cls, value: Any) -> ModelVariable:
         """Create a ``ModelVariable`` and auto-detect the training framework.
 
-        The framework is set to ``"custom"`` when ``value`` implements the
-        ``CustomModel`` ABC, ``"pytorch"`` when it's a ``torch.nn.Module``,
-        and otherwise left unset (callers must populate ``metadata`` manually
-        before calling ``save()``).
+        Detection order — first match wins:
+
+        1. ``CustomModel`` (the ``Model`` ABC from
+           ``michelangelo.lib.model_manager.interface.custom_model``)
+           → ``training_framework="custom"``.
+        2. ``pytorch_lightning.LightningModule`` →
+           ``training_framework="lightning"``. Checked before plain PyTorch
+           because ``LightningModule`` subclasses ``torch.nn.Module``.
+        3. ``torch.nn.Module`` → ``training_framework="pytorch"``.
+
+        Any other type leaves ``training_framework`` unset; callers must
+        populate ``metadata`` manually before calling ``save()``.
 
         Args:
-            value: The in-memory model. ``CustomModel`` and ``torch.nn.Module``
-                instances are recognised automatically; other framework types
-                require manual ``metadata.training_framework`` setup.
+            value: The in-memory model. ``CustomModel``, ``LightningModule``,
+                and ``torch.nn.Module`` instances are recognised
+                automatically; other framework types require manual
+                ``metadata.training_framework`` setup.
 
         Returns:
             A new ``ModelVariable`` with ``value`` ready in memory and
-            ``metadata`` populated with framework + ``model_class``.
-
-        Example:
-            >>> import torch  # doctest: +SKIP
-            >>> var = ModelVariable.create(torch.nn.Linear(2, 1))  # doctest: +SKIP
-            >>> var.metadata.training_framework  # doctest: +SKIP
-            'pytorch'
+            ``metadata`` populated with the detected framework +
+            ``model_class``.
         """
         res = super().create(value)
         res.metadata = ModelMetadata()
@@ -87,6 +144,16 @@ class ModelVariable(Variable):
 
             if isinstance(value, CustomModel):
                 res.metadata.training_framework = TRAINING_FRAMEWORK_CUSTOM
+                res.metadata.model_class = dot_path(type(value))
+                return res
+        except ImportError:
+            pass
+
+        try:
+            import pytorch_lightning as pl
+
+            if isinstance(value, pl.LightningModule):
+                res.metadata.training_framework = TRAINING_FRAMEWORK_LIGHTNING
                 res.metadata.model_class = dot_path(type(value))
                 return res
         except ImportError:
@@ -119,17 +186,15 @@ class ModelVariable(Variable):
         elif self.metadata.training_framework == TRAINING_FRAMEWORK_LIGHTNING:
             self.load_lightning_model()
         else:
-            raise ValueError(
-                f"Unrecognized training framework: {self.metadata.training_framework}"
-            )
+            raise ValueError(self._unknown_framework_message())
 
     def save(self):
         """Save value to variable path, dispatched on training_framework.
 
         Raises:
             ValueError: If no value has been set on this variable, or if
-                ``metadata.training_framework`` is unset or unrecognised. Call
-                the framework-specific ``save_*`` method directly when
+                ``metadata.training_framework`` is unset or unrecognised.
+                Call the framework-specific ``save_*`` method directly when
                 auto-dispatch is not possible.
         """
         if self._value is None:
@@ -141,9 +206,19 @@ class ModelVariable(Variable):
         elif self.metadata.training_framework == TRAINING_FRAMEWORK_LIGHTNING:
             self.save_lightning_model()
         else:
-            raise ValueError(
-                f"Unrecognized training framework: {self.metadata.training_framework}"
-            )
+            raise ValueError(self._unknown_framework_message())
+
+    def _unknown_framework_message(self) -> str:
+        """Build an actionable error message for an unset/unknown framework."""
+        return (
+            f"Unrecognized training framework: "
+            f"{self.metadata.training_framework!r}. "
+            f"Set metadata.training_framework to one of "
+            f"{TRAINING_FRAMEWORK_CUSTOM!r}, {TRAINING_FRAMEWORK_PYTORCH!r}, "
+            f"or {TRAINING_FRAMEWORK_LIGHTNING!r} "
+            f"(see michelangelo.workflow.variables.metadata), or construct "
+            f"the variable via ModelVariable.create(value) which auto-detects."
+        )
 
     # ------------------------------------------------------------------
     # Custom model
@@ -185,7 +260,9 @@ class ModelVariable(Variable):
 
         if not self.metadata.model_class:
             raise ValueError(
-                "model_class must be set in metadata to load a custom model."
+                "metadata.model_class must be set to load a custom model "
+                "(e.g. var.metadata.model_class = 'mypackage.models.MyModel'). "
+                "ModelVariable.create(value) sets it automatically."
             )
 
         model_class = import_attribute(self.metadata.model_class)
@@ -202,12 +279,15 @@ class ModelVariable(Variable):
     # ------------------------------------------------------------------
 
     def save_torch_model(self):
-        """Save a ``torch.nn.Module`` to ``self.path`` with a ``.pt`` suffix.
+        """Save a ``torch.nn.Module``'s ``state_dict`` to ``self.path``.
 
-        The ``.pt`` extension is appended when missing — required for
-        compatibility with the Triton torch packager. The full model object
-        is pickled via ``torch.save(self._value, ...)``; loading therefore
-        requires ``weights_only=False`` (see ``load_torch_model``).
+        Persists only the ``state_dict`` (not the full ``nn.Module``
+        object). This matches the PyTorch-recommended serialization pattern
+        and lets the artifact be loaded safely with ``weights_only=True``.
+
+        Reconstruction on load requires ``metadata.model_class`` (set
+        automatically by ``ModelVariable.create()``) and, when the class
+        constructor needs arguments, ``metadata.hyperparameters``.
         """
         import torch
 
@@ -219,47 +299,65 @@ class ModelVariable(Variable):
             )
             return
 
-        if not self.path.endswith(".pt"):
-            self.path = f"{self.path}.pt"
+        if not self.metadata.model_class:
+            self.metadata.model_class = dot_path(type(self._value))
 
         fs, path = fsspec.core.url_to_fs(self.path)
         with tempfile.TemporaryDirectory() as temp_dir:
             model_file = os.path.join(temp_dir, "model.pt")
-            torch.save(self._value, model_file)
+            torch.save(self._value.state_dict(), model_file)
             fs.put(model_file, path)
 
         self._saved = True
 
-    def load_torch_model(self, weights_only: bool = True):
-        """Load a ``torch.nn.Module`` via ``torch.load`` (CPU map-location).
+    def load_torch_model(self):
+        """Load a ``torch.nn.Module`` by re-instantiating ``model_class``.
 
-        Args:
-            weights_only: Forwarded to ``torch.load``. Defaults to ``True`` —
-                the safer mode that refuses to execute arbitrary pickle
-                opcodes. Pass ``weights_only=False`` when loading artifacts
-                produced by ``save_torch_model``, which pickle the full
-                ``nn.Module`` object (state_dict-only artifacts work with
-                the default).
+        Steps:
 
-        Security:
-            ``weights_only=False`` permits arbitrary code execution from the
-            pickle stream. Only set it when the artifact source is trusted.
+        1. Import the class from ``metadata.model_class``.
+        2. Construct an instance via
+           ``model_class(**metadata.hyperparameters)`` (empty dict when
+           ``hyperparameters`` is ``None``).
+        3. Download the ``state_dict`` from ``self.path`` and apply
+           ``load_state_dict`` (``weights_only=True`` — only tensors are
+           unpickled, so the call is safe against malicious artifacts).
+
+        Raises:
+            ValueError: If ``metadata.model_class`` is not set, or if the
+                class constructor requires arguments not supplied via
+                ``metadata.hyperparameters``.
         """
+        if not self.metadata.model_class:
+            raise ValueError(
+                "metadata.model_class must be set to load a PyTorch model "
+                "(ModelVariable.create(value) sets it automatically for "
+                "torch.nn.Module instances)."
+            )
+
         import torch
 
-        _logger.info(
-            "Loading PyTorch model from %s (weights_only=%s)",
-            self.path,
-            weights_only,
-        )
+        _logger.info("Loading PyTorch model from %s", self.path)
+
+        model_class = import_attribute(self.metadata.model_class)
+        hyperparameters = self.metadata.hyperparameters or {}
+        try:
+            model = model_class(**hyperparameters)
+        except TypeError as e:
+            raise ValueError(
+                f"Cannot reconstruct {self.metadata.model_class}: {e}. "
+                "Set metadata.hyperparameters before save() with the kwargs "
+                "required by the model constructor."
+            ) from e
 
         fs, path = fsspec.core.url_to_fs(self.path)
         with tempfile.TemporaryDirectory() as temp_dir:
-            model_path = os.path.join(temp_dir, "model")
-            fs.get(path, model_path, recursive=True)
-            self._value = torch.load(
-                model_path, map_location="cpu", weights_only=weights_only
-            )
+            model_file = os.path.join(temp_dir, "model.pt")
+            fs.get(path, model_file)
+            state_dict = torch.load(model_file, map_location="cpu", weights_only=True)
+            model.load_state_dict(state_dict)
+
+        self._value = model
         self._saved = True
 
     # ------------------------------------------------------------------
@@ -284,11 +382,14 @@ class ModelVariable(Variable):
             )
             return
 
+        if not self.metadata.model_class:
+            self.metadata.model_class = dot_path(type(self._value))
+
         fs, path = fsspec.core.url_to_fs(self.path)
         with tempfile.TemporaryDirectory() as temp_dir:
             model_file = os.path.join(temp_dir, "model.pt")
             torch.save(self._value.state_dict(), model_file)
-            fs.put(model_file, path, recursive=True)
+            fs.put(model_file, path)
 
         self._saved = True
 
@@ -298,19 +399,24 @@ class ModelVariable(Variable):
         Steps:
 
         1. Import the class from ``metadata.model_class``.
-        2. Construct an instance via ``model_class(**metadata.hyperparameters)``
-           (empty dict when ``hyperparameters`` is ``None``).
+        2. Construct an instance via
+           ``model_class(**metadata.hyperparameters)`` (empty dict when
+           ``hyperparameters`` is ``None``).
         3. Download the ``state_dict`` from ``self.path`` and apply
            ``load_state_dict`` (``weights_only=True`` — only tensors are
            unpickled, so the call is safe against malicious artifacts).
         4. Call ``model.eval()`` and store as ``self._value``.
 
         Raises:
-            ValueError: If ``metadata.model_class`` is not set.
+            ValueError: If ``metadata.model_class`` is not set, or if the
+                class constructor requires arguments not supplied via
+                ``metadata.hyperparameters``.
         """
         if not self.metadata.model_class:
             raise ValueError(
-                "model_class must be set in metadata to load Lightning model"
+                "metadata.model_class must be set to load a Lightning model "
+                "(ModelVariable.create(value) sets it automatically for "
+                "pytorch_lightning.LightningModule instances)."
             )
 
         import torch
@@ -319,12 +425,19 @@ class ModelVariable(Variable):
 
         model_class = import_attribute(self.metadata.model_class)
         hyperparameters = self.metadata.hyperparameters or {}
-        model = model_class(**hyperparameters)
+        try:
+            model = model_class(**hyperparameters)
+        except TypeError as e:
+            raise ValueError(
+                f"Cannot reconstruct {self.metadata.model_class}: {e}. "
+                "Set metadata.hyperparameters before save() with the kwargs "
+                "required by the model constructor."
+            ) from e
 
         fs, path = fsspec.core.url_to_fs(self.path)
         with tempfile.TemporaryDirectory() as temp_dir:
             model_file = os.path.join(temp_dir, "model.pt")
-            fs.get(path, model_file, recursive=True)
+            fs.get(path, model_file)
             state_dict = torch.load(model_file, map_location="cpu", weights_only=True)
             model.load_state_dict(state_dict)
 

--- a/python/michelangelo/workflow/variables/metadata.py
+++ b/python/michelangelo/workflow/variables/metadata.py
@@ -3,10 +3,20 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from io import BytesIO
+
+
+TRAINING_FRAMEWORK_CUSTOM = "custom"
+"""Training framework identifier for user-defined ``CustomModel`` subclasses."""
+
+TRAINING_FRAMEWORK_PYTORCH = "pytorch"
+"""Training framework identifier for plain ``torch.nn.Module`` models."""
+
+TRAINING_FRAMEWORK_LIGHTNING = "lightning"
+"""Training framework identifier for ``pytorch_lightning.LightningModule`` models."""
 
 
 @dataclass
@@ -51,6 +61,11 @@ class ModelMetadata:
             the deployed model. Not included in ``repr``.
         _hyperparameters: Serialised training hyperparameters for
             reproducibility. Not included in ``repr``.
+        hyperparameters: Live training hyperparameters as a Python dict.
+            Used by ``ModelVariable.load_lightning_model()`` to re-instantiate
+            the model class via ``model_class(**hyperparameters)``. Distinct
+            from ``_hyperparameters``, which is the registry-bound serialised
+            form.
 
     Example:
         >>> meta = ModelMetadata(training_framework="xgboost", deployable=True)
@@ -67,6 +82,7 @@ class ModelMetadata:
     _schema: BytesIO | None = field(default=None, repr=False)
     _sample_data: BytesIO | None = field(default=None, repr=False)
     _hyperparameters: BytesIO | None = field(default=None, repr=False)
+    hyperparameters: dict[str, Any] | None = None
 
     def to_registry_dict(self) -> dict[str, str]:
         """Return a flat string dict of public fields suitable for registry tags.

--- a/python/michelangelo/workflow/variables/tests/variables_test.py
+++ b/python/michelangelo/workflow/variables/tests/variables_test.py
@@ -7,12 +7,18 @@ import types as _types
 from dataclasses import dataclass
 from io import BytesIO
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 
 from michelangelo.workflow.variables._private.dataset import DatasetVariable
-from michelangelo.workflow.variables.metadata import ModelMetadata
+from michelangelo.workflow.variables._private.model import ModelVariable
+from michelangelo.workflow.variables.metadata import (
+    TRAINING_FRAMEWORK_CUSTOM,
+    TRAINING_FRAMEWORK_LIGHTNING,
+    TRAINING_FRAMEWORK_PYTORCH,
+    ModelMetadata,
+)
 from michelangelo.workflow.variables.types import (
     AssembledModel,
     ModelArtifact,
@@ -445,3 +451,462 @@ class TestDatasetVariableSaveLoadSparkRay(TestCase):
         ):
             artifact._load()
             mock_load.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# ModelVariable
+# ---------------------------------------------------------------------------
+
+
+_MODEL_PATH = "michelangelo.workflow.variables._private.model"
+
+
+def _mock_torch(module_instance=None):
+    """Return (mock_torch_module, mock_module_instance) for sys.modules patching.
+
+    The fake torch module exposes a ``nn.Module`` class and stub ``save`` /
+    ``load`` callables suitable for ``patch.object`` assertions.
+    """
+    mock_nn_module = type("Module", (), {})
+    mock_nn = _types.SimpleNamespace(Module=mock_nn_module)
+    instance = module_instance if module_instance is not None else mock_nn_module()
+    mock_torch = _types.SimpleNamespace(
+        nn=mock_nn,
+        save=MagicMock(name="torch.save"),
+        load=MagicMock(name="torch.load"),
+    )
+    return mock_torch, instance
+
+
+def _mock_custom_model(instance=None):
+    """Return (mock_module, mock_class, mock_instance) for sys.modules patching.
+
+    The fake module mirrors
+    ``michelangelo.lib.model_manager.interface.custom_model``: exposes a
+    ``Model`` class that can be used for ``isinstance`` checks and as a
+    ``model_class.load`` target.
+    """
+    mock_custom_class = type(
+        "Model",
+        (),
+        {"save": MagicMock(name="Model.save"), "load": MagicMock(name="Model.load")},
+    )
+    mock_module = _types.SimpleNamespace(Model=mock_custom_class)
+    inst = instance if instance is not None else mock_custom_class()
+    return mock_module, mock_custom_class, inst
+
+
+def _custom_mods(mock_module):
+    """sys.modules patch dict for the custom_model interface module."""
+    return {
+        "michelangelo.lib.model_manager.interface.custom_model": mock_module,
+    }
+
+
+class TestModelMetadataConstantsAndHyperparameters(TestCase):
+    """Tests for the TRAINING_FRAMEWORK_* constants and hyperparameters field."""
+
+    def test_training_framework_constants_are_lowercase_strings(self):
+        """The framework constants expose stable lowercase string values."""
+        self.assertEqual(TRAINING_FRAMEWORK_CUSTOM, "custom")
+        self.assertEqual(TRAINING_FRAMEWORK_PYTORCH, "pytorch")
+        self.assertEqual(TRAINING_FRAMEWORK_LIGHTNING, "lightning")
+
+    def test_hyperparameters_field_defaults_to_none(self):
+        """ModelMetadata.hyperparameters defaults to None for backwards compat."""
+        meta = ModelMetadata()
+        self.assertIsNone(meta.hyperparameters)
+
+    def test_hyperparameters_field_accepts_dict(self):
+        """ModelMetadata stores a hyperparameters dict for Lightning loading."""
+        meta = ModelMetadata(hyperparameters={"lr": 0.001, "batch_size": 32})
+        self.assertEqual(meta.hyperparameters["lr"], 0.001)
+        self.assertEqual(meta.hyperparameters["batch_size"], 32)
+
+
+class TestModelVariableCreate(TestCase):
+    """Tests for ModelVariable.create() auto-detection."""
+
+    def test_create_with_non_model_leaves_framework_unset(self):
+        """create() on a non-model object leaves training_framework=None."""
+        var = ModelVariable.create("not-a-model")
+        self.assertIsNone(var.metadata.training_framework)
+        self.assertIsNone(var.metadata.model_class)
+
+    def test_create_auto_generates_path(self):
+        """create() auto-generates a memory:// path when UF_STORAGE_URL is unset."""
+        var = ModelVariable.create("anything")
+        self.assertTrue(var.path.startswith("memory://"))
+
+    def test_create_attaches_fresh_model_metadata(self):
+        """create() attaches a new ModelMetadata instance even for unknown types."""
+        var = ModelVariable.create("anything")
+        self.assertIsInstance(var.metadata, ModelMetadata)
+
+    def test_create_detects_custom_model(self):
+        """create() sets framework=custom when value is a CustomModel instance."""
+        mock_module, mock_class, inst = _mock_custom_model()
+        with patch.dict(sys.modules, _custom_mods(mock_module)):
+            var = ModelVariable.create(inst)
+        self.assertEqual(var.metadata.training_framework, TRAINING_FRAMEWORK_CUSTOM)
+        self.assertEqual(
+            var.metadata.model_class,
+            f"{type(inst).__module__}.{type(inst).__name__}",
+        )
+
+    def test_create_detects_torch_module(self):
+        """create() sets framework=pytorch when value is a torch.nn.Module instance."""
+        mock_torch, inst = _mock_torch()
+        with patch.dict(sys.modules, {"torch": mock_torch}):
+            var = ModelVariable.create(inst)
+        self.assertEqual(var.metadata.training_framework, TRAINING_FRAMEWORK_PYTORCH)
+        self.assertEqual(
+            var.metadata.model_class,
+            f"{type(inst).__module__}.{type(inst).__name__}",
+        )
+
+    def test_create_skips_torch_check_when_torch_missing(self):
+        """create() does not raise when torch is unavailable."""
+        with patch.dict(sys.modules, {"torch": None}):
+            var = ModelVariable.create(object())
+        self.assertIsNone(var.metadata.training_framework)
+
+
+class TestModelVariableSaveDispatch(TestCase):
+    """Tests for ModelVariable.save() dispatch and pre-conditions."""
+
+    def test_save_raises_when_no_value_set(self):
+        """save() raises ValueError when _value is None (no value attached)."""
+        var = ModelVariable(path="/tmp/no-value", metadata=ModelMetadata())
+        with self.assertRaises(ValueError) as ctx:
+            var.save()
+        self.assertIn("no value has been set", str(ctx.exception))
+
+    def test_save_raises_when_framework_unset(self):
+        """save() raises ValueError when training_framework is None."""
+        var = ModelVariable(path="/tmp/no-fw", metadata=ModelMetadata())
+        var._value = object()
+        with self.assertRaises(ValueError) as ctx:
+            var.save()
+        self.assertIn("Unrecognized training framework", str(ctx.exception))
+
+    def test_save_raises_when_framework_unknown(self):
+        """save() raises ValueError for an unrecognised framework string."""
+        var = ModelVariable(
+            path="/tmp/x", metadata=ModelMetadata(training_framework="tensorflow")
+        )
+        var._value = object()
+        with self.assertRaises(ValueError):
+            var.save()
+
+    def test_save_dispatches_to_custom(self):
+        """save() routes to save_custom_model when framework=custom."""
+        var = ModelVariable(
+            path="/tmp/x",
+            metadata=ModelMetadata(training_framework=TRAINING_FRAMEWORK_CUSTOM),
+        )
+        var._value = object()
+        with patch.object(var, "save_custom_model") as mock_save:
+            var.save()
+            mock_save.assert_called_once()
+
+    def test_save_dispatches_to_torch(self):
+        """save() routes to save_torch_model when framework=pytorch."""
+        var = ModelVariable(
+            path="/tmp/x",
+            metadata=ModelMetadata(training_framework=TRAINING_FRAMEWORK_PYTORCH),
+        )
+        var._value = object()
+        with patch.object(var, "save_torch_model") as mock_save:
+            var.save()
+            mock_save.assert_called_once()
+
+    def test_save_dispatches_to_lightning(self):
+        """save() routes to save_lightning_model when framework=lightning."""
+        var = ModelVariable(
+            path="/tmp/x",
+            metadata=ModelMetadata(training_framework=TRAINING_FRAMEWORK_LIGHTNING),
+        )
+        var._value = object()
+        with patch.object(var, "save_lightning_model") as mock_save:
+            var.save()
+            mock_save.assert_called_once()
+
+
+class TestModelVariableLoadDispatch(TestCase):
+    """Tests for ModelVariable._load() dispatch and pre-conditions."""
+
+    def test_load_raises_when_framework_unset(self):
+        """_load() raises ValueError when training_framework is None."""
+        var = ModelVariable(path="/tmp/x", metadata=ModelMetadata())
+        with self.assertRaises(ValueError):
+            var._load()
+
+    def test_load_dispatches_to_custom(self):
+        """_load() routes to load_custom_model when framework=custom."""
+        var = ModelVariable(
+            path="/tmp/x",
+            metadata=ModelMetadata(training_framework=TRAINING_FRAMEWORK_CUSTOM),
+        )
+        with patch.object(var, "load_custom_model") as mock_load:
+            var._load()
+            mock_load.assert_called_once()
+
+    def test_load_dispatches_to_torch(self):
+        """_load() routes to load_torch_model when framework=pytorch."""
+        var = ModelVariable(
+            path="/tmp/x",
+            metadata=ModelMetadata(training_framework=TRAINING_FRAMEWORK_PYTORCH),
+        )
+        with patch.object(var, "load_torch_model") as mock_load:
+            var._load()
+            mock_load.assert_called_once()
+
+    def test_load_dispatches_to_lightning(self):
+        """_load() routes to load_lightning_model when framework=lightning."""
+        var = ModelVariable(
+            path="/tmp/x",
+            metadata=ModelMetadata(training_framework=TRAINING_FRAMEWORK_LIGHTNING),
+        )
+        with patch.object(var, "load_lightning_model") as mock_load:
+            var._load()
+            mock_load.assert_called_once()
+
+
+class TestModelVariableSkipWhenAlreadySaved(TestCase):
+    """The save_* methods are idempotent — they no-op when _saved is True."""
+
+    def test_save_custom_skips_when_already_saved(self):
+        """save_custom_model() returns early without touching value or fs."""
+        var = ModelVariable(path="memory://x", metadata=ModelMetadata())
+        var._value = MagicMock(name="custom-model")
+        var._saved = True
+        with patch(f"{_MODEL_PATH}.fsspec") as mock_fsspec:
+            var.save_custom_model()
+            mock_fsspec.core.url_to_fs.assert_not_called()
+            var._value.save.assert_not_called()
+
+    def test_save_torch_skips_when_already_saved(self):
+        """save_torch_model() returns early without touching torch or fs."""
+        mock_torch, _ = _mock_torch()
+        var = ModelVariable(path="memory://x.pt", metadata=ModelMetadata())
+        var._value = object()
+        var._saved = True
+        with (
+            patch.dict(sys.modules, {"torch": mock_torch}),
+            patch(f"{_MODEL_PATH}.fsspec") as mock_fsspec,
+        ):
+            var.save_torch_model()
+            mock_torch.save.assert_not_called()
+            mock_fsspec.core.url_to_fs.assert_not_called()
+
+
+class TestModelVariableCustomIO(TestCase):
+    """Tests for save_custom_model / load_custom_model IO."""
+
+    def test_save_custom_uploads_temp_dir(self):
+        """save_custom_model() calls model.save(temp) and fs.put(temp, path)."""
+        mock_fs = MagicMock(name="fs")
+        var = ModelVariable(path="memory://target", metadata=ModelMetadata())
+        var._value = MagicMock(name="model")
+        with patch(f"{_MODEL_PATH}.fsspec") as mock_fsspec:
+            mock_fsspec.core.url_to_fs.return_value = (mock_fs, "target")
+            var.save_custom_model()
+            var._value.save.assert_called_once()
+            mock_fs.put.assert_called_once()
+            put_args, put_kwargs = mock_fs.put.call_args
+            self.assertEqual(put_args[1], "target")
+            self.assertTrue(put_kwargs.get("recursive"))
+        self.assertTrue(var._saved)
+
+    def test_load_custom_imports_class_and_calls_load(self):
+        """load_custom_model() imports model_class and calls .load(temp_path)."""
+        var = ModelVariable(
+            path="memory://target",
+            metadata=ModelMetadata(model_class="pkg.mod.MyModel"),
+        )
+        mock_fs = MagicMock(name="fs")
+        loaded_value = object()
+        mock_class = MagicMock(load=MagicMock(return_value=loaded_value))
+        with (
+            patch(
+                f"{_MODEL_PATH}.import_attribute", return_value=mock_class
+            ) as mock_imp,
+            patch(f"{_MODEL_PATH}.fsspec") as mock_fsspec,
+        ):
+            mock_fsspec.core.url_to_fs.return_value = (mock_fs, "target")
+            var.load_custom_model()
+            mock_imp.assert_called_once_with("pkg.mod.MyModel")
+            mock_class.load.assert_called_once()
+            mock_fs.get.assert_called_once()
+        self.assertIs(var._value, loaded_value)
+        self.assertTrue(var._saved)
+
+    def test_load_custom_raises_when_model_class_missing(self):
+        """load_custom_model() raises ValueError when model_class is not set."""
+        var = ModelVariable(path="memory://x", metadata=ModelMetadata())
+        with self.assertRaises(ValueError) as ctx:
+            var.load_custom_model()
+        self.assertIn("model_class must be set", str(ctx.exception))
+
+
+class TestModelVariableTorchIO(TestCase):
+    """Tests for save_torch_model / load_torch_model IO."""
+
+    def test_save_torch_auto_appends_pt_extension(self):
+        """save_torch_model() appends .pt to the path when missing."""
+        mock_torch, _ = _mock_torch()
+        var = ModelVariable(path="memory://target", metadata=ModelMetadata())
+        var._value = object()
+        with (
+            patch.dict(sys.modules, {"torch": mock_torch}),
+            patch(f"{_MODEL_PATH}.fsspec") as mock_fsspec,
+        ):
+            mock_fsspec.core.url_to_fs.return_value = (MagicMock(), "target.pt")
+            var.save_torch_model()
+        self.assertTrue(var.path.endswith(".pt"))
+        mock_torch.save.assert_called_once()
+
+    def test_save_torch_preserves_existing_pt_extension(self):
+        """save_torch_model() does not double-append .pt."""
+        mock_torch, _ = _mock_torch()
+        var = ModelVariable(path="memory://target.pt", metadata=ModelMetadata())
+        var._value = object()
+        with (
+            patch.dict(sys.modules, {"torch": mock_torch}),
+            patch(f"{_MODEL_PATH}.fsspec") as mock_fsspec,
+        ):
+            mock_fsspec.core.url_to_fs.return_value = (MagicMock(), "target.pt")
+            var.save_torch_model()
+        self.assertEqual(var.path, "memory://target.pt")
+
+    def test_load_torch_defaults_to_weights_only_true(self):
+        """load_torch_model() forwards weights_only=True to torch.load by default."""
+        loaded_obj = object()
+        mock_torch, _ = _mock_torch()
+        mock_torch.load = MagicMock(return_value=loaded_obj)
+        var = ModelVariable(path="memory://x.pt", metadata=ModelMetadata())
+        with (
+            patch.dict(sys.modules, {"torch": mock_torch}),
+            patch(f"{_MODEL_PATH}.fsspec") as mock_fsspec,
+        ):
+            mock_fsspec.core.url_to_fs.return_value = (MagicMock(), "x.pt")
+            var.load_torch_model()
+        _, load_kwargs = mock_torch.load.call_args
+        self.assertTrue(load_kwargs.get("weights_only"))
+        self.assertEqual(load_kwargs.get("map_location"), "cpu")
+        self.assertIs(var._value, loaded_obj)
+
+    def test_load_torch_respects_weights_only_override(self):
+        """load_torch_model(weights_only=False) forwards the override to torch.load."""
+        mock_torch, _ = _mock_torch()
+        mock_torch.load = MagicMock(return_value=object())
+        var = ModelVariable(path="memory://x.pt", metadata=ModelMetadata())
+        with (
+            patch.dict(sys.modules, {"torch": mock_torch}),
+            patch(f"{_MODEL_PATH}.fsspec") as mock_fsspec,
+        ):
+            mock_fsspec.core.url_to_fs.return_value = (MagicMock(), "x.pt")
+            var.load_torch_model(weights_only=False)
+        _, load_kwargs = mock_torch.load.call_args
+        self.assertFalse(load_kwargs.get("weights_only"))
+
+
+class TestModelVariableLightningIO(TestCase):
+    """Tests for save_lightning_model / load_lightning_model IO."""
+
+    def test_save_lightning_writes_state_dict(self):
+        """save_lightning_model() calls torch.save(model.state_dict(), ...)."""
+        mock_torch, _ = _mock_torch()
+        state_dict = {"w": "tensor"}
+        mock_model = MagicMock()
+        mock_model.state_dict.return_value = state_dict
+        var = ModelVariable(path="memory://lit", metadata=ModelMetadata())
+        var._value = mock_model
+        with (
+            patch.dict(sys.modules, {"torch": mock_torch}),
+            patch(f"{_MODEL_PATH}.fsspec") as mock_fsspec,
+        ):
+            mock_fsspec.core.url_to_fs.return_value = (MagicMock(), "lit")
+            var.save_lightning_model()
+        save_args, _ = mock_torch.save.call_args
+        self.assertIs(save_args[0], state_dict)
+        mock_model.state_dict.assert_called_once()
+
+    def test_load_lightning_raises_when_model_class_missing(self):
+        """load_lightning_model() raises ValueError when model_class is not set."""
+        var = ModelVariable(path="memory://x", metadata=ModelMetadata())
+        with self.assertRaises(ValueError) as ctx:
+            var.load_lightning_model()
+        self.assertIn("model_class", str(ctx.exception))
+
+    def test_load_lightning_instantiates_with_hyperparameters(self):
+        """load_lightning_model() builds model_class(**hyperparameters)."""
+        mock_torch, _ = _mock_torch()
+        mock_torch.load = MagicMock(return_value={"w": 1.0})
+        built = MagicMock(name="built")
+        mock_class = MagicMock(return_value=built)
+        var = ModelVariable(
+            path="memory://lit",
+            metadata=ModelMetadata(
+                model_class="pkg.M",
+                hyperparameters={"hidden": 16},
+            ),
+        )
+        with (
+            patch.dict(sys.modules, {"torch": mock_torch}),
+            patch(f"{_MODEL_PATH}.import_attribute", return_value=mock_class),
+            patch(f"{_MODEL_PATH}.fsspec") as mock_fsspec,
+        ):
+            mock_fsspec.core.url_to_fs.return_value = (MagicMock(), "lit")
+            var.load_lightning_model()
+        mock_class.assert_called_once_with(hidden=16)
+        built.load_state_dict.assert_called_once_with({"w": 1.0})
+        built.eval.assert_called_once()
+        self.assertIs(var._value, built)
+
+    def test_load_lightning_uses_weights_only_true_for_state_dict(self):
+        """load_lightning_model() forwards weights_only=True to torch.load."""
+        mock_torch, _ = _mock_torch()
+        mock_torch.load = MagicMock(return_value={})
+        var = ModelVariable(
+            path="memory://lit",
+            metadata=ModelMetadata(model_class="pkg.M"),
+        )
+        with (
+            patch.dict(sys.modules, {"torch": mock_torch}),
+            patch(f"{_MODEL_PATH}.import_attribute", return_value=MagicMock()),
+            patch(f"{_MODEL_PATH}.fsspec") as mock_fsspec,
+        ):
+            mock_fsspec.core.url_to_fs.return_value = (MagicMock(), "lit")
+            var.load_lightning_model()
+        _, load_kwargs = mock_torch.load.call_args
+        self.assertTrue(load_kwargs.get("weights_only"))
+
+    def test_load_lightning_defaults_hyperparameters_to_empty_dict(self):
+        """load_lightning_model() treats hyperparameters=None as {}."""
+        mock_torch, _ = _mock_torch()
+        mock_torch.load = MagicMock(return_value={})
+        mock_class = MagicMock(return_value=MagicMock())
+        var = ModelVariable(
+            path="memory://lit",
+            metadata=ModelMetadata(model_class="pkg.M", hyperparameters=None),
+        )
+        with (
+            patch.dict(sys.modules, {"torch": mock_torch}),
+            patch(f"{_MODEL_PATH}.import_attribute", return_value=mock_class),
+            patch(f"{_MODEL_PATH}.fsspec") as mock_fsspec,
+        ):
+            mock_fsspec.core.url_to_fs.return_value = (MagicMock(), "lit")
+            var.load_lightning_model()
+        mock_class.assert_called_once_with()
+
+
+class TestModelVariableImports(TestCase):
+    """Tests for the public package surface of ModelVariable."""
+
+    def test_init_import_from_package(self):
+        """ModelVariable is importable from the package __init__."""
+        from michelangelo.workflow import variables as _wv
+
+        self.assertIs(_wv.ModelVariable, ModelVariable)

--- a/python/michelangelo/workflow/variables/tests/variables_test.py
+++ b/python/michelangelo/workflow/variables/tests/variables_test.py
@@ -859,6 +859,34 @@ class TestModelVariableTorchIO(TestCase):
         _, load_kwargs = mock_torch.load.call_args
         self.assertTrue(load_kwargs.get("weights_only"))
 
+    def test_load_torch_respects_map_location_override(self):
+        """load_torch_model(map_location=...) forwards the override to torch.load."""
+        mock_torch, _ = _mock_torch()
+        mock_torch.load = MagicMock(return_value=object())
+        var = ModelVariable(path="memory://x")
+        with (
+            patch.dict(sys.modules, {"torch": mock_torch}),
+            patch(f"{_MODEL_PATH}.fsspec") as mock_fsspec,
+        ):
+            mock_fsspec.core.url_to_fs.return_value = (MagicMock(), "x")
+            var.load_torch_model(map_location="cuda:0")
+        _, load_kwargs = mock_torch.load.call_args
+        self.assertEqual(load_kwargs.get("map_location"), "cuda:0")
+
+    def test_load_torch_accepts_map_location_none(self):
+        """map_location=None is forwarded so torch.load uses original device."""
+        mock_torch, _ = _mock_torch()
+        mock_torch.load = MagicMock(return_value=object())
+        var = ModelVariable(path="memory://x")
+        with (
+            patch.dict(sys.modules, {"torch": mock_torch}),
+            patch(f"{_MODEL_PATH}.fsspec") as mock_fsspec,
+        ):
+            mock_fsspec.core.url_to_fs.return_value = (MagicMock(), "x")
+            var.load_torch_model(map_location=None)
+        _, load_kwargs = mock_torch.load.call_args
+        self.assertIsNone(load_kwargs.get("map_location"))
+
     def test_load_torch_uses_non_recursive_get(self):
         """load_torch_model() reads a single file with fs.get (no recursive)."""
         mock_torch, _ = _mock_torch()
@@ -945,6 +973,25 @@ class TestModelVariableLightningIO(TestCase):
             var.load_lightning_model()
         _, load_kwargs = mock_torch.load.call_args
         self.assertTrue(load_kwargs.get("weights_only"))
+        self.assertEqual(load_kwargs.get("map_location"), "cpu")
+
+    def test_load_lightning_respects_map_location_override(self):
+        """load_lightning_model(map_location=...) is forwarded to torch.load."""
+        mock_torch, _ = _mock_torch()
+        mock_torch.load = MagicMock(return_value={})
+        var = ModelVariable(
+            path="memory://lit",
+            metadata=ModelMetadata(model_class="pkg.M"),
+        )
+        with (
+            patch.dict(sys.modules, {"torch": mock_torch}),
+            patch(f"{_MODEL_PATH}.import_attribute", return_value=MagicMock()),
+            patch(f"{_MODEL_PATH}.fsspec") as mock_fsspec,
+        ):
+            mock_fsspec.core.url_to_fs.return_value = (MagicMock(), "lit")
+            var.load_lightning_model(map_location="cuda:0")
+        _, load_kwargs = mock_torch.load.call_args
+        self.assertEqual(load_kwargs.get("map_location"), "cuda:0")
 
     def test_load_lightning_wraps_constructor_typeerror(self):
         """load_lightning_model() turns a TypeError from __init__ into a ValueError."""

--- a/python/michelangelo/workflow/variables/tests/variables_test.py
+++ b/python/michelangelo/workflow/variables/tests/variables_test.py
@@ -775,14 +775,19 @@ class TestModelVariableCustomIO(TestCase):
 
 
 class TestModelVariableTorchIO(TestCase):
-    """Tests for save_torch_model / load_torch_model IO (state_dict + metadata)."""
+    """Tests for save_torch_model / load_torch_model IO (full nn.Module pickle).
 
-    def test_save_torch_writes_state_dict_not_full_module(self):
-        """save_torch_model() persists model.state_dict(), not the model itself."""
+    ``ModelVariable`` is workflow scratch storage; the PyTorch path pickles
+    the full ``nn.Module`` so fused models with nested submodules and
+    non-trivial constructors round-trip without callers re-supplying
+    constructor arguments. See ``save_torch_model`` / ``load_torch_model``
+    docstrings for the security trade-off.
+    """
+
+    def test_save_torch_writes_full_module(self):
+        """save_torch_model() persists the full nn.Module (not state_dict)."""
         mock_torch, _ = _mock_torch()
-        state_dict = {"layer.weight": "tensor"}
-        mock_model = MagicMock()
-        mock_model.state_dict.return_value = state_dict
+        mock_model = MagicMock(name="full-module")
         var = ModelVariable(path="memory://target")
         var._value = mock_model
         with (
@@ -792,16 +797,14 @@ class TestModelVariableTorchIO(TestCase):
             mock_fsspec.core.url_to_fs.return_value = (MagicMock(), "target")
             var.save_torch_model()
         save_args, _ = mock_torch.save.call_args
-        self.assertIs(save_args[0], state_dict)
-        mock_model.state_dict.assert_called_once()
+        self.assertIs(save_args[0], mock_model)
+        mock_model.state_dict.assert_not_called()
 
     def test_save_torch_does_not_mutate_path(self):
         """save_torch_model() leaves self.path unchanged (no .pt auto-append)."""
         mock_torch, _ = _mock_torch()
-        mock_model = MagicMock()
-        mock_model.state_dict.return_value = {}
-        var = ModelVariable(path="memory://target", _io_metadata=None)
-        var._value = mock_model
+        var = ModelVariable(path="memory://target")
+        var._value = MagicMock()
         with (
             patch.dict(sys.modules, {"torch": mock_torch}),
             patch(f"{_MODEL_PATH}.fsspec") as mock_fsspec,
@@ -813,11 +816,9 @@ class TestModelVariableTorchIO(TestCase):
     def test_save_torch_uses_non_recursive_put(self):
         """save_torch_model() writes a single file with fs.put (no recursive)."""
         mock_torch, _ = _mock_torch()
-        mock_model = MagicMock()
-        mock_model.state_dict.return_value = {}
         mock_fs = MagicMock()
         var = ModelVariable(path="memory://target")
-        var._value = mock_model
+        var._value = MagicMock()
         with (
             patch.dict(sys.modules, {"torch": mock_torch}),
             patch(f"{_MODEL_PATH}.fsspec") as mock_fsspec,
@@ -827,109 +828,51 @@ class TestModelVariableTorchIO(TestCase):
         _, put_kwargs = mock_fs.put.call_args
         self.assertNotIn("recursive", put_kwargs)
 
-    def test_save_torch_auto_populates_model_class(self):
-        """save_torch_model() sets metadata.model_class from type(value) if unset."""
+    def test_load_torch_defaults_weights_only_false(self):
+        """load_torch_model() defaults weights_only=False to match full-pickle save."""
+        loaded = object()
         mock_torch, _ = _mock_torch()
-
-        class _FakeModel:
-            def state_dict(self):
-                return {}
-
-        var = ModelVariable(path="memory://target")
-        var._value = _FakeModel()
-        with (
-            patch.dict(sys.modules, {"torch": mock_torch}),
-            patch(f"{_MODEL_PATH}.fsspec") as mock_fsspec,
-        ):
-            mock_fsspec.core.url_to_fs.return_value = (MagicMock(), "target")
-            var.save_torch_model()
-        self.assertIsNotNone(var.metadata.model_class)
-        self.assertTrue(var.metadata.model_class.endswith("_FakeModel"))
-
-    def test_load_torch_raises_when_model_class_missing(self):
-        """load_torch_model() raises ValueError without importing torch first."""
+        mock_torch.load = MagicMock(return_value=loaded)
         var = ModelVariable(path="memory://x")
-        with self.assertRaises(ValueError) as ctx:
-            var.load_torch_model()
-        self.assertIn("model_class", str(ctx.exception))
-
-    def test_load_torch_instantiates_with_hyperparameters(self):
-        """load_torch_model() builds model_class(**hyperparameters)."""
-        mock_torch, _ = _mock_torch()
-        mock_torch.load = MagicMock(return_value={"w": 1.0})
-        built = MagicMock(name="built")
-        mock_class = MagicMock(return_value=built)
-        var = ModelVariable(
-            path="memory://x",
-            metadata=ModelMetadata(model_class="pkg.M", hyperparameters={"hidden": 16}),
-        )
         with (
             patch.dict(sys.modules, {"torch": mock_torch}),
-            patch(f"{_MODEL_PATH}.import_attribute", return_value=mock_class),
-            patch(f"{_MODEL_PATH}.fsspec") as mock_fsspec,
-        ):
-            mock_fsspec.core.url_to_fs.return_value = (MagicMock(), "x")
-            var.load_torch_model()
-        mock_class.assert_called_once_with(hidden=16)
-        built.load_state_dict.assert_called_once_with({"w": 1.0})
-        self.assertIs(var._value, built)
-
-    def test_load_torch_uses_weights_only_true(self):
-        """load_torch_model() always loads state_dict with weights_only=True."""
-        mock_torch, _ = _mock_torch()
-        mock_torch.load = MagicMock(return_value={})
-        var = ModelVariable(
-            path="memory://x", metadata=ModelMetadata(model_class="pkg.M")
-        )
-        with (
-            patch.dict(sys.modules, {"torch": mock_torch}),
-            patch(f"{_MODEL_PATH}.import_attribute", return_value=MagicMock()),
             patch(f"{_MODEL_PATH}.fsspec") as mock_fsspec,
         ):
             mock_fsspec.core.url_to_fs.return_value = (MagicMock(), "x")
             var.load_torch_model()
         _, load_kwargs = mock_torch.load.call_args
-        self.assertTrue(load_kwargs.get("weights_only"))
+        self.assertFalse(load_kwargs.get("weights_only"))
         self.assertEqual(load_kwargs.get("map_location"), "cpu")
+        self.assertIs(var._value, loaded)
+
+    def test_load_torch_respects_weights_only_override(self):
+        """load_torch_model(weights_only=True) forwards the override to torch.load."""
+        mock_torch, _ = _mock_torch()
+        mock_torch.load = MagicMock(return_value=object())
+        var = ModelVariable(path="memory://x")
+        with (
+            patch.dict(sys.modules, {"torch": mock_torch}),
+            patch(f"{_MODEL_PATH}.fsspec") as mock_fsspec,
+        ):
+            mock_fsspec.core.url_to_fs.return_value = (MagicMock(), "x")
+            var.load_torch_model(weights_only=True)
+        _, load_kwargs = mock_torch.load.call_args
+        self.assertTrue(load_kwargs.get("weights_only"))
 
     def test_load_torch_uses_non_recursive_get(self):
         """load_torch_model() reads a single file with fs.get (no recursive)."""
         mock_torch, _ = _mock_torch()
-        mock_torch.load = MagicMock(return_value={})
+        mock_torch.load = MagicMock(return_value=object())
         mock_fs = MagicMock()
-        var = ModelVariable(
-            path="memory://x", metadata=ModelMetadata(model_class="pkg.M")
-        )
+        var = ModelVariable(path="memory://x")
         with (
             patch.dict(sys.modules, {"torch": mock_torch}),
-            patch(f"{_MODEL_PATH}.import_attribute", return_value=MagicMock()),
             patch(f"{_MODEL_PATH}.fsspec") as mock_fsspec,
         ):
             mock_fsspec.core.url_to_fs.return_value = (mock_fs, "x")
             var.load_torch_model()
         _, get_kwargs = mock_fs.get.call_args
         self.assertNotIn("recursive", get_kwargs)
-
-    def test_load_torch_wraps_constructor_typeerror(self):
-        """load_torch_model() turns a constructor TypeError into a clear ValueError."""
-        mock_torch, _ = _mock_torch()
-        mock_torch.load = MagicMock(return_value={})
-
-        def _bad_ctor(**kwargs):
-            raise TypeError("missing 1 required positional argument: 'in_features'")
-
-        var = ModelVariable(
-            path="memory://x", metadata=ModelMetadata(model_class="pkg.M")
-        )
-        with (
-            patch.dict(sys.modules, {"torch": mock_torch}),
-            patch(f"{_MODEL_PATH}.import_attribute", return_value=_bad_ctor),
-            patch(f"{_MODEL_PATH}.fsspec"),
-            self.assertRaises(ValueError) as ctx,
-        ):
-            var.load_torch_model()
-        self.assertIn("hyperparameters", str(ctx.exception))
-        self.assertIn("pkg.M", str(ctx.exception))
 
 
 class TestModelVariableLightningIO(TestCase):
@@ -1184,19 +1127,45 @@ except ImportError:
     _HAS_LIGHTNING = False
 
 
+if _HAS_TORCH:
+
+    class _FusedRoundTripModel(_torch_real.nn.Module):
+        """Fused model with nested submodules and a non-trivial constructor.
+
+        Exercises the exact case raised in review (kenns29, 2026-06-16):
+        ``state_dict + model_class(**hyperparameters)`` could not reconstruct
+        fused models whose ``__init__`` builds nested submodules whose
+        shapes depend on positional/keyword args not preserved in a flat
+        ``hyperparameters`` dict. The full-pickle path round-trips them.
+        """
+
+        def __init__(self, encoder, decoder, scale: float):
+            super().__init__()
+            self.encoder = encoder
+            self.decoder = decoder
+            self.register_buffer("scale", _torch_real.tensor(scale))
+
+        def forward(self, x):
+            return self.decoder(self.encoder(x)) * self.scale
+
+
 @unittest.skipUnless(_HAS_TORCH, "torch not installed")
 class TestModelVariableTorchRoundTrip(TestCase):
     """End-to-end save/load round-trip for plain torch.nn.Module."""
 
     def test_create_save_then_lazy_load_via_value(self):
-        """create() -> save() -> ModelVariable(path, metadata).value reconstructs."""
+        """create() -> save() -> ModelVariable(path, metadata).value reconstructs.
+
+        No ``hyperparameters`` are set on the metadata: the full ``nn.Module``
+        is pickled by ``save_torch_model``, so the loader does not need to
+        re-instantiate the class from constructor args.
+        """
         import tempfile
 
         torch = _torch_real
         original = torch.nn.Linear(2, 1)
 
         var = ModelVariable.create(original)
-        var.metadata.hyperparameters = {"in_features": 2, "out_features": 1}
         with tempfile.TemporaryDirectory() as tmp:
             var.path = f"{tmp}/model"
             var.save()
@@ -1207,6 +1176,32 @@ class TestModelVariableTorchRoundTrip(TestCase):
             self.assertEqual(loaded.in_features, 2)
             self.assertEqual(loaded.out_features, 1)
 
+            for k, v in original.state_dict().items():
+                self.assertTrue(torch.equal(loaded.state_dict()[k], v))
+
+    def test_fused_model_with_nested_submodules_round_trips(self):
+        """Fused module whose ctor takes prebuilt submodules round-trips.
+
+        ``_FusedRoundTripModel.__init__(encoder, decoder, scale)`` cannot
+        be reconstructed from a flat hyperparameters dict, but the
+        full-pickle save/load contract handles it transparently.
+        """
+        import tempfile
+
+        torch = _torch_real
+        encoder = torch.nn.Sequential(torch.nn.Linear(3, 4), torch.nn.ReLU())
+        decoder = torch.nn.Linear(4, 2)
+        original = _FusedRoundTripModel(encoder, decoder, scale=0.5)
+
+        var = ModelVariable.create(original)
+        with tempfile.TemporaryDirectory() as tmp:
+            var.path = f"{tmp}/fused"
+            var.save()
+
+            restored = ModelVariable(path=var.path, metadata=var.metadata)
+            loaded = restored.value
+            self.assertIsInstance(loaded, _FusedRoundTripModel)
+            self.assertTrue(torch.equal(loaded.scale, original.scale))
             for k, v in original.state_dict().items():
                 self.assertTrue(torch.equal(loaded.state_dict()[k], v))
 

--- a/python/michelangelo/workflow/variables/tests/variables_test.py
+++ b/python/michelangelo/workflow/variables/tests/variables_test.py
@@ -571,6 +571,14 @@ class TestModelVariableCreate(TestCase):
             var = ModelVariable.create(object())
         self.assertIsNone(var.metadata.training_framework)
 
+    def test_create_falls_through_when_torch_importable_but_value_not_module(self):
+        """create() returns unset framework when torch loads but value is non-Module."""
+        mock_torch, _ = _mock_torch()
+        with patch.dict(sys.modules, {"torch": mock_torch}):
+            var = ModelVariable.create("not-a-module")
+        self.assertIsNone(var.metadata.training_framework)
+        self.assertIsNone(var.metadata.model_class)
+
 
 class TestModelVariableSaveDispatch(TestCase):
     """Tests for ModelVariable.save() dispatch and pre-conditions."""
@@ -699,6 +707,21 @@ class TestModelVariableSkipWhenAlreadySaved(TestCase):
             var.save_torch_model()
             mock_torch.save.assert_not_called()
             mock_fsspec.core.url_to_fs.assert_not_called()
+
+    def test_save_lightning_skips_when_already_saved(self):
+        """save_lightning_model() returns early without touching torch or fs."""
+        mock_torch, _ = _mock_torch()
+        var = ModelVariable(path="memory://lit", metadata=ModelMetadata())
+        var._value = MagicMock(name="lightning-model")
+        var._saved = True
+        with (
+            patch.dict(sys.modules, {"torch": mock_torch}),
+            patch(f"{_MODEL_PATH}.fsspec") as mock_fsspec,
+        ):
+            var.save_lightning_model()
+            mock_torch.save.assert_not_called()
+            mock_fsspec.core.url_to_fs.assert_not_called()
+            var._value.state_dict.assert_not_called()
 
 
 class TestModelVariableCustomIO(TestCase):

--- a/python/michelangelo/workflow/variables/tests/variables_test.py
+++ b/python/michelangelo/workflow/variables/tests/variables_test.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 import types as _types
+import unittest
 from dataclasses import dataclass
 from io import BytesIO
 from unittest import TestCase
@@ -774,65 +775,161 @@ class TestModelVariableCustomIO(TestCase):
 
 
 class TestModelVariableTorchIO(TestCase):
-    """Tests for save_torch_model / load_torch_model IO."""
+    """Tests for save_torch_model / load_torch_model IO (state_dict + metadata)."""
 
-    def test_save_torch_auto_appends_pt_extension(self):
-        """save_torch_model() appends .pt to the path when missing."""
+    def test_save_torch_writes_state_dict_not_full_module(self):
+        """save_torch_model() persists model.state_dict(), not the model itself."""
         mock_torch, _ = _mock_torch()
-        var = ModelVariable(path="memory://target", metadata=ModelMetadata())
-        var._value = object()
+        state_dict = {"layer.weight": "tensor"}
+        mock_model = MagicMock()
+        mock_model.state_dict.return_value = state_dict
+        var = ModelVariable(path="memory://target")
+        var._value = mock_model
         with (
             patch.dict(sys.modules, {"torch": mock_torch}),
             patch(f"{_MODEL_PATH}.fsspec") as mock_fsspec,
         ):
-            mock_fsspec.core.url_to_fs.return_value = (MagicMock(), "target.pt")
+            mock_fsspec.core.url_to_fs.return_value = (MagicMock(), "target")
             var.save_torch_model()
-        self.assertTrue(var.path.endswith(".pt"))
-        mock_torch.save.assert_called_once()
+        save_args, _ = mock_torch.save.call_args
+        self.assertIs(save_args[0], state_dict)
+        mock_model.state_dict.assert_called_once()
 
-    def test_save_torch_preserves_existing_pt_extension(self):
-        """save_torch_model() does not double-append .pt."""
+    def test_save_torch_does_not_mutate_path(self):
+        """save_torch_model() leaves self.path unchanged (no .pt auto-append)."""
         mock_torch, _ = _mock_torch()
-        var = ModelVariable(path="memory://target.pt", metadata=ModelMetadata())
-        var._value = object()
+        mock_model = MagicMock()
+        mock_model.state_dict.return_value = {}
+        var = ModelVariable(path="memory://target", _io_metadata=None)
+        var._value = mock_model
         with (
             patch.dict(sys.modules, {"torch": mock_torch}),
             patch(f"{_MODEL_PATH}.fsspec") as mock_fsspec,
         ):
-            mock_fsspec.core.url_to_fs.return_value = (MagicMock(), "target.pt")
+            mock_fsspec.core.url_to_fs.return_value = (MagicMock(), "target")
             var.save_torch_model()
-        self.assertEqual(var.path, "memory://target.pt")
+        self.assertEqual(var.path, "memory://target")
 
-    def test_load_torch_defaults_to_weights_only_true(self):
-        """load_torch_model() forwards weights_only=True to torch.load by default."""
-        loaded_obj = object()
+    def test_save_torch_uses_non_recursive_put(self):
+        """save_torch_model() writes a single file with fs.put (no recursive)."""
         mock_torch, _ = _mock_torch()
-        mock_torch.load = MagicMock(return_value=loaded_obj)
-        var = ModelVariable(path="memory://x.pt", metadata=ModelMetadata())
+        mock_model = MagicMock()
+        mock_model.state_dict.return_value = {}
+        mock_fs = MagicMock()
+        var = ModelVariable(path="memory://target")
+        var._value = mock_model
         with (
             patch.dict(sys.modules, {"torch": mock_torch}),
             patch(f"{_MODEL_PATH}.fsspec") as mock_fsspec,
         ):
-            mock_fsspec.core.url_to_fs.return_value = (MagicMock(), "x.pt")
+            mock_fsspec.core.url_to_fs.return_value = (mock_fs, "target")
+            var.save_torch_model()
+        _, put_kwargs = mock_fs.put.call_args
+        self.assertNotIn("recursive", put_kwargs)
+
+    def test_save_torch_auto_populates_model_class(self):
+        """save_torch_model() sets metadata.model_class from type(value) if unset."""
+        mock_torch, _ = _mock_torch()
+
+        class _FakeModel:
+            def state_dict(self):
+                return {}
+
+        var = ModelVariable(path="memory://target")
+        var._value = _FakeModel()
+        with (
+            patch.dict(sys.modules, {"torch": mock_torch}),
+            patch(f"{_MODEL_PATH}.fsspec") as mock_fsspec,
+        ):
+            mock_fsspec.core.url_to_fs.return_value = (MagicMock(), "target")
+            var.save_torch_model()
+        self.assertIsNotNone(var.metadata.model_class)
+        self.assertTrue(var.metadata.model_class.endswith("_FakeModel"))
+
+    def test_load_torch_raises_when_model_class_missing(self):
+        """load_torch_model() raises ValueError without importing torch first."""
+        var = ModelVariable(path="memory://x")
+        with self.assertRaises(ValueError) as ctx:
+            var.load_torch_model()
+        self.assertIn("model_class", str(ctx.exception))
+
+    def test_load_torch_instantiates_with_hyperparameters(self):
+        """load_torch_model() builds model_class(**hyperparameters)."""
+        mock_torch, _ = _mock_torch()
+        mock_torch.load = MagicMock(return_value={"w": 1.0})
+        built = MagicMock(name="built")
+        mock_class = MagicMock(return_value=built)
+        var = ModelVariable(
+            path="memory://x",
+            metadata=ModelMetadata(model_class="pkg.M", hyperparameters={"hidden": 16}),
+        )
+        with (
+            patch.dict(sys.modules, {"torch": mock_torch}),
+            patch(f"{_MODEL_PATH}.import_attribute", return_value=mock_class),
+            patch(f"{_MODEL_PATH}.fsspec") as mock_fsspec,
+        ):
+            mock_fsspec.core.url_to_fs.return_value = (MagicMock(), "x")
+            var.load_torch_model()
+        mock_class.assert_called_once_with(hidden=16)
+        built.load_state_dict.assert_called_once_with({"w": 1.0})
+        self.assertIs(var._value, built)
+
+    def test_load_torch_uses_weights_only_true(self):
+        """load_torch_model() always loads state_dict with weights_only=True."""
+        mock_torch, _ = _mock_torch()
+        mock_torch.load = MagicMock(return_value={})
+        var = ModelVariable(
+            path="memory://x", metadata=ModelMetadata(model_class="pkg.M")
+        )
+        with (
+            patch.dict(sys.modules, {"torch": mock_torch}),
+            patch(f"{_MODEL_PATH}.import_attribute", return_value=MagicMock()),
+            patch(f"{_MODEL_PATH}.fsspec") as mock_fsspec,
+        ):
+            mock_fsspec.core.url_to_fs.return_value = (MagicMock(), "x")
             var.load_torch_model()
         _, load_kwargs = mock_torch.load.call_args
         self.assertTrue(load_kwargs.get("weights_only"))
         self.assertEqual(load_kwargs.get("map_location"), "cpu")
-        self.assertIs(var._value, loaded_obj)
 
-    def test_load_torch_respects_weights_only_override(self):
-        """load_torch_model(weights_only=False) forwards the override to torch.load."""
+    def test_load_torch_uses_non_recursive_get(self):
+        """load_torch_model() reads a single file with fs.get (no recursive)."""
         mock_torch, _ = _mock_torch()
-        mock_torch.load = MagicMock(return_value=object())
-        var = ModelVariable(path="memory://x.pt", metadata=ModelMetadata())
+        mock_torch.load = MagicMock(return_value={})
+        mock_fs = MagicMock()
+        var = ModelVariable(
+            path="memory://x", metadata=ModelMetadata(model_class="pkg.M")
+        )
         with (
             patch.dict(sys.modules, {"torch": mock_torch}),
+            patch(f"{_MODEL_PATH}.import_attribute", return_value=MagicMock()),
             patch(f"{_MODEL_PATH}.fsspec") as mock_fsspec,
         ):
-            mock_fsspec.core.url_to_fs.return_value = (MagicMock(), "x.pt")
-            var.load_torch_model(weights_only=False)
-        _, load_kwargs = mock_torch.load.call_args
-        self.assertFalse(load_kwargs.get("weights_only"))
+            mock_fsspec.core.url_to_fs.return_value = (mock_fs, "x")
+            var.load_torch_model()
+        _, get_kwargs = mock_fs.get.call_args
+        self.assertNotIn("recursive", get_kwargs)
+
+    def test_load_torch_wraps_constructor_typeerror(self):
+        """load_torch_model() turns a constructor TypeError into a clear ValueError."""
+        mock_torch, _ = _mock_torch()
+        mock_torch.load = MagicMock(return_value={})
+
+        def _bad_ctor(**kwargs):
+            raise TypeError("missing 1 required positional argument: 'in_features'")
+
+        var = ModelVariable(
+            path="memory://x", metadata=ModelMetadata(model_class="pkg.M")
+        )
+        with (
+            patch.dict(sys.modules, {"torch": mock_torch}),
+            patch(f"{_MODEL_PATH}.import_attribute", return_value=_bad_ctor),
+            patch(f"{_MODEL_PATH}.fsspec"),
+            self.assertRaises(ValueError) as ctx,
+        ):
+            var.load_torch_model()
+        self.assertIn("hyperparameters", str(ctx.exception))
+        self.assertIn("pkg.M", str(ctx.exception))
 
 
 class TestModelVariableLightningIO(TestCase):
@@ -906,6 +1003,27 @@ class TestModelVariableLightningIO(TestCase):
         _, load_kwargs = mock_torch.load.call_args
         self.assertTrue(load_kwargs.get("weights_only"))
 
+    def test_load_lightning_wraps_constructor_typeerror(self):
+        """load_lightning_model() turns a TypeError from __init__ into a ValueError."""
+        mock_torch, _ = _mock_torch()
+        mock_torch.load = MagicMock(return_value={})
+
+        def _bad_ctor(**kwargs):
+            raise TypeError("missing 1 required positional argument: 'hidden'")
+
+        var = ModelVariable(
+            path="memory://lit", metadata=ModelMetadata(model_class="pkg.M")
+        )
+        with (
+            patch.dict(sys.modules, {"torch": mock_torch}),
+            patch(f"{_MODEL_PATH}.import_attribute", return_value=_bad_ctor),
+            patch(f"{_MODEL_PATH}.fsspec"),
+            self.assertRaises(ValueError) as ctx,
+        ):
+            var.load_lightning_model()
+        self.assertIn("hyperparameters", str(ctx.exception))
+        self.assertIn("pkg.M", str(ctx.exception))
+
     def test_load_lightning_defaults_hyperparameters_to_empty_dict(self):
         """load_lightning_model() treats hyperparameters=None as {}."""
         mock_torch, _ = _mock_torch()
@@ -933,3 +1051,205 @@ class TestModelVariableImports(TestCase):
         from michelangelo.workflow import variables as _wv
 
         self.assertIs(_wv.ModelVariable, ModelVariable)
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for review-feedback fixes (M1, M5, M6, M4-lightning)
+# ---------------------------------------------------------------------------
+
+
+def _mock_lightning(instance=None):
+    """Return (mock_pytorch_lightning_module, mock_lightning_instance).
+
+    The fake module exposes a ``LightningModule`` class that subclasses the
+    mock torch ``nn.Module``, mirroring the real ``pl.LightningModule`` <:
+    ``torch.nn.Module`` relationship that powers the M1 detection check.
+    """
+    mock_torch, _ = _mock_torch()
+    nn_module_cls = mock_torch.nn.Module
+    lit_module_cls = type("LightningModule", (nn_module_cls,), {})
+    mock_pl = _types.SimpleNamespace(LightningModule=lit_module_cls)
+    inst = instance if instance is not None else lit_module_cls()
+    return mock_pl, mock_torch, inst
+
+
+class TestModelVariableCreateLightning(TestCase):
+    """Regression for M1: Lightning is detected before plain PyTorch in create()."""
+
+    def test_create_detects_lightning_module_before_pytorch(self):
+        """A LightningModule (subclass of nn.Module) is classified as lightning."""
+        mock_pl, mock_torch, inst = _mock_lightning()
+        with patch.dict(
+            sys.modules, {"pytorch_lightning": mock_pl, "torch": mock_torch}
+        ):
+            var = ModelVariable.create(inst)
+        self.assertEqual(var.metadata.training_framework, TRAINING_FRAMEWORK_LIGHTNING)
+        self.assertTrue(var.metadata.model_class.endswith("LightningModule"))
+
+    def test_create_falls_back_to_pytorch_when_lightning_missing(self):
+        """Plain torch.nn.Module is still detected when pytorch_lightning is absent."""
+        mock_torch, inst = _mock_torch()
+        with patch.dict(sys.modules, {"torch": mock_torch, "pytorch_lightning": None}):
+            var = ModelVariable.create(inst)
+        self.assertEqual(var.metadata.training_framework, TRAINING_FRAMEWORK_PYTORCH)
+
+
+class TestModelVariableInitErgonomics(TestCase):
+    """Regression for M5 (metadata None footgun) and M6 (value= constructor)."""
+
+    def test_init_accepts_value_keyword(self):
+        """ModelVariable(value=model) attaches the value without using create()."""
+        sentinel = object()
+        var = ModelVariable(value=sentinel)
+        self.assertIs(var._value, sentinel)
+
+    def test_init_auto_generates_path_when_omitted(self):
+        """ModelVariable() generates a memory:// path when none is provided."""
+        var = ModelVariable()
+        self.assertTrue(var.path.startswith("memory://"))
+
+    def test_init_defaults_metadata_to_empty_model_metadata(self):
+        """ModelVariable(metadata=None) attaches a fresh ModelMetadata, not None."""
+        var = ModelVariable(path="/tmp/x")
+        self.assertIsInstance(var.metadata, ModelMetadata)
+        self.assertIsNone(var.metadata.training_framework)
+
+    def test_save_with_default_metadata_raises_value_error(self):
+        """Default metadata + save() raises a guided ValueError, not AttributeError."""
+        var = ModelVariable(value=object(), path="/tmp/x")
+        with self.assertRaises(ValueError) as ctx:
+            var.save()
+        msg = str(ctx.exception)
+        self.assertIn("training_framework", msg)
+        self.assertIn("pytorch", msg)
+        self.assertIn("custom", msg)
+        self.assertIn("lightning", msg)
+
+
+class TestModelVariableLightningFsspecFlags(TestCase):
+    """Regression for M4: Lightning save/load use non-recursive fsspec ops."""
+
+    def test_save_lightning_uses_non_recursive_put(self):
+        """save_lightning_model() writes a single file with fs.put (no recursive)."""
+        mock_torch, _ = _mock_torch()
+        mock_fs = MagicMock()
+        var = ModelVariable(path="memory://lit")
+        var._value = MagicMock(state_dict=MagicMock(return_value={}))
+        with (
+            patch.dict(sys.modules, {"torch": mock_torch}),
+            patch(f"{_MODEL_PATH}.fsspec") as mock_fsspec,
+        ):
+            mock_fsspec.core.url_to_fs.return_value = (mock_fs, "lit")
+            var.save_lightning_model()
+        _, put_kwargs = mock_fs.put.call_args
+        self.assertNotIn("recursive", put_kwargs)
+
+    def test_load_lightning_uses_non_recursive_get(self):
+        """load_lightning_model() reads a single file with fs.get (no recursive)."""
+        mock_torch, _ = _mock_torch()
+        mock_torch.load = MagicMock(return_value={})
+        mock_fs = MagicMock()
+        var = ModelVariable(
+            path="memory://lit", metadata=ModelMetadata(model_class="pkg.M")
+        )
+        with (
+            patch.dict(sys.modules, {"torch": mock_torch}),
+            patch(f"{_MODEL_PATH}.import_attribute", return_value=MagicMock()),
+            patch(f"{_MODEL_PATH}.fsspec") as mock_fsspec,
+        ):
+            mock_fsspec.core.url_to_fs.return_value = (mock_fs, "lit")
+            var.load_lightning_model()
+        _, get_kwargs = mock_fs.get.call_args
+        self.assertNotIn("recursive", get_kwargs)
+
+
+# ---------------------------------------------------------------------------
+# B3 — End-to-end round-trip tests (guarded; run only when torch/lightning
+# are installed). These would have caught the previous
+# save(full-pickle) / load(weights_only=True) contract mismatch in CI.
+# ---------------------------------------------------------------------------
+
+try:
+    import torch as _torch_real
+
+    _HAS_TORCH = True
+except ImportError:
+    _HAS_TORCH = False
+
+try:
+    import pytorch_lightning as _pl_real
+
+    _HAS_LIGHTNING = True
+except ImportError:
+    _HAS_LIGHTNING = False
+
+
+@unittest.skipUnless(_HAS_TORCH, "torch not installed")
+class TestModelVariableTorchRoundTrip(TestCase):
+    """End-to-end save/load round-trip for plain torch.nn.Module."""
+
+    def test_create_save_then_lazy_load_via_value(self):
+        """create() -> save() -> ModelVariable(path, metadata).value reconstructs."""
+        import tempfile
+
+        torch = _torch_real
+        original = torch.nn.Linear(2, 1)
+
+        var = ModelVariable.create(original)
+        var.metadata.hyperparameters = {"in_features": 2, "out_features": 1}
+        with tempfile.TemporaryDirectory() as tmp:
+            var.path = f"{tmp}/model"
+            var.save()
+
+            restored = ModelVariable(path=var.path, metadata=var.metadata)
+            loaded = restored.value
+            self.assertIsInstance(loaded, torch.nn.Linear)
+            self.assertEqual(loaded.in_features, 2)
+            self.assertEqual(loaded.out_features, 1)
+
+            for k, v in original.state_dict().items():
+                self.assertTrue(torch.equal(loaded.state_dict()[k], v))
+
+
+if _HAS_TORCH and _HAS_LIGHTNING:
+
+    class _RoundTripLightningModel(_pl_real.LightningModule):
+        """Module-level Lightning model so dot-path import_attribute can find it."""
+
+        def __init__(self, hidden: int = 4):
+            super().__init__()
+            self.hidden = hidden
+            self.layer = _torch_real.nn.Linear(hidden, 1)
+
+        def forward(self, x):
+            return self.layer(x)
+
+
+@unittest.skipUnless(
+    _HAS_TORCH and _HAS_LIGHTNING, "torch + pytorch_lightning not installed"
+)
+class TestModelVariableLightningRoundTrip(TestCase):
+    """End-to-end save/load round-trip for pytorch_lightning.LightningModule."""
+
+    def test_create_save_then_lazy_load_via_value(self):
+        """create() detects lightning, save+reload reconstructs and calls eval()."""
+        import tempfile
+
+        torch = _torch_real
+
+        original = _RoundTripLightningModel(hidden=4)
+        var = ModelVariable.create(original)
+        self.assertEqual(var.metadata.training_framework, TRAINING_FRAMEWORK_LIGHTNING)
+        var.metadata.hyperparameters = {"hidden": 4}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            var.path = f"{tmp}/lit"
+            var.save()
+
+            restored = ModelVariable(path=var.path, metadata=var.metadata)
+            loaded = restored.value
+            self.assertIsInstance(loaded, _RoundTripLightningModel)
+            self.assertEqual(loaded.hidden, 4)
+            self.assertFalse(loaded.training)
+            for k, v in original.state_dict().items():
+                self.assertTrue(torch.equal(loaded.state_dict()[k], v))


### PR DESCRIPTION
add the `ModelVariable` (custom / pytorch / lightning save+load dispatch) to the open-source `michelangelo.workflow.variables` package, replacing internal imports with their open-source equivalents and lazy- importing `torch` / `CustomModel` so the module remains importable without the optional ML dependencies.

Adds the `TRAINING_FRAMEWORK_*` constants and a `hyperparameters` dict field to `ModelMetadata`, and exports `ModelVariable` from the package `__init__`.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
Add ModelVariable Supporting torch model serd logic

<!-- Tell your future self why have you made these changes -->
**Why?**
It is a convenient tool for torch model training

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No Prod impact

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
Add ModelVariable support torch model serialization and de-serialization logic
<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
