### PR TITLE
Add eslint-plugin-react with structural component rules

### DIFF
--- a/javascript/eslint.config.js
+++ b/javascript/eslint.config.js
@@ -12,11 +12,13 @@ import testingLibrary from 'eslint-plugin-testing-library';
 import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
 import simpleImportSort from 'eslint-plugin-simple-import-sort';
+import react from 'eslint-plugin-react';
 import globals from 'globals';
 
 // Shared plugins (used in app and packages/*)
 const sharedPlugins = {
   'react-hooks': reactHooks,
+  'react': react,
   'simple-import-sort': simpleImportSort,
   'react-refresh': reactRefresh,
   baseui: baseUIEslint,
@@ -25,6 +27,9 @@ const sharedPlugins = {
 // Shared rules (used in app and packages/*)
 const sharedRules = {
   ...reactHooks.configs.recommended.rules,
+  'react/no-multi-comp': ['error', { ignoreStateless: false }],
+  'react/no-unstable-nested-components': ['error', { allowAsProps: true }],
+  'react/jsx-no-constructed-context-values': 'error',
   'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
   'simple-import-sort/imports': [
     'error',
@@ -282,6 +287,20 @@ export default [
   {
     files: ['vitest.config.ts'],
     ...tseslint.configs.disableTypeChecked,
+  },
+
+  // no-multi-comp: tests and styled-component files legitimately define multiple components
+  {
+    files: [
+      'packages/**/__tests__/**/*.{ts,tsx}',
+      'app/**/__tests__/**/*.{ts,tsx}',
+      'packages/**/test/**/*.{ts,tsx}',
+      'packages/**/*styled-components.tsx',
+      'app/**/*styled-components.tsx',
+    ],
+    rules: {
+      'react/no-multi-comp': 'off',
+    },
   },
 
   // Disable conflicting style rules (Prettier)

--- a/javascript/eslint.config.js
+++ b/javascript/eslint.config.js
@@ -53,6 +53,7 @@ const sharedRules = {
   // 'baseui/deprecated-theme-api': 'warn',
   // 'baseui/deprecated-component-api': 'warn',
   'no-nested-ternary': 'error',
+  'no-console': ['error', { allow: ['warn', 'error'] }],
   eqeqeq: ['error', 'always', { null: 'ignore' }],
   'no-restricted-syntax': [
     'error',

--- a/javascript/eslint.config.js
+++ b/javascript/eslint.config.js
@@ -18,7 +18,7 @@ import globals from 'globals';
 // Shared plugins (used in app and packages/*)
 const sharedPlugins = {
   'react-hooks': reactHooks,
-  'react': react,
+  react: react,
   'simple-import-sort': simpleImportSort,
   'react-refresh': reactRefresh,
   baseui: baseUIEslint,

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -38,6 +38,7 @@
     "eslint-config-prettier": "^10.1.1",
     "eslint-plugin-baseui": "^13.0.0",
     "eslint-plugin-prettier": "^5.2.5",
+    "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.1.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "eslint-plugin-simple-import-sort": "^12.1.1",

--- a/javascript/packages/core/components/breadcrumb-bar/breadcrumb-bar.tsx
+++ b/javascript/packages/core/components/breadcrumb-bar/breadcrumb-bar.tsx
@@ -1,3 +1,7 @@
+// Each breadcrumb segment is a small private component that reads URL params via
+// useStudioParams. Keeping them co-located avoids prop-drilling the same params
+// through BreadcrumbBar and makes the rendering logic easy to follow in sequence.
+/* eslint-disable react/no-multi-comp */
 import { useStyletron } from 'baseui';
 import { Breadcrumbs } from 'baseui/breadcrumbs';
 import { Cell, Grid } from 'baseui/layout-grid';

--- a/javascript/packages/core/components/breadcrumb-bar/breadcrumb-bar.tsx
+++ b/javascript/packages/core/components/breadcrumb-bar/breadcrumb-bar.tsx
@@ -1,6 +1,5 @@
-// Each breadcrumb segment is a small private component that reads URL params via
-// useStudioParams. Keeping them co-located avoids prop-drilling the same params
-// through BreadcrumbBar and makes the rendering logic easy to follow in sequence.
+// Each breadcrumb segment is a small private component. Keeping them co-located
+// makes the rendering logic easy to follow in sequence.
 /* eslint-disable react/no-multi-comp */
 import { useStyletron } from 'baseui';
 import { Breadcrumbs } from 'baseui/breadcrumbs';

--- a/javascript/packages/core/components/form/components/form-control.tsx
+++ b/javascript/packages/core/components/form/components/form-control.tsx
@@ -66,6 +66,9 @@ export const FormControl: React.FC<FormControlProps> = ({
   );
 };
 
+// Counter and labelEndEnhancer are rendered together with shared spacing — keeping
+// this helper inline avoids threading both props through an intermediate component.
+// eslint-disable-next-line react/no-multi-comp
 const LabelEndEnhancerContent: React.FC<Pick<FormControlProps, 'counter' | 'labelEndEnhancer'>> = ({
   counter,
   labelEndEnhancer,

--- a/javascript/packages/core/components/form/components/form-control.tsx
+++ b/javascript/packages/core/components/form/components/form-control.tsx
@@ -5,6 +5,7 @@ import { FormControl as BaseFormControl } from 'baseui/form-control';
 import { Markdown } from '#core/components/markdown/markdown';
 import { TruncatedText } from '#core/components/truncated-text/truncated-text';
 import { Label } from './label/label';
+import { LabelEndEnhancerContent } from './label/label-end-enhancer-content';
 
 import type { FormControlProps } from './types';
 
@@ -63,31 +64,5 @@ export const FormControl: React.FC<FormControlProps> = ({
         {children}
       </BaseFormControl>
     </div>
-  );
-};
-
-// Counter and labelEndEnhancer are rendered together with shared spacing — keeping
-// this helper inline avoids threading both props through an intermediate component.
-// eslint-disable-next-line react/no-multi-comp
-const LabelEndEnhancerContent: React.FC<Pick<FormControlProps, 'counter' | 'labelEndEnhancer'>> = ({
-  counter,
-  labelEndEnhancer,
-}) => {
-  const [css, theme] = useStyletron();
-
-  return (
-    <>
-      {counter && (
-        <span
-          className={css({
-            ...theme.typography.font100,
-            color: theme.colors.contentPrimary,
-          })}
-        >
-          {counter.length}/{counter.maxLength}
-        </span>
-      )}
-      {labelEndEnhancer}
-    </>
   );
 };

--- a/javascript/packages/core/components/form/components/label/label-end-enhancer-content.tsx
+++ b/javascript/packages/core/components/form/components/label/label-end-enhancer-content.tsx
@@ -1,0 +1,32 @@
+import { useStyletron } from 'baseui';
+
+import type { FormControlProps } from '#core/components/form/components/types';
+
+/**
+ * Renders content intended for FormControl's label end enhancer slot. Includes counter
+ * display and/or arbitrary enhancer content, side-by-side.
+ *
+ * **Relies on parent FormControl's LabelEndEnhancer override for flex layout**
+ */
+export const LabelEndEnhancerContent = ({
+  counter,
+  labelEndEnhancer,
+}: Pick<FormControlProps, 'counter' | 'labelEndEnhancer'>) => {
+  const [css, theme] = useStyletron();
+
+  return (
+    <>
+      {counter && (
+        <span
+          className={css({
+            ...theme.typography.font100,
+            color: theme.colors.contentPrimary,
+          })}
+        >
+          {counter.length}/{counter.maxLength}
+        </span>
+      )}
+      {labelEndEnhancer}
+    </>
+  );
+};

--- a/javascript/packages/core/components/form/form.tsx
+++ b/javascript/packages/core/components/form/form.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useMemo, useRef } from 'react';
 import { Form as FinalForm } from 'react-final-form';
 import { useStyletron } from 'baseui';
 import arrayMutators from 'final-form-arrays';
@@ -23,9 +23,10 @@ export const Form = <FieldValues extends FormData = FormData>({
 }: FormProps<FieldValues>) => {
   const [css, theme] = useStyletron();
   const registryRef = useRef<FieldRegistry>(new Map());
+  const formContextValue = useMemo(() => ({ fieldRegistry: registryRef.current }), []);
 
   return (
-    <FormContext.Provider value={{ fieldRegistry: registryRef.current }}>
+    <FormContext.Provider value={formContextValue}>
       <FinalForm
         onSubmit={onSubmit}
         initialValues={initialValues}

--- a/javascript/packages/core/components/table/__tests__/table.test.tsx
+++ b/javascript/packages/core/components/table/__tests__/table.test.tsx
@@ -1611,8 +1611,6 @@ describe('Table', () => {
       const customSortingFn = (rowA: unknown, rowB: unknown, columnId: string) => {
         const aValue = (rowA as { getValue: (id: string) => string }).getValue(columnId);
         const bValue = (rowB as { getValue: (id: string) => string }).getValue(columnId);
-        console.log('aValue', aValue);
-        console.log('bValue', bValue);
         return aValue.length - bValue.length;
       };
 

--- a/javascript/packages/core/components/table/components/table-pagination/table-pagination.tsx
+++ b/javascript/packages/core/components/table/components/table-pagination/table-pagination.tsx
@@ -49,7 +49,10 @@ export function TablePagination(props: TablePaginationProps) {
   );
 }
 
-export function LoadingButton() {
+// BaseUI requires a stable component reference in overrides — an inline arrow function
+// would remount the button on every render. Keeping it here avoids a one-off file.
+// eslint-disable-next-line react/no-multi-comp
+function LoadingButton() {
   return (
     <Button isLoading={true} kind={KIND.tertiary}>
       Next

--- a/javascript/packages/core/components/table/components/table-pagination/table-pagination.tsx
+++ b/javascript/packages/core/components/table/components/table-pagination/table-pagination.tsx
@@ -49,8 +49,8 @@ export function TablePagination(props: TablePaginationProps) {
   );
 }
 
-// BaseUI requires a stable component reference in overrides — an inline arrow function
-// would remount the button on every render. Keeping it here avoids a one-off file.
+// Extracted to reduce nesting in BasePagination overrides. Not substantial enough
+// to warrant a separate file.
 // eslint-disable-next-line react/no-multi-comp
 function LoadingButton() {
   return (

--- a/javascript/packages/core/hooks/use-studio-query.ts
+++ b/javascript/packages/core/hooks/use-studio-query.ts
@@ -82,7 +82,7 @@ export const useStudioQuery = <TData>(args: {
       try {
         return (await request(queryName, { ...serviceOptions, namespace })) as Promise<TData>;
       } catch (error) {
-        console.log('error', error);
+        console.error('error', error);
         throw normalizeError(error)!;
       }
     },

--- a/javascript/packages/core/providers/cell-provider/cell-provider.tsx
+++ b/javascript/packages/core/providers/cell-provider/cell-provider.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import { CellContext } from './cell-context';
 
 import type { CellContextType } from './types';
@@ -23,9 +25,7 @@ export const CellProvider = ({
   children,
   renderers = {},
 }: { children: React.ReactNode } & Partial<CellContextType>) => {
-  const contextValue: CellContextType = {
-    renderers,
-  };
+  const contextValue = useMemo<CellContextType>(() => ({ renderers }), [renderers]);
 
   return <CellContext.Provider value={contextValue}>{children}</CellContext.Provider>;
 };

--- a/javascript/yarn.lock
+++ b/javascript/yarn.lock
@@ -1725,7 +1725,7 @@ array-buffer-byte-length@^1.0.1, array-buffer-byte-length@^1.0.2:
     call-bound "^1.0.3"
     is-array-buffer "^3.0.5"
 
-array-includes@^3.1.6:
+array-includes@^3.1.6, array-includes@^3.1.8:
   version "3.1.9"
   resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.9.tgz#1f0ccaa08e90cdbc3eb433210f903ad0f17c3f3a"
   integrity sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==
@@ -1744,6 +1744,18 @@ array-union@^2.1.0:
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
+array.prototype.findlast@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz#3e4fbcb30a15a7f5bf64cf2faae22d139c2e4904"
+  integrity sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==
+  dependencies:
+    call-bind "^1.0.7"
+    define-properties "^1.2.1"
+    es-abstract "^1.23.2"
+    es-errors "^1.3.0"
+    es-object-atoms "^1.0.0"
+    es-shim-unscopables "^1.0.2"
+
 array.prototype.flat@^1.3.1:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz#534aaf9e6e8dd79fb6b9a9917f839ef1ec63afe5"
@@ -1752,6 +1764,27 @@ array.prototype.flat@^1.3.1:
     call-bind "^1.0.8"
     define-properties "^1.2.1"
     es-abstract "^1.23.5"
+    es-shim-unscopables "^1.0.2"
+
+array.prototype.flatmap@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz#712cc792ae70370ae40586264629e33aab5dd38b"
+  integrity sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==
+  dependencies:
+    call-bind "^1.0.8"
+    define-properties "^1.2.1"
+    es-abstract "^1.23.5"
+    es-shim-unscopables "^1.0.2"
+
+array.prototype.tosorted@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz#fe954678ff53034e717ea3352a03f0b0b86f7ffc"
+  integrity sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==
+  dependencies:
+    call-bind "^1.0.7"
+    define-properties "^1.2.1"
+    es-abstract "^1.23.3"
+    es-errors "^1.3.0"
     es-shim-unscopables "^1.0.2"
 
 arraybuffer.prototype.slice@^1.0.4:
@@ -1927,6 +1960,16 @@ call-bind@^1.0.7, call-bind@^1.0.8:
     call-bind-apply-helpers "^1.0.0"
     es-define-property "^1.0.0"
     get-intrinsic "^1.2.4"
+    set-function-length "^1.2.2"
+
+call-bind@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.9.tgz#39a644700c80bc7d0ca9102fc6d1d43b2fd7eee7"
+  integrity sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==
+  dependencies:
+    call-bind-apply-helpers "^1.0.2"
+    es-define-property "^1.0.1"
+    get-intrinsic "^1.3.0"
     set-function-length "^1.2.2"
 
 call-bound@^1.0.2, call-bound@^1.0.3, call-bound@^1.0.4:
@@ -2456,7 +2499,7 @@ define-data-property@^1.0.1, define-data-property@^1.1.4:
     es-errors "^1.3.0"
     gopd "^1.0.1"
 
-define-properties@^1.2.1:
+define-properties@^1.1.3, define-properties@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.2.1.tgz#10781cc616eb951a80a034bafcaa7377f6af2b6c"
   integrity sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==
@@ -2491,6 +2534,13 @@ dir-glob@^3.0.1:
   integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
   dependencies:
     path-type "^4.0.0"
+
+doctrine@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
+  integrity sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==
+  dependencies:
+    esutils "^2.0.2"
 
 dom-accessibility-api@^0.5.9:
   version "0.5.16"
@@ -2555,6 +2605,66 @@ error-ex@^1.3.1:
   integrity sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==
   dependencies:
     is-arrayish "^0.2.1"
+
+es-abstract@^1.17.5, es-abstract@^1.23.2, es-abstract@^1.23.3, es-abstract@^1.23.6, es-abstract@^1.24.2:
+  version "1.24.2"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.24.2.tgz#2dbd38c180735ee983f77585140a2706a963ed9a"
+  integrity sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==
+  dependencies:
+    array-buffer-byte-length "^1.0.2"
+    arraybuffer.prototype.slice "^1.0.4"
+    available-typed-arrays "^1.0.7"
+    call-bind "^1.0.8"
+    call-bound "^1.0.4"
+    data-view-buffer "^1.0.2"
+    data-view-byte-length "^1.0.2"
+    data-view-byte-offset "^1.0.1"
+    es-define-property "^1.0.1"
+    es-errors "^1.3.0"
+    es-object-atoms "^1.1.1"
+    es-set-tostringtag "^2.1.0"
+    es-to-primitive "^1.3.0"
+    function.prototype.name "^1.1.8"
+    get-intrinsic "^1.3.0"
+    get-proto "^1.0.1"
+    get-symbol-description "^1.1.0"
+    globalthis "^1.0.4"
+    gopd "^1.2.0"
+    has-property-descriptors "^1.0.2"
+    has-proto "^1.2.0"
+    has-symbols "^1.1.0"
+    hasown "^2.0.2"
+    internal-slot "^1.1.0"
+    is-array-buffer "^3.0.5"
+    is-callable "^1.2.7"
+    is-data-view "^1.0.2"
+    is-negative-zero "^2.0.3"
+    is-regex "^1.2.1"
+    is-set "^2.0.3"
+    is-shared-array-buffer "^1.0.4"
+    is-string "^1.1.1"
+    is-typed-array "^1.1.15"
+    is-weakref "^1.1.1"
+    math-intrinsics "^1.1.0"
+    object-inspect "^1.13.4"
+    object-keys "^1.1.1"
+    object.assign "^4.1.7"
+    own-keys "^1.0.1"
+    regexp.prototype.flags "^1.5.4"
+    safe-array-concat "^1.1.3"
+    safe-push-apply "^1.0.0"
+    safe-regex-test "^1.1.0"
+    set-proto "^1.0.0"
+    stop-iteration-iterator "^1.1.0"
+    string.prototype.trim "^1.2.10"
+    string.prototype.trimend "^1.0.9"
+    string.prototype.trimstart "^1.0.8"
+    typed-array-buffer "^1.0.3"
+    typed-array-byte-length "^1.0.3"
+    typed-array-byte-offset "^1.0.4"
+    typed-array-length "^1.0.7"
+    unbox-primitive "^1.1.0"
+    which-typed-array "^1.1.19"
 
 es-abstract@^1.23.5, es-abstract@^1.23.9, es-abstract@^1.24.0:
   version "1.24.0"
@@ -2625,6 +2735,28 @@ es-errors@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
   integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
+
+es-iterator-helpers@^1.2.1:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/es-iterator-helpers/-/es-iterator-helpers-1.3.3.tgz#0a229dc38ada0450b8cfaa85809fd73dbb34113c"
+  integrity sha512-0PuBxFi+4uPanB97iDxCLWuHeYud2FALrw5HFZGtAF38UpJDbDC8frwp2cnDyae692CQ0dou60UwWfhgsa4U/g==
+  dependencies:
+    call-bind "^1.0.9"
+    call-bound "^1.0.4"
+    define-properties "^1.2.1"
+    es-abstract "^1.24.2"
+    es-errors "^1.3.0"
+    es-set-tostringtag "^2.1.0"
+    function-bind "^1.1.2"
+    get-intrinsic "^1.3.0"
+    globalthis "^1.0.4"
+    gopd "^1.2.0"
+    has-property-descriptors "^1.0.2"
+    has-proto "^1.2.0"
+    has-symbols "^1.1.0"
+    internal-slot "^1.1.0"
+    iterator.prototype "^1.1.5"
+    math-intrinsics "^1.1.0"
 
 es-module-lexer@^1.7.0:
   version "1.7.0"
@@ -2741,6 +2873,30 @@ eslint-plugin-react-refresh@^0.4.19:
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.24.tgz#6914e8757eb7d7ccc3efb9dbcc8a51feda71d89e"
   integrity sha512-nLHIW7TEq3aLrEYWpVaJ1dRgFR+wLDPN8e8FpYAql/bMV2oBEfC37K0gLEGgv9fy66juNShSMV8OkTqzltcG/w==
 
+eslint-plugin-react@^7.37.5:
+  version "7.37.5"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz#2975511472bdda1b272b34d779335c9b0e877065"
+  integrity sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==
+  dependencies:
+    array-includes "^3.1.8"
+    array.prototype.findlast "^1.2.5"
+    array.prototype.flatmap "^1.3.3"
+    array.prototype.tosorted "^1.1.4"
+    doctrine "^2.1.0"
+    es-iterator-helpers "^1.2.1"
+    estraverse "^5.3.0"
+    hasown "^2.0.2"
+    jsx-ast-utils "^2.4.1 || ^3.0.0"
+    minimatch "^3.1.2"
+    object.entries "^1.1.9"
+    object.fromentries "^2.0.8"
+    object.values "^1.2.1"
+    prop-types "^15.8.1"
+    resolve "^2.0.0-next.5"
+    semver "^6.3.1"
+    string.prototype.matchall "^4.0.12"
+    string.prototype.repeat "^1.0.0"
+
 eslint-plugin-simple-import-sort@^12.1.1:
   version "12.1.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.1.1.tgz#e64bfdaf91c5b98a298619aa634a9f7aa43b709e"
@@ -2840,7 +2996,7 @@ esrecurse@^4.3.0:
   dependencies:
     estraverse "^5.2.0"
 
-estraverse@^5.1.0, estraverse@^5.2.0:
+estraverse@^5.1.0, estraverse@^5.2.0, estraverse@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
@@ -3065,7 +3221,7 @@ get-intrinsic@^1.2.4, get-intrinsic@^1.2.5, get-intrinsic@^1.2.6, get-intrinsic@
     hasown "^2.0.2"
     math-intrinsics "^1.1.0"
 
-get-proto@^1.0.1:
+get-proto@^1.0.0, get-proto@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/get-proto/-/get-proto-1.0.1.tgz#150b3f2743869ef3e851ec0c49d15b1d14d00ee1"
   integrity sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==
@@ -3220,6 +3376,13 @@ hasown@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
+  dependencies:
+    function-bind "^1.1.2"
+
+hasown@^2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.4.tgz#8c62d8cb90beb2aad5d0a5b67581ad9854c3f003"
+  integrity sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==
   dependencies:
     function-bind "^1.1.2"
 
@@ -3415,6 +3578,13 @@ is-core-module@^2.16.1:
   integrity sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==
   dependencies:
     hasown "^2.0.2"
+
+is-core-module@^2.16.2:
+  version "2.16.2"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.16.2.tgz#3e07450a8080ebce3fbf0cac494f4d2ab324e082"
+  integrity sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==
+  dependencies:
+    hasown "^2.0.3"
 
 is-data-view@^1.0.1, is-data-view@^1.0.2:
   version "1.0.2"
@@ -3613,6 +3783,18 @@ istanbul-reports@^3.1.7:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
+iterator.prototype@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/iterator.prototype/-/iterator.prototype-1.1.5.tgz#12c959a29de32de0aa3bbbb801f4d777066dae39"
+  integrity sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==
+  dependencies:
+    define-data-property "^1.1.4"
+    es-object-atoms "^1.0.0"
+    get-intrinsic "^1.2.6"
+    get-proto "^1.0.0"
+    has-symbols "^1.1.0"
+    set-function-name "^2.0.2"
+
 jackspeak@^3.1.2:
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-3.4.3.tgz#8833a9d89ab4acde6188942bd1c53b6390ed5a8a"
@@ -3747,7 +3929,7 @@ json5@^2.2.3:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
-jsx-ast-utils@^3.2.1:
+"jsx-ast-utils@^2.4.1 || ^3.0.0", jsx-ast-utils@^3.2.1:
   version "3.3.5"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz#4766bd05a8e2a11af222becd19e15575e52a853a"
   integrity sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==
@@ -4001,6 +4183,16 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
+node-exports-info@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/node-exports-info/-/node-exports-info-1.6.0.tgz#1aedafb01a966059c9a5e791a94a94d93f5c2a13"
+  integrity sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==
+  dependencies:
+    array.prototype.flatmap "^1.3.3"
+    es-errors "^1.3.0"
+    object.entries "^1.1.9"
+    semver "^6.3.1"
+
 node-releases@^2.0.27:
   version "2.0.27"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.27.tgz#eedca519205cf20f650f61d56b070db111231e4e"
@@ -4043,7 +4235,27 @@ object.assign@^4.1.4, object.assign@^4.1.7:
     has-symbols "^1.1.0"
     object-keys "^1.1.1"
 
-object.values@^1.1.6:
+object.entries@^1.1.9:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.9.tgz#e4770a6a1444afb61bd39f984018b5bede25f8b3"
+  integrity sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==
+  dependencies:
+    call-bind "^1.0.8"
+    call-bound "^1.0.4"
+    define-properties "^1.2.1"
+    es-object-atoms "^1.1.1"
+
+object.fromentries@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/object.fromentries/-/object.fromentries-2.0.8.tgz#f7195d8a9b97bd95cbc1999ea939ecd1a2b00c65"
+  integrity sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==
+  dependencies:
+    call-bind "^1.0.7"
+    define-properties "^1.2.1"
+    es-abstract "^1.23.2"
+    es-object-atoms "^1.0.0"
+
+object.values@^1.1.6, object.values@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.2.1.tgz#deed520a50809ff7f75a7cfd4bc64c7a038c6216"
   integrity sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==
@@ -4560,7 +4772,7 @@ reflect.getprototypeof@^1.0.6, reflect.getprototypeof@^1.0.9:
     get-proto "^1.0.1"
     which-builtin-type "^1.2.1"
 
-regexp.prototype.flags@^1.5.4:
+regexp.prototype.flags@^1.5.3, regexp.prototype.flags@^1.5.4:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz#1ad6c62d44a259007e55b3970e00f746efbcaa19"
   integrity sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==
@@ -4605,6 +4817,18 @@ resolve@^1.19.0:
   integrity sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==
   dependencies:
     is-core-module "^2.16.1"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
+resolve@^2.0.0-next.5:
+  version "2.0.0-next.7"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-2.0.0-next.7.tgz#ba3b035d4b1ee7c522426eee73cabcb0fd5515dd"
+  integrity sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==
+  dependencies:
+    es-errors "^1.3.0"
+    is-core-module "^2.16.2"
+    node-exports-info "^1.6.0"
+    object-keys "^1.1.1"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
@@ -4891,6 +5115,33 @@ string-width@^5.0.1, string-width@^5.1.2:
     eastasianwidth "^0.2.0"
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
+
+string.prototype.matchall@^4.0.12:
+  version "4.0.12"
+  resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz#6c88740e49ad4956b1332a911e949583a275d4c0"
+  integrity sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==
+  dependencies:
+    call-bind "^1.0.8"
+    call-bound "^1.0.3"
+    define-properties "^1.2.1"
+    es-abstract "^1.23.6"
+    es-errors "^1.3.0"
+    es-object-atoms "^1.0.0"
+    get-intrinsic "^1.2.6"
+    gopd "^1.2.0"
+    has-symbols "^1.1.0"
+    internal-slot "^1.1.0"
+    regexp.prototype.flags "^1.5.3"
+    set-function-name "^2.0.2"
+    side-channel "^1.1.0"
+
+string.prototype.repeat@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz#e90872ee0308b29435aa26275f6e1b762daee01a"
+  integrity sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.5"
 
 string.prototype.trim@^1.2.10:
   version "1.2.10"


### PR DESCRIPTION
- [x] Refactor

**What changed?**

Adds `eslint-plugin-react` and enables three rules that enforce how components are structured: one component per file, no components defined inline in JSX, and no inline object literals passed to Context Providers.

Relocated FormControl Label private component to dedicated file.

**Why?**

These patterns were already followed by convention but had no enforcement. The goal is to reduce surface area required to be annotated in agent skills/agent md files.

FormControl Label relocated rather than eslint ignored because logic is substantial and there is already a dedicated label/ directory within the form-control component.

**How did you test it?**

Lint passes

**Potential risks**

Low. The two `useMemo` additions are correctness fixes with no functional side effects.