### PR TITLE
fix: make CRD incompatibility errors actionable

### DIFF
--- a/go/api/crd/gateway.go
+++ b/go/api/crd/gateway.go
@@ -3,7 +3,9 @@ package crd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/michelangelo-ai/michelangelo/go/api/utils"
 
@@ -127,7 +129,9 @@ func (r *gateway) ConditionalUpsert(
 			return e
 		}
 		if has {
-			return fmt.Errorf("failed to update CRD. Schema is incompatible, and there are existing instances. Abort updating CRD %s", crd.Name)
+			r.logSchemaDiff(crdOnServer, crd, compareResult.IncompatibilityDetails)
+			return fmt.Errorf("failed to update CRD %s: schema incompatible with existing instances%s",
+				crd.Name, formatIncompatibilityDetails(compareResult.IncompatibilityDetails))
 		}
 	}
 
@@ -169,6 +173,58 @@ func (r *gateway) List(ctx context.Context) (*apiextv1.CustomResourceDefinitionL
 	}
 
 	return listResponse, nil
+}
+
+func formatIncompatibilityDetails(details []VersionIncompatibility) string {
+	if len(details) == 0 {
+		return ""
+	}
+	var parts []string
+	for _, d := range details {
+		if len(d.Reasons) > 0 {
+			parts = append(parts, fmt.Sprintf("version %s: [%s]", d.Version, strings.Join(d.Reasons, "; ")))
+		} else {
+			parts = append(parts, fmt.Sprintf("version %s: incompatible (no details)", d.Version))
+		}
+	}
+	return "; " + strings.Join(parts, ", ")
+}
+
+// logSchemaDiff emits a debug log with the full old and new OpenAPI schemas for each
+// incompatible version, enabling side-by-side comparison without a redeploy.
+// Enable via the /debug/logging endpoint (uMonitor debug admin tab).
+func (r *gateway) logSchemaDiff(oldCRD, newCRD *apiextv1.CustomResourceDefinition, details []VersionIncompatibility) {
+	if !r.logger.Core().Enabled(zap.DebugLevel) {
+		return
+	}
+	oldVersions := make(map[string]*apiextv1.CustomResourceDefinitionVersion, len(oldCRD.Spec.Versions))
+	for i := range oldCRD.Spec.Versions {
+		oldVersions[oldCRD.Spec.Versions[i].Name] = &oldCRD.Spec.Versions[i]
+	}
+	newVersions := make(map[string]*apiextv1.CustomResourceDefinitionVersion, len(newCRD.Spec.Versions))
+	for i := range newCRD.Spec.Versions {
+		newVersions[newCRD.Spec.Versions[i].Name] = &newCRD.Spec.Versions[i]
+	}
+	for _, d := range details {
+		oldSchema, newSchema := "{}", "{}"
+		if v, ok := oldVersions[d.Version]; ok && v.Schema != nil {
+			if b, err := json.Marshal(v.Schema.OpenAPIV3Schema); err == nil {
+				oldSchema = string(b)
+			}
+		}
+		if v, ok := newVersions[d.Version]; ok && v.Schema != nil {
+			if b, err := json.Marshal(v.Schema.OpenAPIV3Schema); err == nil {
+				newSchema = string(b)
+			}
+		}
+		r.logger.Debug("incompatible CRD schema diff",
+			zap.String("name", oldCRD.Name),
+			zap.String("version", d.Version),
+			zap.Strings("reasons", d.Reasons),
+			zap.String("old_schema", oldSchema),
+			zap.String("new_schema", newSchema),
+		)
+	}
 }
 
 func (r *gateway) hasInstances(ctx context.Context, crd *apiextv1.CustomResourceDefinition) (bool, error) {

--- a/go/api/crd/gateway_test.go
+++ b/go/api/crd/gateway_test.go
@@ -204,7 +204,7 @@ func TestConditionalUpsert(t *testing.T) {
 		newCRD.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties["spec"].Properties["meta"].Properties["testProperty"] = testProperty
 		err = crdGateway.ConditionalUpsert(ctx, newCRD, false)
 		assert.Error(t, err)
-		assert.True(t, strings.Contains(err.Error(), "Abort updating CRD"))
+		assert.True(t, strings.Contains(err.Error(), "schema incompatible with existing instances"))
 	})
 
 	t.Run("test failed to create CRD", func(t *testing.T) {

--- a/go/api/crd/schema_diff.go
+++ b/go/api/crd/schema_diff.go
@@ -139,6 +139,32 @@ func (d *schemaDiff) compatible() bool {
 	return true
 }
 
+func (d *schemaDiff) incompatibleReasons(path string) []string {
+	if d == nil {
+		return nil
+	}
+	var reasons []string
+	if d.typeDiff != nil && !d.typeDiff.compatible() {
+		reasons = append(reasons, fmt.Sprintf("type changed at %q: %v → %v", path, d.typeDiff.from, d.typeDiff.to))
+	}
+	if d.propertiesDiff != nil {
+		reasons = append(reasons, d.propertiesDiff.incompatibleReasons(path)...)
+	}
+	if d.itemsDiff != nil && !d.itemsDiff.compatible() {
+		reasons = append(reasons, d.itemsDiff.incompatibleReasons(path+"[*]")...)
+	}
+	if d.anyOfDiff != nil && !d.anyOfDiff.compatible() {
+		reasons = append(reasons, d.anyOfDiff.incompatibleReasons(path+".anyOf")...)
+	}
+	if d.allOfDiff != nil && !d.allOfDiff.compatible() {
+		reasons = append(reasons, d.allOfDiff.incompatibleReasons(path+".allOf")...)
+	}
+	if d.oneOfDiff != nil && !d.oneOfDiff.compatible() {
+		reasons = append(reasons, d.oneOfDiff.incompatibleReasons(path+".oneOf")...)
+	}
+	return reasons
+}
+
 // schemaArrayDiff compares two arrays of JSON property schemas
 type schemaArrayDiff struct {
 	deleted  []*apiextv1.JSONSchemaProps
@@ -194,6 +220,20 @@ func (d *schemaArrayDiff) compatible() bool {
 	}
 
 	return true
+}
+
+func (d *schemaArrayDiff) incompatibleReasons(prefix string) []string {
+	if d == nil {
+		return nil
+	}
+	var reasons []string
+	for i := range d.deleted {
+		reasons = append(reasons, fmt.Sprintf("deleted element at %s[%d]", prefix, i))
+	}
+	for _, mod := range d.modified {
+		reasons = append(reasons, mod.incompatibleReasons(prefix)...)
+	}
+	return reasons
 }
 
 // schemaObjectDiff compares the property maps of two JSON object schemas
@@ -261,11 +301,32 @@ func (d *schemaObjectDiff) compatible() bool {
 	return true
 }
 
+func (d *schemaObjectDiff) incompatibleReasons(prefix string) []string {
+	if d == nil {
+		return nil
+	}
+	var reasons []string
+	for name := range d.deleted {
+		reasons = append(reasons, fmt.Sprintf("deleted field %s.%s", prefix, name))
+	}
+	for name, mod := range d.modified {
+		reasons = append(reasons, mod.incompatibleReasons(fmt.Sprintf("%s.%s", prefix, name))...)
+	}
+	return reasons
+}
+
+// VersionIncompatibility describes which fields made a specific CRD version's schema incompatible.
+type VersionIncompatibility struct {
+	Version string
+	Reasons []string
+}
+
 // CompareResult is the result of CompareCRDSchemas function,
 // indicating whether there is a change and whether the change is compatible
 type CompareResult struct {
-	HasChange  bool
-	Compatible bool
+	HasChange              bool
+	Compatible             bool
+	IncompatibilityDetails []VersionIncompatibility // populated when Compatible=false
 }
 
 // CompareCRDSchemas compares two CRD schemas
@@ -282,14 +343,15 @@ func CompareCRDSchemas(oldCRD *apiextv1.CustomResourceDefinition, newCRD *apiext
 		}, nil
 	}
 
-	changeCompatible, err := isSpecChangeCompatible(oldCRD, newCRD)
+	details, err := incompatibleVersions(oldCRD, newCRD)
 	if err != nil {
 		return nil, err
 	}
 
 	return &CompareResult{
-		HasChange:  true,
-		Compatible: changeCompatible,
+		HasChange:              true,
+		Compatible:             len(details) == 0,
+		IncompatibilityDetails: details,
 	}, nil
 }
 
@@ -300,6 +362,14 @@ func hasChange(oldCRD *apiextv1.CustomResourceDefinition, newCRD *apiextv1.Custo
 }
 
 func isSpecChangeCompatible(oldCRD *apiextv1.CustomResourceDefinition, newCRD *apiextv1.CustomResourceDefinition) (bool, error) {
+	details, err := incompatibleVersions(oldCRD, newCRD)
+	if err != nil {
+		return false, err
+	}
+	return len(details) == 0, nil
+}
+
+func incompatibleVersions(oldCRD *apiextv1.CustomResourceDefinition, newCRD *apiextv1.CustomResourceDefinition) ([]VersionIncompatibility, error) {
 	oldVersions := map[string]*apiextv1.CustomResourceDefinitionVersion{}
 	for _, v := range oldCRD.Spec.Versions {
 		oldVersions[v.Name] = &v
@@ -310,25 +380,28 @@ func isSpecChangeCompatible(oldCRD *apiextv1.CustomResourceDefinition, newCRD *a
 	}
 
 	if len(newVersions) == 0 {
-		// new CRD has no versions defined
-		return false, nil
+		return []VersionIncompatibility{{Version: "*", Reasons: []string{"new CRD has no versions defined"}}}, nil
 	}
 
+	var result []VersionIncompatibility
 	for k, oldVersion := range oldVersions {
 		newVersion, present := newVersions[k]
 		if !present {
-			return false, fmt.Errorf("CRD %s has version %s that is not in the new CRD", oldCRD.Name, k)
+			return nil, fmt.Errorf("CRD %s has version %s that is not in the new CRD", oldCRD.Name, k)
 		}
 
 		// compare the two schemas with the same version name
 		diff := newSchemaDiff(oldVersion.Schema.OpenAPIV3Schema, newVersion.Schema.OpenAPIV3Schema)
 
 		if diff != nil && !diff.compatible() {
-			return false, nil
+			result = append(result, VersionIncompatibility{
+				Version: k,
+				Reasons: diff.incompatibleReasons(""),
+			})
 		}
 	}
 
 	// Allow adding new CRD versions, so no need to check newVersions again
 
-	return true, nil
+	return result, nil
 }


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Bug Fix

**What changed?**
`ConditionalUpsert` now includes the incompatible CRD version name and the specific deleted/changed field paths in its error return. `CompareResult` gains an `IncompatibilityDetails` field (additive, no callers break). A debug-level log emits full before/after OpenAPI schemas for each incompatible version, gated on log level so it is a no-op in normal operation.

**Why?**
CRD schema incompatibility errors were completely opaque — the message only named the CRD, not which version or which field triggered the check. The diff structs had already computed that information but discarded it before the error propagated, leaving no path to diagnosis without injecting code into the running service.

**How did you test it?**
Ran `go test ./go/api/crd/...`; all existing tests pass. The new error format is exercised by the existing incompatibility test case and verified in test output.

**Potential risks**
The error message string changes. Any code outside this repo asserting on the exact text would need updating, but the change is strictly more informative and backward-compatible at the API level.

**Release notes**
N/A

**Documentation Changes**
N/A