### PR TITLE
cli: add pre-apply hook registry for downstream policy enforcement

### DIFF
--- a/python/michelangelo/cli/mactl/apply_hooks.py
+++ b/python/michelangelo/cli/mactl/apply_hooks.py
@@ -1,0 +1,37 @@
+"""Pre-apply check registry — pluggable hook fired before every CRD apply.
+
+Consumers register callbacks via ``register_pre_apply_check``. ``apply_func_impl``
+invokes ``run_pre_apply_checks(crd_full_name)`` at the top of every apply, so a
+registered callback can short-circuit the apply by raising.
+
+This module exists so that downstream distributions (e.g. internal CLIs) can
+enforce policy on every CRD without monkey-patching ``apply_func_impl`` or
+wiring per-plugin call sites.
+"""
+
+from typing import Callable
+
+PreApplyCheck = Callable[[str], None]
+
+_pre_apply_checks: list[PreApplyCheck] = []
+
+
+def register_pre_apply_check(fn: PreApplyCheck) -> None:
+    """Register a callback to run before every CRD apply.
+
+    The callback receives the CRD's gRPC full name (e.g.
+    ``michelangelo.api.v1.Pipeline``) and should raise to abort the apply.
+    Callbacks run in registration order; an exception from any callback
+    propagates without running the remaining callbacks.
+    """
+    _pre_apply_checks.append(fn)
+
+
+def run_pre_apply_checks(crd_full_name: str) -> None:
+    """Run all registered pre-apply checks.
+
+    Called from ``apply_func_impl``. If no callbacks are registered this is a
+    no-op, which is the default behavior for OSS users.
+    """
+    for fn in _pre_apply_checks:
+        fn(crd_full_name)

--- a/python/michelangelo/cli/mactl/apply_hooks_test.py
+++ b/python/michelangelo/cli/mactl/apply_hooks_test.py
@@ -1,0 +1,60 @@
+"""Tests for the pre-apply hook registry."""
+
+import pytest
+
+from michelangelo.cli.mactl import apply_hooks
+
+
+@pytest.fixture(autouse=True)
+def reset_registry():
+    """Clear registered checks between tests."""
+    apply_hooks._pre_apply_checks.clear()
+    yield
+    apply_hooks._pre_apply_checks.clear()
+
+
+def test_no_checks_registered_is_noop():
+    """An empty registry must not raise."""
+    apply_hooks.run_pre_apply_checks("michelangelo.api.v1.Pipeline")
+
+
+def test_single_check_receives_crd_full_name():
+    """A registered check is invoked with the CRD full name."""
+    received: list[str] = []
+    apply_hooks.register_pre_apply_check(received.append)
+
+    apply_hooks.run_pre_apply_checks("michelangelo.api.v1.Pipeline")
+
+    assert received == ["michelangelo.api.v1.Pipeline"]
+
+
+def test_multiple_checks_run_in_registration_order():
+    """Checks fire in the order they were registered."""
+    order: list[str] = []
+    apply_hooks.register_pre_apply_check(lambda _: order.append("first"))
+    apply_hooks.register_pre_apply_check(lambda _: order.append("second"))
+    apply_hooks.register_pre_apply_check(lambda _: order.append("third"))
+
+    apply_hooks.run_pre_apply_checks("michelangelo.api.v1.Pipeline")
+
+    assert order == ["first", "second", "third"]
+
+
+def test_raising_check_aborts_remaining_checks():
+    """A raising check propagates and skips later checks."""
+    later_ran = False
+
+    def raises(_: str) -> None:
+        raise RuntimeError("nope")
+
+    def later(_: str) -> None:
+        nonlocal later_ran
+        later_ran = True
+
+    apply_hooks.register_pre_apply_check(raises)
+    apply_hooks.register_pre_apply_check(later)
+
+    with pytest.raises(RuntimeError, match="nope"):
+        apply_hooks.run_pre_apply_checks("michelangelo.api.v1.Pipeline")
+
+    assert later_ran is False

--- a/python/michelangelo/cli/mactl/crd.py
+++ b/python/michelangelo/cli/mactl/crd.py
@@ -22,6 +22,7 @@ from grpc import (
 from yaml import YAMLError
 from yaml import safe_load as yaml_safe_load
 
+from michelangelo.cli.mactl.apply_hooks import run_pre_apply_checks
 from michelangelo.cli.mactl.grpc_tools import (
     get_message_class_by_name,
     get_methods_from_service,
@@ -425,6 +426,7 @@ def delete_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> M
 
 def apply_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Message:
     """Default common CRD member method implementation for APPLY method."""
+    run_pre_apply_checks(crd_method_info.crd_full_name)
     _LOG.info("Bound arguments: %r", bound_args.arguments)
     _self: CRD = bound_args.arguments["self"]
     _LOG.info("Start apply_func for %r", _self.full_name)

--- a/python/michelangelo/cli/mactl/crd_test.py
+++ b/python/michelangelo/cli/mactl/crd_test.py
@@ -434,6 +434,66 @@ class ApplyFuncImplTest(TestCase):
         mock_crd._get.assert_called_once_with("ns", "name")
         mock_crd.read_yaml_and_update_crd_request.assert_called_once()
 
+    @patch("michelangelo.cli.mactl.crd.crd_method_call")
+    @patch("michelangelo.cli.mactl.crd.get_crd_namespace_and_name_from_yaml")
+    def test_apply_func_impl_invokes_pre_apply_hook(
+        self, mock_get_ns: MagicMock, _
+    ):
+        """apply_func_impl runs registered pre-apply checks with the CRD full name."""
+        from michelangelo.cli.mactl import apply_hooks
+
+        received: list[str] = []
+        apply_hooks._pre_apply_checks.clear()
+        apply_hooks.register_pre_apply_check(received.append)
+        self.addCleanup(apply_hooks._pre_apply_checks.clear)
+
+        crd_method_info = CrdMethodInfo(
+            channel=Mock(),
+            crd_full_name="test.Service",
+            method_name="Apply",
+            input_class=Mock,
+            output_class=Mock,
+        )
+        mock_crd = Mock()
+        mock_crd.full_name = "test.Service"
+        mock_crd._get.return_value = Mock()
+        mock_crd.read_yaml_and_update_crd_request.return_value = Mock()
+        mock_get_ns.return_value = ("ns", "name")
+
+        apply_func_impl(
+            crd_method_info, Mock(arguments={"self": mock_crd, "file": "f.yaml"})
+        )
+
+        self.assertEqual(received, ["test.Service"])
+
+    def test_apply_func_impl_pre_apply_hook_can_abort(self):
+        """A raising pre-apply check halts apply_func_impl before any gRPC call."""
+        from michelangelo.cli.mactl import apply_hooks
+
+        def reject(_: str) -> None:
+            raise RuntimeError("blocked by hook")
+
+        apply_hooks._pre_apply_checks.clear()
+        apply_hooks.register_pre_apply_check(reject)
+        self.addCleanup(apply_hooks._pre_apply_checks.clear)
+
+        crd_method_info = CrdMethodInfo(
+            channel=Mock(),
+            crd_full_name="test.Service",
+            method_name="Apply",
+            input_class=Mock,
+            output_class=Mock,
+        )
+        mock_crd = Mock()
+
+        with self.assertRaisesRegex(RuntimeError, "blocked by hook"):
+            apply_func_impl(
+                crd_method_info,
+                Mock(arguments={"self": mock_crd, "file": "f.yaml"}),
+            )
+
+        mock_crd._get.assert_not_called()
+
 
 class CreateFuncImplTest(TestCase):
     """Test cases for create_func_impl function."""

--- a/python/michelangelo/cli/mactl/crd_test.py
+++ b/python/michelangelo/cli/mactl/crd_test.py
@@ -436,9 +436,7 @@ class ApplyFuncImplTest(TestCase):
 
     @patch("michelangelo.cli.mactl.crd.crd_method_call")
     @patch("michelangelo.cli.mactl.crd.get_crd_namespace_and_name_from_yaml")
-    def test_apply_func_impl_invokes_pre_apply_hook(
-        self, mock_get_ns: MagicMock, _
-    ):
+    def test_apply_func_impl_invokes_pre_apply_hook(self, mock_get_ns: MagicMock, _):
         """apply_func_impl runs registered pre-apply checks with the CRD full name."""
         from michelangelo.cli.mactl import apply_hooks
 


### PR DESCRIPTION
## Summary

Adds a pluggable pre-apply hook in \`michelangelo.cli.mactl\` so downstream distributions (e.g. internal CLIs that wrap \`ma\`) can enforce policy on every CRD apply without monkey-patching \`apply_func_impl\` or wiring per-plugin call sites.

- New module \`apply_hooks.py\` exposes \`register_pre_apply_check(fn)\` and \`run_pre_apply_checks(crd_full_name)\`.
- \`crd.py:apply_func_impl\` calls \`run_pre_apply_checks(crd_method_info.crd_full_name)\` as its first statement (1 line + 1 import).
- Default registry is empty, so OSS behavior is unchanged.

## Motivation

Today the only way for a wrapper distribution to enforce per-CRD policy (e.g. \"refuse apply on a dirty workspace\" or \"require on-main for these specific CRDs\") is to:
- Monkey-patch \`apply_func_impl\` (brittle — breaks on any signature change), or
- Wire per-plugin call sites into each custom \`*_apply_func_impl\` (incomplete — leaves the default \`apply_func_impl\` path uncovered for every gRPC-reflected CRD that doesn't have a custom plugin).

A single registration point inside \`apply_func_impl\` covers both the generic and plugin-overridden paths because plugin overrides typically wrap the generic apply rather than fully replace it.

## API

\`\`\`python
from michelangelo.cli.mactl.apply_hooks import register_pre_apply_check

def my_policy(crd_full_name: str) -> None:
    if not_allowed(crd_full_name):
        raise RuntimeError(\"reason\")

register_pre_apply_check(my_policy)
\`\`\`

- Callbacks receive the CRD's gRPC full name (e.g. \`michelangelo.api.v1.Pipeline\`).
- Callbacks run in registration order; a raised exception propagates and skips remaining callbacks.
- Empty registry is a no-op — no behavior change for OSS users.

## Test plan

| command | what it covers |
|---|---|
| \`pytest michelangelo/cli/mactl/apply_hooks_test.py\` | empty-registry no-op, single-callback receives CRD name, multi-callback order, raising callback aborts later callbacks |
| \`pytest michelangelo/cli/mactl/crd_test.py::ApplyFuncImplTest\` | integration: \`apply_func_impl\` invokes hook with correct full name; raising hook prevents gRPC \`_get\` from being called |

All 7 new + existing tests pass locally. One unrelated failure (\`mactl_test.py::TLSConfigurationTest::test_use_tls_default_value\`) is pre-existing on \`main\`.