### PR TITLE
fix: atomic update to prevent Temporal schedule race condition

### DIFF
--- a/go/base/workflowclient/cadenceclient/cadenceclient.go
+++ b/go/base/workflowclient/cadenceclient/cadenceclient.go
@@ -302,6 +302,6 @@ func (c *CadenceClient) DeleteTrigger(ctx context.Context, workflowID string, ru
 // UpdateTrigger is a no-op for Cadence (schedule updates are a Temporal feature).
 // In Cadence, cron schedules are embedded in the workflow and cannot be updated in place.
 // Returns nil to indicate success - the operation is silently skipped.
-func (c *CadenceClient) UpdateTrigger(_ context.Context, _ string, _ string) error {
+func (c *CadenceClient) UpdateTrigger(_ context.Context, _ string, _ string, _ *bool) error {
 	return nil
 }

--- a/go/base/workflowclient/cadenceclient/cadenceclient_test.go
+++ b/go/base/workflowclient/cadenceclient/cadenceclient_test.go
@@ -732,7 +732,7 @@ func TestUpdateTrigger(t *testing.T) {
 	client := &CadenceClient{
 		Client: &cadencemocks.Client{},
 	}
-	err := client.UpdateTrigger(context.Background(), workflowID, newCronSchedule)
+	err := client.UpdateTrigger(context.Background(), workflowID, newCronSchedule, nil)
 	assert.NoError(t, err)
 }
 

--- a/go/base/workflowclient/interface/interface_mock/workflowclient.go
+++ b/go/base/workflowclient/interface/interface_mock/workflowclient.go
@@ -270,17 +270,17 @@ func (mr *MockWorkflowClientMockRecorder) DeleteTrigger(ctx, workflowID, runID i
 }
 
 // UpdateTrigger mocks base method.
-func (m *MockWorkflowClient) UpdateTrigger(ctx context.Context, workflowID string, newCronSchedule string) error {
+func (m *MockWorkflowClient) UpdateTrigger(ctx context.Context, workflowID string, newCronSchedule string, paused *bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateTrigger", ctx, workflowID, newCronSchedule)
+	ret := m.ctrl.Call(m, "UpdateTrigger", ctx, workflowID, newCronSchedule, paused)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateTrigger indicates an expected call of UpdateTrigger.
-func (mr *MockWorkflowClientMockRecorder) UpdateTrigger(ctx, workflowID, newCronSchedule interface{}) *gomock.Call {
+func (mr *MockWorkflowClientMockRecorder) UpdateTrigger(ctx, workflowID, newCronSchedule, paused interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTrigger", reflect.TypeOf((*MockWorkflowClient)(nil).UpdateTrigger), ctx, workflowID, newCronSchedule)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTrigger", reflect.TypeOf((*MockWorkflowClient)(nil).UpdateTrigger), ctx, workflowID, newCronSchedule, paused)
 }
 
 // GetTriggerSchedule mocks base method.

--- a/go/base/workflowclient/interface/workflowclient.go
+++ b/go/base/workflowclient/interface/workflowclient.go
@@ -114,8 +114,10 @@ type WorkflowClient interface {
 	// DeleteTrigger deletes a recurring trigger and terminates any running execution.
 	// workflowID identifies the trigger; runID is the currently running execution (empty if none).
 	DeleteTrigger(ctx context.Context, workflowID string, runID string) error
-	// UpdateTrigger updates the cron schedule of a recurring trigger.
-	// workflowID identifies the trigger; newCronSchedule is the new cron expression.
+	// UpdateTrigger updates the cron schedule and optionally the paused state of a recurring trigger
+	// in a single atomic operation. workflowID identifies the trigger; newCronSchedule is the new
+	// cron expression; paused, when non-nil, sets the schedule's paused state atomically with the
+	// cron update to avoid race conditions between separate Update and Pause/Unpause calls.
 	// Only supported for Temporal. Returns an error for Cadence.
-	UpdateTrigger(ctx context.Context, workflowID string, newCronSchedule string) error
+	UpdateTrigger(ctx context.Context, workflowID string, newCronSchedule string, paused *bool) error
 }

--- a/go/base/workflowclient/temporalclient/temporalclient.go
+++ b/go/base/workflowclient/temporalclient/temporalclient.go
@@ -405,9 +405,9 @@ func (c *TemporalClient) DeleteTrigger(ctx context.Context, workflowID string, r
 	return c.Client.TerminateWorkflow(ctx, workflowID, runID, "trigger killed")
 }
 
-// UpdateTrigger updates the cron schedule for a recurring trigger.
-// Returns an error if the schedule doesn't exist.
-func (c *TemporalClient) UpdateTrigger(ctx context.Context, workflowID string, newCronSchedule string) error {
+// UpdateTrigger updates the cron schedule and optionally the paused state of a recurring trigger
+// in a single atomic Temporal schedule.Update() call.
+func (c *TemporalClient) UpdateTrigger(ctx context.Context, workflowID string, newCronSchedule string, paused *bool) error {
 	scheduleID := scheduleIDForWorkflow(workflowID)
 	handle := c.Client.ScheduleClient().GetHandle(ctx, scheduleID)
 
@@ -420,6 +420,16 @@ func (c *TemporalClient) UpdateTrigger(ctx context.Context, workflowID string, n
 			// don't merge with stale Calendars, which would cause both old and new
 			// schedules to fire.
 			input.Description.Schedule.Spec.Calendars = nil
+
+			if paused != nil {
+				input.Description.Schedule.State.Paused = *paused
+				if *paused {
+					input.Description.Schedule.State.Note = "paused by michelangelo"
+				} else {
+					input.Description.Schedule.State.Note = "unpaused by michelangelo"
+				}
+			}
+
 			return &temporalClient.ScheduleUpdate{
 				Schedule: &input.Description.Schedule,
 			}, nil

--- a/go/base/workflowclient/temporalclient/temporalclient_test.go
+++ b/go/base/workflowclient/temporalclient/temporalclient_test.go
@@ -725,14 +725,18 @@ func TestUpdateTrigger(t *testing.T) {
 	workflowID := "testWorkflowID"
 	scheduleID := workflowID + "-schedule"
 	newCronSchedule := "0 6 * * *"
+	pauseTrue := true
+	pauseFalse := false
 
 	testCases := []struct {
 		name      string
+		paused    *bool
 		setupMock func(mockClient *temporalMocks.Client, mockScheduleClient *temporalMocks.ScheduleClient, mockScheduleHandle *temporalMocks.ScheduleHandle)
 		errMsg    string
 	}{
 		{
-			name: "success",
+			name:   "success - cron only",
+			paused: nil,
 			setupMock: func(mockClient *temporalMocks.Client, mockScheduleClient *temporalMocks.ScheduleClient, mockScheduleHandle *temporalMocks.ScheduleHandle) {
 				mockClient.On("ScheduleClient").Return(mockScheduleClient)
 				mockScheduleClient.On("GetHandle", mock.Anything, scheduleID).Return(mockScheduleHandle)
@@ -740,16 +744,36 @@ func TestUpdateTrigger(t *testing.T) {
 			},
 		},
 		{
-			name: "error - describe fails",
+			name:   "success - cron with pause",
+			paused: &pauseTrue,
 			setupMock: func(mockClient *temporalMocks.Client, mockScheduleClient *temporalMocks.ScheduleClient, mockScheduleHandle *temporalMocks.ScheduleHandle) {
 				mockClient.On("ScheduleClient").Return(mockScheduleClient)
 				mockScheduleClient.On("GetHandle", mock.Anything, scheduleID).Return(mockScheduleHandle)
-				mockScheduleHandle.On("Update", mock.Anything, mock.Anything).Return(fmt.Errorf("describe error"))
+				mockScheduleHandle.On("Update", mock.Anything, mock.Anything).Return(nil)
 			},
-			errMsg: "describe error",
 		},
 		{
-			name: "error - update fails",
+			name:   "success - cron with resume",
+			paused: &pauseFalse,
+			setupMock: func(mockClient *temporalMocks.Client, mockScheduleClient *temporalMocks.ScheduleClient, mockScheduleHandle *temporalMocks.ScheduleHandle) {
+				mockClient.On("ScheduleClient").Return(mockScheduleClient)
+				mockScheduleClient.On("GetHandle", mock.Anything, scheduleID).Return(mockScheduleHandle)
+				mockScheduleHandle.On("Update", mock.Anything, mock.Anything).Return(nil)
+			},
+		},
+		{
+			name:   "error - update fails",
+			paused: nil,
+			setupMock: func(mockClient *temporalMocks.Client, mockScheduleClient *temporalMocks.ScheduleClient, mockScheduleHandle *temporalMocks.ScheduleHandle) {
+				mockClient.On("ScheduleClient").Return(mockScheduleClient)
+				mockScheduleClient.On("GetHandle", mock.Anything, scheduleID).Return(mockScheduleHandle)
+				mockScheduleHandle.On("Update", mock.Anything, mock.Anything).Return(fmt.Errorf("update error"))
+			},
+			errMsg: "update error",
+		},
+		{
+			name:   "error - update fails with pause",
+			paused: &pauseTrue,
 			setupMock: func(mockClient *temporalMocks.Client, mockScheduleClient *temporalMocks.ScheduleClient, mockScheduleHandle *temporalMocks.ScheduleHandle) {
 				mockClient.On("ScheduleClient").Return(mockScheduleClient)
 				mockScheduleClient.On("GetHandle", mock.Anything, scheduleID).Return(mockScheduleHandle)
@@ -766,7 +790,7 @@ func TestUpdateTrigger(t *testing.T) {
 			mockScheduleHandle := temporalMocks.NewScheduleHandle(t)
 			client := &TemporalClient{Client: mockClient}
 			testCase.setupMock(mockClient, mockScheduleClient, mockScheduleHandle)
-			err := client.UpdateTrigger(context.Background(), workflowID, newCronSchedule)
+			err := client.UpdateTrigger(context.Background(), workflowID, newCronSchedule, testCase.paused)
 			if testCase.errMsg != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), testCase.errMsg)

--- a/go/components/triggerrun/backfill_trigger.go
+++ b/go/components/triggerrun/backfill_trigger.go
@@ -228,6 +228,6 @@ func (b *backfillTrigger) Resume(ctx context.Context, triggerRun *v2pb.TriggerRu
 // have recurring schedules to update. This method always returns success.
 //
 // Returns current TriggerRunStatus (state unchanged).
-func (b *backfillTrigger) Update(ctx context.Context, triggerRun *v2pb.TriggerRun) (v2pb.TriggerRunStatus, error) {
-	return v2pb.TriggerRunStatus{State: triggerRun.Status.State}, nil
+func (b *backfillTrigger) Update(ctx context.Context, triggerRun *v2pb.TriggerRun, action v2pb.TriggerRunAction) (v2pb.TriggerRunStatus, bool, error) {
+	return v2pb.TriggerRunStatus{State: triggerRun.Status.State}, false, nil
 }

--- a/go/components/triggerrun/backfill_trigger_test.go
+++ b/go/components/triggerrun/backfill_trigger_test.go
@@ -484,7 +484,7 @@ func TestBackfillTrigger_Update(t *testing.T) {
 	// No workflow client calls expected - backfill update is a no-op
 
 	backfillTrigger := NewBackfillTrigger(logger, mockClient)
-	status, err := backfillTrigger.Update(context.Background(), triggerRun)
+	status, _, err := backfillTrigger.Update(context.Background(), triggerRun, v2pb.TRIGGER_RUN_ACTION_NO_ACTION)
 
 	assert.NoError(t, err)
 	assert.Equal(t, v2pb.TRIGGER_RUN_STATE_RUNNING, status.State)

--- a/go/components/triggerrun/controller.go
+++ b/go/components/triggerrun/controller.go
@@ -204,14 +204,6 @@ StateMachine:
 	case v2pb.TRIGGER_RUN_STATE_RUNNING:
 		log.Info("TRIGGER_RUN_STATE_RUNNING")
 
-		// Sync TriggerRun spec changes to workflow engine
-		if status, err := runner.Update(ctx, triggerRun); err != nil {
-			log.Error(err, "failed to sync trigger spec to workflow engine")
-			triggerRun.Status.ErrorMessage = err.Error()
-			triggerRun.Status.State = status.State
-			break StateMachine
-		}
-
 		// Handle actions using the new action field (preferred) or deprecated boolean fields (backward compatibility)
 		actionToPerform := triggerRun.Spec.Action
 
@@ -222,9 +214,27 @@ StateMachine:
 			}
 		}
 
+		// Sync TriggerRun spec changes to workflow engine, passing the action so cron
+		// update and pause/resume can be applied atomically in a single API call.
+		status, actionHandled, err := runner.Update(ctx, triggerRun, actionToPerform)
+		if err != nil {
+			log.Error(err, "failed to sync trigger spec to workflow engine")
+			triggerRun.Status.ErrorMessage = err.Error()
+			triggerRun.Status.State = status.State
+			break StateMachine
+		}
+		triggerRun.Status = status
+
+		// If Update already applied the action atomically, clear and skip
+		if actionHandled {
+			triggerRun.Spec.Action = v2pb.TRIGGER_RUN_ACTION_NO_ACTION
+			triggerRun.Spec.Kill = false
+			break StateMachine
+		}
+
 		switch actionToPerform {
 		case v2pb.TRIGGER_RUN_ACTION_KILL:
-			status, err := runner.Kill(ctx, triggerRun)
+			status, err = runner.Kill(ctx, triggerRun)
 			if err != nil {
 				log.Error(err, "failed to kill scheduled workflow")
 				triggerRun.Status.ErrorMessage = err.Error()
@@ -233,13 +243,12 @@ StateMachine:
 			}
 			log.Info("trigger run killed")
 			triggerRun.Status = status
-			// Clear action and deprecated fields after processing
 			triggerRun.Spec.Action = v2pb.TRIGGER_RUN_ACTION_NO_ACTION
 			triggerRun.Spec.Kill = false
 			break StateMachine
 
 		case v2pb.TRIGGER_RUN_ACTION_PAUSE:
-			status, err := runner.Pause(ctx, triggerRun)
+			status, err = runner.Pause(ctx, triggerRun)
 			if err != nil {
 				log.Error(err, "failed to pause scheduled workflow")
 				triggerRun.Status.ErrorMessage = err.Error()
@@ -248,30 +257,21 @@ StateMachine:
 			}
 			log.Info("trigger run paused")
 			triggerRun.Status = status
-			// Clear action after processing
 			triggerRun.Spec.Action = v2pb.TRIGGER_RUN_ACTION_NO_ACTION
 			break StateMachine
 		}
 
-		status, err := runner.GetStatus(ctx, triggerRun)
+		status2, err := runner.GetStatus(ctx, triggerRun)
 		if err != nil {
 			log.Error(err, "TriggerRun GetStatus failed")
 			triggerRun.Status.ErrorMessage = err.Error()
-			triggerRun.Status.State = status.State
+			triggerRun.Status.State = status2.State
 			break StateMachine
 		}
-		triggerRun.Status.State = status.State
+		triggerRun.Status.State = status2.State
 
 	case v2pb.TRIGGER_RUN_STATE_PAUSED:
 		log.Info("TRIGGER_RUN_STATE_PAUSED")
-
-		// Sync TriggerRun spec changes to workflow engine even when paused
-		if status, err := runner.Update(ctx, triggerRun); err != nil {
-			log.Error(err, "failed to sync trigger spec to workflow engine")
-			triggerRun.Status.ErrorMessage = err.Error()
-			triggerRun.Status.State = status.State
-			break StateMachine
-		}
 
 		// Handle actions using the new action field
 		actionToPerform := triggerRun.Spec.Action
@@ -281,9 +281,27 @@ StateMachine:
 			actionToPerform = v2pb.TRIGGER_RUN_ACTION_KILL
 		}
 
+		// Sync TriggerRun spec changes to workflow engine, passing the action so cron
+		// update and resume can be applied atomically in a single API call.
+		status, actionHandled, err := runner.Update(ctx, triggerRun, actionToPerform)
+		if err != nil {
+			log.Error(err, "failed to sync trigger spec to workflow engine")
+			triggerRun.Status.ErrorMessage = err.Error()
+			triggerRun.Status.State = status.State
+			break StateMachine
+		}
+		triggerRun.Status = status
+
+		// If Update already applied the action atomically, clear and skip
+		if actionHandled {
+			triggerRun.Spec.Action = v2pb.TRIGGER_RUN_ACTION_NO_ACTION
+			triggerRun.Spec.Kill = false
+			break StateMachine
+		}
+
 		switch actionToPerform {
 		case v2pb.TRIGGER_RUN_ACTION_KILL:
-			status, err := runner.Kill(ctx, triggerRun)
+			status, err = runner.Kill(ctx, triggerRun)
 			if err != nil {
 				log.Error(err, "failed to kill paused workflow")
 				triggerRun.Status.ErrorMessage = err.Error()
@@ -292,12 +310,11 @@ StateMachine:
 			}
 			log.Info("paused trigger run killed")
 			triggerRun.Status = status
-			// Clear action after processing
 			triggerRun.Spec.Action = v2pb.TRIGGER_RUN_ACTION_NO_ACTION
 			break StateMachine
 
 		case v2pb.TRIGGER_RUN_ACTION_RESUME:
-			status, err := runner.Resume(ctx, triggerRun)
+			status, err = runner.Resume(ctx, triggerRun)
 			if err != nil {
 				log.Error(err, "failed to resume scheduled workflow")
 				triggerRun.Status.ErrorMessage = err.Error()
@@ -306,7 +323,6 @@ StateMachine:
 			}
 			log.Info("trigger run resumed")
 			triggerRun.Status = status
-			// Clear action after processing
 			triggerRun.Spec.Action = v2pb.TRIGGER_RUN_ACTION_NO_ACTION
 			break StateMachine
 		}

--- a/go/components/triggerrun/controller_test.go
+++ b/go/components/triggerrun/controller_test.go
@@ -57,9 +57,9 @@ func (m *MockRunner) Resume(ctx context.Context, triggerRun *v2pb.TriggerRun) (v
 }
 
 // Update mocks base method.
-func (m *MockRunner) Update(ctx context.Context, triggerRun *v2pb.TriggerRun) (v2pb.TriggerRunStatus, error) {
-	args := m.Called(ctx, triggerRun)
-	return args.Get(0).(v2pb.TriggerRunStatus), args.Error(1)
+func (m *MockRunner) Update(ctx context.Context, triggerRun *v2pb.TriggerRun, action v2pb.TriggerRunAction) (v2pb.TriggerRunStatus, bool, error) {
+	args := m.Called(ctx, triggerRun, action)
+	return args.Get(0).(v2pb.TriggerRunStatus), args.Bool(1), args.Error(2)
 }
 
 var (
@@ -171,8 +171,8 @@ func TestReconcile(t *testing.T) {
 			initialStatus: v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING},
 			cronRunnerProvider: func() Runner {
 				mockRunner := &MockRunner{}
-				mockRunner.On("Update", mock.Anything, mock.Anything).
-					Return(v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING}, nil)
+				mockRunner.On("Update", mock.Anything, mock.Anything, mock.Anything).
+					Return(v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING}, false, nil)
 				mockRunner.On("Kill", mock.Anything, mock.Anything).
 					Return(v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_KILLED}, nil)
 				return mockRunner
@@ -193,8 +193,8 @@ func TestReconcile(t *testing.T) {
 			initialStatus: v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING},
 			cronRunnerProvider: func() Runner {
 				mockRunner := &MockRunner{}
-				mockRunner.On("Update", mock.Anything, mock.Anything).
-					Return(v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING}, nil)
+				mockRunner.On("Update", mock.Anything, mock.Anything, mock.Anything).
+					Return(v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING}, false, nil)
 				mockRunner.On("Kill", mock.Anything, mock.Anything).
 					Return(v2pb.TriggerRunStatus{}, fmt.Errorf("failed to cancel the cadence workflow"))
 				return mockRunner
@@ -215,8 +215,8 @@ func TestReconcile(t *testing.T) {
 			initialStatus: v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING},
 			cronRunnerProvider: func() Runner {
 				mockRunner := &MockRunner{}
-				mockRunner.On("Update", mock.Anything, mock.Anything).
-					Return(v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING}, nil)
+				mockRunner.On("Update", mock.Anything, mock.Anything, mock.Anything).
+					Return(v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING}, false, nil)
 				mockRunner.On("Kill", mock.Anything, mock.Anything).
 					Return(v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING}, nil)
 				return mockRunner
@@ -237,8 +237,8 @@ func TestReconcile(t *testing.T) {
 			initialStatus: v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING},
 			cronRunnerProvider: func() Runner {
 				mockRunner := &MockRunner{}
-				mockRunner.On("Update", mock.Anything, mock.Anything).
-					Return(v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING}, nil)
+				mockRunner.On("Update", mock.Anything, mock.Anything, mock.Anything).
+					Return(v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING}, false, nil)
 				mockRunner.On("Kill", mock.Anything, mock.Anything).
 					Return(v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_FAILED},
 						fmt.Errorf("execution workflow id is empty"))
@@ -287,8 +287,8 @@ func TestReconcile(t *testing.T) {
 			initialStatus: v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING},
 			cronRunnerProvider: func() Runner {
 				mockRunner := &MockRunner{}
-				mockRunner.On("Update", mock.Anything, mock.Anything).
-					Return(v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING}, nil)
+				mockRunner.On("Update", mock.Anything, mock.Anything, mock.Anything).
+					Return(v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING}, false, nil)
 				mockRunner.On("GetStatus", mock.Anything, mock.Anything).
 					Return(v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING}, fmt.Errorf("failed to GetStatus"))
 				return mockRunner
@@ -308,8 +308,8 @@ func TestReconcile(t *testing.T) {
 			initialStatus: v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING},
 			cronRunnerProvider: func() Runner {
 				mockRunner := &MockRunner{}
-				mockRunner.On("Update", mock.Anything, mock.Anything).
-					Return(v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING}, nil)
+				mockRunner.On("Update", mock.Anything, mock.Anything, mock.Anything).
+					Return(v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING}, false, nil)
 				mockRunner.On("GetStatus", mock.Anything, mock.Anything).
 					Return(v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING}, nil)
 				return mockRunner
@@ -329,8 +329,8 @@ func TestReconcile(t *testing.T) {
 			initialStatus: v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING},
 			cronRunnerProvider: func() Runner {
 				mockRunner := &MockRunner{}
-				mockRunner.On("Update", mock.Anything, mock.Anything).
-					Return(v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING}, fmt.Errorf("update failed"))
+				mockRunner.On("Update", mock.Anything, mock.Anything, mock.Anything).
+					Return(v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING}, false, fmt.Errorf("update failed"))
 				// GetStatus should NOT be called - StateMachine breaks on Update error
 				return mockRunner
 			},
@@ -352,8 +352,8 @@ func TestReconcile(t *testing.T) {
 			initialStatus: v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING},
 			cronRunnerProvider: func() Runner {
 				mockRunner := &MockRunner{}
-				mockRunner.On("Update", mock.Anything, mock.Anything).
-					Return(v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING}, nil)
+				mockRunner.On("Update", mock.Anything, mock.Anything, mock.Anything).
+					Return(v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING}, false, nil)
 				mockRunner.On("GetStatus", mock.Anything, mock.Anything).
 					Return(v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_SUCCEEDED}, nil)
 				return mockRunner
@@ -373,8 +373,8 @@ func TestReconcile(t *testing.T) {
 			initialStatus: v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING},
 			cronRunnerProvider: func() Runner {
 				mockRunner := &MockRunner{}
-				mockRunner.On("Update", mock.Anything, mock.Anything).
-					Return(v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING}, nil)
+				mockRunner.On("Update", mock.Anything, mock.Anything, mock.Anything).
+					Return(v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING}, false, nil)
 				mockRunner.On("GetStatus", mock.Anything, mock.Anything).
 					Return(v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_FAILED}, nil)
 				return mockRunner
@@ -395,8 +395,8 @@ func TestReconcile(t *testing.T) {
 			cronRunnerProvider: func() Runner {
 				mockRunner := &MockRunner{}
 				// Update() skips for Cadence - returns success immediately
-				mockRunner.On("Update", mock.Anything, mock.Anything).
-					Return(v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING}, nil)
+				mockRunner.On("Update", mock.Anything, mock.Anything, mock.Anything).
+					Return(v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING}, false, nil)
 				// GetStatus() succeeds
 				mockRunner.On("GetStatus", mock.Anything, mock.Anything).
 					Return(v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING}, nil)

--- a/go/components/triggerrun/cron_trigger.go
+++ b/go/components/triggerrun/cron_trigger.go
@@ -198,7 +198,7 @@ func (c *cronTrigger) Resume(ctx context.Context, triggerRun *v2pb.TriggerRun) (
 //
 // Returns the current TriggerRunStatus (preserving state) on success, or an error status if
 // the update fails.
-func (c *cronTrigger) Update(ctx context.Context, triggerRun *v2pb.TriggerRun) (v2pb.TriggerRunStatus, error) {
+func (c *cronTrigger) Update(ctx context.Context, triggerRun *v2pb.TriggerRun, action v2pb.TriggerRunAction) (v2pb.TriggerRunStatus, bool, error) {
 	log := c.Log.WithValues("triggerRun", k8stypes.NamespacedName{
 		Namespace: triggerRun.Namespace,
 		Name:      triggerRun.Name,
@@ -208,7 +208,7 @@ func (c *cronTrigger) Update(ctx context.Context, triggerRun *v2pb.TriggerRun) (
 	desiredCron := triggerRun.Spec.Trigger.GetCronSchedule().GetCron()
 	if desiredCron == "" {
 		log.Info("no cron schedule in spec, skipping update")
-		return triggerRun.Status, nil
+		return triggerRun.Status, false, nil
 	}
 
 	// Get actual cron schedule from status
@@ -217,17 +217,29 @@ func (c *cronTrigger) Update(ctx context.Context, triggerRun *v2pb.TriggerRun) (
 		actualCron = triggerRun.Status.ActualTrigger.GetCronSchedule().GetCron()
 	}
 
+	// Determine if we need to set paused state atomically with the cron update
+	var paused *bool
+	actionHandled := false
+	if action == v2pb.TRIGGER_RUN_ACTION_PAUSE {
+		p := true
+		paused = &p
+	} else if action == v2pb.TRIGGER_RUN_ACTION_RESUME {
+		p := false
+		paused = &p
+	}
+
 	// Compare and update if different
 	if actualCron != desiredCron {
 		log.Info("cron schedule drift detected, updating workflow engine schedule",
 			"desiredCron", desiredCron,
-			"actualCron", actualCron)
+			"actualCron", actualCron,
+			"atomicPaused", paused)
 
 		// Get workflow ID
 		wid := generateWorkflowID(triggerRun)
 
-		// Try to update the schedule in workflow engine
-		err := c.WorkflowClient.UpdateTrigger(ctx, wid, desiredCron)
+		// Try to update the schedule in workflow engine (with optional pause state)
+		err := c.WorkflowClient.UpdateTrigger(ctx, wid, desiredCron, paused)
 		if err != nil {
 			// If schedule doesn't exist (e.g., manually deleted), recreate it
 			if strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "NotFound") {
@@ -252,7 +264,7 @@ func (c *cronTrigger) Update(ctx context.Context, triggerRun *v2pb.TriggerRun) (
 					return v2pb.TriggerRunStatus{
 							ErrorMessage: createErr.Error(),
 							State:        triggerRun.Status.State,
-						}, fmt.Errorf("recreate schedule for %s/%s: %w",
+						}, false, fmt.Errorf("recreate schedule for %s/%s: %w",
 							triggerRun.Namespace, triggerRun.Name, createErr)
 				}
 
@@ -268,7 +280,7 @@ func (c *cronTrigger) Update(ctx context.Context, triggerRun *v2pb.TriggerRun) (
 						CronSchedule: &v2pb.CronSchedule{Cron: desiredCron},
 					},
 				}
-				return newStatus, nil
+				return newStatus, false, nil
 			}
 
 			// Other errors - return as failure
@@ -278,13 +290,14 @@ func (c *cronTrigger) Update(ctx context.Context, triggerRun *v2pb.TriggerRun) (
 			return v2pb.TriggerRunStatus{
 					ErrorMessage: err.Error(),
 					State:        triggerRun.Status.State,
-				}, fmt.Errorf("update trigger schedule for %s/%s: %w",
+				}, false, fmt.Errorf("update trigger schedule for %s/%s: %w",
 					triggerRun.Namespace, triggerRun.Name, err)
 		}
 
 		log.Info("successfully updated trigger schedule",
 			"workflowId", wid,
-			"newCron", desiredCron)
+			"newCron", desiredCron,
+			"atomicPaused", paused)
 
 		// Update status with the new actual trigger
 		newStatus := triggerRun.Status
@@ -293,9 +306,21 @@ func (c *cronTrigger) Update(ctx context.Context, triggerRun *v2pb.TriggerRun) (
 				CronSchedule: &v2pb.CronSchedule{Cron: desiredCron},
 			},
 		}
-		return newStatus, nil
+
+		// If pause/resume was applied atomically, update state accordingly
+		if paused != nil {
+			actionHandled = true
+			if *paused {
+				newStatus.State = v2pb.TRIGGER_RUN_STATE_PAUSED
+			} else {
+				newStatus.State = v2pb.TRIGGER_RUN_STATE_RUNNING
+			}
+			newStatus.ErrorMessage = ""
+		}
+
+		return newStatus, actionHandled, nil
 	}
 
 	// No drift, return current status unchanged
-	return triggerRun.Status, nil
+	return triggerRun.Status, false, nil
 }

--- a/go/components/triggerrun/cron_trigger_test.go
+++ b/go/components/triggerrun/cron_trigger_test.go
@@ -406,7 +406,7 @@ func TestCronTrigger_Update(t *testing.T) {
 			workflowClientProvider: func(t *testing.T) clientInterface.WorkflowClient {
 				ctrl := gomock.NewController(t)
 				mockClient := interfaceMock.NewMockWorkflowClient(ctrl)
-				mockClient.EXPECT().UpdateTrigger(gomock.Any(), "test-namespace.test-triggerrun", "0 0 * * *").Return(nil)
+				mockClient.EXPECT().UpdateTrigger(gomock.Any(), "test-namespace.test-triggerrun", "0 0 * * *", gomock.Any()).Return(nil)
 				return mockClient
 			},
 			expectError:        false,
@@ -435,7 +435,7 @@ func TestCronTrigger_Update(t *testing.T) {
 				ctrl := gomock.NewController(t)
 				mockClient := interfaceMock.NewMockWorkflowClient(ctrl)
 				// UpdateTrigger fails with "not found"
-				mockClient.EXPECT().UpdateTrigger(gomock.Any(), "test-namespace.test-triggerrun", "0 0 * * *").Return(fmt.Errorf("schedule not found"))
+				mockClient.EXPECT().UpdateTrigger(gomock.Any(), "test-namespace.test-triggerrun", "0 0 * * *", gomock.Any()).Return(fmt.Errorf("schedule not found"))
 				// StartWorkflow should be called to recreate
 				mockClient.EXPECT().StartWorkflow(gomock.Any(), gomock.Any(), "trigger.CronTrigger", gomock.Any()).Return(&clientInterface.WorkflowExecution{ID: "test-namespace.test-triggerrun", RunID: "test-run-id"}, nil)
 				return mockClient
@@ -493,7 +493,7 @@ func TestCronTrigger_Update(t *testing.T) {
 			workflowClientProvider: func(t *testing.T) clientInterface.WorkflowClient {
 				ctrl := gomock.NewController(t)
 				mockClient := interfaceMock.NewMockWorkflowClient(ctrl)
-				mockClient.EXPECT().UpdateTrigger(gomock.Any(), "test-namespace.test-triggerrun", "0 0 * * *").Return(fmt.Errorf("update failed"))
+				mockClient.EXPECT().UpdateTrigger(gomock.Any(), "test-namespace.test-triggerrun", "0 0 * * *", gomock.Any()).Return(fmt.Errorf("update failed"))
 				return mockClient
 			},
 			expectError:        true,
@@ -522,7 +522,7 @@ func TestCronTrigger_Update(t *testing.T) {
 				ctrl := gomock.NewController(t)
 				mockClient := interfaceMock.NewMockWorkflowClient(ctrl)
 				// UpdateTrigger fails with "not found"
-				mockClient.EXPECT().UpdateTrigger(gomock.Any(), "test-namespace.test-triggerrun", "0 0 * * *").Return(fmt.Errorf("schedule not found"))
+				mockClient.EXPECT().UpdateTrigger(gomock.Any(), "test-namespace.test-triggerrun", "0 0 * * *", gomock.Any()).Return(fmt.Errorf("schedule not found"))
 				// StartWorkflow fails
 				mockClient.EXPECT().StartWorkflow(gomock.Any(), gomock.Any(), "trigger.CronTrigger", gomock.Any()).Return(nil, fmt.Errorf("recreate failed"))
 				return mockClient
@@ -538,7 +538,7 @@ func TestCronTrigger_Update(t *testing.T) {
 			workflowClient := test.workflowClientProvider(t)
 			cronTrigger := NewCronTrigger(logger, workflowClient)
 
-			status, err := cronTrigger.Update(context.Background(), test.triggerRun)
+			status, _, err := cronTrigger.Update(context.Background(), test.triggerRun, v2pb.TRIGGER_RUN_ACTION_NO_ACTION)
 
 			if test.expectError {
 				assert.Error(t, err)

--- a/go/components/triggerrun/runner.go
+++ b/go/components/triggerrun/runner.go
@@ -79,6 +79,11 @@ type Runner interface {
 	// and updates the workflow engine if they differ. For recurring triggers (cron/interval),
 	// this updates the schedule. For one-time triggers (backfill/batch rerun), this is a no-op.
 	//
-	// Returns current TriggerRunStatus. Does not change the state.
-	Update(ctx context.Context, triggerRun *v2pb.TriggerRun) (v2pb.TriggerRunStatus, error)
+	// The action parameter allows folding pause/resume into the same atomic update as a cron
+	// change, avoiding race conditions between separate Update and Pause/Unpause API calls.
+	// When action is PAUSE or RESUME and there is a cron drift, both are applied atomically.
+	// Returns true in the second return value if the action was handled atomically.
+	//
+	// Returns current TriggerRunStatus. Does not change the state unless action was applied.
+	Update(ctx context.Context, triggerRun *v2pb.TriggerRun, action v2pb.TriggerRunAction) (v2pb.TriggerRunStatus, bool, error)
 }


### PR DESCRIPTION
When updating both a cron schedule and pause/resume action simultaneously, the controller made two separate Temporal API calls (schedule.Update for cron, then schedule.Pause/Unpause for action). These calls raced at the Temporal server level, causing ~2.5% of operations to lose the pause/resume state. This merges both into a single atomic schedule.Update() call by passing the desired paused state into the DoUpdate callback alongside the cron change.

Verified: 0 failures across 200 stress-test iterations (vs 5/200 before fix).

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
                                                                                                                                                                                         
  Merged the Temporal schedule.Update() (cron change) and schedule.Pause()/schedule.Unpause() (action change) into a single atomic API call when both are requested simultaneously.      
                                                                                                                                                                                         
  - Added paused *bool parameter to UpdateTrigger in the WorkflowClient interface                                                                                                        
  - The Temporal implementation now sets State.Paused inside the DoUpdate callback alongside the cron expression change                                                                  
  - Runner.Update() now accepts the pending action and returns whether it was handled atomically, so the controller skips the separate Pause()/Unpause() call when the action was already
  folded into the cron update                                                                                                                                                            
  - When only an action OR only a cron change is requested (no overlap), the existing separate code paths are used — no behavioral change                                                
                                                                                                                                                                                         
  Why?                                                                                                                                                                                   
                                                                                                                                                                                         
  When a user updates both the crontab and the run action (e.g. PAUSE) on a TriggerRun simultaneously, the controller made two sequential Temporal API calls: schedule.Update() for the  cron change, then schedule.Pause() for the action. These two calls race at t Jump to bottom (ctrl+End) ↓ hedule.Update() does a full schedule replace (including the State.Paused field), which can overwrite or conflict with the subsequent Pause()/Unpause() call. This caused ~2.5% of simultaneous cron+action updates to silently lose the pause/resume state while the cron change succeeded.                                                                                                                                                             
        
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
                                                                                                                                                                                 
  1. Unit tests pass: bazel test //go/components/triggerrun:go_default_test — all existing + updated tests pass                                                                          
  2. Reproduced the race condition before the fix: ran a 200-iteration stress test alternating cron+PAUSE and cron+RESUME via kubectl apply, verified against Temporal HTTP API          
  (/api/v1/namespaces/default/schedules/...). Result: 5 failures out of 200 iterations (2.5%)                                                                                            
  3. Verified the fix: same 200-iteration stress test with the fix deployed. Result: 0 failures out of 200 iterations                                                                    
  4. Each iteration verified both the cron step value and the paused state directly from the Temporal API (not just the TriggerRun CR status)                                            
                         

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
 
  implementations of WorkflowClient will need to add the parameter.                                                                                                                      
  - When there is no cron drift (only an action change), the controller still uses the separate Pause()/Unpause() path — this is the same behavior as before and is race-free since      
  there's no competing Update() call.      

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
