### PR TITLE
cli: add [plugin.packages] discovery for import-based plugin loading

### DIFF
--- a/python/michelangelo/cli/mactl/config.py
+++ b/python/michelangelo/cli/mactl/config.py
@@ -32,6 +32,7 @@ DEFAULT_CONFIG = {
     },
     "plugin": {
         "dirs": [],
+        "packages": [],
         "modules": {},
     },
 }

--- a/python/michelangelo/cli/mactl/mactl.py
+++ b/python/michelangelo/cli/mactl/mactl.py
@@ -5,6 +5,7 @@ A command line interface to interact with the Michelangelo API server via gRPC.
 
 import importlib
 import logging
+import pkgutil
 import re
 import sys
 from argparse import ArgumentParser, Namespace
@@ -126,6 +127,75 @@ def read_module_from_file(
         return None
     _LOG.info("Loaded plugin module: %r", plugin_module)
     return plugin_module
+
+
+def read_module_from_package(
+    crd_name: str, package_name: str
+) -> Union[object, None]:
+    """Read and load a plugin module via the import system, not by file path.
+
+    Looks for ``{package_name}.entity.{crd_name}.main`` and returns it on
+    success.
+
+    Why prefer this over :func:`read_module_from_file`:
+
+    * Works inside PEX / zipimport bundles (no ``Path.exists()`` filesystem
+      check on a synthetic zip path).
+    * The loaded module has a real ``__package__``, so relative imports
+      (``from . import apply``, ``from ...git_validation import X``) work
+      inside the plugin.
+    * Plugins do not have to know their own absolute module name —
+      consumers register the parent package once and discovery walks it.
+    """
+    module_name = f"{package_name}.entity.{crd_name}.main"
+    _LOG.info("Importing plugin module: %r", module_name)
+    try:
+        return importlib.import_module(module_name)
+    except ModuleNotFoundError as e:
+        # The whole point of multi-package discovery is that not every
+        # registered package contains every CRD. Log and move on.
+        _LOG.debug("Plugin module %r not found: %s", module_name, e)
+        return None
+    except Exception as e:
+        _LOG.error(
+            "Failed to import plugin module %r (skipped): %s",
+            module_name,
+            e,
+            exc_info=True,
+        )
+        return None
+
+
+def _iter_entity_names_in_package(package_name: str) -> list[str]:
+    """Yield entity names from ``{package_name}.entity`` via the import system.
+
+    PEX/zipimport-safe: uses :func:`pkgutil.iter_modules` rather than
+    :func:`Path.iterdir`. Returns an empty list if the entity subpackage does
+    not exist or cannot be imported.
+    """
+    entity_pkg_name = f"{package_name}.entity"
+    try:
+        entity_pkg = importlib.import_module(entity_pkg_name)
+    except ModuleNotFoundError:
+        _LOG.debug("Entity subpackage not found: %r", entity_pkg_name)
+        return []
+    except Exception as e:
+        _LOG.error(
+            "Failed to import entity subpackage %r (skipped): %s",
+            entity_pkg_name,
+            e,
+            exc_info=True,
+        )
+        return []
+
+    paths = getattr(entity_pkg, "__path__", None)
+    if not paths:
+        return []
+    return [
+        name
+        for _, name, is_pkg in pkgutil.iter_modules(paths)
+        if is_pkg and not name.startswith("__")
+    ]
 
 
 def read_plugins(crd: CRD, channel: Channel) -> None:
@@ -341,8 +411,14 @@ def apply_module_overrides() -> None:
 def discover_all_plugins() -> dict[str, list[object]]:
     """Discover and import all entity plugins early.
 
-    Scans all plugin directories and imports all entity plugin modules,
-    but does NOT apply them yet (lazy application).
+    Scans both filesystem-based plugin directories (``[plugin.dirs]``) and
+    importable plugin packages (``[plugin.packages]``) and imports all entity
+    plugin modules, but does NOT apply them yet (lazy application).
+
+    Prefer ``[plugin.packages]`` for plugins that ship inside a Python wheel
+    or PEX: the import-based loader gives plugins a real ``__package__`` and
+    works inside zipimport bundles. ``[plugin.dirs]`` remains supported for
+    free-form on-disk plugins.
 
     Returns:
         dict[str, list[object]]: Plugin registry mapping entity names to modules
@@ -355,6 +431,7 @@ def discover_all_plugins() -> dict[str, list[object]]:
 
     registry: dict[str, list[object]] = {}
     plugin_dirs = [str(DEFAULT_DIR_PLUGINS), *_CONFIG.get("plugin", {}).get("dirs", [])]
+    plugin_packages = _CONFIG.get("plugin", {}).get("packages", [])
 
     for plugin_dir_path in plugin_dirs:
         plugin_dir = Path(plugin_dir_path)
@@ -386,6 +463,19 @@ def discover_all_plugins() -> dict[str, list[object]]:
                     registry[entity_name] = []
                 registry[entity_name].append(plugin_module)
                 _LOG.info("Registered plugin for entity '%s'", entity_name)
+
+    for package_name in plugin_packages:
+        _LOG.debug("Scanning plugin package: %r", package_name)
+        for entity_name in _iter_entity_names_in_package(package_name):
+            _LOG.debug("Found entity plugin: %s (from %s)", entity_name, package_name)
+            plugin_module = read_module_from_package(entity_name, package_name)
+            if plugin_module is not None:
+                registry.setdefault(entity_name, []).append(plugin_module)
+                _LOG.info(
+                    "Registered plugin for entity '%s' from package %r",
+                    entity_name,
+                    package_name,
+                )
 
     _LOG.info(
         "Plugin discovery complete. Found plugins for %d entities: %s",

--- a/python/michelangelo/cli/mactl/mactl.py
+++ b/python/michelangelo/cli/mactl/mactl.py
@@ -129,9 +129,7 @@ def read_module_from_file(
     return plugin_module
 
 
-def read_module_from_package(
-    crd_name: str, package_name: str
-) -> Union[object, None]:
+def read_module_from_package(crd_name: str, package_name: str) -> Union[object, None]:
     """Read and load a plugin module via the import system, not by file path.
 
     Looks for ``{package_name}.entity.{crd_name}.main`` and returns it on

--- a/python/michelangelo/cli/mactl/mactl.py
+++ b/python/michelangelo/cli/mactl/mactl.py
@@ -468,14 +468,8 @@ def discover_all_plugins() -> dict[str, list[object]]:
             _LOG.debug("Found entity plugin: %s (from %s)", entity_name, package_name)
             plugin_module = read_module_from_package(entity_name, package_name)
             if plugin_module is None:
-                # Entity package was discoverable but main.py failed to import.
-                # Surface at WARNING so users see it at default log level —
-                # the helper only logs DEBUG for ModuleNotFoundError, which
-                # would otherwise be a silent failure.
                 _LOG.warning(
-                    "Skipped entity '%s' from package %r "
-                    "(entity package present but main.py failed to load — "
-                    "see prior log for details)",
+                    "Skipped entity '%s' from package %r — main.py failed to load",
                     entity_name,
                     package_name,
                 )

--- a/python/michelangelo/cli/mactl/mactl.py
+++ b/python/michelangelo/cli/mactl/mactl.py
@@ -467,13 +467,25 @@ def discover_all_plugins() -> dict[str, list[object]]:
         for entity_name in _iter_entity_names_in_package(package_name):
             _LOG.debug("Found entity plugin: %s (from %s)", entity_name, package_name)
             plugin_module = read_module_from_package(entity_name, package_name)
-            if plugin_module is not None:
-                registry.setdefault(entity_name, []).append(plugin_module)
-                _LOG.info(
-                    "Registered plugin for entity '%s' from package %r",
+            if plugin_module is None:
+                # Entity package was discoverable but main.py failed to import.
+                # Surface at WARNING so users see it at default log level —
+                # the helper only logs DEBUG for ModuleNotFoundError, which
+                # would otherwise be a silent failure.
+                _LOG.warning(
+                    "Skipped entity '%s' from package %r "
+                    "(entity package present but main.py failed to load — "
+                    "see prior log for details)",
                     entity_name,
                     package_name,
                 )
+                continue
+            registry.setdefault(entity_name, []).append(plugin_module)
+            _LOG.info(
+                "Registered plugin for entity '%s' from package %r",
+                entity_name,
+                package_name,
+            )
 
     _LOG.info(
         "Plugin discovery complete. Found plugins for %d entities: %s",

--- a/python/michelangelo/cli/mactl/mactl_test.py
+++ b/python/michelangelo/cli/mactl/mactl_test.py
@@ -1143,9 +1143,7 @@ class IterEntityNamesInPackageTest(TestCase):
             _write_pkg_plugin(Path(tmpdir), "ien_pkg", "alpha", "")
             _write_pkg_plugin(Path(tmpdir), "ien_pkg", "beta", "")
             # Also drop a non-package file that should be ignored.
-            non_pkg_file = (
-                Path(tmpdir) / "ien_pkg" / "entity" / "stray_file.py"
-            )
+            non_pkg_file = Path(tmpdir) / "ien_pkg" / "entity" / "stray_file.py"
             non_pkg_file.write_text("# not a subpackage")
             sys.path.insert(0, tmpdir)
             try:
@@ -1178,6 +1176,47 @@ class IterEntityNamesInPackageTest(TestCase):
 
         self.assertEqual(names, [])
 
+    def test_returns_empty_when_entity_import_raises_unexpected_error(self):
+        """Resilience: entity subpackage whose code raises is skipped, not raised."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pkg_dir = Path(tmpdir) / "ien_boom_pkg"
+            pkg_dir.mkdir()
+            (pkg_dir / "__init__.py").write_text("")
+            entity_pkg = pkg_dir / "entity"
+            entity_pkg.mkdir()
+            entity_pkg.joinpath("__init__.py").write_text(
+                "raise RuntimeError('entity boom')"
+            )
+            sys.path.insert(0, tmpdir)
+            try:
+                names = _iter_entity_names_in_package("ien_boom_pkg")
+            finally:
+                sys.path.remove(tmpdir)
+                for k in list(sys.modules):
+                    if k.startswith("ien_boom_pkg"):
+                        del sys.modules[k]
+
+        self.assertEqual(names, [])
+
+    def test_returns_empty_when_entity_has_no_path_attr(self):
+        """Edge: `{pkg}.entity` resolves to a single-file module (no `__path__`)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pkg_dir = Path(tmpdir) / "ien_nopath_pkg"
+            pkg_dir.mkdir()
+            (pkg_dir / "__init__.py").write_text("")
+            # `entity` is a single .py module, not a subpackage — no iter
+            (pkg_dir / "entity.py").write_text("# not a package")
+            sys.path.insert(0, tmpdir)
+            try:
+                names = _iter_entity_names_in_package("ien_nopath_pkg")
+            finally:
+                sys.path.remove(tmpdir)
+                for k in list(sys.modules):
+                    if k.startswith("ien_nopath_pkg"):
+                        del sys.modules[k]
+
+        self.assertEqual(names, [])
+
 
 class DiscoverAllPluginsFromPackagesTest(TestCase):
     """Tests covering the [plugin.packages] discovery path of discover_all_plugins."""
@@ -1185,9 +1224,7 @@ class DiscoverAllPluginsFromPackagesTest(TestCase):
     def test_discovers_plugins_from_configured_packages(self):
         """Core: configured packages are scanned and their entity plugins registered."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            _write_pkg_plugin(
-                Path(tmpdir), "daps_one_pkg", "pipeline", "loaded = True"
-            )
+            _write_pkg_plugin(Path(tmpdir), "daps_one_pkg", "pipeline", "loaded = True")
             sys.path.insert(0, tmpdir)
             try:
                 with (
@@ -1247,10 +1284,11 @@ class DiscoverAllPluginsFromPackagesTest(TestCase):
 
     def test_returns_empty_when_packages_key_missing(self):
         """Edge: no `packages` key behaves identically to packages = []."""
-        with patch(
-            "michelangelo.cli.mactl.mactl._CONFIG", {"plugin": {"dirs": []}}
-        ), patch(
-            "michelangelo.cli.mactl.mactl.DEFAULT_DIR_PLUGINS", Path("/nonexistent")
+        with (
+            patch("michelangelo.cli.mactl.mactl._CONFIG", {"plugin": {"dirs": []}}),
+            patch(
+                "michelangelo.cli.mactl.mactl.DEFAULT_DIR_PLUGINS", Path("/nonexistent")
+            ),
         ):
             registry = discover_all_plugins()
 

--- a/python/michelangelo/cli/mactl/mactl_test.py
+++ b/python/michelangelo/cli/mactl/mactl_test.py
@@ -16,6 +16,7 @@ from michelangelo.cli.mactl.mactl import (
     ADDRESS,
     DEFAULT_DIR_PLUGINS,
     _is_service_name,
+    _iter_entity_names_in_package,
     add_plugin_dirs_to_syspath,
     apply_command_plugins,
     apply_entity_plugins,
@@ -27,6 +28,7 @@ from michelangelo.cli.mactl.mactl import (
     handle_crd_action_help,
     pre_parse_args,
     read_module_from_file,
+    read_module_from_package,
     read_plugin_command,
     read_plugin_modules,
     read_plugins,
@@ -997,6 +999,257 @@ class DiscoverAllPluginsTest(TestCase):
     def test_returns_empty_registry_when_plugin_config_missing(self):
         """Edge: returns empty registry when plugin config key is absent."""
         with patch(
+            "michelangelo.cli.mactl.mactl.DEFAULT_DIR_PLUGINS", Path("/nonexistent")
+        ):
+            registry = discover_all_plugins()
+
+        self.assertEqual(registry, {})
+
+
+def _write_pkg_plugin(
+    root: Path, package_name: str, entity_name: str, body: str
+) -> None:
+    """Helper: lay out an importable plugin package on disk for tests.
+
+    Creates ``{root}/{package_name}/__init__.py``,
+    ``{package_name}/entity/__init__.py``,
+    ``{package_name}/entity/{entity_name}/__init__.py``,
+    ``{package_name}/entity/{entity_name}/main.py`` (containing ``body``).
+    Caller is responsible for inserting ``root`` into ``sys.path``.
+    """
+    pkg_parts = package_name.split(".")
+    cur = root
+    for part in pkg_parts:
+        cur = cur / part
+        cur.mkdir(parents=True, exist_ok=True)
+        (cur / "__init__.py").write_text("")
+    entity_pkg = cur / "entity"
+    entity_pkg.mkdir(parents=True, exist_ok=True)
+    (entity_pkg / "__init__.py").write_text("")
+    crd_pkg = entity_pkg / entity_name
+    crd_pkg.mkdir(parents=True, exist_ok=True)
+    (crd_pkg / "__init__.py").write_text("")
+    (crd_pkg / "main.py").write_text(body)
+
+
+class ReadModuleFromPackageTest(TestCase):
+    """Tests for read_module_from_package function."""
+
+    def test_returns_module_when_import_succeeds(self):
+        """Core: imports `{pkg}.entity.{crd}.main` and returns it."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_pkg_plugin(
+                Path(tmpdir),
+                "rmp_ok_pkg",
+                "test_entity",
+                "marker = 'from-package'",
+            )
+            sys.path.insert(0, tmpdir)
+            try:
+                result = read_module_from_package("test_entity", "rmp_ok_pkg")
+            finally:
+                sys.path.remove(tmpdir)
+                # Clean importlib cache so other tests aren't polluted.
+                for k in list(sys.modules):
+                    if k.startswith("rmp_ok_pkg"):
+                        del sys.modules[k]
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result.marker, "from-package")
+
+    def test_returns_none_when_package_missing(self):
+        """Edge: unknown package name returns None, does not raise."""
+        result = read_module_from_package(
+            "test_entity", "this_pkg_does_not_exist_zzz_12345"
+        )
+        self.assertIsNone(result)
+
+    def test_returns_none_when_main_module_missing(self):
+        """Edge: existing package but no entity/<crd>/main.py returns None."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Make the package importable but omit the entity subpackage.
+            pkg_dir = Path(tmpdir) / "rmp_empty_pkg"
+            pkg_dir.mkdir()
+            (pkg_dir / "__init__.py").write_text("")
+            sys.path.insert(0, tmpdir)
+            try:
+                result = read_module_from_package("missing_entity", "rmp_empty_pkg")
+            finally:
+                sys.path.remove(tmpdir)
+                sys.modules.pop("rmp_empty_pkg", None)
+
+        self.assertIsNone(result)
+
+    def test_returns_none_when_plugin_main_raises(self):
+        """Resilience: a plugin whose main.py raises is skipped, not propagated."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_pkg_plugin(
+                Path(tmpdir),
+                "rmp_broken_pkg",
+                "broken_entity",
+                "raise RuntimeError('plugin boom')",
+            )
+            sys.path.insert(0, tmpdir)
+            try:
+                result = read_module_from_package("broken_entity", "rmp_broken_pkg")
+            finally:
+                sys.path.remove(tmpdir)
+                for k in list(sys.modules):
+                    if k.startswith("rmp_broken_pkg"):
+                        del sys.modules[k]
+
+        self.assertIsNone(result)
+
+    def test_relative_imports_inside_plugin_work(self):
+        """Regression: package-loaded plugin's relative imports resolve correctly.
+
+        ``read_module_from_file`` cannot deliver this because spec_from_file_location
+        leaves ``__package__`` unset.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_pkg_plugin(
+                Path(tmpdir),
+                "rmp_relimport_pkg",
+                "test_entity",
+                "from . import sibling\nresolved = sibling.value",
+            )
+            sibling = (
+                Path(tmpdir)
+                / "rmp_relimport_pkg"
+                / "entity"
+                / "test_entity"
+                / "sibling.py"
+            )
+            sibling.write_text("value = 'sibling-loaded-via-relative-import'")
+            sys.path.insert(0, tmpdir)
+            try:
+                result = read_module_from_package("test_entity", "rmp_relimport_pkg")
+            finally:
+                sys.path.remove(tmpdir)
+                for k in list(sys.modules):
+                    if k.startswith("rmp_relimport_pkg"):
+                        del sys.modules[k]
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result.resolved, "sibling-loaded-via-relative-import")
+
+
+class IterEntityNamesInPackageTest(TestCase):
+    """Tests for _iter_entity_names_in_package helper."""
+
+    def test_lists_entity_subpackages(self):
+        """Core: returns entity names that are subpackages of `{pkg}.entity`."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_pkg_plugin(Path(tmpdir), "ien_pkg", "alpha", "")
+            _write_pkg_plugin(Path(tmpdir), "ien_pkg", "beta", "")
+            # Also drop a non-package file that should be ignored.
+            non_pkg_file = (
+                Path(tmpdir) / "ien_pkg" / "entity" / "stray_file.py"
+            )
+            non_pkg_file.write_text("# not a subpackage")
+            sys.path.insert(0, tmpdir)
+            try:
+                names = _iter_entity_names_in_package("ien_pkg")
+            finally:
+                sys.path.remove(tmpdir)
+                for k in list(sys.modules):
+                    if k.startswith("ien_pkg"):
+                        del sys.modules[k]
+
+        self.assertEqual(sorted(names), ["alpha", "beta"])
+
+    def test_returns_empty_when_package_missing(self):
+        """Edge: unknown package returns []."""
+        names = _iter_entity_names_in_package("this_pkg_does_not_exist_zzz_67890")
+        self.assertEqual(names, [])
+
+    def test_returns_empty_when_entity_subpackage_missing(self):
+        """Edge: package exists but has no `entity` subpackage."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pkg_dir = Path(tmpdir) / "ien_no_entity_pkg"
+            pkg_dir.mkdir()
+            (pkg_dir / "__init__.py").write_text("")
+            sys.path.insert(0, tmpdir)
+            try:
+                names = _iter_entity_names_in_package("ien_no_entity_pkg")
+            finally:
+                sys.path.remove(tmpdir)
+                sys.modules.pop("ien_no_entity_pkg", None)
+
+        self.assertEqual(names, [])
+
+
+class DiscoverAllPluginsFromPackagesTest(TestCase):
+    """Tests covering the [plugin.packages] discovery path of discover_all_plugins."""
+
+    def test_discovers_plugins_from_configured_packages(self):
+        """Core: configured packages are scanned and their entity plugins registered."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_pkg_plugin(
+                Path(tmpdir), "daps_one_pkg", "pipeline", "loaded = True"
+            )
+            sys.path.insert(0, tmpdir)
+            try:
+                with (
+                    patch(
+                        "michelangelo.cli.mactl.mactl._CONFIG",
+                        {"plugin": {"dirs": [], "packages": ["daps_one_pkg"]}},
+                    ),
+                    patch(
+                        "michelangelo.cli.mactl.mactl.DEFAULT_DIR_PLUGINS",
+                        Path("/nonexistent"),
+                    ),
+                ):
+                    registry = discover_all_plugins()
+            finally:
+                sys.path.remove(tmpdir)
+                for k in list(sys.modules):
+                    if k.startswith("daps_one_pkg"):
+                        del sys.modules[k]
+
+        self.assertIn("pipeline", registry)
+        self.assertEqual(len(registry["pipeline"]), 1)
+        self.assertTrue(registry["pipeline"][0].loaded)
+
+    def test_dirs_and_packages_accumulate(self):
+        """Edge: registry combines hits from `[plugin.dirs]` and `[plugin.packages]`."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_pkg_plugin(
+                Path(tmpdir), "daps_two_pkg", "pipeline", "from_package = True"
+            )
+            sys.path.insert(0, tmpdir)
+            try:
+                with (
+                    patch(
+                        "michelangelo.cli.mactl.mactl._CONFIG",
+                        {
+                            "plugin": {
+                                "dirs": [str(PLUGIN_TEST_DIR / "plugins_1")],
+                                "packages": ["daps_two_pkg"],
+                            }
+                        },
+                    ),
+                    patch(
+                        "michelangelo.cli.mactl.mactl.DEFAULT_DIR_PLUGINS",
+                        Path("/nonexistent"),
+                    ),
+                ):
+                    registry = discover_all_plugins()
+            finally:
+                sys.path.remove(tmpdir)
+                for k in list(sys.modules):
+                    if k.startswith("daps_two_pkg"):
+                        del sys.modules[k]
+
+        # One from the dir fixture, one from the package fixture.
+        self.assertIn("pipeline", registry)
+        self.assertEqual(len(registry["pipeline"]), 2)
+
+    def test_returns_empty_when_packages_key_missing(self):
+        """Edge: no `packages` key behaves identically to packages = []."""
+        with patch(
+            "michelangelo.cli.mactl.mactl._CONFIG", {"plugin": {"dirs": []}}
+        ), patch(
             "michelangelo.cli.mactl.mactl.DEFAULT_DIR_PLUGINS", Path("/nonexistent")
         ):
             registry = discover_all_plugins()


### PR DESCRIPTION
## Summary

Adds a parallel plugin discovery mechanism that loads plugins **by importable module path** instead of by filesystem path. New TOML key:

```toml
[plugin]
packages = ["my_pkg.plugins"]   # importable package containing entity/<crd>/main.py
```

Both `[plugin.dirs]` (existing) and `[plugin.packages]` (new) are scanned by `discover_all_plugins`; results accumulate into the same registry. No behavior change for existing consumers — the new key defaults to `[]`.

## Motivation

The existing `[plugin.dirs]` loader has two structural limitations that show up the moment a downstream distribution ships plugins inside a wheel or PEX:

1. **PEX / zipimport incompatibility.** Discovery uses `Path.exists()` + `Path.iterdir()` on a real filesystem directory. Inside a PEX, bundled `plugins/` is a zip entry — `Path.exists()` returns False and the loader silently skips every bundled plugin.

2. **No `__package__` on loaded plugins.** `read_module_from_file` uses `spec_from_file_location` with no `__package__` set. Python then refuses relative imports (`from . import apply`, `from ...git_validation import X`) inside the plugin. Worse, plugins shipping in multiple namespaces (e.g. `my_pkg.plugins.entity.foo` at pip-install vs `org.team.product.my_pkg.plugins.entity.foo` inside a monorepo's bazel sandbox) have to manage that themselves with dual-namespace try/except imports.

The package-based loader fixes both:

- Uses `importlib.import_module` + `pkgutil.iter_modules` — both honor zipimporter, so PEX and wheel-bundled plugins are discoverable.
- Loaded plugin has a real `__package__`, so relative imports just work and plugin authors don't need to know their plugin's absolute name.

## Design

- `read_module_from_package(crd_name, package_name)` — imports `{package_name}.entity.{crd_name}.main` and returns it. Returns None on `ModuleNotFoundError` (different packages contain different CRDs — expected) or any other plugin-load exception (resilience — one broken plugin can't crash the CLI).
- `_iter_entity_names_in_package(package_name)` — uses `pkgutil.iter_modules` over `{package_name}.entity` to enumerate entity subpackages without touching the filesystem.
- `discover_all_plugins` — after scanning `[plugin.dirs]` as today, also iterates `[plugin.packages]` and appends discovered plugins to the same registry.

## What this unblocks (referenced consumers)

A downstream CLI that wraps `ma` and ships its plugins inside a pip wheel currently has to:

- Maintain dual-namespace try/except imports in every plugin's `main.py` and `apply.py` (e.g. `import my_pkg.git_validation` with a fallback to `from org.team.product.my_pkg import git_validation`).
- Add `# gazelle:ignore` directives in build-system tooling because the pip namespace doesn't exist as a build target.
- Keep a path-based `_load_sibling()` helper because `from . import apply` can't resolve.
- Lose the option to package itself as a PEX because the bundled plugins go undiscovered.

Switching that CLI's config from `[plugin.dirs]` to `[plugin.packages]` lets it drop all of the above. The cleanup is purely consumer-side after this lands.

## Test plan

| command | run | verified |
|---|---|---|
| `pytest michelangelo/cli/mactl/mactl_test.py -k 'ReadModuleFromPackage or IterEntityNamesInPackage or DiscoverAllPluginsFromPackages'` | yes | 13/13 pass |
| `pytest michelangelo/cli/mactl/mactl_test.py` (full suite, including existing `DiscoverAllPluginsTest`) | yes | no regressions vs main |
| `ruff check python/michelangelo/cli/mactl/` + `ruff format --check python/michelangelo/cli/mactl/` | yes | clean |
| **ETE hot-patch:** built a local-tagged wheel from this branch, `pip install --force-reinstall` over an existing `michelangelo-0.1.1.58` install, pointed a downstream wrapper CLI's `~/.ma/config.toml` at `[plugin] dirs=[] packages=["downstream_pkg.plugins"]`, ran `LOG_LEVEL=info ma --help` | yes | all 5 wrapper-CLI plugins (`pipeline`, `project`, `prompt_template`, `ray_job`, `spark_job`) registered via the new path; log shows `Registered plugin for entity 'X' from package 'downstream_pkg.plugins'`; loaded modules have real `__package__` (e.g. `downstream_pkg.plugins.entity.pipeline`); `ma --help` dispatch table includes every plugin CRD |

New coverage:
- Successful package import + module return
- Missing package returns None (not raised)
- Existing package without entity subpackage returns None
- Plugin whose top-level code raises is skipped (resilience)
- Relative imports inside a package-loaded plugin resolve correctly (the structural win)
- Entity enumeration via `pkgutil.iter_modules` filters non-package files
- Entity subpackage whose top-level code raises is skipped (covers broad-Exception branch)
- Entity resolved to a single-file module (no `__path__`) returns `[]`
- `discover_all_plugins` end-to-end with packages
- `[plugin.dirs]` and `[plugin.packages]` accumulate into one registry
- Missing `packages` config key behaves identically to `packages = []`
