### PR TITLE
feat: add MetadataStoragePrimaryKey annotation for k8s migration

### DIFF
--- a/go/api/api.go
+++ b/go/api/api.go
@@ -34,6 +34,13 @@ const (
 	// object can be changed in MySQL later on.
 	ImmutableAnnotation = "michelangelo/Immutable"
 
+	// MetadataStoragePrimaryKeyAnnotation stores a stable identifier to use as the primary
+	// key in metadata storage (MySQL, Postgres, etc). When set, ingester and metadata
+	// storage use this value instead of K8s UID. This enables disaster recovery across
+	// clusters where UIDs change but logical identity (namespace + name) remains the same.
+	// The value is typically the original UID from the first cluster, preserved during migration.
+	MetadataStoragePrimaryKeyAnnotation = "michelangelo/MetadataStoragePrimaryKey"
+
 	/////////////////////////// K8s Labels ///////////////////////////
 
 	// SpecUpdateTimestampLabel is used to record the last time the spec of the object is updated.

--- a/go/components/ingester/controller.go
+++ b/go/components/ingester/controller.go
@@ -150,6 +150,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return r.handleDeletionAnnotation(ctx, log, object)
 	}
 
+	// Ensure MetadataStoragePrimaryKey annotation is set so the metadata storage PK
+	// remains stable across cluster migrations. Return early on first write; the Update
+	// triggers a new reconcile that will proceed to upsert with the annotation in place.
+	if updated, err := r.ensureMetadataStoragePrimaryKey(ctx, object); err != nil {
+		log.Error(err, "Failed to set MetadataStoragePrimaryKey annotation")
+		return ctrl.Result{RequeueAfter: r.getRequeuePeriod()}, err
+	} else if updated {
+		return ctrl.Result{}, nil
+	}
+
 	// Check if object is immutable (either by kind or annotation)
 	if isImmutable(object) || isImmutableKind(object) {
 		return r.handleImmutableObject(ctx, log, object)
@@ -426,4 +436,24 @@ func isImmutableKind(object client.Object) bool {
 		return ik.IsImmutableKind()
 	}
 	return false
+}
+
+// ensureMetadataStoragePrimaryKey sets MetadataStoragePrimaryKeyAnnotation to the object's
+// UID when the annotation is absent, then patches the object in k8s. Returns true if the
+// annotation was added so the caller can return early and let the next reconcile proceed
+// with the annotation already in place.
+func (r *Reconciler) ensureMetadataStoragePrimaryKey(ctx context.Context, object client.Object) (bool, error) {
+	annotations := object.GetAnnotations()
+	if _, ok := annotations[api.MetadataStoragePrimaryKeyAnnotation]; ok {
+		return false, nil
+	}
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[api.MetadataStoragePrimaryKeyAnnotation] = string(object.GetUID())
+	object.SetAnnotations(annotations)
+	if err := r.Update(ctx, object); err != nil {
+		return false, err
+	}
+	return true, nil
 }

--- a/go/components/ingester/controller_test.go
+++ b/go/components/ingester/controller_test.go
@@ -2,6 +2,7 @@ package ingester
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -89,6 +90,9 @@ func TestReconciler_HandleSync(t *testing.T) {
 			Namespace:  "default",
 			UID:        types.UID("test-uid"),
 			Finalizers: []string{api.IngesterFinalizer},
+			Annotations: map[string]string{
+				api.MetadataStoragePrimaryKeyAnnotation: "test-uid",
+			},
 		},
 	}
 
@@ -144,6 +148,9 @@ func TestReconciler_HandleSync_UpsertsWithFinalizer(t *testing.T) {
 			Namespace:  "default",
 			UID:        types.UID("test-uid"),
 			Finalizers: []string{api.IngesterFinalizer},
+			Annotations: map[string]string{
+				api.MetadataStoragePrimaryKeyAnnotation: "test-uid",
+			},
 		},
 	}
 
@@ -320,6 +327,9 @@ func TestReconciler_HandleImmutableKind(t *testing.T) {
 			Namespace:  "default",
 			UID:        types.UID("test-uid"),
 			Finalizers: []string{api.IngesterFinalizer},
+			Annotations: map[string]string{
+				api.MetadataStoragePrimaryKeyAnnotation: "test-uid",
+			},
 		},
 		Spec: v2.ModelSpec{
 			Description: "Test immutable kind model",
@@ -381,7 +391,8 @@ func TestReconciler_HandleImmutableObject(t *testing.T) {
 			Namespace: "default",
 			UID:       types.UID("test-uid"),
 			Annotations: map[string]string{
-				api.ImmutableAnnotation: "true",
+				api.ImmutableAnnotation:                 "true",
+				api.MetadataStoragePrimaryKeyAnnotation: "test-uid",
 			},
 			Finalizers: []string{api.IngesterFinalizer},
 		},
@@ -756,4 +767,118 @@ func TestReconciler_HandleDeletionAnnotation_HonorsPropagationPolicy(t *testing.
 	assert.Equal(t, metav1.DeletePropagationForeground, *capturedOpts.PropagationPolicy)
 
 	mockStorage.AssertCalled(t, "Delete", mock.Anything, mock.Anything, "default", "test-model")
+}
+
+// TestReconciler_SetsMetadataStoragePrimaryKey_WhenAbsent verifies that on first reconcile
+// of a new object (no MetadataStoragePrimaryKeyAnnotation), the ingester patches the
+// annotation to the object's UID and returns early without calling Upsert. The watch on the
+// updated object triggers a second reconcile that proceeds to upsert.
+func TestReconciler_SetsMetadataStoragePrimaryKey_WhenAbsent(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = v2.AddToScheme(scheme)
+
+	deployment := &v2.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-deployment",
+			Namespace:  "default",
+			UID:        types.UID("original-uid"),
+			Finalizers: []string{api.IngesterFinalizer},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployment).Build()
+	mockStorage := new(MockMetadataStorage)
+
+	reconciler := NewReconciler(
+		fakeClient, logr.Discard(), scheme, &v2.Deployment{}, mockStorage,
+		WithConfig(Config{ConcurrentReconciles: 1, RequeuePeriod: 30 * time.Second}),
+	)
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "test-deployment", Namespace: "default"}}
+	result, err := reconciler.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	// Upsert must NOT be called on the first pass (returned early after patching).
+	mockStorage.AssertNotCalled(t, "Upsert")
+
+	// Annotation must be persisted to k8s with the object's UID as value.
+	updated := &v2.Deployment{}
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-deployment", Namespace: "default"}, updated))
+	assert.Equal(t, "original-uid", updated.GetAnnotations()[api.MetadataStoragePrimaryKeyAnnotation])
+}
+
+// TestReconciler_SkipsMetadataStoragePrimaryKey_WhenPresent verifies that when the
+// annotation is already set (second reconcile or migrated resource), the ingester skips
+// the patch and proceeds directly to upsert.
+func TestReconciler_SkipsMetadataStoragePrimaryKey_WhenPresent(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = v2.AddToScheme(scheme)
+
+	deployment := &v2.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-deployment",
+			Namespace:  "default",
+			UID:        types.UID("new-uid"),
+			Finalizers: []string{api.IngesterFinalizer},
+			Annotations: map[string]string{
+				api.MetadataStoragePrimaryKeyAnnotation: "original-uid",
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployment).Build()
+	mockStorage := new(MockMetadataStorage)
+	mockStorage.On("Upsert", mock.Anything, mock.Anything, false, mock.Anything).Return(nil)
+
+	reconciler := NewReconciler(
+		fakeClient, logr.Discard(), scheme, &v2.Deployment{}, mockStorage,
+		WithConfig(Config{ConcurrentReconciles: 1, RequeuePeriod: 30 * time.Second}),
+	)
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "test-deployment", Namespace: "default"}}
+	result, err := reconciler.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	// Upsert must be called (annotation already present, no patch needed).
+	mockStorage.AssertCalled(t, "Upsert", mock.Anything, mock.Anything, false, mock.Anything)
+}
+
+// TestReconciler_MetadataStoragePrimaryKey_UpdateError verifies that a k8s Update failure
+// while setting the annotation is surfaced as an error and triggers a requeue.
+func TestReconciler_MetadataStoragePrimaryKey_UpdateError(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = v2.AddToScheme(scheme)
+
+	deployment := &v2.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-deployment",
+			Namespace:  "default",
+			UID:        types.UID("original-uid"),
+			Finalizers: []string{api.IngesterFinalizer},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(deployment).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				return fmt.Errorf("simulated update failure")
+			},
+		}).
+		Build()
+	mockStorage := new(MockMetadataStorage)
+
+	reconciler := NewReconciler(
+		fakeClient, logr.Discard(), scheme, &v2.Deployment{}, mockStorage,
+		WithConfig(Config{ConcurrentReconciles: 1, RequeuePeriod: 30 * time.Second}),
+	)
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "test-deployment", Namespace: "default"}}
+	result, err := reconciler.Reconcile(context.Background(), req)
+	require.Error(t, err)
+	assert.Equal(t, 30*time.Second, result.RequeueAfter)
+	mockStorage.AssertNotCalled(t, "Upsert")
 }

--- a/go/storage/mysql/BUILD.bazel
+++ b/go/storage/mysql/BUILD.bazel
@@ -33,5 +33,6 @@ go_test(
         "@com_github_stretchr_testify//require:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
+        "@io_k8s_apimachinery//pkg/types:go_default_library",
     ],
 )

--- a/go/storage/mysql/BUILD.bazel
+++ b/go/storage/mysql/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/michelangelo-ai/michelangelo/go/storage/mysql",
     visibility = ["//visibility:public"],
     deps = [
+        "//go/api:go_default_library",
         "//go/api/utils:go_default_library",
         "//go/storage:go_default_library",
         "//proto/api:go_default_library",
@@ -24,12 +25,17 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["mysql_test.go"],
+    srcs = [
+        "mysql_integration_test.go",
+        "mysql_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
+        "//go/api:go_default_library",
         "//proto/api:go_default_library",
         "//proto/api/v2:go_default_library",
         "@com_github_gogo_protobuf//types:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",

--- a/go/storage/mysql/mysql.go
+++ b/go/storage/mysql/mysql.go
@@ -13,6 +13,7 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	proto "github.com/gogo/protobuf/proto"
 	gogotypes "github.com/gogo/protobuf/types"
+	api "github.com/michelangelo-ai/michelangelo/go/api"
 	"github.com/michelangelo-ai/michelangelo/go/api/utils"
 	"github.com/michelangelo-ai/michelangelo/go/storage"
 	apipb "github.com/michelangelo-ai/michelangelo/proto-go/api"
@@ -1108,7 +1109,7 @@ func (m *mysqlMetadataStorage) fullUpsert(ctx context.Context, tx *sql.Tx, table
 	// This enables stable identity across cluster migrations
 	primaryKey := string(metaObj.GetUID())
 	if annotations := metaObj.GetAnnotations(); annotations != nil {
-		if storagePK, exists := annotations["michelangelo/MetadataStoragePrimaryKey"]; exists && storagePK != "" {
+		if storagePK, exists := annotations[api.MetadataStoragePrimaryKeyAnnotation]; exists && storagePK != "" {
 			primaryKey = storagePK
 		}
 	}

--- a/go/storage/mysql/mysql.go
+++ b/go/storage/mysql/mysql.go
@@ -148,20 +148,23 @@ func (m *mysqlMetadataStorage) Upsert(ctx context.Context, object runtime.Object
 		return m.directUpdate(ctx, tx, tableName, metaObj, object)
 	}
 
-	// Full upsert: update all fields
+	// Full upsert: update all fields. Compute the stable primary key once so the main
+	// object row and its label/annotation child rows are all keyed consistently.
+	primaryKey := metadataStoragePrimaryKey(metaObj)
+
 	err = m.fullUpsert(ctx, tx, tableName, groupVer, metaObj, protoBytes, jsonBytes, indexedFields)
 	if err != nil {
 		return err
 	}
 
 	// Upsert labels
-	err = m.upsertLabels(ctx, tx, tableName, string(metaObj.GetUID()), metaObj.GetLabels())
+	err = m.upsertLabels(ctx, tx, tableName, primaryKey, metaObj.GetLabels())
 	if err != nil {
 		return err
 	}
 
 	// Upsert annotations
-	err = m.upsertAnnotations(ctx, tx, tableName, string(metaObj.GetUID()), metaObj.GetAnnotations())
+	err = m.upsertAnnotations(ctx, tx, tableName, primaryKey, metaObj.GetAnnotations())
 	if err != nil {
 		return err
 	}
@@ -1098,6 +1101,20 @@ func (m *mysqlMetadataStorage) Close() {
 
 // Helper functions
 
+// metadataStoragePrimaryKey returns the stable primary key for metadata storage: the
+// MetadataStoragePrimaryKeyAnnotation value when present and non-empty, otherwise the
+// object's K8s UID. The main object row and its label/annotation child rows must all be
+// keyed by this same value so they remain joinable across cluster migrations, where the
+// K8s UID changes but the annotation preserves the original logical identity.
+func metadataStoragePrimaryKey(metaObj metav1.Object) string {
+	if annotations := metaObj.GetAnnotations(); annotations != nil {
+		if pk, ok := annotations[api.MetadataStoragePrimaryKeyAnnotation]; ok && pk != "" {
+			return pk
+		}
+	}
+	return string(metaObj.GetUID())
+}
+
 func (m *mysqlMetadataStorage) fullUpsert(ctx context.Context, tx *sql.Tx, tableName string, groupVer string, metaObj metav1.Object, protoBytes, jsonBytes []byte, indexedFields []storage.IndexedField) error {
 	// Build indexed fields map
 	indexedFieldsMap := make(map[string]interface{})
@@ -1105,14 +1122,9 @@ func (m *mysqlMetadataStorage) fullUpsert(ctx context.Context, tx *sql.Tx, table
 		indexedFieldsMap[field.Key] = field.Value
 	}
 
-	// Determine primary key: use MetadataStoragePrimaryKeyAnnotation if set, else UID
-	// This enables stable identity across cluster migrations
-	primaryKey := string(metaObj.GetUID())
-	if annotations := metaObj.GetAnnotations(); annotations != nil {
-		if storagePK, exists := annotations[api.MetadataStoragePrimaryKeyAnnotation]; exists && storagePK != "" {
-			primaryKey = storagePK
-		}
-	}
+	// Determine primary key: use MetadataStoragePrimaryKeyAnnotation if set, else UID.
+	// This enables stable identity across cluster migrations.
+	primaryKey := metadataStoragePrimaryKey(metaObj)
 
 	// Build dynamic SQL based on indexed fields
 	columns := []string{"uid", "group_ver", "namespace", "name", "res_version", "create_time", "update_time", "proto", "json"}

--- a/go/storage/mysql/mysql.go
+++ b/go/storage/mysql/mysql.go
@@ -1104,11 +1104,20 @@ func (m *mysqlMetadataStorage) fullUpsert(ctx context.Context, tx *sql.Tx, table
 		indexedFieldsMap[field.Key] = field.Value
 	}
 
+	// Determine primary key: use MetadataStoragePrimaryKeyAnnotation if set, else UID
+	// This enables stable identity across cluster migrations
+	primaryKey := string(metaObj.GetUID())
+	if annotations := metaObj.GetAnnotations(); annotations != nil {
+		if storagePK, exists := annotations["michelangelo/MetadataStoragePrimaryKey"]; exists && storagePK != "" {
+			primaryKey = storagePK
+		}
+	}
+
 	// Build dynamic SQL based on indexed fields
 	columns := []string{"uid", "group_ver", "namespace", "name", "res_version", "create_time", "update_time", "proto", "json"}
 	placeholders := []string{"?", "?", "?", "?", "?", "?", "?", "?", "?"}
 	values := []interface{}{
-		string(metaObj.GetUID()),
+		primaryKey, // Use annotation-based PK if available
 		groupVer,
 		metaObj.GetNamespace(),
 		metaObj.GetName(),

--- a/go/storage/mysql/mysql_integration_test.go
+++ b/go/storage/mysql/mysql_integration_test.go
@@ -1,0 +1,219 @@
+package mysql
+
+// Integration tests that require a live MySQL instance. They are skipped automatically
+// when MySQL is unreachable, so they are safe to run in any environment.
+//
+// To run locally with the k3d sandbox:
+//   MYSQL_HOST=localhost MYSQL_PORT=3306 go test -mod=mod -run TestIntegration ./storage/mysql/...
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	api "github.com/michelangelo-ai/michelangelo/go/api"
+	v2pb "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// mysqlIntegrationConfig returns the Config for the local sandbox MySQL, reading
+// MYSQL_HOST / MYSQL_PORT / MYSQL_USER / MYSQL_PASSWORD / MYSQL_DATABASE from env with
+// safe defaults.
+func mysqlIntegrationConfig() Config {
+	host := os.Getenv("MYSQL_HOST")
+	if host == "" {
+		host = "localhost"
+	}
+	port := 3306
+	if v := os.Getenv("MYSQL_PORT"); v != "" {
+		fmt.Sscanf(v, "%d", &port)
+	}
+	user := os.Getenv("MYSQL_USER")
+	if user == "" {
+		user = "root"
+	}
+	password := os.Getenv("MYSQL_PASSWORD")
+	if password == "" {
+		password = "root"
+	}
+	database := os.Getenv("MYSQL_DATABASE")
+	if database == "" {
+		database = "michelangelo"
+	}
+	return Config{Host: host, Port: port, User: user, Password: password, Database: database}
+}
+
+// openIntegrationDB connects to MySQL and returns the raw *sql.DB. The test is skipped
+// (not failed) when MySQL is unreachable so the suite stays green in CI without a DB.
+func openIntegrationDB(t *testing.T) *sql.DB {
+	t.Helper()
+	cfg := mysqlIntegrationConfig()
+	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?parseTime=true&loc=UTC",
+		cfg.User, cfg.Password, cfg.Host, cfg.Port, cfg.Database)
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Skipf("skipping integration test: cannot open MySQL: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := db.PingContext(ctx); err != nil {
+		t.Skipf("skipping integration test: MySQL unreachable at %s:%d: %v", cfg.Host, cfg.Port, err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+// newIntegrationStorage creates a mysqlMetadataStorage wired to the live DB.
+func newIntegrationStorage(t *testing.T, db *sql.DB) *mysqlMetadataStorage {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, v2pb.AddToScheme(s))
+	return &mysqlMetadataStorage{db: db, scheme: s}
+}
+
+// cleanupDeploymentRow removes rows created by the test so re-runs are idempotent.
+func cleanupDeploymentRow(t *testing.T, db *sql.DB, namespace, name string) {
+	t.Helper()
+	_, err := db.Exec("DELETE FROM deployment WHERE namespace=? AND name=?", namespace, name)
+	require.NoError(t, err)
+}
+
+// TestIntegration_MetadataStoragePrimaryKey_MigrationScenario exercises the full
+// cluster-migration flow end-to-end against a live MySQL:
+//
+//  1. Create a CR with MetadataStoragePrimaryKeyAnnotation set to its own UID ("cluster 1").
+//  2. Upsert to MySQL - verify a single row keyed by the original UID.
+//  3. Simulate migration: same name, new k8s UID ("cluster 2"), annotation still points
+//     to the original UID.
+//  4. Upsert again - the UPSERT must hit the existing row (no duplicate).
+//  5. Assert: still exactly one row, and its PK is the original UID.
+func TestIntegration_MetadataStoragePrimaryKey_MigrationScenario(t *testing.T) {
+	db := openIntegrationDB(t)
+	store := newIntegrationStorage(t, db)
+
+	const (
+		namespace   = "integration-test-ns"
+		name        = "migration-test-deployment"
+		originalUID = "original-cluster-uid-aaa111"
+		newUID      = "new-cluster-uid-bbb222"
+	)
+
+	t.Cleanup(func() { cleanupDeploymentRow(t, db, namespace, name) })
+
+	ctx := context.Background()
+
+	// --- Step 1: Upsert with original UID (first cluster) ---
+	cr1 := &v2pb.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "michelangelo.uber.com/v2",
+			Kind:       "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         namespace,
+			UID:               types.UID(originalUID),
+			ResourceVersion:   "1",
+			CreationTimestamp: metav1.Now(),
+			Annotations: map[string]string{
+				api.MetadataStoragePrimaryKeyAnnotation: originalUID,
+			},
+		},
+	}
+	require.NoError(t, store.Upsert(ctx, cr1, false, nil), "first Upsert must succeed")
+
+	// Verify exactly one row exists keyed by the original UID.
+	var storedUID string
+	var rowCount int
+	require.NoError(t,
+		db.QueryRowContext(ctx, "SELECT uid FROM deployment WHERE namespace=? AND name=?", namespace, name).
+			Scan(&storedUID),
+		"row must exist after first Upsert")
+	require.NoError(t,
+		db.QueryRowContext(ctx, "SELECT COUNT(*) FROM deployment WHERE namespace=? AND name=?", namespace, name).
+			Scan(&rowCount))
+	assert.Equal(t, 1, rowCount, "exactly one row after first Upsert")
+	assert.Equal(t, originalUID, storedUID, "PK must equal the original UID")
+
+	// --- Step 2: Simulate migration - same name, new k8s UID, annotation preserved ---
+	cr2 := &v2pb.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "michelangelo.uber.com/v2",
+			Kind:       "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         namespace,
+			UID:               types.UID(newUID), // new UID assigned by new cluster
+			ResourceVersion:   "1",
+			CreationTimestamp: metav1.Now(),
+			Annotations: map[string]string{
+				// operator preserved the annotation from the original CR
+				api.MetadataStoragePrimaryKeyAnnotation: originalUID,
+			},
+		},
+	}
+	require.NoError(t, store.Upsert(ctx, cr2, false, nil), "second Upsert (migration) must succeed")
+
+	// --- Step 3: Assert no duplicate row and stable PK ---
+	require.NoError(t,
+		db.QueryRowContext(ctx, "SELECT uid FROM deployment WHERE namespace=? AND name=?", namespace, name).
+			Scan(&storedUID),
+		"row must exist after migration Upsert")
+	require.NoError(t,
+		db.QueryRowContext(ctx, "SELECT COUNT(*) FROM deployment WHERE namespace=? AND name=?", namespace, name).
+			Scan(&rowCount))
+	assert.Equal(t, 1, rowCount, "still exactly one row after migration Upsert - no duplicate")
+	assert.Equal(t, originalUID, storedUID, "PK must still equal the original UID, not the new cluster UID")
+}
+
+// TestIntegration_MetadataStoragePrimaryKey_FallbackToUID verifies the backwards-compatible
+// path: when the annotation is absent the storage uses the object's UID as PK, and a
+// subsequent Upsert with the same UID updates the row in-place.
+func TestIntegration_MetadataStoragePrimaryKey_FallbackToUID(t *testing.T) {
+	db := openIntegrationDB(t)
+	store := newIntegrationStorage(t, db)
+
+	const (
+		namespace = "integration-test-ns"
+		name      = "fallback-uid-test-deployment"
+		uid       = "fallback-uid-ccc333"
+	)
+
+	t.Cleanup(func() { cleanupDeploymentRow(t, db, namespace, name) })
+
+	ctx := context.Background()
+
+	cr := &v2pb.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "michelangelo.uber.com/v2",
+			Kind:       "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         namespace,
+			UID:               types.UID(uid),
+			ResourceVersion:   "1",
+			CreationTimestamp: metav1.Now(),
+			// No MetadataStoragePrimaryKeyAnnotation - old behavior
+		},
+	}
+	require.NoError(t, store.Upsert(ctx, cr, false, nil))
+
+	var storedUID string
+	var rowCount int
+	require.NoError(t,
+		db.QueryRowContext(ctx, "SELECT uid FROM deployment WHERE namespace=? AND name=?", namespace, name).
+			Scan(&storedUID))
+	require.NoError(t,
+		db.QueryRowContext(ctx, "SELECT COUNT(*) FROM deployment WHERE namespace=? AND name=?", namespace, name).
+			Scan(&rowCount))
+	assert.Equal(t, 1, rowCount, "one row when annotation is absent")
+	assert.Equal(t, uid, storedUID, "PK falls back to the object UID when annotation is absent")
+}

--- a/go/storage/mysql/mysql_integration_test.go
+++ b/go/storage/mysql/mysql_integration_test.go
@@ -79,10 +79,18 @@ func newIntegrationStorage(t *testing.T, db *sql.DB) *mysqlMetadataStorage {
 }
 
 // cleanupDeploymentRow removes rows created by the test so re-runs are idempotent.
-func cleanupDeploymentRow(t *testing.T, db *sql.DB, namespace, name string) {
+// It clears the main table plus the label/annotation child tables for the given uids
+// (child rows are keyed by obj_uid, not namespace/name, so they must be cleaned by uid).
+func cleanupDeploymentRow(t *testing.T, db *sql.DB, namespace, name string, uids ...string) {
 	t.Helper()
 	_, err := db.Exec("DELETE FROM deployment WHERE namespace=? AND name=?", namespace, name)
 	require.NoError(t, err)
+	for _, uid := range uids {
+		_, err = db.Exec("DELETE FROM deployment_labels WHERE obj_uid=?", uid)
+		require.NoError(t, err)
+		_, err = db.Exec("DELETE FROM deployment_annotations WHERE obj_uid=?", uid)
+		require.NoError(t, err)
+	}
 }
 
 // TestIntegration_MetadataStoragePrimaryKey_MigrationScenario exercises the full
@@ -105,7 +113,7 @@ func TestIntegration_MetadataStoragePrimaryKey_MigrationScenario(t *testing.T) {
 		newUID      = "new-cluster-uid-bbb222"
 	)
 
-	t.Cleanup(func() { cleanupDeploymentRow(t, db, namespace, name) })
+	t.Cleanup(func() { cleanupDeploymentRow(t, db, namespace, name, originalUID, newUID) })
 
 	ctx := context.Background()
 
@@ -121,6 +129,9 @@ func TestIntegration_MetadataStoragePrimaryKey_MigrationScenario(t *testing.T) {
 			UID:               types.UID(originalUID),
 			ResourceVersion:   "1",
 			CreationTimestamp: metav1.Now(),
+			Labels: map[string]string{
+				"app": "migration-test",
+			},
 			Annotations: map[string]string{
 				api.MetadataStoragePrimaryKeyAnnotation: originalUID,
 			},
@@ -153,6 +164,9 @@ func TestIntegration_MetadataStoragePrimaryKey_MigrationScenario(t *testing.T) {
 			UID:               types.UID(newUID), // new UID assigned by new cluster
 			ResourceVersion:   "1",
 			CreationTimestamp: metav1.Now(),
+			Labels: map[string]string{
+				"app": "migration-test",
+			},
 			Annotations: map[string]string{
 				// operator preserved the annotation from the original CR
 				api.MetadataStoragePrimaryKeyAnnotation: originalUID,
@@ -171,6 +185,29 @@ func TestIntegration_MetadataStoragePrimaryKey_MigrationScenario(t *testing.T) {
 			Scan(&rowCount))
 	assert.Equal(t, 1, rowCount, "still exactly one row after migration Upsert - no duplicate")
 	assert.Equal(t, originalUID, storedUID, "PK must still equal the original UID, not the new cluster UID")
+
+	// --- Step 4: Assert child rows stay keyed by the stable PK (no orphans) ---
+	// The label/annotation child tables join back to the main row on obj_uid = uid.
+	// After migration they must be keyed by the original UID (the stable PK), and there
+	// must be no rows left under the new cluster UID.
+	var childUnderOriginal, childUnderNew int
+	require.NoError(t,
+		db.QueryRowContext(ctx, "SELECT COUNT(*) FROM deployment_labels WHERE obj_uid=?", originalUID).
+			Scan(&childUnderOriginal))
+	assert.Equal(t, 1, childUnderOriginal, "label rows must be keyed by the stable PK (original UID)")
+	require.NoError(t,
+		db.QueryRowContext(ctx, "SELECT COUNT(*) FROM deployment_labels WHERE obj_uid=?", newUID).
+			Scan(&childUnderNew))
+	assert.Equal(t, 0, childUnderNew, "no label rows may be orphaned under the new cluster UID")
+
+	require.NoError(t,
+		db.QueryRowContext(ctx, "SELECT COUNT(*) FROM deployment_annotations WHERE obj_uid=?", originalUID).
+			Scan(&childUnderOriginal))
+	assert.Positive(t, childUnderOriginal, "annotation rows must be keyed by the stable PK (original UID)")
+	require.NoError(t,
+		db.QueryRowContext(ctx, "SELECT COUNT(*) FROM deployment_annotations WHERE obj_uid=?", newUID).
+			Scan(&childUnderNew))
+	assert.Equal(t, 0, childUnderNew, "no annotation rows may be orphaned under the new cluster UID")
 }
 
 // TestIntegration_MetadataStoragePrimaryKey_FallbackToUID verifies the backwards-compatible
@@ -186,7 +223,7 @@ func TestIntegration_MetadataStoragePrimaryKey_FallbackToUID(t *testing.T) {
 		uid       = "fallback-uid-ccc333"
 	)
 
-	t.Cleanup(func() { cleanupDeploymentRow(t, db, namespace, name) })
+	t.Cleanup(func() { cleanupDeploymentRow(t, db, namespace, name, uid) })
 
 	ctx := context.Background()
 

--- a/go/storage/mysql/mysql_test.go
+++ b/go/storage/mysql/mysql_test.go
@@ -417,11 +417,11 @@ func TestExtractMatchValue_EmptyStringWrapperFallsThrough(t *testing.T) {
 
 func TestFullUpsert_StablePrimaryKey(t *testing.T) {
 	tests := []struct {
-		name                  string
-		uid                   string
-		annotations           map[string]string
-		expectedPrimaryKey    string
-		description           string
+		name               string
+		uid                string
+		annotations        map[string]string
+		expectedPrimaryKey string
+		description        string
 	}{
 		{
 			name:               "uses UID when no annotation",
@@ -449,8 +449,8 @@ func TestFullUpsert_StablePrimaryKey(t *testing.T) {
 			uid:  "uid-xyz-456",
 			annotations: map[string]string{
 				"michelangelo/MetadataStoragePrimaryKey": "stable-pk-999",
-				"michelangelo/Immutable":                  "true",
-				"other-annotation":                        "some-value",
+				"michelangelo/Immutable":                 "true",
+				"other-annotation":                       "some-value",
 			},
 			expectedPrimaryKey: "stable-pk-999",
 			description:        "Stable PK works alongside other annotations",
@@ -462,12 +462,12 @@ func TestFullUpsert_StablePrimaryKey(t *testing.T) {
 			// Create a mock object with UID and annotations
 			obj := &v2pb.PipelineRun{
 				ObjectMeta: metav1.ObjectMeta{
-					UID:                types.UID(tt.uid),
-					Name:               "test-pipeline",
-					Namespace:          "default",
-					ResourceVersion:    "1",
-					CreationTimestamp:  metav1.Now(),
-					Annotations:        tt.annotations,
+					UID:               types.UID(tt.uid),
+					Name:              "test-pipeline",
+					Namespace:         "default",
+					ResourceVersion:   "1",
+					CreationTimestamp: metav1.Now(),
+					Annotations:       tt.annotations,
 				},
 				Spec: v2pb.PipelineRunSpec{},
 			}

--- a/go/storage/mysql/mysql_test.go
+++ b/go/storage/mysql/mysql_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 
 	apipb "github.com/michelangelo-ai/michelangelo/proto-go/api"
 	v2pb "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
@@ -412,4 +413,144 @@ func TestExtractMatchValue_EmptyStringWrapperFallsThrough(t *testing.T) {
 	v, err := extractMatchValue(any)
 	require.NoError(t, err)
 	require.Equal(t, "", v)
+}
+
+func TestFullUpsert_StablePrimaryKey(t *testing.T) {
+	tests := []struct {
+		name                  string
+		uid                   string
+		annotations           map[string]string
+		expectedPrimaryKey    string
+		description           string
+	}{
+		{
+			name:               "uses UID when no annotation",
+			uid:                "uid-abc-123",
+			annotations:        nil,
+			expectedPrimaryKey: "uid-abc-123",
+			description:        "Default behavior: use K8s UID as primary key",
+		},
+		{
+			name:               "uses UID when annotation empty",
+			uid:                "uid-abc-123",
+			annotations:        map[string]string{"michelangelo/MetadataStoragePrimaryKey": ""},
+			expectedPrimaryKey: "uid-abc-123",
+			description:        "Empty annotation falls back to UID",
+		},
+		{
+			name:               "uses annotation when present",
+			uid:                "uid-new-789",
+			annotations:        map[string]string{"michelangelo/MetadataStoragePrimaryKey": "uid-original-123"},
+			expectedPrimaryKey: "uid-original-123",
+			description:        "Stable PK preserved across cluster migration",
+		},
+		{
+			name: "uses annotation with other annotations",
+			uid:  "uid-xyz-456",
+			annotations: map[string]string{
+				"michelangelo/MetadataStoragePrimaryKey": "stable-pk-999",
+				"michelangelo/Immutable":                  "true",
+				"other-annotation":                        "some-value",
+			},
+			expectedPrimaryKey: "stable-pk-999",
+			description:        "Stable PK works alongside other annotations",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a mock object with UID and annotations
+			obj := &v2pb.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:                types.UID(tt.uid),
+					Name:               "test-pipeline",
+					Namespace:          "default",
+					ResourceVersion:    "1",
+					CreationTimestamp:  metav1.Now(),
+					Annotations:        tt.annotations,
+				},
+				Spec: v2pb.PipelineRunSpec{},
+			}
+
+			// Extract the primary key using the same logic as fullUpsert
+			metaObj := obj.GetObjectMeta()
+			primaryKey := string(metaObj.GetUID())
+			if annotations := metaObj.GetAnnotations(); annotations != nil {
+				if storagePK, exists := annotations["michelangelo/MetadataStoragePrimaryKey"]; exists && storagePK != "" {
+					primaryKey = storagePK
+				}
+			}
+
+			// Verify the primary key matches expected
+			require.Equal(t, tt.expectedPrimaryKey, primaryKey, tt.description)
+		})
+	}
+}
+
+func TestFullUpsert_CrossClusterMigration(t *testing.T) {
+	// This test simulates a cross-cluster migration scenario:
+	// 1. Original cluster: CR with UID abc-123, annotation set to abc-123
+	// 2. New cluster: Same CR recreated with UID xyz-789, annotation preserved as abc-123
+	// 3. Result: Both use same primary key (abc-123), no duplicate records
+
+	originalUID := "uid-abc-123"
+	newUID := "uid-xyz-789"
+
+	// Step 1: Original cluster - first creation
+	originalObj := &v2pb.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:               types.UID(originalUID),
+			Name:              "my-pipeline",
+			Namespace:         "default",
+			ResourceVersion:   "1",
+			CreationTimestamp: metav1.Now(),
+			Annotations: map[string]string{
+				"michelangelo/MetadataStoragePrimaryKey": originalUID,
+			},
+		},
+	}
+
+	// Extract PK for original object
+	metaObjOriginal := originalObj.GetObjectMeta()
+	primaryKeyOriginal := string(metaObjOriginal.GetUID())
+	if annotations := metaObjOriginal.GetAnnotations(); annotations != nil {
+		if storagePK, exists := annotations["michelangelo/MetadataStoragePrimaryKey"]; exists && storagePK != "" {
+			primaryKeyOriginal = storagePK
+		}
+	}
+
+	require.Equal(t, originalUID, primaryKeyOriginal, "Original cluster uses original UID as PK")
+
+	// Step 2: New cluster - recreated with different UID but preserved annotation
+	newObj := &v2pb.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:               types.UID(newUID), // NEW UID from new cluster
+			Name:              "my-pipeline",
+			Namespace:         "default",
+			ResourceVersion:   "1",
+			CreationTimestamp: metav1.Now(),
+			Annotations: map[string]string{
+				"michelangelo/MetadataStoragePrimaryKey": originalUID, // PRESERVED annotation
+			},
+		},
+	}
+
+	// Extract PK for new object
+	metaObjNew := newObj.GetObjectMeta()
+	primaryKeyNew := string(metaObjNew.GetUID())
+	if annotations := metaObjNew.GetAnnotations(); annotations != nil {
+		if storagePK, exists := annotations["michelangelo/MetadataStoragePrimaryKey"]; exists && storagePK != "" {
+			primaryKeyNew = storagePK
+		}
+	}
+
+	require.Equal(t, originalUID, primaryKeyNew, "New cluster uses preserved annotation as PK")
+
+	// Step 3: Verify both use the same primary key
+	require.Equal(t, primaryKeyOriginal, primaryKeyNew,
+		"Both original and new cluster use same PK - no duplicate records!")
+
+	// Verify the UIDs are actually different
+	require.NotEqual(t, string(metaObjOriginal.GetUID()), string(metaObjNew.GetUID()),
+		"UIDs are different across clusters as expected")
 }


### PR DESCRIPTION
Add annotation-based stable primary key for metadata storage to solve the UID mismatch problem when migrating CRs across Kubernetes clusters.

Problem:
- K8s UID changes when recreating CRs in new cluster
- Metadata storage (MySQL/Postgres) uses UID as primary key
- Ingester syncs CRs to metadata storage on recreation
- Result: duplicate records (old UID + new UID) for same resource

Solution:
- New annotation: michelangelo/MetadataStoragePrimaryKey
- Metadata storage uses annotation value if present, else falls back to UID
- Enables stable identity across cluster migrations
- Set annotation value before migration to preserve PK

Changes:
- go/api/api.go: Define MetadataStoragePrimaryKeyAnnotation constant
- go/storage/mysql/mysql.go: Check annotation in fullUpsert, use as PK

Benefits:
- No duplicate records when recreating CRs with same name
- Stable foreign key references across migrations
- Database agnostic (works with MySQL, Postgres, etc)
- Backwards compatible (falls back to UID if annotation not present)
- Enables true disaster recovery scenarios

Usage:
Set the annotation before migrating to a new cluster:
  kubectl annotate pipelinerun my-run \
    michelangelo/MetadataStoragePrimaryKey=$(kubectl get pipelinerun my-run -o jsonpath='{.metadata.uid}')

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
