### PR TITLE
Make michelangelo a shared-namespace package via pkgutil.extend_path

### DIFF
--- a/python/michelangelo/__init__.py
+++ b/python/michelangelo/__init__.py
@@ -1,0 +1,14 @@
+"""Michelangelo package init — declares a shared-namespace package.
+
+`michelangelo` is a shared-namespace package: contents from multiple
+``sys.path`` entries merge into one logical package. The legacy
+:func:`pkgutil.extend_path` form is used (rather than PEP 420) to keep
+``__file__`` defined and to remain compatible with downstream consumers
+that previously treated this as a regular package.
+
+Bazel / PEX consumers that bundle the wheel alongside separately-generated
+proto stubs (e.g. from local IDL trees) need cross-``sys.path`` merging to
+import ``michelangelo.api.*``.
+"""
+
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/python/michelangelo/__init___test.py
+++ b/python/michelangelo/__init___test.py
@@ -1,0 +1,70 @@
+"""Tests for the michelangelo package's namespace-package declaration.
+
+`michelangelo/__init__.py` calls :func:`pkgutil.extend_path` so that contents
+from multiple ``sys.path`` entries merge into one logical package. This is
+needed by bazel / PEX consumers that bundle the wheel alongside separately
+generated proto stubs.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+
+
+class NamespacePackageTest(TestCase):
+    """Verify michelangelo behaves as a shared-namespace package."""
+
+    def test_import_succeeds(self):
+        """Smoke test: the package still imports cleanly after the change."""
+        import michelangelo
+
+        self.assertTrue(hasattr(michelangelo, "__path__"))
+        self.assertTrue(hasattr(michelangelo, "__file__"))
+
+    def test_path_is_a_list_of_strings(self):
+        """`__path__` is the standard list-of-paths shape after extend_path."""
+        import michelangelo
+
+        paths = list(michelangelo.__path__)
+        self.assertGreaterEqual(len(paths), 1)
+        for p in paths:
+            self.assertIsInstance(p, str)
+
+    def test_extends_across_sys_path(self):
+        """Confirm cross-sys.path merge — the structural win.
+
+        Drop a fake ``michelangelo/extra.py`` on a second sys.path entry and
+        confirm it becomes importable as ``michelangelo.extra``.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fake_pkg_dir = Path(tmpdir) / "michelangelo"
+            fake_pkg_dir.mkdir()
+            (fake_pkg_dir / "extra_for_namespace_test.py").write_text(
+                "VALUE = 'merged'"
+            )
+
+            sys.path.insert(0, tmpdir)
+            try:
+                # Force a re-read of michelangelo.__path__ so extend_path picks up
+                # the new sys.path entry on this import.
+                import michelangelo
+
+                importlib.reload(michelangelo)
+                self.assertIn(str(fake_pkg_dir), list(michelangelo.__path__))
+
+                from michelangelo import (
+                    extra_for_namespace_test,  # type: ignore[attr-defined]
+                )
+
+                self.assertEqual(extra_for_namespace_test.VALUE, "merged")
+            finally:
+                sys.path.remove(tmpdir)
+                sys.modules.pop("michelangelo.extra_for_namespace_test", None)
+                # Reload one more time to drop the fake path from __path__.
+                import michelangelo
+
+                importlib.reload(michelangelo)


### PR DESCRIPTION
## Summary

Replaces empty `michelangelo/__init__.py` with the one-line `pkgutil.extend_path` declaration. Makes `michelangelo` a shared-namespace package so its contents can come from multiple `sys.path` entries. Zero behavior change when only one source provides `michelangelo/`.

## Motivation

Empty `__init__.py` works for `pip install michelangelo` (one wheel, one site-packages dir). It breaks the moment a consumer ships additional content under `michelangelo.*` from a different `sys.path` entry — e.g. a bazel / PEX consumer that bundles the wheel **and** generates proto stubs from a local IDL tree. Python currently resolves `michelangelo` to the wheel directory only and raises `ModuleNotFoundError` on `michelangelo.api.options_pb2` even though the file exists at the other entry. `pkgutil.extend_path` fixes this.

`extend_path` (legacy declarative) over PEP 420 (remove file): keeps `__file__` defined, no static-analyzer config tweaks, standard pattern used by numpy / scipy / sphinx / flask.

## Test plan

| command | run | verified |
|---|---|---|
| `pytest python/michelangelo/__init___test.py -v` | yes | 3/3 pass (smoke import, `__path__` shape, cross-`sys.path` merge) |
| `ruff check` + `ruff format --check` on both files | yes | clean |
| Manual cross-dir: `mkdir /tmp/fake/michelangelo && echo "V='ok'">/tmp/fake/michelangelo/x.py && PYTHONPATH=python:/tmp/fake python3 -c "from michelangelo import x; print(x.V)"` | yes | prints `ok` (vs `ModuleNotFoundError` on main) |