### PR TITLE
docs(operator-guides): add notification delivery setup guide

### DIFF
--- a/docs/operator-guides/index.md
+++ b/docs/operator-guides/index.md
@@ -58,6 +58,7 @@ Michelangelo is designed to run alongside existing ML infrastructure. The guides
 | Guide | Description |
 |-------|-------------|
 | [Experiment Tracking Setup](experiment-tracking.md) | Make an experiment tracking server reachable from task pods — network, ConfigMap injection, auth, and operator/user boundary |
+| [Notification Delivery Setup](notifications.md) | Wire in email and Slack delivery for PipelineRun state-change notifications — task queue config, activity implementation, and verification |
 | [Browse all integrations](integrations/index.md) | MLflow and other third-party integration guides |
 
 ## Operations

--- a/docs/operator-guides/notifications.md
+++ b/docs/operator-guides/notifications.md
@@ -1,0 +1,243 @@
+# Notification Delivery Setup
+
+Michelangelo does not bundle an email or Slack delivery service — it provides a notification workflow that calls pluggable activity functions when a PipelineRun changes state. By default those functions are no-ops. This guide shows platform operators how to wire in real delivery by implementing the activity functions in their own worker binary.
+
+It covers the notification flow, Helm configuration, how to implement email and Slack delivery, supported event types, and verification.
+
+---
+
+## How Notifications Work
+
+When a PipelineRun transitions to a terminal state, the controller manager starts a `PRNotificationWorkflow` on the `notification_worker` Temporal or Cadence task queue. The worker picks it up and executes one activity per configured channel.
+
+```text
+┌─────────────────────────────────────────────────┐
+│ controller manager                              │
+│ ├─ Detects PipelineRun state transition         │
+│ └─ Starts PRNotificationWorkflow                │
+│    └─ task queue: notification_worker           │
+└───────────────────────┬─────────────────────────┘
+                        │ Temporal / Cadence
+                        ▼
+┌─────────────────────────────────────────────────┐
+│ worker                                          │
+│ ├─ SendMessageToEmailActivity (no-op by default)│
+│ └─ SendMessageToSlackActivity (no-op by default)│
+└─────────────────────────────────────────────────┘
+```
+
+**Operators** implement the activity functions and register them in the worker binary.
+**Users** annotate their PipelineRun specs with the channels and event types they want notified.
+
+---
+
+## Prerequisites
+
+- A running Temporal or Cadence cluster reachable from the worker pod.
+- The worker Helm release is deployed (see [Platform Setup](setup/platform-setup.md)).
+- Ability to build and push a custom worker image, or to fork the `go/cmd/worker` package.
+
+---
+
+## Step 1: Enable the `notification_worker` Task Queue
+
+The worker listens on multiple task queues. Add `notification_worker` to the `taskLists` array in your Helm values:
+
+```yaml
+workflow:
+  # ... host, provider, domain ...
+  taskLists:
+    - default
+    - trigger_run
+    - pipeline_run
+    - notification_worker   # add this
+```
+
+Apply with:
+
+```bash
+helm upgrade michelangelo ./helm/michelangelo -f values.yaml
+```
+
+Restart the worker pod to pick up the new task queue:
+
+```bash
+kubectl rollout restart deployment/michelangelo-worker -n <release-namespace>
+```
+
+---
+
+## Step 2: Implement Delivery
+
+Both activity functions in `go/worker/activities/notification/activities.go` are no-ops with a `TODO` comment. You have two paths:
+
+### Option A — Override with `fx.Decorate` (recommended)
+
+In your fork of `go/cmd/worker/main.go`, use `fx.Decorate` to replace the activity implementations without modifying the shared package:
+
+```go
+import (
+    notificationactivities "github.com/michelangelo-ai/michelangelo/go/worker/activities/notification"
+    "go.uber.org/fx"
+)
+
+func options() fx.Option {
+    return fx.Options(
+        // ... existing modules ...
+
+        fx.Decorate(func() notificationactivities.EmailSender {
+            return &myEmailClient{}
+        }),
+        fx.Decorate(func() notificationactivities.SlackSender {
+            return &mySlackClient{}
+        }),
+    )
+}
+```
+
+Implement `myEmailClient` and `mySlackClient` to call your organization's email and Slack APIs.
+
+### Option B — Edit the activity functions directly
+
+Open `go/worker/activities/notification/activities.go` and replace the placeholder bodies of `SendMessageToEmailActivity` and `SendMessageToSlackActivity` with real delivery logic. This is simpler for single-organization deployments.
+
+#### Email activity signature
+
+```go
+func SendMessageToEmailActivity(ctx context.Context, req *SendMessageToEmailActivityRequest) error
+```
+
+`SendMessageToEmailActivityRequest` fields:
+
+| Field     | Type       | Description                          |
+|-----------|------------|--------------------------------------|
+| `To`      | `[]string` | Recipient email addresses            |
+| `Cc`      | `[]string` | CC addresses (optional)              |
+| `Bcc`     | `[]string` | BCC addresses (optional)             |
+| `Subject` | `string`   | Generated subject line               |
+| `ReplyTo` | `string`   | Reply-to address (optional)          |
+| `HTML`    | `string`   | HTML body (optional)                 |
+| `Text`    | `string`   | Plain-text body                      |
+| `SendAs`  | `string`   | Sender address shown to recipient    |
+
+#### Slack activity signature
+
+```go
+func SendMessageToSlackActivity(ctx context.Context, req *SendMessageToSlackActivityRequest) error
+```
+
+`SendMessageToSlackActivityRequest` fields:
+
+| Field     | Type     | Description                |
+|-----------|----------|----------------------------|
+| `Channel` | `string` | Slack channel ID or name   |
+| `Text`    | `string` | Formatted message text     |
+
+---
+
+## Step 3: Configure Notifications on a PipelineRun
+
+Users add a `notifications` block to their PipelineRun spec. No operator action is needed for this step — it is shown here so you can verify end-to-end behavior.
+
+```yaml
+apiVersion: michelangelo.api/v2
+kind: PipelineRun
+metadata:
+  name: my-training-run
+  namespace: my-project
+spec:
+  pipeline:
+    name: my-training-pipeline
+    namespace: my-project
+  notifications:
+    - notificationType: NOTIFICATION_TYPE_EMAIL
+      resourceType: RESOURCE_TYPE_PIPELINE_RUN
+      emails:
+        - alice@example.com
+        - oncall@example.com
+      eventTypes:
+        - EVENT_TYPE_PIPELINE_RUN_STATE_SUCCEEDED
+        - EVENT_TYPE_PIPELINE_RUN_STATE_FAILED
+    - notificationType: NOTIFICATION_TYPE_SLACK
+      resourceType: RESOURCE_TYPE_PIPELINE_RUN
+      slackDestinations:
+        - "#ml-alerts"
+      eventTypes:
+        - EVENT_TYPE_PIPELINE_RUN_STATE_FAILED
+```
+
+### Supported event types
+
+| Event type                             | Triggers when                    |
+|----------------------------------------|----------------------------------|
+| `EVENT_TYPE_PIPELINE_RUN_STATE_SUCCEEDED` | Run completed successfully    |
+| `EVENT_TYPE_PIPELINE_RUN_STATE_FAILED`    | Run failed                    |
+| `EVENT_TYPE_PIPELINE_RUN_STATE_KILLED`    | Run was killed                |
+| `EVENT_TYPE_PIPELINE_RUN_STATE_SKIPPED`   | Run was skipped               |
+
+---
+
+## Message Body
+
+The workflow builds subject lines and message bodies automatically from the PipelineRun name, namespace, state, and a Studio URL. The Studio URL is constructed from the constant `_defaultMaURL` in `go/base/notification/types/types.go`. To point it at your own Michelangelo Studio deployment, update that constant and rebuild the worker image.
+
+Example email subject:
+```
+Pipeline Run (my-training-run) has completed with state FAILED
+```
+
+Example Slack message:
+```
+Pipeline Run (my-training-run) has completed with state FAILED:
+- Name: my-training-run
+- Project: my-project
+- State: FAILED
+- Pipeline Type: TRAIN
+- <https://michelangelo.your-org.com/ma/my-project/train/my-training-run|Michelangelo Studio URL>
+```
+
+---
+
+## Verification
+
+### Worker startup logs
+
+After deploying the worker with `notification_worker` in `taskLists`, check the worker pod logs:
+
+```bash
+kubectl logs -n <release-namespace> deployment/michelangelo-worker | grep notification_worker
+```
+
+You should see:
+
+```
+INFO  Started Worker  {"TaskQueue": "notification_worker", "WorkerID": "..."}
+```
+
+If this line is absent, verify that `notification_worker` is in `workflow.taskLists` in your Helm values and that the worker pod was restarted after the upgrade.
+
+### Temporal / Cadence workflow history
+
+To confirm that the workflow fired and the activities ran:
+
+```bash
+# Temporal
+temporal workflow show --workflow-id "<namespace>.<run-name>.notification" --namespace default
+
+# Cadence
+cadence --domain default workflow show --workflow_id "<namespace>.<run-name>.notification"
+```
+
+A successful run shows `ActivityTaskCompleted` events for `SendMessageToEmailActivity` and/or `SendMessageToSlackActivity`.
+
+### Activity no-op check
+
+If the workflow history shows `ActivityTaskCompleted` but no emails or Slack messages arrived, the activity implementations are still no-ops. Confirm you have replaced them with real delivery logic and rebuilt the worker image.
+
+---
+
+## Next Steps
+
+- [Platform Setup](setup/platform-setup.md) — configure workflow engine endpoints and task queue settings for the worker
+- [Helm Chart](helm-chart.md) — full `values.yaml` reference including `workflow.taskLists`
+- [Jobs Overview](jobs/index.md) — understand how PipelineRuns are scheduled and what triggers state transitions

--- a/docs/operator-guides/notifications.md
+++ b/docs/operator-guides/notifications.md
@@ -71,8 +71,6 @@ kubectl rollout restart deployment/michelangelo-worker -n <release-namespace>
 
 Both activity functions in `go/worker/activities/notification/activities.go` are no-ops with a `TODO` comment. You have two paths:
 
-### Option A — Override with `fx.Decorate` (recommended)
-
 In your fork of `go/cmd/worker/main.go`, use `fx.Decorate` to replace the activity implementations without modifying the shared package:
 
 ```go
@@ -96,10 +94,6 @@ func options() fx.Option {
 ```
 
 Implement `myEmailClient` and `mySlackClient` to call your organization's email and Slack APIs.
-
-### Option B — Edit the activity functions directly
-
-Open `go/worker/activities/notification/activities.go` and replace the placeholder bodies of `SendMessageToEmailActivity` and `SendMessageToSlackActivity` with real delivery logic. This is simpler for single-organization deployments.
 
 #### Email activity signature
 

--- a/docs/operator-guides/notifications.md
+++ b/docs/operator-guides/notifications.md
@@ -1,6 +1,6 @@
 # Notification Delivery Setup
 
-Michelangelo does not bundle an email or Slack delivery service — it provides a notification workflow that calls pluggable activity functions when a PipelineRun changes state. By default those functions are no-ops. This guide shows platform operators how to wire in real delivery by implementing the activity functions in their own worker binary.
+Michelangelo does not bundle an email or Slack delivery service — it provides a notification workflow that calls pluggable activity functions when a PipelineRun changes state. By default those functions are no-ops that log a warning. This guide shows platform operators how to wire in real delivery by replacing the default Sink implementations.
 
 It covers the notification flow, Helm configuration, how to implement email and Slack delivery, supported event types, and verification.
 
@@ -8,26 +8,27 @@ It covers the notification flow, Helm configuration, how to implement email and 
 
 ## How Notifications Work
 
-When a PipelineRun transitions to a terminal state, the controller manager starts a `PRNotificationWorkflow` on the `notification_worker` Temporal or Cadence task queue. The worker picks it up and executes one activity per configured channel.
+When a PipelineRun transitions to a matching state, the controller manager starts an `io.michelangelo.notification.PipelineRunFanout` workflow on the `notification_worker` Temporal or Cadence task queue. The worker picks it up and fans out to each configured Sink (one per channel type).
 
 ```text
 ┌─────────────────────────────────────────────────┐
 │ controller manager                              │
 │ ├─ Detects PipelineRun state transition         │
-│ └─ Starts PRNotificationWorkflow                │
-│    └─ task queue: notification_worker           │
+│ └─ Starts PipelineRunFanout workflow            │
+│    └─ task queue: notification_worker            │
 └───────────────────────┬─────────────────────────┘
                         │ Temporal / Cadence
                         ▼
 ┌─────────────────────────────────────────────────┐
 │ worker                                          │
-│ ├─ SendMessageToEmailActivity (no-op by default)│
-│ └─ SendMessageToSlackActivity (no-op by default)│
+│ ├─ EmailSink → SendMessageToEmailActivity       │
+│ ├─ SlackSink → SendMessageToSlackActivity       │
+│ └─ (custom sinks: PagerDuty, Teams, etc.)       │
 └─────────────────────────────────────────────────┘
 ```
 
-**Operators** implement the activity functions and register them in the worker binary.
-**Users** annotate their PipelineRun specs with the channels and event types they want notified.
+**Operators** replace the default Sink implementations (or add new ones) and configure Helm values.
+**Users** annotate their PipelineRun specs with the channels and event types they want notified — see [Pipeline Notifications](../user-guides/ml-pipelines/notifications.md) for the user-facing guide.
 
 ---
 
@@ -39,9 +40,9 @@ When a PipelineRun transitions to a terminal state, the controller manager start
 
 ---
 
-## Step 1: Enable the `notification_worker` Task Queue
+## Step 1: Verify Helm Configuration
 
-The worker listens on multiple task queues. Add `notification_worker` to the `taskLists` array in your Helm values:
+The `notification_worker` task queue is included in the default Helm values. Verify it is present in your `values.yaml`:
 
 ```yaml
 workflow:
@@ -49,33 +50,38 @@ workflow:
   taskLists:
     - default
     - trigger_run
-    - pipeline_run
-    - notification_worker   # add this
+    - notification_worker
 ```
 
-Apply with:
+Configure the notification settings — the Studio base URL enables deep links in messages, and the sender email sets the From address for outgoing email:
+
+```yaml
+notification:
+  taskList: notification_worker
+  studioBaseURL: "https://ml.mycompany.com/studio/"   # leave empty to omit links
+  senderEmail: "notifications@mycompany.com"           # used as the email From address
+```
+
+Apply and restart:
 
 ```bash
 helm upgrade michelangelo ./helm/michelangelo -f values.yaml
-```
-
-Restart the worker pod to pick up the new task queue:
-
-```bash
 kubectl rollout restart deployment/michelangelo-worker -n <release-namespace>
 ```
+
+:::tip
+Set `notification.taskList` to `""` to disable notifications entirely — the controller manager will skip dispatch.
+:::
 
 ---
 
 ## Step 2: Implement Delivery
 
-Both activity functions in `go/worker/activities/notification/activities.go` are no-ops with a `TODO` comment. You have two paths:
-
-In your fork of `go/cmd/worker/main.go`, use `fx.Decorate` to replace the activity implementations without modifying the shared package:
+The default `EmailSink` and `SlackSink` call activity functions that are no-ops — they log a warning (`no-op: no transport configured`) and return nil. The recommended approach uses `fx.Decorate` to replace the default Sink list without modifying the shared package:
 
 ```go
 import (
-    notificationactivities "github.com/michelangelo-ai/michelangelo/go/worker/activities/notification"
+    notification "github.com/michelangelo-ai/michelangelo/go/worker/workflows/notification"
     "go.uber.org/fx"
 )
 
@@ -83,17 +89,37 @@ func options() fx.Option {
     return fx.Options(
         // ... existing modules ...
 
-        fx.Decorate(func() notificationactivities.EmailSender {
-            return &myEmailClient{}
-        }),
-        fx.Decorate(func() notificationactivities.SlackSender {
-            return &mySlackClient{}
+        // Replace default sinks with real delivery implementations.
+        fx.Decorate(func() []notification.Sink {
+            return []notification.Sink{
+                &myEmailSink{},   // implements notification.Sink
+                &mySlackSink{},   // implements notification.Sink
+            }
         }),
     )
 }
 ```
 
-Implement `myEmailClient` and `mySlackClient` to call your organization's email and Slack APIs.
+Each Sink must implement the `notification.Sink` interface:
+
+```go
+type Sink interface {
+    Notify(ctx workflow.Context, logger *zap.Logger, notif *v2pb.Notification, msg Message) error
+}
+```
+
+The `Message` struct passed to each Sink contains:
+
+| Field             | Type                | Description                                      |
+|-------------------|---------------------|--------------------------------------------------|
+| `Subject`         | `string`            | Short summary line (e.g. email subject)          |
+| `Body`            | `string`            | Plain-text body, suitable for any channel        |
+| `FormattedBodies` | `map[string]string` | Format-specific overrides (e.g. `text/html`, `text/slack`) |
+| `SendAs`          | `string`            | Sender identity (e.g. email From address)        |
+
+Each Sink checks `FormattedBodies` for its preferred format and falls back to `Body`. See the built-in `EmailSink` and `SlackSink` in `go/worker/workflows/notification/sinks.go` for reference implementations.
+
+Alternatively, you can directly replace the activity function bodies in `go/worker/activities/notification/activities.go` and rebuild the worker image. This is simpler but less portable across upgrades.
 
 #### Email activity signature
 
@@ -131,7 +157,7 @@ func SendMessageToSlackActivity(ctx context.Context, req *SendMessageToSlackActi
 
 ## Step 3: Configure Notifications on a PipelineRun
 
-Users add a `notifications` block to their PipelineRun spec. No operator action is needed for this step — it is shown here so you can verify end-to-end behavior.
+Users add a `notifications` block to their PipelineRun spec. No operator action is needed for this step — it is shown here so you can verify end-to-end behavior. For the full user-facing guide including CLI shorthand and all event types, see [Pipeline Notifications](../user-guides/ml-pipelines/notifications.md).
 
 ```yaml
 apiVersion: michelangelo.api/v2
@@ -160,35 +186,44 @@ spec:
         - EVENT_TYPE_PIPELINE_RUN_STATE_FAILED
 ```
 
-### Supported event types
-
-| Event type                             | Triggers when                    |
-|----------------------------------------|----------------------------------|
-| `EVENT_TYPE_PIPELINE_RUN_STATE_SUCCEEDED` | Run completed successfully    |
-| `EVENT_TYPE_PIPELINE_RUN_STATE_FAILED`    | Run failed                    |
-| `EVENT_TYPE_PIPELINE_RUN_STATE_KILLED`    | Run was killed                |
-| `EVENT_TYPE_PIPELINE_RUN_STATE_SKIPPED`   | Run was skipped               |
+For the full list of supported event types and resource types, see [Event Types](../user-guides/ml-pipelines/notifications.md#event-types) in the user guide.
 
 ---
 
 ## Message Body
 
-The workflow builds subject lines and message bodies automatically from the PipelineRun name, namespace, state, and a Studio URL. The Studio URL is constructed from the constant `_defaultMaURL` in `go/base/notification/types/types.go`. To point it at your own Michelangelo Studio deployment, update that constant and rebuild the worker image.
+The workflow builds subject lines and message bodies automatically from the PipelineRun name, namespace, state, and Studio URL (configured via `notification.studioBaseURL` in Helm values).
 
 Example email subject:
 ```
-Pipeline Run (my-training-run) has completed with state FAILED
+Pipeline Run (my-training-run) state: FAILED
 ```
 
-Example Slack message:
+Example email body:
 ```
-Pipeline Run (my-training-run) has completed with state FAILED:
+Pipeline Run Status Update:
 - Name: my-training-run
 - Project: my-project
 - State: FAILED
 - Pipeline Type: TRAIN
-- <https://michelangelo.your-org.com/ma/my-project/train/my-training-run|Michelangelo Studio URL>
+- Studio URL: https://ml.mycompany.com/studio/my-project/train/runs/my-training-run
 ```
+
+Example Slack message (mrkdwn):
+```
+Pipeline Run (my-training-run) state: FAILED:
+- Name: my-training-run
+- Project: my-project
+- State: FAILED
+- Pipeline Type: TRAIN
+- <https://ml.mycompany.com/studio/my-project/train/runs/my-training-run|Studio URL>
+```
+
+---
+
+## Upgrade Notes
+
+If upgrading from a previous release, the workflow name changed from `PRNotificationWorkflow` to `io.michelangelo.notification.PipelineRunFanout`. The worker registers the old name as a deprecated alias so that in-flight workflows dispatched by a pre-upgrade controller manager can drain (up to 60h `ExecutionStartToCloseTimeout`). The alias will be removed in a future release — no operator action is needed for the transition.
 
 ---
 
@@ -196,7 +231,7 @@ Pipeline Run (my-training-run) has completed with state FAILED:
 
 ### Worker startup logs
 
-After deploying the worker with `notification_worker` in `taskLists`, check the worker pod logs:
+After deploying the worker, check the pod logs for the notification task queue:
 
 ```bash
 kubectl logs -n <release-namespace> deployment/michelangelo-worker | grep notification_worker
@@ -210,28 +245,41 @@ INFO  Started Worker  {"TaskQueue": "notification_worker", "WorkerID": "..."}
 
 If this line is absent, verify that `notification_worker` is in `workflow.taskLists` in your Helm values and that the worker pod was restarted after the upgrade.
 
+If you haven't replaced the default Sinks yet, you'll also see warnings when notifications fire:
+
+```
+WARN  SendMessageToEmailActivity called (no-op: no transport configured)
+WARN  SendMessageToSlackActivity called (no-op: no transport configured)
+```
+
+These confirm the workflow is dispatching correctly — replace the Sinks with real delivery to stop seeing them.
+
 ### Temporal / Cadence workflow history
 
-To confirm that the workflow fired and the activities ran:
+To confirm that the workflow fired and the activities ran, use the state-scoped workflow ID format `<namespace>.<run-name>.notification.<state>`:
 
 ```bash
 # Temporal
-temporal workflow show --workflow-id "<namespace>.<run-name>.notification" --namespace default
+temporal workflow show \
+  --workflow-id "my-project.my-training-run.notification.failed" \
+  --namespace default
 
 # Cadence
-cadence --domain default workflow show --workflow_id "<namespace>.<run-name>.notification"
+cadence --domain default workflow show \
+  --workflow_id "my-project.my-training-run.notification.failed"
 ```
 
 A successful run shows `ActivityTaskCompleted` events for `SendMessageToEmailActivity` and/or `SendMessageToSlackActivity`.
 
 ### Activity no-op check
 
-If the workflow history shows `ActivityTaskCompleted` but no emails or Slack messages arrived, the activity implementations are still no-ops. Confirm you have replaced them with real delivery logic and rebuilt the worker image.
+If the workflow history shows `ActivityTaskCompleted` but no emails or Slack messages arrived, the Sink implementations are still no-ops. Confirm you have replaced them with real delivery logic (see [Step 2](#step-2-implement-delivery)) and rebuilt the worker image.
 
 ---
 
 ## Next Steps
 
+- [Pipeline Notifications (user guide)](../user-guides/ml-pipelines/notifications.md) — how users configure notification rules on their specs
 - [Platform Setup](setup/platform-setup.md) — configure workflow engine endpoints and task queue settings for the worker
-- [Helm Chart](helm-chart.md) — full `values.yaml` reference including `workflow.taskLists`
+- [Helm Chart](helm-chart.md) — full `values.yaml` reference including `workflow.taskLists` and `notification.*`
 - [Jobs Overview](jobs/index.md) — understand how PipelineRuns are scheduled and what triggers state transitions


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**

- Added `docs/operator-guides/notifications.md` — a new guide for platform operators to wire real email and Slack delivery into the notification workflow
- Added link to the guide in `docs/operator-guides/index.md` under Third-Party Integrations
- Covers: architecture overview, Helm configuration (`notification.studioBaseURL`, `senderEmail`, `taskList`), `fx.Decorate` Sink replacement pattern, verification steps, and upgrade notes

**Why?**

The notification workflow (PR #1283) ships with no-op activity stubs. Operators need a clear guide to:
1. Understand the pluggable Sink architecture (`[]notification.Sink` via `fx.Decorate`)
2. Configure Helm values for Studio deep links and sender email
3. Verify end-to-end delivery using workflow history and worker logs
4. Understand the deprecated workflow name alias drain during upgrades

Without this doc, operators would have to read the Go source to figure out the extension points.

**How did you test it?**

- Verified all technical claims against source code via 3-agent review team (engineer, tech-writer, PM)
- Fixed 6 P0 accuracy issues found during review (wrong interfaces, nonexistent constant, stale workflow name, wrong ID format, wrong message formats)
- Docusaurus dev server: all pages render (200) including cross-links to user guide
- All internal links verified: `setup/platform-setup.md`, `helm-chart.md`, `jobs/index.md`, `../user-guides/ml-pipelines/notifications.md`

**Potential risks**

None — documentation-only change, no code modifications.

**Release notes**

N/A

**Documentation Changes**

- New file: `docs/operator-guides/notifications.md` — notification delivery setup guide for platform operators
- Updated: `docs/operator-guides/index.md` — added link under Third-Party Integrations
- Cross-links to `docs/user-guides/ml-pipelines/notifications.md` for user-facing configuration reference

## Test Plan
- [x] Docusaurus dev server renders `/docs/operator-guides/notifications` (200)
- [x] Cross-links to `/docs/operator-guides/` and `/docs/user-guides/ml-pipelines/notifications` resolve (200)
- [x] All source code claims verified by engineer agent against Go source
- [x] `fx.Decorate` pattern matches `go/worker/workflows/notification/module.go:17-23`
- [x] Workflow name matches `go/base/notification/types/types.go:25`
- [x] Workflow ID format matches `go/components/pipelinerun/notification/notifier.go:104`
- [x] Message format strings match `go/base/notification/types/types.go:127,149,194`
- [x] Helm values match `helm/michelangelo/values.yaml:327-338`

Related: PR #1283 (notification system refactor)