### PR TITLE
fix(helm): auto-register Temporal default namespace on sandbox create

### DIFF
--- a/helm/michelangelo/templates/core/temporal-namespace-setup-job.yaml
+++ b/helm/michelangelo/templates/core/temporal-namespace-setup-job.yaml
@@ -1,0 +1,48 @@
+{{- if and .Values.temporal.enabled (eq .Values.workflow.engine "temporal") }}
+{{- $endpoint := required "workflow.endpoint is required" .Values.workflow.endpoint }}
+{{- $domain := .Values.workflow.domain | default "default" }}
+{{- $frontendHost := $endpoint | regexFind "^[^:]+" }}
+{{- $frontendPort := "7233" }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "michelangelo.componentFullname" (dict "context" . "component" "temporal-namespace-setup") }}
+  labels:
+    {{- include "michelangelo.componentLabels" (dict "context" . "component" "temporal-namespace-setup") | nindent 4 }}
+    app.kubernetes.io/name: temporal
+    app.kubernetes.io/component: schema
+spec:
+  backoffLimit: 10
+  template:
+    metadata:
+      labels:
+        {{- include "michelangelo.componentLabels" (dict "context" . "component" "temporal-namespace-setup") | nindent 8 }}
+    spec:
+      restartPolicy: OnFailure
+      initContainers:
+        - name: wait-for-temporal-frontend
+          image: busybox
+          command:
+            - sh
+            - -c
+            - |
+              until nc -z {{ $frontendHost }} {{ $frontendPort }}; do
+                echo "waiting for temporal frontend {{ $frontendHost }}:{{ $frontendPort }}..."; sleep 2;
+              done
+      containers:
+        - name: register-namespace
+          image: "{{ .Values.temporal.admintools.image.repository }}:{{ .Values.temporal.admintools.image.tag }}"
+          imagePullPolicy: {{ .Values.temporal.admintools.image.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - |
+              if tctl --address {{ $endpoint }} --namespace {{ $domain }} namespace describe 2>&1 | grep -q "Name:"; then
+                echo "Namespace '{{ $domain }}' already exists — skipping registration."
+                exit 0
+              fi
+              tctl --address {{ $endpoint }} --namespace {{ $domain }} namespace register \
+                --retention 7 \
+                --description "Default Michelangelo namespace (auto-registered by Helm)"
+              echo "Namespace '{{ $domain }}' registered."
+{{- end }}


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

Adds `helm/michelangelo/templates/core/temporal-namespace-setup-job.yaml` — a new Helm Job that automatically registers the Temporal `default` namespace after the schema Job completes. The job is gated on `temporal.enabled=true && workflow.engine=temporal` and is a no-op for Cadence or when Temporal is disabled.

<!-- Tell your future self why have you made these changes -->
**Why?**

Temporal does not auto-create namespaces on startup, unlike Cadence which registers its default domain on first boot. The existing schema Job (`michelangelo-temporal-schema`) only runs `temporal-sql-tool` for database setup. Without namespace registration, the worker pod crashes immediately with `Namespace default is not found` and enters CrashLoopBackOff, making every `ma sandbox create --workflow temporal` broken out of the box. Fixes #1345.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

- `helm template` with `temporal.enabled=true` renders the job correctly; with `temporal.enabled=false` or `workflow.engine=cadence` renders nothing (confirmed via grep)
- Deleted and recreated sandbox with `--workflow temporal` using locally-built images — worker started cleanly on first boot with no manual `tctl` intervention
- Ran full notification E2E test on Temporal: `PRNotificationWorkflow` completed on `notification_worker` task queue with both `SendMessageToEmailActivity` and `SendMessageToSlackActivity` completing successfully

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

None for Cadence deployments (template is fully gated). For Temporal deployments, the job is idempotent — if the namespace already exists it exits 0 — so `helm upgrade` is safe.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

N/A — sandbox-only fix, no production schema or config changes.

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**

N/A