### PR TITLE
docs(contributing): local image build and fix stale Helm-era references

### DIFF
--- a/docs/contributing/custom-docker-images.md
+++ b/docs/contributing/custom-docker-images.md
@@ -2,8 +2,126 @@
 
 > **Who is this for?** This guide is for **contributors** developing Michelangelo's core platform services (API server, controller manager, worker). If you're building ML pipelines using the Michelangelo SDK, you don't need custom Docker images -- the default sandbox images work out of the box.
 
-This guide explains how to build and publish custom Docker images for a feature branch using the dev release workflow, update sandbox manifests to reference those images, and run the sandbox to test your changes.
+This guide explains two ways to build and test custom images:
 
+- **[Option A — Local build](#option-a--local-build-no-github-push-required)**: build on your machine, import directly into k3d. Fast iteration loop — no GitHub push or CI required.
+- **[Option B — CI build](#option-b--ci-build-via-github-actions)**: push your branch, let GitHub Actions build multi-arch images and push them to GHCR, then point the sandbox at those images.
+
+---
+
+## Option A — Local build (no GitHub push required)
+
+Use this option when you want a fast feedback loop or are not ready to push your branch.
+
+### Prerequisites
+
+- Docker with BuildKit enabled (Docker Desktop ≥ 4.x)
+- `k3d` — a sandbox cluster must already exist or you will create one in step 5
+- The bazel-managed Go 1.24 binary (downloaded automatically on the first `bazel build`):
+  ```bash
+  # Locate it after any bazel build has run
+  find /private/var/tmp/_bazel_$(whoami) -name "go" -path "*/rules_go~~go_sdk~*/bin/go" 2>/dev/null | head -1
+  ```
+  Set a shell variable for convenience:
+  ```bash
+  export GOBIN=$(find /private/var/tmp/_bazel_$(whoami) -name "go" -path "*/rules_go~~go_sdk~*/bin/go" 2>/dev/null | head -1)
+  ```
+
+### Step 1: Build the binaries
+
+Run all three builds in parallel from the repo root. The binaries must target `linux/arm64` (Apple Silicon) or `linux/amd64` (Intel/CI).
+
+```bash
+cd go
+
+# Apple Silicon (arm64)
+GOOS=linux GOARCH=arm64 CGO_ENABLED=0 $GOBIN build -o ../apiserver     ./cmd/apiserver     &
+GOOS=linux GOARCH=arm64 CGO_ENABLED=0 $GOBIN build -o ../controllermgr ./cmd/controllermgr &
+GOOS=linux GOARCH=arm64 CGO_ENABLED=0 $GOBIN build -o ../worker        ./cmd/worker        &
+wait && echo "All builds done"
+```
+
+> **Why `CGO_ENABLED=0`?** The distroless base image has no C runtime. Disabling CGO produces a fully static binary that works without it.
+
+### Step 2: Build the Docker images
+
+```bash
+cd ..   # repo root
+
+for svc in apiserver controllermgr worker; do
+  docker build --platform linux/arm64 \
+    -f docker/service.Dockerfile \
+    --build-arg BINARY_PATH=$svc \
+    --build-arg CONFIG_PATH=go/cmd/$svc/config \
+    -t ghcr.io/michelangelo-ai/$svc:local-dev \
+    --quiet . && echo "$svc image: OK" &
+done
+wait && echo "All images built"
+```
+
+### Step 3: Delete and recreate the sandbox
+
+```bash
+cd python
+poetry run ma sandbox delete
+poetry run ma sandbox create --workflow cadence   # or --workflow temporal
+```
+
+### Step 4: Import images into k3d
+
+```bash
+k3d image import \
+  ghcr.io/michelangelo-ai/apiserver:local-dev \
+  ghcr.io/michelangelo-ai/controllermgr:local-dev \
+  ghcr.io/michelangelo-ai/worker:local-dev \
+  -c michelangelo-sandbox
+```
+
+### Step 5: Point deployments at the local images
+
+```bash
+kubectl set image deployment/michelangelo-apiserver    apiserver=ghcr.io/michelangelo-ai/apiserver:local-dev
+kubectl set image deployment/michelangelo-controllermgr app=ghcr.io/michelangelo-ai/controllermgr:local-dev
+kubectl set image deployment/michelangelo-worker        app=ghcr.io/michelangelo-ai/worker:local-dev
+```
+
+### Step 6: Verify
+
+```bash
+kubectl rollout status deployment/michelangelo-apiserver \
+  deployment/michelangelo-controllermgr \
+  deployment/michelangelo-worker
+kubectl get pods -l app.kubernetes.io/instance=michelangelo
+```
+
+All three pods should reach `Running`. Confirm the image is the local build:
+
+```bash
+kubectl describe pod -l app.kubernetes.io/component=apiserver | grep Image:
+```
+
+### Iterating on changes
+
+After each code change, rebuild only the affected binary and image, then re-import and restart that one pod:
+
+```bash
+# Example: rebuilding only the worker
+cd go && GOOS=linux GOARCH=arm64 CGO_ENABLED=0 $GOBIN build -o ../worker ./cmd/worker
+cd ..
+docker build --platform linux/arm64 -f docker/service.Dockerfile \
+  --build-arg BINARY_PATH=worker \
+  --build-arg CONFIG_PATH=go/cmd/worker/config \
+  -t ghcr.io/michelangelo-ai/worker:local-dev --quiet .
+k3d image import ghcr.io/michelangelo-ai/worker:local-dev -c michelangelo-sandbox
+kubectl rollout restart deployment/michelangelo-worker
+kubectl rollout status  deployment/michelangelo-worker
+```
+
+---
+
+## Option B — CI build via GitHub Actions
+
+Use this option when your branch is ready to share, you need multi-arch images (`linux/amd64` + `linux/arm64`), or you want a stable image tag to share with teammates.
 
 ### 1) Create or switch to your feature branch
 ```bash

--- a/docs/contributing/custom-docker-images.md
+++ b/docs/contributing/custom-docker-images.md
@@ -1,6 +1,6 @@
 # Custom Docker Images for Feature Branches and Sandbox Testing
 
-> **Who is this for?** This guide is for **contributors** developing Michelangelo's core platform services (API server, controller manager, worker). If you're building ML pipelines using the Michelangelo SDK, you don't need custom Docker images -- the default sandbox images work out of the box.
+> **Who is this for?** This guide is for **contributors** developing Michelangelo's core platform services (API server, controller manager, worker). If you're building ML pipelines using the Michelangelo SDK, you don't need custom Docker images — the default sandbox images work out of the box. See the [Sandbox Setup Guide](../getting-started/sandbox-setup.md) for getting started.
 
 This guide explains two ways to build and test custom images:
 
@@ -16,28 +16,33 @@ Use this option when you want a fast feedback loop or are not ready to push your
 ### Prerequisites
 
 - Docker with BuildKit enabled (Docker Desktop ≥ 4.x)
-- `k3d` — a sandbox cluster must already exist or you will create one in step 5
+- A sandbox cluster (create one with `ma sandbox create` — see [Sandbox Setup](../getting-started/sandbox-setup.md))
 - The bazel-managed Go 1.24 binary (downloaded automatically on the first `bazel build`):
   ```bash
-  # Locate it after any bazel build has run
+  # macOS
   find /private/var/tmp/_bazel_$(whoami) -name "go" -path "*/rules_go~~go_sdk~*/bin/go" 2>/dev/null | head -1
+
+  # Linux
+  find ~/.cache/bazel -name "go" -path "*/rules_go~~go_sdk~*/bin/go" 2>/dev/null | head -1
   ```
   Set a shell variable for convenience:
   ```bash
-  export GOBIN=$(find /private/var/tmp/_bazel_$(whoami) -name "go" -path "*/rules_go~~go_sdk~*/bin/go" 2>/dev/null | head -1)
+  export GOEXEC=$(find /private/var/tmp/_bazel_$(whoami) -name "go" -path "*/rules_go~~go_sdk~*/bin/go" 2>/dev/null | head -1)
+  # Linux: replace /private/var/tmp/_bazel_$(whoami) with ~/.cache/bazel
   ```
 
 ### Step 1: Build the binaries
 
-Run all three builds in parallel from the repo root. The binaries must target `linux/arm64` (Apple Silicon) or `linux/amd64` (Intel/CI).
+Run all three builds in parallel from the repo root. Set `GOARCH` to match your machine (`arm64` for Apple Silicon, `amd64` for Intel/Linux).
 
 ```bash
 cd go
 
-# Apple Silicon (arm64)
-GOOS=linux GOARCH=arm64 CGO_ENABLED=0 $GOBIN build -o ../apiserver     ./cmd/apiserver     &
-GOOS=linux GOARCH=arm64 CGO_ENABLED=0 $GOBIN build -o ../controllermgr ./cmd/controllermgr &
-GOOS=linux GOARCH=arm64 CGO_ENABLED=0 $GOBIN build -o ../worker        ./cmd/worker        &
+ARCH=arm64   # or amd64 for Intel/Linux
+
+GOOS=linux GOARCH=$ARCH CGO_ENABLED=0 $GOEXEC build -o ../apiserver     ./cmd/apiserver     &
+GOOS=linux GOARCH=$ARCH CGO_ENABLED=0 $GOEXEC build -o ../controllermgr ./cmd/controllermgr &
+GOOS=linux GOARCH=$ARCH CGO_ENABLED=0 $GOEXEC build -o ../worker        ./cmd/worker        &
 wait && echo "All builds done"
 ```
 
@@ -49,7 +54,7 @@ wait && echo "All builds done"
 cd ..   # repo root
 
 for svc in apiserver controllermgr worker; do
-  docker build --platform linux/arm64 \
+  docker build --platform linux/$ARCH \
     -f docker/service.Dockerfile \
     --build-arg BINARY_PATH=$svc \
     --build-arg CONFIG_PATH=go/cmd/$svc/config \
@@ -63,8 +68,8 @@ wait && echo "All images built"
 
 ```bash
 cd python
-poetry run ma sandbox delete
-poetry run ma sandbox create --workflow cadence   # or --workflow temporal
+ma sandbox delete
+ma sandbox create --workflow cadence   # or --workflow temporal
 ```
 
 ### Step 4: Import images into k3d
@@ -84,6 +89,14 @@ kubectl set image deployment/michelangelo-apiserver    apiserver=ghcr.io/michela
 kubectl set image deployment/michelangelo-controllermgr app=ghcr.io/michelangelo-ai/controllermgr:local-dev
 kubectl set image deployment/michelangelo-worker        app=ghcr.io/michelangelo-ai/worker:local-dev
 ```
+
+> **Note:** `kubectl set image` is ephemeral — running `ma sandbox sync` or `helm upgrade` will revert the images to the Helm defaults. For a durable override, pass `--set` flags when creating the sandbox:
+> ```bash
+> ma sandbox create \
+>   --set images.apiserver=ghcr.io/michelangelo-ai/apiserver:local-dev \
+>   --set images.controllermgr=ghcr.io/michelangelo-ai/controllermgr:local-dev \
+>   --set images.worker=ghcr.io/michelangelo-ai/worker:local-dev
+> ```
 
 ### Step 6: Verify
 
@@ -106,9 +119,9 @@ After each code change, rebuild only the affected binary and image, then re-impo
 
 ```bash
 # Example: rebuilding only the worker
-cd go && GOOS=linux GOARCH=arm64 CGO_ENABLED=0 $GOBIN build -o ../worker ./cmd/worker
+cd go && GOOS=linux GOARCH=$ARCH CGO_ENABLED=0 $GOEXEC build -o ../worker ./cmd/worker
 cd ..
-docker build --platform linux/arm64 -f docker/service.Dockerfile \
+docker build --platform linux/$ARCH -f docker/service.Dockerfile \
   --build-arg BINARY_PATH=worker \
   --build-arg CONFIG_PATH=go/cmd/worker/config \
   -t ghcr.io/michelangelo-ai/worker:local-dev --quiet .
@@ -117,11 +130,36 @@ kubectl rollout restart deployment/michelangelo-worker
 kubectl rollout status  deployment/michelangelo-worker
 ```
 
+### Troubleshooting
+
+- **Pod stuck in `ImagePullBackOff`**: The default `pullPolicy` is `IfNotPresent`. If k3d can't find the image, make sure you ran `k3d image import` after building. Check with `k3d image ls -c michelangelo-sandbox | grep local-dev`.
+- **`exec format error`**: Architecture mismatch — you built for `arm64` but the k3d node is `amd64` (or vice versa). Rebuild with the correct `ARCH`.
+- **Bazel Go binary not found**: Run any `./tools/bazel build` target first to trigger the SDK download, then re-run the `find` command.
+
+### Cleanup
+
+Remove the locally built binaries from the repo root:
+
+```bash
+rm -f apiserver controllermgr worker
+```
+
+To tear down the sandbox:
+
+```bash
+ma sandbox delete
+```
+
 ---
 
 ## Option B — CI build via GitHub Actions
 
 Use this option when your branch is ready to share, you need multi-arch images (`linux/amd64` + `linux/arm64`), or you want a stable image tag to share with teammates.
+
+### Prerequisites
+
+- Push access to the repository (or a fork with GitHub Actions enabled)
+- GHCR pull access from your k3d cluster (public images work automatically)
 
 ### 1) Create or switch to your feature branch
 ```bash
@@ -152,6 +190,8 @@ git push origin $(git branch --show-current)
 
 > **Caution**: Only use `git push -f` (force push) if you intentionally need to overwrite remote history. In most cases, a regular `git push` is sufficient and safer.
 
+> **Important**: Don't merge the `dev-release.yml` change into `main` — it's only for your branch. Revert it before opening a PR, or exclude it from your PR's commits.
+
 ### 4) Wait for images to be published
 - Monitor the GitHub Actions run for `Dev Release` on your branch.
 - Upon success, images will be available as:
@@ -159,64 +199,46 @@ git push origin $(git branch --show-current)
   - `ghcr.io/michelangelo-ai/controllermgr:my-feature-branch`
   - `ghcr.io/michelangelo-ai/worker:my-feature-branch`
 
-### 5) Update sandbox manifests to use your new image tag
-Edit the following files to set the image tag to your branch name:
-- `python/michelangelo/cli/sandbox/resources/michelangelo-apiserver.yaml`
-- `python/michelangelo/cli/sandbox/resources/michelangelo-controllermgr.yaml`
-- `python/michelangelo/cli/sandbox/resources/michelangelo-worker.yaml`
+### 5) Point the sandbox at your branch images
 
-Example (replace `my-feature-branch` with your branch):
-```yaml
-# michelangelo-apiserver.yaml
-spec:
-  containers:
-    - name: michelangelo-apiserver
-      image: ghcr.io/michelangelo-ai/apiserver:my-feature-branch
-```
+The sandbox deploys core services via the Helm chart at `helm/michelangelo/`. Override the image tags using `--set` when creating the sandbox:
 
-```yaml
-# michelangelo-controllermgr.yaml
-spec:
-  containers:
-    - name: app
-      image: ghcr.io/michelangelo-ai/controllermgr:my-feature-branch
-```
-
-```yaml
-# michelangelo-worker.yaml
-spec:
-  containers:
-    - name: app
-      image: ghcr.io/michelangelo-ai/worker:my-feature-branch
-```
-
-Note: The repository already contains working examples where the image tag equals the branch name.
-
-### 6) Start the sandbox to test your changes
-From the `python/` directory in the repo root:
 ```bash
-poetry install
-source .venv/bin/activate
-ma sandbox create
+cd python
+ma sandbox create \
+  --set images.apiserver=ghcr.io/michelangelo-ai/apiserver:my-feature-branch \
+  --set images.controllermgr=ghcr.io/michelangelo-ai/controllermgr:my-feature-branch \
+  --set images.worker=ghcr.io/michelangelo-ai/worker:my-feature-branch
 ```
 
-Useful operations:
-- Recreate: `ma sandbox delete && ma sandbox create`
-- Inspect: `kubectl get pods -A | grep michelangelo`
-- Logs (example): `kubectl logs pod/michelangelo-controllermgr -f`
+Or, if the sandbox is already running, import and swap the images:
 
-### 7) Verify deployment
+```bash
+kubectl set image deployment/michelangelo-apiserver    apiserver=ghcr.io/michelangelo-ai/apiserver:my-feature-branch
+kubectl set image deployment/michelangelo-controllermgr app=ghcr.io/michelangelo-ai/controllermgr:my-feature-branch
+kubectl set image deployment/michelangelo-worker        app=ghcr.io/michelangelo-ai/worker:my-feature-branch
+```
+
+### 6) Verify deployment
 - Ensure the pods for `apiserver`, `controllermgr`, and `worker` are running.
-- Confirm they are using your branch image tags via `kubectl describe pod <pod-name>`.
+- Confirm they are using your branch image tags via `kubectl describe pod <pod-name> | grep Image:`.
 - Exercise your changes via the sandbox workflows or APIs as needed.
 
 ### Troubleshooting
-- Builds not triggering: Confirm `.github/workflows/dev-release.yml` includes your branch under `on.push.branches` and that you pushed to the exact branch name.
-- Image pull errors: Ensure the action completed successfully and images exist at `ghcr.io/michelangelo-ai`. If private, verify permissions for your cluster's image puller.
-- Wrong image tag: Double-check manifests reference your exact branch name.
-- Multi-arch issues: The workflow builds `linux/amd64` and `linux/arm64`. Confirm your cluster nodes match one of these.
+- **Builds not triggering**: Confirm `.github/workflows/dev-release.yml` includes your branch under `on.push.branches` and that you pushed to the exact branch name.
+- **Image pull errors**: Ensure the action completed successfully and images exist at `ghcr.io/michelangelo-ai`. If private, verify permissions for your cluster's image puller.
+- **Wrong image tag**: Double-check your `--set` flags reference the exact branch name.
+- **Multi-arch issues**: The workflow builds `linux/amd64` and `linux/arm64`. Confirm your cluster nodes match one of these.
 
 ### Cleanup
 ```bash
 ma sandbox delete
 ```
+
+---
+
+## Next Steps
+
+- [Sandbox Setup Guide](../getting-started/sandbox-setup.md) — create and configure the local development environment
+- [Building from Source](building-michelangelo-ai-from-source.md) — full build instructions for all components
+- [Helm Chart Reference](../operator-guides/helm-chart.md) — `values.yaml` reference including `images.*` overrides


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**

- Added **Option A — Local build**: build Go binaries, Docker images, and import into k3d for fast iteration without pushing to GitHub
- Fixed **Option B — CI build**: replaced references to deleted sandbox manifest files with correct Helm `--set images.*` overrides
- Renamed `GOBIN` to `GOEXEC` to avoid overloading Go's real `GOBIN` env var
- Parameterized architecture (`$ARCH`) instead of hardcoding `arm64`
- Added ephemeral-override warning for `kubectl set image` with durable `--set` alternative
- Added troubleshooting and cleanup sections to both options
- Added Next Steps with onward links
- Added cross-link to Sandbox Setup guide
- Standardized CLI invocation (`ma` throughout)
- Added Linux bazel path alongside macOS

**Why?**

Option B Step 5 was broken — it instructed editing three manifest files (`resources/michelangelo-{apiserver,controllermgr,worker}.yaml`) that were removed when the sandbox migrated to Helm (#1162). Contributors following the guide hit a dead end. Option A fills a gap for contributors who need fast local iteration without a CI round-trip.

**How did you test it?**

- 3-agent review team (engineer, tech-writer, PM) verified all technical claims against source code
- All file paths confirmed: `docker/service.Dockerfile`, `go/cmd/{apiserver,controllermgr,worker}/config/`, `helm/michelangelo/values.yaml`
- `--set` passthrough verified in `sandbox.py:191-196`
- Deployment and container names verified against Helm templates
- Docusaurus dev server: page renders at `/docs/contributing/custom-docker-images` (200)

**Potential risks**

None — documentation-only change.

**Release notes**

N/A

**Documentation Changes**

- Rewrote `docs/contributing/custom-docker-images.md`