### PR TITLE
feat(cli): add --notify-slack, --notify-email, --notify-on to pipeline run

### DIFF
--- a/docs/user-guides/ml-pipelines/notifications.md
+++ b/docs/user-guides/ml-pipelines/notifications.md
@@ -38,6 +38,22 @@ notifications:
 
 That's it! When you apply this spec with `ma apply -f your-spec.yaml`, Michelangelo will send you an email each time the run reaches one of those states.
 
+### CLI Shorthand
+
+For one-off runs, you can skip the YAML and attach notifications directly from the command line:
+
+```bash
+ma pipeline run -n my-project --name training-pipeline \
+  --notify-email you@example.com \
+  --notify-slack "#ml-alerts" \
+  --notify-on FAILED \
+  --notify-on SUCCEEDED
+```
+
+The `--notify-on` filter applies to **all** destinations. For per-destination event filtering (e.g., Slack on every status, email only on failure), use the YAML spec approach below instead.
+
+See the [CLI Reference](../reference/cli.md#notification-arguments) for full flag details.
+
 Want Slack notifications instead? Swap the type and destination:
 
 ```yaml

--- a/docs/user-guides/ml-pipelines/notifications.md
+++ b/docs/user-guides/ml-pipelines/notifications.md
@@ -44,10 +44,9 @@ For one-off runs, you can skip the YAML and attach notifications directly from t
 
 ```bash
 ma pipeline run -n my-project --name training-pipeline \
-  --notify-email you@example.com \
+  --notify-email you@example.com,oncall@example.com \
   --notify-slack "#ml-alerts" \
-  --notify-on FAILED \
-  --notify-on SUCCEEDED
+  --notify-on FAILED,SUCCEEDED
 ```
 
 The `--notify-on` filter applies to **all** destinations. For per-destination event filtering (e.g., Slack on every status, email only on failure), use the YAML spec approach below instead.

--- a/docs/user-guides/reference/cli.md
+++ b/docs/user-guides/reference/cli.md
@@ -230,9 +230,9 @@ ma pipeline run --namespace="my-project" --name="bert-cola-test" --resume_from=r
 
 You can attach notification rules directly to a pipeline run so you're alerted when it reaches a terminal state. This is useful for one-off runs where you want a quick "ping me when it's done" without editing YAML specs.
 
-- `--notify-slack` — Slack destination (channel or @user). Repeatable for multiple destinations.
-- `--notify-email` — Email address. Repeatable for multiple recipients.
-- `--notify-on` — Event type to trigger on: `SUCCEEDED`, `FAILED`, `KILLED`, or `SKIPPED`. Repeatable. Defaults to all four when omitted. Applies to all destinations (per-destination filtering is not yet supported — use YAML specs for that).
+- `--notify-slack` — Slack destination (channel or @user). Repeatable or comma-separated.
+- `--notify-email` — Email address. Repeatable or comma-separated.
+- `--notify-on` — Event type to trigger on: `SUCCEEDED`, `FAILED`, `KILLED`, or `SKIPPED`. Repeatable or comma-separated. Defaults to all four when omitted. Applies to all destinations (per-destination filtering is not yet supported — use YAML specs for that).
 
 Syntax:
 
@@ -249,10 +249,8 @@ Example:
 # Notify a Slack channel and two email addresses on failure or success
 ma pipeline run -n "my-project" --name="bert-cola-test" \
   --notify-slack "#ml-alerts" \
-  --notify-email alice@example.com \
-  --notify-email oncall@example.com \
-  --notify-on FAILED \
-  --notify-on SUCCEEDED
+  --notify-email alice@example.com,oncall@example.com \
+  --notify-on FAILED,SUCCEEDED
 ```
 
 For advanced notification configuration (per-destination event filtering, trigger run notifications, or standing notification rules), see [Pipeline Notifications](../ml-pipelines/notifications.md).

--- a/docs/user-guides/reference/cli.md
+++ b/docs/user-guides/reference/cli.md
@@ -226,6 +226,37 @@ Example:
 ma pipeline run --namespace="my-project" --name="bert-cola-test" --resume_from=run-1759873504-b93b7f612:train
 ```
 
+##### Notification Arguments
+
+You can attach notification rules directly to a pipeline run so you're alerted when it reaches a terminal state. This is useful for one-off runs where you want a quick "ping me when it's done" without editing YAML specs.
+
+- `--notify-slack` — Slack destination (channel or @user). Repeatable for multiple destinations.
+- `--notify-email` — Email address. Repeatable for multiple recipients.
+- `--notify-on` — Event type to trigger on: `SUCCEEDED`, `FAILED`, `KILLED`, or `SKIPPED`. Repeatable. Defaults to all four when omitted. Applies to all destinations (per-destination filtering is not yet supported — use YAML specs for that).
+
+Syntax:
+
+```bash
+ma pipeline run -n "<namespace>" --name="<pipeline_name>" \
+  --notify-slack "<channel_or_user>" \
+  --notify-email "<email_address>" \
+  --notify-on <EVENT_TYPE>
+```
+
+Example:
+
+```bash
+# Notify a Slack channel and two email addresses on failure or success
+ma pipeline run -n "my-project" --name="bert-cola-test" \
+  --notify-slack "#ml-alerts" \
+  --notify-email alice@example.com \
+  --notify-email oncall@example.com \
+  --notify-on FAILED \
+  --notify-on SUCCEEDED
+```
+
+For advanced notification configuration (per-destination event filtering, trigger run notifications, or standing notification rules), see [Pipeline Notifications](../ml-pipelines/notifications.md).
+
 #### DEV RUN - Execute a pipeline in DEV mode
 
 The DEV RUN command is used to run a pipeline without registering it. This command is to allow users to quickly iterate on their pipelines. The dev-run command supports an `--env` flag for passing environment variables, which are injected into the pipeline's execution environment.

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/run.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/run.py
@@ -112,8 +112,7 @@ def add_function_signature(crd: CRD) -> None:
                         "action": "append",
                         "default": None,
                         "help": (
-                            "Email address for run notifications. "
-                            "Can be repeated."
+                            "Email address for run notifications. Can be repeated."
                         ),
                     },
                 },
@@ -343,19 +342,14 @@ def generate_pipeline_run_object(
     return pipeline_run_dict
 
 
-_DEFAULT_NOTIFY_ON = [
-    "EVENT_TYPE_PIPELINE_RUN_STATE_SUCCEEDED",
-    "EVENT_TYPE_PIPELINE_RUN_STATE_FAILED",
-    "EVENT_TYPE_PIPELINE_RUN_STATE_KILLED",
-    "EVENT_TYPE_PIPELINE_RUN_STATE_SKIPPED",
-]
-
 _NOTIFY_ON_MAP = {
     "SUCCEEDED": "EVENT_TYPE_PIPELINE_RUN_STATE_SUCCEEDED",
     "FAILED": "EVENT_TYPE_PIPELINE_RUN_STATE_FAILED",
     "KILLED": "EVENT_TYPE_PIPELINE_RUN_STATE_KILLED",
     "SKIPPED": "EVENT_TYPE_PIPELINE_RUN_STATE_SKIPPED",
 }
+
+_DEFAULT_NOTIFY_ON = list(_NOTIFY_ON_MAP.values())
 
 
 def _build_notifications(
@@ -364,7 +358,15 @@ def _build_notifications(
     notify_on: Optional[list[str]] = None,
 ) -> list[dict]:
     """Build notification entries from notification flags."""
-    if not notify_slack and not notify_email:
+    slack_destinations = [s for s in (notify_slack or []) if s.strip()]
+    email_addresses = [e for e in (notify_email or []) if e.strip()]
+
+    if not slack_destinations and not email_addresses:
+        if notify_on:
+            _LOG.warning(
+                "--notify-on specified without --notify-slack or --notify-email; "
+                "no notifications will be sent"
+            )
         return []
 
     event_types = (
@@ -372,22 +374,22 @@ def _build_notifications(
     )
 
     notifications: list[dict] = []
-    if notify_slack:
+    if slack_destinations:
         notifications.append(
             {
                 "notificationType": "NOTIFICATION_TYPE_SLACK",
                 "eventTypes": event_types,
                 "resourceType": "RESOURCE_TYPE_PIPELINE_RUN",
-                "slackDestinations": notify_slack,
+                "slackDestinations": slack_destinations,
             }
         )
-    if notify_email:
+    if email_addresses:
         notifications.append(
             {
                 "notificationType": "NOTIFICATION_TYPE_EMAIL",
                 "eventTypes": event_types,
                 "resourceType": "RESOURCE_TYPE_PIPELINE_RUN",
-                "emails": notify_email,
+                "emails": email_addresses,
             }
         )
     return notifications

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/run.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/run.py
@@ -135,6 +135,7 @@ def add_function_signature(crd: CRD) -> None:
                         ],
                         "help": (
                             "Event type to notify on. Can be repeated. "
+                            "Applies to all destinations. "
                             "Default: SUCCEEDED FAILED KILLED SKIPPED"
                         ),
                     },

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/run.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/run.py
@@ -85,35 +85,58 @@ def add_function_signature(crd: CRD) -> None:
                 },
                 {
                     "func_signature": Parameter(
-                        "slack",
+                        "notify_slack",
                         Parameter.POSITIONAL_OR_KEYWORD,
                         default=None,
                     ),
-                    "args": ["--slack"],
+                    "args": ["--notify-slack"],
                     "kwargs": {
                         "type": str,
-                        "required": False,
+                        "action": "append",
                         "default": None,
                         "help": (
-                            "Comma-separated Slack destinations (channels or "
-                            "@users) for run notifications"
+                            "Slack destination (channel or @user) for run "
+                            "notifications. Can be repeated."
                         ),
                     },
                 },
                 {
                     "func_signature": Parameter(
-                        "email",
+                        "notify_email",
                         Parameter.POSITIONAL_OR_KEYWORD,
                         default=None,
                     ),
-                    "args": ["--email"],
+                    "args": ["--notify-email"],
                     "kwargs": {
                         "type": str,
-                        "required": False,
+                        "action": "append",
                         "default": None,
                         "help": (
-                            "Comma-separated email addresses for run "
-                            "notifications"
+                            "Email address for run notifications. "
+                            "Can be repeated."
+                        ),
+                    },
+                },
+                {
+                    "func_signature": Parameter(
+                        "notify_on",
+                        Parameter.POSITIONAL_OR_KEYWORD,
+                        default=None,
+                    ),
+                    "args": ["--notify-on"],
+                    "kwargs": {
+                        "type": str,
+                        "action": "append",
+                        "default": None,
+                        "choices": [
+                            "SUCCEEDED",
+                            "FAILED",
+                            "KILLED",
+                            "SKIPPED",
+                        ],
+                        "help": (
+                            "Event type to notify on. Can be repeated. "
+                            "Default: SUCCEEDED FAILED KILLED SKIPPED"
                         ),
                     },
                 },
@@ -164,15 +187,17 @@ def generate_run(crd: CRD, channel: Channel, parser: Optional[ArgumentParser] = 
 
         # Handle optional parameters
         _resume_from = bound_args.arguments.get("resume_from")
-        _slack = bound_args.arguments.get("slack")
-        _email = bound_args.arguments.get("email")
+        _notify_slack = bound_args.arguments.get("notify_slack")
+        _notify_email = bound_args.arguments.get("notify_email")
+        _notify_on = bound_args.arguments.get("notify_on")
 
         run_kwargs = {
             "namespace": _namespace,
             "name": _name,
             "resume_from": _resume_from,
-            "slack": _slack,
-            "email": _email,
+            "notify_slack": _notify_slack,
+            "notify_email": _notify_email,
+            "notify_on": _notify_on,
         }
 
         pipeline_run_dict = _self.func_crd_metadata_converter(
@@ -227,8 +252,9 @@ def convert_crd_metadata_pipeline_run(
     namespace = yaml_dict["namespace"]
     pipeline_name = yaml_dict["name"]
     resume_from = yaml_dict.get("resume_from")
-    slack = yaml_dict.get("slack")
-    email = yaml_dict.get("email")
+    notify_slack = yaml_dict.get("notify_slack")
+    notify_email = yaml_dict.get("notify_email")
+    notify_on = yaml_dict.get("notify_on")
     run_name = generate_pipeline_run_name()
 
     _LOG.info(
@@ -243,8 +269,9 @@ def convert_crd_metadata_pipeline_run(
         pipeline_name=pipeline_name,
         namespace=namespace,
         resume_from=resume_from,
-        slack=slack,
-        email=email,
+        notify_slack=notify_slack,
+        notify_email=notify_email,
+        notify_on=notify_on,
     )
 
     return {"pipeline_run": pipeline_run}
@@ -255,8 +282,9 @@ def generate_pipeline_run_object(
     pipeline_name: str,
     namespace: str,
     resume_from: Optional[str] = None,
-    slack: Optional[str] = None,
-    email: Optional[str] = None,
+    notify_slack: Optional[list[str]] = None,
+    notify_email: Optional[list[str]] = None,
+    notify_on: Optional[list[str]] = None,
 ) -> dict:
     """Generate PipelineRun object as dictionary.
 
@@ -266,8 +294,9 @@ def generate_pipeline_run_object(
         namespace: Kubernetes namespace
         resume_from: Optional resume specification in format
             "pipeline_run_name:step_name"
-        slack: Comma-separated Slack destinations for notifications
-        email: Comma-separated email addresses for notifications
+        notify_slack: Slack destinations for notifications
+        notify_email: Email addresses for notifications
+        notify_on: Event types to notify on (defaults to all)
 
     Returns:
         dict: Configured pipeline run object as dictionary
@@ -302,7 +331,11 @@ def generate_pipeline_run_object(
             _LOG.warning("Failed to parse resume_from: %r", resume_from)
 
     # Add notifications if --slack or --email provided
-    notifications = _build_notifications(slack=slack, email=email)
+    notifications = _build_notifications(
+        notify_slack=notify_slack,
+        notify_email=notify_email,
+        notify_on=notify_on,
+    )
     if notifications:
         pipeline_run_dict["spec"]["notifications"] = notifications
 
@@ -310,36 +343,51 @@ def generate_pipeline_run_object(
     return pipeline_run_dict
 
 
-_NOTIFICATION_EVENT_TYPES = [
+_DEFAULT_NOTIFY_ON = [
     "EVENT_TYPE_PIPELINE_RUN_STATE_SUCCEEDED",
     "EVENT_TYPE_PIPELINE_RUN_STATE_FAILED",
     "EVENT_TYPE_PIPELINE_RUN_STATE_KILLED",
+    "EVENT_TYPE_PIPELINE_RUN_STATE_SKIPPED",
 ]
+
+_NOTIFY_ON_MAP = {
+    "SUCCEEDED": "EVENT_TYPE_PIPELINE_RUN_STATE_SUCCEEDED",
+    "FAILED": "EVENT_TYPE_PIPELINE_RUN_STATE_FAILED",
+    "KILLED": "EVENT_TYPE_PIPELINE_RUN_STATE_KILLED",
+    "SKIPPED": "EVENT_TYPE_PIPELINE_RUN_STATE_SKIPPED",
+}
 
 
 def _build_notifications(
-    slack: Optional[str] = None, email: Optional[str] = None
+    notify_slack: Optional[list[str]] = None,
+    notify_email: Optional[list[str]] = None,
+    notify_on: Optional[list[str]] = None,
 ) -> list[dict]:
-    """Build notification entries from --slack and --email flag values."""
+    """Build notification entries from notification flags."""
+    if not notify_slack and not notify_email:
+        return []
+
+    event_types = (
+        [_NOTIFY_ON_MAP[e] for e in notify_on] if notify_on else _DEFAULT_NOTIFY_ON
+    )
+
     notifications: list[dict] = []
-    if slack:
-        destinations = [s.strip() for s in slack.split(",")]
+    if notify_slack:
         notifications.append(
             {
                 "notificationType": "NOTIFICATION_TYPE_SLACK",
-                "eventTypes": _NOTIFICATION_EVENT_TYPES,
+                "eventTypes": event_types,
                 "resourceType": "RESOURCE_TYPE_PIPELINE_RUN",
-                "slackDestinations": destinations,
+                "slackDestinations": notify_slack,
             }
         )
-    if email:
-        addresses = [e.strip() for e in email.split(",")]
+    if notify_email:
         notifications.append(
             {
                 "notificationType": "NOTIFICATION_TYPE_EMAIL",
-                "eventTypes": _NOTIFICATION_EVENT_TYPES,
+                "eventTypes": event_types,
                 "resourceType": "RESOURCE_TYPE_PIPELINE_RUN",
-                "emails": addresses,
+                "emails": notify_email,
             }
         )
     return notifications

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/run.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/run.py
@@ -96,7 +96,7 @@ def add_function_signature(crd: CRD) -> None:
                         "default": None,
                         "help": (
                             "Slack destination (channel or @user) for run "
-                            "notifications. Can be repeated."
+                            "notifications. Repeatable or comma-separated."
                         ),
                     },
                 },
@@ -112,7 +112,8 @@ def add_function_signature(crd: CRD) -> None:
                         "action": "append",
                         "default": None,
                         "help": (
-                            "Email address for run notifications. Can be repeated."
+                            "Email address for run notifications. "
+                            "Repeatable or comma-separated."
                         ),
                     },
                 },
@@ -127,16 +128,10 @@ def add_function_signature(crd: CRD) -> None:
                         "type": str,
                         "action": "append",
                         "default": None,
-                        "choices": [
-                            "SUCCEEDED",
-                            "FAILED",
-                            "KILLED",
-                            "SKIPPED",
-                        ],
                         "help": (
-                            "Event type to notify on. Can be repeated. "
-                            "Applies to all destinations. "
-                            "Default: SUCCEEDED FAILED KILLED SKIPPED"
+                            "Event type to notify on: SUCCEEDED, FAILED, "
+                            "KILLED, SKIPPED. Repeatable or comma-separated. "
+                            "Applies to all destinations. Default: all"
                         ),
                     },
                 },
@@ -353,26 +348,41 @@ _NOTIFY_ON_MAP = {
 _DEFAULT_NOTIFY_ON = list(_NOTIFY_ON_MAP.values())
 
 
+def _split_csv(values: Optional[list[str]]) -> list[str]:
+    """Flatten comma-separated values into a single list, stripping whitespace."""
+    if not values:
+        return []
+    return [item.strip() for raw in values for item in raw.split(",") if item.strip()]
+
+
 def _build_notifications(
     notify_slack: Optional[list[str]] = None,
     notify_email: Optional[list[str]] = None,
     notify_on: Optional[list[str]] = None,
 ) -> list[dict]:
     """Build notification entries from notification flags."""
-    slack_destinations = [s for s in (notify_slack or []) if s.strip()]
-    email_addresses = [e for e in (notify_email or []) if e.strip()]
+    slack_destinations = _split_csv(notify_slack)
+    email_addresses = _split_csv(notify_email)
+    event_keys = _split_csv(notify_on)
 
     if not slack_destinations and not email_addresses:
-        if notify_on:
+        if event_keys:
             _LOG.warning(
                 "--notify-on specified without --notify-slack or --notify-email; "
                 "no notifications will be sent"
             )
         return []
 
-    event_types = (
-        [_NOTIFY_ON_MAP[e] for e in notify_on] if notify_on else _DEFAULT_NOTIFY_ON
-    )
+    if event_keys:
+        invalid = [e for e in event_keys if e not in _NOTIFY_ON_MAP]
+        if invalid:
+            raise ValueError(
+                f"Invalid --notify-on values: {invalid}. "
+                f"Valid choices: {list(_NOTIFY_ON_MAP)}"
+            )
+        event_types = [_NOTIFY_ON_MAP[e] for e in event_keys]
+    else:
+        event_types = _DEFAULT_NOTIFY_ON
 
     notifications: list[dict] = []
     if slack_destinations:

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/run.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/run.py
@@ -83,6 +83,40 @@ def add_function_signature(crd: CRD) -> None:
                         ),
                     },
                 },
+                {
+                    "func_signature": Parameter(
+                        "slack",
+                        Parameter.POSITIONAL_OR_KEYWORD,
+                        default=None,
+                    ),
+                    "args": ["--slack"],
+                    "kwargs": {
+                        "type": str,
+                        "required": False,
+                        "default": None,
+                        "help": (
+                            "Comma-separated Slack destinations (channels or "
+                            "@users) for run notifications"
+                        ),
+                    },
+                },
+                {
+                    "func_signature": Parameter(
+                        "email",
+                        Parameter.POSITIONAL_OR_KEYWORD,
+                        default=None,
+                    ),
+                    "args": ["--email"],
+                    "kwargs": {
+                        "type": str,
+                        "required": False,
+                        "default": None,
+                        "help": (
+                            "Comma-separated email addresses for run "
+                            "notifications"
+                        ),
+                    },
+                },
             ],
         },
     )
@@ -128,13 +162,17 @@ def generate_run(crd: CRD, channel: Channel, parser: Optional[ArgumentParser] = 
         _namespace = get_single_arg(bound_args.arguments, "namespace")
         _name = get_single_arg(bound_args.arguments, "name")
 
-        # Handle optional resume_from parameter
+        # Handle optional parameters
         _resume_from = bound_args.arguments.get("resume_from")
+        _slack = bound_args.arguments.get("slack")
+        _email = bound_args.arguments.get("email")
 
         run_kwargs = {
             "namespace": _namespace,
             "name": _name,
             "resume_from": _resume_from,
+            "slack": _slack,
+            "email": _email,
         }
 
         pipeline_run_dict = _self.func_crd_metadata_converter(
@@ -189,6 +227,8 @@ def convert_crd_metadata_pipeline_run(
     namespace = yaml_dict["namespace"]
     pipeline_name = yaml_dict["name"]
     resume_from = yaml_dict.get("resume_from")
+    slack = yaml_dict.get("slack")
+    email = yaml_dict.get("email")
     run_name = generate_pipeline_run_name()
 
     _LOG.info(
@@ -203,13 +243,20 @@ def convert_crd_metadata_pipeline_run(
         pipeline_name=pipeline_name,
         namespace=namespace,
         resume_from=resume_from,
+        slack=slack,
+        email=email,
     )
 
     return {"pipeline_run": pipeline_run}
 
 
 def generate_pipeline_run_object(
-    run_name: str, pipeline_name: str, namespace: str, resume_from: Optional[str] = None
+    run_name: str,
+    pipeline_name: str,
+    namespace: str,
+    resume_from: Optional[str] = None,
+    slack: Optional[str] = None,
+    email: Optional[str] = None,
 ) -> dict:
     """Generate PipelineRun object as dictionary.
 
@@ -219,6 +266,8 @@ def generate_pipeline_run_object(
         namespace: Kubernetes namespace
         resume_from: Optional resume specification in format
             "pipeline_run_name:step_name"
+        slack: Comma-separated Slack destinations for notifications
+        email: Comma-separated email addresses for notifications
 
     Returns:
         dict: Configured pipeline run object as dictionary
@@ -252,8 +301,48 @@ def generate_pipeline_run_object(
         else:
             _LOG.warning("Failed to parse resume_from: %r", resume_from)
 
+    # Add notifications if --slack or --email provided
+    notifications = _build_notifications(slack=slack, email=email)
+    if notifications:
+        pipeline_run_dict["spec"]["notifications"] = notifications
+
     _LOG.info("Generated pipeline run object: %s", run_name)
     return pipeline_run_dict
+
+
+_NOTIFICATION_EVENT_TYPES = [
+    "EVENT_TYPE_PIPELINE_RUN_STATE_SUCCEEDED",
+    "EVENT_TYPE_PIPELINE_RUN_STATE_FAILED",
+    "EVENT_TYPE_PIPELINE_RUN_STATE_KILLED",
+]
+
+
+def _build_notifications(
+    slack: Optional[str] = None, email: Optional[str] = None
+) -> list[dict]:
+    """Build notification entries from --slack and --email flag values."""
+    notifications: list[dict] = []
+    if slack:
+        destinations = [s.strip() for s in slack.split(",")]
+        notifications.append(
+            {
+                "notificationType": "NOTIFICATION_TYPE_SLACK",
+                "eventTypes": _NOTIFICATION_EVENT_TYPES,
+                "resourceType": "RESOURCE_TYPE_PIPELINE_RUN",
+                "slackDestinations": destinations,
+            }
+        )
+    if email:
+        addresses = [e.strip() for e in email.split(",")]
+        notifications.append(
+            {
+                "notificationType": "NOTIFICATION_TYPE_EMAIL",
+                "eventTypes": _NOTIFICATION_EVENT_TYPES,
+                "resourceType": "RESOURCE_TYPE_PIPELINE_RUN",
+                "emails": addresses,
+            }
+        )
+    return notifications
 
 
 def parse_resume_from(resume_from: str, namespace: str) -> dict:

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/run_test.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/run_test.py
@@ -189,8 +189,9 @@ class PipelineRunTest(TestCase):
             pipeline_name="test-pipeline",
             namespace="test-ns",
             resume_from=None,
-            slack=None,
-            email=None,
+            notify_slack=None,
+            notify_email=None,
+            notify_on=None,
         )
 
     @patch(
@@ -222,8 +223,9 @@ class PipelineRunTest(TestCase):
             pipeline_name="test-pipeline",
             namespace="test-ns",
             resume_from="previous-run:step-1",
-            slack=None,
-            email=None,
+            notify_slack=None,
+            notify_email=None,
+            notify_on=None,
         )
 
     @patch("michelangelo.cli.mactl.plugins.entity.pipeline.run.get_service_name")
@@ -334,29 +336,28 @@ class PipelineRunTest(TestCase):
 
     def test_build_notifications_slack(self):
         """Test _build_notifications with Slack destinations."""
-        result = _build_notifications(slack="@sally.lee,ml-team-channel")
+        result = _build_notifications(
+            notify_slack=["@sally.lee", "#ml-alerts"]
+        )
 
         self.assertEqual(len(result), 1)
         self.assertEqual(
             result[0]["notificationType"], "NOTIFICATION_TYPE_SLACK"
         )
         self.assertEqual(
-            result[0]["slackDestinations"], ["@sally.lee", "ml-team-channel"]
+            result[0]["slackDestinations"], ["@sally.lee", "#ml-alerts"]
         )
-        self.assertEqual(result[0]["resourceType"], "RESOURCE_TYPE_PIPELINE_RUN")
-        self.assertIn(
-            "EVENT_TYPE_PIPELINE_RUN_STATE_SUCCEEDED", result[0]["eventTypes"]
+        self.assertEqual(
+            result[0]["resourceType"], "RESOURCE_TYPE_PIPELINE_RUN"
         )
-        self.assertIn(
-            "EVENT_TYPE_PIPELINE_RUN_STATE_FAILED", result[0]["eventTypes"]
-        )
-        self.assertIn(
-            "EVENT_TYPE_PIPELINE_RUN_STATE_KILLED", result[0]["eventTypes"]
-        )
+        # All 4 event types by default
+        self.assertEqual(len(result[0]["eventTypes"]), 4)
 
     def test_build_notifications_email(self):
         """Test _build_notifications with email addresses."""
-        result = _build_notifications(email="a@x.com, b@x.com")
+        result = _build_notifications(
+            notify_email=["a@x.com", "b@x.com"]
+        )
 
         self.assertEqual(len(result), 1)
         self.assertEqual(
@@ -367,7 +368,8 @@ class PipelineRunTest(TestCase):
     def test_build_notifications_both(self):
         """Test _build_notifications with both Slack and email."""
         result = _build_notifications(
-            slack="@user", email="user@example.com"
+            notify_slack=["@user"],
+            notify_email=["user@example.com"],
         )
 
         self.assertEqual(len(result), 2)
@@ -382,26 +384,68 @@ class PipelineRunTest(TestCase):
         result = _build_notifications()
         self.assertEqual(result, [])
 
+    def test_build_notifications_custom_notify_on(self):
+        """Test _build_notifications with custom --notify-on event types."""
+        result = _build_notifications(
+            notify_slack=["#alerts"],
+            notify_on=["FAILED", "KILLED"],
+        )
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(
+            result[0]["eventTypes"],
+            [
+                "EVENT_TYPE_PIPELINE_RUN_STATE_FAILED",
+                "EVENT_TYPE_PIPELINE_RUN_STATE_KILLED",
+            ],
+        )
+
+    def test_build_notifications_single_notify_on(self):
+        """Test _build_notifications with a single --notify-on value."""
+        result = _build_notifications(
+            notify_email=["oncall@example.com"],
+            notify_on=["FAILED"],
+        )
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(
+            result[0]["eventTypes"],
+            ["EVENT_TYPE_PIPELINE_RUN_STATE_FAILED"],
+        )
+
     @patch("michelangelo.cli.mactl.plugins.entity.pipeline.run.get_user_name")
-    def test_generate_pipeline_run_object_with_slack(self, mock_get_user_name):
-        """Test pipeline run object includes Slack notifications."""
+    def test_generate_pipeline_run_object_with_notifications(
+        self, mock_get_user_name
+    ):
+        """Test pipeline run object includes notifications."""
         mock_get_user_name.return_value = "test-user"
 
         result = generate_pipeline_run_object(
             run_name="run-123",
             pipeline_name="test-pipeline",
             namespace="test-ns",
-            slack="@sally.lee,ml-team",
+            notify_slack=["@sally.lee", "#ml-team"],
+            notify_email=["oncall@example.com"],
+            notify_on=["FAILED", "SUCCEEDED"],
         )
 
         self.assertIn("notifications", result["spec"])
         notifs = result["spec"]["notifications"]
-        self.assertEqual(len(notifs), 1)
-        self.assertEqual(
-            notifs[0]["notificationType"], "NOTIFICATION_TYPE_SLACK"
+        self.assertEqual(len(notifs), 2)
+
+        slack_notif = next(
+            n for n in notifs
+            if n["notificationType"] == "NOTIFICATION_TYPE_SLACK"
         )
         self.assertEqual(
-            notifs[0]["slackDestinations"], ["@sally.lee", "ml-team"]
+            slack_notif["slackDestinations"], ["@sally.lee", "#ml-team"]
+        )
+        self.assertEqual(
+            slack_notif["eventTypes"],
+            [
+                "EVENT_TYPE_PIPELINE_RUN_STATE_FAILED",
+                "EVENT_TYPE_PIPELINE_RUN_STATE_SUCCEEDED",
+            ],
         )
 
     @patch("michelangelo.cli.mactl.plugins.entity.pipeline.run.get_user_name")

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/run_test.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/run_test.py
@@ -336,33 +336,21 @@ class PipelineRunTest(TestCase):
 
     def test_build_notifications_slack(self):
         """Test _build_notifications with Slack destinations."""
-        result = _build_notifications(
-            notify_slack=["@sally.lee", "#ml-alerts"]
-        )
+        result = _build_notifications(notify_slack=["@sally.lee", "#ml-alerts"])
 
         self.assertEqual(len(result), 1)
-        self.assertEqual(
-            result[0]["notificationType"], "NOTIFICATION_TYPE_SLACK"
-        )
-        self.assertEqual(
-            result[0]["slackDestinations"], ["@sally.lee", "#ml-alerts"]
-        )
-        self.assertEqual(
-            result[0]["resourceType"], "RESOURCE_TYPE_PIPELINE_RUN"
-        )
+        self.assertEqual(result[0]["notificationType"], "NOTIFICATION_TYPE_SLACK")
+        self.assertEqual(result[0]["slackDestinations"], ["@sally.lee", "#ml-alerts"])
+        self.assertEqual(result[0]["resourceType"], "RESOURCE_TYPE_PIPELINE_RUN")
         # All 4 event types by default
         self.assertEqual(len(result[0]["eventTypes"]), 4)
 
     def test_build_notifications_email(self):
         """Test _build_notifications with email addresses."""
-        result = _build_notifications(
-            notify_email=["a@x.com", "b@x.com"]
-        )
+        result = _build_notifications(notify_email=["a@x.com", "b@x.com"])
 
         self.assertEqual(len(result), 1)
-        self.assertEqual(
-            result[0]["notificationType"], "NOTIFICATION_TYPE_EMAIL"
-        )
+        self.assertEqual(result[0]["notificationType"], "NOTIFICATION_TYPE_EMAIL")
         self.assertEqual(result[0]["emails"], ["a@x.com", "b@x.com"])
 
     def test_build_notifications_both(self):
@@ -414,9 +402,7 @@ class PipelineRunTest(TestCase):
         )
 
     @patch("michelangelo.cli.mactl.plugins.entity.pipeline.run.get_user_name")
-    def test_generate_pipeline_run_object_with_notifications(
-        self, mock_get_user_name
-    ):
+    def test_generate_pipeline_run_object_with_notifications(self, mock_get_user_name):
         """Test pipeline run object includes notifications."""
         mock_get_user_name.return_value = "test-user"
 
@@ -434,12 +420,9 @@ class PipelineRunTest(TestCase):
         self.assertEqual(len(notifs), 2)
 
         slack_notif = next(
-            n for n in notifs
-            if n["notificationType"] == "NOTIFICATION_TYPE_SLACK"
+            n for n in notifs if n["notificationType"] == "NOTIFICATION_TYPE_SLACK"
         )
-        self.assertEqual(
-            slack_notif["slackDestinations"], ["@sally.lee", "#ml-team"]
-        )
+        self.assertEqual(slack_notif["slackDestinations"], ["@sally.lee", "#ml-team"])
         self.assertEqual(
             slack_notif["eventTypes"],
             [
@@ -449,9 +432,7 @@ class PipelineRunTest(TestCase):
         )
 
     @patch("michelangelo.cli.mactl.plugins.entity.pipeline.run.get_user_name")
-    def test_generate_pipeline_run_object_no_notifications(
-        self, mock_get_user_name
-    ):
+    def test_generate_pipeline_run_object_no_notifications(self, mock_get_user_name):
         """Test pipeline run object has no notifications field when flags absent."""
         mock_get_user_name.return_value = "test-user"
 

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/run_test.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/run_test.py
@@ -443,3 +443,22 @@ class PipelineRunTest(TestCase):
         )
 
         self.assertNotIn("notifications", result["spec"])
+
+    def test_build_notifications_empty_string_destinations_filtered(self):
+        """Test that empty-string destinations are filtered out."""
+        result = _build_notifications(notify_slack=["", " ", "#valid"])
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["slackDestinations"], ["#valid"])
+
+    def test_build_notifications_all_empty_destinations(self):
+        """Test that all-empty destinations produce no notifications."""
+        result = _build_notifications(notify_slack=["", "  "])
+        self.assertEqual(result, [])
+
+    @patch("michelangelo.cli.mactl.plugins.entity.pipeline.run._LOG")
+    def test_build_notifications_notify_on_without_destinations_warns(self, mock_log):
+        """Test that --notify-on without destinations logs a warning."""
+        result = _build_notifications(notify_on=["FAILED"])
+        self.assertEqual(result, [])
+        mock_log.warning.assert_called_once()
+        self.assertIn("--notify-on", mock_log.warning.call_args[0][0])

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/run_test.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/run_test.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 
 from michelangelo.cli.mactl.plugins.entity.pipeline.run import (
     _build_notifications,
+    _split_csv,
     convert_crd_metadata_pipeline_run,
     generate_pipeline_run_name,
     generate_pipeline_run_object,
@@ -462,3 +463,56 @@ class PipelineRunTest(TestCase):
         self.assertEqual(result, [])
         mock_log.warning.assert_called_once()
         self.assertIn("--notify-on", mock_log.warning.call_args[0][0])
+
+    # ------------------------------------------------------------------
+    # Comma-separated value tests
+    # ------------------------------------------------------------------
+
+    def test_split_csv_basic(self):
+        """Test _split_csv splits comma-separated values."""
+        self.assertEqual(_split_csv(["a,b,c"]), ["a", "b", "c"])
+
+    def test_split_csv_mixed_repeat_and_csv(self):
+        """Test _split_csv handles mix of repeated and comma-separated."""
+        self.assertEqual(_split_csv(["a", "b,c"]), ["a", "b", "c"])
+
+    def test_split_csv_strips_whitespace(self):
+        """Test _split_csv strips whitespace around values."""
+        self.assertEqual(_split_csv(["a , b"]), ["a", "b"])
+
+    def test_split_csv_filters_empty(self):
+        """Test _split_csv filters empty segments."""
+        self.assertEqual(_split_csv(["a,,b", ""]), ["a", "b"])
+
+    def test_split_csv_none(self):
+        """Test _split_csv returns empty list for None."""
+        self.assertEqual(_split_csv(None), [])
+
+    def test_build_notifications_csv_email(self):
+        """Test _build_notifications with comma-separated emails."""
+        result = _build_notifications(notify_email=["a@x.com,b@x.com"])
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["emails"], ["a@x.com", "b@x.com"])
+
+    def test_build_notifications_csv_notify_on(self):
+        """Test _build_notifications with comma-separated --notify-on."""
+        result = _build_notifications(
+            notify_slack=["#alerts"],
+            notify_on=["SUCCEEDED,FAILED"],
+        )
+        self.assertEqual(
+            result[0]["eventTypes"],
+            [
+                "EVENT_TYPE_PIPELINE_RUN_STATE_SUCCEEDED",
+                "EVENT_TYPE_PIPELINE_RUN_STATE_FAILED",
+            ],
+        )
+
+    def test_build_notifications_invalid_notify_on_raises(self):
+        """Test _build_notifications raises on invalid --notify-on value."""
+        with self.assertRaises(ValueError) as ctx:
+            _build_notifications(
+                notify_slack=["#alerts"],
+                notify_on=["INVALID"],
+            )
+        self.assertIn("INVALID", str(ctx.exception))

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/run_test.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/run_test.py
@@ -9,6 +9,7 @@ from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 from michelangelo.cli.mactl.plugins.entity.pipeline.run import (
+    _build_notifications,
     convert_crd_metadata_pipeline_run,
     generate_pipeline_run_name,
     generate_pipeline_run_object,
@@ -188,6 +189,8 @@ class PipelineRunTest(TestCase):
             pipeline_name="test-pipeline",
             namespace="test-ns",
             resume_from=None,
+            slack=None,
+            email=None,
         )
 
     @patch(
@@ -219,6 +222,8 @@ class PipelineRunTest(TestCase):
             pipeline_name="test-pipeline",
             namespace="test-ns",
             resume_from="previous-run:step-1",
+            slack=None,
+            email=None,
         )
 
     @patch("michelangelo.cli.mactl.plugins.entity.pipeline.run.get_service_name")
@@ -322,3 +327,94 @@ class PipelineRunTest(TestCase):
         with patch("builtins.print") as mock_print:
             mock_crd.run(namespace="test-ns", name="test-pipeline")
             mock_print.assert_called_once_with(mock_response)
+
+    # ------------------------------------------------------------------
+    # Notification tests
+    # ------------------------------------------------------------------
+
+    def test_build_notifications_slack(self):
+        """Test _build_notifications with Slack destinations."""
+        result = _build_notifications(slack="@sally.lee,ml-team-channel")
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(
+            result[0]["notificationType"], "NOTIFICATION_TYPE_SLACK"
+        )
+        self.assertEqual(
+            result[0]["slackDestinations"], ["@sally.lee", "ml-team-channel"]
+        )
+        self.assertEqual(result[0]["resourceType"], "RESOURCE_TYPE_PIPELINE_RUN")
+        self.assertIn(
+            "EVENT_TYPE_PIPELINE_RUN_STATE_SUCCEEDED", result[0]["eventTypes"]
+        )
+        self.assertIn(
+            "EVENT_TYPE_PIPELINE_RUN_STATE_FAILED", result[0]["eventTypes"]
+        )
+        self.assertIn(
+            "EVENT_TYPE_PIPELINE_RUN_STATE_KILLED", result[0]["eventTypes"]
+        )
+
+    def test_build_notifications_email(self):
+        """Test _build_notifications with email addresses."""
+        result = _build_notifications(email="a@x.com, b@x.com")
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(
+            result[0]["notificationType"], "NOTIFICATION_TYPE_EMAIL"
+        )
+        self.assertEqual(result[0]["emails"], ["a@x.com", "b@x.com"])
+
+    def test_build_notifications_both(self):
+        """Test _build_notifications with both Slack and email."""
+        result = _build_notifications(
+            slack="@user", email="user@example.com"
+        )
+
+        self.assertEqual(len(result), 2)
+        types = {n["notificationType"] for n in result}
+        self.assertEqual(
+            types,
+            {"NOTIFICATION_TYPE_SLACK", "NOTIFICATION_TYPE_EMAIL"},
+        )
+
+    def test_build_notifications_none(self):
+        """Test _build_notifications with no flags returns empty list."""
+        result = _build_notifications()
+        self.assertEqual(result, [])
+
+    @patch("michelangelo.cli.mactl.plugins.entity.pipeline.run.get_user_name")
+    def test_generate_pipeline_run_object_with_slack(self, mock_get_user_name):
+        """Test pipeline run object includes Slack notifications."""
+        mock_get_user_name.return_value = "test-user"
+
+        result = generate_pipeline_run_object(
+            run_name="run-123",
+            pipeline_name="test-pipeline",
+            namespace="test-ns",
+            slack="@sally.lee,ml-team",
+        )
+
+        self.assertIn("notifications", result["spec"])
+        notifs = result["spec"]["notifications"]
+        self.assertEqual(len(notifs), 1)
+        self.assertEqual(
+            notifs[0]["notificationType"], "NOTIFICATION_TYPE_SLACK"
+        )
+        self.assertEqual(
+            notifs[0]["slackDestinations"], ["@sally.lee", "ml-team"]
+        )
+
+    @patch("michelangelo.cli.mactl.plugins.entity.pipeline.run.get_user_name")
+    def test_generate_pipeline_run_object_no_notifications(
+        self, mock_get_user_name
+    ):
+        """Test pipeline run object has no notifications field when flags absent."""
+        mock_get_user_name.return_value = "test-user"
+
+        result = generate_pipeline_run_object(
+            run_name="run-123",
+            pipeline_name="test-pipeline",
+            namespace="test-ns",
+        )
+
+        self.assertNotIn("notifications", result["spec"])


### PR DESCRIPTION
## Summary

Adds `--notify-slack`, `--notify-email`, and `--notify-on` CLI flags to `ma pipeline run`, wiring up the existing notification infrastructure so users can receive Slack or email alerts on pipeline run state changes without hand-crafting YAML.

Closes #1344

### CLI Interface

```
usage: ma pipeline run [-h] -n NAMESPACE --name NAME
                        [--resume_from RESUME_FROM]
                        [--notify-slack NOTIFY_SLACK]
                        [--notify-email NOTIFY_EMAIL]
                        [--notify-on NOTIFY_ON]
```

| Flag | Description | Format |
|------|-------------|--------|
| `--notify-slack` | Slack destination (channel or @user) | Repeatable or comma-separated |
| `--notify-email` | Email address | Repeatable or comma-separated |
| `--notify-on` | Event types: `SUCCEEDED`, `FAILED`, `KILLED`, `SKIPPED` | Repeatable or comma-separated. Default: all |

`--notify-on` applies to **all** destinations. For per-destination event filtering, use YAML specs ([notifications guide](docs/user-guides/ml-pipelines/notifications.md)).

### Usage Examples

```bash
# Comma-separated (concise)
ma pipeline run -n my-project --name california-housing-xgb \
  --notify-email alice@example.com,oncall@example.com \
  --notify-slack "#ml-alerts" \
  --notify-on FAILED,SUCCEEDED

# Repeatable (also works, can mix both styles)
ma pipeline run -n my-project --name california-housing-xgb \
  --notify-email alice@example.com \
  --notify-email oncall@example.com \
  --notify-slack "#ml-alerts" \
  --notify-on FAILED --notify-on SUCCEEDED

# Minimal — notify on all events (default)
ma pipeline run -n my-project --name california-housing-xgb \
  --notify-slack "#ml-alerts"
```

### Files Changed (4 files, +390 lines)

**`python/michelangelo/cli/mactl/plugins/entity/pipeline/run.py`** (+154)

- `add_function_signature()` — 3 new argparse args (`action=append`)
- `run_func()` / `convert_crd_metadata_pipeline_run()` / `generate_pipeline_run_object()` — pass notification args through the pipeline
- `_split_csv()` — flattens comma-separated + repeated values, strips whitespace, filters empties
- `_build_notifications()` — builds proto-compatible Notification dicts; validates `--notify-on` values; warns when `--notify-on` set without destinations
- `_NOTIFY_ON_MAP` / `_DEFAULT_NOTIFY_ON` — short names → proto enum strings (single source of truth)

**`python/michelangelo/cli/mactl/plugins/entity/pipeline/run_test.py`** (+194)

- 19 new tests: slack/email/both/none, custom/single `--notify-on`, comma-separated, mixed repeat+CSV, empty-string filtering, warn-on-no-destination, invalid value validation, `_split_csv` edge cases
- 2 existing tests updated for new kwargs

**`docs/user-guides/reference/cli.md`** (+29)

- "Notification Arguments" section with flag table, syntax, examples, cross-reference

**`docs/user-guides/ml-pipelines/notifications.md`** (+15)

- "CLI Shorthand" section with example and shared-filter limitation note

### No Backend Changes

The proto layer (`PipelineRunSpec.notifications` field 11) and Go controller (`notifier.NotifyOnStateChange()`) already support notifications end-to-end. This PR only wires up the Python CLI.

### OSS Review Findings

| # | Finding | Status |
|---|---------|--------|
| 1 | `--notify-on` without destinations silently ignored | Fixed — warns |
| 2 | Empty-string destinations pass through | Fixed — filtered via `_split_csv` |
| 3 | `--resume_from` vs `--notify-*` naming inconsistency | #1352 filed |
| 5 | `_DEFAULT_NOTIFY_ON` duplicates map values | Fixed — derived from map |
| 7 | Help text doesn't explain shared filter | Fixed — "Applies to all destinations" |
| 8 | Docs needed | Fixed — CLI reference + notifications guide |
| 9 | Per-destination filtering v1 limitation | Documented |

## E2E Verification

Verified on local k3d sandbox with the california-housing-xgb pipeline:

```bash
ma pipeline run -n ma-examples --name california-housing-xgb \
  --notify-slack @sally.lee \
  --notify-email sally@example.com \
  --notify-on SUCCEEDED,FAILED
```

`ma pipeline_run get` confirms notifications persisted and run succeeded:

```
spec {
  notifications {
    notification_type: NOTIFICATION_TYPE_SLACK
    event_types: EVENT_TYPE_PIPELINE_RUN_STATE_SUCCEEDED
    event_types: EVENT_TYPE_PIPELINE_RUN_STATE_FAILED
    slack_destinations: "@sally.lee"
  }
  notifications {
    notification_type: NOTIFICATION_TYPE_EMAIL
    event_types: EVENT_TYPE_PIPELINE_RUN_STATE_SUCCEEDED
    event_types: EVENT_TYPE_PIPELINE_RUN_STATE_FAILED
    emails: "sally@example.com"
  }
}
status { state: PIPELINE_RUN_STATE_SUCCEEDED }
```

Controller dispatched `PRNotificationWorkflow` successfully. Worker panic on nil email sender is a pre-existing Go bug (SMTP not configured in sandbox).

## Test Plan

- [x] 33 unit tests pass (14 existing + 19 new)
- [x] Ruff lint/format clean
- [x] `ma pipeline run --help` shows all 3 flags
- [x] E2E: notifications in `spec.notifications` verified via apiserver
- [x] E2E: `PIPELINE_RUN_STATE_SUCCEEDED`
- [x] E2E: `PRNotificationWorkflow` dispatched by controller
- [ ] CI passes