### PR TITLE
ci(release): add cliff.toml for changelog generation

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,48 @@
+[changelog]
+header = """
+# Changelog\n
+All notable changes to this project will be documented in this file.\n
+"""
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [Unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group }}\n
+    {% for commit in commits %}
+        - {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message | upper_first }}\
+            {% if commit.breaking %} [**BREAKING**]{% endif %}\n
+    {% endfor %}
+{% endfor %}\n
+"""
+footer = ""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+split_commits = false
+protect_breaking_commits = true
+tag_pattern = "v[0-9].*"
+skip_tags = ".*\\.dev.*"
+ignore_tags = ""
+topo_order = false
+sort_commits = "oldest"
+
+commit_preprocessors = [
+    { pattern = "\\.$", replace = "" },
+]
+
+commit_parsers = [
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^docs", group = "Documentation" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Refactoring" },
+    { message = "^ci", group = "CI/CD" },
+    { message = "^test", group = "Testing" },
+    { message = "^chore", group = "Miscellaneous" },
+    { message = ".*", group = "Miscellaneous" },
+]


### PR DESCRIPTION
## Summary
- Adds `cliff.toml` at repo root for [git-cliff](https://git-cliff.org/) changelog generation
- Configures conventional commit parsers mapping to 8 groups: Features, Bug Fixes, Documentation, Performance, Refactoring, CI/CD, Testing, Miscellaneous
- Enables BREAKING CHANGE detection via commit body/footer (`protect_breaking_commits = true`)
- Skips nightly dev tags (`*.dev.*`), targets release tags (`v[0-9].*`)
- Catch-all parser routes unrecognized commit types to Miscellaneous

## Test plan
- [x] TOML validates cleanly (`python3 -c "import tomllib; tomllib.load(open('cliff.toml', 'rb'))"`)
- [ ] Run `git-cliff` against repo history to verify output format

Part of #1338