### PR TITLE
fix(helm): add missing taskList to Temporal workflowClient config

### DIFF
--- a/helm/michelangelo/templates/core/controllermgr-configmap.yaml
+++ b/helm/michelangelo/templates/core/controllermgr-configmap.yaml
@@ -65,6 +65,7 @@ data:
       transport: grpc
       domain: {{ .Values.workflow.domain | default "default" | quote }}
       provider: Temporal
+      taskList: default
       {{- with .Values.controllermgr.workflowClient.executionUrlFormat }}
       executionUrlFormat: {{ . | quote }}
       {{- end }}


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Added `taskList: default` to the Temporal branch of the controllermgr configmap template. The Cadence branch already had this field, but it was missing from the Temporal block.

**Why?**

When using `--workflow temporal`, all pipeline runs fail immediately with `"WorkflowClient TaskList is empty"` because the `getTaskList()` fallback in `executeworkflow.go` reads `workflowConfig.TaskList` from the configmap — which was empty for Temporal. This brings the Temporal config to parity with Cadence.

Discovered during sandbox E2E testing of notification changes (PR #1283).

**How did you test it?**

- Created a Temporal sandbox (`ma sandbox create --workflow temporal`)
- Verified pipeline runs failed with `"WorkflowClient TaskList is empty"` before the fix
- Applied the fix to the configmap, restarted controllermgr
- Pipeline run progressed to RUNNING state (feature_prep step executing)

**Potential risks**

None — this adds a missing config field that the Cadence path already has. Operators who set `project.annotations["michelangelo/worker_queue"]` are unaffected (that takes priority over the config fallback).

**Release notes**

Temporal sandbox users: pipeline runs now work out of the box. Previously required manually patching the controllermgr configmap.

**Documentation Changes**

N/A