### PR TITLE
ci(release): add PyPI publishing step to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,6 +32,13 @@ jobs:
       - run: |
           poetry build -f wheel
       #----------------------------------------------
+      #  Publish to PyPI
+      #----------------------------------------------
+      - name: Configure PyPI token
+        run: poetry config pypi-token.pypi ${{ secrets.PYPI_API_TOKEN }}
+      - name: Publish to PyPI
+        run: poetry publish --no-interaction
+      #----------------------------------------------
       #  Upload the wheel file to the release
       #----------------------------------------------
       - uses: softprops/action-gh-release@v2


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**
Added PyPI publishing steps to the existing `release.yaml` workflow. After building the wheel, the workflow now configures the PyPI token and runs `poetry publish --no-interaction` before uploading to GitHub Release.

**Why?**
Enables users to install Michelangelo via `pip install michelangelo` from PyPI, instead of downloading wheel files from GitHub Releases manually.

**How did you test it?**
- Verified YAML structure is valid
- `PYPI_API_TOKEN` secret has been configured in repo settings
- Full validation will occur on next tagged release

**Potential risks**
Publishing step will fail if `PYPI_API_TOKEN` is misconfigured or the package name is already taken on PyPI.

**Release notes**
Python packages will now be published to PyPI on every tagged release.

**Documentation Changes**
N/A

Part of #1338