### PR TITLE
feat(cli): add STARTED event type to --notify-on flag

### DIFF
--- a/docs/user-guides/ml-pipelines/notifications.md
+++ b/docs/user-guides/ml-pipelines/notifications.md
@@ -105,6 +105,7 @@ Choose events based on the `resourceType` you're watching.
 | `EVENT_TYPE_PIPELINE_RUN_STATE_FAILED` | Run failed |
 | `EVENT_TYPE_PIPELINE_RUN_STATE_KILLED` | Run was manually stopped |
 | `EVENT_TYPE_PIPELINE_RUN_STATE_SKIPPED` | Run was skipped (e.g., by a trigger concurrency policy) |
+| `EVENT_TYPE_PIPELINE_RUN_STATE_STARTED` | Run started executing (opt-in via `--notify-on STARTED`) |
 
 #### Trigger Run Events (`RESOURCE_TYPE_TRIGGER_RUN`)
 

--- a/docs/user-guides/ml-pipelines/notifications.md
+++ b/docs/user-guides/ml-pipelines/notifications.md
@@ -105,7 +105,7 @@ Choose events based on the `resourceType` you're watching.
 | `EVENT_TYPE_PIPELINE_RUN_STATE_FAILED` | Run failed |
 | `EVENT_TYPE_PIPELINE_RUN_STATE_KILLED` | Run was manually stopped |
 | `EVENT_TYPE_PIPELINE_RUN_STATE_SKIPPED` | Run was skipped (e.g., by a trigger concurrency policy) |
-| `EVENT_TYPE_PIPELINE_RUN_STATE_STARTED` | Run started executing (opt-in via `--notify-on STARTED`) |
+| `EVENT_TYPE_PIPELINE_RUN_STATE_STARTED` | Run started executing (not included in CLI defaults) |
 
 #### Trigger Run Events (`RESOURCE_TYPE_TRIGGER_RUN`)
 

--- a/docs/user-guides/reference/cli.md
+++ b/docs/user-guides/reference/cli.md
@@ -232,7 +232,7 @@ You can attach notification rules directly to a pipeline run so you're alerted w
 
 - `--notify-slack` — Slack destination (channel or @user). Repeatable or comma-separated.
 - `--notify-email` — Email address. Repeatable or comma-separated.
-- `--notify-on` — Event type to trigger on: `SUCCEEDED`, `FAILED`, `KILLED`, or `SKIPPED`. Repeatable or comma-separated. Defaults to all four when omitted. Applies to all destinations (per-destination filtering is not yet supported — use YAML specs for that).
+- `--notify-on` — Event type to trigger on: `SUCCEEDED`, `FAILED`, `KILLED`, `SKIPPED`, or `STARTED`. Repeatable or comma-separated. Defaults to the four terminal states (`SUCCEEDED`, `FAILED`, `KILLED`, `SKIPPED`) when omitted; `STARTED` is opt-in. Applies to all destinations (per-destination filtering is not yet supported — use YAML specs for that).
 
 Syntax:
 

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/run.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/run.py
@@ -130,8 +130,9 @@ def add_function_signature(crd: CRD) -> None:
                         "default": None,
                         "help": (
                             "Event type to notify on: SUCCEEDED, FAILED, "
-                            "KILLED, SKIPPED. Repeatable or comma-separated. "
-                            "Applies to all destinations. Default: all"
+                            "KILLED, SKIPPED, STARTED. Repeatable or comma-separated. "
+                            "Applies to all destinations. Default: SUCCEEDED, FAILED, "
+                            "KILLED, SKIPPED (terminal states)"
                         ),
                     },
                 },
@@ -343,9 +344,15 @@ _NOTIFY_ON_MAP = {
     "FAILED": "EVENT_TYPE_PIPELINE_RUN_STATE_FAILED",
     "KILLED": "EVENT_TYPE_PIPELINE_RUN_STATE_KILLED",
     "SKIPPED": "EVENT_TYPE_PIPELINE_RUN_STATE_SKIPPED",
+    "STARTED": "EVENT_TYPE_PIPELINE_RUN_STATE_STARTED",
 }
 
-_DEFAULT_NOTIFY_ON = list(_NOTIFY_ON_MAP.values())
+_DEFAULT_NOTIFY_ON = [
+    "EVENT_TYPE_PIPELINE_RUN_STATE_SUCCEEDED",
+    "EVENT_TYPE_PIPELINE_RUN_STATE_FAILED",
+    "EVENT_TYPE_PIPELINE_RUN_STATE_KILLED",
+    "EVENT_TYPE_PIPELINE_RUN_STATE_SKIPPED",
+]
 
 
 def _split_csv(values: Optional[list[str]]) -> list[str]:

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/run_test.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/run_test.py
@@ -402,6 +402,46 @@ class PipelineRunTest(TestCase):
             ["EVENT_TYPE_PIPELINE_RUN_STATE_FAILED"],
         )
 
+    def test_build_notifications_started_event(self):
+        """Test _build_notifications with STARTED event type."""
+        result = _build_notifications(
+            notify_slack=["#alerts"],
+            notify_on=["STARTED"],
+        )
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(
+            result[0]["eventTypes"],
+            ["EVENT_TYPE_PIPELINE_RUN_STATE_STARTED"],
+        )
+
+    def test_build_notifications_started_with_terminal_events(self):
+        """Test _build_notifications with STARTED combined with terminal events."""
+        result = _build_notifications(
+            notify_email=["oncall@example.com"],
+            notify_on=["STARTED", "FAILED", "SUCCEEDED"],
+        )
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(
+            result[0]["eventTypes"],
+            [
+                "EVENT_TYPE_PIPELINE_RUN_STATE_STARTED",
+                "EVENT_TYPE_PIPELINE_RUN_STATE_FAILED",
+                "EVENT_TYPE_PIPELINE_RUN_STATE_SUCCEEDED",
+            ],
+        )
+
+    def test_build_notifications_defaults_exclude_started(self):
+        """Test that default event types do not include STARTED."""
+        result = _build_notifications(notify_slack=["#alerts"])
+        self.assertEqual(len(result), 1)
+        self.assertNotIn(
+            "EVENT_TYPE_PIPELINE_RUN_STATE_STARTED",
+            result[0]["eventTypes"],
+        )
+        self.assertEqual(len(result[0]["eventTypes"]), 4)
+
     @patch("michelangelo.cli.mactl.plugins.entity.pipeline.run.get_user_name")
     def test_generate_pipeline_run_object_with_notifications(self, mock_get_user_name):
         """Test pipeline run object includes notifications."""


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**

- Added `STARTED` as a valid `--notify-on` value for `ma pipeline run`, mapping to `EVENT_TYPE_PIPELINE_RUN_STATE_STARTED` (proto value 11)
- `STARTED` is opt-in only — default event types remain the four terminal states (`SUCCEEDED`, `FAILED`, `KILLED`, `SKIPPED`)
- Updated CLI help text, CLI reference docs, and notifications guide

**Why?**

PR #1283 introduced `EVENT_TYPE_PIPELINE_RUN_STATE_STARTED` in the proto and Go backend, but the CLI didn't expose it. Users who want to know when a long-running pipeline begins executing (e.g., after queueing) had no way to subscribe via the CLI.

**How did you test it?**

- 3 new unit tests: `STARTED` alone, `STARTED` combined with terminal events, defaults exclude `STARTED`
- All 8 notification-related tests pass
- `python -m pytest run_test.py -v -k "started or notify"` — 8 passed

**Potential risks**

None — additive change, no existing behavior modified. Default event types unchanged.

**Release notes**

- `STARTED` is now a valid `--notify-on` value for `ma pipeline run`

**Documentation Changes**

- `docs/user-guides/reference/cli.md` — added `STARTED` to valid values list
- `docs/user-guides/ml-pipelines/notifications.md` — added `STARTED` to Pipeline Run Events table

## Test Plan
- [x] `test_build_notifications_started_event` — STARTED alone maps correctly
- [x] `test_build_notifications_started_with_terminal_events` — STARTED + FAILED + SUCCEEDED
- [x] `test_build_notifications_defaults_exclude_started` — defaults stay as 4 terminal states

Closes #1368
Related: PR #1283 (introduced EVENT_TYPE_PIPELINE_RUN_STATE_STARTED)