### PR TITLE
ci(release): add Helm OCI chart publishing to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,3 +38,36 @@ jobs:
         with:
           tag_name: ${{ github.ref_name }}
           files: python/dist/*.whl
+
+  helm-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Log in to GHCR
+        run: |
+          helm registry login ghcr.io \
+            -u ${{ github.actor }} \
+            -p ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Package Helm chart
+        run: |
+          helm package helm/michelangelo \
+            --version ${{ steps.version.outputs.VERSION }} \
+            --app-version ${{ steps.version.outputs.VERSION }}
+
+      - name: Push chart to OCI registry
+        run: |
+          helm push \
+            michelangelo-${{ steps.version.outputs.VERSION }}.tgz \
+            oci://ghcr.io/michelangelo-ai/michelangelo/charts


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
Added a `helm-publish` job to `release.yaml` that packages and pushes the Helm chart to `oci://ghcr.io/michelangelo-ai/michelangelo/charts` on every tagged release. Runs in parallel with the existing `build-upload` job.

**Why?**
Enables users to install the Michelangelo Helm chart via OCI registry (`helm install michelangelo oci://ghcr.io/michelangelo-ai/michelangelo/charts/michelangelo --version X.Y.Z`) instead of cloning the repo.

**How did you test it?**
- actionlint and yamllint pass
- Full validation will occur on next tagged release

**Potential risks**
First push to ghcr.io OCI registry — the package namespace needs to exist or will be auto-created on first push.

**Breaking Changes**
- [x] No breaking changes

**Release notes**
Helm chart will now be published to ghcr.io OCI registry on every tagged release.

**Documentation Changes**
N/A

Part of #1338