### PR TITLE
chore: align all component versions to 0.3.0

### DIFF
--- a/helm/michelangelo/Chart.yaml
+++ b/helm/michelangelo/Chart.yaml
@@ -7,8 +7,8 @@ description: |
   and RBAC — into any Kubernetes cluster. Bring your own metadata storage,
   object storage, and workflow engine (Cadence or Temporal).
 type: application
-version: 0.1.0
-appVersion: "0.2.1"
+version: 0.3.0
+appVersion: "0.3.0"
 kubeVersion: ">=1.27.0-0"
 
 dependencies:

--- a/javascript/packages/core/package.json
+++ b/javascript/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@michelangelo-ai/core",
   "license": "Apache-2.0",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "type": "module",
   "main": "./dist/michelangelo-core.js",
   "module": "./dist/michelangelo-core.js",

--- a/javascript/packages/rpc/package.json
+++ b/javascript/packages/rpc/package.json
@@ -2,7 +2,7 @@
   "name": "@michelangelo/rpc",
   "license": "Apache-2.0",
   "type": "module",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "scripts": {
     "build": "vite build",
     "test": "cd ../../ && yarn test:rpc"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "michelangelo"
-version = "0.1.1"
+version = "0.3.0"
 description = "Michelangelo is an end-to-end model lifecycle management system at large scale"
 authors = ["Michelangelo Team <michelangelo-oss-group@uber.com>"]
 readme = "README.md"

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "website",
-  "version": "0.0.0",
+  "version": "0.3.0",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**

Unified version numbers across all 6 release artifacts to `0.3.0`:

| Component | File | Before | After |
|---|---|---|---|
| Python SDK | `python/pyproject.toml` | 0.1.1 | 0.3.0 |
| UI app | `website/package.json` | 0.0.0 | 0.3.0 |
| npm core | `javascript/packages/core/package.json` | 0.2.4 | 0.3.0 |
| npm rpc | `javascript/packages/rpc/package.json` | 0.1.0 | 0.3.0 |
| Helm chart version | `helm/michelangelo/Chart.yaml` | 0.1.0 | 0.3.0 |
| Helm appVersion | `helm/michelangelo/Chart.yaml` | 0.2.1 | 0.3.0 |

**Why?**

Prerequisite for the first coordinated release (v0.3.0). All artifacts must share the same Major.Minor version so users know which versions are compatible. Starting at 0.3.0 (not 0.2.0) because npm core is already at 0.2.4 — publishing 0.2.0 would be a version downgrade that npm rejects.

Part of [Release] Phase 1: Foundation (#1338).

**How did you test it?**

Ran `check_version_alignment.py` — confirms all 6 components report `0.3.0` and are aligned at `0.3.x`.

**Potential risks**

None — version numbers are metadata only and do not affect runtime behavior. No artifacts are published from this change alone.

**Release notes**

All component versions aligned to 0.3.0 in preparation for the first coordinated release.

**Documentation Changes**

N/A