### PR TITLE
ci: add changelog generation workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,79 @@
+name: Changelog
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to generate changelog for (e.g. v0.3.0). Defaults to latest tag.'
+        required: false
+
+permissions:
+  contents: write
+
+jobs:
+  generate-changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.tag }}" ]; then
+            TAG="${{ inputs.tag }}"
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            TAG="${{ github.ref_name }}"
+          else
+            TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          fi
+
+          if [ -z "$TAG" ]; then
+            echo "::error::No tag found. Push a tag or provide one via workflow_dispatch."
+            exit 1
+          fi
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Using tag: $TAG"
+
+      - name: Generate release notes
+        uses: orhun/git-cliff-action@v4
+        id: cliff-latest
+        with:
+          config: cliff.toml
+          args: --latest --strip header
+        env:
+          OUTPUT: RELEASE_NOTES.md
+          GITHUB_REPO: ${{ github.repository }}
+
+      - name: Generate full changelog
+        uses: orhun/git-cliff-action@v4
+        id: cliff-full
+        with:
+          config: cliff.toml
+          args: --output CHANGELOG.md
+        env:
+          OUTPUT: CHANGELOG.md
+          GITHUB_REPO: ${{ github.repository }}
+
+      - name: Update GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          body_path: RELEASE_NOTES.md
+          append_body: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload changelog artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: changelog
+          path: |
+            CHANGELOG.md
+            RELEASE_NOTES.md
+          retention-days: 90


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [x] CI/CD changes
- [ ] Other

## What changed?

Added `.github/workflows/changelog.yml` that automatically generates release notes when a version tag is pushed. Uses `git-cliff` with the existing `cliff.toml` configuration to produce categorized changelogs from conventional commits.

## Why?

Release task 008 (Phase 2). Automated changelog generation ensures every release has consistent, accurate release notes derived from commit history. Eliminates manual changelog authoring.

Closes: Part of https://github.com/michelangelo-ai/michelangelo/issues/1339

## How did you test it?

- Verified YAML syntax and workflow structure
- Confirmed `orhun/git-cliff-action@v4` and `softprops/action-gh-release@v2` match existing repo patterns
- Validated compatibility with existing `cliff.toml` commit parsers and template

## Potential risks

None — new workflow file only. Runs only on tag pushes and manual dispatch.

## Release notes

Added automated changelog generation. Release notes are now auto-generated from conventional commits when a version tag is pushed.

## Documentation Changes

N/A

Closes: Part of #1339