### PR TITLE
ci: add release checklist issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -1,0 +1,50 @@
+---
+name: Release Checklist
+about: Track all steps for cutting a new release
+title: 'Release vX.Y.Z'
+labels: ['release']
+assignees: ''
+---
+
+## Pre-Release
+
+- [ ] All CI checks pass on the release branch
+- [ ] Version numbers updated across all components:
+  - [ ] `python/pyproject.toml`
+  - [ ] `javascript/packages/core/package.json`
+  - [ ] `javascript/packages/rpc/package.json`
+  - [ ] `website/package.json`
+  - [ ] `helm/michelangelo/Chart.yaml` (both `version` and `appVersion`)
+- [ ] `CHANGELOG.md` updated via `git cliff`
+- [ ] Release notes drafted (follows three-layer template: summary, categorized changes, compatibility matrix)
+- [ ] Migration guide written (if breaking changes)
+- [ ] Compatibility matrix updated in release notes
+- [ ] `UPGRADING.md` updated (if breaking changes)
+
+## Release Candidate
+
+- [ ] Release branch created: `release/vX.Y`
+- [ ] RC tag pushed (e.g. `v0.3.0-rc.1`)
+- [ ] RC artifacts published and accessible:
+  - [ ] Python wheel on PyPI (PEP 440: `0.3.0rc1`)
+  - [ ] Go service containers on ghcr.io
+  - [ ] UI container on ghcr.io
+  - [ ] npm packages (`@michelangelo/core`, `@michelangelo/rpc`)
+  - [ ] Helm OCI chart on ghcr.io
+- [ ] RC announcement posted (GitHub Discussions or relevant channel)
+- [ ] Soak period complete (minimum 1 week for minor releases)
+- [ ] No P0/P1 issues reported against RC
+
+## Final Release
+
+- [ ] Release tag pushed (e.g. `v0.3.0`)
+- [ ] All artifacts published and accessible:
+  - [ ] Python wheel on PyPI
+  - [ ] Go service containers on ghcr.io (tagged `v0.3.0` + `latest`)
+  - [ ] UI container on ghcr.io
+  - [ ] npm packages (latest dist-tag)
+  - [ ] Helm OCI chart on ghcr.io
+- [ ] GitHub Release created with generated release notes
+- [ ] Announcement posted
+- [ ] Release branch merged back to main (if diverged)
+- [ ] Next development version bumped on main (if applicable)


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [x] CI/CD changes
- [ ] Other

## What changed?

Added `.github/ISSUE_TEMPLATE/release-checklist.md` — a GitHub issue template that provides a standardized checklist for cutting releases. Three sections: pre-release (CI checks, version files, changelog), release candidate (artifacts, soak period), and final release (publish, announce, merge back).

## Why?

Release task 009 (Phase 2). A formal release checklist ensures no steps are missed when cutting releases. It lists all 5 version files and all artifact types so the release manager can track each one.

Closes: Part of https://github.com/michelangelo-ai/michelangelo/issues/1339

## How did you test it?

- Verified markdown renders correctly as a GitHub issue template
- Cross-referenced checklist items with RELEASE_PROPOSAL.md requirements
- Confirmed all 5 version files and all artifact types are listed

## Potential risks

None — new issue template only.

## Release notes

Added release checklist issue template for standardized release tracking.

## Documentation Changes

N/A

Closes: Part of #1339