### PR TITLE
ci: add tag-based triggers to container and UI release workflows

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches: [ main ]
+    tags: ['v*']
     paths-ignore:
       - 'docs/**'
       - 'website/**'

--- a/.github/workflows/ui-release.yml
+++ b/.github/workflows/ui-release.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches: [ main ]
+    tags: ['v*']
     paths:
       - 'javascript/**'
 
@@ -38,7 +39,7 @@ jobs:
 
   build-ui-image:
     needs: check-version-change
-    if: needs.check-version-change.outputs.version-changed == 'true' || github.event_name == 'workflow_dispatch'
+    if: needs.check-version-change.outputs.version-changed == 'true' || github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [x] CI/CD changes
- [ ] Other

## What changed?

Added `tags: ['v*']` triggers to two existing workflows:
- **`dev-release.yml`** — Go service containers (controllermgr, worker, apiserver) now build on version tag pushes
- **`ui-release.yml`** — UI container now builds on version tag pushes, skipping the version-change check for tag events

## Why?

Release task 010 (Phase 2). Tagged releases need to automatically build and push all container images. Previously, only `release.yaml` (Python/PyPI) had tag triggers. The Go service and UI container workflows only ran on main branch pushes.

Closes: Part of https://github.com/michelangelo-ai/michelangelo/issues/1339

## How did you test it?

- Verified YAML syntax
- Confirmed `release.yaml` already has `v*` tag trigger (no change needed)
- Verified the `startsWith(github.ref, 'refs/tags/v')` condition correctly bypasses version-change check

## Potential risks

None — additive trigger change. Existing main-branch behavior is unchanged.

## Release notes

Container release workflows now trigger automatically on version tag pushes.

## Documentation Changes

N/A

Closes: Part of #1339