### PR TITLE
Add Support & Community section to docs landing page

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -74,3 +74,11 @@ Understanding scope helps you decide if Michelangelo is the right tool.
 - [GitHub Repository](https://github.com/michelangelo-ai/michelangelo)
 - [CLI Reference](./user-guides/reference/cli.md)
 - [ML Pipelines Overview](./user-guides/ml-pipelines/index.md)
+
+## Support & Community
+
+Connect with the Michelangelo core team and developer community through our dedicated channels:
+
+- **[GitHub Discussions](https://github.com/michelangelo-ai/michelangelo/discussions):** Our primary channel for general Q&A, troubleshooting, technical support, and sharing ideas.
+- **[Slack Workspace](https://michelangelo-ai.slack.com/):** For real-time chat, networking, and focused conversations with other developers in the ecosystem.
+- **[Email](mailto:michelangelo-oss@uber.com):** For private, sensitive, or 1-on-1 inquiries that cannot be discussed publicly (for example, security disclosures or enterprise partnerships).


### PR DESCRIPTION
## Summary

- Adds a **Support & Community** section to the docs Welcome page (`docs/intro.md`)
- Lists three contact channels: GitHub Discussions, Slack workspace, and email

## Context

From internal discussion — after talking with the OSPO team, we're adding a Slack channel alongside the existing GitHub Discussions and email channels so users have a clear path to get help.


## Test plan

- [ ] Verify the section renders correctly on the Docusaurus site (`npm start` in `docs/`)
- [ ] Confirm all three links resolve (GitHub Discussions, Slack workspace, email mailto)