### PR TITLE
Add Dual-Track Pipeline and RFC process to contribution guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,19 @@ When contributing to any Uber Open Source project, you agree that you have autho
 
 You’re required to sign our [Contributor License Agreement](https://cla-assistant.io/michelangelo-ai) to confirm this and you’ll be prompted to do this when submitting your first contribution.
 
+## Our Contribution Tracks
+
+To keep our development moving fast while protecting the stability of the platform, Michelangelo uses a **Dual-Track Pipeline**. Before you open an issue or write any code, please match your goal to the correct track:
+
+* **Track 1: Maintenance:** For everyday bug fixes, code optimizations, testing improvements, or documentation updates. (This repo handles Track 1 entirely via standard Issues and Pull Requests).
+* **Track 2: Evolution:** For major architectural changes, public API modifications, new core modules, or substantial new framework dependencies. (These require a design proposal in our dedicated enhancements repository *before* any code is written here).
+
+*Note on Ecosystem Tools:* Backward-compatible updates, minor version bumps, and bug fixes to deployment configurations (like Helm charts) fall under Track 1. Breaking changes or entirely new deployment patterns belong in Track 2.
+
+## Working on Track 1: Maintenance (Standard PR Loop)
+
+If your contribution falls under Track 1, you will operate entirely within this repository using the standard sequence: **Open an Issue ➔ Submit a Pull Request ➔ Review & Merge**.
+
 <a id="enhancements-and-features"></a>
 ## Enhancements and Features
 
@@ -267,6 +280,24 @@ If you want to fix a bug or propose a new feature you’ll do this through creat
 * **Use comments in the code** that you provide to give us more context to any code based submissions.
 
 Thanks for contributing into our project.
+
+## Working on Track 2: Evolution (The RFC Process)
+
+If your proposal falls under Track 2, **please do not open a standard issue or code PR in this repository first**. Large features must secure architectural design consensus before code implementation begins.
+
+1. Head over to the [Michelangelo Enhancements Repository](https://github.com/michelangelo-ai/enhancements).
+2. Review the review SLAs, lifecycle stages, and copy the baseline design template (`rfcs/20260101-template.md`) to open a proposal Pull Request there.
+
+### Implementing an Approved RFC
+
+Once the enhancements process marks your proposal as **Accepted**, you will return here to implement the code under an operational agreement:
+
+* **Tracking & Targeting:** Your assigned Shepherd will open a dedicated tracking issue in this repository to map individual code PRs and target them to an upcoming release milestone branch (e.g., `release-0.2`).
+* **The Code Review Guarantee:** Subsequent code PRs are evaluated strictly for code quality, style, and test coverage. Core design, framework choices, and structural layout debates are locked and will not be reopened during code review because they were already settled during the RFC design phase.
+
+### Handling Unexpected Design Blocks
+
+If an insurmountable architectural blocker (such as a critical performance regression or unforeseen security flaw) is uncovered *during* implementation, the Shepherd will pause the PRs. The Shepherd will sync with the Core Architecture Panel to choose a path forward via minor amendment, formal withdrawal, or temporary deferment.
 
 <a id="deprecation-policy"></a>
 ## Deprecation Policy

--- a/docs/contributing/pr-process.md
+++ b/docs/contributing/pr-process.md
@@ -82,3 +82,18 @@ After merge, delete your branch.
 ## Stacked PRs
 
 If your change is large, consider splitting it into sequential PRs where each builds on the previous. Open them in order, set the base branch of PR 2 to PR 1's branch, and update the base to `main` after each merge. This makes review faster and reduces merge conflicts.
+
+## Code Review Guarantee for Approved RFCs
+
+If you are submitting code Pull Requests that implement a formally approved Track 2 RFC, your PR is protected by our **Code Review Guarantee**:
+
+* **Focused Evaluations:** Core maintainers will evaluate your code PR strictly for code quality, architectural adherence, style guides, and test coverage.
+* **No Reopened Debates:** Core design, framework choices, and structural layout debates will not be reopened during the code review stage because they were already settled during the RFC design phase.
+
+### Exception: Unavoidable Post-Acceptance Design Blocks
+
+In rare instances where an insurmountable architectural blocker is discovered *during* code implementation (like an unforeseen security risk or an unexpected engine performance degradation), the assigned Shepherd is empowered to pause implementation. The Shepherd will coordinate with the Core Architecture Panel to execute one of three explicit paths:
+
+1. **Minor Amendment:** A quick, documented tweak to the existing RFC text so implementation can safely resume.
+2. **Major Withdrawal:** The flaw is critical; the RFC is marked "Withdrawn," code PRs are paused, and a new design cycle must start.
+3. **Deferment:** The RFC remains accepted, but implementation is blocked until an underlying platform dependency is resolved elsewhere.


### PR DESCRIPTION
## Summary

- Adds the **Dual-Track Pipeline** (Track 1: Maintenance, Track 2: Evolution) to `CONTRIBUTING.md` to clarify when to open standard issues/PRs vs. RFC proposals
- Adds **Track 1 and Track 2** section headers to frame existing contribution content
- Adds the **Code Review Guarantee** for approved RFCs to `docs/contributing/pr-process.md`
- Covers the exception path for post-acceptance design blocks (amendment, withdrawal, deferment)

## Context

Based on internal RFC process discussions. This PR covers the `michelangelo-ai/michelangelo` repo changes (Updates 3 & 4). The `michelangelo-ai/enhancements` repo changes (Updates 1 & 2) will be in a separate PR.

## Files changed

- `CONTRIBUTING.md` — 3 modifications: Dual-Track intro after "I Want to Contribute", Track 1 header above bugs/issues, Track 2 routing + RFC implementation guidance before Deprecation Policy
- `docs/contributing/pr-process.md` — Code Review Guarantee section appended with exception handling paths

## Test plan

- [ ] Review that the new sections integrate naturally with existing CONTRIBUTING.md content
- [ ] Verify links to enhancements repo resolve correctly
- [ ] Confirm pr-process.md renders properly on the Docusaurus site

🤖 Generated with [Claude Code](https://claude.com/claude-code)