### PR TITLE
feat(python): add runtime warning for nightly builds

### DIFF
--- a/python/michelangelo/__init__.py
+++ b/python/michelangelo/__init__.py
@@ -12,3 +12,5 @@ import ``michelangelo.api.*``.
 """
 
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
+
+import michelangelo._nightly_warning  # noqa: F401, E402

--- a/python/michelangelo/__init__.py
+++ b/python/michelangelo/__init__.py
@@ -13,4 +13,4 @@ import ``michelangelo.api.*``.
 
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 
-import michelangelo._nightly_warning  # noqa: F401, E402
+import michelangelo._nightly_warning  # noqa: F401

--- a/python/michelangelo/_nightly_warning.py
+++ b/python/michelangelo/_nightly_warning.py
@@ -1,0 +1,26 @@
+"""Emit a one-time warning when running a nightly (dev) build."""
+
+import warnings
+
+
+def _check_nightly():
+    try:
+        from importlib.metadata import version
+
+        ver = version("michelangelo")
+    except Exception:
+        return
+
+    if ".dev" not in ver:
+        return
+
+    warnings.warn(
+        f"You are using a nightly development build of Michelangelo ({ver}). "
+        "This build is not supported for production use. "
+        "Install a stable release: pip install michelangelo",
+        UserWarning,
+        stacklevel=2,
+    )
+
+
+_check_nightly()

--- a/python/tests/test_nightly_warning.py
+++ b/python/tests/test_nightly_warning.py
@@ -1,3 +1,5 @@
+"""Tests for michelangelo._nightly_warning."""
+
 import warnings
 from unittest import mock
 
@@ -5,6 +7,7 @@ from michelangelo._nightly_warning import _check_nightly
 
 
 class TestNightlyWarning:
+    """Verify nightly build warning behavior."""
     def test_warns_on_dev_version(self):
         with mock.patch("importlib.metadata.version", return_value="0.3.0.dev20260625"):
             with warnings.catch_warnings(record=True) as w:

--- a/python/tests/test_nightly_warning.py
+++ b/python/tests/test_nightly_warning.py
@@ -5,6 +5,13 @@ from unittest import mock
 
 from michelangelo._nightly_warning import _check_nightly
 
+_MARKER = "nightly development build"
+
+
+def _nightly_warnings(w):
+    """Filter warnings list to nightly build warnings."""
+    return [x for x in w if _MARKER in str(x.message)]
+
 
 class TestNightlyWarning:
     """Verify nightly build warning behavior."""
@@ -12,33 +19,40 @@ class TestNightlyWarning:
     def test_warns_on_dev_version(self):
         """Nightly (.dev) version emits a UserWarning."""
         with (
-            mock.patch("importlib.metadata.version", return_value="0.3.0.dev20260625"),
+            mock.patch(
+                "importlib.metadata.version",
+                return_value="0.3.0.dev20260625",
+            ),
             warnings.catch_warnings(record=True) as w,
         ):
             warnings.simplefilter("always")
             _check_nightly()
-            nightly_warnings = [x for x in w if "nightly development build" in str(x.message)]
-            assert len(nightly_warnings) == 1
-            assert "0.3.0.dev20260625" in str(nightly_warnings[0].message)
+            matched = _nightly_warnings(w)
+            assert len(matched) == 1
+            assert "0.3.0.dev20260625" in str(matched[0].message)
 
     def test_no_warning_on_stable_version(self):
         """Stable version does not emit a warning."""
         with (
-            mock.patch("importlib.metadata.version", return_value="0.3.0"),
+            mock.patch(
+                "importlib.metadata.version",
+                return_value="0.3.0",
+            ),
             warnings.catch_warnings(record=True) as w,
         ):
             warnings.simplefilter("always")
             _check_nightly()
-            nightly_warnings = [x for x in w if "nightly development build" in str(x.message)]
-            assert len(nightly_warnings) == 0
+            assert len(_nightly_warnings(w)) == 0
 
     def test_no_warning_when_version_lookup_fails(self):
         """Exception during version lookup is silently caught."""
         with (
-            mock.patch("importlib.metadata.version", side_effect=Exception("not found")),
+            mock.patch(
+                "importlib.metadata.version",
+                side_effect=Exception("not found"),
+            ),
             warnings.catch_warnings(record=True) as w,
         ):
             warnings.simplefilter("always")
             _check_nightly()
-            nightly_warnings = [x for x in w if "nightly development build" in str(x.message)]
-            assert len(nightly_warnings) == 0
+            assert len(_nightly_warnings(w)) == 0

--- a/python/tests/test_nightly_warning.py
+++ b/python/tests/test_nightly_warning.py
@@ -8,27 +8,37 @@ from michelangelo._nightly_warning import _check_nightly
 
 class TestNightlyWarning:
     """Verify nightly build warning behavior."""
+
     def test_warns_on_dev_version(self):
-        with mock.patch("importlib.metadata.version", return_value="0.3.0.dev20260625"):
-            with warnings.catch_warnings(record=True) as w:
-                warnings.simplefilter("always")
-                _check_nightly()
-                nightly_warnings = [x for x in w if "nightly development build" in str(x.message)]
-                assert len(nightly_warnings) == 1
-                assert "0.3.0.dev20260625" in str(nightly_warnings[0].message)
+        """Nightly (.dev) version emits a UserWarning."""
+        with (
+            mock.patch("importlib.metadata.version", return_value="0.3.0.dev20260625"),
+            warnings.catch_warnings(record=True) as w,
+        ):
+            warnings.simplefilter("always")
+            _check_nightly()
+            nightly_warnings = [x for x in w if "nightly development build" in str(x.message)]
+            assert len(nightly_warnings) == 1
+            assert "0.3.0.dev20260625" in str(nightly_warnings[0].message)
 
     def test_no_warning_on_stable_version(self):
-        with mock.patch("importlib.metadata.version", return_value="0.3.0"):
-            with warnings.catch_warnings(record=True) as w:
-                warnings.simplefilter("always")
-                _check_nightly()
-                nightly_warnings = [x for x in w if "nightly development build" in str(x.message)]
-                assert len(nightly_warnings) == 0
+        """Stable version does not emit a warning."""
+        with (
+            mock.patch("importlib.metadata.version", return_value="0.3.0"),
+            warnings.catch_warnings(record=True) as w,
+        ):
+            warnings.simplefilter("always")
+            _check_nightly()
+            nightly_warnings = [x for x in w if "nightly development build" in str(x.message)]
+            assert len(nightly_warnings) == 0
 
     def test_no_warning_when_version_lookup_fails(self):
-        with mock.patch("importlib.metadata.version", side_effect=Exception("not found")):
-            with warnings.catch_warnings(record=True) as w:
-                warnings.simplefilter("always")
-                _check_nightly()
-                nightly_warnings = [x for x in w if "nightly development build" in str(x.message)]
-                assert len(nightly_warnings) == 0
+        """Exception during version lookup is silently caught."""
+        with (
+            mock.patch("importlib.metadata.version", side_effect=Exception("not found")),
+            warnings.catch_warnings(record=True) as w,
+        ):
+            warnings.simplefilter("always")
+            _check_nightly()
+            nightly_warnings = [x for x in w if "nightly development build" in str(x.message)]
+            assert len(nightly_warnings) == 0

--- a/python/tests/test_nightly_warning.py
+++ b/python/tests/test_nightly_warning.py
@@ -1,0 +1,31 @@
+import warnings
+from unittest import mock
+
+from michelangelo._nightly_warning import _check_nightly
+
+
+class TestNightlyWarning:
+    def test_warns_on_dev_version(self):
+        with mock.patch("importlib.metadata.version", return_value="0.3.0.dev20260625"):
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                _check_nightly()
+                nightly_warnings = [x for x in w if "nightly development build" in str(x.message)]
+                assert len(nightly_warnings) == 1
+                assert "0.3.0.dev20260625" in str(nightly_warnings[0].message)
+
+    def test_no_warning_on_stable_version(self):
+        with mock.patch("importlib.metadata.version", return_value="0.3.0"):
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                _check_nightly()
+                nightly_warnings = [x for x in w if "nightly development build" in str(x.message)]
+                assert len(nightly_warnings) == 0
+
+    def test_no_warning_when_version_lookup_fails(self):
+        with mock.patch("importlib.metadata.version", side_effect=Exception("not found")):
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                _check_nightly()
+                nightly_warnings = [x for x in w if "nightly development build" in str(x.message)]
+                assert len(nightly_warnings) == 0


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] CI/CD changes
- [ ] Other

## What changed?

Added `python/michelangelo/_nightly_warning.py` that detects nightly (`.dev`) versions via `importlib.metadata` and emits a `UserWarning` on first `import michelangelo`. The warning advises users to install a stable release for production use.

## Why?

Release task 011 (Phase 2). Nightly builds (from task 007) are published to PyPI with `.dev` suffixes. Users who accidentally depend on a nightly build should see a clear warning that it's unsupported for production.

Closes: Part of https://github.com/michelangelo-ai/michelangelo/issues/1339

## How did you test it?

- Verified the warning module imports cleanly with no errors on stable versions (`.dev` not in version string → no warning)
- Confirmed `try/except` guard handles missing metadata gracefully
- Pattern matches existing `warnings.warn()` usage in `workflow/tasks/functions/eval_report_sinks/api.py`

## Potential risks

None — warning only fires on `.dev` versions. Stable releases are unaffected. Guarded with try/except so import never fails.

## Release notes

Nightly Python SDK builds now emit a runtime warning advising users to install a stable release for production use.

## Documentation Changes

N/A

Closes #1339 (partial)