### PR TITLE
ci: add nightly build trigger to integration tests

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -2,7 +2,7 @@ name: Integration tests
 
 on:
   workflow_run:
-    workflows: ["Build examples Docker image"]
+    workflows: ["Build examples Docker image", "Nightly Build"]
     types: [completed]
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [x] CI/CD changes
- [ ] Other

## What changed?

Added `"Nightly Build"` to the `workflow_run.workflows` list in `integration-test.yaml` so integration tests automatically trigger after successful nightly builds.

## Why?

Release task 013 (Phase 2). Nightly builds (task 007) should be validated by integration tests. The existing integration test workflow already handles `workflow_run` events correctly — this adds the nightly workflow as an additional trigger source.

Closes: Part of https://github.com/michelangelo-ai/michelangelo/issues/1339

## How did you test it?

- Verified YAML syntax
- Confirmed the existing `workflow_run` guard (`github.event.workflow_run.conclusion == 'success'`) applies to all workflow_run triggers including the new one
- No duplication with the existing daily schedule (03:00 UTC) — nightly runs at 02:00 UTC, integration test runs again after nightly completes

## Potential risks

None — additive trigger. Existing integration test behavior unchanged.

## Release notes

Integration tests now run automatically after successful nightly builds.

## Documentation Changes

N/A

Part of #1339