### PR TITLE
ci: enhance changelog and release checklist for breaking changes

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -17,9 +17,12 @@ assignees: ''
   - [ ] `helm/michelangelo/Chart.yaml` (both `version` and `appVersion`)
 - [ ] `CHANGELOG.md` updated via `git cliff`
 - [ ] Release notes drafted (follows three-layer template: summary, categorized changes, compatibility matrix)
-- [ ] Migration guide written (if breaking changes)
+- [ ] Breaking changes reviewed and documented:
+  - [ ] All `BREAKING CHANGE:` commits identified in changelog
+  - [ ] Migration guide written for each breaking change
+  - [ ] `UPGRADING.md` updated with migration steps
+  - [ ] Deprecation warnings added for items being removed (see [Deprecation Policy](../../CONTRIBUTING.md#deprecation-policy))
 - [ ] Compatibility matrix updated in release notes
-- [ ] `UPGRADING.md` updated (if breaking changes)
 
 ## Release Candidate
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -9,6 +9,15 @@ body = """
 {% else %}\
     ## [Unreleased]
 {% endif %}\
+{% raw %}\n{% endraw %}\
+{% set breaking_commits = commits | filter(attribute="breaking", value=true) %}\
+{% if breaking_commits | length > 0 %}\
+    ### ⚠ Breaking Changes\n
+    {% for commit in breaking_commits %}\
+        - {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message | upper_first }}\
+            {% if commit.breaking_description %} — {{ commit.breaking_description }}{% endif %}\n
+    {% endfor %}\n
+{% endif %}\
 {% for group, commits in commits | group_by(attribute="group") %}
     ### {{ group }}\n
     {% for commit in commits %}


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [x] CI/CD changes
- [ ] Other

## What changed?

Two enhancements for breaking change visibility:

1. **`cliff.toml`** — Added a dedicated "Breaking Changes" section to the changelog template. Breaking commits now appear in their own section at the top of each release entry (with full breaking description), in addition to their normal category listing.

2. **`.github/ISSUE_TEMPLATE/release-checklist.md`** — Expanded Pre-Release section with explicit breaking change review items: identify all BREAKING CHANGE commits, write migration guides, update UPGRADING.md, and verify deprecation warnings.

## Why?

Release task 023 (Phase 2). Breaking changes were only tagged inline with `[**BREAKING**]` in the changelog, making them easy to miss. A dedicated section ensures they're prominently surfaced. The release checklist lacked explicit steps for breaking change review.

Closes: Part of https://github.com/michelangelo-ai/michelangelo/issues/1339

## How did you test it?

- Verified cliff.toml Jinja2 template syntax matches git-cliff conventions
- Confirmed `breaking_description` field is available in git-cliff's commit context
- Verified release checklist markdown renders correctly

## Potential risks

None — changelog template change only affects future changelog generation. Release checklist is advisory.

## Release notes

Breaking changes now appear in a dedicated section at the top of generated changelogs with full migration descriptions.

## Documentation Changes

Updated release checklist template with breaking change review steps.

Part of #1339