### PR TITLE
fixed //go/components/jobs/client/k8sengine:go_default_test build failure

### DIFF
--- a/go/components/jobs/client/k8sengine/BUILD.bazel
+++ b/go/components/jobs/client/k8sengine/BUILD.bazel
@@ -40,6 +40,5 @@ go_test(
         "@io_k8s_apimachinery//pkg/api/resource:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
-        "@io_k8s_utils//ptr:go_default_library",
     ],
 )

--- a/go/components/jobs/client/k8sengine/mapper_test.go
+++ b/go/components/jobs/client/k8sengine/mapper_test.go
@@ -10,7 +10,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
-	k8sptr "k8s.io/utils/ptr"
 
 	v2pb "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
 )
@@ -73,7 +72,7 @@ func TestMapper_MapGlobalJobToLocal(t *testing.T) {
 						"ray.io/cluster":      rayCluster.Name,
 						"rayClusterNamespace": RayLocalNamespace,
 					},
-					TTLSecondsAfterFinished: k8sptr.To(int32(300)),
+					TTLSecondsAfterFinished: int32(300),
 					SubmitterPodTemplate:    submitterPod,
 				},
 			},

--- a/go/components/jobs/client/k8sengine/ray.go
+++ b/go/components/jobs/client/k8sengine/ray.go
@@ -61,7 +61,7 @@ func (m Mapper) mapRay(rayJob *v2pb.RayJob, jobClusterObject runtime.Object, clu
 				"rayClusterNamespace": RayLocalNamespace,
 			},
 			Entrypoint:              rayJob.Spec.Entrypoint,
-			TTLSecondsAfterFinished: k8sptr.To(int32(300)),
+			TTLSecondsAfterFinished: int32(300),
 			// kuberay 1.0 only support SubmitterPodTemplate for configuration submitter pod
 			// We need to allow user to configure the submitter pod template via ray task configuration
 			// Note: Add support for v1.2.2 kuberay once we upgrade to newer version


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
Applied three edits to fix the compile error:                                     
  - go/components/jobs/client/k8sengine/ray.go:64 — k8sptr.To(int32(300)) →         
  int32(300)                                                                        
  - go/components/jobs/client/k8sengine/mapper_test.go:76 — same change             
  - mapper_test.go import block — removed the now-unused k8sptr "k8s.io/utils/ptr"  
  import                                                                            
                                                                                    
  //go/components/jobs/client/k8sengine:go_default_test now PASSED


<!-- Tell your future self why have you made these changes -->
  //go/components/jobs/client/k8sengine:go_default_test build failure


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
local test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Does this PR introduce a breaking change? Check all that apply. -->
**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

> If any breaking change box is checked (other than "No breaking changes"), you **must**:
> 1. Use the `BREAKING CHANGE:` footer **or** the `!` suffix (e.g. `feat!:`) in your commit message — see [Commit Messages](../CONTRIBUTING.md#commit-messages).
> 2. Fill in the **Migration guide** section below with step-by-step upgrade instructions.

<!-- Required only if a breaking change box above is checked. Delete this section if no breaking changes. -->
**Migration guide**

_Describe the steps an operator or downstream consumer must take to upgrade. Include before/after examples for any API, config, or schema change._

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
