### PR TITLE
fix(kubeproto): decode CRD mutations through the jsonpb (YARPC) path

### DIFF
--- a/go/kubeproto/templates/crd.tmpl
+++ b/go/kubeproto/templates/crd.tmpl
@@ -371,6 +371,30 @@ func (m *{{.Name}}Status) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
+/* When a {{.Name}} is nested inside another proto message (e.g. an
+   Update request decoded by YARPC), gogo's jsonpb dispatches to
+   UnmarshalJSONPB if it is implemented and otherwise reflects into the
+   struct directly. That reflection path mishandles embedded k8s types
+   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
+   are decoded as messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), and it never reaches the Spec/Status
+   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
+   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
+   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
+   type strips this method to avoid infinite recursion.
+
+   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
+   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
+   the web client back into numbers, which is what encoding/json expects. */
+func (m *{{.Name}}) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
+	b, err := util.CoerceObjectMetaIntegers(b)
+	if err != nil {
+		return err
+	}
+	type Alias {{.Name}}
+	return json.Unmarshal(b, (*Alias)(m))
+}
+
 func (in *{{.Name}}) DeepCopy() *{{.Name}} {
 	if in == nil {
 		return nil

--- a/go/kubeproto/templates/crd.tmpl
+++ b/go/kubeproto/templates/crd.tmpl
@@ -371,21 +371,18 @@ func (m *{{.Name}}Status) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
-/* When a {{.Name}} is nested inside another proto message (e.g. an
-   Update request decoded by YARPC), gogo's jsonpb dispatches to
-   UnmarshalJSONPB if it is implemented and otherwise reflects into the
-   struct directly. That reflection path mishandles embedded k8s types
-   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
-   are decoded as messages ("cannot unmarshal string into Go value of type
-   map[string]json.RawMessage"), and it never reaches the Spec/Status
-   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
-   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
-   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
-   type strips this method to avoid infinite recursion.
-
-   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
-   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
-   the web client back into numbers, which is what encoding/json expects. */
+/* gogo's jsonpb dispatches to UnmarshalJSONPB when a {{.Name}} is nested in
+   another proto message (e.g. an Update request decoded by YARPC); without it,
+   jsonpb reflects into the struct and mishandles embedded k8s types such as
+   metav1.Time in ObjectMeta, which serialize as JSON strings but are decoded as
+   messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), never reaching the Spec/Status UnmarshalJSON
+   fallbacks above. Delegating to encoding/json decodes TypeMeta/ObjectMeta
+   natively and routes Spec/Status through their own UnmarshalJSON (still jsonpb
+   for oneofs and enums); the Alias type strips this method to avoid recursion.
+   CoerceObjectMetaIntegers first converts ObjectMeta integers (e.g. generation)
+   from the proto3 JSON strings jsonpb and the web client emit back to numbers,
+   which is what encoding/json expects. */
 func (m *{{.Name}}) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
 	b, err := util.CoerceObjectMetaIntegers(b)
 	if err != nil {

--- a/go/kubeproto/util/BUILD.bazel
+++ b/go/kubeproto/util/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_tidwall_gjson//:go_default_library",
         "@com_github_tidwall_sjson//:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@org_golang_google_protobuf//compiler/protogen:go_default_library",
         "@org_golang_google_protobuf//proto:go_default_library",
         "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
@@ -26,6 +27,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "crd_unmarshal_jsonpb_test.go",
         "index_test.go",
         "util_test.go",
     ],
@@ -39,6 +41,7 @@ go_test(
         "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_gogo_protobuf//types:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
         "@org_golang_google_protobuf//compiler/protogen:go_default_library",
         "@org_golang_google_protobuf//reflect/protoregistry:go_default_library",
         "@org_golang_google_protobuf//types/descriptorpb:go_default_library",

--- a/go/kubeproto/util/crd_unmarshal_jsonpb_test.go
+++ b/go/kubeproto/util/crd_unmarshal_jsonpb_test.go
@@ -1,0 +1,85 @@
+package util_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gogo/protobuf/jsonpb"
+	"github.com/stretchr/testify/require"
+
+	"github.com/michelangelo-ai/michelangelo/go/kubeproto/util"
+	testpb "github.com/michelangelo-ai/michelangelo/proto-go/test/kubeproto"
+)
+
+// CRD types embed metav1.ObjectMeta, which mixes two field encodings that no
+// single JSON decoder handles:
+//   - creationTimestamp is a metav1.Time, a Go struct that serializes as a JSON
+//     string; gogo jsonpb reflects into it and fails with "cannot unmarshal
+//     string into Go value of type map[string]json.RawMessage".
+//   - generation is an int64; jsonpb and the protobuf-es web client serialize it
+//     as a JSON string (proto3 JSON), which encoding/json refuses to decode.
+//
+// crd.tmpl now generates UnmarshalJSONPB for every CRD type. gogo jsonpb only
+// dispatches to UnmarshalJSONPB (never UnmarshalJSON) for nested messages, e.g.
+// the TriggerRun inside an UpdateTriggerRunRequest. The method coerces the
+// integer fields and delegates to encoding/json, so both the controller-runtime
+// path and the YARPC/UI path decode the same round-tripped payload.
+func TestCRDUnmarshal_ObjectMeta_BothPaths(t *testing.T) {
+	// A CRD as it comes back from the API and is echoed into an Update:
+	// generation is a quoted int64, creationTimestamp is a quoted timestamp.
+	payload := `{
+		"metadata": {
+			"name": "test",
+			"namespace": "default",
+			"generation": "2",
+			"creationTimestamp": "2026-06-25T00:00:00Z"
+		}
+	}`
+
+	t.Run("encoding/json (controller-runtime path)", func(t *testing.T) {
+		// encoding/json needs the proto3 string-encoded integers coerced first,
+		// exactly as the generated UnmarshalJSONPB does.
+		coerced, err := util.CoerceObjectMetaIntegers([]byte(payload))
+		require.NoError(t, err)
+
+		var obj testpb.TestObject
+		require.NoError(t, json.Unmarshal(coerced, &obj))
+		require.Equal(t, "test", obj.Name)
+		require.Equal(t, int64(2), obj.Generation)
+		require.False(t, obj.CreationTimestamp.IsZero())
+	})
+
+	t.Run("gogo jsonpb (YARPC/UI path)", func(t *testing.T) {
+		var obj testpb.TestObject
+		err := (&jsonpb.Unmarshaler{AllowUnknownFields: true}).Unmarshal(
+			strings.NewReader(payload), &obj,
+		)
+		require.NoError(t, err, "UnmarshalJSONPB should decode metav1.Time and string-encoded int64")
+		require.Equal(t, "test", obj.Name)
+		require.Equal(t, int64(2), obj.Generation)
+		require.False(t, obj.CreationTimestamp.IsZero())
+	})
+}
+
+func TestCoerceObjectMetaIntegers(t *testing.T) {
+	t.Run("converts string-encoded generation to a number", func(t *testing.T) {
+		out, err := util.CoerceObjectMetaIntegers([]byte(`{"metadata":{"generation":"7"}}`))
+		require.NoError(t, err)
+		require.JSONEq(t, `{"metadata":{"generation":7}}`, string(out))
+	})
+
+	t.Run("leaves string fields like resourceVersion untouched", func(t *testing.T) {
+		in := `{"metadata":{"resourceVersion":"123","generation":"7"}}`
+		out, err := util.CoerceObjectMetaIntegers([]byte(in))
+		require.NoError(t, err)
+		require.JSONEq(t, `{"metadata":{"resourceVersion":"123","generation":7}}`, string(out))
+	})
+
+	t.Run("is a no-op when integers are already numbers", func(t *testing.T) {
+		in := `{"metadata":{"generation":7}}`
+		out, err := util.CoerceObjectMetaIntegers([]byte(in))
+		require.NoError(t, err)
+		require.JSONEq(t, in, string(out))
+	})
+}

--- a/go/kubeproto/util/crd_unmarshal_jsonpb_test.go
+++ b/go/kubeproto/util/crd_unmarshal_jsonpb_test.go
@@ -12,22 +12,13 @@ import (
 	testpb "github.com/michelangelo-ai/michelangelo/proto-go/test/kubeproto"
 )
 
-// CRD types embed metav1.ObjectMeta, which mixes two field encodings that no
-// single JSON decoder handles:
-//   - creationTimestamp is a metav1.Time, a Go struct that serializes as a JSON
-//     string; gogo jsonpb reflects into it and fails with "cannot unmarshal
-//     string into Go value of type map[string]json.RawMessage".
-//   - generation is an int64; jsonpb and the protobuf-es web client serialize it
-//     as a JSON string (proto3 JSON), which encoding/json refuses to decode.
-//
-// crd.tmpl now generates UnmarshalJSONPB for every CRD type. gogo jsonpb only
-// dispatches to UnmarshalJSONPB (never UnmarshalJSON) for nested messages, e.g.
-// the TriggerRun inside an UpdateTriggerRunRequest. The method coerces the
-// integer fields and delegates to encoding/json, so both the controller-runtime
-// path and the YARPC/UI path decode the same round-tripped payload.
+// Regression guard for the generated CRD UnmarshalJSONPB (see crd.tmpl) and
+// util.CoerceObjectMetaIntegers: a CRD round-tripped through the API must decode
+// via both gogo jsonpb (the YARPC/UI path, which only ever calls UnmarshalJSONPB)
+// and encoding/json (the controller-runtime path). The payload mixes the two
+// fields that broke each decoder — a quoted metav1.Time and a quoted int64.
 func TestCRDUnmarshal_ObjectMeta_BothPaths(t *testing.T) {
-	// A CRD as it comes back from the API and is echoed into an Update:
-	// generation is a quoted int64, creationTimestamp is a quoted timestamp.
+	// As returned by the API and echoed back into an Update: both fields quoted.
 	payload := `{
 		"metadata": {
 			"name": "test",

--- a/go/kubeproto/util/util.go
+++ b/go/kubeproto/util/util.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/tidwall/gjson"
@@ -22,6 +23,7 @@ import (
 	"google.golang.org/protobuf/reflect/protoregistry"
 	"google.golang.org/protobuf/types/descriptorpb"
 	"google.golang.org/protobuf/types/pluginpb"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var reGogoTypeRemapPath = regexp.MustCompile(`github\.com\/gogo\/protobuf\/types`)
@@ -381,6 +383,58 @@ func ApplyInlineFields(jsonData []byte, fields []InlineFieldMapping) ([]byte, er
 	}
 
 	return []byte(jsonStr), nil
+}
+
+// objectMetaIntegerJSONFields holds the JSON names of the integer-typed fields
+// declared directly on metav1.ObjectMeta (e.g. "generation",
+// "deletionGracePeriodSeconds"), derived once via reflection so the set stays
+// correct if k8s changes ObjectMeta.
+var objectMetaIntegerJSONFields = func() []string {
+	var names []string
+	t := reflect.TypeOf(metav1.ObjectMeta{})
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		fieldType := field.Type
+		for fieldType.Kind() == reflect.Ptr {
+			fieldType = fieldType.Elem()
+		}
+		switch fieldType.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+			reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			if name := extractFieldName(field.Tag.Get("json"), field.Tag.Get("protobuf"), field.Name); name != "" && name != "-" {
+				names = append(names, name)
+			}
+		}
+	}
+	return names
+}()
+
+// CoerceObjectMetaIntegers rewrites the integer fields of the top-level
+// "metadata" object from JSON strings to JSON numbers.
+//
+// gogo's jsonpb and the protobuf-es web client serialize proto int64/uint64 as
+// JSON strings (the proto3 JSON spec), but metav1.ObjectMeta is decoded with
+// encoding/json, which accepts only numbers for its integer fields such as
+// generation. This reconciles the two so a CRD round-tripped through the API
+// (e.g. read via Get, then sent back in Update) decodes with encoding/json.
+func CoerceObjectMetaIntegers(b []byte) ([]byte, error) {
+	s := string(b)
+	for _, name := range objectMetaIntegerJSONFields {
+		path := "metadata." + name
+		value := gjson.Get(s, path)
+		if value.Type != gjson.String {
+			continue
+		}
+		if _, err := strconv.ParseInt(value.String(), 10, 64); err != nil {
+			continue
+		}
+		updated, err := sjson.SetRaw(s, path, value.String())
+		if err != nil {
+			return nil, err
+		}
+		s = updated
+	}
+	return []byte(s), nil
 }
 
 // ReadRequest reads the protoc request from stdin and returns it as a byte slice.

--- a/go/kubeproto/util/util.go
+++ b/go/kubeproto/util/util.go
@@ -385,10 +385,9 @@ func ApplyInlineFields(jsonData []byte, fields []InlineFieldMapping) ([]byte, er
 	return []byte(jsonStr), nil
 }
 
-// objectMetaIntegerJSONFields holds the JSON names of the integer-typed fields
-// declared directly on metav1.ObjectMeta (e.g. "generation",
-// "deletionGracePeriodSeconds"), derived once via reflection so the set stays
-// correct if k8s changes ObjectMeta.
+// objectMetaIntegerJSONFields is derived via reflection (rather than hardcoded)
+// so it stays correct if k8s changes which metav1.ObjectMeta fields are
+// integers, e.g. "generation" and "deletionGracePeriodSeconds".
 var objectMetaIntegerJSONFields = func() []string {
 	var names []string
 	t := reflect.TypeOf(metav1.ObjectMeta{})

--- a/proto-go/api/v2/cached_output.pb.go
+++ b/proto-go/api/v2/cached_output.pb.go
@@ -2482,6 +2482,30 @@ func (m *CachedOutputStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
+/* When a CachedOutput is nested inside another proto message (e.g. an
+   Update request decoded by YARPC), gogo's jsonpb dispatches to
+   UnmarshalJSONPB if it is implemented and otherwise reflects into the
+   struct directly. That reflection path mishandles embedded k8s types
+   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
+   are decoded as messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), and it never reaches the Spec/Status
+   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
+   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
+   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
+   type strips this method to avoid infinite recursion.
+
+   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
+   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
+   the web client back into numbers, which is what encoding/json expects. */
+func (m *CachedOutput) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
+	b, err := util.CoerceObjectMetaIntegers(b)
+	if err != nil {
+		return err
+	}
+	type Alias CachedOutput
+	return json.Unmarshal(b, (*Alias)(m))
+}
+
 func (in *CachedOutput) DeepCopy() *CachedOutput {
 	if in == nil {
 		return nil

--- a/proto-go/api/v2/cached_output.pb.go
+++ b/proto-go/api/v2/cached_output.pb.go
@@ -2482,21 +2482,18 @@ func (m *CachedOutputStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
-/* When a CachedOutput is nested inside another proto message (e.g. an
-   Update request decoded by YARPC), gogo's jsonpb dispatches to
-   UnmarshalJSONPB if it is implemented and otherwise reflects into the
-   struct directly. That reflection path mishandles embedded k8s types
-   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
-   are decoded as messages ("cannot unmarshal string into Go value of type
-   map[string]json.RawMessage"), and it never reaches the Spec/Status
-   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
-   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
-   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
-   type strips this method to avoid infinite recursion.
-
-   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
-   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
-   the web client back into numbers, which is what encoding/json expects. */
+/* gogo's jsonpb dispatches to UnmarshalJSONPB when a CachedOutput is nested in
+   another proto message (e.g. an Update request decoded by YARPC); without it,
+   jsonpb reflects into the struct and mishandles embedded k8s types such as
+   metav1.Time in ObjectMeta, which serialize as JSON strings but are decoded as
+   messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), never reaching the Spec/Status UnmarshalJSON
+   fallbacks above. Delegating to encoding/json decodes TypeMeta/ObjectMeta
+   natively and routes Spec/Status through their own UnmarshalJSON (still jsonpb
+   for oneofs and enums); the Alias type strips this method to avoid recursion.
+   CoerceObjectMetaIntegers first converts ObjectMeta integers (e.g. generation)
+   from the proto3 JSON strings jsonpb and the web client emit back to numbers,
+   which is what encoding/json expects. */
 func (m *CachedOutput) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
 	b, err := util.CoerceObjectMetaIntegers(b)
 	if err != nil {

--- a/proto-go/api/v2/cluster.pb.go
+++ b/proto-go/api/v2/cluster.pb.go
@@ -1400,6 +1400,30 @@ func (m *ClusterStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
+/* When a Cluster is nested inside another proto message (e.g. an
+   Update request decoded by YARPC), gogo's jsonpb dispatches to
+   UnmarshalJSONPB if it is implemented and otherwise reflects into the
+   struct directly. That reflection path mishandles embedded k8s types
+   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
+   are decoded as messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), and it never reaches the Spec/Status
+   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
+   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
+   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
+   type strips this method to avoid infinite recursion.
+
+   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
+   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
+   the web client back into numbers, which is what encoding/json expects. */
+func (m *Cluster) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
+	b, err := util.CoerceObjectMetaIntegers(b)
+	if err != nil {
+		return err
+	}
+	type Alias Cluster
+	return json.Unmarshal(b, (*Alias)(m))
+}
+
 func (in *Cluster) DeepCopy() *Cluster {
 	if in == nil {
 		return nil

--- a/proto-go/api/v2/cluster.pb.go
+++ b/proto-go/api/v2/cluster.pb.go
@@ -1400,21 +1400,18 @@ func (m *ClusterStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
-/* When a Cluster is nested inside another proto message (e.g. an
-   Update request decoded by YARPC), gogo's jsonpb dispatches to
-   UnmarshalJSONPB if it is implemented and otherwise reflects into the
-   struct directly. That reflection path mishandles embedded k8s types
-   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
-   are decoded as messages ("cannot unmarshal string into Go value of type
-   map[string]json.RawMessage"), and it never reaches the Spec/Status
-   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
-   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
-   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
-   type strips this method to avoid infinite recursion.
-
-   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
-   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
-   the web client back into numbers, which is what encoding/json expects. */
+/* gogo's jsonpb dispatches to UnmarshalJSONPB when a Cluster is nested in
+   another proto message (e.g. an Update request decoded by YARPC); without it,
+   jsonpb reflects into the struct and mishandles embedded k8s types such as
+   metav1.Time in ObjectMeta, which serialize as JSON strings but are decoded as
+   messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), never reaching the Spec/Status UnmarshalJSON
+   fallbacks above. Delegating to encoding/json decodes TypeMeta/ObjectMeta
+   natively and routes Spec/Status through their own UnmarshalJSON (still jsonpb
+   for oneofs and enums); the Alias type strips this method to avoid recursion.
+   CoerceObjectMetaIntegers first converts ObjectMeta integers (e.g. generation)
+   from the proto3 JSON strings jsonpb and the web client emit back to numbers,
+   which is what encoding/json expects. */
 func (m *Cluster) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
 	b, err := util.CoerceObjectMetaIntegers(b)
 	if err != nil {

--- a/proto-go/api/v2/deployment.pb.go
+++ b/proto-go/api/v2/deployment.pb.go
@@ -6642,21 +6642,18 @@ func (m *DeploymentStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
-/* When a Deployment is nested inside another proto message (e.g. an
-   Update request decoded by YARPC), gogo's jsonpb dispatches to
-   UnmarshalJSONPB if it is implemented and otherwise reflects into the
-   struct directly. That reflection path mishandles embedded k8s types
-   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
-   are decoded as messages ("cannot unmarshal string into Go value of type
-   map[string]json.RawMessage"), and it never reaches the Spec/Status
-   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
-   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
-   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
-   type strips this method to avoid infinite recursion.
-
-   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
-   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
-   the web client back into numbers, which is what encoding/json expects. */
+/* gogo's jsonpb dispatches to UnmarshalJSONPB when a Deployment is nested in
+   another proto message (e.g. an Update request decoded by YARPC); without it,
+   jsonpb reflects into the struct and mishandles embedded k8s types such as
+   metav1.Time in ObjectMeta, which serialize as JSON strings but are decoded as
+   messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), never reaching the Spec/Status UnmarshalJSON
+   fallbacks above. Delegating to encoding/json decodes TypeMeta/ObjectMeta
+   natively and routes Spec/Status through their own UnmarshalJSON (still jsonpb
+   for oneofs and enums); the Alias type strips this method to avoid recursion.
+   CoerceObjectMetaIntegers first converts ObjectMeta integers (e.g. generation)
+   from the proto3 JSON strings jsonpb and the web client emit back to numbers,
+   which is what encoding/json expects. */
 func (m *Deployment) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
 	b, err := util.CoerceObjectMetaIntegers(b)
 	if err != nil {

--- a/proto-go/api/v2/deployment.pb.go
+++ b/proto-go/api/v2/deployment.pb.go
@@ -6642,6 +6642,30 @@ func (m *DeploymentStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
+/* When a Deployment is nested inside another proto message (e.g. an
+   Update request decoded by YARPC), gogo's jsonpb dispatches to
+   UnmarshalJSONPB if it is implemented and otherwise reflects into the
+   struct directly. That reflection path mishandles embedded k8s types
+   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
+   are decoded as messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), and it never reaches the Spec/Status
+   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
+   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
+   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
+   type strips this method to avoid infinite recursion.
+
+   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
+   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
+   the web client back into numbers, which is what encoding/json expects. */
+func (m *Deployment) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
+	b, err := util.CoerceObjectMetaIntegers(b)
+	if err != nil {
+		return err
+	}
+	type Alias Deployment
+	return json.Unmarshal(b, (*Alias)(m))
+}
+
 func (in *Deployment) DeepCopy() *Deployment {
 	if in == nil {
 		return nil

--- a/proto-go/api/v2/evaluation_report.pb.go
+++ b/proto-go/api/v2/evaluation_report.pb.go
@@ -1437,6 +1437,30 @@ func (m *EvaluationReportStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
+/* When a EvaluationReport is nested inside another proto message (e.g. an
+   Update request decoded by YARPC), gogo's jsonpb dispatches to
+   UnmarshalJSONPB if it is implemented and otherwise reflects into the
+   struct directly. That reflection path mishandles embedded k8s types
+   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
+   are decoded as messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), and it never reaches the Spec/Status
+   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
+   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
+   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
+   type strips this method to avoid infinite recursion.
+
+   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
+   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
+   the web client back into numbers, which is what encoding/json expects. */
+func (m *EvaluationReport) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
+	b, err := util.CoerceObjectMetaIntegers(b)
+	if err != nil {
+		return err
+	}
+	type Alias EvaluationReport
+	return json.Unmarshal(b, (*Alias)(m))
+}
+
 func (in *EvaluationReport) DeepCopy() *EvaluationReport {
 	if in == nil {
 		return nil

--- a/proto-go/api/v2/evaluation_report.pb.go
+++ b/proto-go/api/v2/evaluation_report.pb.go
@@ -1437,21 +1437,18 @@ func (m *EvaluationReportStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
-/* When a EvaluationReport is nested inside another proto message (e.g. an
-   Update request decoded by YARPC), gogo's jsonpb dispatches to
-   UnmarshalJSONPB if it is implemented and otherwise reflects into the
-   struct directly. That reflection path mishandles embedded k8s types
-   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
-   are decoded as messages ("cannot unmarshal string into Go value of type
-   map[string]json.RawMessage"), and it never reaches the Spec/Status
-   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
-   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
-   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
-   type strips this method to avoid infinite recursion.
-
-   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
-   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
-   the web client back into numbers, which is what encoding/json expects. */
+/* gogo's jsonpb dispatches to UnmarshalJSONPB when a EvaluationReport is nested in
+   another proto message (e.g. an Update request decoded by YARPC); without it,
+   jsonpb reflects into the struct and mishandles embedded k8s types such as
+   metav1.Time in ObjectMeta, which serialize as JSON strings but are decoded as
+   messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), never reaching the Spec/Status UnmarshalJSON
+   fallbacks above. Delegating to encoding/json decodes TypeMeta/ObjectMeta
+   natively and routes Spec/Status through their own UnmarshalJSON (still jsonpb
+   for oneofs and enums); the Alias type strips this method to avoid recursion.
+   CoerceObjectMetaIntegers first converts ObjectMeta integers (e.g. generation)
+   from the proto3 JSON strings jsonpb and the web client emit back to numbers,
+   which is what encoding/json expects. */
 func (m *EvaluationReport) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
 	b, err := util.CoerceObjectMetaIntegers(b)
 	if err != nil {

--- a/proto-go/api/v2/inference_server.pb.go
+++ b/proto-go/api/v2/inference_server.pb.go
@@ -3628,21 +3628,18 @@ func (m *InferenceServerStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
-/* When a InferenceServer is nested inside another proto message (e.g. an
-   Update request decoded by YARPC), gogo's jsonpb dispatches to
-   UnmarshalJSONPB if it is implemented and otherwise reflects into the
-   struct directly. That reflection path mishandles embedded k8s types
-   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
-   are decoded as messages ("cannot unmarshal string into Go value of type
-   map[string]json.RawMessage"), and it never reaches the Spec/Status
-   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
-   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
-   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
-   type strips this method to avoid infinite recursion.
-
-   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
-   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
-   the web client back into numbers, which is what encoding/json expects. */
+/* gogo's jsonpb dispatches to UnmarshalJSONPB when a InferenceServer is nested in
+   another proto message (e.g. an Update request decoded by YARPC); without it,
+   jsonpb reflects into the struct and mishandles embedded k8s types such as
+   metav1.Time in ObjectMeta, which serialize as JSON strings but are decoded as
+   messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), never reaching the Spec/Status UnmarshalJSON
+   fallbacks above. Delegating to encoding/json decodes TypeMeta/ObjectMeta
+   natively and routes Spec/Status through their own UnmarshalJSON (still jsonpb
+   for oneofs and enums); the Alias type strips this method to avoid recursion.
+   CoerceObjectMetaIntegers first converts ObjectMeta integers (e.g. generation)
+   from the proto3 JSON strings jsonpb and the web client emit back to numbers,
+   which is what encoding/json expects. */
 func (m *InferenceServer) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
 	b, err := util.CoerceObjectMetaIntegers(b)
 	if err != nil {

--- a/proto-go/api/v2/inference_server.pb.go
+++ b/proto-go/api/v2/inference_server.pb.go
@@ -3628,6 +3628,30 @@ func (m *InferenceServerStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
+/* When a InferenceServer is nested inside another proto message (e.g. an
+   Update request decoded by YARPC), gogo's jsonpb dispatches to
+   UnmarshalJSONPB if it is implemented and otherwise reflects into the
+   struct directly. That reflection path mishandles embedded k8s types
+   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
+   are decoded as messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), and it never reaches the Spec/Status
+   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
+   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
+   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
+   type strips this method to avoid infinite recursion.
+
+   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
+   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
+   the web client back into numbers, which is what encoding/json expects. */
+func (m *InferenceServer) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
+	b, err := util.CoerceObjectMetaIntegers(b)
+	if err != nil {
+		return err
+	}
+	type Alias InferenceServer
+	return json.Unmarshal(b, (*Alias)(m))
+}
+
 func (in *InferenceServer) DeepCopy() *InferenceServer {
 	if in == nil {
 		return nil

--- a/proto-go/api/v2/model.pb.go
+++ b/proto-go/api/v2/model.pb.go
@@ -5377,21 +5377,18 @@ func (m *ModelStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
-/* When a Model is nested inside another proto message (e.g. an
-   Update request decoded by YARPC), gogo's jsonpb dispatches to
-   UnmarshalJSONPB if it is implemented and otherwise reflects into the
-   struct directly. That reflection path mishandles embedded k8s types
-   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
-   are decoded as messages ("cannot unmarshal string into Go value of type
-   map[string]json.RawMessage"), and it never reaches the Spec/Status
-   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
-   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
-   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
-   type strips this method to avoid infinite recursion.
-
-   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
-   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
-   the web client back into numbers, which is what encoding/json expects. */
+/* gogo's jsonpb dispatches to UnmarshalJSONPB when a Model is nested in
+   another proto message (e.g. an Update request decoded by YARPC); without it,
+   jsonpb reflects into the struct and mishandles embedded k8s types such as
+   metav1.Time in ObjectMeta, which serialize as JSON strings but are decoded as
+   messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), never reaching the Spec/Status UnmarshalJSON
+   fallbacks above. Delegating to encoding/json decodes TypeMeta/ObjectMeta
+   natively and routes Spec/Status through their own UnmarshalJSON (still jsonpb
+   for oneofs and enums); the Alias type strips this method to avoid recursion.
+   CoerceObjectMetaIntegers first converts ObjectMeta integers (e.g. generation)
+   from the proto3 JSON strings jsonpb and the web client emit back to numbers,
+   which is what encoding/json expects. */
 func (m *Model) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
 	b, err := util.CoerceObjectMetaIntegers(b)
 	if err != nil {

--- a/proto-go/api/v2/model.pb.go
+++ b/proto-go/api/v2/model.pb.go
@@ -5377,6 +5377,30 @@ func (m *ModelStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
+/* When a Model is nested inside another proto message (e.g. an
+   Update request decoded by YARPC), gogo's jsonpb dispatches to
+   UnmarshalJSONPB if it is implemented and otherwise reflects into the
+   struct directly. That reflection path mishandles embedded k8s types
+   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
+   are decoded as messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), and it never reaches the Spec/Status
+   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
+   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
+   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
+   type strips this method to avoid infinite recursion.
+
+   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
+   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
+   the web client back into numbers, which is what encoding/json expects. */
+func (m *Model) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
+	b, err := util.CoerceObjectMetaIntegers(b)
+	if err != nil {
+		return err
+	}
+	type Alias Model
+	return json.Unmarshal(b, (*Alias)(m))
+}
+
 func (in *Model) DeepCopy() *Model {
 	if in == nil {
 		return nil

--- a/proto-go/api/v2/model_family.pb.go
+++ b/proto-go/api/v2/model_family.pb.go
@@ -1042,6 +1042,30 @@ func (m *ModelFamilyStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
+/* When a ModelFamily is nested inside another proto message (e.g. an
+   Update request decoded by YARPC), gogo's jsonpb dispatches to
+   UnmarshalJSONPB if it is implemented and otherwise reflects into the
+   struct directly. That reflection path mishandles embedded k8s types
+   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
+   are decoded as messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), and it never reaches the Spec/Status
+   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
+   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
+   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
+   type strips this method to avoid infinite recursion.
+
+   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
+   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
+   the web client back into numbers, which is what encoding/json expects. */
+func (m *ModelFamily) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
+	b, err := util.CoerceObjectMetaIntegers(b)
+	if err != nil {
+		return err
+	}
+	type Alias ModelFamily
+	return json.Unmarshal(b, (*Alias)(m))
+}
+
 func (in *ModelFamily) DeepCopy() *ModelFamily {
 	if in == nil {
 		return nil

--- a/proto-go/api/v2/model_family.pb.go
+++ b/proto-go/api/v2/model_family.pb.go
@@ -1042,21 +1042,18 @@ func (m *ModelFamilyStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
-/* When a ModelFamily is nested inside another proto message (e.g. an
-   Update request decoded by YARPC), gogo's jsonpb dispatches to
-   UnmarshalJSONPB if it is implemented and otherwise reflects into the
-   struct directly. That reflection path mishandles embedded k8s types
-   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
-   are decoded as messages ("cannot unmarshal string into Go value of type
-   map[string]json.RawMessage"), and it never reaches the Spec/Status
-   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
-   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
-   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
-   type strips this method to avoid infinite recursion.
-
-   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
-   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
-   the web client back into numbers, which is what encoding/json expects. */
+/* gogo's jsonpb dispatches to UnmarshalJSONPB when a ModelFamily is nested in
+   another proto message (e.g. an Update request decoded by YARPC); without it,
+   jsonpb reflects into the struct and mishandles embedded k8s types such as
+   metav1.Time in ObjectMeta, which serialize as JSON strings but are decoded as
+   messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), never reaching the Spec/Status UnmarshalJSON
+   fallbacks above. Delegating to encoding/json decodes TypeMeta/ObjectMeta
+   natively and routes Spec/Status through their own UnmarshalJSON (still jsonpb
+   for oneofs and enums); the Alias type strips this method to avoid recursion.
+   CoerceObjectMetaIntegers first converts ObjectMeta integers (e.g. generation)
+   from the proto3 JSON strings jsonpb and the web client emit back to numbers,
+   which is what encoding/json expects. */
 func (m *ModelFamily) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
 	b, err := util.CoerceObjectMetaIntegers(b)
 	if err != nil {

--- a/proto-go/api/v2/pipeline.pb.go
+++ b/proto-go/api/v2/pipeline.pb.go
@@ -3033,21 +3033,18 @@ func (m *PipelineStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
-/* When a Pipeline is nested inside another proto message (e.g. an
-   Update request decoded by YARPC), gogo's jsonpb dispatches to
-   UnmarshalJSONPB if it is implemented and otherwise reflects into the
-   struct directly. That reflection path mishandles embedded k8s types
-   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
-   are decoded as messages ("cannot unmarshal string into Go value of type
-   map[string]json.RawMessage"), and it never reaches the Spec/Status
-   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
-   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
-   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
-   type strips this method to avoid infinite recursion.
-
-   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
-   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
-   the web client back into numbers, which is what encoding/json expects. */
+/* gogo's jsonpb dispatches to UnmarshalJSONPB when a Pipeline is nested in
+   another proto message (e.g. an Update request decoded by YARPC); without it,
+   jsonpb reflects into the struct and mishandles embedded k8s types such as
+   metav1.Time in ObjectMeta, which serialize as JSON strings but are decoded as
+   messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), never reaching the Spec/Status UnmarshalJSON
+   fallbacks above. Delegating to encoding/json decodes TypeMeta/ObjectMeta
+   natively and routes Spec/Status through their own UnmarshalJSON (still jsonpb
+   for oneofs and enums); the Alias type strips this method to avoid recursion.
+   CoerceObjectMetaIntegers first converts ObjectMeta integers (e.g. generation)
+   from the proto3 JSON strings jsonpb and the web client emit back to numbers,
+   which is what encoding/json expects. */
 func (m *Pipeline) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
 	b, err := util.CoerceObjectMetaIntegers(b)
 	if err != nil {

--- a/proto-go/api/v2/pipeline.pb.go
+++ b/proto-go/api/v2/pipeline.pb.go
@@ -3033,6 +3033,30 @@ func (m *PipelineStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
+/* When a Pipeline is nested inside another proto message (e.g. an
+   Update request decoded by YARPC), gogo's jsonpb dispatches to
+   UnmarshalJSONPB if it is implemented and otherwise reflects into the
+   struct directly. That reflection path mishandles embedded k8s types
+   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
+   are decoded as messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), and it never reaches the Spec/Status
+   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
+   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
+   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
+   type strips this method to avoid infinite recursion.
+
+   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
+   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
+   the web client back into numbers, which is what encoding/json expects. */
+func (m *Pipeline) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
+	b, err := util.CoerceObjectMetaIntegers(b)
+	if err != nil {
+		return err
+	}
+	type Alias Pipeline
+	return json.Unmarshal(b, (*Alias)(m))
+}
+
 func (in *Pipeline) DeepCopy() *Pipeline {
 	if in == nil {
 		return nil

--- a/proto-go/api/v2/pipeline_run.pb.go
+++ b/proto-go/api/v2/pipeline_run.pb.go
@@ -6076,6 +6076,30 @@ func (m *PipelineRunStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
+/* When a PipelineRun is nested inside another proto message (e.g. an
+   Update request decoded by YARPC), gogo's jsonpb dispatches to
+   UnmarshalJSONPB if it is implemented and otherwise reflects into the
+   struct directly. That reflection path mishandles embedded k8s types
+   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
+   are decoded as messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), and it never reaches the Spec/Status
+   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
+   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
+   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
+   type strips this method to avoid infinite recursion.
+
+   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
+   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
+   the web client back into numbers, which is what encoding/json expects. */
+func (m *PipelineRun) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
+	b, err := util.CoerceObjectMetaIntegers(b)
+	if err != nil {
+		return err
+	}
+	type Alias PipelineRun
+	return json.Unmarshal(b, (*Alias)(m))
+}
+
 func (in *PipelineRun) DeepCopy() *PipelineRun {
 	if in == nil {
 		return nil

--- a/proto-go/api/v2/pipeline_run.pb.go
+++ b/proto-go/api/v2/pipeline_run.pb.go
@@ -6076,21 +6076,18 @@ func (m *PipelineRunStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
-/* When a PipelineRun is nested inside another proto message (e.g. an
-   Update request decoded by YARPC), gogo's jsonpb dispatches to
-   UnmarshalJSONPB if it is implemented and otherwise reflects into the
-   struct directly. That reflection path mishandles embedded k8s types
-   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
-   are decoded as messages ("cannot unmarshal string into Go value of type
-   map[string]json.RawMessage"), and it never reaches the Spec/Status
-   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
-   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
-   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
-   type strips this method to avoid infinite recursion.
-
-   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
-   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
-   the web client back into numbers, which is what encoding/json expects. */
+/* gogo's jsonpb dispatches to UnmarshalJSONPB when a PipelineRun is nested in
+   another proto message (e.g. an Update request decoded by YARPC); without it,
+   jsonpb reflects into the struct and mishandles embedded k8s types such as
+   metav1.Time in ObjectMeta, which serialize as JSON strings but are decoded as
+   messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), never reaching the Spec/Status UnmarshalJSON
+   fallbacks above. Delegating to encoding/json decodes TypeMeta/ObjectMeta
+   natively and routes Spec/Status through their own UnmarshalJSON (still jsonpb
+   for oneofs and enums); the Alias type strips this method to avoid recursion.
+   CoerceObjectMetaIntegers first converts ObjectMeta integers (e.g. generation)
+   from the proto3 JSON strings jsonpb and the web client emit back to numbers,
+   which is what encoding/json expects. */
 func (m *PipelineRun) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
 	b, err := util.CoerceObjectMetaIntegers(b)
 	if err != nil {

--- a/proto-go/api/v2/project.pb.go
+++ b/proto-go/api/v2/project.pb.go
@@ -3052,21 +3052,18 @@ func (m *ProjectStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
-/* When a Project is nested inside another proto message (e.g. an
-   Update request decoded by YARPC), gogo's jsonpb dispatches to
-   UnmarshalJSONPB if it is implemented and otherwise reflects into the
-   struct directly. That reflection path mishandles embedded k8s types
-   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
-   are decoded as messages ("cannot unmarshal string into Go value of type
-   map[string]json.RawMessage"), and it never reaches the Spec/Status
-   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
-   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
-   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
-   type strips this method to avoid infinite recursion.
-
-   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
-   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
-   the web client back into numbers, which is what encoding/json expects. */
+/* gogo's jsonpb dispatches to UnmarshalJSONPB when a Project is nested in
+   another proto message (e.g. an Update request decoded by YARPC); without it,
+   jsonpb reflects into the struct and mishandles embedded k8s types such as
+   metav1.Time in ObjectMeta, which serialize as JSON strings but are decoded as
+   messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), never reaching the Spec/Status UnmarshalJSON
+   fallbacks above. Delegating to encoding/json decodes TypeMeta/ObjectMeta
+   natively and routes Spec/Status through their own UnmarshalJSON (still jsonpb
+   for oneofs and enums); the Alias type strips this method to avoid recursion.
+   CoerceObjectMetaIntegers first converts ObjectMeta integers (e.g. generation)
+   from the proto3 JSON strings jsonpb and the web client emit back to numbers,
+   which is what encoding/json expects. */
 func (m *Project) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
 	b, err := util.CoerceObjectMetaIntegers(b)
 	if err != nil {

--- a/proto-go/api/v2/project.pb.go
+++ b/proto-go/api/v2/project.pb.go
@@ -3052,6 +3052,30 @@ func (m *ProjectStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
+/* When a Project is nested inside another proto message (e.g. an
+   Update request decoded by YARPC), gogo's jsonpb dispatches to
+   UnmarshalJSONPB if it is implemented and otherwise reflects into the
+   struct directly. That reflection path mishandles embedded k8s types
+   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
+   are decoded as messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), and it never reaches the Spec/Status
+   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
+   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
+   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
+   type strips this method to avoid infinite recursion.
+
+   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
+   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
+   the web client back into numbers, which is what encoding/json expects. */
+func (m *Project) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
+	b, err := util.CoerceObjectMetaIntegers(b)
+	if err != nil {
+		return err
+	}
+	type Alias Project
+	return json.Unmarshal(b, (*Alias)(m))
+}
+
 func (in *Project) DeepCopy() *Project {
 	if in == nil {
 		return nil

--- a/proto-go/api/v2/ray_cluster.pb.go
+++ b/proto-go/api/v2/ray_cluster.pb.go
@@ -3850,21 +3850,18 @@ func (m *RayClusterStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
-/* When a RayCluster is nested inside another proto message (e.g. an
-   Update request decoded by YARPC), gogo's jsonpb dispatches to
-   UnmarshalJSONPB if it is implemented and otherwise reflects into the
-   struct directly. That reflection path mishandles embedded k8s types
-   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
-   are decoded as messages ("cannot unmarshal string into Go value of type
-   map[string]json.RawMessage"), and it never reaches the Spec/Status
-   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
-   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
-   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
-   type strips this method to avoid infinite recursion.
-
-   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
-   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
-   the web client back into numbers, which is what encoding/json expects. */
+/* gogo's jsonpb dispatches to UnmarshalJSONPB when a RayCluster is nested in
+   another proto message (e.g. an Update request decoded by YARPC); without it,
+   jsonpb reflects into the struct and mishandles embedded k8s types such as
+   metav1.Time in ObjectMeta, which serialize as JSON strings but are decoded as
+   messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), never reaching the Spec/Status UnmarshalJSON
+   fallbacks above. Delegating to encoding/json decodes TypeMeta/ObjectMeta
+   natively and routes Spec/Status through their own UnmarshalJSON (still jsonpb
+   for oneofs and enums); the Alias type strips this method to avoid recursion.
+   CoerceObjectMetaIntegers first converts ObjectMeta integers (e.g. generation)
+   from the proto3 JSON strings jsonpb and the web client emit back to numbers,
+   which is what encoding/json expects. */
 func (m *RayCluster) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
 	b, err := util.CoerceObjectMetaIntegers(b)
 	if err != nil {

--- a/proto-go/api/v2/ray_cluster.pb.go
+++ b/proto-go/api/v2/ray_cluster.pb.go
@@ -3850,6 +3850,30 @@ func (m *RayClusterStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
+/* When a RayCluster is nested inside another proto message (e.g. an
+   Update request decoded by YARPC), gogo's jsonpb dispatches to
+   UnmarshalJSONPB if it is implemented and otherwise reflects into the
+   struct directly. That reflection path mishandles embedded k8s types
+   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
+   are decoded as messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), and it never reaches the Spec/Status
+   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
+   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
+   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
+   type strips this method to avoid infinite recursion.
+
+   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
+   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
+   the web client back into numbers, which is what encoding/json expects. */
+func (m *RayCluster) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
+	b, err := util.CoerceObjectMetaIntegers(b)
+	if err != nil {
+		return err
+	}
+	type Alias RayCluster
+	return json.Unmarshal(b, (*Alias)(m))
+}
+
 func (in *RayCluster) DeepCopy() *RayCluster {
 	if in == nil {
 		return nil

--- a/proto-go/api/v2/ray_job.pb.go
+++ b/proto-go/api/v2/ray_job.pb.go
@@ -1685,6 +1685,30 @@ func (m *RayJobStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
+/* When a RayJob is nested inside another proto message (e.g. an
+   Update request decoded by YARPC), gogo's jsonpb dispatches to
+   UnmarshalJSONPB if it is implemented and otherwise reflects into the
+   struct directly. That reflection path mishandles embedded k8s types
+   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
+   are decoded as messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), and it never reaches the Spec/Status
+   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
+   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
+   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
+   type strips this method to avoid infinite recursion.
+
+   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
+   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
+   the web client back into numbers, which is what encoding/json expects. */
+func (m *RayJob) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
+	b, err := util.CoerceObjectMetaIntegers(b)
+	if err != nil {
+		return err
+	}
+	type Alias RayJob
+	return json.Unmarshal(b, (*Alias)(m))
+}
+
 func (in *RayJob) DeepCopy() *RayJob {
 	if in == nil {
 		return nil

--- a/proto-go/api/v2/ray_job.pb.go
+++ b/proto-go/api/v2/ray_job.pb.go
@@ -1685,21 +1685,18 @@ func (m *RayJobStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
-/* When a RayJob is nested inside another proto message (e.g. an
-   Update request decoded by YARPC), gogo's jsonpb dispatches to
-   UnmarshalJSONPB if it is implemented and otherwise reflects into the
-   struct directly. That reflection path mishandles embedded k8s types
-   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
-   are decoded as messages ("cannot unmarshal string into Go value of type
-   map[string]json.RawMessage"), and it never reaches the Spec/Status
-   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
-   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
-   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
-   type strips this method to avoid infinite recursion.
-
-   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
-   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
-   the web client back into numbers, which is what encoding/json expects. */
+/* gogo's jsonpb dispatches to UnmarshalJSONPB when a RayJob is nested in
+   another proto message (e.g. an Update request decoded by YARPC); without it,
+   jsonpb reflects into the struct and mishandles embedded k8s types such as
+   metav1.Time in ObjectMeta, which serialize as JSON strings but are decoded as
+   messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), never reaching the Spec/Status UnmarshalJSON
+   fallbacks above. Delegating to encoding/json decodes TypeMeta/ObjectMeta
+   natively and routes Spec/Status through their own UnmarshalJSON (still jsonpb
+   for oneofs and enums); the Alias type strips this method to avoid recursion.
+   CoerceObjectMetaIntegers first converts ObjectMeta integers (e.g. generation)
+   from the proto3 JSON strings jsonpb and the web client emit back to numbers,
+   which is what encoding/json expects. */
 func (m *RayJob) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
 	b, err := util.CoerceObjectMetaIntegers(b)
 	if err != nil {

--- a/proto-go/api/v2/revision.pb.go
+++ b/proto-go/api/v2/revision.pb.go
@@ -1519,6 +1519,30 @@ func (m *RevisionStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
+/* When a Revision is nested inside another proto message (e.g. an
+   Update request decoded by YARPC), gogo's jsonpb dispatches to
+   UnmarshalJSONPB if it is implemented and otherwise reflects into the
+   struct directly. That reflection path mishandles embedded k8s types
+   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
+   are decoded as messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), and it never reaches the Spec/Status
+   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
+   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
+   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
+   type strips this method to avoid infinite recursion.
+
+   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
+   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
+   the web client back into numbers, which is what encoding/json expects. */
+func (m *Revision) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
+	b, err := util.CoerceObjectMetaIntegers(b)
+	if err != nil {
+		return err
+	}
+	type Alias Revision
+	return json.Unmarshal(b, (*Alias)(m))
+}
+
 func (in *Revision) DeepCopy() *Revision {
 	if in == nil {
 		return nil

--- a/proto-go/api/v2/revision.pb.go
+++ b/proto-go/api/v2/revision.pb.go
@@ -1519,21 +1519,18 @@ func (m *RevisionStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
-/* When a Revision is nested inside another proto message (e.g. an
-   Update request decoded by YARPC), gogo's jsonpb dispatches to
-   UnmarshalJSONPB if it is implemented and otherwise reflects into the
-   struct directly. That reflection path mishandles embedded k8s types
-   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
-   are decoded as messages ("cannot unmarshal string into Go value of type
-   map[string]json.RawMessage"), and it never reaches the Spec/Status
-   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
-   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
-   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
-   type strips this method to avoid infinite recursion.
-
-   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
-   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
-   the web client back into numbers, which is what encoding/json expects. */
+/* gogo's jsonpb dispatches to UnmarshalJSONPB when a Revision is nested in
+   another proto message (e.g. an Update request decoded by YARPC); without it,
+   jsonpb reflects into the struct and mishandles embedded k8s types such as
+   metav1.Time in ObjectMeta, which serialize as JSON strings but are decoded as
+   messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), never reaching the Spec/Status UnmarshalJSON
+   fallbacks above. Delegating to encoding/json decodes TypeMeta/ObjectMeta
+   natively and routes Spec/Status through their own UnmarshalJSON (still jsonpb
+   for oneofs and enums); the Alias type strips this method to avoid recursion.
+   CoerceObjectMetaIntegers first converts ObjectMeta integers (e.g. generation)
+   from the proto3 JSON strings jsonpb and the web client emit back to numbers,
+   which is what encoding/json expects. */
 func (m *Revision) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
 	b, err := util.CoerceObjectMetaIntegers(b)
 	if err != nil {

--- a/proto-go/api/v2/spark_job.pb.go
+++ b/proto-go/api/v2/spark_job.pb.go
@@ -2934,6 +2934,30 @@ func (m *SparkJobStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
+/* When a SparkJob is nested inside another proto message (e.g. an
+   Update request decoded by YARPC), gogo's jsonpb dispatches to
+   UnmarshalJSONPB if it is implemented and otherwise reflects into the
+   struct directly. That reflection path mishandles embedded k8s types
+   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
+   are decoded as messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), and it never reaches the Spec/Status
+   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
+   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
+   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
+   type strips this method to avoid infinite recursion.
+
+   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
+   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
+   the web client back into numbers, which is what encoding/json expects. */
+func (m *SparkJob) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
+	b, err := util.CoerceObjectMetaIntegers(b)
+	if err != nil {
+		return err
+	}
+	type Alias SparkJob
+	return json.Unmarshal(b, (*Alias)(m))
+}
+
 func (in *SparkJob) DeepCopy() *SparkJob {
 	if in == nil {
 		return nil

--- a/proto-go/api/v2/spark_job.pb.go
+++ b/proto-go/api/v2/spark_job.pb.go
@@ -2934,21 +2934,18 @@ func (m *SparkJobStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
-/* When a SparkJob is nested inside another proto message (e.g. an
-   Update request decoded by YARPC), gogo's jsonpb dispatches to
-   UnmarshalJSONPB if it is implemented and otherwise reflects into the
-   struct directly. That reflection path mishandles embedded k8s types
-   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
-   are decoded as messages ("cannot unmarshal string into Go value of type
-   map[string]json.RawMessage"), and it never reaches the Spec/Status
-   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
-   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
-   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
-   type strips this method to avoid infinite recursion.
-
-   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
-   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
-   the web client back into numbers, which is what encoding/json expects. */
+/* gogo's jsonpb dispatches to UnmarshalJSONPB when a SparkJob is nested in
+   another proto message (e.g. an Update request decoded by YARPC); without it,
+   jsonpb reflects into the struct and mishandles embedded k8s types such as
+   metav1.Time in ObjectMeta, which serialize as JSON strings but are decoded as
+   messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), never reaching the Spec/Status UnmarshalJSON
+   fallbacks above. Delegating to encoding/json decodes TypeMeta/ObjectMeta
+   natively and routes Spec/Status through their own UnmarshalJSON (still jsonpb
+   for oneofs and enums); the Alias type strips this method to avoid recursion.
+   CoerceObjectMetaIntegers first converts ObjectMeta integers (e.g. generation)
+   from the proto3 JSON strings jsonpb and the web client emit back to numbers,
+   which is what encoding/json expects. */
 func (m *SparkJob) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
 	b, err := util.CoerceObjectMetaIntegers(b)
 	if err != nil {

--- a/proto-go/api/v2/trigger_run.pb.go
+++ b/proto-go/api/v2/trigger_run.pb.go
@@ -3686,21 +3686,18 @@ func (m *TriggerRunStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
-/* When a TriggerRun is nested inside another proto message (e.g. an
-   Update request decoded by YARPC), gogo's jsonpb dispatches to
-   UnmarshalJSONPB if it is implemented and otherwise reflects into the
-   struct directly. That reflection path mishandles embedded k8s types
-   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
-   are decoded as messages ("cannot unmarshal string into Go value of type
-   map[string]json.RawMessage"), and it never reaches the Spec/Status
-   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
-   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
-   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
-   type strips this method to avoid infinite recursion.
-
-   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
-   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
-   the web client back into numbers, which is what encoding/json expects. */
+/* gogo's jsonpb dispatches to UnmarshalJSONPB when a TriggerRun is nested in
+   another proto message (e.g. an Update request decoded by YARPC); without it,
+   jsonpb reflects into the struct and mishandles embedded k8s types such as
+   metav1.Time in ObjectMeta, which serialize as JSON strings but are decoded as
+   messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), never reaching the Spec/Status UnmarshalJSON
+   fallbacks above. Delegating to encoding/json decodes TypeMeta/ObjectMeta
+   natively and routes Spec/Status through their own UnmarshalJSON (still jsonpb
+   for oneofs and enums); the Alias type strips this method to avoid recursion.
+   CoerceObjectMetaIntegers first converts ObjectMeta integers (e.g. generation)
+   from the proto3 JSON strings jsonpb and the web client emit back to numbers,
+   which is what encoding/json expects. */
 func (m *TriggerRun) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
 	b, err := util.CoerceObjectMetaIntegers(b)
 	if err != nil {

--- a/proto-go/api/v2/trigger_run.pb.go
+++ b/proto-go/api/v2/trigger_run.pb.go
@@ -3686,6 +3686,30 @@ func (m *TriggerRunStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
+/* When a TriggerRun is nested inside another proto message (e.g. an
+   Update request decoded by YARPC), gogo's jsonpb dispatches to
+   UnmarshalJSONPB if it is implemented and otherwise reflects into the
+   struct directly. That reflection path mishandles embedded k8s types
+   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
+   are decoded as messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), and it never reaches the Spec/Status
+   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
+   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
+   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
+   type strips this method to avoid infinite recursion.
+
+   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
+   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
+   the web client back into numbers, which is what encoding/json expects. */
+func (m *TriggerRun) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
+	b, err := util.CoerceObjectMetaIntegers(b)
+	if err != nil {
+		return err
+	}
+	type Alias TriggerRun
+	return json.Unmarshal(b, (*Alias)(m))
+}
+
 func (in *TriggerRun) DeepCopy() *TriggerRun {
 	if in == nil {
 		return nil

--- a/proto-go/test/api/v2alpha1/project.pb.go
+++ b/proto-go/test/api/v2alpha1/project.pb.go
@@ -3050,21 +3050,18 @@ func (m *ProjectStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
-/* When a Project is nested inside another proto message (e.g. an
-   Update request decoded by YARPC), gogo's jsonpb dispatches to
-   UnmarshalJSONPB if it is implemented and otherwise reflects into the
-   struct directly. That reflection path mishandles embedded k8s types
-   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
-   are decoded as messages ("cannot unmarshal string into Go value of type
-   map[string]json.RawMessage"), and it never reaches the Spec/Status
-   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
-   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
-   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
-   type strips this method to avoid infinite recursion.
-
-   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
-   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
-   the web client back into numbers, which is what encoding/json expects. */
+/* gogo's jsonpb dispatches to UnmarshalJSONPB when a Project is nested in
+   another proto message (e.g. an Update request decoded by YARPC); without it,
+   jsonpb reflects into the struct and mishandles embedded k8s types such as
+   metav1.Time in ObjectMeta, which serialize as JSON strings but are decoded as
+   messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), never reaching the Spec/Status UnmarshalJSON
+   fallbacks above. Delegating to encoding/json decodes TypeMeta/ObjectMeta
+   natively and routes Spec/Status through their own UnmarshalJSON (still jsonpb
+   for oneofs and enums); the Alias type strips this method to avoid recursion.
+   CoerceObjectMetaIntegers first converts ObjectMeta integers (e.g. generation)
+   from the proto3 JSON strings jsonpb and the web client emit back to numbers,
+   which is what encoding/json expects. */
 func (m *Project) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
 	b, err := util.CoerceObjectMetaIntegers(b)
 	if err != nil {

--- a/proto-go/test/api/v2alpha1/project.pb.go
+++ b/proto-go/test/api/v2alpha1/project.pb.go
@@ -3050,6 +3050,30 @@ func (m *ProjectStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
+/* When a Project is nested inside another proto message (e.g. an
+   Update request decoded by YARPC), gogo's jsonpb dispatches to
+   UnmarshalJSONPB if it is implemented and otherwise reflects into the
+   struct directly. That reflection path mishandles embedded k8s types
+   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
+   are decoded as messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), and it never reaches the Spec/Status
+   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
+   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
+   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
+   type strips this method to avoid infinite recursion.
+
+   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
+   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
+   the web client back into numbers, which is what encoding/json expects. */
+func (m *Project) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
+	b, err := util.CoerceObjectMetaIntegers(b)
+	if err != nil {
+		return err
+	}
+	type Alias Project
+	return json.Unmarshal(b, (*Alias)(m))
+}
+
 func (in *Project) DeepCopy() *Project {
 	if in == nil {
 		return nil

--- a/proto-go/test/kubeproto/conversion/v1/testobject.pb.go
+++ b/proto-go/test/kubeproto/conversion/v1/testobject.pb.go
@@ -2937,21 +2937,18 @@ func (m *TestObjectStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
-/* When a TestObject is nested inside another proto message (e.g. an
-   Update request decoded by YARPC), gogo's jsonpb dispatches to
-   UnmarshalJSONPB if it is implemented and otherwise reflects into the
-   struct directly. That reflection path mishandles embedded k8s types
-   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
-   are decoded as messages ("cannot unmarshal string into Go value of type
-   map[string]json.RawMessage"), and it never reaches the Spec/Status
-   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
-   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
-   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
-   type strips this method to avoid infinite recursion.
-
-   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
-   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
-   the web client back into numbers, which is what encoding/json expects. */
+/* gogo's jsonpb dispatches to UnmarshalJSONPB when a TestObject is nested in
+   another proto message (e.g. an Update request decoded by YARPC); without it,
+   jsonpb reflects into the struct and mishandles embedded k8s types such as
+   metav1.Time in ObjectMeta, which serialize as JSON strings but are decoded as
+   messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), never reaching the Spec/Status UnmarshalJSON
+   fallbacks above. Delegating to encoding/json decodes TypeMeta/ObjectMeta
+   natively and routes Spec/Status through their own UnmarshalJSON (still jsonpb
+   for oneofs and enums); the Alias type strips this method to avoid recursion.
+   CoerceObjectMetaIntegers first converts ObjectMeta integers (e.g. generation)
+   from the proto3 JSON strings jsonpb and the web client emit back to numbers,
+   which is what encoding/json expects. */
 func (m *TestObject) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
 	b, err := util.CoerceObjectMetaIntegers(b)
 	if err != nil {

--- a/proto-go/test/kubeproto/conversion/v1/testobject.pb.go
+++ b/proto-go/test/kubeproto/conversion/v1/testobject.pb.go
@@ -2937,6 +2937,30 @@ func (m *TestObjectStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
+/* When a TestObject is nested inside another proto message (e.g. an
+   Update request decoded by YARPC), gogo's jsonpb dispatches to
+   UnmarshalJSONPB if it is implemented and otherwise reflects into the
+   struct directly. That reflection path mishandles embedded k8s types
+   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
+   are decoded as messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), and it never reaches the Spec/Status
+   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
+   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
+   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
+   type strips this method to avoid infinite recursion.
+
+   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
+   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
+   the web client back into numbers, which is what encoding/json expects. */
+func (m *TestObject) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
+	b, err := util.CoerceObjectMetaIntegers(b)
+	if err != nil {
+		return err
+	}
+	type Alias TestObject
+	return json.Unmarshal(b, (*Alias)(m))
+}
+
 func (in *TestObject) DeepCopy() *TestObject {
 	if in == nil {
 		return nil

--- a/proto-go/test/kubeproto/conversion/v2/testobject.pb.go
+++ b/proto-go/test/kubeproto/conversion/v2/testobject.pb.go
@@ -2880,6 +2880,30 @@ func (m *TestObjectStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
+/* When a TestObject is nested inside another proto message (e.g. an
+   Update request decoded by YARPC), gogo's jsonpb dispatches to
+   UnmarshalJSONPB if it is implemented and otherwise reflects into the
+   struct directly. That reflection path mishandles embedded k8s types
+   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
+   are decoded as messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), and it never reaches the Spec/Status
+   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
+   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
+   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
+   type strips this method to avoid infinite recursion.
+
+   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
+   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
+   the web client back into numbers, which is what encoding/json expects. */
+func (m *TestObject) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
+	b, err := util.CoerceObjectMetaIntegers(b)
+	if err != nil {
+		return err
+	}
+	type Alias TestObject
+	return json.Unmarshal(b, (*Alias)(m))
+}
+
 func (in *TestObject) DeepCopy() *TestObject {
 	if in == nil {
 		return nil

--- a/proto-go/test/kubeproto/conversion/v2/testobject.pb.go
+++ b/proto-go/test/kubeproto/conversion/v2/testobject.pb.go
@@ -2880,21 +2880,18 @@ func (m *TestObjectStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
-/* When a TestObject is nested inside another proto message (e.g. an
-   Update request decoded by YARPC), gogo's jsonpb dispatches to
-   UnmarshalJSONPB if it is implemented and otherwise reflects into the
-   struct directly. That reflection path mishandles embedded k8s types
-   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
-   are decoded as messages ("cannot unmarshal string into Go value of type
-   map[string]json.RawMessage"), and it never reaches the Spec/Status
-   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
-   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
-   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
-   type strips this method to avoid infinite recursion.
-
-   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
-   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
-   the web client back into numbers, which is what encoding/json expects. */
+/* gogo's jsonpb dispatches to UnmarshalJSONPB when a TestObject is nested in
+   another proto message (e.g. an Update request decoded by YARPC); without it,
+   jsonpb reflects into the struct and mishandles embedded k8s types such as
+   metav1.Time in ObjectMeta, which serialize as JSON strings but are decoded as
+   messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), never reaching the Spec/Status UnmarshalJSON
+   fallbacks above. Delegating to encoding/json decodes TypeMeta/ObjectMeta
+   natively and routes Spec/Status through their own UnmarshalJSON (still jsonpb
+   for oneofs and enums); the Alias type strips this method to avoid recursion.
+   CoerceObjectMetaIntegers first converts ObjectMeta integers (e.g. generation)
+   from the proto3 JSON strings jsonpb and the web client emit back to numbers,
+   which is what encoding/json expects. */
 func (m *TestObject) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
 	b, err := util.CoerceObjectMetaIntegers(b)
 	if err != nil {

--- a/proto-go/test/kubeproto/crd_info_ut.pb.go
+++ b/proto-go/test/kubeproto/crd_info_ut.pb.go
@@ -930,21 +930,18 @@ func (m *TestCRDStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
-/* When a TestCRD is nested inside another proto message (e.g. an
-   Update request decoded by YARPC), gogo's jsonpb dispatches to
-   UnmarshalJSONPB if it is implemented and otherwise reflects into the
-   struct directly. That reflection path mishandles embedded k8s types
-   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
-   are decoded as messages ("cannot unmarshal string into Go value of type
-   map[string]json.RawMessage"), and it never reaches the Spec/Status
-   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
-   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
-   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
-   type strips this method to avoid infinite recursion.
-
-   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
-   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
-   the web client back into numbers, which is what encoding/json expects. */
+/* gogo's jsonpb dispatches to UnmarshalJSONPB when a TestCRD is nested in
+   another proto message (e.g. an Update request decoded by YARPC); without it,
+   jsonpb reflects into the struct and mishandles embedded k8s types such as
+   metav1.Time in ObjectMeta, which serialize as JSON strings but are decoded as
+   messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), never reaching the Spec/Status UnmarshalJSON
+   fallbacks above. Delegating to encoding/json decodes TypeMeta/ObjectMeta
+   natively and routes Spec/Status through their own UnmarshalJSON (still jsonpb
+   for oneofs and enums); the Alias type strips this method to avoid recursion.
+   CoerceObjectMetaIntegers first converts ObjectMeta integers (e.g. generation)
+   from the proto3 JSON strings jsonpb and the web client emit back to numbers,
+   which is what encoding/json expects. */
 func (m *TestCRD) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
 	b, err := util.CoerceObjectMetaIntegers(b)
 	if err != nil {

--- a/proto-go/test/kubeproto/crd_info_ut.pb.go
+++ b/proto-go/test/kubeproto/crd_info_ut.pb.go
@@ -930,6 +930,30 @@ func (m *TestCRDStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
+/* When a TestCRD is nested inside another proto message (e.g. an
+   Update request decoded by YARPC), gogo's jsonpb dispatches to
+   UnmarshalJSONPB if it is implemented and otherwise reflects into the
+   struct directly. That reflection path mishandles embedded k8s types
+   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
+   are decoded as messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), and it never reaches the Spec/Status
+   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
+   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
+   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
+   type strips this method to avoid infinite recursion.
+
+   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
+   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
+   the web client back into numbers, which is what encoding/json expects. */
+func (m *TestCRD) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
+	b, err := util.CoerceObjectMetaIntegers(b)
+	if err != nil {
+		return err
+	}
+	type Alias TestCRD
+	return json.Unmarshal(b, (*Alias)(m))
+}
+
 func (in *TestCRD) DeepCopy() *TestCRD {
 	if in == nil {
 		return nil

--- a/proto-go/test/kubeproto/indexing.pb.go
+++ b/proto-go/test/kubeproto/indexing.pb.go
@@ -2368,21 +2368,18 @@ func (m *TestIndexingStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
-/* When a TestIndexing is nested inside another proto message (e.g. an
-   Update request decoded by YARPC), gogo's jsonpb dispatches to
-   UnmarshalJSONPB if it is implemented and otherwise reflects into the
-   struct directly. That reflection path mishandles embedded k8s types
-   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
-   are decoded as messages ("cannot unmarshal string into Go value of type
-   map[string]json.RawMessage"), and it never reaches the Spec/Status
-   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
-   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
-   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
-   type strips this method to avoid infinite recursion.
-
-   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
-   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
-   the web client back into numbers, which is what encoding/json expects. */
+/* gogo's jsonpb dispatches to UnmarshalJSONPB when a TestIndexing is nested in
+   another proto message (e.g. an Update request decoded by YARPC); without it,
+   jsonpb reflects into the struct and mishandles embedded k8s types such as
+   metav1.Time in ObjectMeta, which serialize as JSON strings but are decoded as
+   messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), never reaching the Spec/Status UnmarshalJSON
+   fallbacks above. Delegating to encoding/json decodes TypeMeta/ObjectMeta
+   natively and routes Spec/Status through their own UnmarshalJSON (still jsonpb
+   for oneofs and enums); the Alias type strips this method to avoid recursion.
+   CoerceObjectMetaIntegers first converts ObjectMeta integers (e.g. generation)
+   from the proto3 JSON strings jsonpb and the web client emit back to numbers,
+   which is what encoding/json expects. */
 func (m *TestIndexing) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
 	b, err := util.CoerceObjectMetaIntegers(b)
 	if err != nil {

--- a/proto-go/test/kubeproto/indexing.pb.go
+++ b/proto-go/test/kubeproto/indexing.pb.go
@@ -2368,6 +2368,30 @@ func (m *TestIndexingStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
+/* When a TestIndexing is nested inside another proto message (e.g. an
+   Update request decoded by YARPC), gogo's jsonpb dispatches to
+   UnmarshalJSONPB if it is implemented and otherwise reflects into the
+   struct directly. That reflection path mishandles embedded k8s types
+   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
+   are decoded as messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), and it never reaches the Spec/Status
+   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
+   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
+   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
+   type strips this method to avoid infinite recursion.
+
+   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
+   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
+   the web client back into numbers, which is what encoding/json expects. */
+func (m *TestIndexing) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
+	b, err := util.CoerceObjectMetaIntegers(b)
+	if err != nil {
+		return err
+	}
+	type Alias TestIndexing
+	return json.Unmarshal(b, (*Alias)(m))
+}
+
 func (in *TestIndexing) DeepCopy() *TestIndexing {
 	if in == nil {
 		return nil

--- a/proto-go/test/kubeproto/project_ut.pb.go
+++ b/proto-go/test/kubeproto/project_ut.pb.go
@@ -1278,21 +1278,18 @@ func (m *ProjectStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
-/* When a Project is nested inside another proto message (e.g. an
-   Update request decoded by YARPC), gogo's jsonpb dispatches to
-   UnmarshalJSONPB if it is implemented and otherwise reflects into the
-   struct directly. That reflection path mishandles embedded k8s types
-   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
-   are decoded as messages ("cannot unmarshal string into Go value of type
-   map[string]json.RawMessage"), and it never reaches the Spec/Status
-   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
-   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
-   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
-   type strips this method to avoid infinite recursion.
-
-   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
-   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
-   the web client back into numbers, which is what encoding/json expects. */
+/* gogo's jsonpb dispatches to UnmarshalJSONPB when a Project is nested in
+   another proto message (e.g. an Update request decoded by YARPC); without it,
+   jsonpb reflects into the struct and mishandles embedded k8s types such as
+   metav1.Time in ObjectMeta, which serialize as JSON strings but are decoded as
+   messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), never reaching the Spec/Status UnmarshalJSON
+   fallbacks above. Delegating to encoding/json decodes TypeMeta/ObjectMeta
+   natively and routes Spec/Status through their own UnmarshalJSON (still jsonpb
+   for oneofs and enums); the Alias type strips this method to avoid recursion.
+   CoerceObjectMetaIntegers first converts ObjectMeta integers (e.g. generation)
+   from the proto3 JSON strings jsonpb and the web client emit back to numbers,
+   which is what encoding/json expects. */
 func (m *Project) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
 	b, err := util.CoerceObjectMetaIntegers(b)
 	if err != nil {

--- a/proto-go/test/kubeproto/project_ut.pb.go
+++ b/proto-go/test/kubeproto/project_ut.pb.go
@@ -1278,6 +1278,30 @@ func (m *ProjectStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
+/* When a Project is nested inside another proto message (e.g. an
+   Update request decoded by YARPC), gogo's jsonpb dispatches to
+   UnmarshalJSONPB if it is implemented and otherwise reflects into the
+   struct directly. That reflection path mishandles embedded k8s types
+   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
+   are decoded as messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), and it never reaches the Spec/Status
+   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
+   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
+   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
+   type strips this method to avoid infinite recursion.
+
+   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
+   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
+   the web client back into numbers, which is what encoding/json expects. */
+func (m *Project) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
+	b, err := util.CoerceObjectMetaIntegers(b)
+	if err != nil {
+		return err
+	}
+	type Alias Project
+	return json.Unmarshal(b, (*Alias)(m))
+}
+
 func (in *Project) DeepCopy() *Project {
 	if in == nil {
 		return nil

--- a/proto-go/test/kubeproto/testobject.pb.go
+++ b/proto-go/test/kubeproto/testobject.pb.go
@@ -4877,21 +4877,18 @@ func (m *TestMsg3Status) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
-/* When a TestMsg3 is nested inside another proto message (e.g. an
-   Update request decoded by YARPC), gogo's jsonpb dispatches to
-   UnmarshalJSONPB if it is implemented and otherwise reflects into the
-   struct directly. That reflection path mishandles embedded k8s types
-   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
-   are decoded as messages ("cannot unmarshal string into Go value of type
-   map[string]json.RawMessage"), and it never reaches the Spec/Status
-   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
-   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
-   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
-   type strips this method to avoid infinite recursion.
-
-   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
-   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
-   the web client back into numbers, which is what encoding/json expects. */
+/* gogo's jsonpb dispatches to UnmarshalJSONPB when a TestMsg3 is nested in
+   another proto message (e.g. an Update request decoded by YARPC); without it,
+   jsonpb reflects into the struct and mishandles embedded k8s types such as
+   metav1.Time in ObjectMeta, which serialize as JSON strings but are decoded as
+   messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), never reaching the Spec/Status UnmarshalJSON
+   fallbacks above. Delegating to encoding/json decodes TypeMeta/ObjectMeta
+   natively and routes Spec/Status through their own UnmarshalJSON (still jsonpb
+   for oneofs and enums); the Alias type strips this method to avoid recursion.
+   CoerceObjectMetaIntegers first converts ObjectMeta integers (e.g. generation)
+   from the proto3 JSON strings jsonpb and the web client emit back to numbers,
+   which is what encoding/json expects. */
 func (m *TestMsg3) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
 	b, err := util.CoerceObjectMetaIntegers(b)
 	if err != nil {
@@ -9526,21 +9523,18 @@ func (m *TestObjectStatus) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
-/* When a TestObject is nested inside another proto message (e.g. an
-   Update request decoded by YARPC), gogo's jsonpb dispatches to
-   UnmarshalJSONPB if it is implemented and otherwise reflects into the
-   struct directly. That reflection path mishandles embedded k8s types
-   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
-   are decoded as messages ("cannot unmarshal string into Go value of type
-   map[string]json.RawMessage"), and it never reaches the Spec/Status
-   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
-   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
-   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
-   type strips this method to avoid infinite recursion.
-
-   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
-   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
-   the web client back into numbers, which is what encoding/json expects. */
+/* gogo's jsonpb dispatches to UnmarshalJSONPB when a TestObject is nested in
+   another proto message (e.g. an Update request decoded by YARPC); without it,
+   jsonpb reflects into the struct and mishandles embedded k8s types such as
+   metav1.Time in ObjectMeta, which serialize as JSON strings but are decoded as
+   messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), never reaching the Spec/Status UnmarshalJSON
+   fallbacks above. Delegating to encoding/json decodes TypeMeta/ObjectMeta
+   natively and routes Spec/Status through their own UnmarshalJSON (still jsonpb
+   for oneofs and enums); the Alias type strips this method to avoid recursion.
+   CoerceObjectMetaIntegers first converts ObjectMeta integers (e.g. generation)
+   from the proto3 JSON strings jsonpb and the web client emit back to numbers,
+   which is what encoding/json expects. */
 func (m *TestObject) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
 	b, err := util.CoerceObjectMetaIntegers(b)
 	if err != nil {

--- a/proto-go/test/kubeproto/testobject.pb.go
+++ b/proto-go/test/kubeproto/testobject.pb.go
@@ -4877,6 +4877,30 @@ func (m *TestMsg3Status) UnmarshalJSON(b []byte) error {
     return json.Unmarshal(b, aux)
 }
 
+/* When a TestMsg3 is nested inside another proto message (e.g. an
+   Update request decoded by YARPC), gogo's jsonpb dispatches to
+   UnmarshalJSONPB if it is implemented and otherwise reflects into the
+   struct directly. That reflection path mishandles embedded k8s types
+   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
+   are decoded as messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), and it never reaches the Spec/Status
+   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
+   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
+   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
+   type strips this method to avoid infinite recursion.
+
+   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
+   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
+   the web client back into numbers, which is what encoding/json expects. */
+func (m *TestMsg3) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
+	b, err := util.CoerceObjectMetaIntegers(b)
+	if err != nil {
+		return err
+	}
+	type Alias TestMsg3
+	return json.Unmarshal(b, (*Alias)(m))
+}
+
 func (in *TestMsg3) DeepCopy() *TestMsg3 {
 	if in == nil {
 		return nil
@@ -9500,6 +9524,30 @@ func (m *TestObjectStatus) UnmarshalJSON(b []byte) error {
     aux := (*Alias)(m)
 
     return json.Unmarshal(b, aux)
+}
+
+/* When a TestObject is nested inside another proto message (e.g. an
+   Update request decoded by YARPC), gogo's jsonpb dispatches to
+   UnmarshalJSONPB if it is implemented and otherwise reflects into the
+   struct directly. That reflection path mishandles embedded k8s types
+   such as metav1.Time in ObjectMeta, which serialize as JSON strings but
+   are decoded as messages ("cannot unmarshal string into Go value of type
+   map[string]json.RawMessage"), and it never reaches the Spec/Status
+   UnmarshalJSON fallbacks above. Delegating to encoding/json decodes
+   TypeMeta/ObjectMeta natively and routes Spec/Status through their own
+   UnmarshalJSON, which still use jsonpb for oneofs and enums. The Alias
+   type strips this method to avoid infinite recursion.
+
+   CoerceObjectMetaIntegers first converts ObjectMeta integer fields
+   (e.g. generation) from the proto3 JSON string form emitted by jsonpb and
+   the web client back into numbers, which is what encoding/json expects. */
+func (m *TestObject) UnmarshalJSONPB(u *jsonpb.Unmarshaler, b []byte) error {
+	b, err := util.CoerceObjectMetaIntegers(b)
+	if err != nil {
+		return err
+	}
+	type Alias TestObject
+	return json.Unmarshal(b, (*Alias)(m))
 }
 
 func (in *TestObject) DeepCopy() *TestObject {


### PR DESCRIPTION
CRD mutations from the UI (e.g. UpdateTriggerRun) failed at the YARPC JSON boundary with "cannot unmarshal string into Go value of type map[string]json.RawMessage". YARPC decodes requests with gogo's jsonpb, which dispatches to UnmarshalJSONPB for a nested message if implemented and otherwise reflects into the struct. CRD types implemented no such method, so jsonpb reflected into the embedded metav1.ObjectMeta and failed on metav1.Time fields (e.g. creationTimestamp), which serialize as JSON strings but are decoded as messages. The Spec/Status UnmarshalJSON fallbacks were never reached, because jsonpb only calls UnmarshalJSONPB, never UnmarshalJSON.

Generate UnmarshalJSONPB for every CRD type. It delegates to encoding/json, which decodes TypeMeta/ObjectMeta natively and routes Spec/Status through their existing jsonpb-based UnmarshalJSON. Because gogo jsonpb (and the protobuf-es web client) serialize int64 as JSON strings per proto3, ObjectMeta integer fields such as generation are first coerced back to numbers via util.CoerceObjectMetaIntegers, whose field set is derived by reflection over metav1.ObjectMeta.

Verified end to end against a sandbox: GetTriggerRun followed by UpdateTriggerRun of the full object (generation as a quoted string) now returns 200.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Does this PR introduce a breaking change? Check all that apply. -->
**Breaking Changes**

- [ ] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

> If any breaking change box is checked (other than "No breaking changes"), you **must**:
> 1. Use the `BREAKING CHANGE:` footer **or** the `!` suffix (e.g. `feat!:`) in your commit message — see [Commit Messages](../CONTRIBUTING.md#commit-messages).
> 2. Fill in the **Migration guide** section below with step-by-step upgrade instructions.

<!-- Required only if a breaking change box above is checked. Delete this section if no breaking changes. -->
**Migration guide**

_Describe the steps an operator or downstream consumer must take to upgrade. Include before/after examples for any API, config, or schema change._

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
