### PR TITLE
fix(ci): add helm dependency build before packaging

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,6 +67,9 @@ jobs:
         id: version
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
+      - name: Build Helm dependencies
+        run: helm dependency build helm/michelangelo
+
       - name: Package Helm chart
         run: |
           helm package helm/michelangelo \


### PR DESCRIPTION
## Summary
- The `helm-publish` job in `release.yaml` failed on the `v0.3.0` tag because `Chart.yaml` declares `cadence` and `temporal` as dependencies, but `helm package` was run without fetching them first
- Adds a `helm dependency build` step before `helm package` to download sub-charts

## Test plan
- [ ] Verify CI passes on this PR
- [ ] Re-run the release workflow on `v0.3.0` tag after merge to confirm helm publish succeeds

Fixes helm-publish failure in https://github.com/michelangelo-ai/michelangelo/actions/runs/28264878783

Related: #1339