### PR TITLE
ci: add Trivy CVE scanning workflow for container images

### DIFF
--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -60,3 +60,21 @@ jobs:
           name: trivy-report-${{ matrix.service }}
           path: trivy-${{ matrix.service }}.sarif
           retention-days: 30
+
+  # ---------------------------------------------------------------------------
+  # Notify Slack when the CVE scan fails (i.e. CRITICAL/HIGH vulns found)
+  # ---------------------------------------------------------------------------
+  notify-on-failure:
+    needs: scan
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack on failure
+        uses: slackapi/slack-github-action@v1.27.0
+        with:
+          channel-id: '#michelangelo-releases'
+          slack-message: |
+            :x: *${{ github.workflow }}* failed
+            Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -2,7 +2,7 @@ name: CVE Scan
 
 on:
   workflow_run:
-    workflows: ["Go Containers Release", "UI Release"]
+    workflows: ["Dev Release", "UI Release", "Nightly Build"]
     types: [completed]
     branches: [main]
   schedule:

--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -1,0 +1,62 @@
+name: CVE Scan
+
+on:
+  workflow_run:
+    workflows: ["Go Containers Release", "UI Release"]
+    types: [completed]
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+  packages: read
+
+env:
+  REGISTRY: ghcr.io
+  ORG: michelangelo-ai
+
+jobs:
+  scan:
+    runs-on: ubuntu-24.04
+    if: github.event.workflow_run.conclusion == 'success' || github.event_name != 'workflow_run'
+    strategy:
+      fail-fast: false
+      matrix:
+        service: [apiserver, worker, controllermgr, ui]
+
+    steps:
+      - name: Run Trivy vulnerability scanner (${{ matrix.service }})
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.ORG }}/${{ matrix.service }}:latest
+          format: sarif
+          output: trivy-${{ matrix.service }}.sarif
+          severity: CRITICAL,HIGH
+          exit-code: '1'
+
+      - name: Upload SARIF to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: trivy-${{ matrix.service }}.sarif
+          category: trivy-${{ matrix.service }}
+
+      - name: Run Trivy table output for summary
+        uses: aquasecurity/trivy-action@0.28.0
+        if: always()
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.ORG }}/${{ matrix.service }}:latest
+          format: table
+          severity: CRITICAL,HIGH
+          exit-code: '0'
+
+      - name: Upload Trivy SARIF report as artifact
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: trivy-report-${{ matrix.service }}
+          path: trivy-${{ matrix.service }}.sarif
+          retention-days: 30


### PR DESCRIPTION
## Summary

Adds a scheduled + post-release Trivy CVE scanning workflow that scans all container images for CRITICAL and HIGH severity vulnerabilities and uploads results to the GitHub Security tab.

## What this adds

**`.github/workflows/cve-scan.yml`** — new workflow:
- **Triggers:**
  - `workflow_run` on `Dev Release`, `UI Release`, and `Nightly Build` completing on `main` (scans freshly pushed images)
  - Weekly schedule: Mondays at 06:00 UTC (ongoing baseline scan)
  - `workflow_dispatch` for manual runs
- **Matrix:** `apiserver`, `worker`, `controllermgr`, `ui`
- **Severity:** `CRITICAL,HIGH` — fails the job if found
- **Output:** SARIF uploaded to GitHub Security tab + artifact per service + table summary in job log
- **`fail-fast: false`** so all services are scanned even if one has CVEs

## Validation

- `actionlint` passes
- `workflow_run` trigger names verified against actual `.github/workflows/` files:
  - `"Dev Release"` → `dev-release.yml` (Go service containers)
  - `"UI Release"` → `ui-release.yml` (UI container)
  - `"Nightly Build"` → `nightly.yml` (all nightly images)
- Trivy scan tested locally against `ghcr.io/michelangelo-ai/apiserver:nightly` — connects to GHCR and returns CVE results correctly

## Note on double scan (nit from review)

Two Trivy steps per service is intentional: SARIF mode captures structured results for the Security tab (with `exit-code: 1` to fail on CVEs); table mode provides human-readable output in the job log (with `exit-code: 0`, always runs). The extra scan time is acceptable for a weekly + post-release cadence.

Related: #1340