### PR TITLE
ci: add cross-compiled Go binary builds to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -145,3 +145,18 @@ jobs:
           helm push \
             michelangelo-${{ steps.version.outputs.VERSION }}.tgz \
             oci://ghcr.io/michelangelo-ai/michelangelo/charts
+
+  notify-on-failure:
+    needs: [build-upload, build-go-binaries, upload-binaries, helm-publish]
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack on failure
+        uses: slackapi/slack-github-action@v1.27.0
+        with:
+          channel-id: '#michelangelo-releases'
+          slack-message: |
+            :x: *${{ github.workflow }}* failed for ${{ github.ref_name }}
+            Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,14 +3,8 @@ name: build-release
 on:
   push:
     tags: ["v*"]
-  workflow_dispatch:
-    inputs:
-      test_version:
-        description: 'Test version for workflow_dispatch runs'
-        default: '0.0.0-test.1'
 jobs:
   build-upload:
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -88,7 +82,6 @@ jobs:
           retention-days: 1
 
   upload-binaries:
-    if: github.event_name == 'push'
     needs: build-go-binaries
     runs-on: ubuntu-latest
     permissions:
@@ -112,7 +105,6 @@ jobs:
           files: binaries/*
 
   helm-publish:
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,8 +3,14 @@ name: build-release
 on:
   push:
     tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      test_version:
+        description: 'Test version for workflow_dispatch runs'
+        default: '0.0.0-test.1'
 jobs:
   build-upload:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -53,6 +59,9 @@ jobs:
         service: [apiserver, worker, controllermgr]
         os: [linux, darwin]
         arch: [amd64, arm64]
+    defaults:
+      run:
+        working-directory: go
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -68,8 +77,8 @@ jobs:
           GOOS: ${{ matrix.os }}
           GOARCH: ${{ matrix.arch }}
           CGO_ENABLED: '0'
-          BIN: ${{ matrix.service }}-${{ matrix.os }}-${{ matrix.arch }}
-        run: go build -o "$BIN" ./go/cmd/${{ matrix.service }}
+          BIN: ${{ github.workspace }}/${{ matrix.service }}-${{ matrix.os }}-${{ matrix.arch }}
+        run: go build -o "$BIN" ./cmd/${{ matrix.service }}
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v4
@@ -79,6 +88,7 @@ jobs:
           retention-days: 1
 
   upload-binaries:
+    if: github.event_name == 'push'
     needs: build-go-binaries
     runs-on: ubuntu-latest
     permissions:
@@ -99,11 +109,10 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
-          files: |
-            binaries/*
-            binaries/checksums-sha256.txt
+          files: binaries/*
 
   helm-publish:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,6 +46,63 @@ jobs:
           tag_name: ${{ github.ref_name }}
           files: python/dist/*.whl
 
+  build-go-binaries:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        service: [apiserver, worker, controllermgr]
+        os: [linux, darwin]
+        arch: [amd64, arm64]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+          cache-dependency-path: go/go.sum
+
+      - name: Build binary
+        env:
+          GOOS: ${{ matrix.os }}
+          GOARCH: ${{ matrix.arch }}
+          CGO_ENABLED: '0'
+          BIN: ${{ matrix.service }}-${{ matrix.os }}-${{ matrix.arch }}
+        run: go build -o "$BIN" ./go/cmd/${{ matrix.service }}
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.service }}-${{ matrix.os }}-${{ matrix.arch }}
+          path: ${{ matrix.service }}-${{ matrix.os }}-${{ matrix.arch }}
+          retention-days: 1
+
+  upload-binaries:
+    needs: build-go-binaries
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all binary artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: binaries
+          merge-multiple: true
+
+      - name: Generate SHA-256 checksums
+        run: |
+          cd binaries
+          sha256sum ./* > checksums-sha256.txt
+
+      - name: Attach binaries and checksums to release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: |
+            binaries/*
+            binaries/checksums-sha256.txt
+
   helm-publish:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- Add cross-compiled Go binaries (3 services × 4 platforms) to GitHub Release artifacts
- Generate SHA-256 checksums file

## Test plan
- [ ] Verify workflow syntax with actionlint
- [ ] Verify Go cross-compilation works locally
- [ ] CI passes on PR

Related: #1340