### PR TITLE
ci: add nightly artifact retention cleanup workflow

### DIFF
--- a/.github/workflows/cleanup-nightlies.yml
+++ b/.github/workflows/cleanup-nightlies.yml
@@ -1,0 +1,187 @@
+name: Nightly Cleanup
+
+on:
+  schedule:
+    - cron: '0 4 * * *'  # 04:00 UTC daily
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run — list what would be deleted without deleting'
+        type: boolean
+        default: true
+
+permissions:
+  packages: write
+  contents: write
+
+env:
+  ORG: michelangelo-ai
+  CUTOFF_DAYS: 14
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Delete nightly container image versions older than 14 days
+  # ---------------------------------------------------------------------------
+  cleanup-containers:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package: [apiserver, worker, controllermgr, ui]
+    steps:
+      - name: Delete old nightly image versions (${{ matrix.package }})
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run != false }}
+        run: |
+          CUTOFF=$(date -u -d "${{ env.CUTOFF_DAYS }} days ago" +%s)
+          DELETED=()
+          WOULD_DELETE=()
+
+          # Paginate through all versions for this package
+          PAGE=1
+          while true; do
+            VERSIONS=$(gh api \
+              "/orgs/${{ env.ORG }}/packages/container/${{ matrix.package }}/versions?per_page=100&page=${PAGE}" \
+              --jq '.[] | {id: .id, name: .name, created_at: .created_at, tags: .metadata.container.tags}')
+
+            [ -z "$VERSIONS" ] && break
+
+            while IFS= read -r VERSION_JSON; do
+              VERSION_ID=$(echo "$VERSION_JSON" | jq -r '.id')
+              CREATED_AT=$(echo "$VERSION_JSON" | jq -r '.created_at')
+              TAGS=$(echo "$VERSION_JSON" | jq -r '.tags[]?' 2>/dev/null || true)
+
+              # Only target versions tagged nightly-*
+              if ! echo "$TAGS" | grep -q '^nightly-'; then
+                continue
+              fi
+
+              CREATED_TS=$(date -u -d "$CREATED_AT" +%s 2>/dev/null || date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$CREATED_AT" +%s 2>/dev/null)
+              if [ "$CREATED_TS" -lt "$CUTOFF" ]; then
+                TAG_LABEL=$(echo "$TAGS" | grep '^nightly-' | head -1)
+                if [ "$DRY_RUN" = "true" ]; then
+                  WOULD_DELETE+=("${{ matrix.package }}:${TAG_LABEL} (id=${VERSION_ID})")
+                else
+                  gh api --method DELETE \
+                    "/orgs/${{ env.ORG }}/packages/container/${{ matrix.package }}/versions/${VERSION_ID}" \
+                    && DELETED+=("${{ matrix.package }}:${TAG_LABEL} (id=${VERSION_ID})")
+                fi
+              fi
+            done <<< "$(gh api \
+              "/orgs/${{ env.ORG }}/packages/container/${{ matrix.package }}/versions?per_page=100&page=${PAGE}" \
+              --jq '.[]')"
+
+            PAGE=$((PAGE + 1))
+            REMAINING=$(gh api \
+              "/orgs/${{ env.ORG }}/packages/container/${{ matrix.package }}/versions?per_page=100&page=${PAGE}" \
+              --jq 'length')
+            [ "$REMAINING" = "0" ] && break
+          done
+
+          echo "### Container cleanup: ${{ matrix.package }}" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "**Dry run** — would delete ${#WOULD_DELETE[@]} version(s):" >> "$GITHUB_STEP_SUMMARY"
+            for v in "${WOULD_DELETE[@]}"; do echo "- $v" >> "$GITHUB_STEP_SUMMARY"; done
+          else
+            echo "Deleted ${#DELETED[@]} version(s):" >> "$GITHUB_STEP_SUMMARY"
+            for v in "${DELETED[@]}"; do echo "- $v" >> "$GITHUB_STEP_SUMMARY"; done
+          fi
+
+  # ---------------------------------------------------------------------------
+  # Delete nightly GitHub pre-releases older than 14 days
+  # ---------------------------------------------------------------------------
+  cleanup-releases:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete old nightly pre-releases
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run != false }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          CUTOFF=$(date -u -d "${{ env.CUTOFF_DAYS }} days ago" +%s)
+          DELETED=()
+          WOULD_DELETE=()
+
+          # gh release list returns: type, tag, published-at (tab-separated)
+          while IFS=$'\t' read -r TYPE TAG PUBLISHED_AT; do
+            [ "$TYPE" != "Pre-release" ] && continue
+            # Only target nightly releases
+            echo "$TAG" | grep -q '^v.*nightly' || continue
+
+            CREATED_TS=$(date -u -d "$PUBLISHED_AT" +%s 2>/dev/null || \
+                         date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$PUBLISHED_AT" +%s 2>/dev/null)
+            if [ "$CREATED_TS" -lt "$CUTOFF" ]; then
+              if [ "$DRY_RUN" = "true" ]; then
+                WOULD_DELETE+=("$TAG")
+              else
+                gh release delete "$TAG" --yes --cleanup-tag \
+                  && DELETED+=("$TAG")
+              fi
+            fi
+          done < <(gh release list --limit 200 --json tagName,isPrerelease,publishedAt \
+            --jq '.[] | [(if .isPrerelease then "Pre-release" else "Release" end), .tagName, .publishedAt] | @tsv')
+
+          echo "### Release cleanup" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "**Dry run** — would delete ${#WOULD_DELETE[@]} release(s):" >> "$GITHUB_STEP_SUMMARY"
+            for r in "${WOULD_DELETE[@]}"; do echo "- $r" >> "$GITHUB_STEP_SUMMARY"; done
+          else
+            echo "Deleted ${#DELETED[@]} release(s):" >> "$GITHUB_STEP_SUMMARY"
+            for r in "${DELETED[@]}"; do echo "- $r" >> "$GITHUB_STEP_SUMMARY"; done
+          fi
+
+  # ---------------------------------------------------------------------------
+  # Deprecate old nightly npm versions (npm does not support deletion)
+  # ---------------------------------------------------------------------------
+  cleanup-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Deprecate old nightly npm versions
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run != false }}
+        run: |
+          # PyPI note: PyPI does not support version deletion; nightly Python
+          # packages are published with a .devYYYYMMDD pre-release suffix and
+          # are naturally superseded. No cleanup action is taken for PyPI.
+
+          CUTOFF=$(date -u -d "${{ env.CUTOFF_DAYS }} days ago" +%Y%m%d)
+          DEPRECATED=()
+          WOULD_DEPRECATE=()
+
+          for PKG in @michelangelo/core @michelangelo/rpc; do
+            # List all versions with nightly dist-tag pattern
+            VERSIONS=$(npm view "$PKG" versions --json 2>/dev/null | jq -r '.[]' | grep 'nightly\.' || true)
+
+            while IFS= read -r VER; do
+              [ -z "$VER" ] && continue
+              # Extract date from version like 0.3.0-nightly.20260101
+              DATE_PART=$(echo "$VER" | grep -o 'nightly\.[0-9]\{8\}' | cut -d. -f2 || true)
+              [ -z "$DATE_PART" ] && continue
+
+              if [ "$DATE_PART" -lt "$CUTOFF" ]; then
+                if [ "$DRY_RUN" = "true" ]; then
+                  WOULD_DEPRECATE+=("${PKG}@${VER}")
+                else
+                  npm deprecate "${PKG}@${VER}" "Nightly build superseded; use latest or a stable release." \
+                    && DEPRECATED+=("${PKG}@${VER}")
+                fi
+              fi
+            done <<< "$VERSIONS"
+          done
+
+          echo "### npm cleanup" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "**Dry run** — would deprecate ${#WOULD_DEPRECATE[@]} version(s):" >> "$GITHUB_STEP_SUMMARY"
+            for v in "${WOULD_DEPRECATE[@]}"; do echo "- $v" >> "$GITHUB_STEP_SUMMARY"; done
+          else
+            echo "Deprecated ${#DEPRECATED[@]} version(s):" >> "$GITHUB_STEP_SUMMARY"
+            for v in "${DEPRECATED[@]}"; do echo "- $v" >> "$GITHUB_STEP_SUMMARY"; done
+          fi

--- a/.github/workflows/cleanup-nightlies.yml
+++ b/.github/workflows/cleanup-nightlies.yml
@@ -185,3 +185,21 @@ jobs:
             echo "Deprecated ${#DEPRECATED[@]} version(s):" >> "$GITHUB_STEP_SUMMARY"
             for v in "${DEPRECATED[@]}"; do echo "- $v" >> "$GITHUB_STEP_SUMMARY"; done
           fi
+
+  # ---------------------------------------------------------------------------
+  # Notify Slack when any cleanup job fails
+  # ---------------------------------------------------------------------------
+  notify-on-failure:
+    needs: [cleanup-containers, cleanup-releases, cleanup-npm]
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack on failure
+        uses: slackapi/slack-github-action@v1.27.0
+        with:
+          channel-id: '#michelangelo-releases'
+          slack-message: |
+            :x: *${{ github.workflow }}* failed
+            Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/cleanup-nightlies.yml
+++ b/.github/workflows/cleanup-nightlies.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Delete old nightly image versions (${{ matrix.package }})
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DRY_RUN: ${{ inputs.dry_run != false }}
+          DRY_RUN: ${{ inputs.dry_run == true }}
         run: |
           CUTOFF=$(date -u -d "${{ env.CUTOFF_DAYS }} days ago" +%s)
           DELETED=()
@@ -96,7 +96,7 @@ jobs:
       - name: Delete old nightly pre-releases
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DRY_RUN: ${{ inputs.dry_run != false }}
+          DRY_RUN: ${{ inputs.dry_run == true }}
           GH_REPO: ${{ github.repository }}
         run: |
           CUTOFF=$(date -u -d "${{ env.CUTOFF_DAYS }} days ago" +%s)
@@ -146,7 +146,7 @@ jobs:
       - name: Deprecate old nightly npm versions
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          DRY_RUN: ${{ inputs.dry_run != false }}
+          DRY_RUN: ${{ inputs.dry_run == true }}
         run: |
           # PyPI note: PyPI does not support version deletion; nightly Python
           # packages are published with a .devYYYYMMDD pre-release suffix and

--- a/.github/workflows/cleanup-nightlies.yml
+++ b/.github/workflows/cleanup-nightlies.yml
@@ -156,7 +156,7 @@ jobs:
           DEPRECATED=()
           WOULD_DEPRECATE=()
 
-          for PKG in @michelangelo/core @michelangelo/rpc; do
+          for PKG in @michelangelo-ai/core @michelangelo-ai/rpc; do
             # List all versions with nightly dist-tag pattern
             VERSIONS=$(npm view "$PKG" versions --json 2>/dev/null | jq -r '.[]' | grep 'nightly\.' || true)
 


### PR DESCRIPTION
## Summary

Adds a daily scheduled workflow that prunes nightly build artifacts older than 14 days across all artifact stores.

## What this adds

**`.github/workflows/cleanup-nightlies.yml`** — three independent cleanup jobs:

| Job | Target | Mechanism |
|---|---|---|
| `cleanup-containers` | GHCR container image versions tagged `nightly-*` | `gh api DELETE /orgs/.../packages/container/.../versions/{id}` |
| `cleanup-releases` | GitHub pre-releases tagged `v*nightly*` | `gh release delete --cleanup-tag` |
| `cleanup-npm` | npm versions matching `*-nightly.*` pattern | `npm deprecate` (npm doesn't support deletion) |

**PyPI**: no cleanup — nightly `.devYYYYMMDD` versions are naturally superseded and PyPI doesn't support deletion.

**Triggers:** daily cron `0 4 * * *` + `workflow_dispatch` with `dry_run` input (default: `true`).

## Fixes addressed
- **DRY_RUN expression**: changed `inputs.dry_run != false` → `inputs.dry_run == true` so scheduled runs (no inputs) actually delete rather than being permanently stuck in dry-run mode
- **npm package names**: updated to `@michelangelo-ai/core` and `@michelangelo-ai/rpc` to match the renamed scopes

## Validation

- `actionlint` passes
- **DRY_RUN expression** tested for all 3 scenarios:
  - Scheduled run (no input): `'' == true` → `false` → **deletes** ✓
  - Manual `dry_run=true`: `true == true` → `true` → **dry-run** ✓
  - Manual `dry_run=false`: `false == true` → `false` → **deletes** ✓
- **Date cutoff logic** verified locally: 20-day-old image correctly flagged for deletion; 5-day-old correctly kept
- **`gh release list`** command tested against repo — works correctly
- **npm version listing** tested against `@michelangelo-ai/core` — pattern matching works
- Container API returns 403 locally (local token lacks `read:packages`); CI `GITHUB_TOKEN` with `permissions: packages: write` will have the required scope

Related: #1340