### PR TITLE
ci: configure Release Drafter for PR-based release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,85 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+categories:
+  - title: '⚠ Breaking Changes'
+    labels:
+      - 'breaking-change'
+    collapse-after: 5
+  - title: '🚀 Features'
+    labels:
+      - 'feat'
+      - 'feature'
+    collapse-after: 10
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bug'
+    collapse-after: 10
+  - title: '📚 Documentation'
+    labels:
+      - 'docs'
+      - 'documentation'
+    collapse-after: 5
+  - title: '🔧 CI / Build'
+    labels:
+      - 'ci'
+      - 'build'
+      - 'chore'
+    collapse-after: 5
+  - title: '🔒 Security'
+    labels:
+      - 'security'
+
+autolabeler:
+  - label: 'breaking-change'
+    title:
+      - '/^.+!:/i'
+      - '/BREAKING CHANGE/i'
+  - label: 'feat'
+    title:
+      - '/^feat(\(.+\))?:/i'
+  - label: 'fix'
+    title:
+      - '/^fix(\(.+\))?:/i'
+  - label: 'docs'
+    title:
+      - '/^docs(\(.+\))?:/i'
+  - label: 'ci'
+    title:
+      - '/^ci(\(.+\))?:/i'
+      - '/^build(\(.+\))?:/i'
+  - label: 'chore'
+    title:
+      - '/^chore(\(.+\))?:/i'
+      - '/^refactor(\(.+\))?:/i'
+      - '/^perf(\(.+\))?:/i'
+      - '/^test(\(.+\))?:/i'
+
+version-resolver:
+  major:
+    labels:
+      - 'breaking-change'
+  minor:
+    labels:
+      - 'feat'
+      - 'feature'
+  patch:
+    labels:
+      - 'fix'
+      - 'bug'
+      - 'docs'
+      - 'ci'
+      - 'chore'
+      - 'security'
+  default: patch
+
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&'
+
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/michelangelo-ai/michelangelo/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,22 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-release-draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Configures [Release Drafter](https://github.com/release-drafter/release-drafter) to automatically maintain a draft GitHub Release that updates on every merge to `main`. Each merged PR is categorized by its conventional commit prefix and listed in the draft, giving a live preview of what will be in the next release.

## What this adds

**`.github/workflows/release-drafter.yml`** — triggers on `push: main` (updates draft) and `pull_request` (applies labels via autolabeler)

**`.github/release-drafter.yml`** — categorization config:
| Category | Conventional prefix | Version bump |
|---|---|---|
| ⚠ Breaking Changes | `feat!:`, `BREAKING CHANGE` | major |
| 🚀 Features | `feat:` | minor |
| 🐛 Bug Fixes | `fix:` | patch |
| 📚 Documentation | `docs:` | patch |
| 🔧 CI / Build | `ci:`, `build:`, `chore:` | patch |
| 🔒 Security | `security` label | patch |

Version is auto-resolved from labels: `breaking-change` → major, `feat` → minor, everything else → patch.

## Relationship to git-cliff

These two tools complement each other:
- **Release Drafter** — living draft that updates after every PR merge; useful for tracking what's coming in the next release
- **git-cliff** — generates the authoritative `CHANGELOG.md` at tag time from commit history

## Note on CI failure on this PR

The workflow will show a failure on this PR because Release Drafter reads its config (`.github/release-drafter.yml`) from the **default branch** (main) by design — it cannot read config from a feature branch. This is a security feature, not a bug. The workflow will work correctly once merged.

## Validation
- `actionlint` passes on `release-drafter.yml`
- Workflow triggered successfully on PR push (correctly failed with "config not found on default branch" — expected pre-merge behavior)

## Pre-merge requirement
Create these labels in the repo before or after merging (autolabeler applies them going forward):
`feat`, `fix`, `docs`, `ci`, `chore`, `breaking-change`, `security`

```
gh label create feat --color 0075ca
gh label create fix --color d73a4a
gh label create docs --color 0075ca
gh label create ci --color e4e669
gh label create chore --color ededed
gh label create breaking-change --color b60205
gh label create security --color ee0701
```

Related: #1340