### PR TITLE
fix(helm,ci): nil pointer guards on upgrade + configurable integration-test ref

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -13,6 +13,12 @@ on:
           Defaults to "latest" (built from main).
         required: false
         default: "latest"
+      integration_test_ref:
+        description: >
+          Branch or ref of michelangelo-ai/integration-test to check out.
+          Defaults to "main". Use a feature branch to test unreleased fixture changes.
+        required: false
+        default: "main"
   workflow_call:
     inputs:
       image_tag:
@@ -20,6 +26,11 @@ on:
         required: false
         type: string
         default: "latest"
+      integration_test_ref:
+        description: "Branch or ref of michelangelo-ai/integration-test to check out"
+        required: false
+        type: string
+        default: "main"
   schedule:
     - cron: "0 3 * * *"   # 03:00 UTC every day
 
@@ -67,7 +78,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: michelangelo-ai/integration-test
-          ref: main
+          ref: ${{ inputs.integration_test_ref || 'main' }}
           token: ${{ secrets.CR_PAT }}
           path: integration-test
 

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -104,6 +104,11 @@ jobs:
         working-directory: ${{ github.workspace }}/integration-test
         env:
           MA_API_SERVER: localhost:15566
+          # GIT_REF tells the controllermgr which branch of michelangelo to fetch
+          # pipeline manifest YAMLs from. No-op for current tests (pipeline CRUD
+          # has no state_check so the YAML is never fetched); becomes meaningful
+          # when lifecycle tests that wait for PIPELINE_STATE_READY are added and
+          # pipelines/integration_tests/ YAMLs exist in the repo.
           GIT_REF: ${{ inputs.git_ref || 'main' }}
           PYTHONPATH: ${{ github.workspace }}/integration-test
 

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -104,12 +104,6 @@ jobs:
         working-directory: ${{ github.workspace }}/integration-test
         env:
           MA_API_SERVER: localhost:15566
-          # GIT_REF tells the controllermgr which branch of michelangelo to fetch
-          # pipeline manifest YAMLs from. No-op for current tests (pipeline CRUD
-          # has no state_check so the YAML is never fetched); becomes meaningful
-          # when lifecycle tests that wait for PIPELINE_STATE_READY are added and
-          # pipelines/integration_tests/ YAMLs exist in the repo.
-          GIT_REF: ${{ inputs.git_ref || 'main' }}
           PYTHONPATH: ${{ github.workspace }}/integration-test
 
       - name: Run API MySQL backend tests
@@ -120,7 +114,6 @@ jobs:
         working-directory: ${{ github.workspace }}/integration-test
         env:
           MA_API_SERVER: localhost:15566
-          GIT_REF: ${{ inputs.git_ref || 'main' }}
           PYTHONPATH: ${{ github.workspace }}/integration-test
 
       - name: Wait for worker to connect to Cadence

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -19,6 +19,12 @@ on:
           Defaults to "main". Use a feature branch to test unreleased fixture changes.
         required: false
         default: "main"
+      git_ref:
+        description: >
+          Branch or ref of michelangelo-ai/michelangelo used for pipeline manifests (GIT_REF).
+          Defaults to "main". Set to your feature branch when testing pipeline YAML changes.
+        required: false
+        default: "main"
   workflow_call:
     inputs:
       image_tag:
@@ -28,6 +34,11 @@ on:
         default: "latest"
       integration_test_ref:
         description: "Branch or ref of michelangelo-ai/integration-test to check out"
+        required: false
+        type: string
+        default: "main"
+      git_ref:
+        description: "Branch or ref of michelangelo-ai/michelangelo used for pipeline manifests (GIT_REF)"
         required: false
         type: string
         default: "main"
@@ -93,7 +104,7 @@ jobs:
         working-directory: ${{ github.workspace }}/integration-test
         env:
           MA_API_SERVER: localhost:15566
-          GIT_REF: main
+          GIT_REF: ${{ inputs.git_ref || 'main' }}
           PYTHONPATH: ${{ github.workspace }}/integration-test
 
       - name: Run API MySQL backend tests
@@ -104,7 +115,7 @@ jobs:
         working-directory: ${{ github.workspace }}/integration-test
         env:
           MA_API_SERVER: localhost:15566
-          GIT_REF: main
+          GIT_REF: ${{ inputs.git_ref || 'main' }}
           PYTHONPATH: ${{ github.workspace }}/integration-test
 
       - name: Wait for worker to connect to Cadence

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -19,12 +19,6 @@ on:
           Defaults to "main". Use a feature branch to test unreleased fixture changes.
         required: false
         default: "main"
-      git_ref:
-        description: >
-          Branch or ref of michelangelo-ai/michelangelo used for pipeline manifests (GIT_REF).
-          Defaults to "main". Set to your feature branch when testing pipeline YAML changes.
-        required: false
-        default: "main"
   workflow_call:
     inputs:
       image_tag:
@@ -34,11 +28,6 @@ on:
         default: "latest"
       integration_test_ref:
         description: "Branch or ref of michelangelo-ai/integration-test to check out"
-        required: false
-        type: string
-        default: "main"
-      git_ref:
-        description: "Branch or ref of michelangelo-ai/michelangelo used for pipeline manifests (GIT_REF)"
         required: false
         type: string
         default: "main"

--- a/helm/michelangelo/templates/core/controllermgr-configmap.yaml
+++ b/helm/michelangelo/templates/core/controllermgr-configmap.yaml
@@ -92,11 +92,12 @@ data:
     {{- end }}
 
     notification:
-      taskList: {{ .Values.notification.taskList | default "" | quote }}
-      {{- with .Values.notification.studioBaseURL }}
+      {{- $notif := default dict .Values.notification }}
+      taskList: {{ index $notif "taskList" | default "" | quote }}
+      {{- with index $notif "studioBaseURL" }}
       studioBaseURL: {{ . | quote }}
       {{- end }}
-      {{- with .Values.notification.senderEmail }}
+      {{- with index $notif "senderEmail" }}
       senderEmail: {{ . | quote }}
       {{- end }}
 {{- end }}

--- a/helm/michelangelo/templates/core/controllermgr-configmap.yaml
+++ b/helm/michelangelo/templates/core/controllermgr-configmap.yaml
@@ -47,7 +47,7 @@ data:
       {{- end }}
 
     pipeline:
-      revisioningEnabled: {{ .Values.controllermgr.pipeline.revisioningEnabled }}
+      revisioningEnabled: {{ dig "pipeline" "revisioningEnabled" false .Values.controllermgr }}
 
     workflowClient:
       {{- if eq .Values.workflow.engine "cadence" }}


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Bug Fix
- [ ] Refactor
- [ ] Feature
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

**`helm/michelangelo/templates/core/controllermgr-configmap.yaml`** — two nil-pointer guards for config blocks absent in older installed releases:

1. `controllermgr.pipeline.revisioningEnabled` (line 50): `dig "pipeline" "revisioningEnabled" false .Values.controllermgr` — safe when `controllermgr.pipeline` map is nil
2. `notification` block (lines 94–101): `default dict .Values.notification` + `index` — safe when `.Values.notification` is nil; `studioBaseURL` and `senderEmail` omitted when empty

**`.github/workflows/integration-test.yaml`** — two configurable inputs added, one removed:

- `integration_test_ref` (new): branch/ref of `michelangelo-ai/integration-test` to check out; replaces hardcoded `ref: main`. Fixes #1404.
- `GIT_REF` env removed from CRUD and MySQL test steps: investigation showed it is a no-op — the pipeline CRUD test has no `state_check` so the controllermgr never fetches the pipeline YAML, and the MySQL tests have no pipeline fixtures. `GIT_REF` will be re-introduced when lifecycle tests that wait for `PIPELINE_STATE_READY` are added and `pipelines/integration_tests/` YAMLs exist in the repo.

**Why?**

The nightly CI runs failed at `Sync sandbox` with nil-pointer panics:

- Run [28276779314](https://github.com/michelangelo-ai/michelangelo/actions/runs/28276779314/job/83784846276): `nil pointer evaluating interface {}.revisioningEnabled` — `controllermgr.pipeline` block added recently; `--reuse-values` replays stored values from before that key existed
- Run [28277184870](https://github.com/michelangelo-ai/michelangelo/actions/runs/28277184870/job/83786056776): `nil pointer evaluating interface {}.taskList` — same pattern for the `notification` block

The hardcoded `ref: main` on the integration-test checkout (fixes #1404) made it impossible to run CI against a fixture branch before merging.

**How did you test it?**

```bash
# nil-pointer guards
helm template … -f values-k3d.yaml --set workflow.engine=cadence … | grep -A5 "notification:"
# → taskList: ""  (normal)

helm template … --set notification=null | grep -A5 "notification:"
# → taskList: ""  (nil map — no panic)

helm template … --set notification.taskList=notification_worker \
  --set notification.studioBaseURL=https://ml.example.com | grep -A5 "notification:"
# → all fields rendered correctly

# GIT_REF investigation
# pipeline CRUD crud_config comment: "No state_check: sandbox controller manager
# doesn't run the Pipeline controller, so status.state never advances."
# MySQL tests: no pipeline fixtures — GIT_REF not read at all.
```

**Potential risks**

None. Both Helm fallbacks match `values.yaml` defaults (`false`, `""`). The CI workflow changes are additive with safe defaults; removing `GIT_REF` from env has no effect on currently passing tests.

**Breaking Changes**

- [x] No breaking changes

**Release notes**

N/A

**Documentation Changes**

N/A