### PR TITLE
fix(ci): bypass poetry-dynamic-versioning in nightly Python build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -61,14 +61,20 @@ jobs:
           working-directory: './python'
 
       - name: Set nightly version
+        env:
+          POETRY_DYNAMIC_VERSIONING_BYPASS: "0.0.0"
         run: |
           DATE_TAG="${{ needs.check-changes.outputs.date_tag }}"
-          BASE_VERSION=$(poetry version -s | sed 's/\.dev.*//')
+          BASE_VERSION=$(grep '^version' pyproject.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
           NIGHTLY_VERSION="${BASE_VERSION}.dev${DATE_TAG}"
           poetry version "$NIGHTLY_VERSION"
+          echo "nightly_version=$NIGHTLY_VERSION" >> "$GITHUB_OUTPUT"
           echo "Publishing Python nightly: $NIGHTLY_VERSION"
+        id: version
 
       - name: Build wheel
+        env:
+          POETRY_DYNAMIC_VERSIONING_BYPASS: ${{ steps.version.outputs.nightly_version }}
         run: poetry build -f wheel
 
       - name: Configure PyPI token


### PR DESCRIPTION
## Summary
- Nightly Python build failed with PyPI 400: local version identifiers not allowed
- Root cause: `poetry-dynamic-versioning` plugin generates versions from `git describe`, producing `0.3.1.post2.dev0+9f309156` instead of clean `0.3.0.dev20260627`
- Fix: read base version from `pyproject.toml` directly (not `poetry version -s`), set `POETRY_DYNAMIC_VERSIONING_BYPASS` env var to prevent the plugin from overriding the version at build time

## Test plan
- [ ] CI passes on PR
- [ ] Next nightly run publishes to PyPI successfully

Related: #1340