### PR TITLE
fix(ci): update npm workspace name in nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -288,10 +288,10 @@ jobs:
 
       - name: Build packages
         run: |
-          yarn workspace @michelangelo/core build
+          yarn workspace @michelangelo-ai/core build
           yarn workspace @michelangelo/rpc build
 
-      - name: Publish @michelangelo/core
+      - name: Publish @michelangelo-ai/core
         run: cd packages/core && npm publish --tag nightly --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- The `@michelangelo/core` package was renamed to `@michelangelo-ai/core` but the nightly workflow still used the old name
- `yarn workspace @michelangelo/core build` fails with `Unknown workspace "@michelangelo/core"`
- Updates both the build step and publish step name to `@michelangelo-ai/core`

## Test plan
- [ ] CI passes on PR
- [ ] Next nightly run completes npm-nightly job successfully

Related: #1340