### PR TITLE
fix(ci): add helm repo registration before dependency build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,6 +67,12 @@ jobs:
         id: version
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
+      - name: Add Helm dependency repos
+        run: |
+          helm repo add cadence https://cadence-workflow.github.io/cadence-charts
+          helm repo add temporal https://go.temporal.io/helm-charts
+          helm repo update
+
       - name: Build Helm dependencies
         run: helm dependency build helm/michelangelo
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,8 +3,15 @@ name: build-release
 on:
   push:
     tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      test_version:
+        description: 'Test version (e.g. 0.0.0-test.1)'
+        required: false
+        default: '0.0.0-test.1'
 jobs:
   build-upload:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -65,7 +72,12 @@ jobs:
 
       - name: Extract version from tag
         id: version
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "VERSION=${{ inputs.test_version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Add Helm dependency repos
         run: |
@@ -83,6 +95,7 @@ jobs:
             --app-version ${{ steps.version.outputs.VERSION }}
 
       - name: Push chart to OCI registry
+        if: github.event_name == 'push'
         run: |
           helm push \
             michelangelo-${{ steps.version.outputs.VERSION }}.tgz \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,15 +3,8 @@ name: build-release
 on:
   push:
     tags: ["v*"]
-  workflow_dispatch:
-    inputs:
-      test_version:
-        description: 'Test version (e.g. 0.0.0-test.1)'
-        required: false
-        default: '0.0.0-test.1'
 jobs:
   build-upload:
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -72,12 +65,7 @@ jobs:
 
       - name: Extract version from tag
         id: version
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "VERSION=${{ inputs.test_version }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
-          fi
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
       - name: Add Helm dependency repos
         run: |
@@ -95,7 +83,6 @@ jobs:
             --app-version ${{ steps.version.outputs.VERSION }}
 
       - name: Push chart to OCI registry
-        if: github.event_name == 'push'
         run: |
           helm push \
             michelangelo-${{ steps.version.outputs.VERSION }}.tgz \


### PR DESCRIPTION
## Summary
- Adds `helm repo add` for cadence and temporal chart repositories before `helm dependency build` in the release workflow
- The v0.3.1 helm-publish job failed because the chart dependencies (cadence, temporal) require their Helm repos to be registered first
- Same fix already exists in `nightly.yml` — this aligns `release.yaml`

## Test plan
- [ ] Re-run the v0.3.1 release workflow after merge to verify helm-publish succeeds
- [ ] Verify `helm dependency build helm/michelangelo` completes without errors