### PR TITLE
feat(ui): add pipeline run notification settings (toggle + email/Slack recipients)

### DIFF
--- a/javascript/packages/core/components/form/fields/multi-input/__tests__/multi-input-field.test.tsx
+++ b/javascript/packages/core/components/form/fields/multi-input/__tests__/multi-input-field.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+
+import { Form } from '#core/components/form/form';
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
+import { MultiInputField } from '../multi-input-field';
+
+describe('MultiInputField', () => {
+  it('adds a tag when Enter is pressed and removes it via Backspace', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Form onSubmit={vi.fn()}>
+        <MultiInputField name="emails" label="Email addresses" />
+      </Form>,
+      buildWrapper([getBaseProviderWrapper()])
+    );
+
+    const input = screen.getByRole('textbox', { name: 'Email addresses' });
+    await user.type(input, 'a@example.com');
+    await user.keyboard('{Enter}');
+
+    expect(screen.getByText('a@example.com')).toBeInTheDocument();
+    expect(input).toHaveValue('');
+
+    // The tag's remove action is a visually-hidden icon; BaseUI wires actual removal to
+    // Backspace/Delete on the focused tag itself (the accessible "button").
+    screen.getByRole('button', { name: /a@example.com/i }).focus();
+    await user.keyboard('{Backspace}');
+    expect(screen.queryByText('a@example.com')).not.toBeInTheDocument();
+  });
+
+  it('does not add a duplicate or empty tag', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Form onSubmit={vi.fn()}>
+        <MultiInputField name="emails" label="Email addresses" />
+      </Form>,
+      buildWrapper([getBaseProviderWrapper()])
+    );
+
+    const input = screen.getByRole('textbox', { name: 'Email addresses' });
+    await user.type(input, 'a@example.com{Enter}');
+    await user.type(input, 'a@example.com{Enter}');
+    await user.keyboard('{Enter}');
+
+    expect(screen.getAllByText('a@example.com')).toHaveLength(1);
+  });
+
+  it('blocks form submission and shows the error when validation fails', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(
+      <Form onSubmit={onSubmit}>
+        <MultiInputField
+          name="emails"
+          label="Email addresses"
+          validate={(value) => ((value as string[])?.length ? undefined : 'Required.')}
+        />
+        <button type="submit">Submit</button>
+      </Form>,
+      buildWrapper([getBaseProviderWrapper()])
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+    expect(await screen.findByText('Required.')).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/javascript/packages/core/components/form/fields/multi-input/multi-input-field.tsx
+++ b/javascript/packages/core/components/form/fields/multi-input/multi-input-field.tsx
@@ -1,10 +1,10 @@
 import { useState } from 'react';
-import { useStyletron } from 'baseui';
 import { Input } from 'baseui/input';
 
 import { FormControl } from '#core/components/form/components/form-control';
 import { useField } from '#core/components/form/hooks/use-field';
 import { Tag } from '#core/components/tag/tag';
+import { TagList } from './styled-components';
 
 import type { KeyboardEvent } from 'react';
 import type { MultiInputFieldProps } from './types';
@@ -35,7 +35,6 @@ export function MultiInputField({
   caption,
   labelEndEnhancer,
 }: MultiInputFieldProps) {
-  const [css, theme] = useStyletron();
   const { input, meta } = useField<string[]>(name, {
     required,
     validate,
@@ -92,14 +91,7 @@ export function MultiInputField({
         />
       </FormControl>
       {values.length > 0 && (
-        <div
-          className={css({
-            display: 'flex',
-            flexWrap: 'wrap',
-            gap: theme.sizing.scale300,
-            marginTop: theme.sizing.scale300,
-          })}
-        >
+        <TagList>
           {values.map((value) => (
             <Tag
               key={value}
@@ -109,7 +101,7 @@ export function MultiInputField({
               {value}
             </Tag>
           ))}
-        </div>
+        </TagList>
       )}
     </>
   );

--- a/javascript/packages/core/components/form/fields/multi-input/multi-input-field.tsx
+++ b/javascript/packages/core/components/form/fields/multi-input/multi-input-field.tsx
@@ -1,0 +1,116 @@
+import { useState } from 'react';
+import { useStyletron } from 'baseui';
+import { Input } from 'baseui/input';
+
+import { FormControl } from '#core/components/form/components/form-control';
+import { useField } from '#core/components/form/hooks/use-field';
+import { Tag } from '#core/components/tag/tag';
+
+import type { KeyboardEvent } from 'react';
+import type { MultiInputFieldProps } from './types';
+
+// Stable reference: passing a fresh `[]` literal as `defaultValue` on every render would change
+// identity each time, and react-final-form's `useField` re-registers the field whenever
+// `defaultValue` changes identity — causing an infinite render loop.
+const EMPTY_VALUE: string[] = [];
+
+/**
+ * Free-form multi-value text input: type a value and press Enter to add it as a removable
+ * tag ("create-delete-tags" pattern).
+ *
+ * Use for lists of ad hoc strings (email addresses, Slack channel names) that aren't chosen
+ * from a fixed set of options — unlike `SelectField`, this never presents an empty dropdown.
+ */
+export function MultiInputField({
+  name,
+  label,
+  defaultValue,
+  initialValue,
+  required,
+  validate,
+  readOnly,
+  disabled,
+  placeholder,
+  description,
+  caption,
+  labelEndEnhancer,
+}: MultiInputFieldProps) {
+  const [css, theme] = useStyletron();
+  const { input, meta } = useField<string[]>(name, {
+    required,
+    validate,
+    defaultValue: defaultValue ?? EMPTY_VALUE,
+    initialValue,
+    label,
+  });
+  const [draft, setDraft] = useState('');
+
+  const values = input.value ?? [];
+
+  const commitDraft = () => {
+    const nextValue = draft.trim();
+    if (nextValue && !values.includes(nextValue)) {
+      input.onChange([...values, nextValue]);
+    }
+    setDraft('');
+    input.onBlur();
+  };
+
+  const removeValue = (removed: string) => {
+    input.onChange(values.filter((value) => value !== removed));
+  };
+
+  const handleDraftKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      commitDraft();
+    }
+  };
+
+  const handleDraftBlur = () => commitDraft();
+
+  return (
+    <>
+      <FormControl
+        label={label}
+        required={required}
+        description={description}
+        labelEndEnhancer={labelEndEnhancer}
+        caption={caption}
+        error={meta.touched && meta.error ? meta.error : undefined}
+      >
+        <Input
+          id={name}
+          value={draft}
+          onChange={(e) => setDraft(e.currentTarget.value)}
+          onKeyDown={handleDraftKeyDown}
+          onBlur={handleDraftBlur}
+          onFocus={input.onFocus}
+          placeholder={!disabled && !readOnly ? placeholder : ''}
+          disabled={disabled}
+          readOnly={readOnly}
+        />
+      </FormControl>
+      {values.length > 0 && (
+        <div
+          className={css({
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: theme.sizing.scale300,
+            marginTop: theme.sizing.scale300,
+          })}
+        >
+          {values.map((value) => (
+            <Tag
+              key={value}
+              closeable={!disabled && !readOnly}
+              onActionClick={() => removeValue(value)}
+            >
+              {value}
+            </Tag>
+          ))}
+        </div>
+      )}
+    </>
+  );
+}

--- a/javascript/packages/core/components/form/fields/multi-input/styled-components.ts
+++ b/javascript/packages/core/components/form/fields/multi-input/styled-components.ts
@@ -1,0 +1,8 @@
+import { styled } from 'baseui';
+
+export const TagList = styled('div', ({ $theme }) => ({
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: $theme.sizing.scale300,
+  marginTop: $theme.sizing.scale300,
+}));

--- a/javascript/packages/core/components/form/fields/multi-input/types.ts
+++ b/javascript/packages/core/components/form/fields/multi-input/types.ts
@@ -1,0 +1,3 @@
+import type { BaseFieldProps } from '../types';
+
+export type MultiInputFieldProps = BaseFieldProps<string[], string[]>;

--- a/javascript/packages/core/components/form/fields/select/build-select-overrides.ts
+++ b/javascript/packages/core/components/form/fields/select/build-select-overrides.ts
@@ -9,8 +9,8 @@ export function buildSelectOverrides(
   readOnly?: boolean
 ): SelectOverrides {
   // When rendered inside modals, dropdown options can overflow past the modal body into its backdrop.
-  // ignoreBoundary lets the dropdown escape the modal clip region; popperOptions ensures
-  // preventOverflow is registered before the hide modifier (Popper.js v1 requires this order).
+  // popperOptions ensures preventOverflow is registered before the hide modifier (Popper.js v1
+  // requires this order), so ignoreBoundary doesn't get its overflow-prevention undone by hide.
   // name is forwarded to the internal <input> so form-focus libraries (e.g. final-form-focus) can
   // match this control to its field error by name.
   const base = {

--- a/javascript/packages/core/components/form/fields/select/build-select-overrides.ts
+++ b/javascript/packages/core/components/form/fields/select/build-select-overrides.ts
@@ -9,10 +9,21 @@ export function buildSelectOverrides(
   readOnly?: boolean
 ): SelectOverrides {
   // When rendered inside modals, dropdown options can overflow past the modal body into its backdrop.
+  // ignoreBoundary lets the dropdown escape the modal clip region; popperOptions ensures
+  // preventOverflow is registered before the hide modifier (Popper.js v1 requires this order).
   // name is forwarded to the internal <input> so form-focus libraries (e.g. final-form-focus) can
   // match this control to its field error by name.
   const base = {
-    Popover: { props: { ignoreBoundary: true } },
+    Popover: {
+      props: {
+        ignoreBoundary: true,
+        popperOptions: {
+          modifiers: {
+            preventOverflow: { enabled: true, boundariesElement: 'window', padding: 8 },
+          },
+        },
+      },
+    },
     Input: { props: { name } },
   };
 

--- a/javascript/packages/core/config/entities/pipeline/__tests__/create-pipeline-run-form.test.tsx
+++ b/javascript/packages/core/config/entities/pipeline/__tests__/create-pipeline-run-form.test.tsx
@@ -220,5 +220,12 @@ describe('CreatePipelineRunForm', () => {
     await user.keyboard('{Enter}');
 
     await screen.findByText('Enter valid email addresses, e.g. user@example.com.');
+
+    // Submitting with the invalid email must not call the API or close the dialog.
+    await user.click(screen.getByRole('button', { name: 'Run' }));
+
+    await screen.findAllByText('Enter valid email addresses, e.g. user@example.com.');
+    expect(mockRequest).not.toHaveBeenCalled();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
   });
 });

--- a/javascript/packages/core/config/entities/pipeline/__tests__/create-pipeline-run-form.test.tsx
+++ b/javascript/packages/core/config/entities/pipeline/__tests__/create-pipeline-run-form.test.tsx
@@ -138,7 +138,7 @@ describe('CreatePipelineRunForm', () => {
     });
   });
 
-  it('notification fields are disabled by default and enabled after toggling on', async () => {
+  it('notification fields are disabled until the toggle is switched on, then submit includes them', async () => {
     const user = userEvent.setup();
     const mockRequest = createQueryMockRouter({ CreatePipelineRun: {} });
 
@@ -156,45 +156,24 @@ describe('CreatePipelineRunForm', () => {
 
     await screen.findByRole('dialog', { name: 'Start new pipeline run' });
 
-    // Toggle is visible; email combobox is present but disabled
+    // Toggle is visible and off by default; email combobox is present but disabled.
+    // The toggle's accessible name is its own label text ("Enabled"/"Disabled"), which
+    // starts as "Disabled" since notifications default to off.
     expect(screen.getByText('Send notifications')).toBeInTheDocument();
     expect(screen.getByRole('combobox', { name: /email addresses/i })).toBeDisabled();
 
     // Enable notifications via toggle
-    await user.click(screen.getByRole('checkbox', { name: /enabled|disabled/i }));
+    await user.click(screen.getByRole('checkbox', { name: 'Disabled' }));
 
     // Email combobox is now enabled
-    await waitFor(() => {
-      expect(screen.getByRole('combobox', { name: /email addresses/i })).not.toBeDisabled();
-    });
-  });
-
-  it('includes notifications in payload when toggle is on and email is entered', async () => {
-    const user = userEvent.setup();
-    const mockRequest = createQueryMockRouter({ CreatePipelineRun: {} });
-
-    render(
-      <FormWrapper />,
-      buildWrapper([
-        getBaseProviderWrapper(),
-        getIconProviderWrapper(),
-        getErrorProviderWrapper(),
-        getInterpolationProviderWrapper(),
-        getRouterWrapper({ location: '/ma-dev-test/train/pipelines' }),
-        getServiceProviderWrapper({ request: mockRequest }),
-      ])
-    );
-
-    await screen.findByRole('dialog', { name: 'Start new pipeline run' });
-
-    // Enable notifications
-    await user.click(screen.getByRole('checkbox', { name: /enabled|disabled/i }));
-
-    // Type an email into the email addresses combobox and commit with Enter
     const emailCombo = await screen.findByRole('combobox', { name: /email addresses/i });
+    await waitFor(() => {
+      expect(emailCombo).toBeEnabled();
+    });
+
+    // Type an email and submit — payload should include the notification
     await user.type(emailCombo, 'notify@example.com');
     await user.keyboard('{Enter}');
-
     await user.click(screen.getByRole('button', { name: 'Run' }));
 
     await waitFor(() => {
@@ -233,7 +212,7 @@ describe('CreatePipelineRunForm', () => {
     await screen.findByRole('dialog', { name: 'Start new pipeline run' });
 
     // Enable notifications
-    await user.click(screen.getByRole('checkbox', { name: /enabled|disabled/i }));
+    await user.click(screen.getByRole('checkbox', { name: 'Disabled' }));
 
     // Type an invalid email into the email addresses combobox and commit with Enter
     const emailCombo = await screen.findByRole('combobox', { name: /email addresses/i });

--- a/javascript/packages/core/config/entities/pipeline/__tests__/create-pipeline-run-form.test.tsx
+++ b/javascript/packages/core/config/entities/pipeline/__tests__/create-pipeline-run-form.test.tsx
@@ -156,23 +156,23 @@ describe('CreatePipelineRunForm', () => {
 
     await screen.findByRole('dialog', { name: 'Start new pipeline run' });
 
-    // Toggle is visible and off by default; email combobox is present but disabled.
+    // Toggle is visible and off by default; email input is present but disabled.
     // The toggle's accessible name is its own label text ("Enabled"/"Disabled"), which
     // starts as "Disabled" since notifications default to off.
     expect(screen.getByText('Send notifications')).toBeInTheDocument();
-    expect(screen.getByRole('combobox', { name: /email addresses/i })).toBeDisabled();
+    expect(screen.getByRole('textbox', { name: /email addresses/i })).toBeDisabled();
 
     // Enable notifications via toggle
     await user.click(screen.getByRole('checkbox', { name: 'Disabled' }));
 
-    // Email combobox is now enabled
-    const emailCombo = await screen.findByRole('combobox', { name: /email addresses/i });
+    // Email input is now enabled
+    const emailInput = await screen.findByRole('textbox', { name: /email addresses/i });
     await waitFor(() => {
-      expect(emailCombo).toBeEnabled();
+      expect(emailInput).toBeEnabled();
     });
 
     // Type an email and submit — payload should include the notification
-    await user.type(emailCombo, 'notify@example.com');
+    await user.type(emailInput, 'notify@example.com');
     await user.keyboard('{Enter}');
     await user.click(screen.getByRole('button', { name: 'Run' }));
 
@@ -216,12 +216,12 @@ describe('CreatePipelineRunForm', () => {
     // Enable notifications
     await user.click(screen.getByRole('checkbox', { name: 'Disabled' }));
 
-    // Type an invalid email into the email addresses combobox and commit with Enter
-    const emailCombo = await screen.findByRole('combobox', { name: /email addresses/i });
-    await user.type(emailCombo, 'not-an-email');
+    // Type an invalid email into the email addresses input and commit with Enter
+    const emailInput = await screen.findByRole('textbox', { name: /email addresses/i });
+    await user.type(emailInput, 'not-an-email');
     await user.keyboard('{Enter}');
 
-    await screen.findByText('Enter valid email addresses, e.g. user@example.com.');
+    await screen.findAllByText('Enter valid email addresses, e.g. user@example.com.');
 
     // Submitting with the invalid email must not call the API or close the dialog.
     await user.click(screen.getByRole('button', { name: 'Run' }));

--- a/javascript/packages/core/config/entities/pipeline/__tests__/create-pipeline-run-form.test.tsx
+++ b/javascript/packages/core/config/entities/pipeline/__tests__/create-pipeline-run-form.test.tsx
@@ -186,7 +186,7 @@ describe('CreatePipelineRunForm', () => {
                 emails: ['notify@example.com'],
                 slackDestinations: [],
                 // Default selection covers every trigger condition (see NOTIFICATION_EVENT_TYPES).
-                eventTypes: [1, 2, 3, 4],
+                eventTypes: [11, 1, 2, 3, 4],
               }),
             ],
           }) as Record<string, unknown>,

--- a/javascript/packages/core/config/entities/pipeline/__tests__/create-pipeline-run-form.test.tsx
+++ b/javascript/packages/core/config/entities/pipeline/__tests__/create-pipeline-run-form.test.tsx
@@ -137,4 +137,109 @@ describe('CreatePipelineRunForm', () => {
       );
     });
   });
+
+  it('notification fields are disabled by default and enabled after toggling on', async () => {
+    const user = userEvent.setup();
+    const mockRequest = createQueryMockRouter({ CreatePipelineRun: {} });
+
+    render(
+      <FormWrapper />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getErrorProviderWrapper(),
+        getInterpolationProviderWrapper(),
+        getRouterWrapper({ location: '/ma-dev-test/train/pipelines' }),
+        getServiceProviderWrapper({ request: mockRequest }),
+      ])
+    );
+
+    await screen.findByRole('dialog', { name: 'Start new pipeline run' });
+
+    // Toggle is visible; email combobox is present but disabled
+    expect(screen.getByText('Send notifications')).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: /email addresses/i })).toBeDisabled();
+
+    // Enable notifications via toggle
+    await user.click(screen.getByRole('checkbox', { name: /enabled|disabled/i }));
+
+    // Email combobox is now enabled
+    await waitFor(() => {
+      expect(screen.getByRole('combobox', { name: /email addresses/i })).not.toBeDisabled();
+    });
+  });
+
+  it('includes notifications in payload when toggle is on and email is entered', async () => {
+    const user = userEvent.setup();
+    const mockRequest = createQueryMockRouter({ CreatePipelineRun: {} });
+
+    render(
+      <FormWrapper />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getErrorProviderWrapper(),
+        getInterpolationProviderWrapper(),
+        getRouterWrapper({ location: '/ma-dev-test/train/pipelines' }),
+        getServiceProviderWrapper({ request: mockRequest }),
+      ])
+    );
+
+    await screen.findByRole('dialog', { name: 'Start new pipeline run' });
+
+    // Enable notifications
+    await user.click(screen.getByRole('checkbox', { name: /enabled|disabled/i }));
+
+    // Type an email into the email addresses combobox and commit with Enter
+    const emailCombo = await screen.findByRole('combobox', { name: /email addresses/i });
+    await user.type(emailCombo, 'notify@example.com');
+    await user.keyboard('{Enter}');
+
+    await user.click(screen.getByRole('button', { name: 'Run' }));
+
+    await waitFor(() => {
+      expect(mockRequest).toHaveBeenCalledWith(
+        'CreatePipelineRun',
+        expect.objectContaining({
+          spec: expect.objectContaining({
+            notifications: [
+              expect.objectContaining({
+                emails: ['notify@example.com'],
+                slackDestinations: [],
+              }),
+            ],
+          }) as Record<string, unknown>,
+        })
+      );
+    });
+  });
+
+  it('shows a validation error when an invalid email address is entered', async () => {
+    const user = userEvent.setup();
+    const mockRequest = createQueryMockRouter({ CreatePipelineRun: {} });
+
+    render(
+      <FormWrapper />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getErrorProviderWrapper(),
+        getInterpolationProviderWrapper(),
+        getRouterWrapper({ location: '/ma-dev-test/train/pipelines' }),
+        getServiceProviderWrapper({ request: mockRequest }),
+      ])
+    );
+
+    await screen.findByRole('dialog', { name: 'Start new pipeline run' });
+
+    // Enable notifications
+    await user.click(screen.getByRole('checkbox', { name: /enabled|disabled/i }));
+
+    // Type an invalid email into the email addresses combobox and commit with Enter
+    const emailCombo = await screen.findByRole('combobox', { name: /email addresses/i });
+    await user.type(emailCombo, 'not-an-email');
+    await user.keyboard('{Enter}');
+
+    await screen.findByText('Enter valid email addresses, e.g. user@example.com.');
+  });
 });

--- a/javascript/packages/core/config/entities/pipeline/__tests__/create-pipeline-run-form.test.tsx
+++ b/javascript/packages/core/config/entities/pipeline/__tests__/create-pipeline-run-form.test.tsx
@@ -185,6 +185,8 @@ describe('CreatePipelineRunForm', () => {
               expect.objectContaining({
                 emails: ['notify@example.com'],
                 slackDestinations: [],
+                // Default selection covers every trigger condition (see NOTIFICATION_EVENT_TYPES).
+                eventTypes: [1, 2, 3, 4],
               }),
             ],
           }) as Record<string, unknown>,

--- a/javascript/packages/core/config/entities/pipeline/create-pipeline-run-form.tsx
+++ b/javascript/packages/core/config/entities/pipeline/create-pipeline-run-form.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { useStyletron } from 'baseui';
 import { Checkbox, LABEL_PLACEMENT, STYLE_TYPE } from 'baseui/checkbox';
 
 import { FormControl } from '#core/components/form/components/form-control';
@@ -8,7 +7,6 @@ import { StringField } from '#core/components/form/fields/string/string-field';
 import { TextareaField } from '#core/components/form/fields/textarea/textarea-field';
 import { FormGroup } from '#core/components/form/layout/form-group/form-group';
 import { NotificationDetails } from '#core/config/entities/pipeline/notification-details';
-import { getEmailValidationError } from '#core/config/entities/pipeline/notification-validation';
 import {
   ALL_NOTIFICATION_EVENT_TYPES,
   NOTIFICATION_EVENT_TYPES,
@@ -18,7 +16,7 @@ import { useStudioMutation } from '#core/hooks/use-studio-mutation';
 import { generateSuffix } from '#core/utils/name-utils';
 
 import type { ActionComponentProps } from '#core/components/actions/types';
-import type { NotificationDetailsValue, Pipeline } from '#core/config/entities/pipeline/types';
+import type { NotificationFormFields, Pipeline } from '#core/config/entities/pipeline/types';
 import type { NotificationEventType, PipelineRun } from '#core/config/entities/run/types';
 
 const EVENT_TYPE_TO_PROTO_VALUE: Record<NotificationEventType, number> = Object.fromEntries(
@@ -26,15 +24,12 @@ const EVENT_TYPE_TO_PROTO_VALUE: Record<NotificationEventType, number> = Object.
 ) as Record<NotificationEventType, number>;
 
 export const CreatePipelineRunForm = ({ record, onClose }: ActionComponentProps<Pipeline>) => {
-  const [css, theme] = useStyletron();
   const { projectId } = useStudioParams('base');
 
   const [notificationEnabled, setNotificationEnabled] = useState(false);
-  const [notificationDetails, setNotificationDetails] = useState<NotificationDetailsValue>({
-    emails: [],
-    slackChannels: [],
-    eventTypes: [...ALL_NOTIFICATION_EVENT_TYPES],
-  });
+  const [eventTypes, setEventTypes] = useState<NotificationEventType[]>([
+    ...ALL_NOTIFICATION_EVENT_TYPES,
+  ]);
 
   const createPipelineRunMutation = useStudioMutation<PipelineRun, PipelineRun>({
     mutationName: 'CreatePipelineRun',
@@ -44,34 +39,28 @@ export const CreatePipelineRunForm = ({ record, onClose }: ActionComponentProps<
     setNotificationEnabled(event.currentTarget.checked);
   };
 
-  const handleRecipientsChange = (details: NotificationDetailsValue) => {
-    setNotificationDetails(details);
+  const handleEventTypeSelectionChange = (types: NotificationEventType[]) => {
+    setEventTypes(types);
   };
 
-  const handleRunSubmit = async (values: PipelineRun) => {
+  const handleRunSubmit = async (values: PipelineRun & NotificationFormFields) => {
     if (createPipelineRunMutation.isPending) {
       return;
     }
 
-    const { emails, slackChannels, eventTypes } = notificationDetails;
-
-    if (notificationEnabled) {
-      const emailError = getEmailValidationError(emails);
-      if (emailError) {
-        throw new Error(emailError);
-      }
-    }
+    const { notificationEmails = [], notificationSlackChannels = [], ...pipelineRun } = values;
 
     const payload: PipelineRun = {
-      ...values,
+      ...pipelineRun,
       spec: {
-        ...values.spec,
-        ...(notificationEnabled && (emails.length > 0 || slackChannels.length > 0)
+        ...pipelineRun.spec,
+        ...(notificationEnabled &&
+        (notificationEmails.length > 0 || notificationSlackChannels.length > 0)
           ? {
               notifications: [
                 {
-                  emails,
-                  slackDestinations: slackChannels,
+                  emails: notificationEmails,
+                  slackDestinations: notificationSlackChannels,
                   eventTypes: eventTypes.map((t) => EVENT_TYPE_TO_PROTO_VALUE[t]),
                 },
               ],
@@ -100,7 +89,7 @@ export const CreatePipelineRunForm = ({ record, onClose }: ActionComponentProps<
   };
 
   return (
-    <FormDialog<PipelineRun>
+    <FormDialog<PipelineRun & NotificationFormFields>
       isOpen
       onDismiss={onClose}
       heading="Start new pipeline run"
@@ -121,25 +110,21 @@ export const CreatePipelineRunForm = ({ record, onClose }: ActionComponentProps<
         title="Set Up Notifications"
         description="Receive an alert when this run completes, fails, or is killed."
       >
-        <div
-          className={css({ display: 'flex', flexDirection: 'column', gap: theme.sizing.scale600 })}
-        >
-          <FormControl label="Send notifications">
-            <Checkbox
-              checked={notificationEnabled}
-              onChange={handleNotificationEnabledChange}
-              checkmarkType={STYLE_TYPE.toggle_round}
-              labelPlacement={LABEL_PLACEMENT.right}
-            >
-              {notificationEnabled ? 'Enabled' : 'Disabled'}
-            </Checkbox>
-          </FormControl>
-          <NotificationDetails
-            enabled={notificationEnabled}
-            value={notificationDetails}
-            onNotificationDetailsChange={handleRecipientsChange}
-          />
-        </div>
+        <FormControl label="Send notifications">
+          <Checkbox
+            checked={notificationEnabled}
+            onChange={handleNotificationEnabledChange}
+            checkmarkType={STYLE_TYPE.toggle_round}
+            labelPlacement={LABEL_PLACEMENT.right}
+          >
+            {notificationEnabled ? 'Enabled' : 'Disabled'}
+          </Checkbox>
+        </FormControl>
+        <NotificationDetails
+          enabled={notificationEnabled}
+          eventTypes={eventTypes}
+          onEventTypesChange={handleEventTypeSelectionChange}
+        />
       </FormGroup>
     </FormDialog>
   );

--- a/javascript/packages/core/config/entities/pipeline/create-pipeline-run-form.tsx
+++ b/javascript/packages/core/config/entities/pipeline/create-pipeline-run-form.tsx
@@ -9,7 +9,10 @@ import { TextareaField } from '#core/components/form/fields/textarea/textarea-fi
 import { FormGroup } from '#core/components/form/layout/form-group/form-group';
 import { NotificationDetails } from '#core/config/entities/pipeline/notification-details';
 import { getEmailValidationError } from '#core/config/entities/pipeline/notification-validation';
-import { ALL_NOTIFICATION_EVENT_TYPES } from '#core/config/entities/run/types';
+import {
+  ALL_NOTIFICATION_EVENT_TYPES,
+  NOTIFICATION_EVENT_TYPES,
+} from '#core/config/entities/run/types';
 import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
 import { useStudioMutation } from '#core/hooks/use-studio-mutation';
 import { generateSuffix } from '#core/utils/name-utils';
@@ -18,13 +21,9 @@ import type { ActionComponentProps } from '#core/components/actions/types';
 import type { NotificationDetailsValue, Pipeline } from '#core/config/entities/pipeline/types';
 import type { NotificationEventType, PipelineRun } from '#core/config/entities/run/types';
 
-// Proto enum Notification.EventType numeric values (notification.proto).
-const EVENT_TYPE_TO_NUMBER: Record<NotificationEventType, number> = {
-  EVENT_TYPE_PIPELINE_RUN_STATE_SUCCEEDED: 1,
-  EVENT_TYPE_PIPELINE_RUN_STATE_KILLED: 2,
-  EVENT_TYPE_PIPELINE_RUN_STATE_FAILED: 3,
-  EVENT_TYPE_PIPELINE_RUN_STATE_SKIPPED: 4,
-};
+const EVENT_TYPE_TO_PROTO_VALUE: Record<NotificationEventType, number> = Object.fromEntries(
+  NOTIFICATION_EVENT_TYPES.map(({ id, protoValue }) => [id, protoValue])
+) as Record<NotificationEventType, number>;
 
 export const CreatePipelineRunForm = ({ record, onClose }: ActionComponentProps<Pipeline>) => {
   const [css, theme] = useStyletron();
@@ -73,7 +72,7 @@ export const CreatePipelineRunForm = ({ record, onClose }: ActionComponentProps<
                 {
                   emails,
                   slackDestinations: slackChannels,
-                  eventTypes: eventTypes.map((t) => EVENT_TYPE_TO_NUMBER[t]),
+                  eventTypes: eventTypes.map((t) => EVENT_TYPE_TO_PROTO_VALUE[t]),
                 },
               ],
             }

--- a/javascript/packages/core/config/entities/pipeline/create-pipeline-run-form.tsx
+++ b/javascript/packages/core/config/entities/pipeline/create-pipeline-run-form.tsx
@@ -44,7 +44,7 @@ export const CreatePipelineRunForm = ({ record, onClose }: ActionComponentProps<
     setNotificationEnabled(event.currentTarget.checked);
   };
 
-  const handleNotificationDetailsChange = (details: NotificationDetailsValue) => {
+  const handleRecipientsChange = (details: NotificationDetailsValue) => {
     setNotificationDetails(details);
   };
 
@@ -130,7 +130,7 @@ export const CreatePipelineRunForm = ({ record, onClose }: ActionComponentProps<
           <NotificationDetails
             enabled={notificationEnabled}
             value={notificationDetails}
-            onChange={handleNotificationDetailsChange}
+            onNotificationDetailsChange={handleRecipientsChange}
           />
         </div>
       </FormGroup>

--- a/javascript/packages/core/config/entities/pipeline/create-pipeline-run-form.tsx
+++ b/javascript/packages/core/config/entities/pipeline/create-pipeline-run-form.tsx
@@ -8,6 +8,7 @@ import { StringField } from '#core/components/form/fields/string/string-field';
 import { TextareaField } from '#core/components/form/fields/textarea/textarea-field';
 import { FormGroup } from '#core/components/form/layout/form-group/form-group';
 import { NotificationDetails } from '#core/config/entities/pipeline/notification-details';
+import { getEmailValidationError } from '#core/config/entities/pipeline/notification-validation';
 import { ALL_NOTIFICATION_EVENT_TYPES } from '#core/config/entities/run/types';
 import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
 import { useStudioMutation } from '#core/hooks/use-studio-mutation';
@@ -54,6 +55,13 @@ export const CreatePipelineRunForm = ({ record, onClose }: ActionComponentProps<
     }
 
     const { emails, slackChannels, eventTypes } = notificationDetails;
+
+    if (notificationEnabled) {
+      const emailError = getEmailValidationError(emails);
+      if (emailError) {
+        throw new Error(emailError);
+      }
+    }
 
     const payload: PipelineRun = {
       ...values,

--- a/javascript/packages/core/config/entities/pipeline/create-pipeline-run-form.tsx
+++ b/javascript/packages/core/config/entities/pipeline/create-pipeline-run-form.tsx
@@ -1,27 +1,79 @@
+import { useState } from 'react';
+import { useStyletron } from 'baseui';
+import { Checkbox, LABEL_PLACEMENT, STYLE_TYPE } from 'baseui/checkbox';
+
+import { FormControl } from '#core/components/form/components/form-control';
 import { FormDialog } from '#core/components/form/components/form-dialog/form-dialog';
 import { StringField } from '#core/components/form/fields/string/string-field';
 import { TextareaField } from '#core/components/form/fields/textarea/textarea-field';
+import { FormGroup } from '#core/components/form/layout/form-group/form-group';
+import { NotificationDetails } from '#core/config/entities/pipeline/notification-details';
+import { ALL_NOTIFICATION_EVENT_TYPES } from '#core/config/entities/run/types';
 import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
 import { useStudioMutation } from '#core/hooks/use-studio-mutation';
 import { generateSuffix } from '#core/utils/name-utils';
 
 import type { ActionComponentProps } from '#core/components/actions/types';
-import type { Pipeline } from '#core/config/entities/pipeline/types';
-import type { PipelineRun } from '#core/config/entities/run/types';
+import type { NotificationDetailsValue, Pipeline } from '#core/config/entities/pipeline/types';
+import type { NotificationEventType, PipelineRun } from '#core/config/entities/run/types';
+
+// Proto enum Notification.EventType numeric values (notification.proto).
+const EVENT_TYPE_TO_NUMBER: Record<NotificationEventType, number> = {
+  EVENT_TYPE_PIPELINE_RUN_STATE_SUCCEEDED: 1,
+  EVENT_TYPE_PIPELINE_RUN_STATE_KILLED: 2,
+  EVENT_TYPE_PIPELINE_RUN_STATE_FAILED: 3,
+  EVENT_TYPE_PIPELINE_RUN_STATE_SKIPPED: 4,
+};
 
 export const CreatePipelineRunForm = ({ record, onClose }: ActionComponentProps<Pipeline>) => {
+  const [css, theme] = useStyletron();
   const { projectId } = useStudioParams('base');
+
+  const [notificationEnabled, setNotificationEnabled] = useState(false);
+  const [notificationDetails, setNotificationDetails] = useState<NotificationDetailsValue>({
+    emails: [],
+    slackChannels: [],
+    eventTypes: [...ALL_NOTIFICATION_EVENT_TYPES],
+  });
 
   const createPipelineRunMutation = useStudioMutation<PipelineRun, PipelineRun>({
     mutationName: 'CreatePipelineRun',
   });
+
+  const handleNotificationEnabledChange = (event: React.FormEvent<HTMLInputElement>) => {
+    setNotificationEnabled(event.currentTarget.checked);
+  };
+
+  const handleNotificationDetailsChange = (details: NotificationDetailsValue) => {
+    setNotificationDetails(details);
+  };
 
   const handleRunSubmit = async (values: PipelineRun) => {
     if (createPipelineRunMutation.isPending) {
       return;
     }
 
-    await createPipelineRunMutation.mutateAsync(values);
+    const { emails, slackChannels, eventTypes } = notificationDetails;
+
+    const payload: PipelineRun = {
+      ...values,
+      spec: {
+        ...values.spec,
+        ...(notificationEnabled && (emails.length > 0 || slackChannels.length > 0)
+          ? {
+              notifications: [
+                {
+                  emails,
+                  slackDestinations: slackChannels,
+                  eventTypes: eventTypes.map((t) => EVENT_TYPE_TO_NUMBER[t]),
+                },
+              ],
+            }
+          : {}),
+      },
+    };
+
+    await createPipelineRunMutation.mutateAsync(payload);
   };
 
   const initialValues: PipelineRun = {
@@ -57,6 +109,31 @@ export const CreatePipelineRunForm = ({ record, onClose }: ActionComponentProps<
         placeholder="Enter a description for this run…"
         description="Optional. Helps identify this run in the pipeline run list."
       />
+
+      <FormGroup
+        title="Set Up Notifications"
+        description="Receive an alert when this run completes, fails, or is killed."
+      >
+        <div
+          className={css({ display: 'flex', flexDirection: 'column', gap: theme.sizing.scale600 })}
+        >
+          <FormControl label="Send notifications">
+            <Checkbox
+              checked={notificationEnabled}
+              onChange={handleNotificationEnabledChange}
+              checkmarkType={STYLE_TYPE.toggle_round}
+              labelPlacement={LABEL_PLACEMENT.right}
+            >
+              {notificationEnabled ? 'Enabled' : 'Disabled'}
+            </Checkbox>
+          </FormControl>
+          <NotificationDetails
+            enabled={notificationEnabled}
+            value={notificationDetails}
+            onChange={handleNotificationDetailsChange}
+          />
+        </div>
+      </FormGroup>
     </FormDialog>
   );
 };

--- a/javascript/packages/core/config/entities/pipeline/notification-details.tsx
+++ b/javascript/packages/core/config/entities/pipeline/notification-details.tsx
@@ -1,0 +1,100 @@
+import { useStyletron } from 'baseui';
+import { Checkbox } from 'baseui/checkbox';
+import { Select } from 'baseui/select';
+
+import { FormControl } from '#core/components/form/components/form-control';
+
+import type { OnChangeParams } from 'baseui/select';
+import type { NotificationDetailsValue } from '#core/config/entities/pipeline/types';
+import type { NotificationEventType } from '#core/config/entities/run/types';
+
+const EVENT_TYPE_OPTIONS: Array<{ id: NotificationEventType; label: string }> = [
+  { id: 'EVENT_TYPE_PIPELINE_RUN_STATE_SUCCEEDED', label: 'Succeeded' },
+  { id: 'EVENT_TYPE_PIPELINE_RUN_STATE_FAILED', label: 'Failed' },
+  { id: 'EVENT_TYPE_PIPELINE_RUN_STATE_KILLED', label: 'Killed' },
+  { id: 'EVENT_TYPE_PIPELINE_RUN_STATE_SKIPPED', label: 'Skipped' },
+];
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+type NotificationDetailsProps = {
+  enabled: boolean;
+  value: NotificationDetailsValue;
+  onChange: (value: NotificationDetailsValue) => void;
+};
+
+const toSelectValue = (items: string[]) => items.map((item) => ({ id: item, label: item }));
+const fromSelectParams = (params: OnChangeParams) => params.value.map((item) => String(item.id));
+
+/**
+ * Controlled notification recipient inputs (emails, Slack, event types).
+ * Pure UI state driven entirely by props — not react-final-form — so the
+ * caller decides when and whether to merge this into a submitted payload.
+ */
+export function NotificationDetails({ enabled, value, onChange }: NotificationDetailsProps) {
+  const [css, theme] = useStyletron();
+
+  const emailError = value.emails.some((email) => !EMAIL_REGEX.test(email.trim()))
+    ? 'Enter valid email addresses, e.g. user@example.com.'
+    : undefined;
+
+  const toggleEventType = (id: NotificationEventType) => {
+    onChange({
+      ...value,
+      eventTypes: value.eventTypes.includes(id)
+        ? value.eventTypes.filter((t) => t !== id)
+        : [...value.eventTypes, id],
+    });
+  };
+
+  return (
+    <>
+      <FormControl label="Email addresses" caption="Use valid email addresses." error={emailError}>
+        <Select
+          id="notificationEmails"
+          value={toSelectValue(value.emails)}
+          options={[]}
+          onChange={(params) => onChange({ ...value, emails: fromSelectParams(params) })}
+          disabled={!enabled}
+          multi
+          creatable
+          placeholder="user@example.com"
+        />
+      </FormControl>
+
+      <FormControl
+        label="Slack channels or users"
+        caption="Use a channel name or @person for direct messages."
+      >
+        <Select
+          id="notificationSlackChannels"
+          value={toSelectValue(value.slackChannels)}
+          options={[]}
+          onChange={(params) => onChange({ ...value, slackChannels: fromSelectParams(params) })}
+          disabled={!enabled}
+          multi
+          creatable
+          placeholder="#channel or @username"
+        />
+      </FormControl>
+
+      <FormControl
+        label="Notify on"
+        caption="At least one state must be selected to receive notifications."
+      >
+        <div className={css({ display: 'flex', flexWrap: 'wrap', gap: theme.sizing.scale600 })}>
+          {EVENT_TYPE_OPTIONS.map((option) => (
+            <Checkbox
+              key={option.id}
+              checked={value.eventTypes.includes(option.id)}
+              disabled={!enabled}
+              onChange={() => toggleEventType(option.id)}
+            >
+              {option.label}
+            </Checkbox>
+          ))}
+        </div>
+      </FormControl>
+    </>
+  );
+}

--- a/javascript/packages/core/config/entities/pipeline/notification-details.tsx
+++ b/javascript/packages/core/config/entities/pipeline/notification-details.tsx
@@ -64,7 +64,7 @@ export function NotificationDetails({
           disabled={!enabled}
           multi
           creatable
-          placeholder="user@example.com"
+          placeholder="e.g. user@example.com"
         />
       </FormControl>
 

--- a/javascript/packages/core/config/entities/pipeline/notification-details.tsx
+++ b/javascript/packages/core/config/entities/pipeline/notification-details.tsx
@@ -1,81 +1,55 @@
 import { useStyletron } from 'baseui';
 import { Checkbox } from 'baseui/checkbox';
-import { Select } from 'baseui/select';
 
 import { FormControl } from '#core/components/form/components/form-control';
-import { getEmailValidationError } from '#core/config/entities/pipeline/notification-validation';
+import { MultiInputField } from '#core/components/form/fields/multi-input/multi-input-field';
+import { validateEmails } from '#core/config/entities/pipeline/notification-validation';
 import { NOTIFICATION_EVENT_TYPES } from '#core/config/entities/run/types';
 
-import type { OnChangeParams } from 'baseui/select';
-import type { NotificationDetailsValue } from '#core/config/entities/pipeline/types';
 import type { NotificationEventType } from '#core/config/entities/run/types';
 
 type NotificationDetailsProps = {
   enabled: boolean;
-  value: NotificationDetailsValue;
-  onNotificationDetailsChange: (value: NotificationDetailsValue) => void;
+  eventTypes: NotificationEventType[];
+  onEventTypesChange: (eventTypes: NotificationEventType[]) => void;
 };
 
-const toSelectValue = (items: string[]) => items.map((item) => ({ id: item, label: item }));
-const fromSelectParams = (params: OnChangeParams) => params.value.map((item) => String(item.id));
-
 /**
- * Controlled notification recipient inputs (emails, Slack, event types).
- * Pure UI state driven entirely by props — not react-final-form — so the
- * caller decides when and whether to merge this into a submitted payload.
+ * Notification recipient inputs (emails, Slack, event types) for `CreatePipelineRunForm`.
+ * Emails and Slack destinations are real form fields (registered via `MultiInputField`), so
+ * `Form`'s built-in validation gating blocks submission on an invalid email automatically.
+ * Event types are pure UI state, passed through to the parent to merge into the payload.
  */
 export function NotificationDetails({
   enabled,
-  value,
-  onNotificationDetailsChange,
+  eventTypes,
+  onEventTypesChange,
 }: NotificationDetailsProps) {
   const [css, theme] = useStyletron();
 
-  const emailError = getEmailValidationError(value.emails);
-
   const toggleEventType = (id: NotificationEventType) => {
-    onNotificationDetailsChange({
-      ...value,
-      eventTypes: value.eventTypes.includes(id)
-        ? value.eventTypes.filter((t) => t !== id)
-        : [...value.eventTypes, id],
-    });
+    onEventTypesChange(
+      eventTypes.includes(id) ? eventTypes.filter((t) => t !== id) : [...eventTypes, id]
+    );
   };
 
   return (
     <>
-      <FormControl label="Email addresses" error={emailError}>
-        <Select
-          id="notificationEmails"
-          value={toSelectValue(value.emails)}
-          options={[]}
-          onChange={(params) =>
-            onNotificationDetailsChange({ ...value, emails: fromSelectParams(params) })
-          }
-          disabled={!enabled}
-          multi
-          creatable
-          placeholder="e.g. user@example.com"
-        />
-      </FormControl>
+      <MultiInputField
+        name="notificationEmails"
+        label="Email addresses"
+        placeholder="e.g. user@example.com"
+        disabled={!enabled}
+        validate={validateEmails}
+      />
 
-      <FormControl
+      <MultiInputField
+        name="notificationSlackChannels"
         label="Slack channels or users"
         caption="Use a channel name or @person for direct messages."
-      >
-        <Select
-          id="notificationSlackChannels"
-          value={toSelectValue(value.slackChannels)}
-          options={[]}
-          onChange={(params) =>
-            onNotificationDetailsChange({ ...value, slackChannels: fromSelectParams(params) })
-          }
-          disabled={!enabled}
-          multi
-          creatable
-          placeholder="e.g. #channel or @username"
-        />
-      </FormControl>
+        placeholder="e.g. #channel or @username"
+        disabled={!enabled}
+      />
 
       <FormControl
         label="Notify on"
@@ -85,7 +59,7 @@ export function NotificationDetails({
           {NOTIFICATION_EVENT_TYPES.map((option) => (
             <Checkbox
               key={option.id}
-              checked={value.eventTypes.includes(option.id)}
+              checked={eventTypes.includes(option.id)}
               disabled={!enabled}
               onChange={() => toggleEventType(option.id)}
             >

--- a/javascript/packages/core/config/entities/pipeline/notification-details.tsx
+++ b/javascript/packages/core/config/entities/pipeline/notification-details.tsx
@@ -20,7 +20,7 @@ const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 type NotificationDetailsProps = {
   enabled: boolean;
   value: NotificationDetailsValue;
-  onChange: (value: NotificationDetailsValue) => void;
+  onNotificationDetailsChange: (value: NotificationDetailsValue) => void;
 };
 
 const toSelectValue = (items: string[]) => items.map((item) => ({ id: item, label: item }));
@@ -31,7 +31,11 @@ const fromSelectParams = (params: OnChangeParams) => params.value.map((item) => 
  * Pure UI state driven entirely by props — not react-final-form — so the
  * caller decides when and whether to merge this into a submitted payload.
  */
-export function NotificationDetails({ enabled, value, onChange }: NotificationDetailsProps) {
+export function NotificationDetails({
+  enabled,
+  value,
+  onNotificationDetailsChange,
+}: NotificationDetailsProps) {
   const [css, theme] = useStyletron();
 
   const emailError = value.emails.some((email) => !EMAIL_REGEX.test(email.trim()))
@@ -39,7 +43,7 @@ export function NotificationDetails({ enabled, value, onChange }: NotificationDe
     : undefined;
 
   const toggleEventType = (id: NotificationEventType) => {
-    onChange({
+    onNotificationDetailsChange({
       ...value,
       eventTypes: value.eventTypes.includes(id)
         ? value.eventTypes.filter((t) => t !== id)
@@ -49,12 +53,14 @@ export function NotificationDetails({ enabled, value, onChange }: NotificationDe
 
   return (
     <>
-      <FormControl label="Email addresses" caption="Use valid email addresses." error={emailError}>
+      <FormControl label="Email addresses" error={emailError}>
         <Select
           id="notificationEmails"
           value={toSelectValue(value.emails)}
           options={[]}
-          onChange={(params) => onChange({ ...value, emails: fromSelectParams(params) })}
+          onChange={(params) =>
+            onNotificationDetailsChange({ ...value, emails: fromSelectParams(params) })
+          }
           disabled={!enabled}
           multi
           creatable
@@ -70,7 +76,9 @@ export function NotificationDetails({ enabled, value, onChange }: NotificationDe
           id="notificationSlackChannels"
           value={toSelectValue(value.slackChannels)}
           options={[]}
-          onChange={(params) => onChange({ ...value, slackChannels: fromSelectParams(params) })}
+          onChange={(params) =>
+            onNotificationDetailsChange({ ...value, slackChannels: fromSelectParams(params) })
+          }
           disabled={!enabled}
           multi
           creatable

--- a/javascript/packages/core/config/entities/pipeline/notification-details.tsx
+++ b/javascript/packages/core/config/entities/pipeline/notification-details.tsx
@@ -3,6 +3,7 @@ import { Checkbox } from 'baseui/checkbox';
 import { Select } from 'baseui/select';
 
 import { FormControl } from '#core/components/form/components/form-control';
+import { getEmailValidationError } from '#core/config/entities/pipeline/notification-validation';
 
 import type { OnChangeParams } from 'baseui/select';
 import type { NotificationDetailsValue } from '#core/config/entities/pipeline/types';
@@ -14,8 +15,6 @@ const EVENT_TYPE_OPTIONS: Array<{ id: NotificationEventType; label: string }> = 
   { id: 'EVENT_TYPE_PIPELINE_RUN_STATE_KILLED', label: 'Killed' },
   { id: 'EVENT_TYPE_PIPELINE_RUN_STATE_SKIPPED', label: 'Skipped' },
 ];
-
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 type NotificationDetailsProps = {
   enabled: boolean;
@@ -38,9 +37,7 @@ export function NotificationDetails({
 }: NotificationDetailsProps) {
   const [css, theme] = useStyletron();
 
-  const emailError = value.emails.some((email) => !EMAIL_REGEX.test(email.trim()))
-    ? 'Enter valid email addresses, e.g. user@example.com.'
-    : undefined;
+  const emailError = getEmailValidationError(value.emails);
 
   const toggleEventType = (id: NotificationEventType) => {
     onNotificationDetailsChange({

--- a/javascript/packages/core/config/entities/pipeline/notification-details.tsx
+++ b/javascript/packages/core/config/entities/pipeline/notification-details.tsx
@@ -82,7 +82,7 @@ export function NotificationDetails({
           disabled={!enabled}
           multi
           creatable
-          placeholder="#channel or @username"
+          placeholder="e.g. #channel or @username"
         />
       </FormControl>
 

--- a/javascript/packages/core/config/entities/pipeline/notification-details.tsx
+++ b/javascript/packages/core/config/entities/pipeline/notification-details.tsx
@@ -4,17 +4,11 @@ import { Select } from 'baseui/select';
 
 import { FormControl } from '#core/components/form/components/form-control';
 import { getEmailValidationError } from '#core/config/entities/pipeline/notification-validation';
+import { NOTIFICATION_EVENT_TYPES } from '#core/config/entities/run/types';
 
 import type { OnChangeParams } from 'baseui/select';
 import type { NotificationDetailsValue } from '#core/config/entities/pipeline/types';
 import type { NotificationEventType } from '#core/config/entities/run/types';
-
-const EVENT_TYPE_OPTIONS: Array<{ id: NotificationEventType; label: string }> = [
-  { id: 'EVENT_TYPE_PIPELINE_RUN_STATE_SUCCEEDED', label: 'Succeeded' },
-  { id: 'EVENT_TYPE_PIPELINE_RUN_STATE_FAILED', label: 'Failed' },
-  { id: 'EVENT_TYPE_PIPELINE_RUN_STATE_KILLED', label: 'Killed' },
-  { id: 'EVENT_TYPE_PIPELINE_RUN_STATE_SKIPPED', label: 'Skipped' },
-];
 
 type NotificationDetailsProps = {
   enabled: boolean;
@@ -88,7 +82,7 @@ export function NotificationDetails({
         caption="At least one state must be selected to receive notifications."
       >
         <div className={css({ display: 'flex', flexWrap: 'wrap', gap: theme.sizing.scale600 })}>
-          {EVENT_TYPE_OPTIONS.map((option) => (
+          {NOTIFICATION_EVENT_TYPES.map((option) => (
             <Checkbox
               key={option.id}
               checked={value.eventTypes.includes(option.id)}

--- a/javascript/packages/core/config/entities/pipeline/notification-validation.ts
+++ b/javascript/packages/core/config/entities/pipeline/notification-validation.ts
@@ -1,9 +1,15 @@
+import type { FieldValidator } from '#core/components/form/validation/types';
+
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const INVALID_EMAIL_MESSAGE = 'Enter valid email addresses, e.g. user@example.com.';
 
-/** Validation error for a list of recipient emails, or `undefined` if all are valid. */
-export function getEmailValidationError(emails: string[]): string | undefined {
+/**
+ * Field-level validator for a list of recipient emails, for use with `MultiInputField`'s
+ * `validate` prop — every entry must match a basic email shape.
+ */
+export const validateEmails: FieldValidator = (value) => {
+  const emails = Array.isArray(value) ? (value as string[]) : [];
   return emails.some((email) => !EMAIL_REGEX.test(email.trim()))
     ? INVALID_EMAIL_MESSAGE
     : undefined;
-}
+};

--- a/javascript/packages/core/config/entities/pipeline/notification-validation.ts
+++ b/javascript/packages/core/config/entities/pipeline/notification-validation.ts
@@ -1,0 +1,9 @@
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const INVALID_EMAIL_MESSAGE = 'Enter valid email addresses, e.g. user@example.com.';
+
+/** Validation error for a list of recipient emails, or `undefined` if all are valid. */
+export function getEmailValidationError(emails: string[]): string | undefined {
+  return emails.some((email) => !EMAIL_REGEX.test(email.trim()))
+    ? INVALID_EMAIL_MESSAGE
+    : undefined;
+}

--- a/javascript/packages/core/config/entities/pipeline/types.ts
+++ b/javascript/packages/core/config/entities/pipeline/types.ts
@@ -1,3 +1,5 @@
+import type { NotificationEventType } from '#core/config/entities/run/types';
+
 export interface Pipeline {
   metadata: {
     name: string;
@@ -9,3 +11,10 @@ export interface Pipeline {
     };
   };
 }
+
+/** Notification recipient state for CreatePipelineRunForm, held as local React state. */
+export type NotificationDetailsValue = {
+  emails: string[];
+  slackChannels: string[];
+  eventTypes: NotificationEventType[];
+};

--- a/javascript/packages/core/config/entities/pipeline/types.ts
+++ b/javascript/packages/core/config/entities/pipeline/types.ts
@@ -1,5 +1,3 @@
-import type { NotificationEventType } from '#core/config/entities/run/types';
-
 export interface Pipeline {
   metadata: {
     name: string;
@@ -12,9 +10,13 @@ export interface Pipeline {
   };
 }
 
-/** Notification recipient state for CreatePipelineRunForm, held as local React state. */
-export type NotificationDetailsValue = {
-  emails: string[];
-  slackChannels: string[];
-  eventTypes: NotificationEventType[];
+/**
+ * `notificationEmails`/`notificationSlackChannels` aren't real `PipelineRun` fields — they're
+ * registered by `MultiInputField` (inside `NotificationDetails`) purely so Form's built-in
+ * validation gating gates submission on an invalid email, matching the Field API used
+ * everywhere else in this form instead of a hand-rolled check in the submit handler.
+ */
+export type NotificationFormFields = {
+  notificationEmails?: string[];
+  notificationSlackChannels?: string[];
 };

--- a/javascript/packages/core/config/entities/run/types.ts
+++ b/javascript/packages/core/config/entities/run/types.ts
@@ -1,13 +1,23 @@
-/** All trigger conditions for pipeline run notifications, used as the default selection. */
-export const ALL_NOTIFICATION_EVENT_TYPES = [
-  'EVENT_TYPE_PIPELINE_RUN_STATE_SUCCEEDED',
-  'EVENT_TYPE_PIPELINE_RUN_STATE_FAILED',
-  'EVENT_TYPE_PIPELINE_RUN_STATE_KILLED',
-  'EVENT_TYPE_PIPELINE_RUN_STATE_SKIPPED',
+/**
+ * Single source of truth for pipeline run notification trigger conditions: each entry's
+ * proto enum id, UI display label, and proto `Notification.EventType` numeric value
+ * (see notification.proto). Adding a new trigger condition only requires adding one
+ * entry here — the id list, UI options, and proto-value lookup all derive from it.
+ */
+export const NOTIFICATION_EVENT_TYPES = [
+  { id: 'EVENT_TYPE_PIPELINE_RUN_STATE_SUCCEEDED', label: 'Succeeded', protoValue: 1 },
+  { id: 'EVENT_TYPE_PIPELINE_RUN_STATE_KILLED', label: 'Killed', protoValue: 2 },
+  { id: 'EVENT_TYPE_PIPELINE_RUN_STATE_FAILED', label: 'Failed', protoValue: 3 },
+  { id: 'EVENT_TYPE_PIPELINE_RUN_STATE_SKIPPED', label: 'Skipped', protoValue: 4 },
 ] as const;
 
 /** Trigger condition for a pipeline run notification. */
-export type NotificationEventType = (typeof ALL_NOTIFICATION_EVENT_TYPES)[number];
+export type NotificationEventType = (typeof NOTIFICATION_EVENT_TYPES)[number]['id'];
+
+/** All trigger conditions for pipeline run notifications, used as the default selection. */
+export const ALL_NOTIFICATION_EVENT_TYPES: NotificationEventType[] = NOTIFICATION_EVENT_TYPES.map(
+  (eventType) => eventType.id
+);
 
 /**
  * A single notification channel attached to a pipeline run.

--- a/javascript/packages/core/config/entities/run/types.ts
+++ b/javascript/packages/core/config/entities/run/types.ts
@@ -5,6 +5,7 @@
  * entry here — the id list, UI options, and proto-value lookup all derive from it.
  */
 export const NOTIFICATION_EVENT_TYPES = [
+  { id: 'EVENT_TYPE_PIPELINE_RUN_STATE_STARTED', label: 'Started', protoValue: 11 },
   { id: 'EVENT_TYPE_PIPELINE_RUN_STATE_SUCCEEDED', label: 'Succeeded', protoValue: 1 },
   { id: 'EVENT_TYPE_PIPELINE_RUN_STATE_KILLED', label: 'Killed', protoValue: 2 },
   { id: 'EVENT_TYPE_PIPELINE_RUN_STATE_FAILED', label: 'Failed', protoValue: 3 },

--- a/javascript/packages/core/config/entities/run/types.ts
+++ b/javascript/packages/core/config/entities/run/types.ts
@@ -12,8 +12,9 @@ export type NotificationEventType = (typeof ALL_NOTIFICATION_EVENT_TYPES)[number
 /**
  * A single notification channel attached to a pipeline run.
  * Sent when any of the listed event types fires.
+ * Mirrors the proto `Notification` message (see notification.proto).
  */
-export type PipelineRunNotification = {
+export type Notification = {
   emails: string[];
   slackDestinations: string[];
   /** Proto enum Notification.EventType numeric values (see notification.proto). */
@@ -36,6 +37,6 @@ export type PipelineRun = {
     /** Optional human-readable description for this run. */
     description?: string;
     /** Optional notification channels. Omitted when the user leaves the section blank. */
-    notifications?: PipelineRunNotification[];
+    notifications?: Notification[];
   };
 };

--- a/javascript/packages/core/config/entities/run/types.ts
+++ b/javascript/packages/core/config/entities/run/types.ts
@@ -1,3 +1,25 @@
+/** All trigger conditions for pipeline run notifications, used as the default selection. */
+export const ALL_NOTIFICATION_EVENT_TYPES = [
+  'EVENT_TYPE_PIPELINE_RUN_STATE_SUCCEEDED',
+  'EVENT_TYPE_PIPELINE_RUN_STATE_FAILED',
+  'EVENT_TYPE_PIPELINE_RUN_STATE_KILLED',
+  'EVENT_TYPE_PIPELINE_RUN_STATE_SKIPPED',
+] as const;
+
+/** Trigger condition for a pipeline run notification. */
+export type NotificationEventType = (typeof ALL_NOTIFICATION_EVENT_TYPES)[number];
+
+/**
+ * A single notification channel attached to a pipeline run.
+ * Sent when any of the listed event types fires.
+ */
+export type PipelineRunNotification = {
+  emails: string[];
+  slackDestinations: string[];
+  /** Proto enum Notification.EventType numeric values (see notification.proto). */
+  eventTypes: number[];
+};
+
 export type PipelineRun = {
   metadata: {
     name: string;
@@ -13,5 +35,7 @@ export type PipelineRun = {
     };
     /** Optional human-readable description for this run. */
     description?: string;
+    /** Optional notification channels. Omitted when the user leaves the section blank. */
+    notifications?: PipelineRunNotification[];
   };
 };


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Adds a **"Set Up Notifications"** section to the `CreatePipelineRunForm` dialog:

- A toggle (`Send notifications` — Enabled/Disabled) that enables/disables the section
- Email address recipients, entered as tags (multi + creatable select)
- Slack channel / user handle recipients, entered as tags
- Checkboxes for which run states trigger a notification (Succeeded, Failed, Killed, Skipped — all selected by default)
- Notifications are omitted from the `CreatePipelineRun` payload unless the toggle is on and at least one email or Slack recipient is set

The notification toggle and recipient inputs are pure UI state, not part of the `PipelineRun` entity being submitted, so they're held in local `useState` rather than modeled as virtual fields on the form. `CreatePipelineRunForm` is typed as `FormDialog<PipelineRun>` directly — no separate form-values type. `handleRunSubmit` receives a clean `PipelineRun` and merges in `spec.notifications` from local state before calling the mutation.

Files changed:

| File | Change |
|---|---|
| `packages/core/config/entities/run/types.ts` | Export `ALL_NOTIFICATION_EVENT_TYPES` const; `NotificationEventType`, `PipelineRunNotification` types; extend `PipelineRun.spec.notifications?` |
| `packages/core/config/entities/pipeline/types.ts` | `NotificationDetailsValue` type (local UI state shape) |
| `packages/core/config/entities/pipeline/create-pipeline-run-form.tsx` | `FormDialog<PipelineRun>`; notification toggle (`useState`) merged into payload in `handleRunSubmit` |
| `packages/core/config/entities/pipeline/notification-details.tsx` | Controlled component (`enabled`/`value`/`onChange` props) rendering email/Slack/event-type inputs via BaseUI `Select`/`Checkbox` primitives directly |
| `packages/core/components/form/fields/select/build-select-overrides.ts` | Minor override tweak needed for the tag-style multi/creatable select |
| `packages/core/config/entities/pipeline/__tests__/create-pipeline-run-form.test.tsx` | Tests: notification fields disabled by default and enabled after toggling; notifications included in payload when toggle on + email entered |

**Why?**

Pipeline runs previously had no way to trigger completion alerts from the Studio UI. This mirrors the internal MAStudio notification UX (enable/disable toggle + tag-style recipient inputs) rather than a collapsible-optional section, per review feedback.

**How did you test it?**

- `yarn vitest run packages/core/config/entities/pipeline` — 4/4 tests pass
- `tsc --noEmit` — no new type errors
- `eslint` — 0 errors on changed files

**Potential risks**

None. The notification section is off by default — existing `CreatePipelineRun` calls are unchanged when the toggle is left off. No breaking changes to existing types (`notifications` is optional on `PipelineRun.spec`).

**Breaking Changes**

- [x] No breaking changes

**Release notes**

Pipeline run form now supports a notification toggle with email and Slack recipients, and a choice of which run states trigger an alert.