### PR TITLE
Move Roadmap page to Getting Started section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -244,7 +244,7 @@ Git tags use SemVer, but PyPI requires [PEP 440](https://peps.python.org/pep-044
 
 - Tags are only created on **release branches** (`release/vX.Y`), never directly on `main`.
 - All artifacts (Python, npm, Go, Helm, containers) receive the same Major.Minor from the tag.
-- See the [Versioning Policy](./docs/about/roadmap.md#versioning-policy) for stability level guarantees (stable, beta, alpha).
+- See the [Versioning Policy](./docs/getting-started/roadmap.md#versioning-policy) for stability level guarantees (stable, beta, alpha).
 
 ## Creating a Pull Request
 
@@ -313,5 +313,5 @@ resources: {}
 ### Reference
 
 - See [UPGRADING.md](./UPGRADING.md) for examples of past migrations.
-- See the [Versioning Policy](./docs/about/roadmap.md#versioning-policy) for stability level guarantees.
+- See the [Versioning Policy](./docs/getting-started/roadmap.md#versioning-policy) for stability level guarantees.
 

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -120,3 +120,4 @@ Have questions? See the [full FAQ](./faq.md) — covering getting started, data 
 - **Ready to build?** [Set up your local sandbox](./sandbox-setup.md) and follow the [Getting Started with Pipelines](../user-guides/getting-started/getting-started.md) guide (~30 min)
 - **Want to understand the concepts first?** Read [Core Concepts and Key Terms](./core-concepts-and-key-terms.md)
 - **Looking for examples?** Browse [end-to-end tutorials](../user-guides/index.md#examples) covering XGBoost, BERT, GPT fine-tuning, and recommendation systems
+- **Curious where we're headed?** Check the [Roadmap](./roadmap.md) for release milestones and planned features

--- a/docs/getting-started/roadmap.md
+++ b/docs/getting-started/roadmap.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 sidebar_label: "Roadmap"
 ---
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -31,6 +31,7 @@ Understand what the platform does, how it compares to your current stack, and wh
 
 - **[Overview](./getting-started/overview.md)** — What Michelangelo is, how it works, and how familiar tools map to it
 - **[Core Concepts](./getting-started/core-concepts-and-key-terms.md)** — Projects, workflows, tasks, and the key terms you'll encounter
+- **[Roadmap](./getting-started/roadmap.md)** — Release milestones, what's available now, and what's planned
 
 ### I want to build my first pipeline
 


### PR DESCRIPTION
## Summary

- Move `docs/about/roadmap.md` to `docs/getting-started/roadmap.md` so it appears in the Getting Started sidebar alongside Overview, Core Concepts, and Sandbox Setup
- Add Roadmap link to the Welcome page's "I'm evaluating Michelangelo" section
- Add Roadmap link to the Overview page's "What's next?" section
- Update `CONTRIBUTING.md` references to the new path

## Why

The Roadmap page is currently buried under About, which most evaluators never visit. Moving it to Getting Started puts it where evaluators naturally land — next to the pages that answer "what is this?" and "how do I try it?". Adding links from the Welcome and Overview pages gives it three discovery paths.

## Test plan

- [ ] Verify Roadmap appears in the Getting Started sidebar in the correct position
- [ ] Confirm the old `/docs/about/roadmap` URL redirects or is no longer accessible
- [ ] Check that Welcome page and Overview page Roadmap links resolve correctly
- [ ] Verify CONTRIBUTING.md versioning policy links still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)