### PR TITLE
fix(ci): fix python and npm nightly publish failures

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -32,7 +32,7 @@ assignees: ''
   - [ ] Python wheel on PyPI (PEP 440: `0.3.0rc1`)
   - [ ] Go service containers on ghcr.io
   - [ ] UI container on ghcr.io
-  - [ ] npm packages (`@michelangelo/core`, `@michelangelo/rpc`)
+  - [ ] npm packages (`@michelangelo-ai/core`, `@michelangelo-ai/rpc`)
   - [ ] Helm OCI chart on ghcr.io
 - [ ] RC announcement posted (GitHub Discussions or relevant channel)
 - [ ] Soak period complete (minimum 1 week for minor releases)

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -297,7 +297,7 @@ jobs:
       - name: Build packages
         run: |
           yarn workspace @michelangelo-ai/core build
-          yarn workspace @michelangelo/rpc build
+          yarn workspace @michelangelo-ai/rpc build
 
       - name: Publish @michelangelo-ai/core
         run: cd packages/core && npm publish --tag nightly --access public
@@ -305,7 +305,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_LEGACY_PEER_DEPS: 'true'
 
-      - name: Publish @michelangelo/rpc
+      - name: Publish @michelangelo-ai/rpc
         run: cd packages/rpc && npm publish --tag nightly --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -81,6 +81,8 @@ jobs:
         run: poetry config pypi-token.pypi ${{ secrets.PYPI_API_TOKEN }}
 
       - name: Publish to PyPI (pre-release)
+        env:
+          POETRY_DYNAMIC_VERSIONING_BYPASS: ${{ steps.version.outputs.nightly_version }}
         run: poetry publish --no-interaction
 
   # ---------------------------------------------------------------------------
@@ -298,11 +300,11 @@ jobs:
           yarn workspace @michelangelo/rpc build
 
       - name: Publish @michelangelo-ai/core
-        run: cd packages/core && npm publish --tag nightly --access public
+        run: yarn workspace @michelangelo-ai/core npm publish --tag nightly --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish @michelangelo/rpc
-        run: cd packages/rpc && npm publish --tag nightly --access public
+        run: yarn workspace @michelangelo/rpc npm publish --tag nightly --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -300,11 +300,13 @@ jobs:
           yarn workspace @michelangelo/rpc build
 
       - name: Publish @michelangelo-ai/core
-        run: yarn workspace @michelangelo-ai/core npm publish --tag nightly --access public --legacy-peer-deps
+        run: cd packages/core && npm publish --tag nightly --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_LEGACY_PEER_DEPS: 'true'
 
       - name: Publish @michelangelo/rpc
-        run: yarn workspace @michelangelo/rpc npm publish --tag nightly --access public --legacy-peer-deps
+        run: cd packages/rpc && npm publish --tag nightly --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_LEGACY_PEER_DEPS: 'true'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -290,8 +290,8 @@ jobs:
         run: |
           DATE_TAG="${{ needs.check-changes.outputs.date_tag }}"
           NIGHTLY_VERSION="0.3.0-nightly.${DATE_TAG}"
-          cd packages/core && npm version "$NIGHTLY_VERSION" --no-git-tag-version && cd ../..
-          cd packages/rpc  && npm version "$NIGHTLY_VERSION" --no-git-tag-version && cd ../..
+          jq ".version = \"$NIGHTLY_VERSION\"" packages/core/package.json > /tmp/core-pkg.json && mv /tmp/core-pkg.json packages/core/package.json
+          jq ".version = \"$NIGHTLY_VERSION\""  packages/rpc/package.json  > /tmp/rpc-pkg.json  && mv /tmp/rpc-pkg.json  packages/rpc/package.json
           echo "Publishing npm nightly: $NIGHTLY_VERSION"
 
       - name: Build packages

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -300,11 +300,11 @@ jobs:
           yarn workspace @michelangelo/rpc build
 
       - name: Publish @michelangelo-ai/core
-        run: yarn workspace @michelangelo-ai/core npm publish --tag nightly --access public
+        run: yarn workspace @michelangelo-ai/core npm publish --tag nightly --access public --legacy-peer-deps
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish @michelangelo/rpc
-        run: yarn workspace @michelangelo/rpc npm publish --tag nightly --access public
+        run: yarn workspace @michelangelo/rpc npm publish --tag nightly --access public --legacy-peer-deps
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/docs/contributing/dev/ui/index.md
+++ b/docs/contributing/dev/ui/index.md
@@ -33,7 +33,7 @@ javascript/
 │   ├── core/               # Core UI components and utilities
 │   │   └── package.json    # @uber/michelangelo-core
 │   └── rpc/                # RPC client and error handling
-│       └── package.json    # @michelangelo/rpc
+│       └── package.json    # @michelangelo-ai/rpc
 └── package.json            # Workspace root
 ```
 
@@ -51,7 +51,7 @@ javascript/
 - Type definitions
 - Test utilities
 
-**@michelangelo/rpc**: RPC client and error handling. Contains:
+**@michelangelo-ai/rpc**: RPC client and error handling. Contains:
 - Connect RPC client configuration
 - Error normalization for Connect errors
 
@@ -80,7 +80,7 @@ yarn build
 Build order:
 1. Generate gRPC client code (`yarn generate`)
 2. Build `@uber/michelangelo-core`
-3. Build `@michelangelo/rpc`
+3. Build `@michelangelo-ai/rpc`
 4. Build `@michelangelo/app`
 
 ### Scripts
@@ -105,7 +105,7 @@ The codebase uses TypeScript path aliases:
 import { useStudioQuery } from '#core/hooks/use-studio-query';
 import { Phase } from '#core/types/common/studio-types';
 
-// In @michelangelo/rpc
+// In @michelangelo-ai/rpc
 import { normalizeConnectError } from '#rpc/normalize-connect-error';
 ```
 

--- a/javascript/app/App.tsx
+++ b/javascript/app/App.tsx
@@ -1,6 +1,6 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom-v5-compat';
-import { normalizeConnectError, request } from '@michelangelo-ai/rpc';
 import { CoreApp } from '@michelangelo-ai/core';
+import { normalizeConnectError, request } from '@michelangelo-ai/rpc';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Client as Styletron } from 'styletron-engine-atomic';
 import { Provider as StyletronProvider } from 'styletron-react';

--- a/javascript/app/App.tsx
+++ b/javascript/app/App.tsx
@@ -1,5 +1,5 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom-v5-compat';
-import { normalizeConnectError, request } from '@michelangelo/rpc';
+import { normalizeConnectError, request } from '@michelangelo-ai/rpc';
 import { CoreApp } from '@michelangelo-ai/core';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Client as Styletron } from 'styletron-engine-atomic';

--- a/javascript/app/package.json
+++ b/javascript/app/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
-    "@michelangelo/rpc": "*",
+    "@michelangelo-ai/rpc": "*",
     "@mui/icons-material": "^7.1.0",
     "@mui/material": "^7.1.0",
     "@tanstack/react-query": "5.39.0",

--- a/javascript/packages/core/config/entities/trigger/types.ts
+++ b/javascript/packages/core/config/entities/trigger/types.ts
@@ -1,5 +1,5 @@
 /**
- * Mirrors generated types from @michelangelo/rpc trigger_run_pb.
+ * Mirrors generated types from @michelangelo-ai/rpc trigger_run_pb.
  * Update alongside proto/api/v2/trigger_run.proto.
  */
 

--- a/javascript/packages/rpc/package.json
+++ b/javascript/packages/rpc/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@michelangelo/rpc",
+  "name": "@michelangelo-ai/rpc",
   "license": "Apache-2.0",
   "type": "module",
   "version": "0.3.0",


### PR DESCRIPTION
Fixes all failures from the 2026-06-30 nightly run. Validated with a full end-to-end nightly workflow run ([#28494493638](https://github.com/michelangelo-ai/michelangelo/actions/runs/28494493638)) — all 8 jobs green.

## Changes

### 1. python-nightly: "No files to publish"
`poetry publish` ran without `POETRY_DYNAMIC_VERSIONING_BYPASS`, so dynamic versioning computed a different version than what was built in `dist/`. Poetry couldn't match and aborted.

**Fix:** Add `POETRY_DYNAMIC_VERSIONING_BYPASS: ${{ steps.version.outputs.nightly_version }}` to the publish step, same as the build step.

### 2. npm-nightly: ERESOLVE in `npm version`
`npm version` in npm v10+ performs peer dependency resolution. `eslint-plugin-baseui@13` (a root devDependency) requires `eslint@^3-8` but the workspace has `eslint@9`, causing ERESOLVE before publish even ran.

**Fix:** Replace `npm version` with `jq` to edit `package.json` directly — no npm invocation, no resolver.

### 3. npm-nightly: rename `@michelangelo/rpc` → `@michelangelo-ai/rpc`
The `@michelangelo/rpc` scope belongs to a different npm organization. Both packages now live under `@michelangelo-ai` so a single org token covers both.

**Fix:** Updated `package.json`, `nightly.yml`, `app/App.tsx`, `app/package.json`, `docs/`, `release-checklist.md`, and a comment in `types.ts`.

## Test run results
| Job | Status |
|---|---|
| check-changes | ✅ success |
| python-nightly | ✅ success |
| npm-nightly | ✅ success |
| helm-nightly | ✅ success |
| ui-nightly | ✅ success |
| container-nightly (apiserver) | ✅ success |
| container-nightly (worker) | ✅ success |
| container-nightly (controllermgr) | ✅ success |

## Pre-merge checklist
- [x] `NPM_TOKEN` secret set in repo (linked to `michelangelo-ai` npm org)

Tracking: #1340