### PR TITLE
feat(trainer): add tabular_trainer config schema (PR 7a, issue #1359)

### DIFF
--- a/python/michelangelo/workflow/schema/ray_data_io.py
+++ b/python/michelangelo/workflow/schema/ray_data_io.py
@@ -1,0 +1,96 @@
+"""Ray Data I/O configuration dataclasses shared across workflow tasks.
+
+These classes configure how Ray Data reads and iterates over training datasets.
+They are shared across multiple workflow tasks (e.g. ``tabular_trainer``,
+future ``llm_trainer``) and are kept separate from task-specific schemas.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = [
+    "BatchIterConfig",
+    "DataloadingConfig",
+    "ParquetReadConfig",
+]
+
+
+@dataclass
+class ParquetReadConfig:
+    """Subset of ``ray.data.read_parquet`` kwargs forwarded at read time.
+
+    This is a curated subset of the full ``ray.data.read_parquet`` API —
+    resource knobs and schema hints only. Fields that overlap with the
+    tabular_trainer's own column management (``columns``, ``paths``) and
+    Ray-version-specific placement logic are intentionally omitted. OSS
+    pins a single Ray version so the internal ``<2.50`` branch is unused.
+
+    Column projection is derived automatically from ``input_columns``,
+    ``labels``, and ``metadata_columns`` — do not include ``columns`` here.
+
+    See: https://docs.ray.io/en/latest/data/api/input_output.html#ray.data.read_parquet
+
+    Attributes:
+        num_cpus: CPUs to reserve per parallel read worker.
+        num_gpus: GPUs to reserve per parallel read worker.
+        memory: Heap memory in bytes per read worker.
+        concurrency: Maximum number of concurrent Ray read tasks.
+        override_num_blocks: Override the number of output blocks.
+        shuffle: Set to ``"files"`` to randomly shuffle input file order.
+        tensor_column_schema: Column name → ``{"dtype": ..., "shape": ...}``
+            for serialised tensor columns.
+        arrow_parquet_args: Additional kwargs forwarded to PyArrow's reader.
+
+    Example:
+        >>> ParquetReadConfig(num_cpus=2, shuffle="files")
+        ParquetReadConfig(num_cpus=2, ...)
+    """
+
+    num_cpus: float | None = None
+    num_gpus: float | None = None
+    memory: int | None = None
+    concurrency: int | None = None
+    override_num_blocks: int | None = None
+    shuffle: str | None = None
+    tensor_column_schema: dict | None = None
+    arrow_parquet_args: dict | None = None
+
+
+@dataclass
+class BatchIterConfig:
+    """Configuration for ``ray.data.Dataset.iter_torch_batches``.
+
+    Attributes:
+        batch_size: Number of samples per batch. Required.
+        num_shuffle_batches: Number of batches to buffer for local
+            shuffling. ``0`` disables local shuffle.
+        collate_fn: Dotted import path to a collate function. When set,
+            the function is resolved at training time via ``get_module_attr``
+            and passed as ``collate_fn`` to ``iter_torch_batches``.
+
+    Example:
+        >>> BatchIterConfig(batch_size=64, num_shuffle_batches=4)
+        BatchIterConfig(batch_size=64, num_shuffle_batches=4, collate_fn=None)
+    """
+
+    batch_size: int
+    num_shuffle_batches: int = 0
+    collate_fn: str | None = None
+
+
+@dataclass
+class DataloadingConfig:
+    """Container for Ray Data read and batch iteration settings.
+
+    Attributes:
+        parquet_read_config: kwargs forwarded to ``ray.data.read_parquet``.
+        batch_iter_config: Batch size, shuffle, and collate settings.
+
+    Example:
+        >>> DataloadingConfig(batch_iter_config=BatchIterConfig(batch_size=32))
+        DataloadingConfig(...)
+    """
+
+    parquet_read_config: ParquetReadConfig | None = None
+    batch_iter_config: BatchIterConfig | None = None

--- a/python/michelangelo/workflow/schema/tabular_trainer.py
+++ b/python/michelangelo/workflow/schema/tabular_trainer.py
@@ -151,7 +151,8 @@ class CheckpointConfig:
 
     Raises:
         ConfigurationError: If ``save_every_n_steps`` is set to a value
-            less than 1.
+            less than 1. Set it to ``None`` (the default) to disable
+            mid-epoch checkpointing.
 
     Example:
         >>> CheckpointConfig(num_to_keep=3, checkpoint_score_attribute="val_loss",
@@ -170,6 +171,7 @@ class CheckpointConfig:
         if self.save_every_n_steps is not None and self.save_every_n_steps < 1:
             raise ConfigurationError(
                 f"save_every_n_steps must be >= 1, got {self.save_every_n_steps}."
+                " Set it to None to disable mid-epoch checkpointing."
             )
 
 
@@ -177,9 +179,14 @@ class CheckpointConfig:
 class ParquetReadConfig:
     """Subset of ``ray.data.read_parquet`` kwargs forwarded at read time.
 
-    Only resource and schema-related knobs are exposed. Column projection is
-    derived automatically from ``input_columns``, ``labels``, and
-    ``metadata_columns`` — do not include ``columns`` here.
+    This is a curated subset of the full ``ray.data.read_parquet`` API —
+    resource knobs and schema hints only. Fields that overlap with the
+    tabular_trainer's own column management (``columns``, ``paths``) and
+    Ray-version-specific placement logic are intentionally omitted. OSS
+    pins a single Ray version so the internal ``<2.50`` branch is unused.
+
+    Column projection is derived automatically from ``input_columns``,
+    ``labels``, and ``metadata_columns`` — do not include ``columns`` here.
 
     Attributes:
         num_cpus: CPUs to reserve per parallel read worker.
@@ -358,6 +365,10 @@ class LightningTrainerKwargs:
     sync_batchnorm: bool = False
     reload_dataloaders_every_n_epochs: int = 0
     default_root_dir: str | None = None
+    # Note: Lightning's ``profiler`` kwarg is intentionally omitted here.
+    # The profiler subsystem will be re-introduced in PR 5 with a pluggable
+    # upload sink via TrainingObserver. Use ``profiler=None`` (the Lightning
+    # default) until then.
 
     def __post_init__(self) -> None:
         """Validate mutually exclusive limit_*_batches pairs."""
@@ -375,6 +386,8 @@ class LightningTrainerKwargs:
                 raise ConfigurationError(
                     f"Cannot set both '{float_field}' and"
                     f" '{count_field}' simultaneously."
+                    f" Use '{float_field}' (float fraction) or"
+                    f" '{count_field}' (int count), not both."
                 )
 
 
@@ -489,16 +502,49 @@ class TabularTrainerConfig:
             ``NotImplementedError`` until ported).
 
     Raises:
-        ConfigurationError: If neither or both backends are set.
+        ConfigurationError: If neither or both backends are set. Set exactly
+            one of ``lightning`` or ``custom``.
 
     Example:
+        Minimal config — model class, columns, no optional tuning:
+
         >>> cfg = TabularTrainerConfig(
         ...     lightning=LightningTrainerConfig(
-        ...         model_class="myproject.models.Net",
-        ...         input_columns={"x": ColumnConfig("torch.float32")},
-        ...         output_columns={"y": ColumnConfig("torch.float32")},
-        ...         labels={"label": ColumnConfig("torch.long")},
-        ...         metadata_columns=[],
+        ...         model_class="myproject.models.TabularNet",
+        ...         input_columns={"age": ColumnConfig("torch.float32"),
+        ...                        "income": ColumnConfig("torch.float32")},
+        ...         output_columns={"score": ColumnConfig("torch.float32")},
+        ...         labels={"clicked": ColumnConfig("torch.long")},
+        ...         metadata_columns=["user_id"],
+        ...     )
+        ... )
+
+        Realistic config — batch size, epochs, checkpointing by val loss:
+
+        >>> cfg = TabularTrainerConfig(
+        ...     lightning=LightningTrainerConfig(
+        ...         model_class="myproject.models.TabularNet",
+        ...         input_columns={"age": ColumnConfig("torch.float32"),
+        ...                        "income": ColumnConfig("torch.float32")},
+        ...         output_columns={"score": ColumnConfig("torch.float32")},
+        ...         labels={"clicked": ColumnConfig("torch.long")},
+        ...         metadata_columns=["user_id"],
+        ...         dataloading_config=DataloadingConfig(
+        ...             batch_iter_config=BatchIterConfig(
+        ...                 batch_size=256,
+        ...                 num_shuffle_batches=4,
+        ...             ),
+        ...         ),
+        ...         checkpoint_config=CheckpointConfig(
+        ...             num_to_keep=3,
+        ...             checkpoint_score_attribute="val_loss",
+        ...             checkpoint_score_order=CheckpointScoreOrder.MIN,
+        ...         ),
+        ...         lightning_trainer_kwargs=LightningTrainerKwargs(
+        ...             max_epochs=20,
+        ...             precision="bf16-mixed",
+        ...         ),
+        ...         scaling_config=ScalingConfig(cpu_per_worker=4),
         ...     )
         ... )
     """
@@ -513,5 +559,9 @@ class TabularTrainerConfig:
                 "Exactly one of 'lightning' or 'custom' must be set on "
                 "TabularTrainerConfig, got "
                 f"lightning={'set' if self.lightning else 'None'}, "
-                f"custom={'set' if self.custom else 'None'}."
+                f"custom={'set' if self.custom else 'None'}. "
+                "Set TabularTrainerConfig(lightning=LightningTrainerConfig(...)) "
+                "for the Lightning backend or "
+                "TabularTrainerConfig(custom=CustomTrainerConfig(...)) "
+                "for a custom backend."
             )

--- a/python/michelangelo/workflow/schema/tabular_trainer.py
+++ b/python/michelangelo/workflow/schema/tabular_trainer.py
@@ -150,6 +150,12 @@ class ExperimentTrackerConfig:
     disable experiment tracking entirely. Setting more than one raises
     ``ConfigurationError``.
 
+    **Adding a new backend:** add a typed field here (e.g.
+    ``wandb: WandbConfig | None = None``) and a corresponding branch in
+    ``trainer_task._build_experiment_tracker``. When a second workflow task
+    (e.g. ``llm_trainer``) needs this class, extract it to
+    ``michelangelo.workflow.schema.experiment_tracker`` and import from there.
+
     Attributes:
         comet: Comet ML tracker configuration.
         mlflow: MLflow tracker configuration.

--- a/python/michelangelo/workflow/schema/tabular_trainer.py
+++ b/python/michelangelo/workflow/schema/tabular_trainer.py
@@ -1,0 +1,517 @@
+"""Configuration dataclasses for the tabular_trainer workflow task.
+
+These classes are the canonical configuration schema for ``train_tabular()``
+and its backends. Mirrors the structure of ``michelangelo.workflow.schema.pusher``
+— plain ``@dataclass`` with ``__post_init__`` validation; no Pydantic dependency.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+from michelangelo.workflow.schema.exceptions import ConfigurationError
+
+__all__ = [
+    "BatchIterConfig",
+    "CheckpointConfig",
+    "CheckpointScoreOrder",
+    "ColumnConfig",
+    "CometConfig",
+    "CustomTrainerConfig",
+    "DataloadingConfig",
+    "IncrementalTrainingModeConfig",
+    "LightningTrainerConfig",
+    "LightningTrainerKwargs",
+    "ParquetReadConfig",
+    "ScalingConfig",
+    "TabularTrainerConfig",
+    "TransferLearningSpecConfig",
+]
+
+
+class CheckpointScoreOrder(str, Enum):
+    """Sort order for checkpoint scoring.
+
+    Attributes:
+        MAX: Keep the checkpoint with the highest metric value.
+        MIN: Keep the checkpoint with the lowest metric value.
+
+    Example:
+        >>> CheckpointScoreOrder.MAX.value
+        'max'
+    """
+
+    MAX = "max"
+    MIN = "min"
+
+
+class IncrementalTrainingModeConfig(str, Enum):
+    """Incremental training mode for tabular_trainer.
+
+    Attributes:
+        NONE: No incremental training; train from scratch.
+        BASELINE: Use the initial model as a warm-start baseline and mark
+            the result as incrementally trained.
+
+    Example:
+        >>> IncrementalTrainingModeConfig.BASELINE.value
+        'BASELINE'
+    """
+
+    NONE = "NONE"
+    BASELINE = "BASELINE"
+
+
+@dataclass
+class ColumnConfig:
+    """Schema descriptor for a single model input, output, or label column.
+
+    Attributes:
+        data_type: PyTorch dtype string, e.g. ``"torch.float32"``.
+        shape: Tensor shape *excluding* the batch dimension, e.g.
+            ``[128]`` for a 128-element embedding. Defaults to ``[]``
+            (scalar).
+
+    Example:
+        >>> ColumnConfig(data_type="torch.float32", shape=[128])
+        ColumnConfig(data_type='torch.float32', shape=[128])
+    """
+
+    data_type: str
+    shape: list[int] = field(default_factory=list)
+
+
+@dataclass
+class CometConfig:
+    """Comet ML experiment tracking configuration.
+
+    All four fields are required when ``comet`` is set on
+    ``LightningTrainerConfig``.
+
+    Attributes:
+        api_key: Comet API key.
+        workspace: Comet workspace name.
+        project_name: Comet project name.
+        experiment_name: Comet experiment name.
+
+    Example:
+        >>> cfg = CometConfig(
+        ...     api_key="key",
+        ...     workspace="ws",
+        ...     project_name="proj",
+        ...     experiment_name="exp",
+        ... )
+    """
+
+    api_key: str
+    workspace: str
+    project_name: str
+    experiment_name: str
+
+
+@dataclass
+class ScalingConfig:
+    """Ray Train scaling configuration for distributed training.
+
+    Attributes:
+        cpu_per_worker: Number of CPU cores allocated per Ray Train worker.
+            Defaults to ``1``.
+
+    Example:
+        >>> ScalingConfig(cpu_per_worker=4)
+        ScalingConfig(cpu_per_worker=4)
+    """
+
+    cpu_per_worker: int = 1
+
+
+@dataclass
+class CheckpointConfig:
+    """Checkpoint retention and scoring configuration.
+
+    Mirrors ``ray.train.CheckpointConfig`` field-for-field with two additions
+    for future mid-epoch checkpointing (``save_every_n_steps``,
+    ``random_seed``). Both additions are gated in the dispatcher — setting
+    ``save_every_n_steps`` raises ``NotImplementedError`` at runtime until
+    the mid-epoch checkpoint planner is ported.
+
+    Attributes:
+        num_to_keep: Maximum number of checkpoints to retain. ``None`` keeps
+            all checkpoints; ``1`` (default) keeps only the best.
+        checkpoint_score_attribute: Metric key used to rank checkpoints.
+            ``None`` uses the last reported checkpoint.
+        checkpoint_score_order: Whether to maximise or minimise the score
+            attribute. Defaults to ``MAX``.
+        save_every_n_steps: Enable mid-epoch checkpointing every N global
+            steps. Must be ``>= 1`` when set. Currently gated — raises
+            ``NotImplementedError`` in the dispatcher.
+        random_seed: Optional shuffle seed for chunk-based mid-epoch reads.
+            Currently gated with ``save_every_n_steps``.
+
+    Raises:
+        ConfigurationError: If ``save_every_n_steps`` is set to a value
+            less than 1.
+
+    Example:
+        >>> CheckpointConfig(num_to_keep=3, checkpoint_score_attribute="val_loss",
+        ...                   checkpoint_score_order=CheckpointScoreOrder.MIN)
+        CheckpointConfig(num_to_keep=3, ...)
+    """
+
+    num_to_keep: int = 1
+    checkpoint_score_attribute: str | None = None
+    checkpoint_score_order: CheckpointScoreOrder = CheckpointScoreOrder.MAX
+    save_every_n_steps: int | None = None
+    random_seed: int | None = None
+
+    def __post_init__(self) -> None:
+        """Validate save_every_n_steps is a positive integer when set."""
+        if self.save_every_n_steps is not None and self.save_every_n_steps < 1:
+            raise ConfigurationError(
+                f"save_every_n_steps must be >= 1, got {self.save_every_n_steps}."
+            )
+
+
+@dataclass
+class ParquetReadConfig:
+    """Subset of ``ray.data.read_parquet`` kwargs forwarded at read time.
+
+    Only resource and schema-related knobs are exposed. Column projection is
+    derived automatically from ``input_columns``, ``labels``, and
+    ``metadata_columns`` — do not include ``columns`` here.
+
+    Attributes:
+        num_cpus: CPUs to reserve per parallel read worker.
+        num_gpus: GPUs to reserve per parallel read worker.
+        memory: Heap memory in bytes per read worker.
+        concurrency: Maximum number of concurrent Ray read tasks.
+        override_num_blocks: Override the number of output blocks.
+        shuffle: Set to ``"files"`` to randomly shuffle input file order.
+        tensor_column_schema: Column name → ``{"dtype": ..., "shape": ...}``
+            for serialised tensor columns.
+        arrow_parquet_args: Additional kwargs forwarded to PyArrow's reader.
+
+    Example:
+        >>> ParquetReadConfig(num_cpus=2, shuffle="files")
+        ParquetReadConfig(num_cpus=2, ...)
+    """
+
+    num_cpus: float | None = None
+    num_gpus: float | None = None
+    memory: int | None = None
+    concurrency: int | None = None
+    override_num_blocks: int | None = None
+    shuffle: str | None = None
+    tensor_column_schema: dict | None = None
+    arrow_parquet_args: dict | None = None
+
+
+@dataclass
+class BatchIterConfig:
+    """Configuration for ``ray.data.Dataset.iter_torch_batches``.
+
+    Attributes:
+        batch_size: Number of samples per batch. Required.
+        num_shuffle_batches: Number of batches to buffer for local
+            shuffling. ``0`` disables local shuffle.
+        collate_fn: Dotted import path to a collate function. When set,
+            the function is resolved at training time via ``get_module_attr``
+            and passed as ``collate_fn`` to ``iter_torch_batches``.
+
+    Example:
+        >>> BatchIterConfig(batch_size=64, num_shuffle_batches=4)
+        BatchIterConfig(batch_size=64, num_shuffle_batches=4, collate_fn=None)
+    """
+
+    batch_size: int
+    num_shuffle_batches: int = 0
+    collate_fn: str | None = None
+
+
+@dataclass
+class DataloadingConfig:
+    """Container for data reading and batch iteration settings.
+
+    Attributes:
+        parquet_read_config: kwargs forwarded to ``ray.data.read_parquet``.
+        batch_iter_config: Batch size, shuffle, and collate settings.
+
+    Example:
+        >>> DataloadingConfig(batch_iter_config=BatchIterConfig(batch_size=32))
+        DataloadingConfig(...)
+    """
+
+    parquet_read_config: ParquetReadConfig | None = None
+    batch_iter_config: BatchIterConfig | None = None
+
+
+@dataclass
+class LightningTrainerKwargs:
+    """Passthrough kwargs for ``lightning.pytorch.Trainer.__init__``.
+
+    All fields are optional and default to ``None`` (or the Lightning
+    default). Fields forwarded verbatim to the Trainer constructor after
+    any ``_count`` → ``limit_*_batches`` merge (int counts take precedence).
+
+    The ``limit_*_batches`` / ``limit_*_batches_count`` pairs are mutually
+    exclusive: setting both raises ``ConfigurationError``.
+
+    Attributes:
+        strategy: Distributed strategy name, e.g. ``"ddp"``, ``"fsdp"``,
+            ``"deepspeed"``.
+        strategy_kwargs: Extra kwargs forwarded to the strategy constructor.
+        precision: Training precision, e.g. ``"32"``, ``"bf16-mixed"``,
+            ``"16-mixed"``.
+        logger: Dotted import path to a ``Logger`` class or factory.
+        logger_kwargs: kwargs forwarded to the logger constructor.
+        callbacks: Dotted import path to a ``Callback`` class or factory
+            returning a list of callbacks.
+        callback_kwargs: kwargs forwarded to the callback constructor.
+        fast_dev_run: Run N batches for fast debugging. ``0`` disables.
+        max_epochs: Maximum number of training epochs.
+        min_epochs: Minimum number of training epochs.
+        max_steps: Maximum number of global training steps. ``-1`` is
+            unlimited.
+        min_steps: Minimum number of global training steps.
+        max_time: Maximum wall-clock time as ``"DD:HH:MM:SS"`` string.
+        limit_train_batches: Fraction of training batches to use each epoch.
+        limit_train_batches_count: Exact number of training batches per epoch.
+        limit_val_batches: Fraction of validation batches.
+        limit_val_batches_count: Exact number of validation batches.
+        limit_test_batches: Fraction of test batches.
+        limit_test_batches_count: Exact number of test batches.
+        limit_predict_batches: Fraction of prediction batches.
+        limit_predict_batches_count: Exact number of prediction batches.
+        overfit_batches: Fraction or count of batches to overfit on.
+        val_check_interval: Validation check frequency (fraction or steps).
+        check_val_every_n_epoch: Run validation every N epochs.
+        num_sanity_val_steps: Number of sanity-check validation steps.
+        log_every_n_steps: Logging frequency in global steps.
+        enable_progress_bar: Show or hide the training progress bar.
+        enable_model_summary: Show or hide the model summary at startup.
+        accumulate_grad_batches: Gradient accumulation steps.
+        gradient_clip_val: Max gradient norm for clipping.
+        gradient_clip_algorithm: Clipping algorithm, e.g. ``"norm"``.
+        deterministic: Force deterministic CUDA ops (``"True"`` / ``"False"``
+            / ``"warn"``).
+        benchmark: Enable cuDNN auto-tuner.
+        inference_mode: Use ``torch.inference_mode`` during validation.
+        use_distributed_sampler: Wrap the sampler for distributed training.
+        detect_anomaly: Enable autograd anomaly detection.
+        barebones: Disable all non-essential Lightning features.
+        plugins: Dotted import path to a plugin class or factory.
+        plugins_kwargs: kwargs forwarded to the plugins constructor.
+        sync_batchnorm: Synchronise batch normalisation across devices.
+        reload_dataloaders_every_n_epochs: Re-create dataloaders every N
+            epochs.
+        default_root_dir: Default directory for logs and checkpoints.
+
+    Raises:
+        ConfigurationError: If both a ``limit_*_batches`` float field and
+            its corresponding ``limit_*_batches_count`` int field are set.
+
+    Example:
+        >>> LightningTrainerKwargs(max_epochs=10, precision="bf16-mixed")
+        LightningTrainerKwargs(max_epochs=10, precision='bf16-mixed', ...)
+    """
+
+    strategy: str | None = None
+    strategy_kwargs: dict | None = None
+    precision: str | None = None
+    logger: str | None = None
+    logger_kwargs: dict | None = None
+    callbacks: str | None = None
+    callback_kwargs: dict | None = None
+    fast_dev_run: int = 0
+    max_epochs: int | None = None
+    min_epochs: int | None = None
+    max_steps: int = -1
+    min_steps: int | None = None
+    max_time: str | None = None
+    limit_train_batches: float | None = None
+    limit_train_batches_count: int | None = None
+    limit_val_batches: float | None = None
+    limit_val_batches_count: int | None = None
+    limit_test_batches: float | None = None
+    limit_test_batches_count: int | None = None
+    limit_predict_batches: float | None = None
+    limit_predict_batches_count: int | None = None
+    overfit_batches: float = 0.0
+    val_check_interval: float | None = None
+    check_val_every_n_epoch: int | None = 1
+    num_sanity_val_steps: int | None = None
+    log_every_n_steps: int | None = None
+    enable_progress_bar: bool | None = None
+    enable_model_summary: bool | None = None
+    accumulate_grad_batches: int = 1
+    gradient_clip_val: float | None = None
+    gradient_clip_algorithm: str | None = None
+    deterministic: str | None = None
+    benchmark: bool | None = None
+    inference_mode: bool = True
+    use_distributed_sampler: bool = True
+    detect_anomaly: bool = False
+    barebones: bool = False
+    plugins: str | None = None
+    plugins_kwargs: dict | None = None
+    sync_batchnorm: bool = False
+    reload_dataloaders_every_n_epochs: int = 0
+    default_root_dir: str | None = None
+
+    def __post_init__(self) -> None:
+        """Validate mutually exclusive limit_*_batches pairs."""
+        pairs = [
+            ("limit_train_batches", "limit_train_batches_count"),
+            ("limit_val_batches", "limit_val_batches_count"),
+            ("limit_test_batches", "limit_test_batches_count"),
+            ("limit_predict_batches", "limit_predict_batches_count"),
+        ]
+        for float_field, count_field in pairs:
+            if (
+                getattr(self, float_field) is not None
+                and getattr(self, count_field) is not None
+            ):
+                raise ConfigurationError(
+                    f"Cannot set both '{float_field}' and"
+                    f" '{count_field}' simultaneously."
+                )
+
+
+@dataclass
+class TransferLearningSpecConfig:
+    """Placeholder config for transfer-learning spec building.
+
+    Setting this field on ``LightningTrainerConfig`` raises
+    ``NotImplementedError`` in the dispatcher until the spec builder is
+    ported from the internal SDK.
+
+    Attributes:
+        transfer_learning_spec: Opaque dict forwarded to the internal
+            spec builder. Shape is intentionally untyped until the full
+            builder is available in OSS.
+
+    Example:
+        >>> TransferLearningSpecConfig(transfer_learning_spec={"layers": 3})
+        TransferLearningSpecConfig(transfer_learning_spec={'layers': 3})
+    """
+
+    transfer_learning_spec: dict | None = None
+
+
+@dataclass
+class CustomTrainerConfig:
+    """Configuration for a custom (non-Lightning) trainer backend.
+
+    Using this config raises ``NotImplementedError`` in the dispatcher until
+    the custom Ray trainer subsystem is ported from the internal SDK.
+
+    Attributes:
+        train_class: Dotted import path to the custom trainer class.
+        train_constructor_kwargs: Optional kwargs forwarded to the trainer
+            constructor.
+
+    Example:
+        >>> CustomTrainerConfig(train_class="myproject.trainers.MyTrainer")
+        CustomTrainerConfig(train_class='myproject.trainers.MyTrainer', ...)
+    """
+
+    train_class: str
+    train_constructor_kwargs: dict | None = None
+
+
+@dataclass
+class LightningTrainerConfig:
+    """Configuration for the PyTorch Lightning training backend.
+
+    All column maps (``input_columns``, ``output_columns``, ``labels``) use
+    column name as key and ``ColumnConfig`` as value.
+    ``metadata_columns`` names columns read from Parquet for logging and
+    callbacks but excluded from the model schema.
+
+    Attributes:
+        model_class: Dotted import path to a ``LightningModule`` subclass.
+        input_columns: Feature columns fed to the model.
+        output_columns: Model output columns included in the model schema.
+        labels: Target/label columns.
+        metadata_columns: Columns read for logging; excluded from schema.
+        checkpoint_config: Checkpoint retention settings.
+        model_kwargs: Extra kwargs forwarded to ``model_class.__init__``.
+        dataloading_config: Parquet read and batch iteration settings.
+        scaling_config: Ray Train worker resource allocation.
+        lightning_trainer_kwargs: Passthrough kwargs for
+            ``lightning.pytorch.Trainer``.
+        hyperparameters: Catch-all dict for kwargs not covered by the
+            structured fields. Highly discouraged; prefer structured fields.
+        comet: Comet ML experiment tracking. ``None`` disables Comet.
+        transfer_learning_spec: Transfer-learning spec config. Setting this
+            raises ``NotImplementedError`` until the spec builder is ported.
+        incremental_training_mode: Incremental training mode config.
+
+    Example:
+        >>> from michelangelo.workflow.schema.tabular_trainer import (
+        ...     LightningTrainerConfig, ColumnConfig
+        ... )
+        >>> cfg = LightningTrainerConfig(
+        ...     model_class="myproject.models.TabularNet",
+        ...     input_columns={"age": ColumnConfig("torch.float32")},
+        ...     output_columns={"score": ColumnConfig("torch.float32")},
+        ...     labels={"clicked": ColumnConfig("torch.long")},
+        ...     metadata_columns=["user_id"],
+        ... )
+    """
+
+    model_class: str
+    input_columns: dict[str, ColumnConfig]
+    output_columns: dict[str, ColumnConfig]
+    labels: dict[str, ColumnConfig]
+    metadata_columns: list[str]
+    checkpoint_config: CheckpointConfig = field(default_factory=CheckpointConfig)
+    model_kwargs: dict | None = None
+    dataloading_config: DataloadingConfig | None = None
+    scaling_config: ScalingConfig | None = None
+    lightning_trainer_kwargs: LightningTrainerKwargs | None = None
+    hyperparameters: dict | None = None
+    comet: CometConfig | None = None
+    transfer_learning_spec: TransferLearningSpecConfig | None = None
+    incremental_training_mode: IncrementalTrainingModeConfig | None = None
+
+
+@dataclass
+class TabularTrainerConfig:
+    """Top-level config for ``train_tabular()``.
+
+    Exactly one of ``lightning`` or ``custom`` must be set.
+
+    Attributes:
+        lightning: Config for the PyTorch Lightning backend.
+        custom: Config for a custom trainer backend (raises
+            ``NotImplementedError`` until ported).
+
+    Raises:
+        ConfigurationError: If neither or both backends are set.
+
+    Example:
+        >>> cfg = TabularTrainerConfig(
+        ...     lightning=LightningTrainerConfig(
+        ...         model_class="myproject.models.Net",
+        ...         input_columns={"x": ColumnConfig("torch.float32")},
+        ...         output_columns={"y": ColumnConfig("torch.float32")},
+        ...         labels={"label": ColumnConfig("torch.long")},
+        ...         metadata_columns=[],
+        ...     )
+        ... )
+    """
+
+    lightning: LightningTrainerConfig | None = None
+    custom: CustomTrainerConfig | None = None
+
+    def __post_init__(self) -> None:
+        """Validate that exactly one backend is configured."""
+        if (self.lightning is None) == (self.custom is None):
+            raise ConfigurationError(
+                "Exactly one of 'lightning' or 'custom' must be set on "
+                "TabularTrainerConfig, got "
+                f"lightning={'set' if self.lightning else 'None'}, "
+                f"custom={'set' if self.custom else 'None'}."
+            )

--- a/python/michelangelo/workflow/schema/tabular_trainer.py
+++ b/python/michelangelo/workflow/schema/tabular_trainer.py
@@ -20,9 +20,11 @@ __all__ = [
     "CometConfig",
     "CustomTrainerConfig",
     "DataloadingConfig",
+    "ExperimentTrackerConfig",
     "IncrementalTrainingModeConfig",
     "LightningTrainerConfig",
     "LightningTrainerKwargs",
+    "MlflowConfig",
     "ParquetReadConfig",
     "ScalingConfig",
     "TabularTrainerConfig",
@@ -86,7 +88,7 @@ class ColumnConfig:
 class CometConfig:
     """Comet ML experiment tracking configuration.
 
-    All four fields are required when ``comet`` is set on
+    Pass to ``ExperimentTrackerConfig(comet=CometConfig(...))`` on
     ``LightningTrainerConfig``.
 
     Attributes:
@@ -108,6 +110,87 @@ class CometConfig:
     workspace: str
     project_name: str
     experiment_name: str
+
+
+@dataclass
+class MlflowConfig:
+    """MLflow experiment tracking configuration.
+
+    Pass to ``ExperimentTrackerConfig(mlflow=MlflowConfig(...))`` on
+    ``LightningTrainerConfig``.
+
+    Attributes:
+        tracking_uri: MLflow tracking server URI, e.g.
+            ``"http://localhost:5000"`` or ``"sqlite:///mlflow.db"``.
+        experiment_name: Name of the MLflow experiment. Created automatically
+            if it does not exist.
+        run_name: Optional display name for this training run. Auto-generated
+            when ``None``.
+        tags: Key-value string tags attached to the MLflow run.
+
+    Example:
+        >>> cfg = MlflowConfig(
+        ...     tracking_uri="http://mlflow.example.com",
+        ...     experiment_name="tabular-ctr",
+        ...     run_name="xgb-baseline",
+        ... )
+    """
+
+    tracking_uri: str
+    experiment_name: str
+    run_name: str | None = None
+    tags: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class ExperimentTrackerConfig:
+    """Experiment tracking backend configuration.
+
+    Exactly zero or one tracker may be active at a time. Set neither to
+    disable experiment tracking entirely. Setting more than one raises
+    ``ConfigurationError``.
+
+    Attributes:
+        comet: Comet ML tracker configuration.
+        mlflow: MLflow tracker configuration.
+
+    Raises:
+        ConfigurationError: If more than one tracker backend is configured.
+            Set at most one of ``comet`` or ``mlflow``.
+
+    Example — Comet ML:
+        >>> ExperimentTrackerConfig(
+        ...     comet=CometConfig(
+        ...         api_key="key", workspace="ws",
+        ...         project_name="proj", experiment_name="exp",
+        ...     )
+        ... )
+
+    Example — MLflow:
+        >>> ExperimentTrackerConfig(
+        ...     mlflow=MlflowConfig(
+        ...         tracking_uri="http://mlflow.example.com",
+        ...         experiment_name="tabular-ctr",
+        ...     )
+        ... )
+    """
+
+    comet: CometConfig | None = None
+    mlflow: MlflowConfig | None = None
+
+    def __post_init__(self) -> None:
+        """Validate that at most one tracker backend is configured."""
+        active = [
+            name
+            for name, val in [("comet", self.comet), ("mlflow", self.mlflow)]
+            if val is not None
+        ]
+        if len(active) > 1:
+            raise ConfigurationError(
+                f"At most one experiment tracker can be set, got: {active}. "
+                "Choose one of ExperimentTrackerConfig(comet=...) or "
+                "ExperimentTrackerConfig(mlflow=...)."
+            )
 
 
 @dataclass
@@ -456,7 +539,8 @@ class LightningTrainerConfig:
             ``lightning.pytorch.Trainer``.
         hyperparameters: Catch-all dict for kwargs not covered by the
             structured fields. Highly discouraged; prefer structured fields.
-        comet: Comet ML experiment tracking. ``None`` disables Comet.
+        experiment_tracker: Experiment tracking backend (Comet ML or MLflow).
+            ``None`` disables experiment tracking.
         transfer_learning_spec: Transfer-learning spec config. Setting this
             raises ``NotImplementedError`` until the spec builder is ported.
         incremental_training_mode: Incremental training mode config.
@@ -485,7 +569,7 @@ class LightningTrainerConfig:
     scaling_config: ScalingConfig | None = None
     lightning_trainer_kwargs: LightningTrainerKwargs | None = None
     hyperparameters: dict | None = None
-    comet: CometConfig | None = None
+    experiment_tracker: ExperimentTrackerConfig | None = None
     transfer_learning_spec: TransferLearningSpecConfig | None = None
     incremental_training_mode: IncrementalTrainingModeConfig | None = None
 
@@ -545,6 +629,12 @@ class TabularTrainerConfig:
         ...             precision="bf16-mixed",
         ...         ),
         ...         scaling_config=ScalingConfig(cpu_per_worker=4),
+        ...         experiment_tracker=ExperimentTrackerConfig(
+        ...             mlflow=MlflowConfig(
+        ...                 tracking_uri="http://mlflow.example.com",
+        ...                 experiment_name="tabular-ctr",
+        ...             ),
+        ...         ),
         ...     )
         ... )
     """

--- a/python/michelangelo/workflow/schema/tabular_trainer.py
+++ b/python/michelangelo/workflow/schema/tabular_trainer.py
@@ -11,6 +11,11 @@ from dataclasses import dataclass, field
 from enum import Enum
 
 from michelangelo.workflow.schema.exceptions import ConfigurationError
+from michelangelo.workflow.schema.ray_data_io import (
+    BatchIterConfig,
+    DataloadingConfig,
+    ParquetReadConfig,
+)
 
 __all__ = [
     "BatchIterConfig",
@@ -262,84 +267,6 @@ class CheckpointConfig:
                 f"save_every_n_steps must be >= 1, got {self.save_every_n_steps}."
                 " Set it to None to disable mid-epoch checkpointing."
             )
-
-
-@dataclass
-class ParquetReadConfig:
-    """Subset of ``ray.data.read_parquet`` kwargs forwarded at read time.
-
-    This is a curated subset of the full ``ray.data.read_parquet`` API —
-    resource knobs and schema hints only. Fields that overlap with the
-    tabular_trainer's own column management (``columns``, ``paths``) and
-    Ray-version-specific placement logic are intentionally omitted. OSS
-    pins a single Ray version so the internal ``<2.50`` branch is unused.
-
-    Column projection is derived automatically from ``input_columns``,
-    ``labels``, and ``metadata_columns`` — do not include ``columns`` here.
-
-    Attributes:
-        num_cpus: CPUs to reserve per parallel read worker.
-        num_gpus: GPUs to reserve per parallel read worker.
-        memory: Heap memory in bytes per read worker.
-        concurrency: Maximum number of concurrent Ray read tasks.
-        override_num_blocks: Override the number of output blocks.
-        shuffle: Set to ``"files"`` to randomly shuffle input file order.
-        tensor_column_schema: Column name → ``{"dtype": ..., "shape": ...}``
-            for serialised tensor columns.
-        arrow_parquet_args: Additional kwargs forwarded to PyArrow's reader.
-
-    Example:
-        >>> ParquetReadConfig(num_cpus=2, shuffle="files")
-        ParquetReadConfig(num_cpus=2, ...)
-    """
-
-    num_cpus: float | None = None
-    num_gpus: float | None = None
-    memory: int | None = None
-    concurrency: int | None = None
-    override_num_blocks: int | None = None
-    shuffle: str | None = None
-    tensor_column_schema: dict | None = None
-    arrow_parquet_args: dict | None = None
-
-
-@dataclass
-class BatchIterConfig:
-    """Configuration for ``ray.data.Dataset.iter_torch_batches``.
-
-    Attributes:
-        batch_size: Number of samples per batch. Required.
-        num_shuffle_batches: Number of batches to buffer for local
-            shuffling. ``0`` disables local shuffle.
-        collate_fn: Dotted import path to a collate function. When set,
-            the function is resolved at training time via ``get_module_attr``
-            and passed as ``collate_fn`` to ``iter_torch_batches``.
-
-    Example:
-        >>> BatchIterConfig(batch_size=64, num_shuffle_batches=4)
-        BatchIterConfig(batch_size=64, num_shuffle_batches=4, collate_fn=None)
-    """
-
-    batch_size: int
-    num_shuffle_batches: int = 0
-    collate_fn: str | None = None
-
-
-@dataclass
-class DataloadingConfig:
-    """Container for data reading and batch iteration settings.
-
-    Attributes:
-        parquet_read_config: kwargs forwarded to ``ray.data.read_parquet``.
-        batch_iter_config: Batch size, shuffle, and collate settings.
-
-    Example:
-        >>> DataloadingConfig(batch_iter_config=BatchIterConfig(batch_size=32))
-        DataloadingConfig(...)
-    """
-
-    parquet_read_config: ParquetReadConfig | None = None
-    batch_iter_config: BatchIterConfig | None = None
 
 
 @dataclass

--- a/python/michelangelo/workflow/schema/tests/ray_data_io_test.py
+++ b/python/michelangelo/workflow/schema/tests/ray_data_io_test.py
@@ -1,0 +1,90 @@
+"""Tests for michelangelo.workflow.schema.ray_data_io dataclasses."""
+
+from __future__ import annotations
+
+from unittest import TestCase
+
+from michelangelo.workflow.schema.ray_data_io import (
+    BatchIterConfig,
+    DataloadingConfig,
+    ParquetReadConfig,
+)
+
+# ---------------------------------------------------------------------------
+# ParquetReadConfig
+# ---------------------------------------------------------------------------
+
+
+class TestParquetReadConfig(TestCase):
+    """Tests for ParquetReadConfig dataclass."""
+
+    def test_all_none_by_default(self):
+        """All optional fields default to None."""
+        cfg = ParquetReadConfig()
+        for attr in (
+            "num_cpus",
+            "num_gpus",
+            "memory",
+            "concurrency",
+            "override_num_blocks",
+            "shuffle",
+            "tensor_column_schema",
+            "arrow_parquet_args",
+        ):
+            self.assertIsNone(getattr(cfg, attr), msg=f"{attr} should be None")
+
+    def test_fields_stored(self):
+        """It stores provided values."""
+        cfg = ParquetReadConfig(num_cpus=2.0, shuffle="files", concurrency=4)
+        self.assertEqual(cfg.num_cpus, 2.0)
+        self.assertEqual(cfg.shuffle, "files")
+        self.assertEqual(cfg.concurrency, 4)
+
+
+# ---------------------------------------------------------------------------
+# BatchIterConfig
+# ---------------------------------------------------------------------------
+
+
+class TestBatchIterConfig(TestCase):
+    """Tests for BatchIterConfig dataclass."""
+
+    def test_required_batch_size(self):
+        """batch_size is required; rest default."""
+        cfg = BatchIterConfig(batch_size=64)
+        self.assertEqual(cfg.batch_size, 64)
+        self.assertEqual(cfg.num_shuffle_batches, 0)
+        self.assertIsNone(cfg.collate_fn)
+
+    def test_all_fields(self):
+        """It stores all fields."""
+        cfg = BatchIterConfig(
+            batch_size=32,
+            num_shuffle_batches=4,
+            collate_fn="myproject.collate.fn",
+        )
+        self.assertEqual(cfg.num_shuffle_batches, 4)
+        self.assertEqual(cfg.collate_fn, "myproject.collate.fn")
+
+
+# ---------------------------------------------------------------------------
+# DataloadingConfig
+# ---------------------------------------------------------------------------
+
+
+class TestDataloadingConfig(TestCase):
+    """Tests for DataloadingConfig dataclass."""
+
+    def test_all_none_by_default(self):
+        """Both optional fields default to None."""
+        cfg = DataloadingConfig()
+        self.assertIsNone(cfg.parquet_read_config)
+        self.assertIsNone(cfg.batch_iter_config)
+
+    def test_fields_stored(self):
+        """It stores provided sub-configs."""
+        pr = ParquetReadConfig(shuffle="files")
+        bi = BatchIterConfig(batch_size=32)
+        cfg = DataloadingConfig(parquet_read_config=pr, batch_iter_config=bi)
+        self.assertIs(cfg.parquet_read_config, pr)
+        self.assertIs(cfg.batch_iter_config, bi)

--- a/python/michelangelo/workflow/schema/tests/tabular_trainer_test.py
+++ b/python/michelangelo/workflow/schema/tests/tabular_trainer_test.py
@@ -13,9 +13,11 @@ from michelangelo.workflow.schema.tabular_trainer import (
     CometConfig,
     CustomTrainerConfig,
     DataloadingConfig,
+    ExperimentTrackerConfig,
     IncrementalTrainingModeConfig,
     LightningTrainerConfig,
     LightningTrainerKwargs,
+    MlflowConfig,
     ParquetReadConfig,
     ScalingConfig,
     TabularTrainerConfig,
@@ -348,6 +350,96 @@ class TestCustomTrainerConfig(TestCase):
 
 
 # ---------------------------------------------------------------------------
+# MlflowConfig
+# ---------------------------------------------------------------------------
+
+
+class TestMlflowConfig(TestCase):
+    """Tests for MlflowConfig dataclass."""
+
+    def test_required_fields(self):
+        """tracking_uri and experiment_name are required; rest default."""
+        cfg = MlflowConfig(
+            tracking_uri="http://mlflow.example.com",
+            experiment_name="tabular-ctr",
+        )
+        self.assertEqual(cfg.tracking_uri, "http://mlflow.example.com")
+        self.assertEqual(cfg.experiment_name, "tabular-ctr")
+        self.assertIsNone(cfg.run_name)
+        self.assertEqual(cfg.tags, {})
+
+    def test_all_fields_stored(self):
+        """It stores all optional fields when provided."""
+        cfg = MlflowConfig(
+            tracking_uri="sqlite:///mlflow.db",
+            experiment_name="exp",
+            run_name="run-1",
+            tags={"env": "prod"},
+        )
+        self.assertEqual(cfg.run_name, "run-1")
+        self.assertEqual(cfg.tags, {"env": "prod"})
+
+    def test_tags_instances_are_independent(self):
+        """Default tags dicts are not shared between instances."""
+        a = MlflowConfig(tracking_uri="u", experiment_name="e")
+        b = MlflowConfig(tracking_uri="u", experiment_name="e")
+        a.tags["key"] = "val"
+        self.assertEqual(b.tags, {})
+
+
+# ---------------------------------------------------------------------------
+# ExperimentTrackerConfig
+# ---------------------------------------------------------------------------
+
+
+class TestExperimentTrackerConfig(TestCase):
+    """Tests for ExperimentTrackerConfig validation."""
+
+    def _comet(self) -> CometConfig:
+        return CometConfig(
+            api_key="k", workspace="ws", project_name="p", experiment_name="e"
+        )
+
+    def _mlflow(self) -> MlflowConfig:
+        return MlflowConfig(
+            tracking_uri="http://mlflow.example.com", experiment_name="exp"
+        )
+
+    def test_no_tracker_ok(self):
+        """Setting neither tracker is valid (no tracking)."""
+        cfg = ExperimentTrackerConfig()
+        self.assertIsNone(cfg.comet)
+        self.assertIsNone(cfg.mlflow)
+
+    def test_comet_only_ok(self):
+        """Setting only comet is valid."""
+        comet = self._comet()
+        cfg = ExperimentTrackerConfig(comet=comet)
+        self.assertIs(cfg.comet, comet)
+        self.assertIsNone(cfg.mlflow)
+
+    def test_mlflow_only_ok(self):
+        """Setting only mlflow is valid."""
+        mlflow = self._mlflow()
+        cfg = ExperimentTrackerConfig(mlflow=mlflow)
+        self.assertIs(cfg.mlflow, mlflow)
+        self.assertIsNone(cfg.comet)
+
+    def test_both_raises(self):
+        """Setting both comet and mlflow raises ConfigurationError."""
+        with self.assertRaises(ConfigurationError):
+            ExperimentTrackerConfig(comet=self._comet(), mlflow=self._mlflow())
+
+    def test_both_error_message(self):
+        """Error message names both active trackers and suggests the fix."""
+        with self.assertRaises(ConfigurationError) as ctx:
+            ExperimentTrackerConfig(comet=self._comet(), mlflow=self._mlflow())
+        msg = str(ctx.exception)
+        self.assertIn("comet", msg)
+        self.assertIn("mlflow", msg)
+
+
+# ---------------------------------------------------------------------------
 # LightningTrainerConfig
 # ---------------------------------------------------------------------------
 
@@ -380,23 +472,26 @@ class TestLightningTrainerConfig(TestCase):
         self.assertIsNone(cfg.scaling_config)
         self.assertIsNone(cfg.lightning_trainer_kwargs)
         self.assertIsNone(cfg.hyperparameters)
-        self.assertIsNone(cfg.comet)
+        self.assertIsNone(cfg.experiment_tracker)
         self.assertIsNone(cfg.transfer_learning_spec)
         self.assertIsNone(cfg.incremental_training_mode)
 
     def test_optional_fields_stored(self):
         """It stores all optional fields when provided."""
-        comet = CometConfig(
-            api_key="k", workspace="ws", project_name="p", experiment_name="e"
+        tracker = ExperimentTrackerConfig(
+            mlflow=MlflowConfig(
+                tracking_uri="http://mlflow.example.com",
+                experiment_name="tabular-ctr",
+            )
         )
         scaling = ScalingConfig(cpu_per_worker=4)
         cfg = _minimal_lightning_config(
-            comet=comet,
+            experiment_tracker=tracker,
             scaling_config=scaling,
             hyperparameters={"lr": 0.001},
             incremental_training_mode=IncrementalTrainingModeConfig.BASELINE,
         )
-        self.assertIs(cfg.comet, comet)
+        self.assertIs(cfg.experiment_tracker, tracker)
         self.assertIs(cfg.scaling_config, scaling)
         self.assertEqual(cfg.hyperparameters, {"lr": 0.001})
         self.assertEqual(

--- a/python/michelangelo/workflow/schema/tests/tabular_trainer_test.py
+++ b/python/michelangelo/workflow/schema/tests/tabular_trainer_test.py
@@ -1,0 +1,456 @@
+"""Tests for michelangelo.workflow.schema.tabular_trainer config dataclasses."""
+
+from __future__ import annotations
+
+from unittest import TestCase
+
+from michelangelo.workflow.schema.exceptions import ConfigurationError
+from michelangelo.workflow.schema.tabular_trainer import (
+    BatchIterConfig,
+    CheckpointConfig,
+    CheckpointScoreOrder,
+    ColumnConfig,
+    CometConfig,
+    CustomTrainerConfig,
+    DataloadingConfig,
+    IncrementalTrainingModeConfig,
+    LightningTrainerConfig,
+    LightningTrainerKwargs,
+    ParquetReadConfig,
+    ScalingConfig,
+    TabularTrainerConfig,
+)
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class TestCheckpointScoreOrder(TestCase):
+    """Tests for CheckpointScoreOrder enum."""
+
+    def test_values(self):
+        """It exposes 'max' and 'min' string values."""
+        self.assertEqual(CheckpointScoreOrder.MAX.value, "max")
+        self.assertEqual(CheckpointScoreOrder.MIN.value, "min")
+
+    def test_is_str_subclass(self):
+        """It is a str subclass and compares equal to its value."""
+        self.assertEqual(CheckpointScoreOrder.MAX, "max")
+        self.assertIsInstance(CheckpointScoreOrder.MIN, str)
+
+
+class TestIncrementalTrainingModeConfig(TestCase):
+    """Tests for IncrementalTrainingModeConfig enum."""
+
+    def test_values(self):
+        """It exposes 'NONE' and 'BASELINE' string values."""
+        self.assertEqual(IncrementalTrainingModeConfig.NONE.value, "NONE")
+        self.assertEqual(IncrementalTrainingModeConfig.BASELINE.value, "BASELINE")
+
+    def test_is_str_subclass(self):
+        """It is a str subclass."""
+        self.assertIsInstance(IncrementalTrainingModeConfig.NONE, str)
+
+
+# ---------------------------------------------------------------------------
+# ColumnConfig
+# ---------------------------------------------------------------------------
+
+
+class TestColumnConfig(TestCase):
+    """Tests for ColumnConfig dataclass."""
+
+    def test_required_data_type(self):
+        """It stores data_type and defaults shape to []."""
+        cfg = ColumnConfig(data_type="torch.float32")
+        self.assertEqual(cfg.data_type, "torch.float32")
+        self.assertEqual(cfg.shape, [])
+
+    def test_shape_stored(self):
+        """It stores an explicit shape."""
+        cfg = ColumnConfig(data_type="torch.long", shape=[128])
+        self.assertEqual(cfg.shape, [128])
+
+    def test_shape_instances_are_independent(self):
+        """Default shape lists are not shared between instances."""
+        a = ColumnConfig(data_type="torch.float32")
+        b = ColumnConfig(data_type="torch.float32")
+        a.shape.append(1)
+        self.assertEqual(b.shape, [])
+
+
+# ---------------------------------------------------------------------------
+# CometConfig
+# ---------------------------------------------------------------------------
+
+
+class TestCometConfig(TestCase):
+    """Tests for CometConfig dataclass."""
+
+    def test_all_fields_stored(self):
+        """It stores all four required fields."""
+        cfg = CometConfig(
+            api_key="k", workspace="ws", project_name="proj", experiment_name="exp"
+        )
+        self.assertEqual(cfg.api_key, "k")
+        self.assertEqual(cfg.workspace, "ws")
+        self.assertEqual(cfg.project_name, "proj")
+        self.assertEqual(cfg.experiment_name, "exp")
+
+
+# ---------------------------------------------------------------------------
+# ScalingConfig
+# ---------------------------------------------------------------------------
+
+
+class TestScalingConfig(TestCase):
+    """Tests for ScalingConfig dataclass."""
+
+    def test_default_cpu_per_worker(self):
+        """cpu_per_worker defaults to 1."""
+        self.assertEqual(ScalingConfig().cpu_per_worker, 1)
+
+    def test_explicit_cpu_per_worker(self):
+        """It stores an explicit value."""
+        self.assertEqual(ScalingConfig(cpu_per_worker=4).cpu_per_worker, 4)
+
+
+# ---------------------------------------------------------------------------
+# CheckpointConfig
+# ---------------------------------------------------------------------------
+
+
+class TestCheckpointConfig(TestCase):
+    """Tests for CheckpointConfig dataclass."""
+
+    def test_defaults(self):
+        """It defaults num_to_keep=1, MAX order, no attribute or steps."""
+        cfg = CheckpointConfig()
+        self.assertEqual(cfg.num_to_keep, 1)
+        self.assertIsNone(cfg.checkpoint_score_attribute)
+        self.assertEqual(cfg.checkpoint_score_order, CheckpointScoreOrder.MAX)
+        self.assertIsNone(cfg.save_every_n_steps)
+        self.assertIsNone(cfg.random_seed)
+
+    def test_explicit_fields(self):
+        """It stores explicit values for all fields."""
+        cfg = CheckpointConfig(
+            num_to_keep=3,
+            checkpoint_score_attribute="val_loss",
+            checkpoint_score_order=CheckpointScoreOrder.MIN,
+            random_seed=42,
+        )
+        self.assertEqual(cfg.num_to_keep, 3)
+        self.assertEqual(cfg.checkpoint_score_attribute, "val_loss")
+        self.assertEqual(cfg.checkpoint_score_order, CheckpointScoreOrder.MIN)
+        self.assertEqual(cfg.random_seed, 42)
+
+    def test_save_every_n_steps_zero_raises(self):
+        """save_every_n_steps=0 raises ConfigurationError."""
+        with self.assertRaises(
+            ConfigurationError, msg="save_every_n_steps must be >= 1"
+        ):
+            CheckpointConfig(save_every_n_steps=0)
+
+    def test_save_every_n_steps_negative_raises(self):
+        """Negative save_every_n_steps raises ConfigurationError."""
+        with self.assertRaises(ConfigurationError):
+            CheckpointConfig(save_every_n_steps=-5)
+
+    def test_save_every_n_steps_one_ok(self):
+        """save_every_n_steps=1 is valid."""
+        cfg = CheckpointConfig(save_every_n_steps=1)
+        self.assertEqual(cfg.save_every_n_steps, 1)
+
+    def test_save_every_n_steps_none_ok(self):
+        """save_every_n_steps=None (default) does not raise."""
+        CheckpointConfig(save_every_n_steps=None)
+
+
+# ---------------------------------------------------------------------------
+# ParquetReadConfig
+# ---------------------------------------------------------------------------
+
+
+class TestParquetReadConfig(TestCase):
+    """Tests for ParquetReadConfig dataclass."""
+
+    def test_all_none_by_default(self):
+        """All optional fields default to None."""
+        cfg = ParquetReadConfig()
+        for attr in (
+            "num_cpus",
+            "num_gpus",
+            "memory",
+            "concurrency",
+            "override_num_blocks",
+            "shuffle",
+            "tensor_column_schema",
+            "arrow_parquet_args",
+        ):
+            self.assertIsNone(getattr(cfg, attr), msg=f"{attr} should be None")
+
+    def test_fields_stored(self):
+        """It stores provided values."""
+        cfg = ParquetReadConfig(num_cpus=2.0, shuffle="files", concurrency=4)
+        self.assertEqual(cfg.num_cpus, 2.0)
+        self.assertEqual(cfg.shuffle, "files")
+        self.assertEqual(cfg.concurrency, 4)
+
+
+# ---------------------------------------------------------------------------
+# BatchIterConfig
+# ---------------------------------------------------------------------------
+
+
+class TestBatchIterConfig(TestCase):
+    """Tests for BatchIterConfig dataclass."""
+
+    def test_required_batch_size(self):
+        """batch_size is required."""
+        cfg = BatchIterConfig(batch_size=64)
+        self.assertEqual(cfg.batch_size, 64)
+        self.assertEqual(cfg.num_shuffle_batches, 0)
+        self.assertIsNone(cfg.collate_fn)
+
+    def test_all_fields(self):
+        """It stores all fields."""
+        cfg = BatchIterConfig(
+            batch_size=32,
+            num_shuffle_batches=4,
+            collate_fn="myproject.collate.fn",
+        )
+        self.assertEqual(cfg.num_shuffle_batches, 4)
+        self.assertEqual(cfg.collate_fn, "myproject.collate.fn")
+
+
+# ---------------------------------------------------------------------------
+# DataloadingConfig
+# ---------------------------------------------------------------------------
+
+
+class TestDataloadingConfig(TestCase):
+    """Tests for DataloadingConfig dataclass."""
+
+    def test_all_none_by_default(self):
+        """Both optional fields default to None."""
+        cfg = DataloadingConfig()
+        self.assertIsNone(cfg.parquet_read_config)
+        self.assertIsNone(cfg.batch_iter_config)
+
+    def test_fields_stored(self):
+        """It stores provided sub-configs."""
+        pr = ParquetReadConfig(shuffle="files")
+        bi = BatchIterConfig(batch_size=32)
+        cfg = DataloadingConfig(parquet_read_config=pr, batch_iter_config=bi)
+        self.assertIs(cfg.parquet_read_config, pr)
+        self.assertIs(cfg.batch_iter_config, bi)
+
+
+# ---------------------------------------------------------------------------
+# LightningTrainerKwargs
+# ---------------------------------------------------------------------------
+
+
+class TestLightningTrainerKwargs(TestCase):
+    """Tests for LightningTrainerKwargs validation and defaults."""
+
+    def test_defaults(self):
+        """All optional fields default correctly."""
+        cfg = LightningTrainerKwargs()
+        self.assertIsNone(cfg.strategy)
+        self.assertIsNone(cfg.precision)
+        self.assertEqual(cfg.fast_dev_run, 0)
+        self.assertEqual(cfg.max_steps, -1)
+        self.assertTrue(cfg.inference_mode)
+        self.assertTrue(cfg.use_distributed_sampler)
+        self.assertFalse(cfg.detect_anomaly)
+        self.assertFalse(cfg.barebones)
+        self.assertEqual(cfg.accumulate_grad_batches, 1)
+        self.assertEqual(cfg.overfit_batches, 0.0)
+
+    def test_explicit_fields_stored(self):
+        """It stores explicit values."""
+        cfg = LightningTrainerKwargs(
+            strategy="ddp", max_epochs=10, precision="bf16-mixed"
+        )
+        self.assertEqual(cfg.strategy, "ddp")
+        self.assertEqual(cfg.max_epochs, 10)
+        self.assertEqual(cfg.precision, "bf16-mixed")
+
+    def test_limit_train_both_raises(self):
+        """Setting both limit_train_batches and limit_train_batches_count raises."""
+        with self.assertRaises(ConfigurationError):
+            LightningTrainerKwargs(
+                limit_train_batches=0.5, limit_train_batches_count=100
+            )
+
+    def test_limit_val_both_raises(self):
+        """Setting both limit_val_batches and limit_val_batches_count raises."""
+        with self.assertRaises(ConfigurationError):
+            LightningTrainerKwargs(limit_val_batches=0.1, limit_val_batches_count=10)
+
+    def test_limit_test_both_raises(self):
+        """Setting both limit_test_batches and limit_test_batches_count raises."""
+        with self.assertRaises(ConfigurationError):
+            LightningTrainerKwargs(limit_test_batches=0.2, limit_test_batches_count=5)
+
+    def test_limit_predict_both_raises(self):
+        """Setting both limit_predict_batches and limit_predict_batches_count raises."""
+        with self.assertRaises(ConfigurationError):
+            LightningTrainerKwargs(
+                limit_predict_batches=0.3, limit_predict_batches_count=20
+            )
+
+    def test_limit_train_float_only_ok(self):
+        """Setting only limit_train_batches (no count) is valid."""
+        cfg = LightningTrainerKwargs(limit_train_batches=0.8)
+        self.assertEqual(cfg.limit_train_batches, 0.8)
+        self.assertIsNone(cfg.limit_train_batches_count)
+
+    def test_limit_train_count_only_ok(self):
+        """Setting only limit_train_batches_count (no float) is valid."""
+        cfg = LightningTrainerKwargs(limit_train_batches_count=100)
+        self.assertEqual(cfg.limit_train_batches_count, 100)
+        self.assertIsNone(cfg.limit_train_batches)
+
+    def test_mixed_pairs_ok(self):
+        """Setting float for train and count for val (different pairs) is valid."""
+        cfg = LightningTrainerKwargs(
+            limit_train_batches=0.5, limit_val_batches_count=10
+        )
+        self.assertEqual(cfg.limit_train_batches, 0.5)
+        self.assertEqual(cfg.limit_val_batches_count, 10)
+
+
+# ---------------------------------------------------------------------------
+# CustomTrainerConfig
+# ---------------------------------------------------------------------------
+
+
+class TestCustomTrainerConfig(TestCase):
+    """Tests for CustomTrainerConfig dataclass."""
+
+    def test_required_train_class(self):
+        """train_class is stored; train_constructor_kwargs defaults to None."""
+        cfg = CustomTrainerConfig(train_class="myproject.MyTrainer")
+        self.assertEqual(cfg.train_class, "myproject.MyTrainer")
+        self.assertIsNone(cfg.train_constructor_kwargs)
+
+    def test_kwargs_stored(self):
+        """train_constructor_kwargs is stored when provided."""
+        cfg = CustomTrainerConfig(
+            train_class="myproject.MyTrainer",
+            train_constructor_kwargs={"lr": 0.01},
+        )
+        self.assertEqual(cfg.train_constructor_kwargs, {"lr": 0.01})
+
+
+# ---------------------------------------------------------------------------
+# LightningTrainerConfig
+# ---------------------------------------------------------------------------
+
+
+def _minimal_lightning_config(**overrides) -> LightningTrainerConfig:
+    """Build a minimal valid LightningTrainerConfig."""
+    defaults = {
+        "model_class": "myproject.models.Net",
+        "input_columns": {"x": ColumnConfig("torch.float32")},
+        "output_columns": {"y": ColumnConfig("torch.float32")},
+        "labels": {"label": ColumnConfig("torch.long")},
+        "metadata_columns": [],
+    }
+    defaults.update(overrides)
+    return LightningTrainerConfig(**defaults)
+
+
+class TestLightningTrainerConfig(TestCase):
+    """Tests for LightningTrainerConfig dataclass."""
+
+    def test_required_fields_stored(self):
+        """It stores all required fields and uses correct defaults."""
+        cfg = _minimal_lightning_config()
+        self.assertEqual(cfg.model_class, "myproject.models.Net")
+        self.assertEqual(cfg.input_columns, {"x": ColumnConfig("torch.float32")})
+        self.assertEqual(cfg.metadata_columns, [])
+        self.assertIsInstance(cfg.checkpoint_config, CheckpointConfig)
+        self.assertIsNone(cfg.model_kwargs)
+        self.assertIsNone(cfg.dataloading_config)
+        self.assertIsNone(cfg.scaling_config)
+        self.assertIsNone(cfg.lightning_trainer_kwargs)
+        self.assertIsNone(cfg.hyperparameters)
+        self.assertIsNone(cfg.comet)
+        self.assertIsNone(cfg.transfer_learning_spec)
+        self.assertIsNone(cfg.incremental_training_mode)
+
+    def test_optional_fields_stored(self):
+        """It stores all optional fields when provided."""
+        comet = CometConfig(
+            api_key="k", workspace="ws", project_name="p", experiment_name="e"
+        )
+        scaling = ScalingConfig(cpu_per_worker=4)
+        cfg = _minimal_lightning_config(
+            comet=comet,
+            scaling_config=scaling,
+            hyperparameters={"lr": 0.001},
+            incremental_training_mode=IncrementalTrainingModeConfig.BASELINE,
+        )
+        self.assertIs(cfg.comet, comet)
+        self.assertIs(cfg.scaling_config, scaling)
+        self.assertEqual(cfg.hyperparameters, {"lr": 0.001})
+        self.assertEqual(
+            cfg.incremental_training_mode, IncrementalTrainingModeConfig.BASELINE
+        )
+
+    def test_checkpoint_config_default_is_independent(self):
+        """Default CheckpointConfig instances are not shared."""
+        a = _minimal_lightning_config()
+        b = _minimal_lightning_config()
+        self.assertIsNot(a.checkpoint_config, b.checkpoint_config)
+
+
+# ---------------------------------------------------------------------------
+# TabularTrainerConfig
+# ---------------------------------------------------------------------------
+
+
+class TestTabularTrainerConfig(TestCase):
+    """Tests for TabularTrainerConfig validation."""
+
+    def _lightning_cfg(self) -> LightningTrainerConfig:
+        return _minimal_lightning_config()
+
+    def test_lightning_only_ok(self):
+        """Setting only lightning is valid."""
+        cfg = TabularTrainerConfig(lightning=self._lightning_cfg())
+        self.assertIsNotNone(cfg.lightning)
+        self.assertIsNone(cfg.custom)
+
+    def test_custom_only_ok(self):
+        """Setting only custom is valid."""
+        cfg = TabularTrainerConfig(
+            custom=CustomTrainerConfig(train_class="myproject.Trainer")
+        )
+        self.assertIsNone(cfg.lightning)
+        self.assertIsNotNone(cfg.custom)
+
+    def test_neither_raises(self):
+        """Setting neither raises ConfigurationError."""
+        with self.assertRaises(ConfigurationError):
+            TabularTrainerConfig()
+
+    def test_both_raises(self):
+        """Setting both raises ConfigurationError."""
+        with self.assertRaises(ConfigurationError):
+            TabularTrainerConfig(
+                lightning=self._lightning_cfg(),
+                custom=CustomTrainerConfig(train_class="myproject.Trainer"),
+            )
+
+    def test_error_message_neither(self):
+        """ConfigurationError message mentions 'lightning' and 'custom'."""
+        with self.assertRaises(ConfigurationError) as ctx:
+            TabularTrainerConfig()
+        self.assertIn("lightning", str(ctx.exception))
+        self.assertIn("custom", str(ctx.exception))

--- a/python/michelangelo/workflow/schema/tests/tabular_trainer_test.py
+++ b/python/michelangelo/workflow/schema/tests/tabular_trainer_test.py
@@ -6,19 +6,16 @@ from unittest import TestCase
 
 from michelangelo.workflow.schema.exceptions import ConfigurationError
 from michelangelo.workflow.schema.tabular_trainer import (
-    BatchIterConfig,
     CheckpointConfig,
     CheckpointScoreOrder,
     ColumnConfig,
     CometConfig,
     CustomTrainerConfig,
-    DataloadingConfig,
     ExperimentTrackerConfig,
     IncrementalTrainingModeConfig,
     LightningTrainerConfig,
     LightningTrainerKwargs,
     MlflowConfig,
-    ParquetReadConfig,
     ScalingConfig,
     TabularTrainerConfig,
 )
@@ -168,86 +165,6 @@ class TestCheckpointConfig(TestCase):
     def test_save_every_n_steps_none_ok(self):
         """save_every_n_steps=None (default) does not raise."""
         CheckpointConfig(save_every_n_steps=None)
-
-
-# ---------------------------------------------------------------------------
-# ParquetReadConfig
-# ---------------------------------------------------------------------------
-
-
-class TestParquetReadConfig(TestCase):
-    """Tests for ParquetReadConfig dataclass."""
-
-    def test_all_none_by_default(self):
-        """All optional fields default to None."""
-        cfg = ParquetReadConfig()
-        for attr in (
-            "num_cpus",
-            "num_gpus",
-            "memory",
-            "concurrency",
-            "override_num_blocks",
-            "shuffle",
-            "tensor_column_schema",
-            "arrow_parquet_args",
-        ):
-            self.assertIsNone(getattr(cfg, attr), msg=f"{attr} should be None")
-
-    def test_fields_stored(self):
-        """It stores provided values."""
-        cfg = ParquetReadConfig(num_cpus=2.0, shuffle="files", concurrency=4)
-        self.assertEqual(cfg.num_cpus, 2.0)
-        self.assertEqual(cfg.shuffle, "files")
-        self.assertEqual(cfg.concurrency, 4)
-
-
-# ---------------------------------------------------------------------------
-# BatchIterConfig
-# ---------------------------------------------------------------------------
-
-
-class TestBatchIterConfig(TestCase):
-    """Tests for BatchIterConfig dataclass."""
-
-    def test_required_batch_size(self):
-        """batch_size is required."""
-        cfg = BatchIterConfig(batch_size=64)
-        self.assertEqual(cfg.batch_size, 64)
-        self.assertEqual(cfg.num_shuffle_batches, 0)
-        self.assertIsNone(cfg.collate_fn)
-
-    def test_all_fields(self):
-        """It stores all fields."""
-        cfg = BatchIterConfig(
-            batch_size=32,
-            num_shuffle_batches=4,
-            collate_fn="myproject.collate.fn",
-        )
-        self.assertEqual(cfg.num_shuffle_batches, 4)
-        self.assertEqual(cfg.collate_fn, "myproject.collate.fn")
-
-
-# ---------------------------------------------------------------------------
-# DataloadingConfig
-# ---------------------------------------------------------------------------
-
-
-class TestDataloadingConfig(TestCase):
-    """Tests for DataloadingConfig dataclass."""
-
-    def test_all_none_by_default(self):
-        """Both optional fields default to None."""
-        cfg = DataloadingConfig()
-        self.assertIsNone(cfg.parquet_read_config)
-        self.assertIsNone(cfg.batch_iter_config)
-
-    def test_fields_stored(self):
-        """It stores provided sub-configs."""
-        pr = ParquetReadConfig(shuffle="files")
-        bi = BatchIterConfig(batch_size=32)
-        cfg = DataloadingConfig(parquet_read_config=pr, batch_iter_config=bi)
-        self.assertIs(cfg.parquet_read_config, pr)
-        self.assertIs(cfg.batch_iter_config, bi)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements PR 7a from the [tabular_trainer implementation plan](https://vibe-mcp.uberinternal.com/v/webdocs/#/d/0918273f-7c5e-4c1b-a9d2-84be5d32f159) — the config schema layer, which the pure helpers (7b) and dispatcher (7c) will stack on top of.

**New files:**
- `python/michelangelo/workflow/schema/tabular_trainer.py` (~400 lines) — all configuration dataclasses and enums
- `python/michelangelo/workflow/schema/tests/tabular_trainer_test.py` (~250 lines) — 41 tests

**What's in the schema:**
- `CheckpointScoreOrder`, `IncrementalTrainingModeConfig` (str enums)
- `ColumnConfig`, `CometConfig`, `ScalingConfig`, `CheckpointConfig`
- `ParquetReadConfig`, `BatchIterConfig`, `DataloadingConfig`
- `LightningTrainerKwargs` — 44 passthrough Lightning `Trainer.__init__` kwargs + `__post_init__` exclusivity validator for `limit_*_batches` vs `limit_*_batches_count` pairs
- `TransferLearningSpecConfig`, `CustomTrainerConfig`
- `LightningTrainerConfig` — main config; `comet` now Optional; `data_collate_fn` dropped (use `dataloading_config.batch_iter_config.collate_fn`)
- `TabularTrainerConfig` — `__post_init__` enforces exactly one of `lightning`/`custom`; `TorchTrainerConfig` dropped (never dispatched)

**Design divergences from internal (intentional):**
- Plain `@dataclass` — no Pydantic/JSONData dependency
- `comet` is `Optional` on `LightningTrainerConfig` (was required internally)
- Top-level `data_collate_fn` dropped (use `batch_iter_config.collate_fn`)
- `TorchTrainerConfig` dropped (internal dead code, never dispatched)
- `ParquetReadConfig` simplified to single Ray version (OSS pins one Ray)
- `TabularTrainerConfig.__post_init__` fails at construction vs internal's call-time check

## Test plan

- [x] 41 unit tests — all passing locally
- [x] `ruff format --check` passes
- [x] `ruff check` passes
- [ ] CI green

Closes #1359 (part 1 of 3 — stacked with 7b and 7c)

🤖 Generated with [Claude Code](https://claude.com/claude-code)