### PR TITLE
chore(precommit): add gofmt and go vet hooks for Go files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,14 @@ repos:
         language: system
         files: ^javascript/
         pass_filenames: false
+      - id: gofmt
+        name: go formatter
+        entry: gofmt -l -w
+        language: system
+        files: ^go/.*\.go$
+      - id: go-vet
+        name: go vet
+        entry: bash -c 'cd go && go vet ./...'
+        language: system
+        files: ^go/.*\.go$
+        pass_filenames: false


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Two hooks added to `.pre-commit-config.yaml`: `gofmt` auto-formats Go files on commit, and `go vet` runs package-level static analysis from the `go/` directory. Both are scoped to `^go/.*\.go$`.

<!-- Tell your future self why have you made these changes -->
**Why?**

Python and JavaScript both have formatter + linter pre-commit hooks; Go had none. Formatting drift and basic static analysis issues (wrong printf format strings, unreachable code, etc.) could accumulate silently between CI runs.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Verified each hook command directly:

1. **Syntax error blocked by gofmt** — created a file with a missing comma; `gofmt -l -w` exited 2 and blocked the commit.
2. **Formatting auto-fixed by gofmt** — created a file with `x:=1` (missing spaces); `gofmt -l` listed the file as needing changes; `gofmt -w` rewrote it. Pre-commit would see the staged file modified and fail, requiring a re-stage.
3. **go vet violation blocked** — created a file with `fmt.Printf("%d", "not an int")`; `cd go && go vet ./cmd/...` exited 1 with "format %d has arg of wrong type string".

<!-- Does this PR introduce a breaking change? Check all that apply. -->
**Breaking Changes**

- [x] No breaking changes