### PR TITLE
feat(trainer): tabular_trainer pure helpers module (_dataset.py) [PR 7b]

### DIFF
--- a/python/michelangelo/workflow/tasks/tabular_trainer/__init__.py
+++ b/python/michelangelo/workflow/tasks/tabular_trainer/__init__.py
@@ -1,0 +1,1 @@
+"""Tabular Lightning trainer workflow task."""

--- a/python/michelangelo/workflow/tasks/tabular_trainer/_dataset.py
+++ b/python/michelangelo/workflow/tasks/tabular_trainer/_dataset.py
@@ -1,0 +1,496 @@
+"""Shared helpers for tabular Lightning training.
+
+Provides dtype maps, model-schema builders, sample-data normalisation, and
+Ray-read kwargs construction. These are pure functions with no OSS-infra
+dependencies (no Ray clusters, no storage backends) so they can be tested
+without a Ray session.
+
+All public functions are imported by ``trainer_task.py`` (PR 7c). Tests live
+in ``tests/dataset_test.py``.
+"""
+
+from __future__ import annotations
+
+import ast
+import contextlib
+import logging
+import warnings
+from typing import TYPE_CHECKING, Callable
+
+import numpy as np
+
+from michelangelo.lib.model_manager.schema.data_type import DataType
+from michelangelo.lib.model_manager.schema.model_schema import ModelSchema
+from michelangelo.lib.model_manager.schema.model_schema_item import ModelSchemaItem
+from michelangelo.lib.trainer.torch.data_collate_functions import pad_ragged_lists
+
+if TYPE_CHECKING:
+    from michelangelo.workflow.schema.tabular_trainer import (
+        ColumnConfig,
+        LightningTrainerConfig,
+    )
+
+_logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Dtype maps
+# ---------------------------------------------------------------------------
+
+_TORCH_DTYPE_TO_NUMPY: dict[str, type] = {
+    "torch.float32": np.float32,
+    "torch.float64": np.float64,
+    "torch.float": np.float32,
+    "torch.int32": np.int32,
+    "torch.int64": np.int64,
+    "torch.int": np.int32,
+    "torch.long": np.int64,
+    "torch.int16": np.int16,
+    "torch.short": np.int16,
+    "torch.int8": np.int8,
+    "torch.uint8": np.uint8,
+    "torch.bool": np.bool_,
+}
+
+_TORCH_DTYPE_TO_DATATYPE: dict[str, DataType] = {
+    "torch.float32": DataType.FLOAT,
+    "torch.float64": DataType.DOUBLE,
+    "torch.float": DataType.FLOAT,
+    "torch.int32": DataType.INT,
+    "torch.int64": DataType.LONG,
+    "torch.int": DataType.INT,
+    "torch.long": DataType.LONG,
+    "torch.int16": DataType.SHORT,
+    "torch.short": DataType.SHORT,
+    "torch.int8": DataType.BYTE,
+    "torch.uint8": DataType.BYTE,
+    "torch.bool": DataType.BOOLEAN,
+}
+
+
+def _map_torch_dtype_to_numpy(torch_dtype_str: str) -> type:
+    """Map a PyTorch dtype string to the corresponding NumPy dtype.
+
+    Args:
+        torch_dtype_str: PyTorch dtype string, e.g. ``"torch.float32"``.
+
+    Returns:
+        NumPy dtype class. Falls back to ``np.float32`` for unknown strings.
+
+    Example:
+        >>> _map_torch_dtype_to_numpy("torch.long")
+        <class 'numpy.int64'>
+    """
+    return _TORCH_DTYPE_TO_NUMPY.get(torch_dtype_str, np.float32)
+
+
+def _map_torch_dtype_to_datatype(torch_dtype_str: str) -> DataType:
+    """Map a PyTorch dtype string to a Michelangelo ``DataType`` enum value.
+
+    Args:
+        torch_dtype_str: PyTorch dtype string, e.g. ``"torch.float32"``.
+
+    Returns:
+        ``DataType`` enum member. Falls back to ``DataType.FLOAT`` for unknowns.
+
+    Example:
+        >>> _map_torch_dtype_to_datatype("torch.int64")
+        <DataType.LONG: 19>
+    """
+    return _TORCH_DTYPE_TO_DATATYPE.get(torch_dtype_str, DataType.FLOAT)
+
+
+# ---------------------------------------------------------------------------
+# Schema builder
+# ---------------------------------------------------------------------------
+
+
+def get_model_schema(
+    input_columns: dict[str, ColumnConfig],
+    output_columns: dict[str, ColumnConfig],
+) -> ModelSchema:
+    """Build a ``ModelSchema`` from column config dicts.
+
+    Args:
+        input_columns: Mapping of feature name → ``ColumnConfig`` for model
+            inputs.
+        output_columns: Mapping of output name → ``ColumnConfig`` for model
+            outputs.
+
+    Returns:
+        ``ModelSchema`` with ``input_schema`` and ``output_schema`` populated.
+
+    Example:
+        >>> from michelangelo.workflow.schema.tabular_trainer import ColumnConfig
+        >>> schema = get_model_schema(
+        ...     input_columns={"x": ColumnConfig("torch.float32", [4])},
+        ...     output_columns={"y": ColumnConfig("torch.float32")},
+        ... )
+        >>> len(schema.input_schema)
+        1
+    """
+    _logger.info("Generating model schema")
+    input_schema: list[ModelSchemaItem] = [
+        ModelSchemaItem(
+            name=name,
+            data_type=_map_torch_dtype_to_datatype(cfg.data_type),
+            shape=cfg.shape,
+        )
+        for name, cfg in input_columns.items()
+    ]
+    output_schema: list[ModelSchemaItem] = [
+        ModelSchemaItem(
+            name=name,
+            data_type=_map_torch_dtype_to_datatype(cfg.data_type),
+            shape=cfg.shape,
+        )
+        for name, cfg in output_columns.items()
+    ]
+    return ModelSchema(input_schema=input_schema, output_schema=output_schema)
+
+
+# ---------------------------------------------------------------------------
+# Sample-row normalisation
+# ---------------------------------------------------------------------------
+
+
+def _pad_row(row: dict) -> dict[str, np.ndarray]:
+    """Normalise a raw single-sample dict to dense numpy arrays.
+
+    Replaces the internal ``shared.utils.numpy_utils.pad.pad_batch`` on the
+    OSS collate library:
+
+    - ``list`` values are padded via :func:`pad_ragged_lists`.
+    - ``np.ndarray`` with ``object`` dtype: string cells are parsed with
+      ``ast.literal_eval`` then padded via :func:`pad_ragged_lists`.
+    - Plain ``np.ndarray``: returned unchanged.
+    - Scalar ``str``: parsed with ``ast.literal_eval`` if possible.
+    - All other scalars: wrapped in a 1-D ``np.ndarray``.
+
+    Args:
+        row: Dict from ``train_data.take(1)[0]`` with metadata columns
+            already removed.
+
+    Returns:
+        Dict mapping column names to dense ``np.ndarray`` values.
+    """
+    result: dict[str, np.ndarray] = {}
+    for key, value in row.items():
+        if isinstance(value, np.ndarray):
+            if value.dtype == np.object_:
+                parsed = [
+                    ast.literal_eval(item) if isinstance(item, str) else item
+                    for item in value.flat
+                ]
+                result[key] = pad_ragged_lists(parsed)
+            else:
+                result[key] = value
+        elif isinstance(value, list):
+            result[key] = pad_ragged_lists(value)
+        elif isinstance(value, str):
+            try:
+                parsed_val = ast.literal_eval(value)
+                result[key] = np.asarray(parsed_val, dtype=np.float32)
+            except (ValueError, SyntaxError):
+                result[key] = np.array([value], dtype=object)
+        else:
+            result[key] = np.array(value)
+    return result
+
+
+def collate_sample_row(
+    sample_row: dict,
+    data_collate_fn: Callable | None = None,
+    metadata_columns: list[str] | None = None,
+) -> dict[str, np.ndarray]:
+    """Normalise a single raw sample row to numpy arrays for ``sample_data``.
+
+    When *data_collate_fn* is provided the row is wrapped in a batch of 1 and
+    routed through the same collate function used during training so that
+    ``sample_data`` undergoes identical transformations (literal_eval, padding)
+    as the data the model actually sees.
+
+    ``metadata_columns`` are fed to the collate function (same as training) but
+    removed from the result. Each remaining value must be a ``torch.Tensor``
+    with a leading batch dimension of 1; values are squeezed and converted to
+    numpy.
+
+    Falls back to :func:`_pad_row` when no collate function is provided.
+
+    Args:
+        sample_row: A single raw row dict from ``train_data.take(1)[0]``.
+        data_collate_fn: Collate function configured for training. When
+            provided the sample is routed through it to match training-time
+            behaviour.
+        metadata_columns: Column names aligned with
+            ``LightningTrainerConfig.metadata_columns``. Removed from the
+            collate result but not from the final ``sample_data``.
+
+    Returns:
+        Dict mapping column names to numpy arrays with the batch dimension
+        removed.
+    """
+    if data_collate_fn is not None:
+        _logger.info(
+            "Normalising sample row via data_collate_fn %s (batch-of-1 wrapper).",
+            data_collate_fn,
+        )
+        batch: dict[str, np.ndarray] = {}
+        for k, v in sample_row.items():
+            if isinstance(v, np.ndarray):
+                batch[k] = np.expand_dims(v, axis=0)
+            elif isinstance(v, str):
+                batch[k] = np.array([v], dtype=object)
+            else:
+                batch[k] = np.array([v])
+
+        collated = data_collate_fn(batch)
+        if metadata_columns:
+            for name in metadata_columns:
+                collated.pop(name, None)
+
+        return {k: t.squeeze(0).detach().cpu().numpy() for k, t in collated.items()}
+    else:
+        _logger.info("No data_collate_fn configured; using _pad_row for sample data.")
+        row = dict(sample_row)
+        if metadata_columns:
+            for name in metadata_columns:
+                row.pop(name, None)
+        return _pad_row(row)
+
+
+# ---------------------------------------------------------------------------
+# Sample-data extraction
+# ---------------------------------------------------------------------------
+
+
+def get_sample_data(
+    sample_data_dict: dict[str, np.ndarray],
+    input_columns: dict[str, ColumnConfig],
+) -> list[dict[str, np.ndarray]]:
+    """Extract and type-cast sample data for model inference testing.
+
+    Filters ``sample_data_dict`` to only the features listed in
+    ``input_columns``, converts each to the configured numpy dtype, and
+    attempts to reshape to the expected shape when element counts match.
+
+    Args:
+        sample_data_dict: Normalised sample dict from :func:`collate_sample_row`.
+        input_columns: Mapping of feature name → ``ColumnConfig``.
+
+    Returns:
+        A single-element list containing a dict of feature name → numpy array,
+        suitable for passing to ``ModelMetadata._sample_data``.
+
+    Example:
+        >>> import numpy as np
+        >>> data = get_sample_data(
+        ...     {"x": np.array(1.0)},
+        ...     {"x": ColumnConfig("torch.float32")},
+        ... )
+        >>> len(data)
+        1
+    """
+    _logger.info("Generating sample data")
+    filtered: dict[str, np.ndarray] = {}
+
+    for feature_name, cfg in input_columns.items():
+        if feature_name not in sample_data_dict:
+            _logger.warning(
+                "Feature '%s' not found in sample data, skipping.", feature_name
+            )
+            continue
+
+        raw = sample_data_dict[feature_name]
+
+        # Parse stringified arrays produced by object-dtype Ray columns.
+        if isinstance(raw, str) and raw.startswith("[") and raw.endswith("]"):
+            with contextlib.suppress(ValueError, SyntaxError):
+                raw = ast.literal_eval(raw)
+        elif (
+            isinstance(raw, np.ndarray)
+            and raw.dtype == np.object_
+            and raw.size > 0
+            and isinstance(next(iter(raw.flat)), str)
+        ):
+            parsed_items = [
+                ast.literal_eval(item)
+                if isinstance(item, str) and item.startswith("[")
+                else item
+                for item in raw.flat
+            ]
+            raw = np.array(parsed_items, dtype=np.float32)
+
+        target_dtype = _map_torch_dtype_to_numpy(cfg.data_type)
+        data = np.asarray(raw, dtype=target_dtype)
+
+        expected = tuple(cfg.shape)
+        if expected and data.shape != expected:
+            if data.size == np.prod(expected):
+                data = data.reshape(expected)
+                _logger.debug("Reshaped '%s' to %s.", feature_name, expected)
+            else:
+                _logger.warning(
+                    "Feature '%s' shape mismatch: got %s, expected %s. Using as-is.",
+                    feature_name,
+                    data.shape,
+                    expected,
+                )
+
+        filtered[feature_name] = data
+
+    return [filtered]
+
+
+# ---------------------------------------------------------------------------
+# Deprecation warnings
+# ---------------------------------------------------------------------------
+
+
+def _raise_hyperparameter_deprecation_warnings(
+    lightning_trainer_config: LightningTrainerConfig,
+) -> None:
+    """Warn for hyperparameter keys that now have first-class config fields.
+
+    Args:
+        lightning_trainer_config: The ``LightningTrainerConfig`` to inspect.
+    """
+    deprecated: dict[str, tuple[str, str]] = {
+        "num_epochs": ("max_epochs", "lightning_trainer_kwargs"),
+        "precision": ("precision", "lightning_trainer_kwargs"),
+        "batch_size": ("batch_size", "dataloading_config.batch_iter_config"),
+        "num_shuffle_batches": (
+            "num_shuffle_batches",
+            "dataloading_config.batch_iter_config",
+        ),
+    }
+
+    if lightning_trainer_config.hyperparameters is None:
+        return
+
+    for key in lightning_trainer_config.hyperparameters:
+        if key in deprecated:
+            new_key, dest = deprecated[key]
+            warnings.warn(
+                f"Providing '{key}' in hyperparameters is deprecated. "
+                f"Set '{new_key}' in '{dest}' instead.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+        else:
+            warnings.warn(
+                f"Providing '{key}' in hyperparameters is not supported by "
+                "the tabular_trainer task and will have no effect.",
+                UserWarning,
+                stacklevel=3,
+            )
+
+
+def _raise_trainer_config_deprecation_warnings(
+    lightning_trainer_config: LightningTrainerConfig,
+) -> None:
+    """Warn for any deprecated top-level ``LightningTrainerConfig`` fields.
+
+    ``data_collate_fn``, ``project_name``, and ``experiment_name`` were
+    dropped from the OSS schema so there is nothing to warn about here.
+    The function is kept as an extension point — add entries to
+    ``deprecated_config_fields`` when a new field is deprecated.
+
+    Args:
+        lightning_trainer_config: The ``LightningTrainerConfig`` to inspect.
+    """
+    deprecated_config_fields: dict[str, tuple[str, str]] = {
+        # Example entry format:
+        # "old_field": ("new_field", "config.lightning.<destination>"),
+    }
+
+    for key, (new_key, dest) in deprecated_config_fields.items():
+        if getattr(lightning_trainer_config, key, None) is not None:
+            warnings.warn(
+                f"Providing '{key}' in config.lightning is deprecated. "
+                f"Set '{new_key}' in '{dest}' instead.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+
+
+def raise_lightning_trainer_config_deprecation_warnings(
+    lightning_trainer_config: LightningTrainerConfig,
+) -> None:
+    """Run all deprecation-warning checks for a ``LightningTrainerConfig``.
+
+    Combines :func:`_raise_hyperparameter_deprecation_warnings` and
+    :func:`_raise_trainer_config_deprecation_warnings`.
+
+    Args:
+        lightning_trainer_config: The ``LightningTrainerConfig`` to inspect.
+    """
+    _raise_hyperparameter_deprecation_warnings(lightning_trainer_config)
+    _raise_trainer_config_deprecation_warnings(lightning_trainer_config)
+
+
+# ---------------------------------------------------------------------------
+# Ray read kwargs
+# ---------------------------------------------------------------------------
+
+
+def construct_read_kwargs(config: LightningTrainerConfig) -> dict:
+    """Build ``ray.data.read_parquet`` kwargs from trainer config.
+
+    Derives the ``columns`` projection from ``input_columns``, ``labels``,
+    and ``metadata_columns`` (``output_columns`` excluded — they are not
+    present in the raw dataset). Adds any ``ParquetReadConfig`` resource
+    knobs that are explicitly set.
+
+    Args:
+        config: The ``LightningTrainerConfig`` to read from.
+
+    Returns:
+        Dict of kwargs ready to unpack into ``ray.data.read_parquet(path,
+        **kwargs)``.
+
+    Example:
+        >>> from michelangelo.workflow.schema.tabular_trainer import (
+        ...     LightningTrainerConfig, ColumnConfig
+        ... )
+        >>> cfg = LightningTrainerConfig(
+        ...     model_class="m", metadata_columns=["id"],
+        ...     input_columns={"x": ColumnConfig("torch.float32")},
+        ...     output_columns={"y": ColumnConfig("torch.float32")},
+        ...     labels={"label": ColumnConfig("torch.long")},
+        ... )
+        >>> construct_read_kwargs(cfg)
+        {'columns': ['id', 'label', 'x']}
+    """
+    read_kwargs: dict = {}
+
+    # Resource knobs from ParquetReadConfig.
+    prc = (
+        config.dataloading_config.parquet_read_config
+        if config.dataloading_config
+        else None
+    )
+    if prc is not None:
+        _parquet_read_fields = (
+            "num_cpus",
+            "num_gpus",
+            "memory",
+            "concurrency",
+            "override_num_blocks",
+            "shuffle",
+            "tensor_column_schema",
+            "arrow_parquet_args",
+        )
+        for attr in _parquet_read_fields:
+            val = getattr(prc, attr, None)
+            if val is not None:
+                read_kwargs[attr] = val
+
+    # Column projection: inputs | labels | metadata (output_columns excluded).
+    metadata = list(config.metadata_columns) if config.metadata_columns else []
+    columns = sorted(
+        set(config.input_columns.keys()) | set(config.labels.keys()) | set(metadata)
+    )
+    if columns:
+        read_kwargs["columns"] = columns
+
+    return read_kwargs

--- a/python/michelangelo/workflow/tasks/tabular_trainer/_dataset.py
+++ b/python/michelangelo/workflow/tasks/tabular_trainer/_dataset.py
@@ -164,7 +164,8 @@ def _pad_row(row: dict) -> dict[str, np.ndarray]:
       ``ast.literal_eval`` then padded via :func:`pad_ragged_lists`.
     - Plain ``np.ndarray``: returned unchanged.
     - Scalar ``str``: parsed with ``ast.literal_eval`` if possible.
-    - All other scalars: wrapped in a 1-D ``np.ndarray``.
+    - All other scalars: wrapped in a 0-D ``np.ndarray`` (use ``np.atleast_1d``
+      downstream if a 1-D array is required).
 
     Args:
         row: Dict from ``train_data.take(1)[0]`` with metadata columns
@@ -218,8 +219,10 @@ def collate_sample_row(
 
     Args:
         sample_row: A single raw row dict from ``train_data.take(1)[0]``.
-        data_collate_fn: Collate function configured for training. When
-            provided the sample is routed through it to match training-time
+        data_collate_fn: Collate function configured for training. Must accept
+            a ``dict[str, np.ndarray]`` (batch of 1) and return a
+            ``dict[str, torch.Tensor]`` with a leading batch dimension of 1.
+            When provided the sample is routed through it to match training-time
             behaviour.
         metadata_columns: Column names aligned with
             ``LightningTrainerConfig.metadata_columns``. Removed from the
@@ -228,6 +231,10 @@ def collate_sample_row(
     Returns:
         Dict mapping column names to numpy arrays with the batch dimension
         removed.
+
+    Raises:
+        AttributeError: If *data_collate_fn* returns values that are not
+            ``torch.Tensor`` objects (e.g. plain numpy arrays or scalars).
     """
     if data_collate_fn is not None:
         _logger.info(
@@ -281,6 +288,10 @@ def get_sample_data(
         A single-element list containing a dict of feature name → numpy array,
         suitable for passing to ``ModelMetadata._sample_data``.
 
+        If a feature is absent from *sample_data_dict* it is skipped (warning
+        logged). If the data shape does not match ``ColumnConfig.shape`` and
+        cannot be reshaped, the data is passed through as-is (warning logged).
+
     Example:
         >>> import numpy as np
         >>> data = get_sample_data(
@@ -318,7 +329,8 @@ def get_sample_data(
                 else item
                 for item in raw.flat
             ]
-            raw = np.array(parsed_items, dtype=np.float32)
+            # Use pad_ragged_lists to handle variable-length (ragged) rows.
+            raw = pad_ragged_lists(parsed_items)
 
         target_dtype = _map_torch_dtype_to_numpy(cfg.data_type)
         data = np.asarray(raw, dtype=target_dtype)

--- a/python/michelangelo/workflow/tasks/tabular_trainer/tests/__init__.py
+++ b/python/michelangelo/workflow/tasks/tabular_trainer/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the tabular_trainer workflow task."""

--- a/python/michelangelo/workflow/tasks/tabular_trainer/tests/dataset_test.py
+++ b/python/michelangelo/workflow/tasks/tabular_trainer/tests/dataset_test.py
@@ -424,6 +424,29 @@ class TestGetSampleData(TestCase):
         )
         self.assertEqual(result[0]["x"].dtype, np.float32)
 
+    def test_object_array_ragged_strings_padded(self):
+        """Ragged stringified rows in an object array are padded (not crashed)."""
+        raw = np.array(["[1.0]", "[2.0, 3.0]"], dtype=object)
+        result = get_sample_data(
+            {"x": raw},
+            {"x": ColumnConfig("torch.float32")},
+        )
+        self.assertIsInstance(result[0]["x"], np.ndarray)
+        self.assertNotEqual(result[0]["x"].dtype, object)
+
+    def test_shape_mismatch_no_reshape_warn_and_continue(self):
+        """Shape mismatch with no valid reshape logs a warning and passes through."""
+        raw = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        with self.assertLogs(
+            "michelangelo.workflow.tasks.tabular_trainer._dataset", level="WARNING"
+        ) as log:
+            result = get_sample_data(
+                {"x": raw},
+                {"x": ColumnConfig("torch.float32", [2, 2])},
+            )
+        self.assertIn("shape mismatch", " ".join(log.output))
+        self.assertEqual(result[0]["x"].shape, (3,))
+
     def test_only_input_columns_included(self):
         """Keys not in input_columns are excluded from the result."""
         result = get_sample_data(

--- a/python/michelangelo/workflow/tasks/tabular_trainer/tests/dataset_test.py
+++ b/python/michelangelo/workflow/tasks/tabular_trainer/tests/dataset_test.py
@@ -1,0 +1,591 @@
+"""Tests for michelangelo.workflow.tasks.tabular_trainer._dataset."""
+
+from __future__ import annotations
+
+import warnings
+from unittest import TestCase
+from unittest.mock import patch
+
+import numpy as np
+
+from michelangelo.lib.model_manager.schema.data_type import DataType
+from michelangelo.lib.model_manager.schema.model_schema import ModelSchema
+from michelangelo.workflow.schema.tabular_trainer import (
+    ColumnConfig,
+    LightningTrainerConfig,
+)
+from michelangelo.workflow.tasks.tabular_trainer._dataset import (
+    _map_torch_dtype_to_datatype,
+    _map_torch_dtype_to_numpy,
+    _pad_row,
+    collate_sample_row,
+    construct_read_kwargs,
+    get_model_schema,
+    get_sample_data,
+    raise_lightning_trainer_config_deprecation_warnings,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_BASE_LIGHTNING_CFG = {
+    "model_class": "m",
+    "input_columns": {"x": ColumnConfig("torch.float32")},
+    "output_columns": {"y": ColumnConfig("torch.float32")},
+    "labels": {"label": ColumnConfig("torch.long")},
+    "metadata_columns": [],
+}
+
+
+def _lightning_cfg(**overrides) -> LightningTrainerConfig:
+    """Build a minimal valid LightningTrainerConfig with optional overrides."""
+    return LightningTrainerConfig(**{**_BASE_LIGHTNING_CFG, **overrides})
+
+
+# ---------------------------------------------------------------------------
+# _map_torch_dtype_to_numpy
+# ---------------------------------------------------------------------------
+
+
+class TestMapTorchDtypeToNumpy(TestCase):
+    """Tests for _map_torch_dtype_to_numpy."""
+
+    def test_float32(self):
+        """Maps torch.float32 to np.float32."""
+        self.assertIs(_map_torch_dtype_to_numpy("torch.float32"), np.float32)
+
+    def test_float32_alias(self):
+        """Maps torch.float alias to np.float32."""
+        self.assertIs(_map_torch_dtype_to_numpy("torch.float"), np.float32)
+
+    def test_float64(self):
+        """Maps torch.float64 to np.float64."""
+        self.assertIs(_map_torch_dtype_to_numpy("torch.float64"), np.float64)
+
+    def test_int32(self):
+        """Maps torch.int32 to np.int32."""
+        self.assertIs(_map_torch_dtype_to_numpy("torch.int32"), np.int32)
+
+    def test_int32_alias(self):
+        """Maps torch.int alias to np.int32."""
+        self.assertIs(_map_torch_dtype_to_numpy("torch.int"), np.int32)
+
+    def test_int64(self):
+        """Maps torch.int64 to np.int64."""
+        self.assertIs(_map_torch_dtype_to_numpy("torch.int64"), np.int64)
+
+    def test_long(self):
+        """Maps torch.long to np.int64."""
+        self.assertIs(_map_torch_dtype_to_numpy("torch.long"), np.int64)
+
+    def test_int16(self):
+        """Maps torch.int16 to np.int16."""
+        self.assertIs(_map_torch_dtype_to_numpy("torch.int16"), np.int16)
+
+    def test_short(self):
+        """Maps torch.short to np.int16."""
+        self.assertIs(_map_torch_dtype_to_numpy("torch.short"), np.int16)
+
+    def test_int8(self):
+        """Maps torch.int8 to np.int8."""
+        self.assertIs(_map_torch_dtype_to_numpy("torch.int8"), np.int8)
+
+    def test_uint8(self):
+        """Maps torch.uint8 to np.uint8."""
+        self.assertIs(_map_torch_dtype_to_numpy("torch.uint8"), np.uint8)
+
+    def test_bool(self):
+        """Maps torch.bool to np.bool_."""
+        self.assertIs(_map_torch_dtype_to_numpy("torch.bool"), np.bool_)
+
+    def test_unknown_falls_back_to_float32(self):
+        """Falls back to np.float32 for unknown dtype strings."""
+        self.assertIs(_map_torch_dtype_to_numpy("torch.bfloat16"), np.float32)
+
+
+# ---------------------------------------------------------------------------
+# _map_torch_dtype_to_datatype
+# ---------------------------------------------------------------------------
+
+
+class TestMapTorchDtypeToDatatype(TestCase):
+    """Tests for _map_torch_dtype_to_datatype."""
+
+    def test_float32(self):
+        """Maps torch.float32 to DataType.FLOAT."""
+        self.assertEqual(_map_torch_dtype_to_datatype("torch.float32"), DataType.FLOAT)
+
+    def test_float32_alias(self):
+        """Maps torch.float alias to DataType.FLOAT."""
+        self.assertEqual(_map_torch_dtype_to_datatype("torch.float"), DataType.FLOAT)
+
+    def test_float64(self):
+        """Maps torch.float64 to DataType.DOUBLE."""
+        self.assertEqual(_map_torch_dtype_to_datatype("torch.float64"), DataType.DOUBLE)
+
+    def test_int32(self):
+        """Maps torch.int32 to DataType.INT."""
+        self.assertEqual(_map_torch_dtype_to_datatype("torch.int32"), DataType.INT)
+
+    def test_int32_alias(self):
+        """Maps torch.int alias to DataType.INT."""
+        self.assertEqual(_map_torch_dtype_to_datatype("torch.int"), DataType.INT)
+
+    def test_int64(self):
+        """Maps torch.int64 to DataType.LONG."""
+        self.assertEqual(_map_torch_dtype_to_datatype("torch.int64"), DataType.LONG)
+
+    def test_long(self):
+        """Maps torch.long to DataType.LONG."""
+        self.assertEqual(_map_torch_dtype_to_datatype("torch.long"), DataType.LONG)
+
+    def test_int16(self):
+        """Maps torch.int16 to DataType.SHORT."""
+        self.assertEqual(_map_torch_dtype_to_datatype("torch.int16"), DataType.SHORT)
+
+    def test_short(self):
+        """Maps torch.short to DataType.SHORT."""
+        self.assertEqual(_map_torch_dtype_to_datatype("torch.short"), DataType.SHORT)
+
+    def test_int8(self):
+        """Maps torch.int8 to DataType.BYTE."""
+        self.assertEqual(_map_torch_dtype_to_datatype("torch.int8"), DataType.BYTE)
+
+    def test_uint8(self):
+        """Maps torch.uint8 to DataType.BYTE."""
+        self.assertEqual(_map_torch_dtype_to_datatype("torch.uint8"), DataType.BYTE)
+
+    def test_bool(self):
+        """Maps torch.bool to DataType.BOOLEAN."""
+        self.assertEqual(_map_torch_dtype_to_datatype("torch.bool"), DataType.BOOLEAN)
+
+    def test_unknown_falls_back_to_float(self):
+        """Falls back to DataType.FLOAT for unknown dtype strings."""
+        self.assertEqual(_map_torch_dtype_to_datatype("torch.bfloat16"), DataType.FLOAT)
+
+
+# ---------------------------------------------------------------------------
+# get_model_schema
+# ---------------------------------------------------------------------------
+
+
+class TestGetModelSchema(TestCase):
+    """Tests for get_model_schema."""
+
+    def test_returns_model_schema(self):
+        """It returns a ModelSchema instance."""
+        schema = get_model_schema(
+            input_columns={"x": ColumnConfig("torch.float32")},
+            output_columns={"y": ColumnConfig("torch.float32")},
+        )
+        self.assertIsInstance(schema, ModelSchema)
+
+    def test_input_schema_names(self):
+        """Input schema items carry the correct feature names."""
+        schema = get_model_schema(
+            input_columns={
+                "age": ColumnConfig("torch.float32"),
+                "income": ColumnConfig("torch.float32"),
+            },
+            output_columns={},
+        )
+        names = [item.name for item in schema.input_schema]
+        self.assertIn("age", names)
+        self.assertIn("income", names)
+
+    def test_output_schema_names(self):
+        """Output schema items carry the correct names."""
+        schema = get_model_schema(
+            input_columns={},
+            output_columns={"score": ColumnConfig("torch.float32")},
+        )
+        self.assertEqual(schema.output_schema[0].name, "score")
+
+    def test_input_dtype_mapping(self):
+        """DataType is correctly derived from the ColumnConfig data_type."""
+        schema = get_model_schema(
+            input_columns={"emb": ColumnConfig("torch.float64", [128])},
+            output_columns={},
+        )
+        self.assertEqual(schema.input_schema[0].data_type, DataType.DOUBLE)
+
+    def test_input_shape_propagated(self):
+        """Shape is propagated to ModelSchemaItem."""
+        schema = get_model_schema(
+            input_columns={"emb": ColumnConfig("torch.float32", [64])},
+            output_columns={},
+        )
+        self.assertEqual(schema.input_schema[0].shape, [64])
+
+    def test_empty_configs(self):
+        """Empty dicts produce empty schemas."""
+        schema = get_model_schema(input_columns={}, output_columns={})
+        self.assertEqual(schema.input_schema, [])
+        self.assertEqual(schema.output_schema, [])
+
+    def test_feature_store_schema_empty(self):
+        """feature_store_features_schema is always empty (not set here)."""
+        schema = get_model_schema(
+            input_columns={"x": ColumnConfig("torch.float32")},
+            output_columns={"y": ColumnConfig("torch.float32")},
+        )
+        self.assertEqual(schema.feature_store_features_schema, [])
+
+
+# ---------------------------------------------------------------------------
+# _pad_row
+# ---------------------------------------------------------------------------
+
+
+class TestPadRow(TestCase):
+    """Tests for _pad_row -- the no-collate-fn normalisation path."""
+
+    def test_plain_ndarray_unchanged(self):
+        """A non-object numpy array is returned as-is."""
+        arr = np.array([1.0, 2.0], dtype=np.float32)
+        result = _pad_row({"x": arr})
+        np.testing.assert_array_equal(result["x"], arr)
+
+    def test_scalar_wrapped(self):
+        """A scalar is wrapped in a 1-D array."""
+        result = _pad_row({"x": 3.0})
+        self.assertIsInstance(result["x"], np.ndarray)
+        self.assertAlmostEqual(result["x"].item(), 3.0)
+
+    def test_list_padded(self):
+        """A list value is padded to a dense numpy array."""
+        result = _pad_row({"x": [1.0, 2.0, 3.0]})
+        self.assertIsInstance(result["x"], np.ndarray)
+        self.assertEqual(result["x"].shape[0], 3)
+
+    def test_string_literal_eval(self):
+        """A stringified list is parsed via literal_eval."""
+        result = _pad_row({"x": "[1.0, 2.0]"})
+        self.assertIsInstance(result["x"], np.ndarray)
+        self.assertEqual(result["x"].shape[0], 2)
+
+    def test_string_unparseable_kept_as_object(self):
+        """An unparseable string is stored in an object array."""
+        result = _pad_row({"x": "not_a_list"})
+        self.assertEqual(result["x"].dtype, object)
+
+    def test_object_array_with_string_cells(self):
+        """Object array whose cells are stringified arrays is parsed and padded."""
+        obj = np.array(["[1.0, 2.0]", "[3.0, 4.0]"], dtype=object)
+        result = _pad_row({"x": obj})
+        self.assertIsInstance(result["x"], np.ndarray)
+        self.assertNotEqual(result["x"].dtype, object)
+
+    def test_multiple_keys(self):
+        """All keys in the row are processed."""
+        result = _pad_row({"a": 1.0, "b": np.array([2.0])})
+        self.assertIn("a", result)
+        self.assertIn("b", result)
+
+
+# ---------------------------------------------------------------------------
+# collate_sample_row
+# ---------------------------------------------------------------------------
+
+
+class TestCollateSampleRow(TestCase):
+    """Tests for collate_sample_row."""
+
+    def test_no_collate_fn_calls_pad_row(self):
+        """Without a collate fn, _pad_row is invoked."""
+        with patch(
+            "michelangelo.workflow.tasks.tabular_trainer._dataset._pad_row",
+            return_value={"x": np.array([1.0])},
+        ) as mock_pad:
+            result = collate_sample_row({"x": np.array([1.0])})
+        mock_pad.assert_called_once()
+        self.assertIn("x", result)
+
+    def test_no_collate_fn_metadata_removed(self):
+        """Metadata columns are stripped before _pad_row is called."""
+        row = {"x": np.array([1.0]), "meta_id": "abc"}
+        result = collate_sample_row(row, metadata_columns=["meta_id"])
+        self.assertIn("x", result)
+        self.assertNotIn("meta_id", result)
+
+    def test_with_collate_fn_returns_numpy(self):
+        """With a collate fn, tensors are squeezed to numpy."""
+        import torch
+
+        def _collate(batch):
+            return {"x": torch.tensor([[1.0, 2.0]])}
+
+        result = collate_sample_row(
+            {"x": np.array([1.0, 2.0])}, data_collate_fn=_collate
+        )
+        self.assertIsInstance(result["x"], np.ndarray)
+        self.assertEqual(result["x"].shape, (2,))
+
+    def test_with_collate_fn_metadata_removed(self):
+        """Metadata columns are popped from the collate output."""
+        import torch
+
+        def _collate(batch):
+            return {"x": torch.tensor([[1.0]]), "meta_id": torch.tensor([[0]])}
+
+        result = collate_sample_row(
+            {"x": np.array([1.0]), "meta_id": np.array([0])},
+            data_collate_fn=_collate,
+            metadata_columns=["meta_id"],
+        )
+        self.assertIn("x", result)
+        self.assertNotIn("meta_id", result)
+
+    def test_with_collate_fn_string_wrapped_as_object(self):
+        """String values are wrapped in object arrays before collate."""
+        import torch
+
+        captured = {}
+
+        def _collate(batch):
+            captured.update(batch)
+            return {"x": torch.tensor([[1.0]])}
+
+        collate_sample_row({"x": "abc"}, data_collate_fn=_collate)
+        self.assertEqual(captured["x"].dtype, object)
+
+    def test_without_collate_fn_no_metadata_columns(self):
+        """Passing metadata_columns=None does not raise."""
+        result = collate_sample_row({"x": np.array(1.0)}, metadata_columns=None)
+        self.assertIn("x", result)
+
+
+# ---------------------------------------------------------------------------
+# get_sample_data
+# ---------------------------------------------------------------------------
+
+
+class TestGetSampleData(TestCase):
+    """Tests for get_sample_data."""
+
+    def test_returns_list_of_one_dict(self):
+        """It always returns a single-element list."""
+        result = get_sample_data(
+            {"x": np.array(1.0)},
+            {"x": ColumnConfig("torch.float32")},
+        )
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+        self.assertIsInstance(result[0], dict)
+
+    def test_dtype_cast(self):
+        """Values are cast to the dtype specified in ColumnConfig."""
+        result = get_sample_data(
+            {"x": np.array(1.0, dtype=np.float64)},
+            {"x": ColumnConfig("torch.float32")},
+        )
+        self.assertEqual(result[0]["x"].dtype, np.float32)
+
+    def test_reshape_when_element_count_matches(self):
+        """Data is reshaped when the total element count matches expected shape."""
+        result = get_sample_data(
+            {"x": np.array([1.0, 2.0, 3.0, 4.0])},
+            {"x": ColumnConfig("torch.float32", [2, 2])},
+        )
+        self.assertEqual(result[0]["x"].shape, (2, 2))
+
+    def test_no_reshape_when_shape_empty(self):
+        """Scalar columns (shape=[]) are not reshaped."""
+        result = get_sample_data(
+            {"x": np.array(1.0)},
+            {"x": ColumnConfig("torch.float32", [])},
+        )
+        self.assertIn("x", result[0])
+
+    def test_missing_feature_skipped(self):
+        """A feature not in sample_data_dict is skipped (no KeyError)."""
+        result = get_sample_data(
+            {},
+            {"x": ColumnConfig("torch.float32")},
+        )
+        self.assertNotIn("x", result[0])
+
+    def test_stringified_list_parsed(self):
+        """A string value starting with '[' is parsed via ast.literal_eval."""
+        result = get_sample_data(
+            {"x": "[1.0, 2.0]"},
+            {"x": ColumnConfig("torch.float32")},
+        )
+        self.assertEqual(result[0]["x"].dtype, np.float32)
+        self.assertEqual(len(result[0]["x"]), 2)
+
+    def test_object_array_of_strings_parsed(self):
+        """Object arrays whose elements are stringified lists are parsed."""
+        raw = np.array(["[1.0, 2.0]"], dtype=object)
+        result = get_sample_data(
+            {"x": raw},
+            {"x": ColumnConfig("torch.float32")},
+        )
+        self.assertEqual(result[0]["x"].dtype, np.float32)
+
+    def test_only_input_columns_included(self):
+        """Keys not in input_columns are excluded from the result."""
+        result = get_sample_data(
+            {"x": np.array(1.0), "y": np.array(0)},
+            {"x": ColumnConfig("torch.float32")},
+        )
+        self.assertIn("x", result[0])
+        self.assertNotIn("y", result[0])
+
+
+# ---------------------------------------------------------------------------
+# Deprecation warnings
+# ---------------------------------------------------------------------------
+
+
+class TestDeprecationWarnings(TestCase):
+    """Tests for raise_lightning_trainer_config_deprecation_warnings."""
+
+    def test_no_hyperparameters_no_warning(self):
+        """No warning is emitted when hyperparameters is None."""
+        cfg = _lightning_cfg(hyperparameters=None)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            raise_lightning_trainer_config_deprecation_warnings(cfg)
+
+    def test_deprecated_hyperparameter_num_epochs(self):
+        """Num_epochs in hyperparameters emits a DeprecationWarning."""
+        cfg = _lightning_cfg(hyperparameters={"num_epochs": 10})
+        with self.assertWarns(DeprecationWarning):
+            raise_lightning_trainer_config_deprecation_warnings(cfg)
+
+    def test_deprecated_hyperparameter_precision(self):
+        """Precision in hyperparameters emits a DeprecationWarning."""
+        cfg = _lightning_cfg(hyperparameters={"precision": "bf16-mixed"})
+        with self.assertWarns(DeprecationWarning):
+            raise_lightning_trainer_config_deprecation_warnings(cfg)
+
+    def test_deprecated_hyperparameter_batch_size(self):
+        """Batch_size in hyperparameters emits a DeprecationWarning."""
+        cfg = _lightning_cfg(hyperparameters={"batch_size": 64})
+        with self.assertWarns(DeprecationWarning):
+            raise_lightning_trainer_config_deprecation_warnings(cfg)
+
+    def test_deprecated_hyperparameter_num_shuffle_batches(self):
+        """Num_shuffle_batches in hyperparameters emits a DeprecationWarning."""
+        cfg = _lightning_cfg(hyperparameters={"num_shuffle_batches": 4})
+        with self.assertWarns(DeprecationWarning):
+            raise_lightning_trainer_config_deprecation_warnings(cfg)
+
+    def test_unknown_hyperparameter_emits_user_warning(self):
+        """An unknown hyperparameter key emits a UserWarning."""
+        cfg = _lightning_cfg(hyperparameters={"unknown_key": "value"})
+        with self.assertWarns(UserWarning):
+            raise_lightning_trainer_config_deprecation_warnings(cfg)
+
+    def test_no_deprecated_config_fields_no_warning(self):
+        """No warning is emitted for a clean config with no deprecated fields."""
+        cfg = _lightning_cfg()
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            raise_lightning_trainer_config_deprecation_warnings(cfg)
+
+
+# ---------------------------------------------------------------------------
+# construct_read_kwargs
+# ---------------------------------------------------------------------------
+
+
+class TestConstructReadKwargs(TestCase):
+    """Tests for construct_read_kwargs."""
+
+    def test_columns_include_inputs_labels_metadata(self):
+        """Columns = sorted(inputs | labels | metadata)."""
+        cfg = _lightning_cfg(
+            input_columns={"feat_a": ColumnConfig("torch.float32")},
+            labels={"label": ColumnConfig("torch.long")},
+            metadata_columns=["user_id"],
+        )
+        result = construct_read_kwargs(cfg)
+        self.assertEqual(result["columns"], sorted(["feat_a", "label", "user_id"]))
+
+    def test_output_columns_excluded(self):
+        """output_columns are NOT included in the column projection."""
+        cfg = _lightning_cfg(
+            input_columns={"x": ColumnConfig("torch.float32")},
+            output_columns={"y": ColumnConfig("torch.float32")},
+            labels={"label": ColumnConfig("torch.long")},
+            metadata_columns=[],
+        )
+        result = construct_read_kwargs(cfg)
+        self.assertNotIn("y", result.get("columns", []))
+
+    def test_columns_sorted(self):
+        """Columns list is always sorted."""
+        cfg = _lightning_cfg(
+            input_columns={
+                "z_feat": ColumnConfig("torch.float32"),
+                "a_feat": ColumnConfig("torch.float32"),
+            },
+            labels={"m_label": ColumnConfig("torch.long")},
+            metadata_columns=[],
+        )
+        result = construct_read_kwargs(cfg)
+        self.assertEqual(result["columns"], sorted(result["columns"]))
+
+    def test_no_dataloading_config(self):
+        """With no dataloading_config, only columns key is set."""
+        cfg = _lightning_cfg(dataloading_config=None)
+        result = construct_read_kwargs(cfg)
+        self.assertIn("columns", result)
+        self.assertNotIn("num_cpus", result)
+
+    def test_parquet_read_config_num_cpus(self):
+        """ParquetReadConfig.num_cpus is forwarded."""
+        from michelangelo.workflow.schema.ray_data_io import (
+            DataloadingConfig,
+            ParquetReadConfig,
+        )
+
+        cfg = _lightning_cfg(
+            dataloading_config=DataloadingConfig(
+                parquet_read_config=ParquetReadConfig(num_cpus=4.0)
+            )
+        )
+        result = construct_read_kwargs(cfg)
+        self.assertEqual(result["num_cpus"], 4.0)
+
+    def test_parquet_read_config_shuffle(self):
+        """ParquetReadConfig.shuffle is forwarded."""
+        from michelangelo.workflow.schema.ray_data_io import (
+            DataloadingConfig,
+            ParquetReadConfig,
+        )
+
+        cfg = _lightning_cfg(
+            dataloading_config=DataloadingConfig(
+                parquet_read_config=ParquetReadConfig(shuffle="files")
+            )
+        )
+        result = construct_read_kwargs(cfg)
+        self.assertEqual(result["shuffle"], "files")
+
+    def test_none_parquet_fields_not_included(self):
+        """ParquetReadConfig fields that are None are not added to the dict."""
+        from michelangelo.workflow.schema.ray_data_io import (
+            DataloadingConfig,
+            ParquetReadConfig,
+        )
+
+        cfg = _lightning_cfg(
+            dataloading_config=DataloadingConfig(
+                parquet_read_config=ParquetReadConfig(num_cpus=None, shuffle=None)
+            )
+        )
+        result = construct_read_kwargs(cfg)
+        self.assertNotIn("num_cpus", result)
+        self.assertNotIn("shuffle", result)
+
+    def test_empty_metadata_columns(self):
+        """Empty metadata_columns list does not add spurious entries."""
+        cfg = _lightning_cfg(metadata_columns=[])
+        result = construct_read_kwargs(cfg)
+        # columns should be inputs | labels only
+        expected = sorted(list(cfg.input_columns.keys()) + list(cfg.labels.keys()))
+        self.assertEqual(result["columns"], expected)


### PR DESCRIPTION
## Summary

- Ports 10 pure-function helpers from internal `lightning_dataset.py` to `python/michelangelo/workflow/tasks/tabular_trainer/_dataset.py`
- Replaces internal `pad_batch` (absent in OSS) with `_pad_row()` using `pad_ragged_lists` / `ast.literal_eval`
- Builds `construct_read_kwargs` by iterating `ParquetReadConfig` fields directly (no internal `parquet_read_config_to_kwargs` needed)
- 69 unit tests in `tests/dataset_test.py`, all passing
- No Uber-internal references; zero OSS-infra dependencies (no Ray cluster required)

## Functions ported

| Function | Purpose |
|---|---|
| `_map_torch_dtype_to_numpy` | dtype string → numpy type |
| `_map_torch_dtype_to_datatype` | dtype string → DataType enum |
| `get_model_schema` | builds ModelSchema from ColumnConfig dicts |
| `_pad_row` | OSS replacement for `pad_batch` |
| `collate_sample_row` | normalises a single sample row for `sample_data` |
| `get_sample_data` | extracts / type-casts features for inference testing |
| `_raise_hyperparameter_deprecation_warnings` | warns for deprecated hyperparameter keys |
| `_raise_trainer_config_deprecation_warnings` | extension point for future field deprecations |
| `raise_lightning_trainer_config_deprecation_warnings` | combines both warning helpers |
| `construct_read_kwargs` | builds `ray.data.read_parquet` kwargs |

## Related

- Closes #1359
- Builds on PR 7a (#1415) — imports `ParquetReadConfig`/`DataloadingConfig` from `ray_data_io`
- PR 7c (dispatcher + glue) will follow

## Test plan

- [x] `ruff format --check` clean
- [x] `ruff check` clean
- [x] `pytest` — 69/69 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)