### PR TITLE
feat(ui): add description field to pipeline run form and list

### DIFF
--- a/javascript/packages/core/config/entities/pipeline/__tests__/create-pipeline-run-form.test.tsx
+++ b/javascript/packages/core/config/entities/pipeline/__tests__/create-pipeline-run-form.test.tsx
@@ -102,4 +102,39 @@ describe('CreatePipelineRunForm', () => {
     await screen.findByText(/Test error/);
     expect(screen.getByRole('dialog')).toBeInTheDocument();
   });
+
+  it('includes description in payload when filled in', async () => {
+    const user = userEvent.setup();
+    const mockRequest = createQueryMockRouter({ CreatePipelineRun: {} });
+
+    render(
+      <FormWrapper />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getErrorProviderWrapper(),
+        getInterpolationProviderWrapper(),
+        getRouterWrapper({ location: '/ma-dev-test/train/pipelines' }),
+        getServiceProviderWrapper({ request: mockRequest }),
+      ])
+    );
+
+    const dialog = await screen.findByRole('dialog', { name: 'Start new pipeline run' });
+    await user.type(
+      screen.getByRole('textbox', { name: /description/i }),
+      'nightly evaluation run'
+    );
+    await user.click(within(dialog).getByRole('button', { name: 'Run' }));
+
+    await waitFor(() => {
+      expect(mockRequest).toHaveBeenCalledWith(
+        'CreatePipelineRun',
+        expect.objectContaining({
+          spec: expect.objectContaining({
+            description: 'nightly evaluation run',
+          }) as Record<string, unknown>,
+        })
+      );
+    });
+  });
 });

--- a/javascript/packages/core/config/entities/pipeline/create-pipeline-run-form.tsx
+++ b/javascript/packages/core/config/entities/pipeline/create-pipeline-run-form.tsx
@@ -1,5 +1,6 @@
 import { FormDialog } from '#core/components/form/components/form-dialog/form-dialog';
 import { StringField } from '#core/components/form/fields/string/string-field';
+import { TextareaField } from '#core/components/form/fields/textarea/textarea-field';
 import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
 import { useStudioMutation } from '#core/hooks/use-studio-mutation';
 import { generateSuffix } from '#core/utils/name-utils';
@@ -23,7 +24,7 @@ export const CreatePipelineRunForm = ({ record, onClose }: ActionComponentProps<
     await createPipelineRunMutation.mutateAsync(values);
   };
 
-  const initialValues = {
+  const initialValues: PipelineRun = {
     metadata: {
       name: `run${generateSuffix({ withDate: true })}`,
       namespace: projectId,
@@ -49,6 +50,13 @@ export const CreatePipelineRunForm = ({ record, onClose }: ActionComponentProps<
       initialValues={initialValues}
     >
       <StringField name="spec.pipeline.name" label="Pipeline to run" readOnly />
+
+      <TextareaField
+        name="spec.description"
+        label="Description"
+        placeholder="Enter a description for this run…"
+        description="Optional. Helps identify this run in the pipeline run list."
+      />
     </FormDialog>
   );
 };

--- a/javascript/packages/core/config/entities/run/list.ts
+++ b/javascript/packages/core/config/entities/run/list.ts
@@ -1,3 +1,4 @@
+import { CellType } from '#core/components/cell/constants';
 import { SHARED_RUN_CELL_CONFIG } from './shared';
 
 import type { ColumnConfig } from '#core/components/table/types/column-types';
@@ -7,7 +8,16 @@ export const PIPELINE_RUN_CELL_CONFIG: ColumnConfig<object>[] = [
   {
     id: 'metadata.name',
     label: 'Name',
-    url: '/${studio.projectId}/${studio.phase}/runs/${data.metadata.name}',
+    items: [
+      {
+        id: 'metadata.name',
+        url: '/${studio.projectId}/${studio.phase}/runs/${data.metadata.name}',
+      },
+      {
+        id: 'spec.description',
+        type: CellType.DESCRIPTION,
+      },
+    ],
   },
   ...SHARED_RUN_CELL_CONFIG,
 ];

--- a/javascript/packages/core/config/entities/run/types.ts
+++ b/javascript/packages/core/config/entities/run/types.ts
@@ -11,5 +11,7 @@ export type PipelineRun = {
       name: string;
       namespace: string;
     };
+    /** Optional human-readable description for this run. */
+    description?: string;
   };
 };


### PR DESCRIPTION
Closes #1423

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Adds an optional free-text description to pipeline runs:

- `PipelineRun.spec.description` — new optional `string` field on the type
- `CreatePipelineRunForm` — `TextareaField` bound to `spec.description` directly in the form (no form type extension; the field maps 1:1 to the API shape)
- Pipeline run list — description rendered as secondary text beneath the run name in the Name column via `CellType.DESCRIPTION` + `items` array, matching the standard multi-line cell pattern used in other list views

**Why?**

Pipeline runs had no way to attach a human-readable label to help identify them in the run list. A free-text description field makes it easy to distinguish runs at a glance — especially when multiple runs of the same pipeline are in flight.

**How did you test it?**

- `yarn vitest run packages/core/config/entities/pipeline` — 3/3 tests pass (2 existing + 1 new covering description in payload)
- `prettier --check` — clean
- `eslint` — 0 errors

**Potential risks**

None. `spec.description` is optional — existing `CreatePipelineRun` calls that omit it are unaffected.

**Breaking Changes**

- [x] No breaking changes

**Release notes**

Pipeline run form now includes an optional Description field. When filled in, the description appears beneath the run name in the pipeline run list.

**Documentation Changes**

N/A