### PR TITLE
feat(trainer): flexible experiment tracking abstraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- To be populated.
+- `CustomTrackerConfig` on `ExperimentTrackerConfig`: bring-your-own experiment
+  tracker via a dotted-path factory function (`factory_fn`/`factory_kwargs`),
+  for trackers (W&B, Neptune, etc.) with no dedicated config class.
+- `ExperimentTrackerConfig.tracker` field, a unified entry point for
+  `CometConfig`/`MlflowConfig`/`CustomTrackerConfig` (the legacy `comet=`/
+  `mlflow=` fields still work and are promoted into `tracker` internally).
+- `build_comet_logger` / `build_mlflow_logger` factory functions in
+  `michelangelo.lib.trainer.torch.pytorch_lightning._private.util`, usable
+  as `CustomTrackerConfig.factory_fn` targets.
 
 ### Changed
 
@@ -15,6 +23,12 @@ All notable changes to this project will be documented in this file.
   retained in MySQL. Opt out per delete with `kubectl delete pipeline … --cascade=orphan`. GC deletes
   children with the controller's RBAC, and the MA Studio UI does not yet cascade. See the
   [Cascade Delete operator guide](docs/operator-guides/cascade-delete.md).
+- `MlflowConfig` now fails fast with `ConfigurationError` at construction time
+  (previously it raised `NotImplementedError` later, from inside
+  `train_tabular()`). The error message points at GitHub issue #1427 and the
+  `CustomTrackerConfig` + `build_mlflow_logger` workaround usable today.
+- `MlflowConfig.tracking_uri` is now optional (`str | None`, defaults to
+  `None`), falling back to the `MLFLOW_TRACKING_URI` environment variable.
 
 ### Fixed
 
@@ -40,6 +54,12 @@ All notable changes to this project will be documented in this file.
 
 ### Removed
 
+- **BREAKING: `CometParam` and `LightningTrainerParam.comet_param` have been
+  removed outright**, not deprecated. The original design called for a
+  deprecation cycle, but a repo-wide audit found `task.py` was the only
+  production caller and it is migrated onto the new `ExperimentTrackerConfig`
+  tracker abstraction in this same release — there is no external consumer to
+  break. Use `ExperimentTrackerConfig(tracker=CometConfig(...))` instead.
 - The `controllermgr.cascadeDelete.enable` Helm value and its associated config (cross-binary cascade
   config key, controller-manager `CascadeDeleteConfig`). Cascade is now always on and controlled by
   Kubernetes propagation policy + RBAC instead of a flag.

--- a/python/examples/movielens/README.md
+++ b/python/examples/movielens/README.md
@@ -50,9 +50,10 @@ export COMET_TAGS=demo,movielens,smoke            # optional, comma-separated
 python -m examples.movielens.train
 ```
 
-`train.py` reads these and builds a `CometParam`, which `LightningTrainer`
-forwards through to `_get_comet_logger`. With Comet enabled you'll see a
-"Comet experiment URL: ..." line in the worker logs.
+`train.py` reads these and resolves them into `build_comet_logger` factory
+kwargs, forwarded through `LightningTrainerParam.lightning_trainer_kwargs` so
+the `CometLogger` is constructed inside the Ray Train worker. With Comet
+enabled you'll see a "Comet experiment URL: ..." line in the worker logs.
 
 ### MLflow
 

--- a/python/examples/movielens/train.py
+++ b/python/examples/movielens/train.py
@@ -29,7 +29,6 @@ import ray
 from examples.movielens.data import load_movielens_100k
 from examples.movielens.model import create_ncf_model
 from michelangelo.lib.trainer.torch.pytorch_lightning.lightning_trainer import (
-    CometParam,
     LightningTrainer,
     LightningTrainerParam,
 )
@@ -44,13 +43,20 @@ _STORAGE_DIR = "/tmp/movielens_runs"
 _DEFAULT_COMET_PROJECT = "michelangelo-movielens-demo"
 _DEFAULT_COMET_EXPERIMENT = "ncf-movielens100k"
 _DEFAULT_MLFLOW_EXPERIMENT = "ncf-movielens100k"
+_COMET_LOGGER_FACTORY = (
+    "michelangelo.lib.trainer.torch.pytorch_lightning._private.util.build_comet_logger"
+)
 
 
-def _build_comet_param() -> CometParam | None:
-    """Build a CometParam from env vars, or return None to skip Comet logging.
+def _build_comet_logger_kwargs() -> dict | None:
+    """Build build_comet_logger kwargs from env vars, or None to skip Comet logging.
 
     Both COMET_API_KEY and COMET_WORKSPACE must be set to enable Comet. The
-    other fields fall back to module defaults if unset.
+    other fields fall back to module defaults if unset. Returned as a plain
+    dict (rather than a constructed Logger) so the actual CometLogger is
+    built inside the Ray Train worker via the dotted-path factory —
+    required for the rank-0-creates/others-attach barrier pattern in
+    ``build_comet_logger``.
     """
     api_key = os.environ.get("COMET_API_KEY")
     workspace = os.environ.get("COMET_WORKSPACE")
@@ -58,15 +64,15 @@ def _build_comet_param() -> CometParam | None:
         return None
     tags_env = os.environ.get("COMET_TAGS", "").strip()
     tags = [t.strip() for t in tags_env.split(",") if t.strip()] or None
-    return CometParam(
-        api_key=api_key,
-        workspace=workspace,
-        project_name=os.environ.get("COMET_PROJECT_NAME", _DEFAULT_COMET_PROJECT),
-        experiment_name=os.environ.get(
+    return {
+        "api_key": api_key,
+        "workspace": workspace,
+        "project_name": os.environ.get("COMET_PROJECT_NAME", _DEFAULT_COMET_PROJECT),
+        "experiment_name": os.environ.get(
             "COMET_EXPERIMENT_NAME", _DEFAULT_COMET_EXPERIMENT
         ),
-        tags=tags,
-    )
+        "tags": tags,
+    }
 
 
 def _parse_mlflow_tags(tags_env: str) -> dict | None:
@@ -113,14 +119,14 @@ def main() -> dict:
     splits = load_movielens_100k()
 
     # Pick at most one tracking backend. Comet wins if both env-sets are present.
-    comet_param = _build_comet_param()
+    comet_logger_kwargs = _build_comet_logger_kwargs()
     mlflow_logger = None
-    if comet_param is not None:
+    if comet_logger_kwargs is not None:
         log.info(
             "Comet logging enabled (workspace=%s project=%s experiment=%s)",
-            comet_param.workspace,
-            comet_param.project_name,
-            comet_param.experiment_name,
+            comet_logger_kwargs["workspace"],
+            comet_logger_kwargs["project_name"],
+            comet_logger_kwargs["experiment_name"],
         )
         if os.environ.get("MLFLOW_TRACKING_URI"):
             log.info(
@@ -152,7 +158,13 @@ def main() -> dict:
         # accelerator to CPU keeps this example working on macOS.
         "accelerator": "cpu",
     }
-    if mlflow_logger is not None:
+    if comet_logger_kwargs is not None:
+        # Dotted-path factory: the CometLogger is constructed inside the Ray
+        # Train worker (required for the rank-0-creates/others-attach
+        # barrier pattern in build_comet_logger).
+        lightning_trainer_kwargs["logger"] = _COMET_LOGGER_FACTORY
+        lightning_trainer_kwargs["logger_kwargs"] = comet_logger_kwargs
+    elif mlflow_logger is not None:
         # _resolve_logger accepts a pre-built Logger instance and forwards it
         # to the Lightning Trainer unchanged.
         lightning_trainer_kwargs["logger"] = mlflow_logger
@@ -170,7 +182,6 @@ def main() -> dict:
         val_data=splits.val,
         batch_size=256,
         num_shuffle_batches=10,
-        comet_param=comet_param,
         lightning_trainer_kwargs=lightning_trainer_kwargs,
     )
 

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/__init__.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/__init__.py
@@ -11,18 +11,14 @@ Public surface re-exported below:
   :meth:`update_model_state_dict` for loading trained weights into a fresh
   ``torch.nn.Module``.
 * :class:`LightningTrainerParam` — dataclass holding the training
-  configuration (model factory, datasets, batch size, optional Comet config,
-  warm-start specs, etc.).
-* :class:`CometParam` — Comet ML logger configuration. Forwarded to
-  ``comet_ml`` (imported lazily, so this dataclass is safe to construct
-  without ``comet_ml`` installed).
+  configuration (model factory, datasets, batch size, optional Lightning
+  logger, warm-start specs, etc.).
 * :class:`TransferLearningSpec`, :class:`IncrementalTrainingSpec`,
   :class:`ModelSpec`, :class:`TrainingType`, :class:`LearningMode` — warm-start
   schema types consumed by the trainer.
 """
 
 from michelangelo.lib.trainer.torch.pytorch_lightning.lightning_trainer import (
-    CometParam,
     LightningTrainer,
     LightningTrainerParam,
     LightningTrainerWithStateDict,
@@ -37,7 +33,6 @@ from michelangelo.lib.trainer.torch.pytorch_lightning.schema import (
 )
 
 __all__ = [
-    "CometParam",
     "IncrementalTrainingSpec",
     "LearningMode",
     "LightningTrainer",

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/_private/util.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/_private/util.py
@@ -154,7 +154,7 @@ def _get_comet_logger(
     instance to the shared experiment key derived from ``run_id``.
 
     ``comet_ml`` is imported lazily so the trainer can be imported without it
-    installed; only callers that actually pass a ``comet_param`` need it.
+    installed; only callers that actually build a Comet logger need it.
     """
     import comet_ml
 
@@ -191,6 +191,81 @@ def _get_comet_logger(
     if ray.train.get_context().get_world_rank() == 0:
         _logger.info("Comet experiment URL: %s", comet_logger.experiment.url)
     return comet_logger
+
+
+def build_comet_logger(
+    api_key: str,
+    workspace: str,
+    project_name: str,
+    experiment_name: str,
+    tags: list[str] | None = None,
+    run_id: str | None = None,
+) -> CometLogger:
+    """Build a ``CometLogger`` inside a Ray Train worker.
+
+    Dotted-path factory target for ``LightningTrainerKwargs.logger``,
+    resolved by :func:`_resolve_logger`. ``run_id`` is injected automatically
+    when set on the driver, providing cross-worker experiment correlation.
+
+    Args:
+        api_key: Comet API key.
+        workspace: Comet workspace name.
+        project_name: Comet project name.
+        experiment_name: Comet experiment name.
+        tags: Optional tags attached to the Comet experiment.
+        run_id: Cross-worker correlation id; required for the barrier-based
+            rank-0 experiment creation in :func:`_get_comet_logger`.
+
+    Returns:
+        A ``CometLogger`` attached to the shared experiment for this run.
+    """
+    return _get_comet_logger(
+        run_id=run_id or "",
+        api_key=api_key,
+        workspace=workspace,
+        project_name=project_name,
+        experiment_name=experiment_name,
+        tags=tags,
+    )
+
+
+def build_mlflow_logger(
+    experiment_name: str,
+    tracking_uri: str | None = None,
+    run_name: str | None = None,
+    tags: dict[str, str] | None = None,
+    run_id: str | None = None,
+) -> Logger:
+    """Build an ``MLFlowLogger`` for a Ray Train worker.
+
+    Dotted-path factory target for ``LightningTrainerKwargs.logger``.
+    Unlike Comet, MLflow's client is process-safe and requires no
+    distributed barrier — each worker constructs its logger independently.
+    ``run_id`` lets all workers attach to the same MLflow run for per-rank
+    metric correlation; when ``None``, Lightning's default (rank-0-only
+    logging) applies.
+
+    Args:
+        experiment_name: Name of the MLflow experiment. Created
+            automatically if it does not exist.
+        tracking_uri: MLflow tracking server URI. Falls back to the
+            ``MLFLOW_TRACKING_URI`` environment variable when ``None``.
+        run_name: Optional display name for this training run.
+        tags: Key-value string tags attached to the MLflow run.
+        run_id: Cross-worker correlation id for shared-run logging.
+
+    Returns:
+        An ``MLFlowLogger`` instance.
+    """
+    from pytorch_lightning.loggers import MLFlowLogger
+
+    return MLFlowLogger(
+        experiment_name=experiment_name,
+        tracking_uri=tracking_uri,
+        run_name=run_name,
+        tags=tags or {},
+        run_id=run_id,
+    )
 
 
 def _resolve_strategy(
@@ -278,10 +353,16 @@ def _resolve_plugins(
 def _resolve_logger(
     logger: str | bool | Logger | list[Logger] | None = None,
     logger_kwargs: dict[str, Any] | None = None,
-    comet_param: dict[str, Any] | None = None,
     run_id: str | None = None,
 ) -> bool | Logger | list[Logger] | None:
-    """Resolve the logger for the Lightning Trainer."""
+    """Resolve the logger for the Lightning Trainer.
+
+    When *logger* is a dotted import path, *run_id* is injected into the
+    kwargs passed to the factory (unless already present in *logger_kwargs*)
+    so factories can opt into cross-worker run correlation by declaring a
+    ``run_id: str | None = None`` parameter. Factories that don't need it
+    can omit the parameter — see ``build_comet_logger``/``build_mlflow_logger``.
+    """
     if logger_kwargs is not None and not isinstance(logger_kwargs, dict):
         raise TypeError(
             f"logger_kwargs must be a dict or None, got {type(logger_kwargs)!r}"
@@ -289,10 +370,6 @@ def _resolve_logger(
     if logger_kwargs is not None and not isinstance(logger, str):
         raise TypeError(
             "logger_kwargs can only be used when logger is a str import path"
-        )
-    if comet_param is not None and not isinstance(comet_param, dict):
-        raise TypeError(
-            f"comet_param must be a dict or None, got {type(comet_param)!r}"
         )
 
     if isinstance(logger, bool):
@@ -307,20 +384,14 @@ def _resolve_logger(
         return list(logger)
     if isinstance(logger, str):
         logger_fn = get_module_attr(logger)
-        result = logger_fn(**(logger_kwargs or {}))
+        kwargs = dict(logger_kwargs or {})
+        if run_id is not None:
+            kwargs.setdefault("run_id", run_id)
+        result = logger_fn(**kwargs)
         return list(result) if isinstance(result, (list, tuple)) else result
     if logger is not None:
         raise TypeError(
             f"logger must be a str, bool, Logger instance, list of Logger instances, or None, got {type(logger)!r}"
-        )
-    if comet_param and run_id:
-        return _get_comet_logger(
-            run_id,
-            api_key=comet_param["api_key"],
-            workspace=comet_param["workspace"],
-            project_name=comet_param["project_name"],
-            experiment_name=comet_param["experiment_name"],
-            tags=comet_param.get("tags"),
         )
     return None
 
@@ -520,7 +591,6 @@ def _train_loop_per_worker(train_loop_config):
     logger = _resolve_logger(
         trainer_kwargs.pop("logger", None),
         trainer_kwargs.pop("logger_kwargs", None),
-        train_loop_config.get("comet_param"),
         train_loop_config.get("run_id"),
     )
     callbacks, has_model_checkpoint = _resolve_callbacks(

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/_private/util.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/_private/util.py
@@ -8,6 +8,7 @@ logger / callback resolution helpers. Public APIs live in
 from __future__ import annotations
 
 import hashlib
+import inspect
 import logging
 import os
 import re
@@ -360,8 +361,11 @@ def _resolve_logger(
     When *logger* is a dotted import path, *run_id* is injected into the
     kwargs passed to the factory (unless already present in *logger_kwargs*)
     so factories can opt into cross-worker run correlation by declaring a
-    ``run_id: str | None = None`` parameter. Factories that don't need it
-    can omit the parameter — see ``build_comet_logger``/``build_mlflow_logger``.
+    ``run_id: str | None = None`` parameter — see
+    ``build_comet_logger``/``build_mlflow_logger``. The factory's signature
+    is inspected first, so factories that genuinely don't accept ``run_id``
+    (and don't take ``**kwargs``) are called without it instead of raising
+    ``TypeError`` for an unexpected keyword argument.
     """
     if logger_kwargs is not None and not isinstance(logger_kwargs, dict):
         raise TypeError(
@@ -385,7 +389,7 @@ def _resolve_logger(
     if isinstance(logger, str):
         logger_fn = get_module_attr(logger)
         kwargs = dict(logger_kwargs or {})
-        if run_id is not None:
+        if run_id is not None and _accepts_run_id(logger_fn):
             kwargs.setdefault("run_id", run_id)
         result = logger_fn(**kwargs)
         return list(result) if isinstance(result, (list, tuple)) else result
@@ -394,6 +398,24 @@ def _resolve_logger(
             f"logger must be a str, bool, Logger instance, list of Logger instances, or None, got {type(logger)!r}"
         )
     return None
+
+
+def _accepts_run_id(fn: Any) -> bool:
+    """Return True if calling *fn* with a ``run_id=`` kwarg would not raise.
+
+    True when *fn* declares a ``run_id`` parameter, or accepts ``**kwargs``.
+    Used to make ``run_id`` injection in :func:`_resolve_logger` opt-in for
+    custom tracker factories that don't need cross-worker correlation.
+    """
+    try:
+        params = inspect.signature(fn).parameters
+    except (TypeError, ValueError):
+        # Signature introspection can fail for builtins/some C extensions;
+        # fail open and let the injected run_id surface any real mismatch.
+        return True
+    return "run_id" in params or any(
+        p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()
+    )
 
 
 def _resolve_callbacks(

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/lightning_trainer.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/lightning_trainer.py
@@ -60,30 +60,6 @@ _UNSET = object()
 
 
 @dataclass
-class CometParam:
-    """Configuration for the Comet ML logger.
-
-    Credentials are forwarded as-is to ``comet_ml``; ``api_key`` should be treated
-    as a secret. ``comet_ml`` is imported lazily inside the worker, so this
-    dataclass can be constructed even when ``comet_ml`` is not installed (the
-    import only fires when the trainer actually attaches the logger).
-
-    Attributes:
-        api_key: Comet API key for the target workspace.
-        project_name: Comet project name to log under.
-        experiment_name: Display name for the experiment in the Comet UI.
-        workspace: Comet workspace owning the project.
-        tags: Optional list of tags to attach to the experiment.
-    """
-
-    api_key: str
-    project_name: str
-    experiment_name: str
-    workspace: str
-    tags: list[str] | None = field(default_factory=list)
-
-
-@dataclass
 class LightningTrainerParam:
     """Configuration for :class:`LightningTrainer`.
 
@@ -105,8 +81,6 @@ class LightningTrainerParam:
         data_collate_fn: Optional custom collate function passed to
             ``Dataset.iter_torch_batches``; defaults to Ray Data's column-tensor
             output.
-        comet_param: Optional :class:`CometParam`; when set, a CometLogger is
-            attached on each worker.
         lightning_trainer_kwargs: Extra keyword arguments forwarded verbatim to
             ``pytorch_lightning.Trainer(...)``.
         transfer_learning_spec: Optional warm-start spec describing layer freezing
@@ -131,7 +105,6 @@ class LightningTrainerParam:
     )
     num_epochs: int | None = field(default=_UNSET)  # type: ignore[assignment]  # sentinel replaced in __post_init__
     data_collate_fn: Callable | None = None
-    comet_param: CometParam | None = None
     lightning_trainer_kwargs: dict = field(default_factory=dict)
 
     transfer_learning_spec: TransferLearningSpec | None = None

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_lightning_trainer.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_lightning_trainer.py
@@ -17,66 +17,11 @@ import pytest
 
 from michelangelo.lib.trainer.torch.pytorch_lightning.lightning_trainer import (
     CHECKPOINT_PATH_KEY,
-    CometParam,
     LightningTrainer,
     LightningTrainerParam,
     LightningTrainerWithStateDict,
     _torch_weights_only_disabled,
 )
-
-# -----------------------------------------------------------------------------
-# CometParam
-# -----------------------------------------------------------------------------
-
-
-class TestCometParam:
-    """``CometParam`` dataclass behavior."""
-
-    def test_required_fields(self):
-        """All four required fields are stored verbatim."""
-        param = CometParam(
-            api_key="secret",
-            project_name="proj",
-            experiment_name="exp",
-            workspace="ws",
-        )
-        assert param.api_key == "secret"
-        assert param.project_name == "proj"
-        assert param.experiment_name == "exp"
-        assert param.workspace == "ws"
-
-    def test_tags_default_to_empty_list(self):
-        """The default tag list is an empty list, not None."""
-        param = CometParam(
-            api_key="k",
-            project_name="p",
-            experiment_name="e",
-            workspace="w",
-        )
-        assert param.tags == []
-
-    def test_tags_default_factory_isolates_instances(self):
-        """Mutating one instance's tags must not leak into a sibling."""
-        a = CometParam(
-            api_key="k", project_name="p", experiment_name="e", workspace="w"
-        )
-        b = CometParam(
-            api_key="k", project_name="p", experiment_name="e", workspace="w"
-        )
-        a.tags.append("x")
-        assert b.tags == []
-
-    def test_tags_explicit(self):
-        """Explicit ``tags`` value is preserved."""
-        param = CometParam(
-            api_key="k",
-            project_name="p",
-            experiment_name="e",
-            workspace="w",
-            tags=["foo", "bar"],
-        )
-        assert param.tags == ["foo", "bar"]
-
 
 # -----------------------------------------------------------------------------
 # LightningTrainerParam
@@ -105,7 +50,6 @@ class TestLightningTrainerParam:
         assert param.num_shuffle_batches == 10
         assert param.num_epochs == 1  # _UNSET → 1 in __post_init__
         assert param.data_collate_fn is None
-        assert param.comet_param is None
         assert param.lightning_trainer_kwargs == {}
         assert param.transfer_learning_spec is None
         assert param.incremental_training_spec is None
@@ -149,9 +93,6 @@ class TestLightningTrainerParam:
 
     def test_passes_through_extra_fields(self):
         """Optional fields are accepted and stored as-is."""
-        comet = CometParam(
-            api_key="k", project_name="p", experiment_name="e", workspace="w"
-        )
         collate = MagicMock(name="collate")
         lightning_kwargs = {"strategy": "deepspeed"}
 
@@ -159,7 +100,6 @@ class TestLightningTrainerParam:
             batch_size=64,
             num_shuffle_batches=0,
             data_collate_fn=collate,
-            comet_param=comet,
             lightning_trainer_kwargs=lightning_kwargs,
             initial_weights_path="s3://bucket/weights.pt",
         )
@@ -167,7 +107,6 @@ class TestLightningTrainerParam:
         assert param.batch_size == 64
         assert param.num_shuffle_batches == 0
         assert param.data_collate_fn is collate
-        assert param.comet_param is comet
         assert param.lightning_trainer_kwargs is lightning_kwargs
         assert param.initial_weights_path == "s3://bucket/weights.pt"
 

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_resolve_helpers.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_resolve_helpers.py
@@ -22,6 +22,7 @@ from ray.train.lightning import (
 )
 
 from michelangelo.lib.trainer.torch.pytorch_lightning._private.util import (
+    _accepts_run_id,
     _resolve_callbacks,
     _resolve_logger,
     _resolve_plugins,
@@ -157,6 +158,38 @@ class _FakeLogger(Logger):
         """No-op for tests."""
 
 
+class TestAcceptsRunId:
+    """Signature inspection used to gate ``run_id`` injection."""
+
+    def test_explicit_run_id_param_accepted(self):
+        """A factory declaring ``run_id`` accepts it."""
+
+        def factory(run_id=None):
+            pass
+
+        assert _accepts_run_id(factory) is True
+
+    def test_var_keyword_accepted(self):
+        """A factory accepting ``**kwargs`` accepts ``run_id``."""
+
+        def factory(**kwargs):
+            pass
+
+        assert _accepts_run_id(factory) is True
+
+    def test_no_matching_param_rejected(self):
+        """A factory with neither ``run_id`` nor ``**kwargs`` is rejected."""
+
+        def factory(api_key):
+            pass
+
+        assert _accepts_run_id(factory) is False
+
+    def test_signature_introspection_failure_fails_open(self):
+        """If the signature can't be inspected, fail open (return True)."""
+        assert _accepts_run_id(dict) is True
+
+
 class TestResolveLogger:
     """Logger resolution covers bool, instance, list, and ``None`` paths."""
 
@@ -217,6 +250,28 @@ class TestResolveLogger:
         with patch(f"{_UTIL_MODULE}.get_module_attr", return_value=factory):
             _resolve_logger("some.factory", {"api_key": "k"})
         factory.assert_called_once_with(api_key="k")
+
+    def test_string_logger_without_run_id_param_is_not_injected(self):
+        """A factory that declares no ``run_id`` param is called without it."""
+
+        def factory(api_key: str) -> _FakeLogger:
+            return _FakeLogger()
+
+        with patch(f"{_UTIL_MODULE}.get_module_attr", return_value=factory):
+            result = _resolve_logger("some.factory", {"api_key": "k"}, run_id="run-123")
+        assert isinstance(result, _FakeLogger)
+
+    def test_string_logger_with_kwargs_param_receives_run_id(self):
+        """A factory accepting ``**kwargs`` still receives an injected run_id."""
+        calls = {}
+
+        def factory(**kwargs) -> _FakeLogger:
+            calls.update(kwargs)
+            return _FakeLogger()
+
+        with patch(f"{_UTIL_MODULE}.get_module_attr", return_value=factory):
+            _resolve_logger("some.factory", {"api_key": "k"}, run_id="run-123")
+        assert calls == {"api_key": "k", "run_id": "run-123"}
 
 
 # -----------------------------------------------------------------------------

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_resolve_helpers.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_resolve_helpers.py
@@ -26,6 +26,8 @@ from michelangelo.lib.trainer.torch.pytorch_lightning._private.util import (
     _resolve_logger,
     _resolve_plugins,
     _resolve_strategy,
+    build_comet_logger,
+    build_mlflow_logger,
 )
 
 _UTIL_MODULE = "michelangelo.lib.trainer.torch.pytorch_lightning._private.util"
@@ -184,8 +186,8 @@ class TestResolveLogger:
         with pytest.raises(TypeError, match="logger must be"):
             _resolve_logger(123)
 
-    def test_none_with_no_comet_returns_none(self):
-        """``None`` input + no ``comet_param`` falls back to ``None``."""
+    def test_none_with_no_logger_returns_none(self):
+        """``None`` input falls back to ``None`` (tracking disabled)."""
         assert _resolve_logger(None) is None
 
     def test_logger_kwargs_requires_string_logger(self):
@@ -193,10 +195,99 @@ class TestResolveLogger:
         with pytest.raises(TypeError, match="logger_kwargs can only be used"):
             _resolve_logger(True, logger_kwargs={"x": 1})
 
-    def test_invalid_comet_param_type_raises(self):
-        """``comet_param`` must be a dict when set."""
-        with pytest.raises(TypeError, match="comet_param must be"):
-            _resolve_logger(None, comet_param="not-a-dict")
+    def test_string_logger_injects_run_id(self):
+        """A string-path logger factory receives run_id when the driver sets one."""
+        factory = MagicMock(return_value=_FakeLogger())
+        with patch(f"{_UTIL_MODULE}.get_module_attr", return_value=factory):
+            _resolve_logger("some.factory", {"api_key": "k"}, run_id="run-123")
+        factory.assert_called_once_with(api_key="k", run_id="run-123")
+
+    def test_string_logger_does_not_override_explicit_run_id(self):
+        """An explicit run_id in logger_kwargs is not overwritten by the driver's run_id."""
+        factory = MagicMock(return_value=_FakeLogger())
+        with patch(f"{_UTIL_MODULE}.get_module_attr", return_value=factory):
+            _resolve_logger(
+                "some.factory", {"run_id": "explicit"}, run_id="driver-run-id"
+            )
+        factory.assert_called_once_with(run_id="explicit")
+
+    def test_string_logger_without_run_id_omits_it(self):
+        """When the driver has no run_id, it is not injected into kwargs."""
+        factory = MagicMock(return_value=_FakeLogger())
+        with patch(f"{_UTIL_MODULE}.get_module_attr", return_value=factory):
+            _resolve_logger("some.factory", {"api_key": "k"})
+        factory.assert_called_once_with(api_key="k")
+
+
+# -----------------------------------------------------------------------------
+# build_comet_logger / build_mlflow_logger
+# -----------------------------------------------------------------------------
+
+
+class TestBuildCometLogger:
+    """``build_comet_logger`` delegates to ``_get_comet_logger`` with run_id."""
+
+    def test_delegates_to_get_comet_logger(self):
+        """All kwargs are forwarded, with run_id defaulting to an empty string."""
+        sentinel = _FakeLogger()
+        with patch(
+            f"{_UTIL_MODULE}._get_comet_logger", return_value=sentinel
+        ) as mock_get:
+            result = build_comet_logger(
+                api_key="k",
+                workspace="ws",
+                project_name="proj",
+                experiment_name="exp",
+                tags=["a"],
+                run_id="run-1",
+            )
+        assert result is sentinel
+        mock_get.assert_called_once_with(
+            run_id="run-1",
+            api_key="k",
+            workspace="ws",
+            project_name="proj",
+            experiment_name="exp",
+            tags=["a"],
+        )
+
+    def test_run_id_defaults_to_empty_string(self):
+        """When run_id is None, an empty string is passed through (rank-0 barrier still works)."""
+        with patch(
+            f"{_UTIL_MODULE}._get_comet_logger", return_value=_FakeLogger()
+        ) as mock_get:
+            build_comet_logger(
+                api_key="k", workspace="ws", project_name="p", experiment_name="e"
+            )
+        assert mock_get.call_args.kwargs["run_id"] == ""
+
+
+class TestBuildMlflowLogger:
+    """``build_mlflow_logger`` constructs an ``MLFlowLogger``."""
+
+    def test_constructs_mlflow_logger_with_kwargs(self):
+        """All kwargs are forwarded to MLFlowLogger, including run_id for correlation."""
+        with patch("pytorch_lightning.loggers.MLFlowLogger") as mock_cls:
+            build_mlflow_logger(
+                experiment_name="exp",
+                tracking_uri="http://mlflow.example.com",
+                run_name="run-1",
+                tags={"env": "prod"},
+                run_id="run-123",
+            )
+        mock_cls.assert_called_once_with(
+            experiment_name="exp",
+            tracking_uri="http://mlflow.example.com",
+            run_name="run-1",
+            tags={"env": "prod"},
+            run_id="run-123",
+        )
+
+    def test_defaults_tags_to_empty_dict(self):
+        """tags=None is normalized to an empty dict."""
+        with patch("pytorch_lightning.loggers.MLFlowLogger") as mock_cls:
+            build_mlflow_logger(experiment_name="exp")
+        assert mock_cls.call_args.kwargs["tags"] == {}
 
 
 # -----------------------------------------------------------------------------

--- a/python/michelangelo/workflow/schema/tabular_trainer.py
+++ b/python/michelangelo/workflow/schema/tabular_trainer.py
@@ -7,10 +7,9 @@ and its backends. Mirrors the structure of ``michelangelo.workflow.schema.pusher
 
 from __future__ import annotations
 
-import dataclasses
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any
+from typing import Any, ClassVar
 
 from michelangelo.workflow.schema.exceptions import ConfigurationError
 from michelangelo.workflow.schema.ray_data_io import (
@@ -102,9 +101,14 @@ class TrackerConfig:
     raise with a specific message; ``__post_init__`` calls it immediately
     at construction time so misconfiguration is caught before training
     starts, not minutes into a run.
+
+    ``_oss_supported`` is a ``ClassVar``, not a dataclass field: these
+    configs are serialized through the UniFlow codec (``asdict()`` then
+    ``cls(**dct)``), and a field would round-trip into the constructor as
+    an unexpected keyword argument.
     """
 
-    _oss_supported: bool = dataclasses.field(default=True, init=False, repr=False)
+    _oss_supported: ClassVar[bool] = True
 
     def __post_init__(self) -> None:
         """Fail fast at construction time for trackers not yet supported in OSS."""
@@ -168,32 +172,43 @@ class MlflowConfig(TrackerConfig):
         tags: Key-value string tags attached to the MLflow run.
 
     Raises:
-        ConfigurationError: MLflow experiment tracking is not yet wired in
-            OSS michelangelo (see GitHub issue #1427). Raised immediately at
-            construction time. Use ``CometConfig`` or ``CustomTrackerConfig``
-            instead.
+        ConfigurationError: ``MlflowConfig`` itself is not yet wired in OSS
+            michelangelo (see GitHub issue #1427). Raised immediately at
+            construction time. MLflow is usable today via
+            ``CustomTrackerConfig(factory_fn="michelangelo.lib.trainer.torch"
+            ".pytorch_lightning._private.util.build_mlflow_logger", ...)``.
 
     Example:
         Constructing this config always raises ``ConfigurationError`` until
         GitHub issue #1427 is resolved::
 
             MlflowConfig(experiment_name="tabular-ctr")
-            # ConfigurationError: MLflow experiment tracking is not yet
-            # wired in OSS michelangelo (see GitHub issue #1427)...
+            # ConfigurationError: MlflowConfig is not yet wired in OSS
+            # michelangelo (see GitHub issue #1427)...
+
+        Use MLflow today via the BYOT escape hatch instead::
+
+            CustomTrackerConfig(
+                factory_fn="michelangelo.lib.trainer.torch.pytorch_lightning"
+                "._private.util.build_mlflow_logger",
+                factory_kwargs={"experiment_name": "tabular-ctr"},
+            )
     """
 
     experiment_name: str
     tracking_uri: str | None = None
     run_name: str | None = None
     tags: dict[str, str] = field(default_factory=dict)
-    _oss_supported: bool = dataclasses.field(default=False, init=False, repr=False)
+    _oss_supported: ClassVar[bool] = False
 
     def _check_oss_supported(self) -> None:
         """Raise with a message pointing at the tracking issue and alternatives."""
         raise ConfigurationError(
-            "MLflow experiment tracking is not yet wired in OSS michelangelo "
-            "(see GitHub issue #1427). Use CometConfig or CustomTrackerConfig "
-            "instead. This will be removed once #1427 ships."
+            "MlflowConfig is not yet wired in OSS michelangelo (see GitHub "
+            "issue #1427). MLflow is usable today via CustomTrackerConfig("
+            "factory_fn='michelangelo.lib.trainer.torch.pytorch_lightning."
+            "_private.util.build_mlflow_logger', ...); this MlflowConfig "
+            "convenience wrapper will be enabled once #1427 ships."
         )
 
 
@@ -294,8 +309,8 @@ class ExperimentTrackerConfig:
         if len(legacy) > 1:
             raise ConfigurationError(
                 f"At most one tracker allowed, got: {[n for n, _ in legacy]}. "
-                "Choose one of ExperimentTrackerConfig(comet=...) or "
-                "ExperimentTrackerConfig(mlflow=...)."
+                "Use ExperimentTrackerConfig(tracker=CometConfig(...)) "
+                "(preferred) or a single legacy field."
             )
         if self.comet is not None:
             self.tracker = self.comet

--- a/python/michelangelo/workflow/schema/tabular_trainer.py
+++ b/python/michelangelo/workflow/schema/tabular_trainer.py
@@ -7,8 +7,10 @@ and its backends. Mirrors the structure of ``michelangelo.workflow.schema.pusher
 
 from __future__ import annotations
 
+import dataclasses
 from dataclasses import dataclass, field
 from enum import Enum
+from typing import Any
 
 from michelangelo.workflow.schema.exceptions import ConfigurationError
 from michelangelo.workflow.schema.ray_data_io import (
@@ -23,6 +25,7 @@ __all__ = [
     "CheckpointScoreOrder",
     "ColumnConfig",
     "CometConfig",
+    "CustomTrackerConfig",
     "CustomTrainerConfig",
     "DataloadingConfig",
     "ExperimentTrackerConfig",
@@ -33,6 +36,7 @@ __all__ = [
     "ParquetReadConfig",
     "ScalingConfig",
     "TabularTrainerConfig",
+    "TrackerConfig",
     "TransferLearningSpecConfig",
 ]
 
@@ -90,10 +94,36 @@ class ColumnConfig:
 
 
 @dataclass
-class CometConfig:
+class TrackerConfig:
+    """Base for all experiment tracker configurations.
+
+    Subclasses that are not yet wired in OSS set ``_oss_supported = False``
+    as a class-level default and override :meth:`_check_oss_supported` to
+    raise with a specific message; ``__post_init__`` calls it immediately
+    at construction time so misconfiguration is caught before training
+    starts, not minutes into a run.
+    """
+
+    _oss_supported: bool = dataclasses.field(default=True, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        """Fail fast at construction time for trackers not yet supported in OSS."""
+        if not self._oss_supported:
+            self._check_oss_supported()
+
+    def _check_oss_supported(self) -> None:
+        """Raise ``ConfigurationError``; subclasses override with a specific message."""
+        raise ConfigurationError(
+            f"{type(self).__name__} is not yet supported in OSS michelangelo."
+        )
+
+
+@dataclass
+class CometConfig(TrackerConfig):
     """Comet ML experiment tracking configuration.
 
-    Pass to ``ExperimentTrackerConfig(comet=CometConfig(...))`` on
+    Pass to ``ExperimentTrackerConfig(tracker=CometConfig(...))`` (or the
+    legacy ``ExperimentTrackerConfig(comet=CometConfig(...))``) on
     ``LightningTrainerConfig``.
 
     Attributes:
@@ -101,6 +131,7 @@ class CometConfig:
         workspace: Comet workspace name.
         project_name: Comet project name.
         experiment_name: Comet experiment name.
+        tags: Optional tags attached to the Comet experiment.
 
     Example:
         >>> cfg = CometConfig(
@@ -115,93 +146,161 @@ class CometConfig:
     workspace: str
     project_name: str
     experiment_name: str
+    tags: list[str] = field(default_factory=list)
 
 
 @dataclass
-class MlflowConfig:
+class MlflowConfig(TrackerConfig):
     """MLflow experiment tracking configuration.
 
     Pass to ``ExperimentTrackerConfig(mlflow=MlflowConfig(...))`` on
     ``LightningTrainerConfig``.
 
     Attributes:
-        tracking_uri: MLflow tracking server URI, e.g.
-            ``"http://localhost:5000"`` or ``"sqlite:///mlflow.db"``.
         experiment_name: Name of the MLflow experiment. Created automatically
             if it does not exist.
+        tracking_uri: MLflow tracking server URI, e.g.
+            ``"http://localhost:5000"`` or ``"sqlite:///mlflow.db"``. Falls
+            back to the ``MLFLOW_TRACKING_URI`` environment variable when
+            ``None``.
         run_name: Optional display name for this training run. Auto-generated
             when ``None``.
         tags: Key-value string tags attached to the MLflow run.
 
+    Raises:
+        ConfigurationError: MLflow experiment tracking is not yet wired in
+            OSS michelangelo (see GitHub issue #1427). Raised immediately at
+            construction time. Use ``CometConfig`` or ``CustomTrackerConfig``
+            instead.
+
     Example:
-        >>> cfg = MlflowConfig(
-        ...     tracking_uri="http://mlflow.example.com",
-        ...     experiment_name="tabular-ctr",
-        ...     run_name="xgb-baseline",
-        ... )
+        Constructing this config always raises ``ConfigurationError`` until
+        GitHub issue #1427 is resolved::
+
+            MlflowConfig(experiment_name="tabular-ctr")
+            # ConfigurationError: MLflow experiment tracking is not yet
+            # wired in OSS michelangelo (see GitHub issue #1427)...
     """
 
-    tracking_uri: str
     experiment_name: str
+    tracking_uri: str | None = None
     run_name: str | None = None
     tags: dict[str, str] = field(default_factory=dict)
+    _oss_supported: bool = dataclasses.field(default=False, init=False, repr=False)
+
+    def _check_oss_supported(self) -> None:
+        """Raise with a message pointing at the tracking issue and alternatives."""
+        raise ConfigurationError(
+            "MLflow experiment tracking is not yet wired in OSS michelangelo "
+            "(see GitHub issue #1427). Use CometConfig or CustomTrackerConfig "
+            "instead. This will be removed once #1427 ships."
+        )
+
+
+@dataclass
+class CustomTrackerConfig(TrackerConfig):
+    """Bring-your-own experiment tracker via a dotted-path factory function.
+
+    ``factory_fn`` is a dotted import path to a callable that returns a
+    ``lightning.pytorch.loggers.Logger`` or ``list[Logger]``. The factory is
+    called inside the Ray Train worker with ``**factory_kwargs`` plus an
+    optional ``run_id: str | None`` kwarg for distributed correlation.
+    Factories that want per-worker run correlation should accept
+    ``run_id=None`` as an optional kwarg; factories that don't need it can
+    omit the parameter entirely.
+
+    Attributes:
+        factory_fn: Dotted import path to the logger factory callable.
+        factory_kwargs: Kwargs forwarded to the factory (excluding ``run_id``,
+            which is injected automatically when the factory accepts it).
+
+    Example — Weights & Biases:
+        >>> # myproject/loggers.py
+        >>> def make_wandb_logger(project, run_name, run_id=None):
+        ...     from lightning.pytorch.loggers import WandbLogger
+        ...     return WandbLogger(project=project, name=run_name, id=run_id)
+        >>> CustomTrackerConfig(
+        ...     factory_fn="myproject.loggers.make_wandb_logger",
+        ...     factory_kwargs={"project": "ctr-model", "run_name": "xgb-v3"},
+        ... )
+        CustomTrackerConfig(factory_fn='myproject.loggers.make_wandb_logger', ...)
+    """
+
+    factory_fn: str
+    factory_kwargs: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
 class ExperimentTrackerConfig:
     """Experiment tracking backend configuration.
 
-    Exactly zero or one tracker may be active at a time. Set neither to
-    disable experiment tracking entirely. Setting more than one raises
-    ``ConfigurationError``.
+    Two styles accepted, mutually exclusive:
 
-    **Adding a new backend:** add a typed field here (e.g.
-    ``wandb: WandbConfig | None = None``) and a corresponding branch in
-    ``trainer_task._build_experiment_tracker``. When a second workflow task
-    (e.g. ``llm_trainer``) needs this class, extract it to
-    ``michelangelo.workflow.schema.experiment_tracker`` and import from there.
+    - **New style** (preferred): ``tracker=CometConfig(...)`` or
+      ``tracker=CustomTrackerConfig(...)``.
+    - **Legacy style**: ``comet=CometConfig(...)`` or
+      ``mlflow=MlflowConfig(...)`` — promoted to ``tracker`` in
+      ``__post_init__``. All existing configs continue to work unchanged.
+
+    **Adding a new backend:** define a ``TrackerConfig`` subclass and pass
+    it via ``tracker=``. No changes to this class are required — see
+    ``CustomTrackerConfig`` for the bring-your-own-tracker escape hatch.
 
     Attributes:
-        comet: Comet ML tracker configuration.
-        mlflow: MLflow tracker configuration.
+        tracker: Unified tracker config field (preferred).
+        comet: Legacy Comet ML tracker configuration field.
+        mlflow: Legacy MLflow tracker configuration field.
 
     Raises:
-        ConfigurationError: If more than one tracker backend is configured.
-            Set at most one of ``comet`` or ``mlflow``.
+        ConfigurationError: If both ``tracker`` and a legacy field are set,
+            if more than one legacy field is set, or if the resolved tracker
+            type sets ``_oss_supported = False`` (e.g. ``MlflowConfig``,
+            which raises when constructed regardless of this class).
 
     Example — Comet ML:
         >>> ExperimentTrackerConfig(
-        ...     comet=CometConfig(
+        ...     tracker=CometConfig(
         ...         api_key="key", workspace="ws",
         ...         project_name="proj", experiment_name="exp",
         ...     )
         ... )
 
-    Example — MLflow:
+    Example — bring-your-own tracker:
         >>> ExperimentTrackerConfig(
-        ...     mlflow=MlflowConfig(
-        ...         tracking_uri="http://mlflow.example.com",
-        ...         experiment_name="tabular-ctr",
+        ...     tracker=CustomTrackerConfig(
+        ...         factory_fn="myproject.loggers.make_wandb_logger",
+        ...         factory_kwargs={"project": "ctr-model"},
         ...     )
         ... )
     """
 
+    tracker: TrackerConfig | None = None
     comet: CometConfig | None = None
     mlflow: MlflowConfig | None = None
 
     def __post_init__(self) -> None:
-        """Validate that at most one tracker backend is configured."""
-        active = [
-            name
+        """Validate exclusivity and promote legacy fields into ``tracker``."""
+        legacy = [
+            (name, val)
             for name, val in [("comet", self.comet), ("mlflow", self.mlflow)]
             if val is not None
         ]
-        if len(active) > 1:
+        if self.tracker is not None and legacy:
             raise ConfigurationError(
-                f"At most one experiment tracker can be set, got: {active}. "
+                f"Cannot set both 'tracker' and legacy fields "
+                f"{[n for n, _ in legacy]}. "
+                "Use ExperimentTrackerConfig(tracker=...) alone."
+            )
+        if len(legacy) > 1:
+            raise ConfigurationError(
+                f"At most one tracker allowed, got: {[n for n, _ in legacy]}. "
                 "Choose one of ExperimentTrackerConfig(comet=...) or "
                 "ExperimentTrackerConfig(mlflow=...)."
             )
+        if self.comet is not None:
+            self.tracker = self.comet
+        elif self.mlflow is not None:
+            self.tracker = self.mlflow
 
 
 @dataclass
@@ -472,8 +571,10 @@ class LightningTrainerConfig:
             ``lightning.pytorch.Trainer``.
         hyperparameters: Catch-all dict for kwargs not covered by the
             structured fields. Highly discouraged; prefer structured fields.
-        experiment_tracker: Experiment tracking backend (Comet ML or MLflow).
-            ``None`` disables experiment tracking.
+        experiment_tracker: Experiment tracking backend (Comet ML, or a
+            custom tracker via ``CustomTrackerConfig``). ``None`` disables
+            experiment tracking. MLflow is not yet wired in OSS — see
+            ``MlflowConfig``.
         transfer_learning_spec: Transfer-learning spec config. Setting this
             raises ``NotImplementedError`` until the spec builder is ported.
         incremental_training_mode: Incremental training mode config.
@@ -563,9 +664,9 @@ class TabularTrainerConfig:
         ...         ),
         ...         scaling_config=ScalingConfig(cpu_per_worker=4),
         ...         experiment_tracker=ExperimentTrackerConfig(
-        ...             mlflow=MlflowConfig(
-        ...                 tracking_uri="http://mlflow.example.com",
-        ...                 experiment_name="tabular-ctr",
+        ...             tracker=CometConfig(
+        ...                 api_key="key", workspace="ws",
+        ...                 project_name="tabular-ctr", experiment_name="xgb-v3",
         ...             ),
         ...         ),
         ...     )

--- a/python/michelangelo/workflow/schema/tests/tabular_trainer_test.py
+++ b/python/michelangelo/workflow/schema/tests/tabular_trainer_test.py
@@ -95,6 +95,64 @@ class TestTrackerConfig(TestCase):
         self.assertTrue(cfg._oss_supported)
 
 
+class TestTrackerConfigSerialization(TestCase):
+    """Tracker configs must round-trip through serialization.
+
+    They must round-trip through both ``dataclasses.asdict`` and the UniFlow
+    ``DataclassCodec``, since task args/kwargs are codec-encoded on the
+    driver and decoded on the worker. ``_oss_supported`` is a ``ClassVar``
+    specifically so it is excluded from both.
+    """
+
+    def test_comet_config_asdict_roundtrip(self):
+        """dataclasses.asdict()/cls(**dct) round-trips CometConfig."""
+        import dataclasses
+
+        cfg = CometConfig(
+            api_key="k", workspace="ws", project_name="proj", experiment_name="exp"
+        )
+        dct = dataclasses.asdict(cfg)
+        self.assertNotIn("_oss_supported", dct)
+        self.assertEqual(CometConfig(**dct), cfg)
+
+    def test_custom_tracker_config_asdict_roundtrip(self):
+        """dataclasses.asdict()/cls(**dct) round-trips CustomTrackerConfig."""
+        import dataclasses
+
+        cfg = CustomTrackerConfig(factory_fn="myproject.loggers.make_logger")
+        dct = dataclasses.asdict(cfg)
+        self.assertNotIn("_oss_supported", dct)
+        self.assertEqual(CustomTrackerConfig(**dct), cfg)
+
+    def test_comet_config_codec_roundtrip(self):
+        """CometConfig round-trips through the UniFlow DataclassCodec."""
+        from michelangelo.uniflow.core.codec import DataclassCodec
+
+        codec = DataclassCodec()
+        cfg = CometConfig(
+            api_key="k", workspace="ws", project_name="proj", experiment_name="exp"
+        )
+        decoded = codec.decode(codec.encode(cfg))
+        self.assertEqual(decoded, cfg)
+
+    def test_nested_experiment_tracker_config_codec_roundtrip(self):
+        """Nested tracker configs survive an outer codec round-trip.
+
+        ``ExperimentTrackerConfig(tracker=CometConfig(...))`` round-trips
+        through the codec at both levels (the outer dict encodes the nested
+        dataclass as a plain dict via ``dataclasses.asdict`` semantics).
+        """
+        from michelangelo.uniflow.core.codec import DataclassCodec
+
+        codec = DataclassCodec()
+        comet = CometConfig(
+            api_key="k", workspace="ws", project_name="proj", experiment_name="exp"
+        )
+        cfg = ExperimentTrackerConfig(tracker=comet)
+        decoded = codec.decode(codec.encode(cfg))
+        self.assertEqual(decoded.tracker, comet)
+
+
 # ---------------------------------------------------------------------------
 # CometConfig
 # ---------------------------------------------------------------------------
@@ -352,15 +410,15 @@ class TestMlflowConfig(TestCase):
             MlflowConfig(experiment_name="tabular-ctr")
 
     def test_error_message_references_issue_and_alternatives(self):
-        """Error message points at #1427 and suggests alternative trackers."""
+        """Error message points at #1427 and the CustomTrackerConfig workaround."""
         with self.assertRaises(ConfigurationError) as ctx:
             MlflowConfig(
                 experiment_name="exp", tracking_uri="http://mlflow.example.com"
             )
         msg = str(ctx.exception)
         self.assertIn("1427", msg)
-        self.assertIn("CometConfig", msg)
         self.assertIn("CustomTrackerConfig", msg)
+        self.assertIn("build_mlflow_logger", msg)
 
     def test_tracking_uri_is_optional(self):
         """tracking_uri defaults to None, independent of the OSS-support raise."""

--- a/python/michelangelo/workflow/schema/tests/tabular_trainer_test.py
+++ b/python/michelangelo/workflow/schema/tests/tabular_trainer_test.py
@@ -10,6 +10,7 @@ from michelangelo.workflow.schema.tabular_trainer import (
     CheckpointScoreOrder,
     ColumnConfig,
     CometConfig,
+    CustomTrackerConfig,
     CustomTrainerConfig,
     ExperimentTrackerConfig,
     IncrementalTrainingModeConfig,
@@ -18,6 +19,7 @@ from michelangelo.workflow.schema.tabular_trainer import (
     MlflowConfig,
     ScalingConfig,
     TabularTrainerConfig,
+    TrackerConfig,
 )
 
 # ---------------------------------------------------------------------------
@@ -80,6 +82,20 @@ class TestColumnConfig(TestCase):
 
 
 # ---------------------------------------------------------------------------
+# TrackerConfig
+# ---------------------------------------------------------------------------
+
+
+class TestTrackerConfig(TestCase):
+    """Tests for the TrackerConfig base class."""
+
+    def test_default_oss_supported_true(self):
+        """Base class defaults to _oss_supported=True and does not raise."""
+        cfg = TrackerConfig()
+        self.assertTrue(cfg._oss_supported)
+
+
+# ---------------------------------------------------------------------------
 # CometConfig
 # ---------------------------------------------------------------------------
 
@@ -88,7 +104,7 @@ class TestCometConfig(TestCase):
     """Tests for CometConfig dataclass."""
 
     def test_all_fields_stored(self):
-        """It stores all four required fields."""
+        """It stores all required fields and defaults tags to an empty list."""
         cfg = CometConfig(
             api_key="k", workspace="ws", project_name="proj", experiment_name="exp"
         )
@@ -96,6 +112,62 @@ class TestCometConfig(TestCase):
         self.assertEqual(cfg.workspace, "ws")
         self.assertEqual(cfg.project_name, "proj")
         self.assertEqual(cfg.experiment_name, "exp")
+        self.assertEqual(cfg.tags, [])
+
+    def test_is_tracker_config(self):
+        """CometConfig extends TrackerConfig and is OSS-supported."""
+        cfg = CometConfig(
+            api_key="k", workspace="ws", project_name="proj", experiment_name="exp"
+        )
+        self.assertIsInstance(cfg, TrackerConfig)
+        self.assertTrue(cfg._oss_supported)
+
+    def test_tags_instances_are_independent(self):
+        """Default tags lists are not shared between instances."""
+        a = CometConfig(
+            api_key="k", workspace="w", project_name="p", experiment_name="e"
+        )
+        b = CometConfig(
+            api_key="k", workspace="w", project_name="p", experiment_name="e"
+        )
+        a.tags.append("x")
+        self.assertEqual(b.tags, [])
+
+
+# ---------------------------------------------------------------------------
+# CustomTrackerConfig
+# ---------------------------------------------------------------------------
+
+
+class TestCustomTrackerConfig(TestCase):
+    """Tests for CustomTrackerConfig (bring-your-own tracker)."""
+
+    def test_required_field(self):
+        """factory_fn is required; factory_kwargs defaults to an empty dict."""
+        cfg = CustomTrackerConfig(factory_fn="myproject.loggers.make_wandb_logger")
+        self.assertEqual(cfg.factory_fn, "myproject.loggers.make_wandb_logger")
+        self.assertEqual(cfg.factory_kwargs, {})
+
+    def test_factory_kwargs_stored(self):
+        """factory_kwargs round-trips."""
+        cfg = CustomTrackerConfig(
+            factory_fn="myproject.loggers.make_wandb_logger",
+            factory_kwargs={"project": "ctr-model"},
+        )
+        self.assertEqual(cfg.factory_kwargs, {"project": "ctr-model"})
+
+    def test_is_tracker_config(self):
+        """CustomTrackerConfig extends TrackerConfig and is OSS-supported."""
+        cfg = CustomTrackerConfig(factory_fn="myproject.loggers.make_wandb_logger")
+        self.assertIsInstance(cfg, TrackerConfig)
+        self.assertTrue(cfg._oss_supported)
+
+    def test_factory_kwargs_instances_are_independent(self):
+        """Default factory_kwargs dicts are not shared between instances."""
+        a = CustomTrackerConfig(factory_fn="f")
+        b = CustomTrackerConfig(factory_fn="f")
+        a.factory_kwargs["k"] = "v"
+        self.assertEqual(b.factory_kwargs, {})
 
 
 # ---------------------------------------------------------------------------
@@ -272,36 +344,28 @@ class TestCustomTrainerConfig(TestCase):
 
 
 class TestMlflowConfig(TestCase):
-    """Tests for MlflowConfig dataclass."""
+    """Tests for MlflowConfig dataclass — not yet supported in OSS."""
 
-    def test_required_fields(self):
-        """tracking_uri and experiment_name are required; rest default."""
-        cfg = MlflowConfig(
-            tracking_uri="http://mlflow.example.com",
-            experiment_name="tabular-ctr",
-        )
-        self.assertEqual(cfg.tracking_uri, "http://mlflow.example.com")
-        self.assertEqual(cfg.experiment_name, "tabular-ctr")
-        self.assertIsNone(cfg.run_name)
-        self.assertEqual(cfg.tags, {})
+    def test_construction_raises_configuration_error(self):
+        """Constructing MlflowConfig always raises ConfigurationError (issue #1427)."""
+        with self.assertRaises(ConfigurationError):
+            MlflowConfig(experiment_name="tabular-ctr")
 
-    def test_all_fields_stored(self):
-        """It stores all optional fields when provided."""
-        cfg = MlflowConfig(
-            tracking_uri="sqlite:///mlflow.db",
-            experiment_name="exp",
-            run_name="run-1",
-            tags={"env": "prod"},
-        )
-        self.assertEqual(cfg.run_name, "run-1")
-        self.assertEqual(cfg.tags, {"env": "prod"})
+    def test_error_message_references_issue_and_alternatives(self):
+        """Error message points at #1427 and suggests alternative trackers."""
+        with self.assertRaises(ConfigurationError) as ctx:
+            MlflowConfig(
+                experiment_name="exp", tracking_uri="http://mlflow.example.com"
+            )
+        msg = str(ctx.exception)
+        self.assertIn("1427", msg)
+        self.assertIn("CometConfig", msg)
+        self.assertIn("CustomTrackerConfig", msg)
 
-    def test_tags_instances_are_independent(self):
-        """Default tags dicts are not shared between instances."""
-        a = MlflowConfig(tracking_uri="u", experiment_name="e")
-        b = MlflowConfig(tracking_uri="u", experiment_name="e")
-        a.tags["key"] = "val"
-        self.assertEqual(b.tags, {})
+    def test_tracking_uri_is_optional(self):
+        """tracking_uri defaults to None, independent of the OSS-support raise."""
+        with self.assertRaises(ConfigurationError):
+            MlflowConfig(experiment_name="exp")
 
 
 # ---------------------------------------------------------------------------
@@ -310,50 +374,55 @@ class TestMlflowConfig(TestCase):
 
 
 class TestExperimentTrackerConfig(TestCase):
-    """Tests for ExperimentTrackerConfig validation."""
+    """Tests for ExperimentTrackerConfig validation and legacy-field promotion."""
 
     def _comet(self) -> CometConfig:
         return CometConfig(
             api_key="k", workspace="ws", project_name="p", experiment_name="e"
         )
 
-    def _mlflow(self) -> MlflowConfig:
-        return MlflowConfig(
-            tracking_uri="http://mlflow.example.com", experiment_name="exp"
-        )
-
     def test_no_tracker_ok(self):
-        """Setting neither tracker is valid (no tracking)."""
+        """Setting nothing is valid (no tracking)."""
         cfg = ExperimentTrackerConfig()
+        self.assertIsNone(cfg.tracker)
         self.assertIsNone(cfg.comet)
         self.assertIsNone(cfg.mlflow)
 
-    def test_comet_only_ok(self):
-        """Setting only comet is valid."""
+    def test_tracker_field_ok(self):
+        """Setting tracker= directly (preferred style) is valid."""
+        comet = self._comet()
+        cfg = ExperimentTrackerConfig(tracker=comet)
+        self.assertIs(cfg.tracker, comet)
+
+    def test_custom_tracker_via_tracker_field(self):
+        """CustomTrackerConfig is accepted via the tracker field."""
+        custom = CustomTrackerConfig(factory_fn="myproject.loggers.make_wandb_logger")
+        cfg = ExperimentTrackerConfig(tracker=custom)
+        self.assertIs(cfg.tracker, custom)
+
+    def test_legacy_comet_promoted_to_tracker(self):
+        """Legacy comet= is promoted into the tracker field."""
         comet = self._comet()
         cfg = ExperimentTrackerConfig(comet=comet)
         self.assertIs(cfg.comet, comet)
-        self.assertIsNone(cfg.mlflow)
+        self.assertIs(cfg.tracker, comet)
 
-    def test_mlflow_only_ok(self):
-        """Setting only mlflow is valid."""
-        mlflow = self._mlflow()
-        cfg = ExperimentTrackerConfig(mlflow=mlflow)
-        self.assertIs(cfg.mlflow, mlflow)
-        self.assertIsNone(cfg.comet)
-
-    def test_both_raises(self):
-        """Setting both comet and mlflow raises ConfigurationError."""
+    def test_legacy_mlflow_raises_at_construction(self):
+        """Legacy mlflow= raises at MlflowConfig(...) construction time."""
         with self.assertRaises(ConfigurationError):
-            ExperimentTrackerConfig(comet=self._comet(), mlflow=self._mlflow())
+            ExperimentTrackerConfig(mlflow=MlflowConfig(experiment_name="exp"))
 
-    def test_both_error_message(self):
-        """Error message names both active trackers and suggests the fix."""
-        with self.assertRaises(ConfigurationError) as ctx:
-            ExperimentTrackerConfig(comet=self._comet(), mlflow=self._mlflow())
-        msg = str(ctx.exception)
-        self.assertIn("comet", msg)
-        self.assertIn("mlflow", msg)
+    def test_tracker_and_legacy_mixed_raises(self):
+        """Setting both tracker and a legacy field raises ConfigurationError."""
+        with self.assertRaises(ConfigurationError):
+            ExperimentTrackerConfig(tracker=self._comet(), comet=self._comet())
+
+    def test_multiple_legacy_fields_raises(self):
+        """Setting both legacy fields raises (mlflow's own error surfaces first)."""
+        with self.assertRaises(ConfigurationError):
+            ExperimentTrackerConfig(
+                comet=self._comet(), mlflow=MlflowConfig(experiment_name="e")
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -396,9 +465,8 @@ class TestLightningTrainerConfig(TestCase):
     def test_optional_fields_stored(self):
         """It stores all optional fields when provided."""
         tracker = ExperimentTrackerConfig(
-            mlflow=MlflowConfig(
-                tracking_uri="http://mlflow.example.com",
-                experiment_name="tabular-ctr",
+            tracker=CometConfig(
+                api_key="k", workspace="ws", project_name="p", experiment_name="e"
             )
         )
         scaling = ScalingConfig(cpu_per_worker=4)

--- a/python/michelangelo/workflow/tasks/tabular_trainer/_private/__init__.py
+++ b/python/michelangelo/workflow/tasks/tabular_trainer/_private/__init__.py
@@ -1,0 +1,1 @@
+"""Private helpers for the tabular_trainer workflow task (not part of public API)."""

--- a/python/michelangelo/workflow/tasks/tabular_trainer/_private/tracker.py
+++ b/python/michelangelo/workflow/tasks/tabular_trainer/_private/tracker.py
@@ -1,8 +1,7 @@
 """Driver-side bridge: ``ExperimentTrackerConfig`` to Lightning logger kwargs.
 
 Pure function with no OSS-infra dependencies (no Ray clusters, no storage
-backends) so it can be tested without a Ray session. Mirrors the style of
-``_dataset.py`` in this package.
+backends) so it can be tested without a Ray session.
 """
 
 from __future__ import annotations

--- a/python/michelangelo/workflow/tasks/tabular_trainer/_tracker.py
+++ b/python/michelangelo/workflow/tasks/tabular_trainer/_tracker.py
@@ -1,0 +1,80 @@
+"""Driver-side bridge: ``ExperimentTrackerConfig`` to Lightning logger kwargs.
+
+Pure function with no OSS-infra dependencies (no Ray clusters, no storage
+backends) so it can be tested without a Ray session. Mirrors the style of
+``_dataset.py`` in this package.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from michelangelo.workflow.schema.exceptions import ConfigurationError
+
+if TYPE_CHECKING:
+    from michelangelo.workflow.schema.tabular_trainer import ExperimentTrackerConfig
+
+_COMET_FACTORY = (
+    "michelangelo.lib.trainer.torch.pytorch_lightning._private.util.build_comet_logger"
+)
+
+
+def build_tracker_logger_kwargs(
+    config: ExperimentTrackerConfig | None,
+) -> dict[str, Any]:
+    """Convert ``ExperimentTrackerConfig`` into Lightning logger kwargs.
+
+    Logger construction is deferred to the Ray Train worker (via the
+    dotted-path ``logger`` string resolved by ``_resolve_logger``) so that
+    per-worker distributed coordination — e.g. Comet's
+    ``torch.distributed.barrier()`` — runs correctly inside the worker
+    process rather than on the driver.
+
+    Args:
+        config: Tracker config, or ``None`` to disable experiment tracking.
+
+    Returns:
+        A dict with ``"logger"`` (a dotted import path, or ``None``) and
+        ``"logger_kwargs"`` (a dict, or ``None``) suitable for merging into
+        ``LightningTrainerKwargs``.
+
+    Raises:
+        ConfigurationError: If ``config.tracker`` is a ``TrackerConfig``
+            subclass not recognised here. This should not be reachable in
+            practice since ``TrackerConfig.__post_init__`` already rejects
+            unsupported types (e.g. ``MlflowConfig``) at construction time;
+            this guards against future subclasses added without a
+            corresponding branch here.
+    """
+    from michelangelo.workflow.schema.tabular_trainer import (
+        CometConfig,
+        CustomTrackerConfig,
+    )
+
+    if config is None or config.tracker is None:
+        return {"logger": None, "logger_kwargs": None}
+
+    tracker = config.tracker
+
+    if isinstance(tracker, CometConfig):
+        return {
+            "logger": _COMET_FACTORY,
+            "logger_kwargs": {
+                "api_key": tracker.api_key,
+                "workspace": tracker.workspace,
+                "project_name": tracker.project_name,
+                "experiment_name": tracker.experiment_name,
+                "tags": tracker.tags,
+            },
+        }
+
+    if isinstance(tracker, CustomTrackerConfig):
+        return {
+            "logger": tracker.factory_fn,
+            "logger_kwargs": dict(tracker.factory_kwargs),
+        }
+
+    raise ConfigurationError(
+        f"Unsupported tracker type: {type(tracker).__name__}. "
+        "Supported: CometConfig, CustomTrackerConfig."
+    )

--- a/python/michelangelo/workflow/tasks/tabular_trainer/task.py
+++ b/python/michelangelo/workflow/tasks/tabular_trainer/task.py
@@ -319,8 +319,11 @@ def _train_lightning(
     # dotted-path logger + kwargs, deferred to worker-side construction.
     # Never overrides a user-supplied lightning_trainer_kwargs.logger.
     tracker_kwargs = build_tracker_logger_kwargs(config.experiment_tracker)
-    if tracker_kwargs["logger"] is not None:
-        lightning_trainer_kwargs.setdefault("logger", tracker_kwargs["logger"])
+    if (
+        tracker_kwargs["logger"] is not None
+        and "logger" not in lightning_trainer_kwargs
+    ):
+        lightning_trainer_kwargs["logger"] = tracker_kwargs["logger"]
         if tracker_kwargs["logger_kwargs"]:
             lightning_trainer_kwargs.setdefault(
                 "logger_kwargs", tracker_kwargs["logger_kwargs"]

--- a/python/michelangelo/workflow/tasks/tabular_trainer/task.py
+++ b/python/michelangelo/workflow/tasks/tabular_trainer/task.py
@@ -33,7 +33,7 @@ from michelangelo.workflow.tasks.tabular_trainer._dataset import (
     get_sample_data,
     raise_lightning_trainer_config_deprecation_warnings,
 )
-from michelangelo.workflow.tasks.tabular_trainer._tracker import (
+from michelangelo.workflow.tasks.tabular_trainer._private.tracker import (
     build_tracker_logger_kwargs,
 )
 from michelangelo.workflow.variables import ModelVariable

--- a/python/michelangelo/workflow/tasks/tabular_trainer/task.py
+++ b/python/michelangelo/workflow/tasks/tabular_trainer/task.py
@@ -17,7 +17,6 @@ from typing import TYPE_CHECKING, Callable, Optional
 
 from michelangelo._internal.utils.reflection_utils.module_attr import get_module_attr
 from michelangelo.lib.trainer.torch.pytorch_lightning.lightning_trainer import (
-    CometParam,
     LightningTrainerParam,
     LightningTrainerWithStateDict,
 )
@@ -33,6 +32,9 @@ from michelangelo.workflow.tasks.tabular_trainer._dataset import (
     get_model_schema,
     get_sample_data,
     raise_lightning_trainer_config_deprecation_warnings,
+)
+from michelangelo.workflow.tasks.tabular_trainer._tracker import (
+    build_tracker_logger_kwargs,
 )
 from michelangelo.workflow.variables import ModelVariable
 from michelangelo.workflow.variables.metadata import (
@@ -170,8 +172,7 @@ def train_tabular(
             file.
         NotImplementedError: If ``config.lightning.checkpoint_config
             .save_every_n_steps`` is set, if
-            ``config.lightning.transfer_learning_spec`` is set, if
-            ``config.lightning.experiment_tracker.mlflow`` is set, or if
+            ``config.lightning.transfer_learning_spec`` is set, or if
             ``config.custom`` is used (custom backend not yet in OSS).
     """
     if config.lightning:
@@ -253,32 +254,6 @@ def _train_lightning(
         num_shuffle_batches = dl.num_shuffle_batches
         data_collate_fn = get_module_attr(dl.collate_fn) if dl.collate_fn else None
 
-    # Experiment tracking
-    comet_param: CometParam | None = None
-    if (
-        config.experiment_tracker is not None
-        and config.experiment_tracker.comet is not None
-    ):
-        c = config.experiment_tracker.comet
-        comet_param = CometParam(
-            api_key=c.api_key,
-            project_name=c.project_name,
-            experiment_name=c.experiment_name,
-            workspace=c.workspace,
-        )
-
-    # MLflow gate — wiring not yet implemented
-    # TODO(#1427): wire MLflow tracking into LightningTrainerParam
-    if (
-        config.experiment_tracker is not None
-        and config.experiment_tracker.mlflow is not None
-    ):
-        raise NotImplementedError(
-            "MLflow experiment tracking is not yet wired in OSS. "
-            "Remove mlflow from ExperimentTrackerConfig to proceed, "
-            "or use CometML tracking instead."
-        )
-
     # Mid-epoch checkpointing gate
     if config.checkpoint_config.save_every_n_steps is not None:
         raise NotImplementedError(
@@ -340,6 +315,17 @@ def _train_lightning(
         "precision", hp.get("precision", default_precision)
     )
 
+    # Experiment tracking: resolve config.experiment_tracker into a
+    # dotted-path logger + kwargs, deferred to worker-side construction.
+    # Never overrides a user-supplied lightning_trainer_kwargs.logger.
+    tracker_kwargs = build_tracker_logger_kwargs(config.experiment_tracker)
+    if tracker_kwargs["logger"] is not None:
+        lightning_trainer_kwargs.setdefault("logger", tracker_kwargs["logger"])
+        if tracker_kwargs["logger_kwargs"]:
+            lightning_trainer_kwargs.setdefault(
+                "logger_kwargs", tracker_kwargs["logger_kwargs"]
+            )
+
     # ModelArtifact.path is always a local filesystem path (per its
     # contract) to the packaged state-dict file itself — matching what
     # LightningTrainerParam.initial_weights_path expects (see
@@ -367,7 +353,6 @@ def _train_lightning(
         num_shuffle_batches=num_shuffle_batches,
         data_collate_fn=data_collate_fn,
         lightning_trainer_kwargs=lightning_trainer_kwargs,
-        comet_param=comet_param,
         transfer_learning_spec=None,
         initial_weights_path=initial_weights_path,
     )

--- a/python/michelangelo/workflow/tasks/tabular_trainer/tests/task_test.py
+++ b/python/michelangelo/workflow/tasks/tabular_trainer/tests/task_test.py
@@ -13,6 +13,7 @@ from michelangelo.workflow.schema.tabular_trainer import (
     BatchIterConfig,
     CheckpointConfig,
     CometConfig,
+    CustomTrackerConfig,
     CustomTrainerConfig,
     DataloadingConfig,
     ExperimentTrackerConfig,
@@ -199,27 +200,14 @@ class TestTrainTabularGuards(TestCase):
                 mock_validation_dataset(),
             )
 
-    def test_mlflow_config_raises_not_implemented(self):
-        """ExperimentTrackerConfig(mlflow=...) raises NotImplementedError."""
-        config = make_tabular_config(
-            experiment_tracker=ExperimentTrackerConfig(
+    def test_mlflow_config_raises_at_construction(self):
+        """MlflowConfig(...) raises ConfigurationError immediately at construction."""
+        with self.assertRaises(ConfigurationError):
+            ExperimentTrackerConfig(
                 mlflow=MlflowConfig(
                     tracking_uri="http://localhost:5000",
                     experiment_name="test-exp",
                 )
-            )
-        )
-        with (
-            self.assertRaises(NotImplementedError),
-            patch(
-                f"{_TRAINER_TASK}.get_module_attr",
-                return_value=lambda **kw: Mock(),
-            ),
-        ):
-            train_tabular(
-                config,
-                mock_train_dataset(),
-                mock_validation_dataset(),
             )
 
     def test_empty_train_dataset_raises(self):
@@ -387,8 +375,8 @@ class TestTrainTabularLightning(TestCase):
                 )
         self.assertEqual(mp.call_args.kwargs.get("batch_size"), 16)
 
-    def test_comet_param_built_from_experiment_tracker(self):
-        """CometParam is constructed when experiment_tracker.comet is set."""
+    def test_comet_tracker_sets_logger_kwargs(self):
+        """CometConfig resolves to the build_comet_logger dotted path + kwargs."""
         config = make_tabular_config(
             experiment_tracker=ExperimentTrackerConfig(
                 comet=CometConfig(
@@ -404,9 +392,8 @@ class TestTrainTabularLightning(TestCase):
                 f"{_TRAINER_TASK}.get_module_attr",
                 return_value=lambda **kw: Mock(),
             ),
-            patch(f"{_TRAINER_TASK}.CometParam") as mock_comet,
             patch(f"{_TRAINER_TASK}.ModelVariable"),
-            patch(f"{_TRAINER_TASK}.LightningTrainerParam"),
+            patch(f"{_TRAINER_TASK}.LightningTrainerParam") as mp,
             patch(f"{_TRAINER_TASK}.LightningTrainerWithStateDict") as mt,
         ):
             mt.return_value.train.return_value = None
@@ -416,12 +403,56 @@ class TestTrainTabularLightning(TestCase):
                 mock_train_dataset(),
                 mock_validation_dataset(),
             )
-        mock_comet.assert_called_once_with(
-            api_key="k", project_name="proj", experiment_name="exp", workspace="ws"
+        lightning_kwargs = mp.call_args.kwargs["lightning_trainer_kwargs"]
+        self.assertEqual(
+            lightning_kwargs["logger"],
+            "michelangelo.lib.trainer.torch.pytorch_lightning._private.util.build_comet_logger",
+        )
+        self.assertEqual(
+            lightning_kwargs["logger_kwargs"],
+            {
+                "api_key": "k",
+                "workspace": "ws",
+                "project_name": "proj",
+                "experiment_name": "exp",
+                "tags": [],
+            },
         )
 
-    def test_no_comet_when_experiment_tracker_none(self):
-        """comet_param is None when experiment_tracker is not set."""
+    def test_custom_tracker_sets_logger_kwargs(self):
+        """CustomTrackerConfig resolves to its factory_fn + factory_kwargs."""
+        config = make_tabular_config(
+            experiment_tracker=ExperimentTrackerConfig(
+                tracker=CustomTrackerConfig(
+                    factory_fn="myproject.loggers.make_wandb_logger",
+                    factory_kwargs={"project": "ctr-model"},
+                )
+            )
+        )
+        with (
+            patch(
+                f"{_TRAINER_TASK}.get_module_attr",
+                return_value=lambda **kw: Mock(),
+            ),
+            patch(f"{_TRAINER_TASK}.ModelVariable"),
+            patch(f"{_TRAINER_TASK}.LightningTrainerParam") as mp,
+            patch(f"{_TRAINER_TASK}.LightningTrainerWithStateDict") as mt,
+        ):
+            mt.return_value.train.return_value = None
+            mt.return_value.update_model_state_dict.return_value = None
+            train_tabular(
+                config,
+                mock_train_dataset(),
+                mock_validation_dataset(),
+            )
+        lightning_kwargs = mp.call_args.kwargs["lightning_trainer_kwargs"]
+        self.assertEqual(
+            lightning_kwargs["logger"], "myproject.loggers.make_wandb_logger"
+        )
+        self.assertEqual(lightning_kwargs["logger_kwargs"], {"project": "ctr-model"})
+
+    def test_no_logger_when_experiment_tracker_none(self):
+        """No 'logger' key is set when experiment_tracker is unset."""
         with (
             patch(
                 f"{_TRAINER_TASK}.get_module_attr",
@@ -438,7 +469,8 @@ class TestTrainTabularLightning(TestCase):
                 mock_train_dataset(),
                 mock_validation_dataset(),
             )
-        self.assertIsNone(mp.call_args.kwargs.get("comet_param"))
+        lightning_kwargs = mp.call_args.kwargs["lightning_trainer_kwargs"]
+        self.assertNotIn("logger", lightning_kwargs)
 
     def test_initial_model_sets_weights_path(self):
         """initial_weights_path is read directly from initial_model.path.

--- a/python/michelangelo/workflow/tasks/tabular_trainer/tests/tracker_test.py
+++ b/python/michelangelo/workflow/tasks/tabular_trainer/tests/tracker_test.py
@@ -1,4 +1,4 @@
-"""Tests for michelangelo.workflow.tasks.tabular_trainer._tracker."""
+"""Tests for michelangelo.workflow.tasks.tabular_trainer._private.tracker."""
 
 from __future__ import annotations
 
@@ -10,7 +10,7 @@ from michelangelo.workflow.schema.tabular_trainer import (
     CustomTrackerConfig,
     ExperimentTrackerConfig,
 )
-from michelangelo.workflow.tasks.tabular_trainer._tracker import (
+from michelangelo.workflow.tasks.tabular_trainer._private.tracker import (
     build_tracker_logger_kwargs,
 )
 

--- a/python/michelangelo/workflow/tasks/tabular_trainer/tests/tracker_test.py
+++ b/python/michelangelo/workflow/tasks/tabular_trainer/tests/tracker_test.py
@@ -1,0 +1,99 @@
+"""Tests for michelangelo.workflow.tasks.tabular_trainer._tracker."""
+
+from __future__ import annotations
+
+from unittest import TestCase
+
+from michelangelo.workflow.schema.exceptions import ConfigurationError
+from michelangelo.workflow.schema.tabular_trainer import (
+    CometConfig,
+    CustomTrackerConfig,
+    ExperimentTrackerConfig,
+)
+from michelangelo.workflow.tasks.tabular_trainer._tracker import (
+    build_tracker_logger_kwargs,
+)
+
+_COMET_FACTORY = (
+    "michelangelo.lib.trainer.torch.pytorch_lightning._private.util.build_comet_logger"
+)
+
+
+class TestBuildTrackerLoggerKwargs(TestCase):
+    """Tests for build_tracker_logger_kwargs."""
+
+    def test_none_config_returns_no_logger(self):
+        """config=None disables tracking."""
+        result = build_tracker_logger_kwargs(None)
+        self.assertEqual(result, {"logger": None, "logger_kwargs": None})
+
+    def test_empty_config_returns_no_logger(self):
+        """ExperimentTrackerConfig() with no tracker set disables tracking."""
+        result = build_tracker_logger_kwargs(ExperimentTrackerConfig())
+        self.assertEqual(result, {"logger": None, "logger_kwargs": None})
+
+    def test_comet_config_resolves_to_build_comet_logger(self):
+        """CometConfig maps to the build_comet_logger dotted path + kwargs."""
+        config = ExperimentTrackerConfig(
+            tracker=CometConfig(
+                api_key="k",
+                workspace="ws",
+                project_name="proj",
+                experiment_name="exp",
+                tags=["a", "b"],
+            )
+        )
+        result = build_tracker_logger_kwargs(config)
+        self.assertEqual(result["logger"], _COMET_FACTORY)
+        self.assertEqual(
+            result["logger_kwargs"],
+            {
+                "api_key": "k",
+                "workspace": "ws",
+                "project_name": "proj",
+                "experiment_name": "exp",
+                "tags": ["a", "b"],
+            },
+        )
+
+    def test_legacy_comet_field_resolves_same_as_tracker_field(self):
+        """Legacy comet= promotion produces the same result as tracker=."""
+        comet = CometConfig(
+            api_key="k", workspace="ws", project_name="proj", experiment_name="exp"
+        )
+        result = build_tracker_logger_kwargs(ExperimentTrackerConfig(comet=comet))
+        self.assertEqual(result["logger"], _COMET_FACTORY)
+
+    def test_custom_tracker_config_resolves_to_factory_fn(self):
+        """CustomTrackerConfig maps directly to factory_fn/factory_kwargs."""
+        config = ExperimentTrackerConfig(
+            tracker=CustomTrackerConfig(
+                factory_fn="myproject.loggers.make_wandb_logger",
+                factory_kwargs={"project": "ctr-model"},
+            )
+        )
+        result = build_tracker_logger_kwargs(config)
+        self.assertEqual(result["logger"], "myproject.loggers.make_wandb_logger")
+        self.assertEqual(result["logger_kwargs"], {"project": "ctr-model"})
+
+    def test_custom_tracker_config_default_kwargs(self):
+        """No factory_kwargs given returns an empty dict, not None."""
+        config = ExperimentTrackerConfig(
+            tracker=CustomTrackerConfig(factory_fn="myproject.loggers.make_logger")
+        )
+        result = build_tracker_logger_kwargs(config)
+        self.assertEqual(result["logger_kwargs"], {})
+
+    def test_unsupported_tracker_type_raises(self):
+        """A TrackerConfig subclass not handled here raises ConfigurationError."""
+        from dataclasses import dataclass
+
+        from michelangelo.workflow.schema.tabular_trainer import TrackerConfig
+
+        @dataclass
+        class _FutureTrackerConfig(TrackerConfig):
+            pass
+
+        config = ExperimentTrackerConfig(tracker=_FutureTrackerConfig())
+        with self.assertRaises(ConfigurationError):
+            build_tracker_logger_kwargs(config)


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Replaces the closed, hardcoded `comet`/`mlflow` fields on `ExperimentTrackerConfig` with a pluggable `TrackerConfig` abstraction:

- New `TrackerConfig` base class with a `_check_oss_supported()` fail-fast hook, so unsupported trackers raise `ConfigurationError` at construction time instead of deep inside `train_tabular()`.
- New `CustomTrackerConfig` (bring-your-own-tracker): a dotted-path `factory_fn` + `factory_kwargs`, letting external users wire W&B/Neptune/ClearML with zero library changes.
- `ExperimentTrackerConfig.tracker` unified field (legacy `comet=`/`mlflow=` still work and are promoted into `tracker`).
- New pure bridge `_tracker.py::build_tracker_logger_kwargs()` resolves a config into a dotted-path logger + kwargs on the driver; `_resolve_logger()` (worker-side) now injects `run_id` for cross-worker correlation only when a factory's signature actually accepts it.
- New `build_comet_logger`/`build_mlflow_logger` factories in `util.py`, replacing the old `comet_param`-specific code path.
- **Breaking:** `CometParam`/`LightningTrainerParam.comet_param` removed outright (no deprecation cycle) — `task.py` was the only production consumer and it's migrated onto the new abstraction in this same PR.
- `MlflowConfig.tracking_uri` is now optional.

**Why?**

MLflow was documented with usage examples but always raised `NotImplementedError` at runtime (issue #1427), and there was no extension point for any tracker besides Comet/MLflow — adding one required forking the task module. See design doc: https://vibe-mcp.uberinternal.com/v/webdocs/#/d/8a3ed71e-a8ee-417f-a16e-1c8ce84644c4

**How did you test it?**

- `pytest` on `workflow/schema/tests/tabular_trainer_test.py`, `workflow/tasks/tabular_trainer/tests/`, `lib/trainer/torch/pytorch_lightning/tests/` — 306 passed, including new tests for `CustomTrackerConfig`, the `run_id` signature-guard (real non-Mock factories), and `dataclasses.asdict()`/UniFlow `DataclassCodec` round-trips for `CometConfig`/`ExperimentTrackerConfig`.
- `ruff format --check` and `ruff check` clean on all changed files.
- Independently re-reviewed by three separate agent passes (dev-experience, architecture, and an independent code-quality pass that re-ran the suite/lint itself rather than trusting prior claims); all findings from those passes are fixed in this PR (signature-guarded `run_id` injection, `_oss_supported` as `ClassVar` instead of an `init=False` field to fix a codec round-trip regression, improved error messages, CHANGELOG entries).

**Potential risks**

- Any external caller still constructing `LightningTrainerParam(comet_param=...)` or importing `CometParam` will break immediately (`TypeError`/`ImportError`) — no deprecation window. Mitigated by `CometParam` having exactly one internal consumer (`task.py`, migrated in this PR) and the MovieLens example (updated in this PR).
- `MlflowConfig(...)` now raises at construction instead of at `train_tabular()` call time — strictly earlier failure, but any code catching `NotImplementedError` around the old call site needs updating to catch `ConfigurationError` instead.

**Breaking Changes**

- [ ] No breaking changes
- [x] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Migration guide**

- Replace `LightningTrainerParam(comet_param=CometParam(api_key=..., workspace=..., project_name=..., experiment_name=...))` with `LightningTrainerKwargs(logger="michelangelo.lib.trainer.torch.pytorch_lightning._private.util.build_comet_logger", logger_kwargs={"api_key": ..., "workspace": ..., "project_name": ..., "experiment_name": ...})`, or (for `tabular_trainer` users) `ExperimentTrackerConfig(tracker=CometConfig(api_key=..., workspace=..., project_name=..., experiment_name=...))`.
- Replace any `except NotImplementedError` around MLflow config usage with `except ConfigurationError`.
- MLflow is usable today (ahead of #1427/PR 10) via `CustomTrackerConfig(factory_fn="michelangelo.lib.trainer.torch.pytorch_lightning._private.util.build_mlflow_logger", factory_kwargs={"experiment_name": ...})`.

**Release notes**

See `CHANGELOG.md` under `Unreleased` — new `CustomTrackerConfig`/`TrackerConfig`, `MlflowConfig` fail-fast behavior change, and the breaking `CometParam` removal.

**Documentation Changes**

Updated `python/examples/movielens/train.py` and its `README.md` to use the new dotted-path Comet factory instead of `CometParam`. Docstrings on all new/changed public classes and functions follow Google style with Args/Returns/Raises.