### PR TITLE
feat(trainer): wire MLflow experiment tracking (PR 10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to this project will be documented in this file.
 - `build_comet_logger` / `build_mlflow_logger` factory functions in
   `michelangelo.lib.trainer.torch.pytorch_lightning._private.util`, usable
   as `CustomTrackerConfig.factory_fn` targets.
+- `MlflowConfig` is now fully supported — set
+  `ExperimentTrackerConfig(tracker=MlflowConfig(...))` to log to MLflow.
+  Closes GitHub issue #1427.
 
 ### Changed
 
@@ -23,10 +26,6 @@ All notable changes to this project will be documented in this file.
   retained in MySQL. Opt out per delete with `kubectl delete pipeline … --cascade=orphan`. GC deletes
   children with the controller's RBAC, and the MA Studio UI does not yet cascade. See the
   [Cascade Delete operator guide](docs/operator-guides/cascade-delete.md).
-- `MlflowConfig` now fails fast with `ConfigurationError` at construction time
-  (previously it raised `NotImplementedError` later, from inside
-  `train_tabular()`). The error message points at GitHub issue #1427 and the
-  `CustomTrackerConfig` + `build_mlflow_logger` workaround usable today.
 - `MlflowConfig.tracking_uri` is now optional (`str | None`, defaults to
   `None`), falling back to the `MLFLOW_TRACKING_URI` environment variable.
 

--- a/python/michelangelo/workflow/schema/tabular_trainer.py
+++ b/python/michelangelo/workflow/schema/tabular_trainer.py
@@ -157,7 +157,8 @@ class CometConfig(TrackerConfig):
 class MlflowConfig(TrackerConfig):
     """MLflow experiment tracking configuration.
 
-    Pass to ``ExperimentTrackerConfig(mlflow=MlflowConfig(...))`` on
+    Pass to ``ExperimentTrackerConfig(tracker=MlflowConfig(...))`` (or the
+    legacy ``ExperimentTrackerConfig(mlflow=MlflowConfig(...))``) on
     ``LightningTrainerConfig``.
 
     Attributes:
@@ -171,45 +172,17 @@ class MlflowConfig(TrackerConfig):
             when ``None``.
         tags: Key-value string tags attached to the MLflow run.
 
-    Raises:
-        ConfigurationError: ``MlflowConfig`` itself is not yet wired in OSS
-            michelangelo (see GitHub issue #1427). Raised immediately at
-            construction time. MLflow is usable today via
-            ``CustomTrackerConfig(factory_fn="michelangelo.lib.trainer.torch"
-            ".pytorch_lightning._private.util.build_mlflow_logger", ...)``.
-
     Example:
-        Constructing this config always raises ``ConfigurationError`` until
-        GitHub issue #1427 is resolved::
-
-            MlflowConfig(experiment_name="tabular-ctr")
-            # ConfigurationError: MlflowConfig is not yet wired in OSS
-            # michelangelo (see GitHub issue #1427)...
-
-        Use MLflow today via the BYOT escape hatch instead::
-
-            CustomTrackerConfig(
-                factory_fn="michelangelo.lib.trainer.torch.pytorch_lightning"
-                "._private.util.build_mlflow_logger",
-                factory_kwargs={"experiment_name": "tabular-ctr"},
-            )
+        >>> cfg = MlflowConfig(
+        ...     experiment_name="tabular-ctr",
+        ...     tracking_uri="http://mlflow.example.com",
+        ... )
     """
 
     experiment_name: str
     tracking_uri: str | None = None
     run_name: str | None = None
     tags: dict[str, str] = field(default_factory=dict)
-    _oss_supported: ClassVar[bool] = False
-
-    def _check_oss_supported(self) -> None:
-        """Raise with a message pointing at the tracking issue and alternatives."""
-        raise ConfigurationError(
-            "MlflowConfig is not yet wired in OSS michelangelo (see GitHub "
-            "issue #1427). MLflow is usable today via CustomTrackerConfig("
-            "factory_fn='michelangelo.lib.trainer.torch.pytorch_lightning."
-            "_private.util.build_mlflow_logger', ...); this MlflowConfig "
-            "convenience wrapper will be enabled once #1427 ships."
-        )
 
 
 @dataclass
@@ -269,14 +242,22 @@ class ExperimentTrackerConfig:
     Raises:
         ConfigurationError: If both ``tracker`` and a legacy field are set,
             if more than one legacy field is set, or if the resolved tracker
-            type sets ``_oss_supported = False`` (e.g. ``MlflowConfig``,
-            which raises when constructed regardless of this class).
+            type sets ``_oss_supported = False`` (subclasses not yet wired
+            in OSS raise when constructed regardless of this class).
 
     Example — Comet ML:
         >>> ExperimentTrackerConfig(
         ...     tracker=CometConfig(
         ...         api_key="key", workspace="ws",
         ...         project_name="proj", experiment_name="exp",
+        ...     )
+        ... )
+
+    Example — MLflow:
+        >>> ExperimentTrackerConfig(
+        ...     tracker=MlflowConfig(
+        ...         experiment_name="tabular-ctr",
+        ...         tracking_uri="http://mlflow.example.com",
         ...     )
         ... )
 
@@ -586,10 +567,9 @@ class LightningTrainerConfig:
             ``lightning.pytorch.Trainer``.
         hyperparameters: Catch-all dict for kwargs not covered by the
             structured fields. Highly discouraged; prefer structured fields.
-        experiment_tracker: Experiment tracking backend (Comet ML, or a
-            custom tracker via ``CustomTrackerConfig``). ``None`` disables
-            experiment tracking. MLflow is not yet wired in OSS — see
-            ``MlflowConfig``.
+        experiment_tracker: Experiment tracking backend (Comet ML, MLflow,
+            or a custom tracker via ``CustomTrackerConfig``). ``None``
+            disables experiment tracking.
         transfer_learning_spec: Transfer-learning spec config. Setting this
             raises ``NotImplementedError`` until the spec builder is ported.
         incremental_training_mode: Incremental training mode config.

--- a/python/michelangelo/workflow/schema/tests/tabular_trainer_test.py
+++ b/python/michelangelo/workflow/schema/tests/tabular_trainer_test.py
@@ -152,6 +152,28 @@ class TestTrackerConfigSerialization(TestCase):
         decoded = codec.decode(codec.encode(cfg))
         self.assertEqual(decoded.tracker, comet)
 
+    def test_mlflow_config_asdict_roundtrip(self):
+        """dataclasses.asdict()/cls(**dct) round-trips MlflowConfig."""
+        import dataclasses
+
+        cfg = MlflowConfig(
+            experiment_name="exp", tracking_uri="http://mlflow.example.com"
+        )
+        dct = dataclasses.asdict(cfg)
+        self.assertNotIn("_oss_supported", dct)
+        self.assertEqual(MlflowConfig(**dct), cfg)
+
+    def test_mlflow_config_codec_roundtrip(self):
+        """MlflowConfig round-trips through the UniFlow DataclassCodec."""
+        from michelangelo.uniflow.core.codec import DataclassCodec
+
+        codec = DataclassCodec()
+        cfg = MlflowConfig(
+            experiment_name="exp", tracking_uri="http://mlflow.example.com"
+        )
+        decoded = codec.decode(codec.encode(cfg))
+        self.assertEqual(decoded, cfg)
+
 
 # ---------------------------------------------------------------------------
 # CometConfig
@@ -402,28 +424,37 @@ class TestCustomTrainerConfig(TestCase):
 
 
 class TestMlflowConfig(TestCase):
-    """Tests for MlflowConfig dataclass — not yet supported in OSS."""
+    """Tests for MlflowConfig dataclass."""
 
-    def test_construction_raises_configuration_error(self):
-        """Constructing MlflowConfig always raises ConfigurationError (issue #1427)."""
-        with self.assertRaises(ConfigurationError):
-            MlflowConfig(experiment_name="tabular-ctr")
+    def test_construction_succeeds(self):
+        """Constructing MlflowConfig with just experiment_name works."""
+        cfg = MlflowConfig(experiment_name="tabular-ctr")
+        self.assertEqual(cfg.experiment_name, "tabular-ctr")
+        self.assertIsNone(cfg.tracking_uri)
+        self.assertIsNone(cfg.run_name)
+        self.assertEqual(cfg.tags, {})
 
-    def test_error_message_references_issue_and_alternatives(self):
-        """Error message points at #1427 and the CustomTrackerConfig workaround."""
-        with self.assertRaises(ConfigurationError) as ctx:
-            MlflowConfig(
-                experiment_name="exp", tracking_uri="http://mlflow.example.com"
-            )
-        msg = str(ctx.exception)
-        self.assertIn("1427", msg)
-        self.assertIn("CustomTrackerConfig", msg)
-        self.assertIn("build_mlflow_logger", msg)
+    def test_all_fields_stored(self):
+        """It stores all fields when explicitly provided."""
+        cfg = MlflowConfig(
+            experiment_name="exp",
+            tracking_uri="http://mlflow.example.com",
+            run_name="run-1",
+            tags={"team": "ctr"},
+        )
+        self.assertEqual(cfg.experiment_name, "exp")
+        self.assertEqual(cfg.tracking_uri, "http://mlflow.example.com")
+        self.assertEqual(cfg.run_name, "run-1")
+        self.assertEqual(cfg.tags, {"team": "ctr"})
 
     def test_tracking_uri_is_optional(self):
-        """tracking_uri defaults to None, independent of the OSS-support raise."""
-        with self.assertRaises(ConfigurationError):
-            MlflowConfig(experiment_name="exp")
+        """tracking_uri defaults to None."""
+        cfg = MlflowConfig(experiment_name="exp")
+        self.assertIsNone(cfg.tracking_uri)
+
+    def test_is_oss_supported(self):
+        """MlflowConfig no longer gates on OSS support (issue #1427 closed)."""
+        self.assertTrue(MlflowConfig(experiment_name="exp")._oss_supported)
 
 
 # ---------------------------------------------------------------------------
@@ -465,10 +496,12 @@ class TestExperimentTrackerConfig(TestCase):
         self.assertIs(cfg.comet, comet)
         self.assertIs(cfg.tracker, comet)
 
-    def test_legacy_mlflow_raises_at_construction(self):
-        """Legacy mlflow= raises at MlflowConfig(...) construction time."""
-        with self.assertRaises(ConfigurationError):
-            ExperimentTrackerConfig(mlflow=MlflowConfig(experiment_name="exp"))
+    def test_legacy_mlflow_promoted_to_tracker(self):
+        """Legacy mlflow= is promoted into the tracker field."""
+        mlflow = MlflowConfig(experiment_name="exp")
+        cfg = ExperimentTrackerConfig(mlflow=mlflow)
+        self.assertIs(cfg.mlflow, mlflow)
+        self.assertIs(cfg.tracker, mlflow)
 
     def test_tracker_and_legacy_mixed_raises(self):
         """Setting both tracker and a legacy field raises ConfigurationError."""
@@ -476,7 +509,7 @@ class TestExperimentTrackerConfig(TestCase):
             ExperimentTrackerConfig(tracker=self._comet(), comet=self._comet())
 
     def test_multiple_legacy_fields_raises(self):
-        """Setting both legacy fields raises (mlflow's own error surfaces first)."""
+        """Setting both legacy fields raises ConfigurationError."""
         with self.assertRaises(ConfigurationError):
             ExperimentTrackerConfig(
                 comet=self._comet(), mlflow=MlflowConfig(experiment_name="e")

--- a/python/michelangelo/workflow/tasks/tabular_trainer/_private/tracker.py
+++ b/python/michelangelo/workflow/tasks/tabular_trainer/_private/tracker.py
@@ -16,6 +16,9 @@ if TYPE_CHECKING:
 _COMET_FACTORY = (
     "michelangelo.lib.trainer.torch.pytorch_lightning._private.util.build_comet_logger"
 )
+_MLFLOW_FACTORY = (
+    "michelangelo.lib.trainer.torch.pytorch_lightning._private.util.build_mlflow_logger"
+)
 
 
 def build_tracker_logger_kwargs(
@@ -41,13 +44,13 @@ def build_tracker_logger_kwargs(
         ConfigurationError: If ``config.tracker`` is a ``TrackerConfig``
             subclass not recognised here. This should not be reachable in
             practice since ``TrackerConfig.__post_init__`` already rejects
-            unsupported types (e.g. ``MlflowConfig``) at construction time;
-            this guards against future subclasses added without a
-            corresponding branch here.
+            unsupported types at construction time; this guards against
+            future subclasses added without a corresponding branch here.
     """
     from michelangelo.workflow.schema.tabular_trainer import (
         CometConfig,
         CustomTrackerConfig,
+        MlflowConfig,
     )
 
     if config is None or config.tracker is None:
@@ -67,6 +70,17 @@ def build_tracker_logger_kwargs(
             },
         }
 
+    if isinstance(tracker, MlflowConfig):
+        return {
+            "logger": _MLFLOW_FACTORY,
+            "logger_kwargs": {
+                "experiment_name": tracker.experiment_name,
+                "tracking_uri": tracker.tracking_uri,
+                "run_name": tracker.run_name,
+                "tags": tracker.tags,
+            },
+        }
+
     if isinstance(tracker, CustomTrackerConfig):
         return {
             "logger": tracker.factory_fn,
@@ -75,5 +89,5 @@ def build_tracker_logger_kwargs(
 
     raise ConfigurationError(
         f"Unsupported tracker type: {type(tracker).__name__}. "
-        "Supported: CometConfig, CustomTrackerConfig."
+        "Supported: CometConfig, MlflowConfig, CustomTrackerConfig."
     )

--- a/python/michelangelo/workflow/tasks/tabular_trainer/tests/task_test.py
+++ b/python/michelangelo/workflow/tasks/tabular_trainer/tests/task_test.py
@@ -200,15 +200,15 @@ class TestTrainTabularGuards(TestCase):
                 mock_validation_dataset(),
             )
 
-    def test_mlflow_config_raises_at_construction(self):
-        """MlflowConfig(...) raises ConfigurationError immediately at construction."""
-        with self.assertRaises(ConfigurationError):
-            ExperimentTrackerConfig(
-                mlflow=MlflowConfig(
-                    tracking_uri="http://localhost:5000",
-                    experiment_name="test-exp",
-                )
+    def test_mlflow_config_construction_succeeds(self):
+        """MlflowConfig(...) no longer raises at construction (issue #1427 closed)."""
+        cfg = ExperimentTrackerConfig(
+            mlflow=MlflowConfig(
+                tracking_uri="http://localhost:5000",
+                experiment_name="test-exp",
             )
+        )
+        self.assertIs(cfg.tracker, cfg.mlflow)
 
     def test_empty_train_dataset_raises(self):
         """Zero-row train dataset raises ConfigurationError."""
@@ -416,6 +416,48 @@ class TestTrainTabularLightning(TestCase):
                 "project_name": "proj",
                 "experiment_name": "exp",
                 "tags": [],
+            },
+        )
+
+    def test_mlflow_tracker_sets_logger_kwargs(self):
+        """MlflowConfig resolves to the build_mlflow_logger dotted path + kwargs."""
+        config = make_tabular_config(
+            experiment_tracker=ExperimentTrackerConfig(
+                mlflow=MlflowConfig(
+                    experiment_name="exp",
+                    tracking_uri="http://mlflow.example.com",
+                )
+            )
+        )
+        with (
+            patch(
+                f"{_TRAINER_TASK}.get_module_attr",
+                return_value=lambda **kw: Mock(),
+            ),
+            patch(f"{_TRAINER_TASK}.torch"),
+            patch(f"{_TRAINER_TASK}.LightningTrainerParam") as mp,
+            patch(f"{_TRAINER_TASK}.LightningTrainerWithStateDict") as mt,
+        ):
+            mt.return_value.train.return_value = None
+            mt.return_value.update_model_state_dict.return_value = None
+            train_tabular(
+                config,
+                mock_train_dataset(),
+                mock_validation_dataset(),
+                storage_backend=mock_storage_backend(),
+            )
+        lightning_kwargs = mp.call_args.kwargs["lightning_trainer_kwargs"]
+        self.assertEqual(
+            lightning_kwargs["logger"],
+            "michelangelo.lib.trainer.torch.pytorch_lightning._private.util.build_mlflow_logger",
+        )
+        self.assertEqual(
+            lightning_kwargs["logger_kwargs"],
+            {
+                "experiment_name": "exp",
+                "tracking_uri": "http://mlflow.example.com",
+                "run_name": None,
+                "tags": {},
             },
         )
 

--- a/python/michelangelo/workflow/tasks/tabular_trainer/tests/task_test.py
+++ b/python/michelangelo/workflow/tasks/tabular_trainer/tests/task_test.py
@@ -434,7 +434,7 @@ class TestTrainTabularLightning(TestCase):
                 f"{_TRAINER_TASK}.get_module_attr",
                 return_value=lambda **kw: Mock(),
             ),
-            patch(f"{_TRAINER_TASK}.torch"),
+            patch(f"{_TRAINER_TASK}.ModelVariable"),
             patch(f"{_TRAINER_TASK}.LightningTrainerParam") as mp,
             patch(f"{_TRAINER_TASK}.LightningTrainerWithStateDict") as mt,
         ):
@@ -444,7 +444,6 @@ class TestTrainTabularLightning(TestCase):
                 config,
                 mock_train_dataset(),
                 mock_validation_dataset(),
-                storage_backend=mock_storage_backend(),
             )
         lightning_kwargs = mp.call_args.kwargs["lightning_trainer_kwargs"]
         self.assertEqual(

--- a/python/michelangelo/workflow/tasks/tabular_trainer/tests/tracker_test.py
+++ b/python/michelangelo/workflow/tasks/tabular_trainer/tests/tracker_test.py
@@ -9,6 +9,7 @@ from michelangelo.workflow.schema.tabular_trainer import (
     CometConfig,
     CustomTrackerConfig,
     ExperimentTrackerConfig,
+    MlflowConfig,
 )
 from michelangelo.workflow.tasks.tabular_trainer._private.tracker import (
     build_tracker_logger_kwargs,
@@ -16,6 +17,9 @@ from michelangelo.workflow.tasks.tabular_trainer._private.tracker import (
 
 _COMET_FACTORY = (
     "michelangelo.lib.trainer.torch.pytorch_lightning._private.util.build_comet_logger"
+)
+_MLFLOW_FACTORY = (
+    "michelangelo.lib.trainer.torch.pytorch_lightning._private.util.build_mlflow_logger"
 )
 
 
@@ -63,6 +67,34 @@ class TestBuildTrackerLoggerKwargs(TestCase):
         )
         result = build_tracker_logger_kwargs(ExperimentTrackerConfig(comet=comet))
         self.assertEqual(result["logger"], _COMET_FACTORY)
+
+    def test_mlflow_config_resolves_to_build_mlflow_logger(self):
+        """MlflowConfig maps to the build_mlflow_logger dotted path + kwargs."""
+        config = ExperimentTrackerConfig(
+            tracker=MlflowConfig(
+                experiment_name="exp",
+                tracking_uri="http://mlflow.example.com",
+                run_name="run-1",
+                tags={"team": "ctr"},
+            )
+        )
+        result = build_tracker_logger_kwargs(config)
+        self.assertEqual(result["logger"], _MLFLOW_FACTORY)
+        self.assertEqual(
+            result["logger_kwargs"],
+            {
+                "experiment_name": "exp",
+                "tracking_uri": "http://mlflow.example.com",
+                "run_name": "run-1",
+                "tags": {"team": "ctr"},
+            },
+        )
+
+    def test_legacy_mlflow_field_resolves_same_as_tracker_field(self):
+        """Legacy mlflow= promotion produces the same result as tracker=."""
+        mlflow = MlflowConfig(experiment_name="exp")
+        result = build_tracker_logger_kwargs(ExperimentTrackerConfig(mlflow=mlflow))
+        self.assertEqual(result["logger"], _MLFLOW_FACTORY)
 
     def test_custom_tracker_config_resolves_to_factory_fn(self):
         """CustomTrackerConfig maps directly to factory_fn/factory_kwargs."""


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Wires `MlflowConfig` into the tracker abstraction added in PR #1432:

- `MlflowConfig._oss_supported` now inherits `TrackerConfig`'s default of `True` (previously `False`), so constructing `MlflowConfig(...)` succeeds instead of raising `ConfigurationError`.
- `build_tracker_logger_kwargs()` (`_tracker.py`) gained an `MlflowConfig` branch mapping to the `build_mlflow_logger` dotted-path factory added in PR 8 — mirrors the existing `CometConfig` branch exactly.
- Removed the now-dead `_check_oss_supported()` override and stale docstrings/error messages that pointed at issue #1427 as unresolved.
- Test coverage: `MlflowConfig` construction/`asdict`/UniFlow codec round-trip, `build_tracker_logger_kwargs()` resolution (including legacy `mlflow=` promotion), and an end-to-end `task.py` dispatcher test mirroring the existing Comet one.

Closes [#1427](https://github.com/michelangelo-ai/michelangelo/issues/1427).

**Why?**

PR 8 built the whole tracker abstraction and already added `build_mlflow_logger` to `util.py`, but gated `MlflowConfig` itself behind a `ConfigurationError` since wiring it up was scoped out as a separate PR (per the design doc's PR breakdown). This is that follow-up — as anticipated, it's small since PR 8 did the hard part.

**How did you test it?**

`pytest michelangelo/workflow/schema/tests/tabular_trainer_test.py michelangelo/workflow/tasks/tabular_trainer/tests/ michelangelo/lib/trainer/torch/pytorch_lightning/tests/ -q` — 312 passed (up from 306 on PR 8). `ruff format --check` / `ruff check` clean on all changed files.

**Potential risks**

None — this only *enables* previously-blocked construction of `MlflowConfig`; no existing passing code path changes behavior.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

See `CHANGELOG.md` under `Unreleased` — `MlflowConfig` is now fully supported (issue #1427 closed).

**Documentation Changes**

Docstrings on `MlflowConfig` and `ExperimentTrackerConfig` updated to reflect that MLflow is now a first-class supported tracker (added an MLflow usage example alongside the existing Comet one).

---

Draft — stacked on #1432 (base branch `trainer-pr8-experiment-tracking-abstraction`). Do not merge until PR 8 lands; will rebase onto `main` once it does.