### PR TITLE
feat(trainer): restore fused_model_submodule to warm-start schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ All notable changes to this project will be documented in this file.
 - `MlflowConfig` is now fully supported — set
   `ExperimentTrackerConfig(tracker=MlflowConfig(...))` to log to MLflow.
   Closes GitHub issue #1427.
+- `fused_model_submodule` field on `IncrementalTrainingSpec` and
+  `TransferLearningSpec` (`lib/trainer/torch/pytorch_lightning/schema.py`),
+  restoring schema-shape parity with the internal Uber SDK. Schema-only for
+  now — no OSS code reads or acts on this field yet.
 
 ### Changed
 

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/schema.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/schema.py
@@ -135,7 +135,10 @@ class IncrementalTrainingSpec:
             fused native-transform package). Schema-only in OSS today —
             carried through for forward compatibility with internal
             Michelangelo's warm-start config shape; no OSS code currently
-            strips or consumes this prefix.
+            strips or consumes this prefix. Defaults to ``None`` here,
+            unlike internal Michelangelo's ``"predictor_module"`` default —
+            reconcile this divergence deliberately once OSS implements the
+            stripping behavior (see the PR that ports it).
     """
 
     metadata: IncrementalTrainingMetadata
@@ -174,7 +177,10 @@ class TransferLearningSpec:
             fused native-transform package). Schema-only in OSS today —
             carried through for forward compatibility with internal
             Michelangelo's warm-start config shape; no OSS code currently
-            strips or consumes this prefix.
+            strips or consumes this prefix. Defaults to ``None`` here,
+            unlike internal Michelangelo's ``"predictor_module"`` default —
+            reconcile this divergence deliberately once OSS implements the
+            stripping behavior (see the PR that ports it).
     """
 
     metadata: TransferLearningMetadata

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/schema.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/schema.py
@@ -120,11 +120,28 @@ class IncrementalTrainingMetadata:
 
 @dataclass
 class IncrementalTrainingSpec:
-    """Consolidated specification for all incremental training configurations."""
+    """Consolidated specification for all incremental training configurations.
+
+    Attributes:
+        metadata: Baseline model and training-type metadata for this run.
+        load_optimizer_weights: Whether to restore optimizer state from the
+            baseline checkpoint in addition to model weights.
+        override_incremental_training_epoch: Explicit starting epoch for the
+            incremental run. ``None`` continues from the baseline's own epoch
+            count.
+        fused_model_submodule: Optional submodule-prefix used to select a
+            slice of a fused checkpoint's combined state dict before loading
+            it (e.g. ``"predictor_module"`` for the DL predictor half of a
+            fused native-transform package). Schema-only in OSS today —
+            carried through for forward compatibility with internal
+            Michelangelo's warm-start config shape; no OSS code currently
+            strips or consumes this prefix.
+    """
 
     metadata: IncrementalTrainingMetadata
     load_optimizer_weights: bool = False
     override_incremental_training_epoch: int | None = None
+    fused_model_submodule: str | None = None
 
 
 @dataclass
@@ -137,7 +154,28 @@ class TransferLearningMetadata:
 
 @dataclass
 class TransferLearningSpec:
-    """Consolidated specification for all transfer learning configurations."""
+    """Consolidated specification for all transfer learning configurations.
+
+    Attributes:
+        metadata: Baseline model and learning-mode metadata for this run.
+        model_loader_function: Optional dotted path to a custom function for
+            loading the baseline model, overriding the default loader.
+        layer_names_to_inherit: Exact layer names to copy weights for from
+            the baseline model.
+        layer_names_to_inherit_regex: Regex patterns matching layer names to
+            copy weights for from the baseline model.
+        layer_names_to_freeze: Exact layer names to freeze (exclude from
+            gradient updates) after loading baseline weights.
+        layer_names_to_freeze_regex: Regex patterns matching layer names to
+            freeze after loading baseline weights.
+        fused_model_submodule: Optional submodule-prefix used to select a
+            slice of a fused checkpoint's combined state dict before loading
+            it (e.g. ``"predictor_module"`` for the DL predictor half of a
+            fused native-transform package). Schema-only in OSS today —
+            carried through for forward compatibility with internal
+            Michelangelo's warm-start config shape; no OSS code currently
+            strips or consumes this prefix.
+    """
 
     metadata: TransferLearningMetadata
 
@@ -146,3 +184,4 @@ class TransferLearningSpec:
     layer_names_to_inherit_regex: list[str] = field(default_factory=list)
     layer_names_to_freeze: list[str] = field(default_factory=list)
     layer_names_to_freeze_regex: list[str] = field(default_factory=list)
+    fused_model_submodule: str | None = None

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_schema.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_schema.py
@@ -225,6 +225,7 @@ class TestIncrementalTrainingSpec:
         spec = IncrementalTrainingSpec(metadata=self._metadata())
         assert spec.load_optimizer_weights is False
         assert spec.override_incremental_training_epoch is None
+        assert spec.fused_model_submodule is None
 
     def test_overrides(self):
         """Optional fields are honored when provided."""
@@ -232,9 +233,11 @@ class TestIncrementalTrainingSpec:
             metadata=self._metadata(),
             load_optimizer_weights=True,
             override_incremental_training_epoch=5,
+            fused_model_submodule="predictor_module",
         )
         assert spec.load_optimizer_weights is True
         assert spec.override_incremental_training_epoch == 5
+        assert spec.fused_model_submodule == "predictor_module"
 
 
 # -----------------------------------------------------------------------------
@@ -286,9 +289,10 @@ class TestTransferLearningSpec:
         assert spec.metadata is meta
 
     def test_default_scalar_fields(self):
-        """``model_loader_function`` defaults to ``None``."""
+        """``model_loader_function`` and ``fused_model_submodule`` default to ``None``."""
         spec = TransferLearningSpec(metadata=self._metadata())
         assert spec.model_loader_function is None
+        assert spec.fused_model_submodule is None
 
     def test_default_list_fields_are_empty(self):
         """All four layer-name list fields default to empty lists."""
@@ -315,9 +319,11 @@ class TestTransferLearningSpec:
             layer_names_to_inherit_regex=[r"enc\..*"],
             layer_names_to_freeze=["enc.0"],
             layer_names_to_freeze_regex=[r"frozen\..*"],
+            fused_model_submodule="predictor_module",
         )
         assert spec.model_loader_function == "pkg.module.load"
         assert spec.layer_names_to_inherit == ["enc.0"]
         assert spec.layer_names_to_inherit_regex == [r"enc\..*"]
         assert spec.layer_names_to_freeze == ["enc.0"]
         assert spec.layer_names_to_freeze_regex == [r"frozen\..*"]
+        assert spec.fused_model_submodule == "predictor_module"


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Adds a `fused_model_submodule: str | None = None` field to `IncrementalTrainingSpec` and `TransferLearningSpec` in `lib/trainer/torch/pytorch_lightning/schema.py`. Also expands both classes' one-line docstrings into full Google-style `Attributes:` blocks that document every field, not just the new one.

The field names an optional submodule prefix for warm-starting from a *fused* checkpoint — one whose `state_dict` combines several submodules under prefixed keys (e.g. `predictor_module.*`). The prefix identifies which submodule's keys to select before loading them into the target model. It defaults to `None`, meaning "the baseline is not a fused checkpoint; load its keys as-is."

This PR is schema-shape only: it carries the field so warm-start configs can *express* fused-checkpoint routing, but it does **not** add any prefix selection/stripping or loading logic. Defaulting to a non-`None` value would imply selection behavior that this package does not implement yet, so the default is `None`.

**Why?**

The warm-start schema is a stable config surface that downstream tooling serializes and round-trips. Consumers that produce fused checkpoints need a place in the config to record which submodule to warm-start from. Adding the field now — as an inert, optional, forward-compatible addition — lets those configs be expressed and preserved today, and lets a future PR implement the actual selection behavior without a later breaking change to the schema shape.

**How did you test it?**

`pytest michelangelo/lib/trainer/torch/pytorch_lightning/tests/ -q` — 128 passed (two existing tests extended to cover the new field's default and override paths). `ruff format --check` / `ruff check` clean.

**Potential risks**

None — purely additive. Neither dataclass field is read anywhere else in this package today (`lightning_trainer.py` forwards these specs as opaque config objects; `_private/util.py`'s `_apply_layer_freeze` only reads the `layer_names_*` fields off a plain dict), so no existing behavior changes. The field is a trailing optional with a default, so existing construction call sites are unaffected.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

N/A — additive schema field, no behavior change.

**Documentation Changes**

`schema.py` docstrings expanded to Google-style `Attributes:` blocks for `IncrementalTrainingSpec` and `TransferLearningSpec`.
