### PR TITLE
ci(examples): wire california_housing_xgb integration test env + mark Phase 2 done

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -128,6 +128,8 @@ jobs:
         env:
           MA_API_SERVER: localhost:15566
           MA_NAMESPACE: ma-dev-test
+          MA_EXAMPLES_NAMESPACE: ma-examples
+          EXAMPLES_IMAGE_TAG: ${{ inputs.image_tag || 'latest' }}
           MICHELANGELO_PYTHON_DIR: ${{ github.workspace }}/python
           PYTHONPATH: ${{ github.workspace }}/integration-test
 

--- a/integration_test.md
+++ b/integration_test.md
@@ -94,8 +94,7 @@ Without end-to-end coverage, a breaking change in any one component (a CRD schem
 | Test | Go components | Python CLI | UI |
 |---|---|---|---|
 | UniFLOW (bert_cola) | API server (CRD CRUD), controllermgr (reconcile), worker (pod scheduling) | `ma pipeline apply`, `ma pipeline run`, poll | — |
-| Ray | API server, controllermgr (RayJob), kuberay-operator [4] | `ma pipeline apply`, `ma pipeline run` | — |
-| Spark | API server, controllermgr (SparkApplication), spark-operator [5] | `ma pipeline apply`, `ma pipeline run` | — |
+| Ray + Spark (california_housing_xgb) | API server, controllermgr (RayJob + SparkApplication), kuberay-operator [4], spark-operator [5] | `ma project apply`, `ma pipeline apply`, `ma pipeline run`, poll | — |
 | UI smoke | API server (HTTP/JSON) | — | Project list, detail; pipeline list; run detail |
 
 ---
@@ -399,9 +398,9 @@ This surfaces a ranked list of suspect PRs and likely root cause hypotheses with
 
 ### Rollout Plan
 
-**Phase 1** — UniFLOW baseline (current): Land CI workflows, verify bert_cola pipeline succeeds end-to-end on a 16-core runner.
+**Phase 1** — UniFLOW baseline (done): Land CI workflows, verify bert_cola pipeline succeeds end-to-end on a 16-core runner.
 
-**Phase 2** — Ray + Spark: Add lightweight example jobs and demo pipeline YAMLs; activate Ray and Spark test steps.
+**Phase 2** — Ray + Spark (done): Add lightweight example jobs and demo pipeline YAMLs; activate Ray and Spark test steps via `california_housing_xgb` (`test_examples_project_apply`, `test_california_housing_xgb_e2e` in `integration-test/functional/cli/test_cli.py`).
 
 **Phase 3** — UI smoke tests + dual engine: Add curl smoke test step; enable Cadence/Temporal matrix with port conflict resolution.
 


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**
- `.github/workflows/integration-test.yaml`: add `MA_EXAMPLES_NAMESPACE` and `EXAMPLES_IMAGE_TAG` env vars to the "Run CLI e2e tests" step, needed by the new `test_examples_project_apply` / `test_california_housing_xgb_e2e` tests in `michelangelo-ai/integration-test`.
- `integration_test.md`: merge the separate Ray/Spark table rows into one `Ray + Spark (california_housing_xgb)` row (both engines are now exercised together by the same example pipeline), and mark Rollout Plan Phase 1 and Phase 2 as done, referencing the new tests.

**Why?**
Companion PR to `michelangelo-ai/integration-test#<TBD>`, which adds two sequenced CLI integration tests for the `california_housing_xgb` example pipeline (Ray+Spark, via `ma pipeline run` against Cadence — unlike the existing dev-run-based `bert_cola` test). This repo needs the corresponding CI env vars and doc updates so the new tests run correctly in CI and `integration_test.md` reflects actual coverage.

**How did you test it?**
Sandbox-validated on a fresh k3d cluster (Cadence workflow engine): both `test_examples_project_apply` and `test_california_housing_xgb_e2e` passed end-to-end, along with a `test_bert_cola_e2e` regression check. Full evidence in the harness repo's `specs/003-california-housing-xgb-integration-test/sandbox.md` (verdict: PASS).

**Potential risks**
Low — this PR only adds two env vars (additive, defaulted via `inputs.image_tag || 'latest'`) and doc text. No production code paths change.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**
N/A

**Documentation Changes**
`integration_test.md` updated to reflect current test coverage and rollout status.