### PR TITLE
ci: notify Slack on scheduled/release workflow failures

### DIFF
--- a/.github/workflows/cleanup-nightlies.yml
+++ b/.github/workflows/cleanup-nightlies.yml
@@ -197,7 +197,7 @@ jobs:
       - name: Notify Slack on failure
         uses: slackapi/slack-github-action@v1.27.0
         with:
-          channel-id: '#michelangelo-releases'
+          channel-id: 'C0BER0RCQ8P'
           slack-message: |
             :x: *${{ github.workflow }}* failed
             Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/compat-matrix.yml
+++ b/.github/workflows/compat-matrix.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Notify Slack on failure
         uses: slackapi/slack-github-action@v1.27.0
         with:
-          channel-id: '#michelangelo-releases'
+          channel-id: 'C0BER0RCQ8P'
           slack-message: |
             :x: *${{ github.workflow }}* failed
             Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Notify Slack on failure
         uses: slackapi/slack-github-action@v1.27.0
         with:
-          channel-id: '#michelangelo-releases'
+          channel-id: 'C0BER0RCQ8P'
           slack-message: |
             :x: *${{ github.workflow }}* failed
             Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -310,3 +310,21 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_LEGACY_PEER_DEPS: 'true'
+
+  # ---------------------------------------------------------------------------
+  # Notify Slack when any nightly job fails
+  # ---------------------------------------------------------------------------
+  notify-on-failure:
+    needs: [check-changes, python-nightly, container-nightly, ui-nightly, helm-nightly, npm-nightly]
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack on failure
+        uses: slackapi/slack-github-action@v1.27.0
+        with:
+          channel-id: '#michelangelo-releases'
+          slack-message: |
+            :x: *${{ github.workflow }}* failed
+            Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -322,7 +322,7 @@ jobs:
       - name: Notify Slack on failure
         uses: slackapi/slack-github-action@v1.27.0
         with:
-          channel-id: '#michelangelo-releases'
+          channel-id: 'C0BER0RCQ8P'
           slack-message: |
             :x: *${{ github.workflow }}* failed
             Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -154,7 +154,7 @@ jobs:
       - name: Notify Slack on failure
         uses: slackapi/slack-github-action@v1.27.0
         with:
-          channel-id: '#michelangelo-releases'
+          channel-id: 'C0BER0RCQ8P'
           slack-message: |
             :x: *${{ github.workflow }}* failed for ${{ github.ref_name }}
             Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
## Summary
- Adds a `notify-on-failure` job to `nightly.yml` that posts to Slack via `slackapi/slack-github-action` when any nightly job fails, with a direct link to the failing run.
- **Consolidates the channel-id fix** for the same `notify-on-failure` pattern that was already merged into `main` via #1398 (cve-scan.yml), #1399 (release.yaml), #1400 (cleanup-nightlies.yml), and #1403 (compat-matrix.yml) — those PRs merged while this one was still open, carrying the placeholder `#michelangelo-releases` channel-id.
- Per paulzim's review feedback (same note across all 5 PRs): `channel-id` must be a real Slack channel ID (`Cxxxxxxxxxx`), not a `#channel-name` string, and CI failures should route to `#ma-oss-ci`. All 5 workflows now use the actual channel ID `C0BER0RCQ8P`.

Requires the `SLACK_BOT_TOKEN` repo secret (already configured) with `chat:write` scope, and the bot invited to the `#ma-oss-ci` channel.

Closes #1436.

## Test plan
- [x] `actionlint` passes on all 5 modified workflow files
- [ ] After merge, trigger via `workflow_dispatch` with a deliberately broken step (or wait for a real failure) to confirm the Slack message is posted to `#ma-oss-ci`