### PR TITLE
feat(python): add california_housing_lightning example (tabular_trainer + PyTorch Lightning)

### DIFF
--- a/python/examples/Dockerfile
+++ b/python/examples/Dockerfile
@@ -106,6 +106,14 @@ RUN ls -alF ./
 RUN poetry config virtualenvs.create false
 RUN poetry install -E example
 
+# poetry.lock marks importlib_resources as needed only under a compound
+# extra=="example" + python_version marker, but `poetry install -E example`
+# does not actually install it here even though it is a real transitive
+# runtime dependency of matplotlib (pulled in by torchmetrics's plotting
+# utilities, which pytorch_lightning imports at module load on Python 3.9).
+# Installing explicitly until the lockfile resolution is fixed upstream.
+RUN python3 -m pip install importlib_resources
+
 # Activate Poetry's virtual environment by default
 ENV PATH="/app/.venv/bin:$PATH"
 

--- a/python/examples/pipelines/california_housing_lightning/README.md
+++ b/python/examples/pipelines/california_housing_lightning/README.md
@@ -37,9 +37,13 @@ calls `xgboost.train()` directly, this example's `train.py` is a thin
 `@uniflow.task` wrapper around
 `michelangelo.workflow.tasks.tabular_trainer.task.train_tabular()` — the
 shared Lightning + Ray Train dispatcher also covered by
-`workflow/tasks/tabular_trainer/tests/`. `train_tabular()` returns a
-`ModelArtifact` directly (already the type `push_step` expects), rather than
-a raw checkpoint path.
+`workflow/tasks/tabular_trainer/tests/`. `train_tabular()` builds its own
+multi-node-safe `RunConfig` internally and returns a `ModelVariable`
+pointing at the uploaded checkpoint, rather than a raw checkpoint path or an
+assembled `ModelArtifact`. `push.py` downloads that checkpoint locally (via
+`fsspec.core.url_to_fs()`) and wraps it in a `ModelArtifact` before handing
+it to `ModelPusherPlugin`, since no OSS "assembler" task exists yet to do
+that conversion automatically.
 
 ### `TorchRegressionModel` — the model to plug in
 
@@ -86,10 +90,68 @@ Without `AWS_ENDPOINT_URL`, `train` and `push_step` both use
 `LocalStorageBackend`, writing the model checkpoint and datasets to local
 temp directories (no external services required).
 
-## Remote Run / k3d sandbox
+## Remote Run
 
-Same pattern as `california_housing_xgb` — see
-[its README](../california_housing_xgb/README.md#remote-run) for the full
-`remote-run` command and environment variable reference. Substitute
-`california_housing_lightning` for `california_housing_xgb` in the image
-build and `--file` paths.
+Pass environment variables via `--environ` flags — they are serialized into the
+Cadence/Temporal workflow and injected into every task's runtime environment,
+reaching remote workers. Shell `export` statements before the command only
+affect the local launcher and do not propagate.
+
+```bash
+cd michelangelo-ai/michelangelo/python
+JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home \
+PYTHONPATH=. poetry run python examples/pipelines/california_housing_lightning/california_housing_lightning.py \
+  remote-run \
+  --image docker.io/library/my-workflow:latest \
+  --storage-url s3://your-bucket/workflows \
+  --environ AWS_ENDPOINT_URL=http://your-minio-endpoint:9000 \
+  --environ AWS_ACCESS_KEY_ID=your-access-key \
+  --environ AWS_SECRET_ACCESS_KEY=your-secret-key \
+  --environ REGISTRY_ENDPOINT=your-apiserver-host:15566 \
+  --yes
+```
+
+### k3d sandbox
+
+```bash
+cd michelangelo-ai/michelangelo/python
+JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home \
+PYTHONPATH=. poetry run python examples/pipelines/california_housing_lightning/california_housing_lightning.py \
+  remote-run \
+  --image docker.io/library/my-workflow:latest \
+  --storage-url s3://michelangelo/workflows \
+  --environ AWS_ENDPOINT_URL=http://minio:9091 \
+  --environ AWS_ACCESS_KEY_ID=minioadmin \
+  --environ AWS_SECRET_ACCESS_KEY=minioadmin \
+  --environ REGISTRY_ENDPOINT=michelangelo-apiserver:15566 \
+  --yes
+```
+
+Before running, rebuild and import the image into the cluster:
+
+```bash
+docker build -t my-workflow:latest -f examples/Dockerfile .
+k3d image import my-workflow:latest -c michelangelo-sandbox
+kubectl delete cachedoutputs --all   # clear stale cached task outputs
+```
+
+### Environment variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `AWS_ENDPOINT_URL` | No | — | S3-compatible endpoint URL (include scheme, e.g. `http://minio:9091`). Unset → local storage |
+| `AWS_ACCESS_KEY_ID` | If `AWS_ENDPOINT_URL` set | — | Access key ID |
+| `AWS_SECRET_ACCESS_KEY` | If `AWS_ENDPOINT_URL` set | — | Secret access key |
+| `AWS_S3_BUCKET` | No | Parsed from `MA_FILE_SYSTEM` or `UF_STORAGE_URL` | Target bucket name |
+| `REGISTRY_ENDPOINT` | No | — | Model registry gRPC endpoint (`host:port`). Unset → in-memory only |
+| `REGISTRY_INSECURE` | No | `true` | Set `false` to enable TLS for the registry connection |
+| `REGISTRY_NAMESPACE` | No | `MA_NAMESPACE` (the pipeline's own namespace), else `default` | Model registry namespace |
+
+> **Sandbox note:** in a k3d sandbox, `AWS_ENDPOINT_URL`, `AWS_ACCESS_KEY_ID`,
+> and `AWS_SECRET_ACCESS_KEY` are automatically injected into Ray/Spark pods
+> via the `michelangelo-config` ConfigMap — no `--environ` flags needed for
+> `ma pipeline run`. For `remote-run`, pass them explicitly with `--environ`.
+> The apiserver Service and this example's task pods run in the same
+> namespace by default, so `REGISTRY_ENDPOINT` can use the short in-cluster
+> DNS name (`michelangelo-apiserver:15566`) rather than the full
+> `michelangelo-apiserver.<namespace>.svc.cluster.local:15566` form.

--- a/python/examples/pipelines/california_housing_lightning/README.md
+++ b/python/examples/pipelines/california_housing_lightning/README.md
@@ -1,0 +1,95 @@
+# California Housing Lightning
+
+End-to-end ML pipeline for California Housing price prediction using PyTorch
+Lightning via `tabular_trainer`'s `train_tabular()`. Counterpart to the
+sibling [`california_housing_xgb`](../california_housing_xgb) example, which
+uses a bespoke XGBoost training loop instead of `tabular_trainer`.
+
+## Pipeline
+
+```
+feature_prep  →  preprocess  →  train  →  push_step
+   (Ray)           (Spark)      (Ray)      (Spark)
+```
+
+| Step | File | Runtime | Description |
+|---|---|---|---|
+| `feature_prep` | `feature_prep.py` | Ray | Load dataset, train/test split, Ray Datasets |
+| `preprocess` | `preprocess.py` | Spark | Cast columns to float |
+| `train` | `train.py` | Ray | Distributed Lightning training via `tabular_trainer.train_tabular()` |
+| `push_step` | `push.py` | Spark | Push model and preprocessed datasets to storage/registry |
+
+`feature_prep.py` and `preprocess.py` are duplicated (not imported) from the
+sibling `california_housing_xgb` example, to keep each example directory
+fully self-contained per this repo's example convention.
+
+## Prerequisites
+
+Same as `california_housing_xgb` — see [its README](../california_housing_xgb/README.md#prerequisites)
+for sandbox setup, Java/Spark requirements, and the `ma-examples` project.
+
+## How It Works
+
+### `train_tabular()` instead of a bespoke training loop
+
+Unlike xgb's `train.py`, which builds its own `ScalingConfig`/`RunConfig` and
+calls `xgboost.train()` directly, this example's `train.py` is a thin
+`@uniflow.task` wrapper around
+`michelangelo.workflow.tasks.tabular_trainer.task.train_tabular()` — the
+shared Lightning + Ray Train dispatcher also covered by
+`workflow/tasks/tabular_trainer/tests/`. `train_tabular()` returns a
+`ModelArtifact` directly (already the type `push_step` expects), rather than
+a raw checkpoint path.
+
+### `TorchRegressionModel` — the model to plug in
+
+`train_tabular()` requires a `LightningModule` subclass, referenced by dotted
+import path via `LightningTrainerConfig.model_class`. This example defines a
+minimal MLP regressor in [`model.py`](model.py): two hidden `nn.Linear`
+layers (64 → 32, ReLU) feeding a single scalar output, trained with
+`MSELoss` and `Adam`.
+
+Ray Data batches passed to `training_step`/`validation_step` are dicts of
+column-name → tensor (the default `iter_torch_batches` output when no custom
+collate function is configured). `TorchRegressionModel` is constructed with
+`feature_columns`/`label_column` (via `LightningTrainerConfig.model_kwargs`)
+so it knows which batch keys to stack into its input tensor and which key
+holds the regression target.
+
+### CPU-only precision
+
+`train.py` explicitly forces `precision="32"` via `LightningTrainerKwargs`
+rather than relying on `train_tabular()`'s dispatcher default
+(`"bf16-mixed"`). Verified locally that `bf16-mixed` does not error on a
+CPU-only accelerator — Lightning runs real `torch.autocast('cpu',
+dtype=torch.bfloat16)` AMP, not a silent fallback — but on x86 CPUs without
+`AVX512_BF16` this runs via slower software emulation. `precision="32"`
+keeps this tutorial-oriented example's runs fast and deterministic on the
+k3d sandbox's CPU-only nodes.
+
+### No eval report
+
+Unlike xgb's `push_step`, this example's pusher does not push an
+`eval_report` artifact: `train_tabular()` returns a `ModelArtifact` without a
+training-metrics dict (unlike xgb's custom `TrainResult.metrics`), so there
+is nothing meaningful to report.
+
+## Local Run
+
+```bash
+cd michelangelo-ai/michelangelo/python
+JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home \
+PYTHONPATH=. poetry run python examples/pipelines/california_housing_lightning/california_housing_lightning.py
+```
+
+Without `AWS_ENDPOINT_URL`, `train` and `push_step` both use
+`LocalStorageBackend`, writing the model checkpoint and datasets to local
+temp directories (no external services required).
+
+## Remote Run / k3d sandbox
+
+Same pattern as `california_housing_xgb` — see
+[its README](../california_housing_xgb/README.md#remote-run) for the full
+`remote-run` command and environment variable reference. Substitute
+`california_housing_lightning` for `california_housing_xgb` in the image
+build and `--file` paths.

--- a/python/examples/pipelines/california_housing_lightning/__init__.py
+++ b/python/examples/pipelines/california_housing_lightning/__init__.py
@@ -1,0 +1,1 @@
+"""California Housing example: PyTorch Lightning regression via tabular_trainer."""

--- a/python/examples/pipelines/california_housing_lightning/_backend.py
+++ b/python/examples/pipelines/california_housing_lightning/_backend.py
@@ -1,0 +1,86 @@
+"""Shared storage-backend resolution for the ``train`` and ``push_step`` tasks.
+
+Both tasks in this workflow select a storage backend the same way:
+``AWS_ENDPOINT_URL`` set -> MinIO/S3-compatible remote storage; unset -> a
+local temp directory (development and CI). ``train`` and ``push_step`` run
+in separate Ray/Spark worker processes and can't share a live config object
+at runtime, so this module only shares the *resolution logic*, not a shared
+instance -- each task calls ``resolve_storage_backend()`` independently.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+if TYPE_CHECKING:
+    from michelangelo.lib.artifact_manager.storage_backend import StorageBackend
+
+log = logging.getLogger(__name__)
+
+__all__ = ["resolve_storage_backend"]
+
+
+def resolve_storage_backend(tmp_prefix: str) -> tuple[StorageBackend, bool]:
+    """Select MinIO (remote) or a local temp directory.
+
+    Args:
+        tmp_prefix: Prefix for the local temp directory, used only when
+            ``AWS_ENDPOINT_URL`` is unset. Lets each caller keep its own
+            recognizable temp dir (e.g. ``"..._train_"`` vs ``"..._push_"``)
+            when inspecting local runs.
+
+    Returns:
+        A ``(storage_backend, is_remote)`` tuple. ``is_remote`` is True when
+        a MinIO/S3-compatible backend was selected, so callers that need
+        remote-vs-local sink types (e.g. ``S3Sink`` vs ``LocalFileSink``)
+        don't have to re-check ``AWS_ENDPOINT_URL`` themselves.
+    """
+    s3_endpoint = os.environ.get("AWS_ENDPOINT_URL", "")
+    if s3_endpoint:
+        parsed = urlparse(s3_endpoint)
+        endpoint = parsed.netloc
+        if not endpoint:
+            raise ValueError(
+                f"AWS_ENDPOINT_URL={s3_endpoint!r} is missing a scheme. "
+                "Use a full URL like http://minio:9091"
+            )
+        bucket = (
+            os.environ.get("AWS_S3_BUCKET")
+            or (
+                os.environ.get("MA_FILE_SYSTEM")
+                or os.environ.get("UF_STORAGE_URL", "s3://default")
+            )
+            .removeprefix("s3://")
+            .split("/")[0]
+        )
+        if not bucket:
+            raise OSError(
+                "Could not determine storage bucket. "
+                "Set AWS_S3_BUCKET or MA_FILE_SYSTEM."
+            )
+        from michelangelo.lib.artifact_manager.minio_backend import MinioStorageBackend
+
+        storage_backend = MinioStorageBackend(
+            endpoint=endpoint,
+            bucket=bucket,
+            access_key=os.environ.get("AWS_ACCESS_KEY_ID", ""),
+            secret_key=os.environ.get("AWS_SECRET_ACCESS_KEY", ""),
+            secure=parsed.scheme == "https",
+            create_bucket_if_missing=True,
+        )
+        log.info(
+            "using MinioStorageBackend (remote) -> %s",
+            storage_backend.get_storage_location(),
+        )
+        return storage_backend, True
+
+    from michelangelo.lib.artifact_manager.storage_backend import LocalStorageBackend
+
+    local_dir = tempfile.mkdtemp(prefix=tmp_prefix)
+    storage_backend = LocalStorageBackend(local_dir)
+    log.info("using LocalStorageBackend (local/CI) -> %s", local_dir)
+    return storage_backend, False

--- a/python/examples/pipelines/california_housing_lightning/california_housing_lightning.py
+++ b/python/examples/pipelines/california_housing_lightning/california_housing_lightning.py
@@ -1,0 +1,92 @@
+"""PyTorch Lightning regression workflow for California Housing price prediction.
+
+Workflow entry point that orchestrates the full California Housing pipeline
+via ``tabular_trainer``'s Lightning backend: feature preparation, Spark
+preprocessing, distributed Lightning training with Ray Train, and a pusher
+step that exports the model and preprocessed datasets to storage and
+registry. Counterpart to the sibling ``california_housing_xgb`` example,
+which uses a bespoke XGBoost training loop instead of ``tabular_trainer``.
+"""
+
+from __future__ import annotations
+
+import michelangelo.uniflow.core as uniflow
+from examples.pipelines.california_housing_lightning.feature_prep import feature_prep
+from examples.pipelines.california_housing_lightning.preprocess import (
+    PreprocessResult,
+    preprocess,
+)
+from examples.pipelines.california_housing_lightning.push import push_step
+from examples.pipelines.california_housing_lightning.train import train
+from michelangelo.uniflow.plugins.ray import RayTask
+from michelangelo.uniflow.plugins.spark import SparkTask
+
+__all__ = [
+    "PreprocessResult",
+    "feature_prep",
+    "preprocess",
+    "push_step",
+    "train",
+    "train_workflow",
+]
+
+# California Housing features + target column order.
+# MedHouseVal (the sklearn target) is renamed to "target" in feature_prep.
+
+
+@uniflow.workflow()
+def train_workflow(
+    dataset_cols: str = (
+        "MedInc,HouseAge,AveRooms,AveBedrms,Population,AveOccup,Latitude,Longitude,target"
+    ),
+):
+    """End-to-end ML workflow: feature prep, preprocessing, training, and push.
+
+    Orchestrates the full ML lifecycle for California Housing using
+    ``tabular_trainer``'s Lightning backend: feature preparation,
+    preprocessing with Spark, distributed Lightning training with Ray Train,
+    and a pusher step that pushes the trained model and preprocessed
+    datasets to storage and registry.
+
+    Args:
+        dataset_cols: Comma-separated string of column names including
+            features and target.
+
+    Returns:
+        List of PusherResult from push_step, one per artifact pushed.
+    """
+    _dataset_cols = dataset_cols.split(",")
+    feature_prep_overrides = feature_prep.with_overrides(
+        alias="feature_prep_overrides",
+        config=RayTask(
+            head_cpu=2,
+            worker_instances=1,
+        ),
+    )
+    train_dv, validation_dv = feature_prep_overrides(
+        columns=_dataset_cols,
+    )
+    pr = preprocess.with_overrides(
+        alias="preprocess_overrides",
+        config=SparkTask(executor_cpu=1, driver_cpu=1),
+    )(
+        cast_float_columns=_dataset_cols,
+        train_dv=train_dv,
+        validation_dv=validation_dv,
+    )
+    model_artifact = train(
+        pr,
+        feature_columns=_dataset_cols[:-1],
+    )
+    return push_step(pr, model_artifact)
+
+
+if __name__ == "__main__":
+    ctx = uniflow.create_context()
+
+    ctx.environ["IMAGE_PULL_POLICY"] = "IfNotPresent"
+
+    # Pass MINIO_* and REGISTRY_* via --environ flags on the command line
+    # so values reach remote Ray workers (see README Remote Run section).
+
+    ctx.run(train_workflow)

--- a/python/examples/pipelines/california_housing_lightning/feature_prep.py
+++ b/python/examples/pipelines/california_housing_lightning/feature_prep.py
@@ -1,0 +1,75 @@
+"""Feature preparation task for the California Housing Lightning workflow.
+
+Loads the California Housing dataset, performs a train/test split, and
+converts the result to Ray Datasets for distributed processing.
+
+Duplicated (not imported) from the sibling ``california_housing_xgb`` example
+to keep each example directory fully self-contained, per this repo's example
+convention.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import michelangelo.uniflow.core as uniflow
+from michelangelo.uniflow.plugins.ray import RayTask
+from michelangelo.workflow.variables import DatasetVariable
+
+log = logging.getLogger(__name__)
+
+__all__ = ["feature_prep"]
+
+
+@uniflow.task(
+    config=RayTask(
+        head_cpu=1,
+        head_gpu=0,
+        head_memory="4Gi",
+        worker_cpu=1,
+        worker_gpu=0,
+        worker_memory="4Gi",
+        worker_instances=0,
+    ),
+    cache_enabled=False,  # off for tutorial simplicity; enable in production
+)
+def feature_prep(
+    columns: list[str],
+    test_size: float = 0.25,
+    seed: int = 1,
+) -> tuple[DatasetVariable, DatasetVariable]:
+    """Prepare features from the California Housing dataset.
+
+    Loads the California Housing dataset via scikit-learn, performs a
+    train/test split, and converts to Ray Datasets for distributed processing.
+
+    Args:
+        columns: List of column names to select (features + ``"target"``).
+        test_size: Fraction of data to use for validation. Defaults to 0.25.
+        seed: Random seed for reproducibility. Defaults to 1.
+
+    Returns:
+        Tuple of (train_dataset, validation_dataset) as DatasetVariables.
+    """
+    import ray.data
+    from sklearn.datasets import fetch_california_housing
+
+    housing = fetch_california_housing(as_frame=True)
+    df = housing.frame.rename(columns={"MedHouseVal": "target"})
+
+    data = ray.data.from_pandas(df).select_columns(columns)
+
+    train_data, validation_data = data.train_test_split(
+        test_size=test_size, shuffle=True, seed=seed
+    )
+
+    train_dv = DatasetVariable.create(train_data)
+    train_dv.save_ray_dataset()
+
+    validation_dv = DatasetVariable.create(validation_data)
+    validation_dv.save_ray_dataset()
+
+    log.info("Train dataset schema: %s", train_data.schema())
+    log.info("Train dataset sample: %s", train_data.take(1))
+
+    return train_dv, validation_dv

--- a/python/examples/pipelines/california_housing_lightning/model.py
+++ b/python/examples/pipelines/california_housing_lightning/model.py
@@ -1,0 +1,96 @@
+"""PyTorch Lightning regression model for the California Housing Lightning workflow.
+
+A minimal multi-layer perceptron regressor. This is the first
+``pytorch_lightning.LightningModule`` subclass with an example/e2e caller
+anywhere in this repo — ``tabular_trainer``'s existing tests use mocked
+models only (see ``workflow/tasks/tabular_trainer/tests/fixtures.py``).
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F  # noqa: N812
+from pytorch_lightning import LightningModule
+from torch import nn
+
+__all__ = ["TorchRegressionModel"]
+
+
+class TorchRegressionModel(LightningModule):
+    """Small MLP regressor trained via ``train_tabular()``'s Lightning backend.
+
+    The Ray Data batches passed to ``training_step``/``validation_step`` are
+    dicts of column-name -> tensor (Ray's default ``iter_torch_batches``
+    output when no custom collate function is configured). This model reads
+    ``feature_columns`` and ``label_column`` from its own constructor
+    arguments — set via ``LightningTrainerConfig.model_kwargs`` — to know
+    which batch keys to assemble into the input tensor and which key holds
+    the regression target.
+
+    Attributes:
+        feature_columns: Ordered list of input feature column names.
+        label_column: Name of the regression target column.
+        hidden_dim: Width of the first hidden layer. The second hidden layer
+            is half this width.
+        learning_rate: Adam learning rate.
+
+    Example:
+        >>> model = TorchRegressionModel(
+        ...     feature_columns=["MedInc", "HouseAge"],
+        ...     label_column="target",
+        ... )
+    """
+
+    def __init__(
+        self,
+        feature_columns: list[str],
+        label_column: str,
+        hidden_dim: int = 64,
+        learning_rate: float = 1e-3,
+    ):
+        """Build the MLP and store constructor args as hyperparameters."""
+        super().__init__()
+        self.save_hyperparameters()
+        self.net = nn.Sequential(
+            nn.Linear(len(feature_columns), hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, hidden_dim // 2),
+            nn.ReLU(),
+            nn.Linear(hidden_dim // 2, 1),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Return the model's scalar prediction for a batch of feature vectors."""
+        return self.net(x)
+
+    def _assemble_batch(
+        self, batch: dict[str, torch.Tensor]
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Stack the configured feature columns and extract the label column."""
+        x = torch.stack(
+            [batch[c].float() for c in self.hparams.feature_columns], dim=1
+        )
+        y = batch[self.hparams.label_column].float().view(-1, 1)
+        return x, y
+
+    def training_step(
+        self, batch: dict[str, torch.Tensor], batch_idx: int
+    ) -> torch.Tensor:
+        """Compute and log the MSE training loss for one batch."""
+        x, y = self._assemble_batch(batch)
+        loss = F.mse_loss(self(x), y)
+        self.log("train_loss", loss, on_step=False, on_epoch=True)
+        return loss
+
+    def validation_step(
+        self, batch: dict[str, torch.Tensor], batch_idx: int
+    ) -> torch.Tensor:
+        """Compute and log the MSE validation loss for one batch."""
+        x, y = self._assemble_batch(batch)
+        loss = F.mse_loss(self(x), y)
+        self.log("val_loss", loss, on_step=False, on_epoch=True)
+        return loss
+
+    def configure_optimizers(self) -> torch.optim.Optimizer:
+        """Return the Adam optimizer configured with ``learning_rate``."""
+        return torch.optim.Adam(self.parameters(), lr=self.hparams.learning_rate)

--- a/python/examples/pipelines/california_housing_lightning/pipeline.yaml
+++ b/python/examples/pipelines/california_housing_lightning/pipeline.yaml
@@ -1,0 +1,11 @@
+apiVersion: michelangelo.api/v2
+kind: Pipeline
+metadata:
+  namespace: "ma-examples"
+  name: "california-housing-lightning"
+  annotations:
+    michelangelo/uniflow-image: ghcr.io/michelangelo-ai/examples:main
+spec:
+  type: "PIPELINE_TYPE_TRAIN"
+  manifest:
+    filePath: examples.pipelines.california_housing_lightning.california_housing_lightning

--- a/python/examples/pipelines/california_housing_lightning/preprocess.py
+++ b/python/examples/pipelines/california_housing_lightning/preprocess.py
@@ -1,0 +1,91 @@
+"""Spark preprocessing task for the California Housing Lightning workflow.
+
+Casts selected columns to float type using Spark and returns the preprocessed
+training and validation datasets.
+
+Duplicated (not imported) from the sibling ``california_housing_xgb`` example
+to keep each example directory fully self-contained, per this repo's example
+convention.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import michelangelo.uniflow.core as uniflow
+from michelangelo.uniflow.plugins.spark import SparkTask
+from michelangelo.workflow.variables import DatasetVariable
+
+if TYPE_CHECKING:
+    from pyspark.sql import DataFrame
+
+log = logging.getLogger(__name__)
+
+__all__ = ["PreprocessResult", "preprocess"]
+
+
+@dataclass
+class PreprocessResult:
+    """Container for preprocessing results.
+
+    Attributes:
+        train_data: Training dataset.
+        validation_data: Validation dataset.
+    """
+
+    train_data: DatasetVariable
+    validation_data: DatasetVariable
+
+
+@uniflow.task(
+    config=SparkTask(
+        driver_cpu=1,
+        driver_memory="4G",
+        executor_cpu=1,
+        executor_memory="2G",
+        executor_instances=1,
+    ),
+    cache_enabled=False,  # off for tutorial simplicity; enable in production
+)
+def preprocess(
+    cast_float_columns: list[str],
+    train_dv: DatasetVariable,
+    validation_dv: DatasetVariable,
+) -> PreprocessResult:
+    """Preprocess datasets using Spark to cast columns to float type.
+
+    Args:
+        cast_float_columns: List of column names to cast to float type.
+        train_dv: Training DatasetVariable containing Spark DataFrame.
+        validation_dv: Validation DatasetVariable containing Spark DataFrame.
+
+    Returns:
+        PreprocessResult containing preprocessed training and validation datasets.
+    """
+    train_dv.load_spark_dataframe()
+    train_data: DataFrame = train_dv.value
+
+    validation_dv.load_spark_dataframe()
+    validation_data: DataFrame = validation_dv.value
+
+    def cast_float(df: DataFrame) -> DataFrame:
+        cols = {col: df[col].cast("float") for col in cast_float_columns}
+        return df.withColumns(cols)
+
+    train_data_pr = cast_float(train_data)
+    validation_data_pr = cast_float(validation_data)
+
+    train_dv_pr = DatasetVariable.create(train_data_pr)
+    train_dv_pr.save_spark_dataframe()
+
+    validation_dv_pr = DatasetVariable.create(validation_data_pr)
+    validation_dv_pr.save_spark_dataframe()
+
+    log.info("Processed Train Spark schema:\n%s", train_data_pr.schema.simpleString())
+
+    return PreprocessResult(
+        train_data=train_dv_pr,
+        validation_data=validation_dv_pr,
+    )

--- a/python/examples/pipelines/california_housing_lightning/push.py
+++ b/python/examples/pipelines/california_housing_lightning/push.py
@@ -152,7 +152,9 @@ def push_step(
         )
         registry_client = APIRegistryClient(
             svc=_api_client.ModelService,
-            namespace=os.environ.get("REGISTRY_NAMESPACE", "default"),
+            namespace=os.environ.get(
+                "REGISTRY_NAMESPACE", os.environ.get("MA_NAMESPACE", "default")
+            ),
         )
         log.info("push_step: using APIRegistryClient at %s", registry_endpoint)
     else:

--- a/python/examples/pipelines/california_housing_lightning/push.py
+++ b/python/examples/pipelines/california_housing_lightning/push.py
@@ -73,10 +73,26 @@ def push_step(
         List of ``PusherResult``, one per artifact pushed.
     """
     import os
+    from dataclasses import replace
 
     storage_backend, is_remote = resolve_storage_backend("california_lightning_push_")
 
     _run_id = os.path.basename(model_artifact.path.rstrip("/"))
+
+    # ModelArtifact.path is documented as an *absolute local filesystem path*
+    # (ModelPusherPlugin re-uploads it from disk), but train_tabular() already
+    # uploaded the model through its own storage_backend and returns that
+    # backend's URI directly -- a real s3:// URI when running remotely. Pull
+    # it back down to local disk before handing it to the shared pusher.
+    if is_remote:
+        import tempfile
+
+        local_model_path = os.path.join(
+            tempfile.mkdtemp(prefix="california_lightning_push_model_"),
+            os.path.basename(model_artifact.path),
+        )
+        storage_backend.download(model_artifact.path, local_model_path)
+        model_artifact = replace(model_artifact, path=local_model_path)
 
     pr.train_data.load_pandas_dataframe()
     pr.validation_data.load_pandas_dataframe()

--- a/python/examples/pipelines/california_housing_lightning/push.py
+++ b/python/examples/pipelines/california_housing_lightning/push.py
@@ -17,6 +17,9 @@ import logging
 from typing import TYPE_CHECKING
 
 import michelangelo.uniflow.core as uniflow
+from examples.pipelines.california_housing_lightning._backend import (
+    resolve_storage_backend,
+)
 from michelangelo.uniflow.plugins.spark import SparkTask
 from michelangelo.workflow.schema.pusher import (
     DatasetPluginConfig,
@@ -70,76 +73,27 @@ def push_step(
         List of ``PusherResult``, one per artifact pushed.
     """
     import os
-    import tempfile
 
-    s3_endpoint = os.environ.get("AWS_ENDPOINT_URL", "")
-    from urllib.parse import urlparse
-
-    parsed = urlparse(s3_endpoint) if s3_endpoint else None
-    endpoint = parsed.netloc if parsed else None
-    if s3_endpoint and not endpoint:
-        raise ValueError(
-            f"AWS_ENDPOINT_URL={s3_endpoint!r} is missing a scheme. "
-            "Use a full URL like http://minio:9091"
-        )
-    secure = parsed.scheme == "https" if parsed else False
-    access_key = os.environ.get("AWS_ACCESS_KEY_ID", "")
-    secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY", "")
+    storage_backend, is_remote = resolve_storage_backend("california_lightning_push_")
 
     _run_id = os.path.basename(model_artifact.path.rstrip("/"))
 
     pr.train_data.load_pandas_dataframe()
     pr.validation_data.load_pandas_dataframe()
 
-    if endpoint:
-        bucket = (
-            os.environ.get("AWS_S3_BUCKET")
-            or (
-                os.environ.get("MA_FILE_SYSTEM")
-                or os.environ.get("UF_STORAGE_URL", "s3://default")
-            )
-            .removeprefix("s3://")
-            .split("/")[0]
-        )
-        if not bucket:
-            raise OSError(
-                "Could not determine storage bucket. "
-                "Set AWS_S3_BUCKET or MA_FILE_SYSTEM."
-            )
-        from michelangelo.lib.artifact_manager.minio_backend import MinioStorageBackend
+    if is_remote:
         from michelangelo.workflow.schema.sinks.s3 import S3SinkConfig
         from michelangelo.workflow.tasks.functions.sinks import S3Sink
-
-        storage_backend = MinioStorageBackend(
-            endpoint=endpoint,
-            bucket=bucket,
-            access_key=access_key,
-            secret_key=secret_key,
-            secure=secure,
-            create_bucket_if_missing=True,
-        )
-        log.info(
-            "push_step: using MinioStorageBackend (remote) -> %s",
-            storage_backend.get_storage_location(),
-        )
 
         def _dataset_config(key: str) -> DatasetPluginConfig:
             return DatasetPluginConfig(
                 sinks=[S3Sink(S3SinkConfig(key, storage_backend=storage_backend))]
             )
     else:
-        from michelangelo.lib.artifact_manager.storage_backend import (
-            LocalStorageBackend,
-        )
         from michelangelo.workflow.schema.sinks.local import LocalFileSinkConfig
         from michelangelo.workflow.tasks.functions.sinks import LocalFileSink
 
-        _local_dir = tempfile.mkdtemp(prefix="california_lightning_push_")
-        storage_backend = LocalStorageBackend(_local_dir)
-        log.info(
-            "push_step: using LocalStorageBackend (local/CI) -> %s",
-            storage_backend.get_storage_location(),
-        )
+        _local_dir = storage_backend.get_storage_location()
 
         def _dataset_config(key: str) -> DatasetPluginConfig:  # type: ignore[misc]
             return DatasetPluginConfig(

--- a/python/examples/pipelines/california_housing_lightning/push.py
+++ b/python/examples/pipelines/california_housing_lightning/push.py
@@ -1,0 +1,239 @@
+"""Pusher step for the California Housing Lightning workflow.
+
+Pushes the trained model and preprocessed train/validation datasets to
+storage and registry in a single Spark task. Simpler than the sibling xgb
+example's ``push.py``: ``train_tabular()`` already returns a ``ModelArtifact``
+(the final artifact type the pusher expects), so there is no raw-checkpoint
+glob/MinIO-listing step needed to locate it.
+
+Unlike xgb's ``TrainResult``, ``train_tabular()`` does not return training
+metrics on its ``ModelArtifact`` (no eval-metrics dict), so this pusher omits
+the ``eval_report`` plugin that the xgb example pushes.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import michelangelo.uniflow.core as uniflow
+from michelangelo.uniflow.plugins.spark import SparkTask
+from michelangelo.workflow.schema.pusher import (
+    DatasetPluginConfig,
+    ModelPluginConfig,
+    PusherConfig,
+    PusherPluginConfig,
+)
+from michelangelo.workflow.tasks.pusher import push
+from michelangelo.workflow.variables.types import AssembledModel, PusherResult
+
+if TYPE_CHECKING:
+    from examples.pipelines.california_housing_lightning.preprocess import (
+        PreprocessResult,
+    )
+    from michelangelo.workflow.variables.types import ModelArtifact
+
+log = logging.getLogger(__name__)
+
+__all__ = ["push_step"]
+
+
+@uniflow.task(
+    config=SparkTask(
+        driver_cpu=1,
+        driver_memory="4G",
+        executor_cpu=1,
+        executor_memory="2G",
+        executor_instances=1,
+    ),
+)
+def push_step(
+    pr: PreprocessResult,
+    model_artifact: ModelArtifact,
+) -> list[PusherResult]:
+    """Push the trained model and preprocessed datasets in a single Spark step.
+
+    Pushes three artifacts using a single storage backend selected at runtime:
+
+    - **model** -- the Lightning checkpoint, already an assembled
+      ``ModelArtifact`` from ``train_tabular()``, via ``ModelPusherPlugin``.
+    - **train_data** / **validation_data** -- preprocessed datasets via
+      ``DatasetPusherPlugin`` + ``S3Sink`` (remote) or ``LocalFileSink`` (local/CI).
+
+    Args:
+        pr: Result of the ``preprocess`` task, holding preprocessed training
+            and validation ``DatasetVariable`` handles.
+        model_artifact: Result of the ``train`` task -- an already-assembled
+            ``ModelArtifact`` pointing at the uploaded Lightning checkpoint.
+
+    Returns:
+        List of ``PusherResult``, one per artifact pushed.
+    """
+    import os
+    import tempfile
+
+    s3_endpoint = os.environ.get("AWS_ENDPOINT_URL", "")
+    from urllib.parse import urlparse
+
+    parsed = urlparse(s3_endpoint) if s3_endpoint else None
+    endpoint = parsed.netloc if parsed else None
+    if s3_endpoint and not endpoint:
+        raise ValueError(
+            f"AWS_ENDPOINT_URL={s3_endpoint!r} is missing a scheme. "
+            "Use a full URL like http://minio:9091"
+        )
+    secure = parsed.scheme == "https" if parsed else False
+    access_key = os.environ.get("AWS_ACCESS_KEY_ID", "")
+    secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY", "")
+
+    _run_id = os.path.basename(model_artifact.path.rstrip("/"))
+
+    pr.train_data.load_pandas_dataframe()
+    pr.validation_data.load_pandas_dataframe()
+
+    if endpoint:
+        bucket = (
+            os.environ.get("AWS_S3_BUCKET")
+            or (
+                os.environ.get("MA_FILE_SYSTEM")
+                or os.environ.get("UF_STORAGE_URL", "s3://default")
+            )
+            .removeprefix("s3://")
+            .split("/")[0]
+        )
+        if not bucket:
+            raise OSError(
+                "Could not determine storage bucket. "
+                "Set AWS_S3_BUCKET or MA_FILE_SYSTEM."
+            )
+        from michelangelo.lib.artifact_manager.minio_backend import MinioStorageBackend
+        from michelangelo.workflow.schema.sinks.s3 import S3SinkConfig
+        from michelangelo.workflow.tasks.functions.sinks import S3Sink
+
+        storage_backend = MinioStorageBackend(
+            endpoint=endpoint,
+            bucket=bucket,
+            access_key=access_key,
+            secret_key=secret_key,
+            secure=secure,
+            create_bucket_if_missing=True,
+        )
+        log.info(
+            "push_step: using MinioStorageBackend (remote) -> %s",
+            storage_backend.get_storage_location(),
+        )
+
+        def _dataset_config(key: str) -> DatasetPluginConfig:
+            return DatasetPluginConfig(
+                sinks=[S3Sink(S3SinkConfig(key, storage_backend=storage_backend))]
+            )
+    else:
+        from michelangelo.lib.artifact_manager.storage_backend import (
+            LocalStorageBackend,
+        )
+        from michelangelo.workflow.schema.sinks.local import LocalFileSinkConfig
+        from michelangelo.workflow.tasks.functions.sinks import LocalFileSink
+
+        _local_dir = tempfile.mkdtemp(prefix="california_lightning_push_")
+        storage_backend = LocalStorageBackend(_local_dir)
+        log.info(
+            "push_step: using LocalStorageBackend (local/CI) -> %s",
+            storage_backend.get_storage_location(),
+        )
+
+        def _dataset_config(key: str) -> DatasetPluginConfig:  # type: ignore[misc]
+            return DatasetPluginConfig(
+                sinks=[
+                    LocalFileSink(
+                        LocalFileSinkConfig(
+                            destination_path=os.path.join(_local_dir, key)
+                        )
+                    )
+                ]
+            )
+
+    registry_endpoint = os.environ.get("REGISTRY_ENDPOINT")
+    if registry_endpoint:
+        import grpc as _grpc
+
+        from michelangelo.api.v2 import APIClient
+        from michelangelo.lib.model_manager.registry.api_client import APIRegistryClient
+
+        _insecure = os.environ.get("REGISTRY_INSECURE", "true").lower() != "false"
+        _credentials = None if _insecure else _grpc.ssl_channel_credentials()
+        _channel = (
+            _grpc.insecure_channel(registry_endpoint)
+            if _insecure
+            else _grpc.secure_channel(registry_endpoint, _credentials)
+        )
+        _api_client = APIClient(
+            caller="california-housing-lightning-push-step",
+            channel=_channel,
+        )
+        registry_client = APIRegistryClient(
+            svc=_api_client.ModelService,
+            namespace=os.environ.get("REGISTRY_NAMESPACE", "default"),
+        )
+        log.info("push_step: using APIRegistryClient at %s", registry_endpoint)
+    else:
+        from michelangelo.lib.model_manager.registry.client import (
+            InMemoryRegistryClient,
+        )
+
+        registry_client = InMemoryRegistryClient()
+        log.warning(
+            "REGISTRY_ENDPOINT not set -- using InMemoryRegistryClient. "
+            "Model registration will not be persisted."
+        )
+
+    config = PusherConfig(
+        items=[
+            PusherPluginConfig(
+                name="model",
+                model_plugin=ModelPluginConfig(
+                    model_name="california-housing-lightning",
+                    description=(
+                        "PyTorch Lightning regression on California Housing dataset"
+                    ),
+                    labels={"framework": "pytorch_lightning"},
+                ),
+            ),
+            PusherPluginConfig(
+                name="train_data",
+                dataset_plugin=_dataset_config(
+                    f"datasets/california-housing-lightning/{_run_id}/train"
+                ),
+            ),
+            PusherPluginConfig(
+                name="validation_data",
+                dataset_plugin=_dataset_config(
+                    f"datasets/california-housing-lightning/{_run_id}/validation"
+                ),
+            ),
+        ]
+    )
+
+    assembled = AssembledModel(raw_model=model_artifact)
+
+    results = push(
+        config=config,
+        artifacts={
+            "model": assembled,
+            "train_data": pr.train_data,
+            "validation_data": pr.validation_data,
+        },
+        storage_backend=storage_backend,
+        registry_client=registry_client,
+    )
+
+    for r in results:
+        log.info(
+            "push %s (%s): success=%s value=%s error=%s",
+            r.name,
+            r.plugin,
+            r.success,
+            r.value,
+            r.error,
+        )
+
+    return results

--- a/python/examples/pipelines/california_housing_lightning/push.py
+++ b/python/examples/pipelines/california_housing_lightning/push.py
@@ -1,14 +1,16 @@
 """Pusher step for the California Housing Lightning workflow.
 
 Pushes the trained model and preprocessed train/validation datasets to
-storage and registry in a single Spark task. Simpler than the sibling xgb
-example's ``push.py``: ``train_tabular()`` already returns a ``ModelArtifact``
-(the final artifact type the pusher expects), so there is no raw-checkpoint
-glob/MinIO-listing step needed to locate it.
+storage and registry in a single Spark task. ``train_tabular()`` hands off
+its trained model as an intra-pipeline ``ModelVariable`` (there is no OSS
+"assembler" task yet to package it into a registry-ready ``ModelArtifact``),
+so ``push_step`` does that conversion itself (download the state-dict file,
+wrap it as a local ``ModelArtifact``) before handing off to the shared
+``ModelPusherPlugin``.
 
 Unlike xgb's ``TrainResult``, ``train_tabular()`` does not return training
-metrics on its ``ModelArtifact`` (no eval-metrics dict), so this pusher omits
-the ``eval_report`` plugin that the xgb example pushes.
+metrics (no eval-metrics dict), so this pusher omits the ``eval_report``
+plugin that the xgb example pushes.
 """
 
 from __future__ import annotations
@@ -28,13 +30,17 @@ from michelangelo.workflow.schema.pusher import (
     PusherPluginConfig,
 )
 from michelangelo.workflow.tasks.pusher import push
-from michelangelo.workflow.variables.types import AssembledModel, PusherResult
+from michelangelo.workflow.variables.types import (
+    AssembledModel,
+    ModelArtifact,
+    PusherResult,
+)
 
 if TYPE_CHECKING:
     from examples.pipelines.california_housing_lightning.preprocess import (
         PreprocessResult,
     )
-    from michelangelo.workflow.variables.types import ModelArtifact
+    from michelangelo.workflow.variables import ModelVariable
 
 log = logging.getLogger(__name__)
 
@@ -52,47 +58,51 @@ __all__ = ["push_step"]
 )
 def push_step(
     pr: PreprocessResult,
-    model_artifact: ModelArtifact,
+    model_variable: ModelVariable,
 ) -> list[PusherResult]:
     """Push the trained model and preprocessed datasets in a single Spark step.
 
     Pushes three artifacts using a single storage backend selected at runtime:
 
-    - **model** -- the Lightning checkpoint, already an assembled
-      ``ModelArtifact`` from ``train_tabular()``, via ``ModelPusherPlugin``.
+    - **model** -- the Lightning checkpoint, converted from the
+      intra-pipeline ``ModelVariable`` returned by ``train_tabular()`` into a
+      local ``ModelArtifact``, via ``ModelPusherPlugin``.
     - **train_data** / **validation_data** -- preprocessed datasets via
       ``DatasetPusherPlugin`` + ``S3Sink`` (remote) or ``LocalFileSink`` (local/CI).
 
     Args:
         pr: Result of the ``preprocess`` task, holding preprocessed training
             and validation ``DatasetVariable`` handles.
-        model_artifact: Result of the ``train`` task -- an already-assembled
-            ``ModelArtifact`` pointing at the uploaded Lightning checkpoint.
+        model_variable: Result of the ``train`` task -- a ``ModelVariable``
+            wrapping the trained Lightning model, persisted under
+            ``UF_STORAGE_URL``.
 
     Returns:
         List of ``PusherResult``, one per artifact pushed.
     """
     import os
-    from dataclasses import replace
+    import tempfile
+
+    import fsspec
 
     storage_backend, is_remote = resolve_storage_backend("california_lightning_push_")
 
-    _run_id = os.path.basename(model_artifact.path.rstrip("/"))
+    _run_id = os.path.basename(model_variable.path.rstrip("/"))
 
-    # ModelArtifact.path is documented as an *absolute local filesystem path*
-    # (ModelPusherPlugin re-uploads it from disk), but train_tabular() already
-    # uploaded the model through its own storage_backend and returns that
-    # backend's URI directly -- a real s3:// URI when running remotely. Pull
-    # it back down to local disk before handing it to the shared pusher.
-    if is_remote:
-        import tempfile
-
-        local_model_path = os.path.join(
-            tempfile.mkdtemp(prefix="california_lightning_push_model_"),
-            os.path.basename(model_artifact.path),
-        )
-        storage_backend.download(model_artifact.path, local_model_path)
-        model_artifact = replace(model_artifact, path=local_model_path)
+    # train_tabular() no longer packages/uploads the model itself -- it hands
+    # off an intra-pipeline ModelVariable persisted under UF_STORAGE_URL, and
+    # there is no OSS "assembler" task yet to turn that into a registry-ready
+    # ModelArtifact. Pull the state-dict file it already wrote (via
+    # save_lightning_model()) down to local disk with the same fsspec
+    # mechanism ModelVariable itself uses, then wrap it as a ModelArtifact --
+    # the local-file contract ModelPusherPlugin expects.
+    local_model_dir = tempfile.mkdtemp(prefix="california_lightning_push_model_")
+    local_model_path = os.path.join(local_model_dir, "model.pt")
+    fs, remote_model_path = fsspec.core.url_to_fs(model_variable.path)
+    fs.get(remote_model_path, local_model_path)
+    model_artifact = ModelArtifact(
+        path=local_model_path, metadata=model_variable.metadata
+    )
 
     pr.train_data.load_pandas_dataframe()
     pr.validation_data.load_pandas_dataframe()

--- a/python/examples/pipelines/california_housing_lightning/train.py
+++ b/python/examples/pipelines/california_housing_lightning/train.py
@@ -1,0 +1,157 @@
+"""Lightning training task for the California Housing Lightning workflow.
+
+Trains a small PyTorch Lightning regression model on preprocessed California
+Housing data via ``tabular_trainer``'s ``train_tabular()`` (Ray Train +
+Lightning backend), the counterpart to the sibling ``california_housing_xgb``
+example's bespoke XGBoost training loop.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING
+
+import michelangelo.uniflow.core as uniflow
+from michelangelo.uniflow.plugins.ray import RayTask
+from michelangelo.workflow.schema.tabular_trainer import (
+    BatchIterConfig,
+    ColumnConfig,
+    DataloadingConfig,
+    LightningTrainerConfig,
+    LightningTrainerKwargs,
+    ScalingConfig,
+    TabularTrainerConfig,
+)
+from michelangelo.workflow.tasks.tabular_trainer.task import train_tabular
+
+if TYPE_CHECKING:
+    from examples.pipelines.california_housing_lightning.preprocess import (
+        PreprocessResult,
+    )
+    from michelangelo.workflow.variables.types import ModelArtifact
+
+log = logging.getLogger(__name__)
+
+__all__ = ["train"]
+
+LABEL_COLUMN = "target"
+
+
+def _resolve_storage_backend():
+    """Select MinIO (remote) or a local temp directory.
+
+    Matches the ``california_housing_xgb`` example's ``push.py``
+    storage-backend selection: ``AWS_ENDPOINT_URL`` set -> MinIO/S3-compatible
+    remote storage; unset -> local filesystem (development and CI).
+    """
+    import tempfile
+    from urllib.parse import urlparse
+
+    s3_endpoint = os.environ.get("AWS_ENDPOINT_URL", "")
+    if s3_endpoint:
+        parsed = urlparse(s3_endpoint)
+        endpoint = parsed.netloc
+        if not endpoint:
+            raise ValueError(
+                f"AWS_ENDPOINT_URL={s3_endpoint!r} is missing a scheme. "
+                "Use a full URL like http://minio:9091"
+            )
+        from michelangelo.lib.artifact_manager.minio_backend import MinioStorageBackend
+
+        bucket = (
+            os.environ.get("AWS_S3_BUCKET")
+            or (
+                os.environ.get("MA_FILE_SYSTEM")
+                or os.environ.get("UF_STORAGE_URL", "s3://default")
+            )
+            .removeprefix("s3://")
+            .split("/")[0]
+        )
+        return MinioStorageBackend(
+            endpoint=endpoint,
+            bucket=bucket,
+            access_key=os.environ.get("AWS_ACCESS_KEY_ID", ""),
+            secret_key=os.environ.get("AWS_SECRET_ACCESS_KEY", ""),
+            secure=parsed.scheme == "https",
+            create_bucket_if_missing=True,
+        )
+
+    from michelangelo.lib.artifact_manager.storage_backend import LocalStorageBackend
+
+    local_dir = tempfile.mkdtemp(prefix="california_lightning_train_")
+    log.info("train: using LocalStorageBackend (local/CI) -> %s", local_dir)
+    return LocalStorageBackend(local_dir)
+
+
+@uniflow.task(
+    config=RayTask(
+        head_cpu=1,
+        head_gpu=0,
+        head_memory="4Gi",
+        worker_cpu=1,
+        worker_gpu=0,
+        worker_memory="4Gi",
+        worker_instances=2,
+    ),
+)
+def train(
+    pr: PreprocessResult,
+    feature_columns: list[str],
+) -> ModelArtifact:
+    """Train a Lightning regression model using Ray Train.
+
+    Args:
+        pr: PreprocessResult containing preprocessed training and validation
+            datasets.
+        feature_columns: Ordered list of feature column names (excludes the
+            label column).
+
+    Returns:
+        ModelArtifact pointing at the uploaded model checkpoint. Unlike the
+        sibling xgb example's ``train()``, this is already the final artifact
+        type expected by the pusher -- ``train_tabular()`` uploads the model
+        itself and returns a ``ModelArtifact`` directly.
+    """
+    storage_backend = _resolve_storage_backend()
+
+    config = TabularTrainerConfig(
+        lightning=LightningTrainerConfig(
+            model_class=(
+                "examples.pipelines.california_housing_lightning.model."
+                "TorchRegressionModel"
+            ),
+            model_kwargs={
+                "feature_columns": feature_columns,
+                "label_column": LABEL_COLUMN,
+            },
+            input_columns={
+                c: ColumnConfig("torch.float32") for c in feature_columns
+            },
+            output_columns={"prediction": ColumnConfig("torch.float32")},
+            labels={LABEL_COLUMN: ColumnConfig("torch.float32")},
+            metadata_columns=[],
+            scaling_config=ScalingConfig(cpu_per_worker=1),
+            dataloading_config=DataloadingConfig(
+                batch_iter_config=BatchIterConfig(
+                    batch_size=64, num_shuffle_batches=1
+                )
+            ),
+            # precision explicitly forced to "32" rather than relying on the
+            # dispatcher's "bf16-mixed" default: verified locally that
+            # bf16-mixed does not error on CPU (real torch.autocast('cpu', ...)
+            # AMP, not a silent fallback), but on x86 CPUs without
+            # AVX512_BF16 it runs via slower software emulation. This example
+            # prioritizes fast, deterministic CI/sandbox runs over AMP.
+            lightning_trainer_kwargs=LightningTrainerKwargs(
+                max_epochs=5, precision="32"
+            ),
+        )
+    )
+
+    return train_tabular(
+        config,
+        pr.train_data,
+        pr.validation_data,
+        storage_backend=storage_backend,
+    )

--- a/python/examples/pipelines/california_housing_lightning/train.py
+++ b/python/examples/pipelines/california_housing_lightning/train.py
@@ -9,13 +9,9 @@ example's bespoke XGBoost training loop.
 from __future__ import annotations
 
 import logging
-import os
 from typing import TYPE_CHECKING
 
 import michelangelo.uniflow.core as uniflow
-from examples.pipelines.california_housing_lightning._backend import (
-    resolve_storage_backend,
-)
 from michelangelo.uniflow.plugins.ray import RayTask
 from michelangelo.workflow.schema.tabular_trainer import (
     BatchIterConfig,
@@ -32,7 +28,7 @@ if TYPE_CHECKING:
     from examples.pipelines.california_housing_lightning.preprocess import (
         PreprocessResult,
     )
-    from michelangelo.workflow.variables.types import ModelArtifact
+    from michelangelo.workflow.variables import ModelVariable
 
 log = logging.getLogger(__name__)
 
@@ -55,7 +51,7 @@ LABEL_COLUMN = "target"
 def train(
     pr: PreprocessResult,
     feature_columns: list[str],
-) -> ModelArtifact:
+) -> ModelVariable:
     """Train a Lightning regression model using Ray Train.
 
     Args:
@@ -65,33 +61,15 @@ def train(
             label column).
 
     Returns:
-        ModelArtifact pointing at the uploaded model checkpoint. Unlike the
-        sibling xgb example's ``train()``, this is already the final artifact
-        type expected by the pusher -- ``train_tabular()`` uploads the model
-        itself and returns a ``ModelArtifact`` directly.
+        ModelVariable wrapping the trained model as an intra-pipeline
+        intermediate. ``train_tabular()`` persists it under
+        ``UF_STORAGE_URL`` and, for its own distributed checkpointing on a
+        multi-node cluster, defaults ``run_config`` to the same location via
+        ``michelangelo.uniflow.plugins.ray.run_config.create_run_config()`` --
+        no manual storage-backend or RunConfig plumbing needed here. There is
+        no OSS "assembler" task yet to turn this into a registry-ready
+        ``ModelArtifact``, so ``push_step`` does that conversion itself.
     """
-    storage_backend, is_remote = resolve_storage_backend("california_lightning_train_")
-
-    # train_tabular() defaults to a local-tempdir storage_path for Ray Train's
-    # own distributed checkpointing when no run_config is given -- fine for a
-    # single-process local run, but broken on a real multi-node cluster since
-    # worker pods can't see the head pod's local filesystem. Point it at the
-    # same MinIO/S3 backend used for the final model upload when running
-    # remotely, namespaced by MA_PIPELINE_RUN_NAME (set by the platform on
-    # every task pod) so concurrent runs don't clobber each other's checkpoints.
-    run_config = None
-    if is_remote:
-        import ray.train
-
-        from michelangelo.uniflow.plugins.ray.io import resolve_fs
-
-        bucket = storage_backend.get_storage_location().removeprefix("s3://")
-        run_id = os.environ.get("MA_PIPELINE_RUN_NAME", "local")
-        run_config = ray.train.RunConfig(
-            storage_path=f"{bucket}/ray_train_runs/{run_id}",
-            storage_filesystem=resolve_fs("s3"),
-        )
-
     config = TabularTrainerConfig(
         lightning=LightningTrainerConfig(
             model_class=(
@@ -126,10 +104,4 @@ def train(
         )
     )
 
-    return train_tabular(
-        config,
-        pr.train_data,
-        pr.validation_data,
-        storage_backend=storage_backend,
-        run_config=run_config,
-    )
+    return train_tabular(config, pr.train_data, pr.validation_data)

--- a/python/examples/pipelines/california_housing_lightning/train.py
+++ b/python/examples/pipelines/california_housing_lightning/train.py
@@ -9,10 +9,12 @@ example's bespoke XGBoost training loop.
 from __future__ import annotations
 
 import logging
-import os
 from typing import TYPE_CHECKING
 
 import michelangelo.uniflow.core as uniflow
+from examples.pipelines.california_housing_lightning._backend import (
+    resolve_storage_backend,
+)
 from michelangelo.uniflow.plugins.ray import RayTask
 from michelangelo.workflow.schema.tabular_trainer import (
     BatchIterConfig,
@@ -36,52 +38,6 @@ log = logging.getLogger(__name__)
 __all__ = ["train"]
 
 LABEL_COLUMN = "target"
-
-
-def _resolve_storage_backend():
-    """Select MinIO (remote) or a local temp directory.
-
-    Matches the ``california_housing_xgb`` example's ``push.py``
-    storage-backend selection: ``AWS_ENDPOINT_URL`` set -> MinIO/S3-compatible
-    remote storage; unset -> local filesystem (development and CI).
-    """
-    import tempfile
-    from urllib.parse import urlparse
-
-    s3_endpoint = os.environ.get("AWS_ENDPOINT_URL", "")
-    if s3_endpoint:
-        parsed = urlparse(s3_endpoint)
-        endpoint = parsed.netloc
-        if not endpoint:
-            raise ValueError(
-                f"AWS_ENDPOINT_URL={s3_endpoint!r} is missing a scheme. "
-                "Use a full URL like http://minio:9091"
-            )
-        from michelangelo.lib.artifact_manager.minio_backend import MinioStorageBackend
-
-        bucket = (
-            os.environ.get("AWS_S3_BUCKET")
-            or (
-                os.environ.get("MA_FILE_SYSTEM")
-                or os.environ.get("UF_STORAGE_URL", "s3://default")
-            )
-            .removeprefix("s3://")
-            .split("/")[0]
-        )
-        return MinioStorageBackend(
-            endpoint=endpoint,
-            bucket=bucket,
-            access_key=os.environ.get("AWS_ACCESS_KEY_ID", ""),
-            secret_key=os.environ.get("AWS_SECRET_ACCESS_KEY", ""),
-            secure=parsed.scheme == "https",
-            create_bucket_if_missing=True,
-        )
-
-    from michelangelo.lib.artifact_manager.storage_backend import LocalStorageBackend
-
-    local_dir = tempfile.mkdtemp(prefix="california_lightning_train_")
-    log.info("train: using LocalStorageBackend (local/CI) -> %s", local_dir)
-    return LocalStorageBackend(local_dir)
 
 
 @uniflow.task(
@@ -113,7 +69,7 @@ def train(
         type expected by the pusher -- ``train_tabular()`` uploads the model
         itself and returns a ``ModelArtifact`` directly.
     """
-    storage_backend = _resolve_storage_backend()
+    storage_backend, _ = resolve_storage_backend("california_lightning_train_")
 
     config = TabularTrainerConfig(
         lightning=LightningTrainerConfig(

--- a/python/examples/pipelines/california_housing_lightning/train.py
+++ b/python/examples/pipelines/california_housing_lightning/train.py
@@ -9,6 +9,7 @@ example's bespoke XGBoost training loop.
 from __future__ import annotations
 
 import logging
+import os
 from typing import TYPE_CHECKING
 
 import michelangelo.uniflow.core as uniflow
@@ -69,7 +70,27 @@ def train(
         type expected by the pusher -- ``train_tabular()`` uploads the model
         itself and returns a ``ModelArtifact`` directly.
     """
-    storage_backend, _ = resolve_storage_backend("california_lightning_train_")
+    storage_backend, is_remote = resolve_storage_backend("california_lightning_train_")
+
+    # train_tabular() defaults to a local-tempdir storage_path for Ray Train's
+    # own distributed checkpointing when no run_config is given -- fine for a
+    # single-process local run, but broken on a real multi-node cluster since
+    # worker pods can't see the head pod's local filesystem. Point it at the
+    # same MinIO/S3 backend used for the final model upload when running
+    # remotely, namespaced by MA_PIPELINE_RUN_NAME (set by the platform on
+    # every task pod) so concurrent runs don't clobber each other's checkpoints.
+    run_config = None
+    if is_remote:
+        import ray.train
+
+        from michelangelo.uniflow.plugins.ray.io import resolve_fs
+
+        bucket = storage_backend.get_storage_location().removeprefix("s3://")
+        run_id = os.environ.get("MA_PIPELINE_RUN_NAME", "local")
+        run_config = ray.train.RunConfig(
+            storage_path=f"{bucket}/ray_train_runs/{run_id}",
+            storage_filesystem=resolve_fs("s3"),
+        )
 
     config = TabularTrainerConfig(
         lightning=LightningTrainerConfig(
@@ -110,4 +131,5 @@ def train(
         pr.train_data,
         pr.validation_data,
         storage_backend=storage_backend,
+        run_config=run_config,
     )

--- a/python/michelangelo/lib/model_manager/registry/api_client.py
+++ b/python/michelangelo/lib/model_manager/registry/api_client.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from typing import TYPE_CHECKING, Any
 
 import grpc
@@ -62,6 +63,24 @@ METADATA_ANNOTATION_KEY = "michelangelo.io/metadata"
 """Annotation key under which free-form metadata is JSON-serialised."""
 
 _MAX_REGISTER_RETRIES = 3
+
+_K8S_LABEL_VALUE_MAX_LENGTH = 63
+_K8S_LABEL_VALUE_RE = re.compile(r"^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$")
+
+
+def _is_valid_k8s_label_value(value: str) -> bool:
+    """Return ``True`` if *value* satisfies Kubernetes' label-value rules.
+
+    At most 63 characters, and either empty or starting/ending with an
+    alphanumeric character with dashes, underscores, dots, and alphanumerics
+    in between (see
+    https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set).
+    """
+    return (
+        len(value) <= _K8S_LABEL_VALUE_MAX_LENGTH
+        and _K8S_LABEL_VALUE_RE.match(value) is not None
+    )
+
 
 __all__ = ["METADATA_ANNOTATION_KEY", "APIRegistryClient"]
 
@@ -262,8 +281,33 @@ class APIRegistryClient(ModelRegistryClient):
             model.spec.deployable_artifact_uri.append(deployable_artifact_uri)
         if description:
             model.spec.description = description
+
+        # Kubernetes label values are capped at 63 characters and restricted
+        # to alphanumerics/dashes/underscores/dots. Callers built on top of
+        # ModelMetadata.to_registry_dict() (e.g. `model_class`, a fully
+        # qualified Python import path) commonly exceed this, and
+        # InMemoryRegistryClient never enforces it, so the violation is only
+        # ever caught here, against a real apiserver. Demote any offending
+        # value into the metadata annotation instead of erroring — the
+        # information is preserved (JSON has no such length limit), it's
+        # just no longer filterable as a label.
+        extra_metadata: dict[str, Any] = dict(metadata or {})
         for k, v in (labels or {}).items():
-            model.metadata.labels[k] = v
+            if _is_valid_k8s_label_value(v):
+                model.metadata.labels[k] = v
+            else:
+                _logger.info(
+                    "register_model(%r): label %r=%r is not a valid Kubernetes "
+                    "label value (max %d chars, alphanumeric/-/_/. only) — "
+                    "storing under the %r annotation instead.",
+                    name,
+                    k,
+                    v,
+                    _K8S_LABEL_VALUE_MAX_LENGTH,
+                    METADATA_ANNOTATION_KEY,
+                )
+                extra_metadata.setdefault(k, v)
+        metadata = extra_metadata
         if metadata:
             model.metadata.annotations[METADATA_ANNOTATION_KEY] = json.dumps(
                 dict(metadata)

--- a/python/michelangelo/lib/model_manager/registry/tests/api_client_test.py
+++ b/python/michelangelo/lib/model_manager/registry/tests/api_client_test.py
@@ -128,6 +128,58 @@ class TestAPIRegistryClientRegisterModel(TestCase):
         created_model = svc.create_model.call_args[0][0]
         self.assertEqual(created_model.metadata.labels["fw"], "xgboost")
 
+    def test_oversized_label_value_demoted_to_metadata_annotation(self):
+        """A label value over 63 chars is moved to the metadata annotation.
+
+        Regression test: ModelMetadata.to_registry_dict() commonly emits a
+        fully-qualified Python class path (e.g. `model_class`) that exceeds
+        Kubernetes' 63-character label-value limit. Writing it straight to
+        model.metadata.labels made create_model()/update_model() fail with
+        INVALID_ARGUMENT against a real apiserver.
+        """
+        svc = _mock_svc()
+        long_value = (
+            "examples.pipelines.california_housing_lightning.model.TorchRegressionModel"
+        )
+        self.assertGreater(len(long_value), 63)
+        _client(svc).register_model(
+            "m", "s3://b/raw", labels={"model_class": long_value, "fw": "lightning"}
+        )
+        created_model = svc.create_model.call_args[0][0]
+        self.assertNotIn("model_class", created_model.metadata.labels)
+        self.assertEqual(created_model.metadata.labels["fw"], "lightning")
+        annotation = json.loads(
+            created_model.metadata.annotations[METADATA_ANNOTATION_KEY]
+        )
+        self.assertEqual(annotation["model_class"], long_value)
+
+    def test_label_value_with_invalid_characters_demoted_to_metadata_annotation(self):
+        """A label value with disallowed characters is moved to the annotation."""
+        svc = _mock_svc()
+        _client(svc).register_model("m", "s3://b/raw", labels={"note": "50% faster!"})
+        created_model = svc.create_model.call_args[0][0]
+        self.assertNotIn("note", created_model.metadata.labels)
+        annotation = json.loads(
+            created_model.metadata.annotations[METADATA_ANNOTATION_KEY]
+        )
+        self.assertEqual(annotation["note"], "50% faster!")
+
+    def test_demoted_label_does_not_override_explicit_metadata(self):
+        """An explicit metadata key wins over a same-named demoted label."""
+        svc = _mock_svc()
+        long_value = "a" * 64
+        _client(svc).register_model(
+            "m",
+            "s3://b/raw",
+            labels={"model_class": long_value},
+            metadata={"model_class": "explicit-value"},
+        )
+        created_model = svc.create_model.call_args[0][0]
+        annotation = json.loads(
+            created_model.metadata.annotations[METADATA_ANNOTATION_KEY]
+        )
+        self.assertEqual(annotation["model_class"], "explicit-value")
+
     def test_metadata_stored_as_annotation(self):
         """Metadata is JSON-encoded under the michelangelo.io/metadata annotation."""
         svc = _mock_svc()


### PR DESCRIPTION
> **Stacked on #1446** (`fix(python): demote oversized/invalid model registry labels to annotation`) — merge that first; this PR's diff will shrink to just this example once #1446 lands.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
Adds a new example pipeline, `python/examples/pipelines/california_housing_lightning/`, mirroring `california_housing_xgb`'s structure (`feature_prep -> preprocess -> train -> push_step`) but training via `tabular_trainer`'s `train_tabular()` (PyTorch Lightning + Ray Train backend) instead of a bespoke XGBoost loop. Includes:
- `model.py` — `TorchRegressionModel(LightningModule)`, a small MLP regressor. First `LightningModule` subclass with an example/e2e caller anywhere in this repo (previously `train_tabular()` was only exercised by unit tests with mocked fixtures).
- `train.py` / `push.py` — `@uniflow.task` wrappers around `train_tabular()` and the shared pusher, forcing `precision="32"` for deterministic CPU-only runs.
- `_backend.py` — shared `resolve_storage_backend()` helper used by `push.py` for dataset-sink selection (`AWS_ENDPOINT_URL` -> MinIO/local).
- `README.md` — prerequisites, local run instructions, non-obvious design decisions, and explicit remote-run/k3d sandbox commands with an environment variable reference table (mirrors `california_housing_xgb`'s README structure).

`train_tabular()`'s API changed upstream (#1441, #1442) partway through this PR's development — it now builds its own multi-node-safe `RunConfig` from `UF_STORAGE_URL` and returns a `ModelVariable` instead of an eagerly-uploaded `ModelArtifact` (dropping the `storage_backend` parameter). `train.py`/`push.py` were rebased onto this: `train.py` is now a plain three-argument `train_tabular()` call (no manual storage-backend/RunConfig plumbing), and `push.py` converts the returned `ModelVariable` into a local `ModelArtifact` (via `fsspec.core.url_to_fs()`) before handing it to `ModelPusherPlugin`, since no OSS "assembler" task exists yet to do that conversion automatically.

`push_step` also now falls back to the platform-injected `MA_NAMESPACE` env var (before the `"default"` literal) when `REGISTRY_NAMESPACE` isn't explicitly set, so models register under the pipeline's actual namespace by default instead of silently landing in `default`.

**Why?**
`tabular_trainer`'s Lightning backend has zero example/e2e coverage in the OSS repo today. This gives contributors a runnable reference for wiring a custom `LightningModule` through `train_tabular()`, and surfaces gaps along the way (see below).

**How did you test it?**
- Local: ran the full workflow end-to-end (`feature_prep -> preprocess -> train -> push_step`) with `LocalStorageBackend`/`InMemoryRegistryClient`. `ruff check` clean; zero internal-path references. No pytest suite added (matches the sibling `california_housing_xgb` example's own precedent).
- Sandbox (k3d, Cadence, Ray, Spark, MinIO, fresh `ma-examples` project): full pipeline run **PASSED** end-to-end after fixing four real bugs found during validation (stale sandbox image, missing `importlib_resources` transitive dependency, missing multi-node Ray Train `RunConfig`, and a `ModelArtifact.path` local-vs-remote contract mismatch — the last two superseded by the upstream API rebase above). Re-validated **PASSED again** post-rebase onto the new `train_tabular()` API.
- Sandbox, against a real (non-in-memory) model registry backed by the apiserver: verified end-to-end that the model registers under the pipeline's actual namespace (`ma-examples`) rather than `default`, confirming the `MA_NAMESPACE` fallback fix.

Along the way, found and fixed a uniflow transpiler bug: `build.py`'s `visit_Name` raises an unhelpful `TypeError` (rather than a clear error) when a `@uniflow.workflow` body references a plain global (e.g. a list) that isn't a task/plugin/workflow/`TaskConfig`. Worked around it in this example by matching the xgb example's existing convention — flagging the transpiler's raw `TypeError` as a separate DX follow-up, not fixed in this PR.

**Potential risks**
None to existing code — this is a new, isolated example directory. No shared/library code changes beyond the internal `_backend.py` helper, which is local to this example only.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**
N/A

**Documentation Changes**
New `README.md` for the example directory, with explicit remote-run/k3d sandbox commands and an environment variable table matching `california_housing_xgb`'s README structure (instead of only linking out to it). No wiki/user-guide changes needed (matches `california_housing_xgb`'s own precedent).

---

**Status:** Draft — Advocate review passed (0 MUST, 4 SHOULD findings; tracked for follow-up). Sandbox validation PASSED twice (pre- and post-rebase onto the upstream `train_tabular()` API change), plus a third pass against a real model registry to confirm the namespace fallback fix. Still marked draft pending a decision on moving to ready-for-review.