### PR TITLE
fix(python): train_tabular returns ModelVariable, drops storage_backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,11 +29,14 @@ All notable changes to this project will be documented in this file.
   instead of eagerly packaging and uploading it as a `ModelArtifact`. The
   trained model is an intra-pipeline intermediate, not a registry-ready
   artifact — packaging and uploading into the consolidated model manager /
-  artifact store is the assembler/pusher's job. The now-unused
-  `storage_backend` parameter has been removed from `train_tabular()`;
-  warm-start weights for `initial_model` are read directly from
-  `ModelArtifact.path` (always a local filesystem path per its contract),
-  with no storage backend involved.
+  artifact store is a downstream packaging task's job (no such task exists
+  in OSS yet). The now-unused `storage_backend` parameter has been removed
+  from `train_tabular()`; for a lightning warm-start, `initial_model.path`
+  must now point directly to the local state-dict file (e.g. as written by
+  `ModelVariable.save_lightning_model()`), not a directory — this matches
+  what `LightningTrainerParam.initial_weights_path` always expected. No
+  storage backend is involved, and a missing file now raises
+  `ConfigurationError` eagerly instead of failing deep inside Ray Train.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ All notable changes to this project will be documented in this file.
   same variable `DatasetVariable`/`ModelVariable` already use), so worker
   pods on a multi-node Ray cluster share checkpoint storage with the head
   pod. Falls back to a local tempdir when `UF_STORAGE_URL` is unset.
+- `train_tabular()` now returns the trained model as a `ModelVariable`
+  instead of eagerly packaging and uploading it as a `ModelArtifact`. The
+  trained model is an intra-pipeline intermediate, not a registry-ready
+  artifact — packaging and uploading into the consolidated model manager /
+  artifact store is the assembler/pusher's job. The now-unused
+  `storage_backend` parameter has been removed from `train_tabular()`;
+  warm-start weights for `initial_model` are read directly from
+  `ModelArtifact.path` (always a local filesystem path per its contract),
+  with no storage backend involved.
 
 ### Removed
 

--- a/python/michelangelo/workflow/tasks/tabular_trainer/task.py
+++ b/python/michelangelo/workflow/tasks/tabular_trainer/task.py
@@ -1,4 +1,10 @@
-"""Dispatcher and lightning glue for the tabular trainer workflow task."""
+"""Dispatcher and lightning glue for the tabular trainer workflow task.
+
+This task never touches a storage backend — it hands off its trained model
+as an intra-pipeline ``ModelVariable``. Only a downstream packaging task
+(e.g. the pusher, see ``michelangelo.workflow.tasks.pusher``) owns uploading
+into the consolidated model manager/artifact store via a ``StorageBackend``.
+"""
 
 from __future__ import annotations
 
@@ -106,9 +112,19 @@ def train_tabular(
     trained model is an intra-pipeline intermediate, not a registry-ready
     artifact — it is handed off as a ``ModelVariable`` (persisted under
     ``UF_STORAGE_URL``, the same convention ``DatasetVariable`` uses) for a
-    downstream assembler/pusher task to package and push. Uploading into the
-    consolidated model manager/artifact store is the pusher's job, not the
-    trainer's.
+    downstream task to package and push. Uploading into the consolidated
+    model manager/artifact store is a packaging task's job, not the
+    trainer's — no such packaging ("assembler") task exists in OSS yet, so
+    today the returned ``ModelVariable`` is a stopping point for
+    programmatic use of its ``.value`` (the in-memory trained model) until
+    that task is added.
+
+    Example:
+        >>> config = TabularTrainerConfig(lightning=...)  # doctest: +SKIP
+        >>> result = train_tabular(  # doctest: +SKIP
+        ...     config, train_dataset, validation_dataset
+        ... )
+        >>> trained_model = result.value  # in-memory model  # doctest: +SKIP
 
     Args:
         config: ``TabularTrainerConfig`` — exactly one of ``lightning`` or
@@ -116,10 +132,10 @@ def train_tabular(
         train_dataset: Training dataset variable.
         validation_dataset: Validation dataset variable.
         initial_model: Optional warm-start artifact. ``ModelArtifact.path``
-            is always a local filesystem path (per its contract), so the
-            weights are read directly from ``initial_model.path`` — no
-            storage backend is involved. The path is passed to
-            ``LightningTrainerParam.initial_weights_path``.
+            must point directly to a local state-dict file (e.g. as written
+            by ``ModelVariable.save_lightning_model()``) — not a directory.
+            No storage backend is involved; the path is passed straight
+            through to ``LightningTrainerParam.initial_weights_path``.
         run_config: Optional ``ray.train.RunConfig``. When ``None``, a default
             is built by
             :func:`michelangelo.uniflow.plugins.ray.run_config.create_run_config`,
@@ -141,11 +157,17 @@ def train_tabular(
 
     Returns:
         A ``ModelVariable`` wrapping the trained model, with
-        ``metadata.assembled=False`` and ``metadata.deployable=False``. Use
-        the assembler task to produce a serving-ready ``ModelArtifact``.
+        ``metadata.assembled=False`` and ``metadata.deployable=False``.
+        There is no OSS packaging ("assembler") task yet to turn this into
+        a serving-ready ``ModelArtifact`` — until one exists, use
+        ``result.value`` for the in-memory model directly, or
+        ``result.save()``/``ModelVariable(path=..., metadata=...)`` to
+        persist/reload it across tasks.
 
     Raises:
-        ConfigurationError: If the training dataset is empty.
+        ConfigurationError: If the training dataset is empty, or if
+            *initial_model* is provided but ``initial_model.path`` is not a
+            file.
         NotImplementedError: If ``config.lightning.checkpoint_config
             .save_every_n_steps`` is set, if
             ``config.lightning.transfer_learning_spec`` is set, if
@@ -319,11 +341,20 @@ def _train_lightning(
     )
 
     # ModelArtifact.path is always a local filesystem path (per its
-    # contract), so warm-start weights are read directly — no storage
-    # backend involved.
+    # contract) to the packaged state-dict file itself — matching what
+    # LightningTrainerParam.initial_weights_path expects (see
+    # lightning_trainer.py). No storage backend is involved; weights are
+    # read directly.
     initial_weights_path: str | None = None
     if initial_model is not None:
-        initial_weights_path = os.path.join(initial_model.path, "model.pt")
+        if not os.path.isfile(initial_model.path):
+            raise ConfigurationError(
+                f"initial_model.path {initial_model.path!r} is not a file. "
+                "ModelArtifact.path for a lightning warm-start must point "
+                "directly to the state-dict file (e.g. as written by "
+                "ModelVariable.save_lightning_model())."
+            )
+        initial_weights_path = initial_model.path
         _logger.info("Using initial weights from: %s", initial_weights_path)
 
     # Build and run trainer

--- a/python/michelangelo/workflow/tasks/tabular_trainer/task.py
+++ b/python/michelangelo/workflow/tasks/tabular_trainer/task.py
@@ -2,17 +2,12 @@
 
 from __future__ import annotations
 
-import contextlib
 import dataclasses
 import io
 import logging
 import os
 import pickle
-import tempfile
-import uuid
 from typing import TYPE_CHECKING, Callable, Optional
-
-import torch
 
 from michelangelo._internal.utils.reflection_utils.module_attr import get_module_attr
 from michelangelo.lib.trainer.torch.pytorch_lightning.lightning_trainer import (
@@ -33,6 +28,7 @@ from michelangelo.workflow.tasks.tabular_trainer._dataset import (
     get_sample_data,
     raise_lightning_trainer_config_deprecation_warnings,
 )
+from michelangelo.workflow.variables import ModelVariable
 from michelangelo.workflow.variables.metadata import (
     TRAINING_FRAMEWORK_LIGHTNING,
     ModelMetadata,
@@ -43,7 +39,6 @@ if TYPE_CHECKING:
     import ray
     import ray.train
 
-    from michelangelo.lib.artifact_manager.storage_backend import StorageBackend
     from michelangelo.workflow.variables._private.dataset import DatasetVariable
 
 _logger = logging.getLogger(__name__)
@@ -97,7 +92,6 @@ def train_tabular(
     train_dataset: DatasetVariable,
     validation_dataset: DatasetVariable,
     *,
-    storage_backend: StorageBackend | None,
     initial_model: ModelArtifact | None = None,
     run_config: ray.train.RunConfig | None = None,
     scaling_config: ray.train.ScalingConfig | None = None,
@@ -105,23 +99,26 @@ def train_tabular(
     apply_incremental_training_metadata: (
         ApplyIncrementalTrainingMetadataFn
     ) = _apply_incremental_training_metadata,
-) -> ModelArtifact:
-    """Run tabular training and return a packaged ``ModelArtifact``.
+) -> ModelVariable:
+    """Run tabular training and return the trained model as a ``ModelVariable``.
 
     Dispatches to the lightning or custom backend based on *config*. The
-    resulting torch model is serialised to a temp dir and uploaded via
-    *storage_backend*; the returned artifact's ``path`` is the upload URI.
+    trained model is an intra-pipeline intermediate, not a registry-ready
+    artifact — it is handed off as a ``ModelVariable`` (persisted under
+    ``UF_STORAGE_URL``, the same convention ``DatasetVariable`` uses) for a
+    downstream assembler/pusher task to package and push. Uploading into the
+    consolidated model manager/artifact store is the pusher's job, not the
+    trainer's.
 
     Args:
         config: ``TabularTrainerConfig`` — exactly one of ``lightning`` or
             ``custom`` must be set.
         train_dataset: Training dataset variable.
         validation_dataset: Validation dataset variable.
-        storage_backend: Backend used to upload the trained model and to
-            download warm-start weights for *initial_model* (if provided).
-            Raises ``ConfigurationError`` when ``None``.
-        initial_model: Optional warm-start artifact. Weights are downloaded to
-            a local temp dir before training begins; the local path is passed to
+        initial_model: Optional warm-start artifact. ``ModelArtifact.path``
+            is always a local filesystem path (per its contract), so the
+            weights are read directly from ``initial_model.path`` — no
+            storage backend is involved. The path is passed to
             ``LightningTrainerParam.initial_weights_path``.
         run_config: Optional ``ray.train.RunConfig``. When ``None``, a default
             is built by
@@ -143,30 +140,23 @@ def train_tabular(
             :func:`_apply_incremental_training_metadata`; injectable for testing.
 
     Returns:
-        A ``ModelArtifact`` with ``assembled=False`` and ``deployable=False``.
-        Use the assembler task to produce a serving-ready artifact.
+        A ``ModelVariable`` wrapping the trained model, with
+        ``metadata.assembled=False`` and ``metadata.deployable=False``. Use
+        the assembler task to produce a serving-ready ``ModelArtifact``.
 
     Raises:
-        ConfigurationError: If *storage_backend* is ``None``, or if the
-            training dataset is empty.
+        ConfigurationError: If the training dataset is empty.
         NotImplementedError: If ``config.lightning.checkpoint_config
             .save_every_n_steps`` is set, if
             ``config.lightning.transfer_learning_spec`` is set, if
             ``config.lightning.experiment_tracker.mlflow`` is set, or if
             ``config.custom`` is used (custom backend not yet in OSS).
     """
-    if storage_backend is None:
-        raise ConfigurationError(
-            "storage_backend is required for train_tabular. "
-            "Provide a StorageBackend instance (e.g. MinioStorageBackend)."
-        )
-
     if config.lightning:
         return _train_lightning(
             config.lightning,
             train_dataset,
             validation_dataset,
-            storage_backend=storage_backend,
             initial_model=initial_model,
             run_config=run_config,
             scaling_config=scaling_config,
@@ -186,13 +176,12 @@ def _train_lightning(
     train_dataset: DatasetVariable,
     validation_dataset: DatasetVariable,
     *,
-    storage_backend: StorageBackend,
     initial_model: ModelArtifact | None,
     run_config: ray.train.RunConfig | None,
     scaling_config: ray.train.ScalingConfig | None,
     is_local_run: bool,
     apply_incremental_training_metadata: ApplyIncrementalTrainingMetadataFn,
-) -> ModelArtifact:
+) -> ModelVariable:
     """Lightning + Ray Train implementation of :func:`train_tabular`."""
     import ray.train
 
@@ -302,8 +291,7 @@ def _train_lightning(
 
     # RunConfig: use injected or build a default via the shared UniFlow helper,
     # which points Ray Train's distributed checkpointing at UF_STORAGE_URL
-    # (falling back to a local tempdir if unset) instead of each task
-    # re-deriving storage from its own storage_backend parameter.
+    # (falling back to a local tempdir if unset).
     if run_config is None:
         run_config = create_run_config(checkpoint_config=checkpoint_config)
 
@@ -330,39 +318,35 @@ def _train_lightning(
         "precision", hp.get("precision", default_precision)
     )
 
-    # Download warm-start weights, keep dir alive for the duration of training,
-    # then clean up. Uses ExitStack for conditional cleanup.
+    # ModelArtifact.path is always a local filesystem path (per its
+    # contract), so warm-start weights are read directly — no storage
+    # backend involved.
     initial_weights_path: str | None = None
-    with contextlib.ExitStack() as stack:
-        if initial_model is not None:
-            _weights_dir = stack.enter_context(
-                tempfile.TemporaryDirectory(prefix="michelangelo_weights_")
-            )
-            storage_backend.download(initial_model.path, _weights_dir)
-            initial_weights_path = os.path.join(_weights_dir, "model.pt")
-            _logger.info("Downloaded initial weights to: %s", initial_weights_path)
+    if initial_model is not None:
+        initial_weights_path = os.path.join(initial_model.path, "model.pt")
+        _logger.info("Using initial weights from: %s", initial_weights_path)
 
-        # Build and run trainer
-        trainer_param = LightningTrainerParam(
-            create_model_fn=create_model_fn,
-            create_model_fn_kwargs=create_model_fn_kwargs,
-            train_data=train_data,
-            val_data=validation_data,
-            batch_size=batch_size,
-            num_shuffle_batches=num_shuffle_batches,
-            data_collate_fn=data_collate_fn,
-            lightning_trainer_kwargs=lightning_trainer_kwargs,
-            comet_param=comet_param,
-            transfer_learning_spec=None,
-            initial_weights_path=initial_weights_path,
-        )
-        trainer = LightningTrainerWithStateDict(
-            trainer_param, run_config=run_config, scaling_config=scaling_config
-        )
-        trainer.train()
-        _logger.info("Training complete")
+    # Build and run trainer
+    trainer_param = LightningTrainerParam(
+        create_model_fn=create_model_fn,
+        create_model_fn_kwargs=create_model_fn_kwargs,
+        train_data=train_data,
+        val_data=validation_data,
+        batch_size=batch_size,
+        num_shuffle_batches=num_shuffle_batches,
+        data_collate_fn=data_collate_fn,
+        lightning_trainer_kwargs=lightning_trainer_kwargs,
+        comet_param=comet_param,
+        transfer_learning_spec=None,
+        initial_weights_path=initial_weights_path,
+    )
+    trainer = LightningTrainerWithStateDict(
+        trainer_param, run_config=run_config, scaling_config=scaling_config
+    )
+    trainer.train()
+    _logger.info("Training complete")
 
-    # Rebuild model from Ray checkpoint (weights dir already cleaned up above)
+    # Rebuild model from Ray checkpoint
     trained_model = create_model_fn(**create_model_fn_kwargs)
     trainer.update_model_state_dict(trained_model)
 
@@ -393,11 +377,10 @@ def _train_lightning(
         metadata, initial_model, config.incremental_training_mode
     )
 
-    # Serialise and upload model
-    with tempfile.TemporaryDirectory(prefix="michelangelo_upload_") as upload_tmp:
-        model_path = f"{upload_tmp}/model.pt"
-        torch.save(trained_model.state_dict(), model_path)
-        key = f"models/{uuid.uuid4().hex}"
-        uri = storage_backend.upload(upload_tmp, key)
-
-    return ModelArtifact(path=uri, metadata=metadata)
+    # Hand off as an intra-pipeline ModelVariable — persisted under
+    # UF_STORAGE_URL, dispatched to save_lightning_model() via
+    # metadata.training_framework. Packaging into a registry-ready
+    # ModelArtifact is the assembler's job, not the trainer's.
+    model_variable = ModelVariable(value=trained_model, metadata=metadata)
+    model_variable.save()
+    return model_variable

--- a/python/michelangelo/workflow/tasks/tabular_trainer/tests/fixtures.py
+++ b/python/michelangelo/workflow/tasks/tabular_trainer/tests/fixtures.py
@@ -51,15 +51,19 @@ def mock_validation_dataset() -> Mock:
 
 
 def make_model_artifact(
-    path: str = "/tmp/models/base",
+    path: str = "/tmp/models/base/model.pt",
     *,
     is_incremental_training: bool = False,
     baseline_model_identifier: str | None = None,
 ) -> ModelArtifact:
     """Return a ``ModelArtifact`` for use as an ``initial_model``.
 
-    ``path`` is a local directory containing ``model.pt``, matching
-    ``ModelArtifact.path``'s "always local" contract.
+    ``path`` points directly to a local state-dict file (matching what
+    ``LightningTrainerParam.initial_weights_path`` expects and what
+    ``ModelVariable.save_lightning_model()`` writes) — not a directory.
+    The default path does not exist on disk; tests exercising the
+    ``os.path.isfile`` guard in ``_train_lightning`` should mock it or
+    pass a real file path.
     """
     meta = ModelMetadata(
         training_framework="lightning",

--- a/python/michelangelo/workflow/tasks/tabular_trainer/tests/fixtures.py
+++ b/python/michelangelo/workflow/tasks/tabular_trainer/tests/fixtures.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, Mock
+from unittest.mock import Mock
 
 import numpy as np
 
-from michelangelo.lib.artifact_manager.storage_backend import StorageBackend
 from michelangelo.workflow.schema.tabular_trainer import (
     ColumnConfig,
     LightningTrainerConfig,
@@ -51,20 +50,17 @@ def mock_validation_dataset() -> Mock:
     return ds_mock
 
 
-def mock_storage_backend() -> Mock:
-    """Return a Mock ``StorageBackend`` that records calls."""
-    backend = MagicMock(spec=StorageBackend)
-    backend.upload.return_value = "s3://bucket/models/abc123"
-    return backend
-
-
 def make_model_artifact(
-    path: str = "s3://bucket/models/base",
+    path: str = "/tmp/models/base",
     *,
     is_incremental_training: bool = False,
     baseline_model_identifier: str | None = None,
 ) -> ModelArtifact:
-    """Return a ``ModelArtifact`` for use as an ``initial_model``."""
+    """Return a ``ModelArtifact`` for use as an ``initial_model``.
+
+    ``path`` is a local directory containing ``model.pt``, matching
+    ``ModelArtifact.path``'s "always local" contract.
+    """
     meta = ModelMetadata(
         training_framework="lightning",
         is_incremental_training=is_incremental_training,

--- a/python/michelangelo/workflow/tasks/tabular_trainer/tests/task_test.py
+++ b/python/michelangelo/workflow/tasks/tabular_trainer/tests/task_test.py
@@ -27,12 +27,10 @@ from michelangelo.workflow.tasks.tabular_trainer.task import (
 from michelangelo.workflow.tasks.tabular_trainer.tests.fixtures import (
     make_model_artifact,
     make_tabular_config,
-    mock_storage_backend,
     mock_train_dataset,
     mock_validation_dataset,
 )
 from michelangelo.workflow.variables.metadata import ModelMetadata
-from michelangelo.workflow.variables.types import ModelArtifact
 
 _TRAINER_TASK = "michelangelo.workflow.tasks.tabular_trainer.task"
 
@@ -147,16 +145,6 @@ class TestModelMetadataRegistryDict(TestCase):
 class TestTrainTabularGuards(TestCase):
     """Tests for train_tabular input validation."""
 
-    def test_missing_storage_backend_raises(self):
-        """Passing storage_backend=None raises ConfigurationError."""
-        with self.assertRaises(ConfigurationError):
-            train_tabular(
-                make_tabular_config(),
-                mock_train_dataset(),
-                mock_validation_dataset(),
-                storage_backend=None,
-            )
-
     def test_custom_backend_raises_not_implemented(self):
         """config.custom raises NotImplementedError."""
         config = TabularTrainerConfig(
@@ -167,7 +155,6 @@ class TestTrainTabularGuards(TestCase):
                 config,
                 mock_train_dataset(),
                 mock_validation_dataset(),
-                storage_backend=mock_storage_backend(),
             )
 
     def test_save_every_n_steps_raises(self):
@@ -186,7 +173,6 @@ class TestTrainTabularGuards(TestCase):
                 config,
                 mock_train_dataset(),
                 mock_validation_dataset(),
-                storage_backend=mock_storage_backend(),
             )
 
     def test_transfer_learning_spec_raises(self):
@@ -211,7 +197,6 @@ class TestTrainTabularGuards(TestCase):
                 config,
                 mock_train_dataset(),
                 mock_validation_dataset(),
-                storage_backend=mock_storage_backend(),
             )
 
     def test_mlflow_config_raises_not_implemented(self):
@@ -235,7 +220,6 @@ class TestTrainTabularGuards(TestCase):
                 config,
                 mock_train_dataset(),
                 mock_validation_dataset(),
-                storage_backend=mock_storage_backend(),
             )
 
     def test_empty_train_dataset_raises(self):
@@ -249,7 +233,6 @@ class TestTrainTabularGuards(TestCase):
                 f"{_TRAINER_TASK}.get_module_attr",
                 return_value=lambda **kw: Mock(),
             ),
-            patch(f"{_TRAINER_TASK}.torch"),
             patch(f"{_TRAINER_TASK}.LightningTrainerParam"),
             patch(f"{_TRAINER_TASK}.LightningTrainerWithStateDict") as mt,
         ):
@@ -259,7 +242,6 @@ class TestTrainTabularGuards(TestCase):
                 make_tabular_config(),
                 train_ds,
                 mock_validation_dataset(),
-                storage_backend=mock_storage_backend(),
             )
 
 
@@ -268,27 +250,24 @@ class TestTrainTabularGuards(TestCase):
 # ---------------------------------------------------------------------------
 
 
-def _run_train(config=None, train_ds=None, val_ds=None, backend=None, **kwargs):
+def _run_train(config=None, train_ds=None, val_ds=None, **kwargs):
     """Run train_tabular with all Ray/Lightning deps mocked."""
     config = config or make_tabular_config()
     train_ds = train_ds or mock_train_dataset()
     val_ds = val_ds or mock_validation_dataset()
-    backend = backend or mock_storage_backend()
     with (
         patch(
             f"{_TRAINER_TASK}.get_module_attr",
             return_value=lambda **kw: Mock(),
         ),
-        patch(f"{_TRAINER_TASK}.torch"),
+        patch(f"{_TRAINER_TASK}.ModelVariable") as mv_cls,
         patch(f"{_TRAINER_TASK}.LightningTrainerParam"),
         patch(f"{_TRAINER_TASK}.LightningTrainerWithStateDict") as mt,
     ):
         mt.return_value.train.return_value = None
         mt.return_value.update_model_state_dict.return_value = None
-        result = train_tabular(
-            config, train_ds, val_ds, storage_backend=backend, **kwargs
-        )
-    return result, backend, mt
+        result = train_tabular(config, train_ds, val_ds, **kwargs)
+    return result, mv_cls, mt
 
 
 # ---------------------------------------------------------------------------
@@ -299,35 +278,33 @@ def _run_train(config=None, train_ds=None, val_ds=None, backend=None, **kwargs):
 class TestTrainTabularLightning(TestCase):
     """Tests for the lightning success path of train_tabular."""
 
-    def test_returns_model_artifact(self):
-        """Returns a ModelArtifact instance."""
-        result, _, _ = _run_train()
-        self.assertIsInstance(result, ModelArtifact)
+    def test_returns_model_variable(self):
+        """Returns the constructed ModelVariable instance."""
+        result, mv_cls, _ = _run_train()
+        self.assertIs(result, mv_cls.return_value)
 
-    def test_artifact_assembled_false(self):
-        """Returned artifact has assembled=False."""
-        result, _, _ = _run_train()
-        self.assertFalse(result.metadata.assembled)
+    def test_model_variable_save_called(self):
+        """ModelVariable.save() is called once to persist the trained model."""
+        _, mv_cls, _ = _run_train()
+        mv_cls.return_value.save.assert_called_once()
 
-    def test_artifact_deployable_false(self):
-        """Returned artifact has deployable=False."""
-        result, _, _ = _run_train()
-        self.assertFalse(result.metadata.deployable)
+    def test_model_variable_assembled_false(self):
+        """Constructed ModelVariable's metadata has assembled=False."""
+        _, mv_cls, _ = _run_train()
+        metadata = mv_cls.call_args.kwargs["metadata"]
+        self.assertFalse(metadata.assembled)
 
-    def test_artifact_training_framework_lightning(self):
-        """Returned artifact carries training_framework='lightning'."""
-        result, _, _ = _run_train()
-        self.assertEqual(result.metadata.training_framework, "lightning")
+    def test_model_variable_deployable_false(self):
+        """Constructed ModelVariable's metadata has deployable=False."""
+        _, mv_cls, _ = _run_train()
+        metadata = mv_cls.call_args.kwargs["metadata"]
+        self.assertFalse(metadata.deployable)
 
-    def test_storage_backend_upload_called(self):
-        """storage_backend.upload() is called once."""
-        _, backend, _ = _run_train()
-        backend.upload.assert_called_once()
-
-    def test_artifact_path_from_upload(self):
-        """Artifact path equals the URI returned by storage_backend.upload."""
-        result, backend, _ = _run_train()
-        self.assertEqual(result.path, backend.upload.return_value)
+    def test_model_variable_training_framework_lightning(self):
+        """Constructed ModelVariable's metadata carries training_framework."""
+        _, mv_cls, _ = _run_train()
+        metadata = mv_cls.call_args.kwargs["metadata"]
+        self.assertEqual(metadata.training_framework, "lightning")
 
     def test_datasets_loaded(self):
         """load_ray_dataset() is called on both datasets."""
@@ -344,7 +321,7 @@ class TestTrainTabularLightning(TestCase):
                 f"{_TRAINER_TASK}.get_module_attr",
                 return_value=lambda **kw: Mock(),
             ),
-            patch(f"{_TRAINER_TASK}.torch"),
+            patch(f"{_TRAINER_TASK}.ModelVariable"),
             patch(f"{_TRAINER_TASK}.LightningTrainerParam") as mp,
             patch(f"{_TRAINER_TASK}.LightningTrainerWithStateDict") as mt,
         ):
@@ -354,7 +331,6 @@ class TestTrainTabularLightning(TestCase):
                 make_tabular_config(),
                 mock_train_dataset(),
                 mock_validation_dataset(),
-                storage_backend=mock_storage_backend(),
                 is_local_run=False,
             )
         kwargs_dict = mp.call_args.kwargs.get("lightning_trainer_kwargs", {})
@@ -367,7 +343,7 @@ class TestTrainTabularLightning(TestCase):
                 f"{_TRAINER_TASK}.get_module_attr",
                 return_value=lambda **kw: Mock(),
             ),
-            patch(f"{_TRAINER_TASK}.torch"),
+            patch(f"{_TRAINER_TASK}.ModelVariable"),
             patch(f"{_TRAINER_TASK}.LightningTrainerParam") as mp,
             patch(f"{_TRAINER_TASK}.LightningTrainerWithStateDict") as mt,
         ):
@@ -377,7 +353,6 @@ class TestTrainTabularLightning(TestCase):
                 make_tabular_config(),
                 mock_train_dataset(),
                 mock_validation_dataset(),
-                storage_backend=mock_storage_backend(),
                 is_local_run=True,
             )
         kwargs_dict = mp.call_args.kwargs.get("lightning_trainer_kwargs", {})
@@ -396,7 +371,7 @@ class TestTrainTabularLightning(TestCase):
                 f"{_TRAINER_TASK}.get_module_attr",
                 return_value=lambda **kw: Mock(),
             ),
-            patch(f"{_TRAINER_TASK}.torch"),
+            patch(f"{_TRAINER_TASK}.ModelVariable"),
             patch(f"{_TRAINER_TASK}.LightningTrainerParam") as mp,
             patch(f"{_TRAINER_TASK}.LightningTrainerWithStateDict") as mt,
         ):
@@ -408,7 +383,6 @@ class TestTrainTabularLightning(TestCase):
                     config,
                     mock_train_dataset(),
                     mock_validation_dataset(),
-                    storage_backend=mock_storage_backend(),
                 )
         self.assertEqual(mp.call_args.kwargs.get("batch_size"), 16)
 
@@ -430,7 +404,7 @@ class TestTrainTabularLightning(TestCase):
                 return_value=lambda **kw: Mock(),
             ),
             patch(f"{_TRAINER_TASK}.CometParam") as mock_comet,
-            patch(f"{_TRAINER_TASK}.torch"),
+            patch(f"{_TRAINER_TASK}.ModelVariable"),
             patch(f"{_TRAINER_TASK}.LightningTrainerParam"),
             patch(f"{_TRAINER_TASK}.LightningTrainerWithStateDict") as mt,
         ):
@@ -440,7 +414,6 @@ class TestTrainTabularLightning(TestCase):
                 config,
                 mock_train_dataset(),
                 mock_validation_dataset(),
-                storage_backend=mock_storage_backend(),
             )
         mock_comet.assert_called_once_with(
             api_key="k", project_name="proj", experiment_name="exp", workspace="ws"
@@ -453,7 +426,7 @@ class TestTrainTabularLightning(TestCase):
                 f"{_TRAINER_TASK}.get_module_attr",
                 return_value=lambda **kw: Mock(),
             ),
-            patch(f"{_TRAINER_TASK}.torch"),
+            patch(f"{_TRAINER_TASK}.ModelVariable"),
             patch(f"{_TRAINER_TASK}.LightningTrainerParam") as mp,
             patch(f"{_TRAINER_TASK}.LightningTrainerWithStateDict") as mt,
         ):
@@ -463,38 +436,75 @@ class TestTrainTabularLightning(TestCase):
                 make_tabular_config(),
                 mock_train_dataset(),
                 mock_validation_dataset(),
-                storage_backend=mock_storage_backend(),
             )
         self.assertIsNone(mp.call_args.kwargs.get("comet_param"))
 
-    def test_initial_model_triggers_download(self):
-        """storage_backend.download() is called when initial_model is provided."""
-        initial = make_model_artifact(path="s3://bucket/base")
-        _, backend, _ = _run_train(initial_model=initial)
-        backend.download.assert_called_once()
-        self.assertEqual(backend.download.call_args[0][0], "s3://bucket/base")
+    def test_initial_model_sets_weights_path(self):
+        """initial_weights_path is read directly from initial_model.path.
 
-    def test_no_initial_model_no_download(self):
-        """storage_backend.download() is NOT called without initial_model."""
-        _, backend, _ = _run_train()
-        backend.download.assert_not_called()
+        No storage backend is involved — ModelArtifact.path is always a
+        local filesystem path, per its contract.
+        """
+        initial = make_model_artifact(path="/tmp/base")
+        with (
+            patch(
+                f"{_TRAINER_TASK}.get_module_attr",
+                return_value=lambda **kw: Mock(),
+            ),
+            patch(f"{_TRAINER_TASK}.ModelVariable"),
+            patch(f"{_TRAINER_TASK}.LightningTrainerParam") as mp,
+            patch(f"{_TRAINER_TASK}.LightningTrainerWithStateDict") as mt,
+        ):
+            mt.return_value.train.return_value = None
+            mt.return_value.update_model_state_dict.return_value = None
+            train_tabular(
+                make_tabular_config(),
+                mock_train_dataset(),
+                mock_validation_dataset(),
+                initial_model=initial,
+            )
+        self.assertEqual(
+            mp.call_args.kwargs["initial_weights_path"], "/tmp/base/model.pt"
+        )
+
+    def test_no_initial_model_no_weights_path(self):
+        """initial_weights_path is None without initial_model."""
+        with (
+            patch(
+                f"{_TRAINER_TASK}.get_module_attr",
+                return_value=lambda **kw: Mock(),
+            ),
+            patch(f"{_TRAINER_TASK}.ModelVariable"),
+            patch(f"{_TRAINER_TASK}.LightningTrainerParam") as mp,
+            patch(f"{_TRAINER_TASK}.LightningTrainerWithStateDict") as mt,
+        ):
+            mt.return_value.train.return_value = None
+            mt.return_value.update_model_state_dict.return_value = None
+            train_tabular(
+                make_tabular_config(),
+                mock_train_dataset(),
+                mock_validation_dataset(),
+            )
+        self.assertIsNone(mp.call_args.kwargs["initial_weights_path"])
 
     def test_incremental_metadata_propagated(self):
         """is_incremental_training propagates from initial_model."""
         initial = make_model_artifact(
             is_incremental_training=True, baseline_model_identifier="base-v1"
         )
-        result, _, _ = _run_train(initial_model=initial)
-        self.assertTrue(result.metadata.is_incremental_training)
-        self.assertEqual(result.metadata.baseline_model_identifier, "base-v1")
+        _, mv_cls, _ = _run_train(initial_model=initial)
+        metadata = mv_cls.call_args.kwargs["metadata"]
+        self.assertTrue(metadata.is_incremental_training)
+        self.assertEqual(metadata.baseline_model_identifier, "base-v1")
 
     def test_baseline_mode_sets_incremental(self):
         """BASELINE incremental mode sets is_incremental_training=True."""
         config = make_tabular_config(
             incremental_training_mode=IncrementalTrainingModeConfig.BASELINE
         )
-        result, _, _ = _run_train(config=config)
-        self.assertTrue(result.metadata.is_incremental_training)
+        _, mv_cls, _ = _run_train(config=config)
+        metadata = mv_cls.call_args.kwargs["metadata"]
+        self.assertTrue(metadata.is_incremental_training)
 
     def test_metadata_columns_excluded_from_sample(self):
         """metadata_columns are passed to collate_sample_row."""
@@ -564,13 +574,12 @@ class TestTrainTabularDispatch(TestCase):
         """A config with lightning= dispatches to _train_lightning."""
         with patch(
             f"{_TRAINER_TASK}._train_lightning",
-            return_value=ModelArtifact(path="s3://ok", metadata=ModelMetadata()),
+            return_value=Mock(),
         ) as mock_tl:
             train_tabular(
                 make_tabular_config(),
                 mock_train_dataset(),
                 mock_validation_dataset(),
-                storage_backend=mock_storage_backend(),
             )
         mock_tl.assert_called_once()
 
@@ -584,5 +593,4 @@ class TestTrainTabularDispatch(TestCase):
                 config,
                 mock_train_dataset(),
                 mock_validation_dataset(),
-                storage_backend=mock_storage_backend(),
             )

--- a/python/michelangelo/workflow/tasks/tabular_trainer/tests/task_test.py
+++ b/python/michelangelo/workflow/tasks/tabular_trainer/tests/task_test.py
@@ -260,6 +260,7 @@ def _run_train(config=None, train_ds=None, val_ds=None, **kwargs):
             f"{_TRAINER_TASK}.get_module_attr",
             return_value=lambda **kw: Mock(),
         ),
+        patch(f"{_TRAINER_TASK}.os.path.isfile", return_value=True),
         patch(f"{_TRAINER_TASK}.ModelVariable") as mv_cls,
         patch(f"{_TRAINER_TASK}.LightningTrainerParam"),
         patch(f"{_TRAINER_TASK}.LightningTrainerWithStateDict") as mt,
@@ -442,15 +443,17 @@ class TestTrainTabularLightning(TestCase):
     def test_initial_model_sets_weights_path(self):
         """initial_weights_path is read directly from initial_model.path.
 
-        No storage backend is involved — ModelArtifact.path is always a
-        local filesystem path, per its contract.
+        No storage backend is involved — ModelArtifact.path for a lightning
+        warm-start points directly at the state-dict file, matching what
+        LightningTrainerParam.initial_weights_path expects.
         """
-        initial = make_model_artifact(path="/tmp/base")
+        initial = make_model_artifact(path="/tmp/base/model.pt")
         with (
             patch(
                 f"{_TRAINER_TASK}.get_module_attr",
                 return_value=lambda **kw: Mock(),
             ),
+            patch(f"{_TRAINER_TASK}.os.path.isfile", return_value=True),
             patch(f"{_TRAINER_TASK}.ModelVariable"),
             patch(f"{_TRAINER_TASK}.LightningTrainerParam") as mp,
             patch(f"{_TRAINER_TASK}.LightningTrainerWithStateDict") as mt,
@@ -466,6 +469,23 @@ class TestTrainTabularLightning(TestCase):
         self.assertEqual(
             mp.call_args.kwargs["initial_weights_path"], "/tmp/base/model.pt"
         )
+
+    def test_initial_model_missing_file_raises(self):
+        """A nonexistent initial_model.path raises ConfigurationError."""
+        initial = make_model_artifact(path="/tmp/definitely_does_not_exist/model.pt")
+        with (
+            self.assertRaises(ConfigurationError),
+            patch(
+                f"{_TRAINER_TASK}.get_module_attr",
+                return_value=lambda **kw: Mock(),
+            ),
+        ):
+            train_tabular(
+                make_tabular_config(),
+                mock_train_dataset(),
+                mock_validation_dataset(),
+                initial_model=initial,
+            )
 
     def test_no_initial_model_no_weights_path(self):
         """initial_weights_path is None without initial_model."""


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Bug Fix
- [ ] Feature
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
`train_tabular()` now returns the trained model wrapped in a `ModelVariable` (persisted under `UF_STORAGE_URL`, same convention `DatasetVariable` uses) instead of eagerly packaging it as a `ModelArtifact` and uploading it via `storage_backend.upload()`. The now-unused `storage_backend` parameter is removed entirely from `train_tabular()`/`_train_lightning()`.

For a lightning warm-start, `initial_model.path` must now point directly to the local state-dict file (matching what `LightningTrainerParam.initial_weights_path` has always expected, and what `ModelVariable.save_lightning_model()` actually writes) — not a directory with a hardcoded `model.pt` inside it, which an earlier version of this PR incorrectly assumed. A missing/invalid path now raises `ConfigurationError` eagerly instead of failing deep inside a Ray Train worker.

Docstrings were reworked per DX review feedback: `train_tabular()` no longer points at a non-existent "assembler" task; it now says plainly that no such OSS packaging task exists yet and that `result.value`/`ModelVariable.save()` is the current stopping point. Added a runnable-shape `Example:` block and a module-level docstring note clarifying the trainer/pusher storage-backend boundary.

**Why?**
Follow-up from review discussion on #1441 (https://github.com/michelangelo-ai/michelangelo/pull/1441/changes#r3531522700). The trained model produced by the trainer is an intra-pipeline intermediate, not a registry-ready artifact — only a downstream packaging task should own uploading into the consolidated model manager/artifact store. The trainer calling `storage_backend.upload()` on its own output violated that boundary and also violated `ModelArtifact.path`'s "always local" contract. Since `train_tabular()` has no consumers yet, this is a clean contract fix rather than a compat-preserving change.

This PR also went through an internal two-pass review (OSS Coder for code correctness/tests/sanitization, OSS Dev Advocate for API ergonomics/docs) before being finalized. That review caught a real logic bug in the first pass — `initial_model.path` was joined with a hardcoded `"model.pt"` on the assumption of a directory layout that neither `ModelArtifact`'s documented contract nor `ModelVariable.save_lightning_model()`'s actual write behavior support — and a docstring dead end (pointing at a non-existent "assembler" task). Both are fixed in this PR as submitted.

**How did you test it?**
- `ruff format --check` / `ruff check` on all changed files — pass.
- `pytest michelangelo/workflow/tasks/tabular_trainer/ michelangelo/uniflow/plugins/ray/` — 139 passed (added a new test covering the `ConfigurationError` guard on a missing `initial_model.path`).
- `pytest michelangelo/lib/trainer/ michelangelo/lib/artifact_manager/ michelangelo/workflow/variables/` — 303 passed (no regressions in adjacent modules).

**Potential risks**
None currently — `train_tabular()` has no callers yet in this repo. The main risk is for any future caller relying on the old `ModelArtifact`/`storage_backend` contract; this PR establishes the correct one (state-dict file path, no backend) before any such caller is added.

**Breaking Changes**

- [ ] No breaking changes
- [x] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Migration guide**
No live consumers exist to migrate. For any future caller: drop the `storage_backend` argument; treat the return value as a `ModelVariable` (`.value` for the in-memory model) instead of a `ModelArtifact` with a remote `path`; and if warm-starting, pass `initial_model.path` as the state-dict file path directly (not a directory).

**Release notes**
N/A — no released consumers of `train_tabular()` yet.

**Documentation Changes**
`train_tabular()`'s docstring and the module-level docstring updated in place. `CHANGELOG.md` updated under `Unreleased > Fixed`.