### PR TITLE
fix(ci): CVE Scan fails to resolve trivy-action/trivy binary version

### DIFF
--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -36,6 +36,7 @@ jobs:
           output: trivy-${{ matrix.service }}.sarif
           severity: CRITICAL,HIGH
           exit-code: '1'
+          version: v0.72.0
 
       - name: Upload SARIF to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
@@ -52,6 +53,7 @@ jobs:
           format: table
           severity: CRITICAL,HIGH
           exit-code: '0'
+          version: v0.72.0
 
       - name: Upload Trivy SARIF report as artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Run Trivy vulnerability scanner (${{ matrix.service }})
-        uses: aquasecurity/trivy-action@v0.28.0
+        uses: aquasecurity/trivy-action@v0.32.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.ORG }}/${{ matrix.service }}:latest
           format: sarif
@@ -45,7 +45,7 @@ jobs:
           category: trivy-${{ matrix.service }}
 
       - name: Run Trivy table output for summary
-        uses: aquasecurity/trivy-action@v0.28.0
+        uses: aquasecurity/trivy-action@v0.32.0
         if: always()
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.ORG }}/${{ matrix.service }}:latest

--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Run Trivy vulnerability scanner (${{ matrix.service }})
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.28.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.ORG }}/${{ matrix.service }}:latest
           format: sarif
@@ -45,7 +45,7 @@ jobs:
           category: trivy-${{ matrix.service }}
 
       - name: Run Trivy table output for summary
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.28.0
         if: always()
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.ORG }}/${{ matrix.service }}:latest


### PR DESCRIPTION
Closes #1445

## Summary

Investigated https://github.com/michelangelo-ai/michelangelo/actions/runs/28831990997 (`CVE Scan` failing on every job).

Two separate, stacked upstream breakages, both now fixed:

1. **`aquasecurity/trivy-action@0.28.0` was never a valid ref** — the action only publishes `v`-prefixed tags (`v0.28.0`). This has apparently been wrong since the workflow was first added in #1398, but went unnoticed because the `workflow_run` trigger (fires after Dev Release / UI Release / Nightly Build complete) hadn't actually run until now.
2. **Even after fixing the tag**, `trivy-action@v0.32.0`'s default `version: v0.64.1` (the Trivy *scanner binary*, not the action) points at a Trivy release whose GitHub Release/assets have since been pulled upstream (the git tag still exists, but `gh api repos/aquasecurity/trivy/releases/tags/v0.64.1` 404s). This caused the install script to fail immediately after resolving the tag, with no useful error surfaced. Pinned to `v0.72.0`, which is currently published.

## Verification

Tested via `workflow_dispatch` on the fix branch (3 iterations, since the second failure only appeared after fixing the first):
- Confirmed action now resolves and Trivy actually runs, downloads its vulnerability DB, and scans all 4 images.
- All 4 `scan (*)` jobs still show `failure` — but that's now the *intended* signal: `exit-code: '1'` is configured so the job fails when CRITICAL/HIGH CVEs are found, and the images do have real CRITICAL/HIGH findings (a separate, genuine finding — not a CI infra bug).
- Confirmed `notify-on-failure` (added in #1436 / #1438) correctly fired and would have posted to `#ma-oss-ci`.

## Test plan
- [x] `actionlint` passes on `cve-scan.yml`
- [x] `workflow_dispatch` run confirms Trivy actually executes and scans images
- [x] `notify-on-failure` job fires correctly on scan failure
- [ ] Separate follow-up needed to actually remediate the CRITICAL/HIGH CVEs found in the container images (tracked separately, out of scope for this CI fix)