### PR TITLE
fix(python): demote oversized/invalid model registry labels to annotation

### DIFF
--- a/python/michelangelo/lib/model_manager/registry/api_client.py
+++ b/python/michelangelo/lib/model_manager/registry/api_client.py
@@ -296,7 +296,7 @@ class APIRegistryClient(ModelRegistryClient):
             if _is_valid_k8s_label_value(v):
                 model.metadata.labels[k] = v
             else:
-                _logger.info(
+                _logger.warning(
                     "register_model(%r): label %r=%r is not a valid Kubernetes "
                     "label value (max %d chars, alphanumeric/-/_/. only) — "
                     "storing under the %r annotation instead.",

--- a/python/michelangelo/lib/model_manager/registry/api_client.py
+++ b/python/michelangelo/lib/model_manager/registry/api_client.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from typing import TYPE_CHECKING, Any
 
 import grpc
@@ -62,6 +63,24 @@ METADATA_ANNOTATION_KEY = "michelangelo.io/metadata"
 """Annotation key under which free-form metadata is JSON-serialised."""
 
 _MAX_REGISTER_RETRIES = 3
+
+_K8S_LABEL_VALUE_MAX_LENGTH = 63
+_K8S_LABEL_VALUE_RE = re.compile(r"^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$")
+
+
+def _is_valid_k8s_label_value(value: str) -> bool:
+    """Return ``True`` if *value* satisfies Kubernetes' label-value rules.
+
+    At most 63 characters, and either empty or starting/ending with an
+    alphanumeric character with dashes, underscores, dots, and alphanumerics
+    in between (see
+    https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set).
+    """
+    return (
+        len(value) <= _K8S_LABEL_VALUE_MAX_LENGTH
+        and _K8S_LABEL_VALUE_RE.match(value) is not None
+    )
+
 
 __all__ = ["METADATA_ANNOTATION_KEY", "APIRegistryClient"]
 
@@ -262,8 +281,33 @@ class APIRegistryClient(ModelRegistryClient):
             model.spec.deployable_artifact_uri.append(deployable_artifact_uri)
         if description:
             model.spec.description = description
+
+        # Kubernetes label values are capped at 63 characters and restricted
+        # to alphanumerics/dashes/underscores/dots. Callers built on top of
+        # ModelMetadata.to_registry_dict() (e.g. `model_class`, a fully
+        # qualified Python import path) commonly exceed this, and
+        # InMemoryRegistryClient never enforces it, so the violation is only
+        # ever caught here, against a real apiserver. Demote any offending
+        # value into the metadata annotation instead of erroring — the
+        # information is preserved (JSON has no such length limit), it's
+        # just no longer filterable as a label.
+        extra_metadata: dict[str, Any] = dict(metadata or {})
         for k, v in (labels or {}).items():
-            model.metadata.labels[k] = v
+            if _is_valid_k8s_label_value(v):
+                model.metadata.labels[k] = v
+            else:
+                _logger.info(
+                    "register_model(%r): label %r=%r is not a valid Kubernetes "
+                    "label value (max %d chars, alphanumeric/-/_/. only) — "
+                    "storing under the %r annotation instead.",
+                    name,
+                    k,
+                    v,
+                    _K8S_LABEL_VALUE_MAX_LENGTH,
+                    METADATA_ANNOTATION_KEY,
+                )
+                extra_metadata.setdefault(k, v)
+        metadata = extra_metadata
         if metadata:
             model.metadata.annotations[METADATA_ANNOTATION_KEY] = json.dumps(
                 dict(metadata)

--- a/python/michelangelo/lib/model_manager/registry/tests/api_client_test.py
+++ b/python/michelangelo/lib/model_manager/registry/tests/api_client_test.py
@@ -128,6 +128,58 @@ class TestAPIRegistryClientRegisterModel(TestCase):
         created_model = svc.create_model.call_args[0][0]
         self.assertEqual(created_model.metadata.labels["fw"], "xgboost")
 
+    def test_oversized_label_value_demoted_to_metadata_annotation(self):
+        """A label value over 63 chars is moved to the metadata annotation.
+
+        Regression test: ModelMetadata.to_registry_dict() commonly emits a
+        fully-qualified Python class path (e.g. `model_class`) that exceeds
+        Kubernetes' 63-character label-value limit. Writing it straight to
+        model.metadata.labels made create_model()/update_model() fail with
+        INVALID_ARGUMENT against a real apiserver.
+        """
+        svc = _mock_svc()
+        long_value = (
+            "examples.pipelines.california_housing_lightning.model.TorchRegressionModel"
+        )
+        self.assertGreater(len(long_value), 63)
+        _client(svc).register_model(
+            "m", "s3://b/raw", labels={"model_class": long_value, "fw": "lightning"}
+        )
+        created_model = svc.create_model.call_args[0][0]
+        self.assertNotIn("model_class", created_model.metadata.labels)
+        self.assertEqual(created_model.metadata.labels["fw"], "lightning")
+        annotation = json.loads(
+            created_model.metadata.annotations[METADATA_ANNOTATION_KEY]
+        )
+        self.assertEqual(annotation["model_class"], long_value)
+
+    def test_label_value_with_invalid_characters_demoted_to_metadata_annotation(self):
+        """A label value with disallowed characters is moved to the annotation."""
+        svc = _mock_svc()
+        _client(svc).register_model("m", "s3://b/raw", labels={"note": "50% faster!"})
+        created_model = svc.create_model.call_args[0][0]
+        self.assertNotIn("note", created_model.metadata.labels)
+        annotation = json.loads(
+            created_model.metadata.annotations[METADATA_ANNOTATION_KEY]
+        )
+        self.assertEqual(annotation["note"], "50% faster!")
+
+    def test_demoted_label_does_not_override_explicit_metadata(self):
+        """An explicit metadata key wins over a same-named demoted label."""
+        svc = _mock_svc()
+        long_value = "a" * 64
+        _client(svc).register_model(
+            "m",
+            "s3://b/raw",
+            labels={"model_class": long_value},
+            metadata={"model_class": "explicit-value"},
+        )
+        created_model = svc.create_model.call_args[0][0]
+        annotation = json.loads(
+            created_model.metadata.annotations[METADATA_ANNOTATION_KEY]
+        )
+        self.assertEqual(annotation["model_class"], "explicit-value")
+
     def test_metadata_stored_as_annotation(self):
         """Metadata is JSON-encoded under the michelangelo.io/metadata annotation."""
         svc = _mock_svc()


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

`APIRegistryClient.register_model()` now validates each `labels` value against Kubernetes' label-value constraints (max 63 characters, `^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$`) before writing it to `model.metadata.labels`. Any value that fails validation is demoted into the existing `michelangelo.io/metadata` annotation (JSON-encoded) instead of being sent to the apiserver as a label. If an explicit `metadata` key with the same name is already provided, the explicit value wins over the demoted label value.

**Why?**

`ModelMetadata.to_registry_dict()` commonly includes `model_class`, a fully-qualified Python import path (e.g. `examples.pipelines.california_housing_lightning.model.TorchRegressionModel`, 77 chars) that routinely exceeds Kubernetes' 63-character label-value limit. `register_model()` passed this straight through to `model.metadata.labels`, which only fails against a real Kubernetes-backed apiserver — the in-memory test double (`InMemoryRegistryClient`) never enforces the constraint, so the bug was invisible until running against a live cluster, where `create_model`/`update_model` fail with `INVALID_ARGUMENT`.

**How did you test it?**

- Added 3 unit tests covering: an oversized label value being demoted to the annotation, a label value with disallowed characters being demoted, and an explicit `metadata` value taking precedence over a same-named demoted label. All 46 tests in `michelangelo/lib/model_manager/registry/tests/` pass.
- Verified end-to-end against a real apiserver: a standalone script calling `register_model()` with a 74-character `model_class` label succeeded and the value was retrievable only from `metadata`, not `labels`.
- Verified with a full pipeline run against a live cluster (Ray/Spark pipeline with a `push_step` registering a model with an oversized `model_class` label) — the run completed successfully with the label demotion applied, confirmed via the push step's logs.

**Potential risks**

Low. This only relaxes a previously-fatal path (an `INVALID_ARGUMENT` error) into a non-fatal one; no previously-succeeding call changes behavior, since values passing Kubernetes' label constraints are unaffected.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

N/A

**Documentation Changes**

N/A