### PR TITLE
fix(python): fall back to MA_NAMESPACE for california_housing_xgb push_step

### DIFF
--- a/python/examples/pipelines/california_housing_xgb/README.md
+++ b/python/examples/pipelines/california_housing_xgb/README.md
@@ -191,7 +191,7 @@ kubectl delete cachedoutputs --all   # clear stale cached task outputs
 | `AWS_S3_BUCKET` | No | Parsed from `MA_FILE_SYSTEM` or `UF_STORAGE_URL` | Target bucket name |
 | `REGISTRY_ENDPOINT` | No | — | Model registry gRPC endpoint (`host:port`). Unset → in-memory only |
 | `REGISTRY_INSECURE` | No | `true` | Set `false` to enable TLS for the registry connection |
-| `REGISTRY_NAMESPACE` | No | `default` | Model registry namespace |
+| `REGISTRY_NAMESPACE` | No | `MA_NAMESPACE` (the pipeline's own namespace), else `default` | Model registry namespace |
 
 > **Sandbox note:** in a k3d sandbox, `AWS_ENDPOINT_URL`, `AWS_ACCESS_KEY_ID`,
 > and `AWS_SECRET_ACCESS_KEY` are automatically injected into Ray/Spark pods

--- a/python/examples/pipelines/california_housing_xgb/push.py
+++ b/python/examples/pipelines/california_housing_xgb/push.py
@@ -256,7 +256,9 @@ def push_step(
         )
         registry_client = APIRegistryClient(
             svc=_api_client.ModelService,
-            namespace=os.environ.get("REGISTRY_NAMESPACE", "default"),
+            namespace=os.environ.get(
+                "REGISTRY_NAMESPACE", os.environ.get("MA_NAMESPACE", "default")
+            ),
         )
         log.info("push_step: using APIRegistryClient at %s", registry_endpoint)
     else:


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

`push_step` now falls back to the platform-injected `MA_NAMESPACE` env var (before the `"default"` literal) when `REGISTRY_NAMESPACE` isn't explicitly set. Also updates the README's environment variable table to document the new default.

**Why?**

`REGISTRY_NAMESPACE` was never set anywhere, so registered models always landed under the `"default"` namespace regardless of which namespace the pipeline actually ran in. The platform already injects `MA_NAMESPACE` (the pipeline's own namespace) into every task pod automatically — `push_step` just never read it. Same root cause found and fixed for the sibling `california_housing_lightning` example in #1440.

**How did you test it?**

`ruff check`/`ruff format --check` clean. Not re-run end-to-end against a live sandbox for this specific example (the equivalent fix was verified end-to-end in `california_housing_lightning`'s `push_step`, which shares the identical code pattern) — the change here is a one-line default-fallback mirroring that already-verified fix.

**Potential risks**

Low. Only changes behavior when `REGISTRY_NAMESPACE` is unset and `MA_NAMESPACE` is set (i.e. real remote/sandbox runs) — previously silently registered under `default`, now correctly registers under the run's actual namespace. No change when `REGISTRY_ENDPOINT` itself is unset (still uses `InMemoryRegistryClient`).

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

N/A

**Documentation Changes**

Updated the `REGISTRY_NAMESPACE` row in the example's README environment variable table.