### PR TITLE
Fold successOperations into useStudioMutation

### DIFF
--- a/javascript/packages/core/components/actions/__tests__/actions-popover.test.tsx
+++ b/javascript/packages/core/components/actions/__tests__/actions-popover.test.tsx
@@ -577,8 +577,10 @@ describe('ActionsPopover', () => {
             display: { label: 'Kill' },
             operation: {
               type: 'mutation',
-              mutation: { mutationName: 'UpdateTriggerRun' },
-              successOperations: [{ type: 'toast', message: 'Trigger killed' }],
+              mutation: {
+                mutationName: 'UpdateTriggerRun',
+                successOperations: [{ type: 'toast', message: 'Trigger killed' }],
+              },
             },
             modal: {
               type: 'confirm',
@@ -621,8 +623,10 @@ describe('ActionsPopover', () => {
             display: { label: 'Kill' },
             operation: {
               type: 'mutation',
-              mutation: { mutationName: 'UpdateTriggerRun' },
-              successOperations: [{ type: 'toast', message: 'Should not appear' }],
+              mutation: {
+                mutationName: 'UpdateTriggerRun',
+                successOperations: [{ type: 'toast', message: 'Should not appear' }],
+              },
             },
             modal: {
               type: 'confirm',

--- a/javascript/packages/core/components/actions/confirm-dispatcher.tsx
+++ b/javascript/packages/core/components/actions/confirm-dispatcher.tsx
@@ -7,7 +7,6 @@ import { Markdown } from '#core/components/markdown/markdown';
 import { ConfirmDialog } from '#core/components/modal/confirm-dialog/confirm-dialog';
 import { useSchemaMiddleware } from '#core/hooks/use-schema-middleware/use-schema-middleware';
 import { useStudioMutation } from '#core/hooks/use-studio-mutation';
-import { useSuccessOperations } from './use-success-operations';
 
 import type {
   ActionConfig,
@@ -34,14 +33,10 @@ export function ConfirmDispatcher<T extends Data>({ action, record, onClose }: P
   const mutation = useStudioMutation<unknown, T>(
     action.operation.type === 'mutation' ? action.operation.mutation : null
   );
-  const runSuccessOperations = useSuccessOperations(
-    action.operation.type === 'mutation' ? action.operation.successOperations : undefined
-  );
 
   const handleActionExecute = async () => {
     if (action.operation.type === 'mutation') {
-      const response = await mutation.mutateAsync(applyMiddleware(record));
-      runSuccessOperations(response);
+      await mutation.mutateAsync(applyMiddleware(record));
     } else {
       navigate(action.operation.route);
     }

--- a/javascript/packages/core/components/actions/types.ts
+++ b/javascript/packages/core/components/actions/types.ts
@@ -53,8 +53,6 @@ export type MutationActionConfig = {
   type: 'mutation';
   mutation: MutationConfig;
   middleware?: MiddlewareSchema;
-  /** Side-effects to run after the mutation succeeds (in order). */
-  successOperations?: SuccessOperation[];
 };
 
 /**

--- a/javascript/packages/core/config/entities/trigger/trigger.ts
+++ b/javascript/packages/core/config/entities/trigger/trigger.ts
@@ -32,21 +32,23 @@ export const TRIGGER_ENTITY_CONFIG: PhaseEntityConfig = {
       ],
       operation: {
         type: 'mutation',
-        mutation: { mutationName: 'UpdateTriggerRun' },
+        mutation: {
+          mutationName: 'UpdateTriggerRun',
+          // status.state is set by a controller after the spec change is reconciled.
+          // Auto-invalidation runs immediately and refetches stale state; this delayed
+          // re-invalidation gives the backend time to process the kill so the next
+          // refetch shows PENDING_KILL / KILLED.
+          successOperations: [
+            {
+              type: 'invalidate',
+              targets: ['GetTriggerRun', 'ListTriggerRun'],
+              delayMs: 2000,
+            },
+          ],
+        },
         middleware: {
           operations: [{ destination: 'spec.action', default: TriggerRunAction.KILL }],
         },
-        // status.state is set by a controller after the spec change is reconciled.
-        // Auto-invalidation runs immediately and refetches stale state; this delayed
-        // re-invalidation gives the backend time to process the kill so the next
-        // refetch shows PENDING_KILL / KILLED.
-        successOperations: [
-          {
-            type: 'invalidate',
-            targets: ['GetTriggerRun', 'ListTriggerRun'],
-            delayMs: 2000,
-          },
-        ],
       },
       modal: {
         type: 'confirm',

--- a/javascript/packages/core/hooks/__tests__/use-studio-mutation.test.ts
+++ b/javascript/packages/core/hooks/__tests__/use-studio-mutation.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { renderHook, screen, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 
 import { GrpcStatusCode } from '#core/constants/grpc-status-codes';
@@ -10,6 +10,7 @@ import {
   createQueryMockRouter,
   getServiceProviderWrapper,
 } from '#core/test/wrappers/get-service-provider-wrapper';
+import { getSnackbarProviderWrapper } from '#core/test/wrappers/get-snackbar-provider-wrapper';
 import { ApplicationError } from '#core/types/error-types';
 
 import type { ErrorNormalizer } from '#core/types/error-types';
@@ -27,6 +28,7 @@ describe('useStudioMutation', () => {
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/ma-dev-test' }),
         getServiceProviderWrapper({ request: mockRequest }),
+        getSnackbarProviderWrapper(),
       ])
     );
 
@@ -49,6 +51,7 @@ describe('useStudioMutation', () => {
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/ma-dev-test' }),
         getServiceProviderWrapper({ request: mockRequest }),
+        getSnackbarProviderWrapper(),
       ])
     );
 
@@ -58,6 +61,59 @@ describe('useStudioMutation', () => {
       expect(result.current.data).toEqual(mockResponse);
       expect(result.current.isSuccess).toBe(true);
     });
+  });
+
+  test('runs successOperations by default on success', async () => {
+    const mockResponse = { id: 'test-id' };
+    const mockRequest = createQueryMockRouter({
+      CreatePipelineRun: mockResponse,
+    });
+
+    renderHook(
+      () =>
+        useStudioMutation({
+          mutationName: 'CreatePipelineRun',
+          successOperations: [{ type: 'toast', message: 'Pipeline run created' }],
+        }),
+      buildWrapper([
+        getErrorProviderWrapper(),
+        getRouterWrapper(),
+        getServiceProviderWrapper({ request: mockRequest }),
+        getSnackbarProviderWrapper(),
+      ])
+    ).result.current.mutate({ name: 'test-run' });
+
+    expect(await screen.findByText('Pipeline run created')).toBeInTheDocument();
+  });
+
+  test('clientOptions.onSuccess fully replaces default successOperations', async () => {
+    const mockResponse = { id: 'test-id' };
+    const onSuccess = vi.fn();
+    const mockRequest = createQueryMockRouter({
+      CreatePipelineRun: mockResponse,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useStudioMutation({
+          mutationName: 'CreatePipelineRun',
+          successOperations: [{ type: 'toast', message: 'Should not appear' }],
+          clientOptions: { onSuccess },
+        }),
+      buildWrapper([
+        getErrorProviderWrapper(),
+        getRouterWrapper(),
+        getServiceProviderWrapper({ request: mockRequest }),
+        getSnackbarProviderWrapper(),
+      ])
+    );
+
+    result.current.mutate({ name: 'test-run' });
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledWith(mockResponse);
+    });
+    expect(screen.queryByText('Should not appear')).not.toBeInTheDocument();
   });
 
   test('passes onSuccess callback with response data', async () => {
@@ -77,6 +133,7 @@ describe('useStudioMutation', () => {
         getErrorProviderWrapper(),
         getRouterWrapper(),
         getServiceProviderWrapper({ request: mockRequest }),
+        getSnackbarProviderWrapper(),
       ])
     );
 
@@ -104,6 +161,7 @@ describe('useStudioMutation', () => {
         getErrorProviderWrapper(),
         getRouterWrapper(),
         getServiceProviderWrapper({ request: mockRequest }),
+        getSnackbarProviderWrapper(),
       ])
     );
 
@@ -141,6 +199,7 @@ describe('useStudioMutation', () => {
         getErrorProviderWrapper({ normalizeError: customNormalizer }),
         getRouterWrapper(),
         getServiceProviderWrapper({ request: mockRequest }),
+        getSnackbarProviderWrapper(),
       ])
     );
 

--- a/javascript/packages/core/hooks/__tests__/use-studio-mutation.test.ts
+++ b/javascript/packages/core/hooks/__tests__/use-studio-mutation.test.ts
@@ -86,18 +86,18 @@ describe('useStudioMutation', () => {
     expect(await screen.findByText('Pipeline run created')).toBeInTheDocument();
   });
 
-  test('clientOptions.onSuccess fully replaces default successOperations', async () => {
+  test('clientOptions.onSuccess runs alongside default successOperations', async () => {
     const mockResponse = { id: 'test-id' };
     const onSuccess = vi.fn();
     const mockRequest = createQueryMockRouter({
       CreatePipelineRun: mockResponse,
     });
 
-    const { result } = renderHook(
+    renderHook(
       () =>
         useStudioMutation({
           mutationName: 'CreatePipelineRun',
-          successOperations: [{ type: 'toast', message: 'Should not appear' }],
+          successOperations: [{ type: 'toast', message: 'Pipeline run created' }],
           clientOptions: { onSuccess },
         }),
       buildWrapper([
@@ -106,14 +106,10 @@ describe('useStudioMutation', () => {
         getServiceProviderWrapper({ request: mockRequest }),
         getSnackbarProviderWrapper(),
       ])
-    );
+    ).result.current.mutate({ name: 'test-run' });
 
-    result.current.mutate({ name: 'test-run' });
-
-    await waitFor(() => {
-      expect(onSuccess).toHaveBeenCalledWith(mockResponse);
-    });
-    expect(screen.queryByText('Should not appear')).not.toBeInTheDocument();
+    expect(await screen.findByText('Pipeline run created')).toBeInTheDocument();
+    expect(onSuccess).toHaveBeenCalledWith(mockResponse);
   });
 
   test('passes onSuccess callback with response data', async () => {

--- a/javascript/packages/core/hooks/use-studio-mutation.ts
+++ b/javascript/packages/core/hooks/use-studio-mutation.ts
@@ -25,10 +25,10 @@ export const useStudioMutation = <TData, TVariables extends Record<string, unkno
         throw normalizeError(error)!;
       }
     },
-    onSuccess: (data) =>
-      config?.clientOptions?.onSuccess
-        ? config.clientOptions.onSuccess(data)
-        : runSuccessOperations(data),
+    onSuccess: (data) => {
+      runSuccessOperations(data);
+      config?.clientOptions?.onSuccess?.(data);
+    },
     onError: config?.clientOptions?.onError
       ? (error) => config.clientOptions!.onError!(error)
       : undefined,

--- a/javascript/packages/core/hooks/use-studio-mutation.ts
+++ b/javascript/packages/core/hooks/use-studio-mutation.ts
@@ -1,5 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
 
+import { useSuccessOperations } from '#core/components/actions/use-success-operations';
 import { useErrorNormalizer } from '#core/providers/error-provider/use-error-normalizer';
 import { useServiceProvider } from '#core/providers/service-provider/use-service-provider';
 
@@ -12,6 +13,7 @@ export const useStudioMutation = <TData, TVariables extends Record<string, unkno
 ): UseMutationResult<TData, ApplicationError, TVariables> => {
   const { request } = useServiceProvider();
   const normalizeError = useErrorNormalizer();
+  const runSuccessOperations = useSuccessOperations(config?.successOperations);
 
   return useMutation<TData, ApplicationError, TVariables>({
     mutationFn: async (variables: TVariables) => {
@@ -23,9 +25,10 @@ export const useStudioMutation = <TData, TVariables extends Record<string, unkno
         throw normalizeError(error)!;
       }
     },
-    onSuccess: config?.clientOptions?.onSuccess
-      ? (data) => config.clientOptions!.onSuccess!(data)
-      : undefined,
+    onSuccess: (data) =>
+      config?.clientOptions?.onSuccess
+        ? config.clientOptions.onSuccess(data)
+        : runSuccessOperations(data),
     onError: config?.clientOptions?.onError
       ? (error) => config.clientOptions!.onError!(error)
       : undefined,

--- a/javascript/packages/core/types/query-types.ts
+++ b/javascript/packages/core/types/query-types.ts
@@ -1,6 +1,7 @@
 import { useStudioMutation as _useStudioMutation } from '#core/hooks/use-studio-mutation';
 import { useStudioQuery as _useStudioQuery } from '#core/hooks/use-studio-query';
 
+import type { SuccessOperation } from '#core/components/actions/types';
 import type { ApplicationError } from '#core/types/error-types';
 
 /**
@@ -37,6 +38,9 @@ export interface MutationConfig {
 
   /** Options to pass to the mutation, e.g. 'onSuccess', 'onError' */
   clientOptions?: MutationOptions;
+
+  /** Side-effects to run after the mutation succeeds (in order). */
+  successOperations?: SuccessOperation[];
 }
 
 /**


### PR DESCRIPTION
**Summary**
Move successOperations from MutationActionConfig onto MutationConfig, and run them automatically inside useStudioMutation instead of requiring each caller to wire useSuccessOperations by hand. useStudioMutation runs the mutation's successOperations on success, and also invokes clientOptions.onSuccess if one is supplied.

ConfirmDispatcher was the only caller, and it had to remember to invoke useSuccessOperations itself after every successful mutation. That pattern doesn't scale to other dispatch paths (e.g. a future bare mutation action with no confirm modal) without duplicating the same wiring at each new call site.

**Test Plan**
Updated trigger.ts to include toast successOperations and verified it appeared on successful trigger kill action.
