### PR TITLE
fix(spark): infer SparkApplication.Type from entrypoint instead of hardcoding Python

### DIFF
--- a/go/components/spark/job/client/BUILD.bazel
+++ b/go/components/spark/job/client/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -22,5 +22,15 @@ go_library(
         "@io_k8s_client_go//rest:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/manager:go_default_library",
         "@org_uber_go_fx//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["client_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//go/thirdparty/k8s-crds/apis/sparkoperator.k8s.io/v1beta2:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
     ],
 )

--- a/go/components/spark/job/client/client.go
+++ b/go/components/spark/job/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"strings"
 
 	"github.com/go-logr/logr"
 	constants "github.com/michelangelo-ai/michelangelo/go/components/jobs/common/constants"
@@ -28,6 +29,23 @@ type SparkClient struct {
 // Compile-time assertion that SparkClient implements job.Client interface.
 var _ job.Client = &SparkClient{}
 
+// sparkApplicationType infers the Spark Operator SparkApplicationType from a
+// SparkJob's main_application_file, since SparkJobSpec has no dedicated
+// language field. Falls back to JavaApplicationType (functionally identical
+// to Scala for the operator's dispatch, since both are JVM entrypoints
+// invoked via --class) when the extension doesn't identify a Python or R
+// script.
+func sparkApplicationType(mainApplicationFile string) sparkv1beta2.SparkApplicationType {
+	switch {
+	case strings.HasSuffix(mainApplicationFile, ".py"):
+		return sparkv1beta2.PythonApplicationType
+	case strings.HasSuffix(mainApplicationFile, ".R"), strings.HasSuffix(mainApplicationFile, ".r"):
+		return sparkv1beta2.RApplicationType
+	default:
+		return sparkv1beta2.JavaApplicationType
+	}
+}
+
 // CreateJob creates a new SparkApplication from a SparkJob specification.
 //
 // This method:
@@ -51,7 +69,7 @@ func (r SparkClient) CreateJob(ctx context.Context, log logr.Logger, job *v2pb.S
 			Namespace: job.Namespace,
 		},
 		Spec: sparkv1beta2.SparkApplicationSpec{
-			Type:                sparkv1beta2.PythonApplicationType,
+			Type:                sparkApplicationType(spec.MainApplicationFile),
 			SparkVersion:        spec.SparkVersion,
 			Mode:                sparkv1beta2.ClusterMode,
 			Image:               &spec.Driver.Pod.Image,

--- a/go/components/spark/job/client/client_test.go
+++ b/go/components/spark/job/client/client_test.go
@@ -1,0 +1,48 @@
+package client
+
+import (
+	"testing"
+
+	sparkv1beta2 "github.com/michelangelo-ai/michelangelo/go/thirdparty/k8s-crds/apis/sparkoperator.k8s.io/v1beta2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSparkApplicationType(t *testing.T) {
+	cases := []struct {
+		name                string
+		mainApplicationFile string
+		expected            sparkv1beta2.SparkApplicationType
+	}{
+		{
+			name:                "python script",
+			mainApplicationFile: "s3://bucket/custom_job.py",
+			expected:            sparkv1beta2.PythonApplicationType,
+		},
+		{
+			name:                "R script uppercase extension",
+			mainApplicationFile: "s3://bucket/analysis.R",
+			expected:            sparkv1beta2.RApplicationType,
+		},
+		{
+			name:                "R script lowercase extension",
+			mainApplicationFile: "s3://bucket/analysis.r",
+			expected:            sparkv1beta2.RApplicationType,
+		},
+		{
+			name:                "jar with main class defaults to Java",
+			mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.12-3.5.5.jar",
+			expected:            sparkv1beta2.JavaApplicationType,
+		},
+		{
+			name:                "empty file defaults to Java",
+			mainApplicationFile: "",
+			expected:            sparkv1beta2.JavaApplicationType,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, sparkApplicationType(tc.mainApplicationFile))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`SparkClient.CreateJob` (`go/components/spark/job/client/client.go`) always set `Type: sparkv1beta2.PythonApplicationType` on every `SparkApplication`, regardless of the actual entrypoint. `SparkJobSpec` has no dedicated language field, so this infers the type from `main_application_file`'s extension:

- `.py` → `PythonApplicationType`
- `.R` / `.r` → `RApplicationType`
- otherwise (jar + `main_class`) → `JavaApplicationType`

Java and Scala are functionally identical to the spark-operator's dispatch (both JVM entrypoints invoked via `--class`), and the proto has no way to distinguish the two languages for a jar entrypoint, so `Java` is used as the generic JVM default.

Found while sandbox-validating a new pure-Python `spark.create_job`/`spark.sensor_job` builtin pair, submitting the bundled SparkPi jar example — the job still ran and reached `Succeeded` (the operator falls back to `--class` when `main_class` is set regardless of declared `Type`), but the CRD's declared type was misleading.

Fixes #1457

## Test plan

- [x] `go build ./components/spark/...` — clean
- [x] `go vet ./components/spark/job/client/...` — clean
- [x] `gofmt -l` — clean
- [x] New unit test `TestSparkApplicationType` covering `.py`, `.R`, `.r`, jar+main_class, and empty-file cases — all pass