### PR TITLE
feat(uniflow): run_spark_job() -- custom Spark entrypoints without a wrapped Python task

### DIFF
--- a/docs/user-guides/ml-pipelines/custom-spark-entrypoints.md
+++ b/docs/user-guides/ml-pipelines/custom-spark-entrypoints.md
@@ -1,0 +1,100 @@
+# Custom Spark Entrypoints with `run_spark_job()`
+
+`run_spark_job()` submits a custom Spark entrypoint (a Scala/JVM jar or a standalone PySpark script) and waits for it to complete. It is callable directly inside a `@workflow()` body — no `@task` decorator or `TaskConfig` object needed.
+
+## When to use `run_spark_job()` vs `SparkTask`
+
+| | `SparkTask` | `run_spark_job()` |
+|---|---|---|
+| **Entrypoint** | Uniflow-wrapped Python function (`run_task.py`) | Your own jar or `.py` file |
+| **Typed I/O** | Full — reads/writes through Uniflow's I/O registry | None — returns job status only |
+| **Return value** | Marshaled Python return value from the task function | Terminal job status dict (metadata + status conditions) |
+| **Use when** | Your task logic lives in Python and you want typed data passed between workflow steps | You have an existing Spark job (Scala/JVM or standalone PySpark) and don't need Uniflow I/O |
+
+**Key trade-off:** `run_spark_job()` returns only the terminal job status — not a Python return value. If a downstream workflow step needs data the Spark job produced, that data must be written by the job itself to a known location (a table, an S3 path passed via `args` or `spark_conf`) and referenced explicitly in the next step.
+
+## Usage
+
+```python
+import michelangelo.uniflow.core as uniflow
+from michelangelo.uniflow.core.lib.spark import run_spark_job
+
+
+@uniflow.workflow()
+def my_pipeline(date: str):
+    # Scala/JVM jar example
+    result = run_spark_job(
+        namespace="my-project",
+        main_application_file="s3://my-bucket/my-app-1.0.jar",
+        main_class="com.example.MySparkApp",
+        args=["--date", date],
+        image="apache/spark:3.5.5",
+        executor_cpu=4,
+        executor_memory="4G",
+        executor_instances=10,
+        retry_attempts=2,
+    )
+    return result
+```
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `namespace` | `str` | Yes | Namespace where the SparkJob will be created |
+| `main_application_file` | `str` | Yes | Path or URI to the entrypoint jar or `.py` file |
+| `main_class` | `str` | No | Fully qualified main class (required for jar entrypoints, omit for `.py`) |
+| `args` | `list[str]` | No | Arguments passed to the application |
+| `image` | `str` | No | Container image for driver and executor pods |
+| `driver_cpu` | `int` | No | CPU cores for the driver |
+| `driver_memory` | `str` | No | Memory for the driver (e.g. `"4G"`) |
+| `executor_cpu` | `int` | No | CPU cores per executor |
+| `executor_memory` | `str` | No | Memory per executor (e.g. `"8G"`) |
+| `executor_instances` | `int` | No | Number of executor instances |
+| `spark_conf` | `dict[str, str]` | No | Spark configuration properties |
+| `deps_jars` | `list[str]` | No | JAR dependencies |
+| `deps_py_files` | `list[str]` | No | Python file dependencies |
+| `spark_version` | `str` | No | Spark version (default: `"3.5.5"`) |
+| `timeout_seconds` | `int` | No | Max wait time in seconds (default: 10 years) |
+| `poll_seconds` | `int` | No | Poll interval in seconds (default: 10) |
+| `retry_attempts` | `int` | No | Number of retries on failure (default: 0) |
+
+## Return value
+
+```python
+{
+    "metadata": {
+        "name": "uniflow-splg-abc12",
+        "namespace": "my-project"
+    },
+    "status": {
+        "status_conditions": [
+            {"type": "Succeeded", "status": 1, "reason": "...", "message": "..."}
+        ],
+        "job_url": "...",
+        "application_id": "..."
+    }
+}
+```
+
+## Retry behavior
+
+When `retry_attempts > 0`, `run_spark_job()` re-submits a fresh SparkJob on any non-succeeded terminal state, including both Failed and Killed conditions. Killed is retried because it is commonly caused by infrastructure instability (node preemption, resource pressure), not deliberate cancellation. Explicit run cancellation is handled separately by the workflow engine's own cancellation mechanism and is unaffected by `retry_attempts`.
+
+## Accessing job outputs
+
+Since `run_spark_job()` does not marshal a Python return value, downstream steps must access job outputs through external storage:
+
+```python
+@uniflow.workflow()
+def my_pipeline():
+    output_path = "s3://my-bucket/output/"
+    run_spark_job(
+        namespace="my-project",
+        main_application_file="s3://my-bucket/etl.jar",
+        main_class="com.example.ETL",
+        args=["--output", output_path],
+    )
+    # Next step references the output location directly
+    return process_results(output_path)
+```

--- a/go/worker/plugins/spark/BUILD.bazel
+++ b/go/worker/plugins/spark/BUILD.bazel
@@ -11,12 +11,14 @@ go_library(
     deps = [
         "//go/worker/activities/spark:go_default_library",
         "//go/worker/plugins/utils:go_default_library",
+        "//proto/api:go_default_library",
         "//proto/api/v2:go_default_library",
         "@com_github_cadence_workflow_starlark_worker//ext:go_default_library",
         "@com_github_cadence_workflow_starlark_worker//service:go_default_library",
         "@com_github_cadence_workflow_starlark_worker//star:go_default_library",
         "@com_github_cadence_workflow_starlark_worker//worker:go_default_library",
         "@com_github_cadence_workflow_starlark_worker//workflow:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@net_starlark_go//starlark:go_default_library",
     ],
 )

--- a/go/worker/plugins/spark/starlark_module.go
+++ b/go/worker/plugins/spark/starlark_module.go
@@ -12,6 +12,7 @@ import (
 	"github.com/michelangelo-ai/michelangelo/go/worker/plugins/utils"
 	v2pb "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
 	"go.starlark.net/starlark"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // These are some error reasons
@@ -217,30 +218,54 @@ func (r *module) sensorJob(t *starlark.Thread, _ *starlark.Builtin, args starlar
 	return sparkJobValue, nil
 }
 
-// run_job creates a spark job and waits for it to reach a terminal state.
+// run_job creates a spark job from flat parameters and waits for it to reach a terminal state.
+// The kwargs match run_spark_job()'s Python signature exactly, so the transpiled
+// __spark__.run_job(...) call works without restructuring.
 //
-//	run_job(job, timeout_seconds=0, poll_seconds=10, assert_condition_type="succeeded") -> job
-//
-//	  job: a spark job spec dict (same format as create_job)
-//	  timeout_seconds: int: max time for the entire create+wait cycle
-//	  poll_seconds: int: job status poll interval
-//	  assert_condition_type: str: condition type to wait for
+//	run_job(namespace, main_application_file, main_class=None, args=None, image=None,
+//	        driver_cpu=None, driver_memory=None, executor_cpu=None, executor_memory=None,
+//	        executor_instances=None, spark_conf=None, deps_jars=None, deps_py_files=None,
+//	        spark_version="3.5.5", timeout_seconds=0, poll_seconds=10) -> job
 //
 //	  return: dict: final job status
 func (r *module) runJob(t *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	ctx := service.GetContext(t)
 	logger := workflow.GetLogger(ctx)
 
-	var _job *starlark.Dict
+	var namespace string
+	var mainApplicationFile string
+	var mainClass string
+	var mainArgs *starlark.List
+	var image string
+	var driverCPU int
+	var driverMemory string
+	var executorCPU int
+	var executorMemory string
+	var executorInstances int
+	var sparkConf *starlark.Dict
+	var depsJars *starlark.List
+	var depsPyFiles *starlark.List
+	var sparkVersion string = "3.5.5"
 	var timeout int64
 	pollSeconds := defaultPollSeconds
-	assertConditionType := utils.SucceededCondition
 
 	if err := starlark.UnpackArgs("run_job", args, kwargs,
-		"job", &_job,
+		"namespace", &namespace,
+		"main_application_file", &mainApplicationFile,
+		"main_class?", &mainClass,
+		"args?", &mainArgs,
+		"image?", &image,
+		"driver_cpu?", &driverCPU,
+		"driver_memory?", &driverMemory,
+		"executor_cpu?", &executorCPU,
+		"executor_memory?", &executorMemory,
+		"executor_instances?", &executorInstances,
+		"spark_conf?", &sparkConf,
+		"deps_jars?", &depsJars,
+		"deps_py_files?", &depsPyFiles,
+		"spark_version?", &sparkVersion,
 		"timeout_seconds?", &timeout,
 		"poll_seconds?", &pollSeconds,
-		"assert_condition_type?", &assertConditionType,
 	); err != nil {
 		logger.Error(errorReasonUnpackArgs, ext.ZapError(err)...)
 		return nil, err
@@ -249,18 +274,79 @@ func (r *module) runJob(t *starlark.Thread, _ *starlark.Builtin, args starlark.T
 		timeout = int64(utils.LongTimeout.Seconds())
 	}
 
-	var sparkJob v2pb.SparkJob
-	if err := utils.AsGo(_job, &sparkJob); err != nil {
-		logger.Error(errorReasonConvertJob, ext.ZapError(err)...)
-		return nil, err
+	sparkJob := &v2pb.SparkJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:    namespace,
+			GenerateName: "uniflow-splg-",
+		},
+		Spec: v2pb.SparkJobSpec{
+			MainApplicationFile: mainApplicationFile,
+			MainClass:           mainClass,
+			SparkVersion:        sparkVersion,
+			Driver: &v2pb.DriverSpec{
+				Pod: &v2pb.PodSpec{
+					Resource: &v2pb.ResourceSpec{
+						Cpu:    int32(driverCPU),
+						Memory: driverMemory,
+					},
+					Image: image,
+				},
+			},
+			Executor: &v2pb.ExecutorSpec{
+				Pod: &v2pb.PodSpec{
+					Resource: &v2pb.ResourceSpec{
+						Cpu:    int32(executorCPU),
+						Memory: executorMemory,
+					},
+					Image: image,
+				},
+				Instances: int32(executorInstances),
+			},
+		},
 	}
 
-	createRes, err := r.doCreateJob(ctx, &sparkJob, timeout)
+	if mainArgs != nil {
+		for i := 0; i < mainArgs.Len(); i++ {
+			if s, ok := mainArgs.Index(i).(starlark.String); ok {
+				sparkJob.Spec.MainArgs = append(sparkJob.Spec.MainArgs, string(s))
+			}
+		}
+	}
+
+	if sparkConf != nil {
+		sparkJob.Spec.SparkConf = make(map[string]string)
+		for _, item := range sparkConf.Items() {
+			if k, ok := item[0].(starlark.String); ok {
+				if v, ok := item[1].(starlark.String); ok {
+					sparkJob.Spec.SparkConf[string(k)] = string(v)
+				}
+			}
+		}
+	}
+
+	deps := &v2pb.Dependencies{}
+	if depsJars != nil {
+		for i := 0; i < depsJars.Len(); i++ {
+			if s, ok := depsJars.Index(i).(starlark.String); ok {
+				deps.Jars = append(deps.Jars, string(s))
+			}
+		}
+	}
+	if depsPyFiles != nil {
+		for i := 0; i < depsPyFiles.Len(); i++ {
+			if s, ok := depsPyFiles.Index(i).(starlark.String); ok {
+				deps.PyFiles = append(deps.PyFiles, string(s))
+			}
+		}
+	}
+	sparkJob.Spec.Deps = deps
+
+	createRes, err := r.doCreateJob(ctx, sparkJob, timeout)
 	if err != nil {
 		return nil, err
 	}
 
-	sensorRes, err := r.doSensorJob(ctx, createRes.SparkJob, timeout, pollSeconds, assertConditionType)
+	sensorRes, err := r.doSensorJob(ctx, createRes.SparkJob, timeout, pollSeconds, utils.SucceededCondition)
 	if err != nil {
 		return nil, err
 	}

--- a/go/worker/plugins/spark/starlark_module.go
+++ b/go/worker/plugins/spark/starlark_module.go
@@ -344,6 +344,12 @@ func (r *module) runJob(t *starlark.Thread, _ *starlark.Builtin, args starlark.T
 	}
 	sparkJob.Spec.Deps = deps
 
+	// Retry loop: re-submit a fresh SparkJob on any non-succeeded terminal
+	// state (Failed or Killed). Killed is retried because it's commonly caused
+	// by infra instability (node preemption, resource pressure), not deliberate
+	// cancellation. Explicit run cancellation is handled separately by
+	// doSensorJob's workflow.IsCanceledError path, which tears down the Cadence
+	// context and calls TerminateSparkJob — that path never reaches this loop.
 	var lastSensorRes *spark.SensorSparkJobResponse
 	totalAttempts := retryAttempts + 1
 	for attempt := 1; attempt <= totalAttempts; attempt++ {
@@ -359,11 +365,6 @@ func (r *module) runJob(t *starlark.Thread, _ *starlark.Builtin, args starlark.T
 		lastSensorRes = sensorRes
 
 		if isSparkJobSucceeded(sensorRes.SparkJob) {
-			break
-		}
-
-		if isSparkJobKilled(sensorRes.SparkJob) {
-			logger.Error("spark job killed, no retry", ext.ZapError(fmt.Errorf("spark job killed"))...)
 			break
 		}
 
@@ -388,18 +389,6 @@ func isSparkJobSucceeded(job *v2pb.SparkJob) bool {
 	}
 	for _, c := range job.Status.GetStatusConditions() {
 		if c.Type == utils.SucceededCondition && c.Status == apipb.CONDITION_STATUS_TRUE {
-			return true
-		}
-	}
-	return false
-}
-
-func isSparkJobKilled(job *v2pb.SparkJob) bool {
-	if job == nil {
-		return false
-	}
-	for _, c := range job.Status.GetStatusConditions() {
-		if c.Type == utils.KilledCondition && c.Status == apipb.CONDITION_STATUS_TRUE {
 			return true
 		}
 	}

--- a/go/worker/plugins/spark/starlark_module.go
+++ b/go/worker/plugins/spark/starlark_module.go
@@ -47,6 +47,7 @@ func newModule() starlark.Value {
 	m.attributes = map[string]*starlark.Builtin{
 		"create_job": starlark.NewBuiltin("create_job", m.createJob),
 		"sensor_job": starlark.NewBuiltin("sensor_job", m.sensorJob),
+		"run_job":    starlark.NewBuiltin("run_job", m.runJob),
 	}
 	m.properties = map[string]star.PropertyFactory{
 		"running_condition_type":   getRunningConditionType,
@@ -66,6 +67,68 @@ func (r *module) Attr(n string) (starlark.Value, error) {
 		r, n, r.attributes, r.properties)
 }
 func (r *module) AttrNames() []string { return ext.SortedKeys(r.attributes) }
+
+func (r *module) doCreateJob(ctx workflow.Context, sparkJob *v2pb.SparkJob, timeout int64) (*spark.CreateSparkJobActivityResponse, error) {
+	logger := workflow.GetLogger(ctx)
+
+	srp := utils.DefaultRetryPolicy
+	srp.ExpirationInterval = time.Second * time.Duration(timeout)
+	srp.InitialInterval = time.Second * time.Duration(poll)
+	createCtx := workflow.WithRetryPolicy(ctx, srp)
+
+	var createRes spark.CreateSparkJobActivityResponse
+	if err := workflow.ExecuteActivity(createCtx, spark.Activities.CreateSparkJob, v2pb.CreateSparkJobRequest{
+		SparkJob: sparkJob,
+	}).Get(ctx, &createRes); err != nil {
+		logger.Error("builtin-error", ext.ZapError(err)...)
+		return nil, err
+	}
+	return &createRes, nil
+}
+
+func (r *module) doSensorJob(ctx workflow.Context, sparkJob *v2pb.SparkJob, timeout int64, pollInterval int, assertConditionType string) (*spark.SensorSparkJobResponse, error) {
+	logger := workflow.GetLogger(ctx)
+
+	srp := utils.DefaultSensorRetryPolicy
+	srp.ExpirationInterval = time.Second * time.Duration(timeout)
+	srp.InitialInterval = time.Second * time.Duration(pollInterval)
+	sensorCtx := workflow.WithRetryPolicy(ctx, srp)
+
+	getSparkJobRequest := v2pb.GetSparkJobRequest{
+		Name:      sparkJob.Name,
+		Namespace: sparkJob.Namespace,
+	}
+	var getSparkJobResponse spark.SensorSparkJobResponse
+	maxSensorTries := maxJobSensorRetries
+	for i := 0; i < maxSensorTries; i++ {
+		if err := workflow.ExecuteActivity(sensorCtx, spark.Activities.SensorSparkJob, getSparkJobRequest).Get(ctx, &getSparkJobResponse); err != nil {
+			if workflow.IsCanceledError(ctx, err) {
+				ctx, _ = workflow.NewDisconnectedContext(ctx)
+				terminateRequest := spark.TerminateSparkJobRequest{
+					Name:      sparkJob.Name,
+					Namespace: sparkJob.Namespace,
+					Type:      v2pb.TERMINATION_TYPE_FAILED,
+					Reason:    reasonForCancel,
+				}
+				var terminateResponse v2pb.UpdateSparkJobResponse
+				if terminateErr := workflow.ExecuteActivity(ctx, spark.Activities.TerminateSparkJob, terminateRequest).Get(ctx, &terminateResponse); terminateErr != nil {
+					logger.Error(errorReasonTermninateJob, ext.ZapError(terminateErr)...)
+					return nil, terminateErr
+				}
+				return &spark.SensorSparkJobResponse{
+					SparkJob: terminateResponse.SparkJob,
+					Terminal: true,
+				}, nil
+			}
+			logger.Error(errorReasonSensorJob, ext.ZapError(err)...)
+			continue
+		}
+		if getSparkJobResponse.Terminal {
+			break
+		}
+	}
+	return &getSparkJobResponse, nil
+}
 
 func (r *module) createJob(t *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	ctx := service.GetContext(t)
@@ -91,16 +154,8 @@ func (r *module) createJob(t *starlark.Thread, _ *starlark.Builtin, args starlar
 		return nil, err
 	}
 
-	srp := utils.DefaultRetryPolicy
-	srp.ExpirationInterval = time.Second * time.Duration(timeout)
-	srp.InitialInterval = time.Second * time.Duration(poll)
-	createCtx := workflow.WithRetryPolicy(ctx, srp)
-
-	var createRes spark.CreateSparkJobActivityResponse
-	if err := workflow.ExecuteActivity(createCtx, spark.Activities.CreateSparkJob, v2pb.CreateSparkJobRequest{
-		SparkJob: &sparkJob,
-	}).Get(ctx, &createRes); err != nil {
-		logger.Error("builtin-error", ext.ZapError(err)...)
+	createRes, err := r.doCreateJob(ctx, &sparkJob, timeout)
+	if err != nil {
 		return nil, err
 	}
 
@@ -149,51 +204,69 @@ func (r *module) sensorJob(t *starlark.Thread, _ *starlark.Builtin, args starlar
 		return nil, err
 	}
 
-	srp := utils.DefaultSensorRetryPolicy
-	srp.ExpirationInterval = time.Second * time.Duration(timeout)
-	srp.InitialInterval = time.Second * time.Duration(poll)
-	sensorCtx := workflow.WithRetryPolicy(ctx, srp)
-
-	getSparkJobRequest := v2pb.GetSparkJobRequest{
-		Name:      sparkJob.Name,
-		Namespace: sparkJob.Namespace,
-	}
-	var getSparkJobResponse spark.SensorSparkJobResponse
-	maxSensorTries := maxJobSensorRetries
-	for i := 0; i < maxSensorTries; i++ {
-		if err := workflow.ExecuteActivity(sensorCtx, spark.Activities.SensorSparkJob, getSparkJobRequest).Get(ctx, &getSparkJobResponse); err != nil {
-			if workflow.IsCanceledError(ctx, err) {
-				// killing spark job in cadence once workflow is cancelled
-				ctx, _ = workflow.NewDisconnectedContext(ctx)
-				terminateRequest := spark.TerminateSparkJobRequest{
-					Name:      sparkJob.Name,
-					Namespace: sparkJob.Namespace,
-					Type:      v2pb.TERMINATION_TYPE_FAILED,
-					Reason:    reasonForCancel,
-				}
-				var terminateResponse v2pb.UpdateSparkJobResponse
-				if terminateErr := workflow.ExecuteActivity(ctx, spark.Activities.TerminateSparkJob, terminateRequest).Get(ctx, &terminateResponse); terminateErr != nil {
-					logger.Error(errorReasonTermninateJob, ext.ZapError(terminateErr)...)
-					return nil, terminateErr
-				}
-				var res starlark.Value
-				if convertErr := utils.AsStar(terminateResponse.SparkJob, &res); convertErr != nil {
-					logger.Error(errorReasonConvertJob, ext.ZapError(err)...)
-					return nil, convertErr
-				}
-				return res, nil
-			}
-			logger.Error(errorReasonSensorJob, ext.ZapError(err)...)
-			continue
-		}
-		// we will break as long as succeeded condition has been set
-		if getSparkJobResponse.Terminal {
-			break
-		}
+	sensorRes, err := r.doSensorJob(ctx, &sparkJob, timeout, poll, assertConditionType)
+	if err != nil {
+		return nil, err
 	}
 
 	var sparkJobValue starlark.Value
-	if err := utils.AsStar(getSparkJobResponse.SparkJob, &sparkJobValue); err != nil {
+	if err := utils.AsStar(sensorRes.SparkJob, &sparkJobValue); err != nil {
+		logger.Error(errorReasonConvertStarlarkValue, ext.ZapError(err)...)
+		return nil, err
+	}
+	return sparkJobValue, nil
+}
+
+// run_job creates a spark job and waits for it to reach a terminal state.
+//
+//	run_job(job, timeout_seconds=0, poll_seconds=10, assert_condition_type="succeeded") -> job
+//
+//	  job: a spark job spec dict (same format as create_job)
+//	  timeout_seconds: int: max time for the entire create+wait cycle
+//	  poll_seconds: int: job status poll interval
+//	  assert_condition_type: str: condition type to wait for
+//
+//	  return: dict: final job status
+func (r *module) runJob(t *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	ctx := service.GetContext(t)
+	logger := workflow.GetLogger(ctx)
+
+	var _job *starlark.Dict
+	var timeout int64
+	pollSeconds := defaultPollSeconds
+	assertConditionType := utils.SucceededCondition
+
+	if err := starlark.UnpackArgs("run_job", args, kwargs,
+		"job", &_job,
+		"timeout_seconds?", &timeout,
+		"poll_seconds?", &pollSeconds,
+		"assert_condition_type?", &assertConditionType,
+	); err != nil {
+		logger.Error(errorReasonUnpackArgs, ext.ZapError(err)...)
+		return nil, err
+	}
+	if timeout == 0 {
+		timeout = int64(utils.LongTimeout.Seconds())
+	}
+
+	var sparkJob v2pb.SparkJob
+	if err := utils.AsGo(_job, &sparkJob); err != nil {
+		logger.Error(errorReasonConvertJob, ext.ZapError(err)...)
+		return nil, err
+	}
+
+	createRes, err := r.doCreateJob(ctx, &sparkJob, timeout)
+	if err != nil {
+		return nil, err
+	}
+
+	sensorRes, err := r.doSensorJob(ctx, createRes.SparkJob, timeout, pollSeconds, assertConditionType)
+	if err != nil {
+		return nil, err
+	}
+
+	var sparkJobValue starlark.Value
+	if err := utils.AsStar(sensorRes.SparkJob, &sparkJobValue); err != nil {
 		logger.Error(errorReasonConvertStarlarkValue, ext.ZapError(err)...)
 		return nil, err
 	}

--- a/go/worker/plugins/spark/starlark_module.go
+++ b/go/worker/plugins/spark/starlark_module.go
@@ -82,7 +82,7 @@ func (r *module) doCreateJob(ctx workflow.Context, sparkJob *v2pb.SparkJob, time
 	if err := workflow.ExecuteActivity(createCtx, spark.Activities.CreateSparkJob, v2pb.CreateSparkJobRequest{
 		SparkJob: sparkJob,
 	}).Get(ctx, &createRes); err != nil {
-		logger.Error("builtin-error", ext.ZapError(err)...)
+		logger.Error("spark.create_job activity failed", ext.ZapError(err)...)
 		return nil, err
 	}
 	return &createRes, nil
@@ -371,7 +371,7 @@ func (r *module) runJob(t *starlark.Thread, _ *starlark.Builtin, args starlark.T
 		if attempt < totalAttempts {
 			logger.Info(fmt.Sprintf("spark job failed (attempt %d/%d), retrying", attempt, totalAttempts))
 		} else {
-			logger.Error(fmt.Sprintf("spark job failed after all %d attempts", totalAttempts))
+			return nil, fmt.Errorf("spark job failed after all %d attempts exhausted", totalAttempts)
 		}
 	}
 

--- a/go/worker/plugins/spark/starlark_module.go
+++ b/go/worker/plugins/spark/starlark_module.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cadence-workflow/starlark-worker/workflow"
 	"github.com/michelangelo-ai/michelangelo/go/worker/activities/spark"
 	"github.com/michelangelo-ai/michelangelo/go/worker/plugins/utils"
+	apipb "github.com/michelangelo-ai/michelangelo/proto-go/api"
 	v2pb "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
 	"go.starlark.net/starlark"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -248,6 +249,7 @@ func (r *module) runJob(t *starlark.Thread, _ *starlark.Builtin, args starlark.T
 	var sparkVersion string = "3.5.5"
 	var timeout int64
 	pollSeconds := defaultPollSeconds
+	var retryAttempts int
 
 	if err := starlark.UnpackArgs("run_job", args, kwargs,
 		"namespace", &namespace,
@@ -266,6 +268,7 @@ func (r *module) runJob(t *starlark.Thread, _ *starlark.Builtin, args starlark.T
 		"spark_version?", &sparkVersion,
 		"timeout_seconds?", &timeout,
 		"poll_seconds?", &pollSeconds,
+		"retry_attempts?", &retryAttempts,
 	); err != nil {
 		logger.Error(errorReasonUnpackArgs, ext.ZapError(err)...)
 		return nil, err
@@ -341,22 +344,66 @@ func (r *module) runJob(t *starlark.Thread, _ *starlark.Builtin, args starlark.T
 	}
 	sparkJob.Spec.Deps = deps
 
-	createRes, err := r.doCreateJob(ctx, sparkJob, timeout)
-	if err != nil {
-		return nil, err
-	}
+	var lastSensorRes *spark.SensorSparkJobResponse
+	totalAttempts := retryAttempts + 1
+	for attempt := 1; attempt <= totalAttempts; attempt++ {
+		createRes, err := r.doCreateJob(ctx, sparkJob, timeout)
+		if err != nil {
+			return nil, err
+		}
 
-	sensorRes, err := r.doSensorJob(ctx, createRes.SparkJob, timeout, pollSeconds, utils.SucceededCondition)
-	if err != nil {
-		return nil, err
+		sensorRes, err := r.doSensorJob(ctx, createRes.SparkJob, timeout, pollSeconds, utils.SucceededCondition)
+		if err != nil {
+			return nil, err
+		}
+		lastSensorRes = sensorRes
+
+		if isSparkJobSucceeded(sensorRes.SparkJob) {
+			break
+		}
+
+		if isSparkJobKilled(sensorRes.SparkJob) {
+			logger.Error("spark job killed, no retry", ext.ZapError(fmt.Errorf("spark job killed"))...)
+			break
+		}
+
+		if attempt < totalAttempts {
+			logger.Info(fmt.Sprintf("spark job failed (attempt %d/%d), retrying", attempt, totalAttempts))
+		} else {
+			logger.Error(fmt.Sprintf("spark job failed after all %d attempts", totalAttempts))
+		}
 	}
 
 	var sparkJobValue starlark.Value
-	if err := utils.AsStar(sensorRes.SparkJob, &sparkJobValue); err != nil {
+	if err := utils.AsStar(lastSensorRes.SparkJob, &sparkJobValue); err != nil {
 		logger.Error(errorReasonConvertStarlarkValue, ext.ZapError(err)...)
 		return nil, err
 	}
 	return sparkJobValue, nil
+}
+
+func isSparkJobSucceeded(job *v2pb.SparkJob) bool {
+	if job == nil {
+		return false
+	}
+	for _, c := range job.Status.GetStatusConditions() {
+		if c.Type == utils.SucceededCondition && c.Status == apipb.CONDITION_STATUS_TRUE {
+			return true
+		}
+	}
+	return false
+}
+
+func isSparkJobKilled(job *v2pb.SparkJob) bool {
+	if job == nil {
+		return false
+	}
+	for _, c := range job.Status.GetStatusConditions() {
+		if c.Type == utils.KilledCondition && c.Status == apipb.CONDITION_STATUS_TRUE {
+			return true
+		}
+	}
+	return false
 }
 
 func getRunningConditionType(receiver starlark.Value) (starlark.Value, error) {

--- a/go/worker/plugins/spark/starlark_module_test.go
+++ b/go/worker/plugins/spark/starlark_module_test.go
@@ -166,3 +166,65 @@ func (s *SparkModuleTestSuite) TestRunJobSuccessfully() {
 	require.Equal(int32(1), createJobReq.SparkJob.Spec.Driver.Pod.Resource.Cpu)
 	require.Equal("1G", createJobReq.SparkJob.Spec.Driver.Pod.Resource.Memory)
 }
+
+func (s *SparkModuleTestSuite) TestRunJobRetryThenSucceed() {
+	env := s.env.Cadence.GetTestWorkflowEnvironment()
+	env.RegisterActivity(spark.Activities.CreateSparkJob)
+	env.RegisterActivity(spark.Activities.SensorSparkJob)
+
+	createCallCount := 0
+	env.OnActivity(spark.Activities.CreateSparkJob, mock.Anything, mock.Anything).
+		Return(func(ctx context.Context, req v2pb.CreateSparkJobRequest) (*spark.CreateSparkJobActivityResponse, error) {
+			createCallCount++
+			return &spark.CreateSparkJobActivityResponse{
+				SparkJob: &v2pb.SparkJob{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "uniflow-splg-retry",
+						Namespace: "test-namespace",
+					},
+				},
+				ActivityID: "",
+			}, nil
+		})
+
+	sensorCallCount := 0
+	env.OnActivity(spark.Activities.SensorSparkJob, mock.Anything, mock.Anything).
+		Return(func(ctx context.Context, req v2pb.GetSparkJobRequest) (*spark.SensorSparkJobResponse, error) {
+			sensorCallCount++
+			if sensorCallCount == 1 {
+				return &spark.SensorSparkJobResponse{
+					SparkJob: &v2pb.SparkJob{
+						Status: v2pb.SparkJobStatus{
+							StatusConditions: []*apipb.Condition{
+								{
+									Type:   "Succeeded",
+									Status: apipb.CONDITION_STATUS_FALSE,
+								},
+							},
+						},
+					},
+					Terminal: true,
+				}, nil
+			}
+			return &spark.SensorSparkJobResponse{
+				SparkJob: &v2pb.SparkJob{
+					Status: v2pb.SparkJobStatus{
+						StatusConditions: []*apipb.Condition{
+							{
+								Type:   "Succeeded",
+								Status: apipb.CONDITION_STATUS_TRUE,
+							},
+						},
+					},
+				},
+				Terminal: true,
+			}, nil
+		})
+
+	s.env.Cadence.ExecuteFunction("/test.star", "test_run_job_retry", nil, nil, nil)
+	require := s.Require()
+	var res any
+	require.NoError(s.env.Cadence.GetResult(&res))
+	require.Equal(2, createCallCount)
+	require.Equal(2, sensorCallCount)
+}

--- a/go/worker/plugins/spark/starlark_module_test.go
+++ b/go/worker/plugins/spark/starlark_module_test.go
@@ -228,3 +228,65 @@ func (s *SparkModuleTestSuite) TestRunJobRetryThenSucceed() {
 	require.Equal(2, createCallCount)
 	require.Equal(2, sensorCallCount)
 }
+
+func (s *SparkModuleTestSuite) TestRunJobRetryOnKilledThenSucceed() {
+	env := s.env.Cadence.GetTestWorkflowEnvironment()
+	env.RegisterActivity(spark.Activities.CreateSparkJob)
+	env.RegisterActivity(spark.Activities.SensorSparkJob)
+
+	createCallCount := 0
+	env.OnActivity(spark.Activities.CreateSparkJob, mock.Anything, mock.Anything).
+		Return(func(ctx context.Context, req v2pb.CreateSparkJobRequest) (*spark.CreateSparkJobActivityResponse, error) {
+			createCallCount++
+			return &spark.CreateSparkJobActivityResponse{
+				SparkJob: &v2pb.SparkJob{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "uniflow-splg-killed",
+						Namespace: "test-namespace",
+					},
+				},
+				ActivityID: "",
+			}, nil
+		})
+
+	sensorCallCount := 0
+	env.OnActivity(spark.Activities.SensorSparkJob, mock.Anything, mock.Anything).
+		Return(func(ctx context.Context, req v2pb.GetSparkJobRequest) (*spark.SensorSparkJobResponse, error) {
+			sensorCallCount++
+			if sensorCallCount == 1 {
+				return &spark.SensorSparkJobResponse{
+					SparkJob: &v2pb.SparkJob{
+						Status: v2pb.SparkJobStatus{
+							StatusConditions: []*apipb.Condition{
+								{
+									Type:   "Killed",
+									Status: apipb.CONDITION_STATUS_TRUE,
+								},
+							},
+						},
+					},
+					Terminal: true,
+				}, nil
+			}
+			return &spark.SensorSparkJobResponse{
+				SparkJob: &v2pb.SparkJob{
+					Status: v2pb.SparkJobStatus{
+						StatusConditions: []*apipb.Condition{
+							{
+								Type:   "Succeeded",
+								Status: apipb.CONDITION_STATUS_TRUE,
+							},
+						},
+					},
+				},
+				Terminal: true,
+			}, nil
+		})
+
+	s.env.Cadence.ExecuteFunction("/test.star", "test_run_job_retry", nil, nil, nil)
+	require := s.Require()
+	var res any
+	require.NoError(s.env.Cadence.GetResult(&res))
+	require.Equal(2, createCallCount)
+	require.Equal(2, sensorCallCount)
+}

--- a/go/worker/plugins/spark/starlark_module_test.go
+++ b/go/worker/plugins/spark/starlark_module_test.go
@@ -290,3 +290,48 @@ func (s *SparkModuleTestSuite) TestRunJobRetryOnKilledThenSucceed() {
 	require.Equal(2, createCallCount)
 	require.Equal(2, sensorCallCount)
 }
+
+func (s *SparkModuleTestSuite) TestRunJobRetryExhaustedReturnsError() {
+	env := s.env.Cadence.GetTestWorkflowEnvironment()
+	env.RegisterActivity(spark.Activities.CreateSparkJob)
+	env.RegisterActivity(spark.Activities.SensorSparkJob)
+
+	createCallCount := 0
+	env.OnActivity(spark.Activities.CreateSparkJob, mock.Anything, mock.Anything).
+		Return(func(ctx context.Context, req v2pb.CreateSparkJobRequest) (*spark.CreateSparkJobActivityResponse, error) {
+			createCallCount++
+			return &spark.CreateSparkJobActivityResponse{
+				SparkJob: &v2pb.SparkJob{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "uniflow-splg-exhaust",
+						Namespace: "test-namespace",
+					},
+				},
+				ActivityID: "",
+			}, nil
+		})
+
+	env.OnActivity(spark.Activities.SensorSparkJob, mock.Anything, mock.Anything).
+		Return(func(ctx context.Context, req v2pb.GetSparkJobRequest) (*spark.SensorSparkJobResponse, error) {
+			return &spark.SensorSparkJobResponse{
+				SparkJob: &v2pb.SparkJob{
+					Status: v2pb.SparkJobStatus{
+						StatusConditions: []*apipb.Condition{
+							{
+								Type:   "Succeeded",
+								Status: apipb.CONDITION_STATUS_FALSE,
+							},
+						},
+					},
+				},
+				Terminal: true,
+			}, nil
+		})
+
+	s.env.Cadence.ExecuteFunction("/test.star", "test_run_job_retry", nil, nil, nil)
+	require := s.Require()
+	var res any
+	err := s.env.Cadence.GetResult(&res)
+	require.Error(err)
+	require.Equal(2, createCallCount)
+}

--- a/go/worker/plugins/spark/starlark_module_test.go
+++ b/go/worker/plugins/spark/starlark_module_test.go
@@ -105,3 +105,53 @@ func (s *SparkModuleTestSuite) TestSensorJobSuccessfully() {
 	var res any
 	require.NoError(s.env.Cadence.GetResult(&res))
 }
+
+func (s *SparkModuleTestSuite) TestRunJobSuccessfully() {
+	env := s.env.Cadence.GetTestWorkflowEnvironment()
+	env.RegisterActivity(spark.Activities.CreateSparkJob)
+	env.RegisterActivity(spark.Activities.SensorSparkJob)
+
+	sparkJob := &v2pb.SparkJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-spark-job",
+			Namespace: "default",
+		},
+		Spec: v2pb.SparkJobSpec{
+			MainClass: "org.apache.spark.examples.SparkPi",
+		},
+	}
+
+	env.OnActivity(spark.Activities.CreateSparkJob, mock.Anything, mock.Anything).Once().
+		Return(func(ctx context.Context, req v2pb.CreateSparkJobRequest) (*spark.CreateSparkJobActivityResponse, error) {
+			return &spark.CreateSparkJobActivityResponse{
+				SparkJob:   sparkJob,
+				ActivityID: "",
+			}, nil
+		})
+
+	env.OnActivity(spark.Activities.SensorSparkJob, mock.Anything, mock.Anything).
+		Return(func(ctx context.Context, req v2pb.GetSparkJobRequest) (*spark.SensorSparkJobResponse, error) {
+			return &spark.SensorSparkJobResponse{
+				SparkJob: &v2pb.SparkJob{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-spark-job",
+						Namespace: "default",
+					},
+					Status: v2pb.SparkJobStatus{
+						StatusConditions: []*apipb.Condition{
+							{
+								Type:   "Succeeded",
+								Status: apipb.CONDITION_STATUS_TRUE,
+							},
+						},
+					},
+				},
+				Terminal: true,
+			}, nil
+		})
+
+	s.env.Cadence.ExecuteFunction("/test.star", "test_run_job", nil, nil, nil)
+	require := s.Require()
+	var res any
+	require.NoError(s.env.Cadence.GetResult(&res))
+}

--- a/go/worker/plugins/spark/starlark_module_test.go
+++ b/go/worker/plugins/spark/starlark_module_test.go
@@ -111,20 +111,25 @@ func (s *SparkModuleTestSuite) TestRunJobSuccessfully() {
 	env.RegisterActivity(spark.Activities.CreateSparkJob)
 	env.RegisterActivity(spark.Activities.SensorSparkJob)
 
-	sparkJob := &v2pb.SparkJob{
+	createdJob := &v2pb.SparkJob{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-spark-job",
-			Namespace: "default",
+			Name:      "uniflow-splg-abc12",
+			Namespace: "test-namespace",
 		},
 		Spec: v2pb.SparkJobSpec{
-			MainClass: "org.apache.spark.examples.SparkPi",
+			MainClass:           "org.apache.spark.examples.SparkPi",
+			MainApplicationFile: "local:///opt/spark/examples/jars/spark-examples.jar",
 		},
 	}
 
+	var createJobReq v2pb.CreateSparkJobRequest
 	env.OnActivity(spark.Activities.CreateSparkJob, mock.Anything, mock.Anything).Once().
+		Run(func(args mock.Arguments) {
+			createJobReq = args.Get(1).(v2pb.CreateSparkJobRequest)
+		}).
 		Return(func(ctx context.Context, req v2pb.CreateSparkJobRequest) (*spark.CreateSparkJobActivityResponse, error) {
 			return &spark.CreateSparkJobActivityResponse{
-				SparkJob:   sparkJob,
+				SparkJob:   createdJob,
 				ActivityID: "",
 			}, nil
 		})
@@ -134,8 +139,8 @@ func (s *SparkModuleTestSuite) TestRunJobSuccessfully() {
 			return &spark.SensorSparkJobResponse{
 				SparkJob: &v2pb.SparkJob{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-spark-job",
-						Namespace: "default",
+						Name:      "uniflow-splg-abc12",
+						Namespace: "test-namespace",
 					},
 					Status: v2pb.SparkJobStatus{
 						StatusConditions: []*apipb.Condition{
@@ -154,4 +159,10 @@ func (s *SparkModuleTestSuite) TestRunJobSuccessfully() {
 	require := s.Require()
 	var res any
 	require.NoError(s.env.Cadence.GetResult(&res))
+	require.Equal("test-namespace", createJobReq.SparkJob.Namespace)
+	require.Equal("org.apache.spark.examples.SparkPi", createJobReq.SparkJob.Spec.MainClass)
+	require.Equal("local:///opt/spark/examples/jars/spark-examples.jar", createJobReq.SparkJob.Spec.MainApplicationFile)
+	require.Equal("apache/spark:3.5.5", createJobReq.SparkJob.Spec.Driver.Pod.Image)
+	require.Equal(int32(1), createJobReq.SparkJob.Spec.Driver.Pod.Resource.Cpu)
+	require.Equal("1G", createJobReq.SparkJob.Spec.Driver.Pod.Resource.Memory)
 }

--- a/go/worker/plugins/spark/testdata/test.star
+++ b/go/worker/plugins/spark/testdata/test.star
@@ -68,3 +68,40 @@ def test_sensor_job():
     }
 
     spark.sensor_job(spec, assert_condition_type = "Succeeded")
+
+def test_run_job():
+    spec = {
+        "kind": "SparkJob",
+        "metadata": {
+            "namespace": "test-namespace",
+            "name": "test-name",
+        },
+        "spec": {
+            "user": {
+                "name": "michelangelo",
+                "proxyUser": "michelangelo",
+            },
+            "driver": {
+                "pod": {
+                    "resource": {
+                        "cpu": 1,
+                        "memory": "1G",
+                    },
+                },
+            },
+            "executor": {
+                "pod": {
+                    "resource": {
+                        "cpu": 1,
+                        "memory": "1G",
+                    },
+                },
+                "instances": 1,
+            },
+            "mainClass": "org.apache.spark.examples.SparkPi",
+            "mainApplicationFile": "local:///opt/spark/examples/jars/spark-examples.jar",
+            "mainArgs": ["2"],
+            "sparkVersion": "3.5.5",
+        },
+    }
+    spark.run_job(job = spec)

--- a/go/worker/plugins/spark/testdata/test.star
+++ b/go/worker/plugins/spark/testdata/test.star
@@ -70,38 +70,16 @@ def test_sensor_job():
     spark.sensor_job(spec, assert_condition_type = "Succeeded")
 
 def test_run_job():
-    spec = {
-        "kind": "SparkJob",
-        "metadata": {
-            "namespace": "test-namespace",
-            "name": "test-name",
-        },
-        "spec": {
-            "user": {
-                "name": "michelangelo",
-                "proxyUser": "michelangelo",
-            },
-            "driver": {
-                "pod": {
-                    "resource": {
-                        "cpu": 1,
-                        "memory": "1G",
-                    },
-                },
-            },
-            "executor": {
-                "pod": {
-                    "resource": {
-                        "cpu": 1,
-                        "memory": "1G",
-                    },
-                },
-                "instances": 1,
-            },
-            "mainClass": "org.apache.spark.examples.SparkPi",
-            "mainApplicationFile": "local:///opt/spark/examples/jars/spark-examples.jar",
-            "mainArgs": ["2"],
-            "sparkVersion": "3.5.5",
-        },
-    }
-    spark.run_job(job = spec)
+    spark.run_job(
+        namespace = "test-namespace",
+        main_application_file = "local:///opt/spark/examples/jars/spark-examples.jar",
+        main_class = "org.apache.spark.examples.SparkPi",
+        args = ["2"],
+        image = "apache/spark:3.5.5",
+        driver_cpu = 1,
+        driver_memory = "1G",
+        executor_cpu = 1,
+        executor_memory = "1G",
+        executor_instances = 1,
+        spark_version = "3.5.5",
+    )

--- a/go/worker/plugins/spark/testdata/test.star
+++ b/go/worker/plugins/spark/testdata/test.star
@@ -83,3 +83,19 @@ def test_run_job():
         executor_instances = 1,
         spark_version = "3.5.5",
     )
+
+def test_run_job_retry():
+    spark.run_job(
+        namespace = "test-namespace",
+        main_application_file = "local:///opt/spark/examples/jars/spark-examples.jar",
+        main_class = "org.apache.spark.examples.SparkPi",
+        args = ["2"],
+        image = "apache/spark:3.5.5",
+        driver_cpu = 1,
+        driver_memory = "1G",
+        executor_cpu = 1,
+        executor_memory = "1G",
+        executor_instances = 1,
+        spark_version = "3.5.5",
+        retry_attempts = 1,
+    )

--- a/python/michelangelo/uniflow/core/lib/spark/__init__.py
+++ b/python/michelangelo/uniflow/core/lib/spark/__init__.py
@@ -1,0 +1,23 @@
+"""Spark job builtins for Uniflow workflows.
+
+Provides pure-Python equivalents of the Go/Starlark spark.create_job and
+spark.sensor_job builtins, using APIClient.SparkJobService directly.
+"""
+
+from michelangelo.uniflow.core.lib.spark.job import (
+    KILLED_CONDITION_TYPE,
+    SUCCEEDED_CONDITION_TYPE,
+    create_job,
+    create_spark_job,
+    poll_spark_job,
+    sensor_job,
+)
+
+__all__ = [
+    "KILLED_CONDITION_TYPE",
+    "SUCCEEDED_CONDITION_TYPE",
+    "create_job",
+    "create_spark_job",
+    "poll_spark_job",
+    "sensor_job",
+]

--- a/python/michelangelo/uniflow/core/lib/spark/__init__.py
+++ b/python/michelangelo/uniflow/core/lib/spark/__init__.py
@@ -8,6 +8,7 @@ directly.
 from michelangelo.uniflow.core.lib.spark.job import (
     KILLED_CONDITION_TYPE,
     SUCCEEDED_CONDITION_TYPE,
+    SparkJobKilledError,
     create_job,
     create_spark_job,
     poll_spark_job,
@@ -18,6 +19,7 @@ from michelangelo.uniflow.core.lib.spark.job import (
 __all__ = [
     "KILLED_CONDITION_TYPE",
     "SUCCEEDED_CONDITION_TYPE",
+    "SparkJobKilledError",
     "create_job",
     "create_spark_job",
     "poll_spark_job",

--- a/python/michelangelo/uniflow/core/lib/spark/__init__.py
+++ b/python/michelangelo/uniflow/core/lib/spark/__init__.py
@@ -1,7 +1,8 @@
 """Spark job builtins for Uniflow workflows.
 
-Provides pure-Python equivalents of the Go/Starlark spark.create_job and
-spark.sensor_job builtins, using APIClient.SparkJobService directly.
+Provides pure-Python equivalents of the Go/Starlark spark.create_job,
+spark.sensor_job, and spark.run_job builtins, using APIClient.SparkJobService
+directly.
 """
 
 from michelangelo.uniflow.core.lib.spark.job import (
@@ -10,6 +11,7 @@ from michelangelo.uniflow.core.lib.spark.job import (
     create_job,
     create_spark_job,
     poll_spark_job,
+    run_spark_job,
     sensor_job,
 )
 
@@ -19,5 +21,6 @@ __all__ = [
     "create_job",
     "create_spark_job",
     "poll_spark_job",
+    "run_spark_job",
     "sensor_job",
 ]

--- a/python/michelangelo/uniflow/core/lib/spark/job.py
+++ b/python/michelangelo/uniflow/core/lib/spark/job.py
@@ -72,6 +72,7 @@ def create_spark_job(
     main_application_file: str,
     main_class: str | None = None,
     args: list[str] | None = None,
+    image: str | None = None,
     driver_cpu: int | None = None,
     driver_memory: str | None = None,
     executor_cpu: int | None = None,
@@ -93,6 +94,8 @@ def create_spark_job(
     if driver_memory is not None:
         driver_resource.memory = driver_memory
     driver_pod = PodSpec(resource=driver_resource)
+    if image:
+        driver_pod.image = image
     driver.pod.CopyFrom(driver_pod)
 
     executor = ExecutorSpec()
@@ -102,6 +105,8 @@ def create_spark_job(
     if executor_memory is not None:
         executor_resource.memory = executor_memory
     executor_pod = PodSpec(resource=executor_resource)
+    if image:
+        executor_pod.image = image
     executor.pod.CopyFrom(executor_pod)
     if executor_instances is not None:
         executor.instances = executor_instances
@@ -227,6 +232,7 @@ def create_job(
     main_application_file: str,
     main_class: str | None = None,
     args: list[str] | None = None,
+    image: str | None = None,
     driver_cpu: int | None = None,
     driver_memory: str | None = None,
     executor_cpu: int | None = None,
@@ -243,6 +249,7 @@ def create_job(
         main_application_file=main_application_file,
         main_class=main_class,
         args=args,
+        image=image,
         driver_cpu=driver_cpu,
         driver_memory=driver_memory,
         executor_cpu=executor_cpu,

--- a/python/michelangelo/uniflow/core/lib/spark/job.py
+++ b/python/michelangelo/uniflow/core/lib/spark/job.py
@@ -43,7 +43,13 @@ _DEFAULT_POLL_SECONDS = 10
 
 
 class SparkJobKilledError(RuntimeError):
-    """Raised when a SparkJob is killed. Not retryable."""
+    """Raised when a SparkJob's Killed condition is TRUE.
+
+    Subclass of RuntimeError. run_spark_job()'s retry loop catches and
+    retries this the same way as a failed job — Killed is commonly caused
+    by infra instability, not deliberate cancellation. Callers who need
+    to distinguish a kill from a failure can catch this type specifically.
+    """
 
 
 def _spark_job_to_dict(job: SparkJob) -> dict[str, Any]:
@@ -211,7 +217,9 @@ def poll_spark_job(
                 grpc.StatusCode.DEADLINE_EXCEEDED,
                 grpc.StatusCode.RESOURCE_EXHAUSTED,
             ):
-                log.debug("Transient error polling spark job %s: %s", name, e.details())
+                log.warning(
+                    "Transient error polling spark job %s: %s", name, e.details()
+                )
             elif e.code() in (
                 grpc.StatusCode.PERMISSION_DENIED,
                 grpc.StatusCode.UNAUTHENTICATED,
@@ -221,11 +229,11 @@ def poll_spark_job(
                     f"Failed to get spark job {name}: {e.details()}"
                 ) from e
             else:
-                log.debug("Error polling spark job %s: %s", name, e.details())
+                log.warning("Error polling spark job %s: %s", name, e.details())
         except RuntimeError:
             raise
         except Exception as e:
-            log.debug("Error polling spark job %s: %s", name, e)
+            log.warning("Error polling spark job %s: %s", name, e)
 
         time.sleep(poll_seconds)
 

--- a/python/michelangelo/uniflow/core/lib/spark/job.py
+++ b/python/michelangelo/uniflow/core/lib/spark/job.py
@@ -280,3 +280,55 @@ def sensor_job(
         timeout_seconds=timeout_seconds,
         poll_seconds=poll_seconds,
     )
+
+
+@star_plugin("spark.run_job")
+def run_spark_job(
+    namespace: str,
+    main_application_file: str,
+    main_class: str | None = None,
+    args: list[str] | None = None,
+    image: str | None = None,
+    driver_cpu: int | None = None,
+    driver_memory: str | None = None,
+    executor_cpu: int | None = None,
+    executor_memory: str | None = None,
+    executor_instances: int | None = None,
+    spark_conf: dict[str, str] | None = None,
+    deps_jars: list[str] | None = None,
+    deps_py_files: list[str] | None = None,
+    spark_version: str = "3.5.5",
+    timeout_seconds: int = 0,
+    poll_seconds: int = _DEFAULT_POLL_SECONDS,
+) -> dict[str, Any]:
+    """Submit a SparkJob and wait for it to reach a terminal state.
+
+    Combines create_spark_job + poll_spark_job into a single call, matching
+    the pipeline.run_pipeline() pattern for use directly in @workflow() bodies.
+    """
+    if timeout_seconds == 0:
+        timeout_seconds = _DEFAULT_TIMEOUT_SECONDS
+
+    created = create_spark_job(
+        namespace=namespace,
+        main_application_file=main_application_file,
+        main_class=main_class,
+        args=args,
+        image=image,
+        driver_cpu=driver_cpu,
+        driver_memory=driver_memory,
+        executor_cpu=executor_cpu,
+        executor_memory=executor_memory,
+        executor_instances=executor_instances,
+        spark_conf=spark_conf,
+        deps_jars=deps_jars,
+        deps_py_files=deps_py_files,
+        spark_version=spark_version,
+    )
+
+    return poll_spark_job(
+        namespace=created.metadata.namespace,
+        name=created.metadata.name,
+        timeout_seconds=timeout_seconds,
+        poll_seconds=poll_seconds,
+    )

--- a/python/michelangelo/uniflow/core/lib/spark/job.py
+++ b/python/michelangelo/uniflow/core/lib/spark/job.py
@@ -300,35 +300,50 @@ def run_spark_job(
     spark_version: str = "3.5.5",
     timeout_seconds: int = 0,
     poll_seconds: int = _DEFAULT_POLL_SECONDS,
+    retry_attempts: int = 0,
 ) -> dict[str, Any]:
     """Submit a SparkJob and wait for it to reach a terminal state.
 
     Combines create_spark_job + poll_spark_job into a single call, matching
     the pipeline.run_pipeline() pattern for use directly in @workflow() bodies.
+    On failure or kill, re-submits up to retry_attempts times before raising.
     """
     if timeout_seconds == 0:
         timeout_seconds = _DEFAULT_TIMEOUT_SECONDS
 
-    created = create_spark_job(
-        namespace=namespace,
-        main_application_file=main_application_file,
-        main_class=main_class,
-        args=args,
-        image=image,
-        driver_cpu=driver_cpu,
-        driver_memory=driver_memory,
-        executor_cpu=executor_cpu,
-        executor_memory=executor_memory,
-        executor_instances=executor_instances,
-        spark_conf=spark_conf,
-        deps_jars=deps_jars,
-        deps_py_files=deps_py_files,
-        spark_version=spark_version,
-    )
+    for attempt in range(retry_attempts + 1):
+        created = create_spark_job(
+            namespace=namespace,
+            main_application_file=main_application_file,
+            main_class=main_class,
+            args=args,
+            image=image,
+            driver_cpu=driver_cpu,
+            driver_memory=driver_memory,
+            executor_cpu=executor_cpu,
+            executor_memory=executor_memory,
+            executor_instances=executor_instances,
+            spark_conf=spark_conf,
+            deps_jars=deps_jars,
+            deps_py_files=deps_py_files,
+            spark_version=spark_version,
+        )
 
-    return poll_spark_job(
-        namespace=created.metadata.namespace,
-        name=created.metadata.name,
-        timeout_seconds=timeout_seconds,
-        poll_seconds=poll_seconds,
-    )
+        try:
+            return poll_spark_job(
+                namespace=created.metadata.namespace,
+                name=created.metadata.name,
+                timeout_seconds=timeout_seconds,
+                poll_seconds=poll_seconds,
+            )
+        except RuntimeError as e:
+            if attempt < retry_attempts:
+                log.info(
+                    "Spark job %s failed (attempt %d/%d), retrying: %s",
+                    created.metadata.name,
+                    attempt + 1,
+                    retry_attempts + 1,
+                    e,
+                )
+            else:
+                raise

--- a/python/michelangelo/uniflow/core/lib/spark/job.py
+++ b/python/michelangelo/uniflow/core/lib/spark/job.py
@@ -1,0 +1,275 @@
+"""Python implementation of spark.create_job / spark.sensor_job builtins.
+
+Mirrors the Go/Starlark spark builtins (create_job, sensor_job) as pure-Python
+functions using APIClient.SparkJobService, following the same pattern as
+plugins/pipeline/run.py (create_pipeline_run / poll_pipeline_run / run_pipeline).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+import grpc
+
+from michelangelo.api.v2 import APIClient
+from michelangelo.gen.api.conditions_pb2 import (
+    CONDITION_STATUS_FALSE,
+    CONDITION_STATUS_TRUE,
+)
+from michelangelo.gen.api.v2.pod_pb2 import PodSpec, ResourceSpec
+from michelangelo.gen.api.v2.spark_job_pb2 import (
+    Dependencies,
+    DriverSpec,
+    ExecutorSpec,
+    SparkJob,
+    SparkJobSpec,
+)
+from michelangelo.gen.k8s.io.apimachinery.pkg.apis.meta.v1.generated_pb2 import (
+    CreateOptions,
+    GetOptions,
+    ObjectMeta,
+)
+from michelangelo.uniflow.core import star_plugin
+
+log = logging.getLogger(__name__)
+
+SUCCEEDED_CONDITION_TYPE = "Succeeded"
+KILLED_CONDITION_TYPE = "Killed"
+
+_DEFAULT_TIMEOUT_SECONDS = 10 * 365 * 24 * 60 * 60
+_DEFAULT_POLL_SECONDS = 10
+
+
+def _spark_job_to_dict(job: SparkJob) -> dict[str, Any]:
+    conditions = []
+    for c in job.status.status_conditions:
+        conditions.append(
+            {
+                "type": c.type,
+                "status": c.status,
+                "reason": c.reason,
+                "message": c.message,
+            }
+        )
+
+    return {
+        "metadata": {
+            "name": job.metadata.name,
+            "namespace": job.metadata.namespace,
+        },
+        "status": {
+            "status_conditions": conditions,
+            "job_url": job.status.job_url,
+            "application_id": job.status.application_id,
+        },
+    }
+
+
+def create_spark_job(
+    namespace: str,
+    main_application_file: str,
+    main_class: str | None = None,
+    args: list[str] | None = None,
+    driver_cpu: int | None = None,
+    driver_memory: str | None = None,
+    executor_cpu: int | None = None,
+    executor_memory: str | None = None,
+    executor_instances: int | None = None,
+    spark_conf: dict[str, str] | None = None,
+    deps_jars: list[str] | None = None,
+    deps_py_files: list[str] | None = None,
+    spark_version: str = "3.5.5",
+) -> SparkJob:
+    """Build a SparkJob proto and submit it via the API.
+
+    Returns the created SparkJob as returned by the server.
+    """
+    driver = DriverSpec()
+    driver_resource = ResourceSpec()
+    if driver_cpu is not None:
+        driver_resource.cpu = driver_cpu
+    if driver_memory is not None:
+        driver_resource.memory = driver_memory
+    driver_pod = PodSpec(resource=driver_resource)
+    driver.pod.CopyFrom(driver_pod)
+
+    executor = ExecutorSpec()
+    executor_resource = ResourceSpec()
+    if executor_cpu is not None:
+        executor_resource.cpu = executor_cpu
+    if executor_memory is not None:
+        executor_resource.memory = executor_memory
+    executor_pod = PodSpec(resource=executor_resource)
+    executor.pod.CopyFrom(executor_pod)
+    if executor_instances is not None:
+        executor.instances = executor_instances
+
+    deps = Dependencies()
+    if deps_jars:
+        deps.jars.extend(deps_jars)
+    if deps_py_files:
+        deps.py_files.extend(deps_py_files)
+
+    spec = SparkJobSpec(
+        main_application_file=main_application_file,
+        spark_version=spark_version,
+    )
+    if main_class:
+        spec.main_class = main_class
+    if args:
+        spec.main_args.extend(args)
+    if spark_conf:
+        for k, v in spark_conf.items():
+            spec.spark_conf[k] = v
+    spec.driver.CopyFrom(driver)
+    spec.executor.CopyFrom(executor)
+    spec.deps.CopyFrom(deps)
+
+    spark_job = SparkJob()
+    spark_job.metadata.CopyFrom(
+        ObjectMeta(namespace=namespace, generateName="uniflow-splg-")
+    )
+    spark_job.spec.CopyFrom(spec)
+
+    log.info(
+        "Creating spark job in namespace %s with entrypoint %s",
+        namespace,
+        main_application_file,
+    )
+    created = APIClient.SparkJobService.create_spark_job(
+        spark_job=spark_job, create_options=CreateOptions()
+    )
+    return created
+
+
+def poll_spark_job(
+    namespace: str,
+    name: str,
+    timeout_seconds: int = _DEFAULT_TIMEOUT_SECONDS,
+    poll_seconds: int = _DEFAULT_POLL_SECONDS,
+) -> dict[str, Any]:
+    """Poll a SparkJob until it reaches a terminal state or times out.
+
+    Returns a dict with metadata and status (matching run_pipeline's return
+    convention). Raises RuntimeError on failure/killed, TimeoutError on timeout.
+    """
+    log.info(
+        "Monitoring spark job %s in namespace %s (timeout=%ds, poll_interval=%ds)",
+        name,
+        namespace,
+        timeout_seconds,
+        poll_seconds,
+    )
+
+    start_time = time.time()
+    while time.time() - start_time < timeout_seconds:
+        try:
+            current_job = APIClient.SparkJobService.get_spark_job(
+                namespace=namespace, name=name, get_options=GetOptions()
+            )
+
+            for cond in current_job.status.status_conditions:
+                if (
+                    cond.type == KILLED_CONDITION_TYPE
+                    and cond.status == CONDITION_STATUS_TRUE
+                ):
+                    raise RuntimeError(f"Spark job {name} was killed: {cond.message}")
+
+                if (
+                    cond.type == SUCCEEDED_CONDITION_TYPE
+                    and cond.status == CONDITION_STATUS_TRUE
+                ):
+                    log.info("Spark job %s succeeded", name)
+                    return _spark_job_to_dict(current_job)
+
+                if (
+                    cond.type == SUCCEEDED_CONDITION_TYPE
+                    and cond.status == CONDITION_STATUS_FALSE
+                ):
+                    raise RuntimeError(f"Spark job {name} failed: {cond.message}")
+
+        except grpc.RpcError as e:
+            if e.code() == grpc.StatusCode.NOT_FOUND:
+                raise RuntimeError(
+                    f"Spark job {name} not found in namespace {namespace}"
+                ) from e
+            elif e.code() in (
+                grpc.StatusCode.UNAVAILABLE,
+                grpc.StatusCode.DEADLINE_EXCEEDED,
+                grpc.StatusCode.RESOURCE_EXHAUSTED,
+            ):
+                log.debug("Transient error polling spark job %s: %s", name, e.details())
+            elif e.code() in (
+                grpc.StatusCode.PERMISSION_DENIED,
+                grpc.StatusCode.UNAUTHENTICATED,
+                grpc.StatusCode.INVALID_ARGUMENT,
+            ):
+                raise RuntimeError(
+                    f"Failed to get spark job {name}: {e.details()}"
+                ) from e
+            else:
+                log.debug("Error polling spark job %s: %s", name, e.details())
+        except RuntimeError:
+            raise
+        except Exception as e:
+            log.debug("Error polling spark job %s: %s", name, e)
+
+        time.sleep(poll_seconds)
+
+    raise TimeoutError(f"Spark job {name} timed out after {timeout_seconds} seconds")
+
+
+@star_plugin("spark.create_job")
+def create_job(
+    namespace: str,
+    main_application_file: str,
+    main_class: str | None = None,
+    args: list[str] | None = None,
+    driver_cpu: int | None = None,
+    driver_memory: str | None = None,
+    executor_cpu: int | None = None,
+    executor_memory: str | None = None,
+    executor_instances: int | None = None,
+    spark_conf: dict[str, str] | None = None,
+    deps_jars: list[str] | None = None,
+    deps_py_files: list[str] | None = None,
+    spark_version: str = "3.5.5",
+) -> dict[str, Any]:
+    """Submit a SparkJob and return its metadata/status as a dict."""
+    created = create_spark_job(
+        namespace=namespace,
+        main_application_file=main_application_file,
+        main_class=main_class,
+        args=args,
+        driver_cpu=driver_cpu,
+        driver_memory=driver_memory,
+        executor_cpu=executor_cpu,
+        executor_memory=executor_memory,
+        executor_instances=executor_instances,
+        spark_conf=spark_conf,
+        deps_jars=deps_jars,
+        deps_py_files=deps_py_files,
+        spark_version=spark_version,
+    )
+    return _spark_job_to_dict(created)
+
+
+@star_plugin("spark.sensor_job")
+def sensor_job(
+    namespace: str,
+    name: str,
+    timeout_seconds: int = 0,
+    poll_seconds: int = _DEFAULT_POLL_SECONDS,
+) -> dict[str, Any]:
+    """Poll a SparkJob until terminal state. Returns metadata/status dict."""
+    if timeout_seconds == 0:
+        timeout_seconds = _DEFAULT_TIMEOUT_SECONDS
+
+    return poll_spark_job(
+        namespace=namespace,
+        name=name,
+        timeout_seconds=timeout_seconds,
+        poll_seconds=poll_seconds,
+    )

--- a/python/michelangelo/uniflow/core/lib/spark/job.py
+++ b/python/michelangelo/uniflow/core/lib/spark/job.py
@@ -42,6 +42,10 @@ _DEFAULT_TIMEOUT_SECONDS = 10 * 365 * 24 * 60 * 60
 _DEFAULT_POLL_SECONDS = 10
 
 
+class SparkJobKilledError(RuntimeError):
+    """Raised when a SparkJob is killed. Not retryable."""
+
+
 def _spark_job_to_dict(job: SparkJob) -> dict[str, Any]:
     conditions = []
     for c in job.status.status_conditions:
@@ -180,7 +184,9 @@ def poll_spark_job(
                     cond.type == KILLED_CONDITION_TYPE
                     and cond.status == CONDITION_STATUS_TRUE
                 ):
-                    raise RuntimeError(f"Spark job {name} was killed: {cond.message}")
+                    raise SparkJobKilledError(
+                        f"Spark job {name} was killed: {cond.message}"
+                    )
 
                 if (
                     cond.type == SUCCEEDED_CONDITION_TYPE
@@ -336,6 +342,8 @@ def run_spark_job(
                 timeout_seconds=timeout_seconds,
                 poll_seconds=poll_seconds,
             )
+        except SparkJobKilledError:
+            raise
         except RuntimeError as e:
             if attempt < retry_attempts:
                 log.info(

--- a/python/michelangelo/uniflow/core/lib/spark/job.py
+++ b/python/michelangelo/uniflow/core/lib/spark/job.py
@@ -342,8 +342,6 @@ def run_spark_job(
                 timeout_seconds=timeout_seconds,
                 poll_seconds=poll_seconds,
             )
-        except SparkJobKilledError:
-            raise
         except RuntimeError as e:
             if attempt < retry_attempts:
                 log.info(

--- a/python/tests/uniflow/core/test_spark_job.py
+++ b/python/tests/uniflow/core/test_spark_job.py
@@ -407,3 +407,46 @@ class TestRunSparkJob:
         )
 
         assert result["metadata"]["name"] == "test-job"
+
+    @patch("michelangelo.uniflow.core.lib.spark.job.time")
+    @patch("michelangelo.uniflow.core.lib.spark.job.APIClient")
+    def test_retry_then_succeed(self, mock_client, mock_time):
+        """Verify run_spark_job retries on failure and succeeds on second attempt."""
+        mock_time.time.side_effect = [0.0, 0.1, 0.0, 0.1]
+        created_job = _make_spark_job()
+        failed_job = _make_spark_job(conditions=[_failed_condition()])
+        succeeded_job = _make_spark_job(conditions=[_succeeded_condition()])
+        mock_client.SparkJobService.create_spark_job.return_value = created_job
+        mock_client.SparkJobService.get_spark_job.side_effect = [
+            failed_job,
+            succeeded_job,
+        ]
+
+        result = run_spark_job(
+            namespace="my-ns",
+            main_application_file="s3://bucket/app.jar",
+            retry_attempts=1,
+        )
+
+        assert result["metadata"]["name"] == "test-job"
+        assert mock_client.SparkJobService.create_spark_job.call_count == 2
+        assert mock_client.SparkJobService.get_spark_job.call_count == 2
+
+    @patch("michelangelo.uniflow.core.lib.spark.job.time")
+    @patch("michelangelo.uniflow.core.lib.spark.job.APIClient")
+    def test_retry_exhausted(self, mock_client, mock_time):
+        """Verify run_spark_job raises after exhausting all retry attempts."""
+        mock_time.time.side_effect = [0.0, 0.1, 0.0, 0.1]
+        created_job = _make_spark_job()
+        failed_job = _make_spark_job(conditions=[_failed_condition()])
+        mock_client.SparkJobService.create_spark_job.return_value = created_job
+        mock_client.SparkJobService.get_spark_job.return_value = failed_job
+
+        with pytest.raises(RuntimeError, match="failed"):
+            run_spark_job(
+                namespace="my-ns",
+                main_application_file="s3://bucket/app.jar",
+                retry_attempts=1,
+            )
+
+        assert mock_client.SparkJobService.create_spark_job.call_count == 2

--- a/python/tests/uniflow/core/test_spark_job.py
+++ b/python/tests/uniflow/core/test_spark_job.py
@@ -26,6 +26,7 @@ from michelangelo.uniflow.core.lib.spark.job import (
     create_job,
     create_spark_job,
     poll_spark_job,
+    run_spark_job,
     sensor_job,
 )
 
@@ -327,6 +328,82 @@ class TestSensorJob:
             name="test-job",
             timeout_seconds=3600,
             poll_seconds=5,
+        )
+
+        assert result["metadata"]["name"] == "test-job"
+
+
+class TestRunSparkJob:
+    """Tests for run_spark_job combined create+poll wrapper."""
+
+    @patch("michelangelo.uniflow.core.lib.spark.job.time")
+    @patch("michelangelo.uniflow.core.lib.spark.job.APIClient")
+    def test_creates_and_polls_to_success(self, mock_client, mock_time):
+        """Verify run_spark_job creates a job then polls it to success."""
+        mock_time.time.side_effect = [0.0, 0.1]
+        created_job = _make_spark_job()
+        succeeded_job = _make_spark_job(conditions=[_succeeded_condition()])
+        mock_client.SparkJobService.create_spark_job.return_value = created_job
+        mock_client.SparkJobService.get_spark_job.return_value = succeeded_job
+
+        result = run_spark_job(
+            namespace="my-ns",
+            main_application_file="s3://bucket/app.jar",
+            main_class="com.example.Main",
+            timeout_seconds=300,
+        )
+
+        assert isinstance(result, dict)
+        assert result["metadata"]["name"] == "test-job"
+        mock_client.SparkJobService.create_spark_job.assert_called_once()
+        mock_client.SparkJobService.get_spark_job.assert_called_once()
+
+    @patch("michelangelo.uniflow.core.lib.spark.job.time")
+    @patch("michelangelo.uniflow.core.lib.spark.job.APIClient")
+    def test_raises_on_job_failure(self, mock_client, mock_time):
+        """Verify run_spark_job raises RuntimeError when the job fails."""
+        mock_time.time.side_effect = [0.0, 0.1]
+        created_job = _make_spark_job()
+        failed_job = _make_spark_job(conditions=[_failed_condition()])
+        mock_client.SparkJobService.create_spark_job.return_value = created_job
+        mock_client.SparkJobService.get_spark_job.return_value = failed_job
+
+        with pytest.raises(RuntimeError, match="failed"):
+            run_spark_job(
+                namespace="my-ns",
+                main_application_file="s3://bucket/app.jar",
+            )
+
+    @patch("michelangelo.uniflow.core.lib.spark.job.time")
+    @patch("michelangelo.uniflow.core.lib.spark.job.APIClient")
+    def test_raises_on_timeout(self, mock_client, mock_time):
+        """Verify run_spark_job raises TimeoutError when polling exceeds timeout."""
+        mock_time.time.side_effect = [0.0, 100.0]
+        created_job = _make_spark_job()
+        running_job = _make_spark_job()
+        mock_client.SparkJobService.create_spark_job.return_value = created_job
+        mock_client.SparkJobService.get_spark_job.return_value = running_job
+
+        with pytest.raises(TimeoutError, match="timed out"):
+            run_spark_job(
+                namespace="my-ns",
+                main_application_file="s3://bucket/app.jar",
+                timeout_seconds=10,
+            )
+
+    @patch("michelangelo.uniflow.core.lib.spark.job.time")
+    @patch("michelangelo.uniflow.core.lib.spark.job.APIClient")
+    def test_default_timeout(self, mock_client, mock_time):
+        """Verify run_spark_job uses default timeout when timeout_seconds is 0."""
+        mock_time.time.side_effect = [0.0, 0.1]
+        created_job = _make_spark_job()
+        succeeded_job = _make_spark_job(conditions=[_succeeded_condition()])
+        mock_client.SparkJobService.create_spark_job.return_value = created_job
+        mock_client.SparkJobService.get_spark_job.return_value = succeeded_job
+
+        result = run_spark_job(
+            namespace="my-ns",
+            main_application_file="s3://bucket/app.jar",
         )
 
         assert result["metadata"]["name"] == "test-job"

--- a/python/tests/uniflow/core/test_spark_job.py
+++ b/python/tests/uniflow/core/test_spark_job.py
@@ -112,6 +112,7 @@ class TestCreateSparkJob:
             main_application_file="s3://bucket/app.jar",
             main_class="com.example.Main",
             args=["--date", "2026-01-01"],
+            image="apache/spark:3.5.5",
             driver_cpu=2,
             driver_memory="4G",
             executor_cpu=4,
@@ -135,8 +136,10 @@ class TestCreateSparkJob:
         assert list(spark_job.spec.main_args) == ["--date", "2026-01-01"]
         assert spark_job.spec.driver.pod.resource.cpu == 2
         assert spark_job.spec.driver.pod.resource.memory == "4G"
+        assert spark_job.spec.driver.pod.image == "apache/spark:3.5.5"
         assert spark_job.spec.executor.pod.resource.cpu == 4
         assert spark_job.spec.executor.pod.resource.memory == "8G"
+        assert spark_job.spec.executor.pod.image == "apache/spark:3.5.5"
         assert spark_job.spec.executor.instances == 10
         assert spark_job.spec.spark_conf["spark.sql.shuffle.partitions"] == "200"
         assert list(spark_job.spec.deps.jars) == ["s3://bucket/dep.jar"]

--- a/python/tests/uniflow/core/test_spark_job.py
+++ b/python/tests/uniflow/core/test_spark_job.py
@@ -1,0 +1,304 @@
+"""Tests for michelangelo.uniflow.core.lib.spark.job builtins."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import grpc
+import pytest
+
+from michelangelo.gen.api.conditions_pb2 import (
+    CONDITION_STATUS_FALSE,
+    CONDITION_STATUS_TRUE,
+    Condition,
+)
+from michelangelo.gen.api.v2.spark_job_pb2 import (
+    SparkJob,
+    SparkJobSpec,
+)
+from michelangelo.gen.k8s.io.apimachinery.pkg.apis.meta.v1.generated_pb2 import (
+    ObjectMeta,
+)
+from michelangelo.uniflow.core.lib.spark.job import (
+    KILLED_CONDITION_TYPE,
+    SUCCEEDED_CONDITION_TYPE,
+    _spark_job_to_dict,
+    create_job,
+    create_spark_job,
+    poll_spark_job,
+    sensor_job,
+)
+
+
+def _make_spark_job(
+    name: str = "test-job",
+    namespace: str = "test-ns",
+    conditions: list[Condition] | None = None,
+) -> SparkJob:
+    job = SparkJob()
+    job.metadata.CopyFrom(ObjectMeta(name=name, namespace=namespace))
+    job.spec.CopyFrom(
+        SparkJobSpec(
+            main_application_file="s3://bucket/app.jar",
+            main_class="com.example.Main",
+        )
+    )
+    if conditions:
+        for c in conditions:
+            job.status.status_conditions.append(c)
+    return job
+
+
+def _succeeded_condition() -> Condition:
+    return Condition(
+        type=SUCCEEDED_CONDITION_TYPE,
+        status=CONDITION_STATUS_TRUE,
+        message="Job completed successfully",
+    )
+
+
+def _killed_condition() -> Condition:
+    return Condition(
+        type=KILLED_CONDITION_TYPE,
+        status=CONDITION_STATUS_TRUE,
+        message="Job was killed",
+    )
+
+
+def _failed_condition() -> Condition:
+    return Condition(
+        type=SUCCEEDED_CONDITION_TYPE,
+        status=CONDITION_STATUS_FALSE,
+        message="Job failed",
+    )
+
+
+class TestSparkJobToDict:
+    def test_basic_conversion(self):
+        job = _make_spark_job(conditions=[_succeeded_condition()])
+        result = _spark_job_to_dict(job)
+
+        assert result["metadata"]["name"] == "test-job"
+        assert result["metadata"]["namespace"] == "test-ns"
+        assert len(result["status"]["status_conditions"]) == 1
+        assert (
+            result["status"]["status_conditions"][0]["type"] == SUCCEEDED_CONDITION_TYPE
+        )
+        assert (
+            result["status"]["status_conditions"][0]["status"] == CONDITION_STATUS_TRUE
+        )
+
+    def test_empty_conditions(self):
+        job = _make_spark_job()
+        result = _spark_job_to_dict(job)
+        assert result["status"]["status_conditions"] == []
+
+
+class TestCreateSparkJob:
+    @patch("michelangelo.uniflow.core.lib.spark.job.APIClient")
+    def test_creates_job_with_all_fields(self, mock_client):
+        returned_job = _make_spark_job()
+        mock_client.SparkJobService.create_spark_job.return_value = returned_job
+
+        result = create_spark_job(
+            namespace="my-ns",
+            main_application_file="s3://bucket/app.jar",
+            main_class="com.example.Main",
+            args=["--date", "2026-01-01"],
+            driver_cpu=2,
+            driver_memory="4G",
+            executor_cpu=4,
+            executor_memory="8G",
+            executor_instances=10,
+            spark_conf={"spark.sql.shuffle.partitions": "200"},
+            deps_jars=["s3://bucket/dep.jar"],
+            deps_py_files=["s3://bucket/utils.py"],
+            spark_version="3.5.5",
+        )
+
+        assert result == returned_job
+        mock_client.SparkJobService.create_spark_job.assert_called_once()
+        call_kwargs = mock_client.SparkJobService.create_spark_job.call_args
+        spark_job = call_kwargs.kwargs["spark_job"]
+
+        assert spark_job.metadata.namespace == "my-ns"
+        assert spark_job.metadata.generateName == "uniflow-splg-"
+        assert spark_job.spec.main_application_file == "s3://bucket/app.jar"
+        assert spark_job.spec.main_class == "com.example.Main"
+        assert list(spark_job.spec.main_args) == ["--date", "2026-01-01"]
+        assert spark_job.spec.driver.pod.resource.cpu == 2
+        assert spark_job.spec.driver.pod.resource.memory == "4G"
+        assert spark_job.spec.executor.pod.resource.cpu == 4
+        assert spark_job.spec.executor.pod.resource.memory == "8G"
+        assert spark_job.spec.executor.instances == 10
+        assert spark_job.spec.spark_conf["spark.sql.shuffle.partitions"] == "200"
+        assert list(spark_job.spec.deps.jars) == ["s3://bucket/dep.jar"]
+        assert list(spark_job.spec.deps.py_files) == ["s3://bucket/utils.py"]
+        assert spark_job.spec.spark_version == "3.5.5"
+
+    @patch("michelangelo.uniflow.core.lib.spark.job.APIClient")
+    def test_creates_job_minimal_fields(self, mock_client):
+        returned_job = _make_spark_job()
+        mock_client.SparkJobService.create_spark_job.return_value = returned_job
+
+        result = create_spark_job(
+            namespace="my-ns",
+            main_application_file="s3://bucket/script.py",
+        )
+
+        assert result == returned_job
+        call_kwargs = mock_client.SparkJobService.create_spark_job.call_args
+        spark_job = call_kwargs.kwargs["spark_job"]
+        assert spark_job.spec.main_class == ""
+        assert list(spark_job.spec.main_args) == []
+        assert spark_job.spec.driver.pod.resource.cpu == 0
+        assert spark_job.spec.driver.pod.resource.memory == ""
+
+
+class TestPollSparkJob:
+    @patch("michelangelo.uniflow.core.lib.spark.job.time")
+    @patch("michelangelo.uniflow.core.lib.spark.job.APIClient")
+    def test_succeeds_immediately(self, mock_client, mock_time):
+        mock_time.time.side_effect = [0.0, 0.1]
+        succeeded_job = _make_spark_job(conditions=[_succeeded_condition()])
+        mock_client.SparkJobService.get_spark_job.return_value = succeeded_job
+
+        result = poll_spark_job("test-ns", "test-job")
+
+        assert result["metadata"]["name"] == "test-job"
+        assert (
+            result["status"]["status_conditions"][0]["type"] == SUCCEEDED_CONDITION_TYPE
+        )
+
+    @patch("michelangelo.uniflow.core.lib.spark.job.time")
+    @patch("michelangelo.uniflow.core.lib.spark.job.APIClient")
+    def test_polls_then_succeeds(self, mock_client, mock_time):
+        mock_time.time.side_effect = [0.0, 1.0, 2.0]
+        running_job = _make_spark_job()
+        succeeded_job = _make_spark_job(conditions=[_succeeded_condition()])
+        mock_client.SparkJobService.get_spark_job.side_effect = [
+            running_job,
+            succeeded_job,
+        ]
+
+        result = poll_spark_job("test-ns", "test-job", timeout_seconds=60)
+
+        assert (
+            result["status"]["status_conditions"][0]["type"] == SUCCEEDED_CONDITION_TYPE
+        )
+        assert mock_client.SparkJobService.get_spark_job.call_count == 2
+
+    @patch("michelangelo.uniflow.core.lib.spark.job.time")
+    @patch("michelangelo.uniflow.core.lib.spark.job.APIClient")
+    def test_raises_on_killed(self, mock_client, mock_time):
+        mock_time.time.side_effect = [0.0, 0.1]
+        killed_job = _make_spark_job(conditions=[_killed_condition()])
+        mock_client.SparkJobService.get_spark_job.return_value = killed_job
+
+        with pytest.raises(RuntimeError, match="was killed"):
+            poll_spark_job("test-ns", "test-job")
+
+    @patch("michelangelo.uniflow.core.lib.spark.job.time")
+    @patch("michelangelo.uniflow.core.lib.spark.job.APIClient")
+    def test_raises_on_failed(self, mock_client, mock_time):
+        mock_time.time.side_effect = [0.0, 0.1]
+        failed_job = _make_spark_job(conditions=[_failed_condition()])
+        mock_client.SparkJobService.get_spark_job.return_value = failed_job
+
+        with pytest.raises(RuntimeError, match="failed"):
+            poll_spark_job("test-ns", "test-job")
+
+    @patch("michelangelo.uniflow.core.lib.spark.job.time")
+    @patch("michelangelo.uniflow.core.lib.spark.job.APIClient")
+    def test_raises_on_timeout(self, mock_client, mock_time):
+        mock_time.time.side_effect = [0.0, 100.0]
+        mock_client.SparkJobService.get_spark_job.return_value = _make_spark_job()
+
+        with pytest.raises(TimeoutError, match="timed out"):
+            poll_spark_job("test-ns", "test-job", timeout_seconds=10)
+
+    @patch("michelangelo.uniflow.core.lib.spark.job.time")
+    @patch("michelangelo.uniflow.core.lib.spark.job.APIClient")
+    def test_raises_on_not_found(self, mock_client, mock_time):
+        mock_time.time.side_effect = [0.0, 0.1]
+        rpc_error = grpc.RpcError()
+        rpc_error.code = lambda: grpc.StatusCode.NOT_FOUND
+        rpc_error.details = lambda: "not found"
+        mock_client.SparkJobService.get_spark_job.side_effect = rpc_error
+
+        with pytest.raises(RuntimeError, match="not found"):
+            poll_spark_job("test-ns", "test-job")
+
+    @patch("michelangelo.uniflow.core.lib.spark.job.time")
+    @patch("michelangelo.uniflow.core.lib.spark.job.APIClient")
+    def test_retries_on_transient_error(self, mock_client, mock_time):
+        mock_time.time.side_effect = [0.0, 1.0, 2.0]
+        rpc_error = grpc.RpcError()
+        rpc_error.code = lambda: grpc.StatusCode.UNAVAILABLE
+        rpc_error.details = lambda: "unavailable"
+        succeeded_job = _make_spark_job(conditions=[_succeeded_condition()])
+        mock_client.SparkJobService.get_spark_job.side_effect = [
+            rpc_error,
+            succeeded_job,
+        ]
+
+        result = poll_spark_job("test-ns", "test-job", timeout_seconds=60)
+        assert result["metadata"]["name"] == "test-job"
+
+    @patch("michelangelo.uniflow.core.lib.spark.job.time")
+    @patch("michelangelo.uniflow.core.lib.spark.job.APIClient")
+    def test_raises_on_permission_denied(self, mock_client, mock_time):
+        mock_time.time.side_effect = [0.0, 0.1]
+        rpc_error = grpc.RpcError()
+        rpc_error.code = lambda: grpc.StatusCode.PERMISSION_DENIED
+        rpc_error.details = lambda: "permission denied"
+        mock_client.SparkJobService.get_spark_job.side_effect = rpc_error
+
+        with pytest.raises(RuntimeError, match="permission denied"):
+            poll_spark_job("test-ns", "test-job")
+
+
+class TestCreateJob:
+    @patch("michelangelo.uniflow.core.lib.spark.job.APIClient")
+    def test_returns_dict(self, mock_client):
+        returned_job = _make_spark_job(conditions=[_succeeded_condition()])
+        mock_client.SparkJobService.create_spark_job.return_value = returned_job
+
+        result = create_job(
+            namespace="my-ns",
+            main_application_file="s3://bucket/app.jar",
+            main_class="com.example.Main",
+        )
+
+        assert isinstance(result, dict)
+        assert result["metadata"]["name"] == "test-job"
+        assert result["metadata"]["namespace"] == "test-ns"
+
+
+class TestSensorJob:
+    @patch("michelangelo.uniflow.core.lib.spark.job.time")
+    @patch("michelangelo.uniflow.core.lib.spark.job.APIClient")
+    def test_default_timeout(self, mock_client, mock_time):
+        mock_time.time.side_effect = [0.0, 0.1]
+        succeeded_job = _make_spark_job(conditions=[_succeeded_condition()])
+        mock_client.SparkJobService.get_spark_job.return_value = succeeded_job
+
+        result = sensor_job(namespace="test-ns", name="test-job")
+
+        assert result["metadata"]["name"] == "test-job"
+
+    @patch("michelangelo.uniflow.core.lib.spark.job.time")
+    @patch("michelangelo.uniflow.core.lib.spark.job.APIClient")
+    def test_custom_timeout(self, mock_client, mock_time):
+        mock_time.time.side_effect = [0.0, 0.1]
+        succeeded_job = _make_spark_job(conditions=[_succeeded_condition()])
+        mock_client.SparkJobService.get_spark_job.return_value = succeeded_job
+
+        result = sensor_job(
+            namespace="test-ns",
+            name="test-job",
+            timeout_seconds=3600,
+            poll_seconds=5,
+        )
+
+        assert result["metadata"]["name"] == "test-job"

--- a/python/tests/uniflow/core/test_spark_job.py
+++ b/python/tests/uniflow/core/test_spark_job.py
@@ -454,19 +454,24 @@ class TestRunSparkJob:
 
     @patch("michelangelo.uniflow.core.lib.spark.job.time")
     @patch("michelangelo.uniflow.core.lib.spark.job.APIClient")
-    def test_retry_stops_on_kill(self, mock_client, mock_time):
-        """Verify run_spark_job does not retry when job is killed."""
-        mock_time.time.side_effect = [0.0, 0.1]
+    def test_retry_on_kill_then_succeed(self, mock_client, mock_time):
+        """Verify run_spark_job retries on killed job (infra-driven, not deliberate)."""
+        mock_time.time.side_effect = [0.0, 0.1, 0.0, 0.1]
         created_job = _make_spark_job()
         killed_job = _make_spark_job(conditions=[_killed_condition()])
+        succeeded_job = _make_spark_job(conditions=[_succeeded_condition()])
         mock_client.SparkJobService.create_spark_job.return_value = created_job
-        mock_client.SparkJobService.get_spark_job.return_value = killed_job
+        mock_client.SparkJobService.get_spark_job.side_effect = [
+            killed_job,
+            succeeded_job,
+        ]
 
-        with pytest.raises(SparkJobKilledError, match="was killed"):
-            run_spark_job(
-                namespace="my-ns",
-                main_application_file="s3://bucket/app.jar",
-                retry_attempts=2,
-            )
+        result = run_spark_job(
+            namespace="my-ns",
+            main_application_file="s3://bucket/app.jar",
+            retry_attempts=1,
+        )
 
-        assert mock_client.SparkJobService.create_spark_job.call_count == 1
+        assert result["metadata"]["name"] == "test-job"
+        assert mock_client.SparkJobService.create_spark_job.call_count == 2
+        assert mock_client.SparkJobService.get_spark_job.call_count == 2

--- a/python/tests/uniflow/core/test_spark_job.py
+++ b/python/tests/uniflow/core/test_spark_job.py
@@ -22,6 +22,7 @@ from michelangelo.gen.k8s.io.apimachinery.pkg.apis.meta.v1.generated_pb2 import 
 from michelangelo.uniflow.core.lib.spark.job import (
     KILLED_CONDITION_TYPE,
     SUCCEEDED_CONDITION_TYPE,
+    SparkJobKilledError,
     _spark_job_to_dict,
     create_job,
     create_spark_job,
@@ -207,12 +208,12 @@ class TestPollSparkJob:
     @patch("michelangelo.uniflow.core.lib.spark.job.time")
     @patch("michelangelo.uniflow.core.lib.spark.job.APIClient")
     def test_raises_on_killed(self, mock_client, mock_time):
-        """Verify RuntimeError is raised when job has Killed condition."""
+        """Verify SparkJobKilledError is raised when job has Killed condition."""
         mock_time.time.side_effect = [0.0, 0.1]
         killed_job = _make_spark_job(conditions=[_killed_condition()])
         mock_client.SparkJobService.get_spark_job.return_value = killed_job
 
-        with pytest.raises(RuntimeError, match="was killed"):
+        with pytest.raises(SparkJobKilledError, match="was killed"):
             poll_spark_job("test-ns", "test-job")
 
     @patch("michelangelo.uniflow.core.lib.spark.job.time")
@@ -450,3 +451,22 @@ class TestRunSparkJob:
             )
 
         assert mock_client.SparkJobService.create_spark_job.call_count == 2
+
+    @patch("michelangelo.uniflow.core.lib.spark.job.time")
+    @patch("michelangelo.uniflow.core.lib.spark.job.APIClient")
+    def test_retry_stops_on_kill(self, mock_client, mock_time):
+        """Verify run_spark_job does not retry when job is killed."""
+        mock_time.time.side_effect = [0.0, 0.1]
+        created_job = _make_spark_job()
+        killed_job = _make_spark_job(conditions=[_killed_condition()])
+        mock_client.SparkJobService.create_spark_job.return_value = created_job
+        mock_client.SparkJobService.get_spark_job.return_value = killed_job
+
+        with pytest.raises(SparkJobKilledError, match="was killed"):
+            run_spark_job(
+                namespace="my-ns",
+                main_application_file="s3://bucket/app.jar",
+                retry_attempts=2,
+            )
+
+        assert mock_client.SparkJobService.create_spark_job.call_count == 1

--- a/python/tests/uniflow/core/test_spark_job.py
+++ b/python/tests/uniflow/core/test_spark_job.py
@@ -74,7 +74,10 @@ def _failed_condition() -> Condition:
 
 
 class TestSparkJobToDict:
+    """Tests for _spark_job_to_dict conversion helper."""
+
     def test_basic_conversion(self):
+        """Verify SparkJob proto converts to dict with metadata and conditions."""
         job = _make_spark_job(conditions=[_succeeded_condition()])
         result = _spark_job_to_dict(job)
 
@@ -89,14 +92,18 @@ class TestSparkJobToDict:
         )
 
     def test_empty_conditions(self):
+        """Verify conversion handles a job with no status conditions."""
         job = _make_spark_job()
         result = _spark_job_to_dict(job)
         assert result["status"]["status_conditions"] == []
 
 
 class TestCreateSparkJob:
+    """Tests for create_spark_job internal helper."""
+
     @patch("michelangelo.uniflow.core.lib.spark.job.APIClient")
     def test_creates_job_with_all_fields(self, mock_client):
+        """Verify all SparkJobSpec fields are set correctly on the proto."""
         returned_job = _make_spark_job()
         mock_client.SparkJobService.create_spark_job.return_value = returned_job
 
@@ -138,6 +145,7 @@ class TestCreateSparkJob:
 
     @patch("michelangelo.uniflow.core.lib.spark.job.APIClient")
     def test_creates_job_minimal_fields(self, mock_client):
+        """Verify job creation works with only required fields."""
         returned_job = _make_spark_job()
         mock_client.SparkJobService.create_spark_job.return_value = returned_job
 
@@ -156,9 +164,12 @@ class TestCreateSparkJob:
 
 
 class TestPollSparkJob:
+    """Tests for poll_spark_job internal helper."""
+
     @patch("michelangelo.uniflow.core.lib.spark.job.time")
     @patch("michelangelo.uniflow.core.lib.spark.job.APIClient")
     def test_succeeds_immediately(self, mock_client, mock_time):
+        """Verify polling returns on first successful status check."""
         mock_time.time.side_effect = [0.0, 0.1]
         succeeded_job = _make_spark_job(conditions=[_succeeded_condition()])
         mock_client.SparkJobService.get_spark_job.return_value = succeeded_job
@@ -173,6 +184,7 @@ class TestPollSparkJob:
     @patch("michelangelo.uniflow.core.lib.spark.job.time")
     @patch("michelangelo.uniflow.core.lib.spark.job.APIClient")
     def test_polls_then_succeeds(self, mock_client, mock_time):
+        """Verify polling retries when job is still running, then returns on success."""
         mock_time.time.side_effect = [0.0, 1.0, 2.0]
         running_job = _make_spark_job()
         succeeded_job = _make_spark_job(conditions=[_succeeded_condition()])
@@ -191,6 +203,7 @@ class TestPollSparkJob:
     @patch("michelangelo.uniflow.core.lib.spark.job.time")
     @patch("michelangelo.uniflow.core.lib.spark.job.APIClient")
     def test_raises_on_killed(self, mock_client, mock_time):
+        """Verify RuntimeError is raised when job has Killed condition."""
         mock_time.time.side_effect = [0.0, 0.1]
         killed_job = _make_spark_job(conditions=[_killed_condition()])
         mock_client.SparkJobService.get_spark_job.return_value = killed_job
@@ -201,6 +214,7 @@ class TestPollSparkJob:
     @patch("michelangelo.uniflow.core.lib.spark.job.time")
     @patch("michelangelo.uniflow.core.lib.spark.job.APIClient")
     def test_raises_on_failed(self, mock_client, mock_time):
+        """Verify RuntimeError is raised when Succeeded condition is FALSE."""
         mock_time.time.side_effect = [0.0, 0.1]
         failed_job = _make_spark_job(conditions=[_failed_condition()])
         mock_client.SparkJobService.get_spark_job.return_value = failed_job
@@ -211,6 +225,7 @@ class TestPollSparkJob:
     @patch("michelangelo.uniflow.core.lib.spark.job.time")
     @patch("michelangelo.uniflow.core.lib.spark.job.APIClient")
     def test_raises_on_timeout(self, mock_client, mock_time):
+        """Verify TimeoutError is raised when polling exceeds timeout."""
         mock_time.time.side_effect = [0.0, 100.0]
         mock_client.SparkJobService.get_spark_job.return_value = _make_spark_job()
 
@@ -220,6 +235,7 @@ class TestPollSparkJob:
     @patch("michelangelo.uniflow.core.lib.spark.job.time")
     @patch("michelangelo.uniflow.core.lib.spark.job.APIClient")
     def test_raises_on_not_found(self, mock_client, mock_time):
+        """Verify RuntimeError is raised on gRPC NOT_FOUND."""
         mock_time.time.side_effect = [0.0, 0.1]
         rpc_error = grpc.RpcError()
         rpc_error.code = lambda: grpc.StatusCode.NOT_FOUND
@@ -232,6 +248,7 @@ class TestPollSparkJob:
     @patch("michelangelo.uniflow.core.lib.spark.job.time")
     @patch("michelangelo.uniflow.core.lib.spark.job.APIClient")
     def test_retries_on_transient_error(self, mock_client, mock_time):
+        """Verify polling continues past transient gRPC UNAVAILABLE errors."""
         mock_time.time.side_effect = [0.0, 1.0, 2.0]
         rpc_error = grpc.RpcError()
         rpc_error.code = lambda: grpc.StatusCode.UNAVAILABLE
@@ -248,6 +265,7 @@ class TestPollSparkJob:
     @patch("michelangelo.uniflow.core.lib.spark.job.time")
     @patch("michelangelo.uniflow.core.lib.spark.job.APIClient")
     def test_raises_on_permission_denied(self, mock_client, mock_time):
+        """Verify RuntimeError is raised on gRPC PERMISSION_DENIED."""
         mock_time.time.side_effect = [0.0, 0.1]
         rpc_error = grpc.RpcError()
         rpc_error.code = lambda: grpc.StatusCode.PERMISSION_DENIED
@@ -259,8 +277,11 @@ class TestPollSparkJob:
 
 
 class TestCreateJob:
+    """Tests for create_job star_plugin wrapper."""
+
     @patch("michelangelo.uniflow.core.lib.spark.job.APIClient")
     def test_returns_dict(self, mock_client):
+        """Verify create_job returns a dict with metadata and status."""
         returned_job = _make_spark_job(conditions=[_succeeded_condition()])
         mock_client.SparkJobService.create_spark_job.return_value = returned_job
 
@@ -276,9 +297,12 @@ class TestCreateJob:
 
 
 class TestSensorJob:
+    """Tests for sensor_job star_plugin wrapper."""
+
     @patch("michelangelo.uniflow.core.lib.spark.job.time")
     @patch("michelangelo.uniflow.core.lib.spark.job.APIClient")
     def test_default_timeout(self, mock_client, mock_time):
+        """Verify sensor_job uses default timeout when timeout_seconds is 0."""
         mock_time.time.side_effect = [0.0, 0.1]
         succeeded_job = _make_spark_job(conditions=[_succeeded_condition()])
         mock_client.SparkJobService.get_spark_job.return_value = succeeded_job
@@ -290,6 +314,7 @@ class TestSensorJob:
     @patch("michelangelo.uniflow.core.lib.spark.job.time")
     @patch("michelangelo.uniflow.core.lib.spark.job.APIClient")
     def test_custom_timeout(self, mock_client, mock_time):
+        """Verify sensor_job passes custom timeout and poll interval through."""
         mock_time.time.side_effect = [0.0, 0.1]
         succeeded_job = _make_spark_job(conditions=[_succeeded_condition()])
         mock_client.SparkJobService.get_spark_job.return_value = succeeded_job

--- a/python/tests/uniflow/core/test_spark_transpile.py
+++ b/python/tests/uniflow/core/test_spark_transpile.py
@@ -1,0 +1,32 @@
+"""Tests that run_spark_job transpiles correctly inside a @workflow body."""
+
+import tests.uniflow.core.test_spark_transpile_workflow as wf_module
+from michelangelo.uniflow.core.build import build
+
+
+class TestRunSparkJobTranspilation:
+    """Verify @star_plugin('spark.run_job') rewrites to __spark__.run_job."""
+
+    def test_transpiles_to_spark_run_job(self):
+        """Verify run_spark_job is rewritten to __spark__.run_job in Starlark output."""
+        package = build(wf_module.spark_pi_workflow)
+
+        main_content = package.files[package.main_file]
+        decoded = main_content.decode("utf-8")
+
+        assert "__spark__.run_job(" in decoded
+        assert "load('@plugin', __spark__='spark')" in decoded
+        assert "run_spark_job" not in decoded
+
+    def test_preserves_keyword_arguments(self):
+        """Verify all keyword arguments are preserved in the transpiled output."""
+        package = build(wf_module.spark_pi_workflow)
+
+        main_content = package.files[package.main_file]
+        decoded = main_content.decode("utf-8")
+
+        assert "namespace='default'" in decoded
+        assert "main_class='org.apache.spark.examples.SparkPi'" in decoded
+        assert "main_application_file=" in decoded
+        assert "image='apache/spark:3.5.5'" in decoded
+        assert "driver_cpu=1" in decoded

--- a/python/tests/uniflow/core/test_spark_transpile_workflow.py
+++ b/python/tests/uniflow/core/test_spark_transpile_workflow.py
@@ -3,6 +3,7 @@
 Used to verify the transpiler rewrites run_spark_job to __spark__.run_job.
 """
 
+import michelangelo.uniflow.core as uniflow
 from michelangelo.uniflow.core import workflow
 from michelangelo.uniflow.core.lib.spark.job import run_spark_job
 
@@ -22,3 +23,8 @@ def spark_pi_workflow():
         executor_memory="1g",
         executor_instances=1,
     )
+
+
+if __name__ == "__main__":
+    ctx = uniflow.create_context()
+    ctx.run(spark_pi_workflow)

--- a/python/tests/uniflow/core/test_spark_transpile_workflow.py
+++ b/python/tests/uniflow/core/test_spark_transpile_workflow.py
@@ -1,0 +1,24 @@
+"""Minimal test workflow that calls run_spark_job directly in a @workflow body.
+
+Used to verify the transpiler rewrites run_spark_job to __spark__.run_job.
+"""
+
+from michelangelo.uniflow.core import workflow
+from michelangelo.uniflow.core.lib.spark.job import run_spark_job
+
+
+@workflow()
+def spark_pi_workflow():
+    """Submit SparkPi and wait for completion."""
+    return run_spark_job(
+        namespace="default",
+        main_application_file="local:///opt/spark/examples/jars/spark-examples.jar",
+        main_class="org.apache.spark.examples.SparkPi",
+        args=["2"],
+        image="apache/spark:3.5.5",
+        driver_cpu=1,
+        driver_memory="1g",
+        executor_cpu=1,
+        executor_memory="1g",
+        executor_instances=1,
+    )


### PR DESCRIPTION
## Summary

Adds `run_spark_job()`, a new Uniflow function callable directly inside a `@workflow()` body (no `@task`/`TaskConfig` wrapper) for running custom Spark entrypoints -- a Scala/JVM jar with a `main_class`, or a standalone PySpark script -- through Uniflow without a Python wrapper function.

- **Python** (`python/michelangelo/uniflow/core/lib/spark/job.py`): `run_spark_job()`, `@star_plugin("spark.run_job")`-bound, composing `create_spark_job()`/`poll_spark_job()` for local execution. Also exposes lower-level `create_job()`/`sensor_job()` builtins.
- **Go** (`go/worker/plugins/spark/starlark_module.go`): new combined `run_job` Starlark builtin backing the remote/transpiled path, composing the existing `CreateSparkJob`/`SensorSparkJob` Cadence activities (refactored into shared `doCreateJob`/`doSensorJob` helpers also used by the existing `create_job`/`sensor_job` builtins -- their behavior is unchanged).
- **`retry_attempts`**: both sides support retrying on any non-succeeded terminal state (Failed or Killed) -- Killed is retried because it's commonly caused by infra instability (node preemption, resource pressure), not deliberate cancellation. Deliberate cancellation is handled separately via `doSensorJob`'s cancellation path, which never reaches the retry loop.
- **Docs**: `docs/user-guides/ml-pipelines/custom-spark-entrypoints.md` -- when to use `run_spark_job()` vs `SparkTask`, the job-status-only return trade-off (no typed Uniflow I/O passthrough), full parameter reference, and retry semantics.

No new CRDs, gRPC services, or REST endpoints. `SparkTask` is unaffected.

Full design writeup: RFC #15 (michelangelo-ai/enhancements). Tracking issue: #1463.

## Test plan

- [x] `go build ./worker/plugins/spark/...` -- clean
- [x] `go vet ./worker/plugins/spark/...` -- clean
- [x] `go test ./worker/plugins/spark/... -count=1 -v` -- 6/6 pass
- [x] `pytest tests/uniflow/core/test_spark_job.py -v` -- 22/22 pass
- [x] `ruff check` on changed Python -- clean
- [x] End-to-end sandbox validation on k3d/Cadence: an example `@workflow()` calling `run_spark_job()` directly (no `@task`) transpiles correctly, registers via `ma pipeline apply`, and dispatches through Cadence to a real `SparkApplication` that completes successfully (`Pi is roughly 3.14...`)
- [x] Zero internal-domain references