### PR TITLE
Add examples gallery page with all 9 working examples

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -17,6 +17,7 @@ Ready to get hands-on? Follow these guides in order. You'll have a working local
 
 1. **[Sandbox Setup](./sandbox-setup.md)** — Set up a local Michelangelo cluster with all services running (~20 min)
 2. **[Getting Started with Pipelines](../user-guides/getting-started/getting-started.md)** — Build and run your first ML pipeline (~30 min)
+3. **[Browse Examples](../user-guides/examples/index.md)** — 9 end-to-end workflows: XGBoost, BERT, GPT fine-tuning, batch inference, and more
 
 ### Reference
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -38,7 +38,7 @@ Get a local environment running and build an end-to-end ML pipeline.
 
 - **[Sandbox Setup](./getting-started/sandbox-setup.md)** — Set up a local Michelangelo cluster (~20 min)
 - **[Getting Started with Pipelines](./user-guides/getting-started/getting-started.md)** — Build your first pipeline from scratch (~30 min)
-- **[Example Projects](https://github.com/michelangelo-ai/michelangelo/tree/main/python/examples)** — California Housing, BERT text classification, GPT fine-tuning, and more
+- **[Example Projects](./user-guides/examples/index.md)** — 9 end-to-end workflows: XGBoost, BERT, GPT fine-tuning, batch inference, and more
 
 ### I'm deploying or operating the platform
 

--- a/docs/user-guides/examples/index.md
+++ b/docs/user-guides/examples/index.md
@@ -63,5 +63,5 @@ See each example's README for specific prerequisites and run instructions.
 ## What's Next?
 
 - **New to Michelangelo?** Start with [California Housing (XGBoost)](https://github.com/michelangelo-ai/michelangelo/tree/main/python/examples/pipelines/california_housing_xgb) — it covers the full pipeline end-to-end
-- **Want to understand the framework?** Read [Getting Started with Pipelines](./getting-started/getting-started.md) for a guided walkthrough
-- **Ready to deploy?** See [Deploy a Model](./train-and-deploy-models/deploy-a-model.md) after training
+- **Want to understand the framework?** Read [Getting Started with Pipelines](../getting-started/getting-started.md) for a guided walkthrough
+- **Ready to deploy?** See [Deploy a Model](../train-and-deploy-models/deploy-a-model.md) after training

--- a/docs/user-guides/examples/index.md
+++ b/docs/user-guides/examples/index.md
@@ -1,0 +1,67 @@
+---
+sidebar_position: 5
+sidebar_label: "Examples"
+---
+
+# Examples
+
+End-to-end ML pipeline examples covering training, inference, recommendation systems, and model packaging. Each example is a complete, working workflow you can run locally or on a Michelangelo cluster.
+
+All examples live in [`python/examples/`](https://github.com/michelangelo-ai/michelangelo/tree/main/python/examples).
+
+## By Use Case
+
+### Training & Fine-tuning
+
+| Example | Description | Runtime | Difficulty |
+|---------|-------------|---------|------------|
+| [California Housing (XGBoost)](https://github.com/michelangelo-ai/michelangelo/tree/main/python/examples/pipelines/california_housing_xgb) | Full pipeline — feature prep, Spark preprocessing, distributed XGBoost training, and pusher step that exports model + eval report to storage and registry. | Ray + Spark | Beginner |
+| [BERT Text Classification](https://github.com/michelangelo-ai/michelangelo/tree/main/python/examples/bert_cola) | Fine-tune BERT for linguistic acceptability classification on the CoLA benchmark (GLUE). Uses HuggingFace Transformers with distributed Ray training. | Ray | Intermediate |
+| [GPT Fine-tuning with LoRA](https://github.com/michelangelo-ai/michelangelo/tree/main/python/examples/gpt_oss_20b_finetune) | Parameter-efficient fine-tuning using LoRA (1.29% trainable params) on the Stanford Alpaca instruction-following dataset. Includes perplexity and generation quality evaluation. | Ray | Advanced |
+| [Nomic AI Embedding Training](https://github.com/michelangelo-ai/michelangelo/tree/main/python/examples/nomic_ai) | Train a long-context Nomic BERT model (2048 tokens) on WikiText using PyTorch Lightning with distributed Ray execution. | Ray | Intermediate |
+| [MovieLens Collaborative Filtering](https://github.com/michelangelo-ai/michelangelo/tree/main/python/examples/movielens) | Neural Collaborative Filtering on MovieLens-100k. Minimal smoke test for the `LightningTrainer` SDK — trains on CPU with a single Ray Train worker. | Ray | Beginner |
+
+### Recommendation Systems
+
+| Example | Description | Runtime | Difficulty |
+|---------|-------------|---------|------------|
+| [Amazon Books Recommendation](https://github.com/michelangelo-ai/michelangelo/tree/main/python/examples/amazon_books_qwen) | Dual-encoder recommendation system using Qwen-based architecture for Amazon Books. Demonstrates Chronon feature engineering on Spark and distributed Ray training. | Ray + Spark | Advanced |
+
+### Inference
+
+| Example | Description | Runtime | Difficulty |
+|---------|-------------|---------|------------|
+| [HuggingFace Batch Inference](https://github.com/michelangelo-ai/michelangelo/tree/main/python/examples/llm_prediction) | Batch inference with two backends: HuggingFace Transformers (CPU/GPU) and vLLM (optimized GPU with tensor parallelism). Configurable sampling parameters (temperature, top-p, max tokens). | Ray | Intermediate |
+
+### Model Packaging
+
+| Example | Description | Runtime | Difficulty |
+|---------|-------------|---------|------------|
+| [Custom Model Packaging](https://github.com/michelangelo-ai/michelangelo/tree/main/python/examples/model_manager/simple_custom) | Package a custom model with `CustomTritonPackager` for Triton Inference Server. Demonstrates the `Model` interface (save/load/predict) with raw and deployable packaging modes. | — | Advanced |
+| [Custom PyTorch Model Packaging](https://github.com/michelangelo-ai/michelangelo/tree/main/python/examples/model_manager/simple_custom_torch) | Package a PyTorch model (`TorchLinearModel`) with `CustomTritonPackager`. Uses numpy arrays for I/O (as required by the Model interface) with internal torch conversion. | — | Advanced |
+
+## Running Examples
+
+Most examples follow the same pattern:
+
+```bash
+cd python
+poetry install --extras "trainer example"
+PYTHONPATH=. poetry run python examples/<example_dir>/<script>.py
+```
+
+For remote execution on a Michelangelo cluster, append `remote-run`:
+
+```bash
+PYTHONPATH=. poetry run python examples/pipelines/california_housing_xgb/california_housing_xgb.py remote-run \
+  --project ma-examples \
+  --image ghcr.io/michelangelo-ai/examples:main
+```
+
+See each example's README for specific prerequisites and run instructions.
+
+## What's Next?
+
+- **New to Michelangelo?** Start with [California Housing (XGBoost)](https://github.com/michelangelo-ai/michelangelo/tree/main/python/examples/pipelines/california_housing_xgb) — it covers the full pipeline end-to-end
+- **Want to understand the framework?** Read [Getting Started with Pipelines](./getting-started/getting-started.md) for a guided walkthrough
+- **Ready to deploy?** See [Deploy a Model](./train-and-deploy-models/deploy-a-model.md) after training

--- a/docs/user-guides/index.md
+++ b/docs/user-guides/index.md
@@ -47,9 +47,4 @@ New to Michelangelo? Follow this path:
 
 ## Examples
 
-| Example | Description |
-|---------|-------------|
-| [California Housing Regression](https://github.com/michelangelo-ai/michelangelo/tree/main/python/examples/pipelines/california_housing_xgb) | Predict house prices with XGBoost |
-| [BERT Text Classification](https://github.com/michelangelo-ai/michelangelo/tree/main/python/examples/bert_cola) | Classify text with pre-trained transformers |
-| [GPT Fine-tuning](https://github.com/michelangelo-ai/michelangelo/tree/main/python/examples/gpt_oss_20b_finetune) | Fine-tune large language models with LoRA |
-| [Amazon Books Recommendation](https://github.com/michelangelo-ai/michelangelo/tree/main/python/examples/amazon_books_qwen) | Dual-encoder recommendation system |
+Browse the full **[Examples Gallery](./examples/index.md)** — 9 end-to-end workflows covering training, inference, recommendation systems, and model packaging, organized by use case with difficulty levels.


### PR DESCRIPTION
## Summary

- Create a dedicated **Examples Gallery** page (`docs/user-guides/examples/index.md`) that surfaces all 9 working examples organized by use case (training, recommendation, inference, model packaging) with descriptions, runtime tags, and difficulty levels
- Replace the partial 4-example table in `docs/user-guides/index.md` with a link to the gallery
- Update Getting Started index and Welcome page to link to the gallery instead of the raw GitHub tree

## Why

Previously only 4 of 9 examples were linked from the docs. The other 5 (HuggingFace batch inference, MovieLens, Nomic AI embeddings, and two model packaging examples) were invisible to users. Ray and Flyte both use examples galleries as primary discovery paths for new users.

## Files changed

- `docs/user-guides/examples/index.md` — New gallery page with all 9 examples
- `docs/user-guides/index.md` — Replace partial table with gallery link
- `docs/getting-started/index.md` — Add gallery link to "I want to set up and start building"
- `docs/intro.md` — Point "Example Projects" to gallery instead of GitHub tree

## Test plan

- [ ] Verify the gallery page renders correctly on the Docusaurus site
- [ ] Confirm all 9 example links resolve to the correct GitHub directories
- [ ] Check that the sidebar shows "Examples" under User Guides
- [ ] Verify links from Welcome, Getting Started, and User Guides index all work