### PR TITLE
chore(worker): remove stale implementation TODOs in ray/spark starlark plugins

### DIFF
--- a/go/worker/plugins/ray/starlark_module.go
+++ b/go/worker/plugins/ray/starlark_module.go
@@ -18,8 +18,6 @@ import (
 	v2pb "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
 )
 
-// TODO(#559): andrii: implement Ray starlark plugin here
-
 var _ starlark.HasAttrs = (*module)(nil)
 var poll int64 = 10
 

--- a/go/worker/plugins/spark/starlark_module.go
+++ b/go/worker/plugins/spark/starlark_module.go
@@ -32,8 +32,6 @@ const (
 	maxJobSensorRetries = 100
 )
 
-// TODO(#561): andrii: implement Spark starlark plugin here
-
 var _ starlark.HasAttrs = (*module)(nil)
 var poll int64 = 10
 


### PR DESCRIPTION
## Summary
- Removes two leftover `TODO(#559)`/`TODO(#561)` "implement plugin here" comments in the Ray and Spark starlark plugins — both plugins are already fully implemented, so the comments no longer reflect reality.

## Evidence
- `go/worker/plugins/ray/starlark_module.go` (263 lines): `createCluster` (create → poll readiness via sensor → terminate on failure), `createJob` (submit → sensor), `terminateCluster` — all wired to real activities (`ray.Activities.CreateRayCluster`, `SensorRayClusterReadiness`, `CreateRayJob`, `TerminateCluster`).
- `go/worker/plugins/spark/starlark_module.go` (213 lines): `createJob` (submits via `spark.Activities.CreateSparkJob`), `sensorJob` (polls with retry, handles cancellation via `TerminateSparkJob`).

Neither file contains stub/not-implemented logic — this is a comment-only cleanup.

Closes #559
Closes #561

## Test plan
- [x] `go build ./worker/plugins/ray/... ./worker/plugins/spark/...` succeeds
- [x] Comment-only change, no behavior modified