### PR TITLE
fix(api/handler): status updates skip full-spec validation

### DIFF
--- a/go/api/handler/handler.go
+++ b/go/api/handler/handler.go
@@ -198,14 +198,6 @@ func (handler *apiHandler) UpdateStatus(ctx context.Context, obj ctrlRTClient.Ob
 	log, headers := initLogger(ctx, handler.logger, "UpdateStatus", obj.GetNamespace(), obj.GetName(), kind)
 	defer emitAPIMetrics("UpdateStatus", handler.metrics, log, start, kind, headers)
 
-	if handler.validationHandler != nil {
-		if err := handler.validationHandler.ValidateUpdate(obj); err != nil {
-			return err
-		}
-	} else if err := api.Validate(obj); err != nil {
-		return err
-	}
-
 	tmpObj, ok := obj.DeepCopyObject().(ctrlRTClient.Object)
 	if !ok {
 		return status.Errorf(codes.InvalidArgument, "object does not implement the controller-runtime client.Object interface")


### PR DESCRIPTION
## Summary

The Kubernetes `/status` subresource only writes the status fields — the API server discards any spec changes in a status update request. Re-running full object validation (including required spec fields) on a status-only write violates this contract: it rejects valid controller writes on objects whose specs are intentionally minimal.

Discovered when testing the revision controller against sandbox Revisions created with minimal specs (no required `spec.source`): the controller's status update was rejected even though the spec was never touched.

Spec fields are already validated on Create and Update. There is nothing new to validate on the status path.

## Test plan

Both phases use the same temporary echo handler (not committed): it clears `spec.source` before returning READY, which triggers the `source cannot be empty` validation error on the unpatched code path.

### Before (unpatched) — UpdateStatus rejected, Revision stuck in retry loop

```
kubectl apply -f - <<EOF
apiVersion: michelangelo.api/v2
kind: Revision
metadata:
  name: test-echo-before
  namespace: default
spec:
  source: "Unknown"
  baseType:
    apiVersion: michelangelo.api/v2
    kind: TestEcho
EOF
```

```
{"level":"info","logger":"echo-handler","msg":"clearing spec.source and setting revision to READY","name":"test-echo-before"}
{"level":"error","caller":"controller/controller.go:316","msg":"Reconciler error","controller":"revision","name":"test-echo-before","error":"update revision status default/test-echo-before: rpc error: code = InvalidArgument desc = spec.source cannot be empty"}
```

The Revision loops in exponential backoff — status can never be persisted because `UpdateStatus` re-validates the full spec.

### After (this PR) — UpdateStatus succeeds, Revision reaches READY → immutable → GC

```
kubectl apply -f - <<EOF
apiVersion: michelangelo.api/v2
kind: Revision
metadata:
  name: test-echo-after
  namespace: default
spec:
  source: "Unknown"
  baseType:
    apiVersion: michelangelo.api/v2
    kind: TestEcho
EOF
```

```
{"level":"info","logger":"echo-handler","msg":"clearing spec.source and setting revision to READY","name":"test-echo-after"}
{"level":"info","caller":"handler/handler.go:499","msg":"API UpdateStatus took 5 milli seconds","action":"UpdateStatus","namespace":"default","name":"test-echo-after","kind":"Revision"}
{"level":"info","caller":"revision/controller.go:76","msg":"revision in terminal state; marking immutable","controller":"revision","namespace-name":"default/test-echo-after","state":"REVISION_STATE_READY"}
{"level":"info","logger":"ingester.Revision","caller":"ingester/controller.go:349","msg":"Successfully moved immutable object to metadata storage only","namespace":"default","name":"test-echo-after"}
```

`UpdateStatus` returns in 5 ms. The fix removes the re-validation call; status writes succeed regardless of spec validity.

## Revert Plan
Revert this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
