### PR TITLE
Update to the license docs page formatting/nesting

### DIFF
--- a/docs/about/license.md
+++ b/docs/about/license.md
@@ -8,7 +8,7 @@ The source code in this repository is licensed under the Apache 2.0 License. See
 
 The documentation in this repository is licensed under the Creative Commons Attribution 4.0 International License. See below for the full license text.
 
-## Attribution 4.0 International
+## Creative Commons Attribution 4.0 International License
 
 By exercising the Licensed Rights (defined below), You accept and agree to be bound by the terms and conditions of this Creative Commons Attribution 4.0 International Public License ("Public License"). To the extent this Public License may be interpreted as a contract, You are granted the Licensed Rights in consideration of Your acceptance of these terms and conditions, and the Licensor grants You such rights in consideration of benefits the Licensor receives from making the Licensed Material available under these terms and conditions.
 
@@ -102,7 +102,7 @@ For the avoidance of doubt, this Section [4](https://creativecommons.org/licens
 3.  No term or condition of this Public License will be waived and no failure to comply consented to unless expressly agreed to by the Licensor.
 4.  Nothing in this Public License constitutes or may be interpreted as a limitation upon, or waiver of, any privileges and immunities that apply to the Licensor or You, including from the legal processes of any jurisdiction or authority.
 
-### Apache 2.0 License
+## Apache 2.0 License
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/


### PR DESCRIPTION
The Apache 2.0 license was wrongly nested under the CC license - this is now split out.

The title of the Creative Commons Attribution 4.0 International License wasn't included at the head of this section - this is now referenced.