### PR TITLE
Add eslint rule enforcing primary-export-first ordering

### DIFF
--- a/javascript/.claude/skills/ui-coding-principles/SKILL.md
+++ b/javascript/.claude/skills/ui-coding-principles/SKILL.md
@@ -28,12 +28,3 @@ The right amount of complexity is the minimum needed for the current task.
 
 - Only optimize with data justifying it — profile before changing anything
 - Unoptimized readable code is better than optimized unreadable code
-
-## Code Ordering Within a File
-
-Put the primary export first. Private helpers and implementation details should follow, not precede, the thing they support. Readers should see the main thing before the internals.
-
-The mechanical case — a helper function, arrow function, or class declared above the single primary export it supports — is enforced by `local/primary-export-first` (see `eslint-local-rules/primary-export-first.md`). That rule only fires on single-export files and only flags function-like helpers; it intentionally leaves two things to judgment:
-
-- **Files with multiple top-level exports** — there's no single "primary" to anchor ordering on, so use your own sense of what a reader should see first.
-- **Plain data constants** (object/array/string/number literals) placed above the export — these read more like configuration than "implementation details," so ordering them is a style call, not a lint violation.

--- a/javascript/.claude/skills/ui-coding-principles/SKILL.md
+++ b/javascript/.claude/skills/ui-coding-principles/SKILL.md
@@ -32,3 +32,8 @@ The right amount of complexity is the minimum needed for the current task.
 ## Code Ordering Within a File
 
 Put the primary export first. Private helpers and implementation details should follow, not precede, the thing they support. Readers should see the main thing before the internals.
+
+The mechanical case — a helper function, arrow function, or class declared above the single primary export it supports — is enforced by `local/primary-export-first` (see `eslint-local-rules/primary-export-first.md`). That rule only fires on single-export files and only flags function-like helpers; it intentionally leaves two things to judgment:
+
+- **Files with multiple top-level exports** — there's no single "primary" to anchor ordering on, so use your own sense of what a reader should see first.
+- **Plain data constants** (object/array/string/number literals) placed above the export — these read more like configuration than "implementation details," so ordering them is a style call, not a lint violation.

--- a/javascript/eslint-local-rules/__tests__/primary-export-first.test.js
+++ b/javascript/eslint-local-rules/__tests__/primary-export-first.test.js
@@ -1,0 +1,158 @@
+import { RuleTester } from 'eslint';
+import tseslint from 'typescript-eslint';
+
+import rule from '../primary-export-first.js';
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const tester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+    parser: tseslint.parser,
+  },
+});
+
+tester.run('primary-export-first', rule, {
+  valid: [
+    {
+      name: 'primary export first, helper function follows',
+      filename: 'row-summary.ts',
+      code: `export function RowSummary() { return formatLabel(); } function formatLabel() { return ''; }`,
+    },
+    {
+      name: 'primary export first, arrow helper follows',
+      filename: 'row-summary.ts',
+      code: `export const RowSummary = () => formatLabel(); const formatLabel = () => '';`,
+    },
+    {
+      name: 'no helpers, just the export',
+      filename: 'row-summary.ts',
+      code: `export function RowSummary() { return null; }`,
+    },
+    {
+      name: 'plain object constant before the export is not a helper function',
+      filename: 'row-summary.ts',
+      code: `const CONFIG = { max: 10 }; export function RowSummary() { return CONFIG.max; }`,
+    },
+    {
+      name: 'plain string constant before the export is not a helper function',
+      filename: 'row-summary.ts',
+      code: `const SUFFIX_DELIMITER = '::'; export function buildKey() { return SUFFIX_DELIMITER; }`,
+    },
+    {
+      name: 'plain array constant before the export is not a helper function',
+      filename: 'row-summary.ts',
+      code: `const TERMINATED_STATES = ['DONE', 'FAILED']; export function isTerminal(s) { return TERMINATED_STATES.includes(s); }`,
+    },
+    {
+      name: 'multiple top-level exports — no single primary to anchor on',
+      filename: 'multi.ts',
+      code: `function helper() { return ''; } export function A() { return helper(); } export function B() { return helper(); }`,
+    },
+    {
+      name: 'zero value exports — nothing to analyze',
+      filename: 'constants.ts',
+      code: `function helper() { return ''; } const X = helper();`,
+    },
+    {
+      name: 'index.ts is always skipped',
+      filename: 'index.ts',
+      code: `function helper() { return ''; } export function Anything() { return helper(); }`,
+    },
+    {
+      name: 'index.tsx is always skipped',
+      filename: 'index.tsx',
+      code: `function helper() { return null; } export function Anything() { return helper(); }`,
+    },
+    {
+      name: 'types.ts is always skipped',
+      filename: 'types.ts',
+      code: `function helper() { return ''; } export function Anything() { return helper(); }`,
+    },
+    {
+      name: 'styled-components.tsx is skipped',
+      filename: 'styled-components.tsx',
+      code: `function helper() { return null; } export const StyledRow = helper();`,
+    },
+    {
+      name: 'styled-components.ts is skipped',
+      filename: 'row-styled-components.ts',
+      code: `function helper() { return null; } export const styles = helper();`,
+    },
+    {
+      name: '.test.ts files are skipped',
+      filename: 'row-summary.test.ts',
+      code: `function helper() { return ''; } export function RowSummary() { return helper(); }`,
+    },
+    {
+      name: 'files under __tests__/ are skipped',
+      filename: 'some-dir/__tests__/row-summary.ts',
+      code: `function helper() { return ''; } export function RowSummary() { return helper(); }`,
+    },
+    {
+      name: '.d.ts files are skipped',
+      filename: 'row-summary.d.ts',
+      code: `function helper() { return ''; } export function RowSummary(): string;`,
+    },
+    {
+      name: 'non-ts/tsx files are skipped',
+      filename: 'row-summary.js.snap',
+      code: `function helper() { return ''; } export function RowSummary() { return helper(); }`,
+    },
+    {
+      name: 'forwardRef/HOC-wrapped export is skipped (CallExpression init)',
+      filename: 'row.tsx',
+      code: `function BaseRow() { return null; } export const Row = forwardRef(BaseRow);`,
+    },
+    {
+      name: 'class primary export is skipped',
+      filename: 'row-model.ts',
+      code: `function helper() { return ''; } export class RowModel {}`,
+    },
+    {
+      name: 'specifier-style export is skipped',
+      filename: 're-export.ts',
+      code: `function helper() { return ''; } const X = helper(); export { X };`,
+    },
+    {
+      name: 'type-only declarations never count as the helper or the export',
+      filename: 'row-summary.ts',
+      code: `type Config = { max: number }; export function RowSummary(c: Config) { return c.max; }`,
+    },
+  ],
+
+  invalid: [
+    {
+      name: 'function helper declared before the function export it supports',
+      filename: 'row-summary.ts',
+      code: `function formatLabel() { return ''; } export function RowSummary() { return formatLabel(); }`,
+      errors: [{ messageId: 'helperBeforePrimary' }],
+    },
+    {
+      name: 'arrow-function helper declared before the const export it supports',
+      filename: 'row-summary.ts',
+      code: `const formatLabel = () => ''; export const RowSummary = () => formatLabel();`,
+      errors: [{ messageId: 'helperBeforePrimary' }],
+    },
+    {
+      name: 'class expression helper declared before the export it supports',
+      filename: 'row-model.ts',
+      code: `const RowBase = class { toString() { return ''; } }; export const RowModel = () => new RowBase();`,
+      errors: [{ messageId: 'helperBeforePrimary' }],
+    },
+    {
+      name: 'multiple helper functions declared before the export — each flagged',
+      filename: 'row-summary.ts',
+      code: `function formatLabel() { return ''; } function formatValue() { return ''; } export function RowSummary() { return formatLabel() + formatValue(); }`,
+      errors: [{ messageId: 'helperBeforePrimary' }, { messageId: 'helperBeforePrimary' }],
+    },
+    {
+      name: 'plain constant is not flagged, but the function helper alongside it still is',
+      filename: 'row-summary.ts',
+      code: `const CONFIG = { max: 10 }; function formatLabel() { return ''; } export function RowSummary() { return formatLabel() + CONFIG.max; }`,
+      errors: [{ messageId: 'helperBeforePrimary' }],
+    },
+  ],
+});

--- a/javascript/eslint-local-rules/primary-export-first.js
+++ b/javascript/eslint-local-rules/primary-export-first.js
@@ -1,0 +1,169 @@
+/**
+ * @fileoverview Flags private helper functions declared before a file's primary export.
+ *
+ * Per "Code Ordering Within a File" in the ui-coding-principles skill: put the
+ * primary export first. Private helpers and implementation details should
+ * follow, not precede, the thing they support — readers should see the main
+ * thing before the internals.
+ *
+ * SCOPE (intentionally narrow):
+ *
+ * This only analyzes files with EXACTLY ONE top-level, non-type, value-level
+ * export, and only when that export is unambiguously a function declaration
+ * or a `const` bound directly to a function/arrow expression. Everything else
+ * is skipped without reporting anything, rather than guessing:
+ *
+ *   - Non ts/tsx files, `.d.ts` files
+ *   - `*.test.ts(x)`, anything under `__tests__/`
+ *   - `index.ts(x)`, `types.ts`
+ *   - `*styled-components.ts(x)`
+ *   - Files with zero or >1 top-level value exports
+ *   - `export { a, b }` specifier-style exports (including re-exports) and
+ *     `export default` — out of scope for this analysis
+ *   - A single export whose init is a class or a CallExpression (e.g.
+ *     `export const Foo = forwardRef(...)` or `memo(Foo)`) — unwrapping
+ *     HOC-wrapped exports is left for a follow-up
+ *
+ * Within an in-scope file, only FUNCTION-like preceding declarations are
+ * flagged: a top-level `function` declaration, or a top-level `const`/`let`
+ * whose initializer is a function expression, arrow function, or class.
+ * Plain object/array/literal-valued constants (e.g. a `SUFFIX_DELIMITER` or
+ * `TERMINATED_STATES` sitting near the imports) are a different, more
+ * debatable style question and are intentionally never flagged here.
+ */
+
+const isHelperDeclaration = (stmt) => {
+  if (stmt.type === 'FunctionDeclaration') return true;
+  if (stmt.type !== 'VariableDeclaration') return false;
+
+  return stmt.declarations.some((declarator) => {
+    const init = declarator.init;
+    if (!init) return false;
+    return (
+      init.type === 'FunctionExpression' ||
+      init.type === 'ArrowFunctionExpression' ||
+      init.type === 'ClassExpression'
+    );
+  });
+};
+
+const getHelperName = (stmt) => {
+  if (stmt.type === 'FunctionDeclaration') return stmt.id?.name ?? '(anonymous)';
+
+  const declarator = stmt.declarations.find((d) => {
+    const init = d.init;
+    return (
+      init?.type === 'FunctionExpression' ||
+      init?.type === 'ArrowFunctionExpression' ||
+      init?.type === 'ClassExpression'
+    );
+  });
+  return declarator?.id?.type === 'Identifier' ? declarator.id.name : '(anonymous)';
+};
+
+/** @type {import('eslint').Rule.RuleModule} */
+const rule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        "Flag private helper functions declared before a file's single primary export",
+      recommended: true,
+      url: 'https://github.com/michelangelo-ai/michelangelo/blob/main/javascript/eslint-local-rules/primary-export-first.md',
+    },
+    messages: {
+      helperBeforePrimary:
+        "'{{helperName}}' is defined before the primary export '{{primaryName}}'. " +
+        'Move private helpers after the thing they support (Code Ordering Within a File).',
+    },
+    schema: [],
+  },
+
+  create(context) {
+    const filename = context.getPhysicalFilename?.() ?? context.filename;
+    const basename = filename.split('/').pop() ?? '';
+
+    // --- File-level skip rules: report nothing, don't even analyze. ---
+    if (basename.endsWith('.d.ts')) return {};
+    if (!/\.(tsx|ts)$/.test(basename)) return {};
+    if (basename.endsWith('.test.ts') || basename.endsWith('.test.tsx')) return {};
+    if (filename.includes('/__tests__/')) return {};
+    if (basename === 'index.ts' || basename === 'index.tsx') return {};
+    if (basename === 'types.ts') return {};
+    if (basename.endsWith('styled-components.ts') || basename.endsWith('styled-components.tsx')) {
+      return {};
+    }
+
+    return {
+      'Program:exit'(program) {
+        const body = program.body;
+
+        // Bail if the file uses specifier-style exports or a default export
+        // anywhere at top level — out of scope for this rule.
+        const hasSpecifierOrDefaultExport = body.some((stmt) => {
+          if (stmt.type === 'ExportDefaultDeclaration') return true;
+          if (stmt.type === 'ExportNamedDeclaration' && !stmt.declaration) return true;
+          return false;
+        });
+        if (hasSpecifierOrDefaultExport) return;
+
+        // Collect top-level, non-type, value-level exports.
+        const valueExports = [];
+        for (const stmt of body) {
+          if (stmt.type !== 'ExportNamedDeclaration' || !stmt.declaration) continue;
+          if (stmt.exportKind === 'type') continue;
+
+          const decl = stmt.declaration;
+          if (decl.type === 'FunctionDeclaration' && decl.id) {
+            valueExports.push({ node: stmt, name: decl.id.name, kind: 'function' });
+          } else if (decl.type === 'ClassDeclaration' && decl.id) {
+            valueExports.push({ node: stmt, name: decl.id.name, kind: 'class' });
+          } else if (decl.type === 'VariableDeclaration') {
+            for (const d of decl.declarations) {
+              if (d.id?.type === 'Identifier') {
+                valueExports.push({ node: stmt, name: d.id.name, kind: 'variable', init: d.init });
+              }
+            }
+          }
+          // TSTypeAliasDeclaration / TSInterfaceDeclaration / TSEnumDeclaration
+          // intentionally fall through unmatched — types don't count.
+        }
+
+        // Skip: no exports, or more than one — can't identify a single primary.
+        if (valueExports.length !== 1) return;
+
+        const primary = valueExports[0];
+
+        // Skip: primary is a class — not in scope per spec.
+        if (primary.kind === 'class') return;
+
+        if (primary.kind === 'variable') {
+          const init = primary.init;
+          if (!init) return; // ambient `export const x: Foo;` — nothing to anchor on
+          if (init.type === 'CallExpression') return; // forwardRef(...)/memo(...)/HOC(...)
+          if (init.type !== 'FunctionExpression' && init.type !== 'ArrowFunctionExpression') {
+            return; // not a function-valued const — ambiguous
+          }
+        }
+
+        const primaryIndex = body.indexOf(primary.node);
+
+        // Flag only function-like top-level declarations before the primary:
+        // a `function` declaration, or a `const`/`let` bound to a function,
+        // arrow function, or class. Plain data constants are left alone.
+        for (let i = 0; i < primaryIndex; i++) {
+          const stmt = body[i];
+          if (!isHelperDeclaration(stmt)) continue;
+
+          context.report({
+            node: stmt,
+            messageId: 'helperBeforePrimary',
+            data: { helperName: getHelperName(stmt), primaryName: primary.name },
+          });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/javascript/eslint-local-rules/primary-export-first.md
+++ b/javascript/eslint-local-rules/primary-export-first.md
@@ -1,0 +1,76 @@
+# primary-export-first
+
+## What this rule enforces
+
+A file's primary export should come first. Private helper functions and implementation details should follow, not precede, the thing they support — a reader opening the file should see the main export before the internals it depends on.
+
+## Flagged patterns
+
+```ts
+// ❌ helper function declared above the export it supports
+function formatRowLabel(row: Row) {
+  return row.name.toUpperCase();
+}
+
+export function RowSummary(row: Row) {
+  return formatRowLabel(row);
+}
+```
+
+```tsx
+// ❌ arrow-function helper above the component that uses it
+const withStickySides = (Component: RowComponent) => (props: RowProps) => (
+  <Sticky>
+    <Component {...props} />
+  </Sticky>
+);
+
+export const TableRow = withStickySides(BaseRow);
+```
+
+## Correct patterns
+
+```ts
+// ✓ export first, helper follows
+export function RowSummary(row: Row) {
+  return formatRowLabel(row);
+}
+
+function formatRowLabel(row: Row) {
+  return row.name.toUpperCase();
+}
+```
+
+Function hoisting means a `function` declaration used before its textual position still works at runtime, but reordering it after the primary export is what this rule enforces (and what the file should look like either way).
+
+## What is not flagged
+
+This rule only flags **function-like** declarations: a top-level `function` declaration, or a top-level `const`/`let` whose initializer is a function expression, arrow function, or class. Plain data — object literals, arrays, strings, numbers — sitting above the primary export is a different, more debatable style question and is intentionally out of scope:
+
+```ts
+// ✓ not flagged — a plain constant, not a helper function
+const SUFFIX_DELIMITER = '::';
+
+export function buildKey(id: string) {
+  return `${id}${SUFFIX_DELIMITER}suffix`;
+}
+```
+
+## Exemptions (auto-detected)
+
+This rule only analyzes files where a single "primary export" can be identified unambiguously. It reports nothing (rather than guessing) for:
+
+| Case                                                  | Why exempt                                                            |
+| ------------------------------------------------------ | ----------------------------------------------------------------------- |
+| Non-`.ts`/`.tsx` files, `.d.ts`                       | not applicable                                                         |
+| `*.test.ts(x)`, files under `__tests__/`              | test files have their own structure conventions                       |
+| `index.ts(x)`                                         | entry points are intentionally multi-export                           |
+| `types.ts`                                            | type-only files                                                       |
+| `*styled-components.ts(x)`                            | multi-component styled collections, no single "primary" export        |
+| Zero or more than one top-level value export          | no single primary export to anchor on                                 |
+| `export { a, b }` specifier-style or re-export         | resolving which declaration an alias refers to is out of scope         |
+| `export default`                                      | already banned elsewhere in this config; skipped defensively           |
+| Single export whose initializer is a class             | classes are out of scope for this rule                                |
+| Single export whose initializer is a `CallExpression`  | e.g. `forwardRef(...)`/`memo(...)`-wrapped exports — unwrapping HOCs is a separate, more complex analysis |
+
+Type-only top-level declarations (`type X = ...`, `interface X {}`) are never flagged and never count toward the "exactly one export" check — colocating a component's prop type above the component is a distinct, idiomatic convention.

--- a/javascript/eslint.config.js
+++ b/javascript/eslint.config.js
@@ -9,6 +9,7 @@ import requireCastComment from './eslint-local-rules/require-cast-comment.js';
 import noFixtureConstants from './eslint-local-rules/no-fixture-constants.js';
 import noModuleScopeTestSetup from './eslint-local-rules/no-module-scope-test-setup.js';
 import typesInTypesFile from './eslint-local-rules/types-in-types-file.js';
+import primaryExportFirst from './eslint-local-rules/primary-export-first.js';
 import tseslint from 'typescript-eslint';
 import prettierConfig from 'eslint-config-prettier';
 import baseUIEslint from 'eslint-plugin-baseui';
@@ -242,6 +243,7 @@ export default [
           'filename-matches-export': filenameMatchesExport,
           'require-cast-comment': requireCastComment,
           'types-in-types-file': typesInTypesFile,
+          'primary-export-first': primaryExportFirst,
         },
       },
     },
@@ -252,6 +254,7 @@ export default [
       'local/filename-matches-export': 'error',
       'local/require-cast-comment': 'error',
       'local/types-in-types-file': 'error',
+      'local/primary-export-first': 'error',
     },
   },
 

--- a/javascript/packages/rpc/handlers.ts
+++ b/javascript/packages/rpc/handlers.ts
@@ -6,6 +6,15 @@ import type { ExtractUnaryRpc } from './types';
 
 let handlersPromise: Promise<Awaited<ReturnType<typeof createHandlers>>> | null = null;
 
+/** Gets the RPC handlers, initializing them with runtime configuration on first call. */
+export async function getRpcHandlers() {
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+  if (!handlersPromise) {
+    handlersPromise = createHandlers();
+  }
+  return handlersPromise;
+}
+
 function unary<Fn>(fn: Fn): ExtractUnaryRpc<Fn> {
   // cast: TS can't resolve ExtractUnaryRpc's conditional type against the unconstrained generic Fn
   // from within this function; fn always satisfies it at call sites
@@ -36,13 +45,4 @@ async function createHandlers() {
       services.PipelineRunService.updatePipelineRun({ pipelineRun: record }),
     ListModel: unary(services.ModelService.listModel),
   } as const;
-}
-
-/** Gets the RPC handlers, initializing them with runtime configuration on first call. */
-export async function getRpcHandlers() {
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  if (!handlersPromise) {
-    handlersPromise = createHandlers();
-  }
-  return handlersPromise;
 }

--- a/javascript/packages/rpc/services.ts
+++ b/javascript/packages/rpc/services.ts
@@ -16,6 +16,19 @@ import type { FetchTransport, ServiceClient, Services } from './types';
 
 const typeRegistry = createRegistry(TypedStructSchema);
 
+let servicesPromise: Promise<Services> | null = null;
+
+/**
+ * Gets the RPC services, initializing them with runtime configuration on first call.
+ */
+export async function getServices(): Promise<Services> {
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+  if (!servicesPromise) {
+    servicesPromise = createServices();
+  }
+  return servicesPromise;
+}
+
 /**
  * Builds a service client whose methods JSON-encode the request, POST it
  * through the fetch transport, and decode the JSON response back into a
@@ -43,8 +56,6 @@ function createServiceClient<T extends DescService>(
   return client as ServiceClient<T>;
 }
 
-let servicesPromise: Promise<Services> | null = null;
-
 async function createServices(): Promise<Services> {
   const { apiBaseUrl } = await getRuntimeConfig();
 
@@ -59,15 +70,4 @@ async function createServices(): Promise<Services> {
     TriggerRunService: createServiceClient(TriggerRunService, transport),
     ModelService: createServiceClient(ModelService, transport),
   } as const;
-}
-
-/**
- * Gets the RPC services, initializing them with runtime configuration on first call.
- */
-export async function getServices(): Promise<Services> {
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  if (!servicesPromise) {
-    servicesPromise = createServices();
-  }
-  return servicesPromise;
 }


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Added a new eslint rule, `local/primary-export-first`, that flags a helper function, arrow function, or class declared above the single primary export it supports. It's scoped narrowly: it only fires on files with exactly one top-level value export, only flags function-like helpers (not plain data constants), and skips test/index/types/styled-components files and forwardRef/memo/HOC-wrapped exports. Fixed the two real violations it found in `packages/rpc/handlers.ts` and `services.ts` by moving the helpers below the exports they support. Removed the now-redundant "Code Ordering Within a File" section from `ui-coding-principles/SKILL.md` since the mechanical case is fully covered by the new rule and its doc.

**Why?**

"Primary export first" existed only as unenforced prose, easy to apply inconsistently. Scoping the rule narrowly (single-export files, function-like helpers only) keeps false positives near zero while covering the common case; multi-export files and ordering of plain data constants are left to judgment rather than force-fit into the rule.

**How did you test it?**

Added a 26-case RuleTester suite for the new rule (21 valid, 5 invalid), covering every skip condition and the function-vs-plain-constant distinction. Ran the full `javascript/` lint, typecheck, and test suite (146 files / 1373 tests) to confirm the reordering in `packages/rpc` doesn't change runtime behavior — the moved declarations are either hoisted functions or lazily invoked, never touched at module-evaluation time.

**Potential risks**

Low. The rule's scope is intentionally narrow to avoid false positives, and the only behavior-adjacent change is a declaration reorder in two files, verified against their existing test coverage.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

None — internal tooling/lint change, no user-facing or API impact.

**Documentation Changes**

Added `javascript/eslint-local-rules/primary-export-first.md`; trimmed the now-redundant section in `javascript/.claude/skills/ui-coding-principles/SKILL.md`.
