### PR TITLE
refactor(ui): centralize mutation middleware in the mutation hook

### DIFF
--- a/javascript/packages/core/components/actions/confirm-dispatcher.tsx
+++ b/javascript/packages/core/components/actions/confirm-dispatcher.tsx
@@ -5,8 +5,7 @@ import { Banner } from '#core/components/banner/banner';
 import { Icon } from '#core/components/icon/icon';
 import { Markdown } from '#core/components/markdown/markdown';
 import { ConfirmDialog } from '#core/components/modal/confirm-dialog/confirm-dialog';
-import { useSchemaMiddleware } from '#core/hooks/use-schema-middleware/use-schema-middleware';
-import { useStudioMutation } from '#core/hooks/use-studio-mutation';
+import { useStudioMutation } from '#core/hooks/use-studio-mutation/use-studio-mutation';
 
 import type {
   ActionConfig,
@@ -27,16 +26,13 @@ type Props<T extends Data> = {
 
 export function ConfirmDispatcher<T extends Data>({ action, record, onClose }: Props<T>) {
   const navigate = useNavigate();
-  const { applyMiddleware } = useSchemaMiddleware(
-    action.operation.type === 'mutation' ? (action.operation.middleware ?? null) : null
-  );
   const mutation = useStudioMutation<unknown, T>(
     action.operation.type === 'mutation' ? action.operation.mutation : null
   );
 
   const handleActionExecute = async () => {
     if (action.operation.type === 'mutation') {
-      await mutation.mutateAsync(applyMiddleware(record));
+      await mutation.mutateAsync(record);
     } else {
       navigate(action.operation.route);
     }

--- a/javascript/packages/core/components/actions/types.ts
+++ b/javascript/packages/core/components/actions/types.ts
@@ -1,7 +1,6 @@
 import type { BannerProps } from 'baseui/banner';
 import type { Size as DialogSize } from 'baseui/dialog';
 import type { ComponentType, ReactNode } from 'react';
-import type { MiddlewareSchema } from '#core/hooks/use-schema-middleware/types';
 import type { DeepInterpolatable } from '#core/interpolation/types';
 import type { MutationConfig } from '#core/types/query-types';
 
@@ -48,11 +47,10 @@ export type ActionConfigBase = {
   disabled?: DisabledRule[];
 };
 
-/** Action that fires a mutation against the API, with optional middleware to shape the record first. */
+/** Action that fires a mutation against the API. Configure `mutation.middleware` to shape the record first. */
 export type MutationActionConfig = {
   type: 'mutation';
   mutation: MutationConfig;
-  middleware?: MiddlewareSchema;
 };
 
 /**

--- a/javascript/packages/core/components/cell/renderers/retry/retry-cell.tsx
+++ b/javascript/packages/core/components/cell/renderers/retry/retry-cell.tsx
@@ -6,7 +6,7 @@ import { Textarea } from 'baseui/textarea';
 
 import { Dialog } from '#core/components/dialog/dialog';
 import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
-import { useStudioMutation } from '#core/hooks/use-studio-mutation';
+import { useStudioMutation } from '#core/hooks/use-studio-mutation/use-studio-mutation';
 import { useStudioQuery } from '#core/hooks/use-studio-query';
 
 import type { CellRendererProps } from '#core/components/cell/types';

--- a/javascript/packages/core/config/entities/pipeline/create-pipeline-run-form.tsx
+++ b/javascript/packages/core/config/entities/pipeline/create-pipeline-run-form.tsx
@@ -2,7 +2,7 @@ import { FormDialog } from '#core/components/form/components/form-dialog/form-di
 import { StringField } from '#core/components/form/fields/string/string-field';
 import { TextareaField } from '#core/components/form/fields/textarea/textarea-field';
 import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
-import { useStudioMutation } from '#core/hooks/use-studio-mutation';
+import { useStudioMutation } from '#core/hooks/use-studio-mutation/use-studio-mutation';
 import { generateSuffix } from '#core/utils/name-utils';
 
 import type { ActionComponentProps } from '#core/components/actions/types';

--- a/javascript/packages/core/config/entities/trigger/trigger.ts
+++ b/javascript/packages/core/config/entities/trigger/trigger.ts
@@ -47,9 +47,9 @@ export const TRIGGER_ENTITY_CONFIG: PhaseEntityConfig = {
               delayMs: 2000,
             },
           ],
-        },
-        middleware: {
-          operations: [{ destination: 'spec.action', default: TriggerRunAction.KILL }],
+          middleware: {
+            operations: [{ destination: 'spec.action', default: TriggerRunAction.KILL }],
+          },
         },
       },
       modal: {

--- a/javascript/packages/core/hooks/use-studio-mutation/__tests__/use-studio-mutation.test.ts
+++ b/javascript/packages/core/hooks/use-studio-mutation/__tests__/use-studio-mutation.test.ts
@@ -2,7 +2,7 @@ import { renderHook, screen, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 
 import { GrpcStatusCode } from '#core/constants/grpc-status-codes';
-import { useStudioMutation } from '#core/hooks/use-studio-mutation';
+import { useStudioMutation } from '#core/hooks/use-studio-mutation/use-studio-mutation';
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getErrorProviderWrapper } from '#core/test/wrappers/get-error-provider-wrapper';
 import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';

--- a/javascript/packages/core/hooks/use-studio-mutation/__tests__/use-studio-mutation.test.ts
+++ b/javascript/packages/core/hooks/use-studio-mutation/__tests__/use-studio-mutation.test.ts
@@ -39,6 +39,70 @@ describe('useStudioMutation', () => {
     });
   });
 
+  test('applies config.middleware to variables before calling request', async () => {
+    const mockResponse = { id: 'test-id' };
+    const mockRequest = createQueryMockRouter({
+      CreatePipelineRun: mockResponse,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useStudioMutation({
+          mutationName: 'CreatePipelineRun',
+          middleware: { operations: [{ destination: 'spec.action', default: 'KILL' }] },
+        }),
+      buildWrapper([
+        getErrorProviderWrapper(),
+        getRouterWrapper(),
+        getServiceProviderWrapper({ request: mockRequest }),
+        getSnackbarProviderWrapper(),
+      ])
+    );
+
+    result.current.mutate({ name: 'test-run' });
+
+    await waitFor(() => {
+      expect(mockRequest).toHaveBeenCalledWith(
+        'CreatePipelineRun',
+        expect.objectContaining({ spec: { action: 'KILL' } })
+      );
+    });
+  });
+
+  test('reads middleware source from sourceFromObject when provided', async () => {
+    const mockResponse = { id: 'test-id' };
+    const mockRequest = createQueryMockRouter({
+      CreatePipelineRun: mockResponse,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useStudioMutation({
+          mutationName: 'CreatePipelineRun',
+          middleware: {
+            operations: [
+              { source: 'name', destination: 'metadata.name', transformation: (v) => v },
+            ],
+          },
+        }),
+      buildWrapper([
+        getErrorProviderWrapper(),
+        getRouterWrapper(),
+        getServiceProviderWrapper({ request: mockRequest }),
+        getSnackbarProviderWrapper(),
+      ])
+    );
+
+    result.current.mutate({ metadata: {} }, { sourceFromObject: { name: 'from-source' } });
+
+    await waitFor(() => {
+      expect(mockRequest).toHaveBeenCalledWith(
+        'CreatePipelineRun',
+        expect.objectContaining({ metadata: { name: 'from-source' } })
+      );
+    });
+  });
+
   test('returns mutation response data', async () => {
     const mockResponse = { id: 'test-id', name: 'test-pipeline-run' };
     const mockRequest = createQueryMockRouter({

--- a/javascript/packages/core/hooks/use-studio-mutation/__tests__/use-studio-mutation.test.ts
+++ b/javascript/packages/core/hooks/use-studio-mutation/__tests__/use-studio-mutation.test.ts
@@ -123,7 +123,7 @@ describe('useStudioMutation', () => {
 
     await waitFor(() => {
       expect(result.current.data).toEqual(mockResponse);
-      expect(result.current.isSuccess).toBe(true);
+      expect(result.current.isPending).toBe(false);
     });
   });
 

--- a/javascript/packages/core/hooks/use-studio-mutation/types.ts
+++ b/javascript/packages/core/hooks/use-studio-mutation/types.ts
@@ -1,15 +1,14 @@
-import type { UseMutationResult } from '@tanstack/react-query';
 import type { ApplicationError } from '#core/types/error-types';
 
-export type StudioMutateOptions<TVariables> = {
-  /** Read middleware `source` paths from this object instead of the submitted variables. */
-  sourceFromObject?: TVariables;
+export type StudioMutateOptions<TPayload> = {
+  /** Read middleware `source` paths from this object instead of the submitted payload. */
+  sourceFromObject?: TPayload;
 };
 
-export type UseStudioMutationResult<TData, TVariables extends Record<string, unknown>> = Omit<
-  UseMutationResult<TData, ApplicationError, TVariables>,
-  'mutate' | 'mutateAsync'
-> & {
-  mutate: (variables: TVariables, options?: StudioMutateOptions<TVariables>) => void;
-  mutateAsync: (variables: TVariables, options?: StudioMutateOptions<TVariables>) => Promise<TData>;
+export type UseStudioMutationResult<TResponse, TPayload extends Record<string, unknown>> = {
+  isPending: boolean;
+  error: ApplicationError | null;
+  data: TResponse | undefined;
+  mutate: (payload: TPayload, options?: StudioMutateOptions<TPayload>) => void;
+  mutateAsync: (payload: TPayload, options?: StudioMutateOptions<TPayload>) => Promise<TResponse>;
 };

--- a/javascript/packages/core/hooks/use-studio-mutation/types.ts
+++ b/javascript/packages/core/hooks/use-studio-mutation/types.ts
@@ -1,0 +1,15 @@
+import type { UseMutationResult } from '@tanstack/react-query';
+import type { ApplicationError } from '#core/types/error-types';
+
+export type StudioMutateOptions<TVariables> = {
+  /** Read middleware `source` paths from this object instead of the submitted variables. */
+  sourceFromObject?: TVariables;
+};
+
+export type UseStudioMutationResult<TData, TVariables extends Record<string, unknown>> = Omit<
+  UseMutationResult<TData, ApplicationError, TVariables>,
+  'mutate' | 'mutateAsync'
+> & {
+  mutate: (variables: TVariables, options?: StudioMutateOptions<TVariables>) => void;
+  mutateAsync: (variables: TVariables, options?: StudioMutateOptions<TVariables>) => Promise<TData>;
+};

--- a/javascript/packages/core/hooks/use-studio-mutation/use-studio-mutation.ts
+++ b/javascript/packages/core/hooks/use-studio-mutation/use-studio-mutation.ts
@@ -9,20 +9,20 @@ import type { ApplicationError } from '#core/types/error-types';
 import type { MutationConfig } from '#core/types/query-types';
 import type { UseStudioMutationResult } from './types';
 
-export const useStudioMutation = <TData, TVariables extends Record<string, unknown>>(
+export const useStudioMutation = <TResponse, TPayload extends Record<string, unknown>>(
   config: MutationConfig | null
-): UseStudioMutationResult<TData, TVariables> => {
+): UseStudioMutationResult<TResponse, TPayload> => {
   const { request } = useServiceProvider();
   const normalizeError = useErrorNormalizer();
   const runSuccessOperations = useSuccessOperations(config?.successOperations);
   const { applyMiddleware } = useSchemaMiddleware(config?.middleware);
 
-  const mutation = useMutation<TData, ApplicationError, TVariables>({
-    mutationFn: async (variables: TVariables) => {
+  const mutation = useMutation<TResponse, ApplicationError, TPayload>({
+    mutationFn: async (payload: TPayload) => {
       if (!config) throw new Error('useStudioMutation called without config');
       try {
-        // cast: service request returns unknown; TData is the caller-declared response type
-        return (await request(config.mutationName, variables)) as TData;
+        // cast: service request returns unknown; TResponse is the caller-declared response type
+        return (await request(config.mutationName, payload)) as TResponse;
       } catch (error) {
         console.error('mutation error', error);
         throw normalizeError(error)!;
@@ -38,12 +38,14 @@ export const useStudioMutation = <TData, TVariables extends Record<string, unkno
   });
 
   return {
-    ...mutation,
-    mutate: (variables, options) =>
-      mutation.mutate(applyMiddleware(variables, { sourceFromObject: options?.sourceFromObject })),
-    mutateAsync: (variables, options) =>
+    isPending: mutation.isPending,
+    error: mutation.error,
+    data: mutation.data,
+    mutate: (payload, options) =>
+      mutation.mutate(applyMiddleware(payload, { sourceFromObject: options?.sourceFromObject })),
+    mutateAsync: (payload, options) =>
       mutation.mutateAsync(
-        applyMiddleware(variables, { sourceFromObject: options?.sourceFromObject })
+        applyMiddleware(payload, { sourceFromObject: options?.sourceFromObject })
       ),
   };
 };

--- a/javascript/packages/core/hooks/use-studio-mutation/use-studio-mutation.ts
+++ b/javascript/packages/core/hooks/use-studio-mutation/use-studio-mutation.ts
@@ -1,21 +1,23 @@
 import { useMutation } from '@tanstack/react-query';
 
 import { useSuccessOperations } from '#core/components/actions/use-success-operations';
+import { useSchemaMiddleware } from '#core/hooks/use-schema-middleware/use-schema-middleware';
 import { useErrorNormalizer } from '#core/providers/error-provider/use-error-normalizer';
 import { useServiceProvider } from '#core/providers/service-provider/use-service-provider';
 
-import type { UseMutationResult } from '@tanstack/react-query';
 import type { ApplicationError } from '#core/types/error-types';
 import type { MutationConfig } from '#core/types/query-types';
+import type { UseStudioMutationResult } from './types';
 
 export const useStudioMutation = <TData, TVariables extends Record<string, unknown>>(
   config: MutationConfig | null
-): UseMutationResult<TData, ApplicationError, TVariables> => {
+): UseStudioMutationResult<TData, TVariables> => {
   const { request } = useServiceProvider();
   const normalizeError = useErrorNormalizer();
   const runSuccessOperations = useSuccessOperations(config?.successOperations);
+  const { applyMiddleware } = useSchemaMiddleware(config?.middleware);
 
-  return useMutation<TData, ApplicationError, TVariables>({
+  const mutation = useMutation<TData, ApplicationError, TVariables>({
     mutationFn: async (variables: TVariables) => {
       if (!config) throw new Error('useStudioMutation called without config');
       try {
@@ -34,4 +36,14 @@ export const useStudioMutation = <TData, TVariables extends Record<string, unkno
       ? (error) => config.clientOptions!.onError!(error)
       : undefined,
   });
+
+  return {
+    ...mutation,
+    mutate: (variables, options) =>
+      mutation.mutate(applyMiddleware(variables, { sourceFromObject: options?.sourceFromObject })),
+    mutateAsync: (variables, options) =>
+      mutation.mutateAsync(
+        applyMiddleware(variables, { sourceFromObject: options?.sourceFromObject })
+      ),
+  };
 };

--- a/javascript/packages/core/types/query-types.ts
+++ b/javascript/packages/core/types/query-types.ts
@@ -1,7 +1,8 @@
-import { useStudioMutation as _useStudioMutation } from '#core/hooks/use-studio-mutation';
+import { useStudioMutation as _useStudioMutation } from '#core/hooks/use-studio-mutation/use-studio-mutation';
 import { useStudioQuery as _useStudioQuery } from '#core/hooks/use-studio-query';
 
 import type { SuccessOperation } from '#core/components/actions/types';
+import type { MiddlewareSchema } from '#core/hooks/use-schema-middleware/types';
 import type { ApplicationError } from '#core/types/error-types';
 
 /**
@@ -41,6 +42,9 @@ export interface MutationConfig {
 
   /** Side-effects to run after the mutation succeeds (in order). */
   successOperations?: SuccessOperation[];
+
+  /** Schema-driven transformations applied to variables before the request is sent. */
+  middleware?: MiddlewareSchema;
 }
 
 /**


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Mutation middleware — the schema-driven transformations that shape a record before it's submitted — now lives inside the mutation hook itself instead of at each call site. Previously, a component dispatching a mutation had to fetch its own middleware schema and transform the record before calling the mutation. The hook also gained the ability to accept an alternate source object for a single call, so middleware doesn't always have to read from the exact object being submitted.

The mutation hook's public interface was also narrowed so it no longer mirrors the full shape of the query library it's built on. It exposes only the handful of fields callers actually use, named for what they mean in this domain rather than borrowed wholesale from that library's vocabulary.

**Why?**

Centralizing middleware in the hook removes duplicated wiring at call sites and makes it available to every mutation, not just the one dispatcher that previously implemented it by hand. Narrowing the public interface at the same time keeps that consolidation from also locking callers into the underlying query library's shape.

**How did you test it?**

Two new test suites and verified trigger run kill still behaves as expcted.

**Potential risks**

Low. Behavior for existing callers is unchanged, since none previously passed a second argument to the mutate functions.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

N/A

**Documentation Changes**

N/A
