### PR TITLE
Drop skill guidance now enforced by existing eslint rules

### DIFF
--- a/javascript/.claude/skills/file-directory-structure/SKILL.md
+++ b/javascript/.claude/skills/file-directory-structure/SKILL.md
@@ -31,12 +31,9 @@ user-invocable: false
 
 ## Naming
 
-- **Files**: kebab-case, `.tsx` for JSX, `.ts` otherwise
-- **Components**: PascalCase in code, kebab-case filename
 - **Variables**: camelCase
 - **Constants**: UPPER_SNAKE_CASE
 
 ## Anti-Patterns
 
-- ❌ Default exports — use named exports for all modules
 - ❌ Generic filenames without namespace (`action-button.tsx` vs `table-action-button.tsx`)

--- a/javascript/.claude/skills/react-component-development/SKILL.md
+++ b/javascript/.claude/skills/react-component-development/SKILL.md
@@ -35,20 +35,6 @@ export const TaskSeparator = styled('div', ({ $theme }) => ({
 - ❌ `Container`, `Card`, `Wrapper` (collide everywhere)
 - ✅ `TaskSeparator`, `ExecutionMatrix`, `PipelineHeader`
 
-## Event Handler Naming
-
-Name handlers by intent, not by event type:
-
-```typescript
-// ❌
-const handleOnMouseEnter = () => {};
-const handleOnClick = () => {};
-
-// ✅
-const showTooltipAfterDelay = () => {};
-const toggleMenu = () => {};
-```
-
 ## Component Props Naming
 
 - `Props` — single component in the file

--- a/javascript/.claude/skills/testing-standards/SKILL.md
+++ b/javascript/.claude/skills/testing-standards/SKILL.md
@@ -29,38 +29,6 @@ user-invocable: false
 - Keep tests flat when individual test names provide enough context
 - Prefer `expect(fn(args)).toEqual(result)` over assigning to intermediate variables
 
-## Querying Elements
-
-Query priority: `getByRole` → `getByLabelText` → `getByText` → `getByTestId`
-
-**Only use `getByTestId` if the element has no semantic role** (spinners, skeletons, custom visual elements) **or is a mock component**. Every other use of `getByTestId` is a bug — fix it by using an accessible query or by adding `aria-label`/`role` to the component under test.
-
-```typescript
-// ❌ Wrong — element has a role
-screen.getByTestId('submit-button');
-// ✅ Fix
-screen.getByRole('button', { name: /submit/i });
-
-// ❌ Wrong — element has text content
-screen.getByTestId('error-message');
-// ✅ Fix
-screen.getByText(/something went wrong/i);
-
-// ✅ Correct — spinner has no semantic role
-screen.queryByTestId('loading-spinner');
-
-// ✅ Correct — testId is on the mock itself, not the real component.
-// The real MetricChart has no accessible role worth testing here;
-// the test cares only that the parent rendered it with the right name.
-vi.mock('../MetricChart', () => ({
-  MetricChart: ({ name }: { name: string }) => (
-    <div data-testid={`metric-chart-${name}`} />
-  ),
-}));
-// ...
-screen.getByTestId('metric-chart-accuracy');
-```
-
 ## Anti-Patterns
 
 - ❌ Testing implementation details (`container.firstChild`, verifying props passed to children)


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Removed four sections/bullets from `javascript/.claude/skills/` that restate conventions already mechanically enforced by a shipped eslint rule.

**Why?**

These skill files exist to steer an AI coding agent's behavior. Once a convention is mechanically enforced by eslint, keeping a prose restatement of it is pure duplication.

**How did you test it?**

No behavior change

**Potential risks**

No behavior change

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

None — internal agent-guidance cleanup, no user-facing or API impact.

**Documentation Changes**

None beyond the skill file trims described above.
