### PR TITLE
Add a route successOperation that skips the toast

### DIFF
--- a/javascript/packages/core/components/actions/__tests__/use-success-operations.test.tsx
+++ b/javascript/packages/core/components/actions/__tests__/use-success-operations.test.tsx
@@ -339,4 +339,27 @@ describe('useSuccessOperations', () => {
       expect(await screen.findByText('Pipeline training-v2 created')).toBeInTheDocument();
     });
   });
+
+  describe('route', () => {
+    it('navigates without showing a toast', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <UseSuccessOperationsTestHarness
+          operations={[{ type: 'route', route: '/pipelines/run-1' }]}
+        />,
+        buildWrapper([
+          getBaseProviderWrapper(),
+          getRouterWrapper({ location: '/start' }),
+          createServiceProviderTestContext({ request: vi.fn() }).wrapper,
+          getSnackbarProviderWrapper(),
+          getIconProviderWrapper(),
+        ])
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Run success operations' }));
+
+      expect(screen.getByText(/Current pathname: \/pipelines\/run-1/)).toBeInTheDocument();
+    });
+  });
 });

--- a/javascript/packages/core/components/actions/types.ts
+++ b/javascript/packages/core/components/actions/types.ts
@@ -61,7 +61,7 @@ export type MutationActionConfig = {
  * Use `invalidate` to refresh related queries explicitly after a mutation
  * succeeds, either broadly by query name or narrowly by name + args.
  */
-export type SuccessOperation = InvalidateOperation | ToastOperation;
+export type SuccessOperation = InvalidateOperation | ToastOperation | RouteSuccessOperation;
 
 export type InvalidateOperation = {
   type: 'invalidate';
@@ -91,6 +91,12 @@ export type ToastOperation = {
 };
 
 export type RouteActionConfig = {
+  type: 'route';
+  route: string;
+};
+
+/** Navigates without showing a toast. Use {@link ToastOperation.action} instead when the navigation should be user-initiated. */
+export type RouteSuccessOperation = {
   type: 'route';
   route: string;
 };

--- a/javascript/packages/core/components/actions/use-success-operations.tsx
+++ b/javascript/packages/core/components/actions/use-success-operations.tsx
@@ -42,6 +42,8 @@ export function useSuccessOperations(operations?: SuccessOperation[]) {
           }
         } else if (op.type === 'toast') {
           enqueue(buildToastPayload(op, navigate, dequeue));
+        } else if (op.type === 'route') {
+          navigate(op.route);
         }
       }
     },


### PR DESCRIPTION
**Summary**
Redirecting after a mutation succeeded only worked as a side effect of showing a toast message — there was no way to navigate on success without also displaying one. This adds a standalone success operation that just navigates, for cases where a message alongside the redirect isn't wanted.

**Test Plan**
Covered by a new unit test exercising the navigation directly; no additional manual verification was needed.
