### PR TITLE
Extract configurable NavigationBar from CoreApp

### DIFF
--- a/javascript/app/App.tsx
+++ b/javascript/app/App.tsx
@@ -7,12 +7,6 @@ import { Provider as StyletronProvider } from 'styletron-react';
 
 import { ICONS } from './icons/icons';
 
-import type { NavigationLink } from '@michelangelo-ai/core';
-
-const NAVIGATION_LINKS: NavigationLink[] = [
-  { label: 'Docs', href: 'https://michelangelo-ai.github.io/michelangelo/' },
-];
-
 const dependencies = {
   error: {
     normalizeError: normalizeTranscoderError,
@@ -24,7 +18,7 @@ const dependencies = {
     request,
   },
   navigationBar: {
-    links: NAVIGATION_LINKS,
+    links: [{ label: 'Docs', href: 'https://michelangelo-ai.github.io/michelangelo/' }],
   },
 };
 

--- a/javascript/app/App.tsx
+++ b/javascript/app/App.tsx
@@ -7,6 +7,12 @@ import { Provider as StyletronProvider } from 'styletron-react';
 
 import { ICONS } from './icons/icons';
 
+import type { NavigationLink } from '@michelangelo-ai/core';
+
+const NAVIGATION_LINKS: NavigationLink[] = [
+  { label: 'Docs', href: 'https://michelangelo-ai.github.io/michelangelo/' },
+];
+
 const dependencies = {
   error: {
     normalizeError: normalizeTranscoderError,
@@ -16,6 +22,9 @@ const dependencies = {
   },
   service: {
     request,
+  },
+  navigationBar: {
+    links: NAVIGATION_LINKS,
   },
 };
 

--- a/javascript/packages/core/components/navigation-bar/__tests__/navigation-bar.test.tsx
+++ b/javascript/packages/core/components/navigation-bar/__tests__/navigation-bar.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
@@ -10,13 +9,21 @@ import { NavigationBar } from '../navigation-bar';
 import type { NavigationLink } from '../types';
 
 describe('NavigationBar', () => {
-  it('renders the title', () => {
+  // AppNavBar renders both its desktop and mobile menu variants at once and switches
+  // between them with a `matchMedia` query, which jsdom doesn't implement — the inactive
+  // variant reports as hidden to the accessibility tree, so role queries need `hidden: true`.
+  it('renders the title as a link to the app root', () => {
     render(<NavigationBar />, buildWrapper([getBaseProviderWrapper(), getRouterWrapper()]));
 
-    expect(screen.getAllByText('Michelangelo Studio').length).toBeGreaterThan(0);
+    const titleLinks = screen.getAllByRole('link', {
+      name: 'Michelangelo Studio',
+      hidden: true,
+    });
+    expect(titleLinks.length).toBeGreaterThan(0);
+    titleLinks.forEach((link) => expect(link).toHaveAttribute('href', '/'));
   });
 
-  it('renders navigation links', () => {
+  it('renders navigation links with their destination href', () => {
     const links: NavigationLink[] = [
       { label: 'Docs', href: 'https://example.com/docs' },
       { label: 'Help', href: 'https://example.com/help' },
@@ -27,26 +34,28 @@ describe('NavigationBar', () => {
       buildWrapper([getBaseProviderWrapper(), getRouterWrapper()])
     );
 
-    expect(screen.getAllByText('Docs').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('Help').length).toBeGreaterThan(0);
+    const docsLinks = screen.getAllByRole('link', { name: 'Docs', hidden: true });
+    expect(docsLinks.length).toBeGreaterThan(0);
+    docsLinks.forEach((link) => expect(link).toHaveAttribute('href', 'https://example.com/docs'));
+
+    const helpLinks = screen.getAllByRole('link', { name: 'Help', hidden: true });
+    expect(helpLinks.length).toBeGreaterThan(0);
+    helpLinks.forEach((link) => expect(link).toHaveAttribute('href', 'https://example.com/help'));
   });
 
-  it('opens link in a new tab when clicked', async () => {
-    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+  it('opens navigation links in a new tab without leaking a window reference', () => {
     const links: NavigationLink[] = [{ label: 'Docs', href: 'https://example.com/docs' }];
 
     render(
       <NavigationBar links={links} />,
       buildWrapper([getBaseProviderWrapper(), getRouterWrapper()])
     );
-    await userEvent.click(screen.getAllByText('Docs')[0]);
 
-    expect(openSpy).toHaveBeenCalledWith(
-      'https://example.com/docs',
-      '_blank',
-      'noopener,noreferrer'
-    );
-
-    openSpy.mockRestore();
+    const docsLinks = screen.getAllByRole('link', { name: 'Docs', hidden: true });
+    expect(docsLinks.length).toBeGreaterThan(0);
+    docsLinks.forEach((link) => {
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'));
+    });
   });
 });

--- a/javascript/packages/core/components/navigation-bar/__tests__/navigation-bar.test.tsx
+++ b/javascript/packages/core/components/navigation-bar/__tests__/navigation-bar.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
+import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
+import { NavigationBar } from '../navigation-bar';
+
+import type { NavigationLink } from '../types';
+
+describe('NavigationBar', () => {
+  it('renders the title', () => {
+    render(<NavigationBar />, buildWrapper([getBaseProviderWrapper(), getRouterWrapper()]));
+
+    expect(screen.getAllByText('Michelangelo Studio').length).toBeGreaterThan(0);
+  });
+
+  it('renders navigation links', () => {
+    const links: NavigationLink[] = [
+      { label: 'Docs', href: 'https://example.com/docs' },
+      { label: 'Help', href: 'https://example.com/help' },
+    ];
+
+    render(
+      <NavigationBar links={links} />,
+      buildWrapper([getBaseProviderWrapper(), getRouterWrapper()])
+    );
+
+    expect(screen.getAllByText('Docs').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Help').length).toBeGreaterThan(0);
+  });
+
+  it('opens link in a new tab when clicked', async () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    const links: NavigationLink[] = [{ label: 'Docs', href: 'https://example.com/docs' }];
+
+    render(
+      <NavigationBar links={links} />,
+      buildWrapper([getBaseProviderWrapper(), getRouterWrapper()])
+    );
+    await userEvent.click(screen.getAllByText('Docs')[0]);
+
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://example.com/docs',
+      '_blank',
+      'noopener,noreferrer'
+    );
+
+    openSpy.mockRestore();
+  });
+});

--- a/javascript/packages/core/components/navigation-bar/navigation-bar.tsx
+++ b/javascript/packages/core/components/navigation-bar/navigation-bar.tsx
@@ -1,0 +1,76 @@
+import { AppNavBar } from 'baseui/app-nav-bar';
+import { Button, KIND, SIZE } from 'baseui/button';
+
+import { Link } from '#core/components/link/link';
+
+import type { NavItem } from 'baseui/app-nav-bar';
+import type { Theme } from 'baseui/theme';
+import type { NavigationLink } from './types';
+
+type Props = {
+  links?: NavigationLink[];
+};
+
+export function NavigationBar({ links }: Props) {
+  const mainItems: NavItem[] =
+    links?.map((link) => ({
+      label: link.label,
+      info: { href: link.href },
+    })) ?? [];
+
+  const handleNavigationLinkSelect = (item: NavItem) => {
+    // cast: NavItem.info is typed as `any` in BaseUI
+    const info = item.info as { href: string } | undefined;
+    if (info?.href) {
+      window.open(info.href, '_blank', 'noopener,noreferrer');
+    }
+  };
+
+  return (
+    <AppNavBar
+      title={
+        <Link href="/" overrides={{ Link: { style: { ':hover': { textDecoration: 'unset' } } } }}>
+          Michelangelo Studio
+        </Link>
+      }
+      mainItems={mainItems}
+      onMainItemSelect={handleNavigationLinkSelect}
+      mapItemToNode={(item) => (
+        <Button
+          kind={KIND.tertiary}
+          size={SIZE.compact}
+          overrides={{
+            BaseButton: {
+              style: ({ $theme }: { $theme: Theme }) => ({
+                display: 'flex',
+                alignItems: 'flex-start',
+                whiteSpace: 'nowrap',
+                backgroundColor: 'transparent',
+                ':hover': {
+                  backgroundColor: $theme.colors.backgroundSecondary,
+                },
+              }),
+            },
+          }}
+        >
+          {item.label}
+        </Button>
+      )}
+      overrides={{
+        AppName: { style: { whiteSpace: 'nowrap' } },
+        PrimaryMenuContainer: {
+          style: ({ $theme }: { $theme: Theme }) => ({
+            marginLeft: $theme.sizing.scale1000,
+          }),
+        },
+        DesktopMenu: {
+          style: {
+            height: '64px',
+            boxSizing: 'border-box',
+            paddingBlockStart: '20px',
+          },
+        },
+      }}
+    />
+  );
+}

--- a/javascript/packages/core/components/navigation-bar/navigation-bar.tsx
+++ b/javascript/packages/core/components/navigation-bar/navigation-bar.tsx
@@ -3,28 +3,19 @@ import { Button, KIND, SIZE } from 'baseui/button';
 
 import { Link } from '#core/components/link/link';
 
-import type { NavItem } from 'baseui/app-nav-bar';
 import type { Theme } from 'baseui/theme';
-import type { NavigationLink } from './types';
+import type { LinkNavItem, NavigationLink } from './types';
 
 type Props = {
   links?: NavigationLink[];
 };
 
 export function NavigationBar({ links }: Props) {
-  const mainItems: NavItem[] =
+  const mainItems: LinkNavItem[] =
     links?.map((link) => ({
       label: link.label,
       info: { href: link.href },
     })) ?? [];
-
-  const handleNavigationLinkSelect = (item: NavItem) => {
-    // cast: NavItem.info is typed as `any` in BaseUI
-    const info = item.info as { href: string } | undefined;
-    if (info?.href) {
-      window.open(info.href, '_blank', 'noopener,noreferrer');
-    }
-  };
 
   return (
     <AppNavBar
@@ -34,28 +25,30 @@ export function NavigationBar({ links }: Props) {
         </Link>
       }
       mainItems={mainItems}
-      onMainItemSelect={handleNavigationLinkSelect}
-      mapItemToNode={(item) => (
-        <Button
-          kind={KIND.tertiary}
-          size={SIZE.compact}
-          overrides={{
-            BaseButton: {
-              style: ({ $theme }: { $theme: Theme }) => ({
-                display: 'flex',
-                alignItems: 'flex-start',
-                whiteSpace: 'nowrap',
-                backgroundColor: 'transparent',
-                ':hover': {
-                  backgroundColor: $theme.colors.backgroundSecondary,
+      mapItemToNode={(item) => {
+        // cast: see LinkNavItem's doc comment in types.ts
+        const { href } = (item as LinkNavItem).info;
+        return (
+          <Button
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            kind={KIND.tertiary}
+            size={SIZE.compact}
+            overrides={{
+              BaseButton: {
+                style: {
+                  display: 'flex',
+                  alignItems: 'flex-start',
+                  whiteSpace: 'nowrap',
                 },
-              }),
-            },
-          }}
-        >
-          {item.label}
-        </Button>
-      )}
+              },
+            }}
+          >
+            {item.label}
+          </Button>
+        );
+      }}
       overrides={{
         AppName: { style: { whiteSpace: 'nowrap' } },
         PrimaryMenuContainer: {

--- a/javascript/packages/core/components/navigation-bar/types.ts
+++ b/javascript/packages/core/components/navigation-bar/types.ts
@@ -1,0 +1,4 @@
+export type NavigationLink = {
+  label: string;
+  href: string;
+};

--- a/javascript/packages/core/components/navigation-bar/types.ts
+++ b/javascript/packages/core/components/navigation-bar/types.ts
@@ -1,4 +1,9 @@
+import type { NavItem } from 'baseui/app-nav-bar';
+
 export type NavigationLink = {
   label: string;
   href: string;
 };
+
+/** BaseUI types `mainItems`/`mapItemToNode` against the generic `NavItem` (`info: any`); these are always the entries built from `NavigationLink`s. */
+export type LinkNavItem = Omit<NavItem, 'info'> & { info: { href: string } };

--- a/javascript/packages/core/index.tsx
+++ b/javascript/packages/core/index.tsx
@@ -205,7 +205,3 @@ export type {
   DetailViewTab,
   DetailViewPagesProps,
 } from '#core/components/views/detail-view/types/detail-view-component-types';
-
-// Navigation Bar
-export { NavigationBar } from '#core/components/navigation-bar/navigation-bar';
-export type { NavigationLink } from '#core/components/navigation-bar/types';

--- a/javascript/packages/core/index.tsx
+++ b/javascript/packages/core/index.tsx
@@ -1,14 +1,14 @@
-import { AppNavBar } from 'baseui/app-nav-bar';
 import { LayersManager } from 'baseui/layer';
 import { SnackbarProvider } from 'baseui/snackbar';
 
-import { Link } from '#core/components/link/link';
+import { NavigationBar } from '#core/components/navigation-bar/navigation-bar';
 import { ErrorProvider } from '#core/providers/error-provider/error-provider';
 import { IconProvider } from '#core/providers/icon-provider/icon-provider';
 import { ServiceProvider } from '#core/providers/service-provider/service-provider';
 import { Router } from '#core/router/router';
 import { ThemeProvider } from '#core/themes/theme-provider';
 
+import type { NavigationLink } from '#core/components/navigation-bar/types';
 import type { ErrorContextValue } from '#core/providers/error-provider/types';
 import type { IconProviderContext } from '#core/providers/icon-provider/types';
 import type { ServiceContextType } from '#core/providers/service-provider/types';
@@ -21,6 +21,9 @@ type Props = {
     error: ErrorContextValue;
     service: ServiceContextType;
     theme: IconProviderContext;
+    navigationBar?: {
+      links?: NavigationLink[];
+    };
   };
 };
 
@@ -32,16 +35,7 @@ export function CoreApp({ dependencies }: Props) {
           <ServiceProvider {...dependencies.service}>
             <ErrorProvider {...dependencies.error}>
               <IconProvider icons={dependencies.theme.icons}>
-                <AppNavBar
-                  title={
-                    <Link
-                      href="/"
-                      overrides={{ Link: { style: { ':hover': { textDecoration: 'unset' } } } }}
-                    >
-                      Michelangelo Studio
-                    </Link>
-                  }
-                />
+                <NavigationBar links={dependencies.navigationBar?.links} />
                 <Router />
               </IconProvider>
             </ErrorProvider>
@@ -211,3 +205,7 @@ export type {
   DetailViewTab,
   DetailViewPagesProps,
 } from '#core/components/views/detail-view/types/detail-view-component-types';
+
+// Navigation Bar
+export { NavigationBar } from '#core/components/navigation-bar/navigation-bar';
+export type { NavigationLink } from '#core/components/navigation-bar/types';


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature

**What changed?**

CoreApp previously rendered a hardcoded navigation bar with only a title link. Consumers had no way to add items like documentation links, help channels, or bug report links to the top bar.

The navigation bar is now extracted into its own component and accepts consumer-provided links through a new `dependencies.navigationBar` configuration. Links render as tertiary buttons (transparent at rest, highlighted on hover) and open in new tabs.

Nav items also render as real links rather than buttons that open a new tab through a click handler — native browser behaviors like middle-click and copy-link now work as expected. The component isn't exported from the package's public entry point, since nothing outside the app shell uses it directly yet; it's still assembled internally exactly as before, the same way the router is.

**Why?**

Different deployments of the platform need different navigation links — the OSS app points to GitHub docs, an internal deployment might point to an internal wiki and Slack channel. Making this configurable follows the same provider-based architecture the rest of the dependency system uses.

**How did you test it?**

I ran the dev server and verified the navigation bar renders the configured "Docs" link, that clicking it opens the URL in a new tab, and that it's reachable via keyboard and screen-reader link semantics. I also compared the nav item's styling against the design system's own default button styling and removed a few overrides that turned out to just duplicate those defaults, confirming the rendered output was unchanged before and after.

Hover state:
<img width="1840" height="1106" alt="Screenshot 2026-07-09 at 8 53 50 PM" src="https://github.com/user-attachments/assets/135e14f4-3776-45ec-9aa6-428575205d4e" />


**Potential risks**

Low. The inline `AppNavBar` that was in CoreApp is replaced 1:1 by the new component. Consumers that don't pass `navigationBar` see the same title-only bar as before.

**Breaking Changes**

- [x] No breaking changes

**Release notes**

Navigation bar now supports consumer-configured links via `dependencies.navigationBar.links`.

**Documentation Changes**

N/A — API is self-documenting via TypeScript types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
