### PR TITLE
Strip pagination from table state when pagination is disabled

### DIFF
--- a/javascript/packages/core/components/table/types/table-types.ts
+++ b/javascript/packages/core/components/table/types/table-types.ts
@@ -318,6 +318,16 @@ export type ControlledTableState = TableState & {
 };
 
 /**
+ * Controlled table state with pagination fields removed, for tables that
+ * have pagination disabled and therefore never surface `pagination` or
+ * `setPagination`.
+ */
+export type ControlledTableStateNoPagination = Omit<
+  ControlledTableState,
+  'pagination' | 'setPagination'
+>;
+
+/**
  * Table state that users can provide as input to control table behavior.
  *
  * Excludes `pageIndex` from pagination state to prevent users from being

--- a/javascript/packages/core/components/table/types/table-types.ts
+++ b/javascript/packages/core/components/table/types/table-types.ts
@@ -318,16 +318,6 @@ export type ControlledTableState = TableState & {
 };
 
 /**
- * Controlled table state with pagination fields removed, for tables that
- * have pagination disabled and therefore never surface `pagination` or
- * `setPagination`.
- */
-export type ControlledTableStateNoPagination = Omit<
-  ControlledTableState,
-  'pagination' | 'setPagination'
->;
-
-/**
  * Table state that users can provide as input to control table behavior.
  *
  * Excludes `pageIndex` from pagination state to prevent users from being

--- a/javascript/packages/core/components/table/utils/apply-default-props.tsx
+++ b/javascript/packages/core/components/table/utils/apply-default-props.tsx
@@ -11,6 +11,7 @@ import type { PageSizeOption } from '../components/table-pagination/types';
 import type { TableData } from '../types/data-types';
 import type {
   ControlledTableState,
+  ControlledTableStateNoPagination,
   InputTableState,
   TableProps,
   TablePropsResolved,
@@ -76,8 +77,8 @@ function resolveTableState(
     // Strip pagination — InputTableState.pagination only allows { pageSize? } (no pageIndex),
     // so passing it through would leak a partial shape that callers assume is complete
     const { pagination: _pagination, setPagination: _setPagination, ...rest } = baseState;
-    // cast: spread of non-pagination InputTableState fields
-    return rest as Partial<ControlledTableState>;
+    const noPaginationState: Partial<ControlledTableStateNoPagination> = rest;
+    return noPaginationState;
   }
 
   const requestedPageSize = baseState?.pagination?.pageSize;

--- a/javascript/packages/core/components/table/utils/apply-default-props.tsx
+++ b/javascript/packages/core/components/table/utils/apply-default-props.tsx
@@ -11,7 +11,6 @@ import type { PageSizeOption } from '../components/table-pagination/types';
 import type { TableData } from '../types/data-types';
 import type {
   ControlledTableState,
-  ControlledTableStateNoPagination,
   InputTableState,
   TableProps,
   TablePropsResolved,
@@ -77,7 +76,8 @@ function resolveTableState(
     // Strip pagination — InputTableState.pagination only allows { pageSize? } (no pageIndex),
     // so passing it through would leak a partial shape that callers assume is complete
     const { pagination: _pagination, setPagination: _setPagination, ...rest } = baseState;
-    const noPaginationState: Partial<ControlledTableStateNoPagination> = rest;
+    const noPaginationState: Partial<Omit<ControlledTableState, 'pagination' | 'setPagination'>> =
+      rest;
     return noPaginationState;
   }
 

--- a/javascript/packages/core/components/table/utils/apply-default-props.tsx
+++ b/javascript/packages/core/components/table/utils/apply-default-props.tsx
@@ -73,9 +73,11 @@ function resolveTableState(
   };
 
   if (disablePagination) {
-    // cast: baseState.pagination only allows { pageSize? }, so this can produce a pagination object
-    // missing pageIndex despite the asserted shape; see #1460
-    return baseState as Partial<ControlledTableState>;
+    // Strip pagination — InputTableState.pagination only allows { pageSize? } (no pageIndex),
+    // so passing it through would leak a partial shape that callers assume is complete
+    const { pagination: _pagination, setPagination: _setPagination, ...rest } = baseState;
+    // cast: spread of non-pagination InputTableState fields
+    return rest as Partial<ControlledTableState>;
   }
 
   const requestedPageSize = baseState?.pagination?.pageSize;


### PR DESCRIPTION
## Summary

The `disablePagination` early-return in `resolveTableState` was passing through the user-provided pagination object unchanged. But `InputTableState.pagination` only allows `{ pageSize? }` — no `pageIndex`. The cast to `Partial<ControlledTableState>` asserted the full `PaginationState` shape, masking the missing field.

When pagination is disabled, the pagination state is meaningless. This change strips both `pagination` and `setPagination` from the returned state instead of forwarding a partial object that downstream code could mistakenly trust as complete.

## Test plan

I ran the full table test suite — 307 tests across 29 test files pass. Typecheck clean.

Closes #1460

🤖 Generated with [Claude Code](https://claude.com/claude-code)