### PR TITLE
chore(release): prepare v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,181 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.0] - 2026-07-10
+
+
+### Bug Fixes
+
+
+- **helm,ci:** Nil pointer guards on upgrade + configurable integration-test ref (#1405)
+
+
+- **ci:** Bypass poetry-dynamic-versioning in nightly Python build (#1406)
+
+
+- **ci:** Add helm repo registration before dependency build (#1408)
+
+
+- **ci:** Update npm workspace name in nightly workflow (#1407)
+
+
+- Reflector error monitoring via DefaultWatchErrorHandler (#1319)
+
+
+- **ci:** Fix python and npm nightly publish failures (#1414)
+
+
+- **python:** Sanitize pre-existing model_manager leaks + fix broken custom-packager import (#1431)
+
+
+- **trainer:** Default RunConfig storage to backend bucket on multi-node runs (#1441)
+
+
+- **python:** Train_tabular returns ModelVariable, drops storage_backend (#1442)
+
+
+- **ci:** CVE Scan fails to resolve trivy-action/trivy binary version (#1444)
+
+
+- **spark:** Infer SparkApplication.Type from entrypoint instead of hardcoding Python (#1465)
+
+
+- **python:** Demote oversized/invalid model registry labels to annotation (#1446)
+
+
+- **sandbox:** Add missing minio-credentials secret and kuberay images (#1474)
+
+
+
+### CI/CD
+
+
+- Add Trivy CVE scanning workflow for container images (#1398)
+
+
+- Add cross-compiled Go binary builds to release workflow (#1399)
+
+
+- Add nightly artifact retention cleanup workflow (#1400)
+
+
+- Add API surface change detection for Go, Proto, and Helm (#1402)
+
+
+- Add compatibility testing matrix for Python, Node.js, and Helm (#1403)
+
+
+- Configure Release Drafter for PR-based release notes (#1401)
+
+
+- Notify Slack on scheduled/release workflow failures (#1438)
+
+
+
+### Documentation
+
+
+- Address sandbox setup feedback — timing, sync, missing prereqs, troubleshooting (#1247)
+
+
+
+### Features
+
+
+- **trainer:** Add TrainingObserver protocol for pluggable metrics observation (#1364)
+
+
+- **triggerrun:** Make notification settings updatable post-creation (#1385)
+
+
+- **trainer:** Add tabular_trainer config schema (PR 7a, issue #1359) (#1415)
+
+
+- **ui:** Add description field to pipeline run form and list (#1422)
+
+
+- **trainer:** Tabular_trainer pure helpers module (_dataset.py) [PR 7b] (#1421)
+
+
+- **trainer:** Tabular_trainer dispatcher + ModelMetadata fields (PR 7c) (#1426)
+
+
+- **trainer:** Flexible experiment tracking abstraction (#1432)
+
+
+- **trainer:** Wire MLflow experiment tracking (PR 10) (#1434)
+
+
+- **trainer:** Restore fused_model_submodule to warm-start schema (#1435)
+
+
+- **revision:** Add pluggable Revision controller (#1314)
+
+
+
+### Miscellaneous
+
+
+- Add proxy_user to v2 Trigger message (#1374)
+
+
+- Move Roadmap page to Getting Started section (#1412)
+
+
+- Add Support & Community section to docs landing page (#1386)
+
+
+- Add Dual-Track Pipeline and RFC process to contribution guides (#1387)
+
+
+- Respect primary and secondary actions' disabled state (#1413)
+
+
+- **precommit:** Add gofmt and go vet hooks for Go files (#1420)
+
+
+- Rename pusher/pusher.py -> pusher/task.py; complete task.py convention (#1429)
+
+
+- **examples:** Remove unused notebook_workflow example (#1439)
+
+
+- Delete MAINTAINERS.md (#1449)
+
+
+- Fold successOperations into useStudioMutation (#1455)
+
+
+- Update intro.md (#1467)
+
+
+- Add standalone Support & Community page (#1470)
+
+
+- Add require-cast-comment rule; annotate all existing as-assertions (#1333)
+
+
+- Replace connect_grpc_bridge with grpc_json_transcoder (#1468)
+
+
+- **worker:** Remove stale implementation TODOs in ray/spark starlark plugins (#1475)
+
+
+- Drop skill guidance now enforced by existing eslint rules (#1483)
+
+
+- Add a route successOperation that skips the toast (#1485)
+
+
+
+### Refactoring
+
+
+- **trainer:** Move _dataset.py into a _private/ subpackage (#1433)
+
+
+- **ui:** Centralize mutation middleware in the mutation hook (#1482)
+
 ## Unreleased
 
 ### Added

--- a/cliff.toml
+++ b/cliff.toml
@@ -41,6 +41,7 @@ topo_order = false
 sort_commits = "oldest"
 
 commit_preprocessors = [
+    { pattern = "(?s)\\n.*", replace = "" },
     { pattern = "\\.$", replace = "" },
 ]
 

--- a/helm/michelangelo/Chart.yaml
+++ b/helm/michelangelo/Chart.yaml
@@ -7,8 +7,8 @@ description: |
   and RBAC — into any Kubernetes cluster. Bring your own metadata storage,
   object storage, and workflow engine (Cadence or Temporal).
 type: application
-version: 0.3.0
-appVersion: "0.3.0"
+version: 0.4.0
+appVersion: "0.4.0"
 kubeVersion: ">=1.27.0-0"
 
 dependencies:

--- a/javascript/app/package.json
+++ b/javascript/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@michelangelo/app",
-  "license": "UNLICENSED",
+  "license": "Apache-2.0",
   "version": "0.4.0",
   "private": true,
   "scripts": {

--- a/javascript/app/package.json
+++ b/javascript/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@michelangelo/app",
   "license": "UNLICENSED",
-  "version": "0.1.8",
+  "version": "0.4.0",
   "private": true,
   "scripts": {
     "build": "vite build --config vite.config.ts",

--- a/javascript/packages/core/package.json
+++ b/javascript/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@michelangelo-ai/core",
   "license": "Apache-2.0",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "type": "module",
   "main": "./dist/michelangelo-core.js",
   "module": "./dist/michelangelo-core.js",

--- a/javascript/packages/rpc/package.json
+++ b/javascript/packages/rpc/package.json
@@ -2,7 +2,7 @@
   "name": "@michelangelo-ai/rpc",
   "license": "Apache-2.0",
   "type": "module",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "scripts": {
     "build": "vite build",
     "test": "cd ../../ && yarn test:rpc"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "michelangelo"
-version = "0.3.0"
+version = "0.4.0"
 description = "Michelangelo is an end-to-end model lifecycle management system at large scale"
 authors = ["Michelangelo Team <michelangelo-oss-group@uber.com>"]
 readme = "README.md"

--- a/scripts/version-bump.sh
+++ b/scripts/version-bump.sh
@@ -7,7 +7,7 @@ VERSION_FILES=(
   "python/pyproject.toml"
   "javascript/packages/core/package.json"
   "javascript/packages/rpc/package.json"
-  "website/package.json"
+  "javascript/app/package.json"
   "helm/michelangelo/Chart.yaml"
 )
 
@@ -94,7 +94,7 @@ set_version() {
   printf "  %-50s → %s\n" "python/pyproject.toml" "$new_version"
 
   # JSON package files
-  for file in javascript/packages/core/package.json javascript/packages/rpc/package.json website/package.json; do
+  for file in javascript/packages/core/package.json javascript/packages/rpc/package.json javascript/app/package.json; do
     sed -i.bak "s/\"version\": \"[^\"]*\"/\"version\": \"$new_version\"/" "$REPO_ROOT/$file"
     rm -f "$REPO_ROOT/$file.bak"
     printf "  %-50s → %s\n" "$file" "$new_version"


### PR DESCRIPTION
## Summary

Preparation PR for the v0.4.0 release (Phase 3 "Polish" scope, tracked in #1340).

**Version bump: 0.3.1 → 0.4.0** (minor). Since v0.3.1 there are 10 `feat` commits and one breaking change (`CometParam`/`LightningTrainerParam.comet_param` removed outright in #1432) — no `!`/`BREAKING CHANGE:` marker was used in that commit, but per SemVer's initial-development clause, breaking changes in the `0.x` series bump minor rather than major, consistent with this project's existing `0.3.x` series.

**Two bugs found and fixed while preparing this release:**
1. `scripts/version-bump.sh` and the harness's `check_version_alignment.py` both pointed the "UI app" version at `website/package.json` (the Docusaurus docs site) instead of `javascript/app/package.json` (`@michelangelo/app`, the actual UI). The real UI app version had been stuck at a stale `0.1.8` since this project started and was never covered by version tooling. Fixed both scripts; UI app is now correctly at `0.4.0`.
2. `cliff.toml` had no commit-body preprocessor, so non-conventional commits (missing a `type:` prefix) dumped their entire PR description (Summary/Test Plan/Context sections) into the changelog's "Miscellaneous" section — turned a ~50-commit range into a 16,000+ line changelog. Added a preprocessor to strip everything after the first line before grouping.

## Changes
- All component versions bumped to `0.4.0`: `python/pyproject.toml`, `javascript/packages/{core,rpc}/package.json`, `javascript/app/package.json`, `helm/michelangelo/Chart.yaml` (version + appVersion)
- `CHANGELOG.md`: new `[0.4.0]` section generated via `git-cliff v0.3.1..HEAD`, prepended above the existing hand-maintained `Unreleased` section (left untouched — it documents an already-shipped v0.3.x change plus additional context worth preserving)

## Test plan
- [x] `scripts/version-bump.sh --check` confirms all components aligned at `0.4.0`
- [x] Verified `javascript/app/package.json` (`@michelangelo/app`) is the real UI app, not `website/package.json`
- [x] Verified the `CometParam` removal commit (`df94eb90` / #1432) is new since `v0.3.1`, and the cascade-delete breaking-change note in `CHANGELOG.md`'s `Unreleased` section predates `v0.3.1` (already shipped, confirmed via `git merge-base --is-ancestor`)
- [ ] After merge: tag `v0.4.0-rc.1` on this branch, let CI publish RC artifacts, begin 1-week soak period per `skills/release_process.md`