### PR TITLE
ci: run CI on release/v* branches

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -2,7 +2,7 @@ name: Go Lint & TODO Tracking
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, 'release/v*']
     paths:
       - 'go/**/*.go'
       - 'go/.golangci.yml'

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,7 +2,7 @@ name: Python Ruff Lint & Format
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, 'release/v*']
     paths:
       - 'python/**'
       - '.github/workflows/lint.yaml'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,13 +3,13 @@ name: Bazel Test
 # Trigger the workflow on push and pull request events for the main branch
 on:
   push:
-    branches: [main]
+    branches: [main, 'release/v*']
     paths-ignore:
       - 'docs/**'
       - 'website/**'
       - 'javascript/**'
   pull_request:
-    branches: [main]
+    branches: [main, 'release/v*']
     paths-ignore:
       - 'docs/**'
       - 'website/**'


### PR DESCRIPTION
## Summary
- Add `release/v*` to the `push`/`pull_request` branch filters in `main.yml` (Bazel Test), `lint.yaml` (Ruff), and `go-lint.yml` (Go lint) so CI runs on release branches, not just `main`.

Part of #1395.

## Test plan
- [x] `actionlint` on all three modified workflow files — only pre-existing shellcheck/action-version findings unrelated to this change; `main.yml` has zero findings
- [x] Confirmed `release/v*` matches the `release/v0.4` branch pattern used by the current release