### PR TITLE
ci(release): npm-publish workflow_call + PyPI PEP 440 normalization

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,6 +2,7 @@ name: Publish @michelangelo-ai/core to npm
 
 on:
   workflow_dispatch:
+  workflow_call:
   push:
     branches: [main]
     paths:
@@ -34,7 +35,7 @@ jobs:
 
   publish:
     needs: check-version-change
-    if: needs.check-version-change.outputs.version-changed == 'true' || github.event_name == 'workflow_dispatch'
+    if: needs.check-version-change.outputs.version-changed == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,6 +3,11 @@ name: Publish @michelangelo-ai/core to npm
 on:
   workflow_dispatch:
   workflow_call:
+    inputs:
+      ref:
+        description: 'Branch/tag/SHA to publish from (defaults to the calling workflow ref)'
+        required: false
+        type: string
   push:
     branches: [main]
     paths:
@@ -18,6 +23,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 2
 
       - name: Check if core package.json version changed
@@ -45,6 +51,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,10 +27,30 @@ jobs:
         with:
           working-directory: './python'
       #----------------------------------------------
+      #  Normalize the git tag to a PEP 440 version
+      #  (poetry-dynamic-versioning enforces PEP 440, so
+      #  SemVer pre-release tags like v0.4.0-rc.1 must be
+      #  converted to 0.4.0rc1 before build/publish)
+      #----------------------------------------------
+      - name: Normalize version for PyPI (PEP 440)
+        id: pep440
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          if [[ "$TAG" =~ ^([0-9]+\.[0-9]+\.[0-9]+)-rc\.([0-9]+)$ ]]; then
+            VERSION="${BASH_REMATCH[1]}rc${BASH_REMATCH[2]}"
+          else
+            VERSION="$TAG"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+      - name: Set poetry version
+        run: poetry version "${{ steps.pep440.outputs.version }}"
+      #----------------------------------------------
       #  Build the wheel file
       #----------------------------------------------
       - run: |
           poetry build -f wheel
+        env:
+          POETRY_DYNAMIC_VERSIONING_BYPASS: ${{ steps.pep440.outputs.version }}
       #----------------------------------------------
       #  Publish to PyPI
       #----------------------------------------------
@@ -38,6 +58,8 @@ jobs:
         run: poetry config pypi-token.pypi ${{ secrets.PYPI_API_TOKEN }}
       - name: Publish to PyPI
         run: poetry publish --no-interaction
+        env:
+          POETRY_DYNAMIC_VERSIONING_BYPASS: ${{ steps.pep440.outputs.version }}
       #----------------------------------------------
       #  Upload the wheel file to the release
       #----------------------------------------------


### PR DESCRIPTION
## Summary
- `npm-publish.yml`: add `workflow_call` trigger so `release-promote.yml` (task 029) can invoke npm publish directly, without depending on a `main`-branch push to `javascript/packages/core/**`.
- `release.yaml`: normalize SemVer RC tags (`v0.4.0-rc.1`) to PEP 440 (`0.4.0rc1`) before `poetry build`/`poetry publish`, reusing the `POETRY_DYNAMIC_VERSIONING_BYPASS` mechanism already used in `nightly.yml` — otherwise `poetry-dynamic-versioning` derives the version from `git describe` and ignores `poetry version`.

Part of #1395. Dashboard: https://vibe-mcp.uberinternal.com/v/webdocs/#/d/ma-oss-release

## Test plan
- [x] `actionlint` on both files — only pre-existing shellcheck info findings unrelated to this change
- [x] Verified the PEP 440 regex against `v0.4.0-rc.1` → `0.4.0rc1` and plain `v0.4.0` → `0.4.0`