### PR TITLE
ci(release): add release-promote.yml workflow

### DIFF
--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -17,6 +17,8 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
+    outputs:
+      branch: ${{ steps.vars.outputs.branch }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -49,7 +51,7 @@ jobs:
       - name: Validate CI is green on release branch
         run: |
           SHA=$(git rev-parse HEAD)
-          STATES=$(gh api "repos/${{ github.repository }}/commits/$SHA/check-runs" --jq '.check_runs[] | select(.status != "completed" or .conclusion != "success") | .name')
+          STATES=$(gh api --paginate "repos/${{ github.repository }}/commits/$SHA/check-runs" --jq '.check_runs[] | select(.status != "completed" or (.conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral")) | .name')
           if [ -n "$STATES" ]; then
             echo "ERROR: the following checks are not green on ${{ steps.vars.outputs.branch }}@$SHA:"
             echo "$STATES"
@@ -96,7 +98,12 @@ jobs:
 
   publish-npm:
     needs: promote
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/npm-publish.yml
+    with:
+      ref: ${{ needs.promote.outputs.branch }}
     secrets: inherit
 
   notify-on-failure:

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -1,0 +1,115 @@
+name: Release Promote
+
+# Promote the latest RC on a release branch to the final release: verify CI
+# is green, strip the RC suffix, tag the final version, publish npm, and
+# mark the merge-back PR ready for review.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Final release version being promoted, no prerelease suffix (e.g. 0.4.0)'
+        required: true
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Compute branch and tag
+        id: vars
+        run: |
+          VERSION="${{ inputs.version }}"
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "ERROR: version must be a plain X.Y.Z SemVer, got '$VERSION'"
+            exit 1
+          fi
+          MAJOR_MINOR=$(echo "$VERSION" | cut -d. -f1,2)
+          BRANCH="release/v${MAJOR_MINOR}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Check out release branch
+        run: git checkout -B "${{ steps.vars.outputs.branch }}" "origin/${{ steps.vars.outputs.branch }}"
+
+      - name: Validate CI is green on release branch
+        run: |
+          SHA=$(git rev-parse HEAD)
+          STATES=$(gh api "repos/${{ github.repository }}/commits/$SHA/check-runs" --jq '.check_runs[] | select(.status != "completed" or .conclusion != "success") | .name')
+          if [ -n "$STATES" ]; then
+            echo "ERROR: the following checks are not green on ${{ steps.vars.outputs.branch }}@$SHA:"
+            echo "$STATES"
+            exit 1
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Strip RC suffix and set final version
+        run: |
+          bash scripts/version-bump.sh "${{ steps.vars.outputs.version }}"
+          git add -A
+          git commit -m "chore: release ${{ steps.vars.outputs.version }}"
+          git push origin "${{ steps.vars.outputs.branch }}"
+
+      - name: Tag final release
+        run: |
+          git tag "${{ steps.vars.outputs.tag }}"
+          git push origin "${{ steps.vars.outputs.tag }}"
+
+      - name: Mark merge-back PR ready for review
+        run: |
+          PR_NUMBER=$(gh pr list --head "${{ steps.vars.outputs.branch }}" --base main --state open --json number --jq '.[0].number')
+          if [ -z "$PR_NUMBER" ]; then
+            echo "WARNING: no open merge-back PR found for ${{ steps.vars.outputs.branch }} -> main"
+          else
+            gh pr ready "$PR_NUMBER"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Comment on tracking issue
+        run: |
+          ISSUE_NUMBER=$(gh issue list --search "in:title \"Release v${{ steps.vars.outputs.version }}\"" --state open --json number,title \
+            --jq '.[] | select(.title == "Release v${{ steps.vars.outputs.version }}") | .number' | head -1)
+          if [ -z "$ISSUE_NUMBER" ]; then
+            echo "WARNING: no open tracking issue found for Release v${{ steps.vars.outputs.version }}"
+          else
+            gh issue comment "$ISSUE_NUMBER" \
+              --body "Promoted to final: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ steps.vars.outputs.tag }}. Artifact publish run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-npm:
+    needs: promote
+    uses: ./.github/workflows/npm-publish.yml
+    secrets: inherit
+
+  notify-on-failure:
+    needs: [promote, publish-npm]
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack on failure
+        uses: slackapi/slack-github-action@v1.27.0
+        with:
+          channel-id: 'C0BER0RCQ8P'
+          slack-message: |
+            :x: *${{ github.workflow }}* failed promoting v${{ inputs.version }}
+            Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
## Summary
- New `workflow_dispatch` workflow `release-promote.yml` that promotes the latest RC on a release branch to the final release:
  - Validates all check-runs are green on `release/vX.Y`'s HEAD before doing anything.
  - Strips the `-rc.N` suffix via `scripts/version-bump.sh` and commits the final version.
  - Tags `vX.Y.Z` (triggers `release.yaml`'s full artifact publish — PyPI, Go binaries, Helm).
  - Invokes `npm-publish.yml` via `workflow_call` (added in #1492).
  - Marks the merge-back PR (opened by `release-cut.yml`, #1493) ready for review.
  - Comments on the tracking issue with links to the release and the publish run.
  - Notifies Slack on failure, matching `release.yaml`'s existing pattern.

**Depends on #1492** — `actionlint` currently reports the reusable-workflow reference to `npm-publish.yml` as unresolved because `main` doesn't yet have the `workflow_call` trigger added there; this resolves once #1492 merges.

Part of #1395. Dashboard: https://vibe-mcp.uberinternal.com/v/webdocs/#/d/ma-oss-release

## Test plan
- [x] `actionlint` — one expected failure pending #1492 merge (documented above), otherwise only a pre-existing style-level shellcheck note
- [x] Traced the promotion logic against `skills/release_process.md`'s "RELEASE" step list
- [ ] Not exercised end-to-end — verified statically, consistent with tasks 026/028