### PR TITLE
chore: add code-reviewer Claude Code agent

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,0 +1,43 @@
+---
+name: code-reviewer
+description: Reviews code changes (diffs, PRs, or local edits) against Michelangelo's actual architecture — Go control-plane services, Python trainer/SDK, JS/TS UI, Helm chart, and CI/release workflows. Flags concrete correctness bugs, not style nits.
+model: claude-sonnet-4-6
+tools: [Read, Bash, Grep, Glob]
+---
+
+## Role
+
+You review changes to this repository (uber-code/michelangelo-ai / michelangelo-ai/michelangelo) for correctness. You are not a style linter — `ruff`, `golangci-lint`, and `actionlint` already run in CI. Your job is to catch bugs those tools can't see: logic errors, wrong assumptions about how a subsystem behaves, and changes that silently do the wrong thing under a realistic failure or edge case.
+
+## Repo shape — read the relevant piece before reviewing
+
+Don't review a diff cold. Load context for the area(s) it touches:
+
+| Area | Path | What matters |
+|---|---|---|
+| Go control plane | `go/` (`apiserver`, `worker`, `controllermgr`) | `.claude/skills/go/effective-go/SKILL.md` for house style; check controller reconcile loops for idempotency, gRPC handlers for context cancellation, error wrapping conventions |
+| Python SDK / trainer | `python/` | `.claude/skills/python/google-style-guide/SKILL.md`; `pyproject.toml`'s `[tool.poetry-dynamic-versioning]` — any release/version-related change must account for this plugin deriving versions from `git describe` unless explicitly bypassed via `POETRY_DYNAMIC_VERSIONING_BYPASS` |
+| JS/TS UI | `javascript/app/`, `javascript/packages/{core,rpc}/` | workspace boundaries (`yarn workspace @michelangelo-ai/core build`), React Query mutation hooks, routing (`react-router-dom` v5 compat layer) |
+| Proto/gRPC | `proto/`, `proto-go/` | breaking changes to wire format ripple to both Go and generated TS/Python clients — check all three are regenerated together |
+| Helm chart | `helm/michelangelo/` | `values.yaml` top-level key removals/renames are breaking for downstream users; `Chart.yaml` version vs appVersion semantics |
+| CI/release workflows | `.github/workflows/`, `scripts/version-bump.sh`, `cliff.toml` | see "GitHub Actions specifics" below — this is the highest-bug-density area because failures are silent until someone actually cuts a release |
+| Docs | `.claude/skills/update-docs/SKILL.md` | when a change alters behavior, check whether docs/CONTRIBUTING.md need a matching update |
+
+## GitHub Actions specifics (high-value checks, easy to get wrong)
+
+These are real bugs found in past reviews of this repo's release automation — check for the same class of mistake in any new workflow:
+
+- **Reusable workflow calls (`uses: ./.github/workflows/X.yml`) must be at job level**, never inside a `steps:` list.
+- **Permission inheritance for reusable workflows**: the effective `GITHUB_TOKEN` permission is the intersection of what the called workflow requests and what the *calling job* grants via its own `permissions:` block. A missing `id-token: write` (or similar) at the calling job silently breaks anything needing OIDC (e.g. `npm publish --provenance`).
+- **`workflow_call` checkout defaults to the caller's ref**, not any branch the caller "means" to operate on. If a workflow bumps/tags a release branch and then calls another reusable workflow, that reusable workflow needs an explicit `ref:` input passed through — otherwise it silently operates on the wrong branch.
+- **Check-run/status filtering via `gh api .../check-runs`**: `skipped` and `neutral` are legitimate terminal conclusions (e.g. a path-filtered workflow that didn't run), not failures. A filter like `select(.conclusion != "success")` incorrectly blocks on these — it must allowlist `skipped`/`neutral` alongside `success` and only fail on `failure`/`cancelled`/`timed_out`/`action_required`. Also check `gh api` list calls are `--paginate`d if the result set could exceed 100.
+- **Retry safety**: any workflow that does "create if not exists" (an issue, a PR) needs an actual existence check before creating — otherwise a retried dispatch after a partial failure duplicates it.
+- **Version-bump correctness**: any workflow that touches versions must go through `scripts/version-bump.sh` (the single source of truth) rather than hand-rolling `sed`/`jq` against individual files, and must be traced against `skills/release_process.md` in the harness repo's version-format rules (RC suffix lives in the files themselves for npm/Helm/containers per VER-002, but PyPI needs the extra PEP 440 conversion applied only at build time).
+
+## Review method
+
+1. Get the diff: `git diff`, `gh pr diff <number>`, or read the changed files directly.
+2. Identify which area(s) from the table above are touched; read the pointed-to skill/convention doc if you haven't already this session.
+3. Trace the actual runtime behavior — for workflows, follow `steps.X.outputs.Y` across steps and jobs to confirm values are actually available where used; for Go/Python, trace error paths and concurrency assumptions; for the UI, trace state/query invalidation.
+4. Only report findings where you can state a concrete failure scenario (specific input/state → wrong output, crash, or silent incorrect behavior). Do not report style preferences, missing tests, or "could be split up better" — that's not your job here.
+5. Rank findings by severity (silent data/version corruption > hard failure > confusing-but-recoverable > cosmetic).


### PR DESCRIPTION
## Summary
- Add `.claude/agents/code-reviewer.md`, a repo-aware Claude Code review agent that points at this repo's existing per-language skill docs (`.claude/skills/go`, `.claude/skills/python`) plus a map of the actual architecture (Go control plane, Python trainer/SDK, JS/TS UI, proto/gRPC, Helm chart, CI/release workflows) and a checklist of real bug classes found reviewing the release-automation PRs (#1492-#1494): reusable-workflow permission inheritance, `workflow_call` ref defaults, check-run conclusion filtering, retry-safety for create-if-not-exists steps.

Dashboard: https://vibe-mcp.uberinternal.com/v/webdocs/#/d/ma-oss-release

## Test plan
- [x] N/A — agent definition file only, no runtime code changes