### PR TITLE
Populate ColumnMeta augmentation to eliminate columnDef.meta casts

### DIFF
--- a/javascript/packages/core/components/table/components/table-body/row-transformer.ts
+++ b/javascript/packages/core/components/table/components/table-body/row-transformer.ts
@@ -3,7 +3,6 @@ import React from 'react';
 import { TableCellContent } from './table-cell-content';
 
 import type { Row } from '@tanstack/react-table';
-import type { ColumnConfig } from '#core/components/table/types/column-types';
 import type { TableData } from '#core/components/table/types/data-types';
 import type { TableRow } from '#core/components/table/types/row-types';
 
@@ -19,9 +18,7 @@ export function transformRows<T extends TableData = TableData>(
         row,
         columnIndex,
       }),
-      // cast: our ColumnMeta augmentation is an empty interface (TS can't have it extend the
-      // Cell<TData> union); always ColumnConfig<T> per our column setup; see #1417
-      column: cell.column.columnDef.meta! as ColumnConfig<T>,
+      column: cell.column.columnDef.meta!,
       value: cell.getValue(),
       isVisible: cell.column.getIsVisible(),
     })),

--- a/javascript/packages/core/components/table/components/table-cell/types.ts
+++ b/javascript/packages/core/components/table/components/table-cell/types.ts
@@ -5,7 +5,7 @@ import type { TableData } from '#core/components/table/types/data-types';
 import type { TableRow } from '#core/components/table/types/row-types';
 
 export interface TableCellProps<T extends TableData = TableData>
-  extends CellRendererProps<T, ColumnConfig> {
+  extends CellRendererProps<T, ColumnConfig<T>> {
   columnFilterValue?: unknown;
   row: TableRow<T>;
   setColumnFilterValue?: (value: unknown) => void;

--- a/javascript/packages/core/components/table/hooks/use-column-transformer.tsx
+++ b/javascript/packages/core/components/table/hooks/use-column-transformer.tsx
@@ -52,10 +52,7 @@ export function useColumnTransformer<T extends TableData = TableData>(
         header: column.label,
         cell: (props: CellContext<T, unknown>) => (
           <TableCell<T>
-            // cast: our ColumnMeta augmentation is an empty interface (TS can't have it extend the
-            // Cell<TData> union); always ColumnConfig when built via useColumnTransformer; see
-            // #1417
-            column={props.column.columnDef.meta! as ColumnConfig}
+            column={props.column.columnDef.meta!}
             row={transformRows<T>([props.row])[0]}
             // cast: TableData = unknown by convention; row.original is always a plain record
             // object; see #1416
@@ -68,10 +65,7 @@ export function useColumnTransformer<T extends TableData = TableData>(
         aggregatedCell: (props: CellContext<T, unknown>) =>
           column.aggregatedCell ? (
             <column.aggregatedCell
-              // cast: our ColumnMeta augmentation is an empty interface (TS can't have it extend
-              // the Cell<TData> union); always ColumnConfig when built via useColumnTransformer;
-              // see #1417
-              column={props.column.columnDef.meta! as ColumnConfig<T>}
+              column={props.column.columnDef.meta!}
               // cast: TableData = unknown by convention; row.original is always a plain record
               // object; see #1416
               record={props.row.original as object}
@@ -79,10 +73,7 @@ export function useColumnTransformer<T extends TableData = TableData>(
             />
           ) : (
             <TableCell<T>
-              // cast: our ColumnMeta augmentation is an empty interface (TS can't have it extend
-              // the Cell<TData> union); always ColumnConfig when built via useColumnTransformer;
-              // see #1417
-              column={props.column.columnDef.meta! as ColumnConfig}
+              column={props.column.columnDef.meta!}
               row={transformRows<T>([props.row])[0]}
               // cast: TableData = unknown by convention; row.original is always a plain record
               // object; see #1416

--- a/javascript/packages/core/components/table/hooks/use-column-transformer.tsx
+++ b/javascript/packages/core/components/table/hooks/use-column-transformer.tsx
@@ -52,7 +52,10 @@ export function useColumnTransformer<T extends TableData = TableData>(
         header: column.label,
         cell: (props: CellContext<T, unknown>) => (
           <TableCell<T>
-            column={props.column.columnDef.meta!}
+            // cast: ColumnMeta<T, unknown> is not assignable to ColumnConfig when T is generic
+            // — TypeScript cannot verify union-type assignability for unresolved type parameters;
+            // safe at runtime because meta is set from ColumnConfig<T> in the meta: column mapping
+            column={props.column.columnDef.meta! as ColumnConfig}
             row={transformRows<T>([props.row])[0]}
             // cast: TableData = unknown by convention; row.original is always a plain record
             // object; see #1416
@@ -65,7 +68,10 @@ export function useColumnTransformer<T extends TableData = TableData>(
         aggregatedCell: (props: CellContext<T, unknown>) =>
           column.aggregatedCell ? (
             <column.aggregatedCell
-              column={props.column.columnDef.meta!}
+              // cast: ColumnMeta<T, unknown> is not assignable to ColumnConfig when T is generic
+              // — TypeScript cannot verify union-type assignability for unresolved type parameters;
+              // safe at runtime because meta is set from ColumnConfig<T> in the meta: column mapping
+              column={props.column.columnDef.meta! as ColumnConfig<T>}
               // cast: TableData = unknown by convention; row.original is always a plain record
               // object; see #1416
               record={props.row.original as object}
@@ -73,7 +79,10 @@ export function useColumnTransformer<T extends TableData = TableData>(
             />
           ) : (
             <TableCell<T>
-              column={props.column.columnDef.meta!}
+              // cast: ColumnMeta<T, unknown> is not assignable to ColumnConfig when T is generic
+              // — TypeScript cannot verify union-type assignability for unresolved type parameters;
+              // safe at runtime because meta is set from ColumnConfig<T> in the meta: column mapping
+              column={props.column.columnDef.meta! as ColumnConfig}
               row={transformRows<T>([props.row])[0]}
               // cast: TableData = unknown by convention; row.original is always a plain record
               // object; see #1416

--- a/javascript/packages/core/components/table/hooks/use-column-transformer.tsx
+++ b/javascript/packages/core/components/table/hooks/use-column-transformer.tsx
@@ -52,10 +52,7 @@ export function useColumnTransformer<T extends TableData = TableData>(
         header: column.label,
         cell: (props: CellContext<T, unknown>) => (
           <TableCell<T>
-            // cast: ColumnMeta<T, unknown> is not assignable to ColumnConfig when T is generic
-            // — TypeScript cannot verify union-type assignability for unresolved type parameters;
-            // safe at runtime because meta is set from ColumnConfig<T> in the meta: column mapping
-            column={props.column.columnDef.meta! as ColumnConfig}
+            column={props.column.columnDef.meta!}
             row={transformRows<T>([props.row])[0]}
             // cast: TableData = unknown by convention; row.original is always a plain record
             // object; see #1416
@@ -68,10 +65,7 @@ export function useColumnTransformer<T extends TableData = TableData>(
         aggregatedCell: (props: CellContext<T, unknown>) =>
           column.aggregatedCell ? (
             <column.aggregatedCell
-              // cast: ColumnMeta<T, unknown> is not assignable to ColumnConfig when T is generic
-              // — TypeScript cannot verify union-type assignability for unresolved type parameters;
-              // safe at runtime because meta is set from ColumnConfig<T> in the meta: column mapping
-              column={props.column.columnDef.meta! as ColumnConfig<T>}
+              column={props.column.columnDef.meta!}
               // cast: TableData = unknown by convention; row.original is always a plain record
               // object; see #1416
               record={props.row.original as object}
@@ -79,10 +73,7 @@ export function useColumnTransformer<T extends TableData = TableData>(
             />
           ) : (
             <TableCell<T>
-              // cast: ColumnMeta<T, unknown> is not assignable to ColumnConfig when T is generic
-              // — TypeScript cannot verify union-type assignability for unresolved type parameters;
-              // safe at runtime because meta is set from ColumnConfig<T> in the meta: column mapping
-              column={props.column.columnDef.meta! as ColumnConfig}
+              column={props.column.columnDef.meta!}
               row={transformRows<T>([props.row])[0]}
               // cast: TableData = unknown by convention; row.original is always a plain record
               // object; see #1416

--- a/javascript/packages/core/components/table/types/column-types.ts
+++ b/javascript/packages/core/components/table/types/column-types.ts
@@ -1,6 +1,6 @@
 import '@tanstack/react-table'; //or vue, svelte, solid, qwik, etc.
 
-import type { AggregationFnOption, SortingFnOption } from '@tanstack/react-table';
+import type { AggregationFnOption, ColumnMeta, SortingFnOption } from '@tanstack/react-table';
 import type { ComponentType, ReactNode } from 'react';
 import type {
   Cell,
@@ -112,6 +112,10 @@ export type ColumnConfig<TData = TableData> = DistributiveOmit<Cell<TData>, 'too
    */
   tooltip?: ColumnTooltip<TData>;
 };
+
+/** @internal Fails with TS2344 if ColumnMeta diverges from ColumnConfig.
+ * Add missing fields to the ColumnMeta interface above to restore the check. */
+export type CheckColumnMetaSync<T extends ColumnConfig = ColumnMeta<TableData, unknown>> = T;
 
 /**
  * Base column properties extracted from ColumnConfig for rendering.

--- a/javascript/packages/core/components/table/types/column-types.ts
+++ b/javascript/packages/core/components/table/types/column-types.ts
@@ -2,17 +2,40 @@ import '@tanstack/react-table'; //or vue, svelte, solid, qwik, etc.
 
 import type { AggregationFnOption, SortingFnOption } from '@tanstack/react-table';
 import type { ComponentType, ReactNode } from 'react';
-import type { Cell, CellRendererProps, CellTooltip } from '#core/components/cell/types';
+import type {
+  Cell,
+  CellRenderer,
+  CellRendererProps,
+  CellTooltip,
+  SharedCell,
+} from '#core/components/cell/types';
+import type { Accessor } from '#core/types/common/studio-types';
 import type { DistributiveOmit } from '#core/types/utility-types';
 import type { FilterMode } from '../components/filter/types';
 import type { TableData } from './data-types';
 import type { TableRow } from './row-types';
 
 declare module '@tanstack/react-table' {
-  // ColumnConfig cannot be used here to eliminate meta casts: Cell<TData> is a union type,
-  // and TypeScript does not allow interfaces to extend union types; see #1417
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-object-type
-  interface ColumnMeta<TData extends TableData, TValue> {}
+  // ColumnConfig cannot extend ColumnMeta directly because Cell<TData> is a union type
+  // (TypeScript does not allow interfaces to extend union types). Instead, all ColumnConfig
+  // fields are listed explicitly here so column.columnDef.meta is typed without a cast.
+  interface ColumnMeta<TData extends TableData, TValue> {
+    id: string;
+    accessor?: Accessor<TData, TValue>;
+    label?: string;
+    type?: string;
+    icon?: string;
+    endEnhancer?: SharedCell['endEnhancer'];
+    Cell?: CellRenderer<TValue>;
+    style?: SharedCell['style'];
+    filterMode?: FilterMode;
+    enableSorting?: boolean;
+    enableGrouping?: boolean;
+    aggregationFn?: AggregationFnOption<TData>;
+    aggregatedCell?: ComponentType<CellRendererProps<TData, ColumnConfig<TData>>>;
+    sortingFn?: SortingFnOption<TData>;
+    tooltip?: ColumnTooltip<TData>;
+  }
 }
 
 export type ColumnConfig<TData = TableData> = DistributiveOmit<Cell<TData>, 'tooltip'> & {

--- a/javascript/packages/core/components/table/utils/column-resolution-utils.ts
+++ b/javascript/packages/core/components/table/utils/column-resolution-utils.ts
@@ -41,7 +41,7 @@ import type { TableData } from '#core/components/table/types/data-types';
 export function resolveColumnForRow<T extends TableData = TableData>(
   column: ColumnConfig<T>,
   // TableData = unknown makes T extends TableData unconstrained; row: T causes TS2345
-  // when callers pass record: object. Restore row: T once TableData = Record<string, unknown>
+  // when callers pass record: object. Restore row: T once TableData = Record<string, unknown>; see #1416
   row: unknown
 ): ColumnConfig<T> {
   // TODO: #277 generalize typeMeta.kind access in a type-safe way

--- a/javascript/packages/core/components/table/utils/column-resolution-utils.ts
+++ b/javascript/packages/core/components/table/utils/column-resolution-utils.ts
@@ -40,7 +40,7 @@ import type { TableData } from '#core/components/table/types/data-types';
  */
 export function resolveColumnForRow<T extends TableData = TableData>(
   column: ColumnConfig<T>,
-  row: T
+  row: unknown
 ): ColumnConfig<T> {
   // TODO: #277 generalize typeMeta.kind access in a type-safe way
   // @ts-expect-error - typeMeta may not exist on generic type T, but we handle it safely with optional chaining

--- a/javascript/packages/core/components/table/utils/column-resolution-utils.ts
+++ b/javascript/packages/core/components/table/utils/column-resolution-utils.ts
@@ -40,6 +40,8 @@ import type { TableData } from '#core/components/table/types/data-types';
  */
 export function resolveColumnForRow<T extends TableData = TableData>(
   column: ColumnConfig<T>,
+  // TableData = unknown makes T extends TableData unconstrained; row: T causes TS2345
+  // when callers pass record: object. Restore row: T once TableData = Record<string, unknown>
   row: unknown
 ): ColumnConfig<T> {
   // TODO: #277 generalize typeMeta.kind access in a type-safe way

--- a/javascript/packages/core/components/table/utils/transform-columns.ts
+++ b/javascript/packages/core/components/table/utils/transform-columns.ts
@@ -23,9 +23,7 @@ export function transformColumns<T extends TableData = TableData>(
     VisibilityCapability
 > {
   return columns.map((column) => {
-    // cast: our ColumnMeta augmentation is an empty interface (TS can't have it extend the
-    // Cell<TData> union); always ColumnConfig<T> per our column definition setup; see #1417
-    const columnConfig = column.columnDef.meta! as ColumnConfig<T>;
+    const columnConfig = column.columnDef.meta!;
     const label = columnConfig.label ?? column.id;
 
     return {


### PR DESCRIPTION
The TanStack module augmentation hook for `column.columnDef.meta` was in place but empty, because `ColumnConfig`'s type is built from a discriminated union and TypeScript won't allow an interface to extend a union type directly. Populating the augmentation field-by-field achieves the same structural equivalence and removes the cast at every meta access site.

Removing those casts surfaced a second problem: the cell props interface dropped the generic record type when specifying the column type, widening it to `unknown`. Passing augmented meta where the widened column type was expected failed on contravariant function fields. Restoring the type parameter to the column prop keeps both sides consistent and lets TypeScript verify union assignability.

The row parameter in the column resolution utility is widened from `T` to `unknown`: the function never uses row's type-specific structure (it already accesses a dynamic property behind `@ts-expect-error`), and `TableData = unknown` makes the constraint vacuous anyway. It should narrow back when `TableData` tightens to a record type per #1416.

A compile-time guard is added: if a new required field is added to `ColumnConfig` without a matching entry in the augmentation, a TS2344 error fires at the guard's declaration. Optional fields are not caught (structural assignability doesn't require them), so those still need to be synced by hand.

## Test plan

I verified the compile-time guard by temporarily adding a required field to `ColumnConfig` without adding it to `ColumnMeta`:

```
components/table/types/column-types.ts(119,58): error TS2344: Type 'ColumnMeta<unknown, unknown>' does not satisfy the constraint 'ColumnConfig<unknown>'.
```

Closes #1417