### PR TITLE
fix(ci): release-cut/promote tags never triggered artifact publish

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -24,6 +24,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
+      actions: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -80,6 +81,17 @@ jobs:
         run: |
           git tag "${{ steps.vars.outputs.tag }}"
           git push origin "${{ steps.vars.outputs.tag }}"
+
+      - name: Trigger artifact publish for the RC tag
+        run: |
+          gh workflow run release.yaml --ref "${{ steps.vars.outputs.tag }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Ensure the release tracking label exists
+        run: gh label create release --color ededed --description "Release tracking issue" --force
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Find existing tracking issue
         id: find_issue

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -17,6 +17,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
+      actions: write
     outputs:
       branch: ${{ steps.vars.outputs.branch }}
     steps:
@@ -71,6 +72,12 @@ jobs:
         run: |
           git tag "${{ steps.vars.outputs.tag }}"
           git push origin "${{ steps.vars.outputs.tag }}"
+
+      - name: Trigger artifact publish for the final tag
+        run: |
+          gh workflow run release.yaml --ref "${{ steps.vars.outputs.tag }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Mark merge-back PR ready for review
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,7 @@ name: build-release
 on:
   push:
     tags: ["v*"]
+  workflow_dispatch: {}
 jobs:
   build-upload:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Found while actually dispatching `release-cut.yml` for v0.4.0-rc.1: the release branch and RC tag were created, but `release.yaml` (PyPI/Go/Helm publish) never ran, and the run itself failed before opening the tracking issue/merge-back PR.

Two distinct bugs:
1. **GITHUB_TOKEN pushes don't trigger other workflows.** GitHub Actions blocks a `GITHUB_TOKEN`-authored push from firing other workflows (anti-recursion protection). `release-cut.yml`/`release-promote.yml` push the RC/final tag using the default token, so `release.yaml`'s `push: tags` trigger silently never fired. Fix: add `workflow_dispatch` to `release.yaml` and have both callers explicitly `gh workflow run release.yaml --ref <tag>` right after pushing the tag (the documented workaround for this exact scenario), with `actions: write` added to both jobs' permissions.
2. **Missing `release` label.** `gh issue create --label release` failed with `could not add label: 'release' not found` because the label doesn't exist in this repo, killing the job before the merge-back PR step ran. Fix: `gh label create release --force` before creating the issue.

Part of #1395. Dashboard: https://vibe-mcp.uberinternal.com/v/webdocs/#/d/ma-oss-release

## Test plan
- [x] `actionlint` on all three files — only pre-existing style-level shellcheck notes
- [x] Confirmed via `gh api` that no `build-release` run exists for the `v0.4.0-rc.1` tag pushed by the failed run, and that the `release` label doesn't exist in the repo
- [ ] Not exercised end-to-end yet — will be validated by re-running the recovery for v0.4.0-rc.1