### PR TITLE
fix(ci): publish @michelangelo-ai/rpc to npm alongside core

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,4 +1,4 @@
-name: Publish @michelangelo-ai/core to npm
+name: Publish npm packages
 
 on:
   workflow_dispatch:
@@ -12,36 +12,13 @@ on:
     branches: [main]
     paths:
       - 'javascript/packages/core/**'
+      - 'javascript/packages/rpc/**'
 
 jobs:
-  check-version-change:
-    runs-on: ubuntu-latest
-    outputs:
-      version-changed: ${{ steps.check.outputs.changed }}
-      new-version: ${{ steps.check.outputs.version }}
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-          fetch-depth: 2
-
-      - name: Check if core package.json version changed
-        id: check
-        run: |
-          if git diff HEAD~1 HEAD --name-only | grep -q "javascript/packages/core/package.json"; then
-            VERSION=$(jq -r '.version' javascript/packages/core/package.json)
-            echo "version=$VERSION" >> $GITHUB_OUTPUT
-            echo "changed=true" >> $GITHUB_OUTPUT
-            echo "📦 core version changed to: $VERSION"
-          else
-            echo "changed=false" >> $GITHUB_OUTPUT
-            echo "📦 core version unchanged, skipping publish"
-          fi
-
   publish:
-    needs: check-version-change
-    if: needs.check-version-change.outputs.version-changed == 'true' || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
+    strategy:
+      matrix:
+        package: [core, rpc]
     runs-on: ubuntu-latest
 
     permissions:
@@ -53,8 +30,23 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
+          fetch-depth: 2
+
+      - name: Check if ${{ matrix.package }} package.json version changed
+        id: check
+        run: |
+          if [ "${{ github.event_name }}" != "push" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          elif git diff HEAD~1 HEAD --name-only | grep -q "javascript/packages/${{ matrix.package }}/package.json"; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "📦 ${{ matrix.package }} version changed"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "📦 ${{ matrix.package }} version unchanged, skipping publish"
+          fi
 
       - name: Setup Node.js
+        if: steps.check.outputs.changed == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 24.14.1
@@ -63,21 +55,25 @@ jobs:
           cache-dependency-path: javascript/yarn.lock
 
       - name: Set up buf CLI
+        if: steps.check.outputs.changed == 'true'
         uses: bufbuild/buf-setup-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies
+        if: steps.check.outputs.changed == 'true'
         run: |
           cd javascript
           yarn setup
 
-      - name: Build @michelangelo-ai/core
+      - name: Build @michelangelo-ai/${{ matrix.package }}
+        if: steps.check.outputs.changed == 'true'
         run: |
           cd javascript
-          yarn workspace @michelangelo-ai/core build
+          yarn workspace @michelangelo-ai/${{ matrix.package }} build
 
       - name: Publish to npm
+        if: steps.check.outputs.changed == 'true'
         run: |
-          cd javascript/packages/core
+          cd javascript/packages/${{ matrix.package }}
           npm publish --provenance --access public


### PR DESCRIPTION
## Summary
`@michelangelo-ai/rpc` has never had a stable npm release — checked the registry directly, its `latest` dist-tag is still a nightly (`0.3.0-nightly.20260701`). `npm-publish.yml` only ever built/published `core`. `skills/release_process.md`'s artifact matrix documents `rpc` as an npm-published package right alongside `core`, so this was a silent gap that would persist even through the new `release-promote.yml` (which calls this workflow via `workflow_call` but only ever got `core`).

- Restructured `npm-publish.yml` into a single job matrixed over `[core, rpc]` (rather than two separate jobs) — matrix job *outputs* don't disambiguate by matrix value when read from a different job, so keeping the version-check and publish steps inside the same matrixed job (gating later steps on an `if` referencing a step output from that same run) avoids that trap.
- Added `javascript/packages/rpc/**` to the push-path trigger.

Part of #1395. Dashboard: https://vibe-mcp.uberinternal.com/v/webdocs/#/d/ma-oss-release

## Test plan
- [x] `actionlint` — clean
- [x] Confirmed via `curl https://registry.npmjs.org/@michelangelo-ai/rpc` that no stable version has ever been published
- [x] Confirmed `@michelangelo-ai/rpc`'s package name matches the matrix assumption
- [ ] Not exercised end-to-end yet — will be validated on the next push to `javascript/packages/{core,rpc}/**` or the next release promotion