### PR TITLE
Add user identity to NavigationBar

### DIFF
--- a/javascript/app/App.tsx
+++ b/javascript/app/App.tsx
@@ -7,7 +7,7 @@ import { Provider as StyletronProvider } from 'styletron-react';
 
 import { ICONS } from './icons/icons';
 
-import type { NavigationLink, UserMenuItem } from '@michelangelo-ai/core';
+import type { NavigationLink } from '@michelangelo-ai/core';
 
 const NAVIGATION_LINKS: NavigationLink[] = [
   { label: 'Docs', href: 'https://michelangelo-ai.github.io/michelangelo/' },
@@ -19,11 +19,6 @@ const DEV_USER = {
   role: UserRole.Admin,
   timeZone: TimeZone.Local,
 };
-
-const USER_MENU_ITEMS: UserMenuItem[] = [
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  { label: 'Sign out', onClick: () => {} },
-];
 
 const dependencies = {
   error: {
@@ -37,7 +32,6 @@ const dependencies = {
   },
   navigationBar: {
     links: NAVIGATION_LINKS,
-    userMenuItems: USER_MENU_ITEMS,
   },
   user: DEV_USER,
 };

--- a/javascript/app/App.tsx
+++ b/javascript/app/App.tsx
@@ -7,12 +7,6 @@ import { Provider as StyletronProvider } from 'styletron-react';
 
 import { ICONS } from './icons/icons';
 
-import type { NavigationLink } from '@michelangelo-ai/core';
-
-const NAVIGATION_LINKS: NavigationLink[] = [
-  { label: 'Docs', href: 'https://michelangelo-ai.github.io/michelangelo/' },
-];
-
 const DEV_USER = {
   name: 'Local Developer',
   email: 'dev@localhost',
@@ -31,7 +25,7 @@ const dependencies = {
     request,
   },
   navigationBar: {
-    links: NAVIGATION_LINKS,
+    links: [{ label: 'Docs', href: 'https://michelangelo-ai.github.io/michelangelo/' }],
   },
   user: DEV_USER,
 };

--- a/javascript/app/App.tsx
+++ b/javascript/app/App.tsx
@@ -1,11 +1,29 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom-v5-compat';
-import { CoreApp } from '@michelangelo-ai/core';
+import { CoreApp, TimeZone, UserRole } from '@michelangelo-ai/core';
 import { normalizeTranscoderError, request } from '@michelangelo-ai/rpc';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Client as Styletron } from 'styletron-engine-atomic';
 import { Provider as StyletronProvider } from 'styletron-react';
 
 import { ICONS } from './icons/icons';
+
+import type { NavigationLink, UserMenuItem } from '@michelangelo-ai/core';
+
+const NAVIGATION_LINKS: NavigationLink[] = [
+  { label: 'Docs', href: 'https://michelangelo-ai.github.io/michelangelo/' },
+];
+
+const DEV_USER = {
+  name: 'Local Developer',
+  email: 'dev@localhost',
+  role: UserRole.Admin,
+  timeZone: TimeZone.Local,
+};
+
+const USER_MENU_ITEMS: UserMenuItem[] = [
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  { label: 'Sign out', onClick: () => {} },
+];
 
 const dependencies = {
   error: {
@@ -18,8 +36,10 @@ const dependencies = {
     request,
   },
   navigationBar: {
-    links: [{ label: 'Docs', href: 'https://michelangelo-ai.github.io/michelangelo/' }],
+    links: NAVIGATION_LINKS,
+    userMenuItems: USER_MENU_ITEMS,
   },
+  user: DEV_USER,
 };
 
 const engine = new Styletron();

--- a/javascript/app/icons/icons.tsx
+++ b/javascript/app/icons/icons.tsx
@@ -12,6 +12,7 @@ import Delete from '@mui/icons-material/Delete';
 import ErrorIcon from '@mui/icons-material/Error';
 import Info from '@mui/icons-material/Info';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import KeyboardBackspaceIcon from '@mui/icons-material/KeyboardBackspace';
 import Launch from '@mui/icons-material/Launch';
 import MenuIcon from '@mui/icons-material/Menu';
@@ -30,8 +31,9 @@ export const ICONS = {
   arrowLaunch: createMuiIconAdapter(Launch),
   arrowLeft: createMuiIconAdapter(KeyboardBackspaceIcon),
   chartLine: createMuiIconAdapter(ShowChartIcon),
-  chevronRight: createMuiIconAdapter(ChevronRightIcon),
   chevronDown: createMuiIconAdapter(KeyboardArrowDownIcon),
+  chevronRight: createMuiIconAdapter(ChevronRightIcon),
+  chevronUp: createMuiIconAdapter(KeyboardArrowUpIcon),
   circleI: createMuiIconAdapter(Info),
   circleX: createMuiIconAdapter(CancelIcon),
   circleCheck: createMuiIconAdapter(CheckCircle),

--- a/javascript/packages/core/components/navigation-bar/__tests__/navigation-bar.test.tsx
+++ b/javascript/packages/core/components/navigation-bar/__tests__/navigation-bar.test.tsx
@@ -64,7 +64,7 @@ describe('NavigationBar', () => {
     });
   });
 
-  it('renders user initials from the user provider', () => {
+  it('renders user identity from the user provider', () => {
     render(
       <NavigationBar />,
       buildWrapper([
@@ -77,7 +77,7 @@ describe('NavigationBar', () => {
     expect(screen.getAllByText('TU').length).toBeGreaterThan(0);
   });
 
-  it('shows the hardcoded Sign out menu item', async () => {
+  it('shows the Sign out menu item when the user menu is opened', async () => {
     render(
       <NavigationBar />,
       buildWrapper([
@@ -89,6 +89,6 @@ describe('NavigationBar', () => {
 
     await userEvent.click(screen.getAllByText('TU')[0]);
 
-    expect(screen.getAllByText('Sign out').length).toBeGreaterThan(0);
+    expect(screen.getByRole('option', { name: 'Sign out' })).toBeInTheDocument();
   });
 });

--- a/javascript/packages/core/components/navigation-bar/__tests__/navigation-bar.test.tsx
+++ b/javascript/packages/core/components/navigation-bar/__tests__/navigation-bar.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
@@ -8,7 +8,7 @@ import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
 import { getUserProviderWrapper } from '#core/test/wrappers/get-user-provider-wrapper';
 import { NavigationBar } from '../navigation-bar';
 
-import type { NavigationLink, UserMenuItem } from '../types';
+import type { NavigationLink } from '../types';
 
 describe('NavigationBar', () => {
   // AppNavBar renders both its desktop and mobile menu variants at once and switches
@@ -64,11 +64,9 @@ describe('NavigationBar', () => {
     });
   });
 
-  it('renders user initials when user context and menu items are provided', () => {
-    const userMenuItems: UserMenuItem[] = [{ label: 'Settings', onClick: vi.fn() }];
-
+  it('renders user initials from the user provider', () => {
     render(
-      <NavigationBar userMenuItems={userMenuItems} />,
+      <NavigationBar />,
       buildWrapper([
         getBaseProviderWrapper(),
         getRouterWrapper(),
@@ -79,12 +77,9 @@ describe('NavigationBar', () => {
     expect(screen.getAllByText('TU').length).toBeGreaterThan(0);
   });
 
-  it('fires onClick when a user menu item is selected', async () => {
-    const handleClick = vi.fn();
-    const userMenuItems: UserMenuItem[] = [{ label: 'Settings', onClick: handleClick }];
-
+  it('shows the hardcoded Sign out menu item', async () => {
     render(
-      <NavigationBar userMenuItems={userMenuItems} />,
+      <NavigationBar />,
       buildWrapper([
         getBaseProviderWrapper(),
         getRouterWrapper(),
@@ -94,9 +89,6 @@ describe('NavigationBar', () => {
 
     await userEvent.click(screen.getAllByText('TU')[0]);
 
-    const settingsItems = screen.getAllByText('Settings');
-    await userEvent.click(settingsItems[0]);
-
-    expect(handleClick).toHaveBeenCalled();
+    expect(screen.getAllByText('Sign out').length).toBeGreaterThan(0);
   });
 });

--- a/javascript/packages/core/components/navigation-bar/__tests__/navigation-bar.test.tsx
+++ b/javascript/packages/core/components/navigation-bar/__tests__/navigation-bar.test.tsx
@@ -1,19 +1,24 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
 
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
 import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
+import { getUserProviderWrapper } from '#core/test/wrappers/get-user-provider-wrapper';
 import { NavigationBar } from '../navigation-bar';
 
-import type { NavigationLink } from '../types';
+import type { NavigationLink, UserMenuItem } from '../types';
 
 describe('NavigationBar', () => {
   // AppNavBar renders both its desktop and mobile menu variants at once and switches
   // between them with a `matchMedia` query, which jsdom doesn't implement — the inactive
   // variant reports as hidden to the accessibility tree, so role queries need `hidden: true`.
   it('renders the title as a link to the app root', () => {
-    render(<NavigationBar />, buildWrapper([getBaseProviderWrapper(), getRouterWrapper()]));
+    render(
+      <NavigationBar />,
+      buildWrapper([getBaseProviderWrapper(), getRouterWrapper(), getUserProviderWrapper()])
+    );
 
     const titleLinks = screen.getAllByRole('link', {
       name: 'Michelangelo Studio',
@@ -31,7 +36,7 @@ describe('NavigationBar', () => {
 
     render(
       <NavigationBar links={links} />,
-      buildWrapper([getBaseProviderWrapper(), getRouterWrapper()])
+      buildWrapper([getBaseProviderWrapper(), getRouterWrapper(), getUserProviderWrapper()])
     );
 
     const docsLinks = screen.getAllByRole('link', { name: 'Docs', hidden: true });
@@ -48,7 +53,7 @@ describe('NavigationBar', () => {
 
     render(
       <NavigationBar links={links} />,
-      buildWrapper([getBaseProviderWrapper(), getRouterWrapper()])
+      buildWrapper([getBaseProviderWrapper(), getRouterWrapper(), getUserProviderWrapper()])
     );
 
     const docsLinks = screen.getAllByRole('link', { name: 'Docs', hidden: true });
@@ -57,5 +62,41 @@ describe('NavigationBar', () => {
       expect(link).toHaveAttribute('target', '_blank');
       expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'));
     });
+  });
+
+  it('renders user initials when user context and menu items are provided', () => {
+    const userMenuItems: UserMenuItem[] = [{ label: 'Settings', onClick: vi.fn() }];
+
+    render(
+      <NavigationBar userMenuItems={userMenuItems} />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getRouterWrapper(),
+        getUserProviderWrapper({ name: 'Test User', email: 'test@example.com' }),
+      ])
+    );
+
+    expect(screen.getAllByText('TU').length).toBeGreaterThan(0);
+  });
+
+  it('fires onClick when a user menu item is selected', async () => {
+    const handleClick = vi.fn();
+    const userMenuItems: UserMenuItem[] = [{ label: 'Settings', onClick: handleClick }];
+
+    render(
+      <NavigationBar userMenuItems={userMenuItems} />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getRouterWrapper(),
+        getUserProviderWrapper({ name: 'Test User', email: 'test@example.com' }),
+      ])
+    );
+
+    await userEvent.click(screen.getAllByText('TU')[0]);
+
+    const settingsItems = screen.getAllByText('Settings');
+    await userEvent.click(settingsItems[0]);
+
+    expect(handleClick).toHaveBeenCalled();
   });
 });

--- a/javascript/packages/core/components/navigation-bar/__tests__/navigation-bar.test.tsx
+++ b/javascript/packages/core/components/navigation-bar/__tests__/navigation-bar.test.tsx
@@ -74,7 +74,9 @@ describe('NavigationBar', () => {
       ])
     );
 
-    expect(screen.getAllByText('TU').length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByRole('button', { name: /Test User/, hidden: true }).length
+    ).toBeGreaterThan(0);
   });
 
   it('shows the Sign out menu item when the user menu is opened', async () => {
@@ -87,7 +89,7 @@ describe('NavigationBar', () => {
       ])
     );
 
-    await userEvent.click(screen.getAllByText('TU')[0]);
+    await userEvent.click(screen.getAllByRole('button', { name: /Test User/, hidden: true })[0]);
 
     expect(screen.getByRole('option', { name: 'Sign out' })).toBeInTheDocument();
   });

--- a/javascript/packages/core/components/navigation-bar/navigation-bar.tsx
+++ b/javascript/packages/core/components/navigation-bar/navigation-bar.tsx
@@ -2,20 +2,38 @@ import { AppNavBar } from 'baseui/app-nav-bar';
 import { Button, KIND, SIZE } from 'baseui/button';
 
 import { Link } from '#core/components/link/link';
+import { useUserProvider } from '#core/providers/user-provider/use-user-provider';
+import { StableUserMenuButton } from './stable-user-menu-button';
 
+import type { NavItem } from 'baseui/app-nav-bar';
 import type { Theme } from 'baseui/theme';
-import type { LinkNavItem, NavigationLink } from './types';
+import type { LinkNavItem, NavigationLink, UserMenuItem } from './types';
 
 type Props = {
   links?: NavigationLink[];
+  userMenuItems?: UserMenuItem[];
 };
 
-export function NavigationBar({ links }: Props) {
+export function NavigationBar({ links, userMenuItems }: Props) {
+  const user = useUserProvider();
+
   const mainItems: LinkNavItem[] =
     links?.map((link) => ({
       label: link.label,
       info: { href: link.href },
     })) ?? [];
+
+  const userItems: NavItem[] =
+    userMenuItems?.map((item) => ({
+      label: item.label,
+      info: { onClick: item.onClick, icon: item.icon },
+    })) ?? [];
+
+  const handleUserMenuItemSelect = (item: NavItem) => {
+    // cast: NavItem.info is typed as `any` in BaseUI
+    const info = item.info as { onClick?: () => void } | undefined;
+    info?.onClick?.();
+  };
 
   return (
     <AppNavBar
@@ -26,7 +44,7 @@ export function NavigationBar({ links }: Props) {
       }
       mainItems={mainItems}
       mapItemToNode={(item) => {
-        // cast: see LinkNavItem's doc comment in types.ts
+        // cast: see LinkNavItem in types.ts
         const { href } = (item as LinkNavItem).info;
         return (
           <Button
@@ -49,7 +67,13 @@ export function NavigationBar({ links }: Props) {
           </Button>
         );
       }}
+      username={user.name}
+      usernameSubtitle={user.email}
+      userImgUrl={user.avatarUrl}
+      userItems={userItems}
+      onUserItemSelect={handleUserMenuItemSelect}
       overrides={{
+        Root: { style: { position: 'relative' as const } },
         AppName: { style: { whiteSpace: 'nowrap' } },
         PrimaryMenuContainer: {
           style: ({ $theme }: { $theme: Theme }) => ({
@@ -61,6 +85,18 @@ export function NavigationBar({ links }: Props) {
             height: '64px',
             boxSizing: 'border-box',
             paddingBlockStart: '20px',
+          },
+        },
+        UserMenuButton: {
+          component: StableUserMenuButton,
+          props: {
+            overrides: {
+              BaseButton: {
+                style: ({ $theme }: { $theme: Theme }) => ({
+                  gap: $theme.sizing.scale200,
+                }),
+              },
+            },
           },
         },
       }}

--- a/javascript/packages/core/components/navigation-bar/navigation-bar.tsx
+++ b/javascript/packages/core/components/navigation-bar/navigation-bar.tsx
@@ -7,14 +7,15 @@ import { StableUserMenuButton } from './stable-user-menu-button';
 
 import type { NavItem } from 'baseui/app-nav-bar';
 import type { Theme } from 'baseui/theme';
-import type { LinkNavItem, NavigationLink, UserMenuItem } from './types';
+import type { LinkNavItem, NavigationLink } from './types';
 
 type Props = {
   links?: NavigationLink[];
-  userMenuItems?: UserMenuItem[];
 };
 
-export function NavigationBar({ links, userMenuItems }: Props) {
+const USER_MENU_ITEMS: NavItem[] = [{ label: 'Sign out' }];
+
+export function NavigationBar({ links }: Props) {
   const user = useUserProvider();
 
   const mainItems: LinkNavItem[] =
@@ -22,18 +23,6 @@ export function NavigationBar({ links, userMenuItems }: Props) {
       label: link.label,
       info: { href: link.href },
     })) ?? [];
-
-  const userItems: NavItem[] =
-    userMenuItems?.map((item) => ({
-      label: item.label,
-      info: { onClick: item.onClick, icon: item.icon },
-    })) ?? [];
-
-  const handleUserMenuItemSelect = (item: NavItem) => {
-    // cast: NavItem.info is typed as `any` in BaseUI
-    const info = item.info as { onClick?: () => void } | undefined;
-    info?.onClick?.();
-  };
 
   return (
     <AppNavBar
@@ -44,11 +33,12 @@ export function NavigationBar({ links, userMenuItems }: Props) {
       }
       mainItems={mainItems}
       mapItemToNode={(item) => {
-        // cast: see LinkNavItem in types.ts
-        const { href } = (item as LinkNavItem).info;
+        // cast: NavItem.info is typed as `any` in BaseUI; mainItems always carry LinkNavItem shape
+        const info = (item as LinkNavItem).info;
+        if (!info?.href) return <>{item.label}</>;
         return (
           <Button
-            href={href}
+            href={info.href}
             target="_blank"
             rel="noopener noreferrer"
             kind={KIND.tertiary}
@@ -70,8 +60,7 @@ export function NavigationBar({ links, userMenuItems }: Props) {
       username={user.name}
       usernameSubtitle={user.email}
       userImgUrl={user.avatarUrl}
-      userItems={userItems}
-      onUserItemSelect={handleUserMenuItemSelect}
+      userItems={USER_MENU_ITEMS}
       overrides={{
         Root: { style: { position: 'relative' as const } },
         AppName: { style: { whiteSpace: 'nowrap' } },

--- a/javascript/packages/core/components/navigation-bar/stable-user-menu-button.tsx
+++ b/javascript/packages/core/components/navigation-bar/stable-user-menu-button.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Button } from 'baseui/button';
+
+// BaseUI's user-menu applies paddingLeft on the chevron SVG via overrides.Svg.style,
+// but theme icon adapters (e.g. MUI) may strip those overrides. This component
+// normalizes the layout: the wrapper clips any inherited padding so the button's
+// gap property alone controls avatar–chevron spacing across icon libraries.
+export const StableUserMenuButton = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentPropsWithRef<typeof Button>
+>(function StableUserMenuButton(props, ref) {
+  const { children, ...rest } = props;
+  return (
+    <Button {...rest} ref={ref}>
+      {React.Children.map(children, (child: React.ReactNode, i) => {
+        if (i === 1 && React.isValidElement<Record<string, unknown>>(child)) {
+          // cast: cloneElement props are loosely typed; overrides is a valid BaseUI icon prop
+          return React.cloneElement(child, {
+            overrides: { Svg: { style: { paddingLeft: 0 } } },
+          });
+        }
+        return child;
+      })}
+    </Button>
+  );
+});

--- a/javascript/packages/core/components/navigation-bar/types.ts
+++ b/javascript/packages/core/components/navigation-bar/types.ts
@@ -7,9 +7,3 @@ export type NavigationLink = {
 
 /** BaseUI types `mainItems`/`mapItemToNode` against the generic `NavItem` (`info: any`); these are always the entries built from `NavigationLink`s. */
 export type LinkNavItem = Omit<NavItem, 'info'> & { info: { href: string } };
-
-export type UserMenuItem = {
-  label: string;
-  icon?: React.ReactNode;
-  onClick: () => void;
-};

--- a/javascript/packages/core/components/navigation-bar/types.ts
+++ b/javascript/packages/core/components/navigation-bar/types.ts
@@ -7,3 +7,9 @@ export type NavigationLink = {
 
 /** BaseUI types `mainItems`/`mapItemToNode` against the generic `NavItem` (`info: any`); these are always the entries built from `NavigationLink`s. */
 export type LinkNavItem = Omit<NavItem, 'info'> & { info: { href: string } };
+
+export type UserMenuItem = {
+  label: string;
+  icon?: React.ReactNode;
+  onClick: () => void;
+};

--- a/javascript/packages/core/index.tsx
+++ b/javascript/packages/core/index.tsx
@@ -211,11 +211,7 @@ export type {
 } from '#core/components/views/detail-view/types/detail-view-component-types';
 
 // Navigation Bar
-export { NavigationBar } from '#core/components/navigation-bar/navigation-bar';
 export type { NavigationLink } from '#core/components/navigation-bar/types';
 
 // User Provider
-export { UserProvider } from '#core/providers/user-provider/user-provider';
-export { useUserProvider } from '#core/providers/user-provider/use-user-provider';
-export type { UserContextType } from '#core/providers/user-provider/types';
 export { UserRole } from '#core/providers/user-provider/types';

--- a/javascript/packages/core/index.tsx
+++ b/javascript/packages/core/index.tsx
@@ -210,8 +210,5 @@ export type {
   DetailViewPagesProps,
 } from '#core/components/views/detail-view/types/detail-view-component-types';
 
-// Navigation Bar
-export type { NavigationLink } from '#core/components/navigation-bar/types';
-
 // User Provider
 export { UserRole } from '#core/providers/user-provider/types';

--- a/javascript/packages/core/index.tsx
+++ b/javascript/packages/core/index.tsx
@@ -10,7 +10,7 @@ import { Router } from '#core/router/router';
 import { ThemeProvider } from '#core/themes/theme-provider';
 import { TimeZone } from '#core/types/time-types';
 
-import type { NavigationLink, UserMenuItem } from '#core/components/navigation-bar/types';
+import type { NavigationLink } from '#core/components/navigation-bar/types';
 import type { ErrorContextValue } from '#core/providers/error-provider/types';
 import type { IconProviderContext } from '#core/providers/icon-provider/types';
 import type { ServiceContextType } from '#core/providers/service-provider/types';
@@ -26,7 +26,6 @@ type Props = {
     theme: IconProviderContext;
     navigationBar?: {
       links?: NavigationLink[];
-      userMenuItems?: UserMenuItem[];
     };
     user?: UserContextType;
   };
@@ -41,10 +40,7 @@ export function CoreApp({ dependencies }: Props) {
             <ErrorProvider {...dependencies.error}>
               <IconProvider icons={dependencies.theme.icons}>
                 <UserProvider {...(dependencies.user ?? { timeZone: TimeZone.Local })}>
-                  <NavigationBar
-                    links={dependencies.navigationBar?.links}
-                    userMenuItems={dependencies.navigationBar?.userMenuItems}
-                  />
+                  <NavigationBar links={dependencies.navigationBar?.links} />
                   <Router />
                 </UserProvider>
               </IconProvider>
@@ -216,7 +212,7 @@ export type {
 
 // Navigation Bar
 export { NavigationBar } from '#core/components/navigation-bar/navigation-bar';
-export type { NavigationLink, UserMenuItem } from '#core/components/navigation-bar/types';
+export type { NavigationLink } from '#core/components/navigation-bar/types';
 
 // User Provider
 export { UserProvider } from '#core/providers/user-provider/user-provider';

--- a/javascript/packages/core/index.tsx
+++ b/javascript/packages/core/index.tsx
@@ -5,13 +5,16 @@ import { NavigationBar } from '#core/components/navigation-bar/navigation-bar';
 import { ErrorProvider } from '#core/providers/error-provider/error-provider';
 import { IconProvider } from '#core/providers/icon-provider/icon-provider';
 import { ServiceProvider } from '#core/providers/service-provider/service-provider';
+import { UserProvider } from '#core/providers/user-provider/user-provider';
 import { Router } from '#core/router/router';
 import { ThemeProvider } from '#core/themes/theme-provider';
+import { TimeZone } from '#core/types/time-types';
 
-import type { NavigationLink } from '#core/components/navigation-bar/types';
+import type { NavigationLink, UserMenuItem } from '#core/components/navigation-bar/types';
 import type { ErrorContextValue } from '#core/providers/error-provider/types';
 import type { IconProviderContext } from '#core/providers/icon-provider/types';
 import type { ServiceContextType } from '#core/providers/service-provider/types';
+import type { UserContextType } from '#core/providers/user-provider/types';
 
 import '#core/styles/main.css';
 // TODO: Relocate the Props interface once the contents of the
@@ -23,7 +26,9 @@ type Props = {
     theme: IconProviderContext;
     navigationBar?: {
       links?: NavigationLink[];
+      userMenuItems?: UserMenuItem[];
     };
+    user?: UserContextType;
   };
 };
 
@@ -35,8 +40,13 @@ export function CoreApp({ dependencies }: Props) {
           <ServiceProvider {...dependencies.service}>
             <ErrorProvider {...dependencies.error}>
               <IconProvider icons={dependencies.theme.icons}>
-                <NavigationBar links={dependencies.navigationBar?.links} />
-                <Router />
+                <UserProvider {...(dependencies.user ?? { timeZone: TimeZone.Local })}>
+                  <NavigationBar
+                    links={dependencies.navigationBar?.links}
+                    userMenuItems={dependencies.navigationBar?.userMenuItems}
+                  />
+                  <Router />
+                </UserProvider>
               </IconProvider>
             </ErrorProvider>
           </ServiceProvider>
@@ -90,8 +100,6 @@ export { IconProvider } from '#core/providers/icon-provider/icon-provider';
 export * from '#core/providers/icon-provider/types';
 
 export { ThemeProvider };
-
-export { UserProvider } from '#core/providers/user-provider/user-provider';
 
 export { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
 export * from '#core/hooks/routing/use-studio-params/types';
@@ -205,3 +213,13 @@ export type {
   DetailViewTab,
   DetailViewPagesProps,
 } from '#core/components/views/detail-view/types/detail-view-component-types';
+
+// Navigation Bar
+export { NavigationBar } from '#core/components/navigation-bar/navigation-bar';
+export type { NavigationLink, UserMenuItem } from '#core/components/navigation-bar/types';
+
+// User Provider
+export { UserProvider } from '#core/providers/user-provider/user-provider';
+export { useUserProvider } from '#core/providers/user-provider/use-user-provider';
+export type { UserContextType } from '#core/providers/user-provider/types';
+export { UserRole } from '#core/providers/user-provider/types';

--- a/javascript/packages/core/providers/user-provider/types.ts
+++ b/javascript/packages/core/providers/user-provider/types.ts
@@ -1,5 +1,14 @@
 import type { TimeZone } from '#core/types/time-types';
 
+export enum UserRole {
+  Admin = 'admin',
+  Viewer = 'viewer',
+}
+
 export type UserContextType = {
+  name?: string;
+  email?: string;
+  avatarUrl?: string;
+  role?: UserRole;
   timeZone: TimeZone;
 };


### PR DESCRIPTION
## Summary

The navigation bar previously showed no user identity — just navigation links and a title. This wires the user context into the nav bar so it renders the user's avatar, name, and email via BaseUI's built-in user menu support.

The user menu has a single "Sign out" entry hardcoded directly in the component rather than passed as a configurable prop. Initial user menu items will be generic (timezone preference, theme preference).

BaseUI's user-menu button applies chevron padding through icon overrides that theme adapters (like MUI) can strip, leaving inconsistent spacing. A forwarded-ref button wrapper zeros the inherited padding and replaces it with gap-based spacing that works regardless of icon library.

A `UserRole` enum is added to the user context type for downstream authorization decisions.

## Test plan

https://github.com/user-attachments/assets/089f9634-dc67-4872-a57b-508ad176d30c


🤖 Generated with [Claude Code](https://claude.com/claude-code)