### PR TITLE
fix(scripts): pin internal @michelangelo-ai workspace deps on version bump

### DIFF
--- a/scripts/version-bump.sh
+++ b/scripts/version-bump.sh
@@ -100,6 +100,23 @@ set_version() {
     printf "  %-50s → %s\n" "$file" "$new_version"
   done
 
+  # Pin internal @michelangelo-ai/* workspace deps to the exact new version.
+  # A bare "*" range never matches a prerelease version under node-semver, so
+  # yarn's workspace resolver falls back to the npm registry and fails when
+  # the version being bumped to has a -rc./-nightly. suffix. Pinning keeps
+  # local resolution working regardless of prerelease suffixes.
+  sed -i.bak \
+    -e "s/\"@michelangelo-ai\/rpc\": \"[^\"]*\"/\"@michelangelo-ai\/rpc\": \"$new_version\"/" \
+    -e "s/\"@michelangelo-ai\/core\": \"[^\"]*\"/\"@michelangelo-ai\/core\": \"$new_version\"/" \
+    "$REPO_ROOT/javascript/app/package.json"
+  rm -f "$REPO_ROOT/javascript/app/package.json.bak"
+  printf "  %-50s → %s\n" "javascript/app/package.json (internal deps)" "$new_version"
+
+  sed -i.bak "s/\"@michelangelo-ai\/core\": \"[^\"]*\"/\"@michelangelo-ai\/core\": \"$new_version\"/" \
+    "$REPO_ROOT/javascript/packages/rpc/package.json"
+  rm -f "$REPO_ROOT/javascript/packages/rpc/package.json.bak"
+  printf "  %-50s → %s\n" "javascript/packages/rpc/package.json (internal deps)" "$new_version"
+
   # Helm Chart.yaml — version and appVersion
   sed -i.bak "s/^version: .*/version: $new_version/" "$REPO_ROOT/helm/michelangelo/Chart.yaml"
   sed -i.bak "s/^appVersion: .*/appVersion: \"$new_version\"/" "$REPO_ROOT/helm/michelangelo/Chart.yaml"


### PR DESCRIPTION
## What changed?
`version-bump.sh` now pins the internal `@michelangelo-ai/rpc`/`@michelangelo-ai/core` dependency ranges (previously `"*"`) to the exact bumped version in `javascript/app/package.json` and `javascript/packages/rpc/package.json`.

## Why?
Discovered while investigating CI failures on PR #1506 (the v0.4.0-rc.1 merge-back PR): `yarn install --frozen-lockfile` failed with `Couldn't find any versions for "@michelangelo-ai/rpc" that matches "*"`.

Root cause: Yarn Classic v1 (this repo's package manager, see `javascript/package.json` engines) does not support the `workspace:*` protocol, and node-semver's bare `"*"` range never matches a prerelease version (confirmed locally, and a known unfixed upstream bug: [yarnpkg/yarn#6719](https://github.com/yarnpkg/yarn/issues/6719)). Since `version-bump.sh` writes the full version including `-rc.N`/`-nightly.*` suffixes into each package's own `version` field but left dependents at `"*"`, every prerelease bump broke local workspace resolution for CI installs (JS lint/test/format checks) and would also break `npm-publish.yml`'s own install step for RC publishes.

Fix mirrors how Lerna (the standard Yarn-Classic-era monorepo tool) handles this: auto-update semver-range cross-references to the new exact version on every bump.

## How did you test it?
Ran `./scripts/version-bump.sh 0.4.0-rc.2` locally, confirmed the internal dep ranges got pinned, then ran `yarn install --frozen-lockfile` in `javascript/` and confirmed it resolved successfully (previously failed with the registry-lookup error). Reverted the test bump before committing.

## Breaking Changes
No breaking changes.