### PR TITLE
fix(ci): publish npm packages when cutting an RC, not just on promote

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -25,6 +25,8 @@ jobs:
       issues: write
       pull-requests: write
       actions: write
+    outputs:
+      branch: ${{ steps.vars.outputs.branch }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -148,8 +150,18 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  notify-on-failure:
+  publish-npm:
     needs: cut
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/npm-publish.yml
+    with:
+      ref: ${{ needs.cut.outputs.branch }}
+    secrets: inherit
+
+  notify-on-failure:
+    needs: [cut, publish-npm]
     if: failure()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## What changed?
Adds a `publish-npm` job to `release-cut.yml` that calls `npm-publish.yml` via `workflow_call` with the release branch ref, mirroring the job `release-promote.yml` already has for final releases.

## Why?
`release-cut.yml` tagged the RC and triggered `release.yaml` (PyPI + Go binaries) but never published npm packages. Confirmed live during the v0.4.0-rc.1 cut: PyPI got `0.4.0rc1`, but `@michelangelo-ai/core`/`@michelangelo-ai/rpc` on npm were untouched. `skills/release_process.md`'s VER-002 table documents the RC npm format (e.g. `0.3.0-rc.1`), implying RCs are supposed to get npm publishes too — this was an omission, not an intentional gap.

## How did you test it?
Diffed against `release-promote.yml`'s existing (working) `publish-npm` job to confirm the same pattern (workflow_call + ref + secrets: inherit) applies. Ran `scripts/validate_workflows.sh` — no new failures introduced (the pre-existing shellcheck/unpinned-action warnings on this file predate this change, same as `release-promote.yml` already has for its identical local workflow_call reference).

## Breaking Changes
No breaking changes.