### PR TITLE
fix(ci): harden CI gate + fix changelog generation for bot-pushed tags

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -88,6 +88,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Trigger changelog generation for the RC tag
+        run: |
+          gh workflow run changelog.yml --ref "${{ steps.vars.outputs.tag }}" -f tag="${{ steps.vars.outputs.tag }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Ensure the release tracking label exists
         run: gh label create release --color ededed --description "Release tracking issue" --force
         env:

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -52,6 +52,16 @@ jobs:
       - name: Validate CI is green on release branch
         run: |
           SHA=$(git rev-parse HEAD)
+          RUN_COUNT=$(gh api --paginate "repos/${{ github.repository }}/commits/$SHA/check-runs" --jq '.check_runs | length')
+          if [ "$RUN_COUNT" -eq 0 ]; then
+            echo "ERROR: no check-runs found at all for ${{ steps.vars.outputs.branch }}@$SHA."
+            echo "This usually means CI never ran on this commit (e.g. it was pushed by"
+            echo "GITHUB_TOKEN, which does not trigger push-based workflows, and no PR"
+            echo "was open against this branch to trigger pull_request-based checks)."
+            echo "Refusing to promote an unvalidated release. Open a PR against this"
+            echo "branch (or otherwise trigger CI) and re-run once checks are green."
+            exit 1
+          fi
           STATES=$(gh api --paginate "repos/${{ github.repository }}/commits/$SHA/check-runs" --jq '.check_runs[] | select(.status != "completed" or (.conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral")) | .name')
           if [ -n "$STATES" ]; then
             echo "ERROR: the following checks are not green on ${{ steps.vars.outputs.branch }}@$SHA:"
@@ -76,6 +86,12 @@ jobs:
       - name: Trigger artifact publish for the final tag
         run: |
           gh workflow run release.yaml --ref "${{ steps.vars.outputs.tag }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trigger changelog generation for the final tag
+        run: |
+          gh workflow run changelog.yml --ref "${{ steps.vars.outputs.tag }}" -f tag="${{ steps.vars.outputs.tag }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## What changed?
1. `release-promote.yml`'s CI-green check now hard-fails when **zero** check-runs exist for the release-branch HEAD, instead of silently passing.
2. Added the explicit `gh workflow run changelog.yml --ref <tag>` trigger (same pattern PR #1499 used for `release.yaml`) to both `release-cut.yml` and `release-promote.yml`.

## Why?
Found during a full review of the Phase 4 semi-automation flow.

**Bug 1:** `release-promote.yml` computes `STATES` by filtering check-runs for non-green ones; if `check_runs` is empty (nothing ever ran), the filter finds nothing to complain about and the step passes. Confirmed live: every recorded check-run on `release/v0.4` came from `pull_request` events (PR #1506, created manually as a workaround for the org's Actions-PR-creation policy block) — there were **zero** `push`-event check-runs, because `GITHUB_TOKEN`-authored pushes (like `release-cut.yml`'s branch/commit push) don't trigger other workflows. If that merge-back PR had never been created, `release-promote.yml` would have promoted `v0.4.0` with literally no CI ever having run against it.

**Bug 2:** `changelog.yml` triggers on `push: tags: ['v*']`, the same trigger type `release.yaml` had before PR #1499's fix — same anti-recursion problem. Confirmed live: `v0.4.0-rc.1`'s GitHub Release has an empty body, no changelog was ever generated for it.

## How did you test it?
Traced actual GitHub state with `gh api`/`gh run list` (not just reading YAML) to confirm both bugs are real, not theoretical: verified zero push-triggered runs on `release/v0.4`, and verified the empty release body on `v0.4.0-rc.1`. Ran `scripts/validate_workflows.sh` — no new failures (pre-existing shellcheck/unpinned-action warnings on these files predate this change).

## Breaking Changes
No breaking changes. Note: this makes `release-promote.yml` **stricter** — a promote run that previously would have silently passed with no CI at all will now fail loudly and require CI to actually run first.