### PR TITLE
fix(ci): fix npm-publish.yml build order, prerelease tag, auth, and provenance

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -88,3 +88,5 @@ jobs:
           else
             npm publish --provenance --access public
           fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,6 +17,7 @@ on:
 jobs:
   publish:
     strategy:
+      fail-fast: false
       matrix:
         package: [core, rpc]
     runs-on: ubuntu-latest
@@ -83,6 +84,11 @@ jobs:
         run: |
           cd javascript/packages/${{ matrix.package }}
           VERSION=$(node -p "require('./package.json').version")
+          PKG=$(node -p "require('./package.json').name")
+          if npm view "$PKG@$VERSION" version > /dev/null 2>&1; then
+            echo "$PKG@$VERSION is already published, skipping."
+            exit 0
+          fi
           if echo "$VERSION" | grep -q -- '-'; then
             npm publish --provenance --access public --tag rc
           else

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -82,4 +82,9 @@ jobs:
         if: steps.check.outputs.changed == 'true'
         run: |
           cd javascript/packages/${{ matrix.package }}
-          npm publish --provenance --access public
+          VERSION=$(node -p "require('./package.json').version")
+          if echo "$VERSION" | grep -q -- '-'; then
+            npm publish --provenance --access public --tag rc
+          else
+            npm publish --provenance --access public
+          fi

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -70,6 +70,12 @@ jobs:
         if: steps.check.outputs.changed == 'true'
         run: |
           cd javascript
+          # rpc imports core's built dist/ output at build time. Each matrix
+          # instance is an isolated runner, so core's own "publish (core)" job
+          # never populates it here -- build core first whenever it's needed.
+          if [ "${{ matrix.package }}" = "rpc" ]; then
+            yarn workspace @michelangelo-ai/core build
+          fi
           yarn workspace @michelangelo-ai/${{ matrix.package }} build
 
       - name: Publish to npm

--- a/javascript/packages/rpc/package.json
+++ b/javascript/packages/rpc/package.json
@@ -3,6 +3,10 @@
   "license": "Apache-2.0",
   "type": "module",
   "version": "0.4.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/michelangelo-ai/michelangelo"
+  },
   "scripts": {
     "build": "vite build",
     "test": "cd ../../ && yarn test:rpc"


### PR DESCRIPTION
## What changed?
Five fixes to `npm-publish.yml` (and one to `rpc/package.json`), found and fixed one at a time while manually re-publishing npm for the existing `v0.4.0-rc.1`:

1. **Build order**: build `@michelangelo-ai/core` first whenever the current matrix instance is `rpc`, since `rpc`'s vite build imports `core`'s built `dist/` output but the two run as separate, isolated matrix jobs.
2. **Missing `--tag` for prereleases**: `npm publish` refuses a prerelease version without an explicit tag (to avoid accidentally publishing to `latest`). Now passes `--tag rc` when the version contains a hyphen.
3. **Missing `NODE_AUTH_TOKEN`**: the `Publish to npm` step never set this env var, unlike `nightly.yml`'s working `npm-nightly` job. Without it, `npm publish` fails with a misleading `E404` even after successful provenance signing.
4. **`rpc/package.json` missing `repository` field**: npm's provenance verification cross-checks `package.json`'s `repository.url` against the GitHub Actions OIDC attestation. `rpc`'s `package.json` had no `repository` field at all (unlike `core`'s), causing an `E422` provenance-verification failure. Added the same field `core` already has.
5. **Matrix `fail-fast` + non-idempotent publish**: with the default `fail-fast: true`, one matrix job failing (e.g. re-publishing an already-published `core` on a retry) cancels the sibling job before it can complete, making every retry all-or-nothing even though the two packages are independent. Set `fail-fast: false` and added an `npm view` pre-check so publish is skipped if that exact version is already live.

## Why?
Confirmed live, one bug at a time, while retriggering `npm-publish.yml --ref release/v0.4` for the existing RC:
- Build order: run [29280334715](https://github.com/michelangelo-ai/michelangelo/actions/runs/29280334715) — `Failed to resolve entry for package "@michelangelo-ai/core"`
- Missing `--tag`: run [29281098880](https://github.com/michelangelo-ai/michelangelo/actions/runs/29281098880) — `You must specify a tag using --tag when publishing a prerelease version`
- Missing `NODE_AUTH_TOKEN`: runs [29281540350](https://github.com/michelangelo-ai/michelangelo/actions/runs/29281540350) / [29282292882](https://github.com/michelangelo-ai/michelangelo/actions/runs/29282292882) — `E404 ... could not be found or you do not have permission to access it`, despite provenance signing succeeding
- Missing `repository` field: run [29282292882](https://github.com/michelangelo-ai/michelangelo/actions/runs/29282292882) — `E422 ... repository.url is "", expected to match https://github.com/michelangelo-ai/michelangelo from provenance`

## How did you test it?
- Reproduced the build-order bug locally (`yarn workspace @michelangelo-ai/rpc build` fails without `core` built first, succeeds with it) and confirmed the fix.
- Ran `scripts/validate_workflows.sh` — `npm-publish.yml` passes actionlint cleanly.
- Applied all fixes directly to `release/v0.4` (in addition to this PR against `main`) and re-ran `npm-publish.yml --ref release/v0.4` end-to-end: run [29283089567](https://github.com/michelangelo-ai/michelangelo/actions/runs/29283089567) succeeded for both `core` and `rpc`. Verified live on the npm registry — `@michelangelo-ai/core` and `@michelangelo-ai/rpc` both show `dist-tags.rc = 0.4.0-rc.1`.

## Breaking Changes
No breaking changes.