### PR TITLE
Add user identity headers to RPC request contract

### DIFF
--- a/javascript/packages/core/components/actions/__tests__/actions-popover.test.tsx
+++ b/javascript/packages/core/components/actions/__tests__/actions-popover.test.tsx
@@ -443,7 +443,7 @@ describe('ActionsPopover', () => {
     await user.click(within(dialog).getByRole('button', { name: 'Kill it' }));
 
     await waitFor(() => {
-      expect(mockRequest).toHaveBeenCalledWith('UpdateTriggerRun', { id: 'run-1' });
+      expect(mockRequest).toHaveBeenCalledWith('UpdateTriggerRun', { id: 'run-1' }, {});
     });
     await waitFor(() => {
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();

--- a/javascript/packages/core/components/cell/renderers/retry/__tests__/retry-cell.tests.tsx
+++ b/javascript/packages/core/components/cell/renderers/retry/__tests__/retry-cell.tests.tsx
@@ -72,7 +72,8 @@ describe('RetryCell', () => {
     await waitFor(() => {
       expect(mockRequest).toHaveBeenCalledWith(
         'GetPipelineRun',
-        expect.objectContaining({ namespace: 'test-project', name: 'test-run' })
+        expect.objectContaining({ namespace: 'test-project', name: 'test-run' }),
+        {}
       );
     });
 
@@ -132,7 +133,8 @@ describe('RetryCell', () => {
               reason: 'Manual retry from UI',
             },
           }) as Record<string, unknown>,
-        })
+        }),
+        {}
       );
     });
 
@@ -185,7 +187,8 @@ describe('RetryCell', () => {
               reason: 'Pipeline failed due to OOM',
             }) as Record<string, unknown>,
           }) as Record<string, unknown>,
-        })
+        }),
+        {}
       );
     });
   });

--- a/javascript/packages/core/config/entities/pipeline/__tests__/create-pipeline-run-form.test.tsx
+++ b/javascript/packages/core/config/entities/pipeline/__tests__/create-pipeline-run-form.test.tsx
@@ -59,15 +59,13 @@ describe('CreatePipelineRunForm', () => {
             namespace: 'ma-dev-test',
           }) as Record<string, unknown>,
           spec: expect.objectContaining({
-            actor: {
-              name: 'mastudio-user',
-            },
             pipeline: {
               name: 'test-pipeline',
               namespace: 'ma-dev-test',
             },
           }) as Record<string, unknown>,
-        })
+        }),
+        {}
       );
     });
 
@@ -133,7 +131,8 @@ describe('CreatePipelineRunForm', () => {
           spec: expect.objectContaining({
             description: 'nightly evaluation run',
           }) as Record<string, unknown>,
-        })
+        }),
+        {}
       );
     });
   });

--- a/javascript/packages/core/config/entities/pipeline/create-pipeline-run-form.tsx
+++ b/javascript/packages/core/config/entities/pipeline/create-pipeline-run-form.tsx
@@ -30,9 +30,6 @@ export const CreatePipelineRunForm = ({ record, onClose }: ActionComponentProps<
       namespace: projectId,
     },
     spec: {
-      actor: {
-        name: 'mastudio-user',
-      },
       pipeline: {
         name: record?.metadata?.name ?? '',
         namespace: projectId,

--- a/javascript/packages/core/config/entities/run/types.ts
+++ b/javascript/packages/core/config/entities/run/types.ts
@@ -4,7 +4,8 @@ export type PipelineRun = {
     namespace: string;
   };
   spec: {
-    actor: {
+    /** Populated server-side from the `x-user-name` request header, not set by the client. */
+    actor?: {
       name: string;
     };
     pipeline: {

--- a/javascript/packages/core/config/entities/trigger/__tests__/trigger.test.tsx
+++ b/javascript/packages/core/config/entities/trigger/__tests__/trigger.test.tsx
@@ -78,7 +78,8 @@ describe('TRIGGER_ENTITY_CONFIG: kill action', () => {
           spec: expect.objectContaining({
             action: TriggerRunAction.KILL,
           }) as Record<string, unknown>,
-        })
+        }),
+        {}
       );
     });
   });

--- a/javascript/packages/core/hooks/__tests__/use-studio-query.test.ts
+++ b/javascript/packages/core/hooks/__tests__/use-studio-query.test.ts
@@ -7,6 +7,7 @@ import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getErrorProviderWrapper } from '#core/test/wrappers/get-error-provider-wrapper';
 import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
 import { getServiceProviderWrapper } from '#core/test/wrappers/get-service-provider-wrapper';
+import { getUserProviderWrapper } from '#core/test/wrappers/get-user-provider-wrapper';
 import { ApplicationError } from '#core/types/error-types';
 
 import type { ErrorNormalizer } from '#core/types/error-types';
@@ -119,7 +120,8 @@ describe('useStudioQuery', () => {
       await waitFor(() => {
         expect(mockRequest).toHaveBeenCalledWith(
           'GetDataset',
-          expect.objectContaining({ namespace: 'ma-dev-test' })
+          expect.objectContaining({ namespace: 'ma-dev-test' }),
+          {}
         );
       });
     });
@@ -141,7 +143,8 @@ describe('useStudioQuery', () => {
       await waitFor(() => {
         expect(mockRequest).toHaveBeenCalledWith(
           'GetDataset',
-          expect.objectContaining({ namespace: 'provided-namespace' })
+          expect.objectContaining({ namespace: 'provided-namespace' }),
+          {}
         );
       });
     });
@@ -191,10 +194,14 @@ describe('useStudioQuery', () => {
       );
 
       await waitFor(() => {
-        expect(mockRequest).toHaveBeenCalledWith('GetDataset', {
-          filter: 'active',
-          namespace: 'ma-dev-test',
-        });
+        expect(mockRequest).toHaveBeenCalledWith(
+          'GetDataset',
+          {
+            filter: 'active',
+            namespace: 'ma-dev-test',
+          },
+          {}
+        );
       });
     });
   });
@@ -237,6 +244,27 @@ describe('useStudioQuery', () => {
       const error = result.current.error!;
       expect(error.message).toEqual('RPC request failed');
       expect(error.source).toEqual('custom-normalizer');
+    });
+  });
+
+  test('passes user identity as request headers when user context is provided', async () => {
+    mockRequest.mockResolvedValue({});
+
+    renderHook(
+      () => useStudioQuery({ queryName: 'GetDataset', serviceOptions: {} }),
+      buildWrapper([
+        getErrorProviderWrapper(),
+        getRouterWrapper({ location: '/ma-dev-test' }),
+        getServiceProviderWrapper({ request: mockRequest }),
+        getUserProviderWrapper({ name: 'Jane Doe', email: 'jane@example.com' }),
+      ])
+    );
+
+    await waitFor(() => {
+      expect(mockRequest).toHaveBeenCalledWith('GetDataset', expect.any(Object), {
+        'x-user-name': 'Jane Doe',
+        'x-user-email': 'jane@example.com',
+      });
     });
   });
 });

--- a/javascript/packages/core/hooks/use-studio-mutation/__tests__/use-studio-mutation.test.ts
+++ b/javascript/packages/core/hooks/use-studio-mutation/__tests__/use-studio-mutation.test.ts
@@ -11,6 +11,7 @@ import {
   getServiceProviderWrapper,
 } from '#core/test/wrappers/get-service-provider-wrapper';
 import { getSnackbarProviderWrapper } from '#core/test/wrappers/get-snackbar-provider-wrapper';
+import { getUserProviderWrapper } from '#core/test/wrappers/get-user-provider-wrapper';
 import { ApplicationError } from '#core/types/error-types';
 
 import type { ErrorNormalizer } from '#core/types/error-types';
@@ -35,7 +36,7 @@ describe('useStudioMutation', () => {
     result.current.mutate({ name: 'test-run' });
 
     await waitFor(() => {
-      expect(mockRequest).toHaveBeenCalledWith('CreatePipelineRun', { name: 'test-run' });
+      expect(mockRequest).toHaveBeenCalledWith('CreatePipelineRun', { name: 'test-run' }, {});
     });
   });
 
@@ -64,7 +65,8 @@ describe('useStudioMutation', () => {
     await waitFor(() => {
       expect(mockRequest).toHaveBeenCalledWith(
         'CreatePipelineRun',
-        expect.objectContaining({ spec: { action: 'KILL' } })
+        expect.objectContaining({ spec: { action: 'KILL' } }),
+        {}
       );
     });
   });
@@ -98,7 +100,8 @@ describe('useStudioMutation', () => {
     await waitFor(() => {
       expect(mockRequest).toHaveBeenCalledWith(
         'CreatePipelineRun',
-        expect.objectContaining({ metadata: { name: 'from-source' } })
+        expect.objectContaining({ metadata: { name: 'from-source' } }),
+        {}
       );
     });
   });
@@ -272,5 +275,31 @@ describe('useStudioMutation', () => {
     const error = result.current.error!;
     expect(error.message).toEqual('Pipeline run creation failed');
     expect(error.source).toEqual('mutation-normalizer');
+  });
+
+  test('passes user identity as request headers when user context is provided', async () => {
+    const mockRequest = createQueryMockRouter({
+      CreatePipelineRun: { id: 'test-id' },
+    });
+
+    const { result } = renderHook(
+      () => useStudioMutation({ mutationName: 'CreatePipelineRun' }),
+      buildWrapper([
+        getErrorProviderWrapper(),
+        getRouterWrapper(),
+        getServiceProviderWrapper({ request: mockRequest }),
+        getSnackbarProviderWrapper(),
+        getUserProviderWrapper({ name: 'Jane Doe', email: 'jane@example.com' }),
+      ])
+    );
+
+    result.current.mutate({ name: 'test-run' });
+
+    await waitFor(() => {
+      expect(mockRequest).toHaveBeenCalledWith('CreatePipelineRun', expect.any(Object), {
+        'x-user-name': 'Jane Doe',
+        'x-user-email': 'jane@example.com',
+      });
+    });
   });
 });

--- a/javascript/packages/core/hooks/use-studio-mutation/use-studio-mutation.ts
+++ b/javascript/packages/core/hooks/use-studio-mutation/use-studio-mutation.ts
@@ -4,6 +4,7 @@ import { useSuccessOperations } from '#core/components/actions/use-success-opera
 import { useSchemaMiddleware } from '#core/hooks/use-schema-middleware/use-schema-middleware';
 import { useErrorNormalizer } from '#core/providers/error-provider/use-error-normalizer';
 import { useServiceProvider } from '#core/providers/service-provider/use-service-provider';
+import { useUserRequestHeaders } from '#core/providers/user-provider/use-user-request-headers';
 
 import type { ApplicationError } from '#core/types/error-types';
 import type { MutationConfig } from '#core/types/query-types';
@@ -16,13 +17,14 @@ export const useStudioMutation = <TResponse, TPayload extends Record<string, unk
   const normalizeError = useErrorNormalizer();
   const runSuccessOperations = useSuccessOperations(config?.successOperations);
   const { applyMiddleware } = useSchemaMiddleware(config?.middleware);
+  const userHeaders = useUserRequestHeaders();
 
   const mutation = useMutation<TResponse, ApplicationError, TPayload>({
     mutationFn: async (payload: TPayload) => {
       if (!config) throw new Error('useStudioMutation called without config');
       try {
         // cast: service request returns unknown; TResponse is the caller-declared response type
-        return (await request(config.mutationName, payload)) as TResponse;
+        return (await request(config.mutationName, payload, userHeaders)) as TResponse;
       } catch (error) {
         console.error('mutation error', error);
         throw normalizeError(error)!;

--- a/javascript/packages/core/hooks/use-studio-query.ts
+++ b/javascript/packages/core/hooks/use-studio-query.ts
@@ -4,6 +4,7 @@ import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studi
 import { useInterpolationResolver } from '#core/interpolation/use-interpolation-resolver';
 import { useErrorNormalizer } from '#core/providers/error-provider/use-error-normalizer';
 import { useServiceProvider } from '#core/providers/service-provider/use-service-provider';
+import { useUserRequestHeaders } from '#core/providers/user-provider/use-user-request-headers';
 
 import type { UseQueryResult } from '@tanstack/react-query';
 import type { ApplicationError } from '#core/types/error-types';
@@ -70,6 +71,7 @@ export const useStudioQuery = <TData>(args: {
   const { request } = useServiceProvider();
   const normalizeError = useErrorNormalizer();
   const resolver = useInterpolationResolver();
+  const userHeaders = useUserRequestHeaders();
 
   const serviceOptions = resolver(args.serviceOptions);
   // A CR's namespace is the projectId, but the serviceOptions may provide a different namespace
@@ -81,7 +83,7 @@ export const useStudioQuery = <TData>(args: {
     queryFn: async () => {
       try {
         // cast: service request returns unknown; TData is the caller-declared response type
-        return (await request(queryName, { ...serviceOptions, namespace })) as TData;
+        return (await request(queryName, { ...serviceOptions, namespace }, userHeaders)) as TData;
       } catch (error) {
         console.error('error', error);
         throw normalizeError(error)!;

--- a/javascript/packages/core/providers/service-provider/types.ts
+++ b/javascript/packages/core/providers/service-provider/types.ts
@@ -8,5 +8,5 @@
  * return types are unknown.
  */
 export type ServiceContextType = {
-  request: (requestId: string, args: unknown) => Promise<unknown>;
+  request: (requestId: string, args: unknown, headers?: Record<string, string>) => Promise<unknown>;
 };

--- a/javascript/packages/core/providers/user-provider/use-user-request-headers.ts
+++ b/javascript/packages/core/providers/user-provider/use-user-request-headers.ts
@@ -1,0 +1,11 @@
+import { useUserProvider } from './use-user-provider';
+
+export const useUserRequestHeaders = (): Record<string, string> => {
+  const { name, email } = useUserProvider();
+
+  const headers: Record<string, string> = {};
+  if (email !== undefined) headers['x-user-email'] = email;
+  if (name !== undefined) headers['x-user-name'] = name;
+
+  return headers;
+};

--- a/javascript/packages/core/test/wrappers/get-service-provider-wrapper.tsx
+++ b/javascript/packages/core/test/wrappers/get-service-provider-wrapper.tsx
@@ -102,7 +102,7 @@ export function createServiceProviderTestContext(serviceProvider: Partial<Servic
 export function createQueryMockRouter(
   responses: Record<string, object | Error>
 ): ServiceContextType['request'] {
-  return vi.fn((queryName: string, args: object) => {
+  return vi.fn((queryName: string, args: object, _headers?: Record<string, string>) => {
     if (args) {
       for (const [responseKey, response] of Object.entries(responses)) {
         if (isEqual(parseArgsFromKey(responseKey), { queryName, args })) {

--- a/javascript/packages/rpc/__tests__/handlers.test.ts
+++ b/javascript/packages/rpc/__tests__/handlers.test.ts
@@ -29,7 +29,7 @@ describe('rpc handlers — mutation envelope wrapping', () => {
     const record = { metadata: { name: 'test-run' } };
     await handlers.CreatePipelineRun(record as never);
 
-    expect(createPipelineRun).toHaveBeenCalledWith({ pipelineRun: record });
+    expect(createPipelineRun).toHaveBeenCalledWith({ pipelineRun: record }, undefined);
   });
 
   it('UpdatePipelineRun wraps the bare record in a pipelineRun envelope', async () => {
@@ -37,7 +37,7 @@ describe('rpc handlers — mutation envelope wrapping', () => {
     const record = { metadata: { name: 'updated-run' } };
     await handlers.UpdatePipelineRun(record as never);
 
-    expect(updatePipelineRun).toHaveBeenCalledWith({ pipelineRun: record });
+    expect(updatePipelineRun).toHaveBeenCalledWith({ pipelineRun: record }, undefined);
   });
 
   it('UpdateTriggerRun wraps the bare record in a triggerRun envelope', async () => {
@@ -45,6 +45,23 @@ describe('rpc handlers — mutation envelope wrapping', () => {
     const record = { metadata: { name: 'kill-target' } };
     await handlers.UpdateTriggerRun(record as never);
 
-    expect(updateTriggerRun).toHaveBeenCalledWith({ triggerRun: record });
+    expect(updateTriggerRun).toHaveBeenCalledWith({ triggerRun: record }, undefined);
+  });
+
+  it('CreatePipelineRun stamps spec.actor from x-user-name header', async () => {
+    const handlers = await getRpcHandlers();
+    const record = { metadata: { name: 'run-1' }, spec: { pipeline: { name: 'p1' } } };
+    await handlers.CreatePipelineRun(record as never, { 'x-user-name': 'jane' });
+
+    expect(record.spec).toHaveProperty('actor');
+    expect((record.spec as Record<string, unknown>).actor).toMatchObject({ name: 'jane' });
+  });
+
+  it('CreatePipelineRun leaves spec.actor unset when x-user-name header is absent', async () => {
+    const handlers = await getRpcHandlers();
+    const record = { metadata: { name: 'run-2' }, spec: { pipeline: { name: 'p1' } } };
+    await handlers.CreatePipelineRun(record as never);
+
+    expect((record.spec as Record<string, unknown>).actor).toBeUndefined();
   });
 });

--- a/javascript/packages/rpc/create-fetch-transport.ts
+++ b/javascript/packages/rpc/create-fetch-transport.ts
@@ -16,10 +16,10 @@ export function createFetchTransport(options: FetchTransportOptions): FetchTrans
   };
 
   return {
-    async callUnary(serviceName, methodName, request) {
+    async callUnary(serviceName, methodName, request, perRequestHeaders) {
       const response = await fetch(`${baseUrl}/${serviceName}/${methodName}`, {
         method: 'POST',
-        headers,
+        headers: perRequestHeaders ? { ...headers, ...perRequestHeaders } : headers,
         body: JSON.stringify(request),
       });
 

--- a/javascript/packages/rpc/handlers.ts
+++ b/javascript/packages/rpc/handlers.ts
@@ -1,3 +1,6 @@
+import { create } from '@bufbuild/protobuf';
+
+import { UserInfoSchema } from './gen/michelangelo/api/v2/user_pb';
 import { getServices } from './services';
 
 import type { PipelineRun } from './gen/michelangelo/api/v2/pipeline_run_pb';
@@ -28,12 +31,17 @@ async function createHandlers() {
     GetPipelineRun: unary(services.PipelineRunService.getPipelineRun),
     ListTriggerRun: unary(services.TriggerRunService.listTriggerRun),
     GetTriggerRun: unary(services.TriggerRunService.getTriggerRun),
-    UpdateTriggerRun: (record: TriggerRun) =>
-      services.TriggerRunService.updateTriggerRun({ triggerRun: record }),
-    CreatePipelineRun: (record: PipelineRun) =>
-      services.PipelineRunService.createPipelineRun({ pipelineRun: record }),
-    UpdatePipelineRun: (record: PipelineRun) =>
-      services.PipelineRunService.updatePipelineRun({ pipelineRun: record }),
+    UpdateTriggerRun: (record: TriggerRun, headers?: Record<string, string>) =>
+      services.TriggerRunService.updateTriggerRun({ triggerRun: record }, headers),
+    CreatePipelineRun: (record: PipelineRun, headers?: Record<string, string>) => {
+      const actorName = headers?.['x-user-name'];
+      if (actorName && record.spec) {
+        record.spec.actor = create(UserInfoSchema, { name: actorName });
+      }
+      return services.PipelineRunService.createPipelineRun({ pipelineRun: record }, headers);
+    },
+    UpdatePipelineRun: (record: PipelineRun, headers?: Record<string, string>) =>
+      services.PipelineRunService.updatePipelineRun({ pipelineRun: record }, headers),
     ListModel: unary(services.ModelService.listModel),
   } as const;
 }

--- a/javascript/packages/rpc/request.ts
+++ b/javascript/packages/rpc/request.ts
@@ -10,6 +10,7 @@ import type { OmitTypeName, RpcHandlerType } from './types';
  *
  * @param rpcId - The ID of the RPC handler to call.
  * @param args - The arguments to pass to the RPC handler.
+ * @param headers - Optional HTTP headers to send with the request (e.g. user identity).
  * @returns A promise that resolves to the RPC response as a plain object.
  *
  * @example
@@ -21,14 +22,15 @@ import type { OmitTypeName, RpcHandlerType } from './types';
  */
 export async function request<RpcId extends keyof RpcHandlerType>(
   rpcId: RpcId,
-  args: OmitTypeName<Parameters<RpcHandlerType[RpcId]>[0]>
+  args: OmitTypeName<Parameters<RpcHandlerType[RpcId]>[0]>,
+  headers?: Record<string, string>
 ): Promise<OmitTypeName<Awaited<ReturnType<RpcHandlerType[RpcId]>>>> {
   const handlers = await getRpcHandlers();
   // cast: dynamic key lookup on handlers loses the specific RPC signature; we know RpcId is a valid
   // key with matching handler shape
-  const handler = handlers[rpcId] as (a: unknown) => Promise<unknown>;
+  const handler = handlers[rpcId] as (a: unknown, h?: Record<string, string>) => Promise<unknown>;
   // cast: handler returns unknown via dynamic dispatch; RpcId determines the concrete return type
-  const response = (await handler(args)) as Awaited<ReturnType<RpcHandlerType[RpcId]>>;
+  const response = (await handler(args, headers)) as Awaited<ReturnType<RpcHandlerType[RpcId]>>;
   // cast: toPlainObject returns unknown; RpcId determines the proto shape after stripping $typeName
   // fields
   return toPlainObject(response) as OmitTypeName<Awaited<ReturnType<RpcHandlerType[RpcId]>>>;

--- a/javascript/packages/rpc/services.ts
+++ b/javascript/packages/rpc/services.ts
@@ -26,15 +26,23 @@ function createServiceClient<T extends DescService>(
   service: T,
   transport: FetchTransport
 ): ServiceClient<T> {
-  const client: Record<string, (request: Record<string, unknown>) => Promise<unknown>> = {};
+  const client: Record<
+    string,
+    (request: Record<string, unknown>, headers?: Record<string, string>) => Promise<unknown>
+  > = {};
 
   for (const method of service.methods) {
     if (method.methodKind !== 'unary') continue;
 
-    client[method.localName] = async (request) => {
+    client[method.localName] = async (request, headers) => {
       const message = create(method.input, request);
       const requestJson = toJson(method.input, message, { registry: typeRegistry });
-      const responseJson = await transport.callUnary(service.typeName, method.name, requestJson);
+      const responseJson = await transport.callUnary(
+        service.typeName,
+        method.name,
+        requestJson,
+        headers
+      );
       return fromJson(method.output, responseJson, { registry: typeRegistry });
     };
   }

--- a/javascript/packages/rpc/types.ts
+++ b/javascript/packages/rpc/types.ts
@@ -41,7 +41,12 @@ export interface FetchTransport {
    * Calls a unary RPC through Envoy's grpc_json_transcoder by POSTing JSON to
    * `/{serviceName}/{methodName}` and returning the parsed JSON response.
    */
-  callUnary(serviceName: string, methodName: string, request: unknown): Promise<JsonValue>;
+  callUnary(
+    serviceName: string,
+    methodName: string,
+    request: unknown,
+    headers?: Record<string, string>
+  ): Promise<JsonValue>;
 }
 
 /**
@@ -50,7 +55,7 @@ export interface FetchTransport {
  */
 export type ServiceClient<T extends DescService> = {
   [K in keyof T['method']]: T['method'][K] extends DescMethodUnary<infer I, infer O>
-    ? (request: MessageInitShape<I>) => Promise<MessageShape<O>>
+    ? (request: MessageInitShape<I>, headers?: Record<string, string>) => Promise<MessageShape<O>>
     : never;
 };
 
@@ -85,8 +90,11 @@ export type RpcHandlerType = Awaited<ReturnType<typeof getRpcHandlers>>;
  * // => (args: { projectId: string }) => Promise<Project>
  * ```
  */
-export type ExtractUnaryRpc<T> = T extends (args: Record<string, unknown>) => Promise<infer R>
-  ? (args: Record<string, unknown>) => Promise<R>
+export type ExtractUnaryRpc<T> = T extends (
+  args: Record<string, unknown>,
+  headers?: Record<string, string>
+) => Promise<infer R>
+  ? (args: Record<string, unknown>, headers?: Record<string, string>) => Promise<R>
   : never;
 
 /**


### PR DESCRIPTION
## Summary

The request function had no way to carry per-request metadata. User identity was either hardcoded in form values or absent entirely — there was no transport-level mechanism for the platform to know who initiated a request.

This extends the request signature to `request(method, args, headers)`, matching Fusion's contract. Both query and mutation hooks now read the user provider and attach identity headers automatically, so every outgoing RPC carries the caller's identity without forms or components needing to know about it.

The `CreatePipelineRun` handler reads the user name from the header and stamps `spec.actor` at the handler level — the same responsibility studio-web's `wrapCrdMutationsWithOwnership` handles in its BFF layer, moved to the transport boundary so the form stays backend-shape agnostic.

Collateral: test assertions across 8 files updated for the new third argument on request calls.

## Test plan

I verified all 1355 tests pass with the new request signature. Manual verification of headers on the wire deferred to sandbox testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)