### PR TITLE
fix(ci): trigger Go/UI container publish for RC/final tags; fix container tag format

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -59,6 +59,16 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Compute bare version for tag pushes
+        id: bare_version
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+            echo "is_tag=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_tag=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: ${{ matrix.service }} / Extract Docker Metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -70,6 +80,7 @@ jobs:
             type=ref,event=branch
             type=ref,event=tag
             type=ref,prefix=pr-,event=pr
+            type=raw,value=${{ steps.bare_version.outputs.version }},enable=${{ steps.bare_version.outputs.is_tag }}
 
       - name: ${{ matrix.service }} / Build & Push Image
         uses: docker/build-push-action@v6

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -96,6 +96,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Trigger container image publish for the RC tag
+        run: |
+          gh workflow run ui-release.yml --ref "${{ steps.vars.outputs.tag }}"
+          gh workflow run dev-release.yml --ref "${{ steps.vars.outputs.tag }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Ensure the release tracking label exists
         run: gh label create release --color ededed --description "Release tracking issue" --force
         env:

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -95,6 +95,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Trigger container image publish for the final tag
+        run: |
+          gh workflow run ui-release.yml --ref "${{ steps.vars.outputs.tag }}"
+          gh workflow run dev-release.yml --ref "${{ steps.vars.outputs.tag }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Mark merge-back PR ready for review
         run: |
           PR_NUMBER=$(gh pr list --head "${{ steps.vars.outputs.branch }}" --base main --state open --json number --jq '.[0].number')

--- a/.github/workflows/ui-release.yml
+++ b/.github/workflows/ui-release.yml
@@ -65,6 +65,16 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Compute bare version for tag pushes
+        id: bare_version
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+            echo "is_tag=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_tag=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Extract Docker Metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -77,6 +87,7 @@ jobs:
             type=ref,event=tag
             type=ref,prefix=pr-,event=pr
             type=raw,value=v${{ needs.check-version-change.outputs.new-version }},enable={{is_default_branch}}
+            type=raw,value=${{ steps.bare_version.outputs.version }},enable=${{ steps.bare_version.outputs.is_tag }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## What changed?
1. Added an explicit `gh workflow run ui-release.yml` / `dev-release.yml --ref <tag>` step to both `release-cut.yml` and `release-promote.yml`, right after the changelog-generation trigger.
2. Added a bare-version (no `v` prefix) container tag alongside the existing `v`-prefixed one in `ui-release.yml`/`dev-release.yml`, matching `RULES.md` VER-002's documented tag format for containers/npm/Helm/PyPI (`0.3.0-rc.1`, not `v0.3.0-rc.1`).

## Why?
`ui-release.yml` (UI container) and `dev-release.yml` (Go service containers: apiserver/worker/controllermgr) both trigger only on `push: tags: ['v*']`. Every tag `release-cut.yml`/`release-promote.yml` pushes is authored by `GITHUB_TOKEN`, which GitHub's anti-recursion rule blocks from triggering other workflows — the same bug already fixed for `release.yaml` (#1499) and `changelog.yml` (#1509), but never applied to these two.

Confirmed live: `gh run list --workflow=ui-release.yml` / `--workflow=dev-release.yml` show zero runs ever triggered by a `v*` tag, only by pushes to `main`. Every RC (and likely every final release) has silently shipped without containers since release branching started.

`RULES.md` VER-002 and `skills/release_process.md`'s multi-artifact matrix (harness repo) both document Go/UI containers as required release artifacts, RC and final, with the same bare-version tag format used by npm/Helm/PyPI. This is a spec gap, not a design choice.

Full investigation writeup: `specs/042/spec.md` in the harness repo.

## How did you test it?
- `scripts/validate_workflows.sh` — actionlint clean on all four modified files (fixed a shellcheck SC2193 false-positive along the way by using `$GITHUB_REF` instead of embedding `${{ github.ref }}` inside a bash `[[ ]]` comparison, matching the existing convention already used elsewhere in this repo, e.g. `release.yaml`'s `${GITHUB_REF_NAME#v}`).
- Applying the identical diff directly to `release/v0.4` and retriggering `ui-release.yml`/`dev-release.yml` to retroactively publish containers for the existing `v0.4.0-rc.1` (separate follow-up, in progress).

## Breaking Changes
No breaking changes. The tag format change is additive (keeps the existing `v`-prefixed tag, adds a new bare-version one).