### PR TITLE
fix(helm): tie first-party image tags to chart appVersion

### DIFF
--- a/helm/michelangelo/README.md
+++ b/helm/michelangelo/README.md
@@ -253,10 +253,11 @@ Top-level keys. See [`values.yaml`](./values.yaml) for the full annotated schema
 | `workflow.engine` | string | `cadence` | yes | `cadence` or `temporal`. Mutually exclusive — selects which worker config block renders. |
 | `workflow.endpoint` | string | `""` | **yes** | Workflow engine address (e.g. `cadence-frontend:7833`, `temporal-frontend:7233`). |
 | `workflow.domain` | string | `default` | no | Cadence domain or Temporal namespace. |
-| `images.apiserver` | string | `ghcr.io/michelangelo-ai/apiserver:main` | no | Override to pin a version or use a private registry. |
-| `images.worker` | string | `ghcr.io/michelangelo-ai/worker:main` | no | |
-| `images.ui` | string | `ghcr.io/michelangelo-ai/ui:main` | no | |
-| `images.controllermgr` | string | `ghcr.io/michelangelo-ai/controllermgr:main` | no | |
+| `images.apiserver.repository` | string | `ghcr.io/michelangelo-ai/apiserver` | no | Override for a private registry/mirror. |
+| `images.apiserver.tag` | string | `""` | no | Defaults to the chart's `appVersion` (i.e. the release version). Override to pin a different version or a floating tag like `main`. |
+| `images.worker.repository` / `.tag` | string | `ghcr.io/michelangelo-ai/worker` / `""` | no | Same pattern as `images.apiserver`. |
+| `images.ui.repository` / `.tag` | string | `ghcr.io/michelangelo-ai/ui` / `""` | no | Same pattern as `images.apiserver`. |
+| `images.controllermgr.repository` / `.tag` | string | `ghcr.io/michelangelo-ai/controllermgr` / `""` | no | Same pattern as `images.apiserver`. |
 | `images.envoy` | string | `envoyproxy/envoy:v1.29-latest` | no | |
 | `images.pullPolicy` | string | `IfNotPresent` | no | |
 | `imagePullSecrets` | list | `[]` | no | List of Secret names for private registries. |
@@ -422,14 +423,14 @@ See [`values.yaml`](./values.yaml) for the full annotated schema.
 helm upgrade michelangelo ./helm/michelangelo --reuse-values
 ```
 
-`--reuse-values` keeps your previous `--set` and `-f` overrides. Pass new flags only for the values you want to change. To pin to a specific image tag during upgrade:
+`--reuse-values` keeps your previous `--set` and `-f` overrides. Pass new flags only for the values you want to change. Image tags default to the chart's own `appVersion`, so upgrading to a new chart version upgrades the images automatically — no `--set` needed. To pin to a specific image tag instead (e.g. to roll back one service, or track `main`):
 
 ```bash
 helm upgrade michelangelo ./helm/michelangelo --reuse-values \
-  --set images.apiserver=ghcr.io/michelangelo-ai/apiserver:v0.3.1 \
-  --set images.worker=ghcr.io/michelangelo-ai/worker:v0.3.1 \
-  --set images.ui=ghcr.io/michelangelo-ai/ui:v0.3.1 \
-  --set images.controllermgr=ghcr.io/michelangelo-ai/controllermgr:v0.3.1
+  --set images.apiserver.tag=v0.3.1 \
+  --set images.worker.tag=v0.3.1 \
+  --set images.ui.tag=v0.3.1 \
+  --set images.controllermgr.tag=v0.3.1
 ```
 
 The `object-storage-credentials` Secret is annotated `helm.sh/resource-policy: keep` and will not be overwritten on upgrade. To rotate credentials, update the Secret in place with `kubectl edit secret object-storage-credentials` or delete and re-apply it.

--- a/helm/michelangelo/templates/_helpers.tpl
+++ b/helm/michelangelo/templates/_helpers.tpl
@@ -105,3 +105,13 @@ Schema-init volume name (used by apiserver Deployment + ConfigMap).
 {{- define "michelangelo.schemaInitConfigMapName" -}}
 {{- printf "%s-schema-init" (include "michelangelo.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Build a "repository:tag" image reference for a first-party service, falling
+back to the chart's own appVersion when no tag override is set. Call with a
+dict of {repository, tag, Chart}, e.g.:
+  {{ include "michelangelo.image" (dict "repository" .Values.images.apiserver.repository "tag" .Values.images.apiserver.tag "Chart" .Chart) }}
+*/}}
+{{- define "michelangelo.image" -}}
+{{- printf "%s:%s" .repository (.tag | default .Chart.AppVersion) -}}
+{{- end -}}

--- a/helm/michelangelo/templates/core/apiserver-deployment.yaml
+++ b/helm/michelangelo/templates/core/apiserver-deployment.yaml
@@ -108,7 +108,7 @@ spec:
               readOnly: true
       containers:
         - name: apiserver
-          image: {{ .Values.images.apiserver }}
+          image: {{ include "michelangelo.image" (dict "repository" .Values.images.apiserver.repository "tag" .Values.images.apiserver.tag "Chart" .Chart) }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           {{- with .Values.securityContext }}
           securityContext:

--- a/helm/michelangelo/templates/core/controllermgr-deployment.yaml
+++ b/helm/michelangelo/templates/core/controllermgr-deployment.yaml
@@ -29,7 +29,7 @@ spec:
       {{- end }}
       containers:
         - name: app
-          image: {{ .Values.images.controllermgr }}
+          image: {{ include "michelangelo.image" (dict "repository" .Values.images.controllermgr.repository "tag" .Values.images.controllermgr.tag "Chart" .Chart) }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           {{- with .Values.securityContext }}
           securityContext:

--- a/helm/michelangelo/templates/core/ui-deployment.yaml
+++ b/helm/michelangelo/templates/core/ui-deployment.yaml
@@ -27,7 +27,7 @@ spec:
       {{- end }}
       containers:
         - name: ui
-          image: {{ .Values.images.ui }}
+          image: {{ include "michelangelo.image" (dict "repository" .Values.images.ui.repository "tag" .Values.images.ui.tag "Chart" .Chart) }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           {{- with .Values.securityContext }}
           securityContext:

--- a/helm/michelangelo/templates/core/worker-deployment.yaml
+++ b/helm/michelangelo/templates/core/worker-deployment.yaml
@@ -27,7 +27,7 @@ spec:
       {{- end }}
       containers:
         - name: app
-          image: {{ .Values.images.worker }}
+          image: {{ include "michelangelo.image" (dict "repository" .Values.images.worker.repository "tag" .Values.images.worker.tag "Chart" .Chart) }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           {{- with .Values.securityContext }}
           securityContext:

--- a/helm/michelangelo/values-k3d.yaml
+++ b/helm/michelangelo/values-k3d.yaml
@@ -34,6 +34,17 @@ workflow:
 
 images:
   pullPolicy: IfNotPresent
+  # Sandbox tracks main, not a pinned release — base values.yaml defaults
+  # these to the chart's own appVersion, which would resolve to a released
+  # tag that hasn't been built for local dev.
+  apiserver:
+    tag: main
+  worker:
+    tag: main
+  ui:
+    tag: main
+  controllermgr:
+    tag: main
 
 apiserver:
   metadataStorage:

--- a/helm/michelangelo/values.yaml
+++ b/helm/michelangelo/values.yaml
@@ -101,13 +101,28 @@ workflow:
     - notification_worker
 
 # -----------------------------------------------------------------------------
-# Container images. Override to pin a version or use a mirror.
+# Container images.
+#
+# apiserver/worker/ui/controllermgr are built and published together on every
+# chart release. Their `tag` defaults to "" here, which falls back to this
+# chart's own .Chart.AppVersion (see templates/_helpers.tpl's "michelangelo.image")
+# -- so installing chart version X.Y.Z pulls the matching X.Y.Z images without
+# any override needed. Set `tag` explicitly to pin a different version or use
+# a floating tag (e.g. "main" for local development -- see values-k3d.yaml).
 # -----------------------------------------------------------------------------
 images:
-  apiserver:        ghcr.io/michelangelo-ai/apiserver:main
-  worker:           ghcr.io/michelangelo-ai/worker:main
-  ui:               ghcr.io/michelangelo-ai/ui:main
-  controllermgr:    ghcr.io/michelangelo-ai/controllermgr:main
+  apiserver:
+    repository: ghcr.io/michelangelo-ai/apiserver
+    tag: ""
+  worker:
+    repository: ghcr.io/michelangelo-ai/worker
+    tag: ""
+  ui:
+    repository: ghcr.io/michelangelo-ai/ui
+    tag: ""
+  controllermgr:
+    repository: ghcr.io/michelangelo-ai/controllermgr
+    tag: ""
   envoy:            envoyproxy/envoy:v1.29-latest
   kuberayCollector: ghcr.io/michelangelo-ai/kuberay-collector:main
 


### PR DESCRIPTION
## Summary

`scripts/version-bump.sh` bumps `helm/michelangelo/Chart.yaml`'s `version`/`appVersion` on every release, but `values.yaml`'s `images:` block hardcoded `apiserver`/`worker`/`ui`/`controllermgr` to `:main` and was never touched by that script — installing chart version `0.4.0` still pulled `:main` images instead of `0.4.0` images. This is the standard OSS Helm convention gap (see argo-cd/bitnami for the pattern used here).

## Changes

- `templates/_helpers.tpl`: new `michelangelo.image` helper — `{{ .repository }}:{{ .tag | default .Chart.AppVersion }}`
- `values.yaml`: `images.{apiserver,worker,ui,controllermgr}` restructured from plain strings to `{repository, tag: ""}` objects. `envoy`/`kuberayCollector` (not part of the release-cut publish matrix) left untouched.
- 4 deployment templates updated to use the new helper.
- `values-k3d.yaml`: pins `tag: main` explicitly for local sandbox dev, preserving existing behavior.
- `README.md`: values reference table + upgrade example updated for the new schema.

## Breaking change

`images.apiserver`/`worker`/`ui`/`controllermgr` move from plain strings to `{repository, tag}` objects.
Old: `--set images.apiserver=ghcr.io/michelangelo-ai/apiserver:v0.3.1`
New: `--set images.apiserver.tag=v0.3.1`

## Test plan

- [x] `helm lint helm/michelangelo` — passes (only pre-existing unrelated "required value" warnings)
- [x] `helm template` with default values — images resolve to `:0.4.0` (current `Chart.AppVersion`)
- [x] `helm template -f values-k3d.yaml` — images resolve to `:main` (sandbox override preserved)