### PR TITLE
Type CELL_RENDERERS registry with per-entry value types

### DIFF
--- a/javascript/packages/core/components/cell/__tests__/use-get-cell-renderer.tests.tsx
+++ b/javascript/packages/core/components/cell/__tests__/use-get-cell-renderer.tests.tsx
@@ -264,35 +264,7 @@ describe('useGetCellRenderer', () => {
       expect(screen.queryByText('Badge: test value')).not.toBeInTheDocument();
     });
 
-    it('should use provider renderers for custom (non-built-in) cell types', () => {
-      const CUSTOM_TYPE = 'CUSTOM_TYPE';
-      const CustomRenderer: CellRenderer<string> = (props: CellRendererProps<string>) => (
-        <div data-testid="custom-renderer">Custom: {props.value}</div>
-      );
-
-      const renderers = {
-        [CUSTOM_TYPE]: CustomRenderer,
-      };
-
-      const props: CellRendererProps<string> = {
-        column: { id: 'test', type: CUSTOM_TYPE },
-        record: {},
-        value: 'test value',
-      };
-
-      render(
-        <TestCellRenderer props={props} />,
-        buildWrapper([
-          getBaseProviderWrapper(),
-          getIconProviderWrapper(),
-          getCellProviderWrapper({ renderers }),
-        ])
-      );
-
-      expect(screen.getByText('Custom: test value')).toBeInTheDocument();
-    });
-
-    it('should not allow provider renderers to override built-in renderers', () => {
+    it('should prioritize provider renderers over built-in renderers', () => {
       const CustomTextRenderer: CellRenderer<string> = (props: CellRendererProps<string>) => (
         <div data-testid="custom-text">Custom Text: {props.value}</div>
       );
@@ -316,7 +288,7 @@ describe('useGetCellRenderer', () => {
         ])
       );
 
-      expect(screen.queryByText('Custom Text: test value')).not.toBeInTheDocument();
+      expect(screen.getByText('Custom Text: test value')).toBeInTheDocument();
     });
 
     it('should work with empty renderers', () => {

--- a/javascript/packages/core/components/cell/__tests__/use-get-cell-renderer.tests.tsx
+++ b/javascript/packages/core/components/cell/__tests__/use-get-cell-renderer.tests.tsx
@@ -264,7 +264,35 @@ describe('useGetCellRenderer', () => {
       expect(screen.queryByText('Badge: test value')).not.toBeInTheDocument();
     });
 
-    it('should prioritize provider custom renderers over built-in renderers', () => {
+    it('should use provider renderers for custom (non-built-in) cell types', () => {
+      const CUSTOM_TYPE = 'CUSTOM_TYPE';
+      const CustomRenderer: CellRenderer<string> = (props: CellRendererProps<string>) => (
+        <div data-testid="custom-renderer">Custom: {props.value}</div>
+      );
+
+      const renderers = {
+        [CUSTOM_TYPE]: CustomRenderer,
+      };
+
+      const props: CellRendererProps<string> = {
+        column: { id: 'test', type: CUSTOM_TYPE },
+        record: {},
+        value: 'test value',
+      };
+
+      render(
+        <TestCellRenderer props={props} />,
+        buildWrapper([
+          getBaseProviderWrapper(),
+          getIconProviderWrapper(),
+          getCellProviderWrapper({ renderers }),
+        ])
+      );
+
+      expect(screen.getByText('Custom: test value')).toBeInTheDocument();
+    });
+
+    it('should not allow provider renderers to override built-in renderers', () => {
       const CustomTextRenderer: CellRenderer<string> = (props: CellRendererProps<string>) => (
         <div data-testid="custom-text">Custom Text: {props.value}</div>
       );
@@ -288,7 +316,7 @@ describe('useGetCellRenderer', () => {
         ])
       );
 
-      expect(screen.getByText('Custom Text: test value')).toBeInTheDocument();
+      expect(screen.queryByText('Custom Text: test value')).not.toBeInTheDocument();
     });
 
     it('should work with empty renderers', () => {

--- a/javascript/packages/core/components/cell/constants.ts
+++ b/javascript/packages/core/components/cell/constants.ts
@@ -9,7 +9,7 @@ import { TagCell } from './renderers/tag/tag-cell';
 import { TextCell } from './renderers/text/text-cell';
 import { TypeCell } from './renderers/type/type-cell';
 
-import type { CellRenderer } from './types';
+import type { CellRendererRegistry } from './types';
 
 export enum CellType {
   /**
@@ -90,19 +90,15 @@ export enum CellType {
   RETRY = 'RETRY',
 }
 
-export const CELL_RENDERERS: Record<string, CellRenderer<unknown>> = {
-  // cast: registry is typed CellRenderer<unknown>; each renderer expects its specific value type;
-  // see #1419
-  [CellType.BOOLEAN]: BooleanCell as CellRenderer<boolean>,
-  // cast: registry is typed CellRenderer<unknown>; DateCell expects string epoch value; see #1419
-  [CellType.DATE]: DateCell as CellRenderer<string>,
+export const CELL_RENDERERS: Partial<CellRendererRegistry> = {
+  [CellType.BOOLEAN]: BooleanCell,
+  [CellType.DATE]: DateCell,
   [CellType.DESCRIPTION]: DescriptionCell,
   [CellType.LINK]: LinkCell,
   [CellType.MULTI]: MultiCell,
   [CellType.REPEATED_ITEMS]: MultiCell,
   [CellType.RETRY]: RetryCell,
-  // cast: registry is typed CellRenderer<unknown>; StateCell expects string value; see #1419
-  [CellType.STATE]: StateCell as CellRenderer<string>,
+  [CellType.STATE]: StateCell,
   [CellType.TAG]: TagCell,
   [CellType.TYPE]: TypeCell,
   [CellType.TEXT]: TextCell,

--- a/javascript/packages/core/components/cell/constants.ts
+++ b/javascript/packages/core/components/cell/constants.ts
@@ -90,7 +90,7 @@ export enum CellType {
   RETRY = 'RETRY',
 }
 
-export const CELL_RENDERERS: Partial<CellRendererRegistry> = {
+export const CELL_RENDERERS = {
   [CellType.BOOLEAN]: BooleanCell,
   [CellType.DATE]: DateCell,
   [CellType.DESCRIPTION]: DescriptionCell,
@@ -102,4 +102,4 @@ export const CELL_RENDERERS: Partial<CellRendererRegistry> = {
   [CellType.TAG]: TagCell,
   [CellType.TYPE]: TypeCell,
   [CellType.TEXT]: TextCell,
-};
+} satisfies Partial<CellRendererRegistry>;

--- a/javascript/packages/core/components/cell/constants.ts
+++ b/javascript/packages/core/components/cell/constants.ts
@@ -9,8 +9,6 @@ import { TagCell } from './renderers/tag/tag-cell';
 import { TextCell } from './renderers/text/text-cell';
 import { TypeCell } from './renderers/type/type-cell';
 
-import type { CellRendererRegistry } from './types';
-
 export enum CellType {
   /**
    * @description Renders a gray **Tag** with formatted text
@@ -102,4 +100,10 @@ export const CELL_RENDERERS = {
   [CellType.TAG]: TagCell,
   [CellType.TYPE]: TypeCell,
   [CellType.TEXT]: TextCell,
-} satisfies Partial<CellRendererRegistry>;
+};
+
+// Defined here rather than types.ts because it is typeof CELL_RENDERERS — the type is
+// the implementation. Defining it elsewhere would require importing the value, creating
+// a circular dependency. Re-exported from types.ts for consumers who import from there.
+// eslint-disable-next-line local/types-in-types-file
+export type CellRendererRegistry = typeof CELL_RENDERERS;

--- a/javascript/packages/core/components/cell/types.ts
+++ b/javascript/packages/core/components/cell/types.ts
@@ -5,6 +5,7 @@ import type { DescriptionCellConfig } from '#core/components/cell/renderers/desc
 import type { LinkCellConfig } from '#core/components/cell/renderers/link/types';
 import type { MultiCellConfig } from '#core/components/cell/renderers/multi/types';
 import type { Accessor } from '#core/types/common/studio-types';
+import type { CellType } from './constants';
 import type { StateCellConfig } from './renderers/state/types';
 import type { TypeCellConfig } from './renderers/type/types';
 
@@ -182,3 +183,21 @@ export type CellToStringParams<T = unknown, CellConfig = SharedCell> = Pick<
   CellRendererProps<T, CellConfig>,
   'column' | 'value'
 >;
+
+type CellTypeValueMap = {
+  [CellType.BOOLEAN]: boolean;
+  [CellType.DATE]: string;
+  [CellType.DESCRIPTION]: string;
+  [CellType.LINK]: string;
+  [CellType.MULTI]: unknown;
+  [CellType.REPEATED_ITEMS]: unknown;
+  [CellType.RETRY]: string;
+  [CellType.STATE]: string;
+  [CellType.TAG]: string;
+  [CellType.TYPE]: string;
+  [CellType.TEXT]: string;
+};
+
+export type CellRendererRegistry = {
+  [K in keyof CellTypeValueMap]: CellRenderer<CellTypeValueMap[K]>;
+};

--- a/javascript/packages/core/components/cell/types.ts
+++ b/javascript/packages/core/components/cell/types.ts
@@ -5,7 +5,6 @@ import type { DescriptionCellConfig } from '#core/components/cell/renderers/desc
 import type { LinkCellConfig } from '#core/components/cell/renderers/link/types';
 import type { MultiCellConfig } from '#core/components/cell/renderers/multi/types';
 import type { Accessor } from '#core/types/common/studio-types';
-import type { CellType } from './constants';
 import type { StateCellConfig } from './renderers/state/types';
 import type { TypeCellConfig } from './renderers/type/types';
 
@@ -184,20 +183,7 @@ export type CellToStringParams<T = unknown, CellConfig = SharedCell> = Pick<
   'column' | 'value'
 >;
 
-type CellTypeValueMap = {
-  [CellType.BOOLEAN]: boolean;
-  [CellType.DATE]: string;
-  [CellType.DESCRIPTION]: string;
-  [CellType.LINK]: string;
-  [CellType.MULTI]: unknown;
-  [CellType.REPEATED_ITEMS]: unknown;
-  [CellType.RETRY]: string;
-  [CellType.STATE]: string;
-  [CellType.TAG]: string;
-  [CellType.TYPE]: string;
-  [CellType.TEXT]: string;
-};
-
-export type CellRendererRegistry = {
-  [K in keyof CellTypeValueMap]: CellRenderer<CellTypeValueMap[K]>;
-};
+// CellRendererRegistry is defined in constants.ts because it is typeof CELL_RENDERERS —
+// the type is the implementation. Defining it here would require importing the value,
+// creating a circular dependency. Re-exported so consumers can import from either module.
+export type { CellRendererRegistry } from './constants';

--- a/javascript/packages/core/components/cell/use-get-cell-renderer.tsx
+++ b/javascript/packages/core/components/cell/use-get-cell-renderer.tsx
@@ -14,8 +14,8 @@ import type { CellRenderer, CellRendererProps } from '#core/components/cell/type
  *
  * The renderer resolution follows this priority order:
  * 1. Custom renderer from column.Cell if provided
- * 2. Built-in renderer from CELL_RENDERERS if type matches
- * 3. Custom renderer from CellProvider context for application-defined types
+ * 2. Renderer from CellProvider context if registered for the column type
+ * 3. Built-in renderer from CELL_RENDERERS if type matches
  * 4. Auto-detected link renderer for URL values
  * 5. Default TextCell renderer as fallback
  *
@@ -68,14 +68,14 @@ export function useGetCellRenderer(): (args: CellRendererProps<unknown>) => Cell
 
     const columnType = getType(args);
 
-    if (columnType && columnType in CELL_RENDERERS) {
-      // cast: registry lookup narrows value to a specific CellRenderer<T>; caller
-      // works with CellRenderer<unknown> and passes unknown values at runtime
-      return CELL_RENDERERS[columnType] as CellRenderer<unknown>;
-    }
-
     if (columnType && cellContext?.renderers[columnType]) {
       return cellContext.renderers[columnType];
+    }
+
+    if (columnType && columnType in CELL_RENDERERS) {
+      // cast: registry lookup returns a specific CellRenderer<T>; caller works with
+      // CellRenderer<unknown> and passes unknown values at runtime
+      return CELL_RENDERERS[columnType] as CellRenderer<unknown>;
     }
 
     if (typeof value === 'string' && isURL(value, { require_protocol: true, require_tld: false })) {

--- a/javascript/packages/core/components/cell/use-get-cell-renderer.tsx
+++ b/javascript/packages/core/components/cell/use-get-cell-renderer.tsx
@@ -18,8 +18,8 @@ import type {
  *
  * The renderer resolution follows this priority order:
  * 1. Custom renderer from column.Cell if provided
- * 2. Renderer from CellProvider context if registered for the column type
- * 3. Built-in renderer from CELL_RENDERERS if type matches
+ * 2. Built-in renderer from CELL_RENDERERS if type matches
+ * 3. Custom renderer from CellProvider context for application-defined types
  * 4. Auto-detected link renderer for URL values
  * 5. Default TextCell renderer as fallback
  *
@@ -72,14 +72,14 @@ export function useGetCellRenderer(): (args: CellRendererProps<unknown>) => Cell
 
     const columnType = getType(args);
 
-    if (columnType && cellContext?.renderers[columnType]) {
-      return cellContext.renderers[columnType];
-    }
-
     if (columnType && columnType in CELL_RENDERERS) {
       // cast: registry lookup narrows value to a specific CellRenderer<T>; caller
       // works with CellRenderer<unknown> and passes unknown values at runtime
       return CELL_RENDERERS[columnType as keyof CellRendererRegistry] as CellRenderer<unknown>;
+    }
+
+    if (columnType && cellContext?.renderers[columnType]) {
+      return cellContext.renderers[columnType];
     }
 
     if (typeof value === 'string' && isURL(value, { require_protocol: true, require_tld: false })) {

--- a/javascript/packages/core/components/cell/use-get-cell-renderer.tsx
+++ b/javascript/packages/core/components/cell/use-get-cell-renderer.tsx
@@ -6,11 +6,7 @@ import { Link } from '#core/components/link/link';
 import { useCellProvider } from '#core/providers/cell-provider/use-cell-provider';
 import { CellType } from './constants';
 
-import type {
-  CellRenderer,
-  CellRendererProps,
-  CellRendererRegistry,
-} from '#core/components/cell/types';
+import type { CellRenderer, CellRendererProps } from '#core/components/cell/types';
 
 /**
  * Returns a function that resolves the appropriate cell renderer based on column
@@ -75,7 +71,7 @@ export function useGetCellRenderer(): (args: CellRendererProps<unknown>) => Cell
     if (columnType && columnType in CELL_RENDERERS) {
       // cast: registry lookup narrows value to a specific CellRenderer<T>; caller
       // works with CellRenderer<unknown> and passes unknown values at runtime
-      return CELL_RENDERERS[columnType as keyof CellRendererRegistry] as CellRenderer<unknown>;
+      return CELL_RENDERERS[columnType] as CellRenderer<unknown>;
     }
 
     if (columnType && cellContext?.renderers[columnType]) {

--- a/javascript/packages/core/components/cell/use-get-cell-renderer.tsx
+++ b/javascript/packages/core/components/cell/use-get-cell-renderer.tsx
@@ -6,7 +6,11 @@ import { Link } from '#core/components/link/link';
 import { useCellProvider } from '#core/providers/cell-provider/use-cell-provider';
 import { CellType } from './constants';
 
-import type { CellRenderer, CellRendererProps } from '#core/components/cell/types';
+import type {
+  CellRenderer,
+  CellRendererProps,
+  CellRendererRegistry,
+} from '#core/components/cell/types';
 
 /**
  * Returns a function that resolves the appropriate cell renderer based on column
@@ -73,7 +77,9 @@ export function useGetCellRenderer(): (args: CellRendererProps<unknown>) => Cell
     }
 
     if (columnType && columnType in CELL_RENDERERS) {
-      return CELL_RENDERERS[columnType];
+      // cast: registry lookup narrows value to a specific CellRenderer<T>; caller
+      // works with CellRenderer<unknown> and passes unknown values at runtime
+      return CELL_RENDERERS[columnType as keyof CellRendererRegistry] as CellRenderer<unknown>;
     }
 
     if (typeof value === 'string' && isURL(value, { require_protocol: true, require_tld: false })) {

--- a/javascript/packages/core/providers/cell-provider/types.ts
+++ b/javascript/packages/core/providers/cell-provider/types.ts
@@ -9,16 +9,16 @@ import type { CellRenderer } from '#core/components/cell/types';
 export type CellContextType = {
   /**
    * @description
-   * Renderers for custom (application-defined) cell types that extend the
-   * built-in set. Registered renderers are used as a fallback after built-in
-   * renderers are checked, so this map cannot override a built-in CellType.
-   * To render a specific column differently, use the column-level `Cell` prop.
+   * Cell renderers registered at the application level. Checked before built-in
+   * renderers, so a registered renderer for a known CellType will override the
+   * default. Use this for app-wide customization. For per-column overrides, use
+   * the column-level `Cell` prop instead.
    *
    * @example
    * ```tsx
    * const renderers = {
    *   'CUSTOM_BADGE': MyBadgeRenderer,
-   *   'SPECIAL_TYPE': MySpecialRenderer
+   *   [CellType.BOOLEAN]: MyBooleanRenderer,
    * };
    * ```
    */

--- a/javascript/packages/core/providers/cell-provider/types.ts
+++ b/javascript/packages/core/providers/cell-provider/types.ts
@@ -9,8 +9,10 @@ import type { CellRenderer } from '#core/components/cell/types';
 export type CellContextType = {
   /**
    * @description
-   * Custom cell renderers that extend the built-in CELL_RENDERERS.
-   * These will be checked first before falling back to default behavior.
+   * Renderers for custom (application-defined) cell types that extend the
+   * built-in set. Registered renderers are used as a fallback after built-in
+   * renderers are checked, so this map cannot override a built-in CellType.
+   * To render a specific column differently, use the column-level `Cell` prop.
    *
    * @example
    * ```tsx


### PR DESCRIPTION
The cell renderer registry was typed as `Record<string, CellRenderer<unknown>>`, which forced three per-entry casts to satisfy the wide type — obscuring that each renderer knows its correct value type (boolean for BOOLEAN, string for DATE/STATE, etc).

This PR replaces that with a registry typed as `typeof CELL_RENDERERS`, making each renderer's own prop declaration the single source of truth for its value type. When a renderer's value type changes, the registry type updates automatically.

Using `typeof` instead of a type annotation preserves the literal key set, which gives TypeScript's control-flow narrowing enough information to index the registry directly after an `in` check. The one remaining cast is on the return, where the union of specific renderer types must be widened to `CellRenderer<unknown>` for the caller.

`CellRendererRegistry` is defined in `constants.ts` rather than `types.ts` because defining it in `types.ts` would require importing the value back from `constants.ts`, creating a circular dependency. It is re-exported from `types.ts` so consumers can import from either module.

Closes #1419 