### PR TITLE
fix(core): re-export UserProvider for custom provider trees

### DIFF
--- a/javascript/packages/core/index.tsx
+++ b/javascript/packages/core/index.tsx
@@ -211,8 +211,8 @@ export type {
 } from '#core/components/views/detail-view/types/detail-view-component-types';
 
 // User Provider
-// UserProvider is re-exported for consumers that build their own provider tree
-// (e.g. OssProvider in studio-web). CoreApp mounts UserProvider internally via
-// dependencies.user — prefer that path for new integrations.
+// UserProvider is re-exported for consumers that build their own provider tree.
+// CoreApp mounts UserProvider internally via dependencies.user — prefer that
+// path for new integrations.
 export { UserProvider } from '#core/providers/user-provider/user-provider';
 export { UserRole } from '#core/providers/user-provider/types';

--- a/javascript/packages/core/index.tsx
+++ b/javascript/packages/core/index.tsx
@@ -211,4 +211,8 @@ export type {
 } from '#core/components/views/detail-view/types/detail-view-component-types';
 
 // User Provider
+// UserProvider is re-exported for consumers that build their own provider tree
+// (e.g. OssProvider in studio-web). CoreApp mounts UserProvider internally via
+// dependencies.user — prefer that path for new integrations.
+export { UserProvider } from '#core/providers/user-provider/user-provider';
 export { UserRole } from '#core/providers/user-provider/types';


### PR DESCRIPTION
## Summary

PR #1504 moved `UserProvider` into `CoreApp`'s internal provider tree but removed the standalone re-export. Consumers that build their own provider tree need the export during the migration period — this restores it with a comment directing new integrations to use `CoreApp`'s `dependencies.user` instead.

## Test plan

- No runtime behavior change — the component was already exported before #1504

🤖 Generated with [Claude Code](https://claude.com/claude-code)