### PR TITLE
refactor(core): split public API from primitives entrypoint

### DIFF
--- a/javascript/packages/core/index.tsx
+++ b/javascript/packages/core/index.tsx
@@ -52,99 +52,16 @@ export function CoreApp({ dependencies }: Props) {
   );
 }
 
+// ─── Public API ───────────────────────────────────────────────────────────────
+// Feature-level components, configuration types, and hooks that form the stable
+// public contract of @michelangelo-ai/core.
+
+// Query and Mutation
 export { useStudioQuery } from '#core/hooks/use-studio-query';
 export { useStudioMutation } from '#core/hooks/use-studio-mutation/use-studio-mutation';
 export type { UseStudioMutationResult } from '#core/hooks/use-studio-mutation/types';
 export type { MutationConfig, MutationOptions } from '#core/types/query-types';
 export { ServiceProvider } from '#core/providers/service-provider/service-provider';
-
-export { useCellToString } from '#core/components/cell/use-cell-to-string';
-export { cellTooltipHoc } from '#core/components/cell/components/tooltip/cell-tooltip-hoc';
-export { DefaultCellRenderer } from '#core/components/cell/renderers/default-cell-renderer';
-export { useGetCellRenderer } from '#core/components/cell/use-get-cell-renderer';
-export * from '#core/components/cell/types';
-export { CellType } from '#core/components/cell/constants';
-export { useCellStyles } from '#core/components/cell/hooks';
-
-export { BooleanCell } from '#core/components/cell/renderers/boolean/boolean-cell';
-export { DateCell } from '#core/components/cell/renderers/date/date-cell';
-export { DescriptionCell } from '#core/components/cell/renderers/description/description-cell';
-export { DescriptionHierarchy } from '#core/components/cell/renderers/description/constants';
-export { LinkCell } from '#core/components/cell/renderers/link/link-cell';
-export { MultiCell } from '#core/components/cell/renderers/multi/multi-cell';
-export { StateCell } from '#core/components/cell/renderers/state/state-cell';
-export { TagCell } from '#core/components/cell/renderers/tag/tag-cell';
-export { TextCell } from '#core/components/cell/renderers/text/text-cell';
-export { TypeCell } from '#core/components/cell/renderers/type/type-cell';
-
-export { Box } from '#core/components/box/box';
-export * from '#core/components/box/styled-components';
-export { DateTime } from '#core/components/date-time/date-time';
-export { DescriptionText } from '#core/components/description-text';
-export { HelpTooltip } from '#core/components/help-tooltip';
-export { Link } from '#core/components/link/link';
-export * from '#core/components/link/styled-components';
-export { Markdown } from '#core/components/markdown/markdown';
-export { Row } from '#core/components/row/row';
-export type { RowCell, RowProps } from '#core/components/row/types';
-export { Tag } from '#core/components/tag/tag';
-export * from '#core/components/tag/constants';
-export type { TagColor, TagHierarchy, TagBehavior, TagSize } from '#core/components/tag/types';
-export { TruncatedText } from '#core/components/truncated-text/truncated-text';
-export { Banner } from '#core/components/banner/banner';
-
-export { Icon } from '#core/components/icon/icon';
-export { IconKind } from '#core/components/icon/types';
-export { IconProvider } from '#core/providers/icon-provider/icon-provider';
-export * from '#core/providers/icon-provider/types';
-
-export { ThemeProvider };
-
-export { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
-export * from '#core/hooks/routing/use-studio-params/types';
-export { useUrlQueryString } from '#core/hooks/routing/use-url-query-string';
-
-export * from '#core/utils/object-utils';
-export * from '#core/utils/string-utils';
-export * from '#core/utils/time-utils';
-export { TimeZone } from '#core/types/time-types';
-
-export * from '#core/types/common/studio-types';
-export * from '#core/types/common/view-types';
-
-// Cell Provider
-export { CellProvider } from '#core/providers/cell-provider/cell-provider';
-export { useCellProvider } from '#core/providers/cell-provider/use-cell-provider';
-export type { CellContextType } from '#core/providers/cell-provider/types';
-
-// Error Provider
-export { ApplicationError } from '#core/types/error-types';
-export type { ErrorNormalizer } from '#core/types/error-types';
-export { ErrorProvider } from '#core/providers/error-provider/error-provider';
-export { useErrorNormalizer } from '#core/providers/error-provider/use-error-normalizer';
-export { GrpcStatusCode } from '#core/constants/grpc-status-codes';
-
-// Interpolation
-export { interpolate } from '#core/interpolation/interpolate';
-export { Interpolation } from '#core/interpolation/base';
-export { StringInterpolation } from '#core/interpolation/string-interpolation';
-export { FunctionInterpolation } from '#core/interpolation/function-interpolation';
-export { useInterpolationResolver } from '#core/interpolation/use-interpolation-resolver';
-export type {
-  InterpolationContext,
-  InterpolationContextExtensions,
-  Interpolatable,
-  UserDataSources,
-} from '#core/interpolation/types';
-export { isInterpolation } from '#core/interpolation/utils/is-interpolation';
-export { hasInterpolationProperty } from '#core/interpolation/utils/has-interpolation-property';
-export { clearUnresolvedInterpolations } from '#core/interpolation/utils/clear-unresolved-interpolations';
-
-// Interpolation Providers
-export { InterpolationProvider } from '#core/providers/interpolation-provider/interpolation-provider';
-export { RepeatedLayoutProvider } from '#core/providers/repeated-layout-provider/repeated-layout-provider';
-export { useRepeatedLayoutContext } from '#core/providers/repeated-layout-provider/use-repeated-layout-context';
-export type { RepeatedLayoutState } from '#core/providers/repeated-layout-provider/types';
 
 // Table
 export { Table } from '#core/components/table/table';
@@ -153,19 +70,6 @@ export { useTableSelectionContext } from '#core/components/table/plugins/selecti
 export { FilterMode } from '#core/components/table/components/filter/types';
 export type { ColumnConfig } from '#core/components/table/types/column-types';
 export type { TableProps } from '#core/components/table/types/table-types';
-
-// Execution View
-export { Execution } from '#core/components/views/execution/execution';
-export type {
-  ExecutionDetailViewSchema,
-  ExecutionOverrides,
-  Task,
-  TaskState,
-} from '#core/components/views/execution/types';
-export type { TaskListRendererProps } from '#core/components/views/execution/components/types';
-export { TASK_STATE } from '#core/components/views/execution/constants';
-export { TaskListRenderer } from '#core/components/views/execution/components/task-list-renderer';
-export { TaskStepCard } from '#core/components/views/execution/components/task-step-card/task-step-card';
 
 // Form
 export { Form } from '#core/components/form/form';
@@ -201,9 +105,6 @@ export { FormStep } from '#core/components/form/layout/form-step/form-step';
 export { ArrayFormRow } from '#core/components/form/layout/array-form-row/array-form-row';
 export { ArrayFormGroup } from '#core/components/form/layout/array-form-group/array-form-group';
 
-// Actions
-export * from '#core/components/actions/types';
-
 // Detail View
 export { DetailView } from '#core/components/views/detail-view/detail-view';
 export { DetailViewPages } from '#core/components/views/detail-view/components/detail-view-pages/detail-view-pages';
@@ -213,9 +114,121 @@ export type {
   DetailViewPagesProps,
 } from '#core/components/views/detail-view/types/detail-view-component-types';
 
+// Execution View
+export { Execution } from '#core/components/views/execution/execution';
+export type {
+  ExecutionDetailViewSchema,
+  ExecutionOverrides,
+  Task,
+  TaskState,
+} from '#core/components/views/execution/types';
+export type { TaskListRendererProps } from '#core/components/views/execution/components/types';
+export { TASK_STATE } from '#core/components/views/execution/constants';
+export { TaskListRenderer } from '#core/components/views/execution/components/task-list-renderer';
+export { TaskStepCard } from '#core/components/views/execution/components/task-step-card/task-step-card';
+
+// Actions
+export * from '#core/components/actions/types';
+
+// Interpolation
+export { interpolate } from '#core/interpolation/interpolate';
+export { Interpolation } from '#core/interpolation/base';
+export { StringInterpolation } from '#core/interpolation/string-interpolation';
+export { FunctionInterpolation } from '#core/interpolation/function-interpolation';
+export { useInterpolationResolver } from '#core/interpolation/use-interpolation-resolver';
+export type {
+  InterpolationContext,
+  InterpolationContextExtensions,
+  Interpolatable,
+  UserDataSources,
+} from '#core/interpolation/types';
+export { isInterpolation } from '#core/interpolation/utils/is-interpolation';
+export { hasInterpolationProperty } from '#core/interpolation/utils/has-interpolation-property';
+export { clearUnresolvedInterpolations } from '#core/interpolation/utils/clear-unresolved-interpolations';
+export { InterpolationProvider } from '#core/providers/interpolation-provider/interpolation-provider';
+export { RepeatedLayoutProvider } from '#core/providers/repeated-layout-provider/repeated-layout-provider';
+export { useRepeatedLayoutContext } from '#core/providers/repeated-layout-provider/use-repeated-layout-context';
+export type { RepeatedLayoutState } from '#core/providers/repeated-layout-provider/types';
+
+// Cell Renderers
+export { useCellToString } from '#core/components/cell/use-cell-to-string';
+export { cellTooltipHoc } from '#core/components/cell/components/tooltip/cell-tooltip-hoc';
+export { DefaultCellRenderer } from '#core/components/cell/renderers/default-cell-renderer';
+export { useGetCellRenderer } from '#core/components/cell/use-get-cell-renderer';
+export * from '#core/components/cell/types';
+export { CellType } from '#core/components/cell/constants';
+export { useCellStyles } from '#core/components/cell/hooks';
+export { BooleanCell } from '#core/components/cell/renderers/boolean/boolean-cell';
+export { DateCell } from '#core/components/cell/renderers/date/date-cell';
+export { DescriptionCell } from '#core/components/cell/renderers/description/description-cell';
+export { DescriptionHierarchy } from '#core/components/cell/renderers/description/constants';
+export { LinkCell } from '#core/components/cell/renderers/link/link-cell';
+export { MultiCell } from '#core/components/cell/renderers/multi/multi-cell';
+export { StateCell } from '#core/components/cell/renderers/state/state-cell';
+export { TagCell } from '#core/components/cell/renderers/tag/tag-cell';
+export { TextCell } from '#core/components/cell/renderers/text/text-cell';
+export { TypeCell } from '#core/components/cell/renderers/type/type-cell';
+
+// Error Handling
+export { ApplicationError } from '#core/types/error-types';
+export type { ErrorNormalizer } from '#core/types/error-types';
+export { useErrorNormalizer } from '#core/providers/error-provider/use-error-normalizer';
+export { GrpcStatusCode } from '#core/constants/grpc-status-codes';
+
+// Routing
+export { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
+export * from '#core/hooks/routing/use-studio-params/types';
+export { useUrlQueryString } from '#core/hooks/routing/use-url-query-string';
+
+// Utilities
+export * from '#core/utils/object-utils';
+export * from '#core/utils/string-utils';
+export * from '#core/utils/time-utils';
+export { TimeZone } from '#core/types/time-types';
+
+// Domain Types
+export * from '#core/types/common/studio-types';
+export * from '#core/types/common/view-types';
+
 // User Provider
 // UserProvider is re-exported for consumers that build their own provider tree.
 // CoreApp mounts UserProvider internally via dependencies.user — prefer that
 // path for new integrations.
 export { UserProvider } from '#core/providers/user-provider/user-provider';
+
+// User Types
 export { UserRole } from '#core/providers/user-provider/types';
+
+// Icon Provider
+export { Icon } from '#core/components/icon/icon';
+export { IconKind } from '#core/components/icon/types';
+export { IconProvider } from '#core/providers/icon-provider/icon-provider';
+export * from '#core/providers/icon-provider/types';
+
+// Theme
+export { ThemeProvider };
+
+// Cell Provider
+export { CellProvider } from '#core/providers/cell-provider/cell-provider';
+export { useCellProvider } from '#core/providers/cell-provider/use-cell-provider';
+export type { CellContextType } from '#core/providers/cell-provider/types';
+
+// Error Provider
+export { ErrorProvider } from '#core/providers/error-provider/error-provider';
+
+// Primitives
+export { Box } from '#core/components/box/box';
+export * from '#core/components/box/styled-components';
+export { DateTime } from '#core/components/date-time/date-time';
+export { DescriptionText } from '#core/components/description-text';
+export { HelpTooltip } from '#core/components/help-tooltip';
+export { Link } from '#core/components/link/link';
+export * from '#core/components/link/styled-components';
+export { Markdown } from '#core/components/markdown/markdown';
+export { Row } from '#core/components/row/row';
+export type { RowCell, RowProps } from '#core/components/row/types';
+export { Tag } from '#core/components/tag/tag';
+export * from '#core/components/tag/constants';
+export type { TagColor, TagHierarchy, TagBehavior, TagSize } from '#core/components/tag/types';
+export { TruncatedText } from '#core/components/truncated-text/truncated-text';
+export { Banner } from '#core/components/banner/banner';

--- a/javascript/packages/core/index.tsx
+++ b/javascript/packages/core/index.tsx
@@ -52,16 +52,69 @@ export function CoreApp({ dependencies }: Props) {
   );
 }
 
-// ─── Public API ───────────────────────────────────────────────────────────────
-// Feature-level components, configuration types, and hooks that form the stable
-// public contract of @michelangelo-ai/core.
-
-// Query and Mutation
 export { useStudioQuery } from '#core/hooks/use-studio-query';
 export { useStudioMutation } from '#core/hooks/use-studio-mutation/use-studio-mutation';
 export type { UseStudioMutationResult } from '#core/hooks/use-studio-mutation/types';
 export type { MutationConfig, MutationOptions } from '#core/types/query-types';
-export { ServiceProvider } from '#core/providers/service-provider/service-provider';
+
+export { useCellToString } from '#core/components/cell/use-cell-to-string';
+export { cellTooltipHoc } from '#core/components/cell/components/tooltip/cell-tooltip-hoc';
+export { DefaultCellRenderer } from '#core/components/cell/renderers/default-cell-renderer';
+export { useGetCellRenderer } from '#core/components/cell/use-get-cell-renderer';
+export * from '#core/components/cell/types';
+export { CellType } from '#core/components/cell/constants';
+export { useCellStyles } from '#core/components/cell/hooks';
+
+export { BooleanCell } from '#core/components/cell/renderers/boolean/boolean-cell';
+export { DateCell } from '#core/components/cell/renderers/date/date-cell';
+export { DescriptionCell } from '#core/components/cell/renderers/description/description-cell';
+export { DescriptionHierarchy } from '#core/components/cell/renderers/description/constants';
+export { LinkCell } from '#core/components/cell/renderers/link/link-cell';
+export { MultiCell } from '#core/components/cell/renderers/multi/multi-cell';
+export { StateCell } from '#core/components/cell/renderers/state/state-cell';
+export { TagCell } from '#core/components/cell/renderers/tag/tag-cell';
+export { TextCell } from '#core/components/cell/renderers/text/text-cell';
+export { TypeCell } from '#core/components/cell/renderers/type/type-cell';
+
+export { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
+export * from '#core/hooks/routing/use-studio-params/types';
+export { useUrlQueryString } from '#core/hooks/routing/use-url-query-string';
+
+export * from '#core/utils/object-utils';
+export * from '#core/utils/string-utils';
+export * from '#core/utils/time-utils';
+export { TimeZone } from '#core/types/time-types';
+
+export * from '#core/types/common/studio-types';
+export * from '#core/types/common/view-types';
+
+// Error Provider
+export { ApplicationError } from '#core/types/error-types';
+export type { ErrorNormalizer } from '#core/types/error-types';
+export { useErrorNormalizer } from '#core/providers/error-provider/use-error-normalizer';
+export { GrpcStatusCode } from '#core/constants/grpc-status-codes';
+
+// Interpolation
+export { interpolate } from '#core/interpolation/interpolate';
+export { Interpolation } from '#core/interpolation/base';
+export { StringInterpolation } from '#core/interpolation/string-interpolation';
+export { FunctionInterpolation } from '#core/interpolation/function-interpolation';
+export { useInterpolationResolver } from '#core/interpolation/use-interpolation-resolver';
+export type {
+  InterpolationContext,
+  InterpolationContextExtensions,
+  Interpolatable,
+  UserDataSources,
+} from '#core/interpolation/types';
+export { isInterpolation } from '#core/interpolation/utils/is-interpolation';
+export { hasInterpolationProperty } from '#core/interpolation/utils/has-interpolation-property';
+export { clearUnresolvedInterpolations } from '#core/interpolation/utils/clear-unresolved-interpolations';
+
+// Interpolation Providers
+export { InterpolationProvider } from '#core/providers/interpolation-provider/interpolation-provider';
+export { RepeatedLayoutProvider } from '#core/providers/repeated-layout-provider/repeated-layout-provider';
+export { useRepeatedLayoutContext } from '#core/providers/repeated-layout-provider/use-repeated-layout-context';
+export type { RepeatedLayoutState } from '#core/providers/repeated-layout-provider/types';
 
 // Table
 export { Table } from '#core/components/table/table';
@@ -70,6 +123,19 @@ export { useTableSelectionContext } from '#core/components/table/plugins/selecti
 export { FilterMode } from '#core/components/table/components/filter/types';
 export type { ColumnConfig } from '#core/components/table/types/column-types';
 export type { TableProps } from '#core/components/table/types/table-types';
+
+// Execution View
+export { Execution } from '#core/components/views/execution/execution';
+export type {
+  ExecutionDetailViewSchema,
+  ExecutionOverrides,
+  Task,
+  TaskState,
+} from '#core/components/views/execution/types';
+export type { TaskListRendererProps } from '#core/components/views/execution/components/types';
+export { TASK_STATE } from '#core/components/views/execution/constants';
+export { TaskListRenderer } from '#core/components/views/execution/components/task-list-renderer';
+export { TaskStepCard } from '#core/components/views/execution/components/task-step-card/task-step-card';
 
 // Form
 export { Form } from '#core/components/form/form';
@@ -105,6 +171,9 @@ export { FormStep } from '#core/components/form/layout/form-step/form-step';
 export { ArrayFormRow } from '#core/components/form/layout/array-form-row/array-form-row';
 export { ArrayFormGroup } from '#core/components/form/layout/array-form-group/array-form-group';
 
+// Actions
+export * from '#core/components/actions/types';
+
 // Detail View
 export { DetailView } from '#core/components/views/detail-view/detail-view';
 export { DetailViewPages } from '#core/components/views/detail-view/components/detail-view-pages/detail-view-pages';
@@ -114,121 +183,5 @@ export type {
   DetailViewPagesProps,
 } from '#core/components/views/detail-view/types/detail-view-component-types';
 
-// Execution View
-export { Execution } from '#core/components/views/execution/execution';
-export type {
-  ExecutionDetailViewSchema,
-  ExecutionOverrides,
-  Task,
-  TaskState,
-} from '#core/components/views/execution/types';
-export type { TaskListRendererProps } from '#core/components/views/execution/components/types';
-export { TASK_STATE } from '#core/components/views/execution/constants';
-export { TaskListRenderer } from '#core/components/views/execution/components/task-list-renderer';
-export { TaskStepCard } from '#core/components/views/execution/components/task-step-card/task-step-card';
-
-// Actions
-export * from '#core/components/actions/types';
-
-// Interpolation
-export { interpolate } from '#core/interpolation/interpolate';
-export { Interpolation } from '#core/interpolation/base';
-export { StringInterpolation } from '#core/interpolation/string-interpolation';
-export { FunctionInterpolation } from '#core/interpolation/function-interpolation';
-export { useInterpolationResolver } from '#core/interpolation/use-interpolation-resolver';
-export type {
-  InterpolationContext,
-  InterpolationContextExtensions,
-  Interpolatable,
-  UserDataSources,
-} from '#core/interpolation/types';
-export { isInterpolation } from '#core/interpolation/utils/is-interpolation';
-export { hasInterpolationProperty } from '#core/interpolation/utils/has-interpolation-property';
-export { clearUnresolvedInterpolations } from '#core/interpolation/utils/clear-unresolved-interpolations';
-export { InterpolationProvider } from '#core/providers/interpolation-provider/interpolation-provider';
-export { RepeatedLayoutProvider } from '#core/providers/repeated-layout-provider/repeated-layout-provider';
-export { useRepeatedLayoutContext } from '#core/providers/repeated-layout-provider/use-repeated-layout-context';
-export type { RepeatedLayoutState } from '#core/providers/repeated-layout-provider/types';
-
-// Cell Renderers
-export { useCellToString } from '#core/components/cell/use-cell-to-string';
-export { cellTooltipHoc } from '#core/components/cell/components/tooltip/cell-tooltip-hoc';
-export { DefaultCellRenderer } from '#core/components/cell/renderers/default-cell-renderer';
-export { useGetCellRenderer } from '#core/components/cell/use-get-cell-renderer';
-export * from '#core/components/cell/types';
-export { CellType } from '#core/components/cell/constants';
-export { useCellStyles } from '#core/components/cell/hooks';
-export { BooleanCell } from '#core/components/cell/renderers/boolean/boolean-cell';
-export { DateCell } from '#core/components/cell/renderers/date/date-cell';
-export { DescriptionCell } from '#core/components/cell/renderers/description/description-cell';
-export { DescriptionHierarchy } from '#core/components/cell/renderers/description/constants';
-export { LinkCell } from '#core/components/cell/renderers/link/link-cell';
-export { MultiCell } from '#core/components/cell/renderers/multi/multi-cell';
-export { StateCell } from '#core/components/cell/renderers/state/state-cell';
-export { TagCell } from '#core/components/cell/renderers/tag/tag-cell';
-export { TextCell } from '#core/components/cell/renderers/text/text-cell';
-export { TypeCell } from '#core/components/cell/renderers/type/type-cell';
-
-// Error Handling
-export { ApplicationError } from '#core/types/error-types';
-export type { ErrorNormalizer } from '#core/types/error-types';
-export { useErrorNormalizer } from '#core/providers/error-provider/use-error-normalizer';
-export { GrpcStatusCode } from '#core/constants/grpc-status-codes';
-
-// Routing
-export { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
-export * from '#core/hooks/routing/use-studio-params/types';
-export { useUrlQueryString } from '#core/hooks/routing/use-url-query-string';
-
-// Utilities
-export * from '#core/utils/object-utils';
-export * from '#core/utils/string-utils';
-export * from '#core/utils/time-utils';
-export { TimeZone } from '#core/types/time-types';
-
-// Domain Types
-export * from '#core/types/common/studio-types';
-export * from '#core/types/common/view-types';
-
-// User Provider
-// UserProvider is re-exported for consumers that build their own provider tree.
-// CoreApp mounts UserProvider internally via dependencies.user — prefer that
-// path for new integrations.
-export { UserProvider } from '#core/providers/user-provider/user-provider';
-
 // User Types
 export { UserRole } from '#core/providers/user-provider/types';
-
-// Icon Provider
-export { Icon } from '#core/components/icon/icon';
-export { IconKind } from '#core/components/icon/types';
-export { IconProvider } from '#core/providers/icon-provider/icon-provider';
-export * from '#core/providers/icon-provider/types';
-
-// Theme
-export { ThemeProvider };
-
-// Cell Provider
-export { CellProvider } from '#core/providers/cell-provider/cell-provider';
-export { useCellProvider } from '#core/providers/cell-provider/use-cell-provider';
-export type { CellContextType } from '#core/providers/cell-provider/types';
-
-// Error Provider
-export { ErrorProvider } from '#core/providers/error-provider/error-provider';
-
-// Primitives
-export { Box } from '#core/components/box/box';
-export * from '#core/components/box/styled-components';
-export { DateTime } from '#core/components/date-time/date-time';
-export { DescriptionText } from '#core/components/description-text';
-export { HelpTooltip } from '#core/components/help-tooltip';
-export { Link } from '#core/components/link/link';
-export * from '#core/components/link/styled-components';
-export { Markdown } from '#core/components/markdown/markdown';
-export { Row } from '#core/components/row/row';
-export type { RowCell, RowProps } from '#core/components/row/types';
-export { Tag } from '#core/components/tag/tag';
-export * from '#core/components/tag/constants';
-export type { TagColor, TagHierarchy, TagBehavior, TagSize } from '#core/components/tag/types';
-export { TruncatedText } from '#core/components/truncated-text/truncated-text';
-export { Banner } from '#core/components/banner/banner';

--- a/javascript/packages/core/package.json
+++ b/javascript/packages/core/package.json
@@ -72,6 +72,13 @@
       "import": "./dist/michelangelo-core.js",
       "require": "./dist/michelangelo-core.cjs",
       "default": "./dist/michelangelo-core.js"
+    },
+    "./primitives": {
+      "types": "./dist/primitives.d.ts",
+      "workspace": "./primitives.tsx",
+      "import": "./dist/primitives.js",
+      "require": "./dist/primitives.cjs",
+      "default": "./dist/primitives.js"
     }
   },
   "imports": {

--- a/javascript/packages/core/primitives.tsx
+++ b/javascript/packages/core/primitives.tsx
@@ -1,0 +1,40 @@
+// Lower-level building blocks for consumers that need to compose their own app
+// shell or render components outside of CoreApp's config-driven views.
+//
+// The main entrypoint (`@michelangelo-ai/core`) exposes the public API: CoreApp,
+// Table, Form, DetailView, Execution, and their configuration types. This
+// entrypoint provides the providers and components underneath — for consumers
+// that need direct access to the pieces CoreApp assembles internally.
+//
+// New integrations should prefer CoreApp with `dependencies` over mounting
+// these providers directly.
+
+// Providers
+export { ServiceProvider } from '#core/providers/service-provider/service-provider';
+export { ErrorProvider } from '#core/providers/error-provider/error-provider';
+export { ThemeProvider } from '#core/themes/theme-provider';
+export { IconProvider } from '#core/providers/icon-provider/icon-provider';
+export { IconKind } from '#core/components/icon/types';
+export * from '#core/providers/icon-provider/types';
+export { UserProvider } from '#core/providers/user-provider/user-provider';
+export { CellProvider } from '#core/providers/cell-provider/cell-provider';
+export { useCellProvider } from '#core/providers/cell-provider/use-cell-provider';
+export type { CellContextType } from '#core/providers/cell-provider/types';
+
+// Components
+export { Box } from '#core/components/box/box';
+export * from '#core/components/box/styled-components';
+export { DateTime } from '#core/components/date-time/date-time';
+export { DescriptionText } from '#core/components/description-text';
+export { HelpTooltip } from '#core/components/help-tooltip';
+export { Link } from '#core/components/link/link';
+export * from '#core/components/link/styled-components';
+export { Markdown } from '#core/components/markdown/markdown';
+export { Row } from '#core/components/row/row';
+export type { RowCell, RowProps } from '#core/components/row/types';
+export { Tag } from '#core/components/tag/tag';
+export * from '#core/components/tag/constants';
+export type { TagColor, TagHierarchy, TagBehavior, TagSize } from '#core/components/tag/types';
+export { TruncatedText } from '#core/components/truncated-text/truncated-text';
+export { Banner } from '#core/components/banner/banner';
+export { Icon } from '#core/components/icon/icon';

--- a/javascript/packages/core/vite.config.ts
+++ b/javascript/packages/core/vite.config.ts
@@ -5,10 +5,12 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   build: {
     lib: {
-      entry: path.resolve(__dirname, 'index.tsx'),
-      name: 'MichelangeloCore',
+      entry: {
+        'michelangelo-core': path.resolve(__dirname, 'index.tsx'),
+        primitives: path.resolve(__dirname, 'primitives.tsx'),
+      },
       formats: ['es', 'cjs'],
-      fileName: (format) => `michelangelo-core.${format === 'es' ? 'js' : 'cjs'}`,
+      fileName: (format, entryName) => `${entryName}.${format === 'es' ? 'js' : 'cjs'}`,
     },
     rollupOptions: {
       external: [


### PR DESCRIPTION
## Summary

The main entrypoint mixed feature-level components (Table, Form, DetailView) with lower-level building blocks (providers, Box, Link, Tag) that only matter to consumers composing their own app shell outside of CoreApp. This made it unclear which exports were part of the stable public contract.

Providers and primitive components now live under a dedicated `@michelangelo-ai/core/primitives` entrypoint. The main entrypoint keeps only the public API: CoreApp, the four view systems, their configuration types, interpolation, cell renderers, and utilities. The vite build produces both bundles; the `package.json` exports map enforces the boundary at the package level.

**This is a breaking change** — consumers importing providers or primitive components from the main entrypoint will need to update their imports to `@michelangelo-ai/core/primitives`.

## Test plan

- I verified the vite build produces both `michelangelo-core.{js,cjs}` and `primitives.{js,cjs}` with type declarations
- I compared the export sets before and after — no exports were dropped, only reorganized

🤖 Generated with [Claude Code](https://claude.com/claude-code)