### PR TITLE
docs: fix broken links flagged by doc quality scanner

### DIFF
--- a/docs/contributing/documentation-guide.md
+++ b/docs/contributing/documentation-guide.md
@@ -155,8 +155,8 @@ Reference co-located images:
 Use relative paths with `.md` extension for internal links:
 
 ```markdown
-[See the CLI guide](./cli.md)
-[Back to setup](../getting-started/sandbox-setup.md)
+[See the CI guide](./ci.md)
+[Back to getting started](../user-guides/getting-started/getting-started.md)
 ```
 
 - Always include the `.md` extension (Docusaurus converts them)

--- a/docs/operator-guides/api-framework.md
+++ b/docs/operator-guides/api-framework.md
@@ -6,13 +6,6 @@ The Michelangelo API Framework abstracts Kubernetes CRDs through a gRPC API serv
 
 **Prerequisites**: Familiarity with Kubernetes CRDs, gRPC, and the Michelangelo control plane (see [Platform Setup](setup/platform-setup.md)).
 
-<!--
-## Getting Started
-See the [Tutorial](docs/tutorial.md) for step-by-step instructions to
-start a local Michelangelo deployment and how to train and deploy an
-example ML model locally.
--->
-
 ## Architecture
 
 Michelangelo defines the APIs using Protobuf as the IDL and the


### PR DESCRIPTION
## Summary

Fixes 2 of the 9 broken links flagged in the cycle #2 doc quality scan.

| File | Fix |
|---|---|
| `docs/contributing/documentation-guide.md:158` | Link example updated from `./cli.md` (non-existent) to `./ci.md` + corrected getting-started path |
| `docs/operator-guides/api-framework.md:11` | Removed stale HTML comment referencing `docs/tutorial.md` (never written) |

## False positives in the scan

7 of the 9 flagged links are scanner false positives — they appear inside fenced code blocks or HTML comments, which Docusaurus does not validate at build time:

| Location | Reason it's a false positive |
|---|---|
| `documentation-guide.md:134,150` | Image syntax examples inside ` ```markdown ` code blocks |
| `ci.md:154` | Error message examples inside inline backtick code |
| `website/README.md:109,117` | Link syntax examples inside ` ```md ` code blocks |
| `website/blog/2026-05-20-open-source-launch.md:16` | `/docs/contributing` resolves to `docs/contributing/index.md` (valid) |

**Follow-up:** `scan_docs.py` should skip links found inside fenced code blocks (` ``` `) and HTML comments (`<!-- -->`). This will eliminate these false positives in future cycles.

## Test plan

- [x] `documentation-guide.md` renders correctly on GitHub
- [x] `api-framework.md` — stale comment removed, no visible change to rendered page
- [ ] Docusaurus build passes (`cd website && npm run build`)