### PR TITLE
mactl: print help panel on 'ma' / 'ma -h' with prog='ma'

### DIFF
--- a/python/michelangelo/cli/mactl/mactl.py
+++ b/python/michelangelo/cli/mactl/mactl.py
@@ -583,20 +583,44 @@ def discover_crds(channel: Channel) -> dict[str, CRD]:
 
 
 def pre_parse_args(crds: dict[str, CRD]) -> tuple[Namespace, list[str]]:
-    """Pre-parse to get namespace, entity, and remaining info."""
-    base_parser = ArgumentParser(description="MaCTL - Michelangelo CLI", add_help=False)
+    """Pre-parse to get namespace, entity, and remaining info.
+
+    Prints a help panel when the entity is omitted (`ma` / `ma -h`) instead of
+    erroring with an argparse "the following arguments are required: entity"
+    message. Program name is `ma` — matches the console-script entry point in
+    pyproject.toml.
+    """
+    base_parser = ArgumentParser(
+        prog="ma",
+        description="Ma command - Michelangelo CLI",
+        epilog='Use "ma <entity> --help" for more information about an entity.',
+    )
     base_parser.add_argument(
         "-vv",
         "--verbose",
         action="store_true",
         help="Increase verbosity level",
     )
-    entity_subparsers = base_parser.add_subparsers(dest="entity", required=True)
+    entity_subparsers = base_parser.add_subparsers(
+        dest="entity",
+        title="entities",
+        metavar="<entity>",
+    )
 
     for crd_name in crds:
-        entity_subparsers.add_parser(crd_name, add_help=False)
+        entity_subparsers.add_parser(
+            crd_name,
+            add_help=False,
+            help=f"Manage {crd_name} resources",
+        )
 
     namespace, remaining = base_parser.parse_known_args()
+    if namespace.entity is None:
+        # `ma` or `ma -h` — subparsers were optional so parse succeeded with
+        # entity=None. Print the top-level help panel and exit cleanly instead
+        # of falling through to code that assumes an entity is set.
+        base_parser.print_help()
+        sys.exit(0)
     _LOG.debug(
         "Parsed arguments -- namespace: %r / remaining: %r", namespace, remaining
     )
@@ -664,9 +688,7 @@ def main(channel: Channel, plugin_registry: dict[str, list[object]]):
         dir(crds[user_command_crd]),
     )
     func_generator = getattr(crds[user_command_crd], f"generate_{user_command_action}")
-    action_parser = ArgumentParser(
-        prog=f"mactl {user_command_crd} {user_command_action}"
-    )
+    action_parser = ArgumentParser(prog=f"ma {user_command_crd} {user_command_action}")
     func_generator(channel, action_parser)
 
     # Phase 4: Parse remaining arguments

--- a/python/michelangelo/cli/mactl/mactl_test.py
+++ b/python/michelangelo/cli/mactl/mactl_test.py
@@ -644,6 +644,53 @@ class PreParseArgsTest(TestCase):
         self.assertIn("-f", remaining)
         self.assertIn("config.yaml", remaining)
 
+    @patch("sys.argv", ["mactl"])
+    @patch("sys.stdout")
+    def test_pre_parse_args_no_entity_prints_help_and_exits(self, _mock_stdout):
+        """`ma` with no args prints help and exits 0 (not argparse error)."""
+        crds = {"pipeline": Mock(), "project": Mock()}
+        with self.assertRaises(SystemExit) as cm:
+            pre_parse_args(crds)
+        self.assertEqual(cm.exception.code, 0)
+
+    @patch("sys.argv", ["mactl", "-h"])
+    @patch("sys.stdout")
+    def test_pre_parse_args_short_help_flag_exits_zero(self, _mock_stdout):
+        """`ma -h` prints help and exits 0."""
+        crds = {"pipeline": Mock(), "project": Mock()}
+        with self.assertRaises(SystemExit) as cm:
+            pre_parse_args(crds)
+        self.assertEqual(cm.exception.code, 0)
+
+    @patch("sys.argv", ["mactl", "--help"])
+    @patch("sys.stdout")
+    def test_pre_parse_args_long_help_flag_exits_zero(self, _mock_stdout):
+        """`ma --help` prints help and exits 0."""
+        crds = {"pipeline": Mock(), "project": Mock()}
+        with self.assertRaises(SystemExit) as cm:
+            pre_parse_args(crds)
+        self.assertEqual(cm.exception.code, 0)
+
+    @patch("sys.argv", ["mactl", "unknown_entity"])
+    @patch("sys.stderr")
+    def test_pre_parse_args_unknown_entity_still_errors(self, _mock_stderr):
+        """Unknown entity name still triggers argparse's 'invalid choice' error."""
+        crds = {"pipeline": Mock(), "project": Mock()}
+        with self.assertRaises(SystemExit) as cm:
+            pre_parse_args(crds)
+        self.assertEqual(cm.exception.code, 2)
+
+    @patch("sys.argv", ["mactl"])
+    def test_pre_parse_args_prog_is_ma(self):
+        """Help output uses `ma` as the program name."""
+        crds = {"pipeline": Mock()}
+        with patch("sys.stdout") as mock_stdout, self.assertRaises(SystemExit):
+            pre_parse_args(crds)
+        written = "".join(
+            str(call.args[0]) for call in mock_stdout.write.call_args_list if call.args
+        )
+        self.assertIn("usage: ma", written)
+
 
 class HandleCrdActionHelpTest(TestCase):
     """Tests for handle_crd_action_help function."""
@@ -826,7 +873,7 @@ class MainFunctionTest(TestCase):
         )
 
         # Verify ArgumentParser was created and used
-        mock_arg_parser_class.assert_called_once_with(prog="mactl project create")
+        mock_arg_parser_class.assert_called_once_with(prog="ma project create")
         mock_crd.generate_create.assert_called_once_with(
             mock_channel, mock_parser_instance
         )


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

`pre_parse_args` in `python/michelangelo/cli/mactl/mactl.py` now prints the top-level help panel and exits 0 when the entity argument is omitted (`ma` alone or `ma -h`), instead of erroring with `error: the following arguments are required: entity` and exit 2. Program name is fixed to `ma`, matching the console-script entry point declared in `python/pyproject.toml`.

Specifically:
- Root `ArgumentParser` sets `prog="ma"`, `add_help=True` (default), and an epilog.
- Entity subparser drops `required=True` and adds `title="entities"` + `metavar="<entity>"`. When `namespace.entity is None`, `base_parser.print_help()` then `sys.exit(0)`.
- Each `add_parser(crd_name)` now passes `help=f"Manage {crd_name} resources"` so the entity table has descriptions instead of a bare column of names.
- The per-action `ArgumentParser` at `mactl.py:695` swaps its hardcoded `"mactl {crd} {action}"` prog for `"ma {crd} {action}"`.

Before:
```
$ ma
ma: error: the following arguments are required: entity
$ echo $?
2
```

After:
```
$ ma
usage: ma [-h] [-vv] <entity> ...

Ma command - Michelangelo CLI

options:
  -h, --help      show this help message and exit
  -vv, --verbose  Increase verbosity level

entities:
  <entity>
    pipeline      Manage pipeline resources
    project       Manage project resources
    ...

Use "ma <entity> --help" for more information about an entity.
$ echo $?
0
```

<!-- Tell your future self why have you made these changes -->
**Why?**

`ma` is the entry point users invoke; the current failure mode is a bare argparse error that also leaks the wrapping script's filename (e.g. `_env.py`) as the program name, which is unrecognizable to users. It leaves 60+ available entities undiscoverable -- no way to enumerate them via `--help`. This aligns the Python CLI with the shape of help output Go `mactl` prints.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Added 5 cases to `PreParseArgsTest` in `mactl_test.py` covering `ma`, `ma -h`, `ma --help`, `ma unknown_entity` (regression: still exit 2), and prog-name assertion. Full class:

```
$ python3 -m pytest python/michelangelo/cli/mactl/mactl_test.py::PreParseArgsTest -v
============================== 8 passed in 0.11s ===============================
```

Also exercised `pre_parse_args` end-to-end with mocked CRDs (5 scenarios) -- outputs match the "After" above verbatim.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

Existing user-facing paths (`ma <valid_entity> <action> ...`, `ma <invalid_entity>`, `ma pipeline apply -f x.yaml`, verbose flag) are unchanged. The only behavioral change is `ma` / `ma -h` no longer errors -- previously users hit an argparse error page; now they get a help panel. No RPC, no state, no config touched.

<!-- Does this PR introduce a breaking change? Check all that apply. -->
**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

`ma` and `ma -h` now print a help panel and exit 0 (previously exited with an argparse error).

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**

None -- behavior change is discoverable via `ma --help` itself.
