### PR TITLE
fix(ci): exclude release-promote's own jobs from its CI-green check

### DIFF
--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -62,7 +62,7 @@ jobs:
             echo "branch (or otherwise trigger CI) and re-run once checks are green."
             exit 1
           fi
-          STATES=$(gh api --paginate "repos/${{ github.repository }}/commits/$SHA/check-runs" --jq '.check_runs[] | select(.status != "completed" or (.conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral")) | .name')
+          STATES=$(gh api --paginate "repos/${{ github.repository }}/commits/$SHA/check-runs" --jq '.check_runs[] | select(.name != "promote" and .name != "publish-npm" and .name != "notify-on-failure") | select(.status != "completed" or (.conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral")) | .name')
           if [ -n "$STATES" ]; then
             echo "ERROR: the following checks are not green on ${{ steps.vars.outputs.branch }}@$SHA:"
             echo "$STATES"


### PR DESCRIPTION
## Summary

`release-promote.yml`'s "Validate CI is green on release branch" step queries `check-runs` on the commit being promoted to confirm CI is green before proceeding. But this workflow's own `promote` job is itself registered as a check-run on that same commit — and it's necessarily still `in_progress` (not `completed`) at the moment it runs the query, since it hasn't finished yet.

This means the validation step always found itself as a non-green check and failed unconditionally. Discovered live while promoting `release/v0.4` to `v0.4.0`: run failed immediately with `ERROR: the following checks are not green ... promote`, despite all 24 real CI checks on the commit being green. `release-promote.yml` has apparently never been able to succeed, on any branch, regardless of actual upstream CI status.

## Fix

Exclude this workflow's own job names (`promote`, `publish-npm`, `notify-on-failure`) from the check-runs query, so it only validates the external CI checks it's meant to gate on.

## Test plan

- [x] `bash scripts/validate_workflows.sh` — no new actionlint/shellcheck errors (pre-existing warnings only, unrelated to this change)
- [ ] Re-dispatch `release-promote.yml` against `release/v0.4` (has this same fix cherry-picked) and confirm the validate step passes when real CI is green