### PR TITLE
feat(ui): export useStudioMutation and MutationConfig from core

### DIFF
--- a/javascript/packages/core/index.tsx
+++ b/javascript/packages/core/index.tsx
@@ -53,6 +53,9 @@ export function CoreApp({ dependencies }: Props) {
 }
 
 export { useStudioQuery } from '#core/hooks/use-studio-query';
+export { useStudioMutation } from '#core/hooks/use-studio-mutation/use-studio-mutation';
+export type { UseStudioMutationResult } from '#core/hooks/use-studio-mutation/types';
+export type { MutationConfig, MutationOptions } from '#core/types/query-types';
 export { ServiceProvider } from '#core/providers/service-provider/service-provider';
 
 export { useCellToString } from '#core/components/cell/use-cell-to-string';


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**Summary**

Exports `useStudioMutation`, `UseStudioMutationResult`, `MutationConfig`, and `MutationOptions` from the core package entry point. This provides support to consumers building custom provider trees or mutation flows outside the core shell.

**How did you test it?**

- Verified the exports resolve correctly via `yarn build`
- Confirmed no circular dependency introduced (these types are leaf-level)

**Potential risks**

None

**Breaking Changes**

- [x] No breaking changes

**Release notes**

New public exports: `useStudioMutation`, `UseStudioMutationResult`, `MutationConfig`, `MutationOptions`.

**Documentation Changes**

None required — these follow the same pattern as the existing `useStudioQuery` export.