### PR TITLE
Quote templated image/secret-name values in core Deployment charts

### DIFF
--- a/helm/michelangelo/templates/core/apiserver-deployment.yaml
+++ b/helm/michelangelo/templates/core/apiserver-deployment.yaml
@@ -67,7 +67,7 @@ spec:
             - name: METADATA_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.metadataStorage.existingSecret | default (printf "%s-metadata-storage" (include "michelangelo.fullname" .)) }}
+                  name: {{ .Values.metadataStorage.existingSecret | default (printf "%s-metadata-storage" (include "michelangelo.fullname" .)) | quote }}
                   key: password
         - name: schema-init
           image: {{ if eq .Values.metadataStorage.driver "postgres" }}postgres:16{{ else }}mysql:8.0{{ end }}
@@ -100,7 +100,7 @@ spec:
             - name: METADATA_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.metadataStorage.existingSecret | default (printf "%s-metadata-storage" (include "michelangelo.fullname" .)) }}
+                  name: {{ .Values.metadataStorage.existingSecret | default (printf "%s-metadata-storage" (include "michelangelo.fullname" .)) | quote }}
                   key: password
           volumeMounts:
             - name: schema
@@ -108,7 +108,7 @@ spec:
               readOnly: true
       containers:
         - name: apiserver
-          image: {{ include "michelangelo.image" (dict "repository" .Values.images.apiserver.repository "tag" .Values.images.apiserver.tag "Chart" .Chart) }}
+          image: {{ include "michelangelo.image" (dict "repository" .Values.images.apiserver.repository "tag" .Values.images.apiserver.tag "Chart" .Chart) | quote }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           {{- with .Values.securityContext }}
           securityContext:
@@ -118,7 +118,7 @@ spec:
             - name: MYSQL_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.metadataStorage.existingSecret | default (printf "%s-metadata-storage" (include "michelangelo.fullname" .)) }}
+                  name: {{ .Values.metadataStorage.existingSecret | default (printf "%s-metadata-storage" (include "michelangelo.fullname" .)) | quote }}
                   key: password
           ports:
             - name: {{ if .Values.apiserver.tls.enabled }}grpcs{{ else }}grpc{{ end }}

--- a/helm/michelangelo/templates/core/controllermgr-deployment.yaml
+++ b/helm/michelangelo/templates/core/controllermgr-deployment.yaml
@@ -29,7 +29,7 @@ spec:
       {{- end }}
       containers:
         - name: app
-          image: {{ include "michelangelo.image" (dict "repository" .Values.images.controllermgr.repository "tag" .Values.images.controllermgr.tag "Chart" .Chart) }}
+          image: {{ include "michelangelo.image" (dict "repository" .Values.images.controllermgr.repository "tag" .Values.images.controllermgr.tag "Chart" .Chart) | quote }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           {{- with .Values.securityContext }}
           securityContext:
@@ -37,14 +37,14 @@ spec:
           {{- end }}
           envFrom:
             - secretRef:
-                name: {{ .Values.objectStorage.existingSecret | default (include "michelangelo.objectStorageSecretName" .) }}
+                name: {{ .Values.objectStorage.existingSecret | default (include "michelangelo.objectStorageSecretName" .) | quote }}
           env:
             - name: CONFIG_DIR
               value: /config
             - name: MYSQL_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.metadataStorage.existingSecret | default (printf "%s-metadata-storage" (include "michelangelo.fullname" .)) }}
+                  name: {{ .Values.metadataStorage.existingSecret | default (printf "%s-metadata-storage" (include "michelangelo.fullname" .)) | quote }}
                   key: password
           ports:
             - name: metrics

--- a/helm/michelangelo/templates/core/ui-deployment.yaml
+++ b/helm/michelangelo/templates/core/ui-deployment.yaml
@@ -27,7 +27,7 @@ spec:
       {{- end }}
       containers:
         - name: ui
-          image: {{ include "michelangelo.image" (dict "repository" .Values.images.ui.repository "tag" .Values.images.ui.tag "Chart" .Chart) }}
+          image: {{ include "michelangelo.image" (dict "repository" .Values.images.ui.repository "tag" .Values.images.ui.tag "Chart" .Chart) | quote }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           {{- with .Values.securityContext }}
           securityContext:

--- a/helm/michelangelo/templates/core/worker-deployment.yaml
+++ b/helm/michelangelo/templates/core/worker-deployment.yaml
@@ -27,7 +27,7 @@ spec:
       {{- end }}
       containers:
         - name: app
-          image: {{ include "michelangelo.image" (dict "repository" .Values.images.worker.repository "tag" .Values.images.worker.tag "Chart" .Chart) }}
+          image: {{ include "michelangelo.image" (dict "repository" .Values.images.worker.repository "tag" .Values.images.worker.tag "Chart" .Chart) | quote }}
           imagePullPolicy: {{ .Values.images.pullPolicy }}
           {{- with .Values.securityContext }}
           securityContext:
@@ -35,7 +35,7 @@ spec:
           {{- end }}
           envFrom:
             - secretRef:
-                name: {{ .Values.objectStorage.existingSecret | default (include "michelangelo.objectStorageSecretName" .) }}
+                name: {{ .Values.objectStorage.existingSecret | default (include "michelangelo.objectStorageSecretName" .) | quote }}
           volumeMounts:
             - name: worker-config
               mountPath: /config


### PR DESCRIPTION
## Summary
- The `Integration tests` workflow has been failing consistently since at least 2026-07-15 at the sandbox `helm upgrade` step: `YAML parse error on michelangelo/templates/core/apiserver-deployment.yaml: ... yaml: line 110: found character that cannot start any token` ([failing run](https://github.com/michelangelo-ai/michelangelo/actions/runs/29554947640/job/87805006641)).
- `apiserver/worker/ui/controllermgr-deployment.yaml` build their `image:` value via the `michelangelo.image` helper and their metadataStorage/objectStorage `secretKeyRef`/`secretRef` `name:` via a `default (printf ...)` chain — both emitted as bare, unquoted YAML scalars.
- `helm upgrade --reuse-values` on the persistent sandbox release merges old release values with the current ones; the CI logs show `coalesce.go:301: warning: destination for michelangelo.images.<x> is a table. Ignoring non-table value (...)` for all four images, confirming the stored release still carries values from an older (pre-`repository`/`tag` split) chart schema. An unquoted plain scalar built from these interpolations is not guaranteed to be YAML-safe.
- Fix: quote these four interpolated values, matching the `| quote` pattern already used a few lines above for the `METADATA_HOST`/`PORT`/`USER`/`DATABASE` env values in the same file.

## Test plan
- [x] `helm lint helm/michelangelo -f helm/michelangelo/values-k3d.yaml --set workflow.engine=cadence --set workflow.endpoint=michelangelo-cadence-frontend:7833 --set temporal.enabled=false --set cadence.enabled=true --set apiserver.metadataStorage.enable=true --set controllermgr.metadataStorage.enable=true --set controllermgr.jobs.k8sengine.mapper.logPersistence.enabled=false --set objectStorage.existingSecret=minio-credentials` — passes
- [x] `helm template` of the four modified files with the same overrides — all `image:`/secret `name:` values render as valid quoted scalars
- [ ] Re-run the `Integration tests` workflow against the sandbox to confirm the sync step no longer fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)