### PR TITLE
Add LiteLLM gateway Helm chart

### DIFF
--- a/.github/ISSUE_TEMPLATE/llm-gateway-chart-release.md
+++ b/.github/ISSUE_TEMPLATE/llm-gateway-chart-release.md
@@ -1,0 +1,27 @@
+---
+name: LLM gateway chart release
+about: Release the independently versioned LiteLLM gateway Helm chart
+title: 'Release LLM gateway chart vX.Y.Z'
+labels: ['release']
+assignees: ''
+---
+
+## Automated checks
+
+- [ ] The `llm-gateway-chart-release` environment exists and requires approval.
+- [ ] A tag ruleset restricts creation of `michelangelo-llm-gateway-v*` tags.
+- [ ] The version matches `helm/michelangelo-llm-gateway/Chart.yaml`.
+- [ ] `appVersion`, the LiteLLM image tag, and the image digest were reviewed together.
+- [ ] The LLM gateway chart validation workflow passed.
+- [ ] The release tag uses `michelangelo-llm-gateway-vX.Y.Z`.
+
+## Real-cluster evidence
+
+- Staging run:
+- Migration and rollback run:
+- Provider, metrics, and shutdown run:
+- Uninstall cleanup run:
+
+## Publication
+
+- [ ] The OCI artifact is publicly installable without registry credentials.

--- a/.github/scripts/validate-llm-gateway-chart.sh
+++ b/.github/scripts/validate-llm-gateway-chart.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHART_DIR="$ROOT_DIR/helm/michelangelo-llm-gateway"
+
+render() {
+  helm template gateway "$CHART_DIR" \
+    --namespace litellm \
+    --kube-version 1.27.0 \
+    "$@" \
+    >/dev/null
+}
+
+lint_profile() {
+  helm lint --strict "$CHART_DIR" "$@"
+}
+
+validate_profile() {
+  lint_profile "$@"
+  render "$@"
+}
+
+expect_failure() {
+  local name="$1"
+  local expected="$2"
+  local normalized_output
+  local output
+  shift 2
+
+  if output="$(helm template gateway "$CHART_DIR" "$@" 2>&1)"; then
+    printf 'Expected validation failure: %s\n' "$name" >&2
+    exit 1
+  fi
+  normalized_output="${output//\//.}"
+  if [[ "$normalized_output" != *"$expected"* ]]; then
+    printf 'Validation failed for the wrong reason: %s\n%s\n' "$name" "$output" >&2
+    exit 1
+  fi
+}
+
+assert_contains() {
+  local output="$1"
+  local expected="$2"
+
+  if [[ "$output" != *"$expected"* ]]; then
+    printf 'Expected rendered output to contain: %s\n' "$expected" >&2
+    exit 1
+  fi
+}
+
+validate_profile
+validate_profile -f "$CHART_DIR/examples/values-gcp.yaml"
+validate_profile \
+  --set migrationJob.hooks.helm.enabled=false \
+  --set migrationJob.hooks.argocd.enabled=true
+validate_profile \
+  --set config.create=false \
+  --set config.existingConfigMap=litellm-config \
+  --set migrationJob.enabled=false \
+  --set migrationJob.managedExternally=true \
+  --set migrationJob.hooks.helm.enabled=false
+validate_profile \
+  --set networkPolicy.enabled=true \
+  --set networkPolicy.migration.managedExternally=true \
+  --set serviceMonitor.enabled=true \
+  --set serviceMonitor.authorization.secretName=litellm-metrics \
+  --set ingress.enabled=true \
+  --set 'ingress.hosts[0].host=litellm.example.com' \
+  --set 'ingress.hosts[0].paths[0].path=/' \
+  --set 'ingress.hosts[0].paths[0].pathType=Prefix'
+validate_profile \
+  --set-string 'extraEnv[0].name=my.env-name' \
+  --set-string 'extraEnv[0].value=ok'
+
+private_registry_values=(
+  --set 'imagePullSecrets[0].name=registry-creds'
+  --set image.repository=registry.example.com/litellm
+  --set tests.image.repository=registry.example.com/curl
+  --set tests.image.tag=8.12.1
+)
+lint_profile "${private_registry_values[@]}"
+private_registry_output="$(helm template gateway "$CHART_DIR" \
+  --namespace litellm \
+  --kube-version 1.27.0 \
+  "${private_registry_values[@]}")"
+assert_contains "$private_registry_output" 'registry.example.com/litellm@sha256:'
+assert_contains "$private_registry_output" 'registry.example.com/curl@sha256:'
+image_pull_secret_count=0
+remaining_output="$private_registry_output"
+while [[ "$remaining_output" == *'- name: registry-creds'* ]]; do
+  remaining_output="${remaining_output#*'- name: registry-creds'}"
+  ((image_pull_secret_count += 1))
+done
+if [[ "$image_pull_secret_count" -ne 3 ]]; then
+  printf 'Expected imagePullSecrets on Deployment, migration Job, and Helm test Pod\n' >&2
+  exit 1
+fi
+
+test_digest="sha256:$(printf 'a%.0s' {1..64})"
+test_output="$(helm template gateway "$CHART_DIR" \
+  --show-only templates/tests/test-connection.yaml \
+  --set probes.liveness.path=/live \
+  --set probes.readiness.path=/ready \
+  --set-string tests.image.digest="$test_digest")"
+assert_contains "$test_output" "curlimages/curl@$test_digest"
+assert_contains "$test_output" '/ready'
+if [[ "$test_output" == *'/live'* ]]; then
+  printf 'Helm test must use the readiness probe path\n' >&2
+  exit 1
+fi
+
+expect_failure "config ownership" "config.existingConfigMap is required" \
+  --set config.create=false
+expect_failure "migration ownership" "exactly one of migrationJob.enabled" \
+  --set migrationJob.managedExternally=true
+expect_failure "migration hook ownership" "managed migrations require exactly one" \
+  --set migrationJob.hooks.argocd.enabled=true
+expect_failure "reserved migration hook annotation" "cannot override chart-owned hook annotation" \
+  --set-string 'migrationJob.annotations.helm\.sh/hook=post-install'
+expect_failure "migration NetworkPolicy prerequisite" "pre-existing externally managed NetworkPolicy" \
+  --set networkPolicy.enabled=true
+expect_failure "ServiceMonitor authentication" "authorization.secretName" \
+  --set serviceMonitor.enabled=true
+expect_failure "Ingress hosts" "ingress.hosts is required" \
+  --set ingress.enabled=true
+expect_failure "PDB availability" "set only one of podDisruptionBudget" \
+  --set podDisruptionBudget.minAvailable=1
+expect_failure "autoscaling bounds" "minReplicas cannot exceed" \
+  --set autoscaling.minReplicas=11
+expect_failure "plaintext sensitive environment variable" "must use valueFrom" \
+  --set 'extraEnv[0].name=API_TOKEN' \
+  --set 'extraEnv[0].value=secret'
+expect_failure "image digest" "image.digest" \
+  --set image.digest=sha256:bad
+expect_failure "test image digest" "tests.image.digest" \
+  --set-string tests.image.digest=sha256:bad
+expect_failure "service account token type" "automountServiceAccountToken" \
+  --set-string serviceAccount.automountServiceAccountToken=not-a-bool
+expect_failure "image pull secret type" "imagePullSecrets" \
+  --set-string 'imagePullSecrets[0]=registry-creds'
+expect_failure "unknown value" "unknownGatewayValue" \
+  --set unknownGatewayValue=true
+expect_failure "existing Secret name" "masterKey.existingSecret" \
+  --set masterKey.existingSecret=BAD_NAME
+expect_failure "existing Secret key" "masterKey.key" \
+  --set masterKey.key=BAD/KEY
+expect_failure "existing Secret traversal key" "masterKey.key" \
+  --set-string masterKey.key=.
+expect_failure "environment variable traversal prefix" "extraEnv" \
+  --set-string 'extraEnv[0].name=..BAD' \
+  --set-string 'extraEnv[0].value=ok'
+expect_failure "environment variable traversal name" "extraEnv" \
+  --set-string 'extraEnv[0].name=.' \
+  --set-string 'extraEnv[0].value=ok'
+expect_failure "migration ServiceAccount name" "migrationJob.serviceAccountName" \
+  --set migrationJob.serviceAccountName=BAD_NAME
+
+if [[ "${SKIP_PACKAGE:-false}" != "true" ]]; then
+  package_dir="$(mktemp -d)"
+  trap 'rm -rf "$package_dir"' EXIT
+  helm package "$CHART_DIR" --destination "$package_dir" >/dev/null
+fi
+
+printf 'Validated %s\n' "$CHART_DIR"

--- a/.github/workflows/api-surface-check.yml
+++ b/.github/workflows/api-surface-check.yml
@@ -243,10 +243,19 @@ jobs:
 
       - name: Diff top-level Helm values keys
         id: helm-diff
+        shell: bash
         run: |
-          base_keys=$(yq 'keys | .[]' base/helm/michelangelo/values.yaml 2>/dev/null | sort || true)
-          head_keys=$(yq 'keys | .[]' head/helm/michelangelo/values.yaml 2>/dev/null | sort || true)
-          removed=$(comm -23 <(echo "$base_keys") <(echo "$head_keys") || true)
+          removed=""
+          for values_file in \
+            helm/michelangelo/values.yaml \
+            helm/michelangelo-llm-gateway/values.yaml; do
+            base_keys=$(yq 'keys | .[]' "base/$values_file" 2>/dev/null | sort || true)
+            head_keys=$(yq 'keys | .[]' "head/$values_file" 2>/dev/null | sort || true)
+            file_removed=$(comm -23 <(echo "$base_keys") <(echo "$head_keys") || true)
+            if [ -n "$file_removed" ]; then
+              removed+="$values_file:"$'\n'"$file_removed"$'\n'
+            fi
+          done
           echo "HAS_REMOVED=$([ -n "$removed" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
           {
             echo "REMOVED_KEYS<<HELM_EOF"
@@ -281,7 +290,7 @@ jobs:
             const body = [
               '### Helm Values Key Diff (advisory)',
               '',
-              'The following top-level keys were removed or renamed in `helm/michelangelo/values.yaml`:',
+              'The following top-level Helm values keys were removed or renamed:',
               '',
               '```',
               removed,

--- a/.github/workflows/compat-matrix.yml
+++ b/.github/workflows/compat-matrix.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        helm-version: ['3.13.0', '3.14.0', '3.15.0']
+        helm-version: ['3.12.0', '3.13.0', '3.14.0', '3.15.0', '3.16.0', '3.17.0', '4.1.0']
 
     steps:
       - name: Checkout repository
@@ -94,6 +94,9 @@ jobs:
             --debug \
             > /dev/null
 
+      - name: Validate LLM gateway chart
+        run: bash .github/scripts/validate-llm-gateway-chart.sh
+
   summary:
     name: Compatibility Summary
     runs-on: ubuntu-latest
@@ -114,7 +117,7 @@ jobs:
             echo "|-----------|----------|--------|"
             echo "| Python | 3.9, 3.10, 3.11, 3.12 | ${PYTHON_RESULT} |"
             echo "| Node.js | 18, 20 | ${NODE_RESULT} |"
-            echo "| Helm | 3.13.0, 3.14.0, 3.15.0 | ${HELM_RESULT} |"
+            echo "| Helm | 3.12.0–3.17.0, 4.1.0 | ${HELM_RESULT} |"
           } >> "$GITHUB_STEP_SUMMARY"
 
   # ---------------------------------------------------------------------------

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -5,11 +5,17 @@ on:
   pull_request:
     paths:
       - 'helm/**'
+      - '.github/scripts/validate-llm-gateway-chart.sh'
+      - '.github/workflows/helm-lint.yaml'
+      - '.github/workflows/llm-gateway-chart-release.yml'
   push:
     branches:
       - main
     paths:
       - 'helm/**'
+      - '.github/scripts/validate-llm-gateway-chart.sh'
+      - '.github/workflows/helm-lint.yaml'
+      - '.github/workflows/llm-gateway-chart-release.yml'
 
 jobs:
   lint:
@@ -41,6 +47,9 @@ jobs:
 
       - name: Lint
         run: helm lint helm/michelangelo
+
+      - name: Validate LLM gateway chart
+        run: bash .github/scripts/validate-llm-gateway-chart.sh
 
       - name: Template — k3d profile (Cadence, all Ingress disabled)
         run: |

--- a/.github/workflows/llm-gateway-chart-release.yml
+++ b/.github/workflows/llm-gateway-chart-release.yml
@@ -1,0 +1,199 @@
+name: Publish LLM gateway chart
+
+on:
+  push:
+    tags:
+      - 'michelangelo-llm-gateway-v*'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: llm-gateway-chart-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CHART_DIR: helm/michelangelo-llm-gateway
+  CHART_NAME: michelangelo-llm-gateway
+  OCI_ROOT: oci://ghcr.io/michelangelo-ai/michelangelo/charts
+
+jobs:
+  validate:
+    if: github.repository == 'michelangelo-ai/michelangelo'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        helm-version: ['3.12.0', '3.17.0', '4.1.0']
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+        with:
+          version: ${{ matrix.helm-version }}
+
+      - name: Validate chart
+        run: bash .github/scripts/validate-llm-gateway-chart.sh
+
+  publish:
+    if: github.repository == 'michelangelo-ai/michelangelo'
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: llm-gateway-chart-release
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify release source
+        run: |
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" refs/remotes/origin/main; then
+            echo "Release tags must point to a commit on main."
+            exit 1
+          fi
+
+      - name: Set up Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+        with:
+          version: '3.17.0'
+
+      - name: Validate release metadata
+        id: metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          version="${GITHUB_REF_NAME#michelangelo-llm-gateway-v}"
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid chart release tag: $GITHUB_REF_NAME"
+            exit 1
+          fi
+
+          chart_version="$(awk '$1 == "version:" {gsub(/"/, "", $2); print $2; exit}' "$CHART_DIR/Chart.yaml")"
+          app_version="$(awk '$1 == "appVersion:" {gsub(/"/, "", $2); print $2; exit}' "$CHART_DIR/Chart.yaml")"
+          image_tag="$(awk '$1 == "tag:" {gsub(/"/, "", $2); print $2; exit}' "$CHART_DIR/values.yaml")"
+          image_digest="$(awk '$1 == "digest:" {gsub(/"/, "", $2); print $2; exit}' "$CHART_DIR/values.yaml")"
+
+          test "$version" = "$chart_version"
+          test "$app_version" = "$image_tag"
+          [[ "$image_digest" =~ ^sha256:[a-fA-F0-9]{64}$ ]]
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "app_version=$app_version" >> "$GITHUB_OUTPUT"
+
+      - name: Verify image manifests
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          verify_image() {
+            local repository="$1"
+            local tag="$2"
+            local expected_digest="$3"
+            local inspect_output
+            local actual_digest
+
+            inspect_output="$(docker buildx imagetools inspect "$repository:$tag")"
+            if [[ "$inspect_output" =~ Digest:[[:space:]]+(sha256:[a-fA-F0-9]{64}) ]]; then
+              actual_digest="${BASH_REMATCH[1]}"
+            else
+              echo "Could not resolve digest for $repository:$tag"
+              exit 1
+            fi
+            test "$actual_digest" = "$expected_digest"
+            [[ "$inspect_output" == *'linux/amd64'* ]]
+            [[ "$inspect_output" == *'linux/arm64'* ]]
+          }
+
+          main_repository="$(awk '$1 == "repository:" {print $2; exit}' "$CHART_DIR/values.yaml")"
+          main_tag="$(awk '$1 == "tag:" {print $2; exit}' "$CHART_DIR/values.yaml")"
+          main_digest="$(awk '$1 == "digest:" {print $2; exit}' "$CHART_DIR/values.yaml")"
+          test_repository="$(awk '$1 == "tests:" {found=1; next} found && $1 == "repository:" {print $2; exit}' "$CHART_DIR/values.yaml")"
+          test_tag="$(awk '$1 == "tests:" {found=1; next} found && $1 == "tag:" {print $2; exit}' "$CHART_DIR/values.yaml")"
+          test_digest="$(awk '$1 == "tests:" {found=1; next} found && $1 == "digest:" {print $2; exit}' "$CHART_DIR/values.yaml")"
+
+          verify_image "$main_repository" "$main_tag" "$main_digest"
+          verify_image "$test_repository" "$test_tag" "$test_digest"
+
+      - name: Log in to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+            helm registry login ghcr.io \
+              --username "${{ github.actor }}" \
+              --password-stdin
+
+      - name: Reject an existing version
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          repo="michelangelo-ai/michelangelo/charts/$CHART_NAME"
+          version="${{ steps.metadata.outputs.version }}"
+          registry_token="$(
+            curl --fail-with-body --silent --show-error \
+              --user "${GITHUB_ACTOR}:${GHCR_TOKEN}" \
+              --get 'https://ghcr.io/token' \
+              --data-urlencode 'service=ghcr.io' \
+              --data-urlencode "scope=repository:${repo}:pull" |
+              jq -er '.token'
+          )"
+          body="$(mktemp)"
+          trap 'rm -f "$body"' EXIT
+          status="$(
+            curl --silent --show-error \
+              --request HEAD \
+              --output "$body" \
+              --write-out '%{http_code}' \
+              --header "Authorization: Bearer ${registry_token}" \
+              --header 'Accept: application/vnd.oci.image.manifest.v1+json' \
+              "https://ghcr.io/v2/${repo}/manifests/${version}"
+          )"
+
+          case "$status" in
+            200)
+              echo "Chart version already exists; refusing to overwrite it." >&2
+              exit 1
+              ;;
+            404)
+              ;;
+            *)
+              cat "$body" >&2
+              echo "GHCR lookup failed with HTTP $status" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Package and verify
+        run: |
+          mkdir -p /tmp/helm-pkg
+          helm package "$CHART_DIR" --destination /tmp/helm-pkg
+
+          package="/tmp/helm-pkg/$CHART_NAME-${{ steps.metadata.outputs.version }}.tgz"
+          packaged_app_version="$(
+            helm show chart "$package" |
+              awk '$1 == "appVersion:" {gsub(/"/, "", $2); print $2; exit}'
+          )"
+          test "$packaged_app_version" = "${{ steps.metadata.outputs.app_version }}"
+
+      - name: Push
+        run: |
+          helm push \
+            "/tmp/helm-pkg/$CHART_NAME-${{ steps.metadata.outputs.version }}.tgz" \
+            "$OCI_ROOT"

--- a/docs/contributing/dev/yaml-configuration.md
+++ b/docs/contributing/dev/yaml-configuration.md
@@ -56,12 +56,15 @@ Kubernetes resource definitions (Deployments, Services, ConfigMaps) for local sa
 
 ## Helm Chart Values
 
-The Michelangelo Helm chart lives in `helm/michelangelo/`. Key files:
+Michelangelo's Helm charts live in `helm/michelangelo/` for the control plane and `helm/michelangelo-llm-gateway/` for the separate LiteLLM data plane. Key files:
 
 | File | Purpose |
 |------|---------|
-| `helm/michelangelo/values.yaml` | Production defaults |
+| `helm/michelangelo/values.yaml` | Control-plane production defaults |
 | `helm/michelangelo/values-k3d.yaml` | Local k3d overrides for development |
+| `helm/michelangelo-llm-gateway/values.yaml` | LLM gateway defaults |
+| `helm/michelangelo-llm-gateway/examples/values-gcp.yaml` | LLM gateway GCP example |
+| `helm/michelangelo-llm-gateway/README.md` | LLM gateway installation, security, and release guide |
 
 See the [Platform Setup guide](../../operator-guides/setup/platform-setup.md) for Helm configuration details.
 

--- a/docs/operator-guides/index.md
+++ b/docs/operator-guides/index.md
@@ -16,6 +16,7 @@ For a fresh deployment, follow this recommended reading order:
 | Guide | Description |
 |-------|-------------|
 | [Helm Chart](helm-chart.md) | Install the Michelangelo control plane with Helm — chart layout, values reference, and migration phases |
+| [LLM Gateway Helm Chart](https://github.com/michelangelo-ai/michelangelo/tree/main/helm/michelangelo-llm-gateway) | Install LiteLLM as a separately released Michelangelo gateway data plane |
 | [Platform Setup](setup/platform-setup.md) | ConfigMaps and key fields for API server, controller manager, worker, and UI/Envoy |
 | [Network & Ingress](setup/network.md) | Envoy proxy, Ingress setup, TLS with cert-manager, and multi-cluster connectivity |
 | [Authentication](setup/authentication.md) | OIDC identity provider setup, RBAC, session configuration, multi-tenant isolation |

--- a/helm/michelangelo-llm-gateway/.helmignore
+++ b/helm/michelangelo-llm-gateway/.helmignore
@@ -1,0 +1,8 @@
+.DS_Store
+.git/
+.github/
+.idea/
+.vscode/
+*.swp
+*.tmp
+*.tgz

--- a/helm/michelangelo-llm-gateway/Chart.yaml
+++ b/helm/michelangelo-llm-gateway/Chart.yaml
@@ -1,0 +1,27 @@
+apiVersion: v2
+name: michelangelo-llm-gateway
+description: Deploys LiteLLM as the Michelangelo LLM gateway data plane
+type: application
+version: 1.0.0
+appVersion: "v1.85.1"
+kubeVersion: ">=1.27.0-0"
+home: https://github.com/michelangelo-ai/michelangelo
+icon: https://raw.githubusercontent.com/michelangelo-ai/michelangelo/main/website/static/img/michelangelo-logo-color.svg
+sources:
+  - https://github.com/michelangelo-ai/michelangelo
+  - https://github.com/michelangelo-ai/michelangelo/tree/main/helm/michelangelo-llm-gateway
+  - https://github.com/BerriAI/litellm
+keywords:
+  - llm
+  - gateway
+  - litellm
+  - michelangelo
+maintainers:
+  - name: Michelangelo Maintainers
+    email: maintainers@michelangelo-ai.org
+    url: https://github.com/michelangelo-ai/michelangelo
+annotations:
+  artifacthub.io/category: machine-learning
+  artifacthub.io/license: Apache-2.0
+  org.opencontainers.image.source: https://github.com/michelangelo-ai/michelangelo
+  org.opencontainers.image.url: https://docs.litellm.ai/

--- a/helm/michelangelo-llm-gateway/README.md
+++ b/helm/michelangelo-llm-gateway/README.md
@@ -1,0 +1,104 @@
+# Michelangelo LLM Gateway Helm chart
+
+This chart installs LiteLLM as Michelangelo's private LLM gateway data plane. It is installed as a separate Helm release from the Michelangelo control-plane chart, allowing inference to scale and roll independently.
+
+The chart owns the LiteLLM Deployment, ClusterIP Service, non-secret configuration, database migration Job, health probes, HPA, PodDisruptionBudget, topology spread, and optional Ingress, NetworkPolicy, ServiceMonitor, and Helm test.
+
+Cloud SQL, Redis, Secret Manager, External Secrets Operator, private DNS, TLS, platform routing, dashboards, and alerts remain external.
+
+## Prerequisites
+
+- Kubernetes 1.27 or newer.
+- Helm 3.12 or newer.
+- An existing PostgreSQL database supported by the pinned LiteLLM release.
+- Existing Kubernetes Secrets for the master key, salt key, database URL, and provider credentials.
+- At least one provider model approved for use by your organization.
+
+## Secret contract
+
+The chart maps individual keys from existing Secrets into fixed runtime variables:
+
+| Values | Container variable |
+| --- | --- |
+| `masterKey.existingSecret` / `masterKey.key` | `PROXY_MASTER_KEY` |
+| `saltKey.existingSecret` / `saltKey.key` | `LITELLM_SALT_KEY` |
+| `database.existingSecret` / `database.key` | `DATABASE_URL` |
+
+The defaults read `masterkey`, `saltkey`, and `database-url` from `litellm-secrets`. Add provider credential Secrets to `environmentSecrets`; add non-secret provider configuration to `environmentConfigMaps`.
+
+Provision Secrets through External Secrets Operator or your organization's secret-management workflow before installation. Do not put credentials in `config.data`, `extraEnv`, or committed values files: Helm stores supplied values in the release Secret. The chart creates no Secret resources.
+
+## GCP values
+
+Copy `examples/values-gcp.yaml` and replace each `REPLACE_WITH_...` placeholder with values approved for your deployment. The chart deliberately does not hardcode model generations.
+
+The default LiteLLM image is pinned to a verified multi-architecture digest. Review and update `appVersion`, `image.tag`, and `image.digest` together. For Vertex AI, bind the chart ServiceAccount to a least-privilege Google service account:
+
+```yaml
+serviceAccount:
+  annotations:
+    iam.gke.io/gcp-service-account: litellm@my-project.iam.gserviceaccount.com
+```
+
+## Validate and install
+
+From the Michelangelo repository root:
+
+```bash
+helm lint helm/michelangelo-llm-gateway \
+  -f helm/michelangelo-llm-gateway/examples/values-gcp.yaml
+
+helm template litellm helm/michelangelo-llm-gateway \
+  --namespace litellm \
+  -f helm/michelangelo-llm-gateway/examples/values-gcp.yaml
+
+helm upgrade --install litellm helm/michelangelo-llm-gateway \
+  --namespace litellm \
+  --create-namespace \
+  --wait \
+  --timeout 15m \
+  -f path/to/environment-values.yaml
+```
+
+Run the post-rollout health check with:
+
+```bash
+helm test litellm --namespace litellm
+```
+
+## Migrations
+
+The default migration Job is a fail-closed Helm pre-install and pre-upgrade hook. It uses LiteLLM's v2 migration resolver by default. Its database Secret and `migrationJob.serviceAccountName` must exist before installation. For Argo CD, disable the Helm hook and enable the Argo CD hook. For another orchestrator, disable the Job, set `migrationJob.managedExternally=true`, and disable both hooks.
+
+The proxy never owns schema changes. Chart-owned configuration requires `general_settings.disable_prisma_schema_update: true`; an external ConfigMap must set the same value.
+
+Require backward-compatible expand/contract migrations and a current database recovery point before upgrades. Helm rollback does not roll back the database schema. Qualify the v2 resolver against every pinned LiteLLM upgrade before production.
+
+## Rotation and external configuration
+
+Secret and external ConfigMap values are read when a pod starts. After a secret rotation, change `rollout.runtimeRevision`. After changing an external LiteLLM ConfigMap, change `rollout.configRevision`. Either change performs a rolling restart. A cluster reloader can instead be configured through `podAnnotations`.
+
+## Metrics
+
+Chart-owned configuration enables the Prometheus callback. When `serviceMonitor.enabled=true`, provide `serviceMonitor.authorization.secretName` and `secretKey` for a dedicated LiteLLM scrape credential. An external LiteLLM ConfigMap must also enable the Prometheus callback. Restrict `/metrics` access with the environment NetworkPolicy.
+
+## Production requirements
+
+- Keep the Service as `ClusterIP`; integrate private ingress, TLS, and authentication through the owning platform.
+- Add layer-7 isolation because LiteLLM serves inference and Management API routes on the same port.
+- Set `topologySpread.whenUnsatisfiable=DoNotSchedule` and provide capacity in at least two zones.
+- Define caller, observability, database, provider, telemetry, and GKE metadata-server NetworkPolicy rules before enabling the policy. Protect the pre-install migration hook with an equivalent namespace or platform policy.
+- Keep response caching disabled. If Redis is selected for cross-replica coordination, provide it externally and qualify failure behavior.
+- Use a hardened image validated against your cluster's security policy, or document an explicit exception. The upstream image declares a root runtime user; the default chart drops capabilities, blocks privilege escalation, and applies the runtime-default seccomp profile but does not claim restricted-policy compliance.
+
+When `networkPolicy.enabled=true` and this chart owns migrations, provision the migration policy before installing the release. It must select the rendered `app.kubernetes.io/name`, `app.kubernetes.io/instance`, and `app.kubernetes.io/component: migration` labels and allow only DNS and database egress. Then set `networkPolicy.migration.managedExternally=true` to acknowledge that prerequisite. The chart does not create this policy because Helm and Argo CD migration hooks run before ordinary release resources.
+
+## Upgrade policy
+
+The initial runtime contract is LiteLLM `v1.85.1`. For each upgrade:
+
+1. Pin the chart app version, image tag, and digest together.
+2. Review release notes and schema migrations.
+3. Lint and render every environment profile.
+4. Test migrations, readiness, streaming cancellation, budget enforcement, zonal disruption, and rollback in staging.
+5. Confirm logs, traces, spend records, and callbacks exclude prompts, completions, authorization headers, and credentials.

--- a/helm/michelangelo-llm-gateway/README.md
+++ b/helm/michelangelo-llm-gateway/README.md
@@ -1,10 +1,14 @@
 # Michelangelo LLM Gateway Helm chart
 
-This chart installs LiteLLM as Michelangelo's private LLM gateway data plane. It is installed as a separate Helm release from the Michelangelo control-plane chart, allowing inference to scale and roll independently.
+This chart installs LiteLLM as Michelangelo's private LLM gateway data plane. It is installed, versioned, and released separately from the Michelangelo control-plane chart, allowing inference to scale and roll independently.
 
-The chart owns the LiteLLM Deployment, ClusterIP Service, non-secret configuration, database migration Job, health probes, HPA, PodDisruptionBudget, topology spread, and optional Ingress, NetworkPolicy, ServiceMonitor, and Helm test.
+The chart owns the LiteLLM Deployment, Service, non-secret configuration, database migration Job, health probes, HPA, PodDisruptionBudget, topology spread, and optional Ingress, NetworkPolicy, ServiceMonitor, and Helm test.
 
 Cloud SQL, Redis, Secret Manager, External Secrets Operator, private DNS, TLS, platform routing, dashboards, and alerts remain external.
+
+This is a data-plane-only chart. It does not install the Michelangelo control plane, project-sync controller, Project or key reconciliation, caller credential delivery, an authentication adapter, or provider infrastructure.
+
+In the LiteLLM integration rollout, Milestone 0 validates the upstream LiteLLM chart in staging. This reusable Michelangelo-owned chart is the Milestone 1 data-plane packaging deliverable; it is not Milestone 0 runtime evidence or control-plane automation.
 
 ## Prerequisites
 
@@ -26,26 +30,40 @@ The chart maps individual keys from existing Secrets into fixed runtime variable
 
 The defaults read `masterkey`, `saltkey`, and `database-url` from `litellm-secrets`. Add provider credential Secrets to `environmentSecrets`; add non-secret provider configuration to `environmentConfigMaps`.
 
-Provision Secrets through External Secrets Operator or your organization's secret-management workflow before installation. Do not put credentials in `config.data`, `extraEnv`, or committed values files: Helm stores supplied values in the release Secret. The chart creates no Secret resources.
+Provision Secrets through External Secrets Operator or your organization's secret-management workflow before installation. Do not put plaintext credentials in `config.data`, `extraEnv.value`, or committed values files: Helm stores supplied values in the release Secret. The chart creates no Secret resources.
 
 ## GCP values
 
 Copy `examples/values-gcp.yaml` and replace each `REPLACE_WITH_...` placeholder with values approved for your deployment. The chart deliberately does not hardcode model generations.
 
-The default LiteLLM image is pinned to a verified multi-architecture digest. Review and update `appVersion`, `image.tag`, and `image.digest` together. For Vertex AI, bind the chart ServiceAccount to a least-privilege Google service account:
+The GCP profile reuses one externally managed `litellm-secrets` Secret. Configure the ExternalSecret target with these keys:
+
+| Kubernetes Secret key | GCP Secret Manager source | Runtime use |
+| --- | --- | --- |
+| `masterkey` | `litellm/master-key` | LiteLLM master key |
+| `saltkey` | `litellm/salt-key` | LiteLLM salt key |
+| `database-url` | `litellm/db-dsn` | PostgreSQL DSN |
+| `openai-api-key` | `litellm/openai-key` | `OPENAI_API_KEY` |
+
+The profile creates the `litellm` Kubernetes ServiceAccount so an existing `litellm/litellm` Workload Identity binding can be reused. Bind it to a least-privilege Google service account for Vertex AI:
 
 ```yaml
 serviceAccount:
+  name: litellm
   annotations:
     iam.gke.io/gcp-service-account: litellm@my-project.iam.gserviceaccount.com
 ```
+
+The GCP profile also creates a GKE internal LoadBalancer by setting `service.type=LoadBalancer` and `networking.gke.io/load-balancer-type=Internal`. Create the private Cloud DNS record outside this chart after GKE allocates the address. Never expose this Service through a public load balancer.
+
+The default LiteLLM and Helm-test images are pinned to verified multi-architecture digests. Review and update each image tag and digest together.
 
 ## Validate and install
 
 From the Michelangelo repository root:
 
 ```bash
-helm lint helm/michelangelo-llm-gateway \
+helm lint --strict helm/michelangelo-llm-gateway \
   -f helm/michelangelo-llm-gateway/examples/values-gcp.yaml
 
 helm template litellm helm/michelangelo-llm-gateway \
@@ -53,6 +71,19 @@ helm template litellm helm/michelangelo-llm-gateway \
   -f helm/michelangelo-llm-gateway/examples/values-gcp.yaml
 
 helm upgrade --install litellm helm/michelangelo-llm-gateway \
+  --namespace litellm \
+  --create-namespace \
+  --wait \
+  --timeout 15m \
+  -f path/to/environment-values.yaml
+```
+
+Published releases use an independent OCI chart version. Repository administrators must protect the `llm-gateway-chart-release` environment with required reviewers and restrict the `michelangelo-llm-gateway-v*` tag pattern before the first release. The tag version must equal `Chart.yaml` and point to a commit on `main`. Install a version-pinned release with:
+
+```bash
+helm upgrade --install litellm \
+  oci://ghcr.io/michelangelo-ai/michelangelo/charts/michelangelo-llm-gateway \
+  --version 1.0.0 \
   --namespace litellm \
   --create-namespace \
   --wait \
@@ -68,7 +99,7 @@ helm test litellm --namespace litellm
 
 ## Migrations
 
-The default migration Job is a fail-closed Helm pre-install and pre-upgrade hook. It uses LiteLLM's v2 migration resolver by default. Its database Secret and `migrationJob.serviceAccountName` must exist before installation. For Argo CD, disable the Helm hook and enable the Argo CD hook. For another orchestrator, disable the Job, set `migrationJob.managedExternally=true`, and disable both hooks.
+The default migration Job is a fail-closed Helm pre-install and pre-upgrade hook. It uses LiteLLM's v2 migration resolver by default. Its database Secret and `migrationJob.serviceAccountName` must exist before installation. Completed and failed Helm and Argo CD hooks delete themselves; capture controller and pod logs while the operation is running. For Argo CD, disable the Helm hook and enable the Argo CD hook. For another orchestrator, disable the Job, set `migrationJob.managedExternally=true`, and disable both hooks.
 
 The proxy never owns schema changes. Chart-owned configuration requires `general_settings.disable_prisma_schema_update: true`; an external ConfigMap must set the same value.
 
@@ -78,13 +109,23 @@ Require backward-compatible expand/contract migrations and a current database re
 
 Secret and external ConfigMap values are read when a pod starts. After a secret rotation, change `rollout.runtimeRevision`. After changing an external LiteLLM ConfigMap, change `rollout.configRevision`. Either change performs a rolling restart. A cluster reloader can instead be configured through `podAnnotations`.
 
+## Uninstall
+
+Do not uninstall while a migration hook is running. Remove or redirect the external private DNS record, then uninstall the release:
+
+```bash
+helm uninstall litellm --namespace litellm --wait
+```
+
+Uninstall deletes the chart-managed Service and its GKE load balancer. It does not delete Cloud SQL, Secret Manager values, ExternalSecret resources, external Secrets or ConfigMaps, private DNS records, or provider infrastructure. It also does not reverse database migrations. Retain or restore those resources according to the environment rollback plan.
+
 ## Metrics
 
 Chart-owned configuration enables the Prometheus callback. When `serviceMonitor.enabled=true`, provide `serviceMonitor.authorization.secretName` and `secretKey` for a dedicated LiteLLM scrape credential. An external LiteLLM ConfigMap must also enable the Prometheus callback. Restrict `/metrics` access with the environment NetworkPolicy.
 
 ## Production requirements
 
-- Keep the Service as `ClusterIP`; integrate private ingress, TLS, and authentication through the owning platform.
+- Use either the GCP internal LoadBalancer profile or a `ClusterIP` Service behind platform-owned private ingress. Never create a public endpoint.
 - Add layer-7 isolation because LiteLLM serves inference and Management API routes on the same port.
 - Set `topologySpread.whenUnsatisfiable=DoNotSchedule` and provide capacity in at least two zones.
 - Define caller, observability, database, provider, telemetry, and GKE metadata-server NetworkPolicy rules before enabling the policy. Protect the pre-install migration hook with an equivalent namespace or platform policy.

--- a/helm/michelangelo-llm-gateway/examples/values-gcp.yaml
+++ b/helm/michelangelo-llm-gateway/examples/values-gcp.yaml
@@ -1,6 +1,5 @@
 image:
   tag: v1.85.1
-  digest: ""
 
 serviceAccount:
   annotations:

--- a/helm/michelangelo-llm-gateway/examples/values-gcp.yaml
+++ b/helm/michelangelo-llm-gateway/examples/values-gcp.yaml
@@ -2,8 +2,14 @@ image:
   tag: v1.85.1
 
 serviceAccount:
+  name: litellm
   annotations:
     iam.gke.io/gcp-service-account: litellm@REPLACE_WITH_GCP_PROJECT.iam.gserviceaccount.com
+
+service:
+  type: LoadBalancer
+  annotations:
+    networking.gke.io/load-balancer-type: "Internal"
 
 masterKey:
   existingSecret: litellm-secrets
@@ -17,10 +23,15 @@ database:
   existingSecret: litellm-secrets
   key: database-url
 
-environmentSecrets:
-  - litellm-provider-secrets
-environmentConfigMaps:
-  - litellm-runtime-config
+environmentSecrets: []
+environmentConfigMaps: []
+
+extraEnv:
+  - name: OPENAI_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: litellm-secrets
+        key: openai-api-key
 
 config:
   data:
@@ -32,8 +43,8 @@ config:
       - model_name: vertex-default
         litellm_params:
           model: vertex_ai/REPLACE_WITH_APPROVED_VERTEX_MODEL
-          vertex_project: os.environ/VERTEXAI_PROJECT
-          vertex_location: os.environ/VERTEXAI_LOCATION
+          vertex_project: REPLACE_WITH_GCP_PROJECT
+          vertex_location: REPLACE_WITH_VERTEX_LOCATION
     general_settings:
       master_key: os.environ/PROXY_MASTER_KEY
       disable_prisma_schema_update: true

--- a/helm/michelangelo-llm-gateway/examples/values-gcp.yaml
+++ b/helm/michelangelo-llm-gateway/examples/values-gcp.yaml
@@ -1,0 +1,56 @@
+image:
+  tag: v1.85.1
+  digest: ""
+
+serviceAccount:
+  annotations:
+    iam.gke.io/gcp-service-account: litellm@REPLACE_WITH_GCP_PROJECT.iam.gserviceaccount.com
+
+masterKey:
+  existingSecret: litellm-secrets
+  key: masterkey
+
+saltKey:
+  existingSecret: litellm-secrets
+  key: saltkey
+
+database:
+  existingSecret: litellm-secrets
+  key: database-url
+
+environmentSecrets:
+  - litellm-provider-secrets
+environmentConfigMaps:
+  - litellm-runtime-config
+
+config:
+  data:
+    model_list:
+      - model_name: openai-default
+        litellm_params:
+          model: openai/REPLACE_WITH_APPROVED_OPENAI_MODEL
+          api_key: os.environ/OPENAI_API_KEY
+      - model_name: vertex-default
+        litellm_params:
+          model: vertex_ai/REPLACE_WITH_APPROVED_VERTEX_MODEL
+          vertex_project: os.environ/VERTEXAI_PROJECT
+          vertex_location: os.environ/VERTEXAI_LOCATION
+    general_settings:
+      master_key: os.environ/PROXY_MASTER_KEY
+      disable_prisma_schema_update: true
+    litellm_settings:
+      cache: false
+      success_callback:
+        - prometheus
+
+ingress:
+  enabled: false
+
+networkPolicy:
+  enabled: false
+
+serviceMonitor:
+  enabled: false
+
+topologySpread:
+  whenUnsatisfiable: DoNotSchedule

--- a/helm/michelangelo-llm-gateway/templates/NOTES.txt
+++ b/helm/michelangelo-llm-gateway/templates/NOTES.txt
@@ -1,0 +1,24 @@
+LiteLLM is available inside the cluster at:
+
+  http://{{ include "michelangelo-llm-gateway.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.service.port }}
+
+{{- if .Values.tests.enabled }}
+
+Run the chart test with:
+
+  helm test {{ .Release.Name }} --namespace {{ .Release.Namespace }}
+{{- end }}
+
+{{- $secretNames := list .Values.masterKey.existingSecret .Values.saltKey.existingSecret .Values.database.existingSecret }}
+{{- range .Values.environmentSecrets }}
+{{- $secretNames = append $secretNames . }}
+{{- end }}
+
+The chart expects these existing resources:
+
+{{- range ($secretNames | uniq) }}
+  Secret/{{ . }}
+{{- end }}
+{{- range (.Values.environmentConfigMaps | uniq) }}
+  ConfigMap/{{ . }}
+{{- end }}

--- a/helm/michelangelo-llm-gateway/templates/_helpers.tpl
+++ b/helm/michelangelo-llm-gateway/templates/_helpers.tpl
@@ -1,0 +1,61 @@
+{{- define "michelangelo-llm-gateway.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{- define "michelangelo-llm-gateway.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := include "michelangelo-llm-gateway.name" . -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{- define "michelangelo-llm-gateway.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{- define "michelangelo-llm-gateway.labels" -}}
+helm.sh/chart: {{ include "michelangelo-llm-gateway.chart" . }}
+{{ include "michelangelo-llm-gateway.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "michelangelo-llm-gateway.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "michelangelo-llm-gateway.name" . | quote }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+{{- end }}
+
+{{- define "michelangelo-llm-gateway.serverSelectorLabels" -}}
+{{ include "michelangelo-llm-gateway.selectorLabels" . }}
+app.kubernetes.io/component: server
+{{- end }}
+
+{{- define "michelangelo-llm-gateway.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "michelangelo-llm-gateway.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end }}
+
+{{- define "michelangelo-llm-gateway.configMapName" -}}
+{{- if .Values.config.create -}}
+{{- printf "%s-config" (include "michelangelo-llm-gateway.fullname" .) -}}
+{{- else -}}
+{{- .Values.config.existingConfigMap -}}
+{{- end -}}
+{{- end }}
+
+{{- define "michelangelo-llm-gateway.image" -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" .Values.image.repository .Values.image.digest -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
+{{- end -}}
+{{- end }}

--- a/helm/michelangelo-llm-gateway/templates/configmap.yaml
+++ b/helm/michelangelo-llm-gateway/templates/configmap.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.config.create }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "michelangelo-llm-gateway.configMapName" . }}
+  labels:
+    {{- include "michelangelo-llm-gateway.labels" . | nindent 4 }}
+data:
+  {{ .Values.config.key | quote }}: |
+    {{- tpl (toYaml .Values.config.data) . | nindent 4 }}
+{{- end }}

--- a/helm/michelangelo-llm-gateway/templates/deployment.yaml
+++ b/helm/michelangelo-llm-gateway/templates/deployment.yaml
@@ -1,0 +1,199 @@
+{{- $annotations := deepCopy .Values.podAnnotations -}}
+{{- if .Values.config.create -}}
+{{- $_ := set $annotations "checksum/config" (include (print $.Template.BasePath "/configmap.yaml") . | sha256sum) -}}
+{{- end -}}
+{{- with .Values.rollout.runtimeRevision -}}
+{{- $_ := set $annotations "checksum/runtime-secrets" . -}}
+{{- end -}}
+{{- with .Values.rollout.configRevision -}}
+{{- $_ := set $annotations "checksum/external-config" . -}}
+{{- end -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "michelangelo-llm-gateway.fullname" . | quote }}
+  labels:
+    {{- include "michelangelo-llm-gateway.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  minReadySeconds: {{ .Values.deployment.minReadySeconds }}
+  revisionHistoryLimit: {{ .Values.deployment.revisionHistoryLimit }}
+  strategy:
+    type: {{ .Values.deployment.strategy.type }}
+    {{- if eq .Values.deployment.strategy.type "RollingUpdate" }}
+    rollingUpdate:
+      {{- toYaml .Values.deployment.strategy.rollingUpdate | nindent 6 }}
+    {{- end }}
+  selector:
+    matchLabels:
+      {{- include "michelangelo-llm-gateway.serverSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with $annotations }}
+      annotations:
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- include "michelangelo-llm-gateway.serverSelectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "michelangelo-llm-gateway.serviceAccountName" . | quote }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      enableServiceLinks: false
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.extraInitContainers }}
+      initContainers:
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: litellm
+          image: {{ include "michelangelo-llm-gateway.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- with .Values.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            - name: PROXY_MASTER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.masterKey.existingSecret | quote }}
+                  key: {{ .Values.masterKey.key | quote }}
+            - name: LITELLM_SALT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.saltKey.existingSecret | quote }}
+                  key: {{ .Values.saltKey.key | quote }}
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.existingSecret | quote }}
+                  key: {{ .Values.database.key | quote }}
+            - name: HOST
+              value: "0.0.0.0"
+            - name: PORT
+              value: {{ .Values.service.port | quote }}
+            - name: LITELLM_LOG
+              value: {{ .Values.logLevel | quote }}
+            - name: DISABLE_SCHEMA_UPDATE
+              value: "true"
+          {{- if or .Values.environmentConfigMaps .Values.environmentSecrets }}
+          envFrom:
+            {{- range .Values.environmentConfigMaps }}
+            - configMapRef:
+                name: {{ . | quote }}
+            {{- end }}
+            {{- range .Values.environmentSecrets }}
+            - secretRef:
+                name: {{ . | quote }}
+            {{- end }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          startupProbe:
+            httpGet:
+              path: {{ .Values.probes.startup.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+            successThreshold: {{ .Values.probes.startup.successThreshold }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probes.liveness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            successThreshold: {{ .Values.probes.liveness.successThreshold }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probes.readiness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            successThreshold: {{ .Values.probes.readiness.successThreshold }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/litellm/config.yaml
+              subPath: {{ .Values.config.key | quote }}
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+            {{- with .Values.extraVolumeMounts }}
+            {{- tpl (toYaml .) $ | nindent 12 }}
+            {{- end }}
+        {{- with .Values.extraContainers }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "michelangelo-llm-gateway.configMapName" . | quote }}
+            items:
+              - key: {{ .Values.config.key | quote }}
+                path: {{ .Values.config.key | quote }}
+        - name: tmp
+          emptyDir:
+            sizeLimit: 500Mi
+        {{- with .Values.extraVolumes }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- if .Values.topologySpread.enabled }}
+      topologySpreadConstraints:
+        {{- range $topologyKey := .Values.topologySpread.topologyKeys }}
+        - maxSkew: {{ $.Values.topologySpread.maxSkew }}
+          topologyKey: {{ $topologyKey | quote }}
+          whenUnsatisfiable: {{ $.Values.topologySpread.whenUnsatisfiable | quote }}
+          labelSelector:
+            matchLabels:
+              {{- include "michelangelo-llm-gateway.serverSelectorLabels" $ | nindent 14 }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}

--- a/helm/michelangelo-llm-gateway/templates/hpa.yaml
+++ b/helm/michelangelo-llm-gateway/templates/hpa.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "michelangelo-llm-gateway.fullname" . | quote }}
+  labels:
+    {{- include "michelangelo-llm-gateway.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "michelangelo-llm-gateway.fullname" . | quote }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  {{- with .Values.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  metrics:
+    {{- with .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+    {{- end }}
+    {{- with .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+    {{- end }}
+{{- end }}

--- a/helm/michelangelo-llm-gateway/templates/ingress.yaml
+++ b/helm/michelangelo-llm-gateway/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "michelangelo-llm-gateway.fullname" . | quote }}
+  labels:
+    {{- include "michelangelo-llm-gateway.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path | quote }}
+            pathType: {{ .pathType | quote }}
+            backend:
+              service:
+                name: {{ include "michelangelo-llm-gateway.fullname" $ | quote }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/michelangelo-llm-gateway/templates/migrations-job.yaml
+++ b/helm/michelangelo-llm-gateway/templates/migrations-job.yaml
@@ -9,12 +9,12 @@ metadata:
   annotations:
     {{- if .Values.migrationJob.hooks.helm.enabled }}
     helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: {{ .Values.migrationJob.hooks.helm.weight | quote }}
     {{- end }}
     {{- if .Values.migrationJob.hooks.argocd.enabled }}
     argocd.argoproj.io/hook: PreSync
-    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded,HookFailed
     {{- end }}
     {{- with .Values.migrationJob.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/helm/michelangelo-llm-gateway/templates/migrations-job.yaml
+++ b/helm/michelangelo-llm-gateway/templates/migrations-job.yaml
@@ -1,0 +1,90 @@
+{{- if .Values.migrationJob.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "michelangelo-llm-gateway.fullname" . }}-migrations{{ if and (not .Values.migrationJob.hooks.helm.enabled) (not .Values.migrationJob.hooks.argocd.enabled) }}-{{ .Release.Revision }}{{ end }}
+  labels:
+    {{- include "michelangelo-llm-gateway.labels" . | nindent 4 }}
+  {{- if or .Values.migrationJob.hooks.helm.enabled .Values.migrationJob.hooks.argocd.enabled .Values.migrationJob.annotations }}
+  annotations:
+    {{- if .Values.migrationJob.hooks.helm.enabled }}
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: {{ .Values.migrationJob.hooks.helm.weight | quote }}
+    {{- end }}
+    {{- if .Values.migrationJob.hooks.argocd.enabled }}
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    {{- end }}
+    {{- with .Values.migrationJob.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  activeDeadlineSeconds: {{ .Values.migrationJob.activeDeadlineSeconds }}
+  backoffLimit: {{ .Values.migrationJob.backoffLimit }}
+  ttlSecondsAfterFinished: {{ .Values.migrationJob.ttlSecondsAfterFinished }}
+  template:
+    metadata:
+      labels:
+        {{- include "michelangelo-llm-gateway.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: migration
+    spec:
+      serviceAccountName: {{ .Values.migrationJob.serviceAccountName | quote }}
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      restartPolicy: OnFailure
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: prisma-migrations
+          image: {{ include "michelangelo-llm-gateway.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          command:
+            - litellm
+          args:
+            - --skip_server_startup
+            {{- if .Values.migrationJob.useV2Resolver }}
+            - --use_v2_migration_resolver
+            {{- end }}
+            - --enforce_prisma_migration_check
+          workingDir: /app
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.existingSecret | quote }}
+                  key: {{ .Values.database.key | quote }}
+            - name: DISABLE_SCHEMA_UPDATE
+              value: "false"
+          resources:
+            {{- toYaml .Values.migrationJob.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 500Mi
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+{{- end }}

--- a/helm/michelangelo-llm-gateway/templates/networkpolicy.yaml
+++ b/helm/michelangelo-llm-gateway/templates/networkpolicy.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "michelangelo-llm-gateway.fullname" . | quote }}
+  labels:
+    {{- include "michelangelo-llm-gateway.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "michelangelo-llm-gateway.serverSelectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  {{- if or .Values.networkPolicy.ingress .Values.tests.enabled }}
+  ingress:
+    {{- with .Values.networkPolicy.ingress }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
+    {{- if .Values.tests.enabled }}
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "michelangelo-llm-gateway.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: test
+      ports:
+        - port: {{ .Values.service.port }}
+          protocol: TCP
+    {{- end }}
+  {{- else }}
+  ingress: []
+  {{- end }}
+  {{- if or .Values.networkPolicy.allowDNS .Values.networkPolicy.egress }}
+  egress:
+    {{- if .Values.networkPolicy.allowDNS }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              {{- toYaml .Values.networkPolicy.dns.namespaceSelector | nindent 14 }}
+          podSelector:
+            matchLabels:
+              {{- toYaml .Values.networkPolicy.dns.podSelector | nindent 14 }}
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    {{- end }}
+    {{- with .Values.networkPolicy.egress }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
+  {{- else }}
+  egress: []
+  {{- end }}
+{{- end }}

--- a/helm/michelangelo-llm-gateway/templates/poddisruptionbudget.yaml
+++ b/helm/michelangelo-llm-gateway/templates/poddisruptionbudget.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "michelangelo-llm-gateway.fullname" . | quote }}
+  labels:
+    {{- include "michelangelo-llm-gateway.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "michelangelo-llm-gateway.serverSelectorLabels" . | nindent 6 }}
+  {{- if ne .Values.podDisruptionBudget.minAvailable nil }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- else }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+{{- end }}

--- a/helm/michelangelo-llm-gateway/templates/service.yaml
+++ b/helm/michelangelo-llm-gateway/templates/service.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "michelangelo-llm-gateway.fullname" . | quote }}
+  labels:
+    {{- include "michelangelo-llm-gateway.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type | quote }}
+  selector:
+    {{- include "michelangelo-llm-gateway.serverSelectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  {{- if eq .Values.service.type "LoadBalancer" }}
+  {{- with .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ . | quote }}
+  {{- end }}
+  {{- end }}

--- a/helm/michelangelo-llm-gateway/templates/serviceaccount.yaml
+++ b/helm/michelangelo-llm-gateway/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "michelangelo-llm-gateway.serviceAccountName" . | quote }}
+  labels:
+    {{- include "michelangelo-llm-gateway.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/helm/michelangelo-llm-gateway/templates/servicemonitor.yaml
+++ b/helm/michelangelo-llm-gateway/templates/servicemonitor.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "michelangelo-llm-gateway.fullname" . | quote }}
+  labels:
+    {{- include "michelangelo-llm-gateway.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "michelangelo-llm-gateway.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: server
+  {{- with .Values.serviceMonitor.namespaceSelector }}
+  namespaceSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  endpoints:
+    - port: http
+      path: {{ .Values.serviceMonitor.path | quote }}
+      interval: {{ .Values.serviceMonitor.interval | quote }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout | quote }}
+      authorization:
+        type: Bearer
+        credentials:
+          name: {{ .Values.serviceMonitor.authorization.secretName | quote }}
+          key: {{ .Values.serviceMonitor.authorization.secretKey | quote }}
+{{- end }}

--- a/helm/michelangelo-llm-gateway/templates/tests/test-connection.yaml
+++ b/helm/michelangelo-llm-gateway/templates/tests/test-connection.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: test
   annotations:
     helm.sh/hook: test
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
 spec:
   automountServiceAccountToken: false
   restartPolicy: Never

--- a/helm/michelangelo-llm-gateway/templates/tests/test-connection.yaml
+++ b/helm/michelangelo-llm-gateway/templates/tests/test-connection.yaml
@@ -18,6 +18,10 @@ spec:
     runAsGroup: 101
     seccompProfile:
       type: RuntimeDefault
+  {{- with .Values.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   containers:
     - name: curl
       {{- if .Values.tests.image.digest }}

--- a/helm/michelangelo-llm-gateway/templates/tests/test-connection.yaml
+++ b/helm/michelangelo-llm-gateway/templates/tests/test-connection.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.tests.enabled }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "michelangelo-llm-gateway.fullname" . }}-test-connection
+  labels:
+    {{- include "michelangelo-llm-gateway.labels" . | nindent 4 }}
+    app.kubernetes.io/component: test
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  automountServiceAccountToken: false
+  restartPolicy: Never
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 100
+    runAsGroup: 101
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: curl
+      {{- if .Values.tests.image.digest }}
+      image: "{{ .Values.tests.image.repository }}@{{ .Values.tests.image.digest }}"
+      {{- else }}
+      image: "{{ .Values.tests.image.repository }}:{{ .Values.tests.image.tag }}"
+      {{- end }}
+      imagePullPolicy: {{ .Values.tests.image.pullPolicy }}
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL
+      command:
+        - curl
+      args:
+        - --fail
+        - --show-error
+        - --silent
+        - --max-time
+        - "10"
+        - http://{{ include "michelangelo-llm-gateway.fullname" . }}:{{ .Values.service.port }}{{ .Values.probes.readiness.path }}
+{{- end }}

--- a/helm/michelangelo-llm-gateway/templates/validations.yaml
+++ b/helm/michelangelo-llm-gateway/templates/validations.yaml
@@ -1,0 +1,92 @@
+{{- if and .Values.config.create .Values.config.existingConfigMap -}}
+{{- fail "config.create and config.existingConfigMap are mutually exclusive" -}}
+{{- end -}}
+{{- if and (not .Values.config.create) (empty .Values.config.existingConfigMap) -}}
+{{- fail "config.existingConfigMap is required when config.create is false" -}}
+{{- end -}}
+{{- if or (empty .Values.masterKey.existingSecret) (empty .Values.masterKey.key) -}}
+{{- fail "masterKey.existingSecret and masterKey.key are required" -}}
+{{- end -}}
+{{- if or (empty .Values.saltKey.existingSecret) (empty .Values.saltKey.key) -}}
+{{- fail "saltKey.existingSecret and saltKey.key are required" -}}
+{{- end -}}
+{{- if or (empty .Values.database.existingSecret) (empty .Values.database.key) -}}
+{{- fail "database.existingSecret and database.key are required" -}}
+{{- end -}}
+{{- range .Values.extraEnv -}}
+{{- if has .name (list "PROXY_MASTER_KEY" "LITELLM_SALT_KEY" "DATABASE_URL" "HOST" "PORT" "LITELLM_LOG" "DISABLE_SCHEMA_UPDATE" "ENFORCE_PRISMA_MIGRATION_CHECK") -}}
+{{- fail (printf "extraEnv cannot override chart-owned variable %s" .name) -}}
+{{- end -}}
+{{- if and (hasKey . "value") (regexMatch "(?i)(key|token|secret|password|database_url)" .name) -}}
+{{- fail (printf "extraEnv.%s must use valueFrom instead of a plaintext value" .name) -}}
+{{- end -}}
+{{- end -}}
+{{- if eq .Values.migrationJob.enabled .Values.migrationJob.managedExternally -}}
+{{- fail "exactly one of migrationJob.enabled or migrationJob.managedExternally must be true" -}}
+{{- end -}}
+{{- if and .Values.migrationJob.enabled (eq .Values.migrationJob.hooks.helm.enabled .Values.migrationJob.hooks.argocd.enabled) -}}
+{{- fail "managed migrations require exactly one Helm or Argo CD hook backend" -}}
+{{- end -}}
+{{- if and .Values.migrationJob.managedExternally (or .Values.migrationJob.hooks.helm.enabled .Values.migrationJob.hooks.argocd.enabled) -}}
+{{- fail "migration hooks must be disabled when migrations are managed externally" -}}
+{{- end -}}
+{{- range $key := list "helm.sh/hook" "helm.sh/hook-delete-policy" "helm.sh/hook-weight" "argocd.argoproj.io/hook" "argocd.argoproj.io/hook-delete-policy" "argocd.argoproj.io/sync-wave" -}}
+{{- if hasKey $.Values.migrationJob.annotations $key -}}
+{{- fail (printf "migrationJob.annotations cannot override chart-owned hook annotation %s" $key) -}}
+{{- end -}}
+{{- end -}}
+{{- if and .Values.networkPolicy.enabled .Values.migrationJob.enabled (not .Values.networkPolicy.migration.managedExternally) -}}
+{{- fail "chart-managed migration hooks require a pre-existing externally managed NetworkPolicy when networkPolicy.enabled=true" -}}
+{{- end -}}
+{{- if .Values.config.create -}}
+{{- $generalSettings := default dict .Values.config.data.general_settings -}}
+{{- if ne (get $generalSettings "disable_prisma_schema_update") true -}}
+{{- fail "config.data.general_settings.disable_prisma_schema_update must be true" -}}
+{{- end -}}
+{{- end -}}
+{{- if .Values.serviceMonitor.enabled -}}
+{{- if or (empty .Values.serviceMonitor.authorization.secretName) (empty .Values.serviceMonitor.authorization.secretKey) -}}
+{{- fail "serviceMonitor.authorization.secretName and secretKey are required when ServiceMonitor is enabled" -}}
+{{- end -}}
+{{- if .Values.config.create -}}
+{{- $litellmSettings := default dict .Values.config.data.litellm_settings -}}
+{{- $callbacks := default list (get $litellmSettings "success_callback") -}}
+{{- if not (has "prometheus" $callbacks) -}}
+{{- fail "config.data.litellm_settings.success_callback must include prometheus when ServiceMonitor is enabled" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- if and .Values.autoscaling.enabled (gt (int .Values.autoscaling.minReplicas) (int .Values.autoscaling.maxReplicas)) -}}
+{{- fail "autoscaling.minReplicas cannot exceed autoscaling.maxReplicas" -}}
+{{- end -}}
+{{- if and .Values.autoscaling.enabled (not .Values.autoscaling.targetCPUUtilizationPercentage) (not .Values.autoscaling.targetMemoryUtilizationPercentage) -}}
+{{- fail "autoscaling requires at least one CPU or memory target" -}}
+{{- end -}}
+{{- if or (hasKey .Values.podLabels "app.kubernetes.io/name") (hasKey .Values.podLabels "app.kubernetes.io/instance") (hasKey .Values.podLabels "app.kubernetes.io/component") -}}
+{{- fail "podLabels cannot override app.kubernetes.io/name, app.kubernetes.io/instance, or app.kubernetes.io/component" -}}
+{{- end -}}
+{{- $pdbMinSet := ne .Values.podDisruptionBudget.minAvailable nil -}}
+{{- $pdbMaxSet := ne .Values.podDisruptionBudget.maxUnavailable nil -}}
+{{- if and $pdbMinSet $pdbMaxSet -}}
+{{- fail "set only one of podDisruptionBudget.minAvailable or podDisruptionBudget.maxUnavailable" -}}
+{{- end -}}
+{{- if and .Values.podDisruptionBudget.enabled (not (or $pdbMinSet $pdbMaxSet)) -}}
+{{- fail "podDisruptionBudget requires minAvailable or maxUnavailable when enabled" -}}
+{{- end -}}
+{{- if and .Values.ingress.enabled (empty .Values.ingress.hosts) -}}
+{{- fail "ingress.hosts is required when ingress is enabled" -}}
+{{- end -}}
+{{- if and (ne .Values.service.type "LoadBalancer") .Values.service.loadBalancerSourceRanges -}}
+{{- fail "service.loadBalancerSourceRanges requires service.type=LoadBalancer" -}}
+{{- end -}}
+{{- if and (ne .Values.service.type "LoadBalancer") .Values.service.externalTrafficPolicy -}}
+{{- fail "service.externalTrafficPolicy requires service.type=LoadBalancer" -}}
+{{- end -}}
+{{- range $key := .Values.topologySpread.topologyKeys -}}
+{{- if contains "/" $key -}}
+{{- $prefix := index (splitList "/" $key) 0 -}}
+{{- if gt (len $prefix) 253 -}}
+{{- fail (printf "topologySpread topology key prefix exceeds 253 characters: %s" $key) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/helm/michelangelo-llm-gateway/values.schema.json
+++ b/helm/michelangelo-llm-gateway/values.schema.json
@@ -1,0 +1,500 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "image",
+    "service",
+    "config",
+    "masterKey",
+    "saltKey",
+    "database",
+    "resources",
+    "probes",
+    "topologySpread",
+    "migrationJob"
+  ],
+  "definitions": {
+    "resourceQuantity": {
+      "oneOf": [
+        {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^\\+?([0-9]+(\\.[0-9]*)?|\\.[0-9]+)([eE][+-]?[0-9]+|[KMGTPE]i|[numkMGTPE])?$"
+        },
+        {"type": "number", "minimum": 0}
+      ]
+    },
+    "resourceList": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/resourceQuantity"
+      }
+    },
+    "probe": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "initialDelaySeconds",
+        "periodSeconds",
+        "timeoutSeconds",
+        "successThreshold",
+        "failureThreshold"
+      ],
+      "properties": {
+        "path": {"type": "string", "pattern": "^/"},
+        "initialDelaySeconds": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 2147483647
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 2147483647
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 2147483647
+        },
+        "successThreshold": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 2147483647
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 2147483647
+        }
+      }
+    },
+    "singleSuccessProbe": {
+      "allOf": [
+        {"$ref": "#/definitions/probe"},
+        {
+          "properties": {
+            "successThreshold": {"const": 1}
+          }
+        }
+      ]
+    }
+  },
+  "properties": {
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "image": {
+      "type": "object",
+      "required": ["repository", "tag", "pullPolicy"],
+      "properties": {
+        "repository": {"type": "string", "minLength": 1},
+        "tag": {"type": "string", "minLength": 1},
+        "digest": {
+          "type": "string",
+          "pattern": "^$|^sha256:[a-fA-F0-9]{64}$"
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        }
+      }
+    },
+    "resources": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "limits": {"$ref": "#/definitions/resourceList"},
+        "requests": {"$ref": "#/definitions/resourceList"}
+      }
+    },
+    "probes": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["startup", "liveness", "readiness"],
+      "properties": {
+        "startup": {"$ref": "#/definitions/singleSuccessProbe"},
+        "liveness": {"$ref": "#/definitions/singleSuccessProbe"},
+        "readiness": {"$ref": "#/definitions/probe"}
+      }
+    },
+    "service": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "port",
+        "annotations",
+        "loadBalancerSourceRanges",
+        "externalTrafficPolicy"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ClusterIP", "LoadBalancer"]
+        },
+        "port": {"type": "integer", "minimum": 1, "maximum": 65535},
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {"type": "string"}
+        },
+        "loadBalancerSourceRanges": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "string",
+                "pattern": "^((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\\.){3}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])/(3[0-2]|[12]?[0-9])$"
+              },
+              {
+                "type": "string",
+                "$comment": "Kubernetes performs full IPv6 CIDR parsing; this branch validates the character set and prefix length.",
+                "pattern": "^[0-9A-Fa-f.]*:[0-9A-Fa-f:.]*/(12[0-8]|1[01][0-9]|[1-9]?[0-9])$"
+              }
+            ]
+          }
+        },
+        "externalTrafficPolicy": {
+          "type": "string",
+          "enum": ["", "Cluster", "Local"]
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {"const": "ClusterIP"}
+            }
+          },
+          "then": {
+            "properties": {
+              "externalTrafficPolicy": {"const": ""},
+              "loadBalancerSourceRanges": {"maxItems": 0}
+            }
+          }
+        }
+      ]
+    },
+    "deployment": {
+      "type": "object",
+      "required": ["minReadySeconds", "revisionHistoryLimit", "strategy"],
+      "properties": {
+        "minReadySeconds": {"type": "integer", "minimum": 0},
+        "revisionHistoryLimit": {"type": "integer", "minimum": 0},
+        "strategy": {
+          "type": "object",
+          "required": ["type"],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["RollingUpdate", "Recreate"]
+            },
+            "rollingUpdate": {"type": ["object", "null"]}
+          }
+        }
+      }
+    },
+    "config": {
+      "type": "object",
+      "required": ["create", "existingConfigMap", "key", "data"],
+      "properties": {
+        "create": {"type": "boolean"},
+        "existingConfigMap": {"type": "string"},
+        "key": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 253,
+          "pattern": "^[A-Za-z0-9._-]+$",
+          "not": {
+            "enum": [".", ".."]
+          }
+        },
+        "data": {"type": "object"}
+      }
+    },
+    "masterKey": {
+      "type": "object",
+      "required": ["existingSecret", "key"],
+      "properties": {
+        "existingSecret": {"type": "string", "minLength": 1},
+        "key": {"type": "string", "minLength": 1}
+      }
+    },
+    "saltKey": {
+      "type": "object",
+      "required": ["existingSecret", "key"],
+      "properties": {
+        "existingSecret": {"type": "string", "minLength": 1},
+        "key": {"type": "string", "minLength": 1}
+      }
+    },
+    "database": {
+      "type": "object",
+      "required": ["existingSecret", "key"],
+      "properties": {
+        "existingSecret": {"type": "string", "minLength": 1},
+        "key": {"type": "string", "minLength": 1}
+      }
+    },
+    "environmentSecrets": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1}
+    },
+    "environmentConfigMaps": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1}
+    },
+    "rollout": {
+      "type": "object",
+      "required": ["runtimeRevision", "configRevision"],
+      "properties": {
+        "runtimeRevision": {"type": "string"},
+        "configRevision": {"type": "string"}
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "required": ["enabled", "hosts"],
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["host", "paths"],
+            "properties": {
+              "host": {"type": "string", "minLength": 1},
+              "paths": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "object",
+                  "required": ["path", "pathType"],
+                  "properties": {
+                    "path": {"type": "string", "minLength": 1},
+                    "pathType": {
+                      "type": "string",
+                      "enum": ["Exact", "Prefix", "ImplementationSpecific"]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "topologySpread": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "enabled",
+        "maxSkew",
+        "whenUnsatisfiable",
+        "topologyKeys"
+      ],
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "maxSkew": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 2147483647
+        },
+        "whenUnsatisfiable": {
+          "type": "string",
+          "enum": ["DoNotSchedule", "ScheduleAnyway"]
+        },
+        "topologyKeys": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "oneOf": [
+              {
+                "type": "string",
+                "maxLength": 63,
+                "pattern": "^[A-Za-z0-9]([-A-Za-z0-9_.]{0,61}[A-Za-z0-9])?$"
+              },
+              {
+                "type": "string",
+                "maxLength": 317,
+                "pattern": "^([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?\\.)*[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?/[A-Za-z0-9]([-A-Za-z0-9_.]{0,61}[A-Za-z0-9])?$"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "autoscaling": {
+      "type": "object",
+      "required": ["enabled", "minReplicas", "maxReplicas"],
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "minReplicas": {"type": "integer", "minimum": 1},
+        "maxReplicas": {"type": "integer", "minimum": 1},
+        "targetCPUUtilizationPercentage": {
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "maximum": 100
+        },
+        "targetMemoryUtilizationPercentage": {
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "maximum": 100
+        }
+      }
+    },
+    "migrationJob": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "enabled",
+        "managedExternally",
+        "useV2Resolver",
+        "serviceAccountName",
+        "activeDeadlineSeconds",
+        "backoffLimit",
+        "ttlSecondsAfterFinished",
+        "annotations",
+        "resources",
+        "hooks"
+      ],
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "managedExternally": {"type": "boolean"},
+        "useV2Resolver": {"type": "boolean"},
+        "serviceAccountName": {"type": "string", "minLength": 1},
+        "activeDeadlineSeconds": {"type": "integer", "minimum": 1},
+        "backoffLimit": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 2147483647
+        },
+        "ttlSecondsAfterFinished": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 2147483647
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {"type": "string"}
+        },
+        "resources": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "limits": {"$ref": "#/definitions/resourceList"},
+            "requests": {"$ref": "#/definitions/resourceList"}
+          }
+        },
+        "hooks": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["helm", "argocd"],
+          "properties": {
+            "helm": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["enabled", "weight"],
+              "properties": {
+                "enabled": {"type": "boolean"},
+                "weight": {
+                  "type": "integer",
+                  "minimum": -2147483648,
+                  "maximum": 2147483647
+                }
+              }
+            },
+            "argocd": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["enabled"],
+              "properties": {
+                "enabled": {"type": "boolean"}
+              }
+            }
+          }
+        }
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "required": ["enabled", "migration", "allowDNS", "dns", "ingress", "egress"],
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "migration": {
+          "type": "object",
+          "required": ["managedExternally"],
+          "properties": {
+            "managedExternally": {"type": "boolean"}
+          }
+        },
+        "allowDNS": {"type": "boolean"},
+        "dns": {"type": "object"},
+        "ingress": {"type": "array"},
+        "egress": {"type": "array"}
+      }
+    },
+    "tests": {
+      "type": "object",
+      "required": ["enabled", "image"],
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "image": {
+          "type": "object",
+          "required": ["repository", "tag", "digest", "pullPolicy"],
+          "properties": {
+            "repository": {"type": "string", "minLength": 1},
+            "tag": {"type": "string", "minLength": 1},
+            "digest": {
+              "type": "string",
+              "pattern": "^$|^sha256:[a-fA-F0-9]{64}$"
+            },
+            "pullPolicy": {
+              "type": "string",
+              "enum": ["Always", "IfNotPresent", "Never"]
+            }
+          }
+        }
+      }
+    },
+    "serviceMonitor": {
+      "type": "object",
+      "required": ["enabled", "authorization"],
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "authorization": {
+          "type": "object",
+          "required": ["secretName", "secretKey"],
+          "properties": {
+            "secretName": {"type": "string"},
+            "secretKey": {"type": "string", "minLength": 1}
+          }
+        }
+      }
+    },
+    "podDisruptionBudget": {
+      "type": "object",
+      "required": ["enabled"],
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "minAvailable": {
+          "oneOf": [
+            {"type": "integer", "minimum": 0},
+            {"type": "string", "pattern": "^(100|[0-9]{1,2})%$"},
+            {"type": "null"}
+          ]
+        },
+        "maxUnavailable": {
+          "oneOf": [
+            {"type": "integer", "minimum": 0},
+            {"type": "string", "pattern": "^(100|[0-9]{1,2})%$"},
+            {"type": "null"}
+          ]
+        }
+      }
+    }
+  }
+}

--- a/helm/michelangelo-llm-gateway/values.schema.json
+++ b/helm/michelangelo-llm-gateway/values.schema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
+  "additionalProperties": false,
   "required": [
     "image",
     "service",
@@ -28,6 +29,146 @@
       "type": "object",
       "additionalProperties": {
         "$ref": "#/definitions/resourceQuantity"
+      }
+    },
+    "stringMap": {
+      "type": "object",
+      "additionalProperties": {"type": "string"}
+    },
+    "dnsSubdomain": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 253,
+      "pattern": "^[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?(?:\\.[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?)*$"
+    },
+    "dnsLabel": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 63,
+      "pattern": "^[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?$"
+    },
+    "optionalDnsLabel": {
+      "oneOf": [
+        {"const": ""},
+        {"$ref": "#/definitions/dnsLabel"}
+      ]
+    },
+    "optionalDnsSubdomain": {
+      "oneOf": [
+        {"const": ""},
+        {"$ref": "#/definitions/dnsSubdomain"}
+      ]
+    },
+    "dataKey": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 253,
+      "pattern": "^[A-Za-z0-9._-]+$",
+      "not": {
+        "anyOf": [
+          {"const": "."},
+          {"pattern": "^\\.\\."}
+        ]
+      }
+    },
+    "localObjectReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name": {"$ref": "#/definitions/dnsSubdomain"}
+      }
+    },
+    "intOrPercent": {
+      "oneOf": [
+        {"type": "integer", "minimum": 0},
+        {"type": "string", "pattern": "^(100|[0-9]{1,2})%$"}
+      ]
+    },
+    "secretKeySelector": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "key"],
+      "properties": {
+        "name": {"$ref": "#/definitions/dnsSubdomain"},
+        "key": {"$ref": "#/definitions/dataKey"},
+        "optional": {"type": "boolean"}
+      }
+    },
+    "configMapKeySelector": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "key"],
+      "properties": {
+        "name": {"$ref": "#/definitions/dnsSubdomain"},
+        "key": {"$ref": "#/definitions/dataKey"},
+        "optional": {"type": "boolean"}
+      }
+    },
+    "envVarSource": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "maxProperties": 1,
+      "properties": {
+        "secretKeyRef": {"$ref": "#/definitions/secretKeySelector"},
+        "configMapKeyRef": {"$ref": "#/definitions/configMapKeySelector"},
+        "fieldRef": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["fieldPath"],
+          "properties": {
+            "apiVersion": {"type": "string"},
+            "fieldPath": {"type": "string", "minLength": 1}
+          }
+        },
+        "resourceFieldRef": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["resource"],
+          "properties": {
+            "containerName": {"type": "string"},
+            "resource": {"type": "string", "minLength": 1},
+            "divisor": {"type": "string", "minLength": 1}
+          }
+        }
+      }
+    },
+    "envVar": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[-._A-Za-z][-._A-Za-z0-9]*$",
+          "not": {
+            "anyOf": [
+              {"const": "."},
+              {"pattern": "^\\.\\."}
+            ]
+          }
+        },
+        "value": {"type": "string"},
+        "valueFrom": {"$ref": "#/definitions/envVarSource"}
+      },
+      "not": {"required": ["value", "valueFrom"]}
+    },
+    "namedKubernetesObject": {
+      "type": "object",
+      "$comment": "The remaining fields are passed through to the Kubernetes API.",
+      "required": ["name"],
+      "properties": {
+        "name": {"type": "string", "minLength": 1}
+      }
+    },
+    "volumeMount": {
+      "type": "object",
+      "$comment": "The remaining fields are passed through to the Kubernetes API.",
+      "required": ["name", "mountPath"],
+      "properties": {
+        "name": {"type": "string", "minLength": 1},
+        "mountPath": {"type": "string", "minLength": 1}
       }
     },
     "probe": {
@@ -86,8 +227,11 @@
       "type": "integer",
       "minimum": 1
     },
+    "nameOverride": {"$ref": "#/definitions/optionalDnsLabel"},
+    "fullnameOverride": {"$ref": "#/definitions/optionalDnsLabel"},
     "image": {
       "type": "object",
+      "additionalProperties": false,
       "required": ["repository", "tag", "pullPolicy"],
       "properties": {
         "repository": {"type": "string", "minLength": 1},
@@ -101,6 +245,87 @@
           "enum": ["Always", "IfNotPresent", "Never"]
         }
       }
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {"$ref": "#/definitions/localObjectReference"}
+    },
+    "podAnnotations": {"$ref": "#/definitions/stringMap"},
+    "podLabels": {"$ref": "#/definitions/stringMap"},
+    "serviceAccount": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "create",
+        "name",
+        "annotations",
+        "automountServiceAccountToken"
+      ],
+      "properties": {
+        "create": {"type": "boolean"},
+        "name": {"$ref": "#/definitions/optionalDnsSubdomain"},
+        "annotations": {"$ref": "#/definitions/stringMap"},
+        "automountServiceAccountToken": {"type": "boolean"}
+      }
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "$comment": "Kubernetes PodSecurityContext pass-through."
+    },
+    "securityContext": {
+      "type": "object",
+      "$comment": "Kubernetes container SecurityContext pass-through."
+    },
+    "logLevel": {"type": "string"},
+    "extraEnv": {
+      "type": "array",
+      "items": {"$ref": "#/definitions/envVar"}
+    },
+    "command": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "args": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "terminationGracePeriodSeconds": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "lifecycle": {
+      "type": "object",
+      "$comment": "Kubernetes container Lifecycle pass-through."
+    },
+    "nodeSelector": {"$ref": "#/definitions/stringMap"},
+    "tolerations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "$comment": "Kubernetes Toleration pass-through."
+      }
+    },
+    "affinity": {
+      "type": "object",
+      "$comment": "Kubernetes Affinity pass-through."
+    },
+    "priorityClassName": {"$ref": "#/definitions/optionalDnsSubdomain"},
+    "extraInitContainers": {
+      "type": "array",
+      "items": {"$ref": "#/definitions/namedKubernetesObject"}
+    },
+    "extraContainers": {
+      "type": "array",
+      "items": {"$ref": "#/definitions/namedKubernetesObject"}
+    },
+    "extraVolumes": {
+      "type": "array",
+      "items": {"$ref": "#/definitions/namedKubernetesObject"}
+    },
+    "extraVolumeMounts": {
+      "type": "array",
+      "items": {"$ref": "#/definitions/volumeMount"}
     },
     "resources": {
       "type": "object",
@@ -179,36 +404,56 @@
     },
     "deployment": {
       "type": "object",
+      "additionalProperties": false,
       "required": ["minReadySeconds", "revisionHistoryLimit", "strategy"],
       "properties": {
         "minReadySeconds": {"type": "integer", "minimum": 0},
         "revisionHistoryLimit": {"type": "integer", "minimum": 0},
         "strategy": {
           "type": "object",
+          "additionalProperties": false,
           "required": ["type"],
           "properties": {
             "type": {
               "type": "string",
               "enum": ["RollingUpdate", "Recreate"]
             },
-            "rollingUpdate": {"type": ["object", "null"]}
+            "rollingUpdate": {
+              "oneOf": [
+                {"type": "null"},
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "maxUnavailable": {
+                      "$ref": "#/definitions/intOrPercent"
+                    },
+                    "maxSurge": {"$ref": "#/definitions/intOrPercent"}
+                  }
+                }
+              ]
+            }
           }
         }
       }
     },
     "config": {
       "type": "object",
+      "additionalProperties": false,
       "required": ["create", "existingConfigMap", "key", "data"],
       "properties": {
         "create": {"type": "boolean"},
-        "existingConfigMap": {"type": "string"},
+        "existingConfigMap": {"$ref": "#/definitions/optionalDnsSubdomain"},
         "key": {
           "type": "string",
           "minLength": 1,
           "maxLength": 253,
           "pattern": "^[A-Za-z0-9._-]+$",
           "not": {
-            "enum": [".", ".."]
+            "anyOf": [
+              {"const": "."},
+              {"pattern": "^\\.\\."}
+            ]
           }
         },
         "data": {"type": "object"}
@@ -216,38 +461,42 @@
     },
     "masterKey": {
       "type": "object",
+      "additionalProperties": false,
       "required": ["existingSecret", "key"],
       "properties": {
-        "existingSecret": {"type": "string", "minLength": 1},
-        "key": {"type": "string", "minLength": 1}
+        "existingSecret": {"$ref": "#/definitions/dnsSubdomain"},
+        "key": {"$ref": "#/definitions/dataKey"}
       }
     },
     "saltKey": {
       "type": "object",
+      "additionalProperties": false,
       "required": ["existingSecret", "key"],
       "properties": {
-        "existingSecret": {"type": "string", "minLength": 1},
-        "key": {"type": "string", "minLength": 1}
+        "existingSecret": {"$ref": "#/definitions/dnsSubdomain"},
+        "key": {"$ref": "#/definitions/dataKey"}
       }
     },
     "database": {
       "type": "object",
+      "additionalProperties": false,
       "required": ["existingSecret", "key"],
       "properties": {
-        "existingSecret": {"type": "string", "minLength": 1},
-        "key": {"type": "string", "minLength": 1}
+        "existingSecret": {"$ref": "#/definitions/dnsSubdomain"},
+        "key": {"$ref": "#/definitions/dataKey"}
       }
     },
     "environmentSecrets": {
       "type": "array",
-      "items": {"type": "string", "minLength": 1}
+      "items": {"$ref": "#/definitions/dnsSubdomain"}
     },
     "environmentConfigMaps": {
       "type": "array",
-      "items": {"type": "string", "minLength": 1}
+      "items": {"$ref": "#/definitions/dnsSubdomain"}
     },
     "rollout": {
       "type": "object",
+      "additionalProperties": false,
       "required": ["runtimeRevision", "configRevision"],
       "properties": {
         "runtimeRevision": {"type": "string"},
@@ -256,13 +505,23 @@
     },
     "ingress": {
       "type": "object",
-      "required": ["enabled", "hosts"],
+      "additionalProperties": false,
+      "required": [
+        "enabled",
+        "className",
+        "annotations",
+        "hosts",
+        "tls"
+      ],
       "properties": {
         "enabled": {"type": "boolean"},
+        "className": {"$ref": "#/definitions/optionalDnsSubdomain"},
+        "annotations": {"$ref": "#/definitions/stringMap"},
         "hosts": {
           "type": "array",
           "items": {
             "type": "object",
+            "additionalProperties": false,
             "required": ["host", "paths"],
             "properties": {
               "host": {"type": "string", "minLength": 1},
@@ -271,9 +530,10 @@
                 "minItems": 1,
                 "items": {
                   "type": "object",
+                  "additionalProperties": false,
                   "required": ["path", "pathType"],
                   "properties": {
-                    "path": {"type": "string", "minLength": 1},
+                    "path": {"type": "string", "pattern": "^/"},
                     "pathType": {
                       "type": "string",
                       "enum": ["Exact", "Prefix", "ImplementationSpecific"]
@@ -281,6 +541,20 @@
                   }
                 }
               }
+            }
+          }
+        },
+        "tls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "hosts": {
+                "type": "array",
+                "items": {"type": "string", "minLength": 1}
+              },
+              "secretName": {"$ref": "#/definitions/dnsSubdomain"}
             }
           }
         }
@@ -329,6 +603,7 @@
     },
     "autoscaling": {
       "type": "object",
+      "additionalProperties": false,
       "required": ["enabled", "minReplicas", "maxReplicas"],
       "properties": {
         "enabled": {"type": "boolean"},
@@ -343,6 +618,10 @@
           "type": ["integer", "null"],
           "minimum": 1,
           "maximum": 100
+        },
+        "behavior": {
+          "type": "object",
+          "$comment": "Kubernetes HorizontalPodAutoscalerBehavior pass-through."
         }
       }
     },
@@ -365,7 +644,7 @@
         "enabled": {"type": "boolean"},
         "managedExternally": {"type": "boolean"},
         "useV2Resolver": {"type": "boolean"},
-        "serviceAccountName": {"type": "string", "minLength": 1},
+        "serviceAccountName": {"$ref": "#/definitions/dnsSubdomain"},
         "activeDeadlineSeconds": {"type": "integer", "minimum": 1},
         "backoffLimit": {
           "type": "integer",
@@ -421,29 +700,53 @@
     },
     "networkPolicy": {
       "type": "object",
+      "additionalProperties": false,
       "required": ["enabled", "migration", "allowDNS", "dns", "ingress", "egress"],
       "properties": {
         "enabled": {"type": "boolean"},
         "migration": {
           "type": "object",
+          "additionalProperties": false,
           "required": ["managedExternally"],
           "properties": {
             "managedExternally": {"type": "boolean"}
           }
         },
         "allowDNS": {"type": "boolean"},
-        "dns": {"type": "object"},
-        "ingress": {"type": "array"},
-        "egress": {"type": "array"}
+        "dns": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["namespaceSelector", "podSelector"],
+          "properties": {
+            "namespaceSelector": {"$ref": "#/definitions/stringMap"},
+            "podSelector": {"$ref": "#/definitions/stringMap"}
+          }
+        },
+        "ingress": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$comment": "Kubernetes NetworkPolicyIngressRule pass-through."
+          }
+        },
+        "egress": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$comment": "Kubernetes NetworkPolicyEgressRule pass-through."
+          }
+        }
       }
     },
     "tests": {
       "type": "object",
+      "additionalProperties": false,
       "required": ["enabled", "image"],
       "properties": {
         "enabled": {"type": "boolean"},
         "image": {
           "type": "object",
+          "additionalProperties": false,
           "required": ["repository", "tag", "digest", "pullPolicy"],
           "properties": {
             "repository": {"type": "string", "minLength": 1},
@@ -462,35 +765,54 @@
     },
     "serviceMonitor": {
       "type": "object",
-      "required": ["enabled", "authorization"],
+      "additionalProperties": false,
+      "required": [
+        "enabled",
+        "labels",
+        "annotations",
+        "interval",
+        "scrapeTimeout",
+        "path",
+        "namespaceSelector",
+        "authorization"
+      ],
       "properties": {
         "enabled": {"type": "boolean"},
+        "labels": {"$ref": "#/definitions/stringMap"},
+        "annotations": {"$ref": "#/definitions/stringMap"},
+        "interval": {"type": "string", "minLength": 1},
+        "scrapeTimeout": {"type": "string", "minLength": 1},
+        "path": {"type": "string", "pattern": "^/"},
+        "namespaceSelector": {
+          "type": "object",
+          "$comment": "Prometheus Operator NamespaceSelector pass-through."
+        },
         "authorization": {
           "type": "object",
+          "additionalProperties": false,
           "required": ["secretName", "secretKey"],
           "properties": {
-            "secretName": {"type": "string"},
-            "secretKey": {"type": "string", "minLength": 1}
+            "secretName": {"$ref": "#/definitions/optionalDnsSubdomain"},
+            "secretKey": {"$ref": "#/definitions/dataKey"}
           }
         }
       }
     },
     "podDisruptionBudget": {
       "type": "object",
+      "additionalProperties": false,
       "required": ["enabled"],
       "properties": {
         "enabled": {"type": "boolean"},
         "minAvailable": {
           "oneOf": [
-            {"type": "integer", "minimum": 0},
-            {"type": "string", "pattern": "^(100|[0-9]{1,2})%$"},
+            {"$ref": "#/definitions/intOrPercent"},
             {"type": "null"}
           ]
         },
         "maxUnavailable": {
           "oneOf": [
-            {"type": "integer", "minimum": 0},
-            {"type": "string", "pattern": "^(100|[0-9]{1,2})%$"},
+            {"$ref": "#/definitions/intOrPercent"},
             {"type": "null"}
           ]
         }

--- a/helm/michelangelo-llm-gateway/values.yaml
+++ b/helm/michelangelo-llm-gateway/values.yaml
@@ -1,0 +1,218 @@
+replicaCount: 2
+
+image:
+  repository: docker.io/litellm/litellm-database
+  tag: v1.85.1
+  digest: sha256:fb757549de0da017a597ee4b9be0bfb55c49cde77898abe789fa3ad37d770c69
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+deployment:
+  minReadySeconds: 10
+  revisionHistoryLimit: 5
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+
+podAnnotations: {}
+podLabels: {}
+
+rollout:
+  runtimeRevision: ""
+  configRevision: ""
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+  automountServiceAccountToken: false
+
+podSecurityContext:
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false
+  capabilities:
+    drop:
+      - ALL
+
+service:
+  type: ClusterIP
+  port: 4000
+  annotations: {}
+  loadBalancerSourceRanges: []
+  externalTrafficPolicy: ""
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts: []
+  tls: []
+
+config:
+  create: true
+  existingConfigMap: ""
+  key: config.yaml
+  data:
+    model_list: []
+    general_settings:
+      master_key: os.environ/PROXY_MASTER_KEY
+      disable_prisma_schema_update: true
+    litellm_settings:
+      cache: false
+      success_callback:
+        - prometheus
+
+masterKey:
+  existingSecret: litellm-secrets
+  key: masterkey
+
+saltKey:
+  existingSecret: litellm-secrets
+  key: saltkey
+
+database:
+  existingSecret: litellm-secrets
+  key: database-url
+
+environmentSecrets: []
+environmentConfigMaps: []
+
+logLevel: INFO
+extraEnv: []
+
+command: []
+args:
+  - --config
+  - /etc/litellm/config.yaml
+
+resources:
+  requests:
+    cpu: 500m
+    memory: 512Mi
+  limits:
+    cpu: "2"
+    memory: 2Gi
+
+probes:
+  startup:
+    path: /health/readiness
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 30
+  liveness:
+    path: /health/liveliness
+    initialDelaySeconds: 0
+    periodSeconds: 15
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 5
+  readiness:
+    path: /health/readiness
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 3
+
+terminationGracePeriodSeconds: 90
+lifecycle: {}
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: null
+  behavior: {}
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: null
+  maxUnavailable: 1
+
+topologySpread:
+  enabled: true
+  maxSkew: 1
+  whenUnsatisfiable: ScheduleAnyway
+  topologyKeys:
+    - topology.kubernetes.io/zone
+    - kubernetes.io/hostname
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+priorityClassName: ""
+
+networkPolicy:
+  enabled: false
+  migration:
+    # Migration hooks run before release resources. Set this only after a
+    # matching NetworkPolicy has been provisioned outside this chart.
+    managedExternally: false
+  allowDNS: true
+  dns:
+    namespaceSelector:
+      kubernetes.io/metadata.name: kube-system
+    podSelector:
+      k8s-app: kube-dns
+  ingress: []
+  egress: []
+
+serviceMonitor:
+  enabled: false
+  labels: {}
+  annotations: {}
+  interval: 15s
+  scrapeTimeout: 10s
+  path: /metrics
+  namespaceSelector: {}
+  authorization:
+    secretName: ""
+    secretKey: token
+
+migrationJob:
+  enabled: true
+  managedExternally: false
+  useV2Resolver: true
+  serviceAccountName: default
+  activeDeadlineSeconds: 900
+  backoffLimit: 4
+  ttlSecondsAfterFinished: 86400
+  annotations: {}
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  hooks:
+    helm:
+      enabled: true
+      weight: 0
+    argocd:
+      enabled: false
+
+extraInitContainers: []
+extraContainers: []
+extraVolumes: []
+extraVolumeMounts: []
+
+tests:
+  enabled: true
+  image:
+    repository: curlimages/curl
+    tag: 8.12.1
+    digest: ""
+    pullPolicy: IfNotPresent

--- a/helm/michelangelo-llm-gateway/values.yaml
+++ b/helm/michelangelo-llm-gateway/values.yaml
@@ -214,5 +214,5 @@ tests:
   image:
     repository: curlimages/curl
     tag: 8.12.1
-    digest: ""
+    digest: sha256:94e9e444bcba979c2ea12e27ae39bee4cd10bc7041a472c4727a558e213744e6
     pullPolicy: IfNotPresent


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**

- Added a standalone, independently versioned `michelangelo-llm-gateway` Helm chart for LiteLLM v1.85.1 with multi-architecture image digest pins.
- Added existing Secret and ConfigMap contracts, fail-closed Helm and Argo CD migration modes, externally managed migrations, authenticated Helm tests, and optional Ingress, NetworkPolicy, ServiceMonitor, HPA, PodDisruptionBudget, and topology spread resources.
- Added strict values validation, a GCP example, compatibility coverage, packaging checks, and a guarded GHCR publication workflow.

**Why?**

Provide the reusable Milestone 1 data-plane package for running LiteLLM alongside Michelangelo without coupling inference traffic to the Michelangelo control plane. Milestone 0 runtime validation, project reconciliation, caller credential delivery, provider infrastructure, and production platform controls remain separate work.

**How did you test it?**

- Ran `bash .github/scripts/validate-llm-gateway-chart.sh` with Helm 3.12.0 and Helm 4.1.0, including strict lint, every supported render profile, invalid-value rejection, private-registry rendering, and chart packaging.
- Ran `shellcheck .github/scripts/validate-llm-gateway-chart.sh` and `git diff --check`.
- Verified the LiteLLM and curl image tags, digests, and amd64/arm64 manifests with `docker buildx imagetools inspect`.
- Real GKE, Cloud SQL, External Secrets Operator, Prometheus Operator, provider traffic, migration rollback, and uninstall validation are still required before the first production release.

**Potential risks**

- The upstream LiteLLM database image runs as root, so production requires a validated hardened image or an explicit policy exception.
- Database migrations are not reversed by Helm rollback and require backward-compatible changes or a tested Cloud SQL recovery path.
- The chart depends on externally provisioned PostgreSQL, Secrets, provider access, private networking, and environment-specific policy resources.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

Adds the opt-in `michelangelo-llm-gateway` Helm chart at version 1.0.0 for independent OCI publication. Existing Michelangelo chart installations are unchanged.

**Documentation Changes**

Added the chart README and GCP example, and linked the new data-plane chart from the Helm configuration and operator documentation.
