### PR TITLE
feat(native_transform): add IDHashTokenizer torch layer (PR A2)

### DIFF
--- a/python/michelangelo/lib/native_transform/__init__.py
+++ b/python/michelangelo/lib/native_transform/__init__.py
@@ -1,1 +1,5 @@
-"""Native transform layers for Michelangelo feature transformation."""
+"""Native transform layers for Michelangelo feature transformation.
+
+Seeds the native_transform migration with initial transform layers; the full
+transform DAG (TransformSpec, TorchTransformModule, etc.) lands in a follow-up PR.
+"""

--- a/python/michelangelo/lib/native_transform/__init__.py
+++ b/python/michelangelo/lib/native_transform/__init__.py
@@ -1,0 +1,1 @@
+"""Native transform layers for Michelangelo feature transformation."""

--- a/python/michelangelo/lib/native_transform/torch/__init__.py
+++ b/python/michelangelo/lib/native_transform/torch/__init__.py
@@ -1,0 +1,5 @@
+"""PyTorch native transform layers.
+
+TorchScript- and ONNX-exportable ``nn.Module`` layers used to build native
+feature transforms that run identically at train and serve time.
+"""

--- a/python/michelangelo/lib/native_transform/torch/__init__.py
+++ b/python/michelangelo/lib/native_transform/torch/__init__.py
@@ -3,3 +3,9 @@
 TorchScript- and ONNX-exportable ``nn.Module`` layers used to build native
 feature transforms that run identically at train and serve time.
 """
+
+from michelangelo.lib.native_transform.torch.id_hash_tokenizer import (
+    IDHashTokenizer,
+)
+
+__all__ = ["IDHashTokenizer"]

--- a/python/michelangelo/lib/native_transform/torch/id_hash_tokenizer.py
+++ b/python/michelangelo/lib/native_transform/torch/id_hash_tokenizer.py
@@ -1,0 +1,187 @@
+"""ID-hash tokenizer layer for native feature transforms.
+
+Maps arbitrary integer input values to contiguous, zero-based indices based on a
+provided vocabulary, mapping out-of-vocabulary values to a dedicated unknown
+index. The layer is TorchScript- and ONNX-exportable so it can be embedded in a
+model graph and run identically at train and serve time.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import torch
+from torch import nn
+
+__all__ = ["IDHashTokenizer"]
+
+
+class IDHashTokenizer(nn.Module):
+    """Map integer IDs to contiguous vocabulary indices.
+
+    Maps arbitrary input integer values to new, contiguous integer indices based
+    on a provided vocabulary. Values not found in the vocabulary are mapped to an
+    unknown index, which is set to the size of the (deduplicated) vocabulary.
+
+    The input ``vocabulary`` may be unsorted. The mapping from an original
+    vocabulary value to its new index is based on its position in the *provided*
+    vocabulary list (i.e. ``vocabulary[i]`` maps to ``i``). Internally the values
+    are sorted for an efficient :func:`torch.bucketize` lookup, then remapped back
+    to their original positions, so ordering of the provided list is preserved in
+    the output indices.
+
+    The layer is compatible with both TorchScript and ONNX export.
+
+    Args:
+        vocabulary: List of integer values to map to contiguous indices. Duplicate
+            values are removed, preserving the index of their first occurrence.
+
+    Raises:
+        TypeError: If ``vocabulary`` is not a list of integers.
+
+    Example:
+        >>> tokenizer = IDHashTokenizer(vocabulary=[-10, -3, 0, 2, 4, 6])
+        >>> tokenizer(torch.tensor([-10, 0, 5], dtype=torch.long))
+        tensor([0, 2, 6])
+    """
+
+    def __init__(self, vocabulary: list[int]) -> None:
+        """Initialize the tokenizer from a vocabulary of integer values.
+
+        Args:
+            vocabulary: List of integer values to map to contiguous indices.
+                Duplicate values are removed, preserving the index of their first
+                occurrence.
+
+        Raises:
+            TypeError: If ``vocabulary`` is not a list of integers.
+        """
+        super().__init__()
+        # Validate input vocabulary type.
+        if not isinstance(vocabulary, list) or not all(
+            isinstance(v, int) for v in vocabulary
+        ):
+            raise TypeError("Vocabulary must be a list of integers.")
+
+        # Deduplicate while preserving original order. If duplicates exist (e.g.
+        # [10, 20, 10]), only the first occurrence is kept and its original index
+        # is used for the mapping.
+        unique_vocab_values: list[int] = []
+        seen_values: set[int] = set()
+        for v in vocabulary:
+            if v not in seen_values:
+                unique_vocab_values.append(v)
+                seen_values.add(v)
+
+        if len(unique_vocab_values) != len(vocabulary):
+            warnings.warn(
+                "Duplicate values found in vocabulary. Only unique values will be "
+                "used, preserving the index of their first occurrence. Original "
+                f"size: {len(vocabulary)}, effective unique size: "
+                f"{len(unique_vocab_values)}.",
+                stacklevel=2,
+            )
+
+        # Store the effective unique vocabulary (preserving original order).
+        self.vocabulary = unique_vocab_values
+
+        # The unknown index is one past the last valid mapped index.
+        self.unk_index = len(self.vocabulary)
+        self.output_vocab_size = len(self.vocabulary)
+
+        # Map each unique vocabulary value to its original desired output index
+        # (its position in ``self.vocabulary``).
+        value_to_original_idx_map = {
+            val: idx for idx, val in enumerate(self.vocabulary)
+        }
+
+        # Sorted unique values used by torch.bucketize for efficient lookup.
+        sorted_unique_values = sorted(self.vocabulary)
+        self.register_buffer(
+            "_sorted_unique_values_tensor",
+            torch.tensor(sorted_unique_values, dtype=torch.long),
+            persistent=True,  # Saved with the model and moved by ``.to(device)``.
+        )
+
+        # Map from an index in ``_sorted_unique_values_tensor`` back to the value's
+        # *original* index in ``self.vocabulary``, preserving the caller's desired
+        # mapping order. Example: vocabulary=[0, -10] -> sorted=[-10, 0]; -10
+        # (sorted index 0) was at original index 1 and 0 (sorted index 1) was at
+        # original index 0, so this mapping is [1, 0].
+        sorted_to_original_idx_mapping = [
+            value_to_original_idx_map[val] for val in sorted_unique_values
+        ]
+        self.register_buffer(
+            "_sorted_to_original_idx_mapping_tensor",
+            torch.tensor(sorted_to_original_idx_mapping, dtype=torch.long),
+            persistent=True,  # Saved with the model and moved by ``.to(device)``.
+        )
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        """Map input integer IDs to contiguous vocabulary indices.
+
+        Values not found in the vocabulary are mapped to :attr:`unk_index`.
+
+        Args:
+            input_ids: Tensor of integer IDs of any shape (e.g.
+                ``(batch_size, sequence_length)``). Must have dtype
+                ``torch.int32`` or ``torch.long``.
+
+        Returns:
+            Tensor of mapped indices with the same shape and dtype as
+            ``input_ids``.
+
+        Raises:
+            TypeError: If ``input_ids`` is not of integer type (``torch.int32`` or
+                ``torch.long``).
+        """
+        # Ensure input tensor is of integer type.
+        if input_ids.dtype != torch.int32 and input_ids.dtype != torch.long:
+            raise TypeError(
+                "Input tensor must be of integer type (torch.int32 or "
+                f"torch.long), but got {input_ids.dtype}."
+            )
+
+        input_dtype = input_ids.dtype
+
+        # torch.bucketize and tensor indexing work best with long.
+        input_ids_long = input_ids.to(torch.long)
+
+        # Step 1: Find potential mapped indices within the *sorted* vocabulary.
+        # torch.bucketize returns indices in [0, len(sorted)]; a value equal to
+        # len(sorted) means the input is >= the last sorted vocabulary element.
+        potential_sorted_indices = torch.bucketize(
+            input_ids_long, self._sorted_unique_values_tensor
+        )
+
+        # Step 2: Clamp to valid tensor bounds [0, size-1] to prevent IndexError
+        # on the lookups below. ``is_known_mask`` re-identifies clamped
+        # out-of-range values as unknown.
+        clamped_sorted_indices = torch.clamp(
+            potential_sorted_indices, 0, self.output_vocab_size - 1
+        )
+
+        # Step 3: Retrieve the vocabulary value at each clamped index, then compare
+        # it to the original input to confirm the value is actually present.
+        retrieved_value_from_sorted_vocab = self._sorted_unique_values_tensor[
+            clamped_sorted_indices
+        ]
+
+        # Step 4: A value is "known" if its ID matches the retrieved value AND the
+        # (unclamped) bucketize result was within the vocabulary bounds.
+        is_known_mask = (input_ids_long == retrieved_value_from_sorted_vocab) & (
+            potential_sorted_indices < self.output_vocab_size
+        )
+
+        # Step 5: For known values, remap the sorted index back to the value's
+        # original position in the provided vocabulary; for unknown values, assign
+        # ``unk_index``. ``new_full`` keeps the constant on the input's device
+        # (avoids baking a literal device into a TorchScript trace).
+        mapped_to_original_indices = self._sorted_to_original_idx_mapping_tensor[
+            clamped_sorted_indices
+        ]
+        unk = input_ids_long.new_full((), self.unk_index)
+        output_ids = torch.where(is_known_mask, mapped_to_original_indices, unk)
+
+        # Match the input dtype on the way out.
+        return output_ids.to(input_dtype)

--- a/python/michelangelo/lib/native_transform/torch/id_hash_tokenizer.py
+++ b/python/michelangelo/lib/native_transform/torch/id_hash_tokenizer.py
@@ -32,12 +32,17 @@ class IDHashTokenizer(nn.Module):
 
     The layer is compatible with both TorchScript and ONNX export.
 
+    Despite the name "Hash", this performs an exact vocabulary lookup via
+    :func:`torch.bucketize` (not a hash); the name is kept for parity with the
+    internal SDK layer it was migrated from.
+
     Args:
         vocabulary: List of integer values to map to contiguous indices. Duplicate
             values are removed, preserving the index of their first occurrence.
 
     Raises:
         TypeError: If ``vocabulary`` is not a list of integers.
+        ValueError: If ``vocabulary`` is empty.
 
     Example:
         >>> tokenizer = IDHashTokenizer(vocabulary=[-10, -3, 0, 2, 4, 6])
@@ -55,6 +60,7 @@ class IDHashTokenizer(nn.Module):
 
         Raises:
             TypeError: If ``vocabulary`` is not a list of integers.
+            ValueError: If ``vocabulary`` is empty.
         """
         super().__init__()
         # Validate input vocabulary type.
@@ -62,6 +68,12 @@ class IDHashTokenizer(nn.Module):
             isinstance(v, int) for v in vocabulary
         ):
             raise TypeError("Vocabulary must be a list of integers.")
+
+        # An empty vocabulary leaves output_vocab_size == 0, which would collapse
+        # every lookup index to -1 in forward() and only fail there (potentially
+        # at serve time). Reject it up front with a clear message.
+        if not vocabulary:
+            raise ValueError("vocabulary must be non-empty.")
 
         # Deduplicate while preserving original order. If duplicates exist (e.g.
         # [10, 20, 10]), only the first occurrence is kept and its original index

--- a/python/michelangelo/lib/native_transform/torch/id_hash_tokenizer.py
+++ b/python/michelangelo/lib/native_transform/torch/id_hash_tokenizer.py
@@ -161,7 +161,7 @@ class IDHashTokenizer(nn.Module):
 
         # Step 1: Find potential mapped indices within the *sorted* vocabulary.
         # torch.bucketize returns indices in [0, len(sorted)]; a value equal to
-        # len(sorted) means the input is >= the last sorted vocabulary element.
+        # len(sorted) means the input is > the last sorted vocabulary element.
         potential_sorted_indices = torch.bucketize(
             input_ids_long, self._sorted_unique_values_tensor
         )

--- a/python/michelangelo/lib/native_transform/torch/tests/__init__.py
+++ b/python/michelangelo/lib/native_transform/torch/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the native transform torch layers."""

--- a/python/michelangelo/lib/native_transform/torch/tests/test_id_hash_tokenizer.py
+++ b/python/michelangelo/lib/native_transform/torch/tests/test_id_hash_tokenizer.py
@@ -141,6 +141,9 @@ class TestIDHashTokenizer:
 
     def test_onnx_export(self, tokenizer: IDHashTokenizer, tmp_path) -> None:
         """The module exports to ONNX and reproduces eager output via ORT."""
+        # ``torch.onnx.export`` needs ``onnx`` and the session needs
+        # ``onnxruntime``; skip cleanly if either is missing.
+        pytest.importorskip("onnx")
         ort = pytest.importorskip("onnxruntime")
         import torch.onnx
 

--- a/python/michelangelo/lib/native_transform/torch/tests/test_id_hash_tokenizer.py
+++ b/python/michelangelo/lib/native_transform/torch/tests/test_id_hash_tokenizer.py
@@ -129,6 +129,11 @@ class TestIDHashTokenizer:
         with pytest.raises(TypeError, match="list of integers"):
             IDHashTokenizer(vocabulary=[1.0, 2.0])  # type: ignore[list-item]
 
+    def test_rejects_empty_vocabulary(self) -> None:
+        """An empty vocabulary raises ``ValueError`` at construction time."""
+        with pytest.raises(ValueError, match="non-empty"):
+            IDHashTokenizer(vocabulary=[])
+
     def test_rejects_non_integer_input(self, tokenizer: IDHashTokenizer) -> None:
         """A float input tensor raises ``TypeError``."""
         with pytest.raises(TypeError, match="integer type"):

--- a/python/michelangelo/lib/native_transform/torch/tests/test_id_hash_tokenizer.py
+++ b/python/michelangelo/lib/native_transform/torch/tests/test_id_hash_tokenizer.py
@@ -1,0 +1,167 @@
+"""Tests for :mod:`michelangelo.lib.native_transform.torch.id_hash_tokenizer`.
+
+Covers :class:`IDHashTokenizer` mapping of integer IDs to contiguous vocabulary
+indices: 2D and 1D inputs, all-out-of-vocabulary inputs, unsorted vocabularies,
+duplicate-vocabulary warning, and both TorchScript and ONNX export round-trips.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+# These layers operate on real torch tensors/modules. Skip cleanly if torch is
+# unavailable in a lightweight environment.
+torch = pytest.importorskip("torch")
+
+from michelangelo.lib.native_transform.torch.id_hash_tokenizer import (  # noqa: E402
+    IDHashTokenizer,
+)
+
+CUSTOM_VOCAB = [-10, -3, 0, 2, 4, 6]
+
+
+@pytest.fixture
+def tokenizer() -> IDHashTokenizer:
+    """Return an ``IDHashTokenizer`` over ``CUSTOM_VOCAB`` in eval mode."""
+    module = IDHashTokenizer(vocabulary=CUSTOM_VOCAB)
+    module.eval()
+    return module
+
+
+class TestIDHashTokenizer:
+    """Mapping, export, and edge-case behavior of :class:`IDHashTokenizer`."""
+
+    def test_2d_lookup(self, tokenizer: IDHashTokenizer) -> None:
+        """A 2D batch maps known values by position and unknowns to unk_index."""
+        input_batch = torch.tensor(
+            [
+                [-10, 2, 0, 6],  # All from vocab.
+                [0, -3, 5, 4],  # 5 is unknown.
+                [10, -10, 2, -100],  # 10 and -100 are unknown.
+            ],
+            dtype=torch.int32,
+        )
+        expected = torch.tensor(
+            [
+                [0, 3, 2, 5],
+                [2, 1, 6, 4],
+                [6, 0, 3, 6],
+            ],
+            dtype=torch.int32,
+        )
+        output = tokenizer(input_batch)
+        assert torch.equal(expected, output)
+
+    def test_1d_lookup(self, tokenizer: IDHashTokenizer) -> None:
+        """A 1D sequence is mapped element-wise, unknowns to unk_index."""
+        input_seq = torch.tensor([4, -3, 999, 6], dtype=torch.long)
+        expected = torch.tensor([4, 1, 6, 5], dtype=torch.long)
+        output = tokenizer(input_seq)
+        assert torch.equal(expected, output)
+
+    def test_all_unknown(self, tokenizer: IDHashTokenizer) -> None:
+        """Inputs entirely outside the vocabulary all map to unk_index."""
+        input_all_unknown = torch.tensor([[100, 200], [-5, -1000]], dtype=torch.int32)
+        expected = torch.tensor([[6, 6], [6, 6]], dtype=torch.int32)
+        output = tokenizer(input_all_unknown)
+        assert torch.equal(expected, output)
+
+    def test_non_sorted_vocab(self) -> None:
+        """An unsorted vocabulary maps by its provided-list position."""
+        module = IDHashTokenizer(vocabulary=[-3, -10, 0, 2, 4, 6])
+        module.eval()
+        input_batch = torch.tensor(
+            [
+                [-10, 2, 0, 6],
+                [0, -3, 5, 4],
+                [10, -10, 2, -100],
+            ],
+            dtype=torch.int32,
+        )
+        expected = torch.tensor(
+            [
+                [1, 3, 2, 5],
+                [2, 0, 6, 4],
+                [6, 1, 3, 6],
+            ],
+            dtype=torch.int32,
+        )
+        output = module(input_batch)
+        assert torch.equal(expected, output)
+
+    def test_torchscript_roundtrip(self, tokenizer: IDHashTokenizer, tmp_path) -> None:
+        """The module scripts, saves, loads, and reproduces eager output.
+
+        native_transform layers must be TorchScript-exportable so the exact
+        transform runs at serve time; this guards that contract.
+        """
+        input_batch = torch.tensor(
+            [
+                [-10, 2, 0, 6],
+                [0, -3, 5, 4],
+                [10, -10, 2, -100],
+            ],
+            dtype=torch.int32,
+        )
+        eager_output = tokenizer(input_batch)
+
+        scripted = torch.jit.script(tokenizer)
+        assert torch.equal(eager_output, scripted(input_batch))
+
+        model_path = tmp_path / "id_hash_tokenizer_scripted.pt"
+        scripted.save(str(model_path))
+        loaded = torch.jit.load(str(model_path))
+        assert torch.equal(eager_output, loaded(input_batch))
+
+    def test_duplicate_vocab_warns_and_dedupes(self) -> None:
+        """Duplicate vocabulary values warn and are deduplicated by first index."""
+        with pytest.warns(UserWarning, match="Duplicate values"):
+            module = IDHashTokenizer(vocabulary=[10, 20, 10])
+        assert module.vocabulary == [10, 20]
+        assert module.unk_index == 2
+        # First occurrence of 10 -> index 0, 20 -> index 1, unknown -> 2.
+        output = module(torch.tensor([10, 20, 30], dtype=torch.long))
+        assert torch.equal(output, torch.tensor([0, 1, 2], dtype=torch.long))
+
+    def test_rejects_non_integer_vocabulary(self) -> None:
+        """A non-integer vocabulary raises ``TypeError``."""
+        with pytest.raises(TypeError, match="list of integers"):
+            IDHashTokenizer(vocabulary=[1.0, 2.0])  # type: ignore[list-item]
+
+    def test_rejects_non_integer_input(self, tokenizer: IDHashTokenizer) -> None:
+        """A float input tensor raises ``TypeError``."""
+        with pytest.raises(TypeError, match="integer type"):
+            tokenizer(torch.tensor([1.0, 2.0], dtype=torch.float32))
+
+    def test_onnx_export(self, tokenizer: IDHashTokenizer, tmp_path) -> None:
+        """The module exports to ONNX and reproduces eager output via ORT."""
+        ort = pytest.importorskip("onnxruntime")
+        import torch.onnx
+
+        onnx_model_path = str(tmp_path / "id_hash_tokenizer.onnx")
+        dummy_input = torch.tensor([[0, 2, -10]], dtype=torch.int32)
+        torch.onnx.export(
+            tokenizer,
+            dummy_input,
+            onnx_model_path,
+            export_params=True,
+            opset_version=14,
+            do_constant_folding=True,
+            input_names=["input_ids"],
+            output_names=["mapped_ids"],
+            dynamic_axes={
+                "input_ids": {0: "batch_size", 1: "sequence_length"},
+                "mapped_ids": {0: "batch_size", 1: "sequence_length"},
+            },
+        )
+
+        session = ort.InferenceSession(
+            onnx_model_path, providers=["CPUExecutionProvider"]
+        )
+        test_input = torch.tensor(
+            [[-10, 2, 0, 6], [10, -3, 100, 4]], dtype=torch.int32
+        ).numpy()
+        ort_output = session.run(None, {"input_ids": test_input})[0]
+        eager_output = tokenizer(torch.from_numpy(test_input)).numpy()
+        assert np.array_equal(eager_output, ort_output)


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Adds a new `michelangelo/lib/native_transform/torch/` package containing `IDHashTokenizer`, a small, pure-`torch` `nn.Module`:

- `IDHashTokenizer(nn.Module)` in `id_hash_tokenizer.py` — maps arbitrary integer IDs to contiguous, zero-based vocabulary indices, mapping any out-of-vocabulary value to a dedicated unknown index (`len(vocabulary)`). This is the standard "tokenize integer IDs into an embedding-table row index" building block used when embedding categorical/id features in a model.
  - Accepts an **unsorted** vocabulary and preserves the provided-list position as the output index (`vocabulary[i]` maps to `i`); internally it sorts for an efficient `torch.bucketize` lookup and remaps back, so caller ordering is honored.
  - Deduplicates the vocabulary, keeping the first occurrence (and warns via `warnings.warn` when duplicates are dropped).
  - Is both **TorchScript-** and **ONNX-exportable** via buffer-backed lookup tables, so the exact same transform runs at train and serve time.
- Seeds the new `lib/native_transform/` and `lib/native_transform/torch/` packages (with `__init__.py`s), and re-exports `IDHashTokenizer` at the package level so consumers can `from michelangelo.lib.native_transform.torch import IDHashTokenizer`.

Code-quality notes:
- `forward` builds the unknown-index constant with `input_ids_long.new_full((), self.unk_index)` so the constant follows the input's device instead of baking a literal device into a TorchScript trace.
- Google-style docstrings (Args/Returns/Raises) and full type hints on the public API.

**Why?**

`IDHashTokenizer` is a self-contained, dependency-free (`torch` / `torch.nn` only) layer that a larger follow-up PR will build on to assemble native feature-transform graphs. Landing it standalone keeps that follow-up's diff focused on the layer-registry logic, and makes this primitive independently reviewable and reusable on its own.

**How did you test it?**

- `pytest michelangelo/lib/native_transform/torch/tests/test_id_hash_tokenizer.py` → 9 passed, 1 skipped (the ONNX round-trip test skips when `onnx`/`onnxruntime` are absent)
- Tests cover 2D and 1D lookups, all-out-of-vocabulary input, an unsorted vocabulary, a **TorchScript `torch.jit.script` + save/load round-trip** (guards the serving-path contract), a duplicate-vocabulary warning, empty/non-integer vocabulary rejection, non-integer input rejection, and an **ONNX export + onnxruntime** round-trip
- Module coverage: 100% on `id_hash_tokenizer.py`, above the 85% bar
- `ruff format --check` + `ruff check` clean on all touched files (also enforced by pre-commit)

**Potential risks**

Low. `IDHashTokenizer` is a new public class with no existing callers in this repo yet — nothing downstream can regress. Pure-`torch`, no external infra coupling. TorchScript and ONNX export are both covered by tests to protect the serving path.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

N/A — new layer in the `native_transform` library; no existing callers, not yet wired into a user-facing entry point.

**Documentation Changes**

Google-style docstrings (Args/Returns/Raises) added on the new public class, its `__init__`, and `forward`, plus module- and package-level docstrings.

Closes #1538