### PR TITLE
fix(helm): allow x-user-email header in envoy CORS preflight

### DIFF
--- a/helm/michelangelo/templates/core/envoy-configmap.yaml
+++ b/helm/michelangelo/templates/core/envoy-configmap.yaml
@@ -36,7 +36,7 @@ data:
                               - safe_regex:
                                   regex: {{ .Values.envoy.corsOrigins | default ".*" | quote }}
                             allow_methods: "GET, POST, OPTIONS"
-                            allow_headers: "connect-protocol-version,connect-timeout-ms,content-type,context-ttl-ms,grpc-timeout,rpc-caller,rpc-encoding,rpc-service,x-grpc-web,x-user-agent"
+                            allow_headers: "connect-protocol-version,connect-timeout-ms,content-type,context-ttl-ms,grpc-timeout,rpc-caller,rpc-encoding,rpc-service,x-grpc-web,x-user-agent,x-user-email"
                             max_age: "1728000"
                             expose_headers: "grpc-status,grpc-message"
                     http_filters:


### PR DESCRIPTION
## What changed
Added `x-user-email` to Envoy's CORS `allow_headers` list in `helm/michelangelo/templates/core/envoy-configmap.yaml`.

## Why
#1512 added `x-user-email` as a header the frontend sends on every RPC request (`javascript/packages/core/providers/user-provider/use-user-request-headers.ts`), but envoy's CORS config was never updated to permit it. Every browser API call now fails CORS preflight with:

```
Request header field x-user-email is not allowed by Access-Control-Allow-Headers in preflight response.
```

This breaks the UI entirely — confirmed on a fresh sandbox running `v0.5.0-rc.1` artifacts while dry-running the new release-test procedure.

Fixes #1551.

## How did you test it
`helm lint` and `helm template` against `values-k3d.yaml` confirm the ConfigMap renders correctly with the new header. Verified end-to-end against a live sandbox: after applying this fix, the UI's `ListPipelineRun` call (previously failing with the CORS error above) succeeds.

## Potential risks
None — purely additive to an allowlist.

## Breaking Changes
None.

## Release notes
Fixes a regression where the UI's identity-propagation headers (#1512) were blocked by Envoy's CORS policy.