### PR TITLE
fix(helm): allow x-user-email header in envoy CORS preflight [release/v0.5]

### DIFF
--- a/helm/michelangelo/templates/core/envoy-configmap.yaml
+++ b/helm/michelangelo/templates/core/envoy-configmap.yaml
@@ -36,7 +36,7 @@ data:
                               - safe_regex:
                                   regex: {{ .Values.envoy.corsOrigins | default ".*" | quote }}
                             allow_methods: "GET, POST, OPTIONS"
-                            allow_headers: "connect-protocol-version,connect-timeout-ms,content-type,context-ttl-ms,grpc-timeout,rpc-caller,rpc-encoding,rpc-service,x-grpc-web,x-user-agent"
+                            allow_headers: "connect-protocol-version,connect-timeout-ms,content-type,context-ttl-ms,grpc-timeout,rpc-caller,rpc-encoding,rpc-service,x-grpc-web,x-user-agent,x-user-email"
                             max_age: "1728000"
                             expose_headers: "grpc-status,grpc-message"
                     http_filters:


### PR DESCRIPTION
## What changed
Cherry-pick of #1552 onto `release/v0.5`. Adds `x-user-email` to Envoy's CORS `allow_headers` list in `helm/michelangelo/templates/core/envoy-configmap.yaml`.

## Why
`v0.5.0-rc.1` ships with the UI-breaking CORS regression described in #1551 — every browser API call fails preflight because `x-user-email` (added by #1512) isn't in Envoy's `allow_headers`. This needs to land on the release branch so a `v0.5.0-rc.2` can be cut with the fix before promoting to final. See #1552 for the main-branch fix and full details.

Fixes #1551.

## How did you test it
Same as #1552 — `helm lint`/`helm template` render correctly, and verified end-to-end against a live sandbox running `v0.5.0-rc.1` artifacts (previously-failing `ListPipelineRun` UI call succeeds after this fix).

## Potential risks
None — purely additive to an allowlist.

## Breaking Changes
None.

## Release notes
Fixes a regression where the UI's identity-propagation headers (#1512) were blocked by Envoy's CORS policy. Recommend cutting `v0.5.0-rc.2` with this fix before promoting `v0.5.0` to final.