### PR TITLE
feat(sandbox): support --set on ma sandbox create

### DIFF
--- a/python/michelangelo/cli/sandbox/README.md
+++ b/python/michelangelo/cli/sandbox/README.md
@@ -98,6 +98,20 @@ To skip Cadence, use `--workflow temporal` instead — Cadence is bundled with t
 ma sandbox create --include-experimental fluent-bit mlflow
 ```
 
+## Pinning Image Tags
+
+By default the control plane images (`apiserver`, `worker`, `ui`, `controllermgr`) track `main`. Use `--set` to pin them to a specific released version instead — for example, to validate a release candidate:
+
+```bash
+ma sandbox create \
+  --set images.apiserver.tag=0.5.0-rc.1 \
+  --set images.worker.tag=0.5.0-rc.1 \
+  --set images.ui.tag=0.5.0-rc.1 \
+  --set images.controllermgr.tag=0.5.0-rc.1
+```
+
+`--set KEY=VALUE` accepts any Helm value override and can be repeated; it's passed straight through to `helm install`/`helm upgrade`. `ma sandbox sync` supports the same flag.
+
 ## Local Service URLs
 
 | Service | URL | Notes |

--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -142,6 +142,14 @@ def init_arguments(p: argparse.ArgumentParser):
         default=[],
     )
     create_p.add_argument(
+        "--set",
+        dest="helm_set",
+        metavar="KEY=VALUE",
+        action="append",
+        default=[],
+        help="Pass arbitrary --set KEY=VALUE flags through to helm upgrade/install.",
+    )
+    create_p.add_argument(
         "--compute-cluster-name",
         default=_default_compute_kube_cluster_name,
         help=(

--- a/python/tests/cli/sandbox/test_sandbox.py
+++ b/python/tests/cli/sandbox/test_sandbox.py
@@ -433,4 +433,3 @@ class ArgumentParsingTest(TestCase):
         """`ma sandbox create` without --set should default helm_set to []."""
         ns = self._parse(["create"])
         self.assertEqual(ns.helm_set, [])
-

--- a/python/tests/cli/sandbox/test_sandbox.py
+++ b/python/tests/cli/sandbox/test_sandbox.py
@@ -403,3 +403,34 @@ current-context: test-context
             "not found" in str(c) and "skipping deletion" in str(c) for c in print_calls
         )
         self.assertTrue(skip_message_found, "Skip message should be printed")
+
+
+class ArgumentParsingTest(TestCase):
+    """Tests for CLI argument parsing."""
+
+    def _parse(self, args):
+        parser = argparse.ArgumentParser()
+        sandbox.init_arguments(parser)
+        return parser.parse_args(args)
+
+    def test_create_accepts_set_flag(self):
+        """`ma sandbox create --set` should parse into ns.helm_set, same as sync."""
+        ns = self._parse(
+            [
+                "create",
+                "--set",
+                "images.apiserver.tag=0.5.0-rc.1",
+                "--set",
+                "images.worker.tag=0.5.0-rc.1",
+            ]
+        )
+        self.assertEqual(
+            ns.helm_set,
+            ["images.apiserver.tag=0.5.0-rc.1", "images.worker.tag=0.5.0-rc.1"],
+        )
+
+    def test_create_set_defaults_to_empty(self):
+        """`ma sandbox create` without --set should default helm_set to []."""
+        ns = self._parse(["create"])
+        self.assertEqual(ns.helm_set, [])
+


### PR DESCRIPTION
## What changed
Added the same `--set KEY=VALUE` argument to `create_p` that `sync_p` already had, in `python/michelangelo/cli/sandbox/sandbox.py`. Added a usage example to the sandbox README and two argument-parsing tests.

## Why
`ma sandbox create` had no `--set` passthrough at all, so it always deployed `images.{apiserver,worker,ui,controllermgr}.tag: main` (hardcoded in `values-k3d.yaml`). Only `ma sandbox sync` supported `--set`, and only because it falls back to a full create when no cluster exists — an undocumented, confusing workaround rather than a real feature.

The plumbing that turns `ns.helm_set` into `helm --set` flags (`_build_helm_set_args`) is already shared and generic — it's called by both `_sync()` and `_deploy_app_services()` (which `_create()` calls), reading `getattr(ns, "helm_set", [])`. So `_create()`'s Helm install already applies `--set` overrides whenever they're present; `create_p` just never defined the argument in the first place, so `ns.helm_set` never existed on that path.

Fixes #1549.

## How did you test it
- Added `ArgumentParsingTest` with two tests: `--set` parses into `ns.helm_set` on `create`, and defaults to `[]` when omitted. `pytest tests/cli/sandbox/` — 16 passed.
- Manually verified end-to-end against a live sandbox: `ma sandbox create --set images.apiserver.tag=<rc> ...` on a fresh cluster deploys the pinned tag, confirmed via `helm get values michelangelo | grep -A5 images:` and `kubectl get pods -o jsonpath=...`.

## Potential risks
None — additive argparse change; existing `create` invocations without `--set` are unaffected (`ns.helm_set` defaults to `[]`, same as `sync`).

## Breaking Changes
None.

## Release notes
`ma sandbox create` now supports `--set KEY=VALUE` to pin Helm values (e.g. image tags), matching `ma sandbox sync`.