### PR TITLE
fix(helm): envoy checksum annotation + missing x-user-name CORS header

### DIFF
--- a/helm/michelangelo/templates/core/envoy-configmap.yaml
+++ b/helm/michelangelo/templates/core/envoy-configmap.yaml
@@ -36,7 +36,7 @@ data:
                               - safe_regex:
                                   regex: {{ .Values.envoy.corsOrigins | default ".*" | quote }}
                             allow_methods: "GET, POST, OPTIONS"
-                            allow_headers: "connect-protocol-version,connect-timeout-ms,content-type,context-ttl-ms,grpc-timeout,rpc-caller,rpc-encoding,rpc-service,x-grpc-web,x-user-agent,x-user-email"
+                            allow_headers: "connect-protocol-version,connect-timeout-ms,content-type,context-ttl-ms,grpc-timeout,rpc-caller,rpc-encoding,rpc-service,x-grpc-web,x-user-agent,x-user-email,x-user-name"
                             max_age: "1728000"
                             expose_headers: "grpc-status,grpc-message"
                     http_filters:

--- a/helm/michelangelo/templates/core/envoy-deployment.yaml
+++ b/helm/michelangelo/templates/core/envoy-deployment.yaml
@@ -13,6 +13,9 @@ spec:
       {{- include "michelangelo.componentSelectorLabels" (dict "context" . "component" "envoy") | nindent 6 }}
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/core/envoy-configmap.yaml") . | sha256sum }}
+        checksum/descriptors-config: {{ include (print $.Template.BasePath "/core/envoy-descriptors-configmap.yaml") . | sha256sum }}
       labels:
         {{- include "michelangelo.componentSelectorLabels" (dict "context" . "component" "envoy") | nindent 8 }}
     spec:


### PR DESCRIPTION
Two bugs found while re-verifying the v0.5.0-rc.2 CORS fix (#1552/#1553) against a live sandbox:

**1. Envoy deployment missing `checksum/config` annotation.** `apiserver`/`controllermgr` both force a rolling restart on ConfigMap change via this annotation; `envoy` never had one. So a plain `helm upgrade` with an envoy-configmap.yaml-only change (like the CORS fix itself) doesn't restart the pod — the fix silently doesn't take effect. Confirmed live: after deploying rc.2, the ConfigMap had the x-user-email fix but the running (unrestarted) envoy pod still rejected the preflight, until a manual `kubectl rollout restart`.

**2. `x-user-name` also missing from CORS `allow_headers`.** #1512 added both `x-user-email` and `x-user-name` to `useUserRequestHeaders()` (the single source of custom headers on every RPC call, confirmed via full audit of the frontend) at the same time, but #1552/#1553 only added `x-user-email` to the allowlist. Found live: project list failed in the UI with the same CORS error, this time for `x-user-name`.

**Verified end-to-end:** after this fix + a `helm upgrade` (envoy restarted automatically via the new checksum annotation, no manual restart needed), a preflight request now returns both `x-user-email` and `x-user-name` in `access-control-allow-headers`.