### PR TITLE
fix(helm): envoy checksum annotation + missing x-user-name CORS header [release/v0.5]

### DIFF
--- a/helm/michelangelo/templates/core/envoy-configmap.yaml
+++ b/helm/michelangelo/templates/core/envoy-configmap.yaml
@@ -36,7 +36,7 @@ data:
                               - safe_regex:
                                   regex: {{ .Values.envoy.corsOrigins | default ".*" | quote }}
                             allow_methods: "GET, POST, OPTIONS"
-                            allow_headers: "connect-protocol-version,connect-timeout-ms,content-type,context-ttl-ms,grpc-timeout,rpc-caller,rpc-encoding,rpc-service,x-grpc-web,x-user-agent,x-user-email"
+                            allow_headers: "connect-protocol-version,connect-timeout-ms,content-type,context-ttl-ms,grpc-timeout,rpc-caller,rpc-encoding,rpc-service,x-grpc-web,x-user-agent,x-user-email,x-user-name"
                             max_age: "1728000"
                             expose_headers: "grpc-status,grpc-message"
                     http_filters:

--- a/helm/michelangelo/templates/core/envoy-deployment.yaml
+++ b/helm/michelangelo/templates/core/envoy-deployment.yaml
@@ -13,6 +13,9 @@ spec:
       {{- include "michelangelo.componentSelectorLabels" (dict "context" . "component" "envoy") | nindent 6 }}
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/core/envoy-configmap.yaml") . | sha256sum }}
+        checksum/descriptors-config: {{ include (print $.Template.BasePath "/core/envoy-descriptors-configmap.yaml") . | sha256sum }}
       labels:
         {{- include "michelangelo.componentSelectorLabels" (dict "context" . "component" "envoy") | nindent 8 }}
     spec:


### PR DESCRIPTION
Cherry-pick of #1558 onto `release/v0.5` — see #1558 for full detail. Both fixes verified live against the v0.5.0-rc.2 sandbox: envoy now auto-restarts on ConfigMap change, and both `x-user-email`/`x-user-name` are correctly allowed in CORS preflight.