### PR TITLE
fix(rayjob): right-size submitter pod instead of cloning the head

### DIFF
--- a/go/components/jobs/client/k8sengine/mapper_test.go
+++ b/go/components/jobs/client/k8sengine/mapper_test.go
@@ -8,6 +8,7 @@ import (
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 
@@ -17,10 +18,51 @@ import (
 func TestMapper_MapGlobalJobToLocal(t *testing.T) {
 	m := Mapper{}
 
-	headPod := &corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"role": "head"}}}
+	headPod := &corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"role": "head"}},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: "ray-sa",
+			ImagePullSecrets:   []corev1.LocalObjectReference{{Name: "regcred"}},
+			Containers: []corev1.Container{{
+				Name:            "ray-head",
+				Image:           "ray:test",
+				ImagePullPolicy: corev1.PullIfNotPresent,
+				// Head-sized (and GPU) resources that must NOT leak into the submitter.
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:                    resource.MustParse("4"),
+						corev1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+					},
+				},
+			}},
+		},
+	}
 	workerPod := &corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"role": "worker"}}}
-	submitterPod := headPod.DeepCopy()
-	submitterPod.Spec.RestartPolicy = corev1.RestartPolicyNever
+
+	// The submitter reuses the head image + pull/auth settings but is right-sized
+	// (KubeRay-default CPU/mem, no GPU) and never inherits the head's resources.
+	submitterPod := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			RestartPolicy:      corev1.RestartPolicyNever,
+			ServiceAccountName: "ray-sa",
+			ImagePullSecrets:   []corev1.LocalObjectReference{{Name: "regcred"}},
+			Containers: []corev1.Container{{
+				Name:            "ray-job-submitter",
+				Image:           "ray:test",
+				ImagePullPolicy: corev1.PullIfNotPresent,
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("200Mi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+					},
+				},
+			}},
+		},
+	}
 
 	rayJob := &v2pb.RayJob{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-job"},

--- a/go/components/jobs/client/k8sengine/ray.go
+++ b/go/components/jobs/client/k8sengine/ray.go
@@ -41,11 +41,7 @@ func (m Mapper) mapRay(rayJob *v2pb.RayJob, jobClusterObject runtime.Object, clu
 	if !ok {
 		return nil, fmt.Errorf("expected *v2pb.RayCluster, got %T", jobClusterObject)
 	}
-	pod := rayCluster.GetSpec().Head.GetPod()
-	submitterPod := k8sptr.Deref(pod, corev1.PodTemplateSpec{})
-	// Kubernetes Jobs require restartPolicy to be either "OnFailure" or "Never"
-	submitterPod.Spec.RestartPolicy = corev1.RestartPolicyNever
-
+	head := k8sptr.Deref(rayCluster.GetSpec().Head.GetPod(), corev1.PodTemplateSpec{})
 	kubeRayJob := &rayv1.RayJob{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       RayJobKind,
@@ -63,14 +59,72 @@ func (m Mapper) mapRay(rayJob *v2pb.RayJob, jobClusterObject runtime.Object, clu
 			Entrypoint:               rayJob.Spec.Entrypoint,
 			TTLSecondsAfterFinished:  int32(300),
 			ShutdownAfterJobFinishes: true,
-			// kuberay 1.0 only support SubmitterPodTemplate for configuration submitter pod
-			// We need to allow user to configure the submitter pod template via ray task configuration
-			// Note: Add support for v1.2.2 kuberay once we upgrade to newer version
-			SubmitterPodTemplate: &submitterPod,
+			// Right-size the submitter pod rather than cloning the head. The submitter
+			// only runs `ray job submit` against the existing cluster, so it gets modest
+			// resources and none of the head's GPU or scheduling constraints — but it
+			// still reuses the head image and pull/auth settings so it can start in the
+			// same environment. See buildSubmitterPodTemplate.
+			SubmitterPodTemplate: buildSubmitterPodTemplate(head),
 		},
 	}
 
 	return kubeRayJob, nil
+}
+
+// submitterCPURequest, submitterMemRequest, submitterCPULimit and submitterMemLimit
+// mirror KubeRay's built-in default submitter sizing (GetDefaultSubmitterContainer):
+// modest and GPU-free, since the pod only runs `ray job submit`.
+const (
+	submitterCPURequest = "500m"
+	submitterMemRequest = "200Mi"
+	submitterCPULimit   = "1"
+	submitterMemLimit   = "1Gi"
+)
+
+// buildSubmitterPodTemplate builds a right-sized submitter pod template for the RayJob.
+//
+// KubeRay can default this itself when SubmitterPodTemplate is nil, but its default
+// drops pod-level settings the submitter needs to run in the same environment as the
+// cluster it targets — most importantly the container image pull policy (KubeRay's
+// default leaves it unset, so an image tagged :latest falls back to Always and cannot
+// use a preloaded/local-only image), plus image pull secrets and the service account.
+//
+// So instead of cloning the head pod (which would reserve head-sized, possibly GPU,
+// compute) or leaving the template nil, we construct a minimal submitter that reuses
+// the head image and its pull/auth settings while keeping modest resources and none of
+// the head's GPU or scheduling constraints.
+func buildSubmitterPodTemplate(head corev1.PodTemplateSpec) *corev1.PodTemplateSpec {
+	var image string
+	var pullPolicy corev1.PullPolicy
+	if len(head.Spec.Containers) > 0 {
+		image = head.Spec.Containers[0].Image
+		pullPolicy = head.Spec.Containers[0].ImagePullPolicy
+	}
+	return &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			// Kubernetes Jobs require restartPolicy to be either "OnFailure" or "Never".
+			RestartPolicy:      corev1.RestartPolicyNever,
+			ImagePullSecrets:   head.Spec.ImagePullSecrets,
+			ServiceAccountName: head.Spec.ServiceAccountName,
+			Containers: []corev1.Container{
+				{
+					Name:            "ray-job-submitter",
+					Image:           image,
+					ImagePullPolicy: pullPolicy,
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse(submitterCPURequest),
+							corev1.ResourceMemory: resource.MustParse(submitterMemRequest),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse(submitterCPULimit),
+							corev1.ResourceMemory: resource.MustParse(submitterMemLimit),
+						},
+					},
+				},
+			},
+		},
+	}
 }
 
 func (m Mapper) mapRayCluster(rayCluster *v2pb.RayCluster) (runtime.Object, error) {


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

`mapRay` no longer clones the RayCluster head pod template into the KubeRay `RayJob.Spec.SubmitterPodTemplate`. Instead it builds a minimal, right-sized submitter template (`buildSubmitterPodTemplate`): a single `ray-job-submitter` container using the head image with modest resources (500m/200Mi requests, 1/1Gi limits) and `RestartPolicy: Never`. It reuses only the pod-level settings the submitter needs to start in the same environment as its target cluster — `imagePullPolicy`, `imagePullSecrets`, and `serviceAccountName` — and deliberately omits the head's GPU request, `nodeSelector`, `tolerations`, and `affinity`. The stale comment about upgrading to kuberay v1.2.2 (already pinned in `go.mod`) is removed, and the mapper unit test is updated accordingly.

**Why?**

The submitter pod only runs `ray job submit` against an already-running cluster (we always select an existing cluster via `ClusterSelector`). Cloning the head spec made this trivial pod reserve head-sized CPU/memory — and because the head spec can carry GPU requests and GPU node scheduling, it could needlessly reserve scarce GPU compute as well.

KubeRay can default the submitter itself when the template is nil, and its default sizing matches what we set here (500m/200Mi requests, 1/1Gi limits, head image, no GPU — identical on [1.2.2](https://github.com/ray-project/kuberay/blob/v1.2.2/ray-operator/controllers/ray/common/job.go#L121-L145) and 1.6.1). But that nil-default drops the container `imagePullPolicy` (and pull secrets / service account): an image tagged `:latest` then falls back to `Always` and cannot use a preloaded or local-only image, which breaks environments that don't push the task image to a registry. Building the template ourselves keeps the right-sizing while preserving the pull/auth settings the submitter needs.

**How did you test it?**

- `bazel test //go/components/jobs/client/k8sengine:go_default_test` — updated to assert the submitter inherits the head image + pull/auth but is right-sized (500m/200Mi, no GPU).
- End-to-end on the OSS sandbox: ran a remote Uniflow pipeline and confirmed the submitter pod is `500m/200Mi` with no GPU, pulls the local-only image via `IfNotPresent` (no `ImagePullBackOff`), and the RayJob reaches `SUCCEEDED`.

**Potential risks**

Low. The change only affects the submitter pod created for new Ray jobs; existing clusters and running jobs are unaffected. The submitter still derives its image and pull/auth from the head, so it starts in the same environment as the cluster it targets.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

Ray job submitter pods are now right-sized (modest CPU/memory, no GPU) instead of inheriting the head pod's resources, while still reusing the head image and image pull/service-account settings so they start correctly.

**Documentation Changes**

None.
