### PR TITLE
feat(ray): make RayJob TTL configurable, increase default to 30 min

### DIFF
--- a/go/cmd/controllermgr/config/base.yaml
+++ b/go/cmd/controllermgr/config/base.yaml
@@ -63,6 +63,7 @@ jobs:
         # {{.RayLocalNamespace}}. Sandbox default points at the in-cluster MinIO
         # console; production overlays point at OCI Object Storage / S3 console.
         logURLFormat: "http://localhost:9090/browser/{{.Bucket}}/{{.PathPrefix}}/{{.ClusterName}}_{{.RayLocalNamespace}}/"
+      rayJobTTLSeconds: 1800
 
 minio:
   awsRegion: us-east-1

--- a/go/components/jobs/client/k8sengine/mapper.go
+++ b/go/components/jobs/client/k8sengine/mapper.go
@@ -15,8 +15,9 @@ import (
 
 // Mapper helps to map global to local crds and vice versa
 type Mapper struct {
-	LogPersistence LogPersistenceConfig
-	logURLTemplate *template.Template
+	LogPersistence   LogPersistenceConfig
+	RayJobTTLSeconds int32
+	logURLTemplate   *template.Template
 }
 
 // MapperResult has Mapper result
@@ -29,6 +30,12 @@ type MapperResult struct {
 const _mapperName = "k8sengineMapper"
 
 const logPersistenceConfigKey = "jobs.k8sengine.mapper.logPersistence"
+const mapperConfigKey = "jobs.k8sengine.mapper"
+
+// MapperConfig holds top-level mapper configuration loaded from YAML.
+type MapperConfig struct {
+	RayJobTTLSeconds int32 `yaml:"rayJobTTLSeconds"`
+}
 
 // NewLogPersistenceConfig loads LogPersistenceConfig from YAML config provider.
 func NewLogPersistenceConfig(provider config.Provider) (LogPersistenceConfig, error) {
@@ -41,17 +48,28 @@ func NewLogPersistenceConfig(provider config.Provider) (LogPersistenceConfig, er
 	return conf, nil
 }
 
+// NewMapperConfig loads MapperConfig from YAML config provider.
+func NewMapperConfig(provider config.Provider) (MapperConfig, error) {
+	conf := MapperConfig{}
+	err := provider.Get(mapperConfigKey).Populate(&conf)
+	if err != nil {
+		return MapperConfig{}, nil
+	}
+	return conf, nil
+}
+
 // NewMapper constructs the Mapper. Panics if LogURLFormat is set but does not
 // parse as a valid Go text/template — config errors should fail at startup.
-func NewMapper(logPersistence LogPersistenceConfig) MapperResult {
+func NewMapper(logPersistence LogPersistenceConfig, mapperConfig MapperConfig) MapperResult {
 	var tmpl *template.Template
 	if logPersistence.Enabled && logPersistence.LogURLFormat != "" {
 		tmpl = template.Must(template.New("logURL").Parse(logPersistence.LogURLFormat))
 	}
 	return MapperResult{
 		Mapper: Mapper{
-			LogPersistence: logPersistence,
-			logURLTemplate: tmpl,
+			LogPersistence:   logPersistence,
+			RayJobTTLSeconds: mapperConfig.RayJobTTLSeconds,
+			logURLTemplate:   tmpl,
 		},
 	}
 }

--- a/go/components/jobs/client/k8sengine/mapper_test.go
+++ b/go/components/jobs/client/k8sengine/mapper_test.go
@@ -72,7 +72,7 @@ func TestMapper_MapGlobalJobToLocal(t *testing.T) {
 						"ray.io/cluster":      rayCluster.Name,
 						"rayClusterNamespace": RayLocalNamespace,
 					},
-					TTLSecondsAfterFinished:  int32(300),
+					TTLSecondsAfterFinished:  int32(1800),
 					ShutdownAfterJobFinishes: true,
 					SubmitterPodTemplate:     submitterPod,
 				},
@@ -130,6 +130,30 @@ func TestMapper_MapGlobalJobToLocal(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMapper_MapGlobalJobToLocal_CustomTTL(t *testing.T) {
+	m := Mapper{RayJobTTLSeconds: 3600}
+
+	headPod := &corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"role": "head"}}}
+	submitterPod := headPod.DeepCopy()
+	submitterPod.Spec.RestartPolicy = corev1.RestartPolicyNever
+
+	rayJob := &v2pb.RayJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-job"},
+		Spec:       v2pb.RayJobSpec{Entrypoint: "python main.py"},
+	}
+	rayCluster := &v2pb.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
+		Spec: v2pb.RayClusterSpec{
+			Head: &v2pb.RayHeadSpec{Pod: headPod},
+		},
+	}
+
+	lj, err := m.MapGlobalJobToLocal(rayJob, rayCluster, nil)
+	require.NoError(t, err)
+	rayV1Job := lj.(*rayv1.RayJob)
+	assert.Equal(t, int32(3600), rayV1Job.Spec.TTLSecondsAfterFinished)
 }
 
 func TestMapper_MapGlobalJobClusterToLocal(t *testing.T) {

--- a/go/components/jobs/client/k8sengine/module.go
+++ b/go/components/jobs/client/k8sengine/module.go
@@ -7,5 +7,6 @@ import "go.uber.org/fx"
 // client.Module so the consumer/impl boundary stays explicit.
 var Module = fx.Options(
 	fx.Provide(NewLogPersistenceConfig),
+	fx.Provide(NewMapperConfig),
 	fx.Provide(NewMapper),
 )

--- a/go/components/jobs/client/k8sengine/ray.go
+++ b/go/components/jobs/client/k8sengine/ray.go
@@ -61,7 +61,7 @@ func (m Mapper) mapRay(rayJob *v2pb.RayJob, jobClusterObject runtime.Object, clu
 				"rayClusterNamespace": RayLocalNamespace,
 			},
 			Entrypoint:               rayJob.Spec.Entrypoint,
-			TTLSecondsAfterFinished:  int32(300),
+			TTLSecondsAfterFinished:  m.getRayJobTTL(),
 			ShutdownAfterJobFinishes: true,
 			// kuberay 1.0 only support SubmitterPodTemplate for configuration submitter pod
 			// We need to allow user to configure the submitter pod template via ray task configuration
@@ -100,6 +100,13 @@ func (m Mapper) mapRayCluster(rayCluster *v2pb.RayCluster) (runtime.Object, erro
 		},
 	}
 	return rayV1Cluster, nil
+}
+
+func (m Mapper) getRayJobTTL() int32 {
+	if m.RayJobTTLSeconds > 0 {
+		return m.RayJobTTLSeconds
+	}
+	return 1800
 }
 
 func getHeadGroupSpec(head *v2pb.RayHeadSpec) rayv1.HeadGroupSpec {

--- a/helm/michelangelo/templates/core/controllermgr-configmap.yaml
+++ b/helm/michelangelo/templates/core/controllermgr-configmap.yaml
@@ -73,10 +73,11 @@ data:
       {{- fail (printf "workflow.engine must be 'cadence' or 'temporal', got: %s" .Values.workflow.engine) }}
       {{- end }}
 
-    {{- with .Values.controllermgr.jobs.k8sengine.mapper.logPersistence }}
     jobs:
       k8sengine:
         mapper:
+          rayJobTTLSeconds: {{ .Values.controllermgr.jobs.k8sengine.mapper.rayJobTTLSeconds | default 1800 }}
+    {{- with .Values.controllermgr.jobs.k8sengine.mapper.logPersistence }}
           logPersistence:
             enabled: {{ .enabled }}
             storageEndpoint: {{ .storageEndpoint | default $.Values.objectStorage.endpoint | quote }}

--- a/helm/michelangelo/values-k3d.yaml
+++ b/helm/michelangelo/values-k3d.yaml
@@ -87,6 +87,7 @@ controllermgr:
           pathPrefix: log
           s3DisableSSL: true
           logURLFormat: "http://localhost:9090/browser/{{.Bucket}}/{{.PathPrefix}}/{{.ClusterName}}_{{.RayLocalNamespace}}/"
+        rayJobTTLSeconds: 1800
 
 
 

--- a/helm/michelangelo/values.yaml
+++ b/helm/michelangelo/values.yaml
@@ -445,6 +445,10 @@ controllermgr:
           # Example (sandbox MinIO console): "http://localhost:9090/browser/{{.Bucket}}/{{.PathPrefix}}/{{.ClusterName}}_{{.RayLocalNamespace}}/"
           logURLFormat: ""
 
+        # Seconds to keep the RayCluster alive after job finishes (for collector flush + quick debugging).
+        # Log persistence ships logs to S3 in near-real-time; this TTL is just the safety window.
+        rayJobTTLSeconds: 1800
+
   resources: {}
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Makes `TTLSecondsAfterFinished` on RayJob configurable via `jobs.k8sengine.mapper.rayJobTTLSeconds` instead of being hardcoded to 300s (5 min)
- Increases the default to 1800s (30 min) to give the collector sidecar adequate time to flush logs to S3/MinIO before KubeRay tears down the RayCluster
- Places the config at the mapper level (sibling of `logPersistence`) since it controls job lifecycle, not log infrastructure

## Changes

| File | What |
|------|------|
| `ray.go` | Replace hardcoded `int32(300)` with `m.getRayJobTTL()` helper that reads from config with 1800 default |
| `mapper.go` | Add `MapperConfig` struct, `NewMapperConfig` loader, wire `RayJobTTLSeconds` into Mapper |
| `module.go` | Register `NewMapperConfig` provider |
| `mapper_test.go` | Update default TTL assertion, add custom TTL test |
| `base.yaml` | Add `rayJobTTLSeconds: 1800` at mapper level |
| `values.yaml` | Add `rayJobTTLSeconds: 1800` with documentation |
| `values-k3d.yaml` | Add `rayJobTTLSeconds: 1800` |
| `controllermgr-configmap.yaml` | Wire new field into Helm template (always renders, with `default 1800` fallback) |

## Config structure

```yaml
jobs:
  k8sengine:
    mapper:
      rayJobTTLSeconds: 1800        # job lifecycle (new)
      logPersistence:               # log infrastructure (existing)
        enabled: true
```

## Test plan

- [x] `bazel test //go/components/jobs/client/k8sengine:go_default_test` passes
- [ ] Sandbox: `ma sandbox create`, submit a Ray job, verify `kubectl get rayjob -o yaml` shows `ttlSecondsAfterFinished: 1800`
- [ ] Verify collector flushes logs to MinIO within the 30-min window
- [ ] After TTL, verify logs remain accessible via history server URL