### PR TITLE
feat(ray): bubble up RayCluster/RayJob provisioning errors to RayJob status

### DIFF
--- a/go/components/jobs/client/BUILD.bazel
+++ b/go/components/jobs/client/BUILD.bazel
@@ -53,9 +53,11 @@ go_test(
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
+        "@io_k8s_apimachinery//pkg/types:go_default_library",
         "@io_k8s_client_go//discovery:go_default_library",
         "@io_k8s_client_go//rest:go_default_library",
         "@io_k8s_client_go//rest/fake:go_default_library",
+        "@io_k8s_utils//ptr:go_default_library",
         "@org_uber_go_zap//zaptest:go_default_library",
     ],
 )

--- a/go/components/jobs/client/k8sengine/mapper_test.go
+++ b/go/components/jobs/client/k8sengine/mapper_test.go
@@ -10,7 +10,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
-
 	v2pb "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
 )
 
@@ -67,11 +66,11 @@ func TestMapper_MapGlobalJobToLocal(t *testing.T) {
 					Namespace: RayLocalNamespace,
 				},
 				Spec: rayv1.RayJobSpec{
-					Entrypoint: rayJob.Spec.Entrypoint,
 					ClusterSelector: map[string]string{
 						"ray.io/cluster":      rayCluster.Name,
 						"rayClusterNamespace": RayLocalNamespace,
 					},
+					Entrypoint:               rayJob.Spec.Entrypoint,
 					TTLSecondsAfterFinished:  int32(300),
 					ShutdownAfterJobFinishes: true,
 					SubmitterPodTemplate:     submitterPod,
@@ -293,22 +292,103 @@ func TestMapper_GetLocalName(t *testing.T) {
 func TestMapper_MapLocalJobStatusToGlobal(t *testing.T) {
 	m := Mapper{}
 
-	mkRayV1 := func(jobStatus rayv1.JobStatus) *rayv1.RayJob {
+	mkRayV1 := func(status rayv1.RayJobStatus) *rayv1.RayJob {
 		r := &rayv1.RayJob{}
-		r.Status.JobStatus = jobStatus
+		r.Status = status
 		return r
 	}
 
 	tests := []struct {
-		name         string
-		job          k8sruntime.Object
-		expectStatus string
-		expectMsg    string
+		name                   string
+		job                    k8sruntime.Object
+		expectState            v2pb.RayJobState
+		expectJobStatus        string
+		expectDeploymentStatus string
+		expectMsg              string
+		expectJobID            string
+		expectDashboardURL     string
+		expectRayClusterName   string
 	}{
 		{
-			name:         "running RayJob -> RUNNING",
-			job:          mkRayV1(rayv1.JobStatusRunning),
-			expectStatus: string(rayv1.JobStatusRunning),
+			name: "running RayJob -> RUNNING",
+			job: mkRayV1(rayv1.RayJobStatus{
+				JobId:               "ray-job-id",
+				RayClusterName:      "ray-cluster",
+				DashboardURL:        "ray-dashboard:8265",
+				JobStatus:           rayv1.JobStatusRunning,
+				JobDeploymentStatus: rayv1.JobDeploymentStatusRunning,
+				Message:             "job is running",
+			}),
+			expectState:            v2pb.RAY_JOB_STATE_RUNNING,
+			expectJobStatus:        string(rayv1.JobStatusRunning),
+			expectDeploymentStatus: string(rayv1.JobDeploymentStatusRunning),
+			expectMsg:              "job is running",
+			expectJobID:            "ray-job-id",
+			expectDashboardURL:     "ray-dashboard:8265",
+			expectRayClusterName:   "ray-cluster",
+		},
+		{
+			name: "failed deployment with empty Ray job status -> FAILED",
+			job: mkRayV1(rayv1.RayJobStatus{
+				JobDeploymentStatus: rayv1.JobDeploymentStatusFailed,
+				Message:             "Job submission has failed. Reason: BackoffLimitExceeded",
+			}),
+			expectState:            v2pb.RAY_JOB_STATE_FAILED,
+			expectDeploymentStatus: "Failed",
+			expectMsg:              "Job submission has failed. Reason: BackoffLimitExceeded",
+		},
+		{
+			name: "SubmissionFailed reason -> FAILED with reason prefix",
+			job: mkRayV1(rayv1.RayJobStatus{
+				JobDeploymentStatus: rayv1.JobDeploymentStatusFailed,
+				Reason:              rayv1.SubmissionFailed,
+				Message:             "Job deploy failed",
+			}),
+			expectState:            v2pb.RAY_JOB_STATE_FAILED,
+			expectDeploymentStatus: string(rayv1.JobDeploymentStatusFailed),
+			expectMsg:              "[SubmissionFailed] Job deploy failed",
+		},
+		{
+			name: "DeadlineExceeded reason -> FAILED with reason prefix",
+			job: mkRayV1(rayv1.RayJobStatus{
+				JobDeploymentStatus: rayv1.JobDeploymentStatusFailed,
+				Reason:              rayv1.DeadlineExceeded,
+				Message:             "Job exceeded deadline",
+			}),
+			expectState:            v2pb.RAY_JOB_STATE_FAILED,
+			expectDeploymentStatus: string(rayv1.JobDeploymentStatusFailed),
+			expectMsg:              "[DeadlineExceeded] Job exceeded deadline",
+		},
+		{
+			name: "AppFailed reason -> FAILED with reason prefix",
+			job: mkRayV1(rayv1.RayJobStatus{
+				JobDeploymentStatus: rayv1.JobDeploymentStatusFailed,
+				Reason:              rayv1.AppFailed,
+				Message:             "Application exited with error",
+			}),
+			expectState:            v2pb.RAY_JOB_STATE_FAILED,
+			expectDeploymentStatus: string(rayv1.JobDeploymentStatusFailed),
+			expectMsg:              "[AppFailed] Application exited with error",
+		},
+		{
+			name: "Complete deployment -> SUCCEEDED",
+			job: mkRayV1(rayv1.RayJobStatus{
+				JobDeploymentStatus: rayv1.JobDeploymentStatusComplete,
+				JobStatus:           rayv1.JobStatusSucceeded,
+				Message:             "Job completed successfully",
+			}),
+			expectState:            v2pb.RAY_JOB_STATE_SUCCEEDED,
+			expectJobStatus:        string(rayv1.JobStatusSucceeded),
+			expectDeploymentStatus: string(rayv1.JobDeploymentStatusComplete),
+			expectMsg:              "Job completed successfully",
+		},
+		{
+			name: "Suspended deployment -> KILLED",
+			job: mkRayV1(rayv1.RayJobStatus{
+				JobDeploymentStatus: rayv1.JobDeploymentStatusSuspended,
+			}),
+			expectState:            v2pb.RAY_JOB_STATE_KILLED,
+			expectDeploymentStatus: string(rayv1.JobDeploymentStatusSuspended),
 		},
 	}
 
@@ -318,8 +398,13 @@ func TestMapper_MapLocalJobStatusToGlobal(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, js)
 			require.NotNil(t, js.Ray)
-			assert.Equal(t, tt.expectStatus, js.Ray.JobStatus)
+			assert.Equal(t, tt.expectState, js.Ray.State)
+			assert.Equal(t, tt.expectJobStatus, js.Ray.JobStatus)
+			assert.Equal(t, tt.expectDeploymentStatus, js.Ray.JobDeploymentStatus)
 			assert.Equal(t, tt.expectMsg, js.Ray.Message)
+			assert.Equal(t, tt.expectJobID, js.Ray.JobId)
+			assert.Equal(t, tt.expectDashboardURL, js.Ray.DashboardUrl)
+			assert.Equal(t, tt.expectRayClusterName, js.Ray.RayClusterName)
 		})
 	}
 }

--- a/go/components/jobs/client/k8sengine/ray.go
+++ b/go/components/jobs/client/k8sengine/ray.go
@@ -462,16 +462,21 @@ func convertRayV1JobStatusToGlobal(rayV1Job *rayv1.RayJob) *v2pb.RayJobStatus {
 
 	globalJobStatus := &v2pb.RayJobStatus{}
 
+	globalJobStatus.JobId = rayV1Job.Status.JobId
+	globalJobStatus.DashboardUrl = rayV1Job.Status.DashboardURL
 	globalJobStatus.JobStatus = string(rayV1Job.Status.JobStatus)
 	globalJobStatus.JobDeploymentStatus = string(rayV1Job.Status.JobDeploymentStatus)
+	globalJobStatus.RayClusterName = rayV1Job.Status.RayClusterName
 	globalJobStatus.State = mapV1RayJobStatusToMAState(rayV1Job.Status.JobStatus, rayV1Job.Status.JobDeploymentStatus)
-	globalJobStatus.Message = rayV1Job.Status.Message
+	globalJobStatus.Message = enrichMessageWithReason(rayV1Job.Status.Reason, rayV1Job.Status.Message)
 
 	return globalJobStatus
 }
 
 func mapV1RayJobStatusToMAState(status rayv1.JobStatus, deploymentStatus rayv1.JobDeploymentStatus) v2pb.RayJobState {
 	switch status {
+	case rayv1.JobStatusPending:
+		return v2pb.RAY_JOB_STATE_INITIALIZING
 	case rayv1.JobStatusSucceeded:
 		return v2pb.RAY_JOB_STATE_SUCCEEDED
 	case rayv1.JobStatusFailed:
@@ -485,7 +490,25 @@ func mapV1RayJobStatusToMAState(status rayv1.JobStatus, deploymentStatus rayv1.J
 	switch deploymentStatus {
 	case rayv1.JobDeploymentStatusInitializing, rayv1.JobDeploymentStatusWaiting:
 		return v2pb.RAY_JOB_STATE_INITIALIZING
+	case rayv1.JobDeploymentStatusRunning:
+		return v2pb.RAY_JOB_STATE_RUNNING
+	case rayv1.JobDeploymentStatusComplete:
+		return v2pb.RAY_JOB_STATE_SUCCEEDED
+	case rayv1.JobDeploymentStatusSuspended:
+		return v2pb.RAY_JOB_STATE_KILLED
+	case rayv1.JobDeploymentStatusFailed:
+		return v2pb.RAY_JOB_STATE_FAILED
 	}
 
 	return v2pb.RAY_JOB_STATE_INVALID
+}
+
+func enrichMessageWithReason(reason rayv1.JobFailedReason, message string) string {
+	if reason == "" {
+		return message
+	}
+	if message == "" {
+		return string(reason)
+	}
+	return fmt.Sprintf("[%s] %s", reason, message)
 }

--- a/go/components/ray/job/controller.go
+++ b/go/components/ray/job/controller.go
@@ -158,17 +158,52 @@ func (r *Reconciler) fetchRayCluster(ctx context.Context, logger logr.Logger, ra
 }
 
 // ensureClusterReady checks if the RayCluster is in ready state.
-// Returns true if ready, false otherwise (will requeue).
+// Returns true if ready, false otherwise. Terminal cluster states (FAILED, TERMINATED, UNHEALTHY)
+// cause the RayJob to fail immediately with a descriptive message.
 func (r *Reconciler) ensureClusterReady(ctx context.Context, logger logr.Logger, rayJob *v2pb.RayJob, rayCluster *v2pb.RayCluster, res *ctrl.Result) bool {
-	if rayCluster.Status.State != v2pb.RAY_CLUSTER_STATE_READY {
-		logger.Info("cluster is not ready, waiting")
-		// Reflect waiting state while the cluster becomes ready
+	switch rayCluster.Status.State {
+	case v2pb.RAY_CLUSTER_STATE_READY:
+		return true
+
+	case v2pb.RAY_CLUSTER_STATE_FAILED, v2pb.RAY_CLUSTER_STATE_TERMINATED, v2pb.RAY_CLUSTER_STATE_UNHEALTHY:
+		logger.Info("cluster is in terminal state, failing ray job",
+			"clusterState", rayCluster.Status.State.String())
+		rayJob.Status.State = v2pb.RAY_JOB_STATE_FAILED
+		rayJob.Status.Message = buildClusterFailureMessage(rayCluster)
+		return false
+
+	default:
+		logger.Info("cluster is not ready, waiting", "clusterState", rayCluster.Status.State.String())
 		rayJob.Status.State = v2pb.RAY_JOB_STATE_INITIALIZING
-		rayJob.Status.Message = fmt.Sprintf("cluster %s/%s is not ready", rayCluster.Namespace, rayCluster.Name)
+		rayJob.Status.Message = fmt.Sprintf("cluster %s/%s is not ready (state: %s)",
+			rayCluster.Namespace, rayCluster.Name, rayCluster.Status.State.String())
 		res.RequeueAfter = requeueAfter
 		return false
 	}
-	return true
+}
+
+func buildClusterFailureMessage(rayCluster *v2pb.RayCluster) string {
+	msg := fmt.Sprintf("cluster %s/%s is in state %s",
+		rayCluster.Namespace, rayCluster.Name, rayCluster.Status.State.String())
+
+	if len(rayCluster.Status.PodErrors) > 0 {
+		firstErr := rayCluster.Status.PodErrors[0]
+		if firstErr.Reason != "" {
+			msg += fmt.Sprintf(": %s", firstErr.Reason)
+		}
+		if firstErr.Message != "" {
+			msg += fmt.Sprintf(" - %s", firstErr.Message)
+		}
+	}
+
+	for _, cond := range rayCluster.Status.StatusConditions {
+		if cond.Status == apipb.CONDITION_STATUS_FALSE && cond.Reason != "" {
+			msg += fmt.Sprintf("; condition %s: %s", cond.Type, cond.Reason)
+			break
+		}
+	}
+
+	return msg
 }
 
 // getAssignedCluster retrieves the assigned physical cluster from the RayCluster status.
@@ -254,9 +289,12 @@ func (r *Reconciler) applyRayJobStatus(
 		return
 	}
 	rayJob.Status.State = jobStatus.Ray.State
+	rayJob.Status.JobId = jobStatus.Ray.JobId
 	rayJob.Status.JobStatus = jobStatus.Ray.JobStatus
+	rayJob.Status.JobDeploymentStatus = jobStatus.Ray.JobDeploymentStatus
 	rayJob.Status.Message = jobStatus.Ray.Message
 	rayJob.Status.DashboardUrl = jobStatus.Ray.DashboardUrl
+	rayJob.Status.RayClusterName = jobStatus.Ray.RayClusterName
 
 	if !isTerminalRayJobState(jobStatus.Ray.State) {
 		res.RequeueAfter = requeueAfter

--- a/go/components/ray/job/controller_test.go
+++ b/go/components/ray/job/controller_test.go
@@ -185,7 +185,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 			},
 			setupMocks:      func(ctrl *gomock.Controller, mfc *clientmocks.MockFederatedClient, mcc *mockClusterCache) {},
 			expectedState:   v2pb.RAY_JOB_STATE_INITIALIZING,
-			expectedMessage: "cluster default/existing-cluster is not ready",
+			expectedMessage: "cluster default/existing-cluster is not ready (state: RAY_CLUSTER_STATE_PROVISIONING)",
 			errorAssertion:  require.NoError,
 			postCheck: func(res ctrl.Result) {
 				assert.Equal(t, requeueAfter, res.RequeueAfter)
@@ -193,7 +193,137 @@ func TestReconciler_Reconcile(t *testing.T) {
 			verifyConditions: func(t *testing.T, job *v2pb.RayJob) {},
 		},
 		{
-			name: "job status unknown - requeue and initializing",
+			name: "cluster failed - ray job transitions to failed",
+			setup: func() []client.Object {
+				objects := make([]client.Object, 0)
+				rayJob := &v2pb.RayJob{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       rayJobName,
+						Namespace:  testNamespace,
+						Generation: 1,
+					},
+					Spec: v2pb.RayJobSpec{
+						Cluster: &apipb.ResourceIdentifier{
+							Name:      "existing-cluster",
+							Namespace: testNamespace,
+						},
+						Entrypoint: "echo Hello World",
+					},
+				}
+				cluster := &v2pb.RayCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "existing-cluster",
+						Namespace:  testNamespace,
+						Generation: 1,
+					},
+					Status: v2pb.RayClusterStatus{
+						State: v2pb.RAY_CLUSTER_STATE_FAILED,
+					},
+				}
+				objects = append(objects, rayJob)
+				objects = append(objects, cluster)
+				return objects
+			},
+			setupMocks:      func(ctrl *gomock.Controller, mfc *clientmocks.MockFederatedClient, mcc *mockClusterCache) {},
+			expectedState:   v2pb.RAY_JOB_STATE_FAILED,
+			expectedMessage: "cluster default/existing-cluster is in state RAY_CLUSTER_STATE_FAILED",
+			errorAssertion:  require.NoError,
+			postCheck: func(res ctrl.Result) {
+				assert.Equal(t, time.Duration(0), res.RequeueAfter)
+			},
+			verifyConditions: func(t *testing.T, job *v2pb.RayJob) {},
+		},
+		{
+			name: "cluster unhealthy - ray job transitions to failed",
+			setup: func() []client.Object {
+				objects := make([]client.Object, 0)
+				rayJob := &v2pb.RayJob{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       rayJobName,
+						Namespace:  testNamespace,
+						Generation: 1,
+					},
+					Spec: v2pb.RayJobSpec{
+						Cluster: &apipb.ResourceIdentifier{
+							Name:      "existing-cluster",
+							Namespace: testNamespace,
+						},
+						Entrypoint: "echo Hello World",
+					},
+				}
+				cluster := &v2pb.RayCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "existing-cluster",
+						Namespace:  testNamespace,
+						Generation: 1,
+					},
+					Status: v2pb.RayClusterStatus{
+						State: v2pb.RAY_CLUSTER_STATE_UNHEALTHY,
+					},
+				}
+				objects = append(objects, rayJob)
+				objects = append(objects, cluster)
+				return objects
+			},
+			setupMocks:      func(ctrl *gomock.Controller, mfc *clientmocks.MockFederatedClient, mcc *mockClusterCache) {},
+			expectedState:   v2pb.RAY_JOB_STATE_FAILED,
+			expectedMessage: "cluster default/existing-cluster is in state RAY_CLUSTER_STATE_UNHEALTHY",
+			errorAssertion:  require.NoError,
+			postCheck: func(res ctrl.Result) {
+				assert.Equal(t, time.Duration(0), res.RequeueAfter)
+			},
+			verifyConditions: func(t *testing.T, job *v2pb.RayJob) {},
+		},
+		{
+			name: "cluster failed with pod errors - error details surfaced",
+			setup: func() []client.Object {
+				objects := make([]client.Object, 0)
+				rayJob := &v2pb.RayJob{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       rayJobName,
+						Namespace:  testNamespace,
+						Generation: 1,
+					},
+					Spec: v2pb.RayJobSpec{
+						Cluster: &apipb.ResourceIdentifier{
+							Name:      "existing-cluster",
+							Namespace: testNamespace,
+						},
+						Entrypoint: "echo Hello World",
+					},
+				}
+				cluster := &v2pb.RayCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "existing-cluster",
+						Namespace:  testNamespace,
+						Generation: 1,
+					},
+					Status: v2pb.RayClusterStatus{
+						State: v2pb.RAY_CLUSTER_STATE_FAILED,
+						PodErrors: []*v2pb.PodErrors{
+							{
+								Name:    "head-pod-0",
+								Reason:  "ImagePullBackOff",
+								Message: "Failed to pull image us-east.ocir.io/my-image:latest",
+							},
+						},
+					},
+				}
+				objects = append(objects, rayJob)
+				objects = append(objects, cluster)
+				return objects
+			},
+			setupMocks:      func(ctrl *gomock.Controller, mfc *clientmocks.MockFederatedClient, mcc *mockClusterCache) {},
+			expectedState:   v2pb.RAY_JOB_STATE_FAILED,
+			expectedMessage: "ImagePullBackOff",
+			errorAssertion:  require.NoError,
+			postCheck: func(res ctrl.Result) {
+				assert.Equal(t, time.Duration(0), res.RequeueAfter)
+			},
+			verifyConditions: func(t *testing.T, job *v2pb.RayJob) {},
+		},
+		{
+			name: "job status unknown - requeue and state set to invalid",
 			setup: func() []client.Object {
 				objects := make([]client.Object, 0)
 				rayJob := &v2pb.RayJob{
@@ -829,6 +959,81 @@ func TestReconciler_Reconcile(t *testing.T) {
 				assert.Equal(t, requeueAfter, res.RequeueAfter)
 			},
 			verifyConditions: func(t *testing.T, job *v2pb.RayJob) {},
+		},
+		{
+			name: "failed deployment status is propagated",
+			setup: func() []client.Object {
+				objects := make([]client.Object, 0)
+				rayJob := &v2pb.RayJob{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       rayJobName,
+						Namespace:  testNamespace,
+						Generation: 1,
+					},
+					Spec: v2pb.RayJobSpec{
+						Cluster: &apipb.ResourceIdentifier{
+							Name:      "existing-cluster",
+							Namespace: testNamespace,
+						},
+						Entrypoint: "echo Hello World",
+					},
+					Status: v2pb.RayJobStatus{
+						State: v2pb.RAY_JOB_STATE_INITIALIZING,
+						StatusConditions: []*apipb.Condition{
+							{
+								Type:   "Launched",
+								Status: apipb.CONDITION_STATUS_TRUE,
+							},
+						},
+					},
+				}
+				cluster := &v2pb.RayCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "existing-cluster",
+						Namespace:  testNamespace,
+						Generation: 1,
+					},
+					Status: v2pb.RayClusterStatus{
+						State: v2pb.RAY_CLUSTER_STATE_READY,
+						Assignment: &v2pb.AssignmentInfo{
+							Cluster: assignedCluster,
+						},
+					},
+				}
+				objects = append(objects, rayJob)
+				objects = append(objects, cluster)
+				return objects
+			},
+			setupMocks: func(ctrl *gomock.Controller, mfc *clientmocks.MockFederatedClient, mcc *mockClusterCache) {
+				mcc.addCluster(assignedCluster, &v2pb.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: assignedCluster,
+					},
+				})
+				mfc.EXPECT().GetJobStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(&jobtypes.JobStatus{
+					Ray: &v2pb.RayJobStatus{
+						JobId:               "ray-job-id",
+						JobStatus:           "",
+						JobDeploymentStatus: "Failed",
+						RayClusterName:      "ray-cluster",
+						State:               v2pb.RAY_JOB_STATE_FAILED,
+						Message:             "Job submission has failed. Reason: BackoffLimitExceeded",
+						DashboardUrl:        "ray-dashboard:8265",
+					},
+				}, nil)
+			},
+			expectedState:   v2pb.RAY_JOB_STATE_FAILED,
+			expectedMessage: "BackoffLimitExceeded",
+			errorAssertion:  require.NoError,
+			postCheck: func(res ctrl.Result) {
+				assert.Equal(t, time.Duration(0), res.RequeueAfter)
+			},
+			verifyConditions: func(t *testing.T, job *v2pb.RayJob) {
+				assert.Equal(t, "ray-job-id", job.Status.JobId)
+				assert.Equal(t, "Failed", job.Status.JobDeploymentStatus)
+				assert.Equal(t, "ray-cluster", job.Status.RayClusterName)
+				assert.Equal(t, "ray-dashboard:8265", job.Status.DashboardUrl)
+			},
 		},
 		{
 			name: "job creation fails",


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Three related improvements to surface provisioning errors from RayCluster and RayJob resources:

1. **RayJob controller — fail fast on terminal cluster states**: When a RayCluster enters a terminal state (FAILED, TERMINATED, UNHEALTHY), the RayJob now immediately transitions to FAILED with a descriptive error message. Previously it would requeue indefinitely with "cluster is not ready". The failure message includes pod errors (e.g. `ImagePullBackOff`, `CrashLoopBackOff`) and condition details from the cluster status.

2. **RayJob status propagation**: `applyRayJobStatus` now copies `JobId`, `JobDeploymentStatus`, and `RayClusterName` from the federated status to the RayJob status. These fields were previously lost during reconciliation.

3. **Local→global status mapper — v1.2.2 API alignment**: 
   - `convertRayV1JobStatusToGlobal` now maps `JobId`, `DashboardUrl`, `RayClusterName` fields and uses `enrichMessageWithReason` to prefix failure messages with the KubeRay `Reason` field.
   - `mapV1RayJobStatusToMAState` adds mappings for `Pending`, `Running`, `Complete`, `Suspended`, and `Failed` deployment statuses, replacing the removed v1.0.0 fine-grained failure constants (`FailedToGetOrCreateRayCluster`, `FailedJobDeploy`, `FailedToGetJobStatus`) with v1.2.2's single `JobDeploymentStatusFailed` + `JobFailedReason`.

**Why?**

Users submitting RayJobs had no visibility into why their jobs were stuck or failing when the underlying cluster had provisioning issues. Common scenarios like image pull failures, quota exhaustion, or crash loops would cause the RayJob to sit in INITIALIZING state indefinitely, requiring users to manually inspect the RayCluster to understand the problem.

**How did you test it?**

- Unit tests for all new behavior in `controller_test.go` (cluster failed, cluster unhealthy, cluster failed with pod errors, failed deployment status propagation)
- Unit tests for mapper changes in `mapper_test.go` (SubmissionFailed, DeadlineExceeded, AppFailed reasons, deployment status mappings)
- All existing tests continue to pass: `bazel test //go/components/ray/job:go_default_test //go/components/jobs/client/k8sengine:go_default_test //go/components/jobs/client:go_default_test`

**Potential risks**

- RayJobs that previously sat in INITIALIZING indefinitely on a failed cluster will now transition to FAILED. This is the correct behavior but could surface errors that were previously hidden.
- The message format change (`[Reason] message`) is additive — consumers parsing the raw message string should use `Contains` rather than exact match.

**Breaking Changes**

- [x] No breaking changes

**Release notes**

RayJob status now surfaces provisioning errors from the underlying RayCluster (e.g. ImagePullBackOff, quota exceeded) and RayJob deployment failures, giving users immediate actionable feedback instead of indefinite "initializing" state.

**Documentation Changes**

No documentation changes required — this is a behavioral improvement to error reporting.