### PR TITLE
fix(docs): wrap Spark DataFrame in DatasetVariable in branching example

### DIFF
--- a/docs/user-guides/ml-pipelines/workflow-patterns.md
+++ b/docs/user-guides/ml-pipelines/workflow-patterns.md
@@ -73,11 +73,16 @@ def adaptive_training(data_url: str, use_gpu: bool, epochs: int):
 You can also use branching to short-circuit a pipeline early:
 
 ```python
+from michelangelo.workflow.variables import DatasetVariable
+
+
 @uniflow.task(config=SparkTask(driver_cpu=1, driver_memory="4G", executor_instances=2))
 def load_data(data_url: str):
     from pyspark.sql import SparkSession
     df = SparkSession.getActiveSession().read.parquet(data_url)
-    return df, df.count()
+    dv = DatasetVariable.create(df)
+    dv.save_spark_dataframe()
+    return dv, df.count()
 
 
 @uniflow.workflow()


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**
The `load_data` task in the branching example now wraps its Spark DataFrame in a `DatasetVariable` before returning, matching the pattern documented in the DatasetVariable section of the same guide.

**Why?**
The original example returned a raw PySpark DataFrame that was then passed to a Ray task — this fails at runtime since raw DataFrames cannot cross compute backend boundaries. Caught in a review comment on #1527 (merged).

**How did you test it?**
No functional changes — documentation only. Verified the fix is consistent with the `DatasetVariable` patterns already documented in this guide.

**Potential risks**
None.

**Breaking Changes**
- [x] No breaking changes

**Release notes**
N/A

**Documentation Changes**
Fixes an incorrect code example in `docs/user-guides/ml-pipelines/workflow-patterns.md`.