### PR TITLE
fix(build): bump Go SDK to 1.26.3 + rules_go to 0.57.0 (CVE Scan fix, step 1/2)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,7 +4,7 @@ module(name = "michelangelo")
 ############ Bazel modules ################
 ###########################################
 bazel_dep(name = "rules_python", version = "0.40.0")
-bazel_dep(name = "rules_go", version = "0.50.1", repo_name = "io_bazel_rules_go")
+bazel_dep(name = "rules_go", version = "0.57.0", repo_name = "io_bazel_rules_go")
 bazel_dep(name = "gazelle", version = "0.40.0", repo_name = "bazel_gazelle")
 bazel_dep(name = "rules_python_gazelle_plugin", version = "0.40.0")
 bazel_dep(name = "rules_pkg", version = "1.0.1")
@@ -17,7 +17,7 @@ bazel_dep(name = "protobuf", version = "29.0-rc3", repo_name = "com_google_proto
 ###########################################
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(
-    version = "1.23.3",
+    version = "1.26.3",
 )
 go_sdk.nogo(
     includes = ["@//:__subpackages__"],


### PR DESCRIPTION
## Summary

Fixes #1565 (partially — see "Two-step plan" below).

`MODULE.bazel` pinned the actual Bazel-built Go toolchain to `1.23.3`, independently of `go/go.mod`'s `go 1.24.0` directive (a minimum-compat floor, not a toolchain pin). This left 15 known Go stdlib CVEs (1 CRITICAL, 14 HIGH) baked into every Go-built service image (`apiserver`, `controllermgr`, `worker`) — see the failing [`CVE Scan` run](https://github.com/michelangelo-ai/michelangelo/actions/runs/29853464881).

This bumps:
- `go_sdk.download(version = ...)`: `1.23.3` → `1.26.3` (this org's internal Go version standard)
- `rules_go`: `0.50.1` → `0.57.0` (required companion bump — see below)

### Why rules_go also needed a bump

`rules_go` 0.50.1 doesn't build cleanly against Go 1.26.3:
1. It hardcodes `GOEXPERIMENT=coverageredesign`, which Go 1.25+ no longer recognizes as a valid experiment (`go: unknown GOEXPERIMENT coverageredesign`). Fixed in [rules_go#4397](https://github.com/bazel-contrib/rules_go/commit/2af3f27a), first released in `v0.56.0`.
2. It expects a prebuilt `pack` tool under `pkg/tool/<platform>/`, which newer Go SDK releases no longer ship there (`pack` moved to `bin/`). `rules_go` `v0.57.0` fixes this by building `pack` from source instead ([commit](https://github.com/bazel-contrib/rules_go/commit/4d0a821e)).

`v0.57.0` is the first `rules_go` release containing both fixes.

## Two-step plan

This is **step 1 of 2** (see #1565 for full context). `1.26.3` does not close every CVE found in the scan — 3 confirmed CVEs remain open at this version:

| CVE | Needs |
|---|---|
| CVE-2026-27145 | 1.26.4 |
| CVE-2026-42504 | 1.26.4 |
| CVE-2026-39822 | 1.26.5 |

Step 2 (planned ~1 week after this merges, to let this bump soak in CI/nightly builds first) will bump `1.26.3` → `1.26.5`, closing the remaining CVEs and turning the `CVE Scan` workflow fully green.

## Test plan

- [x] `bazel build //go/...` succeeds against the new SDK + `rules_go` versions.
- [x] `bazel test //go/...` — 93/93 tests pass (regression check; several of the CVEs already fixed in 1.26.3 are parsing-strictness changes in `net/mail`/`crypto/x509`/`net/url`).
- [x] CI's own `bazel build`/`bazel test` steps pass on this PR.
- [x] Full k3d sandbox runtime validation: images built off this branch, deployed, end-to-end pipeline run reaches `PIPELINE_RUN_STATE_SUCCEEDED`.
- [ ] ~~`cve-scan.yml` triggered via `workflow_dispatch` on this branch, confirming the expected residual CVE set~~ — not achievable pre-merge: `cve-scan.yml` always scans the `:latest` tag regardless of trigger, so `workflow_dispatch` on a branch can't verify an unmerged fix (see comment below). Residual CVE set will be confirmed from the first post-merge scan instead.
