### PR TITLE
feat(native_transform): add foundation transform layers (PR B1)

### DIFF
--- a/python/michelangelo/lib/native_transform/__init__.py
+++ b/python/michelangelo/lib/native_transform/__init__.py
@@ -1,5 +1,6 @@
 """Native transform layers for Michelangelo feature transformation.
 
-Seeds the native_transform migration with initial transform layers; the full
-transform DAG (TransformSpec, TorchTransformModule, etc.) lands in a follow-up PR.
+Provides TorchScript-exportable transform layers (see the ``torch`` subpackage);
+the full transform DAG (TransformSpec, TorchTransformModule, etc.) lands in
+follow-up work.
 """

--- a/python/michelangelo/lib/native_transform/torch/__init__.py
+++ b/python/michelangelo/lib/native_transform/torch/__init__.py
@@ -4,8 +4,34 @@ TorchScript- and ONNX-exportable ``nn.Module`` layers used to build native
 feature transforms that run identically at train and serve time.
 """
 
+from michelangelo.lib.native_transform.torch.base_layers import (
+    Cast,
+    Ceil,
+    Concatenate,
+    Constant,
+    Divide,
+    Floor,
+    IdentityTransform,
+    LogTransform,
+    Stack,
+    Subtract,
+    TorchTransformBaseLayer,
+)
 from michelangelo.lib.native_transform.torch.id_hash_tokenizer import (
     IDHashTokenizer,
 )
 
-__all__ = ["IDHashTokenizer"]
+__all__ = [
+    "Cast",
+    "Ceil",
+    "Concatenate",
+    "Constant",
+    "Divide",
+    "Floor",
+    "IDHashTokenizer",
+    "IdentityTransform",
+    "LogTransform",
+    "Stack",
+    "Subtract",
+    "TorchTransformBaseLayer",
+]

--- a/python/michelangelo/lib/native_transform/torch/base_layers.py
+++ b/python/michelangelo/lib/native_transform/torch/base_layers.py
@@ -21,6 +21,7 @@ from michelangelo.lib.native_transform.torch.constants import DEFAULT_EPSILON
 from michelangelo.lib.native_transform.torch.utils import (
     format_inputs,
     format_outputs,
+    generate_layer_name,
     initialize_dtype,
 )
 
@@ -50,7 +51,9 @@ class TorchTransformBaseLayer(torch.nn.Module, abc.ABC):
         input_cols: Column names of the input tensors.
         output_cols: Column names of the output tensors.
         **kwargs: Additional options. ``name`` (str) sets the layer name, which
-            must be unique within a model; it defaults to ``"transform_layer"``.
+            must be unique within a model. When omitted, a unique name is
+            generated automatically from the layer's class name (e.g.
+            ``"stack_A1B2C3D4E5"``).
     """
 
     def __init__(self, input_cols: list[str], output_cols: list[str], **kwargs) -> None:
@@ -59,12 +62,16 @@ class TorchTransformBaseLayer(torch.nn.Module, abc.ABC):
         Args:
             input_cols: Column names of the input tensors.
             output_cols: Column names of the output tensors.
-            **kwargs: Additional options; ``name`` (str) sets the layer name.
+            **kwargs: Additional options; ``name`` (str) sets the layer name. When
+                omitted, a unique name is generated from the class name.
         """
         super().__init__()
         self.input_cols = input_cols
         self.output_cols = output_cols
-        self.name = kwargs.get("name", "transform_layer")
+        name = kwargs.get("name")
+        self.name = (
+            name if name is not None else generate_layer_name(self.__class__.__name__)
+        )
 
     @abc.abstractmethod
     def forward(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
@@ -146,21 +153,27 @@ class Stack(TorchTransformBaseLayer):
     Args:
         input_cols: Column names of the input tensors.
         output_cols: Single-element list naming the stacked output column.
-        **kwargs: Additional options. ``dim`` (int) is the dimension along which
-            to stack (default ``-1``); ``name`` sets the layer name.
+        dim: The dimension along which to stack (default ``-1``).
+        **kwargs: Additional base-layer options (e.g. ``name``).
     """
 
-    def __init__(self, input_cols: list[str], output_cols: list[str], **kwargs) -> None:
+    def __init__(
+        self,
+        input_cols: list[str],
+        output_cols: list[str],
+        dim: int = -1,
+        **kwargs,
+    ) -> None:
         """Initialize the Stack layer.
 
         Args:
             input_cols: Column names of the input tensors.
             output_cols: Single-element list naming the stacked output column.
-            **kwargs: Additional options; ``dim`` (int, default ``-1``) selects
-                the new dimension, and ``name`` sets the layer name.
+            dim: The new dimension along which to stack (default ``-1``).
+            **kwargs: Additional base-layer options (e.g. ``name``).
         """
         super().__init__(input_cols, output_cols, **kwargs)
-        self.dim: int = kwargs.get("dim", -1)
+        self.dim: int = dim
 
     def forward(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         """Stack the input columns along ``dim``.
@@ -185,12 +198,15 @@ class Cast(TorchTransformBaseLayer):
         input_cols: Column names of the input tensors.
         output_cols: Column names of the output tensors; must match the length
             of ``input_cols``.
-        dtype: Target dtype to cast to. Defaults to ``torch.int64`` when not a
-            recognized dtype or string alias.
+        dtype: Target dtype to cast to. May be a ``torch.dtype`` or a string
+            alias (e.g. ``"float32"`` or ``"torch.float32"``). Defaults to
+            ``torch.int64`` when ``None``. An unrecognized string alias raises
+            ``ValueError``.
         **kwargs: Additional base-layer options (e.g. ``name``).
 
     Raises:
-        ValueError: If ``input_cols`` and ``output_cols`` differ in length.
+        ValueError: If ``input_cols`` and ``output_cols`` differ in length, or if
+            ``dtype`` is a string that names no recognized dtype.
     """
 
     def __init__(
@@ -206,11 +222,13 @@ class Cast(TorchTransformBaseLayer):
             input_cols: Column names of the input tensors.
             output_cols: Column names of the output tensors; must match the
                 length of ``input_cols``.
-            dtype: Target dtype; defaults to ``torch.int64``.
+            dtype: Target dtype (``torch.dtype`` or string alias); defaults to
+                ``torch.int64`` when ``None``.
             **kwargs: Additional base-layer options (e.g. ``name``).
 
         Raises:
-            ValueError: If ``input_cols`` and ``output_cols`` differ in length.
+            ValueError: If ``input_cols`` and ``output_cols`` differ in length,
+                or if ``dtype`` is a string that names no recognized dtype.
         """
         if len(input_cols) != len(output_cols):
             raise ValueError(
@@ -325,10 +343,10 @@ class Divide(TorchTransformBaseLayer):
         output_cols: Column names of the quotient outputs.
         add_constant_to_divisor: Constant added to every denominator before
             division.
-        **kwargs: Additional options. ``eps`` (float) is the small value
-            substituted for a zero denominator (default
-            :data:`~michelangelo.lib.native_transform.torch.constants.DEFAULT_EPSILON`);
-            ``name`` sets the layer name.
+        eps: Small value substituted for a zero denominator to avoid division by
+            zero (default
+            :data:`~michelangelo.lib.native_transform.torch.constants.DEFAULT_EPSILON`).
+        **kwargs: Additional base-layer options (e.g. ``name``).
 
     Raises:
         ValueError: If ``input_cols`` is not even, or ``output_cols`` is not half
@@ -340,6 +358,7 @@ class Divide(TorchTransformBaseLayer):
         input_cols: list[str],
         output_cols: list[str],
         add_constant_to_divisor: float = 0.0,
+        eps: float = DEFAULT_EPSILON,
         **kwargs,
     ) -> None:
         """Initialize the Divide layer.
@@ -348,8 +367,9 @@ class Divide(TorchTransformBaseLayer):
             input_cols: Column names as ``(numerator, denominator)`` pairs.
             output_cols: Column names of the quotient outputs.
             add_constant_to_divisor: Constant added to every denominator.
-            **kwargs: Additional options; ``eps`` (float) overrides the zero-safe
-                epsilon and ``name`` sets the layer name.
+            eps: Small value substituted for a zero denominator (default
+                :data:`~michelangelo.lib.native_transform.torch.constants.DEFAULT_EPSILON`).
+            **kwargs: Additional base-layer options (e.g. ``name``).
 
         Raises:
             ValueError: If ``input_cols`` is not even, or ``output_cols`` is not
@@ -362,7 +382,7 @@ class Divide(TorchTransformBaseLayer):
                 "input columns."
             )
         self.add_constant_to_divisor = add_constant_to_divisor
-        self.eps = kwargs.get("eps", DEFAULT_EPSILON)
+        self.eps = eps
 
     def forward(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         """Divide numerators by denominators, pairwise and zero-safe.
@@ -405,34 +425,39 @@ class LogTransform(TorchTransformBaseLayer):
         input_cols: Column names of the input tensors.
         output_cols: Column names of the output tensors; must match the length of
             ``input_cols``.
-        **kwargs: Additional options. ``add_constant`` (float) is added before
-            the logarithm to avoid ``log(0)`` (default ``1.0``); ``name`` sets
-            the layer name.
+        add_constant: Value added before the logarithm to avoid ``log(0)``
+            (default ``1.0``).
+        **kwargs: Additional base-layer options (e.g. ``name``).
 
     Raises:
         ValueError: If ``input_cols`` and ``output_cols`` differ in length.
     """
 
-    def __init__(self, input_cols: list[str], output_cols: list[str], **kwargs) -> None:
+    def __init__(
+        self,
+        input_cols: list[str],
+        output_cols: list[str],
+        add_constant: float = 1.0,
+        **kwargs,
+    ) -> None:
         """Initialize the LogTransform layer.
 
         Args:
             input_cols: Column names of the input tensors.
             output_cols: Column names of the output tensors; must match the
                 length of ``input_cols``.
-            **kwargs: Additional options; ``add_constant`` (float, default
-                ``1.0``) is added before the logarithm and ``name`` sets the
-                layer name.
+            add_constant: Value added before the logarithm (default ``1.0``).
+            **kwargs: Additional base-layer options (e.g. ``name``).
 
         Raises:
             ValueError: If ``input_cols`` and ``output_cols`` differ in length.
         """
-        super().__init__(input_cols, output_cols)
+        super().__init__(input_cols, output_cols, **kwargs)
         if len(input_cols) != len(output_cols):
             raise ValueError(
                 "Input columns and output columns must have the same length."
             )
-        self.add_constant = kwargs.get("add_constant", 1.0)
+        self.add_constant = add_constant
 
     def forward(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         """Apply the log transform to each input column.

--- a/python/michelangelo/lib/native_transform/torch/base_layers.py
+++ b/python/michelangelo/lib/native_transform/torch/base_layers.py
@@ -1,0 +1,643 @@
+"""PyTorch native transform layers.
+
+TorchScript- and ONNX-exportable ``nn.Module`` transform layers that operate on a
+``dict[str, torch.Tensor]`` in/out contract so the exact same transform runs at
+train and serve time. Every layer subclasses :class:`TorchTransformBaseLayer` and
+uses :func:`~michelangelo.lib.native_transform.torch.utils.format_inputs` /
+:func:`~michelangelo.lib.native_transform.torch.utils.format_outputs` to map its
+declared input/output columns to and from a single stacked tensor.
+
+This module provides the foundation (stateless, elementwise) layers. Structural,
+fitted-statistics, and tokenizer layers are added in follow-up modules.
+"""
+
+from __future__ import annotations
+
+import abc
+
+import torch
+
+from michelangelo.lib.native_transform.torch.constants import DEFAULT_EPSILON
+from michelangelo.lib.native_transform.torch.utils import (
+    format_inputs,
+    format_outputs,
+    initialize_dtype,
+)
+
+__all__ = [
+    "Cast",
+    "Ceil",
+    "Concatenate",
+    "Constant",
+    "Divide",
+    "Floor",
+    "IdentityTransform",
+    "LogTransform",
+    "Stack",
+    "Subtract",
+    "TorchTransformBaseLayer",
+]
+
+
+class TorchTransformBaseLayer(torch.nn.Module, abc.ABC):
+    """Abstract base for native PyTorch transform layers.
+
+    All layers consume and produce ``dict[str, torch.Tensor]`` so they compose
+    into a single TorchScript-exportable graph. Subclasses select their inputs by
+    ``input_cols`` and write their results under ``output_cols``.
+
+    Args:
+        input_cols: Column names of the input tensors.
+        output_cols: Column names of the output tensors.
+        **kwargs: Additional options. ``name`` (str) sets the layer name, which
+            must be unique within a model; it defaults to ``"transform_layer"``.
+    """
+
+    def __init__(self, input_cols: list[str], output_cols: list[str], **kwargs) -> None:
+        """Initialize the base layer.
+
+        Args:
+            input_cols: Column names of the input tensors.
+            output_cols: Column names of the output tensors.
+            **kwargs: Additional options; ``name`` (str) sets the layer name.
+        """
+        super().__init__()
+        self.input_cols = input_cols
+        self.output_cols = output_cols
+        self.name = kwargs.get("name", "transform_layer")
+
+    @abc.abstractmethod
+    def forward(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """Apply the transform.
+
+        Args:
+            inputs: Mapping from column name to tensor for at least every column
+                in ``input_cols``.
+
+        Returns:
+            A mapping from each column in ``output_cols`` to its result tensor.
+
+        Raises:
+            NotImplementedError: If a subclass does not override this method.
+        """
+        raise NotImplementedError("Please implement the method in your subclass.")
+
+
+class Concatenate(TorchTransformBaseLayer):
+    """Concatenate input tensors along the last dimension.
+
+    When ``dtype`` is ``None`` (default) the output dtype follows torch's
+    standard type-promotion rules (e.g. ``int32`` + ``float64`` -> ``float64``).
+    When ``dtype`` is given, the output is explicitly cast to it.
+
+    Args:
+        input_cols: Column names of the input tensors.
+        output_cols: Single-element list naming the concatenated output column.
+        dtype: Optional output dtype. When ``None``, the input dtype is
+            preserved via type promotion.
+        **kwargs: Additional base-layer options (e.g. ``name``).
+    """
+
+    def __init__(
+        self,
+        input_cols: list[str],
+        output_cols: list[str],
+        dtype: torch.dtype | str | None = None,
+        **kwargs,
+    ) -> None:
+        """Initialize the Concatenate layer.
+
+        Args:
+            input_cols: Column names of the input tensors.
+            output_cols: Single-element list naming the concatenated output.
+            dtype: Optional output dtype; when ``None``, preserves input dtype.
+            **kwargs: Additional base-layer options (e.g. ``name``).
+        """
+        super().__init__(input_cols, output_cols, **kwargs)
+        self.dtype = initialize_dtype(dtype, None)
+
+    def forward(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """Concatenate the input columns along the last dimension.
+
+        Args:
+            inputs: Mapping from column name to tensor.
+
+        Returns:
+            A single-entry mapping from the output column to the concatenated
+            tensor, cast to ``dtype`` when one was provided.
+        """
+        tensors: list[torch.Tensor] = []
+        for in_col in self.input_cols:
+            input_tensor = inputs[in_col]
+            tensors.append(input_tensor)
+        concatenated = torch.cat(tensors, dim=-1)
+        if self.dtype is not None:
+            concatenated = concatenated.to(self.dtype)
+        return {self.output_cols[0]: concatenated}
+
+
+class Stack(TorchTransformBaseLayer):
+    """Stack input tensors along a new dimension.
+
+    Inputs are cast to ``float32`` before stacking. For ``N`` input tensors each
+    of shape ``(B, L)``, the output has shape ``(B, L, N)`` when ``dim=-1`` or
+    ``(B, N, L)`` when ``dim=1``.
+
+    Args:
+        input_cols: Column names of the input tensors.
+        output_cols: Single-element list naming the stacked output column.
+        **kwargs: Additional options. ``dim`` (int) is the dimension along which
+            to stack (default ``-1``); ``name`` sets the layer name.
+    """
+
+    def __init__(self, input_cols: list[str], output_cols: list[str], **kwargs) -> None:
+        """Initialize the Stack layer.
+
+        Args:
+            input_cols: Column names of the input tensors.
+            output_cols: Single-element list naming the stacked output column.
+            **kwargs: Additional options; ``dim`` (int, default ``-1``) selects
+                the new dimension, and ``name`` sets the layer name.
+        """
+        super().__init__(input_cols, output_cols, **kwargs)
+        self.dim: int = kwargs.get("dim", -1)
+
+    def forward(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """Stack the input columns along ``dim``.
+
+        Args:
+            inputs: Mapping from column name to tensor.
+
+        Returns:
+            A single-entry mapping from the output column to the stacked tensor.
+        """
+        tensors: list[torch.Tensor] = []
+        for in_col in self.input_cols:
+            input_tensor = inputs[in_col]
+            tensors.append(input_tensor.to(torch.float32))
+        return {self.output_cols[0]: torch.stack(tensors, dim=self.dim)}
+
+
+class Cast(TorchTransformBaseLayer):
+    """Cast input tensors to a target dtype.
+
+    Args:
+        input_cols: Column names of the input tensors.
+        output_cols: Column names of the output tensors; must match the length
+            of ``input_cols``.
+        dtype: Target dtype to cast to. Defaults to ``torch.int64`` when not a
+            recognized dtype or string alias.
+        **kwargs: Additional base-layer options (e.g. ``name``).
+
+    Raises:
+        ValueError: If ``input_cols`` and ``output_cols`` differ in length.
+    """
+
+    def __init__(
+        self,
+        input_cols: list[str],
+        output_cols: list[str],
+        dtype: torch.dtype | str | None = None,
+        **kwargs,
+    ) -> None:
+        """Initialize the Cast layer.
+
+        Args:
+            input_cols: Column names of the input tensors.
+            output_cols: Column names of the output tensors; must match the
+                length of ``input_cols``.
+            dtype: Target dtype; defaults to ``torch.int64``.
+            **kwargs: Additional base-layer options (e.g. ``name``).
+
+        Raises:
+            ValueError: If ``input_cols`` and ``output_cols`` differ in length.
+        """
+        if len(input_cols) != len(output_cols):
+            raise ValueError(
+                "Input columns and output columns must have the same length."
+            )
+        super().__init__(input_cols, output_cols, **kwargs)
+        self.dtype = initialize_dtype(dtype, torch.int64)
+
+    def forward(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """Cast each input column to ``dtype``.
+
+        Args:
+            inputs: Mapping from column name to tensor.
+
+        Returns:
+            A mapping from each output column to its cast tensor.
+        """
+        stacked_input = format_inputs(self.input_cols, inputs)
+        stacked_output = stacked_input.to(self.dtype)
+        outputs = format_outputs(self.output_cols, stacked_output)
+        return outputs
+
+
+class Constant(TorchTransformBaseLayer):
+    """Produce a constant tensor shaped like the input.
+
+    Useful for migrating conditional expressions (``if (cond) {...} else {...}``)
+    whose branches return constants: the constant is materialized as a tensor
+    matching the reference input's shape.
+
+    Args:
+        input_cols: Column names of the input tensors, used only for shape
+            reference; must match the length of ``output_cols``.
+        output_cols: Column names of the output tensors.
+        constant: The value to fill the output tensor with.
+        dtype: Output dtype. When ``None``, it is inferred from ``constant``.
+        **kwargs: Additional base-layer options (e.g. ``name``).
+
+    Raises:
+        ValueError: If ``input_cols`` and ``output_cols`` differ in length, or if
+            ``input_cols`` is empty (no shape reference available).
+    """
+
+    def __init__(
+        self,
+        input_cols: list[str],
+        output_cols: list[str],
+        constant: int | float | bool,
+        dtype: torch.dtype | str | None = None,
+        **kwargs,
+    ) -> None:
+        """Initialize the Constant layer.
+
+        Args:
+            input_cols: Column names used for shape reference; must match the
+                length of ``output_cols`` and be non-empty.
+            output_cols: Column names of the output tensors.
+            constant: The value to fill the output tensor with.
+            dtype: Output dtype; inferred from ``constant`` when ``None``.
+            **kwargs: Additional base-layer options (e.g. ``name``).
+
+        Raises:
+            ValueError: If ``input_cols`` and ``output_cols`` differ in length,
+                or if ``input_cols`` is empty.
+        """
+        super().__init__(input_cols, output_cols, **kwargs)
+        if len(input_cols) != len(output_cols):
+            raise ValueError(
+                "Input columns and output columns must have the same length."
+            )
+        if not self.input_cols:
+            raise ValueError(
+                "Constant requires at least one input column for shape reference."
+            )
+        self.constant = constant
+        self.dtype = initialize_dtype(dtype, torch.tensor(self.constant).dtype)
+
+    def forward(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """Create a constant tensor matching the input's shape.
+
+        Args:
+            inputs: Mapping from column name to tensor.
+
+        Returns:
+            A mapping from each output column to a constant-filled tensor.
+        """
+        stacked_inputs = format_inputs(self.input_cols, inputs)
+        shape = stacked_inputs.shape
+
+        # ``new_full`` inherits the input's device dynamically. Under
+        # ``torch.jit.trace`` a literal ``torch.tensor(...).to(device)`` would
+        # bake the trace-time device in and break inference after ``.to("cuda")``.
+        stacked_outputs = stacked_inputs.new_full(
+            shape, self.constant, dtype=self.dtype
+        )
+        outputs = format_outputs(self.output_cols, stacked_outputs)
+        return outputs
+
+
+class Divide(TorchTransformBaseLayer):
+    """Divide input columns pairwise, element-wise, with zero-safe handling.
+
+    Input columns are read in ``(numerator, denominator)`` pairs (even indices
+    are numerators, odd indices denominators), so ``len(input_cols)`` must be
+    even and ``output_cols`` half its length. Both operands are upcast to
+    ``float64`` before division. A zero denominator is replaced with ``eps`` to
+    avoid division by zero; when both operands are zero the result is forced to
+    ``0``.
+
+    Args:
+        input_cols: Column names as ``(numerator, denominator)`` pairs.
+        output_cols: Column names of the quotient outputs.
+        add_constant_to_divisor: Constant added to every denominator before
+            division.
+        **kwargs: Additional options. ``eps`` (float) is the small value
+            substituted for a zero denominator (default
+            :data:`~michelangelo.lib.native_transform.torch.constants.DEFAULT_EPSILON`);
+            ``name`` sets the layer name.
+
+    Raises:
+        ValueError: If ``input_cols`` is not even, or ``output_cols`` is not half
+            its length.
+    """
+
+    def __init__(
+        self,
+        input_cols: list[str],
+        output_cols: list[str],
+        add_constant_to_divisor: float = 0.0,
+        **kwargs,
+    ) -> None:
+        """Initialize the Divide layer.
+
+        Args:
+            input_cols: Column names as ``(numerator, denominator)`` pairs.
+            output_cols: Column names of the quotient outputs.
+            add_constant_to_divisor: Constant added to every denominator.
+            **kwargs: Additional options; ``eps`` (float) overrides the zero-safe
+                epsilon and ``name`` sets the layer name.
+
+        Raises:
+            ValueError: If ``input_cols`` is not even, or ``output_cols`` is not
+                half its length.
+        """
+        super().__init__(input_cols, output_cols, **kwargs)
+        if (len(input_cols) % 2 != 0) or (len(input_cols) / 2 != len(output_cols)):
+            raise ValueError(
+                "Input columns must be even and output columns must be half of "
+                "input columns."
+            )
+        self.add_constant_to_divisor = add_constant_to_divisor
+        self.eps = kwargs.get("eps", DEFAULT_EPSILON)
+
+    def forward(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """Divide numerators by denominators, pairwise and zero-safe.
+
+        Args:
+            inputs: Mapping from column name to tensor.
+
+        Returns:
+            A mapping from each output column to its quotient tensor.
+        """
+        evens, odds = self.input_cols[0::2], self.input_cols[1::2]
+        stacked_evens = format_inputs(evens, inputs).to(torch.float64)
+        stacked_odds = format_inputs(odds, inputs).to(torch.float64)
+
+        stacked_odds += self.add_constant_to_divisor
+
+        safe_tensor2 = torch.where(
+            stacked_odds == 0,
+            torch.full_like(stacked_odds, self.eps),
+            stacked_odds,
+        )
+
+        result_tensor = torch.div(stacked_evens, safe_tensor2)
+        result_tensor = torch.where(
+            (stacked_evens == 0) & (stacked_odds == 0),
+            torch.zeros_like(result_tensor),
+            result_tensor,
+        )
+
+        outputs = format_outputs(self.output_cols, result_tensor)
+        return outputs
+
+
+class LogTransform(TorchTransformBaseLayer):
+    """Apply a logarithmic transform with an offset and output clamping.
+
+    Computes ``log(x + add_constant)`` and clamps the result to ``[1.0, 1e20]``.
+
+    Args:
+        input_cols: Column names of the input tensors.
+        output_cols: Column names of the output tensors; must match the length of
+            ``input_cols``.
+        **kwargs: Additional options. ``add_constant`` (float) is added before
+            the logarithm to avoid ``log(0)`` (default ``1.0``); ``name`` sets
+            the layer name.
+
+    Raises:
+        ValueError: If ``input_cols`` and ``output_cols`` differ in length.
+    """
+
+    def __init__(self, input_cols: list[str], output_cols: list[str], **kwargs) -> None:
+        """Initialize the LogTransform layer.
+
+        Args:
+            input_cols: Column names of the input tensors.
+            output_cols: Column names of the output tensors; must match the
+                length of ``input_cols``.
+            **kwargs: Additional options; ``add_constant`` (float, default
+                ``1.0``) is added before the logarithm and ``name`` sets the
+                layer name.
+
+        Raises:
+            ValueError: If ``input_cols`` and ``output_cols`` differ in length.
+        """
+        super().__init__(input_cols, output_cols)
+        if len(input_cols) != len(output_cols):
+            raise ValueError(
+                "Input columns and output columns must have the same length."
+            )
+        self.add_constant = kwargs.get("add_constant", 1.0)
+
+    def forward(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """Apply the log transform to each input column.
+
+        Args:
+            inputs: Mapping from column name to tensor.
+
+        Returns:
+            A mapping from each output column to its transformed, clamped tensor.
+        """
+        stacked_inputs = format_inputs(self.input_cols, inputs)
+        stacked_outputs = torch.log(stacked_inputs + self.add_constant)
+        stacked_outputs = torch.clamp(stacked_outputs, min=1.0, max=1e20)
+        return format_outputs(self.output_cols, stacked_outputs)
+
+
+class Subtract(TorchTransformBaseLayer):
+    """Subtract input columns pairwise, element-wise.
+
+    Input columns are read in ``(minuend, subtrahend)`` pairs (even indices are
+    minuends, odd indices subtrahends), so ``len(input_cols)`` must be even and
+    ``output_cols`` half its length. Both operands are upcast to ``float64``
+    before subtraction.
+
+    Args:
+        input_cols: Column names as ``(minuend, subtrahend)`` pairs.
+        output_cols: Column names of the difference outputs.
+        **kwargs: Additional base-layer options (e.g. ``name``).
+
+    Raises:
+        ValueError: If ``input_cols`` is not even, or ``output_cols`` is not half
+            its length.
+    """
+
+    def __init__(self, input_cols: list[str], output_cols: list[str], **kwargs) -> None:
+        """Initialize the Subtract layer.
+
+        Args:
+            input_cols: Column names as ``(minuend, subtrahend)`` pairs.
+            output_cols: Column names of the difference outputs.
+            **kwargs: Additional base-layer options (e.g. ``name``).
+
+        Raises:
+            ValueError: If ``input_cols`` is not even, or ``output_cols`` is not
+                half its length.
+        """
+        super().__init__(input_cols, output_cols, **kwargs)
+        if (len(input_cols) % 2 != 0) or (len(input_cols) / 2 != len(output_cols)):
+            raise ValueError(
+                "Input columns must be even and output columns must be half of "
+                "input columns."
+            )
+
+    def forward(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """Subtract subtrahends from minuends, pairwise.
+
+        Args:
+            inputs: Mapping from column name to tensor.
+
+        Returns:
+            A mapping from each output column to its difference tensor.
+        """
+        evens, odds = self.input_cols[0::2], self.input_cols[1::2]
+        stacked_evens = format_inputs(evens, inputs).to(torch.float64)
+        stacked_odds = format_inputs(odds, inputs).to(torch.float64)
+
+        result_tensor = torch.sub(stacked_evens, stacked_odds)
+
+        outputs = format_outputs(self.output_cols, result_tensor)
+        return outputs
+
+
+class Floor(TorchTransformBaseLayer):
+    """Apply an element-wise floor to input columns.
+
+    Args:
+        input_cols: Column names of the input tensors.
+        output_cols: Column names of the output tensors; must match the length of
+            ``input_cols``.
+        **kwargs: Additional base-layer options (e.g. ``name``).
+
+    Raises:
+        ValueError: If ``input_cols`` and ``output_cols`` differ in length.
+    """
+
+    def __init__(self, input_cols: list[str], output_cols: list[str], **kwargs) -> None:
+        """Initialize the Floor layer.
+
+        Args:
+            input_cols: Column names of the input tensors.
+            output_cols: Column names of the output tensors; must match the
+                length of ``input_cols``.
+            **kwargs: Additional base-layer options (e.g. ``name``).
+
+        Raises:
+            ValueError: If ``input_cols`` and ``output_cols`` differ in length.
+        """
+        super().__init__(input_cols, output_cols, **kwargs)
+        if len(input_cols) != len(output_cols):
+            raise ValueError(
+                "Input columns and output columns must have the same length."
+            )
+
+    def forward(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """Apply floor to each input column.
+
+        Args:
+            inputs: Mapping from column name to tensor.
+
+        Returns:
+            A mapping from each output column to its floored tensor.
+        """
+        stacked_inputs = format_inputs(self.input_cols, inputs)
+        output_tensor = torch.floor(stacked_inputs)
+        return format_outputs(self.output_cols, output_tensor)
+
+
+class Ceil(TorchTransformBaseLayer):
+    """Apply an element-wise ceiling to input columns.
+
+    Args:
+        input_cols: Column names of the input tensors.
+        output_cols: Column names of the output tensors; must match the length of
+            ``input_cols``.
+        **kwargs: Additional base-layer options (e.g. ``name``).
+
+    Raises:
+        ValueError: If ``input_cols`` and ``output_cols`` differ in length.
+    """
+
+    def __init__(self, input_cols: list[str], output_cols: list[str], **kwargs) -> None:
+        """Initialize the Ceil layer.
+
+        Args:
+            input_cols: Column names of the input tensors.
+            output_cols: Column names of the output tensors; must match the
+                length of ``input_cols``.
+            **kwargs: Additional base-layer options (e.g. ``name``).
+
+        Raises:
+            ValueError: If ``input_cols`` and ``output_cols`` differ in length.
+        """
+        super().__init__(input_cols, output_cols, **kwargs)
+        if len(input_cols) != len(output_cols):
+            raise ValueError(
+                "Input columns and output columns must have the same length."
+            )
+
+    def forward(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """Apply ceiling to each input column.
+
+        Args:
+            inputs: Mapping from column name to tensor.
+
+        Returns:
+            A mapping from each output column to its ceiled tensor.
+        """
+        stacked_inputs = format_inputs(self.input_cols, inputs)
+        output_tensor = torch.ceil(stacked_inputs)
+        return format_outputs(self.output_cols, output_tensor)
+
+
+class IdentityTransform(TorchTransformBaseLayer):
+    """Pass input tensors through unchanged.
+
+    Explicitly includes fields in a native transform's input schema without
+    modifying them — useful for bypass fields that downstream model assembly
+    needs available.
+
+    Args:
+        input_cols: Column names of the input tensors.
+        output_cols: Column names of the output tensors; must match the length of
+            ``input_cols``.
+        **kwargs: Additional base-layer options (e.g. ``name``).
+
+    Raises:
+        ValueError: If ``input_cols`` and ``output_cols`` differ in length.
+    """
+
+    def __init__(self, input_cols: list[str], output_cols: list[str], **kwargs) -> None:
+        """Initialize the IdentityTransform layer.
+
+        Args:
+            input_cols: Column names of the input tensors.
+            output_cols: Column names of the output tensors; must match the
+                length of ``input_cols``.
+            **kwargs: Additional base-layer options (e.g. ``name``).
+
+        Raises:
+            ValueError: If ``input_cols`` and ``output_cols`` differ in length.
+        """
+        super().__init__(input_cols, output_cols, **kwargs)
+        if len(input_cols) != len(output_cols):
+            raise ValueError(
+                "Input columns and output columns must have the same length."
+            )
+
+    def forward(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """Pass each input column through unchanged.
+
+        Args:
+            inputs: Mapping from column name to tensor.
+
+        Returns:
+            A mapping from each output column to the corresponding input tensor.
+        """
+        stacked_inputs = format_inputs(self.input_cols, inputs)
+        return format_outputs(self.output_cols, stacked_inputs)

--- a/python/michelangelo/lib/native_transform/torch/constants.py
+++ b/python/michelangelo/lib/native_transform/torch/constants.py
@@ -1,0 +1,82 @@
+"""Shared constants for PyTorch native transform layers.
+
+Module-level constants, default values, and dtype-mapping dictionaries used
+throughout the ``native_transform`` torch package. These are leaf definitions
+with no dependencies on the rest of the package so every downstream module can
+import them safely.
+"""
+
+from __future__ import annotations
+
+import torch
+
+SHAPE = "shape"
+TENSOR_COMPILATION_TORCH_MINIMUM_VERSION = "2.3"
+DEFAULT_NUM_PARTITIONS = 100
+DEFAULT_PARQUET_BLOCK_SIZE = 512
+DEFAULT_NUM_SAMPLES_TO_EXPLAIN = 10000
+DEFAULT_NUMERICAL_OUTPUT_DTYPE = torch.float32
+DEFAULT_STRING_OUTPUT_DTYPE = "string"
+
+STRING_DATA_TYPE_TO_TORCH_TYPE_MAP: dict[str, torch.dtype] = {
+    "float32": torch.float32,
+    "float64": torch.float64,
+    "int32": torch.int32,
+    "int64": torch.int64,
+    "bool": torch.bool,
+}
+
+TORCH_DTYPE_CLASS_NAME_TO_TORCH_TYPE_MAP: dict[str, torch.dtype | str] = {
+    "torch.int32": torch.int32,
+    "torch.int64": torch.int64,
+    "torch.float32": torch.float32,
+    "torch.float64": torch.float64,
+    "torch.bool": torch.bool,
+    "string": "string",
+}
+
+TORCH_TYPE_TO_TORCH_DTYPE_CLASS_NAME_MAP: dict[torch.dtype | str, str] = {
+    torch.int32: "torch.int32",
+    torch.int64: "torch.int64",
+    torch.float32: "torch.float32",
+    torch.float64: "torch.float64",
+    torch.bool: "torch.bool",
+    "string": "string",
+}
+
+NUMERICAL_TRANSFORM = "numerical_transform"
+CATEGORICAL_TRANSFORM = "categorical_transform"
+STRING_LENGTH_TRANSFORM = "string_length_transform"
+NUM_TO_CAT_TRANSFORM = "num_to_cat_transform"
+IS_NULL_TRANSFORM = "is_null_transform"
+BOOL_TO_FLOAT_TRANSFORM = "bool_to_float_transform"
+STRING_VALUE_CHECK_TRANSFORM = "string_value_check_transform"
+STRING_VALUE_CONTAINS_TRANSFORM = "string_value_contains_transform"
+STRING_VALUE_EQUAL_TRANSFORM = "string_value_equal_transform"
+NUMERICAL_DIFF_TRANSFORM = "numerical_diff_transform"
+GEO_DISTANCE_TRANSFORM = "geo_distance_transform"
+GIBBERISH_SCORE_TRANSFORM = "gibberish_score_transform"
+EDIT_DISTANCE_TRANSFORM = "edit_distance_transform"
+STRING_CONTAINS_TRANSFORM = "string_contains_transform"
+FEATURE_PAIR_MATCH_TRANSFORM = "feature_pair_match_transform"
+FEATURE_DIVIDE_TRANSFORM = "feature_divide_transform"
+STRING_SEQUENCE_TRANSFORM = "string_sequence_transform"
+SIMPLE_FEATURE_ASSEMBLER = "simple_feature_assembler"
+STANDARD_SCALER = "StandardScaler"
+MIN_MAX_SCALER = "MinMaxScaler"
+DEFAULT_VECTOR_TYPE_DICT: dict[str, str] = {
+    "scalar_output_vec": STANDARD_SCALER,
+    "categorical_output_vec": SIMPLE_FEATURE_ASSEMBLER,
+    "ratio_output_vec": SIMPLE_FEATURE_ASSEMBLER,
+    "boolean_output_vec": SIMPLE_FEATURE_ASSEMBLER,
+}
+
+DEFAULT_NULL_STRING = "null_string"
+DEFAULT_NUMERICAL_VALUE = -1.0
+DEFAULT_EMAIL_GIBBERISH_SCORE = 0.05
+DEFAULT_NAME_GIBBERISH_SCORE = 0.113792509289
+DEFAULT_STANDARD_SCALER_NAME = "StandardScaler"
+DEFAULT_MIN_MAX_SCALER_NAME = "MinMaxScaler"
+DEFAULT_STRING_INDEXER_NAME = "StringIndexer"
+DEFAULT_TIME_DURATION_UNIT = 24 * 60 * 60 * 1000
+DEFAULT_EPSILON = 1e-7

--- a/python/michelangelo/lib/native_transform/torch/tests/test_base_layers.py
+++ b/python/michelangelo/lib/native_transform/torch/tests/test_base_layers.py
@@ -1,0 +1,649 @@
+"""Tests for :mod:`michelangelo.lib.native_transform.torch.base_layers`.
+
+Covers the forward semantics of the foundation transform layers and, for every
+layer, a ``torch.jit.script`` round-trip: native transform layers must be
+TorchScript-exportable so the exact transform runs at serve time, and the
+scripted module (including after save/load) must reproduce the eager output.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# These layers operate on real torch tensors/modules. Skip cleanly if torch is
+# unavailable in a lightweight environment.
+torch = pytest.importorskip("torch")
+
+from michelangelo.lib.native_transform.torch.base_layers import (  # noqa: E402
+    Cast,
+    Ceil,
+    Concatenate,
+    Constant,
+    Divide,
+    Floor,
+    IdentityTransform,
+    LogTransform,
+    Stack,
+    Subtract,
+    TorchTransformBaseLayer,
+)
+
+
+class _BaseTestLayer(TorchTransformBaseLayer):
+    """Minimal concrete subclass used to exercise the abstract base."""
+
+    def forward(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """Return the first input column under the first output column."""
+        return {self.output_cols[0]: inputs[self.input_cols[0]]}
+
+
+class TestTorchTransformBaseLayer:
+    """Base-layer construction and abstractness."""
+
+    def test_init_with_kwargs(self) -> None:
+        """``name`` and columns are stored from constructor arguments."""
+        layer = _BaseTestLayer(
+            input_cols=["col1", "col2"], output_cols=["output"], name="test_layer"
+        )
+        assert layer.name == "test_layer"
+        assert layer.input_cols == ["col1", "col2"]
+        assert layer.output_cols == ["output"]
+
+    def test_init_without_kwargs(self) -> None:
+        """``name`` defaults to ``"transform_layer"``."""
+        layer = _BaseTestLayer(input_cols=[], output_cols=[])
+        assert layer.name == "transform_layer"
+
+    def test_abstract_class_cannot_be_instantiated(self) -> None:
+        """The abstract base cannot be instantiated directly."""
+        with pytest.raises(TypeError):
+            TorchTransformBaseLayer(input_cols=["test"], output_cols=["output"])
+
+
+class TestConcatenate:
+    """Concatenation along the last dimension with dtype handling."""
+
+    def test_forward_basic(self) -> None:
+        """Columns concatenate along the last dim, preserving float32."""
+        layer = Concatenate(
+            input_cols=["col1", "col2", "col3"], output_cols=["concatenated"]
+        )
+        inputs = {
+            "col1": torch.tensor([[1.0, 2.0], [3.0, 4.0]]),
+            "col2": torch.tensor([[5.0], [6.0]]),
+            "col3": torch.tensor([[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]]),
+        }
+        outputs = layer(inputs)
+        expected = torch.tensor(
+            [[1.0, 2.0, 5.0, 7.0, 8.0, 9.0], [3.0, 4.0, 6.0, 10.0, 11.0, 12.0]]
+        )
+        torch.testing.assert_close(outputs["concatenated"], expected)
+        assert outputs["concatenated"].dtype == torch.float32
+
+    def test_forward_type_promotion(self) -> None:
+        """Mixed dtypes promote to the widest type when dtype is None."""
+        layer = Concatenate(
+            input_cols=["col1", "col2", "col3"], output_cols=["concatenated"]
+        )
+        inputs = {
+            "col1": torch.tensor([[1, 2]], dtype=torch.int32),
+            "col2": torch.tensor([[3.5]], dtype=torch.float64),
+            "col3": torch.tensor([[4]], dtype=torch.int64),
+        }
+        outputs = layer(inputs)
+        assert outputs["concatenated"].dtype == torch.float64
+        expected = torch.tensor([[1.0, 2.0, 3.5, 4.0]], dtype=torch.float64)
+        torch.testing.assert_close(outputs["concatenated"], expected)
+
+    def test_forward_single_tensor(self) -> None:
+        """A single input column passes through unchanged."""
+        layer = Concatenate(input_cols=["col1"], output_cols=["output"])
+        inputs = {"col1": torch.tensor([[1.0, 2.0, 3.0]])}
+        torch.testing.assert_close(layer(inputs)["output"], inputs["col1"])
+
+    def test_forward_preserve_int_dtype(self) -> None:
+        """Integer inputs keep their dtype when no dtype is given."""
+        layer = Concatenate(input_cols=["col1", "col2"], output_cols=["concatenated"])
+        inputs = {
+            "col1": torch.tensor([[1, 2]], dtype=torch.int32),
+            "col2": torch.tensor([[3, 4]], dtype=torch.int32),
+        }
+        outputs = layer(inputs)
+        assert outputs["concatenated"].dtype == torch.int32
+        torch.testing.assert_close(
+            outputs["concatenated"], torch.tensor([[1, 2, 3, 4]], dtype=torch.int32)
+        )
+
+    def test_forward_explicit_dtype(self) -> None:
+        """An explicit dtype forces conversion of the output."""
+        layer = Concatenate(
+            input_cols=["col1", "col2"],
+            output_cols=["concatenated"],
+            dtype=torch.float32,
+        )
+        inputs = {
+            "col1": torch.tensor([[1, 2]], dtype=torch.int32),
+            "col2": torch.tensor([[3, 4]], dtype=torch.int32),
+        }
+        outputs = layer(inputs)
+        assert outputs["concatenated"].dtype == torch.float32
+        torch.testing.assert_close(
+            outputs["concatenated"],
+            torch.tensor([[1.0, 2.0, 3.0, 4.0]], dtype=torch.float32),
+        )
+
+
+class TestStack:
+    """Stacking along a new dimension (inputs cast to float32)."""
+
+    def test_default_dim(self) -> None:
+        """Default ``dim=-1`` and the layer stores it."""
+        layer = Stack(input_cols=["a", "b"], output_cols=["out"])
+        assert layer.dim == -1
+
+    def test_custom_dim(self) -> None:
+        """A custom ``dim`` kwarg is stored."""
+        assert Stack(input_cols=["a", "b"], output_cols=["out"], dim=1).dim == 1
+
+    def test_forward_default_dim(self) -> None:
+        """2D inputs stack along the last dim to shape ``(B, L, N)``."""
+        layer = Stack(input_cols=["col1", "col2", "col3"], output_cols=["stacked"])
+        inputs = {
+            "col1": torch.tensor([[1.0, 2.0], [3.0, 4.0]]),
+            "col2": torch.tensor([[5.0, 6.0], [7.0, 8.0]]),
+            "col3": torch.tensor([[9.0, 10.0], [11.0, 12.0]]),
+        }
+        outputs = layer(inputs)
+        assert outputs["stacked"].shape == torch.Size([2, 2, 3])
+        expected = torch.stack([inputs["col1"], inputs["col2"], inputs["col3"]], dim=-1)
+        torch.testing.assert_close(outputs["stacked"], expected)
+
+    def test_forward_dim_1(self) -> None:
+        """Stacking along ``dim=1`` inserts the new axis in the middle."""
+        layer = Stack(input_cols=["a", "b"], output_cols=["out"], dim=1)
+        inputs = {
+            "a": torch.tensor([[1.0, 2.0], [3.0, 4.0]]),
+            "b": torch.tensor([[5.0, 6.0], [7.0, 8.0]]),
+        }
+        outputs = layer(inputs)
+        assert outputs["out"].shape == torch.Size([2, 2, 2])
+        torch.testing.assert_close(
+            outputs["out"], torch.stack([inputs["a"], inputs["b"]], dim=1)
+        )
+
+    def test_forward_dim_0(self) -> None:
+        """Stacking 1D inputs along ``dim=0`` yields shape ``(N, L)``."""
+        layer = Stack(input_cols=["a", "b"], output_cols=["out"], dim=0)
+        inputs = {"a": torch.tensor([1.0, 2.0]), "b": torch.tensor([3.0, 4.0])}
+        outputs = layer(inputs)
+        assert outputs["out"].shape == torch.Size([2, 2])
+
+    def test_forward_casts_to_float32(self) -> None:
+        """Mixed-dtype inputs are stacked as float32."""
+        layer = Stack(input_cols=["a", "b"], output_cols=["out"])
+        inputs = {
+            "a": torch.tensor([1, 2], dtype=torch.int32),
+            "b": torch.tensor([3.5, 4.5], dtype=torch.float64),
+        }
+        assert layer(inputs)["out"].dtype == torch.float32
+
+
+class TestCast:
+    """Casting to a target dtype."""
+
+    def test_forward_to_float(self) -> None:
+        """Int input casts to float32."""
+        layer = Cast(
+            input_cols=["feature"], output_cols=["casted"], dtype=torch.float32
+        )
+        inputs = {"feature": torch.tensor([1, 2, 3], dtype=torch.int32)}
+        outputs = layer(inputs)
+        assert outputs["casted"].dtype == torch.float32
+        torch.testing.assert_close(outputs["casted"], torch.tensor([1.0, 2.0, 3.0]))
+
+    def test_forward_to_int(self) -> None:
+        """Float input truncates to int64."""
+        layer = Cast(input_cols=["feature"], output_cols=["casted"], dtype=torch.int64)
+        inputs = {"feature": torch.tensor([1.1, 2.9, 3.5], dtype=torch.float32)}
+        outputs = layer(inputs)
+        assert outputs["casted"].dtype == torch.int64
+        torch.testing.assert_close(outputs["casted"], torch.tensor([1, 2, 3]))
+
+    def test_mismatched_columns_raises(self) -> None:
+        """Unequal input/output column counts raise ``ValueError``."""
+        with pytest.raises(ValueError, match="same length"):
+            Cast(input_cols=["a", "b"], output_cols=["out"])
+
+
+class TestConstant:
+    """Constant tensor generation shaped like the input."""
+
+    def test_forward_scalar(self) -> None:
+        """A scalar constant fills a tensor matching the input shape."""
+        layer = Constant(
+            input_cols=["target"],
+            output_cols=["const"],
+            constant=3.14,
+            dtype=torch.float32,
+        )
+        inputs = {"target": torch.tensor([1, 2, 3])}
+        outputs = layer(inputs)
+        assert outputs["const"].dtype == torch.float32
+        assert outputs["const"].shape == inputs["target"].shape
+        torch.testing.assert_close(outputs["const"], torch.tensor([3.14, 3.14, 3.14]))
+
+    def test_no_input_column_raises(self) -> None:
+        """An empty ``input_cols`` raises ``ValueError``."""
+        with pytest.raises(ValueError):
+            Constant(
+                input_cols=[], output_cols=["const"], constant=42, dtype=torch.int32
+            )
+
+    def test_forward_multiple_columns(self) -> None:
+        """Each output column gets its own constant-filled tensor."""
+        layer = Constant(
+            input_cols=["in1", "in2"], output_cols=["out1", "out2"], constant=1.0
+        )
+        inputs = {"in1": torch.tensor([1, 2]), "in2": torch.tensor([3, 4])}
+        outputs = layer(inputs)
+        expected = torch.tensor([1.0, 1.0])
+        torch.testing.assert_close(outputs["out1"], expected)
+        torch.testing.assert_close(outputs["out2"], expected)
+
+    def test_forward_multi_dimensional(self) -> None:
+        """A 2D reference produces a matching 2D constant tensor."""
+        layer = Constant(
+            input_cols=["matrix"],
+            output_cols=["const"],
+            constant=7.0,
+            dtype=torch.float32,
+        )
+        inputs = {"matrix": torch.tensor([[1, 2], [3, 4]])}
+        torch.testing.assert_close(
+            layer(inputs)["const"], torch.tensor([[7.0, 7.0], [7.0, 7.0]])
+        )
+
+    def test_forward_bool_constant(self) -> None:
+        """A boolean constant infers a bool output dtype."""
+        layer = Constant(input_cols=["ref"], output_cols=["const"], constant=True)
+        inputs = {"ref": torch.tensor([1, 2, 3])}
+        torch.testing.assert_close(
+            layer(inputs)["const"], torch.tensor([True, True, True])
+        )
+
+    def test_forward_infer_dtype(self) -> None:
+        """An int constant infers an int64 output dtype."""
+        layer = Constant(input_cols=["ref"], output_cols=["const"], constant=42)
+        inputs = {"ref": torch.tensor([1.0, 2.0])}
+        assert layer(inputs)["const"].dtype == torch.int64
+
+    def test_mismatched_columns_raises(self) -> None:
+        """Unequal input/output column counts raise ``ValueError``."""
+        with pytest.raises(ValueError, match="same length"):
+            Constant(input_cols=["a", "b"], output_cols=["out"], constant=1.0)
+
+
+class TestDivide:
+    """Pairwise element-wise division with zero-safe handling."""
+
+    def test_forward_basic(self) -> None:
+        """A single numerator/denominator pair divides in float64."""
+        layer = Divide(input_cols=["numerator", "denominator"], output_cols=["divided"])
+        inputs = {
+            "numerator": torch.tensor([10.0, 20.0, 30.0]),
+            "denominator": torch.tensor([2.0, 5.0, 10.0]),
+        }
+        expected = torch.tensor([5.0, 4.0, 3.0], dtype=torch.float64)
+        torch.testing.assert_close(layer(inputs)["divided"], expected)
+
+    def test_forward_safe_division_by_zero(self) -> None:
+        """Zero denominators yield finite results; 0/0 becomes 0."""
+        layer = Divide(input_cols=["numerator", "denominator"], output_cols=["divided"])
+        inputs = {
+            "numerator": torch.tensor([10.0, 0.0]),
+            "denominator": torch.tensor([0.0, 0.0]),
+        }
+        outputs = layer(inputs)
+        assert torch.isfinite(outputs["divided"]).all()
+        assert outputs["divided"][0].abs() > 1e6
+        assert outputs["divided"][1] == 0.0
+
+    def test_forward_multiple_pairs(self) -> None:
+        """Multiple pairs divide independently."""
+        layer = Divide(
+            input_cols=["n1", "d1", "n2", "d2"], output_cols=["out1", "out2"]
+        )
+        inputs = {
+            "n1": torch.tensor([10.0, 20.0]),
+            "d1": torch.tensor([2.0, 4.0]),
+            "n2": torch.tensor([30.0, 40.0]),
+            "d2": torch.tensor([3.0, 8.0]),
+        }
+        outputs = layer(inputs)
+        torch.testing.assert_close(
+            outputs["out1"], torch.tensor([5.0, 5.0], dtype=torch.float64)
+        )
+        torch.testing.assert_close(
+            outputs["out2"], torch.tensor([10.0, 5.0], dtype=torch.float64)
+        )
+
+    def test_forward_add_constant_to_divisor(self) -> None:
+        """The divisor constant shifts the denominator before dividing."""
+        layer = Divide(
+            input_cols=["num", "den"],
+            output_cols=["result"],
+            add_constant_to_divisor=1.0,
+        )
+        inputs = {
+            "num": torch.tensor([10.0, 20.0]),
+            "den": torch.tensor([2.0, 4.0]),
+        }
+        # 10 / (2 + 1) and 20 / (4 + 1).
+        expected = torch.tensor([10.0 / 3.0, 4.0], dtype=torch.float64)
+        torch.testing.assert_close(layer(inputs)["result"], expected)
+
+    def test_odd_input_columns_raises(self) -> None:
+        """An odd number of input columns raises ``ValueError``."""
+        with pytest.raises(ValueError, match="even"):
+            Divide(input_cols=["a", "b", "c"], output_cols=["out"])
+
+
+class TestLogTransform:
+    """Logarithmic transform with offset and clamping."""
+
+    def test_forward_basic(self) -> None:
+        """log(x + 1) is clamped to ``[1.0, 1e20]``."""
+        layer = LogTransform(input_cols=["feature"], output_cols=["log_feature"])
+        inputs = {"feature": torch.tensor([0.0, 1.0, 9.0])}
+        expected = torch.clamp(
+            torch.log(torch.tensor([1.0, 2.0, 10.0])), min=1.0, max=1e20
+        )
+        torch.testing.assert_close(layer(inputs)["log_feature"], expected)
+
+    def test_forward_custom_add_constant(self) -> None:
+        """A custom ``add_constant`` shifts the input before the log."""
+        layer = LogTransform(
+            input_cols=["feature"], output_cols=["log_feature"], add_constant=10.0
+        )
+        inputs = {"feature": torch.tensor([0.0, 90.0])}
+        expected = torch.clamp(
+            torch.log(torch.tensor([10.0, 100.0])), min=1.0, max=1e20
+        )
+        torch.testing.assert_close(layer(inputs)["log_feature"], expected)
+
+    def test_forward_clamping_min(self) -> None:
+        """Results below 1.0 are clamped up to 1.0."""
+        layer = LogTransform(
+            input_cols=["feature"], output_cols=["log_feature"], add_constant=0.1
+        )
+        inputs = {"feature": torch.tensor([0.0])}
+        torch.testing.assert_close(layer(inputs)["log_feature"], torch.tensor([1.0]))
+
+    def test_mismatched_columns_raises(self) -> None:
+        """Unequal input/output column counts raise ``ValueError``."""
+        with pytest.raises(ValueError, match="same length"):
+            LogTransform(input_cols=["feat1", "feat2"], output_cols=["out1"])
+
+
+class TestSubtract:
+    """Pairwise element-wise subtraction in float64."""
+
+    def test_forward_basic(self) -> None:
+        """A single pair subtracts element-wise in float64."""
+        layer = Subtract(input_cols=["a", "b"], output_cols=["result"])
+        inputs = {
+            "a": torch.tensor([10.0, 20.0, 30.0]),
+            "b": torch.tensor([2.0, 5.0, 10.0]),
+        }
+        torch.testing.assert_close(
+            layer(inputs)["result"],
+            torch.tensor([8.0, 15.0, 20.0], dtype=torch.float64),
+        )
+
+    def test_forward_broadcasting(self) -> None:
+        """A scalar subtrahend broadcasts across the minuend."""
+        layer = Subtract(input_cols=["vector", "scalar"], output_cols=["result"])
+        inputs = {
+            "vector": torch.tensor([10.0, 20.0, 30.0]),
+            "scalar": torch.tensor([5.0]),
+        }
+        torch.testing.assert_close(
+            layer(inputs)["result"],
+            torch.tensor([5.0, 15.0, 25.0], dtype=torch.float64),
+        )
+
+    def test_forward_different_dtypes(self) -> None:
+        """Mixed dtypes subtract in float64."""
+        layer = Subtract(input_cols=["a", "b"], output_cols=["result"])
+        inputs = {
+            "a": torch.tensor([10, 20], dtype=torch.int32),
+            "b": torch.tensor([2.5, 5.5], dtype=torch.float64),
+        }
+        outputs = layer(inputs)
+        assert outputs["result"].dtype == torch.float64
+        torch.testing.assert_close(
+            outputs["result"], torch.tensor([7.5, 14.5], dtype=torch.float64)
+        )
+
+    def test_forward_multiple_pairs(self) -> None:
+        """Multiple pairs subtract independently."""
+        layer = Subtract(
+            input_cols=["a1", "b1", "a2", "b2"], output_cols=["out1", "out2"]
+        )
+        inputs = {
+            "a1": torch.tensor([10.0, 20.0]),
+            "b1": torch.tensor([2.0, 5.0]),
+            "a2": torch.tensor([30.0, 40.0]),
+            "b2": torch.tensor([10.0, 20.0]),
+        }
+        outputs = layer(inputs)
+        torch.testing.assert_close(
+            outputs["out1"], torch.tensor([8.0, 15.0], dtype=torch.float64)
+        )
+        torch.testing.assert_close(
+            outputs["out2"], torch.tensor([20.0, 20.0], dtype=torch.float64)
+        )
+
+    def test_odd_input_columns_raises(self) -> None:
+        """An odd number of input columns raises ``ValueError``."""
+        with pytest.raises(ValueError, match="even"):
+            Subtract(input_cols=["a", "b", "c"], output_cols=["out"])
+
+
+class TestFloor:
+    """Element-wise floor."""
+
+    def test_forward_basic(self) -> None:
+        """Floor rounds toward negative infinity."""
+        layer = Floor(input_cols=["val"], output_cols=["floored"])
+        inputs = {"val": torch.tensor([1.1, 2.9, -3.5])}
+        torch.testing.assert_close(
+            layer(inputs)["floored"], torch.tensor([1.0, 2.0, -4.0])
+        )
+
+    def test_forward_integers(self) -> None:
+        """Floor is a no-op on whole numbers."""
+        layer = Floor(input_cols=["val"], output_cols=["floored"])
+        inputs = {"val": torch.tensor([1.0, 2.0, 3.0])}
+        torch.testing.assert_close(
+            layer(inputs)["floored"], torch.tensor([1.0, 2.0, 3.0])
+        )
+
+    def test_mismatched_columns_raises(self) -> None:
+        """Unequal input/output column counts raise ``ValueError``."""
+        with pytest.raises(ValueError, match="same length"):
+            Floor(input_cols=["a", "b"], output_cols=["out"])
+
+
+class TestCeil:
+    """Element-wise ceiling."""
+
+    def test_forward_basic(self) -> None:
+        """Ceil rounds toward positive infinity."""
+        layer = Ceil(input_cols=["val"], output_cols=["ceiled"])
+        inputs = {"val": torch.tensor([1.1, 2.9, -3.5])}
+        torch.testing.assert_close(
+            layer(inputs)["ceiled"], torch.tensor([2.0, 3.0, -3.0])
+        )
+
+    def test_forward_integers(self) -> None:
+        """Ceil is a no-op on whole numbers."""
+        layer = Ceil(input_cols=["val"], output_cols=["ceiled"])
+        inputs = {"val": torch.tensor([1.0, 2.0, 3.0])}
+        torch.testing.assert_close(
+            layer(inputs)["ceiled"], torch.tensor([1.0, 2.0, 3.0])
+        )
+
+    def test_mismatched_columns_raises(self) -> None:
+        """Unequal input/output column counts raise ``ValueError``."""
+        with pytest.raises(ValueError, match="same length"):
+            Ceil(input_cols=["a", "b"], output_cols=["out"])
+
+
+class TestIdentityTransform:
+    """Pass-through transform."""
+
+    def test_basic_identity(self) -> None:
+        """Integer values pass through unchanged."""
+        layer = IdentityTransform(
+            input_cols=["user_id"], output_cols=["bypass_user_id"]
+        )
+        inputs = {"user_id": torch.tensor([123, 456, 789], dtype=torch.long)}
+        torch.testing.assert_close(layer(inputs)["bypass_user_id"], inputs["user_id"])
+
+    def test_multiple_columns(self) -> None:
+        """Multiple columns each map through to their output."""
+        layer = IdentityTransform(
+            input_cols=["col1", "col2"], output_cols=["out1", "out2"]
+        )
+        inputs = {
+            "col1": torch.tensor([10, 20], dtype=torch.long),
+            "col2": torch.tensor([30, 40], dtype=torch.long),
+        }
+        outputs = layer(inputs)
+        torch.testing.assert_close(outputs["out1"], inputs["col1"])
+        torch.testing.assert_close(outputs["out2"], inputs["col2"])
+
+    def test_preserves_dtype(self) -> None:
+        """Input dtype is preserved on the output."""
+        layer = IdentityTransform(input_cols=["data"], output_cols=["bypass_data"])
+        out_int32 = layer({"data": torch.tensor([1, 2, 3], dtype=torch.int32)})
+        assert out_int32["bypass_data"].dtype == torch.int32
+        out_f64 = layer({"data": torch.tensor([1.0, 2.0], dtype=torch.float64)})
+        assert out_f64["bypass_data"].dtype == torch.float64
+
+    def test_preserves_shape(self) -> None:
+        """A 2D tensor keeps its shape."""
+        layer = IdentityTransform(input_cols=["matrix"], output_cols=["bypass_matrix"])
+        inputs = {"matrix": torch.tensor([[1, 2, 3], [4, 5, 6]], dtype=torch.float32)}
+        outputs = layer(inputs)
+        assert outputs["bypass_matrix"].shape == inputs["matrix"].shape
+        torch.testing.assert_close(outputs["bypass_matrix"], inputs["matrix"])
+
+    def test_mismatched_columns_raises(self) -> None:
+        """Unequal input/output column counts raise ``ValueError``."""
+        with pytest.raises(ValueError, match="same length"):
+            IdentityTransform(input_cols=["col1", "col2"], output_cols=["out1"])
+
+
+def _layer_cases() -> list[tuple[str, TorchTransformBaseLayer, dict]]:
+    """Build (id, layer, inputs) cases covering every foundation layer."""
+    return [
+        (
+            "concatenate",
+            Concatenate(input_cols=["a", "b"], output_cols=["out"]),
+            {"a": torch.tensor([[1.0, 2.0]]), "b": torch.tensor([[3.0]])},
+        ),
+        (
+            "concatenate_explicit_dtype",
+            Concatenate(
+                input_cols=["a", "b"], output_cols=["out"], dtype=torch.float32
+            ),
+            {
+                "a": torch.tensor([[1, 2]], dtype=torch.int32),
+                "b": torch.tensor([[3, 4]], dtype=torch.int32),
+            },
+        ),
+        (
+            "stack",
+            Stack(input_cols=["a", "b"], output_cols=["out"]),
+            {"a": torch.tensor([1.0, 2.0]), "b": torch.tensor([3.0, 4.0])},
+        ),
+        (
+            "cast",
+            Cast(input_cols=["a"], output_cols=["out"], dtype=torch.float32),
+            {"a": torch.tensor([1, 2, 3], dtype=torch.int32)},
+        ),
+        (
+            "constant",
+            Constant(
+                input_cols=["a"],
+                output_cols=["out"],
+                constant=3.14,
+                dtype=torch.float32,
+            ),
+            {"a": torch.tensor([1, 2, 3])},
+        ),
+        (
+            "divide",
+            Divide(input_cols=["n", "d"], output_cols=["out"]),
+            {"n": torch.tensor([10.0, 0.0]), "d": torch.tensor([2.0, 0.0])},
+        ),
+        (
+            "log_transform",
+            LogTransform(input_cols=["a"], output_cols=["out"]),
+            {"a": torch.tensor([0.0, 1.0, 9.0])},
+        ),
+        (
+            "subtract",
+            Subtract(input_cols=["a", "b"], output_cols=["out"]),
+            {"a": torch.tensor([10.0, 20.0]), "b": torch.tensor([2.0, 5.0])},
+        ),
+        (
+            "floor",
+            Floor(input_cols=["a"], output_cols=["out"]),
+            {"a": torch.tensor([1.1, 2.9, -3.5])},
+        ),
+        (
+            "ceil",
+            Ceil(input_cols=["a"], output_cols=["out"]),
+            {"a": torch.tensor([1.1, 2.9, -3.5])},
+        ),
+        (
+            "identity",
+            IdentityTransform(input_cols=["a"], output_cols=["out"]),
+            {"a": torch.tensor([1, 2, 3], dtype=torch.long)},
+        ),
+    ]
+
+
+class TestTorchScriptRoundTrip:
+    """Every foundation layer must script, save/load, and match eager output."""
+
+    @pytest.mark.parametrize(
+        ("layer", "inputs"),
+        [(layer, inputs) for _, layer, inputs in _layer_cases()],
+        ids=[case_id for case_id, _, _ in _layer_cases()],
+    )
+    def test_scripted_matches_eager(
+        self,
+        layer: TorchTransformBaseLayer,
+        inputs: dict[str, torch.Tensor],
+        tmp_path,
+    ) -> None:
+        """Scripting (and reloading) reproduces the eager forward output."""
+        layer.eval()
+        eager = layer(inputs)
+
+        scripted = torch.jit.script(layer)
+        scripted_out = scripted(inputs)
+        assert set(scripted_out) == set(eager)
+        for key in eager:
+            torch.testing.assert_close(scripted_out[key], eager[key])
+
+        model_path = tmp_path / "scripted_layer.pt"
+        scripted.save(str(model_path))
+        loaded = torch.jit.load(str(model_path))
+        loaded_out = loaded(inputs)
+        for key in eager:
+            torch.testing.assert_close(loaded_out[key], eager[key])

--- a/python/michelangelo/lib/native_transform/torch/tests/test_base_layers.py
+++ b/python/michelangelo/lib/native_transform/torch/tests/test_base_layers.py
@@ -50,9 +50,22 @@ class TestTorchTransformBaseLayer:
         assert layer.output_cols == ["output"]
 
     def test_init_without_kwargs(self) -> None:
-        """``name`` defaults to ``"transform_layer"``."""
+        """``name`` defaults to a generated snake_case name from the class."""
         layer = _BaseTestLayer(input_cols=[], output_cols=[])
-        assert layer.name == "transform_layer"
+        # ``_BaseTestLayer`` is a private (leading-underscore) class name, so the
+        # generated name is prefixed with "private" per ``to_snake_case``.
+        assert layer.name.startswith("private__base_test_layer_")
+
+    def test_default_names_are_unique(self) -> None:
+        """Two default-constructed layers of the same class get distinct names."""
+        first = _BaseTestLayer(input_cols=[], output_cols=[])
+        second = _BaseTestLayer(input_cols=[], output_cols=[])
+        assert first.name != second.name
+
+    def test_explicit_name_overrides_generation(self) -> None:
+        """An explicit ``name`` is used verbatim, not auto-generated."""
+        layer = _BaseTestLayer(input_cols=[], output_cols=[], name="explicit")
+        assert layer.name == "explicit"
 
     def test_abstract_class_cannot_be_instantiated(self) -> None:
         """The abstract base cannot be instantiated directly."""
@@ -214,6 +227,19 @@ class TestCast:
         with pytest.raises(ValueError, match="same length"):
             Cast(input_cols=["a", "b"], output_cols=["out"])
 
+    @pytest.mark.parametrize("dtype", ["float32", "torch.float32"])
+    def test_string_dtype_aliases_behave_identically(self, dtype: str) -> None:
+        """Bare and ``torch.``-prefixed string aliases both cast correctly."""
+        layer = Cast(input_cols=["feature"], output_cols=["casted"], dtype=dtype)
+        assert layer.dtype == torch.float32
+        inputs = {"feature": torch.tensor([1, 2, 3], dtype=torch.int32)}
+        assert layer(inputs)["casted"].dtype == torch.float32
+
+    def test_unrecognized_dtype_string_raises(self) -> None:
+        """A typo'd dtype string raises instead of silently no-op'ing."""
+        with pytest.raises(ValueError, match="Unsupported dtype specification"):
+            Cast(input_cols=["feature"], output_cols=["casted"], dtype="flaot32")
+
 
 class TestConstant:
     """Constant tensor generation shaped like the input."""
@@ -347,6 +373,16 @@ class TestDivide:
         with pytest.raises(ValueError, match="even"):
             Divide(input_cols=["a", "b", "c"], output_cols=["out"])
 
+    def test_explicit_eps_is_stored_and_applied(self) -> None:
+        """An explicit ``eps`` is stored and substituted for a zero denominator."""
+        layer = Divide(input_cols=["num", "den"], output_cols=["out"], eps=0.5)
+        assert layer.eps == 0.5
+        # 10 / eps when the denominator is zero.
+        inputs = {"num": torch.tensor([10.0]), "den": torch.tensor([0.0])}
+        torch.testing.assert_close(
+            layer(inputs)["out"], torch.tensor([20.0], dtype=torch.float64)
+        )
+
 
 class TestLogTransform:
     """Logarithmic transform with offset and clamping."""
@@ -383,6 +419,13 @@ class TestLogTransform:
         """Unequal input/output column counts raise ``ValueError``."""
         with pytest.raises(ValueError, match="same length"):
             LogTransform(input_cols=["feat1", "feat2"], output_cols=["out1"])
+
+    def test_name_kwarg_is_honored(self) -> None:
+        """``name`` is forwarded to the base class rather than dropped."""
+        layer = LogTransform(
+            input_cols=["feature"], output_cols=["log_feature"], name="my_log"
+        )
+        assert layer.name == "my_log"
 
 
 class TestSubtract:

--- a/python/michelangelo/lib/native_transform/torch/tests/test_base_layers.py
+++ b/python/michelangelo/lib/native_transform/torch/tests/test_base_layers.py
@@ -233,11 +233,11 @@ class TestConstant:
         torch.testing.assert_close(outputs["const"], torch.tensor([3.14, 3.14, 3.14]))
 
     def test_no_input_column_raises(self) -> None:
-        """An empty ``input_cols`` raises ``ValueError``."""
-        with pytest.raises(ValueError):
-            Constant(
-                input_cols=[], output_cols=["const"], constant=42, dtype=torch.int32
-            )
+        """Empty (but length-matched) columns raise for the missing shape ref."""
+        # input_cols and output_cols are both empty, so the length check passes
+        # and the empty-shape-reference guard is what fires.
+        with pytest.raises(ValueError, match="at least one input column"):
+            Constant(input_cols=[], output_cols=[], constant=42, dtype=torch.int32)
 
     def test_forward_multiple_columns(self) -> None:
         """Each output column gets its own constant-filled tensor."""

--- a/python/michelangelo/lib/native_transform/torch/tests/test_utils.py
+++ b/python/michelangelo/lib/native_transform/torch/tests/test_utils.py
@@ -92,6 +92,10 @@ class TestToSnakeCase:
         """Known name/expected pairs convert correctly."""
         assert to_snake_case(name) == expected
 
+    def test_empty_string_does_not_raise(self) -> None:
+        """An empty string is returned unchanged instead of raising."""
+        assert to_snake_case("") == ""
+
 
 class TestResolveTorchDtype:
     """Resolution of dtype specs to concrete torch dtypes."""
@@ -137,9 +141,20 @@ class TestInitializeDtype:
         assert initialize_dtype("float32", torch.int32) == torch.float32
         assert initialize_dtype("int64", torch.int32) == torch.int64
 
-    def test_invalid_string_returns_none(self) -> None:
-        """An unrecognized string alias resolves to ``None``."""
-        assert initialize_dtype("invalid_dtype", torch.int32) is None
+    def test_torch_prefixed_string(self) -> None:
+        """A ``torch.``-prefixed string alias resolves like the bare alias."""
+        assert initialize_dtype("torch.float32", torch.int32) == torch.float32
+        assert initialize_dtype("torch.int64", torch.int32) == torch.int64
+
+    def test_agrees_with_resolve_torch_dtype(self) -> None:
+        """Both string families resolve identically to ``resolve_torch_dtype``."""
+        for spec in ("float32", "torch.float32", "int64", "torch.int64", "bool"):
+            assert initialize_dtype(spec, torch.int32) == resolve_torch_dtype(spec)
+
+    def test_invalid_string_raises(self) -> None:
+        """An unrecognized string alias raises ``ValueError``."""
+        with pytest.raises(ValueError, match="Unsupported dtype specification"):
+            initialize_dtype("flaot32", torch.int32)
 
     def test_falls_back_to_default(self) -> None:
         """Non-dtype, non-string inputs fall back to the default dtype."""

--- a/python/michelangelo/lib/native_transform/torch/tests/test_utils.py
+++ b/python/michelangelo/lib/native_transform/torch/tests/test_utils.py
@@ -1,0 +1,201 @@
+"""Tests for :mod:`michelangelo.lib.native_transform.torch.utils`.
+
+Covers dtype resolution helpers, layer-name generation, the sentinel lookup, and
+the ``format_inputs`` / ``format_outputs`` dict-of-tensors I/O contract.
+"""
+
+from __future__ import annotations
+
+import string
+
+import numpy as np
+import pytest
+
+# These helpers operate on real torch tensors. Skip cleanly if torch is
+# unavailable in a lightweight environment.
+torch = pytest.importorskip("torch")
+
+from michelangelo.lib.constants.sentinel import INT32_SENTINEL  # noqa: E402
+from michelangelo.lib.native_transform.torch.utils import (  # noqa: E402
+    format_inputs,
+    format_outputs,
+    generate_layer_name,
+    id_generator,
+    initialize_dtype,
+    resolve_torch_dtype,
+    sentinel_for_torch_dtype,
+    to_snake_case,
+)
+
+
+class TestGenerateLayerName:
+    """Name generation combines snake_case with a random suffix."""
+
+    def test_prefix_is_snake_case(self) -> None:
+        """The generated name starts with the snake_case base name."""
+        output = generate_layer_name("TestLayer")
+        assert output[:11] == "test_layer_"
+
+
+class TestIdGenerator:
+    """Random identifier generation."""
+
+    def test_default_size_and_charset(self) -> None:
+        """Default output is 10 chars from uppercase ASCII + digits."""
+        result = id_generator()
+        assert len(result) == 10
+        assert all(c in string.ascii_uppercase + string.digits for c in result)
+
+    def test_custom_size(self) -> None:
+        """A custom size yields a string of that length."""
+        assert len(id_generator(size=5)) == 5
+
+    def test_custom_chars(self) -> None:
+        """Only characters from a custom charset appear in the output."""
+        custom_chars = "ABC123"
+        result = id_generator(size=8, chars=custom_chars)
+        assert len(result) == 8
+        assert all(c in custom_chars for c in result)
+
+    def test_randomness(self) -> None:
+        """Successive calls produce different values."""
+        assert id_generator() != id_generator()
+
+    def test_size_zero(self) -> None:
+        """A size of zero yields the empty string."""
+        assert id_generator(size=0) == ""
+
+
+class TestToSnakeCase:
+    """CamelCase-to-snake_case conversion, including private-name handling."""
+
+    @pytest.mark.parametrize(
+        ("name", "expected"),
+        [
+            ("CamelCase", "camel_case"),
+            ("SimpleCase", "simple_case"),
+            ("Word", "word"),
+            ("word", "word"),
+            ("snake_case", "snake_case"),
+            ("XMLHttpRequest", "xml_http_request"),
+            ("HTTPResponse", "http_response"),
+            ("CamelCase2Text", "camel_case2text"),
+            ("Test123Case", "test123_case"),
+            ("parseHTML5Content", "parse_htm_l5content"),
+            ("_PrivateClass", "private__private_class"),
+            ("_privateMethod", "private_private_method"),
+            ("A", "a"),
+            ("a", "a"),
+        ],
+    )
+    def test_conversions(self, name: str, expected: str) -> None:
+        """Known name/expected pairs convert correctly."""
+        assert to_snake_case(name) == expected
+
+
+class TestResolveTorchDtype:
+    """Resolution of dtype specs to concrete torch dtypes."""
+
+    @pytest.mark.parametrize(
+        ("spec", "expected"),
+        [
+            (torch.float32, torch.float32),
+            (torch.int64, torch.int64),
+            (torch.bool, torch.bool),
+            ("float32", torch.float32),
+            ("int64", torch.int64),
+            ("bool", torch.bool),
+            ("torch.float32", torch.float32),
+            ("torch.int64", torch.int64),
+        ],
+    )
+    def test_valid_specs(self, spec, expected) -> None:
+        """Valid dtype objects and string aliases resolve as expected."""
+        assert resolve_torch_dtype(spec) == expected
+
+    def test_invalid_string(self) -> None:
+        """An unrecognized string raises ``ValueError``."""
+        with pytest.raises(ValueError, match="Unsupported dtype specification"):
+            resolve_torch_dtype("invalid_dtype")
+
+    @pytest.mark.parametrize("spec", [123, None])
+    def test_invalid_types(self, spec) -> None:
+        """Non-dtype, non-string inputs raise ``ValueError``."""
+        with pytest.raises(ValueError):
+            resolve_torch_dtype(spec)
+
+
+class TestInitializeDtype:
+    """Layer dtype-argument initialization with default fallback."""
+
+    def test_torch_dtype_passthrough(self) -> None:
+        """A ``torch.dtype`` is returned unchanged."""
+        assert initialize_dtype(torch.float32, torch.int32) == torch.float32
+
+    def test_valid_string(self) -> None:
+        """A recognized string alias resolves to its dtype."""
+        assert initialize_dtype("float32", torch.int32) == torch.float32
+        assert initialize_dtype("int64", torch.int32) == torch.int64
+
+    def test_invalid_string_returns_none(self) -> None:
+        """An unrecognized string alias resolves to ``None``."""
+        assert initialize_dtype("invalid_dtype", torch.int32) is None
+
+    def test_falls_back_to_default(self) -> None:
+        """Non-dtype, non-string inputs fall back to the default dtype."""
+        assert initialize_dtype(None, torch.int32) == torch.int32
+        assert initialize_dtype(123, torch.float64) == torch.float64
+
+
+class TestFormatInputsOutputs:
+    """The stack / unbind I/O contract shared by every layer."""
+
+    def test_format_inputs_selects_and_stacks(self) -> None:
+        """``format_inputs`` stacks only the selected columns, in order."""
+        inputs = {
+            "col1": torch.tensor([1, 2, 3]),
+            "col2": torch.tensor([4, 5, 6]),
+            "col3": torch.tensor([7, 8, 9]),
+        }
+        result = format_inputs(["col1", "col3"], inputs)
+        expected = torch.stack([inputs["col1"], inputs["col3"]])
+        assert torch.equal(result, expected)
+
+    def test_format_outputs_unbinds_to_dict(self) -> None:
+        """``format_outputs`` maps each unbound slice to its column name."""
+        t1 = torch.tensor([1, 2, 3])
+        t2 = torch.tensor([4, 5, 6])
+        outputs_tensor = torch.stack([t1, t2])
+        result = format_outputs(["out1", "out2"], outputs_tensor)
+        assert len(result) == 2
+        assert torch.equal(result["out1"], t1)
+        assert torch.equal(result["out2"], t2)
+
+    def test_round_trip(self) -> None:
+        """``format_outputs`` inverts ``format_inputs`` for matching columns."""
+        cols = ["a", "b"]
+        inputs = {"a": torch.tensor([1.0, 2.0]), "b": torch.tensor([3.0, 4.0])}
+        stacked = format_inputs(cols, inputs)
+        restored = format_outputs(cols, stacked)
+        assert torch.equal(restored["a"], inputs["a"])
+        assert torch.equal(restored["b"], inputs["b"])
+
+
+class TestSentinelForTorchDtype:
+    """Type-native sentinel lookup."""
+
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+    def test_float_returns_nan(self, dtype) -> None:
+        """Floating-point dtypes map to a NaN sentinel."""
+        assert np.isnan(sentinel_for_torch_dtype(dtype))
+
+    @pytest.mark.parametrize("dtype", [torch.int32, torch.int64])
+    def test_int_returns_int_sentinel(self, dtype) -> None:
+        """Integer dtypes map to ``INT32_SENTINEL``."""
+        assert sentinel_for_torch_dtype(dtype) == INT32_SENTINEL
+        assert sentinel_for_torch_dtype(dtype) == -2147483648
+
+    def test_invalid_dtype_raises(self) -> None:
+        """An unsupported dtype raises ``ValueError``."""
+        with pytest.raises(ValueError, match="No sentinel defined for dtype"):
+            sentinel_for_torch_dtype(torch.bool)

--- a/python/michelangelo/lib/native_transform/torch/utils.py
+++ b/python/michelangelo/lib/native_transform/torch/utils.py
@@ -85,8 +85,9 @@ def to_snake_case(name: str) -> str:
     intermediate = re.sub("(.)([A-Z][a-z0-9]+)", r"\1_\2", name)
     insecure = re.sub("([a-z])([A-Z])", r"\1_\2", intermediate).lower()
     # A leading underscore (from a private class name) is not a valid scope
-    # name, so prefix it with "private".
-    if insecure[0] != "_":
+    # name, so prefix it with "private". An empty string has no leading
+    # underscore, so it is returned unchanged.
+    if not insecure or insecure[0] != "_":
         return insecure
     return "private" + insecure
 
@@ -131,26 +132,35 @@ def resolve_torch_dtype(dtype_spec: torch.dtype | str) -> torch.dtype | str:
 
 def initialize_dtype(
     raw_dtype: torch.dtype | str | None, default_dtype: torch.dtype | None
-) -> torch.dtype | None:
+) -> torch.dtype | str | None:
     """Resolve a layer's dtype argument, falling back to a default.
+
+    String inputs are resolved through :func:`resolve_torch_dtype`, so the two
+    functions agree on every string: both the ``"torch."``-prefixed class names
+    (e.g. ``"torch.float32"``) and the bare aliases (e.g. ``"float32"``) are
+    recognized, and an unrecognized string raises ``ValueError`` rather than
+    silently resolving to ``None``.
 
     Args:
         raw_dtype: The dtype value from a layer spec. May be a ``torch.dtype``, a
-            string alias (e.g. ``"float32"``), or ``None``.
+            string alias (e.g. ``"float32"`` or ``"torch.float32"``), or
+            ``None``.
         default_dtype: The dtype to return when ``raw_dtype`` is neither a
-            ``torch.dtype`` nor a string.
+            ``torch.dtype`` nor a string (e.g. ``None``).
 
     Returns:
-        The resolved ``torch.dtype``. When ``raw_dtype`` is an unrecognized
-        string alias, ``None`` is returned (the caller decides how to handle an
-        unresolved dtype).
+        The resolved ``torch.dtype`` for a dtype or recognized string, ``"string"``
+        for the string-type alias, or ``default_dtype`` when ``raw_dtype`` is
+        neither a ``torch.dtype`` nor a string.
+
+    Raises:
+        ValueError: If ``raw_dtype`` is a string that names no recognized dtype.
     """
     if isinstance(raw_dtype, torch.dtype):
         return raw_dtype
-    elif isinstance(raw_dtype, str):
-        return STRING_DATA_TYPE_TO_TORCH_TYPE_MAP.get(raw_dtype, None)
-    else:
-        return default_dtype
+    if isinstance(raw_dtype, str):
+        return resolve_torch_dtype(raw_dtype)
+    return default_dtype
 
 
 def format_inputs(

--- a/python/michelangelo/lib/native_transform/torch/utils.py
+++ b/python/michelangelo/lib/native_transform/torch/utils.py
@@ -1,0 +1,188 @@
+"""Utility helpers for PyTorch native transform layers.
+
+Helpers for dtype resolution, layer-name generation, and the
+dict-of-tensors input/output contract shared by every transform layer. The
+``format_inputs`` / ``format_outputs`` pair defines the package's I/O convention:
+layers receive and return ``dict[str, torch.Tensor]`` (TorchScript-friendly),
+stacking the selected columns into a single tensor for vectorized computation.
+"""
+
+from __future__ import annotations
+
+import random
+import re
+import string
+
+import torch
+
+from michelangelo.lib.constants.sentinel import FLOAT_SENTINEL, INT32_SENTINEL
+from michelangelo.lib.native_transform.torch.constants import (
+    STRING_DATA_TYPE_TO_TORCH_TYPE_MAP,
+    TORCH_DTYPE_CLASS_NAME_TO_TORCH_TYPE_MAP,
+)
+
+__all__ = [
+    "format_inputs",
+    "format_outputs",
+    "generate_layer_name",
+    "id_generator",
+    "initialize_dtype",
+    "resolve_torch_dtype",
+    "sentinel_for_torch_dtype",
+    "to_snake_case",
+]
+
+
+def sentinel_for_torch_dtype(dtype: torch.dtype) -> float | int:
+    """Return the type-native sentinel value for a torch dtype.
+
+    Args:
+        dtype: The torch dtype to look up a sentinel for.
+
+    Returns:
+        ``FLOAT_SENTINEL`` (NaN) for floating-point dtypes and ``INT32_SENTINEL``
+        for integer dtypes.
+
+    Raises:
+        ValueError: If no sentinel is defined for ``dtype``.
+    """
+    if dtype in (torch.float32, torch.float64):
+        return FLOAT_SENTINEL
+    if dtype in (torch.int32, torch.int64):
+        return INT32_SENTINEL
+    raise ValueError(f"No sentinel defined for dtype: {dtype}")
+
+
+def id_generator(
+    size: int = 10, chars: str = string.ascii_uppercase + string.digits
+) -> str:
+    """Generate a random identifier string.
+
+    Args:
+        size: Number of characters in the generated string.
+        chars: Character set to sample from. Defaults to uppercase ASCII letters
+            and digits.
+
+    Returns:
+        A random string of length ``size`` drawn from ``chars``.
+    """
+    return "".join(random.choice(chars) for _ in range(size))
+
+
+def to_snake_case(name: str) -> str:
+    """Convert a class-style name to snake_case.
+
+    Adapted from the Keras backend helper. Names that would begin with an
+    underscore (i.e. from private class names) are prefixed with ``"private"``,
+    since a leading underscore is not a valid TorchScript scope name.
+
+    Args:
+        name: The name to convert (e.g. a class name in ``CamelCase``).
+
+    Returns:
+        The snake_case form of ``name``.
+    """
+    intermediate = re.sub("(.)([A-Z][a-z0-9]+)", r"\1_\2", name)
+    insecure = re.sub("([a-z])([A-Z])", r"\1_\2", intermediate).lower()
+    # A leading underscore (from a private class name) is not a valid scope
+    # name, so prefix it with "private".
+    if insecure[0] != "_":
+        return insecure
+    return "private" + insecure
+
+
+def generate_layer_name(layer_name: str) -> str:
+    """Generate a unique snake_case layer name.
+
+    Args:
+        layer_name: The base name to derive from (typically a layer class name).
+
+    Returns:
+        The snake_case form of ``layer_name`` suffixed with a random identifier,
+        e.g. ``"concatenate_A1B2C3D4E5"``.
+    """
+    return f"{to_snake_case(layer_name)}_{id_generator()}"
+
+
+def resolve_torch_dtype(dtype_spec: torch.dtype | str) -> torch.dtype | str:
+    """Resolve a dtype spec to a concrete torch dtype.
+
+    Args:
+        dtype_spec: Either a ``torch.dtype`` or a string alias. Recognized
+            strings include the ``"torch."``-prefixed class names (e.g.
+            ``"torch.float32"``) and the bare aliases (e.g. ``"float32"``). The
+            special value ``"string"`` resolves to itself.
+
+    Returns:
+        The resolved ``torch.dtype`` (or ``"string"`` for the string alias).
+
+    Raises:
+        ValueError: If ``dtype_spec`` cannot be resolved.
+    """
+    if isinstance(dtype_spec, torch.dtype):
+        return dtype_spec
+    if isinstance(dtype_spec, str):
+        if dtype_spec in TORCH_DTYPE_CLASS_NAME_TO_TORCH_TYPE_MAP:
+            return TORCH_DTYPE_CLASS_NAME_TO_TORCH_TYPE_MAP[dtype_spec]
+        if dtype_spec in STRING_DATA_TYPE_TO_TORCH_TYPE_MAP:
+            return STRING_DATA_TYPE_TO_TORCH_TYPE_MAP[dtype_spec]
+    raise ValueError(f"Unsupported dtype specification: {dtype_spec}")
+
+
+def initialize_dtype(
+    raw_dtype: torch.dtype | str | None, default_dtype: torch.dtype | None
+) -> torch.dtype | None:
+    """Resolve a layer's dtype argument, falling back to a default.
+
+    Args:
+        raw_dtype: The dtype value from a layer spec. May be a ``torch.dtype``, a
+            string alias (e.g. ``"float32"``), or ``None``.
+        default_dtype: The dtype to return when ``raw_dtype`` is neither a
+            ``torch.dtype`` nor a string.
+
+    Returns:
+        The resolved ``torch.dtype``. When ``raw_dtype`` is an unrecognized
+        string alias, ``None`` is returned (the caller decides how to handle an
+        unresolved dtype).
+    """
+    if isinstance(raw_dtype, torch.dtype):
+        return raw_dtype
+    elif isinstance(raw_dtype, str):
+        return STRING_DATA_TYPE_TO_TORCH_TYPE_MAP.get(raw_dtype, None)
+    else:
+        return default_dtype
+
+
+def format_inputs(
+    input_columns: list[str], inputs: dict[str, torch.Tensor]
+) -> torch.Tensor:
+    """Stack selected input columns into a single tensor.
+
+    Args:
+        input_columns: The column names to select, in order.
+        inputs: Mapping from column name to tensor.
+
+    Returns:
+        A tensor stacking ``inputs[col]`` for each column in ``input_columns``
+        along a new leading dimension.
+    """
+    return torch.stack([inputs[col] for col in input_columns])
+
+
+def format_outputs(
+    output_columns: list[str], outputs: torch.Tensor
+) -> dict[str, torch.Tensor]:
+    """Split a stacked output tensor into a column-keyed dictionary.
+
+    Inverse of :func:`format_inputs`: unbinds ``outputs`` along its leading
+    dimension and maps each slice to the corresponding output column name.
+
+    Args:
+        output_columns: The output column names, in order.
+        outputs: The stacked output tensor to split.
+
+    Returns:
+        A mapping from each output column name to its tensor slice.
+    """
+    output_tensors = torch.unbind(outputs)
+    return {output_columns[i]: output_tensors[i] for i in range(len(output_columns))}


### PR DESCRIPTION
## Summary

Establishes the `native_transform` PyTorch transform-layer package: a small set of shared leaf modules plus the first tier of stateless, elementwise transform layers. These layers form the base pattern (dict-of-tensors I/O, device-safe constants, TorchScript export) that the remaining transform layers build on.

~500 source LOC. Follow-up work adds structural, fitted-statistics, tokenizer-wrapper, spec, and DAG-engine layers on top of this foundation.

## What's included

- **`torch/constants.py`** — shared dtype-mapping dicts and default values (a dependency-free leaf module).
- **`torch/utils.py`** — dtype resolution (`resolve_torch_dtype`, `initialize_dtype`), layer-name generation (`generate_layer_name`, `to_snake_case`, `id_generator`), the type-native sentinel lookup, and the `format_inputs` / `format_outputs` pair that defines the package's `dict[str, torch.Tensor]` in/out contract.
- **`torch/base_layers.py`** — the abstract `TorchTransformBaseLayer` plus 10 concrete layers: `Concatenate`, `Stack`, `Cast`, `Constant`, `Divide`, `LogTransform`, `Subtract`, `Floor`, `Ceil`, `IdentityTransform`.
- Package exports updated in `torch/__init__.py`.

## Design notes

- **TorchScript/serve parity:** every layer is `torch.jit.script`-able so the exact transform runs at both train and serve time.
- **Device safety:** `Constant` uses `new_full` (not `torch.tensor(...).to(device)`) so a traced graph does not bake in a literal device.
- **Numerical safety:** `Divide` / `Subtract` upcast to float64; `Divide` substitutes an epsilon for zero denominators and forces `0/0 -> 0`.

## Testing

`python -m pytest michelangelo/lib/native_transform/ -v` → **112 passed, 1 skipped** (the skip is the pre-existing ONNX-export test, which needs `onnx`/`onnxruntime`).

New tests cover each layer's forward semantics and validation errors, all utility functions, and — for every layer — a `torch.jit.script` save/load round-trip asserting scripted output matches eager execution.

**Coverage** (`--cov=michelangelo.lib.native_transform --cov-report=term-missing`): **99.04% total** — `constants.py`, `utils.py`, `id_hash_tokenizer.py`, and `base_layers.py` all at **100%**. The only uncovered lines are the re-export statements in `torch/__init__.py`, which execute at import time before the coverage tracer starts measuring.