### PR TITLE
feat(python): expose clean_reason and clean_details on GitInfo (F037)

### DIFF
--- a/python/michelangelo/cli/mactl/plugins/git_validation/main.py
+++ b/python/michelangelo/cli/mactl/plugins/git_validation/main.py
@@ -21,6 +21,11 @@ class GitInfo:
         commit_hash: Current commit SHA
         is_clean: Whether workspace is clean (no uncommitted changes, all pushed)
         is_on_main: Whether current branch is main/master
+        clean_reason: Machine-readable classification of the clean check outcome:
+            "ok" (clean), "uncommitted" (git status non-empty),
+            "not_pushed" (git push -n rejected), or "git_error" (subprocess raised).
+        clean_details: Raw combined stdout+stderr from the git command that
+            determined ``clean_reason`` — safe to surface to the user verbatim.
     """
 
     repo: str
@@ -28,6 +33,8 @@ class GitInfo:
     commit_hash: str
     is_clean: bool
     is_on_main: bool
+    clean_reason: str = "ok"
+    clean_details: str = ""
 
 
 class GitValidator:
@@ -83,12 +90,15 @@ class GitValidator:
             )
 
         branch = self._get_branch_name(root)
+        clean, reason, details = self._is_clean(root)
         return GitInfo(
             repo=self._get_repo_url(root),
             branch_name=branch,
             commit_hash=self._get_commit_hash(root),
-            is_clean=self._is_clean(root),
+            is_clean=clean,
             is_on_main=self._is_on_main(branch),
+            clean_reason=reason,
+            clean_details=details,
         )
 
     def _detect_workspace_root(self) -> str:
@@ -220,7 +230,7 @@ class GitValidator:
         """
         return os.environ.get("BUILDKITE", "").lower() == "true"
 
-    def _is_clean(self, root: str) -> bool:
+    def _is_clean(self, root: str) -> tuple[bool, str, str]:
         """Check if git workspace is clean.
 
         A workspace is clean if:
@@ -231,10 +241,16 @@ class GitValidator:
             root: Workspace root path.
 
         Returns:
-            True if workspace is clean, False otherwise.
+            Tuple ``(clean, reason, details)``:
+              * ``clean`` — True iff both checks pass.
+              * ``reason`` — one of ``"ok"``, ``"uncommitted"``, ``"not_pushed"``,
+                ``"git_error"``.
+              * ``details`` — raw git stdout/stderr for the failing step, or an
+                empty string when clean. Callers should surface ``details``
+                verbatim so the user sees git's own diagnostic.
         """
         if os.environ.get(self.bypass_env, "").lower() == "true":
-            return True
+            return True, "ok", ""
 
         try:
             result = subprocess.run(
@@ -245,9 +261,9 @@ class GitValidator:
                 check=True,
             )
             if result.stdout.strip():
-                return False
-        except subprocess.CalledProcessError:
-            return False
+                return False, "uncommitted", result.stdout
+        except subprocess.CalledProcessError as e:
+            return False, "git_error", (e.stderr or "").strip()
 
         result = subprocess.run(
             ["git", "push", "-n"],
@@ -257,7 +273,9 @@ class GitValidator:
             check=False,
         )
         output = result.stdout + result.stderr
-        return "Everything up-to-date" in output
+        if "Everything up-to-date" in output:
+            return True, "ok", ""
+        return False, "not_pushed", output
 
     def _is_on_main(self, branch_name: str) -> bool:
         """Check if branch is a main branch.

--- a/python/michelangelo/cli/mactl/plugins/git_validation/main_test.py
+++ b/python/michelangelo/cli/mactl/plugins/git_validation/main_test.py
@@ -27,6 +27,22 @@ class TestGitInfo:
         assert git_info.commit_hash == "abc123"
         assert git_info.is_clean is True
         assert git_info.is_on_main is True
+        assert git_info.clean_reason == "ok"
+        assert git_info.clean_details == ""
+
+    def test_git_info_with_reason_and_details(self):
+        """Test GitInfo dataclass accepts new clean_reason/clean_details fields."""
+        git_info = GitInfo(
+            repo="https://github.com/org/repo.git",
+            branch_name="feature",
+            commit_hash="abc123",
+            is_clean=False,
+            is_on_main=False,
+            clean_reason="not_pushed",
+            clean_details="fatal: The upstream branch of ...",
+        )
+        assert git_info.clean_reason == "not_pushed"
+        assert git_info.clean_details == "fatal: The upstream branch of ..."
 
 
 class TestGitValidator:
@@ -193,7 +209,7 @@ class TestGitValidator:
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("MACTL_IGNORE_GIT_CLEAN_CHECK", None)
             validator = GitValidator()
-            assert validator._is_clean("/path/to/repo") is True
+            assert validator._is_clean("/path/to/repo") == (True, "ok", "")
 
         assert mock_run.call_count == 2
         mock_run.assert_any_call(
@@ -213,7 +229,7 @@ class TestGitValidator:
 
     @patch("subprocess.run")
     def test_is_clean_uncommitted_changes(self, mock_run):
-        """Test workspace is not clean when uncommitted changes exist."""
+        """Test uncommitted branch returns reason='uncommitted' with porcelain."""
         mock_run.return_value = MagicMock(
             stdout=" M file.txt\n", stderr="", returncode=0
         )
@@ -221,8 +237,11 @@ class TestGitValidator:
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("MACTL_IGNORE_GIT_CLEAN_CHECK", None)
             validator = GitValidator()
-            assert validator._is_clean("/path/to/repo") is False
+            clean, reason, details = validator._is_clean("/path/to/repo")
 
+        assert clean is False
+        assert reason == "uncommitted"
+        assert details == " M file.txt\n"
         mock_run.assert_called_once_with(
             ["git", "status", "--porcelain"],
             capture_output=True,
@@ -233,27 +252,44 @@ class TestGitValidator:
 
     @patch("subprocess.run")
     def test_is_clean_unpushed_commits(self, mock_run):
-        """Test workspace is not clean when unpushed commits exist."""
+        """Test unpushed-commits branch returns reason='not_pushed' with git stderr."""
+        push_stderr = "To github.com:org/repo.git\n   abc123..def456  main -> main"
         mock_run.side_effect = [
             MagicMock(stdout="", stderr="", returncode=0),
-            MagicMock(
-                stdout="",
-                stderr="To github.com:org/repo.git\n   abc123..def456  main -> main",
-                returncode=0,
-            ),
+            MagicMock(stdout="", stderr=push_stderr, returncode=0),
         ]
 
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("MACTL_IGNORE_GIT_CLEAN_CHECK", None)
             validator = GitValidator()
-            assert validator._is_clean("/path/to/repo") is False
+            clean, reason, details = validator._is_clean("/path/to/repo")
+
+        assert clean is False
+        assert reason == "not_pushed"
+        assert push_stderr in details
+
+    @patch("subprocess.run")
+    def test_is_clean_git_status_error(self, mock_run):
+        """Test git-error branch returns reason='git_error' with exception stderr."""
+        mock_run.side_effect = subprocess.CalledProcessError(
+            128, "git", stderr="fatal: not a git repository"
+        )
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MACTL_IGNORE_GIT_CLEAN_CHECK", None)
+            validator = GitValidator()
+            clean, reason, details = validator._is_clean("/path/to/repo")
+
+        assert clean is False
+        assert reason == "git_error"
+        assert details == "fatal: not a git repository"
 
     @patch("subprocess.run")
     def test_is_clean_bypass_env(self, mock_run):
         """Test clean check bypassed when MACTL_IGNORE_GIT_CLEAN_CHECK=true."""
         with patch.dict(os.environ, {"MACTL_IGNORE_GIT_CLEAN_CHECK": "true"}):
             validator = GitValidator()
-            assert validator._is_clean("/path/to/repo") is True
+            assert validator._is_clean("/path/to/repo") == (True, "ok", "")
             mock_run.assert_not_called()
 
     def test_is_on_main_in_buildkite(self):
@@ -374,7 +410,7 @@ class TestGitValidator:
         """Test bypass env var is case insensitive."""
         with patch.dict(os.environ, {"MACTL_IGNORE_GIT_CLEAN_CHECK": "TRUE"}):
             validator = GitValidator()
-            assert validator._is_clean("/path/to/repo") is True
+            assert validator._is_clean("/path/to/repo") == (True, "ok", "")
             mock_run.assert_not_called()
 
     @patch("subprocess.run")
@@ -475,6 +511,8 @@ class TestGitValidatorIntegration:
         git_info = validator.get_git_info(workspace_root=temp_git_repo)
 
         assert git_info.is_clean is False
+        assert git_info.clean_reason == "not_pushed"
+        assert git_info.clean_details
 
     def test_integration_bypass_clean_check(self, temp_git_repo):
         """Test bypass clean check in integration test."""


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

- `GitInfo` gains `clean_reason: str` (one of `"ok"`, `"uncommitted"`, `"not_pushed"`, `"git_error"`) and `clean_details: str` (raw git stdout/stderr), both with safe defaults.
- `_is_clean()` now returns `(bool, reason, details)` internally; `get_git_info()` populates the new fields. `is_clean` semantics unchanged.

**Why?**

Downstream callers today collapse every unclean-workspace failure into one hardcoded "uncommitted files" error, hiding the actual cause (often an upstream-tracking mismatch, not uncommitted files). Exposing reason + raw git output lets callers surface git's own diagnostic and give targeted hints.

**How did you test it?**

`pytest plugins/git_validation/main_test.py -v` — 7 tests covering each `clean_reason` branch (ok, uncommitted, not_pushed, git_error, bypass env, clean workspace, defaults), all green. Coverage / python-build green in CI. Also verified end-to-end by patching a downstream caller to consume the new fields and observing `RuntimeError: git push rejected — try: git push -u origin HEAD` (instead of the current generic "uncommitted files" message) on a clean tree with an unpushed branch.

**Potential risks**

None. New fields have defaults; `is_clean` semantics unchanged. `_is_clean()` return type widened from `bool` to `tuple[bool, str, str]`, but it's a private method with no cross-module callers.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

`GitInfo` gains `clean_reason` and `clean_details` fields exposing why `_is_clean()` failed and the raw git stdout/stderr for that step.

**Documentation Changes**

N/A — new fields are self-documenting via `GitInfo` dataclass docstring.
