### PR TITLE
fix(jobs): don't treat transient HeadPodNotFound as terminal; raise RayJob submitter backoff

### DIFF
--- a/go/components/jobs/client/k8sengine/mapper_test.go
+++ b/go/components/jobs/client/k8sengine/mapper_test.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	k8sptr "k8s.io/utils/ptr"
 
 	v2pb "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
 )
@@ -75,6 +76,9 @@ func TestMapper_MapGlobalJobToLocal(t *testing.T) {
 					TTLSecondsAfterFinished:  int32(300),
 					ShutdownAfterJobFinishes: true,
 					SubmitterPodTemplate:     submitterPod,
+					SubmitterConfig: &rayv1.SubmitterConfig{
+						BackoffLimit: k8sptr.To(int32(submitterBackoffLimit)),
+					},
 				},
 			},
 		},

--- a/go/components/jobs/client/k8sengine/ray.go
+++ b/go/components/jobs/client/k8sengine/ray.go
@@ -13,6 +13,12 @@ import (
 	k8sptr "k8s.io/utils/ptr"
 )
 
+// submitterBackoffLimit is the backoffLimit for the k8s Job that runs `ray job submit`.
+// KubeRay's default of 2 (3 total attempts) exhausts in well under a minute — too
+// tight to tolerate even a single transient failure to reach the head pod's
+// dashboard-agent port while the cluster is still starting up.
+const submitterBackoffLimit = 20
+
 // LogPersistenceConfig holds platform-level configuration for log persistence.
 // Loaded from YAML under jobs.k8sengine.mapper.logPersistence.
 // See: https://github.com/ray-project/kuberay/tree/master/historyserver/config
@@ -63,10 +69,10 @@ func (m Mapper) mapRay(rayJob *v2pb.RayJob, jobClusterObject runtime.Object, clu
 			Entrypoint:               rayJob.Spec.Entrypoint,
 			TTLSecondsAfterFinished:  int32(300),
 			ShutdownAfterJobFinishes: true,
-			// kuberay 1.0 only support SubmitterPodTemplate for configuration submitter pod
-			// We need to allow user to configure the submitter pod template via ray task configuration
-			// Note: Add support for v1.2.2 kuberay once we upgrade to newer version
-			SubmitterPodTemplate: &submitterPod,
+			SubmitterPodTemplate:     &submitterPod,
+			SubmitterConfig: &rayv1.SubmitterConfig{
+				BackoffLimit: k8sptr.To(int32(submitterBackoffLimit)),
+			},
 		},
 	}
 

--- a/go/components/jobs/common/utils/utils.go
+++ b/go/components/jobs/common/utils/utils.go
@@ -160,7 +160,10 @@ func IsRegionalCluster(cluster *v2pb.Cluster) bool {
 
 var terminalPodErrorReasons = map[string]bool{
 	// KubeRay condition-level reasons (from HeadPodReady / ReplicaFailure)
-	"HeadPodNotFound":       true,
+	// NOTE: HeadPodNotFound is intentionally excluded — it's a transient state
+	// kuberay sets while the head pod is being created, before the informer
+	// cache reflects the new pod, and routinely clears within a reconcile
+	// cycle or two once the head pod comes up. Not a terminal failure.
 	"FailedCreateHeadPod":   true,
 	"FailedCreateWorkerPod": true,
 	// Kubernetes container-level reasons (if KubeRay exposes them in future versions)

--- a/go/components/jobs/common/utils/utils_test.go
+++ b/go/components/jobs/common/utils/utils_test.go
@@ -104,6 +104,13 @@ func TestHasTerminalPodErrors(t *testing.T) {
 			expected: false,
 		},
 		{
+			name: "HeadPodNotFound is not immediately terminal",
+			errors: []*v2pb.PodErrors{
+				{Reason: "HeadPodNotFound", Message: "head pod not found"},
+			},
+			expected: false,
+		},
+		{
 			name: "CrashLoopBackOff is terminal",
 			errors: []*v2pb.PodErrors{
 				{Reason: "CrashLoopBackOff", Message: "container crashing"},


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Two related fixes in the RayJob/RayCluster job engine:
1. Removed `HeadPodNotFound` from `terminalPodErrorReasons` in [`go/components/jobs/common/utils/utils.go`](go/components/jobs/common/utils/utils.go) — it's a transient reason KubeRay sets on the `HeadPodReady` condition right after a RayCluster is created, before the informer cache reflects the new pod, and it clears within a reconcile cycle or two.
2. Set `RayJobSpec.SubmitterConfig.BackoffLimit` to 20 in `mapRay()` ([`go/components/jobs/client/k8sengine/ray.go`](go/components/jobs/client/k8sengine/ray.go)), replacing a stale comment about `SubmitterPodTemplate` being the only configurable field (true for KubeRay 1.0; #1384 upgraded to v1.2.2, which added `SubmitterConfig`).

**Why?**

Running the sandbox against real hardware — where the Ray head pod's first boot can take several minutes, not the near-instant startup typical in CI — exposes a race: `HasTerminalPodErrors()` is the only gate [`components/ray/cluster/controller.go`](go/components/ray/cluster/controller.go#L637) uses to transition an `UNKNOWN`-state RayCluster to `FAILED`, so a cluster observed with `HeadPodNotFound` in this narrow window is killed immediately instead of being allowed to finish provisioning. Separately, KubeRay's default `submitterBackoffLimit` of 2 (3 total attempts) for the `ray job submit` Job exhausts in well under a minute — long before a fresh head pod's dashboard-agent port is reachable — permanently failing the RayJob with `BackoffLimitExceeded` even though the cluster would have become healthy shortly after. Together these two bugs made local/sandbox RayJob submission fail nearly every time on a cold cluster.

Ports and adapts logic from an unmerged fix on `upstream/badcount/kserve-poc` (commit `33115396`, by @weric) onto the current `isFailureCondition`/`terminalPodErrorReasons` structure introduced by #1384's KubeRay v1.2.2 upgrade. That earlier fix also exempted `HeadPodReady`'s `ContainersNotReady` reason from `isFailureCondition`, but `ContainersNotReady` was never present in `terminalPodErrorReasons` in the current code (see `TestHasTerminalPodErrors`'s existing "ContainersNotReady is not immediately terminal" case) — it was already non-terminal, so no change was needed there. Kept the diff minimal to just `HeadPodNotFound`.

**How did you test it?**

```
$ go test ./components/jobs/client/k8sengine/... ./components/jobs/common/utils/... ./components/ray/cluster/...
ok  	github.com/michelangelo-ai/michelangelo/go/components/jobs/client/k8sengine	0.038s
ok  	github.com/michelangelo-ai/michelangelo/go/components/jobs/common/utils	0.037s
ok  	github.com/michelangelo-ai/michelangelo/go/components/ray/cluster	0.135s
```
- Added a `TestHasTerminalPodErrors` case asserting `HeadPodNotFound` is not terminal.
- Updated `TestMapper_MapGlobalJobToLocal`'s fixture for the new `SubmitterConfig` field.
- `go build ./...` passes.

**Potential risks**

Low. Both changes narrow when a RayCluster/RayJob is marked failed (fewer false positives), and raise a retry budget — neither can newly mask a genuine terminal failure that wasn't already reachable through the container-level error reasons (`CrashLoopBackOff`, `OOMKilled`, etc.) still in `terminalPodErrorReasons`.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

N/A

**Documentation Changes**

N/A