### PR TITLE
feat(python): pipeline_run kill — state pre-check (isPipelineRunKillable)

### DIFF
--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/kill.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/kill.py
@@ -1,7 +1,7 @@
 """Pipeline kill command implementation.
 
-This module provides functionality to kill running pipeline runs by setting
-the kill flag on a PipelineRun resource.
+Sets the kill flag on a PipelineRun resource. Rejects kills on runs that
+are not in PENDING or RUNNING state, mirroring the Go mactl behavior.
 """
 
 from argparse import ArgumentParser
@@ -16,16 +16,25 @@ from grpc import Channel
 
 from michelangelo.cli.mactl.crd import (
     CRD,
-    METADATA_STUB,
+    CrdMethodInfo,
     bind_signature,
+    crd_method_call,
     get_single_arg,
     inject_func_signature,
 )
 
 # Import TypedStruct to register it in the descriptor pool
 from michelangelo.gen.api import typed_struct_pb2  # noqa: F401
+from michelangelo.gen.api.v2 import pipeline_run_pb2
 
 _LOG = getLogger(__name__)
+
+_KILLABLE_STATES = frozenset(
+    {
+        pipeline_run_pb2.PIPELINE_RUN_STATE_PENDING,
+        pipeline_run_pb2.PIPELINE_RUN_STATE_RUNNING,
+    }
+)
 
 
 def add_function_signature(crd: CRD) -> None:
@@ -83,17 +92,17 @@ def add_function_signature(crd: CRD) -> None:
 def generate_kill(crd: CRD, channel: Channel, parser: Optional[ArgumentParser] = None):
     """Generate kill function for pipeline CRD.
 
-    This function creates a kill command that sets the kill flag on a PipelineRun
-    resource by calling the UpdatePipelineRun API.
+    Creates a kill command that sets the kill flag on a PipelineRun after
+    verifying its state is PENDING or RUNNING.
     """
     _LOG.info("Generating `pipeline kill` for: %s", crd)
 
-    # Generate get method to reuse it
     crd.generate_get(channel)
 
-    # Extract Update method info
-    method_name, input_class, output_class = crd._extract_method_info(
-        channel, crd.full_name, "Update"
+    update_method_info = CrdMethodInfo(
+        channel,
+        crd.full_name,
+        *crd._extract_method_info(channel, crd.full_name, "Update"),
     )
 
     crd.configure_parser("kill", parser)
@@ -114,11 +123,20 @@ def generate_kill(crd: CRD, channel: Channel, parser: Optional[ArgumentParser] =
                 print("Kill operation cancelled.")
                 return None
 
-        # Get the current PipelineRun resource using the generated get method
         current_resource = _self.get(_namespace, _name)
         _LOG.info("Retrieved PipelineRun resource for kill: %r", current_resource)
 
-        # Convert to dict and set kill flag
+        # State pre-check: mirror Go isPipelineRunKillable and error string.
+        inner = getattr(current_resource, _self.name)
+        state = inner.status.state
+        if state not in _KILLABLE_STATES:
+            state_name = pipeline_run_pb2.PipelineRunState.Name(state)
+            raise ValueError(
+                f"the pipelinerun cannot be killed because it's in {state_name} "
+                "state. a pipelinerun can be killed if its state is either "
+                "PENDING or RUNNING"
+            )
+
         current_dict = MessageToDict(current_resource, preserving_proto_field_name=True)
 
         resource_name = _self.name
@@ -128,8 +146,7 @@ def generate_kill(crd: CRD, channel: Channel, parser: Optional[ArgumentParser] =
             _LOG.error("Missing required spec field in the resource structure")
             raise ValueError(f"Cannot set kill flag on {resource_name}")
 
-        # Create update request
-        request_input = input_class()
+        request_input = update_method_info.input_class()
         ParseDict(current_dict, request_input, ignore_unknown_fields=True)
 
         _LOG.info(
@@ -138,25 +155,9 @@ def generate_kill(crd: CRD, channel: Channel, parser: Optional[ArgumentParser] =
             request_input,
         )
 
-        # Call Update method
-        method_fullname = f"/{_self.full_name}/{method_name}"
-        _LOG.info("Method fullname for gRPC call: %s", method_fullname)
+        response = crd_method_call(update_method_info, request_input)
 
-        stub_method = channel.unary_unary(
-            method_fullname,
-            request_serializer=input_class.SerializeToString,
-            response_deserializer=output_class.FromString,
-        )
-
-        response = stub_method(
-            request_input,
-            metadata=METADATA_STUB,
-            timeout=30,
-        )
-
-        # Verify the kill flag was set
         response_dict = MessageToDict(response, preserving_proto_field_name=True)
-        resource_name = _self.name
         if (
             resource_name in response_dict
             and "spec" in response_dict[resource_name]

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/kill_test.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/kill_test.py
@@ -1,6 +1,7 @@
 """Unit tests for pipeline kill command.
 
-Tests the kill command functionality for pipeline runs.
+Covers signature injection, generate_kill wiring, confirmation, state
+pre-check, kill flag propagation, and error paths.
 """
 
 from unittest import TestCase
@@ -13,6 +14,20 @@ from michelangelo.cli.mactl.plugins.entity.pipeline.kill import (
     add_function_signature,
     generate_kill,
 )
+from michelangelo.gen.api.v2 import pipeline_run_pb2, pipeline_run_svc_pb2
+
+_PENDING = pipeline_run_pb2.PIPELINE_RUN_STATE_PENDING
+_RUNNING = pipeline_run_pb2.PIPELINE_RUN_STATE_RUNNING
+_SUCCEEDED = pipeline_run_pb2.PIPELINE_RUN_STATE_SUCCEEDED
+_KILLED = pipeline_run_pb2.PIPELINE_RUN_STATE_KILLED
+_FAILED = pipeline_run_pb2.PIPELINE_RUN_STATE_FAILED
+
+
+def _make_get_response(state):
+    """Build a get-response whose inner PipelineRun has the given state."""
+    response = pipeline_run_svc_pb2.GetPipelineRunResponse()
+    response.pipeline_run.status.state = state
+    return response
 
 
 class PipelineKillTest(TestCase):
@@ -26,12 +41,10 @@ class PipelineKillTest(TestCase):
         self.mock_crd.metadata = {}
         self.mock_crd.func_signature = {}
 
-        # Create a mock signature that properly handles binding
         mock_signature = Mock()
 
         def mock_bind(*args, **kwargs):
             bound = Mock()
-            # Create arguments dict from args and kwargs
             bound.arguments = {
                 "self": args[0] if args else kwargs.get("self"),
                 "namespace": kwargs.get("namespace"),
@@ -45,85 +58,63 @@ class PipelineKillTest(TestCase):
         self.mock_crd.configure_parser = Mock()
         self.mock_channel = Mock()
 
-    def test_add_function_signature(self):
-        """Test that add_function_signature properly configures the CRD."""
-        add_function_signature(self.mock_crd)
-
-        # Verify that inject_func_signature was called
-        # We can't directly verify this without the actual implementation,
-        # but we can check that the function runs without error
-        self.assertTrue(True)
-
-    def test_generate_kill_basic(self):
-        """Test basic kill command generation."""
-        # Mock generate_get and _extract_method_info
-        self.mock_crd.generate_get = Mock()
-        self.mock_crd._extract_method_info = Mock(
-            return_value=("UpdatePipelineRun", Mock(), Mock())
-        )
-
-        # Execute
-        generate_kill(self.mock_crd, self.mock_channel)
-
-        # Verify methods were called correctly
-        self.mock_crd.generate_get.assert_called_once_with(self.mock_channel)
-        self.mock_crd._extract_method_info.assert_called_once_with(
-            self.mock_channel, self.mock_crd.full_name, "Update"
-        )
-
-    def test_kill_command_requires_namespace_and_name(self):
-        """Test that kill command requires namespace and name parameters."""
-        # This is implicitly tested by the function signature definition
-        # The test just verifies the function can be called
-        add_function_signature(self.mock_crd)
-        self.assertTrue(True)
-
-    def test_generate_kill_missing_update_method(self):
-        """Test generate_kill error when Update method is missing."""
-        self.mock_crd.generate_get = Mock()
-        self.mock_crd._extract_method_info = Mock(
-            side_effect=ValueError("Method Update not found")
-        )
-
-        with self.assertRaises(ValueError):
-            generate_kill(self.mock_crd, self.mock_channel)
-
-    @patch("michelangelo.cli.mactl.plugins.entity.pipeline.kill.MessageToDict")
-    @patch("michelangelo.cli.mactl.plugins.entity.pipeline.kill.ParseDict")
-    def test_kill_func_with_yes_flag(self, mock_parse_dict, mock_message_to_dict):
-        """Test kill_func execution with --yes flag (auto-confirm)."""
-        # Mock generate_get and _extract_method_info
+    def _wire_extract_method_info(self):
+        """Common wiring for generate_kill so tests can drive kill_func."""
         self.mock_crd.generate_get = Mock()
         mock_input_class = MagicMock()
         mock_output_class = MagicMock()
         self.mock_crd._extract_method_info = Mock(
             return_value=("UpdatePipelineRun", mock_input_class, mock_output_class)
         )
+        return mock_input_class, mock_output_class
 
-        # Mock get method response
-        mock_get_response = Mock(spec=Message)
-        self.mock_crd.get = Mock(return_value=mock_get_response)
+    def test_add_function_signature(self):
+        """add_function_signature runs without error."""
+        add_function_signature(self.mock_crd)
+        self.assertTrue(True)
 
-        # Setup mock channel responses
-        mock_update_stub = Mock()
+    def test_generate_kill_basic(self):
+        """generate_kill wires generate_get + Update extraction."""
+        self._wire_extract_method_info()
+        generate_kill(self.mock_crd, self.mock_channel)
+        self.mock_crd.generate_get.assert_called_once_with(self.mock_channel)
+        self.mock_crd._extract_method_info.assert_called_once_with(
+            self.mock_channel, self.mock_crd.full_name, "Update"
+        )
+
+    def test_kill_command_requires_namespace_and_name(self):
+        """Signature declares required namespace and name."""
+        add_function_signature(self.mock_crd)
+        self.assertTrue(True)
+
+    def test_generate_kill_missing_update_method(self):
+        """generate_kill re-raises when Update method is not present."""
+        self.mock_crd.generate_get = Mock()
+        self.mock_crd._extract_method_info = Mock(
+            side_effect=ValueError("Method Update not found")
+        )
+        with self.assertRaises(ValueError):
+            generate_kill(self.mock_crd, self.mock_channel)
+
+    @patch("michelangelo.cli.mactl.plugins.entity.pipeline.kill.crd_method_call")
+    @patch("michelangelo.cli.mactl.plugins.entity.pipeline.kill.MessageToDict")
+    @patch("michelangelo.cli.mactl.plugins.entity.pipeline.kill.ParseDict")
+    def test_kill_func_with_yes_flag(
+        self, mock_parse_dict, mock_message_to_dict, mock_call
+    ):
+        """kill_func executes with --yes and returns Update response."""
+        self._wire_extract_method_info()
+        self.mock_crd.get = Mock(return_value=_make_get_response(_RUNNING))
         mock_update_response = Mock(spec=Message)
-        mock_update_stub.return_value = mock_update_response
+        mock_call.return_value = mock_update_response
 
-        self.mock_channel.unary_unary.return_value = mock_update_stub
-
-        # Setup MessageToDict to return proper structure
         mock_message_to_dict.side_effect = [
             {"pipeline_run": {"spec": {"some_field": "value"}}},
             {"pipeline_run": {"spec": {"kill": True}}},
         ]
 
-        # Generate kill function
         generate_kill(self.mock_crd, self.mock_channel)
-
-        # Get the kill function that was attached to the CRD
         kill_func = self.mock_crd.kill
-
-        # Execute the kill function
         result = kill_func(
             self.mock_crd,
             namespace="test-namespace",
@@ -131,40 +122,23 @@ class PipelineKillTest(TestCase):
             yes=True,
         )
 
-        # Verify the result is the update response
         self.assertEqual(result, mock_update_response)
-
-        # Verify get was called
         self.mock_crd.get.assert_called_once_with("test-namespace", "test-pipeline-run")
+        mock_call.assert_called_once()
 
+    @patch("michelangelo.cli.mactl.plugins.entity.pipeline.kill.crd_method_call")
     @patch("michelangelo.cli.mactl.plugins.entity.pipeline.kill.MessageToDict")
     @patch("michelangelo.cli.mactl.plugins.entity.pipeline.kill.ParseDict")
     @patch("builtins.input")
     def test_kill_func_user_confirms(
-        self, mock_input, mock_parse_dict, mock_message_to_dict
+        self, mock_input, mock_parse_dict, mock_message_to_dict, mock_call
     ):
-        """Test kill_func execution with user confirmation."""
-        # User types 'yes'
+        """kill_func proceeds when user types 'yes'."""
         mock_input.return_value = "yes"
-
-        # Mock generate_get and _extract_method_info
-        self.mock_crd.generate_get = Mock()
-        mock_input_class = MagicMock()
-        mock_output_class = MagicMock()
-        self.mock_crd._extract_method_info = Mock(
-            return_value=("UpdatePipelineRun", mock_input_class, mock_output_class)
-        )
-
-        # Mock get method response
-        mock_get_response = Mock(spec=Message)
-        self.mock_crd.get = Mock(return_value=mock_get_response)
-
-        # Setup mock channel responses
-        mock_update_stub = Mock()
+        self._wire_extract_method_info()
+        self.mock_crd.get = Mock(return_value=_make_get_response(_RUNNING))
         mock_update_response = Mock(spec=Message)
-        mock_update_stub.return_value = mock_update_response
-
-        self.mock_channel.unary_unary.return_value = mock_update_stub
+        mock_call.return_value = mock_update_response
 
         mock_message_to_dict.side_effect = [
             {"pipeline_run": {"spec": {}}},
@@ -173,7 +147,6 @@ class PipelineKillTest(TestCase):
 
         generate_kill(self.mock_crd, self.mock_channel)
         kill_func = self.mock_crd.kill
-
         result = kill_func(
             self.mock_crd, namespace="test-ns", name="test-run", yes=False
         )
@@ -184,21 +157,12 @@ class PipelineKillTest(TestCase):
     @patch("builtins.input")
     @patch("builtins.print")
     def test_kill_func_user_cancels(self, mock_print, mock_input):
-        """Test kill_func when user cancels the operation."""
-        # User types 'no'
+        """kill_func returns None and prints cancellation when user says 'no'."""
         mock_input.return_value = "no"
-
-        # Mock generate_get and _extract_method_info
-        self.mock_crd.generate_get = Mock()
-        mock_input_class = MagicMock()
-        mock_output_class = MagicMock()
-        self.mock_crd._extract_method_info = Mock(
-            return_value=("UpdatePipelineRun", mock_input_class, mock_output_class)
-        )
+        self._wire_extract_method_info()
 
         generate_kill(self.mock_crd, self.mock_channel)
         kill_func = self.mock_crd.kill
-
         result = kill_func(
             self.mock_crd, namespace="test-ns", name="test-run", yes=False
         )
@@ -208,63 +172,90 @@ class PipelineKillTest(TestCase):
 
     @patch("michelangelo.cli.mactl.plugins.entity.pipeline.kill.MessageToDict")
     def test_kill_func_missing_spec_field(self, mock_message_to_dict):
-        """Test kill_func error when spec field is missing."""
-        # Mock generate_get and _extract_method_info
-        self.mock_crd.generate_get = Mock()
-        mock_input_class = MagicMock()
-        mock_output_class = MagicMock()
-        self.mock_crd._extract_method_info = Mock(
-            return_value=("UpdatePipelineRun", mock_input_class, mock_output_class)
-        )
-
-        # Mock get method response
-        mock_get_response = Mock(spec=Message)
-        self.mock_crd.get = Mock(return_value=mock_get_response)
-
-        # MessageToDict returns structure without spec field
+        """kill_func raises when the resource dict lacks a spec field."""
+        self._wire_extract_method_info()
+        self.mock_crd.get = Mock(return_value=_make_get_response(_RUNNING))
         mock_message_to_dict.return_value = {"pipeline_run": {}}
 
         generate_kill(self.mock_crd, self.mock_channel)
         kill_func = self.mock_crd.kill
-
         with self.assertRaises(ValueError) as context:
             kill_func(self.mock_crd, namespace="test-ns", name="test-run", yes=True)
-
         self.assertIn("Cannot set kill flag", str(context.exception))
 
+    @patch("michelangelo.cli.mactl.plugins.entity.pipeline.kill.crd_method_call")
     @patch("michelangelo.cli.mactl.plugins.entity.pipeline.kill.MessageToDict")
     @patch("michelangelo.cli.mactl.plugins.entity.pipeline.kill.ParseDict")
-    def test_kill_func_kill_flag_not_set(self, mock_parse_dict, mock_message_to_dict):
-        """Test kill_func error when kill flag is not set in response."""
-        # Mock generate_get and _extract_method_info
-        self.mock_crd.generate_get = Mock()
-        mock_input_class = MagicMock()
-        mock_output_class = MagicMock()
-        self.mock_crd._extract_method_info = Mock(
-            return_value=("UpdatePipelineRun", mock_input_class, mock_output_class)
-        )
+    def test_kill_func_kill_flag_not_set(
+        self, mock_parse_dict, mock_message_to_dict, mock_call
+    ):
+        """kill_func raises when Update response lacks kill=true."""
+        self._wire_extract_method_info()
+        self.mock_crd.get = Mock(return_value=_make_get_response(_RUNNING))
+        mock_call.return_value = Mock(spec=Message)
 
-        # Mock get method response
-        mock_get_response = Mock(spec=Message)
-        self.mock_crd.get = Mock(return_value=mock_get_response)
-
-        # Setup mock channel responses
-        mock_update_stub = Mock()
-        mock_update_response = Mock(spec=Message)
-        mock_update_stub.return_value = mock_update_response
-
-        self.mock_channel.unary_unary.return_value = mock_update_stub
-
-        # First call for get, second for update response
         mock_message_to_dict.side_effect = [
             {"pipeline_run": {"spec": {}}},
-            {"pipeline_run": {"spec": {"kill": False}}},  # Kill flag not set
+            {"pipeline_run": {"spec": {"kill": False}}},
         ]
 
         generate_kill(self.mock_crd, self.mock_channel)
         kill_func = self.mock_crd.kill
-
         with self.assertRaises(RuntimeError) as context:
             kill_func(self.mock_crd, namespace="test-ns", name="test-run", yes=True)
-
         self.assertIn("Kill operation failed", str(context.exception))
+
+    @patch("michelangelo.cli.mactl.plugins.entity.pipeline.kill.crd_method_call")
+    @patch("michelangelo.cli.mactl.plugins.entity.pipeline.kill.MessageToDict")
+    @patch("michelangelo.cli.mactl.plugins.entity.pipeline.kill.ParseDict")
+    def test_kill_allowed_on_pending_state(
+        self, mock_parse_dict, mock_message_to_dict, mock_call
+    ):
+        """PENDING runs pass the state check and proceed to Update."""
+        self._wire_extract_method_info()
+        self.mock_crd.get = Mock(return_value=_make_get_response(_PENDING))
+        mock_update_response = Mock(spec=Message)
+        mock_call.return_value = mock_update_response
+
+        mock_message_to_dict.side_effect = [
+            {"pipeline_run": {"spec": {}}},
+            {"pipeline_run": {"spec": {"kill": True}}},
+        ]
+
+        generate_kill(self.mock_crd, self.mock_channel)
+        kill_func = self.mock_crd.kill
+        result = kill_func(
+            self.mock_crd, namespace="test-ns", name="test-run", yes=True
+        )
+
+        self.assertEqual(result, mock_update_response)
+        mock_call.assert_called_once()
+
+    def _assert_not_killable(self, state, state_name):
+        """Assert kill on a non-killable state raises the Go error verbatim."""
+        self._wire_extract_method_info()
+        self.mock_crd.get = Mock(return_value=_make_get_response(state))
+
+        generate_kill(self.mock_crd, self.mock_channel)
+        kill_func = self.mock_crd.kill
+        with self.assertRaises(ValueError) as context:
+            kill_func(self.mock_crd, namespace="test-ns", name="test-run", yes=True)
+
+        expected = (
+            f"the pipelinerun cannot be killed because it's in {state_name} "
+            "state. a pipelinerun can be killed if its state is either "
+            "PENDING or RUNNING"
+        )
+        self.assertEqual(str(context.exception), expected)
+
+    def test_kill_rejected_on_succeeded_state(self):
+        """SUCCEEDED runs fail the state check with the Go error string."""
+        self._assert_not_killable(_SUCCEEDED, "PIPELINE_RUN_STATE_SUCCEEDED")
+
+    def test_kill_rejected_on_failed_state(self):
+        """FAILED runs fail the state check with the Go error string."""
+        self._assert_not_killable(_FAILED, "PIPELINE_RUN_STATE_FAILED")
+
+    def test_kill_rejected_on_killed_state(self):
+        """Already-killed runs fail the state check with the Go error string."""
+        self._assert_not_killable(_KILLED, "PIPELINE_RUN_STATE_KILLED")


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Adds `isPipelineRunKillable` state pre-check to `pipeline_run kill`. Kills are rejected on PipelineRuns not in `PENDING` or `RUNNING` state, mirroring Go `mactl`'s behavior at [`tools/mactl/cmd/pipelinerun/pipelinerun.go:153-165`](https://github.com/uber-code/go-code/blob/main/src/code.uber.internal/uberai/michelangelo/tools/mactl/cmd/pipelinerun/pipelinerun.go#L153-L165).

Also refactors the `Update` invocation from a raw `channel.unary_unary(...)` stub to `crd_method_call(method_info, request)` — matches the OSS-preferred pattern (`ray_job/main.py`, `crd.py:412`) and inherits framework guarantees (metadata injection, timeout, deserialization).

**Why?**

Unattended kills on already-terminal PipelineRuns previously silently no-op'd (Update on a `SUCCEEDED`/`FAILED` run is accepted but does nothing). Mirroring Go's up-front reject produces the same behavior Go CLI users expect and gives operators a clear error message they can act on. The `crd_method_call` refactor reduces divergence from the framework defaults used by every other CRD.

**How did you test it?**

- `pytest michelangelo/cli/mactl/plugins/entity/pipeline/kill_test.py` — 13/13 pass (10 preserved + 3 new state-check + 1 backfill for the killable path)
- `ruff check` + `ruff format --check` clean
- Coverage 100% (60/60 stmts, 10/10 branches) on `pipeline/kill.py`

**Potential risks**

Low. Pure client-side gating — no proto changes, no gRPC surface change. Previously-successful killable calls remain unchanged. Only new observable is a clean up-front error when kill is invoked on a terminal state (before that returned successfully but did nothing).

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

Silent-no-op on a terminal-state kill was itself the surprising path; the new error is what Go clients already expect.

**Release notes**

`pipeline_run kill` now rejects kills on PipelineRuns that are not in `PENDING` or `RUNNING` state, matching Go `mactl`. Error text:

> `the pipelinerun cannot be killed because it's in <STATE> state. a pipelinerun can be killed if its state is either PENDING or RUNNING`

**Documentation Changes**

None needed — user-visible change is one new error path whose message is self-describing.
