### PR TITLE
docs: standardize branding to "Michelangelo AI" across all docs

### DIFF
--- a/docs/about/history-and-evolution.md
+++ b/docs/about/history-and-evolution.md
@@ -3,14 +3,14 @@ sidebar_position: 1
 sidebar_label: "History & Evolution"
 ---
 
-# History and Evolution of Michelangelo
+# History and Evolution of Michelangelo AI
 
-Michelangelo has evolved significantly since its launch in 2016 — from a centralized platform for classical ML to a full-stack system supporting deep learning, generative AI, and agentic workflows. To learn more about that journey, explore the resources below.
+Michelangelo AI has evolved significantly since its launch in 2016 — from a centralized platform for classical ML to a full-stack system supporting deep learning, generative AI, and agentic workflows. To learn more about that journey, explore the resources below.
 
 ## Further Reading
 
-- [From Predictive to Generative AI](https://www.uber.com/us/en/blog/from-predictive-to-generative-ai/) — Uber Engineering blog post covering Michelangelo's architecture evolution in depth
+- [From Predictive to Generative AI](https://www.uber.com/us/en/blog/from-predictive-to-generative-ai/) — Uber Engineering blog post covering Michelangelo AI's architecture evolution in depth
 - [From Monolith to Global Mesh: How Uber Standardized ML at Scale](https://thenewstack.io/uber-standardized-ml-scale/) — The New Stack on how Uber scaled ML across the organization
-- [Michelangelo Deep Dive: Interview with Uber AI Platform PM](https://www.youtube.com/watch?v=x5cIMPmYAzw) — Interview covering history, GenAI use cases, tiering strategy, and open-source plans
-- [Michelangelo Live Demo](https://www.youtube.com/watch?v=KJe8_FLMRx4) — Conference walkthrough of the full ML lifecycle, from project creation to deployment
-- [Michelangelo Open Source Overview](https://www.youtube.com/watch?v=qXgCdkRNCYM) — Short conference talk on Michelangelo's history and open-source roadmap
+- [Michelangelo AI Deep Dive: Interview with Uber AI Platform PM](https://www.youtube.com/watch?v=x5cIMPmYAzw) — Interview covering history, GenAI use cases, tiering strategy, and open-source plans
+- [Michelangelo AI Live Demo](https://www.youtube.com/watch?v=KJe8_FLMRx4) — Conference walkthrough of the full ML lifecycle, from project creation to deployment
+- [Michelangelo AI Open Source Overview](https://www.youtube.com/watch?v=qXgCdkRNCYM) — Short conference talk on Michelangelo AI's history and open-source roadmap

--- a/docs/contributing/TERMINOLOGY.md
+++ b/docs/contributing/TERMINOLOGY.md
@@ -1,13 +1,13 @@
-# Michelangelo Terminology Guide
+# Michelangelo AI Terminology Guide
 
-This glossary defines core concepts used throughout Michelangelo documentation. Use this as the authoritative reference for consistent terminology.
+This glossary defines core concepts used throughout Michelangelo AI documentation. Use this as the authoritative reference for consistent terminology.
 
 ---
 
 ## Core Workflow Concepts
 
 ### Task
-A **task** is a discrete unit of work in a Michelangelo workflow.
+A **task** is a discrete unit of work in a Michelangelo AI workflow.
 
 - **Definition**: A Python function decorated with `@task` that performs a single, focused operation
 - **Execution**: Runs in a container on Kubernetes (using Ray or Spark)
@@ -137,7 +137,7 @@ spec:
 ## Framework & Infrastructure Concepts
 
 ### Uniflow
-**Uniflow** is the Python-first framework for defining and executing ML workflows in Michelangelo.
+**Uniflow** is the Python-first framework for defining and executing ML workflows in Michelangelo AI.
 
 - **Definition**: Decorator-based DSL (Domain-Specific Language) for workflow orchestration
 - **Core**: Provides `@task` and `@workflow` decorators
@@ -184,7 +184,7 @@ A **SparkTask** is a task execution configuration for distributed computing usin
 - **Best For**: Large-scale data preprocessing, SQL-like operations
 
 ### DatasetVariable
-A **DatasetVariable** is Michelangelo's abstraction for passing datasets between tasks.
+A **DatasetVariable** is Michelangelo AI's abstraction for passing datasets between tasks.
 
 - **Definition**: Wrapper that handles datasets in different frameworks (Ray, Pandas, Spark)
 - **Purpose**: Abstracts away framework differences; manages serialization and storage
@@ -210,7 +210,7 @@ df = train_dv.value
 ## Data & Model Concepts
 
 ### Model Registry
-The **Model Registry** is Michelangelo's model versioning and artifact management system.
+The **Model Registry** is Michelangelo AI's model versioning and artifact management system.
 
 - **Purpose**: Version, track, and manage trained models
 - **Integration**: Built on MLflow with Kubernetes Custom Resources
@@ -348,7 +348,7 @@ To understand how these concepts fit together:
 | Talking about registered, versioned deployments | Pipeline | "I registered a pipeline called training-pipeline" |
 | Discussing a single execution | PipelineRun | "The PipelineRun failed at the training step" |
 | Talking about automatic execution | Trigger / TriggerRun | "Set up a trigger to run daily at 9 AM" |
-| Referring to the overall system | Michelangelo + Uniflow | "Uniflow is the framework; Michelangelo is the platform" |
+| Referring to the overall system | Michelangelo AI + Uniflow | "Uniflow is the framework; Michelangelo AI is the platform" |
 | Selecting compute | RayTask / SparkTask | "Use RayTask for distributed ML training" |
 | Passing data between tasks | DatasetVariable | "Pass data as a DatasetVariable for automatic caching" |
 
@@ -356,7 +356,7 @@ To understand how these concepts fit together:
 
 ## Documentation Standards
 
-When writing Michelangelo documentation:
+When writing Michelangelo AI documentation:
 
 1. **Always clarify context**: If using "pipeline," specify whether you mean workflow or deployment
 2. **Use decorators consistently**: `@uniflow.task()` and `@uniflow.workflow()` in all examples
@@ -368,4 +368,4 @@ When writing Michelangelo documentation:
 
 ## Version History
 
-- **v1.0** (March 6, 2026): Initial terminology glossary created based on Michelangelo documentation audit
+- **v1.0** (March 6, 2026): Initial terminology glossary created based on Michelangelo AI documentation audit

--- a/docs/contributing/building-michelangelo-ai-from-source.md
+++ b/docs/contributing/building-michelangelo-ai-from-source.md
@@ -1,6 +1,6 @@
-# Building Michelangelo from Source
+# Building Michelangelo AI from Source
 
-To contribute to the Michelangelo repository, follow the instructions below to build from the main branch.
+To contribute to the Michelangelo AI repository, follow the instructions below to build from the main branch.
 
 ## Architecture for Contributors
 
@@ -8,7 +8,7 @@ Before diving into build commands, here is a map of the main subsystems and wher
 
 | Subsystem | Language | Directory | Description |
 |-----------|----------|-----------|-------------|
-| **API Server** | Go | `go/cmd/apiserver/` | Central gRPC server; CRUD for all Michelangelo resources |
+| **API Server** | Go | `go/cmd/apiserver/` | Central gRPC server; CRUD for all Michelangelo AI resources |
 | **Controller Manager** | Go | `go/cmd/controllermgr/` | Kubernetes controllers (RayCluster, SparkJob, InferenceServer, …) |
 | **Worker** | Go | `go/cmd/worker/` | Temporal/Cadence workflow and activity workers |
 | **Ingester** | Go | `go/components/ingester/` | Watches Kubernetes events and propagates state |
@@ -70,7 +70,7 @@ The Go services live under `go/cmd/` and are built with Bazel.
 
 ### API Server
 
-The unified gRPC server for all Michelangelo APIs. It provides CRUD operations for API resource types, manages resource schemas, and invokes registered API hooks.
+The unified gRPC server for all Michelangelo AI APIs. It provides CRUD operations for API resource types, manages resource schemas, and invokes registered API hooks.
 
 ```bash
 bazel run //go/cmd/apiserver
@@ -97,7 +97,7 @@ bazel run //go/cmd/worker
 
 ### Controller Manager
 
-The Kubernetes controller manager. Requires a Kubernetes config connected to a Michelangelo cluster (or a local sandbox).
+The Kubernetes controller manager. Requires a Kubernetes config connected to a Michelangelo AI cluster (or a local sandbox).
 
 ```bash
 # Create a sandbox cluster first

--- a/docs/contributing/custom-docker-images.md
+++ b/docs/contributing/custom-docker-images.md
@@ -1,6 +1,6 @@
 # Custom Docker Images for Feature Branches and Sandbox Testing
 
-> **Who is this for?** This guide is for **contributors** developing Michelangelo's core platform services (API server, controller manager, worker). If you're building ML pipelines using the Michelangelo SDK, you don't need custom Docker images — the default sandbox images work out of the box. See the [Sandbox Setup Guide](../getting-started/sandbox-setup.md) for getting started.
+> **Who is this for?** This guide is for **contributors** developing Michelangelo AI's core platform services (API server, controller manager, worker). If you're building ML pipelines using the Michelangelo AI SDK, you don't need custom Docker images — the default sandbox images work out of the box. See the [Sandbox Setup Guide](../getting-started/sandbox-setup.md) for getting started.
 
 This guide explains two ways to build and test custom images:
 

--- a/docs/contributing/dev-environment.md
+++ b/docs/contributing/dev-environment.md
@@ -1,6 +1,6 @@
 # Go and Bazel Development Setup
 
-This guide is for developers contributing to Michelangelo's Go backend services (API server, controller manager, worker). If you're building ML pipelines with the Python SDK, see [Python IDE Setup](../getting-started/setup-python-ide.md) instead.
+This guide is for developers contributing to Michelangelo AI's Go backend services (API server, controller manager, worker). If you're building ML pipelines with the Python SDK, see [Python IDE Setup](../getting-started/setup-python-ide.md) instead.
 
 ---
 

--- a/docs/contributing/dev/bazel.md
+++ b/docs/contributing/dev/bazel.md
@@ -7,7 +7,7 @@ sidebar_label: "Bazel Build System"
 
 ## Overview
 
-Michelangelo uses Bazel (version 7.4.1, see `.bazelversion`) for building all Go binaries, generating proto bindings, and running tests. Bazel's hermetic, reproducible builds mean that `bazel build` produces the same output regardless of what is installed on your machine — no implicit toolchain dependencies.
+Michelangelo AI uses Bazel (version 7.4.1, see `.bazelversion`) for building all Go binaries, generating proto bindings, and running tests. Bazel's hermetic, reproducible builds mean that `bazel build` produces the same output regardless of what is installed on your machine — no implicit toolchain dependencies.
 
 ## Key Files
 

--- a/docs/contributing/dev/go/code-style.md
+++ b/docs/contributing/dev/go/code-style.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # Go Code Style Guide
 
-This guide covers Go code conventions used across the Michelangelo codebase. It complements the [error handling guide](error-handling.md) with broader patterns: package structure, interface design, logging, and test organization.
+This guide covers Go code conventions used across the Michelangelo AI codebase. It complements the [error handling guide](error-handling.md) with broader patterns: package structure, interface design, logging, and test organization.
 
 ---
 
@@ -131,7 +131,7 @@ func (r *Registry) GetBackend(backendType v2pb.BackendType) (Backend, error) {
 
 ## Logging Conventions
 
-Michelangelo uses two loggers depending on the context:
+Michelangelo AI uses two loggers depending on the context:
 
 | Logger | Package | Used in |
 |--------|---------|---------|

--- a/docs/contributing/dev/go/key-concepts-and-terms.md
+++ b/docs/contributing/dev/go/key-concepts-and-terms.md
@@ -45,7 +45,7 @@ Other top-level directories include `api/`, `auth/`, `base/`, `kubeproto/`, `log
 
 ### API Server (`go/cmd/apiserver/`)
 
-Central gRPC server that acts as the control plane API. It validates resources, stores them as Kubernetes Custom Resource Definitions (CRDs) via the Kubernetes API, and invokes registered API hooks on mutating operations. All Michelangelo resources (InferenceServer, Pipeline, RayJob, SparkJob, etc.) flow through the API server before being persisted.
+Central gRPC server that acts as the control plane API. It validates resources, stores them as Kubernetes Custom Resource Definitions (CRDs) via the Kubernetes API, and invokes registered API hooks on mutating operations. All Michelangelo AI resources (InferenceServer, Pipeline, RayJob, SparkJob, etc.) flow through the API server before being persisted.
 
 ### Controller Manager (`go/cmd/controllermgr/`)
 
@@ -135,14 +135,14 @@ For platform-wide terms (Pipeline, Workflow, Task, etc.), see [TERMINOLOGY.md](.
 |------|---------|
 | **Uniflow** | The Python-authored workflow framework. Workflows are transpiled to Starlark and executed by the worker. |
 | **Reconciler** | A Kubernetes controller that brings actual cluster state to the desired state stored in Kubernetes (etcd) and the metadata store (MySQL). Must be idempotent. |
-| **CRD** | Custom Resource Definition — Michelangelo resources (InferenceServer, Pipeline, RayJob, SparkJob, etc.) are stored as K8s CRDs. |
+| **CRD** | Custom Resource Definition — Michelangelo AI resources (InferenceServer, Pipeline, RayJob, SparkJob, etc.) are stored as K8s CRDs. |
 | **Finalizer** | A Kubernetes mechanism that prevents object deletion until a cleanup step completes. Used by the ingester to drain in-flight data before a resource is removed. |
 | **Activity** | A Cadence unit of work, corresponding to a single task step in a Uniflow workflow. Activities are retried independently on failure. |
 | **Starlark** | A deterministic, Python-like scripting language used as the intermediate representation for Uniflow workflows. Determinism guarantees replay correctness. |
 | **Plugin** | A Go package in `go/worker/plugins/` that extends the Starlark execution environment with domain-specific builtins (e.g., `ray.create_cluster`). |
 | **fx** | Dependency injection framework (`go.uber.org/fx`). Components declare their dependencies via `fx.Provide`, and the framework wires them at startup. |
 | **logr** | The logging interface from controller-runtime (`sigs.k8s.io/controller-runtime/pkg/log`). Used in some controllers (e.g., the ingester); other controllers and most components use `go.uber.org/zap`. |
-| **mamockgen** | Michelangelo's wrapper around `mockgen`. Generates Go mocks from interface definitions. Lives at `tools/mamockgen` in the repo. Invoked via `//go:generate mamockgen Backend` (also accepts multiple names, e.g., `//go:generate mamockgen Publisher Provider`). See [Using Go Mocks in Unit Tests](../../use-go-mocks-in-unit-test.md) for setup. |
+| **mamockgen** | Michelangelo AI's wrapper around `mockgen`. Generates Go mocks from interface definitions. Lives at `tools/mamockgen` in the repo. Invoked via `//go:generate mamockgen Backend` (also accepts multiple names, e.g., `//go:generate mamockgen Publisher Provider`). See [Using Go Mocks in Unit Tests](../../use-go-mocks-in-unit-test.md) for setup. |
 
 ---
 

--- a/docs/contributing/dev/protobuf.md
+++ b/docs/contributing/dev/protobuf.md
@@ -7,7 +7,7 @@ sidebar_label: "Protocol Buffers"
 
 ## Overview
 
-All Michelangelo API resources are defined in `.proto` files. The gRPC API, message types, and service contracts all live here. Proto files are the source of truth for what resources exist, what fields they have, and what operations the API server supports.
+All Michelangelo AI API resources are defined in `.proto` files. The gRPC API, message types, and service contracts all live here. Proto files are the source of truth for what resources exist, what fields they have, and what operations the API server supports.
 
 ## Module Structure
 

--- a/docs/contributing/dev/python/mactl/coding_guidelines.md
+++ b/docs/contributing/dev/python/mactl/coding_guidelines.md
@@ -1,6 +1,6 @@
 # Mactl Coding Guidelines
 
-This document outlines coding best practices when developing features for the Michelangelo mactl CLI tool.
+This document outlines coding best practices when developing features for the Michelangelo AI mactl CLI tool.
 
 ## Test File Organization
 

--- a/docs/contributing/dev/ui/configuration/cell-type-reference.md
+++ b/docs/contributing/dev/ui/configuration/cell-type-reference.md
@@ -1,6 +1,6 @@
 # Cell Type Reference
 
-Cells are the fundamental building blocks for displaying data in Michelangelo UI. They define how individual fields are rendered across all view types: list views (table columns), detail views (metadata headers), and forms.
+Cells are the fundamental building blocks for displaying data in Michelangelo AI UI. They define how individual fields are rendered across all view types: list views (table columns), detail views (metadata headers), and forms.
 
 **Cell types are powered by the same rendering code** in `components/cell/`, with extensions registered in `components/table/components/table-cell/`.
 

--- a/docs/contributing/dev/ui/configuration/configuration-api.md
+++ b/docs/contributing/dev/ui/configuration/configuration-api.md
@@ -1,6 +1,6 @@
 # Configuration API
 
-Michelangelo UI is configuration-driven, meaning common UI patterns are abstracted into configuration objects. Think of these as component APIs or contracts that cover the standard cases for ML platform interfaces.
+Michelangelo AI UI is configuration-driven, meaning common UI patterns are abstracted into configuration objects. Think of these as component APIs or contracts that cover the standard cases for ML platform interfaces.
 
 **Configuration objects are simply structured interfaces for defining UI behavior:**
 - React developers: Component props interfaces
@@ -11,7 +11,7 @@ We've identified common patterns in ML platform UIs (entity tables, detail views
 
 ## How Configuration Works
 
-Configuration in Michelangelo UI follows a hierarchy:
+Configuration in Michelangelo AI UI follows a hierarchy:
 
 **Phase → Entity → View**
 
@@ -126,7 +126,7 @@ See `javascript/packages/core/config/entities/*/list.ts` and `*/detail.ts` for c
 
 **Engineering best practice: Dual interfaces**
 
-When building new UI components for Michelangelo, provide both interfaces:
+When building new UI components for Michelangelo AI, provide both interfaces:
 
 ```typescript
 // Base component - standard React props

--- a/docs/contributing/dev/ui/configuration/phase-configuration-reference.md
+++ b/docs/contributing/dev/ui/configuration/phase-configuration-reference.md
@@ -1,6 +1,6 @@
 # Phase Configuration Reference
 
-Phases group entities by ML lifecycle stage, providing structure to the Michelangelo UI workflow. Each phase represents a step in the machine learning operations lifecycle (e.g., data preparation, training, deployment, monitoring).
+Phases group entities by ML lifecycle stage, providing structure to the Michelangelo AI UI workflow. Each phase represents a step in the machine learning operations lifecycle (e.g., data preparation, training, deployment, monitoring).
 
 **Phases define:**
 - URL routing structure (`/train`, `/deploy`, etc.)

--- a/docs/contributing/dev/ui/index.md
+++ b/docs/contributing/dev/ui/index.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # UI Architecture
 
-Internal architecture reference for contributors to the Michelangelo UI codebase.
+Internal architecture reference for contributors to the Michelangelo AI UI codebase.
 
 ## Technology Stack
 

--- a/docs/contributing/dev/ui/ui-components.md
+++ b/docs/contributing/dev/ui/ui-components.md
@@ -217,7 +217,7 @@ Available field components:
 
 ### Styletron
 
-Michelangelo UI uses [Styletron](https://styletron.org/) with [BaseUI](https://baseweb.design/) for styling:
+Michelangelo AI UI uses [Styletron](https://styletron.org/) with [BaseUI](https://baseweb.design/) for styling:
 
 ```typescript
 import { useStyletron } from 'baseui';

--- a/docs/contributing/dev/yaml-configuration.md
+++ b/docs/contributing/dev/yaml-configuration.md
@@ -56,7 +56,7 @@ Kubernetes resource definitions (Deployments, Services, ConfigMaps) for local sa
 
 ## Helm Chart Values
 
-The Michelangelo Helm chart lives in `helm/michelangelo/`. Key files:
+The Michelangelo AI Helm chart lives in `helm/michelangelo/`. Key files:
 
 | File | Purpose |
 |------|---------|

--- a/docs/contributing/documentation-guide.md
+++ b/docs/contributing/documentation-guide.md
@@ -1,6 +1,6 @@
 # Documentation Guide
 
-This guide explains how to contribute to Michelangelo's documentation site.
+This guide explains how to contribute to Michelangelo AI's documentation site.
 
 ## Quick Start
 

--- a/docs/contributing/how-to-write-apis.md
+++ b/docs/contributing/how-to-write-apis.md
@@ -1,5 +1,5 @@
 # How to Write APIs
-This guide walks through the steps for building and compiling Protocol Buffers (Protos) of ML entities in the Michelangelo using Bazel and Gazelle.
+This guide walks through the steps for building and compiling Protocol Buffers (Protos) of ML entities in the Michelangelo AI using Bazel and Gazelle.
 
 ## 1. ML Entities in Proto Files
 

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -1,6 +1,6 @@
-# Contributing to Michelangelo
+# Contributing to Michelangelo AI
 
-Michelangelo welcomes contributions from the community. This guide is your entry point — it explains what you can contribute, where each part of the codebase lives, and how to get started.
+Michelangelo AI welcomes contributions from the community. This guide is your entry point — it explains what you can contribute, where each part of the codebase lives, and how to get started.
 
 ## Types of Contributions
 
@@ -47,7 +47,7 @@ Understanding which directory owns which subsystem helps you find the right code
 2. **Read [TERMINOLOGY.md](TERMINOLOGY.md)** — understand the vocabulary (Task, Workflow, Pipeline, PipelineRun, etc.) before reading code
 3. **Go backend contributors**: read [Go Key Concepts and Terms](dev/go/key-concepts-and-terms.md) for the package map, key types, and patterns before making changes
 4. **Build from source** — follow [Building from Source](building-michelangelo-ai-from-source.md) to ensure your environment is working
-5. **Set up the sandbox** — `poetry run ma sandbox create` gives you a local Kubernetes cluster with all Michelangelo components running. Most integration tests and manual testing use this.
+5. **Set up the sandbox** — `poetry run ma sandbox create` gives you a local Kubernetes cluster with all Michelangelo AI components running. Most integration tests and manual testing use this.
 
 ## Finding Work
 
@@ -99,7 +99,7 @@ For changes to the Uniflow decorators, task types, or the `ma` CLI.
 → **[Python Coding Guidelines](dev/python/mactl/coding_guidelines.md)**
 
 ### UI changes
-For changes to the Michelangelo web UI.
+For changes to the Michelangelo AI web UI.
 
 → **[UI Development](dev/ui/index.md)** — component patterns, types, configuration system
 

--- a/docs/contributing/ingester-internals.md
+++ b/docs/contributing/ingester-internals.md
@@ -4,7 +4,7 @@ This guide explains the internal design of the Ingester controller for developer
 
 ## Overview
 
-The Ingester is a generic Kubernetes controller that watches all 13 Michelangelo CRDs and durably syncs them into MySQL. Its purpose is to decouple metadata storage from etcd: Michelangelo's API Server and query layer can read from MySQL (faster, richer query capabilities) rather than depending solely on etcd. One `Reconciler` instance runs per CRD kind, watching only objects of that type and upserting them into a dedicated MySQL table on every create, update, or delete event.
+The Ingester is a generic Kubernetes controller that watches all 13 Michelangelo AI CRDs and durably syncs them into MySQL. Its purpose is to decouple metadata storage from etcd: Michelangelo AI's API Server and query layer can read from MySQL (faster, richer query capabilities) rather than depending solely on etcd. One `Reconciler` instance runs per CRD kind, watching only objects of that type and upserting them into a dedicated MySQL table on every create, update, or delete event.
 
 ## Finalizer Implementation
 

--- a/docs/contributing/pr-process.md
+++ b/docs/contributing/pr-process.md
@@ -1,6 +1,6 @@
 # PR Process
 
-Contributing to Michelangelo follows a standard fork-and-PR workflow. This guide covers everything from branch creation to merge.
+Contributing to Michelangelo AI follows a standard fork-and-PR workflow. This guide covers everything from branch creation to merge.
 
 ## Before You Open a PR
 

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -1,6 +1,6 @@
 # Testing Strategy
 
-Michelangelo uses a three-level test strategy. Understanding when to write each type of test — and how to run them — is the most important thing to know before opening a PR.
+Michelangelo AI uses a three-level test strategy. Understanding when to write each type of test — and how to run them — is the most important thing to know before opening a PR.
 
 ## Test Levels
 
@@ -41,9 +41,9 @@ Use `unittest.mock` or `pytest-mock` for mocking Python dependencies.
 
 ### Integration Tests (Sandbox)
 
-Integration tests validate end-to-end flows that require the Michelangelo control plane — API server, controller manager, and worker all running together.
+Integration tests validate end-to-end flows that require the Michelangelo AI control plane — API server, controller manager, and worker all running together.
 
-**Setup**: The sandbox creates a local Kubernetes cluster (k3d) with all Michelangelo components:
+**Setup**: The sandbox creates a local Kubernetes cluster (k3d) with all Michelangelo AI components:
 
 ```bash
 cd python

--- a/docs/contributing/uniflow-plugin-guide.md
+++ b/docs/contributing/uniflow-plugin-guide.md
@@ -4,7 +4,7 @@ This guide walks you through the end-to-end process of building a new Uniflow pl
 
 ## Architecture Overview
 
-Uniflow is Michelangelo's workflow execution system. Users write Python workflows using `@uniflow.task` and `@uniflow.workflow` decorators. At submission time, these Python workflows are **transpiled to Starlark** — a simplified Python-like scripting language — and executed remotely on a Cadence/Temporal worker.
+Uniflow is Michelangelo AI's workflow execution system. Users write Python workflows using `@uniflow.task` and `@uniflow.workflow` decorators. At submission time, these Python workflows are **transpiled to Starlark** — a simplified Python-like scripting language — and executed remotely on a Cadence/Temporal worker.
 
 **Plugins** extend Starlark with domain-specific capabilities (creating Ray clusters, submitting Spark jobs, triggering pipeline runs, etc.). A plugin has three layers:
 

--- a/docs/getting-started/core-concepts-and-key-terms.md
+++ b/docs/getting-started/core-concepts-and-key-terms.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 ## Overview
 
-Michelangelo utilizes a combination of standard industry terms and product-specific naming conventions. This page provides high-level definitions for the platform's most essential and commonly used concepts. It is recommended you familiarize yourself with these concepts as you will encounter them on your ML development journey.
+Michelangelo AI utilizes a combination of standard industry terms and product-specific naming conventions. This page provides high-level definitions for the platform's most essential and commonly used concepts. It is recommended you familiarize yourself with these concepts as you will encounter them on your ML development journey.
 
 The definitions and examples listed below are organized based on frequency of usage in the documentation and priority for user understanding.
 
@@ -18,7 +18,7 @@ Need to quickly look up a term? Here's a summary of the most commonly used conce
 |------|-----------|-----------------|
 | **Project** | Business use case with trackable metrics | Organizing all ML work for a specific problem (e.g., fraud detection, churn prediction) |
 | **Model Family** | Group of related models for one use case | When multiple models solve different aspects of one business problem |
-| **Dataset** | Registered data in Michelangelo | Providing training, validation, or prediction input data |
+| **Dataset** | Registered data in Michelangelo AI | Providing training, validation, or prediction input data |
 | **Task** | Single unit of computation (function) | Building reusable, modular steps in your ML pipeline |
 | **Workflow** | Chain of tasks with dependencies | Orchestrating multi-step ML pipelines (data prep → training → evaluation) |
 | **Model & Revision** | Trained model artifact with version number | Tracking different versions of your trained models |
@@ -31,13 +31,13 @@ Need to quickly look up a term? Here's a summary of the most commonly used conce
 ---
 
 ## System Components
-These are the frameworks, interfaces, and compute engines provided by Michelangelo to facilitate development.
+These are the frameworks, interfaces, and compute engines provided by Michelangelo AI to facilitate development.
 
 ### Orchestration & Interfaces
 
 #### MA Studio (No Code UI)
 
-**MA Studio** is Michelangelo's UI environment. The standard, code-free ML development experience guides users through the different phases of the ML development lifecycle. This environment provides all the essential tools which allow ML developers to build, train, deploy, monitor, and debug your machine learning models in a single unified visual interface to boost your productivity. 
+**MA Studio** is Michelangelo AI's UI environment. The standard, code-free ML development experience guides users through the different phases of the ML development lifecycle. This environment provides all the essential tools which allow ML developers to build, train, deploy, monitor, and debug your machine learning models in a single unified visual interface to boost your productivity. 
 
 Users can use the no-code dev environment to perform standardized ML tasks without writing a single line of code, including:
 * Prepare data sources for training models or making batch predictions
@@ -98,7 +98,7 @@ if __name__ == "__main__":
 
 #### Job
 
-A batch job running a ML workload. Currently Michelangelo runs [Spark](https://spark.apache.org/docs/latest/index.html) for data processing and [Ray](https://www.ray.io/) for ML training.
+A batch job running a ML workload. Currently Michelangelo AI runs [Spark](https://spark.apache.org/docs/latest/index.html) for data processing and [Ray](https://www.ray.io/) for ML training.
 
 #### Compute Resource
 
@@ -141,15 +141,15 @@ A Model Family is a group of related ML models within a project that address dif
 
 ### Dataset
 
-A piece of data registered in Michelangelo. Users can set up data pipelines and let Michelangelo manage the dataset, or directly register the dataset in Michelangelo and manage it externally. They can use the dataset for training and evaluation.
+A piece of data registered in Michelangelo AI. Users can set up data pipelines and let Michelangelo AI manage the dataset, or directly register the dataset in Michelangelo AI and manage it externally. They can use the dataset for training and evaluation.
 
-**Familiar Equivalent**: Like registering a dataset in a data catalog (e.g., Delta Lake, Data Version Control, or AWS Glue Data Catalog). Michelangelo tracks dataset versions and lineage automatically.
+**Familiar Equivalent**: Like registering a dataset in a data catalog (e.g., Delta Lake, Data Version Control, or AWS Glue Data Catalog). Michelangelo AI tracks dataset versions and lineage automatically.
 
 ### Feature
 
 An individual measurable property or characteristic of a phenomenon, represented as an attribute in a dataset.
 
-**Familiar Equivalent**: Same as in any ML framework - a column in your training data (e.g., "age", "transaction_amount", "embedding_vector"). Can be managed in external feature stores or within Michelangelo.
+**Familiar Equivalent**: Same as in any ML framework - a column in your training data (e.g., "age", "transaction_amount", "embedding_vector"). Can be managed in external feature stores or within Michelangelo AI.
 
 ### Pipeline
 
@@ -302,7 +302,7 @@ python train_workflow.py
 
 ## How Concepts Relate
 
-Understanding how Michelangelo's concepts work together:
+Understanding how Michelangelo AI's concepts work together:
 
 ```
 Project (e.g., "Fraud Detection")
@@ -336,7 +336,7 @@ Project (e.g., "Fraud Detection")
 ### Training Your First Model
 
 1. **Create a Project** for your use case (e.g., "Customer Churn Prediction")
-2. **Register your Dataset** in Michelangelo (connect to data warehouse)
+2. **Register your Dataset** in Michelangelo AI (connect to data warehouse)
 3. **Define a Workflow** with training tasks (or use MA Studio UI for no-code approach)
 4. **Run the workflow** and track results in Model Registry
 5. **Create a Deployment** to serve predictions via an Endpoint

--- a/docs/getting-started/faq.md
+++ b/docs/getting-started/faq.md
@@ -12,9 +12,9 @@ Common questions about getting started, data, training, deployment, monitoring, 
 
 A: See the [Support & Community](./support.md) page for all channels — GitHub Discussions for Q&A, Slack for real-time chat, and email for private inquiries. For bugs, [open a GitHub issue](https://github.com/michelangelo-ai/michelangelo/issues/new/choose).
 
-**Q: Do I need to learn a new framework to use Michelangelo?**
+**Q: Do I need to learn a new framework to use Michelangelo AI?**
 
-A: No. If you're using the UI, it's entirely point-and-click. If you're coding, Michelangelo uses familiar tools:
+A: No. If you're using the UI, it's entirely point-and-click. If you're coding, Michelangelo AI uses familiar tools:
 - Python for model code (PyTorch, TensorFlow, scikit-learn, XGBoost all work)
 - Ray for distributed computing
 - Standard data formats (Parquet, CSV, JSON)
@@ -37,7 +37,7 @@ def train_model(data_path: str):
 
 A: Start small:
 1. Pick one model to migrate (not your most critical one)
-2. Use Michelangelo's data prep → training → deployment workflow
+2. Use Michelangelo AI's data prep → training → deployment workflow
 3. Compare results with your existing pipeline
 4. Gradually migrate more models as you gain confidence
 
@@ -49,11 +49,11 @@ A: Multiple sources:
 - Upload CSV/Parquet files directly to the plugged-in storage
 - Connect to data warehouses (Snowflake, BigQuery, Redshift)
 - Use Spark/Ray for large-scale data processing
-- Reference existing datasets in Michelangelo's data catalog
+- Reference existing datasets in Michelangelo AI's data catalog
 
-**Q: Can I use feature stores with Michelangelo?**
+**Q: Can I use feature stores with Michelangelo AI?**
 
-A: Yes, Michelangelo integrates with feature stores or you can manage features within the platform using the data prep pipelines and inference.
+A: Yes, Michelangelo AI integrates with feature stores or you can manage features within the platform using the data prep pipelines and inference.
 
 **Q: What data formats are supported?**
 
@@ -63,7 +63,7 @@ A: Parquet (recommended). CSV, JSON, Avro. For custom formats, use Uniflow tasks
 
 **Q: What compute resources are available?**
 
-A: Michelangelo provides:
+A: Michelangelo AI provides:
 - CPU-only instances for lightweight models
 - Single-GPU instances (V100, A100) for deep learning
 - Multi-GPU clusters for distributed training
@@ -91,7 +91,7 @@ A: Uniflow automatically:
 
 **Q: How do I monitor model performance in production?**
 
-A: Michelangelo provides:
+A: Michelangelo AI provides:
 - **Model Excellence Scores** tracking accuracy, latency, throughput
 - **Data drift detection** comparing training vs. production distributions
 - **Custom metrics** you define and track
@@ -110,7 +110,7 @@ A: Multiple approaches:
 
 ## Cost & Scaling
 
-**Q: How does Michelangelo handle scaling?**
+**Q: How does Michelangelo AI handle scaling?**
 
 A: Automatically:
 - Online inference autoscales based on request volume
@@ -119,13 +119,13 @@ A: Automatically:
 
 **Q: What if my dataset doesn't fit in memory?**
 
-A: Use Michelangelo's Ray integration for out-of-core processing. Data is streamed from storage (S3, HDFS) and processed in chunks.
+A: Use Michelangelo AI's Ray integration for out-of-core processing. Data is streamed from storage (S3, HDFS) and processed in chunks.
 
 ## Collaboration & Governance
 
 **Q: How do multiple team members collaborate?**
 
-A: Michelangelo provides:
+A: Michelangelo AI provides:
 - **Shared projects** with role-based access control (see [Project Management](../user-guides/getting-started/project-management-for-ml-pipelines.md))
 - **Model lineage** tracking from training data through deployment
 - **Versioning** for models, pipelines, and pipeline runs
@@ -135,7 +135,7 @@ For operator-side RBAC and identity-provider setup, see the [Authentication guid
 
 **Q: Is my data secure?**
 
-A: Yes. Michelangelo enforces:
+A: Yes. Michelangelo AI enforces:
 - Role-based access control (RBAC)
 - Encryption at rest and in transit
 - Audit logs for all operations
@@ -143,9 +143,9 @@ A: Yes. Michelangelo enforces:
 
 See the [Compliance Guide](../operator-guides/operations/compliance.md) for configuration steps specific to each framework.
 
-**Q: Can I use Michelangelo for regulated industries (healthcare, finance)?**
+**Q: Can I use Michelangelo AI for regulated industries (healthcare, finance)?**
 
-A: Yes, with proper configuration. Michelangelo supports:
+A: Yes, with proper configuration. Michelangelo AI supports:
 - Data residency requirements (region-specific storage)
 - Audit trails for model decisions
 - Explainability tools for model interpretability

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,32 +1,32 @@
 # Getting Started
 
-Welcome to Michelangelo! Whether you're evaluating the platform or ready to build your first ML pipeline, you're in the right place.
+Welcome to Michelangelo AI! Whether you're evaluating the platform or ready to build your first ML pipeline, you're in the right place.
 
 ## Choose your path
 
-### I want to understand what Michelangelo does
+### I want to understand what Michelangelo AI does
 
 Start here if you're evaluating the platform or want to learn the key concepts before diving in. Takes about 15 minutes.
 
-- **[Overview](./overview.md)** — What Michelangelo is, how it works, and how familiar ML tools map to it
+- **[Overview](./overview.md)** — What Michelangelo AI is, how it works, and how familiar ML tools map to it
 - **[Core Concepts and Key Terms](./core-concepts-and-key-terms.md)** — Projects, workflows, tasks, and the key terms you'll encounter
 
 ### I want to set up and start building
 
 Ready to get hands-on? Follow these guides in order. You'll have a working local environment in about 20 minutes.
 
-1. **[Sandbox Setup](./sandbox-setup.md)** — Set up a local Michelangelo cluster with all services running (~20 min)
+1. **[Sandbox Setup](./sandbox-setup.md)** — Set up a local Michelangelo AI cluster with all services running (~20 min)
 2. **[Getting Started with Pipelines](../user-guides/getting-started/getting-started.md)** — Build and run your first ML pipeline (~30 min)
 3. **[Browse Examples](../user-guides/examples/index.md)** — 9 end-to-end workflows: XGBoost, BERT, GPT fine-tuning, batch inference, and more
 
 ### Reference
 
 - **[Sandbox Ports and Endpoints](./ma-sandbox-ports-and-endpoints.md)** — Service ports and URLs for your local sandbox
-- **[Python IDE Setup](./setup-python-ide.md)** — Configure VS Code, Cursor, or PyCharm for the Michelangelo SDK
+- **[Python IDE Setup](./setup-python-ide.md)** — Configure VS Code, Cursor, or PyCharm for the Michelangelo AI SDK
 
 ### For contributors
 
-Building on Michelangelo's core platform? These guides cover the contributor development workflow:
+Building on Michelangelo AI's core platform? These guides cover the contributor development workflow:
 
 - **[Go and Bazel Setup](../contributing/dev-environment.md)** — IDE setup for Go backend development
 - **[Custom Docker Images](../contributing/custom-docker-images.md)** — Build and test images from feature branches

--- a/docs/getting-started/ma-sandbox-ports-and-endpoints.md
+++ b/docs/getting-started/ma-sandbox-ports-and-endpoints.md
@@ -4,7 +4,7 @@ sidebar_position: 6
 
 # Sandbox Ports and Endpoints
 
-This is a quick reference for the URLs and ports your local Michelangelo sandbox exposes on `localhost`. After `ma sandbox create` finishes, use this page to find where to point your browser, your CLI, or your SDK client.
+This is a quick reference for the URLs and ports your local Michelangelo AI sandbox exposes on `localhost`. After `ma sandbox create` finishes, use this page to find where to point your browser, your CLI, or your SDK client.
 
 If you haven't set up the sandbox yet, start with [Sandbox Setup](./sandbox-setup.md) first.
 
@@ -38,7 +38,7 @@ These mappings are created automatically by `ma sandbox create`:
 | Service | Host port | NodePort | In-cluster service | Container port | What it's for |
 |---|---:|---:|---|---:|---|
 | MA Studio UI | 8090 | 30011 | `michelangelo-ui` | 8090 | Web UI — your main entry point |
-| Michelangelo API Server | 15566 | 30009 | `michelangelo-apiserver` | 15566 | gRPC API (YARPC) for SDK and CLI clients |
+| Michelangelo AI API Server | 15566 | 30009 | `michelangelo-apiserver` | 15566 | gRPC API (YARPC) for SDK and CLI clients |
 | Envoy (gRPC-web proxy) | 8081 | 30010 | `michelangelo-envoy` | 8081 | gRPC-web → gRPC bridge used by the UI |
 | Cadence Web | 8088 | 30004 | `michelangelo-cadence-web` | 8088 | Inspect, retry, and debug Cadence workflow runs |
 | Cadence Frontend (gRPC) | 7833 | 30002 | `michelangelo-cadence` | 7833 | Cadence SDK and client connections |

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Overview
 
-Michelangelo is an end-to-end ML platform that manages the full model lifecycle — training, versioning, deployment, and monitoring — on Kubernetes, so ML teams can ship models without building infrastructure from scratch.
+Michelangelo AI is an end-to-end ML platform that manages the full model lifecycle — training, versioning, deployment, and monitoring — on Kubernetes, so ML teams can ship models without building infrastructure from scratch.
 
 ## Choose Your Path
 
@@ -17,7 +17,7 @@ Pick the approach that matches your workflow and expertise:
 - Need to **prototype rapidly** before investing in custom code
 
 **Quick Start**:
-1. Navigate to MA Studio (available at your Michelangelo deployment URL, or `http://localhost:8090` in the [local sandbox](./sandbox-setup.md))
+1. Navigate to MA Studio (available at your Michelangelo AI deployment URL, or `http://localhost:8090` in the [local sandbox](./sandbox-setup.md))
 2. Create a new project and define your use case
 3. Prepare your dataset using the Data Prep interface
 4. Train a model using pre-built templates
@@ -33,9 +33,9 @@ Pick the approach that matches your workflow and expertise:
 - Want to apply **software engineering practices** to ML (testing, version control, CI/CD)
 
 **Quick Start**:
-1. Install Michelangelo SDK: `pip install michelangelo`
+1. Install Michelangelo AI SDK: `pip install michelangelo`
 2. Define your workflow using Uniflow decorators (`@uniflow.task`, `@uniflow.workflow`)
-3. Submit a dev-run to the Michelangelo API server (see [Sandbox Setup](./sandbox-setup.md))
+3. Submit a dev-run to the Michelangelo AI API server (see [Sandbox Setup](./sandbox-setup.md))
 4. Monitor execution through the UI
 
 **Best for**: Custom architectures, multi-stage pipelines, A/B testing frameworks, feature engineering at scale
@@ -49,15 +49,15 @@ Many teams start with the **UI for initial experiments**, then transition to **c
 
 ## ML Workflow Mapping
 
-If you're coming from other ML platforms, here's how familiar concepts map to Michelangelo:
+If you're coming from other ML platforms, here's how familiar concepts map to Michelangelo AI:
 
-| Your Workflow | Familiar Tool | Michelangelo Equivalent |
+| Your Workflow | Familiar Tool | Michelangelo AI Equivalent |
 |---------------|---------------|-------------------------|
 | **Data Preparation** | Pandas, Spark notebooks | **MA Studio Data Prep** or **Uniflow tasks** with Ray/Spark * |
 | **Experiment Tracking** | MLflow, Weights & Biases | **Model Registry** with automatic versioning |
 | **Model Training** | Custom scripts, Kubeflow Pipelines | **MA Studio Training** (UI) or **CanvasFlex/Uniflow workflows** (code) |
 | **Hyperparameter Tuning** | Optuna, Ray Tune | **Uniflow tasks** with Ray Tune * |
-| **Model Storage** | S3 buckets, model registries | **Michelangelo Model Registry** with metadata & plugin storage |
+| **Model Storage** | S3 buckets, model registries | **Michelangelo AI Model Registry** with metadata & plugin storage |
 | **Batch Inference** | Airflow + custom scripts | **Deployment to batch endpoint** with offline inference pipeline and Ray / Triton Inference * |
 | **Online Serving** | TorchServe, TensorFlow Serving | **Deployment to inference server** with Triton Inference Server * |
 | **Monitoring** | Prometheus + Grafana | **Model Excellence Scores** + built-in monitoring * |
@@ -105,11 +105,11 @@ def training_pipeline(data_path: str):
 
 ## Architecture
 
-Machine learning at scale requires coordinating many moving parts: data preparation, experiment tracking, model training, deployment, and monitoring. Michelangelo provides an integrated ecosystem that handles all of these concerns, enabling teams to focus on building great models rather than managing infrastructure.
+Machine learning at scale requires coordinating many moving parts: data preparation, experiment tracking, model training, deployment, and monitoring. Michelangelo AI provides an integrated ecosystem that handles all of these concerns, enabling teams to focus on building great models rather than managing infrastructure.
 
-The diagram below shows how Michelangelo's components work together:
+The diagram below shows how Michelangelo AI's components work together:
 
-![Michelangelo Ecosystem Diagram](./images/michelangelo-ecosystem.png)
+![Michelangelo AI Ecosystem Diagram](./images/michelangelo-ecosystem.png)
 
 ## Frequently Asked Questions
 

--- a/docs/getting-started/roadmap.md
+++ b/docs/getting-started/roadmap.md
@@ -5,7 +5,7 @@ sidebar_label: "Roadmap"
 
 # Roadmap
 
-Michelangelo is under active development. This page captures the current state of the platform and the direction we're headed. Things will shift as priorities evolve and the community gives feedback.
+Michelangelo AI is under active development. This page captures the current state of the platform and the direction we're headed. Things will shift as priorities evolve and the community gives feedback.
 
 ## Release Milestones
 
@@ -13,13 +13,13 @@ The OSS release is staged so each version makes a specific, scoped promise rathe
 
 | Version | Target | Focus |
 |---|---|---|
-| **0.4.0** | July 2026 | Release management + core pipeline platform — UniFlow, Ray/Spark integration, pipeline/run/trigger management, Michelangelo CLI, Michelangelo Studio |
+| **0.4.0** | July 2026 | Release management + core pipeline platform — UniFlow, Ray/Spark integration, pipeline/run/trigger management, Michelangelo AI CLI, Michelangelo AI Studio |
 | **0.5.0** | Q3 2026 | End-to-end LLM model management — Foundation Model fine-tuning, model registry, offline inference, progressive serving |
 | **TBD** | H2 2026 | Agent Infrastructure |
 
 ## Versioning Policy
 
-Michelangelo follows [Semantic Versioning 2.0.0](https://semver.org/) with stability declared per component, not per repository.
+Michelangelo AI follows [Semantic Versioning 2.0.0](https://semver.org/) with stability declared per component, not per repository.
 
 | Stability Level | Guarantee |
 |---|---|

--- a/docs/getting-started/sandbox-setup.md
+++ b/docs/getting-started/sandbox-setup.md
@@ -4,9 +4,9 @@ sidebar_position: 3
 
 # Sandbox Setup
 
-This guide walks you through setting up a local Michelangelo environment on your laptop. The sandbox runs a fully functional cluster — API server, controller manager, workflow engine, object storage, and supporting services — entirely on your machine, so you can explore Michelangelo or develop against it without any cloud infrastructure.
+This guide walks you through setting up a local Michelangelo AI environment on your laptop. The sandbox runs a fully functional cluster — API server, controller manager, workflow engine, object storage, and supporting services — entirely on your machine, so you can explore Michelangelo AI or develop against it without any cloud infrastructure.
 
-**Who this is for:** ML engineers, platform engineers, and contributors who want to try Michelangelo locally or develop new features against it.
+**Who this is for:** ML engineers, platform engineers, and contributors who want to try Michelangelo AI locally or develop new features against it.
 
 **What you'll have at the end:** a running sandbox cluster and a successful demo pipeline run, ready for you to build your own workflows on top of.
 
@@ -16,7 +16,7 @@ This guide walks you through setting up a local Michelangelo environment on your
 
 ## Get the code
 
-Clone the Michelangelo repository to your machine:
+Clone the Michelangelo AI repository to your machine:
 
 ```bash
 git clone https://github.com/michelangelo-ai/michelangelo.git
@@ -79,7 +79,7 @@ Docker containers need to communicate with services on your host machine. Verify
 
 ### Install Python dependencies
 
-From the repository you cloned, install the Michelangelo Python packages:
+From the repository you cloned, install the Michelangelo AI Python packages:
 
 ```bash
 cd <repo-root>/python
@@ -117,7 +117,7 @@ ma sandbox demo pipeline
 
 ### Verifying success
 
-When `ma sandbox create` completes, all Michelangelo services start in your k3d cluster. Verify with:
+When `ma sandbox create` completes, all Michelangelo AI services start in your k3d cluster. Verify with:
 
 ```bash
 kubectl get pods
@@ -125,7 +125,7 @@ kubectl get pods
 
 You should see roughly 10–15 pods (the exact count depends on which engine you chose and any `--exclude` flags). On first run, pods may spend 5–10 minutes in `ContainerCreating` while images are pulled — this is expected. All pods should eventually reach `Running` status; if any remain in `ContainerCreating` beyond 15 minutes, check the pod events with `kubectl describe pod <pod-name>`.
 
-Then open the **Michelangelo UI at [http://localhost:8090](http://localhost:8090)** — if the dashboard loads, your sandbox is healthy. See [Sandbox Ports and Endpoints](./ma-sandbox-ports-and-endpoints.md) for the full list of services and their URLs.
+Then open the **Michelangelo AI UI at [http://localhost:8090](http://localhost:8090)** — if the dashboard loads, your sandbox is healthy. See [Sandbox Ports and Endpoints](./ma-sandbox-ports-and-endpoints.md) for the full list of services and their URLs.
 
 ---
 
@@ -247,7 +247,7 @@ You should see workflow logs in your terminal and, when it finishes, a trained m
 
 For the full story on local vs. remote execution, building Docker images, configuring storage, and using either workflow engine end to end, see:
 
-- [Pipeline Running Modes](../user-guides/ml-pipelines/pipeline-running-modes.md) — the four execution modes Michelangelo supports
+- [Pipeline Running Modes](../user-guides/ml-pipelines/pipeline-running-modes.md) — the four execution modes Michelangelo AI supports
 
 > **Note:** Local execution doesn't support caching, retries, or resource constraints. Use remote execution (covered in the ML Pipelines guides) for production-like behavior.
 
@@ -319,7 +319,7 @@ If plugin installation is the failure point, you can exclude Grafana from the sa
 ma sandbox sync --exclude grafana
 ```
 
-Grafana is used for metrics dashboards and is not required for pipeline execution or the Michelangelo UI.
+Grafana is used for metrics dashboards and is not required for pipeline execution or the Michelangelo AI UI.
 ### `ma` CLI commands fail with `connection attempt timed out`
 
 The `ma` CLI connects to the API server over gRPC at `localhost:15566`. The sandbox maps this port via k3d NodePort so it works out of the box after `ma sandbox create`.

--- a/docs/getting-started/setup-python-ide.md
+++ b/docs/getting-started/setup-python-ide.md
@@ -4,7 +4,7 @@ sidebar_position: 4
 
 # Set Up Your Python IDE
 
-Get your editor configured for building ML pipelines with the Michelangelo SDK. This takes about 5 minutes if you've already run `poetry install`.
+Get your editor configured for building ML pipelines with the Michelangelo AI SDK. This takes about 5 minutes if you've already run `poetry install`.
 
 ## Prerequisites
 
@@ -15,9 +15,9 @@ cd <repo-root>/python
 poetry install
 ```
 
-This creates a `.venv` directory with all Michelangelo packages. Your IDE needs to use this environment for autocomplete and import resolution to work.
+This creates a `.venv` directory with all Michelangelo AI packages. Your IDE needs to use this environment for autocomplete and import resolution to work.
 
-> **Tip**: Replace `<repo-root>` with the path where you cloned the Michelangelo repository (e.g., `~/michelangelo`).
+> **Tip**: Replace `<repo-root>` with the path where you cloned the Michelangelo AI repository (e.g., `~/michelangelo`).
 
 ---
 
@@ -39,7 +39,7 @@ This creates a `.venv` directory with all Michelangelo packages. Your IDE needs 
 2. Go to **Settings > Project > Python Interpreter**.
 3. Click the gear icon and select **Add Interpreter > Existing**.
 4. Point to the Poetry environment (usually at `python/.venv/bin/python`).
-5. PyCharm should automatically detect imports and provide autocomplete for the Michelangelo SDK.
+5. PyCharm should automatically detect imports and provide autocomplete for the Michelangelo AI SDK.
 
 ---
 
@@ -66,4 +66,4 @@ If your editor can't resolve the `michelangelo` import:
 ## What's next?
 
 - **Ready to build?** [Set up your local sandbox](./sandbox-setup.md) and follow [Getting Started with Pipelines](../user-guides/getting-started/getting-started.md)
-- **Contributing to Michelangelo's Go backend?** See [Go and Bazel Development Setup](../contributing/dev-environment.md)
+- **Contributing to Michelangelo AI's Go backend?** See [Go and Bazel Development Setup](../contributing/dev-environment.md)

--- a/docs/getting-started/support.md
+++ b/docs/getting-started/support.md
@@ -5,7 +5,7 @@ sidebar_label: "Support & Community"
 
 # Support & Community
 
-Need help with Michelangelo? Connect with the core team and developer community through our dedicated channels.
+Need help with Michelangelo AI? Connect with the core team and developer community through our dedicated channels.
 
 ## Get Help
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -4,17 +4,17 @@ sidebar_position: 1
 title: Welcome
 ---
 
-# Welcome to Michelangelo
+# Welcome to Michelangelo AI
 
-Michelangelo is an end-to-end ML platform for building, deploying, and managing machine learning models. Born at Uber — where it powers **25,000+ model trainings per month** and **~30 million predictions per second** — now open source.
+Michelangelo AI is an end-to-end ML platform for building, deploying, and managing machine learning models. Born at Uber — where it powers **25,000+ model trainings per month** and **~30 million predictions per second** — now open source.
 
-## Why Michelangelo
+## Why Michelangelo AI
 
 Most ML teams spend more engineering time on infrastructure than on models. Training pipelines break in production. Feature logic gets duplicated across teams. Serving containers are hand-rolled for each project. Stitching together a training framework, an experiment tracker, an orchestrator, and a custom serving layer works until it doesn't — and when it breaks, it's your problem to fix.
 
-Michelangelo exists so you don't have to build that stack from scratch. It covers the full ML lifecycle — data preparation, training, evaluation, deployment, and monitoring — in a single system that has been running in production at Uber's scale for eight years. A complete platform, battle-tested across thousands of models, now available for any team to adopt.
+Michelangelo AI exists so you don't have to build that stack from scratch. It covers the full ML lifecycle — data preparation, training, evaluation, deployment, and monitoring — in a single system that has been running in production at Uber's scale for eight years. A complete platform, battle-tested across thousands of models, now available for any team to adopt.
 
-**Michelangelo is worth considering if:**
+**Michelangelo AI is worth considering if:**
 - Your ML team is spending more time on infrastructure than on models
 - You're managing a patchwork of tools with brittle integrations between them
 - You want a platform that handles classic ML, deep learning, and generative AI workflows without switching systems
@@ -25,11 +25,11 @@ The platform is modular: adopt the full stack or integrate individual components
 
 ## Get started
 
-### I'm evaluating Michelangelo
+### I'm evaluating Michelangelo AI
 
 Understand what the platform does, how it compares to your current stack, and whether it fits your use case.
 
-- **[Overview](./getting-started/overview.md)** — What Michelangelo is, how it works, and how familiar tools map to it
+- **[Overview](./getting-started/overview.md)** — What Michelangelo AI is, how it works, and how familiar tools map to it
 - **[Core Concepts](./getting-started/core-concepts-and-key-terms.md)** — Projects, workflows, tasks, and the key terms you'll encounter
 - **[Roadmap](./getting-started/roadmap.md)** — Release milestones, what's available now, and what's planned
 
@@ -37,7 +37,7 @@ Understand what the platform does, how it compares to your current stack, and wh
 
 Get a local environment running and build an end-to-end ML pipeline.
 
-- **[Sandbox Setup](./getting-started/sandbox-setup.md)** — Set up a local Michelangelo cluster (~20 min)
+- **[Sandbox Setup](./getting-started/sandbox-setup.md)** — Set up a local Michelangelo AI cluster (~20 min)
 - **[Getting Started with Pipelines](./user-guides/getting-started/getting-started.md)** — Build your first pipeline from scratch (~30 min)
 - **[Example Projects](./user-guides/examples/index.md)** — 9 end-to-end workflows: XGBoost, BERT, GPT fine-tuning, batch inference, and more
 
@@ -52,22 +52,22 @@ Set up infrastructure, configure compute clusters, and deploy the UI.
 
 - **[Documentation Guide](./contributing/documentation-guide.md)** — How to write and structure docs
 
-## What Michelangelo is — and isn't
+## What Michelangelo AI is — and isn't
 
-Understanding scope helps you decide if Michelangelo is the right tool.
+Understanding scope helps you decide if Michelangelo AI is the right tool.
 
-**Michelangelo is:**
+**Michelangelo AI is:**
 - An **ML lifecycle platform** — data prep, training, evaluation, deployment, and monitoring in one system
 - An **orchestration framework** (Uniflow) for writing ML pipelines as Python code with `@task` and `@workflow` decorators
 - A **model registry** for versioning, tracking, and managing trained models
 - A **deployment system** for online inference (Triton) and batch predictions
 - A **no-code UI** (MA Studio) for standard ML workflows without writing code
 
-**Michelangelo is not:**
-- A **notebook environment** — use Jupyter/Colab for exploration, then bring your code to Michelangelo for production
+**Michelangelo AI is not:**
+- A **notebook environment** — use Jupyter/Colab for exploration, then bring your code to Michelangelo AI for production
 - A **data warehouse** — it connects to your existing data sources (S3, Snowflake, BigQuery, HDFS)
 - A **general-purpose workflow engine** — it's purpose-built for ML, not arbitrary DAGs
-- A **model monitoring SaaS** — monitoring is built in, but Michelangelo is self-hosted infrastructure, not a managed service
+- A **model monitoring SaaS** — monitoring is built in, but Michelangelo AI is self-hosted infrastructure, not a managed service
 - A **replacement for your ML framework** — use PyTorch, TensorFlow, XGBoost, scikit-learn as you normally would
 
 ## Quick links
@@ -79,7 +79,7 @@ Understanding scope helps you decide if Michelangelo is the right tool.
 
 ## Support & Community
 
-Connect with the Michelangelo core team and developer community through our dedicated channels:
+Connect with the Michelangelo AI core team and developer community through our dedicated channels:
 
 - **[GitHub Discussions](https://github.com/michelangelo-ai/michelangelo/discussions):** Our primary channel for general Q&A, troubleshooting, technical support, and sharing ideas.
 - **[Slack Workspace](https://michelangelo-ai.slack.com/):** For real-time chat, networking, and focused conversations with other developers in the ecosystem.

--- a/docs/operator-guides/api-framework.md
+++ b/docs/operator-guides/api-framework.md
@@ -1,22 +1,22 @@
-# Michelangelo API Framework
+# Michelangelo AI API Framework
 
-The Michelangelo API Framework abstracts Kubernetes CRDs through a gRPC API server. It is the control plane component that the `ma` CLI, UI, worker, and SDK all talk to. This guide covers the architecture of that component and how its parts fit together for operators deploying or maintaining Michelangelo.
+The Michelangelo AI API Framework abstracts Kubernetes CRDs through a gRPC API server. It is the control plane component that the `ma` CLI, UI, worker, and SDK all talk to. This guide covers the architecture of that component and how its parts fit together for operators deploying or maintaining Michelangelo AI.
 
 **Audience**: Platform operators and contributors who need to understand how the API layer is structured.
 
-**Prerequisites**: Familiarity with Kubernetes CRDs, gRPC, and the Michelangelo control plane (see [Platform Setup](setup/platform-setup.md)).
+**Prerequisites**: Familiarity with Kubernetes CRDs, gRPC, and the Michelangelo AI control plane (see [Platform Setup](setup/platform-setup.md)).
 
 ## Architecture
 
-Michelangelo defines the APIs using Protobuf as the IDL and the
+Michelangelo AI defines the APIs using Protobuf as the IDL and the
 clients like UI, CLI and SDK can access the API via gRPC or
-HTTP/JSON. Michelangelo will support three SDK bindings by default
+HTTP/JSON. Michelangelo AI will support three SDK bindings by default
 including Python, Golang and Java. Any other language bindings
 supported by gRPC should work as well.
 
-For detailed Michelangelo API definition, see the protobuf definitions in `proto/`.
+For detailed Michelangelo AI API definition, see the protobuf definitions in `proto/`.
 
-Figure below shows the high-level architecture of Michelangelo API
+Figure below shows the high-level architecture of Michelangelo AI API
 framework that consists of the following components:
 
 ![MA API architecture](./images/api-architecture.png)
@@ -27,14 +27,14 @@ framework that consists of the following components:
 **Kubernetes API Server:** A REST service that provides the standard
 methods for each CRD type (API resource type). Controllers monitor the
 creations / modifications of the CRD objects through the Kubernetes
-API server. Michelangelo users cannot directly call Kubernetes API
-server. Instead, they have to use Michelangelo API server (gRPC) or
-Michelangelo CLI(ma) to use Michelangelo APIs.
+API server. Michelangelo AI users cannot directly call Kubernetes API
+server. Instead, they have to use Michelangelo AI API server (gRPC) or
+Michelangelo AI CLI(ma) to use Michelangelo AI APIs.
 
-**Michelangelo API Server:** A gRPC server. For standard declarative
-API resources, Michelangelo API server is a gRPC to REST proxy. The
+**Michelangelo AI API Server:** A gRPC server. For standard declarative
+API resources, Michelangelo AI API server is a gRPC to REST proxy. The
 APIs that do not fit into the declarative design are implemented in
-the Michelangelo API server such as Search APIs.
+the Michelangelo AI API server such as Search APIs.
 
 Kubernetes API server and MA API server will be packaged in the same
 docker container. Both k8s API server and MA API server are
@@ -57,8 +57,8 @@ controller’s job to ensure that, for any given object, the actual
 state of the world matches the desired state (specification) in the
 object.
 
-Currently, all the Michelangelo controllers are in a single process,
-i.e. Michelangelo Controller Manager. There will be multiple
+Currently, all the Michelangelo AI controllers are in a single process,
+i.e. Michelangelo AI Controller Manager. There will be multiple
 controller manager instances deployed into different availability
 zones for high availability. But at any time there is only one
 instance acting as the leader and others will be the followers.
@@ -68,6 +68,6 @@ Kubernetes API server). Controller Manager is based on the Kubernetes open-sourc
 framework, i.e. `controller-runtime`.
 
 Figure below shows how different ML pipelines can be managed and
-executed using the Michelangelo API Framework.
+executed using the Michelangelo AI API Framework.
 
 ![Pipeline management flow](./images/pipeline-management-flow.png)

--- a/docs/operator-guides/components/ingester-configuration.md
+++ b/docs/operator-guides/components/ingester-configuration.md
@@ -1,6 +1,6 @@
 # Ingester Controller: Configuration and Operations
 
-The **Ingester** is a Kubernetes controller that syncs all Michelangelo CRDs into MySQL, decoupling metadata storage from etcd. This guide covers deploying, configuring, and operating the ingester on production clusters.
+The **Ingester** is a Kubernetes controller that syncs all Michelangelo AI CRDs into MySQL, decoupling metadata storage from etcd. This guide covers deploying, configuring, and operating the ingester on production clusters.
 
 ## Architecture Overview
 
@@ -73,7 +73,7 @@ Do not enable the ingester if your deployment uses SparkJob. A pre-existing nil 
 
 ### Prerequisites
 
-- Kubernetes cluster with Michelangelo API Server
+- Kubernetes cluster with Michelangelo AI API Server
 - MySQL 5.7+ accessible from the controllermgr pod
 - Schema init Job (provides 39 MySQL tables)
 
@@ -364,5 +364,5 @@ When the ingester is correctly enabled:
 Once the ingester is running, verify steady-state behavior: all 13 CRD kinds appear in MySQL, object counts match etcd, and `update_time` advances on changes. Then:
 
 - **Monitor**: Set up alerting on requeue errors — elevated `workqueue_retries_total` for ingester controllers indicates MySQL connectivity issues. See [Monitoring](../operations/monitoring.md).
-- **Restrict deletes**: Enforce all CRD deletes through the Michelangelo API Server (not raw `kubectl delete`) to prevent orphan rows from pre-existing objects.
+- **Restrict deletes**: Enforce all CRD deletes through the Michelangelo AI API Server (not raw `kubectl delete`) to prevent orphan rows from pre-existing objects.
 - **Review internals**: See [Ingester Internals](../../contributing/ingester-internals.md) for developer documentation on extending the ingester or adding new CRD kinds.

--- a/docs/operator-guides/components/model-registry.md
+++ b/docs/operator-guides/components/model-registry.md
@@ -1,6 +1,6 @@
 # Model Registry
 
-Michelangelo ships a built-in model registry — no external server required. This guide explains how operators verify the registry is healthy, configure storage and access, and integrate registered models with downstream serving and CI/CD systems.
+Michelangelo AI ships a built-in model registry — no external server required. This guide explains how operators verify the registry is healthy, configure storage and access, and integrate registered models with downstream serving and CI/CD systems.
 
 ---
 
@@ -39,7 +39,7 @@ The registry is backed by a single Kubernetes Custom Resource: `Model` (CRD name
 Before working through this guide, ensure you have completed:
 
 - **[Platform Setup](../setup/platform-setup.md#object-store-configuration)** — the Controller Manager's `minio.*` fields must point to a reachable S3-compatible object store.
-- **Compute cluster registration** — at least one compute cluster registered with the Michelangelo control plane, so Uniflow tasks have somewhere to run.
+- **Compute cluster registration** — at least one compute cluster registered with the Michelangelo AI control plane, so Uniflow tasks have somewhere to run.
 - Sufficient cluster permissions to create Roles and RoleBindings, and to inspect Custom Resource Definitions.
 
 ---
@@ -52,7 +52,7 @@ Confirm the `Model` CRD is present in the cluster before expecting any registrat
 kubectl get crd models.michelangelo.api
 ```
 
-If the CRD is missing, re-run the Michelangelo CRD installation step described in [Platform Setup](../setup/platform-setup.md).
+If the CRD is missing, re-run the Michelangelo AI CRD installation step described in [Platform Setup](../setup/platform-setup.md).
 
 You can also spot-check a namespace for any existing models:
 
@@ -86,7 +86,7 @@ Task pods produce the raw model files during registration. If task pods run unde
 
 ### Artifact URI discovery
 
-The exact S3 layout for a model's artifacts is set by your platform configuration — Michelangelo does not prescribe a fixed directory structure. Rather than hardcoding paths, read the actual locations from each `Model` resource after registration:
+The exact S3 layout for a model's artifacts is set by your platform configuration — Michelangelo AI does not prescribe a fixed directory structure. Rather than hardcoding paths, read the actual locations from each `Model` resource after registration:
 
 ```bash
 # Raw training artifact URIs (weights, checkpoints)
@@ -273,7 +273,7 @@ ma model get -n <namespace> --limit 20
 
 ## Integrating with the Serving Layer
 
-Michelangelo's `InferenceServer` resource does not reference a `Model` resource by name in its spec. The wiring from a registered model to a running server flows through `Deployment` and `Revision` resources managed by the Controller Manager, which update a `modelconfig` ConfigMap consumed by the inference backend.
+Michelangelo AI's `InferenceServer` resource does not reference a `Model` resource by name in its spec. The wiring from a registered model to a running server flows through `Deployment` and `Revision` resources managed by the Controller Manager, which update a `modelconfig` ConfigMap consumed by the inference backend.
 
 A representative `InferenceServer` manifest:
 
@@ -388,7 +388,7 @@ Model artifacts in S3 are not automatically removed when a `Model` resource is d
 
 | Symptom | Likely cause | Resolution |
 |---|---|---|
-| `error: the server doesn't have a resource type "models"` | CRD not installed | Re-run the Michelangelo CRD installation step (see [Platform Setup](../setup/platform-setup.md)) |
+| `error: the server doesn't have a resource type "models"` | CRD not installed | Re-run the Michelangelo AI CRD installation step (see [Platform Setup](../setup/platform-setup.md)) |
 | `kubectl get models` returns `No resources found` but CRD is present | No models registered yet, or wrong namespace | Confirm a registration task has run; check the namespace |
 | `spec.model_artifact_uri` empty after registration | Controller Manager lacks S3 write permissions, or the registration task failed | Check Controller Manager logs; verify IAM policy on the bucket |
 | `spec.deployable_artifact_uri` empty | Packaging step did not run or failed | Inspect the pipeline run logs for the registration task |

--- a/docs/operator-guides/experiment-tracking.md
+++ b/docs/operator-guides/experiment-tracking.md
@@ -1,6 +1,6 @@
 # Experiment Tracking Setup
 
-Michelangelo does not bundle an experiment tracking server — it connects to one you already run. This guide shows platform operators how to expose that server to task pods running inside Michelangelo's compute clusters.
+Michelangelo AI does not bundle an experiment tracking server — it connects to one you already run. This guide shows platform operators how to expose that server to task pods running inside Michelangelo AI's compute clusters.
 
 It covers network setup, ConfigMap injection, credential handling, and the boundary between what operators configure and what users do in their `@uniflow.task()` code.
 
@@ -8,10 +8,10 @@ It covers network setup, ConfigMap injection, credential handling, and the bound
 
 ## How Experiment Tracking Works with Uniflow Tasks
 
-Experiment tracking in Michelangelo follows a clear separation of concerns:
+Experiment tracking in Michelangelo AI follows a clear separation of concerns:
 
 - **Operators** configure network access and make the tracking server URI available to task pods via environment variables or ConfigMaps.
-- **Users** call their tracking server's client library inside `@uniflow.task()` functions. Michelangelo does not intercept or wrap these calls.
+- **Users** call their tracking server's client library inside `@uniflow.task()` functions. Michelangelo AI does not intercept or wrap these calls.
 
 ```text
 ┌─────────────────────────────────────────────┐
@@ -41,7 +41,7 @@ Experiment tracking in Michelangelo follows a clear separation of concerns:
 
 ## Step 1: Verify Network Reachability
 
-Task pods run inside the compute cluster namespace registered with Michelangelo (see [Register a Compute Cluster](setup/register-a-compute-cluster-to-michelangelo-control-plane.md)). Confirm that pods in that namespace can reach your tracking server.
+Task pods run inside the compute cluster namespace registered with Michelangelo AI (see [Register a Compute Cluster](setup/register-a-compute-cluster-to-michelangelo-control-plane.md)). Confirm that pods in that namespace can reach your tracking server.
 
 ```bash
 # Run a connectivity test from a pod in the compute namespace
@@ -92,7 +92,7 @@ spec:
 
 ## Step 2: Add the Tracking URI to the `michelangelo-config` ConfigMap
 
-Michelangelo injects environment variables into every task pod (Ray head, Ray workers, Spark drivers, and Spark executors) via the `michelangelo-config` ConfigMap. This ConfigMap is mounted as an `envFrom` source, so every key in it becomes an environment variable in the pod.
+Michelangelo AI injects environment variables into every task pod (Ray head, Ray workers, Spark drivers, and Spark executors) via the `michelangelo-config` ConfigMap. This ConfigMap is mounted as an `envFrom` source, so every key in it becomes an environment variable in the pod.
 
 You created this ConfigMap when you [registered the compute cluster](setup/register-a-compute-cluster-to-michelangelo-control-plane.md). Add the tracking server URI as a new key:
 
@@ -181,7 +181,7 @@ Users are responsible for:
 
 ## Multi-Cluster Environments
 
-If you have registered multiple compute clusters with Michelangelo, ensure the tracking server URI is injected consistently across all clusters. Each cluster's compute namespace needs the ConfigMap and any required NetworkPolicy entries.
+If you have registered multiple compute clusters with Michelangelo AI, ensure the tracking server URI is injected consistently across all clusters. Each cluster's compute namespace needs the ConfigMap and any required NetworkPolicy entries.
 
 You can manage this with a Kustomize overlay per cluster:
 

--- a/docs/operator-guides/helm-chart.md
+++ b/docs/operator-guides/helm-chart.md
@@ -3,17 +3,17 @@ sidebar_position: 2
 sidebar_label: "Helm Chart"
 ---
 
-# Install Michelangelo with Helm
+# Install Michelangelo AI with Helm
 
-The `michelangelo` Helm chart installs the Michelangelo control plane on any Kubernetes cluster — production, staging, or a local development cluster. After installation you can manage the platform with standard `helm install`, `helm upgrade`, and `helm uninstall` commands.
+The `michelangelo` Helm chart installs the Michelangelo AI control plane on any Kubernetes cluster — production, staging, or a local development cluster. After installation you can manage the platform with standard `helm install`, `helm upgrade`, and `helm uninstall` commands.
 
 This guide walks you through prerequisites, a minimal install, verification, customization, and upgrade or removal. The final sections explain the chart's design so you know what you are getting.
 
 ## Who this is for
 
-This guide is for **platform engineers and infrastructure operators** who want to run Michelangelo on a Kubernetes cluster they manage. By the end, you will have:
+This guide is for **platform engineers and infrastructure operators** who want to run Michelangelo AI on a Kubernetes cluster they manage. By the end, you will have:
 
-- A running Michelangelo control plane on your cluster
+- A running Michelangelo AI control plane on your cluster
 - A clear understanding of what the chart owns and what you must provide
 - The commands to upgrade, customize, and remove the release
 
@@ -353,7 +353,7 @@ Required values use Helm's `required` template function — `helm install` fails
 
 ### Least-privilege RBAC
 
-The chart installs a scoped `ClusterRole` covering only what `controllermgr` and `apiserver` need: CRD lifecycle, Michelangelo CRs, KubeRay/Spark CRs, namespaces (create/update/patch/delete), pods/services, configmaps/secrets, and leader-election leases. There is no `cluster-admin` grant.
+The chart installs a scoped `ClusterRole` covering only what `controllermgr` and `apiserver` need: CRD lifecycle, Michelangelo AI CRs, KubeRay/Spark CRs, namespaces (create/update/patch/delete), pods/services, configmaps/secrets, and leader-election leases. There is no `cluster-admin` grant.
 
 ### Pod security defaults
 

--- a/docs/operator-guides/index.md
+++ b/docs/operator-guides/index.md
@@ -1,13 +1,13 @@
 # Operator Guides
 
-These guides cover deploying, configuring, and integrating Michelangelo in a Kubernetes environment. They target platform engineers and infrastructure operators who are responsible for running Michelangelo in production and for connecting it to the broader ML infrastructure their teams already use — experiment tracking, model registries, compute clusters, schedulers, and serving frameworks.
+These guides cover deploying, configuring, and integrating Michelangelo AI in a Kubernetes environment. They target platform engineers and infrastructure operators who are responsible for running Michelangelo AI in production and for connecting it to the broader ML infrastructure their teams already use — experiment tracking, model registries, compute clusters, schedulers, and serving frameworks.
 
 ## Getting Started
 
 For a fresh deployment, follow this recommended reading order:
 
 1. **[Platform Setup](setup/platform-setup.md)** — configure each component (API server, controller manager, worker, UI/Envoy) via ConfigMaps and Kustomize overlays
-2. **[Register a Compute Cluster](setup/register-a-compute-cluster-to-michelangelo-control-plane.md)** — connect an existing Kubernetes cluster so Michelangelo can dispatch Ray and Spark jobs to it
+2. **[Register a Compute Cluster](setup/register-a-compute-cluster-to-michelangelo-control-plane.md)** — connect an existing Kubernetes cluster so Michelangelo AI can dispatch Ray and Spark jobs to it
 3. **[Cluster Setup for Serving](serving/cluster-setup.md)** — enable model inference on a local or remote cluster
 4. **[Authentication](setup/authentication.md)** — connect an identity provider and configure RBAC before opening to users
 
@@ -15,17 +15,17 @@ For a fresh deployment, follow this recommended reading order:
 
 | Guide | Description |
 |-------|-------------|
-| [Helm Chart](helm-chart.md) | Install the Michelangelo control plane with Helm — chart layout, values reference, and migration phases |
+| [Helm Chart](helm-chart.md) | Install the Michelangelo AI control plane with Helm — chart layout, values reference, and migration phases |
 | [Platform Setup](setup/platform-setup.md) | ConfigMaps and key fields for API server, controller manager, worker, and UI/Envoy |
 | [Network & Ingress](setup/network.md) | Envoy proxy, Ingress setup, TLS with cert-manager, and multi-cluster connectivity |
 | [Authentication](setup/authentication.md) | OIDC identity provider setup, RBAC, session configuration, multi-tenant isolation |
-| [Register a Compute Cluster](setup/register-a-compute-cluster-to-michelangelo-control-plane.md) | Connect an existing Kubernetes cluster to the Michelangelo control plane |
+| [Register a Compute Cluster](setup/register-a-compute-cluster-to-michelangelo-control-plane.md) | Connect an existing Kubernetes cluster to the Michelangelo AI control plane |
 
 ## Platform Components
 
 | Guide | Description |
 |-------|-------------|
-| [Model Registry](components/model-registry.md) | Operate Michelangelo's built-in model registry, configure storage and RBAC, and integrate with serving and CI/CD |
+| [Model Registry](components/model-registry.md) | Operate Michelangelo AI's built-in model registry, configure storage and RBAC, and integrate with serving and CI/CD |
 | [Ingester Controller](components/ingester-configuration.md) | Deploy, configure, and operate the ingester that syncs CRDs into MySQL |
 
 ## Jobs & Compute
@@ -48,12 +48,12 @@ For a fresh deployment, follow this recommended reading order:
 
 | Guide | Description |
 |-------|-------------|
-| [Deploying the UI](ui/deploying-michelangelo-ui.md) | Deploy the Michelangelo web UI to Kubernetes |
+| [Deploying the UI](ui/deploying-michelangelo-ui.md) | Deploy the Michelangelo AI web UI to Kubernetes |
 | [Local UI Development](ui/local-development-setup.md) | Run the UI locally for development |
 
 ## Third-Party Integrations
 
-Michelangelo is designed to run alongside existing ML infrastructure. The guides below cover making external tools reachable from Michelangelo workloads.
+Michelangelo AI is designed to run alongside existing ML infrastructure. The guides below cover making external tools reachable from Michelangelo AI workloads.
 
 | Guide | Description |
 |-------|-------------|
@@ -74,5 +74,5 @@ Michelangelo is designed to run alongside existing ML infrastructure. The guides
 
 | Guide | Description |
 |-------|-------------|
-| [API Framework](api-framework.md) | Architecture overview of the Michelangelo API and control plane |
+| [API Framework](api-framework.md) | Architecture overview of the Michelangelo AI API and control plane |
 | [SQL Key Concepts and Terms](sql-key-concepts-and-terms.md) | Metadata schema, table naming, indexed fields, and SQL query patterns |

--- a/docs/operator-guides/integrations/cometml.md
+++ b/docs/operator-guides/integrations/cometml.md
@@ -4,9 +4,9 @@
 
 ---
 
-## How Comet ML works with Michelangelo
+## How Comet ML works with Michelangelo AI
 
-Comet calls happen inside your `@uniflow.task()` function — Michelangelo doesn't intercept them; the client talks directly to Comet from the task pod. Pick the hook for your framework (see **Integrations**), and make sure `COMET_API_KEY` is available (see **Configuring Comet ML across your environment**).
+Comet calls happen inside your `@uniflow.task()` function — Michelangelo AI doesn't intercept them; the client talks directly to Comet from the task pod. Pick the hook for your framework (see **Integrations**), and make sure `COMET_API_KEY` is available (see **Configuring Comet ML across your environment**).
 
 ```python
 import comet_ml
@@ -187,13 +187,13 @@ When one model is trained by **multiple processes**, you want **one** experiment
 
 ---
 
-## Comet ML Model Registry vs Michelangelo Model Registry
+## Comet ML Model Registry vs Michelangelo AI Model Registry
 
-Comet and Michelangelo each have their own model registry; the two are independent and can be used together.
+Comet and Michelangelo AI each have their own model registry; the two are independent and can be used together.
 
 - **Use Comet's registry** for model governance, lineage, versioning, and stage transitions tied to your tracked experiments.
-- **Use Michelangelo's registry** when you want models deployable via Michelangelo's `InferenceServer`.
-- **Use both:** register to Comet for lineage/governance, and separately register the deployable artifact to Michelangelo for serving.
+- **Use Michelangelo AI's registry** when you want models deployable via Michelangelo AI's `InferenceServer`.
+- **Use both:** register to Comet for lineage/governance, and separately register the deployable artifact to Michelangelo AI for serving.
 
 Register a model to Comet from your task — log it, then register it:
 

--- a/docs/operator-guides/integrations/index.md
+++ b/docs/operator-guides/integrations/index.md
@@ -1,13 +1,13 @@
 # Third-Party Integrations
 
-This section covers connecting third-party tools to Michelangelo. If you are looking for documentation on Michelangelo's own components — the model registry, experiment tracking setup, serving infrastructure, or job scheduler — see the [Operator Guides index](../index.md).
+This section covers connecting third-party tools to Michelangelo AI. If you are looking for documentation on Michelangelo AI's own components — the model registry, experiment tracking setup, serving infrastructure, or job scheduler — see the [Operator Guides index](../index.md).
 
 Before configuring any tool below, complete [Experiment Tracking Setup](../experiment-tracking.md) — the platform-level guide for network reachability, ConfigMap injection, auth, and the operator/user boundary that applies to all third-party tracking integrations.
 
 | Guide | Description |
 |-------|-------------|
-| [Comet ML](cometml.md) | Connect to Comet ML's experiment tracking — network setup, API key injection, PyTorch Lightning / Ray Train / HuggingFace Transformers / custom training loop patterns, distributed experiment coordination, and Comet ML vs Michelangelo model registry comparison|
-| [MLflow](mlflow.md) | Connect a self-hosted or Databricks-managed MLflow Tracking Server — network setup, auth, and MLflow vs Michelangelo registry comparison |
+| [Comet ML](cometml.md) | Connect to Comet ML's experiment tracking — network setup, API key injection, PyTorch Lightning / Ray Train / HuggingFace Transformers / custom training loop patterns, distributed experiment coordination, and Comet ML vs Michelangelo AI model registry comparison|
+| [MLflow](mlflow.md) | Connect a self-hosted or Databricks-managed MLflow Tracking Server — network setup, auth, and MLflow vs Michelangelo AI registry comparison |
 
 ## Next Steps
 

--- a/docs/operator-guides/integrations/mlflow.md
+++ b/docs/operator-guides/integrations/mlflow.md
@@ -1,14 +1,14 @@
 # MLflow
 
-This guide explains how platform operators can connect an [MLflow Tracking Server](https://mlflow.org/docs/latest/tracking.html) to Michelangelo workloads. MLflow overlaps with two Michelangelo capabilities — experiment tracking and the model registry — so this guide covers both, along with the boundary between what operators configure and what users do in their `@uniflow.task()` code.
+This guide explains how platform operators can connect an [MLflow Tracking Server](https://mlflow.org/docs/latest/tracking.html) to Michelangelo AI workloads. MLflow overlaps with two Michelangelo AI capabilities — experiment tracking and the model registry — so this guide covers both, along with the boundary between what operators configure and what users do in their `@uniflow.task()` code.
 
-Michelangelo does not bundle an MLflow server. This guide assumes you are running a self-hosted MLflow Tracking Server or a managed endpoint (such as Databricks Managed MLflow).
+Michelangelo AI does not bundle an MLflow server. This guide assumes you are running a self-hosted MLflow Tracking Server or a managed endpoint (such as Databricks Managed MLflow).
 
 > **Before you begin:** Complete [Experiment Tracking Setup](../experiment-tracking.md) — the platform-level guide for network reachability, ConfigMap injection, and auth. This MLflow guide builds on those foundations.
 
 ---
 
-## How MLflow Works with Michelangelo
+## How MLflow Works with Michelangelo AI
 
 ```text
 ┌─────────────────────────────────────────────┐
@@ -25,7 +25,7 @@ Michelangelo does not bundle an MLflow server. This guide assumes you are runnin
 └─────────────────────────────────────────────┘
 ```
 
-Michelangelo does not intercept or wrap MLflow calls. Users call the MLflow client directly inside `@uniflow.task()` functions and configure the tracking URI themselves. The operator's job is to ensure the MLflow server is reachable from task pods.
+Michelangelo AI does not intercept or wrap MLflow calls. Users call the MLflow client directly inside `@uniflow.task()` functions and configure the tracking URI themselves. The operator's job is to ensure the MLflow server is reachable from task pods.
 
 ---
 
@@ -39,7 +39,7 @@ Michelangelo does not intercept or wrap MLflow calls. Users call the MLflow clie
 
 ## Step 1: Verify Network Reachability
 
-Task pods run inside the compute cluster namespace registered with Michelangelo. Confirm that pods in that namespace can reach your MLflow server before proceeding.
+Task pods run inside the compute cluster namespace registered with Michelangelo AI. Confirm that pods in that namespace can reach your MLflow server before proceeding.
 
 ```bash
 kubectl run mlflow-connectivity-test \
@@ -88,7 +88,7 @@ Replace `<your-pod-selector-label>` with labels that match your task pods. Check
 
 ## Step 2: Configure the Tracking URI
 
-`MLFLOW_TRACKING_URI` is a user-space configuration — it belongs in workflow code or the Ray job pod environment, not in the Michelangelo system ConfigMap. Users should set it themselves using one of these approaches.
+`MLFLOW_TRACKING_URI` is a user-space configuration — it belongs in workflow code or the Ray job pod environment, not in the Michelangelo AI system ConfigMap. Users should set it themselves using one of these approaches.
 
 ### Option A: Set in workflow code
 
@@ -182,22 +182,22 @@ Users are responsible for:
 
 ---
 
-## MLflow Model Registry vs Michelangelo Model Registry
+## MLflow Model Registry vs Michelangelo AI Model Registry
 
-MLflow includes its own model registry. Michelangelo also has a built-in model registry backed by a `Model` Kubernetes custom resource. The two are independent and can be used simultaneously.
+MLflow includes its own model registry. Michelangelo AI also has a built-in model registry backed by a `Model` Kubernetes custom resource. The two are independent and can be used simultaneously.
 
-| | MLflow Model Registry | Michelangelo Model Registry |
+| | MLflow Model Registry | Michelangelo AI Model Registry |
 |---|---|---|
 | Backed by | MLflow Tracking Server database | Kubernetes `Model` CRD + S3 |
 | Queried via | MLflow client / MLflow UI | `kubectl get models` / `ma model get` |
-| Integrates with serving | MLflow serving (`mlflow models serve`) | Michelangelo `InferenceServer` |
-| Required for Michelangelo pipelines? | No | No |
+| Integrates with serving | MLflow serving (`mlflow models serve`) | Michelangelo AI `InferenceServer` |
+| Required for Michelangelo AI pipelines? | No | No |
 
-**When to use MLflow's registry:** If your organization already uses MLflow for model governance, lineage, and stage transitions (Staging → Production), continue using it. Michelangelo does not require you to use its own registry.
+**When to use MLflow's registry:** If your organization already uses MLflow for model governance, lineage, and stage transitions (Staging → Production), continue using it. Michelangelo AI does not require you to use its own registry.
 
-**When to use Michelangelo's registry:** If you want models to be deployable via Michelangelo's `InferenceServer` (Triton, vLLM, etc.), register them in Michelangelo's registry using the `@uniflow.task()` model registration API. You can do this in addition to logging to MLflow.
+**When to use Michelangelo AI's registry:** If you want models to be deployable via Michelangelo AI's `InferenceServer` (Triton, vLLM, etc.), register them in Michelangelo AI's registry using the `@uniflow.task()` model registration API. You can do this in addition to logging to MLflow.
 
-**Using both:** Log experiments and register models to MLflow for lineage and governance, and separately register the deployable artifact to Michelangelo for serving. Both calls can live in the same task function.
+**Using both:** Log experiments and register models to MLflow for lineage and governance, and separately register the deployable artifact to Michelangelo AI for serving. Both calls can live in the same task function.
 
 ---
 
@@ -233,7 +233,7 @@ A `200 OK` response confirms task pods in that namespace can reach the MLflow se
 ## Next Steps
 
 - [Experiment Tracking Setup](../experiment-tracking.md) — platform-level setup guide: network reachability, ConfigMap injection, and auth patterns for any tracking server
-- [Model Registry](../components/model-registry.md) — Michelangelo's built-in model registry: storage configuration, RBAC, and serving integration
-- [Register a Compute Cluster](../setup/register-a-compute-cluster-to-michelangelo-control-plane.md) — how to add a Kubernetes cluster so Michelangelo can dispatch jobs to it
-- [Platform Setup](../setup/platform-setup.md) — full ConfigMap reference for all Michelangelo components
+- [Model Registry](../components/model-registry.md) — Michelangelo AI's built-in model registry: storage configuration, RBAC, and serving integration
+- [Register a Compute Cluster](../setup/register-a-compute-cluster-to-michelangelo-control-plane.md) — how to add a Kubernetes cluster so Michelangelo AI can dispatch jobs to it
+- [Platform Setup](../setup/platform-setup.md) — full ConfigMap reference for all Michelangelo AI components
 - [MLflow Documentation](https://mlflow.org/docs/latest/) — official MLflow docs for tracking, model registry, and deployment

--- a/docs/operator-guides/jobs/extend-michelangelo-batch-job-scheduler-system.md
+++ b/docs/operator-guides/jobs/extend-michelangelo-batch-job-scheduler-system.md
@@ -1,6 +1,6 @@
 # Extend the Job Scheduler System
 
-This page describes the Michelangelo Job Scheduler architecture and how to extend it with custom backends or plugins.
+This page describes the Michelangelo AI Job Scheduler architecture and how to extend it with custom backends or plugins.
 
 ## Architecture overview
 

--- a/docs/operator-guides/jobs/index.md
+++ b/docs/operator-guides/jobs/index.md
@@ -1,11 +1,11 @@
-# Michelangelo Jobs
+# Michelangelo AI Jobs
 
-Michelangelo provides a unified way to run large-scale data processing and ML training jobs on Kubernetes, using **Ray** and **Spark** as execution engines. This guide explains *the core concepts*, how jobs run, compute is allocated, and how users interact with the system.
+Michelangelo AI provides a unified way to run large-scale data processing and ML training jobs on Kubernetes, using **Ray** and **Spark** as execution engines. This guide explains *the core concepts*, how jobs run, compute is allocated, and how users interact with the system.
 
-## **What Is a Michelangelo Job?**
+## **What Is a Michelangelo AI Job?**
 
-A Michelangelo job is any workload—training, batch inference, ETL, feature generation—that runs on a managed compute cluster.
-Users define *what to run*, and Michelangelo handles:
+A Michelangelo AI job is any workload—training, batch inference, ETL, feature generation—that runs on a managed compute cluster.
+Users define *what to run*, and Michelangelo AI handles:
 
 * Selecting a compute cluster
 * Creating the necessary Ray or Spark resources
@@ -13,11 +13,11 @@ Users define *what to run*, and Michelangelo handles:
 * Streaming logs/status
 * Cleaning up when finished
 
-You focus on the job logic; Michelangelo manages the infrastructure.
+You focus on the job logic; Michelangelo AI manages the infrastructure.
 
 ## **Architecture**
 
-The image below displays the Michelangelo (MA) architecture for running Spark and Ray batch jobs end-to-end: submission, scheduling, execution, and reporting.
+The image below displays the Michelangelo AI (MA) architecture for running Spark and Ray batch jobs end-to-end: submission, scheduling, execution, and reporting.
 
 ![Job Controller Flow](./images/job-controller-flow.png)
 
@@ -26,9 +26,9 @@ The image below displays the Michelangelo (MA) architecture for running Spark an
 The execution flow is very similar across Ray and Spark:
 
 1. **Submit**
-   Your pipeline or service submits a job request to Michelangelo.
+   Your pipeline or service submits a job request to Michelangelo AI.
 2. **Schedule & Assign**
-   Michelangelo chooses a compute cluster based on quotas, resource needs, and policies.
+   Michelangelo AI chooses a compute cluster based on quotas, resource needs, and policies.
 3. **Materialize on Compute**
    The system creates the appropriate resources in the target cluster:
    * Ray: `RayCluster` + `RayJob`
@@ -37,7 +37,7 @@ The execution flow is very similar across Ray and Spark:
    The job runs on the generated compute cluster.
    Autoscaling brings up or down workers as needed.
 5. **Monitor & Complete**
-   Michelangelo collects logs, metrics and job status.
+   Michelangelo AI collects logs, metrics and job status.
    After completion, compute resources follow retention/TTL policies.
 
 This mirrors the same control-plane to compute-plane flow seen in platforms like **Databricks** and **Kubeflow**.
@@ -56,7 +56,7 @@ A simple rule:
 
 ## **What You Need to Specify**
 
-Michelangelo abstracts away most of the details. Users only provide the essentials:
+Michelangelo AI abstracts away most of the details. Users only provide the essentials:
 
 ### **For Ray jobs**
 
@@ -74,7 +74,7 @@ Michelangelo abstracts away most of the details. Users only provide the essentia
 
 ## **Observability & Operations**
 
-Michelangelo automatically provides:
+Michelangelo AI automatically provides:
 
 * Job status and lifecycle events
 * Logs from driver/head + workers

--- a/docs/operator-guides/jobs/run-uniflow-pipeline-on-compute-cluster.md
+++ b/docs/operator-guides/jobs/run-uniflow-pipeline-on-compute-cluster.md
@@ -14,7 +14,7 @@ Run a Uniflow pipeline that schedules Ray jobs on the compute Kubernetes cluster
 cd $REPOROOT/python
 ```
 
-2) Create the Michelangelo sandbox and compute cluster:
+2) Create the Michelangelo AI sandbox and compute cluster:
 
 ```bash
 poetry run ma sandbox create --create-compute-cluster

--- a/docs/operator-guides/notifications.md
+++ b/docs/operator-guides/notifications.md
@@ -1,6 +1,6 @@
 # Notification Delivery Setup
 
-Michelangelo does not bundle an email or Slack delivery service — it provides a notification workflow that calls pluggable activity functions when a PipelineRun changes state. By default those functions are no-ops that log a warning. This guide shows platform operators how to wire in real delivery by replacing the default Sink implementations.
+Michelangelo AI does not bundle an email or Slack delivery service — it provides a notification workflow that calls pluggable activity functions when a PipelineRun changes state. By default those functions are no-ops that log a warning. This guide shows platform operators how to wire in real delivery by replacing the default Sink implementations.
 
 It covers the notification flow, Helm configuration, how to implement email and Slack delivery, supported event types, and verification.
 

--- a/docs/operator-guides/operations/compliance.md
+++ b/docs/operator-guides/operations/compliance.md
@@ -5,18 +5,18 @@ sidebar_label: "Compliance"
 
 # Compliance Guide
 
-Michelangelo supports compliance with SOC 2, GDPR, and HIPAA depending on how you deploy and configure the platform. Achieving compliance requires proper configuration of access controls, encryption, audit logging, and data handling practices described in this guide.
+Michelangelo AI supports compliance with SOC 2, GDPR, and HIPAA depending on how you deploy and configure the platform. Achieving compliance requires proper configuration of access controls, encryption, audit logging, and data handling practices described in this guide.
 
 **Audience**: Platform operators responsible for security and compliance configuration.
 
 **Prerequisites**:
-- Running Michelangelo control plane (see [Platform Setup](../setup/platform-setup.md))
+- Running Michelangelo AI control plane (see [Platform Setup](../setup/platform-setup.md))
 - Kubernetes RBAC familiarity
 - An identity provider (IdP) configured for OIDC/OAuth 2.0 (required for access control sections)
 - Cloud provider account with S3-compatible object storage
 
 :::warning
-Compliance is a shared responsibility. This guide covers Michelangelo-specific configuration. You are also responsible for ensuring your broader infrastructure, organizational processes, and legal agreements meet each framework's requirements.
+Compliance is a shared responsibility. This guide covers Michelangelo AI-specific configuration. You are also responsible for ensuring your broader infrastructure, organizational processes, and legal agreements meet each framework's requirements.
 :::
 
 ## SOC 2
@@ -25,7 +25,7 @@ SOC 2 (System and Organization Controls 2) evaluates controls across five Trust 
 
 ### Access Control
 
-Enable RBAC for all Michelangelo resources and grant least-privilege access — users should only have the permissions required for their role.
+Enable RBAC for all Michelangelo AI resources and grant least-privilege access — users should only have the permissions required for their role.
 
 ```yaml
 apiserver:
@@ -36,7 +36,7 @@ apiserver:
 - Integrate with your organization's identity provider (IdP) via OIDC/OAuth 2.0
 - Enforce multi-factor authentication (MFA) at the IdP level
 - Set session token expiry appropriate for your security policy
-- Disable any direct database or object store access that bypasses the Michelangelo API
+- Disable any direct database or object store access that bypasses the Michelangelo AI API
 
 ### Encryption
 
@@ -46,7 +46,7 @@ apiserver:
 
 ### Network Security
 
-- Deploy Michelangelo inside a private VPC with no direct public access to internal services
+- Deploy Michelangelo AI inside a private VPC with no direct public access to internal services
 - Expose only the Envoy proxy and UI to controlled network segments
 - Restrict Kubernetes API server access to authorized operators using network policies
 
@@ -59,7 +59,7 @@ apiserver:
 
 ### Audit Logging
 
-All operations through the Michelangelo API are captured in audit logs. Ensure logs are:
+All operations through the Michelangelo AI API are captured in audit logs. Ensure logs are:
 
 - Forwarded to a centralized, tamper-resistant log store (e.g., CloudWatch, Splunk, Datadog)
 - Retained for a minimum of 12 months
@@ -75,7 +75,7 @@ All operations through the Michelangelo API are captured in audit logs. Ensure l
 
 ## GDPR
 
-The General Data Protection Regulation (GDPR) applies when processing personal data of EU residents. Michelangelo can be configured to meet GDPR requirements around data residency, subject rights, and retention.
+The General Data Protection Regulation (GDPR) applies when processing personal data of EU residents. Michelangelo AI can be configured to meet GDPR requirements around data residency, subject rights, and retention.
 
 ### Data Residency
 
@@ -93,12 +93,12 @@ Ensure your Kubernetes cluster, Temporal/Cadence workflow engine, and any extern
 ### Data Minimization
 
 - Only ingest and store data fields required for the ML task
-- Use Michelangelo's data prep pipelines to strip personally identifiable information (PII) before training
+- Use Michelangelo AI's data prep pipelines to strip personally identifiable information (PII) before training
 - Avoid logging raw personal data in pipeline run outputs or model experiment metadata
 
 ### Data Subject Rights
 
-**Right to Access**: Michelangelo's audit logs and model lineage tracking let you identify which data was used to train a specific model. Use these records to respond to Data Subject Access Requests (DSARs).
+**Right to Access**: Michelangelo AI's audit logs and model lineage tracking let you identify which data was used to train a specific model. Use these records to respond to Data Subject Access Requests (DSARs).
 
 **Right to Erasure**: When a data subject requests deletion:
 1. Identify all datasets, pipeline runs, and model versions that reference their data
@@ -106,7 +106,7 @@ Ensure your Kubernetes cluster, Temporal/Cadence workflow engine, and any extern
 3. Retrain or retire affected models where the data cannot be removed post-hoc
 4. Document the erasure in your organization's records
 
-**Right to Portability**: Use Michelangelo's export capabilities to produce data in standard formats (Parquet, CSV) when a subject requests their data.
+**Right to Portability**: Use Michelangelo AI's export capabilities to produce data in standard formats (Parquet, CSV) when a subject requests their data.
 
 ### Retention Policies
 
@@ -116,11 +116,11 @@ Ensure your Kubernetes cluster, Temporal/Cadence workflow engine, and any extern
 
 ### Consent and Legal Basis
 
-Michelangelo does not manage consent records. Ensure your organization's consent management system is integrated with your data ingestion pipeline so that only data with a valid legal basis flows into Michelangelo training workflows.
+Michelangelo AI does not manage consent records. Ensure your organization's consent management system is integrated with your data ingestion pipeline so that only data with a valid legal basis flows into Michelangelo AI training workflows.
 
 ### Data Processing Agreements
 
-If you use cloud infrastructure providers (AWS, GCP, Azure) to host Michelangelo, you must have a Data Processing Agreement (DPA) in place with each provider before processing personal data on their infrastructure.
+If you use cloud infrastructure providers (AWS, GCP, Azure) to host Michelangelo AI, you must have a Data Processing Agreement (DPA) in place with each provider before processing personal data on their infrastructure.
 
 ---
 
@@ -129,17 +129,17 @@ If you use cloud infrastructure providers (AWS, GCP, Azure) to host Michelangelo
 The Health Insurance Portability and Accountability Act (HIPAA) applies when processing Protected Health Information (PHI). Compliance requires technical, administrative, and physical safeguards.
 
 :::danger
-Do not store PHI in Michelangelo unless your deployment has been reviewed by your compliance and legal teams and all safeguards below are confirmed to be in place. HIPAA violations carry significant legal and financial penalties.
+Do not store PHI in Michelangelo AI unless your deployment has been reviewed by your compliance and legal teams and all safeguards below are confirmed to be in place. HIPAA violations carry significant legal and financial penalties.
 :::
 
 ### Technical Safeguards
 
 **Access Controls**
 
-- Assign unique user IDs to every Michelangelo user — never use shared accounts
+- Assign unique user IDs to every Michelangelo AI user — never use shared accounts
 - Enable RBAC and restrict PHI-containing datasets and models to authorized users only
 - Implement automatic session timeouts at the IdP level
-- Audit all access to PHI-containing resources using Michelangelo's audit logs
+- Audit all access to PHI-containing resources using Michelangelo AI's audit logs
 
 **Encryption**
 
@@ -153,7 +153,7 @@ Do not store PHI in Michelangelo unless your deployment has been reviewed by you
 
 HIPAA requires audit logs that record access to PHI. Configure your logging pipeline to capture:
 
-- User identity and timestamp for every Michelangelo API call
+- User identity and timestamp for every Michelangelo AI API call
 - Dataset reads and writes
 - Model training runs that reference PHI datasets
 - Deployment and inference events
@@ -163,7 +163,7 @@ Forward logs to a HIPAA-eligible log management service and retain them for a mi
 **Integrity Controls**
 
 - Enable object versioning on your S3 bucket to detect unauthorized modification of artifacts
-- Use checksums provided by Michelangelo's artifact storage to verify data integrity on read
+- Use checksums provided by Michelangelo AI's artifact storage to verify data integrity on read
 - Configure S3 Object Lock (WORM mode) on audit log buckets to prevent tampering
 
 **Transmission Security**
@@ -174,7 +174,7 @@ Forward logs to a HIPAA-eligible log management service and retain them for a mi
 ### Administrative Safeguards
 
 - Designate a HIPAA Privacy Officer and Security Officer for your organization
-- Conduct annual risk assessments that explicitly include your Michelangelo deployment
+- Conduct annual risk assessments that explicitly include your Michelangelo AI deployment
 - Train all users with access to PHI-containing projects on HIPAA requirements and your organization's privacy policies
 - Establish and enforce a workforce sanctions policy for unauthorized PHI access
 
@@ -183,12 +183,12 @@ Forward logs to a HIPAA-eligible log management service and retain them for a mi
 You must have a signed BAA with:
 
 - Your cloud infrastructure provider (AWS, GCP, Azure)
-- Any third-party services integrated with Michelangelo that may process PHI
+- Any third-party services integrated with Michelangelo AI that may process PHI
 - Your managed Temporal or Cadence service provider, if applicable
 
 ### PHI Readiness Checklist
 
-Before processing PHI data in Michelangelo, verify each item:
+Before processing PHI data in Michelangelo AI, verify each item:
 
 - [ ] RBAC enabled and scoped to minimum necessary access
 - [ ] TLS enabled on all components (`useTLS: true`)
@@ -209,8 +209,8 @@ These practices improve your security posture across all three frameworks.
 ### Kubernetes Hardening
 
 - Use Kubernetes Network Policies to restrict pod-to-pod communication to only required paths
-- Apply Pod Security Standards (restricted profile) to Michelangelo workloads
-- Regularly patch Kubernetes nodes and Michelangelo component images
+- Apply Pod Security Standards (restricted profile) to Michelangelo AI workloads
+- Regularly patch Kubernetes nodes and Michelangelo AI component images
 - Store credentials in Kubernetes Secrets or an external secrets manager (HashiCorp Vault, AWS Secrets Manager) rather than in ConfigMaps
 
 ### Monitoring and Alerting
@@ -221,7 +221,7 @@ These practices improve your security posture across all three frameworks.
 
 ### Incident Response
 
-- Document an incident response runbook that covers Michelangelo-specific scenarios (unauthorized model access, artifact tampering, credential exposure)
+- Document an incident response runbook that covers Michelangelo AI-specific scenarios (unauthorized model access, artifact tampering, credential exposure)
 - Test the runbook at least annually with tabletop exercises
 - Ensure your runbook includes breach notification timelines:
   - **GDPR**: 72 hours to notify supervisory authority

--- a/docs/operator-guides/operations/monitoring.md
+++ b/docs/operator-guides/operations/monitoring.md
@@ -4,11 +4,11 @@ sidebar_position: 1
 
 # Monitoring & Observability
 
-This guide is for platform operators setting up observability for a Michelangelo deployment.
+This guide is for platform operators setting up observability for a Michelangelo AI deployment.
 
-**Prerequisites**: A running Michelangelo control plane with the controller manager deployed. Familiarity with [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) is helpful but not required.
+**Prerequisites**: A running Michelangelo AI control plane with the controller manager deployed. Familiarity with [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) is helpful but not required.
 
-Michelangelo components expose Prometheus metrics that integrate with a standard Kubernetes observability stack. This guide covers scrape configuration, key metrics to monitor, alerting rules, and logging configuration.
+Michelangelo AI components expose Prometheus metrics that integrate with a standard Kubernetes observability stack. This guide covers scrape configuration, key metrics to monitor, alerting rules, and logging configuration.
 
 ## Prometheus Scrape Configuration
 
@@ -51,7 +51,7 @@ The API server (port `15566`) exposes standard gRPC metrics. If you have a Prome
 
 ### Envoy Proxy
 
-Envoy can expose an admin stats interface for scraping request counts, latency histograms, and upstream error rates. The admin interface is **not enabled by default** in the Michelangelo Envoy configuration — you must add an `admin:` block to your Envoy ConfigMap to enable it. See the [Envoy admin documentation](https://www.envoyproxy.io/docs/envoy/latest/operations/admin) for setup instructions. Once enabled, add a Prometheus scrape job targeting the admin port.
+Envoy can expose an admin stats interface for scraping request counts, latency histograms, and upstream error rates. The admin interface is **not enabled by default** in the Michelangelo AI Envoy configuration — you must add an `admin:` block to your Envoy ConfigMap to enable it. See the [Envoy admin documentation](https://www.envoyproxy.io/docs/envoy/latest/operations/admin) for setup instructions. Once enabled, add a Prometheus scrape job targeting the admin port.
 
 ---
 
@@ -70,7 +70,7 @@ Envoy can expose an admin stats interface for scraping request counts, latency h
 
 ### Workflow Engine
 
-Workflow metrics are emitted by the Cadence or Temporal server, not by Michelangelo. Consult your workflow engine's documentation for its native Prometheus metrics. Michelangelo's worker-side reconcile metrics are captured under the `pipelinerun_*` counters above.
+Workflow metrics are emitted by the Cadence or Temporal server, not by Michelangelo AI. Consult your workflow engine's documentation for its native Prometheus metrics. Michelangelo AI's worker-side reconcile metrics are captured under the `pipelinerun_*` counters above.
 
 ### Model Serving (Envoy)
 
@@ -241,7 +241,7 @@ Create a Grafana dashboard with these panels to get operational visibility at a 
 
 ## Structured Logging
 
-All Michelangelo components emit structured logs. Configure log format and level in the relevant ConfigMap:
+All Michelangelo AI components emit structured logs. Configure log format and level in the relevant ConfigMap:
 
 ```yaml
 logging:

--- a/docs/operator-guides/operations/troubleshooting.md
+++ b/docs/operator-guides/operations/troubleshooting.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # Troubleshooting
 
-This guide is for platform operators diagnosing issues with a Michelangelo deployment. All `kubectl` commands assume access to the control plane cluster.
+This guide is for platform operators diagnosing issues with a Michelangelo AI deployment. All `kubectl` commands assume access to the control plane cluster.
 
 ---
 
@@ -217,7 +217,7 @@ kubectl -n ma-system get serviceaccount michelangelo-controllermgr -o yaml \
 
 ## UI not loading or API calls failing
 
-**Symptoms**: The Michelangelo UI shows a blank page, a CORS error in the browser console, or API calls return 502/504.
+**Symptoms**: The Michelangelo AI UI shows a blank page, a CORS error in the browser console, or API calls return 502/504.
 
 **Diagnostics**:
 ```bash

--- a/docs/operator-guides/serving/cluster-setup.md
+++ b/docs/operator-guides/serving/cluster-setup.md
@@ -1,6 +1,6 @@
 # Run Inference on a Local Sandbox
 
-Deploy a model to a Triton inference server running in a local Michelangelo sandbox cluster.
+Deploy a model to a Triton inference server running in a local Michelangelo AI sandbox cluster.
 
 ## Prerequisites
 - **Repository**: Local checkout with `$REPOROOT` pointing to the repo root
@@ -14,7 +14,7 @@ Deploy a model to a Triton inference server running in a local Michelangelo sand
 cd $REPOROOT/python
 ```
 
-2) Create the Michelangelo sandbox:
+2) Create the Michelangelo AI sandbox:
 
 ```bash
 poetry run ma sandbox create
@@ -99,7 +99,7 @@ curl -X POST http://localhost:8080/inference-server-example/bert-cola-deployment
 ```
 
 **Outcome**:
-- Sandbox cluster is running with Michelangelo controllers
+- Sandbox cluster is running with Michelangelo AI controllers
 - Triton inference server is deployed and healthy
 - Model is loaded and serving inference requests
 

--- a/docs/operator-guides/serving/index.md
+++ b/docs/operator-guides/serving/index.md
@@ -1,12 +1,12 @@
-# Michelangelo Serving
+# Michelangelo AI Serving
 
-Michelangelo provides a unified way to deploy and serve ML models on Kubernetes. This guide covers the architecture, controller lifecycles, and core concepts that operators and contributors should understand.
+Michelangelo AI provides a unified way to deploy and serve ML models on Kubernetes. This guide covers the architecture, controller lifecycles, and core concepts that operators and contributors should understand.
 
-## **What Is Michelangelo Serving?**
+## **What Is Michelangelo AI Serving?**
 
-Michelangelo Serving is a control plane for managing ML model serving infrastructure. It handles the complete lifecycle of inference servers and model deployments, from provisioning to traffic routing to cleanup.
+Michelangelo AI Serving is a control plane for managing ML model serving infrastructure. It handles the complete lifecycle of inference servers and model deployments, from provisioning to traffic routing to cleanup.
 
-Users define *what to deploy*, and Michelangelo handles:
+Users define *what to deploy*, and Michelangelo AI handles:
 
 * Provisioning inference server infrastructure (Deployments, Services)
 * Managing model configurations
@@ -16,7 +16,7 @@ Users define *what to deploy*, and Michelangelo handles:
 
 ## **Architecture**
 
-The image below displays the Michelangelo (MA) architecture for deploying and running inference on a model.
+The image below displays the Michelangelo AI (MA) architecture for deploying and running inference on a model.
 
 ![Architecture Overview](./images/arch.png)
 
@@ -31,7 +31,7 @@ The InferenceServer controller manages the infrastructure that serves models:
 1. **Create**
    User submits an InferenceServer resource.
 2. **Provision**
-   Michelangelo provisions the inference server infrastructure.
+   Michelangelo AI provisions the inference server infrastructure.
 3. **Health Check**
    The system monitors deployment readiness and server health.
 4. **Serve**
@@ -44,7 +44,7 @@ The InferenceServer controller manages the infrastructure that serves models:
 The Deployment controller manages model rollouts to inference servers:
 
 1. **Validation**
-   Michelangelo validates the model and target server.
+   Michelangelo AI validates the model and target server.
 2. **Asset Preparation**
    Model artifacts are staged for loading.
 3. **Resource Acquisition**

--- a/docs/operator-guides/serving/integrate-custom-backend.md
+++ b/docs/operator-guides/serving/integrate-custom-backend.md
@@ -1,10 +1,10 @@
 # Integrate with Your Custom Backend
 
-This guide explains how to extend Michelangelo Inference with custom serving backends, model configuration providers, and traffic routing.
+This guide explains how to extend Michelangelo AI Inference with custom serving backends, model configuration providers, and traffic routing.
 
 ## Overview
 
-Michelangelo Inference uses a plugin-based architecture with three main extension points:
+Michelangelo AI Inference uses a plugin-based architecture with three main extension points:
 
 | Interface | Purpose | Reference Implementation |
 | --------- | ------- | ------------------------ |

--- a/docs/operator-guides/setup/authentication.md
+++ b/docs/operator-guides/setup/authentication.md
@@ -1,12 +1,12 @@
 # Authentication & Identity
 
-This guide is for platform operators and cluster administrators configuring authentication for a Michelangelo deployment.
+This guide is for platform operators and cluster administrators configuring authentication for a Michelangelo AI deployment.
 
-**Prerequisites**: A running Michelangelo control plane (see [Platform Setup](./platform-setup.md)) and `kubectl` access to the `ma-system` namespace.
+**Prerequisites**: A running Michelangelo AI control plane (see [Platform Setup](./platform-setup.md)) and `kubectl` access to the `ma-system` namespace.
 
-Authentication in Michelangelo operates at two levels:
+Authentication in Michelangelo AI operates at two levels:
 
-- **User authentication** — end users authenticate to the Michelangelo API and UI via an identity provider (IdP)
+- **User authentication** — end users authenticate to the Michelangelo AI API and UI via an identity provider (IdP)
 - **Service authentication** — internal services (worker, controller manager) authenticate to each other using Kubernetes service account tokens
 
 This guide covers configuring both, plus RBAC authorization and multi-tenant isolation.
@@ -31,7 +31,7 @@ Once RBAC is enabled, users without a RoleBinding will be denied access to all r
 
 ## Connecting an Identity Provider (OIDC)
 
-Michelangelo supports any OIDC-compliant identity provider. Configure it in the API server ConfigMap:
+Michelangelo AI supports any OIDC-compliant identity provider. Configure it in the API server ConfigMap:
 
 ```yaml
 apiserver:
@@ -58,7 +58,7 @@ apiserver:
 ### Google Workspace
 
 1. In Google Cloud Console, create an **OAuth 2.0 Client ID** of type Web application
-2. Add your Michelangelo Envoy URL as an authorized redirect URI
+2. Add your Michelangelo AI Envoy URL as an authorized redirect URI
 3. Set the issuer URL:
    ```yaml
    oidc:
@@ -71,7 +71,7 @@ apiserver:
 ### Azure Active Directory
 
 1. Register a new application in the Azure portal
-2. Set the redirect URI to your Michelangelo Envoy callback URL
+2. Set the redirect URI to your Michelangelo AI Envoy callback URL
 3. Note the **Application (client) ID** and **Directory (tenant) ID**:
    ```yaml
    oidc:
@@ -105,11 +105,11 @@ apiserver:
 
 ## Multi-Factor Authentication
 
-MFA is enforced at the IdP level, not within Michelangelo. Configure MFA policies in your identity provider's admin console. Michelangelo requires users to complete the full IdP authentication flow — including MFA — before issuing a session token.
+MFA is enforced at the IdP level, not within Michelangelo AI. Configure MFA policies in your identity provider's admin console. Michelangelo AI requires users to complete the full IdP authentication flow — including MFA — before issuing a session token.
 
 ## Granting Access with RBAC
 
-After RBAC is enabled, users need a `RoleBinding` or `ClusterRoleBinding` to access Michelangelo resources.
+After RBAC is enabled, users need a `RoleBinding` or `ClusterRoleBinding` to access Michelangelo AI resources.
 
 ### Grant a user read access to a project namespace
 
@@ -173,11 +173,11 @@ spec:
           kubernetes.io/metadata.name: ma-system   # Control plane needs access
 ```
 
-This allows traffic within the team's namespace and from the Michelangelo control plane, but blocks all other namespaces.
+This allows traffic within the team's namespace and from the Michelangelo AI control plane, but blocks all other namespaces.
 
 ## Service Authentication (Internal)
 
-Michelangelo services authenticate to each other using Kubernetes service account tokens.
+Michelangelo AI services authenticate to each other using Kubernetes service account tokens.
 
 **Worker → API server**: Configured via `worker.useTLS: true` in the worker ConfigMap. The worker uses its Kubernetes pod service account token. Do not set `useTLS: false` in production.
 
@@ -192,7 +192,7 @@ worker:
 
 ## Disabling Direct Storage Access
 
-Do not allow users or services to directly access etcd or object storage (S3/MinIO) in ways that bypass the Michelangelo API. For S3 access:
+Do not allow users or services to directly access etcd or object storage (S3/MinIO) in ways that bypass the Michelangelo AI API. For S3 access:
 
 - Set `useIam: true` in the controller manager ConfigMap — this uses IAM roles attached to pods via ServiceAccount annotations, not hardcoded credentials
 - Do not grant `s3:*` to individual users; use IAM policies scoped to specific buckets and prefixes

--- a/docs/operator-guides/setup/network.md
+++ b/docs/operator-guides/setup/network.md
@@ -1,12 +1,12 @@
 # Network & Ingress Configuration
 
-This guide covers the network configuration required to deploy Michelangelo in a Kubernetes cluster: Envoy proxy settings (CORS, cluster hostnames), Ingress setup for the API server and UI, TLS with cert-manager, and connectivity requirements for multi-cluster deployments.
+This guide covers the network configuration required to deploy Michelangelo AI in a Kubernetes cluster: Envoy proxy settings (CORS, cluster hostnames), Ingress setup for the API server and UI, TLS with cert-manager, and connectivity requirements for multi-cluster deployments.
 
 ---
 
 ## Overview
 
-Michelangelo's network surface has two external-facing entry points:
+Michelangelo AI's network surface has two external-facing entry points:
 
 | Entry Point | Default Port | Purpose |
 |-------------|-------------|---------|
@@ -272,10 +272,10 @@ spec:
 
 ## Multi-Cluster Network Topology
 
-When Michelangelo's control plane dispatches jobs to registered compute clusters, the following connectivity is required:
+When Michelangelo AI's control plane dispatches jobs to registered compute clusters, the following connectivity is required:
 
 :::warning No automatic failover
-Michelangelo does not automatically fail over if the control plane API server becomes unreachable. Task pods in compute clusters cannot report results, and new jobs cannot be dispatched. Configure alerting on the controller manager's health endpoint (`:8083/healthz`) so on-call is paged before users are impacted — see [Monitoring](../operations/monitoring.md).
+Michelangelo AI does not automatically fail over if the control plane API server becomes unreachable. Task pods in compute clusters cannot report results, and new jobs cannot be dispatched. Configure alerting on the controller manager's health endpoint (`:8083/healthz`) so on-call is paged before users are impacted — see [Monitoring](../operations/monitoring.md).
 :::
 
 ```
@@ -295,7 +295,7 @@ Control Plane Cluster                    Compute Cluster
 | Direction | Source | Destination | Port | Purpose |
 |-----------|--------|-------------|------|---------|
 | Outbound from control plane | Controller Manager | Compute cluster K8s API | 443 | Dispatching RayCluster / SparkApplication CRDs |
-| Outbound from compute | Task pods | Michelangelo API server | 443 | Worker connectivity for result reporting |
+| Outbound from compute | Task pods | Michelangelo AI API server | 443 | Worker connectivity for result reporting |
 | Outbound from compute | Task pods | S3 / object store | 443 | Artifact reads and writes |
 
 ### NetworkPolicy for Control Plane → Compute Cluster
@@ -337,7 +337,7 @@ kubectl exec -it deploy/michelangelo-controllermgr -n michelangelo -- /bin/sh
 curl -sk https://<compute-cluster-api-server>:443/healthz
 ```
 
-From a task pod in the compute cluster, verify it can reach the Michelangelo API server:
+From a task pod in the compute cluster, verify it can reach the Michelangelo AI API server:
 
 ```bash
 kubectl exec -it <task-pod> -n <compute-namespace> -- \
@@ -348,7 +348,7 @@ kubectl exec -it <task-pod> -n <compute-namespace> -- \
 
 ## Checklist
 
-Use this checklist when deploying Michelangelo to a new environment:
+Use this checklist when deploying Michelangelo AI to a new environment:
 
 - [ ] Ingress controller installed and supports HTTP/2 (for gRPC)
 - [ ] API server Ingress created with `backend-protocol: GRPC`
@@ -358,7 +358,7 @@ Use this checklist when deploying Michelangelo to a new environment:
 - [ ] Worker ConfigMap `worker.address` updated to `api.your-domain.com:443`
 - [ ] UI `config.json` `apiBaseUrl` updated to UI domain
 - [ ] Cross-cluster connectivity verified (controller manager → compute K8s API)
-- [ ] Task pod → Michelangelo API server connectivity verified
+- [ ] Task pod → Michelangelo AI API server connectivity verified
 
 ---
 

--- a/docs/operator-guides/setup/platform-setup.md
+++ b/docs/operator-guides/setup/platform-setup.md
@@ -1,10 +1,10 @@
 # Platform Setup Guide
 
-This guide describes how to configure **Michelangelo server components** in Kubernetes cluster. It focuses on the **configuration surfaces** (ConfigMaps, fields, and key parameters).
+This guide describes how to configure **Michelangelo AI server components** in Kubernetes cluster. It focuses on the **configuration surfaces** (ConfigMaps, fields, and key parameters).
 
 ## Overview
 
-Michelangelo consists of four core server components:
+Michelangelo AI consists of four core server components:
 
 1. **API Server** – Central gRPC API
 2. **Controller Manager** – Kubernetes controllers
@@ -20,11 +20,11 @@ This document explains:
 * What each field means
 * How to apply changes using Kustomize overlays
 
-## Michelangelo Service architecture diagram
+## Michelangelo AI Service architecture diagram
 
-The following diagram shows the relationship between each of the services in Michelangelo eco-system.
+The following diagram shows the relationship between each of the services in Michelangelo AI eco-system.
 
-![Michelangelo Service Architecture](../images/ma-service-architecture.png)
+![Michelangelo AI Service Architecture](../images/ma-service-architecture.png)
 
 ## Server Configuration
 
@@ -181,7 +181,7 @@ You must customize domain-specific values in overlays:
 
 ## Object Store Configuration
 
-Object storage (MinIO / S3) is used by Michelangelo for artifacts and metadata.
+Object storage (MinIO / S3) is used by Michelangelo AI for artifacts and metadata.
 
 ## Controller Manager Object Store Settings
 
@@ -208,7 +208,7 @@ minio:
 
 ## Workflow Engine Configuration (Temporal/Cadence)
 
-Michelangelo uses a workflow engine (Temporal or Cadence) for orchestrating workflows. Most of your current guide examples use **Temporal**, and Cadence is used in sandbox/dev.
+Michelangelo AI uses a workflow engine (Temporal or Cadence) for orchestrating workflows. Most of your current guide examples use **Temporal**, and Cadence is used in sandbox/dev.
 
 ## Controller Manager Workflow Client
 

--- a/docs/operator-guides/setup/register-a-compute-cluster-to-michelangelo-control-plane.md
+++ b/docs/operator-guides/setup/register-a-compute-cluster-to-michelangelo-control-plane.md
@@ -1,11 +1,11 @@
 # Register a Compute Cluster
 
-Register an existing compute Kubernetes cluster with the Michelangelo control plane to enable running Ray jobs.
+Register an existing compute Kubernetes cluster with the Michelangelo AI control plane to enable running Ray jobs.
 
 ### Prerequisites
 - Existing Kubernetes compute cluster accessible via kubectl
 - KubeRay operator installed in the compute cluster (`ray-system` namespace)
-- Michelangelo control plane running
+- Michelangelo AI control plane running
 - Access to object storage (S3/MinIO) used by the control plane
 - RBAC manifest for service account with permissions to run Ray Jobs / Ray Clusters. 
 - Network connectivity between control plane and compute cluster (control plane must be able to reach compute cluster API server)

--- a/docs/operator-guides/sql-key-concepts-and-terms.md
+++ b/docs/operator-guides/sql-key-concepts-and-terms.md
@@ -1,8 +1,8 @@
 # SQL Key Concepts and Terms
 
-This page is the SQL reference for operators querying Michelangelo's metadata database — schema layout, indexed columns, safe query patterns, and known storage limitations. Michelangelo uses SQL for platform metadata, not for storing training datasets or feature values. The ingester syncs Kubernetes custom resources into MySQL so API and operations workflows can query metadata without depending only on etcd.
+This page is the SQL reference for operators querying Michelangelo AI's metadata database — schema layout, indexed columns, safe query patterns, and known storage limitations. Michelangelo AI uses SQL for platform metadata, not for storing training datasets or feature values. The ingester syncs Kubernetes custom resources into MySQL so API and operations workflows can query metadata without depending only on etcd.
 
-**Audience:** Platform operators running Michelangelo's ingester and metadata DB in production.
+**Audience:** Platform operators running Michelangelo AI's ingester and metadata DB in production.
 
 **Prerequisites:** The ingester must be deployed and connected to MySQL. See [Ingester Controller: Configuration and Operations](./components/ingester-configuration.md) if you haven't done this yet.
 
@@ -29,8 +29,8 @@ The three `.sql` files above are byte-identical copies of the same schema. No au
 
 | Term | Meaning |
 |------|---------|
-| Metadata storage | The optional SQL-backed store for Michelangelo custom resource metadata |
-| Ingester | Controller that watches Michelangelo CRDs and writes their metadata to MySQL |
+| Metadata storage | The optional SQL-backed store for Michelangelo AI custom resource metadata |
+| Ingester | Controller that watches Michelangelo AI CRDs and writes their metadata to MySQL |
 | CRD table | Main table for one Kubernetes custom resource kind, such as `model` or `pipelinerun` |
 | Side table | Per-kind table for labels or annotations, such as `model_labels` or `model_annotations` |
 | Extracted column | A CRD field copied into a dedicated SQL column so callers can read it without parsing the `json` payload. Extracted columns are not necessarily indexed — see [Extracted Columns and SQL Indexes](#extracted-columns-and-sql-indexes) |
@@ -221,7 +221,7 @@ ORDER BY delete_time DESC;
 ## Write Patterns
 
 :::warning
-The ingester owns writes to these tables. Application code should use the Michelangelo API or Kubernetes CRDs rather than writing SQL directly.
+The ingester owns writes to these tables. Application code should use the Michelangelo AI API or Kubernetes CRDs rather than writing SQL directly.
 :::
 
 Each ingester upsert overwrites the row's payload, timestamps, and indexed columns; labels and annotations are replaced wholesale.

--- a/docs/operator-guides/ui/deploying-michelangelo-ui.md
+++ b/docs/operator-guides/ui/deploying-michelangelo-ui.md
@@ -1,9 +1,9 @@
-# Deploying Michelangelo UI
+# Deploying Michelangelo AI UI
 
-This guide covers how the Michelangelo UI fits into Michelangelo's Kubernetes deployments and how operators can adapt the configuration for their environments.
+This guide covers how the Michelangelo AI UI fits into Michelangelo AI's Kubernetes deployments and how operators can adapt the configuration for their environments.
 
 ### Context
-The Michelangelo UI is a React-based web application that provides a graphical interface for managing projects, pipelines, and monitoring pipeline runs in the Michelangelo ML platform.
+The Michelangelo AI UI is a React-based web application that provides a graphical interface for managing projects, pipelines, and monitoring pipeline runs in the Michelangelo AI ML platform.
 
 ### Audience
 - Platform operators looking to understand UI deployment requirements
@@ -21,8 +21,8 @@ The Michelangelo UI is a React-based web application that provides a graphical i
 ## Setup
 
 ### Prerequisites
-- Kubernetes cluster with Michelangelo API server deployed
-- Access to Michelangelo UI container image from GitHub Container Registry
+- Kubernetes cluster with Michelangelo AI API server deployed
+- Access to Michelangelo AI UI container image from GitHub Container Registry
 
 ### UI Deployment Requirements
 
@@ -39,7 +39,7 @@ Available from GitHub Container Registry at `ghcr.io/michelangelo-ai/ui`:
 - **Configuration**: Mount `config.json` at `/usr/share/nginx/html/config.json`
 - **Port**: Container serves on port 80
 
-The UI needs to know how to connect to your Michelangelo API server. This is configured through the ConfigMap mounted within the container.
+The UI needs to know how to connect to your Michelangelo AI API server. This is configured through the ConfigMap mounted within the container.
 
 - **API endpoint**: Point to your actual API server location
 

--- a/docs/operator-guides/ui/index.md
+++ b/docs/operator-guides/ui/index.md
@@ -1,6 +1,6 @@
-# Michelangelo UI
+# Michelangelo AI UI
 
-Michelangelo's User Interface (UI) provides a standard, code free ML development experience. It guides users through five phases in the ML development lifecycle, from developing your first model to productionization.
+Michelangelo AI's User Interface (UI) provides a standard, code free ML development experience. It guides users through five phases in the ML development lifecycle, from developing your first model to productionization.
 
 ## Getting Started
 
@@ -10,10 +10,10 @@ Production deployment using sandbox manifests as templates for your infrastructu
 - **For: Platform operators**
 - **Use case: Full ML platform deployment with UI**
 
-→ **[Deploying Michelangelo UI](./deploying-michelangelo-ui.md)**
+→ **[Deploying Michelangelo AI UI](./deploying-michelangelo-ui.md)**
 
 ### Integrate with Existing React App
-Add Michelangelo components to your existing React application as npm dependencies that connect to your infrastructure.
+Add Michelangelo AI components to your existing React application as npm dependencies that connect to your infrastructure.
 
 - **For: Frontend developers, application teams**
 - **Use case: Separate frontend/backend infrastructure, or embedding ML capabilities in existing developer tools**
@@ -30,7 +30,7 @@ Set up a development environment for contributing to the UI codebase.
 
 ## Architecture
 
-The Michelangelo UI is built with React and communicates with the Michelangelo API server through gRPC-Web. The UI supports two main consumption methods:
+The Michelangelo AI UI is built with React and communicates with the Michelangelo AI API server through gRPC-Web. The UI supports two main consumption methods:
 
 - **Containerized deployment**: Complete UI deployed to Kubernetes clusters
 - **Component integration**: Individual React components embedded in existing applications

--- a/docs/operator-guides/ui/local-development-setup.md
+++ b/docs/operator-guides/ui/local-development-setup.md
@@ -1,12 +1,12 @@
 # Local Development Setup
 
-This guide covers setting up a local development environment for contributing to the Michelangelo UI codebase. The local development setup provides hot-reload capabilities, debugging tools, and integration with the Michelangelo sandbox environment for UI development and testing.
+This guide covers setting up a local development environment for contributing to the Michelangelo AI UI codebase. The local development setup provides hot-reload capabilities, debugging tools, and integration with the Michelangelo AI sandbox environment for UI development and testing.
 
 ## Key Concepts
 
 **Hot Reload**: Automatic browser refresh when code changes are detected
 **Vite**: Modern build tool providing fast development server and optimized builds
-**Sandbox Environment**: Local Kubernetes cluster with all Michelangelo components
+**Sandbox Environment**: Local Kubernetes cluster with all Michelangelo AI components
 **gRPC-Web**: Protocol enabling browser-based gRPC communication
 **Protobuf Generation**: Creating TypeScript clients from .proto files
 **Yarn Workspaces**: Monorepo management tool for handling multiple packages
@@ -46,7 +46,7 @@ npm install --global yarn
 yarn --version  # Verify installation
 ```
 
-**For full-stack development (optional):** following [Michelangelo Sandbox Getting Started](../../getting-started/sandbox-setup.md).
+**For full-stack development (optional):** following [Michelangelo AI Sandbox Getting Started](../../getting-started/sandbox-setup.md).
 
 **Note:** The sandbox is optional for UI development. You can develop UI components and pages without a running API server by mocking responses or working with static data.
 
@@ -111,4 +111,4 @@ A: Yes, you can work with mock data or specifically on data-independent function
 - [Vite Documentation](https://vitejs.dev/)
 - [Yarn Workspaces Guide](https://classic.yarnpkg.com/en/docs/workspaces/)
 - [Node Version Manager (nvm)](https://github.com/nvm-sh/nvm)
-- [Michelangelo Sandbox Documentation](../../getting-started/sandbox-setup.md)
+- [Michelangelo AI Sandbox Documentation](../../getting-started/sandbox-setup.md)

--- a/docs/operator-guides/ui/michelangelo-react-library.md
+++ b/docs/operator-guides/ui/michelangelo-react-library.md
@@ -1,8 +1,8 @@
-# Michelangelo React Library
+# Michelangelo AI React Library
 
-This guide covers integrating Michelangelo UI components into existing React applications as npm dependencies.
+This guide covers integrating Michelangelo AI UI components into existing React applications as npm dependencies.
 
-The Michelangelo React Library allows organizations to embed Michelangelo Studio capabilities within their existing web applications, maintaining their current deployment infrastructure while adding ML platform functionality.
+The Michelangelo AI React Library allows organizations to embed Michelangelo AI Studio capabilities within their existing web applications, maintaining their current deployment infrastructure while adding ML platform functionality.
 
 ## Key Concepts
 
@@ -135,7 +135,7 @@ function App() {
 
 ### API Integration Options
 
-The Michelangelo UI can integrate with your API through two approaches:
+The Michelangelo AI UI can integrate with your API through two approaches:
 
 #### Option 1: Custom Request Handler (Recommended)
 Use your existing API infrastructure:
@@ -156,7 +156,7 @@ const dependencies = {
 };
 ```
 
-#### Option 2: Michelangelo gRPC Client
+#### Option 2: Michelangelo AI gRPC Client
 Use the provided gRPC-Web client (requires Envoy proxy):
 ```tsx
 import { normalizeConnectError, request } from '@michelangelo-ai/rpc';
@@ -171,14 +171,14 @@ const dependencies = {
 };
 ```
 
-**Note:** Option 2 requires an Envoy proxy to translate HTTP requests to gRPC calls to your Michelangelo API server.
+**Note:** Option 2 requires an Envoy proxy to translate HTTP requests to gRPC calls to your Michelangelo AI API server.
 
 #### Envoy Proxy Setup (Required for @michelangelo-ai/rpc)
 
 **Port Configuration:**
 - Envoy listens on port 8081 for gRPC-Web requests
 - UI makes requests to Envoy, not directly to API server
-- Envoy forwards to your Michelangelo API server
+- Envoy forwards to your Michelangelo AI API server
 
 **CORS Configuration:**
 Envoy must allow your application's origin:
@@ -206,11 +206,11 @@ clusters:
               port_value: 8081                # Your API server port
 ```
 
-**Reference Configuration:** See complete Envoy setup in the [Deploying Michelangelo UI](./deploying-michelangelo-ui.md) guide.
+**Reference Configuration:** See complete Envoy setup in the [Deploying Michelangelo AI UI](./deploying-michelangelo-ui.md) guide.
 
 ### Icon Configuration
 
-The Michelangelo UI requires icon mapping through dependency injection.
+The Michelangelo AI UI requires icon mapping through dependency injection.
 
 ```tsx
 import YourLaunchIcon from '@your-icon-library/launch';
@@ -243,13 +243,13 @@ function App() {
 ### FAQ
 
 **Q: Can I use this with Next.js?**
-A: Michelangelo UI is intentionally un-opinionated about web frameworks. While untested, there is no reason Michelangelo UI would be incompatible with Next.js.
+A: Michelangelo AI UI is intentionally un-opinionated about web frameworks. While untested, there is no reason Michelangelo AI UI would be incompatible with Next.js.
 
 **Q: What React versions are supported?**
 A: React 18 is required.
 
 **Q: Can I customize the routing?**
-A: Yes, you can mount Michelangelo components at any route and integrate with your existing router.
+A: Yes, you can mount Michelangelo AI components at any route and integrate with your existing router.
 
 **Q: Can I use only specific components?**
-A: No, MichelangeloStudio is the only component intended for external consumption and customizable through dependency injection and configuration. If you have an unsupported use case, please submit an issue or propose a solution in PR.
+A: No, Michelangelo AIStudio is the only component intended for external consumption and customizable through dependency injection and configuration. If you have an unsupported use case, please submit an issue or propose a solution in PR.

--- a/docs/user-guides/examples/index.md
+++ b/docs/user-guides/examples/index.md
@@ -5,7 +5,7 @@ sidebar_label: "Examples"
 
 # Examples
 
-End-to-end ML pipeline examples covering training, inference, recommendation systems, and model packaging. Each example is a complete, working workflow you can run locally or on a Michelangelo cluster.
+End-to-end ML pipeline examples covering training, inference, recommendation systems, and model packaging. Each example is a complete, working workflow you can run locally or on a Michelangelo AI cluster.
 
 All examples live in [`python/examples/`](https://github.com/michelangelo-ai/michelangelo/tree/main/python/examples).
 
@@ -50,7 +50,7 @@ poetry install --extras "trainer example"
 PYTHONPATH=. poetry run python examples/<example_dir>/<script>.py
 ```
 
-For remote execution on a Michelangelo cluster, append `remote-run`:
+For remote execution on a Michelangelo AI cluster, append `remote-run`:
 
 ```bash
 PYTHONPATH=. poetry run python examples/pipelines/california_housing_xgb/california_housing_xgb.py remote-run \
@@ -62,6 +62,6 @@ See each example's README for specific prerequisites and run instructions.
 
 ## What's Next?
 
-- **New to Michelangelo?** Start with [California Housing (XGBoost)](https://github.com/michelangelo-ai/michelangelo/tree/main/python/examples/pipelines/california_housing_xgb) — it covers the full pipeline end-to-end
+- **New to Michelangelo AI?** Start with [California Housing (XGBoost)](https://github.com/michelangelo-ai/michelangelo/tree/main/python/examples/pipelines/california_housing_xgb) — it covers the full pipeline end-to-end
 - **Want to understand the framework?** Read [Getting Started with Pipelines](../getting-started/getting-started.md) for a guided walkthrough
 - **Ready to deploy?** See [Deploy a Model](../train-and-deploy-models/deploy-a-model.md) after training

--- a/docs/user-guides/getting-started/getting-started.md
+++ b/docs/user-guides/getting-started/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started with ML Pipelines
 
-Build and run your first ML pipeline on Michelangelo in minutes. This guide walks you through a complete example -- from defining tasks and workflows to running locally and deploying remotely.
+Build and run your first ML pipeline on Michelangelo AI in minutes. This guide walks you through a complete example -- from defining tasks and workflows to running locally and deploying remotely.
 
 ## What you'll build
 
@@ -12,7 +12,7 @@ dataset_cols
             └─▶ train()   # Ray task: trains XGBoost model on the splits
 ```
 
-Each step runs as an isolated, containerized task. Michelangelo handles data passing between them, caches intermediate results, and retries on transient failures — your code stays plain Python.
+Each step runs as an isolated, containerized task. Michelangelo AI handles data passing between them, caches intermediate results, and retries on transient failures — your code stays plain Python.
 
 ## What you'll learn
 
@@ -113,7 +113,7 @@ def feature_prep(
 
 ### Choosing a task type
 
-Michelangelo supports two compute backends for tasks:
+Michelangelo AI supports two compute backends for tasks:
 
 | Task Type | Best For | Example Config |
 | --- | --- | --- |

--- a/docs/user-guides/getting-started/prepare-your-data.md
+++ b/docs/user-guides/getting-started/prepare-your-data.md
@@ -1,6 +1,6 @@
 # Data Preparation Guide
 
-Learn how to prepare data in Uniflow for the ML pipeline on Michelangelo using Ray's distributed processing capabilities.
+Learn how to prepare data in Uniflow for the ML pipeline on Michelangelo AI using Ray's distributed processing capabilities.
 
 ## What You'll Learn
 
@@ -52,9 +52,9 @@ train_ds = dataset.filter(lambda x: x["date"] <= "2023-01-01")
 val_ds = dataset.filter(lambda x: "2023-01-01" < x["date"] <= "2023-06-01")
 ```
 
-## DatasetVariable: Michelangelo's Dataset Abstraction
+## DatasetVariable: Michelangelo AI's Dataset Abstraction
 
-Michelangelo provides `DatasetVariable` to handle datasets across different frameworks with automatic storage and serialization.
+Michelangelo AI provides `DatasetVariable` to handle datasets across different frameworks with automatic storage and serialization.
 
 ### Flexible Dataset Usage
 

--- a/docs/user-guides/getting-started/project-management-for-ml-pipelines.md
+++ b/docs/user-guides/getting-started/project-management-for-ml-pipelines.md
@@ -1,6 +1,6 @@
 # Project Management
 
-A **project** in Michelangelo is a top-level organizational unit that groups related ML pipelines, models, and resources under a single namespace. Each project typically maps to a business use case -- for example, a product recommendation system, a fraud detection pipeline, or a document classification service.
+A **project** in Michelangelo AI is a top-level organizational unit that groups related ML pipelines, models, and resources under a single namespace. Each project typically maps to a business use case -- for example, a product recommendation system, a fraud detection pipeline, or a document classification service.
 
 Projects provide:
 
@@ -15,7 +15,7 @@ A project must be created before you can register or run pipelines. See [Pipelin
 
 Before creating a project, complete the initial setup:
 
-1. **Set up the Michelangelo CLI and sandbox environment.** See the [CLI Reference - Prerequisites](../reference/cli.md#prerequisites) for installation and setup instructions.
+1. **Set up the Michelangelo AI CLI and sandbox environment.** See the [CLI Reference - Prerequisites](../reference/cli.md#prerequisites) for installation and setup instructions.
 
 2. **Verify the environment is ready:**
 

--- a/docs/user-guides/index.md
+++ b/docs/user-guides/index.md
@@ -1,10 +1,10 @@
-# Michelangelo User Guides
+# Michelangelo AI User Guides
 
-Build, train, and deploy machine learning models at scale using Michelangelo's unified ML platform.
+Build, train, and deploy machine learning models at scale using Michelangelo AI's unified ML platform.
 
 ## Getting Started
 
-New to Michelangelo? Follow this path:
+New to Michelangelo AI? Follow this path:
 
 1. **[Getting Started with Pipelines](./getting-started/getting-started.md)** — Build your first pipeline in 30 minutes
 2. **[Prepare Your Data](./getting-started/prepare-your-data.md)** — Load, clean, and split datasets using Ray and Spark

--- a/docs/user-guides/ml-pipelines/index.md
+++ b/docs/user-guides/ml-pipelines/index.md
@@ -1,6 +1,6 @@
 # ML Pipelines
 
-ML Pipelines on Michelangelo let you build, run, and manage end-to-end machine learning workflows -- from data preparation to model training and evaluation. Pipelines are built with **Uniflow**, a Python-first framework that lets you define workflows using standard Python functions and run them locally or at production scale.
+ML Pipelines on Michelangelo AI let you build, run, and manage end-to-end machine learning workflows -- from data preparation to model training and evaluation. Pipelines are built with **Uniflow**, a Python-first framework that lets you define workflows using standard Python functions and run them locally or at production scale.
 
 ## What you'll learn
 
@@ -69,7 +69,7 @@ poetry run python my_workflow.py remote-run \
 | | Standard Workflows | Custom Workflows |
 | --- | --- | --- |
 | **Defined by** | YAML configuration (`pipeline_conf.yaml`) | Python code (`@workflow` + `@task`) |
-| **Managed by** | Michelangelo (pre-built workflows) | You (fully custom logic) |
+| **Managed by** | Michelangelo AI (pre-built workflows) | You (fully custom logic) |
 | **Best for** | Common ML patterns (train, predict, evaluate) | Unique or complex use cases |
 | **UI creation** | Yes | No |
 | **Flexibility** | Configurable within pre-defined structure | Unlimited |
@@ -78,7 +78,7 @@ Both types support MA Studio UI management, CLI triggers, remote execution, orch
 
 ## Running modes
 
-Michelangelo provides four running modes for different stages of development:
+Michelangelo AI provides four running modes for different stages of development:
 
 | Mode | When to Use | Provisioning Time |
 | --- | --- | --- |

--- a/docs/user-guides/ml-pipelines/notifications.md
+++ b/docs/user-guides/ml-pipelines/notifications.md
@@ -1,11 +1,11 @@
 # Pipeline Notifications
 
-Stay informed about your ML pipeline outcomes without constantly checking the dashboard. Michelangelo can send you **email or Slack notifications** whenever a pipeline run succeeds, fails, gets stopped, or hits any other terminal state.
+Stay informed about your ML pipeline outcomes without constantly checking the dashboard. Michelangelo AI can send you **email or Slack notifications** whenever a pipeline run succeeds, fails, gets stopped, or hits any other terminal state.
 
 Notifications are configured directly in your resource spec YAML — just add a `notifications` block and you're set. No separate setup, no external webhook configuration, and no per-pipeline toggles to manage.
 
 :::note
-Notifications are configured through YAML specs only. The Michelangelo Studio UI does not currently support notification configuration.
+Notifications are configured through YAML specs only. The Michelangelo AI Studio UI does not currently support notification configuration.
 :::
 
 :::caution Operator Implementation Required
@@ -36,7 +36,7 @@ notifications:
       - "you@example.com"
 ```
 
-That's it! When you apply this spec with `ma apply -f your-spec.yaml`, Michelangelo will send you an email each time the run reaches one of those states.
+That's it! When you apply this spec with `ma apply -f your-spec.yaml`, Michelangelo AI will send you an email each time the run reaches one of those states.
 
 ### CLI Shorthand
 

--- a/docs/user-guides/ml-pipelines/pipeline-management.md
+++ b/docs/user-guides/ml-pipelines/pipeline-management.md
@@ -1,12 +1,12 @@
 # Pipeline Management
 
-In general, there are two categories of Michelangelo pipelines: those that leverage the **standard workflows** and those that depend on user-created **custom workflows**.
+In general, there are two categories of Michelangelo AI pipelines: those that leverage the **standard workflows** and those that depend on user-created **custom workflows**.
 
-The **standard workflows** are a set of workflows provided and managed by Michelangelo meant to address some common use cases, such as model training (for either in-house or custom models), model prediction and evaluation, and embedding generation.
+The **standard workflows** are a set of workflows provided and managed by Michelangelo AI meant to address some common use cases, such as model training (for either in-house or custom models), model prediction and evaluation, and embedding generation.
 
 The **custom workflows** are completely user-defined and can be used for some exceptional use cases that are not supported by the standard workflows.
 
-The Michelangelo team manages the tooling for building and executing the custom workflows but does not manage the workflow definitions for the custom workflows. Pipelines with both standard and custom workflows can be executed and managed in MA Studio.
+The Michelangelo AI team manages the tooling for building and executing the custom workflows but does not manage the workflow definitions for the custom workflows. Pipelines with both standard and custom workflows can be executed and managed in MA Studio.
 
 ## What you'll learn
 
@@ -35,7 +35,7 @@ The Michelangelo team manages the tooling for building and executing the custom 
 
 ## Standard workflows
 
-The standard workflows are a set of workflows provided and managed by Michelangelo meant to address some common use cases. The pipelines of these workflows are defined in a YAML format inside the pipeline_conf.yaml file.
+The standard workflows are a set of workflows provided and managed by Michelangelo AI meant to address some common use cases. The pipelines of these workflows are defined in a YAML format inside the pipeline_conf.yaml file.
 
 ## Custom workflows
 

--- a/docs/user-guides/ml-pipelines/set-up-triggers.md
+++ b/docs/user-guides/ml-pipelines/set-up-triggers.md
@@ -12,7 +12,7 @@
 
 Before you get started, make sure you have the following in place:
 
-- **Michelangelo CLI (`ma`) installed** — You'll use the CLI to register and manage your triggers. If you haven't set it up yet, see the [CLI guide](../reference/cli.md) for installation instructions.
+- **Michelangelo AI CLI (`ma`) installed** — You'll use the CLI to register and manage your triggers. If you haven't set it up yet, see the [CLI guide](../reference/cli.md) for installation instructions.
 - **A running sandbox environment with a project configured** — Triggers run inside a project (set via the `namespace` field in your YAML), so you'll need your sandbox environment up and running. Check out the [Sandbox Setup Guide](../../getting-started/sandbox-setup.md) if you need help with this.
 - **A registered pipeline with at least one revision** — Triggers are linked to a specific pipeline revision, so make sure your pipeline is registered before continuing. See [Train and Register a Model](../train-and-deploy-models/train-and-register-a-model.md) for a walkthrough.
 - **Access to MA Studio UI** *(optional)* — The Studio UI is handy for monitoring your triggers and pipeline runs, but it's not required to complete the setup.

--- a/docs/user-guides/reference/cli.md
+++ b/docs/user-guides/reference/cli.md
@@ -1,6 +1,6 @@
 # CLI Reference
 
-The Michelangelo CLI (`ma`) provides a unified way to manage resources using standard Kubernetes-style commands. This guide covers all supported commands for managing Michelangelo API entities.
+The Michelangelo AI CLI (`ma`) provides a unified way to manage resources using standard Kubernetes-style commands. This guide covers all supported commands for managing Michelangelo AI API entities.
 
 ## Command summary
 
@@ -35,7 +35,7 @@ All resource types support `get`, `apply`, and `delete` (see [supported resource
 | SparkJob | `spark_job` | Job submitted to a Spark cluster | get, apply, delete |
 | CachedOutput | `cached_output` | Cached task output for pipeline resume | get, apply, delete |
 
-> **Note:** In Michelangelo, a *project* is the workspace where your pipelines, models, and triggers live. In YAML files and CLI flags, your project is identified by the `namespace` field — these refer to the same thing. See the [Project Management guide](../getting-started/project-management-for-ml-pipelines.md) for details.
+> **Note:** In Michelangelo AI, a *project* is the workspace where your pipelines, models, and triggers live. In YAML files and CLI flags, your project is identified by the `namespace` field — these refer to the same thing. See the [Project Management guide](../getting-started/project-management-for-ml-pipelines.md) for details.
 
 ## Prerequisites
 
@@ -66,7 +66,7 @@ All resource types support `get`, `apply`, and `delete` (see [supported resource
 
 ## Usage
 
-All Michelangelo API entities support the following standard operations -- GET, APPLY, and DELETE
+All Michelangelo AI API entities support the following standard operations -- GET, APPLY, and DELETE
 
 ### General syntax
 
@@ -301,9 +301,9 @@ ma pipeline dev-run -f "./examples/bert_cola/pipeline.yaml" --file-sync --storag
 
 **1. dev-run: Test Pipeline from Local File**
 
-`pipeline dev-run` command runs a pipeline directly from your committed git snapshot. Pipeline run will be controlled by Michelangelo API server and controller. This command creates a PipelineRun entity but no Pipeline entity, so you will not see the pipeline entity information in MA Studio.
+`pipeline dev-run` command runs a pipeline directly from your committed git snapshot. Pipeline run will be controlled by Michelangelo AI API server and controller. This command creates a PipelineRun entity but no Pipeline entity, so you will not see the pipeline entity information in MA Studio.
 
-**remote-run** (invoked via `python my_workflow.py remote-run`, not an `ma` command) bypasses the Michelangelo API server and submits your workflow directly to Cadence/Temporal. No Michelangelo entities are created, and pipeline status is not visible in MA Studio.
+**remote-run** (invoked via `python my_workflow.py remote-run`, not an `ma` command) bypasses the Michelangelo AI API server and submits your workflow directly to Cadence/Temporal. No Michelangelo AI entities are created, and pipeline status is not visible in MA Studio.
 
 **2. dev-run --file-sync: Test Pipeline + Uncommitted Changes**
 
@@ -311,7 +311,7 @@ Adding `--file-sync` to the `pipeline dev-run` command enables testing of uncomm
 
 **dev-run --file-sync**: Creates two tarballs: a workflow tarball (from committed code) and a file-sync tarball (containing only files changed via `git diff`). When the container starts, `sitecustomize.py` downloads the file-sync tarball and overlays changed files on top of the base code. The file-sync URL is passed via the `UF_FILE_SYNC_TARBALL_URL` environment variable.
 
-**remote-run**: Creates a workflow tarball from committed code and sends it straight to the workflow engine without creating any Michelangelo entities.
+**remote-run**: Creates a workflow tarball from committed code and sends it straight to the workflow engine without creating any Michelangelo AI entities.
 
 **remote-run --file-sync**: Creates two tarballs: a workflow tarball (base64-encoded in the Cadence CLI input) and a file-sync tarball (uploaded to S3). The S3 URL is passed as an environment variable to the container.
 
@@ -371,7 +371,7 @@ The `ma sandbox` commands manage a local K3d development environment. For prereq
 
 | Command | Description |
 |---------|-------------|
-| `ma sandbox create` | Create a K3d cluster with all Michelangelo services |
+| `ma sandbox create` | Create a K3d cluster with all Michelangelo AI services |
 | `ma sandbox create --workflow temporal` | Create with Temporal instead of Cadence |
 | `ma sandbox create --exclude ui` | Create without specific services |
 | `ma sandbox create --create-compute-cluster` | Create with a Ray compute cluster |

--- a/docs/user-guides/train-and-deploy-models/deploy-a-model.md
+++ b/docs/user-guides/train-and-deploy-models/deploy-a-model.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # Deploy a Model
 
-Serve a trained model from Michelangelo so applications can call it for predictions.
+Serve a trained model from Michelangelo AI so applications can call it for predictions.
 
 By the end, you'll have a model running on an inference server and a working `curl` request to prove it. This guide assumes your platform operator has already set up the cluster and serving infrastructure — see [Next Steps](#next-steps) for the operator-facing setup docs.
 
@@ -33,7 +33,7 @@ Before deploying, you need:
 
 ## The Two Resources You Need
 
-A working deployment requires two Michelangelo resources:
+A working deployment requires two Michelangelo AI resources:
 
 | Resource | Purpose | Who Creates It |
 |----------|---------|----------------|
@@ -64,7 +64,7 @@ If you're using the sandbox, `ma sandbox demo inference` already created an `Inf
 Create `inferenceserver.yaml`:
 
 :::note
-If you set up Michelangelo on your own cluster, you are also the operator. The `clusterId`, `tokenTag`, and `caDataTag` values are the identifiers you assigned when registering the cluster with the control plane — see [the cluster setup guide](../../operator-guides/serving/cluster-setup.md) for details.
+If you set up Michelangelo AI on your own cluster, you are also the operator. The `clusterId`, `tokenTag`, and `caDataTag` values are the identifiers you assigned when registering the cluster with the control plane — see [the cluster setup guide](../../operator-guides/serving/cluster-setup.md) for details.
 :::
 
 ```yaml
@@ -99,7 +99,7 @@ Key fields:
 - **`initSpec.resourceSpec`** — CPU and memory per replica. A lightweight model typically needs 2 CPU / 4 Gi; a large deep learning model may need a GPU node — check with your platform operator if you're unsure.
 - **`initSpec.numInstances`** — how many replicas to run for availability and throughput.
 - **`owner.name`** — your username as configured by your platform operator, used for audit purposes. For multi-tenant deployments, your platform operator will configure `ownerSpec` (team identifiers, groups, and tier) separately — ask them if you need to set ownership for capacity attribution.
-- **`clusterTargets`** — required. Specifies which cluster(s) the server is provisioned on. The `clusterId` and secret tags come from your platform operator. See the [Michelangelo Serving overview](../../operator-guides/serving/index.md) for how operators configure cluster targets.
+- **`clusterTargets`** — required. Specifies which cluster(s) the server is provisioned on. The `clusterId` and secret tags come from your platform operator. See the [Michelangelo AI Serving overview](../../operator-guides/serving/index.md) for how operators configure cluster targets.
 
 ## Step 2: Define a Deployment
 
@@ -129,7 +129,7 @@ Key fields:
 - **`strategy`** — required. Controls how the rollout proceeds across server instances. `blast: {}` loads the new model on all instances simultaneously (simplest option). Other strategies — `zonal`, `rolling`, and `red_black` — let you stage rollouts progressively. See the [`Deployment` reference in the operator serving guide](../../operator-guides/serving/index.md) for strategy details.
 
 :::tip
-`ma apply` sends resources to the Michelangelo API server, which manages the deployment lifecycle. This is different from `kubectl apply`, which writes directly to Kubernetes.
+`ma apply` sends resources to the Michelangelo AI API server, which manages the deployment lifecycle. This is different from `kubectl apply`, which writes directly to Kubernetes.
 :::
 
 ## Step 3: Apply Both Resources
@@ -228,7 +228,7 @@ Delete all `Deployment` resources that reference an `InferenceServer` before del
 
 This guide covers the end-user workflow assuming serving infrastructure is already in place. For platform-level concerns:
 
-- **[Michelangelo Serving overview](../../operator-guides/serving/index.md)** — architecture, controller lifecycles, and core concepts
+- **[Michelangelo AI Serving overview](../../operator-guides/serving/index.md)** — architecture, controller lifecycles, and core concepts
 - **[Model Registry Guide](./model-registry-guide.md)** — package and register a model before deploying
 - **[Integrate with a Custom Backend](../../operator-guides/serving/integrate-custom-backend.md)** — add support for new serving frameworks
 - **[CLI Reference](../reference/cli.md)** — every `ma` command, including the full list of supported flags

--- a/docs/user-guides/train-and-deploy-models/model-registry-guide.md
+++ b/docs/user-guides/train-and-deploy-models/model-registry-guide.md
@@ -4,11 +4,11 @@ sidebar_position: 2
 
 # Model Registry Guide
 
-Save, version, and manage trained models using Michelangelo's model packaging system.
+Save, version, and manage trained models using Michelangelo AI's model packaging system.
 
 ## Overview
 
-Michelangelo's model packager turns your trained model into self-contained, versioned artifacts ready for serving or sharing. The packager handles dependency bundling, schema validation, and Triton configuration generation automatically.
+Michelangelo AI's model packager turns your trained model into self-contained, versioned artifacts ready for serving or sharing. The packager handles dependency bundling, schema validation, and Triton configuration generation automatically.
 
 **What the model packager provides:**
 
@@ -220,7 +220,7 @@ from michelangelo.lib.model_manager.packager.custom_triton import CustomTritonPa
 | `model_path` | Yes | -- | Path to saved model artifacts |
 | `model_class` | Yes | -- | Fully qualified Python class name (e.g., `"mypackage.models.MyModel"`) |
 | `model_schema` | Yes | -- | `ModelSchema` instance defining inputs and outputs |
-| `model_name` | No | Derived from class | Display name in Michelangelo Studio |
+| `model_name` | No | Derived from class | Display name in Michelangelo AI Studio |
 | `dest_model_path` | No | Auto temp dir | Output directory for the package |
 | `model_revision` | No | `None` | Revision number for versioning |
 | `model_path_source_type` | No | `StorageType.LOCAL` | Storage backend type |

--- a/docs/user-guides/train-and-deploy-models/train-and-register-a-model.md
+++ b/docs/user-guides/train-and-deploy-models/train-and-register-a-model.md
@@ -4,9 +4,9 @@ sidebar_position: 1
 
 # Model Training Guide
 
-This guide explains **how to retrieve datasets for training** inside Michelangelo workflows and how to optionally scale training using **RayTask** and the **Lightning Trainer SDK**.
+This guide explains **how to retrieve datasets for training** inside Michelangelo AI workflows and how to optionally scale training using **RayTask** and the **Lightning Trainer SDK**.
 
-The focus is simplicity: **you control your training logic**, Michelangelo provides the dataset plumbing and optional distributed compute.
+The focus is simplicity: **you control your training logic**, Michelangelo AI provides the dataset plumbing and optional distributed compute.
 
 ## What You'll Learn
 
@@ -19,12 +19,12 @@ The focus is simplicity: **you control your training logic**, Michelangelo provi
 
 - **A running sandbox** — Remote training runs require a local Kubernetes cluster. Follow the [Sandbox Setup](../../getting-started/sandbox-setup.md) guide if you haven't done this yet.
 - **A prepared dataset** — Training tasks expect datasets passed as `DatasetVariable`. See [Data Preparation](../getting-started/prepare-your-data.md) for how to produce them.
-- **Python 3.11+, Poetry, and the Michelangelo SDK installed** — Run `cd python && poetry install` from the repo root.
+- **Python 3.11+, Poetry, and the Michelangelo AI SDK installed** — Run `cd python && poetry install` from the repo root.
 - **For distributed training:** A Docker image with your workflow code. See [Running Uniflow Pipelines](../ml-pipelines/running-uniflow.md) for image build steps.
 
 ## Understanding Training Inputs
 
-Michelangelo workflows pass datasets using **DatasetVariable**.
+Michelangelo AI workflows pass datasets using **DatasetVariable**.
 
 A `DatasetVariable` may contain:
 


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**
Replaces bare "Michelangelo" with "Michelangelo AI" in prose across 74 files under `docs/`. Code blocks, inline code spans, import paths, and package names are untouched — only human-readable prose was updated.

**Why?**
The USPTO is in the process of approving the trademark for "Michelangelo AI". Consistent use of the full name across all external-facing content is required to support the trademark application.

**How did you test it?**
Automated Python script parsed each file line-by-line, tracking fenced code block state and skipping inline code spans before applying replacements. Post-run grep confirmed zero remaining bare "Michelangelo" instances in prose across all 74 files.

**Potential risks**
None — documentation-only change. No code, APIs, or configs affected.

**Breaking Changes**
- [x] No breaking changes

**Release notes**
N/A

**Documentation Changes**
This PR is the documentation change. 74 files updated across `docs/`.