### PR TITLE
docs: standardize branding to "Michelangelo AI" in READMEs and PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![codecov](https://codecov.io/gh/michelangelo-ai/michelangelo/graph/badge.svg?token=HKJDT0I6CW)](https://codecov.io/gh/michelangelo-ai/michelangelo)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11481/badge)](https://www.bestpractices.dev/projects/11481)
 
-# Michelangelo-AI
+# Michelangelo AI-AI
 
-Michelangelo-AI is an open-source platform designed to streamline the development, deployment, and monitoring of machine learning models at scale. It offers a comprehensive suite of tools and services that facilitate the entire machine learning lifecycle, from data management to model serving.
+Michelangelo AI-AI is an open-source platform designed to streamline the development, deployment, and monitoring of machine learning models at scale. It offers a comprehensive suite of tools and services that facilitate the entire machine learning lifecycle, from data management to model serving.
 
 :warning: **Beta Notice**
  This project is currently in beta. APIs and features may evolve, and breaking changes may occur as we continue to improve and stabilize the platform.
@@ -19,7 +19,7 @@ As part of our commitment to the ML community, we are open-sourcing an **end-to-
 -   **Foster innovation and trust** through collaboration with partner teams, and
 -   **Cultivate a vibrant and responsible ML culture** that empowers the community to build with confidence and speed.
 
-We are **incrementally open-sourcing Michelangelo's core capabilities**, ensuring each release is production-proven and developer-ready. The documentation on this site reflects the current set of available features and will be continuously updated as new components are added to the open-source repository.
+We are **incrementally open-sourcing Michelangelo AI's core capabilities**, ensuring each release is production-proven and developer-ready. The documentation on this site reflects the current set of available features and will be continuously updated as new components are added to the open-source repository.
 
 ## Features
 
@@ -79,7 +79,7 @@ See the [Sandbox Setup](https://michelangelo-ai.org/docs/getting-started/sandbox
 
 ## Contributing
 
-We welcome contributions to Michelangelo-AI!  
+We welcome contributions to Michelangelo AI-AI!  
 If you're interested in contributing, please read our [Contributing Guidelines](https://github.com/michelangelo-ai/michelangelo/blob/main/CONTRIBUTING.md) to get started.
 
 
@@ -90,4 +90,4 @@ This project is licensed under the [Apache 2.0 License](https://github.com/miche
 
 ## Acknowledgments
 
-Thank you to the Michelangelo Open Source team for getting this project off the ground, and thank you in advance to our contributors.
+Thank you to the Michelangelo AI Open Source team for getting this project off the ground, and thank you in advance to our contributors.

--- a/go/cmd/apiserver/README.md
+++ b/go/cmd/apiserver/README.md
@@ -1,9 +1,9 @@
-# Michelangelo API Server
+# Michelangelo AI API Server
 
-Michelangelo API Server is the unified gRPC server for all the Michelangelo APIs. It provides following functions:
-1. Standard CRUD APIs for all the Michelangelo API resource types.
+Michelangelo AI API Server is the unified gRPC server for all the Michelangelo AI APIs. It provides following functions:
+1. Standard CRUD APIs for all the Michelangelo AI API resource types.
 2. Additional APIs may be added to support more complex operations.
-3. Manage Michelangelo API resource schemas.
+3. Manage Michelangelo AI API resource schemas.
 
-   When Michelangelo API server starts, it syncs the latest API resource schemas to Kubernetes (register / update / delete schemas when needed).
+   When Michelangelo AI API server starts, it syncs the latest API resource schemas to Kubernetes (register / update / delete schemas when needed).
 4. Invoke registered API hooks.

--- a/go/cmd/controllermgr/README.md
+++ b/go/cmd/controllermgr/README.md
@@ -2,7 +2,7 @@
 
 ## Run Locally
 
-To run the Controller Manager locally, ensure your Kubernetes configuration is connected to the existing Michelangelo Cluster. Alternatively, you can use the sandbox script to create a production-like replica of the Michelangelo Cluster locally, which will also update your Kubernetes configuration.
+To run the Controller Manager locally, ensure your Kubernetes configuration is connected to the existing Michelangelo AI Cluster. Alternatively, you can use the sandbox script to create a production-like replica of the Michelangelo AI Cluster locally, which will also update your Kubernetes configuration.
 
 1. **Create a sandbox cluster:**
 ```bash

--- a/go/cmd/worker/README.md
+++ b/go/cmd/worker/README.md
@@ -1,6 +1,6 @@
 Worker is both a [Cadence workflow worker](https://cadenceworkflow.io/docs/concepts/topology#workflow-worker), [Cadence activity worker](https://cadenceworkflow.io/docs/concepts/topology#activity-worker), and now also supports [Temporal workflows and activities](https://docs.temporal.io/workflows).
 
-It hosts a set of workflows and activities required for various tasks within the Michelangelo platform.
+It hosts a set of workflows and activities required for various tasks within the Michelangelo AI platform.
 
 ## Developer Guide
 

--- a/go/thirdparty/k8s-crds/apis/sparkoperator.k8s.io/README.md
+++ b/go/thirdparty/k8s-crds/apis/sparkoperator.k8s.io/README.md
@@ -1,12 +1,12 @@
-# Spark Operator CRD Definitions in Michelangelo
+# Spark Operator CRD Definitions in Michelangelo AI
 
 ![Go Report Card](https://goreportcard.com/report/github.com/GoogleCloudPlatform/spark-on-k8s-operator)
 
-The Spark Operator Custom Resource Definitions (CRDs) have been copied directly into Michelangelo's codebase under `go/components/spark/job/client`. This approach avoids potential conflicts arising from managing different versions of the Go modules for the Spark Operator.
+The Spark Operator Custom Resource Definitions (CRDs) have been copied directly into Michelangelo AI's codebase under `go/components/spark/job/client`. This approach avoids potential conflicts arising from managing different versions of the Go modules for the Spark Operator.
 
-In typical production deployments, the control plane managing Spark jobs often resides in a separate cluster, distinct from the Michelangelo control plane environment. This separation of concerns typically results in differing versions of libraries and dependencies across environments.
+In typical production deployments, the control plane managing Spark jobs often resides in a separate cluster, distinct from the Michelangelo AI control plane environment. This separation of concerns typically results in differing versions of libraries and dependencies across environments.
 
-Including the Spark Operator CRD definitions directly within Michelangelo simplifies dependency management, especially for the Michelangelo sandbox environment, ensuring compatibility and ease of use during development and testing.
+Including the Spark Operator CRD definitions directly within Michelangelo AI simplifies dependency management, especially for the Michelangelo AI sandbox environment, ensuring compatibility and ease of use during development and testing.
 
 **Note:** This implementation is primarily intended for simplified sandbox usage.
 

--- a/go/worker/starlark/README.md
+++ b/go/worker/starlark/README.md
@@ -1,10 +1,10 @@
-# Michelangelo Starlark
+# Michelangelo AI Starlark
 
-Michelangelo Starlark lets you write workflows in the Starlark scripting language and run them on Cadence or Temporal, without needing to redeploy the worker.
+Michelangelo AI Starlark lets you write workflows in the Starlark scripting language and run them on Cadence or Temporal, without needing to redeploy the worker.
 
 ## Overview
 
-Michelangelo Starlark is a Cadence/Temporal worker that runs a generic workflow. This workflow takes Starlark code as input and executes it using an embedded Starlark interpreter. The interpreter is integrated with the Cadence/Temporal SDK, so your Starlark code can call Cadence/Temporal APIs directly.
+Michelangelo AI Starlark is a Cadence/Temporal worker that runs a generic workflow. This workflow takes Starlark code as input and executes it using an embedded Starlark interpreter. The interpreter is integrated with the Cadence/Temporal SDK, so your Starlark code can call Cadence/Temporal APIs directly.
 
 ## Getting Started
 

--- a/helm/michelangelo/README.md
+++ b/helm/michelangelo/README.md
@@ -1,8 +1,8 @@
-# Michelangelo Helm Chart
+# Michelangelo AI Helm Chart
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/michelangelo)](https://artifacthub.io/packages/helm/michelangelo/michelangelo)
 
-The `michelangelo` Helm chart installs the Michelangelo control plane — apiserver, gRPC-Web proxy (envoy), UI, workflow worker, controller manager, CRDs, and RBAC — into any Kubernetes cluster.
+The `michelangelo` Helm chart installs the Michelangelo AI control plane — apiserver, gRPC-Web proxy (envoy), UI, workflow worker, controller manager, CRDs, and RBAC — into any Kubernetes cluster.
 
 The chart owns only the **control plane**. Infrastructure (metadata storage, object storage, workflow engine) is your responsibility — bring your own RDS / Cloud SQL, S3 / GCS, and Cadence / Temporal, or use the local development setup below.
 
@@ -22,7 +22,7 @@ The chart owns only the **control plane**. Infrastructure (metadata storage, obj
 
 ### Local development (k3d)
 
-The Michelangelo CLI provisions a local k3d cluster, MySQL, and MinIO, then installs this chart with `values-k3d.yaml` (which enables the bundled Cadence or Temporal subchart based on `--workflow`):
+The Michelangelo AI CLI provisions a local k3d cluster, MySQL, and MinIO, then installs this chart with `values-k3d.yaml` (which enables the bundled Cadence or Temporal subchart based on `--workflow`):
 
 ```bash
 pip install michelangelo
@@ -125,7 +125,7 @@ GRANT ALL PRIVILEGES ON cadence.* TO 'your_user'@'%';
 GRANT ALL PRIVILEGES ON cadence_visibility.* TO 'your_user'@'%';
 ```
 
-The Michelangelo control plane uses the `michelangelo` database — there is no conflict. You can share a single MySQL instance by setting both `metadataStorage.host` and `cadence.config.persistence.database.sql.hosts` to the same hostname.
+The Michelangelo AI control plane uses the `michelangelo` database — there is no conflict. You can share a single MySQL instance by setting both `metadataStorage.host` and `cadence.config.persistence.database.sql.hosts` to the same hostname.
 
 ### Mutual exclusivity with Temporal
 

--- a/helm/michelangelo/crds/README.md
+++ b/helm/michelangelo/crds/README.md
@@ -2,7 +2,7 @@
 
 This directory is intentionally empty.
 
-Michelangelo's CRDs are registered (and updated) by the apiserver at startup
+Michelangelo AI's CRDs are registered (and updated) by the apiserver at startup
 through its `crdSync.enableCRDUpdate: true` config. The apiserver calls
 `crd.SyncCRDs()` (`go/api/crd/sync.go`) which generates each CustomResource
 Definition from the registered protobuf types in `proto-go/api/v2/*` and

--- a/proto/test/api/README.md
+++ b/proto/test/api/README.md
@@ -1,6 +1,6 @@
 # Multi-Version CRD Support Setup Guide
 
-This guide explains how to add multi-version support for Custom Resource Definitions (CRDs) in the Michelangelo API Server. This is useful for testing API versioning, backward compatibility, and CRD conversion webhooks.
+This guide explains how to add multi-version support for Custom Resource Definitions (CRDs) in the Michelangelo AI API Server. This is useful for testing API versioning, backward compatibility, and CRD conversion webhooks.
 
 ## Overview
 

--- a/python/README.md
+++ b/python/README.md
@@ -1,15 +1,15 @@
-# Michelangelo
+# Michelangelo AI
 
 **An end-to-end ML platform for building, training, and registering machine learning models at scale.**
 
 [![Documentation](https://img.shields.io/badge/docs-michelangelo--ai.org-blue)](https://michelangelo-ai.org/docs)
 [![GitHub](https://img.shields.io/badge/github-michelangelo--ai%2Fmichelangelo-lightgrey)](https://github.com/michelangelo-ai/michelangelo)
 
-Michelangelo gives ML engineers and data scientists a unified Python SDK for the entire model lifecycle — from data preparation and distributed training to model registration and production deployment. Define your ML workflows as Python functions using simple decorators, and Michelangelo handles orchestration, caching, and scaling across Ray and Spark clusters.
+Michelangelo AI gives ML engineers and data scientists a unified Python SDK for the entire model lifecycle — from data preparation and distributed training to model registration and production deployment. Define your ML workflows as Python functions using simple decorators, and Michelangelo AI handles orchestration, caching, and scaling across Ray and Spark clusters.
 
 ## Key Features
 
-- **Uniflow Pipeline Framework** — Define ML workflows with `@task` and `@workflow` decorators. Write plain Python functions and Michelangelo handles distributed execution, data passing between tasks, and result caching.
+- **Uniflow Pipeline Framework** — Define ML workflows with `@task` and `@workflow` decorators. Write plain Python functions and Michelangelo AI handles distributed execution, data passing between tasks, and result caching.
 
 - **Distributed Execution** — Scale tasks across Ray or Spark clusters with a single config change. Specify CPU, memory, GPU, and worker resources per task — no changes to your business logic required.
 
@@ -17,7 +17,7 @@ Michelangelo gives ML engineers and data scientists a unified Python SDK for the
 
 - **Python API Client** — Programmatically manage projects, pipelines, model registry, and pipeline runs through a gRPC-based Python client.
 
-- **CLI (`ma`)** — Register pipelines, manage triggers, run sandboxes, and interact with the Michelangelo platform from your terminal.
+- **CLI (`ma`)** — Register pipelines, manage triggers, run sandboxes, and interact with the Michelangelo AI platform from your terminal.
 
 - **Flexible Storage** — Read and write data across S3, GCS, HDFS, and local filesystems using the fsspec-based storage layer.
 
@@ -43,7 +43,7 @@ pip install michelangelo[plugin]
 | `michelangelo[ray-polars]` | Ray, Polars | You read Ray Datasets with nested list/struct columns (Polars fallback for [ray#61675](https://github.com/ray-project/ray/issues/61675)) |
 | `michelangelo[vllm]` | vLLM, Ray, PyTorch, Transformers | You're serving or fine-tuning large language models |
 | `michelangelo[example]` | All ML libraries for examples | You want to run the included example projects |
-| `michelangelo[dev]` | pytest, ruff, pre-commit, Ray | You're contributing to Michelangelo itself |
+| `michelangelo[dev]` | pytest, ruff, pre-commit, Ray | You're contributing to Michelangelo AI itself |
 
 ## Quickstart
 
@@ -101,7 +101,7 @@ def process_data(df):
 
 ### I/O Plugins
 
-Michelangelo provides typed I/O handlers for passing data between tasks. The
+Michelangelo AI provides typed I/O handlers for passing data between tasks. The
 handler is selected automatically based on the Python type of the value being
 written.
 
@@ -155,7 +155,7 @@ export MA_API_SERVER="localhost:12345"
 Evaluation reports capture structured metric charts produced by a training run.
 If you've used MLflow or W&B, here's the conceptual mapping:
 
-| Michelangelo | MLflow | W&B |
+| Michelangelo AI | MLflow | W&B |
 |---|---|---|
 | `metadata.namespace` | Experiment name | entity / project |
 | `metadata.name` | Run name | Run name |

--- a/python/examples/README.md
+++ b/python/examples/README.md
@@ -1,4 +1,4 @@
-Example project showing various capabilities of the Michelangelo workflows.
+Example project showing various capabilities of the Michelangelo AI workflows.
 
 ## Project Structure
 
@@ -61,8 +61,8 @@ Create temporal sandbox
 
 The create setup dependencies for Uniflow including
 
-- Michelangelo-ai API
-- Michelangelo-ai controller manager
+- Michelangelo AI-ai API
+- Michelangelo AI-ai controller manager
 - Cadence
 - Starlark-worker
 - S3 storage

--- a/python/examples/pipelines/california_housing_xgb/README.md
+++ b/python/examples/pipelines/california_housing_xgb/README.md
@@ -1,7 +1,7 @@
 # California Housing XGBoost
 
 End-to-end ML pipeline for California Housing price prediction using XGBoost.
-Demonstrates the full Michelangelo workflow: feature preparation, Spark
+Demonstrates the full Michelangelo AI workflow: feature preparation, Spark
 preprocessing, distributed Ray training, and a pusher step that exports the
 model, evaluation report, and preprocessed datasets to storage and registry.
 
@@ -23,7 +23,7 @@ The workflow is orchestrated in `california_housing_xgb.py`, which imports each 
 
 ## Prerequisites
 
-- A Michelangelo sandbox running (`ma sandbox create`)
+- A Michelangelo AI sandbox running (`ma sandbox create`)
 - A project created: `ma project apply -f examples/config/project.yaml`
 - Python 3.9+
 - Java 17 with `JAVA_HOME` set — required for Spark. Java 21 is incompatible with PySpark 3.5 + Hadoop 3.3 (`getSubject is not supported`). On macOS: `brew install openjdk@17` then `export JAVA_HOME=$(brew --prefix openjdk@17)/libexec/openjdk.jdk/Contents/Home`

--- a/python/examples/workflow_patterns/README.md
+++ b/python/examples/workflow_patterns/README.md
@@ -41,7 +41,7 @@ To run with a larger dataset:
 python -m examples.workflow_patterns.workflow_patterns --input '{"large_dataset": true}'
 ```
 
-For remote execution on a Michelangelo cluster:
+For remote execution on a Michelangelo AI cluster:
 
 ```bash
 python -m examples.workflow_patterns.workflow_patterns remote-run \

--- a/python/michelangelo/cli/sandbox/README.md
+++ b/python/michelangelo/cli/sandbox/README.md
@@ -1,7 +1,7 @@
-Sandbox is a lightweight version of the Michelangelo cluster, designed specifically for development and testing. It also serves as an excellent tool for users to quickly explore the platform and familiarize themselves with its interface.
+Sandbox is a lightweight version of the Michelangelo AI cluster, designed specifically for development and testing. It also serves as an excellent tool for users to quickly explore the platform and familiarize themselves with its interface.
 
 > **Note:** The Sandbox deployment is intended for development and testing purposes only and is not suitable for production environments.
-> For guidance on creating a production-ready Michelangelo deployment, please refer to the `helm/michelangelo/` chart and its README.
+> For guidance on creating a production-ready Michelangelo AI deployment, please refer to the `helm/michelangelo/` chart and its README.
 
 ## User Guide
 
@@ -16,7 +16,7 @@ Please install the following software before proceeding:
 - [k3d](https://k3d.io)
 - [Helm 3.12+](https://helm.sh/docs/intro/install/)
 
-### Install Michelangelo CLI
+### Install Michelangelo AI CLI
 
 ```bash
 pip install michelangelo
@@ -116,7 +116,7 @@ ma sandbox create \
 
 | Service | URL | Notes |
 |---|---|---|
-| Michelangelo UI | http://localhost:8090 | |
+| Michelangelo AI UI | http://localhost:8090 | |
 | Envoy (gRPC-Web) | http://localhost:8081 | |
 | Apiserver (gRPC) | localhost:15566 | |
 | Cadence Web | http://localhost:8088 | Only when `--workflow cadence` (default) — NodePort 30004 |

--- a/python/michelangelo/uniflow/plugins/pipeline/README.md
+++ b/python/michelangelo/uniflow/plugins/pipeline/README.md
@@ -176,5 +176,5 @@ def my_workflow():
 - This implementation matches the Go/Starlark version exactly in terms of parameters, return types, and behavior
 - The function is synchronous and will block until the pipeline run reaches a terminal state
 - Failed or killed pipeline runs will raise a `RuntimeError`
-- The implementation uses the Michelangelo API client (`APIClient.PipelineRunService`) to create and monitor pipeline runs
+- The implementation uses the Michelangelo AI API client (`APIClient.PipelineRunService`) to create and monitor pipeline runs
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,8 +1,8 @@
 [tool.poetry]
 name = "michelangelo"
 version = "0.5.0"
-description = "Michelangelo is an end-to-end model lifecycle management system at large scale"
-authors = ["Michelangelo Team <michelangelo-oss-group@uber.com>"]
+description = "Michelangelo AI is an end-to-end model lifecycle management system at large scale"
+authors = ["Michelangelo AI Team <michelangelo-oss-group@uber.com>"]
 readme = "README.md"
 exclude = ["michelangelo/example", "michelangelo/tests", "michelangelo/tools"]    # TODO: temporary exclude all codes in package building
 packages = [

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,6 +1,6 @@
 # Tools Directory
 
-This directory contains utility scripts for Michelangelo development and testing.
+This directory contains utility scripts for Michelangelo AI development and testing.
 
 ## Directory Structure
 
@@ -21,7 +21,7 @@ Scripts in the root `tools/` directory are for **development purposes** and may 
 - **`gazelle`** - Go BUILD file generator
 - **`go`** - Go toolchain wrapper
 - **`goimports`** - Go import formatter
-- **`mamockgen`** - Mock generator for Michelangelo
+- **`mamockgen`** - Mock generator for Michelangelo AI
 - **`grpc-svc-gen.sh`** - gRPC service generator
 - **`gen-grpc-client.sh`** - gRPC client generator
 - **`run_ruff.sh`** - Python linter runner

--- a/website/README.md
+++ b/website/README.md
@@ -1,6 +1,6 @@
-# Michelangelo Documentation
+# Michelangelo AI Documentation
 
-This is the documentation website for Michelangelo, built with [Docusaurus](https://docusaurus.io/).
+This is the documentation website for Michelangelo AI, built with [Docusaurus](https://docusaurus.io/).
 
 ## Prerequisites
 
@@ -124,7 +124,7 @@ Syntax highlighting is available for: `go`, `python`, `bash`, `yaml`, `json`, `j
 ````md
 ```python
 def hello():
-    print("Hello, Michelangelo!")
+    print("Hello, Michelangelo AI!")
 ```
 ````
 


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**
Replaces bare "Michelangelo" with "Michelangelo AI" in prose across 17 README files and updates the `description` and `authors` fields in `python/pyproject.toml` (the PyPI package metadata). Code blocks, inline code, import paths, and package names are untouched.

**Why?**
Same USPTO trademark requirement as PR #1575 (which covered `docs/`). The `pyproject.toml` description is displayed publicly on PyPI, making it a P0 fix. READMEs are the first thing external contributors and users see on GitHub.

**How did you test it?**
Same automated Python script as #1575 — parses line-by-line, tracks fenced code block state, skips inline code spans. Post-run grep confirmed zero remaining bare "Michelangelo" instances in prose across all 17 files and `pyproject.toml`.

**Potential risks**
None — documentation and package metadata only. No code, APIs, or runtime behavior affected.

**Breaking Changes**
- [x] No breaking changes

**Release notes**
N/A

**Documentation Changes**
17 README files and `python/pyproject.toml` updated. Companion to #1575.