### PR TITLE
Tabular assembler migration 1/5: Triton packager utilities

### DIFF
--- a/python/michelangelo/lib/__init__.py
+++ b/python/michelangelo/lib/__init__.py
@@ -1,0 +1,16 @@
+"""Core library package for Michelangelo.
+
+Houses the model manager, artifact manager, trainer, and related subpackages.
+
+Callers should import from the submodules directly (e.g.
+``michelangelo.lib.model_manager.packager``); this ``__init__.py``
+intentionally exports nothing.
+
+Note: unlike the top-level :mod:`michelangelo` package, this subpackage does
+not need PEP 420 / ``pkgutil``-style namespace merging — its contents are
+fully authored in this repository — so it is a regular package (with this
+``__init__.py``) rather than an implicit namespace package. Regular
+subpackages resolve reliably under ``bazel``-generated wheel installs, where
+implicit namespace subpackages were found not to be picked up correctly by
+the runfiles tree built from ``requirement("michelangelo-ai")``.
+"""

--- a/python/michelangelo/lib/model_manager/_private/packager/custom_triton/__init__.py
+++ b/python/michelangelo/lib/model_manager/_private/packager/custom_triton/__init__.py
@@ -1,6 +1,7 @@
 # flake8: noqa:F401
 """Custom Triton packager for custom models."""
 
+from .additional_imports import serialize_additional_imports
 from .config_pbtxt import generate_config_pbtxt_content
 from .main_module import serialize_main_module
 from .model_class import serialize_model_class

--- a/python/michelangelo/lib/model_manager/_private/packager/custom_triton/additional_imports.py
+++ b/python/michelangelo/lib/model_manager/_private/packager/custom_triton/additional_imports.py
@@ -1,0 +1,47 @@
+"""Serialize additional, dynamically-imported Python modules into a package."""
+
+import os
+from typing import Optional
+
+from michelangelo.lib.model_manager._private.utils.module_finder import (
+    find_dependency_files,
+)
+from michelangelo.lib.model_manager._private.utils.module_utils import (
+    save_module_files,
+)
+
+
+def serialize_additional_imports(
+    additional_import_prefixes: Optional[list[str]],
+    target_dir: str,
+    include_import_prefixes: Optional[list[str]] = None,
+) -> None:
+    """Serialize additional Python modules into the target directory.
+
+    This complements the static import extraction performed for the model
+    class by allowing users to specify module prefixes that are dynamically
+    imported (e.g. via importlib) and would not be captured by the standard
+    import analysis.
+
+    Each prefix is treated as a module path. Its source files and their
+    transitive dependencies are recursively resolved and copied into
+    ``target_dir``, preserving the original directory structure.
+
+    Args:
+        additional_import_prefixes: Module prefixes to resolve and
+            serialize, e.g. ``["mypackage.foo", "mypackage.bar.utils"]``.
+            If None or empty, this function is a no-op.
+        target_dir: The directory to copy the resolved source files into.
+        include_import_prefixes: Optional filter passed to
+            ``find_dependency_files`` so that only transitive dependencies
+            whose module names start with one of these prefixes are
+            included.
+    """
+    if not additional_import_prefixes:
+        return
+
+    os.makedirs(target_dir, exist_ok=True)
+
+    for prefix in additional_import_prefixes:
+        files = find_dependency_files(prefix, prefixes=include_import_prefixes)
+        save_module_files(files, target_dir)

--- a/python/michelangelo/lib/model_manager/_private/packager/custom_triton/config_pbtxt.py
+++ b/python/michelangelo/lib/model_manager/_private/packager/custom_triton/config_pbtxt.py
@@ -1,5 +1,7 @@
 """Config pbtxt generation module."""
 
+from typing import Optional
+
 from michelangelo.lib.model_manager._private.packager.template_renderer import (
     TritonTemplateRenderer,
 )
@@ -14,6 +16,7 @@ def generate_config_pbtxt_content(
     model_revision: str,
     input_schema: dict[str, dict[str, str]],
     output_schema: dict[str, dict[str, str]],
+    triton_parameters: Optional[dict[str, str]] = None,
 ) -> str:
     """Generate the config.pbtxt file content.
 
@@ -23,6 +26,10 @@ def generate_config_pbtxt_content(
         model_revision: the revision of model in MA Studio
         input_schema: the input schema of the model
         output_schema: the output schema of the model
+        triton_parameters: Optional custom Triton model config parameters to
+            include in config.pbtxt. Each key-value pair becomes a
+            ``parameters`` block in the generated config, e.g.
+            ``{"MY_CUSTOM_PARAM": "16"}``.
 
     Returns:
         The config.pbtxt file content
@@ -47,5 +54,6 @@ def generate_config_pbtxt_content(
             "instance_count": 1,
             "inputs": input_schema,
             "outputs": output_schema,
+            "parameters": triton_parameters or {},
         },
     )

--- a/python/michelangelo/lib/model_manager/_private/packager/custom_triton/model_package.py
+++ b/python/michelangelo/lib/model_manager/_private/packager/custom_triton/model_package.py
@@ -4,6 +4,12 @@ import os
 import tempfile
 from typing import Optional
 
+import numpy as np
+from numpy import ndarray
+
+from michelangelo.lib.model_manager._private.packager.custom_triton.additional_imports import (  # noqa: E501
+    serialize_additional_imports,
+)
 from michelangelo.lib.model_manager._private.packager.custom_triton.config_pbtxt import (  # noqa: E501
     generate_config_pbtxt_content,
 )
@@ -31,6 +37,7 @@ from michelangelo.lib.model_manager._private.packager.custom_triton.validation i
 from michelangelo.lib.model_manager._private.packager.template_renderer import (
     TritonTemplateRenderer,
 )
+from michelangelo.lib.model_manager._private.serde.data import dump_model_data
 from michelangelo.lib.model_manager._private.utils.asset_utils import download_assets
 from michelangelo.lib.model_manager.constants import StorageType
 
@@ -46,7 +53,10 @@ def generate_model_package_content(
     model_path_source_type: Optional[str] = StorageType.LOCAL,
     root_path: Optional[str] = None,
     include_import_prefixes: Optional[list[str]] = None,
+    additional_import_prefixes: Optional[list[str]] = None,
     custom_batch_processing: Optional[bool] = False,
+    triton_parameters: Optional[dict[str, str]] = None,
+    sample_data: Optional[list[dict[str, ndarray]]] = None,
 ) -> dict:
     """Generate the model package content.
 
@@ -66,12 +76,28 @@ def generate_model_package_content(
             e.g. ['uber', 'data.michelangelo'] only imports starting
             with 'uber' or 'data.michelangelo' will be saved in the
             model package. If not specified, save all imports
+        additional_import_prefixes (Optional): additional Python module
+            prefixes whose source files should be included in the model
+            package. Useful when the model class uses dynamic imports
+            (e.g. importlib) that are not captured by static import
+            analysis. Each prefix is recursively resolved and its files
+            are serialized into the package.
         custom_batch_processing (Optional): If to inject batch processing
             code to automatically handle batch. Default is False. If set to
             True, the user is responsible for handling batch in the model
             class, and the model input/output will have an additional batch
             dimension on top of the existing model schema. For example, the
             schema shape [1] will be converted to [-1, 1].
+        triton_parameters (Optional): custom Triton model config parameters
+            to include in config.pbtxt. Each key-value pair becomes a
+            ``parameters`` block in the generated config, e.g.
+            ``{"MY_CUSTOM_PARAM": "16"}``.
+        sample_data (Optional): sample inputs for the model's predict
+            method, written to ``metadata/sample_data.json`` for reference
+            and validation. Each item is a dict mapping input feature names
+            to numpy arrays. If ``custom_batch_processing`` is False, a
+            leading batch dimension is added to match what Triton passes to
+            the model at serve time.
 
     Returns:
         The model package content as a dictionary
@@ -88,6 +114,7 @@ def generate_model_package_content(
         model_revision,
         input_schema,
         output_schema,
+        triton_parameters=triton_parameters,
     )
 
     model_0_dir = os.path.join(root_path, "0")
@@ -97,6 +124,12 @@ def generate_model_package_content(
         model_class,
         model_0_dir,
         MODEL_CLASS_FILE_NAME,
+        include_import_prefixes=include_import_prefixes,
+    )
+
+    serialize_additional_imports(
+        additional_import_prefixes,
+        model_0_dir,
         include_import_prefixes=include_import_prefixes,
     )
 
@@ -132,5 +165,13 @@ def generate_model_package_content(
             "model": f"dir://{target_model_path}",
         },
     }
+
+    if sample_data is not None:
+        if not custom_batch_processing:
+            sample_data = [
+                {k: np.expand_dims(v, axis=0) for k, v in sample.items()}
+                for sample in sample_data
+            ]
+        content["metadata"] = {"sample_data.json": dump_model_data(sample_data)}
 
     return content

--- a/python/michelangelo/lib/model_manager/_private/packager/custom_triton/raw_model_package.py
+++ b/python/michelangelo/lib/model_manager/_private/packager/custom_triton/raw_model_package.py
@@ -6,6 +6,9 @@ from typing import Optional, Union
 
 from numpy import ndarray
 
+from michelangelo.lib.model_manager._private.packager.custom_triton.additional_imports import (  # noqa: E501
+    serialize_additional_imports,
+)
 from michelangelo.lib.model_manager._private.packager.custom_triton.constants import (
     MODEL_CLASS_FILE_NAME,
 )
@@ -40,6 +43,7 @@ def generate_raw_model_package_content(
     requirements: Optional[Union[list[str], str]] = None,
     root_path: Optional[str] = None,
     include_import_prefixes: Optional[list[str]] = None,
+    additional_import_prefixes: Optional[list[str]] = None,
     batch_inference: Optional[bool] = False,
 ) -> dict:
     """Generate the raw model package content.
@@ -66,6 +70,12 @@ def generate_raw_model_package_content(
             with 'uber' or 'data.michelangelo' will be saved in the
             model package. Default is ['uber'],
             and if the list is empty, save all imports
+        additional_import_prefixes (Optional): additional Python module
+            prefixes whose source files should be included in the model
+            package. Useful when the model class uses dynamic imports
+            (e.g. importlib) that are not captured by static import
+            analysis. Each prefix is recursively resolved and its files
+            are serialized into the package.
         batch_inference (Optional): Specify if the prediction function in
             the model class handles batch inference. Default is False.
             If set to True, the model input/output will have an additional
@@ -99,6 +109,12 @@ def generate_raw_model_package_content(
         model_class,
         defs_path,
         MODEL_CLASS_FILE_NAME,
+        include_import_prefixes=include_import_prefixes,
+    )
+
+    serialize_additional_imports(
+        additional_import_prefixes,
+        defs_path,
         include_import_prefixes=include_import_prefixes,
     )
 

--- a/python/michelangelo/lib/model_manager/_private/packager/custom_triton/tests/_helpers.py
+++ b/python/michelangelo/lib/model_manager/_private/packager/custom_triton/tests/_helpers.py
@@ -1,0 +1,20 @@
+"""Shared test helpers for custom_triton packager tests."""
+
+import os
+from pathlib import Path
+
+
+def list_relative_files(root):
+    """Walks a directory and returns sorted paths relative to it.
+
+    Args:
+        root: The directory to walk.
+
+    Returns:
+        A sorted list of file paths relative to ``root``.
+    """
+    return sorted(
+        str(Path(os.path.join(dirpath, file)).relative_to(root))
+        for dirpath, _, filenames in os.walk(root)
+        for file in filenames
+    )

--- a/python/michelangelo/lib/model_manager/_private/packager/custom_triton/tests/additional_imports_test.py
+++ b/python/michelangelo/lib/model_manager/_private/packager/custom_triton/tests/additional_imports_test.py
@@ -1,0 +1,89 @@
+"""Tests for serialize_additional_imports."""
+
+import os
+import tempfile
+from unittest import TestCase
+
+from michelangelo.lib.model_manager._private.packager.custom_triton.additional_imports import (  # noqa: E501
+    serialize_additional_imports,
+)
+
+
+class SerializeAdditionalImportsTest(TestCase):
+    """Tests serialization of dynamically-imported module prefixes."""
+
+    def test_serialize_additional_imports_adds_files(self):
+        """It copies the resolved prefix's source file into the target dir."""
+        prefix = (
+            "michelangelo.lib.model_manager._private.utils.module_finder.tests."
+            "fixtures.simple_module"
+        )
+
+        with tempfile.TemporaryDirectory() as target_dir:
+            serialize_additional_imports(
+                [prefix],
+                target_dir,
+                include_import_prefixes=["michelangelo"],
+            )
+
+            expected_file = os.path.join(
+                target_dir,
+                "michelangelo",
+                "lib",
+                "model_manager",
+                "_private",
+                "utils",
+                "module_finder",
+                "tests",
+                "fixtures",
+                "simple_module.py",
+            )
+            self.assertTrue(os.path.exists(expected_file))
+
+            with open(expected_file) as f:
+                content = f.read()
+            self.assertIn("module_attr", content)
+
+    def test_serialize_additional_imports_none_is_noop(self):
+        """It does nothing when additional_import_prefixes is None."""
+        with tempfile.TemporaryDirectory() as target_dir:
+            serialize_additional_imports(None, target_dir)
+            self.assertEqual(os.listdir(target_dir), [])
+
+    def test_serialize_additional_imports_empty_list_is_noop(self):
+        """It does nothing when additional_import_prefixes is empty."""
+        with tempfile.TemporaryDirectory() as target_dir:
+            serialize_additional_imports([], target_dir)
+            self.assertEqual(os.listdir(target_dir), [])
+
+    def test_serialize_additional_imports_multiple_prefixes(self):
+        """It resolves and copies every prefix in the given list."""
+        prefixes = [
+            "michelangelo.lib.model_manager._private.utils.module_finder.tests."
+            "fixtures.simple_module",
+            "michelangelo.lib.model_manager._private.utils.module_finder.tests."
+            "fixtures.module_with_imports",
+        ]
+
+        with tempfile.TemporaryDirectory() as target_dir:
+            serialize_additional_imports(
+                prefixes,
+                target_dir,
+                include_import_prefixes=["michelangelo"],
+            )
+
+            base = os.path.join(
+                target_dir,
+                "michelangelo",
+                "lib",
+                "model_manager",
+                "_private",
+                "utils",
+                "module_finder",
+                "tests",
+                "fixtures",
+            )
+            self.assertTrue(os.path.exists(os.path.join(base, "simple_module.py")))
+            self.assertTrue(
+                os.path.exists(os.path.join(base, "module_with_imports.py"))
+            )

--- a/python/michelangelo/lib/model_manager/_private/packager/custom_triton/tests/config_pbtxt_test.py
+++ b/python/michelangelo/lib/model_manager/_private/packager/custom_triton/tests/config_pbtxt_test.py
@@ -11,56 +11,77 @@ from michelangelo.lib.model_manager._private.packager.template_renderer import (
 )
 
 
+def _build_expected_config_pbtxt(name_line="", parameters_block=""):
+    """Build the expected config.pbtxt body shared by all rendering tests."""
+    body = dedent(
+        """\
+        backend: "python"
+        max_batch_size: 256
+        dynamic_batching: {
+          preferred_batch_size: 10,
+          max_queue_delay_microseconds: 300,
+          preserve_ordering: true
+        }
+        input : [
+          {
+            name: "input",
+            data_type: TYPE_FP32,
+            dims: [1, 100]
+          }
+        ]
+        output: [
+          {
+            name: "output",
+            data_type: TYPE_FP32,
+            dims: [1, 100]
+          }
+        ]
+        """
+    )
+    tail = dedent(
+        """\
+        instance_group: [
+          {
+            kind: KIND_CPU,
+            count: 1
+          }
+        ]
+        """
+    )
+    return name_line + body + parameters_block + tail
+
+
 class ConfigPbtxtTest(TestCase):
     """Tests config.pbtxt template rendering."""
 
     def test_generate_config_pbtxt_content(self):
-        """It renders the expected config.pbtxt contents."""
-        gen = TritonTemplateRenderer()
-        config_pbtxt = generate_config_pbtxt_content(
-            gen,
-            model_name="test_model",
-            model_revision="test_revision",
-            input_schema={"input": {"data_type": "FP32", "shape": [1, 100]}},
-            output_schema={"output": {"data_type": "FP32", "shape": [1, 100]}},
-        )
+        """It renders the expected config.pbtxt contents for name/revision variants."""
+        cases = [
+            ("test_model", "test_revision", 'name: "test_model-test_revision"\n'),
+            ("test_model", None, 'name: "test_model"\n'),
+            (None, "test_revision", ""),
+            (1, None, 'name: "1"\n'),
+            (1, 2.0, 'name: "1-2.0"\n'),
+            (0, None, 'name: "0"\n'),
+            (0, 0, 'name: "0-0"\n'),
+        ]
+        for model_name, model_revision, name_line in cases:
+            with self.subTest(model_name=model_name, model_revision=model_revision):
+                gen = TritonTemplateRenderer()
+                config_pbtxt = generate_config_pbtxt_content(
+                    gen,
+                    model_name=model_name,
+                    model_revision=model_revision,
+                    input_schema={"input": {"data_type": "FP32", "shape": [1, 100]}},
+                    output_schema={"output": {"data_type": "FP32", "shape": [1, 100]}},
+                )
 
-        expected_config_pbtxt = dedent(
-            """\
-            name: "test_model-test_revision"
-            backend: "python"
-            max_batch_size: 256
-            dynamic_batching: {
-              preferred_batch_size: 10,
-              max_queue_delay_microseconds: 300,
-              preserve_ordering: true
-            }
-            input : [
-              {
-                name: "input",
-                data_type: TYPE_FP32,
-                dims: [1, 100]
-              }
-            ]
-            output: [
-              {
-                name: "output",
-                data_type: TYPE_FP32,
-                dims: [1, 100]
-              }
-            ]
-            instance_group: [
-              {
-                kind: KIND_CPU,
-                count: 1
-              }
-            ]
-            """
-        )
-        self.assertEqual(config_pbtxt, expected_config_pbtxt)
+                self.assertEqual(
+                    config_pbtxt, _build_expected_config_pbtxt(name_line=name_line)
+                )
 
-    def test_generate_config_pbtxt_content_without_revision(self):
-        """It renders the expected config.pbtxt contents."""
+    def test_generate_config_pbtxt_content_with_triton_parameters(self):
+        """It renders a parameters block for each triton_parameters entry."""
         gen = TritonTemplateRenderer()
         config_pbtxt = generate_config_pbtxt_content(
             gen,
@@ -68,262 +89,35 @@ class ConfigPbtxtTest(TestCase):
             model_revision=None,
             input_schema={"input": {"data_type": "FP32", "shape": [1, 100]}},
             output_schema={"output": {"data_type": "FP32", "shape": [1, 100]}},
+            triton_parameters={"MY_CUSTOM_PARAM": "16"},
         )
 
-        expected_config_pbtxt = dedent(
+        parameters_block = dedent(
             """\
-            name: "test_model"
-            backend: "python"
-            max_batch_size: 256
-            dynamic_batching: {
-              preferred_batch_size: 10,
-              max_queue_delay_microseconds: 300,
-              preserve_ordering: true
+            parameters: {
+              key: "MY_CUSTOM_PARAM"
+              value: {
+                string_value: "16"
+              }
             }
-            input : [
-              {
-                name: "input",
-                data_type: TYPE_FP32,
-                dims: [1, 100]
-              }
-            ]
-            output: [
-              {
-                name: "output",
-                data_type: TYPE_FP32,
-                dims: [1, 100]
-              }
-            ]
-            instance_group: [
-              {
-                kind: KIND_CPU,
-                count: 1
-              }
-            ]
             """
         )
-        self.assertEqual(config_pbtxt, expected_config_pbtxt)
+        self.assertEqual(
+            config_pbtxt,
+            _build_expected_config_pbtxt(
+                name_line='name: "test_model"\n', parameters_block=parameters_block
+            ),
+        )
 
-    def test_generate_config_pbtxt_content_without_name(self):
-        """It renders the expected config.pbtxt contents without name."""
+    def test_generate_config_pbtxt_content_without_triton_parameters(self):
+        """It omits the parameters block when triton_parameters is None."""
         gen = TritonTemplateRenderer()
         config_pbtxt = generate_config_pbtxt_content(
             gen,
-            model_name=None,
-            model_revision="test_revision",
-            input_schema={"input": {"data_type": "FP32", "shape": [1, 100]}},
-            output_schema={"output": {"data_type": "FP32", "shape": [1, 100]}},
-        )
-
-        expected_config_pbtxt = dedent(
-            """\
-            backend: "python"
-            max_batch_size: 256
-            dynamic_batching: {
-              preferred_batch_size: 10,
-              max_queue_delay_microseconds: 300,
-              preserve_ordering: true
-            }
-            input : [
-              {
-                name: "input",
-                data_type: TYPE_FP32,
-                dims: [1, 100]
-              }
-            ]
-            output: [
-              {
-                name: "output",
-                data_type: TYPE_FP32,
-                dims: [1, 100]
-              }
-            ]
-            instance_group: [
-              {
-                kind: KIND_CPU,
-                count: 1
-              }
-            ]
-            """
-        )
-        self.assertEqual(config_pbtxt, expected_config_pbtxt)
-
-    def test_generate_config_pbtxt_content_with_numeric_name(self):
-        """It renders the expected config.pbtxt contents with numeric name."""
-        gen = TritonTemplateRenderer()
-        config_pbtxt = generate_config_pbtxt_content(
-            gen,
-            model_name=1,
+            model_name="test_model",
             model_revision=None,
             input_schema={"input": {"data_type": "FP32", "shape": [1, 100]}},
             output_schema={"output": {"data_type": "FP32", "shape": [1, 100]}},
         )
 
-        expected_config_pbtxt = dedent(
-            """\
-            name: "1"
-            backend: "python"
-            max_batch_size: 256
-            dynamic_batching: {
-              preferred_batch_size: 10,
-              max_queue_delay_microseconds: 300,
-              preserve_ordering: true
-            }
-            input : [
-              {
-                name: "input",
-                data_type: TYPE_FP32,
-                dims: [1, 100]
-              }
-            ]
-            output: [
-              {
-                name: "output",
-                data_type: TYPE_FP32,
-                dims: [1, 100]
-              }
-            ]
-            instance_group: [
-              {
-                kind: KIND_CPU,
-                count: 1
-              }
-            ]
-            """
-        )
-        self.assertEqual(config_pbtxt, expected_config_pbtxt)
-
-    def test_generate_config_pbtxt_content_with_numeric_name_and_revision(self):
-        """It renders the expected config.pbtxt contents with numeric name."""
-        gen = TritonTemplateRenderer()
-        config_pbtxt = generate_config_pbtxt_content(
-            gen,
-            model_name=1,
-            model_revision=2.0,
-            input_schema={"input": {"data_type": "FP32", "shape": [1, 100]}},
-            output_schema={"output": {"data_type": "FP32", "shape": [1, 100]}},
-        )
-
-        expected_config_pbtxt = dedent(
-            """\
-            name: "1-2.0"
-            backend: "python"
-            max_batch_size: 256
-            dynamic_batching: {
-              preferred_batch_size: 10,
-              max_queue_delay_microseconds: 300,
-              preserve_ordering: true
-            }
-            input : [
-              {
-                name: "input",
-                data_type: TYPE_FP32,
-                dims: [1, 100]
-              }
-            ]
-            output: [
-              {
-                name: "output",
-                data_type: TYPE_FP32,
-                dims: [1, 100]
-              }
-            ]
-            instance_group: [
-              {
-                kind: KIND_CPU,
-                count: 1
-              }
-            ]
-            """
-        )
-        self.assertEqual(config_pbtxt, expected_config_pbtxt)
-
-    def test_generate_config_pbtxt_content_with_zero_name(self):
-        """It renders the expected config.pbtxt contents with model_name == 0."""
-        gen = TritonTemplateRenderer()
-        config_pbtxt = generate_config_pbtxt_content(
-            gen,
-            model_name=0,
-            model_revision=None,
-            input_schema={"input": {"data_type": "FP32", "shape": [1, 100]}},
-            output_schema={"output": {"data_type": "FP32", "shape": [1, 100]}},
-        )
-
-        expected_config_pbtxt = dedent(
-            """\
-            name: "0"
-            backend: "python"
-            max_batch_size: 256
-            dynamic_batching: {
-              preferred_batch_size: 10,
-              max_queue_delay_microseconds: 300,
-              preserve_ordering: true
-            }
-            input : [
-              {
-                name: "input",
-                data_type: TYPE_FP32,
-                dims: [1, 100]
-              }
-            ]
-            output: [
-              {
-                name: "output",
-                data_type: TYPE_FP32,
-                dims: [1, 100]
-              }
-            ]
-            instance_group: [
-              {
-                kind: KIND_CPU,
-                count: 1
-              }
-            ]
-            """
-        )
-        self.assertEqual(config_pbtxt, expected_config_pbtxt)
-
-    def test_generate_config_pbtxt_content_with_zero_name_and_revision(self):
-        """It renders the expected config.pbtxt contents with model_name == 0."""
-        gen = TritonTemplateRenderer()
-        config_pbtxt = generate_config_pbtxt_content(
-            gen,
-            model_name=0,
-            model_revision=0,
-            input_schema={"input": {"data_type": "FP32", "shape": [1, 100]}},
-            output_schema={"output": {"data_type": "FP32", "shape": [1, 100]}},
-        )
-
-        expected_config_pbtxt = dedent(
-            """\
-            name: "0-0"
-            backend: "python"
-            max_batch_size: 256
-            dynamic_batching: {
-              preferred_batch_size: 10,
-              max_queue_delay_microseconds: 300,
-              preserve_ordering: true
-            }
-            input : [
-              {
-                name: "input",
-                data_type: TYPE_FP32,
-                dims: [1, 100]
-              }
-            ]
-            output: [
-              {
-                name: "output",
-                data_type: TYPE_FP32,
-                dims: [1, 100]
-              }
-            ]
-            instance_group: [
-              {
-                kind: KIND_CPU,
-                count: 1
-              }
-            ]
-            """
-        )
-        self.assertEqual(config_pbtxt, expected_config_pbtxt)
+        self.assertNotIn("parameters:", config_pbtxt)

--- a/python/michelangelo/lib/model_manager/_private/packager/custom_triton/tests/fixtures/duck_typed_model.py
+++ b/python/michelangelo/lib/model_manager/_private/packager/custom_triton/tests/fixtures/duck_typed_model.py
@@ -1,0 +1,54 @@
+"""A model that structurally implements the Model interface without
+inheriting from ``michelangelo.lib.model_manager.interface.custom_model.Model``.
+
+Simulates an independently-defined interface (e.g. a model class already
+extending some other, unrelated base class) with an identical method
+surface, used to verify that packager validation rejects it anyway --
+``Model`` conformance is checked nominally, not structurally.
+"""
+
+from __future__ import annotations
+
+from numpy import ndarray
+
+
+class DuckTypedModel:
+    """A model implementing save/load/predict without subclassing Model."""
+
+    def __init__(self, content: str):
+        """Initialize the model.
+
+        Args:
+            content: Arbitrary content held by the model.
+        """
+        self.content = content
+
+    def save(self, path: str) -> None:
+        """Save the model to the given path.
+
+        Args:
+            path: The local filesystem path where the model should be saved.
+        """
+
+    @classmethod
+    def load(cls, path: str) -> DuckTypedModel:
+        """Load the model from the given path.
+
+        Args:
+            path: The local filesystem path containing the saved model.
+
+        Returns:
+            A fully initialized DuckTypedModel instance.
+        """
+        return cls("loaded")
+
+    def predict(self, inputs: dict[str, ndarray]) -> dict[str, ndarray]:
+        """Predict on the given data.
+
+        Args:
+            inputs: A dictionary mapping feature names to numpy arrays.
+
+        Returns:
+            A dictionary mapping output feature names to numpy arrays.
+        """
+        return inputs

--- a/python/michelangelo/lib/model_manager/_private/packager/custom_triton/tests/model_class_test.py
+++ b/python/michelangelo/lib/model_manager/_private/packager/custom_triton/tests/model_class_test.py
@@ -2,11 +2,13 @@
 
 import os
 import tempfile
-from pathlib import Path
 from unittest import TestCase
 
 from michelangelo.lib.model_manager._private.packager.custom_triton import (
     serialize_model_class,
+)
+from michelangelo.lib.model_manager._private.packager.custom_triton.tests._helpers import (  # noqa: E501
+    list_relative_files,
 )
 
 
@@ -52,15 +54,7 @@ class ModelClassTest(TestCase):
                 content = f.read()
                 self.assertIn("class Predict(Model):", content)
 
-            files = sorted(
-                [
-                    str(
-                        Path(os.path.join(dirpath, file)).relative_to(target_dir),
-                    )
-                    for dirpath, _, filenames in os.walk(target_dir)
-                    for file in filenames
-                ],
-            )
+            files = list_relative_files(target_dir)
 
             prefix = "michelangelo/lib/model_manager/"
             self.assertEqual(

--- a/python/michelangelo/lib/model_manager/_private/packager/custom_triton/tests/model_interface_test.py
+++ b/python/michelangelo/lib/model_manager/_private/packager/custom_triton/tests/model_interface_test.py
@@ -63,3 +63,18 @@ class ModelInterfaceTest(TestCase):
         valid, error = validate_model_class(model_class_name)
         self.assertFalse(valid)
         self.assertIsInstance(error, TypeError)
+
+    def test_validate_model_class_duck_typed_rejected(self):
+        """It rejects a model that only structurally implements the interface.
+
+        The model implements save/load/predict without subclassing Model;
+        ``Model`` conformance is checked nominally, not structurally, so this
+        must be rejected.
+        """
+        model_class_name = (
+            "michelangelo.lib.model_manager._private.packager.custom_triton."
+            "tests.fixtures.duck_typed_model.DuckTypedModel"
+        )
+        valid, error = validate_model_class(model_class_name)
+        self.assertFalse(valid)
+        self.assertIsInstance(error, TypeError)

--- a/python/michelangelo/lib/model_manager/_private/packager/custom_triton/tests/model_package_test.py
+++ b/python/michelangelo/lib/model_manager/_private/packager/custom_triton/tests/model_package_test.py
@@ -1,8 +1,12 @@
 """Tests for model package generation."""
 
+import json
+import os
 import re
 import tempfile
 from unittest import TestCase
+
+import numpy as np
 
 from michelangelo.lib.model_manager._private.packager.custom_triton import (
     generate_model_package_content,
@@ -54,3 +58,133 @@ class ModelPackageTest(TestCase):
             )
             model = content["0"]["model"]
             self.assertIsNotNone(re.fullmatch(r"dir://(?:/.+)*/model", model))
+
+    def test_generate_model_package_content_with_sample_data(self):
+        """It writes sample_data.json with an added batch dimension."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            gen = TritonTemplateRenderer()
+            input_schema = {"input": {"type": "int32", "shape": "[ 1 ]"}}
+            output_schema = {"response": {"type": "int32", "shape": "[ 1 ]"}}
+            sample_data = [{"input": np.array([1])}]
+
+            content = generate_model_package_content(
+                gen,
+                temp_dir,
+                "test_model_name",
+                "test_model_revision",
+                "michelangelo.lib.model_manager._private.packager.custom_triton.tests.fixtures.predict.Predict",
+                input_schema,
+                output_schema,
+                include_import_prefixes=["michelangelo"],
+                sample_data=sample_data,
+            )
+
+            self.assertIn("metadata", content)
+            sample_data_json = content["metadata"]["sample_data.json"]
+            loaded = json.loads(sample_data_json)
+            self.assertEqual(loaded[0]["input"], [[1]])
+
+    def test_generate_model_package_content_with_sample_data_custom_batch(self):
+        """It does not add a batch dimension when batching is manual."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            gen = TritonTemplateRenderer()
+            input_schema = {"input": {"type": "int32", "shape": "[ 1 ]"}}
+            output_schema = {"response": {"type": "int32", "shape": "[ 1 ]"}}
+            sample_data = [{"input": np.array([1])}]
+
+            content = generate_model_package_content(
+                gen,
+                temp_dir,
+                "test_model_name",
+                "test_model_revision",
+                "michelangelo.lib.model_manager._private.packager.custom_triton.tests.fixtures.predict.Predict",
+                input_schema,
+                output_schema,
+                include_import_prefixes=["michelangelo"],
+                custom_batch_processing=True,
+                sample_data=sample_data,
+            )
+
+            sample_data_json = content["metadata"]["sample_data.json"]
+            loaded = json.loads(sample_data_json)
+            self.assertEqual(loaded[0]["input"], [1])
+
+    def test_generate_model_package_content_without_sample_data(self):
+        """It omits the metadata block when sample_data is not given."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            gen = TritonTemplateRenderer()
+            input_schema = {"input": {"type": "int32", "shape": "[ 1 ]"}}
+            output_schema = {"response": {"type": "int32", "shape": "[ 1 ]"}}
+
+            content = generate_model_package_content(
+                gen,
+                temp_dir,
+                "test_model_name",
+                "test_model_revision",
+                "michelangelo.lib.model_manager._private.packager.custom_triton.tests.fixtures.predict.Predict",
+                input_schema,
+                output_schema,
+                include_import_prefixes=["michelangelo"],
+            )
+
+            self.assertNotIn("metadata", content)
+
+    def test_generate_model_package_content_with_triton_parameters(self):
+        """It threads triton_parameters into the generated config.pbtxt."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            gen = TritonTemplateRenderer()
+            input_schema = {"input": {"type": "int32", "shape": "[ 1 ]"}}
+            output_schema = {"response": {"type": "int32", "shape": "[ 1 ]"}}
+
+            content = generate_model_package_content(
+                gen,
+                temp_dir,
+                "test_model_name",
+                "test_model_revision",
+                "michelangelo.lib.model_manager._private.packager.custom_triton.tests.fixtures.predict.Predict",
+                input_schema,
+                output_schema,
+                include_import_prefixes=["michelangelo"],
+                triton_parameters={"MY_CUSTOM_PARAM": "16"},
+            )
+
+            self.assertIn('key: "MY_CUSTOM_PARAM"', content["config.pbtxt"])
+
+    def test_generate_model_package_content_with_additional_import_prefixes(self):
+        """It serializes additional dynamically-imported module prefixes."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            gen = TritonTemplateRenderer()
+            input_schema = {"input": {"type": "int32", "shape": "[ 1 ]"}}
+            output_schema = {"response": {"type": "int32", "shape": "[ 1 ]"}}
+
+            content = generate_model_package_content(
+                gen,
+                temp_dir,
+                "test_model_name",
+                "test_model_revision",
+                "michelangelo.lib.model_manager._private.packager.custom_triton.tests.fixtures.predict.Predict",
+                input_schema,
+                output_schema,
+                include_import_prefixes=["michelangelo"],
+                additional_import_prefixes=[
+                    "michelangelo.lib.model_manager._private.utils.module_finder."
+                    "tests.fixtures.simple_module"
+                ],
+            )
+
+            model_class_uri = content["0"]["model_class.txt"]
+            model_0_dir = os.path.dirname(model_class_uri.removeprefix("file://"))
+            expected_file = os.path.join(
+                model_0_dir,
+                "michelangelo",
+                "lib",
+                "model_manager",
+                "_private",
+                "utils",
+                "module_finder",
+                "tests",
+                "fixtures",
+                "simple_module.py",
+            )
+            self.assertTrue(os.path.exists(expected_file))
+            self.assertIn("model", content["0"])

--- a/python/michelangelo/lib/model_manager/_private/packager/custom_triton/tests/pickled_model_binary_test.py
+++ b/python/michelangelo/lib/model_manager/_private/packager/custom_triton/tests/pickled_model_binary_test.py
@@ -3,7 +3,6 @@
 import os
 import pickle
 import tempfile
-from pathlib import Path
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -12,6 +11,9 @@ import numpy as np
 from michelangelo.lib.model_manager._private.packager.custom_triton import (
     serialize_pickle_dependencies,
     serialize_pickled_file_dependencies,
+)
+from michelangelo.lib.model_manager._private.packager.custom_triton.tests._helpers import (  # noqa: E501
+    list_relative_files,
 )
 from michelangelo.lib.model_manager._private.packager.custom_triton.tests.fixtures.invalid_model import (  # noqa: E501
     Model,
@@ -48,11 +50,7 @@ class PickledModelBinaryTest(TestCase):
                 model_path, target_dir, include_import_prefixes=["michelangelo"]
             )
 
-            files = sorted(
-                str(Path(os.path.join(dirpath, file)).relative_to(target_dir))
-                for dirpath, _, filenames in os.walk(target_dir)
-                for file in filenames
-            )
+            files = list_relative_files(target_dir)
 
             prefix = "michelangelo/lib/model_manager/"
             self.assertEqual(
@@ -105,11 +103,7 @@ class PickledModelBinaryTest(TestCase):
                 fn, target_dir, include_import_prefixes=["michelangelo"]
             )
 
-            files = sorted(
-                str(Path(os.path.join(dirpath, file)).relative_to(target_dir))
-                for dirpath, _, filenames in os.walk(target_dir)
-                for file in filenames
-            )
+            files = list_relative_files(target_dir)
 
             prefix = "michelangelo/lib/model_manager/"
             self.assertEqual(
@@ -141,10 +135,6 @@ class PickledModelBinaryTest(TestCase):
                 fn, target_dir, include_import_prefixes=["michelangelo"]
             )
 
-            files = sorted(
-                str(Path(os.path.join(dirpath, file)).relative_to(target_dir))
-                for dirpath, _, filenames in os.walk(target_dir)
-                for file in filenames
-            )
+            files = list_relative_files(target_dir)
 
             self.assertEqual(files, [])

--- a/python/michelangelo/lib/model_manager/_private/packager/custom_triton/tests/raw_model_package_test.py
+++ b/python/michelangelo/lib/model_manager/_private/packager/custom_triton/tests/raw_model_package_test.py
@@ -1,5 +1,6 @@
 """Tests for raw model package generation."""
 
+import os
 import re
 import tempfile
 from unittest import TestCase
@@ -17,52 +18,30 @@ class RawModelPackageTest(TestCase):
 
     def test_generate_raw_model_package_content(self):
         """It generates the raw model package content."""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            content = generate_raw_model_package_content(
-                temp_dir,
-                "michelangelo.lib.model_manager._private.packager.custom_triton.tests.fixtures.predict.Predict",
-                ModelSchema(),
-                [{"input": np.array([1, 2])}],
-                include_import_prefixes=["michelangelo"],
-            )
+        for batch_inference in [False, True]:
+            with self.subTest(batch_inference=batch_inference):
+                with tempfile.TemporaryDirectory() as temp_dir:
+                    content = generate_raw_model_package_content(
+                        temp_dir,
+                        "michelangelo.lib.model_manager._private.packager.custom_triton.tests.fixtures.predict.Predict",
+                        ModelSchema(),
+                        [{"input": np.array([1, 2])}],
+                        include_import_prefixes=["michelangelo"],
+                        batch_inference=batch_inference,
+                    )
 
-        self.assertIsNotNone(content)
-        self.assertIn("metadata", content)
-        self.assertIn("type.yaml", content["metadata"])
-        self.assertIn("schema.yaml", content["metadata"])
-        self.assertIn("sample_data.json", content["metadata"])
-        self.assertIn("model", content)
-        self.assertIn("defs", content)
-        model = content["model"]
-        self.assertIsNotNone(re.fullmatch(r"dir://(?:.+)/model", model))
-        defs = content["defs"]
-        self.assertIsNotNone(re.fullmatch(r"dir://(?:.+)/defs", defs))
-        self.assertNotIn("dependencies", content)
-
-    def test_generate_raw_model_package_content_with_batch_inference(self):
-        """It generates the raw model package content with batch inference."""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            content = generate_raw_model_package_content(
-                temp_dir,
-                "michelangelo.lib.model_manager._private.packager.custom_triton.tests.fixtures.predict.Predict",
-                ModelSchema(),
-                [{"input": np.array([1, 2])}],
-                include_import_prefixes=["michelangelo"],
-                batch_inference=True,
-            )
-
-        self.assertIsNotNone(content)
-        self.assertIn("metadata", content)
-        self.assertIn("type.yaml", content["metadata"])
-        self.assertIn("schema.yaml", content["metadata"])
-        self.assertIn("sample_data.json", content["metadata"])
-        self.assertIn("model", content)
-        self.assertIn("defs", content)
-        model = content["model"]
-        self.assertIsNotNone(re.fullmatch(r"dir://(?:.+)/model", model))
-        defs = content["defs"]
-        self.assertIsNotNone(re.fullmatch(r"dir://(?:.+)/defs", defs))
-        self.assertNotIn("dependencies", content)
+                self.assertIsNotNone(content)
+                self.assertIn("metadata", content)
+                self.assertIn("type.yaml", content["metadata"])
+                self.assertIn("schema.yaml", content["metadata"])
+                self.assertIn("sample_data.json", content["metadata"])
+                self.assertIn("model", content)
+                self.assertIn("defs", content)
+                model = content["model"]
+                self.assertIsNotNone(re.fullmatch(r"dir://(?:.+)/model", model))
+                defs = content["defs"]
+                self.assertIsNotNone(re.fullmatch(r"dir://(?:.+)/defs", defs))
+                self.assertNotIn("dependencies", content)
 
     def test_generate_raw_model_package_content_with_requirements(self):
         """It generates the raw model package content with requirements."""
@@ -87,3 +66,33 @@ class RawModelPackageTest(TestCase):
         self.assertIn("requirements.txt", content["dependencies"])
         requirements = content["dependencies"]["requirements.txt"]
         self.assertEqual(requirements, "numpy\ntorch")
+
+    def test_generate_raw_model_package_content_with_additional_import_prefixes(self):
+        """It serializes additional dynamically-imported module prefixes."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            content = generate_raw_model_package_content(
+                temp_dir,
+                "michelangelo.lib.model_manager._private.packager.custom_triton.tests.fixtures.predict.Predict",
+                ModelSchema(),
+                [{"input": np.array([1, 2])}],
+                include_import_prefixes=["michelangelo"],
+                additional_import_prefixes=[
+                    "michelangelo.lib.model_manager._private.utils.module_finder."
+                    "tests.fixtures.simple_module"
+                ],
+            )
+
+        defs_dir = content["defs"].removeprefix("dir://")
+        expected_file = os.path.join(
+            defs_dir,
+            "michelangelo",
+            "lib",
+            "model_manager",
+            "_private",
+            "utils",
+            "module_finder",
+            "tests",
+            "fixtures",
+            "simple_module.py",
+        )
+        self.assertTrue(os.path.exists(expected_file))

--- a/python/michelangelo/lib/model_manager/_private/packager/custom_triton/tests/validation_test.py
+++ b/python/michelangelo/lib/model_manager/_private/packager/custom_triton/tests/validation_test.py
@@ -57,132 +57,57 @@ class ValidationTest(TestCase):
             predict.save(src_model_path)
             self.generate_package(src_model_path, model_class, dest_model_path)
 
-    def test_validate_raw_model_package_predict_error(self):
-        """Test validation fails when model predict raises an error."""
-        predict = Predict("test_content")
-        model_class = (
-            "michelangelo.lib.model_manager._private.packager.custom_triton."
-            "tests.fixtures.model_for_validation.ModelWithPredictError"
-        )
-        with tempfile.TemporaryDirectory() as temp_dir:
-            src_model_path = os.path.join(temp_dir, "model")
-            dest_model_path = os.path.join(temp_dir, "model_package")
-            os.makedirs(src_model_path)
-            predict.save(src_model_path)
-            with self.assertRaisesRegex(
-                RuntimeError,
-                (
-                    "Error when validating the raw model package. "
-                    "Error when test prediction with the model"
-                ),
-            ):
-                self.generate_package(src_model_path, model_class, dest_model_path)
-
-    def test_validate_raw_model_package_invalid_output(self):
-        """Test validation fails when model output is invalid."""
-        predict = Predict("test_content")
-        model_class = (
-            "michelangelo.lib.model_manager._private.packager.custom_triton."
-            "tests.fixtures.model_for_validation.ModelWithInvalidOutput"
-        )
-        with tempfile.TemporaryDirectory() as temp_dir:
-            src_model_path = os.path.join(temp_dir, "model")
-            dest_model_path = os.path.join(temp_dir, "model_package")
-            os.makedirs(src_model_path)
-            predict.save(src_model_path)
-            with self.assertRaisesRegex(
-                RuntimeError,
-                (
-                    "Error when validating the raw model package. "
-                    "Error validating model output data"
-                ),
-            ):
-                self.generate_package(src_model_path, model_class, dest_model_path)
-
-    def test_validate_raw_model_package_output_not_matching_schema(self):
-        """Test validation fails when model output doesn't match schema."""
-        predict = Predict("test_content")
-        model_class = (
-            "michelangelo.lib.model_manager._private.packager.custom_triton."
-            "tests.fixtures.model_for_validation.ModelWithOutputNotMatchingSchema"
-        )
-        with tempfile.TemporaryDirectory() as temp_dir:
-            src_model_path = os.path.join(temp_dir, "model")
-            dest_model_path = os.path.join(temp_dir, "model_package")
-            os.makedirs(src_model_path)
-            predict.save(src_model_path)
-            with self.assertRaisesRegex(
-                RuntimeError,
-                (
-                    "Error when validating the raw model package. "
-                    "Error validating model output data. "
-                    "Data fields do not match schema"
-                ),
-            ):
-                self.generate_package(src_model_path, model_class, dest_model_path)
-
-    def test_validate_raw_model_package_with_save_error(self):
-        """Test validation fails when model save raises an error."""
-        predict = Predict("test_content")
-        model_class = (
-            "michelangelo.lib.model_manager._private.packager.custom_triton."
-            "tests.fixtures.model_for_validation.ModelWithSaveError"
-        )
-        with tempfile.TemporaryDirectory() as temp_dir:
-            src_model_path = os.path.join(temp_dir, "model")
-            dest_model_path = os.path.join(temp_dir, "model_package")
-            os.makedirs(src_model_path)
-            predict.save(src_model_path)
-            with self.assertRaisesRegex(
-                RuntimeError,
-                (
-                    "Error when validating the raw model package. "
-                    "Error when test saving the model"
-                ),
-            ):
-                self.generate_package(src_model_path, model_class, dest_model_path)
-
-    def test_validate_raw_model_package_with_reload_error(self):
-        """Test validation fails when model reload raises an error."""
-        predict = Predict("test_content")
-        model_class = (
-            "michelangelo.lib.model_manager._private.packager.custom_triton."
-            "tests.fixtures.model_for_validation.ModelWithReloadError"
-        )
-        with tempfile.TemporaryDirectory() as temp_dir:
-            src_model_path = os.path.join(temp_dir, "model")
-            dest_model_path = os.path.join(temp_dir, "model_package")
-            os.makedirs(src_model_path)
-            predict.save(src_model_path)
-            with self.assertRaisesRegex(
-                RuntimeError,
-                (
-                    "Error when validating the raw model package. "
-                    "Error when test reloading the saved model, please double check"
-                ),
-            ):
-                self.generate_package(src_model_path, model_class, dest_model_path)
-
-    def test_validate_raw_model_package_with_invalid_model_class_after_reload(self):
-        """Test validation fails when reloaded model is not the correct class."""
-        predict = Predict("test_content")
-        model_class = (
-            "michelangelo.lib.model_manager._private.packager.custom_triton."
-            "tests.fixtures.model_for_validation.ModelWithMismatchingLoad"
-        )
-        with tempfile.TemporaryDirectory() as temp_dir:
-            src_model_path = os.path.join(temp_dir, "model")
-            dest_model_path = os.path.join(temp_dir, "model_package")
-            os.makedirs(src_model_path)
-            predict.save(src_model_path)
-            with self.assertRaisesRegex(
-                RuntimeError,
-                (
-                    "Error when validating the raw model package. "
-                    "The loaded model is not an instance of"
-                ),
-            ):
-                self.generate_package(src_model_path, model_class, dest_model_path)
+    def test_validate_raw_model_package_error_cases(self):
+        """Test validation failure messages for various model error conditions."""
+        cases = [
+            (
+                "ModelWithPredictError",
+                "Error when validating the raw model package. "
+                "Error when test prediction with the model",
+            ),
+            (
+                "ModelWithInvalidOutput",
+                "Error when validating the raw model package. "
+                "Error validating model output data",
+            ),
+            (
+                "ModelWithOutputNotMatchingSchema",
+                "Error when validating the raw model package. "
+                "Error validating model output data. "
+                "Data fields do not match schema",
+            ),
+            (
+                "ModelWithSaveError",
+                "Error when validating the raw model package. "
+                "Error when test saving the model",
+            ),
+            (
+                "ModelWithReloadError",
+                "Error when validating the raw model package. "
+                "Error when test reloading the saved model, please double check",
+            ),
+            (
+                "ModelWithMismatchingLoad",
+                "Error when validating the raw model package. "
+                "The loaded model is not an instance of",
+            ),
+        ]
+        for class_suffix, expected_message in cases:
+            with self.subTest(class_suffix=class_suffix):
+                predict = Predict("test_content")
+                model_class = (
+                    "michelangelo.lib.model_manager._private.packager.custom_triton."
+                    f"tests.fixtures.model_for_validation.{class_suffix}"
+                )
+                with tempfile.TemporaryDirectory() as temp_dir:
+                    src_model_path = os.path.join(temp_dir, "model")
+                    dest_model_path = os.path.join(temp_dir, "model_package")
+                    os.makedirs(src_model_path)
+                    predict.save(src_model_path)
+                    with self.assertRaisesRegex(RuntimeError, expected_message):
+                        self.generate_package(
+                            src_model_path, model_class, dest_model_path
+                        )
 
     def test_validate_raw_model_package_without_sample_data(self):
         """Test validation of a raw model package without sample data."""

--- a/python/michelangelo/lib/model_manager/_private/packager/templates/triton/config.pbtxt.tmpl
+++ b/python/michelangelo/lib/model_manager/_private/packager/templates/triton/config.pbtxt.tmpl
@@ -35,6 +35,14 @@ output: [
   }{{ "," if not loop.last else "" }}
 {%- endfor %}
 ]
+{%- for key, value in (parameters | default({})).items() %}
+parameters: {
+  key: "{{ key }}"
+  value: {
+    string_value: "{{ value }}"
+  }
+}
+{%- endfor %}
 instance_group: [
   {
     kind: {% if backend == "tensorrt" %}KIND_GPU{% else %}KIND_CPU{% endif %},

--- a/python/michelangelo/lib/model_manager/_private/utils/module_finder/dependency_files.py
+++ b/python/michelangelo/lib/model_manager/_private/utils/module_finder/dependency_files.py
@@ -82,26 +82,44 @@ def find_dependency_files_internal(
 
     # if the module is a package
     if hasattr(package, "__path__"):
-        for importer, name, _ in pkgutil.walk_packages(package.__path__):
-            full_name = f"{module_name}.{name}"
+        # onerror=lambda _: None: pkgutil.walk_packages() re-raises any
+        # exception a submodule's __init__ raises at import time (not just
+        # ImportError -- e.g. stdlib's test.test_gdb raises SkipTest) unless
+        # given an error callback, which would otherwise abort this entire
+        # dependency walk over one unrelated, unimportable submodule.
+        #
+        # onerror only intercepts Exception subclasses, not SystemExit
+        # (BaseException, not Exception) -- and real-world packages ship
+        # __main__.py submodules with unguarded argparse/sys.exit() calls at
+        # import time (e.g. torch.utils.model_dump.__main__), which
+        # walk_packages() imports while probing whether it is itself a
+        # package. Wrap the walk too, so one such submodule doesn't abort
+        # dependency discovery for the rest of the package.
+        try:
+            for importer, name, _ in pkgutil.walk_packages(
+                package.__path__, onerror=lambda _: None
+            ):
+                full_name = f"{module_name}.{name}"
 
-            try:
-                sub_module = importlib.import_module(full_name)
-                files[full_name] = inspect.getfile(sub_module)
-            except (ImportError, TypeError, SystemExit):
-                pass
+                try:
+                    sub_module = importlib.import_module(full_name)
+                    files[full_name] = inspect.getfile(sub_module)
+                except (ImportError, TypeError, SystemExit):
+                    pass
 
-            init_file = os.path.join(importer.path, "__init__.py")
-            if os.path.exists(init_file):
-                files[f"{module_name}.__init__"] = init_file
+                init_file = os.path.join(importer.path, "__init__.py")
+                if os.path.exists(init_file):
+                    files[f"{module_name}.__init__"] = init_file
 
-            find_dependency_files_internal(
-                full_name,
-                files,
-                depth + 1,
-                prefixes,
-                max_depth,
-            )
+                find_dependency_files_internal(
+                    full_name,
+                    files,
+                    depth + 1,
+                    prefixes,
+                    max_depth,
+                )
+        except SystemExit:
+            pass
     # if the module is a file
     elif hasattr(package, "__file__"):
         files[module_name] = package.__file__

--- a/python/michelangelo/lib/model_manager/packager/custom_triton/custom_triton_packager.py
+++ b/python/michelangelo/lib/model_manager/packager/custom_triton/custom_triton_packager.py
@@ -45,7 +45,10 @@ class CustomTritonPackager:
             the model implementation.
     """
 
-    def __init__(self, custom_batch_processing: Optional[bool] = False):
+    def __init__(
+        self,
+        custom_batch_processing: Optional[bool] = False,
+    ):
         """Create a CustomTritonPackager instance.
 
         Args:
@@ -75,6 +78,9 @@ class CustomTritonPackager:
         model_revision: Optional[str] = None,
         model_path_source_type: Optional[str] = StorageType.LOCAL,
         include_import_prefixes: Optional[list[str]] = None,
+        additional_import_prefixes: Optional[list[str]] = None,
+        triton_parameters: Optional[dict[str, str]] = None,
+        sample_data: Optional[list[dict[str, ndarray]]] = None,
     ) -> str:
         """Create a Triton model package for deployment to Michelangelo Studio.
 
@@ -109,6 +115,22 @@ class CustomTritonPackager:
                 example, ['uber', 'data.michelangelo'] will only include modules
                 starting with 'uber' or 'data.michelangelo'. If None or empty,
                 all imported modules will be included.
+            additional_import_prefixes: Additional Python module prefixes
+                whose source files should be included in the model package.
+                Useful when the model class uses dynamic imports (e.g.
+                importlib) that are not captured by static import analysis.
+                Each prefix is recursively resolved and its files are
+                serialized into the package.
+            triton_parameters: Custom Triton model config parameters to
+                include in the generated config.pbtxt. Each key-value pair
+                becomes a ``parameters`` block in the config, e.g.
+                ``{"MY_CUSTOM_PARAM": "16"}``.
+            sample_data: Sample inputs for the model's predict method,
+                written to ``metadata/sample_data.json`` in the package for
+                reference. Each item is a dictionary mapping input feature
+                names to numpy arrays. Unless ``custom_batch_processing`` was
+                set on this packager, a leading batch dimension is added to
+                match what Triton passes to the model at serve time.
 
         Returns:
             The absolute path to the generated model package directory.
@@ -145,7 +167,10 @@ class CustomTritonPackager:
             model_path_source_type=model_path_source_type,
             root_path=dest_model_path,
             include_import_prefixes=include_import_prefixes,
+            additional_import_prefixes=additional_import_prefixes,
             custom_batch_processing=self.custom_batch_processing,
+            triton_parameters=triton_parameters,
+            sample_data=sample_data,
         )
 
         generate_folder(content, dest_model_path)
@@ -162,6 +187,7 @@ class CustomTritonPackager:
         model_path_source_type: Optional[str] = StorageType.LOCAL,
         requirements: Optional[Union[list[str], str]] = None,
         include_import_prefixes: Optional[list[str]] = None,
+        additional_import_prefixes: Optional[list[str]] = None,
     ) -> str:
         """Create a raw model package with sample data for testing.
 
@@ -207,6 +233,12 @@ class CustomTritonPackager:
                 example, ['uber', 'data.michelangelo'] will only include modules
                 starting with 'uber' or 'data.michelangelo'. If None or empty,
                 all imported modules will be included.
+            additional_import_prefixes: Additional Python module prefixes
+                whose source files should be included in the model package.
+                Useful when the model class uses dynamic imports (e.g.
+                importlib) that are not captured by static import analysis.
+                Each prefix is recursively resolved and its files are
+                serialized into the package.
 
         Returns:
             The absolute path to the generated raw model package directory.
@@ -256,6 +288,7 @@ class CustomTritonPackager:
             requirements=requirements,
             root_path=dest_model_path,
             include_import_prefixes=include_import_prefixes,
+            additional_import_prefixes=additional_import_prefixes,
             batch_inference=batch_inference,
         )
 

--- a/python/michelangelo/lib/model_manager/packager/custom_triton/tests/custom_triton_packager_test.py
+++ b/python/michelangelo/lib/model_manager/packager/custom_triton/tests/custom_triton_packager_test.py
@@ -1,14 +1,17 @@
 """Tests for CustomTritonPackager."""
 
 import importlib
+import json
 import os
 import pickle
 import tempfile
-from pathlib import Path
 from unittest import TestCase
 
 import numpy as np
 
+from michelangelo.lib.model_manager._private.packager.custom_triton.tests._helpers import (  # noqa: E501
+    list_relative_files,
+)
 from michelangelo.lib.model_manager._private.schema.common import schema_to_yaml
 from michelangelo.lib.model_manager.packager.custom_triton import CustomTritonPackager
 from michelangelo.lib.model_manager.packager.custom_triton.tests.fixtures.model import (
@@ -62,6 +65,36 @@ class CustomTritonPackagerTest(TestCase):
         packager = CustomTritonPackager()
         self.assertIsNotNone(packager)
 
+    def _assert_config_matches(self, dest_model_path, fixture_name="config.pbtxt"):
+        """Assert that the generated config.pbtxt matches a fixture."""
+        with (
+            open(
+                f"michelangelo/lib/model_manager/packager/custom_triton/tests/fixtures/{fixture_name}"
+            ) as expected_f,
+            open(os.path.join(dest_model_path, "config.pbtxt")) as f,
+        ):
+            expected_config = expected_f.read()
+            config = f.read()
+            self.assertEqual(config, expected_config)
+
+    def _load_predict_obj(self, dest_model_path):
+        """Load and instantiate the packaged model's predict class."""
+        with open(os.path.join(dest_model_path, "0", "model_class.txt")) as f:
+            loaded_model_class = f.read().strip()
+
+        module_def, _, class_name = loaded_model_class.rpartition(".")
+        module = importlib.import_module(module_def)
+        predict_class = getattr(module, class_name)
+        return predict_class()
+
+    def _assert_predict_roundtrip(self, dest_model_path, sample_data):
+        """Assert that the packaged model's predict function echoes its input."""
+        predict_obj = self._load_predict_obj(dest_model_path)
+        self.assertEqual(
+            predict_obj.predict(sample_data),
+            {"response": sample_data.get("input")},
+        )
+
     def assert_model_package(self, dest_model_path):
         """Assert that the model package has the expected structure."""
         with open(os.path.join(dest_model_path, "0", "model_class.txt")) as f:
@@ -97,15 +130,7 @@ class CustomTritonPackagerTest(TestCase):
             content = f.read()
             self.assertIn("class Predict(Model):", content)
 
-        files = sorted(
-            [
-                str(
-                    Path(os.path.join(dirpath, file)).relative_to(dest_model_path),
-                )
-                for dirpath, _, filenames in os.walk(dest_model_path)
-                for file in filenames
-            ],
-        )
+        files = list_relative_files(dest_model_path)
 
         package_files = [
             "0/model.py",
@@ -148,29 +173,8 @@ class CustomTritonPackagerTest(TestCase):
 
             self.assert_model_package(dest_model_path)
 
-            with (
-                open(
-                    "michelangelo/lib/model_manager/packager/custom_triton/tests/fixtures/config.pbtxt"
-                ) as expected_f,
-                open(os.path.join(dest_model_path, "config.pbtxt")) as f,
-            ):
-                expected_config = expected_f.read()
-                config = f.read()
-                self.assertEqual(config, expected_config)
-
-            # running the predict function
-            loaded_model_class = None
-            with open(os.path.join(dest_model_path, "0", "model_class.txt")) as f:
-                loaded_model_class = f.read().strip()
-
-            module_def, _, class_name = loaded_model_class.rpartition(".")
-            module = importlib.import_module(module_def)
-            predict_class = getattr(module, class_name)
-            predict_obj = predict_class()
-            self.assertEqual(
-                predict_obj.predict(self.sample_data[0]),
-                {"response": self.sample_data[0].get("input")},
-            )
+            self._assert_config_matches(dest_model_path)
+            self._assert_predict_roundtrip(dest_model_path, self.sample_data[0])
 
     def test_create_model_package_without_dest_model_path(self):
         """It creates a model package without a destination model path."""
@@ -190,29 +194,8 @@ class CustomTritonPackagerTest(TestCase):
 
             self.assert_model_package(dest_model_path)
 
-            with (
-                open(
-                    "michelangelo/lib/model_manager/packager/custom_triton/tests/fixtures/config.pbtxt"
-                ) as expected_f,
-                open(os.path.join(dest_model_path, "config.pbtxt")) as f,
-            ):
-                expected_config = expected_f.read()
-                config = f.read()
-                self.assertEqual(config, expected_config)
-
-            # running the predict function
-            loaded_model_class = None
-            with open(os.path.join(dest_model_path, "0", "model_class.txt")) as f:
-                loaded_model_class = f.read().strip()
-
-            module_def, _, class_name = loaded_model_class.rpartition(".")
-            module = importlib.import_module(module_def)
-            predict_class = getattr(module, class_name)
-            predict_obj = predict_class()
-            self.assertEqual(
-                predict_obj.predict(self.sample_data[0]),
-                {"response": self.sample_data[0].get("input")},
-            )
+            self._assert_config_matches(dest_model_path)
+            self._assert_predict_roundtrip(dest_model_path, self.sample_data[0])
 
     def test_create_model_package_with_no_name(self):
         """It creates a model package with no name."""
@@ -232,29 +215,10 @@ class CustomTritonPackagerTest(TestCase):
             )
             self.assert_model_package(dest_model_path)
 
-            with (
-                open(
-                    "michelangelo/lib/model_manager/packager/custom_triton/tests/fixtures/config_no_name.pbtxt"
-                ) as expected_f,
-                open(os.path.join(dest_model_path, "config.pbtxt")) as f,
-            ):
-                expected_config = expected_f.read()
-                config = f.read()
-                self.assertEqual(config, expected_config)
-
-            # running the predict function
-            loaded_model_class = None
-            with open(os.path.join(dest_model_path, "0", "model_class.txt")) as f:
-                loaded_model_class = f.read().strip()
-
-            module_def, _, class_name = loaded_model_class.rpartition(".")
-            module = importlib.import_module(module_def)
-            predict_class = getattr(module, class_name)
-            predict_obj = predict_class()
-            self.assertEqual(
-                predict_obj.predict(self.sample_data[0]),
-                {"response": self.sample_data[0].get("input")},
+            self._assert_config_matches(
+                dest_model_path, fixture_name="config_no_name.pbtxt"
             )
+            self._assert_predict_roundtrip(dest_model_path, self.sample_data[0])
 
     def test_create_model_package_with_custom_batch_processing(self):
         """It creates a model package with custom batch processing."""
@@ -276,29 +240,93 @@ class CustomTritonPackagerTest(TestCase):
 
             self.assert_model_package(dest_model_path)
 
-            with (
-                open(
-                    "michelangelo/lib/model_manager/packager/custom_triton/tests/fixtures/config.pbtxt"
-                ) as expected_f,
-                open(os.path.join(dest_model_path, "config.pbtxt")) as f,
-            ):
-                expected_config = expected_f.read()
-                config = f.read()
-                self.assertEqual(config, expected_config)
+            self._assert_config_matches(dest_model_path)
+            self._assert_predict_roundtrip(dest_model_path, self.batch_sample_data[0])
 
-            # running the predict function
-            loaded_model_class = None
-            with open(os.path.join(dest_model_path, "0", "model_class.txt")) as f:
-                loaded_model_class = f.read().strip()
-
-            module_def, _, class_name = loaded_model_class.rpartition(".")
-            module = importlib.import_module(module_def)
-            predict_class = getattr(module, class_name)
-            predict_obj = predict_class()
-            self.assertEqual(
-                predict_obj.predict(self.batch_sample_data[0]),
-                {"response": self.batch_sample_data[0].get("input")},
+    def test_create_model_package_with_sample_data(self):
+        """It writes sample_data.json with an added batch dimension."""
+        packager = CustomTritonPackager()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            model_path = os.path.join(temp_dir, "model")
+            dest_model_path = os.path.join(temp_dir, "deployable_model")
+            os.makedirs(model_path)
+            with open(os.path.join(model_path, "file.txt"), "w") as f:
+                f.write("file_content")
+            dest_model_path = packager.create_model_package(
+                model_path=model_path,
+                dest_model_path=dest_model_path,
+                model_class=model_class,
+                model_schema=self.model_schema,
+                model_name="test_model_name",
+                include_import_prefixes=["michelangelo"],
+                sample_data=self.sample_data,
             )
+
+            with open(
+                os.path.join(dest_model_path, "metadata", "sample_data.json")
+            ) as f:
+                loaded = json.loads(f.read())
+            self.assertEqual(loaded[0]["input"], [[1]])
+
+    def test_create_model_package_with_triton_parameters(self):
+        """It threads triton_parameters into the generated config.pbtxt."""
+        packager = CustomTritonPackager()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            model_path = os.path.join(temp_dir, "model")
+            dest_model_path = os.path.join(temp_dir, "deployable_model")
+            os.makedirs(model_path)
+            with open(os.path.join(model_path, "file.txt"), "w") as f:
+                f.write("file_content")
+            dest_model_path = packager.create_model_package(
+                model_path=model_path,
+                dest_model_path=dest_model_path,
+                model_class=model_class,
+                model_schema=self.model_schema,
+                model_name="test_model_name",
+                include_import_prefixes=["michelangelo"],
+                triton_parameters={"MY_CUSTOM_PARAM": "16"},
+            )
+
+            with open(os.path.join(dest_model_path, "config.pbtxt")) as f:
+                config = f.read()
+            self.assertIn('key: "MY_CUSTOM_PARAM"', config)
+
+    def test_create_model_package_with_additional_import_prefixes(self):
+        """It serializes additional dynamically-imported module prefixes."""
+        packager = CustomTritonPackager()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            model_path = os.path.join(temp_dir, "model")
+            dest_model_path = os.path.join(temp_dir, "deployable_model")
+            os.makedirs(model_path)
+            with open(os.path.join(model_path, "file.txt"), "w") as f:
+                f.write("file_content")
+            dest_model_path = packager.create_model_package(
+                model_path=model_path,
+                dest_model_path=dest_model_path,
+                model_class=model_class,
+                model_schema=self.model_schema,
+                model_name="test_model_name",
+                include_import_prefixes=["michelangelo"],
+                additional_import_prefixes=[
+                    "michelangelo.lib.model_manager._private.utils.module_finder."
+                    "tests.fixtures.simple_module"
+                ],
+            )
+
+            expected_file = os.path.join(
+                dest_model_path,
+                "0",
+                "michelangelo",
+                "lib",
+                "model_manager",
+                "_private",
+                "utils",
+                "module_finder",
+                "tests",
+                "fixtures",
+                "simple_module.py",
+            )
+            self.assertTrue(os.path.exists(expected_file))
 
     def test_create_model_package_with_empty_model_schema(self):
         """It raises ValueError when model schema is empty."""
@@ -387,15 +415,7 @@ class CustomTritonPackagerTest(TestCase):
                 ],
             )
 
-            files = sorted(
-                [
-                    str(
-                        Path(os.path.join(dirpath, file)).relative_to(dest_model_path),
-                    )
-                    for dirpath, _, filenames in os.walk(dest_model_path)
-                    for file in filenames
-                ],
-            )
+            files = list_relative_files(dest_model_path)
 
             package_files = [
                 "0/model.py",
@@ -465,15 +485,7 @@ class CustomTritonPackagerTest(TestCase):
                 content = f.read()
                 self.assertIn("class Predict(Model):", content)
 
-            files = sorted(
-                [
-                    str(
-                        Path(os.path.join(dirpath, file)).relative_to(dest_model_path),
-                    )
-                    for dirpath, _, filenames in os.walk(dest_model_path)
-                    for file in filenames
-                ],
-            )
+            files = list_relative_files(dest_model_path)
 
             package_files = [
                 "0/model.py",
@@ -496,25 +508,9 @@ class CustomTritonPackagerTest(TestCase):
             expected_files = sorted(package_files + self.model_loader_files)
             self.assertEqual(files, expected_files)
 
-            with (
-                open(
-                    "michelangelo/lib/model_manager/packager/custom_triton/tests/fixtures/config.pbtxt"
-                ) as expected_f,
-                open(os.path.join(dest_model_path, "config.pbtxt")) as f,
-            ):
-                expected_config = expected_f.read()
-                config = f.read()
-                self.assertEqual(config, expected_config)
+            self._assert_config_matches(dest_model_path)
 
-            # running the predict function
-            loaded_model_class = None
-            with open(os.path.join(dest_model_path, "0", "model_class.txt")) as f:
-                loaded_model_class = f.read().strip()
-
-            module_def, _, class_name = loaded_model_class.rpartition(".")
-            module = importlib.import_module(module_def)
-            predict_class = getattr(module, class_name)
-            predict_obj = predict_class()
+            predict_obj = self._load_predict_obj(dest_model_path)
             model_path = os.path.join(dest_model_path, "0", "model")
             self.assertEqual(predict_obj.predict(model_path), model_path)
 
@@ -539,15 +535,7 @@ class CustomTritonPackagerTest(TestCase):
                 include_import_prefixes=["michelangelo"],
             )
 
-            files = sorted(
-                [
-                    str(
-                        Path(os.path.join(dirpath, file)).relative_to(dest_model_path),
-                    )
-                    for dirpath, _, filenames in os.walk(dest_model_path)
-                    for file in filenames
-                ],
-            )
+            files = list_relative_files(dest_model_path)
 
             package_files = [
                 "0/model.py",
@@ -588,15 +576,7 @@ class CustomTritonPackagerTest(TestCase):
                 include_import_prefixes=["michelangelo"],
             )
 
-            with (
-                open(
-                    "michelangelo/lib/model_manager/packager/custom_triton/tests/fixtures/config.pbtxt"
-                ) as expected_f,
-                open(os.path.join(dest_model_path, "config.pbtxt")) as f,
-            ):
-                expected_config = expected_f.read()
-                config = f.read()
-                self.assertEqual(config, expected_config)
+            self._assert_config_matches(dest_model_path)
 
             self.assertTrue(os.path.exists(os.path.join(dest_model_path, "0", "model")))
             self.assertEqual(
@@ -652,15 +632,7 @@ class CustomTritonPackagerTest(TestCase):
             else:
                 self.assertEqual(content, '[{"input": [1]}]')
 
-        files = sorted(
-            [
-                str(
-                    Path(os.path.join(dirpath, file)).relative_to(dest_model_path),
-                )
-                for dirpath, _, filenames in os.walk(dest_model_path)
-                for file in filenames
-            ],
-        )
+        files = list_relative_files(dest_model_path)
 
         expected_files = [
             "defs/michelangelo/lib/model_manager/_private/utils/module_finder/tests/fixtures/folder/fn1.py",
@@ -725,6 +697,43 @@ class CustomTritonPackagerTest(TestCase):
                 include_import_prefixes=["michelangelo"],
             )
             self.assert_raw_model_package(dest_model_path, batch_inference=True)
+
+    def test_create_raw_model_package_with_additional_import_prefixes(self):
+        """It serializes additional dynamically-imported module prefixes."""
+        packager = CustomTritonPackager()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            model_path = os.path.join(temp_dir, "model")
+            dest_model_path = os.path.join(temp_dir, "raw_model")
+            os.makedirs(model_path)
+            with open(os.path.join(model_path, "file.txt"), "w") as f:
+                f.write("file_content")
+            dest_model_path = packager.create_raw_model_package(
+                model_path=model_path,
+                model_class=model_class,
+                model_schema=self.model_schema,
+                sample_data=self.sample_data,
+                dest_model_path=dest_model_path,
+                include_import_prefixes=["michelangelo"],
+                additional_import_prefixes=[
+                    "michelangelo.lib.model_manager._private.utils.module_finder."
+                    "tests.fixtures.simple_module"
+                ],
+            )
+
+            expected_file = os.path.join(
+                dest_model_path,
+                "defs",
+                "michelangelo",
+                "lib",
+                "model_manager",
+                "_private",
+                "utils",
+                "module_finder",
+                "tests",
+                "fixtures",
+                "simple_module.py",
+            )
+            self.assertTrue(os.path.exists(expected_file))
 
     def test_create_raw_model_package_with_empty_model_schema(self):
         """It creates a raw model package with empty model schema."""
@@ -860,15 +869,7 @@ class CustomTritonPackagerTest(TestCase):
                 ],
             )
 
-            files = sorted(
-                [
-                    str(
-                        Path(os.path.join(dirpath, file)).relative_to(dest_model_path),
-                    )
-                    for dirpath, _, filenames in os.walk(dest_model_path)
-                    for file in filenames
-                ],
-            )
+            files = list_relative_files(dest_model_path)
 
             self.assertEqual(
                 files,
@@ -908,15 +909,7 @@ class CustomTritonPackagerTest(TestCase):
                 include_import_prefixes=["michelangelo"],
             )
 
-            files = sorted(
-                [
-                    str(
-                        Path(os.path.join(dirpath, file)).relative_to(dest_model_path),
-                    )
-                    for dirpath, _, filenames in os.walk(dest_model_path)
-                    for file in filenames
-                ],
-            )
+            files = list_relative_files(dest_model_path)
 
             self.assertEqual(
                 files,

--- a/python/michelangelo/lib/model_manager/schema/data_type.py
+++ b/python/michelangelo/lib/model_manager/schema/data_type.py
@@ -19,6 +19,10 @@ class DataType(Enum):
             schemas.
         UNKNOWN: Unknown data type. May be used as a placeholder during schema
             inference.
+        NUMERIC: Generic numeric value of unspecified precision. Used by
+            fused/derived schemas (e.g. tabular feature fusion) where the
+            concrete numeric width is decided downstream. Maps to float64 in
+            NumPy/PyTorch; not a Triton wire type on its own.
         BOOLEAN: Boolean values (True/False). Maps to bool in Python and
             BOOL in Triton.
         STRING: String/text data. Maps to str in Python and BYTES in Triton.
@@ -37,6 +41,7 @@ class DataType(Enum):
 
     INVALID = 0
     UNKNOWN = 1
+    NUMERIC = 2
     BOOLEAN = 4
     STRING = 7
     BYTE = 15

--- a/python/michelangelo/lib/model_manager/schema/tests/data_type_test.py
+++ b/python/michelangelo/lib/model_manager/schema/tests/data_type_test.py
@@ -12,3 +12,31 @@ class DataTypeTest(TestCase):
         """It iterates over DataType members without errors."""
         for data_type in DataType:
             self.assertIsInstance(data_type, DataType)
+
+    def test_data_type_values_match_schema_proto(self):
+        """It assigns enum values matching the schema protobuf definition.
+
+        Only the Triton-relevant/OSS-public subset is defined here (see
+        ``proto/api/v2/schema.proto``); the numeric values below intentionally
+        skip the gaps reserved by that proto's own DataType enum. ``NUMERIC``
+        is the one exception -- it has no proto/wire representation (see its
+        docstring) and is used purely for internal fused-schema bookkeeping.
+        """
+        expected_values = {
+            "INVALID": 0,
+            "UNKNOWN": 1,
+            "NUMERIC": 2,
+            "BOOLEAN": 4,
+            "STRING": 7,
+            "BYTE": 15,
+            "CHAR": 16,
+            "SHORT": 17,
+            "INT": 18,
+            "LONG": 19,
+            "FLOAT": 20,
+            "DOUBLE": 21,
+        }
+        for name, value in expected_values.items():
+            with self.subTest(name=name):
+                self.assertEqual(DataType[name].value, value)
+        self.assertEqual({dt.name for dt in DataType}, set(expected_values))

--- a/python/michelangelo/lib/model_manager/utils/__init__.py
+++ b/python/michelangelo/lib/model_manager/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility helpers for the model manager package."""

--- a/python/michelangelo/lib/model_manager/utils/torch/__init__.py
+++ b/python/michelangelo/lib/model_manager/utils/torch/__init__.py
@@ -1,0 +1,7 @@
+"""PyTorch-specific conversion utilities for the model manager package."""
+
+# flake8: noqa:F401
+from michelangelo.lib.model_manager.utils.torch.data_type import (
+    data_type_to_torch_dtype,
+    torch_dtype_to_data_type,
+)

--- a/python/michelangelo/lib/model_manager/utils/torch/data_type.py
+++ b/python/michelangelo/lib/model_manager/utils/torch/data_type.py
@@ -1,0 +1,74 @@
+"""Conversions between ModelSchema DataType and torch.dtype."""
+
+import torch
+
+from michelangelo.lib.model_manager.schema import DataType
+
+_DATA_TYPE_TO_TORCH_DTYPE: dict[DataType, torch.dtype] = {
+    DataType.FLOAT: torch.float32,
+    DataType.DOUBLE: torch.float64,
+    DataType.INT: torch.int32,
+    DataType.SHORT: torch.int16,
+    DataType.BYTE: torch.int8,
+    DataType.LONG: torch.int64,
+    DataType.BOOLEAN: torch.bool,
+    # NUMERIC is a generic, unspecified-precision numeric type used by fused
+    # schemas; widen to float64 so no precision is lost.
+    DataType.NUMERIC: torch.float64,
+}
+
+_TORCH_DTYPE_TO_DATA_TYPE: dict[torch.dtype, DataType] = {
+    torch.float32: DataType.FLOAT,
+    torch.float64: DataType.DOUBLE,
+    torch.int32: DataType.INT,
+    torch.int16: DataType.SHORT,
+    torch.int8: DataType.BYTE,
+    torch.int64: DataType.LONG,
+    torch.bool: DataType.BOOLEAN,
+}
+
+
+def data_type_to_torch_dtype(data_type: DataType) -> torch.dtype:
+    """Map a ModelSchema DataType to the equivalent torch.dtype.
+
+    Used when building sample tensors (e.g. for tracing/scripting) from a
+    ModelSchema whose feature types are expressed as DataType values.
+
+    Args:
+        data_type: The ModelSchema data type to convert.
+
+    Returns:
+        The equivalent torch.dtype.
+
+    Raises:
+        ValueError: If ``data_type`` has no torch.dtype equivalent.
+    """
+    if data_type not in _DATA_TYPE_TO_TORCH_DTYPE:
+        raise ValueError(f"Cannot convert data type {data_type} to torch.dtype")
+    return _DATA_TYPE_TO_TORCH_DTYPE[data_type]
+
+
+def torch_dtype_to_data_type(dtype: torch.dtype) -> DataType:
+    """Map a torch.dtype to the equivalent ModelSchema DataType.
+
+    Note: float16 (half) and bfloat16 are not yet supported — ModelSchema has
+    no corresponding DataType for reduced-precision floats.
+    # TODO: support torch.float16 and torch.bfloat16 once DataType gains
+    # FLOAT16 / BFLOAT16 variants.
+
+    Args:
+        dtype: The torch.dtype to convert.
+
+    Returns:
+        The equivalent ModelSchema DataType.
+
+    Raises:
+        ValueError: If ``dtype`` has no DataType equivalent (including
+            torch.float16 and torch.bfloat16, which are not yet supported).
+    """
+    if dtype not in _TORCH_DTYPE_TO_DATA_TYPE:
+        raise ValueError(
+            f"Cannot convert torch.dtype {dtype} to DataType. "
+            f"float16 and bfloat16 are not yet supported."
+        )
+    return _TORCH_DTYPE_TO_DATA_TYPE[dtype]

--- a/python/michelangelo/lib/model_manager/utils/torch/tests/__init__.py
+++ b/python/michelangelo/lib/model_manager/utils/torch/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the torch conversion utilities."""

--- a/python/michelangelo/lib/model_manager/utils/torch/tests/data_type_test.py
+++ b/python/michelangelo/lib/model_manager/utils/torch/tests/data_type_test.py
@@ -1,0 +1,101 @@
+"""Tests for data_type_to_torch_dtype and torch_dtype_to_data_type."""
+
+from unittest import TestCase
+
+import torch
+
+from michelangelo.lib.model_manager.schema import DataType
+from michelangelo.lib.model_manager.utils.torch.data_type import (
+    data_type_to_torch_dtype,
+    torch_dtype_to_data_type,
+)
+
+
+class DataTypeToTorchDtypeTest(TestCase):
+    """Tests for data_type_to_torch_dtype mapping."""
+
+    def test_float_maps_to_float32(self):
+        """It maps DataType.FLOAT to torch.float32."""
+        self.assertEqual(data_type_to_torch_dtype(DataType.FLOAT), torch.float32)
+
+    def test_double_maps_to_float64(self):
+        """It maps DataType.DOUBLE to torch.float64."""
+        self.assertEqual(data_type_to_torch_dtype(DataType.DOUBLE), torch.float64)
+
+    def test_int_maps_to_int32(self):
+        """It maps DataType.INT to torch.int32."""
+        self.assertEqual(data_type_to_torch_dtype(DataType.INT), torch.int32)
+
+    def test_short_maps_to_int16(self):
+        """It maps DataType.SHORT to torch.int16."""
+        self.assertEqual(data_type_to_torch_dtype(DataType.SHORT), torch.int16)
+
+    def test_byte_maps_to_int8(self):
+        """It maps DataType.BYTE to torch.int8."""
+        self.assertEqual(data_type_to_torch_dtype(DataType.BYTE), torch.int8)
+
+    def test_long_maps_to_int64(self):
+        """It maps DataType.LONG to torch.int64."""
+        self.assertEqual(data_type_to_torch_dtype(DataType.LONG), torch.int64)
+
+    def test_boolean_maps_to_bool(self):
+        """It maps DataType.BOOLEAN to torch.bool."""
+        self.assertEqual(data_type_to_torch_dtype(DataType.BOOLEAN), torch.bool)
+
+    def test_numeric_maps_to_float64(self):
+        """It maps DataType.NUMERIC to torch.float64."""
+        self.assertEqual(data_type_to_torch_dtype(DataType.NUMERIC), torch.float64)
+
+    def test_unsupported_data_type_raises_value_error(self):
+        """It raises ValueError for a DataType with no torch.dtype mapping."""
+        with self.assertRaises(ValueError) as ctx:
+            data_type_to_torch_dtype(DataType.STRING)
+        self.assertIn("Cannot convert data type", str(ctx.exception))
+        self.assertIn("STRING", str(ctx.exception))
+
+    def test_unknown_raises_value_error(self):
+        """It raises ValueError for DataType.UNKNOWN."""
+        with self.assertRaises(ValueError) as ctx:
+            data_type_to_torch_dtype(DataType.UNKNOWN)
+        self.assertIn("Cannot convert data type", str(ctx.exception))
+
+    def test_invalid_raises_value_error(self):
+        """It raises ValueError for DataType.INVALID."""
+        with self.assertRaises(ValueError):
+            data_type_to_torch_dtype(DataType.INVALID)
+
+
+class TorchDtypeToDataTypeTest(TestCase):
+    """Tests for torch_dtype_to_data_type mapping."""
+
+    def test_supported_dtypes(self):
+        """It maps each supported torch.dtype back to its DataType."""
+        cases = [
+            (torch.float32, DataType.FLOAT),
+            (torch.float64, DataType.DOUBLE),
+            (torch.int32, DataType.INT),
+            (torch.int16, DataType.SHORT),
+            (torch.int8, DataType.BYTE),
+            (torch.int64, DataType.LONG),
+            (torch.bool, DataType.BOOLEAN),
+        ]
+        for dtype, expected in cases:
+            with self.subTest(dtype=dtype):
+                self.assertEqual(torch_dtype_to_data_type(dtype), expected)
+
+    def test_float16_raises(self):
+        """It raises ValueError for torch.float16 (not yet supported)."""
+        with self.assertRaises(ValueError) as ctx:
+            torch_dtype_to_data_type(torch.float16)
+        self.assertIn("float16", str(ctx.exception))
+
+    def test_bfloat16_raises(self):
+        """It raises ValueError for torch.bfloat16 (not yet supported)."""
+        with self.assertRaises(ValueError) as ctx:
+            torch_dtype_to_data_type(torch.bfloat16)
+        self.assertIn("bfloat16", str(ctx.exception))
+
+    def test_unsupported_dtype_raises(self):
+        """It raises ValueError for a dtype with no DataType equivalent."""
+        with self.assertRaises(ValueError):
+            torch_dtype_to_data_type(torch.complex64)


### PR DESCRIPTION
Stack: 1/5 of the tabular assembler migration. Base for the rest of the stack.

## Summary
- Adds a torch<->`ModelSchema` `DataType` conversion layer
- Adds additional-import serialization for dynamic-import module bundling in the custom Triton packager
- Extends `CustomTritonPackager` with `additional_import_prefixes`, `sample_data`, and `triton_parameters`

No assembler-specific code — pure packager/utility surface, independently testable.

## Test plan
- [ ] `pytest python/michelangelo/lib/model_manager` for the touched packager/utils modules