### PR TITLE
Tabular assembler migration 2/5: assembler config schema

### DIFF
--- a/python/michelangelo/workflow/schema/assembler.py
+++ b/python/michelangelo/workflow/schema/assembler.py
@@ -1,0 +1,114 @@
+"""Typed configuration dataclasses for the tabular assembler task.
+
+Each dataclass configures one framework-specific assembler path (custom
+Python-backend or PyTorch/Lightning) or, for ``TabularAssemblerConfig``,
+selects between them. Plain dataclasses (rather than a pydantic/ORM model)
+keep validation, serialisation, and inspection by the workflow engine simple
+and dependency-free at pipeline-definition time.
+
+Consumers may subclass these to add provider-specific fields (e.g. a custom
+storage toggle) without modifying this module.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = [
+    "CustomAssemblerConfig",
+    "TabularAssemblerConfig",
+    "TorchAssemblerConfig",
+]
+
+
+@dataclass
+class CustomAssemblerConfig:
+    """Configuration for the custom (Python-backend) assembler path.
+
+    Attributes:
+        custom_batch_processing: When ``True``, the model implementation
+            handles batching itself and receives inputs with an extra leading
+            batch dimension on top of the model schema (schema shape
+            ``[n, ..., m]`` becomes ``[batch, n, ..., m]``). When
+            ``None``/``False``, Triton batches automatically and the model
+            sees schema-shaped inputs.
+        additional_import_prefixes: Extra Python module prefixes whose source
+            files are bundled into the package. Useful when the model class
+            uses dynamic imports (e.g. ``importlib``) that static analysis
+            misses. Each prefix is resolved recursively.
+        include_import_prefixes: Module prefixes the packager's static import
+            analysis is restricted to when deciding which of the model
+            class's imported modules to bundle. When ``None`` (the default),
+            every reachable imported module is considered, which is
+            unbounded and can be extremely slow in environments with a very
+            large importable module graph (e.g. a monorepo where the model
+            class's own package pulls in thousands of transitively-importable
+            modules) — set this to scope the walk to the module prefixes that
+            actually matter for the model (e.g. an internal caller with a
+            single top-level namespace might pass that namespace's prefix).
+
+    Example:
+        >>> CustomAssemblerConfig(custom_batch_processing=True).custom_batch_processing
+        True
+    """
+
+    custom_batch_processing: bool | None = None
+    additional_import_prefixes: list[str] | None = None
+    include_import_prefixes: list[str] | None = None
+
+
+@dataclass
+class TorchAssemblerConfig:
+    """Configuration for the PyTorch/Lightning assembler path.
+
+    Attributes:
+        backend: Triton backend used for the deployable package — one of
+            ``"pytorch"``, ``"tensorrt"``, ``"python"``, ``"onnxruntime"``.
+            ``None`` selects the packager default (TorchScript/PyTorch).
+            Validation of supported values is performed by the packager, not
+            here, to keep a single source of truth.
+        include_import_prefixes: Module prefixes the packager's static import
+            analysis is restricted to when deciding which of the model
+            class's imported modules to bundle. When ``None`` (the default),
+            every reachable imported module is considered, which is
+            unbounded and can be extremely slow (or reach unrelated,
+            side-effecting modules) in environments with a very large
+            importable module graph — set this to scope the walk to the
+            module prefixes that actually matter for the model. Mirrors
+            ``CustomAssemblerConfig.include_import_prefixes``.
+
+    Example:
+        >>> TorchAssemblerConfig(backend="onnxruntime")
+        TorchAssemblerConfig(backend='onnxruntime')
+    """
+
+    backend: str | None = None
+    include_import_prefixes: list[str] | None = None
+
+
+@dataclass
+class TabularAssemblerConfig:
+    """Top-level configuration for the tabular assembler task.
+
+    Selects and parameterises the framework-specific assembler path.
+    ``custom`` and ``torch`` carry path-specific options; ``model_class``
+    overrides the model class resolved from the trained model's metadata.
+
+    Attributes:
+        model_class: Fully-qualified model class (e.g.
+            ``"mypkg.models.MyModel"``). When set, overrides the class
+            recorded in the trained model's metadata and can force the
+            custom path.
+        custom: Options for the custom (Python-backend) path.
+        torch: Options for the PyTorch/Lightning path.
+
+    Example:
+        >>> torch_cfg = TorchAssemblerConfig(backend="pytorch")
+        >>> config = TabularAssemblerConfig(torch=torch_cfg)
+        >>> config.torch.backend
+        'pytorch'
+    """
+
+    model_class: str | None = None
+    custom: CustomAssemblerConfig | None = None
+    torch: TorchAssemblerConfig | None = None

--- a/python/michelangelo/workflow/schema/tests/assembler_test.py
+++ b/python/michelangelo/workflow/schema/tests/assembler_test.py
@@ -1,0 +1,154 @@
+"""Tests for michelangelo.workflow.schema.assembler config dataclasses."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from unittest import TestCase
+
+from michelangelo.workflow.schema.assembler import (
+    CustomAssemblerConfig,
+    TabularAssemblerConfig,
+    TorchAssemblerConfig,
+)
+
+
+class TestCustomAssemblerConfig(TestCase):
+    """Tests for CustomAssemblerConfig defaults and equality."""
+
+    def test_defaults(self):
+        """All fields default to None."""
+        cfg = CustomAssemblerConfig()
+        self.assertIsNone(cfg.custom_batch_processing)
+        self.assertIsNone(cfg.additional_import_prefixes)
+        self.assertIsNone(cfg.include_import_prefixes)
+
+    def test_field_assignment(self):
+        """Fields are set from constructor arguments."""
+        cfg = CustomAssemblerConfig(
+            custom_batch_processing=True,
+            additional_import_prefixes=["mypkg.util"],
+            include_import_prefixes=["mypkg.models"],
+        )
+        self.assertTrue(cfg.custom_batch_processing)
+        self.assertEqual(cfg.additional_import_prefixes, ["mypkg.util"])
+        self.assertEqual(cfg.include_import_prefixes, ["mypkg.models"])
+
+    def test_equality(self):
+        """Two configs with the same fields compare equal."""
+        self.assertEqual(
+            CustomAssemblerConfig(custom_batch_processing=True),
+            CustomAssemblerConfig(custom_batch_processing=True),
+        )
+
+    def test_asdict_round_trip(self):
+        """The config is serialisable via dataclasses.asdict."""
+        cfg = CustomAssemblerConfig(custom_batch_processing=True)
+        self.assertEqual(
+            asdict(cfg),
+            {
+                "custom_batch_processing": True,
+                "additional_import_prefixes": None,
+                "include_import_prefixes": None,
+            },
+        )
+
+
+class TestTorchAssemblerConfig(TestCase):
+    """Tests for TorchAssemblerConfig defaults and equality."""
+
+    def test_defaults(self):
+        """The backend field defaults to None."""
+        cfg = TorchAssemblerConfig()
+        self.assertIsNone(cfg.backend)
+
+    def test_field_assignment(self):
+        """The backend field is set from the constructor argument."""
+        cfg = TorchAssemblerConfig(backend="onnxruntime")
+        self.assertEqual(cfg.backend, "onnxruntime")
+
+    def test_equality(self):
+        """Two configs with the same backend compare equal."""
+        self.assertEqual(
+            TorchAssemblerConfig(backend="pytorch"),
+            TorchAssemblerConfig(backend="pytorch"),
+        )
+
+    def test_asdict_round_trip(self):
+        """The config is serialisable via dataclasses.asdict."""
+        cfg = TorchAssemblerConfig(backend="pytorch")
+        self.assertEqual(
+            asdict(cfg),
+            {"backend": "pytorch", "include_import_prefixes": None},
+        )
+
+
+class TestTabularAssemblerConfig(TestCase):
+    """Tests for TabularAssemblerConfig defaults, nesting, and extensibility."""
+
+    def test_defaults(self):
+        """All fields default to None."""
+        cfg = TabularAssemblerConfig()
+        self.assertIsNone(cfg.model_class)
+        self.assertIsNone(cfg.custom)
+        self.assertIsNone(cfg.torch)
+
+    def test_nesting_custom(self):
+        """The custom sub-config is retained and accessible."""
+        cfg = TabularAssemblerConfig(
+            model_class="mypkg.models.MyModel",
+            custom=CustomAssemblerConfig(custom_batch_processing=True),
+        )
+        self.assertEqual(cfg.model_class, "mypkg.models.MyModel")
+        self.assertTrue(cfg.custom.custom_batch_processing)
+        self.assertIsNone(cfg.torch)
+
+    def test_nesting_torch(self):
+        """The torch sub-config is retained and accessible."""
+        cfg = TabularAssemblerConfig(torch=TorchAssemblerConfig(backend="pytorch"))
+        self.assertEqual(cfg.torch.backend, "pytorch")
+        self.assertIsNone(cfg.custom)
+
+    def test_equality(self):
+        """Two configs with equivalent nested fields compare equal."""
+        self.assertEqual(
+            TabularAssemblerConfig(torch=TorchAssemblerConfig(backend="pytorch")),
+            TabularAssemblerConfig(torch=TorchAssemblerConfig(backend="pytorch")),
+        )
+
+    def test_repr_contains_field_values(self):
+        """The generated repr reflects field values (guards field reordering)."""
+        cfg = TabularAssemblerConfig(model_class="mypkg.models.MyModel")
+        self.assertIn("model_class='mypkg.models.MyModel'", repr(cfg))
+
+    def test_asdict_round_trip(self):
+        """The nested config is serialisable via dataclasses.asdict."""
+        cfg = TabularAssemblerConfig(
+            model_class="mypkg.models.MyModel",
+            custom=CustomAssemblerConfig(custom_batch_processing=True),
+        )
+        self.assertEqual(
+            asdict(cfg),
+            {
+                "model_class": "mypkg.models.MyModel",
+                "custom": {
+                    "custom_batch_processing": True,
+                    "additional_import_prefixes": None,
+                    "include_import_prefixes": None,
+                },
+                "torch": None,
+            },
+        )
+
+    def test_subclassability(self):
+        """Consumers can subclass to add provider-specific fields."""
+
+        @dataclass
+        class _CustomTabularAssemblerConfig(TabularAssemblerConfig):
+            use_remote_storage: bool = False
+
+        cfg = _CustomTabularAssemblerConfig(
+            model_class="mypkg.models.MyModel", use_remote_storage=True
+        )
+        self.assertEqual(cfg.model_class, "mypkg.models.MyModel")
+        self.assertTrue(cfg.use_remote_storage)
+        self.assertIsInstance(cfg, TabularAssemblerConfig)


### PR DESCRIPTION
Stack: 2/5. Based on #1 (packager utilities).

## Summary
- Adds `CustomAssemblerConfig` and `TorchAssemblerConfig` dataclasses describing how a trained tabular model should be packaged (model class, storage options, Triton parameters, import prefixes)
- Consumed by the custom and PyTorch/Lightning assemblers landing in PR 3/5 and PR 5/5

## Test plan
- [ ] `pytest python/michelangelo/workflow/schema/tests/assembler_test.py`