### PR TITLE
Tabular assembler migration 4/5: torch model fuser engine

### DIFF
--- a/python/michelangelo/lib/model_manager/utils/torch/model_fuser/__init__.py
+++ b/python/michelangelo/lib/model_manager/utils/torch/model_fuser/__init__.py
@@ -1,0 +1,27 @@
+"""Model fusion utilities for combining a native-transform model with a predictor.
+
+``FusedModel`` composes a transform module and a predictor module into a
+single ``nn.Module`` for serving. ``fuse`` traces/exports the composed graph
+to TorchScript, ONNX, or a combined state dict for Python-backend serving;
+its public functions are re-exported here for convenience.
+"""
+
+from .fuse import (
+    build_fused_sample_data,
+    compute_python_fuse_metadata,
+    fuse_models_to_onnx,
+    fuse_models_to_python,
+    fuse_models_to_torchscript,
+    get_predictor_output_field_order,
+)
+from .fused_model import FusedModel
+
+__all__ = [
+    "FusedModel",
+    "build_fused_sample_data",
+    "compute_python_fuse_metadata",
+    "fuse_models_to_onnx",
+    "fuse_models_to_python",
+    "fuse_models_to_torchscript",
+    "get_predictor_output_field_order",
+]

--- a/python/michelangelo/lib/model_manager/utils/torch/model_fuser/fuse.py
+++ b/python/michelangelo/lib/model_manager/utils/torch/model_fuser/fuse.py
@@ -1,0 +1,1137 @@
+"""Fuse a PyTorch predictor with a preceding native-transform model.
+
+Both the predictor and the native-transform model are expected to be saved
+as ``state_dict`` (or full-module) ``.pt``/``.pth`` files. They are loaded,
+wrapped in a :class:`~..fused_model.FusedModel` (transform -> predictor) with
+schema-driven input/output merge, and exported as TorchScript, ONNX, or a
+combined state dict for Python-backend serving.
+
+The ONNX export path consolidates the fixes needed for high-quality export
+(MHA fused-fastpath disable, dynamo-with-legacy-fallback, IO shape
+normalization, batch-size expansion) as module-private helpers below —
+mirroring the same fixes applied by the non-fused
+``model_manager`` Triton packagers, so fused and non-fused models get
+equivalent ONNX output quality.
+
+Building the Hydra reconstruction spec for a fused *native-transform* model's
+Python-backend package (:func:`_build_tx_hydra_spec`) requires the native
+transform package, which has not yet been migrated to OSS. Until it lands,
+that one function raises ``NotImplementedError``; every other function in
+this module (TorchScript export, ONNX export, field-order recovery,
+sample-data merge) works standalone.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import inspect
+import logging
+import os
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any
+
+import onnx
+import torch
+
+from michelangelo.lib.model_manager.schema import DataType, ModelSchema
+from michelangelo.lib.model_manager.schema.fuse import fuse_input_schema
+from michelangelo.lib.model_manager.utils.torch.data_type import (
+    data_type_to_torch_dtype,
+)
+from michelangelo.uniflow.core.utils import import_attribute
+
+from .fused_model import FusedModel
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+try:
+    from torch.export import Dim as _TorchExportDim
+except ImportError:  # pragma: no cover - depends on installed torch version
+    _TorchExportDim = None
+
+try:
+    import pytorch_lightning as pl
+except ImportError:  # pragma: no cover - pytorch_lightning is a declared dependency
+    pl = None
+
+__all__ = [
+    "build_fused_sample_data",
+    "compute_python_fuse_metadata",
+    "fuse_models_to_onnx",
+    "fuse_models_to_python",
+    "fuse_models_to_torchscript",
+    "get_predictor_output_field_order",
+]
+
+_logger = logging.getLogger(__name__)
+
+_ONNX_OPSET_LEGACY = 14
+_ONNX_OPSET_DYNAMO = 18
+_ONNX_EXPAND_BATCH_SIZE = 2
+
+
+# ---------------------------------------------------------------------------
+# Module loading / forward-signature helpers
+# ---------------------------------------------------------------------------
+
+
+def _forward_accepts_dict(module: torch.nn.Module) -> bool:
+    """Return whether ``module.forward``'s first parameter is dict-annotated."""
+    try:
+        sig = inspect.signature(module.forward)
+    except (ValueError, TypeError):
+        return False
+    for name, param in sig.parameters.items():
+        if name == "self":
+            continue
+        if param.annotation is inspect.Parameter.empty:
+            return False
+        return "dict" in str(param.annotation).lower()
+    return False
+
+
+def _forward_param_order(module: torch.nn.Module) -> list[str]:
+    """Return ``module.forward``'s parameter names (excluding ``self``), in order."""
+    try:
+        sig = inspect.signature(module.forward)
+    except (ValueError, TypeError):
+        return []
+    return [name for name in sig.parameters if name != "self"]
+
+
+def _schema_input_keys(schema: ModelSchema | None) -> list[str]:
+    """Return input feature names in schema order, or ``[]`` if unset."""
+    if schema is None:
+        return []
+    return [item.name for item in schema.input_schema]
+
+
+def _schema_output_keys(schema: ModelSchema | None) -> list[str]:
+    """Return output feature names in schema order, or ``[]`` if unset."""
+    if schema is None:
+        return []
+    return [item.name for item in schema.output_schema]
+
+
+def _build_fused_sample_input(
+    tx_model_schema: ModelSchema | None,
+    model_schema: ModelSchema | None,
+    batch_size: int = 1,
+) -> dict[str, torch.Tensor]:
+    """Build a sample input dict for the fused model, for tracing/inference.
+
+    Uses the same input feature set as :func:`fuse_input_schema`. Each tensor
+    has shape ``[batch_size, *feature_shape]`` and dtype derived from the
+    item's ``data_type``. Tensors are placed on CUDA when available, else CPU
+    (matching the device the fused module is traced on).
+
+    Args:
+        tx_model_schema: Native-transform model schema, or ``None``.
+        model_schema: Predictor model schema, or ``None``.
+        batch_size: Batch dimension for the sample tensors.
+
+    Returns:
+        Mapping of fused input feature name to a zero-filled sample tensor.
+        Empty if the fused input schema is empty.
+    """
+    input_items = fuse_input_schema(tx_model_schema, model_schema)
+    if not input_items:
+        return {}
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    sample: dict[str, torch.Tensor] = {}
+    for item in input_items:
+        feature_shape = list(item.shape) if item.shape else [1]
+        data_type = item.data_type if item.data_type is not None else DataType.UNKNOWN
+        shape = [batch_size] + [max(1, int(s)) for s in feature_shape]
+        dtype = data_type_to_torch_dtype(data_type)
+        sample[item.name] = torch.zeros(shape, dtype=dtype, device=device)
+    return sample
+
+
+def _is_state_dict(obj: Any) -> bool:
+    """Return whether ``obj`` is a state_dict (a dict of name -> Tensor)."""
+    return isinstance(obj, dict) and all(
+        isinstance(v, torch.Tensor) for v in obj.values()
+    )
+
+
+def _load_module_from_path(
+    path: str,
+    model_class: str,
+    hyperparameters: dict[str, Any],
+) -> torch.nn.Module:
+    """Load an ``nn.Module`` from a local file (state_dict or full module).
+
+    Args:
+        path: Local path to a ``.pt``/``.pth`` file.
+        model_class: Dotted class name to instantiate when the file contains
+            a state_dict.
+        hyperparameters: Constructor kwargs for ``model_class``.
+
+    Returns:
+        The loaded module in eval mode.
+
+    Raises:
+        FileNotFoundError: If ``path`` does not exist.
+        TypeError: If the file contains neither a state_dict nor an
+            ``nn.Module``.
+    """
+    if not os.path.isfile(path):
+        raise FileNotFoundError(f"Model file not found: {path}")
+
+    loaded = torch.load(path, map_location="cpu", weights_only=False)
+
+    if _is_state_dict(loaded):
+        model_cls = import_attribute(model_class)
+        model = model_cls(**(hyperparameters or {}))
+        model.load_state_dict(loaded)
+    else:
+        model = loaded
+
+    if isinstance(model, torch.nn.Module):
+        model.eval()
+        return model
+    raise TypeError(f"File {path} did not contain a state_dict or nn.Module")
+
+
+def _align_predictor_input_keys(
+    pred_module: torch.nn.Module,
+    predictor_input_keys: list[str],
+    predictor_takes_dict: bool,
+) -> list[str]:
+    """Reorder predictor input keys to match ``forward()``'s parameter order.
+
+    For dict-accepting predictors, order does not matter and the keys are
+    returned unchanged. For positional predictors, schema keys are aligned to
+    the ``forward()`` signature order.
+
+    Args:
+        pred_module: The predictor module.
+        predictor_input_keys: Feature names from the predictor's input schema.
+        predictor_takes_dict: Whether the predictor's ``forward`` takes a
+            single dict argument.
+
+    Returns:
+        ``predictor_input_keys``, reordered to match ``forward()`` when the
+        predictor takes positional tensors.
+
+    Raises:
+        ValueError: If a positional predictor's ``forward()`` is missing a
+            parameter named in the schema.
+    """
+    if predictor_takes_dict:
+        return predictor_input_keys
+    forward_params = _forward_param_order(pred_module)
+    schema_set = set(predictor_input_keys)
+    if forward_params and schema_set:
+        forward_param_set = set(forward_params)
+        if not schema_set.issubset(forward_param_set):
+            unknown = sorted(schema_set - forward_param_set)
+            raise ValueError(
+                "Predictor model_schema includes input names that are not "
+                f"parameters of forward(): {unknown}. forward() parameters "
+                f"(excluding self): {forward_params}. Align the model_schema "
+                "with the module's forward(), or use "
+                "forward(inputs: dict[str, torch.Tensor]) so the fused model "
+                "passes a dict."
+            )
+        return [p for p in forward_params if p in schema_set]
+    return predictor_input_keys
+
+
+def _build_fused_model_and_sample(
+    torch_model_path: str,
+    tx_model_path: str,
+    model_class: str,
+    hyperparameters: dict[str, Any],
+    tx_model_class: str,
+    tx_hyperparameters: dict[str, Any],
+    tx_model_schema: ModelSchema | None = None,
+    model_schema: ModelSchema | None = None,
+) -> tuple[FusedModel, dict[str, torch.Tensor], list[str]]:
+    """Load transform + predictor, build the ``FusedModel``, and a sample batch.
+
+    Args:
+        torch_model_path: Local path to the predictor model.
+        tx_model_path: Local path to the native-transform model.
+        model_class: Dotted class name for the predictor.
+        hyperparameters: Constructor kwargs for the predictor.
+        tx_model_class: Dotted class name for the transform.
+        tx_hyperparameters: Constructor kwargs for the transform.
+        tx_model_schema: Native-transform model schema.
+        model_schema: Predictor model schema.
+
+    Returns:
+        A tuple of ``(fused_module, sample_input, input_key_order)`` where
+        ``fused_module`` is on the trace device, ``sample_input`` is a dict
+        of sample tensors, and ``input_key_order`` is the sample's key order
+        (matching ONNX/Triton input names).
+
+    Raises:
+        ValueError: If the fused input schema is empty, so no sample input
+            can be built for tracing.
+    """
+    tx_hyperparameters = tx_hyperparameters or {}
+    hyperparameters = hyperparameters or {}
+
+    transform_module = _load_module_from_path(
+        tx_model_path, tx_model_class, tx_hyperparameters
+    )
+    predictor_module = _load_module_from_path(
+        torch_model_path, model_class, hyperparameters
+    )
+
+    transform_input_keys = _schema_input_keys(tx_model_schema)
+    predictor_takes_dict = _forward_accepts_dict(predictor_module)
+    predictor_input_keys = _schema_input_keys(model_schema)
+    predictor_input_keys = _align_predictor_input_keys(
+        predictor_module, predictor_input_keys, predictor_takes_dict
+    )
+
+    fused = FusedModel(
+        transform_module=transform_module,
+        predictor_module=predictor_module,
+        transform_input_keys=transform_input_keys,
+        predictor_input_keys=predictor_input_keys,
+        predictor_takes_dict=predictor_takes_dict,
+    )
+    fused.eval()
+
+    sample_input = _build_fused_sample_input(tx_model_schema, model_schema)
+    if not sample_input:
+        raise ValueError(
+            "Cannot build sample input for trace: the fused input schema "
+            "(from fuse_input_schema) is empty."
+        )
+    trace_device = next(iter(sample_input.values())).device
+    fused = fused.to(trace_device)
+
+    input_key_order = list(sample_input.keys())
+    return fused, sample_input, input_key_order
+
+
+def _build_tx_hydra_spec(tx_hyperparameters: dict[str, Any]) -> dict[str, Any]:
+    """Build a Hydra reconstruction spec for a fused native-transform layer stack.
+
+    Not yet implemented in OSS michelangelo: reconstructing a native-transform
+    module/layer stack from a stored transform specification dict requires
+    the native-transform package, which has not been migrated. This blocks
+    only the Python-backend *raw* package for a native-transform-fused model
+    (:func:`fuse_models_to_python`); the plain (no native-transform) path and
+    the TorchScript/ONNX fused deployable paths do not call this function.
+
+    Args:
+        tx_hyperparameters: The transform model's serialized hyperparameters
+            dict (the shape a future native-transform package's own
+            ``to_dict()`` would produce).
+
+    Raises:
+        NotImplementedError: Always, until native-transform support lands.
+    """
+    raise NotImplementedError(
+        "Building a Hydra reconstruction spec for a fused native-transform "
+        "model requires the native-transform package, which is not yet "
+        "available in OSS michelangelo."
+    )
+
+
+# ---------------------------------------------------------------------------
+# ONNX export helpers
+#
+# These mirror the fixes applied by the non-fused Triton packager's ONNX
+# export path so fused and non-fused models get equivalent export quality:
+# MHA fused-fastpath disable, dynamo-with-legacy-fallback, IO shape
+# normalization from the model schema, and batch-size expansion.
+# ---------------------------------------------------------------------------
+
+
+def _onnx_dynamo_exporter_dependencies_available() -> bool:
+    """Return whether ``onnxscript`` is installed (required for ``dynamo=True``)."""
+    return importlib.util.find_spec("onnxscript") is not None
+
+
+@contextmanager
+def _disable_transformer_encoder_fused_fastpath_for_onnx(
+    root: torch.nn.Module,
+) -> Iterator[None]:
+    """Disable the MHA fused fast path during ONNX export.
+
+    The fused fast path in ``nn.MultiheadAttention``/``TransformerEncoderLayer``
+    produces graphs that don't export cleanly; disabling it for the duration
+    of export (via ``torch.backends.mha.set_fastpath_enabled``) avoids that
+    without requiring any change to the model itself.
+
+    Args:
+        root: Unused; kept for a stable call signature across callers.
+    """
+    _ = root
+    mha = getattr(torch.backends, "mha", None)
+    setter = getattr(mha, "set_fastpath_enabled", None) if mha is not None else None
+    if setter is None:
+        yield
+        return
+    getter = getattr(mha, "get_fastpath_enabled", None)
+    prev = getter() if callable(getter) else True
+    setter(False)
+    try:
+        yield
+    finally:
+        setter(prev)
+
+
+def _onnx_dynamo_dynamic_shapes_for_tuple_arg(
+    tuple_in: tuple[torch.Tensor, ...],
+) -> tuple[tuple[dict[int, Any], ...]] | None:
+    """Build ``dynamic_shapes`` for ``export(model, (tuple_in,), dynamo=True)``.
+
+    Args:
+        tuple_in: The single tuple-of-tensors argument passed to dynamo
+            export.
+
+    Returns:
+        A one-element tuple wrapping a per-tensor ``{0: Dim("batch")}`` dict,
+        or ``None`` if ``torch.export.Dim`` is unavailable on this torch
+        version.
+    """
+    if _TorchExportDim is None:
+        return None
+    batch = _TorchExportDim("batch")
+    return (tuple({0: batch} for _ in tuple_in),)
+
+
+def _onnx_dynamo_export_error_should_retry_legacy(exc: BaseException) -> bool:
+    """Return whether a dynamo export failure should retry with ``dynamo=False``."""
+    if isinstance(exc, (ImportError, ModuleNotFoundError)):
+        return True
+    msg = str(exc).lower()
+    return (
+        "onnxscript" in msg
+        or "convertversionpass" in msg
+        or "version conversion pass" in msg
+        or "model contains functions" in msg
+        or "passerror" in msg
+        or "failed to convert 'dynamic_axes'" in msg
+        or "treespec.unflatten" in msg
+        # torch.export's Dim-based dynamic_shapes validation has changed shape
+        # across torch releases (e.g. rejecting a Dim keyed by position for a
+        # tuple-of-tensors arg on some versions); treat that whole class of
+        # torch.export capture failures as dynamo-not-usable-here rather than
+        # a genuine model bug, and fall back to the legacy exporter.
+        or "torchexporterror" in msg
+        or "unexpected dimension" in msg
+    )
+
+
+def _expand_batch_for_onnx_export(
+    tensors: tuple[torch.Tensor, ...],
+) -> tuple[torch.Tensor, ...]:
+    """Expand any size-1 batch dimension to size 2 so it isn't baked into the graph."""
+    out: list[torch.Tensor] = []
+    for inp in tensors:
+        if inp.size(0) > 1:
+            out.append(inp)
+        else:
+            out.append(inp.repeat(_ONNX_EXPAND_BATCH_SIZE, *[1] * (inp.dim() - 1)))
+    return tuple(out)
+
+
+def _force_onnx_io_shapes_from_schema(
+    onnx_path: str,
+    model_schemas: list[ModelSchema | None],
+    batch_dim_param: str = "b",
+) -> None:
+    """Override ONNX graph IO shapes to match the schema's static dims.
+
+    PyTorch's ONNX shape inference can drop a fixed non-batch dimension and
+    emit ``[-1, -1]``; Triton's onnxruntime backend then rejects the model
+    because its config declares a static shape. For every graph input/output
+    whose name matches a schema item with a known shape, this overwrites dim
+    0 with ``batch_dim_param`` and the remaining dims with the schema's
+    static values. Names absent from every schema are left untouched.
+
+    Args:
+        onnx_path: Path to the ``.onnx`` file to rewrite in place.
+        model_schemas: Schemas to source static shapes from (``None`` entries
+            are skipped).
+        batch_dim_param: Symbolic name to use for the batch dimension.
+    """
+    name_to_shape: dict[str, list[int]] = {}
+    for schema in model_schemas:
+        if schema is None:
+            continue
+        for item in list(schema.input_schema) + list(schema.output_schema):
+            if item.shape is None:
+                continue
+            name_to_shape[item.name] = [int(s) for s in item.shape]
+
+    if not name_to_shape:
+        return
+
+    model_proto = onnx.load(onnx_path)
+
+    def _override(value_info: Any) -> None:
+        schema_shape = name_to_shape.get(value_info.name)
+        if schema_shape is None:
+            return
+        tensor_type = value_info.type.tensor_type
+        expected_rank = 1 + len(schema_shape)
+        existing_rank = len(tensor_type.shape.dim)
+        if existing_rank != expected_rank:
+            _logger.warning(
+                "Skipping ONNX shape override for '%s': rank %d in graph != "
+                "%d expected from schema.",
+                value_info.name,
+                existing_rank,
+                expected_rank,
+            )
+            return
+        tensor_type.shape.dim[0].ClearField("dim_value")
+        tensor_type.shape.dim[0].dim_param = batch_dim_param
+        for i, dim_size in enumerate(schema_shape, start=1):
+            tensor_type.shape.dim[i].ClearField("dim_param")
+            tensor_type.shape.dim[i].dim_value = dim_size
+
+    for value_info in list(model_proto.graph.input) + list(model_proto.graph.output):
+        _override(value_info)
+
+    onnx.save(model_proto, onnx_path)
+
+
+def _onnx_export_input_preserver(
+    input_tensors: tuple[torch.Tensor, ...],
+    *,
+    ref_dtype: torch.dtype,
+    ref_device: torch.device,
+) -> torch.Tensor:
+    """Return a scalar zero that data-depends on every tensor in ``input_tensors``.
+
+    Used to keep every ONNX graph input alive even when the traced module
+    doesn't otherwise use all of them (the exporter can otherwise prune an
+    unused input from the graph).
+    """
+    acc = torch.zeros((), dtype=ref_dtype, device=ref_device)
+    for tensor in input_tensors:
+        acc = acc + (tensor * 0).sum().to(dtype=ref_dtype)
+    return acc
+
+
+def _onnx_export_attach_inputs_to_output(
+    out: object, input_tensors: tuple[torch.Tensor, ...]
+) -> object:
+    """Add a zero-valued data dependency from each input into one output branch.
+
+    Args:
+        out: The module's forward output — a Tensor, NamedTuple, dict, tuple,
+            or list.
+        input_tensors: The tensors that must remain live graph inputs.
+
+    Returns:
+        ``out`` with one branch adjusted to depend on every input tensor.
+        Returned unchanged if ``input_tensors`` is empty or ``out``'s shape
+        isn't recognized.
+    """
+    if not input_tensors:
+        return out
+    if isinstance(out, torch.Tensor):
+        preserver = _onnx_export_input_preserver(
+            input_tensors, ref_dtype=out.dtype, ref_device=out.device
+        )
+        return out + preserver
+    fields = getattr(out, "_fields", None)
+    if fields:
+        vals = list(out)
+        for i, v in enumerate(vals):
+            if isinstance(v, torch.Tensor):
+                preserver = _onnx_export_input_preserver(
+                    input_tensors, ref_dtype=v.dtype, ref_device=v.device
+                )
+                vals[i] = v + preserver
+                return type(out)(*vals)
+    if isinstance(out, dict):
+        d = dict(out)
+        for k, v in d.items():
+            if isinstance(v, torch.Tensor):
+                preserver = _onnx_export_input_preserver(
+                    input_tensors, ref_dtype=v.dtype, ref_device=v.device
+                )
+                d[k] = v + preserver
+                return d
+        return out
+    if isinstance(out, (tuple, list)):
+        seq = list(out)
+        for i, v in enumerate(seq):
+            if isinstance(v, torch.Tensor):
+                preserver = _onnx_export_input_preserver(
+                    input_tensors, ref_dtype=v.dtype, ref_device=v.device
+                )
+                seq[i] = v + preserver
+                return tuple(seq) if isinstance(out, tuple) else seq
+    return out
+
+
+class _FusedOnnxTupleWrapper(torch.nn.Module):
+    """Adapts a dict-input fused module to positional tensors, for legacy ONNX export.
+
+    ``torch.onnx.export`` (legacy path) traces with positional args; the
+    fused model takes a single ``dict[str, Tensor]``. This wrapper converts
+    ``*inputs`` (in ``input_key_order``) into that dict, calls the inner
+    module, and preserves all inputs in the traced graph.
+    """
+
+    def __init__(self, inner: torch.nn.Module, input_key_order: list[str]) -> None:
+        """Initialize the wrapper.
+
+        Args:
+            inner: The fused module to wrap.
+            input_key_order: Feature name for each positional argument, in
+                order.
+        """
+        super().__init__()
+        self.inner = inner
+        self._input_key_order = input_key_order
+
+    def forward(self, *inputs: torch.Tensor) -> object:
+        """Merge positional ``inputs`` into a dict and call the inner module."""
+        merged = dict(zip(self._input_key_order, inputs))
+        out = self.inner(merged)
+        return _onnx_export_attach_inputs_to_output(out, inputs)
+
+
+class _FusedOnnxDynamoTupleWrapper(torch.nn.Module):
+    """Same as :class:`_FusedOnnxTupleWrapper`, for the dynamo ONNX export path.
+
+    ``torch.onnx.export(..., dynamo=True)`` treats ``args=(tuple_in,)`` as a
+    single pytree argument (a tuple of tensors), so this wrapper takes one
+    tuple argument instead of ``*args``.
+    """
+
+    def __init__(self, inner: torch.nn.Module, input_key_order: list[str]) -> None:
+        """Initialize the wrapper.
+
+        Args:
+            inner: The fused module to wrap.
+            input_key_order: Feature name for each tuple element, in order.
+        """
+        super().__init__()
+        self.inner = inner
+        self._input_key_order = input_key_order
+
+    def forward(self, inputs_tuple: tuple[torch.Tensor, ...]) -> object:
+        """Merge the tuple argument into a dict and call the inner module."""
+        merged = dict(zip(self._input_key_order, inputs_tuple))
+        out = self.inner(merged)
+        return _onnx_export_attach_inputs_to_output(out, inputs_tuple)
+
+
+def _run_export_with_retry(
+    export_args: tuple[Any, Any, str],
+    export_kwargs: dict[str, Any],
+    legacy_export_kwargs: dict[str, Any],
+    use_dynamo: bool,
+    use_tuple_wrapper: bool,
+    model: torch.nn.Module,
+    input_key_order: list[str] | None,
+) -> None:
+    """Run ``torch.onnx.export``, retrying with ``dynamo=False`` on failure.
+
+    Args:
+        export_args: ``(model_or_wrapper, sample_args, dest_path)`` for the
+            dynamo attempt.
+        export_kwargs: Keyword arguments for the dynamo (or sole) export
+            attempt.
+        legacy_export_kwargs: Keyword arguments for the legacy fallback
+            export.
+        use_dynamo: Whether to attempt the dynamo exporter first.
+        use_tuple_wrapper: Whether inputs are wrapped via
+            :class:`_FusedOnnxDynamoTupleWrapper`/:class:`_FusedOnnxTupleWrapper`.
+        model: The unwrapped module, used for the legacy fallback.
+        input_key_order: Feature name per positional/tuple input; required
+            when ``use_tuple_wrapper`` is ``True``.
+    """
+    if use_dynamo and "dynamic_shapes" in export_kwargs and use_tuple_wrapper:
+        dynamo_wrapped = _FusedOnnxDynamoTupleWrapper(model, input_key_order)
+        dynamo_wrapped.eval()
+        try:
+            with _disable_transformer_encoder_fused_fastpath_for_onnx(dynamo_wrapped):
+                sample_args = export_args[1]
+                tuple_arg = (
+                    sample_args[0] if isinstance(sample_args, tuple) else sample_args
+                )
+                torch.onnx.export(
+                    dynamo_wrapped,
+                    (tuple_arg,),
+                    export_args[2],
+                    **export_kwargs,
+                )
+        except Exception as e:
+            if not _onnx_dynamo_export_error_should_retry_legacy(e):
+                raise
+            _logger.warning(
+                "ONNX dynamo export failed (%s); retrying with legacy "
+                "torch.onnx.export.",
+                e,
+            )
+            with _disable_transformer_encoder_fused_fastpath_for_onnx(export_args[0]):
+                model, sample_args, dest_path = export_args
+                torch.onnx.export(model, sample_args, dest_path, **legacy_export_kwargs)
+    else:
+        with _disable_transformer_encoder_fused_fastpath_for_onnx(export_args[0]):
+            model, sample_args, dest_path = export_args
+            torch.onnx.export(model, sample_args, dest_path, **export_kwargs)
+
+
+def _export_fused_onnx(
+    model: torch.nn.Module,
+    dest_path: str,
+    sample_inputs: tuple[torch.Tensor, ...],
+    input_names: list[str],
+    output_names: list[str],
+    model_schemas: list[ModelSchema | None],
+    input_key_order: list[str],
+) -> str:
+    """Export a fused ``nn.Module`` to ONNX with dynamo-first, legacy-fallback.
+
+    Applies MHA fastpath disable, batch-size expansion, dynamo/legacy
+    fallback, and schema-driven IO shape normalization — the same fixes
+    the non-fused Triton packager's ONNX export path applies.
+
+    Args:
+        model: The fused module to export (already in eval mode).
+        dest_path: Local path where the ``.onnx`` file will be saved.
+        sample_inputs: Trace tensors in ``input_key_order``.
+        input_names: ONNX graph input names, in ``input_key_order``.
+        output_names: ONNX graph output names.
+        model_schemas: Schemas used to force static ONNX IO shapes.
+        input_key_order: Feature name per element of ``sample_inputs``.
+
+    Returns:
+        ``dest_path``.
+    """
+    os.makedirs(os.path.dirname(dest_path) or ".", exist_ok=True)
+
+    sample_inputs = _expand_batch_for_onnx_export(sample_inputs)
+
+    dynamic_axes: dict[str, dict[int, str]] = {
+        name: {0: "b"} for name in list(input_names) + list(output_names)
+    }
+
+    export_sig = inspect.signature(torch.onnx.export)
+    supports_dynamo = "dynamo" in export_sig.parameters
+    use_dynamo = supports_dynamo and _onnx_dynamo_exporter_dependencies_available()
+
+    wrapped: torch.nn.Module = _FusedOnnxTupleWrapper(model, input_key_order)
+    wrapped.eval()
+
+    export_kwargs: dict[str, Any] = {
+        "input_names": list(input_names),
+        "output_names": list(output_names) if output_names else None,
+        "do_constant_folding": False,
+    }
+    if use_dynamo:
+        export_kwargs["dynamo"] = True
+        export_kwargs["opset_version"] = _ONNX_OPSET_DYNAMO
+        dynamic_shapes = _onnx_dynamo_dynamic_shapes_for_tuple_arg(sample_inputs)
+        if dynamic_shapes is not None:
+            export_kwargs["dynamic_shapes"] = dynamic_shapes
+        else:
+            export_kwargs["dynamic_axes"] = dynamic_axes or None
+    else:
+        export_kwargs["dynamic_axes"] = dynamic_axes or None
+        export_kwargs["opset_version"] = _ONNX_OPSET_LEGACY
+
+    legacy_export_kwargs: dict[str, Any] = {
+        "input_names": list(input_names),
+        "output_names": list(output_names) if output_names else None,
+        "do_constant_folding": False,
+        "dynamic_axes": dynamic_axes or None,
+        "opset_version": _ONNX_OPSET_LEGACY,
+    }
+    if supports_dynamo:
+        legacy_export_kwargs["dynamo"] = False
+
+    export_args = (wrapped, sample_inputs, dest_path)
+
+    _run_export_with_retry(
+        export_args,
+        export_kwargs,
+        legacy_export_kwargs,
+        use_dynamo,
+        use_tuple_wrapper=True,
+        model=model,
+        input_key_order=input_key_order,
+    )
+
+    try:
+        _force_onnx_io_shapes_from_schema(dest_path, model_schemas)
+    except Exception as e:
+        _logger.warning("Could not normalize ONNX IO shapes from schema: %s", e)
+
+    return dest_path
+
+
+# ---------------------------------------------------------------------------
+# Public fuse API
+# ---------------------------------------------------------------------------
+
+
+def get_predictor_output_field_order(
+    model_path: str,
+    model_class: str,
+    hyperparameters: dict[str, Any],
+    model_schema: ModelSchema | None,
+) -> list[str] | None:
+    """Recover a NamedTuple predictor's output ``_fields`` order.
+
+    Tries two strategies in order:
+
+    1. Inspect ``forward()``'s return-type annotation for a ``_fields``
+       attribute. Works without running the model, so it needs no sample
+       input.
+    2. Run a forward pass with a synthetic sample input and read ``_fields``
+       from the live output. Used only when the annotation strategy fails.
+
+    Args:
+        model_path: Local path to the predictor model.
+        model_class: Dotted class name for the predictor.
+        hyperparameters: Constructor kwargs for the predictor.
+        model_schema: Predictor model schema, used to build a synthetic
+            sample input for strategy 2.
+
+    Returns:
+        The output field names in order, or ``None`` if the predictor's
+        output isn't a NamedTuple or loading/inference fails. Callers should
+        fall back to the original schema order when ``None`` is returned.
+    """
+    try:
+        module = _load_module_from_path(model_path, model_class, hyperparameters)
+
+        try:
+            sig = inspect.signature(module.forward)
+            return_annotation = sig.return_annotation
+            if return_annotation is not inspect.Parameter.empty and hasattr(
+                return_annotation, "_fields"
+            ):
+                _logger.info(
+                    "Predictor output field order recovered from forward() "
+                    "return annotation."
+                )
+                return list(return_annotation._fields)
+        except Exception:
+            pass
+
+        sample_input = _build_fused_sample_input(None, model_schema)
+        with torch.no_grad():
+            if _forward_accepts_dict(module):
+                output = module(sample_input)
+            else:
+                forward_params = _forward_param_order(module)
+                args = [sample_input[p] for p in forward_params if p in sample_input]
+                output = module(*args)
+        if hasattr(output, "_fields"):
+            return list(output._fields)
+        _logger.info("Predictor output has no _fields; output_schema order unchanged.")
+        return None
+    except Exception as e:
+        _logger.warning(
+            "Could not determine predictor output field order: %s. Output "
+            "schema unchanged.",
+            e,
+        )
+        return None
+
+
+@contextmanager
+def _pl_jit_scripting_guard() -> Iterator[None]:
+    """Best-effort wrapper around PyTorch Lightning's private jit-scripting context.
+
+    ``pl.core.module._jit_is_scripting`` avoids tracing LightningModule-only
+    hooks during ``torch.jit.trace``. It's a Lightning-internal API with no
+    public equivalent and has moved across Lightning releases before, so this
+    degrades to a no-op if the installed pytorch_lightning no longer exposes
+    it, rather than breaking the fused-model export.
+    """
+    module_attr = getattr(getattr(pl, "core", None), "module", None) if pl else None
+    jit_is_scripting = getattr(module_attr, "_jit_is_scripting", None)
+    if jit_is_scripting is None:
+        yield
+        return
+    with jit_is_scripting():
+        yield
+
+
+def fuse_models_to_torchscript(
+    torch_model_path: str,
+    tx_model_path: str,
+    model_class: str,
+    hyperparameters: dict[str, Any],
+    tx_model_class: str,
+    tx_hyperparameters: dict[str, Any],
+    dest_path: str,
+    tx_model_schema: ModelSchema | None = None,
+    model_schema: ModelSchema | None = None,
+) -> str:
+    """Fuse the predictor and transform models and save as TorchScript.
+
+    Loads both models from local paths, composes them as a ``FusedModel``
+    with schema-driven merge (transform input/output, predictor input), and
+    exports to ``dest_path`` as TorchScript.
+
+    Args:
+        torch_model_path: Local path to the predictor model.
+        tx_model_path: Local path to the native-transform model.
+        model_class: Dotted class name for the predictor.
+        hyperparameters: Constructor kwargs for the predictor.
+        tx_model_class: Dotted class name for the transform.
+        tx_hyperparameters: Constructor kwargs for the transform.
+        dest_path: Local path where the fused TorchScript model is saved.
+        tx_model_schema: Native-transform model schema.
+        model_schema: Predictor model schema.
+
+    Returns:
+        ``dest_path``.
+    """
+    fused, sample_input, _ = _build_fused_model_and_sample(
+        torch_model_path,
+        tx_model_path,
+        model_class,
+        hyperparameters,
+        tx_model_class,
+        tx_hyperparameters,
+        tx_model_schema=tx_model_schema,
+        model_schema=model_schema,
+    )
+
+    os.makedirs(os.path.dirname(dest_path) or ".", exist_ok=True)
+
+    trace_device = next(iter(sample_input.values())).device
+    _logger.info("Tracing fused model on device: %s", trace_device)
+    # torch.no_grad ensures a consistent eval-mode fast path in
+    # nn.TransformerEncoderLayer during trace; without it, trace vs.
+    # verification runs can diverge.
+    with _pl_jit_scripting_guard(), torch.no_grad():
+        traced = torch.jit.trace(fused, (sample_input,))
+        torch.jit.save(traced, dest_path)
+    return dest_path
+
+
+def fuse_models_to_onnx(
+    torch_model_path: str,
+    tx_model_path: str,
+    model_class: str,
+    hyperparameters: dict[str, Any],
+    tx_model_class: str,
+    tx_hyperparameters: dict[str, Any],
+    dest_path: str,
+    tx_model_schema: ModelSchema | None = None,
+    model_schema: ModelSchema | None = None,
+) -> str:
+    """Fuse the predictor and transform models and save as ONNX.
+
+    Uses the same composition rules as :func:`fuse_models_to_torchscript`,
+    then exports with the dynamo-first/legacy-fallback ONNX pipeline (see the
+    module docstring) so fused and non-fused models get equivalent export
+    quality.
+
+    Args:
+        torch_model_path: Local path to the predictor model.
+        tx_model_path: Local path to the native-transform model.
+        model_class: Dotted class name for the predictor.
+        hyperparameters: Constructor kwargs for the predictor.
+        tx_model_class: Dotted class name for the transform.
+        tx_hyperparameters: Constructor kwargs for the transform.
+        dest_path: Local path where the fused ``.onnx`` model is saved.
+        tx_model_schema: Native-transform model schema.
+        model_schema: Predictor model schema.
+
+    Returns:
+        ``dest_path``.
+    """
+    fused, sample_input, input_key_order = _build_fused_model_and_sample(
+        torch_model_path,
+        tx_model_path,
+        model_class,
+        hyperparameters,
+        tx_model_class,
+        tx_hyperparameters,
+        tx_model_schema=tx_model_schema,
+        model_schema=model_schema,
+    )
+
+    tuple_in = tuple(sample_input[k] for k in input_key_order)
+    input_names = list(input_key_order)
+    output_names = [
+        item.name for item in (model_schema.output_schema if model_schema else [])
+    ]
+
+    try:
+        with torch.no_grad():
+            out = fused(dict(zip(input_key_order, tuple_in)))
+        if hasattr(out, "_fields"):
+            output_names = list(out._fields)
+    except Exception as e:
+        _logger.warning(
+            "Could not infer ONNX output names from forward sample run: %s", e
+        )
+
+    return _export_fused_onnx(
+        model=fused,
+        dest_path=dest_path,
+        sample_inputs=tuple_in,
+        input_names=input_names,
+        output_names=output_names,
+        model_schemas=[tx_model_schema, model_schema],
+        input_key_order=input_key_order,
+    )
+
+
+def compute_python_fuse_metadata(
+    torch_model_path: str,
+    model_class: str,
+    hyperparameters: dict[str, Any],
+    tx_model_schema: ModelSchema | None,
+    model_schema: ModelSchema | None,
+) -> tuple[list[str], list[str], bool]:
+    """Compute fuse routing metadata for Python-backend packaging.
+
+    Loads the predictor to inspect its ``forward()`` signature and derives
+    the key lists and predictor call style needed to reconstruct the fused
+    model at serve time, using the same key-ordering logic as
+    :func:`fuse_models_to_torchscript` but without tracing.
+
+    Args:
+        torch_model_path: Local path to the predictor model.
+        model_class: Dotted class name for the predictor.
+        hyperparameters: Constructor kwargs for the predictor.
+        tx_model_schema: Native-transform model schema.
+        model_schema: Predictor model schema.
+
+    Returns:
+        A tuple ``(transform_input_keys, predictor_input_keys,
+        predictor_takes_dict)``: the feature names routed to the transform,
+        the feature names routed to the predictor (after merge), and whether
+        the predictor's ``forward()`` takes a single dict argument.
+    """
+    hyperparameters = hyperparameters or {}
+    pred_module = _load_module_from_path(torch_model_path, model_class, hyperparameters)
+    predictor_takes_dict = _forward_accepts_dict(pred_module)
+
+    transform_input_keys = _schema_input_keys(tx_model_schema)
+    predictor_input_keys = _schema_input_keys(model_schema)
+    predictor_input_keys = _align_predictor_input_keys(
+        pred_module, predictor_input_keys, predictor_takes_dict
+    )
+
+    return transform_input_keys, predictor_input_keys, predictor_takes_dict
+
+
+def fuse_models_to_python(
+    torch_model_path: str,
+    tx_model_path: str,
+    model_class: str,
+    hyperparameters: dict[str, Any],
+    tx_hyperparameters: dict[str, Any],
+    dest_path: str,
+    tx_model_schema: ModelSchema | None = None,
+    model_schema: ModelSchema | None = None,
+) -> tuple[str, str, dict[str, Any]]:
+    """Fuse predictor and transform into a combined state dict for serving.
+
+    Unlike :func:`fuse_models_to_torchscript`/:func:`fuse_models_to_onnx`,
+    which trace a single ``nn.Module``, this path keeps weights separate and
+    reconstructs the ``FusedModel`` at serve time from the returned
+    hyperparameters spec. The predictor and transform state dicts are
+    combined with submodule prefixes (``predictor_module.*``,
+    ``transform_module.*``) matching ``FusedModel``'s attribute names.
+
+    Args:
+        torch_model_path: Local path to the predictor model (state_dict or
+            full module).
+        tx_model_path: Local path to the native-transform model (full
+            ``nn.Module``).
+        model_class: Dotted class name for the predictor.
+        hyperparameters: Constructor kwargs for the predictor.
+        tx_hyperparameters: The transform's ``to_dict()`` output.
+        dest_path: Local path where the combined state dict is saved.
+        tx_model_schema: Native-transform model schema.
+        model_schema: Predictor model schema.
+
+    Returns:
+        A tuple ``(dest_path, fused_model_class, fused_hyperparameters)``:
+        the saved state dict path, ``FusedModel``'s dotted class name, and
+        the serve-time reconstruction spec.
+
+    Raises:
+        NotImplementedError: Building ``fused_hyperparameters["transform_module"]``
+            requires the native-transform package (see
+            :func:`_build_tx_hydra_spec`), which is not yet available in OSS.
+    """
+    hyperparameters = hyperparameters or {}
+    tx_hyperparameters = tx_hyperparameters or {}
+
+    transform_input_keys, predictor_input_keys, predictor_takes_dict = (
+        compute_python_fuse_metadata(
+            torch_model_path,
+            model_class,
+            hyperparameters,
+            tx_model_schema,
+            model_schema,
+        )
+    )
+
+    predictor_sd = torch.load(torch_model_path, map_location="cpu", weights_only=True)
+    if "state_dict" in predictor_sd and isinstance(predictor_sd["state_dict"], dict):
+        predictor_sd = predictor_sd["state_dict"]
+
+    tx_obj = torch.load(tx_model_path, map_location="cpu", weights_only=False)
+    tx_sd = tx_obj.state_dict()
+    del tx_obj
+
+    combined_sd = {f"predictor_module.{k}": v for k, v in predictor_sd.items()}
+    combined_sd.update({f"transform_module.{k}": v for k, v in tx_sd.items()})
+
+    os.makedirs(os.path.dirname(dest_path) or ".", exist_ok=True)
+    torch.save(combined_sd, dest_path)
+
+    tx_spec = _build_tx_hydra_spec(tx_hyperparameters)
+
+    fused_model_class = f"{FusedModel.__module__}.{FusedModel.__qualname__}"
+    fused_hyperparameters = {
+        "predictor_module": {"_target_": model_class, **hyperparameters},
+        "transform_module": tx_spec,
+        "transform_input_keys": transform_input_keys,
+        "predictor_input_keys": predictor_input_keys,
+        "predictor_takes_dict": predictor_takes_dict,
+    }
+
+    return dest_path, fused_model_class, fused_hyperparameters
+
+
+def build_fused_sample_data(
+    tx_sample_data: list[dict[str, Any]] | None,
+    predictor_sample_data: list[dict[str, Any]] | None,
+    fused_input_cols: set[str],
+) -> list[dict[str, Any]]:
+    """Merge transform + predictor sample data and filter to the fused input schema.
+
+    The predictor is trained on post-transform data, so its sample data
+    includes transform output columns. The fused model's input schema only
+    has pre-transform columns, so this merges both sample sets and filters
+    to the fused input columns.
+
+    Args:
+        tx_sample_data: Native-transform model's sample data.
+        predictor_sample_data: Predictor model's sample data.
+        fused_input_cols: Column names in the fused model's input schema.
+
+    Returns:
+        A single-element list containing the merged, filtered sample dict.
+        When a key appears in both inputs, ``tx_sample_data`` wins — it holds
+        the raw pre-transform values the fused model's input schema expects.
+    """
+    merged: dict[str, Any] = {}
+    for sample in predictor_sample_data or []:
+        merged.update(sample)
+    for sample in tx_sample_data or []:
+        merged.update(sample)
+    return [{k: v for k, v in merged.items() if k in fused_input_cols}]

--- a/python/michelangelo/lib/model_manager/utils/torch/model_fuser/fused_model.py
+++ b/python/michelangelo/lib/model_manager/utils/torch/model_fuser/fused_model.py
@@ -1,0 +1,98 @@
+"""Fused model composing a native-transform module and a predictor module.
+
+``forward`` accepts ``dict[str, Tensor]`` keyed by feature name. The transform
+runs on its input schema; its output is merged with passthrough features from
+the input (the predictor receives the transform's output where available,
+else the original input for that feature). Output is the predictor's output
+tensor. Designed to be TorchScript-exportable.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+__all__ = ["FusedModel"]
+
+
+class FusedModel(nn.Module):
+    """Fuses a transform module and a predictor module with schema-driven merge.
+
+    The native transform is always dict-in, dict-out: ``forward`` is called
+    with a dict and returns a dict. The predictor's input is merged from the
+    transform's output and passthrough values from the fused model's input;
+    the predictor is then called with either a single dict
+    (``predictor_takes_dict=True``) or positional tensor arguments in
+    ``predictor_input_keys`` order (``predictor_takes_dict=False``).
+
+    Attributes:
+        transform_module: Native transform module.
+        predictor_module: Predictor module.
+        transform_input_keys: Input feature names fed to the transform.
+        predictor_input_keys: Feature names the predictor expects, in order.
+        predictor_takes_dict: Whether the predictor is called with a dict.
+    """
+
+    __constants__ = [  # noqa: RUF012
+        "transform_input_keys",
+        "predictor_input_keys",
+        "predictor_takes_dict",
+    ]
+
+    def __init__(
+        self,
+        transform_module: nn.Module,
+        predictor_module: nn.Module,
+        transform_input_keys: list[str],
+        predictor_input_keys: list[str],
+        predictor_takes_dict: bool = False,
+    ) -> None:
+        """Initialize the fused model.
+
+        Args:
+            transform_module: Native transform module. Always
+                ``forward(inputs: dict) -> dict``.
+            predictor_module: Predictor module. Its ``forward`` may accept a
+                dict or multiple positional tensors.
+            transform_input_keys: Input feature names fed to the transform
+                (dict keys).
+            predictor_input_keys: Feature names the predictor expects, in
+                order.
+            predictor_takes_dict: If ``True``, call the predictor with a
+                dict; if ``False``, call it with positional tensors.
+        """
+        super().__init__()
+        self.transform_module = transform_module
+        self.predictor_module = predictor_module
+        self.transform_input_keys = transform_input_keys
+        self.predictor_input_keys = predictor_input_keys
+        self.predictor_takes_dict = predictor_takes_dict
+
+    def forward(self, inputs: dict[str, torch.Tensor]) -> torch.Tensor:
+        """Run the transform then the predictor, merging output with passthrough.
+
+        Args:
+            inputs: Named input tensors (e.g. batched features). Must contain
+                all ``transform_input_keys`` and any ``predictor_input_keys``
+                not produced by the transform.
+
+        Returns:
+            The predictor's output tensor.
+        """
+        # The native transform is always dict-in, dict-out.
+        transform_in_dict = {k: inputs[k] for k in self.transform_input_keys}
+        transformed_dict = self.transform_module(transform_in_dict)
+
+        predictor_input_dict = {}
+        for k in list(inputs.keys()):
+            predictor_input_dict[k] = inputs[k]
+        for k in list(transformed_dict.keys()):
+            predictor_input_dict[k] = transformed_dict[k]
+
+        if self.predictor_takes_dict:
+            predictor_in_dict = {
+                k: predictor_input_dict[k] for k in self.predictor_input_keys
+            }
+            return self.predictor_module(predictor_in_dict)
+        predictor_parts = [predictor_input_dict[k] for k in self.predictor_input_keys]
+        return self.predictor_module(*predictor_parts)

--- a/python/michelangelo/lib/model_manager/utils/torch/model_fuser/tests/__init__.py
+++ b/python/michelangelo/lib/model_manager/utils/torch/model_fuser/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the model-fuser package."""

--- a/python/michelangelo/lib/model_manager/utils/torch/model_fuser/tests/fuse_test.py
+++ b/python/michelangelo/lib/model_manager/utils/torch/model_fuser/tests/fuse_test.py
@@ -1,0 +1,1538 @@
+"""Tests for ``model_fuser.fuse``.
+
+Tests are grouped into non-ONNX cases, ONNX export cases, and
+native-transform-gated cases (present but skipped until native-transform
+support is available).
+
+``fuse_input_schema``/``fuse_model_schema`` already have full coverage in
+``_private/schema/tests/fuse_test.py`` and are not re-tested here.
+``FusedModel.forward`` is exercised directly in
+``torch/model_fuser/tests/fused_model_test.py`` and is likewise not
+duplicated here.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import inspect
+import os
+import tempfile
+import unittest
+from types import SimpleNamespace
+from typing import NamedTuple
+from unittest import mock
+
+import onnx
+import torch
+import torch.nn as nn
+
+from michelangelo.lib.model_manager.schema import DataType, ModelSchema, ModelSchemaItem
+from michelangelo.lib.model_manager.utils.torch.model_fuser import (
+    fuse as fuse_module,
+)
+from michelangelo.lib.model_manager.utils.torch.model_fuser import (
+    fused_model,
+)
+from michelangelo.lib.model_manager.utils.torch.model_fuser.fuse import (
+    _build_fused_sample_input,
+    _disable_transformer_encoder_fused_fastpath_for_onnx,
+    _FusedOnnxDynamoTupleWrapper,
+    _FusedOnnxTupleWrapper,
+    _is_state_dict,
+    _load_module_from_path,
+    _onnx_dynamo_dynamic_shapes_for_tuple_arg,
+    _onnx_dynamo_export_error_should_retry_legacy,
+    _onnx_dynamo_exporter_dependencies_available,
+    _onnx_export_attach_inputs_to_output,
+    _schema_input_keys,
+    _schema_output_keys,
+    build_fused_sample_data,
+    compute_python_fuse_metadata,
+    fuse_models_to_onnx,
+    fuse_models_to_python,
+    fuse_models_to_torchscript,
+    get_predictor_output_field_order,
+)
+
+FusedModel = fused_model.FusedModel
+
+_FUSE_MODULE = "michelangelo.lib.model_manager.utils.torch.model_fuser.fuse"
+
+
+# ---------------------------------------------------------------------------
+# Shared model fixtures
+# ---------------------------------------------------------------------------
+
+
+class _DictTransform(nn.Module):
+    """Transform that accepts a dict and returns a dict."""
+
+    def forward(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        return {"out": next(iter(inputs.values())) + 1.0}
+
+
+class _TensorPredictor(nn.Module):
+    """Predictor accepting a single tensor named to match the transform's output key."""
+
+    def forward(self, out: torch.Tensor) -> torch.Tensor:
+        return out.sum(dim=-1, keepdim=True)
+
+
+class _DictPredictor(nn.Module):
+    """Predictor accepting a dict."""
+
+    def forward(self, inputs: dict[str, torch.Tensor]) -> torch.Tensor:
+        return next(iter(inputs.values())).sum(dim=-1, keepdim=True)
+
+
+class _MultiTensorPredictor(nn.Module):
+    """Predictor accepting three tensors, in forward-order ``b, a, c``."""
+
+    def forward(
+        self, b: torch.Tensor, a: torch.Tensor, c: torch.Tensor
+    ) -> torch.Tensor:
+        return a + b + c
+
+
+class _TwoParamPredictor(nn.Module):
+    """Predictor accepting only ``a, b`` (for schema-not-subset tests)."""
+
+    def forward(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+        return a + b
+
+
+class _TransformerDictTransform(nn.Module):
+    """Transform producing a ``[batch, seq, d_model]`` embedding for a predictor."""
+
+    def __init__(self, d_model: int = 64, seq_len: int = 10) -> None:
+        super().__init__()
+        self.d_model = d_model
+        self.seq_len = seq_len
+        self.proj = nn.Linear(1, d_model * seq_len)
+
+    def forward(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        x = next(iter(inputs.values()))
+        batch = x.size(0)
+        out = self.proj(x).view(batch, self.seq_len, self.d_model)
+        return {"emb": out}
+
+
+class _TransformerPredictor(nn.Module):
+    """Predictor using ``nn.TransformerEncoder``, accepting a dict with an ``emb`` key."""  # noqa: E501
+
+    def __init__(
+        self, d_model: int = 64, n_heads: int = 4, n_layers: int = 2, d_ff: int = 128
+    ) -> None:
+        super().__init__()
+        layer = nn.TransformerEncoderLayer(
+            d_model=d_model,
+            nhead=n_heads,
+            dim_feedforward=d_ff,
+            dropout=0.0,
+            activation="gelu",
+            batch_first=True,
+            norm_first=False,
+        )
+        self.transformer = nn.TransformerEncoder(
+            layer,
+            num_layers=n_layers,
+            norm=nn.LayerNorm(d_model),
+            enable_nested_tensor=False,
+        )
+        self.head = nn.Linear(d_model, 1)
+
+    def forward(self, inputs: dict[str, torch.Tensor]) -> torch.Tensor:
+        x = inputs["emb"]
+        out = self.transformer(x)
+        return self.head(out.mean(dim=1))
+
+
+class _NamedTupleTensorPredictor(nn.Module):
+    """Tensor-arg predictor with a NamedTuple output (fields ``b_out``, ``a_out``)."""
+
+    class Output(NamedTuple):
+        """Output fields, deliberately declared out of alphabetical order."""
+
+        b_out: torch.Tensor
+        a_out: torch.Tensor
+
+    def forward(
+        self, a: torch.Tensor, b: torch.Tensor
+    ) -> _NamedTupleTensorPredictor.Output:
+        return _NamedTupleTensorPredictor.Output(
+            b_out=b.sum(-1, keepdim=True), a_out=a.sum(-1, keepdim=True)
+        )
+
+
+class _NamedTupleDictPredictor(nn.Module):
+    """Dict-arg predictor with a NamedTuple output (fields ``z_out``, ``x_out``)."""
+
+    class Output(NamedTuple):
+        """Output fields, deliberately declared out of alphabetical order."""
+
+        z_out: torch.Tensor
+        x_out: torch.Tensor
+
+    def forward(
+        self, inputs: dict[str, torch.Tensor]
+    ) -> _NamedTupleDictPredictor.Output:
+        x = inputs["x"]
+        z = inputs["z"]
+        return _NamedTupleDictPredictor.Output(
+            z_out=z.sum(-1, keepdim=True), x_out=x.sum(-1, keepdim=True)
+        )
+
+
+class _NoAnnotNTPredictor(nn.Module):
+    """Predictor with no return annotation but a NamedTuple output."""
+
+    class Out(NamedTuple):
+        """Output fields ``c_out``, ``d_out``."""
+
+        c_out: torch.Tensor
+        d_out: torch.Tensor
+
+    def forward(self, x):
+        return _NoAnnotNTPredictor.Out(c_out=x, d_out=x * 2)
+
+
+class _SingleFieldNTPredictor(nn.Module):
+    """Predictor with no return annotation and a single-field NamedTuple output."""
+
+    class Out(NamedTuple):
+        """Output field ``e_out``."""
+
+        e_out: torch.Tensor
+
+    def forward(self, x):
+        return _SingleFieldNTPredictor.Out(e_out=x)
+
+
+class _Strategy1NT(NamedTuple):
+    """NamedTuple used as a concrete ``forward()`` return-type annotation."""
+
+    second: torch.Tensor
+    first: torch.Tensor
+
+
+class _Strategy1AnnotatedPredictor(nn.Module):
+    """Predictor whose ``forward`` return annotation is a concrete NamedTuple type."""
+
+    def forward(self, x: torch.Tensor) -> _Strategy1NT:
+        return _Strategy1NT(second=x * 2, first=x)
+
+
+class _PairTransform(nn.Module):
+    """Transform producing predictor inputs ``a`` and ``b`` from a single feature."""
+
+    def forward(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        x = inputs["in"]
+        return {"a": x, "b": x + 1.0}
+
+
+def _class_path(cls: type) -> str:
+    """Return the dotted import path for a test-fixture class defined in this module."""
+    return f"{__name__}.{cls.__qualname__}"
+
+
+def _simple_tx_and_pred_schemas() -> tuple[ModelSchema, ModelSchema]:
+    """Return a minimal ``tx_schema``/``pred_schema`` pair used by 6 fuse tests."""
+    tx_schema = ModelSchema(
+        input_schema=[ModelSchemaItem(name="in", data_type=DataType.FLOAT, shape=[1])],
+        output_schema=[
+            ModelSchemaItem(name="out", data_type=DataType.FLOAT, shape=[1])
+        ],
+    )
+    pred_schema = ModelSchema(
+        input_schema=[ModelSchemaItem(name="out", data_type=DataType.FLOAT, shape=[1])],
+        output_schema=[
+            ModelSchemaItem(name="output", data_type=DataType.FLOAT, shape=[1])
+        ],
+    )
+    return tx_schema, pred_schema
+
+
+# ===========================================================================
+# Tranche 1: non-native-transform, non-ONNX
+# ===========================================================================
+
+
+class SchemaHelpersTest(unittest.TestCase):
+    """Tests for ``_schema_input_keys`` and ``_schema_output_keys``."""
+
+    def test_schema_input_keys_empty(self):
+        """Schema input keys empty."""
+        self.assertEqual(_schema_input_keys(None), [])
+        self.assertEqual(_schema_input_keys(ModelSchema()), [])
+        self.assertEqual(_schema_input_keys(ModelSchema(input_schema=[])), [])
+
+    def test_schema_input_keys_order(self):
+        """Schema input keys order."""
+        schema = ModelSchema(
+            input_schema=[
+                ModelSchemaItem(name="a", data_type=DataType.FLOAT),
+                ModelSchemaItem(name="b", data_type=DataType.INT),
+            ]
+        )
+        self.assertEqual(_schema_input_keys(schema), ["a", "b"])
+
+    def test_schema_output_keys_empty(self):
+        """Schema output keys empty."""
+        self.assertEqual(_schema_output_keys(None), [])
+        self.assertEqual(_schema_output_keys(ModelSchema()), [])
+        self.assertEqual(_schema_output_keys(ModelSchema(output_schema=[])), [])
+
+    def test_schema_output_keys_order(self):
+        """Schema output keys order."""
+        schema = ModelSchema(
+            output_schema=[
+                ModelSchemaItem(name="x", data_type=DataType.FLOAT),
+                ModelSchemaItem(name="y", data_type=DataType.INT),
+            ]
+        )
+        self.assertEqual(_schema_output_keys(schema), ["x", "y"])
+
+
+class ForwardAcceptsDictTest(unittest.TestCase):
+    """Tests for ``_forward_accepts_dict``."""
+
+    def test_accepts_dict_true(self):
+        """Accepts dict true.
+
+        Also covers the stringized-annotation form: this module has
+        ``from __future__ import annotations``, so every annotation here
+        (including this one) is already stringized.
+        """
+
+        class M(nn.Module):
+            def forward(self, x: dict[str, torch.Tensor]) -> torch.Tensor:
+                return next(iter(x.values()))
+
+        self.assertTrue(fuse_module._forward_accepts_dict(M()))
+
+    def test_accepts_dict_false_single_tensor(self):
+        """Accepts dict false single tensor."""
+
+        class M(nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return x
+
+        self.assertFalse(fuse_module._forward_accepts_dict(M()))
+
+    def test_accepts_dict_false_no_annotation(self):
+        """Accepts dict false no annotation."""
+
+        class M(nn.Module):
+            def forward(self, x):
+                return x
+
+        self.assertFalse(fuse_module._forward_accepts_dict(M()))
+
+    def test_accepts_dict_false_forward_no_params(self):
+        """Accepts dict false forward no params."""
+
+        class M(nn.Module):
+            def forward(self) -> torch.Tensor:
+                return torch.tensor(0.0)
+
+        self.assertFalse(fuse_module._forward_accepts_dict(M()))
+
+    def test_accepts_dict_false_when_signature_raises(self):
+        """Accepts dict false when signature raises."""
+        m = _TensorPredictor()
+        with mock.patch(f"{_FUSE_MODULE}.inspect.signature") as sig:
+            sig.side_effect = ValueError("cannot inspect")
+            self.assertFalse(fuse_module._forward_accepts_dict(m))
+        with mock.patch(f"{_FUSE_MODULE}.inspect.signature") as sig:
+            sig.side_effect = TypeError("cannot inspect")
+            self.assertFalse(fuse_module._forward_accepts_dict(m))
+
+    def test_accepts_dict_false_non_dict_annotation_after_self(self):
+        """Accepts dict false non dict annotation after self."""
+
+        class M(nn.Module):
+            def forward(self, x: int) -> torch.Tensor:
+                return torch.tensor(float(x))
+
+        self.assertFalse(fuse_module._forward_accepts_dict(M()))
+
+    def test_accepts_dict_continue_when_param_is_self(self):
+        """A signature that still lists ``self`` exercises the ``continue`` branch."""
+        m = _TensorPredictor()
+        self_param = inspect.Parameter(
+            "self",
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            annotation=inspect.Parameter.empty,
+        )
+        x_param = inspect.Parameter(
+            "x", inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=dict
+        )
+        fake_sig = inspect.Signature(parameters=[self_param, x_param])
+        with mock.patch(f"{_FUSE_MODULE}.inspect.signature", return_value=fake_sig):
+            self.assertTrue(fuse_module._forward_accepts_dict(m))
+
+
+class ForwardParamOrderTest(unittest.TestCase):
+    """Tests for ``_forward_param_order``."""
+
+    def test_returns_param_names_excluding_self(self):
+        """Returns param names excluding self."""
+        self.assertEqual(fuse_module._forward_param_order(_TensorPredictor()), ["out"])
+        self.assertEqual(fuse_module._forward_param_order(_DictPredictor()), ["inputs"])
+
+    def test_returns_multiple_params_in_signature_order(self):
+        """Returns multiple params in signature order."""
+
+        class M(nn.Module):
+            def forward(
+                self, a: torch.Tensor, b: torch.Tensor, c: torch.Tensor
+            ) -> torch.Tensor:
+                return a + b + c
+
+        self.assertEqual(fuse_module._forward_param_order(M()), ["a", "b", "c"])
+
+    def test_returns_empty_when_no_params_after_self(self):
+        """Returns empty when no params after self."""
+
+        class M(nn.Module):
+            def forward(self) -> torch.Tensor:
+                return torch.tensor(0.0)
+
+        self.assertEqual(fuse_module._forward_param_order(M()), [])
+
+    def test_returns_empty_when_signature_raises(self):
+        """Returns empty when signature raises."""
+        m = _TensorPredictor()
+        with mock.patch(f"{_FUSE_MODULE}.inspect.signature") as sig:
+            sig.side_effect = ValueError("cannot inspect")
+            self.assertEqual(fuse_module._forward_param_order(m), [])
+        with mock.patch(f"{_FUSE_MODULE}.inspect.signature") as sig:
+            sig.side_effect = TypeError("cannot inspect")
+            self.assertEqual(fuse_module._forward_param_order(m), [])
+
+
+class BuildFusedSampleInputTest(unittest.TestCase):
+    """Tests for ``_build_fused_sample_input``."""
+
+    def test_empty_schemas_returns_empty_dict(self):
+        """Empty schemas returns empty dict."""
+        self.assertEqual(_build_fused_sample_input(None, None), {})
+        self.assertEqual(_build_fused_sample_input(ModelSchema(), ModelSchema()), {})
+
+    def test_returns_tensors_with_correct_shape_and_dtype(self):
+        """Returns tensors with correct shape and dtype."""
+        schema = ModelSchema(
+            input_schema=[
+                ModelSchemaItem(name="a", data_type=DataType.FLOAT, shape=[2]),
+                ModelSchemaItem(name="b", data_type=DataType.LONG, shape=[1]),
+            ]
+        )
+        out = _build_fused_sample_input(schema, None)
+        self.assertEqual(set(out.keys()), {"a", "b"})
+        self.assertEqual(out["a"].shape, (1, 2))
+        self.assertEqual(out["a"].dtype, torch.float32)
+        self.assertEqual(out["b"].shape, (1, 1))
+        self.assertEqual(out["b"].dtype, torch.int64)
+
+    def test_batch_size_parameter(self):
+        """Batch size parameter."""
+        schema = ModelSchema(
+            input_schema=[
+                ModelSchemaItem(name="x", data_type=DataType.FLOAT, shape=[1])
+            ]
+        )
+        out = _build_fused_sample_input(schema, None, batch_size=4)
+        self.assertEqual(out["x"].shape, (4, 1))
+
+    def test_sample_tensors_device_matches_cuda_availability(self):
+        """Sample tensors device matches cuda availability."""
+        schema = ModelSchema(
+            input_schema=[
+                ModelSchemaItem(name="x", data_type=DataType.FLOAT, shape=[1])
+            ]
+        )
+        out = _build_fused_sample_input(schema, None)
+        expected_type = "cuda" if torch.cuda.is_available() else "cpu"
+        self.assertTrue(all(t.device.type == expected_type for t in out.values()))
+
+    def test_zero_or_empty_shape_uses_minimum_one(self):
+        """Zero or empty shape uses minimum one."""
+        schema = ModelSchema(
+            input_schema=[
+                ModelSchemaItem(name="a", data_type=DataType.FLOAT, shape=[0])
+            ]
+        )
+        out = _build_fused_sample_input(schema, None)
+        self.assertEqual(out["a"].shape, (1, 1))
+
+    def test_keys_match_fused_input_schema(self):
+        """Keys match fused input schema."""
+        tx = ModelSchema(
+            input_schema=[
+                ModelSchemaItem(name="feat", data_type=DataType.FLOAT, shape=[1])
+            ],
+            output_schema=[
+                ModelSchemaItem(name="emb", data_type=DataType.FLOAT, shape=[10, 64])
+            ],
+        )
+        pred = ModelSchema(
+            input_schema=[
+                ModelSchemaItem(name="emb", data_type=DataType.FLOAT, shape=[10, 64])
+            ],
+            output_schema=[
+                ModelSchemaItem(name="out", data_type=DataType.FLOAT, shape=[1])
+            ],
+        )
+        sample = _build_fused_sample_input(tx, pred)
+        self.assertEqual(set(sample.keys()), {"feat"})
+
+    def test_unmappable_data_type_raises(self):
+        """Unmappable data type raises."""
+        schema = ModelSchema(
+            input_schema=[ModelSchemaItem(name="a", data_type=None, shape=[3])]
+        )
+        with self.assertRaises(ValueError):
+            _build_fused_sample_input(schema, None)
+
+
+class BuildFusedSampleDataTest(unittest.TestCase):
+    """Tests for ``build_fused_sample_data``."""
+
+    def test_merges_and_filters_to_fused_inputs(self):
+        """Merges and filters to fused inputs."""
+        result = build_fused_sample_data(
+            tx_sample_data=[{"raw_a": 1.0}, {"raw_b": 2}],
+            predictor_sample_data=[{"raw_b": 99, "tx_only": 3.0}],
+            fused_input_cols={"raw_a", "raw_b"},
+        )
+        self.assertEqual(result, [{"raw_a": 1.0, "raw_b": 2}])
+
+    def test_none_samples_return_single_empty_batch(self):
+        """None samples return single empty batch."""
+        self.assertEqual(build_fused_sample_data(None, None, {"unused"}), [{}])
+
+
+class IsStateDictTest(unittest.TestCase):
+    """Tests for ``_is_state_dict``."""
+
+    def test_true_for_dict_of_tensors(self):
+        """True for dict of tensors."""
+        self.assertTrue(_is_state_dict({"a": torch.zeros(1), "b": torch.ones(2)}))
+
+    def test_empty_dict_considered_state_dict(self):
+        """Empty dict considered state dict."""
+        self.assertTrue(_is_state_dict({}))
+
+    def test_false_for_non_dict(self):
+        """False for non dict."""
+        self.assertFalse(_is_state_dict(torch.zeros(1)))
+        self.assertFalse(_is_state_dict(None))
+
+    def test_false_for_dict_with_non_tensor_value(self):
+        """False for dict with non tensor value."""
+        self.assertFalse(_is_state_dict({"a": torch.zeros(1), "b": 1}))
+
+
+class LoadModuleFromPathTest(unittest.TestCase):
+    """Tests for ``_load_module_from_path``."""
+
+    def test_missing_file_raises(self):
+        """Missing file raises."""
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "nonexistent.pt")
+            with self.assertRaises(FileNotFoundError) as ctx:
+                _load_module_from_path(path, "some.Class", {})
+            self.assertIn("Model file not found", str(ctx.exception))
+
+    def _save_and_load(self, obj, model_class="ignored", hyperparameters=None):
+        with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
+            path = f.name
+        try:
+            torch.save(obj, path)
+            return _load_module_from_path(path, model_class, hyperparameters)
+        finally:
+            os.unlink(path)
+
+    def test_load_full_module(self):
+        """Load full module."""
+        model = _TensorPredictor()
+        loaded = self._save_and_load(model, hyperparameters={})
+        self.assertIsInstance(loaded, nn.Module)
+        self.assertFalse(loaded.training)
+        x = torch.randn(2, 3)
+        torch.testing.assert_close(loaded(x), model(x))
+
+    def test_load_state_dict_with_class(self):
+        """Load state dict with class."""
+        model = _TensorPredictor()
+        loaded = self._save_and_load(
+            model.state_dict(), _class_path(_TensorPredictor), hyperparameters={}
+        )
+        self.assertIsInstance(loaded, _TensorPredictor)
+        loaded.eval()
+
+    def test_load_state_dict_with_none_hyperparameters(self):
+        """Load state dict with none hyperparameters."""
+        model = _TensorPredictor()
+        loaded = self._save_and_load(model.state_dict(), _class_path(_TensorPredictor))
+        self.assertIsInstance(loaded, _TensorPredictor)
+
+    def test_load_non_module_non_state_dict_raises_type_error(self):
+        """Load non module non state dict raises type error."""
+        with self.assertRaises(TypeError) as ctx:
+            self._save_and_load([1, 2, 3], hyperparameters={})
+        self.assertIn("did not contain a state_dict or nn.Module", str(ctx.exception))
+
+
+class FuseModelsToTorchscriptTest(unittest.TestCase):
+    """Integration tests for ``fuse_models_to_torchscript``."""
+
+    def test_predictor_input_keys_dispatch(self):
+        """Predictor input key selection across dict/tensor predictors.
+
+        Covers 4 distinct dispatch behaviors: schema order for dict
+        predictors, forward order for tensor predictors, a ``ValueError``
+        when the schema isn't a subset of ``forward()``'s params, and
+        schema-order fallback when forward-param inspection is empty.
+        """
+        cases = [
+            {
+                "predictor_cls": _DictPredictor,
+                "schema_names": ["c", "a", "b"],
+                "tx_output_name": "c",
+                "extra_mock_target": None,
+                "expect_error": False,
+                "expected_takes_dict": True,
+                "expected_keys": ["c", "a", "b"],
+            },
+            {
+                "predictor_cls": _MultiTensorPredictor,
+                "schema_names": ["a", "b", "c"],
+                "tx_output_name": "a",
+                "extra_mock_target": None,
+                "expect_error": False,
+                "expected_takes_dict": False,
+                # forward order is (b, a, c); schema order is (a, b, c).
+                "expected_keys": ["b", "a", "c"],
+            },
+            {
+                "predictor_cls": _TwoParamPredictor,
+                "schema_names": ["a", "b", "c"],
+                "tx_output_name": "a",
+                "extra_mock_target": None,
+                "expect_error": True,
+                "expected_takes_dict": None,
+                "expected_keys": None,
+            },
+            {
+                "predictor_cls": _TensorPredictor,
+                "schema_names": ["x"],
+                "tx_output_name": "x",
+                "extra_mock_target": f"{_FUSE_MODULE}._forward_param_order",
+                "expect_error": False,
+                "expected_takes_dict": False,
+                "expected_keys": ["x"],
+            },
+        ]
+        for case in cases:
+            with self.subTest(predictor=case["predictor_cls"].__name__):
+                schema = ModelSchema(
+                    input_schema=[
+                        ModelSchemaItem(name=n, data_type=DataType.FLOAT, shape=[1])
+                        for n in case["schema_names"]
+                    ],
+                    output_schema=[
+                        ModelSchemaItem(name="out", data_type=DataType.FLOAT, shape=[1])
+                    ],
+                )
+                with tempfile.TemporaryDirectory() as d:
+                    tx_path = os.path.join(d, "tx.pt")
+                    pred_path = os.path.join(d, "pred.pt")
+                    dest_path = os.path.join(d, "fused.pt")
+                    torch.save(_DictTransform().state_dict(), tx_path)
+                    torch.save(case["predictor_cls"]().state_dict(), pred_path)
+                    tx_schema = ModelSchema(
+                        input_schema=[
+                            ModelSchemaItem(
+                                name="in", data_type=DataType.FLOAT, shape=[1]
+                            )
+                        ],
+                        output_schema=[
+                            ModelSchemaItem(
+                                name=case["tx_output_name"],
+                                data_type=DataType.FLOAT,
+                                shape=[1],
+                            )
+                        ],
+                    )
+                    ctx = None
+                    with contextlib.ExitStack() as stack:
+                        if case["expect_error"]:
+                            ctx = stack.enter_context(self.assertRaises(ValueError))
+                        else:
+                            mock_fused = stack.enter_context(
+                                mock.patch(f"{_FUSE_MODULE}.FusedModel")
+                            )
+                            stack.enter_context(
+                                mock.patch(
+                                    "torch.jit.trace", return_value=mock.MagicMock()
+                                )
+                            )
+                            stack.enter_context(mock.patch("torch.jit.save"))
+                            if case["extra_mock_target"]:
+                                stack.enter_context(
+                                    mock.patch(
+                                        case["extra_mock_target"], return_value=[]
+                                    )
+                                )
+                        fuse_models_to_torchscript(
+                            torch_model_path=pred_path,
+                            tx_model_path=tx_path,
+                            model_class=_class_path(case["predictor_cls"]),
+                            hyperparameters={},
+                            tx_model_class=_class_path(_DictTransform),
+                            tx_hyperparameters={},
+                            dest_path=dest_path,
+                            tx_model_schema=tx_schema,
+                            model_schema=schema,
+                        )
+                    if case["expect_error"]:
+                        self.assertIn("c", str(ctx.exception))
+                        self.assertIn("forward()", str(ctx.exception))
+                    else:
+                        call_kwargs = mock_fused.call_args[1]
+                        self.assertEqual(
+                            call_kwargs["predictor_takes_dict"],
+                            case["expected_takes_dict"],
+                        )
+                        self.assertEqual(
+                            call_kwargs["predictor_input_keys"],
+                            case["expected_keys"],
+                        )
+
+    def test_dest_filename_only_uses_dot_makedirs(self):
+        """Dest filename only uses dot makedirs."""
+        with tempfile.TemporaryDirectory() as d:
+            tx_path = os.path.join(d, "tx.pt")
+            pred_path = os.path.join(d, "pred.pt")
+            torch.save(_DictTransform().state_dict(), tx_path)
+            torch.save(_TensorPredictor().state_dict(), pred_path)
+            tx_schema, pred_schema = _simple_tx_and_pred_schemas()
+            old = os.getcwd()
+            try:
+                os.chdir(d)
+                fuse_models_to_torchscript(
+                    torch_model_path=pred_path,
+                    tx_model_path=tx_path,
+                    model_class=_class_path(_TensorPredictor),
+                    hyperparameters={},
+                    tx_model_class=_class_path(_DictTransform),
+                    tx_hyperparameters={},
+                    dest_path="bare_name.pt",
+                    tx_model_schema=tx_schema,
+                    model_schema=pred_schema,
+                )
+                self.assertTrue(os.path.isfile(os.path.join(d, "bare_name.pt")))
+            finally:
+                os.chdir(old)
+
+    def test_saves_torchscript_and_returns_dest_path(self):
+        """Saves torchscript and returns dest path."""
+        with tempfile.TemporaryDirectory() as d:
+            tx_path = os.path.join(d, "tx.pt")
+            pred_path = os.path.join(d, "pred.pt")
+            dest_path = os.path.join(d, "fused.pt")
+            torch.save(_DictTransform().state_dict(), tx_path)
+            torch.save(_TensorPredictor().state_dict(), pred_path)
+            tx_schema, pred_schema = _simple_tx_and_pred_schemas()
+            result = fuse_models_to_torchscript(
+                torch_model_path=pred_path,
+                tx_model_path=tx_path,
+                model_class=_class_path(_TensorPredictor),
+                hyperparameters={},
+                tx_model_class=_class_path(_DictTransform),
+                tx_hyperparameters={},
+                dest_path=dest_path,
+                tx_model_schema=tx_schema,
+                model_schema=pred_schema,
+            )
+            self.assertEqual(result, dest_path)
+            self.assertTrue(os.path.isfile(dest_path))
+
+            loaded = torch.jit.load(dest_path)
+            out = loaded({"in": torch.tensor([[1.0]], dtype=torch.float32)})
+            self.assertIsInstance(out, torch.Tensor)
+            self.assertEqual(out.shape, (1, 1))
+
+    def test_raises_when_fused_input_schema_empty(self):
+        """Raises when fused input schema empty."""
+        with tempfile.TemporaryDirectory() as d:
+            tx_path = os.path.join(d, "tx.pt")
+            pred_path = os.path.join(d, "pred.pt")
+            dest_path = os.path.join(d, "fused.pt")
+            torch.save(_DictTransform().state_dict(), tx_path)
+            torch.save(_TensorPredictor().state_dict(), pred_path)
+            with self.assertRaises(ValueError) as ctx:
+                fuse_models_to_torchscript(
+                    torch_model_path=pred_path,
+                    tx_model_path=tx_path,
+                    model_class=_class_path(_TensorPredictor),
+                    hyperparameters={},
+                    tx_model_class=_class_path(_DictTransform),
+                    tx_hyperparameters={},
+                    dest_path=dest_path,
+                    tx_model_schema=None,
+                    model_schema=None,
+                )
+            self.assertIn("Cannot build sample input", str(ctx.exception))
+
+    def test_fuse_with_dict_predictor(self):
+        """Fuse with dict predictor."""
+        with tempfile.TemporaryDirectory() as d:
+            tx_path = os.path.join(d, "tx.pt")
+            pred_path = os.path.join(d, "pred.pt")
+            dest_path = os.path.join(d, "fused.pt")
+            torch.save(_DictTransform().state_dict(), tx_path)
+            torch.save(_DictPredictor().state_dict(), pred_path)
+            tx_schema, pred_schema = _simple_tx_and_pred_schemas()
+            result = fuse_models_to_torchscript(
+                torch_model_path=pred_path,
+                tx_model_path=tx_path,
+                model_class=_class_path(_DictPredictor),
+                hyperparameters={},
+                tx_model_class=_class_path(_DictTransform),
+                tx_hyperparameters={},
+                dest_path=dest_path,
+                tx_model_schema=tx_schema,
+                model_schema=pred_schema,
+            )
+            self.assertEqual(result, dest_path)
+            self.assertTrue(os.path.isfile(dest_path))
+
+    def test_fuse_with_transformer_predictor(self):
+        """Fuse with transformer predictor."""
+        with tempfile.TemporaryDirectory() as d:
+            tx_path = os.path.join(d, "tx.pt")
+            pred_path = os.path.join(d, "pred.pt")
+            dest_path = os.path.join(d, "fused.pt")
+            torch.save(
+                _TransformerDictTransform(d_model=64, seq_len=10).state_dict(), tx_path
+            )
+            torch.save(
+                _TransformerPredictor(
+                    d_model=64, n_heads=4, n_layers=2, d_ff=128
+                ).state_dict(),
+                pred_path,
+            )
+            tx_schema = ModelSchema(
+                input_schema=[
+                    ModelSchemaItem(name="feat", data_type=DataType.FLOAT, shape=[1])
+                ],
+                output_schema=[
+                    ModelSchemaItem(
+                        name="emb", data_type=DataType.FLOAT, shape=[10, 64]
+                    )
+                ],
+            )
+            pred_schema = ModelSchema(
+                input_schema=[
+                    ModelSchemaItem(
+                        name="emb", data_type=DataType.FLOAT, shape=[10, 64]
+                    )
+                ],
+                output_schema=[
+                    ModelSchemaItem(name="output", data_type=DataType.FLOAT, shape=[1])
+                ],
+            )
+            result = fuse_models_to_torchscript(
+                torch_model_path=pred_path,
+                tx_model_path=tx_path,
+                model_class=_class_path(_TransformerPredictor),
+                hyperparameters={
+                    "d_model": 64,
+                    "n_heads": 4,
+                    "n_layers": 2,
+                    "d_ff": 128,
+                },
+                tx_model_class=_class_path(_TransformerDictTransform),
+                tx_hyperparameters={"d_model": 64, "seq_len": 10},
+                dest_path=dest_path,
+                tx_model_schema=tx_schema,
+                model_schema=pred_schema,
+            )
+            self.assertEqual(result, dest_path)
+            self.assertTrue(os.path.isfile(dest_path))
+
+            loaded = torch.jit.load(dest_path)
+            out = loaded({"feat": torch.randn(2, 1, dtype=torch.float32)})
+            self.assertIsInstance(out, torch.Tensor)
+            self.assertEqual(out.shape, (2, 1))
+
+
+class GetPredictorOutputFieldOrderTest(unittest.TestCase):
+    """Tests for ``get_predictor_output_field_order``."""
+
+    def _make_schema(
+        self, input_names: list[str], output_names: list[str]
+    ) -> ModelSchema:
+        return ModelSchema(
+            input_schema=[
+                ModelSchemaItem(name=n, data_type=DataType.FLOAT, shape=[1])
+                for n in input_names
+            ],
+            output_schema=[
+                ModelSchemaItem(name=n, data_type=DataType.FLOAT, shape=[1])
+                for n in output_names
+            ],
+        )
+
+    def _run_field_order(self, obj, model_class="", hyperparameters=None, schema=None):
+        with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
+            path = f.name
+        try:
+            torch.save(obj, path)
+            return get_predictor_output_field_order(
+                path, model_class, hyperparameters or {}, schema
+            )
+        finally:
+            os.unlink(path)
+
+    def test_tensor_predictor_named_tuple_returns_definition_order(self):
+        """Tensor predictor named tuple returns definition order."""
+        schema = self._make_schema(["a", "b"], ["a_out", "b_out"])
+        result = self._run_field_order(_NamedTupleTensorPredictor(), schema=schema)
+        # _fields order is b_out, a_out (definition order), not schema order.
+        self.assertEqual(result, ["b_out", "a_out"])
+
+    def test_dict_predictor_named_tuple_returns_definition_order(self):
+        """Dict predictor named tuple returns definition order."""
+        schema = self._make_schema(["x", "z"], ["x_out", "z_out"])
+        result = self._run_field_order(_NamedTupleDictPredictor(), schema=schema)
+        self.assertEqual(result, ["z_out", "x_out"])
+
+    def test_plain_tensor_output_returns_none(self):
+        """Plain tensor output returns none."""
+        schema = self._make_schema(["out"], ["result"])
+        result = self._run_field_order(_TensorPredictor(), schema=schema)
+        self.assertIsNone(result)
+
+    def test_missing_file_returns_none_with_warning(self):
+        """Missing file returns none with warning."""
+        schema = self._make_schema(["x"], ["y"])
+        with tempfile.TemporaryDirectory() as d:
+            bad_path = os.path.join(d, "nonexistent.pt")
+            with self.assertLogs(level="WARNING") as cm:
+                result = get_predictor_output_field_order(bad_path, "", {}, schema)
+        self.assertIsNone(result)
+        self.assertTrue(any("Output schema unchanged" in line for line in cm.output))
+
+    def test_strategy2_no_annotation_with_named_tuple_output(self):
+        """Strategy2 no annotation with named tuple output."""
+        schema = self._make_schema(["x"], ["c_out", "d_out"])
+        result = self._run_field_order(_NoAnnotNTPredictor(), schema=schema)
+        self.assertEqual(result, ["c_out", "d_out"])
+
+    def test_strategy1_named_tuple_from_return_annotation_state_dict(self):
+        """Strategy1 named tuple from return annotation state dict."""
+        schema = self._make_schema(["x"], ["second", "first"])
+        result = self._run_field_order(
+            _Strategy1AnnotatedPredictor().state_dict(),
+            model_class=_class_path(_Strategy1AnnotatedPredictor),
+            schema=schema,
+        )
+        self.assertEqual(result, ["second", "first"])
+
+    def test_strategy1_signature_failure_falls_through_to_strategy2(self):
+        """When Strategy 1's signature inspection raises, Strategy 2 still runs."""
+        schema = self._make_schema(["x"], ["c_out", "d_out"])
+        calls = {"n": 0}
+        real_sig = inspect.signature
+
+        def _sig(obj):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise ValueError("simulated Strategy 1 failure")
+            return real_sig(obj)
+
+        with mock.patch(f"{_FUSE_MODULE}.inspect.signature", side_effect=_sig):
+            result = self._run_field_order(_NoAnnotNTPredictor(), schema=schema)
+        self.assertEqual(result, ["c_out", "d_out"])
+
+
+class ComputePythonFuseMetadataTest(unittest.TestCase):
+    """Tests for ``compute_python_fuse_metadata``."""
+
+    def _run(self, predictor, pred_class, tx_schema=None, pred_schema=None):
+        with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
+            path = f.name
+        try:
+            torch.save(predictor.state_dict(), path)
+            return compute_python_fuse_metadata(
+                torch_model_path=path,
+                model_class=pred_class,
+                hyperparameters={},
+                tx_model_schema=tx_schema,
+                model_schema=pred_schema,
+            )
+        finally:
+            os.unlink(path)
+
+    def test_dict_predictor_returns_schema_order_keys(self):
+        """Dict predictor returns schema order keys."""
+        tx_schema = ModelSchema(
+            input_schema=[
+                ModelSchemaItem(name="in_a", data_type=DataType.FLOAT, shape=[1]),
+                ModelSchemaItem(name="in_b", data_type=DataType.FLOAT, shape=[1]),
+            ]
+        )
+        pred_schema = ModelSchema(
+            input_schema=[
+                ModelSchemaItem(name="out", data_type=DataType.FLOAT, shape=[1]),
+                ModelSchemaItem(name="extra", data_type=DataType.FLOAT, shape=[1]),
+            ]
+        )
+        tx_keys, pred_keys, takes_dict = self._run(
+            _DictPredictor(), _class_path(_DictPredictor), tx_schema, pred_schema
+        )
+        self.assertEqual(tx_keys, ["in_a", "in_b"])
+        self.assertEqual(pred_keys, ["out", "extra"])
+        self.assertTrue(takes_dict)
+
+    def test_tensor_predictor_reorders_keys_to_forward_order(self):
+        """Tensor predictor reorders keys to forward order."""
+        tx_schema = ModelSchema(
+            input_schema=[
+                ModelSchemaItem(name="tx_in", data_type=DataType.FLOAT, shape=[1])
+            ]
+        )
+        pred_schema = ModelSchema(
+            input_schema=[
+                ModelSchemaItem(name="a", data_type=DataType.FLOAT, shape=[1]),
+                ModelSchemaItem(name="b", data_type=DataType.FLOAT, shape=[1]),
+                ModelSchemaItem(name="c", data_type=DataType.FLOAT, shape=[1]),
+            ]
+        )
+        tx_keys, pred_keys, takes_dict = self._run(
+            _MultiTensorPredictor(),
+            _class_path(_MultiTensorPredictor),
+            tx_schema,
+            pred_schema,
+        )
+        self.assertEqual(tx_keys, ["tx_in"])
+        self.assertEqual(pred_keys, ["b", "a", "c"])
+        self.assertFalse(takes_dict)
+
+    def test_raises_when_schema_not_subset_of_forward(self):
+        """Raises when schema not subset of forward."""
+        bad_schema = ModelSchema(
+            input_schema=[
+                ModelSchemaItem(name="a", data_type=DataType.FLOAT, shape=[1]),
+                ModelSchemaItem(name="b", data_type=DataType.FLOAT, shape=[1]),
+                ModelSchemaItem(name="c", data_type=DataType.FLOAT, shape=[1]),
+            ]
+        )
+        with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
+            path = f.name
+        try:
+            torch.save(_TwoParamPredictor().state_dict(), path)
+            with self.assertRaises(ValueError) as ctx:
+                compute_python_fuse_metadata(
+                    torch_model_path=path,
+                    model_class=_class_path(_TwoParamPredictor),
+                    hyperparameters={},
+                    tx_model_schema=None,
+                    model_schema=bad_schema,
+                )
+            self.assertIn("c", str(ctx.exception))
+            self.assertIn("forward()", str(ctx.exception))
+        finally:
+            os.unlink(path)
+
+    def test_none_schemas_return_empty_keys(self):
+        """None schemas return empty keys."""
+        tx_keys, pred_keys, takes_dict = self._run(
+            _TensorPredictor(), _class_path(_TensorPredictor)
+        )
+        self.assertEqual(tx_keys, [])
+        self.assertEqual(pred_keys, [])
+        self.assertFalse(takes_dict)
+
+
+# ===========================================================================
+# Tranche 2: ONNX
+# ===========================================================================
+
+
+class ExpandBatchForOnnxExportTest(unittest.TestCase):
+    """Tests for ``_expand_batch_for_onnx_export``."""
+
+    def test_repeats_batch_one_to_two(self):
+        """Repeats batch one to two."""
+        a = torch.zeros(1, 3)
+        b = torch.ones(1, 1)
+        out = fuse_module._expand_batch_for_onnx_export((a, b))
+        self.assertEqual(out[0].shape, (2, 3))
+        self.assertEqual(out[1].shape, (2, 1))
+
+    def test_leaves_batch_greater_than_one_unchanged(self):
+        """Leaves batch greater than one unchanged."""
+        a = torch.randn(3, 2)
+        b = torch.randn(1, 2)
+        out = fuse_module._expand_batch_for_onnx_export((a, b))
+        self.assertIs(out[0], a)
+        self.assertEqual(out[1].shape[0], 2)
+
+
+class DisableTransformerEncoderFastpathForOnnxTest(unittest.TestCase):
+    """Tests for ``_disable_transformer_encoder_fused_fastpath_for_onnx``."""
+
+    def test_noop_when_mha_backend_missing(self):
+        """Noop when mha backend missing."""
+        root = nn.Linear(1, 1)
+        root.eval()
+        with mock.patch.object(fuse_module.torch, "backends", SimpleNamespace()):
+            with _disable_transformer_encoder_fused_fastpath_for_onnx(root):
+                self.assertFalse(root.training)
+            self.assertFalse(root.training)
+
+    def test_noop_preserves_train_when_mha_backend_missing(self):
+        """Noop preserves train when mha backend missing."""
+        root = nn.Linear(1, 1)
+        root.train()
+        with mock.patch.object(fuse_module.torch, "backends", SimpleNamespace()):
+            with _disable_transformer_encoder_fused_fastpath_for_onnx(root):
+                self.assertTrue(root.training)
+            self.assertTrue(root.training)
+
+    def test_mha_setter_without_getter_defaults_prev_to_true(self):
+        """Mha setter without getter defaults prev to true."""
+        calls: list[bool] = []
+
+        class _Mha:
+            def set_fastpath_enabled(self, enabled: bool) -> None:
+                calls.append(enabled)
+
+        with mock.patch.object(fuse_module.torch.backends, "mha", _Mha(), create=True):
+            root = nn.Linear(1, 1)
+            with _disable_transformer_encoder_fused_fastpath_for_onnx(root):
+                self.assertEqual(calls, [False])
+            self.assertEqual(calls, [False, True])
+
+
+class OnnxDynamoExporterDepsTest(unittest.TestCase):
+    """Tests for ``_onnx_dynamo_exporter_dependencies_available``."""
+
+    def test_true_when_onnxscript_importable(self):
+        """True when onnxscript importable."""
+        with mock.patch.object(
+            fuse_module.importlib.util, "find_spec", return_value=object()
+        ):
+            self.assertTrue(_onnx_dynamo_exporter_dependencies_available())
+
+    def test_false_when_onnxscript_missing(self):
+        """False when onnxscript missing."""
+        with mock.patch.object(
+            fuse_module.importlib.util, "find_spec", return_value=None
+        ):
+            self.assertFalse(_onnx_dynamo_exporter_dependencies_available())
+
+
+class OnnxDynamoDynamicShapesForTupleArgTest(unittest.TestCase):
+    """Tests for ``_onnx_dynamo_dynamic_shapes_for_tuple_arg``."""
+
+    def test_returns_none_when_torch_export_dim_unavailable(self):
+        """Returns none when torch export dim unavailable."""
+        with mock.patch.object(fuse_module, "_TorchExportDim", None):
+            self.assertIsNone(
+                _onnx_dynamo_dynamic_shapes_for_tuple_arg((torch.zeros(1),))
+            )
+
+    def test_returns_one_dim_dict_per_tensor(self):
+        """Returns one dim dict per tensor."""
+        result = _onnx_dynamo_dynamic_shapes_for_tuple_arg(
+            (torch.zeros(1, 2), torch.zeros(1, 3))
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result), 1)
+        per_tensor_dims = result[0]
+        self.assertEqual(len(per_tensor_dims), 2)
+        for dims in per_tensor_dims:
+            self.assertEqual(set(dims.keys()), {0})
+
+
+class OnnxDynamoExportErrorRetryPolicyTest(unittest.TestCase):
+    """Tests for ``_onnx_dynamo_export_error_should_retry_legacy``."""
+
+    def test_import_errors_always_retry(self):
+        """Import errors always retry."""
+        self.assertTrue(_onnx_dynamo_export_error_should_retry_legacy(ImportError("x")))
+        self.assertTrue(
+            _onnx_dynamo_export_error_should_retry_legacy(ModuleNotFoundError("x"))
+        )
+
+    def test_known_dynamo_failure_signatures_retry(self):
+        """Known dynamo failure signatures retry."""
+        messages = [
+            "onnxscript is required",
+            "ConvertVersionPass failed",
+            "version conversion pass error",
+            "model contains functions that dynamo cannot trace",
+            "torch.onnx._internal.exporter._errors.PassError",
+            "failed to convert 'dynamic_axes' to dynamic_shapes",
+            "TreeSpec.unflatten mismatch",
+            "torch.onnx._internal.exporter._errors.TorchExportError: failed",
+            "Unexpected dimension #0 in input tensor shape",
+        ]
+        for msg in messages:
+            with self.subTest(msg=msg):
+                self.assertTrue(
+                    _onnx_dynamo_export_error_should_retry_legacy(RuntimeError(msg))
+                )
+
+    def test_unrelated_error_does_not_retry(self):
+        """Unrelated error does not retry."""
+        self.assertFalse(
+            _onnx_dynamo_export_error_should_retry_legacy(
+                RuntimeError("shape mismatch")
+            )
+        )
+
+
+class OnnxExportAttachInputsToOutputTest(unittest.TestCase):
+    """Tests for ``_onnx_export_attach_inputs_to_output``."""
+
+    def test_empty_inputs_returns_output_unchanged(self):
+        """Empty inputs returns output unchanged."""
+        out = torch.tensor([1.0])
+        self.assertIs(_onnx_export_attach_inputs_to_output(out, ()), out)
+
+    def test_tensor_output_gains_zero_valued_dependency(self):
+        """Tensor output gains zero valued dependency."""
+        out = torch.tensor([5.0])
+        inputs = (torch.tensor([1.0]), torch.tensor([2.0]))
+        result = _onnx_export_attach_inputs_to_output(out, inputs)
+        torch.testing.assert_close(result, out)
+        self.assertIsNot(result, out)
+
+    def test_named_tuple_output_first_tensor_field_adjusted(self):
+        """Named tuple output first tensor field adjusted."""
+
+        class Out(NamedTuple):
+            a: torch.Tensor
+            b: torch.Tensor
+
+        out = Out(a=torch.tensor([1.0]), b=torch.tensor([2.0]))
+        result = _onnx_export_attach_inputs_to_output(out, (torch.tensor([3.0]),))
+        self.assertIsInstance(result, Out)
+        torch.testing.assert_close(result.a, out.a)
+        torch.testing.assert_close(result.b, out.b)
+
+    def test_dict_output_first_tensor_value_adjusted(self):
+        """Dict output first tensor value adjusted."""
+        out = {"a": torch.tensor([1.0]), "b": torch.tensor([2.0])}
+        result = _onnx_export_attach_inputs_to_output(out, (torch.tensor([3.0]),))
+        self.assertIsInstance(result, dict)
+        torch.testing.assert_close(result["a"], out["a"])
+
+    def test_tuple_output_first_tensor_element_adjusted(self):
+        """Tuple output first tensor element adjusted."""
+        out = (torch.tensor([1.0]), torch.tensor([2.0]))
+        result = _onnx_export_attach_inputs_to_output(out, (torch.tensor([3.0]),))
+        self.assertIsInstance(result, tuple)
+        torch.testing.assert_close(result[0], out[0])
+
+    def test_unrecognized_output_type_returned_unchanged(self):
+        """Unrecognized output type returned unchanged."""
+        out = "not a tensor container"
+        self.assertEqual(
+            _onnx_export_attach_inputs_to_output(out, (torch.tensor([1.0]),)), out
+        )
+
+
+class FusedOnnxTupleWrapperTest(unittest.TestCase):
+    """Tests for ``_FusedOnnxTupleWrapper``."""
+
+    def test_forward_zips_keys_and_runs_fused(self):
+        """Forward zips keys and runs fused."""
+        fused = FusedModel(
+            transform_module=_DictTransform(),
+            predictor_module=_TensorPredictor(),
+            transform_input_keys=["in"],
+            predictor_input_keys=["out"],
+            predictor_takes_dict=False,
+        )
+        wrapper = _FusedOnnxTupleWrapper(fused, ["in"])
+        with torch.no_grad():
+            y = wrapper(torch.tensor([[1.0]], dtype=torch.float32))
+        self.assertEqual(y.shape, (1, 1))
+
+
+class FusedOnnxDynamoTupleWrapperTest(unittest.TestCase):
+    """Tests for ``_FusedOnnxDynamoTupleWrapper``."""
+
+    def test_forward_takes_single_tuple_argument(self):
+        """Forward takes single tuple argument."""
+        fused = FusedModel(
+            transform_module=_DictTransform(),
+            predictor_module=_TensorPredictor(),
+            transform_input_keys=["in"],
+            predictor_input_keys=["out"],
+            predictor_takes_dict=False,
+        )
+        wrapper = _FusedOnnxDynamoTupleWrapper(fused, ["in"])
+        with torch.no_grad():
+            y = wrapper((torch.tensor([[1.0]], dtype=torch.float32),))
+        self.assertEqual(y.shape, (1, 1))
+
+
+class ForceOnnxIoShapesFromSchemaTest(unittest.TestCase):
+    """Tests for ``_force_onnx_io_shapes_from_schema``."""
+
+    def _export_simple_onnx(self, dest_path: str) -> None:
+        class M(nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return x * 2
+
+        torch.onnx.export(
+            M(),
+            (torch.zeros(2, 32),),
+            dest_path,
+            input_names=["x"],
+            output_names=["y"],
+            dynamic_axes={"x": {0: "b"}, "y": {0: "b"}},
+        )
+
+    def test_overrides_dims_to_match_schema(self):
+        """Overrides dims to match schema."""
+        with tempfile.TemporaryDirectory() as d:
+            dest_path = os.path.join(d, "m.onnx")
+            self._export_simple_onnx(dest_path)
+            schema = ModelSchema(
+                input_schema=[
+                    ModelSchemaItem(name="x", data_type=DataType.FLOAT, shape=[32])
+                ],
+                output_schema=[
+                    ModelSchemaItem(name="y", data_type=DataType.FLOAT, shape=[32])
+                ],
+            )
+            fuse_module._force_onnx_io_shapes_from_schema(dest_path, [schema])
+            model_proto = onnx.load(dest_path)
+            for value_info in list(model_proto.graph.input) + list(
+                model_proto.graph.output
+            ):
+                dims = value_info.type.tensor_type.shape.dim
+                self.assertEqual(dims[0].dim_param, "b")
+                self.assertEqual(dims[1].dim_value, 32)
+
+    def test_no_matching_schema_names_is_a_noop(self):
+        """No matching schema names is a noop."""
+        with tempfile.TemporaryDirectory() as d:
+            dest_path = os.path.join(d, "m.onnx")
+            self._export_simple_onnx(dest_path)
+            before = onnx.load(dest_path).SerializeToString()
+            fuse_module._force_onnx_io_shapes_from_schema(dest_path, [None])
+            after = onnx.load(dest_path).SerializeToString()
+            self.assertEqual(before, after)
+
+    def test_rank_mismatch_is_skipped_with_warning(self):
+        """Rank mismatch is skipped with warning."""
+        with tempfile.TemporaryDirectory() as d:
+            dest_path = os.path.join(d, "m.onnx")
+            self._export_simple_onnx(dest_path)
+            # Schema declares a 2D non-batch shape, but the exported graph is
+            # rank-2 overall (batch + 1 dim) -- a rank mismatch that should be
+            # skipped, not raise.
+            schema = ModelSchema(
+                input_schema=[
+                    ModelSchemaItem(name="x", data_type=DataType.FLOAT, shape=[32, 32])
+                ],
+            )
+            with self.assertLogs(fuse_module._logger, level="WARNING") as cm:
+                fuse_module._force_onnx_io_shapes_from_schema(dest_path, [schema])
+            self.assertTrue(
+                any("Skipping ONNX shape override" in line for line in cm.output)
+            )
+
+
+class FuseModelsToOnnxTest(unittest.TestCase):
+    """Integration tests for ``fuse_models_to_onnx``."""
+
+    def test_saves_valid_model(self):
+        """Saves valid model."""
+        with tempfile.TemporaryDirectory() as d:
+            tx_path = os.path.join(d, "tx.pt")
+            pred_path = os.path.join(d, "pred.pt")
+            dest_path = os.path.join(d, "fused.onnx")
+            torch.save(_DictTransform().state_dict(), tx_path)
+            torch.save(_TensorPredictor().state_dict(), pred_path)
+            tx_schema, pred_schema = _simple_tx_and_pred_schemas()
+            result = fuse_models_to_onnx(
+                torch_model_path=pred_path,
+                tx_model_path=tx_path,
+                model_class=_class_path(_TensorPredictor),
+                hyperparameters={},
+                tx_model_class=_class_path(_DictTransform),
+                tx_hyperparameters={},
+                dest_path=dest_path,
+                tx_model_schema=tx_schema,
+                model_schema=pred_schema,
+            )
+            self.assertEqual(result, dest_path)
+            self.assertTrue(os.path.isfile(dest_path))
+            model_proto = onnx.load(dest_path)
+            self.assertGreater(len(model_proto.graph.input), 0)
+            self.assertGreater(len(model_proto.graph.output), 0)
+
+    def test_named_tuple_probe_sets_output_names(self):
+        """Named tuple probe sets output names."""
+        with tempfile.TemporaryDirectory() as d:
+            tx_path = os.path.join(d, "tx.pt")
+            pred_path = os.path.join(d, "pred.pt")
+            dest_path = os.path.join(d, "fused_nt.onnx")
+            torch.save(_PairTransform().state_dict(), tx_path)
+            torch.save(_NamedTupleTensorPredictor().state_dict(), pred_path)
+            tx_schema = ModelSchema(
+                input_schema=[
+                    ModelSchemaItem(name="in", data_type=DataType.FLOAT, shape=[1])
+                ],
+                output_schema=[
+                    ModelSchemaItem(name="a", data_type=DataType.FLOAT, shape=[1]),
+                    ModelSchemaItem(name="b", data_type=DataType.FLOAT, shape=[1]),
+                ],
+            )
+            pred_schema = ModelSchema(
+                input_schema=[
+                    ModelSchemaItem(name="a", data_type=DataType.FLOAT, shape=[1]),
+                    ModelSchemaItem(name="b", data_type=DataType.FLOAT, shape=[1]),
+                ],
+                output_schema=[
+                    ModelSchemaItem(name="a_out", data_type=DataType.FLOAT, shape=[1]),
+                    ModelSchemaItem(name="b_out", data_type=DataType.FLOAT, shape=[1]),
+                ],
+            )
+            fuse_models_to_onnx(
+                torch_model_path=pred_path,
+                tx_model_path=tx_path,
+                model_class=_class_path(_NamedTupleTensorPredictor),
+                hyperparameters={},
+                tx_model_class=_class_path(_PairTransform),
+                tx_hyperparameters={},
+                dest_path=dest_path,
+                tx_model_schema=tx_schema,
+                model_schema=pred_schema,
+            )
+            model_proto = onnx.load(dest_path)
+            onnx_out = [o.name for o in model_proto.graph.output]
+            self.assertEqual(onnx_out, ["b_out", "a_out"])
+
+    def test_dest_filename_only_uses_dot_makedirs(self):
+        """Dest filename only uses dot makedirs."""
+        with tempfile.TemporaryDirectory() as d:
+            tx_path = os.path.join(d, "tx.pt")
+            pred_path = os.path.join(d, "pred.pt")
+            torch.save(_DictTransform().state_dict(), tx_path)
+            torch.save(_TensorPredictor().state_dict(), pred_path)
+            tx_schema, pred_schema = _simple_tx_and_pred_schemas()
+            old = os.getcwd()
+            try:
+                os.chdir(d)
+                fuse_models_to_onnx(
+                    torch_model_path=pred_path,
+                    tx_model_path=tx_path,
+                    model_class=_class_path(_TensorPredictor),
+                    hyperparameters={},
+                    tx_model_class=_class_path(_DictTransform),
+                    tx_hyperparameters={},
+                    dest_path="bare_name.onnx",
+                    tx_model_schema=tx_schema,
+                    model_schema=pred_schema,
+                )
+                self.assertTrue(os.path.isfile(os.path.join(d, "bare_name.onnx")))
+            finally:
+                os.chdir(old)
+
+    def test_logs_when_sample_forward_probe_fails(self):
+        """Logs when sample forward probe fails."""
+        with tempfile.TemporaryDirectory() as d:
+            tx_path = os.path.join(d, "tx.pt")
+            pred_path = os.path.join(d, "pred.pt")
+            dest_path = os.path.join(d, "fused_warn.onnx")
+            torch.save(_DictTransform().state_dict(), tx_path)
+            torch.save(_TensorPredictor().state_dict(), pred_path)
+            tx_schema, pred_schema = _simple_tx_and_pred_schemas()
+            orig_forward = FusedModel.forward
+            calls = {"n": 0}
+
+            def _flaky_forward(self, inputs):
+                calls["n"] += 1
+                if calls["n"] == 1:
+                    raise RuntimeError("probe failure")
+                return orig_forward(self, inputs)
+
+            with (
+                mock.patch.object(FusedModel, "forward", _flaky_forward),
+                self.assertLogs(fuse_module._logger, level="WARNING") as cm,
+            ):
+                fuse_models_to_onnx(
+                    torch_model_path=pred_path,
+                    tx_model_path=tx_path,
+                    model_class=_class_path(_TensorPredictor),
+                    hyperparameters={},
+                    tx_model_class=_class_path(_DictTransform),
+                    tx_hyperparameters={},
+                    dest_path=dest_path,
+                    tx_model_schema=tx_schema,
+                    model_schema=pred_schema,
+                )
+            self.assertTrue(
+                any("Could not infer ONNX output names" in line for line in cm.output)
+            )
+            self.assertTrue(os.path.isfile(dest_path))
+            onnx.load(dest_path)
+
+
+# ===========================================================================
+# Native-transform-gated cases
+# ===========================================================================
+#
+# fuse_models_to_python always raises NotImplementedError for its raw
+# package until the native-transform package (TransformSpec,
+# TorchTransformModule) is migrated -- see _build_tx_hydra_spec's docstring.
+# FuseModelsToPythonNotImplementedTest below locks in that current behavior.
+# Once native-transform lands, add real behavioral coverage for the raw
+# package here.
+
+
+class FuseModelsToPythonNotImplementedTest(unittest.TestCase):
+    """Documents today's actual (gated) behavior of ``fuse_models_to_python``.
+
+    Unlike the placeholder class above (which mirrors the future suite and
+    stays skipped), this test runs today: it locks in that calling
+    ``fuse_models_to_python`` raises a clear, actionable ``NotImplementedError``
+    rather than failing confusingly or silently returning bad data.
+    """
+
+    def test_raises_notimplementederror_pointing_to_native_transform(self):
+        """Raises notimplementederror pointing to native transform."""
+        with tempfile.TemporaryDirectory() as d:
+            tx_path = os.path.join(d, "tx.pt")
+            pred_path = os.path.join(d, "pred.pt")
+            dest_path = os.path.join(d, "fused.pt")
+            torch.save(_TensorPredictor().state_dict(), pred_path)
+            torch.save(_DictTransform(), tx_path)
+            with self.assertRaises(NotImplementedError) as ctx:
+                fuse_models_to_python(
+                    torch_model_path=pred_path,
+                    tx_model_path=tx_path,
+                    model_class=_class_path(_TensorPredictor),
+                    hyperparameters={},
+                    tx_hyperparameters={},
+                    dest_path=dest_path,
+                    tx_model_schema=None,
+                    model_schema=None,
+                )
+            self.assertIn("native-transform", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/michelangelo/lib/model_manager/utils/torch/model_fuser/tests/fused_model_test.py
+++ b/python/michelangelo/lib/model_manager/utils/torch/model_fuser/tests/fused_model_test.py
@@ -1,0 +1,164 @@
+"""Unit tests for ``FusedModel``.
+
+Covers forward with dict vs. positional predictor, and merge of transform
+output with input passthrough.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+import torch.nn as nn
+
+from michelangelo.lib.model_manager.utils.torch.model_fuser import FusedModel
+
+
+class _DictTransform(nn.Module):
+    """Transform: dict in -> dict out. Maps input ``a`` to output ``b`` (``a + 1``)."""
+
+    def forward(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        a = inputs["a"]
+        return {"b": a + 1.0}
+
+
+class _TwoTensorPredictor(nn.Module):
+    """Predictor: two tensors in, tensor out. Sum of both."""
+
+    def forward(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+        return (a + b).sum(dim=-1, keepdim=True)
+
+
+class _DictPredictor(nn.Module):
+    """Predictor: dict in, tensor out. Returns the sum of the first value."""
+
+    def forward(self, inputs: dict[str, torch.Tensor]) -> torch.Tensor:
+        v = next(iter(inputs.values()))
+        return v.sum(dim=-1, keepdim=True)
+
+
+class FusedModelPredictorTakesDictTest(unittest.TestCase):
+    """``FusedModel`` when the predictor accepts a dict."""
+
+    def test_forward_calls_predictor_with_dict(self):
+        """The predictor receives a dict merging transform output and passthrough."""
+        fused = FusedModel(
+            transform_module=_DictTransform(),
+            predictor_module=_DictPredictor(),
+            transform_input_keys=["a"],
+            predictor_input_keys=["a", "b"],
+            predictor_takes_dict=True,
+        )
+        fused.eval()
+        with torch.no_grad():
+            inputs = {"a": torch.tensor([[1.0, 2.0]], dtype=torch.float32)}
+            out = fused(inputs)
+        self.assertIsInstance(out, torch.Tensor)
+        self.assertEqual(out.shape, (1, 1))
+        # Transform: a -> b = a+1 = [2, 3]. Predictor gets {a: [1,2], b: [2,3]},
+        # first value is a, sum = 3.
+        self.assertEqual(out.item(), 3.0)
+
+    def test_merge_transform_output_overwrites_passthrough(self):
+        """Predictor input = merge(inputs, transform_output); transform keys win."""
+        fused = FusedModel(
+            transform_module=_DictTransform(),
+            predictor_module=_DictPredictor(),
+            transform_input_keys=["a"],
+            predictor_input_keys=["a", "b"],
+            predictor_takes_dict=True,
+        )
+        fused.eval()
+        with torch.no_grad():
+            inputs = {"a": torch.tensor([[1.0]], dtype=torch.float32)}
+            out = fused(inputs)
+        self.assertEqual(out.shape, (1, 1))
+        # Transform: a -> b = a+1 = 2. Predictor gets {a: 1, b: 2}; first value
+        # a=1, sum=1.
+        self.assertEqual(out.item(), 1.0)
+
+
+class FusedModelPredictorTakesTensorsTest(unittest.TestCase):
+    """``FusedModel`` when the predictor accepts positional tensors."""
+
+    def test_forward_calls_predictor_with_tensors_in_order(self):
+        """Predictor receives positional tensors in ``predictor_input_keys`` order."""
+        fused = FusedModel(
+            transform_module=_DictTransform(),
+            predictor_module=_TwoTensorPredictor(),
+            transform_input_keys=["a"],
+            predictor_input_keys=["a", "b"],
+            predictor_takes_dict=False,
+        )
+        fused.eval()
+        with torch.no_grad():
+            inputs = {"a": torch.tensor([[1.0, 2.0]], dtype=torch.float32)}
+            out = fused(inputs)
+        self.assertIsInstance(out, torch.Tensor)
+        self.assertEqual(out.shape, (1, 1))
+        # Transform: a -> b = a+1 = [2, 3]. Predictor gets (a, b) = ([1,2],
+        # [2,3]), (a+b).sum() = (3+5) = 8.
+        self.assertEqual(out.item(), 8.0)
+
+    def test_predictor_input_order_follows_predictor_input_keys(self):
+        """Reordering ``predictor_input_keys`` reorders the predictor's args."""
+        call_args = []
+
+        class _CapturePredictor(nn.Module):
+            def forward(
+                self, first: torch.Tensor, second: torch.Tensor
+            ) -> torch.Tensor:
+                call_args.append((first, second))
+                return first + second
+
+        fused = FusedModel(
+            transform_module=_DictTransform(),
+            predictor_module=_CapturePredictor(),
+            transform_input_keys=["a"],
+            predictor_input_keys=["b", "a"],
+            predictor_takes_dict=False,
+        )
+        fused.eval()
+        with torch.no_grad():
+            inputs = {"a": torch.tensor([[1.0]], dtype=torch.float32)}
+            _ = fused(inputs)
+        self.assertEqual(len(call_args), 1)
+        first, second = call_args[0]
+        self.assertEqual(first.shape, (1, 1))
+        self.assertEqual(second.shape, (1, 1))
+        self.assertEqual(first.item(), 2.0)
+        self.assertEqual(second.item(), 1.0)
+
+
+class FusedModelMergeTest(unittest.TestCase):
+    """Merge behavior: passthrough inputs plus transform output."""
+
+    def test_passthrough_keys_not_in_transform_input_are_in_predictor_input(self):
+        """Inputs the transform doesn't consume pass through to the predictor."""
+
+        class _Transform(nn.Module):
+            def forward(
+                self, inputs: dict[str, torch.Tensor]
+            ) -> dict[str, torch.Tensor]:
+                return {"out": inputs["x"] + 1}
+
+        class _Pred(nn.Module):
+            def forward(self, x: torch.Tensor, out: torch.Tensor) -> torch.Tensor:
+                return x + out
+
+        fused = FusedModel(
+            transform_module=_Transform(),
+            predictor_module=_Pred(),
+            transform_input_keys=["x"],
+            predictor_input_keys=["x", "out"],
+            predictor_takes_dict=False,
+        )
+        fused.eval()
+        with torch.no_grad():
+            inputs = {"x": torch.tensor([[1.0]], dtype=torch.float32)}
+            out = fused(inputs)
+        self.assertEqual(out.item(), 1.0 + 2.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stack: 4/5. Based on #3 (custom assembler).

## Summary
- Adds the ONNX/TorchScript fusion engine (`fuse_models_to_onnx` / `fuse_models_to_python`) that combines a native-transform model and a predictor model into a single servable graph
- Adds `FusedModel`, the runtime wrapper used by the PyTorch/Lightning assembler in PR 5/5
- `fuse_models_to_python` currently raises `NotImplementedError` for its raw package until native-transform support is migrated; that gate is locked in by a dedicated test

## Test plan
- [ ] `pytest python/michelangelo/lib/model_manager/utils/torch/model_fuser`