### PR TITLE
Tabular assembler migration 5/5: PyTorch/Lightning assembler

### DIFF
--- a/python/michelangelo/workflow/tasks/tabular_assembler/task.py
+++ b/python/michelangelo/workflow/tasks/tabular_assembler/task.py
@@ -10,6 +10,9 @@ from michelangelo.workflow.tasks.tabular_assembler._private.model_class.resolve 
 from michelangelo.workflow.tasks.tabular_assembler.custom.assembler import (
     custom_assembler,
 )
+from michelangelo.workflow.tasks.tabular_assembler.torch.assembler import (
+    torch_assembler,
+)
 from michelangelo.workflow.variables.metadata import (
     TRAINING_FRAMEWORK_CUSTOM,
     TRAINING_FRAMEWORK_LIGHTNING,
@@ -47,7 +50,7 @@ def tabular_assembler(
         raw_model: The trained model to package.
         native_transform_model: Optional native-transform model preceding
             ``raw_model``. Passed through to the custom or PyTorch/Lightning
-            assembler; ignored for unrecognized training frameworks.
+            assembler; ignored when the framework can't be resolved at all.
         storage_backend: Backend used to download source artifacts and upload
             produced packages. Required, keyword-only — this task boundary is
             an explicit injection point, not a place to silently default to
@@ -55,14 +58,19 @@ def tabular_assembler(
 
     Returns:
         An ``AssembledModel`` with the deployable and raw packaged artifacts.
-        When the training framework is not recognized, both ``raw_model`` and
-        ``deployable_model`` are empty placeholder artifacts (``path=""``)
-        rather than ``None``, matching this task's "always return a pair"
-        contract.
+        When no training framework is recorded and none can be resolved from
+        ``config.model_class``, both ``raw_model`` and ``deployable_model``
+        are empty placeholder artifacts (``path=""``) rather than ``None``,
+        matching this task's "always return a pair" contract.
 
     Raises:
-        NotImplementedError: If dispatch resolves to the PyTorch/Lightning
-            path, which is not yet implemented in this package.
+        ValueError: If ``raw_model.metadata.training_framework`` is set to a
+            non-empty value that doesn't match any known framework. This is
+            almost always a caller bug (e.g. an internal training-framework
+            identifier that was never translated to this package's
+            constants) — failing loudly here is far easier to diagnose than
+            letting it surface as a silently-empty package several pipeline
+            stages later.
     """
     if (
         raw_model.metadata.training_framework == TRAINING_FRAMEWORK_CUSTOM
@@ -72,47 +80,20 @@ def tabular_assembler(
             config, raw_model, native_transform_model, storage_backend=storage_backend
         )
     if raw_model.metadata.training_framework == TRAINING_FRAMEWORK_PYTORCH:
-        return _torch_assembler(config, raw_model, storage_backend=storage_backend)
+        return torch_assembler(config, raw_model, storage_backend=storage_backend)
     if raw_model.metadata.training_framework == TRAINING_FRAMEWORK_LIGHTNING:
-        return _torch_assembler(
+        return torch_assembler(
             config, raw_model, native_transform_model, storage_backend=storage_backend
+        )
+    if raw_model.metadata.training_framework:
+        raise ValueError(
+            "Unrecognized raw_model.metadata.training_framework: "
+            f"{raw_model.metadata.training_framework!r}. Expected one of "
+            f"{TRAINING_FRAMEWORK_CUSTOM!r}, {TRAINING_FRAMEWORK_PYTORCH!r}, "
+            f"{TRAINING_FRAMEWORK_LIGHTNING!r}, or an unset (None) value."
         )
 
     return AssembledModel(
         raw_model=ModelArtifact(path=""),
         deployable_model=ModelArtifact(path=""),
-    )
-
-
-def _torch_assembler(
-    config: TabularAssemblerConfig,
-    raw_model: ModelArtifact,
-    native_transform_model: ModelArtifact | None = None,
-    *,
-    storage_backend: StorageBackend,
-) -> AssembledModel:
-    """Import and delegate to the real ``torch_assembler``, once it exists.
-
-    The PyTorch/Lightning assembler path (``torch_assembler``) is implemented
-    in a follow-up bucket that adds
-    ``michelangelo.workflow.tasks.tabular_assembler.torch.assembler``. This
-    indirection lets that module land without any further change to this
-    dispatch function — once it exists, the import below resolves and this
-    branch becomes live automatically.
-
-    Raises:
-        NotImplementedError: Always, until the ``torch`` subpackage lands.
-    """
-    try:
-        from michelangelo.workflow.tasks.tabular_assembler.torch.assembler import (
-            torch_assembler,
-        )
-    except ImportError as exc:
-        raise NotImplementedError(
-            "The PyTorch/Lightning assembler path is not yet implemented — "
-            "michelangelo.workflow.tasks.tabular_assembler.torch.assembler "
-            "lands in a follow-up change."
-        ) from exc
-    return torch_assembler(
-        config, raw_model, native_transform_model, storage_backend=storage_backend
     )

--- a/python/michelangelo/workflow/tasks/tabular_assembler/tests/task_test.py
+++ b/python/michelangelo/workflow/tasks/tabular_assembler/tests/task_test.py
@@ -39,7 +39,7 @@ class _CustomModelFixture(Model):
         return inputs
 
 
-_CUSTOM_MODEL_CLASS = (
+CUSTOM_MODEL_CLASS_PATH = (
     "michelangelo.workflow.tasks.tabular_assembler.tests.task_test._CustomModelFixture"
 )
 
@@ -88,7 +88,7 @@ class TabularAssemblerDispatchTest(unittest.TestCase):
         This holds even when the recorded training framework is ``lightning``.
         """
         mock_custom.return_value = self._sentinel_result()
-        config = TabularAssemblerConfig(model_class=_CUSTOM_MODEL_CLASS)
+        config = TabularAssemblerConfig(model_class=CUSTOM_MODEL_CLASS_PATH)
         raw_model = ModelArtifact(
             path="p",
             metadata=ModelMetadata(training_framework=TRAINING_FRAMEWORK_LIGHTNING),
@@ -103,43 +103,65 @@ class TabularAssemblerDispatchTest(unittest.TestCase):
             config, raw_model, native_tx, storage_backend=self.storage_backend
         )
 
-    def test_torch_framework_raises_not_implemented(self):
-        """The pytorch path is not yet implemented in this package."""
+    def test_torch_dispatch_resolves_now_that_torch_assembler_exists(self):
+        """``torch.assembler`` now exists and is imported directly by ``task``."""
+        from michelangelo.workflow.tasks.tabular_assembler.task import (
+            torch_assembler,
+        )
+
+        self.assertTrue(callable(torch_assembler))
+
+    @patch("michelangelo.workflow.tasks.tabular_assembler.task.torch_assembler")
+    def test_dispatches_to_torch_assembler_for_pytorch_and_lightning(self, mock_torch):
+        """``pytorch``/``lightning`` frameworks route to the real torch assembler.
+
+        The ``pytorch`` framework does not forward ``native_transform_model``
+        to ``torch_assembler`` (pre-existing dispatch behavior); ``lightning``
+        does.
+        """
+        mock_torch.reset_mock()
+        mock_torch.return_value = self._sentinel_result()
         config = TabularAssemblerConfig()
         raw_model = ModelArtifact(
             path="p",
             metadata=ModelMetadata(training_framework=TRAINING_FRAMEWORK_PYTORCH),
         )
 
-        with self.assertRaises(NotImplementedError):
-            tabular_assembler(config, raw_model, storage_backend=self.storage_backend)
+        result = tabular_assembler(
+            config, raw_model, storage_backend=self.storage_backend
+        )
 
-    def test_lightning_framework_raises_not_implemented(self):
-        """The lightning path is not yet implemented in this package."""
-        config = TabularAssemblerConfig()
+        self.assertIs(result, mock_torch.return_value)
+        mock_torch.assert_called_once_with(
+            config, raw_model, storage_backend=self.storage_backend
+        )
+
+        mock_torch.reset_mock()
+        mock_torch.return_value = self._sentinel_result()
+        native_tx = ModelArtifact(path="tx")
         raw_model = ModelArtifact(
             path="p",
             metadata=ModelMetadata(training_framework=TRAINING_FRAMEWORK_LIGHTNING),
         )
 
-        with self.assertRaises(NotImplementedError):
-            tabular_assembler(config, raw_model, storage_backend=self.storage_backend)
+        result = tabular_assembler(
+            config, raw_model, native_tx, storage_backend=self.storage_backend
+        )
 
-    def test_unsupported_framework_returns_empty_placeholder_pair(self):
-        """An unrecognized framework yields an empty (not ``None``) artifact pair."""
+        self.assertIs(result, mock_torch.return_value)
+        mock_torch.assert_called_once_with(
+            config, raw_model, native_tx, storage_backend=self.storage_backend
+        )
+
+    def test_unsupported_framework_raises_value_error(self):
+        """An unrecognized, non-empty framework raises instead of silently no-op'ing."""
         config = TabularAssemblerConfig()
         raw_model = ModelArtifact(
             path="p", metadata=ModelMetadata(training_framework="unsupported_framework")
         )
 
-        result = tabular_assembler(
-            config, raw_model, storage_backend=self.storage_backend
-        )
-
-        self.assertIsNotNone(result.raw_model)
-        self.assertIsNotNone(result.deployable_model)
-        self.assertEqual(result.raw_model.path, "")
-        self.assertEqual(result.deployable_model.path, "")
+        with self.assertRaisesRegex(ValueError, "unsupported_framework"):
+            tabular_assembler(config, raw_model, storage_backend=self.storage_backend)
 
     def test_no_framework_recorded_and_no_config_model_class_returns_empty_pair(self):
         """No recorded framework and no config model class yields the empty pair."""

--- a/python/michelangelo/workflow/tasks/tabular_assembler/torch/__init__.py
+++ b/python/michelangelo/workflow/tasks/tabular_assembler/torch/__init__.py
@@ -1,0 +1,7 @@
+"""PyTorch/Lightning tabular assembler."""
+
+from michelangelo.workflow.tasks.tabular_assembler.torch.assembler import (
+    torch_assembler,
+)
+
+__all__ = ["torch_assembler"]

--- a/python/michelangelo/workflow/tasks/tabular_assembler/torch/assembler.py
+++ b/python/michelangelo/workflow/tasks/tabular_assembler/torch/assembler.py
@@ -1,0 +1,349 @@
+"""PyTorch/Lightning tabular assembler.
+
+Packages a raw trained PyTorch or Lightning model into deployable and raw
+Triton packages using ``TorchTritonPackager``. When preceded by a
+native-transform stage, the predictor and transform models are fused into a
+single servable artifact via the ``model_fuser`` package
+(``lib.model_manager.utils.torch.model_fuser.fuse``).
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import pickle
+import tempfile
+import uuid
+from dataclasses import replace
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from michelangelo.lib.model_manager.constants import StorageType
+from michelangelo.lib.model_manager.packager.torch_triton import TorchTritonPackager
+from michelangelo.lib.model_manager.schema import ModelSchema, ModelSchemaItem
+from michelangelo.lib.model_manager.schema.fuse import fuse_model_schema
+from michelangelo.lib.model_manager.utils.torch.model_fuser import fuse as _fuse
+from michelangelo.workflow.variables.metadata import ModelMetadata
+from michelangelo.workflow.variables.types import AssembledModel, ModelArtifact
+
+if TYPE_CHECKING:
+    from michelangelo.lib.artifact_manager.storage_backend import StorageBackend
+    from michelangelo.workflow.schema.assembler import TabularAssemblerConfig
+
+__all__ = ["torch_assembler"]
+
+# Triton backend identifiers accepted by ``TorchAssemblerConfig.backend``.
+# These mirror ``michelangelo.lib.model_manager._private.constants
+# .triton_backend_type.TritonBackendType.{PYTHON,ONNX}`` values, duplicated
+# here as plain strings rather than imported: that module is private to
+# ``model_manager`` and the assembler task layer never crosses that
+# boundary (see ``TorchAssemblerConfig.backend``'s docstring, which already
+# documents the accepted string values).
+_BACKEND_PYTHON = "python"
+_BACKEND_ONNX = "onnxruntime"
+
+
+def _normalize_scalar_shapes(
+    schema: ModelSchema, sample_data: list[dict[str, Any]] | None
+) -> tuple[ModelSchema, list[dict[str, Any]] | None]:
+    """Return copies of ``schema``/``sample_data`` with scalar shapes set to ``[1]``.
+
+    ``ColumnConfig``'s documented usage for a scalar column omits ``shape``,
+    defaulting it to ``[]`` (see ``workflow.schema.tabular_trainer
+    .ColumnConfig``), and ``tabular_trainer`` keeps the matching sample-data
+    value at its natural rank-0 shape to match. Triton's schema validation
+    (``validate_model_schema_item``) requires a non-empty shape, and its
+    sample-data validation requires the sample's rank to equal the schema
+    shape's length -- so ``schema`` and ``sample_data`` must be renormalized
+    together, not independently, or the two fall out of sync.
+
+    Args:
+        schema: Schema to normalize.
+        sample_data: Sample inference inputs to normalize alongside
+            ``schema``, or ``None``.
+
+    Returns:
+        ``(normalized_schema, normalized_sample_data)``. Any schema item with
+        an empty ``shape`` is replaced by a copy with ``shape=[1]``; any
+        ``sample_data`` value for a field renamed this way is reshaped from
+        scalar to a 1-element array to match.
+    """
+    scalar_fields = {
+        item.name
+        for item in (
+            *schema.input_schema,
+            *schema.feature_store_features_schema,
+            *schema.output_schema,
+        )
+        if not item.shape
+    }
+
+    def _normalized_item(item: ModelSchemaItem) -> ModelSchemaItem:
+        return item if item.shape else replace(item, shape=[1])
+
+    normalized_schema = ModelSchema(
+        input_schema=[_normalized_item(i) for i in schema.input_schema],
+        feature_store_features_schema=[
+            _normalized_item(i) for i in schema.feature_store_features_schema
+        ],
+        output_schema=[_normalized_item(i) for i in schema.output_schema],
+    )
+
+    if not sample_data or not scalar_fields:
+        return normalized_schema, sample_data
+
+    normalized_sample_data = [
+        {
+            name: (np.reshape(value, (1,)) if name in scalar_fields else value)
+            for name, value in record.items()
+        }
+        for record in sample_data
+    ]
+    return normalized_schema, normalized_sample_data
+
+
+def _reorder_output_schema(
+    schema: ModelSchema, field_order: list[str] | None
+) -> ModelSchema:
+    """Return a copy of ``schema`` with its output fields reordered.
+
+    Fields named in ``field_order`` are placed first, in that order. Any
+    output fields not covered by ``field_order`` are appended at the end,
+    keeping their relative order.
+
+    Args:
+        schema: Schema whose ``output_schema`` should be reordered.
+        field_order: Desired output field name order, or ``None`` to leave
+            ``schema`` unchanged.
+
+    Returns:
+        ``schema`` unchanged when ``field_order`` is ``None``; otherwise a
+        new ``ModelSchema`` with the same ``input_schema`` and a reordered
+        ``output_schema``.
+    """
+    if field_order is None:
+        return schema
+    schema_by_name = {item.name: item for item in schema.output_schema}
+    reordered = [schema_by_name[f] for f in field_order if f in schema_by_name]
+    covered = set(field_order)
+    reordered += [item for item in schema.output_schema if item.name not in covered]
+    return ModelSchema(input_schema=list(schema.input_schema), output_schema=reordered)
+
+
+def torch_assembler(
+    config: TabularAssemblerConfig,
+    raw_model: ModelArtifact,
+    native_transform_model: ModelArtifact | None = None,
+    *,
+    storage_backend: StorageBackend,
+) -> AssembledModel:
+    """Package a PyTorch or Lightning model into deployable and raw packages.
+
+    ``TorchTritonPackager`` only understands locally-resident model
+    artifacts, so ``raw_model.path`` (and, when present,
+    ``native_transform_model.path``) are downloaded via ``storage_backend``
+    to a local temporary directory before packaging. When
+    ``native_transform_model`` is supplied, the predictor and transform are
+    fused (see ``lib.model_manager.utils.torch.model_fuser``) into a single
+    servable artifact with a combined schema; otherwise the predictor is
+    packaged as-is.
+
+    Args:
+        config: The assembler configuration. ``config.torch.backend``
+            selects the Triton backend for the deployable package (one of
+            ``"pytorch"``, ``"tensorrt"``, ``"python"``, ``"onnxruntime"``,
+            or ``None`` for the packager default). ``config.torch
+            .include_import_prefixes`` scopes the packager's dependency-file
+            walk (see ``TorchAssemblerConfig.include_import_prefixes``).
+        raw_model: The trained predictor model to package.
+            ``raw_model.metadata.model_class``, ``.hyperparameters``,
+            ``.schema``, and ``.sample_data`` describe how to load and
+            package it.
+        native_transform_model: Optional native-transform model preceding
+            ``raw_model``. When set, the predictor and transform are fused
+            into a single package with a combined input/output schema.
+        storage_backend: Backend used to download source artifacts and
+            upload produced packages. Required, keyword-only — this task
+            boundary is an explicit injection point, not a place to
+            silently default to throwaway local storage.
+
+    Returns:
+        An ``AssembledModel`` with the deployable and raw packaged
+        artifacts. Both share the same (possibly fused) schema.
+    """
+    packager = TorchTritonPackager()
+    backend = config.torch.backend if config and config.torch else None
+    include_import_prefixes = (
+        config.torch.include_import_prefixes if config and config.torch else None
+    )
+    model_class = raw_model.metadata.model_class
+    hyperparameters = raw_model.metadata.hyperparameters or {}
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        torch_local_path = os.path.join(temp_dir, "torch_model.pt")
+        storage_backend.download(raw_model.path, torch_local_path)
+
+        if native_transform_model is not None:
+            fuse_models_to_onnx = _fuse.fuse_models_to_onnx
+            fuse_models_to_python = _fuse.fuse_models_to_python
+            fuse_models_to_torchscript = _fuse.fuse_models_to_torchscript
+            get_predictor_output_field_order = _fuse.get_predictor_output_field_order
+            build_fused_sample_data = _fuse.build_fused_sample_data
+
+            tx_model_class = native_transform_model.metadata.model_class
+            tx_hyperparameters = native_transform_model.metadata.hyperparameters or {}
+            tx_model_schema = native_transform_model.metadata.schema
+            tx_local_path = os.path.join(temp_dir, "tx_model.pt")
+            storage_backend.download(native_transform_model.path, tx_local_path)
+
+            # Raw package: always fused (combined state dict + FusedModel),
+            # regardless of backend.
+            raw_model_path = os.path.join(temp_dir, "fused_model.pt")
+            raw_model_path, packaged_model_class, packaged_hyperparameters = (
+                fuse_models_to_python(
+                    torch_model_path=torch_local_path,
+                    tx_model_path=tx_local_path,
+                    model_class=model_class,
+                    hyperparameters=hyperparameters,
+                    tx_hyperparameters=tx_hyperparameters,
+                    dest_path=raw_model_path,
+                    tx_model_schema=tx_model_schema,
+                    model_schema=raw_model.metadata.schema,
+                )
+            )
+
+            if backend == _BACKEND_PYTHON:
+                deployable_model_path = raw_model_path
+            elif backend == _BACKEND_ONNX:
+                deployable_model_path = os.path.join(temp_dir, "fused_model.onnx")
+                fuse_models_to_onnx(
+                    torch_model_path=torch_local_path,
+                    tx_model_path=tx_local_path,
+                    model_class=model_class,
+                    hyperparameters=hyperparameters,
+                    tx_model_class=tx_model_class,
+                    tx_hyperparameters=tx_hyperparameters,
+                    dest_path=deployable_model_path,
+                    tx_model_schema=tx_model_schema,
+                    model_schema=raw_model.metadata.schema,
+                )
+            else:
+                deployable_model_path = os.path.join(temp_dir, "fused_model.pt")
+                fuse_models_to_torchscript(
+                    torch_model_path=torch_local_path,
+                    tx_model_path=tx_local_path,
+                    model_class=model_class,
+                    hyperparameters=hyperparameters,
+                    tx_model_class=tx_model_class,
+                    tx_hyperparameters=tx_hyperparameters,
+                    dest_path=deployable_model_path,
+                    tx_model_schema=tx_model_schema,
+                    model_schema=raw_model.metadata.schema,
+                )
+
+            # Reorder output_schema to match the predictor's output order
+            # (NamedTuple _fields for TorchScript, or the same order for
+            # ONNX). Export strips _fields, so Triton inference uses
+            # positional mapping from config.pbtxt; aligning the schema
+            # prevents silent column swaps.
+            field_order = get_predictor_output_field_order(
+                torch_local_path,
+                model_class,
+                hyperparameters,
+                raw_model.metadata.schema,
+            )
+            predictor_schema = _reorder_output_schema(
+                raw_model.metadata.schema, field_order
+            )
+            model_schema_for_package = fuse_model_schema(
+                tx_model_schema, predictor_schema
+            )
+            fused_input_cols = {
+                item.name for item in model_schema_for_package.input_schema
+            }
+            packaged_sample_data = build_fused_sample_data(
+                native_transform_model.metadata.sample_data,
+                raw_model.metadata.sample_data,
+                fused_input_cols,
+            )
+        else:
+            deployable_model_path = torch_local_path
+            raw_model_path = torch_local_path
+            model_schema_for_package = raw_model.metadata.schema
+            packaged_model_class = model_class
+            packaged_hyperparameters = hyperparameters
+            packaged_sample_data = raw_model.metadata.sample_data
+
+        model_schema_for_package, packaged_sample_data = _normalize_scalar_shapes(
+            model_schema_for_package, packaged_sample_data
+        )
+
+        model_package_dest = os.path.join(temp_dir, "model_package")
+        raw_model_package_dest = os.path.join(temp_dir, "raw_model_package")
+
+        model_package_path = packager.create_model_package(
+            deployable_model_path,
+            model_schema=model_schema_for_package,
+            dest_model_path=model_package_dest,
+            model_path_source_type=StorageType.LOCAL,
+            model_class=packaged_model_class,
+            hyperparameters=packaged_hyperparameters,
+            backend=backend,
+            sample_data=packaged_sample_data,
+            include_import_prefixes=include_import_prefixes,
+        )
+        raw_model_package_path = packager.create_raw_model_package(
+            raw_model_path,
+            model_class=packaged_model_class,
+            model_schema=model_schema_for_package,
+            sample_data=packaged_sample_data,
+            dest_model_path=raw_model_package_dest,
+            model_path_source_type=StorageType.LOCAL,
+            hyperparameters=packaged_hyperparameters,
+            include_import_prefixes=include_import_prefixes,
+            transform_spec=(
+                native_transform_model.metadata.transform_spec
+                if native_transform_model is not None
+                else None
+            ),
+            transform_feature_stats=(
+                native_transform_model.metadata.feature_stats
+                if native_transform_model is not None
+                else None
+            ),
+        )
+
+        upload_prefix = f"tabular_assembler/{uuid.uuid4().hex}"
+        deployable_uri = storage_backend.upload(
+            model_package_path, f"{upload_prefix}/deployable"
+        )
+        raw_uri = storage_backend.upload(raw_model_package_path, f"{upload_prefix}/raw")
+
+    deployable_metadata = ModelMetadata(
+        deployable=True,
+        assembled=True,
+        schema=model_schema_for_package,
+        sample_data=packaged_sample_data,
+        _schema=io.BytesIO(pickle.dumps(model_schema_for_package)),
+        _sample_data=io.BytesIO(pickle.dumps(packaged_sample_data)),
+    )
+    raw_metadata = ModelMetadata(
+        deployable=False,
+        assembled=True,
+        schema=model_schema_for_package,
+        sample_data=packaged_sample_data,
+        _schema=io.BytesIO(pickle.dumps(model_schema_for_package)),
+        _sample_data=io.BytesIO(pickle.dumps(packaged_sample_data)),
+        training_framework=raw_model.metadata.training_framework,
+        model_class=packaged_model_class,
+        is_incremental_training=raw_model.metadata.is_incremental_training,
+        baseline_model_identifier=raw_model.metadata.baseline_model_identifier,
+    )
+
+    return AssembledModel(
+        raw_model=ModelArtifact(path=raw_uri, metadata=raw_metadata),
+        deployable_model=ModelArtifact(
+            path=deployable_uri, metadata=deployable_metadata
+        ),
+    )

--- a/python/michelangelo/workflow/tasks/tabular_assembler/torch/tests/__init__.py
+++ b/python/michelangelo/workflow/tasks/tabular_assembler/torch/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the PyTorch/Lightning tabular assembler."""

--- a/python/michelangelo/workflow/tasks/tabular_assembler/torch/tests/assembler_test.py
+++ b/python/michelangelo/workflow/tasks/tabular_assembler/torch/tests/assembler_test.py
@@ -1,0 +1,617 @@
+"""Unit tests for ``...tabular_assembler.torch.assembler``."""
+
+from __future__ import annotations
+
+import os
+import pickle
+import tempfile
+import unittest
+import uuid
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+from michelangelo.lib.artifact_manager.storage_backend import LocalStorageBackend
+from michelangelo.lib.model_manager.constants import StorageType
+from michelangelo.lib.model_manager.schema import DataType, ModelSchema, ModelSchemaItem
+from michelangelo.workflow.schema.assembler import (
+    TabularAssemblerConfig,
+    TorchAssemblerConfig,
+)
+from michelangelo.workflow.tasks.tabular_assembler.torch.assembler import (
+    _reorder_output_schema,
+    torch_assembler,
+)
+from michelangelo.workflow.variables.metadata import (
+    TRAINING_FRAMEWORK_PYTORCH,
+    ModelMetadata,
+)
+from michelangelo.workflow.variables.types import ModelArtifact
+
+_ASSEMBLER_MODULE = "michelangelo.workflow.tasks.tabular_assembler.torch.assembler"
+
+
+class _E2EPredictor(nn.Module):
+    """Tiny real predictor for an end-to-end (real files, no mocks) assembler test."""
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Sum the last dimension, matching ``_make_schema``'s ``input``/``output``."""
+        return input.sum(dim=-1, keepdim=True)
+
+
+class _E2ETxModule(nn.Module):
+    """Tiny real native-transform module for an end-to-end assembler test."""
+
+    def forward(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """Double ``tx_in``, matching ``_native_tx_schema``'s input/output names."""
+        return {"pred_in": inputs["tx_in"] * 2.0}
+
+
+def _make_schema() -> ModelSchema:
+    return ModelSchema(
+        input_schema=[
+            ModelSchemaItem(name="input", data_type=DataType.FLOAT, shape=[2]),
+        ],
+        output_schema=[
+            ModelSchemaItem(name="output", data_type=DataType.FLOAT, shape=[1]),
+        ],
+    )
+
+
+def _fake_create_package(dest_dir_name: str):
+    """Return a packager-method side effect that materializes a real package dir.
+
+    ``storage_backend.upload`` (unmocked, real ``LocalStorageBackend``) needs
+    an actual file on disk to copy, so the packager stand-in must write
+    something to ``dest_model_path`` rather than returning a bare string.
+    """
+
+    def _side_effect(model_path, *, dest_model_path=None, **kwargs):
+        os.makedirs(dest_model_path, exist_ok=True)
+        with open(os.path.join(dest_model_path, "artifact.bin"), "wb") as f:
+            f.write(dest_dir_name.encode())
+        return dest_model_path
+
+    return _side_effect
+
+
+class _LocalBackendTestCase(unittest.TestCase):
+    """Shared ``LocalStorageBackend``-per-test fixture for the tests below."""
+
+    def setUp(self) -> None:
+        """Create a fresh ``LocalStorageBackend`` rooted at a temp dir per test."""
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.storage_backend = LocalStorageBackend(self._tmp.name)
+
+    def _upload_raw_model_source(self, contents: bytes = b"weights") -> str:
+        """Create a local source file and upload it, returning a backend URI."""
+        src = os.path.join(tempfile.mkdtemp(dir=self._tmp.name), "model.pt")
+        with open(src, "wb") as f:
+            f.write(contents)
+        return self.storage_backend.upload(src, f"sources/{os.path.basename(src)}")
+
+
+class TorchAssemblerTest(_LocalBackendTestCase):
+    """Tests for ``torch_assembler``'s plain (no native-transform) path."""
+
+    def _upload_real_module_source(
+        self, module: nn.Module, *, as_state_dict: bool = True
+    ) -> str:
+        """Save a real module (state_dict or full module) and upload it.
+
+        Args:
+            module: The module to persist.
+            as_state_dict: Save ``module.state_dict()`` (the usual predictor
+                format) when ``True``; save the full module object (the
+                format ``fuse_models_to_python`` expects for the
+                native-transform side) when ``False``.
+        """
+        src = os.path.join(tempfile.mkdtemp(dir=self._tmp.name), "model.pt")
+        torch.save(module.state_dict() if as_state_dict else module, src)
+        return self.storage_backend.upload(src, f"sources/{uuid.uuid4().hex}.pt")
+
+    @patch(f"{_ASSEMBLER_MODULE}.TorchTritonPackager.create_model_package")
+    @patch(f"{_ASSEMBLER_MODULE}.TorchTritonPackager.create_raw_model_package")
+    def test_torch_assembler_basic(self, mock_create_raw, mock_create_model):
+        """Deployable/raw metadata reflect the source model."""
+        mock_create_model.side_effect = _fake_create_package("deployable")
+        mock_create_raw.side_effect = _fake_create_package("raw")
+
+        config = TabularAssemblerConfig()
+        sample_data = [{"input": np.array([[1.0, 2.0]])}]
+        raw_model = ModelArtifact(
+            path=self._upload_raw_model_source(),
+            metadata=ModelMetadata(
+                model_class="test.SimpleTorchModel",
+                training_framework=TRAINING_FRAMEWORK_PYTORCH,
+                hyperparameters={"input_dim": 2, "output_dim": 1},
+                schema=_make_schema(),
+                sample_data=sample_data,
+                is_incremental_training=True,
+                baseline_model_identifier="baseline-model-v1",
+            ),
+        )
+
+        assembled = torch_assembler(
+            config, raw_model, storage_backend=self.storage_backend
+        )
+
+        self.assertEqual(assembled.deployable_model.metadata.deployable, True)
+        self.assertEqual(assembled.deployable_model.metadata.assembled, True)
+        self.assertEqual(
+            assembled.deployable_model.metadata.schema, raw_model.metadata.schema
+        )
+        self.assertEqual(
+            assembled.deployable_model.metadata.sample_data,
+            raw_model.metadata.sample_data,
+        )
+        self.assertEqual(
+            pickle.loads(assembled.deployable_model.metadata._schema.getvalue()),
+            raw_model.metadata.schema,
+        )
+        unpickled_sample_data = pickle.loads(
+            assembled.deployable_model.metadata._sample_data.getvalue()
+        )
+        np.testing.assert_array_equal(
+            unpickled_sample_data[0]["input"], sample_data[0]["input"]
+        )
+
+        self.assertEqual(assembled.raw_model.metadata.deployable, False)
+        self.assertEqual(assembled.raw_model.metadata.assembled, True)
+        self.assertEqual(assembled.raw_model.metadata.schema, raw_model.metadata.schema)
+        self.assertEqual(
+            assembled.raw_model.metadata.sample_data, raw_model.metadata.sample_data
+        )
+        self.assertEqual(
+            pickle.loads(assembled.raw_model.metadata._schema.getvalue()),
+            raw_model.metadata.schema,
+        )
+        unpickled_raw_sample_data = pickle.loads(
+            assembled.raw_model.metadata._sample_data.getvalue()
+        )
+        np.testing.assert_array_equal(
+            unpickled_raw_sample_data[0]["input"], sample_data[0]["input"]
+        )
+        self.assertEqual(
+            assembled.raw_model.metadata.training_framework, TRAINING_FRAMEWORK_PYTORCH
+        )
+        self.assertEqual(
+            assembled.raw_model.metadata.model_class, "test.SimpleTorchModel"
+        )
+        self.assertEqual(assembled.raw_model.metadata.is_incremental_training, True)
+        self.assertEqual(
+            assembled.raw_model.metadata.baseline_model_identifier, "baseline-model-v1"
+        )
+
+        self.assertTrue(os.path.exists(assembled.deployable_model.path))
+        self.assertTrue(os.path.exists(assembled.raw_model.path))
+
+        mock_create_model.assert_called_once()
+        kwargs = mock_create_model.call_args.kwargs
+        self.assertIsNone(kwargs["backend"])
+        self.assertEqual(kwargs["model_path_source_type"], StorageType.LOCAL)
+
+        raw_kwargs = mock_create_raw.call_args.kwargs
+        self.assertEqual(raw_kwargs["model_class"], "test.SimpleTorchModel")
+        self.assertEqual(
+            raw_kwargs["hyperparameters"], {"input_dim": 2, "output_dim": 1}
+        )
+        self.assertEqual(raw_kwargs["model_path_source_type"], StorageType.LOCAL)
+        self.assertIsNone(raw_kwargs["transform_spec"])
+        self.assertIsNone(raw_kwargs["transform_feature_stats"])
+
+    @patch(f"{_ASSEMBLER_MODULE}.TorchTritonPackager.create_model_package")
+    @patch(f"{_ASSEMBLER_MODULE}.TorchTritonPackager.create_raw_model_package")
+    def test_downloads_raw_model_locally_before_packaging(
+        self, mock_create_raw, mock_create_model
+    ):
+        """The packager only understands local paths, so the source must be local."""
+        observed: dict[str, object] = {}
+
+        def _observe_and_package(model_path, *, dest_model_path=None, **kwargs):
+            with open(model_path, "rb") as f:
+                observed["contents"] = f.read()
+            observed["model_path_source_type"] = kwargs["model_path_source_type"]
+            os.makedirs(dest_model_path, exist_ok=True)
+            return dest_model_path
+
+        mock_create_model.side_effect = _observe_and_package
+        mock_create_raw.side_effect = _fake_create_package("raw")
+
+        config = TabularAssemblerConfig()
+        raw_model = ModelArtifact(
+            path=self._upload_raw_model_source(contents=b"weights-xyz"),
+            metadata=ModelMetadata(
+                model_class="test.SimpleTorchModel", schema=_make_schema()
+            ),
+        )
+
+        torch_assembler(config, raw_model, storage_backend=self.storage_backend)
+
+        self.assertEqual(observed["contents"], b"weights-xyz")
+        self.assertEqual(observed["model_path_source_type"], StorageType.LOCAL)
+
+    @patch(f"{_ASSEMBLER_MODULE}.TorchTritonPackager.create_model_package")
+    @patch(f"{_ASSEMBLER_MODULE}.TorchTritonPackager.create_raw_model_package")
+    def test_missing_hyperparameters_default_to_empty_dict(
+        self, mock_create_raw, mock_create_model
+    ):
+        """``hyperparameters=None`` on the metadata is normalized to ``{}``."""
+        mock_create_model.side_effect = _fake_create_package("deployable")
+        mock_create_raw.side_effect = _fake_create_package("raw")
+
+        config = TabularAssemblerConfig()
+        raw_model = ModelArtifact(
+            path=self._upload_raw_model_source(),
+            metadata=ModelMetadata(
+                model_class="test.SimpleTorchModel",
+                schema=ModelSchema(),
+                sample_data=[],
+            ),
+        )
+
+        torch_assembler(config, raw_model, storage_backend=self.storage_backend)
+
+        self.assertEqual(mock_create_raw.call_args.kwargs["hyperparameters"], {})
+
+    @patch(f"{_ASSEMBLER_MODULE}.TorchTritonPackager.create_model_package")
+    @patch(f"{_ASSEMBLER_MODULE}.TorchTritonPackager.create_raw_model_package")
+    def test_backend_threaded_to_packager(self, mock_create_raw, mock_create_model):
+        """``config.torch.backend`` reaches ``create_model_package``."""
+        mock_create_model.side_effect = _fake_create_package("deployable")
+        mock_create_raw.side_effect = _fake_create_package("raw")
+
+        config = TabularAssemblerConfig(torch=TorchAssemblerConfig(backend="python"))
+        raw_model = ModelArtifact(
+            path=self._upload_raw_model_source(),
+            metadata=ModelMetadata(
+                model_class="test.SimpleTorchModel",
+                schema=_make_schema(),
+                sample_data=[],
+            ),
+        )
+
+        torch_assembler(config, raw_model, storage_backend=self.storage_backend)
+
+        self.assertEqual(mock_create_model.call_args.kwargs["backend"], "python")
+
+    def test_native_transform_raises_not_implemented_pending_native_transform(self):
+        """Real fusion now runs; native_transform support is still needed.
+
+        ``torch/assembler.py``'s native-transform branch resolves its
+        ``model_fuser.fuse`` import, so this no longer fails at the import
+        stub in ``_model_fuser_functions``. It reaches real fusion code and
+        still raises ``NotImplementedError`` -- now from
+        ``fuse_models_to_python``'s ``_build_tx_hydra_spec`` call, which is
+        gated on the native-transform package, which hasn't landed yet. Real
+        (non-garbage) model files are used here so the
+        ``NotImplementedError`` is unambiguously coming from that gate and
+        not an incidental file-format error.
+        """
+        config = TabularAssemblerConfig()
+        raw_model = ModelArtifact(
+            path=self._upload_real_module_source(_E2EPredictor()),
+            metadata=ModelMetadata(
+                model_class=f"{__name__}._E2EPredictor",
+                schema=_make_schema(),
+                sample_data=[{"input": np.array([1.0, 2.0])}],
+            ),
+        )
+        native_tx = ModelArtifact(
+            path=self._upload_real_module_source(_E2ETxModule(), as_state_dict=False),
+            metadata=ModelMetadata(
+                model_class=f"{__name__}._E2ETxModule",
+                schema=_native_tx_schema(),
+                sample_data=[{"tx_in": np.array([1.0])}],
+            ),
+        )
+
+        with self.assertRaises(NotImplementedError) as ctx:
+            torch_assembler(
+                config,
+                raw_model,
+                native_transform_model=native_tx,
+                storage_backend=self.storage_backend,
+            )
+        self.assertIn("native-transform", str(ctx.exception))
+
+
+def _native_tx_schema() -> ModelSchema:
+    return ModelSchema(
+        input_schema=[
+            ModelSchemaItem(name="tx_in", data_type=DataType.FLOAT, shape=[1]),
+        ],
+        output_schema=[
+            ModelSchemaItem(name="pred_in", data_type=DataType.FLOAT, shape=[1]),
+        ],
+    )
+
+
+class NativeTransformFusionTest(_LocalBackendTestCase):
+    """Tests for ``torch_assembler``'s native-transform fusion branch.
+
+    The individual ``torch.model_fuser.fuse`` functions are patched (via
+    ``assembler._fuse``) so this branch's control flow — backend selection,
+    output reordering, fused schema/sample-data construction, and transform
+    metadata propagation — can be exercised without depending on real
+    fusion/export behavior.
+    """
+
+    def _make_artifacts(self):
+        raw_model = ModelArtifact(
+            path=self._upload_raw_model_source(),
+            metadata=ModelMetadata(
+                model_class="test.SimpleTorchModel",
+                hyperparameters={"input_dim": 1},
+                schema=ModelSchema(
+                    input_schema=[
+                        ModelSchemaItem(
+                            name="pred_in", data_type=DataType.FLOAT, shape=[1]
+                        ),
+                    ],
+                    output_schema=[
+                        ModelSchemaItem(
+                            name="a_out", data_type=DataType.FLOAT, shape=[1]
+                        ),
+                        ModelSchemaItem(
+                            name="b_out", data_type=DataType.FLOAT, shape=[1]
+                        ),
+                    ],
+                ),
+                sample_data=[{"pred_in": np.array([1.0])}],
+            ),
+        )
+        native_tx = ModelArtifact(
+            path=self._upload_raw_model_source(contents=b"tx-weights"),
+            metadata=ModelMetadata(
+                model_class="test.TxModel",
+                schema=_native_tx_schema(),
+                sample_data=[{"tx_in": np.array([1.0])}],
+                transform_spec={"transform_specs": [{"name": "Scale"}]},
+                feature_stats={"tx_in": {"mean": 0.5}},
+            ),
+        )
+        return raw_model, native_tx
+
+    def _patch_fuser(
+        self,
+        fused_model_class="test.FusedModel",
+        fused_hyperparameters=None,
+        field_order=None,
+    ):
+        mock_fuse_python = MagicMock(
+            return_value=(
+                os.path.join(self._tmp.name, "fused_model.pt"),
+                fused_model_class,
+                fused_hyperparameters or {},
+            )
+        )
+        mock_fuse_onnx = MagicMock()
+        mock_fuse_torchscript = MagicMock()
+        mock_field_order = MagicMock(return_value=field_order)
+        mock_sample_data = MagicMock(return_value=[{"tx_in": np.array([1.0])}])
+        patcher = patch.multiple(
+            f"{_ASSEMBLER_MODULE}._fuse",
+            fuse_models_to_onnx=mock_fuse_onnx,
+            fuse_models_to_python=mock_fuse_python,
+            fuse_models_to_torchscript=mock_fuse_torchscript,
+            get_predictor_output_field_order=mock_field_order,
+            build_fused_sample_data=mock_sample_data,
+        )
+        return patcher, (
+            mock_fuse_onnx,
+            mock_fuse_python,
+            mock_fuse_torchscript,
+            mock_field_order,
+        )
+
+    @patch(f"{_ASSEMBLER_MODULE}.TorchTritonPackager.create_model_package")
+    @patch(f"{_ASSEMBLER_MODULE}.TorchTritonPackager.create_raw_model_package")
+    def test_python_backend_fuses_and_reuses_fused_pt_as_deployable(
+        self, mock_create_raw, mock_create_model
+    ):
+        """Python backend: deployable reuses the fused ``.pt``; no separate export."""
+        mock_create_model.side_effect = _fake_create_package("deployable")
+        mock_create_raw.side_effect = _fake_create_package("raw")
+        raw_model, native_tx = self._make_artifacts()
+        patcher, (mock_onnx, mock_python, mock_ts, _mock_order) = self._patch_fuser(
+            fused_model_class="test.FusedModel",
+            fused_hyperparameters={"predictor_module": {}, "transform_module": {}},
+        )
+
+        with patcher:
+            config = TabularAssemblerConfig(
+                torch=TorchAssemblerConfig(backend="python")
+            )
+            assembled = torch_assembler(
+                config,
+                raw_model,
+                native_transform_model=native_tx,
+                storage_backend=self.storage_backend,
+            )
+
+        mock_python.assert_called_once()
+        mock_onnx.assert_not_called()
+        mock_ts.assert_not_called()
+
+        pkg_kwargs = mock_create_model.call_args.kwargs
+        self.assertEqual(pkg_kwargs["backend"], "python")
+        self.assertEqual(pkg_kwargs["model_class"], "test.FusedModel")
+        self.assertEqual(
+            pkg_kwargs["hyperparameters"],
+            {"predictor_module": {}, "transform_module": {}},
+        )
+
+        fused_schema = pkg_kwargs["model_schema"]
+        input_names = [item.name for item in fused_schema.input_schema]
+        self.assertIn("tx_in", input_names)
+        self.assertNotIn("pred_in", input_names, "tx output must not be an input")
+        self.assertEqual(assembled.deployable_model.metadata.schema, fused_schema)
+        self.assertEqual(assembled.raw_model.metadata.schema, fused_schema)
+
+        raw_kwargs = mock_create_raw.call_args.kwargs
+        self.assertEqual(
+            raw_kwargs["transform_spec"], native_tx.metadata.transform_spec
+        )
+        self.assertEqual(
+            raw_kwargs["transform_feature_stats"], native_tx.metadata.feature_stats
+        )
+
+    @patch(f"{_ASSEMBLER_MODULE}.TorchTritonPackager.create_model_package")
+    @patch(f"{_ASSEMBLER_MODULE}.TorchTritonPackager.create_raw_model_package")
+    def test_onnx_backend_uses_fuse_onnx(self, mock_create_raw, mock_create_model):
+        """``onnxruntime`` backend exports via ``fuse_models_to_onnx``."""
+        mock_create_model.side_effect = _fake_create_package("deployable")
+        mock_create_raw.side_effect = _fake_create_package("raw")
+        raw_model, native_tx = self._make_artifacts()
+        patcher, (mock_onnx, mock_python, mock_ts, _mock_order) = self._patch_fuser()
+
+        with patcher:
+            config = TabularAssemblerConfig(
+                torch=TorchAssemblerConfig(backend="onnxruntime")
+            )
+            torch_assembler(
+                config,
+                raw_model,
+                native_transform_model=native_tx,
+                storage_backend=self.storage_backend,
+            )
+
+        mock_python.assert_called_once()
+        mock_onnx.assert_called_once()
+        mock_ts.assert_not_called()
+        kwargs = mock_create_model.call_args.kwargs
+        self.assertEqual(kwargs["backend"], "onnxruntime")
+        model_path = mock_create_model.call_args.args[0]
+        self.assertIn("fused_model.onnx", model_path)
+
+    @patch(f"{_ASSEMBLER_MODULE}.TorchTritonPackager.create_model_package")
+    @patch(f"{_ASSEMBLER_MODULE}.TorchTritonPackager.create_raw_model_package")
+    def test_default_backend_uses_fuse_torchscript(
+        self, mock_create_raw, mock_create_model
+    ):
+        """No (or ``pytorch``) backend exports the fused model via TorchScript."""
+        mock_create_model.side_effect = _fake_create_package("deployable")
+        mock_create_raw.side_effect = _fake_create_package("raw")
+        raw_model, native_tx = self._make_artifacts()
+        patcher, (mock_onnx, mock_python, mock_ts, _mock_order) = self._patch_fuser()
+
+        with patcher:
+            torch_assembler(
+                TabularAssemblerConfig(),
+                raw_model,
+                native_transform_model=native_tx,
+                storage_backend=self.storage_backend,
+            )
+
+        mock_python.assert_called_once()
+        mock_ts.assert_called_once()
+        mock_onnx.assert_not_called()
+
+    @patch(f"{_ASSEMBLER_MODULE}.TorchTritonPackager.create_model_package")
+    @patch(f"{_ASSEMBLER_MODULE}.TorchTritonPackager.create_raw_model_package")
+    def test_fused_output_schema_reordered_by_predictor_field_order(
+        self, mock_create_raw, mock_create_model
+    ):
+        """Output schema passed to the packager follows the predictor's field order."""
+        mock_create_model.side_effect = _fake_create_package("deployable")
+        mock_create_raw.side_effect = _fake_create_package("raw")
+        raw_model, native_tx = self._make_artifacts()
+        patcher, _mocks = self._patch_fuser(field_order=["b_out", "a_out"])
+
+        with patcher:
+            torch_assembler(
+                TabularAssemblerConfig(),
+                raw_model,
+                native_transform_model=native_tx,
+                storage_backend=self.storage_backend,
+            )
+
+        fused_schema = mock_create_model.call_args.kwargs["model_schema"]
+        self.assertEqual(
+            [item.name for item in fused_schema.output_schema], ["b_out", "a_out"]
+        )
+
+    @patch(f"{_ASSEMBLER_MODULE}.TorchTritonPackager.create_model_package")
+    @patch(f"{_ASSEMBLER_MODULE}.TorchTritonPackager.create_raw_model_package")
+    def test_fused_output_schema_keeps_order_when_field_order_unavailable(
+        self, mock_create_raw, mock_create_model
+    ):
+        """A ``None`` field order leaves the predictor's original output order."""
+        mock_create_model.side_effect = _fake_create_package("deployable")
+        mock_create_raw.side_effect = _fake_create_package("raw")
+        raw_model, native_tx = self._make_artifacts()
+        patcher, _mocks = self._patch_fuser(field_order=None)
+
+        with patcher:
+            torch_assembler(
+                TabularAssemblerConfig(),
+                raw_model,
+                native_transform_model=native_tx,
+                storage_backend=self.storage_backend,
+            )
+
+        fused_schema = mock_create_model.call_args.kwargs["model_schema"]
+        self.assertEqual(
+            [item.name for item in fused_schema.output_schema], ["a_out", "b_out"]
+        )
+
+
+class ReorderOutputSchemaTest(unittest.TestCase):
+    """Tests for ``_reorder_output_schema``."""
+
+    def _schema(self) -> ModelSchema:
+        return ModelSchema(
+            input_schema=[
+                ModelSchemaItem(name="in", data_type=DataType.FLOAT, shape=[1])
+            ],
+            output_schema=[
+                ModelSchemaItem(name="a_out", data_type=DataType.FLOAT, shape=[1]),
+                ModelSchemaItem(name="b_out", data_type=DataType.FLOAT, shape=[1]),
+            ],
+        )
+
+    def test_none_field_order_returns_schema_unchanged(self):
+        """``field_order=None`` returns the exact same schema instance."""
+        schema = self._schema()
+        self.assertIs(_reorder_output_schema(schema, None), schema)
+
+    def test_reorders_to_match_field_order(self):
+        """Output fields are reordered to match ``field_order``; input is untouched."""
+        schema = self._schema()
+        reordered = _reorder_output_schema(schema, ["b_out", "a_out"])
+        self.assertEqual(
+            [item.name for item in reordered.output_schema], ["b_out", "a_out"]
+        )
+        self.assertEqual(reordered.input_schema, schema.input_schema)
+
+    def test_fields_not_in_order_are_appended(self):
+        """Output fields absent from ``field_order`` are appended at the end."""
+        schema = self._schema()
+        reordered = _reorder_output_schema(schema, ["b_out"])
+        self.assertEqual(
+            [item.name for item in reordered.output_schema], ["b_out", "a_out"]
+        )
+
+    def test_unknown_field_order_entries_are_ignored(self):
+        """Names in ``field_order`` that aren't in the schema are silently skipped."""
+        schema = self._schema()
+        reordered = _reorder_output_schema(schema, ["nonexistent", "b_out"])
+        self.assertEqual(
+            [item.name for item in reordered.output_schema], ["b_out", "a_out"]
+        )
+
+    def test_empty_field_order_appends_all_original_fields(self):
+        """An empty (but non-``None``) ``field_order`` keeps the original order."""
+        schema = self._schema()
+        reordered = _reorder_output_schema(schema, [])
+        self.assertEqual(
+            [item.name for item in reordered.output_schema], ["a_out", "b_out"]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stack: 5/5 (final). Based on #4 (model fuser engine).

## Summary
- Adds the torch/Lightning assembler path, packaged via `TorchTritonPackager` and fused via the model fuser engine from PR 4/5
- Wires the dispatch task's PyTorch/Lightning branch to the real assembler, replacing the lazy `NotImplementedError` stub added in PR 3/5
- Tightens the dispatch task to raise on an unrecognized recorded `training_framework` instead of silently returning an empty artifact pair

## Test plan
- [ ] `pytest python/michelangelo/workflow/tasks/tabular_assembler/torch`
- [ ] `pytest python/michelangelo/workflow/tasks/tabular_assembler/tests/task_test.py` (full dispatch, both paths)