### PR TITLE
fix(ingester): soft-delete metadata-storage row on kubectl delete for non-opted-in kinds

### DIFF
--- a/docs/operator-guides/components/ingester-configuration.md
+++ b/docs/operator-guides/components/ingester-configuration.md
@@ -240,13 +240,15 @@ Immutable objects (like completed PipelineRuns) no longer consume etcd memory.
 
 Objects created before the ingester was enabled will NOT have the ingester finalizer. They are still synced to MySQL on the controller's first startup, but are not intercepted during deletion via `kubectl delete`. If a user deletes such an object directly through `kubectl`, Kubernetes removes it from etcd immediately — the ingester never sees the deletion — leaving behind an orphan row in MySQL with `delete_time IS NULL`. Over time this causes MySQL to drift out of sync with etcd.
 
-Two mitigations are available:
+Note this is narrower than it may sound: it only applies to objects that never had the ingester finalizer added in the first place. Once an object carries the finalizer (the normal case for anything the ingester has reconciled at least once), a direct `kubectl delete` (or GitOps/foreground-GC deletion) is intercepted correctly — `handleCascadeDeletion` soft-deletes the MySQL row for non-opted-in kinds (and retains the final state for kinds opted into the cascade `RetainPolicy`) before the finalizer is removed, so recreating the object under the same name/namespace does not orphan the old row.
+
+Two mitigations are available for the remaining pre-existing-object gap:
 
 1. **Backfill controller (not yet implemented):** A periodic reconciliation controller that compares MySQL rows against etcd and soft-deletes any rows whose corresponding etcd object no longer exists. This is the cleanest long-term solution but requires additional engineering work.
 
 2. **Require all deletes through the API Server:** The API Server sets the `michelangelo/Deleting` annotation instead of issuing a direct Kubernetes delete, which the ingester detects and handles correctly even without a finalizer. Enforce this operationally by restricting direct `kubectl delete` access to CRD objects.
 
-Until a backfill controller is in place, option 2 is the recommended operational workaround.
+Until a backfill controller is in place, option 2 is the recommended operational workaround for objects predating the ingester finalizer.
 
 ### Schema Evolution
 

--- a/go/components/ingester/BUILD.bazel
+++ b/go/components/ingester/BUILD.bazel
@@ -20,6 +20,8 @@ go_library(
         "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/controller:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/controller/controllerutil:go_default_library",
+        "@org_golang_google_grpc//codes:go_default_library",
+        "@org_golang_google_grpc//status:go_default_library",
         "@org_uber_go_fx//:go_default_library",
         "@org_uber_go_zap//:go_default_library",
     ],
@@ -50,5 +52,7 @@ go_test(
         "@io_k8s_sigs_controller_runtime//pkg/client/fake:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client/interceptor:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/controller/controllerutil:go_default_library",
+        "@org_golang_google_grpc//codes:go_default_library",
+        "@org_golang_google_grpc//status:go_default_library",
     ],
 )

--- a/go/components/ingester/cascade_test.go
+++ b/go/components/ingester/cascade_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -110,8 +112,8 @@ func TestCascadeDeletion_OptedInDrainComplete(t *testing.T) {
 }
 
 // TestCascadeDeletion_NonOptedIn: a non-opted-in kind being deleted directly
-// (no DeletingAnnotation) → NO upsert and NO delete to MySQL; the ingester just
-// removes its finalizer (unchanged behavior). Proves the scoping.
+// (no DeletingAnnotation) → NO upsert, but the row IS soft-deleted from MySQL
+// so a future recreation with the same name/namespace doesn't orphan it.
 func TestCascadeDeletion_NonOptedIn(t *testing.T) {
 	now := metav1.NewTime(time.Now())
 	dep := &v2.Deployment{
@@ -125,19 +127,50 @@ func TestCascadeDeletion_NonOptedIn(t *testing.T) {
 		},
 	}
 	ms := new(MockMetadataStorage)
+	ms.On("Delete", mock.Anything, mock.Anything, "default", "some-deployment").Return(nil)
 	retain := cascadedelete.NewStaticRetainPolicy("PipelineRun", "TriggerRun")
 
 	r, req := makeReconciler(t, dep, &v2.Deployment{}, ms, retain)
 	res, err := r.Reconcile(context.Background(), req)
 	require.NoError(t, err)
 	assert.Zero(t, res.RequeueAfter)
-	// Non-opted-in: no MySQL upsert and no MySQL delete from the cascade path.
+	// Non-opted-in: no MySQL upsert, but the row IS soft-deleted.
 	ms.AssertNotCalled(t, "Upsert", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
-	ms.AssertNotCalled(t, "Delete", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	ms.AssertCalled(t, "Delete", mock.Anything, mock.Anything, "default", "some-deployment")
 
 	got := &v2.Deployment{}
 	require.NoError(t, r.Get(context.Background(), req.NamespacedName, got))
 	assert.False(t, ctrlutil.ContainsFinalizer(got, api.IngesterFinalizer), "ingester finalizer must be removed")
+}
+
+// TestCascadeDeletion_NonOptedIn_DeleteNotFound: the row was never synced (or
+// already deleted) — Delete returns NotFound, which must not block finalizer
+// removal or be treated as an error.
+func TestCascadeDeletion_NonOptedIn_DeleteNotFound(t *testing.T) {
+	now := metav1.NewTime(time.Now())
+	dep := &v2.Deployment{
+		TypeMeta: metav1.TypeMeta{APIVersion: "michelangelo.uber.com/v2", Kind: "Deployment"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "never-synced-deployment",
+			Namespace:         "default",
+			UID:               types.UID("u4"),
+			DeletionTimestamp: &now,
+			Finalizers:        []string{api.IngesterFinalizer},
+		},
+	}
+	ms := new(MockMetadataStorage)
+	ms.On("Delete", mock.Anything, mock.Anything, "default", "never-synced-deployment").
+		Return(status.Error(codes.NotFound, "object not found or already deleted"))
+	retain := cascadedelete.NewStaticRetainPolicy("PipelineRun", "TriggerRun")
+
+	r, req := makeReconciler(t, dep, &v2.Deployment{}, ms, retain)
+	res, err := r.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+	assert.Zero(t, res.RequeueAfter)
+
+	got := &v2.Deployment{}
+	err = r.Get(context.Background(), req.NamespacedName, got)
+	assert.Error(t, err, "object should be deleted once ingester finalizer removed")
 }
 
 func TestHasNonIngesterFinalizer(t *testing.T) {

--- a/go/components/ingester/controller.go
+++ b/go/components/ingester/controller.go
@@ -9,6 +9,8 @@ import (
 	"github.com/michelangelo-ai/michelangelo/go/api"
 	"github.com/michelangelo-ai/michelangelo/go/cascadedelete"
 	"github.com/michelangelo-ai/michelangelo/go/storage"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -194,7 +196,8 @@ func (r *Reconciler) handleSync(ctx context.Context, log logr.Logger, object cli
 // On the normal apiserver delete the row is already soft-deleted/retained via the
 // DeletingAnnotation path, so this only removes the ingester finalizer. On a non-apiserver
 // delete (foreground GC, kubectl/GitOps) the annotation is absent; handleCascadeDeletion then
-// retains the final state of opted-in kinds before the finalizer is removed.
+// either retains the final state (opted-in kinds) or soft-deletes the row (everyone else)
+// before the finalizer is removed.
 func (r *Reconciler) handleDeletion(ctx context.Context, log logr.Logger, object client.Object) (ctrl.Result, error) {
 	log.Info("Object is being deleted")
 
@@ -205,7 +208,8 @@ func (r *Reconciler) handleDeletion(ctx context.Context, log logr.Logger, object
 	}
 
 	// Non-apiserver delete (no DeletingAnnotation: foreground GC, kubectl/GitOps):
-	// retain opted-in kinds before the finalizer is removed; no-op otherwise.
+	// retain opted-in kinds before the finalizer is removed; soft-delete otherwise so a
+	// future recreation with the same name/namespace doesn't leave an orphaned row behind.
 	if !isDeletingAnnotationSet(object) {
 		wait, err := r.handleCascadeDeletion(ctx, log, object)
 		if err != nil {
@@ -231,13 +235,16 @@ func (r *Reconciler) handleDeletion(ctx context.Context, log logr.Logger, object
 }
 
 // handleCascadeDeletion reconciles the MySQL end-state for an object deleted
-// directly (no DeletingAnnotation), scoped to opted-in kinds via the RetainPolicy.
-// It never touches the ingester finalizer or issues a delete — GC owns that. It
-// returns wait=true only while an opted-in object still carries a non-ingester
-// (drain) finalizer, so the caller keeps the ingester finalizer and requeues;
-// there is deliberately no independent ingester timeout (unwedging a stuck drain
-// is the drain safety timeout's job). On drain completion it upserts the final
-// state (retain).
+// directly (no DeletingAnnotation). It never touches the ingester finalizer — GC
+// owns that. It returns wait=true only while an opted-in (RetainPolicy) object
+// still carries a non-ingester (drain) finalizer, so the caller keeps the
+// ingester finalizer and requeues; there is deliberately no independent
+// ingester timeout (unwedging a stuck drain is the drain safety timeout's job).
+// On drain completion it upserts the final state (retain). Kinds not opted into
+// the RetainPolicy are soft-deleted instead: without this, a CR deleted outside
+// michelangelo's own API (e.g. kubectl/GitOps) leaves its row behind, and
+// recreating it assigns a new K8s UID that inserts a distinct row rather than
+// colliding with the stale one, orphaning it permanently.
 func (r *Reconciler) handleCascadeDeletion(ctx context.Context, log logr.Logger, object client.Object) (wait bool, err error) {
 	// TODO(#943): gvks[0] may be non-deterministic when a type is registered under
 	// multiple versions. See issue for planned multi-GVK selection strategy.
@@ -247,8 +254,14 @@ func (r *Reconciler) handleCascadeDeletion(ctx context.Context, log logr.Logger,
 	}
 
 	if !r.retain.RetainOnCascade(gvks[0].Kind) {
-		// Not a cascade-retain kind: the caller just removes the ingester finalizer
-		// (unchanged behavior).
+		// Not a cascade-retain kind: soft-delete the row so a future recreation
+		// with the same name/namespace doesn't leave an orphan behind. NotFound
+		// (row never synced, or already deleted) is not an error here.
+		typeMeta := &metav1.TypeMeta{Kind: gvks[0].Kind, APIVersion: gvks[0].GroupVersion().String()}
+		if err := r.metadataStorage.Delete(ctx, typeMeta, object.GetNamespace(), object.GetName()); err != nil && status.Code(err) != codes.NotFound {
+			log.Error(err, "Failed to delete object from metadata storage")
+			return false, err
+		}
 		return false, nil
 	}
 

--- a/go/components/ingester/controller_test.go
+++ b/go/components/ingester/controller_test.go
@@ -215,8 +215,10 @@ func TestReconciler_HandleDeletion(t *testing.T) {
 		WithObjects(model).
 		Build()
 
-	// Create mock storage (not called — MySQL deletion is handled via annotation path)
+	// Create mock storage — Model isn't opted into the cascade RetainPolicy, so a
+	// plain kubectl delete (no DeletingAnnotation) should soft-delete the row.
 	mockStorage := new(MockMetadataStorage)
+	mockStorage.On("Delete", mock.Anything, mock.Anything, "default", "test-model").Return(nil)
 
 	// Create reconciler
 	reconciler := NewReconciler(
@@ -240,9 +242,9 @@ func TestReconciler_HandleDeletion(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, ctrl.Result{}, result)
 
-	// Verify that storage was NOT called — the DeletionTimestamp path only removes
-	// the finalizer; MySQL deletion happens upstream via the DeletingAnnotation path.
-	mockStorage.AssertNotCalled(t, "Delete")
+	// Verify that storage was deleted so a future recreation with the same
+	// name/namespace doesn't leave this row behind as an orphan.
+	mockStorage.AssertCalled(t, "Delete", mock.Anything, mock.Anything, "default", "test-model")
 
 	// The finalizer is removed so K8s can garbage-collect the object.
 }
@@ -571,8 +573,9 @@ func TestSchemeGVKResolution(t *testing.T) {
 }
 
 // TestHandleDeletion_OnlyRemovesFinalizer verifies that handleDeletion does NOT call
-// storage.Delete — MySQL deletion is owned by the annotation path. The DeletionTimestamp
-// path only removes the ingester finalizer so K8s can garbage-collect the object.
+// storage.Upsert on the plain DeletionTimestamp path for a non-opted-in kind — it
+// soft-deletes the row instead, then removes the ingester finalizer so K8s can
+// garbage-collect the object.
 func TestHandleDeletion_OnlyRemovesFinalizer(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = v2.AddToScheme(scheme)
@@ -594,6 +597,7 @@ func TestHandleDeletion_OnlyRemovesFinalizer(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(model).Build()
 
 	mockStorage := new(MockMetadataStorage)
+	mockStorage.On("Delete", mock.Anything, mock.Anything, "default", "test-model").Return(nil)
 
 	reconciler := NewReconciler(
 		fakeClient,
@@ -609,8 +613,9 @@ func TestHandleDeletion_OnlyRemovesFinalizer(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Storage must not be touched — no MySQL delete on the DeletionTimestamp path.
-	mockStorage.AssertNotCalled(t, "Delete")
+	// No upsert on the DeletionTimestamp path — only the soft-delete.
+	mockStorage.AssertNotCalled(t, "Upsert")
+	mockStorage.AssertCalled(t, "Delete", mock.Anything, mock.Anything, "default", "test-model")
 }
 
 // TestHandleDeletionAnnotation_CorrectTypeMeta verifies the same scheme-based GVK

--- a/go/storage/mysql/mysql_integration_test.go
+++ b/go/storage/mysql/mysql_integration_test.go
@@ -254,3 +254,106 @@ func TestIntegration_MetadataStoragePrimaryKey_FallbackToUID(t *testing.T) {
 	assert.Equal(t, 1, rowCount, "one row when annotation is absent")
 	assert.Equal(t, uid, storedUID, "PK falls back to the object UID when annotation is absent")
 }
+
+// TestIntegration_DeleteThenRecreate_NoOrphanRow reproduces (pre-fix) and
+// verifies the fix (post-fix) for the orphaned-row scenario raised in review on
+// #1332: a CR deleted outside michelangelo's own API (kubectl/GitOps, no
+// DeletingAnnotation) and recreated with the same name/namespace gets a new
+// K8s UID. Because `uid` is the MySQL primary key, the recreated object
+// inserts a distinct row instead of colliding with the old one. The ingester
+// fix (handleCascadeDeletion) now soft-deletes the old row via storage.Delete
+// before the finalizer is removed, which this test simulates directly against
+// the storage layer: Upsert(cr1) -> Delete(cr1) -> Upsert(cr2, new UID) should
+// leave exactly one live row, with the old row present but soft-deleted
+// (not a live duplicate).
+func TestIntegration_DeleteThenRecreate_NoOrphanRow(t *testing.T) {
+	db := openIntegrationDB(t)
+	store := newIntegrationStorage(t, db)
+
+	const (
+		ns   = "default"
+		name = "orphan-repro-deployment"
+	)
+	uid1 := string(types.UID("orig-uid-" + name))
+	uid2 := string(types.UID("new-uid-" + name))
+	t.Cleanup(func() { cleanupDeploymentRow(t, db, ns, name, uid1, uid2) })
+
+	typeMeta := metav1.TypeMeta{Kind: "Deployment", APIVersion: "michelangelo.uber.com/v2"}
+
+	cr1 := &v2pb.Deployment{
+		TypeMeta:   typeMeta,
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns, UID: types.UID(uid1), ResourceVersion: "1", CreationTimestamp: metav1.Now()},
+	}
+	require.NoError(t, store.Upsert(context.Background(), cr1, false, nil))
+
+	// Simulate what handleCascadeDeletion now does on a plain kubectl delete of
+	// a non-opted-in kind: soft-delete the row before the finalizer is removed.
+	require.NoError(t, store.Delete(context.Background(), &typeMeta, ns, name))
+
+	// Recreate: k8s assigns a new UID.
+	cr2 := &v2pb.Deployment{
+		TypeMeta:   typeMeta,
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns, UID: types.UID(uid2), ResourceVersion: "2", CreationTimestamp: metav1.Now()},
+	}
+	require.NoError(t, store.Upsert(context.Background(), cr2, false, nil))
+
+	// Exactly one live row should remain for this namespace/name.
+	var liveCount int
+	require.NoError(t, db.QueryRow(
+		"SELECT COUNT(*) FROM deployment WHERE namespace = ? AND name = ? AND delete_time IS NULL",
+		ns, name,
+	).Scan(&liveCount))
+	assert.Equal(t, 1, liveCount, "exactly one live row should remain after delete+recreate")
+
+	// The old row still physically exists (soft delete, not a hard delete) but
+	// is marked deleted, not a live duplicate.
+	var oldDeleteTime sql.NullTime
+	require.NoError(t, db.QueryRow("SELECT delete_time FROM deployment WHERE uid = ?", uid1).Scan(&oldDeleteTime))
+	assert.True(t, oldDeleteTime.Valid, "old row should be soft-deleted (delete_time set)")
+
+	// The new row is live.
+	var newDeleteTime sql.NullTime
+	require.NoError(t, db.QueryRow("SELECT delete_time FROM deployment WHERE uid = ?", uid2).Scan(&newDeleteTime))
+	assert.False(t, newDeleteTime.Valid, "new row should be live (delete_time NULL)")
+}
+
+// TestIntegration_DeleteThenRecreate_WithoutFix_WouldOrphan documents the bug
+// this fix addresses: skipping the Delete call (the pre-fix behavior for
+// non-opted-in kinds) leaves the old row live under its own UID forever, so
+// namespace/name now maps to two live rows.
+func TestIntegration_DeleteThenRecreate_WithoutFix_WouldOrphan(t *testing.T) {
+	db := openIntegrationDB(t)
+	store := newIntegrationStorage(t, db)
+
+	const (
+		ns   = "default"
+		name = "orphan-repro-no-fix-deployment"
+	)
+	uid1 := string(types.UID("orig-uid-" + name))
+	uid2 := string(types.UID("new-uid-" + name))
+	t.Cleanup(func() { cleanupDeploymentRow(t, db, ns, name, uid1, uid2) })
+
+	typeMeta := metav1.TypeMeta{Kind: "Deployment", APIVersion: "michelangelo.uber.com/v2"}
+
+	cr1 := &v2pb.Deployment{
+		TypeMeta:   typeMeta,
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns, UID: types.UID(uid1), ResourceVersion: "1", CreationTimestamp: metav1.Now()},
+	}
+	require.NoError(t, store.Upsert(context.Background(), cr1, false, nil))
+
+	// No Delete call here — this is the pre-fix `handleCascadeDeletion` no-op
+	// for non-opted-in kinds on a plain kubectl delete.
+
+	cr2 := &v2pb.Deployment{
+		TypeMeta:   typeMeta,
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns, UID: types.UID(uid2), ResourceVersion: "2", CreationTimestamp: metav1.Now()},
+	}
+	require.NoError(t, store.Upsert(context.Background(), cr2, false, nil))
+
+	var liveCount int
+	require.NoError(t, db.QueryRow(
+		"SELECT COUNT(*) FROM deployment WHERE namespace = ? AND name = ? AND delete_time IS NULL",
+		ns, name,
+	).Scan(&liveCount))
+	assert.Equal(t, 2, liveCount, "without the Delete call, both rows are live orphans for the same namespace/name")
+}


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

`handleCascadeDeletion` in `go/components/ingester/controller.go` now soft-deletes the metadata-storage row (via the existing `storage.Delete`) when a CR kind not opted into the cascade `RetainPolicy` is deleted directly (no `michelangelo/Deleting` annotation — i.e. a plain `kubectl delete`, GitOps, or foreground GC). `NotFound` (row never synced, or already deleted) is treated as non-fatal so finalizer removal is never blocked. Kinds opted into the `RetainPolicy` are unaffected — they still upsert their final state.

Also narrows the "Pre-Existing Objects" gap description in `docs/operator-guides/components/ingester-configuration.md` to reflect that it now only applies to objects that never got the ingester finalizer in the first place.

**Why?**

Raised during review of #1332: for any CR kind not opted into the cascade `RetainPolicy`, a direct `kubectl delete` left the MySQL row completely untouched — no soft-delete, no update. Since the table's `PRIMARY KEY` is `uid`, not `(namespace, name)`, recreating the CR with the same name/namespace gets a new K8s UID and inserts a *distinct* row rather than colliding with the stale one — a permanent orphan. This is pre-existing behavior, independent of the stable-PK annotation feature in #1332, so it's fixed here as its own PR. See the discussion thread: https://github.com/michelangelo-ai/michelangelo/pull/1332#discussion_r3634784347

**How did you test it?**

- Unit tests (mocked storage): updated `TestReconciler_HandleDeletion`, `TestHandleDeletion_OnlyRemovesFinalizer`, `TestCascadeDeletion_NonOptedIn` to assert the soft-delete now happens; added `TestCascadeDeletion_NonOptedIn_DeleteNotFound` covering the never-synced case.
- Real-MySQL integration tests: added `TestIntegration_DeleteThenRecreate_NoOrphanRow` (proves the fix — exactly one live row after delete+recreate) and `TestIntegration_DeleteThenRecreate_WithoutFix_WouldOrphan` (proves the bug — two live rows without the `Delete` call).
- Genuine end-to-end verification against the k3d sandbox: drove the real `ingester.Reconciler` and `mysql.mysqlMetadataStorage` against a real k8s API server and real MySQL (no mocks) — create CR, add finalizer, sync, plain delete, reconcile, confirm old row soft-deleted and object removed from k8s, recreate with same name/namespace, reconcile, confirm exactly one live row.

**Potential risks**

Non-opted-in CR kinds now issue one extra MySQL write (`UPDATE ... SET delete_time`) on every direct (non-annotation) delete reconcile, where previously there was none. This is the same soft-delete mechanism already used by the `DeletingAnnotation` path, so no new query patterns. `NotFound` from `Delete` is explicitly non-fatal, so it cannot newly wedge finalizer removal.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

N/A — internal correctness fix, no schema or config changes required.

**Documentation Changes**

Updated `docs/operator-guides/components/ingester-configuration.md` to narrow the scope of the documented "Pre-Existing Objects" orphan-row gap now that finalizer-bearing objects are handled correctly.