### PR TITLE
feat(python): additional_columns + filter_field_map hooks on CRD

### DIFF
--- a/python/michelangelo/cli/mactl/crd.py
+++ b/python/michelangelo/cli/mactl/crd.py
@@ -314,8 +314,9 @@ def prepare_column_info(extra: Sequence[dict] = ()) -> list[dict]:
 
     ``extra`` is a per-CRD ``additional_columns`` list; each entry
     ``{"column_name": str, "retrieve_func": Callable[[Message], str]}`` is
-    appended after the built-in columns with ``max_length`` seeded from the
-    header length.
+    appended after the built-in columns. Each column's ``max_length`` is
+    seeded from ``len(column_name) + 1`` (the header string plus 1 for
+    trailing space) and grown per-row inside ``print_list_formatted``.
     """
     res = [
         {

--- a/python/michelangelo/cli/mactl/crd.py
+++ b/python/michelangelo/cli/mactl/crd.py
@@ -380,8 +380,7 @@ def _render_list_items(
 ) -> None:
     """Render list of CRD items in the requested output format.
 
-    Matches Go mactl `-o {table|yaml|json}` behavior. ``extra_columns`` is
-    table-only; yaml/json emit the raw proto fields.
+    ``extra_columns`` is table-only; yaml/json emit the raw proto fields.
     """
     if output_format == "yaml":
         docs = [MessageToDict(m, preserving_proto_field_name=True) for m in items]

--- a/python/michelangelo/cli/mactl/crd.py
+++ b/python/michelangelo/cli/mactl/crd.py
@@ -290,8 +290,8 @@ def get_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Mess
     _LOG.debug("No name argument passed. List CRD in the namespace.")
     _self.generate_list(crd_method_info.channel)
     # Forward any filter dest args declared in _self.filter_field_map so
-    # `<crd> get --filter foo=bar` (no name) falls through to list with the
-    # filter applied, not silently dropped.
+    # `<crd> get -n <ns> --<attr> <val>` (no name) falls through to list
+    # with the filter applied, not silently dropped.
     filter_field_map = getattr(_self, "filter_field_map", None)
     if not isinstance(filter_field_map, dict):
         filter_field_map = {}

--- a/python/michelangelo/cli/mactl/crd.py
+++ b/python/michelangelo/cli/mactl/crd.py
@@ -289,11 +289,23 @@ def get_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Mess
 
     _LOG.debug("No name argument passed. List CRD in the namespace.")
     _self.generate_list(crd_method_info.channel)
+    # Forward any filter dest args declared in _self.filter_field_map so
+    # `<crd> get --filter foo=bar` (no name) falls through to list with the
+    # filter applied, not silently dropped.
+    filter_field_map = getattr(_self, "filter_field_map", None)
+    if not isinstance(filter_field_map, dict):
+        filter_field_map = {}
+    filter_kwargs = {
+        k: bound_args.arguments[k]
+        for k in filter_field_map
+        if k in bound_args.arguments
+    }
     return _self.list(
         namespace="" if all_namespaces else namespace,
         limit=bound_args.arguments.get("limit", 100),
         all_namespaces=all_namespaces,
         output=output,
+        **filter_kwargs,
     )
 
 
@@ -978,6 +990,12 @@ class CRD:
                     default=False,
                 ),
                 Parameter("output", Parameter.POSITIONAL_OR_KEYWORD, default="table"),
+            ]
+            + [
+                # Per-CRD filter dests, so `_self.list(**filter_kwargs)` (called
+                # from get→list fall-through) doesn't get rejected by bind.
+                Parameter(dest, Parameter.POSITIONAL_OR_KEYWORD, default=None)
+                for dest in getattr(self, "filter_field_map", {})
             ]
         )
 

--- a/python/michelangelo/cli/mactl/crd.py
+++ b/python/michelangelo/cli/mactl/crd.py
@@ -15,6 +15,7 @@ from typing import Any, Callable, Optional
 
 from google.protobuf.json_format import MessageToDict, MessageToJson, ParseDict
 from google.protobuf.message import Message
+from google.protobuf.wrappers_pb2 import StringValue
 from grpc import (
     Channel,
     RpcError,
@@ -296,8 +297,14 @@ def get_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Mess
     )
 
 
-def prepare_column_info() -> list[dict]:
-    """Prepare column info for formatted printing of CRD items."""
+def prepare_column_info(extra: Sequence[dict] = ()) -> list[dict]:
+    """Prepare column info for formatted printing of CRD items.
+
+    ``extra`` is a per-CRD ``additional_columns`` list; each entry
+    ``{"column_name": str, "retrieve_func": Callable[[Message], str]}`` is
+    appended after the built-in columns with ``max_length`` seeded from the
+    header length.
+    """
     res = [
         {
             "column_name": "NAMESPACE",
@@ -322,22 +329,31 @@ def prepare_column_info() -> list[dict]:
             "max_length": len("LAST_UPDATED_SPEC") + 1,
         },
     ]
+    for col in extra:
+        name = col["column_name"]
+        res.append(
+            {
+                "column_name": name,
+                "retrieve_func": col["retrieve_func"],
+                "max_length": len(name) + 1,
+            }
+        )
     _LOG.debug("Prepared column info: %r", res)
     return res
 
 
-def print_list_formatted(items: Sequence[Message]):
+def print_list_formatted(items: Sequence[Message], extra_columns: Sequence[dict] = ()):
     """Print list of CRD items in formatted way."""
     _LOG.info("Print list of CRD items: %r (length %d)", type(items), len(items))
 
     ansi_header = "\033[1;37;44m"  # bold + white + blue background
     ansi_reset = "\033[0m"
 
-    column_info = prepare_column_info()
+    column_info = prepare_column_info(extra_columns)
     for item in items:
         for col in column_info:
             col["max_length"] = max(
-                col["max_length"], len(col["retrieve_func"](item)) + 1
+                col["max_length"], len(str(col["retrieve_func"](item))) + 1
             )
 
     print(
@@ -350,17 +366,22 @@ def print_list_formatted(items: Sequence[Message]):
             " "
             + "".join(
                 [
-                    col["retrieve_func"](item).ljust(col["max_length"])
+                    str(col["retrieve_func"](item)).ljust(col["max_length"])
                     for col in column_info
                 ]
             )
         )
 
 
-def _render_list_items(items: Sequence[Message], output_format: str) -> None:
+def _render_list_items(
+    items: Sequence[Message],
+    output_format: str,
+    extra_columns: Sequence[dict] = (),
+) -> None:
     """Render list of CRD items in the requested output format.
 
-    Matches Go mactl `-o {table|yaml|json}` behavior.
+    Matches Go mactl `-o {table|yaml|json}` behavior. ``extra_columns`` is
+    table-only; yaml/json emit the raw proto fields.
     """
     if output_format == "yaml":
         docs = [MessageToDict(m, preserving_proto_field_name=True) for m in items]
@@ -369,7 +390,7 @@ def _render_list_items(items: Sequence[Message], output_format: str) -> None:
         docs = [MessageToDict(m, preserving_proto_field_name=True) for m in items]
         print(json.dumps({"items": docs}, indent=2))
     else:
-        print_list_formatted(items)
+        print_list_formatted(items, extra_columns=extra_columns)
 
 
 def _render_single_item(msg: Message, output_format: str) -> None:
@@ -390,6 +411,7 @@ def _list_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Me
     """Raw CRD LIST implementation - returns response without printing."""
     _LOG.info("Bound arguments: %r", bound_args.arguments)
 
+    _self: Optional[CRD] = bound_args.arguments.get("self")
     limit = bound_args.arguments.get("limit", 100)
     all_namespaces = bound_args.arguments.get("all_namespaces", False)
     namespace = (
@@ -412,6 +434,17 @@ def _list_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Me
 
     request_input = crd_method_info.input_class()
     ParseDict(request_dict, request_input)
+
+    filter_field_map = getattr(_self, "filter_field_map", {}) if _self else {}
+    for arg_dest, field_name in filter_field_map.items():
+        value = bound_args.arguments.get(arg_dest)
+        if value in (None, "", (), []):
+            continue
+        criterion = request_input.list_options_ext.operation.criterion.add()
+        criterion.field_name = field_name
+        criterion.operator = 1  # CRITERION_OPERATOR_EQUAL
+        criterion.match_value.Pack(StringValue(value=str(value)))
+
     _LOG.info("ListRequest built: %r", request_input)
     call_res = crd_method_call(crd_method_info, request_input)
     _LOG.debug("Succeed to list CRDs: %r", type(call_res))
@@ -443,7 +476,11 @@ def list_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Mes
     # we assume the there is only one list field in the response message
     raw_elems = results[next(iter(results))]
 
-    _render_list_items(raw_elems.items, output)
+    _render_list_items(
+        raw_elems.items,
+        output,
+        extra_columns=getattr(_self, "additional_columns", ()),
+    )
 
     # Show warning if we got exactly the limit (there might be more)
     if len(raw_elems.items) == limit:
@@ -535,6 +572,12 @@ class CRD:
         self.full_name = full_name
         self.func_crd_metadata_converter = convert_crd_metadata
         self.metadata = metadata
+        # Per-CRD extension registries. Subclasses opt in from their own
+        # __init__ after super().__init__(...). See CRD.configure_parser and
+        # _list_func_impl / list_func_impl for how each list is consumed.
+        self.additional_columns: list[dict] = []
+        self.additional_get_args: list[dict] = []
+        self.filter_field_map: dict[str, str] = {}
         self.func_signature: dict[str, dict] = {
             "apply": {
                 "help": "Apply an Entity (create or update)",
@@ -719,21 +762,67 @@ class CRD:
         _LOG.debug(
             "Start to configure parser with args: %r", self.func_signature[action]
         )
-        for arg_def in self.func_signature[action]["args"]:
+        arg_defs = list(self.func_signature[action]["args"])
+        if action == "get":
+            arg_defs.extend(self._validated_additional_get_args())
+        for arg_def in arg_defs:
             args = arg_def.get("args", [])
             kwargs = arg_def.get("kwargs", {})
             parser.add_argument(*args, **kwargs)
 
+    def _validated_additional_get_args(self) -> list[dict]:
+        """Return additional_get_args after validating dest collisions.
+
+        Raises ValueError if any entry shadows a built-in `get` dest or if
+        `filter_field_map` references a dest not declared in
+        `additional_get_args`. Empty list when the CRD hasn't opted in.
+        """
+        if not self.additional_get_args and not self.filter_field_map:
+            return []
+        builtin_dests = {
+            self._arg_dest(arg) for arg in self.func_signature["get"]["args"]
+        }
+        extra_dests: set[str] = set()
+        for arg in self.additional_get_args:
+            dest = self._arg_dest(arg)
+            if dest in builtin_dests:
+                raise ValueError(
+                    f"additional_get_args dest {dest!r} collides with built-in "
+                    f"`get` argument on CRD {self.name!r}"
+                )
+            extra_dests.add(dest)
+        for dest in self.filter_field_map:
+            if dest not in extra_dests:
+                raise ValueError(
+                    f"filter_field_map references dest {dest!r} but no matching "
+                    f"entry in additional_get_args on CRD {self.name!r}"
+                )
+        return list(self.additional_get_args)
+
+    @staticmethod
+    def _arg_dest(arg_def: dict) -> str:
+        """Derive argparse dest for a func_signature args entry.
+
+        Prefers explicit `kwargs.dest`; else the longest `args` string (long
+        option), stripped of leading dashes with hyphens → underscores. Matches
+        argparse's own dest inference.
+        """
+        dest = arg_def.get("kwargs", {}).get("dest")
+        if dest:
+            return dest
+        args = arg_def.get("args", [""])
+        longest = max(args, key=len)
+        return longest.lstrip("-").replace("-", "_")
+
     def _read_signatures(self, method_name: str) -> Signature:
         """Read function signatures for method name."""
         _LOG.debug("Prepare func signature for `%r` function", method_name)
+        arg_defs = list(self.func_signature[method_name]["args"])
+        if method_name == "get":
+            arg_defs.extend(self.additional_get_args)
         res = Signature(
             [Parameter("self", Parameter.POSITIONAL_OR_KEYWORD)]
-            + [
-                arg["func_signature"]
-                for arg in self.func_signature[method_name]["args"]
-                if "func_signature" in arg
-            ]
+            + [arg["func_signature"] for arg in arg_defs if "func_signature" in arg]
         )
         _LOG.debug("Read func signature: %r", res)
         return res

--- a/python/michelangelo/cli/mactl/crd_test.py
+++ b/python/michelangelo/cli/mactl/crd_test.py
@@ -1382,7 +1382,7 @@ class FilterEndToEndTest(TestCase):
     def test_get_fallthrough_forwards_filter_to_list(
         self, _parse, mock_call, mock_extract
     ):
-        """`<crd> get --filter foo` (no name) falls through to list with filter."""
+        """`<crd> get -n <ns> --<attr> <val>` (no name) falls through to list with filter."""
         mock_extract.return_value = ("Op", _recording_input_class(), Mock)
         crd = CRD(name="test_crd", full_name="test.service.TestCrd", metadata=[])
         crd.filter_field_map = {"pipeline_name": "spec.pipeline_name"}

--- a/python/michelangelo/cli/mactl/crd_test.py
+++ b/python/michelangelo/cli/mactl/crd_test.py
@@ -1382,7 +1382,10 @@ class FilterEndToEndTest(TestCase):
     def test_get_fallthrough_forwards_filter_to_list(
         self, _parse, mock_call, mock_extract
     ):
-        """`<crd> get -n <ns> --<attr> <val>` (no name) falls through to list with filter."""
+        """`<crd> get -n <ns> --<attr> <val>` (no name) falls through to list.
+
+        The forwarded filter reaches ``_list_func_impl`` and becomes a criterion.
+        """
         mock_extract.return_value = ("Op", _recording_input_class(), Mock)
         crd = CRD(name="test_crd", full_name="test.service.TestCrd", metadata=[])
         crd.filter_field_map = {"pipeline_name": "spec.pipeline_name"}

--- a/python/michelangelo/cli/mactl/crd_test.py
+++ b/python/michelangelo/cli/mactl/crd_test.py
@@ -1336,3 +1336,91 @@ class ReadSignaturesHookTest(TestCase):
         ]
         sig = crd._read_signatures("apply")
         self.assertNotIn("pipeline_name", sig.parameters)
+
+
+class FilterEndToEndTest(TestCase):
+    """End-to-end: filter flows through generate_list → bind → _list_func_impl.
+
+    Regression against a class of bug where the impl-level logic works but
+    the wiring rejects the filter kwarg at bind_signature time. Direct
+    ``_list_func_impl(bound_args)`` tests hide this by hand-building
+    bound_args; this test goes through ``crd.list(...)`` bound-method call.
+    """
+
+    @patch.object(CRD, "_extract_method_info")
+    @patch("michelangelo.cli.mactl.crd.crd_method_call")
+    @patch("michelangelo.cli.mactl.crd.ParseDict")
+    def test_crd_list_call_accepts_filter_kwarg(self, _parse, mock_call, mock_extract):
+        """`crd.list(pipeline_name="x")` must not TypeError at bind."""
+        mock_extract.return_value = ("ListTestCrd", _recording_input_class(), Mock)
+        crd = CRD(name="test_crd", full_name="test.service.TestCrd", metadata=[])
+        crd.filter_field_map = {"pipeline_name": "spec.pipeline_name"}
+        crd.additional_columns = ()
+
+        captured = {}
+
+        def _capture(_info, req):
+            captured["req"] = req
+            field_desc = Mock()
+            field_desc.name = "test_list"
+            return Mock(ListFields=Mock(return_value=[(field_desc, Mock(items=[]))]))
+
+        mock_call.side_effect = _capture
+
+        crd.generate_list(Mock())
+        # Real bound-method call — goes through bind_signature. Would TypeError
+        # if list_func_signature didn't include the filter dest.
+        crd.list(namespace="ns", pipeline_name="trainer-v2")
+
+        criteria = captured["req"].list_options_ext.operation.criterion
+        self.assertEqual(len(criteria), 1)
+        self.assertEqual(criteria[0].field_name, "spec.pipeline_name")
+
+    @patch.object(CRD, "_extract_method_info")
+    @patch("michelangelo.cli.mactl.crd.crd_method_call")
+    @patch("michelangelo.cli.mactl.crd.ParseDict")
+    def test_get_fallthrough_forwards_filter_to_list(
+        self, _parse, mock_call, mock_extract
+    ):
+        """`<crd> get --filter foo` (no name) falls through to list with filter."""
+        mock_extract.return_value = ("Op", _recording_input_class(), Mock)
+        crd = CRD(name="test_crd", full_name="test.service.TestCrd", metadata=[])
+        crd.filter_field_map = {"pipeline_name": "spec.pipeline_name"}
+        crd.additional_columns = ()
+
+        captured = {}
+
+        def _capture(_info, req):
+            captured["req"] = req
+            field_desc = Mock()
+            field_desc.name = "test_list"
+            return Mock(ListFields=Mock(return_value=[(field_desc, Mock(items=[]))]))
+
+        mock_call.side_effect = _capture
+
+        info = CrdMethodInfo(
+            channel=Mock(),
+            crd_full_name="test.service.TestCrd",
+            method_name="Get",
+            input_class=_recording_input_class(),
+            output_class=Mock,
+        )
+        get_func_impl(
+            info,
+            Mock(
+                arguments={
+                    "self": crd,
+                    "namespace": "ns",
+                    "name": "",
+                    "name_flag": "",
+                    "all_namespaces": False,
+                    "output": "table",
+                    "limit": 100,
+                    "pipeline_name": "trainer-v2",
+                }
+            ),
+        )
+
+        criteria = captured["req"].list_options_ext.operation.criterion
+        self.assertEqual(len(criteria), 1)
+        self.assertEqual(criteria[0].field_name, "spec.pipeline_name")

--- a/python/michelangelo/cli/mactl/crd_test.py
+++ b/python/michelangelo/cli/mactl/crd_test.py
@@ -1104,8 +1104,8 @@ class AdditionalColumnsHookTest(TestCase):
     def test_print_list_formatted_coerces_non_str(self):
         """retrieve_func returning non-str renders without AttributeError.
 
-        SF-1 from spec 043: probe returning int would crash `.ljust()` on
-        pre-F043 code — framework must str()-coerce.
+        A probe returning int would crash ``.ljust()`` — framework must
+        str()-coerce.
         """
         item = Mock()
         item.metadata.namespace = "ns"
@@ -1258,7 +1258,7 @@ class ValidatedAdditionalGetArgsTest(TestCase):
         self.assertEqual(self._crd()._validated_additional_get_args(), [])
 
     def test_dest_collision_with_builtin_raises(self):
-        """SF-3: dest shadowing a built-in `get` arg raises at parser wiring."""
+        """Dest shadowing a built-in `get` arg raises at parser wiring."""
         crd = self._crd()
         crd.additional_get_args = [
             {
@@ -1273,7 +1273,7 @@ class ValidatedAdditionalGetArgsTest(TestCase):
             crd._validated_additional_get_args()
 
     def test_filter_map_unknown_dest_raises(self):
-        """SF-2: filter_field_map dest with no matching arg entry raises."""
+        """filter_field_map dest with no matching arg entry raises."""
         crd = self._crd()
         crd.additional_get_args = [
             {

--- a/python/michelangelo/cli/mactl/crd_test.py
+++ b/python/michelangelo/cli/mactl/crd_test.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime, timezone
 from inspect import Parameter, Signature
+from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import MagicMock, Mock, patch
 
@@ -18,6 +19,7 @@ from michelangelo.cli.mactl.crd import (
     inject_func_signature,
     list_func_impl,
     prepare_column_info,
+    print_list_formatted,
 )
 
 
@@ -159,6 +161,7 @@ class ListFuncImplTest(TestCase):
 
         mock_crd = Mock()
         mock_crd._list.return_value = mock_response
+        mock_crd.additional_columns = ()
 
         list_func_impl(
             crd_method_info,
@@ -200,6 +203,7 @@ class ListFuncImplTest(TestCase):
 
         mock_crd = Mock()
         mock_crd._list.return_value = mock_response
+        mock_crd.additional_columns = ()
 
         list_func_impl(
             crd_method_info,
@@ -368,7 +372,7 @@ class RenderHelpersTest(TestCase):
         items = [self._mock_item("ns", "a")]
         _render_list_items(items, "table")
 
-        mock_print.assert_called_once_with(items)
+        mock_print.assert_called_once_with(items, extra_columns=())
 
     @patch("michelangelo.cli.mactl.crd.MessageToJson")
     def test_render_single_item_json(self, mock_to_json):
@@ -1042,3 +1046,293 @@ class GenerateListTest(TestCase):
         self.assertEqual(result, mock_response)
         request_dict = mock_parse_dict.call_args[0][0]
         self.assertEqual(request_dict["namespace"], "test-ns")
+
+
+class _FakeAny:
+    """Records the Pack() call for filter-criterion assertion."""
+
+    def __init__(self):
+        self.packed = None
+
+    def Pack(self, msg):  # noqa: N802 — mirrors proto Any.Pack
+        self.packed = msg
+
+
+class _RecordingCriterionList(list):
+    """Mimics repeated proto field: `add()` returns a fresh criterion object."""
+
+    def add(self):
+        c = SimpleNamespace(field_name="", operator=0, match_value=_FakeAny())
+        self.append(c)
+        return c
+
+
+def _recording_input_class():
+    """Build an input_class whose instance records criterion additions.
+
+    Bypasses proto so tests don't require the michelangelo.api IDL at import
+    time.
+    """
+
+    def _factory():
+        return SimpleNamespace(
+            list_options_ext=SimpleNamespace(
+                operation=SimpleNamespace(criterion=_RecordingCriterionList())
+            )
+        )
+
+    return _factory
+
+
+class AdditionalColumnsHookTest(TestCase):
+    """CRD.additional_columns extension surface."""
+
+    def test_prepare_column_info_appends_extra_columns(self):
+        """Extra columns append after built-ins with header-length max_length."""
+        extra = [{"column_name": "STATE", "retrieve_func": lambda i: "RUNNING"}]
+
+        result = prepare_column_info(extra=extra)
+
+        self.assertEqual(len(result), 4)
+        self.assertEqual(result[-1]["column_name"], "STATE")
+        self.assertEqual(result[-1]["max_length"], len("STATE") + 1)
+
+    def test_prepare_column_info_no_extra_matches_baseline(self):
+        """Default call (no extras) preserves the 3-column baseline."""
+        self.assertEqual(len(prepare_column_info()), 3)
+
+    def test_print_list_formatted_coerces_non_str(self):
+        """retrieve_func returning non-str renders without AttributeError.
+
+        SF-1 from spec 043: probe returning int would crash `.ljust()` on
+        pre-F043 code — framework must str()-coerce.
+        """
+        item = Mock()
+        item.metadata.namespace = "ns"
+        item.metadata.name = "n"
+        item.metadata.labels = {}
+        extra = [{"column_name": "COUNT", "retrieve_func": lambda i: 42}]
+
+        with patch("builtins.print") as mock_print:
+            print_list_formatted([item], extra_columns=extra)
+
+        # Body row (second print call) contains "42" from the int column.
+        body_call = mock_print.call_args_list[1]
+        self.assertIn("42", body_call.args[0])
+
+    @patch("michelangelo.cli.mactl.crd.crd_method_call")
+    @patch("michelangelo.cli.mactl.crd.ParseDict")
+    @patch.object(CRD, "_extract_method_info")
+    def test_list_func_impl_passes_additional_columns(
+        self, mock_extract_method_info, mock_parse_dict, mock_call
+    ):
+        """`list_func_impl` threads `_self.additional_columns` into render."""
+        mock_extract_method_info.return_value = ("ListTestCrd", Mock, Mock)
+        crd = CRD(name="test_crd", full_name="test.service.TestCrd", metadata=[])
+        crd.additional_columns = [
+            {"column_name": "OWNER", "retrieve_func": lambda i: "alice"}
+        ]
+        crd.generate_list(Mock())
+
+        mock_response = Mock()
+        mock_response.ListFields.return_value = [
+            (Mock(name="test_list"), Mock(items=[]))
+        ]
+        mock_call.return_value = mock_response
+
+        with patch("michelangelo.cli.mactl.crd._render_list_items") as mock_render:
+            list_func_impl(
+                CrdMethodInfo(
+                    channel=Mock(),
+                    crd_full_name="test.service.TestCrd",
+                    method_name="List",
+                    input_class=Mock,
+                    output_class=Mock,
+                ),
+                Mock(arguments={"self": crd, "namespace": "ns", "limit": 100}),
+            )
+
+        _, kwargs = mock_render.call_args
+        self.assertEqual(kwargs["extra_columns"], crd.additional_columns)
+
+
+class FilterFieldMapHookTest(TestCase):
+    """CRD.filter_field_map extension surface."""
+
+    def _method_info(self):
+        return CrdMethodInfo(
+            channel=Mock(),
+            crd_full_name="test.service.TestCrd",
+            method_name="List",
+            input_class=_recording_input_class(),
+            output_class=Mock,
+        )
+
+    @patch("michelangelo.cli.mactl.crd.crd_method_call")
+    @patch("michelangelo.cli.mactl.crd.ParseDict")
+    def test_filter_arg_present_appends_criterion(self, mock_parse_dict, mock_call):
+        """Non-empty filter value maps to a Criterion via Any(StringValue)."""
+        crd = SimpleNamespace(
+            additional_columns=[],
+            filter_field_map={"pipeline_name": "spec.pipeline_name"},
+        )
+        captured = {}
+
+        def _capture(_info, req):
+            captured["req"] = req
+            return Mock(ListFields=Mock(return_value=[]))
+
+        mock_call.side_effect = _capture
+
+        _list_func_impl(
+            self._method_info(),
+            Mock(
+                arguments={
+                    "self": crd,
+                    "namespace": "ns",
+                    "limit": 100,
+                    "pipeline_name": "trainer-v2",
+                }
+            ),
+        )
+
+        criteria = captured["req"].list_options_ext.operation.criterion
+        self.assertEqual(len(criteria), 1)
+        self.assertEqual(criteria[0].field_name, "spec.pipeline_name")
+        self.assertEqual(criteria[0].operator, 1)  # CRITERION_OPERATOR_EQUAL
+        self.assertEqual(criteria[0].match_value.packed.value, "trainer-v2")
+
+    @patch("michelangelo.cli.mactl.crd.crd_method_call")
+    @patch("michelangelo.cli.mactl.crd.ParseDict")
+    def test_filter_arg_empty_skips_criterion(self, mock_parse_dict, mock_call):
+        """Omitted / empty-string filter adds no criterion."""
+        crd = SimpleNamespace(
+            additional_columns=[],
+            filter_field_map={"pipeline_name": "spec.pipeline_name"},
+        )
+        captured = {}
+        mock_call.side_effect = lambda _i, req: (
+            captured.setdefault("req", req) or Mock(ListFields=Mock(return_value=[]))
+        )
+
+        _list_func_impl(
+            self._method_info(),
+            Mock(
+                arguments={
+                    "self": crd,
+                    "namespace": "ns",
+                    "limit": 100,
+                    "pipeline_name": "",
+                }
+            ),
+        )
+
+        self.assertEqual(len(captured["req"].list_options_ext.operation.criterion), 0)
+
+    @patch("michelangelo.cli.mactl.crd.crd_method_call")
+    @patch("michelangelo.cli.mactl.crd.ParseDict")
+    def test_no_filter_map_matches_baseline(self, mock_parse_dict, mock_call):
+        """CRDs that don't opt in emit zero criteria."""
+        crd = SimpleNamespace(additional_columns=[], filter_field_map={})
+        captured = {}
+        mock_call.side_effect = lambda _i, req: (
+            captured.setdefault("req", req) or Mock(ListFields=Mock(return_value=[]))
+        )
+
+        _list_func_impl(
+            self._method_info(),
+            Mock(arguments={"self": crd, "namespace": "ns", "limit": 100}),
+        )
+
+        self.assertEqual(len(captured["req"].list_options_ext.operation.criterion), 0)
+
+
+class ValidatedAdditionalGetArgsTest(TestCase):
+    """CRD._validated_additional_get_args guards plugin load-time errors."""
+
+    def _crd(self):
+        return CRD(name="test_crd", full_name="test.service.TestCrd", metadata=[])
+
+    def test_no_opt_in_returns_empty(self):
+        """CRD that doesn't opt in short-circuits to empty list."""
+        self.assertEqual(self._crd()._validated_additional_get_args(), [])
+
+    def test_dest_collision_with_builtin_raises(self):
+        """SF-3: dest shadowing a built-in `get` arg raises at parser wiring."""
+        crd = self._crd()
+        crd.additional_get_args = [
+            {
+                "func_signature": Parameter(
+                    "namespace", Parameter.POSITIONAL_OR_KEYWORD
+                ),
+                "args": ["--namespace"],
+                "kwargs": {"dest": "namespace", "type": str},
+            }
+        ]
+        with self.assertRaisesRegex(ValueError, "collides with built-in"):
+            crd._validated_additional_get_args()
+
+    def test_filter_map_unknown_dest_raises(self):
+        """SF-2: filter_field_map dest with no matching arg entry raises."""
+        crd = self._crd()
+        crd.additional_get_args = [
+            {
+                "func_signature": Parameter("foo", Parameter.POSITIONAL_OR_KEYWORD),
+                "args": ["--foo"],
+                "kwargs": {"dest": "foo", "type": str},
+            }
+        ]
+        crd.filter_field_map = {"unknown_dest": "spec.foo"}
+        with self.assertRaisesRegex(ValueError, "unknown_dest"):
+            crd._validated_additional_get_args()
+
+    def test_valid_extras_pass_through(self):
+        """Well-formed extras validate and return the same list."""
+        crd = self._crd()
+        crd.additional_get_args = [
+            {
+                "func_signature": Parameter("foo", Parameter.POSITIONAL_OR_KEYWORD),
+                "args": ["--foo"],
+                "kwargs": {"dest": "foo", "type": str},
+            }
+        ]
+        crd.filter_field_map = {"foo": "spec.foo"}
+        self.assertEqual(crd._validated_additional_get_args(), crd.additional_get_args)
+
+
+class ReadSignaturesHookTest(TestCase):
+    """CRD._read_signatures folds additional_get_args into `get` signature."""
+
+    def test_get_signature_includes_additional_get_args(self):
+        """`_read_signatures("get")` adds extra params after built-ins."""
+        crd = CRD(name="test_crd", full_name="test.service.TestCrd", metadata=[])
+        crd.additional_get_args = [
+            {
+                "func_signature": Parameter(
+                    "pipeline_name",
+                    Parameter.POSITIONAL_OR_KEYWORD,
+                    default="",
+                ),
+                "args": ["--pipeline-name"],
+                "kwargs": {"dest": "pipeline_name", "type": str, "default": ""},
+            }
+        ]
+        sig = crd._read_signatures("get")
+        self.assertIn("pipeline_name", sig.parameters)
+
+    def test_non_get_signature_ignores_additional_get_args(self):
+        """`_read_signatures("apply")` does not fold in get-only extras."""
+        crd = CRD(name="test_crd", full_name="test.service.TestCrd", metadata=[])
+        crd.additional_get_args = [
+            {
+                "func_signature": Parameter(
+                    "pipeline_name",
+                    Parameter.POSITIONAL_OR_KEYWORD,
+                    default="",
+                ),
+                "args": ["--pipeline-name"],
+                "kwargs": {"dest": "pipeline_name", "type": str, "default": ""},
+            }
+        ]
+        sig = crd._read_signatures("apply")
+        self.assertNotIn("pipeline_name", sig.parameters)


### PR DESCRIPTION
## What type of PR is this?

- [x] Feature

## What changed?

Adds three opt-in extension registries on `michelangelo.cli.mactl.crd.CRD` so plugins can extend `<crd> get` without monkey-patching the framework:

| attr | purpose |
|---|---|
| `additional_columns: list[dict]` | Extra table columns. Table-only; `-o yaml`/`-o json` unchanged. |
| `additional_get_args: list[dict]` | Extra argparse flags on `get`, same shape as `func_signature["get"]["args"]`. |
| `filter_field_map: dict[str, str]` | argparse-dest → server-field-name. Non-empty values become `Criterion(op=EQUAL, match_value=Any(StringValue))` on `list_options_ext.operation`. |

`<crd> get -n <ns>` with no positional name **and** a filter dest set now falls through to `list` with that filter applied (previously the filter kwarg was silently dropped). `list_func_signature` is extended with each `filter_field_map` dest so the bound-method call passes `bind_signature` cleanly.

Defaults are empty → CRDs that don't opt in see zero behavior change.

`configure_parser("get", …)` calls `_validated_additional_get_args()` which raises `ValueError` if any extra dest collides with a built-in `get` dest, or if `filter_field_map` references an undeclared dest.

## Why?

Plugins that want a `STATE` column or a `--pipeline-name` filter on their `get` command currently monkey-patch `prepare_column_info` / `_list_func_impl` — several near-identical copies drift silently across CRDs. This lifts the pattern into the framework, mirroring k8s `AdditionalPrintColumns` / `--field-selector`.

## How did you test it?

- **Unit tests:** 52/52 pass in `crd_test.py` (15 new — 4 column hook, 3 filter hook, 4 validation guards, 2 signature folding, 2 end-to-end wiring).
  ```
  PYTHONPATH=. python3 -m pytest michelangelo/cli/mactl/crd_test.py
  ```
- **No-regression E2E:** dev-installed this change into an existing PEX cache and ran `<crd> get` against a live cluster in both table and yaml modes — output byte-identical to pre-change baseline (no CRD opts in yet, so the hook is inert end-to-end).

## Potential risks

None for existing CRDs — all three registries default to empty and the render/list paths short-circuit on empty. Table rendering now `str()`-coerces `retrieve_func` return values, which is strictly more forgiving than pre-change.

## Breaking Changes

- [x] No breaking changes

## Release notes

Framework: `CRD` now exposes `additional_columns`, `additional_get_args`, and `filter_field_map` registries so plugins can extend `<crd> get` output and filters without monkey-patching.

## Documentation Changes

None — self-documenting via the empty-default `__init__` block.
