### PR TITLE
fix(docs): correct "Michelangelo AI-AI" double-suffix in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![codecov](https://codecov.io/gh/michelangelo-ai/michelangelo/graph/badge.svg?token=HKJDT0I6CW)](https://codecov.io/gh/michelangelo-ai/michelangelo)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11481/badge)](https://www.bestpractices.dev/projects/11481)
 
-# Michelangelo AI-AI
+# Michelangelo AI
 
-Michelangelo AI-AI is an open-source platform designed to streamline the development, deployment, and monitoring of machine learning models at scale. It offers a comprehensive suite of tools and services that facilitate the entire machine learning lifecycle, from data management to model serving.
+Michelangelo AI is an open-source platform designed to streamline the development, deployment, and monitoring of machine learning models at scale. It offers a comprehensive suite of tools and services that facilitate the entire machine learning lifecycle, from data management to model serving.
 
 :warning: **Beta Notice**
  This project is currently in beta. APIs and features may evolve, and breaking changes may occur as we continue to improve and stabilize the platform.
@@ -79,7 +79,7 @@ See the [Sandbox Setup](https://michelangelo-ai.org/docs/getting-started/sandbox
 
 ## Contributing
 
-We welcome contributions to Michelangelo AI-AI!  
+We welcome contributions to Michelangelo AI!  
 If you're interested in contributing, please read our [Contributing Guidelines](https://github.com/michelangelo-ai/michelangelo/blob/main/CONTRIBUTING.md) to get started.
 
 


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
Fixes three occurrences of `Michelangelo AI-AI` in `README.md` — the title, the opening description, and the contributing section — correcting them to `Michelangelo AI`.

**Why?**
The branding sweep in #1577 matched `Michelangelo` inside the pre-existing hyphenated form `Michelangelo-AI`, producing `Michelangelo AI-AI`. No other files in the repo are affected (verified by full-repo grep).

**How did you test it?**
Ran `grep -rn "Michelangelo AI-AI"` across the entire repo — zero remaining matches after this fix.

**Potential risks**
None — README-only change.

**Breaking Changes**
- [x] No breaking changes

**Release notes**
N/A

**Documentation Changes**
`README.md` corrected.