### PR TITLE
feat(python): framework -r/--root and -R/--recursive on apply+create

### DIFF
--- a/python/michelangelo/cli/mactl/crd.py
+++ b/python/michelangelo/cli/mactl/crd.py
@@ -2,12 +2,14 @@
 
 import json
 from argparse import ArgumentParser
-from collections.abc import MutableMapping, Sequence
+from collections.abc import Iterator, MutableMapping, Sequence
+from contextlib import redirect_stdout
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime
 from functools import partial
 from inspect import Parameter, Signature
+from io import StringIO
 from logging import getLogger
 from pathlib import Path
 from types import MethodType
@@ -112,6 +114,46 @@ def yaml_to_dict(yaml_path_string: str) -> dict[str, Any]:
 
     _LOG.info("YAML content loaded successfully: %r", list(res))
     return res
+
+
+def resolve_yaml_path(file: str, external_root: str) -> str:
+    """Prepend ``external_root`` to ``file`` when set (idempotent).
+
+    Returns ``file`` unchanged when ``external_root`` is empty OR when
+    ``file`` is already absolute under ``external_root`` — so a double
+    call with the same root is a no-op, and users passing an absolute
+    path already under the root are handled correctly.
+    """
+    if not external_root:
+        return file
+    root = str(Path(external_root))
+    if file == root or file.startswith(root + "/"):
+        return file
+    return str(Path(root) / file.lstrip("/"))
+
+
+def walk_crd_yamls(directory: str, kind: str) -> Iterator[Path]:
+    """Yield yaml files under ``directory`` whose top-level ``kind:`` matches.
+
+    Sorted (lexical, stable across runs). Symlinks not followed. Files that
+    fail to parse or don't match ``kind`` are skipped with a message on stdout.
+    Raises ``FileNotFoundError`` if ``directory`` does not exist.
+    """
+    root = Path(directory)
+    if not root.exists():
+        raise FileNotFoundError(f"directory not found: {directory}")
+    for path in sorted(p for p in root.rglob("*") if p.is_file()):
+        if path.suffix != ".yaml":
+            continue
+        try:
+            doc = yaml_safe_load(path.read_text())
+        except (OSError, YAMLError):
+            print(f"Skipped {path} since file can't be opened")
+            continue
+        if not isinstance(doc, dict) or doc.get("kind") != kind:
+            print(f"Skipped {path} since file is not of Kind {kind}")
+            continue
+        yield path
 
 
 def get_crd_namespace_and_name_from_yaml(yaml_path_string: str) -> tuple[str, str]:
@@ -546,15 +588,50 @@ def delete_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> M
 
 
 def apply_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Message:
-    """Default common CRD member method implementation for APPLY method."""
+    """Default common CRD member method implementation for APPLY method.
+
+    Consumes framework flags: `-r/--root` (path prepend + per-CRD Construct context)
+    and `-R/--recursive` (walk directory, filter by kind, apply each).
+    """
     run_pre_apply_checks(crd_method_info.crd_full_name)
     _LOG.info("Bound arguments: %r", bound_args.arguments)
     _self: CRD = bound_args.arguments["self"]
     _LOG.info("Start apply_func for %r", _self.full_name)
 
     _file = get_single_arg(bound_args.arguments, "file")
-    _dry_run = bound_args.arguments.get("dry_run", False)
+    external_root = bound_args.arguments.get("external_root", "") or ""
+    recursive = bound_args.arguments.get("recursive", False)
 
+    _file = resolve_yaml_path(_file, external_root)
+
+    if recursive:
+        kind = snake_to_camel(_self.name)
+        apply_recursive(
+            _file,
+            kind,
+            lambda p: _apply_single(crd_method_info, _self, p, bound_args.arguments),
+        )
+        return None
+
+    return _apply_single(crd_method_info, _self, _file, bound_args.arguments)
+
+
+def _apply_single(
+    crd_method_info: CrdMethodInfo,
+    _self: "CRD",
+    _file: str,
+    bound_args_arguments: dict,
+) -> Message:
+    """Apply one already-resolved yaml file.
+
+    ``bound_args_arguments`` is the caller's ``bound_args.arguments`` dict
+    (from apply's Signature bind). Passed through unchanged so both create
+    and update paths hand the SAME dict to ``apply_dry_run_to_request`` —
+    future helper extensions that read additional keys stay consistent
+    across verbs.
+    """
+    dry_run = bound_args_arguments.get("dry_run", False)
+    external_root = bound_args_arguments.get("external_root", "") or ""
     _namespace, _name = get_crd_namespace_and_name_from_yaml(_file)
 
     message_instance = None
@@ -571,17 +648,53 @@ def apply_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Me
         # fills the default False).
         _LOG.info("Create a new CRD")
         _self.generate_create(crd_method_info.channel)
-        return _self.create(_file, dry_run=_dry_run)
+        return _self.create(_file, dry_run=dry_run, external_root=external_root)
 
     # Update existing CRD
     _LOG.info("Retrieved message instance: %r", message_instance)
     request_input = _self.read_yaml_and_update_crd_request(
         crd_method_info.input_class, _file, message_instance
     )
-    apply_dry_run_to_request(request_input, "update_options", bound_args.arguments)
+    apply_dry_run_to_request(request_input, "update_options", bound_args_arguments)
     call_res = crd_method_call(crd_method_info, request_input)
     print(call_res)
     return call_res
+
+
+def apply_recursive(
+    directory: str, kind: str, per_file_fn: Callable[[str], None]
+) -> None:
+    """Sorted walk + kind-filter + continue-on-error aggregate.
+
+    Calls ``per_file_fn`` with each matched yaml path. Exceptions from
+    ``per_file_fn`` are captured; all matched files are processed even when
+    some fail; a ``RuntimeError`` is raised at the end if any failed.
+
+    Reusable by per-plugin apply overrides that need the same recursive UX
+    with their own per-file logic (e.g. a plugin's custom Construct hook).
+    """
+    failed: list[Path] = []
+    total = 0
+    for path in walk_crd_yamls(directory, kind):
+        total += 1
+        print(f"Applying {path}...")
+        buf = StringIO()
+        try:
+            with redirect_stdout(buf):
+                per_file_fn(str(path))
+        except Exception as e:
+            failed.append(path)
+            # On failure, dump the captured per-file output so the user has
+            # debug context. On success it stays suppressed to keep recursive
+            # output readable.
+            print(buf.getvalue(), end="")
+            print(f"Error: {e}")
+    if failed:
+        raise RuntimeError(
+            f"apply failed on {len(failed)} of {total} files: "
+            + ", ".join(str(p) for p in failed)
+        )
+    print(f"Successfully applied all {total} files in the directory")
 
 
 def create_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Message:
@@ -591,6 +704,8 @@ def create_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> M
     _LOG.info("Start create_func for %r", _self.full_name)
 
     _file = get_single_arg(bound_args.arguments, "file")
+    external_root = bound_args.arguments.get("external_root", "") or ""
+    _file = resolve_yaml_path(_file, external_root)
 
     request_input = read_yaml_to_crd_request(
         crd_method_info.input_class,
@@ -636,6 +751,41 @@ class CRD:
                             "help": (
                                 "Custom Resource YAML file"
                                 " (can be configured with --file)"
+                            ),
+                        },
+                    },
+                    {
+                        "func_signature": Parameter(
+                            "external_root",
+                            Parameter.POSITIONAL_OR_KEYWORD,
+                            default="",
+                        ),
+                        "args": ["-r", "--root"],
+                        "kwargs": {
+                            "dest": "external_root",
+                            "type": str,
+                            "default": "",
+                            "required": False,
+                            "help": (
+                                "External workspace root. Prepended to --file"
+                                " and passed to per-CRD construction hook."
+                            ),
+                        },
+                    },
+                    {
+                        "func_signature": Parameter(
+                            "recursive",
+                            Parameter.POSITIONAL_OR_KEYWORD,
+                            default=False,
+                        ),
+                        "args": ["-R", "--recursive"],
+                        "kwargs": {
+                            "dest": "recursive",
+                            "action": "store_true",
+                            "default": False,
+                            "help": (
+                                "When --file is a directory, apply each"
+                                " matching YAML in the directory."
                             ),
                         },
                     },
@@ -1005,11 +1155,18 @@ class CRD:
         create_func_signature = Signature(
             [
                 Parameter("self", Parameter.POSITIONAL_OR_KEYWORD),
-                # `file` is the only positional; `dry_run` mirrors the apply
+                # `file` is the only positional. `dry_run` mirrors the apply
                 # func_signature so apply_func_impl.create(_, dry_run=...) call
                 # passes bind_signature on the create-when-missing path.
+                # `external_root` is the F046 -r/--root plumbing forwarded
+                # from apply_func_impl on the same create-when-missing path.
                 Parameter("file", Parameter.POSITIONAL_OR_KEYWORD),
                 Parameter("dry_run", Parameter.POSITIONAL_OR_KEYWORD, default=False),
+                Parameter(
+                    "external_root",
+                    Parameter.POSITIONAL_OR_KEYWORD,
+                    default="",
+                ),
             ]
         )
 

--- a/python/michelangelo/cli/mactl/crd_test.py
+++ b/python/michelangelo/cli/mactl/crd_test.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime, timezone
 from inspect import Parameter, Signature
+from pathlib import Path
 from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import MagicMock, Mock, patch
@@ -22,6 +23,8 @@ from michelangelo.cli.mactl.crd import (
     list_func_impl,
     prepare_column_info,
     print_list_formatted,
+    resolve_yaml_path,
+    walk_crd_yamls,
 )
 
 
@@ -997,7 +1000,9 @@ class ApplyFuncImplDryRunTest(TestCase):
             Mock(arguments={"self": mock_crd, "file": "f.yaml", "dry_run": True}),
         )
 
-        mock_crd.create.assert_called_once_with("f.yaml", dry_run=True)
+        mock_crd.create.assert_called_once_with(
+            "f.yaml", dry_run=True, external_root=""
+        )
 
 
 class GenerateCreateSignatureTest(TestCase):
@@ -1050,6 +1055,297 @@ class NotFoundRpcError(RpcError):
 
     def details(self):  # noqa: D102
         return "not found"
+
+
+class ApplyRootRecursiveTest(TestCase):
+    """``-r/--root`` and ``-R/--recursive`` framework wiring on apply."""
+
+    def _mk_info(self):
+        return CrdMethodInfo(
+            channel=Mock(),
+            crd_full_name="test.Service",
+            method_name="Apply",
+            input_class=Mock,
+            output_class=Mock,
+        )
+
+    @patch("michelangelo.cli.mactl.crd.crd_method_call")
+    @patch("michelangelo.cli.mactl.crd.get_crd_namespace_and_name_from_yaml")
+    def test_external_root_prepends_before_yaml_read(self, mock_get_ns: MagicMock, _):
+        """external_root is prepended to file before the yaml is read."""
+        mock_crd = Mock()
+        mock_crd.full_name = "test.Service"
+        mock_crd._get.return_value = Mock()
+        mock_crd.read_yaml_and_update_crd_request.return_value = Mock()
+        mock_get_ns.return_value = ("ns", "name")
+
+        apply_func_impl(
+            self._mk_info(),
+            Mock(
+                arguments={
+                    "self": mock_crd,
+                    "file": "sub/x.yaml",
+                    "external_root": "/root",
+                }
+            ),
+        )
+
+        called_path = mock_get_ns.call_args.args[0]
+        self.assertEqual(called_path, "/root/sub/x.yaml")
+
+    @patch("michelangelo.cli.mactl.crd.crd_method_call")
+    @patch("michelangelo.cli.mactl.crd.get_crd_namespace_and_name_from_yaml")
+    def test_recursive_walks_dir_sorted_and_applies_each(
+        self, mock_get_ns: MagicMock, mock_call: MagicMock
+    ):
+        """Recursive walks matching yamls sorted; one apply per file."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            for n in ["c.yaml", "a.yaml", "b.yaml"]:
+                (tmp / n).write_text(f"kind: Test\nmetadata:\n  name: {n}\n")
+
+            mock_crd = Mock()
+            mock_crd.name = "test"
+            mock_crd.full_name = "test.Service"
+            mock_crd._get.return_value = Mock()
+            mock_crd.read_yaml_and_update_crd_request.return_value = Mock()
+            mock_get_ns.side_effect = [("ns", "a"), ("ns", "b"), ("ns", "c")]
+
+            with patch("builtins.print") as mock_print:
+                apply_func_impl(
+                    self._mk_info(),
+                    Mock(
+                        arguments={
+                            "self": mock_crd,
+                            "file": str(tmp),
+                            "recursive": True,
+                        }
+                    ),
+                )
+
+            called_paths = [c.args[0] for c in mock_get_ns.call_args_list]
+            self.assertEqual(
+                [Path(p).name for p in called_paths], ["a.yaml", "b.yaml", "c.yaml"]
+            )
+            printed = [c.args[0] for c in mock_print.call_args_list]
+            self.assertIn("Successfully applied all 3 files in the directory", printed)
+
+    @patch("michelangelo.cli.mactl.crd.crd_method_call")
+    @patch("michelangelo.cli.mactl.crd.get_crd_namespace_and_name_from_yaml")
+    def test_recursive_continue_on_error_raises_aggregate(
+        self, mock_get_ns: MagicMock, _
+    ):
+        """One file failing does NOT abort the walk; aggregate error raised at end."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            for n in ["a.yaml", "b.yaml", "c.yaml"]:
+                (tmp / n).write_text(f"kind: Test\nmetadata:\n  name: {n}\n")
+
+            mock_crd = Mock()
+            mock_crd.name = "test"
+            mock_crd.full_name = "test.Service"
+            mock_crd._get.return_value = Mock()
+            mock_crd.read_yaml_and_update_crd_request.return_value = Mock()
+            mock_get_ns.side_effect = [
+                ("ns", "a"),
+                RuntimeError("bad b"),
+                ("ns", "c"),
+            ]
+
+            with self.assertRaisesRegex(
+                RuntimeError, r"apply failed on 1 of 3 files: .*b\.yaml"
+            ):
+                apply_func_impl(
+                    self._mk_info(),
+                    Mock(
+                        arguments={
+                            "self": mock_crd,
+                            "file": str(tmp),
+                            "recursive": True,
+                        }
+                    ),
+                )
+
+            # All three files were processed despite the middle one failing.
+            self.assertEqual(mock_get_ns.call_count, 3)
+
+    @patch("michelangelo.cli.mactl.crd.crd_method_call")
+    @patch("michelangelo.cli.mactl.crd.get_crd_namespace_and_name_from_yaml")
+    def test_create_when_missing_forwards_external_root(
+        self, mock_get_ns: MagicMock, _
+    ):
+        """Apply-create path forwards external_root to _self.create (SF-8)."""
+        mock_crd = Mock()
+        mock_crd.full_name = "test.Service"
+        mock_crd._get.side_effect = RpcError()
+        mock_crd._get.side_effect.code = lambda: StatusCode.NOT_FOUND
+        mock_get_ns.return_value = ("ns", "name")
+
+        apply_func_impl(
+            self._mk_info(),
+            Mock(
+                arguments={
+                    "self": mock_crd,
+                    "file": "x.yaml",
+                    "external_root": "/root",
+                }
+            ),
+        )
+
+        mock_crd.create.assert_called_once_with(
+            "/root/x.yaml", dry_run=False, external_root="/root"
+        )
+
+    @patch("michelangelo.cli.mactl.crd.crd_method_call")
+    @patch("michelangelo.cli.mactl.crd.read_yaml_to_crd_request")
+    def test_create_func_impl_resolves_external_root(self, mock_read_yaml, _):
+        """create_func_impl prepends external_root to the yaml path."""
+        mock_crd = Mock()
+        mock_crd.name = "test"
+        mock_crd.func_crd_metadata_converter = Mock()
+
+        create_func_impl(
+            CrdMethodInfo(
+                channel=Mock(),
+                crd_full_name="test.Service",
+                method_name="Create",
+                input_class=Mock,
+                output_class=Mock,
+            ),
+            Mock(
+                arguments={
+                    "self": mock_crd,
+                    "file": "x.yaml",
+                    "external_root": "/root",
+                }
+            ),
+        )
+
+        mock_read_yaml.assert_called_once()
+        called_path = mock_read_yaml.call_args.args[2]
+        self.assertEqual(called_path, "/root/x.yaml")
+
+
+class ResolveYamlPathTest(TestCase):
+    """Tests for ``resolve_yaml_path``."""
+
+    def test_no_root_returns_file_unchanged(self):
+        """Empty root leaves the file argument alone."""
+        self.assertEqual(resolve_yaml_path("pipeline.yaml", ""), "pipeline.yaml")
+
+    def test_root_prepended(self):
+        """Root is prepended when set."""
+        self.assertEqual(resolve_yaml_path("sub/x.yaml", "/root"), "/root/sub/x.yaml")
+
+    def test_trailing_slash_on_root_normalized(self):
+        """Trailing slash on root does not duplicate the separator."""
+        self.assertEqual(resolve_yaml_path("x.yaml", "/root/"), "/root/x.yaml")
+
+    def test_leading_slash_on_file_stripped(self):
+        """Leading slash on file does not confuse the join."""
+        self.assertEqual(resolve_yaml_path("/x.yaml", "/root"), "/root/x.yaml")
+
+    def test_idempotent_double_call(self):
+        """Calling resolve twice with the same root is a no-op (no double-prepend)."""
+        once = resolve_yaml_path("sub/y.yaml", "/root")
+        twice = resolve_yaml_path(once, "/root")
+        self.assertEqual(once, "/root/sub/y.yaml")
+        self.assertEqual(twice, once)
+
+    def test_absolute_file_already_under_root_unchanged(self):
+        """An absolute file already under root is returned unchanged."""
+        self.assertEqual(
+            resolve_yaml_path("/root/foo/y.yaml", "/root"), "/root/foo/y.yaml"
+        )
+
+
+class WalkCrdYamlsTest(TestCase):
+    """Tests for ``walk_crd_yamls``."""
+
+    def _write(self, dir: Path, name: str, kind: str) -> Path:
+        p = dir / name
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(f"kind: {kind}\nmetadata:\n  name: {p.stem}\n")
+        return p
+
+    def test_sorted_lexical_order(self):
+        """Walker yields matching yamls in lexical order (stable across runs)."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            for n in ["c.yaml", "b.yaml", "a.yaml"]:
+                self._write(tmp, n, "Pipeline")
+            got = [p.name for p in walk_crd_yamls(str(tmp), "Pipeline")]
+            self.assertEqual(got, ["a.yaml", "b.yaml", "c.yaml"])
+
+    def test_kind_filter_skips_mismatched(self):
+        """Yamls whose top-level ``kind:`` does not match are skipped."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            self._write(tmp, "p.yaml", "Pipeline")
+            self._write(tmp, "j.yaml", "Project")
+            got = [p.name for p in walk_crd_yamls(str(tmp), "Pipeline")]
+            self.assertEqual(got, ["p.yaml"])
+
+    def test_non_yaml_skipped(self):
+        """Files without a .yaml extension are skipped even if content matches."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            self._write(tmp, "p.yaml", "Pipeline")
+            (tmp / "notes.txt").write_text("kind: Pipeline\n")
+            got = [p.name for p in walk_crd_yamls(str(tmp), "Pipeline")]
+            self.assertEqual(got, ["p.yaml"])
+
+    def test_recursive_descent(self):
+        """Walker descends into subdirectories."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            self._write(tmp, "sub/deep/p.yaml", "Pipeline")
+            self._write(tmp, "top.yaml", "Pipeline")
+            got = [p.name for p in walk_crd_yamls(str(tmp), "Pipeline")]
+            self.assertEqual(set(got), {"top.yaml", "p.yaml"})
+
+    def test_symlink_cycle_not_followed(self):
+        """Symlink loops do not cause infinite descent."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            self._write(tmp, "p.yaml", "Pipeline")
+            (tmp / "loop").symlink_to(tmp)
+            got = [p.name for p in walk_crd_yamls(str(tmp), "Pipeline")]
+            self.assertEqual(got, ["p.yaml"])
+
+    def test_missing_directory_raises(self):
+        """A missing directory raises FileNotFoundError with the path."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = str(Path(tmp) / "nope")
+            with self.assertRaisesRegex(FileNotFoundError, "nope"):
+                list(walk_crd_yamls(missing, "Pipeline"))
+
+    def test_unparseable_yaml_skipped(self):
+        """Unparseable yaml is skipped, valid ones are still returned."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            (tmp / "bad.yaml").write_text("kind: :bad: yaml:\n  ][")
+            self._write(tmp, "good.yaml", "Pipeline")
+            got = [p.name for p in walk_crd_yamls(str(tmp), "Pipeline")]
+            self.assertEqual(got, ["good.yaml"])
 
 
 class BindSignatureTest(TestCase):

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/apply.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/apply.py
@@ -23,7 +23,9 @@ def pipeline_apply_func_impl(
 ) -> Message:
     """Pipeline apply implementation.
 
-    update_method_info is passed by generate_apply via the standard partial mechanism.
+    TODO: this plugin monkey-patches ``apply_func_impl``, so framework
+    ``-r/--root`` + ``-R/--recursive`` wiring is bypassed for the pipeline CRD.
+    Other CRDs are covered. Follow-up PR to plumb ``external_root`` here if needed.
     """
     _self: CRD = bound_args.arguments["self"]
     _file = bound_args.arguments["file"]


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Feature

**What changed?**
Adds `-r/--root` and `-R/--recursive` to `<crd> apply` at the framework level.

- `-r/--root <path>` — prepend to yaml path before file read; forwarded to per-CRD Construct hook via new `external_root` kwarg on `generate_create`.
- `-R/--recursive` — when `-f` is a directory, walk matching yamls sorted, filter by `kind:`, apply each with continue-on-error aggregate. Per-file server response output is suppressed via `redirect_stdout` in recursive mode; on failure the captured context is dumped alongside `Error: ...`.

Helpers `resolve_yaml_path` + `walk_crd_yamls` + `apply_recursive(directory, kind, per_file_fn)` live inline in `crd.py`. Framework `apply_func_impl` is the reference consumer.

**Why?**
Users applying CRD YAMLs from outside the repo root or batching a directory of yamls need both flags; standard shape for both use cases.

**How did you test it?**

**Unit** — 16 new tests in `crd_test.py`; 56/56 pass. Ruff clean. Coverage 71.2% on `crd.py` (>66%).

**Integration (staging)** — via `<crd> apply` on a CRD served by the framework consumer:

| command | result | verified by |
|---|---|---|
| `ma <crd> apply -r <root> -f <rel>` from foreign CWD | server returned spec | get-before → get-after: `resourceVersion` changed, `uid` unchanged |
| `ma <crd> apply -f <rel>` from foreign CWD (no `-r`) | `FileNotFoundError` at CWD-relative path | proves `-r` was load-bearing (negative control) |
| `ma <crd> apply -R -f <3-file-dir>` | 3× `Applying...`, per-file protos suppressed, `Successfully applied all 3 files ...` | per-file `UpdateTimestamp` bumped on all 3 |
| `ma <crd> apply -R -f /nonexistent` | `FileNotFoundError: directory not found: /nonexistent`, non-zero exit | traceback origin in `walk_crd_yamls` proves no gRPC fired |
| `ma <crd> apply -R -f <3-valid+1-broken>` | 4× `Applying...`, error dumped on broken only, `apply failed on 1 of 4 files: <path>`, non-zero exit | server's own rejection string proves round-trip; continue-on-error confirmed |

**Potential risks**
None.

**Breaking Changes**
- [x] No breaking changes

**Release notes**
- `ma <crd> apply -r <path>` — prepends `<path>` to `-f`; lets apply run outside the repo.
- `ma <crd> apply -R -f <dir>` — apply every YAML in a directory (sorted, kind-filtered, continue-on-error).

**Documentation Changes**
None.