### PR TITLE
sandbox: bind k3d port-publishes to loopback instead of 0.0.0.0

### DIFF
--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -70,12 +70,18 @@ _helm_nodeport_map = [
 ]
 
 
+def _loopback(port_spec: str) -> str:
+    """Prefix a 'host:node' k3d port spec with 127.0.0.1 so k3d/Docker
+    binds the host side to loopback instead of the default 0.0.0.0."""
+    return f"127.0.0.1:{port_spec}"
+
+
 def _helm_chart_ports(workflow: str) -> list[str]:
     """Read control plane NodePorts from values-k3d.yaml.
 
     Returns host:nodeport strings for k3d's -p flag. NodePorts come from
-    values-k3d.yaml (single source of truth). Host ports are sandbox
-    conventions for localhost access.
+    values-k3d.yaml (single source of truth). Host ports are bound to
+    loopback for localhost-only access (see _loopback()).
 
     Cadence Web is included only when workflow=cadence; Temporal Web only
     when workflow=temporal.
@@ -278,7 +284,7 @@ def _create(ns: argparse.Namespace):
     ]
 
     for p in ports:
-        args += ["-p", f"{p}@agent:0"]
+        args += ["-p", f"{_loopback(p)}@agent:0"]
 
     _exec(*args)
 
@@ -1482,7 +1488,7 @@ def _create_compute_cluster(cluster_name: str):
 
     # Add port mappings for Ray
     for p in _ray_ports:
-        args += ["-p", f"{p}@agent:0"]
+        args += ["-p", f"{_loopback(p)}@agent:0"]
 
     _exec(*args)
 

--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -71,8 +71,11 @@ _helm_nodeport_map = [
 
 
 def _loopback(port_spec: str) -> str:
-    """Prefix a 'host:node' k3d port spec with 127.0.0.1 so k3d/Docker
-    binds the host side to loopback instead of the default 0.0.0.0."""
+    """Prefix a 'host:node' k3d port spec with 127.0.0.1.
+
+    Ensures k3d/Docker binds the host side to loopback instead of the
+    default 0.0.0.0.
+    """
     return f"127.0.0.1:{port_spec}"
 
 


### PR DESCRIPTION
## Summary
- The sandbox CLI (`ma sandbox create`) publishes k3d NodePorts as bare `host:node` pairs (`_infra_ports`, the Helm-derived control-plane ports, and `_ray_ports`), which Docker/k3d bind to all interfaces (`0.0.0.0`) by default.
- This contradicts the code's own documented intent — `_helm_chart_ports()`'s docstring already states these host ports are "localhost access" conventions — and unnecessarily exposes sandbox services beyond the host running it.
- Adds a small `_loopback()` helper and applies it at both `-p` construction sites (`_create()` and the Ray-ports block in `_create_compute_cluster()`), so every published port is explicitly bound to `127.0.0.1`.

## Why this is safe
- No functional change for any documented workflow: both the CI integration-test job and local `ma` CLI usage already connect exclusively via `localhost`/`127.0.0.1` (see `docs/getting-started/sandbox-setup.md` and `docs/getting-started/ma-sandbox-ports-and-endpoints.md` — the CLI's own default config is `address = "127.0.0.1:15566"`).
- Compatible with local laptop sandboxes (Docker Desktop, Colima, Docker Engine) — these tools transparently proxy loopback-bound publishes to the host's own `localhost`.

## Test plan
- [x] `git diff` reviewed — change is isolated to port-binding construction, no other logic touched.
- [ ] `ma sandbox create` locally; confirm `docker port <k3d-node-container>` shows `127.0.0.1:<port>` instead of `0.0.0.0:<port>` for every mapped port.
- [ ] `ma sandbox demo pipeline` runs successfully end-to-end against the loopback-bound sandbox (no regression to local pipeline workflows).