### PR TITLE
chore(release): prepare v0.6.0

### DIFF
--- a/helm/michelangelo/Chart.yaml
+++ b/helm/michelangelo/Chart.yaml
@@ -7,8 +7,8 @@ description: |
   and RBAC — into any Kubernetes cluster. Bring your own metadata storage,
   object storage, and workflow engine (Cadence or Temporal).
 type: application
-version: 0.5.0
-appVersion: "0.5.0"
+version: 0.6.0
+appVersion: "0.6.0"
 kubeVersion: ">=1.27.0-0"
 
 dependencies:

--- a/javascript/app/package.json
+++ b/javascript/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@michelangelo/app",
   "license": "Apache-2.0",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "scripts": {
     "build": "vite build --config vite.config.ts",
@@ -11,11 +11,11 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
-    "@michelangelo-ai/rpc": "0.5.0",
+    "@michelangelo-ai/rpc": "0.6.0",
     "@mui/icons-material": "^7.1.0",
     "@mui/material": "^7.1.0",
     "@tanstack/react-query": "5.39.0",
-    "@michelangelo-ai/core": "0.5.0",
+    "@michelangelo-ai/core": "0.6.0",
     "baseui": "15.0.0",
     "react-router-dom": "5.3.4",
     "react-router-dom-v5-compat": "6.29.0",

--- a/javascript/packages/core/package.json
+++ b/javascript/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@michelangelo-ai/core",
   "license": "Apache-2.0",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "main": "./dist/michelangelo-core.js",
   "module": "./dist/michelangelo-core.js",

--- a/javascript/packages/rpc/package.json
+++ b/javascript/packages/rpc/package.json
@@ -2,7 +2,7 @@
   "name": "@michelangelo-ai/rpc",
   "license": "Apache-2.0",
   "type": "module",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/michelangelo-ai/michelangelo"
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.2.5",
-    "@michelangelo-ai/core": "0.5.0"
+    "@michelangelo-ai/core": "0.6.0"
   },
   "exports": {
     ".": {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "michelangelo"
-version = "0.5.0"
+version = "0.6.0"
 description = "Michelangelo AI is an end-to-end model lifecycle management system at large scale"
 authors = ["Michelangelo AI Team <michelangelo-oss-group@uber.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Bumps all component versions from `0.5.0` to `0.6.0` via `scripts/version-bump.sh 0.6.0`
- `python/pyproject.toml`, `javascript/packages/{core,rpc}/package.json`, `javascript/app/package.json`, `helm/michelangelo/Chart.yaml` (version + appVersion)
- No functional changes

Tracking issue: #1593

## Test plan
- [x] `./scripts/version-bump.sh --check` confirms all components aligned at `0.6.0`
- [ ] CI passes on `release/v0.6`