### PR TITLE
fix(docs): correct double-suffix branding in README and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![codecov](https://codecov.io/gh/michelangelo-ai/michelangelo/graph/badge.svg?token=HKJDT0I6CW)](https://codecov.io/gh/michelangelo-ai/michelangelo)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11481/badge)](https://www.bestpractices.dev/projects/11481)
 
-# Michelangelo AI-AI
+# Michelangelo AI
 
-Michelangelo AI-AI is an open-source platform designed to streamline the development, deployment, and monitoring of machine learning models at scale. It offers a comprehensive suite of tools and services that facilitate the entire machine learning lifecycle, from data management to model serving.
+Michelangelo AI is an open-source platform designed to streamline the development, deployment, and monitoring of machine learning models at scale. It offers a comprehensive suite of tools and services that facilitate the entire machine learning lifecycle, from data management to model serving.
 
 :warning: **Beta Notice**
  This project is currently in beta. APIs and features may evolve, and breaking changes may occur as we continue to improve and stabilize the platform.
@@ -79,7 +79,7 @@ See the [Sandbox Setup](https://michelangelo-ai.org/docs/getting-started/sandbox
 
 ## Contributing
 
-We welcome contributions to Michelangelo AI-AI!  
+We welcome contributions to Michelangelo AI!  
 If you're interested in contributing, please read our [Contributing Guidelines](https://github.com/michelangelo-ai/michelangelo/blob/main/CONTRIBUTING.md) to get started.
 
 

--- a/python/examples/README.md
+++ b/python/examples/README.md
@@ -61,8 +61,8 @@ Create temporal sandbox
 
 The create setup dependencies for Uniflow including
 
-- Michelangelo AI-ai API
-- Michelangelo AI-ai controller manager
+- Michelangelo AI API
+- Michelangelo AI controller manager
 - Cadence
 - Starlark-worker
 - S3 storage


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
Corrects residual double-suffix branding artifacts introduced by the branding sweep in #1577:
- `README.md`: `Michelangelo AI-AI` → `Michelangelo AI` (title, opening paragraph, contributing section)
- `python/examples/README.md`: `Michelangelo AI-ai` → `Michelangelo AI` (Uniflow dependency list)

**Why?**
The branding sweep regex matched `Michelangelo` inside pre-existing hyphenated forms (`Michelangelo-AI`, `Michelangelo-ai`), producing malformed names. Full-repo grep confirms no remaining instances after this fix.

**How did you test it?**
`grep -rn -i "michelangelo AI-ai\|michelangelo AI-AI"` across the repo — zero matches.

**Potential risks**
None — README and examples documentation only.

**Breaking Changes**
- [x] No breaking changes

**Release notes**
N/A

**Documentation Changes**
`README.md` and `python/examples/README.md` corrected.