### PR TITLE
fix(ci): changelog.yml CR_PAT token + stop full-history CHANGELOG.md regeneration

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -136,15 +136,46 @@ jobs:
           OUTPUT: RELEASE_NOTES.md
           GITHUB_REPO: ${{ github.repository }}
 
-      - name: Generate full changelog
-        uses: orhun/git-cliff-action@v4
-        id: cliff-full
-        with:
-          config: cliff.toml
-          args: --output CHANGELOG.md
-        env:
-          OUTPUT: CHANGELOG.md
-          GITHUB_REPO: ${{ github.repository }}
+      - name: Update CHANGELOG.md (splice in the new section, never rewrite history)
+        run: |
+          python3 - <<'PYEOF'
+          import re
+
+          # CHANGELOG.md accumulates full release history (Keep a Changelog
+          # style): every existing "## [X.Y.Z] - date" section must survive
+          # untouched. Running git-cliff over the whole history with no range
+          # (the old approach) re-derives every section from scratch, which
+          # silently reshuffles/rewrites older sections whenever tag ancestry
+          # is broken (this repo is squash-merge-only, so it always is --
+          # see needs_human_review.md). RELEASE_NOTES.md is already correctly
+          # scoped by the "Determine changelog range" step above and already
+          # carries the right section header via cliff.toml's own template
+          # ("## [Unreleased]" for an ignored RC/nightly tag, "## [X.Y.Z] -
+          # date" for a real final tag) -- so just splice that in place of
+          # the previous placeholder/Unreleased section and leave everything
+          # below it alone.
+          with open("RELEASE_NOTES.md") as f:
+              new_section = f.read().rstrip("\n") + "\n"
+
+          with open("CHANGELOG.md") as f:
+              lines = f.read().split("\n")
+
+          first_idx = next(i for i, l in enumerate(lines) if l.startswith("## "))
+          header, rest = lines[:first_idx], lines[first_idx:]
+
+          if rest and rest[0].strip() in ("## Unreleased", "## [Unreleased]"):
+              next_idx = next(
+                  (i for i in range(1, len(rest)) if rest[i].startswith("## ")),
+                  len(rest),
+              )
+              rest = rest[next_idx:]
+
+          content = "\n".join(header) + "\n" + new_section + "\n" + "\n".join(rest)
+          content = re.sub(r"\n{3,}", "\n\n\n", content).rstrip("\n") + "\n"
+
+          with open("CHANGELOG.md", "w") as f:
+              f.write(content)
+          PYEOF
 
       - name: Update GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -169,7 +169,7 @@ jobs:
         if: steps.changelog-diff.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.CR_PAT }}
           base: ${{ steps.branch.outputs.base }}
           commit-message: "docs: update CHANGELOG.md for ${{ steps.tag.outputs.tag }}"
           title: "docs: update CHANGELOG.md for ${{ steps.tag.outputs.tag }}"


### PR DESCRIPTION
Two bugs found/fixed while cutting v0.6.0-rc.1:

1. `GITHUB_TOKEN` -> `CR_PAT` for the CHANGELOG.md PR-creation step (org policy blocks the default token from creating PRs -- mirrors the fix already applied to michelangelo-examples' changelog.yml). Without this, the workflow generates content but can never open its own PR.

2. The 'Generate full changelog' step ran git-cliff over the entire repo history with no range on every tag push, re-deriving every version section from scratch. Since this repo is squash-merge-only, tag ancestry is permanently broken (v0.5.0 is not an ancestor of main), so a full-history regen doesn't reliably reproduce prior sections -- it silently rewrote [0.5.0]'s content when tested against v0.6.0-rc.1 (caught before merging, see closed PR #1598). Replaced with a splice: reuse the already-correctly-scoped RELEASE_NOTES.md content and insert it in place of the old Unreleased/placeholder section only, leaving every older [X.Y.Z] section untouched. Verified locally against the real CHANGELOG.md -- [0.5.0] and [0.4.0] survive byte-for-byte.