### PR TITLE
docs: update CHANGELOG.md for v0.6.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,91 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## [Unreleased]
+
+
+### Bug Fixes
+
+
+- **helm:** Allow x-user-email header in envoy CORS preflight (#1552)
+
+
+- **helm:** Envoy checksum annotation + missing x-user-name CORS header (#1558)
+
+
+- **release:** Exclude RC/nightly tags from changelog diff boundary, commit CHANGELOG.md via PR (#1561)
+
+
+- **docs:** Wrap Spark DataFrame in DatasetVariable in branching example (#1566)
+
+
+- **rayjob:** Right-size submitter pod instead of cloning the head (#1562)
+
+
+### Documentation
+
+
+- Add v0.5.0 changelog entry (#1569)
+
+
+- Standardize branding to "Michelangelo AI" in READMEs and PyPI (#1577)
+
+
+- Standardize branding to "Michelangelo AI" across all docs (#1575)
+
+
+### Features
+
+
+- **native_transform:** Add pyarrow conversion helpers (PR A) (#1543)
+
+
+- **sandbox:** Support --set on ma sandbox create (#1554)
+
+
+- **native_transform:** Add IDHashTokenizer torch layer (PR A2) (#1548)
+
+
+- Add MetadataStoragePrimaryKey annotation for k8s migration (#1332)
+
+
+- **python:** Expose clean_reason and clean_details on GitInfo (F037) (#1572)
+
+
+- **native_transform:** Add foundation transform layers (PR B1) (#1570)
+
+
+### Miscellaneous
+
+
+- Quote templated image/secret-name values in core Deployment charts (#1544)
+
+
+- Add examples gallery page with all 9 working examples (#1469)
+
+
+- **core:** Upgrade baseui 15→18, move to peerDependencies (#1522)
+
+
+- Merge back release/v0.5 to main (#1547)
+
+
+- Remove stray test artifact python/create-project.json (#1476)
+
+
+- Ma cli: add -o, -A, and default DESC sort to <crd> get (#1576)
+
+
+- **release:** Prepare v0.6.0
+
+
+- Bump version to 0.6.0-rc.1 (#1595)
+
+
+### Refactoring
+
+
+- **core:** Split public API from primitives entrypoint (#1526)
 
 ## [0.5.0] - 2026-07-20
 
@@ -117,9 +201,6 @@ All notable changes to this project will be documented in this file.
 - Print help panel on 'ma' / 'ma -h' with prog='ma' (#1530)
 
 
-
-
-
 ## [0.4.0] - 2026-07-10
 
 
@@ -162,7 +243,6 @@ All notable changes to this project will be documented in this file.
 - **sandbox:** Add missing minio-credentials secret and kuberay images (#1474)
 
 
-
 ### CI/CD
 
 
@@ -187,12 +267,10 @@ All notable changes to this project will be documented in this file.
 - Notify Slack on scheduled/release workflow failures (#1438)
 
 
-
 ### Documentation
 
 
 - Address sandbox setup feedback — timing, sync, missing prereqs, troubleshooting (#1247)
-
 
 
 ### Features
@@ -226,7 +304,6 @@ All notable changes to this project will be documented in this file.
 
 
 - **revision:** Add pluggable Revision controller (#1314)
-
 
 
 ### Miscellaneous
@@ -283,7 +360,6 @@ All notable changes to this project will be documented in this file.
 - Add a route successOperation that skips the toast (#1485)
 
 
-
 ### Refactoring
 
 
@@ -291,4 +367,3 @@ All notable changes to this project will be documented in this file.
 
 
 - **ui:** Centralize mutation middleware in the mutation hook (#1482)
-


### PR DESCRIPTION
Corrected replacement for closed #1598 -- that version regenerated CHANGELOG.md from git-cliff's full, ancestry-blind history, which silently rewrote the existing [0.5.0] section. This version was built by hand using the fix implemented in #1599 (splice the already-correctly-scoped release notes in place of the old Unreleased section only) -- verified [0.5.0] and [0.4.0] survive untouched.