### PR TITLE
feat(native_transform): add structural/shape layers (PR B2)

### DIFF
--- a/python/michelangelo/lib/native_transform/torch/__init__.py
+++ b/python/michelangelo/lib/native_transform/torch/__init__.py
@@ -5,16 +5,23 @@ feature transforms that run identically at train and serve time.
 """
 
 from michelangelo.lib.native_transform.torch.base_layers import (
+    CaseWhen,
     Cast,
     Ceil,
+    Clip,
+    Compare,
     Concatenate,
     Constant,
     Divide,
     Floor,
     IdentityTransform,
     LogTransform,
+    PadOrCrop1D,
+    Scale,
     Stack,
     Subtract,
+    TensorColFillNone,
+    Tile,
     TorchTransformBaseLayer,
 )
 from michelangelo.lib.native_transform.torch.id_hash_tokenizer import (
@@ -22,8 +29,11 @@ from michelangelo.lib.native_transform.torch.id_hash_tokenizer import (
 )
 
 __all__ = [
+    "CaseWhen",
     "Cast",
     "Ceil",
+    "Clip",
+    "Compare",
     "Concatenate",
     "Constant",
     "Divide",
@@ -31,7 +41,11 @@ __all__ = [
     "IDHashTokenizer",
     "IdentityTransform",
     "LogTransform",
+    "PadOrCrop1D",
+    "Scale",
     "Stack",
     "Subtract",
+    "TensorColFillNone",
+    "Tile",
     "TorchTransformBaseLayer",
 ]

--- a/python/michelangelo/lib/native_transform/torch/base_layers.py
+++ b/python/michelangelo/lib/native_transform/torch/base_layers.py
@@ -14,7 +14,6 @@ fitted-statistics, and tokenizer layers are added in follow-up modules.
 from __future__ import annotations
 
 import abc
-import math
 
 import torch
 
@@ -1048,15 +1047,9 @@ class PadOrCrop1D(TorchTransformBaseLayer):
     dimension: shorter sequences are padded with ``pad_value`` and longer ones
     are cropped. ``align`` controls which end is kept and padded.
 
-    Before padding, two kinds of sentinel are converted to ``pad_value`` so that
-    padding introduced upstream (ragged-array collation) is not mistaken for real
-    data:
-
-    - When ``ragged_fill_value`` is set, positions equal to it (or ``NaN`` when
-      it is ``float('nan')``) are replaced with ``pad_value``.
-    - Regardless of ``ragged_fill_value``, remaining ``NaN`` positions (float
-      dtypes) and ``INT32_SENTINEL`` positions (integer dtypes) are replaced with
-      ``pad_value``.
+    Sentinel positions from upstream ragged-batch collation (``NaN`` for float
+    dtypes, ``INT32_SENTINEL`` for integer dtypes) are automatically replaced
+    with ``pad_value`` before the pad/crop logic runs.
 
     Args:
         input_cols: Column names of the input tensors.
@@ -1066,9 +1059,6 @@ class PadOrCrop1D(TorchTransformBaseLayer):
         dtype: Optional output dtype. When ``None``, the input dtype is
             preserved.
         pad_value: The value used for padding (default ``0``).
-        ragged_fill_value: Optional upstream padding sentinel to convert to
-            ``pad_value`` before pad/crop. Supports ``float('nan')`` (detected
-            via ``isnan``) and numeric values (detected via ``==``).
         align: ``"left"`` (default) pads on the right and keeps the first
             ``max_length`` elements; ``"right"`` pads on the left and keeps the
             last ``max_length`` elements of the real content, i.e. sentinel
@@ -1089,7 +1079,6 @@ class PadOrCrop1D(TorchTransformBaseLayer):
         max_length: int,
         dtype: torch.dtype | str | None = None,
         pad_value: int | float = 0,
-        ragged_fill_value: int | float | None = None,
         align: str = "left",
         **kwargs,
     ) -> None:
@@ -1102,8 +1091,6 @@ class PadOrCrop1D(TorchTransformBaseLayer):
             max_length: The fixed target length; must be positive.
             dtype: Optional output dtype; preserves input dtype when ``None``.
             pad_value: The value used for padding (default ``0``).
-            ragged_fill_value: Optional upstream padding sentinel to convert to
-                ``pad_value`` before pad/crop.
             align: ``"left"`` pads/crops on the right; ``"right"`` pads/crops on
                 the left.
             **kwargs: Additional base-layer options (e.g. ``name``).
@@ -1125,12 +1112,6 @@ class PadOrCrop1D(TorchTransformBaseLayer):
         self.dtype = initialize_dtype(dtype, None)
         # Store as float for TorchScript compatibility.
         self.pad_value = float(pad_value)
-        self.ragged_fill_value = (
-            float(ragged_fill_value) if ragged_fill_value is not None else None
-        )
-        self._ragged_sentinel_is_nan = ragged_fill_value is not None and math.isnan(
-            float(ragged_fill_value)
-        )
         self._int_sentinel = INT32_SENTINEL
         self.align = align
 
@@ -1162,23 +1143,11 @@ class PadOrCrop1D(TorchTransformBaseLayer):
         # where the real content ends: once a sentinel is rewritten to
         # ``pad_value`` it is indistinguishable from padding, and cropping to the
         # "last max_length elements" would keep padding over real data.
-        sentinel_mask = torch.zeros_like(stacked_input, dtype=torch.bool)
-        if self.ragged_fill_value is not None:
-            if self._ragged_sentinel_is_nan:
-                sentinel_mask = torch.isnan(stacked_input)
-            elif stacked_input.is_floating_point():
-                incoming = stacked_input.new_full((), self.ragged_fill_value)
-                sentinel_mask = (stacked_input == incoming) | torch.isnan(stacked_input)
-            else:
-                incoming = stacked_input.new_full((), self.ragged_fill_value)
-                sentinel_mask = stacked_input == incoming
-
-        # Remaining collation sentinels: NaN for floats, INT32_SENTINEL for ints.
         if stacked_input.is_floating_point():
-            sentinel_mask = sentinel_mask | torch.isnan(stacked_input)
+            sentinel_mask = torch.isnan(stacked_input)
         else:
             sentinel = stacked_input.new_full((), self._int_sentinel)
-            sentinel_mask = sentinel_mask | (stacked_input == sentinel)
+            sentinel_mask = stacked_input == sentinel
 
         replacement = stacked_input.new_full((), self.pad_value)
         stacked_input = torch.where(sentinel_mask, replacement, stacked_input)

--- a/python/michelangelo/lib/native_transform/torch/base_layers.py
+++ b/python/michelangelo/lib/native_transform/torch/base_layers.py
@@ -740,10 +740,8 @@ class TensorColFillNone(TorchTransformBaseLayer):
             # The int32 minimum encodes a missing value.
             condition = stacked_input == self.int32_min
         elif stacked_input.dtype == torch.int64:
-            # Comparing ``x / 2 == int64_min / 2`` avoids embedding the literal
-            # ``int64`` minimum, which overflows TorchScript's signed-64-bit
-            # constant range.
-            condition = stacked_input / 2 == self.int64_min / 2
+            # The int64 minimum encodes a missing value.
+            condition = stacked_input == self.int64_min
         else:
             # NaN encodes a missing value in floating-point tensors.
             condition = torch.isnan(stacked_input)
@@ -948,6 +946,10 @@ class Tile(TorchTransformBaseLayer):
         target_tensor_provided: When ``True`` and ``count`` is ``None``, infer
             the count from the last input column's size along ``axis``.
         **kwargs: Additional base-layer options (e.g. ``name``).
+
+    Raises:
+        ValueError: If neither ``count`` is set nor ``target_tensor_provided``
+            is ``True``.
     """
 
     def __init__(
@@ -971,8 +973,16 @@ class Tile(TorchTransformBaseLayer):
             target_tensor_provided: When ``True`` and ``count`` is ``None``,
                 infer the count from the last input column's size along ``axis``.
             **kwargs: Additional base-layer options (e.g. ``name``).
+
+        Raises:
+            ValueError: If neither ``count`` is set nor
+                ``target_tensor_provided`` is ``True``.
         """
         super().__init__(input_cols, output_cols, **kwargs)
+        if count is None and not target_tensor_provided:
+            raise ValueError(
+                "Either count must be specified or target_tensor_provided must be True."
+            )
         self.axis = axis
         self.count = count
         self.target_tensor_provided = target_tensor_provided
@@ -996,7 +1006,9 @@ class Tile(TorchTransformBaseLayer):
         elif self.target_tensor_provided:
             source_cols = self.input_cols[:-1]
             target_tensor = inputs[self.input_cols[-1]]
-        else:
+        else:  # pragma: no cover
+            # Unreachable: validated in ``__init__``. Kept so TorchScript sees
+            # every branch bind ``source_cols`` and ``target_tensor``.
             raise ValueError(
                 "Either count must be specified or target_tensor_provided must be True."
             )
@@ -1059,8 +1071,9 @@ class PadOrCrop1D(TorchTransformBaseLayer):
             via ``isnan``) and numeric values (detected via ``==``).
         align: ``"left"`` (default) pads on the right and keeps the first
             ``max_length`` elements; ``"right"`` pads on the left and keeps the
-            last ``max_length`` elements. Retained elements keep their original
-            order.
+            last ``max_length`` elements of the real content, i.e. sentinel
+            positions trailing the data are stripped before the crop rather
+            than being cropped to. Retained elements keep their original order.
         **kwargs: Additional base-layer options (e.g. ``name``).
 
     Raises:
@@ -1144,46 +1157,55 @@ class PadOrCrop1D(TorchTransformBaseLayer):
                 stacked_input.new_full(shape, self.pad_value, dtype=output_dtype),
             )
 
-        # Convert the upstream ragged-padding sentinel to ``pad_value``.
+        # Positions holding upstream ragged padding rather than real data. The
+        # mask is kept (not just applied) because ``align='right'`` must know
+        # where the real content ends: once a sentinel is rewritten to
+        # ``pad_value`` it is indistinguishable from padding, and cropping to the
+        # "last max_length elements" would keep padding over real data.
+        sentinel_mask = torch.zeros_like(stacked_input, dtype=torch.bool)
         if self.ragged_fill_value is not None:
-            replacement = stacked_input.new_full((), self.pad_value)
             if self._ragged_sentinel_is_nan:
-                stacked_input = torch.where(
-                    torch.isnan(stacked_input), replacement, stacked_input
-                )
+                sentinel_mask = torch.isnan(stacked_input)
             elif stacked_input.is_floating_point():
                 incoming = stacked_input.new_full((), self.ragged_fill_value)
-                mask = (stacked_input == incoming) | torch.isnan(stacked_input)
-                stacked_input = torch.where(mask, replacement, stacked_input)
+                sentinel_mask = (stacked_input == incoming) | torch.isnan(stacked_input)
             else:
                 incoming = stacked_input.new_full((), self.ragged_fill_value)
-                stacked_input = torch.where(
-                    stacked_input == incoming, replacement, stacked_input
-                )
+                sentinel_mask = stacked_input == incoming
 
-        # Convert any remaining collation sentinels (NaN for floats,
-        # INT32_SENTINEL for ints) to ``pad_value``.
-        replacement = stacked_input.new_full((), self.pad_value)
+        # Remaining collation sentinels: NaN for floats, INT32_SENTINEL for ints.
         if stacked_input.is_floating_point():
-            stacked_input = torch.where(
-                torch.isnan(stacked_input), replacement, stacked_input
-            )
+            sentinel_mask = sentinel_mask | torch.isnan(stacked_input)
         else:
             sentinel = stacked_input.new_full((), self._int_sentinel)
-            stacked_input = torch.where(
-                stacked_input == sentinel, replacement, stacked_input
-            )
+            sentinel_mask = sentinel_mask | (stacked_input == sentinel)
 
-        # Pad to at least ``max_length``, then crop to ``max_length``.
-        # ``align='left'`` pads right and keeps the first N; ``align='right'``
-        # pads left and keeps the last N.
-        padding = max(self.max_length - stacked_input.size(-1), 0)
+        replacement = stacked_input.new_full((), self.pad_value)
+        stacked_input = torch.where(sentinel_mask, replacement, stacked_input)
+
         if self.align == "right":
-            padded_tensor = torch.nn.functional.pad(
-                stacked_input, (padding, 0), value=self.pad_value
+            # Gather the last ``max_length`` elements of the *real* content
+            # (everything up to and including the last non-sentinel position),
+            # left-padding when the content is shorter than ``max_length``.
+            positions = torch.arange(
+                stacked_input.size(-1), device=stacked_input.device
             )
-            output_tensor = padded_tensor[..., -self.max_length :].to(output_dtype)
+            content_length = torch.where(
+                sentinel_mask, torch.zeros_like(positions), positions + 1
+            ).amax(dim=-1, keepdim=True)
+            source_index = (
+                torch.arange(self.max_length, device=stacked_input.device)
+                + content_length
+                - self.max_length
+            )
+            gathered = torch.gather(stacked_input, -1, source_index.clamp(min=0))
+            output_tensor = torch.where(source_index >= 0, gathered, replacement).to(
+                output_dtype
+            )
         else:
+            # ``align='left'`` pads on the right and keeps the first
+            # ``max_length`` elements, which are always real content.
+            padding = max(self.max_length - stacked_input.size(-1), 0)
             padded_tensor = torch.nn.functional.pad(
                 stacked_input, (0, padding), value=self.pad_value
             )
@@ -1265,7 +1287,8 @@ class Clip(TorchTransformBaseLayer):
         **kwargs: Additional base-layer options (e.g. ``name``).
 
     Raises:
-        ValueError: If ``input_cols`` and ``output_cols`` differ in length.
+        ValueError: If ``input_cols`` and ``output_cols`` differ in length, or if
+            both ``min_value`` and ``max_value`` are ``None``.
     """
 
     def __init__(
@@ -1289,13 +1312,16 @@ class Clip(TorchTransformBaseLayer):
             **kwargs: Additional base-layer options (e.g. ``name``).
 
         Raises:
-            ValueError: If ``input_cols`` and ``output_cols`` differ in length.
+            ValueError: If ``input_cols`` and ``output_cols`` differ in length,
+                or if both ``min_value`` and ``max_value`` are ``None``.
         """
         super().__init__(input_cols, output_cols, **kwargs)
         if len(input_cols) != len(output_cols):
             raise ValueError(
                 "Input columns and output columns must have the same length."
             )
+        if min_value is None and max_value is None:
+            raise ValueError("At least one of min_value or max_value must not be None.")
         self.min_value = min_value
         self.max_value = max_value
         self.ignore_value = ignore_value

--- a/python/michelangelo/lib/native_transform/torch/base_layers.py
+++ b/python/michelangelo/lib/native_transform/torch/base_layers.py
@@ -14,9 +14,11 @@ fitted-statistics, and tokenizer layers are added in follow-up modules.
 from __future__ import annotations
 
 import abc
+import math
 
 import torch
 
+from michelangelo.lib.constants.sentinel import INT32_SENTINEL
 from michelangelo.lib.native_transform.torch.constants import DEFAULT_EPSILON
 from michelangelo.lib.native_transform.torch.utils import (
     format_inputs,
@@ -26,16 +28,23 @@ from michelangelo.lib.native_transform.torch.utils import (
 )
 
 __all__ = [
+    "CaseWhen",
     "Cast",
     "Ceil",
+    "Clip",
+    "Compare",
     "Concatenate",
     "Constant",
     "Divide",
     "Floor",
     "IdentityTransform",
     "LogTransform",
+    "PadOrCrop1D",
+    "Scale",
     "Stack",
     "Subtract",
+    "TensorColFillNone",
+    "Tile",
     "TorchTransformBaseLayer",
 ]
 
@@ -666,3 +675,652 @@ class IdentityTransform(TorchTransformBaseLayer):
         """
         stacked_inputs = format_inputs(self.input_cols, inputs)
         return format_outputs(self.output_cols, stacked_inputs)
+
+
+class TensorColFillNone(TorchTransformBaseLayer):
+    """Replace missing (``None``) positions in each input column with a default.
+
+    Missing values are detected from the runtime tensor dtype rather than a
+    passed-in flag: ``NaN`` marks missing values in floating-point tensors, and
+    the dtype's minimum value marks them in ``int32``/``int64`` tensors (the
+    convention used when ingesting nullable integer columns).
+
+    Args:
+        input_cols: Column names of the input tensors.
+        output_cols: Column names of the output tensors; must match the length of
+            ``input_cols``.
+        default_value: Value substituted for every detected missing position.
+        **kwargs: Additional base-layer options (e.g. ``name``).
+
+    Raises:
+        ValueError: If ``input_cols`` and ``output_cols`` differ in length.
+    """
+
+    def __init__(
+        self,
+        input_cols: list[str],
+        output_cols: list[str],
+        default_value: int | float,
+        **kwargs,
+    ) -> None:
+        """Initialize the TensorColFillNone layer.
+
+        Args:
+            input_cols: Column names of the input tensors.
+            output_cols: Column names of the output tensors; must match the
+                length of ``input_cols``.
+            default_value: Value substituted for every detected missing position.
+            **kwargs: Additional base-layer options (e.g. ``name``).
+
+        Raises:
+            ValueError: If ``input_cols`` and ``output_cols`` differ in length.
+        """
+        super().__init__(input_cols, output_cols, **kwargs)
+        if len(input_cols) != len(output_cols):
+            raise ValueError(
+                "Input columns and output columns must have the same length."
+            )
+        self.default_value = default_value
+        # Precompute integer minimums so ``torch.iinfo`` is not called inside the
+        # TorchScript-traced forward pass.
+        self.int32_min = torch.iinfo(torch.int32).min
+        self.int64_min = torch.iinfo(torch.int64).min
+
+    def forward(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """Fill missing positions in each input column.
+
+        Args:
+            inputs: Mapping from column name to tensor.
+
+        Returns:
+            A mapping from each output column to its filled tensor.
+        """
+        stacked_input = format_inputs(self.input_cols, inputs)
+        if stacked_input.dtype == torch.int32:
+            # The int32 minimum encodes a missing value.
+            condition = stacked_input == self.int32_min
+        elif stacked_input.dtype == torch.int64:
+            # Comparing ``x / 2 == int64_min / 2`` avoids embedding the literal
+            # ``int64`` minimum, which overflows TorchScript's signed-64-bit
+            # constant range.
+            condition = stacked_input / 2 == self.int64_min / 2
+        else:
+            # NaN encodes a missing value in floating-point tensors.
+            condition = torch.isnan(stacked_input)
+
+        stacked_output = torch.where(
+            condition,
+            torch.ones_like(stacked_input) * self.default_value,
+            stacked_input,
+        )
+        outputs = format_outputs(self.output_cols, stacked_output)
+        return outputs
+
+
+class CaseWhen(TorchTransformBaseLayer):
+    """Select values by condition, like a SQL ``CASE WHEN`` expression.
+
+    Input columns are read as ``(condition, value)`` pairs, so
+    ``len(input_cols)`` must be even. For each element, the value of the first
+    pair whose condition is ``True`` is returned; if no condition matches,
+    ``default_value`` is used. Later pairs take lower priority than earlier ones.
+
+    Args:
+        input_cols: Column names ordered as ``condition1, value1, condition2,
+            value2, ...``.
+        output_cols: Single-element list naming the result column.
+        default_value: Value used where no condition matches. A scalar
+            (``int``/``float``/``bool``) is broadcast to the value shape; a list
+            or tensor is used as-is.
+        **kwargs: Additional base-layer options (e.g. ``name``).
+
+    Raises:
+        ValueError: If ``input_cols`` does not contain an even number of columns.
+    """
+
+    def __init__(
+        self,
+        input_cols: list[str],
+        output_cols: list[str],
+        default_value: int | float | bool | list | torch.Tensor,
+        **kwargs,
+    ) -> None:
+        """Initialize the CaseWhen layer.
+
+        Args:
+            input_cols: Column names ordered as ``condition1, value1,
+                condition2, value2, ...``.
+            output_cols: Single-element list naming the result column.
+            default_value: Value used where no condition matches. A scalar is
+                broadcast to the value shape; a list or tensor is used as-is.
+            **kwargs: Additional base-layer options (e.g. ``name``).
+
+        Raises:
+            ValueError: If ``input_cols`` does not contain an even number of
+                columns.
+        """
+        if len(input_cols) % 2 != 0:
+            raise ValueError(
+                "CaseWhen layer must have an even number of input columns "
+                f"(condition-value pairs). Got {len(input_cols)} columns."
+            )
+        super().__init__(input_cols, output_cols, **kwargs)
+        self.default_value = default_value
+
+    def forward(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """Resolve each element to the first matching value, else the default.
+
+        Args:
+            inputs: Mapping from column name to tensor.
+
+        Returns:
+            A single-entry mapping from the output column to the resolved tensor.
+        """
+        if isinstance(self.default_value, (int, float, bool)):
+            result = torch.ones_like(inputs[self.input_cols[1]]) * self.default_value
+        else:
+            # For a non-scalar default, allocate on the input's device via
+            # ``new_empty`` and ``copy_`` the constant in. A literal
+            # ``.to(input.device)`` would bake the trace-time device in.
+            ref = inputs[self.input_cols[1]]
+            src = torch.as_tensor(self.default_value)
+            result = ref.new_empty(src.shape, dtype=src.dtype).copy_(src)
+
+        # Iterate pairs in reverse so earlier conditions overwrite later ones and
+        # thus win ties.
+        for i in range(len(self.input_cols) - 2, -1, -2):
+            condition = self.input_cols[i]
+            value = self.input_cols[i + 1]
+            result = torch.where(inputs[condition], inputs[value], result)
+
+        return {self.output_cols[0]: result}
+
+
+class Compare(TorchTransformBaseLayer):
+    """Compare input columns pairwise with a named comparison operator.
+
+    Input columns are read in ``(left, right)`` pairs (even indices are left
+    operands, odd indices right operands), so ``len(input_cols)`` must be even
+    and ``output_cols`` half its length. Each pair is compared element-wise and
+    the boolean result is written to the corresponding output column.
+
+    Args:
+        input_cols: Column names as ``(left, right)`` pairs.
+        output_cols: Column names of the boolean outputs.
+        compare_op: One of ``"equal"``, ``"greater"``, ``"less"``,
+            ``"greater_equal"``, ``"less_equal"``, or ``"not_equal"``.
+        **kwargs: Additional base-layer options (e.g. ``name``).
+
+    Raises:
+        ValueError: If ``input_cols`` is not even or ``output_cols`` is not half
+            its length, or if ``compare_op`` is not a supported operator.
+    """
+
+    def __init__(
+        self,
+        input_cols: list[str],
+        output_cols: list[str],
+        compare_op: str,
+        **kwargs,
+    ) -> None:
+        """Initialize the Compare layer.
+
+        Args:
+            input_cols: Column names as ``(left, right)`` pairs.
+            output_cols: Column names of the boolean outputs.
+            compare_op: One of ``"equal"``, ``"greater"``, ``"less"``,
+                ``"greater_equal"``, ``"less_equal"``, or ``"not_equal"``.
+            **kwargs: Additional base-layer options (e.g. ``name``).
+
+        Raises:
+            ValueError: If ``input_cols`` is not even or ``output_cols`` is not
+                half its length, or if ``compare_op`` is unsupported.
+        """
+        super().__init__(input_cols, output_cols, **kwargs)
+        if (len(input_cols) % 2 != 0) or (len(input_cols) / 2 != len(output_cols)):
+            raise ValueError(
+                "Input columns must be even and output columns must be half of "
+                "input columns."
+            )
+        if compare_op not in (
+            "equal",
+            "greater",
+            "less",
+            "greater_equal",
+            "less_equal",
+            "not_equal",
+        ):
+            raise ValueError(f"compare_op: {compare_op} is not supported")
+        self.compare_op = compare_op
+
+    def forward(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """Compare each ``(left, right)`` pair element-wise.
+
+        Args:
+            inputs: Mapping from column name to tensor.
+
+        Returns:
+            A mapping from each output column to its boolean result tensor.
+        """
+        evens, odds = self.input_cols[0::2], self.input_cols[1::2]
+        stacked_evens = format_inputs(evens, inputs)
+        stacked_odds = format_inputs(odds, inputs)
+        if self.compare_op == "equal":
+            stacked_output = torch.eq(stacked_evens, stacked_odds)
+        elif self.compare_op == "greater":
+            stacked_output = torch.gt(stacked_evens, stacked_odds)
+        elif self.compare_op == "less":
+            stacked_output = torch.lt(stacked_evens, stacked_odds)
+        elif self.compare_op == "greater_equal":
+            stacked_output = torch.ge(stacked_evens, stacked_odds)
+        elif self.compare_op == "less_equal":
+            stacked_output = torch.le(stacked_evens, stacked_odds)
+        elif self.compare_op == "not_equal":
+            stacked_output = torch.ne(stacked_evens, stacked_odds)
+        else:  # pragma: no cover
+            # Unreachable: ``compare_op`` is validated in ``__init__``. Kept so
+            # TorchScript sees ``stacked_output`` defined on every path.
+            stacked_output = torch.eq(stacked_evens, stacked_odds)
+        outputs = format_outputs(self.output_cols, stacked_output)
+        return outputs
+
+
+class Tile(TorchTransformBaseLayer):
+    """Repeat each input tensor along an axis a fixed or inferred number of times.
+
+    The repeat count is either given explicitly via ``count`` or inferred from a
+    target tensor's size along ``axis``. When inferred, the target tensor is the
+    last input column and the source tensors are the remaining columns.
+
+    As a convenience, when ``axis == 1`` and every source tensor is 1D, sources
+    are unsqueezed to 2D first so tiling produces a ``(batch, count)`` result
+    rather than a flat ``(batch * count,)`` tensor.
+
+    Args:
+        input_cols: Column names of the source tensors. When a target tensor is
+            used to infer the count, it is the last column and the sources are
+            the columns before it.
+        output_cols: Column names of the tiled outputs.
+        axis: Axis along which to tile (default ``0``). Negative values index
+            from the end.
+        count: Explicit number of repetitions. Takes precedence over
+            ``target_tensor_provided`` when set.
+        target_tensor_provided: When ``True`` and ``count`` is ``None``, infer
+            the count from the last input column's size along ``axis``.
+        **kwargs: Additional base-layer options (e.g. ``name``).
+    """
+
+    def __init__(
+        self,
+        input_cols: list[str],
+        output_cols: list[str],
+        axis: int = 0,
+        count: int | None = None,
+        target_tensor_provided: bool = False,
+        **kwargs,
+    ) -> None:
+        """Initialize the Tile layer.
+
+        Args:
+            input_cols: Column names of the source tensors (and, when inferring
+                the count, a trailing target column).
+            output_cols: Column names of the tiled outputs.
+            axis: Axis along which to tile (default ``0``).
+            count: Explicit number of repetitions; takes precedence over
+                ``target_tensor_provided`` when set.
+            target_tensor_provided: When ``True`` and ``count`` is ``None``,
+                infer the count from the last input column's size along ``axis``.
+            **kwargs: Additional base-layer options (e.g. ``name``).
+        """
+        super().__init__(input_cols, output_cols, **kwargs)
+        self.axis = axis
+        self.count = count
+        self.target_tensor_provided = target_tensor_provided
+
+    def forward(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """Tile each source column along ``axis``.
+
+        Args:
+            inputs: Mapping from column name to tensor.
+
+        Returns:
+            A mapping from each output column to its tiled tensor.
+
+        Raises:
+            ValueError: If neither ``count`` is set nor
+                ``target_tensor_provided`` is ``True``.
+        """
+        if self.count is not None:
+            source_cols = self.input_cols
+            target_tensor: torch.Tensor | None = None
+        elif self.target_tensor_provided:
+            source_cols = self.input_cols[:-1]
+            target_tensor = inputs[self.input_cols[-1]]
+        else:
+            raise ValueError(
+                "Either count must be specified or target_tensor_provided must be True."
+            )
+
+        # For axis=1 with all-1D sources, unsqueeze to 2D so the result is
+        # ``(batch, count)`` rather than a flattened ``(batch * count,)``.
+        sources = [inputs[col] for col in source_cols]
+        if self.axis == 1 and all(s.dim() == 1 for s in sources):
+            inputs = {col: inputs[col].unsqueeze(-1) for col in source_cols}
+            if target_tensor is not None:
+                inputs[self.input_cols[-1]] = target_tensor
+
+        stacked_source = format_inputs(source_cols, inputs)
+
+        # ``format_inputs`` prepends a stacking dimension, so a non-negative
+        # ``axis`` shifts by one; a negative ``axis`` stays relative to the end.
+        stack_axis = self.axis + 1 if self.axis >= 0 else self.axis
+
+        multiples = [1] * len(stacked_source.shape)
+        if self.count is not None:
+            multiples[stack_axis] = self.count
+        elif target_tensor is not None:
+            multiples[stack_axis] = target_tensor.shape[self.axis]
+        else:  # pragma: no cover
+            # Unreachable given the guard above; keeps TorchScript's control flow
+            # total.
+            multiples[stack_axis] = 1
+
+        tiled_stacked = torch.tile(stacked_source, multiples)
+        return format_outputs(self.output_cols, tiled_stacked)
+
+
+class PadOrCrop1D(TorchTransformBaseLayer):
+    """Pad or crop each 1D input column to a fixed length.
+
+    Each input column is normalized to exactly ``max_length`` along its last
+    dimension: shorter sequences are padded with ``pad_value`` and longer ones
+    are cropped. ``align`` controls which end is kept and padded.
+
+    Before padding, two kinds of sentinel are converted to ``pad_value`` so that
+    padding introduced upstream (ragged-array collation) is not mistaken for real
+    data:
+
+    - When ``ragged_fill_value`` is set, positions equal to it (or ``NaN`` when
+      it is ``float('nan')``) are replaced with ``pad_value``.
+    - Regardless of ``ragged_fill_value``, remaining ``NaN`` positions (float
+      dtypes) and ``INT32_SENTINEL`` positions (integer dtypes) are replaced with
+      ``pad_value``.
+
+    Args:
+        input_cols: Column names of the input tensors.
+        output_cols: Column names of the output tensors; must match the length of
+            ``input_cols``.
+        max_length: The fixed target length; must be positive.
+        dtype: Optional output dtype. When ``None``, the input dtype is
+            preserved.
+        pad_value: The value used for padding (default ``0``).
+        ragged_fill_value: Optional upstream padding sentinel to convert to
+            ``pad_value`` before pad/crop. Supports ``float('nan')`` (detected
+            via ``isnan``) and numeric values (detected via ``==``).
+        align: ``"left"`` (default) pads on the right and keeps the first
+            ``max_length`` elements; ``"right"`` pads on the left and keeps the
+            last ``max_length`` elements. Retained elements keep their original
+            order.
+        **kwargs: Additional base-layer options (e.g. ``name``).
+
+    Raises:
+        ValueError: If ``input_cols`` and ``output_cols`` differ in length, if
+            ``align`` is not ``"left"`` or ``"right"``, or if ``max_length`` is
+            not positive.
+    """
+
+    def __init__(
+        self,
+        input_cols: list[str],
+        output_cols: list[str],
+        max_length: int,
+        dtype: torch.dtype | str | None = None,
+        pad_value: int | float = 0,
+        ragged_fill_value: int | float | None = None,
+        align: str = "left",
+        **kwargs,
+    ) -> None:
+        """Initialize the PadOrCrop1D layer.
+
+        Args:
+            input_cols: Column names of the input tensors.
+            output_cols: Column names of the output tensors; must match the
+                length of ``input_cols``.
+            max_length: The fixed target length; must be positive.
+            dtype: Optional output dtype; preserves input dtype when ``None``.
+            pad_value: The value used for padding (default ``0``).
+            ragged_fill_value: Optional upstream padding sentinel to convert to
+                ``pad_value`` before pad/crop.
+            align: ``"left"`` pads/crops on the right; ``"right"`` pads/crops on
+                the left.
+            **kwargs: Additional base-layer options (e.g. ``name``).
+
+        Raises:
+            ValueError: If ``input_cols`` and ``output_cols`` differ in length,
+                if ``align`` is invalid, or if ``max_length`` is not positive.
+        """
+        super().__init__(input_cols, output_cols, **kwargs)
+        if len(input_cols) != len(output_cols):
+            raise ValueError(
+                "Input columns and output columns must have the same length."
+            )
+        if align not in ("left", "right"):
+            raise ValueError(f"align must be 'left' or 'right', got {align!r}")
+        if max_length <= 0:
+            raise ValueError(f"max_length must be a positive integer, got {max_length}")
+        self.max_length = max_length
+        self.dtype = initialize_dtype(dtype, None)
+        # Store as float for TorchScript compatibility.
+        self.pad_value = float(pad_value)
+        self.ragged_fill_value = (
+            float(ragged_fill_value) if ragged_fill_value is not None else None
+        )
+        self._ragged_sentinel_is_nan = ragged_fill_value is not None and math.isnan(
+            float(ragged_fill_value)
+        )
+        self._int_sentinel = INT32_SENTINEL
+        self.align = align
+
+    def forward(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """Normalize each input column to ``max_length``.
+
+        Args:
+            inputs: Mapping from column name to tensor.
+
+        Returns:
+            A mapping from each output column to its padded/cropped tensor.
+        """
+        stacked_input = format_inputs(self.input_cols, inputs)
+
+        output_dtype = self.dtype if self.dtype is not None else stacked_input.dtype
+
+        # Empty last dimension: return a full ``pad_value`` tensor of the target
+        # length while preserving the batch dimensions.
+        if stacked_input.size(-1) == 0:
+            shape = list(stacked_input.shape)
+            shape[-1] = self.max_length
+            return format_outputs(
+                self.output_cols,
+                stacked_input.new_full(shape, self.pad_value, dtype=output_dtype),
+            )
+
+        # Convert the upstream ragged-padding sentinel to ``pad_value``.
+        if self.ragged_fill_value is not None:
+            replacement = stacked_input.new_full((), self.pad_value)
+            if self._ragged_sentinel_is_nan:
+                stacked_input = torch.where(
+                    torch.isnan(stacked_input), replacement, stacked_input
+                )
+            elif stacked_input.is_floating_point():
+                incoming = stacked_input.new_full((), self.ragged_fill_value)
+                mask = (stacked_input == incoming) | torch.isnan(stacked_input)
+                stacked_input = torch.where(mask, replacement, stacked_input)
+            else:
+                incoming = stacked_input.new_full((), self.ragged_fill_value)
+                stacked_input = torch.where(
+                    stacked_input == incoming, replacement, stacked_input
+                )
+
+        # Convert any remaining collation sentinels (NaN for floats,
+        # INT32_SENTINEL for ints) to ``pad_value``.
+        replacement = stacked_input.new_full((), self.pad_value)
+        if stacked_input.is_floating_point():
+            stacked_input = torch.where(
+                torch.isnan(stacked_input), replacement, stacked_input
+            )
+        else:
+            sentinel = stacked_input.new_full((), self._int_sentinel)
+            stacked_input = torch.where(
+                stacked_input == sentinel, replacement, stacked_input
+            )
+
+        # Pad to at least ``max_length``, then crop to ``max_length``.
+        # ``align='left'`` pads right and keeps the first N; ``align='right'``
+        # pads left and keeps the last N.
+        padding = max(self.max_length - stacked_input.size(-1), 0)
+        if self.align == "right":
+            padded_tensor = torch.nn.functional.pad(
+                stacked_input, (padding, 0), value=self.pad_value
+            )
+            output_tensor = padded_tensor[..., -self.max_length :].to(output_dtype)
+        else:
+            padded_tensor = torch.nn.functional.pad(
+                stacked_input, (0, padding), value=self.pad_value
+            )
+            output_tensor = padded_tensor[..., : self.max_length].to(output_dtype)
+
+        return format_outputs(self.output_cols, output_tensor)
+
+
+class Scale(TorchTransformBaseLayer):
+    """Multiply each input column by a scalar factor.
+
+    Args:
+        input_cols: Column names of the input tensors.
+        output_cols: Column names of the output tensors; must match the length of
+            ``input_cols``.
+        factor: The scalar multiplier.
+        **kwargs: Additional base-layer options (e.g. ``name``).
+
+    Raises:
+        ValueError: If ``input_cols`` and ``output_cols`` differ in length.
+    """
+
+    def __init__(
+        self,
+        input_cols: list[str],
+        output_cols: list[str],
+        factor: float,
+        **kwargs,
+    ) -> None:
+        """Initialize the Scale layer.
+
+        Args:
+            input_cols: Column names of the input tensors.
+            output_cols: Column names of the output tensors; must match the
+                length of ``input_cols``.
+            factor: The scalar multiplier.
+            **kwargs: Additional base-layer options (e.g. ``name``).
+
+        Raises:
+            ValueError: If ``input_cols`` and ``output_cols`` differ in length.
+        """
+        super().__init__(input_cols, output_cols, **kwargs)
+        if len(input_cols) != len(output_cols):
+            raise ValueError(
+                "Input columns and output columns must have the same length."
+            )
+        self.factor = factor
+
+    def forward(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """Scale each input column by ``factor``.
+
+        Args:
+            inputs: Mapping from column name to tensor.
+
+        Returns:
+            A mapping from each output column to its scaled tensor.
+        """
+        stacked_inputs = format_inputs(self.input_cols, inputs)
+        output_tensor = stacked_inputs * self.factor
+        return format_outputs(self.output_cols, output_tensor)
+
+
+class Clip(TorchTransformBaseLayer):
+    """Clamp each input column to a range, optionally exempting one value.
+
+    Values are clamped to ``[min_value, max_value]``; a bound left as ``None`` is
+    not enforced on that side. When ``ignore_value`` is set, positions equal to
+    it are passed through unchanged even if they fall outside the range (useful
+    for preserving a padding value such as ``-1.0``).
+
+    Args:
+        input_cols: Column names of the input tensors.
+        output_cols: Column names of the output tensors; must match the length of
+            ``input_cols``.
+        min_value: Lower bound, or ``None`` for no lower bound.
+        max_value: Upper bound, or ``None`` for no upper bound.
+        ignore_value: Optional value that is preserved unchanged rather than
+            clamped.
+        **kwargs: Additional base-layer options (e.g. ``name``).
+
+    Raises:
+        ValueError: If ``input_cols`` and ``output_cols`` differ in length.
+    """
+
+    def __init__(
+        self,
+        input_cols: list[str],
+        output_cols: list[str],
+        min_value: float | None = None,
+        max_value: float | None = None,
+        ignore_value: float | None = None,
+        **kwargs,
+    ) -> None:
+        """Initialize the Clip layer.
+
+        Args:
+            input_cols: Column names of the input tensors.
+            output_cols: Column names of the output tensors; must match the
+                length of ``input_cols``.
+            min_value: Lower bound, or ``None`` for no lower bound.
+            max_value: Upper bound, or ``None`` for no upper bound.
+            ignore_value: Optional value preserved unchanged rather than clamped.
+            **kwargs: Additional base-layer options (e.g. ``name``).
+
+        Raises:
+            ValueError: If ``input_cols`` and ``output_cols`` differ in length.
+        """
+        super().__init__(input_cols, output_cols, **kwargs)
+        if len(input_cols) != len(output_cols):
+            raise ValueError(
+                "Input columns and output columns must have the same length."
+            )
+        self.min_value = min_value
+        self.max_value = max_value
+        self.ignore_value = ignore_value
+
+    def forward(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """Clamp each input column, preserving ``ignore_value`` positions.
+
+        Args:
+            inputs: Mapping from column name to tensor.
+
+        Returns:
+            A mapping from each output column to its clamped tensor.
+        """
+        stacked_inputs = format_inputs(self.input_cols, inputs)
+
+        clipped_tensor = torch.clamp(
+            stacked_inputs, min=self.min_value, max=self.max_value
+        )
+
+        # Restore positions equal to ``ignore_value`` that clamping may have
+        # moved (e.g. a padding value outside the range).
+        if self.ignore_value is not None:
+            mask = torch.isclose(
+                stacked_inputs, stacked_inputs.new_full((), self.ignore_value)
+            )
+            clipped_tensor = torch.where(mask, stacked_inputs, clipped_tensor)
+
+        return format_outputs(self.output_cols, clipped_tensor)

--- a/python/michelangelo/lib/native_transform/torch/tests/test_base_layers.py
+++ b/python/michelangelo/lib/native_transform/torch/tests/test_base_layers.py
@@ -1195,27 +1195,6 @@ class TestPadOrCrop1D:
         )["o"]
         torch.testing.assert_close(out, torch.tensor([20, 30], dtype=torch.int32))
 
-    def test_right_align_ragged_fill_value_stripped_before_crop(self) -> None:
-        """A ``ragged_fill_value`` is stripped before an align='right' crop."""
-        ragged_sentinel = -2_000_000_000
-        layer = PadOrCrop1D(
-            input_cols=["f"],
-            output_cols=["o"],
-            max_length=3,
-            dtype=torch.int32,
-            pad_value=-1,
-            ragged_fill_value=ragged_sentinel,
-            align="right",
-        )
-        out = layer(
-            {
-                "f": torch.tensor(
-                    [10, 20, 30, ragged_sentinel, ragged_sentinel], dtype=torch.int32
-                )
-            }
-        )["o"]
-        torch.testing.assert_close(out, torch.tensor([10, 20, 30], dtype=torch.int32))
-
     def test_right_align_pads_when_content_shorter_than_max_length(self) -> None:
         """Sentinel-trimmed content shorter than max_length is left-padded."""
         layer = PadOrCrop1D(
@@ -1356,8 +1335,8 @@ class TestPadOrCrop1D:
         assert out.dtype == torch.int64
         torch.testing.assert_close(out, torch.tensor([-1, -1, -1], dtype=torch.int64))
 
-    def test_default_nan_collation_sentinel_uses_pad_value(self) -> None:
-        """Without ragged_fill_value, NaN positions still become pad_value."""
+    def test_nan_collation_sentinel_uses_pad_value(self) -> None:
+        """NaN collation sentinels become pad_value."""
         layer = PadOrCrop1D(
             input_cols=["f"], output_cols=["o"], max_length=4, pad_value=4.61
         )
@@ -1365,8 +1344,8 @@ class TestPadOrCrop1D:
         assert out[0, 1].item() == pytest.approx(4.61, abs=1e-4)
         assert out[0, 3].item() == pytest.approx(4.61, abs=1e-4)
 
-    def test_default_int_sentinel_uses_pad_value(self) -> None:
-        """Without ragged_fill_value, INT32_SENTINEL positions become pad_value."""
+    def test_int_sentinel_uses_pad_value(self) -> None:
+        """INT32_SENTINEL collation positions become pad_value."""
         layer = PadOrCrop1D(
             input_cols=["f"], output_cols=["o"], max_length=4, pad_value=-1
         )
@@ -1377,67 +1356,14 @@ class TestPadOrCrop1D:
             out, torch.tensor([[10, -1, 30, -1]], dtype=torch.int32)
         )
 
-    def test_ragged_fill_value_nan_replaced(self) -> None:
-        """A NaN ragged_fill_value is converted to pad_value before padding."""
-        layer = PadOrCrop1D(
-            input_cols=["f"],
-            output_cols=["o"],
-            max_length=5,
-            dtype=torch.float32,
-            pad_value=0.0,
-            ragged_fill_value=float("nan"),
-        )
-        out = layer({"f": torch.tensor([1.0, 2.0, float("nan")])})["o"]
-        torch.testing.assert_close(out, torch.tensor([1.0, 2.0, 0.0, 0.0, 0.0]))
-
-    def test_ragged_fill_value_int_replaced(self) -> None:
-        """A numeric ragged_fill_value is converted to pad_value before padding."""
-        layer = PadOrCrop1D(
-            input_cols=["f"],
-            output_cols=["o"],
-            max_length=5,
-            dtype=torch.int32,
-            pad_value=-1,
-            ragged_fill_value=INT32_SENTINEL,
-        )
-        out = layer({"f": torch.tensor([10, 20, INT32_SENTINEL], dtype=torch.int32)})[
-            "o"
-        ]
-        torch.testing.assert_close(
-            out, torch.tensor([10, 20, -1, -1, -1], dtype=torch.int32)
-        )
-
-    def test_ragged_fill_value_legacy_numeric_sentinel_2d(self) -> None:
-        """A legacy -2B ragged sentinel is replaced across a batched 2D input."""
-        ragged_sentinel = -2_000_000_000
+    def test_non_standard_sentinel_is_left_as_data(self) -> None:
+        """A non-standard numeric value (not NaN/INT32_SENTINEL) is left as data."""
         layer = PadOrCrop1D(
             input_cols=["f"],
             output_cols=["o"],
             max_length=4,
             dtype=torch.int32,
             pad_value=-1,
-            ragged_fill_value=ragged_sentinel,
-        )
-        inputs = {
-            "f": torch.tensor(
-                [[10, 20, ragged_sentinel, ragged_sentinel], [30, 40, 50, 60]],
-                dtype=torch.int32,
-            )
-        }
-        torch.testing.assert_close(
-            layer(inputs)["o"],
-            torch.tensor([[10, 20, -1, -1], [30, 40, 50, 60]], dtype=torch.int32),
-        )
-
-    def test_ragged_fill_value_none_is_noop_for_custom_sentinel(self) -> None:
-        """With ragged_fill_value=None, a non-standard sentinel is left as data."""
-        layer = PadOrCrop1D(
-            input_cols=["f"],
-            output_cols=["o"],
-            max_length=4,
-            dtype=torch.int32,
-            pad_value=-1,
-            ragged_fill_value=None,
         )
         out = layer({"f": torch.tensor([10, -2_000_000_000, 30], dtype=torch.int32)})[
             "o"
@@ -1445,54 +1371,6 @@ class TestPadOrCrop1D:
         torch.testing.assert_close(
             out, torch.tensor([10, -2_000_000_000, 30, -1], dtype=torch.int32)
         )
-
-    def test_real_negative_one_preserved_with_ragged_fill_value(self) -> None:
-        """A real -1 survives when the ragged sentinel is a distinct value."""
-        ragged_sentinel = -2_000_000_000
-        layer = PadOrCrop1D(
-            input_cols=["f"],
-            output_cols=["o"],
-            max_length=4,
-            dtype=torch.int32,
-            pad_value=-1,
-            ragged_fill_value=ragged_sentinel,
-        )
-        out = layer({"f": torch.tensor([10, -1, ragged_sentinel], dtype=torch.int32)})[
-            "o"
-        ]
-        torch.testing.assert_close(
-            out, torch.tensor([10, -1, -1, -1], dtype=torch.int32)
-        )
-
-    def test_ragged_fill_value_numeric_on_float_input(self) -> None:
-        """A numeric (non-NaN) ragged sentinel is replaced in a float tensor."""
-        layer = PadOrCrop1D(
-            input_cols=["f"],
-            output_cols=["o"],
-            max_length=5,
-            dtype=torch.float32,
-            pad_value=0.0,
-            ragged_fill_value=-999.0,
-        )
-        # Both the explicit -999.0 sentinel and a stray NaN collapse to pad_value.
-        out = layer({"f": torch.tensor([1.0, -999.0, float("nan")])})["o"]
-        torch.testing.assert_close(out, torch.tensor([1.0, 0.0, 0.0, 0.0, 0.0]))
-
-    def test_ragged_fill_value_replaced_before_crop(self) -> None:
-        """Ragged sentinels are replaced even when the input is then cropped."""
-        ragged_sentinel = -2_000_000_000
-        layer = PadOrCrop1D(
-            input_cols=["f"],
-            output_cols=["o"],
-            max_length=3,
-            dtype=torch.int32,
-            pad_value=-1,
-            ragged_fill_value=ragged_sentinel,
-        )
-        out = layer(
-            {"f": torch.tensor([10, ragged_sentinel, 30, 40, 50], dtype=torch.int32)}
-        )["o"]
-        torch.testing.assert_close(out, torch.tensor([10, -1, 30], dtype=torch.int32))
 
     def test_over_padding_short_input(self) -> None:
         """A single element pads out to the full max_length."""
@@ -1730,7 +1608,6 @@ def _b2_layer_cases() -> list[tuple[str, TorchTransformBaseLayer, dict]]:
                 output_cols=["o"],
                 max_length=5,
                 pad_value=0.0,
-                ragged_fill_value=float("nan"),
             ),
             {"f": torch.tensor([1.0, float("nan"), 3.0])},
         ),
@@ -1741,7 +1618,6 @@ def _b2_layer_cases() -> list[tuple[str, TorchTransformBaseLayer, dict]]:
                 output_cols=["o"],
                 max_length=5,
                 pad_value=-1,
-                ragged_fill_value=INT32_SENTINEL,
             ),
             {"f": torch.tensor([10, INT32_SENTINEL, 30], dtype=torch.int32)},
         ),

--- a/python/michelangelo/lib/native_transform/torch/tests/test_base_layers.py
+++ b/python/michelangelo/lib/native_transform/torch/tests/test_base_layers.py
@@ -14,17 +14,25 @@ import pytest
 # unavailable in a lightweight environment.
 torch = pytest.importorskip("torch")
 
+from michelangelo.lib.constants.sentinel import INT32_SENTINEL  # noqa: E402
 from michelangelo.lib.native_transform.torch.base_layers import (  # noqa: E402
+    CaseWhen,
     Cast,
     Ceil,
+    Clip,
+    Compare,
     Concatenate,
     Constant,
     Divide,
     Floor,
     IdentityTransform,
     LogTransform,
+    PadOrCrop1D,
+    Scale,
     Stack,
     Subtract,
+    TensorColFillNone,
+    Tile,
     TorchTransformBaseLayer,
 )
 
@@ -685,6 +693,958 @@ class TestTorchScriptRoundTrip:
             torch.testing.assert_close(scripted_out[key], eager[key])
 
         model_path = tmp_path / "scripted_layer.pt"
+        scripted.save(str(model_path))
+        loaded = torch.jit.load(str(model_path))
+        loaded_out = loaded(inputs)
+        for key in eager:
+            torch.testing.assert_close(loaded_out[key], eager[key])
+
+
+class TestTensorColFillNone:
+    """Filling missing positions detected from the runtime dtype."""
+
+    def test_mismatched_columns_raises(self) -> None:
+        """Unequal input/output column counts raise ``ValueError``."""
+        with pytest.raises(ValueError, match="same length"):
+            TensorColFillNone(
+                input_cols=["a", "b"], output_cols=["out"], default_value=0.0
+            )
+
+    def test_fill_nan_float(self) -> None:
+        """NaN positions in a float tensor are filled with the default."""
+        layer = TensorColFillNone(
+            input_cols=["feature"], output_cols=["filled"], default_value=0.0
+        )
+        inputs = {"feature": torch.tensor([1.0, float("nan"), 3.0, float("nan")])}
+        torch.testing.assert_close(
+            layer(inputs)["filled"], torch.tensor([1.0, 0.0, 3.0, 0.0])
+        )
+
+    def test_no_missing_values_passthrough(self) -> None:
+        """A tensor with no missing values is unchanged."""
+        layer = TensorColFillNone(
+            input_cols=["feature"], output_cols=["filled"], default_value=0.0
+        )
+        inputs = {"feature": torch.tensor([1.0, 2.0, 3.0])}
+        torch.testing.assert_close(
+            layer(inputs)["filled"], torch.tensor([1.0, 2.0, 3.0])
+        )
+
+    def test_custom_fill_value(self) -> None:
+        """A non-default fill value is used for NaN positions."""
+        layer = TensorColFillNone(
+            input_cols=["feature"], output_cols=["filled"], default_value=-1.0
+        )
+        inputs = {"feature": torch.tensor([1.0, float("nan"), 3.0])}
+        torch.testing.assert_close(
+            layer(inputs)["filled"], torch.tensor([1.0, -1.0, 3.0])
+        )
+
+    def test_detect_int32_min_as_missing(self) -> None:
+        """The int32 minimum is detected as missing and filled."""
+        layer = TensorColFillNone(
+            input_cols=["feature"], output_cols=["filled"], default_value=999
+        )
+        min_val = torch.iinfo(torch.int32).min
+        inputs = {"feature": torch.tensor([1, min_val, 3, min_val], dtype=torch.int32)}
+        outputs = layer(inputs)
+        assert outputs["filled"].dtype == torch.int32
+        torch.testing.assert_close(
+            outputs["filled"], torch.tensor([1, 999, 3, 999], dtype=torch.int32)
+        )
+
+    def test_detect_int64_min_as_missing(self) -> None:
+        """The int64 minimum is detected as missing and filled."""
+        layer = TensorColFillNone(
+            input_cols=["feature"], output_cols=["filled"], default_value=888
+        )
+        min_val = torch.iinfo(torch.int64).min
+        inputs = {"feature": torch.tensor([100, min_val, 200], dtype=torch.int64)}
+        outputs = layer(inputs)
+        assert outputs["filled"].dtype == torch.int64
+        torch.testing.assert_close(
+            outputs["filled"], torch.tensor([100, 888, 200], dtype=torch.int64)
+        )
+
+    def test_int32_all_missing(self) -> None:
+        """An all-missing int32 tensor is fully replaced."""
+        layer = TensorColFillNone(
+            input_cols=["feature"], output_cols=["filled"], default_value=0
+        )
+        min_val = torch.iinfo(torch.int32).min
+        inputs = {"feature": torch.tensor([min_val, min_val], dtype=torch.int32)}
+        torch.testing.assert_close(
+            layer(inputs)["filled"], torch.tensor([0, 0], dtype=torch.int32)
+        )
+
+    def test_int64_no_false_positive_on_real_values(self) -> None:
+        """Genuine int64 values (not the minimum) are left untouched."""
+        layer = TensorColFillNone(
+            input_cols=["feature"], output_cols=["filled"], default_value=0
+        )
+        inputs = {"feature": torch.tensor([10, 20, 30], dtype=torch.int64)}
+        torch.testing.assert_close(layer(inputs)["filled"], inputs["feature"])
+
+    def test_multiple_columns(self) -> None:
+        """Each column is filled independently."""
+        layer = TensorColFillNone(
+            input_cols=["f1", "f2"], output_cols=["o1", "o2"], default_value=0.0
+        )
+        inputs = {
+            "f1": torch.tensor([1.0, float("nan")]),
+            "f2": torch.tensor([float("nan"), 2.0]),
+        }
+        outputs = layer(inputs)
+        torch.testing.assert_close(outputs["o1"], torch.tensor([1.0, 0.0]))
+        torch.testing.assert_close(outputs["o2"], torch.tensor([0.0, 2.0]))
+
+
+class TestCaseWhen:
+    """SQL-like conditional selection over (condition, value) pairs."""
+
+    def test_odd_input_columns_raises(self) -> None:
+        """An odd number of input columns raises ``ValueError``."""
+        with pytest.raises(ValueError, match="even number"):
+            CaseWhen(
+                input_cols=["cond1", "val1", "cond2"],
+                output_cols=["result"],
+                default_value=0,
+            )
+
+    def test_first_matching_condition_wins(self) -> None:
+        """Earlier condition-value pairs take priority over later ones."""
+        layer = CaseWhen(
+            input_cols=["cond1", "val1", "cond2", "val2"],
+            output_cols=["result"],
+            default_value=-1,
+        )
+        inputs = {
+            "cond1": torch.tensor([True, False, True, False]),
+            "val1": torch.tensor([10, 0, 30, 0]),
+            "cond2": torch.tensor([True, True, False, False]),
+            "val2": torch.tensor([100, 200, 0, 0]),
+        }
+        torch.testing.assert_close(
+            layer(inputs)["result"], torch.tensor([10, 200, 30, -1])
+        )
+
+    def test_default_used_when_no_condition_matches(self) -> None:
+        """The scalar default fills positions where no condition is true."""
+        layer = CaseWhen(
+            input_cols=["cond1", "val1", "cond2", "val2"],
+            output_cols=["result"],
+            default_value=99,
+        )
+        inputs = {
+            "cond1": torch.tensor([False, False, False]),
+            "val1": torch.tensor([1, 2, 3]),
+            "cond2": torch.tensor([False, False, False]),
+            "val2": torch.tensor([10, 20, 30]),
+        }
+        torch.testing.assert_close(layer(inputs)["result"], torch.tensor([99, 99, 99]))
+
+    def test_three_condition_pairs(self) -> None:
+        """Three pairs resolve in priority order, falling back to the default."""
+        layer = CaseWhen(
+            input_cols=["c1", "v1", "c2", "v2", "c3", "v3"],
+            output_cols=["result"],
+            default_value=0,
+        )
+        inputs = {
+            "c1": torch.tensor([True, False, False, False]),
+            "v1": torch.tensor([10, 10, 10, 10]),
+            "c2": torch.tensor([False, True, False, False]),
+            "v2": torch.tensor([20, 20, 20, 20]),
+            "c3": torch.tensor([False, False, True, False]),
+            "v3": torch.tensor([30, 30, 30, 30]),
+        }
+        torch.testing.assert_close(
+            layer(inputs)["result"], torch.tensor([10, 20, 30, 0])
+        )
+
+    def test_scalar_tensor_default(self) -> None:
+        """A 0-dim tensor default broadcasts across the value shape."""
+        layer = CaseWhen(
+            input_cols=["cond1", "val1"],
+            output_cols=["result"],
+            default_value=torch.tensor(-1),
+        )
+        inputs = {
+            "cond1": torch.tensor([True, False, True]),
+            "val1": torch.tensor([100, 200, 300]),
+        }
+        torch.testing.assert_close(
+            layer(inputs)["result"], torch.tensor([100, -1, 300])
+        )
+
+    def test_list_default(self) -> None:
+        """A list default is materialized element-wise."""
+        layer = CaseWhen(
+            input_cols=["cond1", "val1"],
+            output_cols=["result"],
+            default_value=[99, 99],
+        )
+        inputs = {
+            "cond1": torch.tensor([True, False]),
+            "val1": torch.tensor([10, 20]),
+        }
+        torch.testing.assert_close(layer(inputs)["result"], torch.tensor([10, 99]))
+
+    def test_all_conditions_true_uses_first(self) -> None:
+        """When every condition is true, the first pair's values are chosen."""
+        layer = CaseWhen(
+            input_cols=["cond1", "val1", "cond2", "val2"],
+            output_cols=["result"],
+            default_value=0,
+        )
+        inputs = {
+            "cond1": torch.tensor([True, True, True]),
+            "val1": torch.tensor([10, 20, 30]),
+            "cond2": torch.tensor([True, True, True]),
+            "val2": torch.tensor([100, 200, 300]),
+        }
+        torch.testing.assert_close(layer(inputs)["result"], torch.tensor([10, 20, 30]))
+
+
+class TestCompare:
+    """Pairwise element-wise comparisons."""
+
+    def test_odd_input_columns_raises(self) -> None:
+        """An odd number of input columns raises ``ValueError``."""
+        with pytest.raises(ValueError, match="even"):
+            Compare(input_cols=["l", "r", "x"], output_cols=["o"], compare_op="equal")
+
+    def test_output_not_half_raises(self) -> None:
+        """Output count not equal to half the input count raises ``ValueError``."""
+        with pytest.raises(ValueError, match="half"):
+            Compare(input_cols=["l", "r"], output_cols=["o1", "o2"], compare_op="equal")
+
+    def test_invalid_op_raises(self) -> None:
+        """An unsupported operator raises ``ValueError``."""
+        with pytest.raises(ValueError, match="not supported"):
+            Compare(input_cols=["l", "r"], output_cols=["o"], compare_op="between")
+
+    @pytest.mark.parametrize(
+        ("op", "expected"),
+        [
+            ("equal", [True, False, True]),
+            ("not_equal", [False, True, False]),
+        ],
+    )
+    def test_equality_ops(self, op: str, expected: list[bool]) -> None:
+        """``equal`` and ``not_equal`` produce boolean masks."""
+        layer = Compare(input_cols=["left", "right"], output_cols=["c"], compare_op=op)
+        inputs = {"left": torch.tensor([1, 2, 3]), "right": torch.tensor([1, 3, 3])}
+        outputs = layer(inputs)
+        assert outputs["c"].dtype == torch.bool
+        torch.testing.assert_close(outputs["c"], torch.tensor(expected))
+
+    @pytest.mark.parametrize(
+        ("op", "expected"),
+        [
+            ("greater", [False, False, True]),
+            ("less", [True, False, False]),
+            ("greater_equal", [False, True, True]),
+            ("less_equal", [True, True, False]),
+        ],
+    )
+    def test_ordering_ops_broadcast_scalar(self, op: str, expected: list[bool]) -> None:
+        """Ordering operators broadcast a scalar right operand."""
+        layer = Compare(input_cols=["left", "right"], output_cols=["c"], compare_op=op)
+        inputs = {"left": torch.tensor([1, 2, 3]), "right": torch.tensor(2)}
+        torch.testing.assert_close(layer(inputs)["c"], torch.tensor(expected))
+
+    def test_multiple_pairs(self) -> None:
+        """Multiple pairs compare independently."""
+        layer = Compare(
+            input_cols=["l1", "r1", "l2", "r2"],
+            output_cols=["o1", "o2"],
+            compare_op="equal",
+        )
+        inputs = {
+            "l1": torch.tensor([1, 2]),
+            "r1": torch.tensor([1, 3]),
+            "l2": torch.tensor([4, 5]),
+            "r2": torch.tensor([4, 5]),
+        }
+        outputs = layer(inputs)
+        torch.testing.assert_close(outputs["o1"], torch.tensor([True, False]))
+        torch.testing.assert_close(outputs["o2"], torch.tensor([True, True]))
+
+
+class TestTile:
+    """Repeating tensors along an axis by count or inferred from a target."""
+
+    def test_default_axis_is_zero(self) -> None:
+        """The default tiling axis is ``0``."""
+        assert Tile(input_cols=["s"], output_cols=["o"], count=2).axis == 0
+
+    def test_forward_with_count(self) -> None:
+        """An explicit count repeats a 2D tensor along axis 0."""
+        layer = Tile(input_cols=["source"], output_cols=["tiled"], axis=0, count=3)
+        inputs = {"source": torch.tensor([[1, 2], [3, 4]])}
+        expected = torch.tensor([[1, 2], [3, 4], [1, 2], [3, 4], [1, 2], [3, 4]])
+        torch.testing.assert_close(layer(inputs)["tiled"], expected)
+
+    def test_forward_1d_axis_0(self) -> None:
+        """A 1D tensor tiled along axis 0 stays 1D."""
+        layer = Tile(input_cols=["source"], output_cols=["tiled"], axis=0, count=4)
+        inputs = {"source": torch.tensor([1, 2, 3])}
+        outputs = layer(inputs)
+        assert outputs["tiled"].dim() == 1
+        torch.testing.assert_close(
+            outputs["tiled"], torch.tensor([1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3])
+        )
+
+    def test_forward_with_target(self) -> None:
+        """The count is inferred from the trailing target tensor's shape."""
+        layer = Tile(
+            input_cols=["source", "target"],
+            output_cols=["tiled"],
+            axis=0,
+            target_tensor_provided=True,
+        )
+        inputs = {
+            "source": torch.tensor([[1, 2]]),
+            "target": torch.tensor([[0], [0], [0]]),
+        }
+        torch.testing.assert_close(
+            layer(inputs)["tiled"], torch.tensor([[1, 2], [1, 2], [1, 2]])
+        )
+
+    def test_missing_count_and_target_raises(self) -> None:
+        """Forward without a count or target tensor raises ``ValueError``."""
+        layer = Tile(input_cols=["source"], output_cols=["tiled"], axis=0)
+        with pytest.raises(ValueError, match="count must be specified"):
+            layer({"source": torch.tensor([1, 2])})
+
+    def test_axis_1_autounsqueeze_1d(self) -> None:
+        """A 1D input with axis=1 is unsqueezed to produce a 2D result."""
+        layer = Tile(input_cols=["source"], output_cols=["tiled"], axis=1, count=3)
+        inputs = {"source": torch.tensor([10, 20])}
+        outputs = layer(inputs)
+        assert outputs["tiled"].shape == torch.Size([2, 3])
+        torch.testing.assert_close(
+            outputs["tiled"], torch.tensor([[10, 10, 10], [20, 20, 20]])
+        )
+
+    def test_axis_1_autounsqueeze_with_target(self) -> None:
+        """Auto-unsqueeze also applies when the count comes from a target."""
+        layer = Tile(
+            input_cols=["source", "target"],
+            output_cols=["tiled"],
+            axis=1,
+            target_tensor_provided=True,
+        )
+        inputs = {
+            "source": torch.tensor([5, 10, 15]),
+            "target": torch.tensor([[0, 0, 0, 0]]),
+        }
+        outputs = layer(inputs)
+        assert outputs["tiled"].shape == torch.Size([3, 4])
+        torch.testing.assert_close(
+            outputs["tiled"],
+            torch.tensor([[5, 5, 5, 5], [10, 10, 10, 10], [15, 15, 15, 15]]),
+        )
+
+    def test_axis_negative_1(self) -> None:
+        """A negative axis tiles along the last dimension."""
+        layer = Tile(input_cols=["source"], output_cols=["tiled"], axis=-1, count=3)
+        inputs = {"source": torch.tensor([[1, 2], [3, 4]])}
+        torch.testing.assert_close(
+            layer(inputs)["tiled"],
+            torch.tensor([[1, 2, 1, 2, 1, 2], [3, 4, 3, 4, 3, 4]]),
+        )
+
+    def test_2d_axis_1_no_unsqueeze(self) -> None:
+        """A 2D input with axis=1 tiles without unsqueezing."""
+        layer = Tile(input_cols=["source"], output_cols=["tiled"], axis=1, count=2)
+        inputs = {"source": torch.tensor([[1], [2]])}
+        outputs = layer(inputs)
+        assert outputs["tiled"].dim() == 2
+        torch.testing.assert_close(outputs["tiled"], torch.tensor([[1, 1], [2, 2]]))
+
+    def test_multiple_columns_with_count(self) -> None:
+        """Multiple source columns are each tiled by the count."""
+        layer = Tile(input_cols=["s1", "s2"], output_cols=["o1", "o2"], count=2)
+        inputs = {"s1": torch.tensor([1, 2]), "s2": torch.tensor([3, 4])}
+        outputs = layer(inputs)
+        torch.testing.assert_close(outputs["o1"], torch.tensor([1, 2, 1, 2]))
+        torch.testing.assert_close(outputs["o2"], torch.tensor([3, 4, 3, 4]))
+
+
+class TestPadOrCrop1D:
+    """Padding/cropping to a fixed length, including sentinel handling."""
+
+    def test_invalid_align_raises(self) -> None:
+        """An align other than left/right raises ``ValueError``."""
+        with pytest.raises(ValueError, match="align"):
+            PadOrCrop1D(
+                input_cols=["x"], output_cols=["y"], max_length=3, align="center"
+            )
+
+    def test_non_positive_max_length_raises(self) -> None:
+        """A non-positive max_length raises ``ValueError``."""
+        with pytest.raises(ValueError, match="positive"):
+            PadOrCrop1D(input_cols=["x"], output_cols=["y"], max_length=0)
+
+    def test_mismatched_columns_raises(self) -> None:
+        """Unequal input/output column counts raise ``ValueError``."""
+        with pytest.raises(ValueError, match="same length"):
+            PadOrCrop1D(input_cols=["a", "b"], output_cols=["y"], max_length=3)
+
+    def test_left_padding_pads_right(self) -> None:
+        """align='left' pads on the right to reach max_length."""
+        layer = PadOrCrop1D(
+            input_cols=["f"], output_cols=["o"], max_length=5, pad_value=-1
+        )
+        out = layer({"f": torch.tensor([1, 2, 3])})["o"]
+        torch.testing.assert_close(out, torch.tensor([1, 2, 3, -1, -1]))
+
+    def test_left_cropping_keeps_first_n(self) -> None:
+        """align='left' crops from the right, keeping the first N."""
+        layer = PadOrCrop1D(
+            input_cols=["f"], output_cols=["o"], max_length=3, pad_value=-1
+        )
+        out = layer({"f": torch.tensor([1, 2, 3, 4, 5])})["o"]
+        torch.testing.assert_close(out, torch.tensor([1, 2, 3]))
+
+    def test_right_padding_pads_left(self) -> None:
+        """align='right' pads on the left."""
+        layer = PadOrCrop1D(
+            input_cols=["f"],
+            output_cols=["o"],
+            max_length=5,
+            pad_value=-1,
+            align="right",
+        )
+        out = layer({"f": torch.tensor([1, 2, 3])})["o"]
+        torch.testing.assert_close(out, torch.tensor([-1, -1, 1, 2, 3]))
+
+    def test_right_cropping_keeps_last_n(self) -> None:
+        """align='right' crops from the left, keeping the last N."""
+        layer = PadOrCrop1D(
+            input_cols=["f"],
+            output_cols=["o"],
+            max_length=3,
+            pad_value=-1,
+            align="right",
+        )
+        out = layer({"f": torch.tensor([1, 2, 3, 4, 5])})["o"]
+        torch.testing.assert_close(out, torch.tensor([3, 4, 5]))
+
+    def test_exact_length_unchanged(self) -> None:
+        """An input already at max_length is returned unchanged."""
+        layer = PadOrCrop1D(input_cols=["f"], output_cols=["o"], max_length=3)
+        out = layer({"f": torch.tensor([1, 2, 3])})["o"]
+        torch.testing.assert_close(out, torch.tensor([1, 2, 3]))
+
+    def test_preserve_input_dtype_when_none(self) -> None:
+        """With dtype=None the input dtype is preserved on pad and crop."""
+        pad_layer = PadOrCrop1D(
+            input_cols=["f"], output_cols=["o"], max_length=5, pad_value=0
+        )
+        pad_out = pad_layer({"f": torch.tensor([1, 2, 3], dtype=torch.int32)})["o"]
+        assert pad_out.dtype == torch.int32
+        torch.testing.assert_close(
+            pad_out, torch.tensor([1, 2, 3, 0, 0], dtype=torch.int32)
+        )
+
+    def test_explicit_dtype_overrides_input(self) -> None:
+        """An explicit dtype converts the output."""
+        layer = PadOrCrop1D(
+            input_cols=["f"],
+            output_cols=["o"],
+            max_length=4,
+            dtype=torch.float32,
+            pad_value=0,
+        )
+        out = layer({"f": torch.tensor([1, 2, 3], dtype=torch.int64)})["o"]
+        assert out.dtype == torch.float32
+        torch.testing.assert_close(out, torch.tensor([1.0, 2.0, 3.0, 0.0]))
+
+    def test_string_dtype_alias(self) -> None:
+        """A string dtype alias resolves to the target dtype."""
+        layer = PadOrCrop1D(
+            input_cols=["f"],
+            output_cols=["o"],
+            max_length=3,
+            dtype="float64",
+            pad_value=0.0,
+        )
+        out = layer({"f": torch.tensor([1, 2, 3, 4], dtype=torch.int32)})["o"]
+        assert out.dtype == torch.float64
+        torch.testing.assert_close(
+            out, torch.tensor([1.0, 2.0, 3.0], dtype=torch.float64)
+        )
+
+    def test_empty_last_dim_returns_full_pad(self) -> None:
+        """A zero-length input becomes a full pad_value tensor of max_length."""
+        layer = PadOrCrop1D(
+            input_cols=["f"],
+            output_cols=["o"],
+            max_length=5,
+            dtype=torch.float32,
+            pad_value=-1.0,
+        )
+        out = layer({"f": torch.tensor([], dtype=torch.float32)})["o"]
+        torch.testing.assert_close(out, torch.full((5,), -1.0))
+
+    def test_empty_last_dim_preserves_batch_dim(self) -> None:
+        """An empty last dim keeps the batch dimension when padding a 2D input."""
+        layer = PadOrCrop1D(
+            input_cols=["f"],
+            output_cols=["o"],
+            max_length=3,
+            pad_value=7,
+            dtype=torch.int64,
+        )
+        out = layer({"f": torch.empty((2, 0), dtype=torch.int64)})["o"]
+        assert out.shape == torch.Size([2, 3])
+        torch.testing.assert_close(out, torch.full((2, 3), 7, dtype=torch.int64))
+
+    def test_empty_last_dim_preserves_dtype(self) -> None:
+        """An empty int64 input keeps its dtype in the full-pad output."""
+        layer = PadOrCrop1D(
+            input_cols=["f"], output_cols=["o"], max_length=3, pad_value=-1
+        )
+        out = layer({"f": torch.tensor([], dtype=torch.int64)})["o"]
+        assert out.dtype == torch.int64
+        torch.testing.assert_close(out, torch.tensor([-1, -1, -1], dtype=torch.int64))
+
+    def test_default_nan_collation_sentinel_uses_pad_value(self) -> None:
+        """Without ragged_fill_value, NaN positions still become pad_value."""
+        layer = PadOrCrop1D(
+            input_cols=["f"], output_cols=["o"], max_length=4, pad_value=4.61
+        )
+        out = layer({"f": torch.tensor([[1.0, float("nan"), 3.0]])})["o"]
+        assert out[0, 1].item() == pytest.approx(4.61, abs=1e-4)
+        assert out[0, 3].item() == pytest.approx(4.61, abs=1e-4)
+
+    def test_default_int_sentinel_uses_pad_value(self) -> None:
+        """Without ragged_fill_value, INT32_SENTINEL positions become pad_value."""
+        layer = PadOrCrop1D(
+            input_cols=["f"], output_cols=["o"], max_length=4, pad_value=-1
+        )
+        out = layer({"f": torch.tensor([[10, INT32_SENTINEL, 30]], dtype=torch.int32)})[
+            "o"
+        ]
+        torch.testing.assert_close(
+            out, torch.tensor([[10, -1, 30, -1]], dtype=torch.int32)
+        )
+
+    def test_ragged_fill_value_nan_replaced(self) -> None:
+        """A NaN ragged_fill_value is converted to pad_value before padding."""
+        layer = PadOrCrop1D(
+            input_cols=["f"],
+            output_cols=["o"],
+            max_length=5,
+            dtype=torch.float32,
+            pad_value=0.0,
+            ragged_fill_value=float("nan"),
+        )
+        out = layer({"f": torch.tensor([1.0, 2.0, float("nan")])})["o"]
+        torch.testing.assert_close(out, torch.tensor([1.0, 2.0, 0.0, 0.0, 0.0]))
+
+    def test_ragged_fill_value_int_replaced(self) -> None:
+        """A numeric ragged_fill_value is converted to pad_value before padding."""
+        layer = PadOrCrop1D(
+            input_cols=["f"],
+            output_cols=["o"],
+            max_length=5,
+            dtype=torch.int32,
+            pad_value=-1,
+            ragged_fill_value=INT32_SENTINEL,
+        )
+        out = layer({"f": torch.tensor([10, 20, INT32_SENTINEL], dtype=torch.int32)})[
+            "o"
+        ]
+        torch.testing.assert_close(
+            out, torch.tensor([10, 20, -1, -1, -1], dtype=torch.int32)
+        )
+
+    def test_ragged_fill_value_legacy_numeric_sentinel_2d(self) -> None:
+        """A legacy -2B ragged sentinel is replaced across a batched 2D input."""
+        ragged_sentinel = -2_000_000_000
+        layer = PadOrCrop1D(
+            input_cols=["f"],
+            output_cols=["o"],
+            max_length=4,
+            dtype=torch.int32,
+            pad_value=-1,
+            ragged_fill_value=ragged_sentinel,
+        )
+        inputs = {
+            "f": torch.tensor(
+                [[10, 20, ragged_sentinel, ragged_sentinel], [30, 40, 50, 60]],
+                dtype=torch.int32,
+            )
+        }
+        torch.testing.assert_close(
+            layer(inputs)["o"],
+            torch.tensor([[10, 20, -1, -1], [30, 40, 50, 60]], dtype=torch.int32),
+        )
+
+    def test_ragged_fill_value_none_is_noop_for_custom_sentinel(self) -> None:
+        """With ragged_fill_value=None, a non-standard sentinel is left as data."""
+        layer = PadOrCrop1D(
+            input_cols=["f"],
+            output_cols=["o"],
+            max_length=4,
+            dtype=torch.int32,
+            pad_value=-1,
+            ragged_fill_value=None,
+        )
+        out = layer({"f": torch.tensor([10, -2_000_000_000, 30], dtype=torch.int32)})[
+            "o"
+        ]
+        torch.testing.assert_close(
+            out, torch.tensor([10, -2_000_000_000, 30, -1], dtype=torch.int32)
+        )
+
+    def test_real_negative_one_preserved_with_ragged_fill_value(self) -> None:
+        """A real -1 survives when the ragged sentinel is a distinct value."""
+        ragged_sentinel = -2_000_000_000
+        layer = PadOrCrop1D(
+            input_cols=["f"],
+            output_cols=["o"],
+            max_length=4,
+            dtype=torch.int32,
+            pad_value=-1,
+            ragged_fill_value=ragged_sentinel,
+        )
+        out = layer({"f": torch.tensor([10, -1, ragged_sentinel], dtype=torch.int32)})[
+            "o"
+        ]
+        torch.testing.assert_close(
+            out, torch.tensor([10, -1, -1, -1], dtype=torch.int32)
+        )
+
+    def test_ragged_fill_value_numeric_on_float_input(self) -> None:
+        """A numeric (non-NaN) ragged sentinel is replaced in a float tensor."""
+        layer = PadOrCrop1D(
+            input_cols=["f"],
+            output_cols=["o"],
+            max_length=5,
+            dtype=torch.float32,
+            pad_value=0.0,
+            ragged_fill_value=-999.0,
+        )
+        # Both the explicit -999.0 sentinel and a stray NaN collapse to pad_value.
+        out = layer({"f": torch.tensor([1.0, -999.0, float("nan")])})["o"]
+        torch.testing.assert_close(out, torch.tensor([1.0, 0.0, 0.0, 0.0, 0.0]))
+
+    def test_ragged_fill_value_replaced_before_crop(self) -> None:
+        """Ragged sentinels are replaced even when the input is then cropped."""
+        ragged_sentinel = -2_000_000_000
+        layer = PadOrCrop1D(
+            input_cols=["f"],
+            output_cols=["o"],
+            max_length=3,
+            dtype=torch.int32,
+            pad_value=-1,
+            ragged_fill_value=ragged_sentinel,
+        )
+        out = layer(
+            {"f": torch.tensor([10, ragged_sentinel, 30, 40, 50], dtype=torch.int32)}
+        )["o"]
+        torch.testing.assert_close(out, torch.tensor([10, -1, 30], dtype=torch.int32))
+
+    def test_over_padding_short_input(self) -> None:
+        """A single element pads out to the full max_length."""
+        layer = PadOrCrop1D(
+            input_cols=["f"],
+            output_cols=["o"],
+            max_length=4,
+            pad_value=9,
+            dtype=torch.int64,
+        )
+        out = layer({"f": torch.tensor([7])})["o"]
+        torch.testing.assert_close(out, torch.tensor([7, 9, 9, 9], dtype=torch.int64))
+
+    def test_multiple_columns(self) -> None:
+        """Multiple columns are padded/cropped independently."""
+        layer = PadOrCrop1D(
+            input_cols=["f1", "f2"],
+            output_cols=["o1", "o2"],
+            max_length=4,
+            dtype=torch.int64,
+            pad_value=-1,
+        )
+        inputs = {
+            "f1": torch.tensor([1, 2, 3, 4, 5]),
+            "f2": torch.tensor([6, 7, 8, 9, 10]),
+        }
+        outputs = layer(inputs)
+        torch.testing.assert_close(
+            outputs["o1"], torch.tensor([1, 2, 3, 4], dtype=torch.int64)
+        )
+        torch.testing.assert_close(
+            outputs["o2"], torch.tensor([6, 7, 8, 9], dtype=torch.int64)
+        )
+
+
+class TestScale:
+    """Scalar multiplication."""
+
+    def test_mismatched_columns_raises(self) -> None:
+        """Unequal input/output column counts raise ``ValueError``."""
+        with pytest.raises(ValueError, match="same length"):
+            Scale(input_cols=["a", "b"], output_cols=["out"], factor=2.0)
+
+    def test_basic_scaling(self) -> None:
+        """Values are multiplied by the factor."""
+        layer = Scale(input_cols=["val"], output_cols=["scaled"], factor=2.0)
+        inputs = {"val": torch.tensor([1.0, 2.0, 3.0])}
+        torch.testing.assert_close(
+            layer(inputs)["scaled"], torch.tensor([2.0, 4.0, 6.0])
+        )
+
+    def test_negative_factor(self) -> None:
+        """A negative factor flips signs and scales."""
+        layer = Scale(input_cols=["val"], output_cols=["scaled"], factor=-0.5)
+        inputs = {"val": torch.tensor([10.0, -20.0])}
+        torch.testing.assert_close(layer(inputs)["scaled"], torch.tensor([-5.0, 10.0]))
+
+    def test_multiple_columns(self) -> None:
+        """Each column is scaled by the same factor."""
+        layer = Scale(input_cols=["v1", "v2"], output_cols=["s1", "s2"], factor=10.0)
+        inputs = {"v1": torch.tensor([1.0, 2.0]), "v2": torch.tensor([3.0, 4.0])}
+        outputs = layer(inputs)
+        torch.testing.assert_close(outputs["s1"], torch.tensor([10.0, 20.0]))
+        torch.testing.assert_close(outputs["s2"], torch.tensor([30.0, 40.0]))
+
+
+class TestClip:
+    """Clamping to a range with optional value exemption."""
+
+    def test_mismatched_columns_raises(self) -> None:
+        """Unequal input/output column counts raise ``ValueError``."""
+        with pytest.raises(ValueError, match="same length"):
+            Clip(input_cols=["a", "b"], output_cols=["out"], min_value=0.0)
+
+    def test_basic_clip(self) -> None:
+        """Values are clamped to ``[min_value, max_value]``."""
+        layer = Clip(
+            input_cols=["val"], output_cols=["clipped"], min_value=0.0, max_value=10.0
+        )
+        inputs = {"val": torch.tensor([-5.0, 5.0, 15.0])}
+        torch.testing.assert_close(
+            layer(inputs)["clipped"], torch.tensor([0.0, 5.0, 10.0])
+        )
+
+    def test_only_min_bound(self) -> None:
+        """A missing upper bound leaves large values untouched."""
+        layer = Clip(input_cols=["val"], output_cols=["clipped"], min_value=0.0)
+        inputs = {"val": torch.tensor([-5.0, 5.0, 1000.0])}
+        torch.testing.assert_close(
+            layer(inputs)["clipped"], torch.tensor([0.0, 5.0, 1000.0])
+        )
+
+    def test_only_max_bound(self) -> None:
+        """A missing lower bound leaves small values untouched."""
+        layer = Clip(input_cols=["val"], output_cols=["clipped"], max_value=10.0)
+        inputs = {"val": torch.tensor([-500.0, 5.0, 15.0])}
+        torch.testing.assert_close(
+            layer(inputs)["clipped"], torch.tensor([-500.0, 5.0, 10.0])
+        )
+
+    def test_ignore_value_preserved(self) -> None:
+        """Positions equal to ignore_value are preserved even if out of range."""
+        layer = Clip(
+            input_cols=["val"],
+            output_cols=["clipped"],
+            min_value=0.0,
+            max_value=10.0,
+            ignore_value=-1.0,
+        )
+        inputs = {"val": torch.tensor([-5.0, 5.0, 15.0, -1.0])}
+        torch.testing.assert_close(
+            layer(inputs)["clipped"], torch.tensor([0.0, 5.0, 10.0, -1.0])
+        )
+
+    def test_multiple_columns(self) -> None:
+        """Each column is clamped independently."""
+        layer = Clip(
+            input_cols=["v1", "v2"],
+            output_cols=["o1", "o2"],
+            min_value=0.0,
+            max_value=1.0,
+        )
+        inputs = {"v1": torch.tensor([-1.0, 2.0]), "v2": torch.tensor([0.5, 5.0])}
+        outputs = layer(inputs)
+        torch.testing.assert_close(outputs["o1"], torch.tensor([0.0, 1.0]))
+        torch.testing.assert_close(outputs["o2"], torch.tensor([0.5, 1.0]))
+
+
+def _b2_layer_cases() -> list[tuple[str, TorchTransformBaseLayer, dict]]:
+    """Build (id, layer, inputs) cases covering every B2 structural layer.
+
+    Each entry exercises the ``forward`` path that a served model relies on so
+    the TorchScript round-trip test can confirm the scripted module (and a
+    save/load cycle) reproduces the eager output.
+    """
+    return [
+        (
+            "tensor_col_fill_none_float",
+            TensorColFillNone(input_cols=["f"], output_cols=["o"], default_value=0.0),
+            {"f": torch.tensor([1.0, float("nan"), 3.0])},
+        ),
+        (
+            "tensor_col_fill_none_int32",
+            TensorColFillNone(input_cols=["f"], output_cols=["o"], default_value=9),
+            {
+                "f": torch.tensor(
+                    [1, torch.iinfo(torch.int32).min, 3], dtype=torch.int32
+                )
+            },
+        ),
+        (
+            "case_when_scalar_default",
+            CaseWhen(
+                input_cols=["c1", "v1", "c2", "v2"],
+                output_cols=["o"],
+                default_value=-1,
+            ),
+            {
+                "c1": torch.tensor([True, False, False]),
+                "v1": torch.tensor([10, 20, 30]),
+                "c2": torch.tensor([False, True, False]),
+                "v2": torch.tensor([100, 200, 300]),
+            },
+        ),
+        (
+            "case_when_tensor_default",
+            CaseWhen(
+                input_cols=["c1", "v1"],
+                output_cols=["o"],
+                default_value=torch.tensor(-1),
+            ),
+            {
+                "c1": torch.tensor([True, False, True]),
+                "v1": torch.tensor([100, 200, 300]),
+            },
+        ),
+        (
+            "compare_equal",
+            Compare(input_cols=["l", "r"], output_cols=["o"], compare_op="equal"),
+            {"l": torch.tensor([1, 2, 3]), "r": torch.tensor([1, 3, 3])},
+        ),
+        (
+            "compare_greater_equal",
+            Compare(
+                input_cols=["l", "r"], output_cols=["o"], compare_op="greater_equal"
+            ),
+            {"l": torch.tensor([1, 2, 3]), "r": torch.tensor(2)},
+        ),
+        (
+            "tile_count",
+            Tile(input_cols=["s"], output_cols=["o"], count=2),
+            {"s": torch.tensor([1, 2])},
+        ),
+        (
+            "tile_axis1_unsqueeze",
+            Tile(input_cols=["s"], output_cols=["o"], axis=1, count=3),
+            {"s": torch.tensor([10, 20])},
+        ),
+        (
+            "pad_or_crop_explicit_dtype",
+            PadOrCrop1D(
+                input_cols=["f"],
+                output_cols=["o"],
+                max_length=5,
+                dtype=torch.int64,
+                pad_value=0,
+            ),
+            {"f": torch.tensor([1, 2, 3])},
+        ),
+        (
+            "pad_or_crop_preserve_dtype",
+            PadOrCrop1D(input_cols=["f"], output_cols=["o"], max_length=5, pad_value=0),
+            {"f": torch.tensor([1, 2, 3], dtype=torch.int32)},
+        ),
+        (
+            "pad_or_crop_align_right",
+            PadOrCrop1D(
+                input_cols=["f"],
+                output_cols=["o"],
+                max_length=5,
+                pad_value=-1,
+                align="right",
+            ),
+            {"f": torch.tensor([1, 2, 3, 4, 5, 6, 7])},
+        ),
+        (
+            "pad_or_crop_ragged_nan",
+            PadOrCrop1D(
+                input_cols=["f"],
+                output_cols=["o"],
+                max_length=5,
+                pad_value=0.0,
+                ragged_fill_value=float("nan"),
+            ),
+            {"f": torch.tensor([1.0, float("nan"), 3.0])},
+        ),
+        (
+            "pad_or_crop_ragged_int",
+            PadOrCrop1D(
+                input_cols=["f"],
+                output_cols=["o"],
+                max_length=5,
+                pad_value=-1,
+                ragged_fill_value=INT32_SENTINEL,
+            ),
+            {"f": torch.tensor([10, INT32_SENTINEL, 30], dtype=torch.int32)},
+        ),
+        (
+            "scale",
+            Scale(input_cols=["v"], output_cols=["o"], factor=2.0),
+            {"v": torch.tensor([1.0, 2.0])},
+        ),
+        (
+            "clip",
+            Clip(input_cols=["v"], output_cols=["o"], min_value=0.0, max_value=10.0),
+            {"v": torch.tensor([-5.0, 5.0, 15.0])},
+        ),
+        (
+            "clip_ignore_value",
+            Clip(
+                input_cols=["v"],
+                output_cols=["o"],
+                min_value=0.0,
+                max_value=10.0,
+                ignore_value=-1.0,
+            ),
+            {"v": torch.tensor([-5.0, 5.0, 15.0, -1.0])},
+        ),
+    ]
+
+
+class TestB2TorchScriptRoundTrip:
+    """Every B2 structural layer must script, save/load, and match eager output."""
+
+    @pytest.mark.parametrize(
+        ("layer", "inputs"),
+        [(layer, inputs) for _, layer, inputs in _b2_layer_cases()],
+        ids=[case_id for case_id, _, _ in _b2_layer_cases()],
+    )
+    def test_scripted_matches_eager(
+        self,
+        layer: TorchTransformBaseLayer,
+        inputs: dict[str, torch.Tensor],
+        tmp_path,
+    ) -> None:
+        """Scripting (and reloading) reproduces the eager forward output."""
+        layer.eval()
+        eager = layer(inputs)
+
+        scripted = torch.jit.script(layer)
+        scripted_out = scripted(inputs)
+        assert set(scripted_out) == set(eager)
+        for key in eager:
+            torch.testing.assert_close(scripted_out[key], eager[key])
+
+        model_path = tmp_path / "scripted_b2_layer.pt"
         scripted.save(str(model_path))
         loaded = torch.jit.load(str(model_path))
         loaded_out = loaded(inputs)

--- a/python/michelangelo/lib/native_transform/torch/tests/test_base_layers.py
+++ b/python/michelangelo/lib/native_transform/torch/tests/test_base_layers.py
@@ -785,6 +785,36 @@ class TestTensorColFillNone:
         inputs = {"feature": torch.tensor([10, 20, 30], dtype=torch.int64)}
         torch.testing.assert_close(layer(inputs)["filled"], inputs["feature"])
 
+    def test_int64_no_false_positive_near_minimum(self) -> None:
+        """Values close to (but not equal to) the int64 minimum are not missing.
+
+        Detection must be an exact comparison. A float-mediated check loses
+        precision at this magnitude and flags a wide band around the sentinel.
+        """
+        min_val = torch.iinfo(torch.int64).min
+        near_min = [min_val + 1, min_val + 1_000_000_000, min_val + 10**15]
+        layer = TensorColFillNone(
+            input_cols=["feature"], output_cols=["filled"], default_value=0
+        )
+        inputs = {"feature": torch.tensor(near_min, dtype=torch.int64)}
+        torch.testing.assert_close(layer(inputs)["filled"], inputs["feature"])
+
+    def test_int64_minimum_still_detected_alongside_near_values(self) -> None:
+        """Only the exact int64 minimum is filled, even next to near-min values."""
+        min_val = torch.iinfo(torch.int64).min
+        layer = TensorColFillNone(
+            input_cols=["feature"], output_cols=["filled"], default_value=7
+        )
+        inputs = {
+            "feature": torch.tensor(
+                [min_val, min_val + 1_000_000_000], dtype=torch.int64
+            )
+        }
+        torch.testing.assert_close(
+            layer(inputs)["filled"],
+            torch.tensor([7, min_val + 1_000_000_000], dtype=torch.int64),
+        )
+
     def test_multiple_columns(self) -> None:
         """Each column is filled independently."""
         layer = TensorColFillNone(
@@ -1013,10 +1043,9 @@ class TestTile:
         )
 
     def test_missing_count_and_target_raises(self) -> None:
-        """Forward without a count or target tensor raises ``ValueError``."""
-        layer = Tile(input_cols=["source"], output_cols=["tiled"], axis=0)
+        """Construction without a count or target tensor raises ``ValueError``."""
         with pytest.raises(ValueError, match="count must be specified"):
-            layer({"source": torch.tensor([1, 2])})
+            Tile(input_cols=["source"], output_cols=["tiled"], axis=0)
 
     def test_axis_1_autounsqueeze_1d(self) -> None:
         """A 1D input with axis=1 is unsqueezed to produce a 2D result."""
@@ -1132,6 +1161,121 @@ class TestPadOrCrop1D:
         )
         out = layer({"f": torch.tensor([1, 2, 3, 4, 5])})["o"]
         torch.testing.assert_close(out, torch.tensor([3, 4, 5]))
+
+    def test_right_align_keeps_real_prefix_over_trailing_sentinels(self) -> None:
+        """align='right' crops to real content, not to sentinel padding.
+
+        A short sequence collated into a longer tensor carries trailing NaN
+        padding. Cropping to the last ``max_length`` raw positions would return
+        that padding; the real prefix must be kept instead.
+        """
+        layer = PadOrCrop1D(
+            input_cols=["f"],
+            output_cols=["o"],
+            max_length=3,
+            pad_value=-1.0,
+            align="right",
+        )
+        out = layer({"f": torch.tensor([1.0, 2.0, 3.0, float("nan"), float("nan")])})[
+            "o"
+        ]
+        torch.testing.assert_close(out, torch.tensor([1.0, 2.0, 3.0]))
+
+    def test_right_align_int_sentinel_stripped_before_crop(self) -> None:
+        """The integer collation sentinel is stripped before an align='right' crop."""
+        layer = PadOrCrop1D(
+            input_cols=["f"],
+            output_cols=["o"],
+            max_length=2,
+            pad_value=-1,
+            align="right",
+        )
+        out = layer(
+            {"f": torch.tensor([10, 20, 30, INT32_SENTINEL], dtype=torch.int32)}
+        )["o"]
+        torch.testing.assert_close(out, torch.tensor([20, 30], dtype=torch.int32))
+
+    def test_right_align_ragged_fill_value_stripped_before_crop(self) -> None:
+        """A ``ragged_fill_value`` is stripped before an align='right' crop."""
+        ragged_sentinel = -2_000_000_000
+        layer = PadOrCrop1D(
+            input_cols=["f"],
+            output_cols=["o"],
+            max_length=3,
+            dtype=torch.int32,
+            pad_value=-1,
+            ragged_fill_value=ragged_sentinel,
+            align="right",
+        )
+        out = layer(
+            {
+                "f": torch.tensor(
+                    [10, 20, 30, ragged_sentinel, ragged_sentinel], dtype=torch.int32
+                )
+            }
+        )["o"]
+        torch.testing.assert_close(out, torch.tensor([10, 20, 30], dtype=torch.int32))
+
+    def test_right_align_pads_when_content_shorter_than_max_length(self) -> None:
+        """Sentinel-trimmed content shorter than max_length is left-padded."""
+        layer = PadOrCrop1D(
+            input_cols=["f"],
+            output_cols=["o"],
+            max_length=4,
+            pad_value=-1.0,
+            align="right",
+        )
+        out = layer({"f": torch.tensor([1.0, 2.0, float("nan")])})["o"]
+        torch.testing.assert_close(out, torch.tensor([-1.0, -1.0, 1.0, 2.0]))
+
+    def test_right_align_all_sentinel_returns_all_pad(self) -> None:
+        """An input that is entirely sentinel yields only ``pad_value``."""
+        layer = PadOrCrop1D(
+            input_cols=["f"],
+            output_cols=["o"],
+            max_length=3,
+            pad_value=-1.0,
+            align="right",
+        )
+        out = layer({"f": torch.tensor([float("nan"), float("nan")])})["o"]
+        torch.testing.assert_close(out, torch.tensor([-1.0, -1.0, -1.0]))
+
+    def test_right_align_content_length_is_per_row(self) -> None:
+        """Each batch row is cropped against its own real-content length."""
+        layer = PadOrCrop1D(
+            input_cols=["f"],
+            output_cols=["o"],
+            max_length=3,
+            pad_value=-1.0,
+            align="right",
+        )
+        inputs = {
+            "f": torch.tensor(
+                [
+                    [1.0, 2.0, 3.0, float("nan"), float("nan")],
+                    [1.0, 2.0, 3.0, 4.0, 5.0],
+                    [1.0, float("nan"), float("nan"), float("nan"), float("nan")],
+                ]
+            )
+        }
+        torch.testing.assert_close(
+            layer(inputs)["o"],
+            torch.tensor([[1.0, 2.0, 3.0], [3.0, 4.0, 5.0], [-1.0, -1.0, 1.0]]),
+        )
+
+    def test_left_align_unaffected_by_trailing_sentinels(self) -> None:
+        """align='left' keeps the real prefix, as it always has."""
+        layer = PadOrCrop1D(
+            input_cols=["f"],
+            output_cols=["o"],
+            max_length=3,
+            pad_value=-1.0,
+            align="left",
+        )
+        out = layer({"f": torch.tensor([1.0, 2.0, 3.0, float("nan"), float("nan")])})[
+            "o"
+        ]
+        torch.testing.assert_close(out, torch.tensor([1.0, 2.0, 3.0]))
 
     def test_exact_length_unchanged(self) -> None:
         """An input already at max_length is returned unchanged."""
@@ -1422,6 +1566,11 @@ class TestClip:
         """Unequal input/output column counts raise ``ValueError``."""
         with pytest.raises(ValueError, match="same length"):
             Clip(input_cols=["a", "b"], output_cols=["out"], min_value=0.0)
+
+    def test_no_bounds_raises(self) -> None:
+        """Omitting both bounds raises ``ValueError`` at construction time."""
+        with pytest.raises(ValueError, match="min_value or max_value"):
+            Clip(input_cols=["val"], output_cols=["clipped"])
 
     def test_basic_clip(self) -> None:
         """Values are clamped to ``[min_value, max_value]``."""


### PR DESCRIPTION
## Summary

Second of an 8-part split (B1–B8) of a larger `native_transform` change, each part adding one family of layers. Builds on **PR B1** (foundation layers), merged as #1570. Adds the **structural / shape-manipulating** torch transform layers to `python/michelangelo/lib/native_transform/torch/base_layers.py`.

### Scope — 7 classes
- `TensorColFillNone` — fill missing (NaN / int-min sentinel) positions with a default
- `CaseWhen` — SQL-like conditional selection over (condition, value) pairs
- `Compare` — pairwise element-wise comparison operators
- `Tile` — repeat along an axis by explicit count or inferred from a target tensor
- `PadOrCrop1D` — pad/crop to fixed length with sentinel handling and left/right align **(riskiest — see below)**
- `Scale` — scalar multiplication
- `Clip` — clamp to a range with optional value exemption

All extend `TorchTransformBaseLayer` from B1 (same `dict[str, torch.Tensor]` forward contract, same `format_inputs`/`format_outputs` pattern). No B3–B8 classes touched.

## Implementation notes
- `INT32_SENTINEL` is imported from the public `michelangelo.lib.constants.sentinel`.
- **Docstrings** are Google style (Args / Returns / Raises) and **full type hints** are present on all public APIs.
- **`CaseWhen`** builds a non-scalar default with `torch.as_tensor` rather than `torch.tensor`, avoiding a copy-construct `UserWarning`; still TorchScript-scriptable for scalar/tensor/list defaults.
- Three genuinely-unreachable defensive `else` branches (the validated `compare_op` in `Compare`; the count/target guard and the matching `multiples` guard in `Tile`) are kept for TorchScript control-flow totality and marked `# pragma: no cover`.
- All seven layers validate their configuration eagerly in `__init__`, matching the B1 layers.

### ⚠️ Reviewer attention: `PadOrCrop1D` sentinel handling
This is the most involved layer. It builds a boolean **sentinel mask** over positions holding upstream ragged padding rather than real data — `NaN` for float dtypes, `INT32_SENTINEL` for int dtypes, auto-detected from the input's dtype — then rewrites those positions to `pad_value`.

The mask is **retained**, not just applied: once a sentinel becomes `pad_value` it is indistinguishable from padding, so `align="right"` uses the mask to find where real content ends and gathers the last `max_length` elements of the *content* (per batch row), left-padding when the content is shorter. `align="left"` pads on the right and keeps the first `max_length` elements, which are always real content.

Tested edge cases: over-padding, zero-length/empty last-dim input (batch dim and dtype preserved), left/right align pad+crop, NaN vs `INT32_SENTINEL` collation sentinels, a non-standard numeric value correctly left as real data, per-row content lengths in a 2D batch, all-sentinel input, and sentinel replacement before cropping.

## Review fixes

`b8afd6eb` fixes three correctness bugs found in review of the initial commit — [full write-up in the commit comment](https://github.com/michelangelo-ai/michelangelo/pull/1603#issuecomment-5098555880):

1. **`PadOrCrop1D` with `align="right"` dropped real data and kept padding.** Sentinel conversion ran before the crop, so trailing `NaN`/`INT32_SENTINEL` became indistinguishable from `pad_value` and the "keep the last `max_length` elements" crop retained the padding. `[1,2,3,nan,nan]` with `max_length=3, pad_value=-1` returned `[3,-1,-1]`; now returns `[1,2,3]`. Fixed by retaining the sentinel mask (described above). `align="left"` was unaffected.
2. **`TensorColFillNone` int64 sentinel detection had a ~±2.7e11 false-positive radius.** `x / 2 == int64_min / 2` promotes int64 to float32, whose 24-bit mantissa cannot resolve values near `int64_min`, so e.g. `int64_min + 1_000_000_000` was wrongly filled. The comment justifying the halved comparison as a TorchScript constant-overflow workaround was incorrect — the direct comparison scripts cleanly (verified with `torch.jit.script`). Replaced with the exact comparison.
3. **`Tile` and `Clip` skipped eager `__init__` validation.** `Tile` without `count` or `target_tensor_provided`, and `Clip` with neither bound, both constructed *and scripted* fine and only failed inside `forward()`. Both now raise `ValueError` at construction, with `Raises:` docstring sections added.

Regression tests were added for all three, covering `align="right"` with float NaN / int sentinel / content shorter than `max_length` / all-sentinel input / per-row content lengths, near-`int64_min` real values, and the two new construction-time errors.

## Tests
Appended to `test_base_layers.py` (the B1 file, not replaced): per-layer coverage of validation errors, dtypes, broadcasting, multi-column inputs, and edge cases, plus a **parametrized TorchScript `script` + save/load round-trip for each of the 7 layers**, following the pattern established in B1.

## Verification
- `pytest michelangelo/lib/native_transform/` → **212 passed, 1 skipped**
- Coverage: **`base_layers.py` 100% statement and branch**
- `ruff format --check` and `ruff check` → **clean** on all touched files
- Full B1 suite (`test_base_layers.py`, `test_utils.py`, `test_id_hash_tokenizer.py`) re-run → **green**, no regressions
