### PR TITLE
fix(uniflow): propagate namespace to Ray cluster spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ All notable changes to this project will be documented in this file.
   (validated via `TorchTrainer.can_restore()`). Defaults to `None` (no tracking,
   no resume); bring your own `ExperimentStore` for other backends.
 
+### Fixed
+
+- Ray tasks now create Michelangelo `RayCluster` and `RayJob` resources in
+  `MA_NAMESPACE`; workflows without `MA_NAMESPACE` continue using `default`,
+  and downstream KubeRay compute-resource placement is unchanged.
+
 ## [0.5.0] - 2026-07-20
 
 ### Breaking Changes
@@ -304,4 +310,3 @@ All notable changes to this project will be documented in this file.
 
 
 - **ui:** Centralize mutation middleware in the mutation hook (#1482)
-

--- a/go/worker/plugins/ray/starlark_module_test.go
+++ b/go/worker/plugins/ray/starlark_module_test.go
@@ -48,7 +48,7 @@ func (r *Test) TestCreateClusterSuccessfully() {
 	rayCluster := &v2pb.RayCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "uf-ray-test",
-			Namespace: "default",
+			Namespace: "ma-dev-test",
 		},
 		Spec: v2pb.RayClusterSpec{
 			User: &v2pb.UserInfo{
@@ -162,8 +162,9 @@ func (r *Test) TestCreateClusterSuccessfully() {
 	err := r.env.Cadence.GetResult(&res)
 	require.NoError(err)
 	require.EqualValues(rayCluster, createClusterReq.RayCluster)
+	require.Equal("ma-dev-test", createClusterReq.RayCluster.Namespace)
 	require.EqualValues(rayCluster.Name, sensorClusterReq.Name)
-	require.EqualValues(rayCluster.Namespace, sensorClusterReq.Namespace)
+	require.Equal("ma-dev-test", sensorClusterReq.Namespace)
 	require.NotNil(res.(map[string]interface{}))
 }
 

--- a/go/worker/plugins/ray/testdata/test.star
+++ b/go/worker/plugins/ray/testdata/test.star
@@ -4,7 +4,7 @@ def test_create_cluster():
     spec = {
         "metadata": {
             "name": "uf-ray-test",
-            "namespace": "default",
+            "namespace": "ma-dev-test",
         },
         "spec": {
             "user": {"name": "test-user"},

--- a/python/michelangelo/uniflow/plugins/ray/task.star
+++ b/python/michelangelo/uniflow/plugins/ray/task.star
@@ -491,7 +491,7 @@ def ray_cluster_spec(
     return {
         "metadata": {
             "generateName": "uf-ray-",
-            "namespace": "default",
+            "namespace": namespace,
             "annotations": annotations,
         },
         "spec": {

--- a/python/michelangelo/uniflow/plugins/ray/tests/ray_cluster_spec_test.py
+++ b/python/michelangelo/uniflow/plugins/ray/tests/ray_cluster_spec_test.py
@@ -1,0 +1,55 @@
+"""Tests for the Ray cluster Starlark specification builder."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import TestCase
+
+
+def _load_ray_cluster_spec():
+    """Load the actual ray_cluster_spec function with controlled globals."""
+    task_path = Path(__file__).resolve().parents[1] / "task.star"
+    tree = ast.parse(task_path.read_text(), filename=str(task_path))
+    function = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "ray_cluster_spec"
+    )
+    module = ast.fix_missing_locations(ast.Module(body=[function], type_ignores=[]))
+    globals_ = {
+        "COMMONS_ENV": {},
+        "IMAGE_PULL_POLICY": "Never",
+        "RAY_ENV": {},
+        "USER_ID": "test-user",
+        "os": SimpleNamespace(environ={}),
+    }
+    exec(compile(module, str(task_path), "exec"), globals_)
+    return globals_["ray_cluster_spec"]
+
+
+class TestRayClusterSpec(TestCase):
+    """Tests for ray_cluster_spec()."""
+
+    def _build_spec(self, namespace: str):
+        ray_cluster_spec = _load_ray_cluster_spec()
+        return ray_cluster_spec(
+            namespace=namespace,
+            image="test-image",
+            head_resource={"cpu": 1, "memory": "1Gi"},
+            worker_resource={"cpu": 1, "memory": "1Gi"},
+            worker_instances=1,
+        )
+
+    def test_preserves_custom_namespace(self):
+        """A project namespace is retained in cluster metadata."""
+        spec = self._build_spec("ma-dev-test")
+
+        self.assertEqual(spec["metadata"]["namespace"], "ma-dev-test")
+
+    def test_preserves_default_namespace(self):
+        """Default-namespace workflows remain unchanged."""
+        spec = self._build_spec("default")
+
+        self.assertEqual(spec["metadata"]["namespace"], "default")


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
As described by the issue in #1604 , the namespace propagation in the Ray cluster spec seems to have all the plumbing needed, but is not passed down to the kubernetes spec generation in the starlark code.
This PR fixes that by propagating the `namespace` argument into `ray_cluster_spec().metadata.namespace`. Add a Python regression test that extracts and executes the actual Starlark builder for custom and default namespaces. Exercise the Starlark-to-Go Ray plugin boundary with `ma-dev-test` and assert that create and readiness requests retain it.

<!-- Tell your future self why have you made these changes -->
**Why?**
Calling `ray_cluster_spec("ma-dev-test", ...)` currently emits `metadata.namespace: default`. The original Ray integration in [#90](https://github.com/michelangelo-ai/michelangelo/pull/90) covered only local/default behavior. [#94](https://github.com/michelangelo-ai/michelangelo/pull/94) later made the caller use `MA_NAMESPACE`, but the builder's hard-coded namespace prevented that value from reaching the Michelangelo `RayCluster`.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Automated tests:

  - `poetry run pytest michelangelo/uniflow/plugins/ray/tests` — 33 passed
  - Ruff formatting and lint checks for the new Python regression test
  - `./tools/bazel test //go/worker/plugins/ray:go_default_test` — 1 passed
  - `git diff --check`

Local k3d verification with `MA_NAMESPACE=ma-dev-test`:

  - On `main`, the Michelangelo `RayCluster` was created in `default`.
  - With this change, the Michelangelo `RayCluster` and `RayJob` were created in
    `ma-dev-test`, and the Ray job completed successfully.
  - The downstream KubeRay compute cluster remained in Kubernetes `default`, as
    intended by the local compute-cluster mapper.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Ray tasks configured with `MA_NAMESPACE` will now create Michelangelo cluster and job resources in that namespace, so the namespace must have the expected project resources and permissions. Workflows without `MA_NAMESPACE` continue using `default`. Ray local-compute KubeRay resources remain in Kubernetes `default`.

<!-- Does this PR introduce a breaking change? Check all that apply. -->
**Breaking Changes**

- [X] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

> If any breaking change box is checked (other than "No breaking changes"), you **must**:
> 1. Use the `BREAKING CHANGE:` footer **or** the `!` suffix (e.g. `feat!:`) in your commit message — see [Commit Messages](../CONTRIBUTING.md#commit-messages).
> 2. Fill in the **Migration guide** section below with step-by-step upgrade instructions.

<!-- Required only if a breaking change box above is checked. Delete this section if no breaking changes. -->
**Migration guide**

_Describe the steps an operator or downstream consumer must take to upgrade. Include before/after examples for any API, config, or schema change._

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
Ray tasks now create Michelangelo Ray cluster and job resources in `MA_NAMESPACE`; default-namespace workflows remain unchanged.

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
