### PR TITLE
chore: release 0.6.0

### DIFF
--- a/helm/michelangelo/Chart.yaml
+++ b/helm/michelangelo/Chart.yaml
@@ -7,8 +7,8 @@ description: |
   and RBAC — into any Kubernetes cluster. Bring your own metadata storage,
   object storage, and workflow engine (Cadence or Temporal).
 type: application
-version: 0.6.0-rc.1
-appVersion: "0.6.0-rc.1"
+version: 0.6.0
+appVersion: "0.6.0"
 kubeVersion: ">=1.27.0-0"
 
 dependencies:

--- a/javascript/app/package.json
+++ b/javascript/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@michelangelo/app",
   "license": "Apache-2.0",
-  "version": "0.6.0-rc.1",
+  "version": "0.6.0",
   "private": true,
   "scripts": {
     "build": "vite build --config vite.config.ts",
@@ -11,11 +11,11 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
-    "@michelangelo-ai/rpc": "0.6.0-rc.1",
+    "@michelangelo-ai/rpc": "0.6.0",
     "@mui/icons-material": "^7.1.0",
     "@mui/material": "^7.1.0",
     "@tanstack/react-query": "5.39.0",
-    "@michelangelo-ai/core": "0.6.0-rc.1",
+    "@michelangelo-ai/core": "0.6.0",
     "baseui": "15.0.0",
     "react-router-dom": "5.3.4",
     "react-router-dom-v5-compat": "6.29.0",

--- a/javascript/packages/core/package.json
+++ b/javascript/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@michelangelo-ai/core",
   "license": "Apache-2.0",
-  "version": "0.6.0-rc.1",
+  "version": "0.6.0",
   "type": "module",
   "main": "./dist/michelangelo-core.js",
   "module": "./dist/michelangelo-core.js",

--- a/javascript/packages/rpc/package.json
+++ b/javascript/packages/rpc/package.json
@@ -2,7 +2,7 @@
   "name": "@michelangelo-ai/rpc",
   "license": "Apache-2.0",
   "type": "module",
-  "version": "0.6.0-rc.1",
+  "version": "0.6.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/michelangelo-ai/michelangelo"
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.2.5",
-    "@michelangelo-ai/core": "0.6.0-rc.1"
+    "@michelangelo-ai/core": "0.6.0"
   },
   "exports": {
     ".": {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "michelangelo"
-version = "0.6.0-rc.1"
+version = "0.6.0"
 description = "Michelangelo AI is an end-to-end model lifecycle management system at large scale"
 authors = ["Michelangelo AI Team <michelangelo-oss-group@uber.com>"]
 readme = "README.md"


### PR DESCRIPTION
Strips the RC suffix and sets the final v0.6.0 version across all components.

## Why manual, not release-promote.yml
`release-promote.yml`'s "Strip RC suffix and set final version" step pushes
directly to `release/v0.6`, which this repo's branch ruleset rejects
unconditionally — `bypass_actors: []`, `current_user_can_bypass: never`.
Confirmed via `gh api repos/.../rulesets/19126671`: **no actor** (not
`github-actions[bot]`, not a PAT, not an admin) can push directly to a
protected branch here. `release-promote.yml` has a 0/5 historical success
rate for exactly this reason (not a flake). Filing a real fix separately;
this PR unblocks promoting v0.6.0 today the same way v0.4.0 was promoted.

## Changes
- python/pyproject.toml, javascript/*/package.json, helm Chart.yaml/appVersion: 0.6.0-rc.1 → 0.6.0

## After merge
Tag `v0.6.0` on `release/v0.6`'s new tip and manually trigger the same
artifact-publish workflows `release-promote.yml` would have (release.yaml,
changelog.yml, ui-release.yml, dev-release.yml, npm-publish.yml).