### PR TITLE
fix(ci): fix Go and Python lint and test checks for fork PRs

### DIFF
--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Coverage report PR comment
         uses: marocchino/sticky-pull-request-comment@v2
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         with:
           header: go-coverage
           message: |

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -25,12 +25,12 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24.3'
           cache-dependency-path: go/go.sum
 
       - name: Install golangci-lint
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.62.2
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.8
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
       - name: Run golangci-lint
@@ -80,7 +80,7 @@ jobs:
 
       - name: Comment on PR with results
         uses: actions/github-script@v7
-        if: always()
+        if: always() && github.event.pull_request.head.repo.full_name == github.repository
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       #----------------------------------------------
       #  Setup Python and Poetry using composite action
@@ -41,7 +41,9 @@ jobs:
       - name: Get base SHA for comparison
         id: get-base-sha
         run: |
-          echo "BASE_SHA=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_ENV"
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          git fetch --no-tags --depth=1 origin "$BASE_SHA"
+          echo "BASE_SHA=$BASE_SHA" >> "$GITHUB_ENV"
 
       - name: Get changed files
         id: changed-files

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,21 +22,10 @@ jobs:
         working-directory: ./python
 
     steps:
-      - name: Checkout base branch
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.base_ref }}
-
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 50      # Fetch 50 max commits in single PR
-
-      - name: Fetch base branch
-        run: git fetch origin ${{ github.base_ref }}
-
-      - name: Check branch list
-        run: git branch -av
+          fetch-depth: 0
 
       #----------------------------------------------
       #  Setup Python and Poetry using composite action
@@ -52,8 +41,7 @@ jobs:
       - name: Get base SHA for comparison
         id: get-base-sha
         run: |
-          BASE_SHA=$(git merge-base origin/${{ github.base_ref }} HEAD)
-          echo "BASE_SHA=$BASE_SHA" >> $GITHUB_ENV
+          echo "BASE_SHA=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_ENV"
 
       - name: Get changed files
         id: changed-files
@@ -107,7 +95,7 @@ jobs:
 
       - name: Comment on PR with Ruff results
         uses: actions/github-script@v6
-        if: env.CHANGED_FILES != ''
+        if: env.CHANGED_FILES != '' && github.event.pull_request.head.repo.full_name == github.repository
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

Fixed three CI failures affecting pull requests opened from forks:

- Updated the Go lint workflow to use Go 1.24.3 and golangci-lint v1.64.8 to prevent a silent failure in the CI [EXAMPLE](https://github.com/michelangelo-ai/michelangelo/actions/runs/30036049055/job/89304177771).
- Simplified the Python workflow to use a full-history checkout and compare changed files against
`github.event.pull_request.base.sha`.
- Prevented the Go lint, Python Ruff, and Go coverage workflows from attempting to post PR
comments when the pull request originates from a fork.

Linting, test, coverage, artifact, and job-summary behavior remains unchanged.

<!-- Tell your future self why have you made these changes -->
**Why?**
GitHub intentionally restricts GITHUB_TOKEN to read-only for public fork PRs, so workflow-level pull-requests: write permissions cannot authorize comments. [Source](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflows-in-forked-repositories)

PR #1605 exposed three workflow infrastructure problems unrelated to its application changes:

1. The Go lint workflow used golangci-lint v1.62.2, built with Go 1.23, while the repository
targets Go 1.24.3. The linter refused to load the project before checking any code.
2. The Python workflow failed while running `git merge-base origin/main HEAD`, before Ruff was
executed.
3. Fork PRs receive a read-only `GITHUB_TOKEN`. The Go lint and Go coverage jobs failed with HTTP
403 when trying to post comments. The Python workflow had the same issue whenever Ruff produced
reportable output.

In the Go coverage job, the Bazel tests and coverage calculation completed successfully, with 63%
coverage against the 60% baseline. Only the subsequent PR-comment step failed.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Ran `actionlint` against all three modified workflow files.
- Verified golangci-lint v1.64.8 is built with Go 1.24.1 and runs against the repository using Go
1.24.3 without the previous toolchain-version error.
- Verified the Python changed-file logic against PR #1605 and confirmed it selects:
  `michelangelo/uniflow/plugins/ray/tests/ray_cluster_spec_test.py`
- Verified a workflow-only change selects no Python files.
- Verified the existing Go TODO-link check still passes.
- Ran `git diff --check` and the repository pre-commit hooks.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- Fork PRs will no longer receive automated lint or coverage comments. Results remain available in
workflow logs, job summaries, and coverage artifacts.
- Full-history checkout may slightly increase checkout time and network usage in the Python
workflow.
- The existing golangci-lint v1 configuration produces deprecation warnings, but migrating to v2
is intentionally outside this focused compatibility fix.

<!-- Does this PR introduce a breaking change? Check all that apply. -->
**Breaking Changes**

- [X] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

> If any breaking change box is checked (other than "No breaking changes"), you **must**:
> 1. Use the `BREAKING CHANGE:` footer **or** the `!` suffix (e.g. `feat!:`) in your commit message — see [Commit Messages](../CONTRIBUTING.md#commit-messages).
> 2. Fill in the **Migration guide** section below with step-by-step upgrade instructions.

<!-- Required only if a breaking change box above is checked. Delete this section if no breaking changes. -->
**Migration guide**

_Describe the steps an operator or downstream consumer must take to upgrade. Include before/after examples for any API, config, or schema change._

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
