### PR TITLE
ci(integration-test): trigger only from Nightly Build

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -2,7 +2,7 @@ name: Integration tests
 
 on:
   workflow_run:
-    workflows: ["Build examples Docker image", "Nightly Build"]
+    workflows: ["Nightly Build"]
     types: [completed]
   workflow_dispatch:
     inputs:
@@ -31,8 +31,6 @@ on:
         required: false
         type: string
         default: "main"
-  schedule:
-    - cron: "0 3 * * *"   # 03:00 UTC every day
 
 jobs:
   sandbox-e2e:


### PR DESCRIPTION
## Summary

`integration-test.yaml` was firing far more often than its declared daily schedule + occasional manual dispatch would suggest — 71 of its last 100 runs were `workflow_run`-triggered.

Root cause: it was set to run on completion of **either** `Build examples Docker image` **or** `Nightly Build`, with no branch filter. `Build examples Docker image` triggers on `pull_request` (not just `push` to `main`) with broad path filters (`python/examples/**`, `python/pyproject.toml`, `python/poetry.lock`), and pushes to GHCR unconditionally even on PR runs. In practice, 88 of its own last 100 runs were `pull_request`-triggered — dominated by long-lived release-process branches getting pushed to repeatedly, each commit re-triggering the image build (release commits routinely touch `pyproject.toml`). Every one of those completions then fanned out into a full ~30-90 minute GCP sandbox e2e run, regardless of whether `main` had actually changed.

## What changed

- `integration-test.yaml`'s `workflow_run` trigger now only listens for `Nightly Build`.
- Removed the workflow's own separate `schedule: "0 3 * * *"` — now redundant, since `Nightly Build`'s own daily schedule (`02:00 UTC`) provides the same cadence via the `workflow_run` chain.
- `workflow_dispatch` and `workflow_call` are unchanged, so manual/programmatic runs still work exactly as before.

## Why this is safe

- No change to what the job actually does — only to what triggers it.
- `Nightly Build` remains a real, working trigger path (already exercised daily).
- Manual triggering (`workflow_dispatch`) and being called from other workflows (`workflow_call`) are untouched.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — YAML parses cleanly.
- [x] `actionlint .github/workflows/integration-test.yaml` — only pre-existing findings (confirmed identical against `main`), nothing introduced by this diff.
- [x] `git diff` shows exactly the intended two changes (trigger list, removed schedule block) — no other lines touched.
- [ ] Post-merge: confirm `workflow_run`-triggered volume drops to roughly one run per day, matching `Nightly Build`'s cadence, instead of the current PR-driven fan-out.