### PR TITLE
feat(trainer): re-introduce profiler subsystem (PR 5)

### DIFF
--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/__init__.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/__init__.py
@@ -18,8 +18,13 @@ Public surface re-exported below:
   schema types consumed by the trainer.
 * :class:`ExperimentStore` — pluggable auto-resume seam;
   :class:`FsspecExperimentStore` is the filesystem default.
+* :func:`comet_profiler_sink` — ready-made ``LightningTrainerParam.profiler_sink``
+  that ships profiler output to a Comet experiment.
 """
 
+from michelangelo.lib.trainer.torch.pytorch_lightning._private.util import (
+    comet_profiler_sink,
+)
 from michelangelo.lib.trainer.torch.pytorch_lightning.experiment_store import (
     FsspecExperimentStore,
 )
@@ -50,4 +55,5 @@ __all__ = [
     "TrainingObserver",
     "TrainingType",
     "TransferLearningSpec",
+    "comet_profiler_sink",
 ]

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/_private/util.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/_private/util.py
@@ -536,6 +536,16 @@ def _compute_steps_per_epoch(
        accumulate_grad_batches`` (``max_steps`` counts optimizer steps, the
        estimate counts mini-batches).
 
+    The division by ``world_size`` assumes each worker iterates roughly
+    ``1 / world_size`` of the rows. That holds for every configuration this
+    trainer supports: the split is performed by Ray Train's default
+    ``DataConfig`` (``datasets_to_split="all"``), which shards the dataset
+    evenly across workers before the Lightning strategy sees it, so it is
+    unaffected by the choice of DDP / FSDP / DeepSpeed. A caller supplying a
+    custom ``Strategy`` under which several workers form one model replica and
+    must therefore see identical batches would break the assumption, and the
+    estimate would then be low by the replication factor.
+
     Args:
         trainer_kwargs: Keyword arguments destined for ``pl.Trainer``. Read
             only; ``limit_train_batches``, ``max_steps``, and

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/_private/util.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/_private/util.py
@@ -64,7 +64,14 @@ _MAX_PROFILER_ACTIVE_STEPS = 10
 _MAX_PROFILER_REPEAT = 3
 
 # Shorthand strings accepted in place of a full profiler config dict.
-_PROFILER_SHORTHANDS = ("simple", "advanced", "pytorch", "xla")
+#
+# Only ``pytorch`` is supported today — Michelangelo OSS is PyTorch-heavy, and
+# the other Lightning profilers (simple / advanced / xla) and a custom-class
+# escape hatch add config surface without a concrete user yet. The dict shape
+# (``{"pytorch": {...}, "upload_to_comet": ...}``) is kept as-is so adding a
+# second backend later, as we expand to more platforms, is additive rather
+# than a breaking config change.
+_PROFILER_SHORTHANDS = ("pytorch",)
 
 # Directory (under the worker's cwd) that every profiler writes its output to.
 # Fixed rather than temporary so a profiler sink can find the results after
@@ -765,6 +772,9 @@ def _build_profiler(
 ) -> tuple[pl.profilers.Profiler | None, str]:
     """Build a Lightning profiler from a user-supplied profiler config.
 
+    Only the ``pytorch`` profiler is currently supported (Michelangelo OSS is
+    PyTorch-heavy); more backends can be added as the platform expands.
+
     Every profiler writes into a fixed ``profiler_logs`` directory under the
     worker's current working directory, so a profiler sink can locate the
     results after training. Traces are named per world rank; Lightning's
@@ -774,21 +784,16 @@ def _build_profiler(
         profiler_config: One of
 
             * ``None`` — no profiler.
-            * A shorthand string: ``"simple"``, ``"advanced"``, ``"pytorch"``,
-              or ``"xla"``, equivalent to that key mapped to ``{}``.
-            * A dict setting exactly one of ``simple``, ``advanced``,
-              ``pytorch``, ``xla``, or ``custom`` to a kwargs dict. The
-              ``simple`` / ``advanced`` / ``xla`` kwargs are forwarded verbatim
-              to the corresponding Lightning profiler; ``pytorch`` is handled by
-              :func:`_build_pytorch_profiler`; ``custom`` takes
-              ``profiler_class`` (a dotted path to a ``pl.profilers.Profiler``
-              subclass) and optional ``profiler_kwargs``.
+            * The shorthand string ``"pytorch"``, equivalent to
+              ``{"pytorch": {}}``.
+            * A dict setting ``pytorch`` to a kwargs dict, handled by
+              :func:`_build_pytorch_profiler`.
 
             ``upload_to_comet`` is reserved metadata read by
             :func:`_resolve_profiler` and is never forwarded to a profiler
             constructor.
-        steps_per_epoch: Estimated steps per epoch, used only by the
-            ``pytorch`` branch to derive or validate a schedule.
+        steps_per_epoch: Estimated steps per epoch, used to derive or
+            validate the profiler's schedule.
 
     Returns:
         A ``(profiler, profiler_logs_path)`` tuple. Both are ``None`` / ``""``
@@ -797,9 +802,7 @@ def _build_profiler(
     Raises:
         TypeError: If ``profiler_config`` is neither a str, dict, nor ``None``.
         ValueError: If a shorthand string is not a recognized profiler name.
-        UserInputError: If the dict sets zero or more than one profiler, or if
-            ``custom`` resolves to something that is not a Lightning
-            ``Profiler`` subclass.
+        UserInputError: If the dict sets zero or more than one profiler.
     """
     if profiler_config is None:
         return None, ""
@@ -817,19 +820,17 @@ def _build_profiler(
 
     # Exactly one profiler flavor must be selected.
     selected = [
-        name
-        for name in ("simple", "advanced", "pytorch", "xla", "custom")
-        if profiler_config.get(name) is not None
+        name for name in _PROFILER_SHORTHANDS if profiler_config.get(name) is not None
     ]
     if not selected:
         raise UserInputError(
-            "Profiler config must set exactly one of: simple, advanced, "
-            "pytorch, xla, custom. None were set."
+            "Profiler config must set exactly one of: "
+            f"{', '.join(_PROFILER_SHORTHANDS)}. None were set."
         )
     if len(selected) > 1:
         raise UserInputError(
-            "Profiler config must set exactly one of: simple, advanced, "
-            f"pytorch, xla, custom. Multiple were set: {selected}."
+            "Profiler config must set exactly one of: "
+            f"{', '.join(_PROFILER_SHORTHANDS)}. Multiple were set: {selected}."
         )
 
     profiler_type = selected[0]
@@ -846,39 +847,8 @@ def _build_profiler(
     # Lightning's Profiler base class appends the local rank to this filename.
     filename = f"profile-world-rank-{world_rank}-local-rank"
 
-    from pytorch_lightning.profilers import (
-        AdvancedProfiler,
-        SimpleProfiler,
-        XLAProfiler,
-    )
-
-    if profiler_type == "simple":
-        return SimpleProfiler(
-            dirpath=profiler_logs_path, filename=filename, **profiler_kwargs
-        ), profiler_logs_path
-    if profiler_type == "advanced":
-        return AdvancedProfiler(
-            dirpath=profiler_logs_path, filename=filename, **profiler_kwargs
-        ), profiler_logs_path
-    if profiler_type == "pytorch":
-        return _build_pytorch_profiler(
-            profiler_logs_path, filename, profiler_kwargs, steps_per_epoch
-        ), profiler_logs_path
-    if profiler_type == "xla":
-        return XLAProfiler(**profiler_kwargs), profiler_logs_path
-
-    profiler_class = profiler_kwargs.get("profiler_class")
-    profiler_cls = get_module_attr(profiler_class)
-    if not (
-        isinstance(profiler_cls, type)
-        and issubclass(profiler_cls, pl.profilers.Profiler)
-    ):
-        raise UserInputError(
-            f"Custom profiler class {profiler_class!r} must be a subclass of "
-            f"pytorch_lightning.profilers.Profiler, got {profiler_cls!r}."
-        )
-    return profiler_cls(
-        **(profiler_kwargs.get("profiler_kwargs") or {})
+    return _build_pytorch_profiler(
+        profiler_logs_path, filename, profiler_kwargs, steps_per_epoch
     ), profiler_logs_path
 
 

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/_private/util.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/_private/util.py
@@ -7,9 +7,11 @@ logger / callback resolution helpers. Public APIs live in
 
 from __future__ import annotations
 
+import glob
 import hashlib
 import inspect
 import logging
+import math
 import os
 import re
 from tempfile import TemporaryDirectory
@@ -54,6 +56,20 @@ _PLUGIN_INPUT = Union[Precision, ClusterEnvironment, CheckpointIO, LayerSync]
 
 CALLBACK_REPORT_PER_NODE = "callback_report_per_node"
 CHECKPOINT_FILENAME = "checkpoint.ckpt"
+
+# Upper bounds on the ``torch.profiler`` schedule. Both windows multiply the
+# volume of trace data written per worker, and traces are large; these caps
+# keep a mis-typed config from filling the run's storage.
+_MAX_PROFILER_ACTIVE_STEPS = 10
+_MAX_PROFILER_REPEAT = 3
+
+# Shorthand strings accepted in place of a full profiler config dict.
+_PROFILER_SHORTHANDS = ("simple", "advanced", "pytorch", "xla")
+
+# Directory (under the worker's cwd) that every profiler writes its output to.
+# Fixed rather than temporary so a profiler sink can find the results after
+# ``trainer.fit()`` returns.
+_PROFILER_LOGS_DIRNAME = "profiler_logs"
 
 _logger = logging.getLogger(__name__)
 
@@ -501,6 +517,488 @@ def _resolve_callbacks(
     return resolved_callbacks, has_model_checkpoint
 
 
+def _compute_steps_per_epoch(
+    trainer_kwargs: dict,
+    dataset_num_rows: int | None,
+    batch_size: int,
+    world_size: int = 1,
+) -> int | None:
+    """Estimate the number of training steps per epoch, per worker.
+
+    The estimate starts at ``ceil(dataset_num_rows / world_size / batch_size)``
+    and then applies Lightning's batch-limiting arguments in the same order
+    Lightning itself does:
+
+    1. ``limit_train_batches`` — a float in ``[0.0, 1.0]`` scales the epoch
+       proportionally; an int ``>= 1`` caps it at that many batches.
+    2. ``max_steps`` — when set, training stops there regardless of epoch
+       length, so the estimate is capped at ``max_steps *
+       accumulate_grad_batches`` (``max_steps`` counts optimizer steps, the
+       estimate counts mini-batches).
+
+    Args:
+        trainer_kwargs: Keyword arguments destined for ``pl.Trainer``. Read
+            only; ``limit_train_batches``, ``max_steps``, and
+            ``accumulate_grad_batches`` are consulted if present.
+        dataset_num_rows: Total rows in the (unsharded) training dataset, or
+            ``None`` when the row count could not be determined.
+        batch_size: Per-worker batch size.
+        world_size: Number of training workers the dataset is sharded across.
+
+    Returns:
+        The estimated number of steps in one epoch on one worker, or ``None``
+        when ``dataset_num_rows`` is ``None``.
+
+    Raises:
+        ValueError: If ``batch_size`` or ``world_size`` is not positive, or if
+            ``limit_train_batches`` / ``accumulate_grad_batches`` hold values
+            Lightning would not accept.
+    """
+    if dataset_num_rows is None:
+        return None
+    if batch_size <= 0:
+        raise ValueError(f"batch_size must be a positive integer, got {batch_size}.")
+    if world_size <= 0:
+        raise ValueError(f"world_size must be a positive integer, got {world_size}.")
+    if dataset_num_rows == 0:
+        _logger.warning("dataset_num_rows is 0; steps_per_epoch will be 0.")
+
+    steps_per_epoch = math.ceil(dataset_num_rows / world_size / batch_size)
+
+    limit_train_batches = trainer_kwargs.get("limit_train_batches")
+    if limit_train_batches is not None:
+        if isinstance(limit_train_batches, float) and 0.0 <= limit_train_batches <= 1.0:
+            steps_per_epoch = int(steps_per_epoch * limit_train_batches)
+        elif type(limit_train_batches) is int and limit_train_batches >= 1:
+            steps_per_epoch = min(steps_per_epoch, limit_train_batches)
+        else:
+            raise ValueError(
+                f"Invalid limit_train_batches: {limit_train_batches!r}. "
+                "Must be a float in [0.0, 1.0] or an int >= 1."
+            )
+
+    max_steps = trainer_kwargs.get("max_steps", -1)
+    if max_steps is not None and max_steps > 0:
+        accumulate_grad_batches = trainer_kwargs.get("accumulate_grad_batches", 1)
+        if not (
+            isinstance(accumulate_grad_batches, int) and accumulate_grad_batches >= 1
+        ):
+            raise ValueError(
+                f"Invalid accumulate_grad_batches: {accumulate_grad_batches!r}. "
+                "Must be an int >= 1."
+            )
+        return min(max_steps * accumulate_grad_batches, steps_per_epoch)
+
+    return steps_per_epoch
+
+
+def _compute_default_schedule(steps_per_epoch: int | None = None) -> dict:
+    """Compute a default ``torch.profiler`` schedule for an epoch of *n* steps.
+
+    ``wait`` scales with the step count so profiling starts once throughput has
+    stabilized. ``warmup`` and ``active`` are small fixed windows (2 and 3
+    steps), shrunk only when the epoch is too short to fit them after the wait.
+
+    ==========================  ====  ======  ======
+    steps_per_epoch             wait  warmup  active
+    ==========================  ====  ======  ======
+    ``None`` or 1               0     0       1
+    2                           1     0       1
+    5                           1     2       2
+    N (N >= 7)                  N//3  2       3
+    ==========================  ====  ======  ======
+
+    Args:
+        steps_per_epoch: Estimated steps in one epoch on one worker, or
+            ``None`` when unknown.
+
+    Returns:
+        A kwargs dict for ``torch.profiler.schedule`` with ``skip_first``,
+        ``wait``, ``warmup``, ``active``, and ``repeat``.
+    """
+    n = steps_per_epoch
+    if n is None or n <= 1:
+        return {"skip_first": 0, "wait": 0, "warmup": 0, "active": 1, "repeat": 1}
+    if n == 2:
+        return {"skip_first": 0, "wait": 1, "warmup": 0, "active": 1, "repeat": 1}
+    # Wait out the first third of the epoch so the profile reflects steady state.
+    wait = n // 3
+    remaining_steps = n - wait
+    warmup = min(2, remaining_steps - 1)  # leave at least 1 step for active
+    active = min(3, remaining_steps - warmup)
+    return {
+        "skip_first": 0,
+        "wait": wait,
+        "warmup": warmup,
+        "active": active,
+        "repeat": 1,
+    }
+
+
+def _validate_profiler_schedule(
+    schedule_config: dict, steps_per_epoch: int | None
+) -> None:
+    """Validate that a user-supplied profiler schedule fits within one epoch.
+
+    Args:
+        schedule_config: Kwargs for ``torch.profiler.schedule``; recognizes
+            ``skip_first``, ``wait``, ``warmup``, ``active``, and ``repeat``.
+        steps_per_epoch: Estimated steps in one epoch on one worker. When
+            ``None`` the per-epoch bounds check is skipped and only the
+            individual field ranges are enforced.
+
+    Returns:
+        ``None``.
+
+    Raises:
+        UserInputError: If any field is out of range, or if the schedule would
+            need more steps than a single epoch provides.
+    """
+    skip_first = schedule_config.get("skip_first", 0)
+    wait = schedule_config.get("wait", 0)
+    warmup = schedule_config.get("warmup", 0)
+    active = schedule_config.get("active", 1)
+    repeat = schedule_config.get("repeat", 1)
+
+    for name, value in (
+        ("skip_first", skip_first),
+        ("wait", wait),
+        ("warmup", warmup),
+    ):
+        if value < 0:
+            raise UserInputError(
+                f"Profiler schedule {name!r} must be non-negative, got {value}."
+            )
+
+    if not 1 <= active <= _MAX_PROFILER_ACTIVE_STEPS:
+        raise UserInputError(
+            f"Profiler schedule 'active' must be between 1 and "
+            f"{_MAX_PROFILER_ACTIVE_STEPS}, got {active}. Large active windows "
+            "can generate extremely large profiler trace files."
+        )
+    if not 1 <= repeat <= _MAX_PROFILER_REPEAT:
+        raise UserInputError(
+            f"Profiler schedule 'repeat' must be between 1 and "
+            f"{_MAX_PROFILER_REPEAT}, got {repeat}. Large repeat values can "
+            "generate extremely large profiler trace files; a repeat of 1 is "
+            "recommended."
+        )
+
+    cycle_length = wait + warmup + active
+    total_profiled_steps = cycle_length * repeat + skip_first
+    if steps_per_epoch is not None and total_profiled_steps > steps_per_epoch:
+        raise UserInputError(
+            f"Profiler schedule requests {total_profiled_steps} steps "
+            f"(({wait} wait + {warmup} warmup + {active} active) * {repeat} "
+            f"repeat + {skip_first} skip_first) but each epoch only has "
+            f"{steps_per_epoch} steps. Reduce wait, warmup, active, and/or "
+            "repeat so that ((wait + warmup + active) * repeat + skip_first) "
+            f"<= {steps_per_epoch}."
+        )
+
+
+def _build_pytorch_profiler(
+    dirpath: str,
+    filename: str,
+    kwargs: dict,
+    steps_per_epoch: int | None = None,
+) -> pl.profilers.Profiler:
+    """Build a ``PyTorchProfiler`` with a validated schedule and trace handler.
+
+    Args:
+        dirpath: Directory the profiler writes traces to.
+        filename: Base filename for this worker's trace.
+        kwargs: The ``pytorch`` sub-config. ``schedule`` (a
+            ``torch.profiler.schedule`` kwargs dict) and ``on_trace_ready`` (a
+            dotted path to a ``fn(prof) -> None`` callable) are consumed here;
+            everything else is forwarded to ``PyTorchProfiler``. Not mutated.
+        steps_per_epoch: Estimated steps per epoch, used to validate an
+            explicit schedule or to derive the default one.
+
+    Returns:
+        A configured ``PyTorchProfiler``.
+
+    Raises:
+        UserInputError: If an explicit ``schedule`` does not fit in one epoch.
+    """
+    from pytorch_lightning.profilers import PyTorchProfiler
+    from torch.profiler import schedule, tensorboard_trace_handler
+
+    kwargs = dict(kwargs)
+    schedule_kwargs = kwargs.pop("schedule", None) or {}
+    if schedule_kwargs:
+        _validate_profiler_schedule(schedule_kwargs, steps_per_epoch)
+    else:
+        schedule_kwargs = _compute_default_schedule(steps_per_epoch)
+
+    # on_trace_ready must resolve to a callable with signature
+    # fn(prof: torch.profiler.profile) -> None.
+    on_trace_ready_path = kwargs.pop("on_trace_ready", None)
+    on_trace_ready_fn = (
+        get_module_attr(on_trace_ready_path)
+        if on_trace_ready_path
+        else tensorboard_trace_handler(dir_name=dirpath)
+    )
+
+    return PyTorchProfiler(
+        dirpath=dirpath,
+        filename=filename,
+        schedule=schedule(**schedule_kwargs),
+        on_trace_ready=on_trace_ready_fn,
+        **kwargs,
+    )
+
+
+def _build_profiler(
+    profiler_config: dict | str | None,
+    steps_per_epoch: int | None = None,
+) -> tuple[pl.profilers.Profiler | None, str]:
+    """Build a Lightning profiler from a user-supplied profiler config.
+
+    Every profiler writes into a fixed ``profiler_logs`` directory under the
+    worker's current working directory, so a profiler sink can locate the
+    results after training. Traces are named per world rank; Lightning's
+    ``Profiler`` base class appends the local rank.
+
+    Args:
+        profiler_config: One of
+
+            * ``None`` — no profiler.
+            * A shorthand string: ``"simple"``, ``"advanced"``, ``"pytorch"``,
+              or ``"xla"``, equivalent to that key mapped to ``{}``.
+            * A dict setting exactly one of ``simple``, ``advanced``,
+              ``pytorch``, ``xla``, or ``custom`` to a kwargs dict. The
+              ``simple`` / ``advanced`` / ``xla`` kwargs are forwarded verbatim
+              to the corresponding Lightning profiler; ``pytorch`` is handled by
+              :func:`_build_pytorch_profiler`; ``custom`` takes
+              ``profiler_class`` (a dotted path to a ``pl.profilers.Profiler``
+              subclass) and optional ``profiler_kwargs``.
+
+            ``upload_to_comet`` is reserved metadata read by
+            :func:`_resolve_profiler` and is never forwarded to a profiler
+            constructor.
+        steps_per_epoch: Estimated steps per epoch, used only by the
+            ``pytorch`` branch to derive or validate a schedule.
+
+    Returns:
+        A ``(profiler, profiler_logs_path)`` tuple. Both are ``None`` / ``""``
+        when ``profiler_config`` is ``None``.
+
+    Raises:
+        TypeError: If ``profiler_config`` is neither a str, dict, nor ``None``.
+        ValueError: If a shorthand string is not a recognized profiler name.
+        UserInputError: If the dict sets zero or more than one profiler, or if
+            ``custom`` resolves to something that is not a Lightning
+            ``Profiler`` subclass.
+    """
+    if profiler_config is None:
+        return None, ""
+    if isinstance(profiler_config, str):
+        if profiler_config not in _PROFILER_SHORTHANDS:
+            raise ValueError(
+                f"Invalid profiler type: {profiler_config!r}. Valid types are: "
+                f"{', '.join(_PROFILER_SHORTHANDS)}."
+            )
+        profiler_config = {profiler_config: {}}
+    elif not isinstance(profiler_config, dict):
+        raise TypeError(
+            f"profiler_config must be a str, dict, or None, got {type(profiler_config)!r}"
+        )
+
+    # Exactly one profiler flavor must be selected.
+    selected = [
+        name
+        for name in ("simple", "advanced", "pytorch", "xla", "custom")
+        if profiler_config.get(name) is not None
+    ]
+    if not selected:
+        raise UserInputError(
+            "Profiler config must set exactly one of: simple, advanced, "
+            "pytorch, xla, custom. None were set."
+        )
+    if len(selected) > 1:
+        raise UserInputError(
+            "Profiler config must set exactly one of: simple, advanced, "
+            f"pytorch, xla, custom. Multiple were set: {selected}."
+        )
+
+    profiler_type = selected[0]
+    profiler_kwargs = profiler_config[profiler_type]
+
+    profiler_logs_path = os.path.join(os.getcwd(), _PROFILER_LOGS_DIRNAME)
+    os.makedirs(profiler_logs_path, exist_ok=True)
+    world_rank = ray.train.get_context().get_world_rank()
+    _logger.info(
+        "[profiler] [Rank %d] Writing profiler logs to %s",
+        world_rank,
+        profiler_logs_path,
+    )
+    # Lightning's Profiler base class appends the local rank to this filename.
+    filename = f"profile-world-rank-{world_rank}-local-rank"
+
+    from pytorch_lightning.profilers import (
+        AdvancedProfiler,
+        SimpleProfiler,
+        XLAProfiler,
+    )
+
+    if profiler_type == "simple":
+        return SimpleProfiler(
+            dirpath=profiler_logs_path, filename=filename, **profiler_kwargs
+        ), profiler_logs_path
+    if profiler_type == "advanced":
+        return AdvancedProfiler(
+            dirpath=profiler_logs_path, filename=filename, **profiler_kwargs
+        ), profiler_logs_path
+    if profiler_type == "pytorch":
+        return _build_pytorch_profiler(
+            profiler_logs_path, filename, profiler_kwargs, steps_per_epoch
+        ), profiler_logs_path
+    if profiler_type == "xla":
+        return XLAProfiler(**profiler_kwargs), profiler_logs_path
+
+    profiler_class = profiler_kwargs.get("profiler_class")
+    profiler_cls = get_module_attr(profiler_class)
+    if not (
+        isinstance(profiler_cls, type)
+        and issubclass(profiler_cls, pl.profilers.Profiler)
+    ):
+        raise UserInputError(
+            f"Custom profiler class {profiler_class!r} must be a subclass of "
+            f"pytorch_lightning.profilers.Profiler, got {profiler_cls!r}."
+        )
+    return profiler_cls(
+        **(profiler_kwargs.get("profiler_kwargs") or {})
+    ), profiler_logs_path
+
+
+def _resolve_profiler(
+    profiler_config: dict | str | None,
+    trainer_kwargs: dict,
+    dataset_num_rows: int | None,
+    batch_size: int,
+    world_sz: int,
+    rank: int,
+) -> tuple[pl.profilers.Profiler | None, str, bool]:
+    """Resolve the profiler for the Lightning Trainer.
+
+    Args:
+        profiler_config: The ``profiler`` entry popped from
+            ``lightning_trainer_kwargs``; see :func:`_build_profiler`.
+        trainer_kwargs: Remaining trainer kwargs. Read only, to estimate the
+            number of steps per epoch.
+        dataset_num_rows: Total rows in the training dataset, or ``None``.
+        batch_size: Per-worker batch size.
+        world_sz: Total number of training workers.
+        rank: This worker's global rank (logging only).
+
+    Returns:
+        A ``(profiler, profiler_logs_path, upload_results)`` tuple.
+        ``upload_results`` mirrors the config's ``upload_to_comet`` flag and
+        gates the post-``fit`` ``profiler_sink`` call; it defaults to ``True``
+        so callers must opt *out* of exporting results.
+    """
+    if profiler_config is None:
+        return None, "", False
+
+    upload_results = (
+        profiler_config.get("upload_to_comet", True)
+        if isinstance(profiler_config, dict)
+        else True
+    )
+    steps_per_epoch = _compute_steps_per_epoch(
+        trainer_kwargs, dataset_num_rows, batch_size, world_sz
+    )
+    _logger.info("[profiler] [Rank %d] Steps per epoch: %s", rank, steps_per_epoch)
+    profiler, profiler_logs_path = _build_profiler(profiler_config, steps_per_epoch)
+    return profiler, profiler_logs_path, upload_results
+
+
+def comet_profiler_sink(
+    profiler: pl.profilers.Profiler,
+    profiler_logs_path: str,
+    logger: Any,
+) -> None:
+    """Upload profiler output to a Comet experiment.
+
+    Ready-made ``LightningTrainerParam.profiler_sink`` for runs that log to
+    Comet via :func:`build_comet_logger`. ``PyTorchProfiler`` traces are in
+    TensorBoard format and go through ``log_tensorflow_folder``;
+    ``SimpleProfiler`` / ``AdvancedProfiler`` write text summaries that are
+    uploaded individually as assets. ``XLAProfiler`` and custom profilers are
+    not supported and are skipped with a log message.
+
+    Every upload is best-effort: a failure is logged and swallowed so a broken
+    export never fails an otherwise-successful training run.
+
+    Note:
+        Lightning decorates ``CometLogger.experiment`` with
+        ``@rank_zero_experiment``, so on any worker whose *global* rank is not 0
+        the property yields a no-op dummy experiment and uploads are silently
+        dropped. In a multi-node run this means only the node holding global
+        rank 0 actually exports its profile. Pass a custom sink that resolves
+        its own Comet experiment if per-node profiles are required.
+
+    Args:
+        profiler: The profiler built for this worker.
+        profiler_logs_path: Directory the profiler wrote its output to.
+        logger: The resolved Lightning logger. Must expose an ``experiment``
+            attribute holding a Comet experiment; anything else is skipped.
+
+    Returns:
+        ``None``.
+    """
+    from pytorch_lightning.profilers import (
+        AdvancedProfiler,
+        PyTorchProfiler,
+        SimpleProfiler,
+    )
+
+    experiment = getattr(logger, "experiment", None)
+    if experiment is None:
+        _logger.warning(
+            "comet_profiler_sink: logger %r has no Comet experiment; "
+            "skipping profiler upload.",
+            type(logger).__name__,
+        )
+        return
+
+    if isinstance(profiler, PyTorchProfiler):
+        try:
+            _logger.info(
+                "Uploading PyTorch profiler traces from %s to Comet",
+                profiler_logs_path,
+            )
+            experiment.log_tensorflow_folder(profiler_logs_path)
+        except Exception:
+            _logger.warning(
+                "Failed to upload PyTorch profiler traces to Comet", exc_info=True
+            )
+        return
+
+    if isinstance(profiler, (SimpleProfiler, AdvancedProfiler)):
+        txt_files = glob.glob(os.path.join(profiler_logs_path, "*.txt"))
+        if not txt_files:
+            _logger.warning("No profiler .txt files found in %s", profiler_logs_path)
+            return
+        for txt_file in txt_files:
+            try:
+                _logger.info("Uploading profiler log %s to Comet", txt_file)
+                experiment.log_asset(txt_file)
+            except Exception:
+                _logger.warning(
+                    "Failed to upload profiler log %s to Comet",
+                    txt_file,
+                    exc_info=True,
+                )
+        return
+
+    _logger.info(
+        "Uploading results for %s is not supported; skipping.",
+        type(profiler).__name__,
+    )
+
+
 def _maybe_track_experiment(train_loop_config: dict, rank: int) -> None:
     """Record this run's experiment directory via the configured ExperimentStore.
 
@@ -677,12 +1175,21 @@ def _train_loop_per_worker(train_loop_config):
         strategy,
         training_observer=train_loop_config.get("training_observer"),
     )
+    profiler, profiler_logs_path, upload_profiler_results = _resolve_profiler(
+        trainer_kwargs.pop("profiler", None),
+        trainer_kwargs,
+        train_loop_config.get("train_dataset_num_rows"),
+        batch_size,
+        world_sz,
+        rank,
+    )
 
     # Update trainer_kwargs with the resolved arguments for the Lightning Trainer.
     trainer_kwargs["strategy"] = strategy
     trainer_kwargs["plugins"] = plugins
     trainer_kwargs["logger"] = logger
     trainer_kwargs["callbacks"] = callbacks
+    trainer_kwargs["profiler"] = profiler
     trainer_kwargs["enable_checkpointing"] = (
         has_model_checkpoint  # enable_checkpointing must be set to True if a ModelCheckpoint callback is used
     )
@@ -723,3 +1230,53 @@ def _train_loop_per_worker(train_loop_config):
         val_dataloaders=val_dataloader,
         ckpt_path=ckpt_path,
     )
+
+    _maybe_export_profiler_results(
+        profiler,
+        profiler_logs_path,
+        logger,
+        upload_profiler_results,
+        train_loop_config.get("profiler_sink"),
+    )
+
+
+def _maybe_export_profiler_results(
+    profiler: pl.profilers.Profiler | None,
+    profiler_logs_path: str,
+    logger: Any,
+    upload_profiler_results: bool,
+    profiler_sink: Any,
+) -> None:
+    """Hand this worker's profiler output to the configured sink, if any.
+
+    Called once per worker after ``trainer.fit()`` returns. Runs only on
+    node-local rank 0: every profiler writes into a ``profiler_logs`` directory
+    under the worker's cwd, which is shared by all workers on a node, so one
+    call per node exports that node's whole directory exactly once.
+
+    Best-effort — a sink that raises is logged and swallowed, since profiling
+    is an observability feature and must not fail a completed training run.
+
+    Args:
+        profiler: The profiler built for this worker, or ``None``.
+        profiler_logs_path: Directory the profiler wrote its output to.
+        logger: The resolved Lightning logger, forwarded to the sink so it can
+            attach results to the active experiment.
+        upload_profiler_results: The config's ``upload_to_comet`` flag; when
+            ``False`` the sink is not called.
+        profiler_sink: The user-supplied
+            ``Callable[[Profiler, str, logger], None]``, or ``None``.
+
+    Returns:
+        ``None``.
+    """
+    if profiler is None or not upload_profiler_results or profiler_sink is None:
+        return
+    if ray.train.get_context().get_local_rank() != 0:
+        return
+    try:
+        profiler_sink(profiler, profiler_logs_path, logger)
+    except Exception:
+        _logger.warning(
+            "profiler_sink raised; profiler results not exported", exc_info=True
+        )

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/lightning_trainer.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/lightning_trainer.py
@@ -117,6 +117,17 @@ class LightningTrainerParam:
             ``None`` (no tracking, no store-driven resume). Use
             :class:`~experiment_store.FsspecExperimentStore` for the filesystem
             default. Must be picklable (serialized to workers for tracking).
+        profiler_sink: Optional callable invoked on each node-local rank 0
+            after ``fit()`` returns, as
+            ``profiler_sink(profiler, profiler_logs_path, logger)``, where
+            ``profiler`` is the profiler built from
+            ``lightning_trainer_kwargs["profiler"]``, ``profiler_logs_path`` is
+            the directory it wrote to, and ``logger`` is the resolved Lightning
+            logger. Use it to ship profiler output to an experiment tracker;
+            :func:`~_private.util.comet_profiler_sink` does this for Comet.
+            Ignored when no profiler is configured or when the profiler config
+            sets ``upload_to_comet: False``. Exceptions raised by the sink are
+            logged and swallowed. Must be picklable (serialized to workers).
     """
 
     create_model_fn: Callable
@@ -136,6 +147,7 @@ class LightningTrainerParam:
     initial_weights_path: str | None = None
     training_observer: TrainingObserver | None = None
     experiment_store: ExperimentStore | None = None
+    profiler_sink: Callable | None = None
 
     def __post_init__(self):
         """Apply default ``num_epochs`` and warn on the deprecated field usage."""
@@ -175,6 +187,29 @@ class LightningTrainer(TorchTrainer):
         # Pop out train and val data since we have to pass them into datasets parameter of TorchTrainer.
         train_data = train_loop_config.pop("train_data")
         val_data = train_loop_config.pop("val_data")
+
+        # A configured profiler needs an estimate of steps-per-epoch to derive
+        # (or validate) its sampling schedule, which needs the training row
+        # count. Only pay for it when a profiler is actually requested: count()
+        # reads Parquet metadata for read_parquet-backed datasets, but any other
+        # lineage forces execution of the dataset's lazy transformations.
+        # Counted off trainer_param rather than the popped train_data, which
+        # asdict() has already deep-copied.
+        profiler_config = (train_loop_config.get("lightning_trainer_kwargs") or {}).get(
+            "profiler"
+        )
+        if profiler_config is not None:
+            try:
+                train_loop_config["train_dataset_num_rows"] = (
+                    trainer_param.train_data.count()
+                )
+            except Exception:
+                _logger.warning(
+                    "Could not determine the training dataset size; the profiler "
+                    "schedule will fall back to its unbounded default.",
+                    exc_info=True,
+                )
+                train_loop_config["train_dataset_num_rows"] = None
         # Pop training_observer — Protocol instances can't survive asdict()
         # because it recursively converts nested objects. We store the original
         # object on self for driver-side use and re-inject it into

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_lightning_trainer.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_lightning_trainer.py
@@ -777,3 +777,69 @@ class TestTrainRunConfigOverride:
             trainer.train(run_config=_run_config(name="different"))
 
         assert not any("re-trigger" in r.message for r in caplog.records)
+
+
+# -----------------------------------------------------------------------------
+# Profiler wiring (driver side)
+# -----------------------------------------------------------------------------
+
+
+class TestProfilerRowCounting:
+    """Driver-side training-row counting that feeds the profiler schedule."""
+
+    def _loop_config(self, param):
+        """Construct a trainer with ``TorchTrainer.__init__`` stubbed out."""
+        with patch(
+            "michelangelo.lib.trainer.torch.pytorch_lightning."
+            "lightning_trainer.TorchTrainer.__init__",
+            return_value=None,
+        ) as mock_super:
+            LightningTrainer(trainer_param=param)
+        return mock_super.call_args.kwargs["train_loop_config"]
+
+    def test_rows_not_counted_without_a_profiler(self):
+        """No profiler config means the (potentially expensive) count is skipped."""
+        train_ds = MagicMock(name="train")
+        loop_cfg = self._loop_config(_make_param(train_data=train_ds))
+
+        train_ds.count.assert_not_called()
+        assert "train_dataset_num_rows" not in loop_cfg
+
+    def test_rows_counted_when_a_profiler_is_configured(self):
+        """A profiler config triggers the count and threads it to the worker."""
+        train_ds = MagicMock(name="train")
+        train_ds.count.return_value = 4096
+        param = _make_param(
+            train_data=train_ds, lightning_trainer_kwargs={"profiler": "simple"}
+        )
+
+        loop_cfg = self._loop_config(param)
+
+        train_ds.count.assert_called_once_with()
+        assert loop_cfg["train_dataset_num_rows"] == 4096
+
+    def test_count_failure_falls_back_to_none(self):
+        """A dataset that cannot be counted degrades to an unknown row count."""
+        train_ds = MagicMock(name="train")
+        train_ds.count.side_effect = RuntimeError("cannot count")
+        param = _make_param(
+            train_data=train_ds, lightning_trainer_kwargs={"profiler": {"pytorch": {}}}
+        )
+
+        loop_cfg = self._loop_config(param)
+
+        assert loop_cfg["train_dataset_num_rows"] is None
+
+    def test_profiler_sink_defaults_to_none(self):
+        """``profiler_sink`` is optional."""
+        assert _make_param().profiler_sink is None
+
+    def test_profiler_sink_reaches_the_worker_config(self):
+        """A plain callable survives ``asdict()`` and is threaded to workers."""
+
+        def my_sink(profiler, profiler_logs_path, logger):
+            """Test sink."""
+
+        loop_cfg = self._loop_config(_make_param(profiler_sink=my_sink))
+
+        assert loop_cfg["profiler_sink"] is my_sink

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_profiler.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_profiler.py
@@ -1,8 +1,8 @@
 """Tests for the profiler subsystem in ``_private/util.py``.
 
-Covers step-count estimation, profiler construction for every supported
-flavor, schedule defaults and validation, config resolution, and the
-post-``fit`` ``profiler_sink`` hook.
+Covers step-count estimation, ``pytorch`` profiler construction, schedule
+defaults and validation, config resolution, and the post-``fit``
+``profiler_sink`` hook.
 
 ``ray.train.get_context`` is mocked throughout so the helpers run without a
 Ray cluster.
@@ -23,9 +23,9 @@ pl = pytest.importorskip("pytorch_lightning")
 
 from pytorch_lightning.profilers import (  # noqa: E402
     AdvancedProfiler,
-    Profiler,
     PyTorchProfiler,
     SimpleProfiler,
+    XLAProfiler,
 )
 
 from michelangelo.lib._internal.errors import UserInputError  # noqa: E402
@@ -40,25 +40,6 @@ from michelangelo.lib.trainer.torch.pytorch_lightning._private.util import (  # 
 )
 
 _UTIL_MODULE = "michelangelo.lib.trainer.torch.pytorch_lightning._private.util"
-
-
-class _CustomProfiler(Profiler):
-    """Minimal ``Profiler`` subclass used to exercise the ``custom`` branch."""
-
-    def __init__(self, tag: str = "x"):
-        """Record ``tag`` so tests can assert kwargs were forwarded."""
-        super().__init__()
-        self.tag = tag
-
-    def start(self, action_name: str) -> None:
-        """No-op start hook."""
-
-    def stop(self, action_name: str) -> None:
-        """No-op stop hook."""
-
-
-class _NotAProfiler:
-    """Plain class used to assert the ``custom`` subclass check rejects it."""
 
 
 @pytest.fixture
@@ -294,39 +275,24 @@ class TestValidateProfilerSchedule:
 
 
 class TestBuildProfiler:
-    """Construction of each profiler flavor and its config validation."""
+    """Construction of the ``pytorch`` profiler and its config validation."""
 
     def test_none_config_builds_nothing(self):
         """A ``None`` config yields no profiler and no logs path."""
         assert _build_profiler(None) == (None, "")
 
-    @pytest.mark.parametrize(
-        ("shorthand", "expected_cls"),
-        [("simple", SimpleProfiler), ("advanced", AdvancedProfiler)],
-    )
-    def test_shorthand_string(self, shorthand, expected_cls, in_tmp_cwd, patched_ray):
-        """A shorthand string builds that profiler with default kwargs."""
-        profiler, logs_path = _build_profiler(shorthand)
-        assert isinstance(profiler, expected_cls)
+    def test_shorthand_string(self, in_tmp_cwd, patched_ray):
+        """The ``pytorch`` shorthand builds a ``PyTorchProfiler`` with default kwargs."""
+        profiler, logs_path = _build_profiler("pytorch")
+        assert isinstance(profiler, PyTorchProfiler)
         assert logs_path == os.path.join(str(in_tmp_cwd), "profiler_logs")
         assert os.path.isdir(logs_path)
 
     def test_logs_path_and_filename_carry_world_rank(self, in_tmp_cwd, patched_ray):
         """The trace filename embeds the world rank; Lightning adds local rank."""
         patched_ray.get_world_rank.return_value = 3
-        profiler, _ = _build_profiler("simple")
+        profiler, _ = _build_profiler("pytorch")
         assert profiler.filename == "profile-world-rank-3-local-rank"
-
-    def test_dict_config_forwards_kwargs(self, in_tmp_cwd, patched_ray):
-        """Sub-config kwargs reach the profiler constructor."""
-        profiler, _ = _build_profiler({"simple": {"extended": False}})
-        assert isinstance(profiler, SimpleProfiler)
-        assert profiler.extended is False
-
-    def test_advanced_dict_config(self, in_tmp_cwd, patched_ray):
-        """The ``advanced`` key builds an ``AdvancedProfiler``."""
-        profiler, _ = _build_profiler({"advanced": {"line_count_restriction": 5}})
-        assert isinstance(profiler, AdvancedProfiler)
 
     def test_pytorch_profiler_gets_default_schedule(self, in_tmp_cwd, patched_ray):
         """The ``pytorch`` key builds a ``PyTorchProfiler`` with a schedule."""
@@ -334,6 +300,12 @@ class TestBuildProfiler:
         assert isinstance(profiler, PyTorchProfiler)
         assert profiler.dirpath == logs_path
         assert profiler._schedule is not None
+
+    def test_dict_config_forwards_kwargs(self, in_tmp_cwd, patched_ray):
+        """Sub-config kwargs reach the ``PyTorchProfiler`` constructor."""
+        profiler, _ = _build_profiler({"pytorch": {"row_limit": 5}}, steps_per_epoch=30)
+        assert isinstance(profiler, PyTorchProfiler)
+        assert profiler._row_limit == 5
 
     def test_pytorch_profiler_validates_explicit_schedule(
         self, in_tmp_cwd, patched_ray
@@ -362,82 +334,36 @@ class TestBuildProfiler:
         _build_profiler(config, steps_per_epoch=30)
         assert sub_config == {"schedule": {"wait": 1, "warmup": 1, "active": 1}}
 
-    def test_xla_profiler(self, in_tmp_cwd, patched_ray):
-        """The ``xla`` key builds an ``XLAProfiler`` with its kwargs."""
-        # XLAProfiler requires a TPU runtime, so patch the class the lazy
-        # import inside _build_profiler resolves.
-        import pytorch_lightning.profilers as profilers_mod
-
-        with patch.object(profilers_mod, "XLAProfiler") as xla_cls:
-            profiler, _ = _build_profiler({"xla": {"port": 9012}})
-
-        xla_cls.assert_called_once_with(port=9012)
-        assert profiler is xla_cls.return_value
-
-    def test_custom_profiler(self, in_tmp_cwd, patched_ray):
-        """The ``custom`` key resolves and instantiates the given class."""
-        with patch(f"{_UTIL_MODULE}.get_module_attr", return_value=_CustomProfiler):
-            profiler, _ = _build_profiler(
-                {
-                    "custom": {
-                        "profiler_class": "pkg.mod._CustomProfiler",
-                        "profiler_kwargs": {"tag": "hello"},
-                    }
-                }
-            )
-        assert isinstance(profiler, _CustomProfiler)
-        assert profiler.tag == "hello"
-
-    def test_custom_profiler_without_kwargs(self, in_tmp_cwd, patched_ray):
-        """``profiler_kwargs`` is optional."""
-        with patch(f"{_UTIL_MODULE}.get_module_attr", return_value=_CustomProfiler):
-            profiler, _ = _build_profiler(
-                {"custom": {"profiler_class": "pkg.mod._CustomProfiler"}}
-            )
-        assert isinstance(profiler, _CustomProfiler)
-
-    def test_custom_profiler_must_subclass_profiler(self, in_tmp_cwd, patched_ray):
-        """A resolved class that is not a Lightning ``Profiler`` is rejected."""
-        with (
-            patch(f"{_UTIL_MODULE}.get_module_attr", return_value=_NotAProfiler),
-            pytest.raises(UserInputError, match="must be a subclass"),
-        ):
-            _build_profiler({"custom": {"profiler_class": "pkg.mod.Nope"}})
-
-    def test_custom_profiler_rejects_non_class(self, in_tmp_cwd, patched_ray):
-        """A resolved non-class (e.g. a function) is rejected, not crashed on."""
-        with (
-            patch(f"{_UTIL_MODULE}.get_module_attr", return_value=lambda: None),
-            pytest.raises(UserInputError, match="must be a subclass"),
-        ):
-            _build_profiler({"custom": {"profiler_class": "pkg.mod.factory"}})
-
     def test_no_profiler_selected_raises(self, in_tmp_cwd, patched_ray):
         """A dict that selects nothing is a user config error."""
         with pytest.raises(UserInputError, match="None were set"):
             _build_profiler({"upload_to_comet": False})
 
     def test_multiple_profilers_selected_raises(self, in_tmp_cwd, patched_ray):
-        """A dict that selects two profilers is a user config error."""
-        with pytest.raises(UserInputError, match="Multiple were set"):
-            _build_profiler({"simple": {}, "advanced": {}})
+        """A dict that selects two profiler flavors is a user config error.
+
+        Only ``pytorch`` is a supported flavor today, so this exercises the
+        general N-way selector (kept generic so a second flavor is additive,
+        see ``_PROFILER_SHORTHANDS``'s docstring) against a patched-in second
+        name rather than a real second profiler.
+        """
+        with (
+            patch(f"{_UTIL_MODULE}._PROFILER_SHORTHANDS", ("pytorch", "other")),
+            pytest.raises(UserInputError, match="Multiple were set"),
+        ):
+            _build_profiler({"pytorch": {}, "other": {}})
 
     def test_upload_to_comet_is_not_a_profiler_selection(self, in_tmp_cwd, patched_ray):
         """``upload_to_comet`` is metadata and never reaches a constructor."""
-        profiler, _ = _build_profiler({"simple": {}, "upload_to_comet": False})
-        assert isinstance(profiler, SimpleProfiler)
+        profiler, _ = _build_profiler({"pytorch": {}, "upload_to_comet": False})
+        assert isinstance(profiler, PyTorchProfiler)
 
     def test_invalid_shorthand_raises(self):
         """An unrecognized shorthand string raises ``ValueError``."""
         with pytest.raises(ValueError, match="Invalid profiler type"):
             _build_profiler("nonsense")
 
-    def test_custom_is_not_a_valid_shorthand(self):
-        """``custom`` needs a dict; it has no shorthand form."""
-        with pytest.raises(ValueError, match="Invalid profiler type"):
-            _build_profiler("custom")
-
-    @pytest.mark.parametrize("bad", [42, ["simple"], object()])
+    @pytest.mark.parametrize("bad", [42, ["pytorch"], object()])
     def test_invalid_config_type_raises(self, bad):
         """A config that is neither str, dict, nor ``None`` raises ``TypeError``."""
         with pytest.raises(TypeError, match="must be a str, dict, or None"):
@@ -458,20 +384,20 @@ class TestResolveProfiler:
 
     def test_shorthand_defaults_to_uploading(self, in_tmp_cwd, patched_ray):
         """A shorthand string cannot opt out, so export defaults to on."""
-        profiler, logs_path, upload = _resolve_profiler("simple", {}, 100, 8, 1, 0)
-        assert isinstance(profiler, SimpleProfiler)
+        profiler, logs_path, upload = _resolve_profiler("pytorch", {}, 100, 8, 1, 0)
+        assert isinstance(profiler, PyTorchProfiler)
         assert logs_path.endswith("profiler_logs")
         assert upload is True
 
     def test_dict_defaults_to_uploading(self, in_tmp_cwd, patched_ray):
         """Users must explicitly opt out of exporting results."""
-        _, _, upload = _resolve_profiler({"simple": {}}, {}, 100, 8, 1, 0)
+        _, _, upload = _resolve_profiler({"pytorch": {}}, {}, 100, 8, 1, 0)
         assert upload is True
 
     def test_upload_can_be_disabled(self, in_tmp_cwd, patched_ray):
         """``upload_to_comet: False`` turns the export off."""
         _, _, upload = _resolve_profiler(
-            {"simple": {}, "upload_to_comet": False}, {}, 100, 8, 1, 0
+            {"pytorch": {}, "upload_to_comet": False}, {}, 100, 8, 1, 0
         )
         assert upload is False
 
@@ -610,7 +536,7 @@ class TestCometProfilerSink:
         """XLA and custom profilers have no supported upload format."""
         logger = MagicMock(name="logger")
 
-        comet_profiler_sink(_CustomProfiler(), "/logs", logger)
+        comet_profiler_sink(MagicMock(spec=XLAProfiler), "/logs", logger)
 
         logger.experiment.log_asset.assert_not_called()
         logger.experiment.log_tensorflow_folder.assert_not_called()

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_profiler.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_profiler.py
@@ -1,0 +1,621 @@
+"""Tests for the profiler subsystem in ``_private/util.py``.
+
+Covers step-count estimation, profiler construction for every supported
+flavor, schedule defaults and validation, config resolution, and the
+post-``fit`` ``profiler_sink`` hook.
+
+``ray.train.get_context`` is mocked throughout so the helpers run without a
+Ray cluster.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# The util module imports ray / torch / pytorch_lightning at import time. Skip
+# cleanly when those optional heavy dependencies are unavailable.
+pytest.importorskip("ray")
+pytest.importorskip("torch")
+pl = pytest.importorskip("pytorch_lightning")
+
+from pytorch_lightning.profilers import (  # noqa: E402
+    AdvancedProfiler,
+    Profiler,
+    PyTorchProfiler,
+    SimpleProfiler,
+)
+
+from michelangelo.lib._internal.errors import UserInputError  # noqa: E402
+from michelangelo.lib.trainer.torch.pytorch_lightning._private.util import (  # noqa: E402
+    _build_profiler,
+    _compute_default_schedule,
+    _compute_steps_per_epoch,
+    _maybe_export_profiler_results,
+    _resolve_profiler,
+    _validate_profiler_schedule,
+    comet_profiler_sink,
+)
+
+_UTIL_MODULE = "michelangelo.lib.trainer.torch.pytorch_lightning._private.util"
+
+
+class _CustomProfiler(Profiler):
+    """Minimal ``Profiler`` subclass used to exercise the ``custom`` branch."""
+
+    def __init__(self, tag: str = "x"):
+        """Record ``tag`` so tests can assert kwargs were forwarded."""
+        super().__init__()
+        self.tag = tag
+
+    def start(self, action_name: str) -> None:
+        """No-op start hook."""
+
+    def stop(self, action_name: str) -> None:
+        """No-op stop hook."""
+
+
+class _NotAProfiler:
+    """Plain class used to assert the ``custom`` subclass check rejects it."""
+
+
+@pytest.fixture
+def in_tmp_cwd(tmp_path, monkeypatch):
+    """Run the test with cwd set to a temp dir so ``profiler_logs`` is isolated."""
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+@pytest.fixture
+def patched_ray(monkeypatch):
+    """Patch ``ray`` in the util module with world rank 0 / local rank 0."""
+    with patch(f"{_UTIL_MODULE}.ray") as ray_mod:
+        ctx = ray_mod.train.get_context.return_value
+        ctx.get_world_rank.return_value = 0
+        ctx.get_local_rank.return_value = 0
+        yield ctx
+
+
+# -----------------------------------------------------------------------------
+# _compute_steps_per_epoch
+# -----------------------------------------------------------------------------
+
+
+class TestComputeStepsPerEpoch:
+    """Steps-per-epoch estimation and Lightning's batch-limiting arguments."""
+
+    def test_none_rows_returns_none(self):
+        """An unknown row count yields an unknown step count."""
+        assert _compute_steps_per_epoch({}, None, batch_size=4) is None
+
+    @pytest.mark.parametrize(
+        ("rows", "batch_size", "world_size", "expected"),
+        [
+            (100, 10, 1, 10),
+            (100, 10, 2, 5),
+            (101, 10, 1, 11),  # ceil
+            (100, 3, 2, 17),  # ceil(100/2/3)
+            (0, 10, 1, 0),
+        ],
+    )
+    def test_basic_estimate(self, rows, batch_size, world_size, expected):
+        """The base estimate is ``ceil(rows / world_size / batch_size)``."""
+        assert _compute_steps_per_epoch({}, rows, batch_size, world_size) == expected
+
+    def test_limit_train_batches_float_scales(self):
+        """A float ``limit_train_batches`` scales the epoch proportionally."""
+        assert _compute_steps_per_epoch({"limit_train_batches": 0.5}, 100, 10, 1) == 5
+
+    def test_limit_train_batches_float_one_is_noop(self):
+        """``1.0`` keeps the full epoch."""
+        assert _compute_steps_per_epoch({"limit_train_batches": 1.0}, 100, 10, 1) == 10
+
+    def test_limit_train_batches_int_caps(self):
+        """An int ``limit_train_batches`` caps but never raises the estimate."""
+        assert _compute_steps_per_epoch({"limit_train_batches": 3}, 100, 10, 1) == 3
+        assert _compute_steps_per_epoch({"limit_train_batches": 50}, 100, 10, 1) == 10
+
+    @pytest.mark.parametrize("bad", [1.5, -0.5, 0, -3, "half"])
+    def test_invalid_limit_train_batches_raises(self, bad):
+        """Values Lightning would reject raise ``ValueError``."""
+        with pytest.raises(ValueError, match="limit_train_batches"):
+            _compute_steps_per_epoch({"limit_train_batches": bad}, 100, 10, 1)
+
+    def test_max_steps_caps_estimate(self):
+        """``max_steps`` below the epoch length wins."""
+        assert _compute_steps_per_epoch({"max_steps": 4}, 100, 10, 1) == 4
+
+    def test_max_steps_above_epoch_is_ignored(self):
+        """``max_steps`` above the epoch length leaves the estimate alone."""
+        assert _compute_steps_per_epoch({"max_steps": 999}, 100, 10, 1) == 10
+
+    def test_max_steps_scaled_by_accumulate_grad_batches(self):
+        """``max_steps`` counts optimizer steps, so it scales by accumulation."""
+        assert (
+            _compute_steps_per_epoch(
+                {"max_steps": 2, "accumulate_grad_batches": 3}, 100, 10, 1
+            )
+            == 6
+        )
+
+    def test_max_steps_disabled_sentinel_is_ignored(self):
+        """Lightning's ``max_steps=-1`` sentinel means "no cap"."""
+        assert _compute_steps_per_epoch({"max_steps": -1}, 100, 10, 1) == 10
+
+    def test_limit_and_max_steps_applied_in_order(self):
+        """``limit_train_batches`` applies first, then ``max_steps`` caps it."""
+        assert (
+            _compute_steps_per_epoch(
+                {"limit_train_batches": 0.5, "max_steps": 3}, 100, 10, 1
+            )
+            == 3
+        )
+
+    @pytest.mark.parametrize("bad", [0, -1, 2.5])
+    def test_invalid_accumulate_grad_batches_raises(self, bad):
+        """A non-positive or non-int accumulation factor raises."""
+        with pytest.raises(ValueError, match="accumulate_grad_batches"):
+            _compute_steps_per_epoch(
+                {"max_steps": 2, "accumulate_grad_batches": bad}, 100, 10, 1
+            )
+
+    @pytest.mark.parametrize("batch_size", [0, -4])
+    def test_invalid_batch_size_raises(self, batch_size):
+        """A non-positive batch size raises."""
+        with pytest.raises(ValueError, match="batch_size"):
+            _compute_steps_per_epoch({}, 100, batch_size, 1)
+
+    @pytest.mark.parametrize("world_size", [0, -2])
+    def test_invalid_world_size_raises(self, world_size):
+        """A non-positive world size raises."""
+        with pytest.raises(ValueError, match="world_size"):
+            _compute_steps_per_epoch({}, 100, 10, world_size)
+
+
+# -----------------------------------------------------------------------------
+# _compute_default_schedule
+# -----------------------------------------------------------------------------
+
+
+class TestComputeDefaultSchedule:
+    """The documented default schedule for each epoch length."""
+
+    @pytest.mark.parametrize("steps", [None, 0, 1, -5])
+    def test_degenerate_epochs_profile_one_step(self, steps):
+        """Unknown or single-step epochs profile exactly one step immediately."""
+        assert _compute_default_schedule(steps) == {
+            "skip_first": 0,
+            "wait": 0,
+            "warmup": 0,
+            "active": 1,
+            "repeat": 1,
+        }
+
+    def test_two_steps_waits_one(self):
+        """Two steps wait one, then profile one."""
+        assert _compute_default_schedule(2) == {
+            "skip_first": 0,
+            "wait": 1,
+            "warmup": 0,
+            "active": 1,
+            "repeat": 1,
+        }
+
+    def test_five_steps_shrinks_active(self):
+        """Five steps fit a full warmup but a shortened active window."""
+        assert _compute_default_schedule(5) == {
+            "skip_first": 0,
+            "wait": 1,
+            "warmup": 2,
+            "active": 2,
+            "repeat": 1,
+        }
+
+    @pytest.mark.parametrize("steps", [7, 30, 300])
+    def test_long_epochs_use_full_windows(self, steps):
+        """From 7 steps up, warmup and active reach their fixed sizes."""
+        assert _compute_default_schedule(steps) == {
+            "skip_first": 0,
+            "wait": steps // 3,
+            "warmup": 2,
+            "active": 3,
+            "repeat": 1,
+        }
+
+    @pytest.mark.parametrize("steps", range(1, 60))
+    def test_default_schedule_always_fits_the_epoch(self, steps):
+        """The default schedule never exceeds the epoch it was derived from."""
+        _validate_profiler_schedule(_compute_default_schedule(steps), steps)
+
+
+# -----------------------------------------------------------------------------
+# _validate_profiler_schedule
+# -----------------------------------------------------------------------------
+
+
+class TestValidateProfilerSchedule:
+    """Range and per-epoch bounds on a user-supplied schedule."""
+
+    def test_valid_schedule_passes(self):
+        """A schedule that fits the epoch is accepted."""
+        _validate_profiler_schedule(
+            {"skip_first": 1, "wait": 2, "warmup": 2, "active": 3, "repeat": 1}, 20
+        )
+
+    def test_empty_schedule_uses_defaults(self):
+        """Omitted fields fall back to defaults that pass validation."""
+        _validate_profiler_schedule({}, 10)
+
+    def test_unknown_steps_per_epoch_skips_bounds_check(self):
+        """With an unknown epoch length only the field ranges are enforced."""
+        _validate_profiler_schedule({"wait": 10_000, "active": 5}, None)
+
+    @pytest.mark.parametrize("field", ["skip_first", "wait", "warmup"])
+    def test_negative_fields_raise(self, field):
+        """Negative wait-style fields are rejected."""
+        with pytest.raises(UserInputError, match=field):
+            _validate_profiler_schedule({field: -1}, 100)
+
+    @pytest.mark.parametrize("active", [0, -1, 11, 100])
+    def test_active_out_of_range_raises(self, active):
+        """``active`` must land in ``[1, 10]``."""
+        with pytest.raises(UserInputError, match="active"):
+            _validate_profiler_schedule({"active": active}, 1000)
+
+    @pytest.mark.parametrize("repeat", [0, -1, 4, 50])
+    def test_repeat_out_of_range_raises(self, repeat):
+        """``repeat`` must land in ``[1, 3]``."""
+        with pytest.raises(UserInputError, match="repeat"):
+            _validate_profiler_schedule({"repeat": repeat}, 1000)
+
+    def test_schedule_longer_than_epoch_raises_with_formula(self):
+        """Overrunning the epoch raises and explains the arithmetic."""
+        with pytest.raises(UserInputError) as excinfo:
+            _validate_profiler_schedule(
+                {"skip_first": 1, "wait": 3, "warmup": 2, "active": 3, "repeat": 2}, 10
+            )
+        message = str(excinfo.value)
+        # (3 + 2 + 3) * 2 + 1 = 17 steps requested against an epoch of 10.
+        assert "17 steps" in message
+        assert "only has 10 steps" in message
+
+    def test_schedule_exactly_filling_epoch_passes(self):
+        """A schedule consuming the whole epoch is on the allowed side."""
+        _validate_profiler_schedule(
+            {"skip_first": 0, "wait": 2, "warmup": 2, "active": 3, "repeat": 2}, 14
+        )
+
+
+# -----------------------------------------------------------------------------
+# _build_profiler
+# -----------------------------------------------------------------------------
+
+
+class TestBuildProfiler:
+    """Construction of each profiler flavor and its config validation."""
+
+    def test_none_config_builds_nothing(self):
+        """A ``None`` config yields no profiler and no logs path."""
+        assert _build_profiler(None) == (None, "")
+
+    @pytest.mark.parametrize(
+        ("shorthand", "expected_cls"),
+        [("simple", SimpleProfiler), ("advanced", AdvancedProfiler)],
+    )
+    def test_shorthand_string(self, shorthand, expected_cls, in_tmp_cwd, patched_ray):
+        """A shorthand string builds that profiler with default kwargs."""
+        profiler, logs_path = _build_profiler(shorthand)
+        assert isinstance(profiler, expected_cls)
+        assert logs_path == os.path.join(str(in_tmp_cwd), "profiler_logs")
+        assert os.path.isdir(logs_path)
+
+    def test_logs_path_and_filename_carry_world_rank(self, in_tmp_cwd, patched_ray):
+        """The trace filename embeds the world rank; Lightning adds local rank."""
+        patched_ray.get_world_rank.return_value = 3
+        profiler, _ = _build_profiler("simple")
+        assert profiler.filename == "profile-world-rank-3-local-rank"
+
+    def test_dict_config_forwards_kwargs(self, in_tmp_cwd, patched_ray):
+        """Sub-config kwargs reach the profiler constructor."""
+        profiler, _ = _build_profiler({"simple": {"extended": False}})
+        assert isinstance(profiler, SimpleProfiler)
+        assert profiler.extended is False
+
+    def test_advanced_dict_config(self, in_tmp_cwd, patched_ray):
+        """The ``advanced`` key builds an ``AdvancedProfiler``."""
+        profiler, _ = _build_profiler({"advanced": {"line_count_restriction": 5}})
+        assert isinstance(profiler, AdvancedProfiler)
+
+    def test_pytorch_profiler_gets_default_schedule(self, in_tmp_cwd, patched_ray):
+        """The ``pytorch`` key builds a ``PyTorchProfiler`` with a schedule."""
+        profiler, logs_path = _build_profiler({"pytorch": {}}, steps_per_epoch=30)
+        assert isinstance(profiler, PyTorchProfiler)
+        assert profiler.dirpath == logs_path
+        assert profiler._schedule is not None
+
+    def test_pytorch_profiler_validates_explicit_schedule(
+        self, in_tmp_cwd, patched_ray
+    ):
+        """An explicit schedule that overruns the epoch is rejected."""
+        with pytest.raises(UserInputError, match="only has 4 steps"):
+            _build_profiler(
+                {"pytorch": {"schedule": {"wait": 5, "warmup": 2, "active": 3}}},
+                steps_per_epoch=4,
+            )
+
+    def test_pytorch_profiler_resolves_on_trace_ready(self, in_tmp_cwd, patched_ray):
+        """A dotted ``on_trace_ready`` path is resolved via ``get_module_attr``."""
+        handler = MagicMock(name="handler")
+        with patch(f"{_UTIL_MODULE}.get_module_attr", return_value=handler) as resolver:
+            _build_profiler(
+                {"pytorch": {"on_trace_ready": "some.module.handler"}},
+                steps_per_epoch=30,
+            )
+        resolver.assert_called_once_with("some.module.handler")
+
+    def test_pytorch_sub_config_is_not_mutated(self, in_tmp_cwd, patched_ray):
+        """The caller's ``pytorch`` dict survives construction unchanged."""
+        sub_config = {"schedule": {"wait": 1, "warmup": 1, "active": 1}}
+        config = {"pytorch": sub_config}
+        _build_profiler(config, steps_per_epoch=30)
+        assert sub_config == {"schedule": {"wait": 1, "warmup": 1, "active": 1}}
+
+    def test_xla_profiler(self, in_tmp_cwd, patched_ray):
+        """The ``xla`` key builds an ``XLAProfiler`` with its kwargs."""
+        # XLAProfiler requires a TPU runtime, so patch the class the lazy
+        # import inside _build_profiler resolves.
+        import pytorch_lightning.profilers as profilers_mod
+
+        with patch.object(profilers_mod, "XLAProfiler") as xla_cls:
+            profiler, _ = _build_profiler({"xla": {"port": 9012}})
+
+        xla_cls.assert_called_once_with(port=9012)
+        assert profiler is xla_cls.return_value
+
+    def test_custom_profiler(self, in_tmp_cwd, patched_ray):
+        """The ``custom`` key resolves and instantiates the given class."""
+        with patch(f"{_UTIL_MODULE}.get_module_attr", return_value=_CustomProfiler):
+            profiler, _ = _build_profiler(
+                {
+                    "custom": {
+                        "profiler_class": "pkg.mod._CustomProfiler",
+                        "profiler_kwargs": {"tag": "hello"},
+                    }
+                }
+            )
+        assert isinstance(profiler, _CustomProfiler)
+        assert profiler.tag == "hello"
+
+    def test_custom_profiler_without_kwargs(self, in_tmp_cwd, patched_ray):
+        """``profiler_kwargs`` is optional."""
+        with patch(f"{_UTIL_MODULE}.get_module_attr", return_value=_CustomProfiler):
+            profiler, _ = _build_profiler(
+                {"custom": {"profiler_class": "pkg.mod._CustomProfiler"}}
+            )
+        assert isinstance(profiler, _CustomProfiler)
+
+    def test_custom_profiler_must_subclass_profiler(self, in_tmp_cwd, patched_ray):
+        """A resolved class that is not a Lightning ``Profiler`` is rejected."""
+        with (
+            patch(f"{_UTIL_MODULE}.get_module_attr", return_value=_NotAProfiler),
+            pytest.raises(UserInputError, match="must be a subclass"),
+        ):
+            _build_profiler({"custom": {"profiler_class": "pkg.mod.Nope"}})
+
+    def test_custom_profiler_rejects_non_class(self, in_tmp_cwd, patched_ray):
+        """A resolved non-class (e.g. a function) is rejected, not crashed on."""
+        with (
+            patch(f"{_UTIL_MODULE}.get_module_attr", return_value=lambda: None),
+            pytest.raises(UserInputError, match="must be a subclass"),
+        ):
+            _build_profiler({"custom": {"profiler_class": "pkg.mod.factory"}})
+
+    def test_no_profiler_selected_raises(self, in_tmp_cwd, patched_ray):
+        """A dict that selects nothing is a user config error."""
+        with pytest.raises(UserInputError, match="None were set"):
+            _build_profiler({"upload_to_comet": False})
+
+    def test_multiple_profilers_selected_raises(self, in_tmp_cwd, patched_ray):
+        """A dict that selects two profilers is a user config error."""
+        with pytest.raises(UserInputError, match="Multiple were set"):
+            _build_profiler({"simple": {}, "advanced": {}})
+
+    def test_upload_to_comet_is_not_a_profiler_selection(self, in_tmp_cwd, patched_ray):
+        """``upload_to_comet`` is metadata and never reaches a constructor."""
+        profiler, _ = _build_profiler({"simple": {}, "upload_to_comet": False})
+        assert isinstance(profiler, SimpleProfiler)
+
+    def test_invalid_shorthand_raises(self):
+        """An unrecognized shorthand string raises ``ValueError``."""
+        with pytest.raises(ValueError, match="Invalid profiler type"):
+            _build_profiler("nonsense")
+
+    def test_custom_is_not_a_valid_shorthand(self):
+        """``custom`` needs a dict; it has no shorthand form."""
+        with pytest.raises(ValueError, match="Invalid profiler type"):
+            _build_profiler("custom")
+
+    @pytest.mark.parametrize("bad", [42, ["simple"], object()])
+    def test_invalid_config_type_raises(self, bad):
+        """A config that is neither str, dict, nor ``None`` raises ``TypeError``."""
+        with pytest.raises(TypeError, match="must be a str, dict, or None"):
+            _build_profiler(bad)
+
+
+# -----------------------------------------------------------------------------
+# _resolve_profiler
+# -----------------------------------------------------------------------------
+
+
+class TestResolveProfiler:
+    """Config resolution, including the ``upload_to_comet`` opt-out."""
+
+    def test_none_config_resolves_to_nothing(self):
+        """No profiler config means no profiler and no export."""
+        assert _resolve_profiler(None, {}, 100, 8, 1, 0) == (None, "", False)
+
+    def test_shorthand_defaults_to_uploading(self, in_tmp_cwd, patched_ray):
+        """A shorthand string cannot opt out, so export defaults to on."""
+        profiler, logs_path, upload = _resolve_profiler("simple", {}, 100, 8, 1, 0)
+        assert isinstance(profiler, SimpleProfiler)
+        assert logs_path.endswith("profiler_logs")
+        assert upload is True
+
+    def test_dict_defaults_to_uploading(self, in_tmp_cwd, patched_ray):
+        """Users must explicitly opt out of exporting results."""
+        _, _, upload = _resolve_profiler({"simple": {}}, {}, 100, 8, 1, 0)
+        assert upload is True
+
+    def test_upload_can_be_disabled(self, in_tmp_cwd, patched_ray):
+        """``upload_to_comet: False`` turns the export off."""
+        _, _, upload = _resolve_profiler(
+            {"simple": {}, "upload_to_comet": False}, {}, 100, 8, 1, 0
+        )
+        assert upload is False
+
+    def test_steps_per_epoch_is_computed_from_the_run_shape(
+        self, in_tmp_cwd, patched_ray
+    ):
+        """Row count, batch size, world size, and trainer kwargs all feed in."""
+        with patch(f"{_UTIL_MODULE}._build_profiler", return_value=(None, "")) as build:
+            _resolve_profiler(
+                {"pytorch": {}},
+                {"limit_train_batches": 0.5},
+                dataset_num_rows=800,
+                batch_size=10,
+                world_sz=4,
+                rank=0,
+            )
+        # ceil(800 / 4 / 10) = 20, halved by limit_train_batches -> 10.
+        build.assert_called_once_with({"pytorch": {}}, 10)
+
+    def test_unknown_row_count_passes_none_through(self, in_tmp_cwd, patched_ray):
+        """An unknown row count leaves the schedule to its unbounded default."""
+        with patch(f"{_UTIL_MODULE}._build_profiler", return_value=(None, "")) as build:
+            _resolve_profiler({"pytorch": {}}, {}, None, 8, 1, 0)
+        build.assert_called_once_with({"pytorch": {}}, None)
+
+
+# -----------------------------------------------------------------------------
+# _maybe_export_profiler_results
+# -----------------------------------------------------------------------------
+
+
+class TestMaybeExportProfilerResults:
+    """Gating and error containment around the post-``fit`` sink call."""
+
+    def test_sink_called_on_local_rank_0(self, patched_ray):
+        """The node-local leader hands the profiler and path to the sink."""
+        sink = MagicMock(name="sink")
+        profiler = MagicMock(name="profiler")
+        logger = MagicMock(name="logger")
+
+        _maybe_export_profiler_results(profiler, "/logs", logger, True, sink)
+
+        sink.assert_called_once_with(profiler, "/logs", logger)
+
+    def test_not_called_on_other_local_ranks(self, patched_ray):
+        """Non-leader workers on a node skip the export."""
+        patched_ray.get_local_rank.return_value = 1
+        sink = MagicMock(name="sink")
+
+        _maybe_export_profiler_results(MagicMock(), "/logs", None, True, sink)
+
+        sink.assert_not_called()
+
+    def test_not_called_without_profiler(self, patched_ray):
+        """No profiler means nothing to export."""
+        sink = MagicMock(name="sink")
+        _maybe_export_profiler_results(None, "", None, True, sink)
+        sink.assert_not_called()
+
+    def test_not_called_when_upload_disabled(self, patched_ray):
+        """``upload_to_comet: False`` suppresses the sink."""
+        sink = MagicMock(name="sink")
+        _maybe_export_profiler_results(MagicMock(), "/logs", None, False, sink)
+        sink.assert_not_called()
+
+    def test_no_sink_configured_is_noop(self, patched_ray):
+        """A profiler without a sink simply leaves results on disk."""
+        # No exception is the assertion here.
+        _maybe_export_profiler_results(MagicMock(), "/logs", None, True, None)
+
+    def test_sink_exception_is_swallowed(self, patched_ray):
+        """A raising sink never fails a completed training run."""
+        sink = MagicMock(name="sink", side_effect=RuntimeError("boom"))
+        _maybe_export_profiler_results(MagicMock(), "/logs", None, True, sink)
+        sink.assert_called_once()
+
+
+# -----------------------------------------------------------------------------
+# comet_profiler_sink
+# -----------------------------------------------------------------------------
+
+
+class TestCometProfilerSink:
+    """Comet upload behavior for each profiler flavor."""
+
+    def test_pytorch_traces_upload_as_tensorboard_folder(self):
+        """``PyTorchProfiler`` traces go up as a TensorBoard folder."""
+        logger = MagicMock(name="logger")
+        profiler = MagicMock(spec=PyTorchProfiler)
+
+        comet_profiler_sink(profiler, "/logs", logger)
+
+        logger.experiment.log_tensorflow_folder.assert_called_once_with("/logs")
+
+    def test_pytorch_upload_failure_is_swallowed(self):
+        """A failed TensorBoard upload is logged, not raised."""
+        logger = MagicMock(name="logger")
+        logger.experiment.log_tensorflow_folder.side_effect = RuntimeError("nope")
+
+        comet_profiler_sink(MagicMock(spec=PyTorchProfiler), "/logs", logger)
+
+    @pytest.mark.parametrize("spec", [SimpleProfiler, AdvancedProfiler])
+    def test_text_summaries_upload_as_assets(self, spec, tmp_path):
+        """Text-summary profilers upload each ``.txt`` file individually."""
+        (tmp_path / "a.txt").write_text("a")
+        (tmp_path / "b.txt").write_text("b")
+        (tmp_path / "ignored.json").write_text("{}")
+        logger = MagicMock(name="logger")
+
+        comet_profiler_sink(MagicMock(spec=spec), str(tmp_path), logger)
+
+        uploaded = {
+            os.path.basename(call.args[0])
+            for call in logger.experiment.log_asset.call_args_list
+        }
+        assert uploaded == {"a.txt", "b.txt"}
+
+    def test_no_text_files_is_noop(self, tmp_path):
+        """An empty logs directory uploads nothing."""
+        logger = MagicMock(name="logger")
+        comet_profiler_sink(MagicMock(spec=SimpleProfiler), str(tmp_path), logger)
+        logger.experiment.log_asset.assert_not_called()
+
+    def test_asset_upload_failure_does_not_stop_remaining_files(self, tmp_path):
+        """One failed asset upload does not abort the rest."""
+        (tmp_path / "a.txt").write_text("a")
+        (tmp_path / "b.txt").write_text("b")
+        logger = MagicMock(name="logger")
+        logger.experiment.log_asset.side_effect = [RuntimeError("nope"), None]
+
+        comet_profiler_sink(MagicMock(spec=SimpleProfiler), str(tmp_path), logger)
+
+        assert logger.experiment.log_asset.call_count == 2
+
+    def test_unsupported_profiler_is_skipped(self):
+        """XLA and custom profilers have no supported upload format."""
+        logger = MagicMock(name="logger")
+
+        comet_profiler_sink(_CustomProfiler(), "/logs", logger)
+
+        logger.experiment.log_asset.assert_not_called()
+        logger.experiment.log_tensorflow_folder.assert_not_called()
+
+    def test_logger_without_experiment_is_skipped(self):
+        """A non-Comet logger is skipped rather than crashing the run."""
+        # object() has no `experiment` attribute; no exception is the assertion.
+        comet_profiler_sink(MagicMock(spec=PyTorchProfiler), "/logs", object())


### PR DESCRIPTION
## Scope

Adds opt-in PyTorch Lightning profiling to `LightningTrainer`, configured through `lightning_trainer_kwargs["profiler"]`. This is the last unimplemented piece of the trainer module migration.

### Profiler construction (`_private/util.py`)

- `_build_profiler` accepts `None`, a shorthand string (`"simple"` / `"advanced"` / `"pytorch"` / `"xla"`), or a dict setting **exactly one** of `simple` / `advanced` / `pytorch` / `xla` / `custom`. Zero or multiple selections raise `UserInputError`. `custom` resolves a dotted class path and rejects anything that is not a `pl.profilers.Profiler` subclass.
- All profilers write to a fixed `profiler_logs/` directory under the worker cwd, with a per-world-rank trace filename (Lightning appends the local rank), so results are locatable after `fit()` returns.
- Lightning profiler classes are imported lazily inside the functions, matching the existing style for optional/heavy deps in this module.

### Schedule derivation

- `_compute_steps_per_epoch` estimates `ceil(rows / world_size / batch_size)`, then applies `limit_train_batches` (float scales, int caps) and `max_steps` (scaled by `accumulate_grad_batches`) in Lightning's own order.
- `_compute_default_schedule` picks a sane `wait`/`warmup`/`active` window for the epoch length; `_validate_profiler_schedule` bounds an explicit schedule (`active` <= 10, `repeat` <= 3) and rejects one that overruns the epoch with a message spelling out the arithmetic so users can fix their config.
- `LightningTrainer.__init__` counts training rows **only** when a profiler is configured, since `count()` is cheap on Parquet-metadata-backed datasets but forces execution otherwise. A failed count degrades to `None` (unbounded default schedule) rather than failing the run.

### Result export: `profiler_sink`

New optional `LightningTrainerParam.profiler_sink`, a `Callable[[Profiler, str, Logger], None]` invoked on each node-local rank 0 after `fit()`:

- The generic profiler builders stay tracker-agnostic; the sink is the only tracker-aware piece, consistent with the pluggable-backend approach used in earlier PRs in this migration.
- Gated on `profiler is not None`, the config's `upload_to_comet` flag, and `local_rank == 0` (one call per node, since `profiler_logs/` is shared by all workers on a node).
- Exceptions from the sink are logged and swallowed — profiling is observability and must not fail a completed run.
- `comet_profiler_sink` ships the standard Comet export (`log_tensorflow_folder` for `PyTorchProfiler`, per-file `log_asset` for `SimpleProfiler`/`AdvancedProfiler`, skip for XLA/custom) and is re-exported from the package so users can reference it without importing from `_private`.

The `TrainingObserver` Protocol is deliberately **not** extended — it is `@runtime_checkable`, so adding a required method would break existing implementations that currently satisfy it.

## Deviations from the source snapshot

1. **Sink receives the logger as a call argument** rather than being a factory closing over it. The logger is built inside the worker by `_resolve_logger`, while `profiler_sink` is set on the driver, so a driver-side closure cannot capture it. Passing it at call time also keeps the sink a plain module-level function, which pickles cleanly to workers.
2. **Row count is read off `trainer_param.train_data`**, not the value popped from the loop config — `dataclasses.asdict()` has already deep-copied the latter.
3. Validation failures raise the repo's `UserInputError` rather than the source's bespoke exception type; `print` diagnostics became `_logger` calls.
4. Environment-specific logger subclasses and pipeline-annotation hooks from the source were dropped; the generic `profiler_sink` seam replaces them.

### Known limitation, documented in `comet_profiler_sink`

Lightning decorates `CometLogger.experiment` with `@rank_zero_experiment`, so on any worker whose **global** rank is not 0 the property yields a no-op dummy. In a multi-node run only the node holding global rank 0 actually exports its profile; other node leaders' uploads are silently dropped. This is called out in the docstring, with a pointer to writing a custom sink that resolves its own experiment if per-node profiles are needed.

## Verification

- Full trainer suite: **353 passed** (up from 293), 0 failures.
- Coverage on the new profiler code in `_private/util.py`: **100%** of statements and branches outside `_train_loop_per_worker`. Package-level coverage for `lightning_trainer.py`, `schema.py`, `experiment_store.py`, and `__init__.py` remains **100.00%**. (`_private/` is excluded from the project coverage gate by `pyproject.toml`, as its worker-loop body needs a live Ray runtime; the two new call sites inside `_train_loop_per_worker` share that exclusion.)
- `ruff format --check` and `ruff check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)