### PR TITLE
feat(python): retry + round_robin service_config on mactl gRPC channels

### DIFF
--- a/python/michelangelo/cli/mactl/config.py
+++ b/python/michelangelo/cli/mactl/config.py
@@ -1,5 +1,6 @@
 """Configuration management for mactl."""
 
+import json
 import sys
 from copy import deepcopy
 from logging import getLogger
@@ -141,3 +142,42 @@ def setup_minio_env() -> None:
     environ["AWS_ACCESS_KEY_ID"] = minio_config.get("access_key_id", "")
     environ["AWS_SECRET_ACCESS_KEY"] = minio_config.get("secret_access_key", "")
     environ["AWS_ENDPOINT_URL"] = minio_config.get("endpoint_url", "")
+
+
+# Retry transient UNAVAILABLE (only status gRPC marks safe to replay: server
+# didn't ack) and prefer round_robin so a multi-endpoint resolver rebalances
+# per-request; behaves like pick_first when the resolver returns one endpoint.
+_DEFAULT_RETRY_SERVICE_CONFIG = json.dumps(
+    {
+        "loadBalancingConfig": [{"round_robin": {}}],
+        "methodConfig": [
+            {
+                "name": [{}],
+                "retryPolicy": {
+                    "maxAttempts": 4,
+                    "initialBackoff": "0.5s",
+                    "maxBackoff": "5s",
+                    "backoffMultiplier": 2,
+                    "retryableStatusCodes": ["UNAVAILABLE"],
+                },
+            }
+        ],
+    }
+)
+
+DEFAULT_CHANNEL_OPTIONS: list[tuple[str, object]] = [
+    ("grpc.enable_retries", 1),
+    ("grpc.service_config", _DEFAULT_RETRY_SERVICE_CONFIG),
+]
+
+
+def get_channel_options() -> list[tuple[str, object]]:
+    """gRPC channel options applied by mactl's run() to every channel.
+
+    Extension point: downstream consumers (e.g. an internal wrapper
+    that needs a different retry budget, TLS knobs, or LB policy) can
+    override this function or reassign DEFAULT_CHANNEL_OPTIONS. mactl
+    calls this via the config module at channel-construction time, so
+    a runtime replacement takes effect on the next run().
+    """
+    return list(DEFAULT_CHANNEL_OPTIONS)

--- a/python/michelangelo/cli/mactl/config.py
+++ b/python/michelangelo/cli/mactl/config.py
@@ -147,27 +147,28 @@ def setup_minio_env() -> None:
 # Retry transient UNAVAILABLE (only status gRPC marks safe to replay: server
 # didn't ack) and prefer round_robin so a multi-endpoint resolver rebalances
 # per-request; behaves like pick_first when the resolver returns one endpoint.
-_DEFAULT_RETRY_SERVICE_CONFIG = json.dumps(
-    {
-        "loadBalancingConfig": [{"round_robin": {}}],
-        "methodConfig": [
-            {
-                "name": [{}],
-                "retryPolicy": {
-                    "maxAttempts": 4,
-                    "initialBackoff": "0.5s",
-                    "maxBackoff": "5s",
-                    "backoffMultiplier": 2,
-                    "retryableStatusCodes": ["UNAVAILABLE"],
-                },
-            }
-        ],
-    }
-)
-
 DEFAULT_CHANNEL_OPTIONS: list[tuple[str, object]] = [
     ("grpc.enable_retries", 1),
-    ("grpc.service_config", _DEFAULT_RETRY_SERVICE_CONFIG),
+    (
+        "grpc.service_config",
+        json.dumps(
+            {
+                "loadBalancingConfig": [{"round_robin": {}}],
+                "methodConfig": [
+                    {
+                        "name": [{}],
+                        "retryPolicy": {
+                            "maxAttempts": 4,
+                            "initialBackoff": "0.5s",
+                            "maxBackoff": "5s",
+                            "backoffMultiplier": 2,
+                            "retryableStatusCodes": ["UNAVAILABLE"],
+                        },
+                    }
+                ],
+            }
+        ),
+    ),
 ]
 
 

--- a/python/michelangelo/cli/mactl/config.py
+++ b/python/michelangelo/cli/mactl/config.py
@@ -173,7 +173,7 @@ DEFAULT_CHANNEL_OPTIONS: list[tuple[str, object]] = [
 
 
 def get_channel_options() -> list[tuple[str, object]]:
-    """gRPC channel options applied by mactl's run() to every channel.
+    """Return gRPC channel options applied by mactl's run() to every channel.
 
     Extension point: downstream consumers (e.g. an internal wrapper
     that needs a different retry budget, TLS knobs, or LB policy) can

--- a/python/michelangelo/cli/mactl/config_test.py
+++ b/python/michelangelo/cli/mactl/config_test.py
@@ -366,57 +366,41 @@ class ChannelOptionsTest(TestCase):
     """gRPC channel options exposed to mactl.run().
 
     Guards the shape of DEFAULT_CHANNEL_OPTIONS + get_channel_options().
-    The getter is the documented extension point for downstream consumers.
     """
 
-    def test_options_include_enable_retries_and_service_config(self):
-        """Both grpc.enable_retries and grpc.service_config are set."""
+    def test_channel_options_shape(self):
+        """Full expected shape.
+
+        Any drift in retry policy, LB config, method match, or the outer
+        tuple pair surfaces here. The safety-critical invariant is
+        ``retryableStatusCodes == ["UNAVAILABLE"]``: DEADLINE_EXCEEDED
+        and RESOURCE_EXHAUSTED are unsafe (server may have partially
+        executed) and must never be added to the list.
+        """
+        self.assertEqual(len(DEFAULT_CHANNEL_OPTIONS), 2)
         opts = dict(DEFAULT_CHANNEL_OPTIONS)
         self.assertEqual(opts["grpc.enable_retries"], 1)
-        self.assertIn("grpc.service_config", opts)
-
-    def test_service_config_is_valid_json(self):
-        """service_config JSON parses and has expected top-level keys."""
-        cfg = json.loads(dict(DEFAULT_CHANNEL_OPTIONS)["grpc.service_config"])
-        self.assertIn("loadBalancingConfig", cfg)
-        self.assertIn("methodConfig", cfg)
-
-    def test_load_balancing_is_round_robin(self):
-        """LB config selects round_robin (needed for multi-endpoint failover)."""
-        cfg = json.loads(dict(DEFAULT_CHANNEL_OPTIONS)["grpc.service_config"])
-        self.assertEqual(cfg["loadBalancingConfig"], [{"round_robin": {}}])
-
-    def test_retry_policy_only_retries_unavailable(self):
-        """Only UNAVAILABLE is retried.
-
-        DEADLINE_EXCEEDED and RESOURCE_EXHAUSTED are unsafe (server may
-        have partially executed) and must not be in the list.
-        """
-        cfg = json.loads(dict(DEFAULT_CHANNEL_OPTIONS)["grpc.service_config"])
-        policy = cfg["methodConfig"][0]["retryPolicy"]
-        self.assertEqual(policy["retryableStatusCodes"], ["UNAVAILABLE"])
-
-    def test_retry_policy_max_attempts_and_backoff(self):
-        """Bounded retry budget: 4 attempts, 0.5s→5s exponential."""
-        cfg = json.loads(dict(DEFAULT_CHANNEL_OPTIONS)["grpc.service_config"])
-        policy = cfg["methodConfig"][0]["retryPolicy"]
-        self.assertEqual(policy["maxAttempts"], 4)
-        self.assertEqual(policy["initialBackoff"], "0.5s")
-        self.assertEqual(policy["maxBackoff"], "5s")
-        self.assertEqual(policy["backoffMultiplier"], 2)
-
-    def test_method_config_applies_to_every_method(self):
-        """Method config `name=[{}]` matches every RPC — applies to all CRDs."""
-        cfg = json.loads(dict(DEFAULT_CHANNEL_OPTIONS)["grpc.service_config"])
-        self.assertEqual(cfg["methodConfig"][0]["name"], [{}])
-
-    def test_get_channel_options_returns_default(self):
-        """Getter returns the default list contents (by value)."""
-        self.assertEqual(get_channel_options(), DEFAULT_CHANNEL_OPTIONS)
+        self.assertEqual(
+            json.loads(opts["grpc.service_config"]),
+            {
+                "loadBalancingConfig": [{"round_robin": {}}],
+                "methodConfig": [
+                    {
+                        "name": [{}],
+                        "retryPolicy": {
+                            "maxAttempts": 4,
+                            "initialBackoff": "0.5s",
+                            "maxBackoff": "5s",
+                            "backoffMultiplier": 2,
+                            "retryableStatusCodes": ["UNAVAILABLE"],
+                        },
+                    }
+                ],
+            },
+        )
 
     def test_get_channel_options_returns_fresh_copy(self):
-        """Getter returns a fresh list so callers can't mutate the default."""
+        """Getter returns a fresh list so callers can't mutate module state."""
         result = get_channel_options()
         result.append(("grpc.max_send_message_length", 1))
-        # Default is unchanged.
         self.assertNotIn(("grpc.max_send_message_length", 1), DEFAULT_CHANNEL_OPTIONS)

--- a/python/michelangelo/cli/mactl/config_test.py
+++ b/python/michelangelo/cli/mactl/config_test.py
@@ -1,16 +1,19 @@
 """Unit tests for config module."""
 
+import json
 from pathlib import Path
 from unittest import TestCase
 from unittest.mock import mock_open, patch
 
 from michelangelo.cli.mactl.config import (
+    DEFAULT_CHANNEL_OPTIONS,
     DEFAULT_CONFIG,
     PACKAGE_CONFIG_FILE,
     USER_CONFIG_FILE,
     _apply_env_overrides,
     _deep_merge,
     _load_toml_file,
+    get_channel_options,
     load_config,
     setup_minio_env,
 )
@@ -357,3 +360,65 @@ class DefaultConstantsTest(TestCase):
         self.assertEqual(PACKAGE_CONFIG_FILE.name, "config.toml")
         self.assertEqual(USER_CONFIG_FILE.name, "user_config.toml")
         self.assertEqual(PACKAGE_CONFIG_FILE.parent, USER_CONFIG_FILE.parent)
+
+
+class ChannelOptionsTest(TestCase):
+    """gRPC channel options exposed to mactl.run().
+
+    Guards the shape of DEFAULT_CHANNEL_OPTIONS + get_channel_options().
+    The getter is the documented extension point for downstream consumers.
+    """
+
+    def test_options_include_enable_retries_and_service_config(self):
+        """Both grpc.enable_retries and grpc.service_config are set."""
+        opts = dict(DEFAULT_CHANNEL_OPTIONS)
+        self.assertEqual(opts["grpc.enable_retries"], 1)
+        self.assertIn("grpc.service_config", opts)
+
+    def test_service_config_is_valid_json(self):
+        """service_config JSON parses and has expected top-level keys."""
+        cfg = json.loads(dict(DEFAULT_CHANNEL_OPTIONS)["grpc.service_config"])
+        self.assertIn("loadBalancingConfig", cfg)
+        self.assertIn("methodConfig", cfg)
+
+    def test_load_balancing_is_round_robin(self):
+        """LB config selects round_robin (needed for multi-endpoint failover)."""
+        cfg = json.loads(dict(DEFAULT_CHANNEL_OPTIONS)["grpc.service_config"])
+        self.assertEqual(cfg["loadBalancingConfig"], [{"round_robin": {}}])
+
+    def test_retry_policy_only_retries_unavailable(self):
+        """Only UNAVAILABLE is retried.
+
+        DEADLINE_EXCEEDED and RESOURCE_EXHAUSTED are unsafe (server may
+        have partially executed) and must not be in the list.
+        """
+        cfg = json.loads(dict(DEFAULT_CHANNEL_OPTIONS)["grpc.service_config"])
+        policy = cfg["methodConfig"][0]["retryPolicy"]
+        self.assertEqual(policy["retryableStatusCodes"], ["UNAVAILABLE"])
+
+    def test_retry_policy_max_attempts_and_backoff(self):
+        """Bounded retry budget: 4 attempts, 0.5s→5s exponential."""
+        cfg = json.loads(dict(DEFAULT_CHANNEL_OPTIONS)["grpc.service_config"])
+        policy = cfg["methodConfig"][0]["retryPolicy"]
+        self.assertEqual(policy["maxAttempts"], 4)
+        self.assertEqual(policy["initialBackoff"], "0.5s")
+        self.assertEqual(policy["maxBackoff"], "5s")
+        self.assertEqual(policy["backoffMultiplier"], 2)
+
+    def test_method_config_applies_to_every_method(self):
+        """Method config `name=[{}]` matches every RPC — applies to all CRDs."""
+        cfg = json.loads(dict(DEFAULT_CHANNEL_OPTIONS)["grpc.service_config"])
+        self.assertEqual(cfg["methodConfig"][0]["name"], [{}])
+
+    def test_get_channel_options_returns_default(self):
+        """Getter returns the default list contents (by value)."""
+        self.assertEqual(get_channel_options(), DEFAULT_CHANNEL_OPTIONS)
+
+    def test_get_channel_options_returns_fresh_copy(self):
+        """Getter returns a fresh list so callers can't mutate the default."""
+        result = get_channel_options()
+        result.append(("grpc.max_send_message_length", 1))
+        # Default is unchanged.
+        self.assertNotIn(
+            ("grpc.max_send_message_length", 1), DEFAULT_CHANNEL_OPTIONS
+        )

--- a/python/michelangelo/cli/mactl/config_test.py
+++ b/python/michelangelo/cli/mactl/config_test.py
@@ -419,6 +419,4 @@ class ChannelOptionsTest(TestCase):
         result = get_channel_options()
         result.append(("grpc.max_send_message_length", 1))
         # Default is unchanged.
-        self.assertNotIn(
-            ("grpc.max_send_message_length", 1), DEFAULT_CHANNEL_OPTIONS
-        )
+        self.assertNotIn(("grpc.max_send_message_length", 1), DEFAULT_CHANNEL_OPTIONS)

--- a/python/michelangelo/cli/mactl/mactl.py
+++ b/python/michelangelo/cli/mactl/mactl.py
@@ -4,7 +4,6 @@ A command line interface to interact with the Michelangelo API server via gRPC.
 """
 
 import importlib
-import json
 import logging
 import pkgutil
 import re
@@ -24,6 +23,7 @@ from grpc import (
     ssl_channel_credentials,
 )
 
+from michelangelo.cli.mactl import config as _config
 from michelangelo.cli.mactl.config import load_config, setup_minio_env
 from michelangelo.cli.mactl.crd import CRD, yaml_to_dict
 from michelangelo.cli.mactl.grpc_tools import list_services
@@ -46,35 +46,6 @@ _LOG = getLogger(__name__)
 
 PWD = Path(__file__).parent.resolve()
 DEFAULT_DIR_PLUGINS = PWD / "plugins"
-
-# gRPC channel options: retry transient UNAVAILABLE + round-robin across
-# resolved endpoints. Applied to every channel constructed below so a
-# briefly-flaky backend or single-node outage no longer surfaces as a
-# hard failure to the user. UNAVAILABLE is the only retryable code per
-# gRPC spec (server didn't ack, safe to replay); round_robin needs a
-# multi-endpoint resolver to actually failover — with pick_first it is
-# a no-op but harmless.
-_RETRY_SERVICE_CONFIG = json.dumps(
-    {
-        "loadBalancingConfig": [{"round_robin": {}}],
-        "methodConfig": [
-            {
-                "name": [{}],
-                "retryPolicy": {
-                    "maxAttempts": 4,
-                    "initialBackoff": "0.5s",
-                    "maxBackoff": "5s",
-                    "backoffMultiplier": 2,
-                    "retryableStatusCodes": ["UNAVAILABLE"],
-                },
-            }
-        ],
-    }
-)
-_CHANNEL_OPTIONS = [
-    ("grpc.enable_retries", 1),
-    ("grpc.service_config", _RETRY_SERVICE_CONFIG),
-]
 
 _LOG.info(f"Config: ADDRESS={ADDRESS}, USE_TLS={USE_TLS}, METADATA={METADATA}")
 
@@ -767,7 +738,9 @@ def run():
         cli_proxy_class = proxy_mod.CLIProxy
         with cli_proxy_class() as proxy:
             local_address = proxy.create_tunnel(ADDRESS)
-            with insecure_channel(local_address, options=_CHANNEL_OPTIONS) as channel:
+            with insecure_channel(
+                local_address, options=_config.get_channel_options()
+            ) as channel:
                 return main(channel, plugin_registry)
 
     if USE_TLS:
@@ -778,7 +751,7 @@ def run():
         )
         # Use secure TLS connection
         with secure_channel(
-            ADDRESS, ssl_channel_credentials(), options=_CHANNEL_OPTIONS
+            ADDRESS, ssl_channel_credentials(), options=_config.get_channel_options()
         ) as channel:
             return main(channel, plugin_registry)
 
@@ -788,7 +761,7 @@ def run():
         ADDRESS,
     )
     # Use insecure connection for local development
-    with insecure_channel(ADDRESS, options=_CHANNEL_OPTIONS) as channel:
+    with insecure_channel(ADDRESS, options=_config.get_channel_options()) as channel:
         return main(channel, plugin_registry)
 
 

--- a/python/michelangelo/cli/mactl/mactl.py
+++ b/python/michelangelo/cli/mactl/mactl.py
@@ -4,6 +4,7 @@ A command line interface to interact with the Michelangelo API server via gRPC.
 """
 
 import importlib
+import json
 import logging
 import pkgutil
 import re
@@ -45,6 +46,35 @@ _LOG = getLogger(__name__)
 
 PWD = Path(__file__).parent.resolve()
 DEFAULT_DIR_PLUGINS = PWD / "plugins"
+
+# gRPC channel options: retry transient UNAVAILABLE + round-robin across
+# resolved endpoints. Applied to every channel constructed below so a
+# briefly-flaky backend or single-node outage no longer surfaces as a
+# hard failure to the user. UNAVAILABLE is the only retryable code per
+# gRPC spec (server didn't ack, safe to replay); round_robin needs a
+# multi-endpoint resolver to actually failover — with pick_first it is
+# a no-op but harmless.
+_RETRY_SERVICE_CONFIG = json.dumps(
+    {
+        "loadBalancingConfig": [{"round_robin": {}}],
+        "methodConfig": [
+            {
+                "name": [{}],
+                "retryPolicy": {
+                    "maxAttempts": 4,
+                    "initialBackoff": "0.5s",
+                    "maxBackoff": "5s",
+                    "backoffMultiplier": 2,
+                    "retryableStatusCodes": ["UNAVAILABLE"],
+                },
+            }
+        ],
+    }
+)
+_CHANNEL_OPTIONS = [
+    ("grpc.enable_retries", 1),
+    ("grpc.service_config", _RETRY_SERVICE_CONFIG),
+]
 
 _LOG.info(f"Config: ADDRESS={ADDRESS}, USE_TLS={USE_TLS}, METADATA={METADATA}")
 
@@ -737,7 +767,7 @@ def run():
         cli_proxy_class = proxy_mod.CLIProxy
         with cli_proxy_class() as proxy:
             local_address = proxy.create_tunnel(ADDRESS)
-            with insecure_channel(local_address) as channel:
+            with insecure_channel(local_address, options=_CHANNEL_OPTIONS) as channel:
                 return main(channel, plugin_registry)
 
     if USE_TLS:
@@ -747,7 +777,9 @@ def run():
             ADDRESS,
         )
         # Use secure TLS connection
-        with secure_channel(ADDRESS, ssl_channel_credentials()) as channel:
+        with secure_channel(
+            ADDRESS, ssl_channel_credentials(), options=_CHANNEL_OPTIONS
+        ) as channel:
             return main(channel, plugin_registry)
 
     _LOG.info(
@@ -756,7 +788,7 @@ def run():
         ADDRESS,
     )
     # Use insecure connection for local development
-    with insecure_channel(ADDRESS) as channel:
+    with insecure_channel(ADDRESS, options=_CHANNEL_OPTIONS) as channel:
         return main(channel, plugin_registry)
 
 

--- a/python/michelangelo/cli/mactl/mactl_test.py
+++ b/python/michelangelo/cli/mactl/mactl_test.py
@@ -1,6 +1,5 @@
 """Unit tests for mactl CLI functions."""
 
-import json
 import os
 import sys
 import tempfile
@@ -11,7 +10,7 @@ from pathlib import Path
 from unittest import TestCase
 from unittest.mock import ANY, MagicMock, Mock, patch
 
-from michelangelo.cli.mactl import mactl
+from michelangelo.cli.mactl import config, mactl
 from michelangelo.cli.mactl.crd import CRD
 from michelangelo.cli.mactl.mactl import (
     ADDRESS,
@@ -183,56 +182,6 @@ class TLSConfigurationTest(TestCase):
         """Test that invalid values for MACTL_USE_TLS are handled."""
         reload(mactl)
         self.assertEqual(mactl.USE_TLS, False)
-
-
-class ChannelOptionsTest(TestCase):
-    """Retry + LB gRPC service_config on every constructed channel.
-
-    Verifies _CHANNEL_OPTIONS carries a well-formed service_config with
-    retry on UNAVAILABLE + round_robin LB, so transient blips no longer
-    surface as hard errors from run().
-    """
-
-    def test_options_include_enable_retries_and_service_config(self):
-        """Both grpc.enable_retries and grpc.service_config are set."""
-        opts = dict(mactl._CHANNEL_OPTIONS)
-        self.assertEqual(opts["grpc.enable_retries"], 1)
-        self.assertIn("grpc.service_config", opts)
-
-    def test_service_config_is_valid_json(self):
-        """service_config JSON parses and has the expected top-level keys."""
-        cfg = json.loads(dict(mactl._CHANNEL_OPTIONS)["grpc.service_config"])
-        self.assertIn("loadBalancingConfig", cfg)
-        self.assertIn("methodConfig", cfg)
-
-    def test_load_balancing_is_round_robin(self):
-        """LB config selects round_robin (needed for multi-endpoint failover)."""
-        cfg = json.loads(dict(mactl._CHANNEL_OPTIONS)["grpc.service_config"])
-        self.assertEqual(cfg["loadBalancingConfig"], [{"round_robin": {}}])
-
-    def test_retry_policy_only_retries_unavailable(self):
-        """Only UNAVAILABLE is retried.
-
-        DEADLINE_EXCEEDED and RESOURCE_EXHAUSTED are unsafe (server may
-        have partially executed) and must not be in the list.
-        """
-        cfg = json.loads(dict(mactl._CHANNEL_OPTIONS)["grpc.service_config"])
-        policy = cfg["methodConfig"][0]["retryPolicy"]
-        self.assertEqual(policy["retryableStatusCodes"], ["UNAVAILABLE"])
-
-    def test_retry_policy_max_attempts_and_backoff(self):
-        """Bounded retry budget: 4 attempts, 0.5s→5s exponential."""
-        cfg = json.loads(dict(mactl._CHANNEL_OPTIONS)["grpc.service_config"])
-        policy = cfg["methodConfig"][0]["retryPolicy"]
-        self.assertEqual(policy["maxAttempts"], 4)
-        self.assertEqual(policy["initialBackoff"], "0.5s")
-        self.assertEqual(policy["maxBackoff"], "5s")
-        self.assertEqual(policy["backoffMultiplier"], 2)
-
-    def test_method_config_applies_to_every_method(self):
-        """Method config `name=[{}]` matches every RPC — applies to all CRDs."""
-        cfg = json.loads(dict(mactl._CHANNEL_OPTIONS)["grpc.service_config"])
-        self.assertEqual(cfg["methodConfig"][0]["name"], [{}])
 
 
 class TLSConnectionTest(TestCase):
@@ -990,7 +939,7 @@ class ProxySupportTest(TestCase):
 
         mock_proxy_instance.create_tunnel.assert_called_once_with("my-service")
         mock_insecure_channel.assert_called_once_with(
-            "localhost:12345", options=mactl._CHANNEL_OPTIONS
+            "localhost:12345", options=config.get_channel_options()
         )
         mock_main.assert_called_once_with(mock_channel, ANY)
 
@@ -1018,7 +967,7 @@ class ProxySupportTest(TestCase):
             run()
 
         mock_insecure_channel.assert_called_once_with(
-            "localhost:8080", options=mactl._CHANNEL_OPTIONS
+            "localhost:8080", options=config.get_channel_options()
         )
         mock_main.assert_called_once_with(mock_channel, ANY)
 
@@ -1046,7 +995,7 @@ class ProxySupportTest(TestCase):
             run()
 
         mock_insecure_channel.assert_called_once_with(
-            "my-service", options=mactl._CHANNEL_OPTIONS
+            "my-service", options=config.get_channel_options()
         )
         mock_main.assert_called_once_with(mock_channel, ANY)
 

--- a/python/michelangelo/cli/mactl/mactl_test.py
+++ b/python/michelangelo/cli/mactl/mactl_test.py
@@ -1,5 +1,6 @@
 """Unit tests for mactl CLI functions."""
 
+import json
 import os
 import sys
 import tempfile
@@ -182,6 +183,56 @@ class TLSConfigurationTest(TestCase):
         """Test that invalid values for MACTL_USE_TLS are handled."""
         reload(mactl)
         self.assertEqual(mactl.USE_TLS, False)
+
+
+class ChannelOptionsTest(TestCase):
+    """Retry + LB gRPC service_config on every constructed channel.
+
+    Verifies _CHANNEL_OPTIONS carries a well-formed service_config with
+    retry on UNAVAILABLE + round_robin LB, so transient blips no longer
+    surface as hard errors from run().
+    """
+
+    def test_options_include_enable_retries_and_service_config(self):
+        """Both grpc.enable_retries and grpc.service_config are set."""
+        opts = dict(mactl._CHANNEL_OPTIONS)
+        self.assertEqual(opts["grpc.enable_retries"], 1)
+        self.assertIn("grpc.service_config", opts)
+
+    def test_service_config_is_valid_json(self):
+        """service_config JSON parses and has the expected top-level keys."""
+        cfg = json.loads(dict(mactl._CHANNEL_OPTIONS)["grpc.service_config"])
+        self.assertIn("loadBalancingConfig", cfg)
+        self.assertIn("methodConfig", cfg)
+
+    def test_load_balancing_is_round_robin(self):
+        """LB config selects round_robin (needed for multi-endpoint failover)."""
+        cfg = json.loads(dict(mactl._CHANNEL_OPTIONS)["grpc.service_config"])
+        self.assertEqual(cfg["loadBalancingConfig"], [{"round_robin": {}}])
+
+    def test_retry_policy_only_retries_unavailable(self):
+        """Only UNAVAILABLE is retried.
+
+        DEADLINE_EXCEEDED and RESOURCE_EXHAUSTED are unsafe (server may
+        have partially executed) and must not be in the list.
+        """
+        cfg = json.loads(dict(mactl._CHANNEL_OPTIONS)["grpc.service_config"])
+        policy = cfg["methodConfig"][0]["retryPolicy"]
+        self.assertEqual(policy["retryableStatusCodes"], ["UNAVAILABLE"])
+
+    def test_retry_policy_max_attempts_and_backoff(self):
+        """Bounded retry budget: 4 attempts, 0.5s→5s exponential."""
+        cfg = json.loads(dict(mactl._CHANNEL_OPTIONS)["grpc.service_config"])
+        policy = cfg["methodConfig"][0]["retryPolicy"]
+        self.assertEqual(policy["maxAttempts"], 4)
+        self.assertEqual(policy["initialBackoff"], "0.5s")
+        self.assertEqual(policy["maxBackoff"], "5s")
+        self.assertEqual(policy["backoffMultiplier"], 2)
+
+    def test_method_config_applies_to_every_method(self):
+        """Method config `name=[{}]` matches every RPC — applies to all CRDs."""
+        cfg = json.loads(dict(mactl._CHANNEL_OPTIONS)["grpc.service_config"])
+        self.assertEqual(cfg["methodConfig"][0]["name"], [{}])
 
 
 class TLSConnectionTest(TestCase):
@@ -938,7 +989,9 @@ class ProxySupportTest(TestCase):
             run()
 
         mock_proxy_instance.create_tunnel.assert_called_once_with("my-service")
-        mock_insecure_channel.assert_called_once_with("localhost:12345")
+        mock_insecure_channel.assert_called_once_with(
+            "localhost:12345", options=mactl._CHANNEL_OPTIONS
+        )
         mock_main.assert_called_once_with(mock_channel, ANY)
 
     @patch("michelangelo.cli.mactl.mactl.main")
@@ -964,7 +1017,9 @@ class ProxySupportTest(TestCase):
 
             run()
 
-        mock_insecure_channel.assert_called_once_with("localhost:8080")
+        mock_insecure_channel.assert_called_once_with(
+            "localhost:8080", options=mactl._CHANNEL_OPTIONS
+        )
         mock_main.assert_called_once_with(mock_channel, ANY)
 
     @patch("michelangelo.cli.mactl.mactl.main")
@@ -990,7 +1045,9 @@ class ProxySupportTest(TestCase):
 
             run()
 
-        mock_insecure_channel.assert_called_once_with("my-service")
+        mock_insecure_channel.assert_called_once_with(
+            "my-service", options=mactl._CHANNEL_OPTIONS
+        )
         mock_main.assert_called_once_with(mock_channel, ANY)
 
 

--- a/python/michelangelo/cli/mactl/mactl_test.py
+++ b/python/michelangelo/cli/mactl/mactl_test.py
@@ -999,6 +999,34 @@ class ProxySupportTest(TestCase):
         )
         mock_main.assert_called_once_with(mock_channel, ANY)
 
+    @patch("michelangelo.cli.mactl.mactl.main")
+    @patch("michelangelo.cli.mactl.mactl.ssl_channel_credentials")
+    @patch("michelangelo.cli.mactl.mactl.secure_channel")
+    @patch("michelangelo.cli.mactl.mactl._CONFIG")
+    def test_run_with_tls(
+        self, mock_config, mock_secure_channel, mock_ssl_creds, mock_main
+    ):
+        """TLS branch: secure_channel gets ADDRESS + creds + shared channel options."""
+        mock_channel = MagicMock()
+        mock_secure_channel.return_value.__enter__ = Mock(return_value=mock_channel)
+        mock_secure_channel.return_value.__exit__ = Mock(return_value=None)
+        mock_ssl_creds.return_value = "ssl-creds"
+
+        mock_config.__getitem__.return_value = {"proxy": ""}
+
+        with (
+            patch("michelangelo.cli.mactl.mactl.ADDRESS", "api.example.com"),
+            patch("michelangelo.cli.mactl.mactl.USE_TLS", True),
+        ):
+            from michelangelo.cli.mactl.mactl import run
+
+            run()
+
+        mock_secure_channel.assert_called_once_with(
+            "api.example.com", "ssl-creds", options=config.get_channel_options()
+        )
+        mock_main.assert_called_once_with(mock_channel, ANY)
+
 
 PLUGIN_TEST_DIR_1 = PLUGIN_TEST_DIR / "plugins_1"
 PLUGIN_TEST_DIR_2 = PLUGIN_TEST_DIR / "plugins_2"


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Feature

**What changed?**

Adds gRPC `service_config` with client-side retry on `UNAVAILABLE` (`maxAttempts=4`, exponential backoff `0.5s → 5s`) and `round_robin` load balancing to every channel constructed by mactl's `run()` (cliproxy tunnel, TLS, insecure). Applied via `grpc.enable_retries=1` + `grpc.service_config`. Defaults live in `config.py` as `DEFAULT_CHANNEL_OPTIONS`, exposed through `get_channel_options()` so downstream consumers can override the retry budget or LB policy without patching mactl.

**Why?**

A transient apiserver blip (pod restart, brief network reset) surfaces today as a hard `_InactiveRpcError` to the user with no automatic recovery. `UNAVAILABLE` is the one status code gRPC's spec marks retryable-by-default (server didn't ack, safe to replay), so client-side retry closes the common flake case. `round_robin` behaves like `pick_first` while the resolver returns a single endpoint but takes effect once multi-endpoint resolution is added.

**How did you test it?**

| Scenario | Command | Result |
|---|---|---|
| Full mactl + config suite | `pytest michelangelo/cli/mactl/` | passes (except pre-existing `TLSConfigurationTest::test_use_tls_default_value`, also fails on `origin/main`) |
| Channel options unit | `pytest michelangelo/cli/mactl/config_test.py -k ChannelOptions` | 2 pass — full service_config shape drift check + getter fresh-copy invariant |
| Proxy + TLS regression | `pytest michelangelo/cli/mactl/mactl_test.py -k ProxySupport` | 4 pass — asserts `options=config.get_channel_options()` on cliproxy, host:port, service-name, and TLS channels |
| End-to-end retry loop | `time (MACTL_ADDRESS=localhost:44444 MACTL_USE_TLS=false ma pipeline get x -n y)` | 4.7s wall time (was ~1s without change); matches 0.5+1+2s backoffs across 4 attempts. Error string switched from pick_first (`"failed to connect to all addresses"`) to round_robin (`"connections to all backends failing"`) — confirms service_config applied end-to-end. |
| Style | `ruff check` + `ruff format --check` | clean |

**Potential risks**

No real risks: retry budget is bounded (4 attempts, ~3.5s of backoffs) and capped by the existing 30s per-RPC deadline in `crd.py`. `retryableStatusCodes` is scoped to `UNAVAILABLE` only — never `DEADLINE_EXCEEDED` or `RESOURCE_EXHAUSTED`, which can partially execute.

**Breaking Changes**

- [x] No breaking changes

**Release notes**

`ma` CLI now retries transient gRPC `UNAVAILABLE` responses (up to 4 attempts, exponential backoff) and uses `round_robin` LB — briefly-flaky apiservers no longer surface as user-visible errors.

**Documentation Changes**

None.
