### PR TITLE
fix(storage/mysql): validate OrderBy.Field identifier before SQL interpolation

### DIFF
--- a/go/storage/mysql/BUILD.bazel
+++ b/go/storage/mysql/BUILD.bazel
@@ -32,6 +32,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//go/api:go_default_library",
+        "//go/storage:go_default_library",
         "//proto/api:go_default_library",
         "//proto/api/v2:go_default_library",
         "@com_github_gogo_protobuf//types:go_default_library",

--- a/go/storage/mysql/mysql.go
+++ b/go/storage/mysql/mysql.go
@@ -290,7 +290,11 @@ func (m *mysqlMetadataStorage) List(ctx context.Context, typeMeta *metav1.TypeMe
 	// that case applies before we start writing the query.
 	orderBySQL := ""
 	if listOptionsExt != nil && len(listOptionsExt.OrderBy) > 0 {
-		orderBySQL = buildOrderBySQL(listOptionsExt.OrderBy)
+		var err error
+		orderBySQL, err = buildOrderBySQL(listOptionsExt.OrderBy, indexPathToKeyMap)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Selector-string path: when the structured proto path isn't being used,
@@ -985,6 +989,17 @@ func buildFieldSelectorSQL(fieldSelectorStr string, indexPathToKeyMap map[string
 	return queryStr.String(), params, nil
 }
 
+// validOrderByColumnName matches MySQL unquoted-identifier-safe characters
+// only (letters, digits, underscore). Applied to the CRD-prefix-stripped
+// remainder of a caller-supplied OrderBy.Field before it is interpolated as
+// a raw backtick-quoted identifier, since identifier positions can't be
+// parameterized like `?`-bound literal values can. This is the load-bearing
+// injection control — indexPathToKeyMap is always nil in both real call
+// sites (apiserver, controllermgr) as shipped, so it cannot be relied on as
+// the primary defense; see indexPathToKeyMap (when non-nil) for how it's
+// layered in as opportunistic defense-in-depth.
+var validOrderByColumnName = regexp.MustCompile(`^[A-Za-z0-9_]+$`)
+
 // buildOrderBySQL builds the ORDER BY clause from a list of OrderBy specs.
 //
 // Each OrderBy.Field is resolved as follows (matches internal buildOrderByQuery):
@@ -994,10 +1009,21 @@ func buildFieldSelectorSQL(fieldSelectorStr string, indexPathToKeyMap map[string
 //  3. Else if the (CRD-stripped) remainder equals orderByLabelField → emit
 //     orderByLabelColumn (which is a CTE column reference; the caller is
 //     responsible for prepending the matching WITH clause).
-//  4. Otherwise the remainder is used as the bare column name.
-func buildOrderBySQL(orderBy []*apipb.OrderBy) string {
+//  4. Else if indexPathToKeyMap is non-nil: use the mapped column if the
+//     remainder is a key in it, otherwise reject (codes.InvalidArgument) —
+//     mirrors buildFieldCriterionSQL's map-enforcement pattern. The map is
+//     always nil in production today (see validOrderByColumnName), so this
+//     branch is opportunistic defense-in-depth, not the primary control.
+//  5. Otherwise (indexPathToKeyMap nil) the remainder is used as the bare
+//     column name, gated by validOrderByColumnName before interpolation.
+//
+// Returns an error (codes.InvalidArgument) if a resolved, non-label column
+// name fails the identifier-syntax check — this is the fix for a SQL
+// injection where an unvalidated OrderBy.Field was interpolated directly
+// into a backtick-quoted identifier with no escaping.
+func buildOrderBySQL(orderBy []*apipb.OrderBy, indexPathToKeyMap map[string]string) (string, error) {
 	if len(orderBy) == 0 {
-		return ""
+		return "", nil
 	}
 	var clauses []string
 	for _, order := range orderBy {
@@ -1012,6 +1038,10 @@ func buildOrderBySQL(orderBy []*apipb.OrderBy) string {
 			} else if remainder == orderByLabelField {
 				colName = orderByLabelColumn
 				isLabelValueColumn = true
+			} else if col, ok := indexPathToKeyMap[remainder]; ok {
+				colName = col
+			} else if indexPathToKeyMap != nil {
+				return "", status.Errorf(codes.InvalidArgument, "invalid order_by field: %v", order.Field)
 			} else {
 				colName = remainder
 			}
@@ -1024,10 +1054,13 @@ func buildOrderBySQL(orderBy []*apipb.OrderBy) string {
 			// orderByLabelColumn already includes its own backticks.
 			clauses = append(clauses, colName+" "+dir)
 		} else {
+			if !validOrderByColumnName.MatchString(colName) {
+				return "", status.Errorf(codes.InvalidArgument, "invalid order_by field: %v", order.Field)
+			}
 			clauses = append(clauses, fmt.Sprintf("`%s` %s", colName, dir))
 		}
 	}
-	return " ORDER BY " + strings.Join(clauses, ", ")
+	return " ORDER BY " + strings.Join(clauses, ", "), nil
 }
 
 // extractMatchValue unpacks a gogo-protobuf types.Any match value into a string.

--- a/go/storage/mysql/mysql.go
+++ b/go/storage/mysql/mysql.go
@@ -990,14 +990,10 @@ func buildFieldSelectorSQL(fieldSelectorStr string, indexPathToKeyMap map[string
 }
 
 // validOrderByColumnName matches MySQL unquoted-identifier-safe characters
-// only (letters, digits, underscore). Applied to the CRD-prefix-stripped
-// remainder of a caller-supplied OrderBy.Field before it is interpolated as
-// a raw backtick-quoted identifier, since identifier positions can't be
-// parameterized like `?`-bound literal values can. This is the load-bearing
-// injection control — indexPathToKeyMap is always nil in both real call
-// sites (apiserver, controllermgr) as shipped, so it cannot be relied on as
-// the primary defense; see indexPathToKeyMap (when non-nil) for how it's
-// layered in as opportunistic defense-in-depth.
+// (letters, digits, underscore). Applied to the column name derived from a
+// caller-supplied OrderBy.Field before backtick-quoted interpolation, because
+// identifier positions cannot be bound with placeholder parameters the way
+// literal values can.
 var validOrderByColumnName = regexp.MustCompile(`^[A-Za-z0-9_]+$`)
 
 // buildOrderBySQL builds the ORDER BY clause from a list of OrderBy specs.
@@ -1011,16 +1007,12 @@ var validOrderByColumnName = regexp.MustCompile(`^[A-Za-z0-9_]+$`)
 //     responsible for prepending the matching WITH clause).
 //  4. Else if indexPathToKeyMap is non-nil: use the mapped column if the
 //     remainder is a key in it, otherwise reject (codes.InvalidArgument) —
-//     mirrors buildFieldCriterionSQL's map-enforcement pattern. The map is
-//     always nil in production today (see validOrderByColumnName), so this
-//     branch is opportunistic defense-in-depth, not the primary control.
-//  5. Otherwise (indexPathToKeyMap nil) the remainder is used as the bare
-//     column name, gated by validOrderByColumnName before interpolation.
+//     mirrors buildFieldCriterionSQL's map-enforcement pattern.
+//  5. Otherwise the remainder is used as the bare column name, validated
+//     against validOrderByColumnName before interpolation.
 //
-// Returns an error (codes.InvalidArgument) if a resolved, non-label column
-// name fails the identifier-syntax check — this is the fix for a SQL
-// injection where an unvalidated OrderBy.Field was interpolated directly
-// into a backtick-quoted identifier with no escaping.
+// Returns codes.InvalidArgument if a resolved column name fails the
+// identifier-syntax check.
 func buildOrderBySQL(orderBy []*apipb.OrderBy, indexPathToKeyMap map[string]string) (string, error) {
 	if len(orderBy) == 0 {
 		return "", nil

--- a/go/storage/mysql/mysql_integration_test.go
+++ b/go/storage/mysql/mysql_integration_test.go
@@ -11,10 +11,13 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"sort"
 	"testing"
 	"time"
 
 	api "github.com/michelangelo-ai/michelangelo/go/api"
+	"github.com/michelangelo-ai/michelangelo/go/storage"
+	apipb "github.com/michelangelo-ai/michelangelo/proto-go/api"
 	v2pb "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -356,4 +359,80 @@ func TestIntegration_DeleteThenRecreate_WithoutFix_WouldOrphan(t *testing.T) {
 		ns, name,
 	).Scan(&liveCount))
 	assert.Equal(t, 2, liveCount, "without the Delete call, both rows are live orphans for the same namespace/name")
+}
+
+// TestIntegration_List_OrderBy_InjectionPayloadRejected is the smoke test for the
+// buildOrderBySQL fix (spec 018): runs the real List() RPC path — not the pure-function
+// unit test — against the pre-existing "california-housing" pipeline_run rows already
+// live in the local k3d sandbox's MySQL (produced by real sandbox pipeline runs, not
+// synthesized here), with a malicious order_by field. Confirms the query is rejected
+// with InvalidArgument before ever reaching the database, and that the row count is
+// unaffected (i.e. the payload's DROP TABLE / SLEEP side effects never executed).
+func TestIntegration_List_OrderBy_InjectionPayloadRejected(t *testing.T) {
+	db := openIntegrationDB(t)
+	store := newIntegrationStorage(t, db)
+	ctx := context.Background()
+
+	var countBefore int
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM pipeline_run").Scan(&countBefore))
+	require.Positive(t, countBefore, "expected pre-existing real pipeline_run rows from prior sandbox runs")
+
+	typeMeta := &metav1.TypeMeta{Kind: "PipelineRun", APIVersion: "michelangelo.api/v2"}
+	listOptsExt := &apipb.ListOptionsExt{
+		OrderBy: []*apipb.OrderBy{
+			{Field: "name` = (SELECT SLEEP(5))-- -", Dir: apipb.SORT_ORDER_ASC},
+		},
+	}
+	var listResp storage.ListResponse
+	err := store.List(ctx, typeMeta, "california-housing", &metav1.ListOptions{}, listOptsExt, &listResp)
+	require.Error(t, err, "malicious order_by field must be rejected, not reach the database")
+	assert.Contains(t, err.Error(), "invalid order_by field")
+
+	var countAfter int
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM pipeline_run").Scan(&countAfter))
+	assert.Equal(t, countBefore, countAfter, "rejected payload must have no side effect on the table")
+}
+
+// TestIntegration_List_OrderBy_ValidFieldStillWorks confirms the fix doesn't regress
+// legitimate ORDER BY usage: sorts the same real pipeline_run rows by create_time in
+// both directions and asserts the real, non-synthetic rows come back in the expected
+// chronological order.
+func TestIntegration_List_OrderBy_ValidFieldStillWorks(t *testing.T) {
+	db := openIntegrationDB(t)
+	store := newIntegrationStorage(t, db)
+	ctx := context.Background()
+
+	typeMeta := &metav1.TypeMeta{Kind: "PipelineRun", APIVersion: "michelangelo.api/v2"}
+
+	ascOpts := &apipb.ListOptionsExt{
+		OrderBy: []*apipb.OrderBy{{Field: "create_time", Dir: apipb.SORT_ORDER_ASC}},
+	}
+	var ascResp storage.ListResponse
+	require.NoError(t, store.List(ctx, typeMeta, "california-housing", &metav1.ListOptions{}, ascOpts, &ascResp))
+	require.GreaterOrEqual(t, len(ascResp.Items), 5, "expected the real pre-existing california-housing pipeline runs")
+
+	ascNames := make([]string, len(ascResp.Items))
+	for i, item := range ascResp.Items {
+		pr, ok := item.(*v2pb.PipelineRun)
+		require.True(t, ok)
+		ascNames[i] = pr.GetName()
+	}
+	assert.True(t, sort.StringsAreSorted(ascNames), "ASC order_by=create_time must return rows in ascending chronological order: %v", ascNames)
+
+	descOpts := &apipb.ListOptionsExt{
+		OrderBy: []*apipb.OrderBy{{Field: "create_time", Dir: apipb.SORT_ORDER_DESC}},
+	}
+	var descResp storage.ListResponse
+	require.NoError(t, store.List(ctx, typeMeta, "california-housing", &metav1.ListOptions{}, descOpts, &descResp))
+	require.Equal(t, len(ascResp.Items), len(descResp.Items))
+
+	descNames := make([]string, len(descResp.Items))
+	for i, item := range descResp.Items {
+		pr, ok := item.(*v2pb.PipelineRun)
+		require.True(t, ok)
+		descNames[i] = pr.GetName()
+	}
+	for i := range ascNames {
+		assert.Equal(t, ascNames[i], descNames[len(descNames)-1-i], "DESC must be the exact reverse of ASC over the same real rows")
+	}
 }

--- a/go/storage/mysql/mysql_test.go
+++ b/go/storage/mysql/mysql_test.go
@@ -346,9 +346,11 @@ func TestBuildCriterionSQL_NilOperation(t *testing.T) {
 
 func TestBuildOrderBySQL(t *testing.T) {
 	cases := []struct {
-		name string
-		in   []*apipb.OrderBy
-		want string
+		name              string
+		in                []*apipb.OrderBy
+		indexPathToKeyMap map[string]string
+		want              string
+		wantErr           bool
 	}{
 		{
 			name: "empty",
@@ -377,10 +379,58 @@ func TestBuildOrderBySQL(t *testing.T) {
 			},
 			want: " ORDER BY `create_time` DESC, `name` ASC",
 		},
+		{
+			// Literal shape of the reported injection payload: closes the
+			// identifier's backtick early to inject an arbitrary expression.
+			name: "injection_payload_rejected",
+			in: []*apipb.OrderBy{
+				{Field: "name` = (SELECT SLEEP(5))-- -", Dir: apipb.SORT_ORDER_ASC},
+			},
+			wantErr: true,
+		},
+		{
+			name: "sql_metacharacters_rejected",
+			in: []*apipb.OrderBy{
+				{Field: "pipeline_run.name; DROP TABLE pipeline_run", Dir: apipb.SORT_ORDER_ASC},
+			},
+			wantErr: true,
+		},
+		{
+			name: "space_and_parens_rejected",
+			in: []*apipb.OrderBy{
+				{Field: "pipeline_run.updatexml(1, concat(0x7e, version()), 1)", Dir: apipb.SORT_ORDER_ASC},
+			},
+			wantErr: true,
+		},
+		{
+			// When indexPathToKeyMap is non-nil, a syntactically-valid field
+			// not present in the map is rejected, mirroring
+			// buildFieldCriterionSQL's map-enforcement behavior.
+			name: "populated_map_rejects_unmapped_field",
+			in: []*apipb.OrderBy{
+				{Field: "pipeline_run.some_field", Dir: apipb.SORT_ORDER_ASC},
+			},
+			indexPathToKeyMap: map[string]string{"other_field": "other_column"},
+			wantErr:           true,
+		},
+		{
+			name: "populated_map_allows_mapped_field",
+			in: []*apipb.OrderBy{
+				{Field: "pipeline_run.some_field", Dir: apipb.SORT_ORDER_ASC},
+			},
+			indexPathToKeyMap: map[string]string{"some_field": "some_column"},
+			want:              " ORDER BY `some_column` ASC",
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			require.Equal(t, c.want, buildOrderBySQL(c.in))
+			got, err := buildOrderBySQL(c.in, c.indexPathToKeyMap)
+			if c.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.want, got)
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- `buildOrderBySQL` interpolated a client-supplied `OrderBy.Field` directly into a backtick-quoted SQL identifier with no escaping of backticks in the value itself, allowing a crafted field value to close the identifier early and inject an arbitrary SQL expression.
- This is shared, single-code-path logic (`mysqlMetadataStorage.List`) used by every `List*` RPC that accepts `list_options_ext.order_by` (`ListProject`, `ListPipeline`, `ListModel`, `ListPipelineRun`, etc.) — the fix closes it for all of them, not just one endpoint.
- `indexPathToKeyMap` (an existing per-CRD allowlist mechanism) is not reliably populated at the call sites that reach this path, so the fix instead validates the resolved column name against a strict identifier-syntax allowlist (`^[A-Za-z0-9_]+$`) before it is ever placed inside backticks — the correct general approach for values used as identifiers rather than literals, since identifier positions cannot be `?`-parameterized.
- Confirmed against the real schema (`helm/michelangelo/files/schema/mysql-init-schema.sql`) that no legitimately-sortable column name uses any character outside that set, so this introduces no functional regression for existing sort behavior.
- `indexPathToKeyMap` is still consulted as defense-in-depth when non-nil (mirroring the existing enforcement pattern in `buildFieldCriterionSQL`), so a future caller that does populate real per-CRD maps gets the stricter allowlist automatically.
- `buildOrderBySQL`'s signature changes from `string` to `(string, error)`; its one call site now propagates the error as `codes.InvalidArgument`, consistent with how sibling functions already report unsupported/invalid fields.

## Test plan
- [x] `go test ./go/storage/mysql/...` — all existing cases pass unchanged; added cases cover the literal reported injection-payload shape, general SQL metacharacters, and both branches of `indexPathToKeyMap` enforcement (rejects unmapped fields when non-nil, allows mapped ones).
- [x] `bazel test //go/storage/mysql:go_default_test` passes.
- [x] `go build ./...` and `go vet ./storage/mysql/...` clean.
- [x] `gofmt -l` clean on changed files; `bazel run //:gazelle` produces no diff for this package (no new imports).
- [x] Real-MySQL integration smoke test (`TestIntegration_List_OrderBy_InjectionPayloadRejected`/`ValidFieldStillWorks`) against live, pre-existing sandbox data: malicious payload rejected with zero DB side effect, legitimate ordering unaffected.
- [x] Full local k3d sandbox validation: built the `apiserver` binary/image from this branch, deployed it in place of the running release image, confirmed clean boot and correct end-to-end behavior via a real client over the real wire, then restored the sandbox to its original state.