### PR TITLE
fix(ci): nightly.yml npm/helm jobs no longer hardcode stale base version 0.3.0

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -237,8 +237,10 @@ jobs:
       - name: Set nightly chart version
         run: |
           DATE_TAG="${{ needs.check-changes.outputs.date_tag }}"
-          sed -i "s/^version:.*/version: 0.3.0-nightly.${DATE_TAG}/" helm/michelangelo/Chart.yaml
-          sed -i "s/^appVersion:.*/appVersion: \"0.3.0-nightly.${DATE_TAG}\"/" helm/michelangelo/Chart.yaml
+          BASE_VERSION=$(grep '^version:' helm/michelangelo/Chart.yaml | head -1 | sed 's/^version: *//')
+          NIGHTLY_VERSION="${BASE_VERSION}-nightly.${DATE_TAG}"
+          sed -i "s/^version:.*/version: ${NIGHTLY_VERSION}/" helm/michelangelo/Chart.yaml
+          sed -i "s/^appVersion:.*/appVersion: \"${NIGHTLY_VERSION}\"/" helm/michelangelo/Chart.yaml
 
       - name: Add Helm repos
         run: |
@@ -289,7 +291,8 @@ jobs:
       - name: Set nightly version
         run: |
           DATE_TAG="${{ needs.check-changes.outputs.date_tag }}"
-          NIGHTLY_VERSION="0.3.0-nightly.${DATE_TAG}"
+          BASE_VERSION=$(jq -r '.version' packages/core/package.json)
+          NIGHTLY_VERSION="${BASE_VERSION}-nightly.${DATE_TAG}"
           jq ".version = \"$NIGHTLY_VERSION\"" packages/core/package.json > /tmp/core-pkg.json && mv /tmp/core-pkg.json packages/core/package.json
           jq ".version = \"$NIGHTLY_VERSION\""  packages/rpc/package.json  > /tmp/rpc-pkg.json  && mv /tmp/rpc-pkg.json  packages/rpc/package.json
           echo "Publishing npm nightly: $NIGHTLY_VERSION"


### PR DESCRIPTION
## Summary

`npm-nightly` and `helm-nightly` jobs in `nightly.yml` both hardcoded `NIGHTLY_VERSION="0.3.0-nightly.${DATE_TAG}"` instead of reading the current base version — a leftover from when this workflow was authored back when the project's version was `0.3.0` (task 007, PR #1379). It's never been updated since, so nightly npm packages and the nightly Helm chart have been reporting a stale `0.3.0-nightly.*` version through every subsequent minor release, even now at v0.6.0.

- `npm-nightly`: reads `BASE_VERSION` from `packages/core/package.json`'s own `version` field, matching `python-nightly`'s existing dynamic-read pattern (`pyproject.toml`). `packages/rpc/package.json` is versioned off the same `$NIGHTLY_VERSION` variable in this job, so it inherits the fix automatically — confirmed both packages are always kept in sync by `scripts/version-bump.sh` on every real release.
- `helm-nightly`: reads `BASE_VERSION` from `helm/michelangelo/Chart.yaml`'s own `version:` field before overwriting both `version:`/`appVersion:` with the nightly-suffixed value.
- `container-nightly`/`ui-nightly` were confirmed clean — they use bare `nightly-${date_tag}` container tags with no embedded base version, so this bug class doesn't apply to them.

Full investigation and root cause writeup: `specs/059/spec.md` in the harness repo.

## Test plan
- [x] `actionlint` clean on the modified `nightly.yml`
- [ ] `workflow_dispatch` test run (or log review) confirming `@michelangelo-ai/core`/`@michelangelo-ai/rpc` publish with the current base version (e.g. `0.6.x-nightly.YYYYMMDD`, not `0.3.0-nightly.*`)
- [ ] Confirm the pushed nightly Helm chart's `version`/`appVersion` reflect the current base version