### PR TITLE
feat(python): --owner and --type filters + OWNER/TYPE columns on pipeline get

### DIFF
--- a/python/michelangelo/cli/mactl/config.py
+++ b/python/michelangelo/cli/mactl/config.py
@@ -35,6 +35,11 @@ DEFAULT_CONFIG = {
         "packages": [],
         "modules": {},
     },
+    # Import path for the generated ``pipeline_pb2`` module the pipeline plugin
+    # consults for PipelineType enum names + values. Downstream distributions
+    # that extend the enum can point this at their own module without patching
+    # the pipeline plugin source.
+    "pipeline_type_pb2_module": "michelangelo.gen.api.v2.pipeline_pb2",
 }
 
 

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/get.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/get.py
@@ -12,6 +12,7 @@ their own generated module without patching this file.
 """
 
 import importlib
+from argparse import ArgumentTypeError
 from inspect import Parameter
 from logging import getLogger
 
@@ -46,10 +47,16 @@ def _pipeline_type_names() -> frozenset[str]:
 def _normalize_pipeline_type(value: str) -> str:
     """Return the full ``PIPELINE_TYPE_*`` name for ``value``.
 
+    Empty / whitespace-only values pass through unchanged so argparse's
+    default="" doesn't trigger validation when the user omits ``--type``.
     Accepts the full name or the short suffix (case-insensitive). Raises
-    ``ValueError`` when the value is not a declared enum member.
+    ``argparse.ArgumentTypeError`` when the value is not a declared enum
+    member — argparse renders that message verbatim.
     """
-    candidate = value.strip().upper()
+    stripped = value.strip()
+    if not stripped:
+        return ""
+    candidate = stripped.upper()
     if not candidate.startswith(_PIPELINE_TYPE_PREFIX):
         candidate = _PIPELINE_TYPE_PREFIX + candidate
     names = _pipeline_type_names()
@@ -59,7 +66,7 @@ def _normalize_pipeline_type(value: str) -> str:
             for n in names
             if n != "PIPELINE_TYPE_INVALID"
         )
-        raise ValueError(
+        raise ArgumentTypeError(
             f"invalid --type {value!r}; expected one of: {', '.join(valid)}"
         )
     return candidate

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/get.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/get.py
@@ -1,0 +1,108 @@
+"""Pipeline get filters + display columns (Owner, Type).
+
+Adds ``--owner`` and ``--type`` to ``pipeline get`` (server-side filter via
+``ListOptionsExt.Operation.Criterion``) and two extra table columns (``OWNER``,
+``TYPE``) rendered per row. Uses the framework hooks on ``CRD``
+(``additional_get_args``, ``filter_field_map``, ``additional_columns``).
+"""
+
+from inspect import Parameter
+from logging import getLogger
+
+from google.protobuf.message import Message
+
+from michelangelo.cli.mactl.crd import CRD
+from michelangelo.gen.api.v2 import pipeline_pb2
+
+_LOG = getLogger(__name__)
+
+_PIPELINE_TYPE_PREFIX = "PIPELINE_TYPE_"
+_PIPELINE_TYPE_NAMES = frozenset(
+    v.name for v in pipeline_pb2.PipelineType.DESCRIPTOR.values
+)
+
+
+def _normalize_pipeline_type(value: str) -> str:
+    """Return the full ``PIPELINE_TYPE_*`` name for ``value``.
+
+    Accepts the full name or the short suffix (case-insensitive). Raises
+    ``ValueError`` when the value is not a declared enum member.
+    """
+    candidate = value.strip().upper()
+    if not candidate.startswith(_PIPELINE_TYPE_PREFIX):
+        candidate = _PIPELINE_TYPE_PREFIX + candidate
+    if candidate not in _PIPELINE_TYPE_NAMES:
+        valid = sorted(
+            n[len(_PIPELINE_TYPE_PREFIX) :]
+            for n in _PIPELINE_TYPE_NAMES
+            if n != "PIPELINE_TYPE_INVALID"
+        )
+        raise ValueError(
+            f"invalid --type {value!r}; expected one of: {', '.join(valid)}"
+        )
+    return candidate
+
+
+def _render_owner(item: Message) -> str:
+    """Column value for OWNER — empty string when spec.owner is unset."""
+    if item.spec.HasField("owner"):
+        return item.spec.owner.name or ""
+    return ""
+
+
+def _render_type(item: Message) -> str:
+    """Column value for TYPE — short name (``PIPELINE_TYPE_`` prefix stripped)."""
+    name = pipeline_pb2.PipelineType.Name(item.spec.type)
+    if name.startswith(_PIPELINE_TYPE_PREFIX):
+        return name[len(_PIPELINE_TYPE_PREFIX) :]
+    return name
+
+
+def add_get_filters(crd: CRD) -> None:
+    """Register --owner / --type filters and OWNER / TYPE columns on ``crd``."""
+    crd.additional_get_args.extend(
+        [
+            {
+                "func_signature": Parameter(
+                    "owner", Parameter.POSITIONAL_OR_KEYWORD, default=""
+                ),
+                "args": ["--owner"],
+                "kwargs": {
+                    "dest": "owner",
+                    "type": str,
+                    "default": "",
+                    "required": False,
+                    "help": "list the pipelines owned by the specified user",
+                },
+            },
+            {
+                "func_signature": Parameter(
+                    "type", Parameter.POSITIONAL_OR_KEYWORD, default=""
+                ),
+                "args": ["--type"],
+                "kwargs": {
+                    "dest": "type",
+                    "type": _normalize_pipeline_type,
+                    "default": "",
+                    "required": False,
+                    "help": (
+                        "list the pipelines of the specified type "
+                        "(e.g. TRAIN, EVAL, UNIFLOW)"
+                    ),
+                },
+            },
+        ]
+    )
+    crd.filter_field_map.update(
+        {
+            "owner": "pipeline.spec.owner.name",
+            "type": "pipeline.spec.type",
+        }
+    )
+    crd.additional_columns.extend(
+        [
+            {"column_name": "OWNER", "retrieve_func": _render_owner},
+            {"column_name": "TYPE", "retrieve_func": _render_type},
+        ]
+    )
+    _LOG.debug("Pipeline get filters + columns registered on crd=%r", crd)

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/get.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/get.py
@@ -4,22 +4,43 @@ Adds ``--owner`` and ``--type`` to ``pipeline get`` (server-side filter via
 ``ListOptionsExt.Operation.Criterion``) and two extra table columns (``OWNER``,
 ``TYPE``) rendered per row. Uses the framework hooks on ``CRD``
 (``additional_get_args``, ``filter_field_map``, ``additional_columns``).
+
+The PipelineType enum module is selected via the ``pipeline_type_pb2_module``
+config key (defaults to ``michelangelo.gen.api.v2.pipeline_pb2``). Distributions
+that extend the enum (e.g. downstream forks with extra values) can point this at
+their own generated module without patching this file.
 """
 
+import importlib
 from inspect import Parameter
 from logging import getLogger
 
 from google.protobuf.message import Message
 
+from michelangelo.cli.mactl.config import load_config
 from michelangelo.cli.mactl.crd import CRD
-from michelangelo.gen.api.v2 import pipeline_pb2
 
 _LOG = getLogger(__name__)
 
 _PIPELINE_TYPE_PREFIX = "PIPELINE_TYPE_"
-_PIPELINE_TYPE_NAMES = frozenset(
-    v.name for v in pipeline_pb2.PipelineType.DESCRIPTOR.values
-)
+_DEFAULT_PB2_MODULE = "michelangelo.gen.api.v2.pipeline_pb2"
+
+
+def _load_pipeline_pb2():
+    """Import the configured ``pipeline_pb2`` module lazily.
+
+    Lazy so importing this plugin module doesn't force resolution of the
+    generated proto — callers only trigger it when the get command actually
+    needs enum names or values.
+    """
+    module_path = load_config().get("pipeline_type_pb2_module", _DEFAULT_PB2_MODULE)
+    return importlib.import_module(module_path)
+
+
+def _pipeline_type_names() -> frozenset[str]:
+    """Enum member names from the configured pipeline_pb2 module."""
+    pb2 = _load_pipeline_pb2()
+    return frozenset(v.name for v in pb2.PipelineType.DESCRIPTOR.values)
 
 
 def _normalize_pipeline_type(value: str) -> str:
@@ -31,10 +52,11 @@ def _normalize_pipeline_type(value: str) -> str:
     candidate = value.strip().upper()
     if not candidate.startswith(_PIPELINE_TYPE_PREFIX):
         candidate = _PIPELINE_TYPE_PREFIX + candidate
-    if candidate not in _PIPELINE_TYPE_NAMES:
+    names = _pipeline_type_names()
+    if candidate not in names:
         valid = sorted(
             n[len(_PIPELINE_TYPE_PREFIX) :]
-            for n in _PIPELINE_TYPE_NAMES
+            for n in names
             if n != "PIPELINE_TYPE_INVALID"
         )
         raise ValueError(
@@ -51,8 +73,17 @@ def _render_owner(item: Message) -> str:
 
 
 def _render_type(item: Message) -> str:
-    """Column value for TYPE — short name (``PIPELINE_TYPE_`` prefix stripped)."""
-    name = pipeline_pb2.PipelineType.Name(item.spec.type)
+    """Column value for TYPE — short name (``PIPELINE_TYPE_`` prefix stripped).
+
+    Falls back to the numeric enum value when the configured pipeline_pb2 does
+    not know this value (e.g. server returns a newer enum than the client's
+    proto knows).
+    """
+    pb2 = _load_pipeline_pb2()
+    try:
+        name = pb2.PipelineType.Name(item.spec.type)
+    except ValueError:
+        return str(item.spec.type)
     if name.startswith(_PIPELINE_TYPE_PREFIX):
         return name[len(_PIPELINE_TYPE_PREFIX) :]
     return name

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/get_test.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/get_test.py
@@ -1,5 +1,6 @@
 """Unit tests for pipeline get filters + display columns."""
 
+from argparse import ArgumentTypeError
 from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
@@ -92,13 +93,21 @@ class NormalizePipelineTypeTest(TestCase):
         self.assertEqual(_normalize_pipeline_type("  train  "), "PIPELINE_TYPE_TRAIN")
 
     def test_unknown_raises_with_valid_list(self):
-        """Unknown value raises ValueError listing the accepted names."""
-        with self.assertRaises(ValueError) as cm:
+        """Unknown value raises ArgumentTypeError listing the accepted names."""
+        with self.assertRaises(ArgumentTypeError) as cm:
             _normalize_pipeline_type("BOGUS")
         msg = str(cm.exception)
         self.assertIn("BOGUS", msg)
         self.assertIn("TRAIN", msg)
         self.assertNotIn("INVALID", msg)
+
+    def test_empty_string_passes_through(self):
+        """Empty argparse default must not trigger validation."""
+        self.assertEqual(_normalize_pipeline_type(""), "")
+
+    def test_whitespace_only_passes_through(self):
+        """Whitespace-only value skips validation (treated as omitted)."""
+        self.assertEqual(_normalize_pipeline_type("   "), "")
 
 
 class NormalizeAcceptsExtendedEnumTest(TestCase):
@@ -206,7 +215,7 @@ class AddGetFiltersTest(TestCase):
         )
         normalize = type_arg["kwargs"]["type"]
         self.assertEqual(normalize("train"), "PIPELINE_TYPE_TRAIN")
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ArgumentTypeError):
             normalize("BOGUS")
 
     def test_owner_arg_default_empty(self):

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/get_test.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/get_test.py
@@ -1,0 +1,141 @@
+"""Unit tests for pipeline get filters + display columns."""
+
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from michelangelo.cli.mactl.plugins.entity.pipeline.get import (
+    _normalize_pipeline_type,
+    _render_owner,
+    _render_type,
+    add_get_filters,
+)
+
+
+class NormalizePipelineTypeTest(TestCase):
+    """--type flag value normalization."""
+
+    def test_short_name_uppercase(self):
+        """Short name in upper case gets the PIPELINE_TYPE_ prefix."""
+        self.assertEqual(_normalize_pipeline_type("TRAIN"), "PIPELINE_TYPE_TRAIN")
+
+    def test_short_name_lowercase_normalizes(self):
+        """Lower-case short name is upper-cased then prefixed."""
+        self.assertEqual(_normalize_pipeline_type("train"), "PIPELINE_TYPE_TRAIN")
+
+    def test_full_name_passes_through(self):
+        """Already-prefixed value returns unchanged."""
+        self.assertEqual(
+            _normalize_pipeline_type("PIPELINE_TYPE_EVAL"), "PIPELINE_TYPE_EVAL"
+        )
+
+    def test_whitespace_stripped(self):
+        """Surrounding whitespace is trimmed before normalization."""
+        self.assertEqual(_normalize_pipeline_type("  train  "), "PIPELINE_TYPE_TRAIN")
+
+    def test_unknown_raises_with_valid_list(self):
+        """Unknown value raises ValueError listing the accepted names."""
+        with self.assertRaises(ValueError) as cm:
+            _normalize_pipeline_type("BOGUS")
+        msg = str(cm.exception)
+        self.assertIn("BOGUS", msg)
+        self.assertIn("TRAIN", msg)
+        self.assertNotIn("INVALID", msg)
+
+    def test_invalid_sentinel_accepted(self):
+        """PIPELINE_TYPE_INVALID is a real enum value so normalize accepts it."""
+        self.assertEqual(_normalize_pipeline_type("INVALID"), "PIPELINE_TYPE_INVALID")
+
+
+class RenderOwnerTest(TestCase):
+    """OWNER column value function."""
+
+    def _pipeline(self, owner_name=None):
+        """Build a Pipeline mock whose spec.owner is set iff owner_name is not None."""
+        spec = MagicMock()
+        spec.HasField.side_effect = lambda f: f == "owner" and owner_name is not None
+        if owner_name is not None:
+            spec.owner.name = owner_name
+        return SimpleNamespace(spec=spec)
+
+    def test_owner_set(self):
+        """Populated owner renders as its name."""
+        self.assertEqual(_render_owner(self._pipeline("alice")), "alice")
+
+    def test_owner_unset_returns_empty(self):
+        """Missing spec.owner renders as empty string."""
+        self.assertEqual(_render_owner(self._pipeline(None)), "")
+
+    def test_owner_empty_string_returns_empty(self):
+        """Owner set with an empty name still renders empty."""
+        self.assertEqual(_render_owner(self._pipeline("")), "")
+
+
+class RenderTypeTest(TestCase):
+    """TYPE column value function."""
+
+    def test_strips_prefix(self):
+        """PipelineType.TRAIN = 1 → short name 'TRAIN'."""
+        item = SimpleNamespace(spec=SimpleNamespace(type=1))
+        self.assertEqual(_render_type(item), "TRAIN")
+
+    def test_invalid_zero_renders_as_invalid_short(self):
+        """PipelineType.INVALID = 0 → 'INVALID' after prefix strip."""
+        item = SimpleNamespace(spec=SimpleNamespace(type=0))
+        self.assertEqual(_render_type(item), "INVALID")
+
+
+class AddGetFiltersTest(TestCase):
+    """CRD hook wiring — additional_get_args, filter_field_map, additional_columns."""
+
+    def _fresh_crd(self):
+        """CRD-like namespace with the three list/dict slots CRD.__init__ creates."""
+        return SimpleNamespace(
+            additional_get_args=[],
+            filter_field_map={},
+            additional_columns=[],
+        )
+
+    def test_registers_two_args_two_columns_two_filter_fields(self):
+        """add_get_filters populates all three CRD hook slots with matched entries."""
+        crd = self._fresh_crd()
+        add_get_filters(crd)
+
+        self.assertEqual(len(crd.additional_get_args), 2)
+        dests = [a["kwargs"]["dest"] for a in crd.additional_get_args]
+        self.assertEqual(dests, ["owner", "type"])
+
+        self.assertEqual(
+            crd.filter_field_map,
+            {
+                "owner": "pipeline.spec.owner.name",
+                "type": "pipeline.spec.type",
+            },
+        )
+
+        self.assertEqual(
+            [c["column_name"] for c in crd.additional_columns],
+            ["OWNER", "TYPE"],
+        )
+
+    def test_type_arg_uses_normalizer_as_argparse_type(self):
+        """--type registers _normalize_pipeline_type as its argparse type callable."""
+        crd = self._fresh_crd()
+        add_get_filters(crd)
+        type_arg = next(
+            a for a in crd.additional_get_args if a["kwargs"]["dest"] == "type"
+        )
+        normalize = type_arg["kwargs"]["type"]
+        self.assertEqual(normalize("train"), "PIPELINE_TYPE_TRAIN")
+        with self.assertRaises(ValueError):
+            normalize("BOGUS")
+
+    def test_owner_arg_default_empty(self):
+        """--owner defaults to empty string and is not required."""
+        crd = self._fresh_crd()
+        add_get_filters(crd)
+        owner_arg = next(
+            a for a in crd.additional_get_args if a["kwargs"]["dest"] == "owner"
+        )
+        self.assertEqual(owner_arg["kwargs"]["default"], "")
+        self.assertFalse(owner_arg["kwargs"]["required"])

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/get_test.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/get_test.py
@@ -2,9 +2,11 @@
 
 from types import SimpleNamespace
 from unittest import TestCase
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from michelangelo.cli.mactl.plugins.entity.pipeline.get import (
+    _DEFAULT_PB2_MODULE,
+    _load_pipeline_pb2,
     _normalize_pipeline_type,
     _render_owner,
     _render_type,
@@ -12,8 +14,64 @@ from michelangelo.cli.mactl.plugins.entity.pipeline.get import (
 )
 
 
+class LoadPipelinePb2Test(TestCase):
+    """The proto module path is configurable via ``pipeline_type_pb2_module``."""
+
+    @patch("michelangelo.cli.mactl.plugins.entity.pipeline.get.importlib.import_module")
+    @patch("michelangelo.cli.mactl.plugins.entity.pipeline.get.load_config")
+    def test_defaults_to_v2_when_config_absent(self, mock_load, mock_import):
+        """Missing key → uses the default OSS v2 module path."""
+        mock_load.return_value = {}
+        _load_pipeline_pb2()
+        mock_import.assert_called_once_with(_DEFAULT_PB2_MODULE)
+
+    @patch("michelangelo.cli.mactl.plugins.entity.pipeline.get.importlib.import_module")
+    @patch("michelangelo.cli.mactl.plugins.entity.pipeline.get.load_config")
+    def test_honors_config_override(self, mock_load, mock_import):
+        """Config value is passed straight to importlib.import_module."""
+        mock_load.return_value = {
+            "pipeline_type_pb2_module": "downstream.pkg.pipeline_pb2"
+        }
+        _load_pipeline_pb2()
+        mock_import.assert_called_once_with("downstream.pkg.pipeline_pb2")
+
+
+def _stub_pb2(names_with_ids):
+    """Build a stand-in for a pipeline_pb2 module carrying the given enum."""
+    stub = MagicMock()
+    stub.PipelineType.DESCRIPTOR.values = [
+        SimpleNamespace(name=n, number=i) for n, i in names_with_ids
+    ]
+
+    def _name(value):
+        for n, i in names_with_ids:
+            if i == value:
+                return n
+        raise ValueError(f"{value} is not a valid PipelineType")
+
+    stub.PipelineType.Name.side_effect = _name
+    return stub
+
+
+_OSS_ENUM = [
+    ("PIPELINE_TYPE_INVALID", 0),
+    ("PIPELINE_TYPE_TRAIN", 1),
+    ("PIPELINE_TYPE_EVAL", 2),
+]
+_EXTENDED_ENUM = [*_OSS_ENUM, ("PIPELINE_TYPE_TRAIN_LLM", 18)]
+
+
 class NormalizePipelineTypeTest(TestCase):
-    """--type flag value normalization."""
+    """--type flag value normalization uses whichever pb2 is configured."""
+
+    def setUp(self):
+        """Pin the plugin's pb2 loader to the OSS 3-value enum stub."""
+        patcher = patch(
+            "michelangelo.cli.mactl.plugins.entity.pipeline.get._load_pipeline_pb2",
+            return_value=_stub_pb2(_OSS_ENUM),
+        )
+        self.mock_load = patcher.start()
+        self.addCleanup(patcher.stop)
 
     def test_short_name_uppercase(self):
         """Short name in upper case gets the PIPELINE_TYPE_ prefix."""
@@ -42,9 +100,17 @@ class NormalizePipelineTypeTest(TestCase):
         self.assertIn("TRAIN", msg)
         self.assertNotIn("INVALID", msg)
 
-    def test_invalid_sentinel_accepted(self):
-        """PIPELINE_TYPE_INVALID is a real enum value so normalize accepts it."""
-        self.assertEqual(_normalize_pipeline_type("INVALID"), "PIPELINE_TYPE_INVALID")
+
+class NormalizeAcceptsExtendedEnumTest(TestCase):
+    """A downstream pb2 with extra values (e.g. TRAIN_LLM) is accepted."""
+
+    @patch("michelangelo.cli.mactl.plugins.entity.pipeline.get._load_pipeline_pb2")
+    def test_extended_value_accepted(self, mock_load):
+        """Configured pb2 exposing TRAIN_LLM → --type TRAIN_LLM validates."""
+        mock_load.return_value = _stub_pb2(_EXTENDED_ENUM)
+        self.assertEqual(
+            _normalize_pipeline_type("TRAIN_LLM"), "PIPELINE_TYPE_TRAIN_LLM"
+        )
 
 
 class RenderOwnerTest(TestCase):
@@ -74,15 +140,24 @@ class RenderOwnerTest(TestCase):
 class RenderTypeTest(TestCase):
     """TYPE column value function."""
 
+    def setUp(self):
+        """Pin the plugin's pb2 loader to the OSS 3-value enum stub."""
+        patcher = patch(
+            "michelangelo.cli.mactl.plugins.entity.pipeline.get._load_pipeline_pb2",
+            return_value=_stub_pb2(_OSS_ENUM),
+        )
+        self.mock_load = patcher.start()
+        self.addCleanup(patcher.stop)
+
     def test_strips_prefix(self):
         """PipelineType.TRAIN = 1 → short name 'TRAIN'."""
         item = SimpleNamespace(spec=SimpleNamespace(type=1))
         self.assertEqual(_render_type(item), "TRAIN")
 
-    def test_invalid_zero_renders_as_invalid_short(self):
-        """PipelineType.INVALID = 0 → 'INVALID' after prefix strip."""
-        item = SimpleNamespace(spec=SimpleNamespace(type=0))
-        self.assertEqual(_render_type(item), "INVALID")
+    def test_unknown_enum_value_renders_as_numeric_fallback(self):
+        """Configured pb2 without this value → numeric fallback, no exception."""
+        item = SimpleNamespace(spec=SimpleNamespace(type=42))
+        self.assertEqual(_render_type(item), "42")
 
 
 class AddGetFiltersTest(TestCase):
@@ -118,7 +193,11 @@ class AddGetFiltersTest(TestCase):
             ["OWNER", "TYPE"],
         )
 
-    def test_type_arg_uses_normalizer_as_argparse_type(self):
+    @patch(
+        "michelangelo.cli.mactl.plugins.entity.pipeline.get._load_pipeline_pb2",
+        return_value=_stub_pb2(_OSS_ENUM),
+    )
+    def test_type_arg_uses_normalizer_as_argparse_type(self, _mock_load):
         """--type registers _normalize_pipeline_type as its argparse type callable."""
         crd = self._fresh_crd()
         add_get_filters(crd)

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline/main.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline/main.py
@@ -25,6 +25,9 @@ from michelangelo.cli.mactl.plugins.entity.pipeline.dev_run import (
     convert_crd_metadata_pipeline_dev_run,
     generate_dev_run,
 )
+from michelangelo.cli.mactl.plugins.entity.pipeline.get import (
+    add_get_filters,
+)
 from michelangelo.cli.mactl.plugins.entity.pipeline.run import (
     add_function_signature as add_run_function_signature,
 )
@@ -55,6 +58,7 @@ def apply_plugins(crd: CRD, channel: Channel, *_, **__):
     crd.generate_delete = MethodType(
         lambda self, ch, parser: generate_delete(self, ch, parser), crd
     )
+    add_get_filters(crd)
     _LOG.info("Plugin entities applied successfully to crd: %s", crd)
 
 


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Feature

**What changed?**

`ma pipeline get` accepts `--owner` (EQUAL) and `--type` (EQUAL) filters, and renders 2 columns (`OWNER`, `TYPE`). `--type` accepts short names (`TRAIN`, `EVAL`, …), normalizes case, and rejects unknown values client-side. The `PipelineType` enum source is selected via a new config key `pipeline_type_pb2_module` (default `michelangelo.gen.api.v2.pipeline_pb2`); downstream distributions with an extended enum can point this at their own generated module without patching the plugin. The `pipeline_pb2` import is lazy — plugin module load does not resolve it.

**Why?**

Parity with related client behavior for the two most-requested `pipeline get` filters. The config knob keeps downstream forks / re-generated protos from having to patch this file.

**How did you test it?**

`pytest michelangelo/cli/mactl/plugins/entity/pipeline/` → 115 pass (18 new, 97 pre-existing untouched). `pytest michelangelo/cli/mactl/config_test.py` → 23 pass. `ruff check` + `ruff format --check` clean.

Integration test — real apiserver, `ma-integration-test` namespace:

| Command | Observed |
|---|---|
| `ma pipeline get -n ma-integration-test --limit 10` | 2 new columns render. TYPE across sample includes `TRAIN`, `EVAL`, `EXPERIMENT`, `SCORER`, `BASIS_FEATURE`; OWNER populated per row |
| `... --owner sumli` | 1 row (`train-xgboost`), OWNER == `sumli` |
| `... --owner kechen1` | 4 rows, all OWNER == `kechen1` |
| `... --type train` | 100 rows (limit hit), all TYPE == `TRAIN` (case-normalized client-side) |
| `... --type BOGUS` | exit 2, `ArgumentTypeError` listing every accepted enum short-name from the configured `pipeline_type_pb2_module` |

**Breaking Changes**

- [x] No breaking changes

**Release notes**

`ma pipeline get` gains `--owner` and `--type` filters and `OWNER`/`TYPE` columns. New config: `pipeline_type_pb2_module` (default `michelangelo.gen.api.v2.pipeline_pb2`).

**Documentation Changes**

None.
