### PR TITLE
feat(python): --actor and --revision filters + REVISION/USER/ENVIRONMENT/STATE columns on pipeline_run get

### DIFF
--- a/python/michelangelo/cli/mactl/config.py
+++ b/python/michelangelo/cli/mactl/config.py
@@ -35,6 +35,15 @@ DEFAULT_CONFIG = {
         "packages": [],
         "modules": {},
     },
+    # Import path for the generated ``pipeline_run_pb2`` module the pipeline_run
+    # plugin consults for the STATE enum name. Downstream distributions with
+    # a different generator layout can point this at their own module without
+    # patching the plugin source.
+    "pipeline_run_state_pb2_module": "michelangelo.gen.api.v2.pipeline_run_pb2",
+    # Label key the pipeline_run plugin reads for the ENVIRONMENT column.
+    # OSS apiserver writes ``pipelinerun.michelangelo/environment``; downstream
+    # distributions may use a different key.
+    "pipeline_run_environment_label": "pipelinerun.michelangelo/environment",
 }
 
 

--- a/python/michelangelo/cli/mactl/crd.py
+++ b/python/michelangelo/cli/mactl/crd.py
@@ -514,13 +514,21 @@ def _list_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Me
     ParseDict(request_dict, request_input)
 
     filter_field_map = getattr(_self, "filter_field_map", {}) if _self else {}
-    for arg_dest, field_name in filter_field_map.items():
+    for arg_dest, spec in filter_field_map.items():
         value = bound_args.arguments.get(arg_dest)
         if value in (None, "", (), []):
             continue
+        # spec is either a plain field-name string (defaults to EQUAL) or a
+        # dict {"field": str, "operator": int} for per-field operator. The
+        # dict form is what CRDs with LIKE / IN / etc. filters need.
+        if isinstance(spec, str):
+            field_name, operator = spec, 1  # CRITERION_OPERATOR_EQUAL
+        else:
+            field_name = spec["field"]
+            operator = spec.get("operator", 1)
         criterion = request_input.list_options_ext.operation.criterion.add()
         criterion.field_name = field_name
-        criterion.operator = 1  # CRITERION_OPERATOR_EQUAL
+        criterion.operator = operator
         criterion.match_value.Pack(StringValue(value=str(value)))
 
     _LOG.info("ListRequest built: %r", request_input)
@@ -733,7 +741,10 @@ class CRD:
         # _list_func_impl / list_func_impl for how each list is consumed.
         self.additional_columns: list[dict] = []
         self.additional_get_args: list[dict] = []
-        self.filter_field_map: dict[str, str] = {}
+        # Value is a plain field-name string (defaults to CRITERION_OPERATOR_EQUAL)
+        # or a dict {"field": str, "operator": int} for per-field operator override
+        # (e.g. CRITERION_OPERATOR_LIKE for partial-match filters).
+        self.filter_field_map: dict[str, str | dict] = {}
         self.func_signature: dict[str, dict] = {
             "apply": {
                 "help": "Apply an Entity (create or update)",

--- a/python/michelangelo/cli/mactl/crd_test.py
+++ b/python/michelangelo/cli/mactl/crd_test.py
@@ -1930,3 +1930,70 @@ class FilterEndToEndTest(TestCase):
         criteria = captured["req"].list_options_ext.operation.criterion
         self.assertEqual(len(criteria), 1)
         self.assertEqual(criteria[0].field_name, "spec.pipeline_name")
+
+
+class FilterFieldMapDictSchemaTest(TestCase):
+    """filter_field_map value can be a dict for per-field operator override.
+
+    Backward compatibility: string values still default to CRITERION_OPERATOR_EQUAL.
+    New: dict values ``{"field": str, "operator": int}`` carry an explicit
+    operator (e.g. CRITERION_OPERATOR_LIKE = 9 for partial-match filters).
+    """
+
+    @patch.object(CRD, "_extract_method_info")
+    @patch("michelangelo.cli.mactl.crd.crd_method_call")
+    @patch("michelangelo.cli.mactl.crd.ParseDict")
+    def test_dict_form_carries_custom_operator(self, _parse, mock_call, mock_extract):
+        """Dict spec uses its declared operator (LIKE = 9), not the EQUAL default."""
+        mock_extract.return_value = ("Op", _recording_input_class(), Mock)
+        crd = CRD(name="test_crd", full_name="test.service.TestCrd", metadata=[])
+        crd.filter_field_map = {
+            "revision": {"field": "spec.revision.name", "operator": 9},
+        }
+        crd.additional_columns = ()
+
+        captured = {}
+
+        def _capture(_info, req):
+            captured["req"] = req
+            field_desc = Mock()
+            field_desc.name = "test_list"
+            return Mock(ListFields=Mock(return_value=[(field_desc, Mock(items=[]))]))
+
+        mock_call.side_effect = _capture
+
+        crd.generate_list(Mock())
+        crd.list(namespace="ns", revision="abc")
+
+        criteria = captured["req"].list_options_ext.operation.criterion
+        self.assertEqual(len(criteria), 1)
+        self.assertEqual(criteria[0].field_name, "spec.revision.name")
+        self.assertEqual(criteria[0].operator, 9)
+
+    @patch.object(CRD, "_extract_method_info")
+    @patch("michelangelo.cli.mactl.crd.crd_method_call")
+    @patch("michelangelo.cli.mactl.crd.ParseDict")
+    def test_string_form_still_defaults_to_equal(self, _parse, mock_call, mock_extract):
+        """String spec continues to work — defaults operator to EQUAL = 1."""
+        mock_extract.return_value = ("Op", _recording_input_class(), Mock)
+        crd = CRD(name="test_crd", full_name="test.service.TestCrd", metadata=[])
+        crd.filter_field_map = {"pipeline_name": "spec.pipeline_name"}
+        crd.additional_columns = ()
+
+        captured = {}
+
+        def _capture(_info, req):
+            captured["req"] = req
+            field_desc = Mock()
+            field_desc.name = "test_list"
+            return Mock(ListFields=Mock(return_value=[(field_desc, Mock(items=[]))]))
+
+        mock_call.side_effect = _capture
+
+        crd.generate_list(Mock())
+        crd.list(namespace="ns", pipeline_name="trainer-v2")
+
+        criteria = captured["req"].list_options_ext.operation.criterion
+        self.assertEqual(len(criteria), 1)
+        self.assertEqual(criteria[0].field_name, "spec.pipeline_name")
+        self.assertEqual(criteria[0].operator, 1)

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline_run/get.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline_run/get.py
@@ -1,0 +1,144 @@
+"""Pipeline_run get filters + display columns (Revision, User, Environment, State).
+
+Adds ``--actor`` (server-side EQUAL) and ``--revision`` (server-side LIKE)
+filters to ``ma pipeline_run get``, plus four extra table columns
+(``REVISION``, ``USER``, ``ENVIRONMENT``, ``STATE``). Uses the framework hooks
+on ``CRD`` (``additional_get_args``, ``filter_field_map``,
+``additional_columns``); ``filter_field_map`` value is a dict with an explicit
+operator for the ``--revision`` LIKE filter.
+
+Two config keys drive per-distribution behavior:
+- ``pipeline_run_state_pb2_module`` selects which generated pb2 provides the
+  ``PipelineRunState`` enum for the STATE column (default OSS v2).
+- ``pipeline_run_environment_label`` selects the label key for the ENVIRONMENT
+  column (default OSS ``pipelinerun.michelangelo/environment``).
+"""
+
+import importlib
+from inspect import Parameter
+from logging import getLogger
+
+from google.protobuf.message import Message
+
+from michelangelo.cli.mactl.config import load_config
+from michelangelo.cli.mactl.crd import CRD
+
+_LOG = getLogger(__name__)
+
+_STATE_PREFIX = "PIPELINE_RUN_STATE_"
+_DEFAULT_STATE_PB2_MODULE = "michelangelo.gen.api.v2.pipeline_run_pb2"
+_DEFAULT_ENV_LABEL = "pipelinerun.michelangelo/environment"
+
+_CRITERION_OPERATOR_EQUAL = 1
+_CRITERION_OPERATOR_LIKE = 9
+
+
+def _load_state_pb2():
+    """Import the configured ``pipeline_run_pb2`` module lazily.
+
+    Lazy so importing this plugin doesn't force resolution of the generated
+    proto — callers only trigger it when the get command actually renders
+    the STATE column.
+    """
+    module_path = load_config().get(
+        "pipeline_run_state_pb2_module", _DEFAULT_STATE_PB2_MODULE
+    )
+    return importlib.import_module(module_path)
+
+
+def _env_label() -> str:
+    """Label key used for the ENVIRONMENT column."""
+    return load_config().get("pipeline_run_environment_label", _DEFAULT_ENV_LABEL)
+
+
+def _render_revision(item: Message) -> str:
+    """Prefer ``spec.revision.name``, fall back to ``spec.draft.name``."""
+    if item.spec.HasField("revision") and item.spec.revision.name:
+        return item.spec.revision.name
+    if item.spec.HasField("draft") and item.spec.draft.name:
+        return item.spec.draft.name
+    return ""
+
+
+def _render_user(item: Message) -> str:
+    """Actor name — empty string when unset."""
+    if item.spec.HasField("actor"):
+        return item.spec.actor.name or ""
+    return ""
+
+
+def _render_env(item: Message) -> str:
+    """Environment label value — empty string when unset."""
+    return item.metadata.labels.get(_env_label(), "")
+
+
+def _render_state(item: Message) -> str:
+    """State short name (``PIPELINE_RUN_STATE_`` prefix stripped).
+
+    Falls back to numeric enum value when the configured pipeline_run_pb2
+    doesn't know this value (e.g. server returns a newer enum than the
+    client's proto knows).
+    """
+    pb2 = _load_state_pb2()
+    try:
+        name = pb2.PipelineRunState.Name(item.status.state)
+    except ValueError:
+        return str(item.status.state)
+    if name.startswith(_STATE_PREFIX):
+        return name[len(_STATE_PREFIX) :]
+    return name
+
+
+def add_get_filters(crd: CRD) -> None:
+    """Register --actor / --revision filters and 4 columns on ``crd``."""
+    crd.additional_get_args.extend(
+        [
+            {
+                "func_signature": Parameter(
+                    "actor", Parameter.POSITIONAL_OR_KEYWORD, default=""
+                ),
+                "args": ["--actor"],
+                "kwargs": {
+                    "dest": "actor",
+                    "type": str,
+                    "default": "",
+                    "required": False,
+                    "help": ("list the pipeline runs launched by the specified user"),
+                },
+            },
+            {
+                "func_signature": Parameter(
+                    "revision", Parameter.POSITIONAL_OR_KEYWORD, default=""
+                ),
+                "args": ["--revision"],
+                "kwargs": {
+                    "dest": "revision",
+                    "type": str,
+                    "default": "",
+                    "required": False,
+                    "help": (
+                        "list the pipeline runs whose revision name matches"
+                        " the given pattern (server-side LIKE)"
+                    ),
+                },
+            },
+        ]
+    )
+    crd.filter_field_map.update(
+        {
+            "actor": "pipeline_run.spec.actor.name",
+            "revision": {
+                "field": "pipeline_run.spec.revision.name",
+                "operator": _CRITERION_OPERATOR_LIKE,
+            },
+        }
+    )
+    crd.additional_columns.extend(
+        [
+            {"column_name": "REVISION", "retrieve_func": _render_revision},
+            {"column_name": "USER", "retrieve_func": _render_user},
+            {"column_name": "ENVIRONMENT", "retrieve_func": _render_env},
+            {"column_name": "STATE", "retrieve_func": _render_state},
+        ]
+    )
+    _LOG.debug("Pipeline_run get filters + columns registered on crd=%r", crd)

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline_run/get.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline_run/get.py
@@ -1,17 +1,9 @@
 """Pipeline_run get filters + display columns (Revision, User, Environment, State).
 
-Adds ``--actor`` (server-side EQUAL) and ``--revision`` (server-side LIKE)
-filters to ``ma pipeline_run get``, plus four extra table columns
-(``REVISION``, ``USER``, ``ENVIRONMENT``, ``STATE``). Uses the framework hooks
-on ``CRD`` (``additional_get_args``, ``filter_field_map``,
-``additional_columns``); ``filter_field_map`` value is a dict with an explicit
-operator for the ``--revision`` LIKE filter.
-
-Two config keys drive per-distribution behavior:
-- ``pipeline_run_state_pb2_module`` selects which generated pb2 provides the
-  ``PipelineRunState`` enum for the STATE column (default OSS v2).
-- ``pipeline_run_environment_label`` selects the label key for the ENVIRONMENT
-  column (default OSS ``pipelinerun.michelangelo/environment``).
+Adds ``--actor`` (EQUAL) and ``--revision`` (LIKE) filters and 4 columns.
+Two config keys let downstream override defaults:
+``pipeline_run_state_pb2_module`` (pb2 for the STATE enum) and
+``pipeline_run_environment_label`` (label key for the ENVIRONMENT column).
 """
 
 import importlib

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline_run/get_test.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline_run/get_test.py
@@ -1,0 +1,238 @@
+"""Unit tests for pipeline_run get filters + display columns."""
+
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from michelangelo.cli.mactl.plugins.entity.pipeline_run.get import (
+    _CRITERION_OPERATOR_LIKE,
+    _DEFAULT_ENV_LABEL,
+    _DEFAULT_STATE_PB2_MODULE,
+    _env_label,
+    _load_state_pb2,
+    _render_env,
+    _render_revision,
+    _render_state,
+    _render_user,
+    add_get_filters,
+)
+
+
+def _stub_pb2(names_with_ids):
+    """Build a stand-in pipeline_run_pb2 with the given PipelineRunState enum."""
+    stub = MagicMock()
+    stub.PipelineRunState.DESCRIPTOR.values = [
+        SimpleNamespace(name=n, number=i) for n, i in names_with_ids
+    ]
+
+    def _name(value):
+        for n, i in names_with_ids:
+            if i == value:
+                return n
+        raise ValueError(f"{value} is not a valid PipelineRunState")
+
+    stub.PipelineRunState.Name.side_effect = _name
+    return stub
+
+
+_STATE_OSS = [
+    ("PIPELINE_RUN_STATE_INVALID", 0),
+    ("PIPELINE_RUN_STATE_PENDING", 1),
+    ("PIPELINE_RUN_STATE_RUNNING", 2),
+    ("PIPELINE_RUN_STATE_SUCCEEDED", 3),
+    ("PIPELINE_RUN_STATE_KILLED", 4),
+]
+
+
+class LoadStatePb2Test(TestCase):
+    """The proto module path is configurable via ``pipeline_run_state_pb2_module``."""
+
+    @patch(
+        "michelangelo.cli.mactl.plugins.entity.pipeline_run.get.importlib.import_module"
+    )
+    @patch("michelangelo.cli.mactl.plugins.entity.pipeline_run.get.load_config")
+    def test_defaults_to_v2(self, mock_load, mock_import):
+        """Missing config key → default OSS v2 module path."""
+        mock_load.return_value = {}
+        _load_state_pb2()
+        mock_import.assert_called_once_with(_DEFAULT_STATE_PB2_MODULE)
+
+    @patch(
+        "michelangelo.cli.mactl.plugins.entity.pipeline_run.get.importlib.import_module"
+    )
+    @patch("michelangelo.cli.mactl.plugins.entity.pipeline_run.get.load_config")
+    def test_honors_override(self, mock_load, mock_import):
+        """Config override reaches importlib."""
+        mock_load.return_value = {
+            "pipeline_run_state_pb2_module": "downstream.pipeline_run_pb2"
+        }
+        _load_state_pb2()
+        mock_import.assert_called_once_with("downstream.pipeline_run_pb2")
+
+
+class EnvLabelTest(TestCase):
+    """The env label key is configurable via ``pipeline_run_environment_label``."""
+
+    @patch("michelangelo.cli.mactl.plugins.entity.pipeline_run.get.load_config")
+    def test_defaults(self, mock_load):
+        """Missing key → default OSS label."""
+        mock_load.return_value = {}
+        self.assertEqual(_env_label(), _DEFAULT_ENV_LABEL)
+
+    @patch("michelangelo.cli.mactl.plugins.entity.pipeline_run.get.load_config")
+    def test_override(self, mock_load):
+        """Config override returned as-is."""
+        mock_load.return_value = {"pipeline_run_environment_label": "internal/env"}
+        self.assertEqual(_env_label(), "internal/env")
+
+
+class RenderRevisionTest(TestCase):
+    """REVISION column falls back through revision → draft → empty."""
+
+    def _run(self, revision_name=None, draft_name=None):
+        """Build a PipelineRun mock with the given revision + draft state."""
+        spec = MagicMock()
+
+        def _has_field(f):
+            return (f == "revision" and revision_name is not None) or (
+                f == "draft" and draft_name is not None
+            )
+
+        spec.HasField.side_effect = _has_field
+        if revision_name is not None:
+            spec.revision.name = revision_name
+        if draft_name is not None:
+            spec.draft.name = draft_name
+        return SimpleNamespace(spec=spec)
+
+    def test_revision_present(self):
+        """Populated revision renders its name (draft ignored)."""
+        self.assertEqual(_render_revision(self._run("rev-abc", "draft-xyz")), "rev-abc")
+
+    def test_revision_missing_draft_present(self):
+        """Missing revision → falls back to draft name."""
+        self.assertEqual(_render_revision(self._run(None, "draft-xyz")), "draft-xyz")
+
+    def test_both_missing(self):
+        """Neither set → empty string."""
+        self.assertEqual(_render_revision(self._run(None, None)), "")
+
+    def test_revision_present_but_empty_name(self):
+        """Revision set with empty name → falls back to draft."""
+        self.assertEqual(_render_revision(self._run("", "draft-xyz")), "draft-xyz")
+
+
+class RenderUserTest(TestCase):
+    """USER column reads spec.actor.name with empty-string fallback."""
+
+    def _run(self, actor_name=None):
+        """Build a PipelineRun mock; spec.actor set iff actor_name is not None."""
+        spec = MagicMock()
+        spec.HasField.side_effect = lambda f: f == "actor" and actor_name is not None
+        if actor_name is not None:
+            spec.actor.name = actor_name
+        return SimpleNamespace(spec=spec)
+
+    def test_actor_set(self):
+        """Populated actor renders as its name."""
+        self.assertEqual(_render_user(self._run("alice")), "alice")
+
+    def test_actor_missing(self):
+        """Missing spec.actor renders as empty."""
+        self.assertEqual(_render_user(self._run(None)), "")
+
+
+class RenderEnvTest(TestCase):
+    """ENVIRONMENT column reads the configured label from metadata.labels."""
+
+    @patch("michelangelo.cli.mactl.plugins.entity.pipeline_run.get._env_label")
+    def test_label_present(self, mock_label):
+        """Configured label present → value returned."""
+        mock_label.return_value = "pipelinerun.michelangelo/environment"
+        item = SimpleNamespace(
+            metadata=SimpleNamespace(
+                labels={"pipelinerun.michelangelo/environment": "prod"}
+            )
+        )
+        self.assertEqual(_render_env(item), "prod")
+
+    @patch("michelangelo.cli.mactl.plugins.entity.pipeline_run.get._env_label")
+    def test_label_missing(self, mock_label):
+        """Configured label absent → empty string."""
+        mock_label.return_value = "pipelinerun.michelangelo/environment"
+        item = SimpleNamespace(metadata=SimpleNamespace(labels={}))
+        self.assertEqual(_render_env(item), "")
+
+
+class RenderStateTest(TestCase):
+    """STATE column strips PIPELINE_RUN_STATE_ prefix and falls back to numeric."""
+
+    def setUp(self):
+        """Pin the plugin's pb2 loader to the OSS 5-value enum stub."""
+        patcher = patch(
+            "michelangelo.cli.mactl.plugins.entity.pipeline_run.get._load_state_pb2",
+            return_value=_stub_pb2(_STATE_OSS),
+        )
+        self.mock_load = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_prefix_stripped(self):
+        """PENDING = 1 → short 'PENDING'."""
+        item = SimpleNamespace(status=SimpleNamespace(state=1))
+        self.assertEqual(_render_state(item), "PENDING")
+
+    def test_running(self):
+        """RUNNING = 2 → 'RUNNING'."""
+        item = SimpleNamespace(status=SimpleNamespace(state=2))
+        self.assertEqual(_render_state(item), "RUNNING")
+
+    def test_unknown_falls_back_to_numeric(self):
+        """State int not in configured pb2 → numeric string, no crash."""
+        item = SimpleNamespace(status=SimpleNamespace(state=99))
+        self.assertEqual(_render_state(item), "99")
+
+
+class AddGetFiltersTest(TestCase):
+    """CRD hook wiring — args, columns, and per-field operator in filter_field_map."""
+
+    def _fresh_crd(self):
+        """CRD-like namespace with the three list/dict slots CRD.__init__ creates."""
+        return SimpleNamespace(
+            additional_get_args=[],
+            filter_field_map={},
+            additional_columns=[],
+        )
+
+    def test_registers_two_args(self):
+        """--actor and --revision are added to additional_get_args."""
+        crd = self._fresh_crd()
+        add_get_filters(crd)
+        dests = [a["kwargs"]["dest"] for a in crd.additional_get_args]
+        self.assertEqual(dests, ["actor", "revision"])
+
+    def test_filter_field_map_actor_is_str_default_equal(self):
+        """--actor entry is a plain string → defaults to EQUAL in _list_func_impl."""
+        crd = self._fresh_crd()
+        add_get_filters(crd)
+        self.assertEqual(crd.filter_field_map["actor"], "pipeline_run.spec.actor.name")
+
+    def test_filter_field_map_revision_carries_like_operator(self):
+        """--revision entry is a dict with explicit LIKE operator."""
+        crd = self._fresh_crd()
+        add_get_filters(crd)
+        self.assertEqual(
+            crd.filter_field_map["revision"],
+            {
+                "field": "pipeline_run.spec.revision.name",
+                "operator": _CRITERION_OPERATOR_LIKE,
+            },
+        )
+
+    def test_registers_four_columns(self):
+        """REVISION, USER, ENVIRONMENT, STATE columns registered in order."""
+        crd = self._fresh_crd()
+        add_get_filters(crd)
+        self.assertEqual(
+            [c["column_name"] for c in crd.additional_columns],
+            ["REVISION", "USER", "ENVIRONMENT", "STATE"],
+        )

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline_run/main.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline_run/main.py
@@ -10,6 +10,7 @@ from michelangelo.cli.mactl.plugins.entity.pipeline.kill import (
     add_function_signature as add_kill_function_signature,
 )
 from michelangelo.cli.mactl.plugins.entity.pipeline.kill import generate_kill
+from michelangelo.cli.mactl.plugins.entity.pipeline_run.get import add_get_filters
 
 _LOG = getLogger(__name__)
 
@@ -17,7 +18,8 @@ _LOG = getLogger(__name__)
 def apply_plugins(crd: CRD, channel: Channel, *_, **__):
     """Apply plugin entity function signatures to the CRD.
 
-    This adds the kill function signature for pipeline_run entity.
+    This adds the kill function signature for pipeline_run entity and
+    registers --actor/--revision filters plus 4 display columns on get.
     """
     _LOG.info("Applying pipeline_run plugin entity to crd: %r", crd)
     _LOG.debug("gRPC Channel: %r", channel)
@@ -26,5 +28,6 @@ def apply_plugins(crd: CRD, channel: Channel, *_, **__):
     crd.generate_kill = MethodType(
         lambda self, ch, parser: generate_kill(self, ch, parser), crd
     )
+    add_get_filters(crd)
 
     _LOG.info("Plugin entities applied successfully to pipeline_run crd: %s", crd)

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline_run/main_test.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline_run/main_test.py
@@ -17,6 +17,11 @@ class PipelineRunPluginTest(TestCase):
         self.mock_crd.full_name = "michelangelo.api.v2.PipelineRunService"
         self.mock_crd.metadata = {}
         self.mock_crd.func_signature = {}
+        # CRD.__init__ populates these; Mock(spec=CRD) uses class-level attrs
+        # only, so instance-level hook slots need to be added explicitly.
+        self.mock_crd.additional_get_args = []
+        self.mock_crd.additional_columns = []
+        self.mock_crd.filter_field_map = {}
         self.mock_channel = Mock()
 
     @patch(


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Feature

**What changed?**

`ma pipeline_run get` accepts `--actor` (EQUAL) and `--revision` (LIKE) filters, and renders 4 columns (`REVISION`, `USER`, `ENVIRONMENT`, `STATE`). REVISION falls back through `spec.revision.name` → `spec.draft.name` → empty. STATE strips `PIPELINE_RUN_STATE_` and degrades to numeric on unknown enums. `CRD.filter_field_map` gains a `dict{"field","operator"}` value shape so plugins can declare non-EQUAL operators (needed for `--revision` LIKE), backward-compatible with the pre-existing string form. Two new config keys, `pipeline_run_state_pb2_module` and `pipeline_run_environment_label`, let downstream distributions swap the STATE proto module or ENVIRONMENT label key.

**Why?**

Parity with related client behavior for the two most-requested `pipeline_run get` filters.

**How did you test it?**

`pytest michelangelo/cli/mactl/` → 385/386 pass (sole failure `TLSConfigurationTest::test_use_tls_default_value` also fails on `origin/main`, unrelated). `ruff check` + `ruff format --check` clean.

Integration test — real apiserver, `ma-integration-test` namespace:

| Command | Observed |
|---|---|
| `ma pipeline_run get -n ma-integration-test --limit 5` | 4 new columns render. STATE across sample: `RUNNING`, `FAILED`, `SUCCEEDED`; ENVIRONMENT: `development`, `testing` |
| `... --actor svc-michelangelo-user --limit 5` | all rows USER == `svc-michelangelo-user` |
| `... --revision boston --limit 5` | all rows REVISION contains `boston` (LIKE) |
| `... --actor svc-michelangelo-user --revision boston --limit 5` | all rows match both (AND) |
| `... --actor svc-michelangelo-user --revision knn --limit 5` | 0 rows — intersection empty, no false positives |

**Breaking Changes**

- [x] No breaking changes

**Release notes**

`ma pipeline_run get` gains `--actor` and `--revision` filters and `REVISION`/`USER`/`ENVIRONMENT`/`STATE` columns. New config keys: `pipeline_run_state_pb2_module`, `pipeline_run_environment_label`.

**Documentation Changes**

None.
