### PR TITLE
feat(python): --pipeline/--model/--deployment/--owner filters + 3 columns on revision get

### DIFF
--- a/python/michelangelo/cli/mactl/crd.py
+++ b/python/michelangelo/cli/mactl/crd.py
@@ -328,6 +328,28 @@ def _get_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Mes
     )
 
 
+def _collect_forward_dests(obj) -> set[str]:
+    """Union of additional_get_args dests + non-callable filter_field_map keys.
+
+    Callable-form filter_field_map keys are synthetic labels (not arg dests)
+    and are excluded — forwarding them as kwargs would break `_self.list()`.
+    """
+    dests: set[str] = set()
+    additional_get_args = getattr(obj, "additional_get_args", None)
+    if isinstance(additional_get_args, list):
+        for arg_spec in additional_get_args:
+            if isinstance(arg_spec, dict):
+                dest = arg_spec.get("kwargs", {}).get("dest")
+                if dest:
+                    dests.add(dest)
+    fmap = getattr(obj, "filter_field_map", None)
+    if isinstance(fmap, dict):
+        for k, v in fmap.items():
+            if isinstance(v, (str, dict)):
+                dests.add(k)
+    return dests
+
+
 def get_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Message:
     """Default common CRD member method implementation for GET method.
 
@@ -355,25 +377,9 @@ def get_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Mess
 
     _LOG.debug("No name argument passed. List CRD in the namespace.")
     _self.generate_list(crd_method_info.channel)
-    # get→list fallthrough: forward every filter dest so `--<attr> <val>`
-    # reaches list. Sources: additional_get_args dests, and string-form
-    # filter_field_map keys (callable-form keys are synthetic — skipped).
-    forward_dests: set[str] = set()
-    additional_get_args = getattr(_self, "additional_get_args", None)
-    if isinstance(additional_get_args, list):
-        for arg_spec in additional_get_args:
-            dest = (
-                arg_spec.get("kwargs", {}).get("dest")
-                if isinstance(arg_spec, dict)
-                else None
-            )
-            if dest:
-                forward_dests.add(dest)
-    filter_field_map = getattr(_self, "filter_field_map", None)
-    if isinstance(filter_field_map, dict):
-        for k, v in filter_field_map.items():
-            if isinstance(v, (str, dict)):
-                forward_dests.add(k)
+    # get→list fallthrough: forward filter dests so `--<attr> <val>` reaches
+    # list (see _collect_forward_dests for source union).
+    forward_dests = _collect_forward_dests(_self)
     filter_kwargs = {
         k: bound_args.arguments[k] for k in forward_dests if k in bound_args.arguments
     }
@@ -1224,17 +1230,7 @@ class CRD:
         )
 
         self.configure_parser("list", parser)
-        # Union sources so a callable filter_field_map entry (synthetic key)
-        # still gets its coordinated dests forwarded to the list Signature.
-        forward_dests: set[str] = set(getattr(self, "filter_field_map", {}) or ())
-        for arg_spec in getattr(self, "additional_get_args", ()) or ():
-            dest = (
-                arg_spec.get("kwargs", {}).get("dest")
-                if isinstance(arg_spec, dict)
-                else None
-            )
-            if dest:
-                forward_dests.add(dest)
+        forward_dests = _collect_forward_dests(self)
         list_func_signature = Signature(
             [
                 Parameter("self", Parameter.POSITIONAL_OR_KEYWORD),

--- a/python/michelangelo/cli/mactl/crd.py
+++ b/python/michelangelo/cli/mactl/crd.py
@@ -355,12 +355,9 @@ def get_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Mess
 
     _LOG.debug("No name argument passed. List CRD in the namespace.")
     _self.generate_list(crd_method_info.channel)
-    # Forward any filter arg declared on the get command so that
-    # `<crd> get -n <ns> --<attr> <val>` (no name) falls through to list with
-    # the filter applied, not silently dropped. Sources: every dest in
-    # additional_get_args (plugin-declared filter args) AND every string-form
-    # key in filter_field_map (a filter dest may be registered there directly
-    # by simpler plugins without also appearing in additional_get_args).
+    # get→list fallthrough: forward every filter dest so `--<attr> <val>`
+    # reaches list. Sources: additional_get_args dests, and string-form
+    # filter_field_map keys (callable-form keys are synthetic — skipped).
     forward_dests: set[str] = set()
     additional_get_args = getattr(_self, "additional_get_args", None)
     if isinstance(additional_get_args, list):
@@ -375,8 +372,6 @@ def get_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Mess
     filter_field_map = getattr(_self, "filter_field_map", None)
     if isinstance(filter_field_map, dict):
         for k, v in filter_field_map.items():
-            # Skip callable-form entries — their key is a synthetic label,
-            # not an arg dest, and forwarding it would inject an unknown kwarg.
             if isinstance(v, (str, dict)):
                 forward_dests.add(k)
     filter_kwargs = {
@@ -531,11 +526,8 @@ def _list_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Me
 
     filter_field_map = getattr(_self, "filter_field_map", {}) if _self else {}
     for arg_dest, spec in filter_field_map.items():
-        # Callable spec: signature (bound_args_arguments) -> list of
-        # {"field": str, "operator": int, "value": str} dicts. Used when
-        # one flag maps to multiple criteria or when several flags coordinate
-        # (e.g. a mutually-exclusive group). The callable itself gates on
-        # bound_args and may raise for validation errors.
+        # Callable spec: (bound_args) -> list of criteria. Used for
+        # one-flag-many-criteria or coordinated (e.g. mutex) flags.
         if callable(spec):
             for c in spec(bound_args.arguments):
                 criterion = request_input.list_options_ext.operation.criterion.add()
@@ -769,10 +761,8 @@ class CRD:
         # _list_func_impl / list_func_impl for how each list is consumed.
         self.additional_columns: list[dict] = []
         self.additional_get_args: list[dict] = []
-        # Value shapes: str = field name (defaults to EQUAL); dict {"field",
-        # "operator"} = per-field operator (e.g. LIKE); callable
-        # (bound_args_arguments) -> list of {"field","operator","value"} =
-        # dynamic multi-criterion (mutex groups, one-flag-many-criteria).
+        # Value: str = field name (default EQUAL); dict = {"field","operator"};
+        # callable = (bound_args) -> list of criteria.
         self.filter_field_map: dict[str, str | dict | Callable] = {}
         self.func_signature: dict[str, dict] = {
             "apply": {
@@ -1042,9 +1032,7 @@ class CRD:
                 )
             extra_dests.add(dest)
         for dest, spec in self.filter_field_map.items():
-            # Callable specs use a synthetic key (not an arg dest) — they
-            # coordinate across multiple flags whose dests are declared
-            # separately in additional_get_args. Skip the dest-cross-check.
+            # Callable specs use a synthetic key — no dest to cross-check.
             if callable(spec):
                 continue
             if dest not in extra_dests:
@@ -1236,11 +1224,8 @@ class CRD:
         )
 
         self.configure_parser("list", parser)
-        # Union filter_field_map keys AND additional_get_args dests: some
-        # plugins (F011/F013 shape) put every filter dest in filter_field_map;
-        # others (F014 shape with a callable) declare dests only in
-        # additional_get_args and coordinate them via a single callable entry
-        # in filter_field_map. The get→list fallthrough forwards from both.
+        # Union sources so a callable filter_field_map entry (synthetic key)
+        # still gets its coordinated dests forwarded to the list Signature.
         forward_dests: set[str] = set(getattr(self, "filter_field_map", {}) or ())
         for arg_spec in getattr(self, "additional_get_args", ()) or ():
             dest = (

--- a/python/michelangelo/cli/mactl/crd.py
+++ b/python/michelangelo/cli/mactl/crd.py
@@ -329,10 +329,13 @@ def _get_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Mes
 
 
 def _collect_forward_dests(obj) -> set[str]:
-    """Union of additional_get_args dests + non-callable filter_field_map keys.
+    """Every arg dest declared in ``additional_get_args``.
 
-    Callable-form filter_field_map keys are synthetic labels (not arg dests)
-    and are excluded — forwarding them as kwargs would break `_self.list()`.
+    ``additional_get_args`` is the sole source of truth for `get` filter
+    flags. Callable-form ``filter_field_map`` entries have synthetic keys
+    (not dests); string/dict-form keys are guaranteed to be matched by an
+    ``additional_get_args`` entry via ``_validated_additional_get_args``,
+    so we only need to walk one container.
     """
     dests: set[str] = set()
     additional_get_args = getattr(obj, "additional_get_args", None)
@@ -342,11 +345,6 @@ def _collect_forward_dests(obj) -> set[str]:
                 dest = arg_spec.get("kwargs", {}).get("dest")
                 if dest:
                     dests.add(dest)
-    fmap = getattr(obj, "filter_field_map", None)
-    if isinstance(fmap, dict):
-        for k, v in fmap.items():
-            if isinstance(v, (str, dict)):
-                dests.add(k)
     return dests
 
 

--- a/python/michelangelo/cli/mactl/crd.py
+++ b/python/michelangelo/cli/mactl/crd.py
@@ -13,7 +13,7 @@ from io import StringIO
 from logging import getLogger
 from pathlib import Path
 from types import MethodType
-from typing import Any, Callable, NotRequired, Optional, TypedDict
+from typing import Any, Callable, Optional, TypedDict
 
 from google.protobuf.json_format import MessageToDict, MessageToJson, ParseDict
 from google.protobuf.message import Message
@@ -23,6 +23,7 @@ from grpc import (
     RpcError,
     StatusCode,
 )
+from typing_extensions import NotRequired
 from yaml import YAMLError
 from yaml import safe_dump as yaml_safe_dump
 from yaml import safe_load as yaml_safe_load

--- a/python/michelangelo/cli/mactl/crd.py
+++ b/python/michelangelo/cli/mactl/crd.py
@@ -511,6 +511,16 @@ def _render_single_item(msg: Message, output_format: str) -> None:
         print(msg)
 
 
+def _emit_criterion(
+    request_input: Message, field_name: str, value, operator: int = 1
+) -> None:
+    """Append one criterion to the ListRequest's operation."""
+    criterion = request_input.list_options_ext.operation.criterion.add()
+    criterion.field_name = field_name
+    criterion.operator = operator
+    criterion.match_value.Pack(StringValue(value=str(value)))
+
+
 def _list_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Message:
     """Raw CRD LIST implementation - returns response without printing."""
     _LOG.info("Bound arguments: %r", bound_args.arguments)
@@ -545,10 +555,9 @@ def _list_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Me
         # one-flag-many-criteria or coordinated (e.g. mutex) flags.
         if callable(spec):
             for c in spec(bound_args.arguments):
-                criterion = request_input.list_options_ext.operation.criterion.add()
-                criterion.field_name = c["field"]
-                criterion.operator = c.get("operator", 1)
-                criterion.match_value.Pack(StringValue(value=str(c["value"])))
+                _emit_criterion(
+                    request_input, c["field"], c["value"], c.get("operator", 1)
+                )
             continue
         value = bound_args.arguments.get(arg_dest)
         if value in (None, "", (), []):
@@ -561,10 +570,7 @@ def _list_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Me
         else:
             field_name = spec["field"]
             operator = spec.get("operator", 1)
-        criterion = request_input.list_options_ext.operation.criterion.add()
-        criterion.field_name = field_name
-        criterion.operator = operator
-        criterion.match_value.Pack(StringValue(value=str(value)))
+        _emit_criterion(request_input, field_name, value, operator)
 
     _LOG.info("ListRequest built: %r", request_input)
     call_res = crd_method_call(crd_method_info, request_input)

--- a/python/michelangelo/cli/mactl/crd.py
+++ b/python/michelangelo/cli/mactl/crd.py
@@ -511,16 +511,6 @@ def _render_single_item(msg: Message, output_format: str) -> None:
         print(msg)
 
 
-def _emit_criterion(
-    request_input: Message, field_name: str, value, operator: int = 1
-) -> None:
-    """Append one criterion to the ListRequest's operation."""
-    criterion = request_input.list_options_ext.operation.criterion.add()
-    criterion.field_name = field_name
-    criterion.operator = operator
-    criterion.match_value.Pack(StringValue(value=str(value)))
-
-
 def _resolve_criteria(spec, bound_args: dict, arg_dest: str) -> list[Criterion]:
     """Normalize any filter_field_map spec shape into a list of criteria.
 
@@ -576,7 +566,10 @@ def _list_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Me
     filter_field_map = getattr(_self, "filter_field_map", {}) if _self else {}
     for arg_dest, spec in filter_field_map.items():
         for c in _resolve_criteria(spec, bound_args.arguments, arg_dest):
-            _emit_criterion(request_input, c["field"], c["value"], c.get("operator", 1))
+            criterion = request_input.list_options_ext.operation.criterion.add()
+            criterion.field_name = c["field"]
+            criterion.operator = c.get("operator", 1)
+            criterion.match_value.Pack(StringValue(value=str(c["value"])))
 
     _LOG.info("ListRequest built: %r", request_input)
     call_res = crd_method_call(crd_method_info, request_input)

--- a/python/michelangelo/cli/mactl/crd.py
+++ b/python/michelangelo/cli/mactl/crd.py
@@ -13,7 +13,7 @@ from io import StringIO
 from logging import getLogger
 from pathlib import Path
 from types import MethodType
-from typing import Any, Callable, Optional
+from typing import Any, Callable, NotRequired, Optional, TypedDict
 
 from google.protobuf.json_format import MessageToDict, MessageToJson, ParseDict
 from google.protobuf.message import Message
@@ -35,6 +35,17 @@ from michelangelo.cli.mactl.grpc_tools import (
 
 _LOG = getLogger(__name__)
 METADATA_STUB = []
+
+
+class Criterion(TypedDict):
+    """Shape of a criterion returned by a callable-form filter_field_map entry."""
+
+    field: str
+    value: str
+    operator: NotRequired[int]  # defaults to CRITERION_OPERATOR_EQUAL (1)
+
+
+FilterCallable = Callable[[dict], list[Criterion]]
 
 
 def bind_signature(signature):
@@ -767,7 +778,7 @@ class CRD:
         self.additional_get_args: list[dict] = []
         # Value: str = field name (default EQUAL); dict = {"field","operator"};
         # callable = (bound_args) -> list of criteria.
-        self.filter_field_map: dict[str, str | dict | Callable] = {}
+        self.filter_field_map: dict[str, str | dict | FilterCallable] = {}
         self.func_signature: dict[str, dict] = {
             "apply": {
                 "help": "Apply an Entity (create or update)",

--- a/python/michelangelo/cli/mactl/crd.py
+++ b/python/michelangelo/cli/mactl/crd.py
@@ -342,11 +342,11 @@ def _get_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Mes
 def _collect_forward_dests(obj) -> set[str]:
     """Every arg dest declared in ``additional_get_args``.
 
-    ``additional_get_args`` is the sole source of truth for `get` filter
-    flags. Callable-form ``filter_field_map`` entries have synthetic keys
-    (not dests); string/dict-form keys are guaranteed to be matched by an
-    ``additional_get_args`` entry via ``_validated_additional_get_args``,
-    so we only need to walk one container.
+    By convention, ``additional_get_args`` entries are filter flags — every
+    current OSS plugin uses it that way. The framework forwards all such
+    dests from `get` to `list`; a non-filter dest (if any plugin ever adds
+    one) would flow through harmlessly, since ``_list_func_impl`` only acts
+    on dests that also appear in ``filter_field_map``.
     """
     dests: set[str] = set()
     additional_get_args = getattr(obj, "additional_get_args", None)

--- a/python/michelangelo/cli/mactl/crd.py
+++ b/python/michelangelo/cli/mactl/crd.py
@@ -355,16 +355,32 @@ def get_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Mess
 
     _LOG.debug("No name argument passed. List CRD in the namespace.")
     _self.generate_list(crd_method_info.channel)
-    # Forward any filter dest args declared in _self.filter_field_map so
-    # `<crd> get -n <ns> --<attr> <val>` (no name) falls through to list
-    # with the filter applied, not silently dropped.
+    # Forward any filter arg declared on the get command so that
+    # `<crd> get -n <ns> --<attr> <val>` (no name) falls through to list with
+    # the filter applied, not silently dropped. Sources: every dest in
+    # additional_get_args (plugin-declared filter args) AND every string-form
+    # key in filter_field_map (a filter dest may be registered there directly
+    # by simpler plugins without also appearing in additional_get_args).
+    forward_dests: set[str] = set()
+    additional_get_args = getattr(_self, "additional_get_args", None)
+    if isinstance(additional_get_args, list):
+        for arg_spec in additional_get_args:
+            dest = (
+                arg_spec.get("kwargs", {}).get("dest")
+                if isinstance(arg_spec, dict)
+                else None
+            )
+            if dest:
+                forward_dests.add(dest)
     filter_field_map = getattr(_self, "filter_field_map", None)
-    if not isinstance(filter_field_map, dict):
-        filter_field_map = {}
+    if isinstance(filter_field_map, dict):
+        for k, v in filter_field_map.items():
+            # Skip callable-form entries — their key is a synthetic label,
+            # not an arg dest, and forwarding it would inject an unknown kwarg.
+            if isinstance(v, (str, dict)):
+                forward_dests.add(k)
     filter_kwargs = {
-        k: bound_args.arguments[k]
-        for k in filter_field_map
-        if k in bound_args.arguments
+        k: bound_args.arguments[k] for k in forward_dests if k in bound_args.arguments
     }
     return _self.list(
         namespace="" if all_namespaces else namespace,
@@ -515,6 +531,18 @@ def _list_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Me
 
     filter_field_map = getattr(_self, "filter_field_map", {}) if _self else {}
     for arg_dest, spec in filter_field_map.items():
+        # Callable spec: signature (bound_args_arguments) -> list of
+        # {"field": str, "operator": int, "value": str} dicts. Used when
+        # one flag maps to multiple criteria or when several flags coordinate
+        # (e.g. a mutually-exclusive group). The callable itself gates on
+        # bound_args and may raise for validation errors.
+        if callable(spec):
+            for c in spec(bound_args.arguments):
+                criterion = request_input.list_options_ext.operation.criterion.add()
+                criterion.field_name = c["field"]
+                criterion.operator = c.get("operator", 1)
+                criterion.match_value.Pack(StringValue(value=str(c["value"])))
+            continue
         value = bound_args.arguments.get(arg_dest)
         if value in (None, "", (), []):
             continue
@@ -741,10 +769,11 @@ class CRD:
         # _list_func_impl / list_func_impl for how each list is consumed.
         self.additional_columns: list[dict] = []
         self.additional_get_args: list[dict] = []
-        # Value is a plain field-name string (defaults to CRITERION_OPERATOR_EQUAL)
-        # or a dict {"field": str, "operator": int} for per-field operator override
-        # (e.g. CRITERION_OPERATOR_LIKE for partial-match filters).
-        self.filter_field_map: dict[str, str | dict] = {}
+        # Value shapes: str = field name (defaults to EQUAL); dict {"field",
+        # "operator"} = per-field operator (e.g. LIKE); callable
+        # (bound_args_arguments) -> list of {"field","operator","value"} =
+        # dynamic multi-criterion (mutex groups, one-flag-many-criteria).
+        self.filter_field_map: dict[str, str | dict | Callable] = {}
         self.func_signature: dict[str, dict] = {
             "apply": {
                 "help": "Apply an Entity (create or update)",
@@ -1012,7 +1041,12 @@ class CRD:
                     f"`get` argument on CRD {self.name!r}"
                 )
             extra_dests.add(dest)
-        for dest in self.filter_field_map:
+        for dest, spec in self.filter_field_map.items():
+            # Callable specs use a synthetic key (not an arg dest) — they
+            # coordinate across multiple flags whose dests are declared
+            # separately in additional_get_args. Skip the dest-cross-check.
+            if callable(spec):
+                continue
             if dest not in extra_dests:
                 raise ValueError(
                     f"filter_field_map references dest {dest!r} but no matching "
@@ -1202,6 +1236,20 @@ class CRD:
         )
 
         self.configure_parser("list", parser)
+        # Union filter_field_map keys AND additional_get_args dests: some
+        # plugins (F011/F013 shape) put every filter dest in filter_field_map;
+        # others (F014 shape with a callable) declare dests only in
+        # additional_get_args and coordinate them via a single callable entry
+        # in filter_field_map. The get→list fallthrough forwards from both.
+        forward_dests: set[str] = set(getattr(self, "filter_field_map", {}) or ())
+        for arg_spec in getattr(self, "additional_get_args", ()) or ():
+            dest = (
+                arg_spec.get("kwargs", {}).get("dest")
+                if isinstance(arg_spec, dict)
+                else None
+            )
+            if dest:
+                forward_dests.add(dest)
         list_func_signature = Signature(
             [
                 Parameter("self", Parameter.POSITIONAL_OR_KEYWORD),
@@ -1218,7 +1266,7 @@ class CRD:
                 # Per-CRD filter dests, so `_self.list(**filter_kwargs)` (called
                 # from get→list fall-through) doesn't get rejected by bind.
                 Parameter(dest, Parameter.POSITIONAL_OR_KEYWORD, default=None)
-                for dest in getattr(self, "filter_field_map", {})
+                for dest in sorted(forward_dests)
             ]
         )
 

--- a/python/michelangelo/cli/mactl/crd.py
+++ b/python/michelangelo/cli/mactl/crd.py
@@ -521,6 +521,30 @@ def _emit_criterion(
     criterion.match_value.Pack(StringValue(value=str(value)))
 
 
+def _resolve_criteria(spec, bound_args: dict, arg_dest: str) -> list[Criterion]:
+    """Normalize any filter_field_map spec shape into a list of criteria.
+
+    - Callable spec: plugin returns its own criteria (0..N).
+    - String spec: one criterion, EQUAL operator, value from bound_args.
+    - Dict spec: one criterion with declared field + operator, value from bound_args.
+    Empty bound-args values (for string/dict specs) yield ``[]`` — no criterion.
+    """
+    if callable(spec):
+        return spec(bound_args)
+    value = bound_args.get(arg_dest)
+    if value in (None, "", (), []):
+        return []
+    if isinstance(spec, str):
+        return [{"field": spec, "value": value}]
+    return [
+        {
+            "field": spec["field"],
+            "value": value,
+            "operator": spec.get("operator", 1),
+        }
+    ]
+
+
 def _list_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Message:
     """Raw CRD LIST implementation - returns response without printing."""
     _LOG.info("Bound arguments: %r", bound_args.arguments)
@@ -551,26 +575,8 @@ def _list_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Me
 
     filter_field_map = getattr(_self, "filter_field_map", {}) if _self else {}
     for arg_dest, spec in filter_field_map.items():
-        # Callable spec: (bound_args) -> list of criteria. Used for
-        # one-flag-many-criteria or coordinated (e.g. mutex) flags.
-        if callable(spec):
-            for c in spec(bound_args.arguments):
-                _emit_criterion(
-                    request_input, c["field"], c["value"], c.get("operator", 1)
-                )
-            continue
-        value = bound_args.arguments.get(arg_dest)
-        if value in (None, "", (), []):
-            continue
-        # spec is either a plain field-name string (defaults to EQUAL) or a
-        # dict {"field": str, "operator": int} for per-field operator. The
-        # dict form is what CRDs with LIKE / IN / etc. filters need.
-        if isinstance(spec, str):
-            field_name, operator = spec, 1  # CRITERION_OPERATOR_EQUAL
-        else:
-            field_name = spec["field"]
-            operator = spec.get("operator", 1)
-        _emit_criterion(request_input, field_name, value, operator)
+        for c in _resolve_criteria(spec, bound_args.arguments, arg_dest):
+            _emit_criterion(request_input, c["field"], c["value"], c.get("operator", 1))
 
     _LOG.info("ListRequest built: %r", request_input)
     call_res = crd_method_call(crd_method_info, request_input)

--- a/python/michelangelo/cli/mactl/crd_test.py
+++ b/python/michelangelo/cli/mactl/crd_test.py
@@ -1841,6 +1841,15 @@ class ReadSignaturesHookTest(TestCase):
         self.assertNotIn("pipeline_name", sig.parameters)
 
 
+def _arg_spec(dest: str) -> dict:
+    """Minimal additional_get_args entry for `dest` — matches real-plugin shape."""
+    return {
+        "func_signature": Parameter(dest, Parameter.POSITIONAL_OR_KEYWORD),
+        "args": [f"--{dest.replace('_', '-')}"],
+        "kwargs": {"dest": dest, "type": str},
+    }
+
+
 class FilterEndToEndTest(TestCase):
     """End-to-end: filter flows through generate_list → bind → _list_func_impl.
 
@@ -1857,6 +1866,7 @@ class FilterEndToEndTest(TestCase):
         """`crd.list(pipeline_name="x")` must not TypeError at bind."""
         mock_extract.return_value = ("ListTestCrd", _recording_input_class(), Mock)
         crd = CRD(name="test_crd", full_name="test.service.TestCrd", metadata=[])
+        crd.additional_get_args = [_arg_spec("pipeline_name")]
         crd.filter_field_map = {"pipeline_name": "spec.pipeline_name"}
         crd.additional_columns = ()
 
@@ -1891,6 +1901,7 @@ class FilterEndToEndTest(TestCase):
         """
         mock_extract.return_value = ("Op", _recording_input_class(), Mock)
         crd = CRD(name="test_crd", full_name="test.service.TestCrd", metadata=[])
+        crd.additional_get_args = [_arg_spec("pipeline_name")]
         crd.filter_field_map = {"pipeline_name": "spec.pipeline_name"}
         crd.additional_columns = ()
 
@@ -1947,6 +1958,7 @@ class FilterFieldMapDictSchemaTest(TestCase):
         """Dict spec uses its declared operator (LIKE = 9), not the EQUAL default."""
         mock_extract.return_value = ("Op", _recording_input_class(), Mock)
         crd = CRD(name="test_crd", full_name="test.service.TestCrd", metadata=[])
+        crd.additional_get_args = [_arg_spec("revision")]
         crd.filter_field_map = {
             "revision": {"field": "spec.revision.name", "operator": 9},
         }
@@ -1977,6 +1989,7 @@ class FilterFieldMapDictSchemaTest(TestCase):
         """String spec continues to work — defaults operator to EQUAL = 1."""
         mock_extract.return_value = ("Op", _recording_input_class(), Mock)
         crd = CRD(name="test_crd", full_name="test.service.TestCrd", metadata=[])
+        crd.additional_get_args = [_arg_spec("pipeline_name")]
         crd.filter_field_map = {"pipeline_name": "spec.pipeline_name"}
         crd.additional_columns = ()
 

--- a/python/michelangelo/cli/mactl/crd_test.py
+++ b/python/michelangelo/cli/mactl/crd_test.py
@@ -1997,3 +1997,105 @@ class FilterFieldMapDictSchemaTest(TestCase):
         self.assertEqual(len(criteria), 1)
         self.assertEqual(criteria[0].field_name, "spec.pipeline_name")
         self.assertEqual(criteria[0].operator, 1)
+
+
+class FilterFieldMapCallableSchemaTest(TestCase):
+    """filter_field_map value can be a callable emitting a list of criteria.
+
+    Used when one flag maps to multiple criteria, or when several flags
+    coordinate (e.g. a mutually-exclusive group). The callable receives
+    ``bound_args.arguments`` and returns a list of ``{field, operator, value}``
+    dicts; the framework appends each one to the request.
+    """
+
+    @patch.object(CRD, "_extract_method_info")
+    @patch("michelangelo.cli.mactl.crd.crd_method_call")
+    @patch("michelangelo.cli.mactl.crd.ParseDict")
+    def test_callable_emits_multiple_criteria(self, _parse, mock_call, mock_extract):
+        """Callable returning 2 criteria appends both to the request."""
+        mock_extract.return_value = ("Op", _recording_input_class(), Mock)
+        crd = CRD(name="test_crd", full_name="test.service.TestCrd", metadata=[])
+
+        def builder(_args):
+            return [
+                {"field": "a.b", "operator": 1, "value": "x"},
+                {"field": "a.c", "operator": 9, "value": "y"},
+            ]
+
+        crd.filter_field_map = {"_group": builder}
+        crd.additional_columns = ()
+
+        captured = {}
+
+        def _capture(_info, req):
+            captured["req"] = req
+            field_desc = Mock()
+            field_desc.name = "test_list"
+            return Mock(ListFields=Mock(return_value=[(field_desc, Mock(items=[]))]))
+
+        mock_call.side_effect = _capture
+
+        crd.generate_list(Mock())
+        crd.list(namespace="ns")
+
+        criteria = captured["req"].list_options_ext.operation.criterion
+        self.assertEqual(len(criteria), 2)
+        self.assertEqual(criteria[0].field_name, "a.b")
+        self.assertEqual(criteria[0].operator, 1)
+        self.assertEqual(criteria[1].field_name, "a.c")
+        self.assertEqual(criteria[1].operator, 9)
+
+    @patch.object(CRD, "_extract_method_info")
+    @patch("michelangelo.cli.mactl.crd.crd_method_call")
+    @patch("michelangelo.cli.mactl.crd.ParseDict")
+    def test_callable_returning_empty_list_adds_no_criteria(
+        self, _parse, mock_call, mock_extract
+    ):
+        """Callable that returns [] cleanly skips adding criteria."""
+        mock_extract.return_value = ("Op", _recording_input_class(), Mock)
+        crd = CRD(name="test_crd", full_name="test.service.TestCrd", metadata=[])
+        crd.filter_field_map = {"_group": lambda _args: []}
+        crd.additional_columns = ()
+
+        captured = {}
+
+        def _capture(_info, req):
+            captured["req"] = req
+            field_desc = Mock()
+            field_desc.name = "test_list"
+            return Mock(ListFields=Mock(return_value=[(field_desc, Mock(items=[]))]))
+
+        mock_call.side_effect = _capture
+
+        crd.generate_list(Mock())
+        crd.list(namespace="ns")
+
+        self.assertEqual(len(captured["req"].list_options_ext.operation.criterion), 0)
+
+    @patch.object(CRD, "_extract_method_info")
+    @patch("michelangelo.cli.mactl.crd.crd_method_call")
+    @patch("michelangelo.cli.mactl.crd.ParseDict")
+    def test_callable_operator_defaults_to_equal(self, _parse, mock_call, mock_extract):
+        """Callable dict without explicit operator gets CRITERION_OPERATOR_EQUAL."""
+        mock_extract.return_value = ("Op", _recording_input_class(), Mock)
+        crd = CRD(name="test_crd", full_name="test.service.TestCrd", metadata=[])
+        crd.filter_field_map = {
+            "_group": lambda _args: [{"field": "a.b", "value": "x"}]
+        }
+        crd.additional_columns = ()
+
+        captured = {}
+
+        def _capture(_info, req):
+            captured["req"] = req
+            field_desc = Mock()
+            field_desc.name = "test_list"
+            return Mock(ListFields=Mock(return_value=[(field_desc, Mock(items=[]))]))
+
+        mock_call.side_effect = _capture
+
+        crd.generate_list(Mock())
+        crd.list(namespace="ns")
+
+        criteria = captured["req"].list_options_ext.operation.criterion
+        self.assertEqual(criteria[0].operator, 1)

--- a/python/michelangelo/cli/mactl/plugins/entity/revision/__init__.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/revision/__init__.py
@@ -1,0 +1,1 @@
+"""MaCTL Plugin entity — revision."""

--- a/python/michelangelo/cli/mactl/plugins/entity/revision/get.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/revision/get.py
@@ -73,21 +73,23 @@ def _render_base_resource(item: Message) -> str:
     return ""
 
 
-def _type_flag_arg(name: str, help_text: str) -> dict:
-    """Build an additional_get_args entry for one of the 3 type flags.
+def _get_flag_arg(name: str, help_text: str, default=None) -> dict:
+    """Build an additional_get_args entry for a `revision get` flag.
 
-    Uses ``default=None`` (not empty string) so ``_build_type_criteria`` can
+    Type flags use ``default=None`` so ``_build_type_criteria`` can
     distinguish "flag omitted" from "flag given with empty value".
+    ``--owner`` uses ``default=""`` so the framework's string-form
+    ``filter_field_map`` dispatch skips it when unset.
     """
     return {
         "func_signature": Parameter(
-            name, Parameter.POSITIONAL_OR_KEYWORD, default=None
+            name, Parameter.POSITIONAL_OR_KEYWORD, default=default
         ),
         "args": [f"--{name}"],
         "kwargs": {
             "dest": name,
             "type": str,
-            "default": None,
+            "default": default,
             "required": False,
             "help": help_text,
         },
@@ -98,34 +100,26 @@ def add_get_filters(crd: CRD) -> None:
     """Register 4 filter args and 3 columns on the revision CRD."""
     crd.additional_get_args.extend(
         [
-            _type_flag_arg(
+            _get_flag_arg(
                 "pipeline",
                 "list revisions whose base_type is pipeline "
                 "(optional pattern matches base_resource.name)",
             ),
-            _type_flag_arg(
+            _get_flag_arg(
                 "model",
                 "list revisions whose base_type is model "
                 "(optional pattern matches base_resource.name)",
             ),
-            _type_flag_arg(
+            _get_flag_arg(
                 "deployment",
                 "list revisions whose base_type is deployment "
                 "(optional pattern matches base_resource.name)",
             ),
-            {
-                "func_signature": Parameter(
-                    "owner", Parameter.POSITIONAL_OR_KEYWORD, default=""
-                ),
-                "args": ["--owner"],
-                "kwargs": {
-                    "dest": "owner",
-                    "type": str,
-                    "default": "",
-                    "required": False,
-                    "help": "list revisions owned by the specified user",
-                },
-            },
+            _get_flag_arg(
+                "owner",
+                "list revisions owned by the specified user",
+                default="",
+            ),
         ]
     )
     crd.filter_field_map.update(

--- a/python/michelangelo/cli/mactl/plugins/entity/revision/get.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/revision/get.py
@@ -13,7 +13,7 @@ from logging import getLogger
 
 from google.protobuf.message import Message
 
-from michelangelo.cli.mactl.crd import CRD
+from michelangelo.cli.mactl.crd import CRD, Criterion
 
 _LOG = getLogger(__name__)
 
@@ -22,7 +22,7 @@ _CRITERION_OPERATOR_EQUAL = 1
 _CRITERION_OPERATOR_LIKE = 9
 
 
-def _build_type_criteria(bound_args_arguments: dict) -> list:
+def _build_type_criteria(bound_args_arguments: dict) -> list[Criterion]:
     """Emit base_type + base_resource_name criteria pair for the type flags.
 
     Enforces mutual exclusion — >1 type flag set raises ``ArgumentTypeError``.

--- a/python/michelangelo/cli/mactl/plugins/entity/revision/get.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/revision/get.py
@@ -52,25 +52,23 @@ def _build_type_criteria(bound_args_arguments: dict) -> list:
     ]
 
 
-def _render_type(item: Message) -> str:
-    """TYPE column — base_type.kind, empty when unset."""
-    if item.spec.HasField("base_type"):
-        return item.spec.base_type.kind or ""
-    return ""
+def _render_field(message_field: str, sub_field: str):
+    """Build a column renderer that reads ``spec.<message_field>.<sub_field>``.
+
+    Returns "" when the parent message is unset or the leaf value is falsy.
+    """
+
+    def _render(item: Message) -> str:
+        if item.spec.HasField(message_field):
+            return getattr(getattr(item.spec, message_field), sub_field) or ""
+        return ""
+
+    return _render
 
 
-def _render_user(item: Message) -> str:
-    """USER column — owner.name, empty when unset."""
-    if item.spec.HasField("owner"):
-        return item.spec.owner.name or ""
-    return ""
-
-
-def _render_base_resource(item: Message) -> str:
-    """BASE_RESOURCE column — base_resource.name, empty when unset."""
-    if item.spec.HasField("base_resource"):
-        return item.spec.base_resource.name or ""
-    return ""
+_render_type = _render_field("base_type", "kind")
+_render_user = _render_field("owner", "name")
+_render_base_resource = _render_field("base_resource", "name")
 
 
 def _get_flag_arg(name: str, help_text: str, default=None) -> dict:

--- a/python/michelangelo/cli/mactl/plugins/entity/revision/get.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/revision/get.py
@@ -66,11 +66,6 @@ def _render_field(message_field: str, sub_field: str):
     return _render
 
 
-_render_type = _render_field("base_type", "kind")
-_render_user = _render_field("owner", "name")
-_render_base_resource = _render_field("base_resource", "name")
-
-
 def _get_flag_arg(name: str, help_text: str, default=None) -> dict:
     """Build an additional_get_args entry for a `revision get` flag.
 
@@ -131,9 +126,15 @@ def add_get_filters(crd: CRD) -> None:
     )
     crd.additional_columns.extend(
         [
-            {"column_name": "TYPE", "retrieve_func": _render_type},
-            {"column_name": "USER", "retrieve_func": _render_user},
-            {"column_name": "BASE_RESOURCE", "retrieve_func": _render_base_resource},
+            {
+                "column_name": "TYPE",
+                "retrieve_func": _render_field("base_type", "kind"),
+            },
+            {"column_name": "USER", "retrieve_func": _render_field("owner", "name")},
+            {
+                "column_name": "BASE_RESOURCE",
+                "retrieve_func": _render_field("base_resource", "name"),
+            },
         ]
     )
     _LOG.debug("Revision get filters + columns registered on crd=%r", crd)

--- a/python/michelangelo/cli/mactl/plugins/entity/revision/get.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/revision/get.py
@@ -1,0 +1,147 @@
+"""Revision get filters + display columns (Type, User, Base Resource).
+
+Three type-scoped filters (``--pipeline`` / ``--model`` / ``--deployment``,
+mutually exclusive, LIKE match on base_resource.name) and one independent
+``--owner`` filter (EQUAL). Uses the framework's callable-form
+``filter_field_map`` value to express the mutex + one-flag-two-criteria
+composite.
+"""
+
+from argparse import ArgumentTypeError
+from inspect import Parameter
+from logging import getLogger
+
+from google.protobuf.message import Message
+
+from michelangelo.cli.mactl.crd import CRD
+
+_LOG = getLogger(__name__)
+
+_TYPE_FLAGS = ("pipeline", "model", "deployment")
+_CRITERION_OPERATOR_EQUAL = 1
+_CRITERION_OPERATOR_LIKE = 9
+
+
+def _build_type_criteria(bound_args_arguments: dict) -> list:
+    """Emit base_type + base_resource_name criteria pair for the type flags.
+
+    Enforces mutual exclusion — >1 type flag set raises ``ArgumentTypeError``.
+    Empty pattern degrades to LIKE ``%`` (match every name of that type).
+    Returns ``[]`` when no type flag is set.
+    """
+    given = [t for t in _TYPE_FLAGS if bound_args_arguments.get(t) is not None]
+    if len(given) > 1:
+        raise ArgumentTypeError(
+            f"conflict options <{', '.join(given)}> are set at the same time"
+        )
+    if not given:
+        return []
+    type_kind = given[0]
+    pattern = bound_args_arguments.get(type_kind) or "%"
+    return [
+        {
+            "field": "revision.spec.base_type.kind",
+            "operator": _CRITERION_OPERATOR_EQUAL,
+            "value": type_kind,
+        },
+        {
+            "field": "revision.spec.base_resource.name",
+            "operator": _CRITERION_OPERATOR_LIKE,
+            "value": pattern,
+        },
+    ]
+
+
+def _render_type(item: Message) -> str:
+    """TYPE column — base_type.kind, empty when unset."""
+    if item.spec.HasField("base_type"):
+        return item.spec.base_type.kind or ""
+    return ""
+
+
+def _render_user(item: Message) -> str:
+    """USER column — owner.name, empty when unset."""
+    if item.spec.HasField("owner"):
+        return item.spec.owner.name or ""
+    return ""
+
+
+def _render_base_resource(item: Message) -> str:
+    """BASE_RESOURCE column — base_resource.name, empty when unset."""
+    if item.spec.HasField("base_resource"):
+        return item.spec.base_resource.name or ""
+    return ""
+
+
+def _type_flag_arg(name: str, help_text: str) -> dict:
+    """Build an additional_get_args entry for one of the 3 type flags.
+
+    Uses ``default=None`` (not empty string) so ``_build_type_criteria`` can
+    distinguish "flag omitted" from "flag given with empty value".
+    """
+    return {
+        "func_signature": Parameter(
+            name, Parameter.POSITIONAL_OR_KEYWORD, default=None
+        ),
+        "args": [f"--{name}"],
+        "kwargs": {
+            "dest": name,
+            "type": str,
+            "default": None,
+            "required": False,
+            "help": help_text,
+        },
+    }
+
+
+def add_get_filters(crd: CRD) -> None:
+    """Register 4 filter args and 3 columns on the revision CRD."""
+    crd.additional_get_args.extend(
+        [
+            _type_flag_arg(
+                "pipeline",
+                "list revisions whose base_type is pipeline "
+                "(optional pattern matches base_resource.name)",
+            ),
+            _type_flag_arg(
+                "model",
+                "list revisions whose base_type is model "
+                "(optional pattern matches base_resource.name)",
+            ),
+            _type_flag_arg(
+                "deployment",
+                "list revisions whose base_type is deployment "
+                "(optional pattern matches base_resource.name)",
+            ),
+            {
+                "func_signature": Parameter(
+                    "owner", Parameter.POSITIONAL_OR_KEYWORD, default=""
+                ),
+                "args": ["--owner"],
+                "kwargs": {
+                    "dest": "owner",
+                    "type": str,
+                    "default": "",
+                    "required": False,
+                    "help": "list revisions owned by the specified user",
+                },
+            },
+        ]
+    )
+    crd.filter_field_map.update(
+        {
+            # Callable — handles mutex + one-flag-two-criteria composite for
+            # the type-scoped flags. Synthetic key (not an arg dest).
+            "_revision_type_group": _build_type_criteria,
+            # Independent owner filter, plain EQUAL.
+            "owner": "revision.spec.owner.name",
+        }
+    )
+    crd.additional_columns.extend(
+        [
+            {"column_name": "TYPE", "retrieve_func": _render_type},
+            {"column_name": "USER", "retrieve_func": _render_user},
+            {"column_name": "BASE_RESOURCE", "retrieve_func": _render_base_resource},
+        ]
+    )
+    _LOG.debug("Revision get filters + columns registered on crd=%r", crd)

--- a/python/michelangelo/cli/mactl/plugins/entity/revision/get_test.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/revision/get_test.py
@@ -7,11 +7,13 @@ from unittest.mock import MagicMock
 
 from michelangelo.cli.mactl.plugins.entity.revision.get import (
     _build_type_criteria,
-    _render_base_resource,
-    _render_type,
-    _render_user,
+    _render_field,
     add_get_filters,
 )
+
+_render_type = _render_field("base_type", "kind")
+_render_user = _render_field("owner", "name")
+_render_base_resource = _render_field("base_resource", "name")
 
 
 class BuildTypeCriteriaTest(TestCase):

--- a/python/michelangelo/cli/mactl/plugins/entity/revision/get_test.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/revision/get_test.py
@@ -1,0 +1,170 @@
+"""Unit tests for revision get filters + display columns."""
+
+from argparse import ArgumentTypeError
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from michelangelo.cli.mactl.plugins.entity.revision.get import (
+    _build_type_criteria,
+    _render_base_resource,
+    _render_type,
+    _render_user,
+    add_get_filters,
+)
+
+
+class BuildTypeCriteriaTest(TestCase):
+    """--pipeline / --model / --deployment mutex + composite criteria builder."""
+
+    def test_no_flag_returns_empty(self):
+        """No type flag set → no criteria."""
+        self.assertEqual(_build_type_criteria({}), [])
+
+    def test_pipeline_with_pattern(self):
+        """--pipeline foo → base_type=pipeline + base_resource_name LIKE foo."""
+        cs = _build_type_criteria({"pipeline": "foo"})
+        self.assertEqual(len(cs), 2)
+        self.assertEqual(cs[0]["field"], "revision.spec.base_type.kind")
+        self.assertEqual(cs[0]["operator"], 1)
+        self.assertEqual(cs[0]["value"], "pipeline")
+        self.assertEqual(cs[1]["field"], "revision.spec.base_resource.name")
+        self.assertEqual(cs[1]["operator"], 9)
+        self.assertEqual(cs[1]["value"], "foo")
+
+    def test_model_with_empty_pattern_uses_percent(self):
+        """--model '' → LIKE % fallback matches any name of that type."""
+        cs = _build_type_criteria({"model": ""})
+        self.assertEqual(cs[0]["value"], "model")
+        self.assertEqual(cs[1]["value"], "%")
+
+    def test_deployment(self):
+        """--deployment sets base_type to 'deployment'."""
+        cs = _build_type_criteria({"deployment": "prod"})
+        self.assertEqual(cs[0]["value"], "deployment")
+        self.assertEqual(cs[1]["value"], "prod")
+
+    def test_mutex_two_flags_raises(self):
+        """Two type flags set at once → ArgumentTypeError."""
+        with self.assertRaises(ArgumentTypeError) as cm:
+            _build_type_criteria({"pipeline": "a", "model": "b"})
+        msg = str(cm.exception)
+        self.assertIn("pipeline", msg)
+        self.assertIn("model", msg)
+        self.assertIn("conflict", msg)
+
+    def test_mutex_three_flags_raises(self):
+        """All three type flags set → ArgumentTypeError names all three."""
+        with self.assertRaises(ArgumentTypeError):
+            _build_type_criteria({"pipeline": "a", "model": "b", "deployment": "c"})
+
+    def test_owner_alone_is_not_a_type_flag(self):
+        """--owner is orthogonal — doesn't trigger the mutex or type criteria."""
+        self.assertEqual(_build_type_criteria({"owner": "alice"}), [])
+
+
+class RenderTypeTest(TestCase):
+    """TYPE column reads base_type.kind with empty fallback."""
+
+    def _rev(self, kind=None):
+        """Build a Revision mock; spec.base_type set iff kind is not None."""
+        spec = MagicMock()
+        spec.HasField.side_effect = lambda f: f == "base_type" and kind is not None
+        if kind is not None:
+            spec.base_type.kind = kind
+        return SimpleNamespace(spec=spec)
+
+    def test_kind_set(self):
+        """base_type.kind returned as-is."""
+        self.assertEqual(_render_type(self._rev("pipeline")), "pipeline")
+
+    def test_missing_base_type(self):
+        """Unset base_type → empty string."""
+        self.assertEqual(_render_type(self._rev(None)), "")
+
+    def test_empty_kind(self):
+        """base_type set with empty kind → empty string."""
+        self.assertEqual(_render_type(self._rev("")), "")
+
+
+class RenderUserTest(TestCase):
+    """USER column reads owner.name with empty fallback."""
+
+    def _rev(self, name=None):
+        """Build a Revision mock; spec.owner set iff name is not None."""
+        spec = MagicMock()
+        spec.HasField.side_effect = lambda f: f == "owner" and name is not None
+        if name is not None:
+            spec.owner.name = name
+        return SimpleNamespace(spec=spec)
+
+    def test_owner_set(self):
+        """owner.name returned as-is."""
+        self.assertEqual(_render_user(self._rev("alice")), "alice")
+
+    def test_owner_missing(self):
+        """Unset owner → empty string."""
+        self.assertEqual(_render_user(self._rev(None)), "")
+
+
+class RenderBaseResourceTest(TestCase):
+    """BASE_RESOURCE column reads base_resource.name with empty fallback."""
+
+    def _rev(self, name=None):
+        """Build a Revision mock; spec.base_resource set iff name is not None."""
+        spec = MagicMock()
+        spec.HasField.side_effect = lambda f: f == "base_resource" and name is not None
+        if name is not None:
+            spec.base_resource.name = name
+        return SimpleNamespace(spec=spec)
+
+    def test_name_set(self):
+        """base_resource.name returned as-is."""
+        self.assertEqual(_render_base_resource(self._rev("my-pipeline")), "my-pipeline")
+
+    def test_missing(self):
+        """Unset base_resource → empty string."""
+        self.assertEqual(_render_base_resource(self._rev(None)), "")
+
+
+class AddGetFiltersTest(TestCase):
+    """CRD hook wiring — 4 args, 3 columns, callable + string filter_field_map."""
+
+    def _fresh_crd(self):
+        """CRD-like namespace with the three hook slots CRD.__init__ creates."""
+        return SimpleNamespace(
+            additional_get_args=[],
+            filter_field_map={},
+            additional_columns=[],
+        )
+
+    def test_registers_four_args(self):
+        """--pipeline, --model, --deployment, --owner all added in that order."""
+        crd = self._fresh_crd()
+        add_get_filters(crd)
+        dests = [a["kwargs"]["dest"] for a in crd.additional_get_args]
+        self.assertEqual(dests, ["pipeline", "model", "deployment", "owner"])
+
+    def test_type_flag_defaults_are_none(self):
+        """Type flags default to None so builder distinguishes omitted from empty."""
+        crd = self._fresh_crd()
+        add_get_filters(crd)
+        for arg in crd.additional_get_args:
+            if arg["kwargs"]["dest"] in ("pipeline", "model", "deployment"):
+                self.assertIsNone(arg["kwargs"]["default"])
+
+    def test_filter_field_map_shape(self):
+        """Callable for type group, string for owner."""
+        crd = self._fresh_crd()
+        add_get_filters(crd)
+        self.assertTrue(callable(crd.filter_field_map["_revision_type_group"]))
+        self.assertEqual(crd.filter_field_map["owner"], "revision.spec.owner.name")
+
+    def test_registers_three_columns(self):
+        """TYPE, USER, BASE_RESOURCE in order."""
+        crd = self._fresh_crd()
+        add_get_filters(crd)
+        self.assertEqual(
+            [c["column_name"] for c in crd.additional_columns],
+            ["TYPE", "USER", "BASE_RESOURCE"],
+        )

--- a/python/michelangelo/cli/mactl/plugins/entity/revision/main.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/revision/main.py
@@ -1,0 +1,18 @@
+"""Revision entity plugin module."""
+
+from logging import getLogger
+
+from grpc import Channel
+
+from michelangelo.cli.mactl.crd import CRD
+from michelangelo.cli.mactl.plugins.entity.revision.get import add_get_filters
+
+_LOG = getLogger(__name__)
+
+
+def apply_plugins(crd: CRD, channel: Channel, *_, **__):
+    """Register the get command filters and columns on the revision CRD."""
+    _LOG.info("Applying revision plugin entity to crd: %r", crd)
+    _LOG.debug("gRPC Channel: %r", channel)
+    add_get_filters(crd)
+    _LOG.info("Plugin entities applied successfully to revision crd: %s", crd)


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Feature

**What changed?**

Adds `--pipeline`, `--model`, `--deployment` (mutually exclusive, LIKE on `base_resource.name`) and `--owner` (EQUAL) filters to `ma revision get`, plus 3 columns (`TYPE`, `USER`, `BASE_RESOURCE`). `CRD.filter_field_map` gains a **callable** value shape — `(bound_args) -> list[{"field","operator","value"}]` — needed for one-flag-many-criteria and mutex coordination. Backward-compatible with the pre-existing string and dict shapes. Widens the `list` Signature to accept every `additional_get_args` dest (not just filter_field_map keys), so callable-only flags reach the list fallthrough.

**Why?**

Parity with related client behavior. Callable-form is the minimum extension letting a plugin declare multi-criterion filters or coordinate flags without overriding the framework's list function.

**How did you test it?**

`pytest michelangelo/cli/mactl/` → 406/407 pass (sole failure `TLSConfigurationTest::test_use_tls_default_value` also fails on `origin/main`, unrelated). `ruff check` + `ruff format --check` clean.

Integration test — real apiserver, `ma-integration-test` namespace:

| Command | Observed |
|---|---|
| `ma revision get -n ma-integration-test --limit 3` | 3 columns render. TYPE across sample: `Model`, `Pipeline` (server writes capitalized) |
| `... --pipeline boston --limit 3` | all rows TYPE == `Pipeline` AND BASE_RESOURCE contains `boston` |
| `... --deployment retrain --limit 10` | all rows TYPE == `Deployment` AND BASE_RESOURCE contains `retrain` (10× `retrainer-pass`) |
| `... --pipeline foo --model bar` | exit 2, `ArgumentTypeError: conflict options <pipeline, model> are set at the same time` |
| `... --owner amanda.yao --limit 3` | all rows USER == `amanda.yao`, mixed TYPE values (`Model` in sample) |

**Breaking Changes**

- [x] No breaking changes

**Release notes**

`ma revision get` gains `--pipeline`, `--model`, `--deployment`, and `--owner` filters and `TYPE`/`USER`/`BASE_RESOURCE` columns. `CRD.filter_field_map` values can now be callables for multi-criterion / coordinated filters.

**Documentation Changes**

None.

