### PR TITLE
fix(sandbox): pin Grafana image to 13.1.1 instead of :latest (CVE-2026-31789)

### DIFF
--- a/python/michelangelo/cli/sandbox/resources/grafana.yaml
+++ b/python/michelangelo/cli/sandbox/resources/grafana.yaml
@@ -123,7 +123,10 @@ spec:
     spec:
       containers:
       - name: grafana
-        image: grafana/grafana:latest
+        # Pinned to an explicit version (not `:latest`) so the sandbox doesn't
+        # silently stick to whatever digest a node happened to cache first.
+        # Bump manually when a CVE affecting this version is reported.
+        image: grafana/grafana:13.1.1
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3000


### PR DESCRIPTION
## Summary

The local sandbox's `grafana.yaml` pinned `image: grafana/grafana:latest` with `imagePullPolicy: IfNotPresent`. That combination means any node that has already cached a `:latest` image never re-pulls it, so whatever digest got cached first sticks around indefinitely, regardless of how far upstream has moved on. In this case that meant Grafana 12.4.2, which bundles `libssl3-3.5.5-r0`, vulnerable to **CVE-2026-31789** (OpenSSL ASN.1 DER parsing heap buffer over-read, fixed in `libssl3` 3.5.6-r0).

This PR pins the sandbox's Grafana image to an explicit, verified-patched tag (`13.1.1`, confirmed to bundle `libssl3-3.5.7-r0`) instead of `:latest`, both fixing the current CVE and making sandbox instances reproducible instead of dependent on pull timing/node cache state.

## Verification

- Confirmed via direct image inspection that the flagged vulnerable digest is Grafana 12.4.2 / `libssl3-3.5.5-r0`, and that pinned tags `12.4.2`/`12.4.3` still ship the same vulnerable `libssl3` baked in at build time — only a current pull resolves to a fixed version. `13.1.1` was independently pulled and confirmed to carry `libssl3-3.5.7-r0`.
- Deployed the pinned image to a local k3d sandbox: pod comes up `1/1 Running`, Grafana UI responds `200 OK`, and `libssl3-3.5.7-r0` confirmed installed in the running container.
- Compared logs against the old `12.4.2` tag side-by-side: two pre-existing, unrelated issues (the `grafana-simple-json-datasource` plugin being rejected for using Angular, and a "Dashboard title cannot be empty" provisioning error for `crd-metrics.json`) are present identically under both versions — confirmed **not** introduced by this version bump, and left out of scope for this fix.

## Test plan

- [x] `git grep` confirms no remaining `grafana/grafana:latest` references in the repo.
- [x] Sandbox Grafana deployment rolls out successfully on the new pinned tag.
- [x] Confirmed `libssl3` version inside the running container is patched (>= 3.5.6-r0).
- [x] Confirmed no new breakage introduced relative to the previously-cached vulnerable version (pre-existing plugin/dashboard-provisioning issues are unchanged, not regressions from this change).