### PR TITLE
website: fix site title, meta description, and favicon for search results

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -3,7 +3,7 @@ import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 
 const config: Config = {
-  title: 'Michelangelo',
+  title: 'Michelangelo AI',
   tagline: 'ML Platform Documentation',
   favicon: 'img/favicon.svg',
 
@@ -64,7 +64,7 @@ const config: Config = {
       respectPrefersColorScheme: true,
     },
     navbar: {
-      title: 'Michelangelo',
+      title: 'Michelangelo AI',
       logo: {
         alt: 'Michelangelo Logo',
         src: 'img/logo.svg',

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -10,7 +10,7 @@ export default function Home(): React.ReactElement {
   return (
     <Layout
       title="The ML Platform Behind Uber's AI"
-      description="Now open source."
+      description="Open-source ML platform for model training, deployment, and monitoring. Built at Uber."
     >
       <main className={styles.landing}>
         <Hero />

--- a/website/static/img/favicon.svg
+++ b/website/static/img/favicon.svg
@@ -6,6 +6,7 @@
       .white { fill: #fff; }
     </style>
   </defs>
+  <rect x="0" y="-50" width="215" height="215" rx="24" ry="24" fill="#000"/>
   <rect class="gray" x="71.59" y="8.43" width="33.14" height="98.37"/>
   <polygon class="white" points="104.81 8.53 66.01 8.53 10.31 106.81 49.29 106.81 104.81 8.53"/>
   <polyline class="gray" points="167.35 71.09 204.38 71.27 167.32 106.81"/>


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**
Three fixes to how the site appears in Google search results:
- `docusaurus.config.ts`: site title `'Michelangelo'` → `'Michelangelo AI'` (fixes search title showing "Michelangelo: The ML Platform Behind Uber's AI")
- `src/pages/index.tsx`: meta description updated to "Open-source ML platform for model training, deployment, and monitoring. Built at Uber." (replaces the stale narrow description about feature stores)
- `static/img/favicon.svg`: added black rounded-rect background so the M logo is visible against Google's white search result background

**Why?**
The search result showed the bare "Michelangelo" name (trademark issue) and a description scoped to the feature store rather than the full platform. The favicon was nearly invisible on white backgrounds.

**How did you test it?**
Visual — SVG change can be previewed in browser. Title and description are string changes.

**Potential risks**
None — static asset and config-only changes.

**Breaking Changes**
- [x] No breaking changes

**Release notes**
N/A

**Documentation Changes**
N/A