### PR TITLE
feat(core): add ConfigProvider to decouple config from rendering engine

### DIFF
--- a/javascript/packages/core/ARCHITECTURE.md
+++ b/javascript/packages/core/ARCHITECTURE.md
@@ -29,12 +29,37 @@ The configuration engine is deliberately kept lightweight. When a use case doesn
 
 `core` provides the runtime that interprets configurations. The configurations themselves — the actual `PhaseConfig` objects, entity definitions, action lists, form schemas — live in the consuming application.
 
-Today the reference configurations live in `javascript/app/`. Consumers building their own apps on top of `@michelangelo-ai/core` provide their own. `core` does not ship a default set of entities; it ships the machinery to render them.
+Consumers pass configuration to `CoreApp` via the `config` prop, typed as `StudioConfig`:
+
+```tsx
+import { CoreApp } from '@michelangelo-ai/core';
+import type { StudioConfig } from '@michelangelo-ai/core';
+
+const studioConfig: StudioConfig = {
+  categories: [{ id: 'core-ml', name: 'Core ML', phases: [TRAIN_PHASE, DEPLOY_PHASE] }],
+};
+
+<CoreApp config={studioConfig} dependencies={deps} />;
+```
+
+`StudioConfig` is a wrapper that groups `CategoryConfig[]` and is extensible for future top-level config (e.g. project-level settings). Today the reference configurations live in `javascript/app/`. `core` does not ship a default set of entities; it ships the machinery to render them.
+
+Internally, `CoreApp` wraps the tree in a `ConfigProvider`. Route components access config via the `useStudioConfig()` hook rather than importing config directly:
+
+```ts
+const { categories, getPhase, getEntity } = useStudioConfig();
+const phase = getPhase('train'); // PhaseConfig | undefined
+const entity = getEntity('train', 'pipelines'); // PhaseEntityConfig | undefined
+```
+
+Convention: read config once at the route boundary via `useStudioConfig()`, then prop-drill to leaf components. Leaf components should not call `useStudioConfig()` directly.
 
 ## 3. Configuration system
 
 A configuration is a declarative description of a view, action, or form, expressed as a TypeScript object. The `core` runtime walks the configuration and renders the right components. Configurations nest:
 
+- A **`StudioConfig`** is the top-level container passed to `CoreApp`. It holds `CategoryConfig[]` and is extensible for future top-level settings.
+- A **`CategoryConfig`** groups phases into a logical section (e.g. _Core ML_, _Gen AI_). Categories drive navigation grouping.
 - A **`PhaseConfig`** describes a phase (e.g. _train_, _deploy_) and lists the entities it contains.
 - An **`EntityConfig`** describes an entity (e.g. _pipeline_, _deployment_) and lists its views and actions.
 - A **`ViewConfig`** describes a view of an entity — `list`, `detail`, or `form` — and specifies the columns, tabs, or fields it renders.
@@ -95,10 +120,10 @@ This is what lets the same `core` package serve different consumers without modi
 import { CoreApp } from '@michelangelo-ai/core';
 import { request } from '@michelangelo-ai/rpc';
 
-<CoreApp dependencies={{ service: { request } }} />;
+<CoreApp config={{ categories: CATEGORIES }} dependencies={{ service: { request } }} />;
 ```
 
-Inside `core`, components consume injected implementations through hooks (e.g. `useServiceProvider`) and never reach for an SDK directly. `useStudioMutation`, for example, is a thin wrapper around `useServiceProvider().request`.
+Inside `core`, components consume injected implementations through hooks (e.g. `useServiceProvider`, `useStudioConfig`) and never reach for an SDK or config module directly. `useStudioMutation`, for example, is a thin wrapper around `useServiceProvider().request`, and route components resolve phase/entity config through `useStudioConfig().getPhase()`.
 
 ### Type-safe extension via declaration merging
 
@@ -175,6 +200,6 @@ Avoid mocking core's hooks (e.g. `vi.mock('#core/hooks/use-studio-mutation', …
 ## 9. Where to look next
 
 - **Coding conventions** — `CLAUDE.md` in this directory (testing patterns) and `javascript/CLAUDE.md` (package layout, scripts, available skills)
-- **Reference application** — `javascript/app/` is a complete integration: it imports from `@michelangelo-ai/core`, wires `@michelangelo-ai/rpc` into `<CoreApp dependencies={...}>`, and supplies a configuration tree
-- **Entity config examples** — `javascript/packages/core/config/entities/pipeline/pipeline.ts` shows the shape of an entity configuration. These configs live in core today and will migrate to consumer packages.
-- **Test wrappers** — `test/wrappers/build-wrapper.tsx` and the `get*ProviderWrapper` helpers in the same directory show how to render `core` components with the right context for tests
+- **Reference application** — `javascript/app/` is a complete integration: it imports from `@michelangelo-ai/core`, wires `@michelangelo-ai/rpc` into `<CoreApp dependencies={...}>`, and supplies a `StudioConfig` via the `config` prop
+- **Entity config examples** — `javascript/packages/core/config/entities/pipeline/pipeline.ts` shows the shape of an entity configuration
+- **Test wrappers** — `test/wrappers/build-wrapper.tsx` and the `get*ProviderWrapper` helpers (including `getConfigProviderWrapper`) in the same directory show how to render `core` components with the right context for tests

--- a/javascript/packages/core/config/entities/deployment/__tests__/deployment-page.test.tsx
+++ b/javascript/packages/core/config/entities/deployment/__tests__/deployment-page.test.tsx
@@ -10,6 +10,7 @@ import { DEPLOY_PHASE } from '#core/config/phases/deploy';
 import { EntityDetailRoute } from '#core/router/entity-detail-route';
 import { PhaseListRoute } from '#core/router/phase-list-route';
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getConfigProviderWrapper } from '#core/test/wrappers/get-config-provider-wrapper';
 import { getErrorProviderWrapper } from '#core/test/wrappers/get-error-provider-wrapper';
 import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
 import {
@@ -20,8 +21,11 @@ import {
 describe('Deployment list page', () => {
   it('renders the Deployments tab', () => {
     render(
-      <PhaseListRoute phases={{ deploy: DEPLOY_PHASE }} />,
+      <PhaseListRoute />,
       buildWrapper([
+        getConfigProviderWrapper({
+          categories: [{ id: 'test', name: 'Test', phases: [DEPLOY_PHASE] }],
+        }),
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/deploy/deployments' }),
         getServiceProviderWrapper({
@@ -35,8 +39,11 @@ describe('Deployment list page', () => {
 
   it('renders the correct column headers', async () => {
     render(
-      <PhaseListRoute phases={{ deploy: DEPLOY_PHASE }} />,
+      <PhaseListRoute />,
       buildWrapper([
+        getConfigProviderWrapper({
+          categories: [{ id: 'test', name: 'Test', phases: [DEPLOY_PHASE] }],
+        }),
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/deploy/deployments' }),
         getServiceProviderWrapper({
@@ -56,8 +63,11 @@ describe('Deployment list page', () => {
 
   it('renders a link to the deployment detail page on the deployment name', async () => {
     render(
-      <PhaseListRoute phases={{ deploy: DEPLOY_PHASE }} />,
+      <PhaseListRoute />,
       buildWrapper([
+        getConfigProviderWrapper({
+          categories: [{ id: 'test', name: 'Test', phases: [DEPLOY_PHASE] }],
+        }),
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/deploy/deployments' }),
         getServiceProviderWrapper({
@@ -92,8 +102,11 @@ describe('Deployment detail page', () => {
 
   it('renders details for deployment', async () => {
     render(
-      <EntityDetailRoute phases={{ deploy: DEPLOY_PHASE }} />,
+      <EntityDetailRoute />,
       buildWrapper([
+        getConfigProviderWrapper({
+          categories: [{ id: 'test', name: 'Test', phases: [DEPLOY_PHASE] }],
+        }),
         getErrorProviderWrapper(),
         getRouterWrapper({
           location: '/myproject/deploy/deployments/sentiment-deployment/stages',
@@ -115,8 +128,11 @@ describe('Deployment detail page', () => {
 
   it('renders the stages for the deployment', async () => {
     render(
-      <EntityDetailRoute phases={{ deploy: DEPLOY_PHASE }} />,
+      <EntityDetailRoute />,
       buildWrapper([
+        getConfigProviderWrapper({
+          categories: [{ id: 'test', name: 'Test', phases: [DEPLOY_PHASE] }],
+        }),
         getErrorProviderWrapper(),
         getRouterWrapper({
           location: '/myproject/deploy/deployments/sentiment-deployment/stages',
@@ -157,8 +173,11 @@ describe('Deployment detail page', () => {
 
   it('renders the Information and Details fields within a deployment stage', async () => {
     render(
-      <EntityDetailRoute phases={{ deploy: DEPLOY_PHASE }} />,
+      <EntityDetailRoute />,
       buildWrapper([
+        getConfigProviderWrapper({
+          categories: [{ id: 'test', name: 'Test', phases: [DEPLOY_PHASE] }],
+        }),
         getErrorProviderWrapper(),
         getRouterWrapper({
           location: '/myproject/deploy/deployments/sentiment-deployment/stages',
@@ -195,8 +214,11 @@ describe('Deployment detail page', () => {
 
   it('renders stages when rollout has failed', async () => {
     render(
-      <EntityDetailRoute phases={{ deploy: DEPLOY_PHASE }} />,
+      <EntityDetailRoute />,
       buildWrapper([
+        getConfigProviderWrapper({
+          categories: [{ id: 'test', name: 'Test', phases: [DEPLOY_PHASE] }],
+        }),
         getErrorProviderWrapper(),
         getRouterWrapper({
           location: '/myproject/deploy/deployments/sentiment-deployment/stages',

--- a/javascript/packages/core/config/entities/targets/__tests__/target-page.test.tsx
+++ b/javascript/packages/core/config/entities/targets/__tests__/target-page.test.tsx
@@ -6,6 +6,7 @@ import { DEPLOY_PHASE } from '#core/config/phases/deploy';
 import { EntityDetailRoute } from '#core/router/entity-detail-route';
 import { PhaseListRoute } from '#core/router/phase-list-route';
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getConfigProviderWrapper } from '#core/test/wrappers/get-config-provider-wrapper';
 import { getErrorProviderWrapper } from '#core/test/wrappers/get-error-provider-wrapper';
 import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
 import {
@@ -16,8 +17,11 @@ import {
 describe('Target list page', () => {
   it('renders the Targets tab', () => {
     render(
-      <PhaseListRoute phases={{ deploy: DEPLOY_PHASE }} />,
+      <PhaseListRoute />,
       buildWrapper([
+        getConfigProviderWrapper({
+          categories: [{ id: 'test', name: 'Test', phases: [DEPLOY_PHASE] }],
+        }),
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/deploy/targets' }),
         getServiceProviderWrapper({
@@ -31,8 +35,11 @@ describe('Target list page', () => {
 
   it('renders the correct column headers', async () => {
     render(
-      <PhaseListRoute phases={{ deploy: DEPLOY_PHASE }} />,
+      <PhaseListRoute />,
       buildWrapper([
+        getConfigProviderWrapper({
+          categories: [{ id: 'test', name: 'Test', phases: [DEPLOY_PHASE] }],
+        }),
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/deploy/targets' }),
         getServiceProviderWrapper({
@@ -49,8 +56,11 @@ describe('Target list page', () => {
 
   it('renders a link to the target detail page on the target name', async () => {
     render(
-      <PhaseListRoute phases={{ deploy: DEPLOY_PHASE }} />,
+      <PhaseListRoute />,
       buildWrapper([
+        getConfigProviderWrapper({
+          categories: [{ id: 'test', name: 'Test', phases: [DEPLOY_PHASE] }],
+        }),
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/deploy/targets' }),
         getServiceProviderWrapper({
@@ -86,8 +96,11 @@ describe('Target detail page', () => {
 
   it('renders details for target', async () => {
     render(
-      <EntityDetailRoute phases={{ deploy: DEPLOY_PHASE }} />,
+      <EntityDetailRoute />,
       buildWrapper([
+        getConfigProviderWrapper({
+          categories: [{ id: 'test', name: 'Test', phases: [DEPLOY_PHASE] }],
+        }),
         getErrorProviderWrapper(),
         getRouterWrapper({
           location: '/myproject/deploy/targets/sentiment-target/stages',
@@ -108,8 +121,11 @@ describe('Target detail page', () => {
 
   it('renders the stages for the target', async () => {
     render(
-      <EntityDetailRoute phases={{ deploy: DEPLOY_PHASE }} />,
+      <EntityDetailRoute />,
       buildWrapper([
+        getConfigProviderWrapper({
+          categories: [{ id: 'test', name: 'Test', phases: [DEPLOY_PHASE] }],
+        }),
         getErrorProviderWrapper(),
         getRouterWrapper({
           location: '/myproject/deploy/targets/sentiment-target/stages',
@@ -150,8 +166,11 @@ describe('Target detail page', () => {
 
   it('renders the Information and Details fields within a target stage', async () => {
     render(
-      <EntityDetailRoute phases={{ deploy: DEPLOY_PHASE }} />,
+      <EntityDetailRoute />,
       buildWrapper([
+        getConfigProviderWrapper({
+          categories: [{ id: 'test', name: 'Test', phases: [DEPLOY_PHASE] }],
+        }),
         getErrorProviderWrapper(),
         getRouterWrapper({
           location: '/myproject/deploy/targets/sentiment-target/stages',
@@ -188,8 +207,11 @@ describe('Target detail page', () => {
 
   it('renders the empty state when no stages are reported', async () => {
     render(
-      <EntityDetailRoute phases={{ deploy: DEPLOY_PHASE }} />,
+      <EntityDetailRoute />,
       buildWrapper([
+        getConfigProviderWrapper({
+          categories: [{ id: 'test', name: 'Test', phases: [DEPLOY_PHASE] }],
+        }),
         getErrorProviderWrapper(),
         getRouterWrapper({
           location: '/myproject/deploy/targets/sentiment-target/stages',

--- a/javascript/packages/core/index.tsx
+++ b/javascript/packages/core/index.tsx
@@ -2,6 +2,8 @@ import { LayersManager } from 'baseui/layer';
 import { SnackbarProvider } from 'baseui/snackbar';
 
 import { NavigationBar } from '#core/components/navigation-bar/navigation-bar';
+import { CATEGORIES } from '#core/config/categories';
+import { ConfigProvider } from '#core/providers/config-provider/config-provider';
 import { ErrorProvider } from '#core/providers/error-provider/error-provider';
 import { IconProvider } from '#core/providers/icon-provider/icon-provider';
 import { ServiceProvider } from '#core/providers/service-provider/service-provider';
@@ -15,11 +17,13 @@ import type { ErrorContextValue } from '#core/providers/error-provider/types';
 import type { IconProviderContext } from '#core/providers/icon-provider/types';
 import type { ServiceContextType } from '#core/providers/service-provider/types';
 import type { UserContextType } from '#core/providers/user-provider/types';
+import type { StudioConfig } from '#core/types/common/studio-types';
 
 import '#core/styles/main.css';
 // TODO: Relocate the Props interface once the contents of the
 // packages/core/index.tsx file are moved to a final location
 type Props = {
+  config?: StudioConfig;
   dependencies: {
     error: ErrorContextValue;
     service: ServiceContextType;
@@ -31,7 +35,7 @@ type Props = {
   };
 };
 
-export function CoreApp({ dependencies }: Props) {
+export function CoreApp({ config, dependencies }: Props) {
   return (
     <ThemeProvider icons={dependencies.theme.icons}>
       <LayersManager zIndex={200}>
@@ -40,8 +44,10 @@ export function CoreApp({ dependencies }: Props) {
             <ErrorProvider {...dependencies.error}>
               <IconProvider icons={dependencies.theme.icons}>
                 <UserProvider {...(dependencies.user ?? { timeZone: TimeZone.Local })}>
-                  <NavigationBar links={dependencies.navigationBar?.links} />
-                  <Router />
+                  <ConfigProvider config={config ?? { categories: CATEGORIES }}>
+                    <NavigationBar links={dependencies.navigationBar?.links} />
+                    <Router />
+                  </ConfigProvider>
                 </UserProvider>
               </IconProvider>
             </ErrorProvider>
@@ -185,3 +191,18 @@ export type {
 
 // User Types
 export { UserRole } from '#core/providers/user-provider/types';
+
+// Config Provider
+export { useStudioConfig } from '#core/providers/config-provider/use-studio-config';
+
+// View Config Types
+export type {
+  ViewConfig,
+  ListViewConfig,
+  DetailViewConfig,
+  TableConfig,
+} from '#core/components/views/types';
+export type { DetailPageConfig } from '#core/components/views/detail-view/types/detail-view-schema-types';
+
+// Query Config Types
+export type { QueryConfig } from '#core/types/query-types';

--- a/javascript/packages/core/providers/config-provider/__tests__/use-studio-config.test.tsx
+++ b/javascript/packages/core/providers/config-provider/__tests__/use-studio-config.test.tsx
@@ -1,0 +1,157 @@
+import { renderHook } from '@testing-library/react';
+
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getConfigProviderWrapper } from '#core/test/wrappers/get-config-provider-wrapper';
+import { useStudioConfig } from '../use-studio-config';
+
+describe('useStudioConfig', () => {
+  test('returns categories from config', () => {
+    const { result } = renderHook(
+      () => useStudioConfig(),
+      buildWrapper([
+        getConfigProviderWrapper({
+          categories: [
+            { id: 'core-ml', name: 'Core ML', phases: [] },
+            { id: 'gen-ai', name: 'Gen AI', phases: [] },
+          ],
+        }),
+      ])
+    );
+
+    expect(result.current.categories).toHaveLength(2);
+    expect(result.current.categories[0].id).toBe('core-ml');
+    expect(result.current.categories[1].id).toBe('gen-ai');
+  });
+
+  test('getPhase returns matching phase across categories', () => {
+    const { result } = renderHook(
+      () => useStudioConfig(),
+      buildWrapper([
+        getConfigProviderWrapper({
+          categories: [
+            {
+              id: 'core-ml',
+              name: 'Core ML',
+              phases: [
+                { id: 'train', icon: 'train', name: 'Train', state: 'active', entities: [] },
+              ],
+            },
+          ],
+        }),
+      ])
+    );
+
+    expect(result.current.getPhase('train')).toEqual(
+      expect.objectContaining({ id: 'train', name: 'Train' })
+    );
+  });
+
+  test('getPhase returns undefined for unknown phase', () => {
+    const { result } = renderHook(
+      () => useStudioConfig(),
+      buildWrapper([
+        getConfigProviderWrapper({
+          categories: [
+            {
+              id: 'core-ml',
+              name: 'Core ML',
+              phases: [
+                { id: 'train', icon: 'train', name: 'Train', state: 'active', entities: [] },
+              ],
+            },
+          ],
+        }),
+      ])
+    );
+
+    expect(result.current.getPhase('nonexistent')).toBeUndefined();
+  });
+
+  test('getEntity returns matching entity within a phase', () => {
+    const { result } = renderHook(
+      () => useStudioConfig(),
+      buildWrapper([
+        getConfigProviderWrapper({
+          categories: [
+            {
+              id: 'core-ml',
+              name: 'Core ML',
+              phases: [
+                {
+                  id: 'train',
+                  icon: 'train',
+                  name: 'Train',
+                  state: 'active',
+                  entities: [
+                    {
+                      id: 'pipelines',
+                      name: 'Pipelines',
+                      service: 'pipeline',
+                      state: 'active',
+                      views: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        }),
+      ])
+    );
+
+    expect(result.current.getEntity('train', 'pipelines')).toEqual(
+      expect.objectContaining({ id: 'pipelines', service: 'pipeline' })
+    );
+  });
+
+  test('getEntity returns undefined for unknown entity in valid phase', () => {
+    const { result } = renderHook(
+      () => useStudioConfig(),
+      buildWrapper([
+        getConfigProviderWrapper({
+          categories: [
+            {
+              id: 'core-ml',
+              name: 'Core ML',
+              phases: [
+                {
+                  id: 'train',
+                  icon: 'train',
+                  name: 'Train',
+                  state: 'active',
+                  entities: [
+                    {
+                      id: 'pipelines',
+                      name: 'Pipelines',
+                      service: 'pipeline',
+                      state: 'active',
+                      views: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        }),
+      ])
+    );
+
+    expect(result.current.getEntity('train', 'nonexistent')).toBeUndefined();
+  });
+
+  test('getEntity returns undefined when phase does not exist', () => {
+    const { result } = renderHook(
+      () => useStudioConfig(),
+      buildWrapper([getConfigProviderWrapper({ categories: [] })])
+    );
+
+    expect(result.current.getEntity('nonexistent', 'pipelines')).toBeUndefined();
+  });
+
+  test('throws when used outside ConfigProvider', () => {
+    expect(() => {
+      const { result } = renderHook(() => useStudioConfig());
+      result.current.getPhase('train');
+    }).toThrow('must be used within a ConfigProvider');
+  });
+});

--- a/javascript/packages/core/providers/config-provider/__tests__/use-studio-config.test.tsx
+++ b/javascript/packages/core/providers/config-provider/__tests__/use-studio-config.test.tsx
@@ -150,8 +150,7 @@ describe('useStudioConfig', () => {
 
   test('throws when used outside ConfigProvider', () => {
     expect(() => {
-      const { result } = renderHook(() => useStudioConfig());
-      result.current.getPhase('train');
-    }).toThrow('must be used within a ConfigProvider');
+      renderHook(() => useStudioConfig());
+    }).toThrow('useStudioConfig must be used within a ConfigProvider');
   });
 });

--- a/javascript/packages/core/providers/config-provider/config-context.ts
+++ b/javascript/packages/core/providers/config-provider/config-context.ts
@@ -2,12 +2,4 @@ import { createContext } from 'react';
 
 import type { StudioConfigContextType } from './types';
 
-export const ConfigContext = createContext<StudioConfigContextType>({
-  categories: [],
-  getPhase: () => {
-    throw new Error('getPhase must be used within a ConfigProvider');
-  },
-  getEntity: () => {
-    throw new Error('getEntity must be used within a ConfigProvider');
-  },
-});
+export const ConfigContext = createContext<StudioConfigContextType | null>(null);

--- a/javascript/packages/core/providers/config-provider/config-context.ts
+++ b/javascript/packages/core/providers/config-provider/config-context.ts
@@ -1,0 +1,13 @@
+import { createContext } from 'react';
+
+import type { StudioConfigContextType } from './types';
+
+export const ConfigContext = createContext<StudioConfigContextType>({
+  categories: [],
+  getPhase: () => {
+    throw new Error('getPhase must be used within a ConfigProvider');
+  },
+  getEntity: () => {
+    throw new Error('getEntity must be used within a ConfigProvider');
+  },
+});

--- a/javascript/packages/core/providers/config-provider/config-provider.tsx
+++ b/javascript/packages/core/providers/config-provider/config-provider.tsx
@@ -1,0 +1,31 @@
+import { useCallback, useMemo } from 'react';
+
+import { ConfigContext } from './config-context';
+
+import type { StudioConfig } from '#core/types/common/studio-types';
+
+export function ConfigProvider({
+  children,
+  config,
+}: {
+  children: React.ReactNode;
+  config: StudioConfig;
+}) {
+  const getPhase = useCallback(
+    (phaseId: string) => config.categories.flatMap((c) => c.phases).find((p) => p.id === phaseId),
+    [config.categories]
+  );
+
+  const getEntity = useCallback(
+    (phaseId: string, entityId: string) =>
+      getPhase(phaseId)?.entities.find((e) => e.id === entityId),
+    [getPhase]
+  );
+
+  const value = useMemo(
+    () => ({ categories: config.categories, getPhase, getEntity }),
+    [config.categories, getPhase, getEntity]
+  );
+
+  return <ConfigContext.Provider value={value}>{children}</ConfigContext.Provider>;
+}

--- a/javascript/packages/core/providers/config-provider/types.ts
+++ b/javascript/packages/core/providers/config-provider/types.ts
@@ -1,0 +1,11 @@
+import type {
+  CategoryConfig,
+  PhaseConfig,
+  PhaseEntityConfig,
+} from '#core/types/common/studio-types';
+
+export type StudioConfigContextType = {
+  categories: CategoryConfig[];
+  getPhase: (phaseId: string) => PhaseConfig | undefined;
+  getEntity: (phaseId: string, entityId: string) => PhaseEntityConfig | undefined;
+};

--- a/javascript/packages/core/providers/config-provider/use-studio-config.ts
+++ b/javascript/packages/core/providers/config-provider/use-studio-config.ts
@@ -1,0 +1,24 @@
+import { useContext } from 'react';
+
+import { ConfigContext } from './config-context';
+
+/**
+ * Access the studio configuration — categories, phases, and entities — provided
+ * to `CoreApp` via the `config` prop.
+ *
+ * Use `getPhase` and `getEntity` for lookups by URL param. Both return
+ * `undefined` when the ID doesn't match any configured item.
+ *
+ * @example
+ * ```ts
+ * const { categories, getPhase, getEntity } = useStudioConfig();
+ *
+ * const phase = getPhase('train');
+ * if (!phase) return <ErrorView title="Phase not found" />;
+ *
+ * const entity = getEntity('train', 'pipelines');
+ * ```
+ */
+export function useStudioConfig() {
+  return useContext(ConfigContext);
+}

--- a/javascript/packages/core/providers/config-provider/use-studio-config.ts
+++ b/javascript/packages/core/providers/config-provider/use-studio-config.ts
@@ -20,5 +20,9 @@ import { ConfigContext } from './config-context';
  * ```
  */
 export function useStudioConfig() {
-  return useContext(ConfigContext);
+  const context = useContext(ConfigContext);
+  if (!context) {
+    throw new Error('useStudioConfig must be used within a ConfigProvider');
+  }
+  return context;
 }

--- a/javascript/packages/core/router/__fixtures__/phase-config-factory.ts
+++ b/javascript/packages/core/router/__fixtures__/phase-config-factory.ts
@@ -3,7 +3,12 @@ import { merge } from 'lodash';
 import { CellType } from '#core/components/cell/constants';
 
 import type { ListViewConfig } from '#core/components/views/types';
-import type { PhaseConfig, PhaseEntityConfig } from '#core/types/common/studio-types';
+import type {
+  CategoryConfig,
+  PhaseConfig,
+  PhaseEntityConfig,
+  StudioConfig,
+} from '#core/types/common/studio-types';
 import type { DeepPartial } from '#core/types/utility-types';
 
 /**
@@ -82,3 +87,49 @@ export const buildPhaseConfigFactory = (base: DeepPartial<PhaseConfig> = {}) => 
     return merge({}, required, base, overrides);
   };
 };
+
+/**
+ * Wraps entities, phases, or categories into a complete StudioConfig with sensible defaults.
+ * Accepts the most specific level you care about — the rest is filled in automatically.
+ *
+ * Priority: entities > phases > categories (most specific wins).
+ *
+ * @example
+ * ```typescript
+ * // Just entities — wraps in default phase ('train') + default category ('test')
+ * buildStudioConfig({ entities: [buildEntity({ views: [...] })] })
+ *
+ * // Custom phases — wraps in default category
+ * buildStudioConfig({ phases: [buildPhase({ id: 'train', entities: [...] })] })
+ *
+ * // Full categories — passes through as-is
+ * buildStudioConfig({ categories: [...] })
+ * ```
+ */
+export function buildStudioConfig(
+  config: {
+    categories?: CategoryConfig[];
+    phases?: PhaseConfig[];
+    entities?: PhaseEntityConfig[];
+  } = {}
+): StudioConfig {
+  if (config.categories) {
+    return { categories: config.categories };
+  }
+
+  const defaultPhase = buildPhaseConfigFactory();
+
+  if (config.phases) {
+    return { categories: [{ id: 'test', name: 'Test', phases: config.phases }] };
+  }
+
+  return {
+    categories: [
+      {
+        id: 'test',
+        name: 'Test',
+        phases: [defaultPhase({ id: 'train', entities: config.entities ?? [] })],
+      },
+    ],
+  };
+}

--- a/javascript/packages/core/router/__tests__/entity-detail-route.test.tsx
+++ b/javascript/packages/core/router/__tests__/entity-detail-route.test.tsx
@@ -15,10 +15,7 @@ import {
   createQueryMockRouter,
   getServiceProviderWrapper,
 } from '#core/test/wrappers/get-service-provider-wrapper';
-import {
-  buildEntityConfigFactory,
-  buildPhaseConfigFactory,
-} from '../__fixtures__/phase-config-factory';
+import { buildEntityConfigFactory, buildStudioConfig } from '../__fixtures__/phase-config-factory';
 import { EntityDetailRoute } from '../entity-detail-route';
 
 import type { ActionComponentProps } from '#core/components/actions/types';
@@ -35,7 +32,6 @@ describe('EntityDetailRoute', () => {
   });
   const buildExecutionSchema = buildExecutionSchemaFactory();
   const buildTableConfig = buildTableConfigFactory();
-  const buildPhase = buildPhaseConfigFactory();
 
   test('renders execution tab', async () => {
     const mockEntityData = {
@@ -67,43 +63,34 @@ describe('EntityDetailRoute', () => {
     render(
       <EntityDetailRoute />,
       buildWrapper([
-        getConfigProviderWrapper({
-          categories: [
-            {
-              id: 'test',
-              name: 'Test',
-              phases: [
-                buildPhase({
-                  id: 'train',
-                  entities: [
-                    buildEntity({
-                      views: [
-                        {
-                          type: 'detail',
-                          metadata: [
-                            {
-                              id: 'metadata.creationTimestamp.seconds',
-                              label: 'Created',
-                              type: CellType.DATE,
-                            },
-                            { id: 'status.state', label: 'State', type: CellType.STATE },
-                          ],
-                          pages: [
-                            {
-                              id: 'execution',
-                              label: 'Execution',
-                              ...buildExecutionSchema(),
-                            },
-                          ],
-                        },
-                      ],
-                    }),
-                  ],
-                }),
-              ],
-            },
-          ],
-        }),
+        getConfigProviderWrapper(
+          buildStudioConfig({
+            entities: [
+              buildEntity({
+                views: [
+                  {
+                    type: 'detail',
+                    metadata: [
+                      {
+                        id: 'metadata.creationTimestamp.seconds',
+                        label: 'Created',
+                        type: CellType.DATE,
+                      },
+                      { id: 'status.state', label: 'State', type: CellType.STATE },
+                    ],
+                    pages: [
+                      {
+                        id: 'execution',
+                        label: 'Execution',
+                        ...buildExecutionSchema(),
+                      },
+                    ],
+                  },
+                ],
+              }),
+            ],
+          })
+        ),
         getErrorProviderWrapper(),
         getRouterWrapper({
           location: '/myproject/train/runs/run-123',
@@ -145,43 +132,34 @@ describe('EntityDetailRoute', () => {
     render(
       <EntityDetailRoute />,
       buildWrapper([
-        getConfigProviderWrapper({
-          categories: [
-            {
-              id: 'test',
-              name: 'Test',
-              phases: [
-                buildPhase({
-                  id: 'train',
-                  entities: [
-                    buildEntity({
-                      views: [
-                        {
-                          type: 'detail',
-                          metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
-                          pages: [
-                            {
-                              id: 'first-page',
-                              label: 'First page',
-                              type: 'custom',
-                              component: () => <div>First page component</div>,
-                            } as CustomDetailPageConfig,
-                            {
-                              id: 'second-page',
-                              label: 'Second page',
-                              type: 'custom',
-                              component: () => <div>Second page component</div>,
-                            } as CustomDetailPageConfig,
-                          ],
-                        },
-                      ],
-                    }),
-                  ],
-                }),
-              ],
-            },
-          ],
-        }),
+        getConfigProviderWrapper(
+          buildStudioConfig({
+            entities: [
+              buildEntity({
+                views: [
+                  {
+                    type: 'detail',
+                    metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
+                    pages: [
+                      {
+                        id: 'first-page',
+                        label: 'First page',
+                        type: 'custom',
+                        component: () => <div>First page component</div>,
+                      } as CustomDetailPageConfig,
+                      {
+                        id: 'second-page',
+                        label: 'Second page',
+                        type: 'custom',
+                        component: () => <div>Second page component</div>,
+                      } as CustomDetailPageConfig,
+                    ],
+                  },
+                ],
+              }),
+            ],
+          })
+        ),
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/train/runs/run-123' }),
         getServiceProviderWrapper({ request: mockRequest }),
@@ -213,43 +191,34 @@ describe('EntityDetailRoute', () => {
     render(
       <EntityDetailRoute />,
       buildWrapper([
-        getConfigProviderWrapper({
-          categories: [
-            {
-              id: 'test',
-              name: 'Test',
-              phases: [
-                buildPhase({
-                  id: 'train',
-                  entities: [
-                    buildEntity({
-                      views: [
-                        {
-                          type: 'detail',
-                          metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
-                          pages: [
-                            // cast: testing runtime behavior with an unknown page type; not representable in
-                            // the type-safe union
-                            {
-                              id: 'unknown-type',
-                              label: 'Unknown Type',
-                              type: 'some-unknown-type',
-                            } as never,
-                            {
-                              id: 'execution',
-                              label: 'Execution',
-                              ...buildExecutionSchema(),
-                            },
-                          ],
-                        },
-                      ],
-                    }),
-                  ],
-                }),
-              ],
-            },
-          ],
-        }),
+        getConfigProviderWrapper(
+          buildStudioConfig({
+            entities: [
+              buildEntity({
+                views: [
+                  {
+                    type: 'detail',
+                    metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
+                    pages: [
+                      // cast: testing runtime behavior with an unknown page type; not representable in
+                      // the type-safe union
+                      {
+                        id: 'unknown-type',
+                        label: 'Unknown Type',
+                        type: 'some-unknown-type',
+                      } as never,
+                      {
+                        id: 'execution',
+                        label: 'Execution',
+                        ...buildExecutionSchema(),
+                      },
+                    ],
+                  },
+                ],
+              }),
+            ],
+          })
+        ),
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/train/runs/run-123' }),
         getServiceProviderWrapper({ request: mockRequest }),
@@ -280,30 +249,21 @@ describe('EntityDetailRoute', () => {
     render(
       <EntityDetailRoute />,
       buildWrapper([
-        getConfigProviderWrapper({
-          categories: [
-            {
-              id: 'test',
-              name: 'Test',
-              phases: [
-                buildPhase({
-                  id: 'train',
-                  entities: [
-                    buildEntity({
-                      views: [
-                        {
-                          type: 'detail',
-                          metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
-                          pages: [],
-                        },
-                      ],
-                    }),
-                  ],
-                }),
-              ],
-            },
-          ],
-        }),
+        getConfigProviderWrapper(
+          buildStudioConfig({
+            entities: [
+              buildEntity({
+                views: [
+                  {
+                    type: 'detail',
+                    metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
+                    pages: [],
+                  },
+                ],
+              }),
+            ],
+          })
+        ),
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/train/runs/run-123' }),
         getServiceProviderWrapper({ request: mockRequest }),
@@ -334,36 +294,27 @@ describe('EntityDetailRoute', () => {
     render(
       <EntityDetailRoute />,
       buildWrapper([
-        getConfigProviderWrapper({
-          categories: [
-            {
-              id: 'test',
-              name: 'Test',
-              phases: [
-                buildPhase({
-                  id: 'train',
-                  entities: [
-                    buildEntity({
-                      views: [
-                        {
-                          type: 'detail',
-                          metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
-                          pages: [
-                            {
-                              id: 'execution',
-                              label: 'Execution',
-                              ...buildExecutionSchema(),
-                            },
-                          ],
-                        },
-                      ],
-                    }),
-                  ],
-                }),
-              ],
-            },
-          ],
-        }),
+        getConfigProviderWrapper(
+          buildStudioConfig({
+            entities: [
+              buildEntity({
+                views: [
+                  {
+                    type: 'detail',
+                    metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
+                    pages: [
+                      {
+                        id: 'execution',
+                        label: 'Execution',
+                        ...buildExecutionSchema(),
+                      },
+                    ],
+                  },
+                ],
+              }),
+            ],
+          })
+        ),
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/train/runs/run-123/invalid-tab' }),
         getServiceProviderWrapper({ request: mockRequest }),
@@ -380,36 +331,27 @@ describe('EntityDetailRoute', () => {
     render(
       <EntityDetailRoute />,
       buildWrapper([
-        getConfigProviderWrapper({
-          categories: [
-            {
-              id: 'test',
-              name: 'Test',
-              phases: [
-                buildPhase({
-                  id: 'train',
-                  entities: [
-                    buildEntity({
-                      views: [
-                        {
-                          type: 'detail',
-                          metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
-                          pages: [
-                            {
-                              id: 'execution',
-                              label: 'Execution',
-                              ...buildExecutionSchema(),
-                            },
-                          ],
-                        },
-                      ],
-                    }),
-                  ],
-                }),
-              ],
-            },
-          ],
-        }),
+        getConfigProviderWrapper(
+          buildStudioConfig({
+            entities: [
+              buildEntity({
+                views: [
+                  {
+                    type: 'detail',
+                    metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
+                    pages: [
+                      {
+                        id: 'execution',
+                        label: 'Execution',
+                        ...buildExecutionSchema(),
+                      },
+                    ],
+                  },
+                ],
+              }),
+            ],
+          })
+        ),
         getErrorProviderWrapper(),
         getRouterWrapper({
           location: '/myproject/train/runs/run-123',
@@ -444,44 +386,35 @@ describe('EntityDetailRoute', () => {
     render(
       <EntityDetailRoute />,
       buildWrapper([
-        getConfigProviderWrapper({
-          categories: [
-            {
-              id: 'test',
-              name: 'Test',
-              phases: [
-                buildPhase({
-                  id: 'train',
-                  entities: [
-                    buildEntity({
-                      views: [
-                        {
-                          type: 'detail',
-                          metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
-                          pages: [
-                            {
-                              id: 'runs-table',
-                              label: 'Related Runs',
-                              type: 'table',
-                              queryConfig: {
-                                service: 'pipelineRun',
-                                serviceOptions: {},
-                                clientOptions: { enabled: false },
-                              },
-                              tableConfig: buildTableConfig({
-                                columns: [{ id: 'name', label: 'Run Name', type: CellType.TEXT }],
-                              }),
-                            },
-                          ],
+        getConfigProviderWrapper(
+          buildStudioConfig({
+            entities: [
+              buildEntity({
+                views: [
+                  {
+                    type: 'detail',
+                    metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
+                    pages: [
+                      {
+                        id: 'runs-table',
+                        label: 'Related Runs',
+                        type: 'table',
+                        queryConfig: {
+                          service: 'pipelineRun',
+                          serviceOptions: {},
+                          clientOptions: { enabled: false },
                         },
-                      ],
-                    }),
-                  ],
-                }),
-              ],
-            },
-          ],
-        }),
+                        tableConfig: buildTableConfig({
+                          columns: [{ id: 'name', label: 'Run Name', type: CellType.TEXT }],
+                        }),
+                      },
+                    ],
+                  },
+                ],
+              }),
+            ],
+          })
+        ),
         getErrorProviderWrapper(),
         getRouterWrapper({
           location: '/myproject/train/runs/run-123',
@@ -517,46 +450,37 @@ describe('EntityDetailRoute', () => {
     render(
       <EntityDetailRoute />,
       buildWrapper([
-        getConfigProviderWrapper({
-          categories: [
-            {
-              id: 'test',
-              name: 'Test',
-              phases: [
-                buildPhase({
-                  id: 'train',
-                  entities: [
-                    buildEntity({
-                      views: [
-                        {
-                          type: 'detail',
-                          metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
-                          pages: [
-                            {
-                              id: 'filtered-runs',
-                              label: 'Filtered Runs',
-                              type: 'table',
-                              queryConfig: {
-                                service: 'pipelineRun',
-                                serviceOptions: {
-                                  filter: 'status=SUCCESS',
-                                  limit: 10,
-                                },
-                              },
-                              tableConfig: buildTableConfig({
-                                columns: [{ id: 'name', label: 'Run Name', type: CellType.TEXT }],
-                              }),
-                            },
-                          ],
+        getConfigProviderWrapper(
+          buildStudioConfig({
+            entities: [
+              buildEntity({
+                views: [
+                  {
+                    type: 'detail',
+                    metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
+                    pages: [
+                      {
+                        id: 'filtered-runs',
+                        label: 'Filtered Runs',
+                        type: 'table',
+                        queryConfig: {
+                          service: 'pipelineRun',
+                          serviceOptions: {
+                            filter: 'status=SUCCESS',
+                            limit: 10,
+                          },
                         },
-                      ],
-                    }),
-                  ],
-                }),
-              ],
-            },
-          ],
-        }),
+                        tableConfig: buildTableConfig({
+                          columns: [{ id: 'name', label: 'Run Name', type: CellType.TEXT }],
+                        }),
+                      },
+                    ],
+                  },
+                ],
+              }),
+            ],
+          })
+        ),
         getErrorProviderWrapper(),
         getRouterWrapper({
           location: '/myproject/train/runs/run-123',
@@ -590,44 +514,35 @@ describe('EntityDetailRoute', () => {
     render(
       <EntityDetailRoute />,
       buildWrapper([
-        getConfigProviderWrapper({
-          categories: [
-            {
-              id: 'test',
-              name: 'Test',
-              phases: [
-                buildPhase({
-                  id: 'train',
-                  entities: [
-                    buildEntity({
-                      views: [
-                        {
-                          type: 'detail',
-                          metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
-                          pages: [
-                            {
-                              id: 'runs-table',
-                              label: 'Related Runs',
-                              type: 'table',
-                              queryConfig: {
-                                service: 'pipelineRun',
-                                endpoint: 'list',
-                                serviceOptions: {},
-                              },
-                              tableConfig: buildTableConfig({
-                                columns: [{ id: 'name', label: 'Run Name', type: CellType.TEXT }],
-                              }),
-                            } as TableDetailPageConfig,
-                          ],
+        getConfigProviderWrapper(
+          buildStudioConfig({
+            entities: [
+              buildEntity({
+                views: [
+                  {
+                    type: 'detail',
+                    metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
+                    pages: [
+                      {
+                        id: 'runs-table',
+                        label: 'Related Runs',
+                        type: 'table',
+                        queryConfig: {
+                          service: 'pipelineRun',
+                          endpoint: 'list',
+                          serviceOptions: {},
                         },
-                      ],
-                    }),
-                  ],
-                }),
-              ],
-            },
-          ],
-        }),
+                        tableConfig: buildTableConfig({
+                          columns: [{ id: 'name', label: 'Run Name', type: CellType.TEXT }],
+                        }),
+                      } as TableDetailPageConfig,
+                    ],
+                  },
+                ],
+              }),
+            ],
+          })
+        ),
         getErrorProviderWrapper(),
         getRouterWrapper({
           location: '/myproject/train/runs/run-123',
@@ -671,63 +586,54 @@ describe('EntityDetailRoute', () => {
     render(
       <EntityDetailRoute />,
       buildWrapper([
-        getConfigProviderWrapper({
-          categories: [
-            {
-              id: 'test',
-              name: 'Test',
-              phases: [
-                buildPhase({
-                  id: 'train',
-                  entities: [
-                    buildEntity({
-                      views: [
-                        {
-                          type: 'detail',
-                          metadata: [
-                            { id: 'status.state', label: 'State', type: CellType.STATE },
+        getConfigProviderWrapper(
+          buildStudioConfig({
+            entities: [
+              buildEntity({
+                views: [
+                  {
+                    type: 'detail',
+                    metadata: [
+                      { id: 'status.state', label: 'State', type: CellType.STATE },
+                      {
+                        id: 'metadata.name',
+                        label: 'Name: ${page.metadata.name}',
+                        type: CellType.TEXT,
+                      },
+                    ],
+                    pages: [
+                      {
+                        id: 'interpolated-table',
+                        label: 'Related Runs',
+                        type: 'table',
+                        queryConfig: {
+                          endpoint: 'list',
+                          service: 'pipelineRun',
+                          serviceOptions: {
+                            listOptions: {
+                              labelSelector:
+                                'pipelinerun.michelangelo/source-trigger=${page.metadata.name}',
+                            },
+                          },
+                        },
+                        tableConfig: buildTableConfig({
+                          columns: [
                             {
                               id: 'metadata.name',
-                              label: 'Name: ${page.metadata.name}',
+                              label: 'Run Name',
                               type: CellType.TEXT,
+                              url: '/${studio.projectId}/${studio.phase}/runs/${row.metadata.name}?page=${page.metadata.name}',
                             },
                           ],
-                          pages: [
-                            {
-                              id: 'interpolated-table',
-                              label: 'Related Runs',
-                              type: 'table',
-                              queryConfig: {
-                                endpoint: 'list',
-                                service: 'pipelineRun',
-                                serviceOptions: {
-                                  listOptions: {
-                                    labelSelector:
-                                      'pipelinerun.michelangelo/source-trigger=${page.metadata.name}',
-                                  },
-                                },
-                              },
-                              tableConfig: buildTableConfig({
-                                columns: [
-                                  {
-                                    id: 'metadata.name',
-                                    label: 'Run Name',
-                                    type: CellType.TEXT,
-                                    url: '/${studio.projectId}/${studio.phase}/runs/${row.metadata.name}?page=${page.metadata.name}',
-                                  },
-                                ],
-                              }),
-                            },
-                          ],
-                        },
-                      ],
-                    }),
-                  ],
-                }),
-              ],
-            },
-          ],
-        }),
+                        }),
+                      },
+                    ],
+                  },
+                ],
+              }),
+            ],
+          })
+        ),
         getErrorProviderWrapper(),
         getRouterWrapper({
           location: '/myproject/train/runs/test-trigger-123',
@@ -772,43 +678,34 @@ describe('EntityDetailRoute', () => {
     render(
       <EntityDetailRoute />,
       buildWrapper([
-        getConfigProviderWrapper({
-          categories: [
-            {
-              id: 'test',
-              name: 'Test',
-              phases: [
-                buildPhase({
-                  id: 'train',
-                  entities: [
-                    buildEntity({
-                      actions: [
-                        {
-                          display: { label: 'Run', icon: 'playerPlay' },
-                          modal: { type: 'custom', component: RunDialog },
-                          hierarchy: ActionHierarchy.PRIMARY,
-                        },
-                      ],
-                      views: [
-                        {
-                          type: 'detail',
-                          metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
-                          pages: [
-                            {
-                              id: 'execution',
-                              label: 'Execution',
-                              ...buildExecutionSchema(),
-                            },
-                          ],
-                        },
-                      ],
-                    }),
-                  ],
-                }),
-              ],
-            },
-          ],
-        }),
+        getConfigProviderWrapper(
+          buildStudioConfig({
+            entities: [
+              buildEntity({
+                actions: [
+                  {
+                    display: { label: 'Run', icon: 'playerPlay' },
+                    modal: { type: 'custom', component: RunDialog },
+                    hierarchy: ActionHierarchy.PRIMARY,
+                  },
+                ],
+                views: [
+                  {
+                    type: 'detail',
+                    metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
+                    pages: [
+                      {
+                        id: 'execution',
+                        label: 'Execution',
+                        ...buildExecutionSchema(),
+                      },
+                    ],
+                  },
+                ],
+              }),
+            ],
+          })
+        ),
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/train/runs/run-123' }),
         getServiceProviderWrapper({ request: mockRequest }),
@@ -838,44 +735,33 @@ describe('EntityDetailRoute', () => {
     render(
       <EntityDetailRoute />,
       buildWrapper([
-        getConfigProviderWrapper({
-          categories: [
-            {
-              id: 'test',
-              name: 'Test',
-              phases: [
-                buildPhase({
-                  id: 'train',
-                  entities: [
-                    buildEntity({
-                      actions: [
-                        {
-                          display: { label: 'Resume' },
-                          modal: { type: 'custom', component: StubDialog },
-                          hierarchy: interpolate(({ data }) => {
-                            const record = data as { status?: { state?: string } } | undefined;
-                            return record?.status?.state === 'PAUSED'
-                              ? ActionHierarchy.PRIMARY
-                              : ActionHierarchy.TERTIARY;
-                          }),
-                        },
-                      ],
-                      views: [
-                        {
-                          type: 'detail',
-                          metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
-                          pages: [
-                            { id: 'execution', label: 'Execution', ...buildExecutionSchema() },
-                          ],
-                        },
-                      ],
+        getConfigProviderWrapper(
+          buildStudioConfig({
+            entities: [
+              buildEntity({
+                actions: [
+                  {
+                    display: { label: 'Resume' },
+                    modal: { type: 'custom', component: StubDialog },
+                    hierarchy: interpolate(({ data }) => {
+                      const record = data as { status?: { state?: string } } | undefined;
+                      return record?.status?.state === 'PAUSED'
+                        ? ActionHierarchy.PRIMARY
+                        : ActionHierarchy.TERTIARY;
                     }),
-                  ],
-                }),
-              ],
-            },
-          ],
-        }),
+                  },
+                ],
+                views: [
+                  {
+                    type: 'detail',
+                    metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
+                    pages: [{ id: 'execution', label: 'Execution', ...buildExecutionSchema() }],
+                  },
+                ],
+              }),
+            ],
+          })
+        ),
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/train/runs/run-123' }),
         getServiceProviderWrapper({ request: mockRequest }),
@@ -900,52 +786,43 @@ describe('EntityDetailRoute', () => {
     render(
       <EntityDetailRoute />,
       buildWrapper([
-        getConfigProviderWrapper({
-          categories: [
-            {
-              id: 'test',
-              name: 'Test',
-              phases: [
-                buildPhase({
-                  id: 'train',
-                  entities: [
-                    buildEntity({
-                      actions: [
-                        {
-                          display: { label: 'Run', icon: 'playerPlay' },
-                          modal: { type: 'custom', component: StubDialog },
-                          hierarchy: ActionHierarchy.PRIMARY,
-                          disabled: [
-                            {
-                              condition: interpolate(({ data }) => {
-                                const record = data as { status?: { state?: string } } | undefined;
-                                return record?.status?.state === 'RUNNING';
-                              }),
-                              message: 'Pipeline is already running',
-                            },
-                          ],
-                        },
-                      ],
-                      views: [
-                        {
-                          type: 'detail',
-                          metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
-                          pages: [
-                            {
-                              id: 'execution',
-                              label: 'Execution',
-                              ...buildExecutionSchema(),
-                            },
-                          ],
-                        },
-                      ],
-                    }),
-                  ],
-                }),
-              ],
-            },
-          ],
-        }),
+        getConfigProviderWrapper(
+          buildStudioConfig({
+            entities: [
+              buildEntity({
+                actions: [
+                  {
+                    display: { label: 'Run', icon: 'playerPlay' },
+                    modal: { type: 'custom', component: StubDialog },
+                    hierarchy: ActionHierarchy.PRIMARY,
+                    disabled: [
+                      {
+                        condition: interpolate(({ data }) => {
+                          const record = data as { status?: { state?: string } } | undefined;
+                          return record?.status?.state === 'RUNNING';
+                        }),
+                        message: 'Pipeline is already running',
+                      },
+                    ],
+                  },
+                ],
+                views: [
+                  {
+                    type: 'detail',
+                    metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
+                    pages: [
+                      {
+                        id: 'execution',
+                        label: 'Execution',
+                        ...buildExecutionSchema(),
+                      },
+                    ],
+                  },
+                ],
+              }),
+            ],
+          })
+        ),
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/train/runs/run-123' }),
         getServiceProviderWrapper({ request: mockRequest }),
@@ -976,43 +853,34 @@ describe('EntityDetailRoute', () => {
       render(
         <EntityDetailRoute />,
         buildWrapper([
-          getConfigProviderWrapper({
-            categories: [
-              {
-                id: 'test',
-                name: 'Test',
-                phases: [
-                  buildPhase({
-                    id: 'train',
-                    entities: [
-                      buildEntity({
-                        views: [
-                          {
-                            type: 'detail',
-                            metadata: [],
-                            pages: [
-                              {
-                                id: 'overview',
-                                label: 'Overview',
-                                type: 'custom',
-                                component: () => <div>Overview content</div>,
-                              } as CustomDetailPageConfig,
-                              {
-                                id: 'logs',
-                                label: 'Logs',
-                                type: 'custom',
-                                component: () => <div>Logs content</div>,
-                              } as CustomDetailPageConfig,
-                            ],
-                          },
-                        ],
-                      }),
-                    ],
-                  }),
-                ],
-              },
-            ],
-          }),
+          getConfigProviderWrapper(
+            buildStudioConfig({
+              entities: [
+                buildEntity({
+                  views: [
+                    {
+                      type: 'detail',
+                      metadata: [],
+                      pages: [
+                        {
+                          id: 'overview',
+                          label: 'Overview',
+                          type: 'custom',
+                          component: () => <div>Overview content</div>,
+                        } as CustomDetailPageConfig,
+                        {
+                          id: 'logs',
+                          label: 'Logs',
+                          type: 'custom',
+                          component: () => <div>Logs content</div>,
+                        } as CustomDetailPageConfig,
+                      ],
+                    },
+                  ],
+                }),
+              ],
+            })
+          ),
           getErrorProviderWrapper(),
           getRouterWrapper({
             initialEntries: ['/myproject/train/runs', '/myproject/train/runs/run-123'],
@@ -1046,43 +914,34 @@ describe('EntityDetailRoute', () => {
       render(
         <EntityDetailRoute />,
         buildWrapper([
-          getConfigProviderWrapper({
-            categories: [
-              {
-                id: 'test',
-                name: 'Test',
-                phases: [
-                  buildPhase({
-                    id: 'train',
-                    entities: [
-                      buildEntity({
-                        views: [
-                          {
-                            type: 'detail',
-                            metadata: [],
-                            pages: [
-                              {
-                                id: 'overview',
-                                label: 'Overview',
-                                type: 'custom',
-                                component: () => <div>Overview content</div>,
-                              } as CustomDetailPageConfig,
-                              {
-                                id: 'logs',
-                                label: 'Logs',
-                                type: 'custom',
-                                component: () => <div>Logs content</div>,
-                              } as CustomDetailPageConfig,
-                            ],
-                          },
-                        ],
-                      }),
-                    ],
-                  }),
-                ],
-              },
-            ],
-          }),
+          getConfigProviderWrapper(
+            buildStudioConfig({
+              entities: [
+                buildEntity({
+                  views: [
+                    {
+                      type: 'detail',
+                      metadata: [],
+                      pages: [
+                        {
+                          id: 'overview',
+                          label: 'Overview',
+                          type: 'custom',
+                          component: () => <div>Overview content</div>,
+                        } as CustomDetailPageConfig,
+                        {
+                          id: 'logs',
+                          label: 'Logs',
+                          type: 'custom',
+                          component: () => <div>Logs content</div>,
+                        } as CustomDetailPageConfig,
+                      ],
+                    },
+                  ],
+                }),
+              ],
+            })
+          ),
           getErrorProviderWrapper(),
           getRouterWrapper({
             initialEntries: ['/myproject/train/runs/run-123/overview'],
@@ -1115,43 +974,34 @@ describe('EntityDetailRoute', () => {
       render(
         <EntityDetailRoute />,
         buildWrapper([
-          getConfigProviderWrapper({
-            categories: [
-              {
-                id: 'test',
-                name: 'Test',
-                phases: [
-                  buildPhase({
-                    id: 'train',
-                    entities: [
-                      buildEntity({
-                        views: [
-                          {
-                            type: 'detail',
-                            metadata: [],
-                            pages: [
-                              {
-                                id: 'overview',
-                                label: 'Overview',
-                                type: 'custom',
-                                component: () => <div>Overview content</div>,
-                              } as CustomDetailPageConfig,
-                              {
-                                id: 'logs',
-                                label: 'Logs',
-                                type: 'custom',
-                                component: () => <div>Logs content</div>,
-                              } as CustomDetailPageConfig,
-                            ],
-                          },
-                        ],
-                      }),
-                    ],
-                  }),
-                ],
-              },
-            ],
-          }),
+          getConfigProviderWrapper(
+            buildStudioConfig({
+              entities: [
+                buildEntity({
+                  views: [
+                    {
+                      type: 'detail',
+                      metadata: [],
+                      pages: [
+                        {
+                          id: 'overview',
+                          label: 'Overview',
+                          type: 'custom',
+                          component: () => <div>Overview content</div>,
+                        } as CustomDetailPageConfig,
+                        {
+                          id: 'logs',
+                          label: 'Logs',
+                          type: 'custom',
+                          component: () => <div>Logs content</div>,
+                        } as CustomDetailPageConfig,
+                      ],
+                    },
+                  ],
+                }),
+              ],
+            })
+          ),
           getErrorProviderWrapper(),
           getRouterWrapper({
             initialEntries: ['/myproject/train/runs', '/myproject/train/runs/run-123'],
@@ -1191,43 +1041,34 @@ describe('EntityDetailRoute', () => {
       render(
         <EntityDetailRoute />,
         buildWrapper([
-          getConfigProviderWrapper({
-            categories: [
-              {
-                id: 'test',
-                name: 'Test',
-                phases: [
-                  buildPhase({
-                    id: 'train',
-                    entities: [
-                      buildEntity({
-                        views: [
-                          {
-                            type: 'detail',
-                            metadata: [],
-                            pages: [
-                              {
-                                id: 'overview',
-                                label: 'Overview',
-                                type: 'custom',
-                                component: () => <div>Overview content</div>,
-                              } as CustomDetailPageConfig,
-                              {
-                                id: 'logs',
-                                label: 'Logs',
-                                type: 'custom',
-                                component: () => <div>Logs content</div>,
-                              } as CustomDetailPageConfig,
-                            ],
-                          },
-                        ],
-                      }),
-                    ],
-                  }),
-                ],
-              },
-            ],
-          }),
+          getConfigProviderWrapper(
+            buildStudioConfig({
+              entities: [
+                buildEntity({
+                  views: [
+                    {
+                      type: 'detail',
+                      metadata: [],
+                      pages: [
+                        {
+                          id: 'overview',
+                          label: 'Overview',
+                          type: 'custom',
+                          component: () => <div>Overview content</div>,
+                        } as CustomDetailPageConfig,
+                        {
+                          id: 'logs',
+                          label: 'Logs',
+                          type: 'custom',
+                          component: () => <div>Logs content</div>,
+                        } as CustomDetailPageConfig,
+                      ],
+                    },
+                  ],
+                }),
+              ],
+            })
+          ),
           getErrorProviderWrapper(),
           getRouterWrapper({
             initialEntries: ['/myproject/train/runs/run-123/overview'],

--- a/javascript/packages/core/router/__tests__/entity-detail-route.test.tsx
+++ b/javascript/packages/core/router/__tests__/entity-detail-route.test.tsx
@@ -8,6 +8,7 @@ import { buildTableConfigFactory } from '#core/components/views/__fixtures__/tab
 import { buildExecutionSchemaFactory } from '#core/components/views/execution/__fixtures__/execution-schema-factory';
 import { interpolate } from '#core/interpolation/interpolate';
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getConfigProviderWrapper } from '#core/test/wrappers/get-config-provider-wrapper';
 import { getErrorProviderWrapper } from '#core/test/wrappers/get-error-provider-wrapper';
 import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
 import {
@@ -37,36 +38,6 @@ describe('EntityDetailRoute', () => {
   const buildPhase = buildPhaseConfigFactory();
 
   test('renders execution tab', async () => {
-    const testPhases = {
-      train: buildPhase({
-        id: 'train',
-        entities: [
-          buildEntity({
-            views: [
-              {
-                type: 'detail',
-                metadata: [
-                  {
-                    id: 'metadata.creationTimestamp.seconds',
-                    label: 'Created',
-                    type: CellType.DATE,
-                  },
-                  { id: 'status.state', label: 'State', type: CellType.STATE },
-                ],
-                pages: [
-                  {
-                    id: 'execution',
-                    label: 'Execution',
-                    ...buildExecutionSchema(),
-                  },
-                ],
-              },
-            ],
-          }),
-        ],
-      }),
-    };
-
     const mockEntityData = {
       pipelineRun: {
         metadata: {
@@ -94,8 +65,45 @@ describe('EntityDetailRoute', () => {
     const mockRequest = vi.fn().mockResolvedValue(mockEntityData);
 
     render(
-      <EntityDetailRoute phases={testPhases} />,
+      <EntityDetailRoute />,
       buildWrapper([
+        getConfigProviderWrapper({
+          categories: [
+            {
+              id: 'test',
+              name: 'Test',
+              phases: [
+                buildPhase({
+                  id: 'train',
+                  entities: [
+                    buildEntity({
+                      views: [
+                        {
+                          type: 'detail',
+                          metadata: [
+                            {
+                              id: 'metadata.creationTimestamp.seconds',
+                              label: 'Created',
+                              type: CellType.DATE,
+                            },
+                            { id: 'status.state', label: 'State', type: CellType.STATE },
+                          ],
+                          pages: [
+                            {
+                              id: 'execution',
+                              label: 'Execution',
+                              ...buildExecutionSchema(),
+                            },
+                          ],
+                        },
+                      ],
+                    }),
+                  ],
+                }),
+              ],
+            },
+          ],
+        }),
         getErrorProviderWrapper(),
         getRouterWrapper({
           location: '/myproject/train/runs/run-123',
@@ -121,36 +129,6 @@ describe('EntityDetailRoute', () => {
   test('renders custom detail pages and navigates between them', async () => {
     const user = userEvent.setup();
 
-    const testPhases = {
-      train: buildPhase({
-        id: 'train',
-        entities: [
-          buildEntity({
-            views: [
-              {
-                type: 'detail',
-                metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
-                pages: [
-                  {
-                    id: 'first-page',
-                    label: 'First page',
-                    type: 'custom',
-                    component: () => <div>First page component</div>,
-                  } as CustomDetailPageConfig,
-                  {
-                    id: 'second-page',
-                    label: 'Second page',
-                    type: 'custom',
-                    component: () => <div>Second page component</div>,
-                  } as CustomDetailPageConfig,
-                ],
-              },
-            ],
-          }),
-        ],
-      }),
-    };
-
     const mockRequest = vi.fn().mockResolvedValue({
       pipelineRun: {
         metadata: {
@@ -165,8 +143,45 @@ describe('EntityDetailRoute', () => {
     });
 
     render(
-      <EntityDetailRoute phases={testPhases} />,
+      <EntityDetailRoute />,
       buildWrapper([
+        getConfigProviderWrapper({
+          categories: [
+            {
+              id: 'test',
+              name: 'Test',
+              phases: [
+                buildPhase({
+                  id: 'train',
+                  entities: [
+                    buildEntity({
+                      views: [
+                        {
+                          type: 'detail',
+                          metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
+                          pages: [
+                            {
+                              id: 'first-page',
+                              label: 'First page',
+                              type: 'custom',
+                              component: () => <div>First page component</div>,
+                            } as CustomDetailPageConfig,
+                            {
+                              id: 'second-page',
+                              label: 'Second page',
+                              type: 'custom',
+                              component: () => <div>Second page component</div>,
+                            } as CustomDetailPageConfig,
+                          ],
+                        },
+                      ],
+                    }),
+                  ],
+                }),
+              ],
+            },
+          ],
+        }),
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/train/runs/run-123' }),
         getServiceProviderWrapper({ request: mockRequest }),
@@ -182,32 +197,6 @@ describe('EntityDetailRoute', () => {
   });
 
   test('handles unknown page types', () => {
-    const testPhases = {
-      train: buildPhase({
-        id: 'train',
-        entities: [
-          buildEntity({
-            views: [
-              {
-                type: 'detail',
-                metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
-                pages: [
-                  // cast: testing runtime behavior with an unknown page type; not representable in
-                  // the type-safe union
-                  { id: 'unknown-type', label: 'Unknown Type', type: 'some-unknown-type' } as never,
-                  {
-                    id: 'execution',
-                    label: 'Execution',
-                    ...buildExecutionSchema(),
-                  },
-                ],
-              },
-            ],
-          }),
-        ],
-      }),
-    };
-
     const mockRequest = vi.fn().mockResolvedValue({
       pipelineRun: {
         metadata: {
@@ -222,8 +211,45 @@ describe('EntityDetailRoute', () => {
     });
 
     render(
-      <EntityDetailRoute phases={testPhases} />,
+      <EntityDetailRoute />,
       buildWrapper([
+        getConfigProviderWrapper({
+          categories: [
+            {
+              id: 'test',
+              name: 'Test',
+              phases: [
+                buildPhase({
+                  id: 'train',
+                  entities: [
+                    buildEntity({
+                      views: [
+                        {
+                          type: 'detail',
+                          metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
+                          pages: [
+                            // cast: testing runtime behavior with an unknown page type; not representable in
+                            // the type-safe union
+                            {
+                              id: 'unknown-type',
+                              label: 'Unknown Type',
+                              type: 'some-unknown-type',
+                            } as never,
+                            {
+                              id: 'execution',
+                              label: 'Execution',
+                              ...buildExecutionSchema(),
+                            },
+                          ],
+                        },
+                      ],
+                    }),
+                  ],
+                }),
+              ],
+            },
+          ],
+        }),
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/train/runs/run-123' }),
         getServiceProviderWrapper({ request: mockRequest }),
@@ -238,23 +264,6 @@ describe('EntityDetailRoute', () => {
   });
 
   test('handles empty pages array', async () => {
-    const testPhases = {
-      train: buildPhase({
-        id: 'train',
-        entities: [
-          buildEntity({
-            views: [
-              {
-                type: 'detail',
-                metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
-                pages: [],
-              },
-            ],
-          }),
-        ],
-      }),
-    };
-
     const mockRequest = vi.fn().mockResolvedValue({
       pipelineRun: {
         metadata: {
@@ -269,8 +278,32 @@ describe('EntityDetailRoute', () => {
     });
 
     render(
-      <EntityDetailRoute phases={testPhases} />,
+      <EntityDetailRoute />,
       buildWrapper([
+        getConfigProviderWrapper({
+          categories: [
+            {
+              id: 'test',
+              name: 'Test',
+              phases: [
+                buildPhase({
+                  id: 'train',
+                  entities: [
+                    buildEntity({
+                      views: [
+                        {
+                          type: 'detail',
+                          metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
+                          pages: [],
+                        },
+                      ],
+                    }),
+                  ],
+                }),
+              ],
+            },
+          ],
+        }),
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/train/runs/run-123' }),
         getServiceProviderWrapper({ request: mockRequest }),
@@ -285,29 +318,6 @@ describe('EntityDetailRoute', () => {
   });
 
   test('redirects to first tab if entityTab is invalid', async () => {
-    const testPhases = {
-      train: buildPhase({
-        id: 'train',
-        entities: [
-          buildEntity({
-            views: [
-              {
-                type: 'detail',
-                metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
-                pages: [
-                  {
-                    id: 'execution',
-                    label: 'Execution',
-                    ...buildExecutionSchema(),
-                  },
-                ],
-              },
-            ],
-          }),
-        ],
-      }),
-    };
-
     const mockRequest = vi.fn().mockResolvedValue({
       pipelineRun: {
         metadata: {
@@ -322,8 +332,38 @@ describe('EntityDetailRoute', () => {
     });
 
     render(
-      <EntityDetailRoute phases={testPhases} />,
+      <EntityDetailRoute />,
       buildWrapper([
+        getConfigProviderWrapper({
+          categories: [
+            {
+              id: 'test',
+              name: 'Test',
+              phases: [
+                buildPhase({
+                  id: 'train',
+                  entities: [
+                    buildEntity({
+                      views: [
+                        {
+                          type: 'detail',
+                          metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
+                          pages: [
+                            {
+                              id: 'execution',
+                              label: 'Execution',
+                              ...buildExecutionSchema(),
+                            },
+                          ],
+                        },
+                      ],
+                    }),
+                  ],
+                }),
+              ],
+            },
+          ],
+        }),
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/train/runs/run-123/invalid-tab' }),
         getServiceProviderWrapper({ request: mockRequest }),
@@ -335,75 +375,41 @@ describe('EntityDetailRoute', () => {
   });
 
   test('handles error when entity not found', async () => {
-    const testPhases = {
-      train: buildPhase({
-        id: 'train',
-        entities: [
-          buildEntity({
-            views: [
-              {
-                type: 'detail',
-                metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
-                pages: [
-                  {
-                    id: 'execution',
-                    label: 'Execution',
-                    ...buildExecutionSchema(),
-                  },
-                ],
-              },
-            ],
-          }),
-        ],
-      }),
-    };
-
     const mockRequest = vi.fn().mockRejectedValue(new Error('Entity not found'));
 
     render(
-      <EntityDetailRoute phases={testPhases} />,
+      <EntityDetailRoute />,
       buildWrapper([
-        getErrorProviderWrapper(),
-        getRouterWrapper({
-          location: '/myproject/train/runs/run-123',
+        getConfigProviderWrapper({
+          categories: [
+            {
+              id: 'test',
+              name: 'Test',
+              phases: [
+                buildPhase({
+                  id: 'train',
+                  entities: [
+                    buildEntity({
+                      views: [
+                        {
+                          type: 'detail',
+                          metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
+                          pages: [
+                            {
+                              id: 'execution',
+                              label: 'Execution',
+                              ...buildExecutionSchema(),
+                            },
+                          ],
+                        },
+                      ],
+                    }),
+                  ],
+                }),
+              ],
+            },
+          ],
         }),
-        getServiceProviderWrapper({ request: mockRequest }),
-      ])
-    );
-
-    await screen.findByText('Entity not found');
-    expect(screen.getByRole('button', { name: /Back to list/i })).toBeInTheDocument();
-  });
-
-  test('handles error when entity not found', async () => {
-    const testPhases = {
-      train: buildPhase({
-        id: 'train',
-        entities: [
-          buildEntity({
-            views: [
-              {
-                type: 'detail',
-                metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
-                pages: [
-                  {
-                    id: 'execution',
-                    label: 'Execution',
-                    ...buildExecutionSchema(),
-                  },
-                ],
-              },
-            ],
-          }),
-        ],
-      }),
-    };
-
-    const mockRequest = vi.fn().mockRejectedValue(new Error('Entity not found'));
-
-    render(
-      <EntityDetailRoute phases={testPhases} />,
-      buildWrapper([
         getErrorProviderWrapper(),
         getRouterWrapper({
           location: '/myproject/train/runs/run-123',
@@ -417,37 +423,6 @@ describe('EntityDetailRoute', () => {
   });
 
   test('table does not fetch data when query is disabled', async () => {
-    const testPhases = {
-      train: buildPhase({
-        id: 'train',
-        entities: [
-          buildEntity({
-            views: [
-              {
-                type: 'detail',
-                metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
-                pages: [
-                  {
-                    id: 'runs-table',
-                    label: 'Related Runs',
-                    type: 'table',
-                    queryConfig: {
-                      service: 'pipelineRun',
-                      serviceOptions: {},
-                      clientOptions: { enabled: false },
-                    },
-                    tableConfig: buildTableConfig({
-                      columns: [{ id: 'name', label: 'Run Name', type: CellType.TEXT }],
-                    }),
-                  },
-                ],
-              },
-            ],
-          }),
-        ],
-      }),
-    };
-
     const mockEntityData = {
       pipelineRun: {
         metadata: {
@@ -467,8 +442,46 @@ describe('EntityDetailRoute', () => {
     });
 
     render(
-      <EntityDetailRoute phases={testPhases} />,
+      <EntityDetailRoute />,
       buildWrapper([
+        getConfigProviderWrapper({
+          categories: [
+            {
+              id: 'test',
+              name: 'Test',
+              phases: [
+                buildPhase({
+                  id: 'train',
+                  entities: [
+                    buildEntity({
+                      views: [
+                        {
+                          type: 'detail',
+                          metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
+                          pages: [
+                            {
+                              id: 'runs-table',
+                              label: 'Related Runs',
+                              type: 'table',
+                              queryConfig: {
+                                service: 'pipelineRun',
+                                serviceOptions: {},
+                                clientOptions: { enabled: false },
+                              },
+                              tableConfig: buildTableConfig({
+                                columns: [{ id: 'name', label: 'Run Name', type: CellType.TEXT }],
+                              }),
+                            },
+                          ],
+                        },
+                      ],
+                    }),
+                  ],
+                }),
+              ],
+            },
+          ],
+        }),
         getErrorProviderWrapper(),
         getRouterWrapper({
           location: '/myproject/train/runs/run-123',
@@ -487,39 +500,6 @@ describe('EntityDetailRoute', () => {
   });
 
   test('table respects custom service options from config', async () => {
-    const testPhases = {
-      train: buildPhase({
-        id: 'train',
-        entities: [
-          buildEntity({
-            views: [
-              {
-                type: 'detail',
-                metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
-                pages: [
-                  {
-                    id: 'filtered-runs',
-                    label: 'Filtered Runs',
-                    type: 'table',
-                    queryConfig: {
-                      service: 'pipelineRun',
-                      serviceOptions: {
-                        filter: 'status=SUCCESS',
-                        limit: 10,
-                      },
-                    },
-                    tableConfig: buildTableConfig({
-                      columns: [{ id: 'name', label: 'Run Name', type: CellType.TEXT }],
-                    }),
-                  },
-                ],
-              },
-            ],
-          }),
-        ],
-      }),
-    };
-
     const mockEntityData = {
       pipelineRun: {
         metadata: { creationTimestamp: { seconds: 1640995200 } },
@@ -535,8 +515,48 @@ describe('EntityDetailRoute', () => {
     });
 
     render(
-      <EntityDetailRoute phases={testPhases} />,
+      <EntityDetailRoute />,
       buildWrapper([
+        getConfigProviderWrapper({
+          categories: [
+            {
+              id: 'test',
+              name: 'Test',
+              phases: [
+                buildPhase({
+                  id: 'train',
+                  entities: [
+                    buildEntity({
+                      views: [
+                        {
+                          type: 'detail',
+                          metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
+                          pages: [
+                            {
+                              id: 'filtered-runs',
+                              label: 'Filtered Runs',
+                              type: 'table',
+                              queryConfig: {
+                                service: 'pipelineRun',
+                                serviceOptions: {
+                                  filter: 'status=SUCCESS',
+                                  limit: 10,
+                                },
+                              },
+                              tableConfig: buildTableConfig({
+                                columns: [{ id: 'name', label: 'Run Name', type: CellType.TEXT }],
+                              }),
+                            },
+                          ],
+                        },
+                      ],
+                    }),
+                  ],
+                }),
+              ],
+            },
+          ],
+        }),
         getErrorProviderWrapper(),
         getRouterWrapper({
           location: '/myproject/train/runs/run-123',
@@ -549,37 +569,6 @@ describe('EntityDetailRoute', () => {
   });
 
   test('handles table tab request failure gracefully', async () => {
-    const testPhases = {
-      train: buildPhase({
-        id: 'train',
-        entities: [
-          buildEntity({
-            views: [
-              {
-                type: 'detail',
-                metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
-                pages: [
-                  {
-                    id: 'runs-table',
-                    label: 'Related Runs',
-                    type: 'table',
-                    queryConfig: {
-                      service: 'pipelineRun',
-                      endpoint: 'list',
-                      serviceOptions: {},
-                    },
-                    tableConfig: buildTableConfig({
-                      columns: [{ id: 'name', label: 'Run Name', type: CellType.TEXT }],
-                    }),
-                  } as TableDetailPageConfig,
-                ],
-              },
-            ],
-          }),
-        ],
-      }),
-    };
-
     const mockEntityData = {
       pipelineRun: {
         metadata: {
@@ -599,8 +588,46 @@ describe('EntityDetailRoute', () => {
     });
 
     render(
-      <EntityDetailRoute phases={testPhases} />,
+      <EntityDetailRoute />,
       buildWrapper([
+        getConfigProviderWrapper({
+          categories: [
+            {
+              id: 'test',
+              name: 'Test',
+              phases: [
+                buildPhase({
+                  id: 'train',
+                  entities: [
+                    buildEntity({
+                      views: [
+                        {
+                          type: 'detail',
+                          metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
+                          pages: [
+                            {
+                              id: 'runs-table',
+                              label: 'Related Runs',
+                              type: 'table',
+                              queryConfig: {
+                                service: 'pipelineRun',
+                                endpoint: 'list',
+                                serviceOptions: {},
+                              },
+                              tableConfig: buildTableConfig({
+                                columns: [{ id: 'name', label: 'Run Name', type: CellType.TEXT }],
+                              }),
+                            } as TableDetailPageConfig,
+                          ],
+                        },
+                      ],
+                    }),
+                  ],
+                }),
+              ],
+            },
+          ],
+        }),
         getErrorProviderWrapper(),
         getRouterWrapper({
           location: '/myproject/train/runs/run-123',
@@ -613,56 +640,6 @@ describe('EntityDetailRoute', () => {
   });
 
   test('resolves interpolation at various configuration levels', async () => {
-    const testPhases = {
-      train: buildPhase({
-        id: 'train',
-        entities: [
-          buildEntity({
-            views: [
-              {
-                type: 'detail',
-                metadata: [
-                  { id: 'status.state', label: 'State', type: CellType.STATE },
-                  {
-                    id: 'metadata.name',
-                    label: 'Name: ${page.metadata.name}',
-                    type: CellType.TEXT,
-                  },
-                ],
-                pages: [
-                  {
-                    id: 'interpolated-table',
-                    label: 'Related Runs',
-                    type: 'table',
-                    queryConfig: {
-                      endpoint: 'list',
-                      service: 'pipelineRun',
-                      serviceOptions: {
-                        listOptions: {
-                          labelSelector:
-                            'pipelinerun.michelangelo/source-trigger=${page.metadata.name}',
-                        },
-                      },
-                    },
-                    tableConfig: buildTableConfig({
-                      columns: [
-                        {
-                          id: 'metadata.name',
-                          label: 'Run Name',
-                          type: CellType.TEXT,
-                          url: '/${studio.projectId}/${studio.phase}/runs/${row.metadata.name}?page=${page.metadata.name}',
-                        },
-                      ],
-                    }),
-                  },
-                ],
-              },
-            ],
-          }),
-        ],
-      }),
-    };
-
     const mockRequest = createQueryMockRouter({
       GetPipelineRun: {
         pipelineRun: {
@@ -692,8 +669,65 @@ describe('EntityDetailRoute', () => {
     });
 
     render(
-      <EntityDetailRoute phases={testPhases} />,
+      <EntityDetailRoute />,
       buildWrapper([
+        getConfigProviderWrapper({
+          categories: [
+            {
+              id: 'test',
+              name: 'Test',
+              phases: [
+                buildPhase({
+                  id: 'train',
+                  entities: [
+                    buildEntity({
+                      views: [
+                        {
+                          type: 'detail',
+                          metadata: [
+                            { id: 'status.state', label: 'State', type: CellType.STATE },
+                            {
+                              id: 'metadata.name',
+                              label: 'Name: ${page.metadata.name}',
+                              type: CellType.TEXT,
+                            },
+                          ],
+                          pages: [
+                            {
+                              id: 'interpolated-table',
+                              label: 'Related Runs',
+                              type: 'table',
+                              queryConfig: {
+                                endpoint: 'list',
+                                service: 'pipelineRun',
+                                serviceOptions: {
+                                  listOptions: {
+                                    labelSelector:
+                                      'pipelinerun.michelangelo/source-trigger=${page.metadata.name}',
+                                  },
+                                },
+                              },
+                              tableConfig: buildTableConfig({
+                                columns: [
+                                  {
+                                    id: 'metadata.name',
+                                    label: 'Run Name',
+                                    type: CellType.TEXT,
+                                    url: '/${studio.projectId}/${studio.phase}/runs/${row.metadata.name}?page=${page.metadata.name}',
+                                  },
+                                ],
+                              }),
+                            },
+                          ],
+                        },
+                      ],
+                    }),
+                  ],
+                }),
+              ],
+            },
+          ],
+        }),
         getErrorProviderWrapper(),
         getRouterWrapper({
           location: '/myproject/train/runs/test-trigger-123',
@@ -728,36 +762,6 @@ describe('EntityDetailRoute', () => {
       </div>
     );
 
-    const testPhases = {
-      train: buildPhase({
-        id: 'train',
-        entities: [
-          buildEntity({
-            actions: [
-              {
-                display: { label: 'Run', icon: 'playerPlay' },
-                modal: { type: 'custom', component: RunDialog },
-                hierarchy: ActionHierarchy.PRIMARY,
-              },
-            ],
-            views: [
-              {
-                type: 'detail',
-                metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
-                pages: [
-                  {
-                    id: 'execution',
-                    label: 'Execution',
-                    ...buildExecutionSchema(),
-                  },
-                ],
-              },
-            ],
-          }),
-        ],
-      }),
-    };
-
     const mockRequest = vi.fn().mockResolvedValue({
       pipelineRun: {
         metadata: { creationTimestamp: { seconds: 1640995200 } },
@@ -766,8 +770,45 @@ describe('EntityDetailRoute', () => {
     });
 
     render(
-      <EntityDetailRoute phases={testPhases} />,
+      <EntityDetailRoute />,
       buildWrapper([
+        getConfigProviderWrapper({
+          categories: [
+            {
+              id: 'test',
+              name: 'Test',
+              phases: [
+                buildPhase({
+                  id: 'train',
+                  entities: [
+                    buildEntity({
+                      actions: [
+                        {
+                          display: { label: 'Run', icon: 'playerPlay' },
+                          modal: { type: 'custom', component: RunDialog },
+                          hierarchy: ActionHierarchy.PRIMARY,
+                        },
+                      ],
+                      views: [
+                        {
+                          type: 'detail',
+                          metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
+                          pages: [
+                            {
+                              id: 'execution',
+                              label: 'Execution',
+                              ...buildExecutionSchema(),
+                            },
+                          ],
+                        },
+                      ],
+                    }),
+                  ],
+                }),
+              ],
+            },
+          ],
+        }),
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/train/runs/run-123' }),
         getServiceProviderWrapper({ request: mockRequest }),
@@ -787,35 +828,6 @@ describe('EntityDetailRoute', () => {
   test('resolves interpolated action hierarchy in the detail page header', async () => {
     const StubDialog = () => <div role="dialog">Stub</div>;
 
-    const testPhases = {
-      train: buildPhase({
-        id: 'train',
-        entities: [
-          buildEntity({
-            actions: [
-              {
-                display: { label: 'Resume' },
-                modal: { type: 'custom', component: StubDialog },
-                hierarchy: interpolate(({ data }) => {
-                  const record = data as { status?: { state?: string } } | undefined;
-                  return record?.status?.state === 'PAUSED'
-                    ? ActionHierarchy.PRIMARY
-                    : ActionHierarchy.TERTIARY;
-                }),
-              },
-            ],
-            views: [
-              {
-                type: 'detail',
-                metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
-                pages: [{ id: 'execution', label: 'Execution', ...buildExecutionSchema() }],
-              },
-            ],
-          }),
-        ],
-      }),
-    };
-
     const mockRequest = vi.fn().mockResolvedValue({
       pipelineRun: {
         metadata: { creationTimestamp: { seconds: 1640995200 } },
@@ -824,60 +836,59 @@ describe('EntityDetailRoute', () => {
     });
 
     render(
-      <EntityDetailRoute phases={testPhases} />,
+      <EntityDetailRoute />,
       buildWrapper([
+        getConfigProviderWrapper({
+          categories: [
+            {
+              id: 'test',
+              name: 'Test',
+              phases: [
+                buildPhase({
+                  id: 'train',
+                  entities: [
+                    buildEntity({
+                      actions: [
+                        {
+                          display: { label: 'Resume' },
+                          modal: { type: 'custom', component: StubDialog },
+                          hierarchy: interpolate(({ data }) => {
+                            const record = data as { status?: { state?: string } } | undefined;
+                            return record?.status?.state === 'PAUSED'
+                              ? ActionHierarchy.PRIMARY
+                              : ActionHierarchy.TERTIARY;
+                          }),
+                        },
+                      ],
+                      views: [
+                        {
+                          type: 'detail',
+                          metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
+                          pages: [
+                            { id: 'execution', label: 'Execution', ...buildExecutionSchema() },
+                          ],
+                        },
+                      ],
+                    }),
+                  ],
+                }),
+              ],
+            },
+          ],
+        }),
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/train/runs/run-123' }),
         getServiceProviderWrapper({ request: mockRequest }),
       ])
     );
 
-    // Hierarchy resolves to PRIMARY → renders as a direct button, not in overflow menu
+    // Hierarchy resolves to PRIMARY -> renders as a direct button, not in overflow menu
     expect(await screen.findByRole('button', { name: 'Resume' })).toBeInTheDocument();
   });
 
   test('disables an entity-level action button based on the record and displays the message on hover', async () => {
     const user = userEvent.setup();
     const StubDialog = () => <div role="dialog">Stub</div>;
-
-    const testPhases = {
-      train: buildPhase({
-        id: 'train',
-        entities: [
-          buildEntity({
-            actions: [
-              {
-                display: { label: 'Run', icon: 'playerPlay' },
-                modal: { type: 'custom', component: StubDialog },
-                hierarchy: ActionHierarchy.PRIMARY,
-                disabled: [
-                  {
-                    condition: interpolate(({ data }) => {
-                      const record = data as { status?: { state?: string } } | undefined;
-                      return record?.status?.state === 'RUNNING';
-                    }),
-                    message: 'Pipeline is already running',
-                  },
-                ],
-              },
-            ],
-            views: [
-              {
-                type: 'detail',
-                metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
-                pages: [
-                  {
-                    id: 'execution',
-                    label: 'Execution',
-                    ...buildExecutionSchema(),
-                  },
-                ],
-              },
-            ],
-          }),
-        ],
-      }),
-    };
 
     const mockRequest = vi.fn().mockResolvedValue({
       pipelineRun: {
@@ -887,8 +898,54 @@ describe('EntityDetailRoute', () => {
     });
 
     render(
-      <EntityDetailRoute phases={testPhases} />,
+      <EntityDetailRoute />,
       buildWrapper([
+        getConfigProviderWrapper({
+          categories: [
+            {
+              id: 'test',
+              name: 'Test',
+              phases: [
+                buildPhase({
+                  id: 'train',
+                  entities: [
+                    buildEntity({
+                      actions: [
+                        {
+                          display: { label: 'Run', icon: 'playerPlay' },
+                          modal: { type: 'custom', component: StubDialog },
+                          hierarchy: ActionHierarchy.PRIMARY,
+                          disabled: [
+                            {
+                              condition: interpolate(({ data }) => {
+                                const record = data as { status?: { state?: string } } | undefined;
+                                return record?.status?.state === 'RUNNING';
+                              }),
+                              message: 'Pipeline is already running',
+                            },
+                          ],
+                        },
+                      ],
+                      views: [
+                        {
+                          type: 'detail',
+                          metadata: [{ id: 'status.state', label: 'State', type: CellType.STATE }],
+                          pages: [
+                            {
+                              id: 'execution',
+                              label: 'Execution',
+                              ...buildExecutionSchema(),
+                            },
+                          ],
+                        },
+                      ],
+                    }),
+                  ],
+                }),
+              ],
+            },
+          ],
+        }),
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/train/runs/run-123' }),
         getServiceProviderWrapper({ request: mockRequest }),
@@ -907,36 +964,6 @@ describe('EntityDetailRoute', () => {
   });
 
   describe('page navigation', () => {
-    const detailPhases = {
-      train: buildPhase({
-        id: 'train',
-        entities: [
-          buildEntity({
-            views: [
-              {
-                type: 'detail',
-                metadata: [],
-                pages: [
-                  {
-                    id: 'overview',
-                    label: 'Overview',
-                    type: 'custom',
-                    component: () => <div>Overview content</div>,
-                  } as CustomDetailPageConfig,
-                  {
-                    id: 'logs',
-                    label: 'Logs',
-                    type: 'custom',
-                    component: () => <div>Logs content</div>,
-                  } as CustomDetailPageConfig,
-                ],
-              },
-            ],
-          }),
-        ],
-      }),
-    };
-
     test('pressing back from the detail page returns to the list', async () => {
       const user = userEvent.setup();
       const mockRequest = vi.fn().mockResolvedValue({
@@ -947,8 +974,45 @@ describe('EntityDetailRoute', () => {
       });
 
       render(
-        <EntityDetailRoute phases={detailPhases} />,
+        <EntityDetailRoute />,
         buildWrapper([
+          getConfigProviderWrapper({
+            categories: [
+              {
+                id: 'test',
+                name: 'Test',
+                phases: [
+                  buildPhase({
+                    id: 'train',
+                    entities: [
+                      buildEntity({
+                        views: [
+                          {
+                            type: 'detail',
+                            metadata: [],
+                            pages: [
+                              {
+                                id: 'overview',
+                                label: 'Overview',
+                                type: 'custom',
+                                component: () => <div>Overview content</div>,
+                              } as CustomDetailPageConfig,
+                              {
+                                id: 'logs',
+                                label: 'Logs',
+                                type: 'custom',
+                                component: () => <div>Logs content</div>,
+                              } as CustomDetailPageConfig,
+                            ],
+                          },
+                        ],
+                      }),
+                    ],
+                  }),
+                ],
+              },
+            ],
+          }),
           getErrorProviderWrapper(),
           getRouterWrapper({
             initialEntries: ['/myproject/train/runs', '/myproject/train/runs/run-123'],
@@ -980,8 +1044,45 @@ describe('EntityDetailRoute', () => {
       });
 
       render(
-        <EntityDetailRoute phases={detailPhases} />,
+        <EntityDetailRoute />,
         buildWrapper([
+          getConfigProviderWrapper({
+            categories: [
+              {
+                id: 'test',
+                name: 'Test',
+                phases: [
+                  buildPhase({
+                    id: 'train',
+                    entities: [
+                      buildEntity({
+                        views: [
+                          {
+                            type: 'detail',
+                            metadata: [],
+                            pages: [
+                              {
+                                id: 'overview',
+                                label: 'Overview',
+                                type: 'custom',
+                                component: () => <div>Overview content</div>,
+                              } as CustomDetailPageConfig,
+                              {
+                                id: 'logs',
+                                label: 'Logs',
+                                type: 'custom',
+                                component: () => <div>Logs content</div>,
+                              } as CustomDetailPageConfig,
+                            ],
+                          },
+                        ],
+                      }),
+                    ],
+                  }),
+                ],
+              },
+            ],
+          }),
           getErrorProviderWrapper(),
           getRouterWrapper({
             initialEntries: ['/myproject/train/runs/run-123/overview'],
@@ -1012,8 +1113,45 @@ describe('EntityDetailRoute', () => {
       });
 
       render(
-        <EntityDetailRoute phases={detailPhases} />,
+        <EntityDetailRoute />,
         buildWrapper([
+          getConfigProviderWrapper({
+            categories: [
+              {
+                id: 'test',
+                name: 'Test',
+                phases: [
+                  buildPhase({
+                    id: 'train',
+                    entities: [
+                      buildEntity({
+                        views: [
+                          {
+                            type: 'detail',
+                            metadata: [],
+                            pages: [
+                              {
+                                id: 'overview',
+                                label: 'Overview',
+                                type: 'custom',
+                                component: () => <div>Overview content</div>,
+                              } as CustomDetailPageConfig,
+                              {
+                                id: 'logs',
+                                label: 'Logs',
+                                type: 'custom',
+                                component: () => <div>Logs content</div>,
+                              } as CustomDetailPageConfig,
+                            ],
+                          },
+                        ],
+                      }),
+                    ],
+                  }),
+                ],
+              },
+            ],
+          }),
           getErrorProviderWrapper(),
           getRouterWrapper({
             initialEntries: ['/myproject/train/runs', '/myproject/train/runs/run-123'],
@@ -1051,8 +1189,45 @@ describe('EntityDetailRoute', () => {
       });
 
       render(
-        <EntityDetailRoute phases={detailPhases} />,
+        <EntityDetailRoute />,
         buildWrapper([
+          getConfigProviderWrapper({
+            categories: [
+              {
+                id: 'test',
+                name: 'Test',
+                phases: [
+                  buildPhase({
+                    id: 'train',
+                    entities: [
+                      buildEntity({
+                        views: [
+                          {
+                            type: 'detail',
+                            metadata: [],
+                            pages: [
+                              {
+                                id: 'overview',
+                                label: 'Overview',
+                                type: 'custom',
+                                component: () => <div>Overview content</div>,
+                              } as CustomDetailPageConfig,
+                              {
+                                id: 'logs',
+                                label: 'Logs',
+                                type: 'custom',
+                                component: () => <div>Logs content</div>,
+                              } as CustomDetailPageConfig,
+                            ],
+                          },
+                        ],
+                      }),
+                    ],
+                  }),
+                ],
+              },
+            ],
+          }),
           getErrorProviderWrapper(),
           getRouterWrapper({
             initialEntries: ['/myproject/train/runs/run-123/overview'],

--- a/javascript/packages/core/router/__tests__/phase-list-route.test.tsx
+++ b/javascript/packages/core/router/__tests__/phase-list-route.test.tsx
@@ -14,10 +14,9 @@ import { getServiceProviderWrapper } from '#core/test/wrappers/get-service-provi
 import {
   buildEntityConfigFactory,
   buildPhaseConfigFactory,
+  buildStudioConfig,
 } from '../__fixtures__/phase-config-factory';
 import { PhaseListRoute } from '../phase-list-route';
-
-import type { StudioConfig } from '#core/types/common/studio-types';
 
 describe('PhaseListRoute', () => {
   const buildEntity = buildEntityConfigFactory();
@@ -26,63 +25,58 @@ describe('PhaseListRoute', () => {
     columns: [{ id: 'name', label: 'Name', type: CellType.TEXT }],
   });
 
-  const buildTestConfig = (): StudioConfig => ({
-    categories: [
-      {
-        id: 'test',
-        name: 'Test',
-        phases: [
-          buildPhase({
-            id: 'train',
-            icon: 'train',
-            name: 'Train',
-            entities: [
-              buildEntity({
-                id: 'pipelines',
-                name: 'Pipelines',
-                service: 'pipeline',
-              }),
-              buildEntity({
-                id: 'runs',
-                name: 'Pipeline Runs',
-                service: 'pipelineRun',
-              }),
-              buildEntity({
-                id: 'disabled-entity',
-                name: 'Disabled Entity',
-                service: 'disabled',
-                state: 'disabled',
-                views: [
-                  {
-                    type: 'list',
-                    tableConfig: buildTableConfig(),
-                  },
-                ],
-              }),
-            ],
-          }),
-          buildPhase({
-            id: 'evaluate',
-            icon: 'evaluate',
-            name: 'Evaluate',
-            entities: [
-              buildEntity({
-                id: 'evaluations',
-                name: 'Evaluations',
-                service: 'evaluation',
-                views: [
-                  {
-                    type: 'list',
-                    tableConfig: buildTableConfig(),
-                  },
-                ],
-              }),
-            ],
-          }),
-        ],
-      },
-    ],
-  });
+  const buildTestConfig = () =>
+    buildStudioConfig({
+      phases: [
+        buildPhase({
+          id: 'train',
+          icon: 'train',
+          name: 'Train',
+          entities: [
+            buildEntity({
+              id: 'pipelines',
+              name: 'Pipelines',
+              service: 'pipeline',
+            }),
+            buildEntity({
+              id: 'runs',
+              name: 'Pipeline Runs',
+              service: 'pipelineRun',
+            }),
+            buildEntity({
+              id: 'disabled-entity',
+              name: 'Disabled Entity',
+              service: 'disabled',
+              state: 'disabled',
+              views: [
+                {
+                  type: 'list',
+                  tableConfig: buildTableConfig(),
+                },
+              ],
+            }),
+          ],
+        }),
+        buildPhase({
+          id: 'evaluate',
+          icon: 'evaluate',
+          name: 'Evaluate',
+          entities: [
+            buildEntity({
+              id: 'evaluations',
+              name: 'Evaluations',
+              service: 'evaluation',
+              views: [
+                {
+                  type: 'list',
+                  tableConfig: buildTableConfig(),
+                },
+              ],
+            }),
+          ],
+        }),
+      ],
+    });
 
   test('renders tabs for active entities only, filtering out disabled ones', () => {
     const mockRequest = vi.fn().mockResolvedValue({
@@ -119,35 +113,29 @@ describe('PhaseListRoute', () => {
   });
 
   test('shows message when phase has no listable entities', () => {
-    const config: StudioConfig = {
-      categories: [
-        {
-          id: 'test',
-          name: 'Test',
-          phases: [
-            buildPhase({
-              id: 'no-listable',
-              icon: 'no-listable',
-              name: 'No Listable',
-              entities: [
-                buildEntity({
-                  id: 'disabled-only',
-                  name: 'Disabled Only',
-                  service: 'disabled',
-                  state: 'disabled',
-                  views: [
-                    {
-                      type: 'list',
-                      tableConfig: buildTableConfig(),
-                    },
-                  ],
-                }),
+    const config = buildStudioConfig({
+      phases: [
+        buildPhase({
+          id: 'no-listable',
+          icon: 'no-listable',
+          name: 'No Listable',
+          entities: [
+            buildEntity({
+              id: 'disabled-only',
+              name: 'Disabled Only',
+              service: 'disabled',
+              state: 'disabled',
+              views: [
+                {
+                  type: 'list',
+                  tableConfig: buildTableConfig(),
+                },
               ],
             }),
           ],
-        },
+        }),
       ],
-    };
+    });
 
     render(
       <PhaseListRoute />,
@@ -286,7 +274,7 @@ describe('PhaseListRoute', () => {
     render(
       <PhaseListRoute />,
       buildWrapper([
-        getConfigProviderWrapper({ categories: [] }),
+        getConfigProviderWrapper(buildStudioConfig({ categories: [] })),
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/train/pipelines' }),
         getServiceProviderWrapper({ request: vi.fn() }),
@@ -297,18 +285,12 @@ describe('PhaseListRoute', () => {
   });
 
   test('handles configuration with empty entity arrays', () => {
-    const config: StudioConfig = {
-      categories: [
-        {
-          id: 'test',
-          name: 'Test',
-          phases: [
-            buildPhase({ id: 'train', entities: [] }),
-            buildPhase({ id: 'evaluate', entities: [] }),
-          ],
-        },
+    const config = buildStudioConfig({
+      phases: [
+        buildPhase({ id: 'train', entities: [] }),
+        buildPhase({ id: 'evaluate', entities: [] }),
       ],
-    };
+    });
 
     render(
       <PhaseListRoute />,
@@ -326,38 +308,27 @@ describe('PhaseListRoute', () => {
   });
 
   test('filters out entities without list views', () => {
-    const config: StudioConfig = {
-      categories: [
-        {
-          id: 'test',
-          name: 'Test',
-          phases: [
-            buildPhase({
-              id: 'train',
-              entities: [
-                buildEntity({
-                  id: 'detail-only',
-                  name: 'Detail Only',
-                  service: 'detail',
-                  views: [],
-                }),
-                buildEntity({
-                  id: 'pipelines',
-                  name: 'Pipelines',
-                  service: 'pipeline',
-                  views: [
-                    {
-                      type: 'list',
-                      tableConfig: buildTableConfig(),
-                    },
-                  ],
-                }),
-              ],
-            }),
+    const config = buildStudioConfig({
+      entities: [
+        buildEntity({
+          id: 'detail-only',
+          name: 'Detail Only',
+          service: 'detail',
+          views: [],
+        }),
+        buildEntity({
+          id: 'pipelines',
+          name: 'Pipelines',
+          service: 'pipeline',
+          views: [
+            {
+              type: 'list',
+              tableConfig: buildTableConfig(),
+            },
           ],
-        },
+        }),
       ],
-    };
+    });
 
     const mockRequest = vi.fn().mockResolvedValue({
       pipelineList: { items: [] },
@@ -378,15 +349,9 @@ describe('PhaseListRoute', () => {
   });
 
   test('handles empty entities array gracefully', () => {
-    const config: StudioConfig = {
-      categories: [
-        {
-          id: 'test',
-          name: 'Test',
-          phases: [buildPhase({ id: 'train', entities: [] })],
-        },
-      ],
-    };
+    const config = buildStudioConfig({
+      phases: [buildPhase({ id: 'train', entities: [] })],
+    });
 
     render(
       <PhaseListRoute />,
@@ -402,26 +367,15 @@ describe('PhaseListRoute', () => {
   });
 
   test('handles single entity', () => {
-    const config: StudioConfig = {
-      categories: [
-        {
-          id: 'test',
-          name: 'Test',
-          phases: [
-            buildPhase({
-              id: 'train',
-              entities: [
-                buildEntity({
-                  id: 'pipelines',
-                  name: 'Pipelines',
-                  service: 'pipeline',
-                }),
-              ],
-            }),
-          ],
-        },
+    const config = buildStudioConfig({
+      entities: [
+        buildEntity({
+          id: 'pipelines',
+          name: 'Pipelines',
+          service: 'pipeline',
+        }),
       ],
-    };
+    });
 
     const mockRequest = vi.fn().mockResolvedValue({
       pipelineList: { items: [] },
@@ -442,30 +396,24 @@ describe('PhaseListRoute', () => {
   });
 
   test('renders phase header with config metadata', () => {
-    const config: StudioConfig = {
-      categories: [
-        {
-          id: 'test',
-          name: 'Test',
-          phases: [
-            buildPhase({
-              id: 'train',
-              icon: 'train',
-              name: 'Train & Evaluate',
-              description: 'Train machine learning models and evaluate their performance',
-              docUrl: 'https://docs.example.com',
-              entities: [
-                buildEntity({
-                  id: 'pipelines',
-                  name: 'Pipelines',
-                  service: 'pipeline',
-                }),
-              ],
+    const config = buildStudioConfig({
+      phases: [
+        buildPhase({
+          id: 'train',
+          icon: 'train',
+          name: 'Train & Evaluate',
+          description: 'Train machine learning models and evaluate their performance',
+          docUrl: 'https://docs.example.com',
+          entities: [
+            buildEntity({
+              id: 'pipelines',
+              name: 'Pipelines',
+              service: 'pipeline',
             }),
           ],
-        },
+        }),
       ],
-    };
+    });
 
     const mockRequest = vi.fn().mockResolvedValue({
       pipelineList: { items: [] },

--- a/javascript/packages/core/router/__tests__/phase-list-route.test.tsx
+++ b/javascript/packages/core/router/__tests__/phase-list-route.test.tsx
@@ -6,6 +6,7 @@ import { vi } from 'vitest';
 import { CellType } from '#core/components/cell/constants';
 import { buildTableConfigFactory } from '#core/components/views/__fixtures__/table-config-factory';
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getConfigProviderWrapper } from '#core/test/wrappers/get-config-provider-wrapper';
 import { getErrorProviderWrapper } from '#core/test/wrappers/get-error-provider-wrapper';
 import { getIconProviderWrapper } from '#core/test/wrappers/get-icon-provider-wrapper';
 import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
@@ -16,7 +17,7 @@ import {
 } from '../__fixtures__/phase-config-factory';
 import { PhaseListRoute } from '../phase-list-route';
 
-import type { PhaseConfig } from '#core/types/common/studio-types';
+import type { StudioConfig } from '#core/types/common/studio-types';
 
 describe('PhaseListRoute', () => {
   const buildEntity = buildEntityConfigFactory();
@@ -25,54 +26,62 @@ describe('PhaseListRoute', () => {
     columns: [{ id: 'name', label: 'Name', type: CellType.TEXT }],
   });
 
-  const buildTestPhaseEntityConfig = (): Record<string, PhaseConfig> => ({
-    train: buildPhase({
-      id: 'train',
-      icon: 'train',
-      name: 'Train',
-      entities: [
-        buildEntity({
-          id: 'pipelines',
-          name: 'Pipelines',
-          service: 'pipeline',
-        }),
-        buildEntity({
-          id: 'runs',
-          name: 'Pipeline Runs',
-          service: 'pipelineRun',
-        }),
-        buildEntity({
-          id: 'disabled-entity',
-          name: 'Disabled Entity',
-          service: 'disabled',
-          state: 'disabled',
-          views: [
-            {
-              type: 'list',
-              tableConfig: buildTableConfig(),
-            },
-          ],
-        }),
-      ],
-    }),
-    evaluate: buildPhase({
-      id: 'evaluate',
-      icon: 'evaluate',
-      name: 'Evaluate',
-      entities: [
-        buildEntity({
-          id: 'evaluations',
-          name: 'Evaluations',
-          service: 'evaluation',
-          views: [
-            {
-              type: 'list',
-              tableConfig: buildTableConfig(),
-            },
-          ],
-        }),
-      ],
-    }),
+  const buildTestConfig = (): StudioConfig => ({
+    categories: [
+      {
+        id: 'test',
+        name: 'Test',
+        phases: [
+          buildPhase({
+            id: 'train',
+            icon: 'train',
+            name: 'Train',
+            entities: [
+              buildEntity({
+                id: 'pipelines',
+                name: 'Pipelines',
+                service: 'pipeline',
+              }),
+              buildEntity({
+                id: 'runs',
+                name: 'Pipeline Runs',
+                service: 'pipelineRun',
+              }),
+              buildEntity({
+                id: 'disabled-entity',
+                name: 'Disabled Entity',
+                service: 'disabled',
+                state: 'disabled',
+                views: [
+                  {
+                    type: 'list',
+                    tableConfig: buildTableConfig(),
+                  },
+                ],
+              }),
+            ],
+          }),
+          buildPhase({
+            id: 'evaluate',
+            icon: 'evaluate',
+            name: 'Evaluate',
+            entities: [
+              buildEntity({
+                id: 'evaluations',
+                name: 'Evaluations',
+                service: 'evaluation',
+                views: [
+                  {
+                    type: 'list',
+                    tableConfig: buildTableConfig(),
+                  },
+                ],
+              }),
+            ],
+          }),
+        ],
+      },
+    ],
   });
 
   test('renders tabs for active entities only, filtering out disabled ones', () => {
@@ -81,8 +90,9 @@ describe('PhaseListRoute', () => {
     });
 
     render(
-      <PhaseListRoute phases={buildTestPhaseEntityConfig()} />,
+      <PhaseListRoute />,
       buildWrapper([
+        getConfigProviderWrapper(buildTestConfig()),
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/train/pipelines' }),
         getServiceProviderWrapper({ request: mockRequest }),
@@ -96,8 +106,9 @@ describe('PhaseListRoute', () => {
 
   test('shows error message for unknown phase', () => {
     render(
-      <PhaseListRoute phases={buildTestPhaseEntityConfig()} />,
+      <PhaseListRoute />,
       buildWrapper([
+        getConfigProviderWrapper(buildTestConfig()),
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/unknown-phase/entity' }),
         getServiceProviderWrapper({ request: vi.fn() }),
@@ -105,35 +116,43 @@ describe('PhaseListRoute', () => {
     );
 
     expect(screen.getByText(/Phase "unknown-phase" configuration not found/)).toBeInTheDocument();
-    expect(screen.getByText(/Available phases: train, evaluate/)).toBeInTheDocument();
   });
 
   test('shows message when phase has no listable entities', () => {
-    const configWithNoListableEntities = {
-      'no-listable': buildPhase({
-        id: 'no-listable',
-        icon: 'no-listable',
-        name: 'No Listable',
-        entities: [
-          buildEntity({
-            id: 'disabled-only',
-            name: 'Disabled Only',
-            service: 'disabled',
-            state: 'disabled',
-            views: [
-              {
-                type: 'list',
-                tableConfig: buildTableConfig(),
-              },
-            ],
-          }),
-        ],
-      }),
+    const config: StudioConfig = {
+      categories: [
+        {
+          id: 'test',
+          name: 'Test',
+          phases: [
+            buildPhase({
+              id: 'no-listable',
+              icon: 'no-listable',
+              name: 'No Listable',
+              entities: [
+                buildEntity({
+                  id: 'disabled-only',
+                  name: 'Disabled Only',
+                  service: 'disabled',
+                  state: 'disabled',
+                  views: [
+                    {
+                      type: 'list',
+                      tableConfig: buildTableConfig(),
+                    },
+                  ],
+                }),
+              ],
+            }),
+          ],
+        },
+      ],
     };
 
     render(
-      <PhaseListRoute phases={configWithNoListableEntities} />,
+      <PhaseListRoute />,
       buildWrapper([
+        getConfigProviderWrapper(config),
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/no-listable/entity' }),
         getServiceProviderWrapper({ request: vi.fn() }),
@@ -151,8 +170,9 @@ describe('PhaseListRoute', () => {
     });
 
     render(
-      <PhaseListRoute phases={buildTestPhaseEntityConfig()} />,
+      <PhaseListRoute />,
       buildWrapper([
+        getConfigProviderWrapper(buildTestConfig()),
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/train' }),
         getServiceProviderWrapper({ request: mockRequest }),
@@ -168,8 +188,9 @@ describe('PhaseListRoute', () => {
     });
 
     render(
-      <PhaseListRoute phases={buildTestPhaseEntityConfig()} />,
+      <PhaseListRoute />,
       buildWrapper([
+        getConfigProviderWrapper(buildTestConfig()),
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/train/runs' }),
         getServiceProviderWrapper({ request: mockRequest }),
@@ -192,8 +213,9 @@ describe('PhaseListRoute', () => {
     });
 
     render(
-      <PhaseListRoute phases={buildTestPhaseEntityConfig()} />,
+      <PhaseListRoute />,
       buildWrapper([
+        getConfigProviderWrapper(buildTestConfig()),
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/train/invalid-entity' }),
         getServiceProviderWrapper({ request: mockRequest }),
@@ -207,8 +229,9 @@ describe('PhaseListRoute', () => {
     const mockRequest = vi.fn().mockRejectedValue(new Error('Network error'));
 
     render(
-      <PhaseListRoute phases={buildTestPhaseEntityConfig()} />,
+      <PhaseListRoute />,
       buildWrapper([
+        getConfigProviderWrapper(buildTestConfig()),
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/train/pipelines' }),
         getServiceProviderWrapper({ request: mockRequest }),
@@ -238,8 +261,9 @@ describe('PhaseListRoute', () => {
       });
 
     render(
-      <PhaseListRoute phases={buildTestPhaseEntityConfig()} />,
+      <PhaseListRoute />,
       buildWrapper([
+        getConfigProviderWrapper(buildTestConfig()),
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/train/pipelines' }),
         getServiceProviderWrapper({ request: mockRequest }),
@@ -258,10 +282,11 @@ describe('PhaseListRoute', () => {
     });
   });
 
-  test('handles empty configuration object', () => {
+  test('shows error for unknown phase with empty config', () => {
     render(
-      <PhaseListRoute phases={{}} />,
+      <PhaseListRoute />,
       buildWrapper([
+        getConfigProviderWrapper({ categories: [] }),
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/train/pipelines' }),
         getServiceProviderWrapper({ request: vi.fn() }),
@@ -269,18 +294,26 @@ describe('PhaseListRoute', () => {
     );
 
     expect(screen.getByText(/Phase "train" configuration not found/)).toBeInTheDocument();
-    expect(screen.getByText(/Available phases:$/)).toBeInTheDocument();
   });
 
   test('handles configuration with empty entity arrays', () => {
-    const emptyConfig = {
-      train: buildPhase({ id: 'train', entities: [] }),
-      evaluate: buildPhase({ id: 'evaluate', entities: [] }),
+    const config: StudioConfig = {
+      categories: [
+        {
+          id: 'test',
+          name: 'Test',
+          phases: [
+            buildPhase({ id: 'train', entities: [] }),
+            buildPhase({ id: 'evaluate', entities: [] }),
+          ],
+        },
+      ],
     };
 
     render(
-      <PhaseListRoute phases={emptyConfig} />,
+      <PhaseListRoute />,
       buildWrapper([
+        getConfigProviderWrapper(config),
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/train/pipelines' }),
         getServiceProviderWrapper({ request: vi.fn() }),
@@ -293,29 +326,37 @@ describe('PhaseListRoute', () => {
   });
 
   test('filters out entities without list views', () => {
-    const configWithNonListViews = {
-      train: buildPhase({
-        id: 'train',
-        entities: [
-          buildEntity({
-            id: 'detail-only',
-            name: 'Detail Only',
-            service: 'detail',
-            views: [],
-          }),
-          buildEntity({
-            id: 'pipelines',
-            name: 'Pipelines',
-            service: 'pipeline',
-            views: [
-              {
-                type: 'list',
-                tableConfig: buildTableConfig(),
-              },
-            ],
-          }),
-        ],
-      }),
+    const config: StudioConfig = {
+      categories: [
+        {
+          id: 'test',
+          name: 'Test',
+          phases: [
+            buildPhase({
+              id: 'train',
+              entities: [
+                buildEntity({
+                  id: 'detail-only',
+                  name: 'Detail Only',
+                  service: 'detail',
+                  views: [],
+                }),
+                buildEntity({
+                  id: 'pipelines',
+                  name: 'Pipelines',
+                  service: 'pipeline',
+                  views: [
+                    {
+                      type: 'list',
+                      tableConfig: buildTableConfig(),
+                    },
+                  ],
+                }),
+              ],
+            }),
+          ],
+        },
+      ],
     };
 
     const mockRequest = vi.fn().mockResolvedValue({
@@ -323,8 +364,9 @@ describe('PhaseListRoute', () => {
     });
 
     render(
-      <PhaseListRoute phases={configWithNonListViews} />,
+      <PhaseListRoute />,
       buildWrapper([
+        getConfigProviderWrapper(config),
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/train/pipelines' }),
         getServiceProviderWrapper({ request: mockRequest }),
@@ -336,9 +378,20 @@ describe('PhaseListRoute', () => {
   });
 
   test('handles empty entities array gracefully', () => {
+    const config: StudioConfig = {
+      categories: [
+        {
+          id: 'test',
+          name: 'Test',
+          phases: [buildPhase({ id: 'train', entities: [] })],
+        },
+      ],
+    };
+
     render(
-      <PhaseListRoute phases={{ train: buildPhase({ id: 'train', entities: [] }) }} />,
+      <PhaseListRoute />,
       buildWrapper([
+        getConfigProviderWrapper(config),
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/train' }),
         getServiceProviderWrapper({ request: vi.fn() }),
@@ -349,17 +402,25 @@ describe('PhaseListRoute', () => {
   });
 
   test('handles single entity', () => {
-    const singleEntityConfig = {
-      train: buildPhase({
-        id: 'train',
-        entities: [
-          buildEntity({
-            id: 'pipelines',
-            name: 'Pipelines',
-            service: 'pipeline',
-          }),
-        ],
-      }),
+    const config: StudioConfig = {
+      categories: [
+        {
+          id: 'test',
+          name: 'Test',
+          phases: [
+            buildPhase({
+              id: 'train',
+              entities: [
+                buildEntity({
+                  id: 'pipelines',
+                  name: 'Pipelines',
+                  service: 'pipeline',
+                }),
+              ],
+            }),
+          ],
+        },
+      ],
     };
 
     const mockRequest = vi.fn().mockResolvedValue({
@@ -367,8 +428,9 @@ describe('PhaseListRoute', () => {
     });
 
     render(
-      <PhaseListRoute phases={singleEntityConfig} />,
+      <PhaseListRoute />,
       buildWrapper([
+        getConfigProviderWrapper(config),
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/train/pipelines' }),
         getServiceProviderWrapper({ request: mockRequest }),
@@ -380,21 +442,29 @@ describe('PhaseListRoute', () => {
   });
 
   test('renders phase header with config metadata', () => {
-    const configWithDescription = {
-      train: buildPhase({
-        id: 'train',
-        icon: 'train',
-        name: 'Train & Evaluate',
-        description: 'Train machine learning models and evaluate their performance',
-        docUrl: 'https://docs.example.com',
-        entities: [
-          buildEntity({
-            id: 'pipelines',
-            name: 'Pipelines',
-            service: 'pipeline',
-          }),
-        ],
-      }),
+    const config: StudioConfig = {
+      categories: [
+        {
+          id: 'test',
+          name: 'Test',
+          phases: [
+            buildPhase({
+              id: 'train',
+              icon: 'train',
+              name: 'Train & Evaluate',
+              description: 'Train machine learning models and evaluate their performance',
+              docUrl: 'https://docs.example.com',
+              entities: [
+                buildEntity({
+                  id: 'pipelines',
+                  name: 'Pipelines',
+                  service: 'pipeline',
+                }),
+              ],
+            }),
+          ],
+        },
+      ],
     };
 
     const mockRequest = vi.fn().mockResolvedValue({
@@ -402,8 +472,9 @@ describe('PhaseListRoute', () => {
     });
 
     render(
-      <PhaseListRoute phases={configWithDescription} />,
+      <PhaseListRoute />,
       buildWrapper([
+        getConfigProviderWrapper(config),
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/train/pipelines' }),
         getServiceProviderWrapper({ request: mockRequest }),

--- a/javascript/packages/core/router/entity-detail-route.tsx
+++ b/javascript/packages/core/router/entity-detail-route.tsx
@@ -9,13 +9,11 @@ import { Row } from '#core/components/row/row';
 import { DetailViewPageRenderer } from '#core/components/views/detail-view/components/detail-view-page-renderer/detail-view-page-renderer';
 import { DetailViewPages } from '#core/components/views/detail-view/components/detail-view-pages/detail-view-pages';
 import { DetailView } from '#core/components/views/detail-view/detail-view';
-import { PHASES } from '#core/config/phases/phases';
 import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
 import { useStudioQuery } from '#core/hooks/use-studio-query';
 import { useInterpolationResolver } from '#core/interpolation/use-interpolation-resolver';
+import { useStudioConfig } from '#core/providers/config-provider/use-studio-config';
 import { capitalizeFirstLetter } from '#core/utils/string-utils';
-
-import type { PhaseConfig } from '#core/types/common/studio-types';
 
 /**
  * Route component that handles entity detail views.
@@ -23,14 +21,13 @@ import type { PhaseConfig } from '#core/types/common/studio-types';
  * Maps URL parameters to specific entity detail pages and handles:
  * - Entity not found scenarios
  * - Navigation back to entity list
- *
- * @param phases - Phase configuration override for testing. Defaults to {@link PHASES}.
  */
-export function EntityDetailRoute({ phases = PHASES }: { phases?: Record<string, PhaseConfig> }) {
+export function EntityDetailRoute() {
   const [, theme] = useStyletron();
   const { phase, entity, entityId, projectId, entityTab } = useStudioParams('detail');
   const navigate = useNavigate();
-  const entityConfig = phases[phase].entities.find((e) => e.id === entity);
+  const { getEntity } = useStudioConfig();
+  const entityConfig = getEntity(phase, entity);
   const resolver = useInterpolationResolver();
 
   const { data, isLoading, error } = useStudioQuery<Record<string, unknown>>({
@@ -55,7 +52,6 @@ export function EntityDetailRoute({ phases = PHASES }: { phases?: Record<string,
     navigate(`/${projectId}/${phase}/${entity}`);
   };
 
-  // TODO: error handling for URLs that don't match any entity config
   const detailViewConfig =
     (entityConfig?.views ?? []).find((view) => view.type === 'detail') ?? undefined;
 
@@ -96,16 +92,36 @@ export function EntityDetailRoute({ phases = PHASES }: { phases?: Record<string,
     );
   }
 
+  if (!entityConfig) {
+    return (
+      <ErrorView
+        title="Entity not found"
+        description={`Entity "${entity}" is not configured in phase "${phase}".`}
+        illustration={
+          <CircleExclamationMark
+            kind={CircleExclamationMarkKind.ERROR}
+            width={theme.sizing.scale1600}
+            height={theme.sizing.scale1600}
+          />
+        }
+        buttonConfig={{
+          onClick: () => navigate(`/${projectId}/${phase}`),
+          content: 'Back to phase',
+        }}
+      />
+    );
+  }
+
   // cast: PhaseEntityConfig carries no entity type generic, so the runtime-selected service key's
   // value is assumed to be the entity object; related to #1425
-  const entityData = data?.[entityConfig!.service] as Record<string, unknown> | undefined;
+  const entityData = data?.[entityConfig.service] as Record<string, unknown> | undefined;
   const resolvedDetailViewConfig = resolver(detailViewConfig, { page: entityData });
   return (
     <DetailView
-      subtitle={entityConfig!.name}
+      subtitle={entityConfig.name}
       title={entityId}
       onGoBack={handleReturnToEntityList}
-      actions={entityConfig!.actions}
+      actions={entityConfig.actions}
       record={entityData}
       loading={isLoading}
       headerContent={

--- a/javascript/packages/core/router/phase-list-route.tsx
+++ b/javascript/packages/core/router/phase-list-route.tsx
@@ -6,10 +6,8 @@ import { CircleExclamationMark } from '#core/components/illustrations/circle-exc
 import { CircleExclamationMarkKind } from '#core/components/illustrations/circle-exclamation-mark/types';
 import { PhaseEntityView } from '#core/components/views/phase-entity-view/phase-entity-view';
 import { isListableEntity } from '#core/components/views/phase-entity-view/utils';
-import { PHASES } from '#core/config/phases/phases';
 import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
-
-import type { PhaseConfig } from '#core/types/common/studio-types';
+import { useStudioConfig } from '#core/providers/config-provider/use-studio-config';
 
 /**
  * Route component that maps phase URL parameters to entity configurations.
@@ -17,19 +15,24 @@ import type { PhaseConfig } from '#core/types/common/studio-types';
  * Handles unknown phases and phases with no active list entities by showing
  * appropriate messages rather than rendering empty UI. Only renders PhaseEntityView
  * when there are valid entities to display.
- *
- * @param phaseEntityConfig - Optional phase entity configuration override for testing
  */
-export function PhaseListRoute({ phases = PHASES }: { phases?: Record<string, PhaseConfig> } = {}) {
+export function PhaseListRoute() {
   const [, theme] = useStyletron();
   const { phase, projectId } = useStudioParams('list');
   const navigate = useNavigate();
+  const { categories, getPhase } = useStudioConfig();
 
-  if (!(phase in phases)) {
+  const phaseConfig = getPhase(phase);
+
+  if (!phaseConfig) {
+    const availablePhases = categories
+      .flatMap((c) => c.phases)
+      .map((p) => p.id)
+      .join(', ');
     return (
       <ErrorView
         title="Phase not found"
-        description={`Phase "${phase}" configuration not found. Available phases: ${Object.keys(phases).join(', ')}`}
+        description={`Phase "${phase}" configuration not found. Available phases: ${availablePhases}`}
         illustration={
           <CircleExclamationMark
             kind={CircleExclamationMarkKind.ERROR}
@@ -45,7 +48,7 @@ export function PhaseListRoute({ phases = PHASES }: { phases?: Record<string, Ph
     );
   }
 
-  const listableEntities = phases[phase].entities.filter(isListableEntity);
+  const listableEntities = phaseConfig.entities.filter(isListableEntity);
 
   if (listableEntities.length === 0) {
     return (
@@ -67,5 +70,5 @@ export function PhaseListRoute({ phases = PHASES }: { phases?: Record<string, Ph
     );
   }
 
-  return <PhaseEntityView phaseConfig={phases[phase]} entities={listableEntities} />;
+  return <PhaseEntityView phaseConfig={phaseConfig} entities={listableEntities} />;
 }

--- a/javascript/packages/core/router/router.tsx
+++ b/javascript/packages/core/router/router.tsx
@@ -4,17 +4,15 @@ import { MainViewContainer } from '#core/components/views/main-view-container';
 import { ProjectDetail } from '#core/components/views/project/project-detail';
 import { ProjectList } from '#core/components/views/project/project-list';
 import { Sandbox } from '#core/components/views/sandbox/sandbox';
-import { CATEGORIES } from '#core/config/categories';
-import { DATA_PHASE } from '#core/config/phases/data';
-import { DEPLOY_PHASE } from '#core/config/phases/deploy';
-import { TRAIN_PHASE } from '#core/config/phases/train';
+import { useStudioConfig } from '#core/providers/config-provider/use-studio-config';
 import { EntityDetailRoute } from './entity-detail-route';
 import { PhaseListRoute } from './phase-list-route';
 import { StudioBar } from './studio-bar';
 
-const PROJECT_PHASES = [DATA_PHASE, TRAIN_PHASE, DEPLOY_PHASE];
-
 export function Router() {
+  const { categories } = useStudioConfig();
+  const phases = categories.flatMap((c) => c.phases);
+
   return (
     <Routes>
       <Route
@@ -33,12 +31,12 @@ export function Router() {
           </MainViewContainer>
         }
       />
-      <Route element={<StudioBar categories={CATEGORIES} />}>
+      <Route element={<StudioBar categories={categories} />}>
         <Route
           path=":projectId"
           element={
             <MainViewContainer>
-              <ProjectDetail phases={PROJECT_PHASES} />
+              <ProjectDetail phases={phases} />
             </MainViewContainer>
           }
         />

--- a/javascript/packages/core/test/wrappers/get-config-provider-wrapper.tsx
+++ b/javascript/packages/core/test/wrappers/get-config-provider-wrapper.tsx
@@ -1,0 +1,13 @@
+import { CATEGORIES } from '#core/config/categories';
+import { ConfigProvider } from '#core/providers/config-provider/config-provider';
+
+import type { StudioConfig } from '#core/types/common/studio-types';
+import type { WrapperComponentProps } from './types';
+
+export function getConfigProviderWrapper(config?: StudioConfig) {
+  return function ConfigProviderWrapper({ children }: WrapperComponentProps) {
+    return (
+      <ConfigProvider config={config ?? { categories: CATEGORIES }}>{children}</ConfigProvider>
+    );
+  };
+}

--- a/javascript/packages/core/types/common/studio-types.ts
+++ b/javascript/packages/core/types/common/studio-types.ts
@@ -198,3 +198,24 @@ export type PhaseEntityState = 'active' | 'disabled';
 export type Accessor<TIn = unknown, TOut = unknown> = AccessorFn<TIn, TOut> | string;
 
 export type AccessorFn<TIn = unknown, TOut = unknown> = (object: TIn) => TOut | undefined;
+
+/**
+ * Top-level configuration passed to `CoreApp`. Describes the domain structure
+ * of a Studio instance — what categories, phases, and entities it contains.
+ *
+ * Core renders whatever config a consumer supplies; it ships the machinery,
+ * not a default set of entities.
+ *
+ * @example
+ * ```tsx
+ * const studioConfig: StudioConfig = {
+ *   categories: [
+ *     { id: 'core-ml', name: 'Core ML', phases: [TRAIN_PHASE, DEPLOY_PHASE] },
+ *   ],
+ * };
+ * <CoreApp config={studioConfig} dependencies={deps} />
+ * ```
+ */
+export type StudioConfig = {
+  categories: CategoryConfig[];
+};


### PR DESCRIPTION
## Summary

Core's router hardcodes imports of `CATEGORIES` and `PHASES`, coupling the rendering engine to specific domain configuration. This means consumers can't supply their own phases, entities, or views — the config is baked into the package.

This PR introduces `StudioConfig`, `ConfigProvider`, and `useStudioConfig()` so consumers can pass config via a top-level `config` prop on `CoreApp`. The router and route components now read config from the provider instead of module-level imports.

A backward-compatible fallback preserves existing behavior when no `config` is supplied. A follow-up PR will move the config files to the consumer app (`javascript/app/`) and make the prop required.

## Test plan
### Project list — live data loads
<img width="1201" height="807" alt="sandbox-test-plan-project-list-data" src="https://github.com/user-attachments/assets/f64331ff-e08e-4028-9227-0471ebce11a6" />


### Project detail — all 3 phase cards render from config
<img width="1201" height="807" alt="sandbox-test-plan-project-detail" src="https://github.com/user-attachments/assets/5cb9b5b4-44a3-4f1e-8e6e-adb8bc540c5a" />


### Phase list — pipelines with live data, breadcrumbs show "Core ML" category
<img width="1201" height="807" alt="sandbox-test-plan-pipelines-data" src="https://github.com/user-attachments/assets/c5994589-e332-403c-8777-ef78682852b2" />


### Pipeline detail — entity metadata, actions, tabs
<img width="1201" height="807" alt="sandbox-test-plan-pipeline-detail" src="https://github.com/user-attachments/assets/ed486786-4c78-4d53-b6cb-f9e732d682da" />


### Error: unknown phase — lists available phases, "Go home" button
<img width="1201" height="807" alt="sandbox-test-plan-unknown-phase" src="https://github.com/user-attachments/assets/1b1ac5f6-96af-40b8-b89c-f445a16fdd67" />


### Error: unknown entity — names the phase, "Back to phase" button
<img width="1201" height="807" alt="sandbox-test-plan-unknown-entity" src="https://github.com/user-attachments/assets/3d1f2d8b-ddc4-45b0-b233-ab90b34f89ba" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)