### PR TITLE
docs(javascript): document icon registry system in core ARCHITECTURE.md

### DIFF
--- a/javascript/packages/core/ARCHITECTURE.md
+++ b/javascript/packages/core/ARCHITECTURE.md
@@ -134,7 +134,7 @@ import { ICONS } from './icons/icons';
 
 <IconProvider icons={ICONS}>
   <App />
-</IconProvider>
+</IconProvider>;
 ```
 
 Components reference icons by key through the configuration system's `icon` field or directly via the hook:
@@ -172,14 +172,14 @@ The reference registry lives in `javascript/app/icons/icons.tsx`. To add an icon
 
 **Naming convention**
 
-Icon keys use **camelCase** throughout. Names should be semantic — describe what the icon *means* in context, not what it looks like:
+Icon keys use **camelCase** throughout. Names should be semantic — describe what the icon _means_ in context, not what it looks like:
 
-| Key | MUI source | Meaning |
-|---|---|---|
-| `trashCan` | `Delete` | Destructive delete action |
-| `circleCheck` | `CheckCircle` | Success / complete state |
-| `overflowMenu` | `MoreVert` | Three-dot overflow menu |
-| `playerPlay` | `PlayArrow` | Start / run an action |
+| Key            | MUI source    | Meaning                   |
+| -------------- | ------------- | ------------------------- |
+| `trashCan`     | `Delete`      | Destructive delete action |
+| `circleCheck`  | `CheckCircle` | Success / complete state  |
+| `overflowMenu` | `MoreVert`    | Three-dot overflow menu   |
+| `playerPlay`   | `PlayArrow`   | Start / run an action     |
 
 Avoid naming icons after their visual shape (`arrowDown`) when a semantic name is available (`sortDescending`).
 

--- a/javascript/packages/core/ARCHITECTURE.md
+++ b/javascript/packages/core/ARCHITECTURE.md
@@ -120,6 +120,69 @@ declare module '@michelangelo-ai/core' {
 
 After this augmentation, interpolated configs reference `user` and `project` with full type inference. Removing the augmentation surfaces type errors at every consumer site.
 
+### Icon registry
+
+The icon system is another provider-based extension point. Consumers register icons once at the application boundary; components anywhere in the tree reference them by name.
+
+**How it works**
+
+`IconProvider` accepts an `icons` prop — an `IconMap`, which is `Record<string, IconComponent>`. Keys are camelCase strings; values are React components that accept `IconProps`. The registry is accessed inside components via `useIconProvider()`.
+
+```tsx
+import { IconProvider } from '@michelangelo-ai/core';
+import { ICONS } from './icons/icons';
+
+<IconProvider icons={ICONS}>
+  <App />
+</IconProvider>
+```
+
+Components reference icons by key through the configuration system's `icon` field or directly via the hook:
+
+```ts
+// In a config — icon name is the registry key
+const action: ActionConfig = {
+  display: { label: 'Delete', icon: 'trashCan' },
+};
+
+// In a component
+const { icons } = useIconProvider();
+const TrashCan = icons.trashCan;
+return <TrashCan />;
+```
+
+**Adding a new icon**
+
+The reference registry lives in `javascript/app/icons/icons.tsx`. To add an icon:
+
+1. Import the MUI icon:
+   ```ts
+   import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
+   ```
+2. Wrap it with `createMuiIconAdapter` and add it to `ICONS`:
+   ```ts
+   export const ICONS = {
+     // ...existing entries
+     deleteForever: createMuiIconAdapter(DeleteForeverIcon),
+   };
+   ```
+3. Reference it by key anywhere in the app or configuration.
+
+`createMuiIconAdapter` (in `javascript/app/icons/mui-icon-adapter.tsx`) adapts MUI's `SvgIconProps` interface to the internal `IconProps` shape, handling prop translation (size scaling, color, title) and stripping BaseUI-specific props that would cause type errors.
+
+**Naming convention**
+
+Icon keys use **camelCase** throughout. Names should be semantic — describe what the icon *means* in context, not what it looks like:
+
+| Key | MUI source | Meaning |
+|---|---|---|
+| `trashCan` | `Delete` | Destructive delete action |
+| `circleCheck` | `CheckCircle` | Success / complete state |
+| `overflowMenu` | `MoreVert` | Three-dot overflow menu |
+| `playerPlay` | `PlayArrow` | Start / run an action |
+
+Avoid naming icons after their visual shape (`arrowDown`) when a semantic name is available (`sortDescending`).
+
 ## 5. Styling
 
 `core` uses Styletron and BaseUI as its styling stack. Both are injected at the application boundary (`StyletronProvider`, `ThemeProvider`). Consumers customize the visual layer through theme tokens.


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**
Adds an "Icon registry" subsection to `javascript/packages/core/ARCHITECTURE.md` under §4 (Customization via providers). Covers how `IconProvider` and `IconMap` work, how to add a new MUI icon using `createMuiIconAdapter`, the camelCase naming convention, and how components reference icons by key.

**Why?**
The icon override system had no contributor documentation (flagged in issue #364). The BaseWeb naming conflict described in the issue is no longer applicable since the codebase migrated to MUI, but the documentation gap remained.

**How did you test it?**
Docs-only change — verified against the actual implementation in `javascript/app/icons/icons.tsx` and `javascript/app/icons/mui-icon-adapter.tsx`.

**Potential risks**
None.

**Breaking Changes**
- [x] No breaking changes

**Release notes**
N/A

**Documentation Changes**
`javascript/packages/core/ARCHITECTURE.md` — new "Icon registry" subsection added under §4.