### PR TITLE
fix(pusher): use the shared api.v2 name generator for auto-generated model names

### DIFF
--- a/python/michelangelo/api/v2/__init__.py
+++ b/python/michelangelo/api/v2/__init__.py
@@ -7,6 +7,14 @@ Example:
     >>> from michelangelo.api.v2 import APIClient
     >>> APIClient.set_caller('my-application')
     >>> model = APIClient.ModelService.get_model(namespace='default', name='my-model')
+
+The package also exposes ``generate_random_name`` for callers that need a unique,
+time-sortable object name when they have no stable identity of their own:
+
+    >>> from michelangelo.api.v2 import generate_random_name
+    >>> generate_random_name('model')  # doctest: +SKIP
+    'model-20260721-114130-2d9c959d'
 """
 
 from .client import APIClient as APIClient
+from .util import generate_random_name as generate_random_name

--- a/python/michelangelo/api/v2/tests/test_util.py
+++ b/python/michelangelo/api/v2/tests/test_util.py
@@ -1,0 +1,66 @@
+"""Tests for michelangelo.api.v2.util — generated object names."""
+
+from __future__ import annotations
+
+import re
+from unittest import TestCase
+
+from michelangelo.api.v2.util import generate_random_name
+
+_NAME_RE = re.compile(r"^(?P<prefix>.+)-(?P<date>\d{8})-(?P<time>\d{6})-[0-9a-f]{8}$")
+
+
+class TestGenerateRandomName(TestCase):
+    """Tests for generate_random_name — format, uniqueness, and prefix validation."""
+
+    def test_format_is_prefix_date_time_hex(self):
+        """It returns '{prefix}-{YYYYMMDD}-{HHMMSS}-{8 hex}'."""
+        match = _NAME_RE.match(generate_random_name("model"))
+        self.assertIsNotNone(match)
+        self.assertEqual(match.group("prefix"), "model")
+
+    def test_successive_calls_are_unique(self):
+        """Two calls in the same second still differ, via the random suffix."""
+        self.assertNotEqual(
+            generate_random_name("model"), generate_random_name("model")
+        )
+
+    def test_names_sort_chronologically(self):
+        """The timestamp leads the random part, so plain string sort is time order."""
+        names = sorted(
+            [
+                "model-20260721-114130-ffffffff",
+                "model-20260721-114129-00000000",
+                "model-20260720-235959-88888888",
+            ]
+        )
+        self.assertEqual(
+            names,
+            [
+                "model-20260720-235959-88888888",
+                "model-20260721-114129-00000000",
+                "model-20260721-114130-ffffffff",
+            ],
+        )
+
+    def test_prefix_is_lowercased(self):
+        """Uppercase prefixes are normalized, per Kubernetes naming rules."""
+        self.assertTrue(generate_random_name("MyModel").startswith("mymodel-"))
+
+    def test_underscores_in_prefix_become_hyphens(self):
+        """Underscores are not valid in Kubernetes names and are replaced."""
+        self.assertTrue(generate_random_name("my_model").startswith("my-model-"))
+
+    def test_empty_prefix_raises(self):
+        """An empty prefix is rejected rather than yielding a leading-hyphen name."""
+        with self.assertRaises(RuntimeError):
+            generate_random_name("")
+
+    def test_overlong_prefix_raises(self):
+        """A prefix over 128 characters is rejected."""
+        with self.assertRaises(RuntimeError):
+            generate_random_name("x" * 129)
+
+    def test_prefix_at_length_limit_is_accepted(self):
+        """128 characters is the inclusive upper bound."""
+        self.assertTrue(generate_random_name("x" * 128).startswith("x" * 128 + "-"))

--- a/python/michelangelo/api/v2/util.py
+++ b/python/michelangelo/api/v2/util.py
@@ -8,18 +8,23 @@ import uuid
 from datetime import datetime, timezone
 
 
-def generate_random_name(prefix):
+def generate_random_name(prefix: str) -> str:
     """Generate a unique object name following Kubernetes naming conventions.
 
     Creates a name with format: {prefix}-{timestamp}-{random_chars}
     where prefix is normalized to lowercase with underscores replaced by hyphens.
+
+    The timestamp is second-granularity UTC, so names sort chronologically as
+    plain strings and a collision requires two calls in the same second that
+    also draw the same 8 hex characters.
 
     Args:
         prefix: Name prefix for the generated name. Must be 1-128 characters.
 
     Returns:
         A unique name string combining the prefix, UTC timestamp (YYYYMMDD-HHMMSS),
-        and the first segment of a random UUID.
+        and the first segment of a random UUID, e.g.
+        ``model-20260721-114130-2d9c959d``.
 
     Raises:
         RuntimeError: If prefix is empty or exceeds 128 characters.

--- a/python/michelangelo/workflow/tasks/pusher/plugins/model_plugin.py
+++ b/python/michelangelo/workflow/tasks/pusher/plugins/model_plugin.py
@@ -93,6 +93,7 @@ import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypedDict
 
+from michelangelo.api.v2.util import generate_random_name
 from michelangelo.workflow.schema.exceptions import ConfigurationError
 from michelangelo.workflow.tasks.pusher.plugins.base import PusherPluginBase
 
@@ -346,7 +347,8 @@ class ModelPusherPlugin(PusherPluginBase):
         if config.model_name == "":
             raise ConfigurationError(
                 "ModelPusherPlugin: model_name must be a non-empty string or None "
-                "(None auto-generates a unique name, e.g. 'model-a1b2c3d4')."
+                "(None auto-generates a unique name, e.g. "
+                "'model-20260721-114130-2d9c959d')."
             )
         # Resolve the effective registry list at init time.
         has_injected = registry_client is not None
@@ -405,10 +407,11 @@ class ModelPusherPlugin(PusherPluginBase):
         """
         if self._config.model_name is None:
             _logger.warning(
-                "No model_name set in config — auto-generating a UUID-based name. "
+                "No model_name set in config — auto-generating a "
+                "timestamp+UUID-based name. "
                 "Set config.model_name explicitly for reproducible model identities."
             )
-            model_name = _generate_name()
+            model_name = generate_random_name("model")
         else:
             model_name = self._config.model_name
         push_id = uuid.uuid4().hex[:16]
@@ -515,8 +518,3 @@ class ModelPusherPlugin(PusherPluginBase):
         if self._config.run_id is not None:
             result["run_id"] = self._config.run_id  # run_id wins on collision
         return result
-
-
-def _generate_name() -> str:
-    """Generate a unique model name with an 8-character hex UUID suffix."""
-    return f"model-{uuid.uuid4().hex[:8]}"

--- a/python/michelangelo/workflow/tasks/pusher/tests/plugins/test_model_plugin.py
+++ b/python/michelangelo/workflow/tasks/pusher/tests/plugins/test_model_plugin.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import itertools
+import re
 from unittest import TestCase
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from michelangelo.lib.model_manager.registry.client import RegisteredModel
 from michelangelo.workflow.schema.exceptions import ConfigurationError
@@ -15,6 +16,8 @@ from michelangelo.workflow.tasks.pusher.plugins.model_plugin import (
 )
 from michelangelo.workflow.variables.metadata import ModelMetadata
 from michelangelo.workflow.variables.types import AssembledModel, ModelArtifact
+
+_GENERATED_NAME_RE = re.compile(r"^model-\d{8}-\d{6}-[0-9a-f]{8}$")
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -153,7 +156,7 @@ class TestModelPusherPluginExecute(TestCase):
         self.assertEqual(call_kwargs["name"], "my-clf")
 
     def test_generates_name_when_model_name_is_none(self):
-        """It auto-generates a 'model-{uuid8}' name when config.model_name is None."""
+        """It auto-generates a timestamped name when config.model_name is None."""
         registry = MagicMock()
         registry.register_model.side_effect = lambda name, **kw: RegisteredModel(
             name=name, version="1", registry_uri=f"mock://{name}/1"
@@ -164,8 +167,27 @@ class TestModelPusherPluginExecute(TestCase):
             storage_backend=_mock_backend(),
             registry_client=registry,
         ).execute()
-        self.assertTrue(result["model_name"].startswith("model-"))
-        self.assertEqual(len(result["model_name"]), len("model-") + 8)
+        self.assertRegex(result["model_name"], _GENERATED_NAME_RE)
+
+    def test_name_generation_delegates_to_shared_api_utility(self):
+        """It calls michelangelo.api.v2 generate_random_name with the 'model' prefix."""
+        registry = MagicMock()
+        registry.register_model.side_effect = lambda name, **kw: RegisteredModel(
+            name=name, version="1", registry_uri=f"mock://{name}/1"
+        )
+        target = (
+            "michelangelo.workflow.tasks.pusher.plugins."
+            "model_plugin.generate_random_name"
+        )
+        with patch(target, return_value="model-20260721-114130-2d9c959d") as gen:
+            result = ModelPusherPlugin(
+                config=ModelPluginConfig(model_name=None),
+                artifact=_assembled(),
+                storage_backend=_mock_backend(),
+                registry_client=registry,
+            ).execute()
+        gen.assert_called_once_with("model")
+        self.assertEqual(result["model_name"], "model-20260721-114130-2d9c959d")
 
     def test_storage_key_includes_push_id_for_uniqueness(self):
         """Each execute() call uses a unique push_id in the storage key."""


### PR DESCRIPTION
## Summary

Closes #1632.

`_generate_name()` in the model pusher plugin produced names of the form `model-a1b2c3d4` — 8 hex
characters, a 2^32 space with no time component. By the birthday bound, collision probability
crosses 50% at roughly 65,000 auto-named models in a single registry, which is reachable for a
registry accumulating models from automated pipelines. Because re-registration under an existing
name is currently a silent upsert, such a collision would quietly replace an unrelated model.

A first pass at this fixed the format inline in the plugin. Further design review caught that
`michelangelo/api/v2/util.py` **already has** a `generate_random_name(prefix)` implementing
exactly the target `{prefix}-{YYYYMMDD}-{HHMMSS}-{8 hex}` format — but it was neither exported
from `michelangelo.api.v2` nor called anywhere in the tree. Fixing the plugin in isolation would
have left two copies of the same logic free to drift.

So instead: delete the private helper, call the shared one, and promote the shared one to public
API so the benefit lands for every `michelangelo.api.v2` consumer rather than just this plugin.
Names now look like `model-20260721-114130-2d9c959d`.

## Changes

- **`workflow/tasks/pusher/plugins/model_plugin.py`** — removed the private `_generate_name()`
  entirely; `execute()` now calls `generate_random_name("model")` directly at its single call
  site. Updated the `config.model_name` validation-error example to the new format, and reworded
  the warning from "auto-generating a UUID-based name" to "auto-generating a
  timestamp+UUID-based name", which is now accurate.
- **`api/v2/__init__.py`** — export `generate_random_name`, so
  `from michelangelo.api.v2 import generate_random_name` works. Previously only `APIClient` was
  exported, leaving the utility unreachable from the package's public surface.
- **`api/v2/util.py`** — added the missing `prefix: str -> str` type hints and documented the
  time-sortability property and an example name. No behavior change.
- **`api/v2/tests/test_util.py`** (new) — the utility had no tests. Covers format, uniqueness
  across successive calls, chronological string sort, prefix lowercasing, underscore-to-hyphen
  normalization, and the empty / over-128-character `RuntimeError` paths, including the
  128-character inclusive boundary.
- **`workflow/tasks/pusher/tests/plugins/test_model_plugin.py`** — the auto-naming test now
  asserts the full format via regex, plus a new test that the plugin delegates to the shared
  utility with the `"model"` prefix. The pre-existing assertion was pinned to the old
  8-character length and had to change either way.

## Implementation note

`model_plugin.py` imports from the `michelangelo.api.v2.util` submodule rather than the
`michelangelo.api.v2` package, because the package `__init__` imports `client`, which imports
`grpc`. Going through the submodule keeps grpc off the pusher plugin's import path. The package
export exists for external consumers, who are already paying that cost.

## Compatibility

Format change only, no semantics change:

- `config.model_name` remains the escape hatch for a stable identity; this path only fires when a
  caller passes `None`, and a warning is already logged when it does.
- The registry treats names as opaque strings and never parses them, so previously registered
  auto-generated names keep working unchanged.
- `generate_random_name` itself is unchanged behaviorally — it moves from unreachable to public.

## Test plan

```
cd python
.venv/bin/python -m pytest michelangelo/api/v2/tests/ michelangelo/workflow/tasks/pusher/tests/ -q
# 150 passed
.venv/bin/python -m pytest michelangelo/api/ michelangelo/workflow/ -q
# 565 passed  (wider sweep, to confirm the new __init__ export introduces no import cycle)
.venv/bin/python -m ruff format --check <touched files>   # clean
.venv/bin/python -m ruff check <touched files>            # clean
```

## Notes for reviewers

This is P3 on its own — a quality-of-life and defense-in-depth improvement rather than a
correctness bug in isolation. It pairs with the separate fix to the silent overwrite-on-collision
behavior in the registry client; the two compound, and landing them together gives the most
benefit.

Worth a look: `generate_random_name` raises `RuntimeError` (not `ValueError`) on a bad prefix.
That is pre-existing behavior now becoming public API, so if it should be `ValueError`, this is
the cheapest moment to change it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
