### PR TITLE
fix(registry): create a revision instead of overwriting on re-registration

### DIFF
--- a/python/michelangelo/lib/model_manager/registry/api_client.py
+++ b/python/michelangelo/lib/model_manager/registry/api_client.py
@@ -94,11 +94,17 @@ class APIRegistryClient(ModelRegistryClient):
     ``rpc-encoding``) on every call via ``DefaultHeaderProvider``, eliminating
     the need for a manual interceptor.
 
-    **Create vs. update (with retry):** :meth:`register_model` attempts
-    ``create_model`` first. On ``ALREADY_EXISTS`` it fetches ``resourceVersion``
-    via ``get_model`` and retries as ``update_model``. On ``FAILED_PRECONDITION``
-    (concurrent write) the whole sequence retries up to
-    :data:`_MAX_REGISTER_RETRIES` times.
+    **Create vs. new revision (with retry):** :meth:`register_model` attempts
+    ``create_model`` first. On ``ALREADY_EXISTS`` it fetches the current model
+    via ``get_model`` and writes back a new revision — ``spec.revision_id`` is
+    incremented and the new artifact URIs are *appended* to the existing ones,
+    so prior pushes stay associated with the model rather than being
+    overwritten. On ``FAILED_PRECONDITION`` (concurrent write) the whole
+    sequence retries up to :data:`_MAX_REGISTER_RETRIES` times.
+
+    Note that :meth:`get_model` still only resolves the latest revision;
+    earlier artifact URIs are retained on the model but are not individually
+    addressable through this client.
 
     **registry_uri format:** ``models:/{namespace}/{name}/{version}`` —
     Michelangelo's three-segment format, not the two-segment MLflow format.
@@ -170,7 +176,12 @@ class APIRegistryClient(ModelRegistryClient):
         labels: Mapping[str, str] | None = None,
         metadata: Mapping[str, Any] | None = None,
     ) -> RegisteredModel:
-        """Register a model via ``create_model``, falling back to ``update_model``.
+        """Register a model via ``create_model``, falling back to a new revision.
+
+        If a model with this name already exists, a new revision is written:
+        ``spec.revision_id`` is incremented and ``artifact_uri`` /
+        ``deployable_artifact_uri`` are appended to the URIs already recorded
+        on the model, so prior pushes remain associated with it.
 
         Args:
             name: Model name. Used as ``model.metadata.name``.
@@ -184,6 +195,7 @@ class APIRegistryClient(ModelRegistryClient):
 
         Returns:
             :class:`~michelangelo.lib.model_manager.registry.client.RegisteredModel`
+            for the newly created revision.
 
         Raises:
             grpc.RpcError: On gRPC errors other than ``ALREADY_EXISTS`` /
@@ -208,14 +220,24 @@ class APIRegistryClient(ModelRegistryClient):
                     raise
 
             _logger.warning(
-                "Model '%s' already exists — fetching resourceVersion and "
-                "updating (attempt %d/%d).",
+                "Model '%s' already exists — fetching it and writing a new "
+                "revision (attempt %d/%d).",
                 name,
                 attempt,
                 _MAX_REGISTER_RETRIES,
             )
             existing = self._svc.get_model(self._namespace, name)
+            model = self._build_model_proto(
+                name=name,
+                artifact_uri=artifact_uri,
+                deployable_artifact_uri=deployable_artifact_uri,
+                description=description,
+                labels=labels,
+                metadata=metadata,
+                existing=existing,
+            )
             model.metadata.resourceVersion = existing.metadata.resourceVersion
+            model.spec.revision_id = existing.spec.revision_id + 1
             try:
                 updated = self._svc.update_model(model)
                 return self._to_registered_model(updated)
@@ -271,11 +293,17 @@ class APIRegistryClient(ModelRegistryClient):
         description: str | None,
         labels: Mapping[str, str] | None,
         metadata: Mapping[str, Any] | None,
+        existing: model_pb2.Model | None = None,
     ) -> model_pb2.Model:
         model = model_pb2.Model()
         model.metadata.name = name
         if self._namespace:
             model.metadata.namespace = self._namespace
+        if existing is not None:
+            model.spec.model_artifact_uri.extend(existing.spec.model_artifact_uri)
+            model.spec.deployable_artifact_uri.extend(
+                existing.spec.deployable_artifact_uri
+            )
         model.spec.model_artifact_uri.append(artifact_uri)
         if deployable_artifact_uri:
             model.spec.deployable_artifact_uri.append(deployable_artifact_uri)
@@ -318,11 +346,12 @@ class APIRegistryClient(ModelRegistryClient):
         name = model.metadata.name
         namespace = model.metadata.namespace or self._namespace
         version = str(model.spec.revision_id)
+        # The URI lists accumulate one entry per revision; the last is this one's.
         artifact_uri = (
-            model.spec.model_artifact_uri[0] if model.spec.model_artifact_uri else None
+            model.spec.model_artifact_uri[-1] if model.spec.model_artifact_uri else None
         )
         deployable_artifact_uri = (
-            model.spec.deployable_artifact_uri[0]
+            model.spec.deployable_artifact_uri[-1]
             if model.spec.deployable_artifact_uri
             else None
         )

--- a/python/michelangelo/lib/model_manager/registry/client.py
+++ b/python/michelangelo/lib/model_manager/registry/client.py
@@ -134,6 +134,12 @@ class ModelRegistryClient(ABC):
     ) -> RegisteredModel:
         """Register a model and its artifact URI in the registry.
 
+        If a model with this name already exists, a new revision is created;
+        prior revisions and their artifact URIs remain associated with the
+        model. Retrieving an earlier revision is implementation-dependent —
+        :meth:`get_model` may only be able to return the latest, so consult the
+        concrete client's documentation.
+
         Args:
             name: Model name to register under. The registry creates the model
                 entry if it does not already exist.

--- a/python/michelangelo/lib/model_manager/registry/tests/api_client_test.py
+++ b/python/michelangelo/lib/model_manager/registry/tests/api_client_test.py
@@ -284,6 +284,98 @@ class TestAPIRegistryClientAlreadyExists(TestCase):
             _client(svc).register_model("m", "s3://b/raw")
 
 
+class _FakeModelService:
+    """Stateful ModelService double implementing create/get/update semantics.
+
+    Echoes back whatever proto the client sends on update, so assertions on the
+    returned ``RegisteredModel`` also assert what the client asked for.
+    """
+
+    def __init__(self) -> None:
+        self._store: dict[str, model_pb2.Model] = {}
+
+    def create_model(self, model: model_pb2.Model) -> model_pb2.Model:
+        if model.metadata.name in self._store:
+            raise _RpcError(grpc.StatusCode.ALREADY_EXISTS)
+        stored = model_pb2.Model()
+        stored.CopyFrom(model)
+        stored.spec.revision_id = 1
+        self._store[model.metadata.name] = stored
+        return stored
+
+    def get_model(self, namespace: str, name: str) -> model_pb2.Model:
+        return self._store[name]
+
+    def update_model(self, model: model_pb2.Model) -> model_pb2.Model:
+        stored = model_pb2.Model()
+        stored.CopyFrom(model)
+        self._store[model.metadata.name] = stored
+        return stored
+
+
+class TestAPIRegistryClientRevisions(TestCase):
+    """Tests for revision semantics when re-registering an existing name."""
+
+    def test_second_registration_increments_revision(self):
+        """Re-registering the same name yields the next revision."""
+        client = _client(_FakeModelService())
+
+        first = client.register_model("m", "s3://b/raw/v1")
+        second = client.register_model("m", "s3://b/raw/v2")
+
+        self.assertEqual(first.version, "1")
+        self.assertEqual(second.version, "2")
+
+    def test_second_registration_reports_latest_artifact_uri(self):
+        """The returned artifact URIs are this push's, not the first push's."""
+        client = _client(_FakeModelService())
+
+        client.register_model("m", "s3://b/raw/v1", deployable_artifact_uri="s3://b/d1")
+        second = client.register_model(
+            "m", "s3://b/raw/v2", deployable_artifact_uri="s3://b/d2"
+        )
+
+        self.assertEqual(second.artifact_uri, "s3://b/raw/v2")
+        self.assertEqual(second.deployable_artifact_uri, "s3://b/d2")
+
+    def test_prior_artifact_uris_are_retained(self):
+        """Earlier revisions' URIs stay on the model instead of being replaced."""
+        svc = _FakeModelService()
+        client = _client(svc)
+
+        client.register_model("m", "s3://b/raw/v1", deployable_artifact_uri="s3://b/d1")
+        client.register_model("m", "s3://b/raw/v2", deployable_artifact_uri="s3://b/d2")
+
+        stored = svc.get_model("default", "m")
+        self.assertEqual(
+            list(stored.spec.model_artifact_uri), ["s3://b/raw/v1", "s3://b/raw/v2"]
+        )
+        self.assertEqual(
+            list(stored.spec.deployable_artifact_uri), ["s3://b/d1", "s3://b/d2"]
+        )
+
+    def test_build_model_proto_extends_existing_uris(self):
+        """_build_model_proto() appends to an existing model's URI lists."""
+        existing = _model("m", artifact_uri="s3://b/raw/v1", deployable_uri="s3://b/d1")
+
+        proto = _client()._build_model_proto(
+            name="m",
+            artifact_uri="s3://b/raw/v2",
+            deployable_artifact_uri="s3://b/d2",
+            description=None,
+            labels=None,
+            metadata=None,
+            existing=existing,
+        )
+
+        self.assertEqual(
+            list(proto.spec.model_artifact_uri), ["s3://b/raw/v1", "s3://b/raw/v2"]
+        )
+        self.assertEqual(
+            list(proto.spec.deployable_artifact_uri), ["s3://b/d1", "s3://b/d2"]
+        )
+
+
 # ---------------------------------------------------------------------------
 # get_model
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1631.

## Problem

`APIRegistryClient.register_model()` silently discarded a model's previous artifact URIs when
called again under an existing name. On `ALREADY_EXISTS` it rebuilt the outgoing proto from
scratch via `_build_model_proto()` — which always starts `spec.model_artifact_uri` /
`spec.deployable_artifact_uri` empty — and sent that as the update. It also never set
`spec.revision_id`, so the client never asked for the next revision.

Net effect: a re-push under an existing name returned a successful `RegisteredModel` while the
prior registration's artifact pointer became unrecoverable through the registry.

## Changes

- `register_model()`: on `ALREADY_EXISTS`, rebuild the proto with the fetched `existing` model
  threaded in, set `spec.revision_id = existing.spec.revision_id + 1`, and write that back. The
  create path is untouched. The `FAILED_PRECONDITION` retry logic is unchanged.
- `_build_model_proto()`: takes an optional `existing` argument. When given, both artifact URI
  lists start from the existing model's entries and the new URIs are appended. Existing
  deployable URIs are preserved even when this push doesn't supply one, so a raw-only re-push
  doesn't wipe the serving-bundle history.
- `_to_registered_model()`: reads `[-1]` rather than `[0]` from both URI lists. Now that the
  lists accumulate history, index 0 is the oldest entry, not this registration's.
- Docstrings: the already-exists contract is stated on the `ModelRegistryClient.register_model()`
  ABC, and `APIRegistryClient`'s class-docstring note no longer describes the collision path as
  an in-place update.

## Not in scope

Per-revision retrieval. `get_model(version=...)` still returns only the latest revision — that
needs the underlying service surface to expose revision lookup. Both docstrings state this
limitation explicitly rather than implying it is fixed.

## Tests

Four cases added to `api_client_test.py`, backed by a small stateful `ModelService` double that
implements real create/get/update semantics (it echoes the client's proto on update, so
assertions on the returned `RegisteredModel` also assert what the client sent):

- re-registering the same name yields `version="2"` on the second call
- the second call's `artifact_uri` / `deployable_artifact_uri` are the second push's, not the
  first's — regression test for the `[0]` → `[-1]` fix
- both URI lists on the stored model retain the first push's entries after the second
- `_build_model_proto()` with an `existing` model extends both lists rather than replacing them

`python -m pytest michelangelo/lib/model_manager/registry/tests/` — 50 passed.
`michelangelo/workflow/tasks/pusher/tests/` — 119 passed.
`ruff format --check` and `ruff check` clean on all touched files.
