### PR TITLE
feat(skills): add ma-sandbox Claude Code skills for local sandbox workflows

### DIFF
--- a/.claude/skills/ma-sandbox-debug/SKILL.md
+++ b/.claude/skills/ma-sandbox-debug/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: ma-sandbox-debug
+description: Tail logs, inspect pods, and diagnose unhealthy services in a running Michelangelo sandbox. Use when a service is crashlooping, returning errors, or not responding as expected. Triggers on "check logs", "why is X failing", "debug sandbox", "kubectl logs".
+user-invocable: true
+---
+
+# Sandbox Debug
+
+Diagnosing service failures in a running sandbox. Start with health overview, then drill into specific services.
+
+## Step 1: Health overview
+
+```bash
+ma sandbox health        # high-level check: cluster, pods, API, envoy, UI
+kubectl get pods -A      # full pod inventory with status
+```
+
+**IF** `kubectl get pods -A` output contains any pod in `CrashLoopBackOff`, `Error`, or `ImagePullBackOff` state (excluding expected noise listed below): **proceed to Step 3** for each affected pod.
+
+**IF** a pod is stuck `Pending` beyond 3 minutes: **proceed to Step 3** for that pod.
+
+**IF** all pods show `Running` or `Completed`: report the cluster as healthy and stop — do not continue to Step 2 unless the user reports a specific symptom.
+
+## Step 2: Tail logs by service
+
+```bash
+# apiserver — handles all API requests (Go)
+kubectl logs -f deployment/michelangelo-apiserver
+
+# worker — handles async tasks
+kubectl logs -f deployment/michelangelo-worker
+
+# controller manager
+kubectl logs -f deployment/michelangelo-controllermgr
+
+# envoy — ingress proxy (proxy errors appear here, not in apiserver)
+kubectl logs -f deployment/michelangelo-envoy
+
+# UI — nginx serving the frontend bundle
+kubectl logs -f deployment/michelangelo-ui
+```
+
+Useful flags: `--tail=100` to limit output; `--previous` to see logs from the last crashed container instance.
+
+## Need more verbose logs?
+
+Go services default to `info` level. Enable debug logging for deeper investigation:
+
+```bash
+bash $(git rev-parse --show-toplevel)/.claude/skills/ma-sandbox-scripts/set_log_level.sh controllermgr debug
+```
+
+Revert when done: replace `debug` with `info`. Pair with `$(git rev-parse --show-toplevel)/.claude/skills/ma-sandbox-scripts/capture_service_logs.sh` to filter the resulting output down to signal.
+
+## Step 3: Inspect a crashing pod
+
+```bash
+# Get the pod name
+kubectl get pods -l app.kubernetes.io/component=apiserver
+
+# Events and last exit reason
+kubectl describe pod <pod-name>
+
+# Logs from the previous crashed instance
+kubectl logs <pod-name> --previous
+```
+
+The **Events** section and **Last State** (exit code, reason) in `describe` output are the most diagnostic fields.
+
+## Common failure patterns
+
+| Symptom | Where to look | Likely cause |
+|---------|--------------|--------------|
+| UI loads, API returns 503 | envoy logs | Envoy can't reach apiserver |
+| UI loads but shows no data | `kubectl get projects,pipelines,pipelineruns -A` | No demo data seeded — run `ma sandbox demo pipeline`. If resources exist but UI is empty, check envoy logs |
+| API returns 500 | apiserver logs | Go panic or DB connection error |
+| Pod in `CrashLoopBackOff` | `describe pod`, `--previous` logs | OOM, missing config, bad binary |
+| Pod stuck `Pending` | `describe pod` Events | No node resources or PVC mount failure |
+| `ImagePullBackOff` | `describe pod` Events | Image not imported — run `k3d image import` |
+| Feature broken after deploy | apiserver logs | Business logic bug in the deployed binary |
+| `create` failed partway / "cluster already exists" | — | Run `ma sandbox sync` to finish — don't delete+recreate |
+
+## Filter logs for errors
+
+```bash
+kubectl logs deployment/michelangelo-apiserver | grep -i "error\|panic\|fatal"
+kubectl logs deployment/michelangelo-worker --tail=200
+```
+
+## Force-restart a stuck service
+
+When a service isn't crashing but isn't picking up new config or code:
+
+```bash
+kubectl rollout restart deployment/michelangelo-apiserver
+kubectl rollout status deployment/michelangelo-apiserver --timeout=60s
+```
+
+## Expected noise (not actual errors)
+
+- `cadence-schema-init`, `ingester-schema-init`, `sandbox-bucket-setup` — reach `Completed` and stay there; this is correct
+- `ray-history-server` in `ImagePullBackOff` — non-blocking; Ray jobs still work without it
+
+## Still stuck?
+
+If the cluster state is unrecoverable, do a full reset: `/ma-sandbox-reset`.

--- a/.claude/skills/ma-sandbox-deploy/SKILL.md
+++ b/.claude/skills/ma-sandbox-deploy/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: ma-sandbox-deploy
+description: Build a Go service binary, package it into a Docker image, import into k3d, and deploy via helm sync. Use when iterating on apiserver (or another Go service) and wanting to test changes in a running sandbox without waiting for CI.
+user-invocable: true
+---
+
+# Sandbox Local Image Dev Loop
+
+For iterating on Go services (primarily `apiserver` and `controllermgr`) inside a running sandbox. Requires a sandbox already running — if not, run `ma sandbox create` first (see `/ma-sandbox-setup`).
+
+```bash
+REPO_ROOT=$(git rev-parse --show-toplevel)
+```
+
+Run this once at the start of your shell session, or prefix paths below with the result.
+
+## Full build + deploy sequence
+
+The steps below use `apiserver` as the example. See [Adapting for controllermgr](#adapting-for-controllermgr) for the controllermgr-specific substitutions.
+
+```bash
+# 1. Build statically-linked linux/arm64 binary (CGO_ENABLED=0 required — Distroless base has no libc)
+cd "$REPO_ROOT/go"
+CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o /tmp/apiserver-local ./cmd/apiserver/
+
+# 2. Copy config (only needed once, or when config files change)
+cp -r "$REPO_ROOT/go/cmd/apiserver/config" /tmp/apiserver-config
+
+# 3. Prepare a clean build context and build Docker image
+mkdir -p /tmp/apiserver-build
+cp /tmp/apiserver-local /tmp/apiserver-build/apiserver-local
+cp -r /tmp/apiserver-config /tmp/apiserver-build/apiserver-config
+docker build \
+  -f "$REPO_ROOT/docker/service.Dockerfile" \
+  --build-arg BINARY_PATH=apiserver-local \
+  --build-arg CONFIG_PATH=apiserver-config \
+  --platform linux/arm64 \
+  --label git.branch="$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)" \
+  --label git.sha="$(git -C "$REPO_ROOT" rev-parse --short HEAD)" \
+  --label git.dirty="$(git -C "$REPO_ROOT" diff --quiet || echo true)" \
+  -t michelangelo-apiserver:local \
+  /tmp/apiserver-build/
+
+# 4. Import image into k3d cluster
+k3d image import michelangelo-apiserver:local -c michelangelo-sandbox
+
+# 5. Sync sandbox with local image override
+# IMPORTANT: pass --set images.apiserver=... on EVERY sync call — helm's --reuse-values
+# silently reverts to the default ghcr.io image if you omit it
+source "$REPO_ROOT/python/.venv/bin/activate"
+ma sandbox sync \
+  --set images.apiserver=michelangelo-apiserver:local \
+  --set images.pullPolicy=IfNotPresent \
+  --set ui.enabled=true \
+  --set envoy.enabled=true \
+  --set controllermgr.enabled=true \
+  --set worker.enabled=true
+```
+
+## Hot-swap (subsequent iterations)
+
+Check whether config files changed since the last sync:
+
+```bash
+git diff --name-only HEAD | grep 'cmd/apiserver/config/'
+```
+
+**IF** that command returns no output — config is unchanged. Skip steps 2–3 (config copy) and run only the binary rebuild + import:
+
+```bash
+# Rebuild binary, re-import, rollout restart
+CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o /tmp/apiserver-local "$REPO_ROOT/go/cmd/apiserver/"
+cp /tmp/apiserver-local /tmp/apiserver-build/apiserver-local
+docker build \
+  -f "$REPO_ROOT/docker/service.Dockerfile" \
+  --build-arg BINARY_PATH=apiserver-local \
+  --build-arg CONFIG_PATH=apiserver-config \
+  --platform linux/arm64 \
+  --label git.branch="$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)" \
+  --label git.sha="$(git -C "$REPO_ROOT" rev-parse --short HEAD)" \
+  --label git.dirty="$(git -C "$REPO_ROOT" diff --quiet || echo true)" \
+  -t michelangelo-apiserver:local \
+  /tmp/apiserver-build/
+k3d image import michelangelo-apiserver:local -c michelangelo-sandbox
+kubectl rollout restart deployment/michelangelo-apiserver
+kubectl rollout status deployment/michelangelo-apiserver --timeout=60s
+```
+
+## Adapting for controllermgr
+
+Substitute these values in every step above:
+
+| apiserver | controllermgr |
+|-----------|--------------|
+| `./cmd/apiserver/` | `./cmd/controllermgr/` |
+| `/tmp/apiserver-local` | `/tmp/controllermgr-local` |
+| `/tmp/apiserver-config` | `/tmp/controllermgr-config` |
+| `/tmp/apiserver-build/` | `/tmp/controllermgr-build/` |
+| `michelangelo-apiserver:local` | `michelangelo-controllermgr:local` |
+| `--set images.apiserver=...` | `--set images.controllermgr=...` |
+| `deployment/michelangelo-apiserver` | `deployment/michelangelo-controllermgr` |
+| `app.kubernetes.io/component=apiserver` | `app.kubernetes.io/component=controllermgr` |
+
+Check whether `cmd/controllermgr/` has a `config/` directory — if not, omit steps 2 and the `CONFIG_PATH` build arg.
+
+## Verify what's deployed
+
+The `:local` tag carries no inherent identity — verify across three signals.
+
+**1. It's your local build, not the released image:**
+
+```bash
+kubectl get pod -l app.kubernetes.io/component=apiserver \
+  -o jsonpath='{.items[0].spec.containers[0].image}'
+```
+
+Should return `michelangelo-apiserver:local`, not `ghcr.io/michelangelo-ai/apiserver:main`.
+
+**2. Which branch/commit it was built from** (requires the `--label` flags above):
+
+```bash
+docker image inspect michelangelo-apiserver:local --format '{{json .Config.Labels}}'
+# {"git.branch":"craig.marker/fix-...","git.sha":"d1046e10","git.dirty":"true"}
+```
+
+The labels are baked into the image, so they survive `k3d image import` — inspecting the
+local image tells you what the imported (and running) image is.
+
+**3. It's your *latest* build, not a stale pod** — compare image build time to pod start
+time. If the pod started *before* your last build, you forgot to `rollout restart`:
+
+```bash
+docker image inspect michelangelo-apiserver:local --format 'built: {{.Created}}'
+kubectl get pod -l app.kubernetes.io/component=apiserver \
+  -o jsonpath='started: {.items[0].status.startTime}{"\n"}'
+```

--- a/.claude/skills/ma-sandbox-references/evidence-quality.md
+++ b/.claude/skills/ma-sandbox-references/evidence-quality.md
@@ -1,0 +1,57 @@
+# Test Evidence
+
+A test plan's value is evidence that CI can't provide: the feature working in a running environment. A reviewer should be able to reconstruct what you actually observed — not just trust your conclusion.
+
+## Example
+
+```markdown
+## Test plan
+
+### Integration on k3d sandbox
+Image: `michelangelo-controllermgr:local` (branch `craig/revision-manager`, sha `d1046e10`)
+Log level: `debug`
+
+#### 1. PipelineRun reconciles through full lifecycle
+Applied `test-revision-happy` → watched phase transitions:
+
+​```
+{"level":"info","msg":"transitioned phase","name":"test-revision-happy","from":"Pending","to":"Running"}
+{"level":"info","msg":"transitioned phase","name":"test-revision-happy","from":"Running","to":"Succeeded"}
+​```
+
+Verified terminal state:
+​```
+$ kubectl get pipelinerun test-revision-happy -n ma-dev-test -o jsonpath='{.status.phase}'
+Succeeded
+​```
+
+#### 2. Immutability enforced on completed run
+Attempted spec mutation on the succeeded run — rejected as expected.
+
+### Known gaps
+- Did not test the Temporal workflow-engine path — sandbox was seeded with Cadence only.
+```
+
+This is one shape, not the only shape. Match the evidence to what the diff actually changes.
+
+## What makes evidence useful vs hollow
+
+**Positive evidence beats negative.** "No errors in the logs" proves the log capture worked, not that the feature worked — a silent no-op produces identical evidence. Show the feature working: phase transitions in logs, screenshots of UI interaction, state confirmed via `kubectl get`.
+
+**One section per code path.** A single "it works" paragraph covering three branches touched by the diff tells a reviewer nothing about which were actually exercised.
+
+**Action → evidence → verify.** Show the exact command, its raw output, and an independent check confirming the state. "Ran X, worked fine" with no output is not evidence.
+
+**Filter to signal.** Don't paste 500 lines of raw logs. Use `capture_service_logs.sh` to show only lines relevant to the resource under test.
+
+**Verify your environment.** Cross-check that the pod is running your build (image labels, branch/sha) before trusting results from it. A stale pod producing "passing" evidence for the wrong binary is worse than no evidence.
+
+**Enable observability first.** `set_log_level.sh <service> debug` before exercising the feature, so the evidence includes the detail you'll need if something goes wrong.
+
+**Named test resources.** Create resources named for the scenario (`test-<feature>-<scenario>`) rather than testing against shared demo data where failures could be leftover state.
+
+**Show time behavior.** A single terminal-state snapshot tells you nothing about whether intermediate states were correct. Show the transitions.
+
+**Show the full lifecycle.** Exercise every path the diff touches — not just the happy-path create, but delete, error handling, immutability enforcement if those are in the diff.
+
+**Flag gaps honestly.** An untested path noted is a known risk. An untested path left silent is a surprise later.

--- a/.claude/skills/ma-sandbox-references/routes.md
+++ b/.claude/skills/ma-sandbox-references/routes.md
@@ -1,0 +1,55 @@
+# Michelangelo Sandbox UI Routes
+
+Route pattern: `http://localhost:5173/{project}/{phase}/{entity}`
+
+Use `ma-dev-test` as the project for all local verification.
+
+## Phase keywords
+
+| Phase | Matches these keywords in the feature description |
+|-------|--------------------------------------------------|
+| `train` | train, training, model training, learning, fitting, pipeline run |
+| `deploy` | deploy, serving, inference, production, online, endpoint |
+
+## Entity keywords
+
+| Entity | Matches these keywords |
+|--------|----------------------|
+| `pipeline` | pipeline, workflow, dag, steps |
+| `run` | run, execution, job, attempt, history |
+| `trigger` | trigger, schedule, cron, automated, recurring |
+| `model` | model, artifact, version, checkpoint, weights |
+| `target` | target, serving target |
+| `deployment` | deployment, rollout, canary, release |
+
+## Route table
+
+| Phase | Entity | URL |
+|-------|--------|-----|
+| train | pipeline | `http://localhost:5173/ma-dev-test/train/pipeline` |
+| train | run | `http://localhost:5173/ma-dev-test/train/run` |
+| train | trigger | `http://localhost:5173/ma-dev-test/train/trigger` |
+| train | model | `http://localhost:5173/ma-dev-test/train/model` |
+| deploy | target | `http://localhost:5173/ma-dev-test/deploy/target` |
+| deploy | deployment | `http://localhost:5173/ma-dev-test/deploy/deployment` |
+
+## Resolution algorithm
+
+Apply in order:
+
+1. **Resolve phase** — scan the feature description for phase keywords (table above). Record all matching phases.
+2. **Resolve entity** — scan the feature description for entity keywords (table above). Record all matching entities.
+3. **Look up (phase, entity)** — find the row in the route table that matches both resolved signals.
+
+**IF** exactly one (phase, entity) pair matches → use that URL.
+
+**IF** the entity exists in multiple phases (collision) AND no phase keyword was found:
+- Default to `train` phase.
+- Note in the Step 5 report: *"Assumed train/{entity}; if you meant deploy/{entity}, re-invoke with the phase specified."*
+
+**IF** no entity keyword matches:
+- Start at `http://localhost:5173/ma-dev-test/train/pipeline`.
+- Note in the report that no entity could be inferred.
+
+**IF** a (phase, entity) combination appears in the description but has no row in the route table:
+- Stop. Report: *"No route found for {phase}/{entity}. Available routes: [list table]."* Do not guess.

--- a/.claude/skills/ma-sandbox-references/sandbox-data.md
+++ b/.claude/skills/ma-sandbox-references/sandbox-data.md
@@ -1,0 +1,81 @@
+# Sandbox Data Reference
+
+How to inspect, seed, reset, and create data in a running Michelangelo sandbox.
+
+## Constraints
+
+- **kubectl is the right inspection tool** — curl, yab, and grpcurl do not work against the YARPC/gRPC apiserver without a compiled protobuf FileDescriptorSet.
+- **UI interactions or `ma` CLI are the right creation tools** — no direct API calls.
+
+---
+
+## Demo data
+
+Seed with:
+
+```bash
+REPO_ROOT=$(git rev-parse --show-toplevel)
+source "$REPO_ROOT/python/.venv/bin/activate"
+ma sandbox demo pipeline       # training pipelines, trigger runs, eval pipeline
+ma sandbox demo inference      # inference server (only needed for deploy-phase testing)
+```
+
+Both commands run `kubectl apply` on the YAML files under:
+- `python/michelangelo/cli/sandbox/demo/pipeline/`
+- `python/michelangelo/cli/sandbox/demo/trigger_run/`
+- `python/michelangelo/cli/sandbox/demo/inference/`
+
+Read those files directly to see exactly what entities get created, their names, and their specs. Both commands are **idempotent** — safe to re-run.
+
+**State after seeding**: entity state is set by the controller manager after apply — inspect with `kubectl get` to see actual current states rather than assuming.
+
+---
+
+## Inspecting state
+
+```bash
+# All resources in the project
+kubectl get pipelines,pipelineruns,triggerruns -n ma-dev-test
+
+# Detailed status of a specific resource
+kubectl describe triggerrun <name> -n ma-dev-test
+
+# Watch state changes live
+kubectl get triggerruns -n ma-dev-test -w
+```
+
+---
+
+## Resetting demo data to a known state
+
+When an entity is in the wrong state for a test:
+
+### Option A — Delete the specific resource and re-apply
+
+```bash
+kubectl delete triggerrun <name> -n ma-dev-test
+ma sandbox demo pipeline
+```
+
+The reconciler will recreate it in its initial state.
+
+### Option B — Create a new entity via the UI
+
+Navigate to the relevant list page, use the "Create" or "Run" action to create a fresh entity. Faster than a full re-seed and exercises more of the stack — prefer this when the goal is to test a state transition.
+
+---
+
+## Ports
+
+| Service | URL |
+|---------|-----|
+| Michelangelo UI (full sandbox) | http://localhost:8090 |
+| API Server | http://localhost:15566 |
+| Vite dev server (frontend only, mocks) | http://localhost:5173 |
+| Cadence Web | http://localhost:8088 |
+| Temporal Web | http://localhost:8080 |
+| MinIO Console | http://localhost:9090 |
+| Grafana | http://localhost:3000 |
+| Ray Dashboard | http://localhost:8265 |
+
+Full port list: `docs/getting-started/ma-sandbox-ports-and-endpoints.md`

--- a/.claude/skills/ma-sandbox-reset/SKILL.md
+++ b/.claude/skills/ma-sandbox-reset/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: ma-sandbox-reset
+description: Tear down the Michelangelo sandbox cluster and recreate it from scratch. Use when the cluster is in a broken state, after major schema changes, or when you want a clean environment. Triggers on "reset sandbox", "start fresh", "sandbox is broken". For service-level issues without nuking the cluster, use /ma-sandbox-debug instead.
+user-invocable: true
+---
+
+# Sandbox Reset
+
+Full teardown and recreation of the local Michelangelo sandbox. Use when `ma sandbox sync` or `ma sandbox health` can't recover the cluster.
+
+## Step 1: Delete the cluster
+
+```bash
+REPO_ROOT=$(git rev-parse --show-toplevel)
+source "$REPO_ROOT/python/.venv/bin/activate"   # or prefix every command with: poetry run
+ma sandbox delete
+```
+
+Tears down the k3d cluster and all resources inside it. Takes ~30 seconds.
+
+## Step 2: Recreate
+
+```bash
+ma sandbox create
+```
+
+## Step 3: Seed demo data (recommended)
+
+```bash
+cd "$REPO_ROOT/python"
+poetry run ma sandbox demo pipeline
+```
+
+Without this the UI loads but shows no data. Skip only if you have a specific reason to start empty.
+
+## Step 4: Verify
+
+```bash
+poetry run ma sandbox health
+```
+
+All checks should pass. Open the sandbox UI and confirm the seeded demo project is visible.

--- a/.claude/skills/ma-sandbox-scripts/capture_service_logs.sh
+++ b/.claude/skills/ma-sandbox-scripts/capture_service_logs.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Filters kubectl logs for a Michelangelo service into clean, PR-ready JSON lines.
+#
+#   capture_service_logs.sh <service> [--resource NAME] [--component NAME] \
+#                            [--level LVL] [--exclude PATTERN] [--tail N]
+#
+# Assumes the service is emitting zap's default JSON encoding (go/base/zapfx,
+# zap.NewProductionEncoderConfig) — run set_log_level.sh first if it isn't.
+# Non-JSON lines are dropped rather than erroring, since a service can still
+# emit occasional plain-text startup lines before logging is configured.
+#
+# By default, strips YARPC's per-RPC observability tracing lines
+# ("Handled inbound request." / "Made outbound call.", logged at debug level
+# by go.uber.org/yarpc's built-in middleware) — this is the noise that makes
+# raw debug logs unreadable.
+
+set -euo pipefail
+
+SERVICE="${1:-}"
+shift || true
+
+usage() {
+  echo "Usage: $(basename "$0") <apiserver|controllermgr|worker> [--resource NAME] [--component NAME] [--level LVL] [--exclude PATTERN] [--tail N]" >&2
+  exit 1
+}
+
+case "$SERVICE" in
+  apiserver|controllermgr|worker) ;;
+  *) echo "error: unknown service '$SERVICE'" >&2; usage ;;
+esac
+
+RESOURCE=""
+COMPONENT=""
+LEVEL=""
+EXCLUDE=""
+TAIL="200"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --resource) RESOURCE="$2"; shift 2 ;;
+    --component) COMPONENT="$2"; shift 2 ;;
+    --level) LEVEL="$2"; shift 2 ;;
+    --exclude) EXCLUDE="$2"; shift 2 ;;
+    --tail) TAIL="$2"; shift 2 ;;
+    *) echo "error: unknown argument '$1'" >&2; usage ;;
+  esac
+done
+
+command -v kubectl >/dev/null 2>&1 || { echo "error: kubectl not found on PATH" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "error: jq not found on PATH" >&2; exit 1; }
+
+DEPLOYMENT="michelangelo-${SERVICE}"
+
+# Build the jq filter incrementally. Drop non-JSON lines first (`fromjson? //
+# empty`), then the always-on tracing-noise filter, then each opt-in filter.
+JQ_FILTER='fromjson? // empty'
+JQ_FILTER="$JQ_FILTER | select(.msg != \"Handled inbound request.\" and .msg != \"Made outbound call.\" and .msg != \"Error handling inbound request.\" and .msg != \"Error making outbound call.\")"
+
+if [ -n "$LEVEL" ]; then
+  JQ_FILTER="$JQ_FILTER | select(.level == \$level)"
+fi
+if [ -n "$COMPONENT" ]; then
+  JQ_FILTER="$JQ_FILTER | select(.component == \$component)"
+fi
+if [ -n "$RESOURCE" ]; then
+  # Identity field names vary by controller (name, namespace-name, pipelineRun,
+  # ...), so match by substring against the whole serialized line instead of
+  # hardcoding one field.
+  JQ_FILTER="$JQ_FILTER | select(tostring | contains(\$resource))"
+fi
+if [ -n "$EXCLUDE" ]; then
+  JQ_FILTER="$JQ_FILTER | select((.msg // \"\") | test(\$exclude) | not)"
+fi
+
+kubectl logs "deployment/${DEPLOYMENT}" --tail="$TAIL" | jq -Rc \
+  --arg level "$LEVEL" \
+  --arg component "$COMPONENT" \
+  --arg resource "$RESOURCE" \
+  --arg exclude "$EXCLUDE" \
+  "$JQ_FILTER"

--- a/.claude/skills/ma-sandbox-scripts/check-backend.sh
+++ b/.claude/skills/ma-sandbox-scripts/check-backend.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Detects whether local Go service changes exist and whether they are deployed.
+# Prints one line to stdout and exits 0 always:
+#
+#   clean                     — no Go backend changes; Vite-only verify is appropriate
+#   deployed <service>        — Go changes exist AND local image is running in k3d
+#   needs-deploy <service>    — Go changes exist but default (non-local) image is running
+#
+# The caller decides how to proceed based on the output.
+
+set -euo pipefail
+
+WORKTREE_ROOT=$(git rev-parse --show-toplevel)
+
+# Collect all changed files: staged, unstaged, and untracked
+CHANGED_FILES=$(
+  { git -C "$WORKTREE_ROOT" diff --name-only HEAD 2>/dev/null
+    git -C "$WORKTREE_ROOT" ls-files --others --exclude-standard 2>/dev/null
+  } | sort -u
+)
+
+APISERVER_CHANGED=$(echo "$CHANGED_FILES" | grep -E '^go/cmd/apiserver/' | head -1 || true)
+CONTROLLERMGR_CHANGED=$(echo "$CHANGED_FILES" | grep -E '^go/cmd/controllermgr/' | head -1 || true)
+
+if [ -z "$APISERVER_CHANGED" ] && [ -z "$CONTROLLERMGR_CHANGED" ]; then
+  echo "clean"
+  exit 0
+fi
+
+# Determine which service has changes (apiserver takes priority)
+if [ -n "$APISERVER_CHANGED" ]; then
+  SERVICE="apiserver"
+else
+  SERVICE="controllermgr"
+fi
+
+# Check what image is currently running in the k3d cluster
+RUNNING_IMAGE=$(kubectl get pod -l "app.kubernetes.io/component=$SERVICE" \
+  -o jsonpath='{.items[0].spec.containers[0].image}' 2>/dev/null || echo "")
+
+if echo "$RUNNING_IMAGE" | grep -q ':local'; then
+  echo "deployed $SERVICE"
+else
+  echo "needs-deploy $SERVICE"
+fi

--- a/.claude/skills/ma-sandbox-scripts/find-vite-port.sh
+++ b/.claude/skills/ma-sandbox-scripts/find-vite-port.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Finds or starts a Vite dev server for the current branch's worktree.
+# On success: prints "<port> <pid> <started|existing>" and exits 0.
+#   started  — we started this server; caller should offer to kill it when done
+#   existing — server was already running; caller should leave it alone
+# On failure: prints an error to stderr and exits 1.
+
+set -euo pipefail
+
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+WORKTREE_ROOT=$(git rev-parse --show-toplevel)
+
+# --- Try to find an existing server for this branch ---
+for port in 5173 5174 5175 5176 5177 5178 5179 5180; do
+  PID=$(lsof -ti ":$port" 2>/dev/null | head -1)
+  [ -z "$PID" ] && continue
+  PORT_CWD=$(lsof -p "$PID" 2>/dev/null | awk '$4=="cwd" {print $NF}')
+  [ -z "$PORT_CWD" ] && continue
+  PORT_ROOT=$(git -C "$PORT_CWD" rev-parse --show-toplevel 2>/dev/null || true)
+  PORT_BRANCH=$(git -C "$PORT_CWD" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+  if [ "$PORT_ROOT" = "$WORKTREE_ROOT" ] && [ "$PORT_BRANCH" = "$CURRENT_BRANCH" ]; then
+    echo "$port $PID existing"
+    exit 0
+  elif [ -n "$PORT_BRANCH" ] && [ "$PORT_BRANCH" != "$CURRENT_BRANCH" ]; then
+    echo "Port $port has Vite for branch '$PORT_BRANCH' (need '$CURRENT_BRANCH') — skipping." >&2
+  fi
+done
+
+# --- No existing server found — start one ---
+JS_DIR="$WORKTREE_ROOT/javascript"
+if [ ! -d "$JS_DIR" ]; then
+  echo "javascript/ directory not found at $JS_DIR" >&2
+  exit 1
+fi
+
+yarn --cwd "$JS_DIR" dev &>/tmp/vite-dev-$$.log &
+SERVER_PID=$!
+
+# Wait for Vite to bind to a port (up to 30 seconds).
+# Detect by worktree root match rather than parent PID — Yarn/Vite forks
+# deeply on macOS so the listening PID is rarely a direct child of SERVER_PID.
+STARTED_PORT=""
+STARTED_PID=""
+for i in $(seq 1 30); do
+  sleep 1
+  # Check if the yarn process itself died early
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    echo "Vite server process exited early. Log at /tmp/vite-dev-$$.log" >&2
+    exit 1
+  fi
+  for port in 5173 5174 5175 5176 5177 5178 5179 5180; do
+    PID=$(lsof -ti ":$port" 2>/dev/null | head -1)
+    [ -z "$PID" ] && continue
+    PORT_CWD=$(lsof -p "$PID" 2>/dev/null | awk '$4=="cwd" {print $NF}')
+    [ -z "$PORT_CWD" ] && continue
+    PORT_ROOT=$(git -C "$PORT_CWD" rev-parse --show-toplevel 2>/dev/null || true)
+    if [ "$PORT_ROOT" = "$WORKTREE_ROOT" ]; then
+      STARTED_PORT=$port
+      STARTED_PID=$SERVER_PID
+      break 2
+    fi
+  done
+done
+
+if [ -z "$STARTED_PORT" ]; then
+  echo "Vite server did not start within 30 seconds. Log at /tmp/vite-dev-$$.log" >&2
+  kill "$SERVER_PID" 2>/dev/null || true
+  exit 1
+fi
+
+echo "$STARTED_PORT $STARTED_PID started"

--- a/.claude/skills/ma-sandbox-scripts/set_log_level.sh
+++ b/.claude/skills/ma-sandbox-scripts/set_log_level.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Sets the zap log level for a Michelangelo Go service running in the local k3d sandbox.
+#
+#   set_log_level.sh <service> <level>
+#     service: apiserver | controllermgr | worker
+#     level:   debug | info | warn | error | dpanic | panic | fatal
+#
+# apiserver/controllermgr ConfigMaps have no `logging:` block by default (only
+# worker's does) — this injects/overwrites a full block rather than editing a
+# field in place. Encoding is always forced to `json` (regardless of the
+# service's helm default) so capture_service_logs.sh can reliably parse it.
+#
+# Config is loaded once at process startup (go/base/config) — there is no
+# hot-reload, so a ConfigMap patch alone does nothing until the deployment
+# is restarted. This script does both and verifies the ConfigMap afterward.
+
+set -euo pipefail
+
+SERVICE="${1:-}"
+LEVEL="${2:-}"
+
+usage() {
+  echo "Usage: $(basename "$0") <apiserver|controllermgr|worker> <debug|info|warn|error|dpanic|panic|fatal>" >&2
+  exit 1
+}
+
+case "$SERVICE" in
+  apiserver|controllermgr|worker) ;;
+  *) echo "error: unknown service '$SERVICE'" >&2; usage ;;
+esac
+
+case "$LEVEL" in
+  debug|info|warn|error|dpanic|panic|fatal) ;;
+  *) echo "error: unknown level '$LEVEL'" >&2; usage ;;
+esac
+
+CONFIGMAP="michelangelo-${SERVICE}-config"
+DEPLOYMENT="michelangelo-${SERVICE}"
+
+command -v kubectl >/dev/null 2>&1 || { echo "error: kubectl not found on PATH" >&2; exit 1; }
+
+# PyYAML isn't guaranteed on the system python3, but it's already a dependency
+# of the michelangelo repo's poetry venv (used for the `ma` CLI). Prefer that
+# venv's interpreter when available, falling back to system python3.
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || true)
+PYTHON_BIN="python3"
+if [ -n "$REPO_ROOT" ] && [ -x "$REPO_ROOT/python/.venv/bin/python3" ]; then
+  PYTHON_BIN="$REPO_ROOT/python/.venv/bin/python3"
+fi
+
+"$PYTHON_BIN" -c "import yaml" 2>/dev/null || {
+  echo "error: PyYAML not importable via '$PYTHON_BIN'. Activate the repo's python venv (source python/.venv/bin/activate) and retry." >&2
+  exit 1
+}
+
+echo "Reading ConfigMap/${CONFIGMAP}..."
+CURRENT_YAML=$(kubectl get configmap "$CONFIGMAP" -o jsonpath='{.data.base\.yaml}')
+
+PATCH_JSON=$(CURRENT_YAML="$CURRENT_YAML" "$PYTHON_BIN" - "$LEVEL" <<'PYEOF'
+import os
+import sys
+import json
+import yaml
+
+level = sys.argv[1]
+current_yaml = os.environ["CURRENT_YAML"]
+
+doc = yaml.safe_load(current_yaml) or {}
+doc["logging"] = {"level": level, "development": False, "encoding": "json"}
+
+new_yaml = yaml.dump(doc, default_flow_style=False, sort_keys=False)
+print(json.dumps({"data": {"base.yaml": new_yaml}}))
+PYEOF
+)
+
+echo "Patching ConfigMap/${CONFIGMAP} (logging.level=${LEVEL}, encoding=json)..."
+kubectl patch configmap "$CONFIGMAP" --type merge -p "$PATCH_JSON" >/dev/null
+
+echo "Restarting deployment/${DEPLOYMENT}..."
+kubectl rollout restart "deployment/${DEPLOYMENT}" >/dev/null
+kubectl rollout status "deployment/${DEPLOYMENT}" --timeout=60s
+
+NEW_YAML=$(kubectl get configmap "$CONFIGMAP" -o jsonpath='{.data.base\.yaml}')
+if echo "$NEW_YAML" | grep -q "level: ${LEVEL}"; then
+  echo "Verified: ${CONFIGMAP} now has logging.level=${LEVEL}."
+  echo "Debug-level lines will only appear once traffic or reconciliation happens — this doesn't send a synthetic request."
+else
+  echo "error: patch did not take — ${CONFIGMAP} does not show level: ${LEVEL} after patching" >&2
+  exit 1
+fi

--- a/.claude/skills/ma-sandbox-setup/SKILL.md
+++ b/.claude/skills/ma-sandbox-setup/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: ma-sandbox-setup
+description: Canonical setup sequence for the Michelangelo local sandbox. Use when setting up a new dev machine, diagnosing sandbox issues, or helping someone get unstuck during sandbox creation. Also applies when checking prereqs or explaining what each step does.
+user-invocable: true
+---
+
+# Michelangelo Sandbox Setup Reference
+
+## Prereqs
+
+Install the required tools if they are not already on your PATH:
+
+```bash
+brew install k3d       # cluster manager (v5.x)
+brew install helm      # Kubernetes package manager
+# kubectl comes with Docker Desktop, or: brew install kubectl
+```
+
+Verify all five are on PATH before proceeding:
+
+```bash
+which k3d helm kubectl docker poetry
+```
+
+IF any command prints "not found" or returns no output: **STOP**. Report which tools are missing and do not proceed to the next step.
+
+**Docker resource limits:** Ensure your Docker runtime (Docker Desktop or Colima) has at least 4 CPUs, 8 GB memory, and 60 GB disk allocated, or pods will crash or fail to schedule.
+
+## Full ordered setup sequence
+
+### 1. Install Python dependencies
+
+```bash
+cd <repo-root>/python
+poetry install
+```
+
+This must be done before any `ma` CLI commands. If skipped, `ma` will fail with an import error because its Python dependencies aren't installed.
+
+### 2. Install the plugin extra (Ray + Spark — optional)
+
+Skip this if you're only doing UI or apiserver work. Required if you'll run or develop pipelines that use Ray or Spark compute:
+
+```bash
+poetry install --extras plugin
+```
+
+### 3. Build kuberay images (required for Ray history-server)
+
+```bash
+bash "$REPO_ROOT/scripts/kuberay/build-kuberay-images.sh"
+```
+
+Without this, `kuberay-historyserver` will be stuck in `ImagePullBackOff` after create — the image isn't in any public registry. Ray jobs still work without it, but the build step is cheap and avoids the noise.
+
+### 4. Activate the venv and create the sandbox
+
+```bash
+REPO_ROOT=$(git rev-parse --show-toplevel)
+source "$REPO_ROOT/python/.venv/bin/activate"     # or prefix every command with: poetry run
+
+ma sandbox create
+```
+
+### 5. Seed demo data
+
+```bash
+cd "$REPO_ROOT/python"
+poetry run ma sandbox demo pipeline
+```
+
+This creates the `ma-dev-test` project with training, eval, and trigger pipelines. Without this step the UI will load but show no data.
+
+### 6. Verify
+
+```bash
+poetry run ma sandbox health
+```
+
+All checks should pass. Then open **http://localhost:8090** — navigate to the `ma-dev-test` project.
+
+## Key commands
+
+| Command                     | What it does                                                    |
+| --------------------------- | --------------------------------------------------------------- |
+| `ma sandbox create`         | Create cluster + deploy all services                            |
+| `ma sandbox sync`           | Restart app services in an existing cluster (fast, skips infra) |
+| `ma sandbox health`         | Run health checks: cluster, pods, API resources, envoy, UI      |
+| `ma sandbox stop`           | Stop the cluster (preserves state)                              |
+| `ma sandbox start`          | Resume a stopped cluster                                        |
+| `ma sandbox delete`         | Tear down cluster entirely                                      |
+| `ma sandbox demo pipeline`  | Deploy pipeline demo resources                                  |
+| `ma sandbox demo inference` | Deploy inference server demo resources                          |
+
+## Debugging tools
+
+If the UI loads but shows no data, or services aren't behaving as expected, use `/ma-sandbox-debug`.
+
+## Known gotchas
+
+**k3d 5.9.0 + k3s version** — k3d 5.9.0 defaulted to k3s v1.35.5 (pre-release, broken). `sandbox.py` now pins `rancher/k3s:v1.30.5-k3s1` explicitly. If you see the API server never come up after `ma sandbox create`, check that you're on a recent checkout.
+
+**`cadence-schema-init` / `ingester-schema-init` / `sandbox-bucket-setup`** — these reach `Completed` status and stay there. That's expected.
+
+## Further reading
+
+Full docs: `docs/getting-started/ma-sandbox-setup.md`.

--- a/.claude/skills/ma-sandbox-test-plan/SKILL.md
+++ b/.claude/skills/ma-sandbox-test-plan/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: ma-sandbox-test-plan
+description: >-
+  Build, test, and verify a sandbox change across Go, JS, and Python.
+  Use when the user asks to verify a change or generate evidence that a feature works.
+argument-hint: <description of what changed>
+user-invocable: true
+---
+
+A pipeline that gates on failure at every stage. The output of each stage IS the evidence —
+don't summarize it away. See `.claude/skills/ma-sandbox-references/evidence-quality.md` for what makes evidence good vs. hollow.
+
+## Stage 0: Detect stack
+
+```bash
+CHANGED_FILES=$(git diff --name-only origin/main...HEAD)
+```
+
+Categorize by path prefix: `go/` → Go, `javascript/` → JS, `python/` → Python. Mixed changes run every
+applicable stage below, once per stack, each gated independently — a Go build failure doesn't block
+the JS pipeline from also reporting its own result.
+
+## Stage 1: Build + lint (gate)
+
+| Stack | Commands |
+|-------|----------|
+| Go | `go build ./cmd/<service>/...` for each changed `go/cmd/<service>/`; `go vet ./go/components/...` |
+| JS | `yarn typecheck`, `yarn lint` |
+| Python | `poetry check` |
+
+**On any failure: stop that stack's pipeline, report the command and full error output, and do not
+proceed to Stage 2 for that stack.** Other stacks (in a mixed change) still run independently.
+
+## Stage 2: Unit tests (gate)
+
+Scope to the packages/dirs actually touched — derive this from Stage 0's `$CHANGED_FILES` directly,
+there's no fixed mapping table to maintain:
+
+| Stack | Command |
+|-------|---------|
+| Go | `go test ./<dir>/...` for each unique directory containing a changed `.go` file under `go/components/` or `go/cmd/` |
+| JS | `yarn test <changed-dir-glob>` (this repo runs `vitest --run`, which accepts path filters) |
+| Python | `pytest <changed-dir>` |
+
+**On failure: stop, report the failing test output, do not proceed to Stage 3 for that stack.**
+
+## Stage 3: Integration setup
+
+Only reached for stacks whose Stage 1–2 passed.
+
+**Go backend:**
+```bash
+bash $(git rev-parse --show-toplevel)/.claude/skills/ma-sandbox-scripts/check-backend.sh
+```
+| Output | Action |
+|--------|--------|
+| `clean` | No local Go changes deployed — skip Go integration scenarios (Stage 4 Go section), note this in "Known gaps" |
+| `deployed <service>` | Enable debug logging before capturing any evidence: `bash $(git rev-parse --show-toplevel)/.claude/skills/ma-sandbox-scripts/set_log_level.sh <service> debug` |
+| `needs-deploy <service>` | **Stop and respond**: "You have local changes to `<service>` that aren't deployed. Run `/ma-sandbox-deploy` first, then re-run `/ma-sandbox-test-plan`." Do not proceed for this stack. |
+
+**JavaScript UI:**
+```bash
+VITE_INFO=$(bash $(git rev-parse --show-toplevel)/.claude/skills/ma-sandbox-scripts/find-vite-port.sh)
+VITE_PORT=$(echo "$VITE_INFO" | awk '{print $1}')
+VITE_PID=$(echo "$VITE_INFO" | awk '{print $2}')
+VITE_MODE=$(echo "$VITE_INFO" | awk '{print $3}')  # "existing" or "started"
+```
+- Exit 0 → use `$VITE_PORT` in place of `5173` in all URLs below. Record `$VITE_MODE`/`$VITE_PID` for cleanup.
+- Non-zero exit → **stop immediately and report the failure.** Do not fall back to guessing a port via curl/lsof — a successful response doesn't confirm which branch is being served.
+- If the Go backend is *also* deployed (Stage 3 said `deployed <service>`), use the full sandbox at `http://localhost:8090` instead of Vite, and skip straight to Stage 4.
+
+**Python:**
+```bash
+poetry run ma sandbox health
+```
+Confirm the services relevant to the change are running.
+
+## Stage 4: Integration scenarios
+
+Before running scenarios, list the code paths identified from the diff and note any paths skipped — this list becomes the "Known gaps" input for Stage 5.
+
+### Go
+
+For each controller/reconcile path touched by the diff:
+
+1. Apply a named test CR (`test-<feature>-<scenario>` — see `.claude/skills/ma-sandbox-references/sandbox-data.md` for demo-data
+   conventions; prefer creating a new entity over disturbing shared demo state, per evidence principle 7).
+2. Capture logs scoped to that resource:
+   ```bash
+   bash $(git rev-parse --show-toplevel)/.claude/skills/ma-sandbox-scripts/capture_service_logs.sh <service> --resource <test-name>
+   ```
+3. Verify state independently via `kubectl get`/`kubectl describe` — don't rely on logs alone.
+4. Show the full lifecycle: creation, intermediate phase transitions, terminal state, and (if the diff
+   touches them) immutability enforcement or garbage collection. See `.claude/skills/ma-sandbox-references/evidence-quality.md` #8–9.
+
+### JavaScript
+
+1. **Playwright setup.** Use `playwright-1`. Clean up stale screenshots: `rm -f .claude/ma-sandbox-test-plan-*.png`
+2. **Derive the route.** Read `.claude/skills/ma-sandbox-references/routes.md` for the phase/entity keyword tables and resolution
+   algorithm. Resolve phase and entity as independent signals, then combine. No matching row → stop and
+   report, don't guess.
+3. **Navigate and check preconditions.**
+   - `browser_snapshot` to confirm the page loaded (no error boundary, no blank state) — stop and report if it didn't.
+   - Read `.claude/skills/ma-sandbox-references/sandbox-data.md` for what state each feature needs. If the required entity/state is
+     missing, create it (prefer the UI over a full re-seed) and document every setup step taken.
+   - Do not use yab/curl/direct API calls for setup — `kubectl` for inspection, UI or `ma` CLI for creation.
+4. **Exercise the feature** — click, fill, trigger the interactions the description calls for.
+5. **Screenshot after each meaningful state:** `browser_take_screenshot` → `.claude/ma-sandbox-test-plan-{state-name}.png`.
+6. **Check console errors:** `browser_console_messages(level: "error")`. Classify:
+
+   | Classification | Matches |
+   |---------------|---------|
+   | **Blocking** | `Uncaught`, `TypeError`, `ReferenceError`, `Failed to fetch`, `Cannot read properties`, React render error |
+   | **Non-blocking** | `deprecated`, `404 /favicon`, `CORS preflight`, `OPTIONS`, `sourceMap`, `net::ERR_ABORTED` for known-missing mock data |
+
+   Anything matching neither list: treat as **Blocking** (unknown = assume blocking).
+
+### Python
+
+1. Run the relevant CLI commands or `kubectl apply` the relevant resources.
+2. Capture service logs (`capture_service_logs.sh`) and CLI stdout/stderr.
+3. Verify state via `kubectl get`.
+
+## Stage 5: Report
+
+Print the integration evidence following `.claude/skills/ma-sandbox-references/evidence-quality.md`'s guidance.
+Build/lint/unit-test results from stages 1–2 are gates, not evidence — don't include them (CI covers that).
+
+## Cleanup
+
+- **If Vite was started by this run** (`$VITE_MODE` = `started`): ask "I started a Vite dev server (PID
+  `$VITE_PID`) for this session. Kill it now?" If yes: `kill "$VITE_PID"`. If `$VITE_MODE` = `existing`,
+  leave it alone.
+- **If log level was changed in Stage 3:** ask whether to revert — `bash $(git rev-parse --show-toplevel)/.claude/skills/ma-sandbox-scripts/set_log_level.sh <service> info`.
+- **Test CRs left in the cluster:** list them in the report. Don't auto-delete — the user may want to
+  inspect them further or reuse them for a follow-up run.


### PR DESCRIPTION
## Summary

Five skills (setup, deploy, debug, reset, test-plan) give agents structured workflows for operating a local Michelangelo k3d sandbox. These skills were built during the implementation of #1314, #1268, #1145 to help facilitate the hot swapping of apiserver/controllermgr with local changes.

Some key design decisions include:

- Evidence guidance to encourage positive verification (eg revision created when pipeline controller reconciled) and discourage reiterating what CICD proves. 
- Helper scripts to increase determinism of skills. For example, it's common for me to have multiple vite dev servers running. Vite automatically increments which port is uses. This is important because we want test-plan to be running against the dev server with the changes.

## Test plan

https://github.com/user-attachments/assets/7eba486e-0d2d-406c-b4df-81dabfeabdd0


