### PR TITLE
chore: add ma-sandbox-debug Claude Code skill

### DIFF
--- a/.claude/skills/ma-sandbox-debug/SKILL.md
+++ b/.claude/skills/ma-sandbox-debug/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: ma-sandbox-debug
+description: Tail logs, inspect pods, and diagnose unhealthy services in a running Michelangelo sandbox. Use when a service is crashlooping, returning errors, or not responding as expected. Triggers on "check logs", "why is X failing", "debug sandbox", "kubectl logs".
+user-invocable: true
+---
+
+# Sandbox Debug
+
+Diagnosing service failures in a running sandbox. Start with health overview, then drill into specific services.
+
+## Step 1: Health overview
+
+```bash
+ma sandbox health        # high-level check: cluster, pods, API, envoy, UI
+kubectl get pods -A      # full pod inventory with status
+```
+
+**IF** `kubectl get pods -A` output contains any pod in `CrashLoopBackOff`, `Error`, or `ImagePullBackOff` state (excluding expected noise listed below): **proceed to Step 3** for each affected pod.
+
+**IF** a pod is stuck `Pending` beyond 3 minutes: **proceed to Step 3** for that pod.
+
+**IF** all pods show `Running` or `Completed`: report the cluster as healthy and stop — do not continue to Step 2 unless the user reports a specific symptom.
+
+## Step 2: Tail logs by service
+
+```bash
+# apiserver — handles all API requests (Go)
+kubectl logs -f deployment/michelangelo-apiserver
+
+# worker — handles async tasks
+kubectl logs -f deployment/michelangelo-worker
+
+# controller manager
+kubectl logs -f deployment/michelangelo-controllermgr
+
+# envoy — ingress proxy (proxy errors appear here, not in apiserver)
+kubectl logs -f deployment/michelangelo-envoy
+
+# UI — nginx serving the frontend bundle
+kubectl logs -f deployment/michelangelo-ui
+```
+
+Useful flags: `--tail=100` to limit output; `--previous` to see logs from the last crashed container instance.
+
+## Need more verbose logs?
+
+Go services default to `info` level. Enable debug logging for deeper investigation:
+
+```bash
+bash $(git rev-parse --show-toplevel)/.claude/skills/ma-sandbox-scripts/set_log_level.sh controllermgr debug
+```
+
+Revert when done: replace `debug` with `info`. Pair with `$(git rev-parse --show-toplevel)/.claude/skills/ma-sandbox-scripts/capture_service_logs.sh` to filter the resulting output down to signal.
+
+## Step 3: Inspect a crashing pod
+
+```bash
+# Get the pod name
+kubectl get pods -l app.kubernetes.io/component=apiserver
+
+# Events and last exit reason
+kubectl describe pod <pod-name>
+
+# Logs from the previous crashed instance
+kubectl logs <pod-name> --previous
+```
+
+The **Events** section and **Last State** (exit code, reason) in `describe` output are the most diagnostic fields.
+
+## Common failure patterns
+
+| Symptom | Where to look | Likely cause |
+|---------|--------------|--------------|
+| UI loads, API returns 503 | envoy logs | Envoy can't reach apiserver |
+| UI loads but shows no data | `kubectl get projects,pipelines,pipelineruns -A` | No demo data seeded — run `ma sandbox demo pipeline`. If resources exist but UI is empty, check envoy logs |
+| API returns 500 | apiserver logs | Go panic or DB connection error |
+| Pod in `CrashLoopBackOff` | `describe pod`, `--previous` logs | OOM, missing config, bad binary |
+| Pod stuck `Pending` | `describe pod` Events | No node resources or PVC mount failure |
+| `ImagePullBackOff` | `describe pod` Events | Image not imported — run `k3d image import` |
+| Feature broken after deploy | apiserver logs | Business logic bug in the deployed binary |
+| `create` failed partway / "cluster already exists" | — | Run `ma sandbox sync` to finish — don't delete+recreate |
+
+## Filter logs for errors
+
+```bash
+kubectl logs deployment/michelangelo-apiserver | grep -i "error\|panic\|fatal"
+kubectl logs deployment/michelangelo-worker --tail=200
+```
+
+## Force-restart a stuck service
+
+When a service isn't crashing but isn't picking up new config or code:
+
+```bash
+kubectl rollout restart deployment/michelangelo-apiserver
+kubectl rollout status deployment/michelangelo-apiserver --timeout=60s
+```
+
+## Expected noise (not actual errors)
+
+- `cadence-schema-init`, `ingester-schema-init`, `sandbox-bucket-setup` — reach `Completed` and stay there; this is correct
+- `ray-history-server` in `ImagePullBackOff` — non-blocking; Ray jobs still work without it
+
+## Still stuck?
+
+If the cluster state is unrecoverable, do a full reset: `/ma-sandbox-reset`.

--- a/.claude/skills/ma-sandbox-scripts/capture_service_logs.sh
+++ b/.claude/skills/ma-sandbox-scripts/capture_service_logs.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Filters kubectl logs for a Michelangelo service into clean, PR-ready JSON lines.
+#
+#   capture_service_logs.sh <service> [--resource NAME] [--component NAME] \
+#                            [--level LVL] [--exclude PATTERN] [--tail N]
+#
+# Assumes the service is emitting zap's default JSON encoding (go/base/zapfx,
+# zap.NewProductionEncoderConfig) — run set_log_level.sh first if it isn't.
+# Non-JSON lines are dropped rather than erroring, since a service can still
+# emit occasional plain-text startup lines before logging is configured.
+#
+# By default, strips YARPC's per-RPC observability tracing lines
+# ("Handled inbound request." / "Made outbound call.", logged at debug level
+# by go.uber.org/yarpc's built-in middleware) — this is the noise that makes
+# raw debug logs unreadable.
+
+set -euo pipefail
+
+SERVICE="${1:-}"
+shift || true
+
+usage() {
+  echo "Usage: $(basename "$0") <apiserver|controllermgr|worker> [--resource NAME] [--component NAME] [--level LVL] [--exclude PATTERN] [--tail N]" >&2
+  exit 1
+}
+
+case "$SERVICE" in
+  apiserver|controllermgr|worker) ;;
+  *) echo "error: unknown service '$SERVICE'" >&2; usage ;;
+esac
+
+RESOURCE=""
+COMPONENT=""
+LEVEL=""
+EXCLUDE=""
+TAIL="200"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --resource) RESOURCE="$2"; shift 2 ;;
+    --component) COMPONENT="$2"; shift 2 ;;
+    --level) LEVEL="$2"; shift 2 ;;
+    --exclude) EXCLUDE="$2"; shift 2 ;;
+    --tail) TAIL="$2"; shift 2 ;;
+    *) echo "error: unknown argument '$1'" >&2; usage ;;
+  esac
+done
+
+command -v kubectl >/dev/null 2>&1 || { echo "error: kubectl not found on PATH" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "error: jq not found on PATH" >&2; exit 1; }
+
+DEPLOYMENT="michelangelo-${SERVICE}"
+
+# Build the jq filter incrementally. Drop non-JSON lines first (`fromjson? //
+# empty`), then the always-on tracing-noise filter, then each opt-in filter.
+JQ_FILTER='fromjson? // empty'
+JQ_FILTER="$JQ_FILTER | select(.msg != \"Handled inbound request.\" and .msg != \"Made outbound call.\" and .msg != \"Error handling inbound request.\" and .msg != \"Error making outbound call.\")"
+
+if [ -n "$LEVEL" ]; then
+  JQ_FILTER="$JQ_FILTER | select(.level == \$level)"
+fi
+if [ -n "$COMPONENT" ]; then
+  JQ_FILTER="$JQ_FILTER | select(.component == \$component)"
+fi
+if [ -n "$RESOURCE" ]; then
+  # Identity field names vary by controller (name, namespace-name, pipelineRun,
+  # ...), so match by substring against the whole serialized line instead of
+  # hardcoding one field.
+  JQ_FILTER="$JQ_FILTER | select(tostring | contains(\$resource))"
+fi
+if [ -n "$EXCLUDE" ]; then
+  JQ_FILTER="$JQ_FILTER | select((.msg // \"\") | test(\$exclude) | not)"
+fi
+
+kubectl logs "deployment/${DEPLOYMENT}" --tail="$TAIL" | jq -Rc \
+  --arg level "$LEVEL" \
+  --arg component "$COMPONENT" \
+  --arg resource "$RESOURCE" \
+  --arg exclude "$EXCLUDE" \
+  "$JQ_FILTER"

--- a/.claude/skills/ma-sandbox-scripts/set_log_level.sh
+++ b/.claude/skills/ma-sandbox-scripts/set_log_level.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Sets the zap log level for a Michelangelo Go service running in the local k3d sandbox.
+#
+#   set_log_level.sh <service> <level>
+#     service: apiserver | controllermgr | worker
+#     level:   debug | info | warn | error | dpanic | panic | fatal
+#
+# apiserver/controllermgr ConfigMaps have no `logging:` block by default (only
+# worker's does) — this injects/overwrites a full block rather than editing a
+# field in place. Encoding is always forced to `json` (regardless of the
+# service's helm default) so capture_service_logs.sh can reliably parse it.
+#
+# Config is loaded once at process startup (go/base/config) — there is no
+# hot-reload, so a ConfigMap patch alone does nothing until the deployment
+# is restarted. This script does both and verifies the ConfigMap afterward.
+
+set -euo pipefail
+
+SERVICE="${1:-}"
+LEVEL="${2:-}"
+
+usage() {
+  echo "Usage: $(basename "$0") <apiserver|controllermgr|worker> <debug|info|warn|error|dpanic|panic|fatal>" >&2
+  exit 1
+}
+
+case "$SERVICE" in
+  apiserver|controllermgr|worker) ;;
+  *) echo "error: unknown service '$SERVICE'" >&2; usage ;;
+esac
+
+case "$LEVEL" in
+  debug|info|warn|error|dpanic|panic|fatal) ;;
+  *) echo "error: unknown level '$LEVEL'" >&2; usage ;;
+esac
+
+CONFIGMAP="michelangelo-${SERVICE}-config"
+DEPLOYMENT="michelangelo-${SERVICE}"
+
+command -v kubectl >/dev/null 2>&1 || { echo "error: kubectl not found on PATH" >&2; exit 1; }
+
+# PyYAML isn't guaranteed on the system python3, but it's already a dependency
+# of the michelangelo repo's poetry venv (used for the `ma` CLI). Prefer that
+# venv's interpreter when available, falling back to system python3.
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || true)
+PYTHON_BIN="python3"
+if [ -n "$REPO_ROOT" ] && [ -x "$REPO_ROOT/python/.venv/bin/python3" ]; then
+  PYTHON_BIN="$REPO_ROOT/python/.venv/bin/python3"
+fi
+
+"$PYTHON_BIN" -c "import yaml" 2>/dev/null || {
+  echo "error: PyYAML not importable via '$PYTHON_BIN'. Activate the repo's python venv (source python/.venv/bin/activate) and retry." >&2
+  exit 1
+}
+
+echo "Reading ConfigMap/${CONFIGMAP}..."
+CURRENT_YAML=$(kubectl get configmap "$CONFIGMAP" -o jsonpath='{.data.base\.yaml}')
+
+PATCH_JSON=$(CURRENT_YAML="$CURRENT_YAML" "$PYTHON_BIN" - "$LEVEL" <<'PYEOF'
+import os
+import sys
+import json
+import yaml
+
+level = sys.argv[1]
+current_yaml = os.environ["CURRENT_YAML"]
+
+doc = yaml.safe_load(current_yaml) or {}
+doc["logging"] = {"level": level, "development": False, "encoding": "json"}
+
+new_yaml = yaml.dump(doc, default_flow_style=False, sort_keys=False)
+print(json.dumps({"data": {"base.yaml": new_yaml}}))
+PYEOF
+)
+
+echo "Patching ConfigMap/${CONFIGMAP} (logging.level=${LEVEL}, encoding=json)..."
+kubectl patch configmap "$CONFIGMAP" --type merge -p "$PATCH_JSON" >/dev/null
+
+echo "Restarting deployment/${DEPLOYMENT}..."
+kubectl rollout restart "deployment/${DEPLOYMENT}" >/dev/null
+kubectl rollout status "deployment/${DEPLOYMENT}" --timeout=60s
+
+NEW_YAML=$(kubectl get configmap "$CONFIGMAP" -o jsonpath='{.data.base\.yaml}')
+if echo "$NEW_YAML" | grep -q "level: ${LEVEL}"; then
+  echo "Verified: ${CONFIGMAP} now has logging.level=${LEVEL}."
+  echo "Debug-level lines will only appear once traffic or reconciliation happens — this doesn't send a synthetic request."
+else
+  echo "error: patch did not take — ${CONFIGMAP} does not show level: ${LEVEL} after patching" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Adds a Claude Code skill for tailing logs, inspecting pods, and diagnosing unhealthy services in a running sandbox — for when a service is crashlooping, returning errors, or not responding as expected.

Its triggers exist so a service-level issue gets fixed in place instead of escalating to a full sandbox reset. Includes `set_log_level.sh` and `capture_service_logs.sh`, the two helper scripts this skill needs for deterministic output the agent can branch on.

## Test plan

**Full run of skill suite**

https://github.com/user-attachments/assets/a9c6f712-c76e-47bd-bcbb-f8b07910dbd8