### PR TITLE
feat(core): add test-utils subpath export

### DIFF
--- a/javascript/app/config/entities/deployment/__tests__/deployment-page.test.tsx
+++ b/javascript/app/config/entities/deployment/__tests__/deployment-page.test.tsx
@@ -1,20 +1,18 @@
+import {
+  buildWrapper,
+  createQueryMockRouter,
+  getConfigProviderWrapper,
+  getErrorProviderWrapper,
+  getRouterWrapper,
+  getServiceProviderWrapper,
+} from '@michelangelo-ai/core/test-utils';
 import { render, screen } from '@testing-library/react';
 import { vi } from 'vitest';
 
-// NOTE: these test utilities and route components are internal to packages/core and are not
-// part of its public export surface, so this test — which moved to app/config with the rest
-// of the deployment entity config — reaches into core's source tree via a relative path
-// rather than through the package's public API. See PR 2 of the config extraction plan.
+// NOTE: these route components are internal to packages/core and are not part of its public
+// export surface. The test wrappers are available via the test-utils subpath export.
 import { EntityDetailRoute } from '../../../../../packages/core/router/entity-detail-route';
 import { PhaseListRoute } from '../../../../../packages/core/router/phase-list-route';
-import { buildWrapper } from '../../../../../packages/core/test/wrappers/build-wrapper';
-import { getConfigProviderWrapper } from '../../../../../packages/core/test/wrappers/get-config-provider-wrapper';
-import { getErrorProviderWrapper } from '../../../../../packages/core/test/wrappers/get-error-provider-wrapper';
-import { getRouterWrapper } from '../../../../../packages/core/test/wrappers/get-router-wrapper';
-import {
-  createQueryMockRouter,
-  getServiceProviderWrapper,
-} from '../../../../../packages/core/test/wrappers/get-service-provider-wrapper';
 import { DEPLOY_PHASE } from '../../../phases/deploy';
 import { DEPLOYMENT_CONDITION_STATUS, DEPLOYMENT_STAGE, DEPLOYMENT_STATE } from '../shared';
 

--- a/javascript/app/config/entities/pipeline/__tests__/create-pipeline-run-form.test.tsx
+++ b/javascript/app/config/entities/pipeline/__tests__/create-pipeline-run-form.test.tsx
@@ -1,21 +1,17 @@
 import { useState } from 'react';
+import {
+  buildWrapper,
+  createQueryMockRouter,
+  getBaseProviderWrapper,
+  getErrorProviderWrapper,
+  getIconProviderWrapper,
+  getInterpolationProviderWrapper,
+  getRouterWrapper,
+  getServiceProviderWrapper,
+} from '@michelangelo-ai/core/test-utils';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-// NOTE: these test utilities are internal to packages/core and are not part of its public
-// export surface, so this test — which moved to app/config with the rest of the pipeline
-// entity config — reaches into core's source tree via a relative path rather than through
-// the package's public API. See PR 2 of the config extraction plan for context.
-import { buildWrapper } from '../../../../../packages/core/test/wrappers/build-wrapper';
-import { getBaseProviderWrapper } from '../../../../../packages/core/test/wrappers/get-base-provider-wrapper';
-import { getErrorProviderWrapper } from '../../../../../packages/core/test/wrappers/get-error-provider-wrapper';
-import { getIconProviderWrapper } from '../../../../../packages/core/test/wrappers/get-icon-provider-wrapper';
-import { getInterpolationProviderWrapper } from '../../../../../packages/core/test/wrappers/get-interpolation-provider-wrapper';
-import { getRouterWrapper } from '../../../../../packages/core/test/wrappers/get-router-wrapper';
-import {
-  createQueryMockRouter,
-  getServiceProviderWrapper,
-} from '../../../../../packages/core/test/wrappers/get-service-provider-wrapper';
 import { CreatePipelineRunForm } from '../create-pipeline-run-form';
 
 describe('CreatePipelineRunForm', () => {

--- a/javascript/app/config/entities/targets/__tests__/target-page.test.tsx
+++ b/javascript/app/config/entities/targets/__tests__/target-page.test.tsx
@@ -1,20 +1,18 @@
+import {
+  buildWrapper,
+  createQueryMockRouter,
+  getConfigProviderWrapper,
+  getErrorProviderWrapper,
+  getRouterWrapper,
+  getServiceProviderWrapper,
+} from '@michelangelo-ai/core/test-utils';
 import { render, screen } from '@testing-library/react';
 import { vi } from 'vitest';
 
-// NOTE: these test utilities and route components are internal to packages/core and are not
-// part of its public export surface, so this test — which moved to app/config with the rest
-// of the targets entity config — reaches into core's source tree via a relative path rather
-// than through the package's public API. See PR 2 of the config extraction plan for context.
+// NOTE: these route components are internal to packages/core and are not part of its public
+// export surface. The test wrappers are available via the test-utils subpath export.
 import { EntityDetailRoute } from '../../../../../packages/core/router/entity-detail-route';
 import { PhaseListRoute } from '../../../../../packages/core/router/phase-list-route';
-import { buildWrapper } from '../../../../../packages/core/test/wrappers/build-wrapper';
-import { getConfigProviderWrapper } from '../../../../../packages/core/test/wrappers/get-config-provider-wrapper';
-import { getErrorProviderWrapper } from '../../../../../packages/core/test/wrappers/get-error-provider-wrapper';
-import { getRouterWrapper } from '../../../../../packages/core/test/wrappers/get-router-wrapper';
-import {
-  createQueryMockRouter,
-  getServiceProviderWrapper,
-} from '../../../../../packages/core/test/wrappers/get-service-provider-wrapper';
 import { DEPLOY_PHASE } from '../../../phases/deploy';
 import { CONDITION_STATUS, INFERENCE_SERVER_STATE } from '../shared';
 

--- a/javascript/app/config/entities/trigger/__tests__/trigger.test.tsx
+++ b/javascript/app/config/entities/trigger/__tests__/trigger.test.tsx
@@ -1,22 +1,20 @@
+import {
+  buildWrapper,
+  createQueryMockRouter,
+  getBaseProviderWrapper,
+  getErrorProviderWrapper,
+  getIconProviderWrapper,
+  getInterpolationProviderWrapper,
+  getRouterWrapper,
+  getServiceProviderWrapper,
+  getSnackbarProviderWrapper,
+} from '@michelangelo-ai/core/test-utils';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-// NOTE: these test utilities and this component are internal to packages/core and are not
-// part of its public export surface, so this test — which moved to app/config with the rest
-// of the trigger entity config — reaches into core's source tree via a relative path rather
-// than through the package's public API. See PR 2 of the config extraction plan for context.
+// NOTE: this component is internal to packages/core and is not part of its public export
+// surface. The test wrappers are available via the test-utils subpath export.
 import { InterpolatableActionsPopover } from '../../../../../packages/core/components/actions/interpolatable-actions-popover';
-import { buildWrapper } from '../../../../../packages/core/test/wrappers/build-wrapper';
-import { getBaseProviderWrapper } from '../../../../../packages/core/test/wrappers/get-base-provider-wrapper';
-import { getErrorProviderWrapper } from '../../../../../packages/core/test/wrappers/get-error-provider-wrapper';
-import { getIconProviderWrapper } from '../../../../../packages/core/test/wrappers/get-icon-provider-wrapper';
-import { getInterpolationProviderWrapper } from '../../../../../packages/core/test/wrappers/get-interpolation-provider-wrapper';
-import { getRouterWrapper } from '../../../../../packages/core/test/wrappers/get-router-wrapper';
-import {
-  createQueryMockRouter,
-  getServiceProviderWrapper,
-} from '../../../../../packages/core/test/wrappers/get-service-provider-wrapper';
-import { getSnackbarProviderWrapper } from '../../../../../packages/core/test/wrappers/get-snackbar-provider-wrapper';
 import { TRIGGER_ENTITY_CONFIG } from '../trigger';
 import { TriggerRunAction, TriggerRunState } from '../types';
 

--- a/javascript/packages/core/package.json
+++ b/javascript/packages/core/package.json
@@ -79,6 +79,10 @@
       "import": "./dist/primitives.js",
       "require": "./dist/primitives.cjs",
       "default": "./dist/primitives.js"
+    },
+    "./test-utils": {
+      "types": "./test-utils.ts",
+      "workspace": "./test-utils.ts"
     }
   },
   "imports": {

--- a/javascript/packages/core/test-utils.ts
+++ b/javascript/packages/core/test-utils.ts
@@ -1,0 +1,18 @@
+export { buildWrapper } from './test/wrappers/build-wrapper';
+export { getBaseProviderWrapper } from './test/wrappers/get-base-provider-wrapper';
+export { getCellProviderWrapper } from './test/wrappers/get-cell-provider-wrapper';
+export { getConfigProviderWrapper } from './test/wrappers/get-config-provider-wrapper';
+export { getErrorProviderWrapper } from './test/wrappers/get-error-provider-wrapper';
+export { getFormProviderWrapper } from './test/wrappers/get-form-provider-wrapper';
+export { getIconProviderWrapper } from './test/wrappers/get-icon-provider-wrapper';
+export { getInterpolationProviderWrapper } from './test/wrappers/get-interpolation-provider-wrapper';
+export { getRepeatedLayoutProviderWrapper } from './test/wrappers/get-repeated-layout-provider-wrapper';
+export { getRouterWrapper } from './test/wrappers/get-router-wrapper';
+export {
+  createQueryMockRouter,
+  createServiceProviderTestContext,
+  getServiceProviderWrapper,
+} from './test/wrappers/get-service-provider-wrapper';
+export { getSnackbarProviderWrapper } from './test/wrappers/get-snackbar-provider-wrapper';
+export { getUserProviderWrapper } from './test/wrappers/get-user-provider-wrapper';
+export type { WrapperComponentProps, Wrappers } from './test/wrappers/types';


### PR DESCRIPTION
## Summary

Consumer app tests used deep relative paths (`../../../../../packages/core/test/wrappers/...`) to reach core's test wrappers after config extraction moved tests to `app/`. A `@michelangelo-ai/core/test-utils` subpath export provides a stable import path across the package boundary.

## Test plan

unit tests & CICD
🤖 Generated with [Claude Code](https://claude.com/claude-code)