### PR TITLE
fix(storage/mysql): implement directUpdate for the generic Update RPC

### DIFF
--- a/go/api/handler/handler.go
+++ b/go/api/handler/handler.go
@@ -185,6 +185,11 @@ func (handler *apiHandler) Update(ctx context.Context, obj ctrlRTClient.Object, 
 		if err != nil {
 			return surfaceGrpcError(err, "update", tmpObj.GetNamespace(), tmpObj.GetName())
 		}
+		// tmpObj is a deep copy, so the resource version metadata storage assigned lives
+		// only on the copy. Copy it onto the caller's object, which the generated service
+		// layer returns to the client as the response body.
+		obj.SetResourceVersion(tmpObj.GetResourceVersion())
+		return nil
 	}
 
 	return surfaceGrpcError(err, "update", tmpObj.GetNamespace(), tmpObj.GetName())

--- a/go/api/handler/handler_test.go
+++ b/go/api/handler/handler_test.go
@@ -979,3 +979,65 @@ func TestUpdateReturnsMetadataStorageResourceVersion(t *testing.T) {
 	assert.Equal(t, "8", testJob.GetResourceVersion(),
 		"the resource version assigned by metadata storage must reach the caller's object")
 }
+
+// TestUpdateEchoesCallerSpecForMetadataOnlyObjects covers the response half of a
+// register_model re-registration: the object exists only in metadata storage, so Update
+// takes the metadata-only direct path and drops the incoming spec, but returns the
+// caller's own object rather than a read-back. The client is therefore handed the artifact
+// URI it just sent while storage still holds the previous one.
+func TestUpdateEchoesCallerSpecForMetadataOnlyObjects(t *testing.T) {
+	k8sClient, err := setupK8s()
+	assert.NoError(t, err)
+
+	mockMetadataStorage, mockBlobStorage := setupMocks(t)
+
+	config := storage.MetadataStorageConfig{
+		EnableMetadataStorage:      true,
+		DeletionDelay:              0,
+		EnableResourceVersionCache: false,
+	}
+
+	builder := NewAPIHandlerBuilder().
+		WithK8sClient(k8sClient).
+		WithMetadataStorage(mockMetadataStorage, config).
+		WithBlobStorage(mockBlobStorage).
+		WithZapLogger(zap.Must(zap.NewDevelopment())).
+		WithMetrics(tally.NoopScope)
+	handler, err := builder.Build()
+	assert.NoError(t, err)
+
+	const newArtifactURI = "s3://models/echo/v2/model.pkl"
+
+	// A fresh proto with the new artifact URI and the resource version copied from the
+	// preceding get_model. Absent from K8s, so Update falls through to metadata storage.
+	incoming := &v2pb.Model{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       "default",
+			Name:            "test-metadata-update-echoes-spec",
+			ResourceVersion: "7",
+		},
+		Spec: v2pb.ModelSpec{ModelArtifactUri: []string{newArtifactURI}},
+	}
+
+	mockMetadataStorage.EXPECT().
+		Upsert(gomock.Any(), gomock.Any(), true, gomock.Any()).
+		Times(1).
+		DoAndReturn(func(ctx context.Context, object runtime.Object, direct bool,
+			indexedFields []storage.IndexedField) error {
+			model, ok := object.(*v2pb.Model)
+			assert.True(t, ok)
+			assert.Equal(t, []string{newArtifactURI}, model.Spec.ModelArtifactUri,
+				"storage is handed the new artifact URI; it is storage that drops it")
+			// A metadata-only update: the spec is ignored, only the version advances.
+			model.SetResourceVersion("8")
+			return nil
+		})
+
+	err = handler.Update(context.Background(), incoming, &metav1.UpdateOptions{})
+	assert.NoError(t, err)
+
+	assert.Equal(t, []string{newArtifactURI}, incoming.Spec.ModelArtifactUri,
+		"the object returned to the client keeps the URI it sent, though it was not persisted")
+	assert.Equal(t, "8", incoming.GetResourceVersion(),
+		"the new resource version must still reach the caller")
+}

--- a/go/api/handler/handler_test.go
+++ b/go/api/handler/handler_test.go
@@ -923,3 +923,59 @@ func TestDeletePropagationPolicy(t *testing.T) {
 	assert.Equal(t, "true", annotations[api.DeletingAnnotation])
 	assert.Equal(t, string(foreground), annotations[api.DeletePropagationAnnotation])
 }
+
+// TestUpdateReturnsMetadataStorageResourceVersion covers the metadata-storage branch of
+// Update: the object is deep-copied before being handed to the metadata handler, so the
+// resource version the storage layer assigns must be copied back onto the caller's
+// object — that object is what the generated service layer returns to the client.
+func TestUpdateReturnsMetadataStorageResourceVersion(t *testing.T) {
+	k8sClient, err := setupK8s()
+	assert.NoError(t, err)
+
+	mockMetadataStorage, mockBlobStorage := setupMocks(t)
+
+	config := storage.MetadataStorageConfig{
+		EnableMetadataStorage:      true,
+		DeletionDelay:              0,
+		EnableResourceVersionCache: false,
+	}
+
+	builder := NewAPIHandlerBuilder().
+		WithK8sClient(k8sClient).
+		WithMetadataStorage(mockMetadataStorage, config).
+		WithBlobStorage(mockBlobStorage).
+		WithZapLogger(zap.Must(zap.NewDevelopment())).
+		WithMetrics(tally.NoopScope)
+	handler, err := builder.Build()
+	assert.NoError(t, err)
+
+	// An object that does not exist in K8s, so Update falls through to metadata storage.
+	testJob := &v2pb.RayJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       "default",
+			Name:            "test-metadata-update-resource-version",
+			ResourceVersion: "7",
+		},
+		Spec: v2pb.RayJobSpec{JobId: "test-metadata-update-resource-version"},
+	}
+
+	// Stand in for the MySQL backend: assign a new resource version on the object the
+	// storage layer is handed (which is the handler's deep copy, not testJob).
+	mockMetadataStorage.EXPECT().
+		Upsert(gomock.Any(), gomock.Any(), true, gomock.Any()).
+		Times(1).
+		DoAndReturn(func(ctx context.Context, object runtime.Object, direct bool,
+			indexedFields []storage.IndexedField) error {
+			metaObj, ok := object.(metav1.Object)
+			assert.True(t, ok)
+			assert.Equal(t, "7", metaObj.GetResourceVersion(),
+				"storage must see the resource version the caller sent")
+			metaObj.SetResourceVersion("8")
+			return nil
+		})
+
+	err = handler.Update(context.Background(), testJob, &metav1.UpdateOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, "8", testJob.GetResourceVersion(),
+		"the resource version assigned by metadata storage must reach the caller's object")
+}

--- a/go/storage/mysql/BUILD.bazel
+++ b/go/storage/mysql/BUILD.bazel
@@ -41,5 +41,7 @@ go_test(
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_apimachinery//pkg/types:go_default_library",
+        "@org_golang_google_grpc//codes:go_default_library",
+        "@org_golang_google_grpc//status:go_default_library",
     ],
 )

--- a/go/storage/mysql/mysql.go
+++ b/go/storage/mysql/mysql.go
@@ -145,7 +145,19 @@ func (m *mysqlMetadataStorage) Upsert(ctx context.Context, object runtime.Object
 	if direct {
 		// Direct update: only update labels, annotations, and resource version
 		// Check resource version for optimistic concurrency control
-		return m.directUpdate(ctx, tx, tableName, metaObj, object)
+		newResVersion, directErr := m.directUpdate(ctx, tx, tableName, metaObj, object)
+		if directErr != nil {
+			return directErr
+		}
+		if commitErr := tx.Commit(); commitErr != nil {
+			return status.Errorf(codes.Internal, "failed to commit direct update: %v", commitErr)
+		}
+		// Hand the new resource version back through the object the caller passed in.
+		// Only after a successful commit, so a failed commit never yields a version the
+		// database does not have. Per the MetadataStorage contract, this version must not
+		// be used for listing or watching.
+		metaObj.SetResourceVersion(strconv.FormatUint(newResVersion, 10))
+		return nil
 	}
 
 	// Full upsert: update all fields. Compute the stable primary key once so the main
@@ -1196,8 +1208,212 @@ func (m *mysqlMetadataStorage) fullUpsert(ctx context.Context, tx *sql.Tx, table
 	return nil
 }
 
-func (m *mysqlMetadataStorage) directUpdate(ctx context.Context, tx *sql.Tx, tableName string, metaObj metav1.Object, object runtime.Object) error {
-	return status.Errorf(codes.Unimplemented, "direct update not yet implemented")
+// directUpdateManagedLabels and directUpdateManagedAnnotations are the label and
+// annotation keys that Michelangelo itself owns.
+//
+// A direct update replaces the caller's label and annotation sets wholesale, matching
+// Kubernetes PUT semantics. But callers of the generic Update RPC routinely build a
+// fresh object rather than doing read-modify-write, so a strict replace would silently
+// destroy server-managed state — the immutability marker, the migration primary key, and
+// the timestamp label that List supports as an ORDER BY key. These keys are therefore
+// carried over from the stored object when, and only when, the incoming object does not
+// supply them at all; an explicitly supplied value always wins.
+var (
+	directUpdateManagedLabels = []string{
+		api.SpecUpdateTimestampLabel,
+		api.UpdateTimestampLabel,
+	}
+	directUpdateManagedAnnotations = []string{
+		api.MetadataStoragePrimaryKeyAnnotation,
+		api.ImmutableAnnotation,
+		api.DeletingAnnotation,
+		api.DeletePropagationAnnotation,
+	}
+)
+
+// checkResourceVersionPrecondition compares the caller-supplied resource version against
+// the value currently stored on the row.
+//
+// An empty incoming resource version means "no precondition", matching Kubernetes update
+// semantics where an unset resourceVersion on PUT is an unconditional update. A
+// syntactically invalid version is rejected as InvalidArgument rather than as a conflict,
+// because it could never have come from the BIGINT UNSIGNED column. A well-formed version
+// that does not match is a lost update, reported as FailedPrecondition to match the
+// StatusReasonConflict mapping in K8sStatusReasonToGrpcError.
+//
+// The comparison is numeric, not textual, so that a zero-padded version such as "007"
+// still matches the 7 that MySQL returns.
+func checkResourceVersionPrecondition(incoming string, stored uint64) error {
+	if incoming == "" {
+		return nil
+	}
+	parsed, err := strconv.ParseUint(incoming, 10, 64)
+	if err != nil {
+		return status.Errorf(codes.InvalidArgument,
+			"invalid resourceVersion %q: must be a base-10 unsigned integer", incoming)
+	}
+	if parsed != stored {
+		return status.Errorf(codes.FailedPrecondition,
+			"resourceVersion conflict: the object has been modified; stored %d, got %d",
+			stored, parsed)
+	}
+	return nil
+}
+
+// mergeDirectUpdateMetadata overlays the incoming object's labels and annotations, plus
+// the new resource version, onto the stored object. Spec and status are left untouched:
+// on the direct path the stored object is the source of truth for everything except
+// metadata (see the MetadataStorage.Upsert contract).
+//
+// Server-managed keys absent from the incoming object are preserved — see
+// directUpdateManagedLabels / directUpdateManagedAnnotations.
+func mergeDirectUpdateMetadata(stored, incoming metav1.Object, newResVersion uint64) {
+	stored.SetLabels(mergeManagedKeys(stored.GetLabels(), incoming.GetLabels(), directUpdateManagedLabels))
+	stored.SetAnnotations(mergeManagedKeys(stored.GetAnnotations(), incoming.GetAnnotations(), directUpdateManagedAnnotations))
+	stored.SetResourceVersion(strconv.FormatUint(newResVersion, 10))
+}
+
+// mergeManagedKeys returns incoming, plus any key in managedKeys that stored has and
+// incoming does not. Returns nil when the result would be empty, so an object that had no
+// labels keeps a nil map rather than gaining an empty one.
+func mergeManagedKeys(stored, incoming map[string]string, managedKeys []string) map[string]string {
+	merged := make(map[string]string, len(incoming)+len(managedKeys))
+	for k, v := range incoming {
+		merged[k] = v
+	}
+	for _, k := range managedKeys {
+		if _, supplied := merged[k]; supplied {
+			continue
+		}
+		if v, ok := stored[k]; ok {
+			merged[k] = v
+		}
+	}
+	if len(merged) == 0 {
+		return nil
+	}
+	return merged
+}
+
+// directUpdate applies a metadata-only update to an object that lives solely in metadata
+// storage, and returns the resource version it assigned.
+//
+// Per the MetadataStorage.Upsert contract this touches only labels, annotations and the
+// resource version; the spec and status are read back from the stored row and written
+// out unchanged, so a caller that submits a modified spec has that part of its request
+// silently ignored. That is intentional — this path is only reached for objects that
+// have been evicted from etcd because they are immutable.
+//
+// The stored proto and json blobs are rewritten rather than just the res_version column,
+// because GetByName and List reconstruct objects from the proto blob alone
+// (TODO(#1173)). Bumping only the column would leave the next read reporting a stale
+// resource version, and the caller's next update would then conflict forever.
+//
+// The returned version is derived from a per-row counter and, as the interface contract
+// notes, must not be used for listing or watching: an ingester re-sync of the same object
+// writes the etcd resource version back over it.
+func (m *mysqlMetadataStorage) directUpdate(ctx context.Context, tx *sql.Tx, tableName string, metaObj metav1.Object, object runtime.Object) (uint64, error) {
+	// Lock and read the live row. Addressed by namespace+name rather than by uid because
+	// callers of the generic Update RPC are not required to echo back a UID, so
+	// metadataStoragePrimaryKey would frequently be empty here. This also matches how
+	// GetByName and Delete address rows.
+	//
+	// FOR UPDATE is load-bearing: without it two concurrent direct updates both read
+	// res_version = N, both compute N+1, and one is silently lost.
+	selectQuery := fmt.Sprintf(`
+		SELECT uid, res_version, proto
+		FROM %s
+		WHERE namespace = ? AND name = ? AND delete_time IS NULL
+		LIMIT 1
+		FOR UPDATE
+	`, tableName)
+
+	var (
+		storedUID   string
+		storedRV    uint64
+		storedProto []byte
+	)
+	err := tx.QueryRowContext(ctx, selectQuery, metaObj.GetNamespace(), metaObj.GetName()).
+		Scan(&storedUID, &storedRV, &storedProto)
+	if err == sql.ErrNoRows {
+		// Soft-deleted rows are excluded by the delete_time predicate and land here too.
+		return 0, status.Errorf(codes.NotFound, "object not found or deleted: %s/%s",
+			metaObj.GetNamespace(), metaObj.GetName())
+	}
+	if err != nil {
+		return 0, status.Errorf(codes.Internal, "failed to load object for direct update: %v", err)
+	}
+	// This is a read-modify-write of the proto blob, so an empty blob must abort rather
+	// than proceed: unmarshalling no bytes succeeds and yields a zero-valued object, and
+	// writing that back would blank out the stored name, namespace and spec while the
+	// row's columns still looked correct.
+	if len(storedProto) == 0 {
+		return 0, status.Errorf(codes.Internal,
+			"stored proto is empty for %s/%s: refusing to overwrite it", tableName, metaObj.GetName())
+	}
+
+	if err = checkResourceVersionPrecondition(metaObj.GetResourceVersion(), storedRV); err != nil {
+		return 0, err
+	}
+	newResVersion := storedRV + 1
+
+	// Rebuild the stored object, changing only its metadata.
+	storedObject := object.DeepCopyObject()
+	storedMsg, ok := storedObject.(proto.Message)
+	if !ok {
+		return 0, status.Errorf(codes.InvalidArgument, "object does not implement proto.Message")
+	}
+	storedMsg.Reset()
+	if err = proto.Unmarshal(storedProto, storedMsg); err != nil {
+		return 0, status.Errorf(codes.Internal, "failed to unmarshal stored proto: %v", err)
+	}
+	storedMeta, err := getObjectMeta(storedObject)
+	if err != nil {
+		return 0, err
+	}
+	mergeDirectUpdateMetadata(storedMeta, metaObj, newResVersion)
+
+	newProtoBytes, err := proto.Marshal(storedMsg)
+	if err != nil {
+		return 0, status.Errorf(codes.Internal, "failed to marshal merged object to proto: %v", err)
+	}
+	newJSONBytes, err := json.Marshal(storedObject)
+	if err != nil {
+		return 0, status.Errorf(codes.Internal, "failed to marshal merged object to JSON: %v", err)
+	}
+
+	// The res_version guard is redundant under FOR UPDATE, but keeps this correct if the
+	// lock hint is ever dropped or the isolation level lowered.
+	updateQuery := fmt.Sprintf(`
+		UPDATE %s
+		SET res_version = ?, update_time = ?, proto = ?, json = ?
+		WHERE uid = ? AND res_version = ? AND delete_time IS NULL
+	`, tableName)
+	result, err := tx.ExecContext(ctx, updateQuery,
+		newResVersion, time.Now().UTC(), newProtoBytes, newJSONBytes, storedUID, storedRV)
+	if err != nil {
+		return 0, status.Errorf(codes.Internal, "failed to apply direct update: %v", err)
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return 0, status.Errorf(codes.Internal, "failed to get rows affected: %v", err)
+	}
+	if rowsAffected != 1 {
+		return 0, status.Errorf(codes.Internal,
+			"direct update affected %d rows, expected exactly 1", rowsAffected)
+	}
+
+	// Child rows are keyed by the uid actually stored on the row, not by
+	// metadataStoragePrimaryKey(metaObj): the latter is empty whenever the caller omits
+	// the UID, which would orphan every label and annotation under obj_uid = ''.
+	if err = m.upsertLabels(ctx, tx, tableName, storedUID, storedMeta.GetLabels()); err != nil {
+		return 0, err
+	}
+	if err = m.upsertAnnotations(ctx, tx, tableName, storedUID, storedMeta.GetAnnotations()); err != nil {
+		return 0, err
+	}
+
+	return newResVersion, nil
 }
 
 func (m *mysqlMetadataStorage) upsertLabels(ctx context.Context, tx *sql.Tx, tableName string, uid string, labels map[string]string) error {

--- a/go/storage/mysql/mysql_integration_test.go
+++ b/go/storage/mysql/mysql_integration_test.go
@@ -21,6 +21,8 @@ import (
 	v2pb "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -435,4 +437,398 @@ func TestIntegration_List_OrderBy_ValidFieldStillWorks(t *testing.T) {
 	for i := range ascNames {
 		assert.Equal(t, ascNames[i], descNames[len(descNames)-1-i], "DESC must be the exact reverse of ASC over the same real rows")
 	}
+}
+
+// ==============================================================================
+// directUpdate — the generic Update RPC path (issue #1622)
+// ==============================================================================
+
+// newDirectUpdateDeployment builds a Deployment CR for the directUpdate tests.
+func newDirectUpdateDeployment(namespace, name, uid, resVersion string,
+	labels, annotations map[string]string) *v2pb.Deployment {
+	return &v2pb.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "michelangelo.uber.com/v2",
+			Kind:       "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         namespace,
+			UID:               types.UID(uid),
+			ResourceVersion:   resVersion,
+			CreationTimestamp: metav1.Now(),
+			Labels:            labels,
+			Annotations:       annotations,
+		},
+	}
+}
+
+// seedDeployment performs the non-direct Upsert a real ingester sync would do, so the
+// direct-update tests have a live row to work against.
+func seedDeployment(t *testing.T, store *mysqlMetadataStorage, namespace, name, uid, resVersion string,
+	labels, annotations map[string]string) *v2pb.Deployment {
+	t.Helper()
+	cr := newDirectUpdateDeployment(namespace, name, uid, resVersion, labels, annotations)
+	require.NoError(t, store.Upsert(context.Background(), cr, false, nil), "seed Upsert must succeed")
+	return cr
+}
+
+// storedResVersion reads the res_version column straight out of the row.
+func storedResVersion(t *testing.T, db *sql.DB, namespace, name string) uint64 {
+	t.Helper()
+	var rv uint64
+	require.NoError(t,
+		db.QueryRow("SELECT res_version FROM deployment WHERE namespace=? AND name=? AND delete_time IS NULL",
+			namespace, name).Scan(&rv))
+	return rv
+}
+
+// TestIntegration_DirectUpdate_HappyPath is the base case: a direct update must succeed,
+// bump the stored resource version, and — critically — actually commit. Before the fix
+// the direct branch of Upsert returned without ever calling tx.Commit(), so the column
+// assertion here is what proves the transaction landed.
+func TestIntegration_DirectUpdate_HappyPath(t *testing.T) {
+	db := openIntegrationDB(t)
+	store := newIntegrationStorage(t, db)
+	ctx := context.Background()
+
+	const (
+		namespace = "integration-test-ns"
+		name      = "direct-update-happy"
+		uid       = "direct-update-happy-uid"
+	)
+	t.Cleanup(func() { cleanupDeploymentRow(t, db, namespace, name, uid) })
+
+	seedDeployment(t, store, namespace, name, uid, "1", map[string]string{"app": "before"}, nil)
+
+	var createTimeBefore, updateTimeBefore time.Time
+	require.NoError(t, db.QueryRowContext(ctx,
+		"SELECT create_time, update_time FROM deployment WHERE uid=?", uid).
+		Scan(&createTimeBefore, &updateTimeBefore))
+
+	update := newDirectUpdateDeployment(namespace, name, "", "1", map[string]string{"app": "after"}, nil)
+	require.NoError(t, store.Upsert(ctx, update, true, nil), "direct update must succeed")
+
+	assert.Equal(t, uint64(2), storedResVersion(t, db, namespace, name),
+		"res_version must be bumped and the transaction committed")
+	assert.Equal(t, "2", update.GetResourceVersion(),
+		"the new resource version must be written back onto the caller's object")
+
+	var createTimeAfter, updateTimeAfter time.Time
+	require.NoError(t, db.QueryRowContext(ctx,
+		"SELECT create_time, update_time FROM deployment WHERE uid=?", uid).
+		Scan(&createTimeAfter, &updateTimeAfter))
+	assert.Equal(t, createTimeBefore.UTC(), createTimeAfter.UTC(), "create_time must not move")
+	assert.False(t, updateTimeAfter.Before(updateTimeBefore), "update_time must not go backwards")
+}
+
+// TestIntegration_DirectUpdate_RewritesProtoSoNextReadSeesNewRV guards the subtle half of
+// #1622: GetByName reconstructs the object from the proto blob alone, so bumping only the
+// res_version column would leave the next read reporting a stale version.
+func TestIntegration_DirectUpdate_RewritesProtoSoNextReadSeesNewRV(t *testing.T) {
+	db := openIntegrationDB(t)
+	store := newIntegrationStorage(t, db)
+	ctx := context.Background()
+
+	const (
+		namespace = "integration-test-ns"
+		name      = "direct-update-proto-rewrite"
+		uid       = "direct-update-proto-rewrite-uid"
+	)
+	t.Cleanup(func() { cleanupDeploymentRow(t, db, namespace, name, uid) })
+
+	seedDeployment(t, store, namespace, name, uid, "1", map[string]string{"app": "before"}, nil)
+
+	update := newDirectUpdateDeployment(namespace, name, "", "1", map[string]string{"app": "after"}, nil)
+	require.NoError(t, store.Upsert(ctx, update, true, nil))
+
+	readBack := &v2pb.Deployment{}
+	require.NoError(t, store.GetByName(ctx, namespace, name, readBack))
+	assert.Equal(t, "2", readBack.GetResourceVersion(),
+		"GetByName reads metadata from the proto blob, so the blob must carry the new version")
+	assert.Equal(t, "after", readBack.GetLabels()["app"],
+		"the merged labels must be persisted into the proto blob too")
+}
+
+// TestIntegration_DirectUpdate_RepeatedReadModifyWriteSucceeds is the #1622 repro reduced
+// to the storage layer: the register_model client re-reads the object and reuses its
+// resource version on every retry. Three successive cycles must all succeed. Without the
+// proto rewrite the third one fails with FailedPrecondition forever.
+func TestIntegration_DirectUpdate_RepeatedReadModifyWriteSucceeds(t *testing.T) {
+	db := openIntegrationDB(t)
+	store := newIntegrationStorage(t, db)
+	ctx := context.Background()
+
+	const (
+		namespace = "integration-test-ns"
+		name      = "direct-update-repeat"
+		uid       = "direct-update-repeat-uid"
+	)
+	t.Cleanup(func() { cleanupDeploymentRow(t, db, namespace, name, uid) })
+
+	seedDeployment(t, store, namespace, name, uid, "1", map[string]string{"attempt": "0"}, nil)
+
+	for i := 1; i <= 3; i++ {
+		existing := &v2pb.Deployment{}
+		require.NoError(t, store.GetByName(ctx, namespace, name, existing),
+			"read before update %d", i)
+
+		update := newDirectUpdateDeployment(namespace, name, "", existing.GetResourceVersion(),
+			map[string]string{"attempt": fmt.Sprintf("%d", i)}, nil)
+		require.NoError(t, store.Upsert(ctx, update, true, nil),
+			"read-modify-write cycle %d must succeed", i)
+	}
+
+	assert.Equal(t, uint64(4), storedResVersion(t, db, namespace, name))
+	final := &v2pb.Deployment{}
+	require.NoError(t, store.GetByName(ctx, namespace, name, final))
+	assert.Equal(t, "3", final.GetLabels()["attempt"])
+}
+
+// TestIntegration_DirectUpdate_EmptyResourceVersionIsUnconditional mirrors Kubernetes
+// semantics: an unset resourceVersion on update means "no precondition".
+func TestIntegration_DirectUpdate_EmptyResourceVersionIsUnconditional(t *testing.T) {
+	db := openIntegrationDB(t)
+	store := newIntegrationStorage(t, db)
+	ctx := context.Background()
+
+	const (
+		namespace = "integration-test-ns"
+		name      = "direct-update-empty-rv"
+		uid       = "direct-update-empty-rv-uid"
+	)
+	t.Cleanup(func() { cleanupDeploymentRow(t, db, namespace, name, uid) })
+
+	seedDeployment(t, store, namespace, name, uid, "5", map[string]string{"app": "before"}, nil)
+
+	update := newDirectUpdateDeployment(namespace, name, "", "", map[string]string{"app": "after"}, nil)
+	require.NoError(t, store.Upsert(ctx, update, true, nil), "empty resourceVersion must not be a precondition")
+	assert.Equal(t, uint64(6), storedResVersion(t, db, namespace, name))
+}
+
+// TestIntegration_DirectUpdate_ResourceVersionMismatchConflicts checks both halves of the
+// optimistic-concurrency contract: the right gRPC code out, and no partial write left
+// behind (which also proves the deferred rollback still works).
+func TestIntegration_DirectUpdate_ResourceVersionMismatchConflicts(t *testing.T) {
+	db := openIntegrationDB(t)
+	store := newIntegrationStorage(t, db)
+	ctx := context.Background()
+
+	const (
+		namespace = "integration-test-ns"
+		name      = "direct-update-conflict"
+		uid       = "direct-update-conflict-uid"
+	)
+	t.Cleanup(func() { cleanupDeploymentRow(t, db, namespace, name, uid) })
+
+	seedDeployment(t, store, namespace, name, uid, "5", map[string]string{"app": "before"}, nil)
+
+	update := newDirectUpdateDeployment(namespace, name, "", "4", map[string]string{"app": "after"}, nil)
+	err := store.Upsert(ctx, update, true, nil)
+	require.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err),
+		"a stale resourceVersion must surface as FailedPrecondition: the Python client "+
+			"catches exactly this code to drive its retry loop")
+
+	assert.Equal(t, uint64(5), storedResVersion(t, db, namespace, name), "row must be unchanged")
+	unchanged := &v2pb.Deployment{}
+	require.NoError(t, store.GetByName(ctx, namespace, name, unchanged))
+	assert.Equal(t, "before", unchanged.GetLabels()["app"], "labels must be unchanged")
+}
+
+// TestIntegration_DirectUpdate_NonNumericResourceVersion rejects a structurally invalid
+// version as InvalidArgument rather than treating it as a lost update.
+func TestIntegration_DirectUpdate_NonNumericResourceVersion(t *testing.T) {
+	db := openIntegrationDB(t)
+	store := newIntegrationStorage(t, db)
+	ctx := context.Background()
+
+	const (
+		namespace = "integration-test-ns"
+		name      = "direct-update-bad-rv"
+		uid       = "direct-update-bad-rv-uid"
+	)
+	t.Cleanup(func() { cleanupDeploymentRow(t, db, namespace, name, uid) })
+
+	seedDeployment(t, store, namespace, name, uid, "5", nil, nil)
+
+	update := newDirectUpdateDeployment(namespace, name, "", "not-a-number", nil, nil)
+	err := store.Upsert(ctx, update, true, nil)
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.Equal(t, uint64(5), storedResVersion(t, db, namespace, name), "row must be unchanged")
+}
+
+// TestIntegration_DirectUpdate_RowNotFound covers a namespace/name that was never stored.
+func TestIntegration_DirectUpdate_RowNotFound(t *testing.T) {
+	db := openIntegrationDB(t)
+	store := newIntegrationStorage(t, db)
+	ctx := context.Background()
+
+	update := newDirectUpdateDeployment("integration-test-ns", "direct-update-never-existed", "", "1", nil, nil)
+	err := store.Upsert(ctx, update, true, nil)
+	require.Error(t, err)
+	assert.Equal(t, codes.NotFound, status.Code(err))
+}
+
+// TestIntegration_DirectUpdate_SoftDeletedRowNotFound verifies a soft-deleted row cannot
+// be resurrected through the direct path.
+func TestIntegration_DirectUpdate_SoftDeletedRowNotFound(t *testing.T) {
+	db := openIntegrationDB(t)
+	store := newIntegrationStorage(t, db)
+	ctx := context.Background()
+
+	const (
+		namespace = "integration-test-ns"
+		name      = "direct-update-soft-deleted"
+		uid       = "direct-update-soft-deleted-uid"
+	)
+	t.Cleanup(func() { cleanupDeploymentRow(t, db, namespace, name, uid) })
+
+	seedDeployment(t, store, namespace, name, uid, "1", nil, nil)
+	typeMeta := &metav1.TypeMeta{APIVersion: "michelangelo.uber.com/v2", Kind: "Deployment"}
+	require.NoError(t, store.Delete(ctx, typeMeta, namespace, name))
+
+	update := newDirectUpdateDeployment(namespace, name, "", "1", nil, nil)
+	err := store.Upsert(ctx, update, true, nil)
+	require.Error(t, err)
+	assert.Equal(t, codes.NotFound, status.Code(err))
+
+	var deleteTime sql.NullTime
+	require.NoError(t, db.QueryRowContext(ctx,
+		"SELECT delete_time FROM deployment WHERE uid=?", uid).Scan(&deleteTime))
+	assert.True(t, deleteTime.Valid, "the row must stay soft-deleted")
+}
+
+// TestIntegration_DirectUpdate_ChildRowsKeyedByStoredUID is the highest-value case: the
+// register_model client sends name/namespace/labels but never a UID, so keying child rows
+// off metadataStoragePrimaryKey(incoming) would file them all under obj_uid = ”.
+func TestIntegration_DirectUpdate_ChildRowsKeyedByStoredUID(t *testing.T) {
+	db := openIntegrationDB(t)
+	store := newIntegrationStorage(t, db)
+	ctx := context.Background()
+
+	const (
+		namespace = "integration-test-ns"
+		name      = "direct-update-child-rows"
+		uid       = "direct-update-child-rows-uid"
+	)
+	t.Cleanup(func() { cleanupDeploymentRow(t, db, namespace, name, uid, "") })
+
+	seedDeployment(t, store, namespace, name, uid, "1",
+		map[string]string{"app": "before", "team": "platform"}, nil)
+
+	// No UID and no primary-key annotation — exactly what the Python client sends.
+	update := newDirectUpdateDeployment(namespace, name, "", "1", map[string]string{"app": "after"}, nil)
+	require.NoError(t, store.Upsert(ctx, update, true, nil))
+
+	rows, err := db.QueryContext(ctx,
+		"SELECT `key`, `value` FROM deployment_labels WHERE obj_uid=? ORDER BY `key`", uid)
+	require.NoError(t, err)
+	defer rows.Close()
+	got := map[string]string{}
+	for rows.Next() {
+		var k, v string
+		require.NoError(t, rows.Scan(&k, &v))
+		got[k] = v
+	}
+	require.NoError(t, rows.Err())
+	assert.Equal(t, map[string]string{"app": "after"}, got,
+		"labels must be replaced wholesale and keyed by the stored uid")
+
+	var orphaned int
+	require.NoError(t, db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM deployment_labels WHERE obj_uid=''").Scan(&orphaned))
+	assert.Equal(t, 0, orphaned, "no label rows may be orphaned under an empty obj_uid")
+}
+
+// TestIntegration_DirectUpdate_PreservesManagedAnnotations verifies that server-managed
+// annotations survive a caller that builds a fresh object and never echoes them back.
+func TestIntegration_DirectUpdate_PreservesManagedAnnotations(t *testing.T) {
+	db := openIntegrationDB(t)
+	store := newIntegrationStorage(t, db)
+	ctx := context.Background()
+
+	const (
+		namespace = "integration-test-ns"
+		name      = "direct-update-managed-annotations"
+		uid       = "direct-update-managed-annotations-uid"
+	)
+	t.Cleanup(func() { cleanupDeploymentRow(t, db, namespace, name, uid) })
+
+	seedDeployment(t, store, namespace, name, uid, "1", nil, map[string]string{
+		api.ImmutableAnnotation:                 "true",
+		api.MetadataStoragePrimaryKeyAnnotation: uid,
+	})
+
+	update := newDirectUpdateDeployment(namespace, name, "", "1", nil,
+		map[string]string{"user-annotation": "set-by-client"})
+	require.NoError(t, store.Upsert(ctx, update, true, nil))
+
+	readBack := &v2pb.Deployment{}
+	require.NoError(t, store.GetByName(ctx, namespace, name, readBack))
+	annotations := readBack.GetAnnotations()
+	assert.Equal(t, "true", annotations[api.ImmutableAnnotation],
+		"the immutability marker must not be destroyed by a metadata-only update")
+	assert.Equal(t, uid, annotations[api.MetadataStoragePrimaryKeyAnnotation],
+		"the migration primary key must not be destroyed by a metadata-only update")
+	assert.Equal(t, "set-by-client", annotations["user-annotation"])
+}
+
+// TestIntegration_DirectUpdate_IgnoresSpecChanges locks in the deliberate contract
+// behaviour: the direct path is metadata-only, so a caller that submits a modified spec
+// has that part of its request silently dropped.
+func TestIntegration_DirectUpdate_IgnoresSpecChanges(t *testing.T) {
+	db := openIntegrationDB(t)
+	store := newIntegrationStorage(t, db)
+	ctx := context.Background()
+
+	const (
+		namespace = "integration-test-ns"
+		name      = "direct-update-spec-ignored"
+		uid       = "direct-update-spec-ignored-uid"
+	)
+	t.Cleanup(func() { cleanupDeploymentRow(t, db, namespace, name, uid) })
+
+	seeded := newDirectUpdateDeployment(namespace, name, uid, "1", nil, nil)
+	seeded.Spec.DesiredRevision = &apipb.ResourceIdentifier{Namespace: namespace, Name: "revision-stored"}
+	require.NoError(t, store.Upsert(ctx, seeded, false, nil))
+
+	update := newDirectUpdateDeployment(namespace, name, "", "1", map[string]string{"app": "after"}, nil)
+	update.Spec.DesiredRevision = &apipb.ResourceIdentifier{Namespace: namespace, Name: "revision-from-caller"}
+	require.NoError(t, store.Upsert(ctx, update, true, nil))
+
+	readBack := &v2pb.Deployment{}
+	require.NoError(t, store.GetByName(ctx, namespace, name, readBack))
+	require.NotNil(t, readBack.Spec.DesiredRevision)
+	assert.Equal(t, "revision-stored", readBack.Spec.DesiredRevision.Name,
+		"the direct path must not persist spec changes")
+	assert.Equal(t, "after", readBack.GetLabels()["app"], "but metadata changes must land")
+}
+
+// TestIntegration_DirectUpdate_EmptyStoredProtoRejected covers a corrupt row: directUpdate
+// is a read-modify-write of the proto blob, and unmarshalling zero bytes succeeds with a
+// zero-valued object. Writing that back would blank out the stored name, namespace and
+// spec while the row's columns still looked correct, so an empty blob must abort.
+func TestIntegration_DirectUpdate_EmptyStoredProtoRejected(t *testing.T) {
+	db := openIntegrationDB(t)
+	store := newIntegrationStorage(t, db)
+	ctx := context.Background()
+
+	const (
+		namespace = "integration-test-ns"
+		name      = "direct-update-empty-proto"
+		uid       = "direct-update-empty-proto-uid"
+	)
+	t.Cleanup(func() { cleanupDeploymentRow(t, db, namespace, name, uid) })
+
+	seedDeployment(t, store, namespace, name, uid, "1", nil, nil)
+	_, err := db.ExecContext(ctx, "UPDATE deployment SET proto = NULL WHERE uid = ?", uid)
+	require.NoError(t, err)
+
+	update := newDirectUpdateDeployment(namespace, name, "", "1", map[string]string{"app": "after"}, nil)
+	err = store.Upsert(ctx, update, true, nil)
+	require.Error(t, err)
+	assert.Equal(t, codes.Internal, status.Code(err))
+	assert.Equal(t, uint64(1), storedResVersion(t, db, namespace, name), "row must be unchanged")
 }

--- a/go/storage/mysql/mysql_integration_test.go
+++ b/go/storage/mysql/mysql_integration_test.go
@@ -473,12 +473,19 @@ func seedDeployment(t *testing.T, store *mysqlMetadataStorage, namespace, name, 
 	return cr
 }
 
-// storedResVersion reads the res_version column straight out of the row.
+// storedResVersion reads the res_version column straight out of the deployment row.
 func storedResVersion(t *testing.T, db *sql.DB, namespace, name string) uint64 {
+	t.Helper()
+	return storedResVersionIn(t, db, "deployment", namespace, name)
+}
+
+// storedResVersionIn is storedResVersion for an arbitrary table.
+func storedResVersionIn(t *testing.T, db *sql.DB, table, namespace, name string) uint64 {
 	t.Helper()
 	var rv uint64
 	require.NoError(t,
-		db.QueryRow("SELECT res_version FROM deployment WHERE namespace=? AND name=? AND delete_time IS NULL",
+		db.QueryRow(fmt.Sprintf(
+			"SELECT res_version FROM %s WHERE namespace=? AND name=? AND delete_time IS NULL", table),
 			namespace, name).Scan(&rv))
 	return rv
 }
@@ -831,4 +838,92 @@ func TestIntegration_DirectUpdate_EmptyStoredProtoRejected(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, codes.Internal, status.Code(err))
 	assert.Equal(t, uint64(1), storedResVersion(t, db, namespace, name), "row must be unchanged")
+}
+
+// cleanupModelRow removes model rows created by a test, including the label/annotation
+// child rows (keyed by obj_uid, so they must be cleaned by uid).
+func cleanupModelRow(t *testing.T, db *sql.DB, namespace, name string, uids ...string) {
+	t.Helper()
+	_, err := db.Exec("DELETE FROM model WHERE namespace=? AND name=?", namespace, name)
+	require.NoError(t, err)
+	for _, uid := range uids {
+		_, err = db.Exec("DELETE FROM model_labels WHERE obj_uid=?", uid)
+		require.NoError(t, err)
+		_, err = db.Exec("DELETE FROM model_annotations WHERE obj_uid=?", uid)
+		require.NoError(t, err)
+	}
+}
+
+// TestIntegration_DirectUpdate_ReregisterModelKeepsStoredArtifactURI runs the register_model
+// re-registration sequence with two different artifact URIs: create, ALREADY_EXISTS, read
+// back the resourceVersion, then update with a fresh proto (api_client.py:221-267). The
+// direct path is metadata-only, so the second registration succeeds while storage keeps the
+// first artifact URI, and the caller's object still carries the second.
+func TestIntegration_DirectUpdate_ReregisterModelKeepsStoredArtifactURI(t *testing.T) {
+	db := openIntegrationDB(t)
+	store := newIntegrationStorage(t, db)
+	ctx := context.Background()
+
+	const (
+		namespace   = "integration-test-ns"
+		name        = "direct-update-reregister-model"
+		uid         = "direct-update-reregister-model-uid"
+		firstURI    = "s3://models/reregister/v1/model.pkl"
+		secondURI   = "s3://models/reregister/v2/model.pkl"
+		firstDeploy = "s3://models/reregister/v1/bundle.zip"
+	)
+	t.Cleanup(func() { cleanupModelRow(t, db, namespace, name, uid) })
+
+	first := &v2pb.Model{
+		TypeMeta: metav1.TypeMeta{APIVersion: "michelangelo.uber.com/v2", Kind: "Model"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         namespace,
+			UID:               types.UID(uid),
+			ResourceVersion:   "1",
+			CreationTimestamp: metav1.Now(),
+			Labels:            map[string]string{"registered-by": "run-1"},
+		},
+		Spec: v2pb.ModelSpec{
+			ModelArtifactUri:      []string{firstURI},
+			DeployableArtifactUri: []string{firstDeploy},
+			Description:           "first registration",
+		},
+	}
+	require.NoError(t, store.Upsert(ctx, first, false, nil))
+
+	existing := &v2pb.Model{}
+	require.NoError(t, store.GetByName(ctx, namespace, name, existing))
+	require.Equal(t, []string{firstURI}, existing.Spec.ModelArtifactUri)
+
+	// _build_model_proto: a fresh object with the new artifact URI and no UID.
+	second := &v2pb.Model{
+		TypeMeta: metav1.TypeMeta{APIVersion: "michelangelo.uber.com/v2", Kind: "Model"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       namespace,
+			ResourceVersion: existing.GetResourceVersion(),
+			Labels:          map[string]string{"registered-by": "run-2"},
+		},
+		Spec: v2pb.ModelSpec{
+			ModelArtifactUri: []string{secondURI},
+			Description:      "second registration",
+		},
+	}
+	require.NoError(t, store.Upsert(ctx, second, true, nil), "re-registration must succeed")
+
+	readBack := &v2pb.Model{}
+	require.NoError(t, store.GetByName(ctx, namespace, name, readBack))
+	assert.Equal(t, []string{firstURI}, readBack.Spec.ModelArtifactUri,
+		"the stored artifact URI must not change")
+	assert.Equal(t, []string{firstDeploy}, readBack.Spec.DeployableArtifactUri,
+		"an omitted spec field must not be cleared either")
+	assert.Equal(t, "first registration", readBack.Spec.Description)
+	assert.Equal(t, "run-2", readBack.GetLabels()["registered-by"],
+		"metadata changes must still land")
+	assert.Equal(t, uint64(2), storedResVersionIn(t, db, "model", namespace, name))
+
+	assert.Equal(t, []string{secondURI}, second.Spec.ModelArtifactUri,
+		"the caller's object keeps the URI it sent, so caller and storage disagree")
+	assert.Equal(t, "2", second.GetResourceVersion())
 }

--- a/go/storage/mysql/mysql_test.go
+++ b/go/storage/mysql/mysql_test.go
@@ -5,10 +5,13 @@ import (
 
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 
+	api "github.com/michelangelo-ai/michelangelo/go/api"
 	apipb "github.com/michelangelo-ai/michelangelo/proto-go/api"
 	v2pb "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
 )
@@ -603,4 +606,129 @@ func TestFullUpsert_CrossClusterMigration(t *testing.T) {
 	// Verify the UIDs are actually different
 	require.NotEqual(t, string(metaObjOriginal.GetUID()), string(metaObjNew.GetUID()),
 		"UIDs are different across clusters as expected")
+}
+
+func TestCheckResourceVersionPrecondition(t *testing.T) {
+	cases := []struct {
+		name     string
+		incoming string
+		stored   uint64
+		wantCode codes.Code
+	}{
+		{"empty is unconditional", "", 5, codes.OK},
+		{"exact match", "5", 5, codes.OK},
+		{"zero padded still matches numerically", "007", 7, codes.OK},
+		{"stale version conflicts", "4", 5, codes.FailedPrecondition},
+		{"future version conflicts", "6", 5, codes.FailedPrecondition},
+		{"non numeric is invalid", "abc", 5, codes.InvalidArgument},
+		{"negative is invalid", "-1", 5, codes.InvalidArgument},
+		{"fractional is invalid", "1.5", 5, codes.InvalidArgument},
+		{"overflow is invalid", "18446744073709551616", 5, codes.InvalidArgument},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := checkResourceVersionPrecondition(c.incoming, c.stored)
+			if c.wantCode == codes.OK {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.Equal(t, c.wantCode, status.Code(err))
+		})
+	}
+}
+
+func TestMergeDirectUpdateMetadata_ReplacesUserSuppliedKeys(t *testing.T) {
+	stored := &v2pb.Model{ObjectMeta: metav1.ObjectMeta{
+		Labels: map[string]string{"app": "old", "team": "platform"},
+	}}
+	incoming := &v2pb.Model{ObjectMeta: metav1.ObjectMeta{
+		Labels: map[string]string{"app": "new"},
+	}}
+
+	mergeDirectUpdateMetadata(stored.GetObjectMeta(), incoming.GetObjectMeta(), 3)
+
+	// Wholesale replace: "app" takes the incoming value and "team" is dropped.
+	require.Equal(t, map[string]string{"app": "new"}, stored.GetLabels())
+	require.Equal(t, "3", stored.GetResourceVersion())
+}
+
+func TestMergeDirectUpdateMetadata_PreservesManagedKeys(t *testing.T) {
+	stored := &v2pb.Model{ObjectMeta: metav1.ObjectMeta{
+		Labels: map[string]string{
+			api.SpecUpdateTimestampLabel: "1700000000000000",
+			"app":                        "old",
+		},
+		Annotations: map[string]string{
+			api.ImmutableAnnotation:                 "true",
+			api.MetadataStoragePrimaryKeyAnnotation: "pk-original",
+			"user-annotation":                       "dropped",
+		},
+	}}
+	incoming := &v2pb.Model{ObjectMeta: metav1.ObjectMeta{
+		Labels:      map[string]string{"app": "new"},
+		Annotations: map[string]string{"user-annotation": "kept"},
+	}}
+
+	mergeDirectUpdateMetadata(stored.GetObjectMeta(), incoming.GetObjectMeta(), 2)
+
+	// Server-managed keys survive even though the caller never sent them.
+	require.Equal(t, "1700000000000000", stored.GetLabels()[api.SpecUpdateTimestampLabel])
+	require.Equal(t, "new", stored.GetLabels()["app"])
+	require.Equal(t, "true", stored.GetAnnotations()[api.ImmutableAnnotation])
+	require.Equal(t, "pk-original", stored.GetAnnotations()[api.MetadataStoragePrimaryKeyAnnotation])
+	require.Equal(t, "kept", stored.GetAnnotations()["user-annotation"])
+}
+
+func TestMergeDirectUpdateMetadata_IncomingManagedKeyWins(t *testing.T) {
+	stored := &v2pb.Model{ObjectMeta: metav1.ObjectMeta{
+		Annotations: map[string]string{api.ImmutableAnnotation: "true"},
+	}}
+	incoming := &v2pb.Model{ObjectMeta: metav1.ObjectMeta{
+		Annotations: map[string]string{api.ImmutableAnnotation: "false"},
+	}}
+
+	mergeDirectUpdateMetadata(stored.GetObjectMeta(), incoming.GetObjectMeta(), 2)
+
+	require.Equal(t, "false", stored.GetAnnotations()[api.ImmutableAnnotation])
+}
+
+func TestMergeDirectUpdateMetadata_LeavesSpecUntouched(t *testing.T) {
+	stored := &v2pb.Model{
+		ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "old"}},
+		Spec:       v2pb.ModelSpec{Algorithm: "xgboost", Description: "stored spec"},
+	}
+	incoming := &v2pb.Model{
+		ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "new"}},
+		Spec:       v2pb.ModelSpec{Algorithm: "pytorch", Description: "caller spec"},
+	}
+
+	mergeDirectUpdateMetadata(stored.GetObjectMeta(), incoming.GetObjectMeta(), 9)
+
+	// The direct path is metadata-only: the caller's spec is deliberately ignored.
+	require.Equal(t, "xgboost", stored.Spec.Algorithm)
+	require.Equal(t, "stored spec", stored.Spec.Description)
+	require.Equal(t, "9", stored.GetResourceVersion())
+}
+
+func TestMergeDirectUpdateMetadata_NilMaps(t *testing.T) {
+	stored := &v2pb.Model{ObjectMeta: metav1.ObjectMeta{
+		Labels:      map[string]string{"app": "old"},
+		Annotations: map[string]string{api.ImmutableAnnotation: "true"},
+	}}
+	incoming := &v2pb.Model{}
+
+	require.NotPanics(t, func() {
+		mergeDirectUpdateMetadata(stored.GetObjectMeta(), incoming.GetObjectMeta(), 1)
+	})
+
+	// User labels are cleared to nil, but the managed annotation is carried over.
+	require.Nil(t, stored.GetLabels())
+	require.Equal(t, map[string]string{api.ImmutableAnnotation: "true"}, stored.GetAnnotations())
+}
+
+func TestMergeManagedKeys_EmptyResultIsNil(t *testing.T) {
+	// Neither side has anything: the result must stay nil rather than become an
+	// empty map, so an object without labels does not gain one.
+	require.Nil(t, mergeManagedKeys(nil, nil, directUpdateManagedLabels))
 }


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Implements `mysqlMetadataStorage.directUpdate`, which was an unconditional `codes.Unimplemented` stub, so the generic `Update` RPC failed for every resource kind whenever the apiserver runs with the MySQL metadata storage backend.

It now follows the `MetadataStorage.Upsert` contract: labels, annotations and the resource version are updated, guarded by an optimistic-concurrency check on `resourceVersion`. A mismatch returns `FailedPrecondition`, matching the `StatusReasonConflict` mapping in `K8sStatusReasonToGrpcError`, which is the code `api_client.py` already catches to drive its retry loop. An empty incoming `resourceVersion` is treated as "no precondition", per Kubernetes update semantics.

Two things beyond the stub itself turned out to be required:

1. **`Upsert` never committed on the direct branch.** It did `return m.directUpdate(...)` under a `defer tx.Rollback()`, so even a correct implementation would have been rolled back.

2. **The `proto`/`json` blobs are rewritten, not just the `res_version` column.** `GetByName` and `List` reconstruct objects from the proto blob alone (the existing TODO #1173 ), so a column-only bump leaves the next read reporting a stale version, and since the client re-reads before each retry, its *next* update conflicts forever. Without this the bug returns on the third registration as an exhausted-retry error instead of `UNIMPLEMENTED`.

Two smaller decisions:

- The row is located by `namespace`+`name` rather than `uid`, and child rows are keyed by the `uid` read back from that row. Callers of the generic Update RPC aren't required to echo a UID (`register_model` doesn't), so `metadataStoragePrimaryKey` is usually empty here and would orphan every label/annotation under `obj_uid = ''`.
- Server-managed labels/annotations absent from the incoming object are preserved. Callers build a fresh object rather than doing read-modify-write, and `setUpdateTimestamp` only sets `SpecUpdateTimestampLabel` when the spec changed, so a strict replace would delete it, along with the immutability marker and the migration primary key.

The second commit copies the assigned resource version back onto the caller's object in `apiHandler.Update`. The object is deep-copied before being handed to the metadata handler, so without this the new version lands on a discarded copy and the client sees the version it sent. It's separated out because it's inert without the first commit.

**Why?**

Fixes #1622. Re-registering any already-existing resource by name was broken, which failed the whole pipeline run whenever a `register_model` step ran a second time even though `preprocess` and `train` had succeeded.

**How did you test it?**

Verified before/after against a local MySQL with `scripts/ingester/ingester_schema.sql` loaded: on `main` the second registration returns `Unimplemented` and `res_version` stays at 1; with the fix it succeeds.

- 8 unit tests (no database) covering the resourceVersion precondition -- empty, match, mismatch, non-numeric, negative, overflow, zero-padded -- and the metadata merge, including managed-key preservation and that the spec is untouched.
- 12 `TestIntegration_DirectUpdate_*` tests against live MySQL: happy path, the read-modify-write cycle repeated three times (the #1622 repro), conflict, invalid and empty resource versions, missing and soft-deleted rows, child rows keyed by the stored uid with no orphans under `obj_uid = ''`, managed-annotation preservation, and a corrupt (NULL) proto blob being rejected rather than overwritten.
- `bazel test //go/... //proto/... --build_tests_only`: all tests pass.

Note the integration tests skip when MySQL is unreachable, matching the 6 existing tests in that file, so they do not currently run in CI. I've asked about that in [this comment](https://github.com/michelangelo-ai/michelangelo/issues/1622#issuecomment-5129683888). Happy to drop them from this PR if you'd rather they land alongside a CI job. One useful data point since: the Bazel test sandbox *can* reach a MySQL on the host, so a GitHub Actions service container would work with `bazel test`, needing only `--test_env` for the connection variables.

**Potential risks**

The changed path returned an error unconditionally before this PR, so no working behaviour can regress through it. The three ingester callers use `direct=false` and are untouched; `metadata_handler.go` is the only `direct=true` caller. No dependency, proto, or exported-signature changes.

Three things to consider during review:

- **Spec changes are silently ignored on this path.** `register_model` sends a full `Model` including its spec, and the RPC will now return success without persisting it. I believe that's correct, this path is only reached once the object has been evicted from etcd as immutable, and there's a test covering the behaviour, but it is a quieter failure mode than `UNIMPLEMENTED`. This is the open question from the issue comment linked above; happy to change direction.
- `(namespace, name)` is a non-unique `KEY`, so `GetByName`'s unordered `LIMIT 1` can in principle resolve to a different row than a later update. Pre-existing; I matched `GetByName` exactly rather than invent a different tiebreak. Can file separately.
- `fullUpsert` writes the resourceVersion *string* into a `BIGINT UNSIGNED` column ([mysql.go:1162](https://github.com/michelangelo-ai/michelangelo/blob/277bb0397471ff162255572874df6523429b6c4c/go/storage/mysql/mysql.go#L1162)); an empty or non-numeric value coerces to 0, or errors under `STRICT_TRANS_TABLES`. Also pre-existing, but it would surface looking like a `directUpdate` bug. Can file separately.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

Fixes the generic `Update` RPC failing with `UNIMPLEMENTED` on the MySQL metadata storage backend. Updating or re-registering an existing resource by name now works, including repeated `register_model` calls in pipeline runs.

**Documentation Changes**

None. The behaviour now matches the contract already documented on `MetadataStorage.Upsert`.