### PR TITLE
feat(core): expose mutationName in success operations resolver context

### DIFF
--- a/javascript/packages/core/components/actions/__fixtures__/use-success-operations-test-harness.tsx
+++ b/javascript/packages/core/components/actions/__fixtures__/use-success-operations-test-harness.tsx
@@ -5,10 +5,15 @@ import type { SuccessOperation } from '#core/components/actions/types';
 type HarnessProps = {
   operations?: SuccessOperation[];
   response?: unknown;
+  mutationName?: string;
 };
 
-export function UseSuccessOperationsTestHarness({ operations, response }: HarnessProps) {
-  const runSuccessOperations = useSuccessOperations(operations);
+export function UseSuccessOperationsTestHarness({
+  operations,
+  response,
+  mutationName,
+}: HarnessProps) {
+  const runSuccessOperations = useSuccessOperations(operations, mutationName);
 
   return <button onClick={() => runSuccessOperations(response)}>Run success operations</button>;
 }

--- a/javascript/packages/core/components/actions/__tests__/use-success-operations.test.tsx
+++ b/javascript/packages/core/components/actions/__tests__/use-success-operations.test.tsx
@@ -362,4 +362,31 @@ describe('useSuccessOperations', () => {
       expect(screen.getByText(/Current pathname: \/pipelines\/run-1/)).toBeInTheDocument();
     });
   });
+
+  describe('mutationName in resolver context', () => {
+    it('interpolates the toast message from mutationName', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <UseSuccessOperationsTestHarness
+          operations={[
+            { type: 'toast', message: interpolate('Mutation ${mutationName} completed') },
+          ]}
+          response={{}}
+          mutationName="CreatePipelineRun"
+        />,
+        buildWrapper([
+          getBaseProviderWrapper(),
+          getRouterWrapper(),
+          createServiceProviderTestContext({ request: vi.fn() }).wrapper,
+          getSnackbarProviderWrapper(),
+          getIconProviderWrapper(),
+        ])
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Run success operations' }));
+
+      expect(await screen.findByText('Mutation CreatePipelineRun completed')).toBeInTheDocument();
+    });
+  });
 });

--- a/javascript/packages/core/components/actions/use-success-operations.tsx
+++ b/javascript/packages/core/components/actions/use-success-operations.tsx
@@ -16,7 +16,7 @@ const DEFAULT_TOAST_ICON = 'checkCircle';
  * The runner resolves response interpolation (e.g. `${response.metadata.name}`)
  * against the mutation result, then applies each operation in order.
  */
-export function useSuccessOperations(operations?: SuccessOperation[]) {
+export function useSuccessOperations(operations?: SuccessOperation[], mutationName?: string) {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const { enqueue, dequeue } = useSnackbar();
@@ -25,7 +25,7 @@ export function useSuccessOperations(operations?: SuccessOperation[]) {
   return useCallback(
     (response: unknown) => {
       if (!operations || operations.length === 0) return;
-      const resolved = resolver(operations, { response });
+      const resolved = resolver(operations, { response, mutationName });
       for (const op of resolved) {
         if (op.type === 'invalidate') {
           const fire = () => {
@@ -47,7 +47,7 @@ export function useSuccessOperations(operations?: SuccessOperation[]) {
         }
       }
     },
-    [operations, resolver, queryClient, navigate, enqueue, dequeue]
+    [operations, mutationName, resolver, queryClient, navigate, enqueue, dequeue]
   );
 }
 

--- a/javascript/packages/core/hooks/use-studio-mutation/use-studio-mutation.ts
+++ b/javascript/packages/core/hooks/use-studio-mutation/use-studio-mutation.ts
@@ -15,7 +15,10 @@ export const useStudioMutation = <TResponse, TPayload extends Record<string, unk
 ): UseStudioMutationResult<TResponse, TPayload> => {
   const { request } = useServiceProvider();
   const normalizeError = useErrorNormalizer();
-  const runSuccessOperations = useSuccessOperations(config?.successOperations);
+  const runSuccessOperations = useSuccessOperations(
+    config?.successOperations,
+    config?.mutationName
+  );
   const { applyMiddleware } = useSchemaMiddleware(config?.middleware);
   const userHeaders = useUserRequestHeaders();
 

--- a/javascript/packages/core/interpolation/types.ts
+++ b/javascript/packages/core/interpolation/types.ts
@@ -44,6 +44,10 @@ export interface UserDataSources {
    * Endpoint that was invoked to generate the {@link response} interpolation property
    */
   endpoint?: string;
+  /**
+   * Name of the mutation that was invoked to generate the {@link response} interpolation property
+   */
+  mutationName?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
Enable consumer success operations to derive behavior based on the mutation name. Mutation name is a proxy for context the interpolation is running in. For example, a single form could have different success behavior for create versus update.

## Test Plan
New test verifies mutationName is available in the resolver context and resolves correctly in toast message interpolation.

