### PR TITLE
feat(core): set mutationKey on useStudioMutation for MutationCache integration

### DIFF
--- a/javascript/packages/core/hooks/use-studio-mutation/__tests__/use-studio-mutation.test.ts
+++ b/javascript/packages/core/hooks/use-studio-mutation/__tests__/use-studio-mutation.test.ts
@@ -8,6 +8,7 @@ import { getErrorProviderWrapper } from '#core/test/wrappers/get-error-provider-
 import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
 import {
   createQueryMockRouter,
+  createServiceProviderTestContext,
   getServiceProviderWrapper,
 } from '#core/test/wrappers/get-service-provider-wrapper';
 import { getSnackbarProviderWrapper } from '#core/test/wrappers/get-snackbar-provider-wrapper';
@@ -40,10 +41,21 @@ describe('useStudioMutation', () => {
     });
   });
 
-  test('sets mutationKey from config.mutationName for query cache tracking', async () => {
+  test('sets mutationKey so MutationCache can observe mutations by name', async () => {
     const mockResponse = { id: 'test-id' };
     const mockRequest = createQueryMockRouter({
       CreatePipeline: mockResponse,
+    });
+    const onMutationSuccess = vi.fn();
+
+    const { handles, wrapper: serviceWrapper } = createServiceProviderTestContext({
+      request: mockRequest,
+    });
+
+    handles.queryClient.getMutationCache().subscribe((event) => {
+      if (event.type === 'updated' && event.mutation.state.status === 'success') {
+        onMutationSuccess(event.mutation.options.mutationKey);
+      }
     });
 
     const { result } = renderHook(
@@ -51,7 +63,7 @@ describe('useStudioMutation', () => {
       buildWrapper([
         getErrorProviderWrapper(),
         getRouterWrapper(),
-        getServiceProviderWrapper({ request: mockRequest }),
+        serviceWrapper,
         getSnackbarProviderWrapper(),
       ])
     );
@@ -59,8 +71,7 @@ describe('useStudioMutation', () => {
     result.current.mutate({ name: 'test-pipeline' });
 
     await waitFor(() => {
-      expect(mockRequest).toHaveBeenCalledWith('CreatePipeline', { name: 'test-pipeline' }, {});
-      expect(result.current.data).toEqual(mockResponse);
+      expect(onMutationSuccess).toHaveBeenCalledWith(['CreatePipeline']);
     });
   });
 

--- a/javascript/packages/core/hooks/use-studio-mutation/__tests__/use-studio-mutation.test.ts
+++ b/javascript/packages/core/hooks/use-studio-mutation/__tests__/use-studio-mutation.test.ts
@@ -40,6 +40,30 @@ describe('useStudioMutation', () => {
     });
   });
 
+  test('sets mutationKey from config.mutationName for query cache tracking', async () => {
+    const mockResponse = { id: 'test-id' };
+    const mockRequest = createQueryMockRouter({
+      CreatePipeline: mockResponse,
+    });
+
+    const { result } = renderHook(
+      () => useStudioMutation({ mutationName: 'CreatePipeline' }),
+      buildWrapper([
+        getErrorProviderWrapper(),
+        getRouterWrapper(),
+        getServiceProviderWrapper({ request: mockRequest }),
+        getSnackbarProviderWrapper(),
+      ])
+    );
+
+    result.current.mutate({ name: 'test-pipeline' });
+
+    await waitFor(() => {
+      expect(mockRequest).toHaveBeenCalledWith('CreatePipeline', { name: 'test-pipeline' }, {});
+      expect(result.current.data).toEqual(mockResponse);
+    });
+  });
+
   test('applies config.middleware to variables before calling request', async () => {
     const mockResponse = { id: 'test-id' };
     const mockRequest = createQueryMockRouter({

--- a/javascript/packages/core/hooks/use-studio-mutation/use-studio-mutation.ts
+++ b/javascript/packages/core/hooks/use-studio-mutation/use-studio-mutation.ts
@@ -20,6 +20,7 @@ export const useStudioMutation = <TResponse, TPayload extends Record<string, unk
   const userHeaders = useUserRequestHeaders();
 
   const mutation = useMutation<TResponse, ApplicationError, TPayload>({
+    mutationKey: config ? [config.mutationName] : undefined,
     mutationFn: async (payload: TPayload) => {
       if (!config) throw new Error('useStudioMutation called without config');
       try {


### PR DESCRIPTION
## Summary
Enable consumer apps to use React Query's MutationCache for automatic query invalidation based on mutation names.

## Test Plan
Integration-style test added on use-studio-mutation 
