### PR TITLE
feat(js): schema-aware wrappers for all field types

### DIFF
--- a/javascript/packages/core/components/form/__tests__/config-driven-form.test.tsx
+++ b/javascript/packages/core/components/form/__tests__/config-driven-form.test.tsx
@@ -7,6 +7,7 @@ import { FormProvider } from '#core/providers/form-provider/form-provider';
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
 import { getIconProviderWrapper } from '#core/test/wrappers/get-icon-provider-wrapper';
+import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
 
 import type { FieldRendererProps, FormConfig } from '#core/components/form/types/config-types';
 
@@ -15,15 +16,40 @@ describe('ConfigDrivenForm', () => {
     const config: FormConfig = {
       fields: {
         name: { type: 'string', label: 'Name' },
-        email: { type: 'string', label: 'Email' },
+        age: { type: 'number', label: 'Age' },
+        active: { type: 'boolean', label: 'Active', checkboxLabel: 'Is Active' },
+        role: { type: 'select', label: 'Role', options: [{ id: 'admin', label: 'Admin' }] },
+        permissions: {
+          type: 'checkbox',
+          label: 'Permissions',
+          options: [{ id: 'read', label: 'Read' }],
+        },
+        size: { type: 'radio', label: 'Size', options: [{ value: 'sm', label: 'Small' }] },
+        startDate: { type: 'date', label: 'Start Date', placeholder: 'MM/DD/YYYY' },
+        notes: { type: 'textarea', label: 'Notes' },
+        website: { type: 'url', label: 'Website', placeholder: 'No URL' },
+        tags: { type: 'map', label: 'Tags' },
+        content: { type: 'markdown', label: 'Content' },
       },
-      layout: ['name', 'email'],
+      layout: [
+        'name',
+        'age',
+        'active',
+        'role',
+        'permissions',
+        'size',
+        'startDate',
+        'notes',
+        'website',
+        'tags',
+        'content',
+      ],
     };
 
     beforeEach(() => {
       render(
         <ConfigDrivenForm config={config} onSubmit={vi.fn()} />,
-        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper(), getRouterWrapper()])
       );
     });
 
@@ -31,9 +57,50 @@ describe('ConfigDrivenForm', () => {
       expect(screen.getByLabelText('Name')).toBeInTheDocument();
     });
 
-    it('renders all configured fields', () => {
-      expect(screen.getByLabelText('Name')).toBeInTheDocument();
-      expect(screen.getByLabelText('Email')).toBeInTheDocument();
+    it('renders a number field', () => {
+      expect(screen.getByLabelText('Age')).toBeInTheDocument();
+    });
+
+    it('renders a boolean field', () => {
+      expect(screen.getByRole('checkbox', { name: 'Is Active' })).toBeInTheDocument();
+    });
+
+    it('renders a select field', async () => {
+      const user = userEvent.setup();
+      await user.click(screen.getByText('Select...'));
+
+      expect(screen.getByRole('option', { name: 'Admin' })).toBeInTheDocument();
+    });
+
+    it('renders a checkbox field', () => {
+      expect(screen.getByRole('checkbox', { name: 'Read' })).toBeInTheDocument();
+    });
+
+    it('renders a radio field', () => {
+      expect(screen.getByRole('radio', { name: 'Small' })).toBeInTheDocument();
+    });
+
+    it('renders a date field', () => {
+      expect(screen.getByPlaceholderText('MM/DD/YYYY')).toBeInTheDocument();
+    });
+
+    it('renders a textarea field', () => {
+      expect(screen.getByLabelText('Notes')).toBeInTheDocument();
+    });
+
+    it('renders a url field', () => {
+      expect(screen.getByText('No URL')).toBeInTheDocument();
+    });
+
+    it('renders a map field', async () => {
+      const user = userEvent.setup();
+      await user.click(screen.getByRole('button', { name: 'Add more' }));
+
+      expect(screen.getAllByRole('textbox', { name: '' }).length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('renders a markdown field', () => {
+      expect(screen.getByLabelText('Content')).toBeInTheDocument();
     });
   });
 

--- a/javascript/packages/core/components/form/constants.ts
+++ b/javascript/packages/core/components/form/constants.ts
@@ -1,8 +1,28 @@
+import { SchemaBooleanField } from './fields/boolean/schema-boolean-field';
+import { SchemaCheckboxField } from './fields/checkbox/schema-checkbox-field';
+import { SchemaDateField } from './fields/date/schema-date-field';
+import { SchemaMapField } from './fields/map/schema-map-field';
+import { SchemaMarkdownField } from './fields/markdown/schema-markdown-field';
+import { SchemaNumberField } from './fields/number/schema-number-field';
+import { SchemaRadioField } from './fields/radio/schema-radio-field';
+import { SchemaSelectField } from './fields/select/schema-select-field';
 import { SchemaStringField } from './fields/string/schema-string-field';
+import { SchemaTextareaField } from './fields/textarea/schema-textarea-field';
+import { SchemaUrlField } from './fields/url/schema-url-field';
 
 import type { FieldRenderer, FieldType } from './types/config-types';
 
 /** Built-in field renderer registry. FormProvider renderers take priority over these. */
-export const FIELD_RENDERERS: Partial<Record<FieldType, FieldRenderer>> = {
+export const FIELD_RENDERERS: Record<FieldType, FieldRenderer> = {
   string: SchemaStringField,
+  number: SchemaNumberField,
+  boolean: SchemaBooleanField,
+  select: SchemaSelectField,
+  checkbox: SchemaCheckboxField,
+  radio: SchemaRadioField,
+  date: SchemaDateField,
+  textarea: SchemaTextareaField,
+  url: SchemaUrlField,
+  map: SchemaMapField,
+  markdown: SchemaMarkdownField,
 };

--- a/javascript/packages/core/components/form/fields/boolean/schema-boolean-field.tsx
+++ b/javascript/packages/core/components/form/fields/boolean/schema-boolean-field.tsx
@@ -1,0 +1,22 @@
+import { BooleanField } from './boolean-field';
+
+import type { FieldRendererProps } from '#core/components/form/types/config-types';
+import type { BooleanFieldConfig } from './types';
+
+export function SchemaBooleanField({ name, config }: FieldRendererProps) {
+  // cast: SchemaField routes by config.type, guaranteeing BooleanFieldConfig
+  const c = config as BooleanFieldConfig;
+  return (
+    <BooleanField
+      name={name}
+      label={c.label}
+      required={c.required}
+      disabled={c.disabled}
+      readOnly={c.readOnly}
+      description={c.description}
+      caption={c.caption}
+      checkboxLabel={c.checkboxLabel}
+      toggle={c.toggle}
+    />
+  );
+}

--- a/javascript/packages/core/components/form/fields/boolean/types.ts
+++ b/javascript/packages/core/components/form/fields/boolean/types.ts
@@ -1,4 +1,4 @@
-import type { BaseFieldProps } from '../types';
+import type { BaseFieldProps, SharedFieldConfig } from '../types';
 
 export interface BooleanFieldProps extends BaseFieldProps<boolean> {
   /**
@@ -15,3 +15,8 @@ export interface BooleanFieldProps extends BaseFieldProps<boolean> {
    */
   toggle?: boolean;
 }
+
+export type BooleanFieldConfig<T = boolean> = SharedFieldConfig<T, boolean> &
+  Pick<BooleanFieldProps, 'checkboxLabel' | 'toggle'> & {
+    type: 'boolean';
+  };

--- a/javascript/packages/core/components/form/fields/checkbox/schema-checkbox-field.tsx
+++ b/javascript/packages/core/components/form/fields/checkbox/schema-checkbox-field.tsx
@@ -1,0 +1,21 @@
+import { CheckboxField } from './checkbox-field';
+
+import type { FieldRendererProps } from '#core/components/form/types/config-types';
+import type { CheckboxFieldConfig } from './types';
+
+export function SchemaCheckboxField({ name, config }: FieldRendererProps) {
+  // cast: SchemaField routes by config.type, guaranteeing CheckboxFieldConfig
+  const c = config as CheckboxFieldConfig;
+  return (
+    <CheckboxField
+      name={name}
+      label={c.label}
+      required={c.required}
+      disabled={c.disabled}
+      readOnly={c.readOnly}
+      description={c.description}
+      caption={c.caption}
+      options={c.options ?? []}
+    />
+  );
+}

--- a/javascript/packages/core/components/form/fields/checkbox/types.ts
+++ b/javascript/packages/core/components/form/fields/checkbox/types.ts
@@ -1,4 +1,4 @@
-import type { BaseFieldProps } from '#core/components/form/fields/types';
+import type { BaseFieldProps, SharedFieldConfig } from '#core/components/form/fields/types';
 
 export interface CheckboxOption {
   id: string;
@@ -9,3 +9,8 @@ export interface CheckboxOption {
 export interface CheckboxFieldProps extends BaseFieldProps<string[]> {
   options: CheckboxOption[];
 }
+
+export type CheckboxFieldConfig<T = string[]> = SharedFieldConfig<T, string[]> &
+  Pick<CheckboxFieldProps, 'options'> & {
+    type: 'checkbox';
+  };

--- a/javascript/packages/core/components/form/fields/date/schema-date-field.tsx
+++ b/javascript/packages/core/components/form/fields/date/schema-date-field.tsx
@@ -1,0 +1,23 @@
+import { DateField } from './date-field';
+
+import type { FieldRendererProps } from '#core/components/form/types/config-types';
+import type { DateFieldConfig } from './types';
+
+export function SchemaDateField({ name, config }: FieldRendererProps) {
+  // cast: SchemaField routes by config.type, guaranteeing DateFieldConfig
+  const c = config as DateFieldConfig;
+  return (
+    <DateField
+      name={name}
+      label={c.label}
+      required={c.required}
+      disabled={c.disabled}
+      readOnly={c.readOnly}
+      placeholder={c.placeholder}
+      description={c.description}
+      caption={c.caption}
+      dateFormat={c.dateFormat}
+      noFutureDate={c.noFutureDate}
+    />
+  );
+}

--- a/javascript/packages/core/components/form/fields/date/types.ts
+++ b/javascript/packages/core/components/form/fields/date/types.ts
@@ -1,4 +1,4 @@
-import type { BaseFieldProps } from '../types';
+import type { BaseFieldProps, SharedFieldConfig } from '../types';
 
 export interface DateFieldProps extends BaseFieldProps<string, Date | null> {
   /** @default DateFormat.ISO_DATE_STRING */
@@ -21,3 +21,8 @@ export enum DateFormat {
    */
   ISO_DATE_STRING = 'iso',
 }
+
+export type DateFieldConfig<T = string> = SharedFieldConfig<T, Date | null> &
+  Pick<DateFieldProps, 'dateFormat' | 'noFutureDate'> & {
+    type: 'date';
+  };

--- a/javascript/packages/core/components/form/fields/map/schema-map-field.tsx
+++ b/javascript/packages/core/components/form/fields/map/schema-map-field.tsx
@@ -1,0 +1,27 @@
+import { MapField } from './map-field';
+
+import type { FieldRendererProps } from '#core/components/form/types/config-types';
+import type { MapFieldConfig } from './types';
+
+export function SchemaMapField({ name, config }: FieldRendererProps) {
+  // cast: SchemaField routes by config.type, guaranteeing MapFieldConfig
+  const c = config as MapFieldConfig;
+  return (
+    <MapField
+      name={name}
+      label={c.label}
+      required={c.required}
+      disabled={c.disabled}
+      readOnly={c.readOnly}
+      description={c.description}
+      caption={c.caption}
+      singleValue={c.singleValue}
+      creatable={c.creatable}
+      deletable={c.deletable}
+      emptyMessage={c.emptyMessage}
+      keyConfig={c.keyConfig}
+      valueConfig={c.valueConfig}
+      size={c.size}
+    />
+  );
+}

--- a/javascript/packages/core/components/form/fields/map/types.ts
+++ b/javascript/packages/core/components/form/fields/map/types.ts
@@ -1,5 +1,5 @@
 import type { SIZE } from 'baseui/input';
-import type { BaseFieldProps } from '#core/components/form/fields/types';
+import type { BaseFieldProps, SharedFieldConfig } from '#core/components/form/fields/types';
 
 export interface KeyValueEntry {
   /** Stable React key — monotonically increasing, never reused after deletion. */
@@ -35,3 +35,20 @@ export interface MapFieldOwnProps extends KeyValueRowConfig {
 }
 
 export type MapFieldProps = MapFieldOwnProps & BaseFieldProps<Record<string, string>>;
+
+export type MapFieldConfig<T = Record<string, string>> = SharedFieldConfig<
+  T,
+  Record<string, string>
+> &
+  Pick<
+    MapFieldOwnProps & KeyValueRowConfig,
+    | 'singleValue'
+    | 'creatable'
+    | 'emptyMessage'
+    | 'keyConfig'
+    | 'valueConfig'
+    | 'deletable'
+    | 'size'
+  > & {
+    type: 'map';
+  };

--- a/javascript/packages/core/components/form/fields/markdown/schema-markdown-field.tsx
+++ b/javascript/packages/core/components/form/fields/markdown/schema-markdown-field.tsx
@@ -1,0 +1,23 @@
+import { MarkdownField } from './markdown-field';
+
+import type { FieldRendererProps } from '#core/components/form/types/config-types';
+import type { MarkdownFieldConfig } from './types';
+
+export function SchemaMarkdownField({ name, config }: FieldRendererProps) {
+  // cast: SchemaField routes by config.type, guaranteeing MarkdownFieldConfig
+  const c = config as MarkdownFieldConfig;
+  return (
+    <MarkdownField
+      name={name}
+      label={c.label}
+      required={c.required}
+      disabled={c.disabled}
+      readOnly={c.readOnly}
+      placeholder={c.placeholder}
+      description={c.description}
+      caption={c.caption}
+      rows={c.rows}
+      maxLength={c.maxLength}
+    />
+  );
+}

--- a/javascript/packages/core/components/form/fields/markdown/types.ts
+++ b/javascript/packages/core/components/form/fields/markdown/types.ts
@@ -1,4 +1,4 @@
-import type { BaseFieldProps } from '../types';
+import type { BaseFieldProps, SharedFieldConfig } from '../types';
 
 export interface MarkdownFieldProps extends BaseFieldProps<string> {
   rows?: number;
@@ -9,3 +9,8 @@ export interface MarkdownFieldProps extends BaseFieldProps<string> {
    */
   maxLength?: number;
 }
+
+export type MarkdownFieldConfig<T = string> = SharedFieldConfig<T, string> &
+  Pick<MarkdownFieldProps, 'rows' | 'maxLength'> & {
+    type: 'markdown';
+  };

--- a/javascript/packages/core/components/form/fields/number/schema-number-field.tsx
+++ b/javascript/packages/core/components/form/fields/number/schema-number-field.tsx
@@ -1,0 +1,21 @@
+import { NumberField } from './number-field';
+
+import type { FieldRendererProps } from '#core/components/form/types/config-types';
+import type { NumberFieldConfig } from './types';
+
+export function SchemaNumberField({ name, config }: FieldRendererProps) {
+  // cast: SchemaField routes by config.type, guaranteeing NumberFieldConfig
+  const c = config as NumberFieldConfig;
+  return (
+    <NumberField
+      name={name}
+      label={c.label}
+      required={c.required}
+      disabled={c.disabled}
+      readOnly={c.readOnly}
+      placeholder={c.placeholder}
+      description={c.description}
+      caption={c.caption}
+    />
+  );
+}

--- a/javascript/packages/core/components/form/fields/number/types.ts
+++ b/javascript/packages/core/components/form/fields/number/types.ts
@@ -1,0 +1,7 @@
+import type { BaseFieldProps, SharedFieldConfig } from '../types';
+
+export type NumberFieldProps = BaseFieldProps<number | undefined>;
+
+export type NumberFieldConfig<T = number | undefined> = SharedFieldConfig<T, number | undefined> & {
+  type: 'number';
+};

--- a/javascript/packages/core/components/form/fields/radio/schema-radio-field.tsx
+++ b/javascript/packages/core/components/form/fields/radio/schema-radio-field.tsx
@@ -1,0 +1,22 @@
+import { RadioField } from './radio-field';
+
+import type { FieldRendererProps } from '#core/components/form/types/config-types';
+import type { RadioFieldConfig } from './types';
+
+export function SchemaRadioField({ name, config }: FieldRendererProps) {
+  // cast: SchemaField routes by config.type, guaranteeing RadioFieldConfig
+  const c = config as RadioFieldConfig;
+  return (
+    <RadioField
+      name={name}
+      label={c.label}
+      required={c.required}
+      disabled={c.disabled}
+      readOnly={c.readOnly}
+      description={c.description}
+      caption={c.caption}
+      options={c.options ?? []}
+      align={c.align}
+    />
+  );
+}

--- a/javascript/packages/core/components/form/fields/radio/types.ts
+++ b/javascript/packages/core/components/form/fields/radio/types.ts
@@ -1,5 +1,5 @@
 import type { Align } from 'baseui/radio';
-import type { BaseFieldProps } from '../types';
+import type { BaseFieldProps, SharedFieldConfig } from '../types';
 
 export interface RadioOption {
   value: string | boolean;
@@ -13,3 +13,8 @@ export interface RadioFieldProps extends BaseFieldProps<string | boolean> {
   options: RadioOption[];
   align?: Align;
 }
+
+export type RadioFieldConfig<T = string | boolean> = SharedFieldConfig<T, string | boolean> &
+  Pick<RadioFieldProps, 'options' | 'align'> & {
+    type: 'radio';
+  };

--- a/javascript/packages/core/components/form/fields/select/schema-select-field.tsx
+++ b/javascript/packages/core/components/form/fields/select/schema-select-field.tsx
@@ -6,29 +6,6 @@ import type { SelectFieldConfig } from './types';
 export function SchemaSelectField({ name, config }: FieldRendererProps) {
   // cast: SchemaField routes by config.type, guaranteeing SelectFieldConfig
   const c = config as SelectFieldConfig;
-  const options = c.options ?? [];
-
-  if (c.multi) {
-    return (
-      <SelectField
-        name={name}
-        label={c.label}
-        required={c.required}
-        disabled={c.disabled}
-        readOnly={c.readOnly}
-        placeholder={c.placeholder}
-        description={c.description}
-        caption={c.caption}
-        options={options}
-        multi
-        clearable={c.clearable}
-        searchable={c.searchable}
-        creatable={c.creatable}
-        isLoading={c.isLoading}
-        visibleOptionLimit={c.visibleOptionLimit}
-      />
-    );
-  }
 
   return (
     <SelectField
@@ -40,7 +17,8 @@ export function SchemaSelectField({ name, config }: FieldRendererProps) {
       placeholder={c.placeholder}
       description={c.description}
       caption={c.caption}
-      options={options}
+      options={c.options ?? []}
+      multi={c.multi}
       clearable={c.clearable}
       searchable={c.searchable}
       creatable={c.creatable}

--- a/javascript/packages/core/components/form/fields/select/schema-select-field.tsx
+++ b/javascript/packages/core/components/form/fields/select/schema-select-field.tsx
@@ -1,0 +1,51 @@
+import { SelectField } from './select-field';
+
+import type { FieldRendererProps } from '#core/components/form/types/config-types';
+import type { SelectFieldConfig } from './types';
+
+export function SchemaSelectField({ name, config }: FieldRendererProps) {
+  // cast: SchemaField routes by config.type, guaranteeing SelectFieldConfig
+  const c = config as SelectFieldConfig;
+  const options = c.options ?? [];
+
+  if (c.multi) {
+    return (
+      <SelectField
+        name={name}
+        label={c.label}
+        required={c.required}
+        disabled={c.disabled}
+        readOnly={c.readOnly}
+        placeholder={c.placeholder}
+        description={c.description}
+        caption={c.caption}
+        options={options}
+        multi
+        clearable={c.clearable}
+        searchable={c.searchable}
+        creatable={c.creatable}
+        isLoading={c.isLoading}
+        visibleOptionLimit={c.visibleOptionLimit}
+      />
+    );
+  }
+
+  return (
+    <SelectField
+      name={name}
+      label={c.label}
+      required={c.required}
+      disabled={c.disabled}
+      readOnly={c.readOnly}
+      placeholder={c.placeholder}
+      description={c.description}
+      caption={c.caption}
+      options={options}
+      clearable={c.clearable}
+      searchable={c.searchable}
+      creatable={c.creatable}
+      isLoading={c.isLoading}
+      visibleOptionLimit={c.visibleOptionLimit}
+    />
+  );
+}

--- a/javascript/packages/core/components/form/fields/select/types.ts
+++ b/javascript/packages/core/components/form/fields/select/types.ts
@@ -1,4 +1,4 @@
-import type { BaseFieldProps } from '../types';
+import type { BaseFieldProps, SharedFieldConfig } from '../types';
 
 export interface SelectOption<V = string | number> {
   id: V;
@@ -22,3 +22,27 @@ interface SelectFieldOwnProps<V> {
 export type SelectFieldProps<V = string | number> =
   | (SelectFieldOwnProps<V> & BaseFieldProps<V> & { multi?: false })
   | (SelectFieldOwnProps<V> & BaseFieldProps<V[]> & { multi: true });
+
+type SelectFieldConfigOwnProps = Pick<
+  SelectFieldOwnProps<string | number>,
+  'options' | 'clearable' | 'searchable' | 'creatable' | 'isLoading' | 'visibleOptionLimit'
+>;
+
+export type SingleSelectFieldConfig<T = string | number> = SharedFieldConfig<T, string | number> &
+  SelectFieldConfigOwnProps & {
+    type: 'select';
+    multi?: false;
+  };
+
+export type MultiSelectFieldConfig<T = Array<string | number>> = SharedFieldConfig<
+  T,
+  Array<string | number>
+> &
+  SelectFieldConfigOwnProps & {
+    type: 'select';
+    multi: true;
+  };
+
+export type SelectFieldConfig<T = string | number> =
+  | SingleSelectFieldConfig<T>
+  | MultiSelectFieldConfig<T>;

--- a/javascript/packages/core/components/form/fields/textarea/schema-textarea-field.tsx
+++ b/javascript/packages/core/components/form/fields/textarea/schema-textarea-field.tsx
@@ -1,0 +1,23 @@
+import { TextareaField } from './textarea-field';
+
+import type { FieldRendererProps } from '#core/components/form/types/config-types';
+import type { TextareaFieldConfig } from './types';
+
+export function SchemaTextareaField({ name, config }: FieldRendererProps) {
+  // cast: SchemaField routes by config.type, guaranteeing TextareaFieldConfig
+  const c = config as TextareaFieldConfig;
+  return (
+    <TextareaField
+      name={name}
+      label={c.label}
+      required={c.required}
+      disabled={c.disabled}
+      readOnly={c.readOnly}
+      placeholder={c.placeholder}
+      description={c.description}
+      caption={c.caption}
+      rows={c.rows}
+      maxLength={c.maxLength}
+    />
+  );
+}

--- a/javascript/packages/core/components/form/fields/textarea/types.ts
+++ b/javascript/packages/core/components/form/fields/textarea/types.ts
@@ -1,4 +1,4 @@
-import type { BaseFieldProps } from '../types';
+import type { BaseFieldProps, SharedFieldConfig } from '../types';
 
 export interface TextareaFieldProps extends BaseFieldProps<string> {
   rows?: number;
@@ -14,3 +14,8 @@ export interface MaxLengthLabelEnhancerProps {
   maxLength: number;
   currentLength: number;
 }
+
+export type TextareaFieldConfig<T = string> = SharedFieldConfig<T, string> &
+  Pick<TextareaFieldProps, 'rows' | 'maxLength'> & {
+    type: 'textarea';
+  };

--- a/javascript/packages/core/components/form/fields/url/schema-url-field.tsx
+++ b/javascript/packages/core/components/form/fields/url/schema-url-field.tsx
@@ -1,0 +1,22 @@
+import { UrlField } from './url-field';
+
+import type { FieldRendererProps } from '#core/components/form/types/config-types';
+import type { UrlFieldConfig } from './types';
+
+export function SchemaUrlField({ name, config }: FieldRendererProps) {
+  // cast: SchemaField routes by config.type, guaranteeing UrlFieldConfig
+  const c = config as UrlFieldConfig;
+  return (
+    <UrlField
+      name={name}
+      label={c.label}
+      required={c.required}
+      disabled={c.disabled}
+      readOnly={c.readOnly}
+      placeholder={c.placeholder}
+      description={c.description}
+      caption={c.caption}
+      urlName={c.urlName}
+    />
+  );
+}

--- a/javascript/packages/core/components/form/fields/url/types.ts
+++ b/javascript/packages/core/components/form/fields/url/types.ts
@@ -1,6 +1,11 @@
-import type { BaseFieldProps } from '#core/components/form/fields/types';
+import type { BaseFieldProps, SharedFieldConfig } from '#core/components/form/fields/types';
 
 export interface UrlFieldProps extends BaseFieldProps<string> {
   /** Display label for the link; falls back to the field value if omitted */
   urlName?: string;
 }
+
+export type UrlFieldConfig<T = string> = SharedFieldConfig<T, string> &
+  Pick<UrlFieldProps, 'urlName'> & {
+    type: 'url';
+  };

--- a/javascript/packages/core/components/form/types/config-types.ts
+++ b/javascript/packages/core/components/form/types/config-types.ts
@@ -1,6 +1,16 @@
 import type { ComponentType } from 'react';
+import type { BooleanFieldConfig } from '#core/components/form/fields/boolean/types';
+import type { CheckboxFieldConfig } from '#core/components/form/fields/checkbox/types';
+import type { DateFieldConfig } from '#core/components/form/fields/date/types';
+import type { MapFieldConfig } from '#core/components/form/fields/map/types';
+import type { MarkdownFieldConfig } from '#core/components/form/fields/markdown/types';
+import type { NumberFieldConfig } from '#core/components/form/fields/number/types';
+import type { RadioFieldConfig } from '#core/components/form/fields/radio/types';
+import type { SelectFieldConfig } from '#core/components/form/fields/select/types';
 import type { StringFieldConfig } from '#core/components/form/fields/string/types';
+import type { TextareaFieldConfig } from '#core/components/form/fields/textarea/types';
 import type { SharedFieldConfig } from '#core/components/form/fields/types';
+import type { UrlFieldConfig } from '#core/components/form/fields/url/types';
 import type { FormGridLayoutConfig } from '#core/components/form/layout/form-grid/types';
 import type { FormGroupLayoutConfig } from '#core/components/form/layout/form-group/types';
 import type { FormRowLayoutConfig } from '#core/components/form/layout/form-row/types';
@@ -27,7 +37,18 @@ export type LayoutItem = LayoutConfig | string;
 export type LayoutConfig = FormGroupLayoutConfig | FormRowLayoutConfig | FormGridLayoutConfig;
 
 /** Union of all field config types implemented by packages/core. */
-export type BuiltinFieldConfig = StringFieldConfig;
+export type BuiltinFieldConfig =
+  | StringFieldConfig
+  | NumberFieldConfig
+  | BooleanFieldConfig
+  | SelectFieldConfig
+  | CheckboxFieldConfig
+  | RadioFieldConfig
+  | DateFieldConfig
+  | TextareaFieldConfig
+  | UrlFieldConfig
+  | MapFieldConfig
+  | MarkdownFieldConfig;
 
 /**
  * Module-augmentation extension point for consumer field configs.
@@ -50,6 +71,56 @@ export enum FieldType {
    * @description Renders a single-line **Input** or, with `multi: true`, a **Tag input** for multiple values
    */
   STRING = 'string',
+
+  /**
+   * @description Renders a numeric **Input** (`type="number"`)
+   */
+  NUMBER = 'number',
+
+  /**
+   * @description Renders a **Checkbox** or, with `toggle: true`, a **Toggle** switch
+   */
+  BOOLEAN = 'boolean',
+
+  /**
+   * @description Renders a **Select** dropdown with searchable options
+   */
+  SELECT = 'select',
+
+  /**
+   * @description Renders a **CheckboxGroup** for multiple selections
+   */
+  CHECKBOX = 'checkbox',
+
+  /**
+   * @description Renders a **RadioGroup** for single selection
+   */
+  RADIO = 'radio',
+
+  /**
+   * @description Renders a **DatePicker** with calendar popover
+   */
+  DATE = 'date',
+
+  /**
+   * @description Renders a multi-line **Textarea**
+   */
+  TEXTAREA = 'textarea',
+
+  /**
+   * @description Renders a read-only **Link** when the value is a navigable URL, otherwise a placeholder
+   */
+  URL = 'url',
+
+  /**
+   * @description Renders a **key-value editor** with add/remove rows
+   */
+  MAP = 'map',
+
+  /**
+   * @description Renders a **Textarea** in edit mode or formatted **Markdown** in read-only mode
+   */
+  MARKDOWN = 'markdown',
 }
 
 /** Props passed to a field renderer by the config-driven form system. */


### PR DESCRIPTION
## Summary
Every built-in field component now has a config-driven counterpart that bridges FieldConfig to component props. Config authors get typed options for each field type — select options, textarea rows, boolean toggle, map key/value config — without writing JSX.

## Test plan

- I verified all 11 field types render correctly in the sandbox (string, number, boolean toggle, select, textarea, url, map, markdown, checkbox, radio, date)
- I verified row layout with side-by-side fields (Priority + Replicas)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Test Plan


## Issues

