### PR TITLE
chore: bump version to 0.7.0-rc.1

### DIFF
--- a/helm/michelangelo/Chart.yaml
+++ b/helm/michelangelo/Chart.yaml
@@ -7,8 +7,8 @@ description: |
   and RBAC — into any Kubernetes cluster. Bring your own metadata storage,
   object storage, and workflow engine (Cadence or Temporal).
 type: application
-version: 0.6.0
-appVersion: "0.6.0"
+version: 0.7.0-rc.1
+appVersion: "0.7.0-rc.1"
 kubeVersion: ">=1.27.0-0"
 
 dependencies:

--- a/javascript/app/package.json
+++ b/javascript/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@michelangelo/app",
   "license": "Apache-2.0",
-  "version": "0.6.0",
+  "version": "0.7.0-rc.1",
   "private": true,
   "scripts": {
     "build": "vite build --config vite.config.ts",
@@ -11,11 +11,11 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
-    "@michelangelo-ai/rpc": "0.6.0",
+    "@michelangelo-ai/rpc": "0.7.0-rc.1",
     "@mui/icons-material": "^7.1.0",
     "@mui/material": "^7.1.0",
     "@tanstack/react-query": "5.39.0",
-    "@michelangelo-ai/core": "0.6.0",
+    "@michelangelo-ai/core": "0.7.0-rc.1",
     "baseui": "15.0.0",
     "react-router-dom": "5.3.4",
     "react-router-dom-v5-compat": "6.29.0",

--- a/javascript/packages/core/package.json
+++ b/javascript/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@michelangelo-ai/core",
   "license": "Apache-2.0",
-  "version": "0.6.0",
+  "version": "0.7.0-rc.1",
   "type": "module",
   "main": "./dist/michelangelo-core.js",
   "module": "./dist/michelangelo-core.js",

--- a/javascript/packages/rpc/package.json
+++ b/javascript/packages/rpc/package.json
@@ -2,7 +2,7 @@
   "name": "@michelangelo-ai/rpc",
   "license": "Apache-2.0",
   "type": "module",
-  "version": "0.6.0",
+  "version": "0.7.0-rc.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/michelangelo-ai/michelangelo"
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.2.5",
-    "@michelangelo-ai/core": "0.6.0"
+    "@michelangelo-ai/core": "0.7.0-rc.1"
   },
   "exports": {
     ".": {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "michelangelo"
-version = "0.6.0"
+version = "0.7.0-rc.1"
 description = "Michelangelo AI is an end-to-end model lifecycle management system at large scale"
 authors = ["Michelangelo AI Team <michelangelo-oss-group@uber.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary
Manual completion of the `v0.7.0-rc.1` cut. `release-cut.yml`'s "Bump versions to RC" step failed with a `GH013` rule violation (push to an already-existing protected branch requires a PR) — confirmed via run history this is a **regression**: the identical rc_number=1 scenario succeeded on 2026-07-17 (run 29616938626), so the branch ruleset appears to have been tightened since then to also block `github-actions[bot]`'s second push within the same workflow run. `release/v0.7` was created (first push, exempt as ref-creation) but left un-bumped at main's tip.

This PR carries the version bump `scripts/version-bump.sh` would have committed directly:
- `python/pyproject.toml`
- `javascript/packages/core/package.json`
- `javascript/packages/rpc/package.json`
- `javascript/app/package.json`
- `helm/michelangelo/Chart.yaml` (version + appVersion)

Failed run: https://github.com/michelangelo-ai/michelangelo/actions/runs/30674238765/job/91298063813

## Next steps after merge
- Tag `v0.7.0-rc.1` on `release/v0.7` and push
- Manually dispatch `release.yaml`, `changelog.yml`, `ui-release.yml`, `dev-release.yml`, `npm-publish.yml` (ref=`release/v0.7`) for the tag — the steps `release-cut.yml` would have triggered had it completed
- Create tracking issue "Release v0.7.0" and draft merge-back PR (`release/v0.7` -> `main`)
- File a follow-up issue: `release-cut.yml` needs the same fix as `release-promote.yml` (`REL-005`/`michelangelo#1608`) — fold the version bump into the branch-creation commit for rc_number=1, and figure out a PR-based path for rc_number>1 (existing-branch pushes are now blocked unconditionally)

## Test plan
- [x] `scripts/version-bump.sh --check` reflects `0.7.0-rc.1` across all components (implicit in the diff)

Related to #1658.