### PR TITLE
fix(website): update footer copyright to "Michelangelo AI"

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -112,7 +112,7 @@ const config: Config = {
           ],
         },
       ],
-      copyright: `Copyright © ${new Date().getFullYear()} Michelangelo.`,
+      copyright: `Copyright © ${new Date().getFullYear()} Michelangelo AI.`,
     },
     prism: {
       theme: prismThemes.github,


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
Updated the footer copyright string in `docusaurus.config.ts` from `"Michelangelo."` to `"Michelangelo AI."`.

**Why?**
The footer displayed "Copyright © 2026 Michelangelo." — missing the "AI" suffix required by the USPTO trademark. Spotted on the live 404 page at michelangelo-ai.org.

**How did you test it?**
Single string change in config — visually verifiable on the live site after deploy.

**Potential risks**
None.

**Breaking Changes**
- [x] No breaking changes

**Release notes**
N/A

**Documentation Changes**
N/A