### PR TITLE
ci(python): run michelangelo-examples CLI e2e tests in integration-test workflow

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -80,8 +80,32 @@ jobs:
           token: ${{ secrets.CR_PAT }}
           path: integration-test
 
+      - name: Check out michelangelo-examples repo
+        uses: actions/checkout@v4
+        with:
+          repository: michelangelo-ai/michelangelo-examples
+          ref: main
+          path: michelangelo-examples
+
       - name: Install integration test dependencies
         run: .venv/bin/pip install retrying pyyaml pymysql -q
+
+      - name: Install michelangelo-examples dependencies
+        # Installed into the same venv `ma` and pytest already use: `ma pipeline apply`
+        # runs a subprocess registration step that imports the pipeline's
+        # manifest.filePath module (e.g. michelangelo_examples.california_housing...)
+        # to discover the workflow function and build the uniflow tar, so
+        # michelangelo_examples must be importable from this venv, not just checked out.
+        # --no-deps: michelangelo-examples' own pyproject pins `michelangelo>=0.6.0`
+        # (a released-package constraint), which conflicts with this venv's locally
+        # editable-installed dev-tip `michelangelo` (version 0.3.0) and isn't on the
+        # index yet -- a plain `pip install` fails outright, or worse would silently
+        # replace the dev checkout under test with a released wheel if a matching
+        # version existed. The `-E example` install above already provides every other
+        # runtime dep pytorch_train/xgb_train need (torch, pytorch_lightning, xgboost,
+        # pyspark, ray, s3fs, etc.) -- only michelangelo_examples' own thin package needs
+        # installing here.
+        run: .venv/bin/pip install -q --no-deps "$GITHUB_WORKSPACE/michelangelo-examples"
 
       - name: Run API CRUD tests
         run: |
@@ -127,6 +151,17 @@ jobs:
           MA_API_SERVER: localhost:15566
           MA_NAMESPACE: ma-dev-test
           MICHELANGELO_PYTHON_DIR: ${{ github.workspace }}/python
+          PYTHONPATH: ${{ github.workspace }}/integration-test
+
+      - name: Run michelangelo-examples CLI e2e tests
+        run: |
+          $GITHUB_WORKSPACE/python/.venv/bin/pytest \
+            functional/cli/test_examples_repo_cli.py \
+            -v -m "cli"
+        working-directory: ${{ github.workspace }}/integration-test
+        env:
+          MA_API_SERVER: localhost:15566
+          MICHELANGELO_EXAMPLES_DIR: ${{ github.workspace }}/michelangelo-examples
           PYTHONPATH: ${{ github.workspace }}/integration-test
 
       # Infrastructure is intentionally kept running between CI runs.

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -96,15 +96,21 @@ jobs:
         # manifest.filePath module (e.g. michelangelo_examples.california_housing...)
         # to discover the workflow function and build the uniflow tar, so
         # michelangelo_examples must be importable from this venv, not just checked out.
-        # --no-deps: michelangelo-examples' own pyproject pins `michelangelo>=0.6.0`
-        # (a released-package constraint), which conflicts with this venv's locally
-        # editable-installed dev-tip `michelangelo` (version 0.3.0) and isn't on the
-        # index yet -- a plain `pip install` fails outright, or worse would silently
+        # --no-deps: this job runs on a self-hosted runner whose `.venv` persists
+        # between CI runs (infra is intentionally kept running -- see below), so
+        # `poetry install`'s editable michelangelo install can carry stale dist-info
+        # metadata across a pyproject.toml version bump until the venv is next fully
+        # rebuilt. `michelangelo-examples`' own pyproject pins `michelangelo>=0.6.0`
+        # (a released-package constraint); if pip sees a stale pre-bump version string
+        # it can't satisfy locally, it falls back to querying the package index --
+        # which doesn't have 0.6.0 yet -- failing the install, or worse, would silently
         # replace the dev checkout under test with a released wheel if a matching
-        # version existed. The `-E example` install above already provides every other
-        # runtime dep pytorch_train/xgb_train need (torch, pytorch_lightning, xgboost,
-        # pyspark, ray, s3fs, etc.) -- only michelangelo_examples' own thin package needs
-        # installing here.
+        # version existed. Verified: a genuinely fresh venv resolves this fine, but a
+        # persisted one (like this runner's) can hit the stale-metadata case; --no-deps
+        # avoids the version check entirely. The `-E example` install above already
+        # provides every other runtime dep pytorch_train/xgb_train need (torch,
+        # pytorch_lightning, xgboost, pyspark, ray, s3fs, etc.) -- only
+        # michelangelo_examples' own thin package needs installing here.
         run: .venv/bin/pip install -q --no-deps "$GITHUB_WORKSPACE/michelangelo-examples"
 
       - name: Run API CRUD tests

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -91,26 +91,7 @@ jobs:
         run: .venv/bin/pip install retrying pyyaml pymysql -q
 
       - name: Install michelangelo-examples dependencies
-        # Installed into the same venv `ma` and pytest already use: `ma pipeline apply`
-        # runs a subprocess registration step that imports the pipeline's
-        # manifest.filePath module (e.g. michelangelo_examples.california_housing...)
-        # to discover the workflow function and build the uniflow tar, so
-        # michelangelo_examples must be importable from this venv, not just checked out.
-        # --no-deps: this job runs on a self-hosted runner whose `.venv` persists
-        # between CI runs (infra is intentionally kept running -- see below), so
-        # `poetry install`'s editable michelangelo install can carry stale dist-info
-        # metadata across a pyproject.toml version bump until the venv is next fully
-        # rebuilt. `michelangelo-examples`' own pyproject pins `michelangelo>=0.6.0`
-        # (a released-package constraint); if pip sees a stale pre-bump version string
-        # it can't satisfy locally, it falls back to querying the package index --
-        # which doesn't have 0.6.0 yet -- failing the install, or worse, would silently
-        # replace the dev checkout under test with a released wheel if a matching
-        # version existed. Verified: a genuinely fresh venv resolves this fine, but a
-        # persisted one (like this runner's) can hit the stale-metadata case; --no-deps
-        # avoids the version check entirely. The `-E example` install above already
-        # provides every other runtime dep pytorch_train/xgb_train need (torch,
-        # pytorch_lightning, xgboost, pyspark, ray, s3fs, etc.) -- only
-        # michelangelo_examples' own thin package needs installing here.
+        # only michelangelo_examples' own thin package needs installing here.
         run: .venv/bin/pip install -q --no-deps "$GITHUB_WORKSPACE/michelangelo-examples"
 
       - name: Run API CRUD tests


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**
Checks out `michelangelo-ai/michelangelo-examples` in the `integration-test` CI job, installs it into the same venv `ma`/pytest use (`pip install --no-deps`, so the subprocess-based pipeline registration step can import `michelangelo_examples.*`), and runs a new `functional/cli/test_examples_repo_cli.py` step from `michelangelo-ai/integration-test#10` against the prebuilt public `ghcr.io/michelangelo-ai/michelangelo-examples:california-housing` image.

**Why?**
`michelangelo-examples`' `pytorch_train`/`xgb_train` pipelines have zero CI coverage today. This closes that gap ahead of `michelangelo`'s own `california_housing_xgb` example being retired, so there's no window with no CI signal that the canonical Ray+Spark example pipeline actually runs end-to-end.

**How did you test it?**
Ran the full step sequence manually against a real local k3d sandbox (project apply, pytorch_train e2e, xgb_train e2e) — all 3 tests passed end-to-end with real Cadence-dispatched Ray jobs. Validated the YAML with `python3 -c "import yaml; yaml.safe_load(...)"`. Confirmed no trigger/runner conflict with `michelangelo-examples`' own `build-image.yaml` workflow (different repo, different trigger wiring, different runner).

**Potential risks**
None to production — CI-only change. `--no-deps` is used deliberately since this job runs on a persistent self-hosted runner whose `.venv` is reused across CI runs; installing with deps could hit stale post-version-bump package metadata or silently swap dependency versions already validated via the existing `-E example` install.

**Breaking Changes**
- [x] No breaking changes

**Release notes**
N/A

**Documentation Changes**
N/A