### PR TITLE
chore: release 0.7.0

### DIFF
--- a/helm/michelangelo/Chart.yaml
+++ b/helm/michelangelo/Chart.yaml
@@ -7,8 +7,8 @@ description: |
   and RBAC — into any Kubernetes cluster. Bring your own metadata storage,
   object storage, and workflow engine (Cadence or Temporal).
 type: application
-version: 0.7.0-rc.1
-appVersion: "0.7.0-rc.1"
+version: 0.7.0
+appVersion: "0.7.0"
 kubeVersion: ">=1.27.0-0"
 
 dependencies:

--- a/javascript/app/package.json
+++ b/javascript/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@michelangelo/app",
   "license": "Apache-2.0",
-  "version": "0.7.0-rc.1",
+  "version": "0.7.0",
   "private": true,
   "scripts": {
     "build": "vite build --config vite.config.ts",
@@ -11,11 +11,11 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
-    "@michelangelo-ai/rpc": "0.7.0-rc.1",
+    "@michelangelo-ai/rpc": "0.7.0",
     "@mui/icons-material": "^7.1.0",
     "@mui/material": "^7.1.0",
     "@tanstack/react-query": "5.39.0",
-    "@michelangelo-ai/core": "0.7.0-rc.1",
+    "@michelangelo-ai/core": "0.7.0",
     "baseui": "15.0.0",
     "react-router-dom": "5.3.4",
     "react-router-dom-v5-compat": "6.29.0",

--- a/javascript/packages/core/package.json
+++ b/javascript/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@michelangelo-ai/core",
   "license": "Apache-2.0",
-  "version": "0.7.0-rc.1",
+  "version": "0.7.0",
   "type": "module",
   "main": "./dist/michelangelo-core.js",
   "module": "./dist/michelangelo-core.js",

--- a/javascript/packages/rpc/package.json
+++ b/javascript/packages/rpc/package.json
@@ -2,7 +2,7 @@
   "name": "@michelangelo-ai/rpc",
   "license": "Apache-2.0",
   "type": "module",
-  "version": "0.7.0-rc.1",
+  "version": "0.7.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/michelangelo-ai/michelangelo"
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.2.5",
-    "@michelangelo-ai/core": "0.7.0-rc.1"
+    "@michelangelo-ai/core": "0.7.0"
   },
   "exports": {
     ".": {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "michelangelo"
-version = "0.7.0-rc.1"
+version = "0.7.0"
 description = "Michelangelo AI is an end-to-end model lifecycle management system at large scale"
 authors = ["Michelangelo AI Team <michelangelo-oss-group@uber.com>"]
 readme = "README.md"


### PR DESCRIPTION
Strip RC suffix and set final version 0.7.0 across all component files, per the REL-005 manual promotion workaround (`release-promote.yml` cannot succeed via dispatch — see michelangelo#1608).

Related to #1658.

Once merged: tag `v0.7.0` on `release/v0.7`, dispatch `release.yaml`/`changelog.yml`/`ui-release.yml`/`dev-release.yml` (ref=tag) and `npm-publish.yml` (ref=release/v0.7), verify all artifacts live, mark #1660 ready for review.