### PR TITLE
feat(jobs): add federated watcher orchestration package

### DIFF
--- a/go/components/jobs/common/watch/BUILD.bazel
+++ b/go/components/jobs/common/watch/BUILD.bazel
@@ -1,0 +1,40 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["federated_watcher.go"],
+    importpath = "github.com/michelangelo-ai/michelangelo/go/components/jobs/common/watch",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//go/components/jobs/client:go_default_library",
+        "//go/components/jobs/cluster:go_default_library",
+        "//go/components/jobs/common/constants:go_default_library",
+        "//go/components/jobs/metrics:go_default_library",
+        "//proto/api/v2:go_default_library",
+        "@com_github_go_logr_logr//:go_default_library",
+        "@com_github_uber_go_tally//:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/wait:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["federated_watcher_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//go/components/jobs/client:go_default_library",
+        "//go/components/jobs/client/clientmocks:go_default_library",
+        "//go/components/jobs/cluster:go_default_library",
+        "//go/components/jobs/cluster/clustermocks:go_default_library",
+        "//go/components/jobs/common/constants:go_default_library",
+        "//go/components/jobs/metrics:go_default_library",
+        "//proto/api/v2:go_default_library",
+        "@com_github_go_logr_zapr//:go_default_library",
+        "@com_github_golang_mock//gomock:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
+        "@com_github_uber_go_tally//:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@org_uber_go_zap//:go_default_library",
+        "@org_uber_go_zap//zaptest:go_default_library",
+    ],
+)

--- a/go/components/jobs/common/watch/federated_watcher.go
+++ b/go/components/jobs/common/watch/federated_watcher.go
@@ -1,0 +1,253 @@
+package watch
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/uber-go/tally"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/michelangelo-ai/michelangelo/go/components/jobs/client"
+	"github.com/michelangelo-ai/michelangelo/go/components/jobs/cluster"
+	"github.com/michelangelo-ai/michelangelo/go/components/jobs/common/constants"
+	"github.com/michelangelo-ai/michelangelo/go/components/jobs/metrics"
+	v2pb "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
+)
+
+const _defaultSyncPeriod = 10 * time.Second
+
+var (
+	_failureWatchPanicMetricName            = "watch_panic"
+	_failureWatchExitWithoutPanicMetricName = "watch_exit_without_panic"
+	_failureWatchAddMetricName              = "watch_add_failure"
+)
+
+// FederatedWatcher setups watches across all the registered clusters.
+//
+// Whenever a new cluster is registered with JC, an informer is
+// created for it based on the watcher params. Informers are stopped
+// when a cluster is either put offline of deleted.
+//
+// The cluster controller
+// keeps an eye on the clusters and thus the clusters in ETCD are up-to-date.
+type FederatedWatcher interface {
+	// Start starts the eager syncing of watches.
+	Start(ctx context.Context)
+}
+
+// FederatedWatcherParams are the params to instantiate a new federated watcher.
+type FederatedWatcherParams struct {
+	ClusterCache    cluster.RegisteredClustersCache
+	FederatedClient client.FederatedClient
+	Logger          logr.Logger
+	WatcherParams   []*client.WatcherParams
+	Scope           tally.Scope
+}
+
+// watcher implements the FederatedWatcher
+type watcher struct {
+	log       logr.Logger
+	metrics   *metrics.ControllerMetrics
+	startOnce sync.Once
+	period    time.Duration
+
+	clusterCache    cluster.RegisteredClustersCache
+	federatedClient client.FederatedClient
+	clusterInfoMap  sync.Map
+	watches         []*client.WatcherParams
+}
+
+type watchInfo struct {
+	resourceWatchers []*client.ResourceWatcher
+	cluster          *v2pb.Cluster
+}
+
+// NewFederatedWatcher returns a new federated watcher.
+func NewFederatedWatcher(p FederatedWatcherParams) FederatedWatcher {
+	return &watcher{
+		clusterCache:    p.ClusterCache,
+		federatedClient: p.FederatedClient,
+		log:             p.Logger,
+		clusterInfoMap:  sync.Map{},
+		period:          _defaultSyncPeriod,
+		watches:         p.WatcherParams,
+		metrics:         &metrics.ControllerMetrics{MetricsScope: p.Scope.SubScope("watcher")},
+	}
+}
+
+// Start starts the eager syncing of watches.
+func (r *watcher) Start(ctx context.Context) {
+	r.startOnce.Do(func() {
+		r.start(ctx)
+	})
+}
+
+func (r *watcher) start(ctx context.Context) {
+	wait.Until(func() {
+		r.log.Info("syncing watches")
+
+		r.sync()
+
+	}, r.period, ctx.Done())
+
+	r.log.Info("exiting watcher")
+}
+
+// sync sets up watches based on the watcher params across all clusters.
+func (r *watcher) sync() {
+	// only sync ready clusters
+	clusters := r.clusterCache.GetClusters(cluster.ReadyClusters)
+
+	clusterNames := make(map[string]struct{})
+	for _, cluster := range clusters {
+		clusterNames[cluster.Name] = struct{}{}
+
+		// sync watch for any new cluster
+		clusterInfo, ok := r.clusterInfoMap.Load(cluster.Name)
+		if !ok {
+			r.log.Info("setting up watch for new cluster", "name", cluster.Name)
+			err := r.addNewClusterToCache(r.watches, cluster)
+			if err != nil {
+				// continue to the next cluster if there is an error
+				r.log.Error(err, "failed to add watch for new cluster", "name", cluster.Name)
+				// emit a metrics that can be alerted on
+				r.metrics.MetricsScope.Counter(_failureWatchAddMetricName).Inc(1)
+			}
+			continue
+		}
+
+		// check if the cluster has been updated
+		wi := clusterInfo.(watchInfo)
+		if shouldClusterBeUpdatedInWatcherCache(wi.cluster, cluster) {
+			r.log.Info("updating watch for existing cluster", "name", cluster.Name)
+			err := r.updateClusterInCache(wi, r.watches, cluster)
+			if err != nil {
+				// continue to the next cluster if there is an error
+				r.log.Error(err, "failed to add watch for updated cluster", "name", cluster.Name)
+				// emit a metrics that can be alerted on
+				r.metrics.MetricsScope.Counter(_failureWatchAddMetricName).Inc(1)
+			}
+		}
+	}
+
+	// remove watch for any cluster no longer in use
+	r.clusterInfoMap.Range(func(key, value interface{}) bool {
+		name := key.(string)
+		info := value.(watchInfo)
+
+		if _, ok := clusterNames[name]; !ok {
+			r.log.Info("Removing watch for cluster", "name", name)
+			for _, rw := range info.resourceWatchers {
+				close(rw.StopCh)
+			}
+
+			r.clusterInfoMap.Delete(name)
+		}
+		return true
+	})
+}
+
+func (r *watcher) updateClusterInCache(
+	info watchInfo,
+	watcherParams []*client.WatcherParams,
+	cluster *v2pb.Cluster) error {
+	for _, rw := range info.resourceWatchers {
+		close(rw.StopCh)
+	}
+	r.clusterInfoMap.Delete(cluster.Name)
+
+	timer := r.metrics.MetricsScope.Timer(constants.WatcherLatency).Start()
+	resourceWatchers, err := r.federatedClient.Watcher(watcherParams, cluster)
+	timer.Stop()
+
+	if err != nil {
+		return err
+	}
+
+	for _, rw := range resourceWatchers {
+		r.startWatchController(rw, cluster.Name)
+	}
+
+	r.clusterInfoMap.Store(cluster.Name, watchInfo{
+		resourceWatchers: resourceWatchers,
+		cluster:          cluster,
+	})
+
+	r.log.Info("Updated cluster in the watch list", "clusterName", cluster.Name)
+	return nil
+}
+
+func (r *watcher) addNewClusterToCache(
+	watcherParams []*client.WatcherParams,
+	cluster *v2pb.Cluster) error {
+	timer := r.metrics.MetricsScope.Timer(constants.WatcherLatency).Start()
+	resourceWatchers, err := r.federatedClient.Watcher(watcherParams, cluster)
+	timer.Stop()
+
+	if err != nil {
+		return err
+	}
+
+	for _, rw := range resourceWatchers {
+		r.startWatchController(rw, cluster.Name)
+	}
+	r.clusterInfoMap.Store(cluster.Name, watchInfo{
+		resourceWatchers: resourceWatchers,
+		cluster:          cluster,
+	})
+
+	r.log.Info("Added cluster to the watch list", "clusterName", cluster.Name)
+	return nil
+}
+
+func (r *watcher) startWatchController(watchInfo *client.ResourceWatcher, clusterName string) {
+	// Make sure to initialize the channel outside of the goroutine. We do this because there could be a
+	// race between starting the controller and an update in the cluster cache. In the update case, we will
+	// try to close the channel. And closing a nil channel will panic.
+	stopCh := make(chan struct{})
+	watchInfo.StopCh = stopCh
+	// start the controller in a goroutine with a recoverer to handle any panics from the controller.
+	// passing stopCh as a parameter to prevent a data race
+	// between startWatchController() writing to watchInfo.StopCh and startWatchGoRoutine() reading it
+	go r.startWatchGoRoutine(watchInfo, stopCh, clusterName)
+}
+
+// DO NOT call directly. Only caller should be startWatchController.
+// This is separated into a method to enable unit testing.
+func (r *watcher) startWatchGoRoutine(watchInfo *client.ResourceWatcher, stopCh chan struct{}, clusterName string) {
+	defer func() {
+		if rvr := recover(); rvr != nil {
+			// watch controller run panicked
+			// log the error
+			r.log.Error(fmt.Errorf("%+v", rvr), "Watch controller exited with panic", "clusterName", clusterName)
+			// emit a metrics that can be alerted on
+			r.metrics.MetricsScope.Counter(_failureWatchPanicMetricName).Inc(1)
+			return
+		}
+
+		// watch controller exited without panic
+		r.log.Info("Watch controller exited without panic", "clusterName", clusterName)
+		// emit a metric that can be alerted on
+		r.metrics.MetricsScope.Counter(_failureWatchExitWithoutPanicMetricName).Inc(1)
+
+		// check if the channel is closed
+		select {
+		case <-stopCh:
+			r.log.Info("Stop channel is closed", "clusterName", clusterName)
+		default:
+			r.log.Info("Stop channel is not closed", "clusterName", clusterName)
+		}
+	}()
+
+	r.log.Info("Starting watch controller", "clusterName", clusterName)
+	watchInfo.Controller.Run(stopCh)
+}
+
+func shouldClusterBeUpdatedInWatcherCache(
+	stored *v2pb.Cluster, latest *v2pb.Cluster) bool {
+	return stored.Spec.GetKubernetes().Rest.Host != latest.Spec.GetKubernetes().Rest.Host ||
+		stored.Spec.GetKubernetes().Rest.Port != latest.Spec.GetKubernetes().Rest.Port
+}

--- a/go/components/jobs/common/watch/federated_watcher_test.go
+++ b/go/components/jobs/common/watch/federated_watcher_test.go
@@ -1,0 +1,294 @@
+package watch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-logr/zapr"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/michelangelo-ai/michelangelo/go/components/jobs/client"
+	"github.com/michelangelo-ai/michelangelo/go/components/jobs/client/clientmocks"
+	"github.com/michelangelo-ai/michelangelo/go/components/jobs/cluster"
+	"github.com/michelangelo-ai/michelangelo/go/components/jobs/cluster/clustermocks"
+	"github.com/michelangelo-ai/michelangelo/go/components/jobs/common/constants"
+	"github.com/michelangelo-ai/michelangelo/go/components/jobs/metrics"
+	v2pb "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
+)
+
+// fakeController implements cache.Controller for testing.
+type fakeController struct {
+	runFunc func(stopCh <-chan struct{})
+}
+
+func (f *fakeController) Run(stopCh <-chan struct{}) {
+	if f.runFunc != nil {
+		f.runFunc(stopCh)
+	}
+}
+
+func (f *fakeController) HasSynced() bool                 { return true }
+func (f *fakeController) LastSyncResourceVersion() string { return "" }
+
+var _testCluster = v2pb.Cluster{
+	TypeMeta: metav1.TypeMeta{
+		Kind:       "Cluster",
+		APIVersion: "michelangelo.uber.com/v2beta1",
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name:            "testCluster",
+		Namespace:       constants.ClustersNamespace,
+		ResourceVersion: "999",
+	},
+	Spec: v2pb.ClusterSpec{
+		Region: "phx",
+		Zone:   "phx5",
+		Cluster: &v2pb.ClusterSpec_Kubernetes{
+			Kubernetes: &v2pb.KubernetesSpec{
+				Rest: &v2pb.ConnectionSpec{
+					Host: "https://k8s-apiserver-kubernetes-batch01.phx5.uber.internal",
+					Port: "port",
+				},
+			},
+		},
+	},
+}
+
+type test struct {
+	cluster v2pb.Cluster
+	changed bool
+	msg     string
+}
+
+func TestSync(t *testing.T) {
+	tt := []test{
+		{
+			cluster: _testCluster,
+			changed: false,
+			msg:     "no change",
+		},
+		{
+			cluster: v2pb.Cluster{
+				ObjectMeta: _testCluster.ObjectMeta,
+				Spec: v2pb.ClusterSpec{
+					Cluster: &v2pb.ClusterSpec_Kubernetes{
+						Kubernetes: &v2pb.KubernetesSpec{
+							Rest: &v2pb.ConnectionSpec{
+								Host: _testCluster.Spec.GetKubernetes().Rest.Host,
+								Port: "NewPort",
+							},
+						},
+					},
+				},
+			},
+			changed: true,
+			msg:     "port change",
+		},
+		{
+			cluster: v2pb.Cluster{
+				ObjectMeta: _testCluster.ObjectMeta,
+				Spec: v2pb.ClusterSpec{
+					Cluster: &v2pb.ClusterSpec_Kubernetes{
+						Kubernetes: &v2pb.KubernetesSpec{
+							Rest: &v2pb.ConnectionSpec{
+								Host: "NewHost",
+								Port: _testCluster.Spec.GetKubernetes().Rest.Port,
+							},
+						},
+					},
+				},
+			},
+			changed: true,
+			msg:     "host change",
+		},
+	}
+
+	for _, test := range tt {
+		t.Run(test.msg, func(t *testing.T) {
+			var wg sync.WaitGroup
+			defer wg.Wait()
+
+			gctrl := gomock.NewController(t)
+
+			mockClusterCache := clustermocks.NewMockRegisteredClustersCache(gctrl)
+			mockClusterCache.EXPECT().GetClusters(cluster.ReadyClusters).Return([]*v2pb.Cluster{&_testCluster})
+
+			w := setupWatcher(t, test, &wg, gctrl)
+			federatedWatcher := w.(*watcher)
+			federatedWatcher.clusterCache = mockClusterCache
+
+			federatedWatcher.sync()
+
+			// test that clusterInfoMap has _testCluster
+			_, ok := federatedWatcher.clusterInfoMap.Load(_testCluster.Name)
+			require.True(t, ok)
+
+			// change the cluster
+			mockClusterCache.EXPECT().GetClusters(cluster.ReadyClusters).Return([]*v2pb.Cluster{&test.cluster})
+
+			federatedWatcher.sync()
+
+			// test cluster update
+			clusterInfo, ok := federatedWatcher.clusterInfoMap.Load(_testCluster.Name)
+			require.True(t, ok)
+
+			cl := clusterInfo.(watchInfo).cluster
+			require.Equal(t, test.cluster.Name, cl.Name)
+			require.Equal(t, test.cluster.Spec.GetKubernetes().Rest.Host, cl.Spec.GetKubernetes().Rest.Host)
+			require.Equal(t, test.cluster.Spec.GetKubernetes().Rest.Port, cl.Spec.GetKubernetes().Rest.Port)
+		})
+	}
+}
+
+func setupWatcher(t *testing.T, test test, wg *sync.WaitGroup, gctrl *gomock.Controller) FederatedWatcher {
+	times := 1 // the first call
+	if test.changed {
+		// if the test mimics a change it would trigger another sync.
+		times++
+	}
+
+	wg.Add(times)
+
+	mockClient := clientmocks.NewMockFederatedClient(gctrl)
+	mockClient.EXPECT().Watcher(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ []*client.WatcherParams, _ *v2pb.Cluster) ([]*client.ResourceWatcher, error) {
+			return []*client.ResourceWatcher{
+				{
+					Controller: &fakeController{
+						runFunc: func(_ <-chan struct{}) {
+							wg.Done()
+						},
+					},
+				},
+			}, nil
+		},
+	).Times(times)
+
+	testScope := tally.NewTestScope("test", map[string]string{})
+
+	federatedWatcher := NewFederatedWatcher(
+		FederatedWatcherParams{
+			Logger:          zapr.NewLogger(zaptest.NewLogger(t)),
+			FederatedClient: mockClient,
+			Scope:           testScope,
+		})
+
+	return federatedWatcher
+}
+
+func TestStartWatchControllerRecoverer(t *testing.T) {
+	testScope := tally.NewTestScope("test", map[string]string{})
+	w := &watcher{
+		log: zapr.NewLogger(zap.NewNop()),
+		metrics: &metrics.ControllerMetrics{
+			MetricsScope: testScope,
+		},
+	}
+
+	ctrl := &fakeController{
+		runFunc: func(_ <-chan struct{}) {
+			panic(errors.New("test error"))
+		},
+	}
+
+	stopCh := make(chan struct{})
+
+	w.startWatchGoRoutine(&client.ResourceWatcher{
+		Controller: ctrl,
+	}, stopCh, "testCluster")
+
+	require.NotNil(t, testScope.Snapshot())
+	require.NotNil(t, testScope.Snapshot().Counters())
+	val, ok := testScope.Snapshot().Counters()[fmt.Sprintf("%s.%s+", "test", _failureWatchPanicMetricName)]
+	require.True(t, ok)
+	require.Equal(t, int64(1), val.Value())
+}
+
+func TestSyncError(t *testing.T) {
+	tt := []struct {
+		existingCluster *v2pb.Cluster
+		newCluster      *v2pb.Cluster
+		msg             string
+	}{
+		{
+			existingCluster: &v2pb.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "existingCluster",
+				},
+			},
+			newCluster: &_testCluster,
+			msg:        "error in adding cluster",
+		},
+		{
+			existingCluster: &_testCluster,
+			newCluster: &v2pb.Cluster{
+				ObjectMeta: _testCluster.ObjectMeta,
+				Spec: v2pb.ClusterSpec{
+					Cluster: &v2pb.ClusterSpec_Kubernetes{
+						Kubernetes: &v2pb.KubernetesSpec{
+							Rest: &v2pb.ConnectionSpec{
+								Host: _testCluster.Spec.GetKubernetes().Rest.Host,
+								Port: "NewPort",
+							},
+						},
+					},
+				},
+			},
+			msg: "error in updating cluster",
+		},
+	}
+
+	for _, test := range tt {
+		t.Run(test.msg, func(t *testing.T) {
+			g := gomock.NewController(t)
+			mockClusterCache := clustermocks.NewMockRegisteredClustersCache(g)
+			mockClusterCache.EXPECT().GetClusters(cluster.ReadyClusters).Return([]*v2pb.Cluster{test.newCluster})
+
+			mockClient := clientmocks.NewMockFederatedClient(g)
+			mockClient.EXPECT().Watcher(gomock.Any(), gomock.Any()).Return(nil, errors.New("test error"))
+
+			federatedWatcher := &watcher{
+				clusterCache:    mockClusterCache,
+				federatedClient: mockClient,
+				log:             zapr.NewLogger(zaptest.NewLogger(t)),
+				metrics: &metrics.ControllerMetrics{
+					MetricsScope: tally.NewTestScope("test", map[string]string{}),
+				},
+			}
+
+			federatedWatcher.clusterInfoMap.Store(test.existingCluster.Name, watchInfo{
+				cluster: test.existingCluster,
+			})
+
+			federatedWatcher.sync()
+		})
+	}
+}
+
+func TestStart(t *testing.T) {
+	g := gomock.NewController(t)
+	mockClusterCache := clustermocks.NewMockRegisteredClustersCache(g)
+	mockClusterCache.EXPECT().GetClusters(cluster.ReadyClusters).Return([]*v2pb.Cluster{}).AnyTimes()
+
+	federatedWatcher := &watcher{
+		clusterCache: mockClusterCache,
+		log:          zapr.NewLogger(zaptest.NewLogger(t)),
+		period:       time.Millisecond,
+	}
+
+	// cancel the context after allowing the watcher to run at least once. There's nothing to sync.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+	require.NotPanics(t, func() {
+		federatedWatcher.start(ctx)
+	})
+}


### PR DESCRIPTION
## Summary

Ports the federated watcher orchestration layer from Uber-internal `controllermgr` (`common/watch/federated_watcher.go`) into the OSS repo at `go/components/jobs/common/watch/`. This is the foundation for replacing polling-based Ray status sync (TODO #605) with event-driven informers that span every registered compute cluster.

A `FederatedWatcher` periodically reconciles the set of ready clusters from the `RegisteredClustersCache` and maintains one set of resource watchers (informers) per cluster. Clusters that appear are watched; clusters whose endpoint changes are re-watched; clusters that disappear have their watchers torn down.

## What Changed

- **`FederatedWatcher` interface** with `Start(ctx)` driven by `sync.Once` → `wait.Until(sync, period, ctx.Done())`.
- **`sync()`** diffs ready clusters against the tracked set: adds new clusters, updates clusters whose Host/Port changed, and tears down watchers for clusters no longer ready.
- **Lifecycle safety**: `StopCh` is initialized *before* the watch goroutine launches (prevents a start/stop race), per-`ResourceWatcher` stop channels avoid loop-variable capture, and `sync.Map` guards concurrent cluster tracking.
- **Panic + exit safety**: each watch goroutine has `defer recover()` with a tally panic counter, plus an exit-without-panic counter so a silently returning informer is observable.
- Bazel `go_library` + `go_test` targets; import path `github.com/michelangelo-ai/michelangelo/go/components/jobs/common/watch`.
- Naming/structure kept deliberately close to the internal source to keep the eventual back-port a near-clean diff.

## Files Changed

```
 go/components/jobs/common/watch/BUILD.bazel        |  40 +++
 go/components/jobs/common/watch/federated_watcher.go       | 253 +++++++++++
 go/components/jobs/common/watch/federated_watcher_test.go  | 294 +++++++++++++
 3 files changed, 587 insertions(+)
```

## Source Document Reference

From `plan.md` — "Federated Watcher for OSS Ray controllers" (TODO #605). Ported from internal `controllermgr/pkg/controllers/jobs/common/watch/federated_watcher.go`.

## Stack Position

Part of a stacked PR chain for **federated-watcher-ray**:

```
[1] #1667 watcher-orchestration  <- main    (THIS PR)
 \--[2] #1668 cluster-watcher     <- #1667
     \--[3] #1669 job-watcher     <- #1668
```

| Relationship | PR |
|---|---|
| Parent | — (base `main`) |
| Child | #1668 — drive RayCluster status via federated watcher |

> Root of the stack. Merge this first, then re-base #1668 onto `main`.

## Review

Reviewed against the internal reference implementation for parity. Package builds and tests pass via bazel (`go_default_test`).

---
Generated with [Claude Code](https://claude.ai/code) — stacked PR workflow