### PR TITLE
fix(release): mark -rc tags as prereleases in GitHub releases

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -181,6 +181,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
+          prerelease: ${{ contains(steps.tag.outputs.tag, '-rc') }}
           body_path: RELEASE_NOTES.md
           append_body: false
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,6 +67,7 @@ jobs:
       - uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
+          prerelease: ${{ contains(github.ref_name, '-rc') }}
           files: python/dist/*.whl
 
   build-go-binaries:
@@ -125,6 +126,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
+          prerelease: ${{ contains(github.ref_name, '-rc') }}
           files: binaries/*
 
   helm-publish:


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
All three softprops/action-gh-release steps now derive the release's prerelease flag from the tag name:
- release.yaml (wheel upload and binaries steps): `prerelease: ${{ contains(github.ref_name, '-rc') }}`
- changelog.yml (release-notes update step): `prerelease: ${{ contains(steps.tag.outputs.tag, '-rc') }}`

**Why?**
RC tags currently publish as full releases. Both v0.6.0-rc.1 and v0.7.0-rc.1 went out with `prerelease: false`, and v0.7.0-rc.1 was served as the repo's **latest release** for ~2 days (Aug 2-3) until the rc release entries were deleted after v0.7.0 final shipped. Deleting the releases fixed the symptom but not the workflow - the next -rc tag will do the same thing. The repo's own tag scheme (vX.Y.Z-rc.N, e.g. the pep440 normalization step in release.yaml matches `-rc\.`) makes the tag name the reliable signal.

**How did you test it?**
- Verified expression semantics: `contains('v0.6.0-rc.1', '-rc')` -> true; `contains('v0.6.0', '-rc')` -> false, so final releases are unaffected.
- Verified all three steps and their tag sources against main (release.yaml uses github.ref_name from the tag push trigger; changelog.yml uses its own resolved steps.tag.outputs.tag).
- Observable on the next -rc tag: the created/updated release should show a "Pre-release" badge. Existing releases are not modified by this PR.

**Potential risks**
On workflow_dispatch of release.yaml, github.ref_name is a branch name; branch names containing "-rc" would be flagged as prerelease. No current branch matches, and dispatch runs of this workflow already have other tag-shaped assumptions.

**Breaking Changes**
- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**
RC releases (tags containing "-rc") are now marked as prereleases on GitHub.

**Documentation Changes**
None needed.
