### PR TITLE
fix(api): log blob-storage delete failure only when it fails

### DIFF
--- a/go/api/handler/BUILD.bazel
+++ b/go/api/handler/BUILD.bazel
@@ -47,6 +47,7 @@ go_test(
     srcs = [
         "builder_test.go",
         "handler_test.go",
+        "metadata_handler_test.go",
     ],
     embed = [":go_default_library"],
     deps = [
@@ -56,6 +57,7 @@ go_test(
         "//go/storage/storagemocks:go_default_library",
         "//proto/api:go_default_library",
         "//proto/api/v2:go_default_library",
+        "@com_github_go_logr_logr//funcr:go_default_library",
         "@com_github_go_logr_zapr//:go_default_library",
         "@com_github_golang_mock//gomock:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",

--- a/go/api/handler/metadata_handler.go
+++ b/go/api/handler/metadata_handler.go
@@ -129,8 +129,9 @@ func handleDelete(ctx context.Context, log logr.Logger, typeMeta *metav1.TypeMet
 		if getErr == nil {
 			// Failed to delete in blob storage is not a critical failure, as orphan blobs can be deleted by garbage
 			// collector. So, do not return error.
-			err := handler.DeleteFromBlobStorage(ctx, object)
-			log.Error(err, "Failed to delete object in blob storage", "uid", object.GetUID())
+			if err := handler.DeleteFromBlobStorage(ctx, object); err != nil {
+				log.Error(err, "Failed to delete object in blob storage", "uid", object.GetUID())
+			}
 		}
 
 		return nil

--- a/go/api/handler/metadata_handler_test.go
+++ b/go/api/handler/metadata_handler_test.go
@@ -1,0 +1,72 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-logr/logr/funcr"
+	"github.com/golang/mock/gomock"
+	"github.com/michelangelo-ai/michelangelo/go/storage/storagemocks"
+	v2pb "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestHandleDeleteBlobStorageErrorLogging verifies that handleDelete logs a
+// blob-storage deletion failure only when the deletion actually fails: a
+// successful delete must not emit the "Failed to delete object in blob
+// storage" error line.
+func TestHandleDeleteBlobStorageErrorLogging(t *testing.T) {
+	typeMeta := &metav1.TypeMeta{Kind: "RayJob"}
+
+	testCases := []struct {
+		name          string
+		blobDeleteErr error
+		wantErrorLogs int
+	}{
+		{
+			name:          "no error log when blob delete succeeds",
+			blobDeleteErr: nil,
+			wantErrorLogs: 0,
+		},
+		{
+			name:          "one error log when blob delete fails",
+			blobDeleteErr: errors.New("blob backend unavailable"),
+			wantErrorLogs: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			metadataStorage := storagemocks.NewMockMetadataStorage(ctrl)
+			blobStorage := storagemocks.NewMockBlobStorage(ctrl)
+
+			obj := &v2pb.RayJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "job01",
+					UID:       "uid-01",
+				},
+			}
+
+			blobStorage.EXPECT().IsObjectInteresting(gomock.Any()).Return(true)
+			metadataStorage.EXPECT().GetByID(gomock.Any(), "uid-01", gomock.Any()).Return(nil)
+			metadataStorage.EXPECT().Delete(gomock.Any(), typeMeta, "default", "job01").Return(nil)
+			blobStorage.EXPECT().DeleteFromBlobStorage(gomock.Any(), gomock.Any()).Return(tc.blobDeleteErr)
+
+			var logLines []string
+			log := funcr.New(func(prefix, args string) {
+				logLines = append(logLines, args)
+			}, funcr.Options{})
+
+			err := handleDelete(context.Background(), log, typeMeta, obj, metadataStorage, blobStorage)
+
+			assert.NoError(t, err)
+			assert.Len(t, logLines, tc.wantErrorLogs)
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
In `handleDelete` (go/api/handler/metadata_handler.go), the call to `log.Error(err, "Failed to delete object in blob storage", ...)` after `DeleteFromBlobStorage` now only happens when the returned error is non-nil. Adds a regression test (table-driven, gomock + funcr log capture) asserting no error line on the happy path and exactly one when the blob delete fails.

**Why?**
`log.Error` was called unconditionally, so every successful delete of a blob-backed object emits a false "Failed to delete object in blob storage" ERROR line with a nil error. That pollutes operator logs and anything alerting on error-level entries. Intended behavior (per the surrounding comment) is unchanged: blob-delete failures are still non-fatal and still logged.

**How did you test it?**
Added `TestHandleDeleteBlobStorageErrorLogging` in go/api/handler/metadata_handler_test.go using the existing storagemocks and a funcr logger to capture log output; covers both the success (0 error logs) and failure (1 error log, nil returned error) paths.

**Potential risks**
Minimal: the only behavior change is the removal of the spurious log line on success. Anyone who (inadvertently) keyed monitoring on the false ERROR line will see it disappear.

**Breaking Changes**
- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**
Fixed a spurious error log emitted on every successful blob-storage delete.

**Documentation Changes**
None needed.
