### PR TITLE
docs(security): update supported versions for 0.7.x

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,9 +6,9 @@ The following versions of the project are currently supported with security upda
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.5.x   | :white_check_mark: |
-| 0.4.x   | :white_check_mark: |
-| < 0.4   | :x:                |
+| 0.7.x   | :white_check_mark: |
+| 0.6.x   | :white_check_mark: |
+| < 0.6   | :x:                |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**
SECURITY.md's supported-versions table now lists 0.7.x and 0.6.x as supported and < 0.6 as unsupported.

**Why?**
v0.7.0 was released on 2026-08-03 (v0.6.0 on 2026-07-27), but the table still says 0.5.x/0.4.x, so the security policy currently gives wrong guidance about which versions receive security updates. This follows the table's existing N and N-1 pattern.

**How did you test it?**
Rendered the markdown table; cross-checked the release dates via the GitHub releases page.

**Potential risks**
None - documentation only. If the team intends to keep supporting older versions, I can adjust the rows.

**Breaking Changes**
- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**
None.

**Documentation Changes**
This is the documentation change.
