### PR TITLE
fix(ui): tighten spacing and fix stuck focus state on multi-string field

### DIFF
--- a/javascript/packages/core/components/form/fields/string/components/editable-string-tag.tsx
+++ b/javascript/packages/core/components/form/fields/string/components/editable-string-tag.tsx
@@ -16,6 +16,18 @@ export function EditableStringTag(props: EditableStringTagProps) {
   const [editing, setEditing] = useState(false);
   const [localValue, setLocalValue] = useState(initialValue);
 
+  // Equal padding on all sides, tighter than the shared Tag's default, to suit a compact
+  // tag-input list — asymmetric padding here would inflate the visible gap between tags on top
+  // of the container's own `gap` (see StringTagInput). Spacing between tags is handled by that
+  // `gap` rather than margin here, since Tag's own overrides always win margin conflicts when
+  // merged.
+  const compactTagRootStyle = {
+    paddingTop: theme.sizing.scale100,
+    paddingRight: theme.sizing.scale100,
+    paddingBottom: theme.sizing.scale100,
+    paddingLeft: theme.sizing.scale100,
+  };
+
   const handleCancelEditing = () => {
     setLocalValue(initialValue);
     setEditing(false);
@@ -43,17 +55,7 @@ export function EditableStringTag(props: EditableStringTagProps) {
             // renders at, so the confirm icon doesn't look oversized next to it.
             props: { name: 'check', onMouseDown: persistEditedValue, size: theme.sizing.scale500 },
           },
-          // Tighter padding than the shared Tag's default, to suit a compact tag-input list.
-          // Spacing between tags is handled by the container's `gap` (see StringTagInput) rather
-          // than margin here, since Tag's own overrides always win margin conflicts when merged.
-          Root: {
-            style: {
-              paddingTop: theme.sizing.scale100,
-              paddingRight: theme.sizing.scale200,
-              paddingBottom: theme.sizing.scale100,
-              paddingLeft: theme.sizing.scale200,
-            },
-          },
+          Root: { style: compactTagRootStyle },
         }}
         behavior={TAG_BEHAVIOR.selection}
         hierarchy={TAG_HIERARCHY.secondary}
@@ -79,17 +81,7 @@ export function EditableStringTag(props: EditableStringTagProps) {
       onActionClick={onRemove}
       onClick={() => setEditing(true)}
       overrides={{
-        // Tighter padding than the shared Tag's default, to suit a compact tag-input list.
-        // Spacing between tags is handled by the container's `gap` (see StringTagInput) rather
-        // than margin here, since Tag's own overrides always win margin conflicts when merged.
-        Root: {
-          style: {
-            paddingTop: theme.sizing.scale100,
-            paddingRight: theme.sizing.scale200,
-            paddingBottom: theme.sizing.scale100,
-            paddingLeft: theme.sizing.scale200,
-          },
-        },
+        Root: { style: compactTagRootStyle },
       }}
       hierarchy={TAG_HIERARCHY.primary}
     >

--- a/javascript/packages/core/components/form/fields/string/components/multi-string-field.tsx
+++ b/javascript/packages/core/components/form/fields/string/components/multi-string-field.tsx
@@ -96,6 +96,11 @@ export function MultiStringField({
         id={name}
         value={unpersistedValue}
         onChange={(e) => setUnpersistedValue(e.currentTarget.value)}
+        // Must be a top-level prop rather than an `Input.props` override below: BaseInput
+        // composes a top-level onBlur with its own internal handler that clears the container's
+        // focused-border state, whereas an `Input.props` override replaces the rendered input's
+        // onBlur outright and skips that internal handler.
+        onBlur={handlePersistValue}
         placeholder={!disabled && !readOnly && valueList.length === 0 ? placeholder : ''}
         readOnly={readOnly}
         disabled={disabled}
@@ -108,7 +113,6 @@ export function MultiStringField({
             component: StringTagInput,
             props: {
               clear: clearValueList,
-              onBlur: handlePersistValue,
               onKeyDown: handleTagEntry,
               readOnly,
               removeValue: removeValueAtIndex,


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

Two fixes to the multi-value tag input rendered by `StringField multi`:

1. Tightened each tag's horizontal padding to match its vertical padding, so the visible gap between adjacent tags isn't inflated by mismatched padding on top of the container's own gap.
2. Fixed the field's focused border getting stuck once the field had been focused once. The tag-entry input's `onBlur` was wired through an `Input.props` override that replaces the rendered `<input>`'s `onBlur` outright, bypassing baseui's internal handler that resets the border's focused state. Moving `onBlur` to a top-level prop on `<Input>` restores baseui's normal composition.

<!-- Tell your future self why have you made these changes -->
**Why?**

Found both while testing form rendering for another change. The spacing looked disproportionately large with short tag values, and the border issue meant any form with a multi-string field would show a permanently "focused"-looking field after the first interaction, regardless of where focus moved afterward.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


https://github.com/user-attachments/assets/2b462ca4-938f-4035-8006-ea1856413aec



<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

None — a visual padding adjustment and a focus-handler wiring fix, both scoped to the existing multi-string tag component with no behavioral changes to form submission.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

N/A

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**

N/A
