### PR TITLE
fix(ui): stop ArrayFormGroup spacing from depending on parent layout

### DIFF
--- a/javascript/packages/core/components/form/layout/array-form-group/array-form-group.tsx
+++ b/javascript/packages/core/components/form/layout/array-form-group/array-form-group.tsx
@@ -1,3 +1,4 @@
+import { useStyletron } from 'baseui';
 import { Button, KIND, SHAPE, SIZE } from 'baseui/button';
 
 import { AddButton } from '#core/components/form/components/add-button/add-button';
@@ -25,9 +26,10 @@ export function ArrayFormGroup({
     readOnly,
   });
   const addLabel = addLabelProp ?? (groupLabel ? `Add ${groupLabel.toLowerCase()}` : 'Add more');
+  const [css, theme] = useStyletron();
 
   return (
-    <>
+    <div className={css({ display: 'flex', flexDirection: 'column', gap: theme.sizing.scale800 })}>
       {entries.map(({ id, indexedFieldPath }, index) => (
         <RepeatedLayoutProvider key={id} index={index} rootFieldPath={rootFieldPath}>
           <FormGroup
@@ -51,9 +53,9 @@ export function ArrayFormGroup({
               )
             }
             overrides={{
-              // FormGroup comes with marginBottom that intends to be applied to separate groups in the
-              // context of an entire form. Since the ArrayFormGroup has a button at the end, we need to
-              // remove the margin bottom to avoid disconnect between the form group and the button.
+              // ArrayFormGroup owns spacing between its own entries and the trailing AddButton via
+              // the wrapping flex gap above, so each entry's own marginBottom would double up
+              // (flex gap and margin are additive, not collapsing) and needs to be zeroed here.
               BoxContainer: { style: { marginBottom: 0 } },
             }}
           >
@@ -62,6 +64,6 @@ export function ArrayFormGroup({
         </RepeatedLayoutProvider>
       ))}
       {!readOnly && <AddButton label={addLabel} shape={SHAPE.pill} onClick={handleItemAdd} />}
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

The repeated-group form layout (`ArrayFormGroup`) no longer relies on its parent to provide spacing between each group card and the trailing "Add" button. It now manages that spacing itself.

**Why?**

Each group card had its own bottom margin zeroed out, with the visible gap coming entirely from the surrounding form's flex layout. That happened to look fine when the repeated group sat directly inside a form, but broke down whenever it was nested one level deeper — inside a collapsible section, for example — where there's no ambient gap to fall back on. The result was the "Add" button rendering flush against the last card, with no separation at all.

Restoring a plain margin wasn't enough on its own either: flex gap and margin stack rather than collapse, so simply adding spacing back would have doubled up in the already-working case. Owning the spacing directly avoids depending on whatever layout the parent happens to use.

**How did you test it?**
**After fix**
<img width="849" height="2048" alt="final-after" src="https://github.com/user-attachments/assets/569ef156-a4ba-4cf8-9d9d-4b87a1927975" />

**Before fix**
<img width="849" height="1968" alt="final-before" src="https://github.com/user-attachments/assets/9017cf32-a332-4b1f-a076-f10782df35c8" />


**Potential risks**

Low — the change is isolated to one layout component's internal spacing and doesn't affect its public API.

**Breaking Changes**

- [x] No breaking changes

**Release notes**

N/A