### PR TITLE
feat(native_transform): add fitted-statistics layers (PR B3)

### DIFF
--- a/python/michelangelo/lib/native_transform/torch/__init__.py
+++ b/python/michelangelo/lib/native_transform/torch/__init__.py
@@ -27,8 +27,14 @@ from michelangelo.lib.native_transform.torch.base_layers import (
 from michelangelo.lib.native_transform.torch.id_hash_tokenizer import (
     IDHashTokenizer,
 )
+from michelangelo.lib.native_transform.torch.stats_layers import (
+    Bucketization,
+    MinMax,
+    Normalization,
+)
 
 __all__ = [
+    "Bucketization",
     "CaseWhen",
     "Cast",
     "Ceil",
@@ -41,6 +47,8 @@ __all__ = [
     "IDHashTokenizer",
     "IdentityTransform",
     "LogTransform",
+    "MinMax",
+    "Normalization",
     "PadOrCrop1D",
     "Scale",
     "Stack",

--- a/python/michelangelo/lib/native_transform/torch/base_layers.py
+++ b/python/michelangelo/lib/native_transform/torch/base_layers.py
@@ -7,8 +7,12 @@ uses :func:`~michelangelo.lib.native_transform.torch.utils.format_inputs` /
 :func:`~michelangelo.lib.native_transform.torch.utils.format_outputs` to map its
 declared input/output columns to and from a single stacked tensor.
 
-This module provides the foundation (stateless, elementwise) layers. Structural,
-fitted-statistics, and tokenizer layers are added in follow-up modules.
+This module provides the foundation (stateless, elementwise) layers, plus
+structural layers (``Tile``, ``PadOrCrop1D``, ``Clip``, ``Scale``, ``CaseWhen``,
+``Compare``, ``TensorColFillNone``, etc.). Fitted-statistics layers (``MinMax``,
+``Normalization``, ``Bucketization``) live in
+:mod:`~michelangelo.lib.native_transform.torch.stats_layers`; tokenizer layers
+are added in a follow-up module.
 """
 
 from __future__ import annotations

--- a/python/michelangelo/lib/native_transform/torch/stats_layers.py
+++ b/python/michelangelo/lib/native_transform/torch/stats_layers.py
@@ -1,0 +1,307 @@
+"""Fitted-statistics PyTorch native transform layers.
+
+Layers whose behavior is parameterized by fitted statistics (a min/max range,
+a mean/std, or bucket boundaries) computed ahead of time and supplied at
+construction. Like the layers in
+:mod:`~michelangelo.lib.native_transform.torch.base_layers`, every layer here
+subclasses
+:class:`~michelangelo.lib.native_transform.torch.base_layers.TorchTransformBaseLayer`
+and uses the same ``dict[str, torch.Tensor]`` in/out contract, but stores its
+fitted parameters as buffers (via ``register_buffer``) so they move with
+``.to(device)`` and persist through TorchScript save/load.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from michelangelo.lib.constants.sentinel import INT32_SENTINEL
+from michelangelo.lib.native_transform.torch.base_layers import (
+    TorchTransformBaseLayer,
+)
+from michelangelo.lib.native_transform.torch.constants import DEFAULT_EPSILON
+from michelangelo.lib.native_transform.torch.utils import (
+    format_inputs,
+    format_outputs,
+    initialize_dtype,
+)
+
+__all__ = [
+    "Bucketization",
+    "MinMax",
+    "Normalization",
+]
+
+
+class MinMax(TorchTransformBaseLayer):
+    """Min-max scale input columns to a ``[0, 1]`` range.
+
+    Concatenates the input columns along ``dim`` and rescales with
+    ``(x - min) / max(max - min, eps)``.
+
+    Args:
+        input_cols: Column names of the input tensors.
+        output_cols: Column names of the output tensor; must contain exactly
+            one column, since the inputs are concatenated into a single
+            output.
+        min: The per-feature minimum values used for scaling.
+        max: The per-feature maximum values used for scaling.
+        dim: The dimension along which input columns are concatenated.
+            Defaults to ``-1``, since dimension ``0`` is typically the batch
+            dimension.
+        eps: A small value added to the denominator to avoid division by zero
+            when ``min == max``. Defaults to ``1e-7``.
+        **kwargs: Additional base-layer options (e.g. ``name``).
+
+    Raises:
+        ValueError: If ``output_cols`` does not contain exactly one column.
+    """
+
+    def __init__(
+        self,
+        input_cols: list[str],
+        output_cols: list[str],
+        min: float | list[float] | torch.Tensor,
+        max: float | list[float] | torch.Tensor,
+        dim: int = -1,
+        eps: float = DEFAULT_EPSILON,
+        **kwargs,
+    ) -> None:
+        """Initialize the MinMax layer.
+
+        Args:
+            input_cols: Column names of the input tensors.
+            output_cols: Column names of the output tensor; must contain
+                exactly one column.
+            min: The per-feature minimum values used for scaling.
+            max: The per-feature maximum values used for scaling.
+            dim: The dimension along which input columns are concatenated.
+            eps: A small value added to the denominator to avoid division by
+                zero when ``min == max``.
+            **kwargs: Additional base-layer options (e.g. ``name``).
+
+        Raises:
+            ValueError: If ``output_cols`` does not contain exactly one
+                column.
+        """
+        super().__init__(input_cols, output_cols, **kwargs)
+        if len(output_cols) != 1:
+            raise ValueError(
+                "output_cols must contain exactly one column, since the "
+                "input columns are concatenated into a single output."
+            )
+        # Registered as buffers so they move with .to(device) and persist
+        # through TorchScript save/load.
+        self.register_buffer("min_buffer", torch.as_tensor(min, dtype=torch.float32))
+        self.register_buffer("max_buffer", torch.as_tensor(max, dtype=torch.float32))
+        self.dim = dim
+        self.eps = eps
+
+    def forward(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """Min-max scale the concatenated input columns.
+
+        Args:
+            inputs: Mapping from column name to tensor.
+
+        Returns:
+            A single-entry mapping from the output column to the scaled
+            tensor.
+        """
+        tensor_list: list[torch.Tensor] = []
+        for col in self.input_cols:
+            col_tensor = inputs[col]
+            if self.dim != 0 and len(col_tensor.shape) == 1:
+                # The input shape should be [batch_size, vector_dim].
+                col_tensor = torch.unsqueeze(col_tensor, 1)
+            tensor_list.append(col_tensor)
+
+        concatenated_tensor = torch.cat(tensor_list, dim=self.dim).float()
+        min_val = self.min_buffer.to(dtype=concatenated_tensor.dtype)
+        max_val = self.max_buffer.to(dtype=concatenated_tensor.dtype)
+        # Clamp the denominator to avoid division by zero when min == max.
+        safe_denominator = torch.clamp(max_val - min_val, min=self.eps)
+        concatenated_tensor.sub_(min_val).div_(safe_denominator)
+        return {self.output_cols[0]: concatenated_tensor}
+
+
+class Normalization(TorchTransformBaseLayer):
+    """Feature-wise standardization: ``(x - mean) / std``.
+
+    Concatenates the input columns along ``dim`` and standardizes the result
+    to be centered around 0 with a standard deviation of 1.
+
+    Args:
+        input_cols: Column names of the input tensors.
+        output_cols: Column names of the output tensor; must contain exactly
+            one column, since the inputs are concatenated into a single
+            output.
+        mean: The per-feature mean values used for standardization.
+        std: The per-feature standard deviation values used for
+            standardization.
+        dim: The dimension along which input columns are concatenated.
+            Defaults to ``-1``, since dimension ``0`` is typically the batch
+            dimension.
+        eps: A small value clamped onto ``std`` to avoid division by zero when
+            ``std == 0``. Defaults to ``1e-7``.
+        **kwargs: Additional base-layer options (e.g. ``name``).
+
+    Raises:
+        ValueError: If ``output_cols`` does not contain exactly one column.
+    """
+
+    def __init__(
+        self,
+        input_cols: list[str],
+        output_cols: list[str],
+        mean: float | list[float] | torch.Tensor,
+        std: float | list[float] | torch.Tensor,
+        dim: int = -1,
+        eps: float = DEFAULT_EPSILON,
+        **kwargs,
+    ) -> None:
+        """Initialize the Normalization layer.
+
+        Args:
+            input_cols: Column names of the input tensors.
+            output_cols: Column names of the output tensor; must contain
+                exactly one column.
+            mean: The per-feature mean values used for standardization.
+            std: The per-feature standard deviation values used for
+                standardization.
+            dim: The dimension along which input columns are concatenated.
+            eps: A small value clamped onto ``std`` to avoid division by zero
+                when ``std == 0``.
+            **kwargs: Additional base-layer options (e.g. ``name``).
+
+        Raises:
+            ValueError: If ``output_cols`` does not contain exactly one
+                column.
+        """
+        super().__init__(input_cols, output_cols, **kwargs)
+        if len(output_cols) != 1:
+            raise ValueError(
+                "output_cols must contain exactly one column, since the "
+                "input columns are concatenated into a single output."
+            )
+        self.register_buffer("mean_buffer", torch.as_tensor(mean, dtype=torch.float32))
+        self.register_buffer("std_buffer", torch.as_tensor(std, dtype=torch.float32))
+        self.dim = dim
+        self.eps = eps
+
+    def forward(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """Standardize the concatenated input columns.
+
+        Args:
+            inputs: Mapping from column name to tensor.
+
+        Returns:
+            A single-entry mapping from the output column to the standardized
+            tensor.
+        """
+        tensor_list: list[torch.Tensor] = []
+        for col in self.input_cols:
+            col_tensor = inputs[col]
+            if self.dim != 0 and len(col_tensor.shape) == 1:
+                # The input shape should be [batch_size, vector_dim].
+                col_tensor = torch.unsqueeze(col_tensor, 1)
+            tensor_list.append(col_tensor)
+
+        concatenated_tensor = torch.cat(tensor_list, dim=self.dim).float()
+        mean_val = self.mean_buffer.to(dtype=concatenated_tensor.dtype)
+        std_val = self.std_buffer.to(dtype=concatenated_tensor.dtype)
+        # Clamp std to avoid division by zero.
+        safe_std = torch.clamp(std_val, min=self.eps)
+        concatenated_tensor.sub_(mean_val).div_(safe_std)
+        return {self.output_cols[0]: concatenated_tensor}
+
+
+class Bucketization(TorchTransformBaseLayer):
+    """Bucketize each input column using shared boundaries.
+
+    Sentinel positions from upstream ragged-batch collation (``NaN`` for float
+    inputs, ``INT32_SENTINEL`` for integer inputs) are automatically detected
+    and preserved through bucketization (rewritten as ``INT32_SENTINEL`` in
+    the output) so downstream layers can distinguish padding from real,
+    bucketized data.
+
+    Args:
+        input_cols: Column names of the input tensors.
+        output_cols: Column names of the output tensors; must match the
+            length of ``input_cols``.
+        boundaries: The boundary values used for bucketization. Bucket edges
+            are closed on the left (``torch.bucketize(..., right=True)``).
+        dtype: Output tensor dtype. Defaults to ``torch.int32``.
+        **kwargs: Additional base-layer options (e.g. ``name``).
+
+    Raises:
+        ValueError: If ``input_cols`` and ``output_cols`` differ in length.
+    """
+
+    def __init__(
+        self,
+        input_cols: list[str],
+        output_cols: list[str],
+        boundaries: list[float],
+        dtype: torch.dtype | str | None = None,
+        **kwargs,
+    ) -> None:
+        """Initialize the Bucketization layer.
+
+        Args:
+            input_cols: Column names of the input tensors.
+            output_cols: Column names of the output tensors; must match the
+                length of ``input_cols``.
+            boundaries: The boundary values used for bucketization.
+            dtype: Output tensor dtype. Defaults to ``torch.int32``.
+            **kwargs: Additional base-layer options (e.g. ``name``).
+
+        Raises:
+            ValueError: If ``input_cols`` and ``output_cols`` differ in
+                length.
+        """
+        super().__init__(input_cols, output_cols, **kwargs)
+        if len(input_cols) != len(output_cols):
+            raise ValueError(
+                "Input columns and output columns must have the same length."
+            )
+        self.register_buffer("boundaries", torch.tensor(boundaries))
+        self.dtype = initialize_dtype(dtype, torch.int32)
+        # Stored as an instance attribute (rather than read from a module) for
+        # TorchScript compatibility.
+        self._int_sentinel = INT32_SENTINEL
+
+    def forward(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """Bucketize the stacked input columns, preserving sentinel positions.
+
+        Args:
+            inputs: Mapping from column name to tensor.
+
+        Returns:
+            A mapping from each output column to its bucketized tensor.
+        """
+        stacked_input = format_inputs(self.input_cols, inputs)
+
+        # torch.bucketize with right=True means the left boundary is closed:
+        # https://pytorch.org/docs/stable/generated/torch.bucketize.html
+        stacked_output = torch.bucketize(stacked_input, self.boundaries, right=True).to(
+            self.dtype
+        )
+
+        # Restore sentinel positions so downstream layers can distinguish
+        # padding from real data; without this, padding would be mapped to
+        # bucket 0 and become indistinguishable from genuine data. The
+        # restored sentinel matches the *output* dtype: NaN when the output
+        # is floating-point (even for integer input), INT32_SENTINEL
+        # otherwise.
+        if stacked_input.is_floating_point():
+            mask = torch.isnan(stacked_input)
+            if stacked_output.is_floating_point():
+                sentinel_out = stacked_output.new_full((), float("nan"))
+            else:
+                sentinel_out = stacked_output.new_full((), self._int_sentinel)
+        else:
+            mask = stacked_input == self._int_sentinel
+            sentinel_out = stacked_output.new_full((), self._int_sentinel)
+        stacked_output = torch.where(mask, sentinel_out, stacked_output)
+
+        return format_outputs(self.output_cols, stacked_output)

--- a/python/michelangelo/lib/native_transform/torch/stats_layers.py
+++ b/python/michelangelo/lib/native_transform/torch/stats_layers.py
@@ -220,9 +220,10 @@ class Bucketization(TorchTransformBaseLayer):
 
     Sentinel positions from upstream ragged-batch collation (``NaN`` for float
     inputs, ``INT32_SENTINEL`` for integer inputs) are automatically detected
-    and preserved through bucketization (rewritten as ``INT32_SENTINEL`` in
-    the output) so downstream layers can distinguish padding from real,
-    bucketized data.
+    and preserved through bucketization, so downstream layers can distinguish
+    padding from real, bucketized data. The restored sentinel matches the
+    *output* dtype: ``NaN`` when the output is floating-point (even for
+    integer input), ``INT32_SENTINEL`` otherwise.
 
     Args:
         input_cols: Column names of the input tensors.

--- a/python/michelangelo/lib/native_transform/torch/tests/test_stats_layers.py
+++ b/python/michelangelo/lib/native_transform/torch/tests/test_stats_layers.py
@@ -1,0 +1,320 @@
+"""Tests for :mod:`michelangelo.lib.native_transform.torch.stats_layers`.
+
+Covers the forward semantics of the fitted-statistics transform layers and,
+for every layer, a ``torch.jit.script`` round-trip: native transform layers
+must be TorchScript-exportable so the exact transform runs at serve time, and
+the scripted module (including after save/load) must reproduce the eager
+output.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# These layers operate on real torch tensors/modules. Skip cleanly if torch is
+# unavailable in a lightweight environment.
+torch = pytest.importorskip("torch")
+
+from michelangelo.lib.constants.sentinel import INT32_SENTINEL  # noqa: E402
+from michelangelo.lib.native_transform.torch.stats_layers import (  # noqa: E402
+    Bucketization,
+    MinMax,
+    Normalization,
+)
+
+
+class TestMinMax:
+    """Min-max scaling, including dim handling and safe division."""
+
+    def test_multi_output_cols_raises(self) -> None:
+        """More than one output column raises ``ValueError``."""
+        with pytest.raises(ValueError, match="exactly one column"):
+            MinMax(input_cols=["x"], output_cols=["a", "b"], min=[0.0], max=[1.0])
+
+    def test_forward_basic(self) -> None:
+        """Values scale linearly into [0, 1] given min/max."""
+        layer = MinMax(input_cols=["x"], output_cols=["o"], min=[0.0], max=[10.0])
+        out = layer({"x": torch.tensor([[0.0], [5.0], [10.0]])})["o"]
+        torch.testing.assert_close(out, torch.tensor([[0.0], [0.5], [1.0]]))
+
+    def test_default_dim_is_minus_one(self) -> None:
+        """The default dim concatenates along the last dimension."""
+        layer = MinMax(
+            input_cols=["a", "b"], output_cols=["o"], min=[0.0, 0.0], max=[10.0, 20.0]
+        )
+        out = layer({"a": torch.tensor([[5.0]]), "b": torch.tensor([[10.0]])})["o"]
+        torch.testing.assert_close(out, torch.tensor([[0.5, 0.5]]))
+
+    def test_1d_input_is_unsqueezed_when_dim_nonzero(self) -> None:
+        """A 1D column is unsqueezed to [batch, 1] before concatenation."""
+        layer = MinMax(input_cols=["x"], output_cols=["o"], min=[0.0], max=[10.0])
+        out = layer({"x": torch.tensor([0.0, 5.0, 10.0])})["o"]
+        torch.testing.assert_close(out, torch.tensor([[0.0], [0.5], [1.0]]))
+
+    def test_dim_zero_does_not_unsqueeze(self) -> None:
+        """dim=0 concatenates along the batch dimension without unsqueezing."""
+        layer = MinMax(
+            input_cols=["a", "b"], output_cols=["o"], min=0.0, max=10.0, dim=0
+        )
+        out = layer({"a": torch.tensor([0.0, 5.0]), "b": torch.tensor([10.0])})["o"]
+        torch.testing.assert_close(out, torch.tensor([0.0, 0.5, 1.0]))
+
+    def test_tensor_typed_min_max(self) -> None:
+        """min/max may be passed as tensors, not just lists."""
+        layer = MinMax(
+            input_cols=["x"],
+            output_cols=["o"],
+            min=torch.tensor([0.0]),
+            max=torch.tensor([4.0]),
+        )
+        out = layer({"x": torch.tensor([[2.0]])})["o"]
+        torch.testing.assert_close(out, torch.tensor([[0.5]]))
+
+    def test_min_equals_max_uses_eps_not_divide_by_zero(self) -> None:
+        """When min == max, the eps-clamped denominator avoids NaN/inf."""
+        layer = MinMax(input_cols=["x"], output_cols=["o"], min=[5.0], max=[5.0])
+        out = layer({"x": torch.tensor([[5.0]])})["o"]
+        assert torch.isfinite(out).all()
+
+    def test_custom_epsilon(self) -> None:
+        """A custom eps is used in place of the default."""
+        layer = MinMax(
+            input_cols=["x"], output_cols=["o"], min=[1.0], max=[1.0], eps=1.0
+        )
+        out = layer({"x": torch.tensor([[1.0]])})["o"]
+        torch.testing.assert_close(out, torch.tensor([[0.0]]))
+
+    def test_negative_values(self) -> None:
+        """Negative inputs and bounds scale correctly."""
+        layer = MinMax(input_cols=["x"], output_cols=["o"], min=[-10.0], max=[10.0])
+        out = layer({"x": torch.tensor([[-10.0], [0.0], [10.0]])})["o"]
+        torch.testing.assert_close(out, torch.tensor([[0.0], [0.5], [1.0]]))
+
+
+class TestNormalization:
+    """Feature-wise standardization, including dim handling and safe division."""
+
+    def test_multi_output_cols_raises(self) -> None:
+        """More than one output column raises ``ValueError``."""
+        with pytest.raises(ValueError, match="exactly one column"):
+            Normalization(
+                input_cols=["x"], output_cols=["a", "b"], mean=[0.0], std=[1.0]
+            )
+
+    def test_forward_basic(self) -> None:
+        """Values standardize to (x - mean) / std."""
+        layer = Normalization(
+            input_cols=["x"], output_cols=["o"], mean=[5.0], std=[5.0]
+        )
+        out = layer({"x": torch.tensor([[0.0], [5.0], [10.0]])})["o"]
+        torch.testing.assert_close(out, torch.tensor([[-1.0], [0.0], [1.0]]))
+
+    def test_default_dim_is_minus_one(self) -> None:
+        """The default dim concatenates along the last dimension."""
+        layer = Normalization(
+            input_cols=["a", "b"], output_cols=["o"], mean=[0.0, 0.0], std=[1.0, 2.0]
+        )
+        out = layer({"a": torch.tensor([[1.0]]), "b": torch.tensor([[4.0]])})["o"]
+        torch.testing.assert_close(out, torch.tensor([[1.0, 2.0]]))
+
+    def test_1d_input_is_unsqueezed_when_dim_nonzero(self) -> None:
+        """A 1D column is unsqueezed to [batch, 1] before concatenation."""
+        layer = Normalization(
+            input_cols=["x"], output_cols=["o"], mean=[0.0], std=[2.0]
+        )
+        out = layer({"x": torch.tensor([0.0, 2.0, 4.0])})["o"]
+        torch.testing.assert_close(out, torch.tensor([[0.0], [1.0], [2.0]]))
+
+    def test_dim_zero_does_not_unsqueeze(self) -> None:
+        """dim=0 concatenates along the batch dimension without unsqueezing."""
+        layer = Normalization(
+            input_cols=["a", "b"], output_cols=["o"], mean=0.0, std=1.0, dim=0
+        )
+        out = layer({"a": torch.tensor([0.0, 1.0]), "b": torch.tensor([2.0])})["o"]
+        torch.testing.assert_close(out, torch.tensor([0.0, 1.0, 2.0]))
+
+    def test_tensor_typed_mean_std(self) -> None:
+        """mean/std may be passed as tensors, not just lists."""
+        layer = Normalization(
+            input_cols=["x"],
+            output_cols=["o"],
+            mean=torch.tensor([1.0]),
+            std=torch.tensor([2.0]),
+        )
+        out = layer({"x": torch.tensor([[3.0]])})["o"]
+        torch.testing.assert_close(out, torch.tensor([[1.0]]))
+
+    def test_std_zero_uses_eps_not_divide_by_zero(self) -> None:
+        """When std == 0, the eps-clamped denominator avoids NaN/inf."""
+        layer = Normalization(
+            input_cols=["x"], output_cols=["o"], mean=[0.0], std=[0.0]
+        )
+        out = layer({"x": torch.tensor([[1.0]])})["o"]
+        assert torch.isfinite(out).all()
+
+    def test_custom_epsilon(self) -> None:
+        """A custom eps is used in place of the default."""
+        layer = Normalization(
+            input_cols=["x"], output_cols=["o"], mean=[0.0], std=[0.0], eps=1.0
+        )
+        out = layer({"x": torch.tensor([[1.0]])})["o"]
+        torch.testing.assert_close(out, torch.tensor([[1.0]]))
+
+    def test_negative_values(self) -> None:
+        """Negative inputs and stats standardize correctly."""
+        layer = Normalization(
+            input_cols=["x"], output_cols=["o"], mean=[-5.0], std=[5.0]
+        )
+        out = layer({"x": torch.tensor([[-10.0], [-5.0], [0.0]])})["o"]
+        torch.testing.assert_close(out, torch.tensor([[-1.0], [0.0], [1.0]]))
+
+
+class TestBucketization:
+    """Bucketization, including dtype handling and sentinel preservation."""
+
+    def test_mismatched_columns_raises(self) -> None:
+        """Unequal input/output column counts raise ``ValueError``."""
+        with pytest.raises(ValueError, match="same length"):
+            Bucketization(
+                input_cols=["a", "b"], output_cols=["o"], boundaries=[0.0, 1.0]
+            )
+
+    def test_forward_basic(self) -> None:
+        """Values bucketize with right=True (left boundary closed) semantics."""
+        layer = Bucketization(
+            input_cols=["x"], output_cols=["o"], boundaries=[0.0, 5.0, 10.0]
+        )
+        out = layer({"x": torch.tensor([-1.0, 0.0, 3.0, 5.0, 12.0])})["o"]
+        torch.testing.assert_close(
+            out, torch.tensor([0, 1, 1, 2, 3], dtype=torch.int32)
+        )
+
+    def test_multi_column(self) -> None:
+        """Multiple columns bucketize independently."""
+        layer = Bucketization(
+            input_cols=["a", "b"], output_cols=["oa", "ob"], boundaries=[0.0, 5.0]
+        )
+        out = layer({"a": torch.tensor([-1.0]), "b": torch.tensor([6.0])})
+        torch.testing.assert_close(out["oa"], torch.tensor([0], dtype=torch.int32))
+        torch.testing.assert_close(out["ob"], torch.tensor([2], dtype=torch.int32))
+
+    def test_explicit_dtype(self) -> None:
+        """An explicit dtype converts the output."""
+        layer = Bucketization(
+            input_cols=["x"],
+            output_cols=["o"],
+            boundaries=[0.0, 5.0],
+            dtype=torch.int64,
+        )
+        out = layer({"x": torch.tensor([1.0])})["o"]
+        assert out.dtype == torch.int64
+
+    def test_string_dtype(self) -> None:
+        """A string dtype alias resolves the same as the torch.dtype."""
+        layer = Bucketization(
+            input_cols=["x"],
+            output_cols=["o"],
+            boundaries=[0.0, 5.0],
+            dtype="int64",
+        )
+        out = layer({"x": torch.tensor([1.0])})["o"]
+        assert out.dtype == torch.int64
+
+    def test_nan_sentinel_is_preserved(self) -> None:
+        """NaN sentinel positions in float input are preserved as INT32_SENTINEL."""
+        layer = Bucketization(
+            input_cols=["x"], output_cols=["o"], boundaries=[0.0, 5.0]
+        )
+        out = layer({"x": torch.tensor([1.0, float("nan"), 6.0])})["o"]
+        torch.testing.assert_close(
+            out, torch.tensor([1, INT32_SENTINEL, 2], dtype=torch.int32)
+        )
+
+    def test_int_sentinel_is_preserved(self) -> None:
+        """INT32_SENTINEL positions in integer input are preserved."""
+        layer = Bucketization(input_cols=["x"], output_cols=["o"], boundaries=[0, 5])
+        out = layer({"x": torch.tensor([1, INT32_SENTINEL, 6], dtype=torch.int32)})["o"]
+        torch.testing.assert_close(
+            out, torch.tensor([1, INT32_SENTINEL, 2], dtype=torch.int32)
+        )
+
+    def test_nan_sentinel_preserved_as_nan_with_float_output_dtype(self) -> None:
+        """A float output dtype preserves the sentinel as NaN, not INT32_SENTINEL.
+
+        Regression test: the sentinel written back must match the *output*
+        dtype, not always fall back to the integer sentinel.
+        """
+        layer = Bucketization(
+            input_cols=["x"],
+            output_cols=["o"],
+            boundaries=[0.0, 5.0],
+            dtype=torch.float32,
+        )
+        out = layer({"x": torch.tensor([1.0, float("nan"), 6.0])})["o"]
+        assert out.dtype == torch.float32
+        assert torch.isnan(out[1])
+        torch.testing.assert_close(out[0], torch.tensor(1.0))
+        torch.testing.assert_close(out[2], torch.tensor(2.0))
+
+
+def _stats_layer_cases() -> list[tuple[str, object, dict]]:
+    """Layer/input pairs shared by the parametrized TorchScript round-trip test."""
+    return [
+        (
+            "min_max",
+            MinMax(input_cols=["x"], output_cols=["o"], min=[0.0], max=[10.0]),
+            {"x": torch.tensor([[0.0], [5.0], [10.0]])},
+        ),
+        (
+            "normalization",
+            Normalization(input_cols=["x"], output_cols=["o"], mean=[5.0], std=[5.0]),
+            {"x": torch.tensor([[0.0], [5.0], [10.0]])},
+        ),
+        (
+            "bucketization",
+            Bucketization(input_cols=["x"], output_cols=["o"], boundaries=[0.0, 5.0]),
+            {"x": torch.tensor([-1.0, 1.0, 6.0])},
+        ),
+        (
+            "bucketization_nan_sentinel",
+            Bucketization(input_cols=["x"], output_cols=["o"], boundaries=[0.0, 5.0]),
+            {"x": torch.tensor([1.0, float("nan"), 6.0])},
+        ),
+        (
+            "bucketization_int_sentinel",
+            Bucketization(input_cols=["x"], output_cols=["o"], boundaries=[0, 5]),
+            {"x": torch.tensor([1, INT32_SENTINEL, 6], dtype=torch.int32)},
+        ),
+    ]
+
+
+class TestB3TorchScriptRoundTrip:
+    """Every B3 fitted-statistics layer must script, save/load, and match eager."""
+
+    @pytest.mark.parametrize(
+        ("layer", "inputs"),
+        [(layer, inputs) for _, layer, inputs in _stats_layer_cases()],
+        ids=[case_id for case_id, _, _ in _stats_layer_cases()],
+    )
+    def test_scripted_matches_eager(
+        self,
+        layer,
+        inputs: dict[str, torch.Tensor],
+        tmp_path,
+    ) -> None:
+        """Scripting (and reloading) reproduces the eager forward output."""
+        layer.eval()
+        eager = layer(inputs)
+
+        scripted = torch.jit.script(layer)
+        scripted_out = scripted(inputs)
+        assert set(scripted_out) == set(eager)
+        for key in eager:
+            torch.testing.assert_close(scripted_out[key], eager[key])
+
+        model_path = tmp_path / "scripted_b3_layer.pt"
+        scripted.save(str(model_path))
+        loaded = torch.jit.load(str(model_path))
+        loaded_out = loaded(inputs)
+        for key in eager:
+            torch.testing.assert_close(loaded_out[key], eager[key])


### PR DESCRIPTION
## Summary

Continues the native_transform migration (PR A, A2, B1, B2 merged) with PR B3: the fitted-statistics torch layers.

- New `stats_layers.py` with `MinMax`, `Normalization`, `Bucketization`, ported from the internal SDK's `base_layers.py` onto the same `TorchTransformBaseLayer` dict-tensor contract established in B1/B2.
- Constructor params (`dim`, `eps`, `dtype`) are explicit and typed rather than pulled out of `**kwargs` post-hoc, matching this repo's established layer style; `**kwargs` is still forwarded to the base layer so `name=` and future options aren't silently dropped.
- `Bucketization` auto-detects and preserves sentinel positions (NaN for float input, `INT32_SENTINEL` for int input) across bucketization, restoring the sentinel in whichever dtype the layer outputs.
- `MinMax`/`Normalization` now validate `output_cols` has exactly one entry (inputs are concatenated into a single output). **This is a genuine behavioral change from internal, not enforcement of an existing contract**: internal has no such check anywhere and silently uses only `output_cols[0]`, discarding any extra entries. Verified against the internal SDK: every real spec/test construction of these layers uses a single input/output column (1:1 scaling), so no known usage relies on the old silent-drop behavior. Failing loudly on a malformed spec is safer than silently dropping data, so the check is kept, but the PR description previously mischaracterized this as "previously documented" — it wasn't; internal's docstrings never mention a single-output-column requirement.

**Module placement**: these land in a new `stats_layers.py` rather than the existing `base_layers.py`. Fitted-statistics layers carry buffer/state concerns (registered `nn.Module` buffers for their fitted parameters) distinct from the stateless layers `base_layers.py` holds, so this is a natural seam to split on. `base_layers.py`'s module docstring is updated to describe what's actually landed there via PR B1/B2 and to point to the new module.

## Review

Reviewed by the migration team before opening: one real bug was caught and fixed pre-merge — `Bucketization`'s sentinel restore always wrote the integer sentinel even when the output dtype was floating-point, silently dropping `NaN` in a float-in/float-out configuration. Fixed to match the output dtype, with a regression test. A second pass added the `output_cols` arity validation above.

## Test plan

- [x] `pytest` on the full `native_transform` suite: 243 passed, 1 pre-existing unrelated skip
- [x] `ruff format --check` / `ruff check`: clean
- [x] TorchScript script + save/load round-trip covered for all three new layers (parametrized `TestB3TorchScriptRoundTrip`)
- [x] Diff scanned for internal-only identifiers/URLs: clean
