### PR TITLE
feat(native_transform): add Pydantic layer specs (PR B5)

### DIFF
--- a/python/michelangelo/lib/native_transform/torch/tests/test_transform_layer_spec.py
+++ b/python/michelangelo/lib/native_transform/torch/tests/test_transform_layer_spec.py
@@ -105,6 +105,26 @@ class TestPlaceholderSpecs:
         assert spec.with_mean is True
         assert spec.with_std is False
 
+    def test_standard_scaler_multi_output_cols_raises(self) -> None:
+        """StandardScalerLayerSpec requires exactly one output column.
+
+        It resolves to NormalizationLayerSpec, which enforces the same
+        constraint; catching it here (at spec-parse time, before fitting)
+        avoids a config that only fails once resolved.
+        """
+        with pytest.raises(pydantic.ValidationError, match="exactly one column"):
+            StandardScalerLayerSpec(input_cols=["a", "b"], output_cols=["c", "d"])
+
+    def test_min_max_scaler_multi_output_cols_raises(self) -> None:
+        """MinMaxScalerLayerSpec requires exactly one output column.
+
+        It resolves to MinMaxLayerSpec, which enforces the same constraint;
+        catching it here (at spec-parse time, before fitting) avoids a
+        config that only fails once resolved.
+        """
+        with pytest.raises(pydantic.ValidationError, match="exactly one column"):
+            MinMaxScalerLayerSpec(input_cols=["a", "b"], output_cols=["c", "d"])
+
 
 class TestNormalizationAndMinMaxLayerSpec:
     """Fitted-statistics spec field defaults."""

--- a/python/michelangelo/lib/native_transform/torch/tests/test_transform_layer_spec.py
+++ b/python/michelangelo/lib/native_transform/torch/tests/test_transform_layer_spec.py
@@ -123,6 +123,16 @@ class TestNormalizationAndMinMaxLayerSpec:
         assert spec.max == [1.0]
         assert spec.dim == -1
 
+    def test_normalization_multi_output_cols_raises(self) -> None:
+        """Normalization requires exactly one output column."""
+        with pytest.raises(pydantic.ValidationError, match="exactly one column"):
+            NormalizationLayerSpec(input_cols=["a", "b"], output_cols=["c", "d"])
+
+    def test_min_max_multi_output_cols_raises(self) -> None:
+        """MinMax requires exactly one output column."""
+        with pytest.raises(pydantic.ValidationError, match="exactly one column"):
+            MinMaxLayerSpec(input_cols=["a", "b"], output_cols=["c", "d"])
+
 
 class TestBucketizationLayerSpec:
     """Bucketization spec requires explicit boundaries."""

--- a/python/michelangelo/lib/native_transform/torch/tests/test_transform_layer_spec.py
+++ b/python/michelangelo/lib/native_transform/torch/tests/test_transform_layer_spec.py
@@ -1,0 +1,227 @@
+"""Tests for :mod:`michelangelo.lib.native_transform.torch.transform_layer_spec`.
+
+Covers field defaults, the shared ``model_validator`` behavior (auto-name
+generation, ``is_training_features`` defaulting), and the validation logic
+on the specs that carry their own custom rules.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# These specs use torch dtypes as field types. Skip cleanly if torch is
+# unavailable in a lightweight environment.
+torch = pytest.importorskip("torch")
+
+pydantic = pytest.importorskip("pydantic")
+
+from michelangelo.lib.native_transform.torch.transform_layer_spec import (  # noqa: E402
+    BucketizationLayerSpec,
+    CastLayerSpec,
+    IDHashTokenizerLayerSpec,
+    MinMaxLayerSpec,
+    MinMaxScalerLayerSpec,
+    NormalizationLayerSpec,
+    NumericalStandardTransformLayerSpec,
+    PercentileBucketizationLayerSpec,
+    StandardScalerLayerSpec,
+    TileLayerSpec,
+    TorchTransformLayerSpec,
+    TransformerMode,
+)
+
+
+class TestTorchTransformLayerSpec:
+    """Shared base-spec behavior: defaulting and validation."""
+
+    def test_name_is_auto_generated_when_omitted(self) -> None:
+        """A spec without an explicit name gets one generated from its class."""
+        spec = CastLayerSpec(input_cols=["a"], output_cols=["b"])
+        assert spec.name.startswith("cast_")
+
+    def test_explicit_name_is_preserved(self) -> None:
+        """An explicit name is used verbatim, not auto-generated."""
+        spec = CastLayerSpec(input_cols=["a"], output_cols=["b"], name="my_cast")
+        assert spec.name == "my_cast"
+
+    def test_auto_generated_names_are_unique(self) -> None:
+        """Two default-named specs of the same class get distinct names."""
+        first = CastLayerSpec(input_cols=["a"], output_cols=["b"])
+        second = CastLayerSpec(input_cols=["a"], output_cols=["b"])
+        assert first.name != second.name
+
+    def test_is_training_features_defaults_to_true_per_output_col(self) -> None:
+        """Omitted is_training_features defaults to True for each output col."""
+        spec = CastLayerSpec(input_cols=["a"], output_cols=["b", "c"])
+        assert spec.is_training_features == [True, True]
+
+    def test_is_training_features_explicit_value_is_preserved(self) -> None:
+        """An explicit is_training_features list overrides the default."""
+        spec = CastLayerSpec(
+            input_cols=["a"],
+            output_cols=["b", "c"],
+            is_training_features=[True, False],
+        )
+        assert spec.is_training_features == [True, False]
+
+    def test_default_mode_is_invalid(self) -> None:
+        """The default per-layer mode is INVALID."""
+        spec = CastLayerSpec(input_cols=["a"], output_cols=["b"])
+        assert spec.mode == TransformerMode.INVALID
+
+    def test_explicit_mode_is_preserved(self) -> None:
+        """An explicit mode overrides the default."""
+        spec = CastLayerSpec(
+            input_cols=["a"], output_cols=["b"], mode=TransformerMode.REFIT
+        )
+        assert spec.mode == TransformerMode.REFIT
+
+    def test_resolved_layer_type_defaults_to_none(self) -> None:
+        """A spec with no placeholder resolution has _resolved_layer_type None."""
+        assert CastLayerSpec._resolved_layer_type is None
+
+
+class TestPlaceholderSpecs:
+    """Placeholder specs resolve to a concrete layer spec via a class var."""
+
+    def test_standard_scaler_resolves_to_normalization(self) -> None:
+        """StandardScalerLayerSpec resolves to NormalizationLayerSpec."""
+        assert StandardScalerLayerSpec._resolved_layer_type == "NormalizationLayerSpec"
+
+    def test_min_max_scaler_resolves_to_min_max(self) -> None:
+        """MinMaxScalerLayerSpec resolves to MinMaxLayerSpec."""
+        assert MinMaxScalerLayerSpec._resolved_layer_type == "MinMaxLayerSpec"
+
+    def test_percentile_bucketization_resolves_to_bucketization(self) -> None:
+        """PercentileBucketizationLayerSpec resolves to BucketizationLayerSpec."""
+        assert (
+            PercentileBucketizationLayerSpec._resolved_layer_type
+            == "BucketizationLayerSpec"
+        )
+
+    def test_standard_scaler_field_defaults(self) -> None:
+        """StandardScalerLayerSpec carries its own with_mean/with_std defaults."""
+        spec = StandardScalerLayerSpec(input_cols=["a"], output_cols=["b"])
+        assert spec.with_mean is True
+        assert spec.with_std is False
+
+
+class TestNormalizationAndMinMaxLayerSpec:
+    """Fitted-statistics spec field defaults."""
+
+    def test_normalization_defaults(self) -> None:
+        """Normalization defaults to mean=[0.0], std=[1.0], dim=-1."""
+        spec = NormalizationLayerSpec(input_cols=["a"], output_cols=["b"])
+        assert spec.mean == [0.0]
+        assert spec.std == [1.0]
+        assert spec.dim == -1
+
+    def test_min_max_defaults(self) -> None:
+        """MinMax defaults to min=[0.0], max=[1.0], dim=-1."""
+        spec = MinMaxLayerSpec(input_cols=["a"], output_cols=["b"])
+        assert spec.min == [0.0]
+        assert spec.max == [1.0]
+        assert spec.dim == -1
+
+
+class TestBucketizationLayerSpec:
+    """Bucketization spec requires explicit boundaries."""
+
+    def test_requires_boundaries(self) -> None:
+        """Boundaries has no default and must be supplied."""
+        with pytest.raises(pydantic.ValidationError):
+            BucketizationLayerSpec(input_cols=["a"], output_cols=["b"])
+
+    def test_default_dtype_is_int64(self) -> None:
+        """The default output dtype is int64."""
+        spec = BucketizationLayerSpec(
+            input_cols=["a"], output_cols=["b"], boundaries=[0.0, 1.0]
+        )
+        assert spec.dtype == torch.int64
+
+
+class TestTileLayerSpec:
+    """Tile spec field defaults."""
+
+    def test_defaults(self) -> None:
+        """Tile defaults to axis=0, count=None, target_tensor_provided=False."""
+        spec = TileLayerSpec(input_cols=["a"], output_cols=["b"])
+        assert spec.axis == 0
+        assert spec.count is None
+        assert spec.target_tensor_provided is False
+
+
+class TestIDHashTokenizerLayerSpec:
+    """IDHashTokenizer spec validates a non-empty vocabulary."""
+
+    def test_empty_vocabulary_raises(self) -> None:
+        """An empty vocabulary raises a validation error."""
+        with pytest.raises(pydantic.ValidationError, match="cannot be empty"):
+            IDHashTokenizerLayerSpec(input_cols=["a"], output_cols=["b"], vocabulary=[])
+
+    def test_valid_vocabulary_is_preserved(self) -> None:
+        """A non-empty vocabulary is stored as given."""
+        spec = IDHashTokenizerLayerSpec(
+            input_cols=["a"], output_cols=["b"], vocabulary=[1, 2, 3]
+        )
+        assert spec.vocabulary == [1, 2, 3]
+
+
+class TestNumericalStandardTransformLayerSpec:
+    """Cap/log/scale spec cross-field validation."""
+
+    def test_output_dtype_mirrors_dtype(self) -> None:
+        """output_dtype is set to dtype by the after-validator."""
+        spec = NumericalStandardTransformLayerSpec(
+            input_cols=["a"], output_cols=["b"], dtype=torch.float64
+        )
+        assert spec.output_dtype == torch.float64
+
+    def test_cap_min_greater_than_cap_max_raises(self) -> None:
+        """cap_min > cap_max raises a validation error."""
+        with pytest.raises(pydantic.ValidationError, match="greater than cap_max"):
+            NumericalStandardTransformLayerSpec(
+                input_cols=["a"], output_cols=["b"], cap_min="0.9", cap_max="0.1"
+            )
+
+    def test_percentile_cap_max_out_of_range_raises(self) -> None:
+        """A percentile-string cap_max outside [0.0, 1.0] raises."""
+        with pytest.raises(pydantic.ValidationError, match=r"cap_max .* not in"):
+            NumericalStandardTransformLayerSpec(
+                input_cols=["a"], output_cols=["b"], cap_max="1.5"
+            )
+
+    def test_percentile_cap_min_out_of_range_raises(self) -> None:
+        """A percentile-string cap_min outside [0.0, 1.0] raises."""
+        with pytest.raises(pydantic.ValidationError, match=r"cap_min .* not in"):
+            NumericalStandardTransformLayerSpec(
+                input_cols=["a"], output_cols=["b"], cap_min="-0.1"
+            )
+
+    def test_percentile_default_value_out_of_range_raises(self) -> None:
+        """A percentile-string default_value outside [0.0, 1.0] raises."""
+        with pytest.raises(pydantic.ValidationError, match=r"default_value .* not in"):
+            NumericalStandardTransformLayerSpec(
+                input_cols=["a"], output_cols=["b"], default_value="1.5"
+            )
+
+    def test_numeric_cap_values_are_not_range_checked(self) -> None:
+        """Non-string (plain numeric) cap values skip the percentile-range check."""
+        spec = NumericalStandardTransformLayerSpec(
+            input_cols=["a"], output_cols=["b"], cap_min=-5.0, cap_max=5.0
+        )
+        assert spec.cap_min == -5.0
+        assert spec.cap_max == 5.0
+
+
+def test_base_spec_is_reused_by_every_layer_spec() -> None:
+    """Every concrete layer spec inherits the shared base-spec contract."""
+    for cls in (
+        CastLayerSpec,
+        MinMaxLayerSpec,
+        NormalizationLayerSpec,
+        TileLayerSpec,
+        BucketizationLayerSpec,
+        IDHashTokenizerLayerSpec,
+    ):
+        assert issubclass(cls, TorchTransformLayerSpec)

--- a/python/michelangelo/lib/native_transform/torch/transform_layer_spec.py
+++ b/python/michelangelo/lib/native_transform/torch/transform_layer_spec.py
@@ -18,7 +18,7 @@ class themselves.
 from __future__ import annotations
 
 from enum import Enum
-from typing import ClassVar
+from typing import ClassVar, Optional, Union
 
 import torch
 from pydantic import BaseModel, Field, field_validator, model_validator
@@ -100,14 +100,18 @@ class TorchTransformLayerSpec(BaseModel, arbitrary_types_allowed=True):
     # model data; pydantic v2 checks ClassVar annotations before its
     # leading-underscore private-attribute inference, so this is not
     # swallowed into PrivateAttr handling.
-    _resolved_layer_type: ClassVar[str | None] = None
+    _resolved_layer_type: ClassVar[Optional[str]] = None
 
     name: str = Field(..., description="Name")
     input_cols: list[str] = Field(..., description="Input columns")
     output_cols: list[str] = Field(..., description="Output columns")
-    input_dtype: torch.dtype | str | None = Field(None, description="Input dtype")
-    output_dtype: torch.dtype | str | None = Field(None, description="Output dtype")
-    input_shape: list[int] | None = Field(
+    input_dtype: Optional[Union[torch.dtype, str]] = Field(
+        None, description="Input dtype"
+    )
+    output_dtype: Optional[Union[torch.dtype, str]] = Field(
+        None, description="Output dtype"
+    )
+    input_shape: Optional[list[int]] = Field(
         None,
         description=(
             "Static per-sample input shape (no batch dim) for each input "
@@ -115,7 +119,7 @@ class TorchTransformLayerSpec(BaseModel, arbitrary_types_allowed=True):
             "package the served model."
         ),
     )
-    is_training_features: list[bool] | None = Field(
+    is_training_features: Optional[list[bool]] = Field(
         None, description="Is training features"
     )
     mode: TransformerMode = Field(
@@ -187,7 +191,7 @@ class StandardScalerLayerSpec(TorchTransformLayerSpec):
         with_std: Whether to scale the data by the standard deviation.
     """
 
-    _resolved_layer_type: ClassVar[str | None] = "NormalizationLayerSpec"
+    _resolved_layer_type: ClassVar[Optional[str]] = "NormalizationLayerSpec"
 
     with_mean: bool = Field(
         True, description="Whether to center the data by subtracting the mean"
@@ -200,7 +204,7 @@ class StandardScalerLayerSpec(TorchTransformLayerSpec):
 class MinMaxScalerLayerSpec(TorchTransformLayerSpec):
     """Placeholder resolved to :class:`MinMaxLayerSpec` after fitting."""
 
-    _resolved_layer_type: ClassVar[str | None] = "MinMaxLayerSpec"
+    _resolved_layer_type: ClassVar[Optional[str]] = "MinMaxLayerSpec"
 
 
 class ConcatenateLayerSpec(TorchTransformLayerSpec):
@@ -211,7 +215,7 @@ class ConcatenateLayerSpec(TorchTransformLayerSpec):
             preserved.
     """
 
-    dtype: torch.dtype | str | None = Field(
+    dtype: Optional[Union[torch.dtype, str]] = Field(
         None, description="Optional output dtype. When None, preserves input dtype."
     )
 
@@ -246,19 +250,19 @@ class NumericalStandardTransformLayerSpec(TorchTransformLayerSpec):
     """
 
     scale_factor: float = Field(1.0, description="Scale factor")
-    default_value: float | str = Field(
+    default_value: Union[float, str] = Field(
         "0.5",
         description=(
             "Default value, string value will be '0.0 - 0.99' for percentile choice"
         ),
     )
-    cap_min: float | str = Field(
+    cap_min: Union[float, str] = Field(
         "0.01",
         description=(
             "Min value, string value will be '0.0 - 0.99' for percentile choice"
         ),
     )
-    cap_max: float | str = Field(
+    cap_max: Union[float, str] = Field(
         "0.99",
         description=(
             "Max value, string value will be '0.0 - 0.99' for percentile choice"
@@ -307,12 +311,12 @@ class PercentileBucketizationLayerSpec(TorchTransformLayerSpec):
         dtype: The output dtype.
     """
 
-    _resolved_layer_type: ClassVar[str | None] = "BucketizationLayerSpec"
+    _resolved_layer_type: ClassVar[Optional[str]] = "BucketizationLayerSpec"
 
     percentiles: list[float] = Field(
         ..., description="Percentile values (0-1 or 1-100) to compute boundaries from"
     )
-    dtype: torch.dtype | str = Field(torch.int64, description="Output dtype")
+    dtype: Union[torch.dtype, str] = Field(torch.int64, description="Output dtype")
 
 
 class BucketizationLayerSpec(TorchTransformLayerSpec):
@@ -326,7 +330,7 @@ class BucketizationLayerSpec(TorchTransformLayerSpec):
     boundaries: list[float] = Field(
         ..., description="Pre-computed boundary values for bucketization"
     )
-    dtype: torch.dtype | str = Field(torch.int64, description="Output dtype")
+    dtype: Union[torch.dtype, str] = Field(torch.int64, description="Output dtype")
 
 
 class TensorColFillNoneLayerSpec(TorchTransformLayerSpec):
@@ -340,7 +344,7 @@ class TensorColFillNoneLayerSpec(TorchTransformLayerSpec):
         default_value: The value to fill ``None`` positions with.
     """
 
-    default_value: int | float = Field(..., description="Value to fill None with")
+    default_value: Union[int, float] = Field(..., description="Value to fill None with")
 
 
 class CastLayerSpec(TorchTransformLayerSpec):
@@ -350,7 +354,7 @@ class CastLayerSpec(TorchTransformLayerSpec):
         dtype: The target dtype to cast to.
     """
 
-    dtype: torch.dtype | str = Field(
+    dtype: Union[torch.dtype, str] = Field(
         torch.float32, description="Target data type for casting"
     )
 
@@ -362,7 +366,7 @@ class CaseWhenLayerSpec(TorchTransformLayerSpec):
         default_value: The value output when no condition matches.
     """
 
-    default_value: int | float | bool | torch.Tensor = Field(
+    default_value: Union[int, float, bool, torch.Tensor] = Field(
         ..., description="Default value if no conditions match"
     )
 
@@ -393,8 +397,10 @@ class ConstantLayerSpec(TorchTransformLayerSpec):
         dtype: The output dtype.
     """
 
-    constant: int | float | bool = Field(..., description="Constant value to output")
-    dtype: torch.dtype | str = Field(torch.float32, description="Output dtype")
+    constant: Union[int, float, bool] = Field(
+        ..., description="Constant value to output"
+    )
+    dtype: Union[torch.dtype, str] = Field(torch.float32, description="Output dtype")
 
 
 class DivideLayerSpec(TorchTransformLayerSpec):
@@ -425,10 +431,10 @@ class PadOrCrop1DLayerSpec(TorchTransformLayerSpec):
     """
 
     max_length: int = Field(..., description="Max length for padding or cropping")
-    dtype: torch.dtype | str | None = Field(
+    dtype: Optional[Union[torch.dtype, str]] = Field(
         None, description="Output dtype. When None, preserves input dtype."
     )
-    pad_value: int | float = Field(0, description="Value to use for padding")
+    pad_value: Union[int, float] = Field(0, description="Value to use for padding")
     align: str = Field(
         "left",
         description=(
@@ -451,7 +457,7 @@ class TileLayerSpec(TorchTransformLayerSpec):
     """
 
     axis: int = Field(0, description="Axis along which to tile the tensor")
-    count: int | None = Field(
+    count: Optional[int] = Field(
         None, description="Number of times to tile the tensor (optional)"
     )
     target_tensor_provided: bool = Field(
@@ -503,9 +509,9 @@ class ClipLayerSpec(TorchTransformLayerSpec):
             clamped.
     """
 
-    min_value: float | None = Field(None, description="Minimum value (lower bound)")
-    max_value: float | None = Field(None, description="Maximum value (upper bound)")
-    ignore_value: float | None = Field(
+    min_value: Optional[float] = Field(None, description="Minimum value (lower bound)")
+    max_value: Optional[float] = Field(None, description="Maximum value (upper bound)")
+    ignore_value: Optional[float] = Field(
         None, description="Optional value to ignore during clipping"
     )
 

--- a/python/michelangelo/lib/native_transform/torch/transform_layer_spec.py
+++ b/python/michelangelo/lib/native_transform/torch/transform_layer_spec.py
@@ -158,6 +158,9 @@ class NormalizationLayerSpec(TorchTransformLayerSpec):
         std: The per-feature standard deviation values used for
             standardization.
         dim: The dimension along which input columns are concatenated.
+
+    Raises:
+        ValueError: If ``output_cols`` does not contain exactly one column.
     """
 
     mean: list[float] = Field([0.0], description="Mean")
@@ -165,6 +168,29 @@ class NormalizationLayerSpec(TorchTransformLayerSpec):
     dim: int = Field(
         -1, description="Dimension along which input columns are concatenated"
     )
+
+    @model_validator(mode="after")
+    def validate_output_cols(self) -> NormalizationLayerSpec:
+        """Require exactly one output column.
+
+        The ``Normalization`` layer concatenates all input columns into a
+        single output, so more than one ``output_cols`` entry would be
+        silently ignored past the first at layer-build time; fail here
+        instead, at spec-parse time.
+
+        Returns:
+            ``self``.
+
+        Raises:
+            ValueError: If ``output_cols`` does not contain exactly one
+                column.
+        """
+        if len(self.output_cols) != 1:
+            raise ValueError(
+                "output_cols must contain exactly one column, since the "
+                "input columns are concatenated into a single output."
+            )
+        return self
 
 
 class MinMaxLayerSpec(TorchTransformLayerSpec):
@@ -174,6 +200,9 @@ class MinMaxLayerSpec(TorchTransformLayerSpec):
         min: The per-feature minimum values used for scaling.
         max: The per-feature maximum values used for scaling.
         dim: The dimension along which input columns are concatenated.
+
+    Raises:
+        ValueError: If ``output_cols`` does not contain exactly one column.
     """
 
     min: list[float] = Field([0.0], description="Min value")
@@ -181,6 +210,29 @@ class MinMaxLayerSpec(TorchTransformLayerSpec):
     dim: int = Field(
         -1, description="Dimension along which input columns are concatenated"
     )
+
+    @model_validator(mode="after")
+    def validate_output_cols(self) -> MinMaxLayerSpec:
+        """Require exactly one output column.
+
+        The ``MinMax`` layer concatenates all input columns into a single
+        output, so more than one ``output_cols`` entry would be silently
+        ignored past the first at layer-build time; fail here instead, at
+        spec-parse time.
+
+        Returns:
+            ``self``.
+
+        Raises:
+            ValueError: If ``output_cols`` does not contain exactly one
+                column.
+        """
+        if len(self.output_cols) != 1:
+            raise ValueError(
+                "output_cols must contain exactly one column, since the "
+                "input columns are concatenated into a single output."
+            )
+        return self
 
 
 class StandardScalerLayerSpec(TorchTransformLayerSpec):

--- a/python/michelangelo/lib/native_transform/torch/transform_layer_spec.py
+++ b/python/michelangelo/lib/native_transform/torch/transform_layer_spec.py
@@ -1,0 +1,551 @@
+"""Pydantic specs for native transform layers.
+
+Declarative, serializable descriptions of the individual layers in a
+``TransformSpec`` DAG (the DAG engine and layer-name-to-spec-class registry
+that consume these specs are added in a follow-up module). Every concrete
+``*LayerSpec`` subclasses :class:`TorchTransformLayerSpec`, which carries the
+fields common to every native transform layer (input/output columns, dtypes,
+shape, training-feature flags, and incremental-training mode).
+
+A handful of specs (e.g. :class:`StandardScalerLayerSpec`,
+:class:`MinMaxScalerLayerSpec`, :class:`PercentileBucketizationLayerSpec`) are
+placeholders: they describe a layer configuration that is resolved to a
+concrete layer spec (named in ``_resolved_layer_type``) once fitted
+statistics are computed, rather than mapping directly to a transform layer
+class themselves.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import ClassVar
+
+import torch
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from michelangelo.lib.native_transform.torch.constants import (
+    DEFAULT_NUMERICAL_OUTPUT_DTYPE,
+)
+from michelangelo.lib.native_transform.torch.utils import generate_layer_name
+
+__all__ = [
+    "BucketizationLayerSpec",
+    "CaseWhenLayerSpec",
+    "CastLayerSpec",
+    "CeilLayerSpec",
+    "ClipLayerSpec",
+    "CompareLayerSpec",
+    "ConcatenateLayerSpec",
+    "ConstantLayerSpec",
+    "DivideLayerSpec",
+    "FloorLayerSpec",
+    "IDHashTokenizerLayerSpec",
+    "IdentityTransformLayerSpec",
+    "LogTransformLayerSpec",
+    "MinMaxLayerSpec",
+    "MinMaxScalerLayerSpec",
+    "NormalizationLayerSpec",
+    "NumericalStandardTransformLayerSpec",
+    "PadOrCrop1DLayerSpec",
+    "PercentileBucketizationLayerSpec",
+    "ScaleLayerSpec",
+    "StackLayerSpec",
+    "StandardScalerLayerSpec",
+    "SubtractLayerSpec",
+    "TensorColFillNoneLayerSpec",
+    "TileLayerSpec",
+    "TorchTransformLayerSpec",
+    "TransformerMode",
+]
+
+
+class TransformerMode(str, Enum):
+    """Per-layer mode controlling behavior during incremental training.
+
+    Attributes:
+        INVALID: Not set by the user; defaults to ``REUSE`` when incremental
+            training is active.
+        REFIT: Compute fitted statistics from the current data (a fresh fit).
+        REUSE: Reuse the base model's pre-fitted statistics as-is.
+        INC_REFIT: Placeholder for a future incremental-refit mode; currently
+            unsupported (schema-only).
+    """
+
+    INVALID = "INVALID"
+    REFIT = "REFIT"
+    REUSE = "REUSE"
+    INC_REFIT = "INC_REFIT"
+
+
+class TorchTransformLayerSpec(BaseModel, arbitrary_types_allowed=True):
+    """Base configuration shared by every native transform layer spec.
+
+    Args:
+        name: The layer's name. Auto-generated from the spec's class name
+            when omitted.
+        input_cols: Column names of the layer's input tensors.
+        output_cols: Column names of the layer's output tensors.
+        input_dtype: Optional input dtype override.
+        output_dtype: Optional output dtype override.
+        input_shape: Static per-sample input shape (excluding the batch
+            dimension) for each input column. For ragged arrays, set the
+            fixed max length used to package the served model.
+        is_training_features: Whether each output column is a training
+            feature. Defaults to ``True`` for every output column when
+            omitted.
+        mode: The per-layer incremental-training mode.
+    """
+
+    # Declared as ClassVar (not a pydantic field) so it isn't treated as
+    # model data; pydantic v2 checks ClassVar annotations before its
+    # leading-underscore private-attribute inference, so this is not
+    # swallowed into PrivateAttr handling.
+    _resolved_layer_type: ClassVar[str | None] = None
+
+    name: str = Field(..., description="Name")
+    input_cols: list[str] = Field(..., description="Input columns")
+    output_cols: list[str] = Field(..., description="Output columns")
+    input_dtype: torch.dtype | str | None = Field(None, description="Input dtype")
+    output_dtype: torch.dtype | str | None = Field(None, description="Output dtype")
+    input_shape: list[int] | None = Field(
+        None,
+        description=(
+            "Static per-sample input shape (no batch dim) for each input "
+            "col; for ragged arrays set the fixed max length used to "
+            "package the served model."
+        ),
+    )
+    is_training_features: list[bool] | None = Field(
+        None, description="Is training features"
+    )
+    mode: TransformerMode = Field(
+        TransformerMode.INVALID, description="Per-layer incremental training mode"
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def set_defaults(cls, values: dict) -> dict:
+        """Default ``is_training_features`` and auto-generate ``name``.
+
+        Args:
+            values: The raw field values supplied to the model.
+
+        Returns:
+            ``values``, with ``is_training_features`` defaulted to
+            ``[True] * len(output_cols)`` and ``name`` auto-generated from
+            the spec's class name when either was omitted.
+        """
+        output_cols = values.get("output_cols")
+        is_training_features = values.get("is_training_features")
+        if is_training_features is None and output_cols is not None:
+            values["is_training_features"] = [True] * len(output_cols)
+        if values.get("name") is None:
+            values["name"] = generate_layer_name(
+                cls.__name__.replace("LayerSpec", "").lower()
+            )
+        return values
+
+
+class NormalizationLayerSpec(TorchTransformLayerSpec):
+    """Spec for the ``Normalization`` layer (a fitted ``StandardScaler``).
+
+    Args:
+        mean: The per-feature mean values used for standardization.
+        std: The per-feature standard deviation values used for
+            standardization.
+        dim: The dimension along which input columns are concatenated.
+    """
+
+    mean: list[float] = Field([0.0], description="Mean")
+    std: list[float] = Field([1.0], description="Std")
+    dim: int = Field(
+        -1, description="Dimension along which input columns are concatenated"
+    )
+
+
+class MinMaxLayerSpec(TorchTransformLayerSpec):
+    """Spec for the ``MinMax`` layer (a fitted ``MinMaxScaler``).
+
+    Args:
+        min: The per-feature minimum values used for scaling.
+        max: The per-feature maximum values used for scaling.
+        dim: The dimension along which input columns are concatenated.
+    """
+
+    min: list[float] = Field([0.0], description="Min value")
+    max: list[float] = Field([1.0], description="Max value")
+    dim: int = Field(
+        -1, description="Dimension along which input columns are concatenated"
+    )
+
+
+class StandardScalerLayerSpec(TorchTransformLayerSpec):
+    """Placeholder resolved to :class:`NormalizationLayerSpec` after fitting.
+
+    Args:
+        with_mean: Whether to center the data by subtracting the mean.
+        with_std: Whether to scale the data by the standard deviation.
+    """
+
+    _resolved_layer_type: ClassVar[str | None] = "NormalizationLayerSpec"
+
+    with_mean: bool = Field(
+        True, description="Whether to center the data by subtracting the mean"
+    )
+    with_std: bool = Field(
+        False, description="Whether to scale the data by the standard deviation"
+    )
+
+
+class MinMaxScalerLayerSpec(TorchTransformLayerSpec):
+    """Placeholder resolved to :class:`MinMaxLayerSpec` after fitting."""
+
+    _resolved_layer_type: ClassVar[str | None] = "MinMaxLayerSpec"
+
+
+class ConcatenateLayerSpec(TorchTransformLayerSpec):
+    """Spec for the ``Concatenate`` layer.
+
+    Args:
+        dtype: Optional output dtype. When ``None``, the input dtype is
+            preserved.
+    """
+
+    dtype: torch.dtype | str | None = Field(
+        None, description="Optional output dtype. When None, preserves input dtype."
+    )
+
+
+class StackLayerSpec(TorchTransformLayerSpec):
+    """Spec for the ``Stack`` layer.
+
+    Args:
+        dim: The dimension along which to stack tensors.
+    """
+
+    dim: int = Field(-1, description="Dimension along which to stack tensors")
+
+
+class NumericalStandardTransformLayerSpec(TorchTransformLayerSpec):
+    """Spec for a numerical standardization transform with capping and log scaling.
+
+    Args:
+        scale_factor: The scale factor applied to the transformed value.
+        default_value: The value substituted for missing data, or a string
+            in ``"0.0"``-``"0.99"`` to select a percentile instead.
+        cap_min: The minimum cap value, or a percentile string as above.
+        cap_max: The maximum cap value, or a percentile string as above.
+        log_base: The logarithm base used when ``is_log_value`` is set.
+        is_cap_value: Whether to cap the value to ``[cap_min, cap_max]``.
+        is_log_value: Whether to apply a log transform to the value.
+        dtype: The output dtype.
+
+    Raises:
+        ValueError: If a percentile string is outside ``[0.0, 1.0]``, or if
+            ``cap_min`` is greater than ``cap_max``.
+    """
+
+    scale_factor: float = Field(1.0, description="Scale factor")
+    default_value: float | str = Field(
+        "0.5",
+        description=(
+            "Default value, string value will be '0.0 - 0.99' for percentile choice"
+        ),
+    )
+    cap_min: float | str = Field(
+        "0.01",
+        description=(
+            "Min value, string value will be '0.0 - 0.99' for percentile choice"
+        ),
+    )
+    cap_max: float | str = Field(
+        "0.99",
+        description=(
+            "Max value, string value will be '0.0 - 0.99' for percentile choice"
+        ),
+    )
+    log_base: float = Field(10.0, description="Log base")
+    is_cap_value: bool = Field(True, description="Is cap value")
+    is_log_value: bool = Field(True, description="Is log value")
+    dtype: torch.dtype = Field(
+        DEFAULT_NUMERICAL_OUTPUT_DTYPE, description="Output dtype"
+    )
+
+    @model_validator(mode="after")
+    def set_output_dtype(self) -> NumericalStandardTransformLayerSpec:
+        """Mirror ``dtype`` onto ``output_dtype`` and validate the cap range.
+
+        Returns:
+            ``self``, with ``output_dtype`` set to ``dtype``.
+
+        Raises:
+            ValueError: If a percentile string is outside ``[0.0, 1.0]``, or
+                if ``cap_min`` is greater than ``cap_max``.
+        """
+        self.output_dtype = self.dtype
+        cap_max = self.cap_max
+        cap_min = self.cap_min
+        if isinstance(cap_max, str) and (float(cap_max) < 0.0 or float(cap_max) > 1.0):
+            raise ValueError(f"cap_max {cap_max} is not in [0.0, 1.0]")
+        if isinstance(cap_min, str) and (float(cap_min) < 0.0 or float(cap_min) > 1.0):
+            raise ValueError(f"cap_min {cap_min} is not in [0.0, 1.0]")
+        if isinstance(self.default_value, str) and (
+            float(self.default_value) < 0.0 or float(self.default_value) > 1.0
+        ):
+            raise ValueError(f"default_value {self.default_value} is not in [0.0, 1.0]")
+        if float(cap_min) > float(cap_max):
+            raise ValueError(f"cap_min {cap_min} is greater than cap_max {cap_max}")
+        return self
+
+
+class PercentileBucketizationLayerSpec(TorchTransformLayerSpec):
+    """Placeholder resolved to :class:`BucketizationLayerSpec` after fitting.
+
+    Args:
+        percentiles: Percentile values (``0``-``1`` or ``1``-``100``) to
+            compute boundaries from.
+        dtype: The output dtype.
+    """
+
+    _resolved_layer_type: ClassVar[str | None] = "BucketizationLayerSpec"
+
+    percentiles: list[float] = Field(
+        ..., description="Percentile values (0-1 or 1-100) to compute boundaries from"
+    )
+    dtype: torch.dtype | str = Field(torch.int64, description="Output dtype")
+
+
+class BucketizationLayerSpec(TorchTransformLayerSpec):
+    """Spec for the ``Bucketization`` layer, with pre-computed boundaries.
+
+    Args:
+        boundaries: Pre-computed boundary values for bucketization.
+        dtype: The output dtype.
+    """
+
+    boundaries: list[float] = Field(
+        ..., description="Pre-computed boundary values for bucketization"
+    )
+    dtype: torch.dtype | str = Field(torch.int64, description="Output dtype")
+
+
+class TensorColFillNoneLayerSpec(TorchTransformLayerSpec):
+    """Spec for the ``TensorColFillNone`` layer.
+
+    None detection is derived from the actual tensor dtype at runtime. The
+    ``input_dtype`` field from the base class is accepted for backward
+    compatibility with existing configs but is not used by the layer.
+
+    Args:
+        default_value: The value to fill ``None`` positions with.
+    """
+
+    default_value: int | float = Field(..., description="Value to fill None with")
+
+
+class CastLayerSpec(TorchTransformLayerSpec):
+    """Spec for the ``Cast`` layer.
+
+    Args:
+        dtype: The target dtype to cast to.
+    """
+
+    dtype: torch.dtype | str = Field(
+        torch.float32, description="Target data type for casting"
+    )
+
+
+class CaseWhenLayerSpec(TorchTransformLayerSpec):
+    """Spec for the ``CaseWhen`` layer.
+
+    Args:
+        default_value: The value output when no condition matches.
+    """
+
+    default_value: int | float | bool | torch.Tensor = Field(
+        ..., description="Default value if no conditions match"
+    )
+
+
+class CompareLayerSpec(TorchTransformLayerSpec):
+    """Spec for the ``Compare`` layer.
+
+    Args:
+        compare_op: The comparison operator, e.g. ``"equal"``, ``"greater"``,
+            ``"less"``, ``"greater_equal"``, ``"less_equal"``,
+            ``"not_equal"``.
+    """
+
+    compare_op: str = Field(
+        ...,
+        description=(
+            "Comparison operator, e.g., 'equal', 'greater', 'less', "
+            "'greater_equal', 'less_equal', 'not_equal'"
+        ),
+    )
+
+
+class ConstantLayerSpec(TorchTransformLayerSpec):
+    """Spec for the ``Constant`` layer.
+
+    Args:
+        constant: The constant value to output.
+        dtype: The output dtype.
+    """
+
+    constant: int | float | bool = Field(..., description="Constant value to output")
+    dtype: torch.dtype | str = Field(torch.float32, description="Output dtype")
+
+
+class DivideLayerSpec(TorchTransformLayerSpec):
+    """Spec for the ``Divide`` layer.
+
+    Args:
+        add_constant_to_divisor: A constant added to the divisor to avoid
+            division by zero.
+    """
+
+    add_constant_to_divisor: float = Field(
+        0.0,
+        description="Constant to add to the divisor to avoid division by zero",
+    )
+
+
+class PadOrCrop1DLayerSpec(TorchTransformLayerSpec):
+    """Spec for the ``PadOrCrop1D`` layer.
+
+    Args:
+        max_length: The fixed target length for padding or cropping.
+        dtype: Optional output dtype. When ``None``, the input dtype is
+            preserved.
+        pad_value: The value used for padding.
+        align: Which end is kept when cropping: ``"left"`` (default) keeps
+            the first ``max_length`` elements; ``"right"`` keeps the last
+            ``max_length`` elements.
+    """
+
+    max_length: int = Field(..., description="Max length for padding or cropping")
+    dtype: torch.dtype | str | None = Field(
+        None, description="Output dtype. When None, preserves input dtype."
+    )
+    pad_value: int | float = Field(0, description="Value to use for padding")
+    align: str = Field(
+        "left",
+        description=(
+            'Controls which end is kept when cropping. "left" (default) '
+            'keeps the first max_length elements; "right" keeps the last '
+            "max_length elements."
+        ),
+    )
+
+
+class TileLayerSpec(TorchTransformLayerSpec):
+    """Spec for the ``Tile`` layer.
+
+    Args:
+        axis: The axis along which to tile the tensor.
+        count: The number of times to tile the tensor, if not derived from a
+            target tensor.
+        target_tensor_provided: Whether a target tensor is provided to tile
+            against, instead of a fixed ``count``.
+    """
+
+    axis: int = Field(0, description="Axis along which to tile the tensor")
+    count: int | None = Field(
+        None, description="Number of times to tile the tensor (optional)"
+    )
+    target_tensor_provided: bool = Field(
+        False, description="Whether a target tensor is provided for tiling"
+    )
+
+
+class LogTransformLayerSpec(TorchTransformLayerSpec):
+    """Spec for the ``LogTransform`` layer.
+
+    Args:
+        add_constant: A constant added before the log transformation.
+    """
+
+    add_constant: float = Field(
+        1.0, description="Constant to add before log transformation"
+    )
+
+
+class SubtractLayerSpec(TorchTransformLayerSpec):
+    """Spec for the ``Subtract`` layer."""
+
+
+class ScaleLayerSpec(TorchTransformLayerSpec):
+    """Spec for the ``Scale`` layer.
+
+    Args:
+        factor: The scalar multiplier.
+    """
+
+    factor: float = Field(..., description="The scalar multiplier")
+
+
+class FloorLayerSpec(TorchTransformLayerSpec):
+    """Spec for the ``Floor`` layer."""
+
+
+class CeilLayerSpec(TorchTransformLayerSpec):
+    """Spec for the ``Ceil`` layer."""
+
+
+class ClipLayerSpec(TorchTransformLayerSpec):
+    """Spec for the ``Clip`` layer.
+
+    Args:
+        min_value: The lower bound, or ``None`` for no lower bound.
+        max_value: The upper bound, or ``None`` for no upper bound.
+        ignore_value: An optional value preserved unchanged rather than
+            clamped.
+    """
+
+    min_value: float | None = Field(None, description="Minimum value (lower bound)")
+    max_value: float | None = Field(None, description="Maximum value (upper bound)")
+    ignore_value: float | None = Field(
+        None, description="Optional value to ignore during clipping"
+    )
+
+
+class IDHashTokenizerLayerSpec(TorchTransformLayerSpec):
+    """Spec for the ``IDHashTokenizer`` layer.
+
+    Args:
+        vocabulary: The list of integer values making up the vocabulary.
+
+    Raises:
+        ValueError: If ``vocabulary`` is empty.
+    """
+
+    vocabulary: list[int] = Field(
+        ..., description="List of integer values representing the vocabulary"
+    )
+
+    @field_validator("vocabulary")
+    @classmethod
+    def validate_vocabulary(cls, v: list[int]) -> list[int]:
+        """Reject an empty vocabulary.
+
+        Args:
+            v: The vocabulary value being validated.
+
+        Returns:
+            ``v`` unchanged.
+
+        Raises:
+            ValueError: If ``v`` is empty.
+        """
+        if not v:
+            raise ValueError("Vocabulary cannot be empty")
+        return v
+
+
+class IdentityTransformLayerSpec(TorchTransformLayerSpec):
+    """Spec for the ``IdentityTransform`` layer.
+
+    Passes input through unchanged; used to ensure fields are included in
+    the native transform input schema for downstream model assembly.
+    """

--- a/python/michelangelo/lib/native_transform/torch/transform_layer_spec.py
+++ b/python/michelangelo/lib/native_transform/torch/transform_layer_spec.py
@@ -150,6 +150,30 @@ class TorchTransformLayerSpec(BaseModel, arbitrary_types_allowed=True):
         return values
 
 
+def _require_single_output_col(output_cols: list[str]) -> None:
+    """Raise unless ``output_cols`` contains exactly one column.
+
+    Shared by every spec whose layer concatenates all input columns into a
+    single output, both the concrete specs (:class:`NormalizationLayerSpec`,
+    :class:`MinMaxLayerSpec`) and their pre-fit placeholder counterparts
+    (:class:`StandardScalerLayerSpec`, :class:`MinMaxScalerLayerSpec`), since
+    a placeholder resolves 1:1 into the concrete spec named in its
+    ``_resolved_layer_type``: an ``output_cols`` value invalid for the
+    concrete spec is invalid for its placeholder too.
+
+    Args:
+        output_cols: The spec's ``output_cols`` value.
+
+    Raises:
+        ValueError: If ``output_cols`` does not contain exactly one column.
+    """
+    if len(output_cols) != 1:
+        raise ValueError(
+            "output_cols must contain exactly one column, since the "
+            "input columns are concatenated into a single output."
+        )
+
+
 class NormalizationLayerSpec(TorchTransformLayerSpec):
     """Spec for the ``Normalization`` layer (a fitted ``StandardScaler``).
 
@@ -185,11 +209,7 @@ class NormalizationLayerSpec(TorchTransformLayerSpec):
             ValueError: If ``output_cols`` does not contain exactly one
                 column.
         """
-        if len(self.output_cols) != 1:
-            raise ValueError(
-                "output_cols must contain exactly one column, since the "
-                "input columns are concatenated into a single output."
-            )
+        _require_single_output_col(self.output_cols)
         return self
 
 
@@ -227,11 +247,7 @@ class MinMaxLayerSpec(TorchTransformLayerSpec):
             ValueError: If ``output_cols`` does not contain exactly one
                 column.
         """
-        if len(self.output_cols) != 1:
-            raise ValueError(
-                "output_cols must contain exactly one column, since the "
-                "input columns are concatenated into a single output."
-            )
+        _require_single_output_col(self.output_cols)
         return self
 
 
@@ -241,6 +257,9 @@ class StandardScalerLayerSpec(TorchTransformLayerSpec):
     Args:
         with_mean: Whether to center the data by subtracting the mean.
         with_std: Whether to scale the data by the standard deviation.
+
+    Raises:
+        ValueError: If ``output_cols`` does not contain exactly one column.
     """
 
     _resolved_layer_type: ClassVar[Optional[str]] = "NormalizationLayerSpec"
@@ -252,11 +271,51 @@ class StandardScalerLayerSpec(TorchTransformLayerSpec):
         False, description="Whether to scale the data by the standard deviation"
     )
 
+    @model_validator(mode="after")
+    def validate_output_cols(self) -> StandardScalerLayerSpec:
+        """Require exactly one output column.
+
+        Resolves to :class:`NormalizationLayerSpec`, which concatenates all
+        input columns into a single output; fail here too, at spec-parse
+        time, rather than only once resolved.
+
+        Returns:
+            ``self``.
+
+        Raises:
+            ValueError: If ``output_cols`` does not contain exactly one
+                column.
+        """
+        _require_single_output_col(self.output_cols)
+        return self
+
 
 class MinMaxScalerLayerSpec(TorchTransformLayerSpec):
-    """Placeholder resolved to :class:`MinMaxLayerSpec` after fitting."""
+    """Placeholder resolved to :class:`MinMaxLayerSpec` after fitting.
+
+    Raises:
+        ValueError: If ``output_cols`` does not contain exactly one column.
+    """
 
     _resolved_layer_type: ClassVar[Optional[str]] = "MinMaxLayerSpec"
+
+    @model_validator(mode="after")
+    def validate_output_cols(self) -> MinMaxScalerLayerSpec:
+        """Require exactly one output column.
+
+        Resolves to :class:`MinMaxLayerSpec`, which concatenates all input
+        columns into a single output; fail here too, at spec-parse time,
+        rather than only once resolved.
+
+        Returns:
+            ``self``.
+
+        Raises:
+            ValueError: If ``output_cols`` does not contain exactly one
+                column.
+        """
+        _require_single_output_col(self.output_cols)
+        return self
 
 
 class ConcatenateLayerSpec(TorchTransformLayerSpec):

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -200,6 +200,13 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 # The trainer package is a one-time snapshot of internal training code; line-length
 # rule is relaxed to preserve the original code shape from the upstream source.
 "michelangelo/lib/trainer/**/*.py" = ["E501"]
+# Pydantic v2 evaluates field annotations at class-definition time to build
+# validators, even with `from __future__ import annotations`. On Python 3.9,
+# evaluating `X | Y` union syntax raises TypeError (PEP 604 added `|` support to
+# `type` only in 3.10) -- so this file must keep `Optional`/`Union` from `typing`
+# rather than the pyupgrade-recommended `X | None`/`X | Y` syntax, or every
+# pydantic model here breaks at import time on 3.9 (see compat-matrix.yml).
+"michelangelo/lib/native_transform/torch/transform_layer_spec.py" = ["UP007", "UP045"]
 
 # Google-style docstrings
 [tool.ruff.lint.pydocstyle]


### PR DESCRIPTION
## Summary

Continues the native_transform migration (PR A, A2, B1, B2, B3, B4 in flight) with PR B5: the Pydantic layer specs.

- Ports the internal SDK's `transform_layer_spec.py` in full: declarative, serializable pydantic v2 specs describing every native transform layer's configuration, consumed by a `TransformSpec` DAG engine that's added in a follow-up PR (not this one — this PR is spec-models only).
- All 27 classes (25 concrete `*LayerSpec` classes + the base `TorchTransformLayerSpec` + the `TransformerMode` enum) ported field-for-field, using `typing.Optional`/`Union` (not `X | None`/`X | Y`) for dtype/optional fields -- see Review section, this repo supports Python 3.9 and pydantic v2 eagerly evaluates field annotations even with `from __future__ import annotations`.
- Placeholder specs (`StandardScalerLayerSpec`, `MinMaxScalerLayerSpec`, `PercentileBucketizationLayerSpec`) resolve to a concrete spec via `_resolved_layer_type`, matching internal's fit-time resolution scheme.
- `NumericalStandardTransformLayerSpec`'s cross-field `cap_min`/`cap_max`/`default_value` percentile-range validation ported with identical error wording.
- This is the **first real usage of pydantic** anywhere in this repo's `lib/` tree (already a declared dependency, previously unused) — sets the v2 style precedent (`Field`, `model_validator`, `field_validator`, `ClassVar`) for future spec PRs.

Per the migration plan, this is scoped to **all** spec classes rather than just the layers already ported (B1-B4) — these are inert models with no functional dependency on the corresponding layer classes existing, so there's no ordering risk and it avoids a second churn PR when B6-B8 land.

## Review

Reviewed by the migration team before opening: architect review confirmed field-for-field parity with internal across all 27 classes, with no bugs found. Dev-advocate review caught a real type/default mismatch (`is_training_features` annotated as non-optional `list[bool]` but defaulting to `None`, only rescued at runtime by a validator) and several under-documented field descriptions — both fixed before this PR opened.

**Post-open fix (2026-08-06)**: caught by review that `X | Y`-style union annotations (the original port style) crash `python-build` under Python 3.9 -- pydantic v2 evaluates field annotations at class-definition time to build validators, and PEP 604's `|` operator on `type` only exists from 3.10; `from __future__ import annotations` defers the Python-level parse but not pydantic's runtime eval. Verified independently against a real Python 3.9 + pydantic install (reproduced the crash on the original file, confirmed clean on the fix). Converted every union annotation in this file to `Optional`/`Union`, and added a scoped `ruff` per-file-ignore (`UP007`/`UP045`) so `ruff check --fix` can't silently reintroduce the `X | Y` syntax and regress this fix later.

**Post-open addition (2026-08-06)**: added a `model_validator` to `MinMaxLayerSpec` and `NormalizationLayerSpec` requiring exactly one `output_cols` entry, matching the runtime check on the corresponding layers (PR B3, `stats_layers.py`). Both layers concatenate all input columns into a single output, so a spec with more than one `output_cols` entry would previously build successfully but silently drop everything past the first only at layer-build time (B6) -- this fails at spec-parse time instead.

## Test plan

- [x] `pytest` on the full `native_transform` suite: 240 passed, 1 pre-existing unrelated skip
- [x] `ruff format --check` / `ruff check`: clean
- [x] Manual sanity check of defaulting/validation behavior against the internal source
- [x] Diff scanned for internal-only identifiers/URLs: clean

