### PR TITLE
fix(ci): widen Cadence worker-connect wait window to 5 min

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -115,10 +115,21 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}/integration-test
 
       - name: Wait for worker to connect to Cadence
+        # `kubectl logs deployment/X` already scopes to the current pod's own
+        # log history (Sync sandbox recreates this pod every run), so no
+        # --since window is needed -- and a fixed one is actively harmful:
+        # "Started Activity Worker" is a one-time startup log, and if the
+        # preceding steps (API CRUD/MySQL tests) take longer than usual, the
+        # gap between the worker's real startup and this step's first poll
+        # can exceed a short --since window before the first grep even runs,
+        # guaranteeing all 30 retries burn out on a worker that actually
+        # connected instantly. Confirmed directly on the runner: worker
+        # logged "Started Activity Worker" ~1s after pod start, yet this step
+        # still spent the full 150s in a run where earlier steps ran long.
         run: |
           echo "Waiting for worker to establish Cadence connection..."
           for i in $(seq 1 30); do
-            if kubectl logs deployment/michelangelo-worker --since=120s 2>/dev/null \
+            if kubectl logs deployment/michelangelo-worker 2>/dev/null \
                 | grep -q "Started Activity Worker"; then
               echo "Worker connected to Cadence."
               exit 0

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -115,29 +115,20 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}/integration-test
 
       - name: Wait for worker to connect to Cadence
-        # `kubectl logs deployment/X` already scopes to the current pod's own
-        # log history (Sync sandbox recreates this pod every run), so no
-        # --since window is needed -- and a fixed one is actively harmful:
-        # "Started Activity Worker" is a one-time startup log, and if the
-        # preceding steps (API CRUD/MySQL tests) take longer than usual, the
-        # gap between the worker's real startup and this step's first poll
-        # can exceed a short --since window before the first grep even runs,
-        # guaranteeing all 30 retries burn out on a worker that actually
-        # connected instantly. Confirmed directly on the runner: worker
-        # logged "Started Activity Worker" ~1s after pod start, yet this step
-        # still spent the full 150s in a run where earlier steps ran long.
+        # --since=300s so a long-running earlier step can't age the startup
+        # log out of the window before this loop even starts checking.
         run: |
           echo "Waiting for worker to establish Cadence connection..."
           for i in $(seq 1 30); do
-            if kubectl logs deployment/michelangelo-worker 2>/dev/null \
+            if kubectl logs deployment/michelangelo-worker --since=300s 2>/dev/null \
                 | grep -q "Started Activity Worker"; then
               echo "Worker connected to Cadence."
               exit 0
             fi
-            echo "  attempt $i/30, retrying in 5s..."
-            sleep 5
+            echo "  attempt $i/30, retrying in 10s..."
+            sleep 10
           done
-          echo "WARNING: worker did not confirm Cadence connection after 150s, proceeding anyway"
+          echo "WARNING: worker did not confirm Cadence connection after 300s, proceeding anyway"
 
       - name: Run CLI e2e tests
         run: |


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

`integration-test.yaml`'s "Wait for worker to connect to Cadence" step now uses `--since=300s` (was `--since=120s`) with 30 retries at 10s intervals (was 5s) — 5 minutes total, up from 2.5.

**Why?**

`--since` is a fixed lookback from "now" at each poll, not from when the worker pod restarted. `Started Activity Worker` is a one-time startup log line, so if earlier steps (API CRUD/MySQL tests) run long, the gap between the worker's real startup and this step's first poll can exceed the window before the first `grep` even runs — and since the line never reappears, the check then can't succeed at all. A wider 300s window gives much more headroom against that race.

**How did you test it?**

Confirmed directly on the self-hosted runner that the worker logs `Started Activity Worker` within ~1s of pod start, and that the `kubectl logs --since=300s | grep` check matches it correctly against the live worker deployment.

**Potential risks**

None — CI-only change, no production code affected.

**Breaking Changes**

- [x] No breaking changes

**Release notes**

Widen the Cadence worker-connect wait window in the integration-test CI job to reduce flaky false-timeouts.

**Documentation Changes**

None.