### PR TITLE
feat(python)!: add kind to ModelPusherPlugin

### DIFF
--- a/python/michelangelo/lib/model_manager/constants/__init__.py
+++ b/python/michelangelo/lib/model_manager/constants/__init__.py
@@ -1,6 +1,7 @@
 """Constants for the model manager."""
 
 # flake8: noqa:F401
+from .model_kind import ModelKind
 from .raw_model_type import RawModelType
 from .storage_type import StorageType
 from .triton_backend_type import TritonBackendType

--- a/python/michelangelo/lib/model_manager/constants/model_kind.py
+++ b/python/michelangelo/lib/model_manager/constants/model_kind.py
@@ -9,9 +9,15 @@ class ModelKind:
         REGRESSION: Regression model.
         BINARY_CLASSIFICATION: Binary classification model.
         MULTICLASS_CLASSIFICATION: Multiclass classification model.
+        LLM_COMPLETION: LLM text-completion model.
+        LLM_CHAT_COMPLETION: LLM chat-completion model.
+        LLM_EMBEDDING: LLM embedding model.
     """
 
     CUSTOM = "custom"
     REGRESSION = "regression"
     BINARY_CLASSIFICATION = "binary-classification"
     MULTICLASS_CLASSIFICATION = "multiclass-classification"
+    LLM_COMPLETION = "llm-completion"
+    LLM_CHAT_COMPLETION = "llm-chat-completion"
+    LLM_EMBEDDING = "llm-embedding"

--- a/python/michelangelo/lib/model_manager/constants/model_kind.py
+++ b/python/michelangelo/lib/model_manager/constants/model_kind.py
@@ -1,0 +1,17 @@
+"""Model kind constants."""
+
+
+class ModelKind:
+    """Model kinds describing the prediction task a registered model performs.
+
+    Attributes:
+        CUSTOM: Model type not covered by the other kinds.
+        REGRESSION: Regression model.
+        BINARY_CLASSIFICATION: Binary classification model.
+        MULTICLASS_CLASSIFICATION: Multiclass classification model.
+    """
+
+    CUSTOM = "custom"
+    REGRESSION = "regression"
+    BINARY_CLASSIFICATION = "binary-classification"
+    MULTICLASS_CLASSIFICATION = "multiclass-classification"

--- a/python/michelangelo/lib/model_manager/constants/tests/model_kind_test.py
+++ b/python/michelangelo/lib/model_manager/constants/tests/model_kind_test.py
@@ -16,3 +16,6 @@ class ModelKindTest(TestCase):
         self.assertEqual(
             ModelKind.MULTICLASS_CLASSIFICATION, "multiclass-classification"
         )
+        self.assertEqual(ModelKind.LLM_COMPLETION, "llm-completion")
+        self.assertEqual(ModelKind.LLM_CHAT_COMPLETION, "llm-chat-completion")
+        self.assertEqual(ModelKind.LLM_EMBEDDING, "llm-embedding")

--- a/python/michelangelo/lib/model_manager/constants/tests/model_kind_test.py
+++ b/python/michelangelo/lib/model_manager/constants/tests/model_kind_test.py
@@ -1,0 +1,18 @@
+"""Tests for ModelKind constants."""
+
+from unittest import TestCase
+
+from michelangelo.lib.model_manager.constants import ModelKind
+
+
+class ModelKindTest(TestCase):
+    """Tests the model kind enum values."""
+
+    def test_model_kind(self):
+        """It exposes user friendly string representations."""
+        self.assertEqual(ModelKind.CUSTOM, "custom")
+        self.assertEqual(ModelKind.REGRESSION, "regression")
+        self.assertEqual(ModelKind.BINARY_CLASSIFICATION, "binary-classification")
+        self.assertEqual(
+            ModelKind.MULTICLASS_CLASSIFICATION, "multiclass-classification"
+        )

--- a/python/michelangelo/lib/model_manager/registry/api_client.py
+++ b/python/michelangelo/lib/model_manager/registry/api_client.py
@@ -16,6 +16,7 @@ Typical usage::
     registered = registry.register_model(
         name="my-classifier",
         artifact_uri="s3://bucket/models/my-classifier/abc123/raw/model.ubj",
+        kind=ModelKind.BINARY_CLASSIFICATION,
         labels={"framework": "xgboost"},
         metadata={"rmse": 0.87},
     )
@@ -47,6 +48,7 @@ from typing import TYPE_CHECKING, Any
 import grpc
 
 from michelangelo.gen.api.v2 import model_pb2
+from michelangelo.lib.model_manager.constants import ModelKind
 from michelangelo.lib.model_manager.registry.client import (
     ModelRegistryClient,
     RegisteredModel,
@@ -66,6 +68,28 @@ _MAX_REGISTER_RETRIES = 3
 
 _K8S_LABEL_VALUE_MAX_LENGTH = 63
 _K8S_LABEL_VALUE_RE = re.compile(r"^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$")
+
+_KIND_TO_PROTO = {
+    ModelKind.CUSTOM: model_pb2.MODEL_KIND_CUSTOM,
+    ModelKind.REGRESSION: model_pb2.MODEL_KIND_REGRESSION,
+    ModelKind.BINARY_CLASSIFICATION: model_pb2.MODEL_KIND_BINARY_CLASSIFICATION,
+    ModelKind.MULTICLASS_CLASSIFICATION: model_pb2.MODEL_KIND_MULTICLASS_CLASSIFICATION,
+    ModelKind.LLM_COMPLETION: model_pb2.MODEL_KIND_LLM_COMPLETION,
+    ModelKind.LLM_CHAT_COMPLETION: model_pb2.MODEL_KIND_LLM_CHAT_COMPLETION,
+    ModelKind.LLM_EMBEDDING: model_pb2.MODEL_KIND_LLM_EMBEDDING,
+}
+_PROTO_TO_KIND = {v: k for k, v in _KIND_TO_PROTO.items()}
+
+
+def _convert_model_kind(kind: str | None) -> model_pb2.ModelKind:
+    """Map a :class:`ModelKind` string to its proto enum value.
+
+    Unrecognized values (including ``None``) default to
+    ``MODEL_KIND_CUSTOM``, mirroring the internal SDK's ``convert_model_kind``.
+    """
+    if kind is None:
+        return model_pb2.MODEL_KIND_CUSTOM
+    return _KIND_TO_PROTO.get(kind, model_pb2.MODEL_KIND_CUSTOM)
 
 
 def _is_valid_k8s_label_value(value: str) -> bool:
@@ -124,6 +148,7 @@ class APIRegistryClient(ModelRegistryClient):
         reg = registry.register_model(
             name="california-housing-xgb",
             artifact_uri="s3://bucket/models/california-housing-xgb/abc/raw/model.ubj",
+            kind=ModelKind.REGRESSION,
             labels={"framework": "xgboost"},
             metadata={"validation-rmse": 0.876},
         )
@@ -166,6 +191,7 @@ class APIRegistryClient(ModelRegistryClient):
         artifact_uri: str,
         deployable_artifact_uri: str | None = None,
         description: str | None = None,
+        kind: str | None = None,
         schema: dict[str, Any] | None = None,
         labels: Mapping[str, str] | None = None,
         metadata: Mapping[str, Any] | None = None,
@@ -177,6 +203,9 @@ class APIRegistryClient(ModelRegistryClient):
             artifact_uri: URI of the raw model artifact.
             deployable_artifact_uri: Optional URI of the serving-ready bundle.
             description: Optional human-readable description.
+            kind: One of the :class:`ModelKind` constants. Stored as
+                ``model.spec.kind``. Unrecognized values (including ``None``)
+                are stored as ``MODEL_KIND_CUSTOM``.
             schema: Ignored — ``ModelService`` has no dedicated schema field.
             labels: String key-value pairs stored in ``model.metadata.labels``.
             metadata: Arbitrary JSON-serializable key-value pairs stored under
@@ -196,6 +225,7 @@ class APIRegistryClient(ModelRegistryClient):
                 artifact_uri=artifact_uri,
                 deployable_artifact_uri=deployable_artifact_uri,
                 description=description,
+                kind=kind,
                 labels=labels,
                 metadata=metadata,
             )
@@ -269,6 +299,7 @@ class APIRegistryClient(ModelRegistryClient):
         artifact_uri: str,
         deployable_artifact_uri: str | None,
         description: str | None,
+        kind: str | None,
         labels: Mapping[str, str] | None,
         metadata: Mapping[str, Any] | None,
     ) -> model_pb2.Model:
@@ -281,6 +312,7 @@ class APIRegistryClient(ModelRegistryClient):
             model.spec.deployable_artifact_uri.append(deployable_artifact_uri)
         if description:
             model.spec.description = description
+        model.spec.kind = _convert_model_kind(kind)
 
         # Kubernetes label values are capped at 63 characters and restricted
         # to alphanumerics/dashes/underscores/dots. Callers built on top of
@@ -344,6 +376,7 @@ class APIRegistryClient(ModelRegistryClient):
             registry_uri=f"models:/{namespace}/{name}/{version}",
             artifact_uri=artifact_uri,
             deployable_artifact_uri=deployable_artifact_uri,
+            kind=_PROTO_TO_KIND.get(model.spec.kind),
             labels=labels,
             metadata=metadata,
         )

--- a/python/michelangelo/lib/model_manager/registry/client.py
+++ b/python/michelangelo/lib/model_manager/registry/client.py
@@ -34,6 +34,9 @@ class RegisteredModel:
             (e.g. Triton config + weights). Use this to load the model onto
             a model server for inference. ``None`` when not applicable or
             not exposed by the registry.
+        kind: The prediction task the model performs (e.g.
+            ``ModelKind.REGRESSION``). Mirrors the ``kind`` parameter passed
+            to ``register_model()``. ``None`` when not set.
         labels: Indexed, filterable string key-value pairs stored with the
             registration (e.g. ``{"training_framework": "xgboost"}``).
             Mirrors the ``labels`` parameter passed to ``register_model()``.
@@ -59,6 +62,7 @@ class RegisteredModel:
     registry_uri: str
     artifact_uri: str | None = None
     deployable_artifact_uri: str | None = None
+    kind: str | None = None
     labels: dict[str, str] = field(default_factory=dict)
     metadata: dict[str, Any] = field(default_factory=dict)
 
@@ -92,6 +96,7 @@ class ModelRegistryClient(ABC):
                 artifact_uri: str,
                 deployable_artifact_uri: str | None = None,
                 description: str | None = None,
+                kind: str | None = None,
                 schema: dict[str, Any] | None = None,
                 labels: Mapping[str, str] | None = None,
                 metadata: Mapping[str, Any] | None = None,
@@ -102,6 +107,7 @@ class ModelRegistryClient(ABC):
                     version=version,
                     registry_uri=f"memory://{name}/{version}",
                     artifact_uri=artifact_uri,
+                    kind=kind,
                     labels=dict(labels or {}),
                     metadata=dict(metadata or {}),
                 )
@@ -128,6 +134,7 @@ class ModelRegistryClient(ABC):
         artifact_uri: str,
         deployable_artifact_uri: str | None = None,
         description: str | None = None,
+        kind: str | None = None,
         schema: dict[str, Any] | None = None,
         labels: Mapping[str, str] | None = None,
         metadata: Mapping[str, Any] | None = None,
@@ -146,6 +153,12 @@ class ModelRegistryClient(ABC):
                 ``None`` means the raw artifact is also used for serving.
             description: Optional human-readable description stored alongside
                 the model version in the registry.
+            kind: Optional prediction task the model performs, e.g.
+                ``ModelKind.REGRESSION`` from
+                ``michelangelo.lib.model_manager.constants``. Surfaced as a
+                dedicated, indexed field by registries that support it (e.g.
+                a "Type" column in a registry UI) rather than folded into
+                ``labels``.
             schema: Optional model input/output schema.
 
                 Implementations that do not support a native schema field
@@ -173,7 +186,7 @@ class ModelRegistryClient(ABC):
         Returns:
             A ``RegisteredModel`` describing the created registration,
             including the registry-assigned ``version``, ``registry_uri``,
-            ``labels``, and ``metadata``.
+            ``kind``, ``labels``, and ``metadata``.
 
         Raises:
             IOError: If the registry cannot be reached.
@@ -229,6 +242,7 @@ class InMemoryRegistryClient(ModelRegistryClient):
         artifact_uri: str,
         deployable_artifact_uri: str | None = None,
         description: str | None = None,
+        kind: str | None = None,
         schema: dict[str, Any] | None = None,
         labels: Mapping[str, str] | None = None,
         metadata: Mapping[str, Any] | None = None,
@@ -241,6 +255,7 @@ class InMemoryRegistryClient(ModelRegistryClient):
             registry_uri=f"memory://{name}/{version_num}",
             artifact_uri=artifact_uri,
             deployable_artifact_uri=deployable_artifact_uri,
+            kind=kind,
             labels=dict(labels or {}),
             metadata=dict(metadata or {}),
         )

--- a/python/michelangelo/lib/model_manager/registry/tests/api_client_test.py
+++ b/python/michelangelo/lib/model_manager/registry/tests/api_client_test.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock
 import grpc
 
 from michelangelo.gen.api.v2 import model_pb2
+from michelangelo.lib.model_manager.constants import ModelKind
 from michelangelo.lib.model_manager.registry.api_client import (
     METADATA_ANNOTATION_KEY,
     APIRegistryClient,
@@ -31,6 +32,7 @@ def _model(
     revision_id: int = 1,
     artifact_uri: str = "s3://bucket/raw/model.ubj",
     deployable_uri: str | None = None,
+    kind: model_pb2.ModelKind | None = None,
 ) -> model_pb2.Model:
     """Build a minimal Model proto that mimics a service response."""
     m = model_pb2.Model()
@@ -40,6 +42,8 @@ def _model(
     m.spec.model_artifact_uri.append(artifact_uri)
     if deployable_uri:
         m.spec.deployable_artifact_uri.append(deployable_uri)
+    if kind is not None:
+        m.spec.kind = kind
     return m
 
 
@@ -207,6 +211,48 @@ class TestAPIRegistryClientRegisterModel(TestCase):
         _client(svc).register_model("m", "s3://b/raw")
         created_model = svc.create_model.call_args[0][0]
         self.assertEqual(len(created_model.spec.deployable_artifact_uri), 0)
+
+    def test_kind_set_on_model_proto(self):
+        """A recognized kind is mapped to its ModelKind proto enum value."""
+        svc = _mock_svc()
+        _client(svc).register_model("m", "s3://b/raw", kind=ModelKind.REGRESSION)
+        created_model = svc.create_model.call_args[0][0]
+        self.assertEqual(created_model.spec.kind, model_pb2.MODEL_KIND_REGRESSION)
+
+    def test_kind_none_defaults_to_custom(self):
+        """Omitting kind stores MODEL_KIND_CUSTOM, not MODEL_KIND_INVALID."""
+        svc = _mock_svc()
+        _client(svc).register_model("m", "s3://b/raw")
+        created_model = svc.create_model.call_args[0][0]
+        self.assertEqual(created_model.spec.kind, model_pb2.MODEL_KIND_CUSTOM)
+
+    def test_unrecognized_kind_defaults_to_custom(self):
+        """An unrecognized kind string also falls back to MODEL_KIND_CUSTOM."""
+        svc = _mock_svc()
+        _client(svc).register_model("m", "s3://b/raw", kind="not-a-real-kind")
+        created_model = svc.create_model.call_args[0][0]
+        self.assertEqual(created_model.spec.kind, model_pb2.MODEL_KIND_CUSTOM)
+
+    def test_kind_round_trips_onto_registered_model(self):
+        """The kind stored on the response proto is mapped back onto RegisteredModel."""
+        svc = _mock_svc(
+            create_return=_model("m", kind=model_pb2.MODEL_KIND_BINARY_CLASSIFICATION)
+        )
+        reg = _client(svc).register_model(
+            "m", "s3://b/raw", kind=ModelKind.BINARY_CLASSIFICATION
+        )
+        self.assertEqual(reg.kind, ModelKind.BINARY_CLASSIFICATION)
+
+    def test_llm_kind_set_on_model_proto(self):
+        """LLM-specific kinds map to their own proto enum values."""
+        svc = _mock_svc()
+        _client(svc).register_model(
+            "m", "s3://b/raw", kind=ModelKind.LLM_CHAT_COMPLETION
+        )
+        created_model = svc.create_model.call_args[0][0]
+        self.assertEqual(
+            created_model.spec.kind, model_pb2.MODEL_KIND_LLM_CHAT_COMPLETION
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/python/michelangelo/lib/model_manager/registry/tests/client_test.py
+++ b/python/michelangelo/lib/model_manager/registry/tests/client_test.py
@@ -103,6 +103,21 @@ class TestRegisteredModel(TestCase):
         )
         self.assertEqual(model.deployable_artifact_uri, "s3://bucket/triton")
 
+    def test_kind_defaults_to_none(self):
+        """It defaults kind to None when not provided."""
+        model = RegisteredModel(name="m", version="1", registry_uri="uri")
+        self.assertIsNone(model.kind)
+
+    def test_kind_can_be_provided(self):
+        """It stores an explicitly provided kind."""
+        model = RegisteredModel(
+            name="m",
+            version="1",
+            registry_uri="uri",
+            kind="regression",
+        )
+        self.assertEqual(model.kind, "regression")
+
 
 class _ConcreteClient(ModelRegistryClient):
     """Minimal concrete implementation for testing the ABC."""
@@ -113,6 +128,7 @@ class _ConcreteClient(ModelRegistryClient):
         artifact_uri: str,
         deployable_artifact_uri: str | None = None,
         description: str | None = None,
+        kind: str | None = None,
         schema: dict[str, Any] | None = None,
         labels: Mapping[str, str] | None = None,
         metadata: Mapping[str, Any] | None = None,
@@ -122,6 +138,7 @@ class _ConcreteClient(ModelRegistryClient):
             name=name,
             version="1",
             registry_uri=f"mem://{name}/1",
+            kind=kind,
             labels=dict(labels or {}),
             metadata=dict(metadata or {}),
         )
@@ -188,6 +205,16 @@ class TestModelRegistryClientABC(TestCase):
         self.assertEqual(result.metadata["run_id"], "run-abc123")
         self.assertEqual(result.metadata["accuracy"], 0.94)
         self.assertNotIn("run_id", result.labels)
+
+    def test_register_model_stores_kind(self):
+        """Kind is forwarded to the returned RegisteredModel."""
+        client = _ConcreteClient()
+        result = client.register_model(
+            name="clf",
+            artifact_uri="s3://bucket/raw",
+            kind="regression",
+        )
+        self.assertEqual(result.kind, "regression")
 
     def test_get_model_returns_registered_model(self):
         """It returns a RegisteredModel from a concrete get_model implementation."""
@@ -269,3 +296,17 @@ class TestInMemoryRegistryClient(TestCase):
         with self.assertRaises(KeyError) as ctx:
             self.registry.get_model(name="clf", version="99")
         self.assertIn("99", str(ctx.exception))
+
+    def test_register_model_stores_kind(self):
+        """Kind is forwarded to the returned record."""
+        reg = self.registry.register_model(
+            name="clf",
+            artifact_uri="s3://raw",
+            kind="regression",
+        )
+        self.assertEqual(reg.kind, "regression")
+
+    def test_register_model_kind_defaults_to_none(self):
+        """Kind defaults to None when not provided."""
+        reg = self.registry.register_model(name="clf", artifact_uri="s3://raw")
+        self.assertIsNone(reg.kind)

--- a/python/michelangelo/workflow/schema/pusher.py
+++ b/python/michelangelo/workflow/schema/pusher.py
@@ -58,6 +58,18 @@ class ModelPluginConfig:
             unique name is generated automatically when ``None``.
         description: Optional human-readable description stored in the
             registry alongside the model version.
+        kind: Optional prediction task the model performs, e.g.
+            ``ModelKind.REGRESSION`` from
+            ``michelangelo.lib.model_manager.constants``. Forwarded as a
+            dedicated ``kind`` argument to ``register_model()`` (not folded
+            into ``labels``), so registries that support it can surface it
+            as a first-class, indexed field (e.g. a "Type" column).
+
+            Example::
+
+                from michelangelo.lib.model_manager.constants import ModelKind
+                cfg = ModelPluginConfig(model_name="clf", kind=ModelKind.REGRESSION)
+
         labels: Indexed, filterable string key-value pairs forwarded to the
             registry at registration time (e.g.
             ``{"owner": "ml-platform", "training_framework": "xgboost"}``).
@@ -118,6 +130,7 @@ class ModelPluginConfig:
 
     model_name: str | None = None
     description: str | None = None
+    kind: str | None = None
     labels: dict[str, str] = field(default_factory=dict)
     run_id: str | None = None
     metadata: dict[str, Any] = field(default_factory=dict)

--- a/python/michelangelo/workflow/tasks/pusher/plugins/model_plugin.py
+++ b/python/michelangelo/workflow/tasks/pusher/plugins/model_plugin.py
@@ -257,8 +257,8 @@ class ModelPusherPlugin(PusherPluginBase):
 
     Args:
         config: ``ModelPluginConfig`` specifying the optional
-            ``model_name``, ``description``, ``labels``, ``run_id``, and
-            ``registry_clients`` list for multi-registry fan-out.
+            ``model_name``, ``description``, ``kind``, ``labels``, ``run_id``,
+            and ``registry_clients`` list for multi-registry fan-out.
         artifact: An ``AssembledModel`` with a pre-packaged ``raw_model``.
             ``deployable_model`` is optional — when ``None``, the deployable
             upload is skipped and ``deployable_artifact_uri`` is ``None`` in
@@ -285,6 +285,7 @@ class ModelPusherPlugin(PusherPluginBase):
         from michelangelo.lib.artifact_manager.storage_backend import (
             LocalStorageBackend,
         )
+        from michelangelo.lib.model_manager.constants import ModelKind
         from michelangelo.lib.model_manager.registry.client import (
             InMemoryRegistryClient,
         )
@@ -300,6 +301,7 @@ class ModelPusherPlugin(PusherPluginBase):
             config=ModelPluginConfig(
                 model_name="my-classifier",
                 description="Boston housing XGBoost model",
+                kind=ModelKind.REGRESSION,
                 labels={"owner": "ml-platform"},
                 run_id="mlflow-run-abc123",
             ),
@@ -445,6 +447,7 @@ class ModelPusherPlugin(PusherPluginBase):
                     artifact_uri=raw_uri,
                     deployable_artifact_uri=deployable_uri,
                     description=self._config.description,
+                    kind=self._config.kind,
                     labels=dict(
                         base_labels
                     ),  # shallow copy — prevents cross-registry mutation

--- a/python/michelangelo/workflow/tasks/pusher/tests/plugins/test_model_plugin.py
+++ b/python/michelangelo/workflow/tasks/pusher/tests/plugins/test_model_plugin.py
@@ -65,6 +65,7 @@ def _plugin(
     registry: MagicMock | None = None,
     labels: dict | None = None,
     description: str | None = None,
+    kind: str | None = None,
     run_id: str | None = None,
     metadata: dict | None = None,
 ) -> ModelPusherPlugin:
@@ -74,6 +75,7 @@ def _plugin(
             model_name=model_name,
             labels=labels or {},
             description=description,
+            kind=kind,
             run_id=run_id,
             metadata=metadata or {},
         ),
@@ -217,6 +219,20 @@ class TestModelPusherPluginExecute(TestCase):
         _plugin(model_name="m", registry=registry).execute()
         call_kwargs = registry.register_model.call_args.kwargs
         self.assertIsNone(call_kwargs["description"])
+
+    def test_kind_forwarded_to_register_model(self):
+        """It passes config.kind to register_model(kind=...)."""
+        registry = _mock_registry(name="m")
+        _plugin(model_name="m", registry=registry, kind="regression").execute()
+        call_kwargs = registry.register_model.call_args.kwargs
+        self.assertEqual(call_kwargs["kind"], "regression")
+
+    def test_kind_none_when_not_set(self):
+        """It forwards kind=None when config.kind is not set."""
+        registry = _mock_registry(name="m")
+        _plugin(model_name="m", registry=registry).execute()
+        call_kwargs = registry.register_model.call_args.kwargs
+        self.assertIsNone(call_kwargs["kind"])
 
     def test_labels_merges_model_metadata_and_config_labels(self):
         """It merges ModelMetadata.to_registry_dict() with config.labels."""


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

- Added a new `ModelKind` constants class (`lib/model_manager/constants/model_kind.py`), mirroring the existing `RawModelType`/`StorageType`/`TritonBackendType` pattern.
- Added a `kind` field to `ModelPluginConfig`.
- Added `kind` as a dedicated `register_model()` parameter on `ModelRegistryClient` (and a matching field on `RegisteredModel`) — not folded into the generic `labels` dict — so registries can surface it as a first-class, indexed field (e.g. a "Type" column).
- Updated `InMemoryRegistryClient` and all affected docstrings/examples.

<!-- Tell your future self why have you made these changes -->
**Why?**

Models registered through the example pipelines render a blank "Type" column in the registry UI. #1673 made the UI degrade gracefully instead of throwing on missing values, but the root cause — `ModelPusherPlugin` never accepting or setting a `kind` — was untouched. This PR closes that gap: `kind` is backed by a typed, public `ModelKind` enum so callers get a stable vocabulary instead of a free-text label.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Added/extended unit tests in `client_test.py`, `model_kind_test.py`, and `test_model_plugin.py` (75 tests passing via the repo's `.venv`). Ran `ruff format` + `ruff check --fix` on all changed files.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

`ModelPusherPlugin.execute()` now always passes a `kind=` keyword argument to every `ModelRegistryClient.register_model()` call. Custom `ModelRegistryClient` implementations with a fixed signature (no `**kwargs` catch-all) that predate this change will raise `TypeError` on the next call. See migration guide.

<!-- Does this PR introduce a breaking change? Check all that apply. -->
**Breaking Changes**

- [ ] No breaking changes
- [x] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

> If any breaking change box is checked (other than "No breaking changes"), you **must**:
> 1. Use the `BREAKING CHANGE:` footer **or** the `!` suffix (e.g. `feat!:`) in your commit message — see [Commit Messages](../CONTRIBUTING.md#commit-messages).
> 2. Fill in the **Migration guide** section below with step-by-step upgrade instructions.

<!-- Required only if a breaking change box above is checked. Delete this section if no breaking changes. -->
**Migration guide**

Custom `ModelRegistryClient` subclasses must add a `kind: str | None = None` parameter to `register_model()` (or accept `**kwargs`):

```python
# Before
def register_model(
    self, name: str, artifact_uri: str,
    deployable_artifact_uri: str | None = None,
    description: str | None = None,
    schema: dict[str, Any] | None = None,
    labels: Mapping[str, str] | None = None,
    metadata: Mapping[str, Any] | None = None,
) -> RegisteredModel: ...

# After
def register_model(
    self, name: str, artifact_uri: str,
    deployable_artifact_uri: str | None = None,
    description: str | None = None,
    kind: str | None = None,
    schema: dict[str, Any] | None = None,
    labels: Mapping[str, str] | None = None,
    metadata: Mapping[str, Any] | None = None,
) -> RegisteredModel: ...
```

`InMemoryRegistryClient` and the built-in registry clients are already updated in this PR.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

New optional `kind` field on `ModelPluginConfig` and `ModelRegistryClient.register_model()`. Custom `ModelRegistryClient` implementations must update their `register_model()` signature (see migration guide).

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**

Docstrings and inline usage examples in `model_plugin.py`, `client.py`, and `pusher.py` updated to cover `kind`. No wiki update made — flagging for follow-up if the public docs site should mention this.
