### PR TITLE
docs(serving): add DeleteXxxCollection to serving API table footnote

### DIFF
--- a/docs/operator-guides/serving/index.md
+++ b/docs/operator-guides/serving/index.md
@@ -109,7 +109,7 @@ The following gRPC services back the serving control plane. All are defined in `
 | `ClusterService` | `cluster_svc.proto` | Manages compute Cluster registrations available to the serving control plane |
 | `RayClusterService` | `ray_cluster_svc.proto` | Manages Ray-specific cluster resources provisioned for inference workloads |
 
-Each service follows the standard CRUD pattern (Create, Get, List, Update, Delete). See the proto definitions for the full request/response schema.
+Each service follows the standard CRUD pattern (Create, Get, List, Update, Delete) and also exposes `DeleteXxxCollection` for bulk deletion. See the proto definitions for the full request/response schema.
 
 ## Next Steps
 


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**

The footnote in the `serving/index.md` gRPC API Services table now mentions that all five serving services (`InferenceServerService`, `DeploymentService`, `RevisionService`, `ClusterService`, `RayClusterService`) also expose `DeleteXxxCollection` for bulk deletion, matching the wording already present in the `jobs/index.md` footnote.

**Why?**

PR #1587 updated the `jobs/index.md` footnote to mention `DeleteXxxCollection` but missed the equivalent footnote in `serving/index.md`. Reviewer @paulzim flagged this inconsistency after #1587 was merged.

**How did you test it?**

Docs-only change; no functional code affected.

**Potential risks**

None.

**Breaking Changes**

- [x] No breaking changes

**Release notes**

N/A

**Documentation Changes**

Updated `docs/operator-guides/serving/index.md` footnote to note `DeleteXxxCollection` bulk-delete RPCs on all serving services.