### PR TITLE
chore: add dependabot config for weekly grouped dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,67 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "ci"
+    groups:
+      actions-minor-and-patch:
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "gomod"
+    directory: "/go"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(go)"
+    groups:
+      go-minor-and-patch:
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "gomod"
+    directory: "/proto-go"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(go)"
+    groups:
+      proto-go-minor-and-patch:
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "pip"
+    directory: "/python"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(python)"
+    groups:
+      python-minor-and-patch:
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "npm"
+    directory: "/javascript"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(npm)"
+    groups:
+      javascript-minor-and-patch:
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "npm"
+    directory: "/website"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(npm)"
+    groups:
+      website-minor-and-patch:
+        update-types: ["minor", "patch"]


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
Adds `.github/dependabot.yml` covering all six dependency surfaces in the repo: GitHub Actions workflows, both Go modules (`go/`, `proto-go/`), the Python package (`python/`, poetry), and both npm trees (`javascript/` yarn workspaces, `website/`).

Tuned to stay low-noise: weekly cadence, minor and patch updates grouped into a single PR per ecosystem, at most 3 open PRs per ecosystem, and commit-message prefixes that follow the conventional-commit types and scopes from CONTRIBUTING.md so dependabot PRs feed the git-cliff changelog correctly.

**Why?**
Dependency updates are currently manual and mostly CVE-driven (recent examples: the Node.js bump in #1621, the Grafana image pin in #1623, the Go SDK bump tracked in #1565). Dependabot surfaces outdated dependencies routinely instead of waiting for a scanner finding, and grouped weekly PRs keep the review cost close to one PR per ecosystem per week. For Go this flows straight into the build: MODULE.bazel consumes `go/go.mod` via `go_deps.from_file`, so a dependabot gomod PR updates the Bazel dependency graph too.

**How did you test it?**
Config parses as valid dependabot v2 YAML; each `directory` was cross-checked against the actual manifest locations in the tree (`go/go.mod`, `proto-go/go.mod`, `python/pyproject.toml` + `poetry.lock`, `javascript/package.json` + `yarn.lock`, `website/package.json`). Behavior is observable after merge in the repo's Dependency graph -> Dependabot tab, where each ecosystem shows its last check.

**Potential risks**
The first run after merge can open several PRs at once as ecosystems catch up; this is bounded by the 3-PR-per-ecosystem limit and the minor+patch grouping. Major version bumps arrive as individual PRs by design and can simply be closed if unwanted. Maintainers can tune or drop any ecosystem entry independently.

**Breaking Changes**
- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**
None.

**Documentation Changes**
None needed.
