### PR TITLE
docs: add Docs badge to README badge row

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![License](https://img.shields.io/github/license/michelangelo-ai/michelangelo)](http://www.apache.org/licenses/LICENSE-2.0)
 [![codecov](https://codecov.io/gh/michelangelo-ai/michelangelo/graph/badge.svg?token=HKJDT0I6CW)](https://codecov.io/gh/michelangelo-ai/michelangelo)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11481/badge)](https://www.bestpractices.dev/projects/11481)
+[![Docs](https://img.shields.io/badge/docs-michelangelo--ai.org-blue)](https://michelangelo-ai.org)
 
 # Michelangelo AI
 


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**

Added a `[![Docs](https://img.shields.io/badge/docs-michelangelo--ai.org-blue)](https://michelangelo-ai.org)` badge to the README badge row, giving readers a direct link to the official documentation site.

**Why?**

PR #1630 adds an "Ask DeepWiki" badge (AI-generated docs). Having the official Docs badge adjacent makes it clear which source is authoritative. This PR is intended to be merged first so #1630 can rebase on top and the two badges appear together.

**How did you test it?**

Rendered the badge HTML locally and confirmed the link and styling are correct. README-only change.

**Potential risks**

None.

**Breaking Changes**

- [x] No breaking changes

**Release notes**

N/A

**Documentation Changes**

Updated `README.md` badge row to include a link to `michelangelo-ai.org`.