### PR TITLE
docs(pipelines): clarify architectural difference between remote-run and dev-run

### DIFF
--- a/docs/user-guides/ml-pipelines/pipeline-running-modes.md
+++ b/docs/user-guides/ml-pipelines/pipeline-running-modes.md
@@ -189,6 +189,27 @@ ma pipeline run --namespace="my-project" --name="my-pipeline"
 ma pipeline run --namespace="my-project" --name="my-pipeline" --resume_from=previous-run:step
 ```
 
+## Remote Run vs Pipeline Dev Run: what's actually different
+
+From the "why this mode exists" framing above, Remote Run and Pipeline Dev Run can look interchangeable — both let you test against real compute without registering a pipeline. The distinction that actually matters when choosing between them is architectural, not just "which dev stage am I in":
+
+| | Remote Run | Pipeline Dev Run |
+| ----- | ----- | ----- |
+| Invoked via | `python workflow.py remote-run` (a Uniflow feature, not an `ma` command) | `ma pipeline dev-run -f pipeline.yaml` |
+| Routed through the Michelangelo AI API server + controller? | No — submits directly to Cadence/Temporal | Yes |
+| Creates a `PipelineRun` entity? | No | Yes |
+| Resumable with `--resume_from`? | No | Yes |
+| Visible in MA Studio? | No | No — no parent `Pipeline` entity is created either, so there's nothing to attach it to in Studio's pipeline list. The run itself is still a real, queryable entity via `ma get pipeline_run` / kubectl |
+| Requires a prebuilt image? | Yes — you pass `--image` | No — builds and validates the image as part of the run |
+
+:::tip
+If you'll need to come back to a run later, share it with a teammate, or resume it from a failed step, use **Pipeline Dev Run** — it's the only one of the two that creates a trackable entity. Reach for **Remote Run** only once you already trust your image and just need real compute for a quick check.
+:::
+
+Job scheduling itself is identical either way: both ultimately submit to the same Cadence/Temporal worker, which is what talks to the Ray/Spark compute cluster. The difference is entirely in what happens *before* that — whether the Michelangelo AI control plane is involved at all.
+
+See the [CLI reference](../reference/cli.md#differences-between-dev-run-and-remote-run) for the full breakdown, including how `--file-sync` behaves differently under each mode.
+
 ## Decision tree: which mode should I use?
 
 ### Stage-based

--- a/docs/user-guides/reference/cli.md
+++ b/docs/user-guides/reference/cli.md
@@ -299,6 +299,8 @@ ma pipeline dev-run -f "./examples/bert_cola/pipeline.yaml" --file-sync --storag
 
 ##### Differences between dev-run and remote-run
 
+> For an architectural overview of how these two modes differ, see [Remote Run vs Pipeline Dev Run: what's actually different](../ml-pipelines/pipeline-running-modes.md#remote-run-vs-pipeline-dev-run-whats-actually-different).
+
 **1. dev-run: Test Pipeline from Local File**
 
 `pipeline dev-run` command runs a pipeline directly from your committed git snapshot. Pipeline run will be controlled by Michelangelo AI API server and controller. This command creates a PipelineRun entity but no Pipeline entity, so you will not see the pipeline entity information in MA Studio.


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**

- Added a new "Remote Run vs Pipeline Dev Run: what's actually different" section to `pipeline-running-modes.md` with a comparison table covering: invocation method, API server routing, `PipelineRun` entity creation, `--resume_from` support, MA Studio visibility, and image requirements. Includes a tip callout and a link to the CLI reference.
- Added a back-link at the top of the "Differences between dev-run and remote-run" section in `cli.md` pointing back to the new section.

**Why?**

A community member was confused about the practical difference between `remote-run` and `pipeline dev-run` because `pipeline-running-modes.md` only framed the distinction in terms of dev lifecycle stage, not architecture. The correct technical explanation existed in `cli.md` but was not surfaced from the more discoverable entry point. Closes #1670.

**How did you test it?**

Verified table content against `cli.md`'s existing "Differences between dev-run and remote-run" section. Docs-only change; no functional code affected.

**Potential risks**

None.

**Breaking Changes**

- [x] No breaking changes

**Release notes**

N/A

**Documentation Changes**

- `docs/user-guides/ml-pipelines/pipeline-running-modes.md` — new architectural comparison section before the decision tree
- `docs/user-guides/reference/cli.md` — back-link added at "Differences between dev-run and remote-run" heading