### PR TITLE
feat(trainer): pluggable MLflow profiler sink

### DIFF
--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/__init__.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/__init__.py
@@ -20,10 +20,13 @@ Public surface re-exported below:
   :class:`FsspecExperimentStore` is the filesystem default.
 * :func:`comet_profiler_sink` — ready-made ``LightningTrainerParam.profiler_sink``
   that ships profiler output to a Comet experiment.
+* :func:`mlflow_profiler_sink` — ready-made ``LightningTrainerParam.profiler_sink``
+  that ships profiler output to an MLflow run.
 """
 
 from michelangelo.lib.trainer.torch.pytorch_lightning._private.util import (
     comet_profiler_sink,
+    mlflow_profiler_sink,
 )
 from michelangelo.lib.trainer.torch.pytorch_lightning.experiment_store import (
     FsspecExperimentStore,
@@ -56,4 +59,5 @@ __all__ = [
     "TrainingType",
     "TransferLearningSpec",
     "comet_profiler_sink",
+    "mlflow_profiler_sink",
 ]

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/_private/util.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/_private/util.py
@@ -68,7 +68,7 @@ _MAX_PROFILER_REPEAT = 3
 # Only ``pytorch`` is supported today — Michelangelo OSS is PyTorch-heavy, and
 # the other Lightning profilers (simple / advanced / xla) and a custom-class
 # escape hatch add config surface without a concrete user yet. The dict shape
-# (``{"pytorch": {...}, "upload_to_comet": ...}``) is kept as-is so adding a
+# (``{"pytorch": {...}, "upload_profiler_results": ...}``) is kept as-is so adding a
 # second backend later, as we expand to more platforms, is additive rather
 # than a breaking config change.
 _PROFILER_SHORTHANDS = ("pytorch",)
@@ -792,7 +792,7 @@ def _build_profiler(
             * A dict setting ``pytorch`` to a kwargs dict, handled by
               :func:`_build_pytorch_profiler`.
 
-            ``upload_to_comet`` is reserved metadata read by
+            ``upload_profiler_results`` is reserved metadata read by
             :func:`_resolve_profiler` and is never forwarded to a profiler
             constructor.
         steps_per_epoch: Estimated steps per epoch, used to derive or
@@ -877,7 +877,7 @@ def _resolve_profiler(
 
     Returns:
         A ``(profiler, profiler_logs_path, upload_results)`` tuple.
-        ``upload_results`` mirrors the config's ``upload_to_comet`` flag and
+        ``upload_results`` mirrors the config's ``upload_profiler_results`` flag and
         gates the post-``fit`` ``profiler_sink`` call; it defaults to ``True``
         so callers must opt *out* of exporting results.
     """
@@ -885,7 +885,7 @@ def _resolve_profiler(
         return None, "", False
 
     upload_results = (
-        profiler_config.get("upload_to_comet", True)
+        profiler_config.get("upload_profiler_results", True)
         if isinstance(profiler_config, dict)
         else True
     )
@@ -1337,7 +1337,7 @@ def _maybe_export_profiler_results(
         profiler_logs_path: Directory the profiler wrote its output to.
         logger: The resolved Lightning logger, forwarded to the sink so it can
             attach results to the active experiment.
-        upload_profiler_results: The config's ``upload_to_comet`` flag; when
+        upload_profiler_results: The config's ``upload_profiler_results`` flag; when
             ``False`` the sink is not called.
         profiler_sink: The user-supplied
             ``Callable[[Profiler, str, logger], None]``, or ``None``.

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/_private/util.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/_private/util.py
@@ -263,8 +263,11 @@ def build_mlflow_logger(
     """Build an ``MLFlowLogger`` for a Ray Train worker.
 
     Dotted-path factory target for ``LightningTrainerKwargs.logger``.
-    Unlike Comet, MLflow's client is process-safe and requires no
-    distributed barrier — each worker constructs its logger independently.
+    Unlike Comet, constructing an ``MLFlowLogger`` is process-safe and
+    requires no distributed barrier — each worker builds its own logger
+    independently. This does not extend to the ``.experiment`` property,
+    which Lightning decorates with the same rank-zero restriction as Comet's;
+    see :func:`mlflow_profiler_sink` for the implication on profiler export.
     ``run_id`` lets all workers attach to the same MLflow run for per-rank
     metric correlation; when ``None``, Lightning's default (rank-0-only
     logging) applies.
@@ -894,6 +897,44 @@ def _resolve_profiler(
     return profiler, profiler_logs_path, upload_results
 
 
+def _profiler_output(
+    profiler: pl.profilers.Profiler, profiler_logs_path: str
+) -> tuple[str, list[str]] | None:
+    """Classify a profiler's output as a directory or a set of text files.
+
+    Shared by :func:`comet_profiler_sink` and :func:`mlflow_profiler_sink`;
+    the classification is backend-independent, only the upload call differs.
+
+    Returns:
+        ``("dir", [profiler_logs_path])`` for ``PyTorchProfiler``
+        (TensorBoard-format traces), ``("files", txt_paths)`` for
+        ``SimpleProfiler``/``AdvancedProfiler`` text summaries (``None`` if
+        the directory has no ``.txt`` files), or ``None`` for any other
+        profiler type, which has no supported export format.
+    """
+    from pytorch_lightning.profilers import (
+        AdvancedProfiler,
+        PyTorchProfiler,
+        SimpleProfiler,
+    )
+
+    if isinstance(profiler, PyTorchProfiler):
+        return "dir", [profiler_logs_path]
+
+    if isinstance(profiler, (SimpleProfiler, AdvancedProfiler)):
+        txt_files = glob.glob(os.path.join(profiler_logs_path, "*.txt"))
+        if not txt_files:
+            _logger.warning("No profiler .txt files found in %s", profiler_logs_path)
+            return None
+        return "files", txt_files
+
+    _logger.info(
+        "Uploading results for %s is not supported; skipping.",
+        type(profiler).__name__,
+    )
+    return None
+
+
 def comet_profiler_sink(
     profiler: pl.profilers.Profiler,
     profiler_logs_path: str,
@@ -928,12 +969,6 @@ def comet_profiler_sink(
     Returns:
         ``None``.
     """
-    from pytorch_lightning.profilers import (
-        AdvancedProfiler,
-        PyTorchProfiler,
-        SimpleProfiler,
-    )
-
     experiment = getattr(logger, "experiment", None)
     if experiment is None:
         _logger.warning(
@@ -943,40 +978,100 @@ def comet_profiler_sink(
         )
         return
 
-    if isinstance(profiler, PyTorchProfiler):
+    classified = _profiler_output(profiler, profiler_logs_path)
+    if classified is None:
+        return
+    kind, paths = classified
+
+    if kind == "dir":
         try:
-            _logger.info(
-                "Uploading PyTorch profiler traces from %s to Comet",
-                profiler_logs_path,
-            )
-            experiment.log_tensorflow_folder(profiler_logs_path)
+            _logger.info("Uploading PyTorch profiler traces from %s to Comet", paths[0])
+            experiment.log_tensorflow_folder(paths[0])
         except Exception:
             _logger.warning(
                 "Failed to upload PyTorch profiler traces to Comet", exc_info=True
             )
         return
 
-    if isinstance(profiler, (SimpleProfiler, AdvancedProfiler)):
-        txt_files = glob.glob(os.path.join(profiler_logs_path, "*.txt"))
-        if not txt_files:
-            _logger.warning("No profiler .txt files found in %s", profiler_logs_path)
-            return
-        for txt_file in txt_files:
-            try:
-                _logger.info("Uploading profiler log %s to Comet", txt_file)
-                experiment.log_asset(txt_file)
-            except Exception:
-                _logger.warning(
-                    "Failed to upload profiler log %s to Comet",
-                    txt_file,
-                    exc_info=True,
-                )
+    for txt_file in paths:
+        try:
+            _logger.info("Uploading profiler log %s to Comet", txt_file)
+            experiment.log_asset(txt_file)
+        except Exception:
+            _logger.warning(
+                "Failed to upload profiler log %s to Comet",
+                txt_file,
+                exc_info=True,
+            )
+
+
+def mlflow_profiler_sink(
+    profiler: pl.profilers.Profiler,
+    profiler_logs_path: str,
+    logger: Any,
+) -> None:
+    """Upload profiler output to an MLflow run.
+
+    Ready-made ``LightningTrainerParam.profiler_sink`` for runs that log to
+    MLflow via :func:`build_mlflow_logger`. ``PyTorchProfiler`` traces are
+    uploaded as a directory via ``MlflowClient.log_artifacts``;
+    ``SimpleProfiler``/``AdvancedProfiler`` text summaries are uploaded
+    per-file via ``MlflowClient.log_artifact``. Unlike Comet's
+    ``log_tensorflow_folder``, MLflow has no TensorBoard-aware upload: traces
+    are stored verbatim under an ``artifact_path="profiler"`` prefix and must
+    be downloaded to view in a trace viewer (e.g. ``chrome://tracing``).
+    ``XLAProfiler`` and custom profilers are not supported and are skipped
+    with a log message.
+
+    Every upload is best-effort: a failure is logged and swallowed so a
+    broken export never fails an otherwise-successful training run.
+
+    Note:
+        Lightning decorates ``MLFlowLogger.experiment`` with
+        ``@rank_zero_experiment``, identically to ``CometLogger.experiment``.
+        On any worker whose *global* rank is not 0 the property yields a
+        no-op dummy client (``_DummyExperiment``) and uploads are silently
+        dropped. ``experiment is None`` is therefore not a reliable
+        "can I upload?" check on any Lightning logger, including this one —
+        a non-zero-rank worker gets a dummy object, not ``None``. Pass a
+        custom sink built on a directly-constructed ``MlflowClient`` if
+        per-node profiles are required.
+
+    Args:
+        profiler: The profiler built for this worker.
+        profiler_logs_path: Directory the profiler wrote its output to.
+        logger: The resolved Lightning logger. Must expose ``experiment``
+            (an ``MlflowClient``) and ``run_id``; anything else is skipped.
+
+    Returns:
+        ``None``.
+    """
+    client = getattr(logger, "experiment", None)
+    run_id = getattr(logger, "run_id", None)
+    if client is None or run_id is None:
+        _logger.warning(
+            "mlflow_profiler_sink: logger %r has no MLflow client or run id; "
+            "skipping profiler upload.",
+            type(logger).__name__,
+        )
         return
 
-    _logger.info(
-        "Uploading results for %s is not supported; skipping.",
-        type(profiler).__name__,
-    )
+    classified = _profiler_output(profiler, profiler_logs_path)
+    if classified is None:
+        return
+    kind, paths = classified
+
+    for path in paths:
+        try:
+            _logger.info("Uploading profiler output %s to MLflow", path)
+            if kind == "dir":
+                client.log_artifacts(run_id, path, artifact_path="profiler")
+            else:
+                client.log_artifact(run_id, path, artifact_path="profiler")
+        except Exception:
+            _logger.warning(
+                "Failed to upload profiler output %s to MLflow", path, exc_info=True
+            )
 
 
 def _maybe_track_experiment(train_loop_config: dict, rank: int) -> None:

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/lightning_trainer.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/lightning_trainer.py
@@ -124,7 +124,8 @@ class LightningTrainerParam:
             ``lightning_trainer_kwargs["profiler"]``, ``profiler_logs_path`` is
             the directory it wrote to, and ``logger`` is the resolved Lightning
             logger. Use it to ship profiler output to an experiment tracker;
-            :func:`~_private.util.comet_profiler_sink` does this for Comet.
+            :func:`~_private.util.comet_profiler_sink` does this for Comet and
+            :func:`~_private.util.mlflow_profiler_sink` does this for MLflow.
             Ignored when no profiler is configured or when the profiler config
             sets ``upload_to_comet: False``. Exceptions raised by the sink are
             logged and swallowed. Must be picklable (serialized to workers).

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/lightning_trainer.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/lightning_trainer.py
@@ -127,7 +127,7 @@ class LightningTrainerParam:
             :func:`~_private.util.comet_profiler_sink` does this for Comet and
             :func:`~_private.util.mlflow_profiler_sink` does this for MLflow.
             Ignored when no profiler is configured or when the profiler config
-            sets ``upload_to_comet: False``. Exceptions raised by the sink are
+            sets ``upload_profiler_results: False``. Exceptions raised by the sink are
             logged and swallowed. Must be picklable (serialized to workers).
     """
 

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_profiler.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_profiler.py
@@ -339,7 +339,7 @@ class TestBuildProfiler:
     def test_no_profiler_selected_raises(self, in_tmp_cwd, patched_ray):
         """A dict that selects nothing is a user config error."""
         with pytest.raises(UserInputError, match="None were set"):
-            _build_profiler({"upload_to_comet": False})
+            _build_profiler({"upload_profiler_results": False})
 
     def test_multiple_profilers_selected_raises(self, in_tmp_cwd, patched_ray):
         """A dict that selects two profiler flavors is a user config error.
@@ -355,9 +355,11 @@ class TestBuildProfiler:
         ):
             _build_profiler({"pytorch": {}, "other": {}})
 
-    def test_upload_to_comet_is_not_a_profiler_selection(self, in_tmp_cwd, patched_ray):
-        """``upload_to_comet`` is metadata and never reaches a constructor."""
-        profiler, _ = _build_profiler({"pytorch": {}, "upload_to_comet": False})
+    def test_upload_profiler_results_is_not_a_profiler_selection(
+        self, in_tmp_cwd, patched_ray
+    ):
+        """``upload_profiler_results`` is metadata and never reaches a constructor."""
+        profiler, _ = _build_profiler({"pytorch": {}, "upload_profiler_results": False})
         assert isinstance(profiler, PyTorchProfiler)
 
     def test_invalid_shorthand_raises(self):
@@ -378,7 +380,7 @@ class TestBuildProfiler:
 
 
 class TestResolveProfiler:
-    """Config resolution, including the ``upload_to_comet`` opt-out."""
+    """Config resolution, including the ``upload_profiler_results`` opt-out."""
 
     def test_none_config_resolves_to_nothing(self):
         """No profiler config means no profiler and no export."""
@@ -397,9 +399,9 @@ class TestResolveProfiler:
         assert upload is True
 
     def test_upload_can_be_disabled(self, in_tmp_cwd, patched_ray):
-        """``upload_to_comet: False`` turns the export off."""
+        """``upload_profiler_results: False`` turns the export off."""
         _, _, upload = _resolve_profiler(
-            {"pytorch": {}, "upload_to_comet": False}, {}, 100, 8, 1, 0
+            {"pytorch": {}, "upload_profiler_results": False}, {}, 100, 8, 1, 0
         )
         assert upload is False
 
@@ -460,7 +462,7 @@ class TestMaybeExportProfilerResults:
         sink.assert_not_called()
 
     def test_not_called_when_upload_disabled(self, patched_ray):
-        """``upload_to_comet: False`` suppresses the sink."""
+        """``upload_profiler_results: False`` suppresses the sink."""
         sink = MagicMock(name="sink")
         _maybe_export_profiler_results(MagicMock(), "/logs", None, False, sink)
         sink.assert_not_called()

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_profiler.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_profiler.py
@@ -34,9 +34,11 @@ from michelangelo.lib.trainer.torch.pytorch_lightning._private.util import (  # 
     _compute_default_schedule,
     _compute_steps_per_epoch,
     _maybe_export_profiler_results,
+    _profiler_output,
     _resolve_profiler,
     _validate_profiler_schedule,
     comet_profiler_sink,
+    mlflow_profiler_sink,
 )
 
 _UTIL_MODULE = "michelangelo.lib.trainer.torch.pytorch_lightning._private.util"
@@ -545,3 +547,130 @@ class TestCometProfilerSink:
         """A non-Comet logger is skipped rather than crashing the run."""
         # object() has no `experiment` attribute; no exception is the assertion.
         comet_profiler_sink(MagicMock(spec=PyTorchProfiler), "/logs", object())
+
+
+# -----------------------------------------------------------------------------
+# _profiler_output
+# -----------------------------------------------------------------------------
+
+
+class TestProfilerOutput:
+    """Classification shared by both built-in sinks."""
+
+    def test_pytorch_profiler_classified_as_dir(self):
+        """``PyTorchProfiler`` output is classified as a single directory."""
+        result = _profiler_output(MagicMock(spec=PyTorchProfiler), "/logs")
+        assert result == ("dir", ["/logs"])
+
+    @pytest.mark.parametrize("spec", [SimpleProfiler, AdvancedProfiler])
+    def test_text_profiler_classified_as_files(self, spec, tmp_path):
+        """Text-summary profilers are classified as their ``.txt`` files."""
+        (tmp_path / "a.txt").write_text("a")
+        (tmp_path / "b.txt").write_text("b")
+        (tmp_path / "ignored.json").write_text("{}")
+
+        kind, paths = _profiler_output(MagicMock(spec=spec), str(tmp_path))
+
+        assert kind == "files"
+        assert {os.path.basename(p) for p in paths} == {"a.txt", "b.txt"}
+
+    def test_no_text_files_returns_none(self, tmp_path):
+        """An empty logs directory has nothing to classify."""
+        assert _profiler_output(MagicMock(spec=SimpleProfiler), str(tmp_path)) is None
+
+    def test_unsupported_profiler_returns_none(self):
+        """XLA and custom profilers have no supported export format."""
+        assert _profiler_output(MagicMock(spec=XLAProfiler), "/logs") is None
+
+
+# -----------------------------------------------------------------------------
+# mlflow_profiler_sink
+# -----------------------------------------------------------------------------
+
+
+class TestMlflowProfilerSink:
+    """MLflow upload behavior for each profiler flavor."""
+
+    def _logger(self):
+        logger = MagicMock(name="logger")
+        logger.run_id = "run-123"
+        return logger
+
+    def test_pytorch_traces_upload_as_directory(self):
+        """``PyTorchProfiler`` traces go up as a directory via ``log_artifacts``."""
+        logger = self._logger()
+        profiler = MagicMock(spec=PyTorchProfiler)
+
+        mlflow_profiler_sink(profiler, "/logs", logger)
+
+        logger.experiment.log_artifacts.assert_called_once_with(
+            "run-123", "/logs", artifact_path="profiler"
+        )
+        logger.experiment.log_artifact.assert_not_called()
+
+    def test_pytorch_upload_failure_is_swallowed(self):
+        """A failed directory upload is logged, not raised."""
+        logger = self._logger()
+        logger.experiment.log_artifacts.side_effect = RuntimeError("nope")
+
+        mlflow_profiler_sink(MagicMock(spec=PyTorchProfiler), "/logs", logger)
+
+    @pytest.mark.parametrize("spec", [SimpleProfiler, AdvancedProfiler])
+    def test_text_summaries_upload_per_file(self, spec, tmp_path):
+        """Text-summary profilers upload each ``.txt`` file individually."""
+        (tmp_path / "a.txt").write_text("a")
+        (tmp_path / "b.txt").write_text("b")
+        (tmp_path / "ignored.json").write_text("{}")
+        logger = self._logger()
+
+        mlflow_profiler_sink(MagicMock(spec=spec), str(tmp_path), logger)
+
+        uploaded = {
+            os.path.basename(call.args[1])
+            for call in logger.experiment.log_artifact.call_args_list
+        }
+        assert uploaded == {"a.txt", "b.txt"}
+        for call in logger.experiment.log_artifact.call_args_list:
+            assert call.args[0] == "run-123"
+            assert call.kwargs == {"artifact_path": "profiler"}
+        logger.experiment.log_artifacts.assert_not_called()
+
+    def test_no_text_files_is_noop(self, tmp_path):
+        """An empty logs directory uploads nothing."""
+        logger = self._logger()
+        mlflow_profiler_sink(MagicMock(spec=SimpleProfiler), str(tmp_path), logger)
+        logger.experiment.log_artifact.assert_not_called()
+
+    def test_asset_upload_failure_does_not_stop_remaining_files(self, tmp_path):
+        """One failed asset upload does not abort the rest."""
+        (tmp_path / "a.txt").write_text("a")
+        (tmp_path / "b.txt").write_text("b")
+        logger = self._logger()
+        logger.experiment.log_artifact.side_effect = [RuntimeError("nope"), None]
+
+        mlflow_profiler_sink(MagicMock(spec=SimpleProfiler), str(tmp_path), logger)
+
+        assert logger.experiment.log_artifact.call_count == 2
+
+    def test_unsupported_profiler_is_skipped(self):
+        """XLA and custom profilers have no supported upload format."""
+        logger = self._logger()
+
+        mlflow_profiler_sink(MagicMock(spec=XLAProfiler), "/logs", logger)
+
+        logger.experiment.log_artifact.assert_not_called()
+        logger.experiment.log_artifacts.assert_not_called()
+
+    def test_logger_without_experiment_is_skipped(self):
+        """A logger with no MLflow client is skipped rather than crashing the run."""
+        # object() has no `experiment`/`run_id` attribute; no exception is the assertion.
+        mlflow_profiler_sink(MagicMock(spec=PyTorchProfiler), "/logs", object())
+
+    def test_logger_without_run_id_is_skipped(self):
+        """A logger with a client but no run id is skipped."""
+        logger = MagicMock(name="logger")
+        logger.run_id = None
+
+        mlflow_profiler_sink(MagicMock(spec=PyTorchProfiler), "/logs", logger)
+
+        logger.experiment.log_artifacts.assert_not_called()

--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -13713,9 +13713,10 @@ ray-polars = ["polars", "ray", "ray"]
 trainer = ["numpy", "pytorch_lightning", "ray", "ray", "torch", "transformers"]
 trainer-comet = ["comet_ml"]
 trainer-deepspeed = ["deepspeed"]
+trainer-mlflow = ["mlflow"]
 vllm = ["accelerate", "datasets", "einops", "numpy", "pandas", "pyarrow", "pytorch_lightning", "ray", "ray", "s3fs", "setuptools", "torch", "transformers", "vllm"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9.0"
-content-hash = "4d8ac79bc38845fcec3e75e599fb98da7dcb6b3d18a53569adb168dd12af13f3"
+content-hash = "c2ce18bb919f0d9d4a5ac617d49d3a6cd6d4ae9cb530a4dc8c86dd0b506c7e21"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -92,6 +92,7 @@ vllm = ["accelerate", "datasets", "numpy", "pandas", "pyarrow", "ray", "s3fs", "
 mactl = []
 trainer = ["ray", "torch", "pytorch_lightning", "transformers", "numpy"]
 trainer-comet = ["comet_ml"]
+trainer-mlflow = ["mlflow"]
 trainer-deepspeed = ["deepspeed"]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
Adds `mlflow_profiler_sink` alongside the existing `comet_profiler_sink` (from #1614), sharing a new `_profiler_output` helper that classifies profiler output as a directory (PyTorch traces) or a set of text files (Simple/Advanced profilers) — `comet_profiler_sink` is refactored onto this helper with no behavior change. Scopes `build_mlflow_logger`'s "process-safe, no distributed barrier" docstring claim to construction only, since `MLFlowLogger.experiment` carries the same `rank_zero_experiment` dummy-client behavior on non-zero global rank as `CometLogger.experiment`. Adds a `trainer-mlflow` packaging extra parallel to `trainer-comet`. Also renames the `upload_to_comet` profiler config key to `upload_profiler_results`, since the sink layer is now backend-agnostic.

**Why?**
Follow-up to #1614 (profiler subsystem), which shipped with a Comet-only sink. This generalizes the extension point to a second backend (MLflow) and removes the Comet-specific name from the one config key that gates it, now that there are two sinks to choose from.

**How did you test it?**
159 unit tests in `test_profiler.py` (13 new), mocking `pytorch_lightning`/`ray`. The MLflow API usage (`MlflowClient.log_artifact`/`log_artifacts`) was additionally verified against a real `mlflow==2.22.5` install (in an isolated venv, not committed) against a local `file://` tracking store — a real run was created, the sink invoked, and the resulting artifact files inspected on disk, not just "no exception raised". `ruff format`/`ruff check` clean.

**Potential risks**
The `upload_to_comet` → `upload_profiler_results` rename is a breaking config key change, but low risk: the old key was introduced entirely by #1614, which has not shipped in any released `michelangelo` package (latest PyPI release is 0.5.0), so no external consumer can be relying on the old name. No deprecation alias was added for this reason.

**Breaking Changes**

- [ ] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [x] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Migration guide**
Any caller passing `profiler={"pytorch": {...}, "upload_to_comet": False}` (or `True`) to `LightningTrainerParam.lightning_trainer_kwargs["profiler"]` must rename the key to `upload_profiler_results`:

```python
# before
profiler = {"pytorch": {}, "upload_to_comet": False}
# after
profiler = {"pytorch": {}, "upload_profiler_results": False}
```

**Release notes**
`upload_to_comet` profiler config key renamed to `upload_profiler_results`; new `mlflow_profiler_sink` available for `LightningTrainerParam.profiler_sink`.

**Documentation Changes**
Docstrings updated in place (`build_mlflow_logger`, `LightningTrainerParam.profiler_sink`, `_build_profiler`, `_resolve_profiler`, `_maybe_export_profiler_results`). No wiki changes.
