### PR TITLE
refactor(trainer): rename upload_to_comet config key to upload_profiler_results

### DIFF
--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/_private/util.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/_private/util.py
@@ -68,7 +68,7 @@ _MAX_PROFILER_REPEAT = 3
 # Only ``pytorch`` is supported today — Michelangelo OSS is PyTorch-heavy, and
 # the other Lightning profilers (simple / advanced / xla) and a custom-class
 # escape hatch add config surface without a concrete user yet. The dict shape
-# (``{"pytorch": {...}, "upload_to_comet": ...}``) is kept as-is so adding a
+# (``{"pytorch": {...}, "upload_profiler_results": ...}``) is kept as-is so adding a
 # second backend later, as we expand to more platforms, is additive rather
 # than a breaking config change.
 _PROFILER_SHORTHANDS = ("pytorch",)
@@ -792,7 +792,7 @@ def _build_profiler(
             * A dict setting ``pytorch`` to a kwargs dict, handled by
               :func:`_build_pytorch_profiler`.
 
-            ``upload_to_comet`` is reserved metadata read by
+            ``upload_profiler_results`` is reserved metadata read by
             :func:`_resolve_profiler` and is never forwarded to a profiler
             constructor.
         steps_per_epoch: Estimated steps per epoch, used to derive or
@@ -877,7 +877,7 @@ def _resolve_profiler(
 
     Returns:
         A ``(profiler, profiler_logs_path, upload_results)`` tuple.
-        ``upload_results`` mirrors the config's ``upload_to_comet`` flag and
+        ``upload_results`` mirrors the config's ``upload_profiler_results`` flag and
         gates the post-``fit`` ``profiler_sink`` call; it defaults to ``True``
         so callers must opt *out* of exporting results.
     """
@@ -885,7 +885,7 @@ def _resolve_profiler(
         return None, "", False
 
     upload_results = (
-        profiler_config.get("upload_to_comet", True)
+        profiler_config.get("upload_profiler_results", True)
         if isinstance(profiler_config, dict)
         else True
     )
@@ -1337,7 +1337,7 @@ def _maybe_export_profiler_results(
         profiler_logs_path: Directory the profiler wrote its output to.
         logger: The resolved Lightning logger, forwarded to the sink so it can
             attach results to the active experiment.
-        upload_profiler_results: The config's ``upload_to_comet`` flag; when
+        upload_profiler_results: The config's ``upload_profiler_results`` flag; when
             ``False`` the sink is not called.
         profiler_sink: The user-supplied
             ``Callable[[Profiler, str, logger], None]``, or ``None``.

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/lightning_trainer.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/lightning_trainer.py
@@ -127,7 +127,7 @@ class LightningTrainerParam:
             :func:`~_private.util.comet_profiler_sink` does this for Comet and
             :func:`~_private.util.mlflow_profiler_sink` does this for MLflow.
             Ignored when no profiler is configured or when the profiler config
-            sets ``upload_to_comet: False``. Exceptions raised by the sink are
+            sets ``upload_profiler_results: False``. Exceptions raised by the sink are
             logged and swallowed. Must be picklable (serialized to workers).
     """
 

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_profiler.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_profiler.py
@@ -339,7 +339,7 @@ class TestBuildProfiler:
     def test_no_profiler_selected_raises(self, in_tmp_cwd, patched_ray):
         """A dict that selects nothing is a user config error."""
         with pytest.raises(UserInputError, match="None were set"):
-            _build_profiler({"upload_to_comet": False})
+            _build_profiler({"upload_profiler_results": False})
 
     def test_multiple_profilers_selected_raises(self, in_tmp_cwd, patched_ray):
         """A dict that selects two profiler flavors is a user config error.
@@ -355,9 +355,11 @@ class TestBuildProfiler:
         ):
             _build_profiler({"pytorch": {}, "other": {}})
 
-    def test_upload_to_comet_is_not_a_profiler_selection(self, in_tmp_cwd, patched_ray):
-        """``upload_to_comet`` is metadata and never reaches a constructor."""
-        profiler, _ = _build_profiler({"pytorch": {}, "upload_to_comet": False})
+    def test_upload_profiler_results_is_not_a_profiler_selection(
+        self, in_tmp_cwd, patched_ray
+    ):
+        """``upload_profiler_results`` is metadata and never reaches a constructor."""
+        profiler, _ = _build_profiler({"pytorch": {}, "upload_profiler_results": False})
         assert isinstance(profiler, PyTorchProfiler)
 
     def test_invalid_shorthand_raises(self):
@@ -378,7 +380,7 @@ class TestBuildProfiler:
 
 
 class TestResolveProfiler:
-    """Config resolution, including the ``upload_to_comet`` opt-out."""
+    """Config resolution, including the ``upload_profiler_results`` opt-out."""
 
     def test_none_config_resolves_to_nothing(self):
         """No profiler config means no profiler and no export."""
@@ -397,9 +399,9 @@ class TestResolveProfiler:
         assert upload is True
 
     def test_upload_can_be_disabled(self, in_tmp_cwd, patched_ray):
-        """``upload_to_comet: False`` turns the export off."""
+        """``upload_profiler_results: False`` turns the export off."""
         _, _, upload = _resolve_profiler(
-            {"pytorch": {}, "upload_to_comet": False}, {}, 100, 8, 1, 0
+            {"pytorch": {}, "upload_profiler_results": False}, {}, 100, 8, 1, 0
         )
         assert upload is False
 
@@ -460,7 +462,7 @@ class TestMaybeExportProfilerResults:
         sink.assert_not_called()
 
     def test_not_called_when_upload_disabled(self, patched_ray):
-        """``upload_to_comet: False`` suppresses the sink."""
+        """``upload_profiler_results: False`` suppresses the sink."""
         sink = MagicMock(name="sink")
         _maybe_export_profiler_results(MagicMock(), "/logs", None, False, sink)
         sink.assert_not_called()


### PR DESCRIPTION
## Summary
Stacked on top of the MLflow profiler sink PR. The profiler_sink
layer is backend-agnostic (Comet and MLflow), but the config key that
gates it was still named for Comet specifically.

Straight rename, no deprecation alias needed: this key was introduced
entirely by #1614 and has never shipped in a released michelangelo
package (latest PyPI release is 0.5.0; #1614 merged after that), so
no external consumer can be relying on the old name.

## Test Plan


## Issues


## Stack
1. #1702
1. @ #1703
