### PR TITLE
fix(storage/mysql): validate criterion field name before SQL interpolation

### DIFF
--- a/go/storage/mysql/mysql.go
+++ b/go/storage/mysql/mysql.go
@@ -550,26 +550,24 @@ func processFieldName(fieldName string) (string, error) {
 //     internal map values "IS NULL "/"IS NOT NULL ").
 //   - IN / NOT IN list has no spaces between placeholders (e.g. "(?,?,?)").
 //
-// TODO(#1171): validate fieldName before splicing it into SQL.
+// fieldName is validated against validColumnName before it is interpolated.
 //
-// Trust model — both this function and the matching internal one assume the
-// caller has already vetted fieldName against an allowlist (internal does so
-// in processListOptExtFieldV2 via the per-CRD indexPathToKeyMap). When that
-// upstream check is bypassed — and in OSS that's the default whenever the
-// constructor is called with a nil indexPathToKeyMaps — fieldName is taken
-// straight from the caller-supplied CriterionOperation and embedded between
-// backticks here. A caller controlling field_name can break out of the
-// backtick-quoted identifier and inject SQL (e.g. field_name="x.` UNION
-// SELECT … --" survives processFieldName and lands here as `+ "`" + ` UNION
-// SELECT … --` `+ "`" + `).
+// Trust model — both this function and the matching internal one otherwise
+// assume the caller has already vetted fieldName against an allowlist (internal
+// does so in processListOptExtFieldV2 via the per-CRD indexPathToKeyMap). In
+// OSS that upstream check is skipped whenever the constructor is called with a
+// nil indexPathToKeyMaps, which both production call sites do, so fieldName
+// arrives here straight from the caller-supplied CriterionOperation. Without
+// the identifier check a caller controlling field_name could close the
+// backtick-quoted identifier and append arbitrary SQL.
 //
-// The right long-term fix is for the OSS constructor to require an
-// indexPathToKeyMaps and remove the permissive mode. As a defence-in-depth
-// stop-gap, we could reject any fieldName containing characters outside
-// [a-zA-Z0-9_] right here (cheap, no schema cost). Neither is done yet to
-// keep the public surface compatible with the existing caller sites that
-// pass nil today.
+// Requiring a non-nil indexPathToKeyMaps in the OSS constructor and dropping
+// the permissive mode would make the check here redundant, but that is a
+// breaking change to a public constructor and is deliberately left separate.
 func convertCriterionOperator(fieldName string, op apipb.CriterionOperator, value string) (string, []interface{}, error) {
+	if !validColumnName.MatchString(fieldName) {
+		return "", nil, status.Errorf(codes.InvalidArgument, "invalid field name: %v", fieldName)
+	}
 	qf := " `" + fieldName + "` "
 	switch op {
 	case apipb.CRITERION_OPERATOR_IS_NULL:
@@ -938,6 +936,13 @@ func buildLabelSelectorSQL(labelSelectorStr, tableName string) (labelSelectorPie
 // MySQL column map); fields not in the map are rejected with InvalidArgument.
 // When indexPathToKeyMap is nil, the path is used as the column name as-is
 // (permissive — matches our criterion-builder convention).
+//
+// Either way the resolved column name is validated against validColumnName
+// before backtick-quoted interpolation. Keys arriving here have already passed
+// labels.Parse, whose grammar excludes the characters needed to escape a
+// backtick, so this is defence-in-depth rather than a live injection fix: it
+// keeps the invariant local to the splice instead of resting on an upstream
+// parser, and turns a non-column key into a clean InvalidArgument.
 func buildFieldSelectorSQL(fieldSelectorStr string, indexPathToKeyMap map[string]string) (string, []interface{}, error) {
 	if fieldSelectorStr == "" {
 		return "", nil, nil
@@ -953,6 +958,10 @@ func buildFieldSelectorSQL(fieldSelectorStr string, indexPathToKeyMap map[string
 		if mapped, ok := indexPathToKeyMap[col]; ok {
 			col = mapped
 		} else if indexPathToKeyMap != nil {
+			return "", nil, status.Errorf(codes.InvalidArgument,
+				"invalid field selector, unsupported field. field: %v", req.Key())
+		}
+		if !validColumnName.MatchString(col) {
 			return "", nil, status.Errorf(codes.InvalidArgument,
 				"invalid field selector, unsupported field. field: %v", req.Key())
 		}
@@ -989,12 +998,15 @@ func buildFieldSelectorSQL(fieldSelectorStr string, indexPathToKeyMap map[string
 	return queryStr.String(), params, nil
 }
 
-// validOrderByColumnName matches MySQL unquoted-identifier-safe characters
-// (letters, digits, underscore). Applied to the column name derived from a
-// caller-supplied OrderBy.Field before backtick-quoted interpolation, because
-// identifier positions cannot be bound with placeholder parameters the way
-// literal values can.
-var validOrderByColumnName = regexp.MustCompile(`^[A-Za-z0-9_]+$`)
+// validColumnName matches MySQL unquoted-identifier-safe characters (letters,
+// digits, underscore). Applied to every column name derived from caller-supplied
+// input before backtick-quoted interpolation, because identifier positions
+// cannot be bound with placeholder parameters the way literal values can.
+//
+// Guards the three paths that resolve a caller-controlled field path to a bare
+// column name: convertCriterionOperator (list_options_ext.operation),
+// buildFieldSelectorSQL (field_selector) and buildOrderBySQL (order_by).
+var validColumnName = regexp.MustCompile(`^[A-Za-z0-9_]+$`)
 
 // buildOrderBySQL builds the ORDER BY clause from a list of OrderBy specs.
 //
@@ -1009,7 +1021,7 @@ var validOrderByColumnName = regexp.MustCompile(`^[A-Za-z0-9_]+$`)
 //     remainder is a key in it, otherwise reject (codes.InvalidArgument) —
 //     mirrors buildFieldCriterionSQL's map-enforcement pattern.
 //  5. Otherwise the remainder is used as the bare column name, validated
-//     against validOrderByColumnName before interpolation.
+//     against validColumnName before interpolation.
 //
 // Returns codes.InvalidArgument if a resolved column name fails the
 // identifier-syntax check.
@@ -1046,7 +1058,7 @@ func buildOrderBySQL(orderBy []*apipb.OrderBy, indexPathToKeyMap map[string]stri
 			// orderByLabelColumn already includes its own backticks.
 			clauses = append(clauses, colName+" "+dir)
 		} else {
-			if !validOrderByColumnName.MatchString(colName) {
+			if !validColumnName.MatchString(colName) {
 				return "", status.Errorf(codes.InvalidArgument, "invalid order_by field: %v", order.Field)
 			}
 			clauses = append(clauses, fmt.Sprintf("`%s` %s", colName, dir))

--- a/go/storage/mysql/mysql_test.go
+++ b/go/storage/mysql/mysql_test.go
@@ -133,6 +133,162 @@ func TestConvertCriterionOperator(t *testing.T) {
 	}
 }
 
+func TestConvertCriterionOperator_RejectsInvalidFieldName(t *testing.T) {
+	// Identifier positions cannot be bound with placeholder parameters, so the
+	// column name is validated against validColumnName before it is spliced
+	// between backticks. Payloads below survive processFieldName unchanged and
+	// reach this function verbatim when indexPathToKeyMaps is nil, which is
+	// what both production constructor sites pass.
+	cases := []struct {
+		name      string
+		fieldName string
+		wantErr   bool
+	}{
+		{"plain_column", "name", false},
+		{"underscores_and_digits", "src_pipeline_run_name2", false},
+		// Literal shape of the reported payload: closes the identifier's
+		// backtick early to append an arbitrary expression.
+		{"backtick_escape_rejected", "name` = (SELECT SLEEP(5))-- -", true},
+		{"union_payload_rejected", "x` UNION SELECT 1 -- ", true},
+		{"semicolon_rejected", "name; DROP TABLE model", true},
+		{"parens_and_spaces_rejected", "updatexml(1, concat(0x7e, version()), 1)", true},
+		// Not an injection, but not a real column either: previously produced
+		// a cryptic MySQL "Unknown column" error, now a clean InvalidArgument.
+		{"dotted_path_rejected", "metadata.name", true},
+		{"empty_rejected", "", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, _, err := convertCriterionOperator(c.fieldName, apipb.CRITERION_OPERATOR_EQUAL, "v")
+			if c.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestBuildFieldCriterionSQL_RejectsInjectionWithNilMap(t *testing.T) {
+	// End-to-end shape of the vulnerability: a nil indexPathToKeyMap (the OSS
+	// default) skips the map-membership check, so field_name reaches the SQL
+	// builder straight from the caller-supplied CriterionOperation.
+	op := &apipb.CriterionOperation{
+		Criterion: []*apipb.Criterion{
+			{
+				FieldName:  "model.name` = (SELECT SLEEP(5))-- -",
+				Operator:   apipb.CRITERION_OPERATOR_EQUAL,
+				MatchValue: stringMatchValue(t, "x"),
+			},
+		},
+	}
+	_, _, err := buildFieldCriterionSQL(op, nil)
+	require.Error(t, err)
+}
+
+func TestBuildLabelCriterionSQL_SlashKeyStillWorks(t *testing.T) {
+	// Label keys legitimately contain '/' and would fail validColumnName, but
+	// they never reach it: buildFieldCriterionSQL skips label fields, and the
+	// key is bound as a parameter rather than interpolated as an identifier.
+	op := &apipb.CriterionOperation{
+		Criterion: []*apipb.Criterion{
+			{
+				FieldName:  "pipeline_run.metadata.labels.michelangelo/SpecUpdateTimestamp",
+				Operator:   apipb.CRITERION_OPERATOR_EQUAL,
+				MatchValue: stringMatchValue(t, "123"),
+			},
+		},
+	}
+	queryStrs, params, err := buildLabelCriterionSQL(op, "pipeline_run")
+	require.NoError(t, err)
+	require.Len(t, queryStrs, 1)
+	require.Contains(t, queryStrs[0], "`key`= ?")
+	require.Equal(t, "michelangelo/SpecUpdateTimestamp", params[0])
+
+	// The same criterion contributes no field clause.
+	fieldStrs, _, err := buildFieldCriterionSQL(op, nil)
+	require.NoError(t, err)
+	require.Empty(t, fieldStrs)
+}
+
+func TestBuildFieldSelectorSQL(t *testing.T) {
+	// Keys reaching this function have already passed labels.Parse via
+	// parseSelector, whose grammar excludes the characters needed to escape a
+	// backtick-quoted identifier. The validColumnName check is therefore
+	// defence-in-depth rather than a live injection fix: it keeps the invariant
+	// local to the splice instead of resting on an upstream parser, and turns a
+	// non-column key into a clean InvalidArgument rather than a MySQL error.
+	cases := []struct {
+		name              string
+		selector          string
+		indexPathToKeyMap map[string]string
+		want              string
+		wantParams        []interface{}
+		wantErr           bool
+	}{
+		{name: "empty", selector: "", want: ""},
+		{
+			name:       "equals_bare_column",
+			selector:   "name=alice",
+			want:       " AND `name`=?",
+			wantParams: []interface{}{"alice"},
+		},
+		{
+			name:     "empty_value_matches_null_or_blank",
+			selector: "name=",
+			want:     " AND (`name` IS NULL OR `name`='')",
+		},
+		{
+			name:       "in_operator",
+			selector:   "namespace in (a,b)",
+			want:       " AND `namespace` IN (?,?)",
+			wantParams: []interface{}{"a", "b"},
+		},
+		{
+			// Survives labels.Parse ('.' is a legal key character) but is not a
+			// column. Previously spliced in and failed at MySQL.
+			name:     "dotted_path_rejected",
+			selector: "metadata.name=alice",
+			wantErr:  true,
+		},
+		{
+			name:     "slash_key_rejected",
+			selector: "michelangelo/Foo=bar",
+			wantErr:  true,
+		},
+		{
+			name:     "hyphen_key_rejected",
+			selector: "foo-bar=baz",
+			wantErr:  true,
+		},
+		{
+			name:              "populated_map_rewrites_to_column",
+			selector:          "metadata.name=alice",
+			indexPathToKeyMap: map[string]string{"metadata.name": "name"},
+			want:              " AND `name`=?",
+			wantParams:        []interface{}{"alice"},
+		},
+		{
+			name:              "populated_map_rejects_unmapped_field",
+			selector:          "other=alice",
+			indexPathToKeyMap: map[string]string{"metadata.name": "name"},
+			wantErr:           true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, params, err := buildFieldSelectorSQL(c.selector, c.indexPathToKeyMap)
+			if c.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.want, got)
+			require.Equal(t, c.wantParams, params)
+		})
+	}
+}
+
 func TestBuildLabelCriterionSQL(t *testing.T) {
 	op := &apipb.CriterionOperation{
 		Criterion: []*apipb.Criterion{


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
`convertCriterionOperator` now validates the resolved column name against an identifier allowlist before splicing it between backticks. The regex added in #1616 for `order_by` is reused (renamed `validOrderByColumnName` → `validColumnName`, both package-private) rather than introducing a second pattern.

Adds the same guard to `buildFieldSelectorSQL`. That path is **not** exploitable as its keys come from `labels.Parse`, whose grammar excludes backticks, so it is defence-in-depth plus a cleaner error.

Fixes #1171 

<!-- Tell your future self why have you made these changes -->
**Why?**
`buildFieldCriterionSQL` enforces the per-CRD `indexPathToKeyMap` only when it is non-nil, and both production constructor sites pass `nil` (`cmd/apiserver/providers.go:25`, `cmd/controllermgr/ingester_providers.go:26`). So in the shipped binaries `field_name` reaches the SQL builder straight from the caller's `CriterionOperation` and can close the identifier to append arbitrary SQL.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit tests for the payload shape from the issue, general SQL metacharacters, both `indexPathToKeyMap` branches, and a label-criterion no-regression case.
- New table test for `buildFieldSelectorSQL`, which had no coverage at all.
- Mutation check: loosening the regex to `^.*$` fails 16 subtests.
- `bazel test //go/... //proto/...` — 94/94. `gazelle` and `goimports` produce no diff.
- Confirmed no legitimate column is rejected: all 56 distinct column names in `mysql-init-schema.sql` and `ingester_schema.sql` match `^[A-Za-z0-9_]+$`, as do the `baseOrderByFields` targets.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
One behaviour change worth flagging: a criterion naming a dotted path now returns `InvalidArgument` instead of reaching MySQL and failing with `Unknown column`.

This affects every `mactl` filter flag: `pipeline.spec.owner.name`, `pipeline.spec.type`, `pipeline_run.spec.actor.name`,
`pipeline_run.spec.revision.name`, `revision.spec.owner.name` all contain dots after the CRD prefix is stripped. They are already broken in OSS: no column in either schema file contains a dot, so they die at MySQL today. This change makes that failure earlier and legible rather than introducing it. With a populated `indexPathToKeyMaps` the mapped bare column name passes the guard untouched, so downstream is unaffected.

Happy to file a separate issue for the CLI filters being non-functional in OSS.

I considered rejecting only the backtick instead, which would preserve today's exact behaviour for dotted paths, but chose the allowlist to match #1616 and because allowlists are the right shape for identifier positions.

<!-- Does this PR introduce a breaking change? Check all that apply. -->
**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)


<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
Fixes a SQL injection in the MySQL metadata storage `List` path.
