### PR TITLE
feat(ui): add status cards to deployment detail page

### DIFF
--- a/javascript/packages/core/config/entities/deployment/__tests__/deployment-page.test.tsx
+++ b/javascript/packages/core/config/entities/deployment/__tests__/deployment-page.test.tsx
@@ -195,6 +195,51 @@ describe('Deployment detail page', () => {
       expect(screen.queryByLabelText('Type of deployment')).not.toBeInTheDocument();
       expect(screen.queryByRole('link', { name: 'triton-server' })).not.toBeInTheDocument();
     });
+
+    it('renders the revision references on the deployment', async () => {
+      render(
+        <EntityDetailRoute phases={{ deploy: DEPLOY_PHASE }} />,
+        buildWrapper([
+          getErrorProviderWrapper(),
+          getRouterWrapper({
+            location: '/myproject/deploy/deployments/sentiment-deployment/info',
+          }),
+          getServiceProviderWrapper({ request: createQueryMockRouter(infoTabResponses()) }),
+        ])
+      );
+
+      expect(await screen.findByText('sentiment-model-rev-2')).toBeInTheDocument();
+      expect(screen.getByText('Current model in production')).toBeInTheDocument();
+      expect(screen.getByText('sentiment-model-rev-3')).toBeInTheDocument();
+      expect(screen.getByText('No model currently being deployed')).toBeInTheDocument();
+    });
+
+    it('renders empty states when no revisions are set', async () => {
+      render(
+        <EntityDetailRoute phases={{ deploy: DEPLOY_PHASE }} />,
+        buildWrapper([
+          getErrorProviderWrapper(),
+          getRouterWrapper({
+            location: '/myproject/deploy/deployments/sentiment-deployment/info',
+          }),
+          getServiceProviderWrapper({
+            request: createQueryMockRouter({
+              GetDeployment: {
+                deployment: {
+                  metadata: { name: 'sentiment-deployment' },
+                  spec: { definition: { type: 1 } },
+                  status: { state: DEPLOYMENT_STATE.EMPTY, stage: DEPLOYMENT_STAGE.INVALID },
+                },
+              },
+            }),
+          }),
+        ])
+      );
+
+      expect(await screen.findByText('No currently deployed model')).toBeInTheDocument();
+      expect(screen.getByText('No model currently being deployed')).toBeInTheDocument();
+      expect(screen.getByText('No model configured to be deployed')).toBeInTheDocument();
+    });
   });
 
   describe('ongoing operations tab', () => {

--- a/javascript/packages/core/config/entities/deployment/deployment-info-page.tsx
+++ b/javascript/packages/core/config/entities/deployment/deployment-info-page.tsx
@@ -7,6 +7,7 @@ import { StringField } from '#core/components/form/fields/string/string-field';
 import { Form } from '#core/components/form/form';
 import { LinksBox } from '#core/components/links-box/links-box';
 import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
+import { DeploymentRevisionCard } from './deployment-revision-card';
 import { TARGET_TYPE_LABELS } from './shared';
 
 import type { DeploymentRecord } from './types';
@@ -39,6 +40,32 @@ export function DeploymentInfoPage({ data, isLoading }: { data?: object; isLoadi
   return (
     <div className={css({ display: 'flex', flexDirection: 'column', gap: theme.sizing.scale600 })}>
       <LinksBox title="Useful links" links={links} isLoading={isLoading} />
+
+      <section>
+        <HeadingSmall marginTop="0" marginBottom={theme.sizing.scale600}>
+          Key status indicators
+        </HeadingSmall>
+        <div className={css({ display: 'flex', gap: theme.sizing.scale600, flexWrap: 'wrap' })}>
+          <DeploymentRevisionCard
+            title="Current model in production"
+            revision={deployment?.status?.currentRevision}
+            emptyText="No currently deployed model"
+            isLoading={isLoading}
+          />
+          <DeploymentRevisionCard
+            title="Candidate model"
+            revision={deployment?.status?.candidateRevision}
+            emptyText="No model currently being deployed"
+            isLoading={isLoading}
+          />
+          <DeploymentRevisionCard
+            title="Desired model to be deployed"
+            revision={deployment?.spec?.desiredRevision}
+            emptyText="No model configured to be deployed"
+            isLoading={isLoading}
+          />
+        </div>
+      </section>
 
       <section>
         <HeadingSmall marginTop="0" marginBottom={theme.sizing.scale600}>

--- a/javascript/packages/core/config/entities/deployment/deployment-revision-card.tsx
+++ b/javascript/packages/core/config/entities/deployment/deployment-revision-card.tsx
@@ -1,0 +1,69 @@
+import { useStyletron } from 'baseui';
+import { ARTWORK_TYPE } from 'baseui/banner';
+import { Spinner } from 'baseui/spinner';
+import { LabelSmall, ParagraphMedium } from 'baseui/typography';
+
+import { Banner } from '#core/components/banner/banner';
+import { Box } from '#core/components/box/box';
+import { Icon } from '#core/components/icon/icon';
+
+import type { ResourceRef } from './types';
+
+const CARD_OVERRIDES = { BoxContainer: { style: { flexBasis: '320px', flexGrow: 1 } } };
+
+/**
+ * Renders a card for one of a deployment's revision references (current,
+ * candidate, or desired). Shows only what is present on the Deployment CR
+ * itself — the revision name — since OSS has no producer of Model revisions to
+ * resolve richer model metadata from.
+ */
+export function DeploymentRevisionCard({
+  title,
+  revision,
+  emptyText,
+  isLoading,
+}: {
+  title: string;
+  revision?: ResourceRef;
+  emptyText: string;
+  isLoading?: boolean;
+}) {
+  const [css, theme] = useStyletron();
+
+  if (isLoading) {
+    return (
+      <Box title={title} overrides={CARD_OVERRIDES}>
+        <div className={css({ display: 'flex', justifyContent: 'center' })}>
+          <Spinner />
+        </div>
+      </Box>
+    );
+  }
+
+  if (!revision?.name) {
+    return (
+      <Box title={title} overrides={CARD_OVERRIDES}>
+        <Banner
+          kind="info"
+          artwork={{
+            type: ARTWORK_TYPE.icon,
+            icon: () => <Icon name="circleI" size={theme.sizing.scale800} />,
+          }}
+        >
+          {emptyText}
+        </Banner>
+      </Box>
+    );
+  }
+
+  return (
+    <Box title={title} overrides={CARD_OVERRIDES}>
+      <LabelSmall color={theme.colors.contentSecondary} marginBottom={theme.sizing.scale200}>
+        Revision
+      </LabelSmall>
+      <ParagraphMedium marginTop="0" marginBottom="0">
+        {revision.name}
+      </ParagraphMedium>
+    </Box>
+  );
+}


### PR DESCRIPTION

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

Add a "Key status indicators" section to the deployment Information tab showing the current, candidate, and desired model revisions as cards. Each card renders the revision name from the Deployment CR (with an empty state when unset).

<img width="1512" height="910" alt="image" src="https://github.com/user-attachments/assets/7a25e8fd-1dcd-4b3d-a373-aa7f49eadb0e" />



<!-- Tell your future self why have you made these changes -->
**Why?**
We would like to display the status indicators on the deployment page.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Visually and unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
None

<!-- Does this PR introduce a breaking change? Check all that apply. -->
**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)


<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
N/A

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
N/A