### PR TITLE
feat(ui): show rollback reason in deployment detail header

### DIFF
--- a/javascript/packages/core/config/entities/deployment/__tests__/deployment-page.test.tsx
+++ b/javascript/packages/core/config/entities/deployment/__tests__/deployment-page.test.tsx
@@ -111,6 +111,36 @@ describe('Deployment detail page', () => {
     expect(screen.getByText('Owner')).toBeInTheDocument();
     expect(screen.getByText('Stage')).toBeInTheDocument();
     expect(screen.getByText('State')).toBeInTheDocument();
+    expect(screen.getByText('Rollback reason')).toBeInTheDocument();
+  });
+
+  it('renders the rollback reason when the annotation is present', async () => {
+    render(
+      <EntityDetailRoute phases={{ deploy: DEPLOY_PHASE }} />,
+      buildWrapper([
+        getErrorProviderWrapper(),
+        getRouterWrapper({
+          location: '/myproject/deploy/deployments/sentiment-deployment/stages',
+        }),
+        getServiceProviderWrapper({
+          request: createQueryMockRouter({
+            GetDeployment: {
+              deployment: buildDeployment({
+                metadata: {
+                  name: 'sentiment-deployment',
+                  creationTimestamp: { seconds: 1746000000 },
+                  labels: { 'michelangelo/owner': 'user-example' },
+                  annotations: { 'deployment.rollback.reason': 'Failed health check' },
+                },
+              }),
+            },
+          }),
+        }),
+      ])
+    );
+
+    expect(await screen.findByText('Rollback reason')).toBeInTheDocument();
+    expect(screen.getByText('Failed health check')).toBeInTheDocument();
   });
 
   it('renders the stages for the deployment', async () => {

--- a/javascript/packages/core/config/entities/deployment/detail.ts
+++ b/javascript/packages/core/config/entities/deployment/detail.ts
@@ -15,6 +15,11 @@ export const DEPLOYMENT_DETAIL_CONFIG: DetailViewConfig = {
     { id: 'metadata.creationTimestamp.seconds', label: 'Created', type: CellType.DATE },
     { id: 'metadata.labels["michelangelo/owner"]', label: 'Owner', type: CellType.TEXT },
     DEPLOYMENT_STAGE_CELL,
+    {
+      id: 'metadata.annotations["deployment.rollback.reason"]',
+      label: 'Rollback reason',
+      type: CellType.TEXT,
+    },
     DEPLOYMENT_STATE_CELL,
   ],
   pages: [


### PR DESCRIPTION


**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**


Add a "Rollback reason" metadata row to the deployment detail header, sourced from the deployment.rollback.reason annotation and hidden when empty.


<!-- Tell your future self why have you made these changes -->
**Why?**
More detail in deployment detail page

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Visually and unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
None
<!-- Does this PR introduce a breaking change? Check all that apply. -->
**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
N/A
<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
N/A