### PR TITLE
chore: remove dead internal tracker links from code comments

### DIFF
--- a/go/components/utils/proto.go
+++ b/go/components/utils/proto.go
@@ -113,7 +113,7 @@ func MapProtoListValueToInterface(x *types.ListValue) ([]interface{}, error) {
 
 // Construct proto.Struct from map[string]interface{} type
 // Reference: https://github.com/protocolbuffers/protobuf-go/blob/master/types/known/structpb/struct.pb.go
-// Not adding the repo directly as it seems there are some compatibility issues tracked in https://code.uberinternal.com/T5741973.
+// Not adding the repo directly as it seems there are some compatibility issues.
 
 // NewValue constructs a Value from a general-purpose Go interface.
 //

--- a/javascript/packages/core/components/row/types.ts
+++ b/javascript/packages/core/components/row/types.ts
@@ -17,8 +17,6 @@ export type RowCell = Cell & {
    * In the "Triggers" metadata row, some columns (i.e. 'Max concurrency') need
    * to be hidden when their value is empty.
    *
-   * @see: https://t3.uberinternal.com/browse/MA-36479
-   *
    * @default false
    */
   hideEmpty?: boolean;


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**
Removes two code-comment links to internal Uber trackers, which are not reachable from outside Uber and so are dead links for every reader of this repository:

1. `go/components/utils/proto.go` - a `code.uberinternal.com` ticket link in the comment above `NewValue`. The substance of the note (that the protobuf-go repo is not imported directly due to compatibility issues) is kept as-is.
2. `javascript/packages/core/components/row/types.ts` - a `@see` link to a `t3.uberinternal.com` ticket on the `hideEmpty` prop. The `@example` above it already documents the behavior, so only the tracker reference is dropped.

**Why?**
Dead internal links in a public codebase are noise for external readers and can be confusing - they look like a resource you are expected to be able to consult. These were the only two occurrences of `uberinternal.com` in tracked files; after this change `git grep uberinternal` comes back empty.

**How did you test it?**
Comment-only change, no code touched. `git grep uberinternal` across the repo confirms these were the only two occurrences and that none remain after the change.

**Potential risks**
None - no code changes.

**Breaking Changes**
- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**
None.

**Documentation Changes**
None needed.
