### PR TITLE
docs: fix community on-ramps in CONTRIBUTING and docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ See the [Table of Contents](#table-of-contents) for different ways to contribute
 
 There are other easy ways to help support the project and show your appreciation including
 * Star the project
-* Join the our community
+* Join our [GitHub Discussions](https://github.com/michelangelo-ai/michelangelo/discussions)
 * Shout about us online or at local meetups with your peers & colleagues
 
 <a id="table-of-contents"></a>
@@ -44,7 +44,7 @@ If you want to ask a question about the project, there are a few options availab
 
 * Check and read our [Documentation](https://michelangelo-ai.org/)
 * Search our existing [Issues](https://github.com/michelangelo-ai/michelangelo/issues) as this may also help you.
-* Join our Community (coming soon) to engage with other users and contributors,
+* Join our [GitHub Discussions](https://github.com/michelangelo-ai/michelangelo/discussions) to engage with other users and contributors.
 
 If you’re still facing issues and need further help, then we recommend the following process:
 * Open an [issue](https://github.com/michelangelo-ai/michelangelo/issues/new/choose).

--- a/docs/getting-started/support.md
+++ b/docs/getting-started/support.md
@@ -11,7 +11,7 @@ Need help with Michelangelo AI? Connect with the core team and developer communi
 
 - **[GitHub Discussions](https://github.com/michelangelo-ai/michelangelo/discussions):** Our primary channel for general Q&A, troubleshooting, technical support, and sharing ideas. Search existing discussions before opening a new one — your question may already be answered.
 
-- **[Slack Workspace](https://michelangelo-ai.slack.com/):** For real-time chat, networking, and focused conversations with other developers in the ecosystem.
+- **[Slack Workspace](https://michelangelo-ai.slack.com/):** For real-time chat, networking, and focused conversations with other developers in the ecosystem. The workspace is invite-based; email [michelangelo-oss@uber.com](mailto:michelangelo-oss@uber.com) to request an invite.
 
 - **[Email](mailto:michelangelo-oss@uber.com):** For private, sensitive, or 1-on-1 inquiries that cannot be discussed publicly (for example, security disclosures or enterprise partnerships).
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -82,5 +82,5 @@ Understanding scope helps you decide if Michelangelo AI is the right tool.
 Connect with the Michelangelo AI core team and developer community through our dedicated channels:
 
 - **[GitHub Discussions](https://github.com/michelangelo-ai/michelangelo/discussions):** Our primary channel for general Q&A, troubleshooting, technical support, and sharing ideas.
-- **[Slack Workspace](https://michelangelo-ai.slack.com/):** For real-time chat, networking, and focused conversations with other developers in the ecosystem.
+- **[Slack Workspace](https://michelangelo-ai.slack.com/):** For real-time chat, networking, and focused conversations with other developers in the ecosystem. The workspace is invite-based; email [michelangelo-oss@uber.com](mailto:michelangelo-oss@uber.com) to request an invite.
 - **[Email](mailto:michelangelo-oss@uber.com):** For private, sensitive, or 1-on-1 inquiries that cannot be discussed publicly (for example, security disclosures or enterprise partnerships), feel free to email us at michelangelo-oss@uber.com.


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**
Three small fixes for readers trying to reach the community:

1. `CONTRIBUTING.md` had a typo ("Join the our community") in the ways-to-support list; the bullet now links to GitHub Discussions.
2. `CONTRIBUTING.md` also said "Join our Community (coming soon)" in the get-help section, while GitHub Discussions is already live and described as the primary channel in `docs/intro.md` and `docs/getting-started/support.md`. The bullet now links there.
3. `docs/intro.md` and `docs/getting-started/support.md` both link the Slack workspace root URL (`https://michelangelo-ai.slack.com/`), which is a dead end for anyone who is not already a member - Slack workspace URLs require an existing account in that workspace. Both lines now note the workspace is invite-based and point to `michelangelo-oss@uber.com`, the contact channel those same pages already publish. If there is a shared invite link you would rather publish, happy to swap it in instead.

**Why?**
These are the first pages a prospective contributor or adopter reads, and right now two of the three community on-ramps are dead ends ("coming soon" for something that exists, and a Slack link that cannot be joined). Small fixes, but they sit directly on the adoption path.

**How did you test it?**
Verified GitHub Discussions is enabled on the repo. Verified the Slack workspace root URL serves Slack's sign-in page for non-members, with no self-serve join path. Checked the diff line-by-line to confirm only the four intended lines change and the surrounding list formatting is untouched.

**Potential risks**
None - docs-only. The Slack wording assumes invite requests via the project email are acceptable; if you prefer a different mechanism (or a public invite link), that is a one-line follow-up.

**Breaking Changes**
- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**
None.

**Documentation Changes**
This PR is itself the documentation change.
