### PR TITLE
fix: reword ma-design-interview skill to reduce duration

### DIFF
--- a/.claude/skills/ma-design-interview/SKILL.md
+++ b/.claude/skills/ma-design-interview/SKILL.md
@@ -20,7 +20,7 @@ Interview discipline derived from [mattpocock/skills](https://github.com/mattpoc
 
 1. **One question at a time.** Never batch. Each answer informs the next question.
 2. **Recommend an answer for every question.** Propose what you'd do and why, then confirm.
-3. **Explore before asking.** If the codebase can answer it, don't ask the contributor.
+3. **Finding facts is your job, not the user's.** If the codebase can answer it, don't ask the contributor.
 4. **Resolve dependencies in order.** When decision A constrains decision B, settle A first.
 5. **Stop only at shared understanding.** Continue until every branch of the design tree has a resolved answer.
 
@@ -37,6 +37,7 @@ Before launching any discovery, resolve every resource-like noun in the input to
 actual proto file. Run `ls proto/api/v2/*.proto` and match the input against filenames.
 
 Examples of why this matters:
+
 - "create a trigger run for a pipeline" → `trigger_run.proto` + `pipeline.proto`, NOT
   `pipeline_run.proto`. The input contains "run" and "pipeline" but the resource is
   TriggerRun, not PipelineRun.


### PR DESCRIPTION
The first invocation of ma-design-interview for onboarding a new pipeline action took a half hour. I took a look at the trace and claude code exclusively spawned Explore agents to build context.

Replaced the **Explore** keyword from interview approach and ran the skill again and it completed (with better output actually) in 10 minutes.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Ran skill without change & with change and noted output quality and duration

<!-- Does this PR introduce a breaking change? Check all that apply. -->
**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

