### PR TITLE
feat(python): add ma sandbox snapshot create/restore for CRD state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -345,3 +345,6 @@ python/test_mlflow_model_loading.py
 
 # Playwright MCP session artifacts
 .playwright-mcp/
+
+# Captured `ma sandbox snapshot create` output — local dev artifacts
+python/michelangelo/cli/sandbox/snapshots/

--- a/python/michelangelo/cli/sandbox/.gitignore
+++ b/python/michelangelo/cli/sandbox/.gitignore
@@ -1,0 +1,1 @@
+snapshots/

--- a/python/michelangelo/cli/sandbox/.gitignore
+++ b/python/michelangelo/cli/sandbox/.gitignore
@@ -1,1 +1,0 @@
-snapshots/

--- a/python/michelangelo/cli/sandbox/README.md
+++ b/python/michelangelo/cli/sandbox/README.md
@@ -34,6 +34,8 @@ ma sandbox --help
 | `ma sandbox stop` | Stop the k3d cluster (preserves data) |
 | `ma sandbox demo pipeline` | Run the pipeline demo against a running sandbox |
 | `ma sandbox demo inference` | Run the inference demo against a running sandbox |
+| `ma sandbox snapshot create` | Capture every Michelangelo CRD in the cluster to `snapshots/<timestamp>/` |
+| `ma sandbox snapshot restore <timestamp>` | Replay a previously captured snapshot into the cluster |
 
 ## Architecture
 
@@ -97,6 +99,17 @@ To skip Cadence, use `--workflow temporal` instead — Cadence is bundled with t
 ```bash
 ma sandbox create --include-experimental fluent-bit mlflow
 ```
+
+## Snapshotting Sandbox State
+
+`ma sandbox snapshot create` captures every Michelangelo custom resource (`Project`, `Pipeline`, `Model`, etc. — anything under the `michelangelo.api` group) in the cluster to `snapshots/<timestamp>/`, one YAML file per kind. Volatile fields (`resourceVersion`, `uid`, `ownerReferences`, etc.) are stripped so the snapshot can be re-applied cleanly; `status` is kept for reference.
+
+```bash
+ma sandbox snapshot create
+ma sandbox snapshot restore 20260807-143000
+```
+
+This is useful for capturing "here's what reproduces this issue" for a test plan or PR description — the resulting directory can be committed alongside a bug report, or just kept locally and restored later. It's scoped to CRDs only: MinIO artifacts, MySQL rows, Secrets/ConfigMaps, and workflow engine history are not captured.
 
 ## Pinning Image Tags
 

--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -9,6 +9,7 @@ import sys
 import tempfile
 import time
 import uuid
+from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
@@ -68,6 +69,37 @@ _helm_nodeport_map = [
     ("8090", ("ui", "service", "nodePort")),  # Michelangelo UI
     ("8088", ("cadence", "web", "service", "nodePort")),  # Cadence Web
     ("8080", ("temporal", "web", "service", "nodePort")),  # Temporal Web
+]
+
+# API group shared by every Michelangelo custom resource — used by
+# `ma sandbox snapshot` to discover CRD kinds dynamically instead of
+# hardcoding a list that would need updating as new CRDs are added.
+_snapshot_api_group = "michelangelo.api"
+
+# Volatile metadata fields stripped from a snapshotted resource so it can be
+# re-applied cleanly. `status` is deliberately left untouched: every
+# Michelangelo CRD registers `status` as a subresource, so `kubectl apply`
+# structurally cannot modify it regardless of what's in the file, and keeping
+# it gives a debugging reference for the state at capture time.
+_snapshot_strip_metadata_fields = [
+    "resourceVersion",
+    "uid",
+    "creationTimestamp",
+    "generation",
+    "selfLink",
+    "managedFields",
+    "ownerReferences",
+]
+
+# Annotations stripped from a snapshotted resource:
+# - last-applied-configuration is kubectl bookkeeping.
+# - MetadataStoragePrimaryKey is set once (idempotently) by the ingester
+#   controller and pinned to the object's original uid as its MySQL primary
+#   key. Left in place, a restored object's controller would never refresh
+#   it, silently decoupling the CRD's live uid from its DB row.
+_snapshot_strip_annotations = [
+    "kubectl.kubernetes.io/last-applied-configuration",
+    "michelangelo/MetadataStoragePrimaryKey",
 ]
 
 
@@ -233,6 +265,25 @@ def init_arguments(p: argparse.ArgumentParser):
         help=("Create a multi-cluster inference server demo."),
     )
 
+    snapshot_p = sp.add_parser(
+        "snapshot", help="Capture or restore Michelangelo CRD state."
+    )
+    snapshot_sp = snapshot_p.add_subparsers(dest="snapshot_action", required=True)
+    _ = snapshot_sp.add_parser(
+        "create", help="Capture all Michelangelo CRDs in the cluster to disk."
+    )
+    restore_p = snapshot_sp.add_parser(
+        "restore", help="Replay a previously captured snapshot into the cluster."
+    )
+    restore_p.add_argument(
+        "timestamp",
+        help=(
+            "Snapshot to restore — either the bare timestamp "
+            "(e.g. 20260807-170000) or the full path printed by "
+            "`snapshot create`."
+        ),
+    )
+
     delete_p = sp.add_parser("delete", help="Delete the cluster.")
     delete_p.add_argument(
         "--compute-cluster-name",
@@ -276,6 +327,8 @@ def run(ns: argparse.Namespace):
         return _stop(ns)
     if ns.action == "demo":
         return _create_demo_crs(ns)
+    if ns.action == "snapshot":
+        return _snapshot(ns)
 
     raise ValueError(f"Unsupported action: {ns.action}")
 
@@ -1152,13 +1205,8 @@ def _create_cadence_domain(links):
     sys.exit(result.returncode)
 
 
-def _create_demo_crs(ns: argparse.Namespace):
-    """Create demo Custom Resources (CRs) for the sandbox environment."""
-    assert ns
-    if ns.demo_action not in ("pipeline", "inference", "inference-multicluster"):
-        raise ValueError(f"Unsupported demo action: {ns.demo_action}")
-
-    # Check if cluster exists
+def _assert_sandbox_cluster_running():
+    """Ensure the sandbox cluster exists and is running, or exit with a hint."""
     try:
         _exec(
             "k3d",
@@ -1173,7 +1221,6 @@ def _create_demo_crs(ns: argparse.Namespace):
             "Please run 'ma sandbox create' first."
         )
 
-    # Check if cluster is running
     try:
         _exec("kubectl", "cluster-info", raise_error=True)
     except subprocess.CalledProcessError:
@@ -1181,6 +1228,15 @@ def _create_demo_crs(ns: argparse.Namespace):
             f"Cluster {_michelangelo_sandbox_kube_cluster_name} is not running. "
             "Please run 'ma sandbox start' first."
         )
+
+
+def _create_demo_crs(ns: argparse.Namespace):
+    """Create demo Custom Resources (CRs) for the sandbox environment."""
+    assert ns
+    if ns.demo_action != "pipeline" and ns.demo_action != "inference":
+        raise ValueError(f"Unsupported demo action: {ns.demo_action}")
+
+    _assert_sandbox_cluster_running()
 
     # Create CRs used by all demo resources
     demo_dir = _dir / "demo"
@@ -1210,6 +1266,143 @@ def _create_demo_crs(ns: argparse.Namespace):
         _create_inference_multicluster_demo_crs()
     else:
         raise ValueError(f"Unsupported demo action: {ns.demo_action}")
+
+
+def _snapshot(ns: argparse.Namespace):
+    """Dispatch `ma sandbox snapshot` to its create/restore action."""
+    assert ns
+    if ns.snapshot_action == "create":
+        return _snapshot_create(ns)
+    if ns.snapshot_action == "restore":
+        return _snapshot_restore(ns)
+    raise ValueError(f"Unsupported snapshot action: {ns.snapshot_action}")
+
+
+def _snapshot_kube_context() -> str:
+    return f"k3d-{_michelangelo_sandbox_kube_cluster_name}"
+
+
+def _snapshot_dir(timestamp: str) -> Path:
+    return _dir / "snapshots" / timestamp
+
+
+def _discover_michelangelo_kinds(context: str) -> list[str]:
+    """Discover plural resource names for every Michelangelo CRD in the cluster.
+
+    Uses `kubectl api-resources` rather than a hardcoded kind list so newly
+    added CRDs are picked up automatically.
+    """
+    result = subprocess.run(
+        [
+            "kubectl",
+            "--context",
+            context,
+            "api-resources",
+            f"--api-group={_snapshot_api_group}",
+            "-o",
+            "name",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def _strip_volatile_fields(item: dict):
+    """Strip volatile identity/bookkeeping fields from a resource in place."""
+    metadata = item.get("metadata", {})
+    for field in _snapshot_strip_metadata_fields:
+        metadata.pop(field, None)
+    annotations = metadata.get("annotations")
+    if annotations:
+        for key in _snapshot_strip_annotations:
+            annotations.pop(key, None)
+        if not annotations:
+            metadata.pop("annotations", None)
+
+
+def _snapshot_create(ns: argparse.Namespace):
+    """Capture every Michelangelo CRD in the cluster to a timestamped directory."""
+    assert ns
+    _assert_sandbox_cluster_running()
+    context = _snapshot_kube_context()
+
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    out_dir = _snapshot_dir(timestamp)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    captured_kinds = []
+    for kind in _discover_michelangelo_kinds(context):
+        result = subprocess.run(
+            ["kubectl", "--context", context, "get", kind, "-A", "-o", "yaml"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        doc = yaml.safe_load(result.stdout) or {}
+        items = doc.get("items") or []
+        if not items:
+            continue
+
+        for item in items:
+            _strip_volatile_fields(item)
+
+        kind_name = kind.split(".", 1)[0]
+        with open(out_dir / f"{kind_name}.yaml", "w") as f:
+            yaml.safe_dump(
+                {"apiVersion": "v1", "kind": "List", "items": items},
+                f,
+                sort_keys=False,
+            )
+        captured_kinds.append(kind_name)
+
+    print(f"\n📸 Snapshot captured at {out_dir}")
+    if captured_kinds:
+        print("Captured kinds:")
+        for kind_name in captured_kinds:
+            print(f"  - {kind_name}")
+    else:
+        print("No Michelangelo resources found in the cluster.")
+
+
+def _snapshot_restore(ns: argparse.Namespace):
+    """Replay a previously captured snapshot into the cluster.
+
+    `projects.yaml` (if present) is applied first, after ensuring each
+    project's namespace exists — namespaces are assumed to correspond 1:1
+    with projects. Every other `<kind>.yaml` file is then applied in any
+    order; nothing in the cluster enforces that a Project must exist before
+    other CRs are created, so this ordering is a courtesy, not a correctness
+    requirement.
+    """
+    assert ns
+    _assert_sandbox_cluster_running()
+    context = _snapshot_kube_context()
+
+    # Accept a bare timestamp ("20260807-104041") or a full/relative path to
+    # the snapshot directory (e.g. copy-pasted from `create`'s output) —
+    # only the final path segment is significant.
+    snapshot_path = _snapshot_dir(Path(ns.timestamp).name)
+    if not snapshot_path.is_dir():
+        _err_exit(f"Snapshot not found: {snapshot_path}")
+
+    projects_file = snapshot_path / "projects.yaml"
+    if projects_file.exists():
+        with open(projects_file) as f:
+            doc = yaml.safe_load(f) or {}
+        for project in doc.get("items") or []:
+            namespace = project.get("metadata", {}).get("namespace")
+            if namespace:
+                _ensure_namespace_exists(namespace)
+        _kube_apply(projects_file, context=context)
+
+    for yaml_file in sorted(snapshot_path.glob("*.yaml")):
+        if yaml_file == projects_file:
+            continue
+        _kube_apply(yaml_file, context=context)
+
+    print(f"\n✅ Restored snapshot from {snapshot_path}")
 
 
 def _delete(ns: argparse.Namespace):
@@ -1349,8 +1542,12 @@ def _sync_config_from_secret():
     )
 
 
-def _kube_apply(path: Path):
-    _exec("kubectl", "apply", "-f", str(path))
+def _kube_apply(path: Path, context: Optional[str] = None):
+    args = ["kubectl"]
+    if context:
+        args += ["--context", context]
+    args += ["apply", "-f", str(path)]
+    _exec(*args)
 
 
 def _apply_model_sync(is_name: str, context: Optional[str] = None):

--- a/python/michelangelo/cli/sandbox/sandbox_test.py
+++ b/python/michelangelo/cli/sandbox/sandbox_test.py
@@ -29,6 +29,75 @@ class SnapshotCreateTest(TestCase):
             written = list(snapshots_dir.glob("*/*.yaml"))
             self.assertEqual(written, [])
 
+    def test_create_writes_stripped_resource_and_keeps_status(self):
+        """Volatile fields are stripped from a captured resource, status kept."""
+        raw_pipeline_list = yaml.safe_dump(
+            {
+                "apiVersion": "v1",
+                "kind": "List",
+                "items": [
+                    {
+                        "apiVersion": "michelangelo.api/v2",
+                        "kind": "Pipeline",
+                        "metadata": {
+                            "name": "eval-pipeline",
+                            "namespace": "ma-dev-test",
+                            "uid": "c3eb9f45-0748-41f0-9415-f46b8b01ac5c",
+                            "resourceVersion": "1775",
+                            "creationTimestamp": "2026-07-30T20:45:45Z",
+                            "generation": 1,
+                            "ownerReferences": [{"name": "some-owner"}],
+                            "annotations": {
+                                "kubectl.kubernetes.io/last-applied-configuration": (
+                                    "{}"
+                                ),
+                                "michelangelo/MetadataStoragePrimaryKey": (
+                                    "c3eb9f45-0748-41f0-9415-f46b8b01ac5c"
+                                ),
+                                "michelangelo/worker_queue": "default",
+                            },
+                        },
+                        "spec": {"type": "PIPELINE_TYPE_EVAL"},
+                        "status": {"state": "PIPELINE_STATE_READY"},
+                    }
+                ],
+            }
+        )
+
+        def fake_run(args, **kwargs):
+            if "api-resources" in args:
+                return Mock(stdout="pipelines.michelangelo.api\n")
+            return Mock(stdout=raw_pipeline_list)
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with (
+                patch.object(sandbox, "_dir", Path(tmp_dir)),
+                patch.object(sandbox, "_assert_sandbox_cluster_running"),
+                patch.object(sandbox.subprocess, "run", side_effect=fake_run),
+            ):
+                sandbox._snapshot_create(argparse.Namespace())
+
+            written_files = list(Path(tmp_dir).glob("snapshots/*/pipelines.yaml"))
+            self.assertEqual(len(written_files), 1)
+
+            with open(written_files[0]) as f:
+                written = yaml.safe_load(f)
+
+            item = written["items"][0]
+            self.assertNotIn("uid", item["metadata"])
+            self.assertNotIn("resourceVersion", item["metadata"])
+            self.assertNotIn("creationTimestamp", item["metadata"])
+            self.assertNotIn("generation", item["metadata"])
+            self.assertNotIn("ownerReferences", item["metadata"])
+            annotations = item["metadata"]["annotations"]
+            self.assertNotIn(
+                "kubectl.kubernetes.io/last-applied-configuration", annotations
+            )
+            self.assertNotIn("michelangelo/MetadataStoragePrimaryKey", annotations)
+            self.assertEqual(annotations, {"michelangelo/worker_queue": "default"})
+            self.assertEqual(item["spec"], {"type": "PIPELINE_TYPE_EVAL"})
+            self.assertEqual(item["status"], {"state": "PIPELINE_STATE_READY"})
+
 
 class SnapshotRestoreTest(TestCase):
     """Test cases for `ma sandbox snapshot restore`."""

--- a/python/michelangelo/cli/sandbox/sandbox_test.py
+++ b/python/michelangelo/cli/sandbox/sandbox_test.py
@@ -1,0 +1,126 @@
+"""Scenario-level tests for `ma sandbox snapshot`."""
+
+import argparse
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+import yaml
+
+from michelangelo.cli.sandbox import sandbox
+
+
+class SnapshotCreateTest(TestCase):
+    """Test cases for `ma sandbox snapshot create`."""
+
+    def test_create_on_empty_sandbox_writes_no_files(self):
+        """No Michelangelo CRDs in the cluster -> snapshot dir has no yaml files."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with (
+                patch.object(sandbox, "_dir", Path(tmp_dir)),
+                patch.object(sandbox, "_assert_sandbox_cluster_running"),
+                patch.object(sandbox.subprocess, "run") as mock_run,
+            ):
+                mock_run.return_value = Mock(stdout="", returncode=0)
+                sandbox._snapshot_create(argparse.Namespace())
+
+            snapshots_dir = Path(tmp_dir) / "snapshots"
+            written = list(snapshots_dir.glob("*/*.yaml"))
+            self.assertEqual(written, [])
+
+
+class SnapshotRestoreTest(TestCase):
+    """Test cases for `ma sandbox snapshot restore`."""
+
+    def _write_kind_file(self, snapshot_dir: Path, filename: str, items: list):
+        with open(snapshot_dir / filename, "w") as f:
+            yaml.safe_dump({"apiVersion": "v1", "kind": "List", "items": items}, f)
+
+    def test_restore_resource_namespace_without_matching_project(self):
+        """A resource whose namespace has no Project in the snapshot still applies."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            snapshot_dir = Path(tmp_dir) / "snapshots" / "20260101-000000"
+            snapshot_dir.mkdir(parents=True)
+            self._write_kind_file(
+                snapshot_dir,
+                "projects.yaml",
+                [{"metadata": {"name": "known", "namespace": "known-ns"}}],
+            )
+            self._write_kind_file(
+                snapshot_dir,
+                "pipelines.yaml",
+                [{"metadata": {"name": "orphan-pipeline", "namespace": "orphan-ns"}}],
+            )
+
+            with (
+                patch.object(sandbox, "_dir", Path(tmp_dir)),
+                patch.object(sandbox, "_assert_sandbox_cluster_running"),
+                patch.object(sandbox, "_ensure_namespace_exists") as mock_ensure_ns,
+                patch.object(sandbox, "_kube_apply") as mock_apply,
+            ):
+                sandbox._snapshot_restore(
+                    argparse.Namespace(timestamp="20260101-000000")
+                )
+
+            # Only the namespace backed by a Project is proactively ensured —
+            # the orphan namespace is left to already exist or to fail at
+            # apply time, not treated as a restore-blocking error.
+            mock_ensure_ns.assert_called_once_with("known-ns")
+
+            applied_paths = {call.args[0].name for call in mock_apply.call_args_list}
+            self.assertEqual(applied_paths, {"projects.yaml", "pipelines.yaml"})
+
+    def test_restore_with_no_projects_file_skips_namespace_ensure(self):
+        """No projects.yaml in snapshot -> everything applies, no namespace setup."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            snapshot_dir = Path(tmp_dir) / "snapshots" / "20260101-000000"
+            snapshot_dir.mkdir(parents=True)
+            self._write_kind_file(
+                snapshot_dir,
+                "pipelines.yaml",
+                [{"metadata": {"name": "some-pipeline", "namespace": "some-ns"}}],
+            )
+
+            with (
+                patch.object(sandbox, "_dir", Path(tmp_dir)),
+                patch.object(sandbox, "_assert_sandbox_cluster_running"),
+                patch.object(sandbox, "_ensure_namespace_exists") as mock_ensure_ns,
+                patch.object(sandbox, "_kube_apply") as mock_apply,
+            ):
+                sandbox._snapshot_restore(
+                    argparse.Namespace(timestamp="20260101-000000")
+                )
+
+            mock_ensure_ns.assert_not_called()
+            applied_paths = {call.args[0].name for call in mock_apply.call_args_list}
+            self.assertEqual(applied_paths, {"pipelines.yaml"})
+
+    def test_restore_accepts_full_path_not_just_bare_timestamp(self):
+        """A full/relative path (e.g. copy-pasted from `create`'s output) works too."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            snapshot_dir = Path(tmp_dir) / "snapshots" / "20260101-000000"
+            snapshot_dir.mkdir(parents=True)
+            self._write_kind_file(snapshot_dir, "pipelines.yaml", [])
+
+            full_path = "michelangelo/cli/sandbox/snapshots/20260101-000000"
+            with (
+                patch.object(sandbox, "_dir", Path(tmp_dir)),
+                patch.object(sandbox, "_assert_sandbox_cluster_running"),
+                patch.object(sandbox, "_kube_apply") as mock_apply,
+            ):
+                sandbox._snapshot_restore(argparse.Namespace(timestamp=full_path))
+
+            mock_apply.assert_called_once()
+
+    def test_restore_missing_snapshot_directory_errors(self):
+        """Restoring a nonexistent timestamp exits with an error, not a crash."""
+        with (
+            tempfile.TemporaryDirectory() as tmp_dir,
+            patch.object(sandbox, "_dir", Path(tmp_dir)),
+            patch.object(sandbox, "_assert_sandbox_cluster_running"),
+            patch.object(sandbox, "_err_exit", side_effect=SystemExit(1)) as mock_err,
+            self.assertRaises(SystemExit),
+        ):
+            sandbox._snapshot_restore(argparse.Namespace(timestamp="does-not-exist"))
+        mock_err.assert_called_once()


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

Adds `ma sandbox snapshot create` and `ma sandbox snapshot restore <timestamp>`. `create` discovers every Michelangelo custom resource in the running sandbox via the shared `michelangelo.api` API group (no hardcoded kind list), strips identity/bookkeeping fields that would otherwise block a clean re-apply, and writes one YAML file per kind to a timestamped directory. `restore` replays a captured snapshot back into a cluster, applying any captured Projects first and ensuring their namespaces exist along the way. `status` is intentionally left in the captured files for debugging reference.

**Why?**

There was no way to capture a sandbox's actual state and hand it to someone else to reproduce — a test plan or bug report could only describe a pipeline config or model setup in prose. This lets you capture what's really running and share (or restore) it directly.

**How did you test it?**
**Full successful flow: create & restore** after deleting single resource

https://github.com/user-attachments/assets/06098cf7-b0ac-4bca-a4a1-547b491a4fb3

**Full successful flow: create & restore** after deleting namespace

https://github.com/user-attachments/assets/47d3f533-49e7-424b-ae89-80e7b62c0630

**Handles empty sandbox**

https://github.com/user-attachments/assets/ceb620e5-2c67-4934-aabf-61b6923a0e95

**Errors with message** when sandbox is not running

<img width="1392" height="1072" alt="Screenshot 2026-08-07 at 10 53 24 AM" src="https://github.com/user-attachments/assets/05307db0-6414-48f2-a963-b385b205ad1f" />

**Potential risks**

Restore applies resources directly via `kubectl apply` against whatever cluster the sandbox context points at — scoped to the sandbox's own k3d context, so it shouldn't be able to affect other clusters.

**Breaking Changes**

- [x] No breaking changes
