### PR TITLE
refactor(uniflow): move JSONData out of canvas into lib/shared

### DIFF
--- a/python/michelangelo/canvas/lib/shared/json_data/__init__.py
+++ b/python/michelangelo/canvas/lib/shared/json_data/__init__.py
@@ -1,4 +1,0 @@
-from .json_data import JSONData
-from .field import field, one_of
-
-__all__ = ["JSONData", "field", "one_of"]

--- a/python/michelangelo/canvas/lib/shared/json_data/tests/__init__.py
+++ b/python/michelangelo/canvas/lib/shared/json_data/tests/__init__.py
@@ -1,1 +1,0 @@
-# Test package for JSONData

--- a/python/michelangelo/lib/shared/json_data/__init__.py
+++ b/python/michelangelo/lib/shared/json_data/__init__.py
@@ -1,0 +1,6 @@
+"""JSONData base class and field helpers for structured configuration."""
+
+from .field import field, one_of
+from .json_data import JSONData
+
+__all__ = ["JSONData", "field", "one_of"]

--- a/python/michelangelo/lib/shared/json_data/field.py
+++ b/python/michelangelo/lib/shared/json_data/field.py
@@ -1,4 +1,7 @@
+"""Field descriptors and one-of constraints for JSONData models."""
+
 from typing import Any, Optional
+
 import pydantic
 from pydantic_core import PydanticUndefined
 
@@ -14,20 +17,20 @@ def field(
     min_length: Optional[int] = PydanticUndefined,
     max_length: Optional[int] = PydanticUndefined,
 ) -> Any:
-    """
-    Specify the default value and / or validation rules for a field.
-    Similar to dataclasses.field() and pydantic.field().
+    """Specify the default value and validation rules for a field.
 
-    :param default: default value for the field. If set to ellipsis(...), the field will have no default value, and
-                    users must specify a value. If not set, the default value will be inferred from the field type.
-                    (i.e. 0 for int, 0.0 for float, False for bool, "" for str, Class() for user defined class, etc.)
-    :param pattern: regular expression pattern used to validate str field.
-    :param gt: greater than
-    :param ge: greater or equal than
-    :param lt: less than
-    :param le: less or equal than
-    :param min_length: minimum length of a list, str, or dict field
-    :param max_length: maximum length of a list, str, or dict field
+    Similar to ``dataclasses.field()`` and ``pydantic.Field()``.
+
+    Args:
+        default: Default value for the field. Ellipsis (``...``)
+            means required. If omitted, inferred from the type.
+        pattern: Regex pattern to validate a str field.
+        gt: Greater than.
+        ge: Greater than or equal.
+        lt: Less than.
+        le: Less than or equal.
+        min_length: Minimum length of a list, str, or dict field.
+        max_length: Maximum length of a list, str, or dict field.
     """
     json_data_info = {}
     if default is Ellipsis:
@@ -52,10 +55,12 @@ class _OneOf(pydantic.BaseModel):
 
 
 def one_of(fields: list[str], required: bool = True) -> _OneOf:
-    """
-    Specify a one of validation rule. At most one field in the fields list may be set (not None).
-    :param fields: A list of field names.
-    :param required: If True, at least one field in the fields list must be not None.
-    :return:
+    """Specify a one-of validation rule.
+
+    At most one field in the list may be set (not None).
+
+    Args:
+        fields: A list of field names.
+        required: If True, at least one field must be not None.
     """
     return _OneOf(fields=fields, required=required)

--- a/python/michelangelo/lib/shared/json_data/json_data.py
+++ b/python/michelangelo/lib/shared/json_data/json_data.py
@@ -1,52 +1,49 @@
+"""JSONData base model with constrained pydantic features for uniflow."""
+
 import typing
 from enum import Enum
 
 import pydantic
-from pydantic import BaseModel, ConfigDict, model_serializer, SerializationInfo
+from pydantic import BaseModel, ConfigDict, SerializationInfo, model_serializer
 from pydantic.fields import FieldInfo
 from pydantic_core import PydanticUndefined
 
-from michelangelo.canvas.lib.shared.json_data.field import field, _OneOf
+from michelangelo.lib.shared.json_data.field import _OneOf, field
 
 
 class JSONData(BaseModel):
-    """
-    Base class for all canvas 2.0 configuration classes.
+    """Base class for structured configuration classes.
 
-    This class is a subclass of pydantic.BaseModel, it
-        1) adds support of default values for fields based on field types
-        2) adds support of "one of"
-        3) only allows a subset of pydantic features that can be safely supported in uniflow go service and starlark
+    Subclass of ``pydantic.BaseModel`` that:
+
+    1. Adds default values for fields based on their types.
+    2. Adds ``one_of`` mutual-exclusion constraints.
+    3. Restricts pydantic features to what uniflow's Go service
+       and Starlark can safely support.
     """
 
     def __init_subclass__(cls, **kwargs):
+        """Validate field types and register one-of constraints."""
         for base in cls.__bases__:
             if JSONData != base and not issubclass(base, JSONData):
                 raise TypeError(
-                    f"{base.__name__} is not a subclass of {JSONData.__name__}. "
-                    f"{JSONData.__name__} classes can only inherit from {JSONData.__name__} or its subclasses."
+                    f"{base.__name__} is not a subclass of"
+                    f" {JSONData.__name__}. {JSONData.__name__}"
+                    f" classes can only inherit from"
+                    f" {JSONData.__name__} or its subclasses."
                 )
 
-        # check field types and assign default values
         fields = {}
         annotations = typing.get_type_hints(cls)
         for field_name, field_type in annotations.items():
             if field_name.startswith("_"):
                 continue
-            # raise exceptions if field_type is not supported
             type_info = _get_type_info(field_name, field_type)
 
             if field_name in cls.__dict__:
-                # field has either field info or default set
                 v = getattr(cls, field_name)
-                if isinstance(v, FieldInfo):
-                    # user set field_info
-                    field_info = v
-                else:
-                    # user set default value
-                    field_info = field(default=v)
+                field_info = v if isinstance(v, FieldInfo) else field(default=v)
             else:
-                # user did not set either field info or default value
                 field_info = field()
 
             if (
@@ -58,7 +55,6 @@ class JSONData(BaseModel):
             field_info.json_schema_extra["json_data_field"] |= type_info
             fields[field_name] = (field_type, field_info)
 
-        # add "one of" to json_schema_extra, we will validate "one of" in pydantic.model_validator: cls.__validate__
         json_data_info = {}
         for attr_name, v in cls.__private_attributes__.items():
             if isinstance(v.default, _OneOf):
@@ -66,13 +62,17 @@ class JSONData(BaseModel):
                 for f in oneof.fields:
                     if f not in fields:
                         raise ValueError(
-                            f"Field in one_of '{attr_name}' does not exist. No field named '{f}' in class {cls.__name__}."
+                            f"Field in one_of '{attr_name}' does"
+                            f" not exist. No field named '{f}'"
+                            f" in class {cls.__name__}."
                         )
                     f_info = fields[f][1]
                     if not f_info.json_schema_extra["json_data_field"].get("nullable"):
                         raise TypeError(
-                            f"Field '{f}' in one_of '{attr_name}' is not optional. "
-                            "All the fields in oneof must be optional (nullable)."
+                            f"Field '{f}' in one_of"
+                            f" '{attr_name}' is not optional."
+                            " All the fields in oneof must be"
+                            " optional (nullable)."
                         )
                 one_of_list = json_data_info.get("oneof", [])
                 one_of_list.append(oneof.model_dump())
@@ -86,11 +86,12 @@ class JSONData(BaseModel):
     def serialize_model(
         self, handler, info: SerializationInfo
     ) -> dict[str, typing.Any]:
+        """Serialize with optional UniflowCodec metadata."""
         dump = handler(self, info)
         if info.context and info.context.get("UniflowCodec", False):
             dump |= {
                 "__codec__": "dataclass",
-                "__class__": f"{type(self).__module__}.{type(self).__name__}",
+                "__class__": (f"{type(self).__module__}.{type(self).__name__}"),
             }
         return dump
 
@@ -100,38 +101,38 @@ def _get_type_info(
 ) -> dict[str, typing.Any]:
     origin = typing.get_origin(field_type)
 
-    # <type> | None or typing.Optional[type]
     if origin is typing.Union:
         if position in ["List item", "Dict value"]:
             raise TypeError(
-                f"{position} type '{field_type}' is not supported in JSONData class. Field: '{field_name}'"
+                f"{position} type '{field_type}' is not"
+                f" supported in JSONData class."
+                f" Field: '{field_name}'"
             )
         type_list = typing.get_args(field_type)
         if len(type_list) > 2 or type(None) not in type_list:
             raise TypeError(
-                f"Field type '{field_type}' is not supported in JSONData class. Field: '{field_name}'"
+                f"Field type '{field_type}' is not supported"
+                f" in JSONData class. Field: '{field_name}'"
             )
         type_info = _get_type_info(
-            field_name, next(iter(t for t in type_list if t is not type(None)))
+            field_name,
+            next(iter(t for t in type_list if t is not type(None))),
         )
         type_info["nullable"] = True
         return type_info
 
-    # simple types
     if field_type in [bool, int, float, str]:
         return {"type": field_type.__name__}
 
-    # enum
     if isinstance(field_type, type) and issubclass(field_type, Enum):
-        # String enum
         if issubclass(field_type, str):
             return {"type": field_type.__name__}
         raise TypeError(
-            f"Enum type {field_type} is not supported in JSONData class. "
-            f"Only string Enum is supported. Field: '{field_name}'"
+            f"Enum type {field_type} is not supported in"
+            f" JSONData class. Only string Enum is supported."
+            f" Field: '{field_name}'"
         )
 
-    # JSONData class
     if (
         origin is None
         and isinstance(field_type, type)
@@ -168,7 +169,9 @@ def _get_type_info(
 
         if key_type is not str:
             raise TypeError(
-                f"Invalid dictionary type: {field_type}. Dictionary keys must be strings. Field: '{field_name}'"
+                f"Invalid dictionary type: {field_type}."
+                " Dictionary keys must be strings."
+                f" Field: '{field_name}'"
             )
 
         return {
@@ -181,7 +184,8 @@ def _get_type_info(
         return {"type": "any"}
 
     raise TypeError(
-        f"{position} type {field_type} is not supported in JSONData class. Field: '{field_name}'"
+        f"{position} type {field_type} is not supported in"
+        f" JSONData class. Field: '{field_name}'"
     )
 
 
@@ -190,14 +194,9 @@ def _get_default_value(type_info: dict[str, str], field_type: type) -> typing.An
         return None
 
     t = type_info["type"]
-    if t == "bool":
-        return False
-    elif t == "int":
-        return 0
-    elif t == "float":
-        return 0.0
-    elif t == "str":
-        return ""
+    defaults = {"bool": False, "int": 0, "float": 0.0, "str": ""}
+    if t in defaults:
+        return defaults[t]
 
     origin = typing.get_origin(field_type)
     if origin is None and isinstance(field_type, type):
@@ -215,10 +214,7 @@ def _get_default_value(type_info: dict[str, str], field_type: type) -> typing.An
 
 
 def _validate_model_(self: BaseModel):
-    """
-    This function will be called by pydantic.BaseModel to do the json_data specific validations.
-    (currently, only oneof validation)
-    """
+    """Run json_data-specific validations (oneof constraints)."""
     one_of_list = self.model_config["json_schema_extra"]["json_data_object"].get(
         "oneof", []
     )
@@ -229,6 +225,7 @@ def _validate_model_(self: BaseModel):
             raise ValueError(f"One field in {one_of.fields} must be set (not None).")
         if len(set_fields) > 1:
             raise ValueError(
-                f"More than one field in {one_of.fields} are set (not None): {set_fields}."
+                f"More than one field in {one_of.fields}"
+                f" are set (not None): {set_fields}."
             )
     return self

--- a/python/michelangelo/lib/shared/json_data/tests/__init__.py
+++ b/python/michelangelo/lib/shared/json_data/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package for JSONData."""

--- a/python/michelangelo/lib/shared/json_data/tests/field_test.py
+++ b/python/michelangelo/lib/shared/json_data/tests/field_test.py
@@ -1,11 +1,17 @@
-import pydantic
+"""Tests for the ``field`` and ``one_of`` helpers."""
+
 from unittest import TestCase
 
-from michelangelo.canvas.lib.shared.json_data.field import field, one_of
+import pydantic
+
+from michelangelo.lib.shared.json_data.field import field, one_of
 
 
 class TestField(TestCase):
+    """Verify field() and one_of() produce correct FieldInfo."""
+
     def test__field(self):
+        """Check default, required, and constraint metadata."""
         f = field()
         self.assertTrue(isinstance(f, pydantic.fields.FieldInfo))
         self.assertTrue(len(f.json_schema_extra["json_data_field"]) == 0)
@@ -35,6 +41,7 @@ class TestField(TestCase):
         self.assertTrue("pattern='\\\\w+'" in str_repr)
 
     def test__one_of(self):
+        """Check one_of creates correct _OneOf instances."""
         f = one_of(fields=["f1", "f2"], required=True)
         self.assertTrue(f.required)
         self.assertListEqual(f.fields, ["f1", "f2"])

--- a/python/michelangelo/lib/shared/json_data/tests/json_data_test.py
+++ b/python/michelangelo/lib/shared/json_data/tests/json_data_test.py
@@ -1,22 +1,27 @@
-from enum import Enum
+"""Tests for the JSONData base model."""
+
 import json
 import typing
+from enum import Enum
 from typing import Optional
+from unittest import TestCase
 
 import pydantic
 
-from michelangelo.canvas.lib.shared.json_data import field, one_of, JSONData
-
-from unittest import TestCase
+from michelangelo.lib.shared.json_data import JSONData, field, one_of
 
 
 class FruitEnum(str, Enum):
+    """String enum for test fixtures."""
+
     pear = "pear"
     banana = "banana"
     apple = "apple"
 
 
 class C(JSONData):
+    """Simple JSONData subclass for testing inheritance."""
+
     c0: int = field(default=0)
     c1: str = field(default="")
     c2: float = field(default=0.0)
@@ -24,28 +29,23 @@ class C(JSONData):
 
 
 class B(C):
+    """JSONData subclass inheriting from C."""
+
     b0: int = field(default=0)
     b1: str = field(default="b1")
     list0: list[int] = field(default=[])
 
 
 class A(JSONData):
-    # Default value of an int field is 0 is not otherwise specified
+    """Full-featured JSONData subclass exercising all field types."""
+
     num1: int = field(default=0)
-    # Optional field is annotated as '<type> | None'.
-    # If not specified, the default value of optional field is None.
     num3: Optional[int] = field(default=None)
-    # set default value and validation rules using field
-    # a float number in [0.0, 1.0)
     num4: float = field(default=0.5, ge=0.0, lt=1.0)
-    # set default value to ... requires users explicitly set this field
     num5: int = field(default=...)
 
-    # one and only one filed in the list must be set (not None)
     _one_of_str12 = one_of(fields=["str1", "str2"], required=True)
-    # optional string field <= 30 characters
     str1: Optional[str] = field(default=None, max_length=30)
-    # optional string field validated with a regular expression
     str2: Optional[str] = field(default=None, pattern=r"\w+")
 
     _one_of_n132 = one_of(fields=["f1", "f2", "f3"], required=False)
@@ -53,14 +53,11 @@ class A(JSONData):
     f2: Optional[float] = field(default=None)
     f3: Optional[int] = field(default=None)
 
-    # default value of bool field is false
     bool1: bool = field(default=False)
 
-    # Only support string enum. If not specified, the default is the 1st member of the enum.
     enum1: FruitEnum = field(default=FruitEnum.banana)
     enum2: FruitEnum = field(default=FruitEnum.pear)
 
-    # another JSONData class. The default value is B()
     b0: B = field(default=B(c0=0, c1="", c2=0.0, b0=0, list0=[]))
     b1: Optional[B] = field(default=B(c0=1, c1="test", c2=1.0, b0=2, list0=[]))
 
@@ -74,8 +71,10 @@ class A(JSONData):
 
 
 class TestJSONData(TestCase):
+    """Verify JSONData construction, validation, and serialization."""
+
     def test__json_data(self):
-        # Test basic functionality
+        """Check default values, types, and nested objects."""
         a = A(num5=100, str1="hello")
         self.assertEqual(a.num1, 0)
         self.assertEqual(a.num3, None)
@@ -85,11 +84,11 @@ class TestJSONData(TestCase):
         self.assertEqual(a.str2, None)
         self.assertFalse(a.bool1)
         self.assertEqual(a.enum1, FruitEnum.banana)
-        self.assertEqual(a.enum2, FruitEnum.pear)  # First enum value as default
+        self.assertEqual(a.enum2, FruitEnum.pear)
         self.assertIsInstance(a.b0, B)
-        self.assertEqual(a.b0.c0, 0)  # From C parent class
-        self.assertEqual(a.b0.c1, "")  # From C parent class
-        self.assertEqual(a.b0.c2, 0.0)  # From C parent class
+        self.assertEqual(a.b0.c0, 0)
+        self.assertEqual(a.b0.c1, "")
+        self.assertEqual(a.b0.c2, 0.0)
         self.assertEqual(a.b0.b0, 0)
         self.assertEqual(a.b0.b1, "b1")
         self.assertEqual(a.b0.list0, [])
@@ -105,27 +104,24 @@ class TestJSONData(TestCase):
         self.assertEqual(a.any0, None)
         self.assertEqual(a.list_any, [])
 
-        # Test validation
         with self.assertRaises(pydantic.ValidationError):
-            A(num5=100)  # Missing required one_of field
+            A(num5=100)
 
     def test__one_of(self):
-        # Test one_of validation
+        """Check one-of mutual exclusion constraints."""
         a = A(num5=100, str1="hello")
         self.assertEqual(a.str1, "hello")
         self.assertEqual(a.str2, None)
 
-        # Test with str2 instead
         a2 = A(num5=100, str2="world")
         self.assertEqual(a2.str1, None)
         self.assertEqual(a2.str2, "world")
 
-        # Test validation error when both are set
         with self.assertRaises(pydantic.ValidationError):
             A(num5=100, str1="hello", str2="world")
 
     def test__type_errors(self):
-        # Test various type validation errors
+        """Check that unsupported types raise TypeError."""
         with self.assertRaises(TypeError):
 
             class A:
@@ -157,13 +153,12 @@ class TestJSONData(TestCase):
                 a: IntEnum
 
     def test__serialize_model(self):
-        # Test serialization
+        """Check model_dump and JSON serialization."""
         a = A(num5=100, str1="hello")
         data = a.model_dump()
         self.assertIn("num5", data)
         self.assertEqual(data["num5"], 100)
         self.assertEqual(data["str1"], "hello")
 
-        # Test JSON serialization
         json_str = json.dumps(data)
         self.assertIn('"num5": 100', json_str)

--- a/python/michelangelo/uniflow/registration/config_builder.py
+++ b/python/michelangelo/uniflow/registration/config_builder.py
@@ -11,11 +11,11 @@ import json
 import logging
 import os
 from contextlib import contextmanager
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Optional
 
 import yaml
 
-from michelangelo.canvas.lib.shared.json_data import JSONData
+from michelangelo.lib.shared.json_data import JSONData
 from michelangelo.uniflow.core.utils import import_attribute
 
 _logger = logging.getLogger(__name__)
@@ -54,7 +54,7 @@ class ConfigBuilder:
     """Builder for workflow configuration and metadata extraction."""
 
     def __init__(
-        self, workflow_function_obj: Callable, config_data: Optional[Dict] = None
+        self, workflow_function_obj: Callable, config_data: Optional[dict] = None
     ):
         """Initialize ConfigBuilder with workflow function and optional config.
 
@@ -84,7 +84,7 @@ class ConfigBuilder:
         _logger.info("Creating ConfigBuilder from config file: %s", config_file_path)
 
         # Read YAML configuration
-        with open(config_file_path, "r") as f:
+        with open(config_file_path) as f:
             config = yaml.safe_load(f)
 
         # Extract manifest path
@@ -113,7 +113,8 @@ class ConfigBuilder:
         """Discover workflow function from manifest path.
 
         Args:
-            manifest_path: Module path like "module.submodule:function" or "module.submodule"
+            manifest_path: Module path like "module.submodule:function" or
+                "module.submodule"
 
         Returns:
             Callable: The discovered workflow function
@@ -136,8 +137,9 @@ class ConfigBuilder:
                 return workflow_function
             except (ImportError, AttributeError) as e:
                 raise ImportError(
-                    f"Could not import workflow function {function_name} from {module_path}: {e}"
-                )
+                    f"Could not import workflow function {function_name} "
+                    f"from {module_path}: {e}"
+                ) from e
         else:
             # No function specified, import module and find workflow function
             module_path = manifest_path
@@ -148,13 +150,17 @@ class ConfigBuilder:
                 workflow_functions = []
                 for attr_name in dir(module):
                     attr = getattr(module, attr_name)
-                    if callable(attr) and hasattr(attr, "__name__"):
-                        # Check if it's decorated with @workflow (look for workflow decorator metadata)
-                        if (
+                    # Check if it's decorated with @workflow (look for
+                    # workflow decorator metadata)
+                    if (
+                        callable(attr)
+                        and hasattr(attr, "__name__")
+                        and (
                             hasattr(attr, "_workflow_config")
                             or "workflow" in attr_name.lower()
-                        ):
-                            workflow_functions.append((attr_name, attr))
+                        )
+                    ):
+                        workflow_functions.append((attr_name, attr))
 
                 if len(workflow_functions) == 0:
                     raise ValueError(
@@ -183,9 +189,9 @@ class ConfigBuilder:
                     return workflow_function
 
             except (ImportError, AttributeError) as e:
-                raise ImportError(f"Could not import module {module_path}: {e}")
+                raise ImportError(f"Could not import module {module_path}: {e}") from e
 
-    def _build_workflow_config(self) -> Dict[str, Any]:
+    def _build_workflow_config(self) -> dict[str, Any]:
         """Build workflow configuration from function and config data."""
         # Get function signature
         sig = inspect.signature(self._workflow_function_obj)
@@ -241,7 +247,10 @@ class ConfigBuilder:
     @property
     def workflow_function(self) -> str:
         """Get the workflow function name as string."""
-        return f"{self._workflow_function_obj.__module__}.{self._workflow_function_obj.__name__}"
+        return (
+            f"{self._workflow_function_obj.__module__}."
+            f"{self._workflow_function_obj.__name__}"
+        )
 
     @property
     def workflow_function_obj(self) -> Callable:
@@ -277,7 +286,7 @@ class ConfigBuilder:
             # Get the module file path
             module_file = module.__file__
             if module_file and os.path.exists(module_file):
-                with open(module_file, "r") as f:
+                with open(module_file) as f:
                     source = f.read()
 
                 # Parse the AST to find ctx.run calls
@@ -285,26 +294,24 @@ class ConfigBuilder:
 
                 for node in ast.walk(tree):
                     # Look for calls like: ctx.run(train_workflow, param=value)
+                    # that invoke our workflow function
                     if (
                         isinstance(node, ast.Call)
                         and isinstance(node.func, ast.Attribute)
                         and isinstance(node.func.value, ast.Name)
                         and node.func.value.id == "ctx"
                         and node.func.attr == "run"
+                        and len(node.args) > 0
+                        and isinstance(node.args[0], ast.Name)
+                        and node.args[0].id == self._workflow_function_obj.__name__
                     ):
-                        # Check if this is calling our workflow function
-                        if (
-                            len(node.args) > 0
-                            and isinstance(node.args[0], ast.Name)
-                            and node.args[0].id == self._workflow_function_obj.__name__
-                        ):
-                            # Extract keyword arguments from the ctx.run call
-                            for keyword in node.keywords:
-                                if isinstance(keyword.value, ast.Constant):
-                                    kwargs[keyword.arg] = keyword.value.value
-                                elif isinstance(keyword.value, ast.Str):  # Python < 3.8
-                                    kwargs[keyword.arg] = keyword.value.s
-                            break
+                        # Extract keyword arguments from the ctx.run call
+                        for keyword in node.keywords:
+                            if isinstance(keyword.value, ast.Constant):
+                                kwargs[keyword.arg] = keyword.value.value
+                            elif isinstance(keyword.value, ast.Str):  # Python < 3.8
+                                kwargs[keyword.arg] = keyword.value.s
+                        break
 
         except Exception as e:
             _logger.warning("Could not extract kwargs from ctx.run calls: %s", e)
@@ -332,7 +339,7 @@ class ConfigBuilder:
             # Get the module file path
             module_file = module.__file__
             if module_file and os.path.exists(module_file):
-                with open(module_file, "r") as f:
+                with open(module_file) as f:
                     source = f.read()
 
                 # Parse the AST to find ctx.environ assignments


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Ports `JSONData` (base class for canvas-2.0-style config classes, constraining pydantic to what uniflow's Go service and Starlark can safely support) and its `field()`/`_OneOf` helper out of `python/michelangelo/canvas/lib/shared/json_data/` into `python/michelangelo/lib/shared/json_data/`, mirroring the existing `lib/shared/utils/` submodule pattern. Updates `uniflow/registration/config_builder.py`'s import to the new path — it's the one live consumer, used in `ConfigEncoder.default()`'s `isinstance(obj, JSONData)` check. Also fixes 14 pre-existing ruff findings in `config_builder.py` (raise-from, `dict`/`Dict`, line length, nested-if), surfaced because CI lints the whole content of any touched file, not just the diff.

Pure move + import-path fix; no behavior change.

**Why?**

`canvas/` no longer aligns with the current repo structure — all canvas SDKs are meant to live under `python/michelangelo/lib`. `JSONData` was the one dependency still living in `canvas/` with real external consumers, so it needs a new home consistent with that convention before `canvas/` can be deleted. Stacked on #1727 (deletes the rest of dead `canvas/` code) so this move happens only after the only other internal-canvas consumer of the old path is already gone — avoids leaving stale imports in files that would otherwise need patching just to be deleted one PR later.

**How did you test it?**

- Relocated `json_data` tests: 6/6 pass (`pytest michelangelo/lib/shared/json_data/tests/`)
- `ruff check` on `lib/shared/json_data/` and `config_builder.py`: all checks passed
- `ruff format --check` on the same files: already formatted
- `pytest --collect-only` on `canvas/` + `uniflow/registration/`: zero errors
- Fresh repo-wide `grep -rln "canvas" --include="*.py"`: one hit, the known unrelated `"canvasflex-pusher"` string literal

**Potential risks**

Low. Pure move + import-path fix, no logic change to `JSONData`/`field`/`_OneOf`. `config_builder.py`'s pre-existing ruff findings were fixed as part of this touch, verified against the pre-change file to confirm no regressions were introduced.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

N/A

**Documentation Changes**

N/A