### PR TITLE
feat(model): add Model API-hook wiring skeleton (Phase 0)

### DIFF
--- a/go/cmd/apiserver/BUILD.bazel
+++ b/go/cmd/apiserver/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//go/base/config:go_default_library",
         "//go/base/env:go_default_library",
         "//go/base/zapfx:go_default_library",
+        "//go/components/model/apihook:go_default_library",
         "//go/components/pipelinerun/apihook:go_default_library",
         "//go/components/project/apihook:go_default_library",
         "//go/components/triggerrun/apihook:go_default_library",

--- a/go/cmd/apiserver/main.go
+++ b/go/cmd/apiserver/main.go
@@ -7,6 +7,7 @@ import (
 	baseconfig "github.com/michelangelo-ai/michelangelo/go/base/config"
 	"github.com/michelangelo-ai/michelangelo/go/base/env"
 	"github.com/michelangelo-ai/michelangelo/go/base/zapfx"
+	modelapihook "github.com/michelangelo-ai/michelangelo/go/components/model/apihook"
 	pipelinerunapihook "github.com/michelangelo-ai/michelangelo/go/components/pipelinerun/apihook"
 	projectapihook "github.com/michelangelo-ai/michelangelo/go/components/project/apihook"
 	triggerrunapihook "github.com/michelangelo-ai/michelangelo/go/components/triggerrun/apihook"
@@ -49,6 +50,7 @@ func opts() fx.Option {
 		// Cascade-delete: stamp the owning Pipeline ownerReference on runs at creation.
 		fx.Invoke(pipelinerunapihook.RegisterPipelineRunAPIHook),
 		fx.Invoke(triggerrunapihook.RegisterTriggerRunAPIHook),
+		fx.Invoke(modelapihook.RegisterModelAPIHook),
 		v2pb.CachedOutputSvcModule,
 		v2pb.ClusterSvcModule,
 		v2pb.DeploymentSvcModule,

--- a/go/components/model/apihook/BUILD.bazel
+++ b/go/components/model/apihook/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["apihook.go"],
+    importpath = "github.com/michelangelo-ai/michelangelo/go/components/model/apihook",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//go/api:go_default_library",
+        "//proto/api/v2:go_default_library",
+        "@org_uber_go_zap//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["apihook_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//proto/api/v2:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+    ],
+)

--- a/go/components/model/apihook/apihook.go
+++ b/go/components/model/apihook/apihook.go
@@ -1,0 +1,48 @@
+// Package apihook registers the Model API hook used to default and inherit
+// the environment label on Models at create/update time. See
+// go/components/pipelinerun/apihook and go/components/triggerrun/apihook for
+// the sibling packages this one follows the shape of.
+//
+// Phase 0 (this file, initial commit): wiring-only skeleton. BeforeCreate and
+// BeforeUpdate pass through to the embedded NoopModelAPIHook with zero
+// behavior change. Label-defaulting/inheritance logic is added in a
+// follow-up commit (see specs/001-environment-label/phase1_plan.md in the
+// migration-planning harness for that commit's design).
+package apihook
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+
+	"github.com/michelangelo-ai/michelangelo/go/api"
+	v2 "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
+)
+
+// RegisterModelAPIHook registers the API hook responsible for Model
+// create/update-time behavior (currently a no-op skeleton; see Phase 1 for
+// the environment-label defaulting/inheritance logic added on top of this).
+func RegisterModelAPIHook(logger *zap.Logger, apiHandler api.Handler) {
+	v2.RegisterModelAPIHook(apiHook{
+		logger:     logger,
+		apiHandler: apiHandler,
+	})
+}
+
+type apiHook struct {
+	v2.NoopModelAPIHook
+	logger     *zap.Logger
+	apiHandler api.Handler
+}
+
+// BeforeCreate currently defers entirely to the embedded NoopModelAPIHook.
+// This method is overridden with real logic in a follow-up commit (Phase 1).
+func (a apiHook) BeforeCreate(ctx context.Context, request *v2.CreateModelRequest) error {
+	return a.NoopModelAPIHook.BeforeCreate(ctx, request)
+}
+
+// BeforeUpdate currently defers entirely to the embedded NoopModelAPIHook.
+// This method is overridden with real logic in a follow-up commit (Phase 1).
+func (a apiHook) BeforeUpdate(ctx context.Context, request *v2.UpdateModelRequest) error {
+	return a.NoopModelAPIHook.BeforeUpdate(ctx, request)
+}

--- a/go/components/model/apihook/apihook_test.go
+++ b/go/components/model/apihook/apihook_test.go
@@ -1,0 +1,21 @@
+package apihook
+
+import (
+	"context"
+	"testing"
+
+	v2 "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBeforeCreate_PassesThroughToNoop(t *testing.T) {
+	hook := apiHook{}
+	err := hook.BeforeCreate(context.Background(), &v2.CreateModelRequest{})
+	assert.NoError(t, err)
+}
+
+func TestBeforeUpdate_PassesThroughToNoop(t *testing.T) {
+	hook := apiHook{}
+	err := hook.BeforeUpdate(context.Background(), &v2.UpdateModelRequest{})
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Part of #1720 — Phase 0 of the `michelangelo/environment` label defaulting/inheritance migration. This issue tracks all phases; do not auto-close it from this PR (or any single-phase PR) — close it manually only once all planned phases have landed.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
Adds a `Model` API-hook wiring skeleton: a new `go/components/model/apihook` package with a `RegisterModelAPIHook` constructor and an `apiHook` struct embedding `v2.NoopModelAPIHook`, mirroring the existing `pipelinerun`/`triggerrun` apihook packages. `BeforeCreate`/`BeforeUpdate` are explicit pass-throughs to the embedded Noop with zero behavior change. Wires the hook into `go/cmd/apiserver/main.go` via one new `fx.Invoke(modelapihook.RegisterModelAPIHook)` line.

This is Phase 0 of a larger environment-label defaulting/inheritance feature (migrated from an internal apiserver feature). It is a pure wiring skeleton — no label logic, no proto/CRD changes, no config plumbing. Real `BeforeCreate`/`BeforeUpdate` defaulting logic lands in a follow-up commit on this same PR/branch (Phase 1), once the preceding label-constant and config plumbing phases are in place, per the design in tracking issue #1720.

**Why?**
Establishes the `Model` API-hook extension point so subsequent commits can add environment-label defaulting/inheritance behavior without needing to first touch the wiring/constructor shape. Splitting the wiring skeleton out as its own commit keeps each diff reviewable and isolates the (zero-risk) fx wiring change from the (behavior-affecting) label logic that follows.

**How did you test it?**
- `gofmt -l .` — clean
- `go vet ./components/model/... ./cmd/apiserver/...` — clean
- `go build ./components/model/... ./cmd/apiserver/...` — passes
- `go test ./components/model/...` — new `TestBeforeCreate_PassesThroughToNoop`/`TestBeforeUpdate_PassesThroughToNoop` smoke tests pass
- `go test ./cmd/apiserver/...` — existing `TestDependenciesAreSatisfied` (`fx.ValidateApp(opts())`) passes, confirming the new `fx.Invoke` line resolves against the existing dependency graph with no new providers needed
- `golangci-lint run ./...` — zero findings in the files touched by this PR (pre-existing, unrelated `godox` findings elsewhere in the repo are untouched by this change)

**Potential risks**
Low. The hook is a pure pass-through to the existing no-op behavior, so this commit introduces no functional change to `Model` create/update handling.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**
N/A — no functional or schema change in this commit.

**Documentation Changes**
N/A.