### PR TITLE
feat(native_transform): add TransformSpec DAG engine + TorchTransformModule (PR B6)

### DIFF
--- a/python/michelangelo/lib/native_transform/torch/__init__.py
+++ b/python/michelangelo/lib/native_transform/torch/__init__.py
@@ -25,13 +25,29 @@ from michelangelo.lib.native_transform.torch.base_layers import (
     Tile,
     TorchTransformBaseLayer,
 )
+from michelangelo.lib.native_transform.torch.base_transform_module import (
+    TorchTransformModule,
+    get_transform_module,
+)
+from michelangelo.lib.native_transform.torch.constants import (
+    TORCH_TYPE_TO_TORCH_DTYPE_CLASS_NAME_MAP,
+)
 from michelangelo.lib.native_transform.torch.stats_layers import (
     Bucketization,
     MinMax,
     Normalization,
 )
+from michelangelo.lib.native_transform.torch.transform_spec import (
+    TORCH_TRANSFORM_LAYERS_DICT,
+    TORCH_TRANSFORM_LAYERS_SPECS_DICT,
+    TransformSpec,
+)
+from michelangelo.lib.native_transform.torch.utils import generate_layer_name
 
 __all__ = [
+    "TORCH_TRANSFORM_LAYERS_DICT",
+    "TORCH_TRANSFORM_LAYERS_SPECS_DICT",
+    "TORCH_TYPE_TO_TORCH_DTYPE_CLASS_NAME_MAP",
     "Bucketization",
     "CaseWhen",
     "Cast",
@@ -54,4 +70,8 @@ __all__ = [
     "TensorColFillNone",
     "Tile",
     "TorchTransformBaseLayer",
+    "TorchTransformModule",
+    "TransformSpec",
+    "generate_layer_name",
+    "get_transform_module",
 ]

--- a/python/michelangelo/lib/native_transform/torch/base_transform_module.py
+++ b/python/michelangelo/lib/native_transform/torch/base_transform_module.py
@@ -1,0 +1,154 @@
+"""The executable ``TorchTransformModule`` DAG runner.
+
+Converts a fitted
+:class:`~michelangelo.lib.native_transform.torch.transform_spec.TransformSpec`
+into a single ``torch.nn.Module`` that runs its layers in topological order.
+The module is TorchScript-exportable, so the exact same transform graph runs
+at training time (batched, ahead of the model) and at serving time (embedded
+in the model artifact).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from michelangelo.lib.native_transform.torch.base_layers import TorchTransformBaseLayer
+from michelangelo.lib.native_transform.torch.utils import generate_layer_name
+
+if TYPE_CHECKING:
+    from michelangelo.lib.native_transform.torch.transform_spec import TransformSpec
+
+__all__ = ["TorchTransformModule", "get_transform_module"]
+
+
+class TorchTransformModule(torch.nn.Module):
+    """Executes a DAG of transform layers, in topological order.
+
+    Args:
+        name: The module's name.
+        input_cols: Column names the module expects as input.
+        output_cols: Column names the module returns as output.
+        layers: The transform layers to run, already in topological order.
+            Every element must be a
+            :class:`~michelangelo.lib.native_transform.torch.base_layers.TorchTransformBaseLayer`.
+
+    Raises:
+        AssertionError: If any element of ``layers`` is not a
+            ``TorchTransformBaseLayer``.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        input_cols: list[str],
+        output_cols: list[str],
+        layers: torch.nn.ModuleList,
+    ) -> None:
+        """Initialize the TorchTransformModule.
+
+        Args:
+            name: The module's name.
+            input_cols: Column names the module expects as input.
+            output_cols: Column names the module returns as output.
+            layers: The transform layers to run, already in topological
+                order. Every element must be a ``TorchTransformBaseLayer``.
+
+        Raises:
+            AssertionError: If any element of ``layers`` is not a
+                ``TorchTransformBaseLayer``.
+        """
+        super().__init__()
+        assert all(isinstance(m, TorchTransformBaseLayer) for m in layers), (
+            "All modules must be instances of TorchTransformBaseLayer"
+        )
+        self.name = name
+        self.input_cols = input_cols
+        self.output_cols = output_cols
+        self.layers = layers
+
+    def forward(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """Run every layer in order, threading outputs into later layers' inputs.
+
+        Args:
+            inputs: Mapping from column name to tensor; must contain every
+                column in ``self.input_cols``.
+
+        Returns:
+            A mapping from each column in ``self.output_cols`` to its
+            computed tensor.
+
+        Raises:
+            ValueError: If ``inputs`` is missing a declared input column, or
+                a layer's declared input column is not yet available (i.e.
+                ``layers`` is not in a valid topological order).
+        """
+        # Node registry stores inputs and intermediate outputs from each layer.
+        nodes: dict[str, torch.Tensor] = {}
+        for name in self.input_cols:
+            if name not in inputs:
+                raise ValueError(f"Missing input name {name}. Inputs={inputs}")
+            nodes[name] = inputs[name]
+
+        for layer in self.layers:
+            layer_inputs: dict[str, torch.Tensor] = {}
+            for col in layer.input_cols:
+                if col not in nodes:
+                    raise ValueError(
+                        f"Missing input name {col} for layer {layer.name}."
+                    )
+                layer_inputs[col] = nodes[col]
+            layer_outputs = layer(layer_inputs)
+            nodes.update(layer_outputs)
+
+        results: dict[str, torch.Tensor] = {}
+        for output_col in self.output_cols:
+            results[output_col] = nodes[output_col]
+        return results
+
+
+def get_transform_module(
+    transform_spec: TransformSpec,
+    start_level: int,
+    end_level: int | None = None,
+    output_cols: set[str] | None = None,
+) -> TorchTransformModule | None:
+    """Materialize a level range of a ``TransformSpec`` into a ``TorchTransformModule``.
+
+    Args:
+        transform_spec: The fitted spec DAG to materialize.
+        start_level: The first transform level to include (inclusive).
+        end_level: The last transform level to include (inclusive). Defaults
+            to the spec's maximum level; clamped to it if given a larger
+            value.
+        output_cols: The columns the module should return. Defaults to every
+            output column produced across the included levels.
+
+    Returns:
+        The materialized module, or ``None`` if the level range contains no
+        layers.
+    """
+    layers = []
+    transform_input_cols: set[str] = set()
+    transform_output_cols: set[str] = set()
+    end_level = (
+        transform_spec.get_max_transform_level()
+        if end_level is None
+        else min(end_level, transform_spec.get_max_transform_level())
+    )
+    for level in range(start_level, end_level + 1):
+        layers.extend(transform_spec.to_transform_layers(level))
+        transform_input_cols.update(transform_spec.get_transform_input_cols(level))
+        transform_output_cols.update(transform_spec.get_transform_output_cols(level))
+    if len(layers) == 0:
+        return None
+    input_cols = transform_input_cols - transform_output_cols
+    return TorchTransformModule(
+        name=generate_layer_name(TorchTransformModule.__name__.lower()),
+        input_cols=sorted(input_cols),
+        output_cols=sorted(transform_output_cols)
+        if output_cols is None
+        else sorted(output_cols),
+        layers=torch.nn.ModuleList(layers),
+    )

--- a/python/michelangelo/lib/native_transform/torch/tests/test_base_transform_module.py
+++ b/python/michelangelo/lib/native_transform/torch/tests/test_base_transform_module.py
@@ -1,0 +1,254 @@
+"""Tests for :mod:`michelangelo.lib.native_transform.torch.base_transform_module`.
+
+Covers ``TorchTransformModule``'s DAG execution (including its
+TorchScript-round-trip contract) and ``get_transform_module``'s level-range
+materialization from a ``TransformSpec``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# These tests build real torch layers/modules and a real TransformSpec.
+torch = pytest.importorskip("torch")
+pytest.importorskip("pydantic")
+
+from michelangelo.lib.native_transform.torch.base_layers import (  # noqa: E402
+    Cast,
+    Concatenate,
+    TorchTransformBaseLayer,
+)
+from michelangelo.lib.native_transform.torch.base_transform_module import (  # noqa: E402
+    TorchTransformModule,
+    get_transform_module,
+)
+from michelangelo.lib.native_transform.torch.transform_spec import (  # noqa: E402
+    TransformSpec,
+)
+
+
+class _RecordingLayer(TorchTransformBaseLayer):
+    """A layer that records its inputs and returns a fixed output dict."""
+
+    def __init__(
+        self, name: str, input_cols: list[str], output_dict: dict[str, torch.Tensor]
+    ) -> None:
+        """Initialize the recording layer."""
+        super().__init__(
+            input_cols=input_cols, output_cols=list(output_dict), name=name
+        )
+        self.output_dict = output_dict
+        self.call_args: dict[str, torch.Tensor] | None = None
+
+    def forward(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """Record ``inputs`` and return the fixed ``output_dict``."""
+        self.call_args = inputs
+        return self.output_dict
+
+
+class TestTorchTransformModule:
+    """``TorchTransformModule``'s construction and forward-execution contract."""
+
+    def test_init(self) -> None:
+        """Constructor arguments are stored verbatim as attributes."""
+        layers = torch.nn.ModuleList()
+        module = TorchTransformModule(
+            name="test_module",
+            input_cols=["input1", "input2"],
+            output_cols=["output1"],
+            layers=layers,
+        )
+        assert module.name == "test_module"
+        assert module.input_cols == ["input1", "input2"]
+        assert module.output_cols == ["output1"]
+        assert module.layers is layers
+
+    def test_forward_chains_layers_in_order(self) -> None:
+        """Each layer's output is threaded into the inputs of later layers."""
+        layer1 = _RecordingLayer(
+            name="layer1",
+            input_cols=["input1"],
+            output_dict={"intermediate": torch.tensor([1.0, 2.0])},
+        )
+        layer2 = _RecordingLayer(
+            name="layer2",
+            input_cols=["intermediate", "input2"],
+            output_dict={
+                "output1": torch.tensor([3.0, 4.0]),
+                "output2": torch.tensor([5.0, 6.0]),
+            },
+        )
+        module = TorchTransformModule(
+            name="test_module",
+            input_cols=["input1", "input2"],
+            output_cols=["output1", "output2"],
+            layers=torch.nn.ModuleList([layer1, layer2]),
+        )
+        inputs = {
+            "input1": torch.tensor([10.0, 20.0]),
+            "input2": torch.tensor([30.0, 40.0]),
+        }
+
+        result = module(inputs)
+
+        assert torch.equal(result["output1"], torch.tensor([3.0, 4.0]))
+        assert torch.equal(result["output2"], torch.tensor([5.0, 6.0]))
+        assert torch.equal(layer1.call_args["input1"], torch.tensor([10.0, 20.0]))
+        assert torch.equal(layer2.call_args["intermediate"], torch.tensor([1.0, 2.0]))
+        assert torch.equal(layer2.call_args["input2"], torch.tensor([30.0, 40.0]))
+
+    def test_forward_missing_input_column_raises(self) -> None:
+        """A missing declared input column raises with the input name."""
+        module = TorchTransformModule(
+            name="test_module",
+            input_cols=["input1", "input2"],
+            output_cols=["output1"],
+            layers=torch.nn.ModuleList(),
+        )
+        with pytest.raises(ValueError, match="Missing input name input2"):
+            module({"input1": torch.tensor([1.0, 2.0])})
+
+    def test_forward_missing_layer_input_raises(self) -> None:
+        """A layer whose declared input isn't available yet raises."""
+        layer = _RecordingLayer(
+            name="test_layer", input_cols=["nonexistent_col"], output_dict={}
+        )
+        module = TorchTransformModule(
+            name="test_module",
+            input_cols=["input1"],
+            output_cols=["input1"],
+            layers=torch.nn.ModuleList([layer]),
+        )
+        with pytest.raises(
+            ValueError, match="Missing input name nonexistent_col for layer test_layer"
+        ):
+            module({"input1": torch.tensor([1.0, 2.0])})
+
+    def test_forward_with_no_layers_passes_through(self) -> None:
+        """With no layers, an input column that is also an output passes through."""
+        module = TorchTransformModule(
+            name="test_module",
+            input_cols=["input1"],
+            output_cols=["input1"],
+            layers=torch.nn.ModuleList(),
+        )
+        result = module({"input1": torch.tensor([1.0, 2.0])})
+        assert torch.equal(result["input1"], torch.tensor([1.0, 2.0]))
+
+    def test_rejects_non_transform_layer_modules(self) -> None:
+        """A ``layers`` entry that isn't a ``TorchTransformBaseLayer`` raises."""
+        invalid_layer = torch.nn.Linear(10, 10)
+        invalid_layer.input_cols = ["input"]
+        invalid_layer.name = "linear"
+        with pytest.raises(
+            AssertionError,
+            match="All modules must be instances of TorchTransformBaseLayer",
+        ):
+            TorchTransformModule(
+                name="test_module",
+                input_cols=["input"],
+                output_cols=["output"],
+                layers=torch.nn.ModuleList([invalid_layer]),
+            )
+
+
+class TestTorchScriptRoundTrip:
+    """The assembled DAG module must script, save/load, and match eager output."""
+
+    def test_scripted_matches_eager(self, tmp_path) -> None:
+        """Scripting (and reloading) reproduces the eager forward output."""
+        concat = Concatenate(input_cols=["a", "b"], output_cols=["ab"])
+        cast = Cast(input_cols=["ab"], output_cols=["ab_int"], dtype=torch.int64)
+        module = TorchTransformModule(
+            name="test_module",
+            input_cols=["a", "b"],
+            output_cols=["ab_int"],
+            layers=torch.nn.ModuleList([concat, cast]),
+        )
+        module.eval()
+        inputs = {"a": torch.tensor([[1.0, 2.0]]), "b": torch.tensor([[3.0]])}
+        eager = module(inputs)
+
+        scripted = torch.jit.script(module)
+        scripted_out = scripted(inputs)
+        assert set(scripted_out) == set(eager)
+        for key in eager:
+            torch.testing.assert_close(scripted_out[key], eager[key])
+
+        model_path = tmp_path / "scripted_module.pt"
+        scripted.save(str(model_path))
+        loaded = torch.jit.load(str(model_path))
+        loaded_out = loaded(inputs)
+        for key in eager:
+            torch.testing.assert_close(loaded_out[key], eager[key])
+
+
+class TestGetTransformModule:
+    """Level-range materialization of a ``TransformSpec`` into a runnable module."""
+
+    def _spec(self) -> TransformSpec:
+        """Build a two-level Cast -> Scale spec for the tests below."""
+        return TransformSpec(
+            raw_transform_specs={
+                "transform_specs": [
+                    {
+                        "transform_name": "Cast",
+                        "input_cols": ["a"],
+                        "output_cols": ["a_cast"],
+                        "dtype": "float32",
+                    },
+                    {
+                        "transform_name": "Scale",
+                        "input_cols": ["a_cast"],
+                        "output_cols": ["a_scaled"],
+                        "factor": 2.0,
+                    },
+                ]
+            }
+        )
+
+    def test_materializes_full_range_by_default(self) -> None:
+        """With no end_level, every level up to the max is materialized."""
+        spec = self._spec()
+        module = get_transform_module(spec, start_level=0)
+        assert module is not None
+        assert len(module.layers) == 2
+        assert module.input_cols == ["a"]
+        # Default output_cols is every output produced across the included
+        # levels, including intermediate ones -- not just the "leftover"
+        # (unconsumed) columns, which is how input_cols is computed instead.
+        assert module.output_cols == ["a_cast", "a_scaled"]
+
+    def test_end_level_clamped_to_max(self) -> None:
+        """An end_level beyond the spec's max level is clamped, not an error."""
+        spec = self._spec()
+        module = get_transform_module(spec, start_level=0, end_level=99)
+        assert len(module.layers) == 2
+
+    def test_single_level_range(self) -> None:
+        """A single-level range materializes only that level's layer."""
+        spec = self._spec()
+        module = get_transform_module(spec, start_level=0, end_level=0)
+        assert len(module.layers) == 1
+        assert module.output_cols == ["a_cast"]
+
+    def test_no_layers_in_range_returns_none(self) -> None:
+        """A level range with no layers returns None instead of an empty module."""
+        spec = self._spec()
+        assert get_transform_module(spec, start_level=5, end_level=5) is None
+
+    def test_custom_output_cols(self) -> None:
+        """An explicit output_cols overrides the default full-output set."""
+        spec = self._spec()
+        module = get_transform_module(
+            spec, start_level=0, end_level=0, output_cols={"a_cast"}
+        )
+        assert module.output_cols == ["a_cast"]
+
+    def test_forward_end_to_end(self) -> None:
+        """The materialized module runs Cast then Scale end to end."""
+        spec = self._spec()
+        module = get_transform_module(spec, start_level=0)
+        module.eval()
+        result = module({"a": torch.tensor([1, 2, 3], dtype=torch.int32)})
+        torch.testing.assert_close(result["a_scaled"], torch.tensor([2.0, 4.0, 6.0]))

--- a/python/michelangelo/lib/native_transform/torch/tests/test_transform_spec.py
+++ b/python/michelangelo/lib/native_transform/torch/tests/test_transform_spec.py
@@ -1,0 +1,837 @@
+"""Tests for :mod:`michelangelo.lib.native_transform.torch.transform_spec`.
+
+Covers ``TransformSpec`` construction/validation, the topological sort, the
+placeholder-hydration ``update_*`` methods, statistics-requirement
+collection, layer materialization, and dict/JSON ser-de round-trips.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import mock_open, patch
+
+import pytest
+
+# TransformSpec composes real torch layers/pydantic specs. Skip cleanly if
+# either is unavailable in a lightweight environment.
+torch = pytest.importorskip("torch")
+pytest.importorskip("pydantic")
+yaml = pytest.importorskip("yaml")
+
+from michelangelo.lib.native_transform.torch.transform_layer_spec import (  # noqa: E402
+    BucketizationLayerSpec,
+    MinMaxLayerSpec,
+    NormalizationLayerSpec,
+    TransformerMode,
+)
+from michelangelo.lib.native_transform.torch.transform_spec import (  # noqa: E402
+    TORCH_TRANSFORM_LAYER_CLASS_NAME_TO_SPEC_CLASS_NAME_DICT,
+    TORCH_TRANSFORM_LAYERS_DICT,
+    TORCH_TRANSFORM_LAYERS_SPECS_DICT,
+    TransformSpec,
+)
+
+RAW_SPECS = {
+    "transform_specs": [
+        {
+            "transform_name": "Concatenate",
+            "input_cols": ["col1"],
+            "output_cols": ["col1_concatenated"],
+        },
+        {
+            "transform_name": "NumericalStandardTransform",
+            "input_cols": ["col2"],
+            "output_cols": ["col2_transformed"],
+            "cap_min": "0.01",
+            "cap_max": "0.99",
+            "default_value": "0.5",
+        },
+        {
+            "transform_name": "StandardScaler",
+            "input_cols": ["col3", "col4"],
+            "output_cols": ["col3_scaled_col4_scaled"],
+        },
+        {
+            "transform_name": "MinMaxScaler",
+            "input_cols": ["col5"],
+            "output_cols": ["col5_scaled"],
+        },
+    ]
+}
+
+
+class TestTransformSpecConstruction:
+    """Loading, validation, and basic accessors."""
+
+    def test_init_from_raw_transform_specs(self) -> None:
+        """Constructing from a raw dict parses every spec and computes levels."""
+        spec = TransformSpec(raw_transform_specs=RAW_SPECS)
+        assert isinstance(spec.transform_specs, dict)
+        assert isinstance(spec.transform_levels, dict)
+        assert len(spec.transform_specs) == 4
+        assert spec.transform_spec_yaml_path is None
+
+    def test_init_from_yaml_path(self) -> None:
+        """Constructing from a YAML path loads and parses it the same as a raw dict."""
+        with (
+            patch("builtins.open", mock_open()),
+            patch("yaml.safe_load", return_value=RAW_SPECS),
+        ):
+            spec = TransformSpec("test.yaml")
+        assert len(spec.transform_specs) == 4
+        assert spec.transform_spec_yaml_path == "test.yaml"
+
+    def test_yaml_path_takes_precedence_over_raw_specs(self) -> None:
+        """When both are given, the YAML path wins over raw_transform_specs."""
+        with (
+            patch("builtins.open", mock_open()),
+            patch("yaml.safe_load", return_value=RAW_SPECS) as mock_yaml,
+        ):
+            spec = TransformSpec(
+                transform_spec_yaml_path="test.yaml",
+                raw_transform_specs={"different": "data"},
+            )
+        assert spec.transform_spec_yaml_path == "test.yaml"
+        mock_yaml.assert_called_once()
+
+    def test_neither_yaml_nor_raw_specs_raises(self) -> None:
+        """Neither argument given raises ValueError."""
+        with pytest.raises(
+            ValueError, match="Either transform_spec_yaml_path or raw_transform_specs"
+        ):
+            TransformSpec()
+
+    def test_empty_raw_transform_specs(self) -> None:
+        """An empty transform_specs list yields an empty spec/level mapping."""
+        spec = TransformSpec(raw_transform_specs={"transform_specs": []})
+        assert len(spec.transform_specs) == 0
+        assert len(spec.transform_levels) == 0
+
+    def test_invalid_transform_name_raises(self) -> None:
+        """An unregistered transform_name raises ValueError."""
+        with pytest.raises(ValueError, match=r"Transform layer spec .* not found"):
+            TransformSpec(
+                raw_transform_specs={
+                    "transform_specs": [
+                        {
+                            "transform_name": "NotARealTransform",
+                            "input_cols": ["a"],
+                            "output_cols": ["b"],
+                        }
+                    ]
+                }
+            )
+
+    def test_duplicate_specs_are_deduplicated(self) -> None:
+        """Two field-for-field-identical specs collapse into one."""
+        duplicate_data = {
+            "transform_specs": [
+                {
+                    "transform_name": "Cast",
+                    "input_cols": ["a"],
+                    "output_cols": ["b"],
+                    "dtype": "float32",
+                },
+                {
+                    "transform_name": "Cast",
+                    "input_cols": ["a"],
+                    "output_cols": ["b"],
+                    "dtype": "float32",
+                },
+            ]
+        }
+        spec = TransformSpec(raw_transform_specs=duplicate_data)
+        assert len(spec.transform_specs) == 1
+
+    def test_duplicate_output_columns_raises(self) -> None:
+        """Two layers producing the same output column raises ValueError."""
+        duplicate_data = {
+            "transform_specs": [
+                {
+                    "transform_name": "Cast",
+                    "input_cols": ["a"],
+                    "output_cols": ["out"],
+                    "dtype": "float32",
+                },
+                {
+                    "transform_name": "Cast",
+                    "input_cols": ["b"],
+                    "output_cols": ["out"],
+                    "dtype": "float64",
+                },
+            ]
+        }
+        with pytest.raises(ValueError, match="is produced by multiple layers"):
+            TransformSpec(raw_transform_specs=duplicate_data)
+
+    def test_circular_dependency_raises(self) -> None:
+        """A cycle in input/output column references raises ValueError."""
+        circular_specs = {
+            "transform_specs": [
+                {
+                    "transform_name": "Cast",
+                    "input_cols": ["col2"],
+                    "output_cols": ["col1"],
+                    "dtype": "float32",
+                },
+                {
+                    "transform_name": "Cast",
+                    "input_cols": ["col1"],
+                    "output_cols": ["col2"],
+                    "dtype": "float32",
+                },
+            ]
+        }
+        with pytest.raises(ValueError, match="Circular dependency detected"):
+            TransformSpec(raw_transform_specs=circular_specs)
+
+    def test_duplicate_layer_name_raises(self) -> None:
+        """Two distinct specs sharing an explicit name raises ValueError."""
+        duplicate_name_data = {
+            "transform_specs": [
+                {
+                    "transform_name": "Cast",
+                    "input_cols": ["a"],
+                    "output_cols": ["out1"],
+                    "dtype": "float32",
+                    "name": "dup",
+                },
+                {
+                    "transform_name": "Cast",
+                    "input_cols": ["b"],
+                    "output_cols": ["out2"],
+                    "dtype": "float64",
+                    "name": "dup",
+                },
+            ]
+        }
+        with pytest.raises(ValueError, match="Layer name dup is duplicated"):
+            TransformSpec(raw_transform_specs=duplicate_name_data)
+
+    def test_duplicate_output_column_via_load_from_dict_raises(self) -> None:
+        """A duplicate output column raises even via the load_from_dict path.
+
+        ``load_from_dict`` bypasses ``_validate_transform_specs``'s dedup/name
+        checks (it assigns ``transform_specs`` directly), so a duplicate
+        output column can only be caught by ``_topological_sort``'s own
+        producer-uniqueness guard. Exercise that path directly.
+        """
+        spec = TransformSpec(raw_transform_specs={"transform_specs": []})
+        with pytest.raises(ValueError, match="is produced by multiple layers"):
+            spec.load_from_dict(
+                {
+                    "transform_spec_yaml_path": None,
+                    "columns_to_keep": None,
+                    "transform_specs": [
+                        {
+                            "layer_spec_class_name": "CastLayerSpec",
+                            "name": "cast_a",
+                            "input_cols": ["a"],
+                            "output_cols": ["out"],
+                        },
+                        {
+                            "layer_spec_class_name": "CastLayerSpec",
+                            "name": "cast_b",
+                            "input_cols": ["b"],
+                            "output_cols": ["out"],
+                        },
+                    ],
+                }
+            )
+
+
+class TestColumnsToKeep:
+    """Validation of the optional ``columns_to_keep`` field."""
+
+    def test_valid_columns_to_keep(self) -> None:
+        """A well-formed columns_to_keep list is stored as-is."""
+        spec = TransformSpec(
+            raw_transform_specs={
+                "columns_to_keep": ["col1", "col2"],
+                "transform_specs": [],
+            }
+        )
+        assert spec.columns_to_keep == ["col1", "col2"]
+
+    def test_not_a_list_raises(self) -> None:
+        """A non-list columns_to_keep raises ValueError."""
+        with pytest.raises(ValueError, match="columns_to_keep must be a list"):
+            TransformSpec(
+                raw_transform_specs={
+                    "columns_to_keep": "not_a_list",
+                    "transform_specs": [],
+                }
+            )
+
+    def test_empty_list_raises(self) -> None:
+        """An empty columns_to_keep list raises ValueError."""
+        with pytest.raises(ValueError, match="columns_to_keep is empty"):
+            TransformSpec(
+                raw_transform_specs={"columns_to_keep": [], "transform_specs": []}
+            )
+
+    def test_non_string_entries_raise(self) -> None:
+        """A columns_to_keep list with a non-string entry raises ValueError."""
+        with pytest.raises(
+            ValueError, match="columns_to_keep must be a list of strings"
+        ):
+            TransformSpec(
+                raw_transform_specs={"columns_to_keep": ["a", 1], "transform_specs": []}
+            )
+
+
+class TestTopologicalSort:
+    """Level assignment and layer materialization across a chained DAG."""
+
+    def test_chained_layers_get_increasing_levels(self) -> None:
+        """A Cast->Scale->Floor->Clip chain gets one layer per level."""
+        chained_specs = {
+            "transform_specs": [
+                {
+                    "transform_name": "Cast",
+                    "input_cols": ["col1"],
+                    "output_cols": ["col1_cast"],
+                    "dtype": "float32",
+                },
+                {
+                    "transform_name": "Scale",
+                    "input_cols": ["col1_cast"],
+                    "output_cols": ["col1_scaled"],
+                    "factor": 2.0,
+                },
+                {
+                    "transform_name": "Floor",
+                    "input_cols": ["col1_scaled"],
+                    "output_cols": ["col1_floored"],
+                },
+                {
+                    "transform_name": "Clip",
+                    "input_cols": ["col1_floored"],
+                    "output_cols": ["col1_clipped"],
+                    "min_value": 0.0,
+                    "max_value": 10.0,
+                },
+            ]
+        }
+        spec = TransformSpec(raw_transform_specs=chained_specs)
+        assert spec.get_max_transform_level() == 3
+        for level in range(4):
+            layers = spec.to_transform_layers(target_transform_level=level)
+            assert len(layers) == 1
+
+    def test_independent_layers_share_a_level(self) -> None:
+        """Specs with no cross-dependencies all land at level 0."""
+        spec = TransformSpec(raw_transform_specs=RAW_SPECS)
+        # None of the four RAW_SPECS entries depend on each other's outputs.
+        assert spec.get_max_transform_level() == 0
+        assert len(spec.get_transform_layer_spec(target_transform_level=0)) == 4
+
+
+class TestUpdateInputDtype:
+    """``update_input_dtype`` populates per-column dtypes at a target level."""
+
+    def test_updates_matching_columns(self) -> None:
+        """Matching columns get their input_dtype populated from the dtype dict."""
+        spec = TransformSpec(raw_transform_specs=RAW_SPECS)
+        spec.update_input_dtype(
+            {
+                "col1": torch.int64,
+                "col2": torch.float64,
+                "col3": torch.float64,
+                "col4": torch.float64,
+                "col5": torch.float64,
+            }
+        )
+        by_col = {s.input_cols[0]: s for s in spec.transform_specs.values()}
+        assert by_col["col1"].input_dtype == torch.int64
+        assert by_col["col2"].input_dtype == torch.float64
+
+    def test_missing_column_raises(self) -> None:
+        """A spec's input column missing from the dtype dict raises ValueError."""
+        spec = TransformSpec(raw_transform_specs=RAW_SPECS)
+        with pytest.raises(ValueError, match="not found in data dtype dict"):
+            spec.update_input_dtype({"col_missing": torch.int64})
+
+    def test_other_level_is_skipped(self) -> None:
+        """A level with no matching specs is a no-op, even with an empty dtype dict."""
+        spec = TransformSpec(raw_transform_specs=RAW_SPECS)
+        # target_transform_level=5 matches nothing (every RAW_SPECS entry is
+        # level 0), so no column lookups happen and nothing raises even
+        # though data_dtype_dict is missing every column.
+        spec.update_input_dtype({}, target_transform_level=5)
+        for layer_spec in spec.transform_specs.values():
+            assert layer_spec.input_dtype is None
+
+
+class TestUpdateNumericalStandardTransformParameters:
+    """``update_numerical_standard_transform_parameters`` percentile resolution."""
+
+    def test_resolves_percentile_strings(self) -> None:
+        """Percentile-string cap/default values resolve to floats from the dict."""
+        spec = TransformSpec(raw_transform_specs=RAW_SPECS)
+        spec.update_numerical_standard_transform_parameters(
+            {"col2_1": 0.1, "col2_99": 0.9, "col2_50": 0.5}
+        )
+        numerical_spec = next(
+            s for s in spec.transform_specs.values() if s.input_cols == ["col2"]
+        )
+        assert numerical_spec.cap_min == 0.1
+        assert numerical_spec.cap_max == 0.9
+        assert numerical_spec.default_value == 0.5
+
+    def test_already_float_values_are_left_unchanged(self) -> None:
+        """Cap/default values that are already floats are not looked up again."""
+        raw = {
+            "transform_specs": [
+                {
+                    "transform_name": "NumericalStandardTransform",
+                    "input_cols": ["col2"],
+                    "output_cols": ["col2_transformed"],
+                    "cap_min": 0.1,
+                    "cap_max": 0.9,
+                    "default_value": 0.5,
+                }
+            ]
+        }
+        spec = TransformSpec(raw_transform_specs=raw)
+        spec.update_numerical_standard_transform_parameters({"col2_1": 999.0})
+        (numerical_spec,) = spec.transform_specs.values()
+        assert numerical_spec.cap_min == 0.1
+        assert numerical_spec.cap_max == 0.9
+        assert numerical_spec.default_value == 0.5
+
+    def test_non_capping_spec_has_no_percentile_requirements(self) -> None:
+        """is_cap_value=False means no percentile statistics are required."""
+        raw = {
+            "transform_specs": [
+                {
+                    "transform_name": "NumericalStandardTransform",
+                    "input_cols": ["col2"],
+                    "output_cols": ["col2_transformed"],
+                    "is_cap_value": False,
+                }
+            ]
+        }
+        stats_specs = TransformSpec(
+            raw_transform_specs=raw
+        ).get_numerical_statistics_computation_specs()
+        assert "col2" not in stats_specs
+
+    def test_other_level_is_skipped(self) -> None:
+        """A level with no matching specs is left unresolved."""
+        spec = TransformSpec(raw_transform_specs=RAW_SPECS)
+        spec.update_numerical_standard_transform_parameters(
+            {"col2_1": 0.1}, target_transform_level=5
+        )
+        numerical_spec = next(
+            s for s in spec.transform_specs.values() if s.input_cols == ["col2"]
+        )
+        assert numerical_spec.cap_min == "0.01"
+
+
+class TestUpdateStandardScalerSpecs:
+    """``update_standard_scaler_specs`` placeholder-hydration behavior."""
+
+    def test_hydrates_into_normalization_spec(self) -> None:
+        """A StandardScaler placeholder hydrates into a fitted Normalization spec."""
+        spec = TransformSpec(raw_transform_specs=RAW_SPECS)
+        spec.update_standard_scaler_specs(
+            {"col3_mean": 10.0, "col3_std": 2.0, "col4_mean": 20.0, "col4_std": 3.0}
+        )
+        hydrated = [
+            s
+            for s in spec.transform_specs.values()
+            if isinstance(s, NormalizationLayerSpec)
+        ]
+        assert len(hydrated) == 1
+        assert hydrated[0].mean == [10.0, 20.0]
+        assert hydrated[0].std == [2.0, 3.0]
+
+    def test_hydration_dispatches_via_generated_name_placeholder(self) -> None:
+        """Placeholder hydration must survive round-tripping through a raw spec dict.
+
+        ``StandardScalerLayerSpec`` auto-generates its ``name`` via the same
+        ``generate_layer_name()`` used by every layer spec, seeded from its
+        own class name (``"StandardScaler"``, already lowercased before
+        ``generate_layer_name`` is called -- see
+        ``TorchTransformLayerSpec.set_defaults``). ``TransformSpec``
+        dispatches hydration by ``isinstance()`` against the placeholder's
+        real pydantic type rather than by parsing that generated name, but
+        this test locks in the full round trip: a raw dict spec produces a
+        placeholder with a generated name in the expected format, and
+        hydration still finds and resolves it.
+        """
+        raw = {
+            "transform_specs": [
+                {
+                    "transform_name": "StandardScaler",
+                    "input_cols": ["x"],
+                    "output_cols": ["x_scaled"],
+                },
+            ]
+        }
+        spec = TransformSpec(raw_transform_specs=raw)
+        (placeholder,) = spec.transform_specs.values()
+        assert placeholder.name.startswith("standardscaler_")
+
+        spec.update_standard_scaler_specs({"x_mean": 5.0, "x_std": 2.0})
+
+        (hydrated,) = spec.transform_specs.values()
+        assert isinstance(hydrated, NormalizationLayerSpec)
+        assert hydrated.mean == [5.0]
+        assert hydrated.std == [2.0]
+        layers = spec.to_transform_layers(target_transform_level=0)
+        assert len(layers) == 1
+
+
+class TestUpdateMinMaxScalerSpecs:
+    """``update_min_max_scaler_specs`` placeholder-hydration behavior."""
+
+    def test_hydrates_into_minmax_spec(self) -> None:
+        """A MinMaxScaler placeholder hydrates into a fitted MinMaxLayerSpec."""
+        spec = TransformSpec(raw_transform_specs=RAW_SPECS)
+        spec.update_min_max_scaler_specs({"col5_min": 0.0, "col5_max": 100.0})
+        hydrated = [
+            s for s in spec.transform_specs.values() if isinstance(s, MinMaxLayerSpec)
+        ]
+        assert len(hydrated) == 1
+        assert hydrated[0].min == [0.0]
+        assert hydrated[0].max == [100.0]
+
+
+class TestUpdateBucketizationSpecs:
+    """``update_bucketization_specs`` placeholder-hydration behavior."""
+
+    def test_hydrates_percentile_placeholder(self) -> None:
+        """A PercentileBucketization placeholder hydrates into boundaries from stats."""
+        raw = {
+            "transform_specs": [
+                {
+                    "transform_name": "PercentileBucketization",
+                    "input_cols": ["col1"],
+                    "output_cols": ["col1_bucketed"],
+                    "percentiles": [0.25, 0.5, 0.75],
+                }
+            ]
+        }
+        spec = TransformSpec(raw_transform_specs=raw)
+        spec.update_bucketization_specs(
+            {"col1_25": 10.0, "col1_50": 20.0, "col1_75": 30.0}
+        )
+        (hydrated,) = spec.transform_specs.values()
+        assert isinstance(hydrated, BucketizationLayerSpec)
+        assert hydrated.boundaries == [10.0, 20.0, 30.0]
+
+    def test_precomputed_boundaries_are_unchanged(self) -> None:
+        """A Bucketization spec with boundaries already set is left untouched."""
+        raw = {
+            "transform_specs": [
+                {
+                    "transform_name": "Bucketization",
+                    "input_cols": ["col1"],
+                    "output_cols": ["col1_bucketed"],
+                    "boundaries": [10.0, 20.0, 30.0],
+                }
+            ]
+        }
+        spec = TransformSpec(raw_transform_specs=raw)
+        spec.update_bucketization_specs({})
+        (unchanged,) = spec.transform_specs.values()
+        assert unchanged.boundaries == [10.0, 20.0, 30.0]
+
+
+class TestGetNumericalStatisticsComputationSpecs:
+    """``get_numerical_statistics_computation_specs`` requirement collection."""
+
+    def test_collects_requirements_across_layer_kinds(self) -> None:
+        """Statistics requirements are collected per column across layer kinds."""
+        spec = TransformSpec(raw_transform_specs=RAW_SPECS)
+        stats_specs = spec.get_numerical_statistics_computation_specs()
+        assert "col2" in stats_specs
+        assert "percentiles" in stats_specs["col2"]
+        assert stats_specs["col3"]["mean"] is True
+        assert stats_specs["col3"]["std"] is False
+        assert stats_specs["col5"]["min"] is True
+        assert stats_specs["col5"]["max"] is True
+
+    def test_percentile_fractions_are_kept_as_is(self) -> None:
+        """Percentiles already in [0, 1] are kept as fractions, not rescaled."""
+        raw = {
+            "transform_specs": [
+                {
+                    "transform_name": "PercentileBucketization",
+                    "input_cols": ["col1"],
+                    "output_cols": ["col1_bucketed"],
+                    "percentiles": [0.25, 0.5, 0.75],
+                }
+            ]
+        }
+        stats_specs = TransformSpec(
+            raw_transform_specs=raw
+        ).get_numerical_statistics_computation_specs()
+        assert stats_specs["col1"]["percentiles"] == [0.25, 0.5, 0.75]
+
+    def test_percentages_are_converted_to_fractions(self) -> None:
+        """Percentiles in [1, 100] are converted to the [0, 1] fraction form."""
+        raw = {
+            "transform_specs": [
+                {
+                    "transform_name": "PercentileBucketization",
+                    "input_cols": ["col1"],
+                    "output_cols": ["col1_bucketed"],
+                    "percentiles": [25, 50, 75],
+                }
+            ]
+        }
+        stats_specs = TransformSpec(
+            raw_transform_specs=raw
+        ).get_numerical_statistics_computation_specs()
+        assert stats_specs["col1"]["percentiles"] == [0.25, 0.5, 0.75]
+
+    def test_precomputed_bucketization_has_no_requirements(self) -> None:
+        """A Bucketization spec with boundaries needs no statistics."""
+        raw = {
+            "transform_specs": [
+                {
+                    "transform_name": "Bucketization",
+                    "input_cols": ["col1"],
+                    "output_cols": ["col1_bucketed"],
+                    "boundaries": [10.0, 20.0, 30.0],
+                }
+            ]
+        }
+        stats_specs = TransformSpec(
+            raw_transform_specs=raw
+        ).get_numerical_statistics_computation_specs()
+        assert "col1" not in stats_specs
+
+    def test_with_std_true_adds_std_requirement(self) -> None:
+        """with_std=True adds a std requirement alongside the default mean one."""
+        raw = {
+            "transform_specs": [
+                {
+                    "transform_name": "StandardScaler",
+                    "input_cols": ["x"],
+                    "output_cols": ["x_scaled"],
+                    "with_std": True,
+                },
+            ]
+        }
+        stats_specs = TransformSpec(
+            raw_transform_specs=raw
+        ).get_numerical_statistics_computation_specs()
+        assert stats_specs["x"]["std"] is True
+        assert stats_specs["x"]["mean"] is True
+
+    def test_non_positive_and_out_of_range_percentiles_are_ignored(self) -> None:
+        """Percentiles <= 0 or >= 100 are dropped from the requirements."""
+        raw = {
+            "transform_specs": [
+                {
+                    "transform_name": "PercentileBucketization",
+                    "input_cols": ["col1"],
+                    "output_cols": ["col1_bucketed"],
+                    "percentiles": [0, 100, 50],
+                }
+            ]
+        }
+        stats_specs = TransformSpec(
+            raw_transform_specs=raw
+        ).get_numerical_statistics_computation_specs()
+        assert stats_specs["col1"]["percentiles"] == [0.5]
+
+    def test_other_level_is_skipped(self) -> None:
+        """A level with no matching specs has no statistics requirements."""
+        spec = TransformSpec(raw_transform_specs=RAW_SPECS)
+        assert (
+            spec.get_numerical_statistics_computation_specs(target_transform_level=5)
+            == {}
+        )
+
+
+class TestAccessors:
+    """Level/type-filtered accessors on a constructed ``TransformSpec``."""
+
+    def test_get_transform_layer_spec(self) -> None:
+        """Every spec is returned, both unfiltered and filtered by level."""
+        spec = TransformSpec(raw_transform_specs=RAW_SPECS)
+        assert len(spec.get_transform_layer_spec()) == 4
+        assert len(spec.get_transform_layer_spec(target_transform_level=0)) == 4
+
+    def test_get_transform_layer_spec_no_match_raises(self) -> None:
+        """A level with no matching specs raises ValueError."""
+        spec = TransformSpec(raw_transform_specs=RAW_SPECS)
+        with pytest.raises(ValueError, match="No transform layer spec found"):
+            spec.get_transform_layer_spec(target_transform_level=99)
+
+    def test_get_transform_input_and_output_cols(self) -> None:
+        """Input/output column accessors return the expected column sets."""
+        spec = TransformSpec(raw_transform_specs=RAW_SPECS)
+        input_cols = spec.get_transform_input_cols()
+        assert {"col2", "col3", "col4", "col5"} <= set(input_cols)
+        output_cols = spec.get_transform_output_cols()
+        assert "col2_transformed" in output_cols
+
+    def test_get_input_dtype_map(self) -> None:
+        """The dtype map reflects dtypes populated by update_input_dtype."""
+        spec = TransformSpec(raw_transform_specs=RAW_SPECS)
+        spec.update_input_dtype(
+            {
+                "col1": torch.int64,
+                "col2": torch.float64,
+                "col3": torch.float64,
+                "col4": torch.float64,
+                "col5": torch.float64,
+            }
+        )
+        dtype_map = spec.get_input_dtype_map()
+        assert dtype_map["col1"] == torch.int64
+
+    def test_get_input_dtype_map_skips_other_levels_and_none_dtype(self) -> None:
+        """Levels with no input_dtype set yield an empty map."""
+        # RAW_SPECS specs are all level 0 and start with input_dtype=None
+        # before update_input_dtype is called.
+        spec = TransformSpec(raw_transform_specs=RAW_SPECS)
+        assert spec.get_input_dtype_map(target_transform_level=0) == {}
+        assert spec.get_input_dtype_map(target_transform_level=5) == {}
+
+    def test_get_max_transform_level_empty(self) -> None:
+        """An empty spec's max transform level is 0."""
+        spec = TransformSpec(raw_transform_specs={"transform_specs": []})
+        assert spec.get_max_transform_level() == 0
+
+    def test_to_transform_layers_unregistered_placeholder_raises(self) -> None:
+        """An unresolved placeholder spec cannot be materialized into a layer."""
+        raw = {
+            "transform_specs": [
+                {
+                    "transform_name": "StandardScaler",
+                    "input_cols": ["x"],
+                    "output_cols": ["x_scaled"],
+                },
+            ]
+        }
+        spec = TransformSpec(raw_transform_specs=raw)
+        with pytest.raises(ValueError, match=r"Transform layer .* not found"):
+            spec.to_transform_layers()
+
+
+class TestSerialization:
+    """to_dict/to_json/load_from_dict/load_from_json round-trip behavior."""
+
+    def test_to_dict_shape(self) -> None:
+        """to_dict returns the expected top-level keys and per-layer entries."""
+        spec = TransformSpec(raw_transform_specs=RAW_SPECS)
+        spec_dict = spec.to_dict()
+        assert set(spec_dict) == {
+            "transform_spec_yaml_path",
+            "transform_specs",
+            "columns_to_keep",
+        }
+        assert len(spec_dict["transform_specs"]) == 4
+
+    def test_to_dict_serializes_enum_values_to_primitives(self) -> None:
+        """Enum fields serialize to their .value, and the result stays yaml-safe."""
+        spec = TransformSpec(
+            raw_transform_specs={
+                "transform_specs": [
+                    {
+                        "transform_name": "Scale",
+                        "input_cols": ["x"],
+                        "output_cols": ["x_scaled"],
+                        "factor": 2.0,
+                    },
+                ]
+            }
+        )
+        (layer,) = spec.to_dict()["transform_specs"]
+        assert isinstance(layer["mode"], str)
+        assert layer["mode"] == TransformerMode.INVALID.value
+        # Must be yaml.safe_dump-compatible -- this was the original internal failure.
+        yaml.safe_dump(spec.to_dict())
+
+    def test_to_json_round_trips_dtype_and_enum(self) -> None:
+        """to_json produces a valid JSON string."""
+        spec = TransformSpec(raw_transform_specs=RAW_SPECS)
+        json_str = spec.to_json()
+        assert isinstance(json_str, str)
+
+    def test_load_from_json_restores_state(self) -> None:
+        """load_from_json restores the same specs and levels as the original."""
+        spec = TransformSpec(raw_transform_specs=RAW_SPECS)
+        json_str = spec.to_json()
+
+        restored = TransformSpec(raw_transform_specs={"transform_specs": []})
+        restored.load_from_json(json_str)
+
+        assert len(restored.transform_specs) == 4
+        assert restored.transform_levels == spec.transform_levels
+
+    def test_load_from_dict_restores_state(self) -> None:
+        """load_from_dict restores the same specs as the original."""
+        spec = TransformSpec(raw_transform_specs=RAW_SPECS)
+        spec_dict = spec.to_dict()
+
+        restored = TransformSpec(raw_transform_specs={"transform_specs": []})
+        restored.load_from_dict(spec_dict)
+
+        assert len(restored.transform_specs) == 4
+
+    def test_load_from_dict_invalid_layer_spec_class_name_raises(self) -> None:
+        """An unregistered layer_spec_class_name raises ValueError."""
+        restored = TransformSpec(raw_transform_specs={"transform_specs": []})
+        with pytest.raises(ValueError, match=r"Layer spec class name .* not found"):
+            restored.load_from_dict(
+                {
+                    "transform_spec_yaml_path": None,
+                    "columns_to_keep": None,
+                    "transform_specs": [
+                        {
+                            "layer_spec_class_name": "NotARealSpec",
+                            "input_cols": ["a"],
+                            "output_cols": ["b"],
+                        }
+                    ],
+                }
+            )
+
+    def test_round_trip_preserves_hydrated_stats(self) -> None:
+        """A hydrated (fitted) spec round-trips through to_dict/load_from_dict."""
+        raw = {
+            "transform_specs": [
+                {
+                    "transform_name": "StandardScaler",
+                    "input_cols": ["x"],
+                    "output_cols": ["x_scaled"],
+                },
+            ]
+        }
+        spec = TransformSpec(raw_transform_specs=raw)
+        spec.update_standard_scaler_specs({"x_mean": 5.0, "x_std": 2.0})
+
+        restored = TransformSpec(raw_transform_specs={"transform_specs": []})
+        restored.load_from_dict(spec.to_dict())
+
+        (restored_spec,) = restored.transform_specs.values()
+        assert isinstance(restored_spec, NormalizationLayerSpec)
+        assert restored_spec.mean == [5.0]
+        assert restored_spec.std == [2.0]
+
+
+class TestRegistries:
+    """Module-level layer/spec registries."""
+
+    def test_registries_are_populated_and_consistent(self) -> None:
+        """The layer/spec/class-name registries are non-empty and consistent."""
+        assert len(TORCH_TRANSFORM_LAYERS_DICT) > 0
+        assert len(TORCH_TRANSFORM_LAYERS_SPECS_DICT) > 0
+        assert len(TORCH_TRANSFORM_LAYER_CLASS_NAME_TO_SPEC_CLASS_NAME_DICT) > 0
+
+        for layer_name, layer_cls in TORCH_TRANSFORM_LAYERS_DICT.items():
+            assert layer_name == layer_cls.__name__
+            assert layer_name in TORCH_TRANSFORM_LAYERS_SPECS_DICT
+
+        for spec_cls in TORCH_TRANSFORM_LAYERS_SPECS_DICT.values():
+            assert (
+                spec_cls.__name__
+                in TORCH_TRANSFORM_LAYER_CLASS_NAME_TO_SPEC_CLASS_NAME_DICT
+            )

--- a/python/michelangelo/lib/native_transform/torch/tests/test_transform_spec.py
+++ b/python/michelangelo/lib/native_transform/torch/tests/test_transform_spec.py
@@ -427,6 +427,39 @@ class TestUpdateNumericalStandardTransformParameters:
         )
         assert numerical_spec.cap_min == "0.01"
 
+    def test_resolves_with_explicit_custom_name_not_matching_prefix(self) -> None:
+        """Percentile resolution must not depend on ``name`` looking like the prefix.
+
+        Internal's name-string-prefix dispatch misses a spec given an
+        explicit ``name`` that doesn't start with the class prefix, silently
+        leaving ``cap_min``/``cap_max`` as unresolved percentile strings
+        instead of raising. This spec's ``name`` is deliberately chosen not
+        to match, to lock in that ``isinstance()`` dispatch has no equivalent
+        blind spot.
+        """
+        raw = {
+            "transform_specs": [
+                {
+                    "transform_name": "NumericalStandardTransform",
+                    "name": "my_custom_numerical_transform",
+                    "input_cols": ["col5"],
+                    "output_cols": ["col5_transformed"],
+                },
+            ]
+        }
+        spec = TransformSpec(raw_transform_specs=raw)
+        (placeholder,) = spec.transform_specs.values()
+        assert placeholder.name == "my_custom_numerical_transform"
+
+        spec.update_numerical_standard_transform_parameters(
+            {"col5_1": 0.1, "col5_99": 99.9, "col5_50": 50.0}
+        )
+
+        (resolved,) = spec.transform_specs.values()
+        assert resolved.cap_min == 0.1
+        assert resolved.cap_max == 99.9
+        assert resolved.default_value == 50.0
+
 
 class TestUpdateStandardScalerSpecs:
     """``update_standard_scaler_specs`` placeholder-hydration behavior."""
@@ -481,6 +514,38 @@ class TestUpdateStandardScalerSpecs:
         assert hydrated.std == [2.0]
         layers = spec.to_transform_layers(target_transform_level=0)
         assert len(layers) == 1
+
+    def test_hydration_with_explicit_custom_name_not_matching_prefix(self) -> None:
+        """Hydration must not depend on ``name`` looking like the class prefix.
+
+        Internal's name-string-prefix dispatch (``layer_spec.name.startswith(
+        "standardscaler")``) silently fails to hydrate a placeholder given an
+        explicit, non-generated ``name`` that doesn't happen to start with the
+        class prefix -- the spec is left un-hydrated with no error. This spec
+        gives the placeholder an explicit custom name specifically chosen to
+        not match that prefix, to lock in that ``isinstance()`` dispatch has
+        no equivalent blind spot.
+        """
+        raw = {
+            "transform_specs": [
+                {
+                    "transform_name": "StandardScaler",
+                    "name": "my_custom_feature_scaler",
+                    "input_cols": ["x"],
+                    "output_cols": ["x_scaled"],
+                },
+            ]
+        }
+        spec = TransformSpec(raw_transform_specs=raw)
+        (placeholder,) = spec.transform_specs.values()
+        assert placeholder.name == "my_custom_feature_scaler"
+
+        spec.update_standard_scaler_specs({"x_mean": 5.0, "x_std": 2.0})
+
+        (hydrated,) = spec.transform_specs.values()
+        assert isinstance(hydrated, NormalizationLayerSpec)
+        assert hydrated.mean == [5.0]
+        assert hydrated.std == [2.0]
 
 
 class TestUpdateMinMaxScalerSpecs:

--- a/python/michelangelo/lib/native_transform/torch/transform_spec.py
+++ b/python/michelangelo/lib/native_transform/torch/transform_spec.py
@@ -264,10 +264,9 @@ class TransformSpec:
                 layer_spec.input_cols[0], torch.float32
             )
             # Regenerate the layer spec so any dtype-dependent validators re-run.
-            spec_cls = TORCH_TRANSFORM_LAYERS_SPECS_DICT[
-                layer_spec.__class__.__name__.replace("LayerSpec", "")
-            ]
-            self.transform_specs[layer_name] = spec_cls(**layer_spec.model_dump())
+            self.transform_specs[layer_name] = type(layer_spec)(
+                **layer_spec.model_dump()
+            )
 
     def update_numerical_standard_transform_parameters(
         self, percentile_dict: dict[str, float], target_transform_level: int = 0

--- a/python/michelangelo/lib/native_transform/torch/transform_spec.py
+++ b/python/michelangelo/lib/native_transform/torch/transform_spec.py
@@ -1,0 +1,911 @@
+"""The ``TransformSpec`` DAG engine.
+
+Bridges the two parallel representations of a native transform: a
+declarative, serializable ``*LayerSpec`` (see
+:mod:`~michelangelo.lib.native_transform.torch.transform_layer_spec`) and an
+executable ``nn.Module`` layer (see
+:mod:`~michelangelo.lib.native_transform.torch.base_layers` and
+:mod:`~michelangelo.lib.native_transform.torch.stats_layers`).
+
+:class:`TransformSpec` parses a raw dict (typically loaded from YAML) of
+layer specs, topologically sorts them into dependency "levels" by their
+input/output column references, and exposes per-level accessors used to
+drive fit-then-materialize training: compute the statistics a level's
+placeholder specs need
+(:meth:`TransformSpec.get_numerical_statistics_computation_specs`), hydrate
+those placeholders into concrete specs once the statistics are available
+(the ``update_*`` methods), then materialize the level as executable layers
+(:meth:`TransformSpec.to_transform_layers`).
+
+Dispatch for placeholder hydration and this fitted category detection is by
+``isinstance()`` against the spec's real pydantic type. This is a deliberate
+change from the internal implementation, which dispatched by parsing a
+name-string prefix off ``layer_spec.name`` (the lowercased class name, from
+:func:`~michelangelo.lib.native_transform.torch.utils.generate_layer_name`).
+Since every spec here is a concrete, statically-known pydantic class,
+``isinstance()`` is strictly more robust: it cannot silently break if a
+layer's name or ``generate_layer_name()``'s output format ever changes,
+which the string-prefix approach could.
+"""
+
+from __future__ import annotations
+
+import json
+from enum import Enum
+from typing import Any
+
+import torch
+import yaml
+
+from michelangelo.lib.native_transform.torch.base_layers import (
+    CaseWhen,
+    Cast,
+    Ceil,
+    Clip,
+    Compare,
+    Concatenate,
+    Constant,
+    Divide,
+    Floor,
+    IdentityTransform,
+    IDHashTokenizer,
+    LogTransform,
+    PadOrCrop1D,
+    Scale,
+    Stack,
+    Subtract,
+    TensorColFillNone,
+    Tile,
+    TorchTransformBaseLayer,
+)
+from michelangelo.lib.native_transform.torch.constants import (
+    DEFAULT_MIN_MAX_SCALER_NAME,
+    DEFAULT_STANDARD_SCALER_NAME,
+    TORCH_DTYPE_CLASS_NAME_TO_TORCH_TYPE_MAP,
+    TORCH_TYPE_TO_TORCH_DTYPE_CLASS_NAME_MAP,
+)
+from michelangelo.lib.native_transform.torch.stats_layers import (
+    Bucketization,
+    MinMax,
+    Normalization,
+)
+from michelangelo.lib.native_transform.torch.transform_layer_spec import (
+    BucketizationLayerSpec,
+    CaseWhenLayerSpec,
+    CastLayerSpec,
+    CeilLayerSpec,
+    ClipLayerSpec,
+    CompareLayerSpec,
+    ConcatenateLayerSpec,
+    ConstantLayerSpec,
+    DivideLayerSpec,
+    FloorLayerSpec,
+    IdentityTransformLayerSpec,
+    IDHashTokenizerLayerSpec,
+    LogTransformLayerSpec,
+    MinMaxLayerSpec,
+    MinMaxScalerLayerSpec,
+    NormalizationLayerSpec,
+    NumericalStandardTransformLayerSpec,
+    PadOrCrop1DLayerSpec,
+    PercentileBucketizationLayerSpec,
+    ScaleLayerSpec,
+    StackLayerSpec,
+    StandardScalerLayerSpec,
+    SubtractLayerSpec,
+    TensorColFillNoneLayerSpec,
+    TileLayerSpec,
+    TorchTransformLayerSpec,
+)
+
+__all__ = [
+    "TORCH_TRANSFORM_LAYERS_DICT",
+    "TORCH_TRANSFORM_LAYERS_SPECS_DICT",
+    "TORCH_TRANSFORM_LAYER_CLASS_NAME_TO_SPEC_CLASS_NAME_DICT",
+    "TransformSpec",
+]
+
+
+TORCH_TRANSFORM_LAYERS_DICT: dict[str, type[TorchTransformBaseLayer]] = {
+    layer_cls.__name__: layer_cls
+    for layer_cls in (
+        Concatenate,
+        Stack,
+        MinMax,
+        Normalization,
+        Bucketization,
+        TensorColFillNone,
+        Cast,
+        CaseWhen,
+        Compare,
+        Constant,
+        Divide,
+        PadOrCrop1D,
+        Tile,
+        LogTransform,
+        Subtract,
+        Scale,
+        Floor,
+        Ceil,
+        Clip,
+        IDHashTokenizer,
+        IdentityTransform,
+    )
+}
+"""Maps a transform layer's class name to the executable layer class."""
+
+
+TORCH_TRANSFORM_LAYERS_SPECS_DICT: dict[str, type[TorchTransformLayerSpec]] = {
+    spec_cls.__name__.replace("LayerSpec", ""): spec_cls
+    for spec_cls in (
+        ConcatenateLayerSpec,
+        StackLayerSpec,
+        MinMaxLayerSpec,
+        NormalizationLayerSpec,
+        NumericalStandardTransformLayerSpec,
+        BucketizationLayerSpec,
+        PercentileBucketizationLayerSpec,
+        TensorColFillNoneLayerSpec,
+        CastLayerSpec,
+        CaseWhenLayerSpec,
+        CompareLayerSpec,
+        ConstantLayerSpec,
+        DivideLayerSpec,
+        PadOrCrop1DLayerSpec,
+        TileLayerSpec,
+        LogTransformLayerSpec,
+        SubtractLayerSpec,
+        ScaleLayerSpec,
+        FloorLayerSpec,
+        CeilLayerSpec,
+        ClipLayerSpec,
+        IDHashTokenizerLayerSpec,
+        IdentityTransformLayerSpec,
+    )
+}
+# Placeholder specs, keyed by the transform name a raw spec dict names them
+# with, that get resolved to a concrete spec after stats/vocab hydration.
+TORCH_TRANSFORM_LAYERS_SPECS_DICT[DEFAULT_STANDARD_SCALER_NAME] = (
+    StandardScalerLayerSpec
+)
+TORCH_TRANSFORM_LAYERS_SPECS_DICT[DEFAULT_MIN_MAX_SCALER_NAME] = MinMaxScalerLayerSpec
+"""Maps a raw spec dict's ``transform_name`` to the pydantic spec class."""
+
+
+TORCH_TRANSFORM_LAYER_CLASS_NAME_TO_SPEC_CLASS_NAME_DICT: dict[
+    str, type[TorchTransformLayerSpec]
+] = {
+    spec_cls.__name__: spec_cls
+    for spec_cls in TORCH_TRANSFORM_LAYERS_SPECS_DICT.values()
+}
+"""Maps a spec class's own ``__name__`` to itself, for ``to_dict``/``load_from_dict``
+round-trips that persist ``layer_spec_class_name`` rather than the transform name."""
+
+
+class TransformSpec:
+    """A declarative DAG of native transform layers.
+
+    Parses a raw dict of layer specs (typically loaded from YAML) into
+    :class:`~michelangelo.lib.native_transform.torch.transform_layer_spec.TorchTransformLayerSpec`
+    instances, topologically sorts them into dependency "levels" by their
+    input/output column references, and exposes accessors used to drive
+    fit-then-materialize training and serving.
+
+    Args:
+        transform_spec_yaml_path: Path to a YAML file containing the raw
+            transform spec dict. Takes precedence over
+            ``raw_transform_specs`` when both are provided.
+        raw_transform_specs: The raw transform spec dict directly, as an
+            alternative to loading it from a YAML file.
+
+    Raises:
+        ValueError: If neither ``transform_spec_yaml_path`` nor
+            ``raw_transform_specs`` is provided.
+    """
+
+    def __init__(
+        self,
+        transform_spec_yaml_path: str | None = None,
+        raw_transform_specs: dict[str, Any] | None = None,
+    ) -> None:
+        """Initialize the TransformSpec.
+
+        Args:
+            transform_spec_yaml_path: Path to a YAML file containing the raw
+                transform spec dict. Takes precedence over
+                ``raw_transform_specs`` when both are provided.
+            raw_transform_specs: The raw transform spec dict directly, as an
+                alternative to loading it from a YAML file.
+
+        Raises:
+            ValueError: If neither ``transform_spec_yaml_path`` nor
+                ``raw_transform_specs`` is provided.
+        """
+        self.transform_spec_yaml_path = transform_spec_yaml_path
+        if transform_spec_yaml_path is None and raw_transform_specs is None:
+            raise ValueError(
+                "Either transform_spec_yaml_path or raw_transform_specs must be "
+                "provided"
+            )
+        if transform_spec_yaml_path is not None:
+            with open(transform_spec_yaml_path) as f:
+                raw_transform_specs = yaml.safe_load(f)
+        self.transform_specs: dict[str, TorchTransformLayerSpec] = (
+            self._generate_transform_specs(raw_transform_specs)
+        )
+        self.columns_to_keep: list[str] | None = self._generate_columns_to_keep(
+            raw_transform_specs
+        )
+        self.transform_levels: dict[str, int] = self._topological_sort()
+
+    def update_input_dtype(
+        self, data_dtype_dict: dict[str, torch.dtype], target_transform_level: int = 0
+    ) -> None:
+        """Populate ``input_dtype`` on every level-0 spec from a dataset's dtypes.
+
+        Args:
+            data_dtype_dict: Mapping from column name to the dtype observed
+                in the dataset.
+            target_transform_level: Only specs at this level are updated.
+
+        Raises:
+            ValueError: If a spec's first input column is not present in
+                ``data_dtype_dict``.
+        """
+        for layer_name, layer_spec in self.transform_specs.items():
+            if self.transform_levels[layer_spec.name] != target_transform_level:
+                continue
+            if layer_spec.input_cols[0] not in data_dtype_dict:
+                raise ValueError(
+                    f"Input column {layer_spec.input_cols[0]} not found in "
+                    "data dtype dict"
+                )
+            layer_spec.input_dtype = data_dtype_dict.get(
+                layer_spec.input_cols[0], torch.float32
+            )
+            # Regenerate the layer spec so any dtype-dependent validators re-run.
+            spec_cls = TORCH_TRANSFORM_LAYERS_SPECS_DICT[
+                layer_spec.__class__.__name__.replace("LayerSpec", "")
+            ]
+            self.transform_specs[layer_name] = spec_cls(**layer_spec.model_dump())
+
+    def update_numerical_standard_transform_parameters(
+        self, percentile_dict: dict[str, float], target_transform_level: int = 0
+    ) -> None:
+        """Resolve percentile-string cap/default values on numerical-transform specs.
+
+        Args:
+            percentile_dict: Mapping from ``f"{column}_{percentile}"`` to the
+                computed percentile value.
+            target_transform_level: Only specs at this level are updated.
+        """
+        for layer_spec in self.transform_specs.values():
+            if self.transform_levels[layer_spec.name] != target_transform_level:
+                continue
+            if not isinstance(layer_spec, NumericalStandardTransformLayerSpec):
+                continue
+            input_col = layer_spec.input_cols[0]
+            if not isinstance(layer_spec.cap_min, float):
+                layer_spec.cap_min = float(
+                    percentile_dict.get(
+                        f"{input_col}_{int(100 * float(layer_spec.cap_min))!s}", 0.0
+                    )
+                )
+            if not isinstance(layer_spec.cap_max, float):
+                layer_spec.cap_max = float(
+                    percentile_dict.get(
+                        f"{input_col}_{int(100 * float(layer_spec.cap_max))!s}", 1.0
+                    )
+                )
+            if not isinstance(layer_spec.default_value, float):
+                layer_spec.default_value = float(
+                    percentile_dict.get(
+                        f"{input_col}_{int(100 * float(layer_spec.default_value))!s}",
+                        -1.0,
+                    )
+                )
+
+    def update_standard_scaler_specs(
+        self, stats_dict: dict[str, float], target_transform_level: int = 0
+    ) -> None:
+        """Hydrate ``StandardScalerLayerSpec`` into a fitted ``NormalizationLayerSpec``.
+
+        Args:
+            stats_dict: Mapping from ``f"{column}_mean"`` / ``f"{column}_std"``
+                to the computed statistic.
+            target_transform_level: Only specs at this level are hydrated.
+        """
+        new_layer_specs: dict[str, TorchTransformLayerSpec] = {}
+        for layer_spec in self.transform_specs.values():
+            if self.transform_levels[
+                layer_spec.name
+            ] != target_transform_level or not isinstance(
+                layer_spec, StandardScalerLayerSpec
+            ):
+                new_layer_specs[layer_spec.name] = layer_spec
+                continue
+            input_cols = layer_spec.input_cols
+            mean_list = []
+            std_list = []
+            for input_col in input_cols:
+                mean_list.append(stats_dict.get(f"{input_col}_mean", 0.0))
+                std_list.append(stats_dict.get(f"{input_col}_std", 1.0))
+            new_layer_spec = NormalizationLayerSpec(
+                input_dtype=torch.float32,
+                input_cols=input_cols,
+                output_cols=layer_spec.output_cols,
+                mean=mean_list,
+                std=std_list,
+            )
+            new_layer_specs[new_layer_spec.name] = new_layer_spec
+        self.transform_specs = new_layer_specs
+        self.transform_levels = self._topological_sort()
+
+    def update_min_max_scaler_specs(
+        self, stats_dict: dict[str, float], target_transform_level: int = 0
+    ) -> None:
+        """Hydrate ``MinMaxScalerLayerSpec`` into a fitted ``MinMaxLayerSpec``.
+
+        Args:
+            stats_dict: Mapping from ``f"{column}_min"`` / ``f"{column}_max"``
+                to the computed statistic.
+            target_transform_level: Only specs at this level are hydrated.
+        """
+        new_layer_specs: dict[str, TorchTransformLayerSpec] = {}
+        for layer_spec in self.transform_specs.values():
+            if self.transform_levels[
+                layer_spec.name
+            ] != target_transform_level or not isinstance(
+                layer_spec, MinMaxScalerLayerSpec
+            ):
+                new_layer_specs[layer_spec.name] = layer_spec
+                continue
+            input_cols = layer_spec.input_cols
+            min_list = []
+            max_list = []
+            for input_col in input_cols:
+                min_list.append(stats_dict.get(f"{input_col}_min", 0.0))
+                max_list.append(stats_dict.get(f"{input_col}_max", 1.0))
+            new_layer_spec = MinMaxLayerSpec(
+                input_dtype=torch.float32,
+                input_cols=input_cols,
+                output_cols=layer_spec.output_cols,
+                min=min_list,
+                max=max_list,
+            )
+            new_layer_specs[new_layer_spec.name] = new_layer_spec
+        self.transform_specs = new_layer_specs
+        self.transform_levels = self._topological_sort()
+
+    def update_bucketization_specs(
+        self, stats_dict: dict[str, float], target_transform_level: int = 0
+    ) -> None:
+        """Hydrate ``PercentileBucketizationLayerSpec`` using computed percentiles.
+
+        Args:
+            stats_dict: Mapping from ``f"{column}_{percentile}"`` to the
+                computed boundary value.
+            target_transform_level: Only specs at this level are hydrated.
+        """
+        new_layer_specs: dict[str, TorchTransformLayerSpec] = {}
+        for layer_spec in self.transform_specs.values():
+            if self.transform_levels[
+                layer_spec.name
+            ] != target_transform_level or not self._is_percentile_bucketization_layer(
+                layer_spec
+            ):
+                new_layer_specs[layer_spec.name] = layer_spec
+                continue
+            input_col = layer_spec.input_cols[0]
+            new_boundaries = []
+            for percentile in layer_spec.percentiles:
+                percentile_key = f"{input_col}_{int(100 * float(percentile))!s}"
+                new_boundaries.append(float(stats_dict.get(percentile_key, 0.0)))
+            new_layer_spec = BucketizationLayerSpec(
+                input_dtype=layer_spec.input_dtype,
+                input_cols=layer_spec.input_cols,
+                output_cols=layer_spec.output_cols,
+                boundaries=new_boundaries,
+                dtype=layer_spec.dtype,
+            )
+            new_layer_specs[new_layer_spec.name] = new_layer_spec
+        self.transform_specs = new_layer_specs
+        self.transform_levels = self._topological_sort()
+
+    def to_transform_layers(
+        self, target_transform_level: int = 0
+    ) -> list[TorchTransformBaseLayer]:
+        """Materialize every spec at a level into an executable layer.
+
+        Args:
+            target_transform_level: Only specs at this level are materialized.
+
+        Returns:
+            The materialized layers, in spec-dict iteration order.
+
+        Raises:
+            ValueError: If a spec's layer class is not registered in
+                :data:`TORCH_TRANSFORM_LAYERS_DICT` (i.e. it is still an
+                unfitted placeholder).
+        """
+        layers = []
+        for layer_spec in self.transform_specs.values():
+            if self.transform_levels[layer_spec.name] != target_transform_level:
+                continue
+            layer_name = layer_spec.__class__.__name__.replace("LayerSpec", "")
+            if layer_name not in TORCH_TRANSFORM_LAYERS_DICT:
+                raise ValueError(f"Transform layer {layer_name} not found")
+            layers.append(
+                TORCH_TRANSFORM_LAYERS_DICT[layer_name](**layer_spec.model_dump())
+            )
+        return layers
+
+    def get_transform_layer_spec(
+        self,
+        target_transform_level: int | None = None,
+        target_transform_type: type[TorchTransformLayerSpec] | None = None,
+    ) -> list[TorchTransformLayerSpec]:
+        """Look up specs by level and/or spec type.
+
+        Args:
+            target_transform_level: Restrict to specs at this level. When
+                ``None``, every level is considered.
+            target_transform_type: Restrict to specs of this type. When
+                ``None``, every type is considered.
+
+        Returns:
+            The matching specs.
+
+        Raises:
+            ValueError: If no spec matches the given filters.
+        """
+        valid_layer_specs = []
+        for layer_spec in self.transform_specs.values():
+            if (
+                target_transform_level is None
+                or self.transform_levels[layer_spec.name] == target_transform_level
+            ) and (
+                target_transform_type is None
+                or type(layer_spec).__name__ == target_transform_type.__name__
+            ):
+                valid_layer_specs.append(layer_spec)
+        if len(valid_layer_specs) == 0:
+            raise ValueError(
+                "No transform layer spec found for transform level "
+                f"{target_transform_level}"
+            )
+        return valid_layer_specs
+
+    def get_input_dtype_map(
+        self, target_transform_level: int = 0
+    ) -> dict[str, torch.dtype]:
+        """Get column -> dtype mapping for input columns at the given level.
+
+        Only meaningful after :meth:`update_input_dtype` has been called,
+        which populates ``input_dtype`` from the dataset's schema.
+
+        Args:
+            target_transform_level: Only specs at this level are considered.
+
+        Returns:
+            Mapping from input column name to its resolved dtype.
+        """
+        dtype_map: dict[str, torch.dtype] = {}
+        for layer_spec in self.transform_specs.values():
+            if self.transform_levels[layer_spec.name] != target_transform_level:
+                continue
+            if layer_spec.input_dtype is not None:
+                for col in layer_spec.input_cols:
+                    if col not in dtype_map:
+                        dtype_map[col] = layer_spec.input_dtype
+        return dtype_map
+
+    def get_transform_input_cols(self, target_transform_level: int = 0) -> list[str]:
+        """Get the sorted set of input columns referenced at a level.
+
+        Args:
+            target_transform_level: Only specs at this level are considered.
+
+        Returns:
+            The sorted, de-duplicated input column names.
+        """
+        input_cols = set()
+        for layer_spec in self.transform_specs.values():
+            if self.transform_levels[layer_spec.name] != target_transform_level:
+                continue
+            input_cols.update(layer_spec.input_cols)
+        return sorted(input_cols)
+
+    def get_transform_output_cols(self, target_transform_level: int = 0) -> list[str]:
+        """Get the sorted set of output columns produced at a level.
+
+        Args:
+            target_transform_level: Only specs at this level are considered.
+
+        Returns:
+            The sorted, de-duplicated output column names.
+        """
+        output_cols = set()
+        for layer_spec in self.transform_specs.values():
+            if self.transform_levels[layer_spec.name] != target_transform_level:
+                continue
+            output_cols.update(layer_spec.output_cols)
+        return sorted(output_cols)
+
+    def get_max_transform_level(self) -> int:
+        """Get the highest transform level in the DAG.
+
+        Returns:
+            The maximum level, or ``0`` if there are no specs.
+        """
+        return max(self.transform_levels.values()) if self.transform_levels else 0
+
+    def get_numerical_statistics_computation_specs(
+        self, target_transform_level: int = 0
+    ) -> dict[str, dict[str, Any]]:
+        """Get the statistics required to hydrate placeholders at a level.
+
+        Args:
+            target_transform_level: Only specs at this level are considered.
+
+        Returns:
+            Mapping from input column to a dict with keys ``percentiles``
+            (a sorted, de-duplicated list of required percentile values),
+            and boolean ``mean``, ``std``, ``min``, ``max`` flags.
+        """
+        numerical_statistics_computation_specs: dict[str, dict[str, Any]] = {}
+        for layer_spec in self.transform_specs.values():
+            if self.transform_levels[layer_spec.name] != target_transform_level:
+                continue
+            self._process_layer_for_statistics(
+                layer_spec, numerical_statistics_computation_specs
+            )
+        self._finalize_numerical_statistics_computation_specs(
+            numerical_statistics_computation_specs
+        )
+        return numerical_statistics_computation_specs
+
+    def _process_layer_for_statistics(
+        self,
+        layer_spec: TorchTransformLayerSpec,
+        statistics_specs: dict[str, dict[str, Any]],
+    ) -> None:
+        """Dispatch a single spec to its statistics-requirement collector."""
+        if isinstance(layer_spec, NumericalStandardTransformLayerSpec):
+            self._add_numerical_transform_requirements(layer_spec, statistics_specs)
+        elif isinstance(layer_spec, StandardScalerLayerSpec):
+            self._add_standard_scaler_requirements(layer_spec, statistics_specs)
+        elif isinstance(layer_spec, MinMaxScalerLayerSpec):
+            self._add_min_max_scaler_requirements(layer_spec, statistics_specs)
+        elif self._is_percentile_bucketization_layer(layer_spec):
+            self._add_percentile_bucketization_requirements(
+                layer_spec, statistics_specs
+            )
+
+    def _is_percentile_bucketization_layer(
+        self, layer_spec: TorchTransformLayerSpec
+    ) -> bool:
+        """Check whether a spec is an unfitted ``PercentileBucketizationLayerSpec``."""
+        return isinstance(layer_spec, PercentileBucketizationLayerSpec)
+
+    def _add_numerical_transform_requirements(
+        self,
+        layer_spec: NumericalStandardTransformLayerSpec,
+        statistics_specs: dict[str, dict[str, Any]],
+    ) -> None:
+        """Add percentile requirements for a numerical-transform spec, if capping."""
+        if not layer_spec.is_cap_value:
+            return
+        input_col = layer_spec.input_cols[0]
+        self._ensure_statistics_entry(input_col, statistics_specs)
+        for value in (layer_spec.cap_min, layer_spec.cap_max, layer_spec.default_value):
+            if isinstance(value, str):
+                statistics_specs[input_col]["percentiles"].append(value)
+
+    def _add_standard_scaler_requirements(
+        self,
+        layer_spec: StandardScalerLayerSpec,
+        statistics_specs: dict[str, dict[str, Any]],
+    ) -> None:
+        """Add mean/std requirements for a standard-scaler placeholder."""
+        for input_col in layer_spec.input_cols:
+            self._ensure_statistics_entry(input_col, statistics_specs)
+            if layer_spec.with_mean:
+                statistics_specs[input_col]["mean"] = True
+            if layer_spec.with_std:
+                statistics_specs[input_col]["std"] = True
+
+    def _add_min_max_scaler_requirements(
+        self,
+        layer_spec: MinMaxScalerLayerSpec,
+        statistics_specs: dict[str, dict[str, Any]],
+    ) -> None:
+        """Add min/max requirements for a min-max-scaler placeholder."""
+        for input_col in layer_spec.input_cols:
+            self._ensure_statistics_entry(input_col, statistics_specs)
+            statistics_specs[input_col]["min"] = True
+            statistics_specs[input_col]["max"] = True
+
+    def _add_percentile_bucketization_requirements(
+        self,
+        layer_spec: PercentileBucketizationLayerSpec,
+        statistics_specs: dict[str, dict[str, Any]],
+    ) -> None:
+        """Add percentile requirements for a percentile-bucketization placeholder."""
+        input_col = layer_spec.input_cols[0]
+        self._ensure_statistics_entry(input_col, statistics_specs)
+        for percentile in layer_spec.percentiles:
+            if percentile <= 0:
+                continue
+            if percentile < 1:
+                statistics_specs[input_col]["percentiles"].append(percentile)
+            elif percentile < 100:
+                statistics_specs[input_col]["percentiles"].append(percentile / 100)
+
+    def _ensure_statistics_entry(
+        self, input_col: str, statistics_specs: dict[str, dict[str, Any]]
+    ) -> None:
+        """Initialize the statistics-requirement entry for a column, if absent."""
+        if input_col not in statistics_specs:
+            statistics_specs[input_col] = {
+                "percentiles": [],
+                "max": False,
+                "min": False,
+                "std": False,
+                "mean": False,
+            }
+
+    def _finalize_numerical_statistics_computation_specs(
+        self, statistics_specs: dict[str, dict[str, Any]]
+    ) -> None:
+        """De-duplicate and sort the collected percentile requirements, in place."""
+        for stats in statistics_specs.values():
+            stats["percentiles"] = sorted(set(stats["percentiles"]))
+
+    def _generate_columns_to_keep(
+        self, raw_transform_specs: dict[str, Any]
+    ) -> list[str] | None:
+        """Validate and return the raw spec dict's ``columns_to_keep``, if any.
+
+        Args:
+            raw_transform_specs: The raw transform spec dict.
+
+        Returns:
+            The validated ``columns_to_keep`` list, or ``None`` if absent.
+
+        Raises:
+            ValueError: If ``columns_to_keep`` is present but is not a
+                non-empty list of strings.
+        """
+        columns_to_keep = raw_transform_specs.get("columns_to_keep")
+        if columns_to_keep is not None:
+            if not isinstance(columns_to_keep, list):
+                raise ValueError("columns_to_keep must be a list")
+            if len(columns_to_keep) == 0:
+                raise ValueError("columns_to_keep is empty")
+            if not all(isinstance(col, str) for col in columns_to_keep):
+                raise ValueError("columns_to_keep must be a list of strings")
+        return columns_to_keep
+
+    def _generate_transform_specs(
+        self, raw_transform_specs: dict[str, Any]
+    ) -> dict[str, TorchTransformLayerSpec]:
+        """Parse, deduplicate, and validate the raw spec dict's transform specs."""
+        transform_specs = self._load_transform_spec(raw_transform_specs)
+        filtered_specs = self._validate_transform_specs(transform_specs)
+        return {layer_spec.name: layer_spec for layer_spec in filtered_specs}
+
+    def _load_transform_spec(
+        self, raw_transform_specs: dict[str, Any]
+    ) -> list[TorchTransformLayerSpec]:
+        """Parse each raw spec dict entry into its pydantic spec class.
+
+        Raises:
+            ValueError: If an entry's ``transform_name`` is not registered in
+                :data:`TORCH_TRANSFORM_LAYERS_SPECS_DICT`.
+        """
+        transform_specs = []
+        for transform_layer_spec in raw_transform_specs.get("transform_specs", []):
+            layer_spec_name = transform_layer_spec.get("transform_name")
+            if layer_spec_name not in TORCH_TRANSFORM_LAYERS_SPECS_DICT:
+                raise ValueError(f"Transform layer spec {layer_spec_name} not found")
+            transform_specs.append(
+                TORCH_TRANSFORM_LAYERS_SPECS_DICT[layer_spec_name](
+                    **transform_layer_spec
+                )
+            )
+        return transform_specs
+
+    def _validate_transform_specs(
+        self, transform_specs: list[TorchTransformLayerSpec]
+    ) -> list[TorchTransformLayerSpec]:
+        """De-duplicate specs and validate output-column/name uniqueness.
+
+        Raises:
+            ValueError: If an output column is produced by more than one
+                layer, or a layer name is duplicated.
+        """
+        seen_specs = set()
+        filtered_specs = []
+        for layer_spec in transform_specs:
+            spec_key = self._get_transform_spec_key(layer_spec)
+            if spec_key in seen_specs:
+                continue
+            seen_specs.add(spec_key)
+            filtered_specs.append(layer_spec)
+
+        output_cols: set[str] = set()
+        layer_names: set[str] = set()
+        for layer_spec in filtered_specs:
+            for output_col in layer_spec.output_cols:
+                if output_col in output_cols:
+                    raise ValueError(
+                        f"Output column {output_col} is produced by multiple layers"
+                    )
+                output_cols.add(output_col)
+            if layer_spec.name in layer_names:
+                raise ValueError(f"Layer name {layer_spec.name} is duplicated")
+            layer_names.add(layer_spec.name)
+        return filtered_specs
+
+    def _topological_sort(self) -> dict[str, int]:
+        """Topologically sort specs into dependency levels via column references.
+
+        A spec at index ``i`` depends on any other spec that produces one of
+        its input columns; a spec with no such dependency starts at level 0,
+        and every other spec's level is one past the maximum level of its
+        dependencies.
+
+        Returns:
+            Mapping from spec name to its transform level.
+
+        Raises:
+            ValueError: If the specs' input/output column references form a
+                circular dependency.
+        """
+        column_to_producer: dict[str, int] = {}
+        layer_dependencies: dict[int, set[int]] = {}
+        layer_dependents: dict[int, set[int]] = {}
+
+        transform_specs = list(self.transform_specs.values())
+
+        for i, layer_spec in enumerate(transform_specs):
+            layer_dependencies[i] = set()
+            layer_dependents[i] = set()
+            for output_col in layer_spec.output_cols:
+                if output_col in column_to_producer:
+                    raise ValueError(
+                        f"Column '{output_col}' is produced by multiple layers"
+                    )
+                column_to_producer[output_col] = i
+
+        for i, layer_spec in enumerate(transform_specs):
+            for input_col in layer_spec.input_cols:
+                # If input_col is not produced by any layer, it is raw data.
+                if input_col in column_to_producer:
+                    producer_idx = column_to_producer[input_col]
+                    layer_dependencies[i].add(producer_idx)
+                    layer_dependents[producer_idx].add(i)
+
+        degree_groups: list[list[TorchTransformLayerSpec]] = []
+        remaining_layers = set(range(len(transform_specs)))
+        processed_layers: set[int] = set()
+
+        while remaining_layers:
+            current_group = [
+                layer_idx
+                for layer_idx in remaining_layers
+                if layer_dependencies[layer_idx].issubset(processed_layers)
+            ]
+            if not current_group:
+                remaining_specs = [transform_specs[i] for i in remaining_layers]
+                remaining_names = [spec.name for spec in remaining_specs]
+                raise ValueError(
+                    f"Circular dependency detected among layers: {remaining_names}"
+                )
+
+            degree_groups.append([transform_specs[i] for i in current_group])
+            for layer_idx in current_group:
+                processed_layers.add(layer_idx)
+                remaining_layers.remove(layer_idx)
+
+        transform_levels: dict[str, int] = {}
+        for i, group in enumerate(degree_groups):
+            for layer_spec in group:
+                transform_levels[layer_spec.name] = i
+        return transform_levels
+
+    def _get_transform_spec_key(self, transform_spec: TorchTransformLayerSpec) -> str:
+        """Generate a dedup key for a spec, ignoring its auto-generated name."""
+        spec_dict = transform_spec.model_dump()
+        spec_dict.pop("name", None)
+        sorted_items = sorted(spec_dict.items())
+        class_name = transform_spec.__class__.__name__
+        return f"{class_name}:{sorted_items!s}"
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the DAG to a plain, YAML/JSON-safe dict.
+
+        ``torch.dtype`` fields are serialized via
+        :data:`~michelangelo.lib.native_transform.torch.constants.TORCH_TYPE_TO_TORCH_DTYPE_CLASS_NAME_MAP`
+        and enum fields via their ``.value``, so the result round-trips
+        through both ``json.dumps`` and ``yaml.safe_dump``.
+
+        Returns:
+            A dict with ``transform_spec_yaml_path``, ``columns_to_keep``,
+            and a ``transform_specs`` list of per-layer dicts (each tagged
+            with ``layer_spec_class_name`` for :meth:`load_from_dict`).
+        """
+        spec_dict: dict[str, Any] = {
+            "transform_spec_yaml_path": self.transform_spec_yaml_path,
+            "transform_specs": [],
+            "columns_to_keep": self.columns_to_keep,
+        }
+        for layer_name, layer_spec in self.transform_specs.items():
+            layer_spec_dict = layer_spec.model_dump()
+            if "name" not in layer_spec_dict:
+                layer_spec_dict["name"] = layer_name
+            layer_spec_dict["layer_spec_class_name"] = layer_spec.__class__.__name__
+            for key, value in layer_spec_dict.items():
+                if isinstance(value, torch.dtype):
+                    layer_spec_dict[key] = TORCH_TYPE_TO_TORCH_DTYPE_CLASS_NAME_MAP[
+                        value
+                    ]
+                elif isinstance(value, Enum):
+                    layer_spec_dict[key] = value.value
+            spec_dict["transform_specs"].append(layer_spec_dict)
+        return spec_dict
+
+    def to_json(self) -> str:
+        """Serialize the DAG to a JSON string.
+
+        Returns:
+            The JSON serialization of :meth:`to_dict`.
+        """
+        return json.dumps(self.to_dict())
+
+    def load_from_json(self, json_str: str) -> None:
+        """Replace this DAG's state from a JSON string produced by :meth:`to_json`.
+
+        Args:
+            json_str: The JSON string to load from.
+        """
+        self.load_from_dict(json.loads(json_str))
+
+    def load_from_dict(self, spec_dict: dict[str, Any]) -> None:
+        """Replace this DAG's state from a dict produced by :meth:`to_dict`.
+
+        Args:
+            spec_dict: The dict to load from.
+
+        Raises:
+            ValueError: If an entry's ``layer_spec_class_name`` is not
+                registered in
+                :data:`TORCH_TRANSFORM_LAYER_CLASS_NAME_TO_SPEC_CLASS_NAME_DICT`.
+        """
+        self.transform_spec_yaml_path = spec_dict["transform_spec_yaml_path"]
+        self.columns_to_keep = spec_dict["columns_to_keep"]
+        transform_specs = []
+        for layer_spec in spec_dict["transform_specs"]:
+            for key, value in layer_spec.items():
+                if (
+                    isinstance(value, str)
+                    and value in TORCH_DTYPE_CLASS_NAME_TO_TORCH_TYPE_MAP
+                ):
+                    layer_spec[key] = TORCH_DTYPE_CLASS_NAME_TO_TORCH_TYPE_MAP[value]
+            layer_spec_class_name = layer_spec["layer_spec_class_name"]
+            if (
+                layer_spec_class_name
+                not in TORCH_TRANSFORM_LAYER_CLASS_NAME_TO_SPEC_CLASS_NAME_DICT
+            ):
+                raise ValueError(
+                    f"Layer spec class name {layer_spec_class_name} not found"
+                )
+            spec_cls = TORCH_TRANSFORM_LAYER_CLASS_NAME_TO_SPEC_CLASS_NAME_DICT[
+                layer_spec_class_name
+            ]
+            transform_specs.append(spec_cls(**layer_spec))
+        self.transform_specs = {
+            layer_spec.name: layer_spec for layer_spec in transform_specs
+        }
+        self.transform_levels = self._topological_sort()


### PR DESCRIPTION
## Summary

This is **PR B6** of the `native_transform` torch-core migration — the assembler-unblock milestone. It delivers:

- `lib/native_transform/torch/transform_spec.py` — the `TORCH_TRANSFORM_LAYERS_DICT` / `TORCH_TRANSFORM_LAYERS_SPECS_DICT` / `TORCH_TRANSFORM_LAYER_CLASS_NAME_TO_SPEC_CLASS_NAME_DICT` registries (spanning all 21 layer classes from PRs B1-B4 and all spec classes from B5), the `TransformSpec` class (topological sort into dependency levels, the `update_*` placeholder-hydration methods, `get_numerical_statistics_computation_specs`, and JSON/dict ser-de), and
- `lib/native_transform/torch/base_transform_module.py` — `TorchTransformModule` (the TorchScript-able `nn.Module` that runs a DAG of transform layers in topological order) and `get_transform_module` (materializes a level range of a `TransformSpec` into one).

Together these are the four+one symbols the `tabular_assembler` torch fuser needs (`TransformSpec`, `TORCH_TRANSFORM_LAYERS_DICT`, `TorchTransformModule`, `generate_layer_name`, `TORCH_TYPE_TO_TORCH_DTYPE_CLASS_NAME_MAP`) — this PR flips that fuser from gated to functional.

## Design deviation from internal (flagged per migration design doc)

Internal's `TransformSpec` dispatches placeholder hydration and fitted-category detection by parsing a **name-string prefix** off `layer_spec.name` (the lowercased class name from `generate_layer_name()`) — flagged in the OSS design doc as "the single riskiest hidden contract in the whole migration," since it breaks silently if layer naming ever drifts.

This port instead dispatches via **`isinstance()`** against the spec's real pydantic type (e.g. `isinstance(layer_spec, StandardScalerLayerSpec)`), since every spec here is a concrete, statically-known pydantic class rather than an untyped dict-like object. This is strictly more robust — it cannot silently break regardless of naming — and eliminates the hidden contract entirely rather than just preserving it. Verified behaviorally equivalent to internal for every hydration path exercised by the ported tests, and added an explicit test (`test_hydration_dispatches_via_generated_name_placeholder`) that builds a placeholder via a raw spec dict (auto-generating its name through the same `generate_layer_name()` used elsewhere), confirms the generated name format, and confirms hydration still resolves it end to end.

## Testing

- 346 tests passed, 1 skipped (pre-existing skip, unrelated) — full `lib/native_transform/` suite, no regressions.
- 99.27% combined statement+branch coverage on the two new files (99.18% `transform_spec.py`, 100% `base_transform_module.py`).
- Added a `torch.jit.script` + save/load round-trip test for `TorchTransformModule` (internal has no such test for this module).
- `ruff format --check` and `ruff check`: clean.

## Scope notes

- Does not touch the Ray-based batch inference/orchestration code (`lib/native_transform/ray/`, a separate PR), the `TransformSpec` <-> `ModelSchema` bridge (`schema.py`, PR B7), or `scale.py`/`duration.py`/`transform_utils.py` (PR B8, in progress in parallel).
