### PR TITLE
fix(go): bump Go SDK from 1.26.3 to 1.26.5 to close remaining CVE Scan findings

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -17,7 +17,7 @@ bazel_dep(name = "protobuf", version = "29.0-rc3", repo_name = "com_google_proto
 ###########################################
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(
-    version = "1.26.3",
+    version = "1.26.5",
 )
 go_sdk.nogo(
     includes = ["@//:__subpackages__"],


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Bumped the pinned Go SDK version in `MODULE.bazel` from `1.26.3` to `1.26.5` (`go_sdk.download(version = ...)`). This is the only file changed -- a single-line version string update.

No `rules_go` bump needed: version `0.57.0` (landed in Step 1, PR #1567) already supports Go 1.26.5.

**Why?**

Step 2 of the phased Go SDK bump to fix the CVE Scan workflow (issue #1565). Step 1 (#1567) bumped Go from 1.23.3 to 1.26.3, resolving 12 of the 15 CRITICAL/HIGH CVEs. Three CVEs remained open after Step 1:

| CVE | Severity | Minimum fix version |
|---|---|---|
| CVE-2026-27145 | HIGH | 1.26.4 |
| CVE-2026-42504 | HIGH | 1.26.4 |
| CVE-2026-39822 | HIGH | 1.26.5 |

Go 1.26.5 is the current latest stable 1.26.x patch release and closes all three remaining CVEs. After this merges and a Dev/Nightly Release rebuilds the `:latest` images, the CVE Scan workflow's `apiserver`/`controllermgr`/`worker` jobs should report zero Go SDK CRITICAL/HIGH findings (the original 15-finding failure).

**How did you test it?**

- `bazel build //go/...` -- succeeds (5115 total actions).
- `bazel test //go/...` -- 92/93 pass. The one failure (`go/storage/mysql` integration test) is pre-existing on `main` (verified: same test, same error on current `main`), not caused by this change.
- Built `apiserver`, `controllermgr`, `worker` linux/arm64 binaries with Go 1.26.5 and Docker images via `docker/service.Dockerfile`.
- Ran `trivy image --severity CRITICAL,HIGH` on all three images: **zero Go SDK CVEs remain** (all 15 original findings eliminated). Remaining findings are from Go module dependencies (golang.org/x/net, x/crypto, grpc, etc.) which require separate `go.mod` bumps and are out of scope for this change.

**Potential risks**

Minimal. This is a same-minor-version patch bump (1.26.3 to 1.26.5) with no API/language changes per Go's compatibility promise. Step 1's larger hop (1.23.3 to 1.26.3) already validated the full `bazel build`/`bazel test` regression pass and a successful sandbox runtime validation (full pipeline apply/run/succeed cycle).

**Breaking Changes**

- [x] No breaking changes

**Release notes**

N/A -- infrastructure-only change (build toolchain version bump), no user-facing behavior change.

**Documentation Changes**

N/A