### PR TITLE
build: bump gazelle 0.40.0 to 0.52.2, compatible with rules_go 0.57.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,7 +5,7 @@ module(name = "michelangelo")
 ###########################################
 bazel_dep(name = "rules_python", version = "0.40.0")
 bazel_dep(name = "rules_go", version = "0.57.0", repo_name = "io_bazel_rules_go")
-bazel_dep(name = "gazelle", version = "0.40.0", repo_name = "bazel_gazelle")
+bazel_dep(name = "gazelle", version = "0.52.2", repo_name = "bazel_gazelle")
 bazel_dep(name = "rules_python_gazelle_plugin", version = "0.40.0")
 bazel_dep(name = "rules_pkg", version = "1.0.1")
 bazel_dep(name = "rules_oci", version = "2.0.1")

--- a/go/cmd/apiserver/BUILD.bazel
+++ b/go/cmd/apiserver/BUILD.bazel
@@ -47,6 +47,7 @@ go_binary(
     env = {
         "CONFIG_DIR": "$(location :config)",
     },
+    # keep
     gc_linkopts = select({
         "@io_bazel_rules_go//go/platform:linux": [
             # The following GC options instruct Bazel to build a static binary for running the service in a static

--- a/go/cmd/controllermgr/BUILD.bazel
+++ b/go/cmd/controllermgr/BUILD.bazel
@@ -56,6 +56,7 @@ go_binary(
     env = {
         "CONFIG_DIR": "$(location :config)",
     },
+    # keep
     gc_linkopts = select({
         "@io_bazel_rules_go//go/platform:linux": [
             # The following GC options instruct Bazel to build a static binary for running the service in a static

--- a/go/cmd/worker/BUILD.bazel
+++ b/go/cmd/worker/BUILD.bazel
@@ -32,6 +32,7 @@ go_binary(
     env = {
         "CONFIG_DIR": "$(location :config)",
     },
+    # keep
     gc_linkopts = select({
         "@io_bazel_rules_go//go/platform:linux": [
             # The following GC options instruct Bazel to build a static binary for running the service in a static

--- a/proto/api/BUILD.bazel
+++ b/proto/api/BUILD.bazel
@@ -1,6 +1,6 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "api_proto",

--- a/proto/api/v2/BUILD.bazel
+++ b/proto/api/v2/BUILD.bazel
@@ -1,10 +1,11 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+
 # gazelle:go_proto_compilers //bazel/rules/proto:go_kubeproto,//bazel/rules/proto:go_kubeconversion
 # gazelle:go_grpc_compilers //bazel/rules/proto:go_kubeproto,//bazel/rules/proto:go_yarpc,//bazel/rules/proto:go_kubeyarpc,//bazel/rules/proto:go_validation,//bazel/rules/proto:go_kubeconversion
 # gazelle:exclude michelangelo_v2mock.go
 load("@io_bazel_rules_go//extras:gomock.bzl", "gomock")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
 load("//bazel/rules/proto:kube_proto_sql.bzl", "kube_proto_sql")
 load("//bazel/rules/proto:kube_proto_yaml.bzl", "kube_proto_yaml")
 

--- a/proto/test/api/v2alpha1/BUILD.bazel
+++ b/proto/test/api/v2alpha1/BUILD.bazel
@@ -1,8 +1,8 @@
 # gazelle:go_proto_compilers //bazel/rules/proto:go_kubeconversion,//bazel/rules/proto:go_kubeproto,//bazel/rules/proto:go_validation
 
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "v2alpha1_proto",

--- a/proto/test/extpackage/BUILD.bazel
+++ b/proto/test/extpackage/BUILD.bazel
@@ -1,6 +1,6 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "extpackage_proto",

--- a/proto/test/kubeproto/BUILD.bazel
+++ b/proto/test/kubeproto/BUILD.bazel
@@ -1,6 +1,6 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
 
 # gazelle:go_proto_compilers //bazel/rules/proto:go_kubeproto,//bazel/rules/proto:go_validation,//bazel/rules/proto:go_kubeproto_unittest
 

--- a/proto/test/kubeproto/conversion/v1/BUILD.bazel
+++ b/proto/test/kubeproto/conversion/v1/BUILD.bazel
@@ -1,6 +1,6 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "v1_proto",

--- a/proto/test/kubeproto/conversion/v2/BUILD.bazel
+++ b/proto/test/kubeproto/conversion/v2/BUILD.bazel
@@ -1,6 +1,6 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "v2_proto",

--- a/proto/test/kubeproto/indexing_errors/BUILD.bazel
+++ b/proto/test/kubeproto/indexing_errors/BUILD.bazel
@@ -1,7 +1,8 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+
 # gazelle:go_proto_compilers //bazel/rules/proto:go_kubeproto_unittest
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "kubeproto_proto",


### PR DESCRIPTION
Part of #1745.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Chore / build tooling

**What changed?**
Bumps `gazelle` from `0.40.0` to `0.52.2` in `MODULE.bazel`, and re-runs `bazel run //:gazelle` to regenerate `BUILD.bazel` files across the repo. `rules_go` was already bumped to `0.57.0` (#1567), and `gazelle` had fallen several releases behind — this repo's Bazel build depends on `rules_go`/`gazelle` staying close together for `BUILD.bazel` generation to stay correct.

Re-running gazelle after the bump produced two categories of change:

1. `proto_library`'s load source switched from `@rules_proto//proto:defs.bzl` to `@com_google_protobuf//bazel:proto_library.bzl` across 8 proto packages. No dependency or `go_grpc` compiler target changes — this is the newer gazelle preferring protobuf's own Bzlmod-native `proto_library` now that `protobuf` is a direct `bazel_dep` in this repo.
2. Gazelle wanted to strip the hand-written `gc_linkopts` static-linking block from `apiserver`/`controllermgr`/`worker`'s `go_binary` rules — that block is required for these binaries to run in the distroless base image (see the inline comment in each `BUILD.bazel`). The newer gazelle version treats `gc_linkopts` as a gazelle-managed attribute for `go_binary` and removes values it didn't generate itself. Fixed with a `# keep` marker above each `gc_linkopts` assignment (gazelle's documented mechanism for protecting a manually-set attribute) — verified by re-running gazelle again and confirming only the `# keep` comment was added, the block itself untouched.

**Why?**
Closes the `gazelle` version gap tracked in #1745, and specifically checks for the `proto_library`/`go_proto_library` dependency-rewiring regression reported in [bazel-contrib/bazel-gazelle#2252](https://github.com/bazel-contrib/bazel-gazelle/issues/2252) (still open/unresolved upstream) before landing — this repo has real proto-generated Go code, so that regression pattern was concretely worth checking for. It did not occur here (the only proto-related change is the `proto_library` load-source switch above, no target/dependency rewiring), but the static-linking-flag stripping was a separate, real regression this bump did trigger, now fixed.

**How did you test it?**
- `bazel build //...` — 5908 actions, full repo build succeeds.
- `bazel test //...` — 94/94 tests pass.
- `gofmt -l .` (scoped to `go/`) — clean.
- `golangci-lint run ./...` — clean (only pre-existing `godox` TODO-tracking findings in files this PR doesn't touch).
- Manually diffed the gazelle-regenerated output twice: once before adding `# keep` (confirmed the `gc_linkopts` stripping issue), once after (confirmed only the `# keep` comment was added, no other changes).

**Potential risks**
Low, but worth a careful review of the `BUILD.bazel` diff specifically: this is a generated-file-heavy change (gazelle can touch any package on a version bump), even though the effective behavior change here is narrow (a `proto_library` load-source swap with no semantic difference, plus a `# keep` marker preserving existing behavior). No source-code changes.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**
N/A — build-tooling change only, no functional or schema change.

**Documentation Changes**
N/A.