### PR TITLE
chore(lib): update california_housing example references in model_manager registry docstrings/tests

### DIFF
--- a/python/michelangelo/lib/model_manager/registry/api_client.py
+++ b/python/michelangelo/lib/model_manager/registry/api_client.py
@@ -146,13 +146,13 @@ class APIRegistryClient(ModelRegistryClient):
         client = APIClient(endpoint="apiserver:15566", caller="push-step")
         registry = APIRegistryClient(svc=client.ModelService, namespace="my-project")
         reg = registry.register_model(
-            name="california-housing-xgb",
-            artifact_uri="s3://bucket/models/california-housing-xgb/abc/raw/model.ubj",
+            name="my-model",
+            artifact_uri="s3://bucket/models/my-model/abc/raw/model.pt",
             kind=ModelKind.REGRESSION,
-            labels={"framework": "xgboost"},
+            labels={"framework": "pytorch"},
             metadata={"validation-rmse": 0.876},
         )
-        print(reg.registry_uri)  # "models:/my-project/california-housing-xgb/1"
+        print(reg.registry_uri)  # "models:/my-project/my-model/1"
     """
 
     def __init__(

--- a/python/michelangelo/lib/model_manager/registry/tests/api_client_test.py
+++ b/python/michelangelo/lib/model_manager/registry/tests/api_client_test.py
@@ -143,7 +143,7 @@ class TestAPIRegistryClientRegisterModel(TestCase):
         """
         svc = _mock_svc()
         long_value = (
-            "examples.pipelines.california_housing_lightning.model.TorchRegressionModel"
+            "com.example.models.california_housing.lightning.TorchRegressionModel"
         )
         self.assertGreater(len(long_value), 63)
         _client(svc).register_model(


### PR DESCRIPTION
Part of https://github.com/michelangelo-ai/michelangelo/issues/1748

**What type of PR is this? (check all applicable)**
- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Swaps a california-housing-specific docstring in `api_client.py` and a matching test fixture string in `api_client_test.py` for generic placeholders, since they no longer need to reference the `california_housing_xgb` pipeline by name.

This is part 2 of a 3-way split of #1746, which bundled these registry docstring/test updates with unrelated doc repointing and the pipeline deletion itself. Splitting lets each group be reviewed independently. See also:
- docs: repoint california_housing doc references to michelangelo-examples (#1749)
- chore(examples): remove california_housing_xgb pipeline (migrated to michelangelo-examples)

**Why?**

`california_housing_xgb` was ported to `michelangelo-examples` and is being removed from core. Docstrings and test fixtures that reference it by name would be stale/misleading once the pipeline is deleted, so they're generalized here independently of the deletion itself.

**How did you test it?**

- `ruff check` and `ruff format --check` on the two changed Python files — pass, already formatted.
- `python -m pytest python/michelangelo/lib/model_manager/registry/tests/api_client_test.py -x` — 25/25 passed.

**Potential risks**

None. This only changes a docstring and a test fixture string; no behavioral or API changes.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

N/A

**Documentation Changes**

N/A