### PR TITLE
fix(python): use __spec__.name for dot_path() under python -m

### DIFF
--- a/python/michelangelo/uniflow/core/utils.py
+++ b/python/michelangelo/uniflow/core/utils.py
@@ -19,15 +19,26 @@ def dot_path(arg: Any) -> str:
     module = arg.__module__
 
     if module == "__main__":
-        # Resolve the real module path of the __main__ module.
-        file = sys.modules[module].__file__
-        assert file
+        # Resolve the real module path of the __main__ module. When run via
+        # `python -m pkg.module`, __spec__.name already IS the real dotted
+        # path -- no path-string reconstruction needed, and unlike deriving
+        # it from __file__'s relative path, this is immune to any "." in
+        # the file path itself (e.g. a venv's own `lib/python3.11/...`).
+        spec = sys.modules[module].__spec__
+        if spec is not None and spec.name != "__main__":
+            module = spec.name
+        else:
+            # Plain `python script.py` invocation: __spec__ is None (or, in
+            # some embeddings, still reports "__main__"). Fall back to the
+            # existing relative-path reconstruction for this case only.
+            file = sys.modules[module].__file__
+            assert file
 
-        file = os.path.relpath(file, start=os.getcwd())
-        file, _ = os.path.splitext(file)
-        assert "." not in file
+            file = os.path.relpath(file, start=os.getcwd())
+            file, _ = os.path.splitext(file)
+            assert "." not in file
 
-        module = file.replace(os.path.sep, ".")
+            module = file.replace(os.path.sep, ".")
 
     return f"{module}.{arg.__name__}"
 

--- a/python/michelangelo/uniflow/core/utils.py
+++ b/python/michelangelo/uniflow/core/utils.py
@@ -1,3 +1,5 @@
+"""Generic helpers shared across the uniflow core package."""
+
 import argparse
 import dataclasses
 import importlib
@@ -16,6 +18,7 @@ log = logging.getLogger(__name__)
 
 
 def dot_path(arg: Any) -> str:
+    """Return the fully-qualified dotted path of a class or function."""
     module = arg.__module__
 
     if module == "__main__":
@@ -49,6 +52,7 @@ def log_attributes(
     obj,
     include_system=False,
 ):
+    """Log every non-dunder attribute of `obj` at the given log level."""
     if not logger.isEnabledFor(level):
         return
     logger.log(level, "%s", dot_path(type(obj)))
@@ -63,6 +67,7 @@ def log_attributes(
 
 
 def import_attribute(path: str, package=None):
+    """Import and return the attribute named by a dotted `path`."""
     m, attr = path.rsplit(".", 1)
     m = importlib.import_module(m, package=package)
     attr = getattr(m, attr)
@@ -70,18 +75,21 @@ def import_attribute(path: str, package=None):
 
 
 def dataclass_dict(v):
+    """Return a dataclass instance's fields as a shallow dict."""
     return {f.name: getattr(v, f.name) for f in dataclasses.fields(v)}
 
 
 def pydantic_dict(v: pydantic.BaseModel):
-    return {f: getattr(v, f) for f in v.model_fields.keys()}
+    """Return a pydantic model instance's fields as a shallow dict."""
+    return {f: getattr(v, f) for f in v.model_fields}
 
 
 class ArgparseEnvironAction(argparse.Action):
-    """Custom argparse action to parse environment variables from command line arguments.
+    """Custom argparse action to parse environment variables from the command line.
 
-    The action expects a list of strings, where each string can either be in the form 'ENV_VAR=value' or simply
-    'ENV_VAR'. If the latter, it fetches the value of 'ENV_VAR' from the current environment variables.
+    The action expects a list of strings, where each string can either be in
+    the form 'ENV_VAR=value' or simply 'ENV_VAR'. If the latter, it fetches
+    the value of 'ENV_VAR' from the current environment variables.
 
     Usage example:
 
@@ -93,6 +101,7 @@ class ArgparseEnvironAction(argparse.Action):
     """
 
     def __call__(self, _parser, namespace, values, _option_string=None):
+        """Parse `values` as ENV_VAR[=value] pairs into the destination dict."""
         assert isinstance(values, list), values
         dest = getattr(namespace, self.dest)
         assert isinstance(dest, dict), dest
@@ -102,14 +111,17 @@ class ArgparseEnvironAction(argparse.Action):
 
     @staticmethod
     def _parse_value(s: str):
-        """Parses a single command line argument to extract the environment variable and its value.
+        """Parse a single command line argument into an env var and its value.
+
         Parameters:
-            s: The command line argument. Expected format: "ENV_VAR=value" or just "ENV_VAR"
+            s: The command line argument. Expected format: "ENV_VAR=value" or
+                just "ENV_VAR"
         Returns:
             tuple: A tuple containing the environment variable name and its value.
 
         Raises:
-            KeyError: If the argument is not in the form 'ENV_VAR=value' and the environment variable is not found in os.environ.
+            KeyError: If the argument is not in the form 'ENV_VAR=value' and the
+                environment variable is not found in os.environ.
         """
         if "=" in s:
             env, val = s.split("=", maxsplit=1)
@@ -137,4 +149,5 @@ def encode_value_to_json(value, json_encoder: Optional[json.JSONEncoder] = None)
 
 
 def is_dataclass_instance(value):
+    """Return True if `value` is a dataclass instance, not a dataclass type."""
     return dataclasses.is_dataclass(value) and not inspect.isclass(value)

--- a/python/tests/uniflow/core/test_utils.py
+++ b/python/tests/uniflow/core/test_utils.py
@@ -132,23 +132,26 @@ class DataclassTestCase(unittest.TestCase):
 
 
 def _subprocess_env(**overrides):
-    """Build a subprocess env without pytest-cov's coverage propagation vars.
+    """Build a subprocess env that measures coverage against the right config.
 
-    pytest-cov injects COV_CORE_*/COVERAGE_PROCESS_START into the test
-    process's environment so that subprocesses can opt into coverage
-    measurement too. But those vars point a bare `COV_CORE_CONFIG=":"`
-    (no config file) at any subprocess that inherits them, so a spawned
-    subprocess re-measures the whole `source = ["michelangelo"]` tree with
-    none of pyproject.toml's `omit` patterns applied -- rediscovering every
-    untouched *_test.py file as "untested" and polluting the combined
-    coverage report. These subprocesses only exist to exercise dot_path()'s
-    `__main__` handling, so they should not participate in coverage at all.
+    pytest-cov injects COV_CORE_SOURCE/COV_CORE_CONFIG/COV_CORE_DATAFILE so
+    that a subprocess can opt into coverage measurement too. By default
+    COV_CORE_CONFIG is ":", meaning "auto-discover a config file from cwd"
+    -- but these tests spawn the subprocess from a throwaway tmp directory,
+    so that discovery can't find pyproject.toml's `omit` patterns and the
+    subprocess instead measures the whole `source = ["michelangelo"]` tree
+    unfiltered, rediscovering every untouched *_test.py file as "untested"
+    and dragging down the combined coverage report. Pointing COV_CORE_CONFIG
+    at the real pyproject.toml (found via COV_CORE_DATAFILE's directory,
+    which pytest-cov always sets alongside it) fixes the config discovery
+    without losing coverage of the lines this subprocess is meant to exercise.
     """
-    env = {
-        k: v
-        for k, v in os.environ.items()
-        if not k.startswith(("COV_CORE_", "COVERAGE_"))
-    }
+    env = dict(os.environ)
+    datafile = env.get("COV_CORE_DATAFILE")
+    if datafile:
+        pyproject = Path(datafile).resolve().parent / "pyproject.toml"
+        if pyproject.is_file():
+            env["COV_CORE_CONFIG"] = str(pyproject)
     env.update(overrides)
     return env
 

--- a/python/tests/uniflow/core/test_utils.py
+++ b/python/tests/uniflow/core/test_utils.py
@@ -1,4 +1,8 @@
 import os
+import subprocess
+import sys
+import tempfile
+import textwrap
 import unittest
 from dataclasses import dataclass, is_dataclass
 from pathlib import Path
@@ -108,3 +112,113 @@ class DataclassTestCase(unittest.TestCase):
         # Standard Python dataclass.is_dataclass returns true for both type and instance.
         self.assertTrue(is_dataclass(instance))
         self.assertTrue(is_dataclass(Resource))
+
+
+class DotPathMainTestCase(unittest.TestCase):
+    """Regression tests for dot_path()'s `__main__` special-case.
+
+    A function's __module__ is only ever bound to the literal string
+    "__main__" when the enclosing module is actually executed as the
+    program entry point -- a plain `import` of the module (as the rest of
+    this test file does) never reproduces that binding. These tests
+    therefore spawn a real `python -m pkg.module` subprocess, which is
+    the only way to genuinely exercise the buggy/fixed code path.
+    """
+
+    def test_dot_path_python_dash_m_with_dotted_file_path(self):
+        """`python -m pkg.module` must not crash on a dotted file path.
+
+        __file__ may transit a directory segment containing a literal "."
+        -- e.g. a virtualenv's own `lib/python3.11/site-packages/...`
+        layout for any pip-installed package. Regression test for GH-1753.
+        """
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_dir_path = Path(tmp_dir).resolve()
+
+            # Simulate a venv-style path segment with a literal "." in it
+            # (e.g. "python3.11") sitting between the run's cwd and the
+            # module's real __file__. The dotted segment only needs to be
+            # part of a sys.path entry -- it must NOT be part of the
+            # dotted package name itself, since directories added to
+            # sys.path are not part of the import path.
+            site_packages = tmp_dir_path / "lib.python3.11" / "site-packages"
+            pkg_dir = site_packages / "fakepkg"
+            pkg_dir.mkdir(parents=True)
+            (pkg_dir / "__init__.py").write_text("")
+            (pkg_dir / "mod.py").write_text(
+                textwrap.dedent(
+                    """
+                    from michelangelo.uniflow.core.utils import dot_path
+
+
+                    def foo():
+                        pass
+
+
+                    print(dot_path(foo))
+                    """
+                )
+            )
+
+            env = dict(os.environ)
+            existing_pythonpath = env.get("PYTHONPATH", "")
+            env["PYTHONPATH"] = os.pathsep.join(
+                p for p in [str(site_packages), existing_pythonpath] if p
+            )
+
+            result = subprocess.run(
+                [sys.executable, "-m", "fakepkg.mod"],
+                cwd=str(tmp_dir_path),
+                env=env,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(
+                0,
+                result.returncode,
+                msg=f"stdout={result.stdout!r} stderr={result.stderr!r}",
+            )
+            self.assertEqual("fakepkg.mod.foo", result.stdout.strip())
+
+    def test_dot_path_plain_script_invocation_still_uses_fallback(self):
+        """Plain `python script.py` invocation must still use the fallback.
+
+        `python script.py` (no `-m`) has no import spec (__spec__ is None),
+        so dot_path() must still fall back to the pre-existing
+        relative-path reconstruction. Confirms the fix doesn't regress this
+        already-working invocation style.
+        """
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_dir_path = Path(tmp_dir).resolve()
+            script_dir = tmp_dir_path / "scripts"
+            script_dir.mkdir()
+            script_path = script_dir / "plain_script.py"
+            script_path.write_text(
+                textwrap.dedent(
+                    """
+                    from michelangelo.uniflow.core.utils import dot_path
+
+
+                    def foo():
+                        pass
+
+
+                    print(dot_path(foo))
+                    """
+                )
+            )
+
+            result = subprocess.run(
+                [sys.executable, str(script_path)],
+                cwd=str(tmp_dir_path),
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(
+                0,
+                result.returncode,
+                msg=f"stdout={result.stdout!r} stderr={result.stderr!r}",
+            )
+            self.assertEqual("scripts.plain_script.foo", result.stdout.strip())

--- a/python/tests/uniflow/core/test_utils.py
+++ b/python/tests/uniflow/core/test_utils.py
@@ -1,3 +1,5 @@
+"""Tests for michelangelo.uniflow.core.utils."""
+
 import os
 import subprocess
 import sys
@@ -22,7 +24,10 @@ pwd = os.environ["PWD"]
 
 
 class Test(unittest.TestCase):
+    """Tests for fsspec URL resolution and JSON encoding helpers."""
+
     def test_fsspec_url_to_fs_no_scheme(self):
+        """A scheme-less path resolves relative to cwd, absolute paths pass through."""
         _, absolute_path = fsspec.core.url_to_fs("/host/path/data.json")
         _, relative_path = fsspec.core.url_to_fs("host/path/data.json")
 
@@ -32,6 +37,7 @@ class Test(unittest.TestCase):
         self.assertEqual(str(expected_relative_path), relative_path)
 
     def test_fsspec_url_to_fs_file(self):
+        """A `file://` URL resolves the same as a scheme-less path."""
         _, absolute_path = fsspec.core.url_to_fs("file:///host/path/data.json")
         _, relative_path = fsspec.core.url_to_fs("file://host/path/data.json")
 
@@ -41,6 +47,7 @@ class Test(unittest.TestCase):
         self.assertEqual(str(expected_relative_path), relative_path)
 
     def test_fsspec_url_to_fs_memory(self):
+        """A `memory://` URL always resolves to an absolute-only path."""
         # memory - absolute only path
         _, path1 = fsspec.core.url_to_fs("memory:///host/path/data.json")
         _, path2 = fsspec.core.url_to_fs("memory://host/path/data.json")
@@ -50,6 +57,7 @@ class Test(unittest.TestCase):
         self.assertEqual(expected_path, path2)
 
     def test_encode_value_to_json(self):
+        """encode_value_to_json() writes through a mocked NamedTemporaryFile."""
         # Mocking tempfile.NamedTemporaryFile
         mock_temp_file = MagicMock()
         mock_file = MagicMock()
@@ -59,14 +67,19 @@ class Test(unittest.TestCase):
 
 
 @dataclass
-class Resource:  # basic dataclass
+class Resource:
+    """Basic dataclass fixture used by the dataclass_dict/is_dataclass tests."""
+
     index: int
     path: str
     metadata: Optional[Any] = None
 
 
 class DataclassTestCase(unittest.TestCase):
+    """Tests for dataclass_dict() and is_dataclass_instance()."""
+
     def test_dataclass_dict_required_only_attrs(self):
+        """dataclass_dict() covers required attributes plus defaulted ones."""
         # Init resource with required only attributes
         resource = Resource(
             index=101,
@@ -81,8 +94,10 @@ class DataclassTestCase(unittest.TestCase):
         self.assertEqual(expected, dct)
 
     def test_dataclass_dict_non_recursive(self):
-        # Init resource with another inner resource in its metadata. The inner resource must not be converted to
-        # dictionary because dataclass_dict supposed to be non-recursive.
+        """dataclass_dict() does not recurse into a nested dataclass field."""
+        # Init resource with another inner resource in its metadata. The
+        # inner resource must not be converted to a dictionary because
+        # dataclass_dict is supposed to be non-recursive.
         resource = Resource(
             index=101,
             path="/resources/101",
@@ -103,15 +118,39 @@ class DataclassTestCase(unittest.TestCase):
         self.assertEqual(expected, dct)
 
     def test_is_dataclass_instance(self):
+        """is_dataclass_instance() is true only for instances, not the type."""
         instance = Resource(index=0, path="")
         self.assertTrue(is_dataclass_instance(instance))
         self.assertFalse(
             is_dataclass_instance(Resource)
         )  # Resource is not a dataclass type, not an instance
 
-        # Standard Python dataclass.is_dataclass returns true for both type and instance.
+        # Standard Python dataclass.is_dataclass returns true for both the
+        # type and an instance.
         self.assertTrue(is_dataclass(instance))
         self.assertTrue(is_dataclass(Resource))
+
+
+def _subprocess_env(**overrides):
+    """Build a subprocess env without pytest-cov's coverage propagation vars.
+
+    pytest-cov injects COV_CORE_*/COVERAGE_PROCESS_START into the test
+    process's environment so that subprocesses can opt into coverage
+    measurement too. But those vars point a bare `COV_CORE_CONFIG=":"`
+    (no config file) at any subprocess that inherits them, so a spawned
+    subprocess re-measures the whole `source = ["michelangelo"]` tree with
+    none of pyproject.toml's `omit` patterns applied -- rediscovering every
+    untouched *_test.py file as "untested" and polluting the combined
+    coverage report. These subprocesses only exist to exercise dot_path()'s
+    `__main__` handling, so they should not participate in coverage at all.
+    """
+    env = {
+        k: v
+        for k, v in os.environ.items()
+        if not k.startswith(("COV_CORE_", "COVERAGE_"))
+    }
+    env.update(overrides)
+    return env
 
 
 class DotPathMainTestCase(unittest.TestCase):
@@ -160,16 +199,15 @@ class DotPathMainTestCase(unittest.TestCase):
                 )
             )
 
-            env = dict(os.environ)
-            existing_pythonpath = env.get("PYTHONPATH", "")
-            env["PYTHONPATH"] = os.pathsep.join(
+            existing_pythonpath = os.environ.get("PYTHONPATH", "")
+            pythonpath = os.pathsep.join(
                 p for p in [str(site_packages), existing_pythonpath] if p
             )
 
             result = subprocess.run(
                 [sys.executable, "-m", "fakepkg.mod"],
                 cwd=str(tmp_dir_path),
-                env=env,
+                env=_subprocess_env(PYTHONPATH=pythonpath),
                 capture_output=True,
                 text=True,
             )
@@ -212,6 +250,7 @@ class DotPathMainTestCase(unittest.TestCase):
             result = subprocess.run(
                 [sys.executable, str(script_path)],
                 cwd=str(tmp_dir_path),
+                env=_subprocess_env(),
                 capture_output=True,
                 text=True,
             )


### PR DESCRIPTION
Closes #1753

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

`dot_path()`'s `__main__` special case now resolves the real dotted module path via `sys.modules["__main__"].__spec__.name` (set by Python's own import machinery for `python -m pkg.module` invocations), instead of reconstructing it by taking `__file__`'s path relative to `cwd`, stripping the extension, and asserting the result contains no `.`. The old relpath-based reconstruction is kept only as a fallback for plain `python script.py` invocations, where `__spec__` is `None`.

**Why?**

`assert "." not in file` fails unconditionally for any pip-installed package run via `python -m`, because a virtualenv's own directory layout (`lib/python3.11/site-packages/...`) always contains a literal `.` in `python3.11`. This crashes at import time inside `@uniflow.task()`/`@uniflow.workflow()`'s own decoration logic (`decorator.py:170`), before any user code runs — including `getting-started.md`'s own documented "fastest way to iterate" local-run command (`pip install "michelangelo-examples[...]"` then `python -m <pkg>.<pipeline>.pipeline`). Reproduced identically for both `xgb_train` and `pytorch_train` example pipelines. `sys.modules["__main__"].__spec__.name` is Python's own authoritative, already-computed real dotted module name for `-m` invocations (stable since PEP 451, Python 3.4+) — no path-string reconstruction needed, and it's immune to any `.` in the underlying file path.

**How did you test it?**

- Added a regression test (`DotPathMainTestCase` in `python/tests/uniflow/core/test_utils.py`) that spawns a real `python -m pkg.module` subprocess against a fixture package placed under a directory with a `.` in a `sys.path` segment (simulating a venv's `lib/python3.11/...` layout), and asserts `dot_path()` returns the correct dotted path instead of raising. Verified this test fails with the original `AssertionError` against the pre-fix code and passes against the fix. Added a second test confirming the plain `python script.py` fallback path (`__spec__ is None`) is unaffected.
- `poetry run pytest python/tests/uniflow` — 106 tests pass (full existing suite unaffected).
- `ruff check` / `ruff format --check` on changed files — no new lint findings introduced (pre-existing docstring/line-length findings in this file are unrelated to this change).
- Built a fresh venv, did an editable install of this branch's `michelangelo`, then `pip install "michelangelo-examples[california-housing]"` on top (confirmed still resolving `michelangelo` to the local editable checkout via `direct_url.json`). Ran the exact previously-crashing commands:
  - `python -m michelangelo_examples.california_housing.pipelines.xgb_train.pipeline`
  - `python -m michelangelo_examples.california_housing.pipelines.pytorch_train.pipeline`

  Both now get past the `dot_path` assertion and proceed through task decoration/context setup into the workflow body (task logging, Spark session bootstrap) — confirming the fix. Both then hit an unrelated local-machine limitation (a JDK 26 vs. this pyspark/hadoop version's `Subject.getSubject` reflection incompatibility) that blocks a full end-to-end local run in this sandbox; that is a pre-existing local Java toolchain issue, not something introduced or affected by this change.
- Confirmed by code inspection that the `ma pipeline apply`/`ma pipeline run` (Cadence-dispatched) path cannot regress from this change: task modules are always loaded there via `importlib.import_module`/`import_attribute`, never bound as `__main__`, so the `__main__` branch touched by this fix is structurally unreachable on that path.

**Potential risks**

Low. The change only affects the already-broken `__main__` + `python -m` combination (which unconditionally raised before this fix, so there is no previously-working behavior to regress there). The plain-script fallback path is preserved byte-for-byte and covered by a regression test. All other call sites of `dot_path()` (serialization round-tripping in `codec.py`, workflow-id construction in `remote_run.py`, logging in `decorator.py`) only consume the returned string as an opaque dotted path and don't distinguish which branch produced it.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

N/A

**Documentation Changes**

N/A — `getting-started.md`'s documented commands are unchanged and now work as written; no doc changes needed.