### PR TITLE
fix(ci): skip JavaScript coverage PR comment on fork pull requests

### DIFF
--- a/.github/workflows/javascript-coverage.yml
+++ b/.github/workflows/javascript-coverage.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Coverage report PR comment
         uses: marocchino/sticky-pull-request-comment@v2
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         with:
           header: javascript-coverage
           message: |


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
One line in `.github/workflows/javascript-coverage.yml`: the "Coverage report PR comment" step now carries the same-repository guard that the equivalent step in `go-coverage.yml` already has, so it is skipped on pull requests from forks.

```
- if: github.event_name == 'pull_request'
+ if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
```

**Why?**
Pull requests from forks run with a read-only `GITHUB_TOKEN`, so the comment step cannot post and fails with `Resource not accessible by integration`. That turns the JavaScript Test & Coverage check red on external contributions even when the build and tests pass, which is a confusing first signal for a new contributor and makes a green run impossible to reach from a fork.

The repository already solves this in the two sibling workflows, in two different ways: `go-coverage.yml` guards the identical `sticky-pull-request-comment` step with the condition added here, and `python-coverage.yml` marks its comment step `continue-on-error: true`. `javascript-coverage.yml` has neither, which makes it the only one of the three that reports failure on fork pull requests. This adopts the `go-coverage.yml` approach so the two workflows using the same action stay consistent.

The coverage job itself is untouched and still runs on forks, including the baseline threshold check. Only the comment is skipped, and only when it could not succeed anyway.

**How did you test it?**
Reproduced on a real fork pull request: the JavaScript Test & Coverage check failed on #1712 while every other check passed. Its failing job's annotation is `Resource not accessible by integration - https://docs.github.com/rest/issues/comments#create-an-issue-comment`, and the failing step is "Coverage report PR comment", confirming the comment call rather than the tests. The pull request was merged with that check red.

Compared all three coverage workflows to confirm the inconsistency and that the condition used here is copied verbatim from the working one in `go-coverage.yml`. YAML still parses.

The behavior change is only observable on a fork pull request, which this PR is, so the JavaScript coverage check on this PR should skip the comment step and complete rather than fail.

**Potential risks**
On pull requests from branches in this repository nothing changes: the guard is true and the comment posts as before. On forks the coverage comment will no longer appear, but it never did - the step failed instead. If you would rather keep attempting the comment and just not fail the check, `continue-on-error: true` as used in `python-coverage.yml` is the alternative, happy to switch.

**Breaking Changes**
- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**
None.

**Documentation Changes**
None needed.
