### PR TITLE
ci: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/setup-python-poetry/action.yml
+++ b/.github/actions/setup-python-poetry/action.yml
@@ -35,7 +35,7 @@ runs:
     #  -----  install & configure poetry  -----
     #----------------------------------------------
     - name: Install Poetry
-      uses: snok/install-poetry@v1
+      uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
       with:
         version: ${{ inputs.poetry-version }}
         virtualenvs-create: true

--- a/.github/workflows/api-surface-check.yml
+++ b/.github/workflows/api-surface-check.yml
@@ -20,7 +20,7 @@ jobs:
       helm: ${{ steps.filter.outputs.helm }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@0e4a8c6effa4802afeda77dc8d303f8176d7dfad # v3.0.4
         id: filter
         with:
           filters: |

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -127,7 +127,7 @@ jobs:
 
 
       - name: Generate release notes
-        uses: orhun/git-cliff-action@v4
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4.8.0
         id: cliff-latest
         with:
           config: cliff.toml
@@ -178,7 +178,7 @@ jobs:
           PYEOF
 
       - name: Update GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
           body_path: RELEASE_NOTES.md
@@ -198,7 +198,7 @@ jobs:
 
       - name: Open PR to update CHANGELOG.md
         if: steps.changelog-diff.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:
           token: ${{ secrets.CR_PAT }}
           base: ${{ steps.branch.outputs.base }}

--- a/.github/workflows/cleanup-nightlies.yml
+++ b/.github/workflows/cleanup-nightlies.yml
@@ -195,7 +195,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify Slack on failure
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
         with:
           channel-id: 'C0BER0RCQ8P'
           slack-message: |

--- a/.github/workflows/compat-matrix.yml
+++ b/.github/workflows/compat-matrix.yml
@@ -126,7 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify Slack on failure
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
         with:
           channel-id: 'C0BER0RCQ8P'
           slack-message: |

--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify Slack on failure
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
         with:
           channel-id: 'C0BER0RCQ8P'
           slack-message: |

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
 

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1.2.2
         with:
           bun-version: latest
 

--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -120,7 +120,7 @@ jobs:
           fi
 
       - name: Coverage report PR comment
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         with:
           header: go-coverage

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -323,7 +323,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify Slack on failure
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
         with:
           channel-id: 'C0BER0RCQ8P'
           slack-message: |

--- a/.github/workflows/python-coverage.yml
+++ b/.github/workflows/python-coverage.yml
@@ -46,7 +46,7 @@ jobs:
           python-version: '3.9'
 
       - name: Install Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
         with:
           version: 1.8.0
           virtualenvs-create: true
@@ -89,7 +89,7 @@ jobs:
 
       # Comment on PR with detailed coverage report
       - name: Coverage comment
-        uses: py-cov-action/python-coverage-comment-action@v3
+        uses: py-cov-action/python-coverage-comment-action@50d15ff8768f6d897b04e5a0805bd1a98f7096c4 # v3
         with:
           GITHUB_TOKEN: ${{ github.token }}
           MINIMUM_GREEN: 90

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -179,7 +179,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify Slack on failure
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
         with:
           channel-id: 'C0BER0RCQ8P'
           slack-message: |

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -15,7 +15,7 @@ jobs:
   update-release-draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@6a93d829887aa2e0748befe2e808c66c0ec6e4c7 # v6.4.0
         with:
           config-name: release-drafter.yml
         env:

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -142,7 +142,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify Slack on failure
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
         with:
           channel-id: 'C0BER0RCQ8P'
           slack-message: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,7 +64,7 @@ jobs:
       #----------------------------------------------
       #  Upload the wheel file to the release
       #----------------------------------------------
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{ github.ref_name }}
           files: python/dist/*.whl
@@ -122,7 +122,7 @@ jobs:
           sha256sum ./* > checksums-sha256.txt
 
       - name: Attach binaries and checksums to release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{ github.ref_name }}
           files: binaries/*
@@ -175,7 +175,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify Slack on failure
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
         with:
           channel-id: 'C0BER0RCQ8P'
           slack-message: |


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

**What changed?**
Pins references to third-party GitHub Actions to full commit SHAs, keeping the human-readable version in a trailing comment (`uses: owner/repo@<sha> # v1.2.3`). Third-party here means everything outside the `actions/`, `github/`, `docker/`, `bufbuild/`, `azure/` and `aquasecurity/` namespaces. 20 references to 10 distinct actions across 15 files: `slackapi/slack-github-action` (7 uses), `softprops/action-gh-release` (3), `oven-sh/setup-bun` (2, at both v1 and v2), `snok/install-poetry` (2), and one each of `dorny/paths-filter`, `marocchino/sticky-pull-request-comment`, `orhun/git-cliff-action`, `peter-evans/create-pull-request`, `py-cov-action/python-coverage-comment-action`, and `release-drafter/release-drafter`.

One third-party reference is deliberately left alone: the `marocchino/sticky-pull-request-comment@v2` in `javascript-coverage.yml`. #1756 changes the line immediately below it, and pinning here too would put the two PRs in conflict over adjacent lines for no good reason. Happy to send that one pin as a small follow-up once #1756 lands, so these two can merge in either order without anyone having to rebase.

First-party actions are deliberately left on tags in this change to keep the diff reviewable. Happy to follow up with those if you want full coverage.

**Why?**
A tag is a mutable pointer: whoever controls the upstream repository can move `v2` to different code at any time, and the next workflow run executes it with whatever token scopes that job holds. Pinning to a SHA makes the executed code immutable and reviewable. This is the OpenSSF Scorecard Pinned-Dependencies check and GitHub's own documented hardening guidance for third-party actions.

One of these is stronger than the usual tag case: `marocchino/sticky-pull-request-comment@v2` resolves to `refs/heads/v2`, a branch rather than a tag, so it can move on any push to that branch.

This composes with the Dependabot config rather than fighting it. Dependabot understands SHA-pinned action refs and updates both the SHA and the trailing version comment, so these stay current automatically ([changelog](https://github.blog/changelog/2022-10-31-dependabot-now-updates-comments-in-github-actions-workflows-referencing-action-versions/)).

**How did you test it?**
Each SHA was resolved from the tag it replaces through the GitHub API (`/git/ref/tags/<tag>`, dereferencing annotated tag objects to their commit), then cross-checked against the repository's tag list so the trailing comment names a real release containing that commit. For the one branch reference, the branch head resolved to the commit tagged `v2.9.4`. No SHA was typed by hand.

Verified mechanically that the diff changes only `uses:` lines: 20 insertions, 20 deletions, zero other changed lines. All 27 workflow and composite-action YAML files still parse. Confirmed the only third-party reference left on a tag is the one noted above. The workflows themselves are unchanged in behavior, since each SHA is the exact commit the tag already resolved to at the time of this change.

**Potential risks**
SHAs are less readable than tags, which is why the version comment is kept on every line. If Dependabot is later disabled these would go stale silently, the same tradeoff any pinning carries. No behavior change: every pin points at the commit the tag resolved to when this was written.

**Breaking Changes**
- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**
None.

**Documentation Changes**
None needed.
