### PR TITLE
Add optional onClick to LinkCellConfig and LinkProps

### DIFF
--- a/javascript/packages/core/components/cell/renderers/link/__tests__/link-cell.tests.tsx
+++ b/javascript/packages/core/components/cell/renderers/link/__tests__/link-cell.tests.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { getIconProviderWrapper } from '#core/test/wrappers/get-icon-provider-wrapper';
 import { LinkCell } from '../link-cell';
@@ -57,5 +58,38 @@ describe('LinkCell', () => {
     );
 
     expect(screen.getByRole('link')).toHaveTextContent('');
+  });
+
+  it('should navigate normally when clicked and onClick is not provided', async () => {
+    render(
+      <LinkCell
+        column={{ id: 'spec.link', url: 'https://example.com' }}
+        record={{ spec: { link: 'Click me' } }}
+        value="Click me"
+      />,
+      { wrapper: getIconProviderWrapper() }
+    );
+
+    const link = screen.getByRole('link');
+    await userEvent.click(link);
+
+    expect(link).toHaveAttribute('href', 'https://example.com');
+  });
+
+  it('should call column.onClick with the record when the link is clicked', async () => {
+    const onClick = vi.fn();
+    const record = { spec: { link: 'Click me' } };
+    render(
+      <LinkCell
+        column={{ id: 'spec.link', url: 'https://example.com', onClick }}
+        record={record}
+        value="Click me"
+      />,
+      { wrapper: getIconProviderWrapper() }
+    );
+
+    await userEvent.click(screen.getByRole('link'));
+
+    expect(onClick).toHaveBeenCalledWith(record);
   });
 });

--- a/javascript/packages/core/components/cell/renderers/link/link-cell.tsx
+++ b/javascript/packages/core/components/cell/renderers/link/link-cell.tsx
@@ -15,9 +15,11 @@ import type { LinkCellConfig } from './types';
  * Supports optional leading icon and automatic text truncation.
  *
  * @param props.value - Text value to display
+ * @param props.record - The data record for the row, passed to column.onClick when provided
  * @param props.column - Column configuration with optional url and icon
  *   - column.url: Link destination
  *   - column.icon: Icon name to show before the text
+ *   - column.onClick: Invoked with the record when the link is clicked, before navigation
  *
  * @example
  * ```tsx
@@ -35,15 +37,21 @@ import type { LinkCellConfig } from './types';
 export function LinkCell(props: CellRendererProps<string, LinkCellConfig>) {
   const [css, theme] = useStyletron();
   const cellToString = useCellToString();
-  const { column } = props;
-  const { icon, url } = column;
+  const { column, record } = props;
+  const { icon, url, onClick } = column;
 
   const content = <TruncatedText>{cellToString(props) ?? props.value}</TruncatedText>;
 
   return (
     <div className={css({ display: 'flex', alignItems: 'center', gap: theme.sizing.scale100 })}>
       {icon && <Icon name={icon} />}
-      {url && typeof url === 'string' ? <Link href={url}>{content}</Link> : content}
+      {url && typeof url === 'string' ? (
+        <Link href={url} onClick={onClick ? () => onClick(record) : undefined}>
+          {content}
+        </Link>
+      ) : (
+        content
+      )}
     </div>
   );
 }

--- a/javascript/packages/core/components/cell/renderers/link/types.ts
+++ b/javascript/packages/core/components/cell/renderers/link/types.ts
@@ -5,4 +5,11 @@ export type LinkCellConfig<TRecord = unknown> = SharedCell<TRecord, string> & {
    * @description When provided, the cell will display a link to the provided url
    */
   url: string;
+
+  /**
+   * @description Invoked with the row's record when the rendered link is clicked, before
+   * navigation occurs. Lets a consumer attach click-tracking or other side effects without
+   * this cell renderer knowing anything about what the callback does.
+   */
+  onClick?: (record: unknown) => void;
 };

--- a/javascript/packages/core/components/link/__tests__/link.test.tsx
+++ b/javascript/packages/core/components/link/__tests__/link.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Alert } from 'baseui/icon';
 
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
@@ -96,6 +97,48 @@ describe('Link', () => {
     it('should render custom icon component', () => {
       // eslint-disable-next-line testing-library/no-test-id-queries -- bare span, no accessible identity
       expect(screen.getByTestId('custom-icon')).toBeInTheDocument();
+    });
+  });
+
+  describe('onClick', () => {
+    it('should render and remain clickable when onClick is omitted', async () => {
+      render(
+        <Link href="/internal-path">Click me</Link>,
+        buildWrapper([getRouterWrapper(), getIconProviderWrapper()])
+      );
+
+      const link = await screen.findByRole('link', { name: 'Click me' });
+      await userEvent.click(link);
+
+      expect(link).toBeInTheDocument();
+    });
+
+    it('should call onClick when an internal link is clicked', async () => {
+      const onClick = vi.fn();
+      render(
+        <Link href="/internal-path" onClick={onClick}>
+          Click me
+        </Link>,
+        buildWrapper([getRouterWrapper(), getIconProviderWrapper()])
+      );
+
+      await userEvent.click(await screen.findByRole('link', { name: 'Click me' }));
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call onClick when an external link is clicked', async () => {
+      const onClick = vi.fn();
+      render(
+        <Link href="https://example.com" onClick={onClick}>
+          External Link
+        </Link>,
+        buildWrapper([getRouterWrapper(), getIconProviderWrapper()])
+      );
+
+      await userEvent.click(await screen.findByRole('link', { name: /External Link/ }));
+
+      expect(onClick).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/javascript/packages/core/components/link/link.tsx
+++ b/javascript/packages/core/components/link/link.tsx
@@ -26,6 +26,8 @@ import type { LinkProps } from './types';
  * @param props.children - Link text or content to display
  * @param props.title - Optional title attribute for accessibility
  * @param props.overrides - BaseUI overrides for Link and ExternalLinkIcon components
+ * @param props.onClick - Optional handler invoked before navigation occurs, e.g. for
+ *   click-tracking supplied by the caller
  *
  * @example
  * ```tsx
@@ -49,7 +51,7 @@ import type { LinkProps } from './types';
  * ```
  */
 export function Link(props: LinkProps) {
-  const { children, href, overrides = {}, title } = props;
+  const { children, href, overrides = {}, title, onClick } = props;
 
   const [Link, linkProps] = getOverrides(overrides.Link, StyledLink);
 
@@ -65,13 +67,14 @@ export function Link(props: LinkProps) {
       target="_blank"
       rel="noopener noreferrer"
       title={title}
+      onClick={onClick}
       {...linkProps}
     >
       {children}
       <ExternalLinkIcon title="External link" {...externalLinkIconProps} />
     </Link>
   ) : (
-    <Link $as={RouterLink} to={href} title={title} {...linkProps}>
+    <Link $as={RouterLink} to={href} title={title} onClick={onClick} {...linkProps}>
       {children}
     </Link>
   );

--- a/javascript/packages/core/components/link/types.ts
+++ b/javascript/packages/core/components/link/types.ts
@@ -6,6 +6,11 @@ export type LinkProps = {
   href: string;
   overrides?: LinkOverrides;
   title?: string;
+  /**
+   * Invoked when the link is clicked, before navigation occurs. Optional — omit for a plain
+   * link with no side effects.
+   */
+  onClick?: () => void;
 };
 
 type LinkOverrides = {


### PR DESCRIPTION
## Summary

Adds an optional `onClick` callback to `LinkCellConfig` (`packages/core/components/cell/renderers/link/`) and `LinkProps` (`packages/core/components/link/`), so a caller can run code when a config-driven link is clicked, before navigation occurs — without either component knowing anything about what that callback does (analytics, logging, or anything else).

- `LinkCellConfig.onClick?: (record: unknown) => void` — invoked with the row's record when the rendered link is clicked.
- `LinkProps.onClick?: () => void` — invoked when the underlying link element is clicked.

Both props are optional and default to a no-op, so this is a non-breaking, additive change: every existing consumer of `LinkCellConfig`/`LinkProps` continues to render and navigate exactly as before.

This PR only adds the generic click-hook capability to the shared, reusable components. It does not wire `onClick` into any specific entity/column configuration — that's intentionally left for a follow-up change in the application that consumes this library, once its own click-tracking callback is ready to be supplied.

## Test plan

- [x] Extended `packages/core/components/link/__tests__/link.test.tsx`: clicking still works with `onClick` omitted (no regression), `onClick` fires on click for both internal and external links.
- [x] Extended `packages/core/components/cell/renderers/link/__tests__/link-cell.tests.tsx`: clicking still navigates normally with `onClick` omitted, `onClick` is called with the row record when provided.
- [x] `npx tsc -p packages/core/tsconfig.json --noEmit` — no errors.
- [x] `npx eslint packages/core/components/link packages/core/components/cell/renderers/link` — no errors/warnings.
- [x] `npx vitest --run packages/core/components/link packages/core/components/cell/renderers/link` — all 22 tests passing.
- [x] `npx prettier --check` on all changed files — clean.