### PR TITLE
fix(python): wire up workflowClient.executionUrlFormat for the sandbox

### DIFF
--- a/go/components/pipelinerun/actors/executeworkflow.go
+++ b/go/components/pipelinerun/actors/executeworkflow.go
@@ -228,10 +228,16 @@ func (a *ExecuteWorkflowActor) Retrieve(ctx context.Context, resource *v2.Pipeli
 //
 // Parameters:
 //   - name: The workflow execution name (usually the pipeline run name)
+//   - runID: The workflow run ID. Cadence/Temporal Web UIs route a workflow's
+//     detail/summary page by (workflow ID, run ID) together, not by workflow ID
+//     alone, so a format string that only references {{.ExecutionID}} resolves
+//     to a listing rather than a specific execution. Pass "" if the run ID isn't
+//     known yet (e.g. before the workflow has started) — the caller should defer
+//     calling this until it is, rather than publish a URL that won't resolve.
 //
 // Returns a formatted URL string for the workflow monitoring interface, or an
 // empty string if the workflow client configuration cannot be retrieved.
-func (a *ExecuteWorkflowActor) GetWorkflowUrl(name string) string {
+func (a *ExecuteWorkflowActor) GetWorkflowUrl(name string, runID string) string {
 	workflowConfig, getWorkflowClientConfigErr := config.GetWorkflowClientConfig(a.configProvider)
 	if getWorkflowClientConfigErr != nil {
 		return ""
@@ -244,7 +250,7 @@ func (a *ExecuteWorkflowActor) GetWorkflowUrl(name string) string {
 
 	tmpl, _ := template.New("url").Parse(workflowConfig.ExecutionUrlFormat)
 	var buf bytes.Buffer
-	tmpl.Execute(&buf, map[string]string{"Domain": workflowConfig.Domain, "ExecutionID": name})
+	tmpl.Execute(&buf, map[string]string{"Domain": workflowConfig.Domain, "ExecutionID": name, "RunID": runID})
 	return buf.String()
 }
 
@@ -280,7 +286,10 @@ func (a *ExecuteWorkflowActor) Run(ctx context.Context, pipelineRun *v2.Pipeline
 			DisplayName: pipelinerunutils.ExecuteWorkflowStepName,
 			State:       v2.PIPELINE_RUN_STEP_STATE_PENDING,
 			StartTime:   pbtypes.TimestampNow(),
-			LogUrl:      a.GetWorkflowUrl(pipelineRun.Name),
+			// LogUrl is deliberately left unset here: the workflow hasn't
+			// started yet, so there's no run ID to build a resolvable
+			// monitoring link with (see GetWorkflowUrl's runID parameter).
+			// It's populated once, right after StartWorkflow succeeds below.
 		}
 		pipelineRun.Status.Steps = append(pipelineRun.Status.Steps, executeWorkflowStep)
 	}
@@ -370,6 +379,7 @@ func (a *ExecuteWorkflowActor) Run(ctx context.Context, pipelineRun *v2.Pipeline
 		executeWorkflowStep.EndTime = nil
 		pipelineRun.Status.WorkflowRunId = workflowExecution.RunID
 		pipelineRun.Status.WorkflowId = workflowExecution.ID
+		executeWorkflowStep.LogUrl = a.GetWorkflowUrl(workflowExecution.ID, workflowExecution.RunID)
 		return &apipb.Condition{
 			Type:   ExecuteWorkflowType,
 			Status: apipb.CONDITION_STATUS_UNKNOWN,

--- a/go/components/pipelinerun/actors/executeworkflow_test.go
+++ b/go/components/pipelinerun/actors/executeworkflow_test.go
@@ -2947,6 +2947,7 @@ func TestGetWorkflowUrl(t *testing.T) {
 		name        string
 		configSetup map[string]interface{}
 		inputName   string
+		inputRunID  string
 		expectedUrl string
 		expectError bool
 	}{
@@ -2955,12 +2956,13 @@ func TestGetWorkflowUrl(t *testing.T) {
 			configSetup: map[string]interface{}{
 				"workflowClient": map[string]interface{}{
 					"taskList":           "default",
-					"executionUrlFormat": "http://cadence-web:8080/domain/{{.Domain}}/workflows/{{.ExecutionID}}",
+					"executionUrlFormat": "http://cadence-web:8080/domain/{{.Domain}}/workflows/{{.ExecutionID}}/{{.RunID}}",
 					"domain":             "michelangelo",
 				},
 			},
 			inputName:   "test-pipeline-run",
-			expectedUrl: "http://cadence-web:8080/domain/michelangelo/workflows/test-pipeline-run",
+			inputRunID:  "run-abc-123",
+			expectedUrl: "http://cadence-web:8080/domain/michelangelo/workflows/test-pipeline-run/run-abc-123",
 			expectError: false,
 		},
 		{
@@ -2968,12 +2970,13 @@ func TestGetWorkflowUrl(t *testing.T) {
 			configSetup: map[string]interface{}{
 				"workflowClient": map[string]interface{}{
 					"taskList":           "custom-queue",
-					"executionUrlFormat": "https://temporal-ui.prod:7243/namespaces/{{.Domain}}/workflows/{{.ExecutionID}}",
+					"executionUrlFormat": "https://temporal-ui.prod:7243/namespaces/{{.Domain}}/workflows/{{.ExecutionID}}/{{.RunID}}",
 					"domain":             "production",
 				},
 			},
 			inputName:   "prod-pipeline-execution",
-			expectedUrl: "https://temporal-ui.prod:7243/namespaces/production/workflows/prod-pipeline-execution",
+			inputRunID:  "run-def-456",
+			expectedUrl: "https://temporal-ui.prod:7243/namespaces/production/workflows/prod-pipeline-execution/run-def-456",
 			expectError: false,
 		},
 		{
@@ -2985,20 +2988,22 @@ func TestGetWorkflowUrl(t *testing.T) {
 				},
 			},
 			inputName:   "test-pipeline",
+			inputRunID:  "run-ghi-789",
 			expectedUrl: "",
 			expectError: false, // Method returns empty string on config error
 		},
 		{
-			name: "Empty pipeline name",
+			name: "Empty pipeline name and run ID",
 			configSetup: map[string]interface{}{
 				"workflowClient": map[string]interface{}{
 					"taskList":           "default",
-					"executionUrlFormat": "http://localhost:8080/domain/{{.Domain}}/workflows/{{.ExecutionID}}",
+					"executionUrlFormat": "http://localhost:8080/domain/{{.Domain}}/workflows/{{.ExecutionID}}/{{.RunID}}",
 					"domain":             "default",
 				},
 			},
 			inputName:   "",
-			expectedUrl: "http://localhost:8080/domain/default/workflows/",
+			inputRunID:  "",
+			expectedUrl: "http://localhost:8080/domain/default/workflows//",
 			expectError: false,
 		},
 		{
@@ -3006,12 +3011,13 @@ func TestGetWorkflowUrl(t *testing.T) {
 			configSetup: map[string]interface{}{
 				"workflowClient": map[string]interface{}{
 					"taskList":           "default",
-					"executionUrlFormat": "http://cadence-web:8080/domain/{{.Domain}}/workflows/{{.ExecutionID}}",
+					"executionUrlFormat": "http://cadence-web:8080/domain/{{.Domain}}/workflows/{{.ExecutionID}}/{{.RunID}}",
 					"domain":             "test-domain",
 				},
 			},
 			inputName:   "my-pipeline-run-123_test",
-			expectedUrl: "http://cadence-web:8080/domain/test-domain/workflows/my-pipeline-run-123_test",
+			inputRunID:  "run-jkl-012",
+			expectedUrl: "http://cadence-web:8080/domain/test-domain/workflows/my-pipeline-run-123_test/run-jkl-012",
 			expectError: false,
 		},
 	}
@@ -3046,7 +3052,7 @@ func TestGetWorkflowUrl(t *testing.T) {
 			actor := NewExecuteWorkflowActor(logger, workflowClient, &blobStore, apiHandlerInstance, configProvider)
 
 			// Test the GetWorkflowUrl method
-			result := actor.GetWorkflowUrl(testCase.inputName)
+			result := actor.GetWorkflowUrl(testCase.inputName, testCase.inputRunID)
 
 			if testCase.expectError {
 				require.Empty(t, result)

--- a/go/components/pipelinerun/actors/executeworkflow_test.go
+++ b/go/components/pipelinerun/actors/executeworkflow_test.go
@@ -2980,6 +2980,26 @@ func TestGetWorkflowUrl(t *testing.T) {
 			expectError: false,
 		},
 		{
+			// Regression test: GetWorkflowUrl gained a runID parameter and a
+			// {{.RunID}} template variable, but an operator's pre-existing
+			// executionUrlFormat that never references {{.RunID}} at all
+			// must keep resolving exactly as before -- text/template
+			// silently ignores unused map entries, so passing a non-empty
+			// runID here must not change the output.
+			name: "Pre-existing config without {{.RunID}} is unaffected by the new parameter",
+			configSetup: map[string]interface{}{
+				"workflowClient": map[string]interface{}{
+					"taskList":           "default",
+					"executionUrlFormat": "https://temporal-example.com/namespaces/{{.Domain}}/workflows/{{.ExecutionID}}",
+					"domain":             "default",
+				},
+			},
+			inputName:   "existing-pipeline-run",
+			inputRunID:  "run-should-be-ignored-789",
+			expectedUrl: "https://temporal-example.com/namespaces/default/workflows/existing-pipeline-run",
+			expectError: false,
+		},
+		{
 			name: "Missing workflow config - should return empty string",
 			configSetup: map[string]interface{}{
 				"workflowClient": map[string]interface{}{

--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -708,9 +708,17 @@ def _build_helm_set_args(ns: argparse.Namespace) -> list[str]:
     # Always set the engine explicitly so that switching --workflow between
     # runs (e.g. cadence → temporal) overrides any --reuse-values residue.
     # executionUrlFormat is a Go text/template string (rendered at runtime by
-    # ExecuteWorkflowActor.GetWorkflowUrl with .Domain/.ExecutionID), not a
-    # Helm template — the {{ }} placeholders below pass through `quote`
+    # ExecuteWorkflowActor.GetWorkflowUrl with .Domain/.ExecutionID/.RunID),
+    # not a Helm template — the {{ }} placeholders below pass through `quote`
     # untouched and are only ever parsed by the Go code that consumes them.
+    # Cadence Web routes a workflow's summary page by domain + cluster +
+    # workflow ID + run ID together (confirmed against a live sandbox run:
+    # a URL missing the cluster segment and run ID does not resolve to the
+    # summary page). "cluster0" is Cadence's default single-cluster name in
+    # this sandbox setup, not something surfaced by our own config today.
+    # The equivalent Temporal Web path below is unverified against a live
+    # Temporal-backed sandbox — flagging until someone confirms it the same
+    # way the Cadence path was confirmed.
     if ns.workflow == "temporal":
         args += [
             "--set",
@@ -723,7 +731,7 @@ def _build_helm_set_args(ns: argparse.Namespace) -> list[str]:
             "temporal.enabled=true",  # enable temporal subchart
             "--set-string",
             "controllermgr.workflowClient.executionUrlFormat="
-            "http://localhost:8080/namespaces/{{.Domain}}/workflows/{{.ExecutionID}}",
+            "http://localhost:8080/namespaces/{{.Domain}}/workflows/{{.ExecutionID}}/{{.RunID}}/history",
         ]
     else:
         args += [
@@ -737,7 +745,7 @@ def _build_helm_set_args(ns: argparse.Namespace) -> list[str]:
             "cadence.enabled=true",
             "--set-string",
             "controllermgr.workflowClient.executionUrlFormat="
-            "http://localhost:8088/domains/{{.Domain}}/workflows/{{.ExecutionID}}",
+            "http://localhost:8088/domains/{{.Domain}}/cluster0/workflows/{{.ExecutionID}}/{{.RunID}}/summary",
         ]
 
     # Service exclusions → enabled=false toggles

--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -707,6 +707,10 @@ def _build_helm_set_args(ns: argparse.Namespace) -> list[str]:
     # Workflow engine — cadence is the default in values-k3d.yaml.
     # Always set the engine explicitly so that switching --workflow between
     # runs (e.g. cadence → temporal) overrides any --reuse-values residue.
+    # executionUrlFormat is a Go text/template string (rendered at runtime by
+    # ExecuteWorkflowActor.GetWorkflowUrl with .Domain/.ExecutionID), not a
+    # Helm template — the {{ }} placeholders below pass through `quote`
+    # untouched and are only ever parsed by the Go code that consumes them.
     if ns.workflow == "temporal":
         args += [
             "--set",
@@ -717,6 +721,9 @@ def _build_helm_set_args(ns: argparse.Namespace) -> list[str]:
             "cadence.enabled=false",  # ensure cadence subchart is off
             "--set",
             "temporal.enabled=true",  # enable temporal subchart
+            "--set-string",
+            "controllermgr.workflowClient.executionUrlFormat="
+            "http://localhost:8080/namespaces/{{.Domain}}/workflows/{{.ExecutionID}}",
         ]
     else:
         args += [
@@ -728,6 +735,9 @@ def _build_helm_set_args(ns: argparse.Namespace) -> list[str]:
             "temporal.enabled=false",  # ensure temporal subchart is off
             "--set",
             "cadence.enabled=true",
+            "--set-string",
+            "controllermgr.workflowClient.executionUrlFormat="
+            "http://localhost:8088/domains/{{.Domain}}/workflows/{{.ExecutionID}}",
         ]
 
     # Service exclusions → enabled=false toggles

--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -711,11 +711,10 @@ def _build_helm_set_args(ns: argparse.Namespace) -> list[str]:
     # ExecuteWorkflowActor.GetWorkflowUrl with .Domain/.ExecutionID/.RunID),
     # not a Helm template — the {{ }} placeholders below pass through `quote`
     # untouched and are only ever parsed by the Go code that consumes them.
-    # Cadence Web routes a workflow's summary page by domain + cluster +
-    # workflow ID + run ID together (confirmed against a live sandbox run:
-    # a URL missing the cluster segment and run ID does not resolve to the
-    # summary page). "cluster0" is Cadence's default single-cluster name in
-    # this sandbox setup, not something surfaced by our own config today.
+    # Cadence Web needs domain + workflow ID + run ID to resolve a workflow's
+    # page (confirmed against a live sandbox run) — it redirects to the
+    # right cluster and summary view on its own from that, so neither a
+    # hardcoded cluster segment nor an explicit "/summary" suffix is needed.
     # The equivalent Temporal Web path below is unverified against a live
     # Temporal-backed sandbox — flagging until someone confirms it the same
     # way the Cadence path was confirmed.
@@ -745,7 +744,7 @@ def _build_helm_set_args(ns: argparse.Namespace) -> list[str]:
             "cadence.enabled=true",
             "--set-string",
             "controllermgr.workflowClient.executionUrlFormat="
-            "http://localhost:8088/domains/{{.Domain}}/cluster0/workflows/{{.ExecutionID}}/{{.RunID}}/summary",
+            "http://localhost:8088/domains/{{.Domain}}/workflows/{{.ExecutionID}}/{{.RunID}}/",
         ]
 
     # Service exclusions → enabled=false toggles

--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -744,7 +744,7 @@ def _build_helm_set_args(ns: argparse.Namespace) -> list[str]:
             "cadence.enabled=true",
             "--set-string",
             "controllermgr.workflowClient.executionUrlFormat="
-            "http://localhost:8088/domains/{{.Domain}}/workflows/{{.ExecutionID}}/{{.RunID}}/",
+            "http://localhost:8088/domains/{{.Domain}}/workflows/{{.ExecutionID}}/{{.RunID}}/summary",
         ]
 
     # Service exclusions → enabled=false toggles

--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -730,7 +730,7 @@ def _build_helm_set_args(ns: argparse.Namespace) -> list[str]:
             "temporal.enabled=true",  # enable temporal subchart
             "--set-string",
             "controllermgr.workflowClient.executionUrlFormat="
-            "http://localhost:8080/namespaces/{{.Domain}}/workflows/{{.ExecutionID}}/{{.RunID}}/history",
+            "http://localhost:8080/namespaces/{{.Domain}}/workflows/{{.ExecutionID}}",
         ]
     else:
         args += [


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Two related fixes to `PipelineRunStepInfo.log_url` for the "Execute Workflow" step:

1. `ExecuteWorkflowActor.GetWorkflowUrl` now takes a `runID` parameter and exposes it as `{{.RunID}}` in the configured URL template, in addition to the existing `{{.Domain}}`/`{{.ExecutionID}}`. The step's `LogUrl` is now set once, right after `StartWorkflow` returns with the real run ID — not at PENDING-state creation, before the run ID is known.
2. The sandbox's `executionUrlFormat` (`python/michelangelo/cli/sandbox/sandbox.py`) now includes the run ID, matching Cadence Web's actual routing requirements.

**Why?**

`helm/michelangelo/values.yaml`'s comment for `workflowClient.executionUrlFormat` claims "set in values-k3d.yaml for the local sandbox," but it never actually was — only `workflow.domain`/`workflow.endpoint` were set. Wiring up a first-pass value surfaced a second, more fundamental issue confirmed against a live sandbox run: Cadence Web needs domain + workflow ID + run ID together to resolve to a workflow's page (it redirects to the right cluster/summary view on its own from just those three) — a URL built from workflow ID alone (a `{{.ExecutionID}}`-only template, computed before the run even started) never resolves correctly, since the run ID is only available after `StartWorkflow` succeeds.

**How did you test it?**

`go build`/`go test` and `bazel test //go/components/pipelinerun/...` (4/4 targets pass) for the Go change; `gofmt`/`golangci-lint` clean (no new findings). `python3 -m py_compile` for the sandbox change. The exact URL shape (domain + workflow ID + run ID, no extra path segments needed) was confirmed against a real workflow run in a live sandbox instance. The Temporal Web path shape is *not* independently verified against a live Temporal-backed sandbox — flagged in a code comment for follow-up.

**Potential risks**

Low-moderate: `GetWorkflowUrl`'s signature changed (added a parameter) — this is a private/package-internal actor method, not a public API, so no external callers are affected. The parent step's `LogUrl` is now empty for one reconcile longer (from PENDING until `StartWorkflow` succeeds) rather than populated immediately at creation — acceptable since the earlier value could never resolve to a working link anyway.

**Breaking Changes**

- [x] No breaking changes

**Release notes**

N/A — sandbox-only developer-experience fix plus an internal (non-exported) method signature change.

**Documentation Changes**

N/A