### PR TITLE
fix(python): restore ColumnConfig.shape optional default

### DIFF
--- a/python/michelangelo/workflow/schema/tabular_trainer.py
+++ b/python/michelangelo/workflow/schema/tabular_trainer.py
@@ -80,17 +80,18 @@ class ColumnConfig:
     Attributes:
         data_type: PyTorch dtype string, e.g. ``"torch.float32"``.
         shape: Tensor shape *excluding* the batch dimension, e.g. ``[128]``
-            for a 128-element embedding, or ``[1]`` for a scalar column.
-            Required -- there is no default; a caller must decide the
-            shape explicitly rather than relying on an implicit value.
+            for a 128-element embedding. Defaults to ``[]``, i.e. a scalar
+            column -- the common tabular case.
 
     Example:
         >>> ColumnConfig(data_type="torch.float32", shape=[128])
         ColumnConfig(data_type='torch.float32', shape=[128])
+        >>> ColumnConfig(data_type="torch.float32")
+        ColumnConfig(data_type='torch.float32', shape=[])
     """
 
     data_type: str
-    shape: list[int]
+    shape: list[int] = field(default_factory=list)
 
 
 @dataclass

--- a/python/michelangelo/workflow/schema/tests/tabular_trainer_test.py
+++ b/python/michelangelo/workflow/schema/tests/tabular_trainer_test.py
@@ -62,10 +62,10 @@ class TestIncrementalTrainingModeConfig(TestCase):
 class TestColumnConfig(TestCase):
     """Tests for ColumnConfig dataclass."""
 
-    def test_shape_required(self):
-        """``shape`` has no default; omitting it is a TypeError."""
-        with self.assertRaises(TypeError):
-            ColumnConfig(data_type="torch.float32")
+    def test_shape_defaults_to_empty_list(self):
+        """``shape`` defaults to ``[]`` (scalar) when omitted."""
+        cfg = ColumnConfig(data_type="torch.float32")
+        self.assertEqual(cfg.shape, [])
 
     def test_shape_stored(self):
         """It stores an explicit shape."""
@@ -73,10 +73,13 @@ class TestColumnConfig(TestCase):
         self.assertEqual(cfg.data_type, "torch.long")
         self.assertEqual(cfg.shape, [128])
 
-    def test_scalar_column_uses_explicit_one_element_shape(self):
-        """A scalar column uses an explicit ``shape=[1]``, not an implicit default."""
-        cfg = ColumnConfig(data_type="torch.float32", shape=[1])
-        self.assertEqual(cfg.shape, [1])
+    def test_shape_default_is_not_shared_between_instances(self):
+        """Each instance gets its own default list, not a shared mutable one."""
+        cfg1 = ColumnConfig(data_type="torch.float32")
+        cfg2 = ColumnConfig(data_type="torch.float32")
+        cfg1.shape.append(1)
+        self.assertEqual(cfg1.shape, [1])
+        self.assertEqual(cfg2.shape, [])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Restores `ColumnConfig.shape`'s default value: `shape: list[int] = field(default_factory=list)`, matching pre-#1430 behavior. Also updated the class docstring/doctest and the test suite (`test_shape_required` → `test_shape_defaults_to_empty_list`, plus a new test confirming the default list isn't shared/mutated across instances).

**Why?**

PR #1430 changed `shape: list[int] = field(default_factory=list)` to `shape: list[int]` (no default), silently making it a required positional argument. Since the commit wasn't marked as a breaking change (no `!` suffix, no `BREAKING CHANGE:` footer), this shipped without any changelog signal. Confirmed via the `v0.8.0-rc.1` release test that `michelangelo-examples`' `pytorch_train/train.py` (which calls `ColumnConfig("torch.float32")` with no `shape`) breaks against this version with `TypeError: ColumnConfig.__init__() missing 1 required positional argument: 'shape'`. Confirmed and requested by Hong: this should be an optional field.

Closes #1723.

**How did you test it?**

- `ruff check` / `ruff format --check` clean on both changed files.
- `pytest python/michelangelo/workflow/schema/tests/tabular_trainer_test.py python/michelangelo/workflow/tasks/tabular_trainer/` — 178 passed.
- `pytest --doctest-modules` on the changed module — the `ColumnConfig` doctest (including the new no-`shape` example) passes; confirmed the file's two unrelated doctest failures (`ExperimentTrackerConfig`, `LightningTrainerKwargs`) are pre-existing on `origin/main` before this change, not introduced by it.

**Potential risks**

None expected — this restores a previously-existing default rather than introducing new behavior. Callers passing `shape` explicitly are unaffected; callers omitting it (broken since #1430) now work again.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

Bug fix: `ColumnConfig.shape` is optional again (defaults to `[]`), fixing a regression introduced in a prior release.

**Documentation Changes**

Updated `ColumnConfig`'s docstring/doctest to reflect the restored default.