### PR TITLE
fix: cherry-pick #1762 (restore ColumnConfig.shape default) + bump to 0.8.0-rc.2

### DIFF
--- a/helm/michelangelo/Chart.yaml
+++ b/helm/michelangelo/Chart.yaml
@@ -7,8 +7,8 @@ description: |
   and RBAC — into any Kubernetes cluster. Bring your own metadata storage,
   object storage, and workflow engine (Cadence or Temporal).
 type: application
-version: 0.8.0-rc.1
-appVersion: "0.8.0-rc.1"
+version: 0.8.0-rc.2
+appVersion: "0.8.0-rc.2"
 kubeVersion: ">=1.27.0-0"
 
 dependencies:

--- a/javascript/app/package.json
+++ b/javascript/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@michelangelo/app",
   "license": "Apache-2.0",
-  "version": "0.8.0-rc.1",
+  "version": "0.8.0-rc.2",
   "private": true,
   "scripts": {
     "build": "vite build --config vite.config.ts",
@@ -11,11 +11,11 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
-    "@michelangelo-ai/rpc": "0.8.0-rc.1",
+    "@michelangelo-ai/rpc": "0.8.0-rc.2",
     "@mui/icons-material": "^7.1.0",
     "@mui/material": "^7.1.0",
     "@tanstack/react-query": "5.39.0",
-    "@michelangelo-ai/core": "0.8.0-rc.1",
+    "@michelangelo-ai/core": "0.8.0-rc.2",
     "baseui": "15.0.0",
     "react-router-dom": "5.3.4",
     "react-router-dom-v5-compat": "6.29.0",

--- a/javascript/packages/core/package.json
+++ b/javascript/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@michelangelo-ai/core",
   "license": "Apache-2.0",
-  "version": "0.8.0-rc.1",
+  "version": "0.8.0-rc.2",
   "type": "module",
   "main": "./dist/michelangelo-core.js",
   "module": "./dist/michelangelo-core.js",

--- a/javascript/packages/rpc/package.json
+++ b/javascript/packages/rpc/package.json
@@ -2,7 +2,7 @@
   "name": "@michelangelo-ai/rpc",
   "license": "Apache-2.0",
   "type": "module",
-  "version": "0.8.0-rc.1",
+  "version": "0.8.0-rc.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/michelangelo-ai/michelangelo"
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.2.5",
-    "@michelangelo-ai/core": "0.8.0-rc.1"
+    "@michelangelo-ai/core": "0.8.0-rc.2"
   },
   "exports": {
     ".": {

--- a/python/michelangelo/workflow/schema/tabular_trainer.py
+++ b/python/michelangelo/workflow/schema/tabular_trainer.py
@@ -80,17 +80,18 @@ class ColumnConfig:
     Attributes:
         data_type: PyTorch dtype string, e.g. ``"torch.float32"``.
         shape: Tensor shape *excluding* the batch dimension, e.g. ``[128]``
-            for a 128-element embedding, or ``[1]`` for a scalar column.
-            Required -- there is no default; a caller must decide the
-            shape explicitly rather than relying on an implicit value.
+            for a 128-element embedding. Defaults to ``[]``, i.e. a scalar
+            column -- the common tabular case.
 
     Example:
         >>> ColumnConfig(data_type="torch.float32", shape=[128])
         ColumnConfig(data_type='torch.float32', shape=[128])
+        >>> ColumnConfig(data_type="torch.float32")
+        ColumnConfig(data_type='torch.float32', shape=[])
     """
 
     data_type: str
-    shape: list[int]
+    shape: list[int] = field(default_factory=list)
 
 
 @dataclass

--- a/python/michelangelo/workflow/schema/tests/tabular_trainer_test.py
+++ b/python/michelangelo/workflow/schema/tests/tabular_trainer_test.py
@@ -62,10 +62,10 @@ class TestIncrementalTrainingModeConfig(TestCase):
 class TestColumnConfig(TestCase):
     """Tests for ColumnConfig dataclass."""
 
-    def test_shape_required(self):
-        """``shape`` has no default; omitting it is a TypeError."""
-        with self.assertRaises(TypeError):
-            ColumnConfig(data_type="torch.float32")
+    def test_shape_defaults_to_empty_list(self):
+        """``shape`` defaults to ``[]`` (scalar) when omitted."""
+        cfg = ColumnConfig(data_type="torch.float32")
+        self.assertEqual(cfg.shape, [])
 
     def test_shape_stored(self):
         """It stores an explicit shape."""
@@ -73,10 +73,13 @@ class TestColumnConfig(TestCase):
         self.assertEqual(cfg.data_type, "torch.long")
         self.assertEqual(cfg.shape, [128])
 
-    def test_scalar_column_uses_explicit_one_element_shape(self):
-        """A scalar column uses an explicit ``shape=[1]``, not an implicit default."""
-        cfg = ColumnConfig(data_type="torch.float32", shape=[1])
-        self.assertEqual(cfg.shape, [1])
+    def test_shape_default_is_not_shared_between_instances(self):
+        """Each instance gets its own default list, not a shared mutable one."""
+        cfg1 = ColumnConfig(data_type="torch.float32")
+        cfg2 = ColumnConfig(data_type="torch.float32")
+        cfg1.shape.append(1)
+        self.assertEqual(cfg1.shape, [1])
+        self.assertEqual(cfg2.shape, [])
 
 
 # ---------------------------------------------------------------------------

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "michelangelo"
-version = "0.8.0-rc.1"
+version = "0.8.0-rc.2"
 description = "Michelangelo AI is an end-to-end model lifecycle management system at large scale"
 authors = ["Michelangelo AI Team <michelangelo-oss-group@uber.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Cherry-picks #1762 (`fix(python): restore ColumnConfig.shape optional default`, merged to `main` at dc0c5ea3) onto `release/v0.8`. This was an unintended breaking change from #1430, caught during the v0.8.0-rc.1 release test (see michelangelo#1723, michelangelo-examples#17).
- Bumps all component versions to `0.8.0-rc.2` to carry the fix and restart the soak period.

## Why
`ColumnConfig.shape` lost its default in #1430 without being marked as a breaking commit. This broke `michelangelo-examples`' `pytorch_train` pipeline during release testing. #1762 restores the intended default on `main`; this PR carries that fix into the `v0.8.0` release line so the workaround in michelangelo-examples#17 is no longer needed.

## Test plan
- [ ] CI green on this PR
- [ ] Merge, tag `v0.8.0-rc.2`, dispatch artifact-publish workflows
- [ ] Re-run release test (Part 1/2a/2b) — expect `pytorch_train` to pass without the `shape=[]` workaround