### PR TITLE
chore: add Algolia crawler domain verification token to robots.txt

### DIFF
--- a/website/static/robots.txt
+++ b/website/static/robots.txt
@@ -2,3 +2,6 @@ User-agent: *
 Allow: /
 
 Sitemap: https://michelangelo-ai.org/sitemap.xml
+
+# Algolia-Crawler-Verif: F1A837F7F81FF130
+


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Added the Algolia crawler domain-verification token to `static/robots.txt`.

**Why?**

Algolia's crawler requires domain-ownership verification before it can index michelangelo-ai.org for site search. The robots.txt method needs this token comment served at the site root. Docusaurus copies `static/` to the site root at build, so it is served at https://michelangelo-ai.org/robots.txt.

**How did you test it?**

Confirmed the token line renders in `static/robots.txt`. Final verification happens post-deploy: check it is live at https://michelangelo-ai.org/robots.txt, then click Verify in the Algolia Crawler dashboard (Algolia reads the production file, not the branch).

**Potential risks**

None. Additive comment line in `robots.txt`; no crawl/allow rules changed.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

None.

**Documentation Changes**

None.
