### PR TITLE
ci: pin the golangci-lint installer script to the version it installs

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install golangci-lint
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.8
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.64.8/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.8
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
       - name: Run golangci-lint


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

**What changed?**
One URL in `.github/workflows/go-lint.yml`: the golangci-lint installer script is fetched from the `v1.64.8` tag instead of `master`.

```
- curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.8
+ curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.64.8/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.8
```

**Why?**
The step already pins the linter version it installs (`v1.64.8`), but it fetches the script that does the installing from `master`, a moving branch, and pipes it straight into `sh`. So the pinned version argument gives less assurance than it looks like it does: whoever controls that branch controls what actually executes in CI, with whatever token scopes the job holds. Taking the installer from the same tag as the binary makes the step self-consistent and immutable.

This is the same argument as pinning actions to commit SHAs, applied to the one place in CI that installs tooling over the network via a shell pipe.

**How did you test it?**
Confirmed the tag-pinned URL actually resolves before proposing it: `https://raw.githubusercontent.com/golangci/golangci-lint/v1.64.8/install.sh` returns HTTP 200, as does the `master` URL it replaces. The workflow still parses as valid YAML. The installed linter version is unchanged, since the `v1.64.8` argument passed to the script is untouched.

Worth noting this is the only `curl | sh` in `.github/`, so there is no similar pattern left behind.

**Potential risks**
Low. If the project ever deletes or rewrites that tag the step would break loudly rather than silently running different code, which is the intended tradeoff. When the pinned linter version is next bumped, this URL needs bumping alongside it -- they are now two occurrences of the same version string on one line, which is easy to miss, so it is worth a mention in review.

One related thing I left alone: `api-surface-check.yml:65` runs `go install golang.org/x/exp/cmd/apidiff@latest`, which is unpinned in the same spirit. I did not touch it here because `golang.org/x/exp` has no stable release tags, so pinning it means committing to a pseudo-version string, which is a different judgement call. Happy to follow up if you want it.

**Breaking Changes**
- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**
None.

**Documentation Changes**
None needed.
