### PR TITLE
fix(helm): drop placeholder signKey annotation from chart metadata

### DIFF
--- a/helm/michelangelo/Chart.yaml
+++ b/helm/michelangelo/Chart.yaml
@@ -65,6 +65,3 @@ annotations:
   artifacthub.io/maintainers: |
     - name: Michelangelo Maintainers
       email: maintainers@michelangelo-ai.org
-  artifacthub.io/signKey: |
-    fingerprint: 0000000000000000000000000000000000000000
-    url: https://github.com/michelangelo-ai/michelangelo/releases


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
Removes the `artifacthub.io/signKey` annotation from `helm/michelangelo/Chart.yaml`. Three lines, no other changes.

```
-  artifacthub.io/signKey: |
-    fingerprint: 0000000000000000000000000000000000000000
-    url: https://github.com/michelangelo-ai/michelangelo/releases
```

**Why?**
The fingerprint is an all-zero placeholder, and the chart is not actually signed. Artifact Hub reads `artifacthub.io/signKey` as a claim that a chart is signed and surfaces it to users deciding whether to trust the package, so a placeholder there is worse than the annotation being absent: it advertises a verification path that does not exist and cannot be followed. Removing it makes the chart metadata honest about its current state.

Deleting rather than filling it in, because there is no key to fill in with. If chart signing gets set up later, the annotation should come back at the same time as a real fingerprint, in the same change.

**How did you test it?**
Checked that the chart is genuinely unsigned rather than assuming it from the placeholder. `helm package helm/michelangelo` is invoked in `release.yaml` and `nightly.yml` with no `--sign`, no keyring, and no `.prov` provenance file produced or published. Searched all of `.github/workflows/` for `--sign`, `gpg`, `keyring`, and `.prov` -- the only provenance in the repo is `npm publish --provenance`, which is unrelated to the Helm chart.

Chart.yaml still parses as valid YAML, and the other six `artifacthub.io/*` annotations (links, maintainers, changelog and so on) are untouched. This is the only placeholder value left in the file.

**Potential risks**
Very low, and reversible. Artifact Hub will stop displaying a signing-key entry for the chart, which is the intended effect since there is no key. No chart behavior, template, or value changes -- this is metadata only, so nothing about an install or upgrade is affected.

**Breaking Changes**
- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**
None.

**Documentation Changes**
None needed.
