### PR TITLE
chore: promote v0.8.0 (version strip from 0.8.0-rc.2)

### DIFF
--- a/helm/michelangelo/Chart.yaml
+++ b/helm/michelangelo/Chart.yaml
@@ -7,8 +7,8 @@ description: |
   and RBAC — into any Kubernetes cluster. Bring your own metadata storage,
   object storage, and workflow engine (Cadence or Temporal).
 type: application
-version: 0.8.0-rc.2
-appVersion: "0.8.0-rc.2"
+version: 0.8.0
+appVersion: "0.8.0"
 kubeVersion: ">=1.27.0-0"
 
 dependencies:

--- a/javascript/app/package.json
+++ b/javascript/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@michelangelo/app",
   "license": "Apache-2.0",
-  "version": "0.8.0-rc.2",
+  "version": "0.8.0",
   "private": true,
   "scripts": {
     "build": "vite build --config vite.config.ts",
@@ -11,11 +11,11 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
-    "@michelangelo-ai/rpc": "0.8.0-rc.2",
+    "@michelangelo-ai/rpc": "0.8.0",
     "@mui/icons-material": "^7.1.0",
     "@mui/material": "^7.1.0",
     "@tanstack/react-query": "5.39.0",
-    "@michelangelo-ai/core": "0.8.0-rc.2",
+    "@michelangelo-ai/core": "0.8.0",
     "baseui": "15.0.0",
     "react-router-dom": "5.3.4",
     "react-router-dom-v5-compat": "6.29.0",

--- a/javascript/packages/core/package.json
+++ b/javascript/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@michelangelo-ai/core",
   "license": "Apache-2.0",
-  "version": "0.8.0-rc.2",
+  "version": "0.8.0",
   "type": "module",
   "main": "./dist/michelangelo-core.js",
   "module": "./dist/michelangelo-core.js",

--- a/javascript/packages/rpc/package.json
+++ b/javascript/packages/rpc/package.json
@@ -2,7 +2,7 @@
   "name": "@michelangelo-ai/rpc",
   "license": "Apache-2.0",
   "type": "module",
-  "version": "0.8.0-rc.2",
+  "version": "0.8.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/michelangelo-ai/michelangelo"
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.2.5",
-    "@michelangelo-ai/core": "0.8.0-rc.2"
+    "@michelangelo-ai/core": "0.8.0"
   },
   "exports": {
     ".": {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "michelangelo"
-version = "0.8.0-rc.2"
+version = "0.8.0"
 description = "Michelangelo AI is an end-to-end model lifecycle management system at large scale"
 authors = ["Michelangelo AI Team <michelangelo-oss-group@uber.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Final promotion of `v0.8.0` off `release/v0.8`'s current HEAD (`c1ae964c`, includes #1762's `ColumnConfig.shape` fix carried in via `v0.8.0-rc.2`).
- Strips the `-rc.2` suffix across all component version files.

## Why
Release test against `v0.8.0-rc.2` passed (Part 1/2a/2b, `specs/064/release_test.md`) — explicit user go-ahead to promote to final.

## Test plan
- [ ] CI green
- [ ] Merge, tag `v0.8.0`, dispatch artifact-publish workflows (per REL-005 manual recovery — `release-promote.yml` can't push directly to a protected branch)
- [ ] Verify all artifacts live