### PR TITLE
fix(python): self-heal sandbox mysql Pod if sync finds it not Running

### DIFF
--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -344,6 +344,7 @@ def _sync(ns: argparse.Namespace):
     # Upgrade or install the control plane via Helm.
     # Infrastructure (mysql, cadence, minio, grafana, prometheus) is left running.
 
+    _ensure_mysql_pod_running()
     _refresh_mysql_schema()
 
     _ensure_credentials_secret()
@@ -432,6 +433,47 @@ def _sync(ns: argparse.Namespace):
         )
 
     _helm_wait(ns)
+
+
+def _ensure_mysql_pod_running():
+    """Revive the bare `mysql` Pod if it isn't in the `Running` phase.
+
+    `_sync()`'s fast path leaves infrastructure Pods running rather than
+    recreating them, which assumes the previous sync's `mysql` Pod is still
+    alive. On a long-lived host, a node-level container-runtime restart can
+    leave a bare Pod (no Deployment/ReplicaSet to self-heal it) stuck in a
+    terminal phase (`Succeeded`/`Failed`) even though its containers never
+    exited on their own — `kubectl exec` then fails outright. Detect that
+    and delete+reapply the Pod manifest before `_refresh_mysql_schema()`
+    tries to exec into it.
+    """
+    phase_result = subprocess.run(
+        ["kubectl", "get", "pod", "mysql", "-o", "jsonpath={.status.phase}"],
+        capture_output=True,
+        text=True,
+    )
+    phase = phase_result.stdout.strip()
+
+    if phase_result.returncode == 0 and phase == "Running":
+        return
+
+    print(
+        f"mysql Pod is not Running (phase={phase or 'missing'}) — "
+        "recreating it before refreshing the schema."
+    )
+    subprocess.run(
+        ["kubectl", "delete", "pod", "mysql", "--ignore-not-found=true", "--wait=true"],
+        check=False,
+    )
+    _kube_apply(_dir / "resources" / "mysql.yaml")
+    _exec(
+        "kubectl",
+        "wait",
+        "--for=condition=ready",
+        "pod",
+        "mysql",
+        "--timeout=180s",
+    )
 
 
 def _refresh_mysql_schema():


### PR DESCRIPTION
## Intent

`ma sandbox sync`'s fast path leaves infrastructure Pods (mysql, minio, prometheus, grafana, history-server) running across syncs instead of recreating them, to avoid re-paying their startup cost. `mysql` is a bare `Pod` with no owning controller, so if the underlying node's container runtime restarts between syncs (e.g. on a long-lived CI runner), kubelet can leave the Pod in a terminal phase (`Succeeded`/`Failed`) with nothing to revive it. The next `sync` then fails outright at `kubectl exec mysql -- mysql ...` instead of just being slow, since `kubectl exec` refuses to attach to a container in a terminal pod phase.

## Changes

- `python/michelangelo/cli/sandbox/sandbox.py`: add `_ensure_mysql_pod_running()`, called from `_sync()` right before `_refresh_mysql_schema()`. It checks the `mysql` Pod's phase and, if it isn't `Running`, deletes and reapplies the Pod manifest and waits for it to become ready before the schema refresh proceeds.

## Test plan

- Verified locally against a live k3d sandbox: patched the `mysql` Pod's status to `Succeeded` (`kubectl patch pod mysql --subresource=status ...`) to simulate the failure mode, then confirmed `_ensure_mysql_pod_running()` detects it, deletes+reapplies the Pod, and it comes back `Running`.
- Confirmed the guard is a silent no-op when the Pod is already `Running` (the common case).
- Ran a full `ma sandbox sync --workflow cadence ...` end-to-end afterward and confirmed all control-plane deployments (apiserver, controllermgr, worker, ui, cadence components) came up healthy.

## Related

Root-caused from a real CI failure on `main`'s `Integration tests` workflow (`kubectl exec` failing with "cannot exec into a container in a completed pod; current phase is Succeeded" at the `_refresh_mysql_schema()` step of `_sync()`).