### PR TITLE
feat(native_transform): add schema bridge for fitted transform DAGs (PR B7)

### DIFF
--- a/python/michelangelo/lib/native_transform/torch/schema.py
+++ b/python/michelangelo/lib/native_transform/torch/schema.py
@@ -1,0 +1,363 @@
+"""Bridges a fitted ``TransformSpec`` DAG to a ``ModelSchema``.
+
+Once a :class:`~michelangelo.lib.native_transform.torch.transform_spec.TransformSpec`
+has been fitted and materialized into a
+:class:`~michelangelo.lib.native_transform.torch.base_transform_module.TorchTransformModule`,
+:func:`derive_native_transform_schema` describes the module's input/output
+contract as a :class:`~michelangelo.lib.model_manager.schema.ModelSchema` —
+the shape/dtype metadata Triton config generation and served-model validation
+consume.
+
+Shapes and dtypes are resolved from two sources, in priority order:
+
+* A forward pass over ``sample_data`` (when given), which runs the module and
+  reads the resulting tensors' shapes and dtypes directly.
+* The spec's own declarations: a level-0 layer's ``input_dtype`` (populated
+  from the dataset's Arrow schema), a layer's ``output_dtype`` (user-set), and
+  a layer's ``input_shape`` override (needed for columns a forward pass alone
+  cannot pin, such as a ragged array's fixed max length or an all-null sample
+  column).
+
+Spec declarations win over the forward pass wherever both are present, since
+they encode an explicit contract rather than an inference from one sample row.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+from michelangelo.lib.model_manager.schema import DataType, ModelSchema, ModelSchemaItem
+
+if TYPE_CHECKING:
+    from michelangelo.lib.native_transform.torch.base_transform_module import (
+        TorchTransformModule,
+    )
+    from michelangelo.lib.native_transform.torch.transform_spec import TransformSpec
+
+__all__ = ["derive_native_transform_schema"]
+
+_logger = logging.getLogger(__name__)
+
+_TORCH_DTYPE_TO_DATA_TYPE: dict[torch.dtype, DataType] = {
+    torch.float32: DataType.FLOAT,
+    torch.float64: DataType.DOUBLE,
+    torch.int32: DataType.INT,
+    torch.int64: DataType.LONG,
+    torch.int16: DataType.SHORT,
+    torch.int8: DataType.BYTE,
+    torch.bool: DataType.BOOLEAN,
+}
+
+
+def _to_batched_tensor(
+    value: Any, dtype_hint: torch.dtype | None = None
+) -> tuple[torch.Tensor, list[int] | None]:
+    """Convert a sample value into a batched tensor for shape/dtype inference.
+
+    Args:
+        value: A single column's sample value (scalar, list, numpy array, or
+            tensor).
+        dtype_hint: Dtype to fall back on when ``value`` is ``None`` or is
+            not convertible to a tensor. Typically the column's dtype from
+            the dataset's Arrow schema.
+
+    Returns:
+        A tuple of ``(batched_tensor, shape)``, where ``shape`` excludes the
+        batch dimension. Returns a zero-filled fallback tensor and ``None``
+        shape when ``value`` is ``None`` or fails conversion.
+    """
+    fallback = torch.zeros([1, 1], dtype=dtype_hint or torch.float32)
+    if value is None:
+        return fallback, None
+    try:
+        tensor = torch.as_tensor(value)
+    except (TypeError, ValueError):
+        return fallback, None
+    if tensor.dim() == 0:
+        tensor = tensor.unsqueeze(0)
+    tensor = tensor.unsqueeze(0)  # Add the batch dimension.
+    return tensor, list(tensor.shape[1:])
+
+
+def _build_schema_items(
+    cols: list[str],
+    dtype_map: dict[str, torch.dtype],
+    shape_map: dict[str, list[int]],
+) -> list[ModelSchemaItem]:
+    """Build a ``ModelSchemaItem`` per column from resolved dtypes and shapes.
+
+    Args:
+        cols: Column names to build items for.
+        dtype_map: Column -> resolved torch dtype. A column missing here
+            defaults to ``DataType.FLOAT``.
+        shape_map: Column -> resolved shape. A column missing here gets an
+            unset (``None``) shape.
+
+    Returns:
+        One ``ModelSchemaItem`` per column, in ``cols`` order.
+    """
+    return [
+        ModelSchemaItem(
+            name=col,
+            data_type=_TORCH_DTYPE_TO_DATA_TYPE.get(
+                dtype_map.get(col, torch.float32), DataType.FLOAT
+            ),
+            shape=shape_map.get(col),
+        )
+        for col in cols
+    ]
+
+
+def _filter_output_cols(
+    output_cols: list[str], columns_to_keep: list[str] | None
+) -> list[str]:
+    """Restrict ``output_cols`` to ``columns_to_keep``, preserving order.
+
+    Args:
+        output_cols: The module's full set of output columns.
+        columns_to_keep: The columns to keep, or ``None`` to keep all.
+
+    Returns:
+        ``output_cols`` filtered to ``columns_to_keep`` (or unchanged, if
+        ``columns_to_keep`` is ``None``).
+    """
+    if columns_to_keep is None:
+        return output_cols
+    keep = set(columns_to_keep)
+    return [col for col in output_cols if col in keep]
+
+
+def _collect_input_shape_overrides(
+    transform_spec: TransformSpec,
+) -> dict[str, list[int]]:
+    """Collect manual ``input_shape`` overrides declared on the spec's layers.
+
+    These pin the per-sample shape (batch dimension excluded) for columns a
+    forward pass cannot reliably derive on its own — for example a ragged
+    array whose sampled length varies row to row, where ``input_shape``
+    instead names the fixed max length used to package the served model.
+
+    Args:
+        transform_spec: The fitted spec DAG to scan.
+
+    Returns:
+        Mapping from input column name to its overridden shape.
+    """
+    overrides: dict[str, list[int]] = {}
+    for layer_spec in transform_spec.transform_specs.values():
+        if layer_spec.input_shape is None:
+            continue
+        for col in layer_spec.input_cols:
+            overrides[col] = list(layer_spec.input_shape)
+    return overrides
+
+
+def _validate_input_shape_overrides(
+    override_shapes: dict[str, list[int]], input_cols: list[str]
+) -> None:
+    """Reject ``input_shape`` overrides declared on non-input columns.
+
+    An override on an intermediate column is silently unused (only the
+    module's raw ``input_cols`` are considered when building the schema), so
+    it is rejected here rather than left to fail silently.
+
+    Args:
+        override_shapes: Column -> overridden shape, from
+            :func:`_collect_input_shape_overrides`.
+        input_cols: The module's raw input columns.
+
+    Raises:
+        ValueError: If ``override_shapes`` names a column not in
+            ``input_cols``.
+    """
+    misplaced = sorted(set(override_shapes) - set(input_cols))
+    if misplaced:
+        raise ValueError(
+            f"input_shape set on non-input column(s) {misplaced}: move it to "
+            "the layer spec that reads the raw input column."
+        )
+
+
+def _get_sample_shapes_and_dtypes(
+    transform_module: TorchTransformModule,
+    sample_data: dict[str, Any],
+    input_dtype_map: dict[str, torch.dtype] | None = None,
+) -> tuple[
+    dict[str, list[int]],
+    dict[str, list[int]],
+    dict[str, torch.dtype],
+    dict[str, torch.dtype],
+]:
+    """Derive input/output shapes and dtypes by running one sample through the module.
+
+    Args:
+        transform_module: The module to run in inference mode.
+        sample_data: A single sample row, keyed by column name.
+        input_dtype_map: Column -> dtype from the dataset's Arrow schema,
+            used as the fallback dtype for columns whose sample value is
+            ``None``.
+
+    Returns:
+        A tuple of ``(input_shapes, output_shapes, input_dtypes,
+        output_dtypes)``. Shapes exclude the batch dimension. Output shapes
+        and dtypes are empty if the forward pass raises.
+    """
+    input_dtype_map = input_dtype_map or {}
+    input_shapes: dict[str, list[int]] = {}
+    input_dtypes: dict[str, torch.dtype] = {}
+    input_tensors: dict[str, torch.Tensor] = {}
+
+    for col in transform_module.input_cols:
+        tensor, shape = _to_batched_tensor(
+            sample_data.get(col), dtype_hint=input_dtype_map.get(col)
+        )
+        input_tensors[col] = tensor
+        input_dtypes[col] = tensor.dtype
+        if shape is not None:
+            input_shapes[col] = shape
+
+    output_shapes: dict[str, list[int]] = {}
+    output_dtypes: dict[str, torch.dtype] = {}
+    try:
+        transform_module.eval()
+        with torch.no_grad():
+            output_tensors = transform_module(input_tensors)
+        output_shapes = {
+            col: list(tensor.shape[1:]) for col, tensor in output_tensors.items()
+        }
+        output_dtypes = {col: tensor.dtype for col, tensor in output_tensors.items()}
+    except Exception as e:
+        _logger.warning(f"Failed to derive native transform output shapes/dtypes: {e}")
+
+    return input_shapes, output_shapes, input_dtypes, output_dtypes
+
+
+def _create_native_transform_schema(
+    transform_spec: TransformSpec,
+    input_cols: list[str],
+    output_cols: list[str],
+    derived_input_shapes: dict[str, list[int]] | None = None,
+    derived_output_shapes: dict[str, list[int]] | None = None,
+    derived_input_dtypes: dict[str, torch.dtype] | None = None,
+    derived_output_dtypes: dict[str, torch.dtype] | None = None,
+) -> ModelSchema:
+    """Assemble a ``ModelSchema`` from a spec plus optionally-derived shapes/dtypes.
+
+    Resolution priority (highest first):
+
+    * Input dtype: spec's level-0 ``input_dtype`` > derived (forward pass) >
+      ``DataType.FLOAT`` fallback.
+    * Output dtype: spec's ``output_dtype`` > derived (forward pass) >
+      ``DataType.FLOAT`` fallback.
+    * Input shape: spec's ``input_shape`` override > derived (forward pass) >
+      unset.
+    * Output shape: derived (forward pass) > unset. Output shapes are never
+      taken from the spec directly.
+
+    Args:
+        transform_spec: The fitted spec DAG providing dtype/shape overrides.
+        input_cols: The module's input column names.
+        output_cols: The module's (possibly filtered) output column names.
+        derived_input_shapes: Input shapes from a forward pass, if run.
+        derived_output_shapes: Output shapes from a forward pass, if run.
+        derived_input_dtypes: Input dtypes from a forward pass, if run.
+        derived_output_dtypes: Output dtypes from a forward pass, if run.
+
+    Returns:
+        The assembled ``ModelSchema``.
+
+    Raises:
+        ValueError: If the spec declares an ``input_shape`` override on a
+            column that is not in ``input_cols`` (see
+            :func:`_validate_input_shape_overrides`).
+    """
+    derived_input_shapes = derived_input_shapes or {}
+    derived_output_shapes = derived_output_shapes or {}
+
+    override_input_shapes = _collect_input_shape_overrides(transform_spec)
+    _validate_input_shape_overrides(override_input_shapes, input_cols)
+    input_shape_map = {**derived_input_shapes, **override_input_shapes}
+    output_shape_map = derived_output_shapes
+
+    spec_input_dtypes = transform_spec.get_input_dtype_map(target_transform_level=0)
+    spec_output_dtypes: dict[str, torch.dtype] = {}
+    for layer_spec in transform_spec.transform_specs.values():
+        if layer_spec.output_dtype is None:
+            continue
+        for col in layer_spec.output_cols:
+            spec_output_dtypes[col] = layer_spec.output_dtype
+
+    input_dtype_map = {**(derived_input_dtypes or {}), **spec_input_dtypes}
+    output_dtype_map = {**(derived_output_dtypes or {}), **spec_output_dtypes}
+
+    return ModelSchema(
+        input_schema=_build_schema_items(input_cols, input_dtype_map, input_shape_map),
+        output_schema=_build_schema_items(
+            output_cols, output_dtype_map, output_shape_map
+        ),
+    )
+
+
+def derive_native_transform_schema(
+    transform_spec: TransformSpec,
+    transform_module: TorchTransformModule,
+    sample_data: dict[str, Any] | None = None,
+) -> ModelSchema:
+    """Derive the ``ModelSchema`` for a materialized native transform module.
+
+    This is the module's public entry point: it filters output columns by
+    the spec's ``columns_to_keep``, optionally runs a sample row through the
+    module to infer shapes and dtypes, and assembles the result into a
+    ``ModelSchema``.
+
+    Args:
+        transform_spec: The fitted spec DAG ``transform_module`` was
+            materialized from.
+        transform_module: The materialized module to derive a schema for.
+        sample_data: An optional sample row, keyed by column name. When
+            given, a forward pass over it infers shapes and dtypes; when
+            omitted, only the spec's own declarations are used.
+
+    Returns:
+        The derived ``ModelSchema``.
+    """
+    input_cols = transform_module.input_cols
+    output_cols = _filter_output_cols(
+        transform_module.output_cols, transform_spec.columns_to_keep
+    )
+
+    input_shapes: dict[str, list[int]] = {}
+    output_shapes: dict[str, list[int]] = {}
+    input_dtypes: dict[str, torch.dtype] = {}
+    output_dtypes: dict[str, torch.dtype] = {}
+
+    if sample_data is not None:
+        input_shapes, output_shapes, input_dtypes, output_dtypes = (
+            _get_sample_shapes_and_dtypes(
+                transform_module,
+                sample_data,
+                # Only level-0 dtypes are needed: the forward pass computes
+                # every intermediate dtype itself.
+                input_dtype_map=transform_spec.get_input_dtype_map(
+                    target_transform_level=0
+                ),
+            )
+        )
+
+    _logger.info(
+        f"Derived native transform schema with {len(input_cols)} input(s) and "
+        f"{len(output_cols)} output(s)"
+    )
+
+    return _create_native_transform_schema(
+        transform_spec=transform_spec,
+        input_cols=input_cols,
+        output_cols=output_cols,
+        derived_input_shapes=input_shapes,
+        derived_output_shapes=output_shapes,
+        derived_input_dtypes=input_dtypes,
+        derived_output_dtypes=output_dtypes,
+    )

--- a/python/michelangelo/lib/native_transform/torch/schema.py
+++ b/python/michelangelo/lib/native_transform/torch/schema.py
@@ -74,7 +74,7 @@ def _to_batched_tensor(
         return fallback, None
     try:
         tensor = torch.as_tensor(value)
-    except (TypeError, ValueError):
+    except Exception:
         return fallback, None
     if tensor.dim() == 0:
         tensor = tensor.unsqueeze(0)

--- a/python/michelangelo/lib/native_transform/torch/tests/test_schema.py
+++ b/python/michelangelo/lib/native_transform/torch/tests/test_schema.py
@@ -99,6 +99,19 @@ class TestToBatchedTensor:
         assert tensor.dtype == torch.float64
         assert shape == [2]
 
+    def test_list_with_null_element_returns_none_shape(self) -> None:
+        """A list with a null element must fall back like a None value."""
+        tensor, shape = _to_batched_tensor([1.0, None, 3.0])
+        assert shape is None
+        assert tensor.shape == torch.Size([1, 1])
+        assert tensor.dtype == torch.float32
+
+    def test_dict_value_returns_none_shape(self) -> None:
+        """A dict value must fall back like a None value, not propagate."""
+        tensor, shape = _to_batched_tensor({"a": 1.0})
+        assert shape is None
+        assert tensor.shape == torch.Size([1, 1])
+
 
 class TestBuildSchemaItems:
     """``_build_schema_items``'s column -> ``ModelSchemaItem`` assembly."""

--- a/python/michelangelo/lib/native_transform/torch/tests/test_schema.py
+++ b/python/michelangelo/lib/native_transform/torch/tests/test_schema.py
@@ -1,0 +1,667 @@
+"""Tests for :mod:`michelangelo.lib.native_transform.torch.schema`.
+
+Covers shape/dtype inference from a sample forward pass, spec-declared
+dtype/shape overrides, output-column filtering via ``columns_to_keep``, and
+the high-level ``derive_native_transform_schema`` entry point end to end.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+# These tests build real torch layers/modules and a real TransformSpec.
+torch = pytest.importorskip("torch")
+pytest.importorskip("pydantic")
+
+from michelangelo.lib.model_manager.schema import DataType  # noqa: E402
+from michelangelo.lib.native_transform.torch.base_transform_module import (  # noqa: E402
+    get_transform_module,
+)
+from michelangelo.lib.native_transform.torch.schema import (  # noqa: E402
+    _build_schema_items,
+    _collect_input_shape_overrides,
+    _create_native_transform_schema,
+    _filter_output_cols,
+    _get_sample_shapes_and_dtypes,
+    _to_batched_tensor,
+    derive_native_transform_schema,
+)
+from michelangelo.lib.native_transform.torch.transform_spec import (  # noqa: E402
+    TransformSpec,
+)
+
+
+class TestToBatchedTensor:
+    """``_to_batched_tensor``'s value -> (tensor, shape) conversion."""
+
+    def test_scalar_returns_correct_shape(self) -> None:
+        """A bare scalar batches to shape [1]."""
+        tensor, shape = _to_batched_tensor(1.0)
+        assert shape == [1]
+        assert tensor.shape[0] == 1
+
+    def test_list_returns_correct_shape(self) -> None:
+        """A 1D list's shape excludes the batch dimension."""
+        _, shape = _to_batched_tensor([1.0, 2.0, 3.0])
+        assert shape == [3]
+
+    def test_2d_list_returns_correct_shape(self) -> None:
+        """A 2D list's shape preserves both dimensions."""
+        _, shape = _to_batched_tensor([[1.0, 2.0], [3.0, 4.0]])
+        assert shape == [2, 2]
+
+    def test_numpy_array_returns_correct_shape(self) -> None:
+        """A numpy array converts to the same shape as an equivalent list."""
+        _, shape = _to_batched_tensor(np.array([1.0, 2.0]))
+        assert shape == [2]
+
+    def test_torch_tensor_returns_correct_shape(self) -> None:
+        """An already-a-tensor value converts without changing its shape."""
+        _, shape = _to_batched_tensor(torch.tensor([1.0, 2.0, 3.0]))
+        assert shape == [3]
+
+    def test_none_returns_none_shape(self) -> None:
+        """A None value falls back to a [1, 1] float32 zero tensor with no shape."""
+        tensor, shape = _to_batched_tensor(None)
+        assert shape is None
+        assert tensor.shape == torch.Size([1, 1])
+        assert tensor.dtype == torch.float32
+
+    def test_none_with_dtype_hint_uses_hint(self) -> None:
+        """A null column should use dtype_hint from the Arrow schema."""
+        tensor, shape = _to_batched_tensor(None, dtype_hint=torch.int64)
+        assert shape is None
+        assert tensor.dtype == torch.int64
+
+    def test_unconvertible_value_returns_none_shape(self) -> None:
+        """A value torch.as_tensor can't convert falls back like a None value."""
+        tensor, shape = _to_batched_tensor("string_value")
+        assert shape is None
+        assert tensor.shape == torch.Size([1, 1])
+
+    def test_dtype_hint_ignored_when_value_present(self) -> None:
+        """dtype_hint must not override an actual present value's dtype."""
+        tensor, _ = _to_batched_tensor(
+            np.array([1, 2], dtype=np.int32), dtype_hint=torch.float64
+        )
+        assert tensor.dtype == torch.int32
+
+    def test_preserves_int32_dtype(self) -> None:
+        """A numpy int32 array's dtype survives batching."""
+        tensor, shape = _to_batched_tensor(np.array([1, 2, 3], dtype=np.int32))
+        assert tensor.dtype == torch.int32
+        assert shape == [3]
+
+    def test_preserves_float64_dtype(self) -> None:
+        """A numpy float64 array's dtype survives batching."""
+        tensor, shape = _to_batched_tensor(np.array([1.0, 2.0], dtype=np.float64))
+        assert tensor.dtype == torch.float64
+        assert shape == [2]
+
+
+class TestBuildSchemaItems:
+    """``_build_schema_items``'s column -> ``ModelSchemaItem`` assembly."""
+
+    def test_creates_items_with_dtypes_and_shapes(self) -> None:
+        """Each column gets its own resolved data_type and shape."""
+        items = _build_schema_items(
+            cols=["col1", "col2"],
+            dtype_map={"col1": torch.float64, "col2": torch.int64},
+            shape_map={"col1": [10], "col2": [5]},
+        )
+        assert len(items) == 2
+        assert items[0].name == "col1"
+        assert items[0].data_type == DataType.DOUBLE
+        assert items[0].shape == [10]
+        assert items[1].name == "col2"
+        assert items[1].data_type == DataType.LONG
+        assert items[1].shape == [5]
+
+    def test_defaults_to_float_for_missing_dtype(self) -> None:
+        """A column absent from dtype_map defaults to DataType.FLOAT."""
+        items = _build_schema_items(["col1"], {}, {})
+        assert items[0].data_type == DataType.FLOAT
+        assert items[0].shape is None
+
+
+class TestFilterOutputCols:
+    """``_filter_output_cols``'s ``columns_to_keep`` filtering."""
+
+    def test_returns_all_when_columns_to_keep_none(self) -> None:
+        """A None columns_to_keep keeps every output column."""
+        assert _filter_output_cols(["a", "b", "c"], None) == ["a", "b", "c"]
+
+    def test_filters_to_kept_columns(self) -> None:
+        """Only columns named in columns_to_keep survive."""
+        assert _filter_output_cols(["a", "b", "c", "d"], ["b", "d"]) == ["b", "d"]
+
+    def test_preserves_output_cols_order(self) -> None:
+        """Filtering preserves output_cols' original order, not columns_to_keep's."""
+        assert _filter_output_cols(["c", "a", "b"], ["a", "b", "c"]) == ["c", "a", "b"]
+
+
+class TestGetSampleShapesAndDtypes:
+    """``_get_sample_shapes_and_dtypes``'s forward-pass-driven inference."""
+
+    def _concatenate_module(self):
+        """Build a one-layer Concatenate module over columns a, b -> ab."""
+        spec = TransformSpec(
+            raw_transform_specs={
+                "transform_specs": [
+                    {
+                        "transform_name": "Concatenate",
+                        "input_cols": ["a", "b"],
+                        "output_cols": ["ab"],
+                    }
+                ]
+            }
+        )
+        return get_transform_module(spec, start_level=0)
+
+    def test_derives_input_and_output_shapes(self) -> None:
+        """Shapes for both inputs and the concatenated output are derived."""
+        module = self._concatenate_module()
+        input_shapes, output_shapes, _, _ = _get_sample_shapes_and_dtypes(
+            module, {"a": [1.0, 2.0], "b": [3.0, 4.0]}
+        )
+        assert input_shapes == {"a": [2], "b": [2]}
+        assert output_shapes["ab"] == [4]
+
+    def test_handles_null_columns(self) -> None:
+        """A None sample value is excluded from input_shapes but not output_shapes."""
+        module = self._concatenate_module()
+        input_shapes, output_shapes, _, _ = _get_sample_shapes_and_dtypes(
+            module, {"a": [1.0, 2.0], "b": None}
+        )
+        assert "a" in input_shapes
+        assert "b" not in input_shapes
+        assert "ab" in output_shapes
+
+    def test_preserves_int32_through_concatenate(self) -> None:
+        """int32 inputs stay int32 through Concatenate when dtypes match."""
+        module = self._concatenate_module()
+        sample_data = {
+            "a": np.array([1, 2], dtype=np.int32),
+            "b": np.array([3, 4], dtype=np.int32),
+        }
+        _, _, input_dtypes, output_dtypes = _get_sample_shapes_and_dtypes(
+            module, sample_data
+        )
+        assert input_dtypes["a"] == torch.int32
+        assert input_dtypes["b"] == torch.int32
+        assert output_dtypes["ab"] == torch.int32
+
+    def test_promotes_mixed_dtypes_through_concatenate(self) -> None:
+        """torch.cat promotes int32 + float32 to float32."""
+        module = self._concatenate_module()
+        sample_data = {
+            "a": np.array([1, 2], dtype=np.int32),
+            "b": np.array([3.0, 4.0], dtype=np.float32),
+        }
+        _, _, input_dtypes, output_dtypes = _get_sample_shapes_and_dtypes(
+            module, sample_data
+        )
+        assert input_dtypes["a"] == torch.int32
+        assert input_dtypes["b"] == torch.float32
+        assert output_dtypes["ab"] == torch.float32
+
+    def test_null_column_uses_dtype_hint_from_input_dtype_map(self) -> None:
+        """A None sample value falls back to input_dtype_map's dtype, not float32."""
+        module = self._concatenate_module()
+        sample_data = {"a": np.array([1, 2], dtype=np.int32), "b": None}
+        _, _, input_dtypes, output_dtypes = _get_sample_shapes_and_dtypes(
+            module, sample_data, input_dtype_map={"b": torch.int32}
+        )
+        assert input_dtypes["a"] == torch.int32
+        assert input_dtypes["b"] == torch.int32
+        assert output_dtypes["ab"] == torch.int32
+
+    def test_null_column_without_dtype_hint_defaults_to_float32(self) -> None:
+        """A None sample value with no dtype hint falls back to float32."""
+        module = self._concatenate_module()
+        sample_data = {"a": np.array([1, 2], dtype=np.int32), "b": None}
+        _, _, input_dtypes, output_dtypes = _get_sample_shapes_and_dtypes(
+            module, sample_data
+        )
+        assert input_dtypes["a"] == torch.int32
+        assert input_dtypes["b"] == torch.float32
+        assert output_dtypes["ab"] == torch.float32
+
+    def test_padorcrop1d_preserves_int32(self) -> None:
+        """PadOrCrop1D with dtype=None preserves an int32 input's dtype."""
+        spec = TransformSpec(
+            raw_transform_specs={
+                "transform_specs": [
+                    {
+                        "transform_name": "PadOrCrop1D",
+                        "input_cols": ["a"],
+                        "output_cols": ["a_padded"],
+                        "max_length": 5,
+                    }
+                ]
+            }
+        )
+        module = get_transform_module(spec, start_level=0)
+        sample_data = {"a": np.array([1, 2, 3], dtype=np.int32)}
+        _, _, input_dtypes, output_dtypes = _get_sample_shapes_and_dtypes(
+            module, sample_data
+        )
+        assert input_dtypes["a"] == torch.int32
+        assert output_dtypes["a_padded"] == torch.int32
+
+
+class TestCreateNativeTransformSchema:
+    """``_create_native_transform_schema``'s dtype/shape merge priority."""
+
+    def test_builds_schema_from_derived_shapes(self) -> None:
+        """Derived input/output shapes populate the resulting schema items."""
+        spec = TransformSpec(
+            raw_transform_specs={
+                "transform_specs": [
+                    {
+                        "transform_name": "Concatenate",
+                        "input_cols": ["a"],
+                        "output_cols": ["out"],
+                    }
+                ]
+            }
+        )
+        schema = _create_native_transform_schema(
+            transform_spec=spec,
+            input_cols=["a"],
+            output_cols=["out"],
+            derived_input_shapes={"a": [10]},
+            derived_output_shapes={"out": [10]},
+        )
+        assert len(schema.input_schema) == 1
+        assert schema.input_schema[0].name == "a"
+        assert schema.input_schema[0].shape == [10]
+        assert len(schema.output_schema) == 1
+        assert schema.output_schema[0].name == "out"
+        assert schema.output_schema[0].shape == [10]
+
+    def test_handles_missing_shapes(self) -> None:
+        """No derived or overridden shapes leaves schema item shapes unset."""
+        spec = TransformSpec(
+            raw_transform_specs={
+                "transform_specs": [
+                    {
+                        "transform_name": "Concatenate",
+                        "input_cols": ["a"],
+                        "output_cols": ["out"],
+                    }
+                ]
+            }
+        )
+        schema = _create_native_transform_schema(
+            transform_spec=spec, input_cols=["a"], output_cols=["out"]
+        )
+        assert schema.input_schema[0].shape is None
+        assert schema.output_schema[0].shape is None
+
+    def test_derived_output_dtype_used_absent_spec_override(self) -> None:
+        """A derived output dtype is used when the spec sets no output_dtype."""
+        spec = TransformSpec(
+            raw_transform_specs={
+                "transform_specs": [
+                    {
+                        "transform_name": "Concatenate",
+                        "input_cols": ["a", "b"],
+                        "output_cols": ["out"],
+                    }
+                ]
+            }
+        )
+        schema = _create_native_transform_schema(
+            transform_spec=spec,
+            input_cols=["a", "b"],
+            output_cols=["out"],
+            derived_output_dtypes={"out": torch.int32},
+        )
+        assert schema.output_schema[0].data_type == DataType.INT
+
+    def test_spec_output_dtype_overrides_derived(self) -> None:
+        """A spec-declared output_dtype takes priority over a derived one."""
+        spec = TransformSpec(
+            raw_transform_specs={
+                "transform_specs": [
+                    {
+                        "transform_name": "NumericalStandardTransform",
+                        "input_cols": ["a"],
+                        "output_cols": ["out"],
+                    }
+                ]
+            }
+        )
+        schema = _create_native_transform_schema(
+            transform_spec=spec,
+            input_cols=["a"],
+            output_cols=["out"],
+            derived_output_dtypes={"out": torch.int64},
+        )
+        # NumericalStandardTransform's model_validator sets output_dtype to
+        # its (float32) dtype field, which must win over the derived int64.
+        assert schema.output_schema[0].data_type == DataType.FLOAT
+
+    def test_derived_input_dtype_used_for_raw_inputs(self) -> None:
+        """A derived input dtype is used when the spec sets no input_dtype."""
+        spec = TransformSpec(
+            raw_transform_specs={
+                "transform_specs": [
+                    {
+                        "transform_name": "Concatenate",
+                        "input_cols": ["a"],
+                        "output_cols": ["out"],
+                    }
+                ]
+            }
+        )
+        schema = _create_native_transform_schema(
+            transform_spec=spec,
+            input_cols=["a"],
+            output_cols=["out"],
+            derived_input_dtypes={"a": torch.float64},
+        )
+        assert schema.input_schema[0].data_type == DataType.DOUBLE
+
+
+class TestInputShapeOverrides:
+    """Manual ``input_shape`` overrides declared on layer specs."""
+
+    def test_collect_shape_overrides_maps_each_col(self) -> None:
+        """Every input column of an override layer gets the same overridden shape."""
+        spec = TransformSpec(
+            raw_transform_specs={
+                "transform_specs": [
+                    {
+                        "transform_name": "TensorColFillNone",
+                        "input_cols": ["delivery_fee"],
+                        "output_cols": ["delivery_fee_filled"],
+                        "default_value": 0.0,
+                        "input_shape": [1],
+                    }
+                ]
+            }
+        )
+        assert _collect_input_shape_overrides(spec) == {"delivery_fee": [1]}
+
+    def test_collect_shape_overrides_empty_when_unset(self) -> None:
+        """A spec with no input_shape overrides collects an empty mapping."""
+        spec = TransformSpec(
+            raw_transform_specs={
+                "transform_specs": [
+                    {
+                        "transform_name": "Concatenate",
+                        "input_cols": ["a"],
+                        "output_cols": ["out"],
+                    }
+                ]
+            }
+        )
+        assert _collect_input_shape_overrides(spec) == {}
+
+    def test_override_backfills_a_shape_the_forward_pass_could_not_derive(
+        self,
+    ) -> None:
+        """An override supplies a shape a null sample value could not derive."""
+        spec = TransformSpec(
+            raw_transform_specs={
+                "transform_specs": [
+                    {
+                        "transform_name": "TensorColFillNone",
+                        "input_cols": ["delivery_fee"],
+                        "output_cols": ["delivery_fee_filled"],
+                        "default_value": 0.0,
+                        "input_shape": [1],
+                    }
+                ]
+            }
+        )
+        schema = _create_native_transform_schema(
+            transform_spec=spec,
+            input_cols=["delivery_fee"],
+            output_cols=["delivery_fee_filled"],
+            derived_input_shapes={},
+        )
+        item = next(i for i in schema.input_schema if i.name == "delivery_fee")
+        assert item.shape == [1]
+
+    def test_override_wins_over_derived_shape(self) -> None:
+        """A spec-declared input_shape takes priority over a derived shape."""
+        spec = TransformSpec(
+            raw_transform_specs={
+                "transform_specs": [
+                    {
+                        "transform_name": "Concatenate",
+                        "input_cols": ["a"],
+                        "output_cols": ["out"],
+                        "input_shape": [4],
+                    }
+                ]
+            }
+        )
+        schema = _create_native_transform_schema(
+            transform_spec=spec,
+            input_cols=["a"],
+            output_cols=["out"],
+            derived_input_shapes={"a": [10]},
+        )
+        assert schema.input_schema[0].shape == [4]
+
+    def test_misplaced_override_on_intermediate_col_raises(self) -> None:
+        """An input_shape on a non-level-0 column must raise, not be dropped."""
+        spec = TransformSpec(
+            raw_transform_specs={
+                "transform_specs": [
+                    {
+                        "transform_name": "TensorColFillNone",
+                        "input_cols": ["delivery_fee"],
+                        "output_cols": ["delivery_fee_filled"],
+                        "default_value": 0.0,
+                    },
+                    {
+                        "transform_name": "PadOrCrop1D",
+                        "input_cols": ["delivery_fee_filled"],
+                        "output_cols": ["delivery_fee_padded"],
+                        "max_length": 32,
+                        "input_shape": [32],
+                    },
+                ]
+            }
+        )
+        with pytest.raises(ValueError, match="delivery_fee_filled"):
+            _create_native_transform_schema(
+                transform_spec=spec,
+                input_cols=["delivery_fee"],
+                output_cols=["delivery_fee_padded"],
+                derived_input_shapes={},
+            )
+
+    def test_correctly_placed_override_passes_guard(self) -> None:
+        """An input_shape on the level-0 input column passes and pins the shape."""
+        spec = TransformSpec(
+            raw_transform_specs={
+                "transform_specs": [
+                    {
+                        "transform_name": "PadOrCrop1D",
+                        "input_cols": ["delivery_fee"],
+                        "output_cols": ["delivery_fee_padded"],
+                        "max_length": 32,
+                        "input_shape": [32],
+                    }
+                ]
+            }
+        )
+        schema = _create_native_transform_schema(
+            transform_spec=spec,
+            input_cols=["delivery_fee"],
+            output_cols=["delivery_fee_padded"],
+            derived_input_shapes={},
+        )
+        item = next(i for i in schema.input_schema if i.name == "delivery_fee")
+        assert item.shape == [32]
+
+
+class TestDeriveNativeTransformSchema:
+    """``derive_native_transform_schema``'s end-to-end public API."""
+
+    def test_derives_schema_with_sample_data(self) -> None:
+        """End to end: a sample forward pass derives both shapes and dtypes."""
+        spec = TransformSpec(
+            raw_transform_specs={
+                "transform_specs": [
+                    {
+                        "transform_name": "Concatenate",
+                        "input_cols": ["a", "b"],
+                        "output_cols": ["ab"],
+                    }
+                ]
+            }
+        )
+        module = get_transform_module(spec, start_level=0)
+        sample_data = {
+            "a": np.array([1.0, 2.0], dtype=np.float64),
+            "b": np.array([3.0], dtype=np.float64),
+        }
+
+        schema = derive_native_transform_schema(spec, module, sample_data=sample_data)
+
+        assert len(schema.input_schema) == 2
+        by_name = {item.name: item for item in schema.input_schema}
+        assert by_name["a"].data_type == DataType.DOUBLE
+        assert by_name["a"].shape == [2]
+        assert by_name["b"].shape == [1]
+        assert len(schema.output_schema) == 1
+        assert schema.output_schema[0].name == "ab"
+        assert schema.output_schema[0].shape == [3]
+
+    def test_derives_schema_without_sample_data(self) -> None:
+        """Without sample_data, shapes are left unset and dtypes default to float."""
+        spec = TransformSpec(
+            raw_transform_specs={
+                "transform_specs": [
+                    {
+                        "transform_name": "Concatenate",
+                        "input_cols": ["a"],
+                        "output_cols": ["out"],
+                    }
+                ]
+            }
+        )
+        module = get_transform_module(spec, start_level=0)
+
+        schema = derive_native_transform_schema(spec, module, sample_data=None)
+
+        assert len(schema.input_schema) == 1
+        assert schema.input_schema[0].name == "a"
+        assert schema.input_schema[0].shape is None
+        assert len(schema.output_schema) == 1
+        assert schema.output_schema[0].name == "out"
+
+    def test_filters_output_cols_via_columns_to_keep(self) -> None:
+        """The spec's columns_to_keep filters which outputs land in the schema."""
+        spec = TransformSpec(
+            raw_transform_specs={
+                "transform_specs": [
+                    {
+                        "transform_name": "Concatenate",
+                        "input_cols": ["a", "b"],
+                        "output_cols": ["ab"],
+                    }
+                ]
+            }
+        )
+        spec.columns_to_keep = ["ab"]
+        module = get_transform_module(spec, start_level=0)
+
+        schema = derive_native_transform_schema(spec, module)
+
+        assert [item.name for item in schema.output_schema] == ["ab"]
+
+    def test_columns_to_keep_excludes_unlisted(self) -> None:
+        """columns_to_keep excludes an unlisted output from another layer."""
+        spec = TransformSpec(
+            raw_transform_specs={
+                "transform_specs": [
+                    {
+                        "transform_name": "Concatenate",
+                        "input_cols": ["a"],
+                        "output_cols": ["out1"],
+                    },
+                    {
+                        "transform_name": "Concatenate",
+                        "input_cols": ["b"],
+                        "output_cols": ["out2"],
+                    },
+                ]
+            }
+        )
+        spec.columns_to_keep = ["out1"]
+        module = get_transform_module(spec, start_level=0)
+
+        schema = derive_native_transform_schema(spec, module)
+
+        output_names = [item.name for item in schema.output_schema]
+        assert output_names == ["out1"]
+        assert "out2" not in output_names
+
+    def test_input_shape_pins_max_length_over_a_ragged_sample(self) -> None:
+        """input_shape pins PadOrCrop1D's fixed max length, overriding a ragged sample.
+
+        The sampled row has a ragged length (3) that must not leak into the
+        packaged model's static input shape; input_shape (32, matching
+        PadOrCrop1D's max_length) wins so Triton/ONNX/TRT get a concrete
+        dimension. The output shape is derived from the forward pass (which
+        PadOrCrop1D always fixes to max_length), so no output override is
+        needed.
+        """
+        spec = TransformSpec(
+            raw_transform_specs={
+                "transform_specs": [
+                    {
+                        "transform_name": "PadOrCrop1D",
+                        "input_cols": ["delivery_fee"],
+                        "output_cols": ["delivery_fee_padded"],
+                        "max_length": 32,
+                        "input_shape": [32],
+                    }
+                ]
+            }
+        )
+        module = get_transform_module(spec, start_level=0)
+
+        schema = derive_native_transform_schema(
+            spec, module, sample_data={"delivery_fee": [1.0, 2.0, 3.0]}
+        )
+
+        in_item = next(i for i in schema.input_schema if i.name == "delivery_fee")
+        out_item = next(
+            i for i in schema.output_schema if i.name == "delivery_fee_padded"
+        )
+        assert in_item.shape == [32]
+        assert out_item.shape == [32]
+
+    def test_derive_schema_uses_override_for_null_sample(self) -> None:
+        """A null sample value cannot derive a shape; the override fills it in."""
+        spec = TransformSpec(
+            raw_transform_specs={
+                "transform_specs": [
+                    {
+                        "transform_name": "TensorColFillNone",
+                        "input_cols": ["delivery_fee"],
+                        "output_cols": ["delivery_fee_filled"],
+                        "default_value": 0.0,
+                        "input_shape": [1],
+                    }
+                ]
+            }
+        )
+        module = get_transform_module(spec, start_level=0)
+
+        schema = derive_native_transform_schema(
+            spec, module, sample_data={"delivery_fee": None}
+        )
+
+        item = next(i for i in schema.input_schema if i.name == "delivery_fee")
+        assert item.shape == [1]


### PR DESCRIPTION
## Context

This is PR B7 of the `native_transform` migration split (B1-B8), and the last sub-PR before PR C (Ray compute lib). B1-B6 and B8 are already merged (#1570, #1603, #1683, #1684, #1685, #1730, #1729).

Once a `TransformSpec` DAG (PR B6) is fitted and materialized into a `TorchTransformModule`, something needs to describe that module's input/output contract as a `ModelSchema` — the shape/dtype metadata Triton config generation and served-model validation consume. This PR adds that bridge.

## Changes

- New `michelangelo/lib/native_transform/torch/schema.py`:
  - `derive_native_transform_schema(transform_spec, transform_module, sample_data=None)`: the public entry point. Filters output columns via the spec's `columns_to_keep`, optionally runs `sample_data` through the module to infer shapes/dtypes, and assembles a `ModelSchema`.
  - Supporting helpers: `_to_batched_tensor` (sample value -> batched tensor), `_get_sample_shapes_and_dtypes` (forward-pass-driven inference), `_collect_input_shape_overrides` / `_validate_input_shape_overrides` (the spec's manual `input_shape` overrides, needed for columns a forward pass can't pin — e.g. a ragged array's fixed max length, or an all-null sample column), `_build_schema_items` / `_filter_output_cols` / `_create_native_transform_schema` (schema assembly with a documented dtype/shape merge priority: spec declarations win over forward-pass inference).
  - Imports `DataType`, `ModelSchema`, `ModelSchemaItem` from the existing `michelangelo.lib.model_manager.schema` package rather than redefining them.
- New `michelangelo/lib/native_transform/torch/tests/test_schema.py`: pytest-style tests covering every function, mirroring the source repo's equivalent test coverage (shape/dtype inference across dtype combinations including int/float promotion, null-column handling, `columns_to_keep` filtering, the `input_shape` override guard and its misplaced-override error path, and full end-to-end `derive_native_transform_schema` runs).

## Design notes

- Preserves the internal implementation's exact dtype/shape merge semantics (a spec-declared `output_dtype` always overrides a forward-pass-derived dtype, even in the one internal-only case where `output_dtype` isn't a real torch dtype — kept as-is for behavioral parity, since no current layer spec in this codebase actually hits that path).
- No changes to `transform_spec.py`, `base_transform_module.py`, or any other B1-B6/B8 file — this PR only adds new files and imports from what's already merged.

## Testing

- `pytest michelangelo/lib/native_transform/` (full suite, not just the new file): 433 passed, 0 failed, no regressions.
- `ruff format --check` and `ruff check`: both clean on the new files.
- Coverage: automated `coverage run` segfaults on this torch-importing target in the sandbox test venv (a known environment limitation, not specific to this PR); coverage was instead verified by manual traceability — every function in `schema.py` has at least one dedicated test class, and every branch (derived vs. spec-declared dtype/shape, override validation, null-sample fallback, `columns_to_keep` filtering with and without exclusions) has an explicit assertion.

## Scope

This PR is self-contained and does not overlap with PR C (Ray compute lib), which starts only after this merges.