### PR TITLE
feat(native_transform): add Ray execution adapter (PR C)

### DIFF
--- a/python/michelangelo/uniflow/plugins/ray/native_transform.py
+++ b/python/michelangelo/uniflow/plugins/ray/native_transform.py
@@ -186,11 +186,7 @@ def compute_numerical_statistics(
     if not aggregate_fns:
         return numerical_stats
 
-    batch_count = (
-        len(numerical_statistics_computation_specs)
-        // numerical_statistics_batch_fn_size
-        + 1
-    )
+    batch_count = len(aggregate_fns) // numerical_statistics_batch_fn_size + 1
     for i in range(batch_count):
         batch = aggregate_fns[
             i * numerical_statistics_batch_fn_size : (i + 1)

--- a/python/michelangelo/uniflow/plugins/ray/native_transform.py
+++ b/python/michelangelo/uniflow/plugins/ray/native_transform.py
@@ -1,0 +1,749 @@
+"""Ray execution adapter for the ``native_transform`` torch compute core.
+
+Runs a fitted :class:`~michelangelo.lib.native_transform.torch.TransformSpec`
+DAG over a ``ray.data.Dataset``: hydrates any missing numerical statistics
+(percentiles, min/max/mean/std) level by level, materializes each level as a
+:class:`~michelangelo.lib.native_transform.torch.TorchTransformModule`, and
+runs it as a Ray ``map_batches`` stage via :class:`TorchBatchPredictor`. The
+same ``TransformSpec`` DAG is TorchScript-exportable, so training-time
+transforms here match serving-time transforms exactly.
+
+Filesystem access for dataset I/O goes through the
+:func:`~michelangelo.uniflow.plugins.ray.io._fs_path` seam already used by
+:class:`~michelangelo.uniflow.plugins.ray.io.RayDatasetIO`, so this module has
+no filesystem-registration side effects of its own.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+import numpy as np
+import pyarrow as pa
+import ray
+import torch
+
+from michelangelo.lib._internal.utils.numpy_utils import (
+    assemble_output_table,
+    infer_dtype,
+    pad_ragged_tensor,
+    pyarrow_to_numpy,
+)
+from michelangelo.lib.native_transform.torch import (
+    TorchTransformBaseLayer,
+    TransformSpec,
+    get_transform_module,
+)
+from michelangelo.lib.native_transform.torch.constants import (
+    DEFAULT_NUMERICAL_OUTPUT_DTYPE,
+)
+from michelangelo.uniflow.plugins.ray.io import _fs_path
+
+_logger = logging.getLogger(__name__)
+
+DEFAULT_MAP_BATCH_CONCURRENCY = 100
+DEFAULT_NUM_STATS_BATCH_FN_SIZE = 500
+DEFAULT_MAP_BATCH_SIZE = 20000
+
+# Only numeric pyarrow types are supported by the torch transform layers.
+PYARROW_TYPE_TO_TORCH_DATA_TYPE_MAP: dict[pa.DataType, torch.dtype] = {
+    pa.int32(): torch.int32,
+    pa.int64(): torch.int64,
+    pa.float32(): torch.float32,
+    pa.float64(): torch.float64,
+}
+
+__all__ = [
+    "DataProcessor",
+    "DefaultDataProcessor",
+    "TorchBatchPredictor",
+    "check_stats_exist",
+    "compute_numerical_statistics",
+    "filter_columns",
+    "get_numerical_stats_names",
+    "get_torch_dtype",
+    "get_transform_torch_inference",
+    "numerical_statistics_preparation",
+    "read_dataset",
+    "transform",
+    "write_dataset",
+]
+
+
+def read_dataset(path: str) -> ray.data.Dataset:
+    """Read a Parquet dataset from *path* as a Ray ``Dataset``.
+
+    Args:
+        path: Directory path or URL containing Parquet files (local,
+            ``s3://``, etc). Resolved to a filesystem via
+            :func:`~michelangelo.uniflow.plugins.ray.io._fs_path`.
+
+    Returns:
+        The loaded Ray ``Dataset``.
+    """
+    fs, resolved_path = _fs_path(path)
+    return ray.data.read_parquet(resolved_path, filesystem=fs)
+
+
+def write_dataset(ds: ray.data.Dataset, path: str, mode: str = "append") -> None:
+    """Write a Ray ``Dataset`` to *path* as Parquet.
+
+    Args:
+        ds: The dataset to write.
+        path: Destination directory path or URL. Resolved to a filesystem via
+            :func:`~michelangelo.uniflow.plugins.ray.io._fs_path`.
+        mode: Ray ``write_parquet`` write mode (``"append"``, ``"overwrite"``,
+            or ``"error_if_exists"``).
+    """
+    fs, resolved_path = _fs_path(path)
+    ds.write_parquet(resolved_path, filesystem=fs, mode=mode)
+
+
+def filter_columns(
+    ds: ray.data.Dataset, columns_to_keep: list[str]
+) -> ray.data.Dataset:
+    """Filter a Ray dataset down to the columns present in *columns_to_keep*.
+
+    Args:
+        ds: The dataset to filter.
+        columns_to_keep: Column names to retain. Names not present in the
+            dataset's schema are silently ignored.
+
+    Returns:
+        A dataset containing only the columns in both *columns_to_keep* and
+        the dataset's schema.
+    """
+    return ds.select_columns(
+        [col for col in columns_to_keep if col in ds.schema().names]
+    )
+
+
+def compute_numerical_statistics(
+    ray_data_df: ray.data.Dataset,
+    existing_numerical_stats: dict[str, float],
+    numerical_statistics_computation_specs: dict[str, dict[str, Any]],
+    numerical_statistics_batch_fn_size: int = DEFAULT_NUM_STATS_BATCH_FN_SIZE,
+) -> dict[str, float]:
+    """Compute numerical statistics (percentiles, max, min, mean, std) for columns.
+
+    Statistics already present in *existing_numerical_stats* are skipped, and
+    aggregate functions are batched to bound how many run in a single Ray
+    ``aggregate`` call.
+
+    Args:
+        ray_data_df: Ray dataset to compute statistics on.
+        existing_numerical_stats: Already computed statistics to skip
+            (keyed ``"{column}_{stat}"``).
+        numerical_statistics_computation_specs: Per-column statistics to
+            compute, e.g. ``{"col": {"percentiles": ["0.5"], "max": True,
+            "min": True, "mean": True, "std": True}}``.
+        numerical_statistics_batch_fn_size: Max aggregate functions to run in
+            a single ``Dataset.aggregate`` call.
+
+    Returns:
+        Newly computed statistics, keyed ``"{column}_{stat}"`` (e.g.
+        ``"age_50"`` for the 50th percentile).
+    """
+    # Local import: pinning ray.data.aggregate at module import time can pick
+    # up an inconsistent Ray version on the driver vs. workers.
+    from ray.data.aggregate import Max, Mean, Min, Quantile, Std
+
+    columns_needed = list(numerical_statistics_computation_specs.keys())
+    if columns_needed:
+        _logger.info(
+            "Projecting dataset to %d columns for aggregation: %s",
+            len(columns_needed),
+            columns_needed,
+        )
+        ray_data_df = ray_data_df.select_columns(columns_needed)
+
+    aggregate_fns = []
+    for input_col, spec in numerical_statistics_computation_specs.items():
+        aggregate_fns.extend(
+            [
+                Quantile(
+                    input_col,
+                    q=float(p),
+                    alias_name=f"{input_col}_{int(100 * float(p))!s}",
+                )
+                for p in spec["percentiles"]
+                if f"{input_col}_{int(100 * float(p))!s}"
+                not in existing_numerical_stats
+            ]
+        )
+        if spec["max"] and f"{input_col}_max" not in existing_numerical_stats:
+            aggregate_fns.append(Max(input_col, alias_name=f"{input_col}_max"))
+        if spec["min"] and f"{input_col}_min" not in existing_numerical_stats:
+            aggregate_fns.append(Min(input_col, alias_name=f"{input_col}_min"))
+        if spec["std"] and f"{input_col}_std" not in existing_numerical_stats:
+            aggregate_fns.append(Std(input_col, alias_name=f"{input_col}_std"))
+        if spec["mean"] and f"{input_col}_mean" not in existing_numerical_stats:
+            aggregate_fns.append(Mean(input_col, alias_name=f"{input_col}_mean"))
+
+    numerical_stats: dict[str, float] = {}
+    if not aggregate_fns:
+        return numerical_stats
+
+    batch_count = (
+        len(numerical_statistics_computation_specs)
+        // numerical_statistics_batch_fn_size
+        + 1
+    )
+    for i in range(batch_count):
+        batch = aggregate_fns[
+            i * numerical_statistics_batch_fn_size : (i + 1)
+            * numerical_statistics_batch_fn_size
+        ]
+        numerical_stats.update(ray_data_df.aggregate(*batch))
+    return numerical_stats
+
+
+def get_torch_dtype(pa_type: pa.DataType) -> torch.dtype:
+    """Return the torch dtype corresponding to a numeric pyarrow type.
+
+    Recursively unwraps nested ``list``/``fixed_size_list`` types (e.g. for
+    2D arrays like ``list<element: list<element: double>>``) down to their
+    innermost value type.
+
+    Args:
+        pa_type: A pyarrow data type.
+
+    Returns:
+        The corresponding ``torch.dtype``.
+
+    Raises:
+        ValueError: If *pa_type* (after unwrapping any nesting) is not one of
+            the supported numeric types.
+    """
+    while isinstance(pa_type, (pa.ListType, pa.FixedSizeListType)):
+        pa_type = pa_type.value_type
+
+    torch_dtype = PYARROW_TYPE_TO_TORCH_DATA_TYPE_MAP.get(pa_type)
+    if torch_dtype is None:
+        raise ValueError(
+            f"Unsupported pyarrow type for torch dtype conversion: {pa_type}"
+        )
+    return torch_dtype
+
+
+def transform(
+    df: ray.data.Dataset,
+    transform_spec: TransformSpec,
+    feature_stats: dict[str, float],
+    batch_size: int = DEFAULT_MAP_BATCH_SIZE,
+    map_batch_concurrency: int = DEFAULT_MAP_BATCH_CONCURRENCY,
+    num_gpus: int = 0,
+) -> tuple[ray.data.Dataset, TransformSpec, dict[str, float]]:
+    """Run a ``TransformSpec`` DAG over a Ray dataset, level by level.
+
+    Non-numeric columns (strings, etc.) pass through unchanged; only numeric
+    columns participate in the transform DAG. Each level hydrates any missing
+    numerical statistics from the dataset before materializing and running
+    that level's layers as a ``map_batches`` stage.
+
+    Args:
+        df: The dataset to transform.
+        transform_spec: The transform DAG to run. Mutated in place: dtypes
+            and fitted statistics are hydrated onto it as levels complete.
+        feature_stats: Previously computed statistics to reuse, keyed
+            ``"{column}_{stat}"``. Updated in place with any newly computed
+            statistics.
+        batch_size: Row batch size passed to ``Dataset.map_batches``.
+        map_batch_concurrency: Concurrent ``map_batches`` workers.
+        num_gpus: GPUs to request per worker; only honored when a CUDA device
+            is available, otherwise runs on CPU.
+
+    Returns:
+        A ``(transformed_dataset, transform_spec, feature_stats)`` tuple.
+    """
+    data_dtype_map: dict[str, torch.dtype] = {}
+    skipped_columns: dict[str, str] = {}
+    for name, pa_type in zip(df.schema().names, df.schema().types):
+        try:
+            data_dtype_map[name] = get_torch_dtype(pa_type)
+        except ValueError:
+            skipped_columns[name] = str(pa_type)
+
+    if skipped_columns:
+        _logger.info(
+            "Skipping %d non-numeric columns: %s", len(skipped_columns), skipped_columns
+        )
+
+    # Register output columns for cross-level dtype tracking. Use the layer's
+    # explicit output_dtype when set, else fall back to float32 so later
+    # levels' update_input_dtype can resolve this column's dtype.
+    for layer_spec in transform_spec.transform_specs.values():
+        for output_col in layer_spec.output_cols:
+            data_dtype_map[output_col] = (
+                layer_spec.output_dtype or DEFAULT_NUMERICAL_OUTPUT_DTYPE
+            )
+
+    max_level = transform_spec.get_max_transform_level()
+    for level in range(max_level + 1):
+        transform_spec.update_input_dtype(data_dtype_map, level)
+
+    finished_levels: list[int] = []
+    for level in range(max_level + 1):
+        start = time.time()
+        if not check_stats_exist(feature_stats, transform_spec, level):
+            torch_inference = get_transform_torch_inference(
+                transform_spec, finished_levels, level - 1
+            )
+            if torch_inference:
+                df = df.map_batches(
+                    torch_inference,
+                    batch_size=batch_size,
+                    num_gpus=num_gpus if torch.cuda.is_available() else 0,
+                    zero_copy_batch=True,
+                    batch_format="pyarrow",  # keeps passthrough columns zero-copy
+                    concurrency=map_batch_concurrency,
+                    num_cpus=1,  # GIL-bound torch inference; 1 Python thread per task
+                )
+            finished_levels.append(level - 1)
+            df = df.materialize()
+        numerical_statistics_preparation(df, feature_stats, transform_spec, level)
+        _logger.info(
+            "native transform level %d finished in %.3f seconds",
+            level,
+            time.time() - start,
+        )
+
+    torch_inference = get_transform_torch_inference(
+        transform_spec, finished_levels, max_level
+    )
+    if torch_inference:
+        df = df.map_batches(
+            torch_inference,
+            batch_size=batch_size,
+            num_gpus=num_gpus if torch.cuda.is_available() else 0,
+            zero_copy_batch=True,
+            batch_format="pyarrow",
+            concurrency=map_batch_concurrency,
+            num_cpus=1,
+        )
+
+    return df, transform_spec, feature_stats
+
+
+def get_numerical_stats_names(specs: dict[str, dict[str, Any]]) -> list[str]:
+    """Return the flattened statistic names a computation spec dict requests.
+
+    Args:
+        specs: Per-column statistics specs, as passed to
+            :func:`compute_numerical_statistics`.
+
+    Returns:
+        Names in the form ``"{column}_{stat}"`` (e.g. ``"age_mean"``,
+        ``"age_50"`` for the 50th percentile).
+    """
+    names = []
+    for col, spec in specs.items():
+        if spec.get("min", False):
+            names.append(f"{col}_min")
+        if spec.get("max", False):
+            names.append(f"{col}_max")
+        if spec.get("std", False):
+            names.append(f"{col}_std")
+        if spec.get("mean", False):
+            names.append(f"{col}_mean")
+        names.extend(
+            f"{col}_{int(100 * float(p))!s}" for p in spec.get("percentiles", [])
+        )
+    return names
+
+
+def check_stats_exist(
+    feature_stats: dict[str, float], transform_spec: TransformSpec, level: int
+) -> bool:
+    """Return whether every statistic *level* needs is already in *feature_stats*.
+
+    Args:
+        feature_stats: Already computed statistics, keyed
+            ``"{column}_{stat}"``.
+        transform_spec: The transform DAG being hydrated.
+        level: The transform level to check.
+
+    Returns:
+        ``True`` if *level* requires no additional statistics computation.
+    """
+    required = get_numerical_stats_names(
+        transform_spec.get_numerical_statistics_computation_specs(level)
+    )
+    return all(name in feature_stats for name in required)
+
+
+def numerical_statistics_preparation(
+    df: ray.data.Dataset,
+    existing_feature_stats: dict[str, float],
+    transform_spec: TransformSpec,
+    level: int,
+) -> None:
+    """Compute and hydrate any numerical statistics *level* still needs.
+
+    Computes missing statistics via :func:`compute_numerical_statistics`,
+    merges them into *existing_feature_stats*, and hydrates the resulting
+    values onto *transform_spec*'s standard-scaler, min-max-scaler, and
+    bucketization layers for *level*.
+
+    Args:
+        df: The dataset to compute statistics from.
+        existing_feature_stats: Previously computed statistics; updated in
+            place with any newly computed values.
+        transform_spec: The transform DAG being hydrated; mutated in place.
+        level: The transform level to prepare statistics for.
+    """
+    specs = transform_spec.get_numerical_statistics_computation_specs(level)
+    start = time.time()
+    if specs:
+        _logger.info("start computing numerical_standard_transform_parameters")
+        new_stats = compute_numerical_statistics(df, existing_feature_stats, specs)
+        existing_feature_stats.update(new_stats)
+        transform_spec.update_numerical_standard_transform_parameters(
+            existing_feature_stats, level
+        )
+        transform_spec.update_standard_scaler_specs(existing_feature_stats, level)
+        _logger.info("standard_scaler_parameters computation finished.")
+        transform_spec.update_min_max_scaler_specs(existing_feature_stats, level)
+        _logger.info("min_max_scaler_parameters computation finished.")
+        transform_spec.update_bucketization_specs(existing_feature_stats, level)
+        _logger.info("bucketization_parameters computation finished.")
+    _logger.info(
+        "numerical_stats computation finished in %.3f seconds", time.time() - start
+    )
+
+
+def get_transform_torch_inference(
+    transform_spec: TransformSpec,
+    finished_levels: list[int],
+    current_level: int,
+) -> TorchBatchPredictor | None:
+    """Materialize the torch layers for levels after the last finished level.
+
+    Args:
+        transform_spec: The transform DAG to materialize from.
+        finished_levels: Levels already run; the next range starts right
+            after the highest of these (or at ``0`` if empty).
+        current_level: The last level to include in the materialized range.
+
+    Returns:
+        A predictor wrapping the materialized level range, or ``None`` if
+        that range contains no layers.
+    """
+    start_level = 0 if not finished_levels else max(finished_levels) + 1
+    transform_module = get_transform_module(transform_spec, start_level, current_level)
+    if transform_module is None:
+        return None
+
+    if transform_spec.columns_to_keep is None:
+        columns_to_keep = None
+    else:
+        # Keep both the user-requested columns and any input columns future
+        # levels still need, since this predictor's output feeds them.
+        max_level = transform_spec.get_max_transform_level()
+        future_input_cols: set[str] = set()
+        for level in range(current_level + 1, max_level + 1):
+            future_input_cols.update(transform_spec.get_transform_input_cols(level))
+        columns_to_keep = set(transform_spec.columns_to_keep) | future_input_cols
+
+    return TorchBatchPredictor(
+        model=transform_module,
+        input_columns=transform_module.input_cols,
+        output_columns=transform_module.output_cols,
+        model_kwargs=None,
+        columns_to_keep=columns_to_keep,
+    )
+
+
+def _pad_ragged_arrays(
+    arrays: np.ndarray,
+    ragged_fill_value: int | float | None = None,
+) -> np.ndarray:
+    """Pad an object-dtype array of variable-length numeric sub-arrays.
+
+    Supports arbitrarily nested ragged structures (e.g. ``list<list<float32>>``
+    from parquet). When *ragged_fill_value* is ``None``, the type-native
+    sentinel from
+    :func:`~michelangelo.lib._internal.utils.numpy_utils.sentinel_for_numpy_dtype`
+    is used.
+
+    Args:
+        arrays: Object-dtype array whose elements are numeric ``np.ndarray``s.
+        ragged_fill_value: Value to pad with. Defaults to the type-native
+            sentinel when ``None``.
+
+    Returns:
+        A uniform numeric array with the original elements' dtype preserved.
+
+    Raises:
+        ValueError: If *arrays* is empty, contains non-``np.ndarray``
+            elements, or its inferred dtype is non-numeric.
+    """
+    if len(arrays) == 0:
+        raise ValueError("Cannot pad empty array")
+
+    if not all(isinstance(a, np.ndarray) for a in arrays):
+        raise ValueError("Not all elements are numpy arrays")
+
+    dtype = infer_dtype(arrays)
+    if dtype is None:
+        raise ValueError("Cannot infer element dtype: all sub-arrays are empty")
+    if dtype.kind in ("U", "S", "O"):
+        raise ValueError(f"Non-numeric dtype: {dtype}")
+
+    padded = pad_ragged_tensor(arrays, pad_value=ragged_fill_value)
+    if padded.dtype != dtype:
+        padded = padded.astype(dtype)
+    return padded
+
+
+class DataProcessor:
+    """Abstract interface for pre/post-processing torch model inference batches."""
+
+    def prepare_inputs(self, batch: dict[str, np.ndarray]) -> dict[str, torch.Tensor]:
+        """Convert a raw numpy batch into model input tensors."""
+        raise NotImplementedError
+
+    def postprocess_outputs(
+        self, outputs: dict[str, torch.Tensor]
+    ) -> dict[str, np.ndarray]:
+        """Convert model output tensors into the expected numpy format."""
+        raise NotImplementedError
+
+
+class DefaultDataProcessor(DataProcessor):
+    """Numeric-only ``DataProcessor`` used by :class:`TorchBatchPredictor`.
+
+    Args:
+        input_columns: Column names to treat as model inputs. ``None`` means
+            every column in the batch.
+        output_columns: Column names to extract from model outputs. ``None``
+            means every key the model returns.
+    """
+
+    def __init__(
+        self,
+        input_columns: list[str] | None = None,
+        output_columns: list[str] | None = None,
+    ) -> None:
+        """Initialize the data processor.
+
+        Args:
+            input_columns: Column names to treat as model inputs. ``None``
+                means every column in the batch.
+            output_columns: Column names to extract from model outputs.
+                ``None`` means every key the model returns.
+        """
+        self.input_columns = input_columns
+        self.output_columns = output_columns
+
+    def prepare_inputs(self, batch: dict[str, np.ndarray]) -> dict[str, torch.Tensor]:
+        """Convert numeric batch columns to torch tensors, preserving dtype and shape.
+
+        Only numeric types are supported. Object-dtype columns holding nested
+        arrays (as parquet list columns commonly deserialize to) are stacked;
+        ragged nested arrays are padded with a type-native sentinel via
+        :func:`_pad_ragged_arrays`.
+
+        Args:
+            batch: Input batch as a dict of numpy arrays.
+
+        Returns:
+            A dict mapping each input column to its input tensor.
+
+        Raises:
+            ValueError: If a column has a non-numeric dtype (string, bytes,
+                or bool), or an object-dtype column cannot be converted to a
+                numeric array.
+        """
+        inputs: dict[str, torch.Tensor] = {}
+
+        for col in self.input_columns or list(batch.keys()):
+            input_data = batch[col]
+
+            is_bool_array = input_data.dtype in (bool, np.bool_)
+            if input_data.dtype.kind in ("U", "S") or is_bool_array:
+                raise ValueError(
+                    f"Column '{col}' has unsupported type {input_data.dtype}. "
+                    "Only numeric types are allowed for torch model inference."
+                )
+
+            if input_data.dtype.kind == "O":
+                try:
+                    input_data = np.stack(input_data)
+                except (ValueError, TypeError):
+                    # np.stack failed: sub-arrays likely have different
+                    # lengths (ragged). Pad to the batch max with the
+                    # sentinel so downstream transforms can tell real data
+                    # from padding.
+                    try:
+                        input_data = _pad_ragged_arrays(input_data)
+                    except (ValueError, TypeError) as pad_err:
+                        raise ValueError(
+                            f"Column '{col}' has object dtype but cannot be "
+                            f"converted to numeric array: {pad_err}"
+                        ) from pad_err
+
+                if input_data.dtype.kind == "O":
+                    try:
+                        # Recursively expand nested structures, e.g. a
+                        # [B, 1, d] column where each element is itself a
+                        # nested array.
+                        input_data = np.array(input_data.tolist(), dtype=np.float64)
+                    except (ValueError, TypeError) as e:
+                        raise ValueError(
+                            f"Column '{col}' contains non-numeric or ragged "
+                            f"array data: {e}"
+                        ) from e
+
+            # np.ascontiguousarray keeps the memory layout compatible with
+            # torch.from_numpy; the original dtype is preserved (rather than
+            # casting to float32) to avoid precision loss for large integers.
+            tensor = torch.from_numpy(np.ascontiguousarray(input_data))
+            inputs[col] = tensor
+        return inputs
+
+    def postprocess_outputs(
+        self, outputs: dict[str, torch.Tensor]
+    ) -> dict[str, np.ndarray]:
+        """Convert model output tensors/values to numpy arrays.
+
+        Args:
+            outputs: Model outputs keyed by column name.
+
+        Returns:
+            A dict mapping each output column to its numpy array.
+
+        Raises:
+            ValueError: If an expected output column is missing from
+                *outputs*.
+        """
+        result: dict[str, np.ndarray] = {}
+        for col in self.output_columns or list(outputs.keys()):
+            if col not in outputs:
+                raise ValueError(
+                    f"Expected output column '{col}' not found in model outputs"
+                )
+            output_value = outputs[col]
+            if isinstance(output_value, torch.Tensor):
+                result[col] = output_value.detach().cpu().numpy()
+            else:
+                result[col] = np.array(output_value)
+        return result
+
+
+class TorchBatchPredictor:
+    """Callable batch-inference adapter for running torch models over Ray datasets.
+
+    Follows the Ray ``Dataset.map_batches`` callable-class pattern: an
+    instance is passed directly to ``map_batches`` and invoked once per
+    batch. Only the configured input columns are materialized to numpy;
+    every other column passes through as native Arrow data untouched.
+
+    Example:
+        >>> predictor = TorchBatchPredictor(
+        ...     model=my_torch_model,
+        ...     input_columns=["features"],
+        ...     output_columns=["predictions"],
+        ... )
+        >>> results = dataset.map_batches(
+        ...     predictor,
+        ...     batch_size=32,
+        ...     num_gpus=1 if torch.cuda.is_available() else 0,
+        ...     zero_copy_batch=True,
+        ...     batch_format="pyarrow",
+        ... )
+    """
+
+    def __init__(
+        self,
+        model: TorchTransformBaseLayer,
+        input_columns: list[str] | None = None,
+        output_columns: list[str] | None = None,
+        model_kwargs: dict[str, Any] | None = None,
+        columns_to_keep: list[str] | set[str] | None = None,
+    ) -> None:
+        """Initialize the batch predictor.
+
+        Args:
+            model: Torch model to run. A ``TorchTransformBaseLayer`` subclass
+                taking and returning ``dict[str, torch.Tensor]``.
+            input_columns: Columns to use as model inputs. ``None`` uses all
+                batch columns.
+            output_columns: Columns to extract from model outputs. ``None``
+                uses every key the model returns.
+            model_kwargs: Extra keyword arguments forwarded to the model's
+                ``forward()``.
+            columns_to_keep: Columns to retain in the output. ``None`` or
+                empty keeps every column.
+
+        Raises:
+            ValueError: If *model* is ``None``.
+        """
+        if model is None:
+            raise ValueError("model must be provided")
+
+        self._model = model
+        self.input_columns = input_columns
+        self.output_columns = output_columns
+        self.columns_to_keep = columns_to_keep
+        self.model_kwargs = model_kwargs or {}
+        self._data_processor: DefaultDataProcessor | None = None
+
+    @property
+    def data_processor(self) -> DefaultDataProcessor:
+        """The lazily-instantiated data processor for this predictor."""
+        if self._data_processor is None:
+            self._data_processor = DefaultDataProcessor(
+                input_columns=self.input_columns,
+                output_columns=self.output_columns,
+            )
+        return self._data_processor
+
+    def _predict(self, batch: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
+        """Run inference on a numpy batch and postprocess the model outputs."""
+        model_inputs = self.data_processor.prepare_inputs(batch)
+        if self.model_kwargs:
+            model_outputs = self._model(model_inputs, **self.model_kwargs)
+        else:
+            model_outputs = self._model(model_inputs)
+        return self.data_processor.postprocess_outputs(model_outputs)
+
+    def __call__(self, batch: pa.Table) -> pa.Table:
+        """Run inference on a PyArrow ``Table`` batch.
+
+        Args:
+            batch: A batch of input rows. Each model-input column must be
+                convertible to numpy via
+                :func:`~michelangelo.lib._internal.utils.numpy_utils.pyarrow_to_numpy`.
+
+        Returns:
+            A ``Table`` of model predictions plus pass-through input columns.
+            Multi-dim outputs are encoded as native nested
+            ``FixedSizeList<T, K>`` columns so the result writes directly to
+            Parquet. When ``columns_to_keep`` is a non-empty collection, only
+            those columns are retained.
+
+        Raises:
+            ValueError: If inference fails.
+        """
+        try:
+            input_cols = (
+                self.input_columns
+                if self.input_columns is not None
+                else list(batch.column_names)
+            )
+            input_batch = {
+                col: pyarrow_to_numpy(batch.column(col)) for col in input_cols
+            }
+
+            with torch.inference_mode():
+                processed_outputs = self._predict(input_batch)
+
+            return assemble_output_table(
+                batch, processed_outputs, columns_to_keep=self.columns_to_keep
+            )
+        except Exception as e:
+            _logger.error("Batch inference failed: %s", e, exc_info=True)
+            raise ValueError(f"Error during batch inference: {e}") from e

--- a/python/michelangelo/uniflow/plugins/ray/tests/native_transform_integration_test.py
+++ b/python/michelangelo/uniflow/plugins/ray/tests/native_transform_integration_test.py
@@ -1,0 +1,88 @@
+"""Real (non-mocked) Ray integration tests for the native_transform adapter.
+
+These exercise ``transform()`` end-to-end against a real local Ray cluster
+(``ray.data``, ``Dataset.map_batches``) to guard against the class of bug
+where a fully-mocked unit suite stays green while the actual Ray/torch
+integration is broken (mismatched ``map_batches`` kwargs, batch-format
+assumptions, etc).
+
+They spin up a real (local, single-process) Ray runtime, which is slow and
+memory-heavier than the mocked unit suite. On memory-constrained CI runners
+this can be tight, so — matching the precedent set by
+``lib/trainer/torch/pytorch_lightning/tests/test_auto_resume_integration.py``
+— these are **skipped in CI by default**. Run them locally (the default
+off-CI), or in a dedicated Ray-enabled CI job, by setting
+``MICHELANGELO_RUN_RAY_INTEGRATION_TESTS=1``.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+if (os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS")) and (
+    os.environ.get("MICHELANGELO_RUN_RAY_INTEGRATION_TESTS") != "1"
+):
+    pytest.skip(
+        "Skipping real-Ray integration tests in CI (they spin up a Ray cluster "
+        "and are memory-heavy on constrained runners). Set "
+        "MICHELANGELO_RUN_RAY_INTEGRATION_TESTS=1 to run them.",
+        allow_module_level=True,
+    )
+
+ray = pytest.importorskip("ray")
+pytest.importorskip("ray.data")
+torch = pytest.importorskip("torch")
+
+from michelangelo.lib.native_transform.torch import TransformSpec  # noqa: E402
+from michelangelo.uniflow.plugins.ray.native_transform import transform  # noqa: E402
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _ray_cluster():
+    ray.init(num_cpus=2, include_dashboard=False, ignore_reinit_error=True)
+    yield
+    ray.shutdown()
+
+
+def _make_concatenate_spec() -> TransformSpec:
+    """Build a single-layer spec: Concatenate(x) -> x_out (identity for one input)."""
+    raw_spec = {
+        "transform_specs": [
+            {
+                "transform_name": "Concatenate",
+                "input_cols": ["x"],
+                "output_cols": ["x_out"],
+            }
+        ],
+    }
+    return TransformSpec(raw_transform_specs=raw_spec)
+
+
+class TestTransformOnRealRayCluster:
+    """End-to-end ``transform()`` against a real local Ray cluster."""
+
+    def test_transform_produces_expected_output_column(self):
+        """A single-level Concatenate spec runs and produces the output column."""
+        ds = ray.data.from_items([{"x": 1.0}, {"x": 2.0}, {"x": 3.0}])
+        spec = _make_concatenate_spec()
+
+        result_ds, result_spec, result_stats = transform(ds, spec, feature_stats={})
+
+        rows = sorted(result_ds.take_all(), key=lambda r: r["x"])
+        assert [r["x_out"] for r in rows] == pytest.approx([1.0, 2.0, 3.0])
+        assert result_spec is spec
+        assert isinstance(result_stats, dict)
+
+    def test_transform_passes_through_non_numeric_columns(self):
+        """A string column not referenced by the spec passes through unchanged."""
+        ds = ray.data.from_items(
+            [{"x": 1.0, "label": "a"}, {"x": 2.0, "label": "b"}],
+        )
+        spec = _make_concatenate_spec()
+
+        result_ds, _, _ = transform(ds, spec, feature_stats={})
+
+        rows = sorted(result_ds.take_all(), key=lambda r: r["x"])
+        assert [r["label"] for r in rows] == ["a", "b"]

--- a/python/michelangelo/uniflow/plugins/ray/tests/native_transform_test.py
+++ b/python/michelangelo/uniflow/plugins/ray/tests/native_transform_test.py
@@ -270,6 +270,61 @@ class ComputeNumericalStatisticsTests(unittest.TestCase):
 
         self.assertEqual(mock_dataset.aggregate.call_count, 2)
 
+    def test_batch_count_covers_all_aggregate_fns_not_just_specs(self):
+        """batch_count must scale with aggregate_fns, not with column specs.
+
+        Two columns each contribute 4 aggregate fns (max/min/mean/std), for 8
+        total, while there are only 2 specs. With a batch size of 2, a
+        batch_count derived from spec count would only cover the first 4
+        aggregate fns, silently dropping the rest.
+        """
+
+        class _FakeAggFn:
+            def __init__(self, input_col, alias_name=None, **_kwargs):
+                self.input_col = input_col
+                self.alias_name = alias_name
+
+        mock_dataset = MagicMock()
+        mock_dataset.select_columns.return_value = mock_dataset
+        mock_dataset.aggregate.side_effect = lambda *fns: {
+            fn.alias_name: 1.0 for fn in fns
+        }
+        specs = {
+            "col1": {
+                "percentiles": [],
+                "max": True,
+                "min": True,
+                "mean": True,
+                "std": True,
+            },
+            "col2": {
+                "percentiles": [],
+                "max": True,
+                "min": True,
+                "mean": True,
+                "std": True,
+            },
+        }
+
+        mock_aggregate = MagicMock()
+        mock_aggregate.Max = mock_aggregate.Min = mock_aggregate.Mean = (
+            mock_aggregate.Std
+        ) = _FakeAggFn
+        with patch.dict("sys.modules", {"ray.data.aggregate": mock_aggregate}):
+            result = compute_numerical_statistics(
+                mock_dataset,
+                existing_numerical_stats={},
+                numerical_statistics_computation_specs=specs,
+                numerical_statistics_batch_fn_size=2,
+            )
+
+        expected_keys = {
+            f"{col}_{stat}"
+            for col in ("col1", "col2")
+            for stat in ("max", "min", "mean", "std")
+        }
+        self.assertEqual(set(result.keys()), expected_keys)
+
 
 class GetTorchDtypeTests(unittest.TestCase):
     """Tests for get torch dtype."""

--- a/python/michelangelo/uniflow/plugins/ray/tests/native_transform_test.py
+++ b/python/michelangelo/uniflow/plugins/ray/tests/native_transform_test.py
@@ -1,0 +1,1025 @@
+"""Tests for the Ray native_transform execution adapter."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, call, patch
+
+import numpy as np
+import pyarrow as pa
+import torch
+
+from michelangelo.lib._internal.utils.numpy_utils import sentinel_for_numpy_dtype
+from michelangelo.uniflow.plugins.ray.native_transform import (
+    DefaultDataProcessor,
+    TorchBatchPredictor,
+    _pad_ragged_arrays,
+    check_stats_exist,
+    compute_numerical_statistics,
+    filter_columns,
+    get_numerical_stats_names,
+    get_torch_dtype,
+    get_transform_torch_inference,
+    numerical_statistics_preparation,
+    read_dataset,
+    transform,
+    write_dataset,
+)
+
+_MODULE = "michelangelo.uniflow.plugins.ray.native_transform"
+
+
+class DummyModel:
+    """A stand-in torch-model callable for TorchBatchPredictor tests."""
+
+    def __init__(self, outputs=None, raise_error=False):
+        """Initialize with fixed outputs, or configure a forced failure."""
+        self.outputs = outputs or {}
+        self.raise_error = raise_error
+        self.last_inputs = None
+
+    def __call__(self, inputs):
+        """Record the received inputs and return the configured outputs."""
+        self.last_inputs = inputs
+        if self.raise_error:
+            raise RuntimeError("inference failed")
+        return self.outputs
+
+
+class FilterColumnsTests(unittest.TestCase):
+    """Tests for filter columns."""
+
+    def test_keeps_existing_columns(self):
+        """Keeps existing columns."""
+        mock_dataset = MagicMock()
+        mock_dataset.schema.return_value.names = ["col1", "col2", "col3"]
+
+        filter_columns(mock_dataset, ["col1", "col3"])
+
+        mock_dataset.select_columns.assert_called_once_with(["col1", "col3"])
+
+    def test_ignores_nonexistent_columns(self):
+        """Ignores nonexistent columns."""
+        mock_dataset = MagicMock()
+        mock_dataset.schema.return_value.names = ["col1", "col2"]
+
+        filter_columns(mock_dataset, ["col1", "nonexistent"])
+
+        mock_dataset.select_columns.assert_called_once_with(["col1"])
+
+    def test_empty_keep_list(self):
+        """Empty keep list."""
+        mock_dataset = MagicMock()
+        mock_dataset.schema.return_value.names = ["col1", "col2"]
+
+        filter_columns(mock_dataset, [])
+
+        mock_dataset.select_columns.assert_called_once_with([])
+
+
+class ReadWriteDatasetTests(unittest.TestCase):
+    """read_dataset/write_dataset route filesystem resolution through _fs_path."""
+
+    @patch(f"{_MODULE}.ray")
+    @patch(f"{_MODULE}._fs_path")
+    def test_read_dataset_uses_fs_path(self, mock_fs_path, mock_ray):
+        """Read dataset uses fs path."""
+        mock_fs = MagicMock()
+        mock_fs_path.return_value = (mock_fs, "/resolved/path")
+        mock_dataset = MagicMock()
+        mock_ray.data.read_parquet.return_value = mock_dataset
+
+        result = read_dataset("s3://some/path")
+
+        mock_fs_path.assert_called_once_with("s3://some/path")
+        mock_ray.data.read_parquet.assert_called_once_with(
+            "/resolved/path", filesystem=mock_fs
+        )
+        self.assertIs(result, mock_dataset)
+
+    @patch(f"{_MODULE}._fs_path")
+    def test_read_dataset_propagates_fs_path_errors(self, mock_fs_path):
+        """Read dataset propagates fs path errors."""
+        mock_fs_path.side_effect = ValueError("invalid path")
+
+        with self.assertRaises(ValueError):
+            read_dataset("invalid://path")
+
+    @patch(f"{_MODULE}._fs_path")
+    def test_write_dataset_default_mode(self, mock_fs_path):
+        """Write dataset default mode."""
+        mock_fs = MagicMock()
+        mock_fs_path.return_value = (mock_fs, "/resolved/out")
+        mock_dataset = MagicMock()
+
+        write_dataset(mock_dataset, "s3://bucket/out")
+
+        mock_fs_path.assert_called_once_with("s3://bucket/out")
+        mock_dataset.write_parquet.assert_called_once_with(
+            "/resolved/out", filesystem=mock_fs, mode="append"
+        )
+
+    @patch(f"{_MODULE}._fs_path")
+    def test_write_dataset_overwrite_mode(self, mock_fs_path):
+        """Write dataset overwrite mode."""
+        mock_fs_path.return_value = (None, "/resolved/out")
+        mock_dataset = MagicMock()
+
+        write_dataset(mock_dataset, "/local/out", mode="overwrite")
+
+        mock_dataset.write_parquet.assert_called_once_with(
+            "/resolved/out", filesystem=None, mode="overwrite"
+        )
+
+    def test_no_custom_filesystem_registration_side_effect(self):
+        """Importing the module must not register any custom fsspec filesystem."""
+        import inspect
+
+        from michelangelo.uniflow.plugins.ray import native_transform as module
+
+        source = inspect.getsource(module)
+        self.assertNotIn("register_implementation", source)
+        self.assertNotIn("fsspec.register", source)
+
+
+class ComputeNumericalStatisticsTests(unittest.TestCase):
+    """Tests for compute numerical statistics."""
+
+    def test_basic(self):
+        """Basic."""
+        mock_dataset = MagicMock()
+        mock_dataset.select_columns.return_value = mock_dataset
+        mock_dataset.aggregate.return_value = {
+            "feature_50": 5.0,
+            "feature_75": 7.5,
+            "feature_max": 10.0,
+            "feature_min": 0.0,
+            "feature_mean": 5.0,
+            "feature_std": 2.5,
+        }
+        specs = {
+            "feature": {
+                "percentiles": ["0.5", "0.75"],
+                "max": True,
+                "min": True,
+                "mean": True,
+                "std": True,
+            }
+        }
+
+        mock_aggregate = MagicMock()
+        with patch.dict("sys.modules", {"ray.data.aggregate": mock_aggregate}):
+            result = compute_numerical_statistics(
+                mock_dataset,
+                existing_numerical_stats={},
+                numerical_statistics_computation_specs=specs,
+            )
+
+        mock_dataset.select_columns.assert_called_once_with(["feature"])
+        self.assertTrue(mock_dataset.aggregate.called)
+        self.assertIsInstance(result, dict)
+
+    def test_skips_existing_stats(self):
+        """Skips existing stats."""
+        mock_dataset = MagicMock()
+        mock_dataset.select_columns.return_value = mock_dataset
+        mock_dataset.aggregate.return_value = {"feature_75": 7.5}
+        existing_stats = {"feature_50": 5.0}
+        specs = {
+            "feature": {
+                "percentiles": ["0.5", "0.75"],
+                "max": False,
+                "min": False,
+                "mean": False,
+                "std": False,
+            }
+        }
+
+        mock_aggregate = MagicMock()
+        with patch.dict("sys.modules", {"ray.data.aggregate": mock_aggregate}):
+            compute_numerical_statistics(
+                mock_dataset,
+                existing_numerical_stats=existing_stats,
+                numerical_statistics_computation_specs=specs,
+            )
+
+        self.assertTrue(mock_dataset.aggregate.called)
+
+    def test_all_existing_returns_empty_without_aggregate_call(self):
+        """All existing returns empty without aggregate call."""
+        mock_dataset = MagicMock()
+        existing_stats = {"feature_50": 5.0, "feature_max": 10.0, "feature_min": 0.0}
+        specs = {
+            "feature": {
+                "percentiles": ["0.5"],
+                "max": True,
+                "min": True,
+                "mean": False,
+                "std": False,
+            }
+        }
+
+        mock_aggregate = MagicMock()
+        with patch.dict("sys.modules", {"ray.data.aggregate": mock_aggregate}):
+            result = compute_numerical_statistics(
+                mock_dataset,
+                existing_numerical_stats=existing_stats,
+                numerical_statistics_computation_specs=specs,
+            )
+
+        self.assertEqual(result, {})
+        mock_dataset.aggregate.assert_not_called()
+
+    def test_empty_specs_skips_projection(self):
+        """Empty specs skips projection."""
+        mock_dataset = MagicMock()
+        mock_aggregate = MagicMock()
+        with patch.dict("sys.modules", {"ray.data.aggregate": mock_aggregate}):
+            result = compute_numerical_statistics(
+                mock_dataset,
+                existing_numerical_stats={},
+                numerical_statistics_computation_specs={},
+            )
+
+        mock_dataset.select_columns.assert_not_called()
+        self.assertEqual(result, {})
+
+    def test_batches_aggregate_calls(self):
+        """Batches aggregate calls."""
+        mock_dataset = MagicMock()
+        mock_dataset.select_columns.return_value = mock_dataset
+        mock_dataset.aggregate.return_value = {}
+        specs = {
+            "col1": {
+                "percentiles": [],
+                "max": True,
+                "min": False,
+                "mean": False,
+                "std": False,
+            }
+        }
+
+        mock_aggregate = MagicMock()
+        with patch.dict("sys.modules", {"ray.data.aggregate": mock_aggregate}):
+            compute_numerical_statistics(
+                mock_dataset,
+                existing_numerical_stats={},
+                numerical_statistics_computation_specs=specs,
+                numerical_statistics_batch_fn_size=1,
+            )
+
+        self.assertEqual(mock_dataset.aggregate.call_count, 2)
+
+
+class GetTorchDtypeTests(unittest.TestCase):
+    """Tests for get torch dtype."""
+
+    def test_scalar(self):
+        """Scalar."""
+        self.assertEqual(get_torch_dtype(pa.float32()), torch.float32)
+
+    def test_list_type(self):
+        """List type."""
+        self.assertEqual(get_torch_dtype(pa.list_(pa.int32())), torch.int32)
+
+    def test_fixed_size_list_type(self):
+        """Fixed size list type."""
+        self.assertEqual(get_torch_dtype(pa.list_(pa.float64(), 3)), torch.float64)
+
+    def test_nested_list_type(self):
+        """Nested list type."""
+        self.assertEqual(
+            get_torch_dtype(pa.list_(pa.list_(pa.float64()))), torch.float64
+        )
+
+    def test_triple_nested_list_type(self):
+        """Triple nested list type."""
+        self.assertEqual(
+            get_torch_dtype(pa.list_(pa.list_(pa.list_(pa.int32())))), torch.int32
+        )
+
+    def test_unsupported_scalar_raises(self):
+        """Unsupported scalar raises."""
+        with self.assertRaises(ValueError):
+            get_torch_dtype(pa.string())
+
+    def test_unsupported_list_type_raises(self):
+        """Unsupported list type raises."""
+        with self.assertRaises(ValueError):
+            get_torch_dtype(pa.list_(pa.bool_()))
+
+
+class GetNumericalStatsNamesTests(unittest.TestCase):
+    """Tests for get numerical stats names."""
+
+    def test_empty_specs(self):
+        """Empty specs."""
+        self.assertEqual(get_numerical_stats_names({}), [])
+
+    def test_all_stats_enabled(self):
+        """All stats enabled."""
+        specs = {
+            "col1": {
+                "min": True,
+                "max": True,
+                "std": True,
+                "mean": True,
+                "percentiles": ["0.25", "0.5", "0.75"],
+            }
+        }
+        result = get_numerical_stats_names(specs)
+        expected = [
+            "col1_min",
+            "col1_max",
+            "col1_std",
+            "col1_mean",
+            "col1_25",
+            "col1_50",
+            "col1_75",
+        ]
+        self.assertEqual(sorted(result), sorted(expected))
+
+    def test_partial_stats(self):
+        """Partial stats."""
+        specs = {
+            "col1": {"min": True, "max": False, "percentiles": ["0.1"]},
+            "col2": {"std": True, "mean": True, "percentiles": []},
+        }
+        result = get_numerical_stats_names(specs)
+        expected = ["col1_min", "col1_10", "col2_std", "col2_mean"]
+        self.assertEqual(sorted(result), sorted(expected))
+
+    def test_no_stats_enabled(self):
+        """No stats enabled."""
+        specs = {
+            "col1": {
+                "min": False,
+                "max": False,
+                "std": False,
+                "mean": False,
+                "percentiles": [],
+            }
+        }
+        self.assertEqual(get_numerical_stats_names(specs), [])
+
+
+class CheckStatsExistTests(unittest.TestCase):
+    """Tests for check stats exist."""
+
+    def setUp(self):
+        """Create a mock TransformSpec shared across test cases."""
+        self.mock_spec = MagicMock()
+
+    @patch(f"{_MODULE}.get_numerical_stats_names")
+    def test_all_exist(self, mock_names):
+        """All exist."""
+        mock_names.return_value = ["col1_mean", "col2_std"]
+        self.mock_spec.get_numerical_statistics_computation_specs.return_value = {}
+
+        self.assertTrue(
+            check_stats_exist({"col1_mean": 0.5, "col2_std": 1.0}, self.mock_spec, 0)
+        )
+
+    @patch(f"{_MODULE}.get_numerical_stats_names")
+    def test_missing(self, mock_names):
+        """Missing."""
+        mock_names.return_value = ["col1_mean", "col2_std"]
+        self.mock_spec.get_numerical_statistics_computation_specs.return_value = {}
+
+        self.assertFalse(check_stats_exist({"col1_mean": 0.5}, self.mock_spec, 0))
+
+    @patch(f"{_MODULE}.get_numerical_stats_names")
+    def test_none_required(self, mock_names):
+        """None required."""
+        mock_names.return_value = []
+        self.mock_spec.get_numerical_statistics_computation_specs.return_value = {}
+
+        self.assertTrue(check_stats_exist({}, self.mock_spec, 0))
+
+
+class NumericalStatisticsPreparationTests(unittest.TestCase):
+    """Tests for numerical statistics preparation."""
+
+    def setUp(self):
+        """Create mock dataset/spec fixtures shared across test cases."""
+        self.mock_dataset = MagicMock()
+        self.mock_spec = MagicMock()
+        self.feature_stats = {}
+
+    @patch(f"{_MODULE}.compute_numerical_statistics")
+    def test_with_specs_hydrates_all_layer_kinds(self, mock_compute):
+        """With specs hydrates all layer kinds."""
+        specs = {"col1": {"mean": True}}
+        self.mock_spec.get_numerical_statistics_computation_specs.return_value = specs
+        mock_compute.return_value = {"col1_mean": 0.5}
+
+        numerical_statistics_preparation(
+            self.mock_dataset, self.feature_stats, self.mock_spec, 0
+        )
+
+        mock_compute.assert_called_once_with(
+            self.mock_dataset, self.feature_stats, specs
+        )
+        self.assertEqual(self.feature_stats, {"col1_mean": 0.5})
+        self.mock_spec.update_numerical_standard_transform_parameters.assert_called_once_with(
+            self.feature_stats, 0
+        )
+        self.mock_spec.update_standard_scaler_specs.assert_called_once_with(
+            self.feature_stats, 0
+        )
+        self.mock_spec.update_min_max_scaler_specs.assert_called_once_with(
+            self.feature_stats, 0
+        )
+        self.mock_spec.update_bucketization_specs.assert_called_once_with(
+            self.feature_stats, 0
+        )
+
+    def test_without_specs_skips_hydration(self):
+        """Without specs skips hydration."""
+        self.mock_spec.get_numerical_statistics_computation_specs.return_value = {}
+
+        numerical_statistics_preparation(
+            self.mock_dataset, self.feature_stats, self.mock_spec, 0
+        )
+
+        self.mock_spec.update_numerical_standard_transform_parameters.assert_not_called()
+        self.mock_spec.update_standard_scaler_specs.assert_not_called()
+        self.mock_spec.update_min_max_scaler_specs.assert_not_called()
+        self.mock_spec.update_bucketization_specs.assert_not_called()
+
+
+class GetTransformTorchInferenceTests(unittest.TestCase):
+    """Tests for get transform torch inference."""
+
+    def setUp(self):
+        """Create a mock TransformSpec with a fixed max transform level."""
+        self.mock_spec = MagicMock()
+        self.mock_spec.get_max_transform_level.return_value = 2
+        self.mock_spec.columns_to_keep = ["keep_col"]
+
+    @patch(f"{_MODULE}.TorchBatchPredictor")
+    @patch(f"{_MODULE}.get_transform_module")
+    def test_with_layers(self, mock_get_module, mock_predictor):
+        """With layers."""
+        mock_module = MagicMock(input_cols=["input1"], output_cols=["output1"])
+        mock_get_module.return_value = mock_module
+        self.mock_spec.get_transform_input_cols.side_effect = [["input2"], ["input3"]]
+
+        result = get_transform_torch_inference(self.mock_spec, [0], 1)
+
+        mock_predictor.assert_called_once()
+        call_kwargs = mock_predictor.call_args.kwargs
+        self.assertEqual(call_kwargs["model"], mock_module)
+        self.assertIsNotNone(result)
+
+    @patch(f"{_MODULE}.get_transform_module")
+    def test_no_layers_returns_none(self, mock_get_module):
+        """No layers returns none."""
+        mock_get_module.return_value = None
+
+        self.assertIsNone(get_transform_torch_inference(self.mock_spec, [], 0))
+
+    @patch(f"{_MODULE}.TorchBatchPredictor")
+    @patch(f"{_MODULE}.get_transform_module")
+    def test_empty_finished_levels_starts_at_zero(
+        self, mock_get_module, mock_predictor
+    ):
+        """Empty finished levels starts at zero."""
+        mock_module = MagicMock(input_cols=["input1"], output_cols=["output1"])
+        mock_get_module.return_value = mock_module
+        self.mock_spec.get_transform_input_cols.side_effect = [["input2"], ["input3"]]
+
+        get_transform_torch_inference(self.mock_spec, [], 0)
+
+        mock_get_module.assert_called_once_with(self.mock_spec, 0, 0)
+
+    @patch(f"{_MODULE}.TorchBatchPredictor")
+    @patch(f"{_MODULE}.get_transform_module")
+    def test_columns_to_keep_none_keeps_all(self, mock_get_module, mock_predictor):
+        """Columns to keep none keeps all."""
+        self.mock_spec.columns_to_keep = None
+        mock_module = MagicMock(input_cols=["input1"], output_cols=["output1"])
+        mock_get_module.return_value = mock_module
+
+        get_transform_torch_inference(self.mock_spec, [], 0)
+
+        self.assertIsNone(mock_predictor.call_args.kwargs["columns_to_keep"])
+
+    @patch(f"{_MODULE}.TorchBatchPredictor")
+    @patch(f"{_MODULE}.get_transform_module")
+    def test_columns_to_keep_includes_future_inputs(
+        self, mock_get_module, mock_predictor
+    ):
+        """Columns to keep includes future inputs."""
+        self.mock_spec.columns_to_keep = ["user_col1", "user_col2"]
+        mock_module = MagicMock(input_cols=["input1"], output_cols=["output1"])
+        mock_get_module.return_value = mock_module
+        self.mock_spec.get_transform_input_cols.side_effect = [
+            ["future_input1"],
+            ["future_input2"],
+        ]
+
+        get_transform_torch_inference(self.mock_spec, [], 0)
+
+        self.assertEqual(
+            mock_predictor.call_args.kwargs["columns_to_keep"],
+            {"user_col1", "user_col2", "future_input1", "future_input2"},
+        )
+
+
+class TransformOrchestrationTests(unittest.TestCase):
+    """Tests for transform orchestration."""
+
+    def setUp(self):
+        """Create a mock Ray dataset and TransformSpec for the transform() suite."""
+        self.mock_dataset = MagicMock()
+        self.mock_schema = MagicMock()
+        self.mock_schema.names = ["col1", "col2", "col3"]
+        self.mock_schema.types = [pa.float32(), pa.float64(), pa.int64()]
+        self.mock_dataset.schema.return_value = self.mock_schema
+        self.mock_dataset.map_batches.return_value = self.mock_dataset
+        self.mock_dataset.materialize.return_value = self.mock_dataset
+
+        self.mock_spec = MagicMock()
+        self.mock_spec.get_max_transform_level.return_value = 2
+        self.mock_spec.transform_specs = {
+            "layer1": MagicMock(output_cols=["out1"], output_dtype=torch.float32),
+            "layer2": MagicMock(output_cols=["out2"], output_dtype=torch.int32),
+        }
+        self.mock_spec.columns_to_keep = ["col1", "out1"]
+
+        self.feature_stats = {"col1_mean": 0.5}
+
+    @patch(f"{_MODULE}.get_transform_torch_inference")
+    @patch(f"{_MODULE}.numerical_statistics_preparation")
+    @patch(f"{_MODULE}.check_stats_exist")
+    def test_transform_with_inference(
+        self, mock_check_stats, mock_numerical_prep, mock_get_inference
+    ):
+        """Transform with inference."""
+        mock_check_stats.return_value = False
+        mock_torch_inference = MagicMock()
+        mock_get_inference.return_value = mock_torch_inference
+
+        result_df, result_spec, result_stats = transform(
+            self.mock_dataset, self.mock_spec, self.feature_stats
+        )
+
+        self.assertEqual(result_df, self.mock_dataset)
+        self.assertEqual(result_spec, self.mock_spec)
+        self.assertEqual(result_stats, self.feature_stats)
+        self.assertEqual(mock_check_stats.call_count, 3)
+        self.assertEqual(mock_get_inference.call_count, 4)
+        self.assertEqual(self.mock_dataset.map_batches.call_count, 4)
+
+    @patch(f"{_MODULE}.get_transform_torch_inference")
+    @patch(f"{_MODULE}.numerical_statistics_preparation")
+    @patch(f"{_MODULE}.check_stats_exist")
+    def test_transform_without_inference(
+        self, mock_check_stats, mock_numerical_prep, mock_get_inference
+    ):
+        """Transform without inference."""
+        mock_check_stats.return_value = True
+        mock_get_inference.return_value = None
+
+        result_df, _, _ = transform(
+            self.mock_dataset, self.mock_spec, self.feature_stats
+        )
+
+        self.assertEqual(result_df, self.mock_dataset)
+        self.assertEqual(self.mock_dataset.map_batches.call_count, 0)
+
+    @patch("torch.cuda.is_available")
+    @patch(f"{_MODULE}.get_transform_torch_inference")
+    @patch(f"{_MODULE}.numerical_statistics_preparation")
+    @patch(f"{_MODULE}.check_stats_exist")
+    def test_transform_with_gpu(
+        self, mock_check_stats, mock_numerical_prep, mock_get_inference, mock_cuda
+    ):
+        """Transform with gpu."""
+        mock_check_stats.return_value = False
+        mock_torch_inference = MagicMock()
+        mock_get_inference.return_value = mock_torch_inference
+        mock_cuda.return_value = True
+        self.mock_spec.get_max_transform_level.return_value = 0
+
+        transform(self.mock_dataset, self.mock_spec, self.feature_stats, num_gpus=2)
+
+        expected_calls = [
+            call(
+                mock_torch_inference,
+                batch_size=20000,
+                num_gpus=2,
+                zero_copy_batch=True,
+                batch_format="pyarrow",
+                concurrency=100,
+                num_cpus=1,
+            ),
+            call(
+                mock_torch_inference,
+                batch_size=20000,
+                num_gpus=2,
+                zero_copy_batch=True,
+                batch_format="pyarrow",
+                concurrency=100,
+                num_cpus=1,
+            ),
+        ]
+        self.mock_dataset.map_batches.assert_has_calls(expected_calls)
+
+    @patch(f"{_MODULE}.get_transform_torch_inference")
+    @patch(f"{_MODULE}.numerical_statistics_preparation")
+    @patch(f"{_MODULE}.check_stats_exist")
+    def test_skips_non_numeric_columns(
+        self, mock_check_stats, mock_numerical_prep, mock_get_inference
+    ):
+        """Skips non numeric columns."""
+        self.mock_schema.names = ["numeric_col", "string_col", "another_numeric"]
+        self.mock_schema.types = [pa.float32(), pa.string(), pa.int64()]
+        mock_check_stats.return_value = True
+        mock_get_inference.return_value = None
+
+        with self.assertLogs(_MODULE, level="INFO") as logs:
+            transform(self.mock_dataset, self.mock_spec, self.feature_stats)
+
+        self.assertTrue(
+            any("Skipping 1 non-numeric columns" in line for line in logs.output)
+        )
+
+    @patch(f"{_MODULE}.get_transform_torch_inference")
+    @patch(f"{_MODULE}.numerical_statistics_preparation")
+    @patch(f"{_MODULE}.check_stats_exist")
+    def test_handles_multidim_numeric_columns(
+        self, mock_check_stats, _mock_numerical_prep, mock_get_inference
+    ):
+        """Handles multidim numeric columns."""
+        self.mock_schema.names = ["numeric_col", "embedding_col"]
+        nested_list_type = pa.list_(pa.list_(pa.float64()))
+        self.mock_schema.types = [pa.float32(), nested_list_type]
+        mock_check_stats.return_value = True
+        mock_get_inference.return_value = None
+
+        mock_layer = MagicMock(
+            input_cols=["embedding_col"],
+            output_cols=["output"],
+            output_dtype=torch.float32,
+        )
+        self.mock_spec.transform_specs = {"identity_layer": mock_layer}
+
+        transform(self.mock_dataset, self.mock_spec, self.feature_stats)
+
+        update_calls = self.mock_spec.update_input_dtype.call_args_list
+        self.assertEqual(len(update_calls), 3)
+        found = any(
+            "embedding_col" in call_args.args[0]
+            and call_args.args[0]["embedding_col"] == torch.float64
+            for call_args in update_calls
+        )
+        self.assertTrue(
+            found,
+            "embedding_col should resolve to torch.float64 via nested list unwrapping",
+        )
+
+
+class DefaultDataProcessorTests(unittest.TestCase):
+    """Tests for default data processor."""
+
+    def test_prepare_inputs_numeric_arrays(self):
+        """Prepare inputs numeric arrays."""
+        processor = DefaultDataProcessor(input_columns=["x"])
+        batch = {"x": np.array([[1, 2], [3, 4]], dtype=np.int32)}
+
+        prepared = processor.prepare_inputs(batch)
+
+        self.assertIsInstance(prepared["x"], torch.Tensor)
+        self.assertEqual(prepared["x"].dtype, torch.int32)
+        np.testing.assert_array_equal(prepared["x"].numpy(), [[1, 2], [3, 4]])
+
+    def test_prepare_inputs_all_columns_when_none(self):
+        """Prepare inputs all columns when none."""
+        processor = DefaultDataProcessor(input_columns=None)
+        batch = {
+            "x": np.array([1.0, 2.0], dtype=np.float32),
+            "y": np.array([3.0, 4.0], dtype=np.float32),
+        }
+
+        prepared = processor.prepare_inputs(batch)
+
+        self.assertEqual(set(prepared.keys()), {"x", "y"})
+
+    def test_prepare_inputs_string_arrays_rejected(self):
+        """Prepare inputs string arrays rejected."""
+        processor = DefaultDataProcessor(input_columns=["x"])
+        batch = {"x": np.array(["a", "b"])}
+
+        with self.assertRaises(ValueError):
+            processor.prepare_inputs(batch)
+
+    def test_prepare_inputs_bool_arrays_rejected(self):
+        """Prepare inputs bool arrays rejected."""
+        processor = DefaultDataProcessor(input_columns=["x"])
+        batch = {"x": np.array([True, False])}
+
+        with self.assertRaises(ValueError):
+            processor.prepare_inputs(batch)
+
+    def test_prepare_inputs_object_arrays_stackable(self):
+        """Prepare inputs object arrays stackable."""
+        processor = DefaultDataProcessor(input_columns=["x"])
+        arr = np.empty(2, dtype=object)
+        arr[0] = np.array([1.0, 2.0], dtype=np.float32)
+        arr[1] = np.array([3.0, 4.0], dtype=np.float32)
+
+        prepared = processor.prepare_inputs({"x": arr})
+
+        self.assertEqual(tuple(prepared["x"].shape), (2, 2))
+
+    def test_prepare_inputs_ragged_arrays_padded_with_sentinel(self):
+        """Prepare inputs ragged arrays padded with sentinel."""
+        processor = DefaultDataProcessor(input_columns=["x"])
+        arr = np.empty(2, dtype=object)
+        arr[0] = np.array([1, 2], dtype=np.int32)
+        arr[1] = np.array([3, 4, 5], dtype=np.int32)
+
+        prepared = processor.prepare_inputs({"x": arr})
+
+        sentinel = sentinel_for_numpy_dtype(np.dtype(np.int32))
+        self.assertEqual(tuple(prepared["x"].shape), (2, 3))
+        np.testing.assert_array_equal(prepared["x"].numpy()[0], [1, 2, sentinel])
+
+    def test_prepare_inputs_object_arrays_non_numeric_rejected(self):
+        """Prepare inputs object arrays non numeric rejected."""
+        processor = DefaultDataProcessor(input_columns=["x"])
+        arr = np.empty(1, dtype=object)
+        arr[0] = {"not": "an array"}
+
+        with self.assertRaises(ValueError):
+            processor.prepare_inputs({"x": arr})
+
+    def test_prepare_inputs_nested_object_arrays_requiring_recursive_conversion(self):
+        """Prepare inputs nested object arrays requiring recursive conversion."""
+        processor = DefaultDataProcessor(input_columns=["x"])
+        inner = np.empty(1, dtype=object)
+        inner[0] = np.array([1.0, 2.0], dtype=np.float64)
+        arr = np.empty(1, dtype=object)
+        arr[0] = inner
+
+        prepared = processor.prepare_inputs({"x": arr})
+
+        self.assertIsInstance(prepared["x"], torch.Tensor)
+
+    def test_prepare_inputs_large_integers_preserve_precision(self):
+        """Prepare inputs large integers preserve precision."""
+        processor = DefaultDataProcessor(input_columns=["x"])
+        large_val = 2**53 + 1
+        batch = {"x": np.array([large_val], dtype=np.int64)}
+
+        prepared = processor.prepare_inputs(batch)
+
+        self.assertEqual(prepared["x"].dtype, torch.int64)
+        self.assertEqual(prepared["x"].item(), large_val)
+
+    def test_postprocess_outputs_tensor_outputs(self):
+        """Postprocess outputs tensor outputs."""
+        processor = DefaultDataProcessor(output_columns=["y"])
+        outputs = {"y": torch.tensor([1.0, 2.0])}
+
+        result = processor.postprocess_outputs(outputs)
+
+        np.testing.assert_array_equal(result["y"], [1.0, 2.0])
+
+    def test_postprocess_outputs_all_when_none(self):
+        """Postprocess outputs all when none."""
+        processor = DefaultDataProcessor(output_columns=None)
+        outputs = {"a": torch.tensor([1.0]), "b": torch.tensor([2.0])}
+
+        result = processor.postprocess_outputs(outputs)
+
+        self.assertEqual(set(result.keys()), {"a", "b"})
+
+    def test_postprocess_outputs_list_outputs(self):
+        """Postprocess outputs list outputs."""
+        processor = DefaultDataProcessor(output_columns=["y"])
+        result = processor.postprocess_outputs({"y": [1.0, 2.0, 3.0]})
+
+        np.testing.assert_array_equal(result["y"], [1.0, 2.0, 3.0])
+
+    def test_postprocess_outputs_missing_column_raises(self):
+        """Postprocess outputs missing column raises."""
+        processor = DefaultDataProcessor(output_columns=["y"])
+
+        with self.assertRaises(ValueError):
+            processor.postprocess_outputs({})
+
+
+class PadRaggedArraysTests(unittest.TestCase):
+    """Tests for pad ragged arrays."""
+
+    def test_basic_int32(self):
+        """Basic int32."""
+        sentinel = sentinel_for_numpy_dtype(np.dtype(np.int32))
+        arrays = np.array(
+            [
+                np.array([10, 20], dtype=np.int32),
+                np.array([30, 40, 50], dtype=np.int32),
+            ],
+            dtype=object,
+        )
+        result = _pad_ragged_arrays(arrays)
+
+        self.assertEqual(result.shape, (2, 3))
+        self.assertEqual(result.dtype, np.int32)
+        np.testing.assert_array_equal(result[0], [10, 20, sentinel])
+
+    def test_basic_float64_nan_sentinel(self):
+        """Basic float64 nan sentinel."""
+        arrays = np.array(
+            [np.array([1.5], dtype=np.float64), np.array([2.5, 3.5], dtype=np.float64)],
+            dtype=object,
+        )
+        result = _pad_ragged_arrays(arrays)
+
+        self.assertTrue(np.isnan(result[0, 1]))
+
+    def test_custom_pad_value(self):
+        """Custom pad value."""
+        arrays = np.array(
+            [np.array([1, 2], dtype=np.int32), np.array([3, 4, 5], dtype=np.int32)],
+            dtype=object,
+        )
+        result = _pad_ragged_arrays(arrays, ragged_fill_value=0)
+
+        np.testing.assert_array_equal(result[0], [1, 2, 0])
+
+    def test_rejects_non_ndarray_elements(self):
+        """Rejects non ndarray elements."""
+        arrays = np.array([{"key": "value"}, [1, 2, 3]], dtype=object)
+
+        with self.assertRaises(ValueError):
+            _pad_ragged_arrays(arrays)
+
+    def test_rejects_string_dtype(self):
+        """Rejects string dtype."""
+        arrays = np.empty(1, dtype=object)
+        arrays[0] = np.array(["hello", "world"], dtype="U10")
+
+        with self.assertRaises(ValueError):
+            _pad_ragged_arrays(arrays)
+
+    def test_rejects_empty_input(self):
+        """Rejects empty input."""
+        with self.assertRaises(ValueError):
+            _pad_ragged_arrays(np.array([], dtype=object))
+
+    def test_all_sub_arrays_empty_raises(self):
+        """All sub arrays empty raises."""
+        arrays = np.empty(2, dtype=object)
+        arrays[0] = np.empty(0, dtype=object)
+        arrays[1] = np.empty(0, dtype=object)
+
+        with self.assertRaises(ValueError):
+            _pad_ragged_arrays(arrays)
+
+
+class TorchBatchPredictorTests(unittest.TestCase):
+    """Tests for torch batch predictor."""
+
+    def test_init_requires_model(self):
+        """Init requires model."""
+        with self.assertRaises(ValueError):
+            TorchBatchPredictor(model=None)
+
+    def test_data_processor_lazy_loading(self):
+        """Data processor lazy loading."""
+        model = DummyModel()
+        predictor = TorchBatchPredictor(model=model)
+        self.assertIsNone(predictor._data_processor)
+        processor = predictor.data_processor
+        self.assertIs(predictor.data_processor, processor)
+
+    def test_call_assembles_native_arrow_output_table(self):
+        """Call assembles native arrow output table."""
+        model_outputs = {
+            "predictions": torch.tensor([[0.1], [0.9]], dtype=torch.float32)
+        }
+        model = DummyModel(outputs=model_outputs)
+        predictor = TorchBatchPredictor(
+            model=model, input_columns=["x"], output_columns=["predictions"]
+        )
+        input_table = pa.table(
+            {"x": pa.array([[5.0], [6.0]], type=pa.list_(pa.float32()))}
+        )
+
+        result = predictor(input_table)
+
+        self.assertIn("predictions", result.column_names)
+        self.assertIn("x", result.column_names)
+
+    def test_call_passthrough_columns_not_materialized_to_numpy(self):
+        """Call passthrough columns not materialized to numpy."""
+        model_outputs = {
+            "predictions": torch.tensor([[0.1], [0.9]], dtype=torch.float32)
+        }
+        model = DummyModel(outputs=model_outputs)
+        predictor = TorchBatchPredictor(
+            model=model, input_columns=["x"], output_columns=["predictions"]
+        )
+        input_table = pa.table(
+            {
+                "x": pa.array([[5.0], [6.0]], type=pa.list_(pa.float32())),
+                "label": pa.array(["alpha", "beta"], type=pa.large_string()),
+            }
+        )
+
+        result = predictor(input_table)
+
+        self.assertEqual(result.schema.field("label").type, pa.large_string())
+        self.assertEqual(set(model.last_inputs.keys()), {"x"})
+
+    def test_call_only_input_columns_reach_model(self):
+        """Call only input columns reach model."""
+        model_outputs = {
+            "predictions": torch.tensor([[0.1], [0.9]], dtype=torch.float32)
+        }
+        model = DummyModel(outputs=model_outputs)
+        predictor = TorchBatchPredictor(
+            model=model, input_columns=["x"], output_columns=["predictions"]
+        )
+        input_table = pa.table(
+            {
+                "x": pa.array([[5.0], [6.0]], type=pa.list_(pa.float32())),
+                "y": pa.array([[1.0], [2.0]], type=pa.list_(pa.float32())),
+            }
+        )
+
+        result = predictor(input_table)
+
+        self.assertEqual(set(model.last_inputs.keys()), {"x"})
+        self.assertEqual(result.column("y").to_pylist(), [[1.0], [2.0]])
+
+    def test_call_exception_handling(self):
+        """Call exception handling."""
+        model = DummyModel(raise_error=True)
+        predictor = TorchBatchPredictor(model=model, input_columns=["x"])
+        input_table = pa.table({"x": pa.array([[1.0]], type=pa.list_(pa.float32()))})
+
+        with self.assertRaises(ValueError):
+            predictor(input_table)
+
+    def test_inference_mode_context(self):
+        """Inference mode context."""
+        captured = {}
+
+        def model(inputs):
+            captured["grad_enabled"] = torch.is_grad_enabled()
+            return {"y": torch.zeros(len(next(iter(inputs.values()))))}
+
+        predictor = TorchBatchPredictor(
+            model=model, input_columns=["x"], output_columns=["y"]
+        )
+        input_table = pa.table({"x": pa.array([1.0, 2.0], type=pa.float32())})
+
+        predictor(input_table)
+
+        self.assertFalse(captured["grad_enabled"])
+
+    def test_model_kwargs_passed_to_model(self):
+        """Model kwargs passed to model."""
+        captured = {}
+
+        def model(inputs, scale=1.0):
+            captured["scale"] = scale
+            return {"y": torch.zeros(len(next(iter(inputs.values()))))}
+
+        predictor = TorchBatchPredictor(
+            model=model,
+            input_columns=["x"],
+            output_columns=["y"],
+            model_kwargs={"scale": 2.0},
+        )
+        input_table = pa.table({"x": pa.array([1.0], type=pa.float32())})
+
+        predictor(input_table)
+
+        self.assertEqual(captured["scale"], 2.0)
+
+    def test_model_called_without_kwargs_when_not_provided(self):
+        """Model called without kwargs when not provided."""
+        calls = []
+
+        def model(inputs):
+            calls.append(inputs)
+            return {"y": torch.zeros(len(next(iter(inputs.values()))))}
+
+        predictor = TorchBatchPredictor(
+            model=model, input_columns=["x"], output_columns=["y"]
+        )
+        input_table = pa.table({"x": pa.array([1.0], type=pa.float32())})
+
+        predictor(input_table)
+
+        self.assertEqual(len(calls), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Context

Next PR in the `native_transform` migration after B1–B8 (torch compute core:
`TransformSpec`, `TorchTransformModule`, `TORCH_TRANSFORM_LAYERS_DICT`, all
merged). This PR ports the Ray execution adapter — the piece that runs a
`TransformSpec` DAG over a `ray.data.Dataset` in production (statistics
hydration, level-by-level materialization, batched torch inference).

## What changed

Consolidated 4 internal source files into a single
`uniflow/plugins/ray/native_transform.py`, matching the flat `io.py`/`task.py`
convention already used by sibling plugins in that package:

- **Dataset I/O** (`read_dataset`, `write_dataset`, `filter_columns`)
- **Statistics hydration** (`compute_numerical_statistics`,
  `numerical_statistics_preparation`, `check_stats_exist`,
  `get_numerical_stats_names`)
- **DAG orchestration** (`transform`, `get_transform_torch_inference`,
  `get_torch_dtype`)
- **Torch batch inference** (`DataProcessor`, `DefaultDataProcessor`,
  `TorchBatchPredictor`, `_pad_ragged_arrays`)

### Deviations from internal (intentional, per IMPL-001)

- **Filesystem seam, no custom registration.** Internal registers a
  proprietary filesystem implementation into `fsspec` at import time and lets
  `read_dataset`/`write_dataset` take a `use_fsspec` bool to opt in or out of
  it. That registration doesn't belong in the OSS package (internal consumers
  can still do it in their own entrypoint), so this PR removes it entirely
  and routes both functions through the filesystem-resolution helper already
  used by the sibling `RayDatasetIO` in `uniflow/plugins/ray/io.py`
  (env-driven fsspec-vs-native-PyArrow selection). This drops the
  `use_fsspec` parameter — the seam itself decides.
- **Logging.** Internal's custom logger wrapper is replaced with stdlib
  `logging`, matching every other OSS plugin module.
- **Numpy/pyarrow helpers.** `pyarrow_to_numpy`, `assemble_output_table`,
  `pad_ragged_tensor`, `infer_dtype` now come from the already-migrated
  `lib/_internal/utils/numpy_utils` package (from PR A) instead of being
  reimplemented. `_pad_ragged_arrays` keeps its own validation (empty/
  non-ndarray/non-numeric checks matching internal's contract) but delegates
  the actual padding to the shared `pad_ragged_tensor`, which already handles
  sentinel selection internally — so the local sentinel-computation logic
  internal had is no longer needed.
- **Dropped two unused block-size tuning constants** that internal ships
  alongside this module but never references anywhere in its own source —
  confirmed via search across the internal module. Not ported (CODE-004: no
  dead code).

### Behavioral equivalence (self-review as CanvasFlex Architect)

Verified line-by-line against internal's 4 source files:
- `transform()`'s per-level loop (dtype resolution, stats-hydration
  short-circuit via `check_stats_exist`, `map_batches` kwargs including the
  CPU/GPU dispatch and `num_cpus=1` GIL-bound-inference note) is unchanged.
- `TorchBatchPredictor.__call__`'s zero-copy passthrough contract (only
  `input_columns` reach the model; everything else stays native Arrow) and
  its default overwrite-on-collision behavior for output columns is
  unchanged.
- `DefaultDataProcessor.prepare_inputs`'s numeric-only validation, object-dtype
  stacking, and ragged-array padding fallback chain (`np.stack` ->
  `_pad_ragged_arrays` -> recursive `tolist()` conversion) is unchanged.
- `get_transform_torch_inference`'s `columns_to_keep` union with
  future-level input columns is unchanged.

## Tests

- 68 unit tests (`native_transform_test.py`), fully mocked for Ray-dependent
  paths, real torch/numpy/pyarrow execution for `DefaultDataProcessor`,
  `_pad_ragged_arrays`, and `TorchBatchPredictor` — one test per function and
  per internal branch (non-numeric skip, GPU dispatch, columns_to_keep
  variants, ragged-array edge cases, etc).
- 2 real (non-mocked) Ray integration tests
  (`native_transform_integration_test.py`) running `transform()` end-to-end
  against a local single-process Ray cluster. Following the precedent set by
  trainer PR 4's Ray V2 auto-resume integration tests, these are **skipped in
  CI by default** (a real Ray cluster can be memory-heavy on constrained
  runners) — set `MICHELANGELO_RUN_RAY_INTEGRATION_TESTS=1` to force them on;
  they run by default locally.
- Full regression: `pytest michelangelo/uniflow/plugins/ray/` (103 passed)
  and `pytest michelangelo/lib/native_transform/` (393 passed) — no
  regressions.
- Coverage tooling hit the same torch/numpy C-extension incompatibility
  under `coverage run` noted in PR #1772 (B7) — used the same fallback:
  manual traceability review confirming a dedicated test per function and
  per branch (see the by-function list above under Tests) instead of a
  coverage percentage.
- `ruff format --check` and `ruff check`: clean on all 3 touched files.

## Scope notes

- Depends on PR A (`#1543`, pyarrow helpers) and PR B6 (`#1730`, `TransformSpec`
  + `TorchTransformModule` + `get_transform_module`), both merged.
- No changes to `RayDatasetIO`, `SparkIO`, `RayTask`, `SparkTask`, or the
  `io_registry` — additive only.
