### PR TITLE
feat(native_transform): add TransformSpecIO + usage guide (PR E)

### DIFF
--- a/docs/user-guides/index.md
+++ b/docs/user-guides/index.md
@@ -34,6 +34,7 @@ New to Michelangelo AI? Follow this path:
 | [Train and Register a Model](./train-and-deploy-models/train-and-register-a-model.md) | Train at scale and register artifacts |
 | [Model Registry Guide](./train-and-deploy-models/model-registry-guide.md) | Version, track, and manage trained models |
 | [Deploy a Model](./train-and-deploy-models/deploy-a-model.md) | Bind a registered model to an inference server |
+| [Native Feature Transforms](./train-and-deploy-models/native-feature-transforms.md) | Fit and materialize transform layers that run identically at train and serve time |
 
 ### Reference
 

--- a/docs/user-guides/train-and-deploy-models/native-feature-transforms.md
+++ b/docs/user-guides/train-and-deploy-models/native-feature-transforms.md
@@ -78,8 +78,8 @@ spec.update_min_max_scaler_specs(fitted_stats)
 
 Once fitted, a `TransformSpec` is a plain value you'll want to pass between
 pipeline stages (e.g. from a "fit transforms" task to a "train" task) or
-persist alongside a model artifact. `TransformSpecIO` registers `TransformSpec`
-with Uniflow's [`default_io`](../reference/type-system.md) registry, so it
+persist alongside a model artifact. `TransformSpecIO` adapts `TransformSpec`
+to Uniflow's [`default_io`](../reference/type-system.md) registry, so it
 round-trips through `write`/`read` the same way a `DataFrame` or `Dataset`
 does:
 
@@ -93,10 +93,16 @@ io.write("s3://bucket/run-id/transform_spec.json", spec)
 restored_spec = io.read("s3://bucket/run-id/transform_spec.json", None)
 ```
 
-Because `TransformSpec` is registered in `default_io`, any Uniflow task that
-declares a `TransformSpec`-typed input or output gets this serialization for
-free without calling `TransformSpecIO` directly — see
-[Type System](../reference/type-system.md) for how task I/O typing works.
+To have any Uniflow task that declares a `TransformSpec`-typed input or
+output get this serialization for free, without calling `TransformSpecIO`
+directly, import the plugin package to register it in `default_io`:
+
+```python
+import michelangelo.uniflow.plugins.native_transform  # noqa: F401  (registers TransformSpec with default_io)
+```
+
+See [Type System](../reference/type-system.md) for how task I/O typing
+works.
 
 ### Materialize and run
 
@@ -144,5 +150,6 @@ of `update_standard_scaler_specs`/`update_min_max_scaler_specs`.
 To support persisting a *new* transform-related type as a workflow value the
 way `TransformSpecIO` does for `TransformSpec`, implement the
 `IO[T]` protocol (`write`/`read`) and register it with
-`default_io[YourType] = YourTypeIO`, matching the pattern in
-`michelangelo/lib/native_transform/torch/io.py`.
+`default_io[YourType] = YourTypeIO` in a `michelangelo.uniflow.plugins.*`
+package, matching the pattern in
+`michelangelo/uniflow/plugins/native_transform/io.py`.

--- a/docs/user-guides/train-and-deploy-models/native-feature-transforms.md
+++ b/docs/user-guides/train-and-deploy-models/native-feature-transforms.md
@@ -1,0 +1,148 @@
+---
+sidebar_position: 4
+---
+
+# Native Feature Transforms
+
+This guide covers `michelangelo.lib.native_transform` — a library of PyTorch
+feature-transform layers that run identically at training time and at
+serving time, so the exact same code that scaled, bucketized, or tokenized a
+column during training also runs inside the served model.
+
+## What it does
+
+A native transform is described declaratively as a **`TransformSpec`**: a DAG
+of layer specs (`Concatenate`, `Cast`, `Bucketization`, `StandardScaler`, and
+others) parsed from a plain dict or YAML file. Some specs are **fitted
+placeholders** — for example `StandardScaler` needs a column's mean and
+standard deviation before it can run — and are resolved into a concrete,
+executable spec once those statistics are computed from the training data.
+
+The typical lifecycle is:
+
+1. **Fit** — ask the spec what statistics its placeholders need
+   (`get_numerical_statistics_computation_specs`), compute them over the
+   training dataset, and hydrate the placeholders (`update_*` methods).
+2. **Materialize** — turn the fitted spec into a single executable
+   `torch.nn.Module` (`get_transform_module`).
+3. **Export** — the module is `torch.jit.script`-compatible, so it can be
+   embedded directly in a served model artifact.
+
+## How to use it
+
+### Define a spec
+
+```python
+from michelangelo.lib.native_transform.torch import TransformSpec
+
+raw_spec = {
+    "transform_specs": [
+        {
+            "transform_name": "StandardScaler",
+            "input_cols": ["age"],
+            "output_cols": ["age_scaled"],
+        },
+        {
+            "transform_name": "MinMaxScaler",
+            "input_cols": ["price"],
+            "output_cols": ["price_scaled"],
+        },
+    ]
+}
+spec = TransformSpec(raw_transform_specs=raw_spec)
+```
+
+`raw_transform_specs` can also be loaded from a YAML file via
+`TransformSpec(transform_spec_yaml_path="spec.yaml")`.
+
+### Fit statistics and hydrate placeholders
+
+```python
+# Ask the spec what statistics its placeholders need.
+stats_needed = spec.get_numerical_statistics_computation_specs()
+# {"age": {..., "mean": True, ...}, "price": {..., "min": True, "max": True, ...}}
+
+# Compute these over your training dataset (Ray, Spark, pandas — whatever
+# fits your pipeline), then hydrate the placeholders in place.
+fitted_stats = {
+    "age_mean": 35.2,
+    "age_std": 12.1,
+    "price_min": 0.0,
+    "price_max": 500.0,
+}
+spec.update_standard_scaler_specs(fitted_stats)
+spec.update_min_max_scaler_specs(fitted_stats)
+```
+
+### Persist the fitted spec as a workflow value
+
+Once fitted, a `TransformSpec` is a plain value you'll want to pass between
+pipeline stages (e.g. from a "fit transforms" task to a "train" task) or
+persist alongside a model artifact. `TransformSpecIO` registers `TransformSpec`
+with Uniflow's [`default_io`](../reference/type-system.md) registry, so it
+round-trips through `write`/`read` the same way a `DataFrame` or `Dataset`
+does:
+
+```python
+from michelangelo.lib.native_transform.torch.io import TransformSpecIO
+
+io = TransformSpecIO()
+io.write("s3://bucket/run-id/transform_spec.json", spec)
+
+# ... later, in a different task or process:
+restored_spec = io.read("s3://bucket/run-id/transform_spec.json", None)
+```
+
+Because `TransformSpec` is registered in `default_io`, any Uniflow task that
+declares a `TransformSpec`-typed input or output gets this serialization for
+free without calling `TransformSpecIO` directly — see
+[Type System](../reference/type-system.md) for how task I/O typing works.
+
+### Materialize and run
+
+```python
+import torch
+from michelangelo.lib.native_transform.torch import get_transform_module
+
+module = get_transform_module(restored_spec, start_level=0)
+
+outputs = module({
+    "age": torch.tensor([20.0, 35.0, 50.0]),
+    "price": torch.tensor([100.0, 250.0, 500.0]),
+})
+# {"age_scaled": tensor([...]), "price_scaled": tensor([...])}
+
+# TorchScript-export for serving.
+scripted_module = torch.jit.script(module)
+```
+
+`start_level`/`end_level` let you materialize a subset of the DAG's
+dependency levels — useful when some transforms run upstream (e.g. in a Ray
+preprocessing task) and others run inside the served model.
+
+## How to extend it
+
+Adding a new transform layer requires three pieces, all in
+`michelangelo.lib.native_transform.torch`:
+
+1. A pydantic **layer spec** in `transform_layer_spec.py`, subclassing
+   `TorchTransformLayerSpec`. This is the declarative, serializable
+   description of the layer's configuration.
+2. An executable **layer** in `base_layers.py` (or a new module), subclassing
+   `TorchTransformBaseLayer` — a `torch.nn.Module` whose constructor accepts
+   the same fields as the spec (`to_transform_layers` calls
+   `LayerClass(**layer_spec.model_dump())`).
+3. Registration of both in `transform_spec.py`'s `TORCH_TRANSFORM_LAYERS_DICT`
+   (spec class name → layer class) and `TORCH_TRANSFORM_LAYERS_SPECS_DICT`
+   (the raw spec dict's `transform_name` → spec class).
+
+If the new layer needs fitted statistics (like `StandardScaler` or
+`MinMaxScaler`), add a placeholder spec plus an `update_*` hydration method on
+`TransformSpec` that resolves it into a concrete spec, following the pattern
+of `update_standard_scaler_specs`/`update_min_max_scaler_specs`.
+
+To support persisting a *new* transform-related type as a workflow value the
+way `TransformSpecIO` does for `TransformSpec`, implement the
+`IO[T]` protocol (`write`/`read`) and register it with
+`default_io[YourType] = YourTypeIO`, matching the pattern in
+`michelangelo/lib/native_transform/torch/io.py`.

--- a/python/michelangelo/lib/native_transform/torch/__init__.py
+++ b/python/michelangelo/lib/native_transform/torch/__init__.py
@@ -54,12 +54,6 @@ from michelangelo.lib.native_transform.torch.transform_utils import (
     update_output_tensor_map,
 )
 from michelangelo.lib.native_transform.torch.utils import generate_layer_name
-from michelangelo.uniflow.core.io_registry import default_io
-
-# Register TransformSpec as a first-class IO-serializable workflow value, so
-# it can be passed between Uniflow tasks the same way a DataFrame or Dataset
-# is (see michelangelo.uniflow.core.io_registry.default_io).
-default_io[TransformSpec] = TransformSpecIO
 
 __all__ = [
     "TORCH_TRANSFORM_LAYERS_DICT",

--- a/python/michelangelo/lib/native_transform/torch/__init__.py
+++ b/python/michelangelo/lib/native_transform/torch/__init__.py
@@ -33,6 +33,7 @@ from michelangelo.lib.native_transform.torch.constants import (
     TORCH_TYPE_TO_TORCH_DTYPE_CLASS_NAME_MAP,
 )
 from michelangelo.lib.native_transform.torch.duration import TimeDuration
+from michelangelo.lib.native_transform.torch.io import TransformSpecIO
 from michelangelo.lib.native_transform.torch.scale import ClipAndScale
 from michelangelo.lib.native_transform.torch.stats_layers import (
     Bucketization,
@@ -53,6 +54,12 @@ from michelangelo.lib.native_transform.torch.transform_utils import (
     update_output_tensor_map,
 )
 from michelangelo.lib.native_transform.torch.utils import generate_layer_name
+from michelangelo.uniflow.core.io_registry import default_io
+
+# Register TransformSpec as a first-class IO-serializable workflow value, so
+# it can be passed between Uniflow tasks the same way a DataFrame or Dataset
+# is (see michelangelo.uniflow.core.io_registry.default_io).
+default_io[TransformSpec] = TransformSpecIO
 
 __all__ = [
     "TORCH_TRANSFORM_LAYERS_DICT",
@@ -84,6 +91,7 @@ __all__ = [
     "TorchTransformBaseLayer",
     "TorchTransformModule",
     "TransformSpec",
+    "TransformSpecIO",
     "generate_cast_transformation",
     "generate_concatenation_transformation",
     "generate_duration_transformation",

--- a/python/michelangelo/lib/native_transform/torch/io.py
+++ b/python/michelangelo/lib/native_transform/torch/io.py
@@ -1,0 +1,79 @@
+"""TransformSpecIO — read/write :class:`TransformSpec` objects via fsspec.
+
+Wraps :meth:`TransformSpec.to_json`/:meth:`TransformSpec.load_from_json` in
+the :class:`~michelangelo.uniflow.core.io_registry.IO` protocol so a fitted
+``TransformSpec`` can be passed between Uniflow tasks (or persisted to a
+pipeline artifact store) as a first-class workflow value, the same way a
+``pandas.DataFrame`` or ``ray.data.Dataset`` is.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import fsspec.core
+
+from michelangelo.lib.native_transform.torch.transform_spec import TransformSpec
+from michelangelo.uniflow.core.io_registry import IO
+
+__all__ = ["TransformSpecIO"]
+
+
+class TransformSpecIO(IO[TransformSpec]):
+    """Read/write :class:`TransformSpec` objects as JSON text via fsspec.
+
+    ``TransformSpec`` already serializes itself to/from JSON
+    (:meth:`~TransformSpec.to_json`, :meth:`~TransformSpec.load_from_json`);
+    this class only adapts that behavior to the ``IO[T]`` protocol so it can
+    be registered in :data:`~michelangelo.uniflow.core.io_registry.default_io`.
+    No metadata is needed for the round-trip.
+
+    Example:
+
+    .. code-block:: python
+
+        from michelangelo.lib.native_transform.torch import TransformSpec
+        from michelangelo.lib.native_transform.torch.io import TransformSpecIO
+
+        spec = TransformSpec(raw_transform_specs={...})
+        io = TransformSpecIO()
+        io.write("/tmp/spec.json", spec)
+        restored = io.read("/tmp/spec.json", None)
+    """
+
+    def write(self, url: str, value: TransformSpec) -> Any | None:
+        """Serialize *value* to JSON text at *url*.
+
+        Args:
+            url: Destination path or fsspec URL (local, ``s3://``, etc.).
+            value: The ``TransformSpec`` to write.
+
+        Returns:
+            ``None``. This implementation does not return metadata.
+        """
+        fs, path = fsspec.core.url_to_fs(url)
+        with fs.open(path, "w") as f:
+            f.write(value.to_json())
+        return None
+
+    def read(self, url: str, _metadata: Any | None) -> TransformSpec:
+        """Deserialize a ``TransformSpec`` from JSON text at *url*.
+
+        Args:
+            url: Source path or fsspec URL.
+            _metadata: Unused; pass ``None``.
+
+        Returns:
+            A ``TransformSpec`` restored from the JSON written by
+            :meth:`write`.
+        """
+        fs, path = fsspec.core.url_to_fs(url)
+        with fs.open(path, "r") as f:
+            json_str = f.read()
+        # load_from_json() is an instance method that replaces state in place
+        # (mirroring TransformSpec's other update_* mutators), so bypass
+        # __init__ -- which otherwise requires a yaml path or raw spec dict --
+        # and populate the instance entirely from the serialized JSON.
+        spec = TransformSpec.__new__(TransformSpec)
+        spec.load_from_json(json_str)
+        return spec

--- a/python/michelangelo/lib/native_transform/torch/tests/test_io.py
+++ b/python/michelangelo/lib/native_transform/torch/tests/test_io.py
@@ -1,0 +1,100 @@
+"""Tests for :mod:`michelangelo.lib.native_transform.torch.io`."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("pydantic")
+pytest.importorskip("yaml")
+pytest.importorskip("fsspec")
+
+from michelangelo.lib.native_transform.torch.io import TransformSpecIO  # noqa: E402
+from michelangelo.lib.native_transform.torch.transform_spec import (  # noqa: E402
+    TransformSpec,
+)
+from michelangelo.uniflow.core.io_registry import default_io  # noqa: E402
+
+RAW_SPECS = {
+    "transform_specs": [
+        {
+            "transform_name": "Concatenate",
+            "input_cols": ["col1"],
+            "output_cols": ["col1_concatenated"],
+        },
+        {
+            "transform_name": "StandardScaler",
+            "input_cols": ["col2", "col3"],
+            "output_cols": ["col2_scaled_col3_scaled"],
+        },
+    ]
+}
+
+
+class TestTransformSpecIO:
+    """Round-trip and edge-case coverage for TransformSpecIO."""
+
+    def test_write_then_read_round_trip(self, tmp_path) -> None:
+        """A spec written to disk reads back with equivalent DAG state."""
+        spec = TransformSpec(raw_transform_specs=RAW_SPECS)
+        url = str(tmp_path / "spec.json")
+        io = TransformSpecIO()
+
+        metadata = io.write(url, spec)
+        restored = io.read(url, metadata)
+
+        assert isinstance(restored, TransformSpec)
+        assert restored.to_dict() == spec.to_dict()
+        assert restored.transform_levels == spec.transform_levels
+
+    def test_write_returns_no_metadata(self, tmp_path) -> None:
+        """write() returns None; the JSON is fully self-describing."""
+        spec = TransformSpec(raw_transform_specs=RAW_SPECS)
+        io = TransformSpecIO()
+
+        assert io.write(str(tmp_path / "spec.json"), spec) is None
+
+    def test_write_produces_valid_json_matching_to_json(self, tmp_path) -> None:
+        """The file written is exactly TransformSpec.to_json()'s output."""
+        spec = TransformSpec(raw_transform_specs=RAW_SPECS)
+        url = str(tmp_path / "spec.json")
+        TransformSpecIO().write(url, spec)
+
+        with open(url) as f:
+            on_disk = json.load(f)
+        assert on_disk == json.loads(spec.to_json())
+
+    def test_read_missing_file_raises(self, tmp_path) -> None:
+        """Reading a nonexistent path surfaces the underlying fsspec error."""
+        io = TransformSpecIO()
+        with pytest.raises(FileNotFoundError):
+            io.read(str(tmp_path / "does_not_exist.json"), None)
+
+    def test_read_malformed_json_raises(self, tmp_path) -> None:
+        """Malformed JSON at the target path raises during deserialization."""
+        url = tmp_path / "bad.json"
+        url.write_text("{not valid json")
+        io = TransformSpecIO()
+        with pytest.raises(json.JSONDecodeError):
+            io.read(str(url), None)
+
+    def test_registered_in_default_io(self) -> None:
+        """Importing the torch native_transform package registers the handler."""
+        import michelangelo.lib.native_transform.torch  # noqa: F401
+
+        assert TransformSpec in default_io
+        assert isinstance(default_io[TransformSpec], TransformSpecIO)
+
+    def test_read_result_is_independent_of_written_instance(self, tmp_path) -> None:
+        """Mutating the original spec after write() doesn't affect the restored copy."""
+        spec = TransformSpec(raw_transform_specs=RAW_SPECS)
+        url = str(tmp_path / "spec.json")
+        io = TransformSpecIO()
+        io.write(url, spec)
+        restored = io.read(url, None)
+
+        spec.update_standard_scaler_specs({"col2_mean": 1.0, "col2_std": 2.0})
+
+        assert restored.to_dict() != spec.to_dict()

--- a/python/michelangelo/lib/native_transform/torch/tests/test_io.py
+++ b/python/michelangelo/lib/native_transform/torch/tests/test_io.py
@@ -15,7 +15,6 @@ from michelangelo.lib.native_transform.torch.io import TransformSpecIO  # noqa: 
 from michelangelo.lib.native_transform.torch.transform_spec import (  # noqa: E402
     TransformSpec,
 )
-from michelangelo.uniflow.core.io_registry import default_io  # noqa: E402
 
 RAW_SPECS = {
     "transform_specs": [
@@ -79,13 +78,6 @@ class TestTransformSpecIO:
         io = TransformSpecIO()
         with pytest.raises(json.JSONDecodeError):
             io.read(str(url), None)
-
-    def test_registered_in_default_io(self) -> None:
-        """Importing the torch native_transform package registers the handler."""
-        import michelangelo.lib.native_transform.torch  # noqa: F401
-
-        assert TransformSpec in default_io
-        assert isinstance(default_io[TransformSpec], TransformSpecIO)
 
     def test_read_result_is_independent_of_written_instance(self, tmp_path) -> None:
         """Mutating the original spec after write() doesn't affect the restored copy."""

--- a/python/michelangelo/uniflow/plugins/native_transform/__init__.py
+++ b/python/michelangelo/uniflow/plugins/native_transform/__init__.py
@@ -1,0 +1,5 @@
+"""Uniflow integration for native_transform."""
+
+from michelangelo.uniflow.plugins.native_transform.io import TransformSpecIO
+
+__all__ = ["TransformSpecIO"]

--- a/python/michelangelo/uniflow/plugins/native_transform/io.py
+++ b/python/michelangelo/uniflow/plugins/native_transform/io.py
@@ -1,0 +1,17 @@
+"""Uniflow IO adapter registration for TransformSpec.
+
+Importing this module registers TransformSpec as an IO-serializable
+Uniflow workflow value, so a fitted TransformSpec can be passed between
+Uniflow tasks (or persisted to a pipeline artifact store) the same way a
+``pandas.DataFrame`` or ``ray.data.Dataset`` is. See
+:class:`~michelangelo.lib.native_transform.torch.io.TransformSpecIO` for
+the serialization implementation.
+"""
+
+from michelangelo.lib.native_transform.torch.io import TransformSpecIO
+from michelangelo.lib.native_transform.torch.transform_spec import TransformSpec
+from michelangelo.uniflow.core.io_registry import default_io
+
+default_io[TransformSpec] = TransformSpecIO
+
+__all__ = ["TransformSpecIO"]

--- a/python/michelangelo/uniflow/plugins/native_transform/tests/__init__.py
+++ b/python/michelangelo/uniflow/plugins/native_transform/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the native_transform uniflow plugin."""

--- a/python/michelangelo/uniflow/plugins/native_transform/tests/native_transform_io_test.py
+++ b/python/michelangelo/uniflow/plugins/native_transform/tests/native_transform_io_test.py
@@ -1,0 +1,26 @@
+"""Tests for the native_transform uniflow plugin's default_io registration."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("pydantic")
+pytest.importorskip("yaml")
+pytest.importorskip("fsspec")
+
+
+class TestNativeTransformIORegistration:
+    """Importing the plugin registers TransformSpec in default_io."""
+
+    def test_registered_in_default_io(self) -> None:
+        """Importing the plugin package registers the handler."""
+        import michelangelo.uniflow.plugins.native_transform  # noqa: F401
+        from michelangelo.lib.native_transform.torch.transform_spec import (
+            TransformSpec,
+        )
+        from michelangelo.uniflow.core.io_registry import default_io
+        from michelangelo.uniflow.plugins.native_transform.io import TransformSpecIO
+
+        assert TransformSpec in default_io
+        assert isinstance(default_io[TransformSpec], TransformSpecIO)


### PR DESCRIPTION
## Summary

Last sub-PR of the `native_transform` migration (PR E — "TransformSpecIO + docs/DX polish" from `specs/native_transform/oss_design.md`). Depends only on `TransformSpec` (merged in PR B6, #1730); no dependency on the still-open B7 (#1772) or PR C (#1773).

`TransformSpec` already serializes itself via `to_json`/`load_from_json`. This PR wraps that in the `IO[T]` protocol so a fitted spec round-trips as a first-class Uniflow workflow value the same way a `DataFrame` or `Dataset` does, and adds a user guide for the module.

## Changes

- **`lib/native_transform/torch/io.py`** — new `TransformSpecIO(IO[TransformSpec])`, following the `ProtoIO`/`SparkIO`/`RayDatasetIO` pattern (fsspec-backed read/write, no extra metadata needed since the JSON is self-describing).
  - `read()` bypasses `TransformSpec.__init__` (which requires a yaml path or raw spec dict) via `TransformSpec.__new__` + `load_from_json`, since `load_from_json` already fully replaces every attribute `__init__` would set — this avoids needing a throwaway placeholder spec dict just to satisfy the constructor.
- **`lib/native_transform/torch/__init__.py`** — registers `default_io[TransformSpec] = TransformSpecIO` (class, not instance — matches the existing `BytesIO: BytesIOIO` registration's lazy-instantiation pattern in `IORegistry.__getitem__`). Registered eagerly at package import time since this `__init__.py` already imports torch-dependent modules unconditionally, so there's no laziness to preserve.
- **`docs/user-guides/train-and-deploy-models/native-feature-transforms.md`** — new usage guide: what the module does (spec DAG + fit/materialize/export lifecycle), a full runnable example (define spec → fit stats → hydrate placeholders → persist via `TransformSpecIO` → materialize `TorchTransformModule` → run + TorchScript-export), and how to extend it with a new layer/spec pair or a new `IO[T]` handler. Linked from `docs/user-guides/index.md`'s Quick Navigation table.

## Tests

- New: `lib/native_transform/torch/tests/test_io.py` — 7 tests: write/read round-trip fidelity (`to_dict()` equality), `write()` returning no metadata, on-disk JSON matching `to_json()` exactly, `FileNotFoundError` on missing file, `JSONDecodeError` on malformed JSON, `default_io` registration presence/type, and independence of a restored instance from later mutation of the original.
- Full `pytest lib/native_transform/`: 400 passed.
- Full `pytest uniflow/`: 50 passed (no regressions to existing IO plugins).
- The doc guide's example was run end-to-end against this branch (fit → hydrate → `TransformSpecIO` round-trip → materialize → forward pass → `torch.jit.script`) to confirm it actually works before publishing.

## Lint

`ruff format --check` and `ruff check` on all new/touched files: clean.

## Scope notes

This is the last PR in the `native_transform` migration's current sequence (A, A2, B1–B8, C, E). No behavior change to `TransformSpec` itself — this PR only adds an adapter and documentation around its existing serialization.