### PR TITLE
fix(python): sandbox sync kubeconfig context and self-referential compute cluster

### DIFF
--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -362,7 +362,6 @@ def _sync(ns: argparse.Namespace):
     # Upgrade or install the control plane via Helm.
     # Infrastructure (mysql, cadence, minio, grafana, prometheus) is left running.
 
-    _ensure_mysql_pod_running()
     _refresh_mysql_schema()
 
     _ensure_credentials_secret()
@@ -451,47 +450,6 @@ def _sync(ns: argparse.Namespace):
         )
 
     _helm_wait(ns)
-
-
-def _ensure_mysql_pod_running():
-    """Revive the bare `mysql` Pod if it isn't in the `Running` phase.
-
-    `_sync()`'s fast path leaves infrastructure Pods running rather than
-    recreating them, which assumes the previous sync's `mysql` Pod is still
-    alive. On a long-lived host, a node-level container-runtime restart can
-    leave a bare Pod (no Deployment/ReplicaSet to self-heal it) stuck in a
-    terminal phase (`Succeeded`/`Failed`) even though its containers never
-    exited on their own — `kubectl exec` then fails outright. Detect that
-    and delete+reapply the Pod manifest before `_refresh_mysql_schema()`
-    tries to exec into it.
-    """
-    phase_result = subprocess.run(
-        ["kubectl", "get", "pod", "mysql", "-o", "jsonpath={.status.phase}"],
-        capture_output=True,
-        text=True,
-    )
-    phase = phase_result.stdout.strip()
-
-    if phase_result.returncode == 0 and phase == "Running":
-        return
-
-    print(
-        f"mysql Pod is not Running (phase={phase or 'missing'}) — "
-        "recreating it before refreshing the schema."
-    )
-    subprocess.run(
-        ["kubectl", "delete", "pod", "mysql", "--ignore-not-found=true", "--wait=true"],
-        check=False,
-    )
-    _kube_apply(_dir / "resources" / "mysql.yaml")
-    _exec(
-        "kubectl",
-        "wait",
-        "--for=condition=ready",
-        "pod",
-        "mysql",
-        "--timeout=180s",
-    )
 
 
 def _refresh_mysql_schema():

--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -344,6 +344,7 @@ def _sync(ns: argparse.Namespace):
     # Upgrade or install the control plane via Helm.
     # Infrastructure (mysql, cadence, minio, grafana, prometheus) is left running.
 
+    _ensure_mysql_pod_running()
     _refresh_mysql_schema()
 
     _ensure_credentials_secret()
@@ -432,6 +433,47 @@ def _sync(ns: argparse.Namespace):
         )
 
     _helm_wait(ns)
+
+
+def _ensure_mysql_pod_running():
+    """Revive the bare `mysql` Pod if it isn't in the `Running` phase.
+
+    `_sync()`'s fast path leaves infrastructure Pods running rather than
+    recreating them, which assumes the previous sync's `mysql` Pod is still
+    alive. On a long-lived host, a node-level container-runtime restart can
+    leave a bare Pod (no Deployment/ReplicaSet to self-heal it) stuck in a
+    terminal phase (`Succeeded`/`Failed`) even though its containers never
+    exited on their own — `kubectl exec` then fails outright. Detect that
+    and delete+reapply the Pod manifest before `_refresh_mysql_schema()`
+    tries to exec into it.
+    """
+    phase_result = subprocess.run(
+        ["kubectl", "get", "pod", "mysql", "-o", "jsonpath={.status.phase}"],
+        capture_output=True,
+        text=True,
+    )
+    phase = phase_result.stdout.strip()
+
+    if phase_result.returncode == 0 and phase == "Running":
+        return
+
+    print(
+        f"mysql Pod is not Running (phase={phase or 'missing'}) — "
+        "recreating it before refreshing the schema."
+    )
+    subprocess.run(
+        ["kubectl", "delete", "pod", "mysql", "--ignore-not-found=true", "--wait=true"],
+        check=False,
+    )
+    _kube_apply(_dir / "resources" / "mysql.yaml")
+    _exec(
+        "kubectl",
+        "wait",
+        "--for=condition=ready",
+        "pod",
+        "mysql",
+        "--timeout=180s",
+    )
 
 
 def _refresh_mysql_schema():

--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -1726,6 +1726,19 @@ def _create_compute_cluster_crd(cluster_name: str):
         )
     host, port = match.groups()
 
+    # On Linux, `k3d kubeconfig get` publishes the API server bound to all
+    # interfaces, so the server URL's host is a loopback-equivalent address
+    # (0.0.0.0, 127.0.0.1, localhost) meant for clients on the VM itself.
+    # The Cluster CR we're building here is read by apiserver, which runs
+    # as a Pod *inside* this same k3d cluster — from its own network
+    # namespace, connecting to a loopback address just loops back to
+    # itself and refuses (nothing listens there), rather than reaching the
+    # host's published port. `host.k3d.internal` is the DNS name k3d
+    # injects into CoreDNS specifically so in-cluster workloads can reach
+    # host-published ports; substitute it for any loopback-equivalent host.
+    if host in ("https://0.0.0.0", "https://127.0.0.1", "https://localhost"):
+        host = "https://host.k3d.internal"
+
     # Create Cluster CRD manifest
     cluster_crd = {
         "apiVersion": "michelangelo.api/v2",

--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -331,16 +331,22 @@ def _sync(ns: argparse.Namespace):
     # Start the cluster in case it was stopped at the end of a previous run.
     _exec("k3d", "cluster", "start", _michelangelo_sandbox_kube_cluster_name)
 
-    # Unlike `k3d cluster create`, `k3d cluster start` does not switch the
-    # kubeconfig's current-context. On a host running more than one k3d
-    # cluster, the ambient context can be left pointing at an unrelated
-    # cluster by prior manual work, silently redirecting every kubectl/helm
-    # call below at the wrong cluster (see spec 035 addendum).
+    # Unlike `k3d cluster create`, `k3d cluster start` does not refresh the
+    # kubeconfig. On a host running more than one k3d cluster, the ambient
+    # context can be left pointing at an unrelated cluster by prior manual
+    # work, and even switching the context name back is not enough: each
+    # k3d cluster's API server is published on a host port chosen at create
+    # time, so a stale kubeconfig entry for this cluster (e.g. from before
+    # a delete+recreate) still has the old, now-dead port. `k3d kubeconfig
+    # merge -d` rewrites the entry with the live port/certs and switches to
+    # it in one step (see spec 035 addendum).
     _exec(
-        "kubectl",
-        "config",
-        "use-context",
-        f"k3d-{_michelangelo_sandbox_kube_cluster_name}",
+        "k3d",
+        "kubeconfig",
+        "merge",
+        _michelangelo_sandbox_kube_cluster_name,
+        "-d",
+        "--kubeconfig-switch-context",
     )
 
     # Wait for the API server to become reachable after start.

--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -1704,40 +1704,48 @@ def _create_compute_cluster_crd(cluster_name: str):
     # Ensure ma-system namespace exists
     _ensure_namespace_exists("ma-system")
 
-    # Get kubeconfig for the Ray jobs cluster
-    kubeconfig = subprocess.check_output(
-        ["k3d", "kubeconfig", "get", cluster_name]
-    ).decode()
+    if cluster_name == _michelangelo_sandbox_kube_cluster_name:
+        # Self-referential case: the cluster being registered is the same
+        # one apiserver runs in. Reach it via the in-cluster Kubernetes
+        # service instead of the host-published API port. The host-external
+        # address (whatever `k3d kubeconfig get` reports — 0.0.0.0 on Linux,
+        # host.docker.internal on Docker Desktop) is meant for clients on
+        # the host machine; from apiserver's own Pod network namespace it
+        # either refuses (loopback-equivalent addresses) or fails TLS
+        # verification (the k3s server cert's SANs don't cover
+        # host.k3d.internal). `kubernetes.default.svc` is already a valid
+        # SAN on every k3s server cert and always resolves in-cluster.
+        host, port = "https://kubernetes.default.svc", "443"
+    else:
+        # Genuinely separate compute cluster: apiserver (in cluster A) must
+        # reach cluster B's host-published API port, so there's no
+        # in-cluster shortcut. Extract host/port from cluster B's own
+        # kubeconfig.
+        kubeconfig = subprocess.check_output(
+            ["k3d", "kubeconfig", "get", cluster_name]
+        ).decode()
+        kubeconfig_data = yaml.safe_load(kubeconfig)
+        server_url = kubeconfig_data["clusters"][0]["cluster"]["server"]
 
-    # Parse the kubeconfig YAML
-    kubeconfig_data = yaml.safe_load(kubeconfig)
+        # Extract host and port from server URL
+        # Example: "https://host.docker.internal:52910"
+        import re
 
-    # Extract server URL from clusters[0].cluster.server
-    server_url = kubeconfig_data["clusters"][0]["cluster"]["server"]
-
-    # Extract host and port from server URL
-    # Example: "https://host.docker.internal:52910"
-    import re
-
-    match = re.search(r"(https://[^:]+):(\d+)", server_url)
-    if not match:
-        raise ValueError(
-            f"Could not extract cluster host and port from server URL: {server_url}"
-        )
-    host, port = match.groups()
-
-    # On Linux, `k3d kubeconfig get` publishes the API server bound to all
-    # interfaces, so the server URL's host is a loopback-equivalent address
-    # (0.0.0.0, 127.0.0.1, localhost) meant for clients on the VM itself.
-    # The Cluster CR we're building here is read by apiserver, which runs
-    # as a Pod *inside* this same k3d cluster — from its own network
-    # namespace, connecting to a loopback address just loops back to
-    # itself and refuses (nothing listens there), rather than reaching the
-    # host's published port. `host.k3d.internal` is the DNS name k3d
-    # injects into CoreDNS specifically so in-cluster workloads can reach
-    # host-published ports; substitute it for any loopback-equivalent host.
-    if host in ("https://0.0.0.0", "https://127.0.0.1", "https://localhost"):
-        host = "https://host.k3d.internal"
+        match = re.search(r"(https://[^:]+):(\d+)", server_url)
+        if not match:
+            raise ValueError(
+                f"Could not extract cluster host and port from server URL: {server_url}"
+            )
+        host, port = match.groups()
+        # NOTE: on Linux, this host is typically a loopback-equivalent
+        # address (0.0.0.0/127.0.0.1/localhost) that only routes from the
+        # VM itself, not from a Pod's network namespace. host.k3d.internal
+        # is reachable in-cluster, but cluster B's default k3s server cert
+        # doesn't carry it as a SAN either, so this still needs
+        # `--tls-san=host.k3d.internal` passed to that cluster's
+        # `k3d cluster create` to pass TLS verification end-to-end.
+        if host in ("https://0.0.0.0", "https://127.0.0.1", "https://localhost"):
+            host = "https://host.k3d.internal"
 
     # Create Cluster CRD manifest
     cluster_crd = {

--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -331,6 +331,18 @@ def _sync(ns: argparse.Namespace):
     # Start the cluster in case it was stopped at the end of a previous run.
     _exec("k3d", "cluster", "start", _michelangelo_sandbox_kube_cluster_name)
 
+    # Unlike `k3d cluster create`, `k3d cluster start` does not switch the
+    # kubeconfig's current-context. On a host running more than one k3d
+    # cluster, the ambient context can be left pointing at an unrelated
+    # cluster by prior manual work, silently redirecting every kubectl/helm
+    # call below at the wrong cluster (see spec 035 addendum).
+    _exec(
+        "kubectl",
+        "config",
+        "use-context",
+        f"k3d-{_michelangelo_sandbox_kube_cluster_name}",
+    )
+
     # Wait for the API server to become reachable after start.
     _exec(
         "kubectl",
@@ -540,6 +552,27 @@ def _helm_ensure_repos():
         _exec("helm", "repo", "add", "temporal", "https://go.temporal.io/helm-charts")
 
 
+def _helm_dependency_update():
+    """Fetch the chart's subchart dependencies into charts/ if not cached.
+
+    `helm template`/`helm dependency update` print status lines like
+    "Hang tight while we grab the latest..." and "Downloading <chart> from
+    repo ..." to stdout ahead of any real output when it has to fetch
+    dependencies. `helm template`'s own `--dependency-update` flag mixes
+    those lines into the manifest stream itself, breaking any caller that
+    parses its stdout as YAML documents (`yaml.safe_load_all` chokes on the
+    first "document" being a bare string). Running the fetch as its own,
+    separate, discarded-output step keeps `helm template`'s stdout clean
+    for callers like _helm_delete_services()/_helm_adopt_orphaned_resources()
+    that need to parse it, while still working on a runner whose charts/
+    cache isn't already warm (e.g. a fresh checkout).
+    """
+    subprocess.run(
+        ["helm", "dependency", "update", str(_chart_dir)],
+        capture_output=True,
+    )
+
+
 def _helm_delete_services(helm_args: list[str]):
     """Delete Services that would conflict with the chart's NodePorts.
 
@@ -547,6 +580,7 @@ def _helm_delete_services(helm_args: list[str]):
     a previous install structure) can still hold NodePorts. We scan all
     Services in the cluster for conflicting NodePorts and delete them.
     """
+    _helm_dependency_update()
     # Collect the NodePorts the chart wants to allocate.
     result = subprocess.run(
         [
@@ -629,6 +663,7 @@ def _helm_adopt_orphaned_resources(helm_args: list[str]):
     recreate it cleanly. Resources already managed by Helm (correct labels)
     are left untouched.
     """
+    _helm_dependency_update()
     result = subprocess.run(
         [
             "helm",


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Two independent fixes to `ma sandbox sync`, both root-caused from real CI failures on the `Integration tests` workflow:

1. `_sync()` now runs `k3d kubeconfig merge <cluster> -d --kubeconfig-switch-context` right after `k3d cluster start`. `k3d cluster start` (unlike `k3d cluster create`) never touches kubeconfig, so on a host that's ever had more than one k3d cluster, the ambient `current-context` can silently point at the wrong cluster, and even a stale-but-correctly-named context entry can carry a dead host port from a prior delete+recreate. `k3d kubeconfig merge -d` refreshes the entry (port/certs) and switches the context in one step.
2. `_create_compute_cluster_crd()` now special-cases the self-referential case (a k3d cluster registering itself as a `Cluster` CRD, later read by `apiserver` — a Pod running inside that same cluster — to make outbound Ray/K8s API calls "into" it). It previously always extracted a host-published address (`0.0.0.0:<port>` on Linux) from `k3d kubeconfig get`, which is unreachable from a Pod's own network namespace. It now uses `https://kubernetes.default.svc:443`, which is always resolvable in-cluster and is already a valid SAN on the k3s server's default certificate. The genuinely-separate-cluster path (cluster A registering cluster B) is left as before, plus a best-effort `host.k3d.internal` substitution for loopback-equivalent hosts — noted in-code that this still needs `--tls-san=host.k3d.internal` at that cluster's creation time to pass TLS verification end-to-end; not exercised by this sandbox's own setup (which only ever registers itself).
3. Small fix bundled in: `_helm_dependency_update()` now runs explicitly before any `helm template` call used for introspection (`_helm_delete_services()`, `_helm_adopt_orphaned_resources()`), so a cold chart-dependency cache doesn't pollute `helm template`'s stdout with fetch-status lines ahead of the YAML the callers parse.

**Why?**

CI (`Integration tests` workflow, self-hosted GCP runner) was failing deterministically at the `Sync sandbox` step. Root cause was the runner user's kubeconfig context having drifted to an unrelated k3d cluster on the shared VM (traced via live inspection of the sandbox instance), which every subsequent `kubectl`/`helm` call in `_sync()` silently followed. Fixing that surfaced a second, previously-latent bug: once sync targeted the right cluster, the sandbox's Ray pipeline test (`test_bert_cola_e2e`) still failed because apiserver couldn't reach the compute cluster it had registered for itself, due to the host-published address being unreachable from inside the cluster's own pod network.

**How did you test it?**

Verified live against the real GCP sandbox instance and real CI runs (not just local k3d):
- Manually confirmed and fixed the stale kubeconfig context/entry on the runner user's account, then verified `kubectl get nodes` worked against the intended cluster.
- Live-patched the `Cluster` CRD's `host`/`port` on the running sandbox to `kubernetes.default.svc:443` and confirmed a RayCluster subsequently reached `Launched` with real head/worker pods staying alive and pulling images (vs. instant termination before the fix).
- Triggered the `Integration tests` GitHub Actions workflow against this branch twice (runs `31498187639` and `31501619092`); both completed with the `Sync sandbox` step succeeding cleanly (`helm upgrade ... STATUS: deployed`) and the full workflow concluding `success`.

**Potential risks**

Low. The kubeconfig-merge call is additive and idempotent (safe to run every sync). The compute-cluster host change only affects the self-referential path exercised by this sandbox; the separate-cluster path's behavior is unchanged except for the same loopback-to-`host.k3d.internal` substitution added defensively (not currently exercised in CI).

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

N/A

**Documentation Changes**

N/A