### PR TITLE
feat(js): FormViewConfig and mutation derivation

### DIFF
--- a/javascript/packages/core/components/form/build-form-mutation-config.ts
+++ b/javascript/packages/core/components/form/build-form-mutation-config.ts
@@ -1,0 +1,26 @@
+import type { SuccessOperation } from '#core/components/actions/types';
+import type { FormOperation } from '#core/components/views/types';
+import type { MiddlewareSchema } from '#core/hooks/use-schema-middleware/types';
+import type { MutationConfig } from '#core/types/query-types';
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+export function buildFormMutationConfig({
+  service,
+  formOperation,
+  successOperations,
+  middleware,
+}: {
+  service: string;
+  formOperation: FormOperation;
+  successOperations?: SuccessOperation[];
+  middleware?: MiddlewareSchema;
+}): MutationConfig {
+  return {
+    mutationName: `${capitalize(formOperation)}${capitalize(service)}`,
+    successOperations,
+    middleware,
+  };
+}

--- a/javascript/packages/core/components/views/types.ts
+++ b/javascript/packages/core/components/views/types.ts
@@ -1,18 +1,23 @@
-import type { ReactNode } from 'react';
-import type { ActionConfigSchema } from '#core/components/actions/types';
+import type { ComponentType, ReactNode } from 'react';
+import type { ActionConfigSchema, SuccessOperation } from '#core/components/actions/types';
 import type { Cell } from '#core/components/cell/types';
+import type { FormConfig } from '#core/components/form/types/config-types';
 import type { EmptyState } from '#core/components/table/components/table-empty-state/types';
 import type { PageSizeOption } from '#core/components/table/components/table-pagination/types';
 import type { ColumnConfig } from '#core/components/table/types/column-types';
 import type { TableData } from '#core/components/table/types/data-types';
 import type { TableProps as _TableProps } from '#core/components/table/types/table-types';
 import type { DetailPageConfig } from '#core/components/views/detail-view/types/detail-view-schema-types';
+import type { MiddlewareSchema } from '#core/hooks/use-schema-middleware/types';
 
 export type MainViewContainerProps = {
   children: ReactNode;
 };
 
-export type ViewConfig<T extends object = object> = ListViewConfig<T> | DetailViewConfig<T>;
+export type ViewConfig<T extends object = object> =
+  | ListViewConfig<T>
+  | DetailViewConfig<T>
+  | FormViewConfig;
 
 export interface ListViewConfig<T extends object = object> {
   type: 'list';
@@ -55,3 +60,21 @@ export interface TableConfig<T extends TableData = TableData> {
   /** Optional actions to render in each table row */
   actions?: ActionConfigSchema<T>[];
 }
+
+export type FormOperation = 'create' | 'update';
+
+export type FormViewConfigSchema = {
+  type: 'form';
+  config: FormConfig;
+  subType?: { path: string; value: string };
+  successOperations?: SuccessOperation[];
+  middleware?: MiddlewareSchema;
+};
+
+export type FormViewConfigComponent = {
+  type: 'form';
+  component: ComponentType<{ record?: unknown; formOperation: FormOperation }>;
+  subType?: { path: string; value: string };
+};
+
+export type FormViewConfig = FormViewConfigSchema | FormViewConfigComponent;


### PR DESCRIPTION
## Summary

- Adds `FormViewConfigSchema` and `FormViewConfigComponent` to the view type system, bridging config-driven forms into the entity view layer
- Adds `buildFormMutationConfig` to derive mutation config from a form view config

Replaces #1654 (closed to fix PR base branch).

## Test plan

I verified typecheck passes and the form view types integrate correctly with the existing view config system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)