### PR TITLE
ci: pin apidiff to a Go 1.24-compatible x/exp pseudo-version

### DIFF
--- a/.github/workflows/api-surface-check.yml
+++ b/.github/workflows/api-surface-check.yml
@@ -62,7 +62,7 @@ jobs:
           cache-dependency-path: head/go/go.sum
 
       - name: Install go-apidiff
-        run: go install golang.org/x/exp/cmd/apidiff@latest
+        run: go install golang.org/x/exp/cmd/apidiff@v0.0.0-20260209203927-2842357ff358
 
       - name: Export base API
         working-directory: base/go


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update

**What changed?**
One line in `.github/workflows/api-surface-check.yml`: `apidiff` is installed from a pinned `golang.org/x/exp` pseudo-version instead of `@latest`.

```
-        run: go install golang.org/x/exp/cmd/apidiff@latest
+        run: go install golang.org/x/exp/cmd/apidiff@v0.0.0-20260209203927-2842357ff358
```

**Why?**
This is the fix proposed in #1752, with the placeholder resolved to a concrete version. Credit for the root cause goes there -- I hit the same failure on #1755 and only found the existing issue afterwards.

Short version: `golang.org/x/exp` has no release tags, so `@latest` floats to the tip of its default branch, and that module's own `go.mod` has required Go >= 1.25 since February. That was harmless while `actions/setup-go` defaulted to `GOTOOLCHAIN=auto`, because `go install` quietly downloaded a newer toolchain. Since the v5 to v7 bump in #1743, `setup-go` sets `GOTOOLCHAIN=local`, so the mismatch is a hard error:

```
go: golang.org/x/exp@v0.0.0-20260811152304-ee035b5b010f requires go >= 1.25.0
(running go 1.24.3; GOTOOLCHAIN=local)
```

`v0.0.0-20260209203927-2842357ff358` is the last x/exp revision before the Go 1.25 bump landed -- it is the parent of `2735e65f0518` ("all: upgrade go directive to at least 1.25.0"), and its `go.mod` still says `go 1.24.0`.

This is the follow-up I offered in #1767, which pinned the golangci-lint installer and left this one alone.

**How did you test it?**
I cannot trigger a workflow run on this repo, so this is verified by inspection rather than by a green check:

- The pinned version resolves: `https://proxy.golang.org/golang.org/x/exp/@v/v0.0.0-20260209203927-2842357ff358.mod` returns HTTP 200 and its go directive is `go 1.24.0`, which the runner's 1.24.3 satisfies.
- `cmd/apidiff` exists at that revision.
- The tool's flag surface is byte-identical between the pinned revision and current tip -- both define exactly `-w`, `-incompatible`, `-allow-internal`, `-m`. The two call sites in this workflow use `-incompatible`, so the pin does not change how the tool is invoked.
- The workflow still parses as valid YAML.
- Confirmed the break is not specific to any one branch: the same failure is present on `fix/mysql-direct-update` and `fix/sandbox-workflow-execution-url-v2`.

**Potential risks**
Low for the change itself. The pin is a fixed pseudo-version, so it cannot drift; when someone wants a newer `apidiff` it becomes an explicit, reviewable bump.

One thing worth flagging separately, because it affects how much this PR is actually worth: **pinning makes the job green again, but the job still does not detect anything.** Both `apidiff` call sites look malformed, and every error is suppressed with `2>/dev/null || true`, so the failures are invisible:

- Line 71 passes `-export`, which is not a flag `apidiff` defines. `flag.Parse` rejects it and the process exits 2. The real flag is `-w FILE IMPORT_PATH`.
- Line 82 passes one positional argument. `apidiff` requires exactly two (`apidiff OLD NEW`) and exits 2 with usage otherwise, so `result` is always empty and `breaking` is always `false`.
- `/tmp/base-api.txt` is written on line 72 and never read anywhere in the repo, so the base checkout and its export step are unused.

I read this out of `cmd/apidiff/main.go` at the pinned revision rather than by running it, so it is worth a second pair of eyes. If that reading is right, the job has never been able to report a breaking change, and #1752's "zero PRs are currently being checked" would remain true after this merges. That is why this says `Refs #1752` rather than `Closes` -- it fixes the install failure and the floating dependency, not the detection gap. Happy to send the invocation fix as a separate PR if you want it, though that one changes the check from "never fires" to "can fire", which felt like a maintainer's call rather than something to slip into a one-line pin.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**
None.

**Documentation Changes**
None needed.
