### PR TITLE
fix(api): use status.Error for non-format error messages

### DIFF
--- a/go/api/handler/handler.go
+++ b/go/api/handler/handler.go
@@ -83,7 +83,7 @@ func (handler *apiHandler) Create(ctx context.Context, obj ctrlRTClient.Object, 
 
 	objMeta, err := meta.Accessor(obj)
 	if err != nil {
-		return status.Errorf(codes.InvalidArgument, err.Error())
+		return status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	if metadataErr := handler.handleMetadataStorageForCreate(ctx, obj, objMeta); metadataErr != nil {
@@ -160,7 +160,7 @@ func (handler *apiHandler) Update(ctx context.Context, obj ctrlRTClient.Object, 
 
 	hasSpecChange, err := handler.hasSpecChange(ctx, obj)
 	if err != nil {
-		return status.Errorf(codes.InvalidArgument, err.Error())
+		return status.Error(codes.InvalidArgument, err.Error())
 	}
 	setUpdateTimestamp(obj, hasSpecChange)
 
@@ -241,7 +241,7 @@ func (handler *apiHandler) Delete(ctx context.Context, obj ctrlRTClient.Object,
 
 	objMeta, err := meta.Accessor(obj)
 	if err != nil {
-		return status.Errorf(codes.InvalidArgument, err.Error())
+		return status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	dryRun, err := checkDryRun(opts.DryRun)
@@ -372,13 +372,13 @@ func (handler *apiHandler) DeleteCollection(
 	// List objects from metadata storage
 	gvk, err := ctrlRTApiutil.GVKForObject(objType, scheme.Scheme)
 	if err != nil {
-		return status.Errorf(codes.InvalidArgument, err.Error())
+		return status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	listGVK := gvk.GroupVersion().WithKind(gvk.Kind + "List")
 	newObj, err := scheme.Scheme.New(listGVK)
 	if err != nil {
-		return status.Errorf(codes.InvalidArgument, err.Error())
+		return status.Error(codes.InvalidArgument, err.Error())
 	}
 	listObj, ok := newObj.(ctrlRTClient.ObjectList)
 	if !ok {

--- a/go/api/utils/utils.go
+++ b/go/api/utils/utils.go
@@ -21,7 +21,7 @@ import (
 func GetObjectTypeMetaFromList(list runtime.Object, scheme *runtime.Scheme) (*metav1.TypeMeta, error) {
 	listGVK, err := apiutil.GVKForObject(list, scheme)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	kindLen := len(listGVK.Kind)
@@ -43,7 +43,7 @@ func GetObjectTypeMetafromObject(obj runtime.Object, scheme *runtime.Scheme) (*m
 	gvk, err := apiutil.GVKForObject(obj, scheme)
 
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	typeMeta.SetGroupVersionKind(gvk)


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
Seven call sites across two files switch from `status.Errorf` to `status.Error`:

```
-		return status.Errorf(codes.InvalidArgument, err.Error())
+		return status.Error(codes.InvalidArgument, err.Error())
```

- `go/api/handler/handler.go` -- 5 sites
- `go/api/utils/utils.go` -- 2 sites

Nothing else changes. Both files still use `status.Errorf` elsewhere for calls that genuinely format.

**Why?**
`status.Errorf(code, err.Error())` passes a runtime string as the format argument with no arguments after it. In grpc-go v1.71.0 (the version pinned in `go/go.mod`) that forwards to `fmt.Sprintf(format)`:

```go
func Error(c codes.Code, msg string) error { return New(c, msg).Err() }
func Errorf(c codes.Code, format string, a ...any) error { return Error(c, fmt.Sprintf(format, a...)) }
```

So any literal `%` in the underlying error gets read as a verb, and the message the caller receives comes back mangled -- a wrapped error containing something like `100%` or a `%s` from a nested template renders as `%!(NOVERB)` or `%!s(MISSING)`. It is unlikely but not impossible for these paths, and the message is the only thing the client gets.

`status.Error` takes the message directly and cannot do this. It is already the idiom here: `handler.go:285` uses it, as do `go/cmd/kubeproto/protoc-gen-validation/main.go` and several tests.

This also silences `go vet`'s non-constant format string check, which is what the `cd go && go vet ./...` pre-commit hook added in #1420 runs.

**How did you test it?**
By inspection, not by running the suite:

- Checked the substitution is exhaustive rather than partial. A repo-wide scan of all Go files found exactly seven instances of this pattern, and all seven are in this diff. Five are the ones in `handler.go`; the other two are the identical pattern in `utils.go`, which is why this covers both files rather than just the one.
- Confirmed `status.Error(codes.Code, string) error` exists with that exact signature in grpc-go at the pinned v1.71.0, not just on tip.
- The swap is behaviour-preserving for every message without a literal `%`, which is all of them in practice, since `fmt.Sprintf` on a verb-free string returns it unchanged. For messages that do contain a `%`, current output is already wrong and this corrects it. There is no input for which this makes correct output incorrect.
- Both files still reference `status` and `codes`, so no imports are affected.

**Potential risks**
Low. To be clear about what this does and does not do: **CI is green today and stays green either way.** `go/.golangci.yml` sets `disable-all: true` and enables only `godox`, so `govet`/`printf` is not running in the lint job at all, and the Bazel job passes with this code present. This is a lint-hygiene and correctness cleanup that shows up for developers running `go vet` or the pre-commit hook locally, not a fix for anything currently red.

Checked for conflicts against the two open PRs that touch `handler.go` -- #1477 and #896. Neither touches any of these lines, so this should not create work for either.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**
None.

**Documentation Changes**
None needed.
