### PR TITLE
docs: add a migration guide for KubeRay users

### DIFF
--- a/docs/user-guides/migration/_category_.json
+++ b/docs/user-guides/migration/_category_.json
@@ -1,0 +1,6 @@
+{
+  "label": "Migration Guides",
+  "position": 5,
+  "collapsed": true,
+  "link": {"type": "generated-index"}
+}

--- a/docs/user-guides/migration/migrate-from-kuberay.md
+++ b/docs/user-guides/migration/migrate-from-kuberay.md
@@ -1,0 +1,206 @@
+---
+sidebar_position: 1
+sidebar_label: "From KubeRay"
+---
+
+# Migrating from KubeRay
+
+This guide is for teams already running Ray on Kubernetes with the KubeRay operator, who are evaluating what changes if they adopt Michelangelo AI.
+
+The short answer is that fewer things change than you might expect. Michelangelo AI does not replace KubeRay — it runs on top of it. The control plane accepts its own `RayCluster` and `RayJob` resources, then creates real `ray.io/v1` resources on a registered compute cluster for the KubeRay operator to reconcile. Your operator, your Ray version, and your cluster topology all survive the move.
+
+:::note
+This page maps **resources and manifests**. For concept-level mapping across MLflow, Kubeflow, Ray, and Airflow, see the [glossary's concept mapping](../../getting-started/glossary.md#concept-mapping). For a broader tool-by-tool view, see [ML Workflow Mapping](../../getting-started/overview.md#ml-workflow-mapping) in the overview.
+:::
+
+## What does not change
+
+- **You still install and run KubeRay yourself.** The chart's README lists KubeRay as an optional cluster operator to install separately from its upstream chart, required only if your pipelines use Ray tasks. It is not a chart dependency — the local sandbox installs it as its own Helm release into a `ray-system` namespace:
+
+  ```bash
+  helm repo add kuberay https://ray-project.github.io/kuberay-helm
+  helm install kuberay-operator kuberay/kuberay-operator --namespace ray-system --create-namespace
+  ```
+- **The resources KubeRay reconciles are still `ray.io/v1`.** Michelangelo AI builds them using the upstream KubeRay Go types, so what lands in your compute cluster is an ordinary `RayCluster` or `RayJob`.
+- **Ray itself is unchanged.** Ray Data and Ray Train are used directly — `ray.data.Dataset` is a first-class type in the pipeline IO system, and the bundled Lightning trainer subclasses Ray Train's `TorchTrainer`.
+
+:::warning
+There is no documented minimum KubeRay version. The control plane currently compiles against the KubeRay operator's Go types at `v1.2.2`, while the local sandbox installs operator `v1.4.2`. Both are in the `ray.io/v1` API, so an existing install in that range is very likely fine, but no version floor is stated anywhere, so confirm against your own operator version before migrating anything you care about.
+:::
+
+## What changes
+
+You stop applying `ray.io/v1` manifests to a cluster directly. Instead you apply a Michelangelo AI resource to the control plane, and it decides which registered compute cluster the workload lands on.
+
+That indirection is the point: it is what enables federated dispatch across multiple compute clusters, and what lets a Ray cluster become one step inside a larger pipeline rather than a standalone object you manage by hand.
+
+## Concept mapping
+
+| Concept | KubeRay | Michelangelo AI |
+|---|---|---|
+| **Cluster resource** | `RayCluster` (`ray.io/v1`) | `RayCluster` (`michelangelo.api/v2`), translated into a `ray.io/v1` `RayCluster` |
+| **Job resource** | `RayJob` (`ray.io/v1`) | `RayJob` (`michelangelo.api/v2`), translated into a `ray.io/v1` `RayJob` |
+| **Head node** | `spec.headGroupSpec` | `spec.head` |
+| **Worker groups** | `spec.workerGroupSpecs[]` | `spec.workers[]` |
+| **Worker group name** | `groupName` | `nodeType`, though the group name on the generated resource is derived from the cluster name rather than from this field |
+| **Worker count** | `replicas`, `minReplicas`, `maxReplicas` | `minInstances`, `maxInstances` |
+| **Ray start params** | `rayStartParams` | `rayStartParams`, on both head and workers |
+| **Ray version** | `spec.rayVersion` | `spec.rayVersion` |
+| **Pod customization** | `template` (a `PodTemplateSpec`) | `pod` (a `PodTemplateSpec`), on both head and workers |
+| **Which cluster a job runs on** | `clusterSelector` or an inline `rayClusterSpec` | `spec.cluster`, a name and namespace reference |
+| **Applying a manifest** | `kubectl apply -f` | `ma ray_cluster apply --file` |
+| **Where the workload lands** | The cluster your `kubectl` context points at | A registered compute cluster, chosen by the control plane |
+| **Serving** | `RayService` | No equivalent. Online serving is a separate Triton-based stack |
+
+## Your RayCluster, before and after
+
+A minimal KubeRay cluster:
+
+```yaml
+apiVersion: ray.io/v1
+kind: RayCluster
+metadata:
+  name: training-cluster
+  namespace: my-project
+spec:
+  rayVersion: "2.9.0"
+  headGroupSpec:
+    rayStartParams:
+      dashboard-host: "0.0.0.0"
+    template:
+      spec:
+        containers:
+          - name: ray-head
+            image: rayproject/ray:2.9.0
+  workerGroupSpecs:
+    - groupName: default-worker
+      replicas: 1
+      minReplicas: 1
+      maxReplicas: 2
+      template:
+        spec:
+          containers:
+            - name: ray-worker
+              image: rayproject/ray:2.9.0
+```
+
+The same cluster as a Michelangelo AI resource:
+
+```yaml
+apiVersion: michelangelo.api/v2
+kind: RayCluster
+metadata:
+  name: training-cluster
+  namespace: my-project
+spec:
+  user:
+    name: your-username
+  rayVersion: "2.9.0"
+  head:
+    rayStartParams:
+      dashboard-host: "0.0.0.0"
+  workers:
+    - nodeType: default-worker
+      minInstances: 1
+      maxInstances: 2
+```
+
+Apply it through the CLI rather than `kubectl`:
+
+```bash
+ma ray_cluster apply --file="./training-cluster.yaml"
+```
+
+The pod templates are gone from the example because they are optional here, not because they are unsupported — `head.pod` and `workers[].pod` both take a full `PodTemplateSpec` for anything the shorthand fields do not cover, including images, node selectors, and tolerations.
+
+## Your RayJob, before and after
+
+A KubeRay job against an existing cluster:
+
+```yaml
+apiVersion: ray.io/v1
+kind: RayJob
+metadata:
+  name: train
+  namespace: my-project
+spec:
+  entrypoint: "python train.py"
+  clusterSelector:
+    ray.io/cluster: training-cluster
+```
+
+The same job here:
+
+```yaml
+apiVersion: michelangelo.api/v2
+kind: RayJob
+metadata:
+  name: train
+  namespace: my-project
+spec:
+  user:
+    name: your-username
+  entrypoint: "python train.py"
+  cluster:
+    name: training-cluster
+    namespace: my-project
+```
+
+```bash
+ma ray_job apply --file="./train.yaml"
+```
+
+:::info
+`ray_cluster` and `ray_job` support `get`, `apply`, and `delete`. There is no `run` subcommand for them — applying the `RayJob` is what starts it. See the [CLI reference](../reference/cli.md) for the full resource table.
+
+The `namespace` in these manifests is a project. Projects are not created implicitly, so create yours before applying anything into it — see [Project Management](../getting-started/project-management-for-ml-pipelines.md).
+:::
+
+## The other path: let a task own the cluster
+
+If you are willing to change how jobs are authored, you can skip cluster manifests entirely. A pipeline task declares the resources it needs, and the platform creates a cluster before the task runs and tears it down afterwards:
+
+```python
+import michelangelo.uniflow.core as uniflow
+from michelangelo.uniflow.plugins.ray import RayTask
+
+@uniflow.task(
+    config=RayTask(
+        head_cpu=2,
+        head_memory="4Gi",
+        worker_cpu=2,
+        worker_memory="4Gi",
+        worker_instances=2,
+    )
+)
+def train(data_path: str):
+    return train_my_model(data_path)
+```
+
+This is the closest thing to a KubeRay `RayJob` with an inline `rayClusterSpec`: the cluster is created for one job and does not outlive it. The trade-off is a smaller configuration surface than the CRD path. `RayTask` accepts `head_cpu`, `head_memory`, `head_disk`, `head_gpu`, `head_object_store_memory`, the same five fields for workers, plus `worker_instances`, `breakpoint`, and `runtime_env`.
+
+Two differences worth knowing before you rely on it:
+
+- **The cluster is fixed size.** `worker_instances` sets the minimum and maximum to the same value, so there is no range to scale within.
+- **The Ray version is not configurable on this path.** Clusters created by a task use a version hardcoded in the plugin, currently 2.3.1, which is considerably older than what most KubeRay users will be running. If you need a specific Ray version, use the `RayCluster` resource, where `rayVersion` is honored.
+
+For the full task authoring model, see [Running Uniflow Pipelines](../ml-pipelines/running-uniflow.md).
+
+## What does not map yet
+
+These are real gaps, not omissions from this page.
+
+- **No autoscaling.** `minInstances` and `maxInstances` do reach the underlying KubeRay resource as `minReplicas` and `maxReplicas`, but the Ray in-tree autoscaler is never enabled, so a cluster runs at `minInstances` and stays there. Treat the range as a declaration rather than as elasticity.
+- **No `RayService` equivalent.** Online serving does not go through Ray. It is a separate stack reached through `InferenceServer` and `Deployment` resources, with pluggable backends — Triton Inference Server for traditional models, vLLM and SGLang for LLM serving. A Ray Serve deployment has to be rebuilt rather than translated.
+- **No Ray Tune integration.** There is no hyperparameter tuning plugin, and nothing in the codebase imports Ray Tune. Sweeps are written by hand as pipeline fan-out — see [Workflow Patterns](../ml-pipelines/workflow-patterns.md) for the shape of that.
+- **No managed Ray Dashboard.** Reaching the dashboard means finding the service and port-forwarding to it yourself.
+- **Effectively one worker group.** The `RayCluster` resource takes a list of worker groups, and a `RayTask` always produces exactly one. Multiple heterogeneous groups are not something this page can recommend yet, since every generated group takes its name from the cluster rather than from its own `nodeType`.
+
+Ray job launch, persistent Ray clusters via the `RayCluster` resource, and federated multi-cluster dispatch are all listed as available on the [roadmap](../../getting-started/roadmap.md). The gaps above are not currently on it, so the honest answer is that they are open rather than scheduled.
+
+## What's next
+
+- [Register a compute cluster](../../operator-guides/setup/register-a-compute-cluster-to-michelangelo-control-plane.md) — required before any Ray workload can be dispatched, and the step most likely to surprise a KubeRay user
+- [Running Uniflow Pipelines](../ml-pipelines/running-uniflow.md) — local and remote execution, and how to reach a running cluster for debugging
+- [CLI Reference](../reference/cli.md) — the full set of resources and operations
+- [Roadmap](../../getting-started/roadmap.md) — what is shipped and what is planned


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**
Adds a `Migration Guides` section under the user guides, with one guide in it: `docs/user-guides/migration/migrate-from-kuberay.md`.

The guide follows the structure proposed in #1705 -- a concept mapping table, worked before/after manifests, and a gaps section -- and reuses the three-column shape of the overview's ML Workflow Mapping rather than inventing a new one.

**Why?**
#1705 asked for path-shaped docs for people arriving with an existing stack. There are already three places that do concept-level mapping: the overview's ML Workflow Mapping, the glossary's Concept mapping, and the FAQ's "how do I migrate from my current ML stack". None of them map at the resource level, which is the level a KubeRay user actually thinks at -- they have a `RayCluster` YAML in a repo and want to know what it becomes. The guide links to all three instead of restating them.

KubeRay went first because it is the stack where this project's behaviour is most concrete and therefore most verifiable. Ray job launch, persistent Ray clusters via the `RayCluster` resource, and federated dispatch are all listed as available on the roadmap, so most of the page describes shipped behaviour rather than intent.

The framing the guide lands on is that this is not a migration away from KubeRay. `mapRayCluster` builds a real `rayv1.RayCluster` using the upstream operator's own Go types, so the reader keeps their operator and gains a control plane above it. That seemed like the single most useful thing to tell someone evaluating the move, and it is not currently stated anywhere in the docs.

**How did you test it?**
I did not run `bun run build`, so the docs build has not been verified locally -- please treat that as unchecked. Everything else was verified by reading the source:

- All eight internal links were resolved by hand from the new file's location, and both `#anchor` targets were confirmed against real headings (`glossary.md:153`, `overview.md:50`).
- Every field name in the "after" manifests was checked against `proto/api/v2/ray_cluster.proto` and `ray_job.proto`, and cross-checked against the real fixtures at `scripts/ingester/ingester-test-crs/09-raycluster.yaml` and `10-rayjob.yaml`.
- Both Python imports were checked against the real definitions. `RayTask` is re-exported from `michelangelo.uniflow.plugins.ray`, which matches how every example in the repo imports it.
- The `RayTask` field list is the complete dataclass, not a selection.
- Each claim in the gaps section was checked in the negative: `enableInTreeAutoscaling` appears nowhere, `rayservice` appears nowhere, and nothing under `python/` imports Ray Tune.
- The page was then reviewed line by line against `docs/contributing/documentation-guide.md`.

**Potential risks**
Low, but three things are worth a reviewer's judgement rather than mine.

**Placement.** This adds a new section rather than a new page in an existing one. `docs/getting-started/` has `sidebar_position` 1 through 9 already taken, so a guide there lands after Support and Community, which seemed like the wrong home for something #1705 describes as high leverage. `docs/user-guides/` children use 1 through 4, so a new section at 5 needs no renumbering of anything that exists. If you would rather these live somewhere else, moving them is cheap now and gets harder once all three exist.

**One guide, not three.** #1705 proposes one PR per source stack so each can be reviewed by whoever knows that ecosystem. This is the first. Kubeflow Trainer and SageMaker/Vertex would follow the same shape, and I would rather find out this format is wrong now than after writing all three.

**One thing the guide contradicts.** It states there is no Ray Tune integration, which is what the code shows -- nothing under `python/` imports it. But `overview.md:59` lists "Uniflow tasks with Ray Tune" as the hyperparameter tuning equivalent. I left it alone rather than widen a docs PR into someone else's area, but the two cannot both be right, and a reader following the cross-link will hit the disagreement. Happy to fix the overview in this PR, or separately, or to be told the integration exists somewhere I did not find.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**
None.

**Documentation Changes**
This PR is the documentation change. New section `Migration Guides` under User Guides, with one page for KubeRay.
