### PR TITLE
feat(ui): change steps to ongoing operations

### DIFF
--- a/javascript/packages/core/config/entities/deployment/__tests__/deployment-page.test.tsx
+++ b/javascript/packages/core/config/entities/deployment/__tests__/deployment-page.test.tsx
@@ -96,7 +96,7 @@ describe('Deployment detail page', () => {
       buildWrapper([
         getErrorProviderWrapper(),
         getRouterWrapper({
-          location: '/myproject/deploy/deployments/sentiment-deployment/stages',
+          location: '/myproject/deploy/deployments/sentiment-deployment/ongoing-operations',
         }),
         getServiceProviderWrapper({
           request: createQueryMockRouter({
@@ -119,7 +119,7 @@ describe('Deployment detail page', () => {
       buildWrapper([
         getErrorProviderWrapper(),
         getRouterWrapper({
-          location: '/myproject/deploy/deployments/sentiment-deployment/stages',
+          location: '/myproject/deploy/deployments/sentiment-deployment/ongoing-operations',
         }),
         getServiceProviderWrapper({
           request: createQueryMockRouter({
@@ -150,7 +150,7 @@ describe('Deployment detail page', () => {
       ])
     );
 
-    expect(await screen.findByRole('tab', { name: 'Stages' })).toBeInTheDocument();
+    expect(await screen.findByRole('tab', { name: 'Ongoing operations' })).toBeInTheDocument();
     await screen.findAllByText('Validation');
     await screen.findAllByText('Placement');
   });
@@ -161,7 +161,7 @@ describe('Deployment detail page', () => {
       buildWrapper([
         getErrorProviderWrapper(),
         getRouterWrapper({
-          location: '/myproject/deploy/deployments/sentiment-deployment/stages',
+          location: '/myproject/deploy/deployments/sentiment-deployment/ongoing-operations',
         }),
         getServiceProviderWrapper({
           request: createQueryMockRouter({
@@ -199,7 +199,7 @@ describe('Deployment detail page', () => {
       buildWrapper([
         getErrorProviderWrapper(),
         getRouterWrapper({
-          location: '/myproject/deploy/deployments/sentiment-deployment/stages',
+          location: '/myproject/deploy/deployments/sentiment-deployment/ongoing-operations',
         }),
         getServiceProviderWrapper({
           request: createQueryMockRouter({

--- a/javascript/packages/core/config/entities/deployment/detail.ts
+++ b/javascript/packages/core/config/entities/deployment/detail.ts
@@ -19,12 +19,12 @@ export const DEPLOYMENT_DETAIL_CONFIG: DetailViewConfig = {
   ],
   pages: [
     {
-      id: 'stages',
-      label: 'Stages',
+      id: 'ongoing-operations',
+      label: 'Ongoing operations',
       type: 'execution',
       emptyState: {
         title: 'No deployment rollout in progress',
-        description: 'Stages will appear here when a deployment rollout is in progress',
+        description: 'Ongoing operations will appear here when a deployment rollout is in progress',
       },
       tasks: {
         accessor: (data: {


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
On the deployments detail page, we're changing the name of the "Steps" tab to "Ongoing Operations". The url path changed from `/stages` to `/ongoing-operations`.

| Before | After |
| -- | -- |
| <img width="1508" height="912" alt="image" src="https://github.com/user-attachments/assets/407a3057-cb36-420e-88a0-f240b8223fd0" /> | <img width="1510" height="913" alt="image" src="https://github.com/user-attachments/assets/84d60399-e402-4a7a-80c4-28a5a9a5f22e" /> |

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Visually and unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Does this PR introduce a breaking change? Check all that apply. -->
**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
N/A
<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
N/A