### PR TITLE
feat(ui): show Coming soon badge on phase cards

### DIFF
--- a/javascript/packages/core/components/views/project/__tests__/project-detail.test.tsx
+++ b/javascript/packages/core/components/views/project/__tests__/project-detail.test.tsx
@@ -139,7 +139,7 @@ describe('ProjectDetail', () => {
     expect(screen.queryByRole('button')).not.toBeInTheDocument();
   });
 
-  test('comingSoon phase shows message and suppresses entity list', async () => {
+  test('comingSoon phase shows a "Coming soon" badge and disables its entity list', async () => {
     render(
       <ProjectDetail
         phases={[
@@ -172,7 +172,8 @@ describe('ProjectDetail', () => {
     await screen.findByText('Deploy & Predict');
 
     expect(screen.getByText('Coming soon')).toBeInTheDocument();
-    expect(screen.queryByText('Endpoints')).not.toBeInTheDocument();
+    expect(screen.getByText('Endpoints')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Endpoints' })).not.toBeInTheDocument();
   });
 
   test('phase description and learn more button render when docUrl is set', async () => {

--- a/javascript/packages/core/components/views/project/components/phase-card.tsx
+++ b/javascript/packages/core/components/views/project/components/phase-card.tsx
@@ -1,16 +1,12 @@
 import { useNavigate } from 'react-router-dom-v5-compat';
 import { useStyletron } from 'baseui';
-import {
-  Badge,
-  COLOR as BADGE_COLOR,
-  HIERARCHY as BADGE_HIERARCHY,
-  SHAPE as BADGE_SHAPE,
-} from 'baseui/badge';
 import { Button, KIND, SHAPE, SIZE } from 'baseui/button';
 
 import { Box } from '#core/components/box/box';
 import { Icon } from '#core/components/icon/icon';
 import { Link } from '#core/components/link/link';
+import { TAG_COLOR, TAG_SIZE } from '#core/components/tag/constants';
+import { Tag } from '#core/components/tag/tag';
 import { capitalizeFirstLetter } from '#core/utils/string-utils';
 
 import type { PhaseConfig } from '#core/types/common/studio-types';
@@ -30,12 +26,9 @@ export function PhaseCard(props: PhaseConfig & { projectId: string }) {
           <Icon name={icon} size={theme.sizing.scale500} />
           {name}
           {isComingSoon && (
-            <Badge
-              content="Coming soon"
-              color={BADGE_COLOR.accent}
-              hierarchy={BADGE_HIERARCHY.secondary}
-              shape={BADGE_SHAPE.pill}
-            />
+            <Tag color={TAG_COLOR.blue} size={TAG_SIZE.xSmall} closeable={false}>
+              Coming soon
+            </Tag>
           )}
         </div>
       }

--- a/javascript/packages/core/components/views/project/components/phase-card.tsx
+++ b/javascript/packages/core/components/views/project/components/phase-card.tsx
@@ -1,5 +1,11 @@
 import { useNavigate } from 'react-router-dom-v5-compat';
 import { useStyletron } from 'baseui';
+import {
+  Badge,
+  COLOR as BADGE_COLOR,
+  HIERARCHY as BADGE_HIERARCHY,
+  SHAPE as BADGE_SHAPE,
+} from 'baseui/badge';
 import { Button, KIND, SHAPE, SIZE } from 'baseui/button';
 
 import { Box } from '#core/components/box/box';
@@ -23,6 +29,14 @@ export function PhaseCard(props: PhaseConfig & { projectId: string }) {
         <div className={css({ display: 'flex', alignItems: 'center', gap: theme.sizing.scale400 })}>
           <Icon name={icon} size={theme.sizing.scale500} />
           {name}
+          {isComingSoon && (
+            <Badge
+              content="Coming soon"
+              color={BADGE_COLOR.accent}
+              hierarchy={BADGE_HIERARCHY.secondary}
+              shape={BADGE_SHAPE.pill}
+            />
+          )}
         </div>
       }
       description={
@@ -44,50 +58,36 @@ export function PhaseCard(props: PhaseConfig & { projectId: string }) {
         )
       }
     >
-      {isComingSoon ? (
-        <div
-          className={css({
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
-            flex: '1',
-            color: theme.colors.contentTertiary,
-          })}
-        >
-          Coming soon
-        </div>
-      ) : (
-        <div className={css({ display: 'flex', flexDirection: 'column' })}>
-          {entities.map((entity) => {
-            const isEntityDisabled = isPhaseDisabled || entity.state === 'disabled';
+      <div className={css({ display: 'flex', flexDirection: 'column' })}>
+        {entities.map((entity) => {
+          const isEntityDisabled = isPhaseDisabled || entity.state === 'disabled';
 
-            if (isEntityDisabled) {
-              return (
-                <span
-                  key={entity.id}
-                  className={css({
-                    ...theme.typography.ParagraphSmall,
-                    cursor: 'default',
-                    color: theme.colors.contentTertiary,
-                  })}
-                >
-                  {capitalizeFirstLetter(entity.name)}
-                </span>
-              );
-            }
-
+          if (isEntityDisabled) {
             return (
-              <Link
+              <span
                 key={entity.id}
-                href={`/${projectId}/${id}/${entity.id}`}
-                overrides={{ Link: { style: theme.typography.ParagraphSmall } }}
+                className={css({
+                  ...theme.typography.ParagraphSmall,
+                  cursor: 'default',
+                  color: theme.colors.contentTertiary,
+                })}
               >
                 {capitalizeFirstLetter(entity.name)}
-              </Link>
+              </span>
             );
-          })}
-        </div>
-      )}
+          }
+
+          return (
+            <Link
+              key={entity.id}
+              href={`/${projectId}/${id}/${entity.id}`}
+              overrides={{ Link: { style: theme.typography.ParagraphSmall } }}
+            >
+              {capitalizeFirstLetter(entity.name)}
+            </Link>
+          );
+        })}
+      </div>
 
       {entities.some((entity) => entity.state === 'active') && !isPhaseDisabled && (
         <Button


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
Phase cards in the `comingSoon` state now show a small "Coming soon" badge next to the phase name instead of replacing the entire card body with plain centered text. The phase's configured entities render underneath in their normal disabled styling, the same treatment already used for a fully `disabled` phase.

**Why?**
The previous full-body text state hid the phase's entity list and looked boring. A small inline badge lets the card stay informative about what's coming while clearly signaling the phase isn't live yet.

**How did you test it?**
**After**
<img width="1393" height="1072" alt="Screenshot 2026-08-12 at 9 14 04 AM" src="https://github.com/user-attachments/assets/6fca0a79-19bd-47c3-a614-1cf46c96198c" />

**Before**
<img width="1393" height="1072" alt="Screenshot 2026-08-12 at 8 57 18 AM" src="https://github.com/user-attachments/assets/167e35cb-9de1-435e-8a03-edc15c663534" />

**Breaking Changes**
- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**
N/A

**Documentation Changes**
N/A