### PR TITLE
refactor(core): rename ErrorView to Signpost

### DIFF
--- a/javascript/packages/core/components/signpost/signpost.tsx
+++ b/javascript/packages/core/components/signpost/signpost.tsx
@@ -3,15 +3,15 @@ import { Button, KIND, SHAPE } from 'baseui/button';
 import { HeadingXSmall, ParagraphMedium } from 'baseui/typography';
 import { omit } from 'lodash';
 
-import { ErrorViewContainer } from './styled-components';
+import { SignpostContainer } from './styled-components';
 
-import type { ErrorViewProps } from './types';
-export function ErrorView(props: ErrorViewProps) {
+import type { SignpostProps } from './types';
+export function Signpost(props: SignpostProps) {
   const [css] = useStyletron();
   const { illustration, title, description, buttonConfig } = props;
 
   return (
-    <ErrorViewContainer>
+    <SignpostContainer>
       {illustration}
       <HeadingXSmall className={css({ margin: 0 })}>{title}</HeadingXSmall>
       {description && (
@@ -22,6 +22,6 @@ export function ErrorView(props: ErrorViewProps) {
           {buttonConfig.content}
         </Button>
       )}
-    </ErrorViewContainer>
+    </SignpostContainer>
   );
 }

--- a/javascript/packages/core/components/signpost/styled-components.ts
+++ b/javascript/packages/core/components/signpost/styled-components.ts
@@ -1,6 +1,6 @@
 import { styled } from 'baseui';
 
-export const ErrorViewContainer = styled('div', ({ $theme }) => ({
+export const SignpostContainer = styled('div', ({ $theme }) => ({
   textAlign: 'center',
   margin: '90px auto',
   maxWidth: '450px',

--- a/javascript/packages/core/components/signpost/types.ts
+++ b/javascript/packages/core/components/signpost/types.ts
@@ -1,7 +1,7 @@
 import type { ButtonProps } from 'baseui/button';
 import type { ReactNode } from 'react';
 
-export type ErrorViewProps = {
+export type SignpostProps = {
   illustration: ReactNode;
   title: string;
   description?: string | null;

--- a/javascript/packages/core/components/table/components/table-empty-state/table-empty-state.tsx
+++ b/javascript/packages/core/components/table/components/table-empty-state/table-empty-state.tsx
@@ -1,4 +1,4 @@
-import { ErrorView } from '#core/components/error-view/error-view';
+import { Signpost } from '#core/components/signpost/signpost';
 import { TableStateWrapper } from '../table-state-wrapper';
 
 import type { TableEmptyStateProps } from './types';
@@ -6,7 +6,7 @@ import type { TableEmptyStateProps } from './types';
 export function TableEmptyState({ emptyState }: TableEmptyStateProps) {
   return (
     <TableStateWrapper>
-      <ErrorView
+      <Signpost
         illustration={emptyState.icon}
         title={emptyState.title}
         description={emptyState.content}

--- a/javascript/packages/core/components/table/components/table-error-state/table-error-state.tsx
+++ b/javascript/packages/core/components/table/components/table-error-state/table-error-state.tsx
@@ -1,6 +1,6 @@
-import { ErrorView } from '#core/components/error-view/error-view';
 import { CircleExclamationMark } from '#core/components/illustrations/circle-exclamation-mark/circle-exclamation-mark';
 import { CircleExclamationMarkKind } from '#core/components/illustrations/circle-exclamation-mark/types';
+import { Signpost } from '#core/components/signpost/signpost';
 import { GrpcStatusCode } from '#core/constants/grpc-status-codes';
 import { TableStateWrapper } from '../table-state-wrapper';
 
@@ -13,7 +13,7 @@ export function TableErrorState({ error }: TableErrorStateProps) {
     case GrpcStatusCode.DEADLINE_EXCEEDED:
       return (
         <TableStateWrapper>
-          <ErrorView
+          <Signpost
             illustration={
               <CircleExclamationMark
                 kind={CircleExclamationMarkKind.ERROR}
@@ -31,7 +31,7 @@ export function TableErrorState({ error }: TableErrorStateProps) {
     default:
       return (
         <TableStateWrapper>
-          <ErrorView
+          <Signpost
             illustration={
               <CircleExclamationMark
                 kind={CircleExclamationMarkKind.ERROR}

--- a/javascript/packages/core/components/table/components/table-no-results-state/table-no-results-state.tsx
+++ b/javascript/packages/core/components/table/components/table-no-results-state/table-no-results-state.tsx
@@ -1,5 +1,5 @@
-import { ErrorView } from '#core/components/error-view/error-view';
 import { QuestionMark } from '#core/components/illustrations/question-mark/question-mark';
+import { Signpost } from '#core/components/signpost/signpost';
 import { TableStateWrapper } from '../table-state-wrapper';
 
 import type { TableNoResultsStateProps } from './types';
@@ -7,7 +7,7 @@ import type { TableNoResultsStateProps } from './types';
 export function TableNoResultsState({ clearFilters }: TableNoResultsStateProps) {
   return (
     <TableStateWrapper>
-      <ErrorView
+      <Signpost
         illustration={<QuestionMark />}
         title="There is no information available for selected filters"
         description="Please change or remove filters to see the information."

--- a/javascript/packages/core/components/views/execution/execution.tsx
+++ b/javascript/packages/core/components/views/execution/execution.tsx
@@ -1,9 +1,9 @@
 import { useStyletron } from 'baseui';
 
 import { Box } from '#core/components/box/box';
-import { ErrorView } from '#core/components/error-view/error-view';
 import { CircleExclamationMark } from '#core/components/illustrations/circle-exclamation-mark/circle-exclamation-mark';
 import { CircleExclamationMarkKind } from '#core/components/illustrations/circle-exclamation-mark/types';
+import { Signpost } from '#core/components/signpost/signpost';
 import { TaskDetails } from './components/task-details/task-details';
 import { TaskFlow } from './components/task-flow';
 import { TaskStateIcon } from './components/task-state-icon';
@@ -29,7 +29,7 @@ export function Execution<
 
   if (!taskList.length) {
     return (
-      <ErrorView
+      <Signpost
         illustration={
           <CircleExclamationMark
             height="64px"

--- a/javascript/packages/core/components/views/phase-entity-view/phase-entity-view.tsx
+++ b/javascript/packages/core/components/views/phase-entity-view/phase-entity-view.tsx
@@ -3,10 +3,10 @@ import { useNavigate } from 'react-router-dom-v5-compat';
 import { useStyletron } from 'baseui';
 import { Tab, Tabs } from 'baseui/tabs-motion';
 
-import { ErrorView } from '#core/components/error-view/error-view';
 import { CircleExclamationMark } from '#core/components/illustrations/circle-exclamation-mark/circle-exclamation-mark';
 import { CircleExclamationMarkKind } from '#core/components/illustrations/circle-exclamation-mark/types';
 import { PageHeader } from '#core/components/page-header/page-header';
+import { Signpost } from '#core/components/signpost/signpost';
 import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
 import { EntityTable } from './entity-table';
 
@@ -49,7 +49,7 @@ export function PhaseEntityView<T extends object = object>({
     // Return null to avoid flashing the error view during that redirect.
     if (!currentEntity) return null;
     return (
-      <ErrorView
+      <Signpost
         buttonConfig={{
           onClick: () => navigate(`/${projectId}`),
           content: 'Go home',

--- a/javascript/packages/core/router/entity-detail-route.tsx
+++ b/javascript/packages/core/router/entity-detail-route.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import { useStyletron } from 'baseui';
 
-import { ErrorView } from '#core/components/error-view/error-view';
 import { CircleExclamationMark } from '#core/components/illustrations/circle-exclamation-mark/circle-exclamation-mark';
 import { CircleExclamationMarkKind } from '#core/components/illustrations/circle-exclamation-mark/types';
 import { Row } from '#core/components/row/row';
+import { Signpost } from '#core/components/signpost/signpost';
 import { DetailViewPageRenderer } from '#core/components/views/detail-view/components/detail-view-page-renderer/detail-view-page-renderer';
 import { DetailViewPages } from '#core/components/views/detail-view/components/detail-view-pages/detail-view-pages';
 import { DetailView } from '#core/components/views/detail-view/detail-view';
@@ -78,7 +78,7 @@ export function EntityDetailRoute({ phases = PHASES }: { phases?: Record<string,
 
   if (error) {
     return (
-      <ErrorView
+      <Signpost
         title="Entity not found"
         description={`Could not load ${entity} "${entityId}". ${error.message}`}
         illustration={

--- a/javascript/packages/core/router/phase-list-route.tsx
+++ b/javascript/packages/core/router/phase-list-route.tsx
@@ -1,9 +1,9 @@
 import { useNavigate } from 'react-router-dom-v5-compat';
 import { useStyletron } from 'baseui';
 
-import { ErrorView } from '#core/components/error-view/error-view';
 import { CircleExclamationMark } from '#core/components/illustrations/circle-exclamation-mark/circle-exclamation-mark';
 import { CircleExclamationMarkKind } from '#core/components/illustrations/circle-exclamation-mark/types';
+import { Signpost } from '#core/components/signpost/signpost';
 import { PhaseEntityView } from '#core/components/views/phase-entity-view/phase-entity-view';
 import { isListableEntity } from '#core/components/views/phase-entity-view/utils';
 import { PHASES } from '#core/config/phases/phases';
@@ -27,7 +27,7 @@ export function PhaseListRoute({ phases = PHASES }: { phases?: Record<string, Ph
 
   if (!(phase in phases)) {
     return (
-      <ErrorView
+      <Signpost
         title="Phase not found"
         description={`Phase "${phase}" configuration not found. Available phases: ${Object.keys(phases).join(', ')}`}
         illustration={
@@ -49,7 +49,7 @@ export function PhaseListRoute({ phases = PHASES }: { phases?: Record<string, Ph
 
   if (listableEntities.length === 0) {
     return (
-      <ErrorView
+      <Signpost
         title="Phase has no active entities"
         description={`Phase "${phase}" has no active entities with list views configured.`}
         illustration={


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
Renamed the `ErrorView` component (and its container/types) to `Signpost`, updating the 7 call sites that use it: table empty/error/no-results states, two not-found routes, the phase-entity tab-redirect fallback, and the empty execution list. Pure rename — no behavior, prop, or styling changes.

**Why?**
`ErrorView` was used for genuine errors, but also for empty tables and no-results filtering, which aren't errors. The name implied every usage was handling a failure, when the component's actual job is generic: swap in an illustration, a title, and an optional description/action in place of normal content. `Signpost` names that shared purpose instead of one narrow use case it happened to originate from.

**How did you test it?**
Ran the full JS test suite, typecheck, and lint — all passing (1400 tests). No test assertions needed to change since this is a pure rename with identical rendered output.

**Potential risks**
Low — mechanical rename with no logic changes; verified no other references to `ErrorView`/`error-view` remain in the codebase.

**Breaking Changes**
- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**
N/A

**Documentation Changes**
N/A