### PR TITLE
fix(docs,examples): correct Lightning trainer imports and parameters

### DIFF
--- a/docs/user-guides/getting-started/prepare-your-data.md
+++ b/docs/user-guides/getting-started/prepare-your-data.md
@@ -137,10 +137,10 @@ def use_prepared_data(datasets: dict):
 
 ```py
 trainer_param = LightningTrainerParam(
-    create_model=create_model_function,
-    model_kwargs=model_config,
+    create_model_fn=create_model_function,
+    create_model_fn_kwargs=model_config,
     train_data=train_dv.value,
-    validation_data=val_dv.value,
+    val_data=val_dv.value,
     batch_size=32,
     num_epochs=10
 )

--- a/docs/user-guides/train-and-deploy-models/train-and-register-a-model.md
+++ b/docs/user-guides/train-and-deploy-models/train-and-register-a-model.md
@@ -86,10 +86,10 @@ To scale training across CPUs/GPUs, wrap your training task using **RayTask**.
 
 ```py
 from michelangelo.lib.trainer.torch.pytorch_lightning.lightning_trainer import (
-    LightningTrainer, LightningTrainerParam, create_run_config, create_scaling_config
+    LightningTrainer, LightningTrainerParam
 )
-from michelangelo.uniflow.plugins.ray import RayTask
-from ray.train import CheckpointConfig
+from michelangelo.uniflow.plugins.ray import RayTask, create_run_config
+from ray.train import CheckpointConfig, ScalingConfig
 
 @uniflow.task(
     config=RayTask(
@@ -119,9 +119,9 @@ def train_distributed_model(
     validation_data = validation_dv.value
 
     # Scaling config
-    scaling_config = create_scaling_config(
-        trainer_cpu=2,
-        cpu_per_worker=4,
+    scaling_config = ScalingConfig(
+        trainer_resources={"CPU": 2},
+        resources_per_worker={"CPU": 4},
         num_workers=num_workers,
         use_gpu=use_gpu,
     )
@@ -138,13 +138,13 @@ def train_distributed_model(
 
     # Lightning trainer parameters
     trainer_param = LightningTrainerParam(
-        create_model=create_model_function,
-        model_kwargs={
+        create_model_fn=create_model_function,
+        create_model_fn_kwargs={
             "model_name": model_name,
             "learning_rate": learning_rate,
         },
         train_data=train_data,
-        validation_data=validation_data,
+        val_data=validation_data,
         batch_size=batch_size,
         num_epochs=num_epochs,
         lightning_trainer_kwargs={

--- a/python/examples/gpt_oss_20b_finetune/simple_train.py
+++ b/python/examples/gpt_oss_20b_finetune/simple_train.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 import mlflow
 from pytorch_lightning.loggers import MLFlowLogger
-from ray.train import CheckpointConfig
+from ray.train import CheckpointConfig, ScalingConfig
 from ray.train.lightning import RayFSDPStrategy
 
 import michelangelo.uniflow.core as uniflow
@@ -14,10 +14,8 @@ from examples.gpt_oss_20b_finetune.model import create_gpt_model
 from michelangelo.lib.trainer.torch.pytorch_lightning.lightning_trainer import (
     LightningTrainer,
     LightningTrainerParam,
-    create_run_config,
-    create_scaling_config,
 )
-from michelangelo.uniflow.plugins.ray import RayTask
+from michelangelo.uniflow.plugins.ray import RayTask, create_run_config
 from michelangelo.workflow.variables import DatasetVariable
 
 if TYPE_CHECKING:
@@ -124,9 +122,9 @@ def simple_train_gpt(
         log.info("No CUDA available - using CPU")
 
     # Create scaling configuration for Ray
-    scaling_config = create_scaling_config(
-        trainer_cpu=1,
-        cpu_per_worker=2,
+    scaling_config = ScalingConfig(
+        trainer_resources={"CPU": 1},
+        resources_per_worker={"CPU": 2},
         num_workers=num_workers,
         use_gpu=use_gpu,
     )
@@ -212,15 +210,15 @@ def simple_train_gpt(
 
     # Create Lightning trainer parameters
     trainer_param = LightningTrainerParam(
-        create_model=create_gpt_model,
-        model_kwargs={
+        create_model_fn=create_gpt_model,
+        create_model_fn_kwargs={
             "model_name": model_name,
             "learning_rate": learning_rate,
             "use_lora": use_lora,
             "lora_rank": lora_rank,
         },
         train_data=train_data,
-        validation_data=validation_data,
+        val_data=validation_data,
         batch_size=batch_size,
         num_epochs=num_epochs,
         lightning_trainer_kwargs=lightning_trainer_kwargs,
@@ -248,9 +246,7 @@ def simple_train_gpt(
     log.info(f"✅ Training completed, MLflow run: {run_id}")
 
     # Return checkpoint path for evaluation (much simpler!)
-    checkpoint = (
-        result.get_best_checkpoint(metric="val_loss", mode="min") or result.checkpoint
-    )
+    checkpoint = result["checkpoint_path"]
 
     # Convert Checkpoint object to directory path
     if hasattr(checkpoint, "as_directory"):


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
Fixes the Lightning trainer snippet in two docs and one example -- `docs/user-guides/train-and-deploy-models/train-and-register-a-model.md`, `docs/user-guides/getting-started/prepare-your-data.md`, and `python/examples/gpt_oss_20b_finetune/simple_train.py`.

All three imported `create_scaling_config` and/or `create_run_config` from `michelangelo.lib.trainer.torch.pytorch_lightning.lightning_trainer`, which defines neither. `create_run_config` is real, just imported from the wrong place. `create_scaling_config` isn't real at all outside one unrelated local helper with a different signature in `california_housing_xgb/train.py`.

They also passed `LightningTrainerParam` kwargs that don't match its actual fields: `create_model` instead of `create_model_fn`, `model_kwargs` instead of `create_model_fn_kwargs`, `validation_data` instead of `val_data`.

`simple_train.py` had a second, independent bug: it read the trainer's return value as a Ray Train `Result` object (`result.get_best_checkpoint(...)`), but `LightningTrainer.train()` returns a plain dict, so that line would raise `AttributeError`.

**Why?**
Copying any of these three snippets as written raises `ImportError` before training even starts. `train-and-register-a-model.md` is the primary "how do I train with Ray" doc, so this is the first thing a lot of people will hit.

**How did you test it?**
Not run -- verified by reading source. `create_run_config`'s real location and signature: `python/michelangelo/uniflow/plugins/ray/run_config.py:27`. `LightningTrainerParam`'s real fields: `python/michelangelo/lib/trainer/torch/pytorch_lightning/lightning_trainer.py:79-98`. `train()`'s real return shape: same file, `lightning_trainer.py:301-304`. Grepped for every other `validation_data=` call site in the repo to make sure I wasn't fixing an intentional API elsewhere -- the one hit left (`california_housing_xgb/preprocess.py:86`) is an unrelated dataclass field, not this one.

**Potential risks**
None to running code -- this only touches docs and one example script, no library code changed.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**
None.

**Documentation Changes**
Corrects the Lightning trainer example in two user guides and one example script to use real imports and real parameter names.
