### PR TITLE
docs: correct Ray Tune and Ray autoscaling claims

### DIFF
--- a/docs/getting-started/faq.md
+++ b/docs/getting-started/faq.md
@@ -115,7 +115,8 @@ A: Multiple approaches:
 A: Automatically:
 - Online inference autoscales based on request volume
 - Batch jobs use spot instances for cost savings
-- Ray clusters elastically scale workers based on workload
+
+Ray clusters run at a fixed worker count today. A cluster resource can declare a min/max range, but the in-tree autoscaler isn't enabled yet, so the cluster stays at its minimum size for the life of the job.
 
 **Q: What if my dataset doesn't fit in memory?**
 

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -56,7 +56,7 @@ If you're coming from other ML platforms, here's how familiar concepts map to Mi
 | **Data Preparation** | Pandas, Spark notebooks | **MA Studio Data Prep** or **Uniflow tasks** with Ray/Spark * |
 | **Experiment Tracking** | MLflow, Weights & Biases | **Model Registry** with automatic versioning |
 | **Model Training** | Custom scripts, Kubeflow Pipelines | **MA Studio Training** (UI) or **CanvasFlex/Uniflow workflows** (code) |
-| **Hyperparameter Tuning** | Optuna, Ray Tune | **Uniflow tasks** with Ray Tune * |
+| **Hyperparameter Tuning** | Optuna, Ray Tune | **Uniflow tasks** with hand-written sweeps * |
 | **Model Storage** | S3 buckets, model registries | **Michelangelo AI Model Registry** with metadata & plugin storage |
 | **Batch Inference** | Airflow + custom scripts | **Deployment to batch endpoint** with offline inference pipeline and Ray / Triton Inference * |
 | **Online Serving** | TorchServe, TensorFlow Serving | **Deployment to inference server** with Triton Inference Server * |


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**
Two one-line corrections in `docs/getting-started/`:

- `overview.md`'s ML Workflow Mapping table listed the hyperparameter-tuning equivalent as "Uniflow tasks with Ray Tune". Changed to "Uniflow tasks with hand-written sweeps".
- `faq.md`'s scaling answer listed "Ray clusters elastically scale workers based on workload" under things that happen automatically. Replaced with a note that clusters run at a fixed worker count today, since the autoscaler isn't enabled.

**Why?**
Neither claim matches the code. Nothing under `python/` imports `ray.tune`, and there's no HPO plugin -- sweeps are hand-written pipeline fan-out (see [Workflow Patterns](../user-guides/ml-pipelines/workflow-patterns.md)). Separately, `enableInTreeAutoscaling` is never set anywhere in the repo, and worker group specs set `Replicas` to `minInstances`, so a cluster stays at its minimum size rather than scaling with load.

Found both while writing the KubeRay migration guide in #1783 -- didn't want to fix them inside a docs-structure PR for an unrelated page, so they're here as their own small change.

**How did you test it?**
Not run -- verified by reading source. `grep -rn "ray\.tune\|from ray import tune" python/` returns nothing. `grep -rn "enableInTreeAutoscaling"` across the repo returns nothing, and `getWorkerGroupSpecs` (`go/components/jobs/client/k8sengine/ray.go:172-174`) sets `Replicas: MinInstances`.

**Potential risks**
None -- docs only, two sentences, no structural change.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**
None.

**Documentation Changes**
This PR is the documentation change -- corrects two inaccurate capability claims in the overview and FAQ.
