### PR TITLE
fix(ui): block entity navigation for disabled/coming-soon phases in menu drawer

### DIFF
--- a/javascript/packages/core/components/breadcrumb-bar/menu-drawer.tsx
+++ b/javascript/packages/core/components/breadcrumb-bar/menu-drawer.tsx
@@ -4,6 +4,7 @@ import { Button, KIND, SHAPE, SIZE } from 'baseui/button';
 import { ANCHOR, Drawer } from 'baseui/drawer';
 
 import { Icon } from '#core/components/icon/icon';
+import { TAG_COLOR } from '#core/components/tag/constants';
 import { Tag } from '#core/components/tag/tag';
 import { PhaseEntityList } from './phase-entity-list';
 import { PhaseHeader, TopLevelNavLink } from './styled-components';
@@ -101,7 +102,7 @@ export function MenuDrawer({ phases, projectId, topLevelLinks }: Props) {
                 {phase.icon && <Icon name={phase.icon} size="16px" title="" />}
                 {phase.name}
                 {phase.state === 'comingSoon' && (
-                  <Tag size="xSmall" closeable={false}>
+                  <Tag color={TAG_COLOR.blue} size="xSmall" closeable={false}>
                     Coming soon
                   </Tag>
                 )}

--- a/javascript/packages/core/components/breadcrumb-bar/phase-entity-list.tsx
+++ b/javascript/packages/core/components/breadcrumb-bar/phase-entity-list.tsx
@@ -26,7 +26,7 @@ export function PhaseEntityList({
   return (
     <ul className={css({ listStyleType: 'none', padding: 0, margin: 0 })}>
       {phase.entities.map((entity) => {
-        const isDisabled = entity.state !== 'active';
+        const isDisabled = phase.state !== 'active' || entity.state !== 'active';
         const isSelected = !isDisabled && currentPhase === phase.id && currentEntity === entity.id;
 
         return (


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
The breadcrumb menu drawer decided whether an entity link was clickable purely from the entity's own state, so an active entity nested under a disabled or coming-soon phase stayed navigable there, even though the phase card already blocked reaching it the same way. The drawer's disabled check now also accounts for the phase's own state, closing that gap.

Also updated the drawer's "Coming soon" tag to the same blue used on phase cards — the two had drifted to different colors.

**Why?**
A phase marked coming soon or disabled shouldn't be reachable from anywhere in the app, but the menu drawer offered a route around that restriction.

**How did you test it?**

https://github.com/user-attachments/assets/e6349f7a-a9a7-4aa3-b111-04f7c0a9f3c6



**Potential risks**
Low — this only tightens an existing disabled check and doesn't change behavior for active phases.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**
N/A

**Documentation Changes**
N/A
