### PR TITLE
feat(ui): Add delete pipeline functionality

### DIFF
--- a/javascript/packages/core/config/entities/pipeline/__tests__/pipeline.test.tsx
+++ b/javascript/packages/core/config/entities/pipeline/__tests__/pipeline.test.tsx
@@ -1,0 +1,172 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { PIPELINE_ENTITY_CONFIG } from '#core/config/entities/pipeline/pipeline';
+import { EntityDetailRoute } from '#core/router/entity-detail-route';
+import { PhaseListRoute } from '#core/router/phase-list-route';
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
+import { getErrorProviderWrapper } from '#core/test/wrappers/get-error-provider-wrapper';
+import { getIconProviderWrapper } from '#core/test/wrappers/get-icon-provider-wrapper';
+import { getInterpolationProviderWrapper } from '#core/test/wrappers/get-interpolation-provider-wrapper';
+import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
+import {
+  createQueryMockRouter,
+  getServiceProviderWrapper,
+} from '#core/test/wrappers/get-service-provider-wrapper';
+import { getSnackbarProviderWrapper } from '#core/test/wrappers/get-snackbar-provider-wrapper';
+
+import type { PhaseConfig } from '#core/types/common/studio-types';
+
+function buildPipeline() {
+  return { metadata: { name: 'eval-pipeline', namespace: 'ma-dev-test' }, spec: { owner: { name: 'me' } } };
+}
+
+function buildTestPhases(): Record<string, PhaseConfig> {
+  return {
+    train: { id: 'train', icon: 'train', name: 'Train', state: 'active', entities: [PIPELINE_ENTITY_CONFIG] },
+  };
+}
+
+// baseui's dialog dismiss button renders an icon component it internally names "Delete"
+// (unrelated to our action) with no aria-label, so it collides with the confirm button's
+// accessible name. Scope to the button-dock footer to find the real submit button.
+function getSubmitButton(dialog: HTMLElement) {
+  const footer = dialog.querySelector('[data-baseweb="button-dock"]');
+  if (!footer) throw new Error('Expected dialog to render a button-dock footer');
+  return within(footer as HTMLElement).getByRole('button', { name: 'Delete' });
+}
+
+describe('PIPELINE_ENTITY_CONFIG: delete action', () => {
+  describe('list view', () => {
+    function renderList(mockRequest: ReturnType<typeof createQueryMockRouter>) {
+      render(
+        <PhaseListRoute phases={buildTestPhases()} />,
+        buildWrapper([
+          getBaseProviderWrapper(),
+          getErrorProviderWrapper(),
+          getIconProviderWrapper(),
+          getInterpolationProviderWrapper(),
+          getRouterWrapper({ location: '/ma-dev-test/train/pipelines' }),
+          getServiceProviderWrapper({ request: mockRequest }),
+          getSnackbarProviderWrapper(),
+        ])
+      );
+    }
+
+    it('opens dialog to confirm deletion of pipeline and deletes pipeline', async () => {
+      const user = userEvent.setup();
+      const mockRequest = createQueryMockRouter({
+        ListPipeline: { pipelineList: { items: [buildPipeline()] } },
+        DeletePipeline: {},
+      });
+
+      renderList(mockRequest);
+
+      await user.click(await screen.findByRole('button', { name: 'Actions' }));
+      await user.click(await screen.findByRole('option', { name: 'Delete' }));
+
+      const dialog = await screen.findByRole('dialog', { name: 'Delete Pipeline' });
+      expect(within(dialog).getByText(/Delete pipeline/)).toHaveTextContent(
+        /Delete pipeline eval-pipeline\? This action cannot be undone\./
+      );
+
+      await user.click(getSubmitButton(dialog));
+
+      await waitFor(() => {
+        expect(mockRequest).toHaveBeenCalledWith(
+          'DeletePipeline',
+          { name: 'eval-pipeline', namespace: 'ma-dev-test' },
+          {}
+        );
+      });
+
+      expect(screen.getByText(/Current pathname: \/ma-dev-test\/train\/pipelines/)).toBeInTheDocument();
+    });
+
+    it('keeps the dialog open and shows the error when delete fails', async () => {
+      const user = userEvent.setup();
+      const mockRequest = createQueryMockRouter({
+        ListPipeline: { pipelineList: { items: [buildPipeline()] } },
+        DeletePipeline: new Error('Delete failed'),
+      });
+
+      renderList(mockRequest);
+
+      await user.click(await screen.findByRole('button', { name: 'Actions' }));
+      await user.click(await screen.findByRole('option', { name: 'Delete' }));
+      const dialog = await screen.findByRole('dialog', { name: 'Delete Pipeline' });
+      await user.click(getSubmitButton(dialog));
+
+      await within(dialog).findByText(/Test error/);
+      expect(screen.getByRole('dialog', { name: 'Delete Pipeline' })).toBeInTheDocument();
+    });
+  });
+
+  describe('pipeline detail page', () => {
+    function renderDetail(mockRequest: ReturnType<typeof createQueryMockRouter>) {
+      render(
+        <EntityDetailRoute phases={buildTestPhases()} />,
+        buildWrapper([
+          getBaseProviderWrapper(),
+          getErrorProviderWrapper(),
+          getIconProviderWrapper(),
+          getInterpolationProviderWrapper(),
+          getRouterWrapper({ location: '/ma-dev-test/train/pipelines/eval-pipeline/runs' }),
+          getServiceProviderWrapper({ request: mockRequest }),
+          getSnackbarProviderWrapper(),
+        ])
+      );
+    }
+
+    it('opens dialog to confirm deletion of pipeline, deletes pipeline and navigates to list view', async () => {
+      const user = userEvent.setup();
+      const mockRequest = createQueryMockRouter({
+        GetPipeline: { pipeline: buildPipeline() },
+        ListPipelineRun: { pipelineRunList: { items: [] } },
+        DeletePipeline: {},
+      });
+
+      renderDetail(mockRequest);
+
+      await user.click(await screen.findByRole('button', { name: 'Actions' }));
+      await user.click(await screen.findByRole('option', { name: 'Delete' }));
+
+      const dialog = await screen.findByRole('dialog', { name: 'Delete Pipeline' });
+      expect(within(dialog).getByText(/Delete pipeline/)).toHaveTextContent(
+        /Delete pipeline eval-pipeline\? This action cannot be undone\./
+      );
+
+      await user.click(getSubmitButton(dialog));
+
+      await waitFor(() => {
+        expect(mockRequest).toHaveBeenCalledWith(
+          'DeletePipeline',
+          { name: 'eval-pipeline', namespace: 'ma-dev-test' },
+          {}
+        );
+      });
+
+      expect(screen.getByText(/Current pathname: \/ma-dev-test\/train\/pipelines/)).toBeInTheDocument();
+    });
+
+    it('keeps the dialog open and shows the error when delete fails', async () => {
+      const user = userEvent.setup();
+      const mockRequest = createQueryMockRouter({
+        GetPipeline: { pipeline: buildPipeline() },
+        ListPipelineRun: { pipelineRunList: { items: [] } },
+        DeletePipeline: new Error('Delete failed'),
+      });
+
+      renderDetail(mockRequest);
+
+      await user.click(await screen.findByRole('button', { name: 'Actions' }));
+      await user.click(await screen.findByRole('option', { name: 'Delete' }));
+      const dialog = await screen.findByRole('dialog', { name: 'Delete Pipeline' });
+      await user.click(getSubmitButton(dialog));
+
+      await within(dialog).findByText(/Test error/);
+      expect(screen.getByRole('dialog', { name: 'Delete Pipeline' })).toBeInTheDocument();
+    });
+  });
+});

--- a/javascript/packages/core/config/entities/pipeline/__tests__/pipeline.test.tsx
+++ b/javascript/packages/core/config/entities/pipeline/__tests__/pipeline.test.tsx
@@ -19,12 +19,21 @@ import { getSnackbarProviderWrapper } from '#core/test/wrappers/get-snackbar-pro
 import type { PhaseConfig } from '#core/types/common/studio-types';
 
 function buildPipeline() {
-  return { metadata: { name: 'eval-pipeline', namespace: 'ma-dev-test' }, spec: { owner: { name: 'me' } } };
+  return {
+    metadata: { name: 'eval-pipeline', namespace: 'ma-dev-test' },
+    spec: { owner: { name: 'me' } },
+  };
 }
 
 function buildTestPhases(): Record<string, PhaseConfig> {
   return {
-    train: { id: 'train', icon: 'train', name: 'Train', state: 'active', entities: [PIPELINE_ENTITY_CONFIG] },
+    train: {
+      id: 'train',
+      icon: 'train',
+      name: 'Train',
+      state: 'active',
+      entities: [PIPELINE_ENTITY_CONFIG],
+    },
   };
 }
 
@@ -81,7 +90,9 @@ describe('PIPELINE_ENTITY_CONFIG: delete action', () => {
         );
       });
 
-      expect(screen.getByText(/Current pathname: \/ma-dev-test\/train\/pipelines/)).toBeInTheDocument();
+      expect(
+        screen.getByText(/Current pathname: \/ma-dev-test\/train\/pipelines/)
+      ).toBeInTheDocument();
     });
 
     it('keeps the dialog open and shows the error when delete fails', async () => {
@@ -147,7 +158,9 @@ describe('PIPELINE_ENTITY_CONFIG: delete action', () => {
         );
       });
 
-      expect(screen.getByText(/Current pathname: \/ma-dev-test\/train\/pipelines/)).toBeInTheDocument();
+      expect(
+        screen.getByText(/Current pathname: \/ma-dev-test\/train\/pipelines/)
+      ).toBeInTheDocument();
     });
 
     it('keeps the dialog open and shows the error when delete fails', async () => {

--- a/javascript/packages/core/config/entities/pipeline/__tests__/pipeline.test.tsx
+++ b/javascript/packages/core/config/entities/pipeline/__tests__/pipeline.test.tsx
@@ -82,16 +82,18 @@ describe('PIPELINE_ENTITY_CONFIG: delete action', () => {
 
       await user.click(getSubmitButton(dialog));
 
+      // The record is sent as-is; reshaping it into the flat DeletePipelineRequest
+      // ({ name, namespace }) the backend expects happens in the RPC handler (see
+      // packages/rpc/handlers.ts's deleteCrd), not in client-side mutation middleware.
       await waitFor(() => {
-        expect(mockRequest).toHaveBeenCalledWith(
-          'DeletePipeline',
-          { name: 'eval-pipeline', namespace: 'ma-dev-test' },
-          {}
-        );
+        expect(mockRequest).toHaveBeenCalledWith('DeletePipeline', buildPipeline(), {});
       });
 
+      // Navigation is a success operation that runs after the mutation resolves, i.e.
+      // asynchronously relative to the waitFor above — assert on it with findByText,
+      // not a synchronous getByText, so the test doesn't race the navigation.
       expect(
-        screen.getByText(/Current pathname: \/ma-dev-test\/train\/pipelines/)
+        await screen.findByText(/Current pathname: \/ma-dev-test\/train\/pipelines/)
       ).toBeInTheDocument();
     });
 
@@ -151,15 +153,14 @@ describe('PIPELINE_ENTITY_CONFIG: delete action', () => {
       await user.click(getSubmitButton(dialog));
 
       await waitFor(() => {
-        expect(mockRequest).toHaveBeenCalledWith(
-          'DeletePipeline',
-          { name: 'eval-pipeline', namespace: 'ma-dev-test' },
-          {}
-        );
+        expect(mockRequest).toHaveBeenCalledWith('DeletePipeline', buildPipeline(), {});
       });
 
+      // Navigation is a success operation that runs after the mutation resolves, i.e.
+      // asynchronously relative to the waitFor above — assert on it with findByText,
+      // not a synchronous getByText, so the test doesn't race the navigation.
       expect(
-        screen.getByText(/Current pathname: \/ma-dev-test\/train\/pipelines/)
+        await screen.findByText(/Current pathname: \/ma-dev-test\/train\/pipelines/)
       ).toBeInTheDocument();
     });
 

--- a/javascript/packages/core/config/entities/pipeline/pipeline.ts
+++ b/javascript/packages/core/config/entities/pipeline/pipeline.ts
@@ -1,9 +1,11 @@
 import { ActionHierarchy } from '#core/components/actions/types';
+import { interpolate } from '#core/interpolation/interpolate';
 import { CreatePipelineRunForm } from './create-pipeline-run-form';
 import { PIPELINE_DETAIL_CONFIG } from './detail';
 import { PIPELINE_LIST_CONFIG } from './list';
 
 import type { PhaseEntityConfig } from '#core/types/common/studio-types';
+import type { Pipeline } from './types';
 
 export const PIPELINE_ENTITY_CONFIG: PhaseEntityConfig = {
   id: 'pipelines',
@@ -16,6 +18,49 @@ export const PIPELINE_ENTITY_CONFIG: PhaseEntityConfig = {
       display: { label: 'Run', icon: 'playerPlay' },
       hierarchy: ActionHierarchy.PRIMARY,
       modal: { type: 'custom', component: CreatePipelineRunForm },
+    },
+    {
+      display: { label: 'Delete', icon: 'trashCan' },
+      hierarchy: ActionHierarchy.TERTIARY,
+      operation: {
+        type: 'mutation',
+        mutation: {
+          mutationName: 'DeletePipeline',
+          // DeletePipelineRequest is flat ({ name, namespace }); the record is a full
+          // Pipeline (metadata/spec/status/typeMeta). Reshape to the request shape —
+          // the backend rejects unknown fields.
+          middleware: {
+            operations: [
+              { source: 'metadata.name', destination: 'name', transformation: (value) => value },
+              {
+                source: 'metadata.namespace',
+                destination: 'namespace',
+                transformation: (value) => value,
+              },
+              { destination: 'metadata', transformation: 'unset' },
+              { destination: 'spec', transformation: 'unset' },
+              { destination: 'status', transformation: 'unset' },
+              { destination: 'typeMeta', transformation: 'unset' },
+            ],
+          },
+          successOperations: [
+            { type: 'invalidate', targets: ['ListPipeline'] },
+            { type: 'route', route: '/${studio.projectId}/${studio.phase}/pipelines' },
+          ],
+        },
+      },
+      modal: {
+        type: 'confirm',
+        header: { title: 'Delete Pipeline' },
+        body: interpolate(
+          ({ data }) =>
+            // cast: data is unknown from interpolation context; always Pipeline in this entity
+            // config; see #1425
+            `Delete pipeline **${(data as Pipeline).metadata.name}**? This action cannot be undone.`
+        ),
+        button: { label: 'Delete' },
+        destructive: true,
+      },
     },
   ],
 };

--- a/javascript/packages/core/config/entities/pipeline/pipeline.ts
+++ b/javascript/packages/core/config/entities/pipeline/pipeline.ts
@@ -26,23 +26,6 @@ export const PIPELINE_ENTITY_CONFIG: PhaseEntityConfig = {
         type: 'mutation',
         mutation: {
           mutationName: 'DeletePipeline',
-          // DeletePipelineRequest is flat ({ name, namespace }); the record is a full
-          // Pipeline (metadata/spec/status/typeMeta). Reshape to the request shape —
-          // the backend rejects unknown fields.
-          middleware: {
-            operations: [
-              { source: 'metadata.name', destination: 'name', transformation: (value) => value },
-              {
-                source: 'metadata.namespace',
-                destination: 'namespace',
-                transformation: (value) => value,
-              },
-              { destination: 'metadata', transformation: 'unset' },
-              { destination: 'spec', transformation: 'unset' },
-              { destination: 'status', transformation: 'unset' },
-              { destination: 'typeMeta', transformation: 'unset' },
-            ],
-          },
           successOperations: [
             { type: 'invalidate', targets: ['ListPipeline'] },
             { type: 'route', route: '/${studio.projectId}/${studio.phase}/pipelines' },

--- a/javascript/packages/rpc/__tests__/handlers.test.ts
+++ b/javascript/packages/rpc/__tests__/handlers.test.ts
@@ -8,6 +8,7 @@ vi.mock('../services', () => ({ getServices: mockGetServices }));
 const createPipelineRun = vi.fn().mockResolvedValue({});
 const updatePipelineRun = vi.fn().mockResolvedValue({});
 const updateTriggerRun = vi.fn().mockResolvedValue({});
+const deletePipeline = vi.fn().mockResolvedValue({});
 
 mockGetServices.mockResolvedValue(
   new Proxy({} as Record<string, Record<string, unknown>>, {
@@ -17,6 +18,9 @@ mockGetServices.mockResolvedValue(
       }
       if (serviceName === 'TriggerRunService') {
         return { updateTriggerRun };
+      }
+      if (serviceName === 'PipelineService') {
+        return { deletePipeline };
       }
       return new Proxy({}, { get: () => vi.fn().mockResolvedValue({}) });
     },
@@ -63,5 +67,19 @@ describe('rpc handlers — mutation envelope wrapping', () => {
     await handlers.CreatePipelineRun(record as never);
 
     expect((record.spec as Record<string, unknown>).actor).toBeUndefined();
+  });
+
+  it('DeletePipeline extracts name/namespace from the full record', async () => {
+    const handlers = await getRpcHandlers();
+    const record = {
+      metadata: { name: 'eval-pipeline', namespace: 'ma-dev-test' },
+      spec: { owner: { name: 'me' } },
+    };
+    await handlers.DeletePipeline(record as never);
+
+    expect(deletePipeline).toHaveBeenCalledWith(
+      { name: 'eval-pipeline', namespace: 'ma-dev-test' },
+      undefined
+    );
   });
 });

--- a/javascript/packages/rpc/handlers.ts
+++ b/javascript/packages/rpc/handlers.ts
@@ -27,6 +27,7 @@ async function createHandlers() {
     GetProject: unary(services.ProjectService.getProject),
     GetPipeline: unary(services.PipelineService.getPipeline),
     ListPipeline: unary(services.PipelineService.listPipeline),
+    DeletePipeline: unary(services.PipelineService.deletePipeline),
     ListPipelineRun: unary(services.PipelineRunService.listPipelineRun),
     GetPipelineRun: unary(services.PipelineRunService.getPipelineRun),
     ListTriggerRun: unary(services.TriggerRunService.listTriggerRun),

--- a/javascript/packages/rpc/handlers.ts
+++ b/javascript/packages/rpc/handlers.ts
@@ -15,6 +15,21 @@ function unary<Fn>(fn: Fn): ExtractUnaryRpc<Fn> {
   return fn as unknown as ExtractUnaryRpc<Fn>;
 }
 
+// Delete<CRD>Request messages are uniformly { name, namespace, deleteOptions? } across every
+// service, while actions send the full CRD record (metadata/spec/status/typeMeta). Wrapping a
+// generated deleteX method here lets every Delete* handler share this reshape instead of each
+// entity config repeating it as mutation middleware.
+function deleteCrd<Req extends { name: string; namespace: string }, Res>(
+  deleteFn: (request: Req, headers?: Record<string, string>) => Promise<Res>
+) {
+  return (
+    record: { metadata: { name: string; namespace: string } },
+    headers?: Record<string, string>
+  ) =>
+    // cast: Req may carry additional optional fields (e.g. deleteOptions) beyond name/namespace
+    deleteFn({ name: record.metadata.name, namespace: record.metadata.namespace } as Req, headers);
+}
+
 async function createHandlers() {
   const services = await getServices();
 
@@ -27,7 +42,7 @@ async function createHandlers() {
     GetProject: unary(services.ProjectService.getProject),
     GetPipeline: unary(services.PipelineService.getPipeline),
     ListPipeline: unary(services.PipelineService.listPipeline),
-    DeletePipeline: unary(services.PipelineService.deletePipeline),
+    DeletePipeline: deleteCrd(services.PipelineService.deletePipeline),
     ListPipelineRun: unary(services.PipelineRunService.listPipelineRun),
     GetPipelineRun: unary(services.PipelineRunService.getPipelineRun),
     ListTriggerRun: unary(services.TriggerRunService.listTriggerRun),


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
This PR adds the ability to delete a pipeline. This can be done from the list view or the pipeline detail page. Note that if the pipeline has any runs, deleting the pipeline will not stop the runs.

https://github.com/user-attachments/assets/954ade3a-580d-48fd-b299-a6fff22d9722


<!-- Tell your future self why have you made these changes -->
**Why?**
We want to add the ability to delete pipelines via the UI.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests and manually

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Deleting a pipeline that has runs will not stop the runs currently running.

<!-- Does this PR introduce a breaking change? Check all that apply. -->
**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
N/A
<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
N/A