### PR TITLE
feat(trainer): add an XGBoost trainer built on Ray Train

### DIFF
--- a/python/michelangelo/lib/trainer/xgboost/__init__.py
+++ b/python/michelangelo/lib/trainer/xgboost/__init__.py
@@ -1,0 +1,20 @@
+"""XGBoost trainer wrapping Ray Train.
+
+Public surface re-exported below:
+
+* :class:`XGBoostTrainer` — Ray ``XGBoostTrainer`` subclass that runs a
+  data-parallel XGBoost training loop and reports checkpoints through Ray
+  Train.
+* :class:`XGBoostTrainerParam` — dataclass holding the training configuration
+  (label column, datasets, booster params, boosting rounds, ...).
+"""
+
+from michelangelo.lib.trainer.xgboost.xgboost_trainer import (
+    XGBoostTrainer,
+    XGBoostTrainerParam,
+)
+
+__all__ = [
+    "XGBoostTrainer",
+    "XGBoostTrainerParam",
+]

--- a/python/michelangelo/lib/trainer/xgboost/tests/__init__.py
+++ b/python/michelangelo/lib/trainer/xgboost/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the XGBoost trainer library."""

--- a/python/michelangelo/lib/trainer/xgboost/tests/test_xgboost_trainer.py
+++ b/python/michelangelo/lib/trainer/xgboost/tests/test_xgboost_trainer.py
@@ -1,0 +1,340 @@
+"""Tests for the XGBoost trainer module.
+
+Cover the public surface of ``michelangelo.lib.trainer.xgboost.xgboost_trainer``:
+dataclass validation, trainer construction and dataset wiring, the ``train()``
+result contract, and the per-worker training loop. Ray Train's parent
+``__init__`` and ``fit()`` are patched throughout, so nothing here needs a Ray
+cluster.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("xgboost")
+pytest.importorskip("ray.train.xgboost")
+
+from michelangelo.lib.trainer.xgboost.xgboost_trainer import (  # noqa: E402
+    CHECKPOINT_PATH_KEY,
+    TRAIN_DATASET_KEY,
+    VALIDATION_DATASET_KEY,
+    XGBoostTrainer,
+    XGBoostTrainerParam,
+    _train_loop_per_worker,
+)
+
+_PARENT_INIT = "ray.train.xgboost.XGBoostTrainer.__init__"
+
+
+def _make_param(**overrides) -> XGBoostTrainerParam:
+    """Build a minimally-valid ``XGBoostTrainerParam`` for tests."""
+    defaults = {
+        "label_column": "target",
+        "train_data": MagicMock(name="train_data"),
+    }
+    defaults.update(overrides)
+    return XGBoostTrainerParam(**defaults)
+
+
+# -----------------------------------------------------------------------------
+# XGBoostTrainerParam
+# -----------------------------------------------------------------------------
+
+
+class TestXGBoostTrainerParam:
+    """``XGBoostTrainerParam`` dataclass behavior."""
+
+    def test_defaults(self):
+        param = _make_param()
+        assert param.val_data is None
+        assert param.params == {}
+        assert param.num_boost_round == 10
+        assert param.feature_columns is None
+        assert param.xgboost_train_kwargs == {}
+
+    def test_mutable_defaults_are_not_shared(self):
+        first = _make_param()
+        second = _make_param()
+        first.params["eta"] = 0.1
+        assert second.params == {}
+
+    def test_empty_label_column_rejected(self):
+        with pytest.raises(ValueError, match="label_column"):
+            _make_param(label_column="")
+
+    @pytest.mark.parametrize("rounds", [0, -1])
+    def test_non_positive_boost_rounds_rejected(self, rounds):
+        with pytest.raises(ValueError, match="num_boost_round"):
+            _make_param(num_boost_round=rounds)
+
+    def test_user_callbacks_rejected(self):
+        with pytest.raises(ValueError, match="callbacks"):
+            _make_param(xgboost_train_kwargs={"callbacks": [object()]})
+
+    def test_other_train_kwargs_allowed(self):
+        param = _make_param(xgboost_train_kwargs={"verbose_eval": False})
+        assert param.xgboost_train_kwargs == {"verbose_eval": False}
+
+
+# -----------------------------------------------------------------------------
+# XGBoostTrainer construction
+# -----------------------------------------------------------------------------
+
+
+class TestXGBoostTrainerInit:
+    """Argument wiring handed to Ray's ``XGBoostTrainer``."""
+
+    def test_train_only_dataset_wiring(self):
+        param = _make_param()
+        with patch(_PARENT_INIT, return_value=None) as parent:
+            XGBoostTrainer(param)
+
+        datasets = parent.call_args.kwargs["datasets"]
+        assert datasets == {TRAIN_DATASET_KEY: param.train_data}
+        assert parent.call_args.kwargs["train_loop_config"]["has_validation"] is False
+
+    def test_validation_dataset_wiring(self):
+        val = MagicMock(name="val_data")
+        param = _make_param(val_data=val)
+        with patch(_PARENT_INIT, return_value=None) as parent:
+            XGBoostTrainer(param)
+
+        datasets = parent.call_args.kwargs["datasets"]
+        assert datasets[VALIDATION_DATASET_KEY] is val
+        assert parent.call_args.kwargs["train_loop_config"]["has_validation"] is True
+
+    def test_train_loop_config_carries_booster_settings(self):
+        param = _make_param(
+            params={"objective": "reg:squarederror"},
+            num_boost_round=42,
+            feature_columns=["a", "b"],
+            xgboost_train_kwargs={"verbose_eval": False},
+        )
+        with patch(_PARENT_INIT, return_value=None) as parent:
+            XGBoostTrainer(param)
+
+        config = parent.call_args.kwargs["train_loop_config"]
+        assert config["label_column"] == "target"
+        assert config["params"] == {"objective": "reg:squarederror"}
+        assert config["num_boost_round"] == 42
+        assert config["feature_columns"] == ["a", "b"]
+        assert config["xgboost_train_kwargs"] == {"verbose_eval": False}
+
+    def test_train_loop_function_is_passed_positionally(self):
+        with patch(_PARENT_INIT, return_value=None) as parent:
+            XGBoostTrainer(_make_param())
+
+        assert parent.call_args.args[0] is _train_loop_per_worker
+
+    def test_configs_forwarded(self):
+        run_config = object()
+        scaling_config = object()
+        with patch(_PARENT_INIT, return_value=None) as parent:
+            XGBoostTrainer(
+                _make_param(), run_config=run_config, scaling_config=scaling_config
+            )
+
+        assert parent.call_args.kwargs["run_config"] is run_config
+        assert parent.call_args.kwargs["scaling_config"] is scaling_config
+
+    def test_trainer_param_retained(self):
+        param = _make_param()
+        with patch(_PARENT_INIT, return_value=None):
+            trainer = XGBoostTrainer(param)
+        assert trainer.trainer_param is param
+
+
+# -----------------------------------------------------------------------------
+# XGBoostTrainer.train
+# -----------------------------------------------------------------------------
+
+
+def _build_trainer() -> XGBoostTrainer:
+    """Construct a trainer with Ray's ``__init__`` patched out."""
+    with patch(_PARENT_INIT, return_value=None):
+        return XGBoostTrainer(_make_param())
+
+
+class TestXGBoostTrainerTrain:
+    """``train()`` result contract and override handling."""
+
+    def test_returns_result_dict(self):
+        trainer = _build_trainer()
+        result = SimpleNamespace(
+            error=None,
+            checkpoint=SimpleNamespace(path="/ckpt/latest"),
+            path="/run/path",
+            metrics={"validation-rmse": 0.5},
+        )
+        with patch.object(XGBoostTrainer, "fit", return_value=result):
+            out = trainer.train()
+
+        assert out == {
+            CHECKPOINT_PATH_KEY: "/ckpt/latest",
+            "path": "/run/path",
+            "metrics": {"validation-rmse": 0.5},
+        }
+
+    def test_missing_checkpoint_yields_none(self):
+        trainer = _build_trainer()
+        result = SimpleNamespace(
+            error=None, checkpoint=None, path="/run/path", metrics={}
+        )
+        with patch.object(XGBoostTrainer, "fit", return_value=result):
+            out = trainer.train()
+
+        assert out[CHECKPOINT_PATH_KEY] is None
+
+    def test_error_is_raised(self):
+        trainer = _build_trainer()
+        boom = RuntimeError("training failed")
+        result = SimpleNamespace(
+            error=boom, checkpoint=None, path="/run/path", metrics={}
+        )
+        with patch.object(XGBoostTrainer, "fit", return_value=result):
+            with pytest.raises(RuntimeError, match="training failed"):
+                trainer.train()
+
+    def test_overrides_applied_before_fit(self):
+        trainer = _build_trainer()
+        run_config = object()
+        scaling_config = object()
+        result = SimpleNamespace(
+            error=None,
+            checkpoint=SimpleNamespace(path="/ckpt"),
+            path="/run",
+            metrics={},
+        )
+        with patch.object(XGBoostTrainer, "fit", return_value=result):
+            trainer.train(run_config=run_config, scaling_config=scaling_config)
+
+        assert trainer.run_config is run_config
+        assert trainer.scaling_config is scaling_config
+
+    def test_checkpoint_retained_on_instance(self):
+        trainer = _build_trainer()
+        checkpoint = SimpleNamespace(path="/ckpt")
+        result = SimpleNamespace(
+            error=None, checkpoint=checkpoint, path="/run", metrics={}
+        )
+        with patch.object(XGBoostTrainer, "fit", return_value=result):
+            trainer.train()
+
+        assert trainer.checkpoint is checkpoint
+
+
+# -----------------------------------------------------------------------------
+# _train_loop_per_worker
+# -----------------------------------------------------------------------------
+
+
+def _base_config(**overrides) -> dict:
+    """Build a ``train_loop_config`` for the worker loop."""
+    config = {
+        "label_column": "target",
+        "feature_columns": None,
+        "params": {"objective": "reg:squarederror"},
+        "num_boost_round": 7,
+        "xgboost_train_kwargs": {},
+        "has_validation": False,
+    }
+    config.update(overrides)
+    return config
+
+
+class _FakeFrame:
+    """Minimal pandas-like stand-in exposing ``columns`` and column selection."""
+
+    def __init__(self, columns):
+        self.columns = list(columns)
+        self.selected = None
+
+    def __getitem__(self, key):
+        self.selected = key
+        return f"frame[{key}]"
+
+
+def _shard_returning(frame):
+    """Build a dataset-shard mock whose ``materialize().to_pandas()`` is ``frame``."""
+    shard = MagicMock()
+    shard.materialize.return_value.to_pandas.return_value = frame
+    return shard
+
+
+@pytest.fixture
+def fake_xgboost(monkeypatch):
+    """Install a fake ``xgboost`` module and report callback for the worker loop."""
+    fake = MagicMock(name="xgboost")
+    monkeypatch.setitem(sys.modules, "xgboost", fake)
+    with patch("ray.train.xgboost.RayTrainReportCallback", MagicMock()):
+        yield fake
+
+
+class TestTrainLoopPerWorker:
+    """Worker-side training loop behavior."""
+
+    def test_infers_feature_columns_excluding_label(self, fake_xgboost):
+        frame = _FakeFrame(["a", "b", "target"])
+        with patch("ray.train.get_dataset_shard", return_value=_shard_returning(frame)):
+            _train_loop_per_worker(_base_config())
+
+        assert frame.selected == "target"
+        first_dmatrix_call = fake_xgboost.DMatrix.call_args_list[0]
+        assert first_dmatrix_call.args[0] == "frame[['a', 'b']]"
+
+    def test_explicit_feature_columns_respected(self, fake_xgboost):
+        frame = _FakeFrame(["a", "b", "c", "target"])
+        with patch("ray.train.get_dataset_shard", return_value=_shard_returning(frame)):
+            _train_loop_per_worker(_base_config(feature_columns=["a", "c"]))
+
+        first_dmatrix_call = fake_xgboost.DMatrix.call_args_list[0]
+        assert first_dmatrix_call.args[0] == "frame[['a', 'c']]"
+
+    def test_missing_label_column_raises(self, fake_xgboost):
+        frame = _FakeFrame(["a", "b"])
+        with patch("ray.train.get_dataset_shard", return_value=_shard_returning(frame)):
+            with pytest.raises(KeyError, match="target"):
+                _train_loop_per_worker(_base_config(feature_columns=["a"]))
+
+    def test_booster_params_forwarded(self, fake_xgboost):
+        frame = _FakeFrame(["a", "target"])
+        with patch("ray.train.get_dataset_shard", return_value=_shard_returning(frame)):
+            _train_loop_per_worker(
+                _base_config(xgboost_train_kwargs={"verbose_eval": False})
+            )
+
+        call = fake_xgboost.train.call_args
+        assert call.args[0] == {"objective": "reg:squarederror"}
+        assert call.kwargs["num_boost_round"] == 7
+        assert call.kwargs["verbose_eval"] is False
+        assert len(call.kwargs["callbacks"]) == 1
+
+    def test_validation_shard_only_read_when_declared(self, fake_xgboost):
+        frame = _FakeFrame(["a", "target"])
+        with patch(
+            "ray.train.get_dataset_shard", return_value=_shard_returning(frame)
+        ) as shard:
+            _train_loop_per_worker(_base_config(has_validation=False))
+        assert shard.call_count == 1
+
+        with patch(
+            "ray.train.get_dataset_shard", return_value=_shard_returning(frame)
+        ) as shard:
+            _train_loop_per_worker(_base_config(has_validation=True))
+        assert shard.call_count == 2
+        assert shard.call_args_list[1].args[0] == VALIDATION_DATASET_KEY
+
+    def test_eval_sets_include_validation(self, fake_xgboost):
+        frame = _FakeFrame(["a", "target"])
+        with patch("ray.train.get_dataset_shard", return_value=_shard_returning(frame)):
+            _train_loop_per_worker(_base_config(has_validation=True))
+
+        evals = fake_xgboost.train.call_args.kwargs["evals"]
+        assert [name for _, name in evals] == [
+            TRAIN_DATASET_KEY,
+            VALIDATION_DATASET_KEY,
+        ]

--- a/python/michelangelo/lib/trainer/xgboost/tests/test_xgboost_trainer.py
+++ b/python/michelangelo/lib/trainer/xgboost/tests/test_xgboost_trainer.py
@@ -18,7 +18,7 @@ import pytest
 pytest.importorskip("xgboost")
 pytest.importorskip("ray.train.xgboost")
 
-from michelangelo.lib.trainer.xgboost.xgboost_trainer import (  # noqa: E402
+from michelangelo.lib.trainer.xgboost.xgboost_trainer import (
     CHECKPOINT_PATH_KEY,
     TRAIN_DATASET_KEY,
     VALIDATION_DATASET_KEY,
@@ -49,6 +49,7 @@ class TestXGBoostTrainerParam:
     """``XGBoostTrainerParam`` dataclass behavior."""
 
     def test_defaults(self):
+        """It applies the documented default for every optional field."""
         param = _make_param()
         assert param.val_data is None
         assert param.params == {}
@@ -57,25 +58,30 @@ class TestXGBoostTrainerParam:
         assert param.xgboost_train_kwargs == {}
 
     def test_mutable_defaults_are_not_shared(self):
+        """It gives each instance its own params dict."""
         first = _make_param()
         second = _make_param()
         first.params["eta"] = 0.1
         assert second.params == {}
 
     def test_empty_label_column_rejected(self):
+        """It rejects an empty label_column."""
         with pytest.raises(ValueError, match="label_column"):
             _make_param(label_column="")
 
     @pytest.mark.parametrize("rounds", [0, -1])
     def test_non_positive_boost_rounds_rejected(self, rounds):
+        """It rejects a num_boost_round below one."""
         with pytest.raises(ValueError, match="num_boost_round"):
             _make_param(num_boost_round=rounds)
 
     def test_user_callbacks_rejected(self):
+        """It rejects user callbacks, which would displace checkpointing."""
         with pytest.raises(ValueError, match="callbacks"):
             _make_param(xgboost_train_kwargs={"callbacks": [object()]})
 
     def test_other_train_kwargs_allowed(self):
+        """It keeps xgboost train kwargs other than callbacks."""
         param = _make_param(xgboost_train_kwargs={"verbose_eval": False})
         assert param.xgboost_train_kwargs == {"verbose_eval": False}
 
@@ -89,6 +95,7 @@ class TestXGBoostTrainerInit:
     """Argument wiring handed to Ray's ``XGBoostTrainer``."""
 
     def test_train_only_dataset_wiring(self):
+        """It passes only the train dataset when no validation set is given."""
         param = _make_param()
         with patch(_PARENT_INIT, return_value=None) as parent:
             XGBoostTrainer(param)
@@ -98,6 +105,7 @@ class TestXGBoostTrainerInit:
         assert parent.call_args.kwargs["train_loop_config"]["has_validation"] is False
 
     def test_validation_dataset_wiring(self):
+        """It passes the validation dataset and flags it in the config."""
         val = MagicMock(name="val_data")
         param = _make_param(val_data=val)
         with patch(_PARENT_INIT, return_value=None) as parent:
@@ -108,6 +116,7 @@ class TestXGBoostTrainerInit:
         assert parent.call_args.kwargs["train_loop_config"]["has_validation"] is True
 
     def test_train_loop_config_carries_booster_settings(self):
+        """It forwards the booster settings through train_loop_config."""
         param = _make_param(
             params={"objective": "reg:squarederror"},
             num_boost_round=42,
@@ -125,12 +134,14 @@ class TestXGBoostTrainerInit:
         assert config["xgboost_train_kwargs"] == {"verbose_eval": False}
 
     def test_train_loop_function_is_passed_positionally(self):
+        """It passes the worker loop as the first positional argument."""
         with patch(_PARENT_INIT, return_value=None) as parent:
             XGBoostTrainer(_make_param())
 
         assert parent.call_args.args[0] is _train_loop_per_worker
 
     def test_configs_forwarded(self):
+        """It forwards run_config and scaling_config unchanged."""
         run_config = object()
         scaling_config = object()
         with patch(_PARENT_INIT, return_value=None) as parent:
@@ -142,6 +153,7 @@ class TestXGBoostTrainerInit:
         assert parent.call_args.kwargs["scaling_config"] is scaling_config
 
     def test_trainer_param_retained(self):
+        """It keeps the trainer param on the instance."""
         param = _make_param()
         with patch(_PARENT_INIT, return_value=None):
             trainer = XGBoostTrainer(param)
@@ -163,6 +175,7 @@ class TestXGBoostTrainerTrain:
     """``train()`` result contract and override handling."""
 
     def test_returns_result_dict(self):
+        """It returns the checkpoint path, the run path and the metrics."""
         trainer = _build_trainer()
         result = SimpleNamespace(
             error=None,
@@ -180,6 +193,7 @@ class TestXGBoostTrainerTrain:
         }
 
     def test_missing_checkpoint_yields_none(self):
+        """It returns None for the checkpoint path when there is no checkpoint."""
         trainer = _build_trainer()
         result = SimpleNamespace(
             error=None, checkpoint=None, path="/run/path", metrics={}
@@ -190,16 +204,20 @@ class TestXGBoostTrainerTrain:
         assert out[CHECKPOINT_PATH_KEY] is None
 
     def test_error_is_raised(self):
+        """It raises the error Ray reports on the result."""
         trainer = _build_trainer()
         boom = RuntimeError("training failed")
         result = SimpleNamespace(
             error=boom, checkpoint=None, path="/run/path", metrics={}
         )
-        with patch.object(XGBoostTrainer, "fit", return_value=result):
-            with pytest.raises(RuntimeError, match="training failed"):
-                trainer.train()
+        with (
+            patch.object(XGBoostTrainer, "fit", return_value=result),
+            pytest.raises(RuntimeError, match="training failed"),
+        ):
+            trainer.train()
 
     def test_overrides_applied_before_fit(self):
+        """It applies run_config and scaling_config overrides before fitting."""
         trainer = _build_trainer()
         run_config = object()
         scaling_config = object()
@@ -216,6 +234,7 @@ class TestXGBoostTrainerTrain:
         assert trainer.scaling_config is scaling_config
 
     def test_checkpoint_retained_on_instance(self):
+        """It keeps the returned checkpoint on the instance."""
         trainer = _build_trainer()
         checkpoint = SimpleNamespace(path="/ckpt")
         result = SimpleNamespace(
@@ -278,6 +297,7 @@ class TestTrainLoopPerWorker:
     """Worker-side training loop behavior."""
 
     def test_infers_feature_columns_excluding_label(self, fake_xgboost):
+        """It treats every column except the label as a feature."""
         frame = _FakeFrame(["a", "b", "target"])
         with patch("ray.train.get_dataset_shard", return_value=_shard_returning(frame)):
             _train_loop_per_worker(_base_config())
@@ -287,6 +307,7 @@ class TestTrainLoopPerWorker:
         assert first_dmatrix_call.args[0] == "frame[['a', 'b']]"
 
     def test_explicit_feature_columns_respected(self, fake_xgboost):
+        """It uses the configured feature columns when they are given."""
         frame = _FakeFrame(["a", "b", "c", "target"])
         with patch("ray.train.get_dataset_shard", return_value=_shard_returning(frame)):
             _train_loop_per_worker(_base_config(feature_columns=["a", "c"]))
@@ -295,12 +316,16 @@ class TestTrainLoopPerWorker:
         assert first_dmatrix_call.args[0] == "frame[['a', 'c']]"
 
     def test_missing_label_column_raises(self, fake_xgboost):
+        """It raises KeyError when the label column is absent from the shard."""
         frame = _FakeFrame(["a", "b"])
-        with patch("ray.train.get_dataset_shard", return_value=_shard_returning(frame)):
-            with pytest.raises(KeyError, match="target"):
-                _train_loop_per_worker(_base_config(feature_columns=["a"]))
+        with (
+            patch("ray.train.get_dataset_shard", return_value=_shard_returning(frame)),
+            pytest.raises(KeyError, match="target"),
+        ):
+            _train_loop_per_worker(_base_config(feature_columns=["a"]))
 
     def test_booster_params_forwarded(self, fake_xgboost):
+        """It forwards params, rounds and train kwargs to ``xgboost.train``."""
         frame = _FakeFrame(["a", "target"])
         with patch("ray.train.get_dataset_shard", return_value=_shard_returning(frame)):
             _train_loop_per_worker(
@@ -314,6 +339,7 @@ class TestTrainLoopPerWorker:
         assert len(call.kwargs["callbacks"]) == 1
 
     def test_validation_shard_only_read_when_declared(self, fake_xgboost):
+        """It reads the validation shard only when one was declared."""
         frame = _FakeFrame(["a", "target"])
         with patch(
             "ray.train.get_dataset_shard", return_value=_shard_returning(frame)
@@ -329,6 +355,7 @@ class TestTrainLoopPerWorker:
         assert shard.call_args_list[1].args[0] == VALIDATION_DATASET_KEY
 
     def test_eval_sets_include_validation(self, fake_xgboost):
+        """It evaluates on both train and validation when both exist."""
         frame = _FakeFrame(["a", "target"])
         with patch("ray.train.get_dataset_shard", return_value=_shard_returning(frame)):
             _train_loop_per_worker(_base_config(has_validation=True))

--- a/python/michelangelo/lib/trainer/xgboost/xgboost_trainer.py
+++ b/python/michelangelo/lib/trainer/xgboost/xgboost_trainer.py
@@ -32,13 +32,11 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
+import ray.data
 import ray.train
 from ray.train.xgboost import XGBoostTrainer as RayXGBoostTrainer
-
-if TYPE_CHECKING:
-    import ray.data
 
 _logger = logging.getLogger(__name__)
 

--- a/python/michelangelo/lib/trainer/xgboost/xgboost_trainer.py
+++ b/python/michelangelo/lib/trainer/xgboost/xgboost_trainer.py
@@ -1,0 +1,237 @@
+"""Public XGBoost trainer wrapping Ray Train.
+
+Distributed, data-parallel XGBoost training on a Ray cluster, exposed with the
+same shape as the PyTorch Lightning trainer in
+``michelangelo.lib.trainer.torch.pytorch_lightning``: a parameter dataclass, a
+``train()`` that returns a small result dict, and checkpointing handled by Ray
+Train's own report callback.
+
+Typical use::
+
+    from michelangelo.lib.trainer.xgboost import (
+        XGBoostTrainer,
+        XGBoostTrainerParam,
+    )
+
+    trainer = XGBoostTrainer(
+        trainer_param=XGBoostTrainerParam(
+            label_column="target",
+            train_data=train_ds,
+            val_data=val_ds,
+            params={"objective": "reg:squarederror", "eta": 0.1},
+            num_boost_round=50,
+        ),
+        run_config=ray.train.RunConfig(name="my_run", storage_path="/tmp/runs"),
+        scaling_config=ray.train.ScalingConfig(num_workers=2, use_gpu=False),
+    )
+    result = trainer.train()
+    print(result["checkpoint_path"])
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import ray.train
+from ray.train.xgboost import XGBoostTrainer as RayXGBoostTrainer
+
+if TYPE_CHECKING:
+    import ray.data
+
+_logger = logging.getLogger(__name__)
+
+CHECKPOINT_PATH_KEY = "checkpoint_path"
+
+TRAIN_DATASET_KEY = "train"
+VALIDATION_DATASET_KEY = "validation"
+
+
+@dataclass
+class XGBoostTrainerParam:
+    """Configuration for :class:`XGBoostTrainer`.
+
+    Attributes:
+        label_column: Name of the target column. Must be present in
+            ``train_data`` and, when supplied, ``val_data``.
+        train_data: Training Ray Dataset.
+        val_data: Optional validation Ray Dataset. When omitted, training runs
+            with the training set as its only eval set.
+        params: XGBoost booster parameters, passed verbatim as the first
+            argument to ``xgboost.train`` (for example
+            ``{"objective": "reg:squarederror", "eta": 0.1}``).
+        num_boost_round: Number of boosting rounds.
+        feature_columns: Explicit feature column names. When ``None`` (the
+            default), every column except ``label_column`` is used as a
+            feature.
+        xgboost_train_kwargs: Extra keyword arguments forwarded verbatim to
+            ``xgboost.train(...)``. ``callbacks`` is reserved -- the trainer
+            supplies Ray Train's report callback, so passing your own here
+            raises ``ValueError`` rather than silently losing checkpointing.
+    """
+
+    label_column: str
+    train_data: ray.data.Dataset
+    val_data: ray.data.Dataset | None = None
+    params: dict[str, Any] = field(default_factory=dict)
+    num_boost_round: int = 10
+    feature_columns: list[str] | None = None
+    xgboost_train_kwargs: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Reject configurations that would silently drop checkpointing.
+
+        Raises:
+            ValueError: If ``label_column`` is empty, ``num_boost_round`` is
+                not positive, or ``xgboost_train_kwargs`` carries ``callbacks``
+                (which would collide with the report callback the trainer
+                installs).
+        """
+        if not self.label_column:
+            raise ValueError("label_column must be a non-empty column name")
+        if self.num_boost_round <= 0:
+            raise ValueError(
+                f"num_boost_round must be positive, got {self.num_boost_round}"
+            )
+        if "callbacks" in self.xgboost_train_kwargs:
+            raise ValueError(
+                "xgboost_train_kwargs must not set 'callbacks'; the trainer "
+                "installs Ray Train's RayTrainReportCallback, and overriding it "
+                "disables checkpoint reporting"
+            )
+
+
+def _train_loop_per_worker(config: dict[str, Any]) -> None:
+    """Train one XGBoost worker against its shard of the datasets.
+
+    Runs inside each Ray Train worker. Imports are deferred to worker-side so
+    that importing this module does not require ``xgboost`` on the driver.
+
+    Args:
+        config: The ``train_loop_config`` assembled by
+            :meth:`XGBoostTrainer.__init__`.
+    """
+    import xgboost
+    from ray.train.xgboost import RayTrainReportCallback
+
+    label_column = config["label_column"]
+    feature_columns = config["feature_columns"]
+    params = config["params"]
+    num_boost_round = config["num_boost_round"]
+    extra_kwargs = config["xgboost_train_kwargs"]
+
+    train_df = ray.train.get_dataset_shard(TRAIN_DATASET_KEY).materialize().to_pandas()
+
+    if feature_columns is None:
+        feature_columns = [c for c in train_df.columns if c != label_column]
+    if label_column not in train_df.columns:
+        raise KeyError(
+            f"label_column {label_column!r} is not present in the training "
+            f"shard; available columns: {sorted(train_df.columns)}"
+        )
+
+    dtrain = xgboost.DMatrix(train_df[feature_columns], label=train_df[label_column])
+    evals = [(dtrain, TRAIN_DATASET_KEY)]
+
+    # Looked up off the flag rather than probing for the shard, so behaviour
+    # does not depend on whether get_dataset_shard returns None or raises for
+    # an absent dataset.
+    if config["has_validation"]:
+        val_df = (
+            ray.train.get_dataset_shard(VALIDATION_DATASET_KEY)
+            .materialize()
+            .to_pandas()
+        )
+        dval = xgboost.DMatrix(val_df[feature_columns], label=val_df[label_column])
+        evals.append((dval, VALIDATION_DATASET_KEY))
+
+    xgboost.train(
+        params,
+        dtrain=dtrain,
+        evals=evals,
+        num_boost_round=num_boost_round,
+        callbacks=[RayTrainReportCallback()],
+        **extra_kwargs,
+    )
+
+
+class XGBoostTrainer(RayXGBoostTrainer):
+    """Ray ``XGBoostTrainer`` subclass running a data-parallel XGBoost fit."""
+
+    def __init__(
+        self,
+        trainer_param: XGBoostTrainerParam,
+        run_config: ray.train.RunConfig | None = None,
+        scaling_config: ray.train.ScalingConfig | None = None,
+    ):
+        """Initialize the trainer.
+
+        Args:
+            trainer_param: Training configuration (label, datasets, booster
+                params, ...).
+            run_config: Optional Ray ``RunConfig`` (storage path, run name, ...).
+            scaling_config: Optional Ray ``ScalingConfig`` (num_workers, GPU/CPU
+                requests, ...).
+        """
+        self.trainer_param = trainer_param
+        _logger.info("XGBoostTrainer initialized with trainer_param: %r", trainer_param)
+
+        # Built field-by-field rather than with dataclasses.asdict(), which
+        # would deep-copy the Ray Datasets before they are split back out.
+        train_loop_config = {
+            "label_column": trainer_param.label_column,
+            "feature_columns": trainer_param.feature_columns,
+            "params": trainer_param.params,
+            "num_boost_round": trainer_param.num_boost_round,
+            "xgboost_train_kwargs": trainer_param.xgboost_train_kwargs,
+            "has_validation": trainer_param.val_data is not None,
+        }
+
+        datasets = {TRAIN_DATASET_KEY: trainer_param.train_data}
+        if trainer_param.val_data is not None:
+            datasets[VALIDATION_DATASET_KEY] = trainer_param.val_data
+
+        super().__init__(
+            _train_loop_per_worker,
+            train_loop_config=train_loop_config,
+            datasets=datasets,
+            run_config=run_config,
+            scaling_config=scaling_config,
+        )
+
+    def train(
+        self,
+        run_config: ray.train.RunConfig | None = None,
+        scaling_config: ray.train.ScalingConfig | None = None,
+    ) -> dict:
+        """Run training and return a small result dict.
+
+        Args:
+            run_config: Optional override applied before ``fit()``.
+            scaling_config: Optional override applied before ``fit()``.
+
+        Returns:
+            Dict with ``checkpoint_path`` (path to the latest checkpoint, or
+            ``None`` if the run reported none), ``path`` (the Ray result path),
+            and ``metrics``.
+
+        Raises:
+            Exception: Whatever Ray Train reports in ``result.error``.
+        """
+        if scaling_config is not None:
+            self.scaling_config = scaling_config
+        if run_config is not None:
+            self.run_config = run_config
+
+        result = self.fit()
+        if result.error:
+            raise result.error
+
+        self.checkpoint = result.checkpoint
+
+        return {
+            CHECKPOINT_PATH_KEY: result.checkpoint.path if result.checkpoint else None,
+            "path": result.path,
+            "metrics": result.metrics,
+        }

--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -13704,7 +13704,7 @@ test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more_it
 type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
 
 [extras]
-dev = ["coverage", "docker", "jinja2", "numpy", "pandas", "polars", "pre-commit", "pyarrow", "pytest", "pytest-cov", "pytorch_lightning", "ray", "ray", "ruff", "torch", "transformers"]
+dev = ["coverage", "docker", "jinja2", "numpy", "pandas", "polars", "pre-commit", "pyarrow", "pytest", "pytest-cov", "pytorch_lightning", "ray", "ray", "ruff", "torch", "transformers", "xgboost"]
 example = ["accelerate", "boto3", "chronon-ai", "datasets", "einops", "kaggle", "minio", "mlflow", "numpy", "pandas", "peft", "pyarrow", "pyspark", "pytorch_lightning", "ray", "ray", "ray", "ray", "s3fs", "scikit-learn", "sqlglot", "thrift", "torch", "transformers", "xgboost", "xgboost_ray"]
 mactl = []
 minio = ["minio"]
@@ -13714,9 +13714,10 @@ trainer = ["numpy", "pytorch_lightning", "ray", "ray", "torch", "transformers"]
 trainer-comet = ["comet_ml"]
 trainer-deepspeed = ["deepspeed"]
 trainer-mlflow = ["mlflow"]
+trainer-xgboost = ["numpy", "pandas", "ray", "ray", "xgboost"]
 vllm = ["accelerate", "datasets", "einops", "numpy", "pandas", "pyarrow", "pytorch_lightning", "ray", "ray", "s3fs", "setuptools", "torch", "transformers", "vllm"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9.0"
-content-hash = "c2ce18bb919f0d9d4a5ac617d49d3a6cd6d4ae9cb530a4dc8c86dd0b506c7e21"
+content-hash = "a07cd70bd3f413438ef9773dab9df67f176fadb71f3c61bca350bbacdcb7c578"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -60,9 +60,11 @@ transformers = { version = "4.48.2", optional = true }
 comet_ml = { version = "^3.49.0", optional = true }
 deepspeed = { version = "^0.14.0", optional = true }
 xgboost_ray = {version = "0.1.19", optional = true }
-xgboost = {version = "2.1.4", optional = true }
 kaggle = { version = "^1.6.17", optional = true }
 scikit-learn = { version = "^1.5.2", optional = true }
+
+# For the XGBoost trainer (michelangelo.lib.trainer.xgboost)
+xgboost = {version = "2.1.4", optional = true }
 
 # For MLflow model packaging
 mlflow = { version = "^2.0.0", optional = true }
@@ -83,7 +85,7 @@ ma = 'michelangelo.cli.cli:main'
 
 
 [tool.poetry.extras]
-dev = ["pytest", "pytest-cov", "coverage", "ruff", "jinja2", "pre-commit", "docker", "torch", "pandas", "numpy", "transformers", "pyarrow", "pytorch_lightning", "ray", "polars"]
+dev = ["pytest", "pytest-cov", "coverage", "ruff", "jinja2", "pre-commit", "docker", "torch", "pandas", "numpy", "transformers", "pyarrow", "pytorch_lightning", "ray", "polars", "xgboost"]
 plugin = ["ray", "pyspark"]
 ray-polars = ["ray", "polars"]  # Polars fallback for PyArrow nested-data bug (ray-project/ray#61675)
 example = ["accelerate", "datasets", "numpy", "pandas", "pyarrow", "ray", "s3fs", "torch", "transformers", "pytorch_lightning", "einops", "xgboost", "xgboost_ray", "kaggle", "scikit-learn", "chronon-ai", "thrift", "sqlglot", "pyspark", "ray", "mlflow", "boto3", "peft", "minio"]
@@ -93,6 +95,7 @@ mactl = []
 trainer = ["ray", "torch", "pytorch_lightning", "transformers", "numpy"]
 trainer-comet = ["comet_ml"]
 trainer-mlflow = ["mlflow"]
+trainer-xgboost = ["ray", "xgboost", "numpy", "pandas"]
 trainer-deepspeed = ["deepspeed"]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
Adds `michelangelo.lib.trainer.xgboost` -- a distributed, data-parallel XGBoost trainer built on `ray.train.xgboost.XGBoostTrainer`.

It follows the shape the Lightning trainer already established, so the two read the same way: an `XGBoostTrainerParam` dataclass for configuration, an `XGBoostTrainer` subclassing Ray's trainer, and a `train()` returning `{"checkpoint_path", "path", "metrics"}`. Checkpointing goes through Ray Train's own `RayTrainReportCallback`, so it lands in the run's storage path with no new artifact handling.

Also adds a `trainer-xgboost` extra alongside the existing `trainer-comet` / `trainer-mlflow`, and moves the `xgboost` dependency declaration out of the example-only block, since it now backs library code rather than just an example.

**Why?**
Per #1706. The existing `trainer` extra is deep-learning shaped (ray, torch, lightning, transformers), so there's no supported path for gradient-boosted trees, which cover a lot of tabular ML. Ray Train already has first-class XGBoost support and the Ray provisioning already exists, so this is a wrapper over both rather than new infrastructure.

**How did you test it?**
Unit tests in `tests/test_xgboost_trainer.py` -- dataclass validation, dataset wiring with and without a validation set, the `train()` result contract including the error path, and the worker loop's feature-column inference and eval-set construction. Ray's parent `__init__` and `fit()` are patched throughout, so no cluster is needed. 24 tests, all passing on Python 3.11 / ray 2.56.1 / xgboost 2.1.4.

Also ran it end-to-end against a real local Ray cluster, since mocked tests can't tell you whether the thing actually trains. Five scenarios, all green:

- train + validation across 2 workers -- produces a real checkpoint (`model.ubj`) on disk and reports both `train-rmse` and `validation-rmse`. On synthetic data with a known linear signal, rmse converges to 0.40 against a ~3.6 baseline, so the model is genuinely fitting rather than just running.
- train-only with no validation set -- reports `train-rmse` only, confirming the validation shard is skipped rather than half-wired.
- an explicit `feature_columns` subset.
- single worker.
- a bad `label_column` -- surfaces as a `WorkerGroupError` whose message names the offending column, rather than failing obscurely inside XGBoost.

Note that CI installs only the `dev` extra, so I added `xgboost` there too -- otherwise the tests `importorskip` and never actually run. That does grow the dev install; happy to move them behind a separate extra and a marker instead if you'd rather keep `dev` lean.

**Potential risks**
Low -- this is additive. No existing module imports it, and nothing changes for current trainer users.

Three things worth a reviewer's eye:

**This overlaps #1751.** That PR removes `california_housing_xgb` and, with it, the `xgboost` / `xgboost_ray` dependency declarations. This PR needs `xgboost` to stay declared, so I moved it to its own line rather than leaving it in the example block. If #1751 lands first the two will want a small manual merge -- happy to rebase whichever way you'd prefer, and to sequence behind it.

**No example pipeline.** #1706 proposed one, but since examples are migrating to `michelangelo-examples`, adding one here seemed like it would just need moving again. Glad to write it in whichever repo you'd like.

**`xgboost_ray` is not used.** `ray.train.xgboost` doesn't need it -- the old example imported it only for build-time dependency discovery. This PR doesn't add it to the new extra.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**
New optional `trainer-xgboost` extra providing `michelangelo.lib.trainer.xgboost` for distributed XGBoost training on Ray.

**Documentation Changes**
None yet. Happy to add a user guide page alongside the Lightning trainer docs if you'd like this documented before it ships.
