### PR TITLE
fix(go): pipeline revision resolve and latest

### DIFF
--- a/go/components/pipeline/controller.go
+++ b/go/components/pipeline/controller.go
@@ -83,8 +83,8 @@ func NewReconciler(
 //   - Transitioning the pipeline state to READY
 //   - Persisting status updates back to Kubernetes
 //
-// When Config.RevisioningEnabled is true, it also snapshots a Revision CR and
-// sets pipeline.Status.LatestRevision to point at it.
+// When Config.RevisioningEnabled is true, it also snapshots a Revision CR and,
+// for main/master commits, sets pipeline.Status.LatestRevision to point at it.
 //
 // The reconcile loop will requeue non-terminal pipelines at regular intervals
 // to ensure continuous monitoring. Terminal states (READY, ERROR) do not requeue.
@@ -116,9 +116,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	logger.Info("Reconciling pipeline", zap.Any("PipelineStatusState", state.String()))
 
 	if r.config.RevisioningEnabled && pipeline.Spec.Commit != nil {
-		pipeline.Status.LatestRevision = &apipb.ResourceIdentifier{
-			Name:      formatRevisionName(pipeline),
-			Namespace: pipeline.Namespace,
+		// Only default-branch commits advance status.latestRevision. Feature-branch
+		// applies still snapshot a Revision CR below — they just must not rewrite
+		// what "latest" means for consumers that resolve it.
+		branch := pipeline.Spec.Commit.GetBranch()
+		if branch == "main" || branch == "master" {
+			pipeline.Status.LatestRevision = &apipb.ResourceIdentifier{
+				Name:      formatRevisionName(pipeline),
+				Namespace: pipeline.Namespace,
+			}
 		}
 	}
 	pipeline.Status.State = v2pb.PIPELINE_STATE_READY

--- a/go/components/pipeline/controller_test.go
+++ b/go/components/pipeline/controller_test.go
@@ -158,6 +158,85 @@ func TestReconcile_RevisioningEnabled_NoCommit(t *testing.T) {
 	assert.True(t, err != nil, "no Revision CR should exist when pipeline has no commit")
 }
 
+// status.latestRevision only advances for main/master. Feature-branch reconciles
+// still snapshot a Revision CR — they just don't move the "latest" pointer.
+func TestReconcile_LatestRevisionOnlyOnDefaultBranch(t *testing.T) {
+	testCases := []struct {
+		name                   string
+		branch                 string
+		existingLatestRevision *apipb.ResourceIdentifier
+		expectLatestRevision   *apipb.ResourceIdentifier
+	}{
+		{
+			name:   "main advances latestRevision",
+			branch: "main",
+			expectLatestRevision: &apipb.ResourceIdentifier{
+				Name:      "pipeline-test-pipeline-abc123456789",
+				Namespace: "test-namespace",
+			},
+		},
+		{
+			name:   "master advances latestRevision",
+			branch: "master",
+			expectLatestRevision: &apipb.ResourceIdentifier{
+				Name:      "pipeline-test-pipeline-abc123456789",
+				Namespace: "test-namespace",
+			},
+		},
+		{
+			name:                 "feature branch does not advance latestRevision",
+			branch:               "feature/my-mr",
+			expectLatestRevision: nil,
+		},
+		{
+			name:   "feature branch leaves an existing latestRevision untouched",
+			branch: "feature/my-mr",
+			existingLatestRevision: &apipb.ResourceIdentifier{
+				Name:      "pipeline-test-pipeline-earlier",
+				Namespace: "test-namespace",
+			},
+			expectLatestRevision: &apipb.ResourceIdentifier{
+				Name:      "pipeline-test-pipeline-earlier",
+				Namespace: "test-namespace",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pipeline := &v2pb.Pipeline{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pipeline",
+					Namespace: "test-namespace",
+				},
+				Spec: v2pb.PipelineSpec{
+					Commit: &v2pb.CommitInfo{
+						GitRef: "abc123456789",
+						Branch: tc.branch,
+					},
+				},
+				Status: v2pb.PipelineStatus{
+					LatestRevision: tc.existingLatestRevision,
+				},
+			}
+
+			reconciler := setUpReconciler(t, []client.Object{pipeline}, env.Context{}, Config{RevisioningEnabled: true})
+			_, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "test-pipeline", Namespace: "test-namespace"}})
+			require.NoError(t, err)
+
+			got := &v2pb.Pipeline{}
+			require.NoError(t, reconciler.Get(context.Background(), "test-namespace", "test-pipeline", &metav1.GetOptions{}, got))
+			require.Equal(t, v2pb.PIPELINE_STATE_READY, got.Status.State)
+			assert.Equal(t, tc.expectLatestRevision, got.Status.LatestRevision)
+
+			rev := &v2pb.Revision{}
+			require.NoError(t, reconciler.Get(context.Background(), "test-namespace", "pipeline-test-pipeline-abc123456789", &metav1.GetOptions{}, rev),
+				"Revision CR must still be snapshotted for non-default branches")
+			assert.Equal(t, "abc123456789", rev.Spec.RevisionId)
+		})
+	}
+}
+
 func TestFormatRevisionName(t *testing.T) {
 	testCases := []struct {
 		name           string

--- a/go/components/pipelinerun/apihook/BUILD.bazel
+++ b/go/components/pipelinerun/apihook/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -9,9 +9,30 @@ go_library(
         "//go/api:go_default_library",
         "//go/api/utils:go_default_library",
         "//go/cascadedelete:go_default_library",
+        "//proto/api:go_default_library",
         "//proto/api/v2:go_default_library",
+        "@com_github_gogo_protobuf//types:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@org_uber_go_zap//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["apihook_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//go/api/handler:go_default_library",
+        "//proto/api:go_default_library",
+        "//proto/api/v2:go_default_library",
+        "@com_github_gogo_protobuf//types:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client/fake:go_default_library",
+        "@org_uber_go_zap//zaptest:go_default_library",
     ],
 )

--- a/go/components/pipelinerun/apihook/BUILD.bazel
+++ b/go/components/pipelinerun/apihook/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
     srcs = ["apihook_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//go/api:go_default_library",
         "//go/api/handler:go_default_library",
         "//proto/api:go_default_library",
         "//proto/api/v2:go_default_library",

--- a/go/components/pipelinerun/apihook/apihook.go
+++ b/go/components/pipelinerun/apihook/apihook.go
@@ -2,16 +2,27 @@ package apihook
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"go.uber.org/zap"
+
+	pbtypes "github.com/gogo/protobuf/types"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/michelangelo-ai/michelangelo/go/api"
 	"github.com/michelangelo-ai/michelangelo/go/api/utils"
 	"github.com/michelangelo-ai/michelangelo/go/cascadedelete"
+	apipb "github.com/michelangelo-ai/michelangelo/proto-go/api"
 	v2 "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 )
+
+// pipelineKind is the Revision.Spec.BaseType.Kind value for Pipeline snapshots.
+// Revisions also snapshot other resource kinds (models, deployments), which are
+// not valid targets for a PipelineRun.
+const pipelineKind = "Pipeline"
 
 // RegisterPipelineRunAPIHook registers the API hook that stamps the owning
 // Pipeline as the controller ownerReference on PipelineRuns at creation, so a run
@@ -34,24 +45,231 @@ type apiHook struct {
 }
 
 func (a apiHook) BeforeCreate(ctx context.Context, request *v2.CreatePipelineRunRequest) error {
-	pipelineRef := request.PipelineRun.Spec.GetPipeline()
-	if pipelineRef == nil || pipelineRef.GetName() == "" {
+	// Fetch the live Pipeline once when a pipeline ref is present. Used both to
+	// optionally pin status.latestRevision and to stamp ownerRef / notifications.
+	pipeline, err := a.getReferencedPipeline(ctx, request)
+	if err != nil {
+		return err
+	}
+
+	// Resolve a revision into an inline PipelineSpec before ownerRef stamping, so
+	// stamping and notification inheritance observe any backfilled Spec.Pipeline.
+	//
+	// Priority:
+	//  1. Explicit Spec.Revision — must resolve; failure rejects the create.
+	//  2. Else Pipeline.Status.LatestRevision — pin that snapshot when present.
+	//     If the Revision CR is missing, fall back to the live Pipeline path.
+	if request.PipelineRun.Spec.GetRevision().GetName() != "" {
+		if err = a.resolveRevision(ctx, request); err != nil {
+			a.logger.Error("BeforeCreate: failed to resolve pinned revision",
+				zap.String("revision", request.PipelineRun.Spec.GetRevision().GetName()),
+				zap.String("pipelinerun", request.PipelineRun.GetName()),
+				zap.Error(err))
+			return err
+		}
+	} else if err = a.tryResolveLatestRevision(ctx, request, pipeline); err != nil {
+		a.logger.Error("BeforeCreate: failed to resolve pipeline status.latestRevision",
+			zap.String("pipelinerun", request.PipelineRun.GetName()),
+			zap.Error(err))
+		return err
+	}
+
+	// resolveRevision may have backfilled Spec.Pipeline from the revision's base
+	// resource; fetch now if we did not already have the live Pipeline.
+	if pipeline == nil {
+		pipeline, err = a.getReferencedPipeline(ctx, request)
+		if err != nil {
+			return err
+		}
+	}
+	if pipeline == nil {
+		a.logger.Info("BeforeCreate: no pipeline reference, skipping ownerRef/notifications")
 		return nil
 	}
-	namespace := pipelineRef.GetNamespace()
-	if namespace == "" {
-		namespace = request.PipelineRun.GetNamespace()
+
+	if len(request.PipelineRun.Spec.Notifications) == 0 && len(pipeline.Spec.Notifications) > 0 {
+		request.PipelineRun.Spec.Notifications = pipeline.Spec.Notifications
+		a.logger.Info("BeforeCreate: copied notifications from Pipeline to PipelineRun",
+			zap.Int("count", len(pipeline.Spec.Notifications)))
 	}
+
+	return cascadedelete.StampOwnerRefOnCreate(ctx, a.logger, a.scheme, request.PipelineRun, pipeline)
+}
+
+// getReferencedPipeline loads Spec.Pipeline when set. Any Get failure (including
+// not-found) returns (nil, nil): latestRevision pinning then no-ops (live
+// fallback), and ownerRef/notification stamping is skipped.
+func (a apiHook) getReferencedPipeline(ctx context.Context, request *v2.CreatePipelineRunRequest) (*v2.Pipeline, error) {
+	pipelineRef := request.PipelineRun.Spec.GetPipeline()
+	if pipelineRef.GetName() == "" {
+		return nil, nil
+	}
+
+	namespace := resourceNamespace(pipelineRef, request.PipelineRun.GetNamespace())
+	a.logger.Info("BeforeCreate: fetching pipeline",
+		zap.String("pipeline", pipelineRef.GetName()),
+		zap.String("namespace", namespace),
+		zap.String("pipelinerun", request.PipelineRun.GetName()))
 
 	pipeline := &v2.Pipeline{}
 	if err := a.apiHandler.Get(ctx, namespace, pipelineRef.GetName(), &metav1.GetOptions{}, pipeline); err != nil {
 		if utils.IsNotFoundError(err) {
-			return nil
+			a.logger.Info("BeforeCreate: pipeline not found",
+				zap.String("pipeline", pipelineRef.GetName()),
+				zap.String("namespace", namespace))
+			return nil, nil
 		}
-		a.logger.Warn("BeforeCreate: failed to resolve owning Pipeline for ownerRef",
-			zap.String("pipeline", pipelineRef.GetName()), zap.Error(err))
+		// Soft for ownerRef/notifications: a transient Get failure should not
+		// block PipelineRun create. Callers that require the Pipeline (latest
+		// revision pinning) treat nil as "no pin".
+		a.logger.Warn("BeforeCreate: failed to get Pipeline",
+			zap.String("pipeline", pipelineRef.GetName()),
+			zap.String("namespace", namespace),
+			zap.Error(err))
+		return nil, nil
+	}
+	return pipeline, nil
+}
+
+// tryResolveLatestRevision sets Spec.Revision from pipeline.Status.LatestRevision
+// and resolves it. Missing latestRevision (nil pipeline, unset pointer, empty
+// name, or Revision CR not found) leaves the request unchanged so execution
+// falls back to the live Pipeline. Other resolution errors reject the create.
+func (a apiHook) tryResolveLatestRevision(ctx context.Context, request *v2.CreatePipelineRunRequest, pipeline *v2.Pipeline) error {
+	if request.PipelineRun.Spec.GetPipelineSpec() != nil {
+		// Dev-run / already-inlined spec wins; do not override with latestRevision.
+		return nil
+	}
+	if pipeline == nil {
 		return nil
 	}
 
-	return cascadedelete.StampOwnerRefOnCreate(ctx, a.logger, a.scheme, request.PipelineRun, pipeline)
+	latest := pipeline.Status.GetLatestRevision()
+	if latest.GetName() == "" {
+		a.logger.Info("BeforeCreate: pipeline has no status.latestRevision; falling back to live Pipeline",
+			zap.String("pipeline", pipeline.Name),
+			zap.String("namespace", pipeline.Namespace))
+		return nil
+	}
+
+	revisionNamespace := resourceNamespace(latest, pipeline.Namespace)
+	request.PipelineRun.Spec.Revision = &apipb.ResourceIdentifier{
+		Name:      latest.GetName(),
+		Namespace: revisionNamespace,
+	}
+
+	if err := a.resolveRevision(ctx, request); err != nil {
+		// Clear the tentative pin so SourcePipelineActor still sees a plain
+		// live-Pipeline run when the Revision CR is gone.
+		request.PipelineRun.Spec.Revision = nil
+		request.PipelineRun.Spec.PipelineSpec = nil
+		if isNotFoundError(err) {
+			a.logger.Info("BeforeCreate: status.latestRevision CR not found; falling back to live Pipeline",
+				zap.String("revision", latest.GetName()),
+				zap.String("namespace", revisionNamespace),
+				zap.String("pipeline", pipeline.Name),
+				zap.Error(err))
+			return nil
+		}
+		return err
+	}
+
+	a.logger.Info("BeforeCreate: pinned status.latestRevision into inline pipeline spec",
+		zap.String("revision", latest.GetName()),
+		zap.String("namespace", revisionNamespace),
+		zap.String("pipeline", pipeline.Name),
+		zap.String("pipelinerun", request.PipelineRun.GetName()))
+	return nil
+}
+
+// resourceNamespace returns ref.Namespace, or fallback when the ref omits it.
+func resourceNamespace(ref *apipb.ResourceIdentifier, fallback string) string {
+	if ns := ref.GetNamespace(); ns != "" {
+		return ns
+	}
+	return fallback
+}
+
+// isNotFoundError reports whether err (or any wrapped cause) is a not-found
+// error. resolveRevision wraps apiHandler.Get failures with fmt.Errorf %w.
+func isNotFoundError(err error) bool {
+	for e := err; e != nil; e = errors.Unwrap(e) {
+		if utils.IsNotFoundError(e) {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveRevision loads the Revision CR pinned by Spec.Revision and normalises
+// the request into the same shape as a dev-run: the snapshotted Pipeline's spec
+// is assigned to Spec.PipelineSpec, so the execution path (SourcePipelineActor)
+// needs no revision-aware logic and never reads the live, mutable Pipeline.
+//
+// It also:
+//   - backfills Spec.Pipeline from the revision's base resource when the caller
+//     supplied only a revision, so ownerRef stamping and notification
+//     inheritance keep working;
+//   - carries the snapshot's annotations (e.g. the uniflow image ID) onto the
+//     PipelineRun, since the dev-run path builds the synthesized Pipeline's
+//     annotations from the PipelineRun rather than a live Pipeline.
+//
+// Any resolution failure is returned as an error so the create is rejected.
+func (a apiHook) resolveRevision(ctx context.Context, request *v2.CreatePipelineRunRequest) error {
+	revisionRef := request.PipelineRun.Spec.GetRevision()
+
+	if request.PipelineRun.Spec.GetPipelineSpec() != nil {
+		return fmt.Errorf("pipeline run %q sets both spec.revision (%s) and an inline spec.pipelineSpec; supply exactly one",
+			request.PipelineRun.GetName(), revisionRef.GetName())
+	}
+
+	namespace := resourceNamespace(revisionRef, request.PipelineRun.GetNamespace())
+
+	rev := &v2.Revision{}
+	if err := a.apiHandler.Get(ctx, namespace, revisionRef.GetName(), &metav1.GetOptions{}, rev); err != nil {
+		return fmt.Errorf("resolve revision %s/%s: %w", namespace, revisionRef.GetName(), err)
+	}
+
+	// Revisions snapshot several resource kinds. Pinning a run to a non-Pipeline
+	// revision is a caller bug and must be a loud error, not a fallback.
+	kind := ""
+	if baseType := rev.Spec.GetBaseType(); baseType != nil {
+		kind = baseType.Kind
+	}
+	if kind != pipelineKind {
+		return fmt.Errorf("revision %s/%s snapshots kind %q, not %q; it cannot be used for a pipeline run",
+			namespace, revisionRef.GetName(), kind, pipelineKind)
+	}
+
+	if rev.Spec.GetContent() == nil {
+		return fmt.Errorf("revision %s/%s has no snapshotted content", namespace, revisionRef.GetName())
+	}
+
+	pipeline := &v2.Pipeline{}
+	if err := pbtypes.UnmarshalAny(rev.Spec.Content, pipeline); err != nil {
+		return fmt.Errorf("unmarshal snapshotted pipeline from revision %s/%s: %w", namespace, revisionRef.GetName(), err)
+	}
+
+	request.PipelineRun.Spec.PipelineSpec = &pipeline.Spec
+
+	if request.PipelineRun.Spec.GetPipeline().GetName() == "" {
+		request.PipelineRun.Spec.Pipeline = rev.Spec.GetBaseResource()
+	}
+
+	for k, v := range pipeline.GetAnnotations() {
+		if request.PipelineRun.Annotations == nil {
+			request.PipelineRun.Annotations = map[string]string{}
+		}
+		// PipelineRun-supplied annotations win over the snapshot's.
+		if _, ok := request.PipelineRun.Annotations[k]; !ok {
+			request.PipelineRun.Annotations[k] = v
+		}
+	}
+
+	a.logger.Info("BeforeCreate: resolved pinned revision into inline pipeline spec",
+		zap.String("revision", revisionRef.GetName()),
+		zap.String("namespace", namespace),
+		zap.String("pipelinerun", request.PipelineRun.GetName()))
+
+	return nil
 }

--- a/go/components/pipelinerun/apihook/apihook.go
+++ b/go/components/pipelinerun/apihook/apihook.go
@@ -46,10 +46,7 @@ type apiHook struct {
 func (a apiHook) BeforeCreate(ctx context.Context, request *v2.CreatePipelineRunRequest) error {
 	// Fetch the live Pipeline once when a pipeline ref is present. Used both to
 	// optionally pin status.latestRevision and to stamp ownerRef / notifications.
-	pipeline, err := a.getReferencedPipeline(ctx, request)
-	if err != nil {
-		return err
-	}
+	pipeline := a.getReferencedPipeline(ctx, request)
 
 	// Resolve a revision into an inline PipelineSpec before ownerRef stamping, so
 	// stamping and notification inheritance observe any backfilled Spec.Pipeline.
@@ -59,14 +56,14 @@ func (a apiHook) BeforeCreate(ctx context.Context, request *v2.CreatePipelineRun
 	//  2. Else Pipeline.Status.LatestRevision — pin that snapshot when present.
 	//     If the Revision CR is missing, fall back to the live Pipeline path.
 	if request.PipelineRun.Spec.GetRevision().GetName() != "" {
-		if err = a.resolveRevision(ctx, request); err != nil {
+		if err := a.resolveRevision(ctx, request); err != nil {
 			a.logger.Error("BeforeCreate: failed to resolve pinned revision",
 				zap.String("revision", request.PipelineRun.Spec.GetRevision().GetName()),
 				zap.String("pipelinerun", request.PipelineRun.GetName()),
 				zap.Error(err))
 			return err
 		}
-	} else if err = a.tryResolveLatestRevision(ctx, request, pipeline); err != nil {
+	} else if err := a.tryResolveLatestRevision(ctx, request, pipeline); err != nil {
 		a.logger.Error("BeforeCreate: failed to resolve pipeline status.latestRevision",
 			zap.String("pipelinerun", request.PipelineRun.GetName()),
 			zap.Error(err))
@@ -76,10 +73,7 @@ func (a apiHook) BeforeCreate(ctx context.Context, request *v2.CreatePipelineRun
 	// resolveRevision may have backfilled Spec.Pipeline from the revision's base
 	// resource; fetch now if we did not already have the live Pipeline.
 	if pipeline == nil {
-		pipeline, err = a.getReferencedPipeline(ctx, request)
-		if err != nil {
-			return err
-		}
+		pipeline = a.getReferencedPipeline(ctx, request)
 	}
 	if pipeline == nil {
 		a.logger.Info("BeforeCreate: no pipeline reference, skipping ownerRef/notifications")
@@ -96,12 +90,12 @@ func (a apiHook) BeforeCreate(ctx context.Context, request *v2.CreatePipelineRun
 }
 
 // getReferencedPipeline loads Spec.Pipeline when set. Any Get failure (including
-// not-found) returns (nil, nil): latestRevision pinning then no-ops (live
-// fallback), and ownerRef/notification stamping is skipped.
-func (a apiHook) getReferencedPipeline(ctx context.Context, request *v2.CreatePipelineRunRequest) (*v2.Pipeline, error) {
+// not-found) returns nil: latestRevision pinning then no-ops (live fallback),
+// and ownerRef/notification stamping is skipped.
+func (a apiHook) getReferencedPipeline(ctx context.Context, request *v2.CreatePipelineRunRequest) *v2.Pipeline {
 	pipelineRef := request.PipelineRun.Spec.GetPipeline()
 	if pipelineRef.GetName() == "" {
-		return nil, nil
+		return nil
 	}
 
 	namespace := resourceNamespace(pipelineRef, request.PipelineRun.GetNamespace())
@@ -116,7 +110,7 @@ func (a apiHook) getReferencedPipeline(ctx context.Context, request *v2.CreatePi
 			a.logger.Info("BeforeCreate: pipeline not found",
 				zap.String("pipeline", pipelineRef.GetName()),
 				zap.String("namespace", namespace))
-			return nil, nil
+			return nil
 		}
 		// Soft for ownerRef/notifications: a transient Get failure should not
 		// block PipelineRun create. Callers that require the Pipeline (latest
@@ -125,9 +119,9 @@ func (a apiHook) getReferencedPipeline(ctx context.Context, request *v2.CreatePi
 			zap.String("pipeline", pipelineRef.GetName()),
 			zap.String("namespace", namespace),
 			zap.Error(err))
-		return nil, nil
+		return nil
 	}
-	return pipeline, nil
+	return pipeline
 }
 
 // tryResolveLatestRevision sets Spec.Revision from pipeline.Status.LatestRevision
@@ -195,6 +189,9 @@ func resourceNamespace(ref *apipb.ResourceIdentifier, fallback string) string {
 // needs no revision-aware logic and never reads the live, mutable Pipeline.
 //
 // It also:
+//   - rejects the create when Spec.Pipeline is set and does not match the
+//     revision's base resource (name or namespace), so we never execute B's
+//     snapshot while stamping ownerRef / notifications from A;
 //   - backfills Spec.Pipeline from the revision's base resource when the caller
 //     supplied only a revision, so ownerRef stamping and notification
 //     inheritance keep working;
@@ -241,11 +238,20 @@ func (a apiHook) resolveRevision(ctx context.Context, request *v2.CreatePipeline
 		return fmt.Errorf("unmarshal snapshotted pipeline from revision %s/%s: %w", namespace, revisionRef.GetName(), err)
 	}
 
-	request.PipelineRun.Spec.PipelineSpec = &pipeline.Spec
-
-	if request.PipelineRun.Spec.GetPipeline().GetName() == "" {
-		request.PipelineRun.Spec.Pipeline = rev.Spec.GetBaseResource()
+	pipelineRef := request.PipelineRun.Spec.GetPipeline()
+	base := rev.Spec.GetBaseResource()
+	runNS := request.PipelineRun.GetNamespace()
+	if pipelineRef.GetName() == "" {
+		request.PipelineRun.Spec.Pipeline = base
+	} else if pipelineRef.GetName() != base.GetName() || resourceNamespace(pipelineRef, runNS) != resourceNamespace(base, runNS) {
+		return fmt.Errorf("pipeline run %q references pipeline %s/%s but revision %s/%s snapshots %s/%s",
+			request.PipelineRun.GetName(),
+			resourceNamespace(pipelineRef, runNS), pipelineRef.GetName(),
+			namespace, revisionRef.GetName(),
+			resourceNamespace(base, runNS), base.GetName())
 	}
+
+	request.PipelineRun.Spec.PipelineSpec = &pipeline.Spec
 
 	for k, v := range pipeline.GetAnnotations() {
 		if request.PipelineRun.Annotations == nil {

--- a/go/components/pipelinerun/apihook/apihook.go
+++ b/go/components/pipelinerun/apihook/apihook.go
@@ -2,7 +2,6 @@ package apihook
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"go.uber.org/zap"
@@ -163,7 +162,7 @@ func (a apiHook) tryResolveLatestRevision(ctx context.Context, request *v2.Creat
 		// live-Pipeline run when the Revision CR is gone.
 		request.PipelineRun.Spec.Revision = nil
 		request.PipelineRun.Spec.PipelineSpec = nil
-		if isNotFoundError(err) {
+		if utils.IsNotFoundError(err) {
 			a.logger.Info("BeforeCreate: status.latestRevision CR not found; falling back to live Pipeline",
 				zap.String("revision", latest.GetName()),
 				zap.String("namespace", revisionNamespace),
@@ -188,17 +187,6 @@ func resourceNamespace(ref *apipb.ResourceIdentifier, fallback string) string {
 		return ns
 	}
 	return fallback
-}
-
-// isNotFoundError reports whether err (or any wrapped cause) is a not-found
-// error. resolveRevision wraps apiHandler.Get failures with fmt.Errorf %w.
-func isNotFoundError(err error) bool {
-	for e := err; e != nil; e = errors.Unwrap(e) {
-		if utils.IsNotFoundError(e) {
-			return true
-		}
-	}
-	return false
 }
 
 // resolveRevision loads the Revision CR pinned by Spec.Revision and normalises
@@ -227,7 +215,10 @@ func (a apiHook) resolveRevision(ctx context.Context, request *v2.CreatePipeline
 
 	rev := &v2.Revision{}
 	if err := a.apiHandler.Get(ctx, namespace, revisionRef.GetName(), &metav1.GetOptions{}, rev); err != nil {
-		return fmt.Errorf("resolve revision %s/%s: %w", namespace, revisionRef.GetName(), err)
+		// Returned unwrapped: the handler already reports namespace and name, and
+		// callers classify it with utils.IsNotFoundError, which does not walk the
+		// error chain.
+		return err
 	}
 
 	// Revisions snapshot several resource kinds. Pinning a run to a non-Pipeline

--- a/go/components/pipelinerun/apihook/apihook_test.go
+++ b/go/components/pipelinerun/apihook/apihook_test.go
@@ -159,7 +159,7 @@ func TestBeforeCreate_RejectsMissingRevision(t *testing.T) {
 
 	err := hook.BeforeCreate(context.Background(), newCreateRequest("does-not-exist"))
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "resolve revision")
+	assert.Contains(t, err.Error(), "does-not-exist")
 }
 
 func TestBeforeCreate_RejectsRevisionWithoutContent(t *testing.T) {
@@ -329,5 +329,5 @@ func TestBeforeCreate_ExplicitMissingRevisionStillRejected(t *testing.T) {
 	}
 	err := hook.BeforeCreate(context.Background(), request)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "resolve revision")
+	assert.Contains(t, err.Error(), "does-not-exist")
 }

--- a/go/components/pipelinerun/apihook/apihook_test.go
+++ b/go/components/pipelinerun/apihook/apihook_test.go
@@ -2,6 +2,7 @@ package apihook
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,6 +15,7 @@ import (
 
 	pbtypes "github.com/gogo/protobuf/types"
 
+	"github.com/michelangelo-ai/michelangelo/go/api"
 	apiHandler "github.com/michelangelo-ai/michelangelo/go/api/handler"
 	apipb "github.com/michelangelo-ai/michelangelo/proto-go/api"
 	v2 "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
@@ -330,4 +332,197 @@ func TestBeforeCreate_ExplicitMissingRevisionStillRejected(t *testing.T) {
 	err := hook.BeforeCreate(context.Background(), request)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "does-not-exist")
+}
+
+// Spec.Pipeline must identify the same Pipeline the Revision snapshotted.
+// Otherwise we would execute B's spec while stamping ownerRef / notifications from A.
+func TestBeforeCreate_RejectsRevisionOfDifferentPipeline(t *testing.T) {
+	snapshottedB := &v2.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "pipeline-b", Namespace: testNamespace},
+		Spec:       v2.PipelineSpec{Description: "snapshot B"},
+	}
+	liveA := &v2.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "pipeline-a", Namespace: testNamespace},
+	}
+	hook := setUpHook(t, liveA, snapshotRevision(t, "rev-b", snapshottedB))
+
+	request := newCreateRequest("rev-b")
+	request.PipelineRun.Spec.Pipeline = &apipb.ResourceIdentifier{
+		Name:      "pipeline-a",
+		Namespace: testNamespace,
+	}
+	err := hook.BeforeCreate(context.Background(), request)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pipeline-a")
+	assert.Contains(t, err.Error(), "pipeline-b")
+	assert.Nil(t, request.PipelineRun.Spec.PipelineSpec,
+		"must not materialize a mismatched snapshot")
+}
+
+func TestBeforeCreate_RejectsRevisionOfDifferentPipelineNamespace(t *testing.T) {
+	snapshotted := &v2.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline", Namespace: "other-namespace"},
+		Spec:       v2.PipelineSpec{Description: "other ns"},
+	}
+	live := &v2.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline", Namespace: testNamespace},
+	}
+	hook := setUpHook(t, live, snapshotRevision(t, "rev-x", snapshotted))
+
+	request := newCreateRequest("rev-x")
+	request.PipelineRun.Spec.Pipeline = &apipb.ResourceIdentifier{
+		Name:      "test-pipeline",
+		Namespace: testNamespace,
+	}
+	err := hook.BeforeCreate(context.Background(), request)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), testNamespace)
+	assert.Contains(t, err.Error(), "other-namespace")
+	assert.Nil(t, request.PipelineRun.Spec.PipelineSpec)
+}
+
+func TestBeforeCreate_MatchingPipelineAndRevisionSucceeds(t *testing.T) {
+	snapshotted := &v2.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline", Namespace: testNamespace},
+		Spec:       v2.PipelineSpec{Description: "revision X"},
+	}
+	live := &v2.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline", Namespace: testNamespace},
+	}
+	hook := setUpHook(t, live, snapshotRevision(t, "rev-x", snapshotted))
+
+	request := newCreateRequest("rev-x")
+	request.PipelineRun.Spec.Pipeline = &apipb.ResourceIdentifier{
+		Name:      "test-pipeline",
+		Namespace: testNamespace,
+	}
+	require.NoError(t, hook.BeforeCreate(context.Background(), request))
+	require.NotNil(t, request.PipelineRun.Spec.PipelineSpec)
+	assert.Equal(t, "revision X", request.PipelineRun.Spec.PipelineSpec.Description)
+}
+
+// interceptGetHandler optionally fails Get for selected object kinds so tests
+// can exercise the soft-fail path that the fake client cannot produce.
+type interceptGetHandler struct {
+	api.Handler
+	failPipeline error
+}
+
+func (h interceptGetHandler) Get(ctx context.Context, namespace, name string, opts *metav1.GetOptions, obj client.Object) error {
+	if h.failPipeline != nil {
+		if _, ok := obj.(*v2.Pipeline); ok {
+			return h.failPipeline
+		}
+	}
+	return h.Handler.Get(ctx, namespace, name, opts, obj)
+}
+
+func TestBeforeCreate_CopiesNotificationsFromPipeline(t *testing.T) {
+	live := &v2.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline", Namespace: testNamespace},
+		Spec: v2.PipelineSpec{
+			Notifications: []*v2.Notification{{
+				NotificationType: v2.NOTIFICATION_TYPE_EMAIL,
+				Emails:           []string{"alerts@example.com"},
+			}},
+		},
+	}
+	hook := setUpHook(t, live)
+
+	request := newPipelineRefRequest("test-pipeline")
+	require.NoError(t, hook.BeforeCreate(context.Background(), request))
+	require.Len(t, request.PipelineRun.Spec.Notifications, 1)
+	assert.Equal(t, "alerts@example.com", request.PipelineRun.Spec.Notifications[0].Emails[0])
+}
+
+func TestBeforeCreate_InlinePipelineSpecSkipsLatestRevision(t *testing.T) {
+	live := &v2.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline", Namespace: testNamespace},
+		Status: v2.PipelineStatus{
+			LatestRevision: &apipb.ResourceIdentifier{
+				Name:      "pipeline-test-pipeline-master",
+				Namespace: testNamespace,
+			},
+		},
+	}
+	hook := setUpHook(t, live)
+
+	request := newPipelineRefRequest("test-pipeline")
+	request.PipelineRun.Spec.PipelineSpec = &v2.PipelineSpec{Description: "dev-run"}
+	require.NoError(t, hook.BeforeCreate(context.Background(), request))
+
+	assert.Nil(t, request.PipelineRun.Spec.Revision, "inline spec must not be overwritten by latestRevision")
+	assert.Equal(t, "dev-run", request.PipelineRun.Spec.PipelineSpec.Description)
+}
+
+func TestBeforeCreate_LatestRevisionWrongKindRejected(t *testing.T) {
+	rev := snapshotRevision(t, "rev-model", &v2.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline", Namespace: testNamespace},
+	})
+	rev.Spec.BaseType.Kind = "Model"
+	live := &v2.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline", Namespace: testNamespace},
+		Status: v2.PipelineStatus{
+			LatestRevision: &apipb.ResourceIdentifier{
+				Name:      "rev-model",
+				Namespace: testNamespace,
+			},
+		},
+	}
+	hook := setUpHook(t, live, rev)
+
+	err := hook.BeforeCreate(context.Background(), newPipelineRefRequest("test-pipeline"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `snapshots kind "Model"`)
+}
+
+func TestBeforeCreate_RejectsRevisionWithCorruptContent(t *testing.T) {
+	rev := snapshotRevision(t, "rev-bad", &v2.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline", Namespace: testNamespace},
+	})
+	rev.Spec.Content = &pbtypes.Any{
+		TypeUrl: "type.googleapis.com/michelangelo.api.v2.Pipeline",
+		Value:   []byte("not-valid-protobuf"),
+	}
+	hook := setUpHook(t, rev)
+
+	err := hook.BeforeCreate(context.Background(), newCreateRequest("rev-bad"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unmarshal snapshotted pipeline")
+}
+
+func TestBeforeCreate_RevisionNamespaceFallsBackToPipelineRun(t *testing.T) {
+	snapshotted := &v2.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline", Namespace: testNamespace},
+		Spec:       v2.PipelineSpec{Description: "revision X"},
+	}
+	hook := setUpHook(t, snapshotRevision(t, "rev-x", snapshotted))
+
+	request := newCreateRequest("rev-x")
+	request.PipelineRun.Spec.Revision.Namespace = ""
+	require.NoError(t, hook.BeforeCreate(context.Background(), request))
+	require.NotNil(t, request.PipelineRun.Spec.PipelineSpec)
+	assert.Equal(t, "revision X", request.PipelineRun.Spec.PipelineSpec.Description)
+}
+
+func TestBeforeCreate_PipelineGetTransientErrorIsSoft(t *testing.T) {
+	live := &v2.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline", Namespace: testNamespace},
+		Status: v2.PipelineStatus{
+			LatestRevision: &apipb.ResourceIdentifier{
+				Name:      "pipeline-test-pipeline-master",
+				Namespace: testNamespace,
+			},
+		},
+	}
+	hook := setUpHook(t, live)
+	hook.apiHandler = interceptGetHandler{
+		Handler:      hook.apiHandler,
+		failPipeline: fmt.Errorf("apiserver unavailable"),
+	}
+
+	request := newPipelineRefRequest("test-pipeline")
+	require.NoError(t, hook.BeforeCreate(context.Background(), request))
+	assert.Nil(t, request.PipelineRun.Spec.Revision)
+	assert.Nil(t, request.PipelineRun.Spec.PipelineSpec)
 }

--- a/go/components/pipelinerun/apihook/apihook_test.go
+++ b/go/components/pipelinerun/apihook/apihook_test.go
@@ -1,0 +1,333 @@
+package apihook
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	pbtypes "github.com/gogo/protobuf/types"
+
+	apiHandler "github.com/michelangelo-ai/michelangelo/go/api/handler"
+	apipb "github.com/michelangelo-ai/michelangelo/proto-go/api"
+	v2 "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
+)
+
+const testNamespace = "test-namespace"
+
+func setUpHook(t *testing.T, initialObjects ...client.Object) apiHook {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, v2.AddToScheme(scheme))
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initialObjects...).Build()
+	return apiHook{
+		logger:     zaptest.NewLogger(t),
+		apiHandler: apiHandler.NewFakeAPIHandler(k8sClient),
+		scheme:     scheme,
+	}
+}
+
+// snapshotRevision builds a Revision CR whose content snapshots the given
+// Pipeline, mirroring what the pipeline controller's snapshotRevision produces.
+func snapshotRevision(t *testing.T, name string, pipeline *v2.Pipeline) *v2.Revision {
+	t.Helper()
+	content, err := pbtypes.MarshalAny(pipeline)
+	require.NoError(t, err)
+	return &v2.Revision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+		},
+		Spec: v2.RevisionSpec{
+			BaseType: &metav1.TypeMeta{
+				Kind:       "Pipeline",
+				APIVersion: "michelangelo.api/v2",
+			},
+			BaseResource: &apipb.ResourceIdentifier{
+				Name:      pipeline.Name,
+				Namespace: pipeline.Namespace,
+			},
+			Content: content,
+		},
+	}
+}
+
+func newCreateRequest(revisionName string) *v2.CreatePipelineRunRequest {
+	return &v2.CreatePipelineRunRequest{
+		PipelineRun: &v2.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-run",
+				Namespace: testNamespace,
+			},
+			Spec: v2.PipelineRunSpec{
+				Revision: &apipb.ResourceIdentifier{
+					Name:      revisionName,
+					Namespace: testNamespace,
+				},
+			},
+		},
+	}
+}
+
+// A run pinned to revision X must execute X's snapshotted spec even after the
+// live Pipeline has been mutated to Y. The hook normalises the pinned run into
+// a dev-run shape (inline PipelineSpec), which the execution path uses verbatim.
+func TestBeforeCreate_ResolvesPinnedRevisionSnapshotNotLivePipeline(t *testing.T) {
+	snapshotted := &v2.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-pipeline",
+			Namespace:   testNamespace,
+			Annotations: map[string]string{"michelangelo.ai/uniflow-image-id": "image-x"},
+		},
+		Spec: v2.PipelineSpec{
+			Description: "revision X",
+			Commit:      &v2.CommitInfo{GitRef: "commit-x", Branch: "main"},
+		},
+	}
+	livePipeline := &v2.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pipeline",
+			Namespace: testNamespace,
+		},
+		Spec: v2.PipelineSpec{
+			Description: "mutated to Y",
+			Commit:      &v2.CommitInfo{GitRef: "commit-y", Branch: "main"},
+		},
+	}
+	hook := setUpHook(t, livePipeline, snapshotRevision(t, "pipeline-test-pipeline-commit-x", snapshotted))
+
+	request := newCreateRequest("pipeline-test-pipeline-commit-x")
+	require.NoError(t, hook.BeforeCreate(context.Background(), request))
+
+	spec := request.PipelineRun.Spec
+	require.NotNil(t, spec.PipelineSpec, "pinned run must be normalised into an inline PipelineSpec")
+	assert.Equal(t, "revision X", spec.PipelineSpec.Description, "must use the snapshotted spec, not the live Pipeline")
+	assert.Equal(t, "commit-x", spec.PipelineSpec.Commit.GitRef)
+
+	// Spec.Pipeline is backfilled from the revision's base resource so ownerRef
+	// stamping and notification inheritance keep working.
+	require.NotNil(t, spec.Pipeline)
+	assert.Equal(t, "test-pipeline", spec.Pipeline.Name)
+
+	// Snapshot annotations are carried onto the PipelineRun, which is where the
+	// dev-run path reads them from.
+	assert.Equal(t, "image-x", request.PipelineRun.Annotations["michelangelo.ai/uniflow-image-id"])
+}
+
+func TestBeforeCreate_RunAnnotationsWinOverSnapshot(t *testing.T) {
+	snapshotted := &v2.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-pipeline",
+			Namespace:   testNamespace,
+			Annotations: map[string]string{"michelangelo.ai/uniflow-image-id": "snapshot-image"},
+		},
+		Spec: v2.PipelineSpec{Description: "revision X"},
+	}
+	hook := setUpHook(t, snapshotRevision(t, "rev-x", snapshotted))
+
+	request := newCreateRequest("rev-x")
+	request.PipelineRun.Annotations = map[string]string{"michelangelo.ai/uniflow-image-id": "run-image"}
+	require.NoError(t, hook.BeforeCreate(context.Background(), request))
+
+	assert.Equal(t, "run-image", request.PipelineRun.Annotations["michelangelo.ai/uniflow-image-id"])
+}
+
+// Revisions snapshot several resource kinds; a non-Pipeline revision must be
+// rejected loudly rather than falling back to the live Pipeline.
+func TestBeforeCreate_RejectsNonPipelineRevision(t *testing.T) {
+	rev := snapshotRevision(t, "rev-model", &v2.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline", Namespace: testNamespace},
+	})
+	rev.Spec.BaseType.Kind = "Model"
+	hook := setUpHook(t, rev)
+
+	err := hook.BeforeCreate(context.Background(), newCreateRequest("rev-model"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `snapshots kind "Model"`)
+}
+
+// An unresolvable revision must fail the create; silently falling back to the
+// live Pipeline is exactly the reproducibility bug this hook fixes.
+func TestBeforeCreate_RejectsMissingRevision(t *testing.T) {
+	hook := setUpHook(t)
+
+	err := hook.BeforeCreate(context.Background(), newCreateRequest("does-not-exist"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resolve revision")
+}
+
+func TestBeforeCreate_RejectsRevisionWithoutContent(t *testing.T) {
+	rev := snapshotRevision(t, "rev-empty", &v2.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline", Namespace: testNamespace},
+	})
+	rev.Spec.Content = nil
+	hook := setUpHook(t, rev)
+
+	err := hook.BeforeCreate(context.Background(), newCreateRequest("rev-empty"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no snapshotted content")
+}
+
+func TestBeforeCreate_RejectsRevisionAndInlineSpecTogether(t *testing.T) {
+	hook := setUpHook(t)
+
+	request := newCreateRequest("rev-x")
+	request.PipelineRun.Spec.PipelineSpec = &v2.PipelineSpec{Description: "inline"}
+
+	err := hook.BeforeCreate(context.Background(), request)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "supply exactly one")
+}
+
+// A run without a pinned revision and without a pipeline reference is unchanged.
+func TestBeforeCreate_NoRevisionNoPipelineIsUnchanged(t *testing.T) {
+	hook := setUpHook(t)
+
+	request := &v2.CreatePipelineRunRequest{
+		PipelineRun: &v2.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-run", Namespace: testNamespace},
+		},
+	}
+	require.NoError(t, hook.BeforeCreate(context.Background(), request))
+	assert.Nil(t, request.PipelineRun.Spec.PipelineSpec)
+	assert.Nil(t, request.PipelineRun.Spec.Revision)
+}
+
+func newPipelineRefRequest(pipelineName string) *v2.CreatePipelineRunRequest {
+	return &v2.CreatePipelineRunRequest{
+		PipelineRun: &v2.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-run",
+				Namespace: testNamespace,
+			},
+			Spec: v2.PipelineRunSpec{
+				Pipeline: &apipb.ResourceIdentifier{
+					Name:      pipelineName,
+					Namespace: testNamespace,
+				},
+			},
+		},
+	}
+}
+
+// When Spec.Revision is omitted, BeforeCreate pins Pipeline.Status.LatestRevision
+// into an inline PipelineSpec (same shape as an explicit pin).
+func TestBeforeCreate_ResolvesLatestRevisionWhenRevisionOmitted(t *testing.T) {
+	snapshotted := &v2.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-pipeline",
+			Namespace:   testNamespace,
+			Annotations: map[string]string{"michelangelo.ai/uniflow-image-id": "image-latest"},
+		},
+		Spec: v2.PipelineSpec{
+			Description: "latest revision snapshot",
+			Commit:      &v2.CommitInfo{GitRef: "commit-latest", Branch: "master"},
+		},
+	}
+	livePipeline := &v2.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pipeline",
+			Namespace: testNamespace,
+		},
+		Spec: v2.PipelineSpec{
+			Description: "live pipeline mutated",
+			Commit:      &v2.CommitInfo{GitRef: "commit-live", Branch: "master"},
+		},
+		Status: v2.PipelineStatus{
+			LatestRevision: &apipb.ResourceIdentifier{
+				Name:      "pipeline-test-pipeline-master",
+				Namespace: testNamespace,
+			},
+		},
+	}
+	hook := setUpHook(t, livePipeline, snapshotRevision(t, "pipeline-test-pipeline-master", snapshotted))
+
+	request := newPipelineRefRequest("test-pipeline")
+	require.NoError(t, hook.BeforeCreate(context.Background(), request))
+
+	spec := request.PipelineRun.Spec
+	require.NotNil(t, spec.Revision, "latestRevision must be recorded on the run")
+	assert.Equal(t, "pipeline-test-pipeline-master", spec.Revision.Name)
+	require.NotNil(t, spec.PipelineSpec)
+	assert.Equal(t, "latest revision snapshot", spec.PipelineSpec.Description,
+		"must use the latestRevision snapshot, not the live Pipeline")
+	assert.Equal(t, "commit-latest", spec.PipelineSpec.Commit.GitRef)
+	assert.Equal(t, "image-latest", request.PipelineRun.Annotations["michelangelo.ai/uniflow-image-id"])
+}
+
+// Missing status.latestRevision leaves the run on the live Pipeline path.
+func TestBeforeCreate_NoLatestRevisionFallsBackToLivePipeline(t *testing.T) {
+	livePipeline := &v2.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pipeline",
+			Namespace: testNamespace,
+		},
+		Spec: v2.PipelineSpec{Description: "live only"},
+	}
+	hook := setUpHook(t, livePipeline)
+
+	request := newPipelineRefRequest("test-pipeline")
+	require.NoError(t, hook.BeforeCreate(context.Background(), request))
+
+	assert.Nil(t, request.PipelineRun.Spec.Revision)
+	assert.Nil(t, request.PipelineRun.Spec.PipelineSpec,
+		"no inline spec — SourcePipelineActor will load the live Pipeline")
+}
+
+// status.latestRevision pointing at a missing Revision CR falls back to live.
+func TestBeforeCreate_MissingLatestRevisionCRFallsBackToLivePipeline(t *testing.T) {
+	livePipeline := &v2.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pipeline",
+			Namespace: testNamespace,
+		},
+		Spec: v2.PipelineSpec{Description: "live only"},
+		Status: v2.PipelineStatus{
+			LatestRevision: &apipb.ResourceIdentifier{
+				Name:      "pipeline-test-pipeline-gone",
+				Namespace: testNamespace,
+			},
+		},
+	}
+	hook := setUpHook(t, livePipeline)
+
+	request := newPipelineRefRequest("test-pipeline")
+	require.NoError(t, hook.BeforeCreate(context.Background(), request))
+
+	assert.Nil(t, request.PipelineRun.Spec.Revision,
+		"tentative pin must be cleared after the Revision CR miss")
+	assert.Nil(t, request.PipelineRun.Spec.PipelineSpec)
+}
+
+// An explicit Spec.Revision still hard-fails when missing; latestRevision
+// fallback applies only when the caller omitted revision.
+func TestBeforeCreate_ExplicitMissingRevisionStillRejected(t *testing.T) {
+	livePipeline := &v2.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pipeline",
+			Namespace: testNamespace,
+		},
+		Status: v2.PipelineStatus{
+			LatestRevision: &apipb.ResourceIdentifier{
+				Name:      "pipeline-test-pipeline-master",
+				Namespace: testNamespace,
+			},
+		},
+	}
+	hook := setUpHook(t, livePipeline)
+
+	request := newCreateRequest("does-not-exist")
+	request.PipelineRun.Spec.Pipeline = &apipb.ResourceIdentifier{
+		Name:      "test-pipeline",
+		Namespace: testNamespace,
+	}
+	err := hook.BeforeCreate(context.Background(), request)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resolve revision")
+}


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Two related fixes so Pipeline revisioning behaves correctly end-to-end: (1) PipelineRuns can pin a Revision into an inline `pipelineSpec` at create time, and (2) `Pipeline.status.latestRevision` only advances for default-branch commits.

### 1) PipelineRun create hook — resolve Revision → inline `pipelineSpec`
(`go/components/pipelinerun/apihook`)

On `BeforeCreate`, when a PipelineRun references a Pipeline:

1. **Explicit `spec.revision`** → load the Revision CR, unmarshal the snapshotted Pipeline, set `spec.pipelineSpec`, backfill `spec.pipeline` / annotations as needed. **Hard-fail** if the Revision is missing, not a Pipeline snapshot, empty, or conflicts with an existing inline `pipelineSpec`.
2. **No `spec.revision`** → if the live Pipeline has `status.latestRevision`, pin and resolve it the same way.
3. **Soft fallback to live Pipeline** when latestRevision is unset, the Pipeline Get soft-fails, or the Revision CR is not found (clear the tentative pin so SourcePipelineActor still runs against the live Pipeline).
4. Existing inline `spec.pipelineSpec` (dev-run) wins — do not override with latestRevision.
5. OwnerRef stamping + notification inheritance still run after resolution (and observe any backfilled `spec.pipeline`).

### 2) Pipeline controller — gate `status.latestRevision` to `main` / `master`
(`go/components/pipeline`)

When revisioning is enabled, every commit still upserts a Revision CR, but **`status.latestRevision` is only updated when `spec.commit.branch` is `main` or `master`**. Feature-branch applies no longer rewrite what “latest” means for create-hook consumers.

**Why?**

Without (1), omitting `spec.revision` always meant “use the mutable live Pipeline,” even when the platform had already published a stable latestRevision. Explicit revision also needed to be materialized into the same shape as a dev-run (`pipelineSpec`) so the execution path stays revision-agnostic.

Without (2), applying a Pipeline from a feature branch would advance `status.latestRevision` to that branch’s snapshot. Subsequent PipelineRuns that omit `spec.revision` would then pin an unintended (non-default) revision.

Together: default-branch publishes “latest”; create-time resolution prefers that pin when present, with a safe live fallback when it is not.

### Behaviour overview

```mermaid
flowchart TD
  A[CreatePipelineRun BeforeCreate] --> B{spec.revision set?}
  B -->|yes| C[resolveRevision]
  C -->|ok| D[Set spec.pipelineSpec<br/>backfill pipeline + annotations]
  C -->|error| E[Reject create]
  B -->|no| F{inline pipelineSpec already set?}
  F -->|yes| G[Skip pin — keep dev-run]
  F -->|no| H{Pipeline.status.latestRevision?}
  H -->|empty / no Pipeline| I[Live Pipeline path]
  H -->|present| J[Pin Spec.Revision = latestRevision]
  J --> K[resolveRevision]
  K -->|ok| D
  K -->|Revision not found| L[Clear pin → live Pipeline]
  K -->|other error| E
  D --> M[Notifications + ownerRef stamp]
  G --> M
  I --> M
  L --> M
```

```mermaid
flowchart LR
  subgraph pipeline_reconcile[Pipeline Reconcile — revisioningEnabled]
    P[Pipeline with Spec.Commit] --> U[Upsert Revision CR]
    U --> BR{branch == main or master?}
    BR -->|yes| LR[Set status.latestRevision]
    BR -->|no| SKIP[Do not advance latestRevision\nRevision CR still exists]
  end
```

```mermaid
sequenceDiagram
  participant Client
  participant APIHook as PipelineRun BeforeCreate
  participant Pipeline
  participant Revision
  participant SPA as SourcePipelineActor

  Client->>APIHook: CreatePipelineRun (pipeline ref, optional revision)
  APIHook->>Pipeline: Get live Pipeline
  alt explicit revision
    APIHook->>Revision: Get Revision
    Revision-->>APIHook: snapshotted Pipeline Any
    APIHook->>APIHook: pipelineSpec = snapshot.Spec
  else no revision, latestRevision present
    APIHook->>Revision: Get status.latestRevision
    alt found
      APIHook->>APIHook: pin + pipelineSpec
    else not found
      APIHook->>APIHook: fall back to live Pipeline
    end
  else no latestRevision
    APIHook->>APIHook: live Pipeline path
  end
  APIHook-->>Client: Create accepted
  Note over SPA: Execution uses inline pipelineSpec if present, otherwise the live Pipeline
```

**How did you test it?**

- Unit tests in `go/components/pipelinerun/apihook/apihook_test.go`:
  - explicit revision → inline `pipelineSpec`
  - missing explicit revision → create rejected
  - no revision + `status.latestRevision` → pinned
  - latestRevision CR missing → live fallback
  - existing inline `pipelineSpec` not overridden
  - non-Pipeline Revision kind rejected
- Unit tests in `go/components/pipeline/controller_test.go`:
  - `main` / `master` advance `status.latestRevision`
  - other branches upsert Revision but do not advance latestRevision
- Local: `go test ./components/pipelinerun/apihook/ ./components/pipeline/ -count=1`

**Potential risks**

- **Behaviour change for create without `spec.revision`:** when `status.latestRevision` is set and the Revision CR exists, runs now pin that snapshot instead of always using the live Pipeline. Intended; operators who relied on “omit revision = always tip of live Pipeline” should either clear `latestRevision` or pass an explicit revision / inline `pipelineSpec`.
- **Behaviour change for non-default-branch Pipeline applies:** feature-branch reconciles no longer move `status.latestRevision`. Existing latestRevision is left as-is until a main/master apply updates it.
- Soft Get failures on the live Pipeline still skip ownerRef/notifications (pre-existing soft path, preserved).

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

> Behavioural semantics change for revision-aware creates / latestRevision publishing, but no API/proto/helm/config contract break. Callers that omit `spec.revision` intentionally for “always live” should be aware of the latestRevision preference above.

**Release notes**

When revisioning is enabled:
- PipelineRuns without `spec.revision` prefer `Pipeline.status.latestRevision` (resolved to inline `pipelineSpec`) when available, with live-Pipeline fallback if the Revision CR is missing.
- Explicit `spec.revision` is required to resolve successfully (no silent live fallback).
- Only `main`/`master` Pipeline commits advance `status.latestRevision`; other branches still create Revision CRs.

**Documentation Changes**

N/A for this PR. Follow-up welcome: wiki / user docs on “PipelineRun revision resolution order” and “when latestRevision advances.”
