### PR TITLE
feat(form): strip stale values for `is`-hidden condition fields on submit

### DIFF
--- a/javascript/packages/core/components/form/__tests__/config-driven-form.test.tsx
+++ b/javascript/packages/core/components/form/__tests__/config-driven-form.test.tsx
@@ -491,4 +491,38 @@ describe('ConfigDrivenForm', () => {
       expect(screen.getByLabelText('Advanced Setting')).toBeInTheDocument();
     });
   });
+
+  it('does not submit values left over from a field hidden by a condition', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    const config: FormConfig = {
+      fields: {
+        mode: { type: 'string', label: 'Mode' },
+        advanced: { type: 'string', label: 'Advanced Setting' },
+      },
+      layout: ['mode', { type: 'condition', when: 'mode', is: 'advanced', items: ['advanced'] }],
+    };
+
+    render(
+      <ConfigDrivenForm config={config} onSubmit={onSubmit} />,
+      buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+    );
+
+    await user.type(screen.getByLabelText('Mode'), 'advanced');
+    await waitFor(() => expect(screen.getByLabelText('Advanced Setting')).toBeInTheDocument());
+
+    await user.type(screen.getByLabelText('Advanced Setting'), 'stale value');
+    await user.clear(screen.getByLabelText('Mode'));
+    await user.type(screen.getByLabelText('Mode'), 'basic');
+    await waitFor(() =>
+      expect(screen.queryByLabelText('Advanced Setting')).not.toBeInTheDocument()
+    );
+
+    fireEvent.submit(screen.getByLabelText('Mode'));
+
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith({ mode: 'basic' }, expect.anything(), expect.anything())
+    );
+  });
 });

--- a/javascript/packages/core/components/form/config-driven-form.tsx
+++ b/javascript/packages/core/components/form/config-driven-form.tsx
@@ -1,5 +1,7 @@
 import { Form } from '#core/components/form/form';
 import { LayoutItemList } from '#core/components/form/layout/layout-item-list';
+import { applySubmitTransforms } from '#core/components/form/utils/apply-submit-transforms';
+import { filterHiddenConditionFields } from '#core/components/form/utils/filter-hidden-condition-fields';
 
 import type { FieldConfig, FormConfig } from '#core/components/form/types/config-types';
 import type { DeepPartial } from '#core/types/utility-types';
@@ -29,7 +31,18 @@ export function ConfigDrivenForm<T extends Record<string, unknown>>({
   initialValues,
 }: ConfigDrivenFormProps<T>) {
   return (
-    <Form<T> onSubmit={onSubmit} initialValues={initialValues}>
+    <Form<T>
+      onSubmit={(values, ...rest) => {
+        const transformed = applySubmitTransforms([filterHiddenConditionFields], values, config);
+        // cast: onSubmit's declared type only accepts `values`; forwarding the extra
+        // final-form args (form, callback) preserves the pre-existing pass-through behavior
+        return (onSubmit as (...args: unknown[]) => void | object | Promise<object>)(
+          transformed,
+          ...rest
+        );
+      }}
+      initialValues={initialValues}
+    >
       <LayoutItemList
         items={config.layout}
         // cast: erases keyof T — layouts are structural and don't depend on the data shape

--- a/javascript/packages/core/components/form/utils/__tests__/filter-hidden-condition-fields.test.ts
+++ b/javascript/packages/core/components/form/utils/__tests__/filter-hidden-condition-fields.test.ts
@@ -1,0 +1,152 @@
+import { filterHiddenConditionFields } from '#core/components/form/utils/filter-hidden-condition-fields';
+
+import type { FormConfig } from '#core/components/form/types/config-types';
+
+describe('filterHiddenConditionFields', () => {
+  it('returns values unchanged when the layout has no conditions', () => {
+    const config: FormConfig = { fields: {}, layout: ['name', 'email'] };
+    const values = { name: 'Alice', email: 'alice@example.com' };
+
+    expect(filterHiddenConditionFields(values, config)).toEqual(values);
+  });
+
+  it('keeps a field whose is condition currently evaluates to true', () => {
+    const config: FormConfig = {
+      fields: {},
+      layout: [
+        'mode',
+        { type: 'condition', when: 'mode', is: 'advanced', items: ['advancedSetting'] },
+      ],
+    };
+    const values = { mode: 'advanced', advancedSetting: 'value' };
+
+    expect(filterHiddenConditionFields(values, config)).toEqual(values);
+  });
+
+  it('strips a field whose is condition currently evaluates to false', () => {
+    const config: FormConfig = {
+      fields: {},
+      layout: [
+        'mode',
+        { type: 'condition', when: 'mode', is: 'advanced', items: ['advancedSetting'] },
+      ],
+    };
+    const values = { mode: 'basic', advancedSetting: 'stale' };
+
+    expect(filterHiddenConditionFields(values, config)).toEqual({ mode: 'basic' });
+  });
+
+  it('strips every leaf field nested under a false is condition wrapping a group', () => {
+    const config: FormConfig = {
+      fields: {},
+      layout: [
+        'mode',
+        {
+          type: 'condition',
+          when: 'mode',
+          is: 'advanced',
+          items: [{ type: 'group', title: 'Advanced', items: ['a', 'b'] }],
+        },
+      ],
+    };
+    const values = { mode: 'basic', a: 'stale-a', b: 'stale-b' };
+
+    expect(filterHiddenConditionFields(values, config)).toEqual({ mode: 'basic' });
+  });
+
+  it('strips a nested is condition when the outer is condition is false, regardless of the inner condition', () => {
+    const config: FormConfig = {
+      fields: {},
+      layout: [
+        'mode',
+        'role',
+        {
+          type: 'condition',
+          when: 'mode',
+          is: 'advanced',
+          items: [{ type: 'condition', when: 'role', is: 'admin', items: ['adminPanel'] }],
+        },
+      ],
+    };
+    const values = { mode: 'basic', role: 'admin', adminPanel: 'stale' };
+
+    expect(filterHiddenConditionFields(values, config)).toEqual({ mode: 'basic', role: 'admin' });
+  });
+
+  it('strips only the false nested is condition when the outer is condition is true', () => {
+    const config: FormConfig = {
+      fields: {},
+      layout: [
+        'mode',
+        'role',
+        'outerField',
+        {
+          type: 'condition',
+          when: 'mode',
+          is: 'advanced',
+          items: [
+            'outerField',
+            { type: 'condition', when: 'role', is: 'admin', items: ['adminPanel'] },
+          ],
+        },
+      ],
+    };
+    const values = { mode: 'advanced', role: 'guest', outerField: 'kept', adminPanel: 'stale' };
+
+    expect(filterHiddenConditionFields(values, config)).toEqual({
+      mode: 'advanced',
+      role: 'guest',
+      outerField: 'kept',
+    });
+  });
+
+  it('only strips the false condition among multiple sibling is conditions', () => {
+    const config: FormConfig = {
+      fields: {},
+      layout: [
+        'mode',
+        'role',
+        { type: 'condition', when: 'mode', is: 'advanced', items: ['advancedSetting'] },
+        { type: 'condition', when: 'role', is: 'admin', items: ['adminPanel'] },
+      ],
+    };
+    const values = {
+      mode: 'advanced',
+      role: 'guest',
+      advancedSetting: 'kept',
+      adminPanel: 'stale',
+    };
+
+    expect(filterHiddenConditionFields(values, config)).toEqual({
+      mode: 'advanced',
+      role: 'guest',
+      advancedSetting: 'kept',
+    });
+  });
+
+  it('never touches fields not wrapped in any condition', () => {
+    const config: FormConfig = {
+      fields: {},
+      layout: [
+        'name',
+        { type: 'condition', when: 'mode', is: 'advanced', items: ['advancedSetting'] },
+      ],
+    };
+    const values = { name: 'Alice', mode: 'basic', advancedSetting: 'stale' };
+
+    expect(filterHiddenConditionFields(values, config)).toEqual({ name: 'Alice', mode: 'basic' });
+  });
+
+  it('does not strip fields under a non-is condition (not yet supported)', () => {
+    const config: FormConfig = {
+      fields: {},
+      layout: [
+        'mode',
+        { type: 'condition', when: 'mode', isNot: 'advanced', items: ['basicSetting'] },
+      ],
+    };
+    const values = { mode: 'advanced', basicSetting: 'still present' };
+
+    expect(filterHiddenConditionFields(values, config)).toEqual(values);
+  });
+});

--- a/javascript/packages/core/components/form/utils/apply-submit-transforms.ts
+++ b/javascript/packages/core/components/form/utils/apply-submit-transforms.ts
@@ -1,0 +1,11 @@
+import type { FormConfig } from '#core/components/form/types/config-types';
+import type { SubmitTransform } from './types';
+
+/** Runs `values` through each `transforms` step in order, threading the result forward. */
+export function applySubmitTransforms<T extends Record<string, unknown>>(
+  transforms: SubmitTransform<T>[],
+  values: T,
+  config: FormConfig<T>
+): T {
+  return transforms.reduce((acc, transform) => transform(acc, config), values);
+}

--- a/javascript/packages/core/components/form/utils/filter-hidden-condition-fields.ts
+++ b/javascript/packages/core/components/form/utils/filter-hidden-condition-fields.ts
@@ -1,0 +1,45 @@
+import { getIn, setIn } from 'final-form';
+
+import type { FormConfig, LayoutItem } from '#core/components/form/types/config-types';
+
+/**
+ * Strips values for fields nested under an `is` condition that currently evaluates to
+ * hidden, so stale data entered while the condition was true never gets submitted after
+ * the user navigates away from it.
+ *
+ * Only the `is` operator is handled for now — conditions using `isNot`/`isEmpty`/
+ * `containsAny` are left untouched (their fields still render conditionally via
+ * `FormCondition`, but their values aren't yet stripped from the submitted payload).
+ */
+export function filterHiddenConditionFields<T extends Record<string, unknown>>(
+  values: T,
+  config: FormConfig<T>
+): T {
+  return stripHiddenConditions(config.layout, values);
+}
+
+function stripHiddenConditions<T extends Record<string, unknown>>(
+  layout: LayoutItem[],
+  values: T
+): T {
+  return layout.reduce((acc, item) => {
+    if (typeof item === 'string') return acc;
+
+    if (item.type === 'condition' && 'is' in item && getIn(acc, item.when) !== item.is) {
+      return stripFieldNames(item.items, acc);
+    }
+
+    return stripHiddenConditions(item.items, acc);
+  }, values);
+}
+
+function stripFieldNames<T extends Record<string, unknown>>(layout: LayoutItem[], values: T): T {
+  return layout.reduce((acc, item) => {
+    if (typeof item === 'string') {
+      // cast: setIn's return type is `object`; it always returns a value of the same shape as `acc`
+      return (setIn(acc, item, undefined) ?? {}) as T;
+    }
+
+    return stripFieldNames(item.items, acc);
+  }, values);
+}

--- a/javascript/packages/core/components/form/utils/types.ts
+++ b/javascript/packages/core/components/form/utils/types.ts
@@ -1,0 +1,6 @@
+import type { FormConfig } from '#core/components/form/types/config-types';
+
+export type SubmitTransform<T extends Record<string, unknown>> = (
+  values: T,
+  config: FormConfig<T>
+) => T;


### PR DESCRIPTION
## Summary
FormCondition only ever controlled rendering — a value entered while an
`is` condition was true stayed in form state (and got submitted) even
after the user changed the triggering field so the condition no longer
holds. filterHiddenConditionFields strips those fields from the payload
at submit time via ConfigDrivenForm, using final-form's own getIn/setIn
for an immutable strip.

Scoped to the `is` operator only for this first slice; isNot/isEmpty/
containsAny-triggered conditions are left untouched for now.

## Test Plan


## Issues

