### PR TITLE
fix(ui): tighten breadcrumb menu drawer close button and icons

### DIFF
--- a/javascript/packages/core/components/breadcrumb-bar/menu-drawer.tsx
+++ b/javascript/packages/core/components/breadcrumb-bar/menu-drawer.tsx
@@ -64,6 +64,7 @@ export function MenuDrawer({ phases, projectId, topLevelLinks }: Props) {
         }}
       >
         <nav
+          aria-label="Phase navigation"
           className={css({ display: 'flex', flexDirection: 'column', gap: theme.sizing.scale400 })}
         >
           {topLevelLinks && topLevelLinks.length > 0 && (
@@ -73,7 +74,7 @@ export function MenuDrawer({ phases, projectId, topLevelLinks }: Props) {
                   <li key={link.path}>
                     <TopLevelNavLink to={link.path} onClick={() => setIsMenuOpen(false)}>
                       {link.label}
-                      <Icon name="chevronRight" title="" />
+                      <Icon name="chevronRight" size={theme.sizing.scale600} title="" />
                     </TopLevelNavLink>
                   </li>
                 ))}

--- a/javascript/packages/core/components/breadcrumb-bar/styled-components.ts
+++ b/javascript/packages/core/components/breadcrumb-bar/styled-components.ts
@@ -17,8 +17,8 @@ export const TopLevelNavLink = styled(Link, ({ $theme }) => ({
   paddingLeft: $theme.sizing.scale600,
   paddingRight: $theme.sizing.scale700,
   textDecoration: 'none',
-  // Override the default visited link color
-  ':visited': { color: $theme.colors.contentPrimary },
+  // Override default browser link coloring
+  color: $theme.colors.contentPrimary,
   ':hover': { backgroundColor: $theme.colors.menuFillHover },
 }));
 

--- a/javascript/packages/core/primitives.tsx
+++ b/javascript/packages/core/primitives.tsx
@@ -24,6 +24,8 @@ export type { CellContextType } from '#core/providers/cell-provider/types';
 // Components
 export { Box } from '#core/components/box/box';
 export * from '#core/components/box/styled-components';
+export { BreadcrumbBar } from '#core/components/breadcrumb-bar/breadcrumb-bar';
+export type { NavLink } from '#core/components/breadcrumb-bar/types';
 export { DateTime } from '#core/components/date-time/date-time';
 export { DescriptionText } from '#core/components/description-text';
 export { HelpTooltip } from '#core/components/help-tooltip';


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Exports `BreadcrumbBar` and its `NavLink` type from `primitives.tsx` so consumers can build their own top-level links, and cleans up a few rough edges in the breadcrumb menu drawer: an `aria-label` on the phase navigation landmark, an explicit size on the top-level nav link's chevron icon, and an explicit link color in place of a `:visited` override.

**Why?**

The BreadcrumbBar styling had not been verified with top level links, which revealed incorrect link styling. Remaining polish updated per design.

**How did you test it?**

<img width="1601" height="1072" alt="Screenshot 2026-08-17 at 3 48 31 PM" src="https://github.com/user-attachments/assets/c598d92e-a8c3-4f26-a868-0f2cf0c85fa3" />

<img width="1601" height="1072" alt="Screenshot 2026-08-17 at 3 48 41 PM" src="https://github.com/user-attachments/assets/82d2cc47-d846-4884-99dc-ecdf39cec93b" />

**Potential risks**

None — this is a self-contained UI change to the breadcrumb drawer and router nav links with no API or behavior change outside of them.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

N/A

**Documentation Changes**

N/A
