### PR TITLE
fix: plumb RayTask gpu, disk and object store memory into the cluster spec

### DIFF
--- a/python/michelangelo/uniflow/plugins/ray/task.star
+++ b/python/michelangelo/uniflow/plugins/ray/task.star
@@ -1,5 +1,5 @@
 load("@plugin", "atexit", "json", "os", "ray", "time")
-load("../../commons.star", "CACHE_OPERATION_GET", "CACHE_OPERATION_PUT", "DEFAULT_RETRY_ATTEMPTS", "TASK_STATE_FAILED", "TASK_STATE_KILLED", "TASK_STATE_PENDING", "TASK_STATE_RUNNING", "TASK_STATE_SKIPPED", "TASK_STATE_SUCCEEDED", "TIME_FOMART", "create_cached_output", "get_cache_enabled", "get_cache_keys", "get_cached_output", "get_pythonpath", "get_result_url", "get_task_image", "get_task_name", "io_read_json", "process_terminated_job", "report_progress", "resource_dict", COMMONS_ENV = "ENV")
+load("../../commons.star", "CACHE_OPERATION_GET", "CACHE_OPERATION_PUT", "DEFAULT_RETRY_ATTEMPTS", "TASK_STATE_FAILED", "TASK_STATE_KILLED", "TASK_STATE_PENDING", "TASK_STATE_RUNNING", "TASK_STATE_SKIPPED", "TASK_STATE_SUCCEEDED", "TIME_FOMART", "create_cached_output", "get_cache_enabled", "get_cache_keys", "get_cached_output", "get_pythonpath", "get_result_url", "get_task_image", "get_task_name", "io_read_json", "process_terminated_job", "report_progress", COMMONS_ENV = "ENV")
 
 DEFAULT_CREATE_CLUSTER_TIMEOUT_SECONDS = 60 * 30  # Timeout duration for cluster creation in seconds.
 RAY_ENV = {
@@ -164,18 +164,31 @@ def task(
         cluster_image = get_task_image(task_name)
         print("ray | create cluster:", "ns:", cluster_namespace, "image:", cluster_image, "task_name:", task_name)
 
+        # Forward disk only when it differs from the shipped default. The
+        # default (512Gi) has never reached the pod spec, so honoring it now
+        # would suddenly attach a large ephemeral-storage request to every
+        # existing RayTask; an explicit parameter or env override still wins.
+        _head_disk_request = _head_disk if _head_disk != RAY_DEFAULT_HEAD_DISK else None
+        _worker_disk_request = _worker_disk if _worker_disk != RAY_DEFAULT_WORKER_DISK else None
+
         cluster = ray_cluster_spec(
             namespace = cluster_namespace,
             image = cluster_image,
-            head_resource = resource_dict(
+            head_resources = container_resources(
                 cpu = _head_cpu,
                 memory = _head_memory,
+                disk = _head_disk_request,
+                gpu = _head_gpu,
             ),
-            worker_resource = resource_dict(
+            worker_resources = container_resources(
                 cpu = _worker_cpu,
                 memory = _worker_memory,
+                disk = _worker_disk_request,
+                gpu = _worker_gpu,
             ),
             worker_instances = _worker_instances,
+            head_object_store_memory = head_object_store_memory,
+            worker_object_store_memory = worker_object_store_memory,
             debug_enabled = breakpoint,
             runtime_env = runtime_env,
         )
@@ -427,6 +440,29 @@ def ray_job_entrypoint(task_path, result_url, args = None, kwargs = None):
 
     return "python3 -m michelangelo.uniflow.core.run_task --task '" + task_path + "' --args '" + args + "' --kwargs '" + kwargs + "' --result-url '" + result_url + "'"
 
+# Builds the k8s.io.api.core.v1.ResourceRequirements dict for a Ray container.
+#
+# Unlike the Spark path, which sends a typed ResourceSpec through
+# utils.ConvertToResourceList on the Go side, the Ray pod spec is consumed as a
+# literal PodTemplateSpec with no renaming step. The keys here must therefore
+# be real Kubernetes resource names ("ephemeral-storage", "nvidia.com/gpu"),
+# not the proto JSON names produced by resource_dict in commons.star
+# ("diskSize", "gpu"), which the scheduler would silently ignore.
+def container_resources(cpu, memory, disk = None, gpu = None):
+    requests = {
+        "cpu": cpu,
+        "memory": memory,
+    }
+    if disk:
+        requests["ephemeral-storage"] = disk
+    resources = {"requests": requests}
+    if gpu:
+        # nvidia.com/gpu is an extended resource: Kubernetes requires the
+        # limit to be present and equal to the request, so it is set in both.
+        requests["nvidia.com/gpu"] = gpu
+        resources["limits"] = {"nvidia.com/gpu": gpu}
+    return resources
+
 # Constructs a Unified API resource for provisioning a Ray Cluster.
 # This function generates a RayJob Custom Resource Definition (CRD) that defines the specifications for a Ray cluster.
 # Refer to the RayJob CRD: https://github.com/michelangelo-ai/michelangelo/blob/main/proto/api/v2/ray_job.proto
@@ -440,17 +476,24 @@ def ray_job_entrypoint(task_path, result_url, args = None, kwargs = None):
 #         - The Docker image containing Ray, application code, and dependencies.
 #         - Example: "127.0.0.1:5055/uber-usi/uber-one-michelangelo-sandbox:bkt1-produ-1719018451-45448"
 #
-#     head_resource (dict):
-#         - Resource configuration for the Ray **head node**.
-#         - Reference: `resource_dict` function in commons.star.
+#     head_resources (dict):
+#         - Kubernetes ResourceRequirements for the Ray **head node** container.
+#         - Reference: `container_resources` in this file.
 #
-#     worker_resource (dict):
-#         - Resource configuration for the Ray **worker nodes**.
-#         - Reference: `resource_dict` function in commons.star.
+#     worker_resources (dict):
+#         - Kubernetes ResourceRequirements for the Ray **worker node** containers.
+#         - Reference: `container_resources` in this file.
 #
 #     worker_instances (int):
 #         - Number of Ray worker instances to launch.
 #         - Must be a non-negative integer.
+#
+#     head_object_store_memory (int, optional):
+#         - Object store memory for the head node, in bytes, passed verbatim to
+#           `ray start --object-store-memory` via rayStartParams.
+#
+#     worker_object_store_memory (int, optional):
+#         - Object store memory per worker node, in bytes, same mechanism.
 #
 #     debug_enabled (bool, optional):
 #         - Enables debugging tools if set to True.
@@ -465,9 +508,11 @@ def ray_job_entrypoint(task_path, result_url, args = None, kwargs = None):
 def ray_cluster_spec(
         namespace,
         image,
-        head_resource,
-        worker_resource,
+        head_resources,
+        worker_resources,
         worker_instances,
+        head_object_store_memory = None,
+        worker_object_store_memory = None,
         debug_enabled = False,
         runtime_env = None):
     ray_init_kwargs = os.environ.get("_RAY_INIT_KWARGS", {})
@@ -481,7 +526,20 @@ def ray_cluster_spec(
         for k, v in env.items()
     ]
 
-    support_gpu = head_resource.get("gpu", 0) + worker_resource.get("gpu", 0) * worker_instances > 0
+    # rayStartParams pass through KubeRay verbatim as `ray start` flags, so
+    # object store memory is forwarded here rather than as a pod resource.
+    head_ray_start_params = {
+        "block": "true",
+        "dashboard-host": "0.0.0.0",
+    }
+    if head_object_store_memory:
+        head_ray_start_params["object-store-memory"] = str(head_object_store_memory)
+    worker_ray_start_params = {
+        "block": "true",
+        "dashboard-host": "0.0.0.0",
+    }
+    if worker_object_store_memory:
+        worker_ray_start_params["object-store-memory"] = str(worker_object_store_memory)
 
     annotations = {}
     if debug_enabled:
@@ -499,10 +557,7 @@ def ray_cluster_spec(
             "rayVersion": "2.3.1",  # Keeping original version
             "head": {
                 "serviceType": "ClusterIP",
-                "rayStartParams": {
-                    "block": "true",
-                    "dashboard-host": "0.0.0.0",
-                },
+                "rayStartParams": head_ray_start_params,
                 "pod": {
                     "spec": {
                         "volumes": [
@@ -518,9 +573,7 @@ def ray_cluster_spec(
                         "containers": [
                             {
                                 "name": "head",
-                                "resources": {
-                                    "requests": head_resource,
-                                },
+                                "resources": head_resources,
                                 "image": image,  # Keeping original variable
                                 "imagePullPolicy": IMAGE_PULL_POLICY,
                                 "env": env,  # Keeping original variable
@@ -557,19 +610,14 @@ def ray_cluster_spec(
                     "maxInstances": worker_instances,
                     "nodeType": "worker-group-1",
                     "objectStoreMemoryRatio": 0.0,
-                    "rayStartParams": {
-                        "block": "true",
-                        "dashboard-host": "0.0.0.0",
-                    },
+                    "rayStartParams": worker_ray_start_params,
                     "pod": {
                         "spec": {
                             "restartPolicy": "Never",
                             "containers": [
                                 {
                                     "name": "worker",
-                                    "resources": {
-                                        "requests": worker_resource,
-                                    },
+                                    "resources": worker_resources,
                                     "image": image,
                                     "imagePullPolicy": IMAGE_PULL_POLICY,
                                     "env": env,

--- a/python/michelangelo/uniflow/plugins/ray/tests/ray_cluster_spec_test.py
+++ b/python/michelangelo/uniflow/plugins/ray/tests/ray_cluster_spec_test.py
@@ -8,16 +8,17 @@ from types import SimpleNamespace
 from unittest import TestCase
 
 
-def _load_ray_cluster_spec():
-    """Load the actual ray_cluster_spec function with controlled globals."""
+def _load_star_functions(*names: str):
+    """Load the named task.star functions with controlled globals."""
     task_path = Path(__file__).resolve().parents[1] / "task.star"
     tree = ast.parse(task_path.read_text(), filename=str(task_path))
-    function = next(
+    functions = [
         node
         for node in tree.body
-        if isinstance(node, ast.FunctionDef) and node.name == "ray_cluster_spec"
-    )
-    module = ast.fix_missing_locations(ast.Module(body=[function], type_ignores=[]))
+        if isinstance(node, ast.FunctionDef) and node.name in names
+    ]
+    assert len(functions) == len(names), f"missing one of {names} in task.star"
+    module = ast.fix_missing_locations(ast.Module(body=functions, type_ignores=[]))
     globals_ = {
         "COMMONS_ENV": {},
         "IMAGE_PULL_POLICY": "Never",
@@ -26,21 +27,67 @@ def _load_ray_cluster_spec():
         "os": SimpleNamespace(environ={}),
     }
     exec(compile(module, str(task_path), "exec"), globals_)
-    return globals_["ray_cluster_spec"]
+    return tuple(globals_[name] for name in names)
+
+
+class TestContainerResources(TestCase):
+    """Tests for container_resources()."""
+
+    def setUp(self):
+        """Load container_resources from task.star."""
+        (self.container_resources,) = _load_star_functions("container_resources")
+
+    def test_cpu_memory_only(self):
+        """Without disk or gpu the dict has requests only."""
+        resources = self.container_resources(cpu=2, memory="4Gi")
+
+        self.assertEqual(resources, {"requests": {"cpu": 2, "memory": "4Gi"}})
+
+    def test_disk_maps_to_ephemeral_storage(self):
+        """Disk lands under the real k8s resource name, not diskSize."""
+        resources = self.container_resources(cpu=2, memory="4Gi", disk="100Gi")
+
+        self.assertEqual(resources["requests"]["ephemeral-storage"], "100Gi")
+        self.assertNotIn("limits", resources)
+
+    def test_gpu_sets_request_and_limit(self):
+        """GPU is an extended resource, so request and limit must match."""
+        resources = self.container_resources(cpu=2, memory="4Gi", gpu=1)
+
+        self.assertEqual(resources["requests"]["nvidia.com/gpu"], 1)
+        self.assertEqual(resources["limits"], {"nvidia.com/gpu": 1})
+
+    def test_gpu_zero_adds_nothing(self):
+        """gpu=0 (the default resolved value) must not emit gpu keys."""
+        resources = self.container_resources(cpu=2, memory="4Gi", gpu=0)
+
+        self.assertNotIn("nvidia.com/gpu", resources["requests"])
+        self.assertNotIn("limits", resources)
 
 
 class TestRayClusterSpec(TestCase):
     """Tests for ray_cluster_spec()."""
 
-    def _build_spec(self, namespace: str):
-        ray_cluster_spec = _load_ray_cluster_spec()
+    def _build_spec(self, namespace: str = "default", **kwargs):
+        (ray_cluster_spec,) = _load_star_functions("ray_cluster_spec")
         return ray_cluster_spec(
             namespace=namespace,
             image="test-image",
-            head_resource={"cpu": 1, "memory": "1Gi"},
-            worker_resource={"cpu": 1, "memory": "1Gi"},
-            worker_instances=1,
+            head_resources=kwargs.pop(
+                "head_resources", {"requests": {"cpu": 1, "memory": "1Gi"}}
+            ),
+            worker_resources=kwargs.pop(
+                "worker_resources", {"requests": {"cpu": 1, "memory": "1Gi"}}
+            ),
+            worker_instances=kwargs.pop("worker_instances", 1),
+            **kwargs,
         )
+
+    def _head_container(self, spec):
+        return spec["spec"]["head"]["pod"]["spec"]["containers"][0]
+
+    def _worker_container(self, spec):
+        return spec["spec"]["workers"][0]["pod"]["spec"]["containers"][0]
 
     def test_preserves_custom_namespace(self):
         """A project namespace is retained in cluster metadata."""
@@ -53,3 +100,39 @@ class TestRayClusterSpec(TestCase):
         spec = self._build_spec("default")
 
         self.assertEqual(spec["metadata"]["namespace"], "default")
+
+    def test_resources_passed_through_verbatim(self):
+        """The ResourceRequirements dicts land on the containers unchanged."""
+        head = {
+            "requests": {"cpu": 4, "memory": "8Gi", "nvidia.com/gpu": 2},
+            "limits": {"nvidia.com/gpu": 2},
+        }
+        worker = {"requests": {"cpu": 2, "memory": "4Gi", "ephemeral-storage": "100Gi"}}
+        spec = self._build_spec(head_resources=head, worker_resources=worker)
+
+        self.assertEqual(self._head_container(spec)["resources"], head)
+        self.assertEqual(self._worker_container(spec)["resources"], worker)
+
+    def test_object_store_memory_reaches_ray_start_params(self):
+        """Object store bytes are forwarded verbatim as a ray start flag."""
+        spec = self._build_spec(
+            head_object_store_memory=2_000_000_000,
+            worker_object_store_memory=1_000_000_000,
+        )
+
+        self.assertEqual(
+            spec["spec"]["head"]["rayStartParams"]["object-store-memory"],
+            "2000000000",
+        )
+        self.assertEqual(
+            spec["spec"]["workers"][0]["rayStartParams"]["object-store-memory"],
+            "1000000000",
+        )
+
+    def test_object_store_memory_absent_by_default(self):
+        """Without the parameter, rayStartParams stay exactly as before."""
+        spec = self._build_spec()
+
+        expected = {"block": "true", "dashboard-host": "0.0.0.0"}
+        self.assertEqual(spec["spec"]["head"]["rayStartParams"], expected)
+        self.assertEqual(spec["spec"]["workers"][0]["rayStartParams"], expected)

--- a/python/michelangelo/uniflow/plugins/ray/tests/ray_cluster_spec_test.py
+++ b/python/michelangelo/uniflow/plugins/ray/tests/ray_cluster_spec_test.py
@@ -8,7 +8,7 @@ from types import SimpleNamespace
 from unittest import TestCase
 
 
-def _load_star_functions(*names: str):
+def _load_star_functions(*names: str, extra_globals: dict | None = None):
     """Load the named task.star functions with controlled globals."""
     task_path = Path(__file__).resolve().parents[1] / "task.star"
     tree = ast.parse(task_path.read_text(), filename=str(task_path))
@@ -26,6 +26,8 @@ def _load_star_functions(*names: str):
         "USER_ID": "test-user",
         "os": SimpleNamespace(environ={}),
     }
+    if extra_globals:
+        globals_.update(extra_globals)
     exec(compile(module, str(task_path), "exec"), globals_)
     return tuple(globals_[name] for name in names)
 
@@ -136,3 +138,127 @@ class TestRayClusterSpec(TestCase):
         expected = {"block": "true", "dashboard-host": "0.0.0.0"}
         self.assertEqual(spec["spec"]["head"]["rayStartParams"], expected)
         self.assertEqual(spec["spec"]["workers"][0]["rayStartParams"], expected)
+
+
+class TestTaskResourcePlumbing(TestCase):
+    """End-to-end tests that task() forwards resources into the cluster spec.
+
+    Runs the real task() from task.star with the plugin runtime stubbed out,
+    capturing the cluster spec handed to execute_ray_task. This is the exact
+    regression surface of the silently-dropped gpu/disk/object-store settings.
+    """
+
+    _DEFAULT_DISK = "512Gi"
+
+    def _run_task(self, environ: dict | None = None, **task_kwargs):
+        captured = {}
+
+        def execute_ray_task(**kwargs):
+            captured.update(kwargs)
+            return "SUCCEEDED", None, "http://cluster", "ray-job-1"
+
+        stubs = {
+            "DEFAULT_RETRY_ATTEMPTS": 1,
+            "RAY_DEFAULT_HEAD_CPU": "8",
+            "RAY_DEFAULT_HEAD_MEMORY": "32Gi",
+            "RAY_DEFAULT_HEAD_DISK": self._DEFAULT_DISK,
+            "RAY_DEFAULT_HEAD_GPU": "0",
+            "RAY_DEFAULT_WORKER_CPU": "8",
+            "RAY_DEFAULT_WORKER_MEMORY": "32Gi",
+            "RAY_DEFAULT_WORKER_DISK": self._DEFAULT_DISK,
+            "RAY_DEFAULT_WORKER_GPU": "0",
+            "RAY_DEFAULT_WORKER_INSTANCES": "1",
+            "RAY_DEFAULT_GPU_SKU": "",
+            "RAY_DEFAULT_ZONE": "",
+            "RAY_LOG_URL_PREFIX": None,
+            "TIME_FOMART": "%Y-%m-%dT%H:%M:%S",
+            "TASK_STATE_SKIPPED": "SKIPPED",
+            "CACHE_OPERATION_GET": "GET",
+            "os": SimpleNamespace(environ=dict(environ or {})),
+            "time": SimpleNamespace(
+                time=lambda: 0.0,
+                utc_format_seconds=lambda fmt, seconds: "2026-01-01T00:00:00",
+            ),
+            "get_task_name": lambda task_path, alias: "test-task",
+            "get_cache_enabled": lambda cache_enabled, task_name: False,
+            "get_result_url": lambda: "s3://bucket/result.json",
+            "get_task_image": lambda task_name: "test-image",
+            "execute_ray_task": execute_ray_task,
+            "process_terminated_job": lambda **kwargs: False,
+            "io_read_json": lambda url: {"ok": True},
+            "report_progress": lambda **kwargs: None,
+            "callable_object": lambda func: func,
+        }
+        task, _, _, _, _ = _load_star_functions(
+            "task",
+            "ray_cluster_spec",
+            "container_resources",
+            "ray_config",
+            "get_ray_log_url",
+            extra_globals=stubs,
+        )
+        result = task(task_path="examples.demo.train", **task_kwargs)()
+        self.assertEqual(result, {"ok": True})
+        return captured["cluster"]
+
+    def _containers(self, cluster):
+        head = cluster["spec"]["head"]["pod"]["spec"]["containers"][0]
+        worker = cluster["spec"]["workers"][0]["pod"]["spec"]["containers"][0]
+        return head, worker
+
+    def test_defaults_produce_cpu_memory_requests_only(self):
+        """With no resource parameters the spec matches the old behavior."""
+        cluster = self._run_task()
+
+        head, worker = self._containers(cluster)
+        self.assertEqual(head["resources"], {"requests": {"cpu": 8, "memory": "32Gi"}})
+        self.assertEqual(
+            worker["resources"], {"requests": {"cpu": 8, "memory": "32Gi"}}
+        )
+        self.assertNotIn(
+            "object-store-memory", cluster["spec"]["head"]["rayStartParams"]
+        )
+
+    def test_explicit_resources_reach_the_pods(self):
+        """gpu, disk and object store memory land where k8s and Ray read them."""
+        cluster = self._run_task(
+            head_gpu="1",
+            head_disk="100Gi",
+            head_object_store_memory=2000000000,
+            worker_gpu="2",
+            worker_disk="200Gi",
+            worker_object_store_memory=1000000000,
+        )
+
+        head, worker = self._containers(cluster)
+        self.assertEqual(head["resources"]["requests"]["nvidia.com/gpu"], 1)
+        self.assertEqual(head["resources"]["limits"], {"nvidia.com/gpu": 1})
+        self.assertEqual(head["resources"]["requests"]["ephemeral-storage"], "100Gi")
+        self.assertEqual(worker["resources"]["requests"]["nvidia.com/gpu"], 2)
+        self.assertEqual(worker["resources"]["limits"], {"nvidia.com/gpu": 2})
+        self.assertEqual(worker["resources"]["requests"]["ephemeral-storage"], "200Gi")
+        self.assertEqual(
+            cluster["spec"]["head"]["rayStartParams"]["object-store-memory"],
+            "2000000000",
+        )
+        self.assertEqual(
+            cluster["spec"]["workers"][0]["rayStartParams"]["object-store-memory"],
+            "1000000000",
+        )
+
+    def test_default_disk_is_not_forwarded(self):
+        """Passing exactly the shipped default disk keeps requests unchanged."""
+        cluster = self._run_task(head_disk=self._DEFAULT_DISK)
+
+        head, _ = self._containers(cluster)
+        self.assertNotIn("ephemeral-storage", head["resources"]["requests"])
+
+    def test_env_override_gpu_reaches_the_pod(self):
+        """A RAY_OVERRIDE_*_GPU env var flows through like the parameter."""
+        cluster = self._run_task(
+            environ={"RAY_OVERRIDE_HEAD_GPU.examples.demo.train": "2"}
+        )
+
+        head, _ = self._containers(cluster)
+        self.assertEqual(head["resources"]["requests"]["nvidia.com/gpu"], 2)
+        self.assertEqual(head["resources"]["limits"], {"nvidia.com/gpu": 2})


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
Fixes #1794. `RayTask` accepts `head_gpu`/`worker_gpu`, `head_disk`/`worker_disk` and `head_object_store_memory`/`worker_object_store_memory` (plus `RAY_OVERRIDE_*` env overrides for gpu and disk), but none of them ever reached the cluster: `ray_cluster_spec` was only handed cpu and memory, built via commons.star `resource_dict`, whose proto-JSON key names (`gpu`, `diskSize`) aren't real Kubernetes resource names anyway.

The fix, all in `python/michelangelo/uniflow/plugins/ray/task.star`:

- new `container_resources` helper builds a real `ResourceRequirements` dict with real k8s resource names, because unlike the Spark path (typed `ResourceSpec` through `utils.ConvertToResourceList`, `go/components/jobs/client/k8sengine/helper.go:217-255`) the Ray pod spec is spliced into a literal `PodTemplateSpec` with no renaming step (`go/components/jobs/client/k8sengine/ray.go:159-165`)
- gpu goes to `nvidia.com/gpu` in requests **and** limits (extended resources require limit == request), matching `constants.ResourceNvidiaGPU` used by the Spark path
- disk goes to `ephemeral-storage` in requests
- object store memory goes to `rayStartParams["object-store-memory"]`, which KubeRay passes verbatim to `ray start` (`ray.go:162,175`)
- removes the dead `support_gpu` computation (assigned, never read) and the now-unused `resource_dict` import

One deliberate choice: disk is only forwarded when it differs from `RAY_DEFAULT_HEAD_DISK`/`RAY_DEFAULT_WORKER_DISK` (512Gi). That default has never reached the pod spec, so honoring it unconditionally would suddenly attach a 512Gi ephemeral-storage request to every existing RayTask and likely make many unschedulable. Explicit parameters and env overrides are always forwarded. The side effect is that explicitly passing exactly "512Gi" is treated as the default and not forwarded; happy to change the mechanism if you'd rather distinguish "unset" with a `None` default.

`gpu_sku` and `zone` remain unwired, as the issue notes: they need a scheduling design decision (nodeSelector vs tolerations vs something at the Job Controller layer), which seems like a maintainer call rather than something to guess at in this PR. Same for the workers' hardcoded `objectStoreMemoryRatio: 0.0`, which is untouched.

**Why?**
Today a user who sets `head_gpu=1` on a RayTask gets a pod with no GPU at all and no error anywhere -- the parameter is accepted, cast to int, and dropped. Same for disk and object store memory. Silent parameter drops are worse than unsupported parameters because the workload runs and produces slow or OOM-killed results instead of failing loudly.

**How did you test it?**
- extended `ray_cluster_spec_test.py` from 2 to 9 tests: gpu request+limit shape, gpu=0 emitting nothing, disk mapping to `ephemeral-storage`, object store memory landing in both head and worker `rayStartParams` as a string, absence of the flag when unset, and the full `ResourceRequirements` dicts passing through to the containers verbatim; all 9 pass (python 3.11, and the file compiles under 3.9)
- the test loads the real functions out of task.star by ast, same harness as before, so it exercises the shipped Starlark, not a copy
- `go test ./...` in `go/worker/plugins/ray` passes (its testdata uses its own test.star, so this confirms no interface drift on the Go plugin side)
- grepped the repo for other `ray_cluster_spec`/`head_resource`/`worker_resource` callers: none outside this file and its test
- ruff format + ruff check clean on the changed test file

**Potential risks**
For any RayTask that never set gpu/disk/object-store-memory (which is all of them that worked correctly so far), the generated spec is byte-identical to before except that nothing changes at all -- requests still contain exactly cpu and memory. The new behavior only activates when a caller explicitly asked for the resources that were previously dropped. Two adjacent open PRs touch the same file: #1698 (draft PoC around resource value sources; its own discussion notes this forwarding bug but the draft doesn't fix it) and #896 (adds a parameter on adjacent lines) -- either may need a trivial rebase depending on merge order.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

`ray_cluster_spec`'s keyword names changed (`head_resource` -> `head_resources` etc.), but it has no callers outside task.star itself and is not exported through any Python module.

**Release notes**
RayTask gpu, disk and object store memory settings now reach the Ray cluster pods instead of being silently dropped.

**Documentation Changes**
None -- the existing parameter docstrings in task.star already describe this as the behavior; now it's true.
