### PR TITLE
ci: build examples image without pushing on fork PRs

### DIFF
--- a/.github/workflows/build-examples-image.yaml
+++ b/.github/workflows/build-examples-image.yaml
@@ -77,7 +77,6 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        if: env.PUSH_OK == 'true'
         uses: docker/build-push-action@v5
         with:
           context: ./python
@@ -88,19 +87,10 @@ jobs:
           # overwrite each other.
           cache-from: type=gha,scope=${{ env.PLATFORM_SLUG }}
           cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_SLUG }}
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
-
-      - name: Build without pushing (fork PR)
-        if: env.PUSH_OK != 'true'
-        uses: docker/build-push-action@v5
-        with:
-          context: ./python
-          file: ./python/examples/Dockerfile
-          platforms: ${{ matrix.platform }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=${{ env.PLATFORM_SLUG }}
-          cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_SLUG }}
-          push: false
+          # push-by-digest is only consulted on the push path inside buildkit's
+          # image exporter, so with push=false it is inert and this builds
+          # without touching the registry.
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ env.PUSH_OK }}
 
       - name: Export digest
         if: env.PUSH_OK == 'true'

--- a/.github/workflows/build-examples-image.yaml
+++ b/.github/workflows/build-examples-image.yaml
@@ -33,6 +33,12 @@ jobs:
     permissions:
       contents: read
       packages: write
+    env:
+      # Fork PRs run with a read-only GITHUB_TOKEN and cannot write org
+      # packages, so pushing to GHCR is only possible for same-repo refs.
+      # On fork PRs we still build the image (validating the Dockerfile and
+      # dependency changes) but skip the push and the manifest merge.
+      PUSH_OK: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
 
     strategy:
       fail-fast: false
@@ -53,6 +59,7 @@ jobs:
           echo "PLATFORM_SLUG=${platform//\//-}" >> "$GITHUB_ENV"
 
       - name: Log in to GHCR
+        if: env.PUSH_OK == 'true'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -70,6 +77,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
+        if: env.PUSH_OK == 'true'
         uses: docker/build-push-action@v5
         with:
           context: ./python
@@ -82,13 +90,27 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_SLUG }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
 
+      - name: Build without pushing (fork PR)
+        if: env.PUSH_OK != 'true'
+        uses: docker/build-push-action@v5
+        with:
+          context: ./python
+          file: ./python/examples/Dockerfile
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ env.PLATFORM_SLUG }}
+          cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_SLUG }}
+          push: false
+
       - name: Export digest
+        if: env.PUSH_OK == 'true'
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest artifact
+        if: env.PUSH_OK == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: digests-${{ env.PLATFORM_SLUG }}
@@ -100,6 +122,10 @@ jobs:
     name: Merge multi-arch manifest
     runs-on: ubuntu-latest
     needs: [build]
+    # Same gate as PUSH_OK in the build job (the env context is not
+    # available in a job-level if): nothing was pushed on a fork PR, so
+    # there are no digests to merge.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
`.github/workflows/build-examples-image.yaml` now skips the GHCR push (and the manifest merge job) for pull requests coming from forks, while still building the image to validate the Dockerfile and dependency changes.

- the build job gets a `PUSH_OK` env flag: true for pushes to main, workflow_dispatch, and same-repo PRs; false for fork PRs
- `Log in to GHCR`, `Build and push by digest`, `Export digest` and `Upload digest artifact` are gated on `PUSH_OK == 'true'`
- the build step always runs, with `push=${{ env.PUSH_OK }}` templated into its `outputs:` string, so fork PRs build the image without pushing (single step, per review feedback)
- the `merge` job gets the equivalent job-level `if:` (the env context isn't available at job level, so the expression is repeated there)

The push path for same-repo refs is byte-identical to before.

**Why?**
Fork PRs run with a read-only `GITHUB_TOKEN` that cannot write org packages, so any fork PR touching `python/examples/**`, `pyproject.toml` or `poetry.lock` currently fails both `Build (linux/amd64)` and `Build (linux/arm64)` at the GHCR push. The failure is literally `denied: installation not allowed to Write organization package` after a successful image build -- see #1787 and #1793 for live examples. The red X looks like broken code but is pure permissions, which costs maintainers a triage round-trip on every affected external PR.

**How did you test it?**
- `actionlint` on the changed workflow: no new findings (the only two reported are pre-existing SC2046 shellcheck warnings on the untouched `imagetools create` step)
- verified the gate expression against the documented event payloads: `github.event.pull_request.head.repo.full_name == github.repository` is the standard same-repo test, and short-circuits to true for non-PR events via the `github.event_name != 'pull_request'` clause
- verified from primary sources that `push-by-digest=true` with `push=false` is well-defined: buildkit's image exporter only consults push-by-digest inside the push path (moby/buildkit exporter/containerimage/export.go), so with push=false it is inert; docker/build-push-action#1009 confirms `outputs.digest` is simply unpopulated when push=false, and the digest-consuming steps here are gated off on forks anyway

I can't exercise the fork path end-to-end from here -- ironically, this PR itself (from a fork) touches `.github/workflows/**` only, so it won't trigger the workflow. The first fork PR touching the examples inputs after merge will be the real test.

**Potential risks**
If the gate expression were wrong in the false direction, same-repo builds would silently skip the push; the expression is the widely used canonical form and `workflow_dispatch`/`push` events bypass it entirely. Fork PRs lose the "image actually pushed" signal, but they never had it -- they had a guaranteed red X instead.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**
None -- CI-only change.

**Documentation Changes**
None.

