### PR TITLE
chore: route major feature requests to the enhancements RFC process

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,6 +7,8 @@ assignees: ''
 
 ---
 
+> ⚠️ **STOP:** Major features and architectural changes require a design contract before implementation begins. If this is a major change — a new core module, a public API or CRD change, or a substantial new dependency — do not open an issue and instead open an RFC proposal directly in the [Michelangelo Enhancements Repository](https://github.com/michelangelo-ai/enhancements). See [Our Contribution Tracks](https://github.com/michelangelo-ai/michelangelo/blob/main/CONTRIBUTING.md#our-contribution-tracks) for how to tell.
+
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**
Adds a short routing banner to the top of `.github/ISSUE_TEMPLATE/feature_request.md` pointing major features and architectural changes to the [Michelangelo Enhancements Repository](https://github.com/michelangelo-ai/enhancements) RFC process, with a link to the "Our Contribution Tracks" section of CONTRIBUTING.md for how to tell which track applies. Two-line diff, no other template changes.

The links are absolute URLs deliberately: relative links resolve against the issue URL once the template is rendered in an issue body, not against the repo tree.

**Why?**
CONTRIBUTING.md's Dual-Track Pipeline requires an accepted RFC in the enhancements repo before implementation for Track 2 changes, and the enhancements repo's own issue template says to check there first. But the michelangelo repo's feature request template -- the form outside contributors actually see -- never mentions the RFC process at all. The routing rule exists; it just isn't visible at the point of filing, so Track 2-sized asks keep landing here as plain issues. Speaking from experience: I filed several enhancement issues before discovering the RFC track existed.

**How did you test it?**
- YAML frontmatter re-validated after the edit (parses, fields unchanged)
- rendered the markdown to confirm the blockquote displays correctly above the first prompt
- verified both link targets resolve: the enhancements repo and the `#our-contribution-tracks` anchor in CONTRIBUTING.md

**Potential risks**
None functional -- issue templates are display-only. Wording is the only reviewable surface; happy to tune the "major change" examples to match how you draw the Track 1/Track 2 line.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**
None.

**Documentation Changes**
Feature request issue template now routes major changes to the enhancements RFC repo.
