### PR TITLE
feat(form): add isNot/isEmpty/containsAny condition operators

### DIFF
--- a/javascript/packages/core/components/form/layout/condition/__tests__/evaluate-condition.test.ts
+++ b/javascript/packages/core/components/form/layout/condition/__tests__/evaluate-condition.test.ts
@@ -1,0 +1,102 @@
+import { evaluateCondition } from '#core/components/form/layout/condition/evaluate-condition';
+
+import type { ConditionLayoutConfig } from '#core/components/form/layout/condition/types';
+
+describe('evaluateCondition', () => {
+  describe('is', () => {
+    const layout: ConditionLayoutConfig = {
+      type: 'condition',
+      when: 'mode',
+      is: 'advanced',
+      items: [],
+    };
+
+    it('returns true when the value matches', () => {
+      expect(evaluateCondition(layout, 'advanced')).toBe(true);
+    });
+
+    it('returns false when the value does not match', () => {
+      expect(evaluateCondition(layout, 'basic')).toBe(false);
+    });
+  });
+
+  describe('isNot', () => {
+    const layout: ConditionLayoutConfig = {
+      type: 'condition',
+      when: 'mode',
+      isNot: 'hidden',
+      items: [],
+    };
+
+    it('returns false when the value equals isNot', () => {
+      expect(evaluateCondition(layout, 'hidden')).toBe(false);
+    });
+
+    it('returns true when the value differs from isNot and is non-empty', () => {
+      expect(evaluateCondition(layout, 'shown')).toBe(true);
+    });
+
+    it('returns false when the value is empty', () => {
+      expect(evaluateCondition(layout, '')).toBe(false);
+    });
+  });
+
+  describe('isEmpty: true', () => {
+    const layout: ConditionLayoutConfig = {
+      type: 'condition',
+      when: 'name',
+      isEmpty: true,
+      items: [],
+    };
+
+    it('returns true when the value is empty', () => {
+      expect(evaluateCondition(layout, '')).toBe(true);
+    });
+
+    it('returns false when the value is non-empty', () => {
+      expect(evaluateCondition(layout, 'Alice')).toBe(false);
+    });
+  });
+
+  describe('isEmpty: false', () => {
+    const layout: ConditionLayoutConfig = {
+      type: 'condition',
+      when: 'name',
+      isEmpty: false,
+      items: [],
+    };
+
+    it('returns true when the value is non-empty', () => {
+      expect(evaluateCondition(layout, 'Alice')).toBe(true);
+    });
+
+    it('returns false when the value is empty', () => {
+      expect(evaluateCondition(layout, '')).toBe(false);
+    });
+  });
+
+  describe('containsAny', () => {
+    const layout: ConditionLayoutConfig = {
+      type: 'condition',
+      when: 'role',
+      containsAny: ['admin', 'superadmin'],
+      items: [],
+    };
+
+    it('returns true when a scalar value is in the list', () => {
+      expect(evaluateCondition(layout, 'admin')).toBe(true);
+    });
+
+    it('returns false when a scalar value is not in the list', () => {
+      expect(evaluateCondition(layout, 'guest')).toBe(false);
+    });
+
+    it('returns true when an array value overlaps with the list', () => {
+      expect(evaluateCondition(layout, ['guest', 'admin'])).toBe(true);
+    });
+
+    it('returns false when an array value does not overlap with the list', () => {
+      expect(evaluateCondition(layout, ['guest', 'viewer'])).toBe(false);
+    });
+  });
+});

--- a/javascript/packages/core/components/form/layout/condition/__tests__/form-condition.test.tsx
+++ b/javascript/packages/core/components/form/layout/condition/__tests__/form-condition.test.tsx
@@ -72,4 +72,270 @@ describe('FormCondition', () => {
       );
     });
   });
+
+  describe('isNot', () => {
+    const layout: ConditionLayoutConfig = {
+      type: 'condition',
+      when: 'mode',
+      isNot: 'hidden',
+      items: [],
+    };
+
+    it('hides children when value equals isNot', () => {
+      render(
+        <Form onSubmit={vi.fn()} initialValues={{ mode: 'hidden' }}>
+          <FormCondition layout={layout}>
+            <div>Conditional Content</div>
+          </FormCondition>
+        </Form>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
+
+      expect(screen.queryByText('Conditional Content')).not.toBeInTheDocument();
+    });
+
+    it('renders children when value differs from isNot and is non-empty', () => {
+      render(
+        <Form onSubmit={vi.fn()} initialValues={{ mode: 'shown' }}>
+          <FormCondition layout={layout}>
+            <div>Conditional Content</div>
+          </FormCondition>
+        </Form>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
+
+      expect(screen.queryByText('Conditional Content')).toBeInTheDocument();
+    });
+
+    it('hides children when value is empty ("not yet determined")', () => {
+      render(
+        <Form onSubmit={vi.fn()} initialValues={{ mode: '' }}>
+          <FormCondition layout={layout}>
+            <div>Conditional Content</div>
+          </FormCondition>
+        </Form>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
+
+      expect(screen.queryByText('Conditional Content')).not.toBeInTheDocument();
+    });
+
+    it('hides children again once value changes back to isNot', async () => {
+      const user = userEvent.setup();
+      render(
+        <Form onSubmit={vi.fn()} initialValues={{ mode: 'shown' }}>
+          <FormCondition layout={layout}>
+            <div>Conditional Content</div>
+          </FormCondition>
+          <SetValueButton name="mode" value="hidden" label="Change value" />
+        </Form>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
+
+      expect(screen.queryByText('Conditional Content')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Change value' }));
+
+      await waitFor(() =>
+        expect(screen.queryByText('Conditional Content')).not.toBeInTheDocument()
+      );
+    });
+  });
+
+  describe('isEmpty: true', () => {
+    const layout: ConditionLayoutConfig = {
+      type: 'condition',
+      when: 'name',
+      isEmpty: true,
+      items: [],
+    };
+
+    it('renders children when field is empty', () => {
+      render(
+        <Form onSubmit={vi.fn()} initialValues={{ name: '' }}>
+          <FormCondition layout={layout}>
+            <div>Conditional Content</div>
+          </FormCondition>
+        </Form>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
+
+      expect(screen.queryByText('Conditional Content')).toBeInTheDocument();
+    });
+
+    it('hides children when field is non-empty', () => {
+      render(
+        <Form onSubmit={vi.fn()} initialValues={{ name: 'Alice' }}>
+          <FormCondition layout={layout}>
+            <div>Conditional Content</div>
+          </FormCondition>
+        </Form>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
+
+      expect(screen.queryByText('Conditional Content')).not.toBeInTheDocument();
+    });
+
+    it('hides children once field becomes non-empty, and shows again once cleared', async () => {
+      const user = userEvent.setup();
+      render(
+        <Form onSubmit={vi.fn()} initialValues={{ name: '' }}>
+          <FormCondition layout={layout}>
+            <div>Conditional Content</div>
+          </FormCondition>
+          <SetValueButton name="name" value="Alice" label="Set to Alice" />
+          <SetValueButton name="name" value="" label="Clear" />
+        </Form>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
+
+      expect(screen.queryByText('Conditional Content')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Set to Alice' }));
+      await waitFor(() =>
+        expect(screen.queryByText('Conditional Content')).not.toBeInTheDocument()
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Clear' }));
+      await waitFor(() => expect(screen.queryByText('Conditional Content')).toBeInTheDocument());
+    });
+  });
+
+  describe('isEmpty: false', () => {
+    const layout: ConditionLayoutConfig = {
+      type: 'condition',
+      when: 'name',
+      isEmpty: false,
+      items: [],
+    };
+
+    it('renders children when field is non-empty', () => {
+      render(
+        <Form onSubmit={vi.fn()} initialValues={{ name: 'Alice' }}>
+          <FormCondition layout={layout}>
+            <div>Conditional Content</div>
+          </FormCondition>
+        </Form>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
+
+      expect(screen.queryByText('Conditional Content')).toBeInTheDocument();
+    });
+
+    it('hides children when field is empty', () => {
+      render(
+        <Form onSubmit={vi.fn()} initialValues={{ name: '' }}>
+          <FormCondition layout={layout}>
+            <div>Conditional Content</div>
+          </FormCondition>
+        </Form>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
+
+      expect(screen.queryByText('Conditional Content')).not.toBeInTheDocument();
+    });
+
+    it('hides children again once field is cleared', async () => {
+      const user = userEvent.setup();
+      render(
+        <Form onSubmit={vi.fn()} initialValues={{ name: 'Alice' }}>
+          <FormCondition layout={layout}>
+            <div>Conditional Content</div>
+          </FormCondition>
+          <SetValueButton name="name" value="" label="Clear" />
+        </Form>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
+
+      expect(screen.queryByText('Conditional Content')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Clear' }));
+
+      await waitFor(() =>
+        expect(screen.queryByText('Conditional Content')).not.toBeInTheDocument()
+      );
+    });
+  });
+
+  describe('containsAny', () => {
+    const layout: ConditionLayoutConfig = {
+      type: 'condition',
+      when: 'role',
+      containsAny: ['admin', 'superadmin'],
+      items: [],
+    };
+
+    it('renders when a scalar value is in the list', () => {
+      render(
+        <Form onSubmit={vi.fn()} initialValues={{ role: 'admin' }}>
+          <FormCondition layout={layout}>
+            <div>Conditional Content</div>
+          </FormCondition>
+        </Form>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
+
+      expect(screen.queryByText('Conditional Content')).toBeInTheDocument();
+    });
+
+    it('hides when a scalar value is not in the list', () => {
+      render(
+        <Form onSubmit={vi.fn()} initialValues={{ role: 'guest' }}>
+          <FormCondition layout={layout}>
+            <div>Conditional Content</div>
+          </FormCondition>
+        </Form>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
+
+      expect(screen.queryByText('Conditional Content')).not.toBeInTheDocument();
+    });
+
+    it('renders when an array value overlaps with the list', () => {
+      render(
+        <Form onSubmit={vi.fn()} initialValues={{ role: ['guest', 'admin'] }}>
+          <FormCondition layout={layout}>
+            <div>Conditional Content</div>
+          </FormCondition>
+        </Form>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
+
+      expect(screen.queryByText('Conditional Content')).toBeInTheDocument();
+    });
+
+    it('hides when an array value does not overlap with the list', () => {
+      render(
+        <Form onSubmit={vi.fn()} initialValues={{ role: ['guest', 'viewer'] }}>
+          <FormCondition layout={layout}>
+            <div>Conditional Content</div>
+          </FormCondition>
+        </Form>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
+
+      expect(screen.queryByText('Conditional Content')).not.toBeInTheDocument();
+    });
+
+    it('hides again once the value changes to a non-matching one', async () => {
+      const user = userEvent.setup();
+      render(
+        <Form onSubmit={vi.fn()} initialValues={{ role: 'admin' }}>
+          <FormCondition layout={layout}>
+            <div>Conditional Content</div>
+          </FormCondition>
+          <SetValueButton name="role" value="guest" label="Change value" />
+        </Form>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
+
+      expect(screen.queryByText('Conditional Content')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Change value' }));
+
+      await waitFor(() =>
+        expect(screen.queryByText('Conditional Content')).not.toBeInTheDocument()
+      );
+    });
+  });
 });

--- a/javascript/packages/core/components/form/layout/condition/evaluate-condition.ts
+++ b/javascript/packages/core/components/form/layout/condition/evaluate-condition.ts
@@ -1,0 +1,26 @@
+import { isEmptyFieldValue } from '#core/components/form/utils/is-empty-field-value';
+
+import type { ConditionLayoutConfig } from './types';
+
+/** Evaluates whether a condition layout's `items` should be visible for the given field value. */
+export function evaluateCondition(layout: ConditionLayoutConfig, value: unknown): boolean {
+  if ('is' in layout) {
+    return value === layout.is;
+  }
+
+  if ('isNot' in layout) {
+    return !isEmptyFieldValue(value) && value !== layout.isNot;
+  }
+
+  if ('isEmpty' in layout) {
+    return layout.isEmpty ? isEmptyFieldValue(value) : !isEmptyFieldValue(value);
+  }
+
+  if ('containsAny' in layout) {
+    return Array.isArray(value)
+      ? layout.containsAny.some((item) => value.includes(item))
+      : layout.containsAny.some((item) => value === item);
+  }
+
+  return true;
+}

--- a/javascript/packages/core/components/form/layout/condition/form-condition.tsx
+++ b/javascript/packages/core/components/form/layout/condition/form-condition.tsx
@@ -1,6 +1,6 @@
 import { useField } from 'react-final-form';
 
-import { isEmptyFieldValue } from '#core/components/form/utils/is-empty-field-value';
+import { evaluateCondition } from './evaluate-condition';
 
 import type { ReactNode } from 'react';
 import type { ConditionLayoutConfig } from './types';
@@ -17,27 +17,5 @@ export function FormCondition({
 }) {
   const { input } = useField(layout.when, { subscription: { value: true } });
 
-  return shouldRender(layout, input.value) ? <>{children}</> : null;
-}
-
-function shouldRender(layout: ConditionLayoutConfig, value: unknown): boolean {
-  if ('is' in layout) {
-    return value === layout.is;
-  }
-
-  if ('isNot' in layout) {
-    return !isEmptyFieldValue(value) && value !== layout.isNot;
-  }
-
-  if ('isEmpty' in layout) {
-    return layout.isEmpty ? isEmptyFieldValue(value) : !isEmptyFieldValue(value);
-  }
-
-  if ('containsAny' in layout) {
-    return Array.isArray(value)
-      ? layout.containsAny.some((item) => value.includes(item))
-      : layout.containsAny.some((item) => value === item);
-  }
-
-  return true;
+  return evaluateCondition(layout, input.value) ? <>{children}</> : null;
 }

--- a/javascript/packages/core/components/form/layout/condition/form-condition.tsx
+++ b/javascript/packages/core/components/form/layout/condition/form-condition.tsx
@@ -1,5 +1,7 @@
 import { useField } from 'react-final-form';
 
+import { isEmptyFieldValue } from '#core/components/form/utils/is-empty-field-value';
+
 import type { ReactNode } from 'react';
 import type { ConditionLayoutConfig } from './types';
 
@@ -19,5 +21,23 @@ export function FormCondition({
 }
 
 function shouldRender(layout: ConditionLayoutConfig, value: unknown): boolean {
-  return value === layout.is;
+  if ('is' in layout) {
+    return value === layout.is;
+  }
+
+  if ('isNot' in layout) {
+    return !isEmptyFieldValue(value) && value !== layout.isNot;
+  }
+
+  if ('isEmpty' in layout) {
+    return layout.isEmpty ? isEmptyFieldValue(value) : !isEmptyFieldValue(value);
+  }
+
+  if ('containsAny' in layout) {
+    return Array.isArray(value)
+      ? layout.containsAny.some((item) => value.includes(item))
+      : layout.containsAny.some((item) => value === item);
+  }
+
+  return true;
 }

--- a/javascript/packages/core/components/form/layout/condition/types.ts
+++ b/javascript/packages/core/components/form/layout/condition/types.ts
@@ -9,4 +9,28 @@ type BaseConditionLayoutConfig = {
 /** Renders `items` only when the `when` field's value strictly equals `is`. */
 type LiteralCondition = BaseConditionLayoutConfig & { is: unknown };
 
-export type ConditionLayoutConfig = LiteralCondition;
+/**
+ * Renders `items` when the `when` field's value differs from `isNot`.
+ *
+ * An empty value is treated as "not yet determined" and is also hidden, even
+ * though it technically differs from `isNot` — this avoids flashing content
+ * before the user has made a choice.
+ */
+type NegationCondition = BaseConditionLayoutConfig & { isNot: unknown };
+
+/** Renders `items` based on whether the `when` field's value is empty (null/undefined/''/[]). */
+type EmptyCondition = BaseConditionLayoutConfig & { isEmpty: boolean };
+
+/**
+ * Renders `items` when the `when` field's value overlaps with `containsAny`.
+ *
+ * If the field value is an array, membership is checked against each of its
+ * elements; otherwise the scalar value itself is checked for membership.
+ */
+type ContainsAnyCondition = BaseConditionLayoutConfig & { containsAny: unknown[] };
+
+export type ConditionLayoutConfig =
+  | LiteralCondition
+  | NegationCondition
+  | EmptyCondition
+  | ContainsAnyCondition;

--- a/javascript/packages/core/components/form/utils/__tests__/filter-hidden-condition-fields.test.ts
+++ b/javascript/packages/core/components/form/utils/__tests__/filter-hidden-condition-fields.test.ts
@@ -149,4 +149,80 @@ describe('filterHiddenConditionFields', () => {
 
     expect(filterHiddenConditionFields(values, config)).toEqual({ name: 'Alice', mode: 'basic' });
   });
+
+  it('strips a field whose isNot condition currently evaluates to hidden', () => {
+    const config: FormConfig = {
+      fields: {},
+      layout: ['mode', { type: 'condition', when: 'mode', isNot: 'hidden', items: ['visible'] }],
+    };
+    const values = { mode: 'hidden', visible: 'stale' };
+
+    expect(filterHiddenConditionFields(values, config)).toEqual({ mode: 'hidden' });
+  });
+
+  it('keeps a field whose isNot condition currently evaluates to visible', () => {
+    const config: FormConfig = {
+      fields: {},
+      layout: ['mode', { type: 'condition', when: 'mode', isNot: 'hidden', items: ['visible'] }],
+    };
+    const values = { mode: 'shown', visible: 'value' };
+
+    expect(filterHiddenConditionFields(values, config)).toEqual(values);
+  });
+
+  it('strips a field whose isEmpty: true condition currently evaluates to hidden', () => {
+    const config: FormConfig = {
+      fields: {},
+      layout: ['name', { type: 'condition', when: 'name', isEmpty: true, items: ['hint'] }],
+    };
+    const values = { name: 'Alice', hint: 'stale' };
+
+    expect(filterHiddenConditionFields(values, config)).toEqual({ name: 'Alice' });
+  });
+
+  it('strips a field whose isEmpty: false condition currently evaluates to hidden', () => {
+    const config: FormConfig = {
+      fields: {},
+      layout: ['name', { type: 'condition', when: 'name', isEmpty: false, items: ['greeting'] }],
+    };
+    const values = { name: '', greeting: 'stale' };
+
+    expect(filterHiddenConditionFields(values, config)).toEqual({ name: '' });
+  });
+
+  it('strips a field whose containsAny condition currently evaluates to hidden', () => {
+    const config: FormConfig = {
+      fields: {},
+      layout: [
+        'role',
+        {
+          type: 'condition',
+          when: 'role',
+          containsAny: ['admin', 'superadmin'],
+          items: ['adminPanel'],
+        },
+      ],
+    };
+    const values = { role: 'guest', adminPanel: 'stale' };
+
+    expect(filterHiddenConditionFields(values, config)).toEqual({ role: 'guest' });
+  });
+
+  it('keeps a field whose containsAny condition currently evaluates to visible', () => {
+    const config: FormConfig = {
+      fields: {},
+      layout: [
+        'role',
+        {
+          type: 'condition',
+          when: 'role',
+          containsAny: ['admin', 'superadmin'],
+          items: ['adminPanel'],
+        },
+      ],
+    };
+    const values = { role: 'admin', adminPanel: 'value' };
+
+    expect(filterHiddenConditionFields(values, config)).toEqual(values);
+  });
 });

--- a/javascript/packages/core/components/form/utils/__tests__/is-empty-field-value.test.ts
+++ b/javascript/packages/core/components/form/utils/__tests__/is-empty-field-value.test.ts
@@ -1,0 +1,19 @@
+import { isEmptyFieldValue } from '#core/components/form/utils/is-empty-field-value';
+
+describe('isEmptyFieldValue', () => {
+  it.each([
+    ['null', null, true],
+    ['undefined', undefined, true],
+    ['empty string', '', true],
+    ['empty array', [], true],
+    ['whitespace string', ' ', false],
+    ['non-empty string', 'a', false],
+    ['zero', 0, false],
+    ['false', false, false],
+    ['non-empty array', [1], false],
+    ['empty object', {}, false],
+    ['NaN', NaN, false],
+  ] as const)('%s -> %s', (_description, value, expected) => {
+    expect(isEmptyFieldValue(value)).toBe(expected);
+  });
+});

--- a/javascript/packages/core/components/form/utils/filter-hidden-condition-fields.ts
+++ b/javascript/packages/core/components/form/utils/filter-hidden-condition-fields.ts
@@ -1,17 +1,17 @@
 import { get } from 'lodash';
 
+import { evaluateCondition } from '#core/components/form/layout/condition/evaluate-condition';
 import { deleteByPath } from '#core/components/form/utils/delete-by-path';
 
 import type { FormConfig, LayoutItem } from '#core/components/form/types/config-types';
 
 /**
- * Strips values for fields nested under an `is` condition that currently evaluates to
- * hidden, so stale data entered while the condition was true never gets submitted after
- * the user navigates away from it.
+ * Strips values for fields nested under a condition that currently evaluates to hidden,
+ * so stale data entered while the condition was true never gets submitted after the user
+ * navigates away from it.
  *
- * Only the `is` operator is handled for now — conditions using `isNot`/`isEmpty`/
- * `containsAny` are left untouched (their fields still render conditionally via
- * `FormCondition`, but their values aren't yet stripped from the submitted payload).
+ * Uses the same `evaluateCondition` logic as `FormCondition`, so every operator
+ * (`is`/`isNot`/`isEmpty`/`containsAny`) is stripped consistently with what's rendered.
  */
 export function filterHiddenConditionFields<T extends Record<string, unknown>>(
   values: T,
@@ -27,7 +27,7 @@ function stripHiddenConditions<T extends Record<string, unknown>>(
   return layout.reduce((acc, item) => {
     if (typeof item === 'string') return acc;
 
-    if (item.type === 'condition' && 'is' in item && get(acc, item.when) !== item.is) {
+    if (item.type === 'condition' && !evaluateCondition(item, get(acc, item.when))) {
       return stripFieldNames(item.items, acc);
     }
 

--- a/javascript/packages/core/components/form/utils/filter-hidden-condition-fields.ts
+++ b/javascript/packages/core/components/form/utils/filter-hidden-condition-fields.ts
@@ -5,9 +5,13 @@ import { deleteByPath } from '#core/components/form/utils/delete-by-path';
 import type { FormConfig, LayoutItem } from '#core/components/form/types/config-types';
 
 /**
- * Strips values for fields nested under a `condition` layout that currently evaluates to
+ * Strips values for fields nested under an `is` condition that currently evaluates to
  * hidden, so stale data entered while the condition was true never gets submitted after
  * the user navigates away from it.
+ *
+ * Only the `is` operator is handled for now — conditions using `isNot`/`isEmpty`/
+ * `containsAny` are left untouched (their fields still render conditionally via
+ * `FormCondition`, but their values aren't yet stripped from the submitted payload).
  */
 export function filterHiddenConditionFields<T extends Record<string, unknown>>(
   values: T,
@@ -23,7 +27,7 @@ function stripHiddenConditions<T extends Record<string, unknown>>(
   return layout.reduce((acc, item) => {
     if (typeof item === 'string') return acc;
 
-    if (item.type === 'condition' && get(acc, item.when) !== item.is) {
+    if (item.type === 'condition' && 'is' in item && get(acc, item.when) !== item.is) {
       return stripFieldNames(item.items, acc);
     }
 

--- a/javascript/packages/core/components/form/utils/is-empty-field-value.ts
+++ b/javascript/packages/core/components/form/utils/is-empty-field-value.ts
@@ -1,0 +1,5 @@
+export function isEmptyFieldValue(value: unknown): boolean {
+  return (
+    value === null || value === undefined || value === '' || (Array.isArray(value) && !value.length)
+  );
+}


### PR DESCRIPTION
## Summary
Extends the `condition` layout landed in the previous slice (which only
handled `is`) with three more comparison operators: negation (isNot,
treating an empty value as "not yet determined" and hiding rather than
showing), presence toggle (isEmpty), and array membership (containsAny).

Submit-time stripping of hidden condition fields initially covered only
`is`, since the two places that matched on the condition operator had
independently duplicated the same logic and only one was updated for the
new operators. Values behind an isNot/isEmpty/containsAny condition were
still rendered conditionally, but stale values could survive into the
submitted payload once hidden. The operator-matching logic is now
extracted into a single shared evaluator, so submit-time stripping covers
all four operators and the two call sites can't drift apart again.

## Test Plan
new unit tests