### PR TITLE
ci: pin sticky-pull-request-comment in javascript-coverage to a full SHA

### DIFF
--- a/.github/workflows/javascript-coverage.yml
+++ b/.github/workflows/javascript-coverage.yml
@@ -98,7 +98,7 @@ jobs:
           fi
 
       - name: Coverage report PR comment
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         with:
           header: javascript-coverage


### PR DESCRIPTION

## Summary

Pins `marocchino/sticky-pull-request-comment` in `javascript-coverage.yml` from the floating `v2` tag to the v2.9.4 commit SHA:

```yaml
uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
```

This is the follow-up that was deliberately deferred out of #1757 (disclosed in that PR's description) to avoid the only merge conflict in the then-open PR set. #1757 has merged, so this completes the SHA-pinning sweep. The string matches the pin #1757 applied to the same action in `go-coverage.yml` exactly.

## Why this is behavior-preserving

- The `v2.9.4` tag is a lightweight tag pointing directly at commit `773744901bac0e8cbb5a0dc842800d45e9b2b405`.
- The `v2` branch currently points at that same commit, so today the pin changes nothing at runtime; it only removes the ability for a moved tag/branch to silently change what runs in CI.
- v3.x tags exist upstream, but the repo standardized on the v2 line in #1757; upgrading majors is out of scope for a pin.

## Testing

- `actionlint` on the changed file: the same 10 pre-existing shellcheck info/style findings as on `main` (verified by running actionlint on the `main` copy side by side); the changed line introduces none.
- Single-line diff; the `uses:` ref format (full 40-char SHA + version comment) is identical to the nine pins merged in #1757.
