### PR TITLE
ci: remove unused attestations permission from release workflows

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -27,7 +27,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      attestations: write
       id-token: write
 
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -98,7 +98,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      attestations: write
       id-token: write
     steps:
       - uses: docker/setup-qemu-action@v3
@@ -158,7 +157,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      attestations: write
       id-token: write
     steps:
       - uses: docker/setup-qemu-action@v3

--- a/.github/workflows/ui-release.yml
+++ b/.github/workflows/ui-release.yml
@@ -45,7 +45,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      attestations: write
       id-token: write
 
     steps:


### PR DESCRIPTION

## Summary

Removes `attestations: write` from the four jobs that grant it (`dev-release.yml`, `ui-release.yml`, and both image jobs in `nightly.yml`). Nothing in the repo consumes it:

- no step uses `actions/attest-build-provenance` or `actions/attest-sbom`
- no step invokes the `gh attestation` CLI
- the only local composite action these workflows call (`setup-python-poetry`) is a Python/Poetry setup helper with no attestation logic

So the permission is granted but never exercised. Dropping it keeps the permission blocks least-privilege and accurate about what each job can do, in the same direction as the earlier workflow-hardening changes.

## Notes

- `id-token: write` in the same blocks also appears to have no current consumer (no cosign, no cloud OIDC login). I left it alone deliberately: it is the standard companion for a future attest/signing step and removing OIDC capability felt like a separate decision for maintainers. Happy to drop it here too if you prefer.
- BuildKit/registry-side provenance from `docker/build-push-action` does not use this permission; it applies only to GitHub's artifact attestations API.
- If attestations are planned, restoring this is one line alongside the attest step that needs it.

## Testing

- `actionlint` over the three changed files: identical findings to `main` (6 pre-existing informational shellcheck notes); the deletions introduce nothing.
- Diff is 4 deleted lines; no step, env, or trigger changes.
