### PR TITLE
feat(core): add Experiment & Productionize phase

### DIFF
--- a/javascript/app/icons/icons.tsx
+++ b/javascript/app/icons/icons.tsx
@@ -16,6 +16,7 @@ import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import KeyboardBackspaceIcon from '@mui/icons-material/KeyboardBackspace';
 import Launch from '@mui/icons-material/Launch';
+import LightbulbIcon from '@mui/icons-material/Lightbulb';
 import MenuIcon from '@mui/icons-material/Menu';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
@@ -45,6 +46,7 @@ export const ICONS = {
   deleteAlt: createMuiIconAdapter(CancelIcon),
   diamondEmpty: createMuiIconAdapter(CropSquareIcon),
   stopCircle: createMuiIconAdapter(StopCircleIcon),
+  lightbulb: createMuiIconAdapter(LightbulbIcon),
   menu: createMuiIconAdapter(MenuIcon),
   overflowMenu: createMuiIconAdapter(MoreVertIcon),
   playerNext: createMuiIconAdapter(SkipNextIcon),

--- a/javascript/packages/core/components/views/project/project-detail.tsx
+++ b/javascript/packages/core/components/views/project/project-detail.tsx
@@ -61,8 +61,8 @@ export function ProjectDetail({ phases }: { phases: PhaseConfig[] }) {
       <div
         className={css({
           display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))',
-          gap: theme.sizing.scale600,
+          gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
+          gap: '12px',
           padding: theme.sizing.scale400,
         })}
       >

--- a/javascript/packages/core/components/views/project/project-detail.tsx
+++ b/javascript/packages/core/components/views/project/project-detail.tsx
@@ -62,7 +62,7 @@ export function ProjectDetail({ phases }: { phases: PhaseConfig[] }) {
         className={css({
           display: 'grid',
           gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
-          gap: '12px',
+          gap: theme.sizing.scale500,
           padding: theme.sizing.scale400,
         })}
       >

--- a/javascript/packages/core/config/phases/experiment-productionize.ts
+++ b/javascript/packages/core/config/phases/experiment-productionize.ts
@@ -5,7 +5,7 @@ import { TRIGGER_ENTITY_CONFIG } from '#core/config/entities/trigger/trigger';
 import type { PhaseConfig } from '#core/types/common/studio-types';
 
 export const EXPERIMENT_PRODUCTIONIZE_PHASE: PhaseConfig = {
-  id: 'experiment-productionize',
+  id: 'retrain',
   icon: 'rocket',
   name: 'Experiment & Productionize',
   description: 'Experiment with pipelines and productionize your machine learning workflows',

--- a/javascript/packages/core/config/phases/experiment-productionize.ts
+++ b/javascript/packages/core/config/phases/experiment-productionize.ts
@@ -6,7 +6,7 @@ import type { PhaseConfig } from '#core/types/common/studio-types';
 
 export const EXPERIMENT_PRODUCTIONIZE_PHASE: PhaseConfig = {
   id: 'retrain',
-  icon: 'rocket',
+  icon: 'lightbulb',
   name: 'Experiment & Productionize',
   description: 'Experiment with pipelines and productionize your machine learning workflows',
   state: 'active' as const,

--- a/javascript/packages/core/config/phases/experiment-productionize.ts
+++ b/javascript/packages/core/config/phases/experiment-productionize.ts
@@ -1,0 +1,14 @@
+import { PIPELINE_ENTITY_CONFIG } from '#core/config/entities/pipeline/pipeline';
+import { RUN_ENTITY_CONFIG } from '#core/config/entities/run/run';
+import { TRIGGER_ENTITY_CONFIG } from '#core/config/entities/trigger/trigger';
+
+import type { PhaseConfig } from '#core/types/common/studio-types';
+
+export const EXPERIMENT_PRODUCTIONIZE_PHASE: PhaseConfig = {
+  id: 'experiment-productionize',
+  icon: 'rocket',
+  name: 'Experiment & Productionize',
+  description: 'Experiment with pipelines and productionize your machine learning workflows',
+  state: 'active' as const,
+  entities: [PIPELINE_ENTITY_CONFIG, RUN_ENTITY_CONFIG, TRIGGER_ENTITY_CONFIG],
+};

--- a/javascript/packages/core/config/phases/phases.ts
+++ b/javascript/packages/core/config/phases/phases.ts
@@ -1,9 +1,11 @@
 import { DATA_PHASE } from './data';
 import { DEPLOY_PHASE } from './deploy';
+import { EXPERIMENT_PRODUCTIONIZE_PHASE } from './experiment-productionize';
 import { TRAIN_PHASE } from './train';
 
 export const PHASES = {
   data: DATA_PHASE,
   train: TRAIN_PHASE,
+  'experiment-productionize': EXPERIMENT_PRODUCTIONIZE_PHASE,
   deploy: DEPLOY_PHASE,
 };

--- a/javascript/packages/core/config/phases/phases.ts
+++ b/javascript/packages/core/config/phases/phases.ts
@@ -6,6 +6,6 @@ import { TRAIN_PHASE } from './train';
 export const PHASES = {
   data: DATA_PHASE,
   train: TRAIN_PHASE,
-  retrain: EXPERIMENT_PRODUCTIONIZE_PHASE,
   deploy: DEPLOY_PHASE,
+  retrain: EXPERIMENT_PRODUCTIONIZE_PHASE,
 };

--- a/javascript/packages/core/config/phases/phases.ts
+++ b/javascript/packages/core/config/phases/phases.ts
@@ -1,11 +1,11 @@
 import { DATA_PHASE } from './data';
 import { DEPLOY_PHASE } from './deploy';
-import { EXPERIMENT_PRODUCTIONIZE_PHASE } from './experiment-productionize';
+import { RETRAIN_PHASE } from './retrain';
 import { TRAIN_PHASE } from './train';
 
 export const PHASES = {
   data: DATA_PHASE,
   train: TRAIN_PHASE,
   deploy: DEPLOY_PHASE,
-  retrain: EXPERIMENT_PRODUCTIONIZE_PHASE,
+  retrain: RETRAIN_PHASE,
 };

--- a/javascript/packages/core/config/phases/phases.ts
+++ b/javascript/packages/core/config/phases/phases.ts
@@ -6,6 +6,6 @@ import { TRAIN_PHASE } from './train';
 export const PHASES = {
   data: DATA_PHASE,
   train: TRAIN_PHASE,
-  'experiment-productionize': EXPERIMENT_PRODUCTIONIZE_PHASE,
+  retrain: EXPERIMENT_PRODUCTIONIZE_PHASE,
   deploy: DEPLOY_PHASE,
 };

--- a/javascript/packages/core/config/phases/retrain.ts
+++ b/javascript/packages/core/config/phases/retrain.ts
@@ -4,7 +4,7 @@ import { TRIGGER_ENTITY_CONFIG } from '#core/config/entities/trigger/trigger';
 
 import type { PhaseConfig } from '#core/types/common/studio-types';
 
-export const EXPERIMENT_PRODUCTIONIZE_PHASE: PhaseConfig = {
+export const RETRAIN_PHASE: PhaseConfig = {
   id: 'retrain',
   icon: 'lightbulb',
   name: 'Experiment & Productionize',

--- a/javascript/packages/core/router/router.tsx
+++ b/javascript/packages/core/router/router.tsx
@@ -7,13 +7,13 @@ import { Sandbox } from '#core/components/views/sandbox/sandbox';
 import { CATEGORIES } from '#core/config/categories';
 import { DATA_PHASE } from '#core/config/phases/data';
 import { DEPLOY_PHASE } from '#core/config/phases/deploy';
-import { EXPERIMENT_PRODUCTIONIZE_PHASE } from '#core/config/phases/experiment-productionize';
+import { RETRAIN_PHASE } from '#core/config/phases/retrain';
 import { TRAIN_PHASE } from '#core/config/phases/train';
 import { EntityDetailRoute } from './entity-detail-route';
 import { PhaseListRoute } from './phase-list-route';
 import { StudioBar } from './studio-bar';
 
-const PROJECT_PHASES = [DATA_PHASE, TRAIN_PHASE, DEPLOY_PHASE, EXPERIMENT_PRODUCTIONIZE_PHASE];
+const PROJECT_PHASES = [DATA_PHASE, TRAIN_PHASE, DEPLOY_PHASE, RETRAIN_PHASE];
 
 export function Router() {
   return (

--- a/javascript/packages/core/router/router.tsx
+++ b/javascript/packages/core/router/router.tsx
@@ -7,12 +7,13 @@ import { Sandbox } from '#core/components/views/sandbox/sandbox';
 import { CATEGORIES } from '#core/config/categories';
 import { DATA_PHASE } from '#core/config/phases/data';
 import { DEPLOY_PHASE } from '#core/config/phases/deploy';
+import { EXPERIMENT_PRODUCTIONIZE_PHASE } from '#core/config/phases/experiment-productionize';
 import { TRAIN_PHASE } from '#core/config/phases/train';
 import { EntityDetailRoute } from './entity-detail-route';
 import { PhaseListRoute } from './phase-list-route';
 import { StudioBar } from './studio-bar';
 
-const PROJECT_PHASES = [DATA_PHASE, TRAIN_PHASE, DEPLOY_PHASE];
+const PROJECT_PHASES = [DATA_PHASE, TRAIN_PHASE, EXPERIMENT_PRODUCTIONIZE_PHASE, DEPLOY_PHASE];
 
 export function Router() {
   return (

--- a/javascript/packages/core/router/router.tsx
+++ b/javascript/packages/core/router/router.tsx
@@ -13,7 +13,7 @@ import { EntityDetailRoute } from './entity-detail-route';
 import { PhaseListRoute } from './phase-list-route';
 import { StudioBar } from './studio-bar';
 
-const PROJECT_PHASES = [DATA_PHASE, TRAIN_PHASE, EXPERIMENT_PRODUCTIONIZE_PHASE, DEPLOY_PHASE];
+const PROJECT_PHASES = [DATA_PHASE, TRAIN_PHASE, DEPLOY_PHASE, EXPERIMENT_PRODUCTIONIZE_PHASE];
 
 export function Router() {
   return (


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Added a new "Experiment & Productionize" phase to the app's phase navigation, registered under the `retrain` key/slug. It surfaces the same pipeline, run, and trigger management that already exists inside Train & Evaluate, by importing the same entity configs rather than duplicating them, so both phases stay in sync automatically.

**Why?**

Pipeline, run, and trigger management currently only live inside Train & Evaluate, but they represent a distinct experiment/productionize workflow that deserves its own place in the app's navigation. A phase's id also doubles as its routable URL segment, so `retrain` was chosen as a short, stable slug while the display name stays "Experiment & Productionize".

**How did you test it?**
<img width="1601" height="1072" alt="Screenshot 2026-08-17 at 3 44 35 PM" src="https://github.com/user-attachments/assets/010c0480-d5e4-42a2-876c-66eba903e055" />



**Potential risks**

Low. This only adds a new phase entry and reuses existing, already-active entity configs; no existing phase's behavior changes.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

N/A

**Documentation Changes**

N/A
