### PR TITLE
feat(core): add Monitor & Debug coming-soon phase

### DIFF
--- a/javascript/app/icons/icons.tsx
+++ b/javascript/app/icons/icons.tsx
@@ -25,6 +25,7 @@ import SettingsIcon from '@mui/icons-material/Settings';
 import ShowChartIcon from '@mui/icons-material/ShowChart';
 import SkipNextIcon from '@mui/icons-material/SkipNext';
 import StopCircleIcon from '@mui/icons-material/StopCircle';
+import VisibilityIcon from '@mui/icons-material/Visibility';
 
 import { createMuiIconAdapter } from './mui-icon-adapter';
 
@@ -48,6 +49,7 @@ export const ICONS = {
   stopCircle: createMuiIconAdapter(StopCircleIcon),
   lightbulb: createMuiIconAdapter(LightbulbIcon),
   menu: createMuiIconAdapter(MenuIcon),
+  monitor: createMuiIconAdapter(VisibilityIcon),
   overflowMenu: createMuiIconAdapter(MoreVertIcon),
   playerNext: createMuiIconAdapter(SkipNextIcon),
   playerPlay: createMuiIconAdapter(PlayArrowIcon),

--- a/javascript/packages/core/components/views/project/components/phase-card.tsx
+++ b/javascript/packages/core/components/views/project/components/phase-card.tsx
@@ -21,6 +21,11 @@ export function PhaseCard(props: PhaseConfig & { projectId: string }) {
 
   return (
     <Box
+      overrides={{
+        BoxContainer: {
+          style: { minHeight: '220px' },
+        },
+      }}
       title={
         <div className={css({ display: 'flex', alignItems: 'center', gap: theme.sizing.scale400 })}>
           <Icon name={icon} size={theme.sizing.scale500} />

--- a/javascript/packages/core/config/phases/monitor-debug.ts
+++ b/javascript/packages/core/config/phases/monitor-debug.ts
@@ -1,7 +1,7 @@
 import type { PhaseConfig } from '#core/types/common/studio-types';
 
 export const MONITOR_DEBUG_PHASE: PhaseConfig = {
-  id: 'monitor-debug',
+  id: 'monitor',
   icon: 'monitor',
   name: 'Monitor & Debug',
   description: 'Monitor model performance and debug issues in production',

--- a/javascript/packages/core/config/phases/monitor-debug.ts
+++ b/javascript/packages/core/config/phases/monitor-debug.ts
@@ -1,0 +1,10 @@
+import type { PhaseConfig } from '#core/types/common/studio-types';
+
+export const MONITOR_DEBUG_PHASE: PhaseConfig = {
+  id: 'monitor-debug',
+  icon: 'monitor',
+  name: 'Monitor & Debug',
+  description: 'Monitor model performance and debug issues in production',
+  state: 'comingSoon' as const,
+  entities: [],
+};

--- a/javascript/packages/core/config/phases/phases.ts
+++ b/javascript/packages/core/config/phases/phases.ts
@@ -1,6 +1,7 @@
 import { DATA_PHASE } from './data';
 import { DEPLOY_PHASE } from './deploy';
 import { RETRAIN_PHASE } from './retrain';
+import { MONITOR_DEBUG_PHASE } from './monitor-debug';
 import { TRAIN_PHASE } from './train';
 
 export const PHASES = {
@@ -8,4 +9,5 @@ export const PHASES = {
   train: TRAIN_PHASE,
   deploy: DEPLOY_PHASE,
   retrain: RETRAIN_PHASE,
+  'monitor-debug': MONITOR_DEBUG_PHASE,
 };

--- a/javascript/packages/core/config/phases/phases.ts
+++ b/javascript/packages/core/config/phases/phases.ts
@@ -1,7 +1,7 @@
 import { DATA_PHASE } from './data';
 import { DEPLOY_PHASE } from './deploy';
-import { RETRAIN_PHASE } from './retrain';
 import { MONITOR_DEBUG_PHASE } from './monitor-debug';
+import { RETRAIN_PHASE } from './retrain';
 import { TRAIN_PHASE } from './train';
 
 export const PHASES = {

--- a/javascript/packages/core/config/phases/phases.ts
+++ b/javascript/packages/core/config/phases/phases.ts
@@ -9,5 +9,5 @@ export const PHASES = {
   train: TRAIN_PHASE,
   deploy: DEPLOY_PHASE,
   retrain: RETRAIN_PHASE,
-  'monitor-debug': MONITOR_DEBUG_PHASE,
+  monitor: MONITOR_DEBUG_PHASE,
 };

--- a/javascript/packages/core/router/router.tsx
+++ b/javascript/packages/core/router/router.tsx
@@ -8,12 +8,19 @@ import { CATEGORIES } from '#core/config/categories';
 import { DATA_PHASE } from '#core/config/phases/data';
 import { DEPLOY_PHASE } from '#core/config/phases/deploy';
 import { RETRAIN_PHASE } from '#core/config/phases/retrain';
+import { MONITOR_DEBUG_PHASE } from '#core/config/phases/monitor-debug';
 import { TRAIN_PHASE } from '#core/config/phases/train';
 import { EntityDetailRoute } from './entity-detail-route';
 import { PhaseListRoute } from './phase-list-route';
 import { StudioBar } from './studio-bar';
 
-const PROJECT_PHASES = [DATA_PHASE, TRAIN_PHASE, DEPLOY_PHASE, RETRAIN_PHASE];
+const PROJECT_PHASES = [
+  DATA_PHASE,
+  TRAIN_PHASE,
+  DEPLOY_PHASE,
+  RETRAIN_PHASE,
+  MONITOR_DEBUG_PHASE,
+];
 
 export function Router() {
   return (

--- a/javascript/packages/core/router/router.tsx
+++ b/javascript/packages/core/router/router.tsx
@@ -7,20 +7,14 @@ import { Sandbox } from '#core/components/views/sandbox/sandbox';
 import { CATEGORIES } from '#core/config/categories';
 import { DATA_PHASE } from '#core/config/phases/data';
 import { DEPLOY_PHASE } from '#core/config/phases/deploy';
-import { RETRAIN_PHASE } from '#core/config/phases/retrain';
 import { MONITOR_DEBUG_PHASE } from '#core/config/phases/monitor-debug';
+import { RETRAIN_PHASE } from '#core/config/phases/retrain';
 import { TRAIN_PHASE } from '#core/config/phases/train';
 import { EntityDetailRoute } from './entity-detail-route';
 import { PhaseListRoute } from './phase-list-route';
 import { StudioBar } from './studio-bar';
 
-const PROJECT_PHASES = [
-  DATA_PHASE,
-  TRAIN_PHASE,
-  DEPLOY_PHASE,
-  RETRAIN_PHASE,
-  MONITOR_DEBUG_PHASE,
-];
+const PROJECT_PHASES = [DATA_PHASE, TRAIN_PHASE, DEPLOY_PHASE, RETRAIN_PHASE, MONITOR_DEBUG_PHASE];
 
 export function Router() {
   return (


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
Adds a "Monitor & Debug" phase to the phase list, marked `comingSoon`,
following the same placeholder pattern already used for "Deploy &
Predict". It shows up in both the project detail phase-card grid and
the navigation menu drawer with an eyeball icon and a "Coming soon"
badge, and has no entities yet.

**Why?**
To signal the upcoming observability phase in navigation ahead of its
entities landing, matching how Deploy & Predict was introduced before
its entities were built out.

**How did you test it?**
<img width="1601" height="1072" alt="Screenshot 2026-08-17 at 3 44 35 PM" src="https://github.com/user-attachments/assets/9b42cef9-8fe6-4401-8c2e-09f2c1d13050" />


**Potential risks**
None — purely additive config change with no entities wired up yet.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**
N/A

**Documentation Changes**
N/A