### PR TITLE
Add buildIndexedFieldId for resolving repeated-layout field ids

### DIFF
--- a/javascript/packages/core/components/form/layout/condition/__tests__/build-indexed-field-id.test.ts
+++ b/javascript/packages/core/components/form/layout/condition/__tests__/build-indexed-field-id.test.ts
@@ -1,0 +1,43 @@
+import { buildIndexedFieldId } from '#core/components/form/layout/condition/build-indexed-field-id';
+
+describe('buildIndexedFieldId', () => {
+  it('inserts the index after the root path and preserves the suffix', () => {
+    expect(
+      buildIndexedFieldId({
+        entityId: 'spec.messages.contents.text',
+        rootFieldPath: 'spec.messages[3].contents',
+        index: 1,
+      })
+    ).toBe('spec.messages[3].contents[1].text');
+  });
+
+  it('produces no suffix when entityId matches the root path exactly', () => {
+    expect(
+      buildIndexedFieldId({
+        entityId: 'spec.messages.contents',
+        rootFieldPath: 'spec.messages[3].contents',
+        index: 2,
+      })
+    ).toBe('spec.messages[3].contents[2]');
+  });
+
+  it('strips multiple existing indices from a nested repeated root path', () => {
+    expect(
+      buildIndexedFieldId({
+        entityId: 'spec.messages.items.nested.text',
+        rootFieldPath: 'spec.messages[3].items[0].nested',
+        index: 5,
+      })
+    ).toBe('spec.messages[3].items[0].nested[5].text');
+  });
+
+  it('supports index 0', () => {
+    expect(
+      buildIndexedFieldId({
+        entityId: 'spec.messages.contents.text',
+        rootFieldPath: 'spec.messages[3].contents',
+        index: 0,
+      })
+    ).toBe('spec.messages[3].contents[0].text');
+  });
+});

--- a/javascript/packages/core/components/form/layout/condition/build-indexed-field-id.ts
+++ b/javascript/packages/core/components/form/layout/condition/build-indexed-field-id.ts
@@ -1,0 +1,20 @@
+import type { RepeatedLayoutState } from '#core/providers/repeated-layout-provider/types';
+
+/**
+ * Builds a field ID with array indices for repeated layouts.
+ *
+ * @example
+ * entityId: 'spec.messages.contents.text'
+ * rootFieldPath: 'spec.messages[3].contents'
+ * index: 1
+ * output: 'spec.messages[3].contents[1].text'
+ */
+export function buildIndexedFieldId({
+  entityId,
+  rootFieldPath,
+  index,
+}: RepeatedLayoutState & { entityId: string }): string {
+  const rootWithoutIndices = rootFieldPath.replace(/\[\d+\]/g, '');
+  const suffix = entityId.replace(rootWithoutIndices, '');
+  return `${rootFieldPath}[${index}]${suffix}`;
+}


### PR DESCRIPTION
## Summary
Repeated layouts render one entity-relative config against every row of an array, so a literal field id isn't enough on its own — the current row's index needs to be spliced into the right spot in the path. This adds that path-building step as a standalone, independently tested utility, stacked on top of the base condition operator and ahead of wiring it into anything that consumes it.

## Test Plan
I ran the utility's unit tests directly, covering index insertion, an exact-match root path, multiple existing indices in a nested repeated root, and index 0.

## Issues