### PR TITLE
Resolve conditions against the current row in repeated layouts

### DIFF
--- a/javascript/packages/core/components/form/layout/condition/__tests__/build-indexed-field-id.test.ts
+++ b/javascript/packages/core/components/form/layout/condition/__tests__/build-indexed-field-id.test.ts
@@ -1,0 +1,43 @@
+import { buildIndexedFieldId } from '#core/components/form/layout/condition/build-indexed-field-id';
+
+describe('buildIndexedFieldId', () => {
+  it('inserts the index after the root path and preserves the suffix', () => {
+    expect(
+      buildIndexedFieldId({
+        entityId: 'spec.messages.contents.text',
+        rootFieldPath: 'spec.messages[3].contents',
+        index: 1,
+      })
+    ).toBe('spec.messages[3].contents[1].text');
+  });
+
+  it('produces no suffix when entityId matches the root path exactly', () => {
+    expect(
+      buildIndexedFieldId({
+        entityId: 'spec.messages.contents',
+        rootFieldPath: 'spec.messages[3].contents',
+        index: 2,
+      })
+    ).toBe('spec.messages[3].contents[2]');
+  });
+
+  it('strips multiple existing indices from a nested repeated root path', () => {
+    expect(
+      buildIndexedFieldId({
+        entityId: 'spec.messages.items.nested.text',
+        rootFieldPath: 'spec.messages[3].items[0].nested',
+        index: 5,
+      })
+    ).toBe('spec.messages[3].items[0].nested[5].text');
+  });
+
+  it('supports index 0', () => {
+    expect(
+      buildIndexedFieldId({
+        entityId: 'spec.messages.contents.text',
+        rootFieldPath: 'spec.messages[3].contents',
+        index: 0,
+      })
+    ).toBe('spec.messages[3].contents[0].text');
+  });
+});

--- a/javascript/packages/core/components/form/layout/condition/__tests__/form-condition.test.tsx
+++ b/javascript/packages/core/components/form/layout/condition/__tests__/form-condition.test.tsx
@@ -5,6 +5,7 @@ import { vi } from 'vitest';
 import { Form } from '#core/components/form/form';
 import { useForm } from '#core/components/form/hooks/use-form';
 import { FormCondition } from '#core/components/form/layout/condition/form-condition';
+import { RepeatedLayoutProvider } from '#core/providers/repeated-layout-provider/repeated-layout-provider';
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
 import { getIconProviderWrapper } from '#core/test/wrappers/get-icon-provider-wrapper';
@@ -70,6 +71,66 @@ describe('FormCondition', () => {
       await waitFor(() =>
         expect(screen.queryByText('Conditional Content')).not.toBeInTheDocument()
       );
+    });
+  });
+
+  describe('within a repeated layout', () => {
+    const layout: ConditionLayoutConfig = {
+      type: 'condition',
+      when: 'items.name',
+      is: 'admin',
+      items: [],
+    };
+
+    it('resolves the condition against the indexed field for the current repeated item', () => {
+      render(
+        <Form onSubmit={vi.fn()} initialValues={{ items: [{ name: 'guest' }, { name: 'admin' }] }}>
+          <RepeatedLayoutProvider rootFieldPath="items" index={1}>
+            <FormCondition layout={layout}>
+              <div>Conditional Content</div>
+            </FormCondition>
+          </RepeatedLayoutProvider>
+        </Form>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
+
+      expect(screen.queryByText('Conditional Content')).toBeInTheDocument();
+    });
+
+    it('does not match against a different index in the same repeated list', () => {
+      render(
+        <Form onSubmit={vi.fn()} initialValues={{ items: [{ name: 'guest' }, { name: 'admin' }] }}>
+          <RepeatedLayoutProvider rootFieldPath="items" index={0}>
+            <FormCondition layout={layout}>
+              <div>Conditional Content</div>
+            </FormCondition>
+          </RepeatedLayoutProvider>
+        </Form>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
+
+      expect(screen.queryByText('Conditional Content')).not.toBeInTheDocument();
+    });
+
+    it('reacts to changes at the indexed field, not the unindexed entity path', async () => {
+      const user = userEvent.setup();
+      render(
+        <Form onSubmit={vi.fn()} initialValues={{ items: [{ name: 'guest' }] }}>
+          <RepeatedLayoutProvider rootFieldPath="items" index={0}>
+            <FormCondition layout={layout}>
+              <div>Conditional Content</div>
+            </FormCondition>
+            <SetValueButton name="items[0].name" value="admin" label="Change value" />
+          </RepeatedLayoutProvider>
+        </Form>,
+        buildWrapper([getBaseProviderWrapper(), getIconProviderWrapper()])
+      );
+
+      expect(screen.queryByText('Conditional Content')).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Change value' }));
+
+      await waitFor(() => expect(screen.queryByText('Conditional Content')).toBeInTheDocument());
     });
   });
 

--- a/javascript/packages/core/components/form/layout/condition/build-indexed-field-id.ts
+++ b/javascript/packages/core/components/form/layout/condition/build-indexed-field-id.ts
@@ -1,0 +1,20 @@
+import type { RepeatedLayoutState } from '#core/providers/repeated-layout-provider/types';
+
+/**
+ * Builds a field ID with array indices for repeated layouts.
+ *
+ * @example
+ * entityId: 'spec.messages.contents.text'
+ * rootFieldPath: 'spec.messages[3].contents'
+ * index: 1
+ * output: 'spec.messages[3].contents[1].text'
+ */
+export function buildIndexedFieldId({
+  entityId,
+  rootFieldPath,
+  index,
+}: RepeatedLayoutState & { entityId: string }): string {
+  const rootWithoutIndices = rootFieldPath.replace(/\[\d+\]/g, '');
+  const suffix = entityId.replace(rootWithoutIndices, '');
+  return `${rootFieldPath}[${index}]${suffix}`;
+}

--- a/javascript/packages/core/components/form/layout/condition/form-condition.tsx
+++ b/javascript/packages/core/components/form/layout/condition/form-condition.tsx
@@ -1,5 +1,7 @@
 import { useField } from 'react-final-form';
 
+import { useRepeatedLayoutContext } from '#core/providers/repeated-layout-provider/use-repeated-layout-context';
+import { buildIndexedFieldId } from './build-indexed-field-id';
 import { evaluateCondition } from './evaluate-condition';
 
 import type { ReactNode } from 'react';
@@ -7,6 +9,11 @@ import type { ConditionLayoutConfig } from './types';
 
 /**
  * Renders `children` when `layout` evaluates to true against the current form state.
+ *
+ * `layout.when` is an entity-relative field path (e.g. `items.name`), not a literal
+ * field id. Inside a `RepeatedLayoutProvider`, it's resolved through
+ * `buildIndexedFieldId` against the current item's index before subscribing, so the
+ * same config can be reused across every item in a repeated layout.
  */
 export function FormCondition({
   layout,
@@ -15,7 +22,18 @@ export function FormCondition({
   layout: ConditionLayoutConfig;
   children: ReactNode;
 }) {
-  const { input } = useField(layout.when, { subscription: { value: true } });
+  const repeatedContext = useRepeatedLayoutContext();
+
+  let fieldId = layout.when;
+  if (repeatedContext) {
+    fieldId = buildIndexedFieldId({
+      rootFieldPath: repeatedContext.rootFieldPath,
+      entityId: layout.when,
+      index: repeatedContext.index,
+    });
+  }
+
+  const { input } = useField(fieldId, { subscription: { value: true } });
 
   return evaluateCondition(layout, input.value) ? <>{children}</> : null;
 }

--- a/javascript/packages/core/components/views/sandbox/repeated-condition-example.tsx
+++ b/javascript/packages/core/components/views/sandbox/repeated-condition-example.tsx
@@ -1,0 +1,32 @@
+import { ArrayFormGroup } from '#core/components/form/layout/array-form-group/array-form-group';
+import { LayoutItemList } from '#core/components/form/layout/layout-item-list';
+
+import type { FieldConfig, LayoutItem } from '#core/components/form/types/config-types';
+
+/**
+ * Each item's `detail` field is conditional on that same item's `enabled` field.
+ * `when: 'items.enabled'` is entity-relative; `FormCondition` resolves it against the current
+ * row's index so the same config doesn't leak across rows.
+ */
+export function RepeatedConditionExample() {
+  return (
+    <ArrayFormGroup rootFieldPath="items" groupLabel="Item" minItems={2}>
+      {(indexedFieldPath) => {
+        const fields: Record<string, FieldConfig | undefined> = {
+          [`${indexedFieldPath}.enabled`]: { type: 'boolean', label: 'Show detail' },
+          [`${indexedFieldPath}.detail`]: { type: 'string', label: 'Detail' },
+        };
+        const layout: LayoutItem[] = [
+          `${indexedFieldPath}.enabled`,
+          {
+            type: 'condition',
+            when: 'items.enabled',
+            is: true,
+            items: [`${indexedFieldPath}.detail`],
+          },
+        ];
+        return <LayoutItemList items={layout} fields={fields} />;
+      }}
+    </ArrayFormGroup>
+  );
+}

--- a/javascript/packages/core/components/views/sandbox/sandbox.tsx
+++ b/javascript/packages/core/components/views/sandbox/sandbox.tsx
@@ -7,6 +7,7 @@ import { Form } from '#core/components/form/form';
 import { LayoutItemList } from '#core/components/form/layout/layout-item-list';
 import { filterHiddenConditionFields } from '#core/components/form/utils/filter-hidden-condition-fields';
 import { MainViewContainer } from '#core/components/views/main-view-container';
+import { RepeatedConditionExample } from '#core/components/views/sandbox/repeated-condition-example';
 
 import type { FormConfig } from '#core/components/form/types/config-types';
 
@@ -28,6 +29,7 @@ const conditionalFormConfig: FormConfig = {
 
 export function Sandbox() {
   const [submitted, setSubmitted] = useState<Record<string, unknown>>();
+  const [repeatedSubmitted, setRepeatedSubmitted] = useState<Record<string, unknown>>();
 
   return (
     <MainViewContainer>
@@ -53,6 +55,24 @@ export function Sandbox() {
           <LabelMedium marginBottom="scale300">Last submitted values</LabelMedium>
           <Block as="pre" backgroundColor="backgroundSecondary" padding="12px">
             {JSON.stringify(submitted, null, 2)}
+          </Block>
+        </Block>
+      ) : null}
+      <Block marginTop="48px" width="400px">
+        <LabelMedium marginBottom="scale300">Condition inside a repeated layout</LabelMedium>
+        <Form
+          initialValues={{ items: [{ enabled: false }, { enabled: false }] }}
+          onSubmit={(values) => setRepeatedSubmitted(values)}
+        >
+          <RepeatedConditionExample />
+          <SubmitButton>Submit</SubmitButton>
+        </Form>
+      </Block>
+      {repeatedSubmitted ? (
+        <Block marginTop="24px">
+          <LabelMedium marginBottom="scale300">Last submitted values</LabelMedium>
+          <Block as="pre" backgroundColor="backgroundSecondary" padding="12px">
+            {JSON.stringify(repeatedSubmitted, null, 2)}
           </Block>
         </Block>
       ) : null}


### PR DESCRIPTION
## Summary
A condition's target field is an entity-relative path, so reusing the same condition config across every row of a repeated layout would otherwise only ever subscribe to the first row's field. Resolving the target against the current row requires splicing that row's index into the right spot in the path, so this adds that path-building step as its own tested helper and wires it directly into the condition renderer.

## Test Plan
I ran the path-building helper's tests (index insertion, an exact-match root path, multiple existing indices in a nested repeated root, index 0) along with the condition renderer's tests covering: resolving against the indexed field for the current row, not matching against a different row's index in the same list, and reacting to changes at the indexed field rather than the unindexed entity path.

I also verified the fix interactively in the sandbox by adding a repeated-layout example whose condition depends on a field in the same row. With two rows rendered, checking the first row's "Show detail" box only revealed that row's detail field, and unchecking it removed it while the second row's own (independently checked) detail field and value stayed exactly as they were. The rendered field names confirmed each row's condition and target resolved against its own index (`items[0].detail` and `items[1].detail`), and submitting the form showed each row's values were tracked independently.
