### PR TITLE
fix(python): render <crd> get <name> as table and fix -o yaml OrderedDict crash

### DIFF
--- a/python/michelangelo/cli/mactl/crd.py
+++ b/python/michelangelo/cli/mactl/crd.py
@@ -512,6 +512,21 @@ def _render_list_items(
         print_list_formatted(items, extra_columns=extra_columns)
 
 
+def _unwrap_single_field_response(msg: Message) -> Message:
+    """Return the inner resource from a single-field wrapper response.
+
+    `GetXxxResponse` messages wrap the resource in one message-typed field
+    (e.g. `GetPipelineResponse.pipeline`). The table formatter needs the
+    resource itself so it can read `metadata.namespace` and friends. Non-
+    wrapper messages (already the resource, or a shape we don't recognize)
+    pass through unchanged.
+    """
+    fields = msg.DESCRIPTOR.fields
+    if len(fields) == 1 and fields[0].message_type is not None:
+        return getattr(msg, fields[0].name)
+    return msg
+
+
 def _render_single_item(
     msg: Message,
     output_format: str,
@@ -533,7 +548,9 @@ def _render_single_item(
     elif output_format == "json":
         print(MessageToJson(msg, preserving_proto_field_name=True))
     else:
-        print_list_formatted([msg], extra_columns=extra_columns)
+        print_list_formatted(
+            [_unwrap_single_field_response(msg)], extra_columns=extra_columns
+        )
 
 
 def _resolve_criteria(spec, bound_args: dict, arg_dest: str) -> list[Criterion]:

--- a/python/michelangelo/cli/mactl/crd.py
+++ b/python/michelangelo/cli/mactl/crd.py
@@ -2,6 +2,7 @@
 
 import json
 from argparse import ArgumentParser
+from collections import OrderedDict
 from collections.abc import Iterator, MutableMapping, Sequence
 from contextlib import redirect_stdout
 from copy import deepcopy
@@ -24,7 +25,7 @@ from grpc import (
     StatusCode,
 )
 from typing_extensions import NotRequired
-from yaml import YAMLError
+from yaml import SafeDumper, YAMLError
 from yaml import safe_dump as yaml_safe_dump
 from yaml import safe_load as yaml_safe_load
 
@@ -36,6 +37,15 @@ from michelangelo.cli.mactl.grpc_tools import (
 
 _LOG = getLogger(__name__)
 METADATA_STUB = []
+
+# MessageToDict emits collections.OrderedDict when it walks a
+# google.protobuf.Any so `@type` sorts first (see json_format._Printer).
+# yaml.SafeDumper only registers a representer for plain dict, so any Any
+# field in a get/list response makes `-o yaml` raise RepresenterError.
+SafeDumper.add_representer(
+    OrderedDict,
+    lambda dumper, data: dumper.represent_dict(data.items()),
+)
 
 
 class Criterion(TypedDict):
@@ -379,7 +389,11 @@ def get_func_impl(crd_method_info: CrdMethodInfo, bound_args: Signature) -> Mess
         if not namespace:
             raise ValueError("--namespace is required when fetching a resource by name")
         call_res = _self._get(namespace=namespace, name=name)
-        _render_single_item(call_res, output)
+        _render_single_item(
+            call_res,
+            output,
+            extra_columns=getattr(_self, "additional_columns", ()),
+        )
         return call_res
 
     if not namespace and not all_namespaces:
@@ -498,8 +512,18 @@ def _render_list_items(
         print_list_formatted(items, extra_columns=extra_columns)
 
 
-def _render_single_item(msg: Message, output_format: str) -> None:
-    """Render a single CRD message in the requested output format."""
+def _render_single_item(
+    msg: Message,
+    output_format: str,
+    extra_columns: Sequence[dict] = (),
+) -> None:
+    """Render a single CRD message in the requested output format.
+
+    Table output prints a one-row table using the same columns as `list`,
+    matching kubectl's `get <resource> <name>` behavior. Prior versions
+    printed the raw proto text_format, which rendered `google.protobuf.Any`
+    payloads (e.g. `spec.manifest.content`) as escaped byte strings.
+    """
     if output_format == "yaml":
         print(
             yaml_safe_dump(
@@ -509,7 +533,7 @@ def _render_single_item(msg: Message, output_format: str) -> None:
     elif output_format == "json":
         print(MessageToJson(msg, preserving_proto_field_name=True))
     else:
-        print(msg)
+        print_list_formatted([msg], extra_columns=extra_columns)
 
 
 def _resolve_criteria(spec, bound_args: dict, arg_dest: str) -> list[Criterion]:

--- a/python/michelangelo/cli/mactl/crd_test.py
+++ b/python/michelangelo/cli/mactl/crd_test.py
@@ -412,6 +412,69 @@ class RenderHelpersTest(TestCase):
 
         self.assertIn("name: x", buf.getvalue())
 
+    @patch("michelangelo.cli.mactl.crd.MessageToDict")
+    def test_render_single_item_yaml_handles_ordereddict(self, mock_to_dict):
+        """OrderedDict from unpacked google.protobuf.Any dumps without error.
+
+        MessageToDict emits OrderedDict when it walks an Any field so `@type`
+        sorts first. yaml.SafeDumper has no representer for OrderedDict by
+        default, so this would raise RepresenterError before the fix.
+        """
+        from collections import OrderedDict
+
+        from michelangelo.cli.mactl.crd import _render_single_item
+
+        mock_to_dict.return_value = {
+            "spec": {
+                "manifest": {
+                    "content": OrderedDict(
+                        [
+                            ("@type", "type.googleapis.com/foo.Bar"),
+                            ("value", {"nested": OrderedDict([("k", "v")])}),
+                        ]
+                    ),
+                }
+            }
+        }
+
+        import io
+        from contextlib import redirect_stdout
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            _render_single_item(Mock(), "yaml")
+
+        out = buf.getvalue()
+        self.assertIn("'@type': type.googleapis.com/foo.Bar", out)
+        self.assertIn("k: v", out)
+
+    @patch("michelangelo.cli.mactl.crd.print_list_formatted")
+    def test_render_single_item_table_uses_list_formatter(self, mock_print):
+        """Default (table) output delegates to print_list_formatted.
+
+        Previously printed raw proto text_format, which rendered
+        google.protobuf.Any payloads (e.g. spec.manifest.content) as escaped
+        byte strings. New behavior matches kubectl's `get <res> <name>`:
+        the same one-row table as `list`.
+        """
+        from michelangelo.cli.mactl.crd import _render_single_item
+
+        msg = self._mock_item("ns", "x")
+        _render_single_item(msg, "table")
+
+        mock_print.assert_called_once_with([msg], extra_columns=())
+
+    @patch("michelangelo.cli.mactl.crd.print_list_formatted")
+    def test_render_single_item_table_forwards_extra_columns(self, mock_print):
+        """extra_columns from the CRD passes through to the table formatter."""
+        from michelangelo.cli.mactl.crd import _render_single_item
+
+        extras = [{"column_name": "OWNER", "retrieve_func": lambda m: "u"}]
+        msg = self._mock_item("ns", "x")
+        _render_single_item(msg, "table", extra_columns=extras)
+
+        mock_print.assert_called_once_with([msg], extra_columns=extras)
+
 
 class DeleteFuncImplTest(TestCase):
     """Test cases for delete_func_impl function."""
@@ -443,7 +506,8 @@ class DeleteFuncImplTest(TestCase):
 class GetFuncImplTest(TestCase):
     """Test cases for get_func_impl function."""
 
-    def test_get_func_impl_with_name_calls_get(self):
+    @patch("michelangelo.cli.mactl.crd._render_single_item")
+    def test_get_func_impl_with_name_calls_get(self, _mock_render):
         """Test get_func_impl with name calls _self._get and prints result."""
         mock_crd = Mock()
         mock_response = Mock()
@@ -464,7 +528,8 @@ class GetFuncImplTest(TestCase):
         mock_crd._get.assert_called_once_with(namespace="ns", name="proj")
         self.assertEqual(result, mock_response)
 
-    def test_get_func_impl_with_name_flag_calls_get(self):
+    @patch("michelangelo.cli.mactl.crd._render_single_item")
+    def test_get_func_impl_with_name_flag_calls_get(self, _mock_render):
         """`--name X` (dest=name_flag) routes through _get just like positional."""
         mock_crd = Mock()
         mock_response = Mock()
@@ -492,7 +557,8 @@ class GetFuncImplTest(TestCase):
         mock_crd._get.assert_called_once_with(namespace="ns", name="proj")
         self.assertEqual(result, mock_response)
 
-    def test_get_func_impl_positional_overrides_name_flag(self):
+    @patch("michelangelo.cli.mactl.crd._render_single_item")
+    def test_get_func_impl_positional_overrides_name_flag(self, _mock_render):
         """Positional `name` wins when both are supplied."""
         mock_crd = Mock()
         mock_crd._get.return_value = Mock()
@@ -1465,10 +1531,11 @@ class GenerateGetTest(TestCase):
         self.assertTrue(hasattr(crd, "_get"))
         self.assertTrue(callable(crd._get))
 
+    @patch("michelangelo.cli.mactl.crd._render_single_item")
     @patch("michelangelo.cli.mactl.crd.crd_method_call_kwargs")
     @patch.object(CRD, "_extract_method_info")
     def test_generate_get_execution(
-        self, mock_extract_method_info, mock_crd_method_call_kwargs
+        self, mock_extract_method_info, mock_crd_method_call_kwargs, _mock_render
     ):
         """Test the generated get method can be executed with correct arguments."""
         mock_channel = Mock()
@@ -1486,10 +1553,11 @@ class GenerateGetTest(TestCase):
         self.assertEqual(call_args.kwargs["namespace"], "test-ns")
         self.assertEqual(call_args.kwargs["name"], "test-name")
 
+    @patch("michelangelo.cli.mactl.crd._render_single_item")
     @patch("michelangelo.cli.mactl.crd.crd_method_call_kwargs")
     @patch.object(CRD, "_extract_method_info")
     def test_generate_get_execution_via_name_flag(
-        self, mock_extract_method_info, mock_crd_method_call_kwargs
+        self, mock_extract_method_info, mock_crd_method_call_kwargs, _mock_render
     ):
         """Generated `get` resolves the --name flag (dest=name_flag) like positional.
 

--- a/python/michelangelo/cli/mactl/crd_test.py
+++ b/python/michelangelo/cli/mactl/crd_test.py
@@ -459,7 +459,10 @@ class RenderHelpersTest(TestCase):
         """
         from michelangelo.cli.mactl.crd import _render_single_item
 
+        # Non-wrapper message: single field but scalar-typed → no unwrap.
         msg = self._mock_item("ns", "x")
+        msg.DESCRIPTOR = Mock()
+        msg.DESCRIPTOR.fields = []
         _render_single_item(msg, "table")
 
         mock_print.assert_called_once_with([msg], extra_columns=())
@@ -471,9 +474,34 @@ class RenderHelpersTest(TestCase):
 
         extras = [{"column_name": "OWNER", "retrieve_func": lambda m: "u"}]
         msg = self._mock_item("ns", "x")
+        msg.DESCRIPTOR = Mock()
+        msg.DESCRIPTOR.fields = []
         _render_single_item(msg, "table", extra_columns=extras)
 
         mock_print.assert_called_once_with([msg], extra_columns=extras)
+
+    @patch("michelangelo.cli.mactl.crd.print_list_formatted")
+    def test_render_single_item_table_unwraps_wrapper_response(self, mock_print):
+        """GetXxxResponse (one message-typed field) is unwrapped for the table.
+
+        `_get` returns e.g. `GetPipelineResponse` with a single `pipeline`
+        field. The table formatter expects the resource itself so it can
+        read `metadata.namespace`.
+        """
+        from michelangelo.cli.mactl.crd import _render_single_item
+
+        inner = self._mock_item("ns", "x")
+        wrapper = Mock()
+        wrapper.DESCRIPTOR = Mock()
+        field = Mock()
+        field.name = "pipeline"
+        field.message_type = Mock()  # truthy → treated as message field
+        wrapper.DESCRIPTOR.fields = [field]
+        wrapper.pipeline = inner
+
+        _render_single_item(wrapper, "table")
+
+        mock_print.assert_called_once_with([inner], extra_columns=())
 
 
 class DeleteFuncImplTest(TestCase):


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug Fix

## What changed?
Two rendering bugs in `<crd> get <name>`:

1. **Default output** now delegates to `print_list_formatted` — one-row table matching `list`, per kubectl's `get <res> <name>`. Previously printed raw proto text_format; on responses containing `google.protobuf.Any` (e.g. `Pipeline.spec.manifest.content`) that rendered thousands of escaped bytes. `_unwrap_single_field_response` extracts the inner resource from `GetXxxResponse` wrappers.
2. **`-o yaml`** no longer raises `RepresenterError` on Any-containing responses. `MessageToDict` returns `OrderedDict` for Any payloads (`@type` first); `yaml.SafeDumper` had no representer. Registered a module-level one that treats `OrderedDict` as a plain mapping.

`_render_single_item` also grows `extra_columns` so per-CRD extras reach the row.

## Why?
`pipeline get -o yaml` was unusable end-to-end on any pipeline with populated manifest content; default output was a byte-string wall.

## How did you test it?
### Unit + style
`pytest python/michelangelo/cli/mactl/crd_test.py` — 88 passed (4 new: yaml-OrderedDict, table-delegates, extras-forwarded, wrapper-unwrap). `ruff check` + `ruff format --check` clean.

### Integration — real apiserver, `ma-integration-test` namespace
| Command | Observed |
| --- | --- |
| `pipeline get -n … boston-housing-train-torch-model-maker` | one-row table (NAMESPACE / NAME / LAST_UPDATED_SPEC / OWNER / TYPE) |
| `... -o yaml` | 300-line YAML, `spec.manifest.content` unpacked as `@type/type_url/value` tree, no traceback |

## Breaking Changes
- [x] No breaking changes

## Release notes
Fix `<crd> get <name>` default output (now a one-row table like `list`) and `<crd> get <name> -o yaml` crash on responses containing `google.protobuf.Any` fields.
