### PR TITLE
fix(go): sync paused TriggerRun schedules

### DIFF
--- a/go/components/triggerrun/cron_trigger.go
+++ b/go/components/triggerrun/cron_trigger.go
@@ -227,19 +227,6 @@ func (c *cronTrigger) Update(ctx context.Context, triggerRun *v2pb.TriggerRun, a
 		Name:      triggerRun.Name,
 	})
 
-	// A paused schedule cannot start workflows with stale inputs, so defer all
-	// schedule synchronization until resume. This also avoids repeatedly calling
-	// Temporal for paused schedules whose workflow has exhausted its signal limit.
-	// Kill is intentionally not handled here; returning actionHandled=false lets
-	// the controller continue to the normal schedule deletion path.
-	if triggerRun.Status.State == v2pb.TRIGGER_RUN_STATE_PAUSED &&
-		action != v2pb.TRIGGER_RUN_ACTION_RESUME {
-		log.Info("trigger is paused, deferring schedule synchronization until resume")
-		// A repeated PAUSE command is already satisfied. Mark it handled so the
-		// controller clears the one-time action without contacting Temporal.
-		return triggerRun.Status, action == v2pb.TRIGGER_RUN_ACTION_PAUSE, nil
-	}
-
 	desiredCron := triggerRun.Spec.Trigger.GetCronSchedule().GetCron()
 	if desiredCron == "" {
 		log.Info("no cron schedule in spec, skipping update")

--- a/go/components/triggerrun/cron_trigger_test.go
+++ b/go/components/triggerrun/cron_trigger_test.go
@@ -754,47 +754,45 @@ func TestCronTrigger_Update(t *testing.T) {
 	}
 }
 
-func TestCronTrigger_UpdateDefersDriftWhilePaused(t *testing.T) {
-	for _, test := range []struct {
-		action          v2pb.TriggerRunAction
-		expectedHandled bool
-	}{
-		{action: v2pb.TRIGGER_RUN_ACTION_NO_ACTION},
-		{action: v2pb.TRIGGER_RUN_ACTION_KILL},
-		{action: v2pb.TRIGGER_RUN_ACTION_PAUSE, expectedHandled: true},
-	} {
-		t.Run(test.action.String(), func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			mockClient := interfaceMock.NewMockWorkflowClient(ctrl)
-			triggerRun := &v2pb.TriggerRun{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "test-namespace",
-					Name:      "test-triggerrun",
+func TestCronTrigger_UpdateSyncsDriftWhilePaused(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockClient := interfaceMock.NewMockWorkflowClient(ctrl)
+	triggerRun := &v2pb.TriggerRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test-namespace",
+			Name:      "test-triggerrun",
+		},
+		Spec: v2pb.TriggerRunSpec{
+			Trigger: &v2pb.Trigger{
+				TriggerType: &v2pb.Trigger_CronSchedule{
+					CronSchedule: &v2pb.CronSchedule{Cron: "0 0 * * *"},
 				},
-				Spec: v2pb.TriggerRunSpec{
-					Trigger: &v2pb.Trigger{
-						TriggerType: &v2pb.Trigger_CronSchedule{
-							CronSchedule: &v2pb.CronSchedule{Cron: "0 0 * * *"},
-						},
-						MaxConcurrency: 2,
-					},
-				},
-				Status: v2pb.TriggerRunStatus{
-					State:                   v2pb.TRIGGER_RUN_STATE_PAUSED,
-					ActualTrigger:           &v2pb.Trigger{TriggerType: &v2pb.Trigger_CronSchedule{CronSchedule: &v2pb.CronSchedule{Cron: "0 6 * * *"}}},
-					ActualScheduleInputHash: "previous-input-hash",
-					ErrorMessage:            "exceeded workflow execution limit for signal events",
-				},
-			}
-
-			status, handled, err := NewCronTrigger(zapr.NewLogger(zap.NewNop()), mockClient).Update(
-				context.Background(), triggerRun, test.action)
-
-			require.NoError(t, err)
-			assert.Equal(t, test.expectedHandled, handled)
-			assert.Equal(t, triggerRun.Status, status)
-		})
+				MaxConcurrency: 2,
+			},
+		},
+		Status: v2pb.TriggerRunStatus{
+			State:                   v2pb.TRIGGER_RUN_STATE_PAUSED,
+			ActualTrigger:           &v2pb.Trigger{TriggerType: &v2pb.Trigger_CronSchedule{CronSchedule: &v2pb.CronSchedule{Cron: "0 6 * * *"}}},
+			ActualScheduleInputHash: "previous-input-hash",
+		},
 	}
+	desiredHash := mustScheduleInputHash(t, triggerRun)
+	mockClient.EXPECT().UpdateTrigger(
+		gomock.Any(),
+		"test-namespace.test-triggerrun",
+		"0 0 * * *",
+		gomock.Nil(),
+		gomock.Eq([]interface{}{CreateTriggerRequest{TriggerRun: scheduleWorkflowInput(triggerRun)}}),
+	).Return(nil)
+
+	status, handled, err := NewCronTrigger(zapr.NewLogger(zap.NewNop()), mockClient).Update(
+		context.Background(), triggerRun, v2pb.TRIGGER_RUN_ACTION_NO_ACTION)
+
+	require.NoError(t, err)
+	assert.False(t, handled)
+	assert.Equal(t, v2pb.TRIGGER_RUN_STATE_PAUSED, status.State)
+	assert.Equal(t, "0 0 * * *", status.ActualTrigger.GetCronSchedule().GetCron())
+	assert.Equal(t, desiredHash, status.ActualScheduleInputHash)
 }
 
 func TestCronTrigger_UpdateSyncsDriftOnResume(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Removed the paused-state early return from cron TriggerRun reconciliation. Cron and workflow-input drift now update the Temporal schedule while preserving the paused state. Replaced the deferral test with regression coverage for immediate paused synchronization.

**Why?**

A paused TriggerRun currently ignores schedule and input changes until it is resumed. Pausing should prevent workflow starts, but it should not prevent the stored schedule configuration from being updated.

**How did you test it?**

`tools/bazel test //go/components/triggerrun:go_default_test --test_output=errors`

**Potential risks**

Paused schedules with pending drift will now call the workflow provider during reconciliation. Provider errors remain visible through the existing TriggerRun error handling, and the TriggerRun remains paused after a successful update.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

Paused TriggerRuns now synchronize cron and workflow inputs without requiring a resume.

**Documentation Changes**

None. No public API or configuration syntax changed.