### PR TITLE
fix: create TriggerRun schedules paused

### DIFF
--- a/go/base/workflowclient/cadenceclient/cadenceclient.go
+++ b/go/base/workflowclient/cadenceclient/cadenceclient.go
@@ -306,9 +306,16 @@ func (c *CadenceClient) DeleteTrigger(ctx context.Context, workflowID string, ru
 	return c.Client.TerminateWorkflow(ctx, workflowID, runID, "trigger killed", nil)
 }
 
-// UpdateTrigger is a no-op for Cadence (schedule updates are a Temporal feature).
-// In Cadence, cron schedules are embedded in the workflow and cannot be updated in place.
-// Returns nil to indicate success - the operation is silently skipped.
-func (c *CadenceClient) UpdateTrigger(_ context.Context, _ string, _ string, _ *bool, _ []interface{}) error {
+// UpdateTrigger is a no-op for Cadence cron/args updates because cron schedules are embedded
+// in workflows. Pause/resume requests return an explicit unsupported-operation error so the
+// controller cannot incorrectly report that a Cadence trigger changed state.
+func (c *CadenceClient) UpdateTrigger(_ context.Context, workflowID string, _ string, paused *bool, _ []interface{}) error {
+	if paused != nil {
+		action := "PauseTrigger"
+		if !*paused {
+			action = "UnpauseTrigger"
+		}
+		return fmt.Errorf("%s not supported by Cadence provider (workflowID: %s)", action, workflowID)
+	}
 	return nil
 }

--- a/go/base/workflowclient/cadenceclient/cadenceclient.go
+++ b/go/base/workflowclient/cadenceclient/cadenceclient.go
@@ -44,6 +44,9 @@ type CadenceClient struct {
 var _ clientInterface.WorkflowClient = &CadenceClient{}
 
 func (c *CadenceClient) StartWorkflow(ctx context.Context, options clientInterface.StartWorkflowOptions, workflowName string, args ...interface{}) (*clientInterface.WorkflowExecution, error) {
+	if options.StartPaused {
+		return nil, fmt.Errorf("starting a paused workflow is not supported by Cadence")
+	}
 
 	cadenceOptions := cadenceClient.StartWorkflowOptions{
 		ID:                              options.ID,

--- a/go/base/workflowclient/cadenceclient/cadenceclient_test.go
+++ b/go/base/workflowclient/cadenceclient/cadenceclient_test.go
@@ -69,6 +69,17 @@ func TestStartWorkflow(t *testing.T) {
 	}
 }
 
+func TestStartWorkflowRejectsStartPaused(t *testing.T) {
+	client := &CadenceClient{Client: &cadencemocks.Client{}}
+	_, err := client.StartWorkflow(
+		context.Background(),
+		clientInterface.StartWorkflowOptions{StartPaused: true},
+		"testWorkflow",
+	)
+
+	assert.EqualError(t, err, "starting a paused workflow is not supported by Cadence")
+}
+
 func TestGetWorkflowExecutionInfo(t *testing.T) {
 	workflowID := "testWorkflowID"
 	runID := "testRunID"

--- a/go/base/workflowclient/cadenceclient/cadenceclient_test.go
+++ b/go/base/workflowclient/cadenceclient/cadenceclient_test.go
@@ -759,6 +759,20 @@ func TestUpdateTrigger(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestUpdateTriggerRejectsPauseForCadence(t *testing.T) {
+	client := &CadenceClient{Client: &cadencemocks.Client{}}
+
+	paused := true
+	err := client.UpdateTrigger(context.Background(), "testWorkflowID", "", &paused, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "PauseTrigger not supported")
+
+	paused = false
+	err = client.UpdateTrigger(context.Background(), "testWorkflowID", "", &paused, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "UnpauseTrigger not supported")
+}
+
 // Mock implementation of cadence history iterator
 type mockHistoryIterator struct {
 	events       []*shared.HistoryEvent

--- a/go/base/workflowclient/interface/workflowclient.go
+++ b/go/base/workflowclient/interface/workflowclient.go
@@ -11,6 +11,8 @@ type StartWorkflowOptions struct {
 	ExecutionStartToCloseTimeout    time.Duration
 	DecisionTaskStartToCloseTimeout time.Duration
 	CronSchedule                    string
+	// StartPaused creates a recurring schedule without allowing its first action to fire.
+	StartPaused bool
 }
 
 type WorkflowExecutionStatus int32

--- a/go/base/workflowclient/temporalclient/temporalclient.go
+++ b/go/base/workflowclient/temporalclient/temporalclient.go
@@ -103,6 +103,12 @@ func (c *TemporalClient) createScheduleForCron(ctx context.Context, options clie
 	if scheduleHandle != nil {
 		_, err := scheduleHandle.Describe(ctx)
 		if err == nil {
+			if options.StartPaused {
+				paused := true
+				if err := c.UpdateTrigger(ctx, options.ID, "", &paused, nil); err != nil {
+					return nil, fmt.Errorf("failed to pause existing Temporal schedule: %w", err)
+				}
+			}
 			// Schedule already exists, return success
 			return &clientInterface.WorkflowExecution{
 				ID:    scheduleID,
@@ -125,6 +131,10 @@ func (c *TemporalClient) createScheduleForCron(ctx context.Context, options clie
 		},
 		Overlap:        overlapPolicy, // Use extracted policy based on maxConcurrency
 		PauseOnFailure: false,
+		Paused:         options.StartPaused,
+	}
+	if options.StartPaused {
+		scheduleOptions.Note = "paused by michelangelo"
 	}
 
 	// Set workflow timeout if provided

--- a/go/base/workflowclient/temporalclient/temporalclient_test.go
+++ b/go/base/workflowclient/temporalclient/temporalclient_test.go
@@ -452,6 +452,28 @@ func TestCreateScheduleForCron(t *testing.T) {
 			errMsg:        "",
 		},
 		{
+			name: "success - schedule created paused",
+			options: clientInterface.StartWorkflowOptions{
+				ID:           "paused-workflow",
+				TaskList:     "test-task-list",
+				CronSchedule: "0 0 * * *",
+				StartPaused:  true,
+			},
+			workflowName: "test-workflow-name",
+			args:         []interface{}{"arg1"},
+			mockFunc: func(mockClient *temporalMocks.Client, mockScheduleClient *temporalMocks.ScheduleClient, mockScheduleHandle *temporalMocks.ScheduleHandle) {
+				mockClient.On("ScheduleClient").Return(mockScheduleClient)
+				mockScheduleClient.On("GetHandle", mock.Anything, "paused-workflow-schedule").Return(mockScheduleHandle)
+				mockScheduleHandle.On("Describe", mock.Anything).Return(nil, fmt.Errorf("schedule not found"))
+				mockScheduleClient.On("Create", mock.Anything, mock.MatchedBy(func(options temporalClient.ScheduleOptions) bool {
+					return options.Paused && options.Note == "paused by michelangelo"
+				})).Return(mockScheduleHandle, nil)
+			},
+			expectedID:    "paused-workflow-schedule",
+			expectedRunID: "",
+			errMsg:        "",
+		},
+		{
 			name: "success - schedule already exists",
 			options: clientInterface.StartWorkflowOptions{
 				ID:           "existing-workflow",
@@ -473,6 +495,35 @@ func TestCreateScheduleForCron(t *testing.T) {
 				// Create should not be called in this case
 			},
 			expectedID:    "existing-workflow-schedule",
+			expectedRunID: "",
+			errMsg:        "",
+		},
+		{
+			name: "success - existing schedule paused immediately",
+			options: clientInterface.StartWorkflowOptions{
+				ID:           "existing-paused-workflow",
+				TaskList:     "test-task-list",
+				CronSchedule: "0 0 * * *",
+				StartPaused:  true,
+			},
+			workflowName: "test-workflow-name",
+			args:         []interface{}{"arg1"},
+			mockFunc: func(mockClient *temporalMocks.Client, mockScheduleClient *temporalMocks.ScheduleClient, mockScheduleHandle *temporalMocks.ScheduleHandle) {
+				mockClient.On("ScheduleClient").Return(mockScheduleClient).Twice()
+				mockScheduleClient.On("GetHandle", mock.Anything, "existing-paused-workflow-schedule").Return(mockScheduleHandle).Twice()
+				mockScheduleHandle.On("Describe", mock.Anything).Return(&temporalClient.ScheduleDescription{}, nil)
+				mockScheduleHandle.On("Update", mock.Anything, mock.MatchedBy(func(options temporalClient.ScheduleUpdateOptions) bool {
+					state := &temporalClient.ScheduleState{}
+					update, err := options.DoUpdate(temporalClient.ScheduleUpdateInput{
+						Description: temporalClient.ScheduleDescription{
+							Schedule: temporalClient.Schedule{State: state},
+						},
+					})
+					require.NoError(t, err)
+					return update.Schedule.State.Paused
+				})).Return(nil)
+			},
+			expectedID:    "existing-paused-workflow-schedule",
 			expectedRunID: "",
 			errMsg:        "",
 		},

--- a/go/components/triggerrun/controller.go
+++ b/go/components/triggerrun/controller.go
@@ -247,6 +247,10 @@ StateMachine:
 			"state", status.State,
 			"execution_workflow_id", status.ExecutionWorkflowId)
 		triggerRun.Status = status
+		if triggerRun.Spec.Action == v2pb.TRIGGER_RUN_ACTION_PAUSE &&
+			status.State == v2pb.TRIGGER_RUN_STATE_PAUSED {
+			triggerRun.Spec.Action = v2pb.TRIGGER_RUN_ACTION_NO_ACTION
+		}
 	case v2pb.TRIGGER_RUN_STATE_RUNNING:
 		log.Info("TRIGGER_RUN_STATE_RUNNING")
 

--- a/go/components/triggerrun/controller_test.go
+++ b/go/components/triggerrun/controller_test.go
@@ -153,6 +153,25 @@ func TestReconcile(t *testing.T) {
 			expectRequeue:  true,
 		},
 		{
+			name:    "first time pause is consumed during creation",
+			request: ctrl.Request{NamespacedName: types.NamespacedName{Namespace: _namespace, Name: _triggerRun.Name}},
+			initialObject: func() v2pb.TriggerRun {
+				tr := _triggerRun.DeepCopy()
+				tr.Spec.Action = v2pb.TRIGGER_RUN_ACTION_PAUSE
+				return *tr
+			}(),
+			initialStatus: v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_INVALID},
+			cronRunnerProvider: func() Runner {
+				mockRunner := &MockRunner{}
+				mockRunner.On("Run", mock.Anything, mock.Anything).
+					Return(v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_PAUSED}, nil)
+				return mockRunner
+			},
+			expectedStatus: v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_PAUSED},
+			expectedAction: v2pb.TRIGGER_RUN_ACTION_NO_ACTION,
+			expectRequeue:  true,
+		},
+		{
 			name:    "kill trigger after initial creation",
 			request: ctrl.Request{NamespacedName: types.NamespacedName{Namespace: _namespace, Name: _triggerRun.Name}},
 			initialObject: func() v2pb.TriggerRun {

--- a/go/components/triggerrun/cron_trigger.go
+++ b/go/components/triggerrun/cron_trigger.go
@@ -53,8 +53,8 @@ func NewCronTrigger(log logr.Logger, workflowClient clientInterface.WorkflowClie
 //   - DecisionTaskStartToCloseTimeout: 30 seconds
 //   - CronSchedule: From TriggerRun spec
 //
-// Returns State=RUNNING if workflow starts successfully or is already running,
-// State=FAILED if workflow start fails.
+// Returns State=RUNNING when an active schedule starts successfully, State=PAUSED when
+// a PAUSE action is applied during creation, or State=FAILED if workflow start fails.
 func (r *cronTrigger) Run(ctx context.Context, triggerRun *v2pb.TriggerRun) (v2pb.TriggerRunStatus, error) {
 	log := r.Log.WithValues("triggerRun", k8stypes.NamespacedName{
 		Namespace: triggerRun.Namespace,
@@ -67,6 +67,7 @@ func (r *cronTrigger) Run(ctx context.Context, triggerRun *v2pb.TriggerRun) (v2p
 		ExecutionStartToCloseTimeout:    time.Hour * 24 * 365, // 1 year, practically no timeout
 		DecisionTaskStartToCloseTimeout: 30 * time.Second,
 		CronSchedule:                    triggerRun.Spec.Trigger.GetCronSchedule().GetCron(),
+		StartPaused:                     triggerRun.Spec.Action == v2pb.TRIGGER_RUN_ACTION_PAUSE,
 	}
 	domain := r.WorkflowClient.GetDomain()
 	rid, err := getWorkflowOpenRunID(ctx, wid, r.WorkflowClient, domain)
@@ -89,10 +90,21 @@ func (r *cronTrigger) Run(ctx context.Context, triggerRun *v2pb.TriggerRun) (v2p
 		// its schedule action contains the current TriggerRun input. Leave the
 		// Actual* fields empty so Update verifies and refreshes them on the next
 		// reconciliation.
-		return v2pb.TriggerRunStatus{
+		status := v2pb.TriggerRunStatus{
 			State:  v2pb.TRIGGER_RUN_STATE_RUNNING,
 			LogUrl: getWorkflowURL(wid, r.WorkflowClient.GetProvider()),
-		}, nil
+		}
+		if opt.StartPaused {
+			paused := true
+			if updateErr := r.WorkflowClient.UpdateTrigger(ctx, wid, "", &paused, nil); updateErr != nil {
+				status.State = v2pb.TRIGGER_RUN_STATE_FAILED
+				status.ErrorMessage = updateErr.Error()
+				return status, fmt.Errorf("pause existing trigger %s/%s: %w",
+					triggerRun.Namespace, triggerRun.Name, updateErr)
+			}
+			status.State = v2pb.TRIGGER_RUN_STATE_PAUSED
+		}
+		return status, nil
 	}
 	inputHash, err := scheduleInputHash(triggerRun)
 	if err != nil {
@@ -122,13 +134,18 @@ func (r *cronTrigger) Run(ctx context.Context, triggerRun *v2pb.TriggerRun) (v2p
 			}, fmt.Errorf("start workflow for trigger %s/%s: %w",
 				triggerRun.Namespace, triggerRun.Name, err)
 	}
-	r.Log.Info("scheduled workflow enabled",
+	r.Log.Info("scheduled workflow created",
 		"operation", "workflow_started",
 		"namespace", triggerRun.Namespace,
 		"name", triggerRun.Name,
+		"paused", opt.StartPaused,
 		"execution_id", exec.ID,
 		"run_id", exec.RunID)
-	return recurringTriggerStatus(triggerRun, wid, opt.CronSchedule, inputHash, r.WorkflowClient.GetProvider()), nil
+	status := recurringTriggerStatus(triggerRun, wid, opt.CronSchedule, inputHash, r.WorkflowClient.GetProvider())
+	if opt.StartPaused {
+		status.State = v2pb.TRIGGER_RUN_STATE_PAUSED
+	}
+	return status, nil
 }
 
 func recurringTriggerStatus(

--- a/go/components/triggerrun/cron_trigger_test.go
+++ b/go/components/triggerrun/cron_trigger_test.go
@@ -143,6 +143,61 @@ func TestRun(t *testing.T) {
 	}
 }
 
+func TestRunStartsSchedulePaused(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockClient := interfaceMock.NewMockWorkflowClient(ctrl)
+	mockClient.EXPECT().GetDomain().Return("test-domain")
+	mockClient.EXPECT().GetProvider().Return("test-provider").AnyTimes()
+	mockClient.EXPECT().ListOpenWorkflow(gomock.Any(), gomock.Any()).Return(
+		&clientInterface.ListOpenWorkflowExecutionsResponse{}, nil)
+	mockClient.EXPECT().StartWorkflow(
+		gomock.Any(),
+		gomock.Any(),
+		"trigger.CronTrigger",
+		gomock.Any(),
+	).DoAndReturn(func(
+		_ context.Context,
+		options clientInterface.StartWorkflowOptions,
+		_ string,
+		_ ...interface{},
+	) (*clientInterface.WorkflowExecution, error) {
+		require.True(t, options.StartPaused)
+		return &clientInterface.WorkflowExecution{ID: _workflowID, RunID: _runID}, nil
+	})
+
+	triggerRun := _triggerRun.DeepCopy()
+	triggerRun.Spec.Action = v2pb.TRIGGER_RUN_ACTION_PAUSE
+	status, err := setupCronTrigger(t, mockClient).Run(context.Background(), triggerRun)
+
+	require.NoError(t, err)
+	assert.Equal(t, v2pb.TRIGGER_RUN_STATE_PAUSED, status.State)
+	assert.Equal(t, mustScheduleInputHash(t, triggerRun), status.ActualScheduleInputHash)
+}
+
+func TestRunPausesExistingScheduleImmediately(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockClient := interfaceMock.NewMockWorkflowClient(ctrl)
+	mockClient.EXPECT().GetDomain().Return("test-domain")
+	mockClient.EXPECT().GetProvider().Return("test-provider")
+	mockClient.EXPECT().ListOpenWorkflow(gomock.Any(), gomock.Any()).Return(
+		&clientInterface.ListOpenWorkflowExecutionsResponse{
+			Executions: []clientInterface.WorkflowExecutionInfo{
+				{Execution: &clientInterface.WorkflowExecution{RunID: _runID}},
+			},
+		}, nil)
+	paused := true
+	mockClient.EXPECT().UpdateTrigger(
+		gomock.Any(), generateWorkflowID(&_triggerRun), "", gomock.Eq(&paused), gomock.Nil()).Return(nil)
+
+	triggerRun := _triggerRun.DeepCopy()
+	triggerRun.Spec.Action = v2pb.TRIGGER_RUN_ACTION_PAUSE
+	status, err := setupCronTrigger(t, mockClient).Run(context.Background(), triggerRun)
+
+	require.NoError(t, err)
+	assert.Equal(t, v2pb.TRIGGER_RUN_STATE_PAUSED, status.State)
+	assert.Empty(t, status.ActualScheduleInputHash)
+}
+
 func TestRunExistingWorkflowLeavesInputForReconciliation(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockClient := interfaceMock.NewMockWorkflowClient(ctrl)


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

- Added a start-paused workflow option and use it when a TriggerRun is created with `spec.action: PAUSE`.
- Create new Temporal schedules paused and pause existing Temporal schedules immediately.
- Consume the initial PAUSE action during the first reconciliation and reject unsupported paused creation on Cadence.

**Why?**

A TriggerRun created with a PAUSE action could briefly create an active schedule because the action was not applied until a later reconciliation. Creating the schedule paused prevents an execution from starting during that window.

**How did you test it?**

- `tools/bazel test //go/components/triggerrun:go_default_test //go/base/workflowclient/temporalclient:go_default_test //go/base/workflowclient/cadenceclient:go_default_test --test_output=errors`

**Potential risks**

The change affects initial Temporal schedule state and the existing-schedule path. Regression tests cover both paths, controller action consumption, and the Cadence rejection behavior.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

TriggerRuns created with `spec.action: PAUSE` now create Temporal schedules in the paused state immediately.

**Documentation Changes**

None. This is a backward-compatible behavior fix.