### PR TITLE
feat: Let EntityTable own phase pipeline-type filtering

### DIFF
--- a/javascript/packages/core/components/views/phase-entity-view/entity-table.tsx
+++ b/javascript/packages/core/components/views/phase-entity-view/entity-table.tsx
@@ -4,6 +4,7 @@ import { adaptTableConfigToTableProps } from '#core/components/views/utils/table
 import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
 import { useStudioQuery } from '#core/hooks/use-studio-query';
 import { capitalizeFirstLetter } from '#core/utils/string-utils';
+import { injectListOptions } from './utils/inject-list-options';
 
 import type { EntityTableProps } from './types';
 
@@ -24,13 +25,16 @@ export function EntityTable<T extends object = object>({
   service,
   tableConfig,
   tableSettingsId,
+  pipelineTypes,
 }: EntityTableProps<T>) {
   const { projectId } = useStudioParams('base');
+  const listOptions = injectListOptions(service, pipelineTypes);
 
   const { data, isLoading, error } = useStudioQuery<Record<`${string}List`, { items: T[] }>>({
     queryName: `List${capitalizeFirstLetter(service)}`,
     serviceOptions: {
       namespace: projectId,
+      ...(listOptions && { listOptions }),
     },
   });
 

--- a/javascript/packages/core/components/views/phase-entity-view/phase-entity-view.tsx
+++ b/javascript/packages/core/components/views/phase-entity-view/phase-entity-view.tsx
@@ -96,6 +96,7 @@ export function PhaseEntityView<T extends object = object>({
                   actions: entity.actions,
                 }}
                 tableSettingsId={`${phaseConfig.id}/${entity.id}`}
+                pipelineTypes={phaseConfig.pipelineTypes}
               />
             )}
           </Tab>

--- a/javascript/packages/core/components/views/phase-entity-view/types.ts
+++ b/javascript/packages/core/components/views/phase-entity-view/types.ts
@@ -17,10 +17,17 @@ export interface PhaseEntityViewProps<T extends object = object> {
   entities: ListableEntity<T>[];
 }
 
+export interface InjectedListOptions {
+  fieldSelector?: string;
+  labelSelector?: string;
+}
+
 export interface EntityTableProps<T extends object = object> {
   /** Service name for data fetching (e.g., 'pipeline' → 'ListPipeline') */
   service: QueryConfig['service'];
   tableConfig: TableConfig<T>;
   /** Unique ID for table state persistence */
   tableSettingsId: string;
+  /** Pipeline types the owning phase restricts this entity's data to, if any */
+  pipelineTypes?: string[];
 }

--- a/javascript/packages/core/components/views/phase-entity-view/utils/inject-list-options.ts
+++ b/javascript/packages/core/components/views/phase-entity-view/utils/inject-list-options.ts
@@ -3,9 +3,13 @@ import type { InjectedListOptions } from '../types';
 
 /**
  * Derives the RPC-level listOptions needed to restrict an entity's list query to a
- * phase's pipeline types, branching per entity service the way studio-web's list view
- * does (pipelines filter by field, everything downstream of a pipeline run filters by
- * label). Returns undefined when there's nothing to inject.
+ * phase's pipeline types. Only `pipeline` is handled today: studio-web's equivalent
+ * also filters pipelineRun/triggerRun by a `michelangelo/SourcePipelineType` label, but
+ * the OSS apiserver never stamps that label onto PipelineRun/TriggerRun rows (it's only
+ * read for notification formatting — see go/base/notification/types/types.go), so
+ * applying it here would silently return zero rows. Leave runs/triggers unfiltered
+ * until a backend change adds that label. Returns undefined when there's nothing to
+ * inject.
  */
 export function injectListOptions(
   service: QueryConfig['service'],
@@ -19,12 +23,6 @@ export function injectListOptions(
       // as a literal MySQL column (indexPathToKeyMaps is nil), so it must be the raw
       // `pipeline_type` column, not the proto path `spec.type`.
       fieldSelector: `pipeline_type in (${pipelineTypes.join(',')})`,
-    };
-  }
-
-  if (service === 'pipelineRun' || service === 'triggerRun') {
-    return {
-      labelSelector: `michelangelo/SourcePipelineType in (${pipelineTypes.join(',')})`,
     };
   }
 

--- a/javascript/packages/core/components/views/phase-entity-view/utils/inject-list-options.ts
+++ b/javascript/packages/core/components/views/phase-entity-view/utils/inject-list-options.ts
@@ -1,0 +1,32 @@
+import type { QueryConfig } from '#core/types/query-types';
+import type { InjectedListOptions } from '../types';
+
+/**
+ * Derives the RPC-level listOptions needed to restrict an entity's list query to a
+ * phase's pipeline types, branching per entity service the way studio-web's list view
+ * does (pipelines filter by field, everything downstream of a pipeline run filters by
+ * label). Returns undefined when there's nothing to inject.
+ */
+export function injectListOptions(
+  service: QueryConfig['service'],
+  pipelineTypes?: string[]
+): InjectedListOptions | undefined {
+  if (!pipelineTypes?.length) return undefined;
+
+  if (service === 'pipeline') {
+    return {
+      // Permissive-mode passthrough: apiserver's field selector parser treats this key
+      // as a literal MySQL column (indexPathToKeyMaps is nil), so it must be the raw
+      // `pipeline_type` column, not the proto path `spec.type`.
+      fieldSelector: `pipeline_type in (${pipelineTypes.join(',')})`,
+    };
+  }
+
+  if (service === 'pipelineRun' || service === 'triggerRun') {
+    return {
+      labelSelector: `michelangelo/SourcePipelineType in (${pipelineTypes.join(',')})`,
+    };
+  }
+
+  return undefined;
+}

--- a/javascript/packages/core/components/views/phase-entity-view/utils/inject-list-options.ts
+++ b/javascript/packages/core/components/views/phase-entity-view/utils/inject-list-options.ts
@@ -3,13 +3,7 @@ import type { InjectedListOptions } from '../types';
 
 /**
  * Derives the RPC-level listOptions needed to restrict an entity's list query to a
- * phase's pipeline types. Only `pipeline` is handled today: studio-web's equivalent
- * also filters pipelineRun/triggerRun by a `michelangelo/SourcePipelineType` label, but
- * the OSS apiserver never stamps that label onto PipelineRun/TriggerRun rows (it's only
- * read for notification formatting — see go/base/notification/types/types.go), so
- * applying it here would silently return zero rows. Leave runs/triggers unfiltered
- * until a backend change adds that label. Returns undefined when there's nothing to
- * inject.
+ * phase's pipeline types.
  */
 export function injectListOptions(
   service: QueryConfig['service'],
@@ -19,9 +13,6 @@ export function injectListOptions(
 
   if (service === 'pipeline') {
     return {
-      // Permissive-mode passthrough: apiserver's field selector parser treats this key
-      // as a literal MySQL column (indexPathToKeyMaps is nil), so it must be the raw
-      // `pipeline_type` column, not the proto path `spec.type`.
       fieldSelector: `pipeline_type in (${pipelineTypes.join(',')})`,
     };
   }

--- a/javascript/packages/core/config/phases/data.ts
+++ b/javascript/packages/core/config/phases/data.ts
@@ -10,6 +10,7 @@ export const DATA_PHASE: PhaseConfig = {
   description: 'Create data pipelines and analyze your datasets',
   docUrl: 'https://michelangelo-ai.org/docs/user-guides/getting-started/prepare-your-data',
   state: 'disabled' as const,
+  pipelineTypes: ['PIPELINE_TYPE_DATA_PREP', 'PIPELINE_TYPE_BASIS_FEATURE'],
   entities: [
     { ...PIPELINE_ENTITY_CONFIG, state: 'disabled' },
     { ...RUN_ENTITY_CONFIG, state: 'disabled' },

--- a/javascript/packages/core/config/phases/deploy.ts
+++ b/javascript/packages/core/config/phases/deploy.ts
@@ -9,5 +9,6 @@ export const DEPLOY_PHASE: PhaseConfig = {
   name: 'Deploy & Predict',
   description: 'Deploy your models and predict new data',
   state: 'comingSoon' as const,
+  pipelineTypes: ['PIPELINE_TYPE_PREDICTION', 'PIPELINE_TYPE_SCORER'],
   entities: [TARGET_ENTITY_CONFIG, DEPLOYMENT_ENTITY_CONFIG],
 };

--- a/javascript/packages/core/config/phases/monitor-debug.ts
+++ b/javascript/packages/core/config/phases/monitor-debug.ts
@@ -6,5 +6,11 @@ export const MONITOR_DEBUG_PHASE: PhaseConfig = {
   name: 'Monitor & Debug',
   description: 'Monitor model performance and debug issues in production',
   state: 'comingSoon' as const,
+  pipelineTypes: [
+    'PIPELINE_TYPE_PERF_EVAL',
+    'PIPELINE_TYPE_PERFORMANCE_MONITORING',
+    'PIPELINE_TYPE_ONLINE_OFFLINE_FEATURE_CONSISTENCY',
+    'PIPELINE_TYPE_ONLINE_OFFLINE_FEATURE_CONSISTENCY_ORCHESTRATION',
+  ],
   entities: [],
 };

--- a/javascript/packages/core/config/phases/retrain.ts
+++ b/javascript/packages/core/config/phases/retrain.ts
@@ -10,5 +10,11 @@ export const RETRAIN_PHASE: PhaseConfig = {
   name: 'Experiment & Productionize',
   description: 'Experiment with pipelines and productionize your machine learning workflows',
   state: 'active' as const,
+  pipelineTypes: [
+    'PIPELINE_TYPE_RETRAIN',
+    'PIPELINE_TYPE_EXPERIMENT',
+    'PIPELINE_TYPE_POST_PROCESSING',
+    'PIPELINE_TYPE_OPTIMIZATION',
+  ],
   entities: [PIPELINE_ENTITY_CONFIG, RUN_ENTITY_CONFIG, TRIGGER_ENTITY_CONFIG],
 };

--- a/javascript/packages/core/config/phases/train.ts
+++ b/javascript/packages/core/config/phases/train.ts
@@ -13,7 +13,7 @@ export const TRAIN_PHASE: PhaseConfig = {
   docUrl:
     'https://michelangelo-ai.org/docs/user-guides/train-and-deploy-models/train-and-register-a-model',
   state: 'active' as const,
-  pipelineTypes: ['PIPELINE_TYPE_TRAIN'],
+  pipelineTypes: ['PIPELINE_TYPE_TRAIN', 'PIPELINE_TYPE_EVAL'],
   entities: [
     PIPELINE_ENTITY_CONFIG,
     RUN_ENTITY_CONFIG,

--- a/javascript/packages/core/config/phases/train.ts
+++ b/javascript/packages/core/config/phases/train.ts
@@ -13,6 +13,7 @@ export const TRAIN_PHASE: PhaseConfig = {
   docUrl:
     'https://michelangelo-ai.org/docs/user-guides/train-and-deploy-models/train-and-register-a-model',
   state: 'active' as const,
+  pipelineTypes: ['PIPELINE_TYPE_TRAIN'],
   entities: [
     PIPELINE_ENTITY_CONFIG,
     RUN_ENTITY_CONFIG,

--- a/javascript/packages/core/types/common/studio-types.ts
+++ b/javascript/packages/core/types/common/studio-types.ts
@@ -134,6 +134,12 @@ export interface PhaseConfig {
   state: PhaseState;
   /** List of entities (like pipelines, models) that belong to this phase */
   entities: PhaseEntityConfig[];
+  /**
+   * Restricts this phase's pipeline-derived entities (pipelines, runs, triggers) to
+   * these pipeline type values (e.g. `['PIPELINE_TYPE_TRAIN', 'PIPELINE_TYPE_EVAL']`).
+   * Omit to show all pipeline types.
+   */
+  pipelineTypes?: string[];
 }
 
 /**


### PR DESCRIPTION
## Summary
EntityTable now derives its own RPC listOptions from a semantic
pipelineTypes prop via a new injectListOptions utility.

Filtering is scoped to the pipeline service only for now. A
label-based filter for pipelineRun/triggerRun was implemented and
then removed after verifying against a live sandbox: the OSS
apiserver never stamps a SourcePipelineType-style label onto those
objects, so that branch would have silently returned zero rows
instead of filtering anything.

The pipeline filter uses the raw pipeline_type MySQL column name
rather than the spec.type proto path, since the apiserver's
field-selector validation (indexPathToKeyMaps) is wired to nil in
this OSS deployment, so it runs in permissive passthrough mode where
the selector key must be a literal column name.

## Test plan
**Train & Evaluate** filters for train/eval pipelines
<img width="1601" height="1072" alt="Screenshot 2026-08-17 at 3 39 01 PM" src="https://github.com/user-attachments/assets/845b6ea7-e372-47a8-b0db-50bf20700275" />

**Experiment & Productionize** filters for retrain pipelines
<img width="1601" height="1072" alt="Screenshot 2026-08-17 at 3 39 09 PM" src="https://github.com/user-attachments/assets/2ff25a74-54e1-469c-b64e-ac8086de4475" />
