### PR TITLE
fix(python): stop shipping test files in wheels and sdists

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,12 @@ version = "0.8.0"
 description = "Michelangelo AI is an end-to-end model lifecycle management system at large scale"
 authors = ["Michelangelo AI Team <michelangelo-oss-group@uber.com>"]
 readme = "README.md"
-exclude = ["michelangelo/example", "michelangelo/tests", "michelangelo/tools"]    # TODO: temporary exclude all codes in package building
+exclude = [
+    "michelangelo/**/tests",
+    "michelangelo/**/*_test.py",
+    "michelangelo/**/test_*.py",
+    "michelangelo/**/conftest.py",
+]
 packages = [
     { include = "michelangelo" },
 ]


### PR DESCRIPTION
## Summary

The `exclude` list in `python/pyproject.toml` points at `michelangelo/example`, `michelangelo/tests` and `michelangelo/tools` - none of which exist in the tree. The actual test files live in nested `tests/` directories (e.g. `michelangelo/api/v2/tests/`) and as `*_test.py` modules next to the code they test, so the excludes have been dead and every published wheel and sdist ships all of them: 256 test files out of the wheel's 754 (about 1.7 MB of the 4.3 MB uncompressed).

This replaces the dead entries with glob patterns matching the real layout:

```toml
exclude = [
    "michelangelo/**/tests",
    "michelangelo/**/*_test.py",
    "michelangelo/**/test_*.py",
    "michelangelo/**/conftest.py",
]
```

## Testing

- Built the wheel and sdist before and after with `poetry build` (Poetry 2.2.1, same as the lock header).
- Before: 256 files matching `tests/`, `*_test.py`, `test_*.py` or `conftest.py` in both artifacts. After: 0 in both.
- Diffed the full file listings: exactly those 256 files are removed, no non-test file is removed, and nothing new is added. Wheel goes from 754 to 498 files.
- Grepped the shipped package for any import of the excluded test paths (`from michelangelo...tests`, `tests.fixtures`): none, so nothing at runtime references what is now excluded.

## Notes

- Scope is deliberately just the packaging metadata - no test file moves, no code changes.
- The old line carried a `# TODO: temporary exclude all codes in package building` comment; this removes the TODO since the excludes now do what it intended.