### PR TITLE
docs: correct batch endpoint, feature store, and traffic splitting claims

### DIFF
--- a/docs/getting-started/faq.md
+++ b/docs/getting-started/faq.md
@@ -53,7 +53,7 @@ A: Multiple sources:
 
 **Q: Can I use feature stores with Michelangelo AI?**
 
-A: Yes, Michelangelo AI integrates with feature stores or you can manage features within the platform using the data prep pipelines and inference.
+A: Not yet. A feature store (online and offline) is on the [roadmap](./roadmap.md). Today you prepare features with the data prep pipelines and reference existing datasets in the data catalog.
 
 **Q: What data formats are supported?**
 

--- a/docs/getting-started/glossary.md
+++ b/docs/getting-started/glossary.md
@@ -43,14 +43,14 @@ A pool of hardware resources (CPU, GPU, memory) registered with the Michelangelo
 A cross-backend dataset reference that allows tasks on different compute backends (Spark and Ray) to pass datasets to each other. A Spark task wraps its output in a `DatasetVariable` and saves it; a Ray task receives the reference and loads it in its own format.
 
 ### Deployment
-A running instance of a model revision, loaded into a target inference environment. A deployment provides a human-readable name for accessing a specific model version and supports traffic splitting and canary rollout.
+A running instance of a model revision, loaded into a target inference environment. A deployment provides a human-readable name for accessing a specific model version and is rolled out with a rolling strategy; additional rollout strategies are on the roadmap.
 
 ---
 
 ## E
 
 ### Endpoint
-The routing layer that directs prediction requests to one or more deployments. Endpoints support traffic splitting across model revisions (e.g., for A/B testing) and are the entry point for online inference.
+The routing layer that directs prediction requests to one or more deployments. Endpoints route requests by inference server and deployment name and are the entry point for online inference; traffic splitting across model revisions (e.g., for A/B testing) is on the roadmap.
 
 ### Evaluation Report
 A structured collection of model metrics produced after a training or evaluation run. Common report types include model performance, feature importance, and data quality reports.

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -58,7 +58,7 @@ If you're coming from other ML platforms, here's how familiar concepts map to Mi
 | **Model Training** | Custom scripts, Kubeflow Pipelines | **MA Studio Training** (UI) or **CanvasFlex/Uniflow workflows** (code) |
 | **Hyperparameter Tuning** | Optuna, Ray Tune | **Uniflow tasks** with hand-written sweeps * |
 | **Model Storage** | S3 buckets, model registries | **Michelangelo AI Model Registry** with metadata & plugin storage |
-| **Batch Inference** | Airflow + custom scripts | **Deployment to batch endpoint** with offline inference pipeline and Ray / Triton Inference * |
+| **Batch Inference** | Airflow + custom scripts | **Uniflow tasks** with Ray for offline inference * |
 | **Online Serving** | TorchServe, TensorFlow Serving | **Deployment to inference server** with Triton Inference Server * |
 | **Monitoring** | Prometheus + Grafana | **Model Excellence Scores** + built-in monitoring * |
 | **Pipeline Orchestration** | Airflow, Prefect, Temporal | **Uniflow workflows** with Cadence/Temporal backend * |


### PR DESCRIPTION
## Summary

Follow-up in the same spirit as #1788 (Ray Tune / autoscaling corrections): three more places where the getting-started docs describe capabilities that are on the roadmap but not in the code yet.

1. **overview.md** - the ML workflow mapping table says Batch Inference maps to "Deployment to batch endpoint". There is no batch endpoint resource anywhere in `proto/` or `go/` (grep for it is empty), and the roadmap doesn't list one either. Offline inference today is a hand-written Uniflow task using Ray - that's what `python/examples/llm_prediction/` does. The row now says **Uniflow tasks with Ray for offline inference**.

2. **faq.md** - "Yes, Michelangelo AI integrates with feature stores" contradicts the roadmap, which lists the entire Feature Store section (online + offline store, drift monitors, lineage) under Planned. No feature-store integration exists in code; the only trace is a forward-looking `feature_store_features` schema field in `model.proto` that references a `Feature` resource type that doesn't exist. The answer now says **not yet, it's on the roadmap**, and describes what you can do today (data prep pipelines, data catalog).

3. **glossary.md** - the Deployment entry claims "traffic splitting and canary rollout" and the Endpoint entry claims "traffic splitting across model revisions (e.g., for A/B testing)". In code, `strategies/strategy.go` has exactly one strategy case (rolling), and `TrafficRoutingActor` adds a path-based route per deployment (`/cluster/{inferenceServer}/{deployment}`) - there is no weighted split or canary anywhere. The roadmap itself lists "Endpoint traffic splitting and shadow routing" and "Deployment rollout strategies (Blast, Zonal, Shadow/A-B)" as Planned. Both entries now describe rolling rollout / name-based routing and defer splitting to the roadmap.

## Why it matters

Same rationale as #1788: users evaluating a migration (from SageMaker/Vertex especially, where batch transform and canary endpoints are table stakes) will make decisions off these three sentences. The roadmap already tells the honest story; this aligns the other docs with it.

## Testing

- 3 files, +4/-4 lines, prose only - no code changes.
- Verified each claim against code at current main before rewording: no batch endpoint type in proto/go, no feature-store implementation, single rolling strategy case, path-based (not weighted) traffic routing.
- Relative link style (`./roadmap.md`) matches the existing links in faq.md.