### PR TITLE
ci: upload coverage reports to Codecov

### DIFF
--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -102,6 +102,14 @@ jobs:
             echo "total: (statements) 0%" > coverage.txt
           fi
 
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: coverage.dat
+          flags: go
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+
       - name: "Check coverage threshold (baseline: 60%)"
         run: |
           BASELINE=60

--- a/.github/workflows/javascript-coverage.yml
+++ b/.github/workflows/javascript-coverage.yml
@@ -53,6 +53,14 @@ jobs:
           # Run tests with vitest coverage
           yarn test:coverage
 
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: javascript/coverage/clover.xml
+          flags: javascript
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+
       - name: Extract coverage percentage
         id: coverage
         working-directory: ./javascript

--- a/.github/workflows/python-coverage.yml
+++ b/.github/workflows/python-coverage.yml
@@ -79,6 +79,14 @@ jobs:
             --junitxml=junit.xml \
             -v
 
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: python/coverage.xml
+          flags: python
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+
       # Generate coverage badge
       - name: Generate coverage badge
         run: |


### PR DESCRIPTION
## What this does

The repo already has the receiving side of Codecov set up -- `.github/codecov.yml` defines `go`/`python`/`javascript` flags, per-component tracking, and the 90%-patch/auto-project targets, and the README carries the badge -- but none of the three coverage workflows actually upload a report, so the badge and the configured checks have nothing to work with.

This wires the missing upload step into each workflow, reusing the flag names codecov.yml already defines:

| Workflow | Report | Flag |
|---|---|---|
| Go Coverage | `coverage.dat` (Bazel combined lcov, externals filtered) | `go` |
| Python Coverage Check | `python/coverage.xml` (pytest `--cov-report=xml`) | `python` |
| JavaScript Coverage | `javascript/coverage/clover.xml` (vitest default clover reporter) | `javascript` |

Design choices:

- **Fail-open**: `fail_ci_if_error: false`, so a Codecov outage or missing token can't break CI. The existing threshold checks stay the enforcement mechanism; Codecov adds the trend/patch view on top.
- Uploads read `secrets.CODECOV_TOKEN`. A maintainer needs to add that repo secret (from the Codecov project settings) for uploads to be accepted -- until then the step no-ops gracefully.
- Action pinned by commit SHA (`codecov-action` v7.0.0), matching how the other third-party actions in these workflows are pinned.

## Test plan

- All three workflow files parse as valid YAML; upload steps verified to reference exactly the report paths the existing steps produce (`coverage.dat` is created at repo root by the process step; pytest runs with `working-directory: ./python`; vitest's default reporters include clover).
- Behavior with no token: the action logs a warning and exits 0 (fail_ci_if_error false), leaving all existing checks unchanged.