### PR TITLE
ci: add OpenSSF Scorecard workflow and badge

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,48 @@
+name: OpenSSF Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '23 3 * * 6'
+  push:
+    branches:
+      - main
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to the code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish results to OpenSSF REST API for the badge and the
+          # scorecard.dev viewer.
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![License](https://img.shields.io/github/license/michelangelo-ai/michelangelo)](http://www.apache.org/licenses/LICENSE-2.0)
 [![codecov](https://codecov.io/gh/michelangelo-ai/michelangelo/graph/badge.svg?token=HKJDT0I6CW)](https://codecov.io/gh/michelangelo-ai/michelangelo)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11481/badge)](https://www.bestpractices.dev/projects/11481)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/michelangelo-ai/michelangelo/badge)](https://scorecard.dev/viewer/?uri=github.com/michelangelo-ai/michelangelo)
 [![Docs](https://img.shields.io/badge/docs-michelangelo--ai.org-blue)](https://michelangelo-ai.org)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/michelangelo-ai/michelangelo)
 


### PR DESCRIPTION
## What this does

Adds the standard [OpenSSF Scorecard](https://github.com/ossf/scorecard) workflow: weekly + on pushes to main, publishing results to the OpenSSF API (which enables the badge and the scorecard.dev viewer) and uploading the SARIF to GitHub code scanning so findings show up under the Security tab.

The README already carries an OpenSSF Best Practices badge; this adds the Scorecard badge next to it. The two are complementary -- Best Practices is a self-attested questionnaire, Scorecard is automated supply-chain checks (token permissions, pinned dependencies, branch protection, etc.).

Setup follows the scorecard-action README's recommended hardening: `permissions: read-all` at the top with per-job elevation only for the SARIF upload (`security-events: write`) and OIDC publishing (`id-token: write`), checkout with `persist-credentials: false`, and the action pinned by commit SHA.

No maintainer setup is required -- `publish_results` uses OIDC, not a secret. The badge will populate after the first run on main.

## Test plan

- Workflow parses as valid YAML; permissions, pinning, and `publish_results: true` asserted programmatically.
- Badge URL follows the api.scorecard.dev format used by scorecard's own docs; it renders as "no data" until the first publish, then populates.