### PR TITLE
test: reproduce transcoder-services-check drift (throwaway, will close)

### DIFF
--- a/javascript/packages/rpc/services.ts
+++ b/javascript/packages/rpc/services.ts
@@ -2,6 +2,7 @@ import { create, createRegistry, fromJson, toJson } from '@bufbuild/protobuf';
 
 import { createFetchTransport } from './create-fetch-transport';
 import { TypedStructSchema } from './gen/michelangelo/api/typed_struct_pb';
+import { ClusterService } from './gen/michelangelo/api/v2/cluster_svc_pb';
 import { DeploymentService } from './gen/michelangelo/api/v2/deployment_svc_pb';
 import { InferenceServerService } from './gen/michelangelo/api/v2/inference_server_svc_pb';
 import { ModelService } from './gen/michelangelo/api/v2/model_svc_pb';


### PR DESCRIPTION
Throwaway PR to verify `transcoder-services-check.yaml` fails when `services.ts` drifts from `helm/michelangelo/files/transcoder-services.json`. Not for review; will be closed after CI confirms the check fails.