### PR TITLE
test: reproduce descriptor-freshness drift (throwaway, will close)

### DIFF
--- a/proto/api/v2/cluster.proto
+++ b/proto/api/v2/cluster.proto
@@ -65,6 +65,9 @@ message ClusterSpec {
 
   // DC type of the cluster
   DCType dc = 7;
+
+  // Description of the cluster
+  string description = 8;
 }
 
 // ClusterStatus will have workload


### PR DESCRIPTION
Throwaway PR to verify main.yml's `dirty-check` job fails when `proto/api/v2/cluster.proto` drifts from `helm/michelangelo/files/descriptors.pb`. Not for review; will be closed after CI confirms the check fails.