### PR TITLE
feat(ui): Add color for phase card

### DIFF
--- a/javascript/packages/core/components/views/project/components/phase-card.tsx
+++ b/javascript/packages/core/components/views/project/components/phase-card.tsx
@@ -23,7 +23,7 @@ export function PhaseCard(props: PhaseConfig & { projectId: string }) {
     <Box
       overrides={{
         BoxContainer: {
-          style: { backgroundColor: theme.colors.backgroundLightAccent, minHeight: '220px' },
+          style: { backgroundColor: theme.colors.backgroundAccentLight, minHeight: '220px' },
         },
       }}
       title={

--- a/javascript/packages/core/components/views/project/components/phase-card.tsx
+++ b/javascript/packages/core/components/views/project/components/phase-card.tsx
@@ -23,7 +23,7 @@ export function PhaseCard(props: PhaseConfig & { projectId: string }) {
     <Box
       overrides={{
         BoxContainer: {
-          style: { minHeight: '220px' },
+          style: { backgroundColor: theme.colors.backgroundLightAccent, minHeight: '220px' },
         },
       }}
       title={
@@ -31,7 +31,7 @@ export function PhaseCard(props: PhaseConfig & { projectId: string }) {
           <Icon name={icon} size={theme.sizing.scale500} />
           {name}
           {isComingSoon && (
-            <Tag color={TAG_COLOR.blue} size={TAG_SIZE.xSmall} closeable={false}>
+            <Tag color={TAG_COLOR.gray} size={TAG_SIZE.xSmall} closeable={false}>
               Coming soon
             </Tag>
           )}
@@ -96,9 +96,17 @@ export function PhaseCard(props: PhaseConfig & { projectId: string }) {
             navigate(`/${projectId}/${id}/${firstActiveEntity.id}`);
           }}
           shape={SHAPE.circle}
-          overrides={{ BaseButton: { style: { marginTop: 'auto' } } }}
+          overrides={{
+            BaseButton: {
+              style: {
+                marginTop: 'auto',
+                backgroundColor: theme.colors.accent,
+                ':hover': { backgroundColor: theme.colors.accent600 },
+              },
+            },
+          }}
         >
-          <Icon name="chevronRight" size={theme.sizing.scale700} />
+          <Icon name="chevronRight" size={theme.sizing.scale700} color={theme.colors.white} />
         </Button>
       )}
     </Box>


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
The phase cards are colored blue.


### Before
<img width="1502" height="715" alt="image" src="https://github.com/user-attachments/assets/eeb31795-50ff-4845-92c5-794ff343f519" />



### After

<img width="1511" height="687" alt="image" src="https://github.com/user-attachments/assets/7cd005e0-47af-4bab-83e9-33891058aea9" />


<!-- Tell your future self why have you made these changes -->
**Why?**
The phase cards stand out better if it's blue on a white background.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Visually.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A
<!-- Does this PR introduce a breaking change? Check all that apply. -->
**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)



<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
N/A
<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
N/A