### PR TITLE
docs(security): update supported versions for 0.8.x

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,9 +6,9 @@ The following versions of the project are currently supported with security upda
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 0.8.x   | :white_check_mark: |
 | 0.7.x   | :white_check_mark: |
-| 0.6.x   | :white_check_mark: |
-| < 0.6   | :x:                |
+| < 0.7   | :x:                |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**
Updates the supported-versions table in SECURITY.md for the 0.8.0 release: 0.8.x and 0.7.x are now the supported lines, and everything below 0.7 is marked unsupported.

**Why?**
0.8.0 shipped (#1721), but SECURITY.md still lists 0.7.x / 0.6.x as the supported pair. This is the same per-release follow-up #1680 did for 0.7.x - the table is not covered by scripts/version-bump.sh, so it needs a manual bump each release.

**How did you test it?**
Rendered the table in a markdown preview; cross-checked the current version against python/pyproject.toml (0.8.0) and CHANGELOG.md.

**Potential risks**
None - documentation-only change to a static table.

**Breaking Changes**

- [x] No breaking changes

**Release notes**
None.

**Documentation Changes**
SECURITY.md only.
