### PR TITLE
fix(release): align website version and add it to version-bump.sh

### DIFF
--- a/scripts/version-bump.sh
+++ b/scripts/version-bump.sh
@@ -8,6 +8,7 @@ VERSION_FILES=(
   "javascript/packages/core/package.json"
   "javascript/packages/rpc/package.json"
   "javascript/app/package.json"
+  "website/package.json"
   "helm/michelangelo/Chart.yaml"
 )
 
@@ -94,7 +95,7 @@ set_version() {
   printf "  %-50s → %s\n" "python/pyproject.toml" "$new_version"
 
   # JSON package files
-  for file in javascript/packages/core/package.json javascript/packages/rpc/package.json javascript/app/package.json; do
+  for file in javascript/packages/core/package.json javascript/packages/rpc/package.json javascript/app/package.json website/package.json; do
     sed -i.bak "s/\"version\": \"[^\"]*\"/\"version\": \"$new_version\"/" "$REPO_ROOT/$file"
     rm -f "$REPO_ROOT/$file.bak"
     printf "  %-50s → %s\n" "$file" "$new_version"

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "website",
-  "version": "0.3.0",
+  "version": "0.8.0",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
Two small things with one root cause:
1. `website/package.json` version goes from 0.3.0 to 0.8.0.
2. `website/package.json` is added to `scripts/version-bump.sh` (both the `VERSION_FILES` check list and the JSON set loop) so it moves with every future release.

**Why?**
#1376 declared `website/package.json` one of the release artifacts that share the coordinated version, but it was never added to `version-bump.sh`, so the 0.4.0 through 0.8.0 merge-backs all missed it - it has been silently stuck at 0.3.0 for five releases.

**How did you test it?**
- `bash -n scripts/version-bump.sh` (syntax) and `scripts/version-bump.sh --check` now reports all 6 files aligned at 0.8.0.
- Ran the set path on a scratch copy with a throwaway version: exactly one line changes in `website/package.json` (the top-level `version` field), the file stays valid JSON, and `--check` round-trips aligned.

**Potential risks**
None in practice - the website package is `private: true` (never published to npm); the version field is metadata for the docusaurus app.

**Breaking Changes**

- [x] No breaking changes

**Release notes**
None.

**Documentation Changes**
None.
