### PR TITLE
ci(codecov): mark project and patch status checks informational

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -9,6 +9,7 @@ coverage:
         target: auto          # Use baseline from main branch
         threshold: 1%         # Allow 1% drop from baseline
         if_ci_failed: error
+        informational: true   # Report-only until the check has real history
 
     # Coverage for changes in PR (strictly enforced)
     patch:
@@ -16,6 +17,7 @@ coverage:
         target: 90%           # New code must have 90% coverage
         threshold: 0%         # No tolerance for drops in new code
         if_ci_failed: error
+        informational: true   # Report-only until the 90% bar is calibrated
 
   precision: 2
   round: down


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

**What changed?**
Adds `informational: true` to the two existing Codecov status blocks in `.github/codecov.yml` (project and patch). Both checks keep posting their numbers on every PR, but they can no longer turn a PR red.

**Why?**
The status gates in codecov.yml (project: auto baseline with 1% threshold, patch: 90% target) have existed since #543, but no workflow uploaded coverage until #1834 merged - so they have been dormant for their entire life and were never calibrated against real data. Now that uploads flow, they go live on every PR with a strict, never-exercised bar. Marking them informational surfaces the same numbers without gating merges; once there is enough history to trust the thresholds, flipping them back is a 2-line change.

**How did you test it?**
- YAML parses cleanly.
- Config accepted by Codecov's own validator (`curl --data-binary @.github/codecov.yml https://codecov.io/validate` returns Valid).

**Potential risks**
Coverage regressions will not block merges while the checks are informational - that is the intended trade-off until the thresholds are calibrated.

**Breaking Changes**

- [x] No breaking changes

**Release notes**
None.

**Documentation Changes**
None.
