### PR TITLE
fix(auth): enforce authn/authz on generated Get and List handlers

### DIFF
--- a/go/kubeproto/templates/crd_svc.tmpl
+++ b/go/kubeproto/templates/crd_svc.tmpl
@@ -236,14 +236,6 @@ func (c {{.LowerKindName}}ServiceHandler) Get{{.KindName}}(
 		logging.EntityNameTag:   request.Name,
 	})
 
-	getOptions := &metav1.GetOptions{}
-	if request.GetOptions != nil {
-		getOptions = request.GetOptions
-	}
-
-	result := &{{.KindName}}{}
-	err = c.apiHandler.Get(ctx, request.Namespace, request.Name, getOptions, result)
-
 	defer c.auditLogEmitter.Emit(ctx, c.build{{.KindName}}AuditLogEventForGet(
 												ctx,
 												request,
@@ -251,6 +243,32 @@ func (c {{.LowerKindName}}ServiceHandler) Get{{.KindName}}(
 												err,
 												),
 				)
+
+	// Authentication
+	userAuthenticated, err := c.auth.UserAuthenticated(ctx)
+	if !userAuthenticated {
+		logger.Error(err, "User is not authenticated")
+		metric.Counter("unauthenticated").Inc(1)
+		return nil, err
+	}
+
+	// Authorization
+	projectName := request.Namespace
+	userAuthorized, err := c.auth.UserAuthorized(ctx, projectName, authapi.Get, "{{.KindName}}")
+
+	if !userAuthorized {
+		logger.Error(err, "User is not authorized")
+		metric.Counter("unauthorized").Inc(1)
+		return nil, err
+	}
+
+	getOptions := &metav1.GetOptions{}
+	if request.GetOptions != nil {
+		getOptions = request.GetOptions
+	}
+
+	result := &{{.KindName}}{}
+	err = c.apiHandler.Get(ctx, request.Namespace, request.Name, getOptions, result)
 
 	if err != nil {
 		logger.Error(err, "Cannot get {{.KindName}} request info from k8s/ETCD", "error", err, "api_msg_tag", "Get{{.KindName}}")
@@ -516,6 +534,32 @@ func (c {{.LowerKindName}}ServiceHandler) List{{.KindName}}(
 		logging.NamespaceTag:    request.Namespace,
 	})
 
+	defer c.auditLogEmitter.Emit(ctx, c.build{{.KindName}}AuditLogEventForList(
+												ctx,
+												request,
+												resp,
+												err,
+												),
+				)
+
+	// Authentication
+	userAuthenticated, err := c.auth.UserAuthenticated(ctx)
+	if !userAuthenticated {
+		logger.Error(err, "User is not authenticated")
+		metric.Counter("unauthenticated").Inc(1)
+		return nil, err
+	}
+
+	// Authorization
+	projectName := request.Namespace
+	userAuthorized, err := c.auth.UserAuthorized(ctx, projectName, authapi.List, "{{.KindName}}")
+
+	if !userAuthorized {
+		logger.Error(err, "User is not authorized")
+		metric.Counter("unauthorized").Inc(1)
+		return nil, err
+	}
+
 	result := &{{.KindName}}List{}
 	listOptions := &metav1.ListOptions{}
 	if request.ListOptions != nil {
@@ -526,14 +570,6 @@ func (c {{.LowerKindName}}ServiceHandler) List{{.KindName}}(
 		listOptionsExt = request.ListOptionsExt
 	}
 	err = c.apiHandler.List(ctx, request.Namespace, listOptions, listOptionsExt, result)
-
-	defer c.auditLogEmitter.Emit(ctx, c.build{{.KindName}}AuditLogEventForList(
-												ctx,
-												request,
-												resp,
-												err,
-												),
-				)
 
 	if err != nil {
 		logger.Error(err, "API Handler failed to List {{.KindName}}", "error", err, "api_msg_tag", "List{{.KindName}}")

--- a/go/kubeproto/templates/templates_test.go
+++ b/go/kubeproto/templates/templates_test.go
@@ -83,3 +83,62 @@ func TestTemplates(t *testing.T) {
 	assert.NotContains(t, crdSvcHandlerCode, "UnifiedLogInfo")
 	assert.NotContains(t, crdSvcHandlerCode, "UnifiedLogError")
 }
+
+// TestCrdSvcHandlerAuthEnforcement locks the auth contract of the generated
+// service handlers: every verb handler must authenticate the caller, then
+// authorize the matching auth Action against the request namespace, and the
+// audit-log defer must be registered before the auth checks so that denied
+// requests are still audit-logged. Get and List historically rendered with no
+// auth block at all, so this guards the template against regressing again.
+func TestCrdSvcHandlerAuthEnforcement(t *testing.T) {
+	var buf strings.Builder
+	crdSvcHandlerInfo := struct {
+		KindName      string
+		LowerKindName string
+	}{"TestName", "LowerTestName"}
+	assert.NoError(t, CrdSvcHandler.Execute(&buf, crdSvcHandlerInfo))
+	code := buf.String()
+
+	handlers := []struct {
+		method string
+		action string
+	}{
+		{"CreateTestName", "authapi.Create"},
+		{"GetTestName", "authapi.Get"},
+		{"UpdateTestName", "authapi.Update"},
+		{"DeleteTestName", "authapi.Delete"},
+		{"DeleteTestNameCollection", "authapi.DeleteCollection"},
+		{"ListTestName", "authapi.List"},
+	}
+
+	for _, h := range handlers {
+		body := handlerBody(t, code, h.method)
+
+		authnIdx := strings.Index(body, "c.auth.UserAuthenticated(ctx)")
+		assert.GreaterOrEqual(t, authnIdx, 0, "%s must authenticate the caller", h.method)
+
+		authzCall := `c.auth.UserAuthorized(ctx, projectName, ` + h.action + `, "TestName")`
+		assert.Contains(t, body, authzCall, "%s must authorize %s", h.method, h.action)
+
+		auditIdx := strings.Index(body, "defer c.auditLogEmitter.Emit(")
+		assert.GreaterOrEqual(t, auditIdx, 0, "%s must emit an audit-log event", h.method)
+		assert.Less(t, auditIdx, authnIdx,
+			"%s must register the audit-log defer before the auth checks so denied requests are audit-logged", h.method)
+	}
+}
+
+// handlerBody returns the rendered source of one generated handler method,
+// from its func declaration up to the next top-level func declaration.
+func handlerBody(t *testing.T, code, method string) string {
+	t.Helper()
+	marker := "func (c LowerTestNameServiceHandler) " + method + "("
+	start := strings.Index(code, marker)
+	if start < 0 {
+		t.Fatalf("generated code has no handler %s", method)
+	}
+	rest := code[start:]
+	if end := strings.Index(rest[1:], "\nfunc "); end >= 0 {
+		rest = rest[:end+1]
+	}
+	return rest
+}

--- a/proto-go/api/v2/cached_output.pb.kubeyarpc.go
+++ b/proto-go/api/v2/cached_output.pb.kubeyarpc.go
@@ -255,14 +255,6 @@ func (c cachedOutputServiceHandler) GetCachedOutput(
 		logging.EntityNameTag:   request.Name,
 	})
 
-	getOptions := &metav1.GetOptions{}
-	if request.GetOptions != nil {
-		getOptions = request.GetOptions
-	}
-
-	result := &CachedOutput{}
-	err = c.apiHandler.Get(ctx, request.Namespace, request.Name, getOptions, result)
-
 	defer c.auditLogEmitter.Emit(ctx, c.buildCachedOutputAuditLogEventForGet(
 		ctx,
 		request,
@@ -270,6 +262,32 @@ func (c cachedOutputServiceHandler) GetCachedOutput(
 		err,
 	),
 	)
+
+	// Authentication
+	userAuthenticated, err := c.auth.UserAuthenticated(ctx)
+	if !userAuthenticated {
+		logger.Error(err, "User is not authenticated")
+		metric.Counter("unauthenticated").Inc(1)
+		return nil, err
+	}
+
+	// Authorization
+	projectName := request.Namespace
+	userAuthorized, err := c.auth.UserAuthorized(ctx, projectName, authapi.Get, "CachedOutput")
+
+	if !userAuthorized {
+		logger.Error(err, "User is not authorized")
+		metric.Counter("unauthorized").Inc(1)
+		return nil, err
+	}
+
+	getOptions := &metav1.GetOptions{}
+	if request.GetOptions != nil {
+		getOptions = request.GetOptions
+	}
+
+	result := &CachedOutput{}
+	err = c.apiHandler.Get(ctx, request.Namespace, request.Name, getOptions, result)
 
 	if err != nil {
 		logger.Error(err, "Cannot get CachedOutput request info from k8s/ETCD", "error", err, "api_msg_tag", "GetCachedOutput")
@@ -535,6 +553,32 @@ func (c cachedOutputServiceHandler) ListCachedOutput(
 		logging.NamespaceTag:    request.Namespace,
 	})
 
+	defer c.auditLogEmitter.Emit(ctx, c.buildCachedOutputAuditLogEventForList(
+		ctx,
+		request,
+		resp,
+		err,
+	),
+	)
+
+	// Authentication
+	userAuthenticated, err := c.auth.UserAuthenticated(ctx)
+	if !userAuthenticated {
+		logger.Error(err, "User is not authenticated")
+		metric.Counter("unauthenticated").Inc(1)
+		return nil, err
+	}
+
+	// Authorization
+	projectName := request.Namespace
+	userAuthorized, err := c.auth.UserAuthorized(ctx, projectName, authapi.List, "CachedOutput")
+
+	if !userAuthorized {
+		logger.Error(err, "User is not authorized")
+		metric.Counter("unauthorized").Inc(1)
+		return nil, err
+	}
+
 	result := &CachedOutputList{}
 	listOptions := &metav1.ListOptions{}
 	if request.ListOptions != nil {
@@ -545,14 +589,6 @@ func (c cachedOutputServiceHandler) ListCachedOutput(
 		listOptionsExt = request.ListOptionsExt
 	}
 	err = c.apiHandler.List(ctx, request.Namespace, listOptions, listOptionsExt, result)
-
-	defer c.auditLogEmitter.Emit(ctx, c.buildCachedOutputAuditLogEventForList(
-		ctx,
-		request,
-		resp,
-		err,
-	),
-	)
 
 	if err != nil {
 		logger.Error(err, "API Handler failed to List CachedOutput", "error", err, "api_msg_tag", "ListCachedOutput")

--- a/proto-go/api/v2/cluster.pb.kubeyarpc.go
+++ b/proto-go/api/v2/cluster.pb.kubeyarpc.go
@@ -255,14 +255,6 @@ func (c clusterServiceHandler) GetCluster(
 		logging.EntityNameTag:   request.Name,
 	})
 
-	getOptions := &metav1.GetOptions{}
-	if request.GetOptions != nil {
-		getOptions = request.GetOptions
-	}
-
-	result := &Cluster{}
-	err = c.apiHandler.Get(ctx, request.Namespace, request.Name, getOptions, result)
-
 	defer c.auditLogEmitter.Emit(ctx, c.buildClusterAuditLogEventForGet(
 		ctx,
 		request,
@@ -270,6 +262,32 @@ func (c clusterServiceHandler) GetCluster(
 		err,
 	),
 	)
+
+	// Authentication
+	userAuthenticated, err := c.auth.UserAuthenticated(ctx)
+	if !userAuthenticated {
+		logger.Error(err, "User is not authenticated")
+		metric.Counter("unauthenticated").Inc(1)
+		return nil, err
+	}
+
+	// Authorization
+	projectName := request.Namespace
+	userAuthorized, err := c.auth.UserAuthorized(ctx, projectName, authapi.Get, "Cluster")
+
+	if !userAuthorized {
+		logger.Error(err, "User is not authorized")
+		metric.Counter("unauthorized").Inc(1)
+		return nil, err
+	}
+
+	getOptions := &metav1.GetOptions{}
+	if request.GetOptions != nil {
+		getOptions = request.GetOptions
+	}
+
+	result := &Cluster{}
+	err = c.apiHandler.Get(ctx, request.Namespace, request.Name, getOptions, result)
 
 	if err != nil {
 		logger.Error(err, "Cannot get Cluster request info from k8s/ETCD", "error", err, "api_msg_tag", "GetCluster")
@@ -535,6 +553,32 @@ func (c clusterServiceHandler) ListCluster(
 		logging.NamespaceTag:    request.Namespace,
 	})
 
+	defer c.auditLogEmitter.Emit(ctx, c.buildClusterAuditLogEventForList(
+		ctx,
+		request,
+		resp,
+		err,
+	),
+	)
+
+	// Authentication
+	userAuthenticated, err := c.auth.UserAuthenticated(ctx)
+	if !userAuthenticated {
+		logger.Error(err, "User is not authenticated")
+		metric.Counter("unauthenticated").Inc(1)
+		return nil, err
+	}
+
+	// Authorization
+	projectName := request.Namespace
+	userAuthorized, err := c.auth.UserAuthorized(ctx, projectName, authapi.List, "Cluster")
+
+	if !userAuthorized {
+		logger.Error(err, "User is not authorized")
+		metric.Counter("unauthorized").Inc(1)
+		return nil, err
+	}
+
 	result := &ClusterList{}
 	listOptions := &metav1.ListOptions{}
 	if request.ListOptions != nil {
@@ -545,14 +589,6 @@ func (c clusterServiceHandler) ListCluster(
 		listOptionsExt = request.ListOptionsExt
 	}
 	err = c.apiHandler.List(ctx, request.Namespace, listOptions, listOptionsExt, result)
-
-	defer c.auditLogEmitter.Emit(ctx, c.buildClusterAuditLogEventForList(
-		ctx,
-		request,
-		resp,
-		err,
-	),
-	)
 
 	if err != nil {
 		logger.Error(err, "API Handler failed to List Cluster", "error", err, "api_msg_tag", "ListCluster")

--- a/proto-go/api/v2/deployment.pb.kubeyarpc.go
+++ b/proto-go/api/v2/deployment.pb.kubeyarpc.go
@@ -255,14 +255,6 @@ func (c deploymentServiceHandler) GetDeployment(
 		logging.EntityNameTag:   request.Name,
 	})
 
-	getOptions := &metav1.GetOptions{}
-	if request.GetOptions != nil {
-		getOptions = request.GetOptions
-	}
-
-	result := &Deployment{}
-	err = c.apiHandler.Get(ctx, request.Namespace, request.Name, getOptions, result)
-
 	defer c.auditLogEmitter.Emit(ctx, c.buildDeploymentAuditLogEventForGet(
 		ctx,
 		request,
@@ -270,6 +262,32 @@ func (c deploymentServiceHandler) GetDeployment(
 		err,
 	),
 	)
+
+	// Authentication
+	userAuthenticated, err := c.auth.UserAuthenticated(ctx)
+	if !userAuthenticated {
+		logger.Error(err, "User is not authenticated")
+		metric.Counter("unauthenticated").Inc(1)
+		return nil, err
+	}
+
+	// Authorization
+	projectName := request.Namespace
+	userAuthorized, err := c.auth.UserAuthorized(ctx, projectName, authapi.Get, "Deployment")
+
+	if !userAuthorized {
+		logger.Error(err, "User is not authorized")
+		metric.Counter("unauthorized").Inc(1)
+		return nil, err
+	}
+
+	getOptions := &metav1.GetOptions{}
+	if request.GetOptions != nil {
+		getOptions = request.GetOptions
+	}
+
+	result := &Deployment{}
+	err = c.apiHandler.Get(ctx, request.Namespace, request.Name, getOptions, result)
 
 	if err != nil {
 		logger.Error(err, "Cannot get Deployment request info from k8s/ETCD", "error", err, "api_msg_tag", "GetDeployment")
@@ -535,6 +553,32 @@ func (c deploymentServiceHandler) ListDeployment(
 		logging.NamespaceTag:    request.Namespace,
 	})
 
+	defer c.auditLogEmitter.Emit(ctx, c.buildDeploymentAuditLogEventForList(
+		ctx,
+		request,
+		resp,
+		err,
+	),
+	)
+
+	// Authentication
+	userAuthenticated, err := c.auth.UserAuthenticated(ctx)
+	if !userAuthenticated {
+		logger.Error(err, "User is not authenticated")
+		metric.Counter("unauthenticated").Inc(1)
+		return nil, err
+	}
+
+	// Authorization
+	projectName := request.Namespace
+	userAuthorized, err := c.auth.UserAuthorized(ctx, projectName, authapi.List, "Deployment")
+
+	if !userAuthorized {
+		logger.Error(err, "User is not authorized")
+		metric.Counter("unauthorized").Inc(1)
+		return nil, err
+	}
+
 	result := &DeploymentList{}
 	listOptions := &metav1.ListOptions{}
 	if request.ListOptions != nil {
@@ -545,14 +589,6 @@ func (c deploymentServiceHandler) ListDeployment(
 		listOptionsExt = request.ListOptionsExt
 	}
 	err = c.apiHandler.List(ctx, request.Namespace, listOptions, listOptionsExt, result)
-
-	defer c.auditLogEmitter.Emit(ctx, c.buildDeploymentAuditLogEventForList(
-		ctx,
-		request,
-		resp,
-		err,
-	),
-	)
 
 	if err != nil {
 		logger.Error(err, "API Handler failed to List Deployment", "error", err, "api_msg_tag", "ListDeployment")

--- a/proto-go/api/v2/evaluation_report.pb.kubeyarpc.go
+++ b/proto-go/api/v2/evaluation_report.pb.kubeyarpc.go
@@ -256,14 +256,6 @@ func (c evaluationReportServiceHandler) GetEvaluationReport(
 		logging.EntityNameTag:   request.Name,
 	})
 
-	getOptions := &metav1.GetOptions{}
-	if request.GetOptions != nil {
-		getOptions = request.GetOptions
-	}
-
-	result := &EvaluationReport{}
-	err = c.apiHandler.Get(ctx, request.Namespace, request.Name, getOptions, result)
-
 	defer c.auditLogEmitter.Emit(ctx, c.buildEvaluationReportAuditLogEventForGet(
 		ctx,
 		request,
@@ -271,6 +263,32 @@ func (c evaluationReportServiceHandler) GetEvaluationReport(
 		err,
 	),
 	)
+
+	// Authentication
+	userAuthenticated, err := c.auth.UserAuthenticated(ctx)
+	if !userAuthenticated {
+		logger.Error(err, "User is not authenticated")
+		metric.Counter("unauthenticated").Inc(1)
+		return nil, err
+	}
+
+	// Authorization
+	projectName := request.Namespace
+	userAuthorized, err := c.auth.UserAuthorized(ctx, projectName, authapi.Get, "EvaluationReport")
+
+	if !userAuthorized {
+		logger.Error(err, "User is not authorized")
+		metric.Counter("unauthorized").Inc(1)
+		return nil, err
+	}
+
+	getOptions := &metav1.GetOptions{}
+	if request.GetOptions != nil {
+		getOptions = request.GetOptions
+	}
+
+	result := &EvaluationReport{}
+	err = c.apiHandler.Get(ctx, request.Namespace, request.Name, getOptions, result)
 
 	if err != nil {
 		logger.Error(err, "Cannot get EvaluationReport request info from k8s/ETCD", "error", err, "api_msg_tag", "GetEvaluationReport")
@@ -536,6 +554,32 @@ func (c evaluationReportServiceHandler) ListEvaluationReport(
 		logging.NamespaceTag:    request.Namespace,
 	})
 
+	defer c.auditLogEmitter.Emit(ctx, c.buildEvaluationReportAuditLogEventForList(
+		ctx,
+		request,
+		resp,
+		err,
+	),
+	)
+
+	// Authentication
+	userAuthenticated, err := c.auth.UserAuthenticated(ctx)
+	if !userAuthenticated {
+		logger.Error(err, "User is not authenticated")
+		metric.Counter("unauthenticated").Inc(1)
+		return nil, err
+	}
+
+	// Authorization
+	projectName := request.Namespace
+	userAuthorized, err := c.auth.UserAuthorized(ctx, projectName, authapi.List, "EvaluationReport")
+
+	if !userAuthorized {
+		logger.Error(err, "User is not authorized")
+		metric.Counter("unauthorized").Inc(1)
+		return nil, err
+	}
+
 	result := &EvaluationReportList{}
 	listOptions := &metav1.ListOptions{}
 	if request.ListOptions != nil {
@@ -546,14 +590,6 @@ func (c evaluationReportServiceHandler) ListEvaluationReport(
 		listOptionsExt = request.ListOptionsExt
 	}
 	err = c.apiHandler.List(ctx, request.Namespace, listOptions, listOptionsExt, result)
-
-	defer c.auditLogEmitter.Emit(ctx, c.buildEvaluationReportAuditLogEventForList(
-		ctx,
-		request,
-		resp,
-		err,
-	),
-	)
 
 	if err != nil {
 		logger.Error(err, "API Handler failed to List EvaluationReport", "error", err, "api_msg_tag", "ListEvaluationReport")

--- a/proto-go/api/v2/inference_server.pb.kubeyarpc.go
+++ b/proto-go/api/v2/inference_server.pb.kubeyarpc.go
@@ -255,14 +255,6 @@ func (c inferenceServerServiceHandler) GetInferenceServer(
 		logging.EntityNameTag:   request.Name,
 	})
 
-	getOptions := &metav1.GetOptions{}
-	if request.GetOptions != nil {
-		getOptions = request.GetOptions
-	}
-
-	result := &InferenceServer{}
-	err = c.apiHandler.Get(ctx, request.Namespace, request.Name, getOptions, result)
-
 	defer c.auditLogEmitter.Emit(ctx, c.buildInferenceServerAuditLogEventForGet(
 		ctx,
 		request,
@@ -270,6 +262,32 @@ func (c inferenceServerServiceHandler) GetInferenceServer(
 		err,
 	),
 	)
+
+	// Authentication
+	userAuthenticated, err := c.auth.UserAuthenticated(ctx)
+	if !userAuthenticated {
+		logger.Error(err, "User is not authenticated")
+		metric.Counter("unauthenticated").Inc(1)
+		return nil, err
+	}
+
+	// Authorization
+	projectName := request.Namespace
+	userAuthorized, err := c.auth.UserAuthorized(ctx, projectName, authapi.Get, "InferenceServer")
+
+	if !userAuthorized {
+		logger.Error(err, "User is not authorized")
+		metric.Counter("unauthorized").Inc(1)
+		return nil, err
+	}
+
+	getOptions := &metav1.GetOptions{}
+	if request.GetOptions != nil {
+		getOptions = request.GetOptions
+	}
+
+	result := &InferenceServer{}
+	err = c.apiHandler.Get(ctx, request.Namespace, request.Name, getOptions, result)
 
 	if err != nil {
 		logger.Error(err, "Cannot get InferenceServer request info from k8s/ETCD", "error", err, "api_msg_tag", "GetInferenceServer")
@@ -535,6 +553,32 @@ func (c inferenceServerServiceHandler) ListInferenceServer(
 		logging.NamespaceTag:    request.Namespace,
 	})
 
+	defer c.auditLogEmitter.Emit(ctx, c.buildInferenceServerAuditLogEventForList(
+		ctx,
+		request,
+		resp,
+		err,
+	),
+	)
+
+	// Authentication
+	userAuthenticated, err := c.auth.UserAuthenticated(ctx)
+	if !userAuthenticated {
+		logger.Error(err, "User is not authenticated")
+		metric.Counter("unauthenticated").Inc(1)
+		return nil, err
+	}
+
+	// Authorization
+	projectName := request.Namespace
+	userAuthorized, err := c.auth.UserAuthorized(ctx, projectName, authapi.List, "InferenceServer")
+
+	if !userAuthorized {
+		logger.Error(err, "User is not authorized")
+		metric.Counter("unauthorized").Inc(1)
+		return nil, err
+	}
+
 	result := &InferenceServerList{}
 	listOptions := &metav1.ListOptions{}
 	if request.ListOptions != nil {
@@ -545,14 +589,6 @@ func (c inferenceServerServiceHandler) ListInferenceServer(
 		listOptionsExt = request.ListOptionsExt
 	}
 	err = c.apiHandler.List(ctx, request.Namespace, listOptions, listOptionsExt, result)
-
-	defer c.auditLogEmitter.Emit(ctx, c.buildInferenceServerAuditLogEventForList(
-		ctx,
-		request,
-		resp,
-		err,
-	),
-	)
 
 	if err != nil {
 		logger.Error(err, "API Handler failed to List InferenceServer", "error", err, "api_msg_tag", "ListInferenceServer")

--- a/proto-go/api/v2/model.pb.kubeyarpc.go
+++ b/proto-go/api/v2/model.pb.kubeyarpc.go
@@ -254,14 +254,6 @@ func (c modelServiceHandler) GetModel(
 		logging.EntityNameTag:   request.Name,
 	})
 
-	getOptions := &metav1.GetOptions{}
-	if request.GetOptions != nil {
-		getOptions = request.GetOptions
-	}
-
-	result := &Model{}
-	err = c.apiHandler.Get(ctx, request.Namespace, request.Name, getOptions, result)
-
 	defer c.auditLogEmitter.Emit(ctx, c.buildModelAuditLogEventForGet(
 		ctx,
 		request,
@@ -269,6 +261,32 @@ func (c modelServiceHandler) GetModel(
 		err,
 	),
 	)
+
+	// Authentication
+	userAuthenticated, err := c.auth.UserAuthenticated(ctx)
+	if !userAuthenticated {
+		logger.Error(err, "User is not authenticated")
+		metric.Counter("unauthenticated").Inc(1)
+		return nil, err
+	}
+
+	// Authorization
+	projectName := request.Namespace
+	userAuthorized, err := c.auth.UserAuthorized(ctx, projectName, authapi.Get, "Model")
+
+	if !userAuthorized {
+		logger.Error(err, "User is not authorized")
+		metric.Counter("unauthorized").Inc(1)
+		return nil, err
+	}
+
+	getOptions := &metav1.GetOptions{}
+	if request.GetOptions != nil {
+		getOptions = request.GetOptions
+	}
+
+	result := &Model{}
+	err = c.apiHandler.Get(ctx, request.Namespace, request.Name, getOptions, result)
 
 	if err != nil {
 		logger.Error(err, "Cannot get Model request info from k8s/ETCD", "error", err, "api_msg_tag", "GetModel")
@@ -534,6 +552,32 @@ func (c modelServiceHandler) ListModel(
 		logging.NamespaceTag:    request.Namespace,
 	})
 
+	defer c.auditLogEmitter.Emit(ctx, c.buildModelAuditLogEventForList(
+		ctx,
+		request,
+		resp,
+		err,
+	),
+	)
+
+	// Authentication
+	userAuthenticated, err := c.auth.UserAuthenticated(ctx)
+	if !userAuthenticated {
+		logger.Error(err, "User is not authenticated")
+		metric.Counter("unauthenticated").Inc(1)
+		return nil, err
+	}
+
+	// Authorization
+	projectName := request.Namespace
+	userAuthorized, err := c.auth.UserAuthorized(ctx, projectName, authapi.List, "Model")
+
+	if !userAuthorized {
+		logger.Error(err, "User is not authorized")
+		metric.Counter("unauthorized").Inc(1)
+		return nil, err
+	}
+
 	result := &ModelList{}
 	listOptions := &metav1.ListOptions{}
 	if request.ListOptions != nil {
@@ -544,14 +588,6 @@ func (c modelServiceHandler) ListModel(
 		listOptionsExt = request.ListOptionsExt
 	}
 	err = c.apiHandler.List(ctx, request.Namespace, listOptions, listOptionsExt, result)
-
-	defer c.auditLogEmitter.Emit(ctx, c.buildModelAuditLogEventForList(
-		ctx,
-		request,
-		resp,
-		err,
-	),
-	)
 
 	if err != nil {
 		logger.Error(err, "API Handler failed to List Model", "error", err, "api_msg_tag", "ListModel")

--- a/proto-go/api/v2/model_family.pb.kubeyarpc.go
+++ b/proto-go/api/v2/model_family.pb.kubeyarpc.go
@@ -255,14 +255,6 @@ func (c modelFamilyServiceHandler) GetModelFamily(
 		logging.EntityNameTag:   request.Name,
 	})
 
-	getOptions := &metav1.GetOptions{}
-	if request.GetOptions != nil {
-		getOptions = request.GetOptions
-	}
-
-	result := &ModelFamily{}
-	err = c.apiHandler.Get(ctx, request.Namespace, request.Name, getOptions, result)
-
 	defer c.auditLogEmitter.Emit(ctx, c.buildModelFamilyAuditLogEventForGet(
 		ctx,
 		request,
@@ -270,6 +262,32 @@ func (c modelFamilyServiceHandler) GetModelFamily(
 		err,
 	),
 	)
+
+	// Authentication
+	userAuthenticated, err := c.auth.UserAuthenticated(ctx)
+	if !userAuthenticated {
+		logger.Error(err, "User is not authenticated")
+		metric.Counter("unauthenticated").Inc(1)
+		return nil, err
+	}
+
+	// Authorization
+	projectName := request.Namespace
+	userAuthorized, err := c.auth.UserAuthorized(ctx, projectName, authapi.Get, "ModelFamily")
+
+	if !userAuthorized {
+		logger.Error(err, "User is not authorized")
+		metric.Counter("unauthorized").Inc(1)
+		return nil, err
+	}
+
+	getOptions := &metav1.GetOptions{}
+	if request.GetOptions != nil {
+		getOptions = request.GetOptions
+	}
+
+	result := &ModelFamily{}
+	err = c.apiHandler.Get(ctx, request.Namespace, request.Name, getOptions, result)
 
 	if err != nil {
 		logger.Error(err, "Cannot get ModelFamily request info from k8s/ETCD", "error", err, "api_msg_tag", "GetModelFamily")
@@ -535,6 +553,32 @@ func (c modelFamilyServiceHandler) ListModelFamily(
 		logging.NamespaceTag:    request.Namespace,
 	})
 
+	defer c.auditLogEmitter.Emit(ctx, c.buildModelFamilyAuditLogEventForList(
+		ctx,
+		request,
+		resp,
+		err,
+	),
+	)
+
+	// Authentication
+	userAuthenticated, err := c.auth.UserAuthenticated(ctx)
+	if !userAuthenticated {
+		logger.Error(err, "User is not authenticated")
+		metric.Counter("unauthenticated").Inc(1)
+		return nil, err
+	}
+
+	// Authorization
+	projectName := request.Namespace
+	userAuthorized, err := c.auth.UserAuthorized(ctx, projectName, authapi.List, "ModelFamily")
+
+	if !userAuthorized {
+		logger.Error(err, "User is not authorized")
+		metric.Counter("unauthorized").Inc(1)
+		return nil, err
+	}
+
 	result := &ModelFamilyList{}
 	listOptions := &metav1.ListOptions{}
 	if request.ListOptions != nil {
@@ -545,14 +589,6 @@ func (c modelFamilyServiceHandler) ListModelFamily(
 		listOptionsExt = request.ListOptionsExt
 	}
 	err = c.apiHandler.List(ctx, request.Namespace, listOptions, listOptionsExt, result)
-
-	defer c.auditLogEmitter.Emit(ctx, c.buildModelFamilyAuditLogEventForList(
-		ctx,
-		request,
-		resp,
-		err,
-	),
-	)
 
 	if err != nil {
 		logger.Error(err, "API Handler failed to List ModelFamily", "error", err, "api_msg_tag", "ListModelFamily")

--- a/proto-go/api/v2/pipeline.pb.kubeyarpc.go
+++ b/proto-go/api/v2/pipeline.pb.kubeyarpc.go
@@ -255,14 +255,6 @@ func (c pipelineServiceHandler) GetPipeline(
 		logging.EntityNameTag:   request.Name,
 	})
 
-	getOptions := &metav1.GetOptions{}
-	if request.GetOptions != nil {
-		getOptions = request.GetOptions
-	}
-
-	result := &Pipeline{}
-	err = c.apiHandler.Get(ctx, request.Namespace, request.Name, getOptions, result)
-
 	defer c.auditLogEmitter.Emit(ctx, c.buildPipelineAuditLogEventForGet(
 		ctx,
 		request,
@@ -270,6 +262,32 @@ func (c pipelineServiceHandler) GetPipeline(
 		err,
 	),
 	)
+
+	// Authentication
+	userAuthenticated, err := c.auth.UserAuthenticated(ctx)
+	if !userAuthenticated {
+		logger.Error(err, "User is not authenticated")
+		metric.Counter("unauthenticated").Inc(1)
+		return nil, err
+	}
+
+	// Authorization
+	projectName := request.Namespace
+	userAuthorized, err := c.auth.UserAuthorized(ctx, projectName, authapi.Get, "Pipeline")
+
+	if !userAuthorized {
+		logger.Error(err, "User is not authorized")
+		metric.Counter("unauthorized").Inc(1)
+		return nil, err
+	}
+
+	getOptions := &metav1.GetOptions{}
+	if request.GetOptions != nil {
+		getOptions = request.GetOptions
+	}
+
+	result := &Pipeline{}
+	err = c.apiHandler.Get(ctx, request.Namespace, request.Name, getOptions, result)
 
 	if err != nil {
 		logger.Error(err, "Cannot get Pipeline request info from k8s/ETCD", "error", err, "api_msg_tag", "GetPipeline")
@@ -535,6 +553,32 @@ func (c pipelineServiceHandler) ListPipeline(
 		logging.NamespaceTag:    request.Namespace,
 	})
 
+	defer c.auditLogEmitter.Emit(ctx, c.buildPipelineAuditLogEventForList(
+		ctx,
+		request,
+		resp,
+		err,
+	),
+	)
+
+	// Authentication
+	userAuthenticated, err := c.auth.UserAuthenticated(ctx)
+	if !userAuthenticated {
+		logger.Error(err, "User is not authenticated")
+		metric.Counter("unauthenticated").Inc(1)
+		return nil, err
+	}
+
+	// Authorization
+	projectName := request.Namespace
+	userAuthorized, err := c.auth.UserAuthorized(ctx, projectName, authapi.List, "Pipeline")
+
+	if !userAuthorized {
+		logger.Error(err, "User is not authorized")
+		metric.Counter("unauthorized").Inc(1)
+		return nil, err
+	}
+
 	result := &PipelineList{}
 	listOptions := &metav1.ListOptions{}
 	if request.ListOptions != nil {
@@ -545,14 +589,6 @@ func (c pipelineServiceHandler) ListPipeline(
 		listOptionsExt = request.ListOptionsExt
 	}
 	err = c.apiHandler.List(ctx, request.Namespace, listOptions, listOptionsExt, result)
-
-	defer c.auditLogEmitter.Emit(ctx, c.buildPipelineAuditLogEventForList(
-		ctx,
-		request,
-		resp,
-		err,
-	),
-	)
 
 	if err != nil {
 		logger.Error(err, "API Handler failed to List Pipeline", "error", err, "api_msg_tag", "ListPipeline")

--- a/proto-go/api/v2/pipeline_run.pb.kubeyarpc.go
+++ b/proto-go/api/v2/pipeline_run.pb.kubeyarpc.go
@@ -255,14 +255,6 @@ func (c pipelineRunServiceHandler) GetPipelineRun(
 		logging.EntityNameTag:   request.Name,
 	})
 
-	getOptions := &metav1.GetOptions{}
-	if request.GetOptions != nil {
-		getOptions = request.GetOptions
-	}
-
-	result := &PipelineRun{}
-	err = c.apiHandler.Get(ctx, request.Namespace, request.Name, getOptions, result)
-
 	defer c.auditLogEmitter.Emit(ctx, c.buildPipelineRunAuditLogEventForGet(
 		ctx,
 		request,
@@ -270,6 +262,32 @@ func (c pipelineRunServiceHandler) GetPipelineRun(
 		err,
 	),
 	)
+
+	// Authentication
+	userAuthenticated, err := c.auth.UserAuthenticated(ctx)
+	if !userAuthenticated {
+		logger.Error(err, "User is not authenticated")
+		metric.Counter("unauthenticated").Inc(1)
+		return nil, err
+	}
+
+	// Authorization
+	projectName := request.Namespace
+	userAuthorized, err := c.auth.UserAuthorized(ctx, projectName, authapi.Get, "PipelineRun")
+
+	if !userAuthorized {
+		logger.Error(err, "User is not authorized")
+		metric.Counter("unauthorized").Inc(1)
+		return nil, err
+	}
+
+	getOptions := &metav1.GetOptions{}
+	if request.GetOptions != nil {
+		getOptions = request.GetOptions
+	}
+
+	result := &PipelineRun{}
+	err = c.apiHandler.Get(ctx, request.Namespace, request.Name, getOptions, result)
 
 	if err != nil {
 		logger.Error(err, "Cannot get PipelineRun request info from k8s/ETCD", "error", err, "api_msg_tag", "GetPipelineRun")
@@ -535,6 +553,32 @@ func (c pipelineRunServiceHandler) ListPipelineRun(
 		logging.NamespaceTag:    request.Namespace,
 	})
 
+	defer c.auditLogEmitter.Emit(ctx, c.buildPipelineRunAuditLogEventForList(
+		ctx,
+		request,
+		resp,
+		err,
+	),
+	)
+
+	// Authentication
+	userAuthenticated, err := c.auth.UserAuthenticated(ctx)
+	if !userAuthenticated {
+		logger.Error(err, "User is not authenticated")
+		metric.Counter("unauthenticated").Inc(1)
+		return nil, err
+	}
+
+	// Authorization
+	projectName := request.Namespace
+	userAuthorized, err := c.auth.UserAuthorized(ctx, projectName, authapi.List, "PipelineRun")
+
+	if !userAuthorized {
+		logger.Error(err, "User is not authorized")
+		metric.Counter("unauthorized").Inc(1)
+		return nil, err
+	}
+
 	result := &PipelineRunList{}
 	listOptions := &metav1.ListOptions{}
 	if request.ListOptions != nil {
@@ -545,14 +589,6 @@ func (c pipelineRunServiceHandler) ListPipelineRun(
 		listOptionsExt = request.ListOptionsExt
 	}
 	err = c.apiHandler.List(ctx, request.Namespace, listOptions, listOptionsExt, result)
-
-	defer c.auditLogEmitter.Emit(ctx, c.buildPipelineRunAuditLogEventForList(
-		ctx,
-		request,
-		resp,
-		err,
-	),
-	)
 
 	if err != nil {
 		logger.Error(err, "API Handler failed to List PipelineRun", "error", err, "api_msg_tag", "ListPipelineRun")

--- a/proto-go/api/v2/project.pb.kubeyarpc.go
+++ b/proto-go/api/v2/project.pb.kubeyarpc.go
@@ -255,14 +255,6 @@ func (c projectServiceHandler) GetProject(
 		logging.EntityNameTag:   request.Name,
 	})
 
-	getOptions := &metav1.GetOptions{}
-	if request.GetOptions != nil {
-		getOptions = request.GetOptions
-	}
-
-	result := &Project{}
-	err = c.apiHandler.Get(ctx, request.Namespace, request.Name, getOptions, result)
-
 	defer c.auditLogEmitter.Emit(ctx, c.buildProjectAuditLogEventForGet(
 		ctx,
 		request,
@@ -270,6 +262,32 @@ func (c projectServiceHandler) GetProject(
 		err,
 	),
 	)
+
+	// Authentication
+	userAuthenticated, err := c.auth.UserAuthenticated(ctx)
+	if !userAuthenticated {
+		logger.Error(err, "User is not authenticated")
+		metric.Counter("unauthenticated").Inc(1)
+		return nil, err
+	}
+
+	// Authorization
+	projectName := request.Namespace
+	userAuthorized, err := c.auth.UserAuthorized(ctx, projectName, authapi.Get, "Project")
+
+	if !userAuthorized {
+		logger.Error(err, "User is not authorized")
+		metric.Counter("unauthorized").Inc(1)
+		return nil, err
+	}
+
+	getOptions := &metav1.GetOptions{}
+	if request.GetOptions != nil {
+		getOptions = request.GetOptions
+	}
+
+	result := &Project{}
+	err = c.apiHandler.Get(ctx, request.Namespace, request.Name, getOptions, result)
 
 	if err != nil {
 		logger.Error(err, "Cannot get Project request info from k8s/ETCD", "error", err, "api_msg_tag", "GetProject")
@@ -535,6 +553,32 @@ func (c projectServiceHandler) ListProject(
 		logging.NamespaceTag:    request.Namespace,
 	})
 
+	defer c.auditLogEmitter.Emit(ctx, c.buildProjectAuditLogEventForList(
+		ctx,
+		request,
+		resp,
+		err,
+	),
+	)
+
+	// Authentication
+	userAuthenticated, err := c.auth.UserAuthenticated(ctx)
+	if !userAuthenticated {
+		logger.Error(err, "User is not authenticated")
+		metric.Counter("unauthenticated").Inc(1)
+		return nil, err
+	}
+
+	// Authorization
+	projectName := request.Namespace
+	userAuthorized, err := c.auth.UserAuthorized(ctx, projectName, authapi.List, "Project")
+
+	if !userAuthorized {
+		logger.Error(err, "User is not authorized")
+		metric.Counter("unauthorized").Inc(1)
+		return nil, err
+	}
+
 	result := &ProjectList{}
 	listOptions := &metav1.ListOptions{}
 	if request.ListOptions != nil {
@@ -545,14 +589,6 @@ func (c projectServiceHandler) ListProject(
 		listOptionsExt = request.ListOptionsExt
 	}
 	err = c.apiHandler.List(ctx, request.Namespace, listOptions, listOptionsExt, result)
-
-	defer c.auditLogEmitter.Emit(ctx, c.buildProjectAuditLogEventForList(
-		ctx,
-		request,
-		resp,
-		err,
-	),
-	)
 
 	if err != nil {
 		logger.Error(err, "API Handler failed to List Project", "error", err, "api_msg_tag", "ListProject")

--- a/proto-go/api/v2/ray_cluster.pb.kubeyarpc.go
+++ b/proto-go/api/v2/ray_cluster.pb.kubeyarpc.go
@@ -255,14 +255,6 @@ func (c rayClusterServiceHandler) GetRayCluster(
 		logging.EntityNameTag:   request.Name,
 	})
 
-	getOptions := &metav1.GetOptions{}
-	if request.GetOptions != nil {
-		getOptions = request.GetOptions
-	}
-
-	result := &RayCluster{}
-	err = c.apiHandler.Get(ctx, request.Namespace, request.Name, getOptions, result)
-
 	defer c.auditLogEmitter.Emit(ctx, c.buildRayClusterAuditLogEventForGet(
 		ctx,
 		request,
@@ -270,6 +262,32 @@ func (c rayClusterServiceHandler) GetRayCluster(
 		err,
 	),
 	)
+
+	// Authentication
+	userAuthenticated, err := c.auth.UserAuthenticated(ctx)
+	if !userAuthenticated {
+		logger.Error(err, "User is not authenticated")
+		metric.Counter("unauthenticated").Inc(1)
+		return nil, err
+	}
+
+	// Authorization
+	projectName := request.Namespace
+	userAuthorized, err := c.auth.UserAuthorized(ctx, projectName, authapi.Get, "RayCluster")
+
+	if !userAuthorized {
+		logger.Error(err, "User is not authorized")
+		metric.Counter("unauthorized").Inc(1)
+		return nil, err
+	}
+
+	getOptions := &metav1.GetOptions{}
+	if request.GetOptions != nil {
+		getOptions = request.GetOptions
+	}
+
+	result := &RayCluster{}
+	err = c.apiHandler.Get(ctx, request.Namespace, request.Name, getOptions, result)
 
 	if err != nil {
 		logger.Error(err, "Cannot get RayCluster request info from k8s/ETCD", "error", err, "api_msg_tag", "GetRayCluster")
@@ -535,6 +553,32 @@ func (c rayClusterServiceHandler) ListRayCluster(
 		logging.NamespaceTag:    request.Namespace,
 	})
 
+	defer c.auditLogEmitter.Emit(ctx, c.buildRayClusterAuditLogEventForList(
+		ctx,
+		request,
+		resp,
+		err,
+	),
+	)
+
+	// Authentication
+	userAuthenticated, err := c.auth.UserAuthenticated(ctx)
+	if !userAuthenticated {
+		logger.Error(err, "User is not authenticated")
+		metric.Counter("unauthenticated").Inc(1)
+		return nil, err
+	}
+
+	// Authorization
+	projectName := request.Namespace
+	userAuthorized, err := c.auth.UserAuthorized(ctx, projectName, authapi.List, "RayCluster")
+
+	if !userAuthorized {
+		logger.Error(err, "User is not authorized")
+		metric.Counter("unauthorized").Inc(1)
+		return nil, err
+	}
+
 	result := &RayClusterList{}
 	listOptions := &metav1.ListOptions{}
 	if request.ListOptions != nil {
@@ -545,14 +589,6 @@ func (c rayClusterServiceHandler) ListRayCluster(
 		listOptionsExt = request.ListOptionsExt
 	}
 	err = c.apiHandler.List(ctx, request.Namespace, listOptions, listOptionsExt, result)
-
-	defer c.auditLogEmitter.Emit(ctx, c.buildRayClusterAuditLogEventForList(
-		ctx,
-		request,
-		resp,
-		err,
-	),
-	)
 
 	if err != nil {
 		logger.Error(err, "API Handler failed to List RayCluster", "error", err, "api_msg_tag", "ListRayCluster")

--- a/proto-go/api/v2/ray_job.pb.kubeyarpc.go
+++ b/proto-go/api/v2/ray_job.pb.kubeyarpc.go
@@ -255,14 +255,6 @@ func (c rayJobServiceHandler) GetRayJob(
 		logging.EntityNameTag:   request.Name,
 	})
 
-	getOptions := &metav1.GetOptions{}
-	if request.GetOptions != nil {
-		getOptions = request.GetOptions
-	}
-
-	result := &RayJob{}
-	err = c.apiHandler.Get(ctx, request.Namespace, request.Name, getOptions, result)
-
 	defer c.auditLogEmitter.Emit(ctx, c.buildRayJobAuditLogEventForGet(
 		ctx,
 		request,
@@ -270,6 +262,32 @@ func (c rayJobServiceHandler) GetRayJob(
 		err,
 	),
 	)
+
+	// Authentication
+	userAuthenticated, err := c.auth.UserAuthenticated(ctx)
+	if !userAuthenticated {
+		logger.Error(err, "User is not authenticated")
+		metric.Counter("unauthenticated").Inc(1)
+		return nil, err
+	}
+
+	// Authorization
+	projectName := request.Namespace
+	userAuthorized, err := c.auth.UserAuthorized(ctx, projectName, authapi.Get, "RayJob")
+
+	if !userAuthorized {
+		logger.Error(err, "User is not authorized")
+		metric.Counter("unauthorized").Inc(1)
+		return nil, err
+	}
+
+	getOptions := &metav1.GetOptions{}
+	if request.GetOptions != nil {
+		getOptions = request.GetOptions
+	}
+
+	result := &RayJob{}
+	err = c.apiHandler.Get(ctx, request.Namespace, request.Name, getOptions, result)
 
 	if err != nil {
 		logger.Error(err, "Cannot get RayJob request info from k8s/ETCD", "error", err, "api_msg_tag", "GetRayJob")
@@ -535,6 +553,32 @@ func (c rayJobServiceHandler) ListRayJob(
 		logging.NamespaceTag:    request.Namespace,
 	})
 
+	defer c.auditLogEmitter.Emit(ctx, c.buildRayJobAuditLogEventForList(
+		ctx,
+		request,
+		resp,
+		err,
+	),
+	)
+
+	// Authentication
+	userAuthenticated, err := c.auth.UserAuthenticated(ctx)
+	if !userAuthenticated {
+		logger.Error(err, "User is not authenticated")
+		metric.Counter("unauthenticated").Inc(1)
+		return nil, err
+	}
+
+	// Authorization
+	projectName := request.Namespace
+	userAuthorized, err := c.auth.UserAuthorized(ctx, projectName, authapi.List, "RayJob")
+
+	if !userAuthorized {
+		logger.Error(err, "User is not authorized")
+		metric.Counter("unauthorized").Inc(1)
+		return nil, err
+	}
+
 	result := &RayJobList{}
 	listOptions := &metav1.ListOptions{}
 	if request.ListOptions != nil {
@@ -545,14 +589,6 @@ func (c rayJobServiceHandler) ListRayJob(
 		listOptionsExt = request.ListOptionsExt
 	}
 	err = c.apiHandler.List(ctx, request.Namespace, listOptions, listOptionsExt, result)
-
-	defer c.auditLogEmitter.Emit(ctx, c.buildRayJobAuditLogEventForList(
-		ctx,
-		request,
-		resp,
-		err,
-	),
-	)
 
 	if err != nil {
 		logger.Error(err, "API Handler failed to List RayJob", "error", err, "api_msg_tag", "ListRayJob")

--- a/proto-go/api/v2/revision.pb.kubeyarpc.go
+++ b/proto-go/api/v2/revision.pb.kubeyarpc.go
@@ -255,14 +255,6 @@ func (c revisionServiceHandler) GetRevision(
 		logging.EntityNameTag:   request.Name,
 	})
 
-	getOptions := &metav1.GetOptions{}
-	if request.GetOptions != nil {
-		getOptions = request.GetOptions
-	}
-
-	result := &Revision{}
-	err = c.apiHandler.Get(ctx, request.Namespace, request.Name, getOptions, result)
-
 	defer c.auditLogEmitter.Emit(ctx, c.buildRevisionAuditLogEventForGet(
 		ctx,
 		request,
@@ -270,6 +262,32 @@ func (c revisionServiceHandler) GetRevision(
 		err,
 	),
 	)
+
+	// Authentication
+	userAuthenticated, err := c.auth.UserAuthenticated(ctx)
+	if !userAuthenticated {
+		logger.Error(err, "User is not authenticated")
+		metric.Counter("unauthenticated").Inc(1)
+		return nil, err
+	}
+
+	// Authorization
+	projectName := request.Namespace
+	userAuthorized, err := c.auth.UserAuthorized(ctx, projectName, authapi.Get, "Revision")
+
+	if !userAuthorized {
+		logger.Error(err, "User is not authorized")
+		metric.Counter("unauthorized").Inc(1)
+		return nil, err
+	}
+
+	getOptions := &metav1.GetOptions{}
+	if request.GetOptions != nil {
+		getOptions = request.GetOptions
+	}
+
+	result := &Revision{}
+	err = c.apiHandler.Get(ctx, request.Namespace, request.Name, getOptions, result)
 
 	if err != nil {
 		logger.Error(err, "Cannot get Revision request info from k8s/ETCD", "error", err, "api_msg_tag", "GetRevision")
@@ -535,6 +553,32 @@ func (c revisionServiceHandler) ListRevision(
 		logging.NamespaceTag:    request.Namespace,
 	})
 
+	defer c.auditLogEmitter.Emit(ctx, c.buildRevisionAuditLogEventForList(
+		ctx,
+		request,
+		resp,
+		err,
+	),
+	)
+
+	// Authentication
+	userAuthenticated, err := c.auth.UserAuthenticated(ctx)
+	if !userAuthenticated {
+		logger.Error(err, "User is not authenticated")
+		metric.Counter("unauthenticated").Inc(1)
+		return nil, err
+	}
+
+	// Authorization
+	projectName := request.Namespace
+	userAuthorized, err := c.auth.UserAuthorized(ctx, projectName, authapi.List, "Revision")
+
+	if !userAuthorized {
+		logger.Error(err, "User is not authorized")
+		metric.Counter("unauthorized").Inc(1)
+		return nil, err
+	}
+
 	result := &RevisionList{}
 	listOptions := &metav1.ListOptions{}
 	if request.ListOptions != nil {
@@ -545,14 +589,6 @@ func (c revisionServiceHandler) ListRevision(
 		listOptionsExt = request.ListOptionsExt
 	}
 	err = c.apiHandler.List(ctx, request.Namespace, listOptions, listOptionsExt, result)
-
-	defer c.auditLogEmitter.Emit(ctx, c.buildRevisionAuditLogEventForList(
-		ctx,
-		request,
-		resp,
-		err,
-	),
-	)
 
 	if err != nil {
 		logger.Error(err, "API Handler failed to List Revision", "error", err, "api_msg_tag", "ListRevision")

--- a/proto-go/api/v2/spark_job.pb.kubeyarpc.go
+++ b/proto-go/api/v2/spark_job.pb.kubeyarpc.go
@@ -255,14 +255,6 @@ func (c sparkJobServiceHandler) GetSparkJob(
 		logging.EntityNameTag:   request.Name,
 	})
 
-	getOptions := &metav1.GetOptions{}
-	if request.GetOptions != nil {
-		getOptions = request.GetOptions
-	}
-
-	result := &SparkJob{}
-	err = c.apiHandler.Get(ctx, request.Namespace, request.Name, getOptions, result)
-
 	defer c.auditLogEmitter.Emit(ctx, c.buildSparkJobAuditLogEventForGet(
 		ctx,
 		request,
@@ -270,6 +262,32 @@ func (c sparkJobServiceHandler) GetSparkJob(
 		err,
 	),
 	)
+
+	// Authentication
+	userAuthenticated, err := c.auth.UserAuthenticated(ctx)
+	if !userAuthenticated {
+		logger.Error(err, "User is not authenticated")
+		metric.Counter("unauthenticated").Inc(1)
+		return nil, err
+	}
+
+	// Authorization
+	projectName := request.Namespace
+	userAuthorized, err := c.auth.UserAuthorized(ctx, projectName, authapi.Get, "SparkJob")
+
+	if !userAuthorized {
+		logger.Error(err, "User is not authorized")
+		metric.Counter("unauthorized").Inc(1)
+		return nil, err
+	}
+
+	getOptions := &metav1.GetOptions{}
+	if request.GetOptions != nil {
+		getOptions = request.GetOptions
+	}
+
+	result := &SparkJob{}
+	err = c.apiHandler.Get(ctx, request.Namespace, request.Name, getOptions, result)
 
 	if err != nil {
 		logger.Error(err, "Cannot get SparkJob request info from k8s/ETCD", "error", err, "api_msg_tag", "GetSparkJob")
@@ -535,6 +553,32 @@ func (c sparkJobServiceHandler) ListSparkJob(
 		logging.NamespaceTag:    request.Namespace,
 	})
 
+	defer c.auditLogEmitter.Emit(ctx, c.buildSparkJobAuditLogEventForList(
+		ctx,
+		request,
+		resp,
+		err,
+	),
+	)
+
+	// Authentication
+	userAuthenticated, err := c.auth.UserAuthenticated(ctx)
+	if !userAuthenticated {
+		logger.Error(err, "User is not authenticated")
+		metric.Counter("unauthenticated").Inc(1)
+		return nil, err
+	}
+
+	// Authorization
+	projectName := request.Namespace
+	userAuthorized, err := c.auth.UserAuthorized(ctx, projectName, authapi.List, "SparkJob")
+
+	if !userAuthorized {
+		logger.Error(err, "User is not authorized")
+		metric.Counter("unauthorized").Inc(1)
+		return nil, err
+	}
+
 	result := &SparkJobList{}
 	listOptions := &metav1.ListOptions{}
 	if request.ListOptions != nil {
@@ -545,14 +589,6 @@ func (c sparkJobServiceHandler) ListSparkJob(
 		listOptionsExt = request.ListOptionsExt
 	}
 	err = c.apiHandler.List(ctx, request.Namespace, listOptions, listOptionsExt, result)
-
-	defer c.auditLogEmitter.Emit(ctx, c.buildSparkJobAuditLogEventForList(
-		ctx,
-		request,
-		resp,
-		err,
-	),
-	)
 
 	if err != nil {
 		logger.Error(err, "API Handler failed to List SparkJob", "error", err, "api_msg_tag", "ListSparkJob")

--- a/proto-go/api/v2/trigger_run.pb.kubeyarpc.go
+++ b/proto-go/api/v2/trigger_run.pb.kubeyarpc.go
@@ -255,14 +255,6 @@ func (c triggerRunServiceHandler) GetTriggerRun(
 		logging.EntityNameTag:   request.Name,
 	})
 
-	getOptions := &metav1.GetOptions{}
-	if request.GetOptions != nil {
-		getOptions = request.GetOptions
-	}
-
-	result := &TriggerRun{}
-	err = c.apiHandler.Get(ctx, request.Namespace, request.Name, getOptions, result)
-
 	defer c.auditLogEmitter.Emit(ctx, c.buildTriggerRunAuditLogEventForGet(
 		ctx,
 		request,
@@ -270,6 +262,32 @@ func (c triggerRunServiceHandler) GetTriggerRun(
 		err,
 	),
 	)
+
+	// Authentication
+	userAuthenticated, err := c.auth.UserAuthenticated(ctx)
+	if !userAuthenticated {
+		logger.Error(err, "User is not authenticated")
+		metric.Counter("unauthenticated").Inc(1)
+		return nil, err
+	}
+
+	// Authorization
+	projectName := request.Namespace
+	userAuthorized, err := c.auth.UserAuthorized(ctx, projectName, authapi.Get, "TriggerRun")
+
+	if !userAuthorized {
+		logger.Error(err, "User is not authorized")
+		metric.Counter("unauthorized").Inc(1)
+		return nil, err
+	}
+
+	getOptions := &metav1.GetOptions{}
+	if request.GetOptions != nil {
+		getOptions = request.GetOptions
+	}
+
+	result := &TriggerRun{}
+	err = c.apiHandler.Get(ctx, request.Namespace, request.Name, getOptions, result)
 
 	if err != nil {
 		logger.Error(err, "Cannot get TriggerRun request info from k8s/ETCD", "error", err, "api_msg_tag", "GetTriggerRun")
@@ -535,6 +553,32 @@ func (c triggerRunServiceHandler) ListTriggerRun(
 		logging.NamespaceTag:    request.Namespace,
 	})
 
+	defer c.auditLogEmitter.Emit(ctx, c.buildTriggerRunAuditLogEventForList(
+		ctx,
+		request,
+		resp,
+		err,
+	),
+	)
+
+	// Authentication
+	userAuthenticated, err := c.auth.UserAuthenticated(ctx)
+	if !userAuthenticated {
+		logger.Error(err, "User is not authenticated")
+		metric.Counter("unauthenticated").Inc(1)
+		return nil, err
+	}
+
+	// Authorization
+	projectName := request.Namespace
+	userAuthorized, err := c.auth.UserAuthorized(ctx, projectName, authapi.List, "TriggerRun")
+
+	if !userAuthorized {
+		logger.Error(err, "User is not authorized")
+		metric.Counter("unauthorized").Inc(1)
+		return nil, err
+	}
+
 	result := &TriggerRunList{}
 	listOptions := &metav1.ListOptions{}
 	if request.ListOptions != nil {
@@ -545,14 +589,6 @@ func (c triggerRunServiceHandler) ListTriggerRun(
 		listOptionsExt = request.ListOptionsExt
 	}
 	err = c.apiHandler.List(ctx, request.Namespace, listOptions, listOptionsExt, result)
-
-	defer c.auditLogEmitter.Emit(ctx, c.buildTriggerRunAuditLogEventForList(
-		ctx,
-		request,
-		resp,
-		err,
-	),
-	)
 
 	if err != nil {
 		logger.Error(err, "API Handler failed to List TriggerRun", "error", err, "api_msg_tag", "ListTriggerRun")


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

- `go/kubeproto/templates/crd_svc.tmpl`: the generated `Get*` and `List*` handlers now carry the same authentication + authorization block as Create/Update/Delete/DeleteCollection, using `authapi.Get` / `authapi.List` as the action and `request.Namespace` as the project (matching the Delete handlers, which also authorize from the request's namespace).
- The audit-log `defer` in Get/List moves ahead of the auth checks, so denied requests are audit-logged -- the ordering the four mutating handlers already have.
- `proto-go/api/v2/*.pb.kubeyarpc.go`: regenerated with `tools/gen-proto-go.sh` -- all 15 generated services change uniformly, no hand edits. Every service now has 6 auth call-sites (was 4).

**Why?**

Fixes #1851. The codegen template emits an authn + authz block in every mutating handler, but Get and List handlers were generated with no auth calls at all -- even though the `Action` enum in `go/auth/auth.go` has always defined `Get` and `List` as first-class values. With the shipped `DummyAuth` this is inert; for any operator wiring a real `Auth` implementation, every read endpoint silently bypassed authorization.

**How did you test it?**

- `tools/gen-proto-go.sh` run end-to-end: the diff is exactly the template plus the 15 generated service files, uniformly, gofmt-formatted by the real pipeline -- confirming no other drift against the templates.
- `bazel build //go/cmd/apiserver:apiserver` succeeds with the regenerated handlers; `bazel test //go/kubeproto/... //go/auth/...` 8/8 pass; `bazel test //go/cmd/kubeproto/...` (the generator's own tests) 4/4 pass.
- Re-validated after rebasing onto current main: `go build ./...` in `proto-go`, `go build ./cmd/apiserver`, and `go test ./kubeproto/... ./auth/... ./cmd/kubeproto/...` all pass. No codegen inputs (protos, templates, generator, `tools/gen-proto-go.sh`) changed upstream since the snapshot was regenerated, so it is exact at HEAD.
- Grep verification: `UserAuthenticated`/`UserAuthorized` now appear in all six handler kinds in every generated service, and only there.

**Potential risks**

Behavior-preserving as shipped: `DummyAuth.UserAuthorized` ignores its `Action` argument and returns true, so responses are unchanged until an operator supplies a real `Auth` implementation. Once a real implementation is wired, read endpoints start enforcing authorization -- that is the point of the fix, but an implementation that never expected `Get`/`List` actions will now receive them. Semantics note: a cluster-wide List (empty `request.Namespace`) passes an empty project string to `UserAuthorized` -- the same contract DeleteCollection already has; this PR keeps that consistent rather than inventing new semantics.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

Generated Get/List handlers now consult the `Auth` interface (`authapi.Get` / `authapi.List`). No behavior change under the default `DummyAuth`.

**Documentation Changes**

None -- the `Auth` interface itself is unchanged; a note on empty-project semantics for cluster-wide List could go in the interface docs as a follow-up.
