### PR TITLE
fix: route go-vet pre-commit hook through bazel nogo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,8 +29,8 @@ repos:
         language: system
         files: ^go/.*\.go$
       - id: go-vet
-        name: go vet
-        entry: bash -c 'cd go && go vet ./...'
+        name: go vet (via bazel nogo)
+        entry: bash -c './tools/bazel build //go/...'
         language: system
         files: ^go/.*\.go$
         pass_filenames: false


### PR DESCRIPTION
## Summary
Route the `go-vet` pre-commit hook through `./tools/bazel build //go/...` instead of plain `go vet ./...`.

Plain `go vet ./...` fails repo-wide because gomock mock packages for proto v2 service clients (e.g. `v2mock`) are wired up as Bazel-virtual import paths with no physical package on disk. This meant any commit touching `go/`, even completely unrelated to these mocks, tripped the local `go-vet` pre-commit hook.

## Test plan

- I ran the fixed hook against `go/worker/activities/trigger/` and `go/worker/activities/cachedoutput/` and confirmed the Bazel-only mock imports no longer error.
- I introduced a scratch printf-format vet violation and confirmed `nogo` still flagged it, then removed the scratch file.