### PR TITLE
fix(core): title-case Data Sources, Evaluations, and Notebooks entity names

### DIFF
--- a/javascript/packages/core/config/phases/data.ts
+++ b/javascript/packages/core/config/phases/data.ts
@@ -16,7 +16,7 @@ export const DATA_PHASE: PhaseConfig = {
     { ...RUN_ENTITY_CONFIG, state: 'disabled' },
     {
       id: 'datasources',
-      name: 'data sources',
+      name: 'Data Sources',
       state: 'disabled',
       service: 'datasource',
       views: [],

--- a/javascript/packages/core/config/phases/train.ts
+++ b/javascript/packages/core/config/phases/train.ts
@@ -21,14 +21,14 @@ export const TRAIN_PHASE: PhaseConfig = {
     MODEL_ENTITY_CONFIG,
     {
       id: 'evaluations',
-      name: 'evaluations',
+      name: 'Evaluations',
       state: 'disabled',
       service: 'evaluationReport',
       views: [],
     },
     {
       id: 'notebooks',
-      name: 'notebooks',
+      name: 'Notebooks',
       state: 'disabled',
       service: 'notebook',
       views: [],


### PR DESCRIPTION
## Summary
- Three entity names in the phase config were still hardcoded in lowercase (`data sources`, `evaluations`, `notebooks`), left over from before entity names stopped being auto-capitalized for display (#1846). Every other entity name already used proper case in its config.
- Titles them consistently with the rest of the phase/entity names: "Data Sources", "Evaluations", "Notebooks".

## Test plan
- Ran the affected test suites (breadcrumb menu drawer, project detail) — all pass, unaffected since they use mocked phase data.
- Ran `yarn typecheck` and `yarn lint --quiet` — clean.
- Verified visually against a running dev server.