### PR TITLE
helm: add optional CRD-gated ServiceMonitor for the controller manager

### DIFF
--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -111,6 +111,30 @@ jobs:
             --set temporal.server.config.persistence.visibility.sql.password=root \
             2>/dev/null
 
+      - name: Template — monitoring enabled (ServiceMonitor renders with CRDs present)
+        run: |
+          helm template michelangelo helm/michelangelo \
+            -f helm/michelangelo/values-k3d.yaml \
+            --set monitoring.enabled=true \
+            --api-versions monitoring.coreos.com/v1 \
+            --debug \
+            | grep 'kind: ServiceMonitor'
+
+      - name: Template — monitoring enabled without CRDs (must skip gracefully)
+        run: |
+          ! helm template michelangelo helm/michelangelo \
+            -f helm/michelangelo/values-k3d.yaml \
+            --set monitoring.enabled=true \
+            | grep 'kind: ServiceMonitor'
+
+      - name: Validate fail-fast guard (monitoring without controllermgr must fail)
+        run: |
+          ! helm template michelangelo helm/michelangelo \
+            -f helm/michelangelo/values-k3d.yaml \
+            --set monitoring.enabled=true \
+            --set controllermgr.enabled=false \
+            2>/dev/null
+
       - name: Template — Ingress enabled (UI + Envoy, hosts[] syntax)
         run: |
           helm template michelangelo helm/michelangelo \

--- a/docs/operator-guides/operations/monitoring.md
+++ b/docs/operator-guides/operations/monitoring.md
@@ -14,7 +14,16 @@ Michelangelo AI components expose Prometheus metrics that integrate with a stand
 
 ### Controller Manager
 
-The controller manager exposes metrics on port `8091` (configured via `metricsBindAddress`). If you are using the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator), create a `ServiceMonitor`:
+The controller manager exposes metrics on port `8091` (configured via `metricsBindAddress`). If you are using the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator), the Helm chart can create the `ServiceMonitor` for you:
+
+```bash
+helm upgrade michelangelo ./helm/michelangelo --reuse-values \
+  --set monitoring.enabled=true
+```
+
+The resource is only rendered when the Prometheus Operator CRDs (`monitoring.coreos.com/v1`) are installed, so the toggle is a safe no-op on clusters without the operator. Scrape interval and extra labels (e.g. to match your Prometheus instance's `serviceMonitorSelector`) are configurable under `monitoring.serviceMonitor.*`.
+
+To create the `ServiceMonitor` yourself instead, select the controller manager Service by its chart labels:
 
 ```yaml
 apiVersion: monitoring.coreos.com/v1
@@ -22,12 +31,12 @@ kind: ServiceMonitor
 metadata:
   name: michelangelo-controllermgr
   namespace: ma-system
-  labels:
-    app: michelangelo-controllermgr
 spec:
   selector:
     matchLabels:
-      app: michelangelo-controllermgr
+      app.kubernetes.io/name: michelangelo
+      app.kubernetes.io/instance: michelangelo   # your Helm release name
+      app.kubernetes.io/component: controllermgr
   endpoints:
   - port: metrics          # Must match the Service port name for port 8091
     path: /metrics
@@ -36,12 +45,12 @@ spec:
 
 ### Health Probes
 
-The controller manager exposes health endpoints on port `8083` (configured via `healthProbeBindAddress`):
+The controller manager exposes health endpoints on port `8081` (configured via `healthProbeBindAddress`; the chart default is `controllermgr.healthPort: 8081`):
 
 | Endpoint | Purpose |
 |----------|---------|
-| `GET :8083/healthz` | Liveness — is the process alive? |
-| `GET :8083/readyz` | Readiness — is the controller ready to reconcile? |
+| `GET :8081/healthz` | Liveness — is the process alive? |
+| `GET :8081/readyz` | Readiness — is the controller ready to reconcile? |
 
 These are used by Kubernetes liveness and readiness probes, but you can also poll them from your monitoring stack for coarser-grained health checks.
 

--- a/helm/michelangelo/README.md
+++ b/helm/michelangelo/README.md
@@ -279,6 +279,10 @@ Top-level keys. See [`values.yaml`](./values.yaml) for the full annotated schema
 | `worker.replicas` | int | `1` | no | Scale horizontally for higher pipeline-run throughput. |
 | `controllermgr.enabled` | bool | `true` | no | |
 | `controllermgr.watchNamespace` | list | `[]` | no | Namespaces the controller watches. Empty = all namespaces (ClusterRole). Set to a list to scope down to namespaced Roles. |
+| `monitoring.enabled` | bool | `false` | no | Master toggle for chart-managed monitoring resources. All resources are CRD-gated: skipped when the owning operator's CRDs are absent, so enabling this is safe on any cluster. |
+| `monitoring.serviceMonitor.enabled` | bool | `true` | no | Create a `ServiceMonitor` for the controller manager's `/metrics` endpoint (requires the Prometheus Operator CRDs, `monitoring.coreos.com/v1`). |
+| `monitoring.serviceMonitor.interval` | string | `30s` | no | Scrape interval. |
+| `monitoring.serviceMonitor.additionalLabels` | object | `{}` | no | Extra labels on the `ServiceMonitor`, e.g. to match a Prometheus instance's `serviceMonitorSelector`. |
 | `serviceAccount.create` | bool | `true` | no | Create a ServiceAccount for the chart. |
 | `serviceAccount.name` | string | `""` | no | Override the generated ServiceAccount name. |
 | `podSecurityContext` | object | see values.yaml | no | Applied to every Pod. |

--- a/helm/michelangelo/templates/monitoring/servicemonitor-controllermgr.yaml
+++ b/helm/michelangelo/templates/monitoring/servicemonitor-controllermgr.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.monitoring.enabled .Values.monitoring.serviceMonitor.enabled .Values.controllermgr.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "michelangelo.componentFullname" (dict "context" . "component" "controllermgr") }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "michelangelo.componentLabels" (dict "context" . "component" "controllermgr") | nindent 4 }}
+    {{- with .Values.monitoring.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "michelangelo.componentSelectorLabels" (dict "context" . "component" "controllermgr") | nindent 6 }}
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.monitoring.serviceMonitor.interval }}
+{{- end }}

--- a/helm/michelangelo/templates/validations.yaml
+++ b/helm/michelangelo/templates/validations.yaml
@@ -5,3 +5,6 @@ This file renders to empty YAML when all checks pass.
 {{- if and .Values.cadence.enabled .Values.temporal.enabled -}}
 {{- fail "cadence.enabled and temporal.enabled cannot both be true — pick one workflow engine per release. Set workflow.engine=cadence + cadence.enabled=true, OR workflow.engine=temporal + temporal.enabled=true. See helm/michelangelo/README.md." -}}
 {{- end -}}
+{{- if and .Values.monitoring.enabled (not .Values.controllermgr.enabled) -}}
+{{- fail "monitoring.enabled requires controllermgr.enabled=true — the controller manager is the only component exposing a /metrics endpoint. See helm/michelangelo/README.md." -}}
+{{- end -}}

--- a/helm/michelangelo/values.yaml
+++ b/helm/michelangelo/values.yaml
@@ -448,6 +448,29 @@ controllermgr:
   resources: {}
 
 # -----------------------------------------------------------------------------
+# Optional monitoring resources. Everything here is CRD-gated: resources are
+# only rendered when the owning operator's CRDs are installed in the cluster,
+# so enabling the toggle on a cluster without the Prometheus Operator is a
+# safe no-op.
+# -----------------------------------------------------------------------------
+monitoring:
+  # Master toggle for chart-managed monitoring resources.
+  enabled: false
+
+  serviceMonitor:
+    # Scrape the controller manager's /metrics endpoint (port
+    # controllermgr.metricsPort). Requires the Prometheus Operator CRDs
+    # (monitoring.coreos.com/v1); skipped when they are absent.
+    enabled: true
+
+    # Scrape interval.
+    interval: 30s
+
+    # Extra labels for the ServiceMonitor, e.g. to match a Prometheus
+    # instance's serviceMonitorSelector.
+    additionalLabels: {}
+
+# -----------------------------------------------------------------------------
 # ServiceAccount used by every chart-managed Pod.
 # -----------------------------------------------------------------------------
 serviceAccount:


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**

First slice of the observability starter pack (#1692): a `monitoring.enabled` toggle (default off) that creates a `ServiceMonitor` for the controller manager's `/metrics` endpoint -- the only component that exposes one today.

```yaml
monitoring:
  enabled: true
  serviceMonitor:
    interval: 30s
    additionalLabels: {}   # e.g. to match a Prometheus serviceMonitorSelector
```

The resource is gated on `.Capabilities.APIVersions.Has "monitoring.coreos.com/v1"`, so enabling the toggle on a cluster without the Prometheus Operator is a safe no-op -- matching the issue's "skipped when the operators are absent" intent. A validation guard fails fast if `monitoring.enabled=true` with `controllermgr.enabled=false`.

Two drive-by fixes in the monitoring guide, since this PR ships the exact resource it describes:

- the ServiceMonitor example used an `app: michelangelo-controllermgr` label that doesn't match the chart's real selector labels (`app.kubernetes.io/name` / `instance` / `component`) -- corrected, and the guide now leads with the chart-managed path
- the health-probe port is `8081` (chart default `controllermgr.healthPort`), not `8083`

Follow-up PRs in this series: PrometheusRule starter alerts, GrafanaDashboard CRs, and a docs pass. The per-job scrape ConfigMap named in the issue (item 3) is deferred -- it needs `FederatedClient.CreatePromConfigMap` call-site work, which is a code change rather than installable YAML.

**Why?**

#1692 lays out the gap: the chart deploys the platform with zero scrape configuration, alerts, or dashboards, and the monitoring guide asks operators to hand-write resources (with examples that do not match the chart's labels). This starts closing that gap with the smallest installable piece, wired the same way other optional chart features are.

**How did you test it?**

- `helm lint` clean; all checks re-run on top of current main before posting.
- Default render is byte-identical to main (verified by diffing full `helm template -f values-k3d.yaml` output against a clean main worktree) -- strictly additive.
- Rendered ServiceMonitor's `selector.matchLabels` verified to exactly match the controllermgr Service's labels, and the `metrics` endpoint port name matches the Service port.
- New CI checks in `helm-lint.yaml`: monitoring-enabled render with `--api-versions monitoring.coreos.com/v1` asserts the resource renders; without it, asserts it is skipped; negative test for the controllermgr guard. All three verified locally with the exact CI invocations.

**Potential risks**

- None for existing deployments: the toggle defaults to off and the default render is byte-identical to main.
- The CRD gate uses `.Capabilities.APIVersions`, which is populated from the cluster on real installs but empty under bare `helm template`; anyone rendering manifests offline for a cluster that has the Prometheus Operator needs `--api-versions monitoring.coreos.com/v1`. The values comment says so.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

Added an optional `monitoring.enabled` chart toggle that creates a ServiceMonitor for the controller manager when the Prometheus Operator CRDs are present. Default off; no action needed for existing deployments. Also corrected the label selector and health-probe port in the monitoring guide's examples.

**Documentation Changes**

`docs/operator-guides/operations/monitoring.md` now leads with the chart-managed ServiceMonitor path and its examples match the chart's real labels and ports. `helm/michelangelo/README.md` documents the new values.
