### PR TITLE
docs: revert getting-started.md tutorial to xgb_train (pytorch_train crashes on Apple Silicon)

### DIFF
--- a/docs/user-guides/getting-started/getting-started.md
+++ b/docs/user-guides/getting-started/getting-started.md
@@ -9,7 +9,7 @@ By the end of this guide you'll have a working pipeline that looks like this:
 ```
 dataset_cols
     └─▶ feature_prep()    # Ray task: downloads data, splits into train/validation
-            └─▶ train()   # Ray task: trains a PyTorch Lightning model on the splits
+            └─▶ train()   # Ray task: trains XGBoost model on the splits
 ```
 
 Each step runs as an isolated, containerized task. Michelangelo AI handles data passing between them, caches intermediate results, and retries on transient failures — your code stays plain Python.
@@ -28,6 +28,7 @@ Each step runs as an isolated, containerized task. Michelangelo AI handles data 
 * Java 17 with `JAVA_HOME` set — required for the Spark preprocessing step. Java 21 is not compatible with PySpark 3.5 + Hadoop 3.3 (`getSubject is not supported` error). On macOS: `brew install openjdk@17` then `export JAVA_HOME=$(brew --prefix openjdk@17)/libexec/openjdk.jdk/Contents/Home`
 * For remote runs: Docker and access to a Kubernetes cluster (or use the [local sandbox](../../getting-started/sandbox-setup.md))
 * [Create a project](./project-management-for-ml-pipelines.md)
+* **macOS only**: XGBoost requires OpenMP (`libomp.dylib`), which is not installed by default. Run `brew install libomp` before installing dependencies.
 
 ## Environment setup
 
@@ -140,9 +141,12 @@ def train_workflow(dataset_cols: str):
         train_dv=train_dv,
         validation_dv=validation_dv,
         params={
-            "max_epochs": 5,
-            "batch_size": 64,
-            "precision": "32",
+            "objective": "reg:squarederror",
+            "colsample_bytree": 0.3,
+            "learning_rate": 0.1,
+            "max_depth": 5,
+            "alpha": 10,
+            "n_estimators": 10,
         },
     )
     return result
@@ -180,33 +184,12 @@ The context provides three methods:
 
 Then run it:
 
-The `feature_prep`/`train` workflow above is exactly what the `pytorch_train` pipeline in [`michelangelo-examples`](https://github.com/michelangelo-ai/michelangelo-examples) implements — this tutorial's example now lives there, in its own pip-installable package, rather than in this repo. Install and run it:
-
 ```bash
-pip install "michelangelo-examples[california-housing]"
-python -m michelangelo_examples.california_housing.pipelines.pytorch_train.pipeline
+cd michelangelo/python
+PYTHONPATH=. poetry run python examples/pipelines/california_housing_xgb/california_housing_xgb.py
 ```
 
-Local runs execute everything in your Python interpreter with zero additional infrastructure setup (beyond the one-time `pip install` above) — the fastest way to iterate on your workflow logic.
-
-> **Why a separate repo?** Heavier example pipelines with their own dependency
-> footprint (here, Spark + PyTorch Lightning) live in
-> [`michelangelo-examples`](https://github.com/michelangelo-ai/michelangelo-examples)
-> to keep this core repo's own dependencies lean. Lighter in-repo examples
-> like `bert_cola` (`python/examples/bert_cola/`) are unrelated to this
-> tutorial's pipeline but still run directly from this checkout:
-> ```bash
-> cd michelangelo/python
-> PYTHONPATH=. poetry run python examples/bert_cola/bert_cola.py
-> ```
->
-> `pytorch_train` also ships a separate, lighter-weight local-only trainer
-> (`python -m michelangelo_examples.california_housing.pipelines.pytorch_train`,
-> no `.pipeline` suffix) that trains directly with plain PyTorch
-> Lightning — no Ray, Spark, or Uniflow context at all. That script is a
-> standalone quick-start, not the `ctx.run(train_workflow)` pattern this
-> tutorial teaches; use the `.pipeline`-suffixed command above to run the
-> actual workflow you just wrote.
+Local runs execute everything in your Python interpreter with zero infrastructure setup. This is the fastest way to iterate on your workflow logic.
 
 ## Step 4: Run remotely
 
@@ -215,29 +198,19 @@ When you need more compute power or want to validate against production infrastr
 ### Build and push a Docker image
 
 ```bash
-# From the michelangelo-examples repo checkout:
-docker build -t michelangelo-examples:local .
-k3d image import michelangelo-examples:local -c michelangelo-sandbox
+docker build -t my-workflow:latest -f ./examples/Dockerfile .
+k3d image import my-workflow:latest -c michelangelo-sandbox
 ```
 
 ### Run with remote execution
 
 ```bash
-python -m michelangelo_examples.california_housing.pipelines.pytorch_train.pipeline \
-  remote-run \
-  --image docker.io/library/michelangelo-examples:local \
-  --storage-url s3://michelangelo/workflows \
-  --environ AWS_ENDPOINT_URL=http://minio:9091 \
-  --environ AWS_ACCESS_KEY_ID=minioadmin \
-  --environ AWS_SECRET_ACCESS_KEY=minioadmin \
-  --environ REGISTRY_ENDPOINT=michelangelo-apiserver:15566 \
+PYTHONPATH=. poetry run python examples/pipelines/california_housing_xgb/california_housing_xgb.py remote-run \
+  --image docker.io/library/my-workflow:latest \
+  --storage-url s3://my-bucket/workflows \
   --yes
 ```
-> **Sandbox storage URL**: the `michelangelo` bucket is created automatically
-> by `ma sandbox create`. The `--environ` flags inject credentials into the
-> Cadence/Temporal workflow so they reach remote Ray/Spark workers. See the
-> [`pytorch_train` README](https://github.com/michelangelo-ai/michelangelo-examples/tree/main/src/michelangelo_examples/california_housing/pipelines/pytorch_train)
-> for the full environment variable reference.
+**Sandbox storage URL**: the `michelangelo` bucket is created automatically by `ma sandbox create`. For other environments replace with your own S3-compatible bucket URL.
 
 Remote runs execute workflow code in a Cadence/Temporal worker and task code in Kubernetes containers with full resource isolation. For detailed remote setup instructions including sandbox configuration, see [Running Uniflow pipelines](../ml-pipelines/running-uniflow.md).
 
@@ -250,15 +223,11 @@ To manage your workflow through MA Studio and the `ma` CLI, register it as a pip
 Pipelines belong to a project. Create one first using the example project config:
 
 ```bash
-# From the michelangelo-examples repo:
-ma project apply -f src/michelangelo_examples/california_housing/config/project.yaml
+ma project apply -f examples/config/project.yaml
 ```
 
-This creates the `california-housing` project with its namespace. The project
-config is specific to `michelangelo-examples`' California Housing pipelines
-and is separate from the core repo's `python/examples/config/project.yaml`
-(which registers the `ma-examples` project for examples that remain in this
-monorepo, such as `workflow_patterns`).
+This creates the `ma-examples` project with its namespace. The project config at
+`examples/config/project.yaml` defines ownership, tier, and repository metadata.
 For details on project configuration, see
 [Project Management for ML Pipelines](./project-management-for-ml-pipelines.md).
 
@@ -271,30 +240,35 @@ annotation specifies the Docker image that runs your task code in Kubernetes:
 apiVersion: michelangelo.api/v2
 kind: Pipeline
 metadata:
-  namespace: "california-housing"
-  name: "pytorch-train"
+  namespace: "ma-examples"
+  name: "california-housing-xgb"
   annotations:
-    michelangelo/uniflow-image: ghcr.io/michelangelo-ai/michelangelo-examples:california-housing
+    michelangelo/uniflow-image: docker.io/library/my-workflow:latest # Example: ghcr.io/michelangelo-ai/examples:main
 spec:
   type: "PIPELINE_TYPE_TRAIN"
   manifest:
-    filePath: michelangelo_examples.california_housing.pipelines.pytorch_train.pipeline
+    filePath: examples.pipelines.california_housing_xgb.california_housing_xgb
 ```
 
-The California Housing PyTorch Lightning example includes this manifest at
-`src/michelangelo_examples/california_housing/pipelines/pytorch_train/pipeline.yaml`
-in the [`michelangelo-examples`](https://github.com/michelangelo-ai/michelangelo-examples) repo.
+The California Housing XGBoost example includes this manifest at
+`examples/pipelines/california_housing_xgb/pipeline.yaml`.
+
+> **Sandbox tip:** the `michelangelo/uniflow-image` annotation controls which
+> Docker image runs your tasks. For a k3d sandbox, build the image from Step 4
+> (`docker build -t my-workflow:latest -f ./examples/Dockerfile .`) and import
+> it with `k3d image import`. The `ghcr.io/michelangelo-ai/examples:main`
+> image is published by CI for production deployments.
 
 ### Register the pipeline
 
 ```bash
-ma pipeline apply -f src/michelangelo_examples/california_housing/pipelines/pytorch_train/pipeline.yaml
+ma pipeline apply -f examples/pipelines/california_housing_xgb/pipeline.yaml
 ```
 
 ### Run the registered pipeline
 
 ```bash
-ma pipeline run -n california-housing --name pytorch-train
+ma pipeline run --namespace ma-examples --name california-housing-xgb
 ```
 
 ## Workflow constraints
@@ -367,7 +341,7 @@ def train_workflow(dataset_cols: str):
 
 ## Complete example
 
-See the full California Housing PyTorch Lightning example at [`pytorch_train/`](https://github.com/michelangelo-ai/michelangelo-examples/tree/main/src/michelangelo_examples/california_housing/pipelines/pytorch_train) in the [michelangelo-examples](https://github.com/michelangelo-ai/michelangelo-examples) repo. This example demonstrates:
+See the full California Housing XGBoost example at [`python/examples/pipelines/california_housing_xgb/`](https://github.com/michelangelo-ai/michelangelo/tree/main/python/examples/pipelines/california_housing_xgb). This example demonstrates:
 
 * **Heterogeneous workflow**: Ray tasks for data prep and training, Spark task for preprocessing
 * **Task caching**: Reuse feature preparation results across runs


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**

Reverts `docs/user-guides/getting-started/getting-started.md`'s tutorial to its pre-#1749 state, teaching the in-core XGBoost pipeline (`python/examples/pipelines/california_housing_xgb/`) again instead of `michelangelo-examples`' `pytorch_train` (PyTorch Lightning). No other file from #1749 is touched — `docs/getting-started/sandbox-setup.md`, `docs/user-guides/examples/index.md`, and `docs/user-guides/ml-pipelines/workflow-patterns.md`'s repoints to `michelangelo-examples` are unaffected and still correct.

**Why?**

#1749 switched the tutorial's flagship worked example to `pytorch_train`. Its documented local-run command (`python -m michelangelo_examples.california_housing.pipelines.pytorch_train.pipeline`) crashes on any Apple Silicon Mac:

```
ValueError: You set `strategy=<...RayDDPStrategy...>` but strategies from the DDP
family are not supported on the MPS accelerator. Either explicitly set
`accelerator='cpu'` or change the strategy.
```

Root-caused and tracked as issue #1867, with a design already written up (fix requires adding a new `accelerator` field to core `michelangelo`'s `LightningTrainerKwargs` — not something fixable from docs or from `michelangelo-examples` alone, since that dataclass has no such field today). Also confirmed `RayDeepSpeedStrategy` doesn't sidestep this — it's a subclass of Lightning's own `DDPStrategy`/`ParallelStrategy`, so it hits the identical MPS rejection.

Until #1867's fix ships, `pytorch_train`'s local-run path is broken for a likely-large fraction of individual contributors' dev machines (any Apple Silicon Mac). The in-core XGBoost example has no PyTorch/MPS dependency at all and runs clean end-to-end (re-verified locally, no manual workarounds). Reverting the tutorial back to it keeps `getting-started.md` trustworthy in the meantime; the switch to `pytorch_train` can be reinstated once #1867 is fixed and released.

**How did you test it?**

- Confirmed no other commit touched `getting-started.md` between #1749's merge and this PR's base, so this is a clean, non-lossy revert of just that file.
- Confirmed the restored content's pipeline (`california_housing_xgb`) still exists in-core (not yet deleted — #1751, the PR that removes it, is still open/unmerged) and has no PyTorch/Lightning/MPS/DDP references at all.
- Re-ran the restored tutorial's documented local-run command against a fresh `origin/main` checkout — completes cleanly, no manual workaround.

**Potential risks**

None beyond a temporary doc/tutorial content change. No code changes.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

N/A

**Documentation Changes**

Yes — reverts the getting-started tutorial's flagship example from `pytorch_train` back to the in-core XGBoost pipeline, until #1867 (`pytorch_train` crashes on Apple Silicon) is fixed.