### PR TITLE
feat(trainer): add an MLflow-backed ExperimentStore for auto-resume

### DIFF
--- a/docs/operator-guides/integrations/mlflow.md
+++ b/docs/operator-guides/integrations/mlflow.md
@@ -182,6 +182,39 @@ Users are responsible for:
 
 ---
 
+## Auto-Resume with MlflowExperimentStore
+
+The [`michelangelo.lib.trainer.torch.pytorch_lightning`](https://github.com/michelangelo-ai/michelangelo/tree/main/python/michelangelo/lib/trainer/torch/pytorch_lightning) trainer supports automatic resumption of interrupted training runs through a pluggable `ExperimentStore`. By default, resume markers are written to the run's storage filesystem (`FsspecExperimentStore`). If your organization already runs an MLflow Tracking Server, `MlflowExperimentStore` records those markers as tagged runs on the MLflow server instead, which makes resume state centrally visible and works even when the storage path is not conveniently listable.
+
+Requires the `mlflow` package in the training image (the `trainer-mlflow` extra: `pip install 'michelangelo[trainer-mlflow]'`).
+
+```python
+from michelangelo.lib.trainer.torch.pytorch_lightning import (
+    LightningTrainerParam,
+    MlflowExperimentStore,
+)
+
+param = LightningTrainerParam(
+    create_model_fn=my_model_factory,
+    create_model_fn_kwargs={},
+    train_data=train_ds,
+    val_data=val_ds,
+    experiment_store=MlflowExperimentStore(
+        tracking_uri="http://mlflow.example.com:5000",
+        experiment_name="team-x-resume",
+    ),
+)
+```
+
+Behavior and configuration notes:
+
+- **Server and credentials follow MLflow's native environment contract.** If `tracking_uri` is omitted, the client resolves `MLFLOW_TRACKING_URI` from the environment. Authentication uses `MLFLOW_TRACKING_USERNAME` / `MLFLOW_TRACKING_PASSWORD` / `MLFLOW_TRACKING_TOKEN`, exactly as in Step 3 above. Credentials are deliberately not constructor arguments: the store is shipped to Ray workers inside the (logged) training loop config, so secrets must stay in the environment.
+- **Best-effort by design.** A marker write or lookup failure (unreachable server, missing `mlflow` package, auth error) is logged and swallowed. It never fails a training run; the run simply starts fresh instead of resuming.
+- **One marker run per training attempt.** Each attempt records a new, immediately terminated MLflow run tagged with the training run's identity; resume uses the most recent marker. Markers accumulate in the dedicated experiment (default name `michelangelo-resume`).
+- **Use a distinct `experiment_name` per project** when multiple teams share one MLflow server, so unrelated projects' markers stay in separate MLflow experiments.
+
+---
+
 ## MLflow Model Registry vs Michelangelo AI Model Registry
 
 MLflow includes its own model registry. Michelangelo AI also has a built-in model registry backed by a `Model` Kubernetes custom resource. The two are independent and can be used simultaneously.

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/__init__.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/__init__.py
@@ -17,7 +17,9 @@ Public surface re-exported below:
   :class:`ModelSpec`, :class:`TrainingType`, :class:`LearningMode` — warm-start
   schema types consumed by the trainer.
 * :class:`ExperimentStore` — pluggable auto-resume seam;
-  :class:`FsspecExperimentStore` is the filesystem default.
+  :class:`FsspecExperimentStore` is the filesystem default and
+  :class:`MlflowExperimentStore` records markers on an MLflow tracking server
+  (requires the ``trainer-mlflow`` extra).
 * :func:`comet_profiler_sink` — ready-made ``LightningTrainerParam.profiler_sink``
   that ships profiler output to a Comet experiment.
 * :func:`mlflow_profiler_sink` — ready-made ``LightningTrainerParam.profiler_sink``
@@ -30,6 +32,9 @@ from michelangelo.lib.trainer.torch.pytorch_lightning._private.util import (
 )
 from michelangelo.lib.trainer.torch.pytorch_lightning.experiment_store import (
     FsspecExperimentStore,
+)
+from michelangelo.lib.trainer.torch.pytorch_lightning.experiment_store_mlflow import (
+    MlflowExperimentStore,
 )
 from michelangelo.lib.trainer.torch.pytorch_lightning.lightning_trainer import (
     LightningTrainer,
@@ -54,6 +59,7 @@ __all__ = [
     "LightningTrainer",
     "LightningTrainerParam",
     "LightningTrainerWithStateDict",
+    "MlflowExperimentStore",
     "ModelSpec",
     "TrainingObserver",
     "TrainingType",

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/experiment_store_mlflow.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/experiment_store_mlflow.py
@@ -1,0 +1,261 @@
+"""MLflow-backed :class:`~schema.ExperimentStore` implementation for auto-resume.
+
+Public module: users import and construct :class:`MlflowExperimentStore` and
+pass it as ``LightningTrainerParam.experiment_store`` to opt into auto-resume
+backed by an MLflow tracking server instead of a filesystem marker file.
+See :class:`michelangelo.lib.trainer.torch.pytorch_lightning.schema.ExperimentStore`
+for the seam it implements and
+:class:`~experiment_store.FsspecExperimentStore` for the filesystem default.
+
+Requires the ``mlflow`` optional dependency (the ``trainer-mlflow`` extra).
+The import is deferred to first use, so merely importing this module does not
+require mlflow to be installed.
+"""
+
+from __future__ import annotations
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+# Tag keys carrying the marker payload on each MLflow run. Underscore-joined
+# (no dots) so they never need identifier quoting in a search ``filter_string``.
+# The ``mlflow.`` prefix is reserved by MLflow for system tags; this namespace
+# cannot collide with it.
+_TAG_SCHEMA_VERSION = "michelangelo_resume_schema_version"
+_TAG_RUN_NAME = "michelangelo_resume_run_name"
+_TAG_STORAGE_PATH = "michelangelo_resume_storage_path"
+_TAG_EXPERIMENT_PATH = "michelangelo_resume_experiment_path"
+
+# How many newest candidate runs to fetch per lookup. The tag filter should
+# already narrow to exact matches; the small window only exists so the
+# client-side identity re-check (see ``locate_resumable``) has alternatives if
+# a same-identity run carries an empty payload.
+_SEARCH_WINDOW = 5
+
+
+def _filter_literal(value: str) -> str | None:
+    """Return ``value`` as a quoted MLflow filter string literal, or ``None``.
+
+    MLflow's filter grammar accepts single- or double-quoted string literals
+    but (unlike SQL) supports no escaping *inside* a literal, so the quote
+    style is chosen to avoid the quotes the value contains. A value containing
+    both quote styles cannot be expressed at all — ``None`` signals the caller
+    to treat the lookup as "nothing to resume".
+    """
+    if "'" not in value:
+        return f"'{value}'"
+    if '"' not in value:
+        return f'"{value}"'
+    return None
+
+
+class MlflowExperimentStore:
+    """MLflow-backed :class:`~schema.ExperimentStore` using marker runs.
+
+    Records each training run's experiment directory as a small, immediately
+    terminated MLflow run ("marker run") in a dedicated MLflow experiment,
+    tagged with the stable ``(storage_path, run_name)`` identity. A re-run with
+    the same ``RunConfig(storage_path=..., name=...)`` locates the most recent
+    marker for that identity and resumes from the directory it records.
+
+    Unlike :class:`~experiment_store.FsspecExperimentStore`, MLflow offers no
+    deterministic key-value lookup or atomic overwrite: every :meth:`track`
+    creates a *new* marker run, and :meth:`locate_resumable` returns the most
+    recent one (ordered by start time). "Most recent wins" gives the same
+    end-user semantics as an overwrite, at the cost of one marker run per
+    training attempt accumulating in the MLflow experiment — a deliberate v1
+    tradeoff, kept simple because :meth:`track` runs on worker rank 0 only.
+
+    The tracking server and credentials follow MLflow's native environment
+    contract: ``MLFLOW_TRACKING_URI`` (unless ``tracking_uri`` is passed) and
+    ``MLFLOW_TRACKING_USERNAME`` / ``MLFLOW_TRACKING_PASSWORD`` /
+    ``MLFLOW_TRACKING_TOKEN``. Credentials are deliberately not accepted as
+    constructor arguments: the store is pickled into ``train_loop_config`` and
+    shipped to Ray workers, and that config is logged, so secrets must stay in
+    the environment.
+
+    Neither method raises: :meth:`track` logs and swallows any failure
+    (including mlflow not being installed), and :meth:`locate_resumable`
+    returns ``None`` when there is nothing to resume or the server cannot be
+    reached.
+
+    Example::
+
+        from michelangelo.lib.trainer.torch.pytorch_lightning import (
+            LightningTrainerParam,
+            MlflowExperimentStore,
+        )
+
+        param = LightningTrainerParam(
+            create_model_fn=my_model_factory,
+            create_model_fn_kwargs={},
+            train_data=train_ds,
+            val_data=val_ds,
+            experiment_store=MlflowExperimentStore(
+                tracking_uri="http://mlflow.example.com",
+                experiment_name="team-x-resume",
+            ),
+        )
+
+    Teams sharing one MLflow server should pass a distinct ``experiment_name``
+    per project so unrelated projects' markers stay in separate experiments.
+    """
+
+    _SCHEMA_VERSION = 1
+
+    def __init__(
+        self,
+        tracking_uri: str | None = None,
+        experiment_name: str = "michelangelo-resume",
+    ) -> None:
+        """Initialize the store.
+
+        Args:
+            tracking_uri: MLflow tracking server URI. Defaults to ``None``,
+                which lets the MLflow client resolve ``MLFLOW_TRACKING_URI``
+                from the environment (on the driver and on workers alike).
+            experiment_name: Name of the MLflow experiment holding the marker
+                runs. Created on first :meth:`track` if absent.
+        """
+        self._tracking_uri = tracking_uri
+        self._experiment_name = experiment_name
+
+    def _client(self):
+        """Construct an ``MlflowClient``, importing mlflow lazily.
+
+        Raises:
+            ImportError: If the ``mlflow`` optional dependency is not
+                installed (callers swallow this per the never-raise contract,
+                but the message tells the user how to fix their environment).
+        """
+        try:
+            from mlflow.tracking import MlflowClient
+        except ImportError as exc:
+            raise ImportError(
+                "MlflowExperimentStore requires the 'mlflow' package. Install"
+                " it with the trainer-mlflow extra, e.g."
+                " pip install 'michelangelo[trainer-mlflow]'"
+            ) from exc
+        return MlflowClient(tracking_uri=self._tracking_uri)
+
+    def _ensure_experiment(self, client) -> str:
+        """Return the marker experiment's id, creating the experiment if absent.
+
+        Tolerates the create/create race (two first-ever runs tracking
+        concurrently): a failed ``create_experiment`` falls back to re-reading
+        by name.
+        """
+        experiment = client.get_experiment_by_name(self._experiment_name)
+        if experiment is not None:
+            return experiment.experiment_id
+        try:
+            return client.create_experiment(self._experiment_name)
+        except Exception:
+            # Lost the creation race (or a transient error) — re-read; if the
+            # experiment still does not exist, let the original caller's
+            # exception handling deal with it.
+            experiment = client.get_experiment_by_name(self._experiment_name)
+            if experiment is None:
+                raise
+            return experiment.experiment_id
+
+    def track(self, *, storage_path: str, run_name: str, experiment_path: str) -> None:
+        """Create a marker run recording this run's experiment directory.
+
+        Best-effort: any failure (unreachable server, missing mlflow package,
+        auth error) is logged and swallowed so a failed marker write can never
+        fail an otherwise-successful training run. The marker run is
+        terminated immediately — it exists only to carry tags.
+
+        Args:
+            storage_path: The driver's ``RunConfig.storage_path``.
+            run_name: The driver's ``RunConfig.name``.
+            experiment_path: Absolute path (scheme-qualified for remote
+                filesystems, e.g. ``s3://bucket/runs/my_run``) of this run's
+                Ray Train experiment directory.
+
+        Returns:
+            ``None``.
+        """
+        try:
+            if not storage_path or not run_name:
+                _logger.debug(
+                    "Not tracking resume marker: empty storage_path or run_name"
+                )
+                return
+            client = self._client()
+            experiment_id = self._ensure_experiment(client)
+            run = client.create_run(
+                experiment_id,
+                tags={
+                    _TAG_SCHEMA_VERSION: str(self._SCHEMA_VERSION),
+                    _TAG_RUN_NAME: run_name,
+                    _TAG_STORAGE_PATH: storage_path,
+                    _TAG_EXPERIMENT_PATH: experiment_path,
+                },
+                run_name=run_name,
+            )
+            client.set_terminated(run.info.run_id, status="FINISHED")
+        except Exception:  # best-effort: never fail training
+            _logger.warning("MlflowExperimentStore.track failed", exc_info=True)
+
+    def locate_resumable(self, *, storage_path: str, run_name: str) -> str | None:
+        """Return the most recent marker's experiment path, or ``None``.
+
+        Searches the marker experiment for runs tagged with this exact
+        ``(storage_path, run_name)`` identity, newest first, and returns the
+        recorded experiment path of the first match. Returns ``None`` (never
+        raises) when the experiment does not exist yet, no marker matches, or
+        the server cannot be reached.
+
+        Args:
+            storage_path: The driver's ``RunConfig.storage_path``.
+            run_name: The driver's ``RunConfig.name``.
+
+        Returns:
+            The recorded candidate experiment directory, or ``None``.
+        """
+        try:
+            if not storage_path or not run_name:
+                _logger.debug("No resumable marker: empty storage_path or run_name")
+                return None
+            run_name_literal = _filter_literal(run_name)
+            storage_path_literal = _filter_literal(storage_path)
+            if run_name_literal is None or storage_path_literal is None:
+                _logger.debug(
+                    "No resumable marker: identity contains both quote styles"
+                    " and cannot be expressed in an MLflow search filter"
+                )
+                return None
+            client = self._client()
+            experiment = client.get_experiment_by_name(self._experiment_name)
+            if experiment is None:
+                return None
+            filter_string = (
+                f"tags.{_TAG_RUN_NAME} = {run_name_literal}"
+                f" and tags.{_TAG_STORAGE_PATH} = {storage_path_literal}"
+            )
+            runs = client.search_runs(
+                experiment_ids=[experiment.experiment_id],
+                filter_string=filter_string,
+                order_by=["attributes.start_time DESC"],
+                max_results=_SEARCH_WINDOW,
+            )
+            for run in runs:
+                tags = run.data.tags
+                # Re-check the identity client-side so a filter-escaping edge
+                # case can never resume from another run's directory.
+                if (
+                    tags.get(_TAG_RUN_NAME) == run_name
+                    and tags.get(_TAG_STORAGE_PATH) == storage_path
+                ):
+                    experiment_path = tags.get(_TAG_EXPERIMENT_PATH)
+                    if experiment_path:
+                        return experiment_path
+            return None
+        except Exception:  # unexpected client/server error -> nothing to resume
+            _logger.warning(
+                "MlflowExperimentStore.locate_resumable failed", exc_info=True
+            )
+            return None

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_experiment_store_mlflow.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_experiment_store_mlflow.py
@@ -11,17 +11,20 @@ protocol.
 
 from __future__ import annotations
 
-from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
 # Importing the store pulls in the package ``__init__`` which eagerly imports the
 # Ray/Lightning-backed trainer. Skip cleanly if those heavy deps are missing.
+# mlflow itself is NOT required: the store imports it lazily inside ``_client``
+# and these tests substitute a fake ``mlflow.tracking`` module, so they run in
+# environments (like CI) where the ``trainer-mlflow`` extra is not installed.
 pytest.importorskip("ray")
 pytest.importorskip("torch")
 pytest.importorskip("pytorch_lightning")
-pytest.importorskip("mlflow")
 
 from michelangelo.lib.trainer.torch.pytorch_lightning.experiment_store_mlflow import (
     _TAG_EXPERIMENT_PATH,
@@ -86,12 +89,29 @@ class _FakeMlflowClient:
         return list(reversed(self.runs))[:max_results]
 
 
+def _install_mlflow_stub(monkeypatch, constructor):
+    """Plant stub ``mlflow``/``mlflow.tracking`` modules exposing ``constructor``.
+
+    The store imports mlflow lazily (``from mlflow.tracking import
+    MlflowClient`` inside ``_client``), so seeding ``sys.modules`` makes that
+    import resolve to the stub whether or not real mlflow is installed —
+    letting these tests run in environments without the ``trainer-mlflow``
+    extra (like CI).
+    """
+    tracking = ModuleType("mlflow.tracking")
+    tracking.MlflowClient = constructor
+    mlflow_stub = ModuleType("mlflow")
+    mlflow_stub.tracking = tracking
+    monkeypatch.setitem(sys.modules, "mlflow", mlflow_stub)
+    monkeypatch.setitem(sys.modules, "mlflow.tracking", tracking)
+
+
 @pytest.fixture()
-def fake_client():
-    """A fresh fake client, patched in as the ``MlflowClient`` constructor."""
+def fake_client(monkeypatch):
+    """A fresh fake client, installed as the ``MlflowClient`` constructor."""
     client = _FakeMlflowClient()
-    with patch("mlflow.tracking.MlflowClient", return_value=client):
-        yield client
+    _install_mlflow_stub(monkeypatch, MagicMock(return_value=client))
+    yield client
 
 
 class TestProtocolConformance:
@@ -236,21 +256,21 @@ class TestNothingToResume:
         )
         assert store.locate_resumable(storage_path="/root", run_name="run1") is None
 
-    def test_locate_swallows_client_errors(self):
+    def test_locate_swallows_client_errors(self, monkeypatch):
         """An unreachable server is swallowed; ``locate`` returns ``None``."""
         store = MlflowExperimentStore()
         raising = MagicMock()
         raising.get_experiment_by_name.side_effect = ConnectionError("boom")
-        with patch("mlflow.tracking.MlflowClient", return_value=raising):
-            assert store.locate_resumable(storage_path="/root", run_name="run1") is None
+        _install_mlflow_stub(monkeypatch, MagicMock(return_value=raising))
+        assert store.locate_resumable(storage_path="/root", run_name="run1") is None
 
-    def test_empty_identity_returns_none_without_client(self):
+    def test_empty_identity_returns_none_without_client(self, monkeypatch):
         """Empty ``storage_path``/``run_name`` short-circuits before any client use."""
         store = MlflowExperimentStore()
         constructor = MagicMock()
-        with patch("mlflow.tracking.MlflowClient", constructor):
-            assert store.locate_resumable(storage_path="", run_name="run1") is None
-            assert store.locate_resumable(storage_path="/root", run_name="") is None
+        _install_mlflow_stub(monkeypatch, constructor)
+        assert store.locate_resumable(storage_path="", run_name="run1") is None
+        assert store.locate_resumable(storage_path="/root", run_name="") is None
         constructor.assert_not_called()
 
 
@@ -259,8 +279,6 @@ class TestMlflowNotInstalled:
 
     def test_track_and_locate_degrade_gracefully(self, monkeypatch):
         """With mlflow unimportable, ``track`` swallows and ``locate`` returns None."""
-        import sys
-
         store = MlflowExperimentStore()
         # Making the module entry None causes ``from mlflow.tracking import
         # MlflowClient`` to raise ImportError, simulating a missing extra.
@@ -270,8 +288,6 @@ class TestMlflowNotInstalled:
 
     def test_client_import_error_message_names_the_extra(self, monkeypatch):
         """The ImportError tells the user which extra to install."""
-        import sys
-
         store = MlflowExperimentStore()
         monkeypatch.setitem(sys.modules, "mlflow.tracking", None)
         with pytest.raises(ImportError, match="trainer-mlflow"):
@@ -281,29 +297,25 @@ class TestMlflowNotInstalled:
 class TestTrackNeverRaises:
     """``track`` is best-effort: a failure must never propagate."""
 
-    def test_track_swallows_lost_race_with_vanishing_experiment(self):
+    def test_track_swallows_lost_race_with_vanishing_experiment(self, monkeypatch):
         """Create fails and the re-read still misses → swallowed, no run created."""
         store = MlflowExperimentStore()
         client = MagicMock()
         client.get_experiment_by_name.return_value = None
         client.create_experiment.side_effect = RuntimeError("server hiccup")
-        with patch("mlflow.tracking.MlflowClient", return_value=client):
-            # Must not raise, even though _ensure_experiment re-raises internally.
-            store.track(
-                storage_path="/root", run_name="run1", experiment_path="/exp/dir"
-            )
+        _install_mlflow_stub(monkeypatch, MagicMock(return_value=client))
+        # Must not raise, even though _ensure_experiment re-raises internally.
+        store.track(storage_path="/root", run_name="run1", experiment_path="/exp/dir")
         client.create_run.assert_not_called()
 
-    def test_track_swallows_client_errors(self):
+    def test_track_swallows_client_errors(self, monkeypatch):
         """An unreachable server during ``track`` does not propagate."""
         store = MlflowExperimentStore()
         raising = MagicMock()
         raising.get_experiment_by_name.side_effect = ConnectionError("boom")
-        with patch("mlflow.tracking.MlflowClient", return_value=raising):
-            # Must not raise.
-            store.track(
-                storage_path="/root", run_name="run1", experiment_path="/exp/dir"
-            )
+        _install_mlflow_stub(monkeypatch, MagicMock(return_value=raising))
+        # Must not raise.
+        store.track(storage_path="/root", run_name="run1", experiment_path="/exp/dir")
 
     def test_track_with_empty_identity_writes_nothing(self, fake_client):
         """Empty ``storage_path``/``run_name`` short-circuits: no run created."""
@@ -312,7 +324,7 @@ class TestTrackNeverRaises:
         store.track(storage_path="/root", run_name="", experiment_path="/exp")
         assert fake_client.runs == []
 
-    def test_track_survives_experiment_creation_race(self):
+    def test_track_survives_experiment_creation_race(self, monkeypatch):
         """Losing the create-experiment race falls back to the winner's id."""
         store = MlflowExperimentStore()
         client = MagicMock()
@@ -324,10 +336,8 @@ class TestTrackNeverRaises:
             info=SimpleNamespace(run_id="run-1"),
             data=SimpleNamespace(tags={}),
         )
-        with patch("mlflow.tracking.MlflowClient", return_value=client):
-            store.track(
-                storage_path="/root", run_name="run1", experiment_path="/exp/dir"
-            )
+        _install_mlflow_stub(monkeypatch, MagicMock(return_value=client))
+        store.track(storage_path="/root", run_name="run1", experiment_path="/exp/dir")
         client.create_run.assert_called_once()
         assert client.create_run.call_args.args[0] == "exp-9"
 
@@ -335,13 +345,13 @@ class TestTrackNeverRaises:
 class TestConstruction:
     """Constructor arguments flow through; the store stays picklable."""
 
-    def test_tracking_uri_forwarded(self):
+    def test_tracking_uri_forwarded(self, monkeypatch):
         """The ``tracking_uri`` reaches the ``MlflowClient`` constructor."""
         store = MlflowExperimentStore(tracking_uri="http://mlflow.example.com")
         constructor = MagicMock()
         constructor.return_value.get_experiment_by_name.return_value = None
-        with patch("mlflow.tracking.MlflowClient", constructor):
-            store.locate_resumable(storage_path="/root", run_name="run1")
+        _install_mlflow_stub(monkeypatch, constructor)
+        store.locate_resumable(storage_path="/root", run_name="run1")
         constructor.assert_called_once_with(tracking_uri="http://mlflow.example.com")
 
     def test_store_is_picklable(self):

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_experiment_store_mlflow.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_experiment_store_mlflow.py
@@ -1,0 +1,361 @@
+"""Tests for the MLflow-backed ``MlflowExperimentStore``.
+
+Covers ``michelangelo.lib.trainer.torch.pytorch_lightning.experiment_store_mlflow``:
+the marker-run round-trip against a fully faked ``MlflowClient`` (no live
+server), the "nothing to resume" paths (missing experiment, no matching run,
+server errors — all returning ``None`` without raising), the best-effort
+swallow on ``track`` failures, filter-string escaping plus the client-side
+identity re-check, and structural conformance to the :class:`ExperimentStore`
+protocol.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Importing the store pulls in the package ``__init__`` which eagerly imports the
+# Ray/Lightning-backed trainer. Skip cleanly if those heavy deps are missing.
+pytest.importorskip("ray")
+pytest.importorskip("torch")
+pytest.importorskip("pytorch_lightning")
+pytest.importorskip("mlflow")
+
+from michelangelo.lib.trainer.torch.pytorch_lightning.experiment_store_mlflow import (
+    _TAG_EXPERIMENT_PATH,
+    _TAG_RUN_NAME,
+    _TAG_STORAGE_PATH,
+    MlflowExperimentStore,
+)
+from michelangelo.lib.trainer.torch.pytorch_lightning.schema import (
+    ExperimentStore,
+)
+
+
+class _FakeMlflowClient:
+    """In-memory stand-in for ``mlflow.tracking.MlflowClient``.
+
+    Implements just the five calls the store makes. ``search_runs`` ignores
+    the filter (it is recorded for assertion instead) and returns all runs
+    newest-first, mirroring the store's ``order_by`` — the store's client-side
+    identity re-check is what narrows to the right run, which is exactly the
+    behavior under test.
+    """
+
+    def __init__(self, tracking_uri=None):
+        self.tracking_uri = tracking_uri
+        self.experiments: dict[str, str] = {}  # name -> experiment_id
+        self.runs: list[SimpleNamespace] = []  # newest appended last
+        self.terminated: list[tuple[str, str]] = []
+        self.last_search_kwargs: dict | None = None
+        self._counter = 0
+
+    def get_experiment_by_name(self, name):
+        if name not in self.experiments:
+            return None
+        return SimpleNamespace(experiment_id=self.experiments[name], name=name)
+
+    def create_experiment(self, name):
+        experiment_id = f"exp-{len(self.experiments)}"
+        self.experiments[name] = experiment_id
+        return experiment_id
+
+    def create_run(self, experiment_id, tags=None, run_name=None):
+        self._counter += 1
+        run = SimpleNamespace(
+            info=SimpleNamespace(
+                run_id=f"run-{self._counter}", experiment_id=experiment_id
+            ),
+            data=SimpleNamespace(tags=dict(tags or {})),
+        )
+        self.runs.append(run)
+        return run
+
+    def set_terminated(self, run_id, status):
+        self.terminated.append((run_id, status))
+
+    def search_runs(self, experiment_ids, filter_string, order_by, max_results):
+        self.last_search_kwargs = {
+            "experiment_ids": experiment_ids,
+            "filter_string": filter_string,
+            "order_by": order_by,
+            "max_results": max_results,
+        }
+        return list(reversed(self.runs))[:max_results]
+
+
+@pytest.fixture()
+def fake_client():
+    """A fresh fake client, patched in as the ``MlflowClient`` constructor."""
+    client = _FakeMlflowClient()
+    with patch("mlflow.tracking.MlflowClient", return_value=client):
+        yield client
+
+
+class TestProtocolConformance:
+    """``MlflowExperimentStore`` structurally satisfies the protocol."""
+
+    def test_is_experiment_store(self):
+        """The store passes the ``@runtime_checkable`` protocol check."""
+        assert isinstance(MlflowExperimentStore(), ExperimentStore)
+
+
+class TestRoundTrip:
+    """Track-then-locate round-trip against the fake client."""
+
+    def test_track_then_locate_returns_experiment_path(self, fake_client):
+        """``track`` creates a tagged marker run that ``locate_resumable`` finds."""
+        store = MlflowExperimentStore()
+        store.track(
+            storage_path="/root/runs",
+            run_name="run1",
+            experiment_path="/exp/run1_dir",
+        )
+
+        # One marker run, tagged with the full identity, and terminated.
+        assert len(fake_client.runs) == 1
+        tags = fake_client.runs[0].data.tags
+        assert tags[_TAG_RUN_NAME] == "run1"
+        assert tags[_TAG_STORAGE_PATH] == "/root/runs"
+        assert tags[_TAG_EXPERIMENT_PATH] == "/exp/run1_dir"
+        assert fake_client.terminated == [(fake_client.runs[0].info.run_id, "FINISHED")]
+
+        located = store.locate_resumable(storage_path="/root/runs", run_name="run1")
+        assert located == "/exp/run1_dir"
+
+    def test_most_recent_marker_wins(self, fake_client):
+        """A second ``track`` for the same identity shadows the first."""
+        store = MlflowExperimentStore()
+        store.track(
+            storage_path="/root/runs", run_name="run1", experiment_path="/exp/old"
+        )
+        store.track(
+            storage_path="/root/runs", run_name="run1", experiment_path="/exp/new"
+        )
+        assert len(fake_client.runs) == 2  # accumulates, does not overwrite
+        assert (
+            store.locate_resumable(storage_path="/root/runs", run_name="run1")
+            == "/exp/new"
+        )
+
+    def test_distinct_identities_are_isolated(self, fake_client):
+        """The client-side re-check keys strictly on ``(storage_path, run_name)``."""
+        store = MlflowExperimentStore()
+        store.track(storage_path="/root", run_name="a", experiment_path="/exp/a")
+        store.track(storage_path="/root", run_name="b", experiment_path="/exp/b")
+        store.track(storage_path="/other", run_name="a", experiment_path="/exp/oa")
+        assert store.locate_resumable(storage_path="/root", run_name="a") == "/exp/a"
+        assert store.locate_resumable(storage_path="/root", run_name="b") == "/exp/b"
+        assert store.locate_resumable(storage_path="/other", run_name="a") == "/exp/oa"
+
+    def test_experiment_created_once_and_reused(self, fake_client):
+        """The marker experiment is created on first track, then reused."""
+        store = MlflowExperimentStore(experiment_name="my-resume")
+        store.track(storage_path="/root", run_name="r", experiment_path="/e1")
+        store.track(storage_path="/root", run_name="r", experiment_path="/e2")
+        assert list(fake_client.experiments) == ["my-resume"]
+
+
+class TestSearchQuery:
+    """The search request carries the identity filter and ordering."""
+
+    def test_filter_and_order(self, fake_client):
+        """Both identity tags are filtered; newest-first, small window."""
+        store = MlflowExperimentStore()
+        store.track(storage_path="/root", run_name="run1", experiment_path="/exp")
+        store.locate_resumable(storage_path="/root", run_name="run1")
+        kwargs = fake_client.last_search_kwargs
+        assert f"tags.{_TAG_RUN_NAME} = 'run1'" in kwargs["filter_string"]
+        assert f"tags.{_TAG_STORAGE_PATH} = '/root'" in kwargs["filter_string"]
+        assert kwargs["order_by"] == ["attributes.start_time DESC"]
+        assert kwargs["max_results"] >= 1
+
+    def test_single_quote_switches_to_double_quoted_literal(self, fake_client):
+        """MLflow filters cannot escape quotes; the literal's quote style flips."""
+        store = MlflowExperimentStore()
+        store.track(storage_path="/root", run_name="it's run", experiment_path="/exp/q")
+        assert (
+            store.locate_resumable(storage_path="/root", run_name="it's run")
+            == "/exp/q"
+        )
+        assert '"it\'s run"' in fake_client.last_search_kwargs["filter_string"]
+
+    def test_double_quote_keeps_single_quoted_literal(self, fake_client):
+        """A double quote in the identity stays inside a single-quoted literal."""
+        store = MlflowExperimentStore()
+        store.track(
+            storage_path="/root", run_name='say "hi"', experiment_path="/exp/dq"
+        )
+        assert (
+            store.locate_resumable(storage_path="/root", run_name='say "hi"')
+            == "/exp/dq"
+        )
+        assert "'say \"hi\"'" in fake_client.last_search_kwargs["filter_string"]
+
+    def test_both_quote_styles_degrade_to_none_without_search(self, fake_client):
+        """An identity with both quote styles is unfilterable -> nothing to resume."""
+        store = MlflowExperimentStore()
+        tricky = 'it\'s "tricky"'
+        store.track(storage_path="/root", run_name=tricky, experiment_path="/exp/t")
+        assert store.locate_resumable(storage_path="/root", run_name=tricky) is None
+        # Short-circuited before issuing a search.
+        assert fake_client.last_search_kwargs is None
+
+    def test_identity_recheck_skips_mismatched_runs(self, fake_client):
+        """A run the server returns despite a different identity is skipped."""
+        store = MlflowExperimentStore()
+        store.track(storage_path="/root", run_name="other", experiment_path="/exp/x")
+        # The fake search returns every run regardless of filter; only an
+        # exact client-side identity match may be resumed.
+        assert store.locate_resumable(storage_path="/root", run_name="run1") is None
+
+
+class TestNothingToResume:
+    """``locate_resumable`` returns ``None`` without raising on the sad paths."""
+
+    def test_missing_experiment_returns_none(self, fake_client):
+        """No marker experiment yet → nothing to resume."""
+        store = MlflowExperimentStore()
+        assert store.locate_resumable(storage_path="/root", run_name="run1") is None
+
+    def test_no_matching_runs_returns_none(self, fake_client):
+        """Experiment exists but holds no marker for this identity."""
+        store = MlflowExperimentStore()
+        fake_client.create_experiment("michelangelo-resume")
+        assert store.locate_resumable(storage_path="/root", run_name="run1") is None
+
+    def test_marker_without_experiment_path_returns_none(self, fake_client):
+        """A marker run missing the payload tag → ``None``."""
+        store = MlflowExperimentStore()
+        experiment_id = fake_client.create_experiment("michelangelo-resume")
+        fake_client.create_run(
+            experiment_id,
+            tags={_TAG_RUN_NAME: "run1", _TAG_STORAGE_PATH: "/root"},
+        )
+        assert store.locate_resumable(storage_path="/root", run_name="run1") is None
+
+    def test_locate_swallows_client_errors(self):
+        """An unreachable server is swallowed; ``locate`` returns ``None``."""
+        store = MlflowExperimentStore()
+        raising = MagicMock()
+        raising.get_experiment_by_name.side_effect = ConnectionError("boom")
+        with patch("mlflow.tracking.MlflowClient", return_value=raising):
+            assert store.locate_resumable(storage_path="/root", run_name="run1") is None
+
+    def test_empty_identity_returns_none_without_client(self):
+        """Empty ``storage_path``/``run_name`` short-circuits before any client use."""
+        store = MlflowExperimentStore()
+        constructor = MagicMock()
+        with patch("mlflow.tracking.MlflowClient", constructor):
+            assert store.locate_resumable(storage_path="", run_name="run1") is None
+            assert store.locate_resumable(storage_path="/root", run_name="") is None
+        constructor.assert_not_called()
+
+
+class TestMlflowNotInstalled:
+    """The lazy import degrades per the never-raise contract when mlflow is absent."""
+
+    def test_track_and_locate_degrade_gracefully(self, monkeypatch):
+        """With mlflow unimportable, ``track`` swallows and ``locate`` returns None."""
+        import sys
+
+        store = MlflowExperimentStore()
+        # Making the module entry None causes ``from mlflow.tracking import
+        # MlflowClient`` to raise ImportError, simulating a missing extra.
+        monkeypatch.setitem(sys.modules, "mlflow.tracking", None)
+        store.track(storage_path="/root", run_name="run1", experiment_path="/exp")
+        assert store.locate_resumable(storage_path="/root", run_name="run1") is None
+
+    def test_client_import_error_message_names_the_extra(self, monkeypatch):
+        """The ImportError tells the user which extra to install."""
+        import sys
+
+        store = MlflowExperimentStore()
+        monkeypatch.setitem(sys.modules, "mlflow.tracking", None)
+        with pytest.raises(ImportError, match="trainer-mlflow"):
+            store._client()
+
+
+class TestTrackNeverRaises:
+    """``track`` is best-effort: a failure must never propagate."""
+
+    def test_track_swallows_lost_race_with_vanishing_experiment(self):
+        """Create fails and the re-read still misses → swallowed, no run created."""
+        store = MlflowExperimentStore()
+        client = MagicMock()
+        client.get_experiment_by_name.return_value = None
+        client.create_experiment.side_effect = RuntimeError("server hiccup")
+        with patch("mlflow.tracking.MlflowClient", return_value=client):
+            # Must not raise, even though _ensure_experiment re-raises internally.
+            store.track(
+                storage_path="/root", run_name="run1", experiment_path="/exp/dir"
+            )
+        client.create_run.assert_not_called()
+
+    def test_track_swallows_client_errors(self):
+        """An unreachable server during ``track`` does not propagate."""
+        store = MlflowExperimentStore()
+        raising = MagicMock()
+        raising.get_experiment_by_name.side_effect = ConnectionError("boom")
+        with patch("mlflow.tracking.MlflowClient", return_value=raising):
+            # Must not raise.
+            store.track(
+                storage_path="/root", run_name="run1", experiment_path="/exp/dir"
+            )
+
+    def test_track_with_empty_identity_writes_nothing(self, fake_client):
+        """Empty ``storage_path``/``run_name`` short-circuits: no run created."""
+        store = MlflowExperimentStore()
+        store.track(storage_path="", run_name="run1", experiment_path="/exp")
+        store.track(storage_path="/root", run_name="", experiment_path="/exp")
+        assert fake_client.runs == []
+
+    def test_track_survives_experiment_creation_race(self):
+        """Losing the create-experiment race falls back to the winner's id."""
+        store = MlflowExperimentStore()
+        client = MagicMock()
+        experiment = SimpleNamespace(experiment_id="exp-9")
+        # First lookup misses, create fails (someone else won), re-read hits.
+        client.get_experiment_by_name.side_effect = [None, experiment]
+        client.create_experiment.side_effect = RuntimeError("already exists")
+        client.create_run.return_value = SimpleNamespace(
+            info=SimpleNamespace(run_id="run-1"),
+            data=SimpleNamespace(tags={}),
+        )
+        with patch("mlflow.tracking.MlflowClient", return_value=client):
+            store.track(
+                storage_path="/root", run_name="run1", experiment_path="/exp/dir"
+            )
+        client.create_run.assert_called_once()
+        assert client.create_run.call_args.args[0] == "exp-9"
+
+
+class TestConstruction:
+    """Constructor arguments flow through; the store stays picklable."""
+
+    def test_tracking_uri_forwarded(self):
+        """The ``tracking_uri`` reaches the ``MlflowClient`` constructor."""
+        store = MlflowExperimentStore(tracking_uri="http://mlflow.example.com")
+        constructor = MagicMock()
+        constructor.return_value.get_experiment_by_name.return_value = None
+        with patch("mlflow.tracking.MlflowClient", constructor):
+            store.locate_resumable(storage_path="/root", run_name="run1")
+        constructor.assert_called_once_with(tracking_uri="http://mlflow.example.com")
+
+    def test_store_is_picklable(self):
+        """The store holds only plain strings, so it survives pickling to workers."""
+        import pickle
+
+        restored = pickle.loads(
+            pickle.dumps(
+                MlflowExperimentStore(
+                    tracking_uri="http://mlflow.example.com",
+                    experiment_name="team-x",
+                )
+            )
+        )
+        assert isinstance(restored, MlflowExperimentStore)
+        assert restored._tracking_uri == "http://mlflow.example.com"
+        assert restored._experiment_name == "team-x"


### PR DESCRIPTION
Implements #1869.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Adds `MlflowExperimentStore`, a second implementation of the `ExperimentStore` auto-resume seam from #1571. Instead of a marker file under the run's `storage_path` (the `FsspecExperimentStore` default), each training attempt records a tagged, immediately-terminated run in a dedicated MLflow experiment, and resume looks up the newest marker for the exact `(storage_path, run_name)` identity.

```python
param = LightningTrainerParam(
    ...,
    experiment_store=MlflowExperimentStore(
        tracking_uri="http://mlflow.example.com:5000",
        experiment_name="team-x-resume",
    ),
)
```

Design choices:

- **Never-raise contract kept.** `track()` logs and swallows any failure; `locate_resumable()` returns `None` on anything unexpected. A down MLflow server means a fresh start, never a failed run.
- **One marker run per attempt, most recent wins.** MLflow has no atomic overwrite or KV lookup, so markers accumulate in the dedicated experiment (default `michelangelo-resume`) and lookup orders by start time. Deliberate v1 tradeoff; `track()` only runs on worker rank 0 so the volume is one run per training attempt.
- **Filter quoting handled per value.** MLflow's search filter grammar has no in-literal quote escaping, so each literal picks the quote style the value doesn't contain; an identity containing both quote styles degrades to "nothing to resume". A client-side identity re-check on the returned runs backstops the filter either way.
- **No secrets in the store.** The store is pickled into the (logged) train loop config, so it only carries `tracking_uri` and `experiment_name`; credentials flow through MLflow's native `MLFLOW_TRACKING_USERNAME`/`PASSWORD`/`TOKEN` env vars. mlflow imports lazily via the existing `trainer-mlflow` extra.

**Why?**

#1869 lays out the gap: with the filesystem marker, resume state is invisible from any dashboard, and some storage backends make the marker-file pattern awkward. Teams already running an MLflow tracking server get resume markers as queryable, visible tracking state instead -- with zero behavior change for anyone not opting in (the filesystem store remains the default).

**How did you test it?**

- 23 new unit tests against a faked `MlflowClient` (no live server): round-trip, most-recent-wins, identity isolation, quote-style selection and the both-quotes degrade path, never-raise on server errors and on mlflow-not-installed, create-experiment race, picklability, protocol conformance. 100% line and branch coverage on the new module; re-run on top of current main before posting.
- Smoke-tested against a real local `mlflow server` (sqlite backend, mlflow 2.22.5): plain round-trip, most-recent-wins, identity isolation, single-quote and double-quote identities resolve through the real filter parser, both-quotes identity returns `None` without raising, unknown identity returns `None`. This caught (and now guards) a real bug: SQL-style `''` quote doubling is rejected by MLflow's actual parser, which the mocked tests could not see.
- Full `pytorch_lightning` package suite passes; `ruff format` + `ruff check` clean.

**Potential risks**

- Opt-in only: nothing changes unless a caller passes `experiment_store=MlflowExperimentStore(...)`. The never-raise contract means the worst failure mode is "no resume, fresh start", same as today's seam guarantees.
- Marker runs accumulate in the dedicated experiment over time (one per training attempt); harmless, but operators who care can point the store at a purpose-made experiment and apply MLflow's own retention.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

Added `MlflowExperimentStore`, an opt-in MLflow-backed implementation of the trainer's auto-resume `ExperimentStore` seam. Installs via the existing `trainer-mlflow` extra; the filesystem store remains the default.

**Documentation Changes**

The MLflow operator guide (`docs/operator-guides/integrations/mlflow.md`) gains a section documenting the store, its configuration, and the credentials flow.


---

**Testing addendum (post-review, re: dkurra's run-link question)**

Verified the full train -> stop -> resume loop against a real local Ray cluster and a real local (file-backed) MLflow tracking store -- see the review thread for the run log evidence. A literal same-identity re-run resumes correctly but can't by itself distinguish the store's own `locate_resumable()` from Ray Train V2's native run-directory restoration; confirmed the store is genuinely load-bearing by physically deleting the native checkpoint directory and re-pointing the store at a relocated copy, then observing `LightningTrainer` log that it seeded the resume from that relocated path.

A permanent regression test reproducing this scenario is ready as a follow-up, stacked on this PR so it doesn't require re-review of anything already approved here.
