### PR TITLE
feat(cli): add 'ma import' to convert PyTorchJob manifests into pipeline scaffolds

### DIFF
--- a/python/michelangelo/cli/cli.py
+++ b/python/michelangelo/cli/cli.py
@@ -2,6 +2,7 @@ import argparse
 import logging
 import sys
 
+from michelangelo.cli.importer import importer
 from michelangelo.cli.mactl import mactl
 from michelangelo.cli.sandbox import sandbox
 
@@ -32,6 +33,18 @@ def main(args=None):
         sandbox.init_arguments(sandbox_p)
         ns = p.parse_args(args=args)
         return sandbox.run(ns)
+
+    if entity == "import":
+        p = argparse.ArgumentParser(description=description)
+        sp = p.add_subparsers(dest="entity", required=True, help="Entity to operate on")
+        import_p = sp.add_parser(
+            "import",
+            description=importer.description,
+            help=importer.short_description,
+        )
+        importer.init_arguments(import_p)
+        ns = p.parse_args(args=args)
+        return importer.run(ns)
 
     # For all other entities, delegate to mactl
     return mactl.run()

--- a/python/michelangelo/cli/cli.py
+++ b/python/michelangelo/cli/cli.py
@@ -1,3 +1,5 @@
+"""Entry point for the ``ma`` command-line interface."""
+
 import argparse
 import logging
 import sys
@@ -7,11 +9,13 @@ from michelangelo.cli.mactl import mactl
 from michelangelo.cli.sandbox import sandbox
 
 description = """
-Michelangelo CLI is a command-line interface that enables seamless access to Michelangelo services directly from your terminal.
+Michelangelo CLI is a command-line interface that enables seamless access to
+Michelangelo services directly from your terminal.
 """
 
 
 def main(args=None):
+    """Dispatch to the ``ma`` subcommand named by ``args`` or ``sys.argv``."""
     logging.basicConfig(level=logging.INFO)
 
     # Determine entity from args or sys.argv

--- a/python/michelangelo/cli/importer/__init__.py
+++ b/python/michelangelo/cli/importer/__init__.py
@@ -1,0 +1,1 @@
+"""Importer CLI: convert training-job manifests into pipeline scaffolds."""

--- a/python/michelangelo/cli/importer/importer.py
+++ b/python/michelangelo/cli/importer/importer.py
@@ -1,0 +1,82 @@
+"""``ma import``: convert training-job manifests into Uniflow pipeline scaffolds."""
+
+import sys
+from pathlib import Path
+
+import yaml
+
+from michelangelo.cli.importer import pytorchjob
+
+short_description = "Convert training-job manifests into pipeline scaffolds."
+
+description = """
+Convert a Kubernetes training-job manifest into a Michelangelo pipeline
+scaffold. The generated file is a starting point, not a finished pipeline:
+cluster sizing is mapped for you, the training code itself is marked with
+TODOs. Currently supports Kubeflow Trainer PyTorchJob manifests.
+"""
+
+# kind -> converter entry point. Additional kinds plug in here.
+_CONVERTERS = {
+    "PyTorchJob": pytorchjob.convert_text,
+}
+
+
+def init_arguments(parser):
+    """Register ``ma import`` arguments on the given subparser."""
+    parser.add_argument(
+        "manifest",
+        help="Path to the training-job manifest to convert (YAML)",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Write the generated pipeline to this file instead of stdout",
+    )
+
+
+def run(ns) -> int:
+    """Convert the manifest named by the parsed CLI arguments."""
+    path = Path(ns.manifest)
+    try:
+        text = path.read_text()
+    except OSError as exc:
+        print(f"error: cannot read {path}: {exc}", file=sys.stderr)
+        return 1
+
+    kind = _detect_kind(text)
+    converter = _CONVERTERS.get(kind)
+    if converter is None:
+        supported = ", ".join(sorted(_CONVERTERS))
+        print(
+            f"error: unsupported manifest kind {kind!r} (supported: {supported})",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        result = converter(text)
+    except pytorchjob.ManifestError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    for warning in result.warnings:
+        print(f"warning: {warning}", file=sys.stderr)
+
+    if ns.output:
+        Path(ns.output).write_text(result.scaffold)
+        print(f"wrote {ns.output}", file=sys.stderr)
+    else:
+        print(result.scaffold, end="")
+    return 0
+
+
+def _detect_kind(text):
+    """Best-effort read of the manifest's kind; converters re-validate."""
+    try:
+        manifest = yaml.safe_load(text)
+    except yaml.YAMLError:
+        return None
+    if isinstance(manifest, dict):
+        return manifest.get("kind")
+    return None

--- a/python/michelangelo/cli/importer/importer_test.py
+++ b/python/michelangelo/cli/importer/importer_test.py
@@ -1,0 +1,117 @@
+"""Tests for the ``ma import`` CLI surface."""
+
+import argparse
+
+import pytest
+
+from michelangelo.cli import cli
+from michelangelo.cli.importer import importer
+
+_MANIFEST = """
+apiVersion: kubeflow.org/v1
+kind: PyTorchJob
+metadata:
+  name: cli-test-job
+spec:
+  pytorchReplicaSpecs:
+    Worker:
+      replicas: 2
+      template:
+        spec:
+          containers:
+            - name: pytorch
+              image: img:1
+"""
+
+
+def _parse(args):
+    parser = argparse.ArgumentParser()
+    importer.init_arguments(parser)
+    return parser.parse_args(args)
+
+
+def test_run_writes_scaffold_to_stdout(tmp_path, capsys):
+    """Run writes scaffold to stdout."""
+    manifest = tmp_path / "job.yaml"
+    manifest.write_text(_MANIFEST)
+    rc = importer.run(_parse([str(manifest)]))
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "worker_instances=2," in captured.out
+    assert "name='cli-test-job'" in captured.out
+
+
+def test_run_writes_scaffold_to_output_file(tmp_path, capsys):
+    """Run writes scaffold to output file."""
+    manifest = tmp_path / "job.yaml"
+    manifest.write_text(_MANIFEST)
+    out = tmp_path / "pipeline.py"
+    rc = importer.run(_parse([str(manifest), "-o", str(out)]))
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out == ""
+    assert f"wrote {out}" in captured.err
+    assert "worker_instances=2," in out.read_text()
+
+
+def test_run_reports_warnings_on_stderr(tmp_path, capsys):
+    """Run reports warnings on stderr."""
+    manifest = tmp_path / "job.yaml"
+    manifest.write_text(_MANIFEST.replace("spec:\n", "spec:\n  nprocPerNode: '2'\n", 1))
+    rc = importer.run(_parse([str(manifest)]))
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "warning: spec.nprocPerNode" in captured.err
+
+
+def test_run_missing_file_fails(tmp_path, capsys):
+    """Run missing file fails."""
+    rc = importer.run(_parse([str(tmp_path / "nope.yaml")]))
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "cannot read" in captured.err
+
+
+def test_run_unsupported_kind_fails(tmp_path, capsys):
+    """Run unsupported kind fails."""
+    manifest = tmp_path / "job.yaml"
+    manifest.write_text("kind: TFJob\n")
+    rc = importer.run(_parse([str(manifest)]))
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "unsupported manifest kind 'TFJob'" in captured.err
+    assert "supported: PyTorchJob" in captured.err
+
+
+def test_run_invalid_manifest_fails(tmp_path, capsys):
+    """Run invalid manifest fails."""
+    manifest = tmp_path / "job.yaml"
+    manifest.write_text("kind: PyTorchJob\nspec: {}\n")
+    rc = importer.run(_parse([str(manifest)]))
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "error: spec.pytorchReplicaSpecs" in captured.err
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("kind: PyTorchJob", "PyTorchJob"),
+        ("kind: [broken", None),
+        ("- a list", None),
+        ("{}", None),
+    ],
+)
+def test_detect_kind(text, expected):
+    """Detect kind."""
+    assert importer._detect_kind(text) == expected
+
+
+def test_cli_dispatches_import_entity(tmp_path, capsys):
+    """Cli dispatches import entity."""
+    manifest = tmp_path / "job.yaml"
+    manifest.write_text(_MANIFEST)
+    rc = cli.main(["import", str(manifest)])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "worker_instances=2," in captured.out

--- a/python/michelangelo/cli/importer/pytorchjob.py
+++ b/python/michelangelo/cli/importer/pytorchjob.py
@@ -1,0 +1,270 @@
+"""Convert a Kubeflow Trainer PyTorchJob manifest into a Uniflow pipeline scaffold.
+
+The generated scaffold follows the shape documented in the Kubeflow Trainer
+migration guide: a ``@uniflow.task`` sized by a ``RayTask`` config, running a
+``LightningTrainer`` whose ``ScalingConfig`` mirrors the job's worker count.
+Fields with no equivalent here (images, commands, volumes, scheduling hints)
+are surfaced as warnings and TODO comments rather than silently dropped.
+"""
+
+import math
+from dataclasses import dataclass
+
+import yaml
+
+_KIND = "PyTorchJob"
+_API_GROUP = "kubeflow.org"
+
+# PyTorchJob fields that have no direct equivalent in a pipeline task. Each is
+# reported as a warning when present so nothing is silently dropped.
+_UNMAPPED_SPEC_FIELDS = ("elasticPolicy", "runPolicy", "nprocPerNode")
+_UNMAPPED_POD_FIELDS = (
+    "volumes",
+    "nodeSelector",
+    "tolerations",
+    "affinity",
+    "initContainers",
+)
+_UNMAPPED_CONTAINER_FIELDS = ("env", "envFrom", "volumeMounts", "ports")
+
+
+class ManifestError(ValueError):
+    """Raised when the input manifest cannot be converted."""
+
+
+@dataclass
+class ConversionResult:
+    """The generated pipeline scaffold plus everything that did not map."""
+
+    scaffold: str
+    warnings: list
+
+
+def convert_text(text: str) -> ConversionResult:
+    """Parse a YAML manifest and convert it. See :func:`convert`."""
+    try:
+        manifest = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise ManifestError(f"input is not valid YAML: {exc}") from exc
+    if not isinstance(manifest, dict):
+        raise ManifestError(
+            "input is not a Kubernetes manifest (expected a YAML mapping)"
+        )
+    return convert(manifest)
+
+
+def convert(manifest: dict) -> ConversionResult:
+    """Convert a PyTorchJob manifest dict into a pipeline scaffold.
+
+    Raises :class:`ManifestError` when the manifest is not a PyTorchJob or has
+    no replica specs at all.
+    """
+    warnings = []
+
+    kind = manifest.get("kind")
+    if kind != _KIND:
+        raise ManifestError(
+            f"unsupported kind {kind!r}: this converter handles {_KIND} manifests"
+        )
+    api_version = str(manifest.get("apiVersion") or "")
+    if not api_version.startswith(_API_GROUP):
+        warnings.append(
+            f"apiVersion {api_version!r} is not from {_API_GROUP}; converting anyway"
+        )
+
+    name = (manifest.get("metadata") or {}).get("name") or "imported-pytorch-job"
+    spec = manifest.get("spec") or {}
+
+    for spec_field in _UNMAPPED_SPEC_FIELDS:
+        if spec_field in spec:
+            warnings.append(
+                f"spec.{spec_field} has no pipeline equivalent and was not converted"
+            )
+
+    replica_specs = spec.get("pytorchReplicaSpecs") or {}
+    master = replica_specs.get("Master")
+    worker = replica_specs.get("Worker")
+    if master is None and worker is None:
+        raise ManifestError(
+            "spec.pytorchReplicaSpecs has neither a Master nor a Worker block"
+        )
+
+    master_container = _first_container(master, "Master", warnings)
+    worker_container = _first_container(worker, "Worker", warnings)
+
+    if worker is not None:
+        worker_replicas = int(worker.get("replicas") or 1)
+    else:
+        worker_replicas = 1
+        warnings.append(
+            "no Worker block: emitting a single-worker training group sized from Master"
+        )
+        worker_container = master_container
+
+    head_cpu, head_memory, head_gpu = _container_resources(master_container)
+    worker_cpu, worker_memory, worker_gpu = _container_resources(worker_container)
+
+    _warn_unmapped_runtime(master_container, "Master", warnings)
+    if worker_container is not master_container:
+        _warn_unmapped_runtime(worker_container, "Worker", warnings)
+
+    ray_task_fields = [
+        ("head_cpu", head_cpu),
+        ("head_memory", _quote(head_memory)),
+        ("head_gpu", head_gpu or None),
+        ("worker_cpu", worker_cpu),
+        ("worker_memory", _quote(worker_memory)),
+        ("worker_gpu", worker_gpu or None),
+        ("worker_instances", worker_replicas),
+    ]
+    ray_task_lines = [f"        {k}={v}," for k, v in ray_task_fields if v is not None]
+    if len(ray_task_lines) == 1:
+        ray_task_lines.insert(0, "        # TODO: size the cluster for your workload.")
+
+    entrypoint = _entrypoint_comment(worker_container or master_container)
+    use_gpu = bool(worker_gpu)
+
+    scaffold = _SCAFFOLD_TEMPLATE.format(
+        source_name=name,
+        ray_task_fields="\n".join(ray_task_lines),
+        entrypoint=entrypoint,
+        run_name=name,
+        num_workers=worker_replicas,
+        use_gpu=use_gpu,
+    )
+    return ConversionResult(scaffold=scaffold, warnings=warnings)
+
+
+def _first_container(replica_spec, role, warnings):
+    """Return the first container of a replica spec, warning about the rest."""
+    if replica_spec is None:
+        return None
+    pod_spec = ((replica_spec.get("template") or {}).get("spec")) or {}
+    for pod_field in _UNMAPPED_POD_FIELDS:
+        if pod_field in pod_spec:
+            warnings.append(
+                f"{role} pod {pod_field} has no pipeline equivalent"
+                " and was not converted"
+            )
+    if pod_spec.get("restartPolicy"):
+        warnings.append(
+            f"{role} restartPolicy was not converted:"
+            " task retries are workflow-level here"
+        )
+    containers = pod_spec.get("containers") or []
+    if not containers:
+        warnings.append(
+            f"{role} block has no containers; its resources were not converted"
+        )
+        return None
+    if len(containers) > 1:
+        warnings.append(
+            f"{role} has {len(containers)} containers; only the first was converted"
+        )
+    return containers[0]
+
+
+def _container_resources(container):
+    """Extract (cpu, memory, gpu) from a container, preferring requests."""
+    if container is None:
+        return None, None, None
+    resources = container.get("resources") or {}
+    requests = resources.get("requests") or {}
+    limits = resources.get("limits") or {}
+    cpu = _cpu_count(requests.get("cpu", limits.get("cpu")))
+    memory = requests.get("memory", limits.get("memory"))
+    gpu = _gpu_count(limits.get("nvidia.com/gpu", requests.get("nvidia.com/gpu")))
+    return cpu, memory, gpu
+
+
+def _cpu_count(quantity):
+    """Round a Kubernetes CPU quantity ("500m", "2", 2.5) up to whole CPUs."""
+    if quantity is None:
+        return None
+    text = str(quantity)
+    if text.endswith("m"):
+        return math.ceil(int(text[:-1]) / 1000)
+    return math.ceil(float(text))
+
+
+def _gpu_count(quantity):
+    if quantity is None:
+        return None
+    return int(str(quantity))
+
+
+def _warn_unmapped_runtime(container, role, warnings):
+    if container is None:
+        return
+    for container_field in _UNMAPPED_CONTAINER_FIELDS:
+        if container_field in container:
+            warnings.append(
+                f"{role} container {container_field} has no pipeline equivalent"
+                " and was not converted"
+            )
+
+
+def _entrypoint_comment(container):
+    """Describe the container entrypoint the user must port into the task body."""
+    lines = [
+        "    # TODO: port the training code from your PyTorchJob image into this task."
+    ]
+    if container:
+        if container.get("image"):
+            lines.append(f"    #   image:   {container['image']}")
+        command = list(container.get("command") or []) + list(
+            container.get("args") or []
+        )
+        if command:
+            lines.append(f"    #   command: {' '.join(str(part) for part in command)}")
+    return "\n".join(lines)
+
+
+def _quote(value):
+    return None if value is None else repr(str(value))
+
+
+_SCAFFOLD_TEMPLATE = '''"""Pipeline scaffold generated from PyTorchJob {source_name!r}.
+
+Review every TODO before running: the converter maps cluster sizing, not
+training code. See docs/user-guides/migration/migrate-from-kubeflow-trainer.md
+for the full field mapping.
+"""
+
+import michelangelo.uniflow.core as uniflow
+import ray.train
+from michelangelo.lib.trainer.torch.pytorch_lightning import (
+    LightningTrainer,
+    LightningTrainerParam,
+)
+from michelangelo.uniflow.plugins.ray import RayTask
+
+
+@uniflow.task(
+    config=RayTask(
+{ray_task_fields}
+    )
+)
+def train(data_path: str):
+{entrypoint}
+    trainer = LightningTrainer(
+        trainer_param=LightningTrainerParam(
+            create_model_fn=create_model,  # TODO: your LightningModule factory
+            create_model_fn_kwargs={{}},
+            train_data=load_train(data_path),  # TODO: training Ray Dataset
+            val_data=load_val(data_path),  # TODO: validation Ray Dataset
+            batch_size=256,  # TODO: per-worker batch size
+        ),
+        run_config=ray.train.RunConfig(name={run_name!r}),
+        scaling_config=ray.train.ScalingConfig(
+            num_workers={num_workers},
+            use_gpu={use_gpu},
+        ),
+    )
+    return trainer.train()
+
+
+@uniflow.workflow()
+def training_pipeline(data_path: str):
+    return train(data_path)
+'''

--- a/python/michelangelo/cli/importer/pytorchjob_test.py
+++ b/python/michelangelo/cli/importer/pytorchjob_test.py
@@ -1,0 +1,195 @@
+"""Tests for the PyTorchJob-to-pipeline converter."""
+
+import pytest
+
+from michelangelo.cli.importer import pytorchjob
+
+_FULL_MANIFEST = """
+apiVersion: kubeflow.org/v1
+kind: PyTorchJob
+metadata:
+  name: pytorch-dist-train
+spec:
+  pytorchReplicaSpecs:
+    Master:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: pytorch
+              image: my-training-image:latest
+              command: ["python", "train.py"]
+              resources:
+                requests:
+                  cpu: "2"
+                  memory: 4Gi
+    Worker:
+      replicas: 3
+      template:
+        spec:
+          containers:
+            - name: pytorch
+              image: my-training-image:latest
+              command: ["python"]
+              args: ["train.py"]
+              resources:
+                requests:
+                  cpu: 500m
+                  memory: 16Gi
+                limits:
+                  nvidia.com/gpu: 1
+"""
+
+
+def test_full_manifest_maps_resources_and_scaling():
+    """Full manifest maps resources and scaling."""
+    result = pytorchjob.convert_text(_FULL_MANIFEST)
+    scaffold = result.scaffold
+    assert "head_cpu=2," in scaffold
+    assert "head_memory='4Gi'," in scaffold
+    assert "worker_cpu=1," in scaffold  # 500m rounds up to a whole CPU
+    assert "worker_memory='16Gi'," in scaffold
+    assert "worker_gpu=1," in scaffold
+    assert "worker_instances=3," in scaffold
+    assert "num_workers=3," in scaffold
+    assert "use_gpu=True," in scaffold
+    assert "name='pytorch-dist-train'" in scaffold
+    # Entrypoint surfaced as TODO comments, with args appended to command.
+    assert "image:   my-training-image:latest" in scaffold
+    assert "command: python train.py" in scaffold
+    assert result.warnings == []
+
+
+def test_scaffold_is_valid_python():
+    """Scaffold is valid python."""
+    result = pytorchjob.convert_text(_FULL_MANIFEST)
+    compile(result.scaffold, "<generated>", "exec")
+
+
+def test_wrong_kind_is_rejected():
+    """Wrong kind is rejected."""
+    with pytest.raises(pytorchjob.ManifestError, match="unsupported kind 'TFJob'"):
+        pytorchjob.convert_text("kind: TFJob\napiVersion: kubeflow.org/v1\n")
+
+
+def test_invalid_yaml_is_rejected():
+    """Invalid yaml is rejected."""
+    with pytest.raises(pytorchjob.ManifestError, match="not valid YAML"):
+        pytorchjob.convert_text("kind: [unclosed")
+
+
+def test_non_mapping_input_is_rejected():
+    """Non mapping input is rejected."""
+    with pytest.raises(pytorchjob.ManifestError, match="expected a YAML mapping"):
+        pytorchjob.convert_text("- just\n- a\n- list\n")
+
+
+def test_missing_replica_specs_is_rejected():
+    """Missing replica specs is rejected."""
+    manifest = "kind: PyTorchJob\napiVersion: kubeflow.org/v1\nspec: {}\n"
+    with pytest.raises(pytorchjob.ManifestError, match="neither a Master nor a Worker"):
+        pytorchjob.convert_text(manifest)
+
+
+def test_master_only_manifest_warns_and_sizes_from_master():
+    """Master only manifest warns and sizes from master."""
+    manifest = """
+apiVersion: kubeflow.org/v1
+kind: PyTorchJob
+spec:
+  pytorchReplicaSpecs:
+    Master:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: pytorch
+              resources:
+                limits:
+                  cpu: 2500m
+                  memory: 8Gi
+"""
+    result = pytorchjob.convert_text(manifest)
+    assert "worker_instances=1," in result.scaffold
+    assert "worker_cpu=3," in result.scaffold  # 2500m rounds up, limits fallback
+    assert "worker_memory='8Gi'," in result.scaffold
+    assert "num_workers=1," in result.scaffold
+    assert "use_gpu=False," in result.scaffold
+    assert "name='imported-pytorch-job'" in result.scaffold
+    assert any("no Worker block" in w for w in result.warnings)
+
+
+def test_unmapped_fields_produce_warnings_not_silence():
+    """Unmapped fields produce warnings not silence."""
+    manifest = """
+apiVersion: training.example.io/v1
+kind: PyTorchJob
+metadata:
+  name: busy-job
+spec:
+  nprocPerNode: "2"
+  elasticPolicy: {minReplicas: 1}
+  runPolicy: {cleanPodPolicy: Running}
+  pytorchReplicaSpecs:
+    Worker:
+      replicas: 2
+      template:
+        spec:
+          restartPolicy: OnFailure
+          nodeSelector: {pool: gpu}
+          volumes: [{name: data}]
+          containers:
+            - name: pytorch
+              env: [{name: FOO, value: bar}]
+              volumeMounts: [{name: data, mountPath: /data}]
+            - name: sidecar
+"""
+    result = pytorchjob.convert_text(manifest)
+    joined = "\n".join(result.warnings)
+    for expected in (
+        "apiVersion 'training.example.io/v1'",
+        "spec.nprocPerNode",
+        "spec.elasticPolicy",
+        "spec.runPolicy",
+        "restartPolicy",
+        "nodeSelector",
+        "volumes",
+        "env",
+        "volumeMounts",
+        "2 containers; only the first",
+    ):
+        assert expected in joined, f"missing warning about {expected}"
+
+
+def test_containerless_worker_warns_and_emits_sizing_todo():
+    """Containerless worker warns and emits sizing todo."""
+    manifest = """
+apiVersion: kubeflow.org/v1
+kind: PyTorchJob
+spec:
+  pytorchReplicaSpecs:
+    Worker:
+      replicas: 2
+      template:
+        spec: {}
+"""
+    result = pytorchjob.convert_text(manifest)
+    assert any("no containers" in w for w in result.warnings)
+    assert "# TODO: size the cluster for your workload." in result.scaffold
+    assert "worker_instances=2," in result.scaffold
+
+
+@pytest.mark.parametrize(
+    ("quantity", "expected"),
+    [(None, None), ("500m", 1), ("1500m", 2), ("2", 2), (2, 2), ("2.5", 3), (0.1, 1)],
+)
+def test_cpu_quantities_round_up(quantity, expected):
+    """Cpu quantities round up."""
+    assert pytorchjob._cpu_count(quantity) == expected
+
+
+def test_gpu_quantities():
+    """Gpu quantities."""
+    assert pytorchjob._gpu_count(None) is None
+    assert pytorchjob._gpu_count("2") == 2
+    assert pytorchjob._gpu_count(1) == 1


### PR DESCRIPTION

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Adds `ma import <manifest.yaml> [-o output.py]`: converts a Kubeflow Trainer `PyTorchJob` manifest into a Uniflow pipeline scaffold following the migration guide's documented mapping (#1853).

- `michelangelo/cli/importer/` -- new CLI entity following the sandbox module's structure (`description` / `init_arguments` / `run`), dispatched from `cli.py` the same way. The manifest kind is auto-detected; unsupported kinds fail with the supported list, so RayJob/TrainJob converters can plug into the same command later.
- `michelangelo/cli/importer/pytorchjob.py` -- the converter: replica resources map to `RayTask` fields (CPU quantities like `500m` round up to whole cores, memory passes through, GPUs from limits), Worker replicas map to `worker_instances` and `ScalingConfig(num_workers=...)`, the training image/command surface as TODO comments, and every manifest field with no pipeline equivalent (env, volumes, scheduling hints, elasticPolicy, runPolicy, nprocPerNode, extra containers) is reported as a warning instead of silently dropped.
- Co-located tests per the mactl convention: 28 tests, 100% line and branch coverage on both new modules.

**Why?**

Teams migrating from Kubeflow Trainer get `ma import` as the mechanical first step the migration guide's mapping table (#1853) implies, with warnings guaranteeing nothing in their manifest is dropped without being named. It ships as a tested CLI feature rather than a drop-in script under `python/examples/`, keeping migration tooling out of the examples tree (which #1748 is slimming down in favor of the michelangelo-examples repo).

**How did you test it?**

- 28 unit tests, 100% line + branch coverage on `importer.py` and `pytorchjob.py`: full-manifest mapping (resources, rounding, GPU flag, naming), generated-scaffold `compile()` check, master-only and containerless edge cases, every unmapped-field warning, every error path (bad YAML, non-mapping, wrong kind, missing replica specs, unreadable file), kind detection, and a dispatch test through the real `cli.main(["import", ...])` entry.
- End-to-end smoke via `python -m michelangelo.cli.cli import demo.yaml -o out.py`: the output compiles and its fields match the guide's mapping (verified against the `RayTask` dataclass on current main).
- Full `michelangelo/cli` suite: 459 passed, 1 pre-existing failure (`mactl_test.py::TLSConfigurationTest::test_use_tls_default_value`) that fails identically on a clean checkout of main -- environment-dependent, unrelated to this change.
- `ruff format` + `ruff check` clean on all new/changed files.

**Potential risks**

New CLI surface only: `cli.py` gains one dispatch branch mirroring the sandbox one, ahead of the mactl fallback, so existing entities are untouched. The generated scaffold is a starting point by design -- it compiles but deliberately references TODO factories the user must fill in; the module docstring and TODO comments say so explicitly.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

New: `ma import` converts Kubeflow Trainer PyTorchJob manifests into pipeline scaffolds (cluster sizing mapped, training code marked with TODOs, unmapped fields reported).

**Documentation Changes**

The migration guide already documents the mapping this implements; a follow-up can add an `ma import` mention to it once both land.

