### PR TITLE
helm: add PrometheusRule starter alerts

### DIFF
--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -111,6 +111,30 @@ jobs:
             --set temporal.server.config.persistence.visibility.sql.password=root \
             2>/dev/null
 
+      - name: Template — monitoring enabled (ServiceMonitor renders with CRDs present)
+        run: |
+          helm template michelangelo helm/michelangelo \
+            -f helm/michelangelo/values-k3d.yaml \
+            --set monitoring.enabled=true \
+            --api-versions monitoring.coreos.com/v1 \
+            --debug \
+            | grep 'kind: ServiceMonitor'
+
+      - name: Template — monitoring enabled without CRDs (must skip gracefully)
+        run: |
+          ! helm template michelangelo helm/michelangelo \
+            -f helm/michelangelo/values-k3d.yaml \
+            --set monitoring.enabled=true \
+            | grep 'kind: ServiceMonitor'
+
+      - name: Validate fail-fast guard (monitoring without controllermgr must fail)
+        run: |
+          ! helm template michelangelo helm/michelangelo \
+            -f helm/michelangelo/values-k3d.yaml \
+            --set monitoring.enabled=true \
+            --set controllermgr.enabled=false \
+            2>/dev/null
+
       - name: Template — Ingress enabled (UI + Envoy, hosts[] syntax)
         run: |
           helm template michelangelo helm/michelangelo \

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -118,14 +118,14 @@ jobs:
             --set monitoring.enabled=true \
             --api-versions monitoring.coreos.com/v1 \
             --debug \
-            | grep 'kind: ServiceMonitor'
+            | grep -e 'kind: ServiceMonitor' -e 'kind: PrometheusRule'
 
       - name: Template — monitoring enabled without CRDs (must skip gracefully)
         run: |
           ! helm template michelangelo helm/michelangelo \
             -f helm/michelangelo/values-k3d.yaml \
             --set monitoring.enabled=true \
-            | grep 'kind: ServiceMonitor'
+            | grep -e 'kind: ServiceMonitor' -e 'kind: PrometheusRule'
 
       - name: Validate fail-fast guard (monitoring without controllermgr must fail)
         run: |

--- a/docs/operator-guides/operations/monitoring.md
+++ b/docs/operator-guides/operations/monitoring.md
@@ -14,7 +14,16 @@ Michelangelo AI components expose Prometheus metrics that integrate with a stand
 
 ### Controller Manager
 
-The controller manager exposes metrics on port `8091` (configured via `metricsBindAddress`). If you are using the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator), create a `ServiceMonitor`:
+The controller manager exposes metrics on port `8091` (configured via `metricsBindAddress`). If you are using the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator), the Helm chart can create the `ServiceMonitor` for you:
+
+```bash
+helm upgrade michelangelo ./helm/michelangelo --reuse-values \
+  --set monitoring.enabled=true
+```
+
+The resource is only rendered when the Prometheus Operator CRDs (`monitoring.coreos.com/v1`) are installed, so the toggle is a safe no-op on clusters without the operator. Scrape interval and extra labels (e.g. to match your Prometheus instance's `serviceMonitorSelector`) are configurable under `monitoring.serviceMonitor.*`.
+
+To create the `ServiceMonitor` yourself instead, select the controller manager Service by its chart labels:
 
 ```yaml
 apiVersion: monitoring.coreos.com/v1
@@ -22,12 +31,12 @@ kind: ServiceMonitor
 metadata:
   name: michelangelo-controllermgr
   namespace: ma-system
-  labels:
-    app: michelangelo-controllermgr
 spec:
   selector:
     matchLabels:
-      app: michelangelo-controllermgr
+      app.kubernetes.io/name: michelangelo
+      app.kubernetes.io/instance: michelangelo   # your Helm release name
+      app.kubernetes.io/component: controllermgr
   endpoints:
   - port: metrics          # Must match the Service port name for port 8091
     path: /metrics
@@ -36,12 +45,12 @@ spec:
 
 ### Health Probes
 
-The controller manager exposes health endpoints on port `8083` (configured via `healthProbeBindAddress`):
+The controller manager exposes health endpoints on port `8081` (configured via `healthProbeBindAddress`; the chart default is `controllermgr.healthPort: 8081`):
 
 | Endpoint | Purpose |
 |----------|---------|
-| `GET :8083/healthz` | Liveness — is the process alive? |
-| `GET :8083/readyz` | Readiness — is the controller ready to reconcile? |
+| `GET :8081/healthz` | Liveness — is the process alive? |
+| `GET :8081/readyz` | Readiness — is the controller ready to reconcile? |
 
 These are used by Kubernetes liveness and readiness probes, but you can also poll them from your monitoring stack for coarser-grained health checks.
 

--- a/helm/michelangelo/README.md
+++ b/helm/michelangelo/README.md
@@ -283,6 +283,9 @@ Top-level keys. See [`values.yaml`](./values.yaml) for the full annotated schema
 | `monitoring.serviceMonitor.enabled` | bool | `true` | no | Create a `ServiceMonitor` for the controller manager's `/metrics` endpoint (requires the Prometheus Operator CRDs, `monitoring.coreos.com/v1`). |
 | `monitoring.serviceMonitor.interval` | string | `30s` | no | Scrape interval. |
 | `monitoring.serviceMonitor.additionalLabels` | object | `{}` | no | Extra labels on the `ServiceMonitor`, e.g. to match a Prometheus instance's `serviceMonitorSelector`. |
+| `monitoring.prometheusRule.enabled` | bool | `true` | no | Create a `PrometheusRule` with starter alerts (pipeline-run failures/duration, reconcile errors, cascade drain timeouts). All default alerts use metrics exposed out of the box. |
+| `monitoring.prometheusRule.additionalLabels` | object | `{}` | no | Extra labels on the `PrometheusRule`, e.g. to match a Prometheus instance's `ruleSelector`. |
+| `monitoring.prometheusRule.envoyAlerts.enabled` | bool | `false` | no | Add inference latency/error alerts on Envoy upstream metrics. Requires the Envoy admin interface + a scrape job (not chart-managed). |
 | `serviceAccount.create` | bool | `true` | no | Create a ServiceAccount for the chart. |
 | `serviceAccount.name` | string | `""` | no | Override the generated ServiceAccount name. |
 | `podSecurityContext` | object | see values.yaml | no | Applied to every Pod. |

--- a/helm/michelangelo/README.md
+++ b/helm/michelangelo/README.md
@@ -279,6 +279,10 @@ Top-level keys. See [`values.yaml`](./values.yaml) for the full annotated schema
 | `worker.replicas` | int | `1` | no | Scale horizontally for higher pipeline-run throughput. |
 | `controllermgr.enabled` | bool | `true` | no | |
 | `controllermgr.watchNamespace` | list | `[]` | no | Namespaces the controller watches. Empty = all namespaces (ClusterRole). Set to a list to scope down to namespaced Roles. |
+| `monitoring.enabled` | bool | `false` | no | Master toggle for chart-managed monitoring resources. All resources are CRD-gated: skipped when the owning operator's CRDs are absent, so enabling this is safe on any cluster. |
+| `monitoring.serviceMonitor.enabled` | bool | `true` | no | Create a `ServiceMonitor` for the controller manager's `/metrics` endpoint (requires the Prometheus Operator CRDs, `monitoring.coreos.com/v1`). |
+| `monitoring.serviceMonitor.interval` | string | `30s` | no | Scrape interval. |
+| `monitoring.serviceMonitor.additionalLabels` | object | `{}` | no | Extra labels on the `ServiceMonitor`, e.g. to match a Prometheus instance's `serviceMonitorSelector`. |
 | `serviceAccount.create` | bool | `true` | no | Create a ServiceAccount for the chart. |
 | `serviceAccount.name` | string | `""` | no | Override the generated ServiceAccount name. |
 | `podSecurityContext` | object | see values.yaml | no | Applied to every Pod. |

--- a/helm/michelangelo/templates/monitoring/prometheusrule.yaml
+++ b/helm/michelangelo/templates/monitoring/prometheusrule.yaml
@@ -1,0 +1,91 @@
+{{- if and .Values.monitoring.enabled .Values.monitoring.prometheusRule.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "michelangelo.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "michelangelo.labels" . | nindent 4 }}
+    {{- with .Values.monitoring.prometheusRule.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  groups:
+    - name: michelangelo
+      rules:
+        # Pipeline run failure rate
+        - alert: PipelineRunFailureRateHigh
+          expr: rate(pipelinerun_result_failure_total[5m]) > 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Pipeline run failures detected"
+            description: >-
+              Pipeline runs are failing at {{`{{ $value | humanize }}`}} failures/sec.
+              Check failure reasons: kubectl get pipelineruns -A --field-selector status.phase=Failed
+
+        # Pipeline run duration: P99 above 1 hour
+        - alert: PipelineRunDurationHigh
+          expr: histogram_quantile(0.99, rate(pipelinerun_duration_seconds_bucket[5m])) > 3600
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Pipeline run P99 duration above 1 hour"
+            description: >-
+              The 99th percentile pipeline run duration is {{`{{ $value | humanize }}`}}s.
+
+        # Controller reconcile errors — sustained error rate from any controller
+        - alert: ControllerReconcileErrorRate
+          expr: rate(controller_runtime_reconcile_errors_total[5m]) > 0.1
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Controller {{`{{ $labels.controller }}`}} has high reconcile error rate"
+            description: >-
+              The {{`{{ $labels.controller }}`}} controller is failing reconciles at
+              {{`{{ $value | humanize }}`}} errors/sec. Check logs:
+              kubectl -n {{ .Release.Namespace }} logs deployment/{{ include "michelangelo.componentFullname" (dict "context" . "component" "controllermgr") }}
+
+        # Cascade delete: safety timeout force-completed a child's drain
+        - alert: CascadeChildDrainTimeout
+          expr: increase(cascade_child_drain_timeout_total[1h]) > 0
+          for: 0m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Cascade delete safety timeout fired"
+            description: >-
+              {{`{{ $value }}`}} child resource(s) were force-killed because their drain
+              did not complete within 24 hours. Investigate why the drain was wedged:
+              kubectl -n {{ .Release.Namespace }} logs deployment/{{ include "michelangelo.componentFullname" (dict "context" . "component" "controllermgr") }} | grep -i "cascade\|force"
+    {{- if .Values.monitoring.prometheusRule.envoyAlerts.enabled }}
+
+    - name: michelangelo-envoy
+      rules:
+        # Inference latency: P99 above 500ms for 5 minutes
+        - alert: InferenceLatencyHigh
+          expr: histogram_quantile(0.99, rate(envoy_cluster_upstream_rq_time_bucket[5m])) > 500
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Inference P99 latency is above 500ms"
+            description: >-
+              The 99th percentile inference request latency is {{`{{ $value }}`}}ms.
+              Check InferenceServer and model-sync sidecar logs.
+
+        # Inference error rate: more than 1% of requests returning 5xx
+        - alert: InferenceErrorRateHigh
+          expr: rate(envoy_cluster_upstream_rq_5xx[5m]) / rate(envoy_cluster_upstream_rq_total[5m]) > 0.01
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Inference 5xx error rate above 1%"
+            description: >-
+              {{`{{ $value | humanizePercentage }}`}} of inference requests are returning 5xx errors.
+    {{- end }}
+{{- end }}

--- a/helm/michelangelo/templates/monitoring/servicemonitor-controllermgr.yaml
+++ b/helm/michelangelo/templates/monitoring/servicemonitor-controllermgr.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.monitoring.enabled .Values.monitoring.serviceMonitor.enabled .Values.controllermgr.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "michelangelo.componentFullname" (dict "context" . "component" "controllermgr") }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "michelangelo.componentLabels" (dict "context" . "component" "controllermgr") | nindent 4 }}
+    {{- with .Values.monitoring.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "michelangelo.componentSelectorLabels" (dict "context" . "component" "controllermgr") | nindent 6 }}
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.monitoring.serviceMonitor.interval }}
+{{- end }}

--- a/helm/michelangelo/templates/validations.yaml
+++ b/helm/michelangelo/templates/validations.yaml
@@ -5,3 +5,6 @@ This file renders to empty YAML when all checks pass.
 {{- if and .Values.cadence.enabled .Values.temporal.enabled -}}
 {{- fail "cadence.enabled and temporal.enabled cannot both be true — pick one workflow engine per release. Set workflow.engine=cadence + cadence.enabled=true, OR workflow.engine=temporal + temporal.enabled=true. See helm/michelangelo/README.md." -}}
 {{- end -}}
+{{- if and .Values.monitoring.enabled (not .Values.controllermgr.enabled) -}}
+{{- fail "monitoring.enabled requires controllermgr.enabled=true — the controller manager is the only component exposing a /metrics endpoint. See helm/michelangelo/README.md." -}}
+{{- end -}}

--- a/helm/michelangelo/values.yaml
+++ b/helm/michelangelo/values.yaml
@@ -470,6 +470,26 @@ monitoring:
     # instance's serviceMonitorSelector.
     additionalLabels: {}
 
+  prometheusRule:
+    # Create a PrometheusRule with starter alerts for pipeline-run failures,
+    # long-running pipeline runs, controller reconcile errors, and cascade
+    # delete drain timeouts. All default alerts fire on metrics the
+    # controller manager exposes out of the box. Requires the Prometheus
+    # Operator CRDs (monitoring.coreos.com/v1); skipped when they are absent.
+    enabled: true
+
+    # Extra labels for the PrometheusRule, e.g. to match a Prometheus
+    # instance's ruleSelector.
+    additionalLabels: {}
+
+    envoyAlerts:
+      # Add inference latency/error-rate alerts on Envoy upstream metrics.
+      # Off by default because the Envoy admin interface (which exposes
+      # those metrics) is not enabled by the chart — enable it and add a
+      # scrape job first, or these alerts can never fire. See
+      # docs/operator-guides/operations/monitoring.md.
+      enabled: false
+
 # -----------------------------------------------------------------------------
 # ServiceAccount used by every chart-managed Pod.
 # -----------------------------------------------------------------------------

--- a/helm/michelangelo/values.yaml
+++ b/helm/michelangelo/values.yaml
@@ -448,6 +448,29 @@ controllermgr:
   resources: {}
 
 # -----------------------------------------------------------------------------
+# Optional monitoring resources. Everything here is CRD-gated: resources are
+# only rendered when the owning operator's CRDs are installed in the cluster,
+# so enabling the toggle on a cluster without the Prometheus Operator is a
+# safe no-op.
+# -----------------------------------------------------------------------------
+monitoring:
+  # Master toggle for chart-managed monitoring resources.
+  enabled: false
+
+  serviceMonitor:
+    # Scrape the controller manager's /metrics endpoint (port
+    # controllermgr.metricsPort). Requires the Prometheus Operator CRDs
+    # (monitoring.coreos.com/v1); skipped when they are absent.
+    enabled: true
+
+    # Scrape interval.
+    interval: 30s
+
+    # Extra labels for the ServiceMonitor, e.g. to match a Prometheus
+    # instance's serviceMonitorSelector.
+    additionalLabels: {}
+
+# -----------------------------------------------------------------------------
 # ServiceAccount used by every chart-managed Pod.
 # -----------------------------------------------------------------------------
 serviceAccount:


### PR DESCRIPTION
> **Stacked on #1865.** This adds the PrometheusRule under the `monitoring` toggle that PR introduces, so the branch is based on that PR's branch rather than main. The first commit here is #1865's, unchanged; only the last commit (`helm: add PrometheusRule starter alerts`) is new. Once #1865 merges I will rebase and the diff collapses to just this change -- happy to hold review until then if that is easier.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Second slice of the observability starter pack (#1692): the alert rules already specified in `docs/operator-guides/operations/monitoring.md`, shipped as an installable `PrometheusRule` under the `monitoring` toggle (CRD-gated like the ServiceMonitor).

The default group carries the four alerts backed by metrics the controller manager exposes out of the box:

- `PipelineRunFailureRateHigh`
- `PipelineRunDurationHigh` (P99 > 1h)
- `ControllerReconcileErrorRate`
- `CascadeChildDrainTimeout`

The two Envoy-based inference alerts (`InferenceLatencyHigh`, `InferenceErrorRateHigh`) sit behind `monitoring.prometheusRule.envoyAlerts.enabled` (default off): the chart does not enable the Envoy admin interface, so by default those metrics don't exist -- shipping alerts that can never fire seemed worse than shipping fewer that all work. Flip the toggle once you've enabled the admin interface and a scrape job for it.

Thresholds and expressions are taken from the monitoring guide unchanged. Two deliberate deviations in the annotation text: kubectl hints use the release namespace and the generated deployment name instead of the doc's hardcoded `ma-system`/`michelangelo-controllermgr`, and the pipeline-run hint uses `-A` since runs live in job namespaces.

**Why?**

#1692 item 2: the monitoring guide tells operators to hand-copy alert rules from documentation into their own PrometheusRule resources, which drifts (the guide's examples already carry labels and namespaces that don't match the chart). Shipping the same rules as chart-managed resources makes them installable, versioned with the chart, and correct by construction.

**How did you test it?**

- `helm lint` clean; default render byte-identical to the base branch -- the resource only appears under the `monitoring` toggle with the Prometheus Operator CRDs present.
- Rendered rule groups extracted and validated with `promtool check rules` (both the 4-alert default and the 6-alert Envoy-enabled variant pass) -- this also proves the `{{ $value }}`-style Prometheus template escapes survive helm rendering intact. Re-run on the rebased branch before posting.
- CRD-absent render verified to skip both ServiceMonitor and PrometheusRule.

**Potential risks**

- Default off and CRD-gated: no change for existing deployments, and enabling on a cluster without the Prometheus Operator is a no-op.
- Alert thresholds are starter values from the guide; operators with different SLOs will tune them via `additionalLabels`/their own rules. Deliberately conservative rather than exhaustive.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

Added chart-managed PrometheusRule starter alerts (pipeline-run failures, long-running pipeline runs, controller reconcile errors, cascade drain timeouts) under the `monitoring` toggle, with optional Envoy-based inference alerts behind `monitoring.prometheusRule.envoyAlerts.enabled`.

**Documentation Changes**

None in this PR; the docs pass repointing the monitoring guide at the chart-managed path comes later in this series.
