### PR TITLE
helm: add Grafana dashboards for the control plane and pipeline runs

### DIFF
--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -111,6 +111,30 @@ jobs:
             --set temporal.server.config.persistence.visibility.sql.password=root \
             2>/dev/null
 
+      - name: Template — monitoring enabled (ServiceMonitor renders with CRDs present)
+        run: |
+          helm template michelangelo helm/michelangelo \
+            -f helm/michelangelo/values-k3d.yaml \
+            --set monitoring.enabled=true \
+            --api-versions monitoring.coreos.com/v1 \
+            --debug \
+            | grep 'kind: ServiceMonitor'
+
+      - name: Template — monitoring enabled without CRDs (must skip gracefully)
+        run: |
+          ! helm template michelangelo helm/michelangelo \
+            -f helm/michelangelo/values-k3d.yaml \
+            --set monitoring.enabled=true \
+            | grep 'kind: ServiceMonitor'
+
+      - name: Validate fail-fast guard (monitoring without controllermgr must fail)
+        run: |
+          ! helm template michelangelo helm/michelangelo \
+            -f helm/michelangelo/values-k3d.yaml \
+            --set monitoring.enabled=true \
+            --set controllermgr.enabled=false \
+            2>/dev/null
+
       - name: Template — Ingress enabled (UI + Envoy, hosts[] syntax)
         run: |
           helm template michelangelo helm/michelangelo \

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -118,14 +118,14 @@ jobs:
             --set monitoring.enabled=true \
             --api-versions monitoring.coreos.com/v1 \
             --debug \
-            | grep 'kind: ServiceMonitor'
+            | grep -e 'kind: ServiceMonitor' -e 'kind: PrometheusRule'
 
       - name: Template — monitoring enabled without CRDs (must skip gracefully)
         run: |
           ! helm template michelangelo helm/michelangelo \
             -f helm/michelangelo/values-k3d.yaml \
             --set monitoring.enabled=true \
-            | grep 'kind: ServiceMonitor'
+            | grep -e 'kind: ServiceMonitor' -e 'kind: PrometheusRule'
 
       - name: Validate fail-fast guard (monitoring without controllermgr must fail)
         run: |

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -117,15 +117,16 @@ jobs:
             -f helm/michelangelo/values-k3d.yaml \
             --set monitoring.enabled=true \
             --api-versions monitoring.coreos.com/v1 \
+            --api-versions grafana.integreatly.org/v1beta1 \
             --debug \
-            | grep -e 'kind: ServiceMonitor' -e 'kind: PrometheusRule'
+            | grep -e 'kind: ServiceMonitor' -e 'kind: PrometheusRule' -e 'kind: GrafanaDashboard'
 
       - name: Template — monitoring enabled without CRDs (must skip gracefully)
         run: |
           ! helm template michelangelo helm/michelangelo \
             -f helm/michelangelo/values-k3d.yaml \
             --set monitoring.enabled=true \
-            | grep -e 'kind: ServiceMonitor' -e 'kind: PrometheusRule'
+            | grep -e 'kind: ServiceMonitor' -e 'kind: PrometheusRule' -e 'kind: GrafanaDashboard'
 
       - name: Validate fail-fast guard (monitoring without controllermgr must fail)
         run: |

--- a/docs/operator-guides/operations/monitoring.md
+++ b/docs/operator-guides/operations/monitoring.md
@@ -14,7 +14,16 @@ Michelangelo AI components expose Prometheus metrics that integrate with a stand
 
 ### Controller Manager
 
-The controller manager exposes metrics on port `8091` (configured via `metricsBindAddress`). If you are using the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator), create a `ServiceMonitor`:
+The controller manager exposes metrics on port `8091` (configured via `metricsBindAddress`). If you are using the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator), the Helm chart can create the `ServiceMonitor` for you:
+
+```bash
+helm upgrade michelangelo ./helm/michelangelo --reuse-values \
+  --set monitoring.enabled=true
+```
+
+The resource is only rendered when the Prometheus Operator CRDs (`monitoring.coreos.com/v1`) are installed, so the toggle is a safe no-op on clusters without the operator. Scrape interval and extra labels (e.g. to match your Prometheus instance's `serviceMonitorSelector`) are configurable under `monitoring.serviceMonitor.*`.
+
+To create the `ServiceMonitor` yourself instead, select the controller manager Service by its chart labels:
 
 ```yaml
 apiVersion: monitoring.coreos.com/v1
@@ -22,12 +31,12 @@ kind: ServiceMonitor
 metadata:
   name: michelangelo-controllermgr
   namespace: ma-system
-  labels:
-    app: michelangelo-controllermgr
 spec:
   selector:
     matchLabels:
-      app: michelangelo-controllermgr
+      app.kubernetes.io/name: michelangelo
+      app.kubernetes.io/instance: michelangelo   # your Helm release name
+      app.kubernetes.io/component: controllermgr
   endpoints:
   - port: metrics          # Must match the Service port name for port 8091
     path: /metrics
@@ -36,12 +45,12 @@ spec:
 
 ### Health Probes
 
-The controller manager exposes health endpoints on port `8083` (configured via `healthProbeBindAddress`):
+The controller manager exposes health endpoints on port `8081` (configured via `healthProbeBindAddress`; the chart default is `controllermgr.healthPort: 8081`):
 
 | Endpoint | Purpose |
 |----------|---------|
-| `GET :8083/healthz` | Liveness — is the process alive? |
-| `GET :8083/readyz` | Readiness — is the controller ready to reconcile? |
+| `GET :8081/healthz` | Liveness — is the process alive? |
+| `GET :8081/readyz` | Readiness — is the controller ready to reconcile? |
 
 These are used by Kubernetes liveness and readiness probes, but you can also poll them from your monitoring stack for coarser-grained health checks.
 

--- a/helm/michelangelo/README.md
+++ b/helm/michelangelo/README.md
@@ -283,6 +283,9 @@ Top-level keys. See [`values.yaml`](./values.yaml) for the full annotated schema
 | `monitoring.serviceMonitor.enabled` | bool | `true` | no | Create a `ServiceMonitor` for the controller manager's `/metrics` endpoint (requires the Prometheus Operator CRDs, `monitoring.coreos.com/v1`). |
 | `monitoring.serviceMonitor.interval` | string | `30s` | no | Scrape interval. |
 | `monitoring.serviceMonitor.additionalLabels` | object | `{}` | no | Extra labels on the `ServiceMonitor`, e.g. to match a Prometheus instance's `serviceMonitorSelector`. |
+| `monitoring.prometheusRule.enabled` | bool | `true` | no | Create a `PrometheusRule` with starter alerts (pipeline-run failures/duration, reconcile errors, cascade drain timeouts). All default alerts use metrics exposed out of the box. |
+| `monitoring.prometheusRule.additionalLabels` | object | `{}` | no | Extra labels on the `PrometheusRule`, e.g. to match a Prometheus instance's `ruleSelector`. |
+| `monitoring.prometheusRule.envoyAlerts.enabled` | bool | `false` | no | Add inference latency/error alerts on Envoy upstream metrics. Requires the Envoy admin interface + a scrape job (not chart-managed). |
 | `serviceAccount.create` | bool | `true` | no | Create a ServiceAccount for the chart. |
 | `serviceAccount.name` | string | `""` | no | Override the generated ServiceAccount name. |
 | `podSecurityContext` | object | see values.yaml | no | Applied to every Pod. |

--- a/helm/michelangelo/README.md
+++ b/helm/michelangelo/README.md
@@ -286,6 +286,9 @@ Top-level keys. See [`values.yaml`](./values.yaml) for the full annotated schema
 | `monitoring.prometheusRule.enabled` | bool | `true` | no | Create a `PrometheusRule` with starter alerts (pipeline-run failures/duration, reconcile errors, cascade drain timeouts). All default alerts use metrics exposed out of the box. |
 | `monitoring.prometheusRule.additionalLabels` | object | `{}` | no | Extra labels on the `PrometheusRule`, e.g. to match a Prometheus instance's `ruleSelector`. |
 | `monitoring.prometheusRule.envoyAlerts.enabled` | bool | `false` | no | Add inference latency/error alerts on Envoy upstream metrics. Requires the Envoy admin interface + a scrape job (not chart-managed). |
+| `monitoring.grafanaDashboards.enabled` | bool | `true` | no | Create `GrafanaDashboard` CRs for the [Grafana Operator](https://github.com/grafana/grafana-operator) (requires its CRDs, `grafana.integreatly.org/v1beta1`). |
+| `monitoring.grafanaDashboards.instanceSelector` | object | `matchLabels: {dashboards: grafana}` | no | Label selector matching your Grafana CR(s). |
+| `monitoring.grafanaDashboards.resyncPeriod` | string | `10m` | no | How often the operator re-applies the dashboards. |
 | `serviceAccount.create` | bool | `true` | no | Create a ServiceAccount for the chart. |
 | `serviceAccount.name` | string | `""` | no | Override the generated ServiceAccount name. |
 | `podSecurityContext` | object | see values.yaml | no | Applied to every Pod. |

--- a/helm/michelangelo/README.md
+++ b/helm/michelangelo/README.md
@@ -279,6 +279,10 @@ Top-level keys. See [`values.yaml`](./values.yaml) for the full annotated schema
 | `worker.replicas` | int | `1` | no | Scale horizontally for higher pipeline-run throughput. |
 | `controllermgr.enabled` | bool | `true` | no | |
 | `controllermgr.watchNamespace` | list | `[]` | no | Namespaces the controller watches. Empty = all namespaces (ClusterRole). Set to a list to scope down to namespaced Roles. |
+| `monitoring.enabled` | bool | `false` | no | Master toggle for chart-managed monitoring resources. All resources are CRD-gated: skipped when the owning operator's CRDs are absent, so enabling this is safe on any cluster. |
+| `monitoring.serviceMonitor.enabled` | bool | `true` | no | Create a `ServiceMonitor` for the controller manager's `/metrics` endpoint (requires the Prometheus Operator CRDs, `monitoring.coreos.com/v1`). |
+| `monitoring.serviceMonitor.interval` | string | `30s` | no | Scrape interval. |
+| `monitoring.serviceMonitor.additionalLabels` | object | `{}` | no | Extra labels on the `ServiceMonitor`, e.g. to match a Prometheus instance's `serviceMonitorSelector`. |
 | `serviceAccount.create` | bool | `true` | no | Create a ServiceAccount for the chart. |
 | `serviceAccount.name` | string | `""` | no | Override the generated ServiceAccount name. |
 | `podSecurityContext` | object | see values.yaml | no | Applied to every Pod. |

--- a/helm/michelangelo/files/dashboards/control-plane.json
+++ b/helm/michelangelo/files/dashboards/control-plane.json
@@ -1,0 +1,406 @@
+{
+  "uid": "michelangelo-control-plane",
+  "title": "Michelangelo AI / Control Plane",
+  "tags": [
+    "michelangelo"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "refresh": "30s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "label": "Data source",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {}
+      }
+    ]
+  },
+  "panels": [
+    {
+      "title": "Pipeline run results",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (state) (rate(pipelinerun_result_total[5m]))",
+          "legendFormat": "{{state}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "ops"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Failed pipeline runs (latest)",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 0,
+        "w": 4,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum(pipelinerun_failed)",
+          "legendFormat": "failed",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Pipelines reached Ready",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 0,
+        "w": 4,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum(pipeline_ready_total)",
+          "legendFormat": "ready",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Reconcile errors",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 0,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(controller_runtime_reconcile_errors_total[5m]))",
+          "legendFormat": "errors/sec",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "ops"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Reconcile error rate by controller",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 8,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (controller) (rate(controller_runtime_reconcile_errors_total[5m]))",
+          "legendFormat": "{{controller}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "ops"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Reconcile latency P99",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 8,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(controller_runtime_reconcile_time_seconds_bucket[5m])))",
+          "legendFormat": "p99",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "s"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Work queue depth",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 8,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "workqueue_depth",
+          "legendFormat": "{{name}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "CR reflector errors",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 16,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (crd_type, error_type) (rate(cr_reflector_errors_total[5m]))",
+          "legendFormat": "{{crd_type}}/{{error_type}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "ops"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Cascade delete: children draining",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 16,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "cascade_child_drain_active",
+          "legendFormat": "{{kind}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Cascade delete: drain duration P99",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 16,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum by (le, kind) (rate(cascade_child_drain_duration_seconds_bucket[5m])))",
+          "legendFormat": "{{kind}} p99",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "s"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Cascade delete: drain timeouts (1h)",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 24,
+        "w": 4,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(cascade_child_drain_timeout_total[1h]))",
+          "legendFormat": "timeouts",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "ownerReference backfills",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 4,
+        "y": 24,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (kind) (rate(cascade_owner_ref_backfill_total[5m]))",
+          "legendFormat": "{{kind}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "ops"
+        },
+        "overrides": []
+      }
+    }
+  ]
+}

--- a/helm/michelangelo/files/dashboards/jobs.json
+++ b/helm/michelangelo/files/dashboards/jobs.json
@@ -1,0 +1,278 @@
+{
+  "uid": "michelangelo-jobs",
+  "title": "Michelangelo AI / Pipeline Runs",
+  "tags": [
+    "michelangelo"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "refresh": "30s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "label": "Data source",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {}
+      }
+    ]
+  },
+  "panels": [
+    {
+      "title": "Run duration P50 / P99",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(pipelinerun_duration_seconds_bucket[5m])))",
+          "legendFormat": "p50",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(pipelinerun_duration_seconds_bucket[5m])))",
+          "legendFormat": "p99",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "s"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Failure rate by reason",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 0,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (failure_reason) (rate(pipelinerun_result_failure_total[5m]))",
+          "legendFormat": "{{failure_reason}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "ops"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Results by state",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 8,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (state) (rate(pipelinerun_result_total[5m]))",
+          "legendFormat": "{{state}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "ops"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Results by pipeline type",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 8,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (pipeline_type) (rate(pipelinerun_result_total[5m]))",
+          "legendFormat": "{{pipeline_type}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "ops"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Successes vs failures",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 8,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(pipelinerun_result_success_total[5m]))",
+          "legendFormat": "success",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        },
+        {
+          "expr": "sum(rate(pipelinerun_result_failure_total[5m]))",
+          "legendFormat": "failure",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "ops"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Step completions by step",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 16,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (step_name) (rate(pipelinerun_step_success_total[5m]))",
+          "legendFormat": "{{step_name}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "ops"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Reconcile outcomes",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 16,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(pipelinerun_reconcile_success_total[5m]))",
+          "legendFormat": "success",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        },
+        {
+          "expr": "sum(rate(pipelinerun_reconcile_errors_total[5m]))",
+          "legendFormat": "errors",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "ops"
+        },
+        "overrides": []
+      }
+    }
+  ]
+}

--- a/helm/michelangelo/templates/monitoring/grafanadashboard-control-plane.yaml
+++ b/helm/michelangelo/templates/monitoring/grafanadashboard-control-plane.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.monitoring.enabled .Values.monitoring.grafanaDashboards.enabled (.Capabilities.APIVersions.Has "grafana.integreatly.org/v1beta1") }}
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: {{ include "michelangelo.fullname" . }}-control-plane
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "michelangelo.labels" . | nindent 4 }}
+spec:
+  resyncPeriod: {{ .Values.monitoring.grafanaDashboards.resyncPeriod }}
+  instanceSelector:
+    {{- toYaml .Values.monitoring.grafanaDashboards.instanceSelector | nindent 4 }}
+  json: |-
+    {{- .Files.Get "files/dashboards/control-plane.json" | nindent 4 }}
+{{- end }}

--- a/helm/michelangelo/templates/monitoring/grafanadashboard-jobs.yaml
+++ b/helm/michelangelo/templates/monitoring/grafanadashboard-jobs.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.monitoring.enabled .Values.monitoring.grafanaDashboards.enabled (.Capabilities.APIVersions.Has "grafana.integreatly.org/v1beta1") }}
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: {{ include "michelangelo.fullname" . }}-jobs
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "michelangelo.labels" . | nindent 4 }}
+spec:
+  resyncPeriod: {{ .Values.monitoring.grafanaDashboards.resyncPeriod }}
+  instanceSelector:
+    {{- toYaml .Values.monitoring.grafanaDashboards.instanceSelector | nindent 4 }}
+  json: |-
+    {{- .Files.Get "files/dashboards/jobs.json" | nindent 4 }}
+{{- end }}

--- a/helm/michelangelo/templates/monitoring/prometheusrule.yaml
+++ b/helm/michelangelo/templates/monitoring/prometheusrule.yaml
@@ -1,0 +1,91 @@
+{{- if and .Values.monitoring.enabled .Values.monitoring.prometheusRule.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "michelangelo.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "michelangelo.labels" . | nindent 4 }}
+    {{- with .Values.monitoring.prometheusRule.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  groups:
+    - name: michelangelo
+      rules:
+        # Pipeline run failure rate
+        - alert: PipelineRunFailureRateHigh
+          expr: rate(pipelinerun_result_failure_total[5m]) > 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Pipeline run failures detected"
+            description: >-
+              Pipeline runs are failing at {{`{{ $value | humanize }}`}} failures/sec.
+              Check failure reasons: kubectl get pipelineruns -A --field-selector status.phase=Failed
+
+        # Pipeline run duration: P99 above 1 hour
+        - alert: PipelineRunDurationHigh
+          expr: histogram_quantile(0.99, rate(pipelinerun_duration_seconds_bucket[5m])) > 3600
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Pipeline run P99 duration above 1 hour"
+            description: >-
+              The 99th percentile pipeline run duration is {{`{{ $value | humanize }}`}}s.
+
+        # Controller reconcile errors — sustained error rate from any controller
+        - alert: ControllerReconcileErrorRate
+          expr: rate(controller_runtime_reconcile_errors_total[5m]) > 0.1
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Controller {{`{{ $labels.controller }}`}} has high reconcile error rate"
+            description: >-
+              The {{`{{ $labels.controller }}`}} controller is failing reconciles at
+              {{`{{ $value | humanize }}`}} errors/sec. Check logs:
+              kubectl -n {{ .Release.Namespace }} logs deployment/{{ include "michelangelo.componentFullname" (dict "context" . "component" "controllermgr") }}
+
+        # Cascade delete: safety timeout force-completed a child's drain
+        - alert: CascadeChildDrainTimeout
+          expr: increase(cascade_child_drain_timeout_total[1h]) > 0
+          for: 0m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Cascade delete safety timeout fired"
+            description: >-
+              {{`{{ $value }}`}} child resource(s) were force-killed because their drain
+              did not complete within 24 hours. Investigate why the drain was wedged:
+              kubectl -n {{ .Release.Namespace }} logs deployment/{{ include "michelangelo.componentFullname" (dict "context" . "component" "controllermgr") }} | grep -i "cascade\|force"
+    {{- if .Values.monitoring.prometheusRule.envoyAlerts.enabled }}
+
+    - name: michelangelo-envoy
+      rules:
+        # Inference latency: P99 above 500ms for 5 minutes
+        - alert: InferenceLatencyHigh
+          expr: histogram_quantile(0.99, rate(envoy_cluster_upstream_rq_time_bucket[5m])) > 500
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Inference P99 latency is above 500ms"
+            description: >-
+              The 99th percentile inference request latency is {{`{{ $value }}`}}ms.
+              Check InferenceServer and model-sync sidecar logs.
+
+        # Inference error rate: more than 1% of requests returning 5xx
+        - alert: InferenceErrorRateHigh
+          expr: rate(envoy_cluster_upstream_rq_5xx[5m]) / rate(envoy_cluster_upstream_rq_total[5m]) > 0.01
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Inference 5xx error rate above 1%"
+            description: >-
+              {{`{{ $value | humanizePercentage }}`}} of inference requests are returning 5xx errors.
+    {{- end }}
+{{- end }}

--- a/helm/michelangelo/templates/monitoring/servicemonitor-controllermgr.yaml
+++ b/helm/michelangelo/templates/monitoring/servicemonitor-controllermgr.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.monitoring.enabled .Values.monitoring.serviceMonitor.enabled .Values.controllermgr.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "michelangelo.componentFullname" (dict "context" . "component" "controllermgr") }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "michelangelo.componentLabels" (dict "context" . "component" "controllermgr") | nindent 4 }}
+    {{- with .Values.monitoring.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "michelangelo.componentSelectorLabels" (dict "context" . "component" "controllermgr") | nindent 6 }}
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.monitoring.serviceMonitor.interval }}
+{{- end }}

--- a/helm/michelangelo/templates/validations.yaml
+++ b/helm/michelangelo/templates/validations.yaml
@@ -5,3 +5,6 @@ This file renders to empty YAML when all checks pass.
 {{- if and .Values.cadence.enabled .Values.temporal.enabled -}}
 {{- fail "cadence.enabled and temporal.enabled cannot both be true — pick one workflow engine per release. Set workflow.engine=cadence + cadence.enabled=true, OR workflow.engine=temporal + temporal.enabled=true. See helm/michelangelo/README.md." -}}
 {{- end -}}
+{{- if and .Values.monitoring.enabled (not .Values.controllermgr.enabled) -}}
+{{- fail "monitoring.enabled requires controllermgr.enabled=true — the controller manager is the only component exposing a /metrics endpoint. See helm/michelangelo/README.md." -}}
+{{- end -}}

--- a/helm/michelangelo/values.yaml
+++ b/helm/michelangelo/values.yaml
@@ -470,6 +470,26 @@ monitoring:
     # instance's serviceMonitorSelector.
     additionalLabels: {}
 
+  prometheusRule:
+    # Create a PrometheusRule with starter alerts for pipeline-run failures,
+    # long-running pipeline runs, controller reconcile errors, and cascade
+    # delete drain timeouts. All default alerts fire on metrics the
+    # controller manager exposes out of the box. Requires the Prometheus
+    # Operator CRDs (monitoring.coreos.com/v1); skipped when they are absent.
+    enabled: true
+
+    # Extra labels for the PrometheusRule, e.g. to match a Prometheus
+    # instance's ruleSelector.
+    additionalLabels: {}
+
+    envoyAlerts:
+      # Add inference latency/error-rate alerts on Envoy upstream metrics.
+      # Off by default because the Envoy admin interface (which exposes
+      # those metrics) is not enabled by the chart — enable it and add a
+      # scrape job first, or these alerts can never fire. See
+      # docs/operator-guides/operations/monitoring.md.
+      enabled: false
+
 # -----------------------------------------------------------------------------
 # ServiceAccount used by every chart-managed Pod.
 # -----------------------------------------------------------------------------

--- a/helm/michelangelo/values.yaml
+++ b/helm/michelangelo/values.yaml
@@ -490,6 +490,23 @@ monitoring:
       # docs/operator-guides/operations/monitoring.md.
       enabled: false
 
+  grafanaDashboards:
+    # Create GrafanaDashboard CRs (control-plane and pipeline-run views)
+    # for the Grafana Operator (https://github.com/grafana/grafana-operator).
+    # Every panel queries metrics the controller manager exposes out of the
+    # box. Requires the Grafana Operator CRDs (grafana.integreatly.org/v1beta1);
+    # skipped when they are absent.
+    enabled: true
+
+    # How often the operator re-applies the dashboards to Grafana.
+    resyncPeriod: 10m
+
+    # Label selector matching the Grafana CR(s) the dashboards should be
+    # installed into. Must match labels you set on your Grafana instance.
+    instanceSelector:
+      matchLabels:
+        dashboards: grafana
+
 # -----------------------------------------------------------------------------
 # ServiceAccount used by every chart-managed Pod.
 # -----------------------------------------------------------------------------

--- a/helm/michelangelo/values.yaml
+++ b/helm/michelangelo/values.yaml
@@ -448,6 +448,29 @@ controllermgr:
   resources: {}
 
 # -----------------------------------------------------------------------------
+# Optional monitoring resources. Everything here is CRD-gated: resources are
+# only rendered when the owning operator's CRDs are installed in the cluster,
+# so enabling the toggle on a cluster without the Prometheus Operator is a
+# safe no-op.
+# -----------------------------------------------------------------------------
+monitoring:
+  # Master toggle for chart-managed monitoring resources.
+  enabled: false
+
+  serviceMonitor:
+    # Scrape the controller manager's /metrics endpoint (port
+    # controllermgr.metricsPort). Requires the Prometheus Operator CRDs
+    # (monitoring.coreos.com/v1); skipped when they are absent.
+    enabled: true
+
+    # Scrape interval.
+    interval: 30s
+
+    # Extra labels for the ServiceMonitor, e.g. to match a Prometheus
+    # instance's serviceMonitorSelector.
+    additionalLabels: {}
+
+# -----------------------------------------------------------------------------
 # ServiceAccount used by every chart-managed Pod.
 # -----------------------------------------------------------------------------
 serviceAccount:


### PR DESCRIPTION
> **Stacked on #1874** (which stacks on #1865). This adds the Grafana dashboards on top of the monitoring toggle and alert rules those PRs introduce, so the branch is based on #1874's branch rather than main. The first two commits here are #1865's and #1874's, unchanged; only the last commit (`helm: add GrafanaDashboard CRs for control plane and pipeline runs`) is new -- [this compare view](https://github.com/apurvapatkeshwar/michelangelo/compare/feat/monitoring-prometheusrules...feat/monitoring-grafana-dashboards) shows just this PR's diff. Once the parents merge I will rebase and the diff here collapses to the same thing -- happy to hold review until then if that is easier.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Third slice of the observability starter pack (#1692): two dashboards shipped as [Grafana Operator](https://github.com/grafana/grafana-operator) `GrafanaDashboard` CRs (`grafana.integreatly.org/v1beta1`), CRD-gated like the other monitoring resources and toggled by `monitoring.grafanaDashboards.enabled`.

- **Control Plane**: pipeline run results and readiness, reconcile error rates and P99 latency by controller, work queue depth, CR reflector errors, and the cascade delete family (active drains, drain duration P99, timeouts, ownerReference backfills).
- **Pipeline Runs**: duration P50/P99, failure rate by reason, results by state and pipeline type, successes vs failures, step completions.

`monitoring.grafanaDashboards.instanceSelector` picks which Grafana instance(s) get the dashboards (default matches `dashboards: grafana`, the operator's common convention).

Two implementation notes:

- The dashboard JSON lives under `files/dashboards/` as plain JSON loaded with `.Files.Get`, so Grafana's `{{label}}` legend syntax never collides with chart templating and the files can be linted or imported directly.
- The panels were built from the metric names in the Go source, not adapted from existing templates -- every query targets a metric the controller manager actually registers today (`pipelinerun_*`, `pipeline_*`, `cascade_*`, `cr_reflector_errors_total`, plus standard controller-runtime/workqueue metrics). Notably the sandbox grafana config references a `crd_unmarshal_errors_*` metric name that doesn't exist in the codebase; these dashboards use the real `cr_reflector_errors_total` instead. No Envoy panels, since those metrics are absent by default.

**Why?**

#1692 item 3: operators wiring up the chart today have to build dashboards from scratch or adapt the sandbox's grafana config, which references metrics that don't exist. Shipping operator-managed dashboards versioned with the chart gives every install the same starting point, correct by construction against the metrics the code actually exposes.

**How did you test it?**

- `helm lint` clean; default render byte-identical to the base branch -- the dashboards only appear under the `monitoring` toggle with the Grafana Operator CRD present.
- Each rendered CR's embedded JSON round-trips through a JSON parser after helm templating (12-panel and 7-panel dashboards, `instanceSelector` present on both). Re-run on the current stack tip before posting.
- Gating matrix verified: Grafana-CRD-absent render skips the dashboards while keeping the Prometheus resources; `monitoring.grafanaDashboards.enabled=false` does the same; `monitoring` off renders none of the three kinds.
- Every PromQL expression in every panel checked against the list of metrics registered in the Go source -- zero references to non-exposed metrics.
- CI monitoring check extended with the Grafana API version and now asserts all three resource kinds render (both the repeated-flag and comma-joined `--api-versions` forms verified against helm v3.16).

**Potential risks**

- Default-off and CRD-gated: no change for existing deployments, and enabling on a cluster without the Grafana Operator is a no-op.
- Dashboards are starter content: operators with existing dashboards can leave the toggle off or use `instanceSelector` to scope them to a sandbox Grafana.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

Added chart-managed Grafana dashboards (control plane health and pipeline runs) as Grafana Operator `GrafanaDashboard` resources under the `monitoring` toggle, gated by `monitoring.grafanaDashboards.enabled`.

**Documentation Changes**

None in this PR; the docs pass repointing the monitoring guide at the chart-managed dashboards comes last in this series.
