### PR TITLE
feat(train): add FSDP2 strategy to the Lightning trainer

### DIFF
--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/_private/model_parallel.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/_private/model_parallel.py
@@ -1,0 +1,81 @@
+"""Ray-aware FSDP2 (``ModelParallelStrategy``) glue.
+
+``ModelParallelStrategy`` requires pytorch-lightning >= 2.3, so ``util.py`` imports this module
+lazily (only once FSDP2 is requested) rather than at top level.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import ray
+import torch
+from pytorch_lightning.strategies import ModelParallelStrategy
+
+_logger = logging.getLogger(__name__)
+
+
+class RayModelParallelStrategy(ModelParallelStrategy):
+    """Ray glue for FSDP2.
+
+    Ray Train ships RayDDPStrategy/RayFSDPStrategy/RayDeepSpeedStrategy but no
+    equivalent for ModelParallelStrategy, so we supply the Ray device and rank
+    wiring ourselves. Remove once Ray adds native ModelParallelStrategy support.
+    """
+
+    def __init__(self, *args, **kwargs):
+        if kwargs.get("save_distributed_checkpoint") is False:
+            _logger.warning(
+                "save_distributed_checkpoint=False is not supported; FSDP2 always saves sharded (DCP) "
+                "checkpoints. Forcing save_distributed_checkpoint=True."
+            )
+        kwargs["save_distributed_checkpoint"] = True
+
+        if kwargs.get("tensor_parallel_size") is not None:
+            raise ValueError(
+                "Tensor parallelism is not currently supported. Leave tensor_parallel_size unset. "
+                f"Got tensor_parallel_size: {kwargs.get('tensor_parallel_size')}"
+            )
+
+        if kwargs.get("data_parallel_size") is not None:
+            raise ValueError(
+                "Configuring data parallelism is not supported; FSDP2 always shards across the "
+                f"full world (data_parallel_size = world_size). Leave data_parallel_size unset. "
+                f"Got data_parallel_size: {kwargs.get('data_parallel_size')}"
+            )
+
+        if kwargs.get("process_group_backend") is not None:
+            raise ValueError(
+                "Configuring the process group is not supported; Ray Train sets the backend. "
+                f"Leave process_group_backend unset. Got process_group_backend: {kwargs.get('process_group_backend')}"
+            )
+
+        if kwargs.get("timeout") is not None:
+            raise ValueError(
+                "Configuring the process group timeout is not supported; Ray Train sets the timeout. "
+                f"Leave timeout unset. Got timeout: {kwargs.get('timeout')}"
+            )
+
+        super().__init__(*args, **kwargs)
+
+    @property
+    def root_device(self) -> torch.device:
+        return ray.train.torch.get_device()
+
+    @property
+    def distributed_sampler_kwargs(self) -> dict[str, Any]:
+        return {"num_replicas": self.world_size, "rank": self.global_rank}
+
+    def setup_environment(self) -> None:
+        self._tensor_parallel_size = 1
+        self._data_parallel_size = self.world_size
+        _logger.info(
+            "FSDP2 parallelism resolved: tensor_parallel_size=%d, "
+            "data_parallel_size=%d, world_size=%d",
+            self._tensor_parallel_size,
+            self._data_parallel_size,
+            self.world_size,
+        )
+        super().setup_environment()
+        _logger.info("FSDP2 device mesh initialized: %s", self._device_mesh)

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/_private/model_parallel.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/_private/model_parallel.py
@@ -7,11 +7,13 @@ lazily (only once FSDP2 is requested) rather than at top level.
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import ray
-import torch
 from pytorch_lightning.strategies import ModelParallelStrategy
+
+if TYPE_CHECKING:
+    import torch
 
 _logger = logging.getLogger(__name__)
 

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/_private/util.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/_private/util.py
@@ -295,6 +295,52 @@ def build_mlflow_logger(
     )
 
 
+def _is_model_parallel_strategy(strategy: str | Strategy | None) -> bool:
+    """True if ``strategy`` is the string "fsdp2" or a ``ModelParallelStrategy`` instance.
+
+    The guarded import returns False on pytorch-lightning < 2.3, where the class does not exist.
+    """
+    if strategy is None:
+        return False
+    if isinstance(strategy, str):
+        return strategy.lower() == "fsdp2"
+    try:
+        from pytorch_lightning.strategies import ModelParallelStrategy
+    except ImportError:
+        return False
+    return isinstance(strategy, ModelParallelStrategy)
+
+
+def _is_deepspeed_strategy(strategy: str | Strategy | None) -> bool:
+    """True if ``strategy`` is the string "deepspeed" or a ``RayDeepSpeedStrategy`` instance."""
+    if strategy is None:
+        return False
+    if isinstance(strategy, str):
+        return strategy.lower() == "deepspeed"
+    return isinstance(strategy, RayDeepSpeedStrategy)
+
+
+def _prepare_trainer_for_ray(trainer: pl.Trainer) -> pl.Trainer:
+    """Prepare a Lightning Trainer for Ray, tolerating ModelParallelStrategy (FSDP2).
+
+    Ray's ``prepare_trainer`` hard-rejects any strategy that is not
+    ``RayDDPStrategy``/``RayFSDPStrategy``/``RayDeepSpeedStrategy``. For FSDP2 we replicate
+    its only meaningful check -- that the cluster environment is ``RayLightningEnvironment`` --
+    and return the trainer unchanged; for the supported strategies we defer to Ray.
+    """
+    if _is_model_parallel_strategy(trainer.strategy):
+        cluster_env = getattr(trainer.strategy, "cluster_environment", None)
+        if cluster_env is not None and not isinstance(
+            cluster_env, RayLightningEnvironment
+        ):
+            raise RuntimeError(
+                f"Invalid cluster environment plugin. The expected class is "
+                f"`RayLightningEnvironment` but got {type(cluster_env)}!"
+            )
+        return trainer
+    return ray.train.lightning.prepare_trainer(trainer)
+
+
 def _resolve_strategy(
     strategy: str | Strategy | None = None,
     strategy_kwargs: dict[str, Any] | None = None,
@@ -320,9 +366,20 @@ def _resolve_strategy(
         return RayDeepSpeedStrategy(**strategy_kwargs)
     elif strategy.lower() == "fsdp":
         return RayFSDPStrategy(**strategy_kwargs)
+    elif strategy.lower() == "fsdp2":
+        try:
+            from michelangelo.lib.trainer.torch.pytorch_lightning._private.model_parallel import (
+                RayModelParallelStrategy,
+            )
+        except ImportError as e:
+            raise ValueError(
+                "strategy 'fsdp2' requires pytorch-lightning >= 2.3 (ModelParallelStrategy). "
+                "Please check the version of pytorch-lightning installed."
+            ) from e
+        return RayModelParallelStrategy(**strategy_kwargs)
     else:
         raise ValueError(
-            f"Unsupported strategy: {strategy!r}; expected 'ddp', 'deepspeed', 'fsdp', or None"
+            f"Unsupported strategy: {strategy!r}; expected 'ddp', 'deepspeed', 'fsdp', 'fsdp2', or None"
         )
 
 
@@ -507,10 +564,12 @@ def _resolve_callbacks(
     )
 
     # Always append a callback that calls ray.train.report() to report metrics and checkpoint.
-    # Per-node reporting is required for model-parallel strategies (DeepSpeed ZeRO, FSDP) because
+    # Per-node reporting is required for model-parallel strategies (DeepSpeed ZeRO, FSDP, FSDP2) because
     # each node holds shards of the model and must upload its own checkpoint shard.
-    _use_per_node = per_node_callback_kwargs is not None or isinstance(
-        strategy, (RayDeepSpeedStrategy, RayFSDPStrategy)
+    _use_per_node = (
+        per_node_callback_kwargs is not None
+        or isinstance(strategy, (RayDeepSpeedStrategy, RayFSDPStrategy))
+        or _is_model_parallel_strategy(strategy)
     )
     if _use_per_node:
         per_node_callback_kwargs = per_node_callback_kwargs or {}
@@ -1272,7 +1331,7 @@ def _train_loop_per_worker(train_loop_config):
     trainer = pl.Trainer(
         **trainer_kwargs,
     )
-    trainer = ray.train.lightning.prepare_trainer(trainer)
+    trainer = _prepare_trainer_for_ray(trainer)
 
     checkpoint = ray.train.get_checkpoint()
     if checkpoint is None:

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/lightning_trainer.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/lightning_trainer.py
@@ -455,10 +455,10 @@ class LightningTrainerWithStateDict(LightningTrainer):
                 )
             elif used_model_parallel:
                 # Private torch API, re-verify on torch upgrade.
+                from torch.distributed.checkpoint import FileSystemReader
                 from torch.distributed.checkpoint.state_dict_loader import (
                     _load_state_dict_from_keys,
                 )
-                from torch.distributed.checkpoint import FileSystemReader
 
                 loaded = _load_state_dict_from_keys(
                     {"state_dict"},
@@ -469,9 +469,7 @@ class LightningTrainerWithStateDict(LightningTrainer):
                     raise RuntimeError(
                         f"FSDP2 sharded checkpoint from {lightning_ckpt_path!r} has no 'state_dict' keys."
                     )
-                _logger.info(
-                    "Loaded FSDP2 model weights from %s", lightning_ckpt_path
-                )
+                _logger.info("Loaded FSDP2 model weights from %s", lightning_ckpt_path)
             else:
                 # DDP checkpoint
                 checkpoint = torch.load(lightning_ckpt_path, map_location="cpu")

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/lightning_trainer.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/lightning_trainer.py
@@ -45,6 +45,8 @@ from pytorch_lightning.utilities.deepspeed import (
 from ray.train.torch import TorchTrainer
 
 from michelangelo.lib.trainer.torch.pytorch_lightning._private.util import (
+    _is_deepspeed_strategy,
+    _is_model_parallel_strategy,
     _train_loop_per_worker,
 )
 
@@ -408,26 +410,9 @@ class LightningTrainerWithStateDict(LightningTrainer):
 
     After ``train()`` completes, callers can pass an initialized ``torch.nn.Module``
     to :meth:`update_model_state_dict` and have it populated from the latest
-    checkpoint. Supports both DDP single-file checkpoints and DeepSpeed ZeRO
-    sharded directories.
+    checkpoint. Supports DDP single-file checkpoints, DeepSpeed ZeRO sharded
+    directories, and FSDP2 distributed checkpoints.
     """
-
-    def _is_deepspeed_strategy(self) -> bool:
-        """Return ``True`` if the configured strategy is DeepSpeed."""
-        strategy = self.trainer_param.lightning_trainer_kwargs.get("strategy")
-        if strategy is None:
-            return False
-
-        # DeepSpeed was used if the strategy is "deepspeed" or a RayDeepSpeedStrategy instance
-        if isinstance(strategy, str):
-            return strategy.lower() == "deepspeed"
-
-        try:
-            from ray.train.lightning import RayDeepSpeedStrategy
-
-            return isinstance(strategy, RayDeepSpeedStrategy)
-        except ImportError:
-            return False
 
     def update_model_state_dict(self, torch_model: torch.nn.Module) -> None:
         """Populate ``torch_model`` in-place from the latest training checkpoint.
@@ -442,8 +427,9 @@ class LightningTrainerWithStateDict(LightningTrainer):
             raise ValueError(
                 "No checkpoint available. Please call train() first to generate a checkpoint."
             )
-        used_deepspeed = self._is_deepspeed_strategy()
-        # use the ray checkpoint as_directory() to get the local temp checkpoint directory
+        strategy = self.trainer_param.lightning_trainer_kwargs.get("strategy")
+        used_deepspeed = _is_deepspeed_strategy(strategy)
+        used_model_parallel = _is_model_parallel_strategy(strategy)
         with self.checkpoint.as_directory() as d:
             _logger.info(
                 "Saving Ray Checkpoint to local temp Checkpoint directory: %s", d
@@ -466,6 +452,25 @@ class LightningTrainerWithStateDict(LightningTrainer):
                     "Loaded DeepSpeed checkpoint from %s to %s",
                     lightning_ckpt_path,
                     local_model_path,
+                )
+            elif used_model_parallel:
+                # Private torch API, re-verify on torch upgrade.
+                from torch.distributed.checkpoint.state_dict_loader import (
+                    _load_state_dict_from_keys,
+                )
+                from torch.distributed.checkpoint import FileSystemReader
+
+                loaded = _load_state_dict_from_keys(
+                    {"state_dict"},
+                    storage_reader=FileSystemReader(lightning_ckpt_path),
+                )
+                model_state_dict = loaded.get("state_dict")
+                if not model_state_dict:
+                    raise RuntimeError(
+                        f"FSDP2 sharded checkpoint from {lightning_ckpt_path!r} has no 'state_dict' keys."
+                    )
+                _logger.info(
+                    "Loaded FSDP2 model weights from %s", lightning_ckpt_path
                 )
             else:
                 # DDP checkpoint

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_lightning_trainer.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_lightning_trainer.py
@@ -435,9 +435,9 @@ class TestLightningTrainerWithStateDict:
 
         # Stub the DCP loader module
         loader_mod = types.ModuleType("torch.distributed.checkpoint.state_dict_loader")
-        loader_mod._load_state_dict_from_keys = (
-            lambda _keys, **_kw: {"state_dict": fake_state}
-        )
+        loader_mod._load_state_dict_from_keys = lambda _keys, **_kw: {
+            "state_dict": fake_state
+        }
         dcp_mod = types.ModuleType("torch.distributed.checkpoint")
         dcp_mod.FileSystemReader = MagicMock()
 
@@ -478,15 +478,17 @@ class TestLightningTrainerWithStateDict:
         dcp_mod = types.ModuleType("torch.distributed.checkpoint")
         dcp_mod.FileSystemReader = MagicMock()
 
-        with patch.dict(
-            sys.modules,
-            {
-                "torch.distributed.checkpoint.state_dict_loader": loader_mod,
-                "torch.distributed.checkpoint": dcp_mod,
-            },
+        with (
+            patch.dict(
+                sys.modules,
+                {
+                    "torch.distributed.checkpoint.state_dict_loader": loader_mod,
+                    "torch.distributed.checkpoint": dcp_mod,
+                },
+            ),
+            pytest.raises(RuntimeError, match="no 'state_dict' keys"),
         ):
-            with pytest.raises(RuntimeError, match="no 'state_dict' keys"):
-                trainer.update_model_state_dict(torch_model)
+            trainer.update_model_state_dict(torch_model)
 
 
 # -----------------------------------------------------------------------------

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_lightning_trainer.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_lightning_trainer.py
@@ -349,38 +349,6 @@ class TestLightningTrainerWithStateDict:
         with pytest.raises(ValueError, match="No checkpoint available"):
             trainer.update_model_state_dict(MagicMock())
 
-    def test_is_deepspeed_strategy_none(self):
-        """No strategy → not DeepSpeed."""
-        trainer = self._build()
-        assert trainer._is_deepspeed_strategy() is False
-
-    def test_is_deepspeed_strategy_string(self):
-        """A string strategy of ``deepspeed`` is recognized (case-insensitive)."""
-        for name in ("deepspeed", "DeepSpeed", "DEEPSPEED"):
-            trainer = self._build(lightning_trainer_kwargs={"strategy": name})
-            assert trainer._is_deepspeed_strategy() is True
-
-    def test_is_deepspeed_strategy_other_string(self):
-        """A string strategy other than ``deepspeed`` is not DeepSpeed."""
-        trainer = self._build(lightning_trainer_kwargs={"strategy": "ddp"})
-        assert trainer._is_deepspeed_strategy() is False
-
-    def test_is_deepspeed_strategy_class(self):
-        """A ``RayDeepSpeedStrategy`` instance is recognized."""
-        try:
-            from ray.train.lightning import RayDeepSpeedStrategy
-        except ImportError:
-            pytest.skip("ray.train.lightning.RayDeepSpeedStrategy not available")
-
-        strategy = MagicMock(spec=RayDeepSpeedStrategy)
-        trainer = self._build(lightning_trainer_kwargs={"strategy": strategy})
-        assert trainer._is_deepspeed_strategy() is True
-
-    def test_is_deepspeed_strategy_other_class(self):
-        """An arbitrary non-DeepSpeed strategy instance is not DeepSpeed."""
-        trainer = self._build(lightning_trainer_kwargs={"strategy": MagicMock()})
-        assert trainer._is_deepspeed_strategy() is False
-
     def test_update_state_dict_ddp_path(self, tmp_path):
         """DDP path loads the state_dict from a torch checkpoint file."""
         trainer = self._build()  # no strategy → DDP path
@@ -442,6 +410,83 @@ class TestLightningTrainerWithStateDict:
         torch_model.load_state_dict.assert_called_once_with(fake_state, strict=False)
         # The env var the context manager sets must be torn down on exit.
         assert "TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD" not in os.environ
+
+    def test_update_state_dict_model_parallel_path(self, tmp_path):
+        """FSDP2 path: read the sharded (DCP) weights and load them into the serving model."""
+        import sys
+        import types
+
+        trainer = self._build(lightning_trainer_kwargs={"strategy": "fsdp2"})
+
+        from michelangelo.lib.trainer.torch.pytorch_lightning.lightning_trainer import (
+            CHECKPOINT_NAME,
+        )
+
+        ckpt_dir = tmp_path
+        (ckpt_dir / CHECKPOINT_NAME).mkdir()
+
+        fake_state = {"layer.weight": "tensor_data"}
+        torch_model = MagicMock(name="torch_model")
+
+        ray_ckpt = MagicMock()
+        ray_ckpt.as_directory.return_value.__enter__ = lambda _: str(ckpt_dir)
+        ray_ckpt.as_directory.return_value.__exit__ = lambda *_: None
+        trainer.checkpoint = ray_ckpt
+
+        # Stub the DCP loader module
+        loader_mod = types.ModuleType("torch.distributed.checkpoint.state_dict_loader")
+        loader_mod._load_state_dict_from_keys = (
+            lambda _keys, **_kw: {"state_dict": fake_state}
+        )
+        dcp_mod = types.ModuleType("torch.distributed.checkpoint")
+        dcp_mod.FileSystemReader = MagicMock()
+
+        with patch.dict(
+            sys.modules,
+            {
+                "torch.distributed.checkpoint.state_dict_loader": loader_mod,
+                "torch.distributed.checkpoint": dcp_mod,
+            },
+        ):
+            trainer.update_model_state_dict(torch_model)
+
+        torch_model.load_state_dict.assert_called_once_with(fake_state, strict=False)
+
+    def test_update_state_dict_model_parallel_empty_raises(self, tmp_path):
+        """FSDP2 path: an empty state_dict raises rather than silently loading nothing."""
+        import sys
+        import types
+
+        trainer = self._build(lightning_trainer_kwargs={"strategy": "fsdp2"})
+
+        from michelangelo.lib.trainer.torch.pytorch_lightning.lightning_trainer import (
+            CHECKPOINT_NAME,
+        )
+
+        ckpt_dir = tmp_path
+        (ckpt_dir / CHECKPOINT_NAME).mkdir()
+
+        torch_model = MagicMock(name="torch_model")
+
+        ray_ckpt = MagicMock()
+        ray_ckpt.as_directory.return_value.__enter__ = lambda _: str(ckpt_dir)
+        ray_ckpt.as_directory.return_value.__exit__ = lambda *_: None
+        trainer.checkpoint = ray_ckpt
+
+        loader_mod = types.ModuleType("torch.distributed.checkpoint.state_dict_loader")
+        loader_mod._load_state_dict_from_keys = lambda _keys, **_kw: {"state_dict": {}}
+        dcp_mod = types.ModuleType("torch.distributed.checkpoint")
+        dcp_mod.FileSystemReader = MagicMock()
+
+        with patch.dict(
+            sys.modules,
+            {
+                "torch.distributed.checkpoint.state_dict_loader": loader_mod,
+                "torch.distributed.checkpoint": dcp_mod,
+            },
+        ):
+            with pytest.raises(RuntimeError, match="no 'state_dict' keys"):
+                trainer.update_model_state_dict(torch_model)
 
 
 # -----------------------------------------------------------------------------

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_resolve_helpers.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_resolve_helpers.py
@@ -23,6 +23,9 @@ from ray.train.lightning import (
 
 from michelangelo.lib.trainer.torch.pytorch_lightning._private.util import (
     _accepts_run_id,
+    _is_deepspeed_strategy,
+    _is_model_parallel_strategy,
+    _prepare_trainer_for_ray,
     _resolve_callbacks,
     _resolve_logger,
     _resolve_plugins,
@@ -86,10 +89,130 @@ class TestResolveStrategy:
         with pytest.raises(TypeError, match="strategy must be"):
             _resolve_strategy(123)
 
+    @pytest.mark.parametrize("name", ["fsdp2", "FSDP2", "Fsdp2"])
+    def test_fsdp2_string_routes_to_model_parallel_strategy(self, name):
+        """The string ``"fsdp2"`` lazily imports and returns ``RayModelParallelStrategy``."""
+        _MP_MODULE = "michelangelo.lib.trainer.torch.pytorch_lightning._private.model_parallel"
+        with patch(f"{_MP_MODULE}.RayModelParallelStrategy") as mock_cls:
+            with patch(
+                f"{_UTIL_MODULE}.RayModelParallelStrategy",
+                mock_cls,
+                create=True,
+            ):
+                # Patch the lazy import inside _resolve_strategy
+                import importlib
+                import michelangelo.lib.trainer.torch.pytorch_lightning._private.model_parallel as mp_mod
+
+                with patch.dict(
+                    "sys.modules",
+                    {_MP_MODULE: mp_mod},
+                ):
+                    with patch.object(mp_mod, "RayModelParallelStrategy", mock_cls):
+                        result = _resolve_strategy(name)
+        mock_cls.assert_called_once_with()
+        assert result is mock_cls.return_value
+
+    def test_fsdp2_raises_when_class_unavailable(self):
+        """FSDP2 on pytorch-lightning < 2.3 raises ``ValueError``, not ``ImportError``."""
+        _MP_MODULE = "michelangelo.lib.trainer.torch.pytorch_lightning._private.model_parallel"
+        with patch.dict("sys.modules", {_MP_MODULE: None}):
+            with pytest.raises(ValueError, match="requires pytorch-lightning >= 2.3"):
+                _resolve_strategy("fsdp2")
+
     def test_invalid_strategy_kwargs_type_raises(self):
         """``strategy_kwargs`` must be a dict."""
         with pytest.raises(TypeError, match="strategy_kwargs must be"):
             _resolve_strategy("ddp", strategy_kwargs=["not", "a", "dict"])
+
+
+# -----------------------------------------------------------------------------
+# _is_model_parallel_strategy
+# -----------------------------------------------------------------------------
+
+
+class TestIsModelParallelStrategy:
+    """Guard function for FSDP2 detection."""
+
+    def test_string_fsdp2_is_true(self):
+        assert _is_model_parallel_strategy("fsdp2") is True
+
+    def test_other_strategy_strings_are_false(self):
+        for name in ("ddp", "fsdp", "deepspeed"):
+            assert _is_model_parallel_strategy(name) is False, name
+
+    def test_none_is_false(self):
+        assert _is_model_parallel_strategy(None) is False
+
+    def test_non_model_parallel_instance_is_false(self):
+        from pytorch_lightning.strategies import Strategy
+
+        assert _is_model_parallel_strategy(MagicMock(spec=Strategy)) is False
+
+
+# -----------------------------------------------------------------------------
+# _is_deepspeed_strategy
+# -----------------------------------------------------------------------------
+
+
+class TestIsDeepSpeedStrategy:
+    """Guard function for DeepSpeed detection."""
+
+    def test_string_deepspeed_is_true(self):
+        assert _is_deepspeed_strategy("deepspeed") is True
+
+    def test_deepspeed_instance_is_true(self):
+        from ray.train.lightning import RayDeepSpeedStrategy
+
+        assert _is_deepspeed_strategy(MagicMock(spec=RayDeepSpeedStrategy)) is True
+
+    def test_other_strategy_strings_are_false(self):
+        for name in ("ddp", "fsdp", "fsdp2", "some_custom"):
+            assert _is_deepspeed_strategy(name) is False, name
+
+    def test_none_is_false(self):
+        assert _is_deepspeed_strategy(None) is False
+
+    def test_non_deepspeed_instance_is_false(self):
+        assert _is_deepspeed_strategy(RayDDPStrategy()) is False
+
+
+# -----------------------------------------------------------------------------
+# _prepare_trainer_for_ray
+# -----------------------------------------------------------------------------
+
+
+class TestPrepareTrainerForRay:
+    """Ray trainer preparation, tolerating FSDP2."""
+
+    _IS_MP = f"{_UTIL_MODULE}._is_model_parallel_strategy"
+
+    @patch(_IS_MP, return_value=False)
+    @patch("ray.train.lightning.prepare_trainer")
+    def test_non_model_parallel_defers_to_ray(self, mock_prepare, _mock_is_mp):
+        trainer = MagicMock()
+        result = _prepare_trainer_for_ray(trainer)
+        mock_prepare.assert_called_once_with(trainer)
+        assert result is mock_prepare.return_value
+
+    @patch(_IS_MP, return_value=True)
+    def test_model_parallel_with_ray_env_returns_trainer(self, _mock_is_mp):
+        env = RayLightningEnvironment.__new__(RayLightningEnvironment)
+        trainer = MagicMock()
+        trainer.strategy.cluster_environment = env
+        assert _prepare_trainer_for_ray(trainer) is trainer
+
+    @patch(_IS_MP, return_value=True)
+    def test_model_parallel_with_wrong_cluster_env_raises(self, _mock_is_mp):
+        trainer = MagicMock()
+        trainer.strategy.cluster_environment = object()
+        with pytest.raises(RuntimeError):
+            _prepare_trainer_for_ray(trainer)
+
+    @patch(_IS_MP, return_value=True)
+    def test_model_parallel_with_no_cluster_env_returns_trainer(self, _mock_is_mp):
+        trainer = MagicMock()
+        trainer.strategy.cluster_environment = None
+        assert _prepare_trainer_for_ray(trainer) is trainer
 
 
 # -----------------------------------------------------------------------------
@@ -419,6 +542,14 @@ class TestResolveCallbacks:
         _, mock_per_node = patched_ray_report_callbacks
         strategy = MagicMock(spec=RayFSDPStrategy)
         callbacks, _ = _resolve_callbacks(None, strategy=strategy)
+        assert callbacks[-1] is mock_per_node.return_value
+
+    def test_fsdp2_strategy_triggers_per_node_callback(
+        self, patched_ray_report_callbacks
+    ):
+        """An FSDP2 (model parallel) strategy triggers the per-node Ray report callback."""
+        _, mock_per_node = patched_ray_report_callbacks
+        callbacks, _ = _resolve_callbacks(None, strategy="fsdp2")
         assert callbacks[-1] is mock_per_node.return_value
 
     def test_explicit_per_node_kwargs_triggers_per_node_callback(

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_resolve_helpers.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_resolve_helpers.py
@@ -92,32 +92,30 @@ class TestResolveStrategy:
     @pytest.mark.parametrize("name", ["fsdp2", "FSDP2", "Fsdp2"])
     def test_fsdp2_string_routes_to_model_parallel_strategy(self, name):
         """The string ``"fsdp2"`` lazily imports and returns ``RayModelParallelStrategy``."""
-        _MP_MODULE = "michelangelo.lib.trainer.torch.pytorch_lightning._private.model_parallel"
-        with patch(f"{_MP_MODULE}.RayModelParallelStrategy") as mock_cls:
-            with patch(
-                f"{_UTIL_MODULE}.RayModelParallelStrategy",
-                mock_cls,
-                create=True,
-            ):
-                # Patch the lazy import inside _resolve_strategy
-                import importlib
-                import michelangelo.lib.trainer.torch.pytorch_lightning._private.model_parallel as mp_mod
+        mp_module = (
+            "michelangelo.lib.trainer.torch.pytorch_lightning._private.model_parallel"
+        )
+        import michelangelo.lib.trainer.torch.pytorch_lightning._private.model_parallel as mp_mod
 
-                with patch.dict(
-                    "sys.modules",
-                    {_MP_MODULE: mp_mod},
-                ):
-                    with patch.object(mp_mod, "RayModelParallelStrategy", mock_cls):
-                        result = _resolve_strategy(name)
+        with (
+            patch(f"{mp_module}.RayModelParallelStrategy") as mock_cls,
+            patch.dict("sys.modules", {mp_module: mp_mod}),
+            patch.object(mp_mod, "RayModelParallelStrategy", mock_cls),
+        ):
+            result = _resolve_strategy(name)
         mock_cls.assert_called_once_with()
         assert result is mock_cls.return_value
 
     def test_fsdp2_raises_when_class_unavailable(self):
         """FSDP2 on pytorch-lightning < 2.3 raises ``ValueError``, not ``ImportError``."""
-        _MP_MODULE = "michelangelo.lib.trainer.torch.pytorch_lightning._private.model_parallel"
-        with patch.dict("sys.modules", {_MP_MODULE: None}):
-            with pytest.raises(ValueError, match="requires pytorch-lightning >= 2.3"):
-                _resolve_strategy("fsdp2")
+        mp_module = (
+            "michelangelo.lib.trainer.torch.pytorch_lightning._private.model_parallel"
+        )
+        with (
+            patch.dict("sys.modules", {mp_module: None}),
+            pytest.raises(ValueError, match="requires pytorch-lightning >= 2.3"),
+        ):
+            _resolve_strategy("fsdp2")
 
     def test_invalid_strategy_kwargs_type_raises(self):
         """``strategy_kwargs`` must be a dict."""
@@ -134,16 +132,20 @@ class TestIsModelParallelStrategy:
     """Guard function for FSDP2 detection."""
 
     def test_string_fsdp2_is_true(self):
+        """``"fsdp2"`` is recognized as model-parallel."""
         assert _is_model_parallel_strategy("fsdp2") is True
 
     def test_other_strategy_strings_are_false(self):
+        """Non-FSDP2 strategy strings are not model-parallel."""
         for name in ("ddp", "fsdp", "deepspeed"):
             assert _is_model_parallel_strategy(name) is False, name
 
     def test_none_is_false(self):
+        """``None`` is not model-parallel."""
         assert _is_model_parallel_strategy(None) is False
 
     def test_non_model_parallel_instance_is_false(self):
+        """A generic ``Strategy`` instance is not model-parallel."""
         from pytorch_lightning.strategies import Strategy
 
         assert _is_model_parallel_strategy(MagicMock(spec=Strategy)) is False
@@ -158,21 +160,26 @@ class TestIsDeepSpeedStrategy:
     """Guard function for DeepSpeed detection."""
 
     def test_string_deepspeed_is_true(self):
+        """``"deepspeed"`` is recognized."""
         assert _is_deepspeed_strategy("deepspeed") is True
 
     def test_deepspeed_instance_is_true(self):
+        """A ``RayDeepSpeedStrategy`` instance is recognized."""
         from ray.train.lightning import RayDeepSpeedStrategy
 
         assert _is_deepspeed_strategy(MagicMock(spec=RayDeepSpeedStrategy)) is True
 
     def test_other_strategy_strings_are_false(self):
+        """Non-DeepSpeed strategy strings are not DeepSpeed."""
         for name in ("ddp", "fsdp", "fsdp2", "some_custom"):
             assert _is_deepspeed_strategy(name) is False, name
 
     def test_none_is_false(self):
+        """``None`` is not DeepSpeed."""
         assert _is_deepspeed_strategy(None) is False
 
     def test_non_deepspeed_instance_is_false(self):
+        """A non-DeepSpeed strategy instance is not DeepSpeed."""
         assert _is_deepspeed_strategy(RayDDPStrategy()) is False
 
 
@@ -189,6 +196,7 @@ class TestPrepareTrainerForRay:
     @patch(_IS_MP, return_value=False)
     @patch("ray.train.lightning.prepare_trainer")
     def test_non_model_parallel_defers_to_ray(self, mock_prepare, _mock_is_mp):
+        """Non-MP strategies delegate to ``ray.train.lightning.prepare_trainer``."""
         trainer = MagicMock()
         result = _prepare_trainer_for_ray(trainer)
         mock_prepare.assert_called_once_with(trainer)
@@ -196,6 +204,7 @@ class TestPrepareTrainerForRay:
 
     @patch(_IS_MP, return_value=True)
     def test_model_parallel_with_ray_env_returns_trainer(self, _mock_is_mp):
+        """MP with ``RayLightningEnvironment`` returns the trainer unchanged."""
         env = RayLightningEnvironment.__new__(RayLightningEnvironment)
         trainer = MagicMock()
         trainer.strategy.cluster_environment = env
@@ -203,6 +212,7 @@ class TestPrepareTrainerForRay:
 
     @patch(_IS_MP, return_value=True)
     def test_model_parallel_with_wrong_cluster_env_raises(self, _mock_is_mp):
+        """MP with an unexpected cluster environment raises ``RuntimeError``."""
         trainer = MagicMock()
         trainer.strategy.cluster_environment = object()
         with pytest.raises(RuntimeError):
@@ -210,6 +220,7 @@ class TestPrepareTrainerForRay:
 
     @patch(_IS_MP, return_value=True)
     def test_model_parallel_with_no_cluster_env_returns_trainer(self, _mock_is_mp):
+        """MP with no cluster environment returns the trainer unchanged."""
         trainer = MagicMock()
         trainer.strategy.cluster_environment = None
         assert _prepare_trainer_for_ray(trainer) is trainer


### PR DESCRIPTION
## Summary

- Adds `strategy: fsdp2` (FSDP2 / `ModelParallelStrategy`) as a training strategy option in the PyTorch Lightning trainer SDK
- New `RayModelParallelStrategy` bridges Lightning's `ModelParallelStrategy` with Ray Train's device and rank wiring
- FSDP2 checkpoint consolidation (sharded DCP → full state_dict) in `LightningTrainerWithStateDict` for serving
- Extracts `_is_deepspeed_strategy` / `_is_model_parallel_strategy` as shared guard functions (previously a private method on the class)

## Usage

Select the strategy in your pipeline config:

```yaml
lightning_trainer_kwargs:
  strategy: fsdp2
```

The user's `LightningModule` must implement `configure_model()` and apply `fully_shard` over the strategy-provided device mesh.

## Design notes

- **Sharded (DCP) checkpointing is enforced** — `save_distributed_checkpoint=True` is always set
- **TP is unsupported** — tensor_parallel_size defaults to 1; an explicit value raises
- **DP is not user-configurable** — data_parallel_size always equals world_size
- **Requires pytorch-lightning >= 2.3** — lazy import with clear error on older versions

## Test plan

- [x] Unit tests for strategy dispatch, guard functions, `_prepare_trainer_for_ray`, per-node callback routing
- [x] Unit tests for FSDP2 checkpoint loading path (success + empty state_dict error)
- [x] Full test suite passes (374 tests)
- [ ] E2E validation on GPU cluster with `strategy: fsdp2` pipeline

🤖 Generated with [Claude Code](https://claude.ai/claude-code)