### PR TITLE
Chain a recurring cron TriggerRun after a backfill completes

### DIFF
--- a/go/components/triggerrun/backfill_successor_test.go
+++ b/go/components/triggerrun/backfill_successor_test.go
@@ -1,0 +1,144 @@
+package triggerrun
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/zapr"
+	"github.com/golang/mock/gomock"
+	pbtypes "github.com/gogo/protobuf/types"
+	clientInterface "github.com/michelangelo-ai/michelangelo/go/base/workflowclient/interface"
+	interfaceMock "github.com/michelangelo-ai/michelangelo/go/base/workflowclient/interface/interface_mock"
+	v2pb "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+const _backfillWorkflowID = "test-namespace.backfill-run"
+
+// newRealBackfillReconciler wires the reconciler with the REAL backfillTrigger
+// runner over a mock workflow client, so these tests exercise the production
+// Update/GetStatus path instead of a MockRunner that can paper over it.
+func newRealBackfillReconciler(
+	t *testing.T, tr *v2pb.TriggerRun, workflowStatus clientInterface.WorkflowExecutionStatus,
+) Reconciler {
+	t.Helper()
+	gctrl := gomock.NewController(t)
+	mockClient := interfaceMock.NewMockWorkflowClient(gctrl)
+	mockClient.EXPECT().GetDomain().Return("test-domain").AnyTimes()
+	mockClient.EXPECT().GetProvider().Return("temporal").AnyTimes()
+	mockClient.EXPECT().GetWorkflowExecutionInfo(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&clientInterface.WorkflowExecutionInfo{Status: workflowStatus}, nil).AnyTimes()
+
+	log := zapr.NewLogger(zaptest.NewLogger(t))
+	return setUpReconciler(t, []runtime.Object{tr.DeepCopy()}, Params{
+		Logger:          log,
+		CronTrigger:     &MockRunner{},
+		BackfillTrigger: NewBackfillTrigger(log, mockClient),
+	})
+}
+
+func newRunningBackfill(t *testing.T, withSuccessorAnnotation bool) *v2pb.TriggerRun {
+	t.Helper()
+	start, err := pbtypes.TimestampProto(time.Now().Add(-48 * time.Hour))
+	require.NoError(t, err)
+	end, err := pbtypes.TimestampProto(time.Now().Add(-24 * time.Hour))
+	require.NoError(t, err)
+
+	tr := _triggerRun.DeepCopy()
+	tr.Name = "backfill-run"
+	tr.Labels = map[string]string{"michelangelo.uber.com/environment": "staging"}
+	if withSuccessorAnnotation {
+		tr.Annotations = map[string]string{AnnotationSuccessorTrigger: "true"}
+	}
+	tr.Spec.StartTimestamp = start
+	tr.Spec.EndTimestamp = end
+	tr.Status = v2pb.TriggerRunStatus{
+		State:               v2pb.TRIGGER_RUN_STATE_RUNNING,
+		ExecutionWorkflowId: _backfillWorkflowID,
+		LogUrl:              "http://example/log",
+	}
+	return tr
+}
+
+// TestReconcile_RunningBackfillIsNotFalselyFailed is a regression test for the
+// bug that broke backfill->cron sequencing: backfillTrigger.Update returned a
+// status rebuilt from State alone, the reconciler assigned it wholesale, and
+// the resulting empty ExecutionWorkflowId made GetStatus fail with "execution
+// workflow id is empty". A healthy running backfill was marked FAILED on its
+// next reconcile, so it never reached a terminal SUCCEEDED and never spawned a
+// successor.
+func TestReconcile_RunningBackfillIsNotFalselyFailed(t *testing.T) {
+	ctx := context.Background()
+	tr := newRunningBackfill(t, true)
+	reconciler := newRealBackfillReconciler(t, tr, clientInterface.WorkflowExecutionStatusRunning)
+
+	_, err := reconciler.Reconcile(ctx,
+		ctrl.Request{NamespacedName: types.NamespacedName{Namespace: _namespace, Name: tr.Name}})
+	assert.NoError(t, err)
+
+	got := &v2pb.TriggerRun{}
+	require.NoError(t, reconciler.Get(ctx, _namespace, tr.Name, &metav1.GetOptions{}, got))
+	assert.Equal(t, v2pb.TRIGGER_RUN_STATE_RUNNING, got.Status.State,
+		"a backfill whose workflow is still running must stay RUNNING")
+	assert.Empty(t, got.Status.ErrorMessage)
+	assert.Equal(t, _backfillWorkflowID, got.Status.ExecutionWorkflowId,
+		"ExecutionWorkflowId must survive the no-op Update; GetStatus needs it")
+
+	// The cron successor must not exist while the backfill is still running.
+	successor := &v2pb.TriggerRun{}
+	err = reconciler.Get(ctx, _namespace, generateSuccessorTriggerRunName(tr.Name), &metav1.GetOptions{}, successor)
+	assert.Error(t, err, "cron successor must not be created before the backfill finishes")
+}
+
+// TestReconcile_BackfillSuccessorThroughRealRunner drives the full ordering
+// guarantee through the production runner: only once the backfill workflow
+// itself reports Completed does the recurring cron TriggerRun get created.
+func TestReconcile_BackfillSuccessorThroughRealRunner(t *testing.T) {
+	ctx := context.Background()
+	tr := newRunningBackfill(t, true)
+	reconciler := newRealBackfillReconciler(t, tr, clientInterface.WorkflowExecutionStatusCompleted)
+
+	_, err := reconciler.Reconcile(ctx,
+		ctrl.Request{NamespacedName: types.NamespacedName{Namespace: _namespace, Name: tr.Name}})
+	assert.NoError(t, err)
+
+	got := &v2pb.TriggerRun{}
+	require.NoError(t, reconciler.Get(ctx, _namespace, tr.Name, &metav1.GetOptions{}, got))
+	assert.Equal(t, v2pb.TRIGGER_RUN_STATE_SUCCEEDED, got.Status.State)
+
+	successor := &v2pb.TriggerRun{}
+	require.NoError(t, reconciler.Get(ctx, _namespace,
+		generateSuccessorTriggerRunName(tr.Name), &metav1.GetOptions{}, successor))
+	assert.Equal(t, TriggerTypeCron, GetTriggerType(successor))
+	assert.Equal(t, v2pb.TRIGGER_RUN_STATE_INVALID, successor.Status.State,
+		"successor starts fresh; its own reconcile arms the cron")
+	assert.Equal(t, "staging", successor.Labels["michelangelo.uber.com/environment"],
+		"labels feed the recurring schedule input hash and must carry over")
+}
+
+// TestReconcile_NoSuccessorAnnotationLeavesBackfillAlone confirms the feature is
+// opt-in: an unannotated backfill completes normally and spawns nothing.
+func TestReconcile_NoSuccessorAnnotationLeavesBackfillAlone(t *testing.T) {
+	ctx := context.Background()
+	tr := newRunningBackfill(t, false)
+	reconciler := newRealBackfillReconciler(t, tr, clientInterface.WorkflowExecutionStatusCompleted)
+
+	_, err := reconciler.Reconcile(ctx,
+		ctrl.Request{NamespacedName: types.NamespacedName{Namespace: _namespace, Name: tr.Name}})
+	assert.NoError(t, err)
+
+	got := &v2pb.TriggerRun{}
+	require.NoError(t, reconciler.Get(ctx, _namespace, tr.Name, &metav1.GetOptions{}, got))
+	assert.Equal(t, v2pb.TRIGGER_RUN_STATE_SUCCEEDED, got.Status.State)
+
+	successor := &v2pb.TriggerRun{}
+	err = reconciler.Get(ctx, _namespace, generateSuccessorTriggerRunName(tr.Name), &metav1.GetOptions{}, successor)
+	assert.Error(t, err, "no annotation means no successor")
+}

--- a/go/components/triggerrun/backfill_trigger.go
+++ b/go/components/triggerrun/backfill_trigger.go
@@ -227,7 +227,13 @@ func (b *backfillTrigger) Resume(ctx context.Context, triggerRun *v2pb.TriggerRu
 // Backfill triggers execute a single workflow and then complete. They don't
 // have recurring schedules to update. This method always returns success.
 //
-// Returns current TriggerRunStatus (state unchanged).
+// It returns the current status unchanged rather than rebuilding one from just
+// the state. The reconciler assigns this return value wholesale
+// (triggerRun.Status = status), so returning a partially-populated status drops
+// every other field -- including ExecutionWorkflowId, which GetStatus needs to
+// find the workflow. Dropping it made the very next reconcile of a healthy
+// running backfill report "execution workflow id is empty" and mark the run
+// FAILED.
 func (b *backfillTrigger) Update(ctx context.Context, triggerRun *v2pb.TriggerRun, action v2pb.TriggerRunAction) (v2pb.TriggerRunStatus, bool, error) {
-	return v2pb.TriggerRunStatus{State: triggerRun.Status.State}, false, nil
+	return triggerRun.Status, false, nil
 }

--- a/go/components/triggerrun/controller.go
+++ b/go/components/triggerrun/controller.go
@@ -47,6 +47,7 @@ import (
 	"github.com/michelangelo-ai/michelangelo/go/cascadedelete"
 	v2pb "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
 	"go.uber.org/fx"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -318,6 +319,18 @@ StateMachine:
 			triggerRun.Status.State = status2.State
 			break StateMachine
 		}
+		if backfillSuccessorPending(triggerRun, status2.State) {
+			// Must create the successor before persisting a terminal state: reconcile()
+			// short-circuits on an already-terminal triggerRun.Status.State before the
+			// state machine runs, so this is the only pass in which it can happen. On
+			// failure, leave triggerRun.Status.State at its prior (RUNNING) value so
+			// this reconcile pass is retried instead of being short-circuited forever.
+			if err := r.createSuccessorTriggerRun(ctx, log, triggerRun); err != nil {
+				log.Error(err, "failed to create successor trigger run after backfill completed, will retry")
+				triggerRun.Status.ErrorMessage = "failed to create successor trigger run: " + err.Error()
+				break StateMachine
+			}
+		}
 		triggerRun.Status.State = status2.State
 
 	case v2pb.TRIGGER_RUN_STATE_PAUSED:
@@ -587,6 +600,25 @@ func (r *Reconciler) Register(mgr ctrl.Manager) error {
 		For(&v2pb.TriggerRun{}).
 		WithOptions(controller.Options{MaxConcurrentReconciles: maximumConcurrentReconciles}).
 		Complete(r)
+}
+
+// createSuccessorTriggerRun creates the recurring cron TriggerRun for a
+// backfill TriggerRun annotated with AnnotationSuccessorTrigger, once the
+// backfill has reached a terminal state. Create is idempotent via the
+// deterministic successor name (generateSuccessorTriggerRunName): if a prior
+// attempt already created it, an AlreadyExists error is treated as success so
+// retries after a transient failure or a crash mid-reconcile are safe.
+func (r *Reconciler) createSuccessorTriggerRun(ctx context.Context, log logr.Logger, backfillTriggerRun *v2pb.TriggerRun) error {
+	successor, err := generateSuccessorTriggerRunSpec(backfillTriggerRun)
+	if err != nil {
+		return err
+	}
+	if err := r.Create(ctx, successor, &metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+	log.Info("created successor cron trigger run after backfill completed",
+		"successorName", successor.Name, "backfillName", backfillTriggerRun.Name)
+	return nil
 }
 
 // getRunner selects the appropriate Runner implementation based on the TriggerRun's trigger type.

--- a/go/components/triggerrun/controller_test.go
+++ b/go/components/triggerrun/controller_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/go-logr/zapr"
+	pbtypes "github.com/gogo/protobuf/types"
 	apiHandler "github.com/michelangelo-ai/michelangelo/go/api/handler"
 	apiutils "github.com/michelangelo-ai/michelangelo/go/api/utils"
 	clientInterface "github.com/michelangelo-ai/michelangelo/go/base/workflowclient/interface"
@@ -18,6 +19,7 @@ import (
 	v2pb "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	temporalClient "go.temporal.io/sdk/client"
 	"go.uber.org/zap/zaptest"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -554,6 +556,133 @@ func TestGetRunner(t *testing.T) {
 
 		})
 	}
+}
+
+// TestReconcile_BackfillSuccessor exercises the sequencing this package adds
+// on top of existing backfill/cron triggers: a backfill TriggerRun annotated
+// with AnnotationSuccessorTrigger must, in the same reconcile pass that first
+// observes a terminal status, create the recurring cron TriggerRun before
+// that terminal status is persisted (see the comment on backfillSuccessorPending
+// for why it must happen in that pass and not a later one).
+func TestReconcile_BackfillSuccessor(t *testing.T) {
+	newBackfillRun := func() v2pb.TriggerRun {
+		tr := _triggerRun.DeepCopy()
+		tr.Name = "backfill-run"
+		tr.Annotations = map[string]string{AnnotationSuccessorTrigger: "true"}
+		start, err := pbtypes.TimestampProto(time.Now().Add(-48 * time.Hour))
+		require.NoError(t, err)
+		end, err := pbtypes.TimestampProto(time.Now().Add(-24 * time.Hour))
+		require.NoError(t, err)
+		tr.Spec.StartTimestamp = start
+		tr.Spec.EndTimestamp = end
+		return *tr
+	}
+
+	tests := []struct {
+		name            string
+		backfillState   v2pb.TriggerRunState
+		expectSuccessor bool
+	}{
+		{name: "succeeded backfill creates successor", backfillState: v2pb.TRIGGER_RUN_STATE_SUCCEEDED, expectSuccessor: true},
+		{name: "failed backfill still creates successor", backfillState: v2pb.TRIGGER_RUN_STATE_FAILED, expectSuccessor: true},
+		{name: "still-running backfill creates nothing yet", backfillState: v2pb.TRIGGER_RUN_STATE_RUNNING, expectSuccessor: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			initialObj := newBackfillRun()
+			initialObj.Status = v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING}
+
+			mockBackfillRunner := &MockRunner{}
+			mockBackfillRunner.On("Update", mock.Anything, mock.Anything, mock.Anything).
+				Return(v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING}, false, nil)
+			mockBackfillRunner.On("GetStatus", mock.Anything, mock.Anything).
+				Return(v2pb.TriggerRunStatus{State: test.backfillState}, nil)
+
+			params := Params{
+				Logger:          zapr.NewLogger(zaptest.NewLogger(t)),
+				CronTrigger:     &MockRunner{},
+				BackfillTrigger: mockBackfillRunner,
+			}
+			reconciler := setUpReconciler(t, []runtime.Object{initialObj.DeepCopy()}, params)
+
+			req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: _namespace, Name: initialObj.Name}}
+			_, err := reconciler.Reconcile(ctx, req)
+			assert.NoError(t, err)
+
+			tr := &v2pb.TriggerRun{}
+			assert.NoError(t, reconciler.Get(ctx, _namespace, initialObj.Name, &metav1.GetOptions{}, tr))
+			assert.Equal(t, test.backfillState, tr.Status.State,
+				"backfill status must still advance to the terminal state once the successor is handled")
+
+			successor := &v2pb.TriggerRun{}
+			successorErr := reconciler.Get(ctx, _namespace, generateSuccessorTriggerRunName(initialObj.Name),
+				&metav1.GetOptions{}, successor)
+			if test.expectSuccessor {
+				require.NoError(t, successorErr)
+				assert.Nil(t, successor.Spec.StartTimestamp)
+				assert.Nil(t, successor.Spec.EndTimestamp)
+				assert.Empty(t, successor.Annotations, "successor must not inherit AnnotationSuccessorTrigger")
+				assert.Equal(t, TriggerTypeCron, GetTriggerType(successor))
+			} else {
+				assert.True(t, apiutils.IsNotFoundError(successorErr))
+			}
+		})
+	}
+}
+
+// TestReconcile_BackfillSuccessorCreateFailureRetries verifies that when
+// successor creation fails, the backfill's terminal status is NOT persisted --
+// reconcile() short-circuits on an already-terminal status before the state
+// machine runs, so persisting the terminal state on a failed successor-create
+// would permanently strand the backfill without ever spawning its successor.
+func TestReconcile_BackfillSuccessorCreateFailureRetries(t *testing.T) {
+	ctx := context.Background()
+	backfillRun := func() v2pb.TriggerRun {
+		tr := _triggerRun.DeepCopy()
+		tr.Name = "backfill-run"
+		tr.Annotations = map[string]string{AnnotationSuccessorTrigger: "true"}
+		start, err := pbtypes.TimestampProto(time.Now().Add(-48 * time.Hour))
+		require.NoError(t, err)
+		end, err := pbtypes.TimestampProto(time.Now().Add(-24 * time.Hour))
+		require.NoError(t, err)
+		tr.Spec.StartTimestamp = start
+		tr.Spec.EndTimestamp = end
+		// An interval-schedule trigger has no cron schedule to hand to a
+		// successor, so generateSuccessorTriggerRunSpec fails deterministically.
+		tr.Spec.Trigger = &v2pb.Trigger{
+			TriggerType: &v2pb.Trigger_IntervalSchedule{
+				IntervalSchedule: &v2pb.IntervalSchedule{Interval: &pbtypes.Duration{Seconds: 3600}},
+			},
+		}
+		return *tr
+	}()
+	backfillRun.Status = v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING}
+
+	mockBackfillRunner := &MockRunner{}
+	mockBackfillRunner.On("Update", mock.Anything, mock.Anything, mock.Anything).
+		Return(v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_RUNNING}, false, nil)
+	mockBackfillRunner.On("GetStatus", mock.Anything, mock.Anything).
+		Return(v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_SUCCEEDED}, nil)
+
+	params := Params{
+		Logger:          zapr.NewLogger(zaptest.NewLogger(t)),
+		CronTrigger:     &MockRunner{},
+		BackfillTrigger: mockBackfillRunner,
+	}
+	reconciler := setUpReconciler(t, []runtime.Object{backfillRun.DeepCopy()}, params)
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: _namespace, Name: backfillRun.Name}}
+	res, err := reconciler.Reconcile(ctx, req)
+	assert.NoError(t, err)
+	assert.NotZero(t, res.RequeueAfter, "must requeue to retry successor creation")
+
+	tr := &v2pb.TriggerRun{}
+	assert.NoError(t, reconciler.Get(ctx, _namespace, backfillRun.Name, &metav1.GetOptions{}, tr))
+	assert.Equal(t, v2pb.TRIGGER_RUN_STATE_RUNNING, tr.Status.State,
+		"terminal status must not be persisted until successor creation succeeds")
+	assert.Contains(t, tr.Status.ErrorMessage, "failed to create successor trigger run")
 }
 
 // TestWatchPredicateIgnoresStatusOnlyUpdates locks in the fix for the

--- a/go/components/triggerrun/util.go
+++ b/go/components/triggerrun/util.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-logr/logr"
 	clientInterface "github.com/michelangelo-ai/michelangelo/go/base/workflowclient/interface"
 	v2pb "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // TriggerType constants define the supported trigger types.
@@ -24,6 +25,22 @@ const (
 	TriggerTypeInterval   = "interval"    // Workflows triggered at fixed intervals
 	TriggerTypeUnknown    = "unknown"     // Unknown or unsupported trigger type
 )
+
+// AnnotationSuccessorTrigger, when present on a backfill TriggerRun, tells the
+// reconciler to create a recurring cron TriggerRun once the backfill reaches a
+// terminal state (SUCCEEDED or FAILED).
+//
+// This exists because workflow engine cron primitives (Cadence/Temporal) have
+// no backfill/catch-up concept of their own: a cron schedule only ever looks
+// forward from "now" or from the previous run's completion. To reproduce
+// Airflow/Flyte-style "run the historical gap, then start the live schedule"
+// behavior, the gap is instead run explicitly as a one-time backfill
+// TriggerRun, and this annotation tells the reconciler to chain a live cron
+// TriggerRun onto it once it finishes.
+//
+// A failed backfill still gets a successor: a failed historical backfill
+// must not block today's live schedule.
+const AnnotationSuccessorTrigger = "triggerrun.michelangelo/successor-trigger"
 
 // CreateTriggerRequest is a data transfer object for trigger workflow execution.
 //
@@ -453,4 +470,63 @@ func resumeWorkflow(ctx context.Context, triggerRun *v2pb.TriggerRun, log logr.L
 	triggerRun.Status.State = v2pb.TRIGGER_RUN_STATE_RUNNING
 	triggerRun.Status.ErrorMessage = ""
 	return triggerRun.Status, nil
+}
+
+// backfillSuccessorPending reports whether tr is a backfill TriggerRun
+// annotated with AnnotationSuccessorTrigger that has just reached a terminal
+// state (newState), and therefore needs its successor cron TriggerRun created
+// before the reconciler is allowed to persist newState.
+//
+// The check must run against the freshly computed newState rather than
+// tr.Status.State: reconcile() short-circuits on an already-terminal
+// tr.Status.State before the state machine runs, so the successor must be
+// created in the same pass that first observes the terminal status, before
+// it is written back.
+func backfillSuccessorPending(tr *v2pb.TriggerRun, newState v2pb.TriggerRunState) bool {
+	if tr.Annotations[AnnotationSuccessorTrigger] == "" {
+		return false
+	}
+	if GetTriggerType(tr) != TriggerTypeBackfill {
+		return false
+	}
+	return newState == v2pb.TRIGGER_RUN_STATE_SUCCEEDED || newState == v2pb.TRIGGER_RUN_STATE_FAILED
+}
+
+// generateSuccessorTriggerRunName derives a deterministic name for the
+// recurring TriggerRun spawned once a backfill completes. Determinism makes
+// creating the successor idempotent: if the reconciler crashes after Create
+// succeeds but before the terminal status is persisted, the next reconcile
+// retries Create against the same name instead of producing a duplicate
+// successor.
+func generateSuccessorTriggerRunName(backfillName string) string {
+	return backfillName + "-successor"
+}
+
+// generateSuccessorTriggerRunSpec builds the recurring cron TriggerRun that
+// should start once a backfill TriggerRun (marked with
+// AnnotationSuccessorTrigger) reaches a terminal state. It reuses the
+// backfill's own Spec (pipeline, revision, trigger, actor, notifications),
+// but strips StartTimestamp/EndTimestamp so GetTriggerType classifies the
+// result as a live cron trigger rather than another backfill, and drops
+// AnnotationSuccessorTrigger itself so the live cron trigger never spawns a
+// successor of its own.
+func generateSuccessorTriggerRunSpec(backfillTriggerRun *v2pb.TriggerRun) (*v2pb.TriggerRun, error) {
+	if backfillTriggerRun.Spec.Trigger.GetCronSchedule() == nil {
+		return nil, fmt.Errorf("backfill trigger run %s/%s has no cron schedule to resume from",
+			backfillTriggerRun.Namespace, backfillTriggerRun.Name)
+	}
+	successor := backfillTriggerRun.DeepCopy()
+	successor.Name = generateSuccessorTriggerRunName(backfillTriggerRun.Name)
+	successor.ResourceVersion = ""
+	successor.UID = ""
+	successor.CreationTimestamp = metav1.Time{}
+	successor.OwnerReferences = nil
+	successor.Finalizers = nil
+	successor.Annotations = nil
+	successor.Status = v2pb.TriggerRunStatus{}
+	successor.Spec.StartTimestamp = nil
+	successor.Spec.EndTimestamp = nil
+	successor.Spec.Kill = false
+	successor.Spec.Action = v2pb.TRIGGER_RUN_ACTION_NO_ACTION
+	return successor, nil
 }

--- a/go/components/triggerrun/util.go
+++ b/go/components/triggerrun/util.go
@@ -515,18 +515,22 @@ func generateSuccessorTriggerRunSpec(backfillTriggerRun *v2pb.TriggerRun) (*v2pb
 		return nil, fmt.Errorf("backfill trigger run %s/%s has no cron schedule to resume from",
 			backfillTriggerRun.Namespace, backfillTriggerRun.Name)
 	}
-	successor := backfillTriggerRun.DeepCopy()
-	successor.Name = generateSuccessorTriggerRunName(backfillTriggerRun.Name)
-	successor.ResourceVersion = ""
-	successor.UID = ""
-	successor.CreationTimestamp = metav1.Time{}
-	successor.OwnerReferences = nil
-	successor.Finalizers = nil
-	successor.Annotations = nil
-	successor.Status = v2pb.TriggerRunStatus{}
-	successor.Spec.StartTimestamp = nil
-	successor.Spec.EndTimestamp = nil
-	successor.Spec.Kill = false
-	successor.Spec.Action = v2pb.TRIGGER_RUN_ACTION_NO_ACTION
-	return successor, nil
+	// Carry over the spec onto a brand new run rather than copying the backfill
+	// and stripping it: nothing outside the spec can then leak into the successor
+	// by omission (status, ownerRefs, finalizers, the successor annotation itself).
+	copied := backfillTriggerRun.DeepCopy()
+	// A successor is a live recurring schedule, not another backfill, and the
+	// timestamp pair is exactly what GetTriggerType keys on.
+	copied.Spec.StartTimestamp = nil
+	copied.Spec.EndTimestamp = nil
+	return &v2pb.TriggerRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      generateSuccessorTriggerRunName(backfillTriggerRun.Name),
+			Namespace: backfillTriggerRun.Namespace,
+			// Labels carry the environment and pipeline-manifest-type that feed
+			// the recurring schedule's input hash (see scheduleInputLabels).
+			Labels: copied.Labels,
+		},
+		Spec: copied.Spec,
+	}, nil
 }

--- a/go/components/triggerrun/util_test.go
+++ b/go/components/triggerrun/util_test.go
@@ -8,10 +8,13 @@ import (
 
 	"github.com/go-logr/zapr"
 	"github.com/golang/mock/gomock"
+	pbtypes "github.com/gogo/protobuf/types"
 	clientInterface "github.com/michelangelo-ai/michelangelo/go/base/workflowclient/interface"
 	interfaceMock "github.com/michelangelo-ai/michelangelo/go/base/workflowclient/interface/interface_mock"
+	api "github.com/michelangelo-ai/michelangelo/proto-go/api"
 	v2pb "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -687,6 +690,135 @@ func TestGetAdhocRunWorkflowStatus(t *testing.T) {
 			}
 
 			assert.Equal(t, tt.expectedState, result.State)
+		})
+	}
+}
+
+func backfillFixture() *v2pb.TriggerRun {
+	start, _ := pbtypes.TimestampProto(time.Now().Add(-48 * time.Hour))
+	end, _ := pbtypes.TimestampProto(time.Now().Add(-24 * time.Hour))
+	return &v2pb.TriggerRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       "test-namespace",
+			Name:            "backfill-run",
+			Annotations:     map[string]string{AnnotationSuccessorTrigger: "true"},
+			OwnerReferences: []metav1.OwnerReference{{Name: "owning-pipeline"}},
+			Finalizers:      []string{drainFinalizer},
+		},
+		Spec: v2pb.TriggerRunSpec{
+			Pipeline: &api.ResourceIdentifier{Namespace: "test-namespace", Name: "test-pipeline"},
+			Revision: &api.ResourceIdentifier{Namespace: "test-namespace", Name: "test-revision"},
+			Actor:    &v2pb.UserInfo{Name: "test-user"},
+			Trigger: &v2pb.Trigger{
+				TriggerType: &v2pb.Trigger_CronSchedule{
+					CronSchedule: &v2pb.CronSchedule{Cron: "0 0 * * *"},
+				},
+				ParametersMap: map[string]*v2pb.PipelineExecutionParameters{"global": {}},
+			},
+			StartTimestamp: start,
+			EndTimestamp:   end,
+		},
+		Status: v2pb.TriggerRunStatus{State: v2pb.TRIGGER_RUN_STATE_SUCCEEDED},
+	}
+}
+
+func TestGenerateSuccessorTriggerRunSpec(t *testing.T) {
+	backfill := backfillFixture()
+
+	successor, err := generateSuccessorTriggerRunSpec(backfill)
+	require.NoError(t, err)
+
+	assert.Equal(t, "backfill-run-successor", successor.Name)
+	assert.Equal(t, backfill.Namespace, successor.Namespace)
+
+	// Must not carry over backfill-specific/lifecycle metadata.
+	assert.Nil(t, successor.Spec.StartTimestamp)
+	assert.Nil(t, successor.Spec.EndTimestamp)
+	assert.Empty(t, successor.Annotations, "successor must not inherit AnnotationSuccessorTrigger")
+	assert.Empty(t, successor.OwnerReferences)
+	assert.Empty(t, successor.Finalizers)
+	assert.Equal(t, v2pb.TriggerRunStatus{}, successor.Status)
+	assert.False(t, successor.Spec.Kill)
+	assert.Equal(t, v2pb.TRIGGER_RUN_ACTION_NO_ACTION, successor.Spec.Action)
+
+	// Must classify as a live cron trigger, not another backfill.
+	assert.Equal(t, TriggerTypeCron, GetTriggerType(successor))
+
+	// Must retain what actually defines the schedule to resume.
+	assert.Equal(t, backfill.Spec.Pipeline, successor.Spec.Pipeline)
+	assert.Equal(t, backfill.Spec.Revision, successor.Spec.Revision)
+	assert.Equal(t, backfill.Spec.Trigger, successor.Spec.Trigger)
+	assert.Equal(t, backfill.Spec.Actor, successor.Spec.Actor)
+}
+
+func TestGenerateSuccessorTriggerRunSpec_NoCronSchedule(t *testing.T) {
+	backfill := backfillFixture()
+	backfill.Spec.Trigger = &v2pb.Trigger{
+		TriggerType: &v2pb.Trigger_BatchRerun{BatchRerun: &v2pb.BatchRerun{}},
+	}
+
+	_, err := generateSuccessorTriggerRunSpec(backfill)
+	assert.Error(t, err)
+}
+
+func TestGenerateSuccessorTriggerRunSpec_Idempotent(t *testing.T) {
+	backfill := backfillFixture()
+
+	first, err := generateSuccessorTriggerRunSpec(backfill)
+	require.NoError(t, err)
+	second, err := generateSuccessorTriggerRunSpec(backfill)
+	require.NoError(t, err)
+
+	assert.Equal(t, first.Name, second.Name)
+}
+
+func TestBackfillSuccessorPending(t *testing.T) {
+	tests := []struct {
+		name     string
+		modify   func(tr *v2pb.TriggerRun)
+		newState v2pb.TriggerRunState
+		want     bool
+	}{
+		{
+			name:     "backfill succeeded with annotation",
+			newState: v2pb.TRIGGER_RUN_STATE_SUCCEEDED,
+			want:     true,
+		},
+		{
+			name:     "backfill failed with annotation",
+			newState: v2pb.TRIGGER_RUN_STATE_FAILED,
+			want:     true,
+		},
+		{
+			name:     "backfill still running",
+			newState: v2pb.TRIGGER_RUN_STATE_RUNNING,
+			want:     false,
+		},
+		{
+			name: "no annotation",
+			modify: func(tr *v2pb.TriggerRun) {
+				tr.Annotations = nil
+			},
+			newState: v2pb.TRIGGER_RUN_STATE_SUCCEEDED,
+			want:     false,
+		},
+		{
+			name: "not a backfill trigger type",
+			modify: func(tr *v2pb.TriggerRun) {
+				tr.Spec.StartTimestamp = nil
+				tr.Spec.EndTimestamp = nil
+			},
+			newState: v2pb.TRIGGER_RUN_STATE_SUCCEEDED,
+			want:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr := backfillFixture()
+			if tt.modify != nil {
+				tt.modify(tr)
+			}
+			assert.Equal(t, tt.want, backfillSuccessorPending(tr, tt.newState))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- Workflow engine cron primitives (Cadence/Temporal) have no backfill/catch-up concept — a schedule only ever looks forward from now or from the previous run's completion, so a past start time or a missed tick is silently dropped.
- Adds reconciler-level sequencing instead: a backfill `TriggerRun` annotated with `triggerrun.michelangelo/successor-trigger` gets its live recurring cron `TriggerRun` created automatically once the backfill reaches `SUCCEEDED` or `FAILED` (a failed historical backfill still gets a successor — it must not block today's live schedule).
- The successor is created in the same reconcile pass that first observes the terminal status (`reconcile()` short-circuits on an already-terminal status before the state machine runs), and creation is idempotent via a deterministic successor name so a failed attempt safely retries on the next reconcile.

## Out of scope

Wiring the entrypoint that decides to annotate a backfill `TriggerRun` this way (e.g. an API create request with a past `start_timestamp`) is left for a follow-up.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./components/triggerrun/...`
- [x] `go test ./components/triggerrun/...` — full existing suite plus new tests:
  - `TestGenerateSuccessorTriggerRunSpec` / `_NoCronSchedule` / `_Idempotent`
  - `TestBackfillSuccessorPending`
  - `TestReconcile_BackfillSuccessor` (SUCCEEDED / FAILED / still-RUNNING)
  - `TestReconcile_BackfillSuccessorCreateFailureRetries`

🤖 Generated with [Claude Code](https://claude.com/claude-code)