### PR TITLE
fix(python): rename evaluation_strategy to eval_strategy in bert_cola example

### DIFF
--- a/python/examples/bert_cola/pipeline.yaml
+++ b/python/examples/bert_cola/pipeline.yaml
@@ -4,7 +4,7 @@ metadata:
   namespace: "ma-dev-test"
   name: "bert-cola-test"
   annotations:
-    michelangelo/uniflow-image: ghcr.io/michelangelo-ai/examples:main
+    michelangelo/uniflow-image: ghcr.io/michelangelo-ai/examples:sha-4b8483e
 spec:
   type: "PIPELINE_TYPE_TRAIN"
   manifest:

--- a/python/examples/bert_cola/pipeline.yaml
+++ b/python/examples/bert_cola/pipeline.yaml
@@ -4,7 +4,7 @@ metadata:
   namespace: "ma-dev-test"
   name: "bert-cola-test"
   annotations:
-    michelangelo/uniflow-image: ghcr.io/michelangelo-ai/examples:sha-4b8483e
+    michelangelo/uniflow-image: ghcr.io/michelangelo-ai/examples:main
 spec:
   type: "PIPELINE_TYPE_TRAIN"
   manifest:

--- a/python/examples/bert_cola/train.py
+++ b/python/examples/bert_cola/train.py
@@ -79,7 +79,7 @@ def train(
     # Define training arguments
     training_args = transformers.TrainingArguments(
         output_dir=output_dir,
-        evaluation_strategy="epoch",
+        eval_strategy="epoch",
         save_strategy="epoch",
         save_total_limit=1,  # Keep only the best checkpoint
         metric_for_best_model="eval_loss",  # Customize based on your needs


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
`examples/bert_cola/train.py` now passes `eval_strategy="epoch"` instead of `evaluation_strategy="epoch"` to `transformers.TrainingArguments()`.

**Why?**
`transformers` renamed `TrainingArguments`' `evaluation_strategy` kwarg to `eval_strategy` — removed (not just deprecated) since 4.46. The pinned `transformers==4.48.2` no longer accepts the old name, so `train()` failed unconditionally with `TypeError: __init__() got an unexpected keyword argument 'evaluation_strategy'`. This was the root cause of `test_bert_cola_e2e`'s `train` task failing end-to-end.

Closes #1882

**How did you test it?**
- `ruff check` / `ruff format --check` on the changed file — clean.
- Built a branch-tagged examples image (`build-examples-image.yaml` dispatched against this branch) and re-ran the `integration-test.yaml` workflow with `image_tag` pointed at that build, so the fix is actually exercised by `test_bert_cola_e2e` rather than the default `latest`/`main`-built image.

**Potential risks**
None — single-keyword rename in an example script, no production code path affected.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**
N/A

**Documentation Changes**
N/A