### PR TITLE
docs: add role-based learning paths sequencing the existing docs

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -2,6 +2,8 @@
 
 Welcome to Michelangelo AI! Whether you're evaluating the platform or ready to build your first ML pipeline, you're in the right place.
 
+Want a single ordered path instead of a menu? The **[Learning Paths](./learning-paths.md)** page sequences the docs into three role-based tracks — ML Engineer, Operator, and Contributor — each with time estimates and a clear endpoint.
+
 ## Choose your path
 
 ### I want to understand what Michelangelo AI does

--- a/docs/getting-started/learning-paths.md
+++ b/docs/getting-started/learning-paths.md
@@ -6,7 +6,7 @@ description: Ordered tracks through the existing docs — pick the one that matc
 
 # Learning Paths
 
-The docs cover a lot of ground. These three tracks sequence the existing pages into an ordered path for the three most common roles, so you always know what to read next. Each step links to a page that already exists — the tracks add order, not new material.
+The docs cover a lot of ground. These three tracks sequence the existing pages into an ordered path for the three most common roles, so you always know what to read next.
 
 Pick the track that matches what you want to do:
 
@@ -27,7 +27,7 @@ From zero to a trained, deployed model.
 5. **[Prepare Your Data](../user-guides/getting-started/prepare-your-data.md)** — load, clean, and split datasets with Ray and Spark
 6. **[Train and Register a Model](../user-guides/train-and-deploy-models/train-and-register-a-model.md)** — train at scale and register artifacts
 7. **[Deploy a Model](../user-guides/train-and-deploy-models/deploy-a-model.md)** — bind a registered model to an inference server
-8. **[Example Projects](../user-guides/examples/index.md)** — nine end-to-end workflows to adapt to your own use case
+8. **[Example Projects](../user-guides/examples/index.md)** — ten end-to-end workflows to adapt to your own use case
 
 **You're done when:** you've run a pipeline that trains a model, registered it, deployed it, and know which example is closest to your real workload.
 

--- a/docs/getting-started/learning-paths.md
+++ b/docs/getting-started/learning-paths.md
@@ -1,0 +1,65 @@
+---
+sidebar_position: 6
+title: Learning Paths
+description: Ordered tracks through the existing docs — pick the one that matches your role and follow it end to end.
+---
+
+# Learning Paths
+
+The docs cover a lot of ground. These three tracks sequence the existing pages into an ordered path for the three most common roles, so you always know what to read next. Each step links to a page that already exists — the tracks add order, not new material.
+
+Pick the track that matches what you want to do:
+
+| Track | You want to... | Time | Prerequisites |
+|-------|----------------|------|---------------|
+| [ML Engineer](#ml-engineer-track) | Build, train, and deploy models on the platform | ~2-3 hours | Python; Docker for the sandbox steps |
+| [Operator](#operator-track) | Deploy and run the platform for your organization | ~3-4 hours | Kubernetes and Helm familiarity |
+| [Contributor](#contributor-track) | Change the platform itself — code, plugins, docs | ~2 hours reading + environment setup | Go or Python, depending on the area |
+
+## ML Engineer Track
+
+From zero to a trained, deployed model.
+
+1. **[Overview](./overview.md)** — what Michelangelo AI is and how tools you already know map to it (~10 min)
+2. **[Core Concepts and Key Terms](./core-concepts-and-key-terms.md)** — projects, workflows, tasks, pipelines (~10 min)
+3. **[Sandbox Setup](./sandbox-setup.md)** — a local cluster with all services running (~20 min)
+4. **[Getting Started with Pipelines](../user-guides/getting-started/getting-started.md)** — build and run your first pipeline (~30 min)
+5. **[Prepare Your Data](../user-guides/getting-started/prepare-your-data.md)** — load, clean, and split datasets with Ray and Spark
+6. **[Train and Register a Model](../user-guides/train-and-deploy-models/train-and-register-a-model.md)** — train at scale and register artifacts
+7. **[Deploy a Model](../user-guides/train-and-deploy-models/deploy-a-model.md)** — bind a registered model to an inference server
+8. **[Example Projects](../user-guides/examples/index.md)** — nine end-to-end workflows to adapt to your own use case
+
+**You're done when:** you've run a pipeline that trains a model, registered it, deployed it, and know which example is closest to your real workload.
+
+## Operator Track
+
+From an empty Kubernetes cluster to a monitored production deployment. The first four steps follow the [operator guides' recommended reading order](../operator-guides/index.md).
+
+1. **[Platform Setup](../operator-guides/setup/platform-setup.md)** — configure each component via ConfigMaps and Kustomize overlays
+2. **[Register a Compute Cluster](../operator-guides/setup/register-a-compute-cluster-to-michelangelo-control-plane.md)** — connect a cluster for Ray and Spark jobs
+3. **[Cluster Setup for Serving](../operator-guides/serving/cluster-setup.md)** — enable model inference
+4. **[Authentication](../operator-guides/setup/authentication.md)** — identity provider and RBAC before opening to users
+5. **[Network & Ingress](../operator-guides/setup/network.md)** — Envoy, Ingress, TLS
+6. **[Helm Chart](../operator-guides/helm-chart.md)** — chart layout, values reference, migration phases
+7. **[Monitoring](../operator-guides/operations/monitoring.md)** — metrics, alerts, and dashboards for the control plane
+8. **[Troubleshooting](../operator-guides/operations/troubleshooting.md)** — the failure modes you'll actually hit
+
+**You're done when:** the control plane is deployed, a compute cluster is registered, users authenticate through your IdP, and you have monitoring in place.
+
+## Contributor Track
+
+From reader to merged PR.
+
+1. **[Contributing Overview](../contributing/index.md)** — what you can contribute and which directory owns what
+2. **[Terminology](../contributing/TERMINOLOGY.md)** — the vocabulary the codebase uses, before you read code
+3. **[Building from Source](../contributing/building-michelangelo-ai-from-source.md)** — verify your environment works
+4. **[Dev Environment](../contributing/dev-environment.md)** — IDE setup for Go backend development
+5. **[Testing Strategy](../contributing/testing.md)** — what to test and where the suites live
+6. **[PR Process](../contributing/pr-process.md)** — branch, commit conventions, review flow
+7. **[Uniflow Plugin Guide](../contributing/uniflow-plugin-guide.md)** — the most common substantial contribution, end to end
+
+**You're done when:** you've built the platform from source, run the tests for the area you're changing, and opened a PR that follows the process.
+
+---
+
+Not sure which track fits? The [Getting Started overview](./index.md) has a lighter-weight chooser, and the [roadmap](./roadmap.md) shows where the platform is heading.

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -25,6 +25,8 @@ The platform is modular: adopt the full stack or integrate individual components
 
 ## Get started
 
+Prefer an ordered path over a menu? **[Learning Paths](./getting-started/learning-paths.md)** sequences the docs into three role-based tracks (ML Engineer, Operator, Contributor) with time estimates.
+
 ### I'm evaluating Michelangelo AI
 
 Understand what the platform does, how it compares to your current stack, and whether it fits your use case.


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**

Adds a new **Learning Paths** page under Getting Started (`docs/getting-started/learning-paths.md`) that sequences the existing docs into three role-based tracks, each with a time estimate and an explicit endpoint:

- **ML Engineer** (8 steps): overview -> core concepts -> sandbox -> first pipeline -> data prep -> train and register -> deploy -> examples
- **Operator** (8 steps): platform setup -> register a cluster -> serving cluster setup -> authentication -> network -> Helm chart -> monitoring -> troubleshooting
- **Contributor** (7 steps): contributing guide -> terminology -> building from source -> dev environment -> testing -> PR process -> Uniflow plugin guide

The page opens with a comparison table (which track, what you want, time, prerequisites) and each track closes with a "You're done when:" checkpoint. Small cross-links were added from `docs/intro.md` and `docs/getting-started/index.md` so the page is discoverable from both entry points.

No existing page was moved or rewritten -- this is purely an ordering layer over docs that already exist.

**Why?**

The docs today are organized as a menu: Getting Started, User Guides, Operator Guides, Contributing. That works as a reference, but a newcomer has to decide the order themselves, and the right order differs by role (an operator should not start with the sandbox; a contributor should not start with pipeline authoring). A single ordered path per role -- with a stated time budget and a clear "you're done" endpoint -- removes that decision and gives newcomers a finish line. This is a common pattern in platform docs (Kubernetes-style guided paths) and costs nothing structurally since it only links to existing pages.

**How did you test it?**

- Verified all 27 linked targets exist on `main` (every link is a relative `.md` path resolved at build time).
- Ran the repo's docs link lint locally (same grep as `docs-check.yml`): no relative links without `.md` extension.
- Full local Docusaurus build (`bun run build`) with `onBrokenLinks: 'throw'` (stricter than CI's warn mode): build succeeded with zero broken links.
- Inspected the rendered page at `build/docs/getting-started/learning-paths/` -- all three tracks, the comparison table, and the footer links render correctly; sidebar shows the page at position 6 under Getting Started (between Python IDE Setup and Roadmap).

**Potential risks**

Docs-only. Worst case is a stale step reference if a linked page is later renamed -- the docs build breaks loudly on broken links, so CI would catch that in the renaming PR.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

None needed -- documentation only.

**Documentation Changes**

This PR is itself the documentation change: new page `docs/getting-started/learning-paths.md` plus discovery links in `docs/intro.md` and `docs/getting-started/index.md`. Backward compatible; no user-facing API change.
