### PR TITLE
docs: add a tiered on-ramp to the contributing guide

### DIFF
--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -2,6 +2,28 @@
 
 Michelangelo AI welcomes contributions from the community. This guide is your entry point — it explains what you can contribute, where each part of the codebase lives, and how to get started.
 
+## Where to Start
+
+Not sure where to jump in? Contributions fall into three tiers of increasing setup cost. Start at the tier that matches the time you have — every tier is a real contribution, not a warm-up exercise.
+
+### Tier 1: Docs and examples — no build required
+
+Fix a guide, clarify a confusing section, or improve an example. You only need a fork and a text editor: the Docs Check CI workflow validates links and builds the site on every PR that touches `docs/`, so there is nothing to run locally.
+
+- Read the [Documentation Guide](documentation-guide.md) for structure and style conventions
+- Browse issues labeled [`good first issue`](https://github.com/michelangelo-ai/michelangelo/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22) or [`help wanted`](https://github.com/michelangelo-ai/michelangelo/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22)
+
+### Tier 2: Uniflow plugins and integrations — extend the edges
+
+Add a task type, compute backend, or serving integration without touching the core control plane. You'll need a working build ([Building from Source](building-michelangelo-ai-from-source.md)), but your changes stay inside well-documented extension points.
+
+- [Uniflow Plugin Guide](uniflow-plugin-guide.md) — end-to-end walkthrough of the most common contribution type
+- [Integrate a Custom Serving Backend](../operator-guides/serving/integrate-custom-backend.md) — add a new model serving backend
+
+### Tier 3: Core platform — controllers, APIs, and the SDK
+
+Changes to the API server, controllers, proto definitions, or the Python SDK. Use the [Component Map](#component-map) below to find the owning directory. Major architectural changes go through the RFC process first — see the Dual-Track model in [CONTRIBUTING.md](https://github.com/michelangelo-ai/michelangelo/blob/main/CONTRIBUTING.md).
+
 ## Types of Contributions
 
 | Type | Examples |


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**

Adds a "Where to Start" section near the top of `docs/contributing/index.md` that sorts contributions into three tiers by setup cost:

- **Tier 1: Docs and examples** -- no build required; points at the Documentation Guide and at live GitHub searches for `good first issue` and `help wanted`, and notes that Docs Check CI validates links and builds the site on every PR touching `docs/`.
- **Tier 2: Uniflow plugins and integrations** -- needs a working build but stays inside extension points; points at the Uniflow Plugin Guide and the custom serving backend guide.
- **Tier 3: Core platform** -- controllers, APIs, SDK; points at the Component Map on the same page and at the Dual-Track/RFC model in `CONTRIBUTING.md`.

Single-file change; no existing content was removed or reordered.

**Why?**

The contributing index currently front-loads the full component map and build setup, which implicitly tells every would-be contributor "first, build the platform". For docs and example contributions that is not true -- CI builds the site on every PR, so a fork and a text editor are enough. Making the tiers explicit lowers the perceived cost of a first contribution and routes people to the right depth of setup for what they actually want to do, while making clear that big changes go through the RFC process before code.

**How did you test it?**

- Verified every linked target exists on `main`: `documentation-guide.md`, `uniflow-plugin-guide.md`, `building-michelangelo-ai-from-source.md`, `../operator-guides/serving/integrate-custom-backend.md`, root `CONTRIBUTING.md` (Dual-Track section), and the `#component-map` anchor on the same page.
- Verified both GitHub label-search URLs return results for the repo and that the `good first issue` / `help wanted` labels exist.
- Ran the repo's docs link lint locally (same grep as `docs-check.yml`): clean.
- Full local Docusaurus build with `onBrokenLinks: 'throw'` (stricter than CI's warn mode): success; inspected the rendered page and confirmed all three tier headings, the resolved hrefs, and the `#component-map` anchor.

**Potential risks**

Docs-only, single page. The one factual claim worth watching is "Docs Check CI validates ... on every PR that touches `docs/`" -- true today per `.github/workflows/docs-check.yml` path filters; if that workflow's triggers change, this sentence should be updated with it.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

None needed -- documentation only.

**Documentation Changes**

This PR is itself the documentation change: a new "Where to Start" section in `docs/contributing/index.md`. Backward compatible; no user-facing API change.
