### PR TITLE
feat(cli): add Kubeflow Trainer v2 TrainJob converter to ma import

### DIFF
--- a/python/michelangelo/cli/cli.py
+++ b/python/michelangelo/cli/cli.py
@@ -2,6 +2,7 @@ import argparse
 import logging
 import sys
 
+from michelangelo.cli.importer import importer
 from michelangelo.cli.mactl import mactl
 from michelangelo.cli.sandbox import sandbox
 
@@ -32,6 +33,18 @@ def main(args=None):
         sandbox.init_arguments(sandbox_p)
         ns = p.parse_args(args=args)
         return sandbox.run(ns)
+
+    if entity == "import":
+        p = argparse.ArgumentParser(description=description)
+        sp = p.add_subparsers(dest="entity", required=True, help="Entity to operate on")
+        import_p = sp.add_parser(
+            "import",
+            description=importer.description,
+            help=importer.short_description,
+        )
+        importer.init_arguments(import_p)
+        ns = p.parse_args(args=args)
+        return importer.run(ns)
 
     # For all other entities, delegate to mactl
     return mactl.run()

--- a/python/michelangelo/cli/cli.py
+++ b/python/michelangelo/cli/cli.py
@@ -1,3 +1,5 @@
+"""Entry point for the ``ma`` command-line interface."""
+
 import argparse
 import logging
 import sys
@@ -7,11 +9,13 @@ from michelangelo.cli.mactl import mactl
 from michelangelo.cli.sandbox import sandbox
 
 description = """
-Michelangelo CLI is a command-line interface that enables seamless access to Michelangelo services directly from your terminal.
+Michelangelo CLI is a command-line interface that enables seamless access to
+Michelangelo services directly from your terminal.
 """
 
 
 def main(args=None):
+    """Dispatch to the ``ma`` subcommand named by ``args`` or ``sys.argv``."""
     logging.basicConfig(level=logging.INFO)
 
     # Determine entity from args or sys.argv

--- a/python/michelangelo/cli/importer/__init__.py
+++ b/python/michelangelo/cli/importer/__init__.py
@@ -1,0 +1,1 @@
+"""Importer CLI: convert training-job manifests into pipeline scaffolds."""

--- a/python/michelangelo/cli/importer/base.py
+++ b/python/michelangelo/cli/importer/base.py
@@ -1,0 +1,15 @@
+"""Shared types for ``ma import`` manifest converters."""
+
+from dataclasses import dataclass
+
+
+class ManifestError(ValueError):
+    """Raised when the input manifest cannot be converted."""
+
+
+@dataclass
+class ConversionResult:
+    """The generated file text plus everything that did not map."""
+
+    scaffold: str
+    warnings: list

--- a/python/michelangelo/cli/importer/importer.py
+++ b/python/michelangelo/cli/importer/importer.py
@@ -1,24 +1,27 @@
-"""``ma import``: convert training-job manifests into Uniflow pipeline scaffolds."""
+"""``ma import``: convert job manifests from other systems into Michelangelo ones."""
 
 import sys
 from pathlib import Path
 
 import yaml
 
-from michelangelo.cli.importer import pytorchjob
+from michelangelo.cli.importer import base, pytorchjob, rayjob
 
-short_description = "Convert training-job manifests into pipeline scaffolds."
+short_description = "Convert job manifests from other systems."
 
 description = """
-Convert a Kubernetes training-job manifest into a Michelangelo pipeline
-scaffold. The generated file is a starting point, not a finished pipeline:
-cluster sizing is mapped for you, the training code itself is marked with
-TODOs. Currently supports Kubeflow Trainer PyTorchJob manifests.
+Convert a Kubernetes job manifest into its Michelangelo equivalent. The
+generated file is a starting point, not a finished artifact: what maps is
+mapped for you, the rest is marked with TODOs and warnings. Kubeflow Trainer
+PyTorchJobs become Uniflow pipeline scaffolds; KubeRay RayJobs become
+michelangelo.api/v2 RayJob (and, for inline cluster specs, RayCluster)
+manifests.
 """
 
 # kind -> converter entry point. Additional kinds plug in here.
 _CONVERTERS = {
     "PyTorchJob": pytorchjob.convert_text,
+    "RayJob": rayjob.convert_text,
 }
 
 
@@ -26,12 +29,12 @@ def init_arguments(parser):
     """Register ``ma import`` arguments on the given subparser."""
     parser.add_argument(
         "manifest",
-        help="Path to the training-job manifest to convert (YAML)",
+        help="Path to the job manifest to convert (YAML)",
     )
     parser.add_argument(
         "-o",
         "--output",
-        help="Write the generated pipeline to this file instead of stdout",
+        help="Write the generated file here instead of stdout",
     )
 
 
@@ -56,7 +59,7 @@ def run(ns) -> int:
 
     try:
         result = converter(text)
-    except pytorchjob.ManifestError as exc:
+    except base.ManifestError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
 

--- a/python/michelangelo/cli/importer/importer.py
+++ b/python/michelangelo/cli/importer/importer.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import yaml
 
-from michelangelo.cli.importer import base, pytorchjob, rayjob
+from michelangelo.cli.importer import base, pytorchjob, rayjob, trainjob
 
 short_description = "Convert job manifests from other systems."
 
@@ -13,8 +13,8 @@ description = """
 Convert a Kubernetes job manifest into its Michelangelo equivalent. The
 generated file is a starting point, not a finished artifact: what maps is
 mapped for you, the rest is marked with TODOs and warnings. Kubeflow Trainer
-PyTorchJobs become Uniflow pipeline scaffolds; KubeRay RayJobs become
-michelangelo.api/v2 RayJob (and, for inline cluster specs, RayCluster)
+PyTorchJobs and TrainJobs become Uniflow pipeline scaffolds; KubeRay RayJobs
+become michelangelo.api/v2 RayJob (and, for inline cluster specs, RayCluster)
 manifests.
 """
 
@@ -22,6 +22,7 @@ manifests.
 _CONVERTERS = {
     "PyTorchJob": pytorchjob.convert_text,
     "RayJob": rayjob.convert_text,
+    "TrainJob": trainjob.convert_text,
 }
 
 

--- a/python/michelangelo/cli/importer/importer.py
+++ b/python/michelangelo/cli/importer/importer.py
@@ -1,0 +1,82 @@
+"""``ma import``: convert training-job manifests into Uniflow pipeline scaffolds."""
+
+import sys
+from pathlib import Path
+
+import yaml
+
+from michelangelo.cli.importer import pytorchjob
+
+short_description = "Convert training-job manifests into pipeline scaffolds."
+
+description = """
+Convert a Kubernetes training-job manifest into a Michelangelo pipeline
+scaffold. The generated file is a starting point, not a finished pipeline:
+cluster sizing is mapped for you, the training code itself is marked with
+TODOs. Currently supports Kubeflow Trainer PyTorchJob manifests.
+"""
+
+# kind -> converter entry point. Additional kinds plug in here.
+_CONVERTERS = {
+    "PyTorchJob": pytorchjob.convert_text,
+}
+
+
+def init_arguments(parser):
+    """Register ``ma import`` arguments on the given subparser."""
+    parser.add_argument(
+        "manifest",
+        help="Path to the training-job manifest to convert (YAML)",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Write the generated pipeline to this file instead of stdout",
+    )
+
+
+def run(ns) -> int:
+    """Convert the manifest named by the parsed CLI arguments."""
+    path = Path(ns.manifest)
+    try:
+        text = path.read_text()
+    except OSError as exc:
+        print(f"error: cannot read {path}: {exc}", file=sys.stderr)
+        return 1
+
+    kind = _detect_kind(text)
+    converter = _CONVERTERS.get(kind)
+    if converter is None:
+        supported = ", ".join(sorted(_CONVERTERS))
+        print(
+            f"error: unsupported manifest kind {kind!r} (supported: {supported})",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        result = converter(text)
+    except pytorchjob.ManifestError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    for warning in result.warnings:
+        print(f"warning: {warning}", file=sys.stderr)
+
+    if ns.output:
+        Path(ns.output).write_text(result.scaffold)
+        print(f"wrote {ns.output}", file=sys.stderr)
+    else:
+        print(result.scaffold, end="")
+    return 0
+
+
+def _detect_kind(text):
+    """Best-effort read of the manifest's kind; converters re-validate."""
+    try:
+        manifest = yaml.safe_load(text)
+    except yaml.YAMLError:
+        return None
+    if isinstance(manifest, dict):
+        return manifest.get("kind")
+    return None

--- a/python/michelangelo/cli/importer/importer_test.py
+++ b/python/michelangelo/cli/importer/importer_test.py
@@ -80,7 +80,7 @@ def test_run_unsupported_kind_fails(tmp_path, capsys):
     captured = capsys.readouterr()
     assert rc == 1
     assert "unsupported manifest kind 'TFJob'" in captured.err
-    assert "supported: PyTorchJob, RayJob" in captured.err
+    assert "supported: PyTorchJob, RayJob, TrainJob" in captured.err
 
 
 def test_run_invalid_manifest_fails(tmp_path, capsys):
@@ -110,6 +110,24 @@ def test_run_dispatches_rayjob_kind(tmp_path, capsys):
     assert "kind: RayJob" in captured.out
     assert "michelangelo.api/v2" in captured.out
     assert "warning: KubeRay manifests carry no user identity" in captured.err
+
+
+def test_run_dispatches_trainjob_kind(tmp_path, capsys):
+    """Run dispatches trainjob kind."""
+    manifest = tmp_path / "job.yaml"
+    manifest.write_text(
+        "apiVersion: trainer.kubeflow.org/v1alpha1\n"
+        "kind: TrainJob\n"
+        "metadata: {name: tj}\n"
+        "spec:\n"
+        "  runtimeRef: {name: torch-distributed}\n"
+        "  trainer: {numNodes: 2}\n"
+    )
+    rc = importer.run(_parse([str(manifest)]))
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "generated from TrainJob 'tj'" in captured.out
+    assert "num_workers=2," in captured.out
 
 
 @pytest.mark.parametrize(

--- a/python/michelangelo/cli/importer/importer_test.py
+++ b/python/michelangelo/cli/importer/importer_test.py
@@ -80,7 +80,7 @@ def test_run_unsupported_kind_fails(tmp_path, capsys):
     captured = capsys.readouterr()
     assert rc == 1
     assert "unsupported manifest kind 'TFJob'" in captured.err
-    assert "supported: PyTorchJob" in captured.err
+    assert "supported: PyTorchJob, RayJob" in captured.err
 
 
 def test_run_invalid_manifest_fails(tmp_path, capsys):
@@ -91,6 +91,25 @@ def test_run_invalid_manifest_fails(tmp_path, capsys):
     captured = capsys.readouterr()
     assert rc == 1
     assert "error: spec.pytorchReplicaSpecs" in captured.err
+
+
+def test_run_dispatches_rayjob_kind(tmp_path, capsys):
+    """Run dispatches rayjob kind."""
+    manifest = tmp_path / "job.yaml"
+    manifest.write_text(
+        "apiVersion: ray.io/v1\n"
+        "kind: RayJob\n"
+        "metadata: {name: rj}\n"
+        "spec:\n"
+        "  entrypoint: python x.py\n"
+        "  clusterSelector: {ray.io/cluster: c1}\n"
+    )
+    rc = importer.run(_parse([str(manifest)]))
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "kind: RayJob" in captured.out
+    assert "michelangelo.api/v2" in captured.out
+    assert "warning: KubeRay manifests carry no user identity" in captured.err
 
 
 @pytest.mark.parametrize(

--- a/python/michelangelo/cli/importer/importer_test.py
+++ b/python/michelangelo/cli/importer/importer_test.py
@@ -1,0 +1,117 @@
+"""Tests for the ``ma import`` CLI surface."""
+
+import argparse
+
+import pytest
+
+from michelangelo.cli import cli
+from michelangelo.cli.importer import importer
+
+_MANIFEST = """
+apiVersion: kubeflow.org/v1
+kind: PyTorchJob
+metadata:
+  name: cli-test-job
+spec:
+  pytorchReplicaSpecs:
+    Worker:
+      replicas: 2
+      template:
+        spec:
+          containers:
+            - name: pytorch
+              image: img:1
+"""
+
+
+def _parse(args):
+    parser = argparse.ArgumentParser()
+    importer.init_arguments(parser)
+    return parser.parse_args(args)
+
+
+def test_run_writes_scaffold_to_stdout(tmp_path, capsys):
+    """Run writes scaffold to stdout."""
+    manifest = tmp_path / "job.yaml"
+    manifest.write_text(_MANIFEST)
+    rc = importer.run(_parse([str(manifest)]))
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "worker_instances=2," in captured.out
+    assert "name='cli-test-job'" in captured.out
+
+
+def test_run_writes_scaffold_to_output_file(tmp_path, capsys):
+    """Run writes scaffold to output file."""
+    manifest = tmp_path / "job.yaml"
+    manifest.write_text(_MANIFEST)
+    out = tmp_path / "pipeline.py"
+    rc = importer.run(_parse([str(manifest), "-o", str(out)]))
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out == ""
+    assert f"wrote {out}" in captured.err
+    assert "worker_instances=2," in out.read_text()
+
+
+def test_run_reports_warnings_on_stderr(tmp_path, capsys):
+    """Run reports warnings on stderr."""
+    manifest = tmp_path / "job.yaml"
+    manifest.write_text(_MANIFEST.replace("spec:\n", "spec:\n  nprocPerNode: '2'\n", 1))
+    rc = importer.run(_parse([str(manifest)]))
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "warning: spec.nprocPerNode" in captured.err
+
+
+def test_run_missing_file_fails(tmp_path, capsys):
+    """Run missing file fails."""
+    rc = importer.run(_parse([str(tmp_path / "nope.yaml")]))
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "cannot read" in captured.err
+
+
+def test_run_unsupported_kind_fails(tmp_path, capsys):
+    """Run unsupported kind fails."""
+    manifest = tmp_path / "job.yaml"
+    manifest.write_text("kind: TFJob\n")
+    rc = importer.run(_parse([str(manifest)]))
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "unsupported manifest kind 'TFJob'" in captured.err
+    assert "supported: PyTorchJob" in captured.err
+
+
+def test_run_invalid_manifest_fails(tmp_path, capsys):
+    """Run invalid manifest fails."""
+    manifest = tmp_path / "job.yaml"
+    manifest.write_text("kind: PyTorchJob\nspec: {}\n")
+    rc = importer.run(_parse([str(manifest)]))
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "error: spec.pytorchReplicaSpecs" in captured.err
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("kind: PyTorchJob", "PyTorchJob"),
+        ("kind: [broken", None),
+        ("- a list", None),
+        ("{}", None),
+    ],
+)
+def test_detect_kind(text, expected):
+    """Detect kind."""
+    assert importer._detect_kind(text) == expected
+
+
+def test_cli_dispatches_import_entity(tmp_path, capsys):
+    """Cli dispatches import entity."""
+    manifest = tmp_path / "job.yaml"
+    manifest.write_text(_MANIFEST)
+    rc = cli.main(["import", str(manifest)])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "worker_instances=2," in captured.out

--- a/python/michelangelo/cli/importer/pytorchjob.py
+++ b/python/michelangelo/cli/importer/pytorchjob.py
@@ -1,0 +1,270 @@
+"""Convert a Kubeflow Trainer PyTorchJob manifest into a Uniflow pipeline scaffold.
+
+The generated scaffold follows the shape documented in the Kubeflow Trainer
+migration guide: a ``@uniflow.task`` sized by a ``RayTask`` config, running a
+``LightningTrainer`` whose ``ScalingConfig`` mirrors the job's worker count.
+Fields with no equivalent here (images, commands, volumes, scheduling hints)
+are surfaced as warnings and TODO comments rather than silently dropped.
+"""
+
+import math
+from dataclasses import dataclass
+
+import yaml
+
+_KIND = "PyTorchJob"
+_API_GROUP = "kubeflow.org"
+
+# PyTorchJob fields that have no direct equivalent in a pipeline task. Each is
+# reported as a warning when present so nothing is silently dropped.
+_UNMAPPED_SPEC_FIELDS = ("elasticPolicy", "runPolicy", "nprocPerNode")
+_UNMAPPED_POD_FIELDS = (
+    "volumes",
+    "nodeSelector",
+    "tolerations",
+    "affinity",
+    "initContainers",
+)
+_UNMAPPED_CONTAINER_FIELDS = ("env", "envFrom", "volumeMounts", "ports")
+
+
+class ManifestError(ValueError):
+    """Raised when the input manifest cannot be converted."""
+
+
+@dataclass
+class ConversionResult:
+    """The generated pipeline scaffold plus everything that did not map."""
+
+    scaffold: str
+    warnings: list
+
+
+def convert_text(text: str) -> ConversionResult:
+    """Parse a YAML manifest and convert it. See :func:`convert`."""
+    try:
+        manifest = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise ManifestError(f"input is not valid YAML: {exc}") from exc
+    if not isinstance(manifest, dict):
+        raise ManifestError(
+            "input is not a Kubernetes manifest (expected a YAML mapping)"
+        )
+    return convert(manifest)
+
+
+def convert(manifest: dict) -> ConversionResult:
+    """Convert a PyTorchJob manifest dict into a pipeline scaffold.
+
+    Raises :class:`ManifestError` when the manifest is not a PyTorchJob or has
+    no replica specs at all.
+    """
+    warnings = []
+
+    kind = manifest.get("kind")
+    if kind != _KIND:
+        raise ManifestError(
+            f"unsupported kind {kind!r}: this converter handles {_KIND} manifests"
+        )
+    api_version = str(manifest.get("apiVersion") or "")
+    if not api_version.startswith(_API_GROUP):
+        warnings.append(
+            f"apiVersion {api_version!r} is not from {_API_GROUP}; converting anyway"
+        )
+
+    name = (manifest.get("metadata") or {}).get("name") or "imported-pytorch-job"
+    spec = manifest.get("spec") or {}
+
+    for spec_field in _UNMAPPED_SPEC_FIELDS:
+        if spec_field in spec:
+            warnings.append(
+                f"spec.{spec_field} has no pipeline equivalent and was not converted"
+            )
+
+    replica_specs = spec.get("pytorchReplicaSpecs") or {}
+    master = replica_specs.get("Master")
+    worker = replica_specs.get("Worker")
+    if master is None and worker is None:
+        raise ManifestError(
+            "spec.pytorchReplicaSpecs has neither a Master nor a Worker block"
+        )
+
+    master_container = _first_container(master, "Master", warnings)
+    worker_container = _first_container(worker, "Worker", warnings)
+
+    if worker is not None:
+        worker_replicas = int(worker.get("replicas") or 1)
+    else:
+        worker_replicas = 1
+        warnings.append(
+            "no Worker block: emitting a single-worker training group sized from Master"
+        )
+        worker_container = master_container
+
+    head_cpu, head_memory, head_gpu = _container_resources(master_container)
+    worker_cpu, worker_memory, worker_gpu = _container_resources(worker_container)
+
+    _warn_unmapped_runtime(master_container, "Master", warnings)
+    if worker_container is not master_container:
+        _warn_unmapped_runtime(worker_container, "Worker", warnings)
+
+    ray_task_fields = [
+        ("head_cpu", head_cpu),
+        ("head_memory", _quote(head_memory)),
+        ("head_gpu", head_gpu or None),
+        ("worker_cpu", worker_cpu),
+        ("worker_memory", _quote(worker_memory)),
+        ("worker_gpu", worker_gpu or None),
+        ("worker_instances", worker_replicas),
+    ]
+    ray_task_lines = [f"        {k}={v}," for k, v in ray_task_fields if v is not None]
+    if len(ray_task_lines) == 1:
+        ray_task_lines.insert(0, "        # TODO: size the cluster for your workload.")
+
+    entrypoint = _entrypoint_comment(worker_container or master_container)
+    use_gpu = bool(worker_gpu)
+
+    scaffold = _SCAFFOLD_TEMPLATE.format(
+        source_name=name,
+        ray_task_fields="\n".join(ray_task_lines),
+        entrypoint=entrypoint,
+        run_name=name,
+        num_workers=worker_replicas,
+        use_gpu=use_gpu,
+    )
+    return ConversionResult(scaffold=scaffold, warnings=warnings)
+
+
+def _first_container(replica_spec, role, warnings):
+    """Return the first container of a replica spec, warning about the rest."""
+    if replica_spec is None:
+        return None
+    pod_spec = ((replica_spec.get("template") or {}).get("spec")) or {}
+    for pod_field in _UNMAPPED_POD_FIELDS:
+        if pod_field in pod_spec:
+            warnings.append(
+                f"{role} pod {pod_field} has no pipeline equivalent"
+                " and was not converted"
+            )
+    if pod_spec.get("restartPolicy"):
+        warnings.append(
+            f"{role} restartPolicy was not converted:"
+            " task retries are workflow-level here"
+        )
+    containers = pod_spec.get("containers") or []
+    if not containers:
+        warnings.append(
+            f"{role} block has no containers; its resources were not converted"
+        )
+        return None
+    if len(containers) > 1:
+        warnings.append(
+            f"{role} has {len(containers)} containers; only the first was converted"
+        )
+    return containers[0]
+
+
+def _container_resources(container):
+    """Extract (cpu, memory, gpu) from a container, preferring requests."""
+    if container is None:
+        return None, None, None
+    resources = container.get("resources") or {}
+    requests = resources.get("requests") or {}
+    limits = resources.get("limits") or {}
+    cpu = _cpu_count(requests.get("cpu", limits.get("cpu")))
+    memory = requests.get("memory", limits.get("memory"))
+    gpu = _gpu_count(limits.get("nvidia.com/gpu", requests.get("nvidia.com/gpu")))
+    return cpu, memory, gpu
+
+
+def _cpu_count(quantity):
+    """Round a Kubernetes CPU quantity ("500m", "2", 2.5) up to whole CPUs."""
+    if quantity is None:
+        return None
+    text = str(quantity)
+    if text.endswith("m"):
+        return math.ceil(int(text[:-1]) / 1000)
+    return math.ceil(float(text))
+
+
+def _gpu_count(quantity):
+    if quantity is None:
+        return None
+    return int(str(quantity))
+
+
+def _warn_unmapped_runtime(container, role, warnings):
+    if container is None:
+        return
+    for container_field in _UNMAPPED_CONTAINER_FIELDS:
+        if container_field in container:
+            warnings.append(
+                f"{role} container {container_field} has no pipeline equivalent"
+                " and was not converted"
+            )
+
+
+def _entrypoint_comment(container):
+    """Describe the container entrypoint the user must port into the task body."""
+    lines = [
+        "    # TODO: port the training code from your PyTorchJob image into this task."
+    ]
+    if container:
+        if container.get("image"):
+            lines.append(f"    #   image:   {container['image']}")
+        command = list(container.get("command") or []) + list(
+            container.get("args") or []
+        )
+        if command:
+            lines.append(f"    #   command: {' '.join(str(part) for part in command)}")
+    return "\n".join(lines)
+
+
+def _quote(value):
+    return None if value is None else repr(str(value))
+
+
+_SCAFFOLD_TEMPLATE = '''"""Pipeline scaffold generated from PyTorchJob {source_name!r}.
+
+Review every TODO before running: the converter maps cluster sizing, not
+training code. See docs/user-guides/migration/migrate-from-kubeflow-trainer.md
+for the full field mapping.
+"""
+
+import michelangelo.uniflow.core as uniflow
+import ray.train
+from michelangelo.lib.trainer.torch.pytorch_lightning import (
+    LightningTrainer,
+    LightningTrainerParam,
+)
+from michelangelo.uniflow.plugins.ray import RayTask
+
+
+@uniflow.task(
+    config=RayTask(
+{ray_task_fields}
+    )
+)
+def train(data_path: str):
+{entrypoint}
+    trainer = LightningTrainer(
+        trainer_param=LightningTrainerParam(
+            create_model_fn=create_model,  # TODO: your LightningModule factory
+            create_model_fn_kwargs={{}},
+            train_data=load_train(data_path),  # TODO: training Ray Dataset
+            val_data=load_val(data_path),  # TODO: validation Ray Dataset
+            batch_size=256,  # TODO: per-worker batch size
+        ),
+        run_config=ray.train.RunConfig(name={run_name!r}),
+        scaling_config=ray.train.ScalingConfig(
+            num_workers={num_workers},
+            use_gpu={use_gpu},
+        ),
+    )
+    return trainer.train()
+
+
+@uniflow.workflow()
+def training_pipeline(data_path: str):
+    return train(data_path)
+'''

--- a/python/michelangelo/cli/importer/pytorchjob.py
+++ b/python/michelangelo/cli/importer/pytorchjob.py
@@ -8,9 +8,10 @@ are surfaced as warnings and TODO comments rather than silently dropped.
 """
 
 import math
-from dataclasses import dataclass
 
 import yaml
+
+from michelangelo.cli.importer.base import ConversionResult, ManifestError
 
 _KIND = "PyTorchJob"
 _API_GROUP = "kubeflow.org"
@@ -26,18 +27,6 @@ _UNMAPPED_POD_FIELDS = (
     "initContainers",
 )
 _UNMAPPED_CONTAINER_FIELDS = ("env", "envFrom", "volumeMounts", "ports")
-
-
-class ManifestError(ValueError):
-    """Raised when the input manifest cannot be converted."""
-
-
-@dataclass
-class ConversionResult:
-    """The generated pipeline scaffold plus everything that did not map."""
-
-    scaffold: str
-    warnings: list
 
 
 def convert_text(text: str) -> ConversionResult:

--- a/python/michelangelo/cli/importer/pytorchjob.py
+++ b/python/michelangelo/cli/importer/pytorchjob.py
@@ -7,10 +7,9 @@ Fields with no equivalent here (images, commands, volumes, scheduling hints)
 are surfaced as warnings and TODO comments rather than silently dropped.
 """
 
-import math
-
 import yaml
 
+from michelangelo.cli.importer import scaffold
 from michelangelo.cli.importer.base import ConversionResult, ManifestError
 
 _KIND = "PyTorchJob"
@@ -99,29 +98,26 @@ def convert(manifest: dict) -> ConversionResult:
 
     ray_task_fields = [
         ("head_cpu", head_cpu),
-        ("head_memory", _quote(head_memory)),
+        ("head_memory", scaffold.quote(head_memory)),
         ("head_gpu", head_gpu or None),
         ("worker_cpu", worker_cpu),
-        ("worker_memory", _quote(worker_memory)),
+        ("worker_memory", scaffold.quote(worker_memory)),
         ("worker_gpu", worker_gpu or None),
         ("worker_instances", worker_replicas),
     ]
-    ray_task_lines = [f"        {k}={v}," for k, v in ray_task_fields if v is not None]
-    if len(ray_task_lines) == 1:
-        ray_task_lines.insert(0, "        # TODO: size the cluster for your workload.")
 
-    entrypoint = _entrypoint_comment(worker_container or master_container)
-    use_gpu = bool(worker_gpu)
-
-    scaffold = _SCAFFOLD_TEMPLATE.format(
+    text = scaffold.TEMPLATE.format(
+        source_kind=_KIND,
         source_name=name,
-        ray_task_fields="\n".join(ray_task_lines),
-        entrypoint=entrypoint,
+        ray_task_fields=scaffold.ray_task_lines(ray_task_fields),
+        entrypoint=scaffold.entrypoint_comment(
+            worker_container or master_container, _KIND
+        ),
         run_name=name,
         num_workers=worker_replicas,
-        use_gpu=use_gpu,
+        use_gpu=bool(worker_gpu),
     )
-    return ConversionResult(scaffold=scaffold, warnings=warnings)
+    return ConversionResult(scaffold=text, warnings=warnings)
 
 
 def _first_container(replica_spec, role, warnings):
@@ -157,29 +153,7 @@ def _container_resources(container):
     """Extract (cpu, memory, gpu) from a container, preferring requests."""
     if container is None:
         return None, None, None
-    resources = container.get("resources") or {}
-    requests = resources.get("requests") or {}
-    limits = resources.get("limits") or {}
-    cpu = _cpu_count(requests.get("cpu", limits.get("cpu")))
-    memory = requests.get("memory", limits.get("memory"))
-    gpu = _gpu_count(limits.get("nvidia.com/gpu", requests.get("nvidia.com/gpu")))
-    return cpu, memory, gpu
-
-
-def _cpu_count(quantity):
-    """Round a Kubernetes CPU quantity ("500m", "2", 2.5) up to whole CPUs."""
-    if quantity is None:
-        return None
-    text = str(quantity)
-    if text.endswith("m"):
-        return math.ceil(int(text[:-1]) / 1000)
-    return math.ceil(float(text))
-
-
-def _gpu_count(quantity):
-    if quantity is None:
-        return None
-    return int(str(quantity))
+    return scaffold.resources_from(container.get("resources"))
 
 
 def _warn_unmapped_runtime(container, role, warnings):
@@ -191,69 +165,3 @@ def _warn_unmapped_runtime(container, role, warnings):
                 f"{role} container {container_field} has no pipeline equivalent"
                 " and was not converted"
             )
-
-
-def _entrypoint_comment(container):
-    """Describe the container entrypoint the user must port into the task body."""
-    lines = [
-        "    # TODO: port the training code from your PyTorchJob image into this task."
-    ]
-    if container:
-        if container.get("image"):
-            lines.append(f"    #   image:   {container['image']}")
-        command = list(container.get("command") or []) + list(
-            container.get("args") or []
-        )
-        if command:
-            lines.append(f"    #   command: {' '.join(str(part) for part in command)}")
-    return "\n".join(lines)
-
-
-def _quote(value):
-    return None if value is None else repr(str(value))
-
-
-_SCAFFOLD_TEMPLATE = '''"""Pipeline scaffold generated from PyTorchJob {source_name!r}.
-
-Review every TODO before running: the converter maps cluster sizing, not
-training code. See docs/user-guides/migration/migrate-from-kubeflow-trainer.md
-for the full field mapping.
-"""
-
-import michelangelo.uniflow.core as uniflow
-import ray.train
-from michelangelo.lib.trainer.torch.pytorch_lightning import (
-    LightningTrainer,
-    LightningTrainerParam,
-)
-from michelangelo.uniflow.plugins.ray import RayTask
-
-
-@uniflow.task(
-    config=RayTask(
-{ray_task_fields}
-    )
-)
-def train(data_path: str):
-{entrypoint}
-    trainer = LightningTrainer(
-        trainer_param=LightningTrainerParam(
-            create_model_fn=create_model,  # TODO: your LightningModule factory
-            create_model_fn_kwargs={{}},
-            train_data=load_train(data_path),  # TODO: training Ray Dataset
-            val_data=load_val(data_path),  # TODO: validation Ray Dataset
-            batch_size=256,  # TODO: per-worker batch size
-        ),
-        run_config=ray.train.RunConfig(name={run_name!r}),
-        scaling_config=ray.train.ScalingConfig(
-            num_workers={num_workers},
-            use_gpu={use_gpu},
-        ),
-    )
-    return trainer.train()
-
-
-@uniflow.workflow()
-def training_pipeline(data_path: str):
-    return train(data_path)
-'''

--- a/python/michelangelo/cli/importer/pytorchjob_test.py
+++ b/python/michelangelo/cli/importer/pytorchjob_test.py
@@ -177,19 +177,3 @@ spec:
     assert any("no containers" in w for w in result.warnings)
     assert "# TODO: size the cluster for your workload." in result.scaffold
     assert "worker_instances=2," in result.scaffold
-
-
-@pytest.mark.parametrize(
-    ("quantity", "expected"),
-    [(None, None), ("500m", 1), ("1500m", 2), ("2", 2), (2, 2), ("2.5", 3), (0.1, 1)],
-)
-def test_cpu_quantities_round_up(quantity, expected):
-    """Cpu quantities round up."""
-    assert pytorchjob._cpu_count(quantity) == expected
-
-
-def test_gpu_quantities():
-    """Gpu quantities."""
-    assert pytorchjob._gpu_count(None) is None
-    assert pytorchjob._gpu_count("2") == 2
-    assert pytorchjob._gpu_count(1) == 1

--- a/python/michelangelo/cli/importer/pytorchjob_test.py
+++ b/python/michelangelo/cli/importer/pytorchjob_test.py
@@ -1,0 +1,195 @@
+"""Tests for the PyTorchJob-to-pipeline converter."""
+
+import pytest
+
+from michelangelo.cli.importer import pytorchjob
+
+_FULL_MANIFEST = """
+apiVersion: kubeflow.org/v1
+kind: PyTorchJob
+metadata:
+  name: pytorch-dist-train
+spec:
+  pytorchReplicaSpecs:
+    Master:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: pytorch
+              image: my-training-image:latest
+              command: ["python", "train.py"]
+              resources:
+                requests:
+                  cpu: "2"
+                  memory: 4Gi
+    Worker:
+      replicas: 3
+      template:
+        spec:
+          containers:
+            - name: pytorch
+              image: my-training-image:latest
+              command: ["python"]
+              args: ["train.py"]
+              resources:
+                requests:
+                  cpu: 500m
+                  memory: 16Gi
+                limits:
+                  nvidia.com/gpu: 1
+"""
+
+
+def test_full_manifest_maps_resources_and_scaling():
+    """Full manifest maps resources and scaling."""
+    result = pytorchjob.convert_text(_FULL_MANIFEST)
+    scaffold = result.scaffold
+    assert "head_cpu=2," in scaffold
+    assert "head_memory='4Gi'," in scaffold
+    assert "worker_cpu=1," in scaffold  # 500m rounds up to a whole CPU
+    assert "worker_memory='16Gi'," in scaffold
+    assert "worker_gpu=1," in scaffold
+    assert "worker_instances=3," in scaffold
+    assert "num_workers=3," in scaffold
+    assert "use_gpu=True," in scaffold
+    assert "name='pytorch-dist-train'" in scaffold
+    # Entrypoint surfaced as TODO comments, with args appended to command.
+    assert "image:   my-training-image:latest" in scaffold
+    assert "command: python train.py" in scaffold
+    assert result.warnings == []
+
+
+def test_scaffold_is_valid_python():
+    """Scaffold is valid python."""
+    result = pytorchjob.convert_text(_FULL_MANIFEST)
+    compile(result.scaffold, "<generated>", "exec")
+
+
+def test_wrong_kind_is_rejected():
+    """Wrong kind is rejected."""
+    with pytest.raises(pytorchjob.ManifestError, match="unsupported kind 'TFJob'"):
+        pytorchjob.convert_text("kind: TFJob\napiVersion: kubeflow.org/v1\n")
+
+
+def test_invalid_yaml_is_rejected():
+    """Invalid yaml is rejected."""
+    with pytest.raises(pytorchjob.ManifestError, match="not valid YAML"):
+        pytorchjob.convert_text("kind: [unclosed")
+
+
+def test_non_mapping_input_is_rejected():
+    """Non mapping input is rejected."""
+    with pytest.raises(pytorchjob.ManifestError, match="expected a YAML mapping"):
+        pytorchjob.convert_text("- just\n- a\n- list\n")
+
+
+def test_missing_replica_specs_is_rejected():
+    """Missing replica specs is rejected."""
+    manifest = "kind: PyTorchJob\napiVersion: kubeflow.org/v1\nspec: {}\n"
+    with pytest.raises(pytorchjob.ManifestError, match="neither a Master nor a Worker"):
+        pytorchjob.convert_text(manifest)
+
+
+def test_master_only_manifest_warns_and_sizes_from_master():
+    """Master only manifest warns and sizes from master."""
+    manifest = """
+apiVersion: kubeflow.org/v1
+kind: PyTorchJob
+spec:
+  pytorchReplicaSpecs:
+    Master:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: pytorch
+              resources:
+                limits:
+                  cpu: 2500m
+                  memory: 8Gi
+"""
+    result = pytorchjob.convert_text(manifest)
+    assert "worker_instances=1," in result.scaffold
+    assert "worker_cpu=3," in result.scaffold  # 2500m rounds up, limits fallback
+    assert "worker_memory='8Gi'," in result.scaffold
+    assert "num_workers=1," in result.scaffold
+    assert "use_gpu=False," in result.scaffold
+    assert "name='imported-pytorch-job'" in result.scaffold
+    assert any("no Worker block" in w for w in result.warnings)
+
+
+def test_unmapped_fields_produce_warnings_not_silence():
+    """Unmapped fields produce warnings not silence."""
+    manifest = """
+apiVersion: training.example.io/v1
+kind: PyTorchJob
+metadata:
+  name: busy-job
+spec:
+  nprocPerNode: "2"
+  elasticPolicy: {minReplicas: 1}
+  runPolicy: {cleanPodPolicy: Running}
+  pytorchReplicaSpecs:
+    Worker:
+      replicas: 2
+      template:
+        spec:
+          restartPolicy: OnFailure
+          nodeSelector: {pool: gpu}
+          volumes: [{name: data}]
+          containers:
+            - name: pytorch
+              env: [{name: FOO, value: bar}]
+              volumeMounts: [{name: data, mountPath: /data}]
+            - name: sidecar
+"""
+    result = pytorchjob.convert_text(manifest)
+    joined = "\n".join(result.warnings)
+    for expected in (
+        "apiVersion 'training.example.io/v1'",
+        "spec.nprocPerNode",
+        "spec.elasticPolicy",
+        "spec.runPolicy",
+        "restartPolicy",
+        "nodeSelector",
+        "volumes",
+        "env",
+        "volumeMounts",
+        "2 containers; only the first",
+    ):
+        assert expected in joined, f"missing warning about {expected}"
+
+
+def test_containerless_worker_warns_and_emits_sizing_todo():
+    """Containerless worker warns and emits sizing todo."""
+    manifest = """
+apiVersion: kubeflow.org/v1
+kind: PyTorchJob
+spec:
+  pytorchReplicaSpecs:
+    Worker:
+      replicas: 2
+      template:
+        spec: {}
+"""
+    result = pytorchjob.convert_text(manifest)
+    assert any("no containers" in w for w in result.warnings)
+    assert "# TODO: size the cluster for your workload." in result.scaffold
+    assert "worker_instances=2," in result.scaffold
+
+
+@pytest.mark.parametrize(
+    ("quantity", "expected"),
+    [(None, None), ("500m", 1), ("1500m", 2), ("2", 2), (2, 2), ("2.5", 3), (0.1, 1)],
+)
+def test_cpu_quantities_round_up(quantity, expected):
+    """Cpu quantities round up."""
+    assert pytorchjob._cpu_count(quantity) == expected
+
+
+def test_gpu_quantities():
+    """Gpu quantities."""
+    assert pytorchjob._gpu_count(None) is None
+    assert pytorchjob._gpu_count("2") == 2
+    assert pytorchjob._gpu_count(1) == 1

--- a/python/michelangelo/cli/importer/rayjob.py
+++ b/python/michelangelo/cli/importer/rayjob.py
@@ -1,0 +1,252 @@
+"""Convert a KubeRay RayJob manifest into michelangelo.api/v2 resources.
+
+Follows the mapping documented in the KubeRay migration guide: a RayJob that
+targets an existing cluster via ``clusterSelector`` becomes a single
+michelangelo.api/v2 RayJob referencing that cluster; a RayJob carrying an
+inline ``rayClusterSpec`` becomes a v2 RayCluster plus a v2 RayJob that
+references it. Fields with no v2 equivalent (shutdown and TTL policies,
+submitter pod templates, runtime envs, autoscaler options) are surfaced as
+warnings rather than silently dropped.
+"""
+
+import yaml
+
+from michelangelo.cli.importer.base import ConversionResult, ManifestError
+
+_KIND = "RayJob"
+_API_GROUP = "ray.io"
+
+# The canonical KubeRay label used by clusterSelector to target a cluster.
+_CLUSTER_SELECTOR_KEY = "ray.io/cluster"
+
+_USER_TODO = "TODO-your-username"
+_ENTRYPOINT_TODO = "TODO: python your_script.py"
+
+# Keys the converter maps. Anything else in the corresponding block is
+# reported as a warning so nothing is silently dropped.
+_HANDLED_SPEC_FIELDS = frozenset(
+    {"entrypoint", "jobId", "clusterSelector", "rayClusterSpec"}
+)
+_HANDLED_CLUSTER_FIELDS = frozenset({"rayVersion", "headGroupSpec", "workerGroupSpecs"})
+_HANDLED_HEAD_FIELDS = frozenset({"serviceType", "rayStartParams", "template"})
+_HANDLED_WORKER_FIELDS = frozenset(
+    {
+        "groupName",
+        "replicas",
+        "minReplicas",
+        "maxReplicas",
+        "rayStartParams",
+        "template",
+    }
+)
+
+
+def convert_text(text: str) -> ConversionResult:
+    """Parse a YAML manifest and convert it. See :func:`convert`."""
+    try:
+        manifest = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise ManifestError(f"input is not valid YAML: {exc}") from exc
+    if not isinstance(manifest, dict):
+        raise ManifestError(
+            "input is not a Kubernetes manifest (expected a YAML mapping)"
+        )
+    return convert(manifest)
+
+
+def convert(manifest: dict) -> ConversionResult:
+    """Convert a KubeRay RayJob dict into michelangelo.api/v2 manifests.
+
+    Raises :class:`ManifestError` when the manifest is not a RayJob or names
+    no cluster at all (neither ``clusterSelector`` nor ``rayClusterSpec``).
+    """
+    warnings = []
+
+    kind = manifest.get("kind")
+    if kind != _KIND:
+        raise ManifestError(
+            f"unsupported kind {kind!r}: this converter handles {_KIND} manifests"
+        )
+    api_version = str(manifest.get("apiVersion") or "")
+    if not api_version.startswith(_API_GROUP):
+        warnings.append(
+            f"apiVersion {api_version!r} is not from {_API_GROUP}; converting anyway"
+        )
+
+    metadata = manifest.get("metadata") or {}
+    name = metadata.get("name") or "imported-ray-job"
+    namespace = metadata.get("namespace")
+    spec = manifest.get("spec") or {}
+
+    _warn_unhandled(spec, _HANDLED_SPEC_FIELDS, "spec", warnings)
+
+    selector = spec.get("clusterSelector")
+    cluster_spec = spec.get("rayClusterSpec")
+    if selector is None and cluster_spec is None:
+        raise ManifestError(
+            "spec has neither clusterSelector nor rayClusterSpec;"
+            " there is no cluster to convert or reference"
+        )
+
+    warnings.append(
+        "KubeRay manifests carry no user identity;"
+        " replace the TODO in spec.user.name before applying"
+    )
+
+    documents = []
+    if selector is not None:
+        if cluster_spec is not None:
+            warnings.append(
+                "both clusterSelector and rayClusterSpec are set; clusterSelector"
+                " wins (as in KubeRay) and the inline spec was not converted"
+            )
+        cluster_ref = _cluster_from_selector(selector, namespace, warnings)
+    else:
+        documents.append(_cluster_manifest(name, namespace, cluster_spec, warnings))
+        cluster_ref = {"name": name}
+        if namespace:
+            cluster_ref["namespace"] = namespace
+
+    documents.append(_job_manifest(name, metadata, spec, cluster_ref, warnings))
+
+    text = yaml.safe_dump_all(documents, sort_keys=False, default_flow_style=False)
+    return ConversionResult(scaffold=text, warnings=warnings)
+
+
+def _cluster_from_selector(selector, namespace, warnings):
+    """Build the v2 cluster reference from a KubeRay clusterSelector."""
+    cluster_name = (selector or {}).get(_CLUSTER_SELECTOR_KEY)
+    if not cluster_name:
+        cluster_name = "TODO-cluster-name"
+        warnings.append(
+            f"clusterSelector has no {_CLUSTER_SELECTOR_KEY!r} label;"
+            " set spec.cluster.name to the target cluster"
+        )
+    extra = sorted(key for key in (selector or {}) if key != _CLUSTER_SELECTOR_KEY)
+    if extra:
+        warnings.append(
+            f"clusterSelector labels {extra} were not converted;"
+            " v2 references clusters by name"
+        )
+    cluster_ref = {"name": cluster_name}
+    if namespace:
+        cluster_ref["namespace"] = namespace
+    return cluster_ref
+
+
+def _cluster_manifest(name, namespace, cluster_spec, warnings):
+    """Convert an inline rayClusterSpec into a v2 RayCluster manifest."""
+    _warn_unhandled(
+        cluster_spec, _HANDLED_CLUSTER_FIELDS, "spec.rayClusterSpec", warnings
+    )
+
+    spec = {"user": {"name": _USER_TODO}}
+    if cluster_spec.get("rayVersion"):
+        spec["rayVersion"] = cluster_spec["rayVersion"]
+
+    head = cluster_spec.get("headGroupSpec")
+    if head is None:
+        warnings.append(
+            "rayClusterSpec has no headGroupSpec;"
+            " add spec.head to the generated RayCluster"
+        )
+    else:
+        spec["head"] = _head(head, warnings)
+
+    workers = cluster_spec.get("workerGroupSpecs") or []
+    if workers:
+        spec["workers"] = [
+            _worker(worker, index, warnings) for index, worker in enumerate(workers)
+        ]
+
+    out_metadata = {"name": name}
+    if namespace:
+        out_metadata["namespace"] = namespace
+    return {
+        "apiVersion": "michelangelo.api/v2",
+        "kind": "RayCluster",
+        "metadata": out_metadata,
+        "spec": spec,
+    }
+
+
+def _head(head, warnings):
+    """Convert a KubeRay headGroupSpec into a v2 head spec."""
+    _warn_unhandled(head, _HANDLED_HEAD_FIELDS, "headGroupSpec", warnings)
+    out = {}
+    if head.get("serviceType"):
+        out["serviceType"] = head["serviceType"]
+    if head.get("template") is not None:
+        out["pod"] = head["template"]
+    if head.get("rayStartParams"):
+        out["rayStartParams"] = head["rayStartParams"]
+    return out
+
+
+def _worker(worker, index, warnings):
+    """Convert one KubeRay workerGroupSpec into a v2 worker spec."""
+    label = f"workerGroupSpecs[{index}]"
+    _warn_unhandled(worker, _HANDLED_WORKER_FIELDS, label, warnings)
+
+    out = {}
+    group_name = worker.get("groupName")
+    if group_name:
+        out["nodeType"] = group_name
+    else:
+        warnings.append(f"{label} has no groupName; set nodeType on the output")
+
+    counts = [
+        worker.get("minReplicas"),
+        worker.get("replicas"),
+        worker.get("maxReplicas"),
+    ]
+    min_instances = next((count for count in counts if count is not None), None)
+    max_instances = next(
+        (count for count in reversed(counts) if count is not None), None
+    )
+    if min_instances is None:
+        min_instances = max_instances = 1
+        warnings.append(f"{label} has no replica counts; defaulting to one instance")
+    out["minInstances"] = int(min_instances)
+    out["maxInstances"] = int(max_instances)
+
+    if worker.get("template") is not None:
+        out["pod"] = worker["template"]
+    if worker.get("rayStartParams"):
+        out["rayStartParams"] = worker["rayStartParams"]
+    return out
+
+
+def _job_manifest(name, metadata, spec, cluster_ref, warnings):
+    """Build the v2 RayJob manifest referencing ``cluster_ref``."""
+    entrypoint = spec.get("entrypoint")
+    if not entrypoint:
+        entrypoint = _ENTRYPOINT_TODO
+        warnings.append("spec.entrypoint is missing; fill in the TODO in the output")
+
+    job_spec = {
+        "user": {"name": _USER_TODO},
+        "entrypoint": entrypoint,
+        "cluster": cluster_ref,
+    }
+    if spec.get("jobId"):
+        job_spec["jobId"] = spec["jobId"]
+
+    out_metadata = {"name": name}
+    if metadata.get("namespace"):
+        out_metadata["namespace"] = metadata["namespace"]
+    for passthrough in ("labels", "annotations"):
+        if metadata.get(passthrough):
+            out_metadata[passthrough] = metadata[passthrough]
+    return {
+        "apiVersion": "michelangelo.api/v2",
+        "kind": "RayJob",
+        "metadata": out_metadata,
+        "spec": job_spec,
+    }
+
+
+def _warn_unhandled(mapping, handled, label, warnings):
+    """Warn once per key in ``mapping`` that the converter does not map."""
+    for key in sorted(key for key in (mapping or {}) if key not in handled):
+        warnings.append(f"{label}.{key} has no v2 equivalent and was not converted")

--- a/python/michelangelo/cli/importer/rayjob_test.py
+++ b/python/michelangelo/cli/importer/rayjob_test.py
@@ -1,0 +1,301 @@
+"""Tests for the RayJob-to-michelangelo.api/v2 converter."""
+
+import pytest
+import yaml
+
+from michelangelo.cli.importer import rayjob
+
+_SELECTOR_MANIFEST = """
+apiVersion: ray.io/v1
+kind: RayJob
+metadata:
+  name: sample-job
+  namespace: team-a
+spec:
+  entrypoint: python sample.py
+  jobId: sample-123
+  clusterSelector:
+    ray.io/cluster: shared-cluster
+"""
+
+_INLINE_MANIFEST = """
+apiVersion: ray.io/v1
+kind: RayJob
+metadata:
+  name: train-job
+spec:
+  entrypoint: python train.py
+  rayClusterSpec:
+    rayVersion: 2.9.0
+    headGroupSpec:
+      serviceType: ClusterIP
+      rayStartParams:
+        dashboard-host: 0.0.0.0
+      template:
+        spec:
+          containers:
+            - name: ray-head
+              image: rayproject/ray:2.9.0
+    workerGroupSpecs:
+      - groupName: gpu-workers
+        replicas: 3
+        minReplicas: 1
+        maxReplicas: 5
+        rayStartParams: {}
+        template:
+          spec:
+            containers:
+              - name: ray-worker
+                image: rayproject/ray:2.9.0
+"""
+
+
+def _docs(result):
+    return list(yaml.safe_load_all(result.scaffold))
+
+
+def test_cluster_selector_emits_single_rayjob():
+    """Cluster selector emits single rayjob."""
+    result = rayjob.convert_text(_SELECTOR_MANIFEST)
+    docs = _docs(result)
+    assert len(docs) == 1
+    job = docs[0]
+    assert job["apiVersion"] == "michelangelo.api/v2"
+    assert job["kind"] == "RayJob"
+    assert job["metadata"] == {"name": "sample-job", "namespace": "team-a"}
+    assert job["spec"]["entrypoint"] == "python sample.py"
+    assert job["spec"]["jobId"] == "sample-123"
+    assert job["spec"]["cluster"] == {"name": "shared-cluster", "namespace": "team-a"}
+    assert job["spec"]["user"]["name"].startswith("TODO")
+    # The only warning is the always-present user identity reminder.
+    assert len(result.warnings) == 1
+    assert "user identity" in result.warnings[0]
+
+
+def test_inline_cluster_emits_cluster_and_job():
+    """Inline cluster emits cluster and job."""
+    result = rayjob.convert_text(_INLINE_MANIFEST)
+    docs = _docs(result)
+    assert len(docs) == 2
+    cluster, job = docs
+    assert cluster["kind"] == "RayCluster"
+    assert cluster["apiVersion"] == "michelangelo.api/v2"
+    assert cluster["metadata"] == {"name": "train-job"}
+    assert cluster["spec"]["rayVersion"] == "2.9.0"
+    head = cluster["spec"]["head"]
+    assert head["serviceType"] == "ClusterIP"
+    assert head["rayStartParams"] == {"dashboard-host": "0.0.0.0"}
+    assert head["pod"]["spec"]["containers"][0]["name"] == "ray-head"
+    (worker,) = cluster["spec"]["workers"]
+    assert worker["nodeType"] == "gpu-workers"
+    assert worker["minInstances"] == 1
+    assert worker["maxInstances"] == 5
+    assert worker["pod"]["spec"]["containers"][0]["name"] == "ray-worker"
+    assert "rayStartParams" not in worker  # empty map is dropped
+    assert job["kind"] == "RayJob"
+    assert job["spec"]["cluster"] == {"name": "train-job"}
+    assert job["spec"]["entrypoint"] == "python train.py"
+    assert "jobId" not in job["spec"]
+    assert len(result.warnings) == 1  # only the user identity reminder
+
+
+def test_worker_replicas_fallback():
+    """Worker replicas fallback."""
+    manifest = yaml.safe_load(_INLINE_MANIFEST)
+    workers = manifest["spec"]["rayClusterSpec"]["workerGroupSpecs"]
+    workers[0] = {
+        "groupName": "cpu",
+        "replicas": 4,
+        "rayStartParams": {"num-cpus": "4"},
+    }
+    result = rayjob.convert(manifest)
+    (worker,) = _docs(result)[0]["spec"]["workers"]
+    assert worker["minInstances"] == 4
+    assert worker["maxInstances"] == 4
+    assert worker["rayStartParams"] == {"num-cpus": "4"}
+
+
+def test_worker_max_only_fallback():
+    """Worker max only fallback."""
+    manifest = yaml.safe_load(_INLINE_MANIFEST)
+    manifest["spec"]["rayClusterSpec"]["workerGroupSpecs"] = [
+        {"groupName": "cpu", "maxReplicas": 6}
+    ]
+    result = rayjob.convert(manifest)
+    (worker,) = _docs(result)[0]["spec"]["workers"]
+    assert worker["minInstances"] == 6
+    assert worker["maxInstances"] == 6
+
+
+def test_worker_without_counts_defaults_to_one():
+    """Worker without counts defaults to one."""
+    manifest = yaml.safe_load(_INLINE_MANIFEST)
+    manifest["spec"]["rayClusterSpec"]["workerGroupSpecs"] = [{"groupName": "cpu"}]
+    result = rayjob.convert(manifest)
+    (worker,) = _docs(result)[0]["spec"]["workers"]
+    assert worker["minInstances"] == 1
+    assert worker["maxInstances"] == 1
+    assert any("no replica counts" in w for w in result.warnings)
+
+
+def test_worker_without_group_name_warns():
+    """Worker without group name warns."""
+    manifest = yaml.safe_load(_INLINE_MANIFEST)
+    manifest["spec"]["rayClusterSpec"]["workerGroupSpecs"] = [{"replicas": 2}]
+    result = rayjob.convert(manifest)
+    (worker,) = _docs(result)[0]["spec"]["workers"]
+    assert "nodeType" not in worker
+    assert any("no groupName" in w for w in result.warnings)
+
+
+def test_wrong_kind_raises():
+    """Wrong kind raises."""
+    with pytest.raises(rayjob.ManifestError, match="unsupported kind 'RayService'"):
+        rayjob.convert({"kind": "RayService"})
+
+
+def test_non_ray_api_group_warns():
+    """Non ray api group warns."""
+    manifest = yaml.safe_load(_SELECTOR_MANIFEST)
+    manifest["apiVersion"] = "example.com/v1"
+    result = rayjob.convert(manifest)
+    assert any("is not from ray.io" in w for w in result.warnings)
+
+
+def test_invalid_yaml_raises():
+    """Invalid yaml raises."""
+    with pytest.raises(rayjob.ManifestError, match="not valid YAML"):
+        rayjob.convert_text("kind: [broken")
+
+
+def test_non_mapping_input_raises():
+    """Non mapping input raises."""
+    with pytest.raises(rayjob.ManifestError, match="expected a YAML mapping"):
+        rayjob.convert_text("- a list")
+
+
+def test_no_cluster_at_all_raises():
+    """No cluster at all raises."""
+    with pytest.raises(rayjob.ManifestError, match="neither clusterSelector"):
+        rayjob.convert({"kind": "RayJob", "spec": {"entrypoint": "python x.py"}})
+
+
+def test_selector_wins_over_inline_spec():
+    """Selector wins over inline spec."""
+    manifest = yaml.safe_load(_SELECTOR_MANIFEST)
+    manifest["spec"]["rayClusterSpec"] = {"rayVersion": "2.9.0"}
+    result = rayjob.convert(manifest)
+    docs = _docs(result)
+    assert len(docs) == 1  # no RayCluster emitted
+    assert docs[0]["spec"]["cluster"]["name"] == "shared-cluster"
+    assert any("clusterSelector wins" in w for w in result.warnings)
+
+
+def test_selector_without_canonical_label():
+    """Selector without canonical label."""
+    manifest = yaml.safe_load(_SELECTOR_MANIFEST)
+    manifest["spec"]["clusterSelector"] = {"env": "prod"}
+    result = rayjob.convert(manifest)
+    job = _docs(result)[0]
+    assert job["spec"]["cluster"]["name"].startswith("TODO")
+    assert any("no 'ray.io/cluster' label" in w for w in result.warnings)
+    assert any("labels ['env']" in w for w in result.warnings)
+
+
+def test_selector_extra_labels_warn():
+    """Selector extra labels warn."""
+    manifest = yaml.safe_load(_SELECTOR_MANIFEST)
+    manifest["spec"]["clusterSelector"]["team"] = "ml"
+    result = rayjob.convert(manifest)
+    job = _docs(result)[0]
+    assert job["spec"]["cluster"]["name"] == "shared-cluster"
+    assert any("labels ['team']" in w for w in result.warnings)
+
+
+def test_missing_entrypoint_leaves_todo():
+    """Missing entrypoint leaves todo."""
+    manifest = yaml.safe_load(_SELECTOR_MANIFEST)
+    del manifest["spec"]["entrypoint"]
+    result = rayjob.convert(manifest)
+    job = _docs(result)[0]
+    assert job["spec"]["entrypoint"].startswith("TODO")
+    assert any("entrypoint is missing" in w for w in result.warnings)
+
+
+def test_unmapped_spec_fields_warn():
+    """Unmapped spec fields warn."""
+    manifest = yaml.safe_load(_SELECTOR_MANIFEST)
+    manifest["spec"]["shutdownAfterJobFinishes"] = True
+    manifest["spec"]["ttlSecondsAfterFinished"] = 60
+    manifest["spec"]["runtimeEnvYAML"] = "pip: [torch]"
+    result = rayjob.convert(manifest)
+    for field in (
+        "shutdownAfterJobFinishes",
+        "ttlSecondsAfterFinished",
+        "runtimeEnvYAML",
+    ):
+        assert any(f"spec.{field} has no v2 equivalent" in w for w in result.warnings)
+
+
+def test_unmapped_cluster_head_and_worker_fields_warn():
+    """Unmapped cluster head and worker fields warn."""
+    manifest = yaml.safe_load(_INLINE_MANIFEST)
+    cluster = manifest["spec"]["rayClusterSpec"]
+    cluster["enableInTreeAutoscaling"] = True
+    cluster["headGroupSpec"]["enableIngress"] = True
+    cluster["workerGroupSpecs"][0]["numOfHosts"] = 2
+    result = rayjob.convert(manifest)
+    assert any(
+        "spec.rayClusterSpec.enableInTreeAutoscaling" in w for w in result.warnings
+    )
+    assert any("headGroupSpec.enableIngress" in w for w in result.warnings)
+    assert any("workerGroupSpecs[0].numOfHosts" in w for w in result.warnings)
+
+
+def test_missing_head_group_warns():
+    """Missing head group warns."""
+    manifest = yaml.safe_load(_INLINE_MANIFEST)
+    del manifest["spec"]["rayClusterSpec"]["headGroupSpec"]
+    result = rayjob.convert(manifest)
+    cluster = _docs(result)[0]
+    assert "head" not in cluster["spec"]
+    assert any("no headGroupSpec" in w for w in result.warnings)
+
+
+def test_minimal_inline_cluster():
+    """Minimal inline cluster."""
+    result = rayjob.convert(
+        {
+            "apiVersion": "ray.io/v1",
+            "kind": "RayJob",
+            "spec": {"rayClusterSpec": {"headGroupSpec": {}}},
+        }
+    )
+    cluster, job = _docs(result)
+    assert cluster["metadata"] == {"name": "imported-ray-job"}
+    assert "rayVersion" not in cluster["spec"]
+    assert cluster["spec"]["head"] == {}
+    assert "workers" not in cluster["spec"]
+    assert job["spec"]["cluster"] == {"name": "imported-ray-job"}
+
+
+def test_namespace_flows_to_cluster_and_reference():
+    """Namespace flows to cluster and reference."""
+    manifest = yaml.safe_load(_INLINE_MANIFEST)
+    manifest["metadata"]["namespace"] = "ml-team"
+    result = rayjob.convert(manifest)
+    cluster, job = _docs(result)
+    assert cluster["metadata"]["namespace"] == "ml-team"
+    assert job["metadata"]["namespace"] == "ml-team"
+    assert job["spec"]["cluster"] == {"name": "train-job", "namespace": "ml-team"}
+
+
+def test_labels_and_annotations_pass_through():
+    """Labels and annotations pass through."""
+    manifest = yaml.safe_load(_SELECTOR_MANIFEST)
+    manifest["metadata"]["labels"] = {"app": "demo"}
+    manifest["metadata"]["annotations"] = {"note": "hi"}
+    result = rayjob.convert(manifest)
+    job = _docs(result)[0]
+    assert job["metadata"]["labels"] == {"app": "demo"}
+    assert job["metadata"]["annotations"] == {"note": "hi"}

--- a/python/michelangelo/cli/importer/scaffold.py
+++ b/python/michelangelo/cli/importer/scaffold.py
@@ -1,0 +1,111 @@
+"""Shared pipeline-scaffold generation for training-job converters."""
+
+import math
+
+
+def cpu_count(quantity):
+    """Round a Kubernetes CPU quantity ("500m", "2", 2.5) up to whole CPUs."""
+    if quantity is None:
+        return None
+    text = str(quantity)
+    if text.endswith("m"):
+        return math.ceil(int(text[:-1]) / 1000)
+    return math.ceil(float(text))
+
+
+def gpu_count(quantity):
+    """Parse a Kubernetes GPU quantity into an int."""
+    if quantity is None:
+        return None
+    return int(str(quantity))
+
+
+def resources_from(requirements):
+    """Extract (cpu, memory, gpu) from a ResourceRequirements dict.
+
+    Requests are preferred over limits for cpu and memory; gpus are usually
+    only set as limits, so limits are preferred there.
+    """
+    requirements = requirements or {}
+    requests = requirements.get("requests") or {}
+    limits = requirements.get("limits") or {}
+    cpu = cpu_count(requests.get("cpu", limits.get("cpu")))
+    memory = requests.get("memory", limits.get("memory"))
+    gpu = gpu_count(limits.get("nvidia.com/gpu", requests.get("nvidia.com/gpu")))
+    return cpu, memory, gpu
+
+
+def quote(value):
+    """Render a value as a Python string literal, passing None through."""
+    return None if value is None else repr(str(value))
+
+
+def ray_task_lines(fields):
+    """Render RayTask keyword lines, dropping unset fields."""
+    lines = [f"        {key}={value}," for key, value in fields if value is not None]
+    if len(lines) == 1:
+        lines.insert(0, "        # TODO: size the cluster for your workload.")
+    return "\n".join(lines)
+
+
+def entrypoint_comment(container, source_kind):
+    """Describe the container entrypoint the user must port into the task body."""
+    lines = [
+        f"    # TODO: port the training code from your {source_kind} image"
+        " into this task."
+    ]
+    if container:
+        if container.get("image"):
+            lines.append(f"    #   image:   {container['image']}")
+        command = list(container.get("command") or []) + list(
+            container.get("args") or []
+        )
+        if command:
+            lines.append(f"    #   command: {' '.join(str(part) for part in command)}")
+    return "\n".join(lines)
+
+
+TEMPLATE = '''"""Pipeline scaffold generated from {source_kind} {source_name!r}.
+
+Review every TODO before running: the converter maps cluster sizing, not
+training code. See docs/user-guides/migration/migrate-from-kubeflow-trainer.md
+for the full field mapping.
+"""
+
+import michelangelo.uniflow.core as uniflow
+import ray.train
+from michelangelo.lib.trainer.torch.pytorch_lightning import (
+    LightningTrainer,
+    LightningTrainerParam,
+)
+from michelangelo.uniflow.plugins.ray import RayTask
+
+
+@uniflow.task(
+    config=RayTask(
+{ray_task_fields}
+    )
+)
+def train(data_path: str):
+{entrypoint}
+    trainer = LightningTrainer(
+        trainer_param=LightningTrainerParam(
+            create_model_fn=create_model,  # TODO: your LightningModule factory
+            create_model_fn_kwargs={{}},
+            train_data=load_train(data_path),  # TODO: training Ray Dataset
+            val_data=load_val(data_path),  # TODO: validation Ray Dataset
+            batch_size=256,  # TODO: per-worker batch size
+        ),
+        run_config=ray.train.RunConfig(name={run_name!r}),
+        scaling_config=ray.train.ScalingConfig(
+            num_workers={num_workers},
+            use_gpu={use_gpu},
+        ),
+    )
+    return trainer.train()
+
+
+@uniflow.workflow()
+def training_pipeline(data_path: str):
+    return train(data_path)
+'''

--- a/python/michelangelo/cli/importer/scaffold_test.py
+++ b/python/michelangelo/cli/importer/scaffold_test.py
@@ -1,0 +1,21 @@
+"""Tests for the shared scaffold helpers."""
+
+import pytest
+
+from michelangelo.cli.importer import scaffold
+
+
+@pytest.mark.parametrize(
+    ("quantity", "expected"),
+    [(None, None), ("500m", 1), ("1500m", 2), ("2", 2), (2, 2), ("2.5", 3), (0.1, 1)],
+)
+def test_cpu_quantities_round_up(quantity, expected):
+    """Cpu quantities round up."""
+    assert scaffold.cpu_count(quantity) == expected
+
+
+def test_gpu_quantities():
+    """Gpu quantities."""
+    assert scaffold.gpu_count(None) is None
+    assert scaffold.gpu_count("2") == 2
+    assert scaffold.gpu_count(1) == 1

--- a/python/michelangelo/cli/importer/trainjob.py
+++ b/python/michelangelo/cli/importer/trainjob.py
@@ -1,0 +1,116 @@
+"""Convert a Kubeflow Trainer v2 TrainJob manifest into a Uniflow pipeline scaffold.
+
+TrainJob is Kubeflow Trainer v2's replacement for the framework-specific v1
+CRDs. Its nodes are homogeneous (no Master/Worker split), so the scaffold
+sizes the Ray head and workers identically from ``trainer.resourcesPerNode``
+and maps ``trainer.numNodes`` onto the worker count. Runtime plumbing with no
+pipeline equivalent (dataset and model initializers, pod overrides, non-torch
+runtimes) is surfaced as warnings and TODO comments rather than silently
+dropped.
+"""
+
+import yaml
+
+from michelangelo.cli.importer import scaffold
+from michelangelo.cli.importer.base import ConversionResult, ManifestError
+
+_KIND = "TrainJob"
+_API_GROUP = "trainer.kubeflow.org"
+
+# Keys the converter maps. Anything else in the corresponding block is
+# reported as a warning so nothing is silently dropped.
+_HANDLED_SPEC_FIELDS = frozenset({"trainer", "runtimeRef"})
+_HANDLED_TRAINER_FIELDS = frozenset(
+    {"image", "command", "args", "numNodes", "resourcesPerNode"}
+)
+
+
+def convert_text(text: str) -> ConversionResult:
+    """Parse a YAML manifest and convert it. See :func:`convert`."""
+    try:
+        manifest = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise ManifestError(f"input is not valid YAML: {exc}") from exc
+    if not isinstance(manifest, dict):
+        raise ManifestError(
+            "input is not a Kubernetes manifest (expected a YAML mapping)"
+        )
+    return convert(manifest)
+
+
+def convert(manifest: dict) -> ConversionResult:
+    """Convert a TrainJob manifest dict into a pipeline scaffold.
+
+    Raises :class:`ManifestError` when the manifest is not a TrainJob. A
+    missing ``spec.trainer`` block is not an error: the runtime supplies
+    defaults in Kubeflow, so the scaffold is emitted unsized with a warning.
+    """
+    warnings = []
+
+    kind = manifest.get("kind")
+    if kind != _KIND:
+        raise ManifestError(
+            f"unsupported kind {kind!r}: this converter handles {_KIND} manifests"
+        )
+    api_version = str(manifest.get("apiVersion") or "")
+    if not api_version.startswith(_API_GROUP):
+        warnings.append(
+            f"apiVersion {api_version!r} is not from {_API_GROUP}; converting anyway"
+        )
+
+    name = (manifest.get("metadata") or {}).get("name") or "imported-train-job"
+    spec = manifest.get("spec") or {}
+
+    _warn_unhandled(spec, _HANDLED_SPEC_FIELDS, "spec", warnings)
+
+    runtime_name = (spec.get("runtimeRef") or {}).get("name") or ""
+    if not runtime_name:
+        warnings.append("spec.runtimeRef names no runtime; assuming a torch runtime")
+    elif "torch" not in runtime_name:
+        warnings.append(
+            f"runtimeRef {runtime_name!r} is not a torch runtime; the scaffold"
+            " uses LightningTrainer, which is PyTorch-only"
+        )
+
+    trainer = spec.get("trainer")
+    if trainer is None:
+        trainer = {}
+        warnings.append(
+            "no spec.trainer block: the runtime's defaults apply in Kubeflow;"
+            " size the RayTask in the scaffold by hand"
+        )
+    else:
+        _warn_unhandled(trainer, _HANDLED_TRAINER_FIELDS, "spec.trainer", warnings)
+
+    num_nodes = int(trainer.get("numNodes") or 1)
+    cpu, memory, gpu = scaffold.resources_from(trainer.get("resourcesPerNode"))
+
+    # TrainJob nodes are homogeneous, so head and workers get the same shape.
+    ray_task_fields = [
+        ("head_cpu", cpu),
+        ("head_memory", scaffold.quote(memory)),
+        ("head_gpu", gpu or None),
+        ("worker_cpu", cpu),
+        ("worker_memory", scaffold.quote(memory)),
+        ("worker_gpu", gpu or None),
+        ("worker_instances", num_nodes),
+    ]
+
+    text = scaffold.TEMPLATE.format(
+        source_kind=_KIND,
+        source_name=name,
+        ray_task_fields=scaffold.ray_task_lines(ray_task_fields),
+        entrypoint=scaffold.entrypoint_comment(trainer, _KIND),
+        run_name=name,
+        num_workers=num_nodes,
+        use_gpu=bool(gpu),
+    )
+    return ConversionResult(scaffold=text, warnings=warnings)
+
+
+def _warn_unhandled(mapping, handled, label, warnings):
+    """Warn once per key in ``mapping`` that the converter does not map."""
+    for key in sorted(key for key in (mapping or {}) if key not in handled):
+        warnings.append(
+            f"{label}.{key} has no pipeline equivalent and was not converted"
+        )

--- a/python/michelangelo/cli/importer/trainjob_test.py
+++ b/python/michelangelo/cli/importer/trainjob_test.py
@@ -1,0 +1,152 @@
+"""Tests for the TrainJob-to-pipeline converter."""
+
+import pytest
+import yaml
+
+from michelangelo.cli.importer import trainjob
+
+_FULL_MANIFEST = """
+apiVersion: trainer.kubeflow.org/v1alpha1
+kind: TrainJob
+metadata:
+  name: llm-finetune
+spec:
+  runtimeRef:
+    name: torch-distributed
+  trainer:
+    image: my-training-image:latest
+    command: ["torchrun"]
+    args: ["train.py", "--epochs", "3"]
+    numNodes: 4
+    resourcesPerNode:
+      requests:
+        cpu: 2500m
+        memory: 16Gi
+      limits:
+        nvidia.com/gpu: 1
+"""
+
+
+def test_full_manifest_maps_resources_and_scaling():
+    """Full manifest maps resources and scaling."""
+    result = trainjob.convert_text(_FULL_MANIFEST)
+    text = result.scaffold
+    # Head and workers are sized identically: TrainJob nodes are homogeneous.
+    assert "head_cpu=3," in text  # 2500m rounds up to whole CPUs
+    assert "head_memory='16Gi'," in text
+    assert "head_gpu=1," in text
+    assert "worker_cpu=3," in text
+    assert "worker_memory='16Gi'," in text
+    assert "worker_gpu=1," in text
+    assert "worker_instances=4," in text
+    assert "num_workers=4," in text
+    assert "use_gpu=True," in text
+    assert "name='llm-finetune'" in text
+    assert "generated from TrainJob 'llm-finetune'" in text
+    # Entrypoint surfaced as TODO comments, with args appended to command.
+    assert "image:   my-training-image:latest" in text
+    assert "command: torchrun train.py --epochs 3" in text
+    assert result.warnings == []
+
+
+def test_defaults_without_trainer_block():
+    """Defaults without trainer block."""
+    result = trainjob.convert(
+        {
+            "apiVersion": "trainer.kubeflow.org/v1alpha1",
+            "kind": "TrainJob",
+            "spec": {"runtimeRef": {"name": "torch-distributed"}},
+        }
+    )
+    text = result.scaffold
+    assert "name='imported-train-job'" in text
+    assert "worker_instances=1," in text
+    assert "num_workers=1," in text
+    assert "use_gpu=False," in text
+    assert "# TODO: size the cluster for your workload." in text
+    assert any("no spec.trainer block" in w for w in result.warnings)
+
+
+def test_non_torch_runtime_warns():
+    """Non torch runtime warns."""
+    manifest = yaml.safe_load(_FULL_MANIFEST)
+    manifest["spec"]["runtimeRef"]["name"] = "deepspeed-distributed"
+    result = trainjob.convert(manifest)
+    assert any("not a torch runtime" in w for w in result.warnings)
+
+
+def test_missing_runtime_ref_warns():
+    """Missing runtime ref warns."""
+    manifest = yaml.safe_load(_FULL_MANIFEST)
+    del manifest["spec"]["runtimeRef"]
+    result = trainjob.convert(manifest)
+    assert any("names no runtime" in w for w in result.warnings)
+
+
+def test_unmapped_spec_fields_warn():
+    """Unmapped spec fields warn."""
+    manifest = yaml.safe_load(_FULL_MANIFEST)
+    manifest["spec"]["datasetConfig"] = {"storageUri": "s3://data"}
+    manifest["spec"]["podSpecOverrides"] = []
+    manifest["spec"]["suspend"] = False
+    result = trainjob.convert(manifest)
+    for field in ("datasetConfig", "podSpecOverrides", "suspend"):
+        assert any(
+            f"spec.{field} has no pipeline equivalent" in w for w in result.warnings
+        )
+
+
+def test_unmapped_trainer_fields_warn():
+    """Unmapped trainer fields warn."""
+    manifest = yaml.safe_load(_FULL_MANIFEST)
+    manifest["spec"]["trainer"]["env"] = [{"name": "X", "value": "1"}]
+    manifest["spec"]["trainer"]["numProcPerNode"] = "auto"
+    result = trainjob.convert(manifest)
+    assert any("spec.trainer.env has no pipeline" in w for w in result.warnings)
+    assert any(
+        "spec.trainer.numProcPerNode has no pipeline" in w for w in result.warnings
+    )
+
+
+def test_limits_fallback_for_cpu_and_memory():
+    """Limits fallback for cpu and memory."""
+    manifest = yaml.safe_load(_FULL_MANIFEST)
+    manifest["spec"]["trainer"]["resourcesPerNode"] = {
+        "limits": {"cpu": "8", "memory": "32Gi"}
+    }
+    result = trainjob.convert(manifest)
+    assert "worker_cpu=8," in result.scaffold
+    assert "worker_memory='32Gi'," in result.scaffold
+    assert "use_gpu=False," in result.scaffold
+
+
+def test_wrong_kind_raises():
+    """Wrong kind raises."""
+    with pytest.raises(trainjob.ManifestError, match="unsupported kind 'TFJob'"):
+        trainjob.convert({"kind": "TFJob"})
+
+
+def test_non_trainer_api_group_warns():
+    """Non trainer api group warns."""
+    manifest = yaml.safe_load(_FULL_MANIFEST)
+    manifest["apiVersion"] = "example.com/v1"
+    result = trainjob.convert(manifest)
+    assert any("is not from trainer.kubeflow.org" in w for w in result.warnings)
+
+
+def test_invalid_yaml_raises():
+    """Invalid yaml raises."""
+    with pytest.raises(trainjob.ManifestError, match="not valid YAML"):
+        trainjob.convert_text("kind: [broken")
+
+
+def test_non_mapping_input_raises():
+    """Non mapping input raises."""
+    with pytest.raises(trainjob.ManifestError, match="expected a YAML mapping"):
+        trainjob.convert_text("- a list")
+
+
+def test_scaffold_is_valid_python():
+    """Scaffold is valid python."""
+    result = trainjob.convert_text(_FULL_MANIFEST)
+    compile(result.scaffold, "<scaffold>", "exec")


### PR DESCRIPTION
> **Stacked on #1875.** This adds a third kind to the `ma import` converter registry, so the branch is based on that PR's branch. Only the last commit (`cli: add Kubeflow Trainer v2 TrainJob converter to ma import`) is new -- [this compare view](https://github.com/apurvapatkeshwar/michelangelo/compare/feat/ma-import-rayjob...feat/ma-import-trainjob) shows just this PR's diff. Once the parents merge I will rebase and the diff here collapses to the same thing.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

`ma import` now converts Kubeflow Trainer v2 `TrainJob` manifests into Uniflow pipeline scaffolds, the same destination the PyTorchJob converter targets (Michelangelo has no training-job CRD, so both v1 and v2 Kubeflow jobs map to a pipeline task sized by `RayTask`):

- TrainJob nodes are homogeneous -- there is no Master/Worker split -- so the scaffold sizes the Ray head and workers identically from `trainer.resourcesPerNode` and maps `trainer.numNodes` onto `worker_instances`/`num_workers`.
- `trainer.image`/`command`/`args` are surfaced as TODO comments at the top of the generated task, same as the PyTorchJob converter.
- `runtimeRef` is checked: a non-torch runtime (DeepSpeed, MPI, ...) produces a warning that the scaffold uses `LightningTrainer`, which is PyTorch-only. A missing `spec.trainer` block is not an error (the runtime supplies defaults in Kubeflow); the scaffold is emitted unsized with a warning.
- Everything else (`datasetConfig`, `modelConfig`, `podSpecOverrides`, `numProcPerNode`, `suspend`, ...) is warned about, never silently dropped.

The scaffold template and Kubernetes quantity parsers move from the PyTorchJob converter into a shared `scaffold.py`, so the two scaffold-producing converters render through one template parameterized by source kind.

**Why?**

Kubeflow Trainer v2 made `TrainJob` the canonical job resource, and the Kubeflow Trainer migration guide covers it alongside the v1 CRDs. Teams on the v2 API should get the same mechanized starting point as teams on PyTorchJob, rather than a "supported: PyTorchJob" error from the importer.

**How did you test it?**

- 12 new TrainJob tests (resource and scaling mapping, homogeneous head/worker sizing, missing-trainer defaults, non-torch and missing runtimeRef warnings, unmapped-field warnings at spec and trainer level, error paths, and a `compile()` check that the generated scaffold is valid Python) plus a CLI dispatch test. The quantity-parser tests moved with the helpers into `scaffold_test.py`.
- 100% line and branch coverage on every module in the importer package (63 tests).
- End-to-end smoke through the CLI: a realistic multi-node GPU fine-tune TrainJob converts to a correctly sized scaffold with the expected warnings and exit code 0.
- Full `michelangelo/cli` suite passes; `ruff format` + `ruff check` clean.

**Potential risks**

- Pure addition plus an internal refactor: the PyTorchJob converter's output is byte-identical -- the PyTorchJob tests that assert on generated content are unchanged and pass against the shared template (only the quantity-parser tests moved along with their helpers).
- The scaffold is a starting point by design: anything the converter cannot know is a TODO or a warning.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

`ma import` now converts Kubeflow Trainer v2 TrainJob manifests into pipeline scaffolds, alongside the existing PyTorchJob and KubeRay RayJob support.

**Documentation Changes**

None in this PR; the Kubeflow Trainer migration guide already frames TrainJob alongside the v1 CRDs, and a follow-up will point it at `ma import` once both land.
