### PR TITLE
chore: bump version to 0.9.0-rc.1

### DIFF
--- a/helm/michelangelo/Chart.yaml
+++ b/helm/michelangelo/Chart.yaml
@@ -7,8 +7,8 @@ description: |
   and RBAC — into any Kubernetes cluster. Bring your own metadata storage,
   object storage, and workflow engine (Cadence or Temporal).
 type: application
-version: 0.8.0
-appVersion: "0.8.0"
+version: 0.9.0-rc.1
+appVersion: "0.9.0-rc.1"
 kubeVersion: ">=1.27.0-0"
 
 dependencies:

--- a/javascript/app/package.json
+++ b/javascript/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@michelangelo/app",
   "license": "Apache-2.0",
-  "version": "0.8.0",
+  "version": "0.9.0-rc.1",
   "private": true,
   "scripts": {
     "build": "vite build --config vite.config.ts",
@@ -12,11 +12,11 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
-    "@michelangelo-ai/rpc": "0.8.0",
+    "@michelangelo-ai/rpc": "0.9.0-rc.1",
     "@mui/icons-material": "^7.1.0",
     "@mui/material": "^7.1.0",
     "@tanstack/react-query": "5.39.0",
-    "@michelangelo-ai/core": "0.8.0",
+    "@michelangelo-ai/core": "0.9.0-rc.1",
     "baseui": "15.0.0",
     "react-router-dom": "5.3.4",
     "react-router-dom-v5-compat": "6.29.0",

--- a/javascript/packages/core/package.json
+++ b/javascript/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@michelangelo-ai/core",
   "license": "Apache-2.0",
-  "version": "0.8.0",
+  "version": "0.9.0-rc.1",
   "type": "module",
   "main": "./dist/michelangelo-core.js",
   "module": "./dist/michelangelo-core.js",

--- a/javascript/packages/rpc/package.json
+++ b/javascript/packages/rpc/package.json
@@ -2,7 +2,7 @@
   "name": "@michelangelo-ai/rpc",
   "license": "Apache-2.0",
   "type": "module",
-  "version": "0.8.0",
+  "version": "0.9.0-rc.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/michelangelo-ai/michelangelo"
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.2.5",
-    "@michelangelo-ai/core": "0.8.0"
+    "@michelangelo-ai/core": "0.9.0-rc.1"
   },
   "exports": {
     ".": {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "michelangelo"
-version = "0.8.0"
+version = "0.9.0-rc.1"
 description = "Michelangelo AI is an end-to-end model lifecycle management system at large scale"
 authors = ["Michelangelo AI Team <michelangelo-oss-group@uber.com>"]
 readme = "README.md"

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "website",
-  "version": "0.8.0",
+  "version": "0.9.0-rc.1",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",


### PR DESCRIPTION
## Summary
- Manual recovery for `release-cut.yml`'s known REL-006 regression (`michelangelo#1661`) — its "Bump versions to RC" step can't push directly to the newly-created `release/v0.9` branch (org ruleset requires a PR for every push, including from `github-actions[bot]`).
- Bumps all component versions to `0.9.0-rc.1`, now including `website/package.json` (fixed by #1849, confirmed picked up correctly here).

## Test plan
- [ ] CI green
- [ ] Merge, tag `v0.9.0-rc.1`, dispatch artifact-publish workflows
- [ ] Open tracking issue + draft merge-back PR