### PR TITLE
fix(helm): grant EndpointSlice RBAC to controllermgr ServiceAccount

### DIFF
--- a/helm/michelangelo/templates/rbac/clusterrole.yaml
+++ b/helm/michelangelo/templates/rbac/clusterrole.yaml
@@ -73,6 +73,12 @@ rules:
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["httproutes"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # InferenceServer controller's EndpointPublish step manages EndpointSlices
+  # directly for serving traffic
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 {{- else if and .Values.serviceAccount.create .Values.controllermgr.watchNamespace }}
 {{- range $ns := .Values.controllermgr.watchNamespace }}
 ---
@@ -142,6 +148,9 @@ rules:
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["httproutes"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 {{- end }}
 {{- end }}

--- a/helm/michelangelo/templates/rbac/clusterrole.yaml
+++ b/helm/michelangelo/templates/rbac/clusterrole.yaml
@@ -74,8 +74,7 @@ rules:
     resources: ["httproutes"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
-  # InferenceServer controller's EndpointPublish step manages EndpointSlices
-  # directly for serving traffic
+  # InferenceServer's EndpointPublish step manages EndpointSlices for serving traffic
   - apiGroups: ["discovery.k8s.io"]
     resources: ["endpointslices"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]


### PR DESCRIPTION
## Summary

The InferenceServer controller's EndpointPublish step manages EndpointSlices directly for serving traffic, but neither the cluster-wide `ClusterRole` nor the per-namespace `Role` in the Helm chart grants any permissions on `endpointslices.discovery.k8s.io`. As a result, the controller's EndpointSlice writes fail with a Kubernetes "forbidden" error and InferenceServer CRs never reach `SERVING`.

This adds the same CRUD verb set already used for the neighboring `httproutes` rule, to both RBAC blocks.

## Test plan

- `helm template helm/michelangelo` renders successfully with the new rule present in the cluster-wide `ClusterRole`.
- `helm template helm/michelangelo --set 'controllermgr.watchNamespace={ma-examples}'` renders successfully with the new rule present in the per-namespace `Role`.
- Verified against a live sandbox cluster: InferenceServer CRs now reach `SERVING` instead of failing on EndpointSlice writes.

Closes #1250