### PR TITLE
fix(helm): add inferenceServer.gateway defaults to controllermgr configmap

### DIFF
--- a/helm/michelangelo/templates/core/controllermgr-configmap.yaml
+++ b/helm/michelangelo/templates/core/controllermgr-configmap.yaml
@@ -91,6 +91,14 @@ data:
             {{- end }}
     {{- end }}
 
+    {{- $gateway := dig "inferenceServer" "gateway" dict .Values.controllermgr }}
+    inferenceServer:
+      gateway:
+        name: {{ $gateway.name | default "ma-gateway" | quote }}
+        serviceName: {{ $gateway.serviceName | default "ma-gateway-istio" | quote }}
+        serviceNamespace: {{ $gateway.serviceNamespace | default "default" | quote }}
+        portName: {{ $gateway.portName | default "http" | quote }}
+
     notification:
       {{- $notif := default dict .Values.notification }}
       taskList: {{ index $notif "taskList" | default "" | quote }}

--- a/helm/michelangelo/values.yaml
+++ b/helm/michelangelo/values.yaml
@@ -402,7 +402,6 @@ controllermgr:
   # Gateway API config read by InferenceServer's EndpointPublish step to publish per-cluster EndpointSlices.
   inferenceServer:
     gateway:
-      # Name of the k8s Gateway resource that HTTPRoutes attach to via parentRefs.
       name: ma-gateway
 
       # Istio's Gateway controller names the resulting Service '<gateway>-istio'.

--- a/helm/michelangelo/values.yaml
+++ b/helm/michelangelo/values.yaml
@@ -399,17 +399,19 @@ controllermgr:
     # revision store (see revision.Manager).
     revisioningEnabled: false
 
-  # Inference serving Gateway API details. The InferenceServer controller's
-  # EndpointPublish step reads the Istio-materialized Service for this Gateway
-  # (named '<gateway>-istio') to publish per-cluster EndpointSlices.
+  # Gateway API details for inference serving. The InferenceServer
+  # controller's EndpointPublish step reads the Istio-materialized Service
+  # for this Gateway (named '<gateway>-istio') to publish per-cluster
+  # EndpointSlices.
   inferenceServer:
     gateway:
       # Name of the k8s Gateway resource that HTTPRoutes attach to via parentRefs.
       name: ma-gateway
 
-      # Istio's Gateway controller materializes a Service named '<gateway>-istio'
-      # for each Gateway resource; the IS controller reads its NodePort + node
-      # InternalIP to publish per-cluster EndpointSlices in the control plane.
+      # Istio's Gateway controller materializes a Service named
+      # '<gateway>-istio' for each Gateway resource; the IS controller reads
+      # its NodePort + node InternalIP to publish per-cluster EndpointSlices
+      # in the control plane.
       serviceName: ma-gateway-istio
       serviceNamespace: default
       portName: http

--- a/helm/michelangelo/values.yaml
+++ b/helm/michelangelo/values.yaml
@@ -399,6 +399,21 @@ controllermgr:
     # revision store (see revision.Manager).
     revisioningEnabled: false
 
+  # Inference serving Gateway API details. The InferenceServer controller's
+  # EndpointPublish step reads the Istio-materialized Service for this Gateway
+  # (named '<gateway>-istio') to publish per-cluster EndpointSlices.
+  inferenceServer:
+    gateway:
+      # Name of the k8s Gateway resource that HTTPRoutes attach to via parentRefs.
+      name: ma-gateway
+
+      # Istio's Gateway controller materializes a Service named '<gateway>-istio'
+      # for each Gateway resource; the IS controller reads its NodePort + node
+      # InternalIP to publish per-cluster EndpointSlices in the control plane.
+      serviceName: ma-gateway-istio
+      serviceNamespace: default
+      portName: http
+
   # Workflow client extras (controllermgr-only).
   workflowClient:
     # Cadence Web URL template. Empty by default; set in values-k3d.yaml for

--- a/helm/michelangelo/values.yaml
+++ b/helm/michelangelo/values.yaml
@@ -399,19 +399,13 @@ controllermgr:
     # revision store (see revision.Manager).
     revisioningEnabled: false
 
-  # Gateway API details for inference serving. The InferenceServer
-  # controller's EndpointPublish step reads the Istio-materialized Service
-  # for this Gateway (named '<gateway>-istio') to publish per-cluster
-  # EndpointSlices.
+  # Gateway API config read by InferenceServer's EndpointPublish step to publish per-cluster EndpointSlices.
   inferenceServer:
     gateway:
       # Name of the k8s Gateway resource that HTTPRoutes attach to via parentRefs.
       name: ma-gateway
 
-      # Istio's Gateway controller materializes a Service named
-      # '<gateway>-istio' for each Gateway resource; the IS controller reads
-      # its NodePort + node InternalIP to publish per-cluster EndpointSlices
-      # in the control plane.
+      # Istio's Gateway controller names the resulting Service '<gateway>-istio'.
       serviceName: ma-gateway-istio
       serviceNamespace: default
       portName: http


### PR DESCRIPTION
## Summary

`base.yaml`'s `inferenceServer` config was never rendered into the chart's `controllermgr-configmap.yaml` template. On a fresh install this leaves `inferenceServer.gateway` at its zero value, and controllermgr fails resolving the inference Gateway's Service with a "resource name may not be empty" error.

This adds an `inferenceServer.gateway` block to the configmap template, with defaults sourced from new `controllermgr.inferenceServer.gateway.*` keys in `values.yaml` (`ma-gateway` / `ma-gateway-istio` / `default` / `http`).

The lookup uses `dig "inferenceServer" "gateway" dict .Values.controllermgr` rather than direct field access (matching the existing `dig "pipeline" ...` pattern one block above in the same file). This matters because `ma sandbox sync`-style upgrades run `helm upgrade --reuse-values`, which reuses a prior release's already-computed values as the base and does not re-merge `values.yaml` defaults for keys that didn't exist when that release was last deployed — direct field access nil-pointer-panics in that case, while `dig` falls through to the `default` filter cleanly.

## Test plan

- `helm template helm/michelangelo` renders the new `inferenceServer.gateway` block with default values.
- `helm template helm/michelangelo --set 'controllermgr.inferenceServer=null'` renders identically, confirming the `dig` fallback path works when the key is entirely absent (the `--reuse-values` scenario above).
- Verified against a live sandbox cluster: controllermgr now resolves the gateway Service correctly on both fresh install and `helm upgrade --reuse-values`.

Closes #1251