### PR TITLE
fix(sandbox): register Cadence domain in ma sandbox sync

### DIFF
--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -434,15 +434,7 @@ def _sync(ns: argparse.Namespace):
     try:
         _helm_wait(ns)
     finally:
-        # _create() registers the Cadence domain after cluster setup, but
-        # _sync() skipped it entirely — leaving the domain absent when sync
-        # is used as the recovery path for a failed create, and every
-        # PipelineRun fails immediately with
-        # EntityNotExistsError{Domain default does not exist}.
-        # Run this in a finally block (not just after _helm_wait()) so it
-        # still happens even if _helm_wait() itself times out waiting on
-        # pods. _create_cadence_domain() treats "domain already exists" as
-        # success, so calling it here on a healthy sync is a safe no-op.
+        # Register the Cadence domain here too, even if _helm_wait() times out.
         if ns.workflow == "cadence":
             _create_cadence_domain([])
 

--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -431,7 +431,20 @@ def _sync(ns: argparse.Namespace):
             *helm_args,
         )
 
-    _helm_wait(ns)
+    try:
+        _helm_wait(ns)
+    finally:
+        # _create() registers the Cadence domain after cluster setup, but
+        # _sync() skipped it entirely — leaving the domain absent when sync
+        # is used as the recovery path for a failed create, and every
+        # PipelineRun fails immediately with
+        # EntityNotExistsError{Domain default does not exist}.
+        # Run this in a finally block (not just after _helm_wait()) so it
+        # still happens even if _helm_wait() itself times out waiting on
+        # pods. _create_cadence_domain() treats "domain already exists" as
+        # success, so calling it here on a healthy sync is a safe no-op.
+        if ns.workflow == "cadence":
+            _create_cadence_domain([])
 
 
 def _refresh_mysql_schema():


### PR DESCRIPTION
## Summary

`_create()` registers the Cadence domain after cluster setup, but `_sync()` — documented as the recovery path when `_create()` fails partway — never called `_create_cadence_domain()` at all. Any sandbox recovered via `ma sandbox sync` after a partial create (e.g. a Helm timeout on kuberay-operator or spark-operator) is left with no registered domain, and every subsequent PipelineRun fails immediately with `EntityNotExistsError{Domain default does not exist}`.

This calls `_create_cadence_domain()` from `_sync()` as well, guarded the same way `_create()` already does (`ns.workflow == "cadence"`). It's placed in a `finally` block around `_helm_wait()` rather than directly after it, so domain registration still runs even if `_helm_wait()` itself times out waiting on pods — a real failure mode, since `_helm_wait()` uses `kubectl wait` rather than `helm --wait` and can exceed its timeout while Cadence is still initializing. `_create_cadence_domain()` already treats "domain already exists" as success, so calling it here on an otherwise-healthy sync is a safe no-op.

## Test plan

- `python -m py_compile michelangelo/cli/sandbox/sandbox.py` passes.
- Manually reviewed against the existing `_create()` call site to confirm matching guard/signature usage.
- Verified against a live sandbox cluster: a sandbox recovered via `ma sandbox sync` after a simulated partial-create failure now has the Cadence domain registered, and PipelineRuns proceed past the domain-lookup step.

Closes #1296