### PR TITLE
ci: rebuild examples image on proto changes

### DIFF
--- a/.github/workflows/build-examples-image.yaml
+++ b/.github/workflows/build-examples-image.yaml
@@ -15,11 +15,13 @@ on:
       - "python/examples/**"
       - "python/pyproject.toml"
       - "python/poetry.lock"
+      - "proto/**"
   pull_request:
     paths:
       - "python/examples/**"
       - "python/pyproject.toml"
       - "python/poetry.lock"
+      - "proto/**"
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Summary

`build-examples-image.yaml` only rebuilds `ghcr.io/michelangelo-ai/examples:main` on changes under `python/examples/**`, `python/pyproject.toml`, or `python/poetry.lock`. A proto-only change (e.g. a new field on `ModelSpec`) never triggers a rebuild, so the published image can silently ship stale generated stubs alongside a repo whose proto source has already moved on.

Adds `proto/**` to both the `push` and `pull_request` path filters, matching the fix proposed in the issue's own follow-up comment.

## Test plan

- Validated the updated workflow file parses as valid YAML (`yaml.safe_load`).
- No way to trigger GitHub Actions from this environment; change is a path-filter-only addition with no effect on existing trigger paths or job logic.

Closes #1451