### PR TITLE
fix(release): close tracking issue on final promotion

### DIFF
--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -113,15 +113,15 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Comment on tracking issue
+      - name: Comment on and close tracking issue
         run: |
           ISSUE_NUMBER=$(gh issue list --search "in:title \"Release v${{ steps.vars.outputs.version }}\"" --state open --json number,title \
             --jq '.[] | select(.title == "Release v${{ steps.vars.outputs.version }}") | .number' | head -1)
           if [ -z "$ISSUE_NUMBER" ]; then
             echo "WARNING: no open tracking issue found for Release v${{ steps.vars.outputs.version }}"
           else
-            gh issue comment "$ISSUE_NUMBER" \
-              --body "Promoted to final: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ steps.vars.outputs.tag }}. Artifact publish run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            gh issue close "$ISSUE_NUMBER" \
+              --comment "Promoted to final: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ steps.vars.outputs.tag }}. Artifact publish run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- `release-promote.yml`'s tracking-issue step now closes the release tracking issue (with a comment linking the release and artifact-publish run) instead of just commenting and leaving it open.

## Why
The release-manager process has been closing these tracking issues by hand after every final promotion (v0.7.0 #1658, v0.8.0 #1718) since the workflow never did it itself. Automating it removes a manual step from every future release.

## Test plan
- [ ] CI green
- [ ] Verify on the next `release-promote.yml` run (v0.9.0's eventual promotion) that the tracking issue closes automatically