### PR TITLE
fix(ci): pin release.yaml's Go setup to go.mod instead of a hardcoded version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,7 +87,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v7
         with:
-          go-version: '1.24'
+          go-version-file: go/go.mod
           cache-dependency-path: go/go.sum
 
       - name: Build binary


### PR DESCRIPTION
## Summary
- `release.yaml`'s `build-go-binaries` job pinned `actions/setup-go` to an exact `go-version: '1.24'`, which disables Go's toolchain auto-download (`GOTOOLCHAIN` behaves as `local` for an exact pin).
- `go/go.mod` was bumped to `go 1.25.0` in #1837, so every `build-go-binaries` matrix job on `v0.9.0-rc.1` failed with `go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)`.
- Switches to `go-version-file: go/go.mod`, matching the pattern `api-surface-check.yml` already uses, so this can't drift again on a future `go.mod` bump.

## Test plan
- [ ] CI green
- [ ] Same fix cherry-picked directly to `release/v0.9` to unblock `v0.9.0-rc.1`'s binary artifacts (see that branch's matching commit)