### PR TITLE
fix(ci): pin release.yaml's Go setup to go.mod (cherry-pick for v0.9.0-rc.1)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,7 +87,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v7
         with:
-          go-version: '1.24'
+          go-version-file: go/go.mod
           cache-dependency-path: go/go.sum
 
       - name: Build binary


### PR DESCRIPTION
Cherry-pick of #1897 directly onto `release/v0.9` — unblocks `build-go-binaries` for `v0.9.0-rc.1`, which is currently failing with `go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)` after #1837 bumped `go.mod`'s directive.