### PR TITLE
fix(blobstore): register the Azure client in worker and controllermgr

### DIFF
--- a/go/base/blobstore/azure/BUILD.bazel
+++ b/go/base/blobstore/azure/BUILD.bazel
@@ -18,7 +18,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["config_test.go"],
+    srcs = [
+        "client_test.go",
+        "config_test.go",
+    ],
     embed = [":go_default_library"],
     deps = ["@org_uber_go_config//:go_default_library"],
 )

--- a/go/base/blobstore/azure/client.go
+++ b/go/base/blobstore/azure/client.go
@@ -41,6 +41,13 @@ func newAzureBlobClient(storageAccount, sasToken, endpoint string) *azureBlobCli
 // Get retrieves an object from Azure Blob Storage using SAS token authentication.
 // The blobURI is expected to be in the format "abfss://container@storageaccount.blob.core.windows.net/path".
 func (c *azureBlobClient) Get(ctx context.Context, blobURI string) ([]byte, error) {
+	// Configuration is validated here rather than at construction so that the
+	// module can be provided unconditionally without failing startup for
+	// deployments that do not use Azure Blob Storage.
+	if c.storageAccount == "" || c.sasToken == "" {
+		return nil, fmt.Errorf("azure blob storage is not configured: storageAccount and sasToken are required to fetch %s", blobURI)
+	}
+
 	parsedURL, err := url.Parse(blobURI)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse url: %w", err)

--- a/go/base/blobstore/azure/client_test.go
+++ b/go/base/blobstore/azure/client_test.go
@@ -1,0 +1,94 @@
+package azure
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestNewClient_UnconfiguredDoesNotFail verifies that the module constructor
+// succeeds with an empty config, so providing the module never fails startup
+// for deployments that do not use Azure Blob Storage.
+func TestNewClient_UnconfiguredDoesNotFail(t *testing.T) {
+	out := newClient(Config{})
+	if out.BlobStoreClient == nil {
+		t.Fatal("newClient returned a nil client for empty config")
+	}
+	if got := out.BlobStoreClient.Scheme(); got != "abfss" {
+		t.Fatalf("Scheme() = %q, want %q", got, "abfss")
+	}
+}
+
+// TestGet_Unconfigured verifies that an unconfigured client fails at first
+// use with a message pointing at the missing settings.
+func TestGet_Unconfigured(t *testing.T) {
+	client := newAzureBlobClient("", "", "")
+	_, err := client.Get(context.Background(), "abfss://container@acct.blob.core.windows.net/path/blob.bin")
+	if err == nil {
+		t.Fatal("Get on an unconfigured client succeeded, want error")
+	}
+	if !strings.Contains(err.Error(), "not configured") {
+		t.Fatalf("Get error = %q, want it to mention 'not configured'", err.Error())
+	}
+}
+
+// TestGet_WrongScheme verifies that a configured client still rejects URIs
+// with a scheme it does not own.
+func TestGet_WrongScheme(t *testing.T) {
+	client := newAzureBlobClient("acct", "sig=token", "")
+	_, err := client.Get(context.Background(), "s3://bucket/path")
+	if err == nil {
+		t.Fatal("Get with s3 scheme succeeded, want error")
+	}
+	if !strings.Contains(err.Error(), "not supported") {
+		t.Fatalf("Get error = %q, want it to mention 'not supported'", err.Error())
+	}
+}
+
+// TestGet_RoundTrip verifies the request path a configured client builds and
+// that the blob body is returned as-is.
+func TestGet_RoundTrip(t *testing.T) {
+	const body = "blob-bytes"
+	var gotPath, gotQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	client := newAzureBlobClient("acct", "sig=token", server.URL)
+	data, err := client.Get(context.Background(), "abfss://container@acct.blob.core.windows.net/dir/blob.bin")
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if string(data) != body {
+		t.Fatalf("Get body = %q, want %q", string(data), body)
+	}
+	if gotPath != "/container/dir/blob.bin" {
+		t.Fatalf("request path = %q, want %q", gotPath, "/container/dir/blob.bin")
+	}
+	if gotQuery != "sig=token" {
+		t.Fatalf("request query = %q, want the SAS token", gotQuery)
+	}
+}
+
+// TestGet_HTTPError verifies that non-200 responses surface as errors with
+// the status code included.
+func TestGet_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "no such blob", http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client := newAzureBlobClient("acct", "sig=token", server.URL)
+	_, err := client.Get(context.Background(), "abfss://container@acct.blob.core.windows.net/missing")
+	if err == nil {
+		t.Fatal("Get on a 404 succeeded, want error")
+	}
+	if !strings.Contains(err.Error(), "HTTP 404") {
+		t.Fatalf("Get error = %q, want it to mention HTTP 404", err.Error())
+	}
+}

--- a/go/base/blobstore/azure/module.go
+++ b/go/base/blobstore/azure/module.go
@@ -1,8 +1,6 @@
 package azure
 
 import (
-	"fmt"
-
 	"github.com/michelangelo-ai/michelangelo/go/base/blobstore"
 	"go.uber.org/fx"
 )
@@ -20,17 +18,11 @@ var Module = fx.Options(
 )
 
 // newClient initializes a new azureBlobClient using the provided configuration.
-// Returns a pointer to azureBlobClient or an error if initialization fails.
-func newClient(config Config) (BlobStoreClientOut, error) {
-	if config.StorageAccount == "" {
-		return BlobStoreClientOut{}, fmt.Errorf("azure storage account is required")
-	}
-	if config.SASToken == "" {
-		return BlobStoreClientOut{}, fmt.Errorf("azure SAS token is required")
-	}
-
-	azureClient := newAzureBlobClient(config.StorageAccount, config.SASToken, config.Endpoint)
+// Required settings are validated on first use (see azureBlobClient.Get), not
+// here, so providing this module never fails startup for deployments that do
+// not configure Azure Blob Storage.
+func newClient(config Config) BlobStoreClientOut {
 	return BlobStoreClientOut{
-		BlobStoreClient: azureClient,
-	}, nil
+		BlobStoreClient: newAzureBlobClient(config.StorageAccount, config.SASToken, config.Endpoint),
+	}
 }

--- a/go/controllermgr/BUILD.bazel
+++ b/go/controllermgr/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//go/base/blobstore:go_default_library",
+        "//go/base/blobstore/azure:go_default_library",
         "//go/base/blobstore/gcs:go_default_library",
         "//go/base/blobstore/minio:go_default_library",
         "//go/kubeproto/metrics:go_default_library",

--- a/go/controllermgr/module.go
+++ b/go/controllermgr/module.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/michelangelo-ai/michelangelo/go/base/blobstore"
+	"github.com/michelangelo-ai/michelangelo/go/base/blobstore/azure"
 	"github.com/michelangelo-ai/michelangelo/go/base/blobstore/gcs"
 	"github.com/michelangelo-ai/michelangelo/go/base/blobstore/minio"
 	"github.com/michelangelo-ai/michelangelo/go/kubeproto/metrics"
@@ -31,6 +32,7 @@ var Module = fx.Options(
 	blobstore.Module,
 	minio.Module,
 	gcs.Module,
+	azure.Module,
 	fx.Provide(newConfig),
 	fx.Provide(create),
 	fx.Invoke(start),

--- a/go/worker/BUILD.bazel
+++ b/go/worker/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//go/base/blobstore:go_default_library",
+        "//go/base/blobstore/azure:go_default_library",
         "//go/base/blobstore/gcs:go_default_library",
         "//go/base/blobstore/minio:go_default_library",
         "//go/worker/activities:go_default_library",

--- a/go/worker/module.go
+++ b/go/worker/module.go
@@ -6,6 +6,7 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/michelangelo-ai/michelangelo/go/base/blobstore"
+	"github.com/michelangelo-ai/michelangelo/go/base/blobstore/azure"
 	"github.com/michelangelo-ai/michelangelo/go/base/blobstore/gcs"
 	"github.com/michelangelo-ai/michelangelo/go/base/blobstore/minio"
 	"github.com/michelangelo-ai/michelangelo/go/worker/activities"
@@ -44,4 +45,5 @@ var Module = fx.Options(
 	blobstore.Module,
 	minio.Module,
 	gcs.Module,
+	azure.Module,
 )


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

- `go/worker/module.go` and `go/controllermgr/module.go`: provide `azure.Module` alongside the MinIO and GCS blobstore modules, so the Azure Blob Storage client actually registers into the blobstore client group.
- `go/base/blobstore/azure/module.go` + `client.go`: required-setting validation (`storageAccount`, `sasToken`) moves from construction time to first use, mirroring the GCS module. This matters because the blobstore group is materialized at startup in both binaries: with the old constructor-time errors, wiring the module in would have crashed every deployment that does not configure Azure. Unconfigured deployments now start normally and an `abfss://` fetch fails with a clear "azure blob storage is not configured" error instead.
- `go/base/blobstore/azure/client_test.go` (new): tests for the unconfigured path, wrong-scheme rejection, a full request round-trip against a local test server (path + SAS-token query verified), and HTTP error propagation.

**Why?**

The Azure blob client (#687) was added with a complete implementation, config section, and fx module -- but the module was never provided by any binary. `git grep` shows zero references to `blobstore/azure` outside the package itself, so it has been dead code since it merged: any `abfss://` blob URI fails with "scheme abfss is not supported" even on a fully configured deployment, despite the docs-visible presence of Azure support in the tree.

**How did you test it?**

- `go build ./...` and both binaries (`./cmd/worker`, `./cmd/controllermgr`) build clean.
- `go test ./base/blobstore/...` passes (5 new Azure client tests plus the existing suites); `go vet` clean on the touched packages.
- `bazel test //go/base/blobstore/azure:go_default_test //go/base/blobstore:go_default_test` both PASS after the gazelle BUILD update.
- The repo's dirty-check trio (gazelle, `go mod tidy`, goimports) run locally to convergence -- no drift, no new dependencies.

**Potential risks**

Behavior change is strictly additive: deployments that never configure Azure get the same startup behavior and a clearer per-request error for `abfss://` URIs ("not configured" instead of "scheme not supported"). Deployments that DID set the `azure:` config section previously got no client at all, so enabling it cannot regress anyone. Partial configuration (account without token or vice versa) is reported at first use rather than at startup -- same posture as the GCS client.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

Azure Blob Storage (`abfss://`) blob URIs now work in the worker and controllermgr when the `azure:` config section is set; previously the client existed but was never registered.

**Documentation Changes**

None in this PR; a follow-up could add the `azure:` section to the operator guide's blob-storage page alongside S3 and GCS.