### PR TITLE
docs: correct sandbox setup prerequisites and resource sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ cd michelangelo/python
 poetry install
 source .venv/bin/activate
 
+# Build the local-only images the sandbox needs
+cd .. && bash scripts/kuberay/build-kuberay-images.sh
+
 # Spin up a local sandbox cluster
 ma sandbox create
 
@@ -69,6 +72,8 @@ def train(learning_rate: float = 0.01) -> str:
 def my_pipeline(learning_rate: float = 0.01):
     model = train(learning_rate=learning_rate)
 ```
+
+See the [Sandbox Setup](https://michelangelo-ai.org/docs/getting-started/sandbox-setup/) guide for prerequisites (including `docker buildx`) and platform-specific notes before running the above.
 
 For a full walkthrough, see the [Getting Started with ML Pipelines](https://michelangelo-ai.org/docs/user-guides/getting-started/getting-started) guide.
 

--- a/docs/contributing/custom-docker-images.md
+++ b/docs/contributing/custom-docker-images.md
@@ -134,6 +134,13 @@ kubectl rollout status  deployment/michelangelo-worker
 
 - **Pod stuck in `ImagePullBackOff`**: The default `pullPolicy` is `IfNotPresent`. If k3d can't find the image, make sure you ran `k3d image import` after building. Check with `k3d image ls -c michelangelo-sandbox | grep local-dev`.
 - **`exec format error`**: Architecture mismatch — you built for `arm64` but the k3d node is `amd64` (or vice versa). Rebuild with the correct `ARCH`.
+- **`fatal error: fault` or a `runtime.sigpanic` stack trace**: also an architecture mismatch, but one that emulation lets start before it dies. When binfmt emulation is registered (as it is under Colima), a mismatched binary launches and then faults inside the Go runtime instead of failing with `exec format error`. Verify by extracting the image's entrypoint and checking it against the node's architecture:
+
+  ```bash
+  cid=$(docker create <image>); docker cp "$cid:/app" ./app-bin; docker rm -f "$cid"
+  file ./app-bin    # want aarch64 on Apple Silicon, x86-64 on Intel/Linux
+  kubectl get nodes -o jsonpath='{.items[*].status.nodeInfo.architecture}'
+  ```
 - **Bazel Go binary not found**: Run any `./tools/bazel build` target first to trigger the SDK download, then re-run the `find` command.
 
 ### Cleanup

--- a/docs/getting-started/sandbox-setup.md
+++ b/docs/getting-started/sandbox-setup.md
@@ -32,6 +32,7 @@ Before you begin, make sure you have the following installed. Install commands b
 | Tool | Install (macOS) | Install (Linux) | Verify |
 |------|-----------------|-----------------|--------|
 | **Docker** | [Docker Desktop](https://docs.docker.com/get-started/get-docker) or [Colima](https://github.com/abiosoft/colima) | [Docker Engine](https://docs.docker.com/engine/install/) | `docker info` |
+| **docker buildx** | `brew install docker-buildx` (see note below) | usually bundled with Docker Engine | `docker buildx version` |
 | **kubectl** | `brew install kubectl` | [official guide](https://kubernetes.io/docs/tasks/tools/#kubectl) | `kubectl version --client` |
 | **k3d** | `brew install k3d` | [official guide](https://k3d.io/#installation) | `k3d --version` |
 | **Helm** | `brew install helm` | [official guide](https://helm.sh/docs/intro/install/) | `helm version` |
@@ -43,27 +44,46 @@ Before you begin, make sure you have the following installed. Install commands b
 
 > **Docker daemon note:** `docker info` (the verify command above) requires the Docker daemon to be running — unlike `docker --version`, which only checks the binary. If `docker info` fails, start Docker Desktop or Colima before continuing.
 
+> **buildx note (Homebrew):** `brew install docker` installs the Docker CLI only — the buildx plugin is a separate formula. Without it, `scripts/kuberay/build-kuberay-images.sh` fails with `unknown flag: --platform`. After installing, link the plugin so the CLI can find it:
+>
+> ```bash
+> mkdir -p ~/.docker/cli-plugins
+> ln -sfn /opt/homebrew/opt/docker-buildx/bin/docker-buildx ~/.docker/cli-plugins/docker-buildx
+> ```
+
+> **Poetry install note (macOS, python.org builds):** if the Poetry install command aborts with `ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED]`, your interpreter has no CA bundle wired into `ssl` — python.org framework builds ship one but do not install it. Run the bundled installer once, then retry:
+>
+> ```bash
+> "/Applications/Python 3.11/Install Certificates.command"
+> ```
+>
+> Alternatively, `brew install poetry` avoids the issue entirely.
+
 ### Colima resource requirements (macOS only)
 
 If you are on macOS and using Colima as your Docker runtime, the default VM resources are too limited for the sandbox. Start Colima with at least:
 
 ```bash
-colima start --cpu 4 --memory 8 --disk 60
+colima start --cpu 6 --memory 12 --disk 100
 ```
 
 | Resource | Minimum | Recommended |
 |----------|---------|-------------|
 | CPU cores | 4 | 6 |
-| Memory (GB) | 8 | 12 |
+| Memory (GiB) | 12 | 12 |
 | Disk (GB) | 60 | 100 |
 
 > **Warning:** Starting Colima with the default settings (2 CPU, 2 GB RAM) will cause pods to crash or fail to schedule. Always pass explicit resource flags.
+
+> **Memory is not a soft limit.** `--memory 8` yields `Total Memory: 7.737GiB` (the flag is GiB), and at that size the `bert_cola` example in `python/examples/` fails: its data-prep task succeeds, then the training task is killed by Ray's memory monitor with `Task was killed due to the node running low on memory ... 7.35GB / 7.74GB (0.950357), which exceeds the memory usage threshold of 0.95`. The same pipeline succeeds unchanged at `--memory 12`. Because the VM needs 12 GiB and macOS needs the rest, a 16 GB host is effectively the floor for running the bundled examples.
+
+> **Apple Silicon:** add `--vz-rosetta` to your `colima start` command. Colima defaults to `rosetta: false`, and some published images run amd64 binaries that fall back to QEMU emulation, where the Go runtime can die with `fatal error: fault` — typically seen as `michelangelo-apiserver` in `CrashLoopBackOff`.
 
 If Colima is already running with insufficient resources, stop it and restart with the new settings:
 
 ```bash
 colima stop
-colima start --cpu 4 --memory 8 --disk 60
+colima start --cpu 6 --memory 12 --disk 100
 ```
 
 ### Configure `host.docker.internal`
@@ -106,6 +126,8 @@ ma sandbox create
 # 4. Verify everything works by running the demo pipeline
 ma sandbox demo pipeline
 ```
+
+> **Note on step 2:** the build script also imports the images it builds into your k3d clusters, but those clusters do not exist until step 3. It will report that cluster `michelangelo-compute-0` was not found and skip it, which is expected. If `history-server` later sits in `ImagePullBackOff`, re-run the script after `ma sandbox create` — the images are already built, so the second run only performs the import.
 
 > **Tip:** If you prefer not to activate the venv, prefix each `ma` command with `poetry run` (e.g., `poetry run ma sandbox create`). If you see `zsh: command not found: ma`, you either skipped step 1 or need to use `poetry run`. See [troubleshooting](#command-not-found-ma) below.
 
@@ -394,7 +416,12 @@ A service is starting but immediately crashing. Check its logs:
 kubectl logs <pod-name>
 ```
 
-If a single service is wedged, the simplest recovery is to delete the pod and let Kubernetes recreate it:
+Before escalating, rule out the two causes that deleting and recreating will **not** fix:
+
+- **Architecture mismatch.** If the log ends in `fatal error: fault` or a `runtime.sigpanic` stack trace, the container is running a binary built for another architecture under emulation. Compare the binary against the node: `kubectl get nodes -o jsonpath='{.items[*].status.nodeInfo.architecture}'`, then extract the image's entrypoint and check it with `file`. On Apple Silicon, start Colima with `--vz-rosetta`.
+- **Memory.** If the pod is OOM-killed (`kubectl describe pod <pod-name>` shows `Reason: OOMKilled`, or Ray reports `Task was killed due to the node running low on memory`), the VM is too small — see [Colima resource requirements](#colima-resource-requirements-macos-only).
+
+If neither applies, the pod may simply be wedged. The simplest recovery is to delete it and let Kubernetes recreate it:
 
 ```bash
 kubectl delete pod <pod-name>

--- a/docs/user-guides/train-and-deploy-models/train-and-register-a-model.md
+++ b/docs/user-guides/train-and-deploy-models/train-and-register-a-model.md
@@ -19,7 +19,7 @@ The focus is simplicity: **you control your training logic**, Michelangelo AI pr
 
 - **A running sandbox** — Remote training runs require a local Kubernetes cluster. Follow the [Sandbox Setup](../../getting-started/sandbox-setup.md) guide if you haven't done this yet.
 - **A prepared dataset** — Training tasks expect datasets passed as `DatasetVariable`. See [Data Preparation](../getting-started/prepare-your-data.md) for how to produce them.
-- **Python 3.11+, Poetry, and the Michelangelo AI SDK installed** — Run `cd python && poetry install` from the repo root.
+- **Python 3.11+, Poetry, and the Michelangelo AI SDK installed** — Run `cd python && poetry install -E example` from the repo root (the `example` extra pulls the ML dependencies the bundled examples import).
 - **For distributed training:** A Docker image with your workflow code. See [Running Uniflow Pipelines](../ml-pipelines/running-uniflow.md) for image build steps.
 
 ## Understanding Training Inputs

--- a/python/examples/bert_cola/README.md
+++ b/python/examples/bert_cola/README.md
@@ -14,9 +14,12 @@ Fine-tuning BERT for linguistic acceptability classification using the Corpus of
 
 ```bash
 cd michelangelo-ai/michelangelo/python
+poetry install -E example   # installs torch, transformers, datasets, ray
 source .venv/bin/activate
 poetry run python examples/bert_cola/bert_cola.py
 ```
+
+> The `example` extra is required. A plain `poetry install` omits it, and the module then fails to import with `No module named 'datasets'`.
 
 ## Expected Output
 


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

Nine corrections to the getting-started path, each traced to a specific failure hit while following the documented setup:

| Area | Change |
|---|---|
| Prerequisites | Add `docker buildx` (the kuberay script calls `docker buildx build`, but `brew install docker` ships the CLI alone) |
| Prerequisites | Note the CA-certificate fix for the Poetry install command on python.org builds |
| Colima sizing | Raise to `--cpu 6 --memory 12 --disk 100`; state memory in GiB |
| Colima sizing | Note `--vz-rosetta` for Apple Silicon |
| Quick start | Explain that the kuberay import step runs before the clusters exist, and may need a re-run |
| Troubleshooting | Add architecture and memory triage to `CrashLoopBackOff`, ahead of the delete-and-recreate escalation |
| custom-docker-images | Document `fatal error: fault` alongside `exec format error` |
| README | Add the missing kuberay build step to the quick start |
| Examples | State `poetry install -E example` where the examples are actually run |

<!-- Tell your future self why have you made these changes -->
**Why?**

Following the documented instructions from a clean macOS machine does not currently reach the guide's stated end state ("a running sandbox cluster and a successful demo pipeline run"). Several steps fail outright, and the errors they produce are not searchable in the docs.

The most consequential is the memory sizing. The guide prints `colima start --cpu 4 --memory 8 --disk 60`, which yields `Total Memory: 7.737GiB` — already below its own stated 8 GB minimum, because the flag is GiB. At that size the `bert_cola` example the repository ships cannot finish: its data-prep task succeeds, then the training task is killed by Ray's memory monitor with

```
Task was killed due to the node running low on memory.
Memory on the node ... was 7.35GB / 7.74GB (0.950357), which exceeds
the memory usage threshold of 0.95.
```

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Followed the corrected instructions end to end on macOS 15 / Apple Silicon (M1 Pro, 16 GB) with Colima, from a clean toolchain through to a pipeline run that reaches `SUCCEEDED`.

The memory change is a controlled comparison — same machine, same commit, same pipeline, same uploaded tar, with VM memory as the only variable:

| VM memory | `load_data` | `train` | Run |
|---|---|---|---|
| 7.74 GB (documented) | `[ ok ]` | OOM-killed at 7.35 GB | FAILED |
| 11.65 GB (`--memory 12`) | `[ ok ]` | `[ ok ]` | **SUCCEEDED** |

Both task outcomes were confirmed in the Ray driver logs, captured live before the cluster tears down. Every other note reproduces the exact error string quoted.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

Documentation only — no code paths, no build or deployment changes.

Two judgement calls worth a reviewer's attention:

1. **Raising the stated minimum from 8 to 12 GiB will turn away users on 8 GB hosts.** That is deliberate: the sandbox cannot finish the bundled example at 8 GiB. Since the VM needs 12 GiB and the host OS needs the rest, a 16 GB machine is effectively the floor. If the project would rather keep a lower entry point, the alternative is to keep 8 GiB documented and state plainly which examples will not run there.
2. **The Minimum and Recommended memory columns now both read 12.** Only 12 was verified as working and 8 as failing; putting a higher figure under "Recommended" would be untested. Happy to adjust.

The buildx install note is Homebrew-specific and uses the Apple Silicon prefix (`/opt/homebrew/...`); Intel Macs need `/usr/local/...`.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

---

**Not included, deliberately**

- The required Python version is stated three different ways — `pyproject.toml:28` (`python = "^3.9.0"`), `.envrc:30` (asserts 3.9), and this guide (3.11 or 3.12 recommended, 3.13+ may fail). A contributor on 3.9 passes both machine-enforced checks and only discovers the real constraint when `poetry install` fails. Fixing that means tightening dependency constraints, which does not belong in a docs change.
- `ma sandbox create` never imports `ghcr.io/michelangelo-ai/examples:main`, yet the sandbox pins `pullPolicy: Never`, so the task image cannot be obtained by any documented step. Left alone pending confirmation of whether that import is intended to be part of `create`.

**Related issues**

Three defects found during the same exercise are filed separately, since they are code rather than documentation: #1901 (Cluster CRD records an unreachable `0.0.0.0` address), #1902 (`createCluster` discards the real error, surfacing `nil (not None)`), #1908 (sandbox MySQL has no data volume).
