### PR TITLE
feat(model): add Information and Performance tabs to the Model detail page

### DIFF
--- a/javascript/packages/core/components/views/detail-view/detail-view.tsx
+++ b/javascript/packages/core/components/views/detail-view/detail-view.tsx
@@ -18,7 +18,14 @@ export function DetailView({
   const [css, theme] = useStyletron();
 
   return (
-    <div className={css({ display: 'flex', flexDirection: 'column', gap: theme.sizing.scale800 })}>
+    <div
+      className={css({
+        display: 'flex',
+        flexDirection: 'column',
+        gap: theme.sizing.scale800,
+        marginTop: theme.sizing.scale600,
+      })}
+    >
       <DetailViewHeader
         title={title}
         subtitle={subtitle}

--- a/javascript/packages/core/config/entities/model/__tests__/model-page.test.tsx
+++ b/javascript/packages/core/config/entities/model/__tests__/model-page.test.tsx
@@ -2,11 +2,15 @@ import { render, screen } from '@testing-library/react';
 import { vi } from 'vitest';
 
 import { TRAIN_PHASE } from '#core/config/phases/train';
+import { EntityDetailRoute } from '#core/router/entity-detail-route';
 import { PhaseListRoute } from '#core/router/phase-list-route';
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getErrorProviderWrapper } from '#core/test/wrappers/get-error-provider-wrapper';
 import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
-import { getServiceProviderWrapper } from '#core/test/wrappers/get-service-provider-wrapper';
+import {
+  createQueryMockRouter,
+  getServiceProviderWrapper,
+} from '#core/test/wrappers/get-service-provider-wrapper';
 
 describe('Model list page', () => {
   it('renders the column headers', async () => {
@@ -96,5 +100,148 @@ describe('Model list page', () => {
 
     expect(screen.getByRole('link', { name: 'user-segmenter' })).toBeInTheDocument();
     expect(screen.getByText('Clustering')).toBeInTheDocument();
+  });
+});
+
+describe('Model detail page', () => {
+  describe('information tab', () => {
+    const buildModel = (overrides = {}) => ({
+      metadata: { name: 'fraud-classifier' },
+      spec: {
+        description: 'model workflow=fraud-classifier git=abc123',
+        sourcePipelineRun: { name: 'run-42' },
+      },
+      ...overrides,
+    });
+
+    it('renders the model description', async () => {
+      render(
+        <EntityDetailRoute phases={{ train: TRAIN_PHASE }} />,
+        buildWrapper([
+          getErrorProviderWrapper(),
+          getRouterWrapper({ location: '/myproject/train/models/fraud-classifier/information' }),
+          getServiceProviderWrapper({
+            request: createQueryMockRouter({ GetModel: { model: buildModel() } }),
+          }),
+        ])
+      );
+
+      expect(
+        await screen.findByText('model workflow=fraud-classifier git=abc123')
+      ).toBeInTheDocument();
+    });
+
+    it('shows a fallback message when no description is set', async () => {
+      render(
+        <EntityDetailRoute phases={{ train: TRAIN_PHASE }} />,
+        buildWrapper([
+          getErrorProviderWrapper(),
+          getRouterWrapper({ location: '/myproject/train/models/fraud-classifier/information' }),
+          getServiceProviderWrapper({
+            request: createQueryMockRouter({
+              GetModel: { model: buildModel({ spec: { sourcePipelineRun: { name: 'run-42' } } }) },
+            }),
+          }),
+        ])
+      );
+
+      expect(await screen.findByText('No description provided.')).toBeInTheDocument();
+    });
+
+    it('renders a link to the source pipeline run', async () => {
+      render(
+        <EntityDetailRoute phases={{ train: TRAIN_PHASE }} />,
+        buildWrapper([
+          getErrorProviderWrapper(),
+          getRouterWrapper({ location: '/myproject/train/models/fraud-classifier/information' }),
+          getServiceProviderWrapper({
+            request: createQueryMockRouter({ GetModel: { model: buildModel() } }),
+          }),
+        ])
+      );
+
+      expect(await screen.findByRole('link', { name: 'run-42' })).toHaveAttribute(
+        'href',
+        '/myproject/train/runs/run-42'
+      );
+    });
+  });
+
+  describe('performance tab', () => {
+    it('shows a message when the model has no performance report configured', async () => {
+      render(
+        <EntityDetailRoute phases={{ train: TRAIN_PHASE }} />,
+        buildWrapper([
+          getErrorProviderWrapper(),
+          getRouterWrapper({ location: '/myproject/train/models/fraud-classifier/performance' }),
+          getServiceProviderWrapper({
+            request: createQueryMockRouter({
+              GetModel: { model: { metadata: { name: 'fraud-classifier' }, spec: {} } },
+            }),
+          }),
+        ])
+      );
+
+      expect(
+        await screen.findByText('No performance report is available for this model.')
+      ).toBeInTheDocument();
+    });
+
+    it('lists chart titles from the fetched evaluation report', async () => {
+      render(
+        <EntityDetailRoute phases={{ train: TRAIN_PHASE }} />,
+        buildWrapper([
+          getErrorProviderWrapper(),
+          getRouterWrapper({ location: '/myproject/train/models/fraud-classifier/performance' }),
+          getServiceProviderWrapper({
+            request: createQueryMockRouter({
+              GetModel: {
+                model: {
+                  metadata: { name: 'fraud-classifier' },
+                  spec: { performanceEvaluationReport: { name: 'report-a' } },
+                },
+              },
+              GetEvaluationReport: {
+                evaluationReport: {
+                  spec: {
+                    title: 'Model Performance',
+                    charts: [{ title: 'Accuracy by class' }, { title: 'ROC Curve' }],
+                  },
+                },
+              },
+            }),
+          }),
+        ])
+      );
+
+      expect(await screen.findByText('Model Performance')).toBeInTheDocument();
+      expect(screen.getByText('Accuracy by class')).toBeInTheDocument();
+      expect(screen.getByText('ROC Curve')).toBeInTheDocument();
+    });
+
+    it('shows a message when the report has no charts', async () => {
+      render(
+        <EntityDetailRoute phases={{ train: TRAIN_PHASE }} />,
+        buildWrapper([
+          getErrorProviderWrapper(),
+          getRouterWrapper({ location: '/myproject/train/models/fraud-classifier/performance' }),
+          getServiceProviderWrapper({
+            request: createQueryMockRouter({
+              GetModel: {
+                model: {
+                  metadata: { name: 'fraud-classifier' },
+                  spec: { performanceEvaluationReport: { name: 'report-a' } },
+                },
+              },
+              GetEvaluationReport: {
+                evaluationReport: { spec: { title: 'Empty Report', charts: [] } },
+              },
+            }),
+          }),
+        ])
+      );
+
+      expect(await screen.findByText('This report has no charts.')).toBeInTheDocument();
+    });
   });
 });

--- a/javascript/packages/core/config/entities/model/__tests__/model-page.test.tsx
+++ b/javascript/packages/core/config/entities/model/__tests__/model-page.test.tsx
@@ -104,6 +104,41 @@ describe('Model list page', () => {
 });
 
 describe('Model detail page', () => {
+  describe('header metadata row', () => {
+    it('renders source pipeline run, owner, timestamps, and type', async () => {
+      render(
+        <EntityDetailRoute phases={{ train: TRAIN_PHASE }} />,
+        buildWrapper([
+          getErrorProviderWrapper(),
+          getRouterWrapper({ location: '/myproject/train/models/fraud-classifier/information' }),
+          getServiceProviderWrapper({
+            request: createQueryMockRouter({
+              GetModel: {
+                model: {
+                  metadata: {
+                    name: 'fraud-classifier',
+                    creationTimestamp: { seconds: 1700000000 },
+                    labels: { 'michelangelo/SpecUpdateTimestamp': '1700500000' },
+                  },
+                  spec: {
+                    sourcePipelineRun: { name: 'run-42' },
+                    owner: { name: 'model-owner' },
+                    kind: 3, // MODEL_KIND_BINARY_CLASSIFICATION
+                  },
+                },
+              },
+            }),
+          }),
+        ])
+      );
+
+      const runLinks = await screen.findAllByRole('link', { name: 'run-42' });
+      expect(runLinks[0]).toHaveAttribute('href', '/myproject/train/runs/run-42');
+      expect(screen.getByText('model-owner')).toBeInTheDocument();
+      expect(screen.getByText('Binary Classification')).toBeInTheDocument();
+    });
+  });
+
   describe('information tab', () => {
     const buildModel = (overrides = {}) => ({
       metadata: { name: 'fraud-classifier' },
@@ -160,10 +195,12 @@ describe('Model detail page', () => {
         ])
       );
 
-      expect(await screen.findByRole('link', { name: 'run-42' })).toHaveAttribute(
-        'href',
-        '/myproject/train/runs/run-42'
-      );
+      // The source pipeline run link appears both in the page header metadata row and in
+      // this tab's "Useful links" section, matching internal's behavior of surfacing it in
+      // both places.
+      const runLinks = await screen.findAllByRole('link', { name: 'run-42' });
+      expect(runLinks.length).toBeGreaterThanOrEqual(1);
+      expect(runLinks[0]).toHaveAttribute('href', '/myproject/train/runs/run-42');
     });
   });
 

--- a/javascript/packages/core/config/entities/model/detail.ts
+++ b/javascript/packages/core/config/entities/model/detail.ts
@@ -1,4 +1,6 @@
 import { CellType } from '#core/components/cell/constants';
+import { getCrdUpdatedSeconds } from '#core/utils/crd-utils';
+import { MODEL_KIND_TEXT_MAP } from './constants';
 import { ModelInfoPage } from './model-info-page';
 import { ModelPerformancePage } from './model-performance-page';
 
@@ -6,7 +8,29 @@ import type { DetailViewConfig } from '#core/components/views/types';
 
 export const MODEL_DETAIL_CONFIG: DetailViewConfig = {
   type: 'detail',
-  metadata: [{ id: 'metadata.creationTimestamp.seconds', label: 'Created', type: CellType.DATE }],
+  metadata: [
+    {
+      id: 'spec.sourcePipelineRun.name',
+      label: 'Source pipeline run',
+      url: '/${studio.projectId}/${studio.phase}/runs/${data.spec.sourcePipelineRun.name}',
+    },
+    { id: 'spec.owner.name', label: 'Trained by', type: CellType.TEXT },
+    { id: 'metadata.creationTimestamp.seconds', label: 'Creation time', type: CellType.DATE },
+    {
+      id: 'metadata',
+      label: 'Last updated',
+      type: CellType.DATE,
+      accessor: (data: unknown) => {
+        // cast: accessor receives unknown data; narrowing to expected proto shape for property
+        // access; see #1425
+        const row = data as {
+          metadata?: { labels?: Record<string, string>; creationTimestamp?: { seconds: number } };
+        };
+        return getCrdUpdatedSeconds(row);
+      },
+    },
+    { id: 'spec.kind', label: 'Type', type: CellType.TYPE, typeTextMap: MODEL_KIND_TEXT_MAP },
+  ],
   pages: [
     { id: 'information', label: 'Information', type: 'custom', component: ModelInfoPage },
     { id: 'performance', label: 'Performance', type: 'custom', component: ModelPerformancePage },

--- a/javascript/packages/core/config/entities/model/detail.ts
+++ b/javascript/packages/core/config/entities/model/detail.ts
@@ -1,0 +1,14 @@
+import { CellType } from '#core/components/cell/constants';
+import { ModelInfoPage } from './model-info-page';
+import { ModelPerformancePage } from './model-performance-page';
+
+import type { DetailViewConfig } from '#core/components/views/types';
+
+export const MODEL_DETAIL_CONFIG: DetailViewConfig = {
+  type: 'detail',
+  metadata: [{ id: 'metadata.creationTimestamp.seconds', label: 'Created', type: CellType.DATE }],
+  pages: [
+    { id: 'information', label: 'Information', type: 'custom', component: ModelInfoPage },
+    { id: 'performance', label: 'Performance', type: 'custom', component: ModelPerformancePage },
+  ],
+};

--- a/javascript/packages/core/config/entities/model/model-info-page.tsx
+++ b/javascript/packages/core/config/entities/model/model-info-page.tsx
@@ -1,0 +1,50 @@
+import { useStyletron } from 'baseui';
+import { Skeleton } from 'baseui/skeleton';
+import { HeadingSmall, ParagraphMedium } from 'baseui/typography';
+
+import { Box } from '#core/components/box/box';
+import { LinksBox } from '#core/components/links-box/links-box';
+import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
+
+import type { ModelRecord } from './types';
+
+/**
+ * Information tab for the Model detail page.
+ *
+ * Shows a link to the pipeline run that produced the model and the model's free-text
+ * description. A table listing the deployments currently running this model is not included
+ * here — it needs its own cross-entity query and loading/empty states, and is planned as a
+ * follow-up to this tab.
+ */
+export function ModelInfoPage({ data, isLoading }: { data?: object; isLoading: boolean }) {
+  const [css, theme] = useStyletron();
+  const { projectId, phase } = useStudioParams('detail');
+
+  // cast: custom detail pages receive the entity as a plain object; narrowing to the
+  // expected proto shape for property access; see #1425
+  const model = data as ModelRecord | undefined;
+
+  const sourceRunName = model?.spec?.sourcePipelineRun?.name;
+  const links = [{ name: sourceRunName, url: `/${projectId}/${phase}/runs/${sourceRunName}` }];
+
+  return (
+    <div className={css({ display: 'flex', flexDirection: 'column', gap: theme.sizing.scale600 })}>
+      <LinksBox title="Useful links" links={links} isLoading={isLoading} />
+
+      <section>
+        <HeadingSmall marginTop="0" marginBottom={theme.sizing.scale600}>
+          Description
+        </HeadingSmall>
+        <Box>
+          {isLoading ? (
+            <Skeleton animation height="24px" width="100%" />
+          ) : (
+            <ParagraphMedium margin="0">
+              {model?.spec?.description ?? 'No description provided.'}
+            </ParagraphMedium>
+          )}
+        </Box>
+      </section>
+    </div>
+  );
+}

--- a/javascript/packages/core/config/entities/model/model-performance-page.tsx
+++ b/javascript/packages/core/config/entities/model/model-performance-page.tsx
@@ -1,0 +1,76 @@
+import { useStyletron } from 'baseui';
+import { Skeleton } from 'baseui/skeleton';
+import { HeadingSmall, ParagraphMedium } from 'baseui/typography';
+
+import { useStudioQuery } from '#core/hooks/use-studio-query';
+
+import type { ChartRecord, EvaluationReportRecord, ModelRecord } from './types';
+
+/**
+ * Performance tab for the Model detail page.
+ *
+ * Resolves the model's `performanceEvaluationReport` reference to its `EvaluationReport`
+ * resource and lists the charts it contains by title. Rendering a chart's actual content (as a
+ * table, line chart, histogram, etc.) is not yet implemented — that depends on a per-chart-type
+ * rendering approach, and for non-table chart types, a charting library, both still to be
+ * decided. This tab proves out the fetch/loading/empty-state plumbing ahead of that work.
+ */
+export function ModelPerformancePage({ data, isLoading }: { data?: object; isLoading: boolean }) {
+  const [css, theme] = useStyletron();
+
+  // cast: custom detail pages receive the entity as a plain object; narrowing to the
+  // expected proto shape for property access; see #1425
+  const model = data as ModelRecord | undefined;
+  const reportName = model?.spec?.performanceEvaluationReport?.name;
+
+  const { data: reportData, isLoading: isReportLoading } = useStudioQuery<{
+    evaluationReport?: EvaluationReportRecord;
+  }>({
+    queryName: 'GetEvaluationReport',
+    serviceOptions: { name: reportName },
+    clientOptions: { enabled: !isLoading && Boolean(reportName) },
+  });
+
+  if (isLoading || isReportLoading) {
+    return (
+      <div
+        className={css({ display: 'flex', flexDirection: 'column', gap: theme.sizing.scale600 })}
+      >
+        <Skeleton animation height="24px" width="240px" />
+        <Skeleton animation height="80px" width="100%" />
+      </div>
+    );
+  }
+
+  if (!reportName) {
+    return (
+      <ParagraphMedium margin="0">
+        No performance report is available for this model.
+      </ParagraphMedium>
+    );
+  }
+
+  const report = reportData?.evaluationReport;
+  const charts: ChartRecord[] = report?.spec?.charts ?? [];
+
+  return (
+    <div className={css({ display: 'flex', flexDirection: 'column', gap: theme.sizing.scale600 })}>
+      {report?.spec?.title && (
+        <HeadingSmall marginTop="0" marginBottom={theme.sizing.scale600}>
+          {report.spec.title}
+        </HeadingSmall>
+      )}
+      {charts.length === 0 ? (
+        <ParagraphMedium margin="0">This report has no charts.</ParagraphMedium>
+      ) : (
+        <ul className={css({ margin: 0, paddingLeft: theme.sizing.scale600 })}>
+          {charts.map((chart, index) => (
+            <li key={chart.title ?? index}>
+              <ParagraphMedium margin="0">{chart.title ?? 'Untitled chart'}</ParagraphMedium>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/javascript/packages/core/config/entities/model/model.ts
+++ b/javascript/packages/core/config/entities/model/model.ts
@@ -1,3 +1,4 @@
+import { MODEL_DETAIL_CONFIG } from './detail';
 import { MODEL_LIST_CONFIG } from './list';
 
 import type { PhaseEntityConfig } from '#core/types/common/studio-types';
@@ -7,5 +8,5 @@ export const MODEL_ENTITY_CONFIG: PhaseEntityConfig = {
   name: 'Trained Models',
   service: 'model',
   state: 'active',
-  views: [MODEL_LIST_CONFIG],
+  views: [MODEL_LIST_CONFIG, MODEL_DETAIL_CONFIG],
 };

--- a/javascript/packages/core/config/entities/model/types.ts
+++ b/javascript/packages/core/config/entities/model/types.ts
@@ -1,0 +1,26 @@
+/** Shape of a `Model` record as read by the Model detail page's custom tab components. */
+export type ModelRecord = {
+  metadata?: { name?: string };
+  spec?: {
+    description?: string;
+    sourcePipelineRun?: { name?: string };
+    performanceEvaluationReport?: { name?: string };
+  };
+};
+
+/** An evaluation report resource, referenced by a model's Performance tab. */
+export type EvaluationReportRecord = {
+  spec?: {
+    title?: string;
+    charts?: ChartRecord[];
+  };
+};
+
+/**
+ * One chart in an evaluation report. Only `title` is used today — rendering a chart's actual
+ * content (as a table, line chart, histogram, etc., depending on its type) is a separate,
+ * not-yet-implemented piece of work.
+ */
+export type ChartRecord = {
+  title?: string;
+};

--- a/javascript/packages/rpc/handlers.ts
+++ b/javascript/packages/rpc/handlers.ts
@@ -59,6 +59,8 @@ async function createHandlers() {
     UpdatePipelineRun: (record: PipelineRun, headers?: Record<string, string>) =>
       services.PipelineRunService.updatePipelineRun({ pipelineRun: record }, headers),
     ListModel: unary(services.ModelService.listModel),
+    GetModel: unary(services.ModelService.getModel),
+    GetEvaluationReport: unary(services.EvaluationReportService.getEvaluationReport),
   } as const;
 }
 

--- a/javascript/packages/rpc/services.ts
+++ b/javascript/packages/rpc/services.ts
@@ -3,6 +3,7 @@ import { create, createRegistry, fromJson, toJson } from '@bufbuild/protobuf';
 import { createFetchTransport } from './create-fetch-transport';
 import { TypedStructSchema } from './gen/michelangelo/api/typed_struct_pb';
 import { DeploymentService } from './gen/michelangelo/api/v2/deployment_svc_pb';
+import { EvaluationReportService } from './gen/michelangelo/api/v2/evaluation_report_svc_pb';
 import { InferenceServerService } from './gen/michelangelo/api/v2/inference_server_svc_pb';
 import { ModelService } from './gen/michelangelo/api/v2/model_svc_pb';
 import { PipelineRunService } from './gen/michelangelo/api/v2/pipeline_run_svc_pb';
@@ -66,6 +67,7 @@ async function createServices(): Promise<Services> {
     PipelineRunService: createServiceClient(PipelineRunService, transport),
     TriggerRunService: createServiceClient(TriggerRunService, transport),
     ModelService: createServiceClient(ModelService, transport),
+    EvaluationReportService: createServiceClient(EvaluationReportService, transport),
   } as const;
 }
 

--- a/javascript/packages/rpc/types.ts
+++ b/javascript/packages/rpc/types.ts
@@ -7,6 +7,7 @@ import type {
   MessageShape,
 } from '@bufbuild/protobuf';
 import type { DeploymentService } from './gen/michelangelo/api/v2/deployment_svc_pb';
+import type { EvaluationReportService } from './gen/michelangelo/api/v2/evaluation_report_svc_pb';
 import type { InferenceServerService } from './gen/michelangelo/api/v2/inference_server_svc_pb';
 import type { ModelService } from './gen/michelangelo/api/v2/model_svc_pb';
 import type { PipelineRunService } from './gen/michelangelo/api/v2/pipeline_run_svc_pb';
@@ -67,6 +68,7 @@ export type Services = {
   PipelineRunService: ServiceClient<typeof PipelineRunService>;
   TriggerRunService: ServiceClient<typeof TriggerRunService>;
   ModelService: ServiceClient<typeof ModelService>;
+  EvaluationReportService: ServiceClient<typeof EvaluationReportService>;
 };
 
 /**


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Trained models previously had only a list view — clicking into one had nowhere to go. This adds
a detail view for the Model entity with two tabs and a filled-out header row:

- **Header row** — source pipeline run (linked), owner, creation time, last updated, and type.
- **Information tab** — a link to the pipeline run that produced the model, and the model's
  free-text description.
- **Performance tab** — resolves the model's referenced evaluation report (`GetEvaluationReport`)
  and lists the titles of the charts it contains.

Also adds a top margin to the shared `DetailView` layout so page content isn't flush against the
sticky navigation bar above it — a pre-existing gap that applies to every entity's detail page,
not just Model's, fixed here since this PR is what surfaced it.

Known limitations, intentionally left as follow-up work:
- The Information tab does not yet show which deployments are currently running this model —
  that needs its own cross-entity query against the deployment service with its own
  loading/empty/table-row states.
- The Performance tab renders chart *titles* only. Rendering a chart's actual content (as a
  table, line chart, histogram, etc., depending on its type) needs a per-chart-type rendering
  approach and, for non-table chart types, a charting library — neither of which exist in this
  codebase yet. This PR proves out the fetch/loading/empty-state plumbing ahead of that work.

**Why?**

Trained models are a core Studio entity, but there was no way to drill into one. Landing the
detail-view registration, header metadata, the Information tab, and the evaluation-report fetch
as one reviewable unit unblocks further tabs (a deployments table, richer chart rendering) as
smaller, independently reviewable follow-ups.

**How did you test it?**

- Added integration-style tests to `packages/core/config/entities/model/__tests__/model-page.test.tsx`
  that render through `EntityDetailRoute` and mock only the RPC boundary (`GetModel`,
  `GetEvaluationReport`), covering: the header metadata row (source-run link, owner, type),
  description rendering (present/absent), the source-pipeline-run link, "no performance report
  configured", chart titles listed from a fetched report, and "report has no charts".
- `yarn typecheck`, `yarn test` (full `packages/core` suite — 146 files / 1347 tests), and
  `yarn lint` all pass for the changed package; `yarn format` reports no diff.

**Potential risks**

Low — this adds a new `views` entry to `MODEL_ENTITY_CONFIG`, two new files, and a `marginTop`
on the shared `DetailView` wrapper (affects spacing on every entity's detail page, verified
against existing tests with no failures). No existing behavior otherwise changes.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

N/A

**Documentation Changes**

N/A
