### PR TITLE
fix(native_transform): use proper ceiling division for stats batch_count

### DIFF
--- a/python/michelangelo/uniflow/plugins/ray/native_transform.py
+++ b/python/michelangelo/uniflow/plugins/ray/native_transform.py
@@ -191,7 +191,9 @@ def compute_numerical_statistics(
     # ray_data_df.aggregate() with zero aggregators crashes inside Ray
     # (assert self._columns in table_block.py, surfaced as
     # RayTaskError(AssertionError)).
-    batch_count = -(-len(aggregate_fns) // numerical_statistics_batch_fn_size)
+    batch_count = (
+        len(aggregate_fns) + numerical_statistics_batch_fn_size - 1
+    ) // numerical_statistics_batch_fn_size
     for i in range(batch_count):
         batch = aggregate_fns[
             i * numerical_statistics_batch_fn_size : (i + 1)

--- a/python/michelangelo/uniflow/plugins/ray/native_transform.py
+++ b/python/michelangelo/uniflow/plugins/ray/native_transform.py
@@ -186,11 +186,11 @@ def compute_numerical_statistics(
     if not aggregate_fns:
         return numerical_stats
 
-    # Ceiling division: `// + 1` would add a guaranteed-empty trailing batch
-    # whenever len(aggregate_fns) is an exact multiple of the batch size, and
-    # ray_data_df.aggregate() with zero aggregators crashes inside Ray
-    # (assert self._columns in table_block.py, surfaced as
-    # RayTaskError(AssertionError)).
+    # `// + 1` adds a guaranteed-empty trailing batch whenever len(aggregate_fns)
+    # is an exact multiple of the batch size, and ray_data_df.aggregate() with
+    # zero aggregators crashes inside Ray (assert self._columns in
+    # table_block.py, surfaced as RayTaskError(AssertionError)) -- must be
+    # exact ceiling division, not // + 1.
     batch_count = (
         len(aggregate_fns) + numerical_statistics_batch_fn_size - 1
     ) // numerical_statistics_batch_fn_size

--- a/python/michelangelo/uniflow/plugins/ray/native_transform.py
+++ b/python/michelangelo/uniflow/plugins/ray/native_transform.py
@@ -186,7 +186,12 @@ def compute_numerical_statistics(
     if not aggregate_fns:
         return numerical_stats
 
-    batch_count = len(aggregate_fns) // numerical_statistics_batch_fn_size + 1
+    # Ceiling division: `// + 1` would add a guaranteed-empty trailing batch
+    # whenever len(aggregate_fns) is an exact multiple of the batch size, and
+    # ray_data_df.aggregate() with zero aggregators crashes inside Ray
+    # (assert self._columns in table_block.py, surfaced as
+    # RayTaskError(AssertionError)).
+    batch_count = -(-len(aggregate_fns) // numerical_statistics_batch_fn_size)
     for i in range(batch_count):
         batch = aggregate_fns[
             i * numerical_statistics_batch_fn_size : (i + 1)

--- a/python/michelangelo/uniflow/plugins/ray/tests/native_transform_test.py
+++ b/python/michelangelo/uniflow/plugins/ray/tests/native_transform_test.py
@@ -245,7 +245,15 @@ class ComputeNumericalStatisticsTests(unittest.TestCase):
         self.assertEqual(result, {})
 
     def test_batches_aggregate_calls(self):
-        """Batches aggregate calls."""
+        """Batches aggregate calls.
+
+        2 aggregate fns (max, min) with a batch size of 1 must produce
+        exactly 2 non-empty batches/calls — not 3. (A prior version of this
+        test used a single aggregate fn with batch size 1, which happened to
+        pass under the old buggy `// batch_fn_size + 1` bound because that
+        formula's extra empty trailing batch was harmless with a mock
+        `return_value`; it would have crashed against real Ray, per GAP-006.)
+        """
         mock_dataset = MagicMock()
         mock_dataset.select_columns.return_value = mock_dataset
         mock_dataset.aggregate.return_value = {}
@@ -253,7 +261,7 @@ class ComputeNumericalStatisticsTests(unittest.TestCase):
             "col1": {
                 "percentiles": [],
                 "max": True,
-                "min": False,
+                "min": True,
                 "mean": False,
                 "std": False,
             }
@@ -318,6 +326,66 @@ class ComputeNumericalStatisticsTests(unittest.TestCase):
                 numerical_statistics_batch_fn_size=2,
             )
 
+        expected_keys = {
+            f"{col}_{stat}"
+            for col in ("col1", "col2")
+            for stat in ("max", "min", "mean", "std")
+        }
+        self.assertEqual(set(result.keys()), expected_keys)
+
+    def test_batch_count_does_not_add_empty_trailing_batch_on_exact_multiple(self):
+        """No empty batch when aggregate_fns is an exact multiple of the batch size.
+
+        Two columns x 4 aggregate fns each = 8 total, with a batch size of 4:
+        len(aggregate_fns) % batch_fn_size == 0. `// batch_fn_size + 1` would
+        add a third, empty batch, and calling ray_data_df.aggregate() with no
+        aggregators crashes inside Ray (assert self._columns in
+        table_block.py). aggregate() must be called exactly twice, never with
+        an empty argument list.
+        """
+
+        class _FakeAggFn:
+            def __init__(self, input_col, alias_name=None, **_kwargs):
+                self.input_col = input_col
+                self.alias_name = alias_name
+
+        def _aggregate(*fns):
+            assert fns, "aggregate() must never be called with zero aggregators"
+            return {fn.alias_name: 1.0 for fn in fns}
+
+        mock_dataset = MagicMock()
+        mock_dataset.select_columns.return_value = mock_dataset
+        mock_dataset.aggregate.side_effect = _aggregate
+        specs = {
+            "col1": {
+                "percentiles": [],
+                "max": True,
+                "min": True,
+                "mean": True,
+                "std": True,
+            },
+            "col2": {
+                "percentiles": [],
+                "max": True,
+                "min": True,
+                "mean": True,
+                "std": True,
+            },
+        }
+
+        mock_aggregate = MagicMock()
+        mock_aggregate.Max = mock_aggregate.Min = mock_aggregate.Mean = (
+            mock_aggregate.Std
+        ) = _FakeAggFn
+        with patch.dict("sys.modules", {"ray.data.aggregate": mock_aggregate}):
+            result = compute_numerical_statistics(
+                mock_dataset,
+                existing_numerical_stats={},
+                numerical_statistics_computation_specs=specs,
+                numerical_statistics_batch_fn_size=4,
+            )
+
+        self.assertEqual(mock_dataset.aggregate.call_count, 2)
         expected_keys = {
             f"{col}_{stat}"
             for col in ("col1", "col2")

--- a/python/michelangelo/uniflow/plugins/ray/tests/native_transform_test.py
+++ b/python/michelangelo/uniflow/plugins/ray/tests/native_transform_test.py
@@ -285,63 +285,13 @@ class ComputeNumericalStatisticsTests(unittest.TestCase):
         total, while there are only 2 specs. With a batch size of 2, a
         batch_count derived from spec count would only cover the first 4
         aggregate fns, silently dropping the rest.
-        """
 
-        class _FakeAggFn:
-            def __init__(self, input_col, alias_name=None, **_kwargs):
-                self.input_col = input_col
-                self.alias_name = alias_name
-
-        mock_dataset = MagicMock()
-        mock_dataset.select_columns.return_value = mock_dataset
-        mock_dataset.aggregate.side_effect = lambda *fns: {
-            fn.alias_name: 1.0 for fn in fns
-        }
-        specs = {
-            "col1": {
-                "percentiles": [],
-                "max": True,
-                "min": True,
-                "mean": True,
-                "std": True,
-            },
-            "col2": {
-                "percentiles": [],
-                "max": True,
-                "min": True,
-                "mean": True,
-                "std": True,
-            },
-        }
-
-        mock_aggregate = MagicMock()
-        mock_aggregate.Max = mock_aggregate.Min = mock_aggregate.Mean = (
-            mock_aggregate.Std
-        ) = _FakeAggFn
-        with patch.dict("sys.modules", {"ray.data.aggregate": mock_aggregate}):
-            result = compute_numerical_statistics(
-                mock_dataset,
-                existing_numerical_stats={},
-                numerical_statistics_computation_specs=specs,
-                numerical_statistics_batch_fn_size=2,
-            )
-
-        expected_keys = {
-            f"{col}_{stat}"
-            for col in ("col1", "col2")
-            for stat in ("max", "min", "mean", "std")
-        }
-        self.assertEqual(set(result.keys()), expected_keys)
-
-    def test_batch_count_does_not_add_empty_trailing_batch_on_exact_multiple(self):
-        """No empty batch when aggregate_fns is an exact multiple of the batch size.
-
-        Two columns x 4 aggregate fns each = 8 total, with a batch size of 4:
-        len(aggregate_fns) % batch_fn_size == 0. `// batch_fn_size + 1` would
-        add a third, empty batch, and calling ray_data_df.aggregate() with no
-        aggregators crashes inside Ray (assert self._columns in
-        table_block.py). aggregate() must be called exactly twice, never with
-        an empty argument list.
+        8 fns at a batch size of 2 is also an exact multiple (4 batches, no
+        remainder), so this doubles as the regression case for `// + 1`
+        adding a guaranteed-empty trailing batch: aggregate() must never be
+        called with zero aggregators (that crashes inside Ray, see
+        table_block.py's `assert self._columns`), and must be called exactly
+        4 times.
         """
 
         class _FakeAggFn:
@@ -382,10 +332,10 @@ class ComputeNumericalStatisticsTests(unittest.TestCase):
                 mock_dataset,
                 existing_numerical_stats={},
                 numerical_statistics_computation_specs=specs,
-                numerical_statistics_batch_fn_size=4,
+                numerical_statistics_batch_fn_size=2,
             )
 
-        self.assertEqual(mock_dataset.aggregate.call_count, 2)
+        self.assertEqual(mock_dataset.aggregate.call_count, 4)
         expected_keys = {
             f"{col}_{stat}"
             for col in ("col1", "col2")


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

`compute_numerical_statistics`'s `batch_count` now uses proper ceiling division (`(n + s - 1) // s`) instead of `n // s + 1`, which added a guaranteed-empty trailing batch whenever `len(aggregate_fns)` was an exact multiple of the batch size. Also folded a duplicate test's empty-batch guard into the existing exact-multiple-case test instead of keeping two nearly-identical tests.

<!-- Tell your future self why have you made these changes -->
**Why?**

`ray_data_df.aggregate()` crashes inside Ray when called with zero aggregators (`assert self._columns` in `table_block.py`, surfaced as `RayTaskError(AssertionError)`). E.g. 125 columns each needing max/min/mean/std is exactly 500 aggregate functions against a default batch size of 500 -- the old formula added a 3rd, empty batch and crashed. This was a regression from #1773's review cycle, which switched `batch_count` to derive from `len(aggregate_fns)` instead of the column-spec count; the spec-based divisor almost never divided evenly, so the exact-multiple case never surfaced until now.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

- `pytest python/michelangelo/uniflow/plugins/ray/` (excluding real-Ray-cluster integration tests): 114 passed.
- Added a regression test asserting `aggregate()` is never called with zero aggregators, using 8 aggregate functions with a batch size of 2/4 (the exact-multiple case) -- confirmed it fails against the old `// + 1` formula and passes against the fix.
- Fixed a pre-existing test (`test_batches_aggregate_calls`) that was inadvertently asserting the buggy behavior (2 calls for what should be 1, with the second an empty call that only avoided crashing because it used a mock instead of real Ray).
- `ruff format --check` / `ruff check` on touched files: clean.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

None -- this only affects batch sizing for internal aggregation calls; output values are unchanged, and the fix strictly removes an invalid empty batch rather than altering any real batch's contents.

<!-- Does this PR introduce a breaking change? Check all that apply. -->
**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

N/A

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**

N/A
