### PR TITLE
feat(native_transform): add tabular_native_transform workflow task

### DIFF
--- a/python/michelangelo/uniflow/plugins/ray/data_context.py
+++ b/python/michelangelo/uniflow/plugins/ray/data_context.py
@@ -1,0 +1,125 @@
+"""Ray ``DataContext`` tuning shared across Ray-based workflow tasks.
+
+Configures Ray Data block sizing, I/O retry patterns, and streaming-executor
+memory/scheduling knobs. This is a general-purpose Ray Data helper — not
+specific to any single workflow task — so it lives alongside the other Ray
+plugin utilities (:mod:`~michelangelo.uniflow.plugins.ray.io`,
+:mod:`~michelangelo.uniflow.plugins.ray.native_transform`) rather than being
+duplicated into each task that reads large Parquet datasets via Ray Data.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import ray
+
+_logger = logging.getLogger(__name__)
+
+__all__ = ["RETRIED_IO_ERRORS", "set_ray_data_context"]
+
+
+RETRIED_IO_ERRORS = [
+    "OSError: Could not open Parquet input source",
+    "Failed to get file info for",
+    "Error opening input stream",
+]
+"""Transient I/O error message substrings that Ray Data should retry.
+
+These occur against distributed/object-store filesystem backends (e.g. S3,
+GCS, or an on-prem distributed filesystem) when the backend is saturated by
+large file counts, or during credential refresh / connection drops.
+"""
+
+
+def set_ray_data_context(
+    min_block_size: int | None = None,
+    max_block_size: int | None = None,
+    retried_io_errors: list[str] | None = None,
+    object_store_memory_limit: int | None = None,
+    wait_for_min_actors_s: int | None = None,
+) -> None:
+    """Configure Ray ``DataContext`` with block sizes and retried I/O error patterns.
+
+    Shared utility for Ray-based workflow steps (native transform, trainer,
+    inference, etc.) that use Ray Data for Parquet I/O over a distributed or
+    object-store filesystem.
+
+    Args:
+        min_block_size: Target min block size in bytes. If ``None``, Ray's
+            default is used.
+        max_block_size: Target max block size in bytes. If ``None``, Ray's
+            default is used.
+        retried_io_errors: Additional I/O error patterns to retry on. If
+            ``None``, uses the default patterns in :data:`RETRIED_IO_ERRORS`.
+            Pass an empty list to skip adding extra patterns beyond Ray's own
+            defaults.
+        object_store_memory_limit: Upper bound in bytes on the object store
+            memory the streaming executor may use for buffered (pending)
+            blocks across all operators. When buffered output reaches this
+            size, upstream read tasks are backpressured and stop launching
+            until a downstream operator (e.g. a GPU predictor) drains
+            blocks. This bounds the worst-case memory peak: during actor
+            warmup the predictor consumes nothing, so without a bound the
+            readers fill the entire object store and keep decompressing,
+            then the actor model loads land on top and OOM-kill the node.
+            ``None`` leaves Ray's default (unbounded, i.e. capped only by
+            the physical object store).
+        wait_for_min_actors_s: Seconds the executor blocks for an actor-pool
+            operator's actors to finish provisioning (model load) before it
+            begins scheduling upstream read tasks. This decouples actor
+            warmup from reader ramp-up: the model loads (large transient
+            memory) happen first, then readers start, so the two memory
+            peaks never overlap and OOM the node. ``None`` keeps Ray's
+            default (no wait; actors provision asynchronously while reads
+            run, which lets readers race the warmup).
+    """
+    ctx = ray.data.DataContext.get_current()
+    # Only override block sizes when explicitly provided; otherwise keep Ray's
+    # auto-tuned defaults.
+    if min_block_size is not None:
+        ctx.target_min_block_size = min_block_size
+    if max_block_size is not None:
+        ctx.target_max_block_size = max_block_size
+
+    extra_errors = (
+        retried_io_errors if retried_io_errors is not None else RETRIED_IO_ERRORS
+    )
+    if extra_errors:
+        ctx.retried_io_errors = [
+            *ctx.retried_io_errors,
+            *extra_errors,
+        ]
+
+    # Cap the executor's buffered-block budget so readers backpressure instead of
+    # racing an actor pool's warmup and OOM-killing the node. See the arg
+    # docstring for the failure mode.
+    # ExecutionResources.object_store_memory is a read-only property on this Ray
+    # version, so we replace resource_limits with a new instance (the setter
+    # fills the unset cpu/gpu/memory fields with inf, leaving them unbounded)
+    # rather than assigning the property in place.
+    if object_store_memory_limit is not None:
+        limits = ctx.execution_options.resource_limits
+        ctx.execution_options.resource_limits = type(limits)(
+            object_store_memory=object_store_memory_limit
+        )
+
+    # Make actor-pool operators block on model load before reads are scheduled, so
+    # reader heap and actor model-load memory don't peak at the same time.
+    if wait_for_min_actors_s is not None:
+        ctx.wait_for_min_actors_s = wait_for_min_actors_s
+
+    _logger.info(
+        "Ray data context set: target_min_block_size=%s MB, "
+        "target_max_block_size=%s MB, object_store_memory_limit=%s, "
+        "wait_for_min_actors_s=%s, retried_io_errors=%s",
+        f"{ctx.target_min_block_size / (1024 * 1024):.0f}"
+        if ctx.target_min_block_size
+        else "ray-default",
+        f"{ctx.target_max_block_size / (1024 * 1024):.0f}"
+        if ctx.target_max_block_size
+        else "ray-default",
+        object_store_memory_limit,
+        wait_for_min_actors_s,
+        ctx.retried_io_errors,
+    )

--- a/python/michelangelo/uniflow/plugins/ray/data_context.py
+++ b/python/michelangelo/uniflow/plugins/ray/data_context.py
@@ -86,10 +86,12 @@ def set_ray_data_context(
         retried_io_errors if retried_io_errors is not None else RETRIED_IO_ERRORS
     )
     if extra_errors:
-        ctx.retried_io_errors = [
-            *ctx.retried_io_errors,
-            *extra_errors,
-        ]
+        # Ray's DataContext is a process-global singleton, so repeated calls in
+        # one driver process (retries, multiple pipeline steps) must not keep
+        # appending duplicate patterns onto it -- dedupe while preserving order.
+        ctx.retried_io_errors = list(
+            dict.fromkeys([*ctx.retried_io_errors, *extra_errors])
+        )
 
     # Cap the executor's buffered-block budget so readers backpressure instead of
     # racing an actor pool's warmup and OOM-killing the node. See the arg

--- a/python/michelangelo/uniflow/plugins/ray/io.py
+++ b/python/michelangelo/uniflow/plugins/ray/io.py
@@ -153,28 +153,37 @@ class RayDatasetIO(IO[Dataset]):
         1
     """
 
-    def write(self, url: str, value: Dataset) -> None:
+    def write(self, url: str, value: Dataset, **write_kwargs: Any) -> None:
         """Write *value* to *url* as Parquet files.
 
         Args:
             url: Destination directory path or URL (local, ``s3://``, etc.).
                 Ray writes multiple shard files under this directory.
             value: Ray Dataset to write.
+            **write_kwargs: Additional kwargs forwarded to
+                ``Dataset.write_parquet`` (e.g. ``max_rows_per_file``,
+                ``min_rows_per_file``). Must not set ``filesystem``, which
+                this method always supplies itself.
 
         Returns:
             ``None`` — no metadata needed for the read path.
         """
         fs, root = _fs_path(url)
-        value.write_parquet(root, filesystem=fs)
+        value.write_parquet(root, filesystem=fs, **write_kwargs)
         _logger.info("RayDatasetIO: wrote dataset to '%s'.", url)
         return None
 
-    def read(self, url: str, _metadata: Any | None) -> Dataset:
+    def read(self, url: str, _metadata: Any | None, **read_kwargs: Any) -> Dataset:
         """Read a Ray Dataset from *url*, skipping empty parquet files.
 
         Args:
             url: Source directory path or URL.
             _metadata: Unused; pass ``None``.
+            **read_kwargs: Additional kwargs forwarded to
+                ``ray.data.read_parquet`` (e.g. as produced by
+                :func:`~michelangelo.uniflow.plugins.ray.parquet_io.parquet_read_config_to_kwargs`).
+                Must not set ``filesystem`` or ``file_extensions``, which
+                this method always supplies itself.
 
         Returns:
             Ray Dataset loaded from Parquet shards under *url*.
@@ -188,7 +197,7 @@ class RayDatasetIO(IO[Dataset]):
             raise FileNotFoundError(f"RayDatasetIO: no parquet files found at '{url}'.")
         try:
             ds = ray.data.read_parquet(
-                paths, filesystem=fs, file_extensions=["parquet"]
+                paths, filesystem=fs, file_extensions=["parquet"], **read_kwargs
             )
             _logger.info("RayDatasetIO: read %d file(s) from '%s'.", len(paths), url)
             return ds

--- a/python/michelangelo/uniflow/plugins/ray/parquet_io.py
+++ b/python/michelangelo/uniflow/plugins/ray/parquet_io.py
@@ -1,0 +1,88 @@
+"""Generic conversion of a Parquet-read config object into ``read_parquet`` kwargs.
+
+Not specific to any single workflow task — any task-level "parquet read
+config" dataclass (or pydantic model) can be converted, which is why this
+accepts a loosely-typed object rather than a single concrete config class.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+from typing import Any
+
+import ray
+from packaging import version
+
+_logger = logging.getLogger(__name__)
+
+__all__ = ["parquet_read_config_to_kwargs"]
+
+
+def _config_to_dict(prc: Any) -> dict[str, Any]:
+    """Flatten a parquet-read config object into a plain dict, dropping ``None``.
+
+    Supports plain ``dataclasses.dataclass`` instances (the convention used
+    by this repo's own workflow config schemas) and pydantic models (via
+    ``model_dump``), so callers are not forced onto one particular config
+    style.
+
+    Raises:
+        TypeError: If ``prc`` is neither a dataclass instance nor an object
+            exposing ``model_dump``.
+    """
+    if dataclasses.is_dataclass(prc) and not isinstance(prc, type):
+        return {k: v for k, v in dataclasses.asdict(prc).items() if v is not None}
+    if hasattr(prc, "model_dump"):
+        return prc.model_dump(exclude_none=True)
+    raise TypeError(
+        f"Cannot convert {type(prc).__name__} to read_parquet kwargs: expected a "
+        "dataclass instance or a pydantic model with model_dump()."
+    )
+
+
+def parquet_read_config_to_kwargs(
+    prc: Any | None, dataset_name: str | None = None
+) -> dict[str, Any]:
+    """Convert a parquet-read config object to ``ray.data.read_parquet`` kwargs.
+
+    Handles the Ray 2.50 API change where ``num_cpus``, ``num_gpus``, and
+    ``memory`` moved from ``ray_remote_args`` to top-level ``read_parquet``
+    kwargs, and flattens an ``arrow_parquet_args`` mapping into top-level keys
+    for the PyArrow reader.
+
+    Args:
+        prc: A parquet-read config object (dataclass instance or pydantic
+            model). ``None`` preserves Ray's defaults (an empty kwargs dict
+            is returned).
+        dataset_name: Selects the entry to use from an optional
+            ``override_num_blocks_per_dataset`` mapping field on ``prc``, if
+            present. Ignored when ``prc`` has no such field.
+
+    Returns:
+        A kwargs dict ready to splat into ``ray.data.read_parquet(**kwargs)``.
+    """
+    read_kwargs = _config_to_dict(prc) if prc is not None else {}
+
+    per_dataset_overrides = read_kwargs.pop("override_num_blocks_per_dataset", None)
+    if per_dataset_overrides is not None:
+        override = (
+            per_dataset_overrides.get(dataset_name)
+            if dataset_name is not None
+            else None
+        )
+        if override is not None:
+            read_kwargs["override_num_blocks"] = override
+        else:
+            read_kwargs.pop("override_num_blocks", None)
+
+    if version.parse(ray.__version__) < version.parse("2.50"):
+        ray_remote_args = read_kwargs.pop("ray_remote_args", None) or {}
+        for key in ("num_cpus", "num_gpus", "memory"):
+            if key in read_kwargs:
+                ray_remote_args[key] = read_kwargs.pop(key)
+        if ray_remote_args:
+            read_kwargs["ray_remote_args"] = ray_remote_args
+
+    read_kwargs.update(read_kwargs.pop("arrow_parquet_args", None) or {})
+    return read_kwargs

--- a/python/michelangelo/uniflow/plugins/ray/tests/data_context_test.py
+++ b/python/michelangelo/uniflow/plugins/ray/tests/data_context_test.py
@@ -1,0 +1,80 @@
+"""Tests for michelangelo.uniflow.plugins.ray.data_context."""
+
+from __future__ import annotations
+
+from unittest import TestCase
+
+import ray
+
+from michelangelo.uniflow.plugins.ray.data_context import (
+    RETRIED_IO_ERRORS,
+    set_ray_data_context,
+)
+
+
+class SetRayDataContextTest(TestCase):
+    """Tests for set_ray_data_context."""
+
+    def setUp(self):
+        """Reset Ray's DataContext to defaults before each test."""
+        ray.data.DataContext._set_current(ray.data.DataContext())
+
+    def tearDown(self):
+        """Reset Ray's DataContext to defaults after each test."""
+        ray.data.DataContext._set_current(ray.data.DataContext())
+
+    def test_no_args_leaves_block_sizes_untouched(self):
+        """Calling with no arguments leaves Ray's default block sizes."""
+        ctx = ray.data.DataContext.get_current()
+        default_min = ctx.target_min_block_size
+        default_max = ctx.target_max_block_size
+        set_ray_data_context()
+        self.assertEqual(ctx.target_min_block_size, default_min)
+        self.assertEqual(ctx.target_max_block_size, default_max)
+
+    def test_block_sizes_are_applied_when_given(self):
+        """Explicit min/max block sizes override Ray's defaults."""
+        set_ray_data_context(min_block_size=1024, max_block_size=2048)
+        ctx = ray.data.DataContext.get_current()
+        self.assertEqual(ctx.target_min_block_size, 1024)
+        self.assertEqual(ctx.target_max_block_size, 2048)
+
+    def test_default_retried_io_errors_are_appended(self):
+        """With no override, the module's default retry patterns are appended."""
+        ctx = ray.data.DataContext.get_current()
+        before = list(ctx.retried_io_errors)
+        set_ray_data_context()
+        for pattern in RETRIED_IO_ERRORS:
+            self.assertIn(pattern, ctx.retried_io_errors)
+        self.assertEqual(
+            len(ctx.retried_io_errors), len(before) + len(RETRIED_IO_ERRORS)
+        )
+
+    def test_custom_retried_io_errors_are_appended_instead(self):
+        """A custom retried_io_errors list replaces the module defaults."""
+        ctx = ray.data.DataContext.get_current()
+        before = list(ctx.retried_io_errors)
+        set_ray_data_context(retried_io_errors=["my custom error"])
+        self.assertIn("my custom error", ctx.retried_io_errors)
+        for pattern in RETRIED_IO_ERRORS:
+            self.assertNotIn(pattern, ctx.retried_io_errors)
+        self.assertEqual(len(ctx.retried_io_errors), len(before) + 1)
+
+    def test_empty_retried_io_errors_list_appends_nothing(self):
+        """An explicit empty list skips appending any extra retry patterns."""
+        ctx = ray.data.DataContext.get_current()
+        before = list(ctx.retried_io_errors)
+        set_ray_data_context(retried_io_errors=[])
+        self.assertEqual(ctx.retried_io_errors, before)
+
+    def test_object_store_memory_limit_sets_resource_limits(self):
+        """A memory limit is applied to the execution options' resource limits."""
+        set_ray_data_context(object_store_memory_limit=512)
+        ctx = ray.data.DataContext.get_current()
+        self.assertEqual(ctx.execution_options.resource_limits.object_store_memory, 512)
+
+    def test_wait_for_min_actors_s_is_applied(self):
+        """An explicit actor-warmup wait is applied to the context."""
+        set_ray_data_context(wait_for_min_actors_s=30)
+        ctx = ray.data.DataContext.get_current()
+        self.assertEqual(ctx.wait_for_min_actors_s, 30)

--- a/python/michelangelo/uniflow/plugins/ray/tests/data_context_test.py
+++ b/python/michelangelo/uniflow/plugins/ray/tests/data_context_test.py
@@ -78,3 +78,19 @@ class SetRayDataContextTest(TestCase):
         set_ray_data_context(wait_for_min_actors_s=30)
         ctx = ray.data.DataContext.get_current()
         self.assertEqual(ctx.wait_for_min_actors_s, 30)
+
+    def test_repeated_calls_do_not_duplicate_retried_io_errors(self):
+        """Calling twice with overlapping patterns does not grow the list unboundedly.
+
+        DataContext is a process-global singleton, so a driver process that
+        calls this more than once (retries, multiple pipeline steps) must not
+        accumulate duplicate patterns indefinitely.
+        """
+        ctx = ray.data.DataContext.get_current()
+        before = list(ctx.retried_io_errors)
+        set_ray_data_context(retried_io_errors=["shared error", "first-only error"])
+        set_ray_data_context(retried_io_errors=["shared error", "second-only error"])
+        self.assertEqual(
+            ctx.retried_io_errors,
+            [*before, "shared error", "first-only error", "second-only error"],
+        )

--- a/python/michelangelo/uniflow/plugins/ray/tests/parquet_io_test.py
+++ b/python/michelangelo/uniflow/plugins/ray/tests/parquet_io_test.py
@@ -1,0 +1,116 @@
+"""Tests for michelangelo.uniflow.plugins.ray.parquet_io."""
+
+from __future__ import annotations
+
+import dataclasses
+from unittest import TestCase
+from unittest.mock import patch
+
+from michelangelo.uniflow.plugins.ray.parquet_io import (
+    _config_to_dict,
+    parquet_read_config_to_kwargs,
+)
+
+
+@dataclasses.dataclass
+class _FakeParquetReadConfig:
+    """A minimal dataclass-based stand-in for a parquet-read config."""
+
+    concurrency: int | None = None
+    num_cpus: int | None = None
+    num_gpus: int | None = None
+    memory: int | None = None
+    arrow_parquet_args: dict | None = None
+    override_num_blocks_per_dataset: dict | None = None
+
+
+class _FakePydanticParquetReadConfig:
+    """A minimal pydantic-like stand-in exposing only ``model_dump``."""
+
+    def __init__(self, **kwargs):
+        """Store the given fields for later ``model_dump``."""
+        self._fields = kwargs
+
+    def model_dump(self, exclude_none: bool = False):
+        """Return the stored fields, dropping ``None`` values if requested."""
+        if exclude_none:
+            return {k: v for k, v in self._fields.items() if v is not None}
+        return dict(self._fields)
+
+
+class ConfigToDictTest(TestCase):
+    """Tests for _config_to_dict."""
+
+    def test_dataclass_instance_drops_none_fields(self):
+        """A dataclass instance is flattened, dropping None-valued fields."""
+        result = _config_to_dict(_FakeParquetReadConfig(concurrency=4))
+        self.assertEqual(result, {"concurrency": 4})
+
+    def test_pydantic_like_object_uses_model_dump(self):
+        """An object with model_dump() is converted via that method."""
+        result = _config_to_dict(_FakePydanticParquetReadConfig(concurrency=2))
+        self.assertEqual(result, {"concurrency": 2})
+
+    def test_unsupported_type_raises_type_error(self):
+        """An object with neither dataclass fields nor model_dump() raises."""
+        with self.assertRaises(TypeError):
+            _config_to_dict(object())
+
+
+class ParquetReadConfigToKwargsTest(TestCase):
+    """Tests for parquet_read_config_to_kwargs."""
+
+    def test_none_config_returns_empty_kwargs(self):
+        """A None config returns an empty kwargs dict (Ray's own defaults)."""
+        self.assertEqual(parquet_read_config_to_kwargs(None), {})
+
+    def test_basic_fields_pass_through(self):
+        """Plain scalar fields pass through unchanged."""
+        result = parquet_read_config_to_kwargs(_FakeParquetReadConfig(concurrency=4))
+        self.assertEqual(result, {"concurrency": 4})
+
+    def test_arrow_parquet_args_flattened_to_top_level(self):
+        """arrow_parquet_args entries are merged into the top-level kwargs."""
+        config = _FakeParquetReadConfig(
+            concurrency=4, arrow_parquet_args={"batch_size": 100}
+        )
+        result = parquet_read_config_to_kwargs(config)
+        self.assertEqual(result, {"concurrency": 4, "batch_size": 100})
+
+    def test_override_num_blocks_per_dataset_selected_by_name(self):
+        """The entry matching dataset_name becomes override_num_blocks."""
+        config = _FakeParquetReadConfig(
+            override_num_blocks_per_dataset={"train": 8, "validation": 2}
+        )
+        result = parquet_read_config_to_kwargs(config, dataset_name="train")
+        self.assertEqual(result, {"override_num_blocks": 8})
+
+    def test_override_num_blocks_per_dataset_no_match_drops_key(self):
+        """No matching entry for dataset_name means override_num_blocks is absent."""
+        config = _FakeParquetReadConfig(override_num_blocks_per_dataset={"train": 8})
+        result = parquet_read_config_to_kwargs(config, dataset_name="validation")
+        self.assertEqual(result, {})
+
+    def test_override_num_blocks_per_dataset_no_dataset_name_drops_key(self):
+        """No dataset_name given means override_num_blocks is absent."""
+        config = _FakeParquetReadConfig(override_num_blocks_per_dataset={"train": 8})
+        result = parquet_read_config_to_kwargs(config)
+        self.assertEqual(result, {})
+
+    @patch("michelangelo.uniflow.plugins.ray.parquet_io.ray")
+    def test_pre_2_50_moves_resource_args_into_ray_remote_args(self, mock_ray):
+        """Before Ray 2.50, num_cpus/num_gpus/memory move under ray_remote_args."""
+        mock_ray.__version__ = "2.40.0"
+        config = _FakeParquetReadConfig(num_cpus=2, num_gpus=1, memory=1024)
+        result = parquet_read_config_to_kwargs(config)
+        self.assertEqual(
+            result, {"ray_remote_args": {"num_cpus": 2, "num_gpus": 1, "memory": 1024}}
+        )
+
+    @patch("michelangelo.uniflow.plugins.ray.parquet_io.ray")
+    def test_post_2_50_keeps_resource_args_top_level(self, mock_ray):
+        """From Ray 2.50 onward, num_cpus/num_gpus/memory stay top-level kwargs."""
+        mock_ray.__version__ = "2.50.0"
+        config = _FakeParquetReadConfig(num_cpus=2, num_gpus=1, memory=1024)
+        result = parquet_read_config_to_kwargs(config)
+        self.assertEqual(result, {"num_cpus": 2, "num_gpus": 1, "memory": 1024})

--- a/python/michelangelo/uniflow/plugins/ray/tests/parquet_io_test.py
+++ b/python/michelangelo/uniflow/plugins/ray/tests/parquet_io_test.py
@@ -21,6 +21,7 @@ class _FakeParquetReadConfig:
     num_gpus: int | None = None
     memory: int | None = None
     arrow_parquet_args: dict | None = None
+    override_num_blocks: int | None = None
     override_num_blocks_per_dataset: dict | None = None
 
 
@@ -86,14 +87,23 @@ class ParquetReadConfigToKwargsTest(TestCase):
         self.assertEqual(result, {"override_num_blocks": 8})
 
     def test_override_num_blocks_per_dataset_no_match_drops_key(self):
-        """No matching entry for dataset_name means override_num_blocks is absent."""
-        config = _FakeParquetReadConfig(override_num_blocks_per_dataset={"train": 8})
+        """No matching entry for dataset_name means override_num_blocks is absent.
+
+        ``override_num_blocks`` is also set directly here (as if it were a
+        base default), to prove it actually gets dropped for the
+        non-matching dataset rather than merely being absent to begin with.
+        """
+        config = _FakeParquetReadConfig(
+            override_num_blocks=4, override_num_blocks_per_dataset={"train": 8}
+        )
         result = parquet_read_config_to_kwargs(config, dataset_name="validation")
         self.assertEqual(result, {})
 
     def test_override_num_blocks_per_dataset_no_dataset_name_drops_key(self):
         """No dataset_name given means override_num_blocks is absent."""
-        config = _FakeParquetReadConfig(override_num_blocks_per_dataset={"train": 8})
+        config = _FakeParquetReadConfig(
+            override_num_blocks=4, override_num_blocks_per_dataset={"train": 8}
+        )
         result = parquet_read_config_to_kwargs(config)
         self.assertEqual(result, {})
 

--- a/python/michelangelo/workflow/schema/common.py
+++ b/python/michelangelo/workflow/schema/common.py
@@ -1,0 +1,87 @@
+"""Config-layer incremental-training schema types shared across workflow tasks.
+
+These types are parsed directly from pipeline configuration and are
+intentionally distinct from any runtime-layer incremental-training state a
+trainer task might construct for its own model training — the two live at
+different layers (parsed configuration vs. constructed runtime state) and
+are not meant to be unified. Kept here (rather than under a single task's
+schema module) because more than one workflow task's config parsing is
+expected to reuse them, matching the shared-then-task-scoped split already
+used for e.g. ``ray_data_io.py``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+__all__ = [
+    "IncrementalTrainingConfig",
+    "TrainingTypeConfig",
+]
+
+
+class TrainingTypeConfig(str, Enum):
+    """Incremental-training mode, as parsed from pipeline configuration.
+
+    A config-layer value — distinct from (and not interchangeable with) any
+    runtime-layer incremental-training enum a trainer task might construct
+    from it. Trainer tasks that build their own runtime training state are
+    expected to derive it from their own config, not from this type.
+
+    Attributes:
+        BASE: A base run whose fitted transform can later be reused/refit by
+            an ``INCREMENTAL`` run.
+        INCREMENTAL: Reuse (and optionally selectively refit) a base run's
+            fitted transform spec and feature statistics.
+
+    Example:
+        >>> TrainingTypeConfig.INCREMENTAL.value
+        'INCREMENTAL'
+    """
+
+    BASE = "BASE"
+    INCREMENTAL = "INCREMENTAL"
+
+
+@dataclass
+class IncrementalTrainingConfig:
+    """Incremental-training configuration, as parsed from pipeline configuration.
+
+    A config-layer type read directly from pipeline configuration for the
+    consuming task. It is intentionally distinct from any runtime-layer
+    incremental-training spec a trainer task might build for its own model
+    training — the two live at different layers (parsed configuration vs.
+    constructed runtime state) and are not meant to be unified. Scoped to
+    only the fields shared by config-parsing consumers today: a more general
+    equivalent configuration (as consumed by a model-initializer-style task
+    elsewhere) would also carry fields like ``load_optimizer_weights`` and
+    ``fused_model_submodule`` that are meaningless here — this config
+    intentionally omits them rather than porting unused surface area.
+
+    Attributes:
+        training_type: Whether this run is a base run, an incremental run,
+            or neither (unset, ``None``).
+        baseline_model_uri: URI of the base run's raw model package, as
+            returned by ``StorageBackend.upload()`` — passed directly to
+            ``StorageBackend.download()`` to retrieve a base run's saved
+            state from its metadata directory. Required when
+            ``training_type == TrainingTypeConfig.INCREMENTAL``.
+        enforce_full_reuse: When ``True`` and ``training_type ==
+            TrainingTypeConfig.INCREMENTAL``, every layer in the (optional)
+            inlined transform spec must use
+            :attr:`~michelangelo.lib.native_transform.torch.transform_layer_spec.TransformerMode.REUSE`
+            (or the default ``INVALID``, which behaves as ``REUSE``) — no
+            refitting allowed. This is the only supported setting for now.
+
+    Example:
+        >>> IncrementalTrainingConfig(
+        ...     training_type=TrainingTypeConfig.INCREMENTAL,
+        ...     baseline_model_uri="s3://bucket/models/base-run/",
+        ... ).enforce_full_reuse
+        True
+    """
+
+    training_type: TrainingTypeConfig | None = None
+    baseline_model_uri: str | None = None
+    enforce_full_reuse: bool = True

--- a/python/michelangelo/workflow/schema/native_transform.py
+++ b/python/michelangelo/workflow/schema/native_transform.py
@@ -8,8 +8,11 @@ Plain ``@dataclass`` with no Pydantic dependency, matching
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from enum import Enum
 
+from michelangelo.workflow.schema.common import (
+    IncrementalTrainingConfig,
+    TrainingTypeConfig,
+)
 from michelangelo.workflow.schema.ray_data_io import (
     ParquetReadConfig,
     RayDataContextConfig,
@@ -25,76 +28,6 @@ __all__ = [
     "TrainingTypeConfig",
     "WriteConfig",
 ]
-
-
-class TrainingTypeConfig(str, Enum):
-    """Incremental-training mode for ``tabular_native_transform``.
-
-    A config-layer value, parsed directly from pipeline configuration —
-    distinct from (and not interchangeable with) any runtime-layer
-    incremental-training enum a trainer task might construct from it. Trainer
-    tasks that build their own runtime training state are expected to derive
-    it from their own config, not from this type.
-
-    Attributes:
-        INVALID: Not set; treated the same as a fresh (non-incremental) run.
-        BASE: A base run whose fitted transform can later be reused/refit by
-            an ``INCREMENTAL`` run.
-        INCREMENTAL: Reuse (and optionally selectively refit) a base run's
-            fitted transform spec and feature statistics.
-
-    Example:
-        >>> TrainingTypeConfig.INCREMENTAL.value
-        'INCREMENTAL'
-    """
-
-    INVALID = "INVALID"
-    BASE = "BASE"
-    INCREMENTAL = "INCREMENTAL"
-
-
-@dataclass
-class IncrementalTrainingConfig:
-    """Incremental-training configuration for ``tabular_native_transform``.
-
-    A config-layer type read directly from pipeline configuration for this
-    task specifically. It is intentionally distinct from any runtime-layer
-    incremental-training spec a trainer task might build for its own model
-    training — the two live at different layers (parsed configuration vs.
-    constructed runtime state) and are not meant to be unified. Scoped to
-    only the fields this task uses: a shared, more general equivalent
-    configuration (as consumed by a model-initializer-style task elsewhere)
-    would also carry fields like ``load_optimizer_weights`` and
-    ``fused_model_submodule`` that are meaningless here — this config
-    intentionally omits them rather than porting unused surface area.
-
-    Attributes:
-        training_type: Whether this run is a base run, an incremental run,
-            or neither (``INVALID``).
-        baseline_model_uri: URI of the base run's raw model package, as
-            returned by ``StorageBackend.upload()`` — passed directly to
-            ``StorageBackend.download()`` to retrieve
-            ``transform_spec.yaml``/``transform_feature_stats.yaml`` from its
-            metadata directory. Required when ``training_type ==
-            TrainingTypeConfig.INCREMENTAL``.
-        enforce_full_reuse: When ``True`` and ``training_type ==
-            TrainingTypeConfig.INCREMENTAL``, every layer in the (optional)
-            inlined ``transform_spec`` must use
-            :attr:`~michelangelo.lib.native_transform.torch.transform_layer_spec.TransformerMode.REUSE`
-            (or the default ``INVALID``, which behaves as ``REUSE``) — no
-            refitting allowed. This is the only supported setting for now.
-
-    Example:
-        >>> IncrementalTrainingConfig(
-        ...     training_type=TrainingTypeConfig.INCREMENTAL,
-        ...     baseline_model_uri="s3://bucket/models/base-run/",
-        ... ).enforce_full_reuse
-        True
-    """
-
-    training_type: TrainingTypeConfig = TrainingTypeConfig.INVALID
-    baseline_model_uri: str | None = None
-    enforce_full_reuse: bool = True
 
 
 @dataclass

--- a/python/michelangelo/workflow/schema/ray_data_io.py
+++ b/python/michelangelo/workflow/schema/ray_data_io.py
@@ -13,6 +13,8 @@ __all__ = [
     "BatchIterConfig",
     "DataloadingConfig",
     "ParquetReadConfig",
+    "RayDataContextConfig",
+    "WriteConfig",
 ]
 
 
@@ -94,3 +96,64 @@ class DataloadingConfig:
 
     parquet_read_config: ParquetReadConfig | None = None
     batch_iter_config: BatchIterConfig | None = None
+
+
+@dataclass
+class RayDataContextConfig:
+    """Ray ``DataContext`` tuning for workflow tasks that use Ray Data I/O.
+
+    Forwarded to
+    :func:`~michelangelo.uniflow.plugins.ray.data_context.set_ray_data_context`.
+
+    Attributes:
+        min_block_size: Target minimum Ray Data block size in bytes. ``None``
+            uses Ray's default.
+        max_block_size: Target maximum Ray Data block size in bytes. ``None``
+            uses Ray's default.
+        retried_io_errors: Extra error-message substrings appended to Ray's
+            ``retried_io_errors``. ``None`` uses the built-in patterns in
+            :data:`~michelangelo.uniflow.plugins.ray.data_context.RETRIED_IO_ERRORS`;
+            pass ``[]`` to skip adding extras beyond Ray's defaults.
+        object_store_memory_limit: Upper bound in bytes on the object store
+            memory the streaming executor may use for buffered (pending)
+            blocks across all operators. ``None`` leaves Ray's default
+            (unbounded, i.e. capped only by the physical object store).
+        wait_for_min_actors_s: Seconds the executor blocks for an actor-pool
+            operator's actors to finish provisioning before it begins
+            scheduling upstream read tasks. ``None`` keeps Ray's default (no
+            wait).
+
+    Example:
+        >>> RayDataContextConfig(min_block_size=32 * 1024 * 1024)
+        RayDataContextConfig(min_block_size=33554432, ...)
+    """
+
+    min_block_size: int | None = None
+    max_block_size: int | None = None
+    retried_io_errors: list[str] | None = None
+    object_store_memory_limit: int | None = None
+    wait_for_min_actors_s: int | None = None
+
+
+@dataclass
+class WriteConfig:
+    """Output file sizing for Ray Dataset write operations.
+
+    These parameters are format-agnostic (supported by ``write_parquet``,
+    ``write_csv``, ``write_json``, etc.) via Ray's ``FileBasedDatasink``.
+
+    Attributes:
+        max_rows_per_file: Max rows per output file. Caps individual file
+            size by splitting large blocks, preventing oversized files in
+            downstream steps. ``None`` uses Ray's default.
+        min_rows_per_file: Min rows per output file. Buffers small blocks
+            into fewer, larger files, reducing write task overhead and
+            storage metadata calls. ``None`` uses Ray's default.
+
+    Example:
+        >>> WriteConfig(max_rows_per_file=1_000_000)
+        WriteConfig(max_rows_per_file=1000000, min_rows_per_file=None)
+    """
+
+    max_rows_per_file: int | None = None
+    min_rows_per_file: int | None = None

--- a/python/michelangelo/workflow/schema/ray_data_io.py
+++ b/python/michelangelo/workflow/schema/ray_data_io.py
@@ -45,8 +45,8 @@ class ParquetReadConfig:
         arrow_parquet_args: Additional kwargs forwarded to PyArrow's reader.
 
     Example:
-        >>> ParquetReadConfig(num_cpus=2, shuffle="files")
-        ParquetReadConfig(num_cpus=2, ...)
+        ``ParquetReadConfig(num_cpus=2, shuffle="files")`` reserves 2 CPUs
+        per read worker and shuffles input file order.
     """
 
     num_cpus: float | None = None
@@ -124,8 +124,9 @@ class RayDataContextConfig:
             wait).
 
     Example:
-        >>> RayDataContextConfig(min_block_size=32 * 1024 * 1024)
-        RayDataContextConfig(min_block_size=33554432, ...)
+        ``RayDataContextConfig(min_block_size=32 * 1024 * 1024)`` sets a
+        32 MiB target minimum block size, leaving every other setting at
+        Ray's default.
     """
 
     min_block_size: int | None = None

--- a/python/michelangelo/workflow/schema/tabular_native_transform.py
+++ b/python/michelangelo/workflow/schema/tabular_native_transform.py
@@ -1,0 +1,146 @@
+"""Configuration dataclasses for the ``tabular_native_transform`` workflow task.
+
+Plain ``@dataclass`` with no Pydantic dependency, matching
+``michelangelo.workflow.schema.tabular_trainer`` and
+``michelangelo.workflow.schema.assembler``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+from michelangelo.workflow.schema.ray_data_io import (
+    ParquetReadConfig,
+    RayDataContextConfig,
+    WriteConfig,
+)
+
+__all__ = [
+    "BatchOptions",
+    "IncrementalTrainingConfig",
+    "ParquetReadConfig",
+    "RayDataContextConfig",
+    "TabularNativeTransformConfig",
+    "TrainingType",
+    "WriteConfig",
+]
+
+
+class TrainingType(str, Enum):
+    """Incremental-training mode for ``tabular_native_transform``.
+
+    Attributes:
+        INVALID: Not set; treated the same as a fresh (non-incremental) run.
+        BASE: A base run whose fitted transform can later be reused/refit by
+            an ``INCREMENTAL`` run.
+        INCREMENTAL: Reuse (and optionally selectively refit) a base run's
+            fitted transform spec and feature statistics.
+
+    Example:
+        >>> TrainingType.INCREMENTAL.value
+        'INCREMENTAL'
+    """
+
+    INVALID = "INVALID"
+    BASE = "BASE"
+    INCREMENTAL = "INCREMENTAL"
+
+
+@dataclass
+class IncrementalTrainingConfig:
+    """Incremental-training configuration for ``tabular_native_transform``.
+
+    Scoped to only the fields this task uses. Internal's equivalent
+    configuration is shared with a model-initializer task and carries extra
+    fields (``load_optimizer_weights``, ``fused_model_submodule``) that are
+    meaningless here — this config intentionally omits them rather than
+    porting unused surface area.
+
+    Attributes:
+        training_type: Whether this run is a base run, an incremental run,
+            or neither (``INVALID``).
+        baseline_model_uri: URI of the base run's raw model package, as
+            returned by ``StorageBackend.upload()`` — passed directly to
+            ``StorageBackend.download()`` to retrieve
+            ``transform_spec.yaml``/``transform_feature_stats.yaml`` from its
+            metadata directory. Required when ``training_type ==
+            TrainingType.INCREMENTAL``.
+        enforce_full_reuse: When ``True`` and ``training_type ==
+            TrainingType.INCREMENTAL``, every layer in the (optional)
+            inlined ``transform_spec`` must use
+            :attr:`~michelangelo.lib.native_transform.torch.transform_layer_spec.TransformerMode.REUSE`
+            (or the default ``INVALID``, which behaves as ``REUSE``) — no
+            refitting allowed. This is the only supported setting for now.
+
+    Example:
+        >>> IncrementalTrainingConfig(
+        ...     training_type=TrainingType.INCREMENTAL,
+        ...     baseline_model_uri="s3://bucket/models/base-run/",
+        ... ).enforce_full_reuse
+        True
+    """
+
+    training_type: TrainingType = TrainingType.INVALID
+    baseline_model_uri: str | None = None
+    enforce_full_reuse: bool = True
+
+
+@dataclass
+class BatchOptions:
+    """Ray processing options for ``tabular_native_transform``.
+
+    Attributes:
+        batch_size: The desired number of rows in each batch.
+        num_gpus: The number of GPUs to reserve for each parallel map
+            worker. For example, ``1`` to request 1 GPU, or ``0.125`` for
+            fractional allocation.
+        concurrency: The number of workers to use concurrently.
+        num_cpus: The number of CPUs to reserve for each parallel map
+            worker. Specifying both ``num_cpus`` and ``num_gpus`` for map
+            tasks is experimental and may result in scheduling or stability
+            issues.
+
+    Example:
+        >>> BatchOptions(batch_size=20_000, num_gpus=0.25)
+        BatchOptions(batch_size=20000, num_gpus=0.25, concurrency=None, num_cpus=None)
+    """
+
+    batch_size: int | None = None
+    num_gpus: float | None = None
+    concurrency: int | None = None
+    num_cpus: int | None = None
+
+
+@dataclass
+class TabularNativeTransformConfig:
+    """Configuration for the ``tabular_native_transform`` workflow task.
+
+    Attributes:
+        transform_spec: Either an inlined transform spec dict, or a string
+            file path to a YAML spec file resolved via
+            :func:`~michelangelo.workflow.tasks.tabular_native_transform.utils.resolve_data_file_path`.
+            May be ``None`` when ``incremental_training`` supplies a
+            baseline spec to reuse (``TrainingType.INCREMENTAL``).
+        batch_options: Batch processing options for Ray operations.
+        parquet_read_config: kwargs forwarded to ``ray.data.read_parquet``
+            when loading the input datasets. Use this to tune read
+            parallelism (e.g. ``override_num_blocks``, ``concurrency``) or
+            per-read-worker resources (``num_cpus``, ``num_gpus``,
+            ``memory``).
+        write_config: Output write config for the transformed datasets.
+        ray_data_context: Ray Data block sizing and I/O retry pattern
+            tuning.
+        incremental_training: Incremental training configuration.
+
+    Example:
+        >>> TabularNativeTransformConfig(transform_spec={"transform_specs": []})
+        TabularNativeTransformConfig(transform_spec={'transform_specs': []}, ...)
+    """
+
+    transform_spec: str | dict | None = None
+    batch_options: BatchOptions = field(default_factory=BatchOptions)
+    parquet_read_config: ParquetReadConfig | None = None
+    write_config: WriteConfig | None = None
+    ray_data_context: RayDataContextConfig | None = None
+    incremental_training: IncrementalTrainingConfig | None = None

--- a/python/michelangelo/workflow/schema/tabular_native_transform.py
+++ b/python/michelangelo/workflow/schema/tabular_native_transform.py
@@ -134,8 +134,9 @@ class TabularNativeTransformConfig:
         incremental_training: Incremental training configuration.
 
     Example:
-        >>> TabularNativeTransformConfig(transform_spec={"transform_specs": []})
-        TabularNativeTransformConfig(transform_spec={'transform_specs': []}, ...)
+        ``TabularNativeTransformConfig(transform_spec={"transform_specs": []})``
+        runs with an empty inlined transform spec and every other setting at
+        its default.
     """
 
     transform_spec: str | dict | None = None

--- a/python/michelangelo/workflow/schema/tabular_native_transform.py
+++ b/python/michelangelo/workflow/schema/tabular_native_transform.py
@@ -22,13 +22,19 @@ __all__ = [
     "ParquetReadConfig",
     "RayDataContextConfig",
     "TabularNativeTransformConfig",
-    "TrainingType",
+    "TrainingTypeConfig",
     "WriteConfig",
 ]
 
 
-class TrainingType(str, Enum):
+class TrainingTypeConfig(str, Enum):
     """Incremental-training mode for ``tabular_native_transform``.
+
+    A config-layer value, parsed directly from pipeline configuration —
+    distinct from (and not interchangeable with) any runtime-layer
+    incremental-training enum a trainer task might construct from it. Trainer
+    tasks that build their own runtime training state are expected to derive
+    it from their own config, not from this type.
 
     Attributes:
         INVALID: Not set; treated the same as a fresh (non-incremental) run.
@@ -38,7 +44,7 @@ class TrainingType(str, Enum):
             fitted transform spec and feature statistics.
 
     Example:
-        >>> TrainingType.INCREMENTAL.value
+        >>> TrainingTypeConfig.INCREMENTAL.value
         'INCREMENTAL'
     """
 
@@ -51,11 +57,16 @@ class TrainingType(str, Enum):
 class IncrementalTrainingConfig:
     """Incremental-training configuration for ``tabular_native_transform``.
 
-    Scoped to only the fields this task uses. Internal's equivalent
-    configuration is shared with a model-initializer task and carries extra
-    fields (``load_optimizer_weights``, ``fused_model_submodule``) that are
-    meaningless here — this config intentionally omits them rather than
-    porting unused surface area.
+    A config-layer type read directly from pipeline configuration for this
+    task specifically. It is intentionally distinct from any runtime-layer
+    incremental-training spec a trainer task might build for its own model
+    training — the two live at different layers (parsed configuration vs.
+    constructed runtime state) and are not meant to be unified. Scoped to
+    only the fields this task uses: a shared, more general equivalent
+    configuration (as consumed by a model-initializer-style task elsewhere)
+    would also carry fields like ``load_optimizer_weights`` and
+    ``fused_model_submodule`` that are meaningless here — this config
+    intentionally omits them rather than porting unused surface area.
 
     Attributes:
         training_type: Whether this run is a base run, an incremental run,
@@ -65,9 +76,9 @@ class IncrementalTrainingConfig:
             ``StorageBackend.download()`` to retrieve
             ``transform_spec.yaml``/``transform_feature_stats.yaml`` from its
             metadata directory. Required when ``training_type ==
-            TrainingType.INCREMENTAL``.
+            TrainingTypeConfig.INCREMENTAL``.
         enforce_full_reuse: When ``True`` and ``training_type ==
-            TrainingType.INCREMENTAL``, every layer in the (optional)
+            TrainingTypeConfig.INCREMENTAL``, every layer in the (optional)
             inlined ``transform_spec`` must use
             :attr:`~michelangelo.lib.native_transform.torch.transform_layer_spec.TransformerMode.REUSE`
             (or the default ``INVALID``, which behaves as ``REUSE``) — no
@@ -75,13 +86,13 @@ class IncrementalTrainingConfig:
 
     Example:
         >>> IncrementalTrainingConfig(
-        ...     training_type=TrainingType.INCREMENTAL,
+        ...     training_type=TrainingTypeConfig.INCREMENTAL,
         ...     baseline_model_uri="s3://bucket/models/base-run/",
         ... ).enforce_full_reuse
         True
     """
 
-    training_type: TrainingType = TrainingType.INVALID
+    training_type: TrainingTypeConfig = TrainingTypeConfig.INVALID
     baseline_model_uri: str | None = None
     enforce_full_reuse: bool = True
 
@@ -121,7 +132,7 @@ class TabularNativeTransformConfig:
             file path to a YAML spec file resolved via
             :func:`~michelangelo.workflow.tasks.tabular_native_transform.utils.resolve_data_file_path`.
             May be ``None`` when ``incremental_training`` supplies a
-            baseline spec to reuse (``TrainingType.INCREMENTAL``).
+            baseline spec to reuse (``TrainingTypeConfig.INCREMENTAL``).
         batch_options: Batch processing options for Ray operations.
         parquet_read_config: kwargs forwarded to ``ray.data.read_parquet``
             when loading the input datasets. Use this to tune read

--- a/python/michelangelo/workflow/tasks/tabular_native_transform/__init__.py
+++ b/python/michelangelo/workflow/tasks/tabular_native_transform/__init__.py
@@ -1,0 +1,47 @@
+"""Tabular native transform workflow task."""
+
+from michelangelo.workflow.schema.exceptions import ConfigurationError
+from michelangelo.workflow.schema.tabular_native_transform import (
+    BatchOptions,
+    IncrementalTrainingConfig,
+    ParquetReadConfig,
+    RayDataContextConfig,
+    TabularNativeTransformConfig,
+    TrainingType,
+    WriteConfig,
+)
+from michelangelo.workflow.tasks.tabular_native_transform._private import (
+    incremental_training as _incremental_training,
+)
+from michelangelo.workflow.tasks.tabular_native_transform._private.utils import (
+    convert_to_numpy_sample,
+    get_sample_data_from_datasets,
+    resolve_data_file_path,
+)
+from michelangelo.workflow.tasks.tabular_native_transform.task import (
+    tabular_native_transform,
+)
+
+is_baseline = _incremental_training.is_baseline
+is_incremental = _incremental_training.is_incremental
+load_incremental_artifacts = _incremental_training.load_incremental_artifacts
+merge_specs_for_selective_refit = _incremental_training.merge_specs_for_selective_refit
+
+__all__ = [
+    "BatchOptions",
+    "ConfigurationError",
+    "IncrementalTrainingConfig",
+    "ParquetReadConfig",
+    "RayDataContextConfig",
+    "TabularNativeTransformConfig",
+    "TrainingType",
+    "WriteConfig",
+    "convert_to_numpy_sample",
+    "get_sample_data_from_datasets",
+    "is_baseline",
+    "is_incremental",
+    "load_incremental_artifacts",
+    "merge_specs_for_selective_refit",
+    "resolve_data_file_path",
+    "tabular_native_transform",
+]

--- a/python/michelangelo/workflow/tasks/tabular_native_transform/__init__.py
+++ b/python/michelangelo/workflow/tasks/tabular_native_transform/__init__.py
@@ -1,7 +1,7 @@
 """Tabular native transform workflow task."""
 
 from michelangelo.workflow.schema.exceptions import ConfigurationError
-from michelangelo.workflow.schema.tabular_native_transform import (
+from michelangelo.workflow.schema.native_transform import (
     BatchOptions,
     IncrementalTrainingConfig,
     ParquetReadConfig,

--- a/python/michelangelo/workflow/tasks/tabular_native_transform/__init__.py
+++ b/python/michelangelo/workflow/tasks/tabular_native_transform/__init__.py
@@ -7,7 +7,7 @@ from michelangelo.workflow.schema.tabular_native_transform import (
     ParquetReadConfig,
     RayDataContextConfig,
     TabularNativeTransformConfig,
-    TrainingType,
+    TrainingTypeConfig,
     WriteConfig,
 )
 from michelangelo.workflow.tasks.tabular_native_transform._private import (
@@ -34,7 +34,7 @@ __all__ = [
     "ParquetReadConfig",
     "RayDataContextConfig",
     "TabularNativeTransformConfig",
-    "TrainingType",
+    "TrainingTypeConfig",
     "WriteConfig",
     "convert_to_numpy_sample",
     "get_sample_data_from_datasets",

--- a/python/michelangelo/workflow/tasks/tabular_native_transform/_private/__init__.py
+++ b/python/michelangelo/workflow/tasks/tabular_native_transform/_private/__init__.py
@@ -1,0 +1,5 @@
+"""Private helpers for the ``tabular_native_transform`` workflow task.
+
+Do not import directly from this package — import from
+``michelangelo.workflow.tasks.tabular_native_transform`` instead.
+"""

--- a/python/michelangelo/workflow/tasks/tabular_native_transform/_private/incremental_training.py
+++ b/python/michelangelo/workflow/tasks/tabular_native_transform/_private/incremental_training.py
@@ -1,0 +1,297 @@
+"""Incremental-training support for the native transform task.
+
+Handles loading a base run's fitted transform artifacts and selectively
+merging them with a new config spec for a refit.
+
+``_private/`` convention: this file lives in ``_private/`` — do not import
+directly from this path. Import from
+``michelangelo.workflow.tasks.tabular_native_transform`` instead.
+"""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import yaml
+
+from michelangelo.lib.native_transform.torch.transform_layer_spec import (
+    TorchTransformLayerSpec,
+    TransformerMode,
+)
+from michelangelo.lib.native_transform.torch.transform_spec import TransformSpec
+from michelangelo.uniflow.plugins.ray.native_transform import get_numerical_stats_names
+from michelangelo.workflow.schema.exceptions import ConfigurationError
+from michelangelo.workflow.schema.tabular_native_transform import (
+    IncrementalTrainingConfig,
+    TrainingType,
+)
+
+if TYPE_CHECKING:
+    from michelangelo.lib.artifact_manager.storage_backend import StorageBackend
+
+_logger = logging.getLogger(__name__)
+
+__all__ = [
+    "is_baseline",
+    "is_incremental",
+    "load_incremental_artifacts",
+    "merge_specs_for_selective_refit",
+]
+
+_TRANSFORM_SPEC_FILE = "transform_spec.yaml"
+_FEATURE_STATS_FILE = "transform_feature_stats.yaml"
+
+_PLACEHOLDER_TO_RESOLVED = {
+    cls.__name__: cls._resolved_layer_type
+    for cls in TorchTransformLayerSpec.__subclasses__()
+    if cls._resolved_layer_type is not None
+}
+
+
+def is_incremental(config: IncrementalTrainingConfig | None) -> bool:
+    """Check whether *config* specifies ``TrainingType.INCREMENTAL`` mode.
+
+    Args:
+        config: The incremental training configuration, or ``None``.
+
+    Returns:
+        ``True`` if incremental (refit-from-baseline) mode is active.
+    """
+    return config is not None and config.training_type == TrainingType.INCREMENTAL
+
+
+def is_baseline(config: IncrementalTrainingConfig | None) -> bool:
+    """Check whether *config* specifies ``TrainingType.BASE`` mode.
+
+    Args:
+        config: The incremental training configuration, or ``None``.
+
+    Returns:
+        ``True`` if this run is a base run for a future incremental run.
+    """
+    return config is not None and config.training_type == TrainingType.BASE
+
+
+def load_incremental_artifacts(
+    config: IncrementalTrainingConfig,
+    storage_backend: StorageBackend,
+) -> tuple[TransformSpec, dict]:
+    """Download the base run's artifacts and load its fitted transform state.
+
+    Steps:
+
+    1. Download ``config.baseline_model_uri`` via ``storage_backend`` to a
+       temporary directory.
+    2. Read ``transform_spec.yaml`` and ``transform_feature_stats.yaml`` from
+       that directory.
+    3. Reconstruct a ``TransformSpec`` from the loaded spec dict.
+    4. When ``config.enforce_full_reuse`` is set, validate every layer uses
+       ``TransformerMode.REUSE`` (or the default ``INVALID``, which behaves
+       as ``REUSE``).
+
+    Args:
+        config: The incremental training configuration. Must specify
+            ``training_type == TrainingType.INCREMENTAL`` and a non-``None``
+            ``baseline_model_uri``.
+        storage_backend: Backend used to download the base run's artifacts.
+
+    Returns:
+        A ``(transform_spec, feature_stats)`` tuple, where ``feature_stats``
+        is ``{}`` when the base run recorded none.
+
+    Raises:
+        ConfigurationError: If ``config.baseline_model_uri`` is unset, the
+            downloaded artifacts have no ``transform_spec.yaml``, or
+            ``enforce_full_reuse`` is set and a layer's mode is not
+            ``REUSE``/``INVALID``.
+    """
+    if not config.baseline_model_uri:
+        raise ConfigurationError(
+            "INCREMENTAL mode requires incremental_training.baseline_model_uri "
+            "to be set to the base run's raw model artifact URI."
+        )
+
+    _logger.info(
+        "INCREMENTAL mode: downloading base run artifacts from %s",
+        config.baseline_model_uri,
+    )
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        storage_backend.download(config.baseline_model_uri, tmp_dir)
+        local_dir = Path(tmp_dir)
+
+        transform_spec_path = local_dir / _TRANSFORM_SPEC_FILE
+        if not transform_spec_path.exists():
+            raise ConfigurationError(
+                f"Base run artifacts at {config.baseline_model_uri!r} do not contain "
+                f"{_TRANSFORM_SPEC_FILE}. Was it produced by a TrainingType.BASE run?"
+            )
+        with open(transform_spec_path) as f:
+            base_spec_dict = yaml.safe_load(f)
+
+        feature_stats_path = local_dir / _FEATURE_STATS_FILE
+        if feature_stats_path.exists():
+            with open(feature_stats_path) as f:
+                feature_stats = yaml.safe_load(f)
+        else:
+            feature_stats = {}
+
+    _logger.info(
+        "Loaded base transform spec (%d layers) and %d feature stats from base run "
+        "artifacts",
+        len(base_spec_dict.get("transform_specs", [])),
+        len(feature_stats),
+    )
+
+    transform_spec = TransformSpec(raw_transform_specs={"transform_specs": []})
+    transform_spec.load_from_dict(base_spec_dict)
+
+    if config.enforce_full_reuse:
+        for layer_spec in transform_spec.transform_specs.values():
+            if layer_spec.mode not in (TransformerMode.INVALID, TransformerMode.REUSE):
+                raise ConfigurationError(
+                    f"enforce_full_reuse=True but layer {layer_spec.name!r} has "
+                    f"mode={layer_spec.mode.value}. All layers must use REUSE (or "
+                    "INVALID, which defaults to REUSE) when enforce_full_reuse is "
+                    "enabled."
+                )
+
+    return transform_spec, feature_stats
+
+
+def _stats_keys_for_refit(transform_spec: TransformSpec) -> set[str]:
+    """Compute the feature-stats keys that must be removed for REFIT columns."""
+    keys: set[str] = set()
+    for level in set(transform_spec.transform_levels.values()):
+        specs = transform_spec.get_numerical_statistics_computation_specs(level)
+        keys.update(get_numerical_stats_names(specs))
+    _logger.info(
+        "Identified %d feature stats keys to remove for REFIT layers: %r",
+        len(keys),
+        keys,
+    )
+    return keys
+
+
+def _layer_key(
+    layer_spec: TorchTransformLayerSpec,
+) -> tuple[str, tuple[str, ...], tuple[str, ...]]:
+    """Build a matching key from layer type, input columns, and output columns.
+
+    Placeholder types are normalized to their resolved counterparts so that
+    a config spec with e.g. ``StandardScalerLayerSpec`` matches a base
+    model's fitted ``NormalizationLayerSpec``.
+    """
+    type_name = _PLACEHOLDER_TO_RESOLVED.get(
+        type(layer_spec).__name__, type(layer_spec).__name__
+    )
+    return (type_name, tuple(layer_spec.input_cols), tuple(layer_spec.output_cols))
+
+
+def merge_specs_for_selective_refit(
+    base_spec: TransformSpec,
+    config_spec: TransformSpec,
+    base_feature_stats: dict,
+) -> tuple[TransformSpec, dict]:
+    """Merge a base spec (concrete layers) with a config spec (placeholders) for refit.
+
+    For each layer in the config spec with ``mode=REFIT``, the config's
+    placeholder layer replaces the base spec's concrete layer. All other
+    layers keep the base spec's fitted values. Stats for REFIT layers' input
+    columns are removed from ``feature_stats`` so the pipeline recomputes
+    them.
+
+    Args:
+        base_spec: The base run's fitted ``TransformSpec``, mutated and
+            returned in place.
+        config_spec: The current run's config spec, whose ``REFIT``-mode
+            layers override the corresponding base layers.
+        base_feature_stats: The base run's feature statistics.
+
+    Returns:
+        A ``(merged_transform_spec, filtered_feature_stats)`` tuple.
+
+    Raises:
+        ConfigurationError: If a non-``REFIT`` layer in ``config_spec`` does
+            not match any layer in ``base_spec`` by type, input columns, and
+            output columns.
+    """
+    refit_lookup = {}
+    for layer_spec in config_spec.transform_specs.values():
+        if layer_spec.mode == TransformerMode.REFIT:
+            refit_lookup[_layer_key(layer_spec)] = layer_spec
+    _logger.info(
+        "%d/%d REFIT layers in config spec: %r",
+        len(refit_lookup),
+        len(config_spec.transform_specs),
+        refit_lookup,
+    )
+
+    base_keys = {_layer_key(ls) for ls in base_spec.transform_specs.values()}
+    for layer_spec in config_spec.transform_specs.values():
+        if (
+            layer_spec.mode != TransformerMode.REFIT
+            and _layer_key(layer_spec) not in base_keys
+        ):
+            raise ConfigurationError(
+                f"Layer {layer_spec.name!r} (type={type(layer_spec).__name__}, "
+                f"input_cols={layer_spec.input_cols}, "
+                f"output_cols={layer_spec.output_cols}) has mode=REUSE but does "
+                "not exist in the base run. REUSE layers must match the base "
+                "run's transform spec by type, input_cols, and output_cols."
+            )
+
+    merged_layers: dict[str, TorchTransformLayerSpec] = {}
+    for layer_spec in base_spec.transform_specs.values():
+        key = _layer_key(layer_spec)
+        if key in refit_lookup:
+            refit_layer = refit_lookup[key]
+            refit_layer.mode = TransformerMode.REFIT
+            merged_layers[refit_layer.name] = refit_layer
+            _logger.info(
+                "REFIT layer: %r (input_cols=%r)",
+                refit_layer.name,
+                refit_layer.input_cols,
+            )
+        else:
+            layer_spec.mode = TransformerMode.REUSE
+            merged_layers[layer_spec.name] = layer_spec
+            _logger.info(
+                "REUSE layer: %r (input_cols=%r)",
+                layer_spec.name,
+                layer_spec.input_cols,
+            )
+
+    base_spec.transform_specs = merged_layers
+    base_spec.transform_levels = base_spec._topological_sort()
+
+    refit_output_cols: set[str] = set()
+    for layer_spec in merged_layers.values():
+        if layer_spec.mode == TransformerMode.REFIT:
+            refit_output_cols.update(layer_spec.output_cols)
+    for layer_spec in merged_layers.values():
+        if layer_spec.mode == TransformerMode.REUSE:
+            overlap = set(layer_spec.input_cols) & refit_output_cols
+            if overlap:
+                _logger.warning(
+                    "REUSE layer %r consumes columns %r produced by a REFIT layer. "
+                    "The REUSE layer will use base run values while its input "
+                    "columns are refitted; verify this is intentional.",
+                    layer_spec.name,
+                    overlap,
+                )
+
+    refit_stats_keys = _stats_keys_for_refit(base_spec)
+    filtered_stats = {
+        k: v for k, v in base_feature_stats.items() if k not in refit_stats_keys
+    }
+    _logger.info(
+        "Selective refit: %d REFIT layers, %d REUSE layers, removed %d stats entries",
+        len(refit_lookup),
+        len(merged_layers) - len(refit_lookup),
+        len(base_feature_stats) - len(filtered_stats),
+    )
+
+    return base_spec, filtered_stats

--- a/python/michelangelo/workflow/tasks/tabular_native_transform/_private/incremental_training.py
+++ b/python/michelangelo/workflow/tasks/tabular_native_transform/_private/incremental_training.py
@@ -26,7 +26,7 @@ from michelangelo.uniflow.plugins.ray.native_transform import get_numerical_stat
 from michelangelo.workflow.schema.exceptions import ConfigurationError
 from michelangelo.workflow.schema.tabular_native_transform import (
     IncrementalTrainingConfig,
-    TrainingType,
+    TrainingTypeConfig,
 )
 
 if TYPE_CHECKING:
@@ -52,7 +52,7 @@ _PLACEHOLDER_TO_RESOLVED = {
 
 
 def is_incremental(config: IncrementalTrainingConfig | None) -> bool:
-    """Check whether *config* specifies ``TrainingType.INCREMENTAL`` mode.
+    """Check whether *config* specifies ``TrainingTypeConfig.INCREMENTAL`` mode.
 
     Args:
         config: The incremental training configuration, or ``None``.
@@ -60,11 +60,11 @@ def is_incremental(config: IncrementalTrainingConfig | None) -> bool:
     Returns:
         ``True`` if incremental (refit-from-baseline) mode is active.
     """
-    return config is not None and config.training_type == TrainingType.INCREMENTAL
+    return config is not None and config.training_type == TrainingTypeConfig.INCREMENTAL
 
 
 def is_baseline(config: IncrementalTrainingConfig | None) -> bool:
-    """Check whether *config* specifies ``TrainingType.BASE`` mode.
+    """Check whether *config* specifies ``TrainingTypeConfig.BASE`` mode.
 
     Args:
         config: The incremental training configuration, or ``None``.
@@ -72,7 +72,7 @@ def is_baseline(config: IncrementalTrainingConfig | None) -> bool:
     Returns:
         ``True`` if this run is a base run for a future incremental run.
     """
-    return config is not None and config.training_type == TrainingType.BASE
+    return config is not None and config.training_type == TrainingTypeConfig.BASE
 
 
 def load_incremental_artifacts(
@@ -94,7 +94,7 @@ def load_incremental_artifacts(
 
     Args:
         config: The incremental training configuration. Must specify
-            ``training_type == TrainingType.INCREMENTAL`` and a non-``None``
+            ``training_type == TrainingTypeConfig.INCREMENTAL`` and a non-``None``
             ``baseline_model_uri``.
         storage_backend: Backend used to download the base run's artifacts.
 
@@ -126,7 +126,8 @@ def load_incremental_artifacts(
         if not transform_spec_path.exists():
             raise ConfigurationError(
                 f"Base run artifacts at {config.baseline_model_uri!r} do not contain "
-                f"{_TRANSFORM_SPEC_FILE}. Was it produced by a TrainingType.BASE run?"
+                f"{_TRANSFORM_SPEC_FILE}. Was it produced by a "
+                "TrainingTypeConfig.BASE run?"
             )
         with open(transform_spec_path) as f:
             base_spec_dict = yaml.safe_load(f)

--- a/python/michelangelo/workflow/tasks/tabular_native_transform/_private/incremental_training.py
+++ b/python/michelangelo/workflow/tasks/tabular_native_transform/_private/incremental_training.py
@@ -162,7 +162,17 @@ def load_incremental_artifacts(
 
 
 def _stats_keys_for_refit(transform_spec: TransformSpec) -> set[str]:
-    """Compute the feature-stats keys that must be removed for REFIT columns."""
+    """Compute the feature-stats keys to remove ahead of a selective refit.
+
+    Invalidates stats per transform *level*, not per individual REFIT layer:
+    every level that contains at least one REFIT layer has its numerical
+    stats removed in full, even for REUSE layers sharing that level. This
+    matches the internal SDK's existing behavior — a conservative-recompute
+    tradeoff, not a bug. A REUSE layer whose stats happen to live on the same
+    level as a REFIT layer will be recomputed unnecessarily rather than
+    reused; this keeps the merge logic simple (no per-layer stats
+    provenance) at the cost of some avoidable recomputation.
+    """
     keys: set[str] = set()
     for level in set(transform_spec.transform_levels.values()):
         specs = transform_spec.get_numerical_statistics_computation_specs(level)
@@ -238,9 +248,10 @@ def merge_specs_for_selective_refit(
             raise ConfigurationError(
                 f"Layer {layer_spec.name!r} (type={type(layer_spec).__name__}, "
                 f"input_cols={layer_spec.input_cols}, "
-                f"output_cols={layer_spec.output_cols}) has mode=REUSE but does "
-                "not exist in the base run. REUSE layers must match the base "
-                "run's transform spec by type, input_cols, and output_cols."
+                f"output_cols={layer_spec.output_cols}) has mode="
+                f"{layer_spec.mode.value} but does not exist in the base run. "
+                "Non-REFIT layers must match the base run's transform spec by "
+                "type, input_cols, and output_cols."
             )
 
     merged_layers: dict[str, TorchTransformLayerSpec] = {}
@@ -283,6 +294,8 @@ def merge_specs_for_selective_refit(
                     overlap,
                 )
 
+    # Per-level invalidation: a REUSE layer sharing a level with a REFIT layer
+    # also has its stats removed here (see _stats_keys_for_refit docstring).
     refit_stats_keys = _stats_keys_for_refit(base_spec)
     filtered_stats = {
         k: v for k, v in base_feature_stats.items() if k not in refit_stats_keys

--- a/python/michelangelo/workflow/tasks/tabular_native_transform/_private/incremental_training.py
+++ b/python/michelangelo/workflow/tasks/tabular_native_transform/_private/incremental_training.py
@@ -23,11 +23,11 @@ from michelangelo.lib.native_transform.torch.transform_layer_spec import (
 )
 from michelangelo.lib.native_transform.torch.transform_spec import TransformSpec
 from michelangelo.uniflow.plugins.ray.native_transform import get_numerical_stats_names
-from michelangelo.workflow.schema.exceptions import ConfigurationError
-from michelangelo.workflow.schema.tabular_native_transform import (
+from michelangelo.workflow.schema.common import (
     IncrementalTrainingConfig,
     TrainingTypeConfig,
 )
+from michelangelo.workflow.schema.exceptions import ConfigurationError
 
 if TYPE_CHECKING:
     from michelangelo.lib.artifact_manager.storage_backend import StorageBackend

--- a/python/michelangelo/workflow/tasks/tabular_native_transform/_private/utils.py
+++ b/python/michelangelo/workflow/tasks/tabular_native_transform/_private/utils.py
@@ -1,0 +1,202 @@
+"""Sampling, numpy-conversion, and path-resolution helpers for native transform.
+
+``_private/`` convention: this file lives in ``_private/`` — do not import
+directly from this path. Import from
+``michelangelo.workflow.tasks.tabular_native_transform`` instead.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from michelangelo.lib.model_manager.schema import DataType, ModelSchemaItem
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from michelangelo.workflow.variables import DatasetVariable
+
+_logger = logging.getLogger(__name__)
+
+__all__ = [
+    "PREFERRED_DATASET_ORDER",
+    "col_to_numpy",
+    "convert_to_numpy_sample",
+    "data_type_to_dtype",
+    "get_sample_data_from_datasets",
+    "resolve_data_file_path",
+]
+
+_DATA_ROOT_ENV_VAR = "MICHELANGELO_DATA_ROOT"
+
+PREFERRED_DATASET_ORDER = ["train", "training", "validation", "test"]
+"""Dataset-name ordering used to prefer training data for stat computation."""
+
+
+def resolve_data_file_path(path: str) -> str:
+    """Resolve a possibly-relative data file path to an absolute path.
+
+    Absolute paths are returned unchanged. A relative path is resolved
+    against the ``MICHELANGELO_DATA_ROOT`` environment variable when it is
+    set, or the current working directory otherwise — this task typically
+    runs inside a container image that bundles spec/data files alongside the
+    task code, so callers set ``MICHELANGELO_DATA_ROOT`` to that image's data
+    root in their deployment environment.
+
+    Args:
+        path: A file path, absolute or relative.
+
+    Returns:
+        The resolved absolute path.
+    """
+    if os.path.isabs(path):
+        return path
+    root = os.environ.get(_DATA_ROOT_ENV_VAR, os.getcwd())
+    return os.path.join(root, path)
+
+
+def get_sample_data_from_datasets(
+    datasets: dict[str, DatasetVariable],
+) -> dict | None:
+    """Get a sample row from the datasets for shape derivation.
+
+    Samples BEFORE transformation to ensure data is available (Ray datasets
+    may be consumed/invalidated after transformation, and input columns may
+    be dropped). Prefers train/training dataset, falls back to any available
+    dataset.
+
+    Args:
+        datasets: Dictionary of dataset variables.
+
+    Returns:
+        Sample row as dict (column -> value), or ``None`` if not available.
+    """
+    ordered_names = [name for name in PREFERRED_DATASET_ORDER if name in datasets]
+    ordered_names.extend(name for name in datasets if name not in ordered_names)
+
+    for name in ordered_names:
+        dataset_var = datasets[name]
+        if dataset_var.value is None:
+            continue
+        try:
+            sample_rows = dataset_var.value.take(1)
+            if sample_rows:
+                return sample_rows[0]
+        except Exception as e:
+            _logger.warning("Failed to sample from dataset %r: %s", name, e)
+
+    _logger.warning("No sample data available from any dataset")
+    return None
+
+
+def data_type_to_dtype(data_type: DataType) -> np.dtype:
+    """Numpy dtype for empty placeholder arrays when a cell is missing or null.
+
+    Used with :func:`convert_to_numpy_sample` when an ``input_schema`` is
+    provided, so missing values match the declared feature type.
+
+    Args:
+        data_type: The declared schema data type.
+
+    Returns:
+        The corresponding numpy dtype, or ``np.object_`` for unmapped types.
+    """
+    dtype_mapping: dict[DataType, np.dtype] = {
+        DataType.FLOAT: np.float32,
+        DataType.DOUBLE: np.float64,
+        DataType.INT: np.int32,
+        DataType.LONG: np.int64,
+        DataType.SHORT: np.int16,
+        DataType.BYTE: np.int8,
+        DataType.BOOLEAN: np.bool_,
+        DataType.STRING: np.object_,
+    }
+    return dtype_mapping.get(data_type, np.object_)
+
+
+def convert_to_numpy_sample(
+    row: dict[str, Any] | None,
+    input_schema: Sequence[ModelSchemaItem] | None = None,
+) -> list[dict[str, np.ndarray]] | None:
+    """Convert one dataset row to model metadata ``sample_data`` format.
+
+    ``ModelMetadata.sample_data`` expects ``list[dict[str, np.ndarray]]`` (a
+    batch of one row). Ray ``Dataset.take(1)[0]`` rows use scalars, lists,
+    numpy arrays, or Arrow-backed types; this normalizes every cell to an
+    ``ndarray``.
+
+    When ``input_schema`` is set (typically ``derived_schema.input_schema``
+    from
+    :func:`~michelangelo.lib.native_transform.torch.schema.derive_native_transform_schema`),
+    only those columns are kept, in schema order. Keys absent from ``row``
+    and ``None`` cells use an empty array whose dtype matches each item's
+    :class:`~michelangelo.lib.model_manager.schema.DataType`.
+
+    Args:
+        row: A single record dict, or ``None``.
+        input_schema: Optional transform input schema; extra keys in ``row``
+            are dropped.
+
+    Returns:
+        A one-element list ``[{ col: ndarray, ... }]``, or ``None`` if
+        ``row`` is ``None``.
+    """
+    if row is None:
+        return None
+    if input_schema is not None:
+        return [
+            {
+                item.name: col_to_numpy(
+                    row.get(item.name),
+                    dtype=data_type_to_dtype(item.data_type),
+                )
+                for item in input_schema
+            }
+        ]
+    return [{key: col_to_numpy(value) for key, value in row.items()}]
+
+
+def col_to_numpy(value: Any, dtype: np.dtype | None = None) -> np.ndarray:
+    """Normalize a single dataset cell value into a numpy ``ndarray``.
+
+    Args:
+        value: The cell value — ``None``, a numpy array, a torch tensor, a
+            scalar, ``bytes``, a ``str``, or an array-like sequence.
+        dtype: Optional dtype to coerce the result to. Used for empty
+            placeholders (``value is None``) and ragged sequences containing
+            ``None`` entries.
+
+    Returns:
+        The value as a numpy ``ndarray``.
+    """
+    if value is None:
+        return np.array([], dtype=dtype or np.object_)
+    if isinstance(value, np.ndarray):
+        return (
+            np.asarray(value, dtype=dtype) if dtype is not None else np.asarray(value)
+        )
+    if hasattr(value, "detach") and callable(getattr(value, "detach", None)):
+        try:
+            return np.asarray(value.detach().cpu().numpy())
+        except Exception:
+            pass
+    if isinstance(value, (bytes, bytearray)):
+        return np.array([bytes(value)], dtype=dtype or np.object_)
+    if isinstance(value, str):
+        return np.array([value], dtype=dtype or np.object_)
+    if isinstance(value, (bool, int, float, np.integer, np.floating, np.bool_)):
+        return (
+            np.array([value], dtype=dtype) if dtype is not None else np.array([value])
+        )
+    if (
+        dtype is not None
+        and isinstance(value, (list, tuple))
+        and any(v is None for v in value)
+    ):
+        default = np.dtype(dtype).type(0)
+        return np.array([default if v is None else v for v in value], dtype=dtype)
+    return np.asarray(value, dtype=dtype) if dtype is not None else np.asarray(value)

--- a/python/michelangelo/workflow/tasks/tabular_native_transform/task.py
+++ b/python/michelangelo/workflow/tasks/tabular_native_transform/task.py
@@ -1,0 +1,400 @@
+"""Tabular native transform workflow task.
+
+Applies PyTorch transformations to tabular datasets using Ray for distributed
+processing. Unlike a Spark-DSL-based transform task, this task uses native
+PyTorch layers for transformations like normalization, scaling,
+concatenation, and custom numerical transforms — the same
+:class:`~michelangelo.lib.native_transform.torch.TransformSpec` DAG runs at
+training time (here, via Ray batch inference) and at serving time (embedded
+in the resulting model artifact).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import TYPE_CHECKING
+
+from michelangelo.lib.native_transform.torch import (
+    TorchTransformModule,
+    TransformSpec,
+    get_transform_module,
+)
+from michelangelo.lib.native_transform.torch.schema import (
+    derive_native_transform_schema,
+)
+from michelangelo.uniflow.plugins.ray.data_context import set_ray_data_context
+from michelangelo.uniflow.plugins.ray.native_transform import (
+    transform as native_transform,
+)
+from michelangelo.uniflow.plugins.ray.parquet_io import parquet_read_config_to_kwargs
+from michelangelo.workflow.schema.exceptions import ConfigurationError
+from michelangelo.workflow.tasks.tabular_native_transform._private import (
+    incremental_training,
+)
+from michelangelo.workflow.tasks.tabular_native_transform._private.utils import (
+    PREFERRED_DATASET_ORDER,
+    convert_to_numpy_sample,
+    get_sample_data_from_datasets,
+    resolve_data_file_path,
+)
+from michelangelo.workflow.variables import DatasetVariable, ModelVariable
+from michelangelo.workflow.variables._private.utils.serialization import save_object
+from michelangelo.workflow.variables.metadata import DatasetMetadata
+from michelangelo.workflow.variables.types import NativeTransformResult
+
+if TYPE_CHECKING:
+    from michelangelo.lib.artifact_manager.storage_backend import StorageBackend
+    from michelangelo.workflow.schema.tabular_native_transform import (
+        TabularNativeTransformConfig,
+    )
+
+_logger = logging.getLogger(__name__)
+
+__all__ = ["tabular_native_transform"]
+
+
+def tabular_native_transform(
+    config: TabularNativeTransformConfig,
+    datasets: dict[str, DatasetVariable],
+    *,
+    storage_backend: StorageBackend | None = None,
+) -> NativeTransformResult:
+    """Run the tabular native transform task using Ray and PyTorch.
+
+    Args:
+        config: Tabular native transform configuration containing:
+
+            - ``transform_spec``: Transform specification as a dict or a
+              YAML file path.
+            - ``batch_options``: Ray processing options (batch size,
+              concurrency, num_gpus, num_cpus).
+            - ``ray_data_context``: Optional Ray Data block size and I/O
+              retry pattern tuning.
+        datasets: A dict of datasets (e.g. ``{"train": train_dataset,
+            "validation": val_dataset, "test": test_dataset}``). The keys
+            are dataset names and the values are ``DatasetVariable``
+            objects; the transform runs on each dataset. For a training
+            pipeline, this typically includes train, validation, and
+            optionally test datasets.
+        storage_backend: Backend used to download a base run's artifacts.
+            Required only when ``config.incremental_training`` specifies
+            ``TrainingType.INCREMENTAL`` mode; ignored otherwise.
+
+    Returns:
+        A ``NativeTransformResult`` containing the transformed datasets and
+        the PyTorch transform module (model), with feature statistics in
+        its metadata.
+
+    Raises:
+        ConfigurationError: If ``datasets`` is empty or every dataset is
+            empty, if ``config.transform_spec`` is not a dict or string
+            path, if incremental mode is active without a
+            ``storage_backend``, or if an incremental merge/reuse
+            constraint is violated (see
+            :mod:`~michelangelo.workflow.tasks.tabular_native_transform._private.incremental_training`).
+    """
+    rc = config.ray_data_context
+    set_ray_data_context(
+        min_block_size=rc.min_block_size if rc else None,
+        max_block_size=rc.max_block_size if rc else None,
+        retried_io_errors=rc.retried_io_errors if rc else None,
+    )
+
+    inc = config.incremental_training
+
+    # Early return if no transform spec provided. INCREMENTAL mode loads its
+    # spec from the base run, so config.transform_spec can be None.
+    if config.transform_spec is None and not incremental_training.is_incremental(inc):
+        _logger.info("No transform spec provided, returning datasets unchanged")
+        return NativeTransformResult(transformed_datasets=datasets)
+
+    # Create Ray Dataset objects from each input dataset, forwarding any
+    # user-provided parquet_read_config to ray.data.read_parquet. This does
+    # not load the data rows into memory — Ray Datasets execute lazily. See:
+    # https://docs.ray.io/en/latest/data/key-concepts.html#data-key-concepts
+    for name, dataset_var in datasets.items():
+        if dataset_var is not None:
+            dataset_var.load_ray_dataset(
+                **parquet_read_config_to_kwargs(
+                    config.parquet_read_config, dataset_name=name
+                )
+            )
+
+    _validate_datasets(datasets)
+
+    # Load transform spec and initial feature stats based on mode.
+    initial_feature_stats: dict = {}
+    if incremental_training.is_incremental(inc):
+        if storage_backend is None:
+            raise ConfigurationError(
+                "storage_backend is required when incremental_training.training_type "
+                "is TrainingType.INCREMENTAL."
+            )
+        base_spec, base_stats = incremental_training.load_incremental_artifacts(
+            inc, storage_backend
+        )
+        if not inc.enforce_full_reuse:
+            config_spec = _load_transform_spec(config)
+            transform_spec, initial_feature_stats = (
+                incremental_training.merge_specs_for_selective_refit(
+                    base_spec, config_spec, base_stats
+                )
+            )
+        else:
+            transform_spec, initial_feature_stats = base_spec, base_stats
+    else:
+        transform_spec = _load_transform_spec(config)
+
+    # Sample data from the original datasets BEFORE transformation, for shape
+    # derivation.
+    sample_data = get_sample_data_from_datasets(datasets)
+
+    # Transform all datasets (train, validation, test). Feature statistics
+    # are computed from training data during transformation, or skipped when
+    # pre-loaded stats already cover the required levels.
+    transformed_datasets, transform_spec, feature_stats = _transform_all_datasets(
+        datasets,
+        transform_spec,
+        config,
+        initial_feature_stats=initial_feature_stats,
+    )
+
+    _logger.info("Creating transform module (model) from transform spec")
+    model_variable = _create_transform_model(transform_spec, feature_stats, sample_data)
+
+    write_kwargs = {}
+    if config.write_config:
+        if config.write_config.max_rows_per_file is not None:
+            write_kwargs["max_rows_per_file"] = config.write_config.max_rows_per_file
+        if config.write_config.min_rows_per_file is not None:
+            write_kwargs["min_rows_per_file"] = config.write_config.min_rows_per_file
+    _save_datasets(transformed_datasets, **write_kwargs)
+
+    if incremental_training.is_incremental(inc) and model_variable is None:
+        raise ConfigurationError(
+            "INCREMENTAL transform produced no model — the transform spec has "
+            "no layers."
+        )
+
+    _logger.info("Native transformation completed successfully")
+    return NativeTransformResult(
+        transformed_datasets=transformed_datasets,
+        model=model_variable,
+    )
+
+
+def _validate_datasets(datasets: dict[str, DatasetVariable]) -> None:
+    """Validate that at least one dataset is non-empty.
+
+    Raises:
+        ConfigurationError: If ``datasets`` is empty, or every dataset in it
+            is empty.
+    """
+    if not datasets:
+        raise ConfigurationError("No datasets provided for native transformation")
+
+    for dataset_var in datasets.values():
+        if dataset_var.value is not None and len(dataset_var.value.take(1)) > 0:
+            return
+
+    raise ConfigurationError(
+        "All datasets are empty. At least one non-empty dataset is required for "
+        "native transformation."
+    )
+
+
+def _load_transform_spec(config: TabularNativeTransformConfig) -> TransformSpec:
+    """Load a transform specification from config.
+
+    ``config.transform_spec`` accepts either:
+
+    - ``dict``: an inlined spec.
+    - ``str``: a file path to a YAML spec, resolved via
+      :func:`~michelangelo.workflow.tasks.tabular_native_transform._private.utils.resolve_data_file_path`.
+
+    Raises:
+        ConfigurationError: If ``config.transform_spec`` is neither a dict
+            nor a string.
+    """
+    if isinstance(config.transform_spec, dict):
+        _logger.info("Loading transform spec from inlined dict")
+        return TransformSpec(raw_transform_specs=config.transform_spec)
+
+    if isinstance(config.transform_spec, str):
+        resolved_path = resolve_data_file_path(config.transform_spec)
+        _logger.info("Loading transform spec from file: %s", resolved_path)
+        return TransformSpec(transform_spec_yaml_path=resolved_path)
+
+    raise ConfigurationError("transform_spec must be a dict or a file path string")
+
+
+def _transform_all_datasets(
+    datasets: dict[str, DatasetVariable],
+    transform_spec: TransformSpec,
+    config: TabularNativeTransformConfig,
+    initial_feature_stats: dict | None = None,
+) -> tuple[dict[str, DatasetVariable], TransformSpec, dict]:
+    """Transform all datasets in order, reusing the updated spec and feature stats.
+
+    Feature statistics are computed from the training data and reused for
+    validation/test. Processes datasets in
+    :data:`~michelangelo.workflow.tasks.tabular_native_transform._private.utils.PREFERRED_DATASET_ORDER`
+    order to ensure stats from training are used first.
+
+    Args:
+        datasets: Dictionary of dataset variables.
+        transform_spec: Transform specification.
+        config: Tabular native transform configuration.
+        initial_feature_stats: Pre-loaded feature stats (e.g. from a base
+            run in ``TrainingType.INCREMENTAL`` mode). When provided, the
+            stats are used as-is and fitting is skipped for levels whose
+            stats are already present.
+
+    Returns:
+        A ``(transformed_datasets, updated_transform_spec,
+        computed_feature_stats)`` tuple.
+    """
+    transformed_datasets: dict[str, DatasetVariable] = {}
+    feature_stats = dict(initial_feature_stats) if initial_feature_stats else {}
+
+    dataset_order = [name for name in PREFERRED_DATASET_ORDER if name in datasets]
+    dataset_order.extend(name for name in datasets if name not in dataset_order)
+
+    for dataset_name in dataset_order:
+        dataset_var = datasets[dataset_name]
+
+        # Pass through empty datasets unchanged (validation/test may be optional).
+        if dataset_var.value is None or len(dataset_var.value.take(1)) == 0:
+            _logger.warning("Passing through empty dataset unchanged: %s", dataset_name)
+            transformed_datasets[dataset_name] = dataset_var
+            continue
+
+        _logger.info("Transforming dataset: %s", dataset_name)
+        t = time.time()
+
+        transformed_data, transform_spec, feature_stats = native_transform(
+            df=dataset_var.value,
+            transform_spec=transform_spec,
+            feature_stats=feature_stats,
+            batch_size=config.batch_options.batch_size,
+            map_batch_concurrency=config.batch_options.concurrency,
+            num_gpus=config.batch_options.num_gpus,
+        )
+        _logger.info(
+            "Transform %s data completed in %.2f seconds", dataset_name, time.time() - t
+        )
+
+        if dataset_name == "train":
+            _logger.info(
+                "Feature stats computed from training data: %s",
+                json.dumps(feature_stats),
+            )
+
+        transformed_dataset = DatasetVariable.create(transformed_data)
+
+        # Derive output columns from the transform spec. Use columns_to_keep
+        # if provided; otherwise use transform outputs at all levels.
+        input_columns = set(dataset_var.value.schema().names)
+        if transform_spec.columns_to_keep is not None:
+            output_columns = set(transform_spec.columns_to_keep)
+        else:
+            output_columns = set()
+            for level in range(transform_spec.get_max_transform_level() + 1):
+                output_columns.update(transform_spec.get_transform_output_cols(level))
+        derived_features = sorted(output_columns - input_columns)
+        _logger.info("Derived features for %s: %s", dataset_name, derived_features)
+        transformed_dataset.metadata = DatasetMetadata(
+            derived_features=derived_features
+        )
+
+        transformed_datasets[dataset_name] = transformed_dataset
+
+    return transformed_datasets, transform_spec, feature_stats
+
+
+def _create_transform_model(
+    transform_spec: TransformSpec,
+    feature_stats: dict,
+    sample_data: dict | None,
+) -> ModelVariable | None:
+    """Create a ``ModelVariable`` wrapping a ``TorchTransformModule`` from the spec.
+
+    The transform module can be used for inference and deployment.
+
+    Args:
+        transform_spec: The transform specification.
+        feature_stats: Feature statistics computed during transformation.
+        sample_data: Sample row from the original dataset (for shape
+            derivation). Stored on ``metadata.sample_data`` as numpy sample
+            rows filtered to the derived ``input_schema`` column names.
+
+    Returns:
+        A ``ModelVariable`` containing the transform module with metadata,
+        or ``None`` if the transform spec has no layers.
+    """
+    transform_module: TorchTransformModule | None = get_transform_module(
+        transform_spec=transform_spec,
+        start_level=0,
+        end_level=transform_spec.get_max_transform_level(),
+    )
+
+    if transform_module is None:
+        _logger.warning("No transform module created (no transform layers)")
+        return None
+
+    model_variable = ModelVariable.create(transform_module)
+    model_variable.metadata.model_class = (
+        f"{transform_module.__class__.__module__}.{transform_module.__class__.__name__}"
+    )
+    # Store in both fields: hyperparameters follows the convention for model
+    # init params, transform_spec is the dedicated field used by the
+    # assembler and pusher for incremental training.
+    model_variable.metadata.hyperparameters = transform_spec.to_dict()
+    model_variable.metadata.transform_spec = transform_spec.to_dict()
+    model_variable.metadata.feature_stats = feature_stats
+
+    # Populate schema from transform_spec with derived shapes for downstream
+    # tasks (trainer, assembler).
+    derived_schema = derive_native_transform_schema(
+        transform_spec=transform_spec,
+        transform_module=transform_module,
+        sample_data=sample_data,
+    )
+    model_variable.metadata._schema = save_object(derived_schema)
+    model_variable.metadata._sample_data = save_object(
+        convert_to_numpy_sample(sample_data, input_schema=derived_schema.input_schema)
+    )
+
+    model_variable.save()
+
+    return model_variable
+
+
+def _save_datasets(
+    transformed_datasets: dict[str, DatasetVariable], **write_kwargs
+) -> None:
+    """Persist each transformed dataset through its ``DatasetVariable``.
+
+    Transformed datasets already carry native PyArrow schemas (the native
+    transform emits ``pa.Table`` blocks with multi-dim columns encoded as
+    nested ``list<list<...>>``), so each dataset is written straight through
+    to its sink.
+
+    Args:
+        transformed_datasets: Mapping of dataset name to the transformed
+            ``DatasetVariable`` to persist.
+        **write_kwargs: Forwarded to ``DatasetVariable.save_ray_dataset()``
+            and ultimately to ``ray.data.Dataset.write_parquet()``.
+            Supported keys include ``max_rows_per_file`` and
+            ``min_rows_per_file``.
+    """
+    for dataset_name, dataset_var in transformed_datasets.items():
+        _logger.info("Saving transformed dataset: %s", dataset_name)
+        t = time.time()
+
+        if write_kwargs:
+            _logger.info("Writing %s with write_kwargs=%s", dataset_name, write_kwargs)
+        dataset_var.save_ray_dataset(**write_kwargs)
+        _logger.info("Saved %s dataset in %.2f seconds", dataset_name, time.time() - t)

--- a/python/michelangelo/workflow/tasks/tabular_native_transform/task.py
+++ b/python/michelangelo/workflow/tasks/tabular_native_transform/task.py
@@ -91,7 +91,7 @@ def tabular_native_transform(
             optionally test datasets.
         storage_backend: Backend used to download a base run's artifacts.
             Required only when ``config.incremental_training`` specifies
-            ``TrainingType.INCREMENTAL`` mode; ignored otherwise.
+            ``TrainingTypeConfig.INCREMENTAL`` mode; ignored otherwise.
 
     Returns:
         A ``NativeTransformResult`` containing the transformed datasets and
@@ -143,7 +143,7 @@ def tabular_native_transform(
         if storage_backend is None:
             raise ConfigurationError(
                 "storage_backend is required when incremental_training.training_type "
-                "is TrainingType.INCREMENTAL."
+                "is TrainingTypeConfig.INCREMENTAL."
             )
         base_spec, base_stats = incremental_training.load_incremental_artifacts(
             inc, storage_backend
@@ -256,7 +256,7 @@ def _transform_all_datasets(
         transform_spec: Transform specification.
         config: Tabular native transform configuration.
         initial_feature_stats: Pre-loaded feature stats (e.g. from a base
-            run in ``TrainingType.INCREMENTAL`` mode). When provided, the
+            run in ``TrainingTypeConfig.INCREMENTAL`` mode). When provided, the
             stats are used as-is and fitting is skipped for levels whose
             stats are already present.
 

--- a/python/michelangelo/workflow/tasks/tabular_native_transform/task.py
+++ b/python/michelangelo/workflow/tasks/tabular_native_transform/task.py
@@ -49,10 +49,10 @@ from michelangelo.workflow.variables.types import NativeTransformResult
 
 if TYPE_CHECKING:
     from michelangelo.lib.artifact_manager.storage_backend import StorageBackend
-    from michelangelo.workflow.schema.ray_data_io import WriteConfig
-    from michelangelo.workflow.schema.tabular_native_transform import (
+    from michelangelo.workflow.schema.native_transform import (
         TabularNativeTransformConfig,
     )
+    from michelangelo.workflow.schema.ray_data_io import WriteConfig
 
 _logger = logging.getLogger(__name__)
 

--- a/python/michelangelo/workflow/tasks/tabular_native_transform/task.py
+++ b/python/michelangelo/workflow/tasks/tabular_native_transform/task.py
@@ -16,6 +16,9 @@ import logging
 import time
 from typing import TYPE_CHECKING
 
+import ray
+from packaging import version
+
 from michelangelo.lib.native_transform.torch import (
     TorchTransformModule,
     TransformSpec,
@@ -46,6 +49,7 @@ from michelangelo.workflow.variables.types import NativeTransformResult
 
 if TYPE_CHECKING:
     from michelangelo.lib.artifact_manager.storage_backend import StorageBackend
+    from michelangelo.workflow.schema.ray_data_io import WriteConfig
     from michelangelo.workflow.schema.tabular_native_transform import (
         TabularNativeTransformConfig,
     )
@@ -53,6 +57,13 @@ if TYPE_CHECKING:
 _logger = logging.getLogger(__name__)
 
 __all__ = ["tabular_native_transform"]
+
+# Ray version floors below which `Dataset.write_parquet` silently swallows the
+# kwarg into `**arrow_parquet_args` instead of applying it, later raising a
+# confusing `TypeError` from inside a write task rather than failing at
+# config time. See `parquet_io.py`'s analogous 2.50 read-API gate.
+_MIN_RAY_VERSION_FOR_MAX_ROWS_PER_FILE = version.parse("2.48")
+_MIN_RAY_VERSION_FOR_MIN_ROWS_PER_FILE = version.parse("2.43")
 
 
 def tabular_native_transform(
@@ -100,6 +111,8 @@ def tabular_native_transform(
         min_block_size=rc.min_block_size if rc else None,
         max_block_size=rc.max_block_size if rc else None,
         retried_io_errors=rc.retried_io_errors if rc else None,
+        object_store_memory_limit=rc.object_store_memory_limit if rc else None,
+        wait_for_min_actors_s=rc.wait_for_min_actors_s if rc else None,
     )
 
     inc = config.incremental_training
@@ -164,12 +177,7 @@ def tabular_native_transform(
     _logger.info("Creating transform module (model) from transform spec")
     model_variable = _create_transform_model(transform_spec, feature_stats, sample_data)
 
-    write_kwargs = {}
-    if config.write_config:
-        if config.write_config.max_rows_per_file is not None:
-            write_kwargs["max_rows_per_file"] = config.write_config.max_rows_per_file
-        if config.write_config.min_rows_per_file is not None:
-            write_kwargs["min_rows_per_file"] = config.write_config.min_rows_per_file
+    write_kwargs = _write_config_to_kwargs(config.write_config)
     _save_datasets(transformed_datasets, **write_kwargs)
 
     if incremental_training.is_incremental(inc) and model_variable is None:
@@ -370,6 +378,46 @@ def _create_transform_model(
     model_variable.save()
 
     return model_variable
+
+
+def _write_config_to_kwargs(write_config: WriteConfig | None) -> dict:
+    """Convert a ``WriteConfig`` into ``write_parquet`` kwargs, gated by Ray version.
+
+    ``max_rows_per_file``/``min_rows_per_file`` are only understood by
+    ``Dataset.write_parquet`` from Ray 2.48/2.43 onward respectively. On an
+    older Ray, the kwarg isn't rejected up front — it flows through to
+    PyArrow's writer as an unexpected option and fails deep inside a write
+    task, after the whole transform has already run. Fail fast here instead.
+
+    Raises:
+        ConfigurationError: If ``write_config`` requests a kwarg the
+            installed Ray version doesn't support.
+    """
+    if not write_config:
+        return {}
+
+    ray_version = version.parse(ray.__version__)
+    write_kwargs = {}
+
+    if write_config.max_rows_per_file is not None:
+        if ray_version < _MIN_RAY_VERSION_FOR_MAX_ROWS_PER_FILE:
+            raise ConfigurationError(
+                f"write_config.max_rows_per_file requires Ray >= "
+                f"{_MIN_RAY_VERSION_FOR_MAX_ROWS_PER_FILE}, but installed Ray is "
+                f"{ray.__version__}."
+            )
+        write_kwargs["max_rows_per_file"] = write_config.max_rows_per_file
+
+    if write_config.min_rows_per_file is not None:
+        if ray_version < _MIN_RAY_VERSION_FOR_MIN_ROWS_PER_FILE:
+            raise ConfigurationError(
+                f"write_config.min_rows_per_file requires Ray >= "
+                f"{_MIN_RAY_VERSION_FOR_MIN_ROWS_PER_FILE}, but installed Ray is "
+                f"{ray.__version__}."
+            )
+        write_kwargs["min_rows_per_file"] = write_config.min_rows_per_file
+
+    return write_kwargs
 
 
 def _save_datasets(

--- a/python/michelangelo/workflow/tasks/tabular_native_transform/tests/__init__.py
+++ b/python/michelangelo/workflow/tasks/tabular_native_transform/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the ``tabular_native_transform`` workflow task."""

--- a/python/michelangelo/workflow/tasks/tabular_native_transform/tests/incremental_training_test.py
+++ b/python/michelangelo/workflow/tasks/tabular_native_transform/tests/incremental_training_test.py
@@ -1,0 +1,263 @@
+"""Tests for tabular_native_transform._private.incremental_training."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from unittest import TestCase
+
+import pytest
+import yaml
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("pydantic")
+
+from michelangelo.lib.artifact_manager.storage_backend import (  # noqa: E402
+    LocalStorageBackend,
+)
+from michelangelo.lib.native_transform.torch.transform_layer_spec import (  # noqa: E402
+    TransformerMode,
+)
+from michelangelo.lib.native_transform.torch.transform_spec import (  # noqa: E402
+    TransformSpec,
+)
+from michelangelo.workflow.schema.exceptions import ConfigurationError  # noqa: E402
+from michelangelo.workflow.schema.tabular_native_transform import (  # noqa: E402
+    IncrementalTrainingConfig,
+    TrainingType,
+)
+from michelangelo.workflow.tasks.tabular_native_transform._private import (  # noqa: E402
+    incremental_training,
+)
+
+_BASE_RAW_SPEC = {
+    "transform_specs": [
+        {
+            "transform_name": "Concatenate",
+            "input_cols": ["col1"],
+            "output_cols": ["col1_concatenated"],
+        },
+        {
+            "transform_name": "StandardScaler",
+            "input_cols": ["col3"],
+            "output_cols": ["col3_scaled"],
+            "with_std": True,
+        },
+    ]
+}
+
+
+def _fitted_base_spec_dict() -> dict:
+    """Build a base spec dict as it would be persisted after a BASE run fit.
+
+    The ``StandardScaler`` placeholder resolves to a concrete
+    ``NormalizationLayerSpec`` once fitted.
+    """
+    spec = TransformSpec(raw_transform_specs=_BASE_RAW_SPEC)
+    # Simulate fitting: hydrate the StandardScaler placeholder.
+    spec.update_standard_scaler_specs({"col3_mean": 1.0, "col3_std": 2.0})
+    return spec.to_dict()
+
+
+class IsIncrementalIsBaselineTest(TestCase):
+    """Tests for is_incremental and is_baseline."""
+
+    def test_is_incremental_none_config(self):
+        """A None config is not incremental."""
+        self.assertFalse(incremental_training.is_incremental(None))
+
+    def test_is_incremental_true(self):
+        """TrainingType.INCREMENTAL is reported as incremental."""
+        cfg = IncrementalTrainingConfig(training_type=TrainingType.INCREMENTAL)
+        self.assertTrue(incremental_training.is_incremental(cfg))
+
+    def test_is_incremental_false_for_base(self):
+        """TrainingType.BASE is not reported as incremental."""
+        cfg = IncrementalTrainingConfig(training_type=TrainingType.BASE)
+        self.assertFalse(incremental_training.is_incremental(cfg))
+
+    def test_is_baseline_true(self):
+        """TrainingType.BASE is reported as a baseline run."""
+        cfg = IncrementalTrainingConfig(training_type=TrainingType.BASE)
+        self.assertTrue(incremental_training.is_baseline(cfg))
+
+    def test_is_baseline_none_config(self):
+        """A None config is not a baseline run."""
+        self.assertFalse(incremental_training.is_baseline(None))
+
+
+class LoadIncrementalArtifactsTest(TestCase):
+    """Tests for load_incremental_artifacts."""
+
+    def setUp(self):
+        """Create a temp-dir-backed LocalStorageBackend for each test."""
+        self._tmp = tempfile.mkdtemp()
+        self.backend = LocalStorageBackend(base_dir=self._tmp)
+
+    def _upload_base_run(self, spec_dict, feature_stats=None) -> str:
+        """Upload a fake base run's artifacts and return its URI."""
+        src = tempfile.mkdtemp()
+        with open(os.path.join(src, "transform_spec.yaml"), "w") as f:
+            yaml.safe_dump(spec_dict, f)
+        if feature_stats is not None:
+            with open(os.path.join(src, "transform_feature_stats.yaml"), "w") as f:
+                yaml.safe_dump(feature_stats, f)
+        return self.backend.upload(src, "base-run")
+
+    def test_requires_baseline_model_uri(self):
+        """A missing baseline_model_uri raises ConfigurationError."""
+        cfg = IncrementalTrainingConfig(training_type=TrainingType.INCREMENTAL)
+        with self.assertRaises(ConfigurationError):
+            incremental_training.load_incremental_artifacts(cfg, self.backend)
+
+    def test_loads_spec_and_stats(self):
+        """The transform spec and feature stats are loaded from the base run."""
+        uri = self._upload_base_run(
+            _fitted_base_spec_dict(), feature_stats={"col3_mean": 1.0, "col3_std": 2.0}
+        )
+        cfg = IncrementalTrainingConfig(
+            training_type=TrainingType.INCREMENTAL, baseline_model_uri=uri
+        )
+        spec, stats = incremental_training.load_incremental_artifacts(cfg, self.backend)
+        self.assertIsInstance(spec, TransformSpec)
+        self.assertEqual(stats, {"col3_mean": 1.0, "col3_std": 2.0})
+
+    def test_missing_feature_stats_file_returns_empty_dict(self):
+        """A base run with no feature stats file yields an empty stats dict."""
+        uri = self._upload_base_run(_fitted_base_spec_dict())
+        cfg = IncrementalTrainingConfig(
+            training_type=TrainingType.INCREMENTAL, baseline_model_uri=uri
+        )
+        _, stats = incremental_training.load_incremental_artifacts(cfg, self.backend)
+        self.assertEqual(stats, {})
+
+    def test_missing_transform_spec_file_raises(self):
+        """A base run with no transform_spec.yaml raises ConfigurationError."""
+        src = tempfile.mkdtemp()
+        with open(os.path.join(src, "unrelated.txt"), "w") as f:
+            f.write("x")
+        uri = self.backend.upload(src, "empty-base-run")
+        cfg = IncrementalTrainingConfig(
+            training_type=TrainingType.INCREMENTAL, baseline_model_uri=uri
+        )
+        with self.assertRaises(ConfigurationError):
+            incremental_training.load_incremental_artifacts(cfg, self.backend)
+
+    def test_enforce_full_reuse_rejects_non_reuse_layer(self):
+        """enforce_full_reuse=True rejects a base spec with a non-REUSE layer."""
+        spec = TransformSpec(raw_transform_specs=_BASE_RAW_SPEC)
+        spec.update_standard_scaler_specs({"col3_mean": 1.0, "col3_std": 2.0})
+        for layer_spec in spec.transform_specs.values():
+            layer_spec.mode = TransformerMode.REFIT
+        uri = self._upload_base_run(spec.to_dict())
+        cfg = IncrementalTrainingConfig(
+            training_type=TrainingType.INCREMENTAL,
+            baseline_model_uri=uri,
+            enforce_full_reuse=True,
+        )
+        with self.assertRaises(ConfigurationError):
+            incremental_training.load_incremental_artifacts(cfg, self.backend)
+
+    def test_enforce_full_reuse_false_skips_validation(self):
+        """enforce_full_reuse=False skips the REUSE-mode validation."""
+        spec = TransformSpec(raw_transform_specs=_BASE_RAW_SPEC)
+        spec.update_standard_scaler_specs({"col3_mean": 1.0, "col3_std": 2.0})
+        for layer_spec in spec.transform_specs.values():
+            layer_spec.mode = TransformerMode.REFIT
+        uri = self._upload_base_run(spec.to_dict())
+        cfg = IncrementalTrainingConfig(
+            training_type=TrainingType.INCREMENTAL,
+            baseline_model_uri=uri,
+            enforce_full_reuse=False,
+        )
+        loaded_spec, _ = incremental_training.load_incremental_artifacts(
+            cfg, self.backend
+        )
+        self.assertIsInstance(loaded_spec, TransformSpec)
+
+
+class MergeSpecsForSelectiveRefitTest(TestCase):
+    """Tests for merge_specs_for_selective_refit."""
+
+    def _base_spec(self) -> TransformSpec:
+        """Build a fitted, all-REUSE base spec fixture."""
+        spec = TransformSpec(raw_transform_specs=_BASE_RAW_SPEC)
+        spec.update_standard_scaler_specs({"col3_mean": 1.0, "col3_std": 2.0})
+        for layer_spec in spec.transform_specs.values():
+            layer_spec.mode = TransformerMode.REUSE
+        return spec
+
+    def test_config_layer_refits_matching_base_layer(self):
+        """A REFIT config layer replaces the matching base layer and drops its stats."""
+        base_spec = self._base_spec()
+        config_spec = TransformSpec(raw_transform_specs=_BASE_RAW_SPEC)
+        for layer_spec in config_spec.transform_specs.values():
+            if type(layer_spec).__name__ == "StandardScalerLayerSpec":
+                layer_spec.mode = TransformerMode.REFIT
+
+        merged, filtered_stats = incremental_training.merge_specs_for_selective_refit(
+            base_spec, config_spec, {"col3_mean": 1.0, "col3_std": 2.0}
+        )
+
+        modes = {type(ls).__name__: ls.mode for ls in merged.transform_specs.values()}
+        self.assertEqual(modes["StandardScalerLayerSpec"], TransformerMode.REFIT)
+        # REFIT layer's stats are dropped so the pipeline recomputes them.
+        self.assertEqual(filtered_stats, {})
+
+    def test_non_refit_layer_not_matching_base_raises(self):
+        """A non-REFIT config layer with no matching base layer raises."""
+        base_spec = self._base_spec()
+        config_spec = TransformSpec(
+            raw_transform_specs={
+                "transform_specs": [
+                    {
+                        "transform_name": "Concatenate",
+                        "input_cols": ["unrelated_col"],
+                        "output_cols": ["unrelated_out"],
+                    },
+                ]
+            }
+        )
+        with self.assertRaises(ConfigurationError):
+            incremental_training.merge_specs_for_selective_refit(
+                base_spec, config_spec, {}
+            )
+
+    def test_reuse_layer_consuming_refit_output_logs_warning(self):
+        """A REUSE layer downstream of a REFIT layer merges without raising."""
+        base_spec = TransformSpec(
+            raw_transform_specs={
+                "transform_specs": [
+                    {
+                        "transform_name": "Concatenate",
+                        "input_cols": ["col1"],
+                        "output_cols": ["col1_concatenated"],
+                    },
+                    {
+                        "transform_name": "Concatenate",
+                        "input_cols": ["col1_concatenated"],
+                        "output_cols": ["col1_final"],
+                    },
+                ]
+            }
+        )
+        for layer_spec in base_spec.transform_specs.values():
+            layer_spec.mode = TransformerMode.REUSE
+
+        config_spec = TransformSpec(
+            raw_transform_specs={
+                "transform_specs": [
+                    {
+                        "transform_name": "Concatenate",
+                        "input_cols": ["col1"],
+                        "output_cols": ["col1_concatenated"],
+                        "mode": TransformerMode.REFIT.value,
+                    },
+                ]
+            }
+        )
+
+        merged, _ = incremental_training.merge_specs_for_selective_refit(
+            base_spec, config_spec, {}
+        )
+        self.assertEqual(len(merged.transform_specs), 2)

--- a/python/michelangelo/workflow/tasks/tabular_native_transform/tests/incremental_training_test.py
+++ b/python/michelangelo/workflow/tasks/tabular_native_transform/tests/incremental_training_test.py
@@ -21,11 +21,11 @@ from michelangelo.lib.native_transform.torch.transform_layer_spec import (  # no
 from michelangelo.lib.native_transform.torch.transform_spec import (  # noqa: E402
     TransformSpec,
 )
-from michelangelo.workflow.schema.exceptions import ConfigurationError  # noqa: E402
-from michelangelo.workflow.schema.tabular_native_transform import (  # noqa: E402
+from michelangelo.workflow.schema.common import (  # noqa: E402
     IncrementalTrainingConfig,
     TrainingTypeConfig,
 )
+from michelangelo.workflow.schema.exceptions import ConfigurationError  # noqa: E402
 from michelangelo.workflow.tasks.tabular_native_transform._private import (  # noqa: E402
     incremental_training,
 )
@@ -84,6 +84,17 @@ class IsIncrementalIsBaselineTest(TestCase):
     def test_is_baseline_none_config(self):
         """A None config is not a baseline run."""
         self.assertFalse(incremental_training.is_baseline(None))
+
+    def test_default_training_type_is_neither(self):
+        """Default (unset) training_type is neither incremental nor baseline.
+
+        Preserves the behavior the removed ``INVALID`` sentinel used to
+        provide, now represented as ``None``.
+        """
+        cfg = IncrementalTrainingConfig()
+        self.assertIsNone(cfg.training_type)
+        self.assertFalse(incremental_training.is_incremental(cfg))
+        self.assertFalse(incremental_training.is_baseline(cfg))
 
 
 class LoadIncrementalArtifactsTest(TestCase):

--- a/python/michelangelo/workflow/tasks/tabular_native_transform/tests/incremental_training_test.py
+++ b/python/michelangelo/workflow/tasks/tabular_native_transform/tests/incremental_training_test.py
@@ -24,7 +24,7 @@ from michelangelo.lib.native_transform.torch.transform_spec import (  # noqa: E4
 from michelangelo.workflow.schema.exceptions import ConfigurationError  # noqa: E402
 from michelangelo.workflow.schema.tabular_native_transform import (  # noqa: E402
     IncrementalTrainingConfig,
-    TrainingType,
+    TrainingTypeConfig,
 )
 from michelangelo.workflow.tasks.tabular_native_transform._private import (  # noqa: E402
     incremental_training,
@@ -67,18 +67,18 @@ class IsIncrementalIsBaselineTest(TestCase):
         self.assertFalse(incremental_training.is_incremental(None))
 
     def test_is_incremental_true(self):
-        """TrainingType.INCREMENTAL is reported as incremental."""
-        cfg = IncrementalTrainingConfig(training_type=TrainingType.INCREMENTAL)
+        """TrainingTypeConfig.INCREMENTAL is reported as incremental."""
+        cfg = IncrementalTrainingConfig(training_type=TrainingTypeConfig.INCREMENTAL)
         self.assertTrue(incremental_training.is_incremental(cfg))
 
     def test_is_incremental_false_for_base(self):
-        """TrainingType.BASE is not reported as incremental."""
-        cfg = IncrementalTrainingConfig(training_type=TrainingType.BASE)
+        """TrainingTypeConfig.BASE is not reported as incremental."""
+        cfg = IncrementalTrainingConfig(training_type=TrainingTypeConfig.BASE)
         self.assertFalse(incremental_training.is_incremental(cfg))
 
     def test_is_baseline_true(self):
-        """TrainingType.BASE is reported as a baseline run."""
-        cfg = IncrementalTrainingConfig(training_type=TrainingType.BASE)
+        """TrainingTypeConfig.BASE is reported as a baseline run."""
+        cfg = IncrementalTrainingConfig(training_type=TrainingTypeConfig.BASE)
         self.assertTrue(incremental_training.is_baseline(cfg))
 
     def test_is_baseline_none_config(self):
@@ -106,7 +106,7 @@ class LoadIncrementalArtifactsTest(TestCase):
 
     def test_requires_baseline_model_uri(self):
         """A missing baseline_model_uri raises ConfigurationError."""
-        cfg = IncrementalTrainingConfig(training_type=TrainingType.INCREMENTAL)
+        cfg = IncrementalTrainingConfig(training_type=TrainingTypeConfig.INCREMENTAL)
         with self.assertRaises(ConfigurationError):
             incremental_training.load_incremental_artifacts(cfg, self.backend)
 
@@ -116,7 +116,7 @@ class LoadIncrementalArtifactsTest(TestCase):
             _fitted_base_spec_dict(), feature_stats={"col3_mean": 1.0, "col3_std": 2.0}
         )
         cfg = IncrementalTrainingConfig(
-            training_type=TrainingType.INCREMENTAL, baseline_model_uri=uri
+            training_type=TrainingTypeConfig.INCREMENTAL, baseline_model_uri=uri
         )
         spec, stats = incremental_training.load_incremental_artifacts(cfg, self.backend)
         self.assertIsInstance(spec, TransformSpec)
@@ -126,7 +126,7 @@ class LoadIncrementalArtifactsTest(TestCase):
         """A base run with no feature stats file yields an empty stats dict."""
         uri = self._upload_base_run(_fitted_base_spec_dict())
         cfg = IncrementalTrainingConfig(
-            training_type=TrainingType.INCREMENTAL, baseline_model_uri=uri
+            training_type=TrainingTypeConfig.INCREMENTAL, baseline_model_uri=uri
         )
         _, stats = incremental_training.load_incremental_artifacts(cfg, self.backend)
         self.assertEqual(stats, {})
@@ -138,7 +138,7 @@ class LoadIncrementalArtifactsTest(TestCase):
             f.write("x")
         uri = self.backend.upload(src, "empty-base-run")
         cfg = IncrementalTrainingConfig(
-            training_type=TrainingType.INCREMENTAL, baseline_model_uri=uri
+            training_type=TrainingTypeConfig.INCREMENTAL, baseline_model_uri=uri
         )
         with self.assertRaises(ConfigurationError):
             incremental_training.load_incremental_artifacts(cfg, self.backend)
@@ -151,7 +151,7 @@ class LoadIncrementalArtifactsTest(TestCase):
             layer_spec.mode = TransformerMode.REFIT
         uri = self._upload_base_run(spec.to_dict())
         cfg = IncrementalTrainingConfig(
-            training_type=TrainingType.INCREMENTAL,
+            training_type=TrainingTypeConfig.INCREMENTAL,
             baseline_model_uri=uri,
             enforce_full_reuse=True,
         )
@@ -166,7 +166,7 @@ class LoadIncrementalArtifactsTest(TestCase):
             layer_spec.mode = TransformerMode.REFIT
         uri = self._upload_base_run(spec.to_dict())
         cfg = IncrementalTrainingConfig(
-            training_type=TrainingType.INCREMENTAL,
+            training_type=TrainingTypeConfig.INCREMENTAL,
             baseline_model_uri=uri,
             enforce_full_reuse=False,
         )

--- a/python/michelangelo/workflow/tasks/tabular_native_transform/tests/incremental_training_test.py
+++ b/python/michelangelo/workflow/tasks/tabular_native_transform/tests/incremental_training_test.py
@@ -205,7 +205,13 @@ class MergeSpecsForSelectiveRefitTest(TestCase):
         self.assertEqual(filtered_stats, {})
 
     def test_non_refit_layer_not_matching_base_raises(self):
-        """A non-REFIT config layer with no matching base layer raises."""
+        """A non-REFIT config layer with no matching base layer raises.
+
+        The unmatched layer's mode here defaults to INVALID (not set
+        explicitly) -- the error message must report the layer's actual
+        mode, not a hardcoded one, so this also guards against the message
+        claiming "mode=REUSE" for a layer that is not REUSE.
+        """
         base_spec = self._base_spec()
         config_spec = TransformSpec(
             raw_transform_specs={
@@ -218,10 +224,15 @@ class MergeSpecsForSelectiveRefitTest(TestCase):
                 ]
             }
         )
-        with self.assertRaises(ConfigurationError):
+        (unmatched_layer,) = config_spec.transform_specs.values()
+        self.assertEqual(unmatched_layer.mode, TransformerMode.INVALID)
+
+        with self.assertRaises(ConfigurationError) as ctx:
             incremental_training.merge_specs_for_selective_refit(
                 base_spec, config_spec, {}
             )
+        self.assertIn("mode=INVALID", str(ctx.exception))
+        self.assertNotIn("mode=REUSE", str(ctx.exception))
 
     def test_reuse_layer_consuming_refit_output_logs_warning(self):
         """A REUSE layer downstream of a REFIT layer merges without raising."""

--- a/python/michelangelo/workflow/tasks/tabular_native_transform/tests/task_test.py
+++ b/python/michelangelo/workflow/tasks/tabular_native_transform/tests/task_test.py
@@ -1,0 +1,456 @@
+"""Tests for michelangelo.workflow.tasks.tabular_native_transform.task."""
+
+from __future__ import annotations
+
+from unittest import TestCase
+from unittest.mock import patch
+
+import pytest
+
+ray = pytest.importorskip("ray")
+pytest.importorskip("torch")
+pytest.importorskip("pydantic")
+
+from michelangelo.lib.artifact_manager.storage_backend import (  # noqa: E402
+    LocalStorageBackend,
+)
+from michelangelo.workflow.schema.exceptions import ConfigurationError  # noqa: E402
+from michelangelo.workflow.schema.ray_data_io import RayDataContextConfig  # noqa: E402
+from michelangelo.workflow.schema.tabular_native_transform import (  # noqa: E402
+    BatchOptions,
+    IncrementalTrainingConfig,
+    TabularNativeTransformConfig,
+    TrainingType,
+)
+from michelangelo.workflow.tasks.tabular_native_transform._private import (  # noqa: E402
+    incremental_training,
+)
+from michelangelo.workflow.tasks.tabular_native_transform.task import (  # noqa: E402
+    _create_transform_model,
+    _load_transform_spec,
+    _save_datasets,
+    _validate_datasets,
+    tabular_native_transform,
+)
+from michelangelo.workflow.variables import DatasetVariable  # noqa: E402
+from michelangelo.workflow.variables.types import NativeTransformResult  # noqa: E402
+
+_TASK = "michelangelo.workflow.tasks.tabular_native_transform.task"
+
+_SIMPLE_SPEC = {
+    "transform_specs": [
+        {
+            "transform_name": "Concatenate",
+            "input_cols": ["feature1"],
+            "output_cols": ["feature1_out"],
+        },
+    ]
+}
+
+
+def _ray_dataset(rows):
+    """Build a small in-memory Ray Dataset from a list of row dicts."""
+    return ray.data.from_items(rows)
+
+
+def setup_module(_module):
+    """Start one Ray instance for every test in this module.
+
+    Several test classes below call ``ray.data.from_items``, which silently
+    auto-starts a local Ray instance if one isn't already running. Without a
+    single shared init/shutdown for the whole module, a class that never
+    explicitly shuts Ray down leaks a live Ray instance into whichever test
+    module runs next in the same pytest process (observed against
+    ``workflow/variables/tests/variables_test.py``, which dispatches
+    ``DatasetVariable._load()`` differently depending on
+    ``ray.is_initialized()``).
+    """
+    if not ray.is_initialized():
+        ray.init(ignore_reinit_error=True, num_cpus=1)
+
+
+def teardown_module(_module):
+    """Shut down the module-shared Ray instance started by setup_module."""
+    ray.shutdown()
+
+
+class TabularNativeTransformTaskTest(TestCase):
+    """Tests for tabular_native_transform (the top-level task function)."""
+
+    def setUp(self):
+        """Build a small two-row fixture reused across tests."""
+        self.rows = [
+            {"feature1": 1.0, "feature2": 2.0},
+            {"feature1": 2.0, "feature2": 3.0},
+        ]
+
+    # -- set_ray_data_context wiring -----------------------------------
+
+    @patch(f"{_TASK}.set_ray_data_context")
+    def test_calls_set_ray_data_context_with_defaults(self, mock_set_context):
+        """set_ray_data_context is called with None defaults when unset."""
+        train = DatasetVariable.create(None)
+        config = TabularNativeTransformConfig(transform_spec=None)
+        tabular_native_transform(config, {"train": train})
+        mock_set_context.assert_called_once_with(
+            min_block_size=None, max_block_size=None, retried_io_errors=None
+        )
+
+    @patch(f"{_TASK}.set_ray_data_context")
+    def test_forwards_ray_data_context_config(self, mock_set_context):
+        """config.ray_data_context values are forwarded to set_ray_data_context."""
+        train = DatasetVariable.create(None)
+        config = TabularNativeTransformConfig(
+            transform_spec=None,
+            ray_data_context=RayDataContextConfig(
+                min_block_size=1024, max_block_size=2048, retried_io_errors=["oops"]
+            ),
+        )
+        tabular_native_transform(config, {"train": train})
+        mock_set_context.assert_called_once_with(
+            min_block_size=1024, max_block_size=2048, retried_io_errors=["oops"]
+        )
+
+    # -- early return ----------------------------------------------------
+
+    def test_no_transform_spec_returns_datasets_unchanged(self):
+        """With no transform_spec and no incremental mode, datasets pass through."""
+        train = DatasetVariable.create(None)
+        config = TabularNativeTransformConfig(transform_spec=None)
+        result = tabular_native_transform(config, {"train": train})
+        self.assertIsInstance(result, NativeTransformResult)
+        self.assertIs(result.transformed_datasets["train"], train)
+        self.assertIsNone(result.model)
+
+    # -- validation --------------------------------------------------------
+
+    def test_validate_datasets_raises_for_empty_dict(self):
+        """An empty datasets dict raises ConfigurationError."""
+        with self.assertRaises(ConfigurationError):
+            _validate_datasets({})
+
+    def test_validate_datasets_raises_when_all_empty(self):
+        """A dict of only empty datasets raises ConfigurationError."""
+        empty = DatasetVariable.create(_ray_dataset([]))
+        with self.assertRaises(ConfigurationError):
+            _validate_datasets({"train": empty})
+
+    def test_validate_datasets_passes_with_one_non_empty(self):
+        """At least one non-empty dataset satisfies validation."""
+        empty = DatasetVariable.create(_ray_dataset([]))
+        non_empty = DatasetVariable.create(_ray_dataset(self.rows))
+        _validate_datasets({"train": non_empty, "test": empty})  # no raise
+
+    # -- _load_transform_spec ----------------------------------------------
+
+    def test_load_transform_spec_from_dict(self):
+        """An inlined dict transform_spec is parsed into a TransformSpec."""
+        config = TabularNativeTransformConfig(transform_spec=dict(_SIMPLE_SPEC))
+        spec = _load_transform_spec(config)
+        self.assertEqual(len(spec.transform_specs), 1)
+
+    def test_load_transform_spec_invalid_type_raises(self):
+        """A transform_spec that is neither dict nor str raises ConfigurationError."""
+        config = TabularNativeTransformConfig(transform_spec=123)  # type: ignore[arg-type]
+        with self.assertRaises(ConfigurationError):
+            _load_transform_spec(config)
+
+    def test_load_transform_spec_from_yaml_file_path(self):
+        """A string transform_spec is resolved and loaded as a YAML file path."""
+        import tempfile
+
+        import yaml
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False
+        ) as tmp_file:
+            yaml.safe_dump(_SIMPLE_SPEC, tmp_file)
+            tmp_path = tmp_file.name
+        config = TabularNativeTransformConfig(transform_spec=tmp_path)
+        spec = _load_transform_spec(config)
+        self.assertEqual(len(spec.transform_specs), 1)
+
+    # -- incremental mode requires storage_backend --------------------------
+
+    def test_incremental_without_storage_backend_raises(self):
+        """INCREMENTAL mode without a storage_backend raises ConfigurationError."""
+        train = DatasetVariable.create(_ray_dataset(self.rows))
+        config = TabularNativeTransformConfig(
+            transform_spec=None,
+            incremental_training=IncrementalTrainingConfig(
+                training_type=TrainingType.INCREMENTAL,
+                baseline_model_uri="file:///does/not/matter",
+            ),
+        )
+        with self.assertRaises(ConfigurationError):
+            tabular_native_transform(config, {"train": train})
+
+    # -- incremental mode end-to-end -----------------------------------
+
+    @patch.object(DatasetVariable, "save_ray_dataset")
+    @patch(f"{_TASK}.native_transform")
+    @patch.object(incremental_training, "load_incremental_artifacts")
+    def test_incremental_with_full_reuse_uses_base_spec_and_stats(
+        self, mock_load_artifacts, mock_transform, _mock_save
+    ):
+        """enforce_full_reuse=True (default) reuses the base run's spec and stats."""
+        train = DatasetVariable.create(_ray_dataset(self.rows))
+        base_spec = _load_transform_spec(
+            TabularNativeTransformConfig(transform_spec=dict(_SIMPLE_SPEC))
+        )
+        mock_load_artifacts.return_value = (base_spec, {"feature1_out_mean": 1.0})
+        mock_transform.return_value = (_ray_dataset(self.rows), base_spec, {})
+
+        config = TabularNativeTransformConfig(
+            transform_spec=None,
+            incremental_training=IncrementalTrainingConfig(
+                training_type=TrainingType.INCREMENTAL,
+                baseline_model_uri="file:///does/not/matter",
+            ),
+        )
+        result = tabular_native_transform(
+            config,
+            {"train": train},
+            storage_backend=LocalStorageBackend(base_dir="/tmp"),
+        )
+        mock_load_artifacts.assert_called_once()
+        self.assertIsNotNone(result.model)
+
+    @patch.object(DatasetVariable, "save_ray_dataset")
+    @patch(f"{_TASK}.native_transform")
+    @patch.object(incremental_training, "merge_specs_for_selective_refit")
+    @patch.object(incremental_training, "load_incremental_artifacts")
+    def test_incremental_without_full_reuse_merges_config_spec(
+        self, mock_load_artifacts, mock_merge, mock_transform, _mock_save
+    ):
+        """enforce_full_reuse=False loads the config spec and merges it for refit."""
+        train = DatasetVariable.create(_ray_dataset(self.rows))
+        base_spec = _load_transform_spec(
+            TabularNativeTransformConfig(transform_spec=dict(_SIMPLE_SPEC))
+        )
+        mock_load_artifacts.return_value = (base_spec, {"feature1_out_mean": 1.0})
+        mock_merge.return_value = (base_spec, {})
+        mock_transform.return_value = (_ray_dataset(self.rows), base_spec, {})
+
+        config = TabularNativeTransformConfig(
+            transform_spec=dict(_SIMPLE_SPEC),
+            incremental_training=IncrementalTrainingConfig(
+                training_type=TrainingType.INCREMENTAL,
+                baseline_model_uri="file:///does/not/matter",
+                enforce_full_reuse=False,
+            ),
+        )
+        result = tabular_native_transform(
+            config,
+            {"train": train},
+            storage_backend=LocalStorageBackend(base_dir="/tmp"),
+        )
+        mock_merge.assert_called_once()
+        self.assertIsNotNone(result.model)
+
+    @patch.object(DatasetVariable, "save_ray_dataset")
+    @patch(f"{_TASK}.get_transform_module")
+    @patch(f"{_TASK}.native_transform")
+    @patch.object(incremental_training, "load_incremental_artifacts")
+    def test_incremental_with_no_model_raises(
+        self, mock_load_artifacts, mock_transform, mock_get_module, _mock_save
+    ):
+        """INCREMENTAL mode yielding no transform module raises ConfigurationError."""
+        train = DatasetVariable.create(_ray_dataset(self.rows))
+        base_spec = _load_transform_spec(
+            TabularNativeTransformConfig(transform_spec=dict(_SIMPLE_SPEC))
+        )
+        mock_load_artifacts.return_value = (base_spec, {})
+        mock_transform.return_value = (_ray_dataset(self.rows), base_spec, {})
+        mock_get_module.return_value = None
+
+        config = TabularNativeTransformConfig(
+            transform_spec=None,
+            incremental_training=IncrementalTrainingConfig(
+                training_type=TrainingType.INCREMENTAL,
+                baseline_model_uri="file:///does/not/matter",
+            ),
+        )
+        with self.assertRaises(ConfigurationError):
+            tabular_native_transform(
+                config,
+                {"train": train},
+                storage_backend=LocalStorageBackend(base_dir="/tmp"),
+            )
+
+    # -- end-to-end happy path ------------------------------------------
+
+    @patch.object(DatasetVariable, "save_ray_dataset")
+    @patch(f"{_TASK}.native_transform")
+    def test_happy_path_produces_model_and_transformed_datasets(
+        self, mock_transform, _mock_save
+    ):
+        """A full run with a real spec produces a model and derived features."""
+        train = DatasetVariable.create(_ray_dataset(self.rows))
+        mock_transform.return_value = (
+            _ray_dataset(self.rows),
+            _load_transform_spec(
+                TabularNativeTransformConfig(transform_spec=dict(_SIMPLE_SPEC))
+            ),
+            {},
+        )
+        config = TabularNativeTransformConfig(
+            transform_spec=dict(_SIMPLE_SPEC),
+            batch_options=BatchOptions(batch_size=10),
+        )
+        result = tabular_native_transform(config, {"train": train})
+        self.assertIn("train", result.transformed_datasets)
+        self.assertIsNotNone(result.model)
+        self.assertEqual(
+            result.transformed_datasets["train"].metadata.derived_features,
+            ["feature1_out"],
+        )
+
+    @patch.object(DatasetVariable, "save_ray_dataset")
+    @patch(f"{_TASK}.native_transform")
+    def test_columns_to_keep_used_for_derived_features(
+        self, mock_transform, _mock_save
+    ):
+        """When the spec sets columns_to_keep, derived features come from it."""
+        train = DatasetVariable.create(_ray_dataset(self.rows))
+        spec_with_keep = dict(_SIMPLE_SPEC)
+        spec_with_keep["columns_to_keep"] = ["feature1_out"]
+        mock_transform.return_value = (
+            _ray_dataset(self.rows),
+            _load_transform_spec(
+                TabularNativeTransformConfig(transform_spec=spec_with_keep)
+            ),
+            {},
+        )
+        config = TabularNativeTransformConfig(transform_spec=spec_with_keep)
+        result = tabular_native_transform(config, {"train": train})
+        self.assertEqual(
+            result.transformed_datasets["train"].metadata.derived_features,
+            ["feature1_out"],
+        )
+
+    @patch.object(DatasetVariable, "save_ray_dataset")
+    @patch.object(DatasetVariable, "load_ray_dataset")
+    @patch(f"{_TASK}.native_transform")
+    def test_parquet_read_config_forwarded_to_load_ray_dataset(
+        self, mock_transform, mock_load, _mock_save
+    ):
+        """config.parquet_read_config kwargs are forwarded to load_ray_dataset."""
+        train = DatasetVariable.create(_ray_dataset(self.rows))
+        mock_transform.return_value = (
+            _ray_dataset(self.rows),
+            _load_transform_spec(
+                TabularNativeTransformConfig(transform_spec=dict(_SIMPLE_SPEC))
+            ),
+            {},
+        )
+        from michelangelo.workflow.schema.ray_data_io import ParquetReadConfig
+
+        config = TabularNativeTransformConfig(
+            transform_spec=dict(_SIMPLE_SPEC),
+            parquet_read_config=ParquetReadConfig(concurrency=4),
+        )
+        tabular_native_transform(config, {"train": train})
+        mock_load.assert_called_once_with(concurrency=4)
+
+    @patch.object(DatasetVariable, "save_ray_dataset")
+    @patch(f"{_TASK}.native_transform")
+    def test_empty_dataset_passed_through_unchanged(self, mock_transform, _mock_save):
+        """A dataset with no rows is passed through unchanged, not transformed."""
+        train = DatasetVariable.create(_ray_dataset(self.rows))
+        empty_val = DatasetVariable.create(_ray_dataset([]))
+        mock_transform.return_value = (
+            _ray_dataset(self.rows),
+            _load_transform_spec(
+                TabularNativeTransformConfig(transform_spec=dict(_SIMPLE_SPEC))
+            ),
+            {},
+        )
+        config = TabularNativeTransformConfig(transform_spec=dict(_SIMPLE_SPEC))
+        result = tabular_native_transform(
+            config, {"train": train, "validation": empty_val}
+        )
+        self.assertIs(result.transformed_datasets["validation"], empty_val)
+
+    @patch.object(DatasetVariable, "save_ray_dataset")
+    @patch(f"{_TASK}.native_transform")
+    def test_write_config_forwarded_to_save_datasets(self, mock_transform, mock_save):
+        """config.write_config kwargs are forwarded to save_ray_dataset."""
+        train = DatasetVariable.create(_ray_dataset(self.rows))
+        mock_transform.return_value = (
+            _ray_dataset(self.rows),
+            _load_transform_spec(
+                TabularNativeTransformConfig(transform_spec=dict(_SIMPLE_SPEC))
+            ),
+            {},
+        )
+        from michelangelo.workflow.schema.ray_data_io import WriteConfig
+
+        config = TabularNativeTransformConfig(
+            transform_spec=dict(_SIMPLE_SPEC),
+            write_config=WriteConfig(max_rows_per_file=100, min_rows_per_file=10),
+        )
+        tabular_native_transform(config, {"train": train})
+        mock_save.assert_called_once_with(max_rows_per_file=100, min_rows_per_file=10)
+
+    @patch.object(DatasetVariable, "save_ray_dataset")
+    @patch(f"{_TASK}.get_transform_module")
+    @patch(f"{_TASK}.native_transform")
+    def test_no_transform_module_returns_none_model(
+        self, mock_transform, mock_get_module, _mock_save
+    ):
+        """When get_transform_module returns None, the result has no model."""
+        train = DatasetVariable.create(_ray_dataset(self.rows))
+        mock_transform.return_value = (
+            _ray_dataset(self.rows),
+            _load_transform_spec(
+                TabularNativeTransformConfig(transform_spec=dict(_SIMPLE_SPEC))
+            ),
+            {},
+        )
+        mock_get_module.return_value = None
+        config = TabularNativeTransformConfig(transform_spec=dict(_SIMPLE_SPEC))
+        result = tabular_native_transform(config, {"train": train})
+        self.assertIsNone(result.model)
+
+
+class CreateTransformModelTest(TestCase):
+    """Tests for _create_transform_model."""
+
+    def test_create_transform_model_populates_metadata(self):
+        """A non-empty spec produces a ModelVariable with populated metadata."""
+        spec = _load_transform_spec(
+            TabularNativeTransformConfig(transform_spec=dict(_SIMPLE_SPEC))
+        )
+        model_variable = _create_transform_model(
+            spec, feature_stats={}, sample_data={"feature1": 1.0}
+        )
+        self.assertIsNotNone(model_variable)
+        self.assertEqual(model_variable.metadata.training_framework, "pytorch")
+        self.assertIsNotNone(model_variable.metadata.transform_spec)
+        self.assertEqual(model_variable.metadata.feature_stats, {})
+
+    def test_create_transform_model_returns_none_for_empty_spec(self):
+        """A spec with no transform layers produces no model."""
+        spec = _load_transform_spec(
+            TabularNativeTransformConfig(transform_spec={"transform_specs": []})
+        )
+        self.assertIsNone(_create_transform_model(spec, {}, None))
+
+
+class SaveDatasetsTest(TestCase):
+    """Tests for _save_datasets."""
+
+    @patch.object(DatasetVariable, "save_ray_dataset")
+    def test_save_datasets_writes_directly(self, mock_save):
+        """Each dataset variable's save_ray_dataset is called with no kwargs."""
+        var = DatasetVariable.create(ray.data.from_items([{"x": 1}]))
+        _save_datasets({"train": var})
+        mock_save.assert_called_once_with()
+
+    @patch.object(DatasetVariable, "save_ray_dataset")
+    def test_save_datasets_forwards_write_kwargs(self, mock_save):
+        """Extra keyword arguments are forwarded to save_ray_dataset."""
+        var = DatasetVariable.create(ray.data.from_items([{"x": 1}]))
+        _save_datasets({"train": var}, max_rows_per_file=5)
+        mock_save.assert_called_once_with(max_rows_per_file=5)

--- a/python/michelangelo/workflow/tasks/tabular_native_transform/tests/task_test.py
+++ b/python/michelangelo/workflow/tasks/tabular_native_transform/tests/task_test.py
@@ -20,7 +20,7 @@ from michelangelo.workflow.schema.tabular_native_transform import (  # noqa: E40
     BatchOptions,
     IncrementalTrainingConfig,
     TabularNativeTransformConfig,
-    TrainingType,
+    TrainingTypeConfig,
 )
 from michelangelo.workflow.tasks.tabular_native_transform._private import (  # noqa: E402
     incremental_training,
@@ -190,7 +190,7 @@ class TabularNativeTransformTaskTest(TestCase):
         config = TabularNativeTransformConfig(
             transform_spec=None,
             incremental_training=IncrementalTrainingConfig(
-                training_type=TrainingType.INCREMENTAL,
+                training_type=TrainingTypeConfig.INCREMENTAL,
                 baseline_model_uri="file:///does/not/matter",
             ),
         )
@@ -216,7 +216,7 @@ class TabularNativeTransformTaskTest(TestCase):
         config = TabularNativeTransformConfig(
             transform_spec=None,
             incremental_training=IncrementalTrainingConfig(
-                training_type=TrainingType.INCREMENTAL,
+                training_type=TrainingTypeConfig.INCREMENTAL,
                 baseline_model_uri="file:///does/not/matter",
             ),
         )
@@ -247,7 +247,7 @@ class TabularNativeTransformTaskTest(TestCase):
         config = TabularNativeTransformConfig(
             transform_spec=dict(_SIMPLE_SPEC),
             incremental_training=IncrementalTrainingConfig(
-                training_type=TrainingType.INCREMENTAL,
+                training_type=TrainingTypeConfig.INCREMENTAL,
                 baseline_model_uri="file:///does/not/matter",
                 enforce_full_reuse=False,
             ),
@@ -279,7 +279,7 @@ class TabularNativeTransformTaskTest(TestCase):
         config = TabularNativeTransformConfig(
             transform_spec=None,
             incremental_training=IncrementalTrainingConfig(
-                training_type=TrainingType.INCREMENTAL,
+                training_type=TrainingTypeConfig.INCREMENTAL,
                 baseline_model_uri="file:///does/not/matter",
             ),
         )

--- a/python/michelangelo/workflow/tasks/tabular_native_transform/tests/task_test.py
+++ b/python/michelangelo/workflow/tasks/tabular_native_transform/tests/task_test.py
@@ -14,14 +14,16 @@ pytest.importorskip("pydantic")
 from michelangelo.lib.artifact_manager.storage_backend import (  # noqa: E402
     LocalStorageBackend,
 )
-from michelangelo.workflow.schema.exceptions import ConfigurationError  # noqa: E402
-from michelangelo.workflow.schema.ray_data_io import RayDataContextConfig  # noqa: E402
-from michelangelo.workflow.schema.tabular_native_transform import (  # noqa: E402
-    BatchOptions,
+from michelangelo.workflow.schema.common import (  # noqa: E402
     IncrementalTrainingConfig,
-    TabularNativeTransformConfig,
     TrainingTypeConfig,
 )
+from michelangelo.workflow.schema.exceptions import ConfigurationError  # noqa: E402
+from michelangelo.workflow.schema.native_transform import (  # noqa: E402
+    BatchOptions,
+    TabularNativeTransformConfig,
+)
+from michelangelo.workflow.schema.ray_data_io import RayDataContextConfig  # noqa: E402
 from michelangelo.workflow.tasks.tabular_native_transform._private import (  # noqa: E402
     incremental_training,
 )

--- a/python/michelangelo/workflow/tasks/tabular_native_transform/tests/task_test.py
+++ b/python/michelangelo/workflow/tasks/tabular_native_transform/tests/task_test.py
@@ -93,7 +93,11 @@ class TabularNativeTransformTaskTest(TestCase):
         config = TabularNativeTransformConfig(transform_spec=None)
         tabular_native_transform(config, {"train": train})
         mock_set_context.assert_called_once_with(
-            min_block_size=None, max_block_size=None, retried_io_errors=None
+            min_block_size=None,
+            max_block_size=None,
+            retried_io_errors=None,
+            object_store_memory_limit=None,
+            wait_for_min_actors_s=None,
         )
 
     @patch(f"{_TASK}.set_ray_data_context")
@@ -103,12 +107,20 @@ class TabularNativeTransformTaskTest(TestCase):
         config = TabularNativeTransformConfig(
             transform_spec=None,
             ray_data_context=RayDataContextConfig(
-                min_block_size=1024, max_block_size=2048, retried_io_errors=["oops"]
+                min_block_size=1024,
+                max_block_size=2048,
+                retried_io_errors=["oops"],
+                object_store_memory_limit=4096,
+                wait_for_min_actors_s=30,
             ),
         )
         tabular_native_transform(config, {"train": train})
         mock_set_context.assert_called_once_with(
-            min_block_size=1024, max_block_size=2048, retried_io_errors=["oops"]
+            min_block_size=1024,
+            max_block_size=2048,
+            retried_io_errors=["oops"],
+            object_store_memory_limit=4096,
+            wait_for_min_actors_s=30,
         )
 
     # -- early return ----------------------------------------------------
@@ -308,6 +320,44 @@ class TabularNativeTransformTaskTest(TestCase):
 
     @patch.object(DatasetVariable, "save_ray_dataset")
     @patch(f"{_TASK}.native_transform")
+    def test_train_processed_before_validation_regardless_of_dict_order(
+        self, mock_transform, _mock_save
+    ):
+        """Train is transformed first even when validation comes first in the dict.
+
+        Feature stats are computed from whichever split runs first through
+        ``native_transform`` (stats are threaded through the loop and only
+        computed once, when empty). Passing ``validation`` before ``train``
+        in the input dict must not change that: the *first* call into
+        ``native_transform`` must carry train's underlying Ray Dataset, not
+        validation's — collapsing dataset ordering to plain dict-insertion
+        order would silently fit stats on validation instead.
+        """
+        train_ray_dataset = _ray_dataset(self.rows)
+        validation_ray_dataset = _ray_dataset(self.rows)
+        train = DatasetVariable.create(train_ray_dataset)
+        validation = DatasetVariable.create(validation_ray_dataset)
+
+        def _fake_transform(*, df, transform_spec, feature_stats, **_kwargs):
+            return df, transform_spec, {"seen": True}
+
+        mock_transform.side_effect = _fake_transform
+        config = TabularNativeTransformConfig(
+            transform_spec=dict(_SIMPLE_SPEC),
+            batch_options=BatchOptions(batch_size=10),
+        )
+        # validation listed first in the dict; PREFERRED_DATASET_ORDER must
+        # still process train first.
+        tabular_native_transform(config, {"validation": validation, "train": train})
+
+        self.assertEqual(mock_transform.call_count, 2)
+        first_call_df = mock_transform.call_args_list[0].kwargs["df"]
+        self.assertIs(first_call_df, train_ray_dataset)
+        second_call_df = mock_transform.call_args_list[1].kwargs["df"]
+        self.assertIs(second_call_df, validation_ray_dataset)
+
+    @patch.object(DatasetVariable, "save_ray_dataset")
+    @patch(f"{_TASK}.native_transform")
     def test_columns_to_keep_used_for_derived_features(
         self, mock_transform, _mock_save
     ):
@@ -392,6 +442,56 @@ class TabularNativeTransformTaskTest(TestCase):
         )
         tabular_native_transform(config, {"train": train})
         mock_save.assert_called_once_with(max_rows_per_file=100, min_rows_per_file=10)
+
+    @patch(f"{_TASK}.ray")
+    @patch.object(DatasetVariable, "save_ray_dataset")
+    @patch(f"{_TASK}.native_transform")
+    def test_max_rows_per_file_below_ray_floor_raises(
+        self, mock_transform, _mock_save, mock_ray
+    ):
+        """max_rows_per_file on a too-old Ray raises before any write happens."""
+        mock_ray.__version__ = "2.47.0"
+        train = DatasetVariable.create(_ray_dataset(self.rows))
+        mock_transform.return_value = (
+            _ray_dataset(self.rows),
+            _load_transform_spec(
+                TabularNativeTransformConfig(transform_spec=dict(_SIMPLE_SPEC))
+            ),
+            {},
+        )
+        from michelangelo.workflow.schema.ray_data_io import WriteConfig
+
+        config = TabularNativeTransformConfig(
+            transform_spec=dict(_SIMPLE_SPEC),
+            write_config=WriteConfig(max_rows_per_file=100),
+        )
+        with self.assertRaises(ConfigurationError):
+            tabular_native_transform(config, {"train": train})
+
+    @patch(f"{_TASK}.ray")
+    @patch.object(DatasetVariable, "save_ray_dataset")
+    @patch(f"{_TASK}.native_transform")
+    def test_min_rows_per_file_below_ray_floor_raises(
+        self, mock_transform, _mock_save, mock_ray
+    ):
+        """min_rows_per_file on a too-old Ray raises before any write happens."""
+        mock_ray.__version__ = "2.42.0"
+        train = DatasetVariable.create(_ray_dataset(self.rows))
+        mock_transform.return_value = (
+            _ray_dataset(self.rows),
+            _load_transform_spec(
+                TabularNativeTransformConfig(transform_spec=dict(_SIMPLE_SPEC))
+            ),
+            {},
+        )
+        from michelangelo.workflow.schema.ray_data_io import WriteConfig
+
+        config = TabularNativeTransformConfig(
+            transform_spec=dict(_SIMPLE_SPEC),
+            write_config=WriteConfig(min_rows_per_file=10),
+        )
+        with self.assertRaises(ConfigurationError):
+            tabular_native_transform(config, {"train": train})
 
     @patch.object(DatasetVariable, "save_ray_dataset")
     @patch(f"{_TASK}.get_transform_module")

--- a/python/michelangelo/workflow/tasks/tabular_native_transform/tests/utils_test.py
+++ b/python/michelangelo/workflow/tasks/tabular_native_transform/tests/utils_test.py
@@ -1,0 +1,252 @@
+"""Tests for michelangelo.workflow.tasks.tabular_native_transform._private.utils."""
+
+from __future__ import annotations
+
+import os
+from unittest import TestCase
+from unittest.mock import patch
+
+import numpy as np
+
+from michelangelo.lib.model_manager.schema import DataType, ModelSchemaItem
+from michelangelo.workflow.tasks.tabular_native_transform._private.utils import (
+    _DATA_ROOT_ENV_VAR,
+    col_to_numpy,
+    convert_to_numpy_sample,
+    data_type_to_dtype,
+    get_sample_data_from_datasets,
+    resolve_data_file_path,
+)
+
+
+class _FakeValue:
+    """Minimal stand-in for a Ray/pandas dataset's ``.take(n)`` interface."""
+
+    def __init__(self, rows=None, raises: bool = False):
+        """Store the rows to return from ``take()``, or a flag to raise instead."""
+        self._rows = rows or []
+        self._raises = raises
+
+    def take(self, n):
+        """Return up to ``n`` rows, or raise ``RuntimeError`` if configured to."""
+        if self._raises:
+            raise RuntimeError("boom")
+        return self._rows[:n]
+
+
+class _FakeDatasetVar:
+    """Minimal stand-in for a ``DatasetVariable`` exposing only ``.value``."""
+
+    def __init__(self, value):
+        """Store the fake dataset value."""
+        self.value = value
+
+
+class ResolveDataFilePathTest(TestCase):
+    """Tests for resolve_data_file_path."""
+
+    def test_absolute_path_passthrough(self):
+        """An absolute path is returned unchanged."""
+        self.assertEqual(resolve_data_file_path("/abs/path.yaml"), "/abs/path.yaml")
+
+    def test_relative_path_uses_env_var_when_set(self):
+        """A relative path resolves against MICHELANGELO_DATA_ROOT when set."""
+        with patch.dict(os.environ, {_DATA_ROOT_ENV_VAR: "/data/root"}):
+            self.assertEqual(
+                resolve_data_file_path("spec.yaml"), "/data/root/spec.yaml"
+            )
+
+    def test_relative_path_uses_cwd_when_env_var_unset(self):
+        """A relative path falls back to the current working directory."""
+        env = dict(os.environ)
+        env.pop(_DATA_ROOT_ENV_VAR, None)
+        with patch.dict(os.environ, env, clear=True):
+            self.assertEqual(
+                resolve_data_file_path("spec.yaml"),
+                os.path.join(os.getcwd(), "spec.yaml"),
+            )
+
+
+class GetSampleDataFromDatasetsTest(TestCase):
+    """Tests for get_sample_data_from_datasets."""
+
+    def test_returns_none_for_empty_datasets(self):
+        """An empty datasets dict returns None."""
+        self.assertIsNone(get_sample_data_from_datasets({}))
+
+    def test_prefers_train_over_other_datasets(self):
+        """The train dataset is preferred over other dataset names."""
+        datasets = {
+            "test": _FakeDatasetVar(_FakeValue([{"x": 99}])),
+            "train": _FakeDatasetVar(_FakeValue([{"x": 1}])),
+        }
+        self.assertEqual(get_sample_data_from_datasets(datasets), {"x": 1})
+
+    def test_falls_back_to_any_available_dataset(self):
+        """A non-preferred dataset name is used when no preferred name is present."""
+        datasets = {"custom": _FakeDatasetVar(_FakeValue([{"x": 7}]))}
+        self.assertEqual(get_sample_data_from_datasets(datasets), {"x": 7})
+
+    def test_skips_dataset_with_none_value(self):
+        """A dataset variable with value=None is skipped in favor of the next one."""
+        datasets = {
+            "train": _FakeDatasetVar(None),
+            "test": _FakeDatasetVar(_FakeValue([{"x": 3}])),
+        }
+        self.assertEqual(get_sample_data_from_datasets(datasets), {"x": 3})
+
+    def test_returns_none_when_take_raises_for_every_dataset(self):
+        """Broad except Exception in the sampling loop (GAP-005 parity)."""
+        datasets = {"train": _FakeDatasetVar(_FakeValue(raises=True))}
+        self.assertIsNone(get_sample_data_from_datasets(datasets))
+
+    def test_falls_through_after_one_dataset_raises(self):
+        """Sampling continues to the next dataset after one raises."""
+        datasets = {
+            "train": _FakeDatasetVar(_FakeValue(raises=True)),
+            "validation": _FakeDatasetVar(_FakeValue([{"x": 5}])),
+        }
+        self.assertEqual(get_sample_data_from_datasets(datasets), {"x": 5})
+
+    def test_returns_none_when_take_returns_empty(self):
+        """A dataset whose take() returns no rows yields no sample."""
+        datasets = {"train": _FakeDatasetVar(_FakeValue([]))}
+        self.assertIsNone(get_sample_data_from_datasets(datasets))
+
+
+class DataTypeToDtypeTest(TestCase):
+    """Tests for data_type_to_dtype."""
+
+    def test_known_mappings(self):
+        """Every declared DataType maps to its expected numpy dtype."""
+        self.assertEqual(data_type_to_dtype(DataType.FLOAT), np.float32)
+        self.assertEqual(data_type_to_dtype(DataType.DOUBLE), np.float64)
+        self.assertEqual(data_type_to_dtype(DataType.INT), np.int32)
+        self.assertEqual(data_type_to_dtype(DataType.LONG), np.int64)
+        self.assertEqual(data_type_to_dtype(DataType.SHORT), np.int16)
+        self.assertEqual(data_type_to_dtype(DataType.BYTE), np.int8)
+        self.assertEqual(data_type_to_dtype(DataType.BOOLEAN), np.bool_)
+        self.assertEqual(data_type_to_dtype(DataType.STRING), np.object_)
+
+    def test_unmapped_type_falls_back_to_object(self):
+        """An unmapped DataType falls back to np.object_."""
+        self.assertEqual(data_type_to_dtype(DataType.UNKNOWN), np.object_)
+
+
+class ColToNumpyTest(TestCase):
+    """Tests for col_to_numpy."""
+
+    def test_none_value_returns_empty_array(self):
+        """A None value with a dtype returns an empty array of that dtype."""
+        result = col_to_numpy(None, dtype=np.float32)
+        self.assertEqual(result.shape, (0,))
+        self.assertEqual(result.dtype, np.float32)
+
+    def test_none_value_default_dtype(self):
+        """A None value with no dtype defaults to np.object_."""
+        result = col_to_numpy(None)
+        self.assertEqual(result.dtype, np.object_)
+
+    def test_ndarray_passthrough(self):
+        """An ndarray with no dtype override is returned as-is."""
+        arr = np.array([1, 2, 3])
+        result = col_to_numpy(arr)
+        np.testing.assert_array_equal(result, arr)
+
+    def test_ndarray_with_dtype_cast(self):
+        """An ndarray is cast to the requested dtype."""
+        arr = np.array([1, 2, 3], dtype=np.int32)
+        result = col_to_numpy(arr, dtype=np.float64)
+        self.assertEqual(result.dtype, np.float64)
+
+    def test_torch_tensor_like_object_uses_detach_path(self):
+        """An object exposing detach()/cpu()/numpy() is converted via that path."""
+
+        class _FakeTensor:
+            def detach(self):
+                return self
+
+            def cpu(self):
+                return self
+
+            def numpy(self):
+                return np.array([1.0, 2.0])
+
+        result = col_to_numpy(_FakeTensor())
+        np.testing.assert_array_equal(result, np.array([1.0, 2.0]))
+
+    def test_object_with_broken_detach_falls_through(self):
+        """Broad except in the detach path (GAP-005 parity)."""
+
+        class _BrokenTensor:
+            def detach(self):
+                raise RuntimeError("no detach here")
+
+        result = col_to_numpy(_BrokenTensor())
+        self.assertEqual(result.dtype, np.object_)
+
+    def test_bytes_value(self):
+        """A bytes value is wrapped in a single-element array."""
+        result = col_to_numpy(b"hello")
+        self.assertEqual(result[0], b"hello")
+
+    def test_str_value(self):
+        """A str value is wrapped in a single-element array."""
+        result = col_to_numpy("hello")
+        self.assertEqual(result[0], "hello")
+
+    def test_scalar_numeric_value(self):
+        """A scalar numeric value is wrapped in a single-element array."""
+        result = col_to_numpy(5)
+        np.testing.assert_array_equal(result, np.array([5]))
+
+    def test_scalar_with_dtype(self):
+        """A scalar value is cast to the requested dtype."""
+        result = col_to_numpy(5, dtype=np.float32)
+        self.assertEqual(result.dtype, np.float32)
+
+    def test_ragged_list_with_none_uses_default_fill(self):
+        """A list containing None fills those entries with the dtype's zero value."""
+        result = col_to_numpy([1.0, None, 3.0], dtype=np.float32)
+        np.testing.assert_array_equal(
+            result, np.array([1.0, 0.0, 3.0], dtype=np.float32)
+        )
+
+    def test_list_without_none_and_no_dtype_uses_asarray(self):
+        """A plain list with no None entries and no dtype uses np.asarray."""
+        result = col_to_numpy([1, 2, 3])
+        np.testing.assert_array_equal(result, np.array([1, 2, 3]))
+
+
+class ConvertToNumpySampleTest(TestCase):
+    """Tests for convert_to_numpy_sample."""
+
+    def test_none_row_returns_none(self):
+        """A None row returns None."""
+        self.assertIsNone(convert_to_numpy_sample(None))
+
+    def test_no_schema_converts_every_key(self):
+        """With no input_schema, every row key is converted."""
+        result = convert_to_numpy_sample({"a": 1, "b": "x"})
+        self.assertEqual(len(result), 1)
+        np.testing.assert_array_equal(result[0]["a"], np.array([1]))
+        self.assertEqual(result[0]["b"][0], "x")
+
+    def test_with_schema_filters_and_orders_columns(self):
+        """With an input_schema, only its columns are kept, in schema order."""
+        schema = [
+            ModelSchemaItem(name="a", data_type=DataType.FLOAT),
+            ModelSchemaItem(name="missing", data_type=DataType.INT),
+        ]
+        result = convert_to_numpy_sample(
+            {"a": 1.5, "extra": "dropped"}, input_schema=schema
+        )
+        self.assertEqual(set(result[0].keys()), {"a", "missing"})
+        self.assertEqual(result[0]["missing"].shape, (0,))
+        self.assertEqual(result[0]["missing"].dtype, np.int32)
+
+    def test_with_schema_missing_key_in_row(self):
+        """A schema column absent from the row becomes an empty typed array."""
+        schema = [ModelSchemaItem(name="absent", data_type=DataType.STRING)]
+        result = convert_to_numpy_sample({}, input_schema=schema)
+        self.assertEqual(result[0]["absent"].shape, (0,))

--- a/python/michelangelo/workflow/variables/__init__.py
+++ b/python/michelangelo/workflow/variables/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from michelangelo.workflow.variables._private.dataset import DatasetVariable
 from michelangelo.workflow.variables._private.model import ModelVariable
 from michelangelo.workflow.variables.metadata import (
+    DatasetMetadata,
     FeaturePackageMetadata,
     ModelMetadata,
 )
@@ -12,16 +13,19 @@ from michelangelo.workflow.variables.types import (
     AssembledModel,
     FeaturePackageArtifact,
     ModelArtifact,
+    NativeTransformResult,
     PusherResult,
 )
 
 __all__ = [
     "AssembledModel",
+    "DatasetMetadata",
     "DatasetVariable",
     "FeaturePackageArtifact",
     "FeaturePackageMetadata",
     "ModelArtifact",
     "ModelMetadata",
     "ModelVariable",
+    "NativeTransformResult",
     "PusherResult",
 ]

--- a/python/michelangelo/workflow/variables/_private/base.py
+++ b/python/michelangelo/workflow/variables/_private/base.py
@@ -70,11 +70,21 @@ class Variable(ABC):
         This method should be implemented by subclasses.
         """
 
-    def _load_value_using_io(self, io_class: type):
+    def _load_value_using_io(self, io_class: type, **read_kwargs):
         """A helper method to load the value from the variable's path using IO.
 
         IO can be given as either as a concrete instance, or as a string
         representing a dot-path to the IO's class.
+
+        Args:
+            io_class: The ``IO[T]`` implementation to instantiate and read
+                with.
+            **read_kwargs: Additional backend-specific kwargs forwarded to
+                ``io_class().read(self.path, self._io_metadata, **read_kwargs)``.
+                Most ``IO`` implementations accept only ``(url, metadata)``
+                and ignore extra kwargs unless they explicitly declare
+                support (e.g.
+                ``michelangelo.uniflow.plugins.ray.io.RayDatasetIO.read``).
         """
         _logger.info(f"loading value for {self.path}")
 
@@ -84,14 +94,24 @@ class Variable(ABC):
 
         io = _create_io(io_class)
 
-        self._value = io.read(self.path, self._io_metadata)
+        self._value = io.read(self.path, self._io_metadata, **read_kwargs)
         self._saved = True  # the value is already saved on disk
 
-    def _save_value_using_io(self, io_class: type):
+    def _save_value_using_io(self, io_class: type, **write_kwargs):
         """A helper method to save the value using the given IO class.
 
         IO can be given as either as a concrete instance, or as a string
         representing a dot-path to the IO's class.
+
+        Args:
+            io_class: The ``IO[T]`` implementation to instantiate and write
+                with.
+            **write_kwargs: Additional backend-specific kwargs forwarded to
+                ``io_class().write(self.path, self._value, **write_kwargs)``.
+                Most ``IO`` implementations accept only ``(url, value)`` and
+                ignore extra kwargs unless they explicitly declare support
+                (e.g.
+                ``michelangelo.uniflow.plugins.ray.io.RayDatasetIO.write``).
         """
         _logger.info(f"saving value for {self.path}")
 
@@ -100,7 +120,7 @@ class Variable(ABC):
             return
 
         io = _create_io(io_class)
-        self._io_metadata = io.write(self.path, self._value)
+        self._io_metadata = io.write(self.path, self._value, **write_kwargs)
         self._saved = True
 
 

--- a/python/michelangelo/workflow/variables/_private/dataset.py
+++ b/python/michelangelo/workflow/variables/_private/dataset.py
@@ -198,11 +198,17 @@ class DatasetVariable(Variable):
 
         self._save_value_using_io(SparkIO)
 
-    def save_ray_dataset(self) -> None:
-        """Persist the Ray Dataset to ``self.path`` via ``RayDatasetIO``."""
+    def save_ray_dataset(self, **write_kwargs: Any) -> None:
+        """Persist the Ray Dataset to ``self.path`` via ``RayDatasetIO``.
+
+        Args:
+            **write_kwargs: Additional kwargs forwarded to
+                ``ray.data.Dataset.write_parquet`` via ``RayDatasetIO.write()``
+                (e.g. ``max_rows_per_file``, ``min_rows_per_file``).
+        """
         from michelangelo.uniflow.plugins.ray.io import RayDatasetIO
 
-        self._save_value_using_io(RayDatasetIO)
+        self._save_value_using_io(RayDatasetIO, **write_kwargs)
 
     # ------------------------------------------------------------------
     # Load — delegates to Variable._load_value_using_io
@@ -248,8 +254,15 @@ class DatasetVariable(Variable):
 
         self._load_value_using_io(SparkIO)
 
-    def load_ray_dataset(self) -> None:
-        """Load the dataset from ``self.path`` as a Ray Dataset."""
+    def load_ray_dataset(self, **read_kwargs: Any) -> None:
+        """Load the dataset from ``self.path`` as a Ray Dataset.
+
+        Args:
+            **read_kwargs: Additional kwargs forwarded to
+                ``ray.data.read_parquet`` via
+                ``RayDatasetIO.read()`` (e.g. as produced by
+                :func:`~michelangelo.uniflow.plugins.ray.parquet_io.parquet_read_config_to_kwargs`).
+        """
         from michelangelo.uniflow.plugins.ray.io import RayDatasetIO
 
-        self._load_value_using_io(RayDatasetIO)
+        self._load_value_using_io(RayDatasetIO, **read_kwargs)

--- a/python/michelangelo/workflow/variables/metadata.py
+++ b/python/michelangelo/workflow/variables/metadata.py
@@ -290,6 +290,31 @@ class ModelMetadata:
 
 
 @dataclass
+class DatasetMetadata:
+    """Typed metadata carried by a ``DatasetVariable`` through workflow tasks.
+
+    Currently scoped to the one field ``tabular_native_transform`` needs to
+    record; extend with additional fields as more tasks need to annotate
+    dataset variables (mirroring how ``ModelMetadata`` grew field-by-field
+    per task).
+
+    Attributes:
+        derived_features: Names of output columns present in the dataset
+            that were not present in its original input (i.e. produced by a
+            transform), in sorted order. Empty when no transform was
+            applied, or when every output column overlaps an input column
+            name.
+
+    Example:
+        >>> meta = DatasetMetadata(derived_features=["scaled_amount"])
+        >>> meta.derived_features
+        ['scaled_amount']
+    """
+
+    derived_features: list[str] = field(default_factory=list)
+
+
+@dataclass
 class FeaturePackageMetadata:
     """Typed metadata carried by a feature-package artifact.
 

--- a/python/michelangelo/workflow/variables/types.py
+++ b/python/michelangelo/workflow/variables/types.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from michelangelo.workflow.variables.metadata import (
     FeaturePackageMetadata,
     ModelMetadata,
 )
+
+if TYPE_CHECKING:
+    from michelangelo.workflow.variables._private.dataset import DatasetVariable
+    from michelangelo.workflow.variables._private.model import ModelVariable
 
 
 @dataclass
@@ -109,6 +113,37 @@ class AssembledModel:
     raw_model: ModelArtifact
     deployable_model: ModelArtifact | None = None
     feature_package: FeaturePackageArtifact | None = None
+
+
+@dataclass
+class NativeTransformResult:
+    """The result of the native transform task (``tabular_native_transform``).
+
+    Contains the transformed datasets and the PyTorch transform module
+    (model). For incremental-training flows, the transform spec and feature
+    stats are stored on ``model.metadata`` (``transform_spec`` and
+    ``feature_stats``) so downstream tasks (assembler, pusher) can persist
+    them as a transform checkpoint for a future incremental run.
+
+    Attributes:
+        transformed_datasets: Mapping of dataset name (e.g. ``"train"``,
+            ``"validation"``, ``"test"``) to its transformed
+            ``DatasetVariable``. Datasets that had no transform spec applied
+            (empty inputs) are passed through unchanged.
+        model: The materialized transform module, wrapped as a
+            ``ModelVariable``, or ``None`` when the transform spec produced
+            no layers (e.g. an empty spec).
+
+    Example:
+        >>> result = NativeTransformResult(
+        ...     transformed_datasets={"train": DatasetVariable.create(None)},
+        ... )
+        >>> result.model is None
+        True
+    """
+
+    transformed_datasets: dict[str, DatasetVariable] = field(default_factory=dict)
+    model: ModelVariable | None = None
 
 
 @dataclass


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

Adds the tabular native transform workflow task -- the final piece of the native_transform migration. Applies PyTorch-native transform layers (normalization, scaling, bucketization, concatenation, custom numerical transforms) to tabular datasets via Ray Data batch inference, producing transformed datasets plus a portable `TorchTransformModule` usable at both training and serving time.

- New `workflow/tasks/tabular_native_transform/` task: entry point, incremental-training selective-refit support, sampling/conversion helpers, and full test coverage.
- New `workflow/schema/tabular_native_transform.py` config types, plus `RayDataContextConfig`/`WriteConfig` additions to `ray_data_io.py`.
- New standalone Ray Data helper modules (`uniflow/plugins/ray/data_context.py`, `uniflow/plugins/ray/parquet_io.py`) -- general-purpose, not task-specific, so factored out rather than inlined.
- Minor additive extension to `DatasetVariable`/`RayDatasetIO` to forward read/write kwargs, and new `DatasetMetadata`/`NativeTransformResult` types.

Two intentional scope simplifications vs. the internal implementation:
- `IncrementalTrainingConfig` is scoped to only the fields this task uses, omitting fields relevant only to a not-yet-migrated model-initializer consumer.
- A direct artifact URI is used in place of a model-registry lookup, following the existing `StorageBackend`-URI convention already established by the assembler/pusher tasks, rather than adding a new `ModelRegistryClient` dependency to this task.

Post-review fixes (applied after initial open):
- Fixed a misleading `ConfigurationError` message in `merge_specs_for_selective_refit` that hardcoded `mode=REUSE` regardless of the layer's actual mode -- now reports the real mode.
- Clarified `_stats_keys_for_refit`'s docstring: it invalidates stats per transform *level*, not per individual REFIT layer (a REUSE layer sharing a level with a REFIT layer is also recomputed) -- this matches the internal SDK's existing behavior, kept as-is, just documented accurately.
- Fixed `set_ray_data_context` to dedupe `retried_io_errors` against Ray's process-global `DataContext`, so repeated calls in one driver process no longer accumulate duplicate patterns.
- Replaced a couple of docstring `Example:` blocks that used literal `...` as fake doctest output (would fail under `--doctest-modules`) with plain prose.
- Rebased onto current `main`.

<!-- Tell your future self why have you made these changes -->
**Why?**

This is the last of the 13 planned native_transform migration PRs -- it's the workflow-task join point that wires together the already-merged pieces (TransformSpec DAG + layers, the Ray execution adapter, and TransformSpecIO) into a runnable pipeline task, closing out the native_transform module.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

- 83 new unit tests, all passing; 100% line coverage on every new/modified module.
- Full `workflow`, `lib/native_transform`, and `uniflow` regression suites pass (two pre-existing, unrelated Ray-cluster integration test failures reproduced identically on a clean `main` checkout).
- `ruff format`/`ruff check` clean.
- Reviewed by both the migration team (compared against the internal reference implementation for parity) and an independent blind reviewer (no internal context, reviewing purely as an external contributor); findings above were fixed and independently re-verified.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

Low -- this is a new, self-contained workflow task; nothing existing calls into it yet. The one shared-surface change (`DatasetVariable`/`RayDatasetIO` gaining optional `**read_kwargs`/`**write_kwargs`) is purely additive with defaults matching prior behavior, so existing callers are unaffected.

<!-- Does this PR introduce a breaking change? Check all that apply. -->
**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

New `tabular_native_transform` workflow task available for pipelines needing PyTorch-native tabular transforms at both train and serve time.

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**

Docstrings added throughout (Args/Returns/Raises) for all new public classes/functions; no wiki update in this PR.
