### PR TITLE
feat(tuner): add a Ray Tune helper for search on RayTask clusters

### DIFF
--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -56,7 +56,7 @@ If you're coming from other ML platforms, here's how familiar concepts map to Mi
 | **Data Preparation** | Pandas, Spark notebooks | **MA Studio Data Prep** or **Uniflow tasks** with Ray/Spark * |
 | **Experiment Tracking** | MLflow, Weights & Biases | **Model Registry** with automatic versioning |
 | **Model Training** | Custom scripts, Kubeflow Pipelines | **MA Studio Training** (UI) or **CanvasFlex/Uniflow workflows** (code) |
-| **Hyperparameter Tuning** | Optuna, Ray Tune | **Uniflow tasks** with hand-written sweeps * |
+| **Hyperparameter Tuning** | Optuna, Ray Tune | **Uniflow tasks** with the Ray Tune helper (`michelangelo.lib.tuner`) * |
 | **Model Storage** | S3 buckets, model registries | **Michelangelo AI Model Registry** with metadata & plugin storage |
 | **Batch Inference** | Airflow + custom scripts | **Uniflow tasks** with Ray for offline inference * |
 | **Online Serving** | TorchServe, TensorFlow Serving | **Deployment to inference server** with Triton Inference Server * |

--- a/docs/user-guides/ml-pipelines/workflow-patterns.md
+++ b/docs/user-guides/ml-pipelines/workflow-patterns.md
@@ -157,6 +157,8 @@ def hyperparameter_sweep(data_url: str, learning_rates: list[float]):
 
 Note that the for-loop pattern runs each task call sequentially. To run all of them in parallel, see [Parallel batch run](#parallel-batch-run) below.
 
+Also note that each task call in the loop provisions its own Ray cluster. For a genuine hyperparameter search (many configurations, early stopping), prefer the Ray Tune helper in `michelangelo.lib.tuner.ray_tune`: a single `RayTask`-decorated step runs all trials on one provisioned cluster via `ray.tune`, and returns the best trial's parameters and checkpoint for downstream tasks.
+
 ---
 
 ## Concurrent run

--- a/python/michelangelo/lib/tuner/__init__.py
+++ b/python/michelangelo/lib/tuner/__init__.py
@@ -1,0 +1,5 @@
+"""Hyperparameter tuning helpers.
+
+Subpackages wrap tuning backends for use inside Uniflow tasks; see
+``michelangelo.lib.tuner.ray_tune`` for the Ray Tune helper.
+"""

--- a/python/michelangelo/lib/tuner/ray_tune/__init__.py
+++ b/python/michelangelo/lib/tuner/ray_tune/__init__.py
@@ -1,0 +1,19 @@
+"""Ray Tune helper for hyperparameter search on a provisioned Ray cluster.
+
+Public surface re-exported below:
+
+* :func:`tune` -- runs a ``ray.tune.Tuner`` search on the Ray runtime the
+  calling process is already connected to and returns a small result dict.
+* :class:`TuneParam` -- dataclass holding the search configuration (trainable,
+  search space, metric, scheduler, trial budget, ...).
+"""
+
+from michelangelo.lib.tuner.ray_tune.tuner import (
+    TuneParam,
+    tune,
+)
+
+__all__ = [
+    "TuneParam",
+    "tune",
+]

--- a/python/michelangelo/lib/tuner/ray_tune/tests/__init__.py
+++ b/python/michelangelo/lib/tuner/ray_tune/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Ray Tune helper library."""

--- a/python/michelangelo/lib/tuner/ray_tune/tests/test_ray_tune.py
+++ b/python/michelangelo/lib/tuner/ray_tune/tests/test_ray_tune.py
@@ -1,0 +1,251 @@
+"""Tests for the Ray Tune helper module.
+
+Cover the public surface of ``michelangelo.lib.tuner.ray_tune.tuner``:
+dataclass validation, scheduler resolution, Tuner wiring, and the ``tune()``
+result contract. ``ray.tune.Tuner`` is patched throughout, so nothing here
+needs a Ray cluster; the real-cluster path lives in
+``test_ray_tune_integration.py``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("ray.tune")
+
+from ray.tune.schedulers import ASHAScheduler, FIFOScheduler
+
+from michelangelo.lib.tuner.ray_tune.tuner import (
+    BEST_CONFIG_KEY,
+    BEST_METRICS_KEY,
+    CHECKPOINT_PATH_KEY,
+    TuneParam,
+    _resolve_scheduler,
+    tune,
+)
+
+_TUNER = "michelangelo.lib.tuner.ray_tune.tuner.ray.tune.Tuner"
+_WITH_RESOURCES = "michelangelo.lib.tuner.ray_tune.tuner.ray.tune.with_resources"
+
+
+def _make_param(**overrides) -> TuneParam:
+    """Build a minimally-valid ``TuneParam`` for tests."""
+    defaults = {
+        "trainable": lambda config: None,
+        "param_space": {"lr": [0.1, 0.01]},
+        "metric": "val_loss",
+    }
+    defaults.update(overrides)
+    return TuneParam(**defaults)
+
+
+def _make_result_grid(
+    *, checkpoint_path: str | None = "/ckpt/best", errors: list | None = None
+) -> MagicMock:
+    """Build a mocked ``ResultGrid`` with one best result."""
+    checkpoint = SimpleNamespace(path=checkpoint_path) if checkpoint_path else None
+    best = SimpleNamespace(
+        config={"lr": 0.1},
+        metrics={"val_loss": 0.25},
+        checkpoint=checkpoint,
+        path="/results/trial_0",
+    )
+    grid = MagicMock(name="result_grid")
+    grid.get_best_result.return_value = best
+    grid.errors = errors or []
+    grid.__len__.return_value = 4
+    return grid
+
+
+# -----------------------------------------------------------------------------
+# TuneParam
+# -----------------------------------------------------------------------------
+
+
+class TestTuneParam:
+    """``TuneParam`` dataclass behavior."""
+
+    def test_defaults(self):
+        """It applies the documented default for every optional field."""
+        param = _make_param()
+        assert param.mode == "min"
+        assert param.num_samples == 10
+        assert param.scheduler == "asha"
+        assert param.resources_per_trial is None
+        assert param.max_concurrent_trials is None
+        assert param.run_config is None
+        assert param.tune_config_kwargs == {}
+
+    def test_mutable_defaults_are_not_shared(self):
+        """Each instance gets its own ``tune_config_kwargs`` dict."""
+        first = _make_param()
+        second = _make_param()
+        first.tune_config_kwargs["reuse_actors"] = True
+        assert second.tune_config_kwargs == {}
+
+    def test_rejects_non_callable_trainable(self):
+        """A non-callable trainable is rejected."""
+        with pytest.raises(ValueError, match="trainable must be callable"):
+            _make_param(trainable="not-a-function")
+
+    def test_rejects_empty_param_space(self):
+        """An empty search space is rejected."""
+        with pytest.raises(ValueError, match="non-empty search space"):
+            _make_param(param_space={})
+
+    def test_rejects_empty_metric(self):
+        """An empty metric name is rejected."""
+        with pytest.raises(ValueError, match="non-empty metric name"):
+            _make_param(metric="")
+
+    def test_rejects_bad_mode(self):
+        """A mode other than min/max is rejected."""
+        with pytest.raises(ValueError, match="mode must be 'min' or 'max'"):
+            _make_param(mode="maximize")
+
+    def test_rejects_non_positive_num_samples(self):
+        """A zero or negative trial budget is rejected."""
+        with pytest.raises(ValueError, match="num_samples must be positive"):
+            _make_param(num_samples=0)
+
+    def test_rejects_unknown_scheduler_name(self):
+        """An unknown scheduler name is rejected."""
+        with pytest.raises(ValueError, match="scheduler must be one of"):
+            _make_param(scheduler="hyperband-but-misspelled")
+
+    def test_rejects_non_scheduler_instance(self):
+        """A non-TrialScheduler object is rejected."""
+        with pytest.raises(ValueError, match="TrialScheduler"):
+            _make_param(scheduler=object())
+
+    def test_accepts_scheduler_instance(self):
+        """Any ``TrialScheduler`` instance passes validation unchanged."""
+        scheduler = FIFOScheduler()
+        assert _make_param(scheduler=scheduler).scheduler is scheduler
+
+    def test_rejects_reserved_tune_config_keys(self):
+        """Keys owned by TuneParam fields are rejected in tune_config_kwargs."""
+        with pytest.raises(ValueError, match="must not set"):
+            _make_param(tune_config_kwargs={"metric": "other"})
+
+
+# -----------------------------------------------------------------------------
+# _resolve_scheduler
+# -----------------------------------------------------------------------------
+
+
+class TestResolveScheduler:
+    """Scheduler name / instance resolution."""
+
+    def test_asha_name(self):
+        """The name 'asha' resolves to an ASHAScheduler."""
+        assert isinstance(_resolve_scheduler("asha"), ASHAScheduler)
+
+    def test_fifo_name(self):
+        """The name 'fifo' resolves to a FIFOScheduler."""
+        assert isinstance(_resolve_scheduler("fifo"), FIFOScheduler)
+
+    def test_instance_passthrough(self):
+        """A TrialScheduler instance is returned unchanged."""
+        scheduler = ASHAScheduler()
+        assert _resolve_scheduler(scheduler) is scheduler
+
+
+# -----------------------------------------------------------------------------
+# tune()
+# -----------------------------------------------------------------------------
+
+
+class TestTune:
+    """``tune()`` wiring and result contract, with ``Tuner`` patched."""
+
+    def test_passes_search_through_to_tuner(self):
+        """Trainable, space, and TuneConfig fields reach the Tuner verbatim."""
+        param = _make_param(
+            mode="max",
+            num_samples=7,
+            max_concurrent_trials=3,
+            tune_config_kwargs={"reuse_actors": True},
+        )
+        with patch(_TUNER) as tuner_cls:
+            tuner_cls.return_value.fit.return_value = _make_result_grid()
+            tune(param)
+
+        (trainable,), kwargs = tuner_cls.call_args
+        assert trainable is param.trainable
+        assert kwargs["param_space"] == {"lr": [0.1, 0.01]}
+        assert kwargs["run_config"] is None
+        tune_config = kwargs["tune_config"]
+        assert tune_config.metric == "val_loss"
+        assert tune_config.mode == "max"
+        assert tune_config.num_samples == 7
+        assert tune_config.max_concurrent_trials == 3
+        assert tune_config.reuse_actors is True
+        assert isinstance(tune_config.scheduler, ASHAScheduler)
+
+    def test_run_config_passthrough(self):
+        """A caller-supplied run_config is handed to the Tuner unchanged."""
+        run_config = MagicMock(name="run_config")
+        with patch(_TUNER) as tuner_cls:
+            tuner_cls.return_value.fit.return_value = _make_result_grid()
+            tune(_make_param(run_config=run_config))
+        assert tuner_cls.call_args.kwargs["run_config"] is run_config
+
+    def test_resources_per_trial_wraps_trainable(self):
+        """``resources_per_trial`` applies ``with_resources`` to the trainable."""
+        param = _make_param(resources_per_trial={"cpu": 2, "gpu": 1})
+        wrapped = MagicMock(name="wrapped_trainable")
+        with (
+            patch(_WITH_RESOURCES, return_value=wrapped) as with_resources,
+            patch(_TUNER) as tuner_cls,
+        ):
+            tuner_cls.return_value.fit.return_value = _make_result_grid()
+            tune(param)
+        with_resources.assert_called_once_with(param.trainable, {"cpu": 2, "gpu": 1})
+        assert tuner_cls.call_args.args[0] is wrapped
+
+    def test_no_resources_leaves_trainable_unwrapped(self):
+        """Without resources_per_trial the trainable is passed as-is."""
+        with (
+            patch(_WITH_RESOURCES) as with_resources,
+            patch(_TUNER) as tuner_cls,
+        ):
+            tuner_cls.return_value.fit.return_value = _make_result_grid()
+            tune(_make_param())
+        with_resources.assert_not_called()
+
+    def test_result_contract(self):
+        """The returned dict carries the documented keys."""
+        with patch(_TUNER) as tuner_cls:
+            tuner_cls.return_value.fit.return_value = _make_result_grid(
+                errors=[RuntimeError("trial 3 died")]
+            )
+            result = tune(_make_param())
+
+        assert result[BEST_CONFIG_KEY] == {"lr": 0.1}
+        assert result[BEST_METRICS_KEY] == {"val_loss": 0.25}
+        assert result[CHECKPOINT_PATH_KEY] == "/ckpt/best"
+        assert result["path"] == "/results/trial_0"
+        assert result["num_trials"] == 4
+        assert result["num_errors"] == 1
+
+    def test_checkpointless_best_result_maps_to_none(self):
+        """A trainable that never reports a checkpoint yields ``None``."""
+        with patch(_TUNER) as tuner_cls:
+            tuner_cls.return_value.fit.return_value = _make_result_grid(
+                checkpoint_path=None
+            )
+            result = tune(_make_param())
+        assert result[CHECKPOINT_PATH_KEY] is None
+
+    def test_no_successful_trial_propagates(self):
+        """Ray's no-completed-trials error is not swallowed."""
+        grid = _make_result_grid()
+        grid.get_best_result.side_effect = RuntimeError("No best trial found")
+        with patch(_TUNER) as tuner_cls:
+            tuner_cls.return_value.fit.return_value = grid
+            with pytest.raises(RuntimeError, match="No best trial"):
+                tune(_make_param())

--- a/python/michelangelo/lib/tuner/ray_tune/tests/test_ray_tune_integration.py
+++ b/python/michelangelo/lib/tuner/ray_tune/tests/test_ray_tune_integration.py
@@ -1,0 +1,100 @@
+"""Real (non-mocked) integration test for the Ray Tune helper.
+
+Exercises :func:`michelangelo.lib.tuner.ray_tune.tune` end-to-end on a local
+Ray cluster -- no mocking -- to guard against the class of bug where the unit
+suite stays green while the helper is broken against the installed Ray
+runtime (schedulers, ``TuneConfig``, and ``ResultGrid`` have all shifted
+across Ray releases).
+
+Like ``lib/trainer``'s ``test_auto_resume_integration.py``, this spins up a
+real Ray runtime, which OOM-kills constrained CI runners -- so it is **skipped
+in CI by default**. Run it locally (the default off-CI), or in a dedicated
+Ray-enabled CI job, by setting ``MICHELANGELO_RUN_RAY_INTEGRATION_TESTS=1``.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+# Skip in CI unless explicitly forced (see module docstring): a real Ray
+# runtime exceeds the memory of shared coverage runners.
+if (os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS")) and (
+    os.environ.get("MICHELANGELO_RUN_RAY_INTEGRATION_TESTS") != "1"
+):
+    pytest.skip(
+        "Skipping real-Ray integration tests in CI (they spin up a Ray "
+        "runtime and OOM on constrained runners). Set "
+        "MICHELANGELO_RUN_RAY_INTEGRATION_TESTS=1 to run them.",
+        allow_module_level=True,
+    )
+
+pytest.importorskip("ray.tune")
+
+import ray
+import ray.train
+
+from michelangelo.lib.tuner.ray_tune import TuneParam, tune
+
+# ray.tune.RunConfig only exists on newer Ray; older supported versions take a
+# ray.train.RunConfig for the same Tuner argument.
+_RunConfig = getattr(ray.tune, "RunConfig", None) or ray.train.RunConfig
+
+
+@pytest.fixture(scope="module")
+def local_ray():
+    """A small local Ray runtime shared by the tests in this module."""
+    ray.init(num_cpus=2, include_dashboard=False, ignore_reinit_error=True)
+    yield
+    ray.shutdown()
+
+
+def _objective(config: dict) -> None:
+    """Deterministic quadratic bowl: best trial is the x closest to 3."""
+    score = -((config["x"] - 3) ** 2)
+    ray.tune.report({"score": score})
+
+
+@pytest.mark.usefixtures("local_ray")
+def test_tune_finds_best_config_on_local_ray(tmp_path):
+    """A real 4-trial grid search completes and picks the best config."""
+    result = tune(
+        TuneParam(
+            trainable=_objective,
+            param_space={"x": ray.tune.grid_search([0, 1, 3, 8])},
+            metric="score",
+            mode="max",
+            num_samples=1,  # grid_search expands to one trial per grid value
+            scheduler="fifo",
+            run_config=_RunConfig(storage_path=str(tmp_path), name="tune_helper_it"),
+        )
+    )
+
+    assert result["best_config"] == {"x": 3}
+    assert result["best_metrics"]["score"] == 0
+    assert result["num_trials"] == 4
+    assert result["num_errors"] == 0
+    # The objective never reports a checkpoint, so the contract maps it to None.
+    assert result["checkpoint_path"] is None
+
+
+@pytest.mark.usefixtures("local_ray")
+def test_tune_asha_random_search_completes(tmp_path):
+    """The default ASHA path runs real sampled trials to completion."""
+    result = tune(
+        TuneParam(
+            trainable=_objective,
+            param_space={"x": ray.tune.uniform(-5, 5)},
+            metric="score",
+            mode="max",
+            num_samples=4,
+            run_config=_RunConfig(
+                storage_path=str(tmp_path), name="tune_helper_asha_it"
+            ),
+        )
+    )
+
+    assert result["num_trials"] == 4
+    assert -5 <= result["best_config"]["x"] <= 5
+    assert result["best_metrics"]["score"] <= 0

--- a/python/michelangelo/lib/tuner/ray_tune/tuner.py
+++ b/python/michelangelo/lib/tuner/ray_tune/tuner.py
@@ -1,0 +1,218 @@
+"""Public Ray Tune helper for hyperparameter search.
+
+Runs a ``ray.tune`` search on the Ray cluster the calling process is already
+connected to, exposed with the same shape as the trainers in
+``michelangelo.lib.trainer``: a parameter dataclass, a ``tune()`` that returns
+a small result dict, and checkpointing handled by Ray's own reporting.
+
+Inside a ``RayTask``-decorated Uniflow task no extra plumbing is needed --
+``RayTask.pre_run()`` has already called ``ray.init()`` against the
+provisioned cluster by the time the task body runs, so every trial is
+scheduled on that cluster. This is the difference from a hand-written sweep
+loop, which provisions one Ray cluster per configuration; here one cluster
+runs all trials.
+
+Typical use::
+
+    import michelangelo.uniflow.core as uniflow
+    from michelangelo.uniflow.plugins.ray import RayTask
+    from michelangelo.lib.tuner.ray_tune import TuneParam, tune
+
+    def objective(config: dict) -> None:
+        loss = train_once(lr=config["lr"], depth=config["depth"])
+        ray.tune.report({"val_loss": loss})
+
+    @uniflow.task(config=RayTask(head_cpu=2, worker_cpu=4, worker_instances=4))
+    def tune_step(data_url: str) -> dict:
+        return tune(
+            TuneParam(
+                trainable=objective,
+                param_space={
+                    "lr": ray.tune.loguniform(1e-4, 1e-1),
+                    "depth": ray.tune.randint(2, 10),
+                },
+                metric="val_loss",
+                mode="min",
+                num_samples=20,
+            )
+        )
+
+To persist trial checkpoints to UniFlow-managed storage, pass
+``run_config=create_run_config()`` (from
+``michelangelo.uniflow.plugins.ray.run_config``), the same helper the
+trainers use.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+import ray.tune
+from ray.tune.schedulers import ASHAScheduler, FIFOScheduler, TrialScheduler
+
+_logger = logging.getLogger(__name__)
+
+BEST_CONFIG_KEY = "best_config"
+BEST_METRICS_KEY = "best_metrics"
+CHECKPOINT_PATH_KEY = "checkpoint_path"
+
+_SCHEDULERS: dict[str, type[TrialScheduler]] = {
+    "asha": ASHAScheduler,
+    "fifo": FIFOScheduler,
+}
+
+# TuneConfig fields owned by TuneParam's first-class fields; allowing them in
+# tune_config_kwargs too would make one of the two values win silently.
+_RESERVED_TUNE_CONFIG_KEYS = frozenset(
+    {"metric", "mode", "num_samples", "scheduler", "max_concurrent_trials"}
+)
+
+
+@dataclass
+class TuneParam:
+    """Configuration for :func:`tune`.
+
+    Attributes:
+        trainable: Per-trial function. Called once per trial with the sampled
+            ``config`` dict; reports metrics via ``ray.tune.report``.
+        param_space: Ray Tune search space, passed verbatim to
+            ``ray.tune.Tuner`` (for example
+            ``{"lr": ray.tune.loguniform(1e-4, 1e-1)}``).
+        metric: Metric name to optimize. Must match a key the trainable
+            reports.
+        mode: ``"min"`` or ``"max"``.
+        num_samples: Number of trials to run.
+        scheduler: ``"asha"`` (default, early-stops bad trials), ``"fifo"``
+            (no early stopping), or any ``ray.tune.schedulers.TrialScheduler``
+            instance for full control.
+        resources_per_trial: Optional per-trial resource request (for example
+            ``{"cpu": 2, "gpu": 1}``), applied with
+            ``ray.tune.with_resources``. When ``None``, Ray's default of one
+            CPU per trial applies.
+        max_concurrent_trials: Optional cap on concurrently running trials.
+        run_config: Optional Ray ``RunConfig`` controlling where trial
+            results and checkpoints are stored. Defaults to Ray's own storage
+            location; pass ``create_run_config()`` to use UniFlow-managed
+            storage.
+        tune_config_kwargs: Extra keyword arguments forwarded verbatim to
+            ``ray.tune.TuneConfig``. Keys owned by the fields above
+            (``metric``, ``mode``, ``num_samples``, ``scheduler``,
+            ``max_concurrent_trials``) are rejected rather than silently
+            overridden.
+    """
+
+    trainable: Callable[[dict[str, Any]], Any]
+    param_space: dict[str, Any]
+    metric: str
+    mode: str = "min"
+    num_samples: int = 10
+    scheduler: str | TrialScheduler = "asha"
+    resources_per_trial: dict[str, float] | None = None
+    max_concurrent_trials: int | None = None
+    run_config: Any | None = None
+    tune_config_kwargs: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Reject configurations Ray would fail on later, or silently misuse.
+
+        Raises:
+            ValueError: If ``trainable`` is not callable, ``param_space`` is
+                empty, ``metric`` is empty, ``mode`` is not ``min``/``max``,
+                ``num_samples`` is not positive, ``scheduler`` is an unknown
+                name or not a ``TrialScheduler``, or ``tune_config_kwargs``
+                carries a reserved key.
+        """
+        if not callable(self.trainable):
+            raise ValueError("trainable must be callable")
+        if not self.param_space:
+            raise ValueError("param_space must be a non-empty search space")
+        if not self.metric:
+            raise ValueError("metric must be a non-empty metric name")
+        if self.mode not in ("min", "max"):
+            raise ValueError(f"mode must be 'min' or 'max', got {self.mode!r}")
+        if self.num_samples <= 0:
+            raise ValueError(f"num_samples must be positive, got {self.num_samples}")
+        if isinstance(self.scheduler, str):
+            if self.scheduler not in _SCHEDULERS:
+                raise ValueError(
+                    f"scheduler must be one of {sorted(_SCHEDULERS)} or a "
+                    f"TrialScheduler instance, got {self.scheduler!r}"
+                )
+        elif not isinstance(self.scheduler, TrialScheduler):
+            raise ValueError(
+                "scheduler must be a scheduler name or a TrialScheduler "
+                f"instance, got {type(self.scheduler).__name__}"
+            )
+        reserved = _RESERVED_TUNE_CONFIG_KEYS.intersection(self.tune_config_kwargs)
+        if reserved:
+            raise ValueError(
+                f"tune_config_kwargs must not set {sorted(reserved)}; use the "
+                "TuneParam fields of the same name instead"
+            )
+
+
+def _resolve_scheduler(scheduler: str | TrialScheduler) -> TrialScheduler:
+    """Return the ``TrialScheduler`` instance for a name or passthrough."""
+    if isinstance(scheduler, TrialScheduler):
+        return scheduler
+    return _SCHEDULERS[scheduler]()
+
+
+def tune(tune_param: TuneParam) -> dict:
+    """Run the search and return a small result dict.
+
+    Args:
+        tune_param: Search configuration (trainable, space, metric, budget,
+            ...).
+
+    Returns:
+        Dict with ``best_config`` (the best trial's sampled parameters),
+        ``best_metrics`` (its last reported metrics), ``checkpoint_path``
+        (path to its checkpoint, or ``None`` if the trainable reported none),
+        ``path`` (the best trial's result directory), ``num_trials``, and
+        ``num_errors`` (trials that raised; the best result is drawn from the
+        trials that completed).
+
+    Raises:
+        RuntimeError: From Ray, when no trial completed successfully.
+    """
+    _logger.info("tune: starting search with tune_param: %r", tune_param)
+
+    trainable = tune_param.trainable
+    if tune_param.resources_per_trial:
+        trainable = ray.tune.with_resources(trainable, tune_param.resources_per_trial)
+
+    tuner = ray.tune.Tuner(
+        trainable,
+        param_space=tune_param.param_space,
+        tune_config=ray.tune.TuneConfig(
+            metric=tune_param.metric,
+            mode=tune_param.mode,
+            num_samples=tune_param.num_samples,
+            scheduler=_resolve_scheduler(tune_param.scheduler),
+            max_concurrent_trials=tune_param.max_concurrent_trials,
+            **tune_param.tune_config_kwargs,
+        ),
+        run_config=tune_param.run_config,
+    )
+    results = tuner.fit()
+
+    if results.errors:
+        _logger.warning(
+            "tune: %d of %d trials errored; best result is drawn from the "
+            "completed trials",
+            len(results.errors),
+            len(results),
+        )
+
+    best = results.get_best_result()
+    return {
+        BEST_CONFIG_KEY: best.config,
+        BEST_METRICS_KEY: best.metrics,
+        CHECKPOINT_PATH_KEY: best.checkpoint.path if best.checkpoint else None,
+        "path": best.path,
+        "num_trials": len(results),
+        "num_errors": len(results.errors),
+    }

--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -67,7 +67,7 @@ description = "Happy Eyeballs for asyncio"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"trainer-xgboost\")"
+markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"trainer-xgboost\" or extra == \"tuner\")"
 files = [
     {file = "aiohappyeyeballs-2.6.1-py3-none-any.whl", hash = "sha256:f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8"},
     {file = "aiohappyeyeballs-2.6.1.tar.gz", hash = "sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558"},
@@ -80,7 +80,7 @@ description = "Happy Eyeballs for asyncio"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\")"
+markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\")"
 files = [
     {file = "aiohappyeyeballs-2.6.2-py3-none-any.whl", hash = "sha256:4708045e2d7a6c6bdf8aafa8ed39649eaf926a4543b54560659129e3365953c4"},
     {file = "aiohappyeyeballs-2.6.2.tar.gz", hash = "sha256:e202810ee718bd01fc6ef49e8ea53d023d5cb6b581076d7925aa499fa55dbe64"},
@@ -93,7 +93,7 @@ description = "Async http client/server framework (asyncio)"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"trainer-xgboost\")"
+markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"trainer-xgboost\" or extra == \"tuner\")"
 files = [
     {file = "aiohttp-3.13.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:02222e7e233295f40e011c1b00e3b0bd451f22cf853a0304c3595633ee47da4b"},
     {file = "aiohttp-3.13.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bace460460ed20614fa6bc8cb09966c0b8517b8c58ad8046828c6078d25333b5"},
@@ -237,7 +237,7 @@ description = "Async http client/server framework (asyncio)"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\")"
+markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\")"
 files = [
     {file = "aiohttp-3.14.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:8f6bb621e5863cfe8fe5ff5468002d200ec31f30f1280b259dc505b02595099e"},
     {file = "aiohttp-3.14.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4f7215cb3933784f79ed20e5f050e15984f390424339b22375d5a53c933a0491"},
@@ -381,7 +381,7 @@ description = "CORS support for aiohttp"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\""
+markers = "extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\""
 files = [
     {file = "aiohttp_cors-0.8.1-py3-none-any.whl", hash = "sha256:3180cf304c5c712d626b9162b195b1db7ddf976a2a25172b35bb2448b890a80d"},
     {file = "aiohttp_cors-0.8.1.tar.gz", hash = "sha256:ccacf9cb84b64939ea15f859a146af1f662a6b1d68175754a07315e305fb1403"},
@@ -413,7 +413,7 @@ description = "aiosignal: a list of registered asynchronous callbacks"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"trainer-xgboost\") or extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\""
+markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"trainer-xgboost\" or extra == \"tuner\") or extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\""
 files = [
     {file = "aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e"},
     {file = "aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7"},
@@ -639,7 +639,7 @@ description = "Timeout context manager for asyncio programs"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"trainer-xgboost\") or python_version < \"3.11\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\")"
+markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"trainer-xgboost\" or extra == \"tuner\") or python_version < \"3.11\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\")"
 files = [
     {file = "async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c"},
     {file = "async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3"},
@@ -652,7 +652,7 @@ description = "Classes Without Boilerplate"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-comet\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"trainer-xgboost\") or extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"trainer-comet\""
+markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-comet\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"trainer-xgboost\" or extra == \"tuner\") or extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-comet\""
 files = [
     {file = "attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309"},
     {file = "attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32"},
@@ -893,7 +893,7 @@ description = "Python package for providing Mozilla's CA Bundle."
 optional = true
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"trainer-mlflow\" or extra == \"trainer-comet\" or extra == \"minio\""
+markers = "extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-mlflow\" or extra == \"trainer-comet\" or extra == \"minio\""
 files = [
     {file = "certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db"},
     {file = "certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432"},
@@ -906,7 +906,7 @@ description = "Foreign Function Interface for Python calling C code."
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "platform_python_implementation != \"PyPy\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"trainer-mlflow\" or extra == \"minio\") or extra == \"example\" or extra == \"minio\" or (extra == \"example\" or extra == \"minio\" or extra == \"vllm\") and implementation_name == \"pypy\" and python_version <= \"3.12\""
+markers = "platform_python_implementation != \"PyPy\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-mlflow\" or extra == \"minio\") or extra == \"example\" or extra == \"minio\" or (extra == \"example\" or extra == \"minio\" or extra == \"vllm\") and implementation_name == \"pypy\" and python_version <= \"3.12\""
 files = [
     {file = "cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44"},
     {file = "cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49"},
@@ -1030,7 +1030,7 @@ description = "The Real First Universal Charset Detector. Open, modern and activ
 optional = true
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"trainer-mlflow\" or extra == \"trainer-comet\""
+markers = "extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-mlflow\" or extra == \"trainer-comet\""
 files = [
     {file = "charset_normalizer-3.4.7-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cdd68a1fb318e290a2077696b7eb7a21a49163c455979c639bf5a5dcdc46617d"},
     {file = "charset_normalizer-3.4.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e17b8d5d6a8c47c85e68ca8379def1303fd360c3e22093a807cd34a71cd082b8"},
@@ -1191,7 +1191,7 @@ description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "python_version == \"3.9\" and (extra == \"vllm\" or extra == \"example\" or extra == \"trainer-mlflow\" or extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"trainer\" or extra == \"trainer-xgboost\")"
+markers = "python_version == \"3.9\" and (extra == \"vllm\" or extra == \"example\" or extra == \"trainer-mlflow\" or extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\")"
 files = [
     {file = "click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2"},
     {file = "click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"},
@@ -1207,7 +1207,7 @@ description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"trainer-mlflow\")"
+markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-mlflow\")"
 files = [
     {file = "click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76"},
     {file = "click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6"},
@@ -1236,7 +1236,7 @@ description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 groups = ["main"]
-markers = "python_version <= \"3.12\" and platform_system == \"Windows\" and sys_platform == \"win32\" and (extra == \"dev\" or extra == \"vllm\" or extra == \"example\" or extra == \"trainer\" or extra == \"trainer-deepspeed\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"trainer-xgboost\" or extra == \"trainer-mlflow\") or python_version == \"3.9\" and platform_system == \"Windows\" and (extra == \"dev\" or extra == \"vllm\" or extra == \"example\" or extra == \"trainer\" or extra == \"trainer-deepspeed\" or extra == \"trainer-mlflow\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"trainer-xgboost\") or platform_system == \"Windows\" and (extra == \"dev\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-deepspeed\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"trainer-xgboost\" or extra == \"trainer-mlflow\") or sys_platform == \"win32\" and (extra == \"dev\" or extra == \"vllm\") and python_version <= \"3.12\" or sys_platform == \"win32\" and extra == \"dev\""
+markers = "python_version <= \"3.12\" and platform_system == \"Windows\" and sys_platform == \"win32\" and (extra == \"dev\" or extra == \"vllm\" or extra == \"example\" or extra == \"trainer\" or extra == \"trainer-deepspeed\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-mlflow\") or python_version == \"3.9\" and platform_system == \"Windows\" and (extra == \"dev\" or extra == \"vllm\" or extra == \"example\" or extra == \"trainer\" or extra == \"trainer-deepspeed\" or extra == \"trainer-mlflow\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"trainer-xgboost\" or extra == \"tuner\") or platform_system == \"Windows\" and (extra == \"dev\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-deepspeed\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-mlflow\") or sys_platform == \"win32\" and (extra == \"dev\" or extra == \"vllm\") and python_version <= \"3.12\" or sys_platform == \"win32\" and extra == \"dev\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
@@ -1267,7 +1267,7 @@ description = "Terminal string styling done right, in Python."
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\""
+markers = "extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\""
 files = [
     {file = "colorful-0.5.8-py2.py3-none-any.whl", hash = "sha256:a9381fdda3337fbaba5771991020abc69676afa102646650b759927892875992"},
     {file = "colorful-0.5.8.tar.gz", hash = "sha256:bb16502b198be2f1c42ba3c52c703d5f651d826076817185f0294c1a549a7445"},
@@ -1834,7 +1834,7 @@ description = "cryptography is a package which provides cryptographic recipes an
 optional = true
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"trainer-mlflow\")"
+markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-mlflow\")"
 files = [
     {file = "cryptography-43.0.3-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:bf7a1932ac4176486eab36a19ed4c0492da5d97123f1406cf15e41b05e787d2e"},
     {file = "cryptography-43.0.3-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:63efa177ff54aec6e1c0aefaa1a241232dcd37413835a9b674b6e3f0ae2bfd3e"},
@@ -1885,7 +1885,7 @@ description = "cryptography is a package which provides cryptographic recipes an
 optional = true
 python-versions = "!=3.9.0,!=3.9.1,>=3.9"
 groups = ["main"]
-markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"trainer-mlflow\")"
+markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-mlflow\")"
 files = [
     {file = "cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db"},
     {file = "cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db"},
@@ -2193,7 +2193,7 @@ description = "Distribution utilities"
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\""
+markers = "extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\""
 files = [
     {file = "distlib-0.4.3-py2.py3-none-any.whl", hash = "sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b"},
     {file = "distlib-0.4.3.tar.gz", hash = "sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed"},
@@ -2878,7 +2878,7 @@ description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version == \"3.9\" and (extra == \"vllm\" or extra == \"dev\" or extra == \"example\" or extra == \"trainer\" or extra == \"trainer-deepspeed\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"trainer-xgboost\")"
+markers = "python_version == \"3.9\" and (extra == \"vllm\" or extra == \"dev\" or extra == \"example\" or extra == \"trainer\" or extra == \"trainer-deepspeed\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"trainer-xgboost\" or extra == \"tuner\")"
 files = [
     {file = "filelock-3.19.1-py3-none-any.whl", hash = "sha256:d38e30481def20772f5baf097c122c3babc4fcdb7e14e57049eb9d88c6dc017d"},
     {file = "filelock-3.19.1.tar.gz", hash = "sha256:66eda1888b0171c998b35be2bcc0f6d75c388a7ce20c3f3f37aa8e96c2dddf58"},
@@ -2891,7 +2891,7 @@ description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "(python_version < \"3.12\" or extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"trainer-deepspeed\") and (extra == \"vllm\" or extra == \"dev\" or extra == \"example\" or extra == \"trainer\" or extra == \"trainer-deepspeed\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"trainer-xgboost\") and python_version >= \"3.10\""
+markers = "(python_version < \"3.12\" or extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-deepspeed\") and (extra == \"vllm\" or extra == \"dev\" or extra == \"example\" or extra == \"trainer\" or extra == \"trainer-deepspeed\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"trainer-xgboost\" or extra == \"tuner\") and python_version >= \"3.10\""
 files = [
     {file = "filelock-3.29.4-py3-none-any.whl", hash = "sha256:dac1648087d5115554850d113e7dd8c83ab2d38e3435dde2d4f163847e57b767"},
     {file = "filelock-3.29.4.tar.gz", hash = "sha256:10cdb3656fc44541cdf30652a93fb10ec6b05325620eb316bd26893e4201538a"},
@@ -3097,7 +3097,7 @@ description = "A list-like structure which implements collections.abc.MutableSeq
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"trainer-xgboost\") or extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\""
+markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"trainer-xgboost\" or extra == \"tuner\") or extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\""
 files = [
     {file = "frozenlist-1.8.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b37f6d31b3dcea7deb5e9696e529a6aa4a898adc33db82da12e4c60a7c4d2011"},
     {file = "frozenlist-1.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ef2b7b394f208233e471abc541cc6991f907ffd47dc72584acee3147899d6565"},
@@ -3360,7 +3360,7 @@ description = "Google API client core library"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\")"
+markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\")"
 files = [
     {file = "google_api_core-2.30.3-py3-none-any.whl", hash = "sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8"},
     {file = "google_api_core-2.30.3.tar.gz", hash = "sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b"},
@@ -3384,7 +3384,7 @@ description = "Google API client core library"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\")"
+markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\")"
 files = [
     {file = "google_api_core-2.31.0-py3-none-any.whl", hash = "sha256:ef79fb3784c71cbac89cbd03301ba0c8fb8ad2aa95d7f9204dd9628f7adf59ab"},
     {file = "google_api_core-2.31.0.tar.gz", hash = "sha256:2be84ee0f584c48e6bde1b36766e23348b361fb7e55e56135fc76ce1c397f9c2"},
@@ -3411,7 +3411,7 @@ description = "Google Authentication Library"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"trainer-mlflow\")"
+markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-mlflow\")"
 files = [
     {file = "google_auth-2.50.0-py3-none-any.whl", hash = "sha256:04382175e28b94f49694977f0a792688b59a668def1499e9d8de996dc9ce5b15"},
     {file = "google_auth-2.50.0.tar.gz", hash = "sha256:f35eafb191195328e8ce10a7883970877e7aeb49c2bfaa54aa0e394316d353d0"},
@@ -3440,7 +3440,7 @@ description = "Google Authentication Library"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"trainer-mlflow\")"
+markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-mlflow\")"
 files = [
     {file = "google_auth-2.55.0-py3-none-any.whl", hash = "sha256:a17cef9dedf98c4ebae2fb0c48c8f75952c877cbc2efe09f329ef16c2783d88a"},
     {file = "google_auth-2.55.0.tar.gz", hash = "sha256:fcd3a130f575fa36403d38774af1c64a4fbfbca09215f0589d2372b5119697cb"},
@@ -3469,7 +3469,7 @@ description = "Common protobufs used in Google APIs"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\""
+markers = "extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\""
 files = [
     {file = "googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed"},
     {file = "googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd"},
@@ -4087,9 +4087,9 @@ files = [
 filelock = "*"
 fsspec = ">=2023.5.0"
 hf-xet = [
+    {version = ">=1.1.3,<2.0.0", markers = "platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"arm64\" or platform_machine == \"aarch64\""},
     {version = ">=1.1.3,<2.0.0", optional = true, markers = "(platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"arm64\" or platform_machine == \"aarch64\") and extra == \"hf-xet\""},
     {version = ">=1.1.2,<2.0.0", optional = true, markers = "extra == \"hf-xet\" and platform_machine != \"x86_64\" and platform_machine != \"amd64\" and platform_machine != \"arm64\" and platform_machine != \"aarch64\""},
-    {version = ">=1.1.3,<2.0.0", markers = "platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"arm64\" or platform_machine == \"aarch64\""},
 ]
 packaging = ">=20.9"
 pyyaml = ">=5.1"
@@ -4168,7 +4168,7 @@ description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-mlflow\" or extra == \"trainer-comet\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"trainer-xgboost\") or extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"trainer-mlflow\" or extra == \"trainer-comet\""
+markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-mlflow\" or extra == \"trainer-comet\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"trainer-xgboost\" or extra == \"tuner\") or extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-mlflow\" or extra == \"trainer-comet\""
 files = [
     {file = "idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"},
     {file = "idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848"},
@@ -4184,7 +4184,7 @@ description = "Read metadata from Python packages"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version == \"3.9\" and (extra == \"example\" or extra == \"trainer-mlflow\" or extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\")"
+markers = "python_version == \"3.9\" and (extra == \"example\" or extra == \"trainer-mlflow\" or extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\")"
 files = [
     {file = "importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151"},
     {file = "importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb"},
@@ -4475,7 +4475,7 @@ description = "An implementation of JSON Schema validation for Python"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"trainer-comet\")"
+markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-comet\")"
 files = [
     {file = "jsonschema-4.25.1-py3-none-any.whl", hash = "sha256:3fba0169e345c7175110351d456342c364814cfcf3b964ba4587f22915230a63"},
     {file = "jsonschema-4.25.1.tar.gz", hash = "sha256:e4a9655ce0da0c0b67a085847e00a3a51449e1157f4f75e9fb5aa545e122eb85"},
@@ -4498,7 +4498,7 @@ description = "An implementation of JSON Schema validation for Python"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"trainer-comet\")"
+markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-comet\")"
 files = [
     {file = "jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce"},
     {file = "jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326"},
@@ -4521,7 +4521,7 @@ description = "The JSON Schema meta-schemas and vocabularies, exposed as a Regis
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"trainer-comet\""
+markers = "extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-comet\""
 files = [
     {file = "jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe"},
     {file = "jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d"},
@@ -5909,7 +5909,7 @@ description = "MessagePack serializer"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\")"
+markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\")"
 files = [
     {file = "msgpack-1.1.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0051fffef5a37ca2cd16978ae4f0aef92f164df86823871b5162812bebecd8e2"},
     {file = "msgpack-1.1.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a605409040f2da88676e9c9e5853b3449ba8011973616189ea5ee55ddbc5bc87"},
@@ -5982,7 +5982,7 @@ description = "MessagePack serializer"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\")"
+markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\")"
 files = [
     {file = "msgpack-1.2.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8c7b398c56ff125feae96c2737abfec5595f1fa0aa186df60c56040b8accb95c"},
     {file = "msgpack-1.2.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1548006a91aa93c5da81f3bdcebc1a0d10cea2d25969754fbe848da622b2b895"},
@@ -6195,7 +6195,7 @@ description = "multidict implementation"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"trainer-xgboost\") or extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\""
+markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"trainer-xgboost\" or extra == \"tuner\") or extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\""
 files = [
     {file = "multidict-6.7.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:c93c3db7ea657dd4637d57e74ab73de31bccefe144d3d4ce370052035bc85fb5"},
     {file = "multidict-6.7.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:974e72a2474600827abaeda71af0c53d9ebbc3c2eb7da37b37d7829ae31232d8"},
@@ -7187,7 +7187,7 @@ description = "A stats collection and distributed tracing framework"
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\""
+markers = "extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\""
 files = [
     {file = "opencensus-0.11.4-py2.py3-none-any.whl", hash = "sha256:a18487ce68bc19900336e0ff4655c5a116daf10c1b3685ece8d971bddad6a864"},
     {file = "opencensus-0.11.4.tar.gz", hash = "sha256:cbef87d8b8773064ab60e5c2a1ced58bbaa38a6d052c41aec224958ce544eff2"},
@@ -7205,7 +7205,7 @@ description = "OpenCensus Runtime Context"
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\""
+markers = "extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\""
 files = [
     {file = "opencensus-context-0.1.3.tar.gz", hash = "sha256:a03108c3c10d8c80bb5ddf5c8a1f033161fa61972a9917f9b9b3a18517f0088c"},
     {file = "opencensus_context-0.1.3-py2.py3-none-any.whl", hash = "sha256:073bb0590007af276853009fac7e4bab1d523c3f03baf4cb4511ca38967c6039"},
@@ -7231,10 +7231,10 @@ files = [
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.19.3", markers = "(python_version >= \"3.8\" and platform_system == \"Linux\" and platform_machine == \"aarch64\" or python_version >= \"3.9\") and (python_version > \"3.9\" or platform_system != \"Darwin\" or platform_machine != \"arm64\")"},
-    {version = ">=1.21.2", markers = "platform_system != \"Darwin\" and python_version >= \"3.10\""},
     {version = ">=1.21.0", markers = "python_version == \"3.9\" and platform_system == \"Darwin\" and platform_machine == \"arm64\""},
+    {version = ">=1.19.3", markers = "(python_version >= \"3.8\" and platform_system == \"Linux\" and platform_machine == \"aarch64\" or python_version >= \"3.9\") and (python_version > \"3.9\" or platform_system != \"Darwin\" or platform_machine != \"arm64\")"},
     {version = ">=1.21.4", markers = "python_version >= \"3.10\" and platform_system == \"Darwin\""},
+    {version = ">=1.21.2", markers = "platform_system != \"Darwin\" and python_version >= \"3.10\""},
     {version = ">=1.23.5", markers = "python_version >= \"3.11\""},
     {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
 ]
@@ -7246,7 +7246,7 @@ description = "OpenTelemetry Python API"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"trainer-mlflow\")"
+markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-mlflow\")"
 files = [
     {file = "opentelemetry_api-1.41.1-py3-none-any.whl", hash = "sha256:a22df900e75c76dc08440710e51f52f1aa6b451b429298896023e60db5b3139f"},
     {file = "opentelemetry_api-1.41.1.tar.gz", hash = "sha256:0ad1814d73b875f84494387dae86ce0b12c68556331ce6ce8fe789197c949621"},
@@ -7263,7 +7263,7 @@ description = "OpenTelemetry Python API"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"trainer-mlflow\")"
+markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-mlflow\")"
 files = [
     {file = "opentelemetry_api-1.43.0-py3-none-any.whl", hash = "sha256:20acf45e9b21851926835292e4045d290acade1edd2ff3de86d2f069687ba1fd"},
     {file = "opentelemetry_api-1.43.0.tar.gz", hash = "sha256:107d0d03857ea8fc7c5fcbbbd83f800c281f0d560553d61c1d675fccfd1761c1"},
@@ -7279,7 +7279,7 @@ description = "Prometheus Metric Exporter for OpenTelemetry"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\")"
+markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\")"
 files = [
     {file = "opentelemetry_exporter_prometheus-0.62b1-py3-none-any.whl", hash = "sha256:7a0b8a6402e107e1f93e38f074a668797e1103936b189561959531a67ffeba55"},
     {file = "opentelemetry_exporter_prometheus-0.62b1.tar.gz", hash = "sha256:7ecbac9aa76e7abb44082ab0ff2983e0a573e4091c4653f7db483b02bae03506"},
@@ -7297,7 +7297,7 @@ description = "Prometheus Metric Exporter for OpenTelemetry"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\")"
+markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\")"
 files = [
     {file = "opentelemetry_exporter_prometheus-0.64b0-py3-none-any.whl", hash = "sha256:9979a15f8d007d442bc7a6e16f4cbde5e8e0c5e99689887ceb5f33da251f0655"},
     {file = "opentelemetry_exporter_prometheus-0.64b0.tar.gz", hash = "sha256:96fec79be9527cb9dc994d7e663051df35161eb936fe2d41954725e4595abbc1"},
@@ -7315,7 +7315,7 @@ description = "OpenTelemetry Python Proto"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\")"
+markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\")"
 files = [
     {file = "opentelemetry_proto-1.41.1-py3-none-any.whl", hash = "sha256:0496713b804d127a4147e32849fbaf5683fac8ee98550e8e7679cd706c289720"},
     {file = "opentelemetry_proto-1.41.1.tar.gz", hash = "sha256:4b9d2eb631237ea43b80e16c073af438554e32bc7e9e3f8ca4a9582f900020e5"},
@@ -7331,7 +7331,7 @@ description = "OpenTelemetry Python Proto"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\")"
+markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\")"
 files = [
     {file = "opentelemetry_proto-1.43.0-py3-none-any.whl", hash = "sha256:c58f1f7ef84bc7dc2834016c0c37fe0081dde7ca9f6339be1970fbf9cdaaa90d"},
     {file = "opentelemetry_proto-1.43.0.tar.gz", hash = "sha256:224778df17e1f3fafeaaa21d874236ca5f6ffc2f86e0899298ec7351aac27924"},
@@ -7347,7 +7347,7 @@ description = "OpenTelemetry Python SDK"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"trainer-mlflow\")"
+markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-mlflow\")"
 files = [
     {file = "opentelemetry_sdk-1.41.1-py3-none-any.whl", hash = "sha256:edee379c126c1bce952b0c812b48fe8ff35b30df0eecf17e98afa4d598b7d85d"},
     {file = "opentelemetry_sdk-1.41.1.tar.gz", hash = "sha256:724b615e1215b5aeacda0abb8a6a8922c9a1853068948bd0bd225a56d0c792e6"},
@@ -7368,7 +7368,7 @@ description = "OpenTelemetry Python SDK"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"trainer-mlflow\")"
+markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-mlflow\")"
 files = [
     {file = "opentelemetry_sdk-1.43.0-py3-none-any.whl", hash = "sha256:d1323a547c1ce69d6a069a17a44b7da82bb8b332051ecb074041f87642c86823"},
     {file = "opentelemetry_sdk-1.43.0.tar.gz", hash = "sha256:d8187c81c162df9913e4003dd6485f7390d9a24fc17026ec7387b8b8218b08e9"},
@@ -7389,7 +7389,7 @@ description = "OpenTelemetry Semantic Conventions"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"trainer-mlflow\")"
+markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-mlflow\")"
 files = [
     {file = "opentelemetry_semantic_conventions-0.62b1-py3-none-any.whl", hash = "sha256:cf506938103d331fbb78eded0d9788095f7fd59016f2bda813c3324e5a74a93c"},
     {file = "opentelemetry_semantic_conventions-0.62b1.tar.gz", hash = "sha256:c5cc6e04a7f8c7cdd30be2ed81499fa4e75bfbd52c9cb70d40af1f9cd3619802"},
@@ -7406,7 +7406,7 @@ description = "OpenTelemetry Semantic Conventions"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"trainer-mlflow\")"
+markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-mlflow\")"
 files = [
     {file = "opentelemetry_semantic_conventions-0.64b0-py3-none-any.whl", hash = "sha256:ea77e85e354b8f604ddbe5f3d9135216f982fa4d77e5859ac30f6d8a50505aa6"},
     {file = "opentelemetry_semantic_conventions-0.64b0.tar.gz", hash = "sha256:72f76fb2d1582d9d033dd1fcd84532e961e6ff3d90d24ba6fabc72975a83864c"},
@@ -7520,7 +7520,7 @@ description = "Powerful data structures for data analysis, time series, and stat
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"example\" or extra == \"vllm\" or extra == \"dev\" or extra == \"trainer-xgboost\" or extra == \"trainer-mlflow\""
+markers = "extra == \"example\" or extra == \"vllm\" or extra == \"dev\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-mlflow\""
 files = [
     {file = "pandas-2.3.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:376c6446ae31770764215a6c937f72d917f214b43560603cd60da6408f183b6c"},
     {file = "pandas-2.3.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e19d192383eab2f4ceb30b412b22ea30690c9e618f78870357ae1d682912015a"},
@@ -7901,7 +7901,7 @@ description = "A small Python package for determining appropriate platform-speci
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\")"
+markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\")"
 files = [
     {file = "platformdirs-4.4.0-py3-none-any.whl", hash = "sha256:abd01743f24e5287cd7a5db3752faf1a2d65353f38ec26d98e25a6db65958c85"},
     {file = "platformdirs-4.4.0.tar.gz", hash = "sha256:ca753cf4d81dc309bc67b0ea38fd15dc97bc30ce419a7f58d13eb3bf14c4febf"},
@@ -7919,7 +7919,7 @@ description = "A small Python package for determining appropriate platform-speci
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\")"
+markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\")"
 files = [
     {file = "platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a"},
     {file = "platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7"},
@@ -8117,7 +8117,7 @@ description = "Python client for the Prometheus monitoring system."
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\""
+markers = "extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\""
 files = [
     {file = "prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1"},
     {file = "prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28"},
@@ -8169,7 +8169,7 @@ description = "Accelerated property cache"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"trainer-xgboost\")"
+markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"trainer-xgboost\" or extra == \"tuner\")"
 files = [
     {file = "propcache-0.4.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7c2d1fa3201efaf55d730400d945b5b3ab6e672e100ba0f9a409d950ab25d7db"},
     {file = "propcache-0.4.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1eb2994229cc8ce7fe9b3db88f5465f5fd8651672840b2e426b88cdb1a30aac8"},
@@ -8302,7 +8302,7 @@ description = "Accelerated property cache"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\")"
+markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\")"
 files = [
     {file = "propcache-0.5.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d5a81be28596d6559f6131ef33e10200de6e17643b3c74ce03f9eb103be6ae8b"},
     {file = "propcache-0.5.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:29cbaac5ea0212663e6845e04b5e188d5a6ae6dd919810ac835bf1d3b42c3f4c"},
@@ -8434,7 +8434,7 @@ description = "Beautiful, Pythonic protocol buffers"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\")"
+markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\")"
 files = [
     {file = "proto_plus-1.27.2-py3-none-any.whl", hash = "sha256:6432f75893d3b9e70b9c412f1d2f03f65b11fb164b793d14ae2ca01821d22718"},
     {file = "proto_plus-1.27.2.tar.gz", hash = "sha256:b2adde53adadf75737c44d3dcb0104fde65250dfc83ad59168b4aa3e574b6a24"},
@@ -8453,7 +8453,7 @@ description = "Beautiful, Pythonic protocol buffers"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\")"
+markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\")"
 files = [
     {file = "proto_plus-1.28.0-py3-none-any.whl", hash = "sha256:a630604310899e73c59ec302e5765c058d412b2f090b9c79c8822589f14955b8"},
     {file = "proto_plus-1.28.0.tar.gz", hash = "sha256:38e5696342835b08fc116f30a25665b29531cda9d5d5643e9b81fc312385abd9"},
@@ -8541,7 +8541,7 @@ description = ""
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\""
+markers = "extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\""
 files = [
     {file = "py_spy-0.4.2-py2.py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:1ccf688393105111684435f035bc14ec3f22117dd2b85b2414612cf27a22755a"},
     {file = "py_spy-0.4.2-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:a0e6f6810ccf0fc5e64e85e0182a5b626c4496eec01b14fb8755154b363a4831"},
@@ -8576,7 +8576,7 @@ description = "Python library for Apache Arrow"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"example\" or extra == \"vllm\" or extra == \"dev\" or extra == \"trainer-mlflow\""
+markers = "extra == \"example\" or extra == \"vllm\" or extra == \"dev\" or extra == \"tuner\" or extra == \"trainer-mlflow\""
 files = [
     {file = "pyarrow-19.0.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:fc28912a2dc924dddc2087679cc8b7263accc71b9ff025a1362b004711661a69"},
     {file = "pyarrow-19.0.1-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:fca15aabbe9b8355800d923cc2e82c8ef514af321e18b437c3d782aa884eaeec"},
@@ -8632,7 +8632,7 @@ description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs 
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"trainer-mlflow\""
+markers = "extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-mlflow\""
 files = [
     {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
     {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
@@ -8645,7 +8645,7 @@ description = "A collection of ASN.1-based protocols modules"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"trainer-mlflow\""
+markers = "extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-mlflow\""
 files = [
     {file = "pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a"},
     {file = "pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6"},
@@ -8911,7 +8911,7 @@ description = "C parser in Python"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "(platform_python_implementation != \"PyPy\" or extra == \"example\" or extra == \"minio\" or extra == \"vllm\") and (platform_python_implementation != \"PyPy\" or extra == \"example\" or extra == \"minio\" or implementation_name == \"pypy\") and python_version == \"3.9\" and implementation_name != \"PyPy\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"trainer-mlflow\" or extra == \"minio\")"
+markers = "(platform_python_implementation != \"PyPy\" or extra == \"example\" or extra == \"minio\" or extra == \"vllm\") and (platform_python_implementation != \"PyPy\" or extra == \"example\" or extra == \"minio\" or implementation_name == \"pypy\") and python_version == \"3.9\" and implementation_name != \"PyPy\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-mlflow\" or extra == \"minio\")"
 files = [
     {file = "pycparser-2.23-py3-none-any.whl", hash = "sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934"},
     {file = "pycparser-2.23.tar.gz", hash = "sha256:78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2"},
@@ -8924,7 +8924,7 @@ description = "C parser in Python"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "(platform_python_implementation != \"PyPy\" or extra == \"example\" or extra == \"minio\" or implementation_name == \"pypy\") and (platform_python_implementation != \"PyPy\" or python_version <= \"3.12\" or extra == \"example\" or extra == \"minio\") and (platform_python_implementation != \"PyPy\" or extra == \"example\" or extra == \"minio\" or extra == \"vllm\") and python_version >= \"3.10\" and implementation_name != \"PyPy\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"trainer-mlflow\" or extra == \"minio\")"
+markers = "(platform_python_implementation != \"PyPy\" or extra == \"example\" or extra == \"minio\" or implementation_name == \"pypy\") and (platform_python_implementation != \"PyPy\" or python_version <= \"3.12\" or extra == \"example\" or extra == \"minio\") and (platform_python_implementation != \"PyPy\" or extra == \"example\" or extra == \"minio\" or extra == \"vllm\") and python_version >= \"3.10\" and implementation_name != \"PyPy\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-mlflow\" or extra == \"minio\")"
 files = [
     {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
     {file = "pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"},
@@ -9376,7 +9376,7 @@ description = "Extensions to the standard Python datetime module"
 optional = true
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 groups = ["main"]
-markers = "extra == \"example\" or extra == \"vllm\" or extra == \"dev\" or extra == \"trainer-xgboost\" or extra == \"trainer-mlflow\""
+markers = "extra == \"example\" or extra == \"vllm\" or extra == \"dev\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-mlflow\""
 files = [
     {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
     {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
@@ -9392,7 +9392,7 @@ description = "Python interpreter discovery"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\""
+markers = "extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\""
 files = [
     {file = "python_discovery-1.4.2-py3-none-any.whl", hash = "sha256:475803f53b7b2ed6e490e27373f9d8340f7d2eebf9acdaf645d7d714c97bb500"},
     {file = "python_discovery-1.4.2.tar.gz", hash = "sha256:8f3746c4b4968d22afbb97d36e1a0e5b66e6c0f297290f2e95f05b9b8bf18690"},
@@ -9590,7 +9590,7 @@ description = "World timezone definitions, modern and historical"
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "extra == \"example\" or extra == \"vllm\" or extra == \"dev\" or extra == \"trainer-xgboost\" or extra == \"trainer-mlflow\""
+markers = "extra == \"example\" or extra == \"vllm\" or extra == \"dev\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-mlflow\""
 files = [
     {file = "pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126"},
     {file = "pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a"},
@@ -9824,7 +9824,7 @@ description = "Ray provides a simple, universal API for building distributed app
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\")"
+markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\")"
 files = [
     {file = "ray-2.51.2-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:eb9b995de9ba3110373f00e77dda86f6a55a80a58114b1eae5e6daf1f5697338"},
     {file = "ray-2.51.2-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:983adacd9cecf2f74f7915560036f14c5d4fabdf6f65d959debc92820373729d"},
@@ -9953,7 +9953,7 @@ description = "Ray provides a simple, universal API for building distributed app
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\")"
+markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\")"
 files = [
     {file = "ray-2.55.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:2d5786661e192148719accc959def6cdcabd7a24cd9008005bf3d0e3c8cfd529"},
     {file = "ray-2.55.1-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:baf2ec89df7838cabdef493ff9bdbec1e6a6452f8bc696ad0c1b8a6198721745"},
@@ -10028,7 +10028,7 @@ description = "JSON Referencing + Python"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"trainer-comet\")"
+markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-comet\")"
 files = [
     {file = "referencing-0.36.2-py3-none-any.whl", hash = "sha256:e8699adbbf8b5c7de96d8ffa0eb5c158b3beafce084968e2ea8bb08c6794dcd0"},
     {file = "referencing-0.36.2.tar.gz", hash = "sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa"},
@@ -10046,7 +10046,7 @@ description = "JSON Referencing + Python"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"trainer-comet\")"
+markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-comet\")"
 files = [
     {file = "referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231"},
     {file = "referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8"},
@@ -10331,7 +10331,7 @@ description = "Python HTTP for Humans."
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"trainer-mlflow\" or extra == \"trainer-comet\")"
+markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-mlflow\" or extra == \"trainer-comet\")"
 files = [
     {file = "requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6"},
     {file = "requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"},
@@ -10354,7 +10354,7 @@ description = "Python HTTP for Humans."
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"trainer-mlflow\" or extra == \"trainer-comet\")"
+markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-mlflow\" or extra == \"trainer-comet\")"
 files = [
     {file = "requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0"},
     {file = "requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed"},
@@ -10596,7 +10596,7 @@ description = "Python bindings to Rust's persistent data structures (rpds)"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"trainer-comet\")"
+markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-comet\")"
 files = [
     {file = "rpds_py-0.27.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:68afeec26d42ab3b47e541b272166a0b4400313946871cba3ed3a4fc0cab1cef"},
     {file = "rpds_py-0.27.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:74e5b2f7bb6fa38b1b10546d27acbacf2a022a8b5543efb06cfebc72a59c85be"},
@@ -10762,7 +10762,7 @@ description = "Python bindings to Rust's persistent data structures (rpds)"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "python_version == \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"trainer-comet\")"
+markers = "python_version == \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-comet\")"
 files = [
     {file = "rpds_py-0.30.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:679ae98e00c0e8d68a7fda324e16b90fd5260945b45d3b824c892cec9eea3288"},
     {file = "rpds_py-0.30.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4cc2206b76b4f576934f0ed374b10d7ca5f457858b157ca52064bdfc26b9fc00"},
@@ -10888,7 +10888,7 @@ description = "Python bindings to Rust's persistent data structures (rpds)"
 optional = true
 python-versions = ">=3.11"
 groups = ["main"]
-markers = "python_version >= \"3.11\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"trainer-comet\")"
+markers = "python_version >= \"3.11\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-comet\")"
 files = [
     {file = "rpds_py-2026.5.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:3397a5ed7174dc2786bb214030232fc36fe8e5584fec43a9952cc542b1a12036"},
     {file = "rpds_py-2026.5.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:99ab6ba7bfa2cb0f96a04e3652355bf04e3f51aceb1e943b8541dab7ba4828cc"},
@@ -11854,7 +11854,7 @@ description = "Python 2 and 3 compatibility utilities"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 groups = ["main"]
-markers = "extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"trainer-mlflow\""
+markers = "extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-mlflow\""
 files = [
     {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
     {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
@@ -11867,7 +11867,7 @@ description = "Utils for streaming large files (S3, HDFS, GCS, SFTP, Azure Blob 
 optional = true
 python-versions = "<4.0,>=3.9"
 groups = ["main"]
-markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\")"
+markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\")"
 files = [
     {file = "smart_open-7.5.0-py3-none-any.whl", hash = "sha256:87e695c5148bbb988f15cec00971602765874163be85acb1c9fb8abc012e6599"},
     {file = "smart_open-7.5.0.tar.gz", hash = "sha256:f394b143851d8091011832ac8113ea4aba6b92e6c35f6e677ddaaccb169d7cb9"},
@@ -11894,7 +11894,7 @@ description = "Utils for streaming large files (S3, HDFS, GCS, SFTP, Azure Blob 
 optional = true
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
-markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\")"
+markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\")"
 files = [
     {file = "smart_open-7.6.1-py3-none-any.whl", hash = "sha256:b4de6aebef023aca91cc9fb372052e1343ba3f152de215bd22391a663e3ddd21"},
     {file = "smart_open-7.6.1.tar.gz", hash = "sha256:4347996e7ba21db7cd1e059632e0b30395407e4f6c660d2ddffc8f2a9ae5f990"},
@@ -12744,7 +12744,7 @@ description = "Provider of IANA time zone data"
 optional = true
 python-versions = ">=2"
 groups = ["main"]
-markers = "extra == \"example\" or extra == \"vllm\" or extra == \"dev\" or extra == \"trainer-xgboost\" or extra == \"trainer-mlflow\""
+markers = "extra == \"example\" or extra == \"vllm\" or extra == \"dev\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-mlflow\""
 files = [
     {file = "tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7"},
     {file = "tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10"},
@@ -12757,7 +12757,7 @@ description = "HTTP library with thread-safe connection pooling, file post, and 
 optional = true
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
 groups = ["main"]
-markers = "python_version == \"3.9\" and (extra == \"vllm\" or extra == \"dev\" or extra == \"example\" or extra == \"trainer-mlflow\" or extra == \"trainer\" or extra == \"trainer-comet\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"trainer-xgboost\" or extra == \"minio\")"
+markers = "python_version == \"3.9\" and (extra == \"vllm\" or extra == \"dev\" or extra == \"example\" or extra == \"trainer-mlflow\" or extra == \"trainer\" or extra == \"trainer-comet\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"minio\")"
 files = [
     {file = "urllib3-1.26.20-py2.py3-none-any.whl", hash = "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e"},
     {file = "urllib3-1.26.20.tar.gz", hash = "sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32"},
@@ -12775,7 +12775,7 @@ description = "HTTP library with thread-safe connection pooling, file post, and 
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"trainer-mlflow\" or extra == \"trainer-comet\" or extra == \"minio\")"
+markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-mlflow\" or extra == \"trainer-comet\" or extra == \"minio\")"
 files = [
     {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
     {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
@@ -12915,7 +12915,7 @@ description = "Virtual Python Environment builder"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\""
+markers = "extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\""
 files = [
     {file = "virtualenv-21.5.1-py3-none-any.whl", hash = "sha256:55aa670b67bbfb991b03fda39bd3276d92c419d702376e98c5df1c9989a26783"},
     {file = "virtualenv-21.5.1.tar.gz", hash = "sha256:dca3bf98275a59c652b69d68e73433e597d977c2da9198882479d1a7188009c8"},
@@ -13461,7 +13461,7 @@ description = "Module for decorators, wrappers and monkey patching."
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"trainer-comet\""
+markers = "extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\" or extra == \"trainer-comet\""
 files = [
     {file = "wrapt-1.17.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:88bbae4d40d5a46142e70d58bf664a89b6b4befaea7b2ecc14e03cedb8e06c04"},
     {file = "wrapt-1.17.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e6b13af258d6a9ad602d57d889f83b9d5543acd471eee12eb51f5b01f8eb1bc2"},
@@ -13868,7 +13868,7 @@ description = "Yet another URL library"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"trainer-xgboost\")"
+markers = "python_version == \"3.9\" and (extra == \"dev\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"trainer-xgboost\" or extra == \"tuner\")"
 files = [
     {file = "yarl-1.22.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:c7bd6683587567e5a49ee6e336e0612bec8329be1b7d4c8af5687dcdeb67ee1e"},
     {file = "yarl-1.22.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5cdac20da754f3a723cceea5b3448e1a2074866406adeb4ef35b469d089adb8f"},
@@ -14014,7 +14014,7 @@ description = "Yet another URL library"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\")"
+markers = "python_version >= \"3.10\" and (extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"example\" or extra == \"vllm\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\")"
 files = [
     {file = "yarl-1.24.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:5249a113065c2b7a958bc699759e359cd61cfc81e3069662208f48f191b7ed12"},
     {file = "yarl-1.24.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7f4425fa244fbf530b006d0c5f79ce920114cfff5b4f5f6056e669f8e160fdc0"},
@@ -14134,7 +14134,7 @@ description = "Backport of pathlib-compatible object wrapper for zip files"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version == \"3.9\" and (extra == \"example\" or extra == \"trainer-mlflow\" or extra == \"vllm\" or extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"trainer\" or extra == \"trainer-xgboost\")"
+markers = "python_version == \"3.9\" and (extra == \"example\" or extra == \"trainer-mlflow\" or extra == \"vllm\" or extra == \"dev\" or extra == \"plugin\" or extra == \"ray-polars\" or extra == \"trainer\" or extra == \"trainer-xgboost\" or extra == \"tuner\")"
 files = [
     {file = "zipp-3.23.1-py3-none-any.whl", hash = "sha256:0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc"},
     {file = "zipp-3.23.1.tar.gz", hash = "sha256:32120e378d32cd9714ad503c1d024619063ec28aad2248dc6672ad13edfa5110"},
@@ -14181,9 +14181,10 @@ trainer-comet = ["comet_ml"]
 trainer-deepspeed = ["deepspeed"]
 trainer-mlflow = ["mlflow"]
 trainer-xgboost = ["numpy", "pandas", "ray", "ray", "xgboost"]
+tuner = ["pandas", "pyarrow", "ray", "ray"]
 vllm = ["accelerate", "datasets", "einops", "numpy", "pandas", "pyarrow", "pytorch_lightning", "ray", "ray", "s3fs", "setuptools", "torch", "transformers", "vllm"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9.0"
-content-hash = "16c893d656f8c53aa3fa69a422edc3974ca0d7067bae640c02b974f225f2301b"
+content-hash = "a7b2954578690a106ecce68e7ddc9dc4611c6f926aed91650861a3c762da697a"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -101,6 +101,7 @@ trainer-comet = ["comet_ml"]
 trainer-mlflow = ["mlflow"]
 trainer-xgboost = ["ray", "xgboost", "numpy", "pandas"]
 trainer-deepspeed = ["deepspeed"]
+tuner = ["ray", "pandas", "pyarrow"]  # Ray Tune helper (michelangelo.lib.tuner.ray_tune)
 
 [tool.pytest.ini_options]
 pythonpath = [


### PR DESCRIPTION
## Summary

Closes #1695.

Adds `michelangelo.lib.tuner.ray_tune`: a `TuneParam` dataclass plus a `tune()` function that run a `ray.tune` search on the Ray runtime the calling process is already connected to. Inside a `RayTask`-decorated Uniflow task that is the provisioned cluster - `RayTask.pre_run()` has already called `ray.init()` by the time the task body executes - so **one cluster runs all trials**:

```python
import michelangelo.uniflow.core as uniflow
from michelangelo.uniflow.plugins.ray import RayTask
from michelangelo.lib.tuner.ray_tune import TuneParam, tune

def objective(config: dict) -> None:
    loss = train_once(lr=config["lr"], depth=config["depth"])
    ray.tune.report({"val_loss": loss})

@uniflow.task(config=RayTask(head_cpu=2, worker_cpu=4, worker_instances=4))
def tune_step(data_url: str) -> dict:
    return tune(TuneParam(
        trainable=objective,
        param_space={"lr": ray.tune.loguniform(1e-4, 1e-1), "depth": ray.tune.randint(2, 10)},
        metric="val_loss", mode="min", num_samples=20,
    ))
```

The result dict (`best_config`, `best_metrics`, `checkpoint_path`, `num_trials`, `num_errors`) is plain data any downstream task can consume, mirroring the XGBoost trainer's contract.

Today's only sweep mechanism is the hand-written loop in `workflow-patterns.md`, which provisions **one Ray cluster per configuration** - N clusters for an N-point sweep. This helper is the "compose with the ray plugin rather than introduce new infrastructure" option #1695 proposed: ASHA by default (early-stops weak trials), `"fifo"` or any `TrialScheduler` instance accepted, per-trial resources via `ray.tune.with_resources`, checkpoints wherever the caller's `RunConfig` points (pass `create_run_config()` for UniFlow-managed storage, same as the trainers).

## Design notes

- **Library, not a new plugin layer.** The three-layer plugin machinery (Starlark + Go worker) exists to add cluster-provisioning capability; tune needs none - it runs inside an already-initialized Ray driver. This follows the shape #1793 established for the XGBoost trainer, and #1695's own preference for composing with the existing ray plugin. If per-trial resource semantics ever need cluster-shape awareness, that would be the trigger to revisit.
- **Builds on #1801** (now merged): GPU trials only make sense once `RayTask(worker_gpu=...)` actually reaches the cluster spec, which is what #1801 fixed.
- **Dependency-light**: the new `tuner` extra reuses already-declared optional deps (`ray`, `pandas`, `pyarrow`); no new package, no version changes.
- `tune_config_kwargs` passes anything else through to `ray.tune.TuneConfig` verbatim, but keys owned by first-class `TuneParam` fields are rejected rather than silently overridden.

## Testing

- 21 fully mocked unit tests (`ray.tune.Tuner` patched; no cluster): dataclass validation, scheduler resolution, Tuner wiring, resources wrapping, result contract, error propagation. **100% line and branch coverage** on the production module, so the 90% diff-coverage gate has headroom.
- 2 real-Ray integration tests in a separate module using the same CI skip guard as `lib/trainer`'s `test_auto_resume_integration.py` (skipped in CI, run locally / via `MICHELANGELO_RUN_RAY_INTEGRATION_TESTS=1`): a 4-point grid search on a local Ray runtime finds the known-best config, and the default ASHA path runs sampled trials to completion. Both pass locally on Ray 2.56.1 (23/23 total, ~15s).
- `ruff format` + `ruff check` clean with the repo config.
- `python/poetry.lock` regenerated for the new extra (`poetry check --lock` clean); the delta is extras-marker-only - no package or version changes.
- Docs: `overview.md`'s HPO row updated from "hand-written sweeps" to the helper (the row #1788 corrected - this PR ships the capability that makes the stronger claim true), and `workflow-patterns.md`'s sweep section gained a callout steering genuine HPO workloads here.
