### PR TITLE
feat(helm): expose the native GCS backend in the chart

### DIFF
--- a/docs/getting-started/roadmap.md
+++ b/docs/getting-started/roadmap.md
@@ -56,6 +56,7 @@ These capabilities are shipped and available in the current release. Individual 
 **Infrastructure & Compute**
 - Compute cluster registration
 - Storage management via any S3-compatible object store
+- Native GCS storage support (`gs://` reads via Application Default Credentials)
 
 **Automation & Self-Healing**
 - Revision-gated state transitions
@@ -102,7 +103,6 @@ These are capabilities we intend to build. Items closer to the top of each secti
 - Guardrail policies (input/output safety filtering, bias detection)
 
 **Infrastructure & Compute**
-- GCS storage support
 - Resource pool selection
 - Vector dataset management for embedding and RAG/similarity search
 

--- a/helm/michelangelo/README.md
+++ b/helm/michelangelo/README.md
@@ -250,6 +250,10 @@ Top-level keys. See [`values.yaml`](./values.yaml) for the full annotated schema
 | `objectStorage.accessKeyId` | string | `""` | conditional | Required unless `objectStorage.existingSecret` is set. |
 | `objectStorage.secretAccessKey` | string | `""` | conditional | Required unless `objectStorage.existingSecret` is set. |
 | `objectStorage.existingSecret` | string | `""` | no | Name of a pre-existing Secret with `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` keys. Takes precedence over the inline keys. |
+| `gcsStorage.enabled` | bool | `false` | no | Render native GCS (`gs://`) client configuration for the worker and controller manager. With workload identity no other keys are needed. |
+| `gcsStorage.existingSecret` | string | `""` | no | Name of a pre-existing Secret with a `credentials.json` key (GCP service account JSON), mounted read-only at `/etc/gcs/credentials.json`. Leave empty for Application Default Credentials. |
+| `gcsStorage.endpoint` | string | `""` | no | Custom storage endpoint (private Google access or an emulator). |
+| `gcsStorage.anonymous` | bool | `false` | no | Disable authentication. Public buckets and emulators only. |
 | `workflow.engine` | string | `cadence` | yes | `cadence` or `temporal`. Mutually exclusive — selects which worker config block renders. |
 | `workflow.endpoint` | string | `""` | **yes** | Workflow engine address (e.g. `cadence-frontend:7833`, `temporal-frontend:7233`). |
 | `workflow.domain` | string | `default` | no | Cadence domain or Temporal namespace. |

--- a/helm/michelangelo/templates/core/controllermgr-configmap.yaml
+++ b/helm/michelangelo/templates/core/controllermgr-configmap.yaml
@@ -25,6 +25,17 @@ data:
       awsSecretAccessKey: ${AWS_SECRET_ACCESS_KEY}
       awsEndpointUrl: {{ required "objectStorage.endpoint is required — see helm/michelangelo/README.md#values-reference" .Values.objectStorage.endpoint | quote }}
       secure: {{ .Values.objectStorage.secure }}
+    {{- if .Values.gcsStorage.enabled }}
+
+    gcs:
+      {{- if .Values.gcsStorage.existingSecret }}
+      credentialsFile: /etc/gcs/credentials.json
+      {{- end }}
+      {{- if .Values.gcsStorage.endpoint }}
+      endpoint: {{ .Values.gcsStorage.endpoint | quote }}
+      {{- end }}
+      anonymous: {{ .Values.gcsStorage.anonymous }}
+    {{- end }}
 
     metadataStorage:
       enableMetadataStorage: {{ .Values.controllermgr.metadataStorage.enable }}

--- a/helm/michelangelo/templates/core/controllermgr-deployment.yaml
+++ b/helm/michelangelo/templates/core/controllermgr-deployment.yaml
@@ -56,6 +56,11 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /config
+            {{- if and .Values.gcsStorage.enabled .Values.gcsStorage.existingSecret }}
+            - name: gcs-credentials
+              mountPath: /etc/gcs
+              readOnly: true
+            {{- end }}
           {{- with (or .Values.controllermgr.resources .Values.resources) }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -64,6 +69,11 @@ spec:
         - name: config
           configMap:
             name: {{ include "michelangelo.componentFullname" (dict "context" . "component" "controllermgr-config") }}
+        {{- if and .Values.gcsStorage.enabled .Values.gcsStorage.existingSecret }}
+        - name: gcs-credentials
+          secret:
+            secretName: {{ .Values.gcsStorage.existingSecret | quote }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/michelangelo/templates/core/worker-configmap.yaml
+++ b/helm/michelangelo/templates/core/worker-configmap.yaml
@@ -41,4 +41,15 @@ data:
       awsSecretAccessKey: ${AWS_SECRET_ACCESS_KEY}
       awsEndpointUrl: {{ required "objectStorage.endpoint is required — see helm/michelangelo/README.md#values-reference" .Values.objectStorage.endpoint | quote }}
       secure: {{ .Values.objectStorage.secure }}
+    {{- if .Values.gcsStorage.enabled }}
+
+    gcs:
+      {{- if .Values.gcsStorage.existingSecret }}
+      credentialsFile: /etc/gcs/credentials.json
+      {{- end }}
+      {{- if .Values.gcsStorage.endpoint }}
+      endpoint: {{ .Values.gcsStorage.endpoint | quote }}
+      {{- end }}
+      anonymous: {{ .Values.gcsStorage.anonymous }}
+    {{- end }}
 {{- end }}

--- a/helm/michelangelo/templates/core/worker-deployment.yaml
+++ b/helm/michelangelo/templates/core/worker-deployment.yaml
@@ -39,6 +39,11 @@ spec:
           volumeMounts:
             - name: worker-config
               mountPath: /config
+            {{- if and .Values.gcsStorage.enabled .Values.gcsStorage.existingSecret }}
+            - name: gcs-credentials
+              mountPath: /etc/gcs
+              readOnly: true
+            {{- end }}
           {{- with (or .Values.worker.resources .Values.resources) }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -47,6 +52,11 @@ spec:
         - name: worker-config
           configMap:
             name: {{ include "michelangelo.componentFullname" (dict "context" . "component" "worker-config") }}
+        {{- if and .Values.gcsStorage.enabled .Values.gcsStorage.existingSecret }}
+        - name: gcs-credentials
+          secret:
+            secretName: {{ .Values.gcsStorage.existingSecret | quote }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/michelangelo/values.yaml
+++ b/helm/michelangelo/values.yaml
@@ -75,6 +75,29 @@ objectStorage:
   existingSecret: ""
 
 # -----------------------------------------------------------------------------
+# Google Cloud Storage — optional native gs:// support for the worker and
+# controller manager. Independent of `objectStorage`, which remains the
+# S3-compatible store for artifacts, models, and logs.
+# -----------------------------------------------------------------------------
+gcsStorage:
+  # Render GCS client configuration. With GKE workload identity,
+  # `enabled: true` alone is enough: credentials resolve via Application
+  # Default Credentials and no keys are stored in the cluster.
+  enabled: false
+
+  # Optional. Name of a pre-existing Secret with a `credentials.json` key
+  # holding a GCP service account JSON key, mounted read-only at
+  # /etc/gcs/credentials.json. Leave empty to use Application Default
+  # Credentials (recommended).
+  existingSecret: ""
+
+  # Optional. Custom storage endpoint (private Google access or an emulator).
+  endpoint: ""
+
+  # Optional. Disable authentication. Public buckets and emulators only.
+  anonymous: false
+
+# -----------------------------------------------------------------------------
 # Workflow engine — Cadence or Temporal. Required by worker and apiserver.
 # -----------------------------------------------------------------------------
 workflow:


### PR DESCRIPTION
## Summary

Follow-up to the native GCS blobstore backend (#1837): exposes it through the chart so operators can configure it without editing configmaps by hand, and moves "GCS storage support" from Planned to Shipped on the roadmap.

New optional values block, off by default:

```yaml
gcsStorage:
  enabled: false        # render gcs client config for worker + controller manager
  existingSecret: ""    # optional Secret with a credentials.json key, mounted read-only
  endpoint: ""          # optional custom endpoint
  anonymous: false      # public buckets / emulators only
```

With GKE workload identity, `enabled: true` alone is enough -- credentials resolve via Application Default Credentials and no keys are stored in the cluster. When `existingSecret` is set, the key is mounted read-only at `/etc/gcs/credentials.json` and the rendered config points `credentialsFile` at it.

## Changes

- `values.yaml`: new `gcsStorage` block (documented inline, mirroring the `objectStorage` section's style).
- worker + controller manager configmaps: conditionally render the `gcs:` config block.
- worker + controller manager deployments: conditionally mount the credentials Secret (read-only).
- chart README: 4 new rows in the values reference.
- roadmap: GCS storage support moves from Planned to Shipped.

## Testing

- `helm lint` clean.
- All four template profiles from the helm CI workflow pass (k3d, production/Temporal, Cadence subchart, Temporal subchart).
- **Additive proof**: with default values, the rendered manifests are byte-identical to the chart before this change (`helm template ... | diff` returns empty against an unmodified checkout).
- Enabled renders verified structurally (parsed with a YAML loader, not grepped): `gcs:` block present and valid inside both configmaps' `base.yaml`; with `existingSecret` set, both deployments carry the read-only `/etc/gcs` mount and the Secret volume; with ADC (no secret), no `credentialsFile` and no mounts render.
