### PR TITLE
docs: point monitoring guide at the chart-managed observability resources

### DIFF
--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -111,6 +111,30 @@ jobs:
             --set temporal.server.config.persistence.visibility.sql.password=root \
             2>/dev/null
 
+      - name: Template — monitoring enabled (ServiceMonitor renders with CRDs present)
+        run: |
+          helm template michelangelo helm/michelangelo \
+            -f helm/michelangelo/values-k3d.yaml \
+            --set monitoring.enabled=true \
+            --api-versions monitoring.coreos.com/v1 \
+            --debug \
+            | grep 'kind: ServiceMonitor'
+
+      - name: Template — monitoring enabled without CRDs (must skip gracefully)
+        run: |
+          ! helm template michelangelo helm/michelangelo \
+            -f helm/michelangelo/values-k3d.yaml \
+            --set monitoring.enabled=true \
+            | grep 'kind: ServiceMonitor'
+
+      - name: Validate fail-fast guard (monitoring without controllermgr must fail)
+        run: |
+          ! helm template michelangelo helm/michelangelo \
+            -f helm/michelangelo/values-k3d.yaml \
+            --set monitoring.enabled=true \
+            --set controllermgr.enabled=false \
+            2>/dev/null
+
       - name: Template — Ingress enabled (UI + Envoy, hosts[] syntax)
         run: |
           helm template michelangelo helm/michelangelo \

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -118,14 +118,14 @@ jobs:
             --set monitoring.enabled=true \
             --api-versions monitoring.coreos.com/v1 \
             --debug \
-            | grep 'kind: ServiceMonitor'
+            | grep -e 'kind: ServiceMonitor' -e 'kind: PrometheusRule'
 
       - name: Template — monitoring enabled without CRDs (must skip gracefully)
         run: |
           ! helm template michelangelo helm/michelangelo \
             -f helm/michelangelo/values-k3d.yaml \
             --set monitoring.enabled=true \
-            | grep 'kind: ServiceMonitor'
+            | grep -e 'kind: ServiceMonitor' -e 'kind: PrometheusRule'
 
       - name: Validate fail-fast guard (monitoring without controllermgr must fail)
         run: |

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -117,15 +117,16 @@ jobs:
             -f helm/michelangelo/values-k3d.yaml \
             --set monitoring.enabled=true \
             --api-versions monitoring.coreos.com/v1 \
+            --api-versions grafana.integreatly.org/v1beta1 \
             --debug \
-            | grep -e 'kind: ServiceMonitor' -e 'kind: PrometheusRule'
+            | grep -e 'kind: ServiceMonitor' -e 'kind: PrometheusRule' -e 'kind: GrafanaDashboard'
 
       - name: Template — monitoring enabled without CRDs (must skip gracefully)
         run: |
           ! helm template michelangelo helm/michelangelo \
             -f helm/michelangelo/values-k3d.yaml \
             --set monitoring.enabled=true \
-            | grep -e 'kind: ServiceMonitor' -e 'kind: PrometheusRule'
+            | grep -e 'kind: ServiceMonitor' -e 'kind: PrometheusRule' -e 'kind: GrafanaDashboard'
 
       - name: Validate fail-fast guard (monitoring without controllermgr must fail)
         run: |

--- a/docs/operator-guides/helm-chart.md
+++ b/docs/operator-guides/helm-chart.md
@@ -127,6 +127,17 @@ objectStorage:
   existingSecret: my-s3-secret       # must contain keys: accessKeyId, secretAccessKey
 ```
 
+### Enable monitoring resources
+
+If your cluster runs the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) and/or the [Grafana Operator](https://github.com/grafana/grafana-operator), one toggle installs a `ServiceMonitor` for the controller manager, a `PrometheusRule` with starter alerts, and two `GrafanaDashboard`s:
+
+```yaml
+monitoring:
+  enabled: true
+```
+
+Every resource is CRD-gated — anything whose operator CRDs are absent is skipped, so the toggle is safe on any cluster. See [Monitoring & Observability](operations/monitoring.md) for the sub-toggles and the metrics behind each artifact.
+
 ### Expose the UI and API
 
 The chart includes per-service Ingress templates (`apiserver.ingress`, `envoy.ingress`, `ui.ingress`). Enable and configure them to expose the UI and API outside the cluster:
@@ -283,6 +294,7 @@ Most commonly set values. See `helm/michelangelo/values.yaml` for the complete l
 | `ui.enabled` / `envoy.enabled` / etc. | no | `true` | Per-service install toggle |
 | `<service>.ingress.enabled` | no | `false` | Per-service Ingress toggle |
 | `controllermgr.watchNamespace` | no | `[]` (all) | Namespaces the controller manager watches |
+| `monitoring.enabled` | no | `false` | Install CRD-gated ServiceMonitor, alert rules, and Grafana dashboards |
 | `cadence.enabled` | no | `false` | Install bundled Cadence subchart |
 | `temporal.enabled` | no | `false` | Install bundled Temporal subchart |
 
@@ -299,7 +311,7 @@ The `michelangelo` chart owns the **control plane only**. Three tiers, with clea
   - `michelangelo-ui` — React frontend (port 80)
   - `michelangelo-worker` — Cadence/Temporal workflow client
   - `michelangelo-controllermgr` — Kubernetes controller manager
-- **Observability tier** — optional. Bring your own Prometheus and Grafana, or see [Monitoring & Observability](operations/monitoring.md).
+- **Observability tier** — optional. Bring your own Prometheus and Grafana; if you run the Prometheus Operator and/or Grafana Operator, `monitoring.enabled=true` installs a ServiceMonitor, starter alert rules, and two dashboards (see [Monitoring & Observability](operations/monitoring.md)).
 
 ### Chart layout
 

--- a/docs/operator-guides/operations/monitoring.md
+++ b/docs/operator-guides/operations/monitoring.md
@@ -119,7 +119,9 @@ The `kind` label is a stable dashboard/alerting **contract**: its value is alway
 
 ## Alerting Rules
 
-Add these rules to your Prometheus configuration:
+If you use the Prometheus Operator, the Helm chart installs these rules as a `PrometheusRule` resource when `monitoring.enabled=true` (on by default under the toggle; disable with `monitoring.prometheusRule.enabled=false`). The four alerts based on controller-manager metrics are always included; the two Envoy-based inference alerts are behind `monitoring.prometheusRule.envoyAlerts.enabled` because they require the Envoy admin interface and a scrape job for it (see [Envoy Proxy](#envoy-proxy) above).
+
+If you manage Prometheus configuration directly, add the rules yourself:
 
 ```yaml
 groups:
@@ -211,7 +213,9 @@ groups:
 
 ## Grafana Dashboard
 
-Create a Grafana dashboard with these panels to get operational visibility at a glance.
+If you run the [Grafana Operator](https://github.com/grafana/grafana-operator), the Helm chart ships two ready-made dashboards as `GrafanaDashboard` resources when `monitoring.enabled=true`: a control-plane view (pipeline results, reconcile health, work queues, cascade delete) and a pipeline-runs view (durations, failure reasons, step completions). Point `monitoring.grafanaDashboards.instanceSelector` at the labels on your `Grafana` CR — the default matches `dashboards: grafana`. Every panel queries metrics the controller manager exposes out of the box.
+
+To build a dashboard by hand instead, use these panels to get operational visibility at a glance.
 
 ### Overview row
 

--- a/docs/operator-guides/operations/monitoring.md
+++ b/docs/operator-guides/operations/monitoring.md
@@ -14,7 +14,16 @@ Michelangelo AI components expose Prometheus metrics that integrate with a stand
 
 ### Controller Manager
 
-The controller manager exposes metrics on port `8091` (configured via `metricsBindAddress`). If you are using the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator), create a `ServiceMonitor`:
+The controller manager exposes metrics on port `8091` (configured via `metricsBindAddress`). If you are using the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator), the Helm chart can create the `ServiceMonitor` for you:
+
+```bash
+helm upgrade michelangelo ./helm/michelangelo --reuse-values \
+  --set monitoring.enabled=true
+```
+
+The resource is only rendered when the Prometheus Operator CRDs (`monitoring.coreos.com/v1`) are installed, so the toggle is a safe no-op on clusters without the operator. Scrape interval and extra labels (e.g. to match your Prometheus instance's `serviceMonitorSelector`) are configurable under `monitoring.serviceMonitor.*`.
+
+To create the `ServiceMonitor` yourself instead, select the controller manager Service by its chart labels:
 
 ```yaml
 apiVersion: monitoring.coreos.com/v1
@@ -22,12 +31,12 @@ kind: ServiceMonitor
 metadata:
   name: michelangelo-controllermgr
   namespace: ma-system
-  labels:
-    app: michelangelo-controllermgr
 spec:
   selector:
     matchLabels:
-      app: michelangelo-controllermgr
+      app.kubernetes.io/name: michelangelo
+      app.kubernetes.io/instance: michelangelo   # your Helm release name
+      app.kubernetes.io/component: controllermgr
   endpoints:
   - port: metrics          # Must match the Service port name for port 8091
     path: /metrics
@@ -36,12 +45,12 @@ spec:
 
 ### Health Probes
 
-The controller manager exposes health endpoints on port `8083` (configured via `healthProbeBindAddress`):
+The controller manager exposes health endpoints on port `8081` (configured via `healthProbeBindAddress`; the chart default is `controllermgr.healthPort: 8081`):
 
 | Endpoint | Purpose |
 |----------|---------|
-| `GET :8083/healthz` | Liveness — is the process alive? |
-| `GET :8083/readyz` | Readiness — is the controller ready to reconcile? |
+| `GET :8081/healthz` | Liveness — is the process alive? |
+| `GET :8081/readyz` | Readiness — is the controller ready to reconcile? |
 
 These are used by Kubernetes liveness and readiness probes, but you can also poll them from your monitoring stack for coarser-grained health checks.
 

--- a/helm/michelangelo/README.md
+++ b/helm/michelangelo/README.md
@@ -283,6 +283,9 @@ Top-level keys. See [`values.yaml`](./values.yaml) for the full annotated schema
 | `monitoring.serviceMonitor.enabled` | bool | `true` | no | Create a `ServiceMonitor` for the controller manager's `/metrics` endpoint (requires the Prometheus Operator CRDs, `monitoring.coreos.com/v1`). |
 | `monitoring.serviceMonitor.interval` | string | `30s` | no | Scrape interval. |
 | `monitoring.serviceMonitor.additionalLabels` | object | `{}` | no | Extra labels on the `ServiceMonitor`, e.g. to match a Prometheus instance's `serviceMonitorSelector`. |
+| `monitoring.prometheusRule.enabled` | bool | `true` | no | Create a `PrometheusRule` with starter alerts (pipeline-run failures/duration, reconcile errors, cascade drain timeouts). All default alerts use metrics exposed out of the box. |
+| `monitoring.prometheusRule.additionalLabels` | object | `{}` | no | Extra labels on the `PrometheusRule`, e.g. to match a Prometheus instance's `ruleSelector`. |
+| `monitoring.prometheusRule.envoyAlerts.enabled` | bool | `false` | no | Add inference latency/error alerts on Envoy upstream metrics. Requires the Envoy admin interface + a scrape job (not chart-managed). |
 | `serviceAccount.create` | bool | `true` | no | Create a ServiceAccount for the chart. |
 | `serviceAccount.name` | string | `""` | no | Override the generated ServiceAccount name. |
 | `podSecurityContext` | object | see values.yaml | no | Applied to every Pod. |

--- a/helm/michelangelo/README.md
+++ b/helm/michelangelo/README.md
@@ -286,6 +286,9 @@ Top-level keys. See [`values.yaml`](./values.yaml) for the full annotated schema
 | `monitoring.prometheusRule.enabled` | bool | `true` | no | Create a `PrometheusRule` with starter alerts (pipeline-run failures/duration, reconcile errors, cascade drain timeouts). All default alerts use metrics exposed out of the box. |
 | `monitoring.prometheusRule.additionalLabels` | object | `{}` | no | Extra labels on the `PrometheusRule`, e.g. to match a Prometheus instance's `ruleSelector`. |
 | `monitoring.prometheusRule.envoyAlerts.enabled` | bool | `false` | no | Add inference latency/error alerts on Envoy upstream metrics. Requires the Envoy admin interface + a scrape job (not chart-managed). |
+| `monitoring.grafanaDashboards.enabled` | bool | `true` | no | Create `GrafanaDashboard` CRs for the [Grafana Operator](https://github.com/grafana/grafana-operator) (requires its CRDs, `grafana.integreatly.org/v1beta1`). |
+| `monitoring.grafanaDashboards.instanceSelector` | object | `matchLabels: {dashboards: grafana}` | no | Label selector matching your Grafana CR(s). |
+| `monitoring.grafanaDashboards.resyncPeriod` | string | `10m` | no | How often the operator re-applies the dashboards. |
 | `serviceAccount.create` | bool | `true` | no | Create a ServiceAccount for the chart. |
 | `serviceAccount.name` | string | `""` | no | Override the generated ServiceAccount name. |
 | `podSecurityContext` | object | see values.yaml | no | Applied to every Pod. |

--- a/helm/michelangelo/README.md
+++ b/helm/michelangelo/README.md
@@ -279,6 +279,10 @@ Top-level keys. See [`values.yaml`](./values.yaml) for the full annotated schema
 | `worker.replicas` | int | `1` | no | Scale horizontally for higher pipeline-run throughput. |
 | `controllermgr.enabled` | bool | `true` | no | |
 | `controllermgr.watchNamespace` | list | `[]` | no | Namespaces the controller watches. Empty = all namespaces (ClusterRole). Set to a list to scope down to namespaced Roles. |
+| `monitoring.enabled` | bool | `false` | no | Master toggle for chart-managed monitoring resources. All resources are CRD-gated: skipped when the owning operator's CRDs are absent, so enabling this is safe on any cluster. |
+| `monitoring.serviceMonitor.enabled` | bool | `true` | no | Create a `ServiceMonitor` for the controller manager's `/metrics` endpoint (requires the Prometheus Operator CRDs, `monitoring.coreos.com/v1`). |
+| `monitoring.serviceMonitor.interval` | string | `30s` | no | Scrape interval. |
+| `monitoring.serviceMonitor.additionalLabels` | object | `{}` | no | Extra labels on the `ServiceMonitor`, e.g. to match a Prometheus instance's `serviceMonitorSelector`. |
 | `serviceAccount.create` | bool | `true` | no | Create a ServiceAccount for the chart. |
 | `serviceAccount.name` | string | `""` | no | Override the generated ServiceAccount name. |
 | `podSecurityContext` | object | see values.yaml | no | Applied to every Pod. |

--- a/helm/michelangelo/files/dashboards/control-plane.json
+++ b/helm/michelangelo/files/dashboards/control-plane.json
@@ -1,0 +1,406 @@
+{
+  "uid": "michelangelo-control-plane",
+  "title": "Michelangelo AI / Control Plane",
+  "tags": [
+    "michelangelo"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "refresh": "30s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "label": "Data source",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {}
+      }
+    ]
+  },
+  "panels": [
+    {
+      "title": "Pipeline run results",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (state) (rate(pipelinerun_result_total[5m]))",
+          "legendFormat": "{{state}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "ops"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Failed pipeline runs (latest)",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 0,
+        "w": 4,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum(pipelinerun_failed)",
+          "legendFormat": "failed",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Pipelines reached Ready",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 0,
+        "w": 4,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum(pipeline_ready_total)",
+          "legendFormat": "ready",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Reconcile errors",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 0,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(controller_runtime_reconcile_errors_total[5m]))",
+          "legendFormat": "errors/sec",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "ops"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Reconcile error rate by controller",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 8,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (controller) (rate(controller_runtime_reconcile_errors_total[5m]))",
+          "legendFormat": "{{controller}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "ops"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Reconcile latency P99",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 8,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(controller_runtime_reconcile_time_seconds_bucket[5m])))",
+          "legendFormat": "p99",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "s"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Work queue depth",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 8,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "workqueue_depth",
+          "legendFormat": "{{name}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "CR reflector errors",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 16,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (crd_type, error_type) (rate(cr_reflector_errors_total[5m]))",
+          "legendFormat": "{{crd_type}}/{{error_type}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "ops"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Cascade delete: children draining",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 16,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "cascade_child_drain_active",
+          "legendFormat": "{{kind}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Cascade delete: drain duration P99",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 16,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum by (le, kind) (rate(cascade_child_drain_duration_seconds_bucket[5m])))",
+          "legendFormat": "{{kind}} p99",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "s"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Cascade delete: drain timeouts (1h)",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 24,
+        "w": 4,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(cascade_child_drain_timeout_total[1h]))",
+          "legendFormat": "timeouts",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "ownerReference backfills",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 4,
+        "y": 24,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (kind) (rate(cascade_owner_ref_backfill_total[5m]))",
+          "legendFormat": "{{kind}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "ops"
+        },
+        "overrides": []
+      }
+    }
+  ]
+}

--- a/helm/michelangelo/files/dashboards/jobs.json
+++ b/helm/michelangelo/files/dashboards/jobs.json
@@ -1,0 +1,278 @@
+{
+  "uid": "michelangelo-jobs",
+  "title": "Michelangelo AI / Pipeline Runs",
+  "tags": [
+    "michelangelo"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "refresh": "30s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "label": "Data source",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {}
+      }
+    ]
+  },
+  "panels": [
+    {
+      "title": "Run duration P50 / P99",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(pipelinerun_duration_seconds_bucket[5m])))",
+          "legendFormat": "p50",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(pipelinerun_duration_seconds_bucket[5m])))",
+          "legendFormat": "p99",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "s"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Failure rate by reason",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 0,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (failure_reason) (rate(pipelinerun_result_failure_total[5m]))",
+          "legendFormat": "{{failure_reason}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "ops"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Results by state",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 8,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (state) (rate(pipelinerun_result_total[5m]))",
+          "legendFormat": "{{state}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "ops"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Results by pipeline type",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 8,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (pipeline_type) (rate(pipelinerun_result_total[5m]))",
+          "legendFormat": "{{pipeline_type}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "ops"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Successes vs failures",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 8,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(pipelinerun_result_success_total[5m]))",
+          "legendFormat": "success",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        },
+        {
+          "expr": "sum(rate(pipelinerun_result_failure_total[5m]))",
+          "legendFormat": "failure",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "ops"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Step completions by step",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 16,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (step_name) (rate(pipelinerun_step_success_total[5m]))",
+          "legendFormat": "{{step_name}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "ops"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Reconcile outcomes",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 16,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(pipelinerun_reconcile_success_total[5m]))",
+          "legendFormat": "success",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        },
+        {
+          "expr": "sum(rate(pipelinerun_reconcile_errors_total[5m]))",
+          "legendFormat": "errors",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "ops"
+        },
+        "overrides": []
+      }
+    }
+  ]
+}

--- a/helm/michelangelo/templates/monitoring/grafanadashboard-control-plane.yaml
+++ b/helm/michelangelo/templates/monitoring/grafanadashboard-control-plane.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.monitoring.enabled .Values.monitoring.grafanaDashboards.enabled (.Capabilities.APIVersions.Has "grafana.integreatly.org/v1beta1") }}
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: {{ include "michelangelo.fullname" . }}-control-plane
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "michelangelo.labels" . | nindent 4 }}
+spec:
+  resyncPeriod: {{ .Values.monitoring.grafanaDashboards.resyncPeriod }}
+  instanceSelector:
+    {{- toYaml .Values.monitoring.grafanaDashboards.instanceSelector | nindent 4 }}
+  json: |-
+    {{- .Files.Get "files/dashboards/control-plane.json" | nindent 4 }}
+{{- end }}

--- a/helm/michelangelo/templates/monitoring/grafanadashboard-jobs.yaml
+++ b/helm/michelangelo/templates/monitoring/grafanadashboard-jobs.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.monitoring.enabled .Values.monitoring.grafanaDashboards.enabled (.Capabilities.APIVersions.Has "grafana.integreatly.org/v1beta1") }}
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: {{ include "michelangelo.fullname" . }}-jobs
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "michelangelo.labels" . | nindent 4 }}
+spec:
+  resyncPeriod: {{ .Values.monitoring.grafanaDashboards.resyncPeriod }}
+  instanceSelector:
+    {{- toYaml .Values.monitoring.grafanaDashboards.instanceSelector | nindent 4 }}
+  json: |-
+    {{- .Files.Get "files/dashboards/jobs.json" | nindent 4 }}
+{{- end }}

--- a/helm/michelangelo/templates/monitoring/prometheusrule.yaml
+++ b/helm/michelangelo/templates/monitoring/prometheusrule.yaml
@@ -1,0 +1,91 @@
+{{- if and .Values.monitoring.enabled .Values.monitoring.prometheusRule.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "michelangelo.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "michelangelo.labels" . | nindent 4 }}
+    {{- with .Values.monitoring.prometheusRule.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  groups:
+    - name: michelangelo
+      rules:
+        # Pipeline run failure rate
+        - alert: PipelineRunFailureRateHigh
+          expr: rate(pipelinerun_result_failure_total[5m]) > 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Pipeline run failures detected"
+            description: >-
+              Pipeline runs are failing at {{`{{ $value | humanize }}`}} failures/sec.
+              Check failure reasons: kubectl get pipelineruns -A --field-selector status.phase=Failed
+
+        # Pipeline run duration: P99 above 1 hour
+        - alert: PipelineRunDurationHigh
+          expr: histogram_quantile(0.99, rate(pipelinerun_duration_seconds_bucket[5m])) > 3600
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Pipeline run P99 duration above 1 hour"
+            description: >-
+              The 99th percentile pipeline run duration is {{`{{ $value | humanize }}`}}s.
+
+        # Controller reconcile errors — sustained error rate from any controller
+        - alert: ControllerReconcileErrorRate
+          expr: rate(controller_runtime_reconcile_errors_total[5m]) > 0.1
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Controller {{`{{ $labels.controller }}`}} has high reconcile error rate"
+            description: >-
+              The {{`{{ $labels.controller }}`}} controller is failing reconciles at
+              {{`{{ $value | humanize }}`}} errors/sec. Check logs:
+              kubectl -n {{ .Release.Namespace }} logs deployment/{{ include "michelangelo.componentFullname" (dict "context" . "component" "controllermgr") }}
+
+        # Cascade delete: safety timeout force-completed a child's drain
+        - alert: CascadeChildDrainTimeout
+          expr: increase(cascade_child_drain_timeout_total[1h]) > 0
+          for: 0m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Cascade delete safety timeout fired"
+            description: >-
+              {{`{{ $value }}`}} child resource(s) were force-killed because their drain
+              did not complete within 24 hours. Investigate why the drain was wedged:
+              kubectl -n {{ .Release.Namespace }} logs deployment/{{ include "michelangelo.componentFullname" (dict "context" . "component" "controllermgr") }} | grep -i "cascade\|force"
+    {{- if .Values.monitoring.prometheusRule.envoyAlerts.enabled }}
+
+    - name: michelangelo-envoy
+      rules:
+        # Inference latency: P99 above 500ms for 5 minutes
+        - alert: InferenceLatencyHigh
+          expr: histogram_quantile(0.99, rate(envoy_cluster_upstream_rq_time_bucket[5m])) > 500
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Inference P99 latency is above 500ms"
+            description: >-
+              The 99th percentile inference request latency is {{`{{ $value }}`}}ms.
+              Check InferenceServer and model-sync sidecar logs.
+
+        # Inference error rate: more than 1% of requests returning 5xx
+        - alert: InferenceErrorRateHigh
+          expr: rate(envoy_cluster_upstream_rq_5xx[5m]) / rate(envoy_cluster_upstream_rq_total[5m]) > 0.01
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Inference 5xx error rate above 1%"
+            description: >-
+              {{`{{ $value | humanizePercentage }}`}} of inference requests are returning 5xx errors.
+    {{- end }}
+{{- end }}

--- a/helm/michelangelo/templates/monitoring/servicemonitor-controllermgr.yaml
+++ b/helm/michelangelo/templates/monitoring/servicemonitor-controllermgr.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.monitoring.enabled .Values.monitoring.serviceMonitor.enabled .Values.controllermgr.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "michelangelo.componentFullname" (dict "context" . "component" "controllermgr") }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "michelangelo.componentLabels" (dict "context" . "component" "controllermgr") | nindent 4 }}
+    {{- with .Values.monitoring.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "michelangelo.componentSelectorLabels" (dict "context" . "component" "controllermgr") | nindent 6 }}
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.monitoring.serviceMonitor.interval }}
+{{- end }}

--- a/helm/michelangelo/templates/validations.yaml
+++ b/helm/michelangelo/templates/validations.yaml
@@ -5,3 +5,6 @@ This file renders to empty YAML when all checks pass.
 {{- if and .Values.cadence.enabled .Values.temporal.enabled -}}
 {{- fail "cadence.enabled and temporal.enabled cannot both be true — pick one workflow engine per release. Set workflow.engine=cadence + cadence.enabled=true, OR workflow.engine=temporal + temporal.enabled=true. See helm/michelangelo/README.md." -}}
 {{- end -}}
+{{- if and .Values.monitoring.enabled (not .Values.controllermgr.enabled) -}}
+{{- fail "monitoring.enabled requires controllermgr.enabled=true — the controller manager is the only component exposing a /metrics endpoint. See helm/michelangelo/README.md." -}}
+{{- end -}}

--- a/helm/michelangelo/values.yaml
+++ b/helm/michelangelo/values.yaml
@@ -470,6 +470,26 @@ monitoring:
     # instance's serviceMonitorSelector.
     additionalLabels: {}
 
+  prometheusRule:
+    # Create a PrometheusRule with starter alerts for pipeline-run failures,
+    # long-running pipeline runs, controller reconcile errors, and cascade
+    # delete drain timeouts. All default alerts fire on metrics the
+    # controller manager exposes out of the box. Requires the Prometheus
+    # Operator CRDs (monitoring.coreos.com/v1); skipped when they are absent.
+    enabled: true
+
+    # Extra labels for the PrometheusRule, e.g. to match a Prometheus
+    # instance's ruleSelector.
+    additionalLabels: {}
+
+    envoyAlerts:
+      # Add inference latency/error-rate alerts on Envoy upstream metrics.
+      # Off by default because the Envoy admin interface (which exposes
+      # those metrics) is not enabled by the chart — enable it and add a
+      # scrape job first, or these alerts can never fire. See
+      # docs/operator-guides/operations/monitoring.md.
+      enabled: false
+
 # -----------------------------------------------------------------------------
 # ServiceAccount used by every chart-managed Pod.
 # -----------------------------------------------------------------------------

--- a/helm/michelangelo/values.yaml
+++ b/helm/michelangelo/values.yaml
@@ -490,6 +490,23 @@ monitoring:
       # docs/operator-guides/operations/monitoring.md.
       enabled: false
 
+  grafanaDashboards:
+    # Create GrafanaDashboard CRs (control-plane and pipeline-run views)
+    # for the Grafana Operator (https://github.com/grafana/grafana-operator).
+    # Every panel queries metrics the controller manager exposes out of the
+    # box. Requires the Grafana Operator CRDs (grafana.integreatly.org/v1beta1);
+    # skipped when they are absent.
+    enabled: true
+
+    # How often the operator re-applies the dashboards to Grafana.
+    resyncPeriod: 10m
+
+    # Label selector matching the Grafana CR(s) the dashboards should be
+    # installed into. Must match labels you set on your Grafana instance.
+    instanceSelector:
+      matchLabels:
+        dashboards: grafana
+
 # -----------------------------------------------------------------------------
 # ServiceAccount used by every chart-managed Pod.
 # -----------------------------------------------------------------------------

--- a/helm/michelangelo/values.yaml
+++ b/helm/michelangelo/values.yaml
@@ -448,6 +448,29 @@ controllermgr:
   resources: {}
 
 # -----------------------------------------------------------------------------
+# Optional monitoring resources. Everything here is CRD-gated: resources are
+# only rendered when the owning operator's CRDs are installed in the cluster,
+# so enabling the toggle on a cluster without the Prometheus Operator is a
+# safe no-op.
+# -----------------------------------------------------------------------------
+monitoring:
+  # Master toggle for chart-managed monitoring resources.
+  enabled: false
+
+  serviceMonitor:
+    # Scrape the controller manager's /metrics endpoint (port
+    # controllermgr.metricsPort). Requires the Prometheus Operator CRDs
+    # (monitoring.coreos.com/v1); skipped when they are absent.
+    enabled: true
+
+    # Scrape interval.
+    interval: 30s
+
+    # Extra labels for the ServiceMonitor, e.g. to match a Prometheus
+    # instance's serviceMonitorSelector.
+    additionalLabels: {}
+
+# -----------------------------------------------------------------------------
 # ServiceAccount used by every chart-managed Pod.
 # -----------------------------------------------------------------------------
 serviceAccount:


### PR DESCRIPTION
> **Note:** stacked on #1876 (the GrafanaDashboard CRs, PR 3 of this pack), so this diff shows its commits until that merges. The docs-only delta is [feat/monitoring-grafana-dashboards...docs/monitoring-starter-pack](https://github.com/apurvapatkeshwar/michelangelo/compare/feat/monitoring-grafana-dashboards...docs/monitoring-starter-pack).

## What this does

Final slice of the observability starter pack (#1692), docs only:

- The monitoring guide's alerting and dashboard sections now lead with the chart-managed path (`monitoring.enabled=true`) and keep the hand-rolled YAML as the alternative for operators not running the Prometheus/Grafana operators. The Envoy-alerts opt-in and its prerequisite are called out.
- The Helm guide gains an "Enable monitoring resources" section, a values-reference row, and an updated observability-tier bullet.

With this, the pack covers items 1, 2, and 4 of the issue's breakdown. Item 3 (per-job Prometheus scrape ConfigMap) is intentionally deferred: `FederatedClient.CreatePromConfigMap` exists but has no production callers and a hardcoded target, so wiring it up is a Go change with its own design questions rather than installable YAML -- happy to file it separately.

Roadmap entries ("Dashboard management via OSS Grafana operator", "Prometheus-based alerting for decommission gating") are left untouched since this pack delivers the artifacts but not the decommission-gating consumer; flipping those feels like a maintainer call.

## Test plan

- `helm lint` clean (no template changes in this PR).
- Docs cross-references checked against the values and template names introduced in the previous three PRs.
- Website build (`bun run build`) passes on the branch.
