### PR TITLE
chore: release 0.9.0

### DIFF
--- a/helm/michelangelo/Chart.yaml
+++ b/helm/michelangelo/Chart.yaml
@@ -7,8 +7,8 @@ description: |
   and RBAC — into any Kubernetes cluster. Bring your own metadata storage,
   object storage, and workflow engine (Cadence or Temporal).
 type: application
-version: 0.9.0-rc.2
-appVersion: "0.9.0-rc.2"
+version: 0.9.0
+appVersion: "0.9.0"
 kubeVersion: ">=1.27.0-0"
 
 dependencies:

--- a/javascript/app/package.json
+++ b/javascript/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@michelangelo/app",
   "license": "Apache-2.0",
-  "version": "0.9.0-rc.2",
+  "version": "0.9.0",
   "private": true,
   "scripts": {
     "build": "vite build --config vite.config.ts",
@@ -12,11 +12,11 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
-    "@michelangelo-ai/rpc": "0.9.0-rc.2",
+    "@michelangelo-ai/rpc": "0.9.0",
     "@mui/icons-material": "^7.1.0",
     "@mui/material": "^7.1.0",
     "@tanstack/react-query": "5.39.0",
-    "@michelangelo-ai/core": "0.9.0-rc.2",
+    "@michelangelo-ai/core": "0.9.0",
     "baseui": "15.0.0",
     "react-router-dom": "5.3.4",
     "react-router-dom-v5-compat": "6.29.0",

--- a/javascript/packages/core/package.json
+++ b/javascript/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@michelangelo-ai/core",
   "license": "Apache-2.0",
-  "version": "0.9.0-rc.2",
+  "version": "0.9.0",
   "type": "module",
   "main": "./dist/michelangelo-core.js",
   "module": "./dist/michelangelo-core.js",

--- a/javascript/packages/rpc/package.json
+++ b/javascript/packages/rpc/package.json
@@ -2,7 +2,7 @@
   "name": "@michelangelo-ai/rpc",
   "license": "Apache-2.0",
   "type": "module",
-  "version": "0.9.0-rc.2",
+  "version": "0.9.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/michelangelo-ai/michelangelo"
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.2.5",
-    "@michelangelo-ai/core": "0.9.0-rc.2"
+    "@michelangelo-ai/core": "0.9.0"
   },
   "exports": {
     ".": {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "michelangelo"
-version = "0.9.0-rc.2"
+version = "0.9.0"
 description = "Michelangelo AI is an end-to-end model lifecycle management system at large scale"
 authors = ["Michelangelo AI Team <michelangelo-oss-group@uber.com>"]
 readme = "README.md"

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "website",
-  "version": "0.9.0-rc.2",
+  "version": "0.9.0",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",


### PR DESCRIPTION
## Summary

Promotes `v0.9.0-rc.2` to final `v0.9.0` per REL-005 manual recovery (`release-promote.yml` cannot push directly to the protected `release/v0.9` branch).

Version-only bump, no code diff — `bash scripts/version-bump.sh 0.9.0` on top of `release/v0.9`'s current tip (`fa1b3198`, includes the rc.2 changelog PR #1906, no code changes since the release test).

## Release test

Full release test (task 066, `specs/066/release_test.md`) passed cleanly against `v0.9.0-rc.2`:

| Part | Result |
|---|---|
| Part 1 — sandbox on release artifacts | PASS |
| Part 2a — local pipeline smoke test | PASS |
| Part 2b — sandbox Cadence-dispatched pipelines | PASS (`pytorch_train`, `xgb_train` both `PIPELINE_RUN_STATE_SUCCEEDED`) |

Confirms the rc.1→rc.2 Go-binary fix (#1897/#1898/#1905) and the full release pipeline work end-to-end.

## Soak note

Promoting after a ~2-day soak (started 2026-08-21), short of the documented 1-week default — explicit user call, no known open blocker. Logged in `needs_human_review.md`.

Tracking issue: #1890

## Next steps after merge

- `git tag v0.9.0` on `release/v0.9`'s post-merge HEAD
- Manually dispatch `release.yaml`, `changelog.yml`, `ui-release.yml`, `dev-release.yml`, `npm-publish.yml` for the tag
- Verify all artifacts live (PyPI, 4 containers, Helm chart, npm `latest` dist-tag, Go binaries)
- Mark the `release/v0.9` → `main` merge-back PR ready for review
- Comment on tracking issue #1890 with the release link