### PR TITLE
fix: forward an explicitly requested disk equal to the old 512Gi default

### DIFF
--- a/python/michelangelo/uniflow/plugins/ray/task.py
+++ b/python/michelangelo/uniflow/plugins/ray/task.py
@@ -16,10 +16,11 @@ from pathlib import Path
 from typing import Optional
 
 import ray
+from ray.data import Dataset
+
 from michelangelo.uniflow.core.io_registry import io_registry
 from michelangelo.uniflow.core.task_config import TaskBinding, TaskConfig
 from michelangelo.uniflow.plugins.ray.io import RayDatasetIO
-from ray.data import Dataset
 
 log = logging.getLogger(__name__)
 

--- a/python/michelangelo/uniflow/plugins/ray/task.star
+++ b/python/michelangelo/uniflow/plugins/ray/task.star
@@ -15,12 +15,12 @@ RAY_ENV = {
 }
 RAY_DEFAULT_HEAD_CPU = os.environ.get("RAY_DEFAULT_HEAD_CPU", "8")
 RAY_DEFAULT_HEAD_MEMORY = os.environ.get("RAY_DEFAULT_HEAD_MEMORY", "32Gi")
-RAY_DEFAULT_HEAD_DISK = os.environ.get("RAY_DEFAULT_HEAD_DISK", "512Gi")
+RAY_DEFAULT_HEAD_DISK = os.environ.get("RAY_DEFAULT_HEAD_DISK", "")
 RAY_DEFAULT_HEAD_GPU = os.environ.get("RAY_DEFAULT_HEAD_GPU", "0")
 
 RAY_DEFAULT_WORKER_CPU = os.environ.get("RAY_DEFAULT_WORKER_CPU", "8")
 RAY_DEFAULT_WORKER_MEMORY = os.environ.get("RAY_DEFAULT_WORKER_MEMORY", "32Gi")
-RAY_DEFAULT_WORKER_DISK = os.environ.get("RAY_DEFAULT_WORKER_DISK", "512Gi")
+RAY_DEFAULT_WORKER_DISK = os.environ.get("RAY_DEFAULT_WORKER_DISK", "")
 RAY_DEFAULT_WORKER_GPU = os.environ.get("RAY_DEFAULT_WORKER_GPU", "0")
 RAY_DEFAULT_WORKER_INSTANCES = os.environ.get("RAY_DEFAULT_WORKER_INSTANCES", "1")
 
@@ -164,12 +164,15 @@ def task(
         cluster_image = get_task_image(task_name)
         print("ray | create cluster:", "ns:", cluster_namespace, "image:", cluster_image, "task_name:", task_name)
 
-        # Forward disk only when it differs from the shipped default. The
-        # default (512Gi) has never reached the pod spec, so honoring it now
-        # would suddenly attach a large ephemeral-storage request to every
-        # existing RayTask; an explicit parameter or env override still wins.
-        _head_disk_request = _head_disk if _head_disk != RAY_DEFAULT_HEAD_DISK else None
-        _worker_disk_request = _worker_disk if _worker_disk != RAY_DEFAULT_WORKER_DISK else None
+        # Forward any non-empty disk value. The shipped default is now the
+        # empty string ("no explicit request"), which matches the historical
+        # behavior where the old 512Gi default never reached the pod spec --
+        # and it lets a user explicitly request any value, 512Gi included
+        # (the old default-equality guard silently dropped exactly that one
+        # value). A RAY_DEFAULT_*_DISK environment override now also reaches
+        # the pod spec, which is what setting it asks for.
+        _head_disk_request = _head_disk if _head_disk else None
+        _worker_disk_request = _worker_disk if _worker_disk else None
 
         cluster = ray_cluster_spec(
             namespace = cluster_namespace,

--- a/python/michelangelo/uniflow/plugins/ray/task.star
+++ b/python/michelangelo/uniflow/plugins/ray/task.star
@@ -164,13 +164,7 @@ def task(
         cluster_image = get_task_image(task_name)
         print("ray | create cluster:", "ns:", cluster_namespace, "image:", cluster_image, "task_name:", task_name)
 
-        # Forward any non-empty disk value. The shipped default is now the
-        # empty string ("no explicit request"), which matches the historical
-        # behavior where the old 512Gi default never reached the pod spec --
-        # and it lets a user explicitly request any value, 512Gi included
-        # (the old default-equality guard silently dropped exactly that one
-        # value). A RAY_DEFAULT_*_DISK environment override now also reaches
-        # the pod spec, which is what setting it asks for.
+        # Forward any non-empty disk value; empty means no explicit request.
         _head_disk_request = _head_disk if _head_disk else None
         _worker_disk_request = _worker_disk if _worker_disk else None
 

--- a/python/michelangelo/uniflow/plugins/ray/tests/ray_cluster_spec_test.py
+++ b/python/michelangelo/uniflow/plugins/ray/tests/ray_cluster_spec_test.py
@@ -148,7 +148,8 @@ class TestTaskResourcePlumbing(TestCase):
     regression surface of the silently-dropped gpu/disk/object-store settings.
     """
 
-    _DEFAULT_DISK = "512Gi"
+    # The shipped default: empty string means "no explicit disk request".
+    _DEFAULT_DISK = ""
 
     def _run_task(self, environ: dict | None = None, **task_kwargs):
         captured = {}
@@ -246,12 +247,34 @@ class TestTaskResourcePlumbing(TestCase):
             "1000000000",
         )
 
-    def test_default_disk_is_not_forwarded(self):
-        """Passing exactly the shipped default disk keeps requests unchanged."""
-        cluster = self._run_task(head_disk=self._DEFAULT_DISK)
+    def test_no_disk_parameter_adds_no_request(self):
+        """Without a disk parameter no ephemeral-storage request renders."""
+        cluster = self._run_task()
 
-        head, _ = self._containers(cluster)
+        head, workers = self._containers(cluster)
         self.assertNotIn("ephemeral-storage", head["resources"]["requests"])
+        self.assertNotIn("ephemeral-storage", workers["resources"]["requests"])
+
+    def test_explicit_512gi_disk_forwards(self):
+        """A user asking for exactly 512Gi gets it.
+
+        Regression test: the old guard compared against a 512Gi shipped
+        default and silently dropped an explicit request for that one value.
+        """
+        cluster = self._run_task(head_disk="512Gi", worker_disk="512Gi")
+
+        head, workers = self._containers(cluster)
+        self.assertEqual(head["resources"]["requests"]["ephemeral-storage"], "512Gi")
+        self.assertEqual(workers["resources"]["requests"]["ephemeral-storage"], "512Gi")
+
+    def test_env_configured_default_disk_reaches_the_pod(self):
+        """A deployment-level RAY_DEFAULT_*_DISK now reaches the pod spec."""
+        self._DEFAULT_DISK = "256Gi"
+        cluster = self._run_task()
+
+        head, workers = self._containers(cluster)
+        self.assertEqual(head["resources"]["requests"]["ephemeral-storage"], "256Gi")
+        self.assertEqual(workers["resources"]["requests"]["ephemeral-storage"], "256Gi")
 
     def test_env_override_gpu_reaches_the_pod(self):
         """A RAY_OVERRIDE_*_GPU env var flows through like the parameter."""

--- a/python/michelangelo/uniflow/plugins/ray/tests/ray_cluster_spec_test.py
+++ b/python/michelangelo/uniflow/plugins/ray/tests/ray_cluster_spec_test.py
@@ -32,6 +32,31 @@ def _load_star_functions(*names: str, extra_globals: dict | None = None):
     return tuple(globals_[name] for name in names)
 
 
+def _load_star_constants(*names: str, environ: dict | None = None):
+    """Load the named task.star module-level constants against a real os.environ.
+
+    Unlike _load_star_functions, which extracts only function bodies, this
+    execs the matching top-level Assign statements so the os.environ.get(...)
+    calls that define these constants actually run.
+    """
+    task_path = Path(__file__).resolve().parents[1] / "task.star"
+    tree = ast.parse(task_path.read_text(), filename=str(task_path))
+    assigns = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name) and target.id in names
+            for target in node.targets
+        )
+    ]
+    assert len(assigns) == len(names), f"missing one of {names} in task.star"
+    module = ast.fix_missing_locations(ast.Module(body=assigns, type_ignores=[]))
+    globals_ = {"os": SimpleNamespace(environ=dict(environ or {}))}
+    exec(compile(module, str(task_path), "exec"), globals_)
+    return tuple(globals_[name] for name in names)
+
+
 class TestContainerResources(TestCase):
     """Tests for container_resources()."""
 
@@ -285,3 +310,35 @@ class TestTaskResourcePlumbing(TestCase):
         head, _ = self._containers(cluster)
         self.assertEqual(head["resources"]["requests"]["nvidia.com/gpu"], 2)
         self.assertEqual(head["resources"]["limits"], {"nvidia.com/gpu": 2})
+
+
+class TestDiskDefaultConstants(TestCase):
+    """Tests for the RAY_DEFAULT_*_DISK module constants themselves.
+
+    TestTaskResourcePlumbing's _run_task stubs these names directly, so its
+    tests never execute the os.environ.get(...) lines that actually define
+    them. These tests load just those two Assign statements instead.
+    """
+
+    def test_defaults_to_empty_when_unset(self):
+        """No RAY_DEFAULT_*_DISK env var means no explicit disk request."""
+        head, worker = _load_star_constants(
+            "RAY_DEFAULT_HEAD_DISK", "RAY_DEFAULT_WORKER_DISK"
+        )
+
+        self.assertEqual(head, "")
+        self.assertEqual(worker, "")
+
+    def test_reads_from_environment_when_set(self):
+        """A deployment-level RAY_DEFAULT_*_DISK env var is picked up."""
+        head, worker = _load_star_constants(
+            "RAY_DEFAULT_HEAD_DISK",
+            "RAY_DEFAULT_WORKER_DISK",
+            environ={
+                "RAY_DEFAULT_HEAD_DISK": "256Gi",
+                "RAY_DEFAULT_WORKER_DISK": "1Ti",
+            },
+        )
+
+        self.assertEqual(head, "256Gi")
+        self.assertEqual(worker, "1Ti")


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Follow-up to #1801, addressing the review note there: a user explicitly requesting exactly `512Gi` of disk was the one value that never reached the pod spec.

The compatibility guard in #1801 forwarded the disk parameter only when it differed from the shipped `512Gi` default, so that honoring the previously-dropped default would not suddenly attach a large ephemeral-storage request to every existing RayTask. The side effect was that an explicit request for exactly `512Gi` was indistinguishable from the default and silently dropped.

This PR ships an empty-string default instead (same effective behavior: no request) and forwards any non-empty value verbatim:

- `RAY_DEFAULT_HEAD_DISK` / `RAY_DEFAULT_WORKER_DISK` shipped defaults change from `"512Gi"` to `""`.
- The default-equality guard becomes a simple non-empty check, so every explicit `head_disk`/`worker_disk` parameter value forwards, `512Gi` included.
- A deployment-level `RAY_DEFAULT_*_DISK` environment override now also reaches the pod spec, which is what configuring it asks for.

**Why?**

Users should be able to request `512Gi` -- with the old guard, that exact value was silently ignored while `511Gi` and `513Gi` both worked. The empty-string default keeps the intended compatibility behavior (tasks that say nothing about disk get no request, exactly as before #1801 and after it) without making any real value unrequestable.

**How did you test it?**

- Full ray plugin suite: 117 tests pass.
- Regression test added: an explicit `head_disk="512Gi"` / `worker_disk="512Gi"` renders `ephemeral-storage: 512Gi` on both containers (this fails on the previous guard).
- Updated tests: no disk parameter renders no ephemeral-storage request on head or workers; a deployment-level `RAY_DEFAULT_*_DISK` value now reaches the pod spec.
- `ruff check` and `ruff format --check` clean on the touched files.

**Potential risks**

- A deployment that explicitly set `RAY_DEFAULT_*_DISK` in the environment and relied on it doing nothing will now see that request applied to RayTask pods. Setting the variable is a statement of intent, so this is the fix working as designed, but it is a visible change for such deployments.
- Tasks that pass exactly `512Gi` today (expecting it to work) will start getting the request they asked for.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

An explicit RayTask disk request of exactly `512Gi` is now honored (it was previously indistinguishable from the shipped default and dropped), and `RAY_DEFAULT_HEAD_DISK` / `RAY_DEFAULT_WORKER_DISK` deployment overrides now reach the pod spec.

**Documentation Changes**

None -- parameter semantics are unchanged; only the previously-dropped values now take effect.