### PR TITLE
docs: correct A/B testing and inference backend claims

### DIFF
--- a/docs/getting-started/faq.md
+++ b/docs/getting-started/faq.md
@@ -78,7 +78,7 @@ A: Deployment time varies:
 
 **Q: Can I do A/B testing?**
 
-A: Yes. Deploy multiple model versions to the same endpoint with traffic splitting. Monitor metrics per variant and gradually shift traffic to the winner.
+A: Not yet for automatic traffic splitting (on the [roadmap](./roadmap.md)). Today you can deploy multiple model versions and route to a specific one by deployment name; compare metrics per deployment manually.
 
 **Q: What happens if my model training fails?**
 

--- a/docs/getting-started/glossary.md
+++ b/docs/getting-started/glossary.md
@@ -70,7 +70,7 @@ A handle returned by `concurrent_run()` representing an in-progress task. The wo
 ## I
 
 ### Inference Server
-The host process that serves online predictions. Michelangelo AI supports Triton Inference Server (for traditional models) and vLLM / SGLang (for LLM serving). Managed by the InferenceServer Controller on the control plane.
+The host process that serves online predictions. Michelangelo AI's InferenceServer Controller manages Triton, LLM-D, Dynamo, and TorchServe backends. vLLM is also available (`pip install michelangelo[vllm]`) for calling directly from your own Ray/Uniflow tasks, such as for offline batch inference.
 
 ### Incremental Training
 A training pattern where a new model revision is trained starting from the weights of a prior revision, rather than from scratch. Each iteration produces a new revision (revision 0 → revision 1 → …).


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**

Corrects two remaining factual overstatements in `docs/getting-started/faq.md` and `docs/getting-started/glossary.md`. The FAQ's "Can I do A/B testing?" answer claimed traffic splitting works today; the glossary's Inference Server entry claimed vLLM and SGLang are backends managed by the InferenceServer Controller. Both are reworded to match what the code actually does.

**Why?**

Follow-up to #1833, which corrected three similar overclaims in these same two files but missed these two nearby ones. Left uncorrected, they directly contradicted #1833's own fixes — e.g. the FAQ said "yes, traffic splitting today" a few sections from a glossary entry that #1833 changed to say traffic splitting is roadmap-only. Found during a doc review pass run after #1833 merged.

**How did you test it?**

2 files, 1 line changed each, prose only — no code changes. Verified each claim against current `main`:
- `go/components/deployment/plugins/oss/rollout/strategies/common/traffic_routing_actor.go` — `TrafficRoutingActor` only writes a single path-based routing rule per deployment (`MatchPath`/`RewritePath`); no weight/percentage field exists anywhere in it.
- `proto/api/v2/inference_server.proto` — `BackendType` enum is `TRITON`, `LLM_D`, `DYNAMO`, `TORCHSERVE` only.
- `python/pyproject.toml` — confirmed a real `vllm` extras group exists (for calling vLLM directly from user Ray/Uniflow tasks), but zero references to SGLang anywhere in the repo.

**Potential risks**

None — prose-only correction, no code/schema/API changes.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

N/A

**Documentation Changes**

- `docs/getting-started/faq.md` — A/B testing answer now describes routing to a specific deployment by name instead of nonexistent traffic splitting, links to the roadmap
- `docs/getting-started/glossary.md` — Inference Server entry lists the actual managed backends (Triton, LLM-D, Dynamo, TorchServe) and clarifies vLLM's real usage path; removes SGLang (not in the codebase)