### PR TITLE
feat(ui): Add configuration tab on run detail page

### DIFF
--- a/javascript/packages/core/components/text-editor/text-editor.tsx
+++ b/javascript/packages/core/components/text-editor/text-editor.tsx
@@ -10,7 +10,7 @@ export function TextEditor({
   language,
   readOnly = false,
   height = '300px',
-  foldGutter = false,
+  foldable = false,
   onChange,
 }: TextEditorProps) {
   const [css] = useStyletron();
@@ -50,7 +50,7 @@ export function TextEditor({
         editable={!readOnly}
         basicSetup={{
           lineNumbers: true,
-          foldGutter,
+          foldGutter: foldable,
           dropCursor: false,
           allowMultipleSelections: false,
           indentOnInput: false,

--- a/javascript/packages/core/components/text-editor/text-editor.tsx
+++ b/javascript/packages/core/components/text-editor/text-editor.tsx
@@ -10,6 +10,7 @@ export function TextEditor({
   language,
   readOnly = false,
   height = '300px',
+  foldGutter = false,
   onChange,
 }: TextEditorProps) {
   const [css] = useStyletron();
@@ -49,7 +50,7 @@ export function TextEditor({
         editable={!readOnly}
         basicSetup={{
           lineNumbers: true,
-          foldGutter: false,
+          foldGutter,
           dropCursor: false,
           allowMultipleSelections: false,
           indentOnInput: false,

--- a/javascript/packages/core/components/text-editor/types.ts
+++ b/javascript/packages/core/components/text-editor/types.ts
@@ -3,5 +3,6 @@ export type TextEditorProps = {
   language?: 'json';
   readOnly?: boolean;
   height?: string;
+  foldGutter?: boolean;
   onChange?: (value: string) => void;
 };

--- a/javascript/packages/core/components/text-editor/types.ts
+++ b/javascript/packages/core/components/text-editor/types.ts
@@ -3,6 +3,10 @@ export type TextEditorProps = {
   language?: 'json';
   readOnly?: boolean;
   height?: string;
-  foldGutter?: boolean;
+  /**
+   * Show controls in the gutter for collapsing/expanding nested blocks
+   * (objects, arrays), useful for navigating large documents. Defaults to false.
+   */
+  foldable?: boolean;
   onChange?: (value: string) => void;
 };

--- a/javascript/packages/core/config/entities/run/__tests__/run.test.tsx
+++ b/javascript/packages/core/config/entities/run/__tests__/run.test.tsx
@@ -1,0 +1,120 @@
+import { render, screen } from '@testing-library/react';
+
+import { TRAIN_PHASE } from '#core/config/phases/train';
+import { EntityDetailRoute } from '#core/router/entity-detail-route';
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getErrorProviderWrapper } from '#core/test/wrappers/get-error-provider-wrapper';
+import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
+import {
+  createQueryMockRouter,
+  getServiceProviderWrapper,
+} from '#core/test/wrappers/get-service-provider-wrapper';
+
+describe('Run detail page', () => {
+  describe('configuration tab', () => {
+    const buildManifestContent = () => ({
+      typeUrl: 'type.googleapis.com/michelangelo.PredictionPipelineConf',
+      value: {
+        meta: {
+          workflow_version: 'v2',
+          app: 'data.michelangelo.asl.app.prediction.PredictionPipeline',
+        },
+        triggers: {
+          'daily-01': { cron: '0 01 * * *' },
+        },
+      },
+    });
+
+    const buildRun = (overrides: Record<string, unknown> = {}) => ({
+      metadata: { name: 'run-1', creationTimestamp: { seconds: 1700000000 } },
+      spec: {
+        actor: { name: 'jsmith' },
+        pipeline: { name: 'prediction-pipeline' },
+      },
+      status: {
+        state: 3,
+        sourcePipeline: {
+          pipeline: {
+            spec: {
+              manifest: {
+                // The generated proto client decodes enum fields to their numeric
+                // discriminant (PIPELINE_MANIFEST_TYPE_YAML = 1), not the enum's string name.
+                type: 1,
+                filePath: 'python/examples/boston/pipeline.yaml',
+                content: buildManifestContent(),
+              },
+            },
+          },
+        },
+      },
+      ...overrides,
+    });
+
+    const buildConfigurationTabWrapper = (run: object) =>
+      buildWrapper([
+        getErrorProviderWrapper(),
+        getRouterWrapper({
+          location: '/myproject/train/runs/run-1/configuration',
+        }),
+        getServiceProviderWrapper({
+          request: createQueryMockRouter({ GetPipelineRun: { pipelineRun: run } }),
+        }),
+      ]);
+
+    it('renders the manifest configuration as JSON', async () => {
+      const run = buildRun();
+      render(
+        <EntityDetailRoute phases={{ train: TRAIN_PHASE }} />,
+        buildConfigurationTabWrapper(run)
+      );
+
+      expect(await screen.findByText('General')).toBeInTheDocument();
+      expect(screen.getByText('Manifest content')).toBeInTheDocument();
+      // The CodeMirror editor exposes its content as a readonly textbox.
+      const editor = await screen.findByRole('textbox');
+      expect(editor).toHaveTextContent('"workflow_version": "v2"');
+      expect(editor).toHaveTextContent('"cron": "0 01 * * *"');
+    });
+
+    it('falls back to the inline dev-run pipeline spec before the source pipeline is resolved', async () => {
+      const run = buildRun({
+        spec: {
+          actor: { name: 'jsmith' },
+          pipelineSpec: {
+            manifest: { type: 1, content: buildManifestContent() },
+          },
+        },
+        status: { state: 1 },
+      });
+      render(
+        <EntityDetailRoute phases={{ train: TRAIN_PHASE }} />,
+        buildConfigurationTabWrapper(run)
+      );
+
+      expect(await screen.findByText('General')).toBeInTheDocument();
+      expect(await screen.findByRole('textbox')).toHaveTextContent('"workflow_version": "v2"');
+    });
+
+    it('shows an empty state when the manifest has no configuration content', async () => {
+      const run = buildRun({
+        status: {
+          state: 3,
+          sourcePipeline: {
+            pipeline: {
+              spec: {
+                manifest: { type: 3, uniflowTar: 's3://default/bert_local.tar' },
+              },
+            },
+          },
+        },
+      });
+      render(
+        <EntityDetailRoute phases={{ train: TRAIN_PHASE }} />,
+        buildConfigurationTabWrapper(run)
+      );
+
+      expect(await screen.findByText('No configuration available')).toBeInTheDocument();
+      expect(screen.queryByText(/workflow_version/)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/javascript/packages/core/config/entities/run/detail.ts
+++ b/javascript/packages/core/config/entities/run/detail.ts
@@ -1,5 +1,6 @@
 import { CellType } from '#core/components/cell/constants';
 import { TASK_STATE } from '#core/components/views/execution/constants';
+import { RunConfigurationPage } from './run-configuration-page';
 import { SHARED_RUN_CELL_CONFIG } from './shared';
 
 import type { DetailViewConfig } from '#core/components/views/types';
@@ -123,6 +124,12 @@ export const RUN_DETAIL_CONFIG: DetailViewConfig = {
           }
         },
       },
+    },
+    {
+      id: 'configuration',
+      label: 'Pipeline Configuration',
+      type: 'custom',
+      component: RunConfigurationPage,
     },
   ],
 };

--- a/javascript/packages/core/config/entities/run/run-configuration-page.tsx
+++ b/javascript/packages/core/config/entities/run/run-configuration-page.tsx
@@ -1,0 +1,62 @@
+import { useStyletron } from 'baseui';
+import { Skeleton } from 'baseui/skeleton';
+import { HeadingSmall } from 'baseui/typography';
+
+import { Box } from '#core/components/box/box';
+import { CircleExclamationMark } from '#core/components/illustrations/circle-exclamation-mark/circle-exclamation-mark';
+import { CircleExclamationMarkKind } from '#core/components/illustrations/circle-exclamation-mark/types';
+import { Signpost } from '#core/components/signpost/signpost';
+import { TextEditor } from '#core/components/text-editor/text-editor';
+
+import type { PipelineRun } from './types';
+
+export function RunConfigurationPage({ data, isLoading }: { data?: object; isLoading: boolean }) {
+  const [, theme] = useStyletron();
+
+  // cast: custom detail pages receive the entity as a plain object; narrowing to the
+  // expected proto shape for property access; see #1425
+  const run = data as PipelineRun | undefined;
+  const sourcePipeline = run?.status?.sourcePipeline;
+  const manifest =
+    sourcePipeline?.pipeline?.spec?.manifest ??
+    sourcePipeline?.draftPipeline?.spec?.manifest ??
+    run?.spec?.pipelineSpec?.manifest;
+  const config = manifest?.content?.value;
+
+  if (isLoading) {
+    return <Skeleton animation height="400px" width="100%" />;
+  }
+
+  if (!config) {
+    return (
+      <Signpost
+        illustration={
+          <CircleExclamationMark
+            height="64px"
+            width="64px"
+            kind={CircleExclamationMarkKind.PRIMARY}
+          />
+        }
+        title="No configuration available"
+        description="This pipeline run has no configuration attached to its manifest"
+      />
+    );
+  }
+
+  return (
+    <section>
+      <HeadingSmall marginTop="0" marginBottom={theme.sizing.scale600}>
+        General
+      </HeadingSmall>
+      <Box title="Manifest content">
+        <TextEditor
+          value={JSON.stringify(config, null, 2)}
+          language="json"
+          readOnly
+          foldGutter
+          height="auto"
+        />
+      </Box>
+    </section>
+  );
+}

--- a/javascript/packages/core/config/entities/run/run-configuration-page.tsx
+++ b/javascript/packages/core/config/entities/run/run-configuration-page.tsx
@@ -53,7 +53,7 @@ export function RunConfigurationPage({ data, isLoading }: { data?: object; isLoa
           value={JSON.stringify(config, null, 2)}
           language="json"
           readOnly
-          foldGutter
+          foldable
           height="auto"
         />
       </Box>

--- a/javascript/packages/core/config/entities/run/run-configuration-page.tsx
+++ b/javascript/packages/core/config/entities/run/run-configuration-page.tsx
@@ -32,8 +32,8 @@ export function RunConfigurationPage({ data, isLoading }: { data?: object; isLoa
       <Signpost
         illustration={
           <CircleExclamationMark
-            height="64px"
-            width="64px"
+            height={theme.sizing.scale1600}
+            width={theme.sizing.scale1600}
             kind={CircleExclamationMarkKind.PRIMARY}
           />
         }

--- a/javascript/packages/core/config/entities/run/types.ts
+++ b/javascript/packages/core/config/entities/run/types.ts
@@ -14,5 +14,32 @@ export type PipelineRun = {
     };
     /** Optional human-readable description for this run. */
     description?: string;
+    /** Inline pipeline spec for dev runs; regular runs reference a Pipeline instead. */
+    pipelineSpec?: PipelineSnapshotSpec;
+  };
+  status?: {
+    /** Snapshot of the pipeline this run executes, captured when the run starts. */
+    sourcePipeline?: {
+      pipeline?: { spec?: PipelineSnapshotSpec };
+      draftPipeline?: { spec?: PipelineSnapshotSpec };
+    };
+  };
+};
+
+export type PipelineSnapshotSpec = {
+  manifest?: PipelineManifest;
+};
+
+export type PipelineManifest = {
+  /** PipelineManifest.Type enum, decoded to its numeric discriminant. */
+  type?: number;
+  filePath?: string;
+  /**
+   * Pipeline configuration, unpacked from its Any/TypedStruct envelope by the rpc layer:
+   * typeUrl names the config type, value is the config itself as plain JSON.
+   */
+  content?: {
+    typeUrl?: string;
+    value?: Record<string, unknown>;
   };
 };

--- a/javascript/packages/rpc/__tests__/services.test.ts
+++ b/javascript/packages/rpc/__tests__/services.test.ts
@@ -40,8 +40,11 @@ it('decodes a ListPipelineRun response containing a TypedStruct Any field', asyn
     result as unknown as { pipelineRunList: { items: { status: { details: unknown[] } }[] } }
   ).pipelineRunList.items[0].status.details;
 
-  // The Any is decoded to { typeUrl, value: Uint8Array } by the registry.
-  // Without TypedStructSchema in the registry, fromJson throws before reaching here.
-  expect(details[0]).toMatchObject({ typeUrl: 'type.googleapis.com/michelangelo.api.TypedStruct' });
-  expect((details[0] as { value: unknown }).value).toBeInstanceOf(Uint8Array);
+  // The registry decodes the Any to a binary TypedStruct, and toPlainObject unpacks it to
+  // { typeUrl, value } where typeUrl names the inner config type and value is its plain
+  // JSON. Without TypedStructSchema in the registry, fromJson throws before reaching here.
+  expect(details[0]).toEqual({
+    typeUrl: 'type.googleapis.com/michelangelo.UniFlowConf',
+    value: {},
+  });
 });

--- a/javascript/packages/rpc/request.ts
+++ b/javascript/packages/rpc/request.ts
@@ -1,5 +1,9 @@
+import { fromBinary, toJson } from '@bufbuild/protobuf';
+
+import { TypedStructSchema } from './gen/michelangelo/api/typed_struct_pb';
 import { getRpcHandlers } from './handlers';
 
+import type { Any } from '@bufbuild/protobuf/wkt';
 import type { OmitTypeName, RpcHandlerType } from './types';
 
 /**
@@ -43,10 +47,27 @@ function toPlainObject(value: unknown): unknown {
   if (value instanceof Uint8Array) return value; // preserve bytes fields (e.g. google.protobuf.Any.value)
   if (Array.isArray(value)) return value.map(toPlainObject);
 
+  const typedStruct = unpackTypedStructAny(value);
+  if (typedStruct) return typedStruct;
+
   const result: Record<string, unknown> = {};
   for (const [key, val] of Object.entries(value)) {
     if (key === '$typeName' || key === '$unknown') continue;
     result[key] = toPlainObject(val);
   }
   return result;
+}
+
+const TYPED_STRUCT_TYPE_URL = `type.googleapis.com/${TypedStructSchema.typeName}`;
+
+// google.protobuf.Any fields survive fromJson as { typeUrl, value: Uint8Array } — the binary
+// payload is useless to consumers. When the payload is a michelangelo.api.TypedStruct
+// (e.g. PipelineManifest.content), expand it to { typeUrl, value } where typeUrl names the
+// inner config type and value is its plain JSON. Other Any payloads are left untouched.
+function unpackTypedStructAny(value: object): unknown {
+  if (!('$typeName' in value) || value.$typeName !== 'google.protobuf.Any') return undefined;
+  // cast: the $typeName check above identifies this as a google.protobuf.Any message
+  const any = value as Any;
+  if (any.typeUrl !== TYPED_STRUCT_TYPE_URL) return undefined;
+  return toJson(TypedStructSchema, fromBinary(TypedStructSchema, any.value));
 }


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
Adds pipeline configuration tab on pipeline run detail page on the path `/<namespace>/train/runs/<pipeline run name>/configuration`

<img width="1512" height="907" alt="image" src="https://github.com/user-attachments/assets/ce7ac216-b237-4c6c-a367-980cc95fbf66" />


<!-- Tell your future self why have you made these changes -->
**Why?**
We can see the pipeline configuration of a pipeline run

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Manually and unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Does this PR introduce a breaking change? Check all that apply. -->
**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
N/A
<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
N/A