### PR TITLE
fix(ui): correct environment label key to pipelinerun.michelangelo/environment

### DIFF
--- a/javascript/packages/core/config/entities/model/__tests__/model-page.test.tsx
+++ b/javascript/packages/core/config/entities/model/__tests__/model-page.test.tsx
@@ -41,7 +41,7 @@ describe('Model list page', () => {
                 {
                   metadata: {
                     name: 'fraud-classifier',
-                    labels: { 'michelangelo/environment': 'production' },
+                    labels: { 'pipelinerun.michelangelo/environment': 'production' },
                     creationTimestamp: { seconds: 1700000000 },
                   },
                   spec: {
@@ -56,7 +56,7 @@ describe('Model list page', () => {
                 {
                   metadata: {
                     name: 'demand-forecaster',
-                    labels: { 'michelangelo/environment': 'development' },
+                    labels: { 'pipelinerun.michelangelo/environment': 'development' },
                     creationTimestamp: { seconds: 1700000000 },
                   },
                   spec: {
@@ -68,7 +68,7 @@ describe('Model list page', () => {
                 {
                   metadata: {
                     name: 'user-segmenter',
-                    labels: { 'michelangelo/environment': 'testing' },
+                    labels: { 'pipelinerun.michelangelo/environment': 'testing' },
                     creationTimestamp: { seconds: 1700000000 },
                   },
                   spec: {

--- a/javascript/packages/core/utils/__tests__/environment-utils.test.ts
+++ b/javascript/packages/core/utils/__tests__/environment-utils.test.ts
@@ -2,19 +2,21 @@ import { readEnvironmentLabel } from '../environment-utils';
 
 describe('readEnvironmentLabel', () => {
   test('returns "Development" for development', () => {
-    expect(readEnvironmentLabel({ 'michelangelo/environment': 'development' })).toEqual(
+    expect(readEnvironmentLabel({ 'pipelinerun.michelangelo/environment': 'development' })).toEqual(
       'Development'
     );
   });
 
   test('returns "Production" for production', () => {
-    expect(readEnvironmentLabel({ 'michelangelo/environment': 'production' })).toEqual(
+    expect(readEnvironmentLabel({ 'pipelinerun.michelangelo/environment': 'production' })).toEqual(
       'Production'
     );
   });
 
   test('returns "Testing" for testing', () => {
-    expect(readEnvironmentLabel({ 'michelangelo/environment': 'testing' })).toEqual('Testing');
+    expect(readEnvironmentLabel({ 'pipelinerun.michelangelo/environment': 'testing' })).toEqual(
+      'Testing'
+    );
   });
 
   test('returns an empty string when the label is absent', () => {
@@ -23,6 +25,6 @@ describe('readEnvironmentLabel', () => {
   });
 
   test('returns an empty string for an unrecognized raw value', () => {
-    expect(readEnvironmentLabel({ 'michelangelo/environment': 'staging' })).toEqual('');
+    expect(readEnvironmentLabel({ 'pipelinerun.michelangelo/environment': 'staging' })).toEqual('');
   });
 });

--- a/javascript/packages/core/utils/environment-utils.ts
+++ b/javascript/packages/core/utils/environment-utils.ts
@@ -1,4 +1,4 @@
-const ENVIRONMENT_LABEL_KEY = 'michelangelo/environment';
+const ENVIRONMENT_LABEL_KEY = 'pipelinerun.michelangelo/environment';
 
 const ENVIRONMENT_LABEL_MAP: Record<string, 'Development' | 'Production' | 'Testing'> = {
   development: 'Development',
@@ -10,16 +10,15 @@ const ENVIRONMENT_LABEL_MAP: Record<string, 'Development' | 'Production' | 'Test
  * Reads the CRD environment label and returns a human-readable environment name.
  *
  * CRD-backed entities have no dedicated `environment` field on their spec — the environment is
- * conveyed out-of-band via a `michelangelo/environment` metadata label with raw lowercase values
- * (`development`, `production`, `testing`). This normalizes those raw values to the labels shown
- * in the UI, and returns an empty string when the label is absent or unrecognized (e.g. an
- * environment value introduced after this map was last updated) so the column renders blank
- * rather than a raw label string. (An earlier version of this function matched a prefixed
- * `ENV_TYPE_*` form that turned out not to match any real label value; this was corrected after
- * review, along with adding the `testing` case.)
+ * conveyed out-of-band via a `pipelinerun.michelangelo/environment` metadata label with raw
+ * lowercase values (`development`, `production`, `testing`) — the same key the OSS apiserver
+ * writes and that `pipelinerun_environment_label` in `mactl/config.py` documents. This normalizes
+ * those raw values to the labels shown in the UI, and returns an empty string when the label is
+ * absent or unrecognized (e.g. an environment value introduced after this map was last updated)
+ * so the column renders blank rather than a raw label string.
  *
  * @example
- * readEnvironmentLabel({ 'michelangelo/environment': 'production' }) // 'Production'
+ * readEnvironmentLabel({ 'pipelinerun.michelangelo/environment': 'production' }) // 'Production'
  * readEnvironmentLabel(undefined) // ''
  */
 export function readEnvironmentLabel(


### PR DESCRIPTION
## Summary
- `readEnvironmentLabel()` read the CRD metadata label `michelangelo/environment`, but the OSS apiserver only ever writes `pipelinerun.michelangelo/environment` (documented as `pipeline_run_environment_label` in `python/michelangelo/cli/mactl/config.py`, and read under that same prefixed key by the Go pipeline-run controller and cron-trigger workflow).
- The bare `michelangelo/environment` key is never written anywhere in the codebase, so a real model's environment value never rendered in the UI (list column or detail page) even when the backend had the data.
- Fixes the constant in `packages/core/utils/environment-utils.ts` and updates its unit tests plus the model list/detail page test fixtures to use the real key.

## Test plan
- [x] `yarn test` — all 1502 tests pass (161 files)
- [x] `yarn typecheck` — clean
- [x] `yarn lint --quiet` — no new issues (one pre-existing, unrelated failure in `app/App.tsx` from `#1819`, not touched by this change)
- [x] `yarn format --write` — clean
- [x] OSS compliance scan — PASS
- [x] Verified against real sandbox data: model `model-20260824-234713-09628403` has `pipelinerun.michelangelo/environment: development` in its CRD labels (confirmed via direct DB read); will redeploy sandbox UI image to confirm the Environment column/field now renders "Development" for this model without needing a new pipeline run.