### PR TITLE
feat(api)!: rename EnvironmentLabel to michelangelo/environment

### DIFF
--- a/go/components/pipelinerun/controller.go
+++ b/go/components/pipelinerun/controller.go
@@ -634,7 +634,7 @@ func getPipelineType(pipelineRun *v2pb.PipelineRun) string {
 // Returns "unknown" if not set
 func getEnvironment(pipelineRun *v2pb.PipelineRun) string {
 	if pipelineRun.Labels != nil {
-		if env, ok := pipelineRun.Labels["pipelinerun.michelangelo/environment"]; ok {
+		if env, ok := pipelineRun.Labels["michelangelo/environment"]; ok {
 			return env
 		}
 	}

--- a/go/components/triggerrun/schedule_input.go
+++ b/go/components/triggerrun/schedule_input.go
@@ -11,8 +11,20 @@ import (
 )
 
 const (
-	scheduleInputEnvironmentLabel          = "pipelinerun.michelangelo/environment"
+	scheduleInputEnvironmentLabel          = "michelangelo/environment"
 	scheduleInputPipelineManifestTypeLabel = "pipeline.michelangelo/PipelineManifestType"
+
+	// scheduleInputLegacyEnvironmentLabel is the pre-rename environment
+	// label key.
+	//
+	// Deprecated: transitional fallback only, kept alongside the
+	// cron_trigger_workflows.go dual-read for consistency. Safe to remove
+	// no earlier than v0.12.0 (2 minor releases after the rename ships),
+	// per CONTRIBUTING.md's Deprecation Policy.
+	// TODO: file a tracking issue and remove this constant and both
+	// dual-read call sites (schedule_input.go, cron_trigger_workflows.go)
+	// together.
+	scheduleInputLegacyEnvironmentLabel = "pipelinerun.michelangelo/environment"
 )
 
 // scheduleInputHash returns a deterministic hash of the TriggerRun data consumed by
@@ -57,13 +69,13 @@ func scheduleWorkflowInput(triggerRun *v2pb.TriggerRun) *v2pb.TriggerRun {
 
 func scheduleInputLabels(labels map[string]string) map[string]string {
 	relevant := make(map[string]string, 2)
-	for _, key := range []string{
-		scheduleInputEnvironmentLabel,
-		scheduleInputPipelineManifestTypeLabel,
-	} {
-		if value, ok := labels[key]; ok {
-			relevant[key] = value
-		}
+	if value, ok := labels[scheduleInputEnvironmentLabel]; ok {
+		relevant[scheduleInputEnvironmentLabel] = value
+	} else if value, ok := labels[scheduleInputLegacyEnvironmentLabel]; ok {
+		relevant[scheduleInputEnvironmentLabel] = value
+	}
+	if value, ok := labels[scheduleInputPipelineManifestTypeLabel]; ok {
+		relevant[scheduleInputPipelineManifestTypeLabel] = value
 	}
 	if len(relevant) == 0 {
 		return nil

--- a/go/worker/workflows/trigger/cron_trigger_workflows.go
+++ b/go/worker/workflows/trigger/cron_trigger_workflows.go
@@ -44,8 +44,23 @@ var (
 	// TriggerredByLabel stores the name of the TriggerRun which triggered the pipeline_run
 	TriggerredByLabel = "pipelinerun.michelangelo/triggered-by"
 
-	// EnvironmentLabel stores the environment of the pipeline_run
-	EnvironmentLabel = "pipelinerun.michelangelo/environment"
+	// EnvironmentLabel stores the environment of the pipeline_run or Model.
+	EnvironmentLabel = "michelangelo/environment"
+
+	// legacyEnvironmentLabel is the pre-rename environment label key.
+	//
+	// Deprecated: transitional fallback only, for in-flight CronTrigger
+	// workflow executions started before the EnvironmentLabel rename
+	// (pipelinerun.michelangelo/environment -> michelangelo/environment).
+	// Not a general external-compatibility shim - no known adopter still
+	// writes this key. Safe to remove once no CronTrigger workflow
+	// execution whose history predates the rename can still be replayed -
+	// no earlier than v0.12.0 (2 minor releases after this rename ships),
+	// per CONTRIBUTING.md's Deprecation Policy.
+	// TODO: file a tracking issue and remove this constant and both
+	// dual-read call sites (schedule_input.go, cron_trigger_workflows.go)
+	// together.
+	legacyEnvironmentLabel = "pipelinerun.michelangelo/environment"
 
 	// SourceTriggerLabel stores the original trigger associated with the pipeline_run.
 	// For resume run, source-trigger is copied over from previous run
@@ -307,6 +322,10 @@ func generatePipelineRunRequest(
 		PipelineNameLabel:                  triggerRun.Spec.Pipeline.Name,
 	}
 	if env, ok := triggerRun.ObjectMeta.Labels[EnvironmentLabel]; ok {
+		labels[EnvironmentLabel] = env
+	} else if env, ok := triggerRun.ObjectMeta.Labels[legacyEnvironmentLabel]; ok {
+		// Falls back to the pre-rename key so a TriggerRun frozen into
+		// workflow history before the rename still replays deterministically.
 		labels[EnvironmentLabel] = env
 	} else {
 		labels[EnvironmentLabel] = "production"

--- a/go/worker/workflows/trigger/cron_trigger_workflows_test.go
+++ b/go/worker/workflows/trigger/cron_trigger_workflows_test.go
@@ -136,6 +136,34 @@ func TestGeneratePipelineRunRequest(t *testing.T) {
 	}
 }
 
+func TestGeneratePipelineRunRequestFallsBackToLegacyEnvironmentLabel(t *testing.T) {
+	triggerRun := &v2pb.TriggerRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test-namespace",
+			Name:      "test-trigger",
+			Labels: map[string]string{
+				legacyEnvironmentLabel: "staging",
+			},
+		},
+		Spec: v2pb.TriggerRunSpec{
+			Pipeline: &api.ResourceIdentifier{
+				Namespace: "test-namespace",
+				Name:      "test-pipeline",
+			},
+			Trigger: &v2pb.Trigger{
+				ParametersMap: map[string]*v2pb.PipelineExecutionParameters{},
+			},
+		},
+	}
+
+	result, err := generatePipelineRunRequest(
+		triggerRun, "", "test-pipeline-run-123", time.Date(2023, 1, 15, 10, 30, 45, 0, time.UTC), nil,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "staging", result.PipelineRun.ObjectMeta.Labels[EnvironmentLabel])
+}
+
 func TestGenerateUniflowPRInput(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/python/michelangelo/cli/mactl/config.py
+++ b/python/michelangelo/cli/mactl/config.py
@@ -42,9 +42,9 @@ DEFAULT_CONFIG = {
     # patching the plugin source.
     "pipeline_run_state_pb2_module": "michelangelo.gen.api.v2.pipeline_run_pb2",
     # Label key the pipeline_run plugin reads for the ENVIRONMENT column.
-    # OSS apiserver writes ``pipelinerun.michelangelo/environment``; downstream
+    # OSS apiserver writes ``michelangelo/environment``; downstream
     # distributions may use a different key.
-    "pipeline_run_environment_label": "pipelinerun.michelangelo/environment",
+    "pipeline_run_environment_label": "michelangelo/environment",
     # Import path for the generated ``pipeline_pb2`` module the pipeline plugin
     # consults for PipelineType enum names + values. Downstream distributions
     # that extend the enum can point this at their own module without patching

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline_run/get.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline_run/get.py
@@ -19,7 +19,7 @@ _LOG = getLogger(__name__)
 
 _STATE_PREFIX = "PIPELINE_RUN_STATE_"
 _DEFAULT_STATE_PB2_MODULE = "michelangelo.gen.api.v2.pipeline_run_pb2"
-_DEFAULT_ENV_LABEL = "pipelinerun.michelangelo/environment"
+_DEFAULT_ENV_LABEL = "michelangelo/environment"
 
 _CRITERION_OPERATOR_EQUAL = 1
 _CRITERION_OPERATOR_LIKE = 9

--- a/python/michelangelo/cli/mactl/plugins/entity/pipeline_run/get_test.py
+++ b/python/michelangelo/cli/mactl/plugins/entity/pipeline_run/get_test.py
@@ -148,10 +148,10 @@ class RenderEnvTest(TestCase):
     @patch("michelangelo.cli.mactl.plugins.entity.pipeline_run.get._env_label")
     def test_label_present(self, mock_label):
         """Configured label present → value returned."""
-        mock_label.return_value = "pipelinerun.michelangelo/environment"
+        mock_label.return_value = "michelangelo/environment"
         item = SimpleNamespace(
             metadata=SimpleNamespace(
-                labels={"pipelinerun.michelangelo/environment": "prod"}
+                labels={"michelangelo/environment": "prod"}
             )
         )
         self.assertEqual(_render_env(item), "prod")
@@ -159,7 +159,7 @@ class RenderEnvTest(TestCase):
     @patch("michelangelo.cli.mactl.plugins.entity.pipeline_run.get._env_label")
     def test_label_missing(self, mock_label):
         """Configured label absent → empty string."""
-        mock_label.return_value = "pipelinerun.michelangelo/environment"
+        mock_label.return_value = "michelangelo/environment"
         item = SimpleNamespace(metadata=SimpleNamespace(labels={}))
         self.assertEqual(_render_env(item), "")
 


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Renames the `EnvironmentLabel` metadata key from `pipelinerun.michelangelo/environment` to `michelangelo/environment`, and updates every reader/writer of it:

- `worker/workflows/trigger/cron_trigger_workflows.go` — renamed `EnvironmentLabel`'s value; added an unexported, `// Deprecated:`-documented `legacyEnvironmentLabel` fallback constant; `generatePipelineRunRequest` now reads the new key first, falling back to the old key, before falling to the existing `"production"` default.
- `components/triggerrun/schedule_input.go` — same treatment: renamed `scheduleInputEnvironmentLabel`, added `scheduleInputLegacyEnvironmentLabel`, and `scheduleInputLabels` reads new-then-old.
- `components/pipelinerun/controller.go` (`getEnvironment`) — hard rename, no fallback (synchronous, non-workflow code).
- `python/michelangelo/cli/mactl/config.py` and `.../pipeline_run/get.py` (+ `get_test.py` fixtures) — hard rename of the hardcoded default label key and its doc comment.

Both fallback sites only ever *read* the old key; every write path writes the new key exclusively, so the old key strictly decays over time.

**Why?**

The `pipelinerun.` prefix was a scoping mistake from this label's introduction: it has always been read directly off `TriggerRun` objects, not just `PipelineRun`s (the code's own doc comment already says "a PipelineRun **or Model** belongs to" while the string itself still said `pipelinerun.`). This rename corrects that and gives the key a name that matches its actual, broader scope.

**How did you test it?**

- `gofmt -l .` — clean.
- `golangci-lint run ./...` — no new findings introduced (pre-existing repo-wide `godox` TODO-tracking output unrelated to this change).
- `go build ./...` — clean.
- `go test ./api/... ./components/model/... ./components/pipelinerun/... ./components/triggerrun/... ./worker/workflows/trigger/... ./cmd/apiserver/...` — all pass, including a new test (`TestGeneratePipelineRunRequestFallsBackToLegacyEnvironmentLabel`) asserting the dual-read fallback: a `TriggerRun` carrying only the legacy key still produces a `CreatePipelineRunRequest` with the real value.
- `pytest` on the touched Python modules (`pipeline_run/get_test.py`, `config_test.py`) — 44 passed.
- Audited every non-Go/Python occurrence of the string in the repo; none found outside the files listed above.

**Potential risks**

Any pre-existing object (`PipelineRun`, `TriggerRun`) that already carries the old key will read as "absent" under the new key at the two hard-rename sites (`getEnvironment`, mactl), silently falling back to their existing "unknown"/absent behavior rather than the object's real historical value. This is a deliberate, accepted trade-off — there is no known external production adopter of this label today, and full backward-compat everywhere would require a persistent shim, not a transitional one. The two sites with real correctness risk (in-flight `CronTrigger` workflow replay) are protected by the dual-read fallback described above.

**Coordination note — PR #1930**

#1930 is open and points `javascript/packages/core/utils/environment-utils.ts`'s `ENVIRONMENT_LABEL_KEY` at `pipelinerun.michelangelo/environment`, to fix that constant's current mismatch with the (then-real) backend key. This PR does **not** touch that file, because `environment-utils.ts` **on `main` today already reads `michelangelo/environment`** (the very key this PR renames *to*) — it appears to be a stale/incorrect key from before, and after this PR merges it becomes the correct one again. If #1930 merges as-is, it will point the UI back at the now-legacy `pipelinerun.michelangelo/environment` key, reintroducing the exact dead-key bug it set out to fix. Flagging this so #1930 is closed, or rebased to a no-op, once this PR lands.

**Breaking Changes**

- [ ] No breaking changes
- [x] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Migration guide**

The `EnvironmentLabel` Kubernetes metadata label value changes from `pipelinerun.michelangelo/environment` to `michelangelo/environment` on all newly created/updated `PipelineRun` and `TriggerRun` objects, and on the `mactl` CLI's default environment-label lookup key.

- If you read this label directly (e.g. via `kubectl get pipelinerun -o jsonpath`, a custom dashboard, or a `mactl` config override), update to the new key.
- If you rely on `mactl`'s built-in `pipeline_run_environment_label` config default, no action is needed — it now points at the new key automatically; only installs that had explicitly overridden this config to something else are unaffected.
- Objects created before this change keep their label under the old key. Two call sites (`generatePipelineRunRequest`, `scheduleInputLabels`) transparently fall back to the old key when reading such objects; all other call sites will treat a pre-existing object's label as absent until it is next recreated/updated under the new key.
- The transitional fallback (`legacyEnvironmentLabel` / `scheduleInputLegacyEnvironmentLabel`) is temporary, per this repo's Deprecation Policy — tracked for removal no earlier than 2 minor releases after this rename ships. A tracking issue should be filed by a maintainer with issue-creation access; both `TODO`s in the code point at removing this fallback once the deprecation window has passed.

**Release notes**

Yes — `EnvironmentLabel`'s value changes from `pipelinerun.michelangelo/environment` to `michelangelo/environment`; should be called out as a breaking change in the next release's CHANGELOG with the migration guide above.

**Documentation Changes**

N/A — no wiki-tracked docs reference this label key.