### PR TITLE
fix(k8sengine): emit rayStartParams as {} not null for RayClusters

### DIFF
--- a/go/components/jobs/client/k8sengine/mapper_test.go
+++ b/go/components/jobs/client/k8sengine/mapper_test.go
@@ -288,6 +288,42 @@ func TestMapper_MapGlobalJobClusterToLocal(t *testing.T) {
 	}
 }
 
+// TestGetHeadGroupSpec_RayStartParams verifies rayStartParams handling: an unset
+// (nil) map becomes a non-nil empty map so it serializes to `{}` rather than
+// `null` (which the RayCluster CRD rejects — see nonNilRayStartParams), while a
+// populated map is passed through unchanged.
+func TestGetHeadGroupSpec_RayStartParams(t *testing.T) {
+	t.Run("nil -> empty non-nil map", func(t *testing.T) {
+		got := getHeadGroupSpec(&v2pb.RayHeadSpec{ServiceType: string(corev1.ServiceTypeClusterIP)})
+		require.NotNil(t, got.RayStartParams)
+		assert.Equal(t, map[string]string{}, got.RayStartParams)
+	})
+	t.Run("populated -> preserved", func(t *testing.T) {
+		got := getHeadGroupSpec(&v2pb.RayHeadSpec{RayStartParams: map[string]string{"dashboard-host": "0.0.0.0"}})
+		assert.Equal(t, map[string]string{"dashboard-host": "0.0.0.0"}, got.RayStartParams)
+	})
+}
+
+// TestGetWorkerGroupSpecs_RayStartParams mirrors the head-group check for worker
+// groups: nil rayStartParams must map to a non-nil empty map, populated is kept.
+func TestGetWorkerGroupSpecs_RayStartParams(t *testing.T) {
+	t.Run("nil -> empty non-nil map", func(t *testing.T) {
+		got := getWorkerGroupSpecs("test-cluster", []*v2pb.RayWorkerSpec{{MinInstances: 1, MaxInstances: 2}})
+		require.Len(t, got, 1)
+		require.NotNil(t, got[0].RayStartParams)
+		assert.Equal(t, map[string]string{}, got[0].RayStartParams)
+	})
+	t.Run("populated -> preserved", func(t *testing.T) {
+		got := getWorkerGroupSpecs("test-cluster", []*v2pb.RayWorkerSpec{{
+			MinInstances:   1,
+			MaxInstances:   2,
+			RayStartParams: map[string]string{"metrics-export-port": "8080"},
+		}})
+		require.Len(t, got, 1)
+		assert.Equal(t, map[string]string{"metrics-export-port": "8080"}, got[0].RayStartParams)
+	})
+}
+
 func TestMapper_GetLocalName(t *testing.T) {
 	m := Mapper{}
 

--- a/go/components/jobs/client/k8sengine/ray.go
+++ b/go/components/jobs/client/k8sengine/ray.go
@@ -156,10 +156,28 @@ func (m Mapper) mapRayCluster(rayCluster *v2pb.RayCluster) (runtime.Object, erro
 	return rayV1Cluster, nil
 }
 
+// nonNilRayStartParams returns params unchanged when non-nil, otherwise an
+// empty (non-nil) map. KubeRay's HeadGroupSpec/WorkerGroupSpec.RayStartParams
+// field has no `omitempty`, so a nil map serializes to JSON `null` — and the
+// RayCluster CRD rejects `null` ("rayStartParams in body must be of type
+// object"). Michelangelo's v2 API omits rayStartParams by default (and proto3
+// drops empty maps on the wire, so callers cannot force `{}` from the request),
+// which leaves this field nil here. The bug stays latent until an admission
+// webhook re-serializes the RayCluster on create — notably Kueue's mutating
+// webhook, which decodes the object and marshals it whole, turning the omitted
+// map into an explicit `null` that the CRD then rejects. Emitting `{}` instead
+// is always valid and is the equivalent of "no extra ray start params".
+func nonNilRayStartParams(params map[string]string) map[string]string {
+	if params == nil {
+		return map[string]string{}
+	}
+	return params
+}
+
 func getHeadGroupSpec(head *v2pb.RayHeadSpec) rayv1.HeadGroupSpec {
 	return rayv1.HeadGroupSpec{
 		ServiceType:    corev1.ServiceType(head.GetServiceType()),
-		RayStartParams: head.GetRayStartParams(),
+		RayStartParams: nonNilRayStartParams(head.GetRayStartParams()),
 		Template:       k8sptr.Deref(head.GetPod(), corev1.PodTemplateSpec{}),
 	}
 }
@@ -172,7 +190,7 @@ func getWorkerGroupSpecs(clusterName string, workers []*v2pb.RayWorkerSpec) []ra
 			Replicas:       &workerGroup.MinInstances,
 			MinReplicas:    &workerGroup.MinInstances,
 			MaxReplicas:    &workerGroup.MaxInstances,
-			RayStartParams: workerGroup.RayStartParams,
+			RayStartParams: nonNilRayStartParams(workerGroup.GetRayStartParams()),
 			Template:       k8sptr.Deref(workerGroup.Pod, corev1.PodTemplateSpec{}),
 		}
 		workerGroupSpecsJSON[i] = wg


### PR DESCRIPTION
## Problem

New MA RayCluster creation fails on Kueue-enabled compute clusters with:

```
RayCluster.ray.io "..." is invalid: [spec.headGroupSpec.rayStartParams:
Invalid value: "null": spec.headGroupSpec.rayStartParams in body must be of
type object: "null", spec.workerGroupSpecs[0].rayStartParams: Invalid value:
"null": ... must be of type object]
```

## Root cause

- Michelangelo's v2 API omits `rayStartParams` by default, and **proto3 drops empty maps on the wire**, so callers cannot force `{}` from the request body — the mapper receives a `nil` map and sets `HeadGroupSpec/WorkerGroupSpec.RayStartParams = nil`.
- KubeRay's `RayStartParams` field has **no `omitempty`** (`ray-operator/apis/ray/v1`, both head and worker), so a `nil` map serializes to JSON `null`.
- This stays latent until an admission webhook re-serializes the RayCluster on create. **Kueue's mutating webhook** (`mraycluster.kb.io`) decodes the object and marshals it whole to build its patch — turning the omitted map into an explicit `rayStartParams: null`, which the RayCluster CRD then rejects (`rayStartParams` is `type: object`, not nullable).

The CRD is unchanged and KubeRay is unchanged — the regression appears the moment Kueue admission is enabled in front of RayCluster creation.

## Fix

Coalesce a `nil` `rayStartParams` to an empty (non-nil) map in the mapper (`getHeadGroupSpec` + `getWorkerGroupSpecs`) so it serializes to `{}` (a valid, empty object) for the head and every worker group. This must live in the mapper: proto3's empty-map collapse means it cannot be fixed from the request/starlark side.

## Evidence

- On `dev-av-labs-test-v2`, a create with an **empty** `ray_start_params: {}` on the head and a **non-empty** map on the worker produced an error **only on `headGroupSpec`** — the worker (non-nil map) passed. Confirms a non-nil map at the mapper is the fix.
- Server dry-run on the compute cluster: explicit `rayStartParams: {}` is accepted by the CRD (through Kueue's live webhook); omitted → `null` → rejected.

## Testing

`go test ./components/jobs/client/k8sengine/` passes, including:
- existing `TestMapper_MapGlobalJobClusterToLocal` (populated maps preserved),
- new `TestGetHeadGroupSpec_RayStartParams` / `TestGetWorkerGroupSpecs_RayStartParams` (nil → non-nil `{}`, populated → preserved).

## Deploy note

Requires a control-plane rebuild + deploy (this mapper runs where MA creates the `ray.io` RayCluster) to take effect on dev-6 / compute clusters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
