### PR TITLE
feat(core): filter pipeline runs and trigger runs by SourcePipelineType label

### DIFF
--- a/javascript/packages/core/components/views/phase-entity-view/utils/__tests__/inject-list-options.test.ts
+++ b/javascript/packages/core/components/views/phase-entity-view/utils/__tests__/inject-list-options.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'vitest';
+
+import { injectListOptions } from '../inject-list-options';
+
+import type { QueryConfig } from '#core/types/query-types';
+
+describe('injectListOptions', () => {
+  test.each<{
+    name: string;
+    service: QueryConfig['service'];
+    pipelineTypes?: string[];
+    expected: ReturnType<typeof injectListOptions>;
+  }>([
+    {
+      name: 'pipeline with pipeline types builds a fieldSelector',
+      service: 'pipeline',
+      pipelineTypes: ['batch', 'streaming'],
+      expected: { fieldSelector: 'pipeline_type in (batch,streaming)' },
+    },
+    {
+      name: 'pipeline with no pipeline types is undefined',
+      service: 'pipeline',
+      pipelineTypes: undefined,
+      expected: undefined,
+    },
+    {
+      name: 'pipeline with empty pipeline types is undefined',
+      service: 'pipeline',
+      pipelineTypes: [],
+      expected: undefined,
+    },
+    {
+      name: 'pipelineRun with pipeline types builds a labelSelector',
+      service: 'pipelineRun',
+      pipelineTypes: ['batch'],
+      expected: { labelSelector: 'michelangelo/SourcePipelineType in (batch)' },
+    },
+    {
+      name: 'triggerRun with pipeline types builds a labelSelector',
+      service: 'triggerRun',
+      pipelineTypes: ['batch'],
+      expected: { labelSelector: 'michelangelo/SourcePipelineType in (batch)' },
+    },
+  ])('$name', ({ service, pipelineTypes, expected }) => {
+    expect(injectListOptions(service, pipelineTypes)).toEqual(expected);
+  });
+});

--- a/javascript/packages/core/components/views/phase-entity-view/utils/inject-list-options.ts
+++ b/javascript/packages/core/components/views/phase-entity-view/utils/inject-list-options.ts
@@ -1,10 +1,8 @@
 import type { QueryConfig } from '#core/types/query-types';
 import type { InjectedListOptions } from '../types';
 
-/**
- * Derives the RPC-level listOptions needed to restrict an entity's list query to a
- * phase's pipeline types.
- */
+const SOURCE_PIPELINE_TYPE_LABEL = 'michelangelo/SourcePipelineType';
+
 export function injectListOptions(
   service: QueryConfig['service'],
   pipelineTypes?: string[]
@@ -14,6 +12,12 @@ export function injectListOptions(
   if (service === 'pipeline') {
     return {
       fieldSelector: `pipeline_type in (${pipelineTypes.join(',')})`,
+    };
+  }
+
+  if (service === 'pipelineRun' || service === 'triggerRun') {
+    return {
+      labelSelector: `${SOURCE_PIPELINE_TYPE_LABEL} in (${pipelineTypes.join(',')})`,
     };
   }
 


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**Stacked on:** #1936 (backend: stamp SourcePipelineType label on PipelineRun/TriggerRun)

**What changed?**

`injectListOptions` now builds a `labelSelector` for PipelineRun and TriggerRun queries, filtering by `michelangelo/SourcePipelineType`. Previously it only handled Pipeline (via `fieldSelector` on `pipeline_type`), leaving runs and triggers unfiltered — every phase showed the same global list.

With the backend PR (#1936) stamping the `SourcePipelineType` label at creation time, the frontend can now scope each phase's run and trigger lists to only the pipeline types that phase owns.

**Why?**

Without run/trigger filtering, the Train phase shows prediction runs and the Deploy phase shows training runs. Each phase declares its `pipelineTypes` in config, and this PR closes the loop by passing those types as a `labelSelector` to the list API.

**How did you test it?**


https://github.com/user-attachments/assets/3c296022-9b7d-44ed-8f33-4ce0fae8415b



**Potential risks**

- Runs/triggers created before the backend PR was deployed won't have the `SourcePipelineType` label and will be filtered out of phase-scoped views. This is expected — only new runs carry the label.

**Breaking Changes**

- [x] No breaking changes

**Release notes**

Pipeline run and trigger run lists are now scoped per phase using the `SourcePipelineType` label.

**Documentation Changes**

None required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)