### PR TITLE
feat(core): add pipelines, triggers, and runs to the deploy phase

### DIFF
--- a/javascript/packages/core/config/phases/deploy.ts
+++ b/javascript/packages/core/config/phases/deploy.ts
@@ -1,5 +1,8 @@
 import { DEPLOYMENT_ENTITY_CONFIG } from '#core/config/entities/deployment/deployment';
+import { PIPELINE_ENTITY_CONFIG } from '#core/config/entities/pipeline/pipeline';
+import { RUN_ENTITY_CONFIG } from '#core/config/entities/run/run';
 import { TARGET_ENTITY_CONFIG } from '#core/config/entities/targets/target';
+import { TRIGGER_ENTITY_CONFIG } from '#core/config/entities/trigger/trigger';
 
 import type { PhaseConfig } from '#core/types/common/studio-types';
 
@@ -10,5 +13,11 @@ export const DEPLOY_PHASE: PhaseConfig = {
   description: 'Deploy your models and predict new data',
   state: 'comingSoon' as const,
   pipelineTypes: ['PIPELINE_TYPE_PREDICTION', 'PIPELINE_TYPE_SCORER'],
-  entities: [TARGET_ENTITY_CONFIG, DEPLOYMENT_ENTITY_CONFIG],
+  entities: [
+    PIPELINE_ENTITY_CONFIG,
+    RUN_ENTITY_CONFIG,
+    TRIGGER_ENTITY_CONFIG,
+    TARGET_ENTITY_CONFIG,
+    DEPLOYMENT_ENTITY_CONFIG,
+  ],
 };


### PR DESCRIPTION
## Summary

Adds pipeline, run, and trigger entity configs to the deploy phase, matching the entity set train already has

## Test plan
<img width="1312" height="1034" alt="Screenshot 2026-08-25 at 12 26 28 PM" src="https://github.com/user-attachments/assets/58ea0f73-bc02-40b7-866c-41428b743530" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)