### PR TITLE
fix(ci): stop dirty-check racing bazel-build's cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,20 +89,27 @@ jobs:
 
   dirty-check:
     runs-on: ubuntu-latest
+    # Ordered after bazel-build so its exact-key cache is guaranteed to be
+    # saved before this job restores it — without this, both jobs race to
+    # restore the same key, and a miss here falls back to a stale cache from
+    # an older commit whose external repo layout can mismatch the current
+    # MODULE.bazel/gazelle version (surfaces as bogus "no such package"
+    # Bazel errors that don't reproduce locally).
+    needs: bazel-build
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # Restore-only: reuse the cache saved by bazel-build (no redundant save)
+      # Restore-only: reuse the cache saved by bazel-build. No restore-keys
+      # fallback — an incompatible cache from a different commit is worse
+      # than a cold cache (see the `needs` comment above).
       - name: Restore Bazel Cache
         uses: actions/cache/restore@v6
         with:
           path: |
             ~/.cache/bazel
           key: bazel-main-${{ runner.os }}-${{ hashFiles('.bazelversion', 'MODULE.bazel', 'MODULE.bazel.lock') }}
-          restore-keys: |
-            bazel-main-${{ runner.os }}-
 
       - name: Run Gazelle
         run: |


### PR DESCRIPTION
## Summary

- Make `dirty-check` depend on `bazel-build` so its cache restore always targets an already-saved exact-match key
- Drop `restore-keys` fallback from both `dirty-check` (main.yml) and `transcoder-services-check.yaml` — a cold cache miss is safer than silently reusing one from an incompatible commit

## Context

After the gazelle 0.40.0 → 0.52.2 bump (#1747, merged Aug 10), an older Bazel cache's external repo layout doesn't match what the current `MODULE.bazel` expects. When `dirty-check` loses the cache race against `bazel-build`, it falls back via `restore-keys` to a stale cache and Bazel raises spurious "no such package" errors. This is nondeterministic — some PRs pass, some fail.

## Test plan

I audited all failed `dirty-check` runs in the last ~7 weeks across the repo. The cache-race signature (`ERROR: no such package '@@[unknown repo ... requested from @@gazelle~~go_deps~...]'`) appears on multiple branches.

| Run | Date | Author | Branch (PR) | Error |
|---|---|---|---|---|
| [32061050827](https://github.com/michelangelo-ai/michelangelo/actions/runs/32061050827) | Aug 17 | apurvapatkeshwar | feat/gcs-blobstore (#1837) | `no such package '@@[unknown repo 'org_golang_x_telemetry'...]'` |
| [31859163853](https://github.com/michelangelo-ai/michelangelo/actions/runs/31859163853) | Aug 15 | dependabot | go-minor-and-patch (#1736) | Same `org_golang_x_telemetry` resolution failure |
| [31343435571](https://github.com/michelangelo-ai/michelangelo/actions/runs/31343435571) | Aug 10 | dependabot | proto-go-minor-and-patch (#1733) | Same error — dirty-check only |

The specific missing package varies (`org_golang_x_telemetry`, `k8s.io/apimachinery/pkg/api/resource`) depending on which external dep the stale cache trips on first, but the root cause is the same: `restore-keys` hands dirty-check a cache from an older commit whose gazelle-managed external repo layout is incompatible with the current `MODULE.bazel`.