### PR TITLE
fix(python): unwrap single-field response and use camelCase for get -o json

### DIFF
--- a/python/michelangelo/cli/mactl/crd.py
+++ b/python/michelangelo/cli/mactl/crd.py
@@ -534,23 +534,30 @@ def _render_single_item(
 ) -> None:
     """Render a single CRD message in the requested output format.
 
-    Table output prints a one-row table using the same columns as `list`,
-    matching kubectl's `get <resource> <name>` behavior. Prior versions
-    printed the raw proto text_format, which rendered `google.protobuf.Any`
-    payloads (e.g. `spec.manifest.content`) as escaped byte strings.
+    All output formats unwrap ``GetXxxResponse`` first via
+    ``_unwrap_single_field_response``, so the wrapper field name never leaks
+    into user-visible output — the caller asked for the resource, not the
+    RPC envelope. JSON follows proto3-JSON defaults (lowerCamelCase), which
+    matches kubectl / k8s-native CRD conventions; YAML keeps the proto
+    snake_case field names, which matches the source-of-truth YAML manifests
+    users write. Table output prints a one-row table using the same columns
+    as ``list``, matching kubectl's ``get <resource> <name>`` behavior.
+    Prior versions printed the raw proto text_format, which rendered
+    ``google.protobuf.Any`` payloads (e.g. ``spec.manifest.content``) as
+    escaped byte strings.
     """
+    inner = _unwrap_single_field_response(msg)
     if output_format == "yaml":
         print(
             yaml_safe_dump(
-                MessageToDict(msg, preserving_proto_field_name=True), sort_keys=False
+                MessageToDict(inner, preserving_proto_field_name=True),
+                sort_keys=False,
             )
         )
     elif output_format == "json":
-        print(MessageToJson(msg, preserving_proto_field_name=True))
+        print(MessageToJson(inner))
     else:
-        print_list_formatted(
-            [_unwrap_single_field_response(msg)], extra_columns=extra_columns
-        )
+        print_list_formatted([inner], extra_columns=extra_columns)
 
 
 def _resolve_criteria(spec, bound_args: dict, arg_dest: str) -> list[Criterion]:

--- a/python/michelangelo/cli/mactl/crd.py
+++ b/python/michelangelo/cli/mactl/crd.py
@@ -534,17 +534,12 @@ def _render_single_item(
 ) -> None:
     """Render a single CRD message in the requested output format.
 
-    All output formats unwrap ``GetXxxResponse`` first via
-    ``_unwrap_single_field_response``, so the wrapper field name never leaks
-    into user-visible output — the caller asked for the resource, not the
-    RPC envelope. JSON follows proto3-JSON defaults (lowerCamelCase), which
-    matches kubectl / k8s-native CRD conventions; YAML keeps the proto
-    snake_case field names, which matches the source-of-truth YAML manifests
-    users write. Table output prints a one-row table using the same columns
-    as ``list``, matching kubectl's ``get <resource> <name>`` behavior.
-    Prior versions printed the raw proto text_format, which rendered
-    ``google.protobuf.Any`` payloads (e.g. ``spec.manifest.content``) as
-    escaped byte strings.
+    All formats unwrap ``GetXxxResponse`` via
+    ``_unwrap_single_field_response`` so the RPC envelope stays out of
+    user-visible output. JSON uses proto3-JSON defaults (lowerCamelCase)
+    to match kubectl / k8s CRD conventions; YAML keeps proto snake_case
+    to match hand-written YAML manifests. Table prints one row using the
+    same columns as ``list``.
     """
     inner = _unwrap_single_field_response(msg)
     if output_format == "yaml":

--- a/python/michelangelo/cli/mactl/crd.py
+++ b/python/michelangelo/cli/mactl/crd.py
@@ -536,19 +536,15 @@ def _render_single_item(
 
     All formats unwrap ``GetXxxResponse`` via
     ``_unwrap_single_field_response`` so the RPC envelope stays out of
-    user-visible output. JSON uses proto3-JSON defaults (lowerCamelCase)
-    to match kubectl / k8s CRD conventions; YAML keeps proto snake_case
-    to match hand-written YAML manifests. Table prints one row using the
-    same columns as ``list``.
+    user-visible output. YAML and JSON both use proto3-JSON defaults
+    (lowerCamelCase) — matching Go ``mactl``, ``kubectl``, and every
+    k8s tool that reads CRD output; the two formats differ only in
+    serialization, not casing. Table prints one row using the same
+    columns as ``list``.
     """
     inner = _unwrap_single_field_response(msg)
     if output_format == "yaml":
-        print(
-            yaml_safe_dump(
-                MessageToDict(inner, preserving_proto_field_name=True),
-                sort_keys=False,
-            )
-        )
+        print(yaml_safe_dump(MessageToDict(inner), sort_keys=False))
     elif output_format == "json":
         print(MessageToJson(inner))
     else:

--- a/python/michelangelo/cli/mactl/crd_test.py
+++ b/python/michelangelo/cli/mactl/crd_test.py
@@ -495,6 +495,24 @@ class RenderHelpersTest(TestCase):
         self.assertIs(args[0], inner)
 
     @patch("michelangelo.cli.mactl.crd.MessageToDict")
+    def test_render_single_item_yaml_uses_proto3_camel_case(self, mock_to_dict):
+        """YAML path does not pass preserving_proto_field_name.
+
+        Proto3-JSON default is lowerCamelCase (`apiVersion`, `metadata`,
+        `revisionId`). Go ``mactl`` and ``kubectl`` both emit camelCase in
+        their YAML output (`sigs.k8s.io/yaml` marshals via JSON), so the
+        Python CLI aligns on camelCase to keep JSON and YAML internally
+        consistent and to match every other tool in the k8s ecosystem.
+        """
+        from michelangelo.cli.mactl.crd import _render_single_item
+
+        mock_to_dict.return_value = {}
+        _render_single_item(self._non_wrapper_msg(), "yaml")
+
+        _, kwargs = mock_to_dict.call_args
+        self.assertNotIn("preserving_proto_field_name", kwargs)
+
+    @patch("michelangelo.cli.mactl.crd.MessageToDict")
     def test_render_single_item_yaml_handles_ordereddict(self, mock_to_dict):
         """OrderedDict from unpacked google.protobuf.Any dumps without error.
 

--- a/python/michelangelo/cli/mactl/crd_test.py
+++ b/python/michelangelo/cli/mactl/crd_test.py
@@ -379,6 +379,20 @@ class RenderHelpersTest(TestCase):
 
         mock_print.assert_called_once_with(items, extra_columns=())
 
+    @staticmethod
+    def _non_wrapper_msg():
+        """Build a Mock message that _unwrap_single_field_response leaves untouched.
+
+        ``_unwrap_single_field_response`` checks ``msg.DESCRIPTOR.fields`` and
+        only unwraps when there is exactly one message-typed field. An empty
+        fields list makes it return ``msg`` unchanged, so tests that only care
+        about the render step can ignore the unwrap detail.
+        """
+        msg = Mock()
+        msg.DESCRIPTOR = Mock()
+        msg.DESCRIPTOR.fields = []
+        return msg
+
     @patch("michelangelo.cli.mactl.crd.MessageToJson")
     def test_render_single_item_json(self, mock_to_json):
         """Json output for a single item uses MessageToJson."""
@@ -391,10 +405,54 @@ class RenderHelpersTest(TestCase):
 
         buf = io.StringIO()
         with redirect_stdout(buf):
-            _render_single_item(Mock(), "json")
+            _render_single_item(self._non_wrapper_msg(), "json")
 
         self.assertIn('"name": "x"', buf.getvalue())
         mock_to_json.assert_called_once()
+
+    @patch("michelangelo.cli.mactl.crd.MessageToJson")
+    def test_render_single_item_json_uses_proto3_camel_case(self, mock_to_json):
+        """JSON path does not pass preserving_proto_field_name.
+
+        Proto3-JSON default is lowerCamelCase (`apiVersion`, `metadata`,
+        `revisionId`), which matches kubectl / k8s-native CRD conventions.
+        The prior `preserving_proto_field_name=True` argument leaked proto
+        snake_case (`type_meta`, `revision_id`) into user-visible output
+        and blocked jq recipes shared with k8s tooling.
+        """
+        from michelangelo.cli.mactl.crd import _render_single_item
+
+        mock_to_json.return_value = "{}"
+        _render_single_item(self._non_wrapper_msg(), "json")
+
+        _, kwargs = mock_to_json.call_args
+        self.assertNotIn("preserving_proto_field_name", kwargs)
+
+    @patch("michelangelo.cli.mactl.crd.MessageToJson")
+    def test_render_single_item_json_unwraps_wrapper_response(self, mock_to_json):
+        """GetXxxResponse (one message-typed field) is unwrapped for JSON.
+
+        `_get` returns e.g. `GetRevisionResponse` with a single `revision`
+        field. Rendering the wrapper directly leaks the RPC envelope as the
+        top-level JSON key (`{"revision": {...}}`); users want the resource
+        itself.
+        """
+        from michelangelo.cli.mactl.crd import _render_single_item
+
+        mock_to_json.return_value = "{}"
+        inner = self._non_wrapper_msg()
+        wrapper = Mock()
+        wrapper.DESCRIPTOR = Mock()
+        field = Mock()
+        field.name = "revision"
+        field.message_type = Mock()
+        wrapper.DESCRIPTOR.fields = [field]
+        wrapper.revision = inner
+
+        _render_single_item(wrapper, "json")
+
+        args, _ = mock_to_json.call_args
+        self.assertIs(args[0], inner)
 
     @patch("michelangelo.cli.mactl.crd.MessageToDict")
     def test_render_single_item_yaml(self, mock_to_dict):
@@ -408,9 +466,33 @@ class RenderHelpersTest(TestCase):
 
         buf = io.StringIO()
         with redirect_stdout(buf):
-            _render_single_item(Mock(), "yaml")
+            _render_single_item(self._non_wrapper_msg(), "yaml")
 
         self.assertIn("name: x", buf.getvalue())
+
+    @patch("michelangelo.cli.mactl.crd.MessageToDict")
+    def test_render_single_item_yaml_unwraps_wrapper_response(self, mock_to_dict):
+        """GetXxxResponse (one message-typed field) is unwrapped for YAML.
+
+        Same rationale as the JSON path: rendering the raw response leaks
+        the RPC envelope name as the top-level YAML key (`revision:`).
+        """
+        from michelangelo.cli.mactl.crd import _render_single_item
+
+        mock_to_dict.return_value = {}
+        inner = self._non_wrapper_msg()
+        wrapper = Mock()
+        wrapper.DESCRIPTOR = Mock()
+        field = Mock()
+        field.name = "revision"
+        field.message_type = Mock()
+        wrapper.DESCRIPTOR.fields = [field]
+        wrapper.revision = inner
+
+        _render_single_item(wrapper, "yaml")
+
+        args, _ = mock_to_dict.call_args
+        self.assertIs(args[0], inner)
 
     @patch("michelangelo.cli.mactl.crd.MessageToDict")
     def test_render_single_item_yaml_handles_ordereddict(self, mock_to_dict):
@@ -442,7 +524,7 @@ class RenderHelpersTest(TestCase):
 
         buf = io.StringIO()
         with redirect_stdout(buf):
-            _render_single_item(Mock(), "yaml")
+            _render_single_item(self._non_wrapper_msg(), "yaml")
 
         out = buf.getvalue()
         self.assertIn("'@type': type.googleapis.com/foo.Bar", out)


### PR DESCRIPTION
## What type of PR is this?

- [x] Improvement

## What changed?

`_render_single_item` in `crd.py` now:

1. Calls `_unwrap_single_field_response` for both the yaml and json paths (the table path 20 lines above already does).
2. Drops `preserving_proto_field_name=True` from **both** `MessageToJson` and `MessageToDict` calls, so both formats emit proto3-JSON default lowerCamelCase.

`<crd> get <name> -o json`:
```
# Before
{"revision": {"type_meta": {...}, "metadata": ...}}
# After
{"typeMeta": {...}, "metadata": ..., "spec": ..., "status": ...}
```

`<crd> get <name> -o yaml`:
```
# Before
revision:
  type_meta:
    kind: Revision
    api_version: michelangelo.uber.com/v2beta1
# After
typeMeta:
  kind: Revision
  apiVersion: michelangelo.uber.com/v2beta1
```

## Why?

Consistency, not a functional fix — nothing was broken, just inconsistent:

1. **Uniform unwrap across output formats.** The table path already unwrapped `GetXxxResponse`; yaml/json didn't. Aligning them removes a shape-per-format surprise for consumers switching between `-o table` and `-o json`.
2. **Uniform casing across output formats.** Go `mactl` uses `sigs.k8s.io/yaml`, which marshals via JSON so yaml and json casings are identical (both camelCase). Kubectl works the same way. Aligning `-o yaml` on camelCase means the two formats inside `ma` differ only in serialization, not casing — and matches every other tool in the k8s ecosystem.

## How did you test it?

**Unit + style:** `pytest michelangelo/cli/mactl/crd_test.py` → 92 passed (13 in `RenderHelpersTest`, +4 new: wrapper-unwrap for json/yaml, proto3-JSON casing default for json/yaml). `ruff check` + `ruff format --check` clean.

**Integration — real apiserver:**

| Command | Observed |
|---|---|
| `ma revision get -n <ns> <name> -o json \| jq keys` | `["metadata","spec","status","typeMeta"]` — no wrapper, camelCase |
| `ma revision get -n <ns> <name> -o yaml \| head -3` | `typeMeta:` at column 0 — no wrapper, camelCase |
| `ma revision get -n <ns> <name> -o yaml` root keys | `["metadata", "spec", "status", "typeMeta"]` — match json exactly |
| `ma revision get -n <ns> <name> -o yaml` recursive walk | 56 keys, 0 snake_case, all camelCase / single-word |
| `ma revision get -n <ns> <name> -o table` | unchanged |

## Breaking Changes

- [x] No breaking changes

Users of `-o yaml` who parsed snake_case field names get camelCase.

## Release notes

`<crd> get <name> -o json` and `-o yaml` no longer include the RPC response wrapper, and both now use lowerCamelCase field names — matching, `kubectl`, and other k8s-native tool. 
