### PR TITLE
feat(ui): Add more detail on key status indicator for deployment

### DIFF
--- a/javascript/packages/core/config/entities/deployment/__tests__/deployment-page.test.tsx
+++ b/javascript/packages/core/config/entities/deployment/__tests__/deployment-page.test.tsx
@@ -206,24 +206,6 @@ describe('Deployment detail page', () => {
       expect(screen.queryByRole('link', { name: 'triton-server' })).not.toBeInTheDocument();
     });
 
-    it('renders the revision references on the deployment', async () => {
-      render(
-        <EntityDetailRoute phases={{ deploy: DEPLOY_PHASE }} />,
-        buildWrapper([
-          getErrorProviderWrapper(),
-          getRouterWrapper({
-            location: '/myproject/deploy/deployments/sentiment-deployment/info',
-          }),
-          getServiceProviderWrapper({ request: createQueryMockRouter(infoTabResponses()) }),
-        ])
-      );
-
-      expect(await screen.findByText('sentiment-model-rev-2')).toBeInTheDocument();
-      expect(screen.getByText('Current model in production')).toBeInTheDocument();
-      expect(screen.getByText('sentiment-model-rev-3')).toBeInTheDocument();
-      expect(screen.getByText('No model currently being deployed')).toBeInTheDocument();
-    });
-
     it('renders the resolved model metadata on the revision cards', async () => {
       render(
         <EntityDetailRoute phases={{ deploy: DEPLOY_PHASE }} />,
@@ -236,7 +218,6 @@ describe('Deployment detail page', () => {
         ])
       );
 
-      // Two cards have revisions (current + desired); each resolves the same mocked model.
       await waitFor(() => expect(screen.getAllByText('model-owner')).toHaveLength(2));
       expect(screen.getAllByText('Regression')).toHaveLength(2);
       expect(screen.getAllByText('run-20260825-080000')).toHaveLength(2);
@@ -264,7 +245,6 @@ describe('Deployment detail page', () => {
       expect(await screen.findByText('sentiment-model-rev-2')).toBeInTheDocument();
       expect(screen.getByText('sentiment-model-rev-3')).toBeInTheDocument();
       expect(screen.queryByText('Regression')).not.toBeInTheDocument();
-      // Every field label still renders on both cards, with placeholder values.
       expect(screen.getAllByText('Creation time')).toHaveLength(2);
       expect(screen.getAllByText('Owner')).toHaveLength(3); // 2 cards + detail page header
       expect(screen.getAllByText('Type')).toHaveLength(2);

--- a/javascript/packages/core/config/entities/deployment/__tests__/deployment-page.test.tsx
+++ b/javascript/packages/core/config/entities/deployment/__tests__/deployment-page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 
 import {
@@ -138,8 +138,18 @@ describe('Deployment detail page', () => {
       },
     });
 
+    const buildModel = () => ({
+      metadata: { creationTimestamp: { seconds: 1746000000 } },
+      spec: {
+        owner: { name: 'model-owner' },
+        kind: 2,
+        sourcePipelineRun: { name: 'run-20260825-080000' },
+      },
+    });
+
     const infoTabResponses = () => ({
       GetDeployment: { deployment: buildDeployment() },
+      GetModel: { model: buildModel() },
     });
 
     it('renders the configuration details', async () => {
@@ -212,6 +222,54 @@ describe('Deployment detail page', () => {
       expect(screen.getByText('Current model in production')).toBeInTheDocument();
       expect(screen.getByText('sentiment-model-rev-3')).toBeInTheDocument();
       expect(screen.getByText('No model currently being deployed')).toBeInTheDocument();
+    });
+
+    it('renders the resolved model metadata on the revision cards', async () => {
+      render(
+        <EntityDetailRoute phases={{ deploy: DEPLOY_PHASE }} />,
+        buildWrapper([
+          getErrorProviderWrapper(),
+          getRouterWrapper({
+            location: '/myproject/deploy/deployments/sentiment-deployment/info',
+          }),
+          getServiceProviderWrapper({ request: createQueryMockRouter(infoTabResponses()) }),
+        ])
+      );
+
+      // Two cards have revisions (current + desired); each resolves the same mocked model.
+      await waitFor(() => expect(screen.getAllByText('model-owner')).toHaveLength(2));
+      expect(screen.getAllByText('Regression')).toHaveLength(2);
+      expect(screen.getAllByText('run-20260825-080000')).toHaveLength(2);
+      expect(screen.getAllByText('Creation time')).toHaveLength(2);
+      expect(screen.getAllByText('Source pipeline run')).toHaveLength(2);
+    });
+
+    it('falls back to the bare revision name when the model cannot be resolved', async () => {
+      render(
+        <EntityDetailRoute phases={{ deploy: DEPLOY_PHASE }} />,
+        buildWrapper([
+          getErrorProviderWrapper(),
+          getRouterWrapper({
+            location: '/myproject/deploy/deployments/sentiment-deployment/info',
+          }),
+          getServiceProviderWrapper({
+            request: createQueryMockRouter({
+              GetDeployment: { deployment: buildDeployment() },
+              GetModel: {},
+            }),
+          }),
+        ])
+      );
+
+      expect(await screen.findByText('sentiment-model-rev-2')).toBeInTheDocument();
+      expect(screen.getByText('sentiment-model-rev-3')).toBeInTheDocument();
+      expect(screen.queryByText('Regression')).not.toBeInTheDocument();
+      // Every field label still renders on both cards, with placeholder values.
+      expect(screen.getAllByText('Creation time')).toHaveLength(2);
+      expect(screen.getAllByText('Owner')).toHaveLength(3); // 2 cards + detail page header
+      expect(screen.getAllByText('Type')).toHaveLength(2);
+      expect(screen.getAllByText('Source pipeline run')).toHaveLength(2);
+      expect(screen.getAllByText('—')).toHaveLength(8);
     });
 
     it('renders empty states when no revisions are set', async () => {

--- a/javascript/packages/core/config/entities/deployment/deployment-revision-card-field.tsx
+++ b/javascript/packages/core/config/entities/deployment/deployment-revision-card-field.tsx
@@ -1,0 +1,24 @@
+import { useStyletron } from 'baseui';
+import { LabelSmall } from 'baseui/typography';
+
+import type { ReactNode } from 'react';
+
+/** A labeled value within a DeploymentRevisionCard's metadata grid. */
+export function DeploymentRevisionCardField({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  const [, theme] = useStyletron();
+
+  return (
+    <div>
+      <LabelSmall color={theme.colors.contentSecondary} marginBottom={theme.sizing.scale200}>
+        {label}
+      </LabelSmall>
+      {children}
+    </div>
+  );
+}

--- a/javascript/packages/core/config/entities/deployment/deployment-revision-card.tsx
+++ b/javascript/packages/core/config/entities/deployment/deployment-revision-card.tsx
@@ -1,21 +1,28 @@
 import { useStyletron } from 'baseui';
 import { ARTWORK_TYPE } from 'baseui/banner';
 import { Spinner } from 'baseui/spinner';
-import { LabelSmall, ParagraphMedium } from 'baseui/typography';
+import { ParagraphMedium } from 'baseui/typography';
 
 import { Banner } from '#core/components/banner/banner';
 import { Box } from '#core/components/box/box';
+import { DateTime } from '#core/components/date-time/date-time';
 import { Icon } from '#core/components/icon/icon';
+import { TAG_BEHAVIOR, TAG_COLOR, TAG_HIERARCHY, TAG_SIZE } from '#core/components/tag/constants';
+import { Tag } from '#core/components/tag/tag';
+import { useStudioQuery } from '#core/hooks/use-studio-query';
+import { MODEL_KIND_TEXT_MAP } from '../model/constants';
+import { DeploymentRevisionCardField } from './deployment-revision-card-field';
 
+import type { ModelRecord } from '../model/types';
 import type { ResourceRef } from './types';
 
 const CARD_OVERRIDES = { BoxContainer: { style: { flexBasis: '320px', flexGrow: 1 } } };
 
 /**
  * Renders a card for one of a deployment's revision references (current,
- * candidate, or desired). Shows only what is present on the Deployment CR
- * itself — the revision name — since OSS has no producer of Model revisions to
- * resolve richer model metadata from.
+ * candidate, or desired). Resolves the referenced Model CR to show its
+ * metadata (owner, type, creation time, source pipeline run); falls back to
+ * the bare revision name when the Model cannot be fetched.
  */
 export function DeploymentRevisionCard({
   title,
@@ -30,7 +37,16 @@ export function DeploymentRevisionCard({
 }) {
   const [css, theme] = useStyletron();
 
-  if (isLoading) {
+  const { data, isLoading: isModelLoading } = useStudioQuery<{ model?: ModelRecord }>({
+    queryName: 'GetModel',
+    serviceOptions: {
+      name: revision?.name,
+      ...(revision?.namespace != null && { namespace: revision.namespace }),
+    },
+    clientOptions: { enabled: Boolean(revision?.name) },
+  });
+
+  if (isLoading || (revision?.name && isModelLoading)) {
     return (
       <Box title={title} overrides={CARD_OVERRIDES}>
         <div className={css({ display: 'flex', justifyContent: 'center' })}>
@@ -56,14 +72,65 @@ export function DeploymentRevisionCard({
     );
   }
 
+  const model = data?.model;
+  const owner = model?.spec?.owner?.name;
+  const kind = model?.spec?.kind;
+  const kindLabel = kind != null ? MODEL_KIND_TEXT_MAP[kind] : undefined;
+  const creationSeconds = model?.metadata?.creationTimestamp?.seconds;
+  const sourcePipelineRun = model?.spec?.sourcePipelineRun?.name;
+
   return (
     <Box title={title} overrides={CARD_OVERRIDES}>
-      <LabelSmall color={theme.colors.contentSecondary} marginBottom={theme.sizing.scale200}>
-        Revision
-      </LabelSmall>
-      <ParagraphMedium marginTop="0" marginBottom="0">
-        {revision.name}
-      </ParagraphMedium>
+      <div
+        className={css({
+          display: 'grid',
+          gridTemplateColumns: 'repeat(2, 1fr)',
+          columnGap: theme.sizing.scale1200,
+          rowGap: theme.sizing.scale900,
+        })}
+      >
+        <DeploymentRevisionCardField label="Model">
+          <ParagraphMedium marginTop="0" marginBottom="0">
+            {revision.name}
+          </ParagraphMedium>
+        </DeploymentRevisionCardField>
+
+        <DeploymentRevisionCardField label="Owner">
+          <ParagraphMedium marginTop="0" marginBottom="0">
+            {owner != null && owner !== '' ? owner : '—'}
+          </ParagraphMedium>
+        </DeploymentRevisionCardField>
+
+        <DeploymentRevisionCardField label="Creation time">
+          <ParagraphMedium marginTop="0" marginBottom="0">
+            {creationSeconds != null ? <DateTime timestamp={creationSeconds} /> : '—'}
+          </ParagraphMedium>
+        </DeploymentRevisionCardField>
+
+        <DeploymentRevisionCardField label="Type">
+          {kindLabel != null ? (
+            <Tag
+              size={TAG_SIZE.xSmall}
+              behavior={TAG_BEHAVIOR.selection}
+              hierarchy={TAG_HIERARCHY.secondary}
+              color={TAG_COLOR.gray}
+              closeable={false}
+            >
+              {kindLabel}
+            </Tag>
+          ) : (
+            <ParagraphMedium marginTop="0" marginBottom="0">
+              —
+            </ParagraphMedium>
+          )}
+        </DeploymentRevisionCardField>
+
+        <DeploymentRevisionCardField label="Source pipeline run">
+          <ParagraphMedium marginTop="0" marginBottom="0">
+            {sourcePipelineRun != null && sourcePipelineRun !== '' ? sourcePipelineRun : '—'}
+          </ParagraphMedium>
+        </DeploymentRevisionCardField>
+      </div>
     </Box>
   );
 }


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
Currently, deployment is backed by a model so we can now add model details on the deployment detail page for the `Key status indicator` cards.


<img width="1913" height="1009" alt="image" src="https://github.com/user-attachments/assets/297accde-9a3f-4a1e-9e03-89a2e26e7e7d" />

<!-- Tell your future self why have you made these changes -->
**Why?**
We'll now have more info about the models on the deployment detail page.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Manually and unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A
<!-- Does this PR introduce a breaking change? Check all that apply. -->
**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)


<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
N/A
<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
N/A