### PR TITLE
chore(go): link legacy env-label TODOs to tracking issue

### DIFF
--- a/go/components/triggerrun/schedule_input.go
+++ b/go/components/triggerrun/schedule_input.go
@@ -20,9 +20,9 @@ const (
 	// cron_trigger_workflows.go dual-read for consistency. Safe to remove
 	// no earlier than 2 minor releases after the rename ships, per
 	// CONTRIBUTING.md's Deprecation Policy.
-	// TODO: file a tracking issue and remove this constant and both
-	// dual-read call sites (schedule_input.go, cron_trigger_workflows.go)
-	// together.
+	// TODO(https://github.com/michelangelo-ai/michelangelo/issues/1939): remove
+	// this constant and both dual-read call sites (schedule_input.go,
+	// cron_trigger_workflows.go) together.
 	scheduleInputLegacyEnvironmentLabel = "pipelinerun.michelangelo/environment"
 )
 

--- a/go/worker/workflows/trigger/cron_trigger_workflows.go
+++ b/go/worker/workflows/trigger/cron_trigger_workflows.go
@@ -55,9 +55,9 @@ var (
 	// execution whose history predates the rename can still be replayed -
 	// no earlier than 2 minor releases after this rename ships, per
 	// CONTRIBUTING.md's Deprecation Policy.
-	// TODO: file a tracking issue and remove this constant and both
-	// dual-read call sites (schedule_input.go, cron_trigger_workflows.go)
-	// together.
+	// TODO(https://github.com/michelangelo-ai/michelangelo/issues/1939): remove
+	// this constant and both dual-read call sites (schedule_input.go,
+	// cron_trigger_workflows.go) together.
 	legacyEnvironmentLabel = "pipelinerun.michelangelo/environment"
 
 	// SourceTriggerLabel stores the original trigger associated with the pipeline_run.


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
Replaced the generic "file a tracking issue" placeholder in the two `legacyEnvironmentLabel` dual-read deprecation TODOs with a reference to issue #1939, which now tracks removal of the fallback. No logic changes — comment text only, in `go/components/triggerrun/schedule_input.go` and `go/worker/workflows/trigger/cron_trigger_workflows.go`.

**Why?**
The `EnvironmentLabel` rename (#1912) added a transitional dual-read fallback at two call sites with TODOs pointing at a tracking issue that didn't exist yet. #1939 has since been filed, so the TODOs should link to it directly instead of the placeholder text.

**How did you test it?**
No functional changes. Ran `gofmt -l .` (clean) and `golangci-lint run ./...` in `go/` — no new findings versus `main` (compared full output; only pre-existing godox TODO warnings remain, same count before and after).

**Potential risks**
None — comment-only change.

**Breaking Changes**

- [x] No breaking changes

**Release notes**
N/A

**Documentation Changes**
N/A