### PR TITLE
feat(core): pluggable ownership resolver for project views

### DIFF
--- a/javascript/app/App.tsx
+++ b/javascript/app/App.tsx
@@ -12,6 +12,18 @@ import { ICONS } from './icons/icons';
 const engine = new Styletron();
 const queryClient = new QueryClient();
 
+// Sandbox/demo-only: fakes Tier-2 ownership resolution (see packages/core's Owner column
+// config) by returning a fixed team for any UUID, rather than wiring a real resolver backend.
+const FAKE_TEAM = {
+  id: 'michelangelo',
+  displayName: 'Michelangelo',
+  url: 'https://github.com/michelangelo-ai/michelangelo',
+};
+
+function resolveTeams(uuids: string[]) {
+  return Promise.resolve(Object.fromEntries(uuids.map((uuid) => [uuid, FAKE_TEAM])));
+}
+
 export function App() {
   const devProfile = useDevProfile();
 
@@ -24,6 +36,9 @@ export function App() {
     },
     service: {
       request,
+      resolvers: {
+        team: resolveTeams,
+      },
     },
     navigationBar: {
       links: [{ label: 'Docs', href: 'https://michelangelo-ai.github.io/michelangelo/' }],

--- a/javascript/packages/core/components/links-box/__tests__/links-box.test.tsx
+++ b/javascript/packages/core/components/links-box/__tests__/links-box.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
+import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
 import { LinksBox } from '../links-box';
 
 describe('LinksBox', () => {
@@ -14,7 +15,7 @@ describe('LinksBox', () => {
           { name: 'Logs', url: 'https://logs.example.com/app' },
         ]}
       />,
-      buildWrapper([getBaseProviderWrapper()])
+      buildWrapper([getBaseProviderWrapper(), getRouterWrapper()])
     );
 
     expect(screen.getByText('Useful links')).toBeInTheDocument();
@@ -38,7 +39,7 @@ describe('LinksBox', () => {
           { name: 'No URL', url: undefined },
         ]}
       />,
-      buildWrapper([getBaseProviderWrapper()])
+      buildWrapper([getBaseProviderWrapper(), getRouterWrapper()])
     );
 
     expect(screen.getByRole('link', { name: 'Valid' })).toBeInTheDocument();
@@ -52,7 +53,7 @@ describe('LinksBox', () => {
         title="Related dashboards"
         links={[{ name: 'Valid', url: 'https://example.com' }]}
       />,
-      buildWrapper([getBaseProviderWrapper()])
+      buildWrapper([getBaseProviderWrapper(), getRouterWrapper()])
     );
 
     expect(screen.getByText('Related dashboards')).toBeInTheDocument();
@@ -62,7 +63,7 @@ describe('LinksBox', () => {
   it('renders an empty box when all links are incomplete', () => {
     render(
       <LinksBox title="Useful links" links={[{ name: undefined, url: undefined }]} />,
-      buildWrapper([getBaseProviderWrapper()])
+      buildWrapper([getBaseProviderWrapper(), getRouterWrapper()])
     );
 
     expect(screen.getByText('Useful links')).toBeInTheDocument();

--- a/javascript/packages/core/components/row/__tests__/row.test.tsx
+++ b/javascript/packages/core/components/row/__tests__/row.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen } from '@testing-library/react';
 
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
 import { Row } from '../row';
 
 describe('Row', () => {
@@ -28,7 +30,8 @@ describe('Row', () => {
           { id: 'email', label: 'Email', hideEmpty: true },
         ]}
         record={{ name: 'John Doe', age: 30, email: undefined }}
-      />
+      />,
+      buildWrapper([getRouterWrapper()])
     );
     expect(screen.getByText('John Doe')).toBeInTheDocument();
     expect(screen.getByText('30')).toBeInTheDocument();
@@ -44,7 +47,8 @@ describe('Row', () => {
           { id: 'email', label: 'Email', hideEmpty: false },
         ]}
         record={{ name: 'John Doe', age: 30, email: undefined }}
-      />
+      />,
+      buildWrapper([getRouterWrapper()])
     );
     expect(screen.getByText('John Doe')).toBeInTheDocument();
     expect(screen.getByText('30')).toBeInTheDocument();
@@ -64,7 +68,10 @@ describe('Row', () => {
       },
     };
 
-    render(<Row items={[{ id: 'name', label: 'Name' }]} overrides={overrides} />);
+    render(
+      <Row items={[{ id: 'name', label: 'Name' }]} overrides={overrides} />,
+      buildWrapper([getRouterWrapper()])
+    );
     // eslint-disable-next-line testing-library/no-test-id-queries -- generic div, no accessible identity
     expect(screen.getByTestId('custom-container')).toBeInTheDocument();
   });
@@ -77,7 +84,10 @@ describe('Row', () => {
       },
     };
 
-    render(<Row items={itemsWithAccessor} record={nestedRecord} />);
+    render(
+      <Row items={itemsWithAccessor} record={nestedRecord} />,
+      buildWrapper([getRouterWrapper()])
+    );
     expect(screen.getByText('John Doe')).toBeInTheDocument();
   });
 });

--- a/javascript/packages/core/components/row/components/__tests__/row-item.test.tsx
+++ b/javascript/packages/core/components/row/components/__tests__/row-item.test.tsx
@@ -1,5 +1,8 @@
 import { render, screen } from '@testing-library/react';
 
+import { interpolate } from '#core/interpolation/interpolate';
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
 import { RowItem } from '../row-item';
 
 import type { CellRenderer } from '#core/components/cell/types';
@@ -10,7 +13,8 @@ describe('RowItem', () => {
       <RowItem
         item={{ id: 'name', label: 'Name', accessor: 'name' }}
         record={{ name: 'John Doe', age: 30 }}
-      />
+      />,
+      buildWrapper([getRouterWrapper()])
     );
 
     expect(screen.getByText('Name')).toBeInTheDocument();
@@ -27,7 +31,8 @@ describe('RowItem', () => {
         item={{ id: 'name', label: 'Name', accessor: 'name' }}
         record={{ name: 'John Doe', age: 30 }}
         CellComponent={CustomCellRenderer}
-      />
+      />,
+      buildWrapper([getRouterWrapper()])
     );
 
     expect(screen.getByText('Name')).toBeInTheDocument();
@@ -47,8 +52,26 @@ describe('RowItem', () => {
       },
     };
 
-    render(<RowItem item={itemWithAccessor} record={recordWithNestedData} />);
+    render(
+      <RowItem item={itemWithAccessor} record={recordWithNestedData} />,
+      buildWrapper([getRouterWrapper()])
+    );
 
     expect(screen.getByText('Jane Smith')).toBeInTheDocument();
+  });
+
+  it('resolves a function-interpolated url against the record and renders a link', () => {
+    const item = {
+      id: 'team',
+      label: 'Team',
+      accessor: 'team.name',
+      url: interpolate(({ row }) => (row as { team: { url: string } }).team.url),
+    };
+    const record = { team: { name: 'Michelangelo', url: 'https://example.com/team' } };
+
+    render(<RowItem item={item} record={record} />, buildWrapper([getRouterWrapper()]));
+
+    const link = screen.getByRole('link', { name: 'Michelangelo' });
+    expect(link).toHaveAttribute('href', 'https://example.com/team');
   });
 });

--- a/javascript/packages/core/components/row/components/row-item.tsx
+++ b/javascript/packages/core/components/row/components/row-item.tsx
@@ -1,6 +1,7 @@
 import { useStyletron } from 'baseui';
 
 import { DefaultCellRenderer } from '#core/components/cell/renderers/default-cell-renderer';
+import { useInterpolationResolver } from '#core/interpolation/use-interpolation-resolver';
 import { getObjectValue } from '#core/utils/object-utils';
 import { RowLabel } from './row-label';
 
@@ -13,7 +14,9 @@ export const RowItem = (props: {
   CellComponent?: CellRenderer<unknown>;
 }) => {
   const [css, theme] = useStyletron();
-  const { record, item, CellComponent = DefaultCellRenderer } = props;
+  const { record, CellComponent = DefaultCellRenderer } = props;
+  const resolver = useInterpolationResolver();
+  const item = resolver(props.item, { row: record });
 
   const value = getObjectValue(record, item.accessor ?? item.id);
   return (

--- a/javascript/packages/core/components/views/execution/components/task-details/__tests__/task-header.test.tsx
+++ b/javascript/packages/core/components/views/execution/components/task-details/__tests__/task-header.test.tsx
@@ -3,6 +3,7 @@ import { ArrowUp, Check, Delete } from 'baseui/icon';
 
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getIconProviderWrapper } from '#core/test/wrappers/get-icon-provider-wrapper';
+import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
 import { TASK_STATE } from '../../../constants';
 import { createTask } from '../__fixtures__/task-details-fixtures';
 import { TaskHeader } from '../task-header';
@@ -45,7 +46,8 @@ describe('TaskHeader', () => {
           { id: 'duration', label: 'Duration' },
           { id: 'startTime', label: 'Started' },
         ]}
-      />
+      />,
+      buildWrapper([getRouterWrapper()])
     );
 
     expect(screen.getByText('Task with Metadata')).toBeInTheDocument();
@@ -113,7 +115,8 @@ describe('TaskHeader', () => {
           { id: 'duration', label: 'Duration' },
           { id: 'startTime', label: 'Started' },
         ]}
-      />
+      />,
+      buildWrapper([getRouterWrapper()])
     );
 
     expect(screen.getByText('Incomplete Task')).toBeInTheDocument();

--- a/javascript/packages/core/components/views/execution/components/task-details/renderers/__tests__/task-body-metadata.test.tsx
+++ b/javascript/packages/core/components/views/execution/components/task-details/renderers/__tests__/task-body-metadata.test.tsx
@@ -2,6 +2,8 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { CellType } from '#core/components/cell/constants';
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
 import { TaskBodyMetadata } from '../task-body-metadata';
 
 describe('TaskBodyMetadata', () => {
@@ -22,7 +24,8 @@ describe('TaskBodyMetadata', () => {
           { id: 'duration', label: 'Duration', type: CellType.TEXT, accessor: 'duration' },
           { id: 'startTime', label: 'Started', type: CellType.DATE, accessor: 'startTime' },
         ]}
-      />
+      />,
+      buildWrapper([getRouterWrapper()])
     );
 
     const accordionButton = screen.getByRole('button', { name: /Task Metadata/ });
@@ -46,7 +49,8 @@ describe('TaskBodyMetadata', () => {
           { id: 'duration', label: 'Duration', type: CellType.TEXT, accessor: 'duration' },
           { id: 'startTime', label: 'Started', type: CellType.DATE, accessor: 'startTime' },
         ]}
-      />
+      />,
+      buildWrapper([getRouterWrapper()])
     );
 
     const accordionButton = screen.getByRole('button', { name: /Empty Metadata/ });
@@ -82,7 +86,8 @@ describe('TaskBodyMetadata', () => {
           { id: 'duration', label: 'Duration', type: CellType.TEXT, accessor: 'duration' },
           { id: 'startTime', label: 'Started', type: CellType.DATE, accessor: 'startTime' },
         ]}
-      />
+      />,
+      buildWrapper([getRouterWrapper()])
     );
 
     const accordionButton = screen.getByRole('button', { name: /Partial Metadata/ });
@@ -113,7 +118,10 @@ describe('TaskBodyMetadata', () => {
 
     const stateData = { state: 'SUCCESS' };
 
-    render(<TaskBodyMetadata label="State Metadata" value={stateData} cells={cellsWithStates} />);
+    render(
+      <TaskBodyMetadata label="State Metadata" value={stateData} cells={cellsWithStates} />,
+      buildWrapper([getRouterWrapper()])
+    );
 
     const accordionButton = screen.getByRole('button', { name: /State Metadata/ });
     await user.click(accordionButton);

--- a/javascript/packages/core/components/views/project/__tests__/project-detail.test.tsx
+++ b/javascript/packages/core/components/views/project/__tests__/project-detail.test.tsx
@@ -45,7 +45,11 @@ describe('ProjectDetail', () => {
     expect(screen.getAllByText('fraud-detection')).not.toHaveLength(0);
   });
 
-  test('renders the Owner as a link when the response is enriched with team data', async () => {
+  test('resolves the Owner field to a linked display name via a registered team resolver', async () => {
+    const resolveTeams = vi.fn().mockResolvedValue({
+      'uuid-1': { id: 'uuid-1', displayName: 'Michelangelo', url: 'https://example.com/team' },
+    });
+
     render(
       <ProjectDetail phases={[]} />,
       buildWrapper([
@@ -60,24 +64,19 @@ describe('ProjectDetail', () => {
                 metadata: { name: 'fraud-detection' },
                 spec: {
                   description: 'Detects fraudulent transactions',
-                  owner: {
-                    owningTeam: 'uuid-1',
-                    team: {
-                      id: 'uuid-1',
-                      displayName: 'Michelangelo',
-                      url: 'https://example.com/team',
-                    },
-                  },
+                  owner: { owningTeam: 'uuid-1' },
                 },
               },
             },
           }),
+          resolvers: { team: resolveTeams },
         }),
       ])
     );
 
     const link = await screen.findByRole('link', { name: 'Michelangelo' });
     expect(link).toHaveAttribute('href', 'https://example.com/team');
+    expect(resolveTeams).toHaveBeenCalledWith(['uuid-1']);
   });
 
   test('falls back to the raw owningTeam UUID as plain text when unenriched', async () => {

--- a/javascript/packages/core/components/views/project/__tests__/project-detail.test.tsx
+++ b/javascript/packages/core/components/views/project/__tests__/project-detail.test.tsx
@@ -45,6 +45,69 @@ describe('ProjectDetail', () => {
     expect(screen.getAllByText('fraud-detection')).not.toHaveLength(0);
   });
 
+  test('renders the Owner as a link when the response is enriched with team data', async () => {
+    render(
+      <ProjectDetail phases={[]} />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getErrorProviderWrapper(),
+        getIconProviderWrapper(),
+        getRouterWrapper({ location: '/fraud-detection' }),
+        getServiceProviderWrapper({
+          request: createQueryMockRouter({
+            GetProject: {
+              project: {
+                metadata: { name: 'fraud-detection' },
+                spec: {
+                  description: 'Detects fraudulent transactions',
+                  owner: {
+                    owningTeam: 'uuid-1',
+                    team: {
+                      id: 'uuid-1',
+                      displayName: 'Michelangelo',
+                      url: 'https://example.com/team',
+                    },
+                  },
+                },
+              },
+            },
+          }),
+        }),
+      ])
+    );
+
+    const link = await screen.findByRole('link', { name: 'Michelangelo' });
+    expect(link).toHaveAttribute('href', 'https://example.com/team');
+  });
+
+  test('falls back to the raw owningTeam UUID as plain text when unenriched', async () => {
+    render(
+      <ProjectDetail phases={[]} />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getErrorProviderWrapper(),
+        getIconProviderWrapper(),
+        getRouterWrapper({ location: '/fraud-detection' }),
+        getServiceProviderWrapper({
+          request: createQueryMockRouter({
+            GetProject: {
+              project: {
+                metadata: { name: 'fraud-detection' },
+                spec: {
+                  description: 'Detects fraudulent transactions',
+                  owner: { owningTeam: 'uuid-1' },
+                },
+              },
+            },
+          }),
+        }),
+      ])
+    );
+
+    expect(await screen.findByText('uuid-1')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'uuid-1' })).not.toBeInTheDocument();
+  });
+
   test('renders a source code link when gitRepo is set', async () => {
     render(
       <ProjectDetail phases={[]} />,

--- a/javascript/packages/core/components/views/project/__tests__/project-list.test.tsx
+++ b/javascript/packages/core/components/views/project/__tests__/project-list.test.tsx
@@ -48,6 +48,38 @@ test('renders project names from API response', async () => {
   expect(screen.getByText('recommendation-engine')).toBeInTheDocument();
 });
 
+test('resolves the Owner column to a linked display name via a registered team resolver', async () => {
+  const mockRequest = createQueryMockRouter({
+    ListProject: {
+      projectList: {
+        items: [
+          {
+            metadata: { name: 'fraud-detection' },
+            spec: { description: 'Detects fraud', owner: { owningTeam: 'ml-team' }, tier: 'P0' },
+          },
+        ],
+      },
+    },
+  });
+  const resolveTeams = vi.fn().mockResolvedValue({
+    'ml-team': { id: 'ml-team', displayName: 'ML Team', url: 'https://example.com/ml-team' },
+  });
+
+  render(
+    <ProjectList />,
+    buildWrapper([
+      getBaseProviderWrapper(),
+      getErrorProviderWrapper(),
+      getIconProviderWrapper(),
+      getRouterWrapper({ location: '/' }),
+      getServiceProviderWrapper({ request: mockRequest, resolvers: { team: resolveTeams } }),
+    ])
+  );
+
+  const link = await screen.findByRole('link', { name: 'ML Team' });
+  expect(link).toHaveAttribute('href', 'https://example.com/ml-team');
+});
+
 test('renders column headers when no projects exist', async () => {
   const mockRequest = createQueryMockRouter({
     ListProject: { projectList: { items: [] } },

--- a/javascript/packages/core/components/views/project/constants.ts
+++ b/javascript/packages/core/components/views/project/constants.ts
@@ -1,4 +1,12 @@
 import { CellType } from '#core/components/cell/constants';
+import { interpolate } from '#core/interpolation/interpolate';
+
+import type { ProjectOwnerData } from './types';
+
+const getOwner = (data: unknown) => {
+  // cast: accessor/interpolation callbacks receive unknown/any data; narrowing to expected proto shape for property access
+  return (data as ProjectOwnerData)?.spec?.owner;
+};
 
 export const SHARED_PROJECT_CELL_CONFIG = [
   {
@@ -14,6 +22,8 @@ export const SHARED_PROJECT_CELL_CONFIG = [
   {
     id: 'spec.owner.owningTeam',
     label: 'Owner',
+    accessor: (data: unknown) => getOwner(data)?.team?.displayName ?? getOwner(data)?.owningTeam,
+    url: interpolate(({ row }) => getOwner(row)?.team?.url),
   },
   {
     id: 'spec.tier',

--- a/javascript/packages/core/components/views/project/types.ts
+++ b/javascript/packages/core/components/views/project/types.ts
@@ -1,0 +1,8 @@
+export interface ProjectOwnerData {
+  spec?: {
+    owner?: {
+      team?: { displayName?: string; url?: string };
+      owningTeam?: string;
+    };
+  };
+}

--- a/javascript/packages/core/providers/service-provider/__tests__/service-provider.tests.tsx
+++ b/javascript/packages/core/providers/service-provider/__tests__/service-provider.tests.tsx
@@ -38,8 +38,9 @@ describe('ServiceProvider ownership enrichment', () => {
     expect(response).toEqual({ project: { spec: { owner: { owningTeam: 'uuid-1', team } } } });
   });
 
-  it('batches all owning team UUIDs into a single resolver call for ListProject', async () => {
-    const team = { id: 'uuid-1', displayName: 'Team One', url: 'https://example.com/team-1' };
+  it('batches all owning team UUIDs into a single resolver call for ListProject and assigns each project its own team', async () => {
+    const teamOne = { id: 'uuid-1', displayName: 'Team One', url: 'https://example.com/team-1' };
+    const teamTwo = { id: 'uuid-2', displayName: 'Team Two', url: 'https://example.com/team-2' };
     const request = vi.fn().mockResolvedValue({
       projectList: {
         items: [
@@ -48,7 +49,7 @@ describe('ServiceProvider ownership enrichment', () => {
         ],
       },
     });
-    const resolveTeams = vi.fn().mockResolvedValue({ 'uuid-1': team, 'uuid-2': team });
+    const resolveTeams = vi.fn().mockResolvedValue({ 'uuid-1': teamOne, 'uuid-2': teamTwo });
 
     const response = await renderRequest({
       children: null,
@@ -61,8 +62,8 @@ describe('ServiceProvider ownership enrichment', () => {
     expect(response).toEqual({
       projectList: {
         items: [
-          { spec: { owner: { owningTeam: 'uuid-1', team } } },
-          { spec: { owner: { owningTeam: 'uuid-2', team } } },
+          { spec: { owner: { owningTeam: 'uuid-1', team: teamOne } } },
+          { spec: { owner: { owningTeam: 'uuid-2', team: teamTwo } } },
         ],
       },
     });

--- a/javascript/packages/core/providers/service-provider/__tests__/service-provider.tests.tsx
+++ b/javascript/packages/core/providers/service-provider/__tests__/service-provider.tests.tsx
@@ -1,33 +1,45 @@
-import { withOwnershipEnrichment } from '../with-ownership-enrichment';
+import { renderHook } from '@testing-library/react';
 
-describe('withOwnershipEnrichment', () => {
-  it('passes through unchanged when no resolver is registered', async () => {
+import { ServiceProvider } from '../service-provider';
+import { useServiceProvider } from '../use-service-provider';
+
+function renderRequest(props: Parameters<typeof ServiceProvider>[0]) {
+  const { result } = renderHook(() => useServiceProvider(), {
+    wrapper: ({ children }) => <ServiceProvider {...props}>{children}</ServiceProvider>,
+  });
+  return result.current.request;
+}
+
+describe('ServiceProvider ownership enrichment', () => {
+  it('passes requests through unchanged when no team resolver is registered', async () => {
     const request = vi
       .fn()
       .mockResolvedValue({ project: { spec: { owner: { owningTeam: 'uuid-1' } } } });
-    const wrapped = withOwnershipEnrichment(request);
 
-    const response = await wrapped('GetProject', {});
+    const response = await renderRequest({ children: null, request })('GetProject', {});
 
     expect(response).toEqual({ project: { spec: { owner: { owningTeam: 'uuid-1' } } } });
   });
 
-  it('enriches a GetProject response with the resolved team', async () => {
-    const team = { id: 'team-1', displayName: 'Team One', url: 'https://example.com/team-1' };
+  it('enriches a GetProject response with the team resolved via a registered resolver', async () => {
+    const team = { id: 'uuid-1', displayName: 'Team One', url: 'https://example.com/team-1' };
     const request = vi
       .fn()
       .mockResolvedValue({ project: { spec: { owner: { owningTeam: 'uuid-1' } } } });
     const resolveTeams = vi.fn().mockResolvedValue({ 'uuid-1': team });
-    const wrapped = withOwnershipEnrichment(request, resolveTeams);
 
-    const response = await wrapped('GetProject', {});
+    const response = await renderRequest({
+      children: null,
+      request,
+      resolvers: { team: resolveTeams },
+    })('GetProject', {});
 
     expect(resolveTeams).toHaveBeenCalledWith(['uuid-1']);
     expect(response).toEqual({ project: { spec: { owner: { owningTeam: 'uuid-1', team } } } });
   });
 
-  it('batches all owning team UUIDs in a single resolver call for ListProject', async () => {
-    const team = { id: 'team-1', displayName: 'Team One', url: 'https://example.com/team-1' };
+  it('batches all owning team UUIDs into a single resolver call for ListProject', async () => {
+    const team = { id: 'uuid-1', displayName: 'Team One', url: 'https://example.com/team-1' };
     const request = vi.fn().mockResolvedValue({
       projectList: {
         items: [
@@ -37,9 +49,12 @@ describe('withOwnershipEnrichment', () => {
       },
     });
     const resolveTeams = vi.fn().mockResolvedValue({ 'uuid-1': team, 'uuid-2': team });
-    const wrapped = withOwnershipEnrichment(request, resolveTeams);
 
-    const response = await wrapped('ListProject', {});
+    const response = await renderRequest({
+      children: null,
+      request,
+      resolvers: { team: resolveTeams },
+    })('ListProject', {});
 
     expect(resolveTeams).toHaveBeenCalledTimes(1);
     expect(resolveTeams).toHaveBeenCalledWith(['uuid-1', 'uuid-2']);
@@ -58,21 +73,27 @@ describe('withOwnershipEnrichment', () => {
       .fn()
       .mockResolvedValue({ project: { spec: { owner: { owningTeam: 'uuid-1' } } } });
     const resolveTeams = vi.fn().mockRejectedValue(new Error('lookup failed'));
-    const wrapped = withOwnershipEnrichment(request, resolveTeams);
 
-    const response = await wrapped('GetProject', {});
+    const response = await renderRequest({
+      children: null,
+      request,
+      resolvers: { team: resolveTeams },
+    })('GetProject', {});
 
     expect(response).toEqual({ project: { spec: { owner: { owningTeam: 'uuid-1' } } } });
   });
 
-  it('leaves the raw owningTeam UUID in place when the resolver omits a UUID', async () => {
+  it('leaves the raw owningTeam UUID in place when the resolver omits it from the result', async () => {
     const request = vi
       .fn()
       .mockResolvedValue({ project: { spec: { owner: { owningTeam: 'uuid-1' } } } });
     const resolveTeams = vi.fn().mockResolvedValue({});
-    const wrapped = withOwnershipEnrichment(request, resolveTeams);
 
-    const response = await wrapped('GetProject', {});
+    const response = await renderRequest({
+      children: null,
+      request,
+      resolvers: { team: resolveTeams },
+    })('GetProject', {});
 
     expect(response).toEqual({ project: { spec: { owner: { owningTeam: 'uuid-1' } } } });
   });
@@ -80,9 +101,12 @@ describe('withOwnershipEnrichment', () => {
   it('does not enrich responses for other RPCs', async () => {
     const request = vi.fn().mockResolvedValue({ pipeline: { spec: {} } });
     const resolveTeams = vi.fn();
-    const wrapped = withOwnershipEnrichment(request, resolveTeams);
 
-    const response = await wrapped('GetPipeline', {});
+    const response = await renderRequest({
+      children: null,
+      request,
+      resolvers: { team: resolveTeams },
+    })('GetPipeline', {});
 
     expect(resolveTeams).not.toHaveBeenCalled();
     expect(response).toEqual({ pipeline: { spec: {} } });

--- a/javascript/packages/core/providers/service-provider/__tests__/with-ownership-enrichment.tests.ts
+++ b/javascript/packages/core/providers/service-provider/__tests__/with-ownership-enrichment.tests.ts
@@ -1,0 +1,90 @@
+import { withOwnershipEnrichment } from '../with-ownership-enrichment';
+
+describe('withOwnershipEnrichment', () => {
+  it('passes through unchanged when no resolver is registered', async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValue({ project: { spec: { owner: { owningTeam: 'uuid-1' } } } });
+    const wrapped = withOwnershipEnrichment(request);
+
+    const response = await wrapped('GetProject', {});
+
+    expect(response).toEqual({ project: { spec: { owner: { owningTeam: 'uuid-1' } } } });
+  });
+
+  it('enriches a GetProject response with the resolved team', async () => {
+    const team = { id: 'team-1', displayName: 'Team One', url: 'https://example.com/team-1' };
+    const request = vi
+      .fn()
+      .mockResolvedValue({ project: { spec: { owner: { owningTeam: 'uuid-1' } } } });
+    const resolveTeams = vi.fn().mockResolvedValue({ 'uuid-1': team });
+    const wrapped = withOwnershipEnrichment(request, resolveTeams);
+
+    const response = await wrapped('GetProject', {});
+
+    expect(resolveTeams).toHaveBeenCalledWith(['uuid-1']);
+    expect(response).toEqual({ project: { spec: { owner: { owningTeam: 'uuid-1', team } } } });
+  });
+
+  it('batches all owning team UUIDs in a single resolver call for ListProject', async () => {
+    const team = { id: 'team-1', displayName: 'Team One', url: 'https://example.com/team-1' };
+    const request = vi.fn().mockResolvedValue({
+      projectList: {
+        items: [
+          { spec: { owner: { owningTeam: 'uuid-1' } } },
+          { spec: { owner: { owningTeam: 'uuid-2' } } },
+        ],
+      },
+    });
+    const resolveTeams = vi.fn().mockResolvedValue({ 'uuid-1': team, 'uuid-2': team });
+    const wrapped = withOwnershipEnrichment(request, resolveTeams);
+
+    const response = await wrapped('ListProject', {});
+
+    expect(resolveTeams).toHaveBeenCalledTimes(1);
+    expect(resolveTeams).toHaveBeenCalledWith(['uuid-1', 'uuid-2']);
+    expect(response).toEqual({
+      projectList: {
+        items: [
+          { spec: { owner: { owningTeam: 'uuid-1', team } } },
+          { spec: { owner: { owningTeam: 'uuid-2', team } } },
+        ],
+      },
+    });
+  });
+
+  it('leaves the raw owningTeam UUID in place when the resolver throws', async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValue({ project: { spec: { owner: { owningTeam: 'uuid-1' } } } });
+    const resolveTeams = vi.fn().mockRejectedValue(new Error('lookup failed'));
+    const wrapped = withOwnershipEnrichment(request, resolveTeams);
+
+    const response = await wrapped('GetProject', {});
+
+    expect(response).toEqual({ project: { spec: { owner: { owningTeam: 'uuid-1' } } } });
+  });
+
+  it('leaves the raw owningTeam UUID in place when the resolver omits a UUID', async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValue({ project: { spec: { owner: { owningTeam: 'uuid-1' } } } });
+    const resolveTeams = vi.fn().mockResolvedValue({});
+    const wrapped = withOwnershipEnrichment(request, resolveTeams);
+
+    const response = await wrapped('GetProject', {});
+
+    expect(response).toEqual({ project: { spec: { owner: { owningTeam: 'uuid-1' } } } });
+  });
+
+  it('does not enrich responses for other RPCs', async () => {
+    const request = vi.fn().mockResolvedValue({ pipeline: { spec: {} } });
+    const resolveTeams = vi.fn();
+    const wrapped = withOwnershipEnrichment(request, resolveTeams);
+
+    const response = await wrapped('GetPipeline', {});
+
+    expect(resolveTeams).not.toHaveBeenCalled();
+    expect(response).toEqual({ pipeline: { spec: {} } });
+  });
+});

--- a/javascript/packages/core/providers/service-provider/service-provider.tsx
+++ b/javascript/packages/core/providers/service-provider/service-provider.tsx
@@ -1,4 +1,7 @@
+import { useMemo } from 'react';
+
 import { ServiceContext } from './service-context';
+import { withOwnershipEnrichment } from './with-ownership-enrichment';
 
 import type { ServiceContextType } from './types';
 
@@ -19,7 +22,13 @@ import type { ServiceContextType } from './types';
  */
 export const ServiceProvider = ({
   children,
-  ...serviceContext
+  request,
+  resolvers,
 }: { children: React.ReactNode } & ServiceContextType) => {
-  return <ServiceContext.Provider value={serviceContext}>{children}</ServiceContext.Provider>;
+  const value = useMemo(
+    () => ({ request: withOwnershipEnrichment(request, resolvers?.team), resolvers }),
+    [request, resolvers]
+  );
+
+  return <ServiceContext.Provider value={value}>{children}</ServiceContext.Provider>;
 };

--- a/javascript/packages/core/providers/service-provider/types.ts
+++ b/javascript/packages/core/providers/service-provider/types.ts
@@ -1,3 +1,9 @@
+export interface TeamInfo {
+  id: string;
+  displayName: string;
+  url: string;
+}
+
 /**
  * @description
  * The service context provided to the application to connect to the services injected
@@ -9,4 +15,28 @@
  */
 export type ServiceContextType = {
   request: (requestId: string, args: unknown, headers?: Record<string, string>) => Promise<unknown>;
+  /**
+   * Resolvers the RPC layer applies to enrich responses before consumers see them, keyed by
+   * concern. `team` is the first user of this pattern (owner UUID -> display info); it's
+   * designed so a future resolver (e.g. proto `Any` unpacking, or hydrating a resource
+   * reference like a model revision) can be added as another optional key here without a
+   * breaking change.
+   */
+  resolvers?: {
+    team?: (uuids: string[]) => Promise<Record<string, TeamInfo>>;
+  };
 };
+
+export interface ProjectWithOwner {
+  spec?: {
+    owner?: {
+      owningTeam?: string;
+      team?: TeamInfo;
+    };
+  };
+}
+
+export interface ProjectResponse {
+  project?: ProjectWithOwner;
+  projectList?: { items?: ProjectWithOwner[] };
+}

--- a/javascript/packages/core/providers/service-provider/types.ts
+++ b/javascript/packages/core/providers/service-provider/types.ts
@@ -1,9 +1,3 @@
-export interface TeamInfo {
-  id: string;
-  displayName: string;
-  url: string;
-}
-
 /**
  * @description
  * The service context provided to the application to connect to the services injected
@@ -15,17 +9,17 @@ export interface TeamInfo {
  */
 export type ServiceContextType = {
   request: (requestId: string, args: unknown, headers?: Record<string, string>) => Promise<unknown>;
-  /**
-   * Resolvers the RPC layer applies to enrich responses before consumers see them, keyed by
-   * concern. `team` is the first user of this pattern (owner UUID -> display info); it's
-   * designed so a future resolver (e.g. proto `Any` unpacking, or hydrating a resource
-   * reference like a model revision) can be added as another optional key here without a
-   * breaking change.
-   */
+  /** Resolvers the RPC layer applies to enrich responses before consumers see them, keyed by concern. */
   resolvers?: {
     team?: (uuids: string[]) => Promise<Record<string, TeamInfo>>;
   };
 };
+
+export interface TeamInfo {
+  id: string;
+  displayName: string;
+  url: string;
+}
 
 export interface ProjectWithOwner {
   spec?: {

--- a/javascript/packages/core/providers/service-provider/with-ownership-enrichment.ts
+++ b/javascript/packages/core/providers/service-provider/with-ownership-enrichment.ts
@@ -1,24 +1,5 @@
 import type { ProjectResponse, ProjectWithOwner, ServiceContextType, TeamInfo } from './types';
 
-function collectOwningTeamUuids(projects: ProjectWithOwner[]): string[] {
-  const uuids = new Set<string>();
-  for (const project of projects) {
-    const uuid = project.spec?.owner?.owningTeam;
-    if (uuid) uuids.add(uuid);
-  }
-  return [...uuids];
-}
-
-function applyTeams(projects: ProjectWithOwner[], teams: Record<string, TeamInfo>) {
-  for (const project of projects) {
-    const uuid = project.spec?.owner?.owningTeam;
-    const team = uuid ? teams[uuid] : undefined;
-    if (team && project.spec?.owner) {
-      project.spec.owner.team = team;
-    }
-  }
-}
-
 /**
  * Wraps a `request` function to enrich GetProject/ListProject responses with team display
  * info, resolved from owner UUIDs via `resolveTeams`. On resolver failure or a UUID missing
@@ -50,4 +31,23 @@ export function withOwnershipEnrichment(
 
     return response;
   };
+}
+
+function collectOwningTeamUuids(projects: ProjectWithOwner[]): string[] {
+  const uuids = new Set<string>();
+  for (const project of projects) {
+    const uuid = project.spec?.owner?.owningTeam;
+    if (uuid) uuids.add(uuid);
+  }
+  return [...uuids];
+}
+
+function applyTeams(projects: ProjectWithOwner[], teams: Record<string, TeamInfo>) {
+  for (const project of projects) {
+    const uuid = project.spec?.owner?.owningTeam;
+    const team = uuid ? teams[uuid] : undefined;
+    if (team && project.spec?.owner) {
+      project.spec.owner.team = team;
+    }
+  }
 }

--- a/javascript/packages/core/providers/service-provider/with-ownership-enrichment.ts
+++ b/javascript/packages/core/providers/service-provider/with-ownership-enrichment.ts
@@ -1,0 +1,53 @@
+import type { ProjectResponse, ProjectWithOwner, ServiceContextType, TeamInfo } from './types';
+
+function collectOwningTeamUuids(projects: ProjectWithOwner[]): string[] {
+  const uuids = new Set<string>();
+  for (const project of projects) {
+    const uuid = project.spec?.owner?.owningTeam;
+    if (uuid) uuids.add(uuid);
+  }
+  return [...uuids];
+}
+
+function applyTeams(projects: ProjectWithOwner[], teams: Record<string, TeamInfo>) {
+  for (const project of projects) {
+    const uuid = project.spec?.owner?.owningTeam;
+    const team = uuid ? teams[uuid] : undefined;
+    if (team && project.spec?.owner) {
+      project.spec.owner.team = team;
+    }
+  }
+}
+
+/**
+ * Wraps a `request` function to enrich GetProject/ListProject responses with team display
+ * info, resolved from owner UUIDs via `resolveTeams`. On resolver failure or a UUID missing
+ * from the resolved map, the project is left with its raw `owningTeam` UUID, which the
+ * Owner column already falls back to displaying.
+ */
+export function withOwnershipEnrichment(
+  request: ServiceContextType['request'],
+  resolveTeams?: (uuids: string[]) => Promise<Record<string, TeamInfo>>
+): ServiceContextType['request'] {
+  if (!resolveTeams) return request;
+
+  return async (requestId, args, headers) => {
+    // cast: request's response type is unknown at this layer; narrowing to the minimal
+    // project shape needed to enrich the owner field
+    const response = (await request(requestId, args, headers)) as ProjectResponse;
+
+    try {
+      if (requestId === 'GetProject' && response?.project) {
+        const teams = await resolveTeams(collectOwningTeamUuids([response.project]));
+        applyTeams([response.project], teams);
+      } else if (requestId === 'ListProject' && response?.projectList?.items) {
+        const teams = await resolveTeams(collectOwningTeamUuids(response.projectList.items));
+        applyTeams(response.projectList.items, teams);
+      }
+    } catch {
+      // Enrichment is best-effort; leave the raw owningTeam UUID in place on failure.
+    }
+
+    return response;
+  };
+}


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

`ServiceProvider` now accepts an optional `resolvers.team` callback that batch-resolves owner UUIDs to display name/link info, and applies it automatically to `GetProject`/`ListProject` responses via a new `withOwnershipEnrichment` wrapper. Apps register the resolver once through `dependencies.service.resolvers` — no more hand-wrapping `request()` to intercept and mutate responses.

`javascript/app` wires a fake "Michelangelo" team resolver for the sandbox demo, replacing the old `ownership-demo.ts` interception shim (deleted).

Also fixed a bug found while wiring up the demo: the project detail view's Owner field wasn't rendering as a link, even though the identical column config worked in the project list table. `RowItem` was passing `interpolate()`-wrapped column config (e.g. `url: interpolate(fn)`) straight to the cell renderer without resolving it first — `TableCell` already did this resolution, `RowItem` didn't. Fixed by resolving the column against the record in `RowItem` the same way `TableCell` does.

**Why?**

Projects store their owning team as a UUID. Deployers need a way to resolve that UUID into a human-readable name and link without forking `packages/core` or hand-rolling response interception in their app shell — every deployer would otherwise have to write the same interception boilerplate.

**How did you test it?**

https://github.com/user-attachments/assets/3a54e1c9-e405-46b3-924e-05db4126c134

<!-- Does this PR introduce a breaking change? Check all that apply. -->
**Breaking Changes**

- [x] No breaking changes

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

Adds a pluggable `dependencies.service.resolvers.team` hook for resolving project owner UUIDs to display names/links. Optional — no behavior change for apps that don't register it.

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**

None.
