### PR TITLE
fix(python): ModelPusherPlugin downloads remote artifact URIs before upload

### DIFF
--- a/python/michelangelo/workflow/tasks/pusher/plugins/model_plugin.py
+++ b/python/michelangelo/workflow/tasks/pusher/plugins/model_plugin.py
@@ -90,7 +90,6 @@ from __future__ import annotations
 
 import logging
 import os
-import shutil
 import tempfile
 import uuid
 from pathlib import Path
@@ -423,8 +422,7 @@ class ModelPusherPlugin(PusherPluginBase):
         base_labels = self._build_labels()
         base_metadata = self._build_metadata()
 
-        tmp_root = tempfile.mkdtemp(prefix="model_pusher_")
-        try:
+        with tempfile.TemporaryDirectory(prefix="model_pusher_") as tmp_root:
             _logger.info(
                 "Uploading raw model artifact for '%s' (push %s).", model_name, push_id
             )
@@ -451,8 +449,6 @@ class ModelPusherPlugin(PusherPluginBase):
                     f"models/{model_name}/{push_id}/deployable/"
                     f"{Path(deployable_local_path).name}",
                 )
-        finally:
-            shutil.rmtree(tmp_root, ignore_errors=True)
 
         registrations: list[RegistrationResult] = []
         for registry in self._registries:

--- a/python/michelangelo/workflow/tasks/pusher/plugins/model_plugin.py
+++ b/python/michelangelo/workflow/tasks/pusher/plugins/model_plugin.py
@@ -500,21 +500,10 @@ class ModelPusherPlugin(PusherPluginBase):
     def _ensure_local(self, path: str, tmp_root: str, name: str) -> str:
         """Return a local filesystem path for ``path``.
 
-        ``AssembledModel.raw_model.path``/``deployable_model.path`` may
-        already be a local path (e.g. the ``ModelPusherPlugin`` docstring's
-        own toy example) or a URI from a prior ``upload()`` on some other
-        ``StorageBackend`` instance (e.g. ``torch_assembler()`` uploads its
-        packaged artifacts before handing off an ``AssembledModel``, so
-        ``self._storage_backend.upload()`` -- which requires an actual local
-        path -- can't be called on it directly). Download it into ``tmp_root``
-        first when it's a URI; ``self._storage_backend.download()`` creates a
-        directory or copies a file as appropriate for the source artifact, so
-        the caller doesn't need to know which in advance.
-
-        A URI is detected by the presence of a ``scheme://`` prefix (e.g.
-        ``s3://``), not by checking whether the path exists on disk -- a
-        genuinely local path may not exist yet at this point in tests using a
-        mocked backend, and must still be passed through unchanged.
+        ``path`` may already be local, or a URI from a prior upload to some
+        other ``StorageBackend``. A URI (detected via a ``scheme://`` prefix,
+        not by checking disk existence) is downloaded into ``tmp_root``
+        first; a local path is returned unchanged.
 
         Args:
             path: Local path or storage-backend URI to resolve.

--- a/python/michelangelo/workflow/tasks/pusher/plugins/model_plugin.py
+++ b/python/michelangelo/workflow/tasks/pusher/plugins/model_plugin.py
@@ -89,6 +89,9 @@ To implement a custom registry, subclass ``ModelRegistryClient``::
 from __future__ import annotations
 
 import logging
+import os
+import shutil
+import tempfile
 import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypedDict
@@ -420,23 +423,36 @@ class ModelPusherPlugin(PusherPluginBase):
         base_labels = self._build_labels()
         base_metadata = self._build_metadata()
 
-        _logger.info(
-            "Uploading raw model artifact for '%s' (push %s).", model_name, push_id
-        )
-        raw_uri = self._storage_backend.upload(
-            self._artifact.raw_model.path,
-            f"models/{model_name}/{push_id}/raw/{Path(self._artifact.raw_model.path).name}",
-        )
-
-        deployable_uri: str | None = None
-        if self._artifact.deployable_model is not None:
+        tmp_root = tempfile.mkdtemp(prefix="model_pusher_")
+        try:
             _logger.info(
-                "Uploading deployable artifact for '%s' (push %s).", model_name, push_id
+                "Uploading raw model artifact for '%s' (push %s).", model_name, push_id
             )
-            deployable_uri = self._storage_backend.upload(
-                self._artifact.deployable_model.path,
-                f"models/{model_name}/{push_id}/deployable/{Path(self._artifact.deployable_model.path).name}",
+            raw_local_path = self._ensure_local(
+                self._artifact.raw_model.path, tmp_root, "raw"
             )
+            raw_uri = self._storage_backend.upload(
+                raw_local_path,
+                f"models/{model_name}/{push_id}/raw/{Path(raw_local_path).name}",
+            )
+
+            deployable_uri: str | None = None
+            if self._artifact.deployable_model is not None:
+                _logger.info(
+                    "Uploading deployable artifact for '%s' (push %s).",
+                    model_name,
+                    push_id,
+                )
+                deployable_local_path = self._ensure_local(
+                    self._artifact.deployable_model.path, tmp_root, "deployable"
+                )
+                deployable_uri = self._storage_backend.upload(
+                    deployable_local_path,
+                    f"models/{model_name}/{push_id}/deployable/"
+                    f"{Path(deployable_local_path).name}",
+                )
+        finally:
+            shutil.rmtree(tmp_root, ignore_errors=True)
 
         registrations: list[RegistrationResult] = []
         for registry in self._registries:
@@ -484,6 +500,39 @@ class ModelPusherPlugin(PusherPluginBase):
             push_id=push_id,
             registrations=registrations,
         )
+
+    def _ensure_local(self, path: str, tmp_root: str, name: str) -> str:
+        """Return a local filesystem path for ``path``.
+
+        ``AssembledModel.raw_model.path``/``deployable_model.path`` may
+        already be a local path (e.g. the ``ModelPusherPlugin`` docstring's
+        own toy example) or a URI from a prior ``upload()`` on some other
+        ``StorageBackend`` instance (e.g. ``torch_assembler()`` uploads its
+        packaged artifacts before handing off an ``AssembledModel``, so
+        ``self._storage_backend.upload()`` -- which requires an actual local
+        path -- can't be called on it directly). Download it into ``tmp_root``
+        first when it's a URI; ``self._storage_backend.download()`` creates a
+        directory or copies a file as appropriate for the source artifact, so
+        the caller doesn't need to know which in advance.
+
+        A URI is detected by the presence of a ``scheme://`` prefix (e.g.
+        ``s3://``), not by checking whether the path exists on disk -- a
+        genuinely local path may not exist yet at this point in tests using a
+        mocked backend, and must still be passed through unchanged.
+
+        Args:
+            path: Local path or storage-backend URI to resolve.
+            tmp_root: Existing local directory to download into, if needed.
+            name: Filename/dirname to use under ``tmp_root`` for the download.
+
+        Returns:
+            A local filesystem path pointing at the artifact.
+        """
+        if "://" not in path:
+            return path
+        local_path = os.path.join(tmp_root, name)
+        self._storage_backend.download(path, local_path)
+        return local_path
 
     def _build_labels(self) -> dict[str, str]:
         """Build the indexed labels dict from artifact metadata and config labels.

--- a/python/michelangelo/workflow/tasks/pusher/tests/plugins/test_model_plugin.py
+++ b/python/michelangelo/workflow/tasks/pusher/tests/plugins/test_model_plugin.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import itertools
+import os
 import re
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
@@ -149,6 +150,59 @@ class TestModelPusherPluginExecute(TestCase):
         self.assertIn("deployable_artifact_uri", result)
         self.assertIn("push_id", result)
         self.assertIn("registrations", result)
+
+    def test_remote_artifact_uri_downloaded_before_upload(self):
+        """A URI artifact.path (e.g. from torch_assembler's own prior upload)
+        is downloaded to a local path before being handed to upload() --
+        upload() requires an actual local filesystem path, so passing a
+        remote URI straight through raises inside the backend. The temp
+        download is cleaned up after execute() returns, so existence is
+        checked from within the upload() call itself, not afterward."""
+        backend = _mock_backend()
+        artifact = AssembledModel(
+            raw_model=ModelArtifact(path="s3://bucket/tabular_assembler/x/raw"),
+            deployable_model=ModelArtifact(
+                path="s3://bucket/tabular_assembler/x/deployable"
+            ),
+        )
+
+        def _fake_download(uri, local_path):
+            with open(local_path, "w") as f:
+                f.write("fake artifact content")
+
+        backend.download.side_effect = _fake_download
+
+        upload_time_existence = []
+
+        def _fake_upload(local_path, destination_key):
+            upload_time_existence.append(os.path.isfile(local_path))
+            return f"s3://uploaded/{destination_key}"
+
+        backend.upload.side_effect = _fake_upload
+
+        _plugin(artifact=artifact, backend=backend).execute()
+
+        self.assertEqual(backend.download.call_count, 2)
+        raw_local_path = backend.upload.call_args_list[0][0][0]
+        dep_local_path = backend.upload.call_args_list[1][0][0]
+        self.assertNotEqual(raw_local_path, "s3://bucket/tabular_assembler/x/raw")
+        self.assertNotEqual(
+            dep_local_path, "s3://bucket/tabular_assembler/x/deployable"
+        )
+        self.assertEqual(upload_time_existence, [True, True])
+
+    def test_local_artifact_path_uploaded_directly_without_download(self):
+        """A plain local path (no URI scheme) is passed straight to upload(),
+        even if it doesn't exist yet (e.g. in tests with a mocked backend) --
+        only a `scheme://` prefix triggers the download-first path."""
+        backend = _mock_backend()
+        artifact = _assembled()
+
+        _plugin(artifact=artifact, backend=backend).execute()
+
+        self.assertEqual(backend.download.call_count, 0)
+        raw_local_path = backend.upload.call_args_list[0][0][0]
+        self.assertEqual(raw_local_path, artifact.raw_model.path)
 
     def test_uses_config_model_name(self):
         """It registers the model under the name set in ModelPluginConfig."""

--- a/python/michelangelo/workflow/tasks/pusher/tests/plugins/test_model_plugin.py
+++ b/python/michelangelo/workflow/tasks/pusher/tests/plugins/test_model_plugin.py
@@ -152,12 +152,14 @@ class TestModelPusherPluginExecute(TestCase):
         self.assertIn("registrations", result)
 
     def test_remote_artifact_uri_downloaded_before_upload(self):
-        """A URI artifact.path (e.g. from torch_assembler's own prior upload)
-        is downloaded to a local path before being handed to upload() --
-        upload() requires an actual local filesystem path, so passing a
-        remote URI straight through raises inside the backend. The temp
-        download is cleaned up after execute() returns, so existence is
-        checked from within the upload() call itself, not afterward."""
+        """A URI artifact.path is downloaded before being uploaded.
+
+        e.g. from torch_assembler's own prior upload -- upload() requires an
+        actual local filesystem path, so passing a remote URI straight
+        through raises inside the backend. The temp download is cleaned up
+        after execute() returns, so existence is checked from within the
+        upload() call itself, not afterward.
+        """
         backend = _mock_backend()
         artifact = AssembledModel(
             raw_model=ModelArtifact(path="s3://bucket/tabular_assembler/x/raw"),
@@ -192,9 +194,12 @@ class TestModelPusherPluginExecute(TestCase):
         self.assertEqual(upload_time_existence, [True, True])
 
     def test_local_artifact_path_uploaded_directly_without_download(self):
-        """A plain local path (no URI scheme) is passed straight to upload(),
-        even if it doesn't exist yet (e.g. in tests with a mocked backend) --
-        only a `scheme://` prefix triggers the download-first path."""
+        """A plain local path is passed straight to upload() without download.
+
+        No URI scheme means it's used as-is, even if it doesn't exist yet
+        (e.g. in tests with a mocked backend) -- only a `scheme://` prefix
+        triggers the download-first path.
+        """
         backend = _mock_backend()
         artifact = _assembled()
 

--- a/python/michelangelo/workflow/tasks/pusher/tests/plugins/test_model_plugin.py
+++ b/python/michelangelo/workflow/tasks/pusher/tests/plugins/test_model_plugin.py
@@ -152,13 +152,10 @@ class TestModelPusherPluginExecute(TestCase):
         self.assertIn("registrations", result)
 
     def test_remote_artifact_uri_downloaded_before_upload(self):
-        """A URI artifact.path is downloaded before being uploaded.
+        """A URI artifact.path is downloaded to a local path before upload().
 
-        e.g. from torch_assembler's own prior upload -- upload() requires an
-        actual local filesystem path, so passing a remote URI straight
-        through raises inside the backend. The temp download is cleaned up
-        after execute() returns, so existence is checked from within the
-        upload() call itself, not afterward.
+        The temp download is cleaned up after execute() returns, so
+        existence is checked from within the upload() call itself.
         """
         backend = _mock_backend()
         artifact = AssembledModel(
@@ -194,12 +191,7 @@ class TestModelPusherPluginExecute(TestCase):
         self.assertEqual(upload_time_existence, [True, True])
 
     def test_local_artifact_path_uploaded_directly_without_download(self):
-        """A plain local path is passed straight to upload() without download.
-
-        No URI scheme means it's used as-is, even if it doesn't exist yet
-        (e.g. in tests with a mocked backend) -- only a `scheme://` prefix
-        triggers the download-first path.
-        """
+        """A plain local path is passed straight to upload() without download."""
         backend = _mock_backend()
         artifact = _assembled()
 


### PR DESCRIPTION
**TL;DR:** `ModelPusherPlugin` assumed model artifacts were always local files; `torch_assembler()` actually uploads them to S3 first, so the pusher crashed trying to `os.stat()` a remote URI. Fixed by downloading remote artifacts to a local temp path before upload.

## Summary

Split out of #1934 for isolated review — this fix is independent of that PR's schema-validation change; it just happened to be found in the same end-to-end sandbox verification (wiring the OSS assembler into the California Housing pipeline surfaces it as the very next blocker once the assembler itself succeeds).

`ModelPusherPlugin.execute()` assumed `AssembledModel.raw_model.path`/`deployable_model.path` were always local filesystem paths and passed them straight to `storage_backend.upload()`. But `torch_assembler()` uploads its packaged artifacts before returning — necessary since `assembler` and `push_step` run as separate distributed tasks with no shared filesystem — so those paths are already remote URIs (e.g. `s3://...`) by the time the pusher sees them. `MinioStorageBackend.upload()`'s underlying `os.stat()` call then raised `FileNotFoundError`.

- Added `ModelPusherPlugin._ensure_local()`: downloads a `scheme://`-prefixed URI to a local temp path first; a plain local path (no `://`) is passed through unchanged.
- Wrapped the raw/deployable upload section in `with tempfile.TemporaryDirectory() as tmp_root:` so downloaded temp copies are cleaned up after `execute()` returns — matches the dominant internal convention for scoped temp-dir cleanup (including internal's own pusher-equivalent), rather than a manual `mkdtemp()`/`try`-`finally`/`rmtree()`.
- This mirrors the same download-then-upload pattern `assembler.py` (in `michelangelo-examples`) already uses one hop earlier for `train`'s output.

## Test plan
- [x] `pytest michelangelo/workflow/tasks/pusher/` — all 124 tests passing, including two new regression tests: `test_remote_artifact_uri_downloaded_before_upload` and `test_local_artifact_path_uploaded_directly_without_download`.
- [x] Verified as part of a full green end-to-end sandbox run of the California Housing pipeline on this PR's final code (`TemporaryDirectory`-based cleanup) combined with #1934's final code (`feature_prep` -> `preprocess` -> `train` -> `assembler` -> `push_step`, using michelangelo-ai/michelangelo-examples#36): run `run-20260827-033805-ad974087` `SUCCEEDED`, model `model-20260827-034145-8cdd3aec` registered, both raw and deployable Triton packages uploaded — see #1934 for the companion schema-validation fix that unblocks the same pipeline one step earlier.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


