### PR TITLE
ci: bump Trivy to v0.74.0 in CVE Scan workflow

### DIFF
--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -36,7 +36,7 @@ jobs:
           output: trivy-${{ matrix.service }}.sarif
           severity: CRITICAL,HIGH
           exit-code: '1'
-          version: v0.72.0
+          version: v0.74.0
 
       - name: Upload SARIF to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
@@ -53,7 +53,7 @@ jobs:
           format: table
           severity: CRITICAL,HIGH
           exit-code: '0'
-          version: v0.72.0
+          version: v0.74.0
 
       - name: Upload Trivy SARIF report as artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- The `CVE Scan` workflow pins `aquasecurity/trivy-action`'s `version` input to `v0.72.0`. Trivy itself flags this as stale in every run's output: "Version 0.74.0 of Trivy is now available, current version is 0.72.0".
- Bumps both occurrences (the SARIF-producing scan step and the table-output summary step) to `v0.74.0`.

Partial follow-up to #1949 — this addresses the tool-version staleness noted in that investigation. It does not address the underlying CRITICAL/HIGH CVE findings themselves (stale Go toolchain, base-image OS packages) or the trigger-cadence noise, both tracked separately in that issue.

## Test plan
- [ ] CI runs the (unrelated) required checks for this repo.
- [ ] Manually trigger `CVE Scan` via `workflow_dispatch` after merge and confirm it runs successfully against Trivy v0.74.0 with no change in behavior other than the newer scanner version.