### PR TITLE
ci: run CVE Scan on schedule only, not on every main-branch release

### DIFF
--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -1,10 +1,6 @@
 name: CVE Scan
 
 on:
-  workflow_run:
-    workflows: ["Dev Release", "UI Release", "Nightly Build"]
-    types: [completed]
-    branches: [main]
   schedule:
     - cron: '0 6 * * 1'
   workflow_dispatch:
@@ -21,7 +17,6 @@ env:
 jobs:
   scan:
     runs-on: ubuntu-24.04
-    if: github.event.workflow_run.conclusion == 'success' || github.event_name != 'workflow_run'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- `CVE Scan` currently triggers via `workflow_run` after **Dev Release** and **UI Release** complete, both of which fire on `push: branches: [main]` — i.e. on essentially every PR merge to `main` — plus once nightly via **Nightly Build**, plus its own weekly `schedule` cron.
- Since Dev Release / UI Release / Nightly Build all publish to the same mutable `:latest` tag, most of these `workflow_run`-triggered scans re-check image content that didn't meaningfully change, and re-fire the same Slack failure notification (`notify-on-failure`) for a CVE condition that won't clear until someone actually patches the underlying image/toolchain — see #1949 for the current findings.
- This PR drops the `workflow_run` triggers so `CVE Scan` runs on its `schedule` (weekly) and `workflow_dispatch` only. Also removes the now-always-true `if: github.event.workflow_run.conclusion == 'success' || github.event_name != 'workflow_run'` guard on the `scan` job, since there's no longer a `workflow_run` event to guard against.

Trade-off: this trades "detect a new CVE as soon as a release publishes" for a large reduction in duplicate Slack noise. Anyone can still get an on-demand scan via `workflow_dispatch`.

Partial follow-up to #1949 — addresses the trigger-cadence noise specifically (fix option 5 in that issue), not the underlying CVE findings, which need separate follow-up work.

## Test plan
- [ ] CI runs the (unrelated) required checks for this repo.
- [ ] Manually trigger `CVE Scan` via `workflow_dispatch` after merge and confirm it still runs the full `scan` matrix successfully.
- [ ] Confirm (over the following week) that `CVE Scan` no longer appears in the Actions history triggered by a `workflow_run` event, only by `schedule`/`workflow_dispatch`.