### PR TITLE
ci: pin base images by digest and track them via Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,3 +65,11 @@ updates:
     groups:
       website-minor-and-patch:
         update-types: ["minor", "patch"]
+
+  - package-ecosystem: "docker"
+    directory: "/docker"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(docker)"

--- a/docker/service.Dockerfile
+++ b/docker/service.Dockerfile
@@ -1,7 +1,10 @@
 # Dockerfile for Michelangelo services.
 
 # Distroless: https://github.com/GoogleContainerTools/distroless
-FROM gcr.io/distroless/base-debian12
+# Pinned by digest (rather than the floating `latest` tag) so Dependabot can
+# track and propose base-image updates -- see .github/dependabot.yml's
+# "docker" entry.
+FROM gcr.io/distroless/base-debian12:latest@sha256:fabbf1c0c357a3d42550111351daed089b20a2c954df13ee2fcff60602515e84
 
 # Path to the service binary built by the BAZEL_TARGET.
 # The path must be relative to the repository root.

--- a/docker/ui-prebuilt.Dockerfile
+++ b/docker/ui-prebuilt.Dockerfile
@@ -1,5 +1,8 @@
 # Simple UI Dockerfile - expects pre-built assets
-FROM nginx:alpine
+# Pinned by digest (rather than the floating `alpine` tag) so Dependabot can
+# track and propose base-image updates -- see .github/dependabot.yml's
+# "docker" entry.
+FROM nginx:alpine@sha256:db35bfc6b2951e7f8a72db5db120288c127ffaeeb4a6d4b95a26fead017d5913
 
 # Copy pre-built UI assets
 COPY javascript/app/dist /usr/share/nginx/html

--- a/docker/ui.Dockerfile
+++ b/docker/ui.Dockerfile
@@ -26,7 +26,10 @@ RUN yarn setup
 RUN yarn workspace @michelangelo/app build
 
 # Production image
-FROM nginx:alpine
+# Pinned by digest (rather than the floating `alpine` tag) so Dependabot can
+# track and propose base-image updates -- see .github/dependabot.yml's
+# "docker" entry.
+FROM nginx:alpine@sha256:db35bfc6b2951e7f8a72db5db120288c127ffaeeb4a6d4b95a26fead017d5913
 
 # Copy built app to nginx
 COPY --from=builder /workspace/javascript/app/dist /usr/share/nginx/html


### PR DESCRIPTION
## Summary
- `docker/service.Dockerfile` and `docker/ui.Dockerfile`/`docker/ui-prebuilt.Dockerfile` pulled `gcr.io/distroless/base-debian12` and `nginx:alpine` as floating tags with no digest pin — so each build silently picked up whatever those tags resolved to at build time, and Dependabot's `docker` ecosystem (which needs a pinned reference to diff against) had nothing to track. `.github/dependabot.yml` also had no `docker` entry at all, so nothing was watching these Dockerfiles either way.
- Pins both images to their current digest (`image:tag@sha256:...`), making builds reproducible.
- Adds a `docker` package-ecosystem entry for `/docker` to `dependabot.yml` so future base-image updates show up as routine PRs instead of only surfacing via a red CVE-scan investigation.

Partial follow-up to #1949 — addresses root cause #1's OS-level (glibc/openssl) CVE cluster by giving it an update path going forward. It does **not** retroactively clear the CVEs already present in the currently-pinned digests (some of the glibc ones are old and marked will-not-fix upstream — those need a `.trivyignore` with justification, not a base-image bump), and it does not touch the separate Go-toolchain-CVE cluster from #1949, which needs a `go.mod` version bump rather than a Dockerfile change.

## Test plan
- [ ] CI runs the (unrelated) required checks for this repo.
- [ ] Confirm `docker build -f docker/service.Dockerfile ...` and the UI image build still succeed with the pinned digests.
- [ ] After merge, confirm Dependabot opens its first `docker` PR on the next weekly run (or trigger a manual Dependabot check) to validate the new ecosystem entry is picked up correctly.