### PR TITLE
fea(ui): Add online/offline type option

### DIFF
--- a/javascript/packages/core/config/entities/deployment/__tests__/create-deployment-form.test.tsx
+++ b/javascript/packages/core/config/entities/deployment/__tests__/create-deployment-form.test.tsx
@@ -45,9 +45,13 @@ describe('CreateDeploymentForm', () => {
   it('submits the deployment with the entered data', async () => {
     const user = userEvent.setup();
     const mockRequest = createQueryMockRouter({
-      ListInferenceServer: { inferenceServerList: { items: [{ metadata: { name: 'triton-server' } }] } },
+      ListInferenceServer: {
+        inferenceServerList: { items: [{ metadata: { name: 'triton-server' } }] },
+      },
       ListModelFamily: {
-        modelFamilyList: { items: [{ metadata: { name: 'family-1' }, spec: { name: 'Family One' } }] },
+        modelFamilyList: {
+          items: [{ metadata: { name: 'family-1' }, spec: { name: 'Family One' } }],
+        },
       },
       ListModel: { modelList: { items: [{ metadata: { name: 'model-1' } }] } },
       CreateDeployment: {},

--- a/javascript/packages/core/config/entities/deployment/__tests__/create-deployment-form.test.tsx
+++ b/javascript/packages/core/config/entities/deployment/__tests__/create-deployment-form.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { CreateDeploymentForm } from '#core/config/entities/deployment/create-deployment-form';
+import { buildWrapper } from '#core/test/wrappers/build-wrapper';
+import { getBaseProviderWrapper } from '#core/test/wrappers/get-base-provider-wrapper';
+import { getErrorProviderWrapper } from '#core/test/wrappers/get-error-provider-wrapper';
+import { getIconProviderWrapper } from '#core/test/wrappers/get-icon-provider-wrapper';
+import { getInterpolationProviderWrapper } from '#core/test/wrappers/get-interpolation-provider-wrapper';
+import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
+import {
+  createQueryMockRouter,
+  getServiceProviderWrapper,
+} from '#core/test/wrappers/get-service-provider-wrapper';
+
+describe('CreateDeploymentForm', () => {
+  it('defaults "Type of deployment" to Online and does not allow switching it', async () => {
+    render(
+      <CreateDeploymentForm onClose={() => undefined} />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getErrorProviderWrapper(),
+        getInterpolationProviderWrapper(),
+        getRouterWrapper({ location: '/ma-dev-test/deploy/deployments' }),
+        getServiceProviderWrapper({
+          request: createQueryMockRouter({
+            ListInferenceServer: { inferenceServerList: { items: [] } },
+          }),
+        }),
+      ])
+    );
+
+    await screen.findByRole('dialog', { name: 'Create deployment' });
+
+    const onlineRadio = screen.getByRole('radio', { name: 'Online' });
+    const offlineRadio = screen.getByRole('radio', { name: 'Offline' });
+
+    expect(onlineRadio).toBeChecked();
+    expect(onlineRadio).toBeDisabled();
+    expect(offlineRadio).not.toBeChecked();
+    expect(offlineRadio).toBeDisabled();
+  });
+
+  it('submits the deployment with the entered data', async () => {
+    const user = userEvent.setup();
+    const mockRequest = createQueryMockRouter({
+      ListInferenceServer: { inferenceServerList: { items: [{ metadata: { name: 'triton-server' } }] } },
+      ListModelFamily: {
+        modelFamilyList: { items: [{ metadata: { name: 'family-1' }, spec: { name: 'Family One' } }] },
+      },
+      ListModel: { modelList: { items: [{ metadata: { name: 'model-1' } }] } },
+      CreateDeployment: {},
+    });
+
+    render(
+      <CreateDeploymentForm onClose={() => undefined} />,
+      buildWrapper([
+        getBaseProviderWrapper(),
+        getIconProviderWrapper(),
+        getErrorProviderWrapper(),
+        getInterpolationProviderWrapper(),
+        getRouterWrapper({ location: '/ma-dev-test/deploy/deployments' }),
+        getServiceProviderWrapper({ request: mockRequest }),
+      ])
+    );
+
+    const dialog = await screen.findByRole('dialog', { name: 'Create deployment' });
+
+    await user.type(within(dialog).getByRole('textbox', { name: 'Name *' }), 'my-deployment');
+    await user.click(within(dialog).getByRole('combobox', { name: 'Inference server *' }));
+    await user.click(await screen.findByText('triton-server'));
+
+    await user.click(within(dialog).getByRole('combobox', { name: 'Model family' }));
+    await user.click(await screen.findByText('Family One'));
+
+    await user.click(within(dialog).getByRole('combobox', { name: 'Model *' }));
+    await user.click(await screen.findByText('model-1'));
+
+    await user.click(within(dialog).getByRole('button', { name: 'Create' }));
+
+    await waitFor(() => {
+      expect(mockRequest).toHaveBeenCalledWith(
+        'CreateDeployment',
+        {
+          metadata: { name: 'my-deployment', namespace: 'ma-dev-test' },
+          spec: {
+            desiredRevision: { name: 'model-1', namespace: 'ma-dev-test' },
+            target: {
+              case: 'inferenceServer',
+              value: { name: 'triton-server', namespace: 'ma-dev-test' },
+            },
+            strategy: { rolloutStrategy: { case: 'rolling', value: { incrementPercentage: 0 } } },
+            definition: { type: 1 },
+          },
+        },
+        {}
+      );
+    });
+  });
+});

--- a/javascript/packages/core/config/entities/deployment/create-deployment-form.tsx
+++ b/javascript/packages/core/config/entities/deployment/create-deployment-form.tsx
@@ -1,4 +1,5 @@
 import { FormDialog } from '#core/components/form/components/form-dialog/form-dialog';
+import { RadioField } from '#core/components/form/fields/radio/radio-field';
 import { SelectField } from '#core/components/form/fields/select/select-field';
 import { StringField } from '#core/components/form/fields/string/string-field';
 import { combineValidators } from '#core/components/form/validation/combine-validators';
@@ -12,10 +13,18 @@ import {
   K8S_NAME_RULES_MESSAGE,
 } from '#core/utils/crd-utils';
 import { ModelFamilyRevisionFields } from './model-family-revision-fields';
-import { TARGET_TYPE } from './shared';
+import { TARGET_TYPE, TARGET_TYPE_LABELS } from './shared';
 
 import type { CreateActionComponentProps } from '#core/components/actions/types';
 import type { DeploymentCreateInput, InferenceServerListResult } from './types';
+
+const DEPLOYMENT_TYPE_OPTIONS = [
+  { value: 'online', label: TARGET_TYPE_LABELS[TARGET_TYPE.INFERENCE_SERVER] },
+  { value: 'offline', label: TARGET_TYPE_LABELS[TARGET_TYPE.OFFLINE] },
+];
+
+const parseDeploymentType = (value?: string) =>
+  value === 'offline' ? TARGET_TYPE.OFFLINE : TARGET_TYPE.INFERENCE_SERVER;
 
 export const CreateDeploymentForm = ({ onClose }: CreateActionComponentProps) => {
   const { projectId } = useStudioParams('base');
@@ -40,7 +49,7 @@ export const CreateDeploymentForm = ({ onClose }: CreateActionComponentProps) =>
 
   const handleCreate = async (values: DeploymentCreateInput) => {
     if (createDeploymentMutation.isPending) return;
-    const { modelFamilyName: _modelFamilyName, ...specRest } = values.spec;
+    const { modelFamilyName: _modelFamilyName, deploymentType, ...specRest } = values.spec;
     await createDeploymentMutation.mutateAsync({
       ...values,
       spec: {
@@ -50,6 +59,7 @@ export const CreateDeploymentForm = ({ onClose }: CreateActionComponentProps) =>
           case: 'inferenceServer',
           value: { ...values.spec.target.value, namespace: projectId },
         },
+        definition: { type: parseDeploymentType(deploymentType) },
       },
     });
   };
@@ -60,6 +70,7 @@ export const CreateDeploymentForm = ({ onClose }: CreateActionComponentProps) =>
       namespace: projectId,
     },
     spec: {
+      deploymentType: 'online',
       desiredRevision: { name: '', namespace: projectId },
       target: { case: 'inferenceServer', value: { name: '', namespace: projectId } },
       strategy: { rolloutStrategy: { case: 'rolling', value: { incrementPercentage: 0 } } },
@@ -88,6 +99,14 @@ export const CreateDeploymentForm = ({ onClose }: CreateActionComponentProps) =>
         )}
         caption={K8S_NAME_RULES_MESSAGE}
         placeholder="my-deployment"
+      />
+
+      <RadioField
+        name="spec.deploymentType"
+        label="Type of deployment"
+        required
+        disabled
+        options={DEPLOYMENT_TYPE_OPTIONS}
       />
 
       <SelectField

--- a/javascript/packages/core/config/entities/deployment/types.ts
+++ b/javascript/packages/core/config/entities/deployment/types.ts
@@ -8,6 +8,8 @@ export type DeploymentCreateInput = {
   spec: {
     /** UI-only: filters the Model dropdown by family. Stripped before submission in handleCreate. */
     modelFamilyName?: string;
+    /** UI-only: drives the disabled "Type of deployment" radio. Stripped before submission in handleCreate. */
+    deploymentType?: string;
     desiredRevision: { name: string; namespace?: string };
     target: {
       case: 'inferenceServer';


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
Added option to choose deployment type of Online and Offline. It is defaulted to Online and the toggle is disabled because only Online is implemented currently.

<img width="1469" height="697" alt="image" src="https://github.com/user-attachments/assets/ed0e523a-8098-456f-92ab-1517103e960d" />


<!-- Tell your future self why have you made these changes -->
**Why?**
To show users what type of deployment is being created.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A
<!-- Does this PR introduce a breaking change? Check all that apply. -->
**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
N/A
<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
N/A