### PR TITLE
fix: preserve backfill TriggerRun status

### DIFF
--- a/go/components/triggerrun/backfill_trigger.go
+++ b/go/components/triggerrun/backfill_trigger.go
@@ -229,5 +229,5 @@ func (b *backfillTrigger) Resume(ctx context.Context, triggerRun *v2pb.TriggerRu
 //
 // Returns current TriggerRunStatus (state unchanged).
 func (b *backfillTrigger) Update(ctx context.Context, triggerRun *v2pb.TriggerRun, action v2pb.TriggerRunAction) (v2pb.TriggerRunStatus, bool, error) {
-	return v2pb.TriggerRunStatus{State: triggerRun.Status.State}, false, nil
+	return triggerRun.Status, false, nil
 }

--- a/go/components/triggerrun/backfill_trigger_test.go
+++ b/go/components/triggerrun/backfill_trigger_test.go
@@ -467,14 +467,17 @@ func setupBackfillTrigger(t *testing.T, workflowClient clientInterface.WorkflowC
 }
 
 func TestBackfillTrigger_Update(t *testing.T) {
+	expectedStatus := v2pb.TriggerRunStatus{
+		State:               v2pb.TRIGGER_RUN_STATE_RUNNING,
+		ExecutionWorkflowId: "test-workflow-id",
+		LogUrl:              "http://localhost:8080/namespaces/default/workflows/test-workflow-id",
+	}
 	triggerRun := &v2pb.TriggerRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "test-namespace",
 			Name:      "test-triggerrun",
 		},
-		Status: v2pb.TriggerRunStatus{
-			State: v2pb.TRIGGER_RUN_STATE_RUNNING,
-		},
+		Status: expectedStatus,
 	}
 
 	logger := zapr.NewLogger(zap.NewNop())
@@ -487,5 +490,5 @@ func TestBackfillTrigger_Update(t *testing.T) {
 	status, _, err := backfillTrigger.Update(context.Background(), triggerRun, v2pb.TRIGGER_RUN_ACTION_NO_ACTION)
 
 	assert.NoError(t, err)
-	assert.Equal(t, v2pb.TRIGGER_RUN_STATE_RUNNING, status.State)
+	assert.Equal(t, expectedStatus, status)
 }


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

Preserve the complete backfill TriggerRun status during no-op workflow updates. Added regression coverage for retaining the execution workflow ID and log URL.

<!-- Tell your future self why have you made these changes -->
**Why?**

Returning a status containing only the state cleared `executionWorkflowId` and `logUrl` before status polling, causing backfill TriggerRuns to fail with `execution workflow id is empty`.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

`bazel test //go/components/triggerrun:go_default_test`

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

Low. The change is limited to returning the TriggerRun status already stored on the object instead of reconstructing a state-only status.

<!-- Does this PR introduce a breaking change? Check all that apply. -->
**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

> If any breaking change box is checked (other than "No breaking changes"), you **must**:
> 1. Use the `BREAKING CHANGE:` footer **or** the `!` suffix (e.g. `feat!:`) in your commit message — see [Commit Messages](../CONTRIBUTING.md#commit-messages).
> 2. Fill in the **Migration guide** section below with step-by-step upgrade instructions.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

Fixes backfill TriggerRuns losing workflow metadata during no-op status updates.

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**

None.