### PR TITLE
fix(python): self-heal sandbox mysql Pod if sync finds it not Running

### DIFF
--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -355,6 +355,8 @@ def _sync(ns: argparse.Namespace):
     # Upgrade or install the control plane via Helm.
     # Infrastructure (mysql, cadence, minio, grafana, prometheus) is left running.
 
+    mysql_pod_recreated = _ensure_mysql_pod_running()
+
     _refresh_mysql_schema()
 
     _ensure_credentials_secret()
@@ -443,6 +445,70 @@ def _sync(ns: argparse.Namespace):
         )
 
     _helm_wait(ns)
+
+    # Ad hoc stopgap: if the bare mysql Pod above had to be recreated, its
+    # emptyDir data (no PVC backs this Pod) was wiped, which drops the
+    # `cadence`/`cadence_visibility` databases along with the Cadence domain
+    # registration record. The `helm upgrade`/`install` above already
+    # recreates the schema itself (values-k3d.yaml: the cadence subchart's
+    # schema-server Job auto-creates cadence/cadence_visibility), but domain
+    # registration is a one-off `cadence domain register` CLI call that only
+    # ever runs from `_create()` — redo it here so `ma pipeline run` doesn't
+    # fail with "domain not found" after a Pod recreation.
+    #
+    # This is not a full fix: any other cluster-side state that lived only in
+    # the wiped mysql data (e.g. previously-applied CRs' rows in the
+    # `michelangelo` DB — already handled by `_refresh_mysql_schema`, but
+    # anything outside that schema) is not restored. The durable fix (back
+    # the mysql Pod with a PVC, or a full reinit path) is tracked separately.
+    if mysql_pod_recreated and ns.workflow == "cadence":
+        _create_cadence_domain([])
+
+
+def _ensure_mysql_pod_running():
+    """Revive the bare `mysql` Pod if it isn't in the `Running` phase.
+
+    `_sync()`'s fast path leaves infrastructure Pods running rather than
+    recreating them, which assumes the previous sync's `mysql` Pod is still
+    alive. On a long-lived host, a node-level container-runtime restart can
+    leave a bare Pod (no Deployment/ReplicaSet to self-heal it) stuck in a
+    terminal phase (`Succeeded`/`Failed`) even though its containers never
+    exited on their own — `kubectl exec` then fails outright. Detect that
+    and delete+reapply the Pod manifest before `_refresh_mysql_schema()`
+    tries to exec into it.
+
+    Returns True if the Pod had to be deleted and recreated (meaning its
+    emptyDir data, including Cadence's schema/domain state, was wiped),
+    False if the existing Pod was already healthy.
+    """
+    phase_result = subprocess.run(
+        ["kubectl", "get", "pod", "mysql", "-o", "jsonpath={.status.phase}"],
+        capture_output=True,
+        text=True,
+    )
+    phase = phase_result.stdout.strip()
+
+    if phase_result.returncode == 0 and phase == "Running":
+        return False
+
+    print(
+        f"mysql Pod is not Running (phase={phase or 'missing'}) — "
+        "recreating it before refreshing the schema."
+    )
+    subprocess.run(
+        ["kubectl", "delete", "pod", "mysql", "--ignore-not-found=true", "--wait=true"],
+        check=False,
+    )
+    _kube_apply(_dir / "resources" / "mysql.yaml")
+    _exec(
+        "kubectl",
+        "wait",
+        "--for=condition=ready",
+        "pod",
+        "mysql",
+        "--timeout=180s",
+    )
+    return True
 
 
 def _refresh_mysql_schema():


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
`ma sandbox sync`'s fast path (used on long-lived CI runners) leaves infrastructure Pods running between runs and execs directly into the bare `mysql` Pod to refresh the schema. If that Pod has fallen out of `Running` phase (e.g. a node-level container-runtime restart, since it's a bare Pod with no Deployment/ReplicaSet to self-heal it), `kubectl exec` fails immediately and `sync` aborts before any pipeline test runs.

This adds `_ensure_mysql_pod_running()`, called right before the schema refresh: if the Pod isn't `Running`, it's deleted and reapplied from `resources/mysql.yaml`, and `sync` waits for it to become ready. Since this Pod has no PVC, a recreation wipes its data — including the Cadence `cadence`/`cadence_visibility` databases and domain registration. The `helm upgrade`/`install` step that already runs later in `sync` recreates the schema itself (the cadence subchart's own schema-server Job does this per `values-k3d.yaml`), so this PR only adds the missing piece: re-registering the Cadence domain via `_create_cadence_domain([])` when a recreation was detected.

**Why?**
This is the ad hoc fix for the mysql-Pod-vanishing failure documented in harness spec 037's addendum. An earlier attempt at this same self-heal guard was merged and then reverted on #1775 (commit `5204a37df`/`5e42bfd80`) because it revived the Pod without addressing the resulting Cadence data loss, which broke workflow dispatch on the next pipeline run. This PR carries the same Pod revival plus the missing domain-reinit step, closing that gap.

This is intentionally a stopgap, not the durable fix — it doesn't restore any state that might live in the wiped mysql data outside the `michelangelo`/Cadence schemas already handled by `sync`. A PVC-backed mysql Pod (or a fuller reinit path) remains the durable fix and is tracked separately.

**How did you test it?**
`python3 -m py_compile` and `ruff check`/`ruff format --check` on the changed file. Verified by code inspection that `_create_cadence_domain`'s `links` parameter is unused (safe to call with `[]`), that `_create_cadence_domain` treats "already registered" as success (safe to call unconditionally on every recreation), and that the Cadence schema-server Job (not this code) is what creates `cadence`/`cadence_visibility` on `helm upgrade`. Not validated against a live occurrence of the Pod actually vanishing on the persistent runner, since that failure mode isn't reliably reproducible on demand.

**Potential risks**
If the mysql Pod is momentarily transitioning phases for a benign reason (not actually unhealthy), this would still delete and reapply it, which is a no-op functionally but adds sync latency. Domain re-registration on every "Pod was recreated" event is idempotent and low-risk. The known residual risk — other cluster state that only lived in the wiped mysql data — is unchanged from before this PR and is called out in the code comments.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**
N/A

**Documentation Changes**
N/A