### PR TITLE
fix(rpc): auto-pack Any/enum fields at the RPC layer, not in UI config

### DIFF
--- a/javascript/packages/core/config/entities/deployment/model-family-revision-fields.tsx
+++ b/javascript/packages/core/config/entities/deployment/model-family-revision-fields.tsx
@@ -1,7 +1,5 @@
 import { useEffect } from 'react';
 import { useForm } from 'react-final-form';
-import { create, toBinary } from '@bufbuild/protobuf';
-import { StringValueSchema } from '@bufbuild/protobuf/wkt';
 
 import { SelectField } from '#core/components/form/fields/select/select-field';
 import { useField } from '#core/components/form/hooks/use-field';
@@ -19,12 +17,7 @@ const modelFamilyListOptionsExt = (modelFamilyName: string) => ({
       {
         fieldName: 'model.model_family_name',
         operator: CRITERION_OPERATOR_EQUAL,
-        matchValue: {
-          typeUrl: 'type.googleapis.com/google.protobuf.StringValue',
-          value: Array.from(
-            toBinary(StringValueSchema, create(StringValueSchema, { value: modelFamilyName }))
-          ),
-        },
+        matchValue: modelFamilyName,
       },
     ],
   },

--- a/javascript/packages/core/config/entities/pipeline/resume-run-fields.tsx
+++ b/javascript/packages/core/config/entities/pipeline/resume-run-fields.tsx
@@ -1,6 +1,4 @@
 import { useMemo, useState } from 'react';
-import { create } from '@bufbuild/protobuf';
-import { anyPack, StringValueSchema } from '@bufbuild/protobuf/wkt';
 
 import { SelectField } from '#core/components/form/fields/select/select-field';
 import { useField } from '#core/components/form/hooks/use-field';
@@ -54,10 +52,7 @@ function buildPipelineCriterion(pipelineName: string) {
           {
             fieldName: 'pipeline_run.pipeline_name',
             operator: CRITERION_OPERATOR_EQUAL,
-            matchValue: anyPack(
-              StringValueSchema,
-              create(StringValueSchema, { value: pipelineName })
-            ),
+            matchValue: pipelineName,
           },
         ],
       },

--- a/javascript/packages/core/interpolation/__tests__/use-interpolation-resolver.test.tsx
+++ b/javascript/packages/core/interpolation/__tests__/use-interpolation-resolver.test.tsx
@@ -342,31 +342,6 @@ describe('useInterpolationResolver', () => {
     });
   });
 
-  describe('Binary payloads', () => {
-    test('passes typed arrays through without rebuilding them as plain objects', () => {
-      const { result } = renderHook(
-        () => useInterpolationResolver(),
-        buildWrapper([getRouterWrapper()])
-      );
-
-      // A packed `google.protobuf.Any` carries its message as bytes. Mapping over those
-      // would yield `{0: …, 1: …}` and the request would fail to encode.
-      const bytes = new Uint8Array([10, 13, 98, 101, 114, 116]);
-      const payload = {
-        matchValue: { typeUrl: 'type.googleapis.com/google.protobuf.StringValue', value: bytes },
-        fieldName: interpolate('${data.column}'),
-      };
-
-      const resolved = result.current<typeof payload>(payload, {
-        row: { column: 'pipeline_name' },
-      });
-
-      expect(resolved.fieldName).toBe('pipeline_name');
-      expect(resolved.matchValue.value).toBeInstanceOf(Uint8Array);
-      expect(Array.from(resolved.matchValue.value)).toEqual([10, 13, 98, 101, 114, 116]);
-    });
-  });
-
   describe('Performance and caching behavior', () => {
     test('caches page and initialValues across multiple resolutions', () => {
       const { result } = renderHook(

--- a/javascript/packages/core/interpolation/resolve-interpolations.ts
+++ b/javascript/packages/core/interpolation/resolve-interpolations.ts
@@ -64,13 +64,6 @@ export function resolveInterpolations(args: {
     );
   }
 
-  // Binary payloads read as records to `isRecord`, and mapping over one would rebuild it
-  // as a plain object and destroy the buffer — a packed `google.protobuf.Any` then fails to
-  // encode. Nothing inside is interpolatable, so pass it through untouched.
-  if (ArrayBuffer.isView(variable) || variable instanceof ArrayBuffer) {
-    return variable;
-  }
-
   if (isRecord(variable)) {
     const symbols = getObjectSymbols(variable);
     const mappedValues = mapValues(variable, (value, key) => {

--- a/javascript/packages/rpc/__tests__/services.test.ts
+++ b/javascript/packages/rpc/__tests__/services.test.ts
@@ -1,4 +1,6 @@
-import { expect, it, vi } from 'vitest';
+import { create } from '@bufbuild/protobuf';
+import { anyPack, StringValueSchema } from '@bufbuild/protobuf/wkt';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { request } from '../request';
 
@@ -46,5 +48,183 @@ it('decodes a ListPipelineRun response containing a TypedStruct Any field', asyn
   expect(details[0]).toEqual({
     typeUrl: 'type.googleapis.com/michelangelo.UniFlowConf',
     value: {},
+  });
+});
+
+// Verifies the Any lands on the wire in the shape Envoy's grpc_json_transcoder expects.
+describe('outgoing request — Any-packing through the real service client', () => {
+  beforeEach(() => {
+    vi.mocked(global.fetch).mockClear();
+  });
+
+  function expectCriteria(
+    ...expected: Array<{ fieldName: string; operator: string; matchValue: unknown }>
+  ) {
+    const calls = vi.mocked(global.fetch).mock.calls;
+    const [, init] = calls.at(-1) as [string, RequestInit];
+    // cast: this test only cares about the shape it itself constructed
+    const body = JSON.parse(init.body as string) as {
+      listOptionsExt: { operation: { criterion: Record<string, unknown>[] } };
+    };
+    const criteria = body.listOptionsExt.operation.criterion;
+    expect(criteria).toHaveLength(expected.length);
+    for (const [i, criterion] of expected.entries()) {
+      expect(criteria[i]).toMatchObject(criterion);
+    }
+  }
+
+  it('packs a string matchValue into a StringValue Any', async () => {
+    await request('ListPipelineRun', {
+      listOptionsExt: {
+        operation: {
+          criterion: [
+            { fieldName: 'pipeline_run.pipeline_name', operator: 1, matchValue: 'my-pipeline' },
+          ],
+        },
+      },
+    } as never);
+
+    expectCriteria({
+      fieldName: 'pipeline_run.pipeline_name',
+      operator: 'CRITERION_OPERATOR_EQUAL',
+      matchValue: {
+        '@type': 'type.googleapis.com/google.protobuf.StringValue',
+        value: 'my-pipeline',
+      },
+    });
+  });
+
+  it('packs a boolean matchValue into a BoolValue Any', async () => {
+    await request('ListPipelineRun', {
+      listOptionsExt: {
+        operation: { criterion: [{ fieldName: 'x', operator: 1, matchValue: true }] },
+      },
+    } as never);
+
+    expectCriteria({
+      fieldName: 'x',
+      operator: 'CRITERION_OPERATOR_EQUAL',
+      matchValue: { '@type': 'type.googleapis.com/google.protobuf.BoolValue', value: true },
+    });
+  });
+
+  it('packs an integer matchValue into an Int64Value Any', async () => {
+    await request('ListPipelineRun', {
+      listOptionsExt: {
+        operation: { criterion: [{ fieldName: 'x', operator: 1, matchValue: 42 }] },
+      },
+    } as never);
+
+    expectCriteria({
+      fieldName: 'x',
+      operator: 'CRITERION_OPERATOR_EQUAL',
+      matchValue: { '@type': 'type.googleapis.com/google.protobuf.Int64Value', value: '42' },
+    });
+  });
+
+  it('packs a float matchValue into a DoubleValue Any', async () => {
+    await request('ListPipelineRun', {
+      listOptionsExt: {
+        operation: { criterion: [{ fieldName: 'x', operator: 1, matchValue: 1.5 }] },
+      },
+    } as never);
+
+    expectCriteria({
+      fieldName: 'x',
+      operator: 'CRITERION_OPERATOR_EQUAL',
+      matchValue: { '@type': 'type.googleapis.com/google.protobuf.DoubleValue', value: 1.5 },
+    });
+  });
+
+  it('sends an already-packed Any (real typeUrl/value) through unchanged', async () => {
+    const realAny = anyPack(
+      StringValueSchema,
+      create(StringValueSchema, { value: 'already-packed' })
+    );
+
+    await request('ListPipelineRun', {
+      listOptionsExt: {
+        operation: { criterion: [{ fieldName: 'x', operator: 1, matchValue: realAny }] },
+      },
+    } as never);
+
+    expectCriteria({
+      fieldName: 'x',
+      operator: 'CRITERION_OPERATOR_EQUAL',
+      matchValue: {
+        '@type': 'type.googleapis.com/google.protobuf.StringValue',
+        value: 'already-packed',
+      },
+    });
+  });
+
+  it('packs Any values across every entry of a repeated field, and leaves fieldName untouched', async () => {
+    await request('ListPipelineRun', {
+      listOptionsExt: {
+        operation: {
+          criterion: [
+            { fieldName: 'a', operator: 1, matchValue: 'one' },
+            { fieldName: 'b', operator: 1, matchValue: 'two' },
+          ],
+        },
+      },
+    } as never);
+
+    expectCriteria(
+      {
+        fieldName: 'a',
+        operator: 'CRITERION_OPERATOR_EQUAL',
+        matchValue: { '@type': 'type.googleapis.com/google.protobuf.StringValue', value: 'one' },
+      },
+      {
+        fieldName: 'b',
+        operator: 'CRITERION_OPERATOR_EQUAL',
+        matchValue: { '@type': 'type.googleapis.com/google.protobuf.StringValue', value: 'two' },
+      }
+    );
+  });
+
+  // Rejects rather than letting create() silently turn this into an empty, corrupted Any —
+  // callers already normalize thrown RPC errors, so this surfaces as a normal query error.
+  it('rejects when an Any field is given a value with no wrapper mapping', async () => {
+    await expect(
+      request('ListPipelineRun', {
+        listOptionsExt: {
+          operation: {
+            criterion: [{ fieldName: 'x', operator: 1, matchValue: { nested: 'object' } }],
+          },
+        },
+      } as never)
+    ).rejects.toThrow(/cannot auto-pack object/);
+  });
+
+  // A map<string, Any> field on an unrelated service/message, proving the packing is
+  // schema-driven rather than special-cased for Criterion.
+  it('packs a map<string, Any> field on CreateDeployment, an unrelated service method', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: () => Promise.resolve({}),
+    });
+
+    await request('CreateDeployment', {
+      metadata: { name: 'my-deployment' },
+      status: { providerStatus: { foo: 'bar-value', replicas: 3 } },
+    } as never);
+
+    const calls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    const [, init] = calls.at(-1) as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as {
+      deployment: { status: { providerStatus: Record<string, unknown> } };
+    };
+
+    expect(body.deployment.status.providerStatus.foo).toEqual({
+      '@type': 'type.googleapis.com/google.protobuf.StringValue',
+      value: 'bar-value',
+    });
+    expect(body.deployment.status.providerStatus.replicas).toEqual({
+      '@type': 'type.googleapis.com/google.protobuf.Int64Value',
+      value: '3',
+    });
   });
 });

--- a/javascript/packages/rpc/pack-any-fields.ts
+++ b/javascript/packages/rpc/pack-any-fields.ts
@@ -1,0 +1,92 @@
+import { create } from '@bufbuild/protobuf';
+import {
+  anyPack,
+  BoolValueSchema,
+  DoubleValueSchema,
+  Int64ValueSchema,
+  StringValueSchema,
+} from '@bufbuild/protobuf/wkt';
+
+import type { DescField, DescMessage } from '@bufbuild/protobuf';
+
+const ANY_TYPE_NAME = 'google.protobuf.Any';
+
+/**
+ * Walks a request object against its proto descriptor, packing JS primitives into well-known
+ * wrapper types wherever the schema has a `google.protobuf.Any` field.
+ *
+ * @example
+ * packAnyFields(CriterionSchema, { fieldName: "x", matchValue: "my-pipeline" })
+ * // matchValue -> anyPack(StringValueSchema, create(StringValueSchema, { value: "my-pipeline" }))
+ */
+export function packAnyFields(desc: DescMessage, value: unknown): unknown {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return value;
+
+  const result: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(value)) {
+    const field: DescField | undefined = desc.field[key];
+    result[key] = field ? packField(field, val) : val;
+  }
+  return result;
+}
+
+function packField(field: DescField, value: unknown): unknown {
+  if (value === null || value === undefined) return value;
+
+  switch (field.fieldKind) {
+    case 'message':
+      return packMessageValue(field.message, value);
+    case 'list':
+      if (field.listKind === 'message') {
+        // cast: repeated fields are always arrays at runtime
+        return (value as unknown[]).map((item) => packMessageValue(field.message, item));
+      }
+      return value;
+    case 'map': {
+      const mapValueMessage = field.message;
+      if (!mapValueMessage) return value;
+      // cast: map fields are always plain objects at runtime, keyed by the (stringified)
+      // map key regardless of its declared scalar type
+      const mapValue = value as Record<string, unknown>;
+      return Object.fromEntries(
+        Object.entries(mapValue).map(([key, item]) => [
+          key,
+          packMessageValue(mapValueMessage, item),
+        ])
+      );
+    }
+    default:
+      return value;
+  }
+}
+
+function packMessageValue(desc: DescMessage, value: unknown): unknown {
+  if (desc.typeName !== ANY_TYPE_NAME) {
+    return packAnyFields(desc, value);
+  }
+
+  // Already a packed Any object (has typeUrl) — pass through
+  if (typeof value === 'object' && value !== null && 'typeUrl' in value) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    return anyPack(StringValueSchema, create(StringValueSchema, { value }));
+  }
+  if (typeof value === 'boolean') {
+    return anyPack(BoolValueSchema, create(BoolValueSchema, { value }));
+  }
+  if (typeof value === 'number') {
+    if (Number.isInteger(value)) {
+      return anyPack(Int64ValueSchema, create(Int64ValueSchema, { value: BigInt(value) }));
+    }
+    return anyPack(DoubleValueSchema, create(DoubleValueSchema, { value }));
+  }
+
+  // create() doesn't validate an Any's shape, so passing this through would silently produce
+  // an empty Any (typeUrl: '') instead of a visible error.
+  throw new Error(
+    `packAnyFields: cannot auto-pack ${typeof value} into google.protobuf.Any — ` +
+      `expected a string, number, or boolean primitive`
+  );
+}

--- a/javascript/packages/rpc/services.ts
+++ b/javascript/packages/rpc/services.ts
@@ -1,5 +1,10 @@
 import { create, createRegistry, fromJson, toJson } from '@bufbuild/protobuf';
-import { StringValueSchema } from '@bufbuild/protobuf/wkt';
+import {
+  BoolValueSchema,
+  DoubleValueSchema,
+  Int64ValueSchema,
+  StringValueSchema,
+} from '@bufbuild/protobuf/wkt';
 
 import { createFetchTransport } from './create-fetch-transport';
 import { TypedStructSchema } from './gen/michelangelo/api/typed_struct_pb';
@@ -11,15 +16,23 @@ import { PipelineRunService } from './gen/michelangelo/api/v2/pipeline_run_svc_p
 import { PipelineService } from './gen/michelangelo/api/v2/pipeline_svc_pb';
 import { ProjectService } from './gen/michelangelo/api/v2/project_svc_pb';
 import { TriggerRunService } from './gen/michelangelo/api/v2/trigger_run_svc_pb';
+import { packAnyFields } from './pack-any-fields';
 import { getRuntimeConfig } from './runtime-config';
 
 import type { DescService } from '@bufbuild/protobuf';
 import type { FetchTransport, ServiceClient, Services } from './types';
 
-// StringValueSchema is registered so criteria that wrap a matchValue in a
-// google.protobuf.Any (e.g. ListOptionsExt filters) can be JSON-encoded — protobuf-es
-// resolves an Any's typeUrl against this registry to serialize it as a well-known type.
-const typeRegistry = createRegistry(TypedStructSchema, StringValueSchema);
+// These wrapper schemas are registered so criteria that wrap a matchValue in a
+// google.protobuf.Any (e.g. ListOptionsExt filters, packed by packAnyFields) can be
+// JSON-encoded — protobuf-es resolves an Any's typeUrl against this registry to serialize
+// it as a well-known type.
+const typeRegistry = createRegistry(
+  TypedStructSchema,
+  StringValueSchema,
+  BoolValueSchema,
+  Int64ValueSchema,
+  DoubleValueSchema
+);
 
 /**
  * Builds a service client whose methods JSON-encode the request, POST it
@@ -40,7 +53,10 @@ function createServiceClient<T extends DescService>(
     if (method.methodKind !== 'unary') continue;
 
     client[method.localName] = async (request, headers) => {
-      const message = create(method.input, request);
+      // cast: packAnyFields recurses generically over `unknown`; called with a Record it
+      // returns one, just with Any fields packed into the shape create() expects
+      const packedRequest = packAnyFields(method.input, request) as Record<string, unknown>;
+      const message = create(method.input, packedRequest);
       const requestJson = toJson(method.input, message, { registry: typeRegistry });
       const responseJson = await transport.callUnary(
         service.typeName,


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Bug Fix
- [ ] Feature
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

`packages/rpc/services.ts`'s request path now runs every outgoing request through `packAnyFields` (`packages/rpc/pack-any-fields.ts`), which walks the request against the RPC method's proto descriptor and packs a plain JS primitive (string, boolean, integer, or float) into the matching well-known wrapper type (`StringValue`, `BoolValue`, `Int64Value`, `DoubleValue`) wherever the schema calls for a `google.protobuf.Any` — at any nesting depth, and whatever the field's shape (singular, repeated, or a map value). It's purely schema-driven, not specific to `Criterion`: one test packs `CreateDeployment`'s `providerStatus`, a `map<string, Any>` field on an unrelated message, to prove it. An already-packed `Any` (real `typeUrl`) passes through unchanged, and a value with no wrapper mapping throws rather than letting `create()` silently produce a corrupted, empty `Any`.

With that in place:
- `resume-run-fields.tsx` and `model-family-revision-fields.tsx` no longer construct a `google.protobuf.Any` by hand — they pass plain JSON (e.g. `matchValue: pipelineName`) with no protobuf imports.
- The `ArrayBuffer.isView`/`ArrayBuffer` guard added to `resolveInterpolations` is reverted, along with its test, since no binary payload reaches the interpolator anymore.

Enum values (`CriterionOperator`) stay as numeric magic numbers for now — #1818 is handling that migration separately.

**Why?**

Two UI config files were hand-building a protobuf `Any` (`anyPack`/`toBinary(StringValueSchema, ...)`) directly in `packages/core` config code. That had two costs:
- It broke `resolveInterpolations`, which had to special-case binary payloads so mapping over a packed `Any`'s bytes didn't rebuild them as a plain object and corrupt the request.
- It reached across the `core`/`rpc` boundary that `packages/core/ARCHITECTURE.md` documents explicitly: RPC internals are only ever injected into `core` via providers, never imported directly.

Since the RPC layer already has the proto descriptors for every request it builds, it can detect an `Any`-typed field from the schema itself and pack it there — config code stays declarative JSON, and the one place that understands protobuf wire format is the one place that already depended on it.

**How did you test it?**

Verified resume from still returns pipeline runs 

https://github.com/user-attachments/assets/ef42fe8e-7b0e-4639-adb4-622a6fe23c10



**Potential risks**

`packAnyFields` runs on every outgoing RPC request, not just the criteria this PR updates. It only changes behavior for fields the schema types as `google.protobuf.Any`; every other field passes through untouched.

**Breaking Changes**
- [x] No breaking changes

**Release notes**
None.

**Documentation Changes**
None.